### PR TITLE
fix(rpc): strip snapcompact archive from compact result

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RPC v1 manual snapcompact compaction reporting a transport failure after the compaction had already persisted by omitting the redundant frame archive from the response ([#8168](https://github.com/can1357/oh-my-pi/issues/8168)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed RPC v1 manual snapcompact compaction reporting a transport failure after the compaction had already persisted by omitting the redundant frame archive from the response ([#8168](https://github.com/can1357/oh-my-pi/issues/8168)).
+- Fixed snapcompact compaction shipping its redundant frame archive out of `SessionMaintenance.compact()` on both the manual RPC response (which hard-failed protocol v1 with a transport error after the compaction had already persisted) and the `auto_compaction_end` event payload (which forced the shrink ladder on every unattended pass); the archive is now stripped from both exits while the persisted compaction entry keeps it ([#8168](https://github.com/can1357/oh-my-pi/issues/8168)).
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2390,7 +2390,10 @@ export class SessionMaintenance {
 					await this.#host.emitSessionEvent({
 						type: "auto_compaction_end",
 						action,
-						result: frameRescueResult,
+						result: frameRescueResult && {
+							...frameRescueResult,
+							preserveData: snapcompact.stripPreservedArchive(frameRescueResult.preserveData),
+						},
 						aborted: false,
 						willRetry: false,
 						skipped: frameRescueResult === undefined,
@@ -2790,7 +2793,7 @@ export class SessionMaintenance {
 				firstKeptEntryId,
 				tokensBefore,
 				details,
-				preserveData,
+				preserveData: snapcompact.stripPreservedArchive(preserveData),
 			};
 			// Post-maintenance progress guard — evaluated BEFORE emitting
 			// auto_compaction_end so the TUI rebuild triggered by that event

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -906,7 +906,7 @@ export class SessionMaintenance {
 				firstKeptEntryId,
 				tokensBefore,
 				details,
-				preserveData,
+				preserveData: snapcompact.stripPreservedArchive(preserveData),
 			};
 			options?.onComplete?.(compactionResult);
 			return compactionResult;

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -25,6 +25,7 @@ import { effectiveReserveTokens, estimateTokens, prepareCompaction } from "@oh-m
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { encodeRpcFrame, MAX_RPC_FRAME_BYTES } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-frame";
 import { computeNonMessageTokens } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -282,5 +283,49 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		await session.compact(undefined, { mode: "snapcompact" });
 
 		expect(compactSpy.mock.calls[0]?.[1]?.maxFrames).toBe(snapcompact.maxFramesForDataBudget());
+	});
+
+	it("keeps the frame archive out of the RPC result after persisting it", async () => {
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+		const archive = {
+			frames: [
+				{
+					data: "A".repeat(MAX_RPC_FRAME_BYTES),
+					mimeType: "image/png",
+					cols: 10,
+					rows: 10,
+					chars: 10,
+				},
+			],
+			totalChars: 10,
+			truncatedChars: 0,
+		};
+		vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "stubbed snapcompact",
+			shortSummary: "stub",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				extensionState: "keep-me",
+				[snapcompact.PRESERVE_KEY]: archive,
+			},
+		});
+
+		const result = await session.compact(undefined, { mode: "snapcompact" });
+		const response = JSON.parse(
+			encodeRpcFrame({ id: "c1", type: "response", command: "compact", success: true, data: result }),
+		) as { success: boolean; error?: string };
+
+		expect(response).toMatchObject({ success: true });
+		expect(result.preserveData).toEqual({ extensionState: "keep-me" });
+		const compactionEntry = sessionManager.getEntries().find(entry => entry.type === "compaction");
+		if (compactionEntry?.type !== "compaction") throw new Error("Expected persisted compaction entry");
+		expect(compactionEntry.preserveData).toEqual({
+			extensionState: "keep-me",
+			[snapcompact.PRESERVE_KEY]: archive,
+		});
 	});
 });

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -27,7 +27,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { encodeRpcFrame, MAX_RPC_FRAME_BYTES } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-frame";
 import { computeNonMessageTokens } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
-import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -321,6 +321,43 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 
 		expect(response).toMatchObject({ success: true });
 		expect(result.preserveData).toEqual({ extensionState: "keep-me" });
+		const compactionEntry = sessionManager.getEntries().find(entry => entry.type === "compaction");
+		if (compactionEntry?.type !== "compaction") throw new Error("Expected persisted compaction entry");
+		expect(compactionEntry.preserveData).toEqual({
+			extensionState: "keep-me",
+			[snapcompact.PRESERVE_KEY]: archive,
+		});
+	});
+
+	it("keeps the frame archive out of the auto_compaction_end event after persisting it", async () => {
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+		// A zero-frame archive clears the payload/projection gates on the auto
+		// path while still carrying PRESERVE_KEY, so the strip is what removes it.
+		const archive = { frames: [], totalChars: 1000, truncatedChars: 0 };
+		vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "stubbed snapcompact",
+			shortSummary: "stub",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				extensionState: "keep-me",
+				[snapcompact.PRESERVE_KEY]: archive,
+			},
+		});
+		const events: AgentSessionEvent[] = [];
+		session.subscribe(event => events.push(event));
+
+		await session.runIdleCompaction();
+
+		const endEvent = events.find(
+			(event): event is Extract<AgentSessionEvent, { type: "auto_compaction_end" }> =>
+				event.type === "auto_compaction_end" && event.result !== undefined,
+		);
+		if (!endEvent?.result) throw new Error("Expected a result-carrying auto_compaction_end event");
+		expect(endEvent.result.preserveData).toEqual({ extensionState: "keep-me" });
 		const compactionEntry = sessionManager.getEntries().find(entry => entry.type === "compaction");
 		if (compactionEntry?.type !== "compaction") throw new Error("Expected persisted compaction entry");
 		expect(compactionEntry.preserveData).toEqual({


### PR DESCRIPTION
## Repro
With snapcompact returning a persisted frame archive larger than protocol v1's 1 MiB frame limit, `bun test packages/coding-agent/test/agent-session-snapcompact-budget.test.ts` encoded the manual `compact` result as a v1 response and received `success: false` with `RPC response exceeded the transport limit` after the compaction entry had already been saved.

## Cause
`SessionMaintenance.compact()` in `packages/coding-agent/src/session/session-maintenance.ts` appended the full snapcompact `preserveData` to the durable `CompactionEntry`, then returned the same object in `CompactionResult`; unlike the LLM compaction path, that returned value still contained the base64 frame archive and overflowed `encodeRpcFrame()` for protocol v1.

## Fix
- Keep the complete snapcompact archive in the persisted compaction entry.
- Strip only `snapcompact.PRESERVE_KEY` from the returned `CompactionResult`, preserving other extension state.
- Cover both the successful v1 response and durable archive retention with a regression test.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-snapcompact-budget.test.ts packages/coding-agent/test/agent-session-manual-snapcompact-fallback.test.ts packages/coding-agent/test/agent-session-handoff.test.ts packages/coding-agent/test/rpc-frame.test.ts` passed: 62 tests, 0 failures. `bun run --cwd packages/coding-agent check` passed. The publish gate also completed `bun run fix` and `bun check`. Fixes #8168