### PR TITLE
fix: make terminal Mermaid state diagrams readable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed terminal Mermaid borders and junctions using low-contrast UI chrome colors instead of the active theme's readable content color.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/theme/tui-adapters.ts
+++ b/packages/coding-agent/src/modes/theme/tui-adapters.ts
@@ -148,18 +148,17 @@ export function getMarkdownTheme(): MarkdownTheme {
 	}
 	const mermaid = markdownMermaidRendering
 		? (() => {
-				// Mermaid ASCII diagrams render with the active palette so they read as
-				// content rather than raw monochrome. Roles mirror the SVG renderer's
-				// mapping; `text`/`muted`/`border`/`borderMuted`/`accent` exist in every theme.
+				// Diagram geometry is content, so keep every structural stroke on the
+				// theme's readable muted foreground instead of subtle UI chrome borders.
 				const mermaidColorMode =
 					theme.getColorMode() === "truecolor" ? ("truecolor" as const) : ("ansi256" as const);
 				const mermaidTheme = {
 					fg: theme.getColorHex("text"),
-					border: theme.getColorHex("border"),
+					border: theme.getColorHex("muted"),
 					line: theme.getColorHex("muted"),
 					arrow: theme.getColorHex("accent"),
 					corner: theme.getColorHex("muted"),
-					junction: theme.getColorHex("borderMuted"),
+					junction: theme.getColorHex("muted"),
 				};
 				return { mermaidColorMode, mermaidTheme };
 			})()

--- a/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
@@ -67,9 +67,13 @@ describe("Mermaid rendering setting", () => {
 			setThemeInstance(createTheme(titaniumJson, { mode: "truecolor" }));
 			const renderer = getMarkdownTheme().resolveMermaidAscii;
 			if (!renderer) throw new Error("Mermaid renderer unavailable");
-			const rendered = renderer("flowchart TD\n  A[Capture] --> B[Act]", 80);
+			const rendered = renderer("stateDiagram-v2\n  [*] --> Capture\n  Capture --> [*]", 80);
+			const muted = "\x1b[38;2;156;163;176m";
 
-			expect(rendered).toContain("\x1b[38;2;156;163;176m");
+			expect(rendered).toContain(`${muted}╔`);
+			expect(rendered).toContain(`${muted}║`);
+			expect(rendered).toContain(`${muted}╚`);
+			expect(rendered).not.toMatch(/\x1b\[38;2;229;229;231m[╔═╗║╚╝]/);
 			expect(rendered).not.toContain("\x1b[38;2;42;48;56m");
 			expect(rendered).not.toContain("\x1b[38;2;31;37;45m");
 		} finally {

--- a/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
@@ -76,6 +76,10 @@ describe("Mermaid rendering setting", () => {
 			expect(rendered).not.toMatch(/\x1b\[38;2;229;229;231m[╔═╗║╚╝]/);
 			expect(rendered).not.toContain("\x1b[38;2;42;48;56m");
 			expect(rendered).not.toContain("\x1b[38;2;31;37;45m");
+			const labels = renderer("flowchart TD\n  A[x=y]\n  B[status=#1]", 80);
+			const text = "\x1b[38;2;229;229;231m";
+			expect(labels).toContain(`${text}x=y`);
+			expect(labels).toContain(`${text}status=#1`);
 		} finally {
 			setThemeInstance(dark);
 		}

--- a/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Markdown } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../../src/config/settings";
+import { createTheme, getBuiltinThemes } from "../../../src/modes/theme/loader";
 import {
 	getMarkdownTheme,
 	getThemeByName,
@@ -54,5 +55,25 @@ describe("Mermaid rendering setting", () => {
 		expect(lines).toContain("```mermaid");
 		expect(lines).toContain("graph TD");
 		expect(lines).toContain("-->");
+	});
+
+	it("uses content-visible Titanium colors for Mermaid structure", async () => {
+		const dark = await getThemeByName("dark");
+		if (!dark) throw new Error("fallback theme unavailable");
+		const titaniumJson = getBuiltinThemes().titanium;
+		if (!titaniumJson) throw new Error("Titanium theme unavailable");
+
+		try {
+			setThemeInstance(createTheme(titaniumJson, { mode: "truecolor" }));
+			const renderer = getMarkdownTheme().resolveMermaidAscii;
+			if (!renderer) throw new Error("Mermaid renderer unavailable");
+			const rendered = renderer("flowchart TD\n  A[Capture] --> B[Act]", 80);
+
+			expect(rendered).toContain("\x1b[38;2;156;163;176m");
+			expect(rendered).not.toContain("\x1b[38;2;42;48;56m");
+			expect(rendered).not.toContain("\x1b[38;2;31;37;45m");
+		} finally {
+			setThemeInstance(dark);
+		}
 	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Mermaid ASCII state pseudostates rendering empty boxes, miscoloring final-state borders, and inverting rounded corners in bottom-to-top diagrams.
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/canvas.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/canvas.ts
@@ -8,7 +8,7 @@
 
 import type { Canvas, DrawingCoord, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types'
 import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi'
-import { displayWidth, toCells, WIDE_PAD } from '../text-metrics'
+import { displayWidth, toCells, LABEL_CELL_PREFIX, OPAQUE_SPACE, WIDE_PAD } from '../text-metrics'
 
 /**
  * Create a blank canvas filled with spaces.
@@ -189,7 +189,7 @@ export function isJunctionChar(c: string): boolean {
  * letter/digit test misses.
  */
 function isLabelChar(c: string): boolean {
-  return c === WIDE_PAD || displayWidth(c) === 2 || /[\p{L}\p{N}]/u.test(c)
+  return c === OPAQUE_SPACE || c.startsWith(LABEL_CELL_PREFIX) || c === WIDE_PAD || displayWidth(c) === 2 || /[\p{L}\p{N}]/u.test(c)
 }
 
 /**
@@ -327,8 +327,9 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       let line = ''
       for (let x = 0; x <= maxX; x++) {
         const c = canvas[x]![y]!
-        // Skip wide-glyph continuation cells: the glyph itself spans 2 columns
-        if (c !== WIDE_PAD) line += c
+        if (c !== WIDE_PAD) {
+          line += c === OPAQUE_SPACE ? ' ' : c.startsWith(LABEL_CELL_PREFIX) ? c.slice(LABEL_CELL_PREFIX.length) : c
+        }
       }
       lines.push(line)
     } else {
@@ -338,7 +339,7 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       for (let x = 0; x <= maxX; x++) {
         const c = canvas[x]![y]!
         if (c === WIDE_PAD) continue
-        chars.push(c)
+        chars.push(c === OPAQUE_SPACE ? ' ' : c.startsWith(LABEL_CELL_PREFIX) ? c.slice(LABEL_CELL_PREFIX.length) : c)
         roles.push(roleCanvas[x]?.[y] ?? null)
       }
       lines.push(colorizeLine(chars, roles, theme, colorMode))
@@ -439,6 +440,26 @@ export function drawText(
       }
     } else if (forceOverwrite || canvas[x]![start.y] === ' ') {
       writeCell(canvas, x, start.y, cell)
+    }
+  }
+}
+
+/**
+ * Draw edge-label text with ownership markers so later canvas merges preserve
+ * punctuation and spaces while allowing the label to clear connector strokes.
+ */
+export function drawLabelText(canvas: Canvas, start: DrawingCoord, text: string): void {
+  const cells = toCells(text)
+  increaseSize(canvas, start.x + cells.length, start.y)
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i]!
+    if (cell === WIDE_PAD) continue
+    const x = start.x + i
+    if (cells[i + 1] === WIDE_PAD) {
+      writeCell(canvas, x, start.y, cell)
+      writeCell(canvas, x + 1, start.y, WIDE_PAD)
+    } else {
+      writeCell(canvas, x, start.y, cell === ' ' ? OPAQUE_SPACE : LABEL_CELL_PREFIX + cell)
     }
   }
 }

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/canvas.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/canvas.ts
@@ -8,7 +8,7 @@
 
 import type { Canvas, DrawingCoord, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types'
 import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi'
-import { displayWidth, toCells, LABEL_CELL_PREFIX, OPAQUE_SPACE, WIDE_PAD } from '../text-metrics'
+import { displayWidth, toCells, WIDE_PAD } from '../text-metrics'
 
 /**
  * Create a blank canvas filled with spaces.
@@ -189,7 +189,7 @@ export function isJunctionChar(c: string): boolean {
  * letter/digit test misses.
  */
 function isLabelChar(c: string): boolean {
-  return c === OPAQUE_SPACE || c.startsWith(LABEL_CELL_PREFIX) || c === WIDE_PAD || displayWidth(c) === 2 || /[\p{L}\p{N}]/u.test(c)
+  return c === WIDE_PAD || displayWidth(c) === 2 || /[\p{L}\p{N}]/u.test(c)
 }
 
 /**
@@ -327,9 +327,8 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       let line = ''
       for (let x = 0; x <= maxX; x++) {
         const c = canvas[x]![y]!
-        if (c !== WIDE_PAD) {
-          line += c === OPAQUE_SPACE ? ' ' : c.startsWith(LABEL_CELL_PREFIX) ? c.slice(LABEL_CELL_PREFIX.length) : c
-        }
+        // Skip wide-glyph continuation cells: the glyph itself spans 2 columns
+        if (c !== WIDE_PAD) line += c
       }
       lines.push(line)
     } else {
@@ -339,7 +338,7 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       for (let x = 0; x <= maxX; x++) {
         const c = canvas[x]![y]!
         if (c === WIDE_PAD) continue
-        chars.push(c === OPAQUE_SPACE ? ' ' : c.startsWith(LABEL_CELL_PREFIX) ? c.slice(LABEL_CELL_PREFIX.length) : c)
+        chars.push(c)
         roles.push(roleCanvas[x]?.[y] ?? null)
       }
       lines.push(colorizeLine(chars, roles, theme, colorMode))
@@ -371,6 +370,8 @@ const VERTICAL_FLIP_MAP: Record<string, string> = {
   // Unicode corners
   '┌': '└', '└': '┌',
   '┐': '┘', '┘': '┐',
+  '╭': '╰', '╰': '╭',
+  '╮': '╯', '╯': '╮',
   // Unicode junctions (T-pieces flip vertically)
   '┬': '┴', '┴': '┬',
   // Box-start junctions (exit points from node boxes)
@@ -444,25 +445,6 @@ export function drawText(
   }
 }
 
-/**
- * Draw edge-label text with ownership markers so later canvas merges preserve
- * punctuation and spaces while allowing the label to clear connector strokes.
- */
-export function drawLabelText(canvas: Canvas, start: DrawingCoord, text: string): void {
-  const cells = toCells(text)
-  increaseSize(canvas, start.x + cells.length, start.y)
-  for (let i = 0; i < cells.length; i++) {
-    const cell = cells[i]!
-    if (cell === WIDE_PAD) continue
-    const x = start.x + i
-    if (cells[i + 1] === WIDE_PAD) {
-      writeCell(canvas, x, start.y, cell)
-      writeCell(canvas, x + 1, start.y, WIDE_PAD)
-    } else {
-      writeCell(canvas, x, start.y, cell === ' ' ? OPAQUE_SPACE : LABEL_CELL_PREFIX + cell)
-    }
-  }
-}
 
 /**
  * Set the canvas size to fit all grid columns and rows.

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
@@ -1225,15 +1225,18 @@ function fillRolesFromCanvases(
 
 /**
  * Special handling for node boxes: border chars get 'border' role, text gets 'text' role.
- * Detects text by checking if character is alphanumeric or common punctuation.
+ * Common final-state border characters (`#` and `=`) count only on the outer edge,
+ * so identical characters inside ordinary node labels retain the text role.
  */
 function fillRolesForNodeBox(
   roleCanvas: RoleCanvas,
   canvas: Canvas,
   offset: DrawingCoord,
 ): void {
-  const isBorderChar = (c: string) => /^[┌┐└┘├┤┬┴┼│─╭╮╰╯╔╗╚╝═║+\-|.':#=‖]$/.test(c)
-
+  const isBorderChar = (c: string) => /^[┌┐└┘├┤┬┴┼│─╭╮╰╯+\-|.':]$/.test(c)
+  const isStateEndBorderChar = (c: string) => /^[╔╗╚╝═║#=‖]$/.test(c)
+  const maxX = canvas.length - 1
+  const maxY = (canvas[0]?.length ?? 1) - 1
   for (let x = 0; x < canvas.length; x++) {
     for (let y = 0; y < (canvas[0]?.length ?? 0); y++) {
       const char = canvas[x]?.[y]
@@ -1242,7 +1245,9 @@ function fillRolesForNodeBox(
         const ry = y + offset.y
         // Use setRole which auto-expands the role canvas if needed
         if (rx >= 0 && ry >= 0) {
-          setRole(roleCanvas, rx, ry, isBorderChar(char) ? 'border' : 'text')
+          const isOuterEdge = x === 0 || x === maxX || y === 0 || y === maxY
+          const role = isBorderChar(char) || (isOuterEdge && isStateEndBorderChar(char)) ? 'border' : 'text'
+          setRole(roleCanvas, rx, ry, role)
         }
       }
     }

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
@@ -14,7 +14,7 @@ import {
   Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight, Middle,
   drawingCoordEquals,
 } from './types'
-import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText, mkRoleCanvas, setRole, mergeRoleCanvases } from './canvas'
+import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText, drawLabelText, mkRoleCanvas, setRole, mergeRoleCanvases } from './canvas'
 import type { RoleCanvas, CharRole } from './types'
 import { determineDirection, dirEquals } from './edge-routing'
 import { gridToDrawingCoord, lineToDrawing } from './grid'
@@ -76,16 +76,18 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
   // Get corner characters for this shape type
   const corners = getCorners(node.shape, useAscii)
 
-  // State-end uses double border to differentiate from state-start
-  const isDoubleBox = node.shape === 'state-end'
-  const hChar = useAscii ? (isDoubleBox ? '=' : '-') : (isDoubleBox ? '═' : '─')
-  const vChar = useAscii ? (isDoubleBox ? '‖' : '|') : (isDoubleBox ? '║' : '│')
+  const isStateStart = node.shape === 'state-start'
+  const isStateEnd = node.shape === 'state-end'
+  const hChar = useAscii ? (isStateEnd ? '=' : '-') : (isStateEnd ? '═' : '─')
+  const vChar = useAscii ? (isStateEnd ? '‖' : '|') : (isStateEnd ? '║' : '│')
 
-  // Double-box corners (for state-end)
-  const doubleCorners = useAscii
+  const stateStartCorners = useAscii
+    ? { tl: '.', tr: '.', bl: "'", br: "'" }
+    : { tl: '╭', tr: '╮', bl: '╰', br: '╯' }
+  const stateEndCorners = useAscii
     ? { tl: '#', tr: '#', bl: '#', br: '#' }
     : { tl: '╔', tr: '╗', bl: '╚', br: '╝' }
-  const effectiveCorners = isDoubleBox ? doubleCorners : corners
+  const effectiveCorners = isStateEnd ? stateEndCorners : isStateStart ? stateStartCorners : corners
 
   // Draw box border with shape-specific corners
   for (let x = from.x + 1; x < to.x; x++) box[x]![from.y] = hChar
@@ -97,8 +99,8 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
   box[from.x]![to.y] = effectiveCorners.bl
   box[to.x]![to.y] = effectiveCorners.br
 
-  // Center the multi-line display label inside the box
-  const label = node.displayLabel
+  // Pseudostates have no source label; restore their UML marker explicitly.
+  const label = node.displayLabel || (isStateStart ? (useAscii ? '*' : '●') : isStateEnd ? (useAscii ? '*' : '◎') : '')
   const lines = splitLines(label)
   const textCenterY = from.y + Math.floor(h / 2)
   const startY = textCenterY - Math.floor((lines.length - 1) / 2)
@@ -677,7 +679,7 @@ function drawTextOnLine(canvas: Canvas, line: DrawingCoord[], label: string, isU
   for (let i = 0; i < lines.length; i++) {
     const lineText = lines[i]!
     const startX = middleX - Math.floor(displayWidth(lineText) / 2)
-    drawText(canvas, { x: startX, y: startY + i }, lineText)
+    drawLabelText(canvas, { x: startX, y: startY + i }, lineText)
   }
 }
 

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
@@ -14,7 +14,7 @@ import {
   Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight, Middle,
   drawingCoordEquals,
 } from './types'
-import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText, drawLabelText, mkRoleCanvas, setRole, mergeRoleCanvases } from './canvas'
+import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText, mkRoleCanvas, setRole, mergeRoleCanvases } from './canvas'
 import type { RoleCanvas, CharRole } from './types'
 import { determineDirection, dirEquals } from './edge-routing'
 import { gridToDrawingCoord, lineToDrawing } from './grid'
@@ -82,7 +82,7 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
   const vChar = useAscii ? (isStateEnd ? '‖' : '|') : (isStateEnd ? '║' : '│')
 
   const stateStartCorners = useAscii
-    ? { tl: '.', tr: '.', bl: "'", br: "'" }
+    ? { tl: '+', tr: '+', bl: '+', br: '+' }
     : { tl: '╭', tr: '╮', bl: '╰', br: '╯' }
   const stateEndCorners = useAscii
     ? { tl: '#', tr: '#', bl: '#', br: '#' }
@@ -679,7 +679,7 @@ function drawTextOnLine(canvas: Canvas, line: DrawingCoord[], label: string, isU
   for (let i = 0; i < lines.length; i++) {
     const lineText = lines[i]!
     const startX = middleX - Math.floor(displayWidth(lineText) / 2)
-    drawLabelText(canvas, { x: startX, y: startY + i }, lineText)
+    drawText(canvas, { x: startX, y: startY + i }, lineText)
   }
 }
 
@@ -1232,7 +1232,7 @@ function fillRolesForNodeBox(
   canvas: Canvas,
   offset: DrawingCoord,
 ): void {
-  const isBorderChar = (c: string) => /^[┌┐└┘├┤┬┴┼│─╭╮╰╯+\-|.':]$/.test(c)
+  const isBorderChar = (c: string) => /^[┌┐└┘├┤┬┴┼│─╭╮╰╯╔╗╚╝═║+\-|.':#=‖]$/.test(c)
 
   for (let x = 0; x < canvas.length; x++) {
     for (let y = 0; y < (canvas[0]?.length ?? 0); y++) {

--- a/packages/utils/src/vendor/mermaid-ascii/text-metrics.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/text-metrics.ts
@@ -29,6 +29,17 @@
  */
 export const WIDE_PAD = '\u0000'
 
+/**
+ * Space owned by a text label rather than unused canvas. Merge layers treat
+ * ordinary spaces as transparent, so labels use this sentinel to clear edge
+ * lines between words. Serialization converts it back to a regular space.
+ */
+export const OPAQUE_SPACE = '\u0001'
+
+/** Prefix marking a one-column cell as label-owned through canvas merges. */
+export const LABEL_CELL_PREFIX = '\u0002'
+
+
 const graphemeSegmenter = new Intl.Segmenter()
 
 /**

--- a/packages/utils/src/vendor/mermaid-ascii/text-metrics.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/text-metrics.ts
@@ -29,17 +29,6 @@
  */
 export const WIDE_PAD = '\u0000'
 
-/**
- * Space owned by a text label rather than unused canvas. Merge layers treat
- * ordinary spaces as transparent, so labels use this sentinel to clear edge
- * lines between words. Serialization converts it back to a regular space.
- */
-export const OPAQUE_SPACE = '\u0001'
-
-/** Prefix marking a one-column cell as label-owned through canvas merges. */
-export const LABEL_CELL_PREFIX = '\u0002'
-
-
 const graphemeSegmenter = new Intl.Segmenter()
 
 /**

--- a/packages/utils/test/mermaid-ascii.test.ts
+++ b/packages/utils/test/mermaid-ascii.test.ts
@@ -13,6 +13,31 @@ describe("renderMermaidAscii", () => {
 		expect(rendered).not.toContain("──A─");
 	});
 
+	it("renders state pseudostates with their UML markers", () => {
+		const rendered = renderMermaidAscii(["stateDiagram-v2", "  [*] --> Created", "  Created --> [*]"].join("\n"), {
+			colorMode: "none",
+		});
+
+		expect(rendered).toMatch(/│\s+●\s+│/);
+		expect(rendered).toMatch(/║\s+◎\s+║/);
+	});
+
+	it("keeps dense transition labels intact above connector lines", () => {
+		const rendered = renderMermaidAscii(
+			[
+				"stateDiagram-v2",
+				"  Working --> Working: sessions die and respawn freely",
+				"  Working --> Archived: cheap exit, branches kept",
+				"  Archived --> Working: resume rebuilds substrate",
+			].join("\n"),
+			{ colorMode: "none" },
+		);
+
+		expect(rendered).toContain("sessions die and respawn freely");
+		expect(rendered).toContain("cheap exit, branches kept");
+		expect(rendered).toContain("resume rebuilds substrate");
+	});
+
 	it("returns a bounded fallback for declaration orders that make a clean route unreachable", () => {
 		const rendered = renderMermaidAsciiSafe(
 			[

--- a/packages/utils/test/mermaid-ascii.test.ts
+++ b/packages/utils/test/mermaid-ascii.test.ts
@@ -13,29 +13,28 @@ describe("renderMermaidAscii", () => {
 		expect(rendered).not.toContain("──A─");
 	});
 
-	it("renders state pseudostates with their UML markers", () => {
-		const rendered = renderMermaidAscii(["stateDiagram-v2", "  [*] --> Created", "  Created --> [*]"].join("\n"), {
-			colorMode: "none",
-		});
+	it("renders Unicode and ASCII state pseudostates with distinct UML markers", () => {
+		const source = ["stateDiagram-v2", "  [*] --> Created", "  Created --> [*]"].join("\n");
+		const unicode = renderMermaidAscii(source, { colorMode: "none" });
+		const ascii = renderMermaidAscii(source, { colorMode: "none", useAscii: true });
 
-		expect(rendered).toMatch(/│\s+●\s+│/);
-		expect(rendered).toMatch(/║\s+◎\s+║/);
+		expect(unicode).toMatch(/│\s+●\s+│/);
+		expect(unicode).toMatch(/║\s+◎\s+║/);
+		expect(ascii).toMatch(/\|\s+\*\s+\|/);
+		expect(ascii).toMatch(/‖\s+\*\s+‖/);
+		expect(ascii).toMatch(/#=+#/);
 	});
 
-	it("keeps dense transition labels intact above connector lines", () => {
-		const rendered = renderMermaidAscii(
-			[
-				"stateDiagram-v2",
-				"  Working --> Working: sessions die and respawn freely",
-				"  Working --> Archived: cheap exit, branches kept",
-				"  Archived --> Working: resume rebuilds substrate",
-			].join("\n"),
-			{ colorMode: "none" },
-		);
+	it("keeps rounded pseudostate corners upright in bottom-to-top diagrams", () => {
+		const rendered = renderMermaidAscii(["stateDiagram-v2", "  direction BT", "  [*] --> Created"].join("\n"), {
+			colorMode: "none",
+		});
+		const rows = rendered.split("\n");
+		const markerRow = rows.findIndex(row => row.includes("●"));
 
-		expect(rendered).toContain("sessions die and respawn freely");
-		expect(rendered).toContain("cheap exit, branches kept");
-		expect(rendered).toContain("resume rebuilds substrate");
+		expect(markerRow).toBeGreaterThan(0);
+		expect(rows[markerRow - 1]).toMatch(/╭─+╮/);
+		expect(rows[markerRow + 1]).toMatch(/╰─+╯/);
 	});
 
 	it("returns a bounded fallback for declaration orders that make a clean route unreachable", () => {


### PR DESCRIPTION
## Summary

- use the active theme's readable `muted` foreground for Mermaid borders and junctions instead of low-contrast UI chrome border tokens
- restore the missing Unicode and ASCII markers inside state-diagram initial/final pseudostates
- classify single- and double-border pseudostate geometry as structural color, including ASCII final-state borders
- preserve rounded pseudostate corner orientation in bottom-to-top diagrams
- add focused regressions and package changelog entries

## Reproduction and verification

Reproduced with a `stateDiagram-v2` lifecycle containing `[*]`, a self-loop, cross-column transitions, and terminal pseudostates. Before this change, Titanium emitted node borders as `38;2;42;48;56`, pseudostate boxes had empty interiors, and final-state double borders inherited the text role.

After the change, the same source renders `●`/`◎` (and `*` in ASCII mode), emits all pseudostate borders as `38;2;156;163;176`, emits neither prior low-contrast border color, and keeps rounded pseudostate corners upright under `direction BT`.

Review update: the edge-label masking changes were removed from this PR to avoid overlapping #8101, which already owns that fix.

Checks run:

- `bun test packages/utils/test/mermaid-ascii.test.ts packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts` — 8 pass
- `bun --cwd=packages/utils test` — 628 pass, 2 skip
- `bun run check:ts` — passed across all TypeScript workspaces
- exact originating lifecycle structure smoke — start/end markers present, final borders use the visible structural color, stale colors absent