### PR TITLE
feat(coding-agent): support MCP protocol 2026-07-28

### DIFF
--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -101,6 +101,7 @@ Shared fields for every transport:
 - `enabled?: boolean` — skip this server when `false`, unless the active-profile user `enabledServers` allowlist names it
 - `timeout?: number` — MCP request timeout in milliseconds; `0` disables client-side MCP timeouts
 - `requestIdFormat?: "number" | "string"` — outgoing JSON-RPC request-id encoding; defaults to per-transport integers. `"string"` uses collision-resistant snowflake IDs. This OMP-specific field is read only from OMP-native files, root `mcp.json` / `.mcp.json`, and OMP extension packages; configs translated from other tools ignore it.
+- `protocolMode?: "legacy" | "auto" | "2026-07-28"` — lifecycle policy; defaults to `"legacy"`. `"auto"` probes `server/discover` and falls back only on explicit legacy evidence. `"2026-07-28"` requires the modern stateless lifecycle. For stdio, auto discovery runs in a disposable sibling process before the session process starts. This OMP-specific field is accepted by the same OMP-owned sources as `requestIdFormat`; translated foreign-tool configs ignore it.
 - `auth?: { ... }` — stored-credential metadata; managed credential injection is implemented for OAuth
 - `oauth?: { ... }` — explicit OAuth client and callback settings used during auth/reauth
 

--- a/docs/mcp-protocol-transports.md
+++ b/docs/mcp-protocol-transports.md
@@ -37,7 +37,7 @@ Does not cover extension authoring UX or command UI.
   - omitted or `"legacy"` sends `initialize`, starts any legacy HTTP SSE listener, then sends `notifications/initialized`
   - `"auto"` probes `server/discover`; HTTP probes use the session transport, while stdio probes use a disposable sibling process
   - `"2026-07-28"` requires successful discovery and never falls back
-- Auto fallback requires explicit legacy evidence (`-32601`, a known legacy version set, or HTTP `404`/`405`). Authentication failures, timeouts, malformed responses, and modern protocol errors remain failures.
+- Auto stdio probes fall back after every non-modern outcome, including an ignored request, process exit, malformed result, timeout, or legacy JSON-RPC error; aborts and recognized modern protocol errors remain failures. Auto HTTP probes fall back only for non-modern `400`, `404`, or `405` responses. A valid discovery result that advertises only known legacy versions also selects the legacy lifecycle.
 - Modern calls carry protocol/client metadata per request and do not send `initialize`; legacy calls retain the initialization-based lifecycle.
 
 ### Transport layer (`MCPTransport`)

--- a/docs/mcp-protocol-transports.md
+++ b/docs/mcp-protocol-transports.md
@@ -19,6 +19,7 @@ Does not cover extension authoring UX or command UI.
 ## Implementation files
 
 - [`src/mcp/types.ts`](../packages/coding-agent/src/mcp/types.ts)
+- [`src/mcp/protocol-negotiation.ts`](../packages/coding-agent/src/mcp/protocol-negotiation.ts)
 - [`src/mcp/transports/stdio.ts`](../packages/coding-agent/src/mcp/transports/stdio.ts)
 - [`src/mcp/transports/http.ts`](../packages/coding-agent/src/mcp/transports/http.ts)
 - [`src/mcp/transports/sse.ts`](../packages/coding-agent/src/mcp/transports/sse.ts)
@@ -32,11 +33,12 @@ Does not cover extension authoring UX or command UI.
 ### Protocol layer (JSON-RPC + MCP methods)
 
 - Message shapes are defined in `types.ts` (`JsonRpcRequest`, `JsonRpcNotification`, `JsonRpcResponse`, `JsonRpcMessage`).
-- MCP client logic (`client.ts`) decides method order and session handshake:
-  1. `initialize` request
-  2. for Streamable HTTP transports, start the optional background SSE listener after the initialize response has established any session id
-  3. `notifications/initialized` notification
-  4. method calls like `tools/list`, `tools/call`
+- `protocol-negotiation.ts` selects one lifecycle from the server's `protocolMode`:
+  - omitted or `"legacy"` sends `initialize`, starts any legacy HTTP SSE listener, then sends `notifications/initialized`
+  - `"auto"` probes `server/discover`; HTTP probes use the session transport, while stdio probes use a disposable sibling process
+  - `"2026-07-28"` requires successful discovery and never falls back
+- Auto fallback requires explicit legacy evidence (`-32601`, a known legacy version set, or HTTP `404`/`405`). Authentication failures, timeouts, malformed responses, and modern protocol errors remain failures.
+- Modern calls carry protocol/client metadata per request and do not send `initialize`; legacy calls retain the initialization-based lifecycle.
 
 ### Transport layer (`MCPTransport`)
 
@@ -67,6 +69,8 @@ Transport implementations own framing and I/O details:
 - `"sse"` -> `createSseTransport`
 
 `"sse"` uses the legacy HTTP+SSE transport: it opens the configured URL with GET, reads the `endpoint` event's plain-text URL/path, POSTs JSON-RPC requests to that endpoint, and receives JSON-RPC responses on the stream.
+
+Legacy SSE cannot carry the 2026 stateless lifecycle. `"auto"` therefore uses legacy initialization for `type: "sse"`, while strict `"2026-07-28"` rejects that transport.
 
 ## JSON-RPC message flow and correlation
 

--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -22,7 +22,7 @@ Config sources (.omp/.claude/.cursor/.vscode/mcp.json, mcp.json, etc.)
 - `stdio` (default when `type` missing): requires `command`, optional `args`, `env`, `cwd`
 - `http`: requires `url`, optional `headers`
 - `sse`: requires `url`, optional `headers` (kept for compatibility)
-- shared fields: `enabled`, `timeout`, `requestIdFormat` (`"number"` or `"string"`), `auth`, `oauth`
+- shared fields: `enabled`, `timeout`, `requestIdFormat` (`"number"` or `"string"`), `protocolMode` (`"legacy"`, `"auto"`, or `"2026-07-28"`), `auth`, `oauth`
 
 `validateServerConfig()` (`src/mcp/config.ts`) enforces transport basics:
 
@@ -42,6 +42,7 @@ Config sources (.omp/.claude/.cursor/.vscode/mcp.json, mcp.json, etc.)
 - `type` omitted means stdio. If you intended HTTP/SSE but omitted `type`, `command` becomes mandatory.
 - `sse` selects the legacy protocol-revision 2024-11-05 HTTP+SSE transport: a persistent GET stream supplies an `endpoint` event whose URL receives JSON-RPC POSTs. It is distinct from the `"http"` Streamable HTTP transport.
 - Outbound JSON-RPC request IDs default to incrementing numbers for ecosystem compatibility. Set `requestIdFormat: "string"` only for a server that requires the older snowflake-string behavior; invalid values are warned about and ignored during discovery.
+- `protocolMode` defaults to `"legacy"`. Use `"auto"` for guarded discovery with legacy fallback, or `"2026-07-28"` when the server is known to require the modern stateless lifecycle. The OMP-only field is ignored when importing another tool's config.
 - Validation is structural, not reachability: a syntactically valid URL can still fail at connect time.
 
 ## 2) Discovery, normalization, and precedence
@@ -76,14 +77,15 @@ Key behavior:
 
 - transport inferred as `server.transport ?? (command ? "stdio" : url ? "http" : "stdio")`
 - `requestIdFormat` is preserved; omitted means numeric IDs
+- `protocolMode` is preserved; omitted and explicit `"legacy"` are equivalent for connection deduplication
 - names in the active-profile user `disabledServers` list are always suppressed; a server with `enabled === false` is suppressed unless the same user config names it in `enabledServers`
 - optional fields are preserved when present
 
 ### Environment expansion during discovery
 
-OMP-native MCP config (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, plus their `.mcp.json` variants) expands `${VAR}` and `${VAR:-default}` placeholders recursively before converting to runtime config. It also accepts boolean/string forms for `enabled` (`true`, `false`, `1`, `0`) and numeric strings for `timeout`. `requestIdFormat` accepts only `"number"` or `"string"`; other values warn and fall back to numeric IDs.
+OMP-native MCP config (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, plus their `.mcp.json` variants) expands `${VAR}` and `${VAR:-default}` placeholders recursively before converting to runtime config. It also accepts boolean/string forms for `enabled` (`true`, `false`, `1`, `0`) and numeric strings for `timeout`. `requestIdFormat` accepts only `"number"` or `"string"`; `protocolMode` accepts only `"legacy"`, `"auto"`, or `"2026-07-28"`. Other values warn and fall back to their defaults.
 
-The standalone fallback provider in `src/discovery/mcp-json.ts` reads project-root `mcp.json` and `.mcp.json`, expands the same `${...}` placeholders, and type-checks `enabled`/`timeout` without coercing string values. It applies the same `requestIdFormat` validation.
+The standalone fallback provider in `src/discovery/mcp-json.ts` reads project-root `mcp.json` and `.mcp.json`, expands the same `${...}` placeholders, and type-checks `enabled`/`timeout` without coercing string values. It applies the same `requestIdFormat` and `protocolMode` validation.
 
 Invalid `enabled`/`timeout` values are ignored with warnings rather than failing the whole file.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in MCP protocol version 2026-07-28 support with guarded discovery, per-request metadata, Streamable HTTP headers, multi-round-trip retries, cache TTLs, subscriptions, and explicit `legacy`, `auto`, and strict modern lifecycle modes. Existing servers remain on the legacy lifecycle by default.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -5,7 +5,7 @@
  * All providers translate their native format to this shape.
  */
 
-import type { MCPRequestIdFormat } from "../mcp/types";
+import type { MCPProtocolMode, MCPRequestIdFormat } from "../mcp/types";
 import { defineCapability } from ".";
 import type { SourceMeta } from "./types";
 
@@ -21,6 +21,8 @@ export interface MCPServer {
 	timeout?: number;
 	/** Encoding for outgoing JSON-RPC request ids (default: `"number"`) */
 	requestIdFormat?: MCPRequestIdFormat;
+	/** MCP protocol lifecycle policy (default: `"legacy"`) */
+	protocolMode?: MCPProtocolMode;
 	/** Command to run (for stdio transport) */
 	command?: string;
 	/** Command arguments */
@@ -74,6 +76,7 @@ function isSameMCPConnection(left: MCPServer, right: MCPServer): boolean {
 	// Normalize against the allocator's own default so an explicit "number" is
 	// equivalent to leaving the option unset, not a distinct connection.
 	if ((left.requestIdFormat ?? "number") !== (right.requestIdFormat ?? "number")) return false;
+	if ((left.protocolMode ?? "legacy") !== (right.protocolMode ?? "legacy")) return false;
 
 	const leftTransport = left.transport ?? (left.command ? "stdio" : left.url ? "http" : "stdio");
 	const rightTransport = right.transport ?? (right.command ? "stdio" : right.url ? "http" : "stdio");

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -123,6 +123,11 @@
           "enum": ["string", "number"],
           "description": "Encoding for outgoing JSON-RPC request ids (default: \"number\"). Use \"string\" for servers that need collision-resistant snowflake string ids instead of per-transport integers. OMP-specific: set it in an OMP-owned config (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, a project `mcp.json`/`.mcp.json`, or an OMP plugin). Servers imported from another tool's config (Claude, Cursor, VS Code, Gemini, OpenCode, Windsurf) ignore it, since that key is not part of those formats."
         },
+        "protocolMode": {
+          "type": "string",
+          "enum": ["legacy", "auto", "2026-07-28"],
+          "description": "MCP lifecycle policy. Defaults to \"legacy\" for compatibility. \"auto\" probes modern discovery with guarded legacy fallback; \"2026-07-28\" requires the modern stateless lifecycle. OMP-specific: foreign tool configuration providers ignore this field."
+        },
         "auth": {
           "$ref": "#/$defs/authConfig"
         },
@@ -138,7 +143,6 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["command"],
           "properties": {
             "type": {
@@ -180,7 +184,6 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
             "type": {
@@ -211,7 +214,6 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
             "type": {
@@ -246,7 +248,8 @@
         {
           "$ref": "#/$defs/sseServer"
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     }
   }
 }

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -31,6 +31,7 @@ import {
 	expandEnvVarsDeep,
 	getExtensionNameFromPath,
 	loadFilesFromDir,
+	parseMCPProtocolMode,
 	parseRequestIdFormat,
 	SOURCE_PATHS,
 	scanSkillsFromDir,
@@ -163,11 +164,19 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				);
 			}
 
+			const protocolMode = parseMCPProtocolMode(serverConfig.protocolMode);
+			if (protocolMode === undefined && serverConfig.protocolMode != null) {
+				logger.warn(
+					`MCP server "${serverName}": invalid protocolMode ${JSON.stringify(serverConfig.protocolMode)}, ignoring`,
+				);
+			}
+
 			result.push({
 				name: serverName,
 				enabled,
 				timeout,
 				requestIdFormat,
+				protocolMode,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,
 				env: serverConfig.env as Record<string, string> | undefined,

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -16,7 +16,7 @@ import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../ca
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
-import type { MCPRequestIdFormat } from "../mcp/types";
+import type { MCPProtocolMode, MCPRequestIdFormat } from "../mcp/types";
 import { type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../thinking";
 import { normalizeToolNames } from "../tools/builtin-names";
 
@@ -148,6 +148,11 @@ export function parseBoolean(value: unknown): boolean | undefined {
  */
 export function parseRequestIdFormat(value: unknown): MCPRequestIdFormat | undefined {
 	if (value === "string" || value === "number") return value;
+	return undefined;
+}
+
+export function parseMCPProtocolMode(value: unknown): MCPProtocolMode | undefined {
+	if (value === "legacy" || value === "auto" || value === "2026-07-28") return value;
 	return undefined;
 }
 

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -12,7 +12,7 @@ import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
-import { createSourceMeta, expandEnvVarsDeep, parseRequestIdFormat } from "./helpers";
+import { createSourceMeta, expandEnvVarsDeep, parseMCPProtocolMode, parseRequestIdFormat } from "./helpers";
 
 const PROVIDER_ID = "mcp-json";
 const DISPLAY_NAME = "MCP Config";
@@ -27,6 +27,7 @@ interface MCPConfigFile {
 			enabled?: boolean;
 			timeout?: number;
 			requestIdFormat?: "string" | "number";
+			protocolMode?: "legacy" | "auto" | "2026-07-28";
 			command?: string;
 			args?: string[];
 			env?: Record<string, string>;
@@ -92,11 +93,20 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				});
 			}
 
+			const protocolMode = parseMCPProtocolMode(serverConfig.protocolMode);
+			if (protocolMode === undefined && serverConfig.protocolMode !== undefined) {
+				logger.warn("MCP server has invalid 'protocolMode' value, ignoring", {
+					name,
+					value: serverConfig.protocolMode,
+				});
+			}
+
 			const server: MCPServer = {
 				name,
 				enabled,
 				timeout,
 				requestIdFormat,
+				protocolMode,
 				command: serverConfig.command,
 				args: serverConfig.args,
 				env: serverConfig.env,

--- a/packages/coding-agent/src/discovery/omp-plugins.ts
+++ b/packages/coding-agent/src/discovery/omp-plugins.ts
@@ -33,6 +33,7 @@ import {
 	buildRuleFromMarkdown,
 	createSourceMeta,
 	loadFilesFromDir,
+	parseMCPProtocolMode,
 	parseRequestIdFormat,
 	scanSkillsFromDir,
 } from "./helpers";
@@ -277,6 +278,7 @@ interface RawMcpServer {
 	enabled?: boolean;
 	timeout?: number;
 	requestIdFormat?: unknown;
+	protocolMode?: unknown;
 	command?: string;
 	args?: string[];
 	env?: Record<string, string>;
@@ -326,11 +328,13 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			// session cwd (MCP stdio spawning resolves relative values there).
 			const rooted = resolvePluginStdioPaths({ command: cfg.command, cwd: cfg.cwd }, root.path);
 			const requestIdFormat = parseRequestIdFormat(cfg.requestIdFormat);
+			const protocolMode = parseMCPProtocolMode(cfg.protocolMode);
 			items.push({
 				name: serverName,
 				...(cfg.enabled !== undefined && { enabled: cfg.enabled }),
 				...(cfg.timeout !== undefined && { timeout: cfg.timeout }),
 				...(requestIdFormat !== undefined && { requestIdFormat }),
+				...(protocolMode !== undefined && { protocolMode }),
 				...(rooted.command !== undefined && { command: rooted.command }),
 				...(cfg.args !== undefined && { args: cfg.args }),
 				...(cfg.env !== undefined && { env: cfg.env }),

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -56,6 +56,8 @@ import type {
 import { MCPError } from "./types";
 
 const MAX_MRTR_ROUND_TRIPS = 8;
+const SUBSCRIPTION_RESTART_INITIAL_DELAY_MS = 250;
+const SUBSCRIPTION_RESTART_MAX_DELAY_MS = 10_000;
 
 const CLIENT_INFO = {
 	name: "omp-coding-agent",
@@ -88,6 +90,10 @@ interface MCPSubscriptionState {
 
 interface MCPConnectionRuntime {
 	subscription?: MCPSubscriptionState;
+	subscriptionRestart?: {
+		timer?: NodeJS.Timeout;
+		delayMs: number;
+	};
 	resourceSubscriptions: Set<string>;
 	cacheScopes: Partial<
 		Record<"tools" | "resources" | "resourceTemplates" | "prompts", "public" | "private" | "uncacheable">
@@ -147,6 +153,32 @@ function withModernRequestMeta(params: Record<string, unknown> = {}): Record<str
 			"io.modelcontextprotocol/clientCapabilities": MODERN_CLIENT_CAPABILITIES,
 		},
 	};
+}
+
+type ToolHeaderBindingResult = {
+	valid: boolean;
+	bindings?: MCPToolHeaderBinding[];
+};
+
+function resolveToolHeaderBindings(connection: MCPServerConnection, tool: MCPToolDefinition): ToolHeaderBindingResult {
+	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION || connection.config.type !== "http") {
+		return { valid: true };
+	}
+
+	const cached = toolHeaderBindings.get(tool);
+	if (cached) return { valid: true, bindings: cached };
+
+	const validation = collectToolHeaderBindings(tool.inputSchema);
+	if (validation.error) {
+		logger.warn("Ignoring invalid MCP tool definition", {
+			server: connection.name,
+			tool: tool.name,
+			error: validation.error,
+		});
+		return { valid: false };
+	}
+	toolHeaderBindings.set(tool, validation.bindings);
+	return { valid: true, bindings: validation.bindings };
 }
 
 function modernServerInfo(name: string, result: MCPDiscoverResult): MCPImplementation {
@@ -322,12 +354,61 @@ export function getToolCachePolicy(
 	};
 }
 
-function settleSubscriptionError(state: MCPSubscriptionState, error: Error): void {
+function clearSubscriptionState(connection: MCPServerConnection, state: MCPSubscriptionState): void {
+	const runtime = connectionRuntimes.get(connection);
+	if (runtime?.subscription === state) runtime.subscription = undefined;
+}
+
+function settleSubscriptionError(connection: MCPServerConnection, state: MCPSubscriptionState, error: Error): void {
 	if (state.settled) return;
 	state.abort.abort(error);
 	state.settled = true;
 	state.reject(error);
+	clearSubscriptionState(connection, state);
 }
+function clearScheduledSubscriptionRestart(runtime: MCPConnectionRuntime): void {
+	const restart = runtime.subscriptionRestart;
+	if (!restart) return;
+	if (restart.timer !== undefined) clearTimeout(restart.timer);
+	restart.timer = undefined;
+}
+
+function scheduleSubscriptionRestart(connection: MCPServerConnection): void {
+	const runtime = connectionRuntimes.get(connection);
+	if (!runtime || runtime.subscription || !connection.transport.connected) return;
+	const restart = runtime.subscriptionRestart ?? { delayMs: SUBSCRIPTION_RESTART_INITIAL_DELAY_MS };
+	if (restart.timer !== undefined) return;
+	const delayMs = restart.delayMs;
+	restart.delayMs = Math.min(delayMs * 2, SUBSCRIPTION_RESTART_MAX_DELAY_MS);
+	restart.timer = setTimeout(() => {
+		restart.timer = undefined;
+		if (
+			runtime.subscriptionRestart !== restart ||
+			runtime.subscription !== undefined ||
+			!connection.transport.connected
+		) {
+			return;
+		}
+		void startModernSubscriptionListener(connection).catch(error => {
+			logger.debug("MCP subscription restart failed", { server: connection.name, error });
+		});
+	}, delayMs);
+	runtime.subscriptionRestart = restart;
+}
+
+function finishSubscriptionListener(
+	connection: MCPServerConnection,
+	state: MCPSubscriptionState,
+	restart: boolean,
+): void {
+	const runtime = connectionRuntimes.get(connection);
+	if (!runtime || runtime.subscription !== state) return;
+	runtime.subscription = undefined;
+	if (restart && !state.abort.signal.aborted && connection.transport.connected) {
+		scheduleSubscriptionRestart(connection);
+	}
+}
+
 function handleSubscriptionAcknowledgment(connection: MCPServerConnection, method: string, params: unknown): void {
 	if (method !== "notifications/subscriptions/acknowledged") return;
 	const runtime = connectionRuntimes.get(connection);
@@ -336,7 +417,11 @@ function handleSubscriptionAcknowledgment(connection: MCPServerConnection, metho
 	const subscriptionId = params._meta["io.modelcontextprotocol/subscriptionId"];
 	if (state.requestId === undefined || subscriptionId === undefined || subscriptionId !== state.requestId) return;
 	if (!isRecord(params.notifications)) {
-		settleSubscriptionError(state, new Error("MCP server returned an invalid subscription acknowledgment"));
+		settleSubscriptionError(
+			connection,
+			state,
+			new Error("MCP server returned an invalid subscription acknowledgment"),
+		);
 		return;
 	}
 	for (const key of ["toolsListChanged", "promptsListChanged", "resourcesListChanged"] as const) {
@@ -345,7 +430,11 @@ function handleSubscriptionAcknowledgment(connection: MCPServerConnection, metho
 			(accepted !== undefined && typeof accepted !== "boolean") ||
 			(accepted === true && state.requested[key] !== true)
 		) {
-			settleSubscriptionError(state, new Error("MCP server acknowledged an invalid subscription filter"));
+			settleSubscriptionError(
+				connection,
+				state,
+				new Error("MCP server acknowledged an invalid subscription filter"),
+			);
 			return;
 		}
 	}
@@ -357,7 +446,7 @@ function handleSubscriptionAcknowledgment(connection: MCPServerConnection, metho
 				? acceptedValue
 				: undefined;
 	if (!accepted || accepted.some(uri => !state.requested.resourceSubscriptions.includes(uri))) {
-		settleSubscriptionError(state, new Error("MCP server acknowledged an invalid resource subscription filter"));
+		settleSubscriptionError(connection, state, new Error("MCP server acknowledged an invalid subscription filter"));
 		return;
 	}
 	if (state.settled) return;
@@ -373,10 +462,11 @@ async function startModernSubscriptionListener(
 	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION) return [];
 	const runtime = connectionRuntimes.get(connection);
 	if (!runtime) return [];
+	clearScheduledSubscriptionRestart(runtime);
 	const previous = runtime.subscription;
 	if (previous) {
 		previous.abort.abort();
-		settleSubscriptionError(previous, new Error("MCP subscription was replaced"));
+		settleSubscriptionError(connection, previous, new Error("MCP subscription was replaced"));
 	}
 	const notifications: MCPSubscriptionFilter = {
 		toolsListChanged: connection.capabilities.tools?.listChanged === true,
@@ -407,7 +497,11 @@ async function startModernSubscriptionListener(
 	let acknowledgmentTimer: NodeJS.Timeout | undefined;
 	const abortAcknowledgment = (): void => {
 		const reason = options?.signal?.reason;
-		settleSubscriptionError(state, reason instanceof Error ? reason : new Error("MCP subscription aborted"));
+		settleSubscriptionError(
+			connection,
+			state,
+			reason instanceof Error ? reason : new Error("MCP subscription aborted"),
+		);
 	};
 	if (options?.signal?.aborted) {
 		abortAcknowledgment();
@@ -416,6 +510,7 @@ async function startModernSubscriptionListener(
 		if (isMCPTimeoutEnabled(acknowledgmentTimeoutMs)) {
 			acknowledgmentTimer = setTimeout(() => {
 				settleSubscriptionError(
+					connection,
 					state,
 					new Error(
 						`MCP subscription acknowledgment timed out after ${describeMCPTimeout(acknowledgmentTimeoutMs)}`,
@@ -437,13 +532,25 @@ async function startModernSubscriptionListener(
 		},
 	)
 		.then(() => {
-			settleSubscriptionError(state, new Error("MCP subscription ended before acknowledgment"));
+			if (!state.settled) {
+				settleSubscriptionError(connection, state, new Error("MCP subscription ended before acknowledgment"));
+			} else {
+				// The request stream can complete after its acknowledgment. It is no
+				// longer a live listener, so restore it through bounded backoff.
+				finishSubscriptionListener(connection, state, true);
+			}
 		})
 		.catch(error => {
-			if (!abort.signal.aborted) {
+			if (!state.settled && !abort.signal.aborted) {
 				logger.warn("MCP subscription listener stopped", { server: connection.name, error });
 			}
-			settleSubscriptionError(state, error instanceof Error ? error : new Error(String(error)));
+			if (!state.settled) {
+				settleSubscriptionError(connection, state, error instanceof Error ? error : new Error(String(error)));
+			} else {
+				// A closed SSE stream reports as a rejected request when it has no
+				// JSON-RPC response. Once acknowledged, that is a normal end.
+				finishSubscriptionListener(connection, state, true);
+			}
 		});
 	return acknowledged.promise.finally(() => {
 		clearTimeout(acknowledgmentTimer);
@@ -590,18 +697,7 @@ export async function listTools(
 		const result = await requestFromServer<MCPToolsListResult>(connection, "tools/list", params, options);
 		updateCacheExpiry(connection, "tools", result);
 		for (const tool of result.tools) {
-			if (connection.protocolVersion === MODERN_PROTOCOL_VERSION && connection.config.type === "http") {
-				const validation = collectToolHeaderBindings(tool.inputSchema);
-				if (validation.error) {
-					logger.warn("Ignoring invalid MCP tool definition", {
-						server: connection.name,
-						tool: tool.name,
-						error: validation.error,
-					});
-					continue;
-				}
-				toolHeaderBindings.set(tool, validation.bindings);
-			}
+			if (!resolveToolHeaderBindings(connection, tool).valid) continue;
 			allTools.push(tool);
 		}
 		cursor = result.nextCursor;
@@ -621,14 +717,15 @@ export async function callTool(
 	toolName: string,
 	args: Record<string, unknown> = {},
 	options?: MCPRequestOptions,
+	toolDefinition?: MCPToolDefinition,
 ): Promise<MCPToolCallResult> {
 	const params: MCPToolCallParams = {
 		name: toolName,
 		arguments: args,
 	};
 
-	const tool = connection.tools?.find(candidate => candidate.name === toolName);
-	const bindings = tool ? toolHeaderBindings.get(tool) : undefined;
+	const tool = toolDefinition ?? connection.tools?.find(candidate => candidate.name === toolName);
+	const bindings = tool ? resolveToolHeaderBindings(connection, tool).bindings : undefined;
 	const generatedHeaders = bindings ? buildToolParameterHeaders(bindings, args) : undefined;
 	return requestFromServer<MCPToolCallResult>(
 		connection,
@@ -642,10 +739,16 @@ export async function callTool(
  * Disconnect from a server.
  */
 export async function disconnectServer(connection: MCPServerConnection): Promise<void> {
-	const subscription = connectionRuntimes.get(connection)?.subscription;
-	if (subscription) {
-		subscription.abort.abort();
-		settleSubscriptionError(subscription, new Error("MCP connection closed"));
+	const runtime = connectionRuntimes.get(connection);
+	if (runtime) {
+		clearScheduledSubscriptionRestart(runtime);
+		runtime.subscriptionRestart = undefined;
+		const subscription = runtime.subscription;
+		if (subscription) {
+			subscription.abort.abort();
+			settleSubscriptionError(connection, subscription, new Error("MCP connection closed"));
+			clearSubscriptionState(connection, subscription);
+		}
 	}
 	await connection.transport.close();
 }

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -391,6 +391,13 @@ function scheduleSubscriptionRestart(connection: MCPServerConnection): void {
 		}
 		void startModernSubscriptionListener(connection).catch(error => {
 			logger.debug("MCP subscription restart failed", { server: connection.name, error });
+			if (
+				runtime.subscriptionRestart === restart &&
+				runtime.subscription === undefined &&
+				connection.transport.connected
+			) {
+				scheduleSubscriptionRestart(connection);
+			}
 		});
 	}, delayMs);
 	runtime.subscriptionRestart = restart;

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -5,15 +5,29 @@
  */
 import * as path from "node:path";
 import * as url from "node:url";
-import { getProjectDir, logger, withTimeout } from "@oh-my-pi/pi-utils";
+import { getProjectDir, isRecord, logger, withTimeout } from "@oh-my-pi/pi-utils";
+import {
+	LEGACY_PROTOCOL_VERSION,
+	type MCPProtocolNegotiationResult,
+	MODERN_PROTOCOL_VERSION,
+	negotiateMCPProtocol,
+} from "./protocol-negotiation";
 import { describeMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "./timeout";
 import { createHttpTransport } from "./transports/http";
+import {
+	buildToolParameterHeaders,
+	collectToolHeaderBindings,
+	type MCPToolHeaderBinding,
+} from "./transports/modern-http";
 import { createSseTransport } from "./transports/sse";
 import { createStdioTransport } from "./transports/stdio";
 import type {
+	MCPCacheableResult,
+	MCPDiscoverResult,
 	MCPGetPromptParams,
 	MCPGetPromptResult,
 	MCPHttpServerConfig,
+	MCPImplementation,
 	MCPInitializeParams,
 	MCPInitializeResult,
 	MCPPrompt,
@@ -26,6 +40,7 @@ import type {
 	MCPResourcesListResult,
 	MCPResourceTemplate,
 	MCPResourceTemplatesListResult,
+	MCPResult,
 	MCPServerCapabilities,
 	MCPServerConfig,
 	MCPServerConnection,
@@ -37,15 +52,30 @@ import type {
 	MCPToolsListResult,
 	MCPTransport,
 } from "./types";
+import { MCPError } from "./types";
 
-/** MCP protocol version we support */
-const PROTOCOL_VERSION = "2025-03-26";
+const MAX_MRTR_ROUND_TRIPS = 8;
 
-/** Client info sent during initialization */
 const CLIENT_INFO = {
 	name: "omp-coding-agent",
 	version: "1.0.0",
 };
+const MODERN_CLIENT_CAPABILITIES = {};
+const toolHeaderBindings = new WeakMap<MCPToolDefinition, MCPToolHeaderBinding[]>();
+
+interface MCPHandshakeResult {
+	protocolVersion: string;
+	serverInfo: MCPImplementation;
+	capabilities: MCPServerCapabilities;
+	instructions?: string;
+}
+interface MCPConnectionRuntime {
+	subscriptionAbort?: AbortController;
+	resourceSubscriptions: Set<string>;
+	cacheExpires: Partial<Record<"tools" | "resources" | "resourceTemplates" | "prompts", number>>;
+}
+
+const connectionRuntimes = new WeakMap<MCPServerConnection, MCPConnectionRuntime>();
 
 /**
  * Default handler for standard MCP server-to-client requests.
@@ -86,44 +116,149 @@ async function createTransport(config: MCPServerConfig): Promise<MCPTransport> {
 	}
 }
 
-/**
- * Initialize connection with MCP server.
- */
+function withModernRequestMeta(params: Record<string, unknown> = {}): Record<string, unknown> {
+	const existingMeta = isRecord(params._meta) ? params._meta : {};
+	return {
+		...params,
+		_meta: {
+			...existingMeta,
+			"io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+			"io.modelcontextprotocol/clientInfo": CLIENT_INFO,
+			"io.modelcontextprotocol/clientCapabilities": MODERN_CLIENT_CAPABILITIES,
+		},
+	};
+}
+
+function modernServerInfo(name: string, result: MCPDiscoverResult): MCPImplementation {
+	const value = result._meta?.["io.modelcontextprotocol/serverInfo"];
+	if (isRecord(value) && typeof value.name === "string" && typeof value.version === "string") {
+		return { name: value.name, version: value.version };
+	}
+	return { name, version: "unknown" };
+}
+
 async function initializeConnection(
+	name: string,
 	transport: MCPTransport,
+	negotiation: MCPProtocolNegotiationResult,
 	options?: {
 		signal?: AbortSignal;
-		/** Called after the initialize response (which sets the session ID) but before notifications/initialized. */
-		onInitialized?: () => void | Promise<void>;
+		onLegacyInitialized?: () => void | Promise<void>;
 	},
-): Promise<MCPInitializeResult> {
+): Promise<MCPHandshakeResult> {
+	if (negotiation.kind === "modern") {
+		return {
+			protocolVersion: MODERN_PROTOCOL_VERSION,
+			serverInfo: modernServerInfo(name, negotiation.discovery),
+			capabilities: negotiation.discovery.capabilities,
+			instructions: negotiation.discovery.instructions,
+		};
+	}
+
 	const params: MCPInitializeParams = {
-		protocolVersion: PROTOCOL_VERSION,
+		protocolVersion: LEGACY_PROTOCOL_VERSION,
 		capabilities: {
 			roots: { listChanged: false },
 		},
 		clientInfo: CLIENT_INFO,
 	};
-
 	const result = await transport.request<MCPInitializeResult>(
 		"initialize",
 		params as unknown as Record<string, unknown>,
 		{ signal: options?.signal },
 	);
-
 	if (options?.signal?.aborted) {
 		throw options.signal.reason instanceof Error ? options.signal.reason : new Error("Aborted");
 	}
-
-	// Hook point: the transport now has the session ID from the initialize response.
-	// For HTTP, this is the moment to open the SSE stream so server-to-client requests
-	// triggered by notifications/initialized (e.g. roots/list) can be delivered.
-	await options?.onInitialized?.();
-
-	// Send initialized notification
+	await options?.onLegacyInitialized?.();
 	await transport.notify("notifications/initialized");
+	return {
+		protocolVersion: result.protocolVersion,
+		serverInfo: result.serverInfo,
+		capabilities: result.capabilities,
+		instructions: result.instructions,
+	};
+}
 
-	return result;
+async function requestFromServer<T>(
+	connection: MCPServerConnection,
+	method: string,
+	params: Record<string, unknown> = {},
+	options?: MCPRequestOptions,
+): Promise<T> {
+	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION) {
+		return connection.transport.request<T>(method, params, options);
+	}
+	let requestParams = withModernRequestMeta(params);
+	for (let round = 0; round < MAX_MRTR_ROUND_TRIPS; round++) {
+		const result = await connection.transport.request<T>(method, requestParams, options);
+		if (!isRecord(result) || typeof result.resultType !== "string") {
+			throw new Error(`MCP server returned an invalid ${MODERN_PROTOCOL_VERSION} result for ${method}`);
+		}
+		if (result.resultType === "complete") return result;
+		if (result.resultType !== "input_required") {
+			throw new Error(`MCP server returned unsupported result type "${result.resultType}" for ${method}`);
+		}
+		if (isRecord(result.inputRequests) && Object.keys(result.inputRequests).length > 0) {
+			throw new Error(`MCP server requires unsupported client input while processing ${method}`);
+		}
+		if (typeof result.requestState !== "string") {
+			throw new Error(`MCP server returned input_required without requestState for ${method}`);
+		}
+		requestParams = withModernRequestMeta({ ...params, requestState: result.requestState });
+	}
+	throw new Error(`MCP server exceeded ${MAX_MRTR_ROUND_TRIPS} input-required rounds for ${method}`);
+}
+
+function cacheIsFresh(
+	connection: MCPServerConnection,
+	key: "tools" | "resources" | "resourceTemplates" | "prompts",
+): boolean {
+	const expires = connectionRuntimes.get(connection)?.cacheExpires[key];
+	return expires === undefined || expires > Date.now();
+}
+
+function updateCacheExpiry(
+	connection: MCPServerConnection,
+	key: "tools" | "resources" | "resourceTemplates" | "prompts",
+	result: MCPCacheableResult,
+): void {
+	const runtime = connectionRuntimes.get(connection);
+	if (!runtime) return;
+	const expires = typeof result.ttlMs === "number" ? Date.now() + Math.max(0, result.ttlMs) : Number.POSITIVE_INFINITY;
+	runtime.cacheExpires[key] = Math.min(runtime.cacheExpires[key] ?? Number.POSITIVE_INFINITY, expires);
+}
+
+function startModernSubscriptionListener(connection: MCPServerConnection): void {
+	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION) return;
+	const runtime = connectionRuntimes.get(connection);
+	if (!runtime) return;
+	runtime.subscriptionAbort?.abort();
+	const notifications = {
+		toolsListChanged: connection.capabilities.tools?.listChanged === true,
+		promptsListChanged: connection.capabilities.prompts?.listChanged === true,
+		resourcesListChanged: connection.capabilities.resources?.listChanged === true,
+		resourceSubscriptions: [...runtime.resourceSubscriptions],
+	};
+	if (
+		!notifications.toolsListChanged &&
+		!notifications.promptsListChanged &&
+		!notifications.resourcesListChanged &&
+		notifications.resourceSubscriptions.length === 0
+	) {
+		runtime.subscriptionAbort = undefined;
+		return;
+	}
+	const abort = new AbortController();
+	runtime.subscriptionAbort = abort;
+	void requestFromServer<MCPResult>(
+		connection,
+		"subscriptions/listen",
+		{ notifications },
+		{ signal: abort.signal, timeout: 0 },
+	).catch(error => {
+		if (!abort.signal.aborted) logger.warn("MCP subscription listener stopped", { server: connection.name, error });
+	});
 }
 
 /**
@@ -143,7 +278,24 @@ export async function connectToServer(
 	const timeoutMs = resolveMCPTimeoutMs(config.timeout);
 	let transport: MCPTransport | undefined;
 
+	const protocolMode = config.protocolMode ?? "legacy";
 	const connect = async (): Promise<MCPServerConnection> => {
+		let negotiation: MCPProtocolNegotiationResult | undefined;
+		if (protocolMode === "auto" && (config.type ?? "stdio") === "stdio") {
+			const probe = await createStdioTransport(config as MCPStdioServerConfig);
+			try {
+				negotiation = await negotiateMCPProtocol(probe, {
+					name,
+					mode: protocolMode,
+					transportType: "stdio",
+					timeoutMs,
+					signal: options?.signal,
+					modernParams: withModernRequestMeta(),
+				});
+			} finally {
+				await probe.close();
+			}
+		}
 		transport = await createTransport(config);
 		if (options?.onNotification) {
 			transport.onNotification = options.onNotification;
@@ -155,25 +307,34 @@ export async function connectToServer(
 		transport.onRequest = options?.onRequest ?? defaultRequestHandler;
 
 		try {
-			const initResult = await initializeConnection(transport, {
+			negotiation ??= await negotiateMCPProtocol(transport, {
+				name,
+				mode: protocolMode,
+				transportType: config.type ?? "stdio",
+				timeoutMs,
 				signal: options?.signal,
-				async onInitialized() {
-					// Open the SSE stream before sending initialized, so server-to-client
-					// requests triggered by on_initialized (e.g. roots/list) are delivered.
+				modernParams: withModernRequestMeta(),
+			});
+			const handshake = await initializeConnection(name, transport, negotiation, {
+				signal: options?.signal,
+				async onLegacyInitialized() {
 					if ("startSSEListener" in transport! && typeof transport!.startSSEListener === "function") {
 						await (transport as { startSSEListener(): Promise<void> }).startSSEListener();
 					}
 				},
 			});
-
-			return {
+			const connection: MCPServerConnection = {
 				name,
 				config,
 				transport,
-				serverInfo: initResult.serverInfo,
-				capabilities: initResult.capabilities,
-				instructions: initResult.instructions,
+				serverInfo: handshake.serverInfo,
+				capabilities: handshake.capabilities,
+				instructions: handshake.instructions,
+				protocolVersion: handshake.protocolVersion,
 			};
+			connectionRuntimes.set(connection, { resourceSubscriptions: new Set(), cacheExpires: {} });
+			startModernSubscriptionListener(connection);
+			return connection;
 		} catch (error) {
 			await transport.close();
 			throw error;
@@ -213,9 +374,11 @@ export async function listTools(
 	}
 
 	// Return cached tools if available
-	if (connection.tools) {
+	if (connection.tools && cacheIsFresh(connection, "tools")) {
 		return connection.tools;
 	}
+	connection.tools = undefined;
+	delete connectionRuntimes.get(connection)?.cacheExpires.tools;
 
 	const allTools: MCPToolDefinition[] = [];
 	let cursor: string | undefined;
@@ -226,8 +389,23 @@ export async function listTools(
 			params.cursor = cursor;
 		}
 
-		const result = await connection.transport.request<MCPToolsListResult>("tools/list", params, options);
-		allTools.push(...result.tools);
+		const result = await requestFromServer<MCPToolsListResult>(connection, "tools/list", params, options);
+		updateCacheExpiry(connection, "tools", result);
+		for (const tool of result.tools) {
+			if (connection.protocolVersion === MODERN_PROTOCOL_VERSION && connection.config.type === "http") {
+				const validation = collectToolHeaderBindings(tool.inputSchema);
+				if (validation.error) {
+					logger.warn("Ignoring invalid MCP tool definition", {
+						server: connection.name,
+						tool: tool.name,
+						error: validation.error,
+					});
+					continue;
+				}
+				toolHeaderBindings.set(tool, validation.bindings);
+			}
+			allTools.push(tool);
+		}
 		cursor = result.nextCursor;
 	} while (cursor);
 
@@ -251,10 +429,14 @@ export async function callTool(
 		arguments: args,
 	};
 
-	return connection.transport.request<MCPToolCallResult>(
+	const tool = connection.tools?.find(candidate => candidate.name === toolName);
+	const bindings = tool ? toolHeaderBindings.get(tool) : undefined;
+	const generatedHeaders = bindings ? buildToolParameterHeaders(bindings, args) : undefined;
+	return requestFromServer<MCPToolCallResult>(
+		connection,
 		"tools/call",
 		params as unknown as Record<string, unknown>,
-		options,
+		generatedHeaders ? { ...options, generatedHeaders } : options,
 	);
 }
 
@@ -262,6 +444,7 @@ export async function callTool(
  * Disconnect from a server.
  */
 export async function disconnectServer(connection: MCPServerConnection): Promise<void> {
+	connectionRuntimes.get(connection)?.subscriptionAbort?.abort();
 	await connection.transport.close();
 }
 
@@ -283,9 +466,11 @@ export async function listResources(
 		return [];
 	}
 
-	if (connection.resources) {
+	if (connection.resources && cacheIsFresh(connection, "resources")) {
 		return connection.resources;
 	}
+	connection.resources = undefined;
+	delete connectionRuntimes.get(connection)?.cacheExpires.resources;
 
 	const allResources: MCPResource[] = [];
 	let cursor: string | undefined;
@@ -296,7 +481,8 @@ export async function listResources(
 			params.cursor = cursor;
 		}
 
-		const result = await connection.transport.request<MCPResourcesListResult>("resources/list", params, options);
+		const result = await requestFromServer<MCPResourcesListResult>(connection, "resources/list", params, options);
+		updateCacheExpiry(connection, "resources", result);
 		allResources.push(...result.resources);
 		cursor = result.nextCursor;
 	} while (cursor);
@@ -307,10 +493,10 @@ export async function listResources(
 
 /** True when an error is a JSON-RPC "method not found" (-32601) response. */
 function isMethodNotFoundError(error: unknown): boolean {
+	if (error instanceof MCPError) return error.code === -32601;
 	const message = error instanceof Error ? error.message : String(error);
-	return message.includes("-32601") || /method not found/i.test(message);
+	return /method not found/i.test(message);
 }
-
 /**
  * List resource templates from a connected server.
  *
@@ -330,9 +516,11 @@ export async function listResourceTemplates(
 		return [];
 	}
 
-	if (connection.resourceTemplates) {
+	if (connection.resourceTemplates && cacheIsFresh(connection, "resourceTemplates")) {
 		return connection.resourceTemplates;
 	}
+	connection.resourceTemplates = undefined;
+	delete connectionRuntimes.get(connection)?.cacheExpires.resourceTemplates;
 
 	const allTemplates: MCPResourceTemplate[] = [];
 	let cursor: string | undefined;
@@ -344,11 +532,13 @@ export async function listResourceTemplates(
 				params.cursor = cursor;
 			}
 
-			const result = await connection.transport.request<MCPResourceTemplatesListResult>(
+			const result = await requestFromServer<MCPResourceTemplatesListResult>(
+				connection,
 				"resources/templates/list",
 				params,
 				options,
 			);
+			updateCacheExpiry(connection, "resourceTemplates", result);
 			allTemplates.push(...result.resourceTemplates);
 			cursor = result.nextCursor;
 		} while (cursor);
@@ -376,7 +566,8 @@ export async function readResource(
 	options?: MCPRequestOptions,
 ): Promise<MCPResourceReadResult> {
 	const params: MCPResourceReadParams = { uri };
-	return connection.transport.request<MCPResourceReadResult>(
+	return requestFromServer<MCPResourceReadResult>(
+		connection,
 		"resources/read",
 		params as unknown as Record<string, unknown>,
 		options,
@@ -392,10 +583,18 @@ export async function subscribeToResources(
 	options?: MCPRequestOptions,
 ): Promise<void> {
 	if (uris.length === 0 || !connection.capabilities.resources?.subscribe) return;
+	if (connection.protocolVersion === MODERN_PROTOCOL_VERSION) {
+		const runtime = connectionRuntimes.get(connection);
+		if (!runtime) return;
+		for (const uri of uris) runtime.resourceSubscriptions.add(uri);
+		startModernSubscriptionListener(connection);
+		return;
+	}
 	const results = await Promise.allSettled(
 		uris.map(uri => {
 			const params: MCPResourceSubscribeParams = { uri };
-			return connection.transport.request(
+			return requestFromServer(
+				connection,
 				"resources/subscribe",
 				params as unknown as Record<string, unknown>,
 				options,
@@ -418,10 +617,18 @@ export async function unsubscribeFromResources(
 	options?: MCPRequestOptions,
 ): Promise<void> {
 	if (uris.length === 0 || !connection.capabilities.resources?.subscribe) return;
+	if (connection.protocolVersion === MODERN_PROTOCOL_VERSION) {
+		const runtime = connectionRuntimes.get(connection);
+		if (!runtime) return;
+		for (const uri of uris) runtime.resourceSubscriptions.delete(uri);
+		startModernSubscriptionListener(connection);
+		return;
+	}
 	const results = await Promise.allSettled(
 		uris.map(uri => {
 			const params: MCPResourceSubscribeParams = { uri };
-			return connection.transport.request(
+			return requestFromServer(
+				connection,
 				"resources/unsubscribe",
 				params as unknown as Record<string, unknown>,
 				options,
@@ -460,9 +667,11 @@ export async function listPrompts(
 		return [];
 	}
 
-	if (connection.prompts) {
+	if (connection.prompts && cacheIsFresh(connection, "prompts")) {
 		return connection.prompts;
 	}
+	connection.prompts = undefined;
+	delete connectionRuntimes.get(connection)?.cacheExpires.prompts;
 
 	const allPrompts: MCPPrompt[] = [];
 	let cursor: string | undefined;
@@ -473,7 +682,8 @@ export async function listPrompts(
 			params.cursor = cursor;
 		}
 
-		const result = await connection.transport.request<MCPPromptsListResult>("prompts/list", params, options);
+		const result = await requestFromServer<MCPPromptsListResult>(connection, "prompts/list", params, options);
+		updateCacheExpiry(connection, "prompts", result);
 		allPrompts.push(...result.prompts);
 		cursor = result.nextCursor;
 	} while (cursor);
@@ -496,7 +706,8 @@ export async function getPrompt(
 		params.arguments = args;
 	}
 
-	return connection.transport.request<MCPGetPromptResult>(
+	return requestFromServer<MCPGetPromptResult>(
+		connection,
 		"prompts/get",
 		params as unknown as Record<string, unknown>,
 		options,

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -724,7 +724,7 @@ export async function callTool(
 		arguments: args,
 	};
 
-	const tool = toolDefinition ?? connection.tools?.find(candidate => candidate.name === toolName);
+	const tool = connection.tools?.find(candidate => candidate.name === toolName) ?? toolDefinition;
 	const bindings = tool ? resolveToolHeaderBindings(connection, tool).bindings : undefined;
 	const generatedHeaders = bindings ? buildToolParameterHeaders(bindings, args) : undefined;
 	return requestFromServer<MCPToolCallResult>(
@@ -893,9 +893,16 @@ export async function subscribeToResources(
 	if (connection.protocolVersion === MODERN_PROTOCOL_VERSION) {
 		const runtime = connectionRuntimes.get(connection);
 		if (!runtime) return [];
+		const previousSubscriptions = new Set(runtime.resourceSubscriptions);
 		for (const uri of uris) runtime.resourceSubscriptions.add(uri);
-		const accepted = await startModernSubscriptionListener(connection, options);
-		return accepted.filter(uri => uris.includes(uri));
+		try {
+			const accepted = await startModernSubscriptionListener(connection, options);
+			return accepted.filter(uri => uris.includes(uri));
+		} catch (error) {
+			runtime.resourceSubscriptions = previousSubscriptions;
+			scheduleSubscriptionRestart(connection);
+			throw error;
+		}
 	}
 	const results = await Promise.allSettled(
 		uris.map(uri => {

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -644,6 +644,7 @@ export async function connectToServer(
 			connectionForNotifications = connection;
 			void startModernSubscriptionListener(connection).catch(error => {
 				logger.warn("MCP subscription acknowledgment failed", { server: connection.name, error });
+				scheduleSubscriptionRestart(connection);
 			});
 			return connection;
 		} catch (error) {

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -30,6 +30,7 @@ import type {
 	MCPImplementation,
 	MCPInitializeParams,
 	MCPInitializeResult,
+	MCPInputRequiredResult,
 	MCPPrompt,
 	MCPPromptsListResult,
 	MCPRequestOptions,
@@ -60,7 +61,7 @@ const CLIENT_INFO = {
 	name: "omp-coding-agent",
 	version: "1.0.0",
 };
-const MODERN_CLIENT_CAPABILITIES = {};
+const MODERN_CLIENT_CAPABILITIES = { roots: {} };
 const toolHeaderBindings = new WeakMap<MCPToolDefinition, MCPToolHeaderBinding[]>();
 
 interface MCPHandshakeResult {
@@ -69,9 +70,28 @@ interface MCPHandshakeResult {
 	capabilities: MCPServerCapabilities;
 	instructions?: string;
 }
+interface MCPSubscriptionFilter {
+	toolsListChanged: boolean;
+	promptsListChanged: boolean;
+	resourcesListChanged: boolean;
+	resourceSubscriptions: string[];
+}
+
+interface MCPSubscriptionState {
+	abort: AbortController;
+	requestId?: string | number;
+	requested: MCPSubscriptionFilter;
+	settled: boolean;
+	resolve: (acceptedResourceUris: string[]) => void;
+	reject: (error: Error) => void;
+}
+
 interface MCPConnectionRuntime {
-	subscriptionAbort?: AbortController;
+	subscription?: MCPSubscriptionState;
 	resourceSubscriptions: Set<string>;
+	cacheScopes: Partial<
+		Record<"tools" | "resources" | "resourceTemplates" | "prompts", "public" | "private" | "uncacheable">
+	>;
 	cacheExpires: Partial<Record<"tools" | "resources" | "resourceTemplates" | "prompts", number>>;
 }
 
@@ -180,6 +200,49 @@ async function initializeConnection(
 	};
 }
 
+async function fulfillInputRequests(
+	connection: MCPServerConnection,
+	result: MCPInputRequiredResult,
+	method: string,
+): Promise<Record<string, unknown> | undefined> {
+	if (result.requestState !== undefined && typeof result.requestState !== "string") {
+		throw new Error(`MCP server returned invalid requestState while processing ${method}`);
+	}
+	if (result.inputRequests === undefined) {
+		if (result.requestState === undefined) {
+			throw new Error(`MCP server returned input_required without inputRequests or requestState for ${method}`);
+		}
+		return undefined;
+	}
+	if (!isRecord(result.inputRequests)) {
+		throw new Error(`MCP server returned invalid inputRequests while processing ${method}`);
+	}
+	if (Object.keys(result.inputRequests).length === 0 && result.requestState === undefined) {
+		throw new Error(`MCP server returned input_required without inputRequests or requestState for ${method}`);
+	}
+	const handler = connection.transport.onRequest;
+	if (!handler && Object.keys(result.inputRequests).length > 0) {
+		throw new Error(`MCP server requires unsupported client input while processing ${method}`);
+	}
+	const entries = await Promise.all(
+		Object.entries(result.inputRequests).map(async ([id, request]) => {
+			if (!isRecord(request) || typeof request.method !== "string") {
+				throw new Error(`MCP server returned an invalid input request while processing ${method}`);
+			}
+			if (request.method !== "roots/list") {
+				throw new Error(
+					`MCP server requested unsupported client input "${request.method}" while processing ${method}`,
+				);
+			}
+			if (request.params !== undefined && !isRecord(request.params)) {
+				throw new Error(`MCP server returned invalid input request params while processing ${method}`);
+			}
+			return [id, await handler!(request.method, request.params)] as const;
+		}),
+	);
+	return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 async function requestFromServer<T>(
 	connection: MCPServerConnection,
 	method: string,
@@ -199,13 +262,16 @@ async function requestFromServer<T>(
 		if (result.resultType !== "input_required") {
 			throw new Error(`MCP server returned unsupported result type "${result.resultType}" for ${method}`);
 		}
-		if (isRecord(result.inputRequests) && Object.keys(result.inputRequests).length > 0) {
-			throw new Error(`MCP server requires unsupported client input while processing ${method}`);
+		if (method !== "tools/call" && method !== "prompts/get" && method !== "resources/read") {
+			throw new Error(`MCP server returned input_required for unsupported method ${method}`);
 		}
-		if (typeof result.requestState !== "string") {
-			throw new Error(`MCP server returned input_required without requestState for ${method}`);
-		}
-		requestParams = withModernRequestMeta({ ...params, requestState: result.requestState });
+		const inputRequired = result as unknown as MCPInputRequiredResult;
+		const inputResponses = await fulfillInputRequests(connection, inputRequired, method);
+		requestParams = withModernRequestMeta({
+			...params,
+			...(inputResponses === undefined ? {} : { inputResponses }),
+			...(inputRequired.requestState === undefined ? {} : { requestState: inputRequired.requestState }),
+		});
 	}
 	throw new Error(`MCP server exceeded ${MAX_MRTR_ROUND_TRIPS} input-required rounds for ${method}`);
 }
@@ -225,16 +291,94 @@ function updateCacheExpiry(
 ): void {
 	const runtime = connectionRuntimes.get(connection);
 	if (!runtime) return;
-	const expires = typeof result.ttlMs === "number" ? Date.now() + Math.max(0, result.ttlMs) : Number.POSITIVE_INFINITY;
+	const ttlMs =
+		connection.protocolVersion === MODERN_PROTOCOL_VERSION
+			? typeof result.ttlMs === "number"
+				? Math.max(0, result.ttlMs)
+				: 0
+			: Number.POSITIVE_INFINITY;
+	const expires = ttlMs === Number.POSITIVE_INFINITY ? ttlMs : Date.now() + ttlMs;
 	runtime.cacheExpires[key] = Math.min(runtime.cacheExpires[key] ?? Number.POSITIVE_INFINITY, expires);
+	if (connection.protocolVersion === MODERN_PROTOCOL_VERSION) {
+		const scope = result.cacheScope ?? "uncacheable";
+		const previousScope = runtime.cacheScopes[key];
+		runtime.cacheScopes[key] = previousScope === undefined ? scope : previousScope === scope ? scope : "uncacheable";
+	}
 }
 
-function startModernSubscriptionListener(connection: MCPServerConnection): void {
-	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION) return;
+export function getToolCachePolicy(
+	connection: MCPServerConnection,
+): { ttlMs?: number; cacheScope?: "public" | "private" } | undefined {
+	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION) return undefined;
 	const runtime = connectionRuntimes.get(connection);
-	if (!runtime) return;
-	runtime.subscriptionAbort?.abort();
-	const notifications = {
+	const expires = runtime?.cacheExpires.tools;
+	return {
+		ttlMs:
+			expires === undefined || expires === Number.POSITIVE_INFINITY ? undefined : Math.max(0, expires - Date.now()),
+		cacheScope:
+			runtime?.cacheScopes.tools === "public" || runtime?.cacheScopes.tools === "private"
+				? runtime.cacheScopes.tools
+				: undefined,
+	};
+}
+
+function settleSubscriptionError(state: MCPSubscriptionState, error: Error): void {
+	if (state.settled) return;
+	state.abort.abort(error);
+	state.settled = true;
+	state.reject(error);
+}
+function handleSubscriptionAcknowledgment(connection: MCPServerConnection, method: string, params: unknown): void {
+	if (method !== "notifications/subscriptions/acknowledged") return;
+	const runtime = connectionRuntimes.get(connection);
+	const state = runtime?.subscription;
+	if (!runtime || !state || !isRecord(params) || !isRecord(params._meta)) return;
+	const subscriptionId = params._meta["io.modelcontextprotocol/subscriptionId"];
+	if (state.requestId === undefined || subscriptionId === undefined || subscriptionId !== state.requestId) return;
+	if (!isRecord(params.notifications)) {
+		settleSubscriptionError(state, new Error("MCP server returned an invalid subscription acknowledgment"));
+		return;
+	}
+	for (const key of ["toolsListChanged", "promptsListChanged", "resourcesListChanged"] as const) {
+		const accepted = params.notifications[key];
+		if (
+			(accepted !== undefined && typeof accepted !== "boolean") ||
+			(accepted === true && state.requested[key] !== true)
+		) {
+			settleSubscriptionError(state, new Error("MCP server acknowledged an invalid subscription filter"));
+			return;
+		}
+	}
+	const acceptedValue = params.notifications.resourceSubscriptions;
+	const accepted =
+		acceptedValue === undefined
+			? []
+			: Array.isArray(acceptedValue) && acceptedValue.every(uri => typeof uri === "string")
+				? acceptedValue
+				: undefined;
+	if (!accepted || accepted.some(uri => !state.requested.resourceSubscriptions.includes(uri))) {
+		settleSubscriptionError(state, new Error("MCP server acknowledged an invalid resource subscription filter"));
+		return;
+	}
+	if (state.settled) return;
+	runtime.resourceSubscriptions = new Set(accepted);
+	state.settled = true;
+	state.resolve(accepted);
+}
+
+async function startModernSubscriptionListener(
+	connection: MCPServerConnection,
+	options?: MCPRequestOptions,
+): Promise<string[]> {
+	if (connection.protocolVersion !== MODERN_PROTOCOL_VERSION) return [];
+	const runtime = connectionRuntimes.get(connection);
+	if (!runtime) return [];
+	const previous = runtime.subscription;
+	if (previous) {
+		previous.abort.abort();
+		settleSubscriptionError(previous, new Error("MCP subscription was replaced"));
+	}
+	const notifications: MCPSubscriptionFilter = {
 		toolsListChanged: connection.capabilities.tools?.listChanged === true,
 		promptsListChanged: connection.capabilities.prompts?.listChanged === true,
 		resourcesListChanged: connection.capabilities.resources?.listChanged === true,
@@ -246,18 +390,64 @@ function startModernSubscriptionListener(connection: MCPServerConnection): void 
 		!notifications.resourcesListChanged &&
 		notifications.resourceSubscriptions.length === 0
 	) {
-		runtime.subscriptionAbort = undefined;
-		return;
+		runtime.subscription = undefined;
+		return [];
 	}
 	const abort = new AbortController();
-	runtime.subscriptionAbort = abort;
+	const acknowledged = Promise.withResolvers<string[]>();
+	const state: MCPSubscriptionState = {
+		abort,
+		requested: notifications,
+		settled: false,
+		resolve: acknowledged.resolve,
+		reject: acknowledged.reject,
+	};
+	runtime.subscription = state;
+	const acknowledgmentTimeoutMs = resolveMCPTimeoutMs(options?.timeout ?? connection.config.timeout);
+	let acknowledgmentTimer: NodeJS.Timeout | undefined;
+	const abortAcknowledgment = (): void => {
+		const reason = options?.signal?.reason;
+		settleSubscriptionError(state, reason instanceof Error ? reason : new Error("MCP subscription aborted"));
+	};
+	if (options?.signal?.aborted) {
+		abortAcknowledgment();
+	} else {
+		options?.signal?.addEventListener("abort", abortAcknowledgment, { once: true });
+		if (isMCPTimeoutEnabled(acknowledgmentTimeoutMs)) {
+			acknowledgmentTimer = setTimeout(() => {
+				settleSubscriptionError(
+					state,
+					new Error(
+						`MCP subscription acknowledgment timed out after ${describeMCPTimeout(acknowledgmentTimeoutMs)}`,
+					),
+				);
+			}, acknowledgmentTimeoutMs);
+		}
+	}
 	void requestFromServer<MCPResult>(
 		connection,
 		"subscriptions/listen",
 		{ notifications },
-		{ signal: abort.signal, timeout: 0 },
-	).catch(error => {
-		if (!abort.signal.aborted) logger.warn("MCP subscription listener stopped", { server: connection.name, error });
+		{
+			signal: abort.signal,
+			timeout: 0,
+			onRequestId: id => {
+				state.requestId = id;
+			},
+		},
+	)
+		.then(() => {
+			settleSubscriptionError(state, new Error("MCP subscription ended before acknowledgment"));
+		})
+		.catch(error => {
+			if (!abort.signal.aborted) {
+				logger.warn("MCP subscription listener stopped", { server: connection.name, error });
+			}
+			settleSubscriptionError(state, error instanceof Error ? error : new Error(String(error)));
+		});
+	return acknowledged.promise.finally(() => {
+		clearTimeout(acknowledgmentTimer);
+		options?.signal?.removeEventListener("abort", abortAcknowledgment);
 	});
 }
 
@@ -297,9 +487,13 @@ export async function connectToServer(
 			}
 		}
 		transport = await createTransport(config);
-		if (options?.onNotification) {
-			transport.onNotification = options.onNotification;
-		}
+		let connectionForNotifications: MCPServerConnection | undefined;
+		transport.onNotification = (method, params) => {
+			if (connectionForNotifications) {
+				handleSubscriptionAcknowledgment(connectionForNotifications, method, params);
+			}
+			options?.onNotification?.(method, params);
+		};
 
 		// Always handle standard MCP server-to-client requests (ping, roots/list).
 		// The initialize request declares roots capability, so we must respond to
@@ -332,8 +526,11 @@ export async function connectToServer(
 				instructions: handshake.instructions,
 				protocolVersion: handshake.protocolVersion,
 			};
-			connectionRuntimes.set(connection, { resourceSubscriptions: new Set(), cacheExpires: {} });
-			startModernSubscriptionListener(connection);
+			connectionRuntimes.set(connection, { resourceSubscriptions: new Set(), cacheExpires: {}, cacheScopes: {} });
+			connectionForNotifications = connection;
+			void startModernSubscriptionListener(connection).catch(error => {
+				logger.warn("MCP subscription acknowledgment failed", { server: connection.name, error });
+			});
 			return connection;
 		} catch (error) {
 			await transport.close();
@@ -379,6 +576,7 @@ export async function listTools(
 	}
 	connection.tools = undefined;
 	delete connectionRuntimes.get(connection)?.cacheExpires.tools;
+	delete connectionRuntimes.get(connection)?.cacheScopes.tools;
 
 	const allTools: MCPToolDefinition[] = [];
 	let cursor: string | undefined;
@@ -444,7 +642,11 @@ export async function callTool(
  * Disconnect from a server.
  */
 export async function disconnectServer(connection: MCPServerConnection): Promise<void> {
-	connectionRuntimes.get(connection)?.subscriptionAbort?.abort();
+	const subscription = connectionRuntimes.get(connection)?.subscription;
+	if (subscription) {
+		subscription.abort.abort();
+		settleSubscriptionError(subscription, new Error("MCP connection closed"));
+	}
 	await connection.transport.close();
 }
 
@@ -471,6 +673,7 @@ export async function listResources(
 	}
 	connection.resources = undefined;
 	delete connectionRuntimes.get(connection)?.cacheExpires.resources;
+	delete connectionRuntimes.get(connection)?.cacheScopes.resources;
 
 	const allResources: MCPResource[] = [];
 	let cursor: string | undefined;
@@ -521,6 +724,7 @@ export async function listResourceTemplates(
 	}
 	connection.resourceTemplates = undefined;
 	delete connectionRuntimes.get(connection)?.cacheExpires.resourceTemplates;
+	delete connectionRuntimes.get(connection)?.cacheScopes.resourceTemplates;
 
 	const allTemplates: MCPResourceTemplate[] = [];
 	let cursor: string | undefined;
@@ -581,14 +785,14 @@ export async function subscribeToResources(
 	connection: MCPServerConnection,
 	uris: string[],
 	options?: MCPRequestOptions,
-): Promise<void> {
-	if (uris.length === 0 || !connection.capabilities.resources?.subscribe) return;
+): Promise<string[]> {
+	if (uris.length === 0 || !connection.capabilities.resources?.subscribe) return [];
 	if (connection.protocolVersion === MODERN_PROTOCOL_VERSION) {
 		const runtime = connectionRuntimes.get(connection);
-		if (!runtime) return;
+		if (!runtime) return [];
 		for (const uri of uris) runtime.resourceSubscriptions.add(uri);
-		startModernSubscriptionListener(connection);
-		return;
+		const accepted = await startModernSubscriptionListener(connection, options);
+		return accepted.filter(uri => uris.includes(uri));
 	}
 	const results = await Promise.allSettled(
 		uris.map(uri => {
@@ -601,11 +805,15 @@ export async function subscribeToResources(
 			);
 		}),
 	);
-	for (const result of results) {
+	const accepted: string[] = [];
+	for (const [index, result] of results.entries()) {
 		if (result.status === "rejected") {
 			logger.warn("Failed to subscribe to MCP resource", { error: result.reason });
+		} else {
+			accepted.push(uris[index]!);
 		}
 	}
+	return accepted;
 }
 
 /**
@@ -621,7 +829,7 @@ export async function unsubscribeFromResources(
 		const runtime = connectionRuntimes.get(connection);
 		if (!runtime) return;
 		for (const uri of uris) runtime.resourceSubscriptions.delete(uri);
-		startModernSubscriptionListener(connection);
+		await startModernSubscriptionListener(connection, options);
 		return;
 	}
 	const results = await Promise.allSettled(
@@ -672,6 +880,7 @@ export async function listPrompts(
 	}
 	connection.prompts = undefined;
 	delete connectionRuntimes.get(connection)?.cacheExpires.prompts;
+	delete connectionRuntimes.get(connection)?.cacheScopes.prompts;
 
 	const allPrompts: MCPPrompt[] = [];
 	let cursor: string | undefined;

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -42,6 +42,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 		enabled: server.enabled,
 		timeout: server.timeout,
 		requestIdFormat: server.requestIdFormat,
+		protocolMode: server.protocolMode,
 		auth: server.auth,
 		oauth: server.oauth,
 	};

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -16,6 +16,7 @@ import {
 	connectToServer,
 	disconnectServer,
 	getPrompt,
+	getToolCachePolicy,
 	listPrompts,
 	listResources,
 	listResourceTemplates,
@@ -319,14 +320,14 @@ export class MCPManager {
 
 	#subscribeAndTrack(name: string, connection: MCPServerConnection, uris: string[], notificationEpoch: number): void {
 		void subscribeToResources(connection, uris)
-			.then(() => {
+			.then(acceptedUris => {
 				const action = resolveSubscriptionPostAction(
 					this.#notificationsEnabled,
 					this.#notificationsEpoch,
 					notificationEpoch,
 				);
 				if (action === "rollback") {
-					void unsubscribeFromResources(connection, uris).catch(error => {
+					void unsubscribeFromResources(connection, acceptedUris).catch(error => {
 						logger.debug("Failed to rollback stale MCP resource subscription", {
 							path: `mcp:${name}`,
 							error,
@@ -337,7 +338,7 @@ export class MCPManager {
 				if (action === "ignore") {
 					return;
 				}
-				this.#subscribedResources.set(name, new Set(uris));
+				this.#subscribedResources.set(name, new Set(acceptedUris));
 			})
 			.catch(error => {
 				logger.debug("Failed to subscribe to MCP resources", { path: `mcp:${name}`, error });
@@ -554,7 +555,7 @@ export class MCPManager {
 					const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 					this.#replaceServerTools(name, customTools);
 					void this.#onToolsChanged?.(this.#tools);
-					void this.toolCache?.set(name, config, serverTools);
+					void this.toolCache?.set(name, config, serverTools, getToolCachePolicy(connection));
 
 					onStatus?.({ type: "connected", serverName: name });
 					await this.#loadServerResourcesAndPrompts(name, connection);
@@ -1123,7 +1124,7 @@ export class MCPManager {
 			const serverTools = await listTools(connection);
 			const reconnect = (options?: { authChallenge?: MCPAuthChallenge }) => this.reconnectServer(name, options);
 			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
-			void this.toolCache?.set(name, config, serverTools);
+			void this.toolCache?.set(name, config, serverTools, getToolCachePolicy(connection));
 			this.#replaceServerTools(name, customTools);
 			void this.#onToolsChanged?.(this.#tools);
 			void this.#loadServerResourcesAndPrompts(name, connection);
@@ -1174,7 +1175,7 @@ export class MCPManager {
 		const serverTools = await listTools(connection);
 		const reconnect = () => this.reconnectServer(name);
 		const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
-		void this.toolCache?.set(name, connection.config, serverTools);
+		void this.toolCache?.set(name, connection.config, serverTools, getToolCachePolicy(connection));
 
 		// Replace tools from this server
 		this.#replaceServerTools(name, customTools);
@@ -1238,14 +1239,14 @@ export class MCPManager {
 				// Subscribe to the current set and update tracking atomically
 				try {
 					const allUris = [...newUris];
-					await subscribeToResources(connection, allUris);
+					const acceptedUris = await subscribeToResources(connection, allUris);
 					const action = resolveSubscriptionPostAction(
 						this.#notificationsEnabled,
 						this.#notificationsEpoch,
 						notificationEpoch,
 					);
 					if (action === "rollback") {
-						await unsubscribeFromResources(connection, allUris).catch(error => {
+						await unsubscribeFromResources(connection, acceptedUris).catch(error => {
 							logger.debug("Failed to rollback stale MCP resource subscription", { path: `mcp:${name}`, error });
 						});
 						return;
@@ -1253,7 +1254,7 @@ export class MCPManager {
 					if (action === "ignore") {
 						return;
 					}
-					this.#subscribedResources.set(name, newUris);
+					this.#subscribedResources.set(name, new Set(acceptedUris));
 				} catch (error) {
 					logger.debug("Failed to re-subscribe to MCP resources", { path: `mcp:${name}`, error });
 				}

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -6,6 +6,7 @@
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { isRecord } from "@oh-my-pi/pi-utils";
 import { withTimeoutSignal } from "../utils/fetch-timeout";
 
 /** Per-request abort deadline for each OAuth discovery metadata fetch. */
@@ -143,28 +144,24 @@ export function extractOAuthEndpoints(error: Error): OAuthEndpoints | null {
 		// Many MCP servers return JSON with OAuth endpoints in error body
 		const jsonMatch = errorMsg.match(/\{[\s\S]*\}/);
 		if (jsonMatch) {
-			const errorBody = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
-
-			// Check for OAuth endpoints in error body
-			if (errorBody.oauth || errorBody.authorization || errorBody.auth) {
-				const oauthData = (errorBody.oauth || errorBody.authorization || errorBody.auth) as Record<string, unknown>;
-				const endpoints = readEndpointsFromObject(oauthData);
-				if (endpoints) {
-					return {
-						...endpoints,
-						clientId: endpoints.clientId || clientIdFromAuthUrl(endpoints.authorizationUrl),
-						scopes: endpoints.scopes || scopeFromAuthUrl(endpoints.authorizationUrl),
-					};
+			const errorBody = JSON.parse(jsonMatch[0]);
+			if (isRecord(errorBody)) {
+				const rpcError = isRecord(errorBody.error) ? errorBody.error : undefined;
+				const rpcData = rpcError && isRecord(rpcError.data) ? rpcError.data : undefined;
+				for (const candidate of [errorBody, rpcError, rpcData]) {
+					if (!candidate) continue;
+					const oauthData = candidate.oauth || candidate.authorization || candidate.auth;
+					const endpoints = isRecord(oauthData)
+						? readEndpointsFromObject(oauthData)
+						: readEndpointsFromObject(candidate);
+					if (endpoints) {
+						return {
+							...endpoints,
+							clientId: endpoints.clientId || clientIdFromAuthUrl(endpoints.authorizationUrl),
+							scopes: endpoints.scopes || scopeFromAuthUrl(endpoints.authorizationUrl),
+						};
+					}
 				}
-			}
-
-			const topLevelEndpoints = readEndpointsFromObject(errorBody);
-			if (topLevelEndpoints) {
-				return {
-					...topLevelEndpoints,
-					clientId: topLevelEndpoints.clientId || clientIdFromAuthUrl(topLevelEndpoints.authorizationUrl),
-					scopes: topLevelEndpoints.scopes || scopeFromAuthUrl(topLevelEndpoints.authorizationUrl),
-				};
 			}
 		}
 	} catch {

--- a/packages/coding-agent/src/mcp/protocol-negotiation.ts
+++ b/packages/coding-agent/src/mcp/protocol-negotiation.ts
@@ -1,0 +1,97 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
+import { isMCPTimeoutEnabled } from "./timeout";
+import type { MCPDiscoverResult, MCPProtocolMode, MCPTransport } from "./types";
+import { MCPError, MCPHttpError } from "./types";
+
+export const MODERN_PROTOCOL_VERSION = "2026-07-28";
+export const LEGACY_PROTOCOL_VERSION = "2025-03-26";
+
+const DISCOVERY_TIMEOUT_MS = 500;
+const MODERN_ERROR_CODES: Record<number, true> = { [-32020]: true, [-32021]: true, [-32022]: true };
+const LEGACY_HTTP_FALLBACK_STATUSES: Record<number, true> = { 404: true, 405: true };
+const KNOWN_LEGACY_PROTOCOL_VERSIONS = new Set(["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]);
+
+export type MCPProtocolNegotiationResult = { kind: "legacy" } | { kind: "modern"; discovery: MCPDiscoverResult };
+
+interface MCPProtocolNegotiationOptions {
+	name: string;
+	mode: MCPProtocolMode;
+	transportType: "stdio" | "http" | "sse";
+	timeoutMs: number;
+	signal?: AbortSignal;
+	modernParams: Record<string, unknown>;
+}
+
+function isValidDiscovery(value: MCPDiscoverResult): boolean {
+	return (
+		value.resultType === "complete" &&
+		Array.isArray(value.supportedVersions) &&
+		value.supportedVersions.every(version => typeof version === "string") &&
+		isRecord(value.capabilities)
+	);
+}
+
+function isLegacyHttpEvidence(error: unknown): boolean {
+	if (error instanceof MCPHttpError) return LEGACY_HTTP_FALLBACK_STATUSES[error.status] === true;
+	return (
+		error instanceof MCPError &&
+		error.code === -32601 &&
+		(error.status === undefined || error.status === 400 || error.status === 404 || error.status === 405)
+	);
+}
+
+function canFallBackFromDiscovery(error: unknown, transportType: "stdio" | "http" | "sse"): boolean {
+	if (error instanceof MCPError && MODERN_ERROR_CODES[error.code]) return false;
+	if (transportType === "http") return isLegacyHttpEvidence(error);
+	if (transportType === "stdio") return error instanceof MCPError && error.code === -32601;
+	return false;
+}
+
+export async function negotiateMCPProtocol(
+	transport: MCPTransport,
+	options: MCPProtocolNegotiationOptions,
+): Promise<MCPProtocolNegotiationResult> {
+	if (options.mode === "legacy" || (options.mode === "auto" && options.transportType === "sse")) {
+		return { kind: "legacy" };
+	}
+	if (options.transportType === "sse") {
+		throw new Error(`MCP server "${options.name}" cannot use protocol ${MODERN_PROTOCOL_VERSION} over legacy SSE`);
+	}
+
+	const discoveryTimeout = isMCPTimeoutEnabled(options.timeoutMs)
+		? Math.min(options.timeoutMs, DISCOVERY_TIMEOUT_MS)
+		: DISCOVERY_TIMEOUT_MS;
+	let discovery: MCPDiscoverResult;
+	try {
+		discovery = await transport.request<MCPDiscoverResult>("server/discover", options.modernParams, {
+			signal: options.signal,
+			timeout: discoveryTimeout,
+		});
+	} catch (error) {
+		if (
+			options.signal?.aborted ||
+			options.mode === "2026-07-28" ||
+			!canFallBackFromDiscovery(error, options.transportType)
+		) {
+			throw error;
+		}
+		return { kind: "legacy" };
+	}
+
+	if (!isValidDiscovery(discovery)) {
+		throw new Error(`MCP server "${options.name}" returned an invalid server/discover result`);
+	}
+	if (discovery.supportedVersions.includes(MODERN_PROTOCOL_VERSION)) {
+		return { kind: "modern", discovery };
+	}
+	if (
+		options.mode === "auto" &&
+		discovery.supportedVersions.length > 0 &&
+		discovery.supportedVersions.every(version => KNOWN_LEGACY_PROTOCOL_VERSIONS.has(version))
+	) {
+		return { kind: "legacy" };
+	}
+	throw new Error(
+		`MCP server "${options.name}" does not support protocol ${MODERN_PROTOCOL_VERSION} (${discovery.supportedVersions.join(", ") || "no versions advertised"})`,
+	);
+}

--- a/packages/coding-agent/src/mcp/protocol-negotiation.ts
+++ b/packages/coding-agent/src/mcp/protocol-negotiation.ts
@@ -57,9 +57,12 @@ export async function negotiateMCPProtocol(
 		throw new Error(`MCP server "${options.name}" cannot use protocol ${MODERN_PROTOCOL_VERSION} over legacy SSE`);
 	}
 
-	const discoveryTimeout = isMCPTimeoutEnabled(options.timeoutMs)
-		? Math.min(options.timeoutMs, DISCOVERY_TIMEOUT_MS)
-		: DISCOVERY_TIMEOUT_MS;
+	const discoveryTimeout =
+		options.mode === "auto"
+			? isMCPTimeoutEnabled(options.timeoutMs)
+				? Math.min(options.timeoutMs, DISCOVERY_TIMEOUT_MS)
+				: DISCOVERY_TIMEOUT_MS
+			: options.timeoutMs;
 	let discovery: MCPDiscoverResult;
 	try {
 		discovery = await transport.request<MCPDiscoverResult>("server/discover", options.modernParams, {

--- a/packages/coding-agent/src/mcp/protocol-negotiation.ts
+++ b/packages/coding-agent/src/mcp/protocol-negotiation.ts
@@ -8,7 +8,7 @@ export const LEGACY_PROTOCOL_VERSION = "2025-03-26";
 
 const DISCOVERY_TIMEOUT_MS = 500;
 const MODERN_ERROR_CODES: Record<number, true> = { [-32020]: true, [-32021]: true, [-32022]: true };
-const LEGACY_HTTP_FALLBACK_STATUSES: Record<number, true> = { 404: true, 405: true };
+const LEGACY_HTTP_FALLBACK_STATUSES: Record<number, true> = { 400: true, 404: true, 405: true };
 const KNOWN_LEGACY_PROTOCOL_VERSIONS = new Set(["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]);
 
 export type MCPProtocolNegotiationResult = { kind: "legacy" } | { kind: "modern"; discovery: MCPDiscoverResult };
@@ -22,8 +22,9 @@ interface MCPProtocolNegotiationOptions {
 	modernParams: Record<string, unknown>;
 }
 
-function isValidDiscovery(value: MCPDiscoverResult): boolean {
+function isValidDiscovery(value: unknown): value is MCPDiscoverResult {
 	return (
+		isRecord(value) &&
 		value.resultType === "complete" &&
 		Array.isArray(value.supportedVersions) &&
 		value.supportedVersions.every(version => typeof version === "string") &&
@@ -32,18 +33,16 @@ function isValidDiscovery(value: MCPDiscoverResult): boolean {
 }
 
 function isLegacyHttpEvidence(error: unknown): boolean {
-	if (error instanceof MCPHttpError) return LEGACY_HTTP_FALLBACK_STATUSES[error.status] === true;
-	return (
-		error instanceof MCPError &&
-		error.code === -32601 &&
-		(error.status === undefined || error.status === 400 || error.status === 404 || error.status === 405)
-	);
+	const status = error instanceof MCPHttpError || error instanceof MCPError ? error.status : undefined;
+	if (status === undefined || LEGACY_HTTP_FALLBACK_STATUSES[status] !== true) return false;
+	if (error instanceof MCPHttpError) return true;
+	return error instanceof MCPError && !MODERN_ERROR_CODES[error.code] && error.code !== -32601;
 }
 
 function canFallBackFromDiscovery(error: unknown, transportType: "stdio" | "http" | "sse"): boolean {
 	if (error instanceof MCPError && MODERN_ERROR_CODES[error.code]) return false;
 	if (transportType === "http") return isLegacyHttpEvidence(error);
-	if (transportType === "stdio") return error instanceof MCPError && error.code === -32601;
+	if (transportType === "stdio") return true;
 	return false;
 }
 
@@ -79,6 +78,7 @@ export async function negotiateMCPProtocol(
 	}
 
 	if (!isValidDiscovery(discovery)) {
+		if (options.mode === "auto" && options.transportType === "stdio") return { kind: "legacy" };
 		throw new Error(`MCP server "${options.name}" returned an invalid server/discover result`);
 	}
 	if (discovery.supportedVersions.includes(MODERN_PROTOCOL_VERSION)) {

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -279,8 +279,9 @@ async function callToolWithAuthRetry(
 	args: MCPToolArgs,
 	reconnect: MCPReconnect | undefined,
 	signal?: AbortSignal,
+	toolDefinition?: MCPToolDefinition,
 ): Promise<MCPToolCallAttempt> {
-	const result = await callTool(connection, toolName, args, { signal });
+	const result = await callTool(connection, toolName, args, { signal }, toolDefinition);
 	const authChallenge = getMcpAuthChallenge(result);
 	if (!authChallenge || !reconnect) return { connection, result };
 
@@ -296,7 +297,7 @@ async function callToolWithAuthRetry(
 	try {
 		return {
 			connection: newConnection,
-			result: await callTool(newConnection, toolName, args, { signal }),
+			result: await callTool(newConnection, toolName, args, { signal }, toolDefinition),
 		};
 	} catch (error) {
 		rethrowIfAborted(error, signal);
@@ -489,7 +490,14 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const providerName = this.connection._source?.providerName;
 
 		try {
-			const attempt = await callToolWithAuthRetry(this.connection, this.tool.name, args, this.reconnect, signal);
+			const attempt = await callToolWithAuthRetry(
+				this.connection,
+				this.tool.name,
+				args,
+				this.reconnect,
+				signal,
+				this.tool,
+			);
 			if (attempt.error !== undefined) {
 				return buildErrorResult(attempt.error, this.connection.name, this.tool.name, provider, providerName);
 			}
@@ -520,7 +528,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 					const retryProvider = newConn._source?.provider ?? provider;
 					const retryProviderName = newConn._source?.providerName ?? providerName;
 					try {
-						const result = await callTool(newConn, this.tool.name, args, { signal });
+						const result = await callTool(newConn, this.tool.name, args, { signal }, this.tool);
 						return buildResult(result, newConn.name, this.tool.name, retryProvider, retryProviderName);
 					} catch (retryError) {
 						rethrowIfAborted(retryError, signal);
@@ -612,7 +620,14 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 			const connection = await untilAborted(signal, () => this.getConnection());
 			throwIfAborted(signal);
 			try {
-				const attempt = await callToolWithAuthRetry(connection, this.tool.name, args, this.reconnect, signal);
+				const attempt = await callToolWithAuthRetry(
+					connection,
+					this.tool.name,
+					args,
+					this.reconnect,
+					signal,
+					this.tool,
+				);
 				if (attempt.error !== undefined) {
 					return buildErrorResult(
 						attempt.error,
@@ -646,7 +661,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 						const retryProvider = newConn._source?.provider ?? provider;
 						const retryProviderName = newConn._source?.providerName ?? providerName;
 						try {
-							const result = await callTool(newConn, this.tool.name, args, { signal });
+							const result = await callTool(newConn, this.tool.name, args, { signal }, this.tool);
 							return buildResult(result, this.serverName, this.tool.name, retryProvider, retryProviderName);
 						} catch (retryError) {
 							rethrowIfAborted(retryError, signal);
@@ -671,7 +686,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 				const newConn = await reconnectWithAbort(this.reconnect, signal);
 				if (newConn) {
 					try {
-						const result = await callTool(newConn, this.tool.name, args, { signal });
+						const result = await callTool(newConn, this.tool.name, args, { signal }, this.tool);
 						return buildResult(
 							result,
 							this.serverName,

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -30,6 +30,7 @@ import type {
 	MCPToolCallResult,
 	MCPToolDefinition,
 } from "./types";
+import { MCPError } from "./types";
 
 /** Reconnect callback: tears down a stale connection, optionally authorizing first. */
 export type MCPReconnect = (options?: { authChallenge?: MCPAuthChallenge }) => Promise<MCPServerConnection | null>;
@@ -53,6 +54,9 @@ const RETRIABLE_PATTERNS = [
 
 export function isRetriableConnectionError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
+	if (error instanceof MCPError && (error.status === 404 || error.status === 502 || error.status === 503)) {
+		return true;
+	}
 	const msg = error.message.toLowerCase();
 	// Stale session (server restarted, old session ID is gone)
 	if (/^http (404|502|503):/.test(msg)) return true;

--- a/packages/coding-agent/src/mcp/tool-cache.ts
+++ b/packages/coding-agent/src/mcp/tool-cache.ts
@@ -7,7 +7,7 @@ import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import type { AgentStorage } from "../session/agent-storage";
 import type { MCPServerConfig, MCPToolDefinition } from "./types";
 
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2;
 const CACHE_PREFIX = "mcp_tools:";
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -15,8 +15,13 @@ type MCPToolCachePayload = {
 	version: number;
 	configHash: string;
 	tools: MCPToolDefinition[];
+	cacheScope?: "public";
 };
 
+export interface MCPToolCachePolicy {
+	ttlMs?: number;
+	cacheScope?: "public" | "private";
+}
 function stableClone(value: unknown): unknown {
 	if (Array.isArray(value)) {
 		return value.map(item => stableClone(item));
@@ -71,6 +76,7 @@ export class MCPToolCache {
 		}
 
 		if (!isRecord(parsed)) return null;
+		if (parsed.cacheScope !== undefined && parsed.cacheScope !== "public") return null;
 		if (parsed.version !== CACHE_VERSION) return null;
 		if (typeof parsed.configHash !== "string") return null;
 		if (!Array.isArray(parsed.tools)) return null;
@@ -88,7 +94,12 @@ export class MCPToolCache {
 		return parsed.tools as MCPToolDefinition[];
 	}
 
-	async set(serverName: string, config: MCPServerConfig, tools: MCPToolDefinition[]): Promise<void> {
+	async set(
+		serverName: string,
+		config: MCPServerConfig,
+		tools: MCPToolDefinition[],
+		policy?: MCPToolCachePolicy,
+	): Promise<void> {
 		let configHash: string;
 		try {
 			configHash = await hashConfig(config);
@@ -97,10 +108,12 @@ export class MCPToolCache {
 			return;
 		}
 
+		const modernCacheable = policy === undefined || (policy.cacheScope === "public" && (policy.ttlMs ?? 0) > 0);
 		const payload: MCPToolCachePayload = {
 			version: CACHE_VERSION,
 			configHash,
-			tools,
+			tools: modernCacheable ? tools : [],
+			...(policy?.cacheScope === "public" ? { cacheScope: "public" as const } : {}),
 		};
 
 		let serialized: string;
@@ -111,7 +124,9 @@ export class MCPToolCache {
 			return;
 		}
 
-		const expiresAtSec = Math.floor((Date.now() + CACHE_TTL_MS) / 1000);
+		const ttlMs =
+			policy === undefined ? CACHE_TTL_MS : modernCacheable ? Math.min(CACHE_TTL_MS, policy.ttlMs ?? 0) : 0;
+		const expiresAtSec = Math.floor((Date.now() + ttlMs) / 1000);
 		this.storage.setCache(cacheKey(serverName), serialized, expiresAtSec);
 	}
 }

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -282,8 +282,6 @@ export class HttpTransport implements MCPTransport {
 
 			if (!response.ok) {
 				const text = await response.text();
-				const rpcError = parseJsonRpcError(text);
-				if (rpcError) throw new MCPError(rpcError, response.status);
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -293,6 +291,11 @@ export class HttpTransport implements MCPTransport {
 					.filter(Boolean)
 					.join("; ");
 				const suffix = authHints ? ` [${authHints}]` : "";
+				const rpcError = parseJsonRpcError(text);
+				if (rpcError) {
+					const message = `MCP error ${rpcError.code}: ${rpcError.message} [HTTP ${response.status}: ${text}]${suffix}`;
+					throw new MCPError(rpcError, response.status, message);
+				}
 				throw new MCPHttpError(response.status, text, suffix);
 			}
 

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -242,6 +242,7 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		const id = this.#requestIds.next(this.config.requestIdFormat);
+		options?.onRequestId?.(id);
 		const body = {
 			jsonrpc: "2.0" as const,
 			id,

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -5,7 +5,7 @@
  * Based on MCP spec 2025-03-26.
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, readSseJson } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -16,11 +16,23 @@ import type {
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCPError, MCPHttpError, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
-import { type MCPFetchInit, mcpFetch } from "./header-policy";
+import { type MCPFetchInit, mcpFetch, setGeneratedHeader } from "./header-policy";
+import { applyModernRequestHeaders } from "./modern-http";
 
+function parseJsonRpcError(text: string): JsonRpcError | undefined {
+	try {
+		const value: unknown = JSON.parse(text);
+		if (!isRecord(value) || !isRecord(value.error)) return undefined;
+		const error = value.error;
+		if (typeof error.code !== "number" || typeof error.message !== "string") return undefined;
+		return { code: error.code, message: error.message, data: error.data };
+	} catch {
+		return undefined;
+	}
+}
 const HTTP_SSE_CONNECT_TIMEOUT_MS = 1_000;
 /**
  * Best-effort startup deadline for the optional Streamable HTTP GET SSE listener.
@@ -35,6 +47,18 @@ export function resolveSSEConnectTimeoutMs(configTimeout?: number): number {
 	if (!isMCPTimeoutEnabled(requestTimeout)) return 0;
 	const boundedTimeout = Math.min(HTTP_SSE_CONNECT_TIMEOUT_MS, Math.floor(requestTimeout / 4));
 	return Math.max(1, boundedTimeout);
+}
+
+const MCP_PROTOCOL_VERSION_META = "io.modelcontextprotocol/protocolVersion";
+
+function hasModernProtocolMeta(params: Record<string, unknown>): boolean {
+	const metadata = params._meta;
+	return (
+		metadata !== null &&
+		typeof metadata === "object" &&
+		!Array.isArray(metadata) &&
+		typeof (metadata as Record<string, unknown>)[MCP_PROTOCOL_VERSION_META] === "string"
+	);
 }
 /**
  * HTTP transport for MCP servers.
@@ -225,16 +249,22 @@ export class HttpTransport implements MCPTransport {
 			params: params ?? {},
 		};
 
-		const generated: Record<string, string> = {
-			"Content-Type": "application/json",
-			Accept: "application/json, text/event-stream",
-		};
-
-		if (this.#sessionId) {
-			generated["Mcp-Session-Id"] = this.#sessionId;
+		const generated: Record<string, string> = {};
+		const modernRequest = hasModernProtocolMeta(body.params);
+		if (modernRequest) {
+			for (const [name, value] of Object.entries(options?.generatedHeaders ?? {})) {
+				setGeneratedHeader(generated, name, value);
+			}
 		}
 
-		const timeout = resolveMCPTimeoutMs(this.config.timeout);
+		setGeneratedHeader(generated, "Content-Type", "application/json");
+		setGeneratedHeader(generated, "Accept", "application/json, text/event-stream");
+		if (this.#sessionId) {
+			setGeneratedHeader(generated, "Mcp-Session-Id", this.#sessionId);
+		}
+		applyModernRequestHeaders(generated, method, body.params);
+
+		const timeout = resolveMCPTimeoutMs(options?.timeout ?? this.config.timeout);
 		const operation = createMCPTimeout(timeout, options?.signal);
 
 		try {
@@ -244,13 +274,15 @@ export class HttpTransport implements MCPTransport {
 			);
 
 			// Check for session ID in response
-			const newSessionId = response.headers.get("Mcp-Session-Id");
-			if (newSessionId) {
-				this.#sessionId = newSessionId;
+			if (!modernRequest) {
+				const newSessionId = response.headers.get("Mcp-Session-Id");
+				if (newSessionId) this.#sessionId = newSessionId;
 			}
 
 			if (!response.ok) {
 				const text = await response.text();
+				const rpcError = parseJsonRpcError(text);
+				if (rpcError) throw new MCPError(rpcError, response.status);
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -260,7 +292,7 @@ export class HttpTransport implements MCPTransport {
 					.filter(Boolean)
 					.join("; ");
 				const suffix = authHints ? ` [${authHints}]` : "";
-				throw new Error(`HTTP ${response.status}: ${text}${suffix}`);
+				throw new MCPHttpError(response.status, text, suffix);
 			}
 
 			const contentType = response.headers.get("Content-Type") ?? "";
@@ -274,7 +306,7 @@ export class HttpTransport implements MCPTransport {
 			const result = (await response.json()) as JsonRpcResponse;
 
 			if (result.error) {
-				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
+				throw new MCPError(result.error);
 			}
 
 			return result.result as T;
@@ -293,7 +325,7 @@ export class HttpTransport implements MCPTransport {
 			throw new Error("No response body");
 		}
 
-		const timeout = resolveMCPTimeoutMs(this.config.timeout);
+		const timeout = resolveMCPTimeoutMs(options?.timeout ?? this.config.timeout);
 		const operation = createMCPTimeout(timeout, options?.signal);
 		const signal = operation.signal ?? getNeverAbortSignal();
 
@@ -320,7 +352,7 @@ export class HttpTransport implements MCPTransport {
 							captured = true;
 							operation.clear();
 							if (message.error) {
-								reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
+								reject(new MCPError(message.error));
 							} else {
 								resolve(message.result as T);
 							}

--- a/packages/coding-agent/src/mcp/transports/modern-http.ts
+++ b/packages/coding-agent/src/mcp/transports/modern-http.ts
@@ -1,0 +1,230 @@
+/**
+ * MCP 2026-07-28 request metadata and tool-parameter headers.
+ *
+ * These headers are opt-in: a request without the negotiated protocol version in
+ * `_meta` remains a legacy 2025-03-26 request.
+ */
+import { setGeneratedHeader } from "./header-policy";
+
+const MCP_PROTOCOL_VERSION_META = "io.modelcontextprotocol/protocolVersion";
+const MCP_HEADER_ANNOTATION = "x-mcp-header";
+const HTTP_FIELD_NAME_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const BASE64_SENTINEL_PREFIX = "=?base64?";
+const BASE64_SENTINEL_SUFFIX = "?=";
+const FORBIDDEN_ANNOTATION_CONTEXT_KEYS = [
+	"items",
+	"prefixItems",
+	"additionalItems",
+	"contains",
+	"oneOf",
+	"anyOf",
+	"allOf",
+	"not",
+	"if",
+	"then",
+	"else",
+	"$ref",
+	"$dynamicRef",
+	"$recursiveRef",
+] as const;
+
+type MCPToolHeaderType = "string" | "integer" | "boolean";
+
+/** A validated mapping from a tool argument path to an MCP parameter header. */
+export interface MCPToolHeaderBinding {
+	headerName: string;
+	path: string[];
+	type: MCPToolHeaderType;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Encode a string for an MCP HTTP field value.
+ *
+ * RFC 9110 permits visible ASCII, spaces, and horizontal tabs. Leading or
+ * trailing whitespace is encoded so that HTTP trimming cannot change the
+ * mirrored value. Values that resemble the sentinel are encoded as well to
+ * avoid ambiguity for servers decoding the wire value.
+ */
+function encodeHeaderValue(value: string): string {
+	const plain = /^[\x20-\x7e\t]*$/.test(value);
+	const hasLeadingOrTrailingWhitespace = /^\s|\s$/u.test(value);
+	const hasSentinelShape = value.startsWith(BASE64_SENTINEL_PREFIX) && value.endsWith(BASE64_SENTINEL_SUFFIX);
+	if (plain && !hasLeadingOrTrailingWhitespace && !hasSentinelShape) return value;
+
+	return `${BASE64_SENTINEL_PREFIX}${Buffer.from(value, "utf8").toString("base64")}${BASE64_SENTINEL_SUFFIX}`;
+}
+
+/**
+ * Add the protocol metadata headers required by MCP 2026-07-28.
+ *
+ * The presence of a string protocol version in `_meta` is the compatibility
+ * switch. No modern headers are added to legacy requests.
+ */
+export function applyModernRequestHeaders(
+	headers: Record<string, string>,
+	method: string,
+	params: Record<string, unknown>,
+): void {
+	const metadata = params._meta;
+	if (!isRecord(metadata)) return;
+
+	const protocolVersion = metadata[MCP_PROTOCOL_VERSION_META];
+	if (typeof protocolVersion !== "string") return;
+
+	setGeneratedHeader(headers, "MCP-Protocol-Version", protocolVersion);
+	setGeneratedHeader(headers, "Mcp-Method", method);
+
+	let name: unknown;
+	if (method === "tools/call" || method === "prompts/get") {
+		name = params.name;
+	} else if (method === "resources/read") {
+		name = params.uri;
+	}
+	if (typeof name === "string") {
+		setGeneratedHeader(headers, "Mcp-Name", encodeHeaderValue(name));
+	}
+}
+
+/**
+ * Collect and validate all x-mcp-header annotations in a tool input schema.
+ *
+ * An annotation is valid only on a primitive property reached from the root
+ * through `properties` keys. Everything below other schema keywords (including
+ * arrays, composition, conditionals, and references) is deliberately treated
+ * as non-static and therefore rejected if it contains an annotation.
+ */
+export function collectToolHeaderBindings(inputSchema: Record<string, unknown>): {
+	bindings: MCPToolHeaderBinding[];
+	error?: string;
+} {
+	if (!isRecord(inputSchema)) {
+		return { bindings: [], error: "inputSchema must be an object" };
+	}
+
+	const bindings: MCPToolHeaderBinding[] = [];
+	const seenHeaderNames = new Set<string>();
+	let error: string | undefined;
+	const activeObjects = new WeakSet<object>();
+
+	const fail = (message: string): void => {
+		error ??= message;
+	};
+
+	const visit = (value: unknown, path: string[] | null, schemaNode: boolean): void => {
+		if (error) return;
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item, null, false);
+			return;
+		}
+		if (!isRecord(value)) return;
+		if (activeObjects.has(value)) return;
+		activeObjects.add(value);
+
+		if (Object.hasOwn(value, MCP_HEADER_ANNOTATION)) {
+			const annotation = value[MCP_HEADER_ANNOTATION];
+			const hasForbiddenContext = FORBIDDEN_ANNOTATION_CONTEXT_KEYS.some(key => Object.hasOwn(value, key));
+			if (!schemaNode || path === null || path.length === 0 || hasForbiddenContext) {
+				fail("x-mcp-header must be on a statically reachable property");
+			} else if (typeof annotation !== "string" || !HTTP_FIELD_NAME_TOKEN.test(annotation)) {
+				fail("x-mcp-header must be a non-empty HTTP field-name token");
+			} else {
+				const normalizedName = annotation.toLowerCase();
+				if (seenHeaderNames.has(normalizedName)) {
+					fail(`duplicate x-mcp-header value: ${annotation}`);
+				} else {
+					seenHeaderNames.add(normalizedName);
+					const type = value.type;
+					if (type !== "string" && type !== "integer" && type !== "boolean") {
+						fail("x-mcp-header requires type string, integer, or boolean");
+					} else {
+						bindings.push({
+							headerName: `Mcp-Param-${annotation}`,
+							path: [...path],
+							type,
+						});
+					}
+				}
+			}
+		}
+
+		for (const [key, child] of Object.entries(value)) {
+			if (key === MCP_HEADER_ANNOTATION || error) continue;
+
+			if (key === "properties" && schemaNode) {
+				if (!isRecord(child)) {
+					visit(child, null, false);
+					continue;
+				}
+				for (const [propertyName, propertySchema] of Object.entries(child)) {
+					if (isRecord(propertySchema)) {
+						visit(propertySchema, [...(path ?? []), propertyName], true);
+					} else {
+						// A malformed property schema cannot be a static annotation
+						// location, but inspect nested values for forbidden annotations.
+						visit(propertySchema, null, false);
+					}
+				}
+				continue;
+			}
+
+			// Any annotation below another schema keyword is forbidden, even if
+			// that keyword happens to contain a nested object with `properties`.
+			visit(child, null, false);
+		}
+
+		activeObjects.delete(value);
+	};
+
+	visit(inputSchema, [], true);
+	return error ? { bindings: [], error } : { bindings };
+}
+
+/**
+ * Extract and encode validated tool-parameter headers from a call's arguments.
+ * Missing, null, and type-mismatched values are omitted.
+ */
+export function buildToolParameterHeaders(
+	bindings: MCPToolHeaderBinding[],
+	args: Record<string, unknown>,
+): Record<string, string> {
+	const headers: Record<string, string> = {};
+
+	for (const binding of bindings) {
+		let value: unknown = args;
+		let present = true;
+		for (const segment of binding.path) {
+			if (!isRecord(value) || !Object.hasOwn(value, segment)) {
+				present = false;
+				break;
+			}
+			value = value[segment];
+		}
+		if (!present || value === null || value === undefined) continue;
+
+		let text: string;
+		switch (binding.type) {
+			case "string":
+				if (typeof value !== "string") continue;
+				text = value;
+				break;
+			case "integer":
+				if (typeof value !== "number" || !Number.isSafeInteger(value)) continue;
+				text = String(value);
+				break;
+			case "boolean":
+				if (typeof value !== "boolean") continue;
+				text = value ? "true" : "false";
+				break;
+			default:
+				continue;
+		}
+
+		setGeneratedHeader(headers, binding.headerName, encodeHeaderValue(text));
+	}
+
+	return headers;
+}

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -9,7 +9,7 @@ import type {
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCPError, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, resolveMCPTimeoutMs } from "../timeout";
 import { type MCPFetchInit, mcpFetch } from "./header-policy";
@@ -179,7 +179,7 @@ export class LegacySseTransport implements MCPTransport {
 				if (pending.abortHandler) pending.operation.signal?.removeEventListener("abort", pending.abortHandler);
 				const response = message as JsonRpcResponse;
 				if (response.error) {
-					pending.reject(new Error(`MCP error ${response.error.code}: ${response.error.message}`));
+					pending.reject(new MCPError(response.error));
 				} else {
 					pending.resolve(response.result);
 				}
@@ -211,7 +211,7 @@ export class LegacySseTransport implements MCPTransport {
 			method,
 			params: params ?? {},
 		};
-		const timeout = resolveMCPTimeoutMs(this.#config.timeout);
+		const timeout = resolveMCPTimeoutMs(options?.timeout ?? this.#config.timeout);
 		const operation = createMCPTimeout(timeout, options?.signal);
 		const deferred = Promise.withResolvers<unknown>();
 		// Observe the response promise synchronously so a stream-close rejection

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -205,6 +205,7 @@ export class LegacySseTransport implements MCPTransport {
 		}
 
 		const id = this.#requestIds.next(this.#config.requestIdFormat);
+		options?.onRequestId?.(id);
 		const body = {
 			jsonrpc: "2.0" as const,
 			id,

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -737,6 +737,7 @@ export class StdioTransport implements MCPTransport {
 		}
 
 		const id = this.#requestIds.next(this.config.requestIdFormat);
+		options?.onRequestId?.(id);
 		const request = {
 			jsonrpc: "2.0" as const,
 			id,

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -19,7 +19,7 @@ import type {
 	MCPStdioServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCPError, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
@@ -676,7 +676,7 @@ export class StdioTransport implements MCPTransport {
 			if (pending) {
 				this.#pendingRequests.delete(response.id);
 				if (response.error) {
-					pending.reject(new Error(`MCP error ${response.error.code}: ${response.error.message}`));
+					pending.reject(new MCPError(response.error));
 				} else {
 					pending.resolve(response.result);
 				}
@@ -744,7 +744,7 @@ export class StdioTransport implements MCPTransport {
 			params: params ?? {},
 		};
 
-		const timeout = resolveMCPTimeoutMs(this.config.timeout);
+		const timeout = resolveMCPTimeoutMs(options?.timeout ?? this.config.timeout);
 		const signal = options?.signal;
 
 		if (signal?.aborted) {
@@ -772,6 +772,7 @@ export class StdioTransport implements MCPTransport {
 		const onAbort = () => {
 			cleanup();
 			const reason = signal?.reason instanceof Error ? signal.reason : new Error("Aborted");
+			void this.notify("notifications/cancelled", { requestId: id, reason: reason.message }).catch(() => {});
 			reject(reason);
 		};
 
@@ -793,6 +794,7 @@ export class StdioTransport implements MCPTransport {
 		if (isMCPTimeoutEnabled(timeout)) {
 			timer = setTimeout(() => {
 				cleanup();
+				void this.notify("notifications/cancelled", { requestId: id, reason: "Request timed out" }).catch(() => {});
 				reject(new Error(`Request timeout after ${timeout}ms`));
 			}, timeout);
 		}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -1,8 +1,7 @@
 /**
  * MCP (Model Context Protocol) type definitions.
  *
- * Based on MCP specification 2025-03-26:
- * https://modelcontextprotocol.io/specification/2025-03-26/
+ * Supports the stateless 2026-07-28 protocol and legacy initialization-based servers.
  */
 
 // =============================================================================
@@ -37,6 +36,30 @@ export interface JsonRpcError {
 	data?: unknown;
 }
 
+export class MCPError extends Error {
+	readonly code: number;
+	readonly data?: unknown;
+	readonly status?: number;
+
+	constructor(error: JsonRpcError, status?: number) {
+		super(`MCP error ${error.code}: ${error.message}`);
+		this.name = "MCPError";
+		this.code = error.code;
+		this.data = error.data;
+		this.status = status;
+	}
+}
+
+export class MCPHttpError extends Error {
+	readonly status: number;
+
+	constructor(status: number, body: string, suffix = "") {
+		super(`HTTP ${status}: ${body}${suffix}`);
+		this.name = "MCPHttpError";
+		this.status = status;
+	}
+}
+
 export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
 
 // =============================================================================
@@ -62,6 +85,9 @@ export interface MCPAuthConfig {
 /** Encoding used for outgoing JSON-RPC request ids. */
 export type MCPRequestIdFormat = "string" | "number";
 
+/** MCP protocol lifecycle policy. */
+export type MCPProtocolMode = "legacy" | "auto" | "2026-07-28";
+
 /** Base server config with shared options */
 interface MCPServerConfigBase {
 	/** Whether this server is enabled (default: true) */
@@ -80,6 +106,13 @@ interface MCPServerConfigBase {
 	 * tool's config do not, since the key is not part of those formats.
 	 */
 	requestIdFormat?: MCPRequestIdFormat;
+	/**
+	 * Protocol lifecycle policy (default: `"legacy"`).
+	 *
+	 * `"auto"` probes modern discovery and falls back only on positive legacy
+	 * evidence. `"2026-07-28"` requires the modern stateless lifecycle.
+	 */
+	protocolMode?: MCPProtocolMode;
 	/** Authentication configuration (optional) */
 	auth?: MCPAuthConfig;
 	/** OAuth configuration for servers requiring explicit client credentials */
@@ -160,7 +193,9 @@ export interface MCPImplementation {
 /** MCP client capabilities */
 export interface MCPClientCapabilities {
 	roots?: { listChanged?: boolean };
-	sampling?: Record<string, never>;
+	sampling?: Record<string, unknown>;
+	elicitation?: { form?: Record<string, unknown>; url?: Record<string, unknown> };
+	extensions?: Record<string, Record<string, unknown>>;
 	experimental?: Record<string, unknown>;
 }
 
@@ -169,7 +204,9 @@ export interface MCPServerCapabilities {
 	tools?: { listChanged?: boolean };
 	resources?: { subscribe?: boolean; listChanged?: boolean };
 	prompts?: { listChanged?: boolean };
-	logging?: Record<string, never>;
+	completions?: Record<string, unknown>;
+	logging?: Record<string, unknown>;
+	extensions?: Record<string, Record<string, unknown>>;
 	experimental?: Record<string, unknown>;
 }
 
@@ -188,9 +225,26 @@ export interface MCPInitializeResult {
 	instructions?: string;
 }
 
+export interface MCPResult {
+	resultType?: "complete" | "input_required" | string;
+	_meta?: Record<string, unknown>;
+}
+
+export interface MCPCacheableResult extends MCPResult {
+	ttlMs?: number;
+	cacheScope?: "public" | "private";
+}
+
+export interface MCPDiscoverResult extends MCPCacheableResult {
+	supportedVersions: string[];
+	capabilities: MCPServerCapabilities;
+	instructions?: string;
+}
+
 /** MCP tool definition */
 export interface MCPToolDefinition {
 	name: string;
+	title?: string;
 	description?: string;
 	inputSchema: {
 		type: "object";
@@ -198,10 +252,12 @@ export interface MCPToolDefinition {
 		required?: string[];
 		[key: string]: unknown;
 	};
+	outputSchema?: Record<string, unknown>;
+	annotations?: Record<string, unknown>;
+	_meta?: Record<string, unknown>;
 }
 
-/** tools/list response */
-export interface MCPToolsListResult {
+export interface MCPToolsListResult extends MCPCacheableResult {
 	tools: MCPToolDefinition[];
 	nextCursor?: string;
 }
@@ -243,10 +299,10 @@ export interface MCPAuthChallenge {
 }
 
 /** tools/call response */
-export interface MCPToolCallResult {
+export interface MCPToolCallResult extends MCPResult {
 	content: MCPContent[];
+	structuredContent?: unknown;
 	isError?: boolean;
-	_meta?: Record<string, unknown>;
 }
 
 // =============================================================================
@@ -256,6 +312,10 @@ export interface MCPToolCallResult {
 export interface MCPRequestOptions {
 	/** Abort signal (e.g. Escape-to-interrupt) */
 	signal?: AbortSignal;
+	/** Per-request timeout override. Zero disables the timeout. */
+	timeout?: number;
+	/** Validated transport-generated HTTP headers. */
+	generatedHeaders?: Record<string, string>;
 }
 
 /** Transport interface - abstracts stdio/http */
@@ -309,6 +369,8 @@ export interface MCPServerConnection {
 	resourceTemplates?: MCPResourceTemplate[];
 	/** Server instructions from initialize */
 	instructions?: string;
+	/** Negotiated MCP protocol version. Absent on synthetic legacy connections. */
+	protocolVersion?: string;
 	/** Cached prompts (populated on demand) */
 	prompts?: MCPPrompt[];
 }
@@ -352,13 +414,13 @@ export interface MCPResourceTemplate {
 }
 
 /** Result of resources/list */
-export interface MCPResourcesListResult {
+export interface MCPResourcesListResult extends MCPCacheableResult {
 	resources: MCPResource[];
 	nextCursor?: string;
 }
 
 /** Result of resources/templates/list */
-export interface MCPResourceTemplatesListResult {
+export interface MCPResourceTemplatesListResult extends MCPCacheableResult {
 	resourceTemplates: MCPResourceTemplate[];
 	nextCursor?: string;
 }
@@ -372,7 +434,7 @@ export interface MCPResourceContentItem {
 }
 
 /** Result of resources/read */
-export interface MCPResourceReadResult {
+export interface MCPResourceReadResult extends MCPCacheableResult {
 	contents: MCPResourceContentItem[];
 }
 
@@ -406,7 +468,7 @@ export interface MCPPrompt {
 }
 
 /** Result of prompts/list */
-export interface MCPPromptsListResult {
+export interface MCPPromptsListResult extends MCPCacheableResult {
 	prompts: MCPPrompt[];
 	nextCursor?: string;
 }
@@ -434,7 +496,7 @@ export interface MCPGetPromptParams {
 }
 
 /** Result of prompts/get */
-export interface MCPGetPromptResult {
+export interface MCPGetPromptResult extends MCPResult {
 	description?: string;
 	messages: MCPPromptMessage[];
 }

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -235,6 +235,17 @@ export interface MCPCacheableResult extends MCPResult {
 	cacheScope?: "public" | "private";
 }
 
+export interface MCPInputRequest {
+	method: string;
+	params?: Record<string, unknown>;
+}
+
+export interface MCPInputRequiredResult extends MCPResult {
+	resultType: "input_required";
+	inputRequests?: Record<string, MCPInputRequest>;
+	requestState?: string;
+}
+
 export interface MCPDiscoverResult extends MCPCacheableResult {
 	supportedVersions: string[];
 	capabilities: MCPServerCapabilities;
@@ -316,6 +327,8 @@ export interface MCPRequestOptions {
 	timeout?: number;
 	/** Validated transport-generated HTTP headers. */
 	generatedHeaders?: Record<string, string>;
+	/** Observe the generated JSON-RPC request ID before the request is sent. */
+	onRequestId?: (id: string | number) => void;
 }
 
 /** Transport interface - abstracts stdio/http */

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -41,8 +41,8 @@ export class MCPError extends Error {
 	readonly data?: unknown;
 	readonly status?: number;
 
-	constructor(error: JsonRpcError, status?: number) {
-		super(`MCP error ${error.code}: ${error.message}`);
+	constructor(error: JsonRpcError, status?: number, message?: string) {
+		super(message ?? `MCP error ${error.code}: ${error.message}`);
 		this.name = "MCPError";
 		this.code = error.code;
 		this.data = error.data;

--- a/packages/coding-agent/test/fixtures/protocol-mode-mcp.ts
+++ b/packages/coding-agent/test/fixtures/protocol-mode-mcp.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+import * as fs from "node:fs/promises";
+import * as readline from "node:readline";
+
+interface RpcRequest {
+	jsonrpc: "2.0";
+	id?: string | number;
+	method: string;
+	params?: Record<string, unknown>;
+}
+
+const mode = process.env.MCP_PROTOCOL_FIXTURE_MODE ?? "modern";
+const logPath = process.env.MCP_PROTOCOL_FIXTURE_LOG;
+const input = readline.createInterface({ input: process.stdin, terminal: false });
+
+async function record(method: string): Promise<void> {
+	if (!logPath) return;
+	await fs.appendFile(logPath, `${JSON.stringify({ pid: process.pid, method })}\n`);
+}
+
+function respond(id: string | number | undefined, result: unknown, exit = false): void {
+	process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`, () => {
+		if (exit) process.exit(0);
+	});
+}
+
+function reject(id: string | number | undefined, code: number, message: string, exit = false): void {
+	process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } })}\n`, () => {
+		if (exit) process.exit(0);
+	});
+}
+
+input.on("line", line => {
+	void (async () => {
+		const request = JSON.parse(line) as RpcRequest;
+		await record(request.method);
+		switch (request.method) {
+			case "server/discover":
+				if (mode === "close") process.exit(0);
+				if (mode === "legacy") {
+					reject(request.id, -32601, "Method not found", true);
+					return;
+				}
+				respond(
+					request.id,
+					{
+						resultType: "complete",
+						supportedVersions: ["2026-07-28"],
+						capabilities: { tools: {} },
+						_meta: { "io.modelcontextprotocol/serverInfo": { name: "protocol-mode-fixture", version: "1.0.0" } },
+					},
+					true,
+				);
+				return;
+			case "initialize":
+				respond(request.id, {
+					protocolVersion: "2025-03-26",
+					capabilities: { tools: {} },
+					serverInfo: { name: "protocol-mode-fixture", version: "1.0.0" },
+				});
+				return;
+			case "tools/list":
+				respond(request.id, { resultType: "complete", tools: [] }, true);
+				return;
+			case "notifications/initialized":
+				process.exit(0);
+		}
+	})();
+});

--- a/packages/coding-agent/test/fixtures/protocol-mode-mcp.ts
+++ b/packages/coding-agent/test/fixtures/protocol-mode-mcp.ts
@@ -37,6 +37,15 @@ input.on("line", line => {
 		switch (request.method) {
 			case "server/discover":
 				if (mode === "close") process.exit(0);
+				if (mode === "ignore") return;
+				if (mode === "invalid-params") {
+					reject(request.id, -32602, "Invalid params", true);
+					return;
+				}
+				if (mode === "malformed") {
+					respond(request.id, null, true);
+					return;
+				}
 				if (mode === "legacy") {
 					reject(request.id, -32601, "Method not found", true);
 					return;

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { analyzeAuthError } from "@oh-my-pi/pi-coding-agent/mcp/oauth-discovery";
 import { HttpTransport } from "@oh-my-pi/pi-coding-agent/mcp/transports/http";
+import { MCPError } from "@oh-my-pi/pi-coding-agent/mcp/types";
 
 const encoder = new TextEncoder();
 const REQUEST_TIMEOUT_MS = 50;
@@ -99,6 +101,61 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 		await expect(withPendingGuard(transport.request<ToolList>("tools/list"), "request")).resolves.toEqual({
 			tools: [{ name: "fast", inputSchema: { type: "object" } }],
 		});
+	});
+
+	it("preserves OAuth hints when an HTTP auth failure has a JSON-RPC body", async () => {
+		const resourceMetadataUrl = "https://gateway.example.com/.well-known/oauth-protected-resource";
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				return Response.json(
+					{
+						jsonrpc: "2.0",
+						id: 1,
+						error: {
+							code: -32001,
+							message: "authorization required",
+							data: {
+								oauth: {
+									authorization_url: "https://auth.example.com/authorize",
+									token_url: "https://auth.example.com/token",
+								},
+							},
+						},
+					},
+					{
+						status: 401,
+						headers: {
+							"WWW-Authenticate": `Bearer scope="tools:read", resource_metadata="${resourceMetadataUrl}"`,
+							"Mcp-Auth-Server": "https://auth.example.com",
+						},
+					},
+				);
+			},
+		});
+		const transport = await connectedTransport();
+		let failure: unknown;
+		try {
+			await transport.request("tools/list");
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).toBeInstanceOf(MCPError);
+		if (!(failure instanceof Error)) throw new Error("Expected MCP auth error");
+		const auth = analyzeAuthError(failure);
+		expect(auth).toMatchObject({
+			requiresAuth: true,
+			authType: "oauth",
+			authServerUrl: "https://auth.example.com/",
+			resourceMetadataUrl,
+			scopes: "tools:read",
+			oauth: {
+				authorizationUrl: "https://auth.example.com/authorize",
+				tokenUrl: "https://auth.example.com/token",
+				scopes: "tools:read",
+			},
+		});
+		await transport.close();
 	});
 
 	it("reports the JSON-RPC ID allocated for an authenticated retry", async () => {

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -100,4 +100,27 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 			tools: [{ name: "fast", inputSchema: { type: "object" } }],
 		});
 	});
+
+	it("reports the JSON-RPC ID allocated for an authenticated retry", async () => {
+		let requestCount = 0;
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				requestCount++;
+				const body = (await request.json()) as { id: string | number };
+				if (requestCount === 1) return new Response("unauthorized", { status: 401 });
+				return Response.json({ jsonrpc: "2.0", id: body.id, result: { ok: true } });
+			},
+		});
+		const transport = await connectedTransport();
+		transport.onAuthError = async () => ({ Authorization: "Bearer refreshed" });
+		const requestIds: Array<string | number> = [];
+
+		await expect(transport.request("tools/list", {}, { onRequestId: id => requestIds.push(id) })).resolves.toEqual({
+			ok: true,
+		});
+		expect(requestIds).toHaveLength(2);
+		expect(requestIds[1]).not.toBe(requestIds[0]);
+		await transport.close();
+	});
 });

--- a/packages/coding-agent/test/mcp-modern-http-headers.test.ts
+++ b/packages/coding-agent/test/mcp-modern-http-headers.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { HttpTransport } from "@oh-my-pi/pi-coding-agent/mcp/transports/http";
+import {
+	applyModernRequestHeaders,
+	buildToolParameterHeaders,
+	collectToolHeaderBindings,
+} from "@oh-my-pi/pi-coding-agent/mcp/transports/modern-http";
+
+const PROTOCOL_VERSION = "2026-07-28";
+let servers: Bun.Server<undefined>[] = [];
+
+function serve(fetchHandler: (request: Request) => Response | Promise<Response>): Bun.Server<undefined> {
+	const server = Bun.serve({ port: 0, fetch: fetchHandler });
+	servers.push(server);
+	return server;
+}
+
+afterEach(() => {
+	for (const server of servers) server.stop(true);
+	servers = [];
+});
+
+function rpcResult(requestBody: unknown): Response {
+	const id = requestBody && typeof requestBody === "object" && "id" in requestBody ? requestBody.id : null;
+	return new Response(JSON.stringify({ jsonrpc: "2.0", id, result: { ok: true } }), {
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("MCP 2026-07-28 request headers", () => {
+	it("adds standard headers only when _meta has a protocol version", () => {
+		const headers: Record<string, string> = {
+			"mcp-protocol-version": "configured",
+			"MCP-METHOD": "configured",
+			"mcp-name": "configured",
+		};
+
+		applyModernRequestHeaders(headers, "tools/call", {
+			name: "weather",
+			_meta: { "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION },
+		});
+
+		expect(headers).toEqual({
+			"MCP-Protocol-Version": PROTOCOL_VERSION,
+			"Mcp-Method": "tools/call",
+			"Mcp-Name": "weather",
+		});
+
+		const legacy: Record<string, string> = {};
+		applyModernRequestHeaders(legacy, "tools/call", { name: "weather" });
+		expect(legacy).toEqual({});
+	});
+
+	it("encodes unsafe, edge, and sentinel-shaped values", () => {
+		const headers = buildToolParameterHeaders(
+			[
+				{ headerName: "Mcp-Param-Plain", path: ["plain"], type: "string" },
+				{ headerName: "Mcp-Param-Unicode", path: ["unicode"], type: "string" },
+				{ headerName: "Mcp-Param-Padded", path: ["padded"], type: "string" },
+				{ headerName: "Mcp-Param-Sentinel", path: ["sentinel"], type: "string" },
+				{ headerName: "Mcp-Param-Count", path: ["count"], type: "integer" },
+				{ headerName: "Mcp-Param-Enabled", path: ["enabled"], type: "boolean" },
+			],
+			{
+				plain: "plain value",
+				unicode: "Hello, 世界",
+				padded: " padded ",
+				sentinel: "=?base64?literal?=",
+				count: -7,
+				enabled: true,
+			},
+		);
+
+		expect(headers).toEqual({
+			"Mcp-Param-Plain": "plain value",
+			"Mcp-Param-Unicode": "=?base64?SGVsbG8sIOS4lueVjA==?=",
+			"Mcp-Param-Padded": "=?base64?IHBhZGRlZCA=?=",
+			"Mcp-Param-Sentinel": "=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=",
+			"Mcp-Param-Count": "-7",
+			"Mcp-Param-Enabled": "true",
+		});
+	});
+
+	it("extracts valid nested properties and omits absent values", () => {
+		const collected = collectToolHeaderBindings({
+			type: "object",
+			properties: {
+				routing: {
+					type: "object",
+					properties: {
+						tenant: { type: "string", "x-mcp-header": "Tenant" },
+						attempt: { type: "integer", "x-mcp-header": "Attempt" },
+						enabled: { type: "boolean", "x-mcp-header": "Enabled" },
+					},
+				},
+			},
+		});
+		expect(collected.error).toBeUndefined();
+		expect(collected.bindings).toEqual([
+			{ headerName: "Mcp-Param-Tenant", path: ["routing", "tenant"], type: "string" },
+			{ headerName: "Mcp-Param-Attempt", path: ["routing", "attempt"], type: "integer" },
+			{ headerName: "Mcp-Param-Enabled", path: ["routing", "enabled"], type: "boolean" },
+		]);
+		expect(
+			buildToolParameterHeaders(collected.bindings, {
+				routing: { tenant: "acme", enabled: false },
+			}),
+		).toEqual({ "Mcp-Param-Tenant": "acme", "Mcp-Param-Enabled": "false" });
+	});
+
+	it("rejects invalid annotation placement, type, name, and duplicates", () => {
+		const invalidSchemas: Record<string, unknown>[] = [
+			{
+				type: "object",
+				properties: { values: { type: "array", items: { type: "string", "x-mcp-header": "Values" } } },
+			},
+			{
+				type: "object",
+				properties: { choice: { oneOf: [{ type: "string", "x-mcp-header": "Choice" }] } },
+			},
+			{
+				type: "object",
+				properties: { value: { type: "number", "x-mcp-header": "Value" } },
+			},
+			{
+				type: "object",
+				properties: { value: { type: "string", "x-mcp-header": "bad name" } },
+			},
+			{
+				type: "object",
+				properties: {
+					first: { type: "string", "x-mcp-header": "Tenant" },
+					second: { type: "string", "x-mcp-header": "tenant" },
+				},
+			},
+		];
+
+		for (const inputSchema of invalidSchemas) {
+			const result = collectToolHeaderBindings(inputSchema);
+			expect(result.bindings).toEqual([]);
+			expect(result.error).toBeString();
+		}
+	});
+
+	it("gives modern standard and parameter headers precedence over configured headers", async () => {
+		let received: Headers | undefined;
+		const server = serve(async request => {
+			received = request.headers;
+			return rpcResult(await request.json());
+		});
+		const transport = new HttpTransport({
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+			headers: {
+				"mcp-protocol-version": "configured-version",
+				"mcp-method": "configured-method",
+				"mcp-name": "configured-name",
+				"mcp-param-tenant": "configured-tenant",
+			},
+		});
+		await transport.connect();
+
+		await transport.request(
+			"tools/call",
+			{
+				name: "weather",
+				arguments: { tenant: "acme" },
+				_meta: { "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION },
+			},
+			{ generatedHeaders: { "Mcp-Param-Tenant": "generated-tenant" } },
+		);
+
+		expect(received?.get("mcp-protocol-version")).toBe(PROTOCOL_VERSION);
+		expect(received?.get("mcp-method")).toBe("tools/call");
+		expect(received?.get("mcp-name")).toBe("weather");
+		expect(received?.get("mcp-param-tenant")).toBe("generated-tenant");
+	});
+
+	it("does not send modern option headers on legacy requests", async () => {
+		let received: Headers | undefined;
+		const server = serve(async request => {
+			received = request.headers;
+			return rpcResult(await request.json());
+		});
+		const transport = new HttpTransport({ type: "http", url: `http://127.0.0.1:${server.port}/mcp` });
+		await transport.connect();
+
+		await transport.request(
+			"tools/call",
+			{ name: "weather", arguments: {} },
+			{
+				generatedHeaders: { "Mcp-Param-Tenant": "must-not-send" },
+			},
+		);
+
+		expect(received?.get("mcp-protocol-version")).toBeNull();
+		expect(received?.get("mcp-method")).toBeNull();
+		expect(received?.get("mcp-param-tenant")).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/mcp-modern-protocol.test.ts
+++ b/packages/coding-agent/test/mcp-modern-protocol.test.ts
@@ -3,6 +3,7 @@ import {
 	callTool,
 	connectToServer,
 	disconnectServer,
+	getToolCachePolicy,
 	listTools,
 	subscribeToResources,
 } from "@oh-my-pi/pi-coding-agent/mcp/client";
@@ -41,6 +42,7 @@ function rpcResult(id: string | number | undefined, result: Record<string, unkno
 describe("MCP 2026-07-28 protocol negotiation", () => {
 	it("uses stateless discovery and per-request metadata without legacy initialization", async () => {
 		const requests: Array<{
+			id?: string | number;
 			method: string;
 			protocolHeader: string | null;
 			methodHeader: string | null;
@@ -52,6 +54,7 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 			async fetch(request) {
 				const rpc = await readRpcRequest(request);
 				requests.push({
+					id: rpc.id,
 					method: rpc.method,
 					protocolHeader: request.headers.get("MCP-Protocol-Version"),
 					methodHeader: request.headers.get("Mcp-Method"),
@@ -79,7 +82,10 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 						if (toolCallCount === 1) {
 							return rpcResult(rpc.id, {
 								resultType: "input_required",
-								requestState: "retry-state",
+								inputRequests: {
+									projectRoot: { method: "roots/list" },
+								},
+								requestState: "opaque-✓",
 							});
 						}
 						return rpcResult(rpc.id, {
@@ -100,6 +106,10 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 		expect(connection.protocolVersion).toBe("2026-07-28");
 		expect(connection.serverInfo).toEqual({ name: "modern-test", version: "1.0.0" });
 		expect((await listTools(connection)).map(tool => tool.name)).toEqual(["echo"]);
+		const cachePolicy = getToolCachePolicy(connection);
+		expect(cachePolicy?.cacheScope).toBe("public");
+		expect(cachePolicy?.ttlMs).toBeGreaterThan(0);
+		expect(cachePolicy?.ttlMs).toBeLessThanOrEqual(60_000);
 		expect(await callTool(connection, "echo", { value: "hello" })).toMatchObject({
 			content: [{ type: "text", text: "ok" }],
 		});
@@ -111,13 +121,19 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 			"tools/call",
 			"tools/call",
 		]);
-		expect(requests[3]?.params.requestState).toBe("retry-state");
+		expect(requests[3]?.id).not.toBe(requests[2]?.id);
+		expect(requests[3]?.params.requestState).toBe("opaque-✓");
+		expect(requests[3]?.params.inputResponses).toEqual({
+			projectRoot: {
+				roots: [expect.objectContaining({ uri: expect.stringMatching(/^file:/) })],
+			},
+		});
 		for (const request of requests) {
 			expect(request.protocolHeader).toBe("2026-07-28");
 			expect(request.methodHeader).toBe(request.method);
 			const meta = request.params._meta;
 			expect(isRecord(meta) && meta["io.modelcontextprotocol/protocolVersion"]).toBe("2026-07-28");
-			expect(isRecord(meta) && meta["io.modelcontextprotocol/clientCapabilities"]).toEqual({});
+			expect(isRecord(meta) && meta["io.modelcontextprotocol/clientCapabilities"]).toEqual({ roots: {} });
 		}
 	});
 
@@ -197,8 +213,9 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 		expect(rpcMethods).toEqual(["server/discover"]);
 	});
 
-	it("opens subscriptions/listen for modern resource subscriptions", async () => {
+	it("waits for the correlated subscription acknowledgment and returns only accepted resources", async () => {
 		const listenRequest = Promise.withResolvers<RpcRequest>();
+		const acceptedUri = "file:///workspace/config.json";
 		server = Bun.serve({
 			port: 0,
 			async fetch(request) {
@@ -214,7 +231,34 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 				}
 				if (rpc.method === "subscriptions/listen") {
 					listenRequest.resolve(rpc);
-					return rpcResult(rpc.id, { resultType: "complete" });
+					const acknowledgment = {
+						jsonrpc: "2.0",
+						method: "notifications/subscriptions/acknowledged",
+						params: {
+							_meta: { "io.modelcontextprotocol/subscriptionId": rpc.id },
+							notifications: { resourceSubscriptions: [acceptedUri] },
+						},
+					};
+					const wrongAcknowledgment = {
+						...acknowledgment,
+						params: {
+							...acknowledgment.params,
+							_meta: { "io.modelcontextprotocol/subscriptionId": `${rpc.id}-wrong` },
+							notifications: { resourceSubscriptions: ["file:///workspace/wrong-id.json"] },
+						},
+					};
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								controller.enqueue(
+									new TextEncoder().encode(
+										`data: ${JSON.stringify(wrongAcknowledgment)}\n\ndata: ${JSON.stringify(acknowledgment)}\n\n`,
+									),
+								);
+							},
+						}),
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
 				}
 				return new Response("unexpected method", { status: 500 });
 			},
@@ -225,14 +269,49 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 			protocolMode: "2026-07-28",
 			url: `http://127.0.0.1:${server.port}/mcp`,
 		});
-		await subscribeToResources(connection, ["file:///workspace/config.json"]);
+		const accepted = await subscribeToResources(connection, [acceptedUri, "file:///workspace/rejected.json"]);
 		const listen = await listenRequest.promise;
+		expect(accepted).toEqual([acceptedUri]);
 		expect(listen.params.notifications).toEqual({
 			toolsListChanged: false,
 			promptsListChanged: false,
 			resourcesListChanged: false,
-			resourceSubscriptions: ["file:///workspace/config.json"],
+			resourceSubscriptions: [acceptedUri, "file:///workspace/rejected.json"],
 		});
+
+		await disconnectServer(connection);
+	});
+	it("bounds the wait for a subscription acknowledgment", async () => {
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				if (rpc.method === "server/discover") {
+					return rpcResult(rpc.id, {
+						resultType: "complete",
+						supportedVersions: ["2026-07-28"],
+						capabilities: { resources: { subscribe: true } },
+						ttlMs: 0,
+						cacheScope: "public",
+					});
+				}
+				if (rpc.method === "subscriptions/listen") {
+					return new Response(new ReadableStream<Uint8Array>(), {
+						headers: { "Content-Type": "text/event-stream" },
+					});
+				}
+				return new Response("unexpected method", { status: 500 });
+			},
+		});
+
+		const connection = await connectToServer("missing-ack", {
+			type: "http",
+			protocolMode: "2026-07-28",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+		});
+		await expect(
+			subscribeToResources(connection, ["file:///workspace/config.json"], { timeout: 50 }),
+		).rejects.toThrow("MCP subscription acknowledgment timed out after 50ms");
 		await disconnectServer(connection);
 	});
 
@@ -289,39 +368,60 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 		expect(rpcMethods).toEqual(["server/discover"]);
 	});
 
-	it("falls back to the legacy initialize handshake for an unrecognized discovery error", async () => {
+	it("does not reinterpret an HTTP 404 method error as legacy evidence", async () => {
 		const rpcMethods: string[] = [];
 		server = Bun.serve({
 			port: 0,
 			async fetch(request) {
-				if (request.method === "GET") return new Response(null, { status: 405 });
 				const rpc = await readRpcRequest(request);
 				rpcMethods.push(rpc.method);
-				if (rpc.method === "server/discover") {
-					return Response.json(
-						{ jsonrpc: "2.0", id: rpc.id, error: { code: -32601, message: "Method not found" } },
-						{ status: 404 },
-					);
-				}
-				if (rpc.method === "initialize") {
-					return rpcResult(rpc.id, {
-						protocolVersion: "2025-03-26",
-						capabilities: { tools: {} },
-						serverInfo: { name: "legacy-test", version: "1.0.0" },
-					});
-				}
-				if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 });
-				return new Response("unexpected method", { status: 500 });
+				return Response.json(
+					{ jsonrpc: "2.0", id: rpc.id, error: { code: -32601, message: "Method not found" } },
+					{ status: 404 },
+				);
 			},
 		});
 
-		const connection = await connectToServer("legacy", {
-			type: "http",
-			protocolMode: "auto",
-			url: `http://127.0.0.1:${server.port}/mcp`,
-		});
-		expect(connection.protocolVersion).toBe("2025-03-26");
-		expect(rpcMethods).toEqual(["server/discover", "initialize", "notifications/initialized"]);
-		await disconnectServer(connection);
+		await expect(
+			connectToServer("modern-method-error", {
+				type: "http",
+				protocolMode: "auto",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			}),
+		).rejects.toThrow("MCP error -32601: Method not found");
+		expect(rpcMethods).toEqual(["server/discover"]);
 	});
+
+	for (const status of [400, 404, 405]) {
+		it(`falls back after a plain HTTP ${status} discovery response`, async () => {
+			const rpcMethods: string[] = [];
+			server = Bun.serve({
+				port: 0,
+				async fetch(request) {
+					if (request.method === "GET") return new Response(null, { status: 405 });
+					const rpc = await readRpcRequest(request);
+					rpcMethods.push(rpc.method);
+					if (rpc.method === "server/discover") return new Response("legacy endpoint", { status });
+					if (rpc.method === "initialize") {
+						return rpcResult(rpc.id, {
+							protocolVersion: "2025-03-26",
+							capabilities: {},
+							serverInfo: { name: "legacy-http", version: "1.0.0" },
+						});
+					}
+					if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 });
+					return new Response("unexpected method", { status: 500 });
+				},
+			});
+
+			const connection = await connectToServer(`legacy-http-${status}`, {
+				type: "http",
+				protocolMode: "auto",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			});
+			expect(connection.protocolVersion).toBe("2025-03-26");
+			expect(rpcMethods).toEqual(["server/discover", "initialize", "notifications/initialized"]);
+			await disconnectServer(connection);
+		});
+	}
 });

--- a/packages/coding-agent/test/mcp-modern-protocol.test.ts
+++ b/packages/coding-agent/test/mcp-modern-protocol.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	callTool,
+	connectToServer,
+	disconnectServer,
+	listTools,
+	subscribeToResources,
+} from "@oh-my-pi/pi-coding-agent/mcp/client";
+import { isRecord } from "@oh-my-pi/pi-utils";
+
+interface RpcRequest {
+	id?: string | number;
+	method: string;
+	params: Record<string, unknown>;
+}
+
+let server: Bun.Server<undefined> | null = null;
+
+afterEach(() => {
+	server?.stop(true);
+	server = null;
+});
+
+async function readRpcRequest(request: Request): Promise<RpcRequest> {
+	const value = await request.json();
+	if (!isRecord(value) || typeof value.method !== "string") throw new Error("Invalid JSON-RPC request");
+	if (value.id !== undefined && typeof value.id !== "string" && typeof value.id !== "number") {
+		throw new Error("Invalid JSON-RPC request id");
+	}
+	return {
+		id: value.id,
+		method: value.method,
+		params: isRecord(value.params) ? value.params : {},
+	};
+}
+
+function rpcResult(id: string | number | undefined, result: Record<string, unknown>): Response {
+	return Response.json({ jsonrpc: "2.0", id, result });
+}
+
+describe("MCP 2026-07-28 protocol negotiation", () => {
+	it("uses stateless discovery and per-request metadata without legacy initialization", async () => {
+		const requests: Array<{
+			method: string;
+			protocolHeader: string | null;
+			methodHeader: string | null;
+			params: Record<string, unknown>;
+		}> = [];
+		let toolCallCount = 0;
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				requests.push({
+					method: rpc.method,
+					protocolHeader: request.headers.get("MCP-Protocol-Version"),
+					methodHeader: request.headers.get("Mcp-Method"),
+					params: rpc.params,
+				});
+				switch (rpc.method) {
+					case "server/discover":
+						return rpcResult(rpc.id, {
+							resultType: "complete",
+							supportedVersions: ["2026-07-28"],
+							capabilities: { tools: {} },
+							ttlMs: 60_000,
+							cacheScope: "public",
+							_meta: { "io.modelcontextprotocol/serverInfo": { name: "modern-test", version: "1.0.0" } },
+						});
+					case "tools/list":
+						return rpcResult(rpc.id, {
+							resultType: "complete",
+							tools: [{ name: "echo", inputSchema: { type: "object" } }],
+							ttlMs: 60_000,
+							cacheScope: "public",
+						});
+					case "tools/call":
+						toolCallCount++;
+						if (toolCallCount === 1) {
+							return rpcResult(rpc.id, {
+								resultType: "input_required",
+								requestState: "retry-state",
+							});
+						}
+						return rpcResult(rpc.id, {
+							resultType: "complete",
+							content: [{ type: "text", text: "ok" }],
+						});
+					default:
+						return new Response("unexpected method", { status: 500 });
+				}
+			},
+		});
+
+		const connection = await connectToServer("modern", {
+			type: "http",
+			protocolMode: "auto",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+		});
+		expect(connection.protocolVersion).toBe("2026-07-28");
+		expect(connection.serverInfo).toEqual({ name: "modern-test", version: "1.0.0" });
+		expect((await listTools(connection)).map(tool => tool.name)).toEqual(["echo"]);
+		expect(await callTool(connection, "echo", { value: "hello" })).toMatchObject({
+			content: [{ type: "text", text: "ok" }],
+		});
+		await disconnectServer(connection);
+
+		expect(requests.map(request => request.method)).toEqual([
+			"server/discover",
+			"tools/list",
+			"tools/call",
+			"tools/call",
+		]);
+		expect(requests[3]?.params.requestState).toBe("retry-state");
+		for (const request of requests) {
+			expect(request.protocolHeader).toBe("2026-07-28");
+			expect(request.methodHeader).toBe(request.method);
+			const meta = request.params._meta;
+			expect(isRecord(meta) && meta["io.modelcontextprotocol/protocolVersion"]).toBe("2026-07-28");
+			expect(isRecord(meta) && meta["io.modelcontextprotocol/clientCapabilities"]).toEqual({});
+		}
+	});
+
+	it("does not reinterpret a recognized modern version error as a legacy server", async () => {
+		const rpcMethods: string[] = [];
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				rpcMethods.push(rpc.method);
+				return Response.json(
+					{
+						jsonrpc: "2.0",
+						id: rpc.id,
+						error: {
+							code: -32022,
+							message: "Unsupported protocol version",
+							data: { supported: ["2027-01-01"], requested: "2026-07-28" },
+						},
+					},
+					{ status: 400 },
+				);
+			},
+		});
+
+		await expect(
+			connectToServer("future", {
+				type: "http",
+				protocolMode: "auto",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			}),
+		).rejects.toThrow("MCP error -32022: Unsupported protocol version");
+		expect(rpcMethods).toEqual(["server/discover"]);
+	});
+
+	for (const status of [401, 403, 500]) {
+		it(`surfaces HTTP ${status} discovery failures without sending initialize`, async () => {
+			const rpcMethods: string[] = [];
+			server = Bun.serve({
+				port: 0,
+				async fetch(request) {
+					const rpc = await readRpcRequest(request);
+					rpcMethods.push(rpc.method);
+					return new Response("discovery failed", { status });
+				},
+			});
+
+			await expect(
+				connectToServer(`http-${status}`, {
+					type: "http",
+					protocolMode: "auto",
+					url: `http://127.0.0.1:${server.port}/mcp`,
+				}),
+			).rejects.toThrow(`HTTP ${status}: discovery failed`);
+			expect(rpcMethods).toEqual(["server/discover"]);
+		});
+	}
+
+	it("surfaces malformed HTTP discovery results without sending initialize", async () => {
+		const rpcMethods: string[] = [];
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				rpcMethods.push(rpc.method);
+				return rpcResult(rpc.id, {});
+			},
+		});
+
+		await expect(
+			connectToServer("malformed", {
+				type: "http",
+				protocolMode: "auto",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			}),
+		).rejects.toThrow('MCP server "malformed" returned an invalid server/discover result');
+		expect(rpcMethods).toEqual(["server/discover"]);
+	});
+
+	it("opens subscriptions/listen for modern resource subscriptions", async () => {
+		const listenRequest = Promise.withResolvers<RpcRequest>();
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				if (rpc.method === "server/discover") {
+					return rpcResult(rpc.id, {
+						resultType: "complete",
+						supportedVersions: ["2026-07-28"],
+						capabilities: { resources: { subscribe: true } },
+						ttlMs: 0,
+						cacheScope: "public",
+					});
+				}
+				if (rpc.method === "subscriptions/listen") {
+					listenRequest.resolve(rpc);
+					return rpcResult(rpc.id, { resultType: "complete" });
+				}
+				return new Response("unexpected method", { status: 500 });
+			},
+		});
+
+		const connection = await connectToServer("subscriptions", {
+			type: "http",
+			protocolMode: "2026-07-28",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+		});
+		await subscribeToResources(connection, ["file:///workspace/config.json"]);
+		const listen = await listenRequest.promise;
+		expect(listen.params.notifications).toEqual({
+			toolsListChanged: false,
+			promptsListChanged: false,
+			resourcesListChanged: false,
+			resourceSubscriptions: ["file:///workspace/config.json"],
+		});
+		await disconnectServer(connection);
+	});
+
+	it("keeps the legacy initialize lifecycle when protocolMode is omitted", async () => {
+		const rpcMethods: string[] = [];
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				if (request.method === "GET") return new Response(null, { status: 405 });
+				const rpc = await readRpcRequest(request);
+				rpcMethods.push(rpc.method);
+				if (rpc.method === "initialize") {
+					return rpcResult(rpc.id, {
+						protocolVersion: "2025-03-26",
+						capabilities: {},
+						serverInfo: { name: "legacy-default", version: "1.0.0" },
+					});
+				}
+				if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 });
+				return new Response("unexpected method", { status: 500 });
+			},
+		});
+
+		const connection = await connectToServer("legacy-default", {
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+		});
+		expect(connection.protocolVersion).toBe("2025-03-26");
+		expect(rpcMethods).toEqual(["initialize", "notifications/initialized"]);
+		await disconnectServer(connection);
+	});
+
+	it("does not fall back when the modern protocol is required", async () => {
+		const rpcMethods: string[] = [];
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				rpcMethods.push(rpc.method);
+				return Response.json(
+					{ jsonrpc: "2.0", id: rpc.id, error: { code: -32601, message: "Method not found" } },
+					{ status: 404 },
+				);
+			},
+		});
+
+		await expect(
+			connectToServer("modern-required", {
+				type: "http",
+				protocolMode: "2026-07-28",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			}),
+		).rejects.toThrow("MCP error -32601: Method not found");
+		expect(rpcMethods).toEqual(["server/discover"]);
+	});
+
+	it("falls back to the legacy initialize handshake for an unrecognized discovery error", async () => {
+		const rpcMethods: string[] = [];
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				if (request.method === "GET") return new Response(null, { status: 405 });
+				const rpc = await readRpcRequest(request);
+				rpcMethods.push(rpc.method);
+				if (rpc.method === "server/discover") {
+					return Response.json(
+						{ jsonrpc: "2.0", id: rpc.id, error: { code: -32601, message: "Method not found" } },
+						{ status: 404 },
+					);
+				}
+				if (rpc.method === "initialize") {
+					return rpcResult(rpc.id, {
+						protocolVersion: "2025-03-26",
+						capabilities: { tools: {} },
+						serverInfo: { name: "legacy-test", version: "1.0.0" },
+					});
+				}
+				if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 });
+				return new Response("unexpected method", { status: 500 });
+			},
+		});
+
+		const connection = await connectToServer("legacy", {
+			type: "http",
+			protocolMode: "auto",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+		});
+		expect(connection.protocolVersion).toBe("2025-03-26");
+		expect(rpcMethods).toEqual(["server/discover", "initialize", "notifications/initialized"]);
+		await disconnectServer(connection);
+	});
+});

--- a/packages/coding-agent/test/mcp-modern-protocol.test.ts
+++ b/packages/coding-agent/test/mcp-modern-protocol.test.ts
@@ -281,6 +281,88 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 
 		await disconnectServer(connection);
 	});
+
+	it("restarts an acknowledged listener after graceful stream completion", async () => {
+		const acceptedUri = "file:///workspace/config.json";
+		const secondListenRequest = Promise.withResolvers<RpcRequest>();
+		const notificationSeen = Promise.withResolvers<void>();
+		let listenCount = 0;
+		const encoder = new TextEncoder();
+		const sseResponse = (messages: unknown[], close: boolean): Response =>
+			new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(
+							encoder.encode(messages.map(message => `data: ${JSON.stringify(message)}\n\n`).join("")),
+						);
+						if (close) controller.close();
+					},
+				}),
+				{ headers: { "Content-Type": "text/event-stream" } },
+			);
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				if (rpc.method === "server/discover") {
+					return rpcResult(rpc.id, {
+						resultType: "complete",
+						supportedVersions: ["2026-07-28"],
+						capabilities: { resources: { subscribe: true } },
+						ttlMs: 0,
+						cacheScope: "public",
+					});
+				}
+				if (rpc.method === "subscriptions/listen") {
+					listenCount++;
+					const acknowledgment = {
+						jsonrpc: "2.0",
+						method: "notifications/subscriptions/acknowledged",
+						params: {
+							_meta: { "io.modelcontextprotocol/subscriptionId": rpc.id },
+							notifications: { resourceSubscriptions: [acceptedUri] },
+						},
+					};
+					if (listenCount === 1) return sseResponse([acknowledgment], true);
+					secondListenRequest.resolve(rpc);
+					return sseResponse(
+						[
+							acknowledgment,
+							{
+								jsonrpc: "2.0",
+								method: "notifications/resources/updated",
+								params: { uri: acceptedUri },
+							},
+						],
+						false,
+					);
+				}
+				return new Response("unexpected method", { status: 500 });
+			},
+		});
+
+		const connection = await connectToServer(
+			"subscription-restart",
+			{
+				type: "http",
+				protocolMode: "2026-07-28",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			},
+			{
+				onNotification(method, params) {
+					if (method === "notifications/resources/updated" && isRecord(params) && params.uri === acceptedUri) {
+						notificationSeen.resolve();
+					}
+				},
+			},
+		);
+		await expect(subscribeToResources(connection, [acceptedUri])).resolves.toEqual([acceptedUri]);
+		await secondListenRequest.promise;
+		await notificationSeen.promise;
+		expect(listenCount).toBe(2);
+
+		await disconnectServer(connection);
+	});
 	it("bounds the wait for a subscription acknowledgment", async () => {
 		server = Bun.serve({
 			port: 0,

--- a/packages/coding-agent/test/mcp-modern-protocol.test.ts
+++ b/packages/coding-agent/test/mcp-modern-protocol.test.ts
@@ -363,7 +363,10 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 
 		await disconnectServer(connection);
 	});
-	it("bounds the wait for a subscription acknowledgment", async () => {
+	it("rolls back resource filters when acknowledgment times out", async () => {
+		const rejectedUri = "file:///workspace/rejected.json";
+		const acceptedUri = "file:///workspace/accepted.json";
+		const requestedNotifications: unknown[] = [];
 		server = Bun.serve({
 			port: 0,
 			async fetch(request) {
@@ -378,9 +381,23 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 					});
 				}
 				if (rpc.method === "subscriptions/listen") {
-					return new Response(new ReadableStream<Uint8Array>(), {
-						headers: { "Content-Type": "text/event-stream" },
-					});
+					requestedNotifications.push(rpc.params.notifications);
+					if (requestedNotifications.length === 1) {
+						return new Response(new ReadableStream<Uint8Array>(), {
+							headers: { "Content-Type": "text/event-stream" },
+						});
+					}
+					return new Response(
+						`data: ${JSON.stringify({
+							jsonrpc: "2.0",
+							method: "notifications/subscriptions/acknowledged",
+							params: {
+								_meta: { "io.modelcontextprotocol/subscriptionId": rpc.id },
+								notifications: { resourceSubscriptions: [acceptedUri] },
+							},
+						})}\n\n`,
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
 				}
 				return new Response("unexpected method", { status: 500 });
 			},
@@ -391,9 +408,24 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 			protocolMode: "2026-07-28",
 			url: `http://127.0.0.1:${server.port}/mcp`,
 		});
-		await expect(
-			subscribeToResources(connection, ["file:///workspace/config.json"], { timeout: 50 }),
-		).rejects.toThrow("MCP subscription acknowledgment timed out after 50ms");
+		await expect(subscribeToResources(connection, [rejectedUri], { timeout: 50 })).rejects.toThrow(
+			"MCP subscription acknowledgment timed out after 50ms",
+		);
+		await expect(subscribeToResources(connection, [acceptedUri])).resolves.toEqual([acceptedUri]);
+		expect(requestedNotifications).toEqual([
+			{
+				toolsListChanged: false,
+				promptsListChanged: false,
+				resourcesListChanged: false,
+				resourceSubscriptions: [rejectedUri],
+			},
+			{
+				toolsListChanged: false,
+				promptsListChanged: false,
+				resourcesListChanged: false,
+				resourceSubscriptions: [acceptedUri],
+			},
+		]);
 		await disconnectServer(connection);
 	});
 

--- a/packages/coding-agent/test/mcp-modern-protocol.test.ts
+++ b/packages/coding-agent/test/mcp-modern-protocol.test.ts
@@ -282,9 +282,9 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 		await disconnectServer(connection);
 	});
 
-	it("restarts an acknowledged listener after graceful stream completion", async () => {
+	it("retries an acknowledged listener after a failed restart", async () => {
 		const acceptedUri = "file:///workspace/config.json";
-		const secondListenRequest = Promise.withResolvers<RpcRequest>();
+		const thirdListenRequest = Promise.withResolvers<RpcRequest>();
 		const notificationSeen = Promise.withResolvers<void>();
 		let listenCount = 0;
 		const encoder = new TextEncoder();
@@ -324,7 +324,8 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 						},
 					};
 					if (listenCount === 1) return sseResponse([acknowledgment], true);
-					secondListenRequest.resolve(rpc);
+					if (listenCount === 2) return new Response("temporary failure", { status: 500 });
+					thirdListenRequest.resolve(rpc);
 					return sseResponse(
 						[
 							acknowledgment,
@@ -357,9 +358,9 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 			},
 		);
 		await expect(subscribeToResources(connection, [acceptedUri])).resolves.toEqual([acceptedUri]);
-		await secondListenRequest.promise;
+		await thirdListenRequest.promise;
 		await notificationSeen.promise;
-		expect(listenCount).toBe(2);
+		expect(listenCount).toBe(3);
 
 		await disconnectServer(connection);
 	});

--- a/packages/coding-agent/test/mcp-modern-protocol.test.ts
+++ b/packages/coding-agent/test/mcp-modern-protocol.test.ts
@@ -137,6 +137,34 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 		}
 	});
 
+	for (const timeout of [0, 1_000]) {
+		it(`respects strict discovery timeout ${timeout}`, async () => {
+			server = Bun.serve({
+				port: 0,
+				async fetch(request) {
+					const rpc = await readRpcRequest(request);
+					await Bun.sleep(600);
+					return rpcResult(rpc.id, {
+						resultType: "complete",
+						supportedVersions: ["2026-07-28"],
+						capabilities: {},
+						ttlMs: 0,
+						cacheScope: "public",
+					});
+				},
+			});
+
+			const connection = await connectToServer(`strict-timeout-${timeout}`, {
+				type: "http",
+				protocolMode: "2026-07-28",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+				timeout,
+			});
+			expect(connection.protocolVersion).toBe("2026-07-28");
+			await disconnectServer(connection);
+		});
+	}
+
 	it("does not reinterpret a recognized modern version error as a legacy server", async () => {
 		const rpcMethods: string[] = [];
 		server = Bun.serve({
@@ -211,6 +239,71 @@ describe("MCP 2026-07-28 protocol negotiation", () => {
 			}),
 		).rejects.toThrow('MCP server "malformed" returned an invalid server/discover result');
 		expect(rpcMethods).toEqual(["server/discover"]);
+	});
+
+	it("retries an initial subscription listener that fails before acknowledgment", async () => {
+		const secondListen = Promise.withResolvers<void>();
+		const notificationSeen = Promise.withResolvers<void>();
+		let listenCount = 0;
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const rpc = await readRpcRequest(request);
+				if (rpc.method === "server/discover") {
+					return rpcResult(rpc.id, {
+						resultType: "complete",
+						supportedVersions: ["2026-07-28"],
+						capabilities: { tools: { listChanged: true } },
+						ttlMs: 0,
+						cacheScope: "public",
+					});
+				}
+				if (rpc.method === "subscriptions/listen") {
+					listenCount++;
+					if (listenCount === 1) return new Response("temporary failure", { status: 500 });
+					secondListen.resolve();
+					return new Response(
+						[
+							{
+								jsonrpc: "2.0",
+								method: "notifications/subscriptions/acknowledged",
+								params: {
+									_meta: { "io.modelcontextprotocol/subscriptionId": rpc.id },
+									notifications: { toolsListChanged: true },
+								},
+							},
+							{
+								jsonrpc: "2.0",
+								method: "notifications/tools/list_changed",
+								params: {},
+							},
+						]
+							.map(message => `data: ${JSON.stringify(message)}\n\n`)
+							.join(""),
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
+				}
+				return new Response("unexpected method", { status: 500 });
+			},
+		});
+
+		const connection = await connectToServer(
+			"initial-subscription-retry",
+			{
+				type: "http",
+				protocolMode: "2026-07-28",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+			},
+			{
+				onNotification(method) {
+					if (method === "notifications/tools/list_changed") notificationSeen.resolve();
+				},
+			},
+		);
+		await secondListen.promise;
+		await notificationSeen.promise;
+		expect(listenCount).toBe(2);
+		await disconnectServer(connection);
 	});
 
 	it("waits for the correlated subscription acknowledgment and returns only accepted resources", async () => {

--- a/packages/coding-agent/test/mcp-protocol-mode-stdio.test.ts
+++ b/packages/coding-agent/test/mcp-protocol-mode-stdio.test.ts
@@ -27,7 +27,10 @@ afterEach(async () => {
 	await removeWithRetries(tempDir);
 });
 
-function config(serverMode: "modern" | "legacy" | "close", protocolMode?: MCPProtocolMode): MCPStdioServerConfig {
+function config(
+	serverMode: "modern" | "legacy" | "close" | "invalid-params" | "ignore" | "malformed",
+	protocolMode?: MCPProtocolMode,
+): MCPStdioServerConfig {
 	return {
 		type: "stdio",
 		command: process.execPath,
@@ -80,12 +83,19 @@ describe("MCP stdio protocol rollout", () => {
 		expect(entries[0]?.pid).not.toBe(entries[1]?.pid);
 	});
 
-	it("does not reinterpret a failed auto probe as legacy", async () => {
-		await expect(connectToServer("closed-probe", config("close", "auto"))).rejects.toThrow("Transport closed");
-		const entries = await readLog(1);
-		expect(entries.map(entry => entry.method)).toEqual(["server/discover"]);
-		expect(new Set(entries.map(entry => entry.pid)).size).toBe(1);
-	});
+	for (const serverMode of ["close", "invalid-params", "ignore", "malformed"] as const) {
+		it(`falls back after a ${serverMode} auto probe outcome`, async () => {
+			connection = await connectToServer(`${serverMode}-probe`, config(serverMode, "auto"));
+			const entries = await readLog(3);
+			expect(entries.map(entry => entry.method)).toEqual([
+				"server/discover",
+				"initialize",
+				"notifications/initialized",
+			]);
+			expect(entries[0]?.pid).not.toBe(entries[1]?.pid);
+			expect(entries[1]?.pid).toBe(entries[2]?.pid);
+		});
+	}
 
 	it("does not fall back when modern mode is required", async () => {
 		await expect(connectToServer("modern-required", config("legacy", "2026-07-28"))).rejects.toThrow(

--- a/packages/coding-agent/test/mcp-protocol-mode-stdio.test.ts
+++ b/packages/coding-agent/test/mcp-protocol-mode-stdio.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { connectToServer, disconnectServer, listTools } from "@oh-my-pi/pi-coding-agent/mcp/client";
+import type { MCPProtocolMode, MCPServerConnection, MCPStdioServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+interface ProtocolLogEntry {
+	pid: number;
+	method: string;
+}
+
+const fixture = path.join(import.meta.dir, "fixtures", "protocol-mode-mcp.ts");
+let tempDir = "";
+let logPath = "";
+let connection: MCPServerConnection | undefined;
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-protocol-mode-"));
+	logPath = path.join(tempDir, "requests.jsonl");
+});
+
+afterEach(async () => {
+	if (connection) await disconnectServer(connection);
+	connection = undefined;
+	await removeWithRetries(tempDir);
+});
+
+function config(serverMode: "modern" | "legacy" | "close", protocolMode?: MCPProtocolMode): MCPStdioServerConfig {
+	return {
+		type: "stdio",
+		command: process.execPath,
+		args: [fixture],
+		env: {
+			MCP_PROTOCOL_FIXTURE_MODE: serverMode,
+			MCP_PROTOCOL_FIXTURE_LOG: logPath,
+		},
+		protocolMode,
+	};
+}
+
+async function readLog(expectedCount: number): Promise<ProtocolLogEntry[]> {
+	const deadline = Date.now() + 1_000;
+	do {
+		try {
+			const entries = Bun.JSONL.parse(await Bun.file(logPath).text()) as ProtocolLogEntry[];
+			if (entries.length >= expectedCount) return entries;
+		} catch {}
+		await Bun.sleep(5);
+	} while (Date.now() < deadline);
+	throw new Error(`Timed out waiting for ${expectedCount} MCP fixture log entries`);
+}
+
+describe("MCP stdio protocol rollout", () => {
+	it("uses one legacy process without probing by default", async () => {
+		connection = await connectToServer("legacy-default", config("legacy"));
+		const entries = await readLog(2);
+		expect(entries.map(entry => entry.method)).toEqual(["initialize", "notifications/initialized"]);
+		expect(new Set(entries.map(entry => entry.pid)).size).toBe(1);
+	});
+
+	it("probes auto mode in a disposable process before legacy initialization", async () => {
+		connection = await connectToServer("legacy-auto", config("legacy", "auto"));
+		const entries = await readLog(3);
+		expect(entries.map(entry => entry.method)).toEqual([
+			"server/discover",
+			"initialize",
+			"notifications/initialized",
+		]);
+		expect(entries[0]?.pid).not.toBe(entries[1]?.pid);
+		expect(entries[1]?.pid).toBe(entries[2]?.pid);
+	});
+
+	it("uses the modern lifecycle in a fresh process after auto discovery", async () => {
+		connection = await connectToServer("modern-auto", config("modern", "auto"));
+		await listTools(connection);
+		const entries = await readLog(2);
+		expect(entries.map(entry => entry.method)).toEqual(["server/discover", "tools/list"]);
+		expect(entries[0]?.pid).not.toBe(entries[1]?.pid);
+	});
+
+	it("does not reinterpret a failed auto probe as legacy", async () => {
+		await expect(connectToServer("closed-probe", config("close", "auto"))).rejects.toThrow("Transport closed");
+		const entries = await readLog(1);
+		expect(entries.map(entry => entry.method)).toEqual(["server/discover"]);
+		expect(new Set(entries.map(entry => entry.pid)).size).toBe(1);
+	});
+
+	it("does not fall back when modern mode is required", async () => {
+		await expect(connectToServer("modern-required", config("legacy", "2026-07-28"))).rejects.toThrow(
+			"MCP error -32601: Method not found",
+		);
+		const entries = await readLog(1);
+		expect(entries.map(entry => entry.method)).toEqual(["server/discover"]);
+		expect(new Set(entries.map(entry => entry.pid)).size).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -7,6 +7,7 @@ import {
 	MCPTool,
 } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import type { MCPServerConnection, MCPToolCallResult, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { MCPError } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import { logger } from "@oh-my-pi/pi-utils";
 
@@ -88,6 +89,12 @@ describe("isRetriableConnectionError", () => {
 	for (const msg of retriable) {
 		it(`matches: ${msg}`, () => {
 			expect(isRetriableConnectionError(new Error(msg))).toBe(true);
+		});
+	}
+	for (const status of [404, 502, 503]) {
+		it(`matches MCP JSON-RPC errors returned with HTTP ${status}`, () => {
+			const error = new MCPError({ code: -32000, message: "stale session" }, status);
+			expect(isRetriableConnectionError(error)).toBe(true);
 		});
 	}
 

--- a/packages/coding-agent/test/mcp-tool-cache.test.ts
+++ b/packages/coding-agent/test/mcp-tool-cache.test.ts
@@ -71,7 +71,7 @@ describe("MCP persistent tool cache policy", () => {
 });
 
 describe("MCP cached deferred tools", () => {
-	it("propagates cached x-mcp-header arguments before live tools/list resolves", async () => {
+	it("uses cached headers before live list and fresh headers afterward", async () => {
 		const modernConfig: MCPServerConfig = {
 			type: "http",
 			protocolMode: "2026-07-28",
@@ -88,11 +88,22 @@ describe("MCP cached deferred tools", () => {
 				required: ["tenant"],
 			},
 		};
+		const liveTool: MCPToolDefinition = {
+			...cachedTool,
+			inputSchema: {
+				type: "object",
+				properties: {
+					tenant: { type: "string", "x-mcp-header": "Account" },
+				},
+				required: ["tenant"],
+			},
+		};
 		const { cache } = createCache();
 
 		const listStarted = Promise.withResolvers<void>();
 		const listGate = Promise.withResolvers<void>();
-		const captured = { header: null as string | null };
+		const liveLoaded = Promise.withResolvers<void>();
+		const captured: Array<{ tenant: string | null; account: string | null }> = [];
 		server = Bun.serve({
 			port: 0,
 			async fetch(request) {
@@ -118,13 +129,16 @@ describe("MCP cached deferred tools", () => {
 							id: body.id,
 							result: {
 								resultType: "complete",
-								tools: [cachedTool],
+								tools: [liveTool],
 								ttlMs: 60_000,
 								cacheScope: "public",
 							},
 						});
 					case "tools/call":
-						captured.header = request.headers.get("Mcp-Param-Tenant");
+						captured.push({
+							tenant: request.headers.get("Mcp-Param-Tenant"),
+							account: request.headers.get("Mcp-Param-Account"),
+						});
 						return Response.json({
 							jsonrpc: "2.0",
 							id: body.id,
@@ -142,6 +156,7 @@ describe("MCP cached deferred tools", () => {
 		const config = { ...modernConfig, url: `http://127.0.0.1:${server.port}/mcp` };
 		await cache.set("modern", config, [cachedTool], { cacheScope: "public", ttlMs: 60_000 });
 		const manager = new MCPManager(process.cwd(), cache);
+		manager.setOnToolsChanged(() => liveLoaded.resolve());
 		const resultPromise = manager.connectServers({ modern: config }, {});
 		await listStarted.promise;
 
@@ -152,7 +167,12 @@ describe("MCP cached deferred tools", () => {
 			if (!deferred) throw new Error("cached deferred tool was not loaded");
 
 			await deferred.execute("call-1", { tenant: "acme" }, undefined, {} as CustomToolContext);
-			expect(captured.header).toBe("acme");
+			expect(captured[0]).toEqual({ tenant: "acme", account: null });
+
+			listGate.resolve();
+			await liveLoaded.promise;
+			await deferred.execute("call-2", { tenant: "acme" }, undefined, {} as CustomToolContext);
+			expect(captured[1]).toEqual({ tenant: null, account: "acme" });
 		} finally {
 			listGate.resolve();
 			await manager.disconnectAll();

--- a/packages/coding-agent/test/mcp-tool-cache.test.ts
+++ b/packages/coding-agent/test/mcp-tool-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { MCPToolCache } from "@oh-my-pi/pi-coding-agent/mcp/tool-cache";
+import type { MCPServerConfig, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import type { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+
+interface CacheRow {
+	value: string;
+	expiresAtSec: number;
+}
+
+const config: MCPServerConfig = { type: "stdio", command: "fixture" };
+const tools: MCPToolDefinition[] = [{ name: "echo", inputSchema: { type: "object" } }];
+
+function createCache(): { cache: MCPToolCache; rows: Map<string, CacheRow> } {
+	const rows = new Map<string, CacheRow>();
+	const storage = {
+		getCache(key: string): string | null {
+			const row = rows.get(key);
+			return row && row.expiresAtSec * 1000 > Date.now() ? row.value : null;
+		},
+		setCache(key: string, value: string, expiresAtSec: number): void {
+			rows.set(key, { value, expiresAtSec });
+		},
+	} as unknown as AgentStorage;
+	return { cache: new MCPToolCache(storage), rows };
+}
+
+describe("MCP persistent tool cache policy", () => {
+	it("retains the fixed legacy TTL when no modern cache policy is provided", async () => {
+		const { cache, rows } = createCache();
+		const before = Date.now();
+		await cache.set("legacy", config, tools);
+
+		expect(await cache.get("legacy", config)).toEqual(tools);
+		const row = rows.get("mcp_tools:legacy");
+		expect(row?.expiresAtSec).toBeGreaterThanOrEqual(Math.floor((before + 30 * 24 * 60 * 60 * 1000) / 1000));
+	});
+
+	it("uses a public modern result's shorter TTL", async () => {
+		const { cache, rows } = createCache();
+		const before = Date.now();
+		await cache.set("public", config, tools, { cacheScope: "public", ttlMs: 2_000 });
+
+		expect(await cache.get("public", config)).toEqual(tools);
+		const row = rows.get("mcp_tools:public");
+		expect(row?.expiresAtSec).toBeLessThanOrEqual(Math.floor((before + 2_000) / 1000));
+	});
+
+	for (const policy of [
+		{ cacheScope: "public" as const, ttlMs: 0 },
+		{ cacheScope: "private" as const, ttlMs: 60_000 },
+	]) {
+		it(`invalidates an older row for ${policy.cacheScope} ttl ${policy.ttlMs}`, async () => {
+			const { cache } = createCache();
+			await cache.set("replaced", config, tools);
+			expect(await cache.get("replaced", config)).toEqual(tools);
+
+			await cache.set("replaced", config, tools, policy);
+			expect(await cache.get("replaced", config)).toBeNull();
+		});
+	}
+});

--- a/packages/coding-agent/test/mcp-tool-cache.test.ts
+++ b/packages/coding-agent/test/mcp-tool-cache.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import type { CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import { MCPToolCache } from "@oh-my-pi/pi-coding-agent/mcp/tool-cache";
 import type { MCPServerConfig, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import type { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
@@ -24,6 +26,13 @@ function createCache(): { cache: MCPToolCache; rows: Map<string, CacheRow> } {
 	} as unknown as AgentStorage;
 	return { cache: new MCPToolCache(storage), rows };
 }
+
+let server: Bun.Server<undefined> | null = null;
+
+afterEach(() => {
+	server?.stop(true);
+	server = null;
+});
 
 describe("MCP persistent tool cache policy", () => {
 	it("retains the fixed legacy TTL when no modern cache policy is provided", async () => {
@@ -59,4 +68,94 @@ describe("MCP persistent tool cache policy", () => {
 			expect(await cache.get("replaced", config)).toBeNull();
 		});
 	}
+});
+
+describe("MCP cached deferred tools", () => {
+	it("propagates cached x-mcp-header arguments before live tools/list resolves", async () => {
+		const modernConfig: MCPServerConfig = {
+			type: "http",
+			protocolMode: "2026-07-28",
+			url: "http://placeholder",
+			timeout: 0,
+		};
+		const cachedTool: MCPToolDefinition = {
+			name: "echo",
+			inputSchema: {
+				type: "object",
+				properties: {
+					tenant: { type: "string", "x-mcp-header": "Tenant" },
+				},
+				required: ["tenant"],
+			},
+		};
+		const { cache } = createCache();
+
+		const listStarted = Promise.withResolvers<void>();
+		const listGate = Promise.withResolvers<void>();
+		const captured = { header: null as string | null };
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const body = (await request.json()) as { id?: string | number; method?: string };
+				switch (body.method) {
+					case "server/discover":
+						return Response.json({
+							jsonrpc: "2.0",
+							id: body.id,
+							result: {
+								resultType: "complete",
+								supportedVersions: ["2026-07-28"],
+								capabilities: { tools: {} },
+								ttlMs: 60_000,
+								cacheScope: "public",
+							},
+						});
+					case "tools/list":
+						listStarted.resolve();
+						await listGate.promise;
+						return Response.json({
+							jsonrpc: "2.0",
+							id: body.id,
+							result: {
+								resultType: "complete",
+								tools: [cachedTool],
+								ttlMs: 60_000,
+								cacheScope: "public",
+							},
+						});
+					case "tools/call":
+						captured.header = request.headers.get("Mcp-Param-Tenant");
+						return Response.json({
+							jsonrpc: "2.0",
+							id: body.id,
+							result: {
+								resultType: "complete",
+								content: [{ type: "text", text: "ok" }],
+							},
+						});
+					default:
+						return new Response("unexpected method", { status: 500 });
+				}
+			},
+		});
+
+		const config = { ...modernConfig, url: `http://127.0.0.1:${server.port}/mcp` };
+		await cache.set("modern", config, [cachedTool], { cacheScope: "public", ttlMs: 60_000 });
+		const manager = new MCPManager(process.cwd(), cache);
+		const resultPromise = manager.connectServers({ modern: config }, {});
+		await listStarted.promise;
+
+		try {
+			const result = await resultPromise;
+			const deferred = result.tools[0];
+			expect(deferred).toBeDefined();
+			if (!deferred) throw new Error("cached deferred tool was not loaded");
+
+			await deferred.execute("call-1", { tenant: "acme" }, undefined, {} as CustomToolContext);
+			expect(captured.header).toBe("acme");
+		} finally {
+			listGate.resolve();
+			await manager.disconnectAll();
+		}
+	});
 });

--- a/packages/coding-agent/test/mcp/config-request-id-format.test.ts
+++ b/packages/coding-agent/test/mcp/config-request-id-format.test.ts
@@ -121,3 +121,38 @@ test('an explicit "number" is the default, so dedup collapses it with an unset a
 	// same connection and only one survives.
 	expect(Object.keys(configs)).toHaveLength(1);
 });
+
+test("protocolMode survives both OMP-owned config paths", async () => {
+	const native = await loadFrom(path.join(".omp", "mcp.json"), {
+		modern: { type: "stdio", command: "/bin/echo", protocolMode: "auto" },
+	});
+	expect(native.modern?.protocolMode).toBe("auto");
+
+	const standalone = await loadFrom(".mcp.json", {
+		"standalone-modern": { type: "stdio", command: "/bin/echo", protocolMode: "2026-07-28" },
+	});
+	expect(standalone["standalone-modern"]?.protocolMode).toBe("2026-07-28");
+});
+
+test("an unrecognized protocolMode is dropped", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		bogus: { type: "stdio", command: "/bin/echo", protocolMode: "future" },
+	});
+	expect(configs.bogus?.protocolMode).toBeUndefined();
+});
+
+test("different protocol modes identify different MCP connections", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		auto: { type: "stdio", command: "/bin/echo", protocolMode: "auto" },
+		legacy: { type: "stdio", command: "/bin/echo" },
+	});
+	expect(Object.keys(configs).sort()).toEqual(["auto", "legacy"]);
+});
+
+test('explicit "legacy" protocolMode matches the default', async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		explicit: { type: "stdio", command: "/bin/echo", protocolMode: "legacy" },
+		implicit: { type: "stdio", command: "/bin/echo" },
+	});
+	expect(Object.keys(configs)).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

- add opt-in MCP 2026-07-28 discovery, per-request metadata, modern HTTP routing headers, MRTR handling, cache TTLs, and subscriptions
- introduce `legacy`, guarded `auto`, and strict `2026-07-28` lifecycle modes while preserving legacy behavior by default
- probe auto-mode stdio servers in a disposable sibling process and restrict fallback to explicit legacy evidence
- preserve reconnect, subscription, cached-tool header, and OAuth discovery behavior across modern HTTP errors and lifecycle transitions
- update OMP-owned MCP config parsing/schema, documentation, changelog, and HTTP/stdio regression coverage

## Verification

- `bun test packages/coding-agent/test/mcp*.test.ts packages/coding-agent/test/mcp` (260 passed, 9 skipped, 0 failed)
- `bun run check` in `packages/coding-agent`
- `git diff --check`