### PR TITLE
feat(rpc): add set_mode command for plan/vibe/goal session modes

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -150,6 +150,25 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_follow_up_mode", mode: "all" | "one-at-a-time" }`
 - `{ id?, type: "set_interrupt_mode", mode: "immediate" | "wait" }`
 
+### Session modes (plan / vibe / goal)
+
+- `{ id?, type: "set_mode", mode: "none" | "plan" | "vibe" | "goal", objective?: string }`
+
+Activates or deactivates a session special mode, with the same mutual-exclusion
+semantics as the TUI's `/plan`, `/vibe` and `/goal` commands: entering a mode
+while another is active fails with `"Exit <mode> mode first."` and the current
+mode stays. `goal` requires an `objective`; `none` exits whichever mode is
+active. The response reports the resulting live mode:
+
+```json
+{ "type": "response", "command": "set_mode", "success": true, "data": { "mode": "plan" } }
+```
+
+Mode state is persisted as `mode_change` session entries, so switching back to
+a session (via `switch_session`) restores its mode automatically. Model-role
+switching on plan entry is intentionally left to the client (use `set_model`),
+matching ACP's `session/set_mode`.
+
 ### Compaction
 
 - `{ id?, type: "compact", customInstructions?: string }`
@@ -251,6 +270,7 @@ is re-armed.
   "thinkingLevel": "off|minimal|low|medium|high|xhigh|max",
   "isStreaming": false,
   "isCompacting": false,
+  "mode": "none|plan|plan_paused|vibe|goal|goal_paused",
   "steeringMode": "all|one-at-a-time",
   "followUpMode": "all|one-at-a-time",
   "interruptMode": "immediate|wait",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- RPC mode: new `set_mode` command to activate/deactivate the plan, vibe and goal session modes headlessly (mirroring the TUI's `/plan` / `/vibe` / `/goal` mutual-exclusion semantics), a `mode` field in `get_state`, and automatic mode restoration across `switch_session`. `RpcClient.setMode()` is available for TypeScript hosts. ([#8171](https://github.com/can1357/oh-my-pi/issues/8171))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -603,6 +603,8 @@ export class RpcClient {
 		const state = this.#getData<RpcSessionState>(response);
 		return {
 			...state,
+			// Older servers predate the `mode` field; treat it as absent → "none".
+			mode: state.mode ?? "none",
 			fastModeEnabled: state.fastModeEnabled === true,
 			fastModeActive: state.fastModeActive === true,
 			tokensPerSecond:

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -32,7 +32,9 @@ import type {
 	RpcHostToolResult,
 	RpcHostToolUpdate,
 	RpcResponse,
+	RpcSessionMode,
 	RpcSessionState,
+	RpcSetModeTarget,
 	RpcSubagentEventFrame,
 	RpcSubagentLifecycleFrame,
 	RpcSubagentMessagesResult,
@@ -650,6 +652,19 @@ export class RpcClient {
 			fromByte: selector.fromByte,
 		});
 		return this.#getData<RpcSubagentMessagesResult>(response);
+	}
+
+	/**
+	 * Switch the session's special mode (plan / vibe / goal). `goal` requires
+	 * an `objective`. Returns the resulting live mode.
+	 */
+	async setMode(mode: RpcSetModeTarget, objective?: string): Promise<RpcSessionMode> {
+		const response = await this.#send({
+			type: "set_mode",
+			mode,
+			...(objective !== undefined ? { objective } : {}),
+		});
+		return this.#getData<{ mode: RpcSessionMode }>(response).mode;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -39,6 +39,7 @@ import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
+import { getSessionMode, reconcileSessionMode, setSessionMode, suspendSessionMode } from "./rpc-modes";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -953,6 +954,12 @@ export async function runRpcMode(
 		output(event);
 	});
 
+	// Restore plan/vibe/goal mode across switch_session like the TUI does: drop
+	// the previous session's live mode state before the switch, then reconcile
+	// the target file's mode_change chain afterwards.
+	session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(session));
+	session.setSessionSwitchReconciler(() => reconcileSessionMode(session));
+
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
 	const reloadPluginState = async () => {
 		const cwd = session.sessionManager.getCwd();
@@ -1078,6 +1085,7 @@ export async function runRpcMode(
 					thinkingLevel: session.thinkingLevel,
 					isStreaming: session.isStreaming,
 					isCompacting: session.isCompacting,
+					mode: getSessionMode(session),
 					steeringMode: session.steeringMode,
 					followUpMode: session.followUpMode,
 					interruptMode: session.interruptMode,
@@ -1250,6 +1258,19 @@ export async function runRpcMode(
 			case "set_interrupt_mode": {
 				session.setInterruptMode(command.mode);
 				return success(id, "set_interrupt_mode");
+			}
+
+			// =================================================================
+			// Session Modes (plan / vibe / goal)
+			// =================================================================
+
+			case "set_mode": {
+				try {
+					const mode = await setSessionMode(session, command.mode, command.objective);
+					return success(id, "set_mode", { mode });
+				} catch (err) {
+					return error(id, "set_mode", err instanceof Error ? err.message : String(err));
+				}
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -13,7 +13,7 @@
 import { once } from "node:events";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
-import { $env, isRecord, readLines, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, isRecord, logger, readLines, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -956,9 +956,21 @@ export async function runRpcMode(
 
 	// Restore plan/vibe/goal mode across switch_session like the TUI does: drop
 	// the previous session's live mode state before the switch, then reconcile
-	// the target file's mode_change chain afterwards.
+	// the target file's mode_change chain afterwards. Reconcile the *current*
+	// session once up front too, so a session resumed with a persisted mode
+	// (e.g. --session pointing at a plan-mode journal) starts with live mode
+	// state instead of reporting "none" until the first switch (mirrors
+	// InteractiveMode's startup reconcile).
 	session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(session));
 	session.setSessionSwitchReconciler(() => reconcileSessionMode(session));
+	try {
+		await reconcileSessionMode(session);
+	} catch (error) {
+		logger.warn("Failed to reconcile session mode on RPC startup", {
+			sessionFile: session.sessionManager.getSessionFile(),
+			error: String(error),
+		});
+	}
 
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
 	const reloadPluginState = async () => {

--- a/packages/coding-agent/src/modes/rpc/rpc-modes.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-modes.ts
@@ -61,6 +61,10 @@ export async function enterPlanMode(
 	session: AgentSession,
 	options?: { planFilePath?: string; persist?: boolean },
 ): Promise<void> {
+	// Idempotent: re-entering plan mode must not re-capture the write-augmented
+	// toolset into `previousToolsByMode` (a later exit would then leave `write`
+	// active). Mirrors InteractiveMode.#enterPlanMode.
+	if (session.getPlanModeState()?.enabled) return;
 	assertNoOtherMode(session, "plan");
 	if (!session.settings.get("plan.enabled")) {
 		throw new Error("Plan mode is disabled. Enable it in settings (plan.enabled).");
@@ -136,6 +140,8 @@ function vibeParentSession(session: AgentSession): VibeParentSession {
 }
 
 export async function enterVibeMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	// Idempotent: re-entering must not re-capture the read-only toolset (see enterPlanMode).
+	if (session.getVibeModeState()?.enabled) return;
 	assertNoOtherMode(session, "vibe");
 	const vibeRegistry = VibeSessionRegistry.global();
 	const parent = vibeParentSession(session);
@@ -182,6 +188,9 @@ export async function enterGoalMode(
 	objective: string,
 	_options?: { persist?: boolean },
 ): Promise<void> {
+	// Idempotent: re-entering must not re-capture the goal-augmented toolset
+	// (see enterPlanMode). Mirrors InteractiveMode.#enterGoalMode.
+	if (session.getGoalModeState()?.enabled) return;
 	assertNoOtherMode(session, "goal");
 	if (!session.settings.get("goal.enabled")) {
 		throw new Error("Goal mode is disabled. Enable it in settings (goal.enabled).");
@@ -303,9 +312,7 @@ export async function reconcileSessionMode(session: AgentSession): Promise<void>
 		if (!session.settings.get("plan.enabled")) {
 			// Clear stale plan/plan_paused mode so re-enabling the setting
 			// later doesn't unexpectedly restore an old plan session.
-			if (mode === "plan" || mode === "plan_paused") {
-				session.sessionManager.appendModeChange("none");
-			}
+			session.sessionManager.appendModeChange("none");
 			return;
 		}
 		if (mode === "plan") {
@@ -317,6 +324,9 @@ export async function reconcileSessionMode(session: AgentSession): Promise<void>
 		return;
 	}
 	if (mode === "vibe") {
+		// Rehydrate suspended workers scoped to this parent before re-entering,
+		// mirroring InteractiveMode.#reconcileModeFromSession.
+		await VibeSessionRegistry.global().rehydrate(vibeParentSession(session));
 		await enterVibeMode(session, { persist: false });
 		return;
 	}

--- a/packages/coding-agent/src/modes/rpc/rpc-modes.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-modes.ts
@@ -1,0 +1,343 @@
+/**
+ * Headless session-mode controller for RPC hosts.
+ *
+ * plan/vibe/goal activation lives in the TUI's `InteractiveModeContext`
+ * (`handlePlanModeCommand` & friends), which RPC hosts cannot reach. This
+ * module mirrors those session-level effects — mode state, toolset changes,
+ * the plan-proposal handler, persisted `mode_change` entries, and mutual
+ * exclusion — using only public `AgentSession` APIs, so `set_mode` behaves
+ * like the TUI's `/plan` / `/vibe` / `/goal` commands.
+ *
+ * Session-switch support mirrors `InteractiveMode.#reconcileModeFromSession`:
+ * `suspendSessionMode` drops live mode state before a switch (without writing
+ * to the target file's mode chain) and `reconcileSessionMode` restores the
+ * persisted mode from the target file's `mode_change` chain afterwards.
+ *
+ * Model-role switching on plan entry is deliberately omitted, matching ACP's
+ * `session/set_mode`: the RPC client already addresses the model via
+ * `set_model`, and a server-side switch would fight the client's selection.
+ */
+import { formatModelString } from "../../config/model-resolver";
+import type { Goal } from "../../goals/state";
+import type { AgentSession } from "../../session/agent-session";
+import { type VibeParentSession, VibeSessionRegistry } from "../../vibe/runtime";
+import type { RpcSessionMode, RpcSetModeTarget } from "./rpc-types";
+
+/**
+ * Pre-enter toolset per session, so exiting a mode restores exactly what was
+ * active before it (plan augments with `write`, vibe replaces with read-only,
+ * goal adds the `goal` tool).
+ */
+const previousToolsByMode = new WeakMap<AgentSession, { plan?: string[]; vibe?: string[]; goal?: string[] }>();
+
+function assertNoOtherMode(session: AgentSession, target: RpcSetModeTarget): void {
+	if (target !== "plan" && session.getPlanModeState()?.enabled) {
+		throw new Error("Exit plan mode first.");
+	}
+	if (target !== "vibe" && session.getVibeModeState()?.enabled) {
+		throw new Error("Exit vibe mode first.");
+	}
+	const goal = session.getGoalModeState();
+	if (target !== "goal" && (goal?.enabled || goal?.goal.status === "paused")) {
+		throw new Error("Exit goal mode first.");
+	}
+}
+
+/** Live session mode, mirroring the mode semantics of `buildSessionContext`. */
+export function getSessionMode(session: AgentSession): RpcSessionMode {
+	if (session.getPlanModeState()?.enabled) return "plan";
+	if (session.getVibeModeState()?.enabled) return "vibe";
+	const goal = session.getGoalModeState();
+	if (goal?.enabled) return "goal";
+	if (goal?.goal.status === "paused") return "goal_paused";
+	return "none";
+}
+
+// ---------------------------------------------------------------------------
+// Plan mode
+// ---------------------------------------------------------------------------
+
+export async function enterPlanMode(
+	session: AgentSession,
+	options?: { planFilePath?: string; persist?: boolean },
+): Promise<void> {
+	assertNoOtherMode(session, "plan");
+	if (!session.settings.get("plan.enabled")) {
+		throw new Error("Plan mode is disabled. Enable it in settings (plan.enabled).");
+	}
+	const planFilePath = options?.planFilePath ?? (session.getPlanReferencePath() || "local://PLAN.md");
+	const previousTools = session.getEnabledToolNames();
+	// Plan approval is a `write` to `xd://propose`; keep `write` in the active
+	// toolset so the agent can draft and submit the plan (mirrors
+	// InteractiveMode.#enterPlanMode and print-mode).
+	const planTools = session.hasBuiltInTool("write") ? [...new Set([...previousTools, "write"])] : previousTools;
+	await session.setActiveToolsByName(planTools);
+	previousToolsByMode.set(session, { ...previousToolsByMode.get(session), plan: previousTools });
+	const previous = session.getPlanModeState();
+	session.setPlanModeState({
+		enabled: true,
+		planFilePath: previous?.planFilePath ?? planFilePath,
+		workflow: previous?.workflow ?? "parallel",
+		reentry: previous !== undefined,
+	});
+	session.setPlanProposalHandler(async title => {
+		const result = await session.preparePlanForReview(title);
+		const details = result.details;
+		if (details) {
+			const state = session.getPlanModeState();
+			if (state?.enabled) {
+				session.setPlanModeState({ ...state, planFilePath: details.planFilePath });
+			}
+			session.sessionManager.appendModeChange("plan", { planFilePath: details.planFilePath });
+		}
+		return result;
+	});
+	if (session.isStreaming) {
+		await session.sendPlanModeContext({ deliverAs: "steer" });
+	}
+	if (options?.persist !== false) {
+		session.sessionManager.appendModeChange("plan", { planFilePath });
+	}
+}
+
+export async function exitPlanMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	if (!session.getPlanModeState()?.enabled) return;
+	const previous = previousToolsByMode.get(session)?.plan;
+	if (previous !== undefined) {
+		await session.setActiveToolsByName(previous);
+	}
+	session.setPlanModeState(undefined);
+	session.setPlanProposalHandler(null);
+	if (options?.persist !== false) {
+		session.sessionManager.appendModeChange("none");
+	}
+	const rest = previousToolsByMode.get(session);
+	if (rest) {
+		delete rest.plan;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Vibe mode
+// ---------------------------------------------------------------------------
+
+function vibeParentSession(session: AgentSession): VibeParentSession {
+	return {
+		getAgentId: () => session.getAgentId() ?? null,
+		getSessionId: () => session.sessionManager.getSessionId(),
+		getSessionFile: () => session.sessionManager.getSessionFile() ?? null,
+		sessionManager: session.sessionManager,
+		asyncJobManager: session.asyncJobManager,
+		settings: session.settings,
+		// Resolve workers against this session's active model (same as the
+		// spawn-path ToolSession), not the settings default.
+		getActiveModelString: () => (session.model ? formatModelString(session.model) : undefined),
+	};
+}
+
+export async function enterVibeMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	assertNoOtherMode(session, "vibe");
+	const vibeRegistry = VibeSessionRegistry.global();
+	const parent = vibeParentSession(session);
+	vibeRegistry.activateScope(vibeRegistry.ownerScope(parent));
+	const previousTools = session.getEnabledToolNames();
+	const vibeBaseTools = ["read"];
+	if (session.hasBuiltInTool("todo")) vibeBaseTools.push("todo");
+	await session.activateVibeTools(vibeBaseTools);
+	previousToolsByMode.set(session, { ...previousToolsByMode.get(session), vibe: previousTools });
+	session.setVibeModeState({ enabled: true });
+	if (session.isStreaming) {
+		await session.sendVibeModeContext({ deliverAs: "steer" });
+	}
+	if (options?.persist !== false) {
+		session.sessionManager.appendModeChange("vibe");
+	}
+}
+
+export async function exitVibeMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	if (!session.getVibeModeState()?.enabled) return;
+	const parent = vibeParentSession(session);
+	const registry = VibeSessionRegistry.global();
+	await registry.killAll(parent, registry.ownerScope(parent));
+	await session.deactivateVibeTools(previousToolsByMode.get(session)?.vibe ?? ["read"]);
+	session.setVibeModeState(undefined);
+	if (options?.persist !== false) {
+		// Persist the exit: unlike the TUI (which relies on the worker-tombstone
+		// path), an explicit headless exit should leave a mode chain that says
+		// "none" so a later switch/restart doesn't resurrect vibe mode.
+		session.sessionManager.appendModeChange("none");
+	}
+	const rest = previousToolsByMode.get(session);
+	if (rest) {
+		delete rest.vibe;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Goal mode
+// ---------------------------------------------------------------------------
+
+export async function enterGoalMode(
+	session: AgentSession,
+	objective: string,
+	_options?: { persist?: boolean },
+): Promise<void> {
+	assertNoOtherMode(session, "goal");
+	if (!session.settings.get("goal.enabled")) {
+		throw new Error("Goal mode is disabled. Enable it in settings (goal.enabled).");
+	}
+	const trimmed = objective.trim();
+	if (!trimmed) {
+		throw new Error("Goal mode requires an objective (pass `objective` to set_mode).");
+	}
+	const previousTools = session.getEnabledToolNames().filter(name => name !== "goal");
+	// sdk.ts excludes "goal" from the initial active tool set unconditionally;
+	// re-add it so the agent can call resume, complete, or drop on this goal.
+	await session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+	const state = await session.goalRuntime.createGoal({ objective: trimmed });
+	session.setGoalModeState(state);
+	previousToolsByMode.set(session, { ...previousToolsByMode.get(session), goal: previousTools });
+	// mode_change persistence is handled by the goal runtime's persist callback.
+}
+
+export async function exitGoalMode(session: AgentSession, _options?: { persist?: boolean }): Promise<void> {
+	const goal = session.getGoalModeState();
+	if (!goal?.enabled && goal?.goal.status !== "paused") return;
+	const previous = previousToolsByMode.get(session)?.goal;
+	if (previous !== undefined) {
+		await session.setActiveToolsByName(previous);
+	}
+	await session.goalRuntime.dropGoal();
+	session.setGoalModeState(undefined);
+	const rest = previousToolsByMode.get(session);
+	if (rest) {
+		delete rest.goal;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/** Apply a mode change; returns the resulting live session mode. */
+export async function setSessionMode(
+	session: AgentSession,
+	mode: RpcSetModeTarget,
+	objective?: string,
+): Promise<RpcSessionMode> {
+	switch (mode) {
+		case "none":
+			await resetSessionMode(session);
+			break;
+		case "plan":
+			await enterPlanMode(session);
+			break;
+		case "vibe":
+			await enterVibeMode(session);
+			break;
+		case "goal":
+			await enterGoalMode(session, objective ?? "");
+			break;
+	}
+	return getSessionMode(session);
+}
+
+/** Exit whichever special mode is currently active (plan / vibe / goal). */
+export async function resetSessionMode(session: AgentSession): Promise<void> {
+	if (session.getPlanModeState()?.enabled) {
+		await exitPlanMode(session);
+	} else if (session.getVibeModeState()?.enabled) {
+		await exitVibeMode(session);
+	} else if (session.getGoalModeState()?.enabled || session.getGoalModeState()?.goal.status === "paused") {
+		await exitGoalMode(session);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session-switch hooks (mirror InteractiveMode.#clearTransientModeState /
+// #reconcileModeFromSession)
+// ---------------------------------------------------------------------------
+
+/**
+ * Drop live mode state before the session switches to another file, without
+ * persisting anything (the target file's mode chain is untouched). Vibe
+ * workers are suspended under their parent scope, not killed, so switching
+ * back to the session can resume them.
+ */
+export async function suspendSessionMode(session: AgentSession): Promise<void> {
+	if (session.getPlanModeState()?.enabled) {
+		const previous = previousToolsByMode.get(session)?.plan;
+		if (previous !== undefined) {
+			await session.setActiveToolsByName(previous);
+		}
+		session.setPlanModeState(undefined);
+		session.setPlanProposalHandler(null);
+	}
+	const goal = session.getGoalModeState();
+	if (goal?.enabled || goal?.goal.status === "paused") {
+		const previous = previousToolsByMode.get(session)?.goal;
+		if (previous !== undefined) {
+			await session.setActiveToolsByName(previous);
+		}
+		session.setGoalModeState(undefined);
+	}
+	if (session.getVibeModeState()?.enabled) {
+		const parent = vibeParentSession(session);
+		const registry = VibeSessionRegistry.global();
+		await registry.suspendScope(registry.ownerScope(parent));
+		await session.deactivateVibeTools(previousToolsByMode.get(session)?.vibe ?? ["read"]);
+		session.setVibeModeState(undefined);
+	}
+	previousToolsByMode.delete(session);
+}
+
+/**
+ * Restore the persisted mode after switching to a session file whose
+ * `mode_change` chain names a special mode. Mirrors
+ * `InteractiveMode.#reconcileModeFromSession` minus the TUI-only state.
+ */
+export async function reconcileSessionMode(session: AgentSession): Promise<void> {
+	const context = session.sessionManager.buildSessionContext();
+	const mode = context.mode;
+	if (mode === "plan" || mode === "plan_paused") {
+		if (!session.settings.get("plan.enabled")) {
+			// Clear stale plan/plan_paused mode so re-enabling the setting
+			// later doesn't unexpectedly restore an old plan session.
+			if (mode === "plan" || mode === "plan_paused") {
+				session.sessionManager.appendModeChange("none");
+			}
+			return;
+		}
+		if (mode === "plan") {
+			const planFilePath = context.modeData?.planFilePath as string | undefined;
+			await enterPlanMode(session, { planFilePath, persist: false });
+		}
+		// plan_paused is an interactive intermediate; headless restore stays in
+		// build mode (the plan file and model remain as persisted).
+		return;
+	}
+	if (mode === "vibe") {
+		await enterVibeMode(session, { persist: false });
+		return;
+	}
+	if (mode === "goal" || mode === "goal_paused") {
+		if (!session.settings.get("goal.enabled")) {
+			session.goalRuntime.clearAccounting();
+			session.sessionManager.appendModeChange("none");
+			return;
+		}
+		const goal = (context.modeData as { goal?: Goal } | undefined)?.goal;
+		if (!goal) {
+			session.sessionManager.appendModeChange("none");
+			return;
+		}
+		session.setGoalModeState({ enabled: mode === "goal", mode: "active", goal });
+		const restored = await session.goalRuntime.onThreadResumed({});
+		if (restored?.goal) {
+			const previousTools = session.getEnabledToolNames().filter(name => name !== "goal");
+			await session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+			previousToolsByMode.set(session, { ...previousToolsByMode.get(session), goal: previousTools });
+		}
+		return;
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-modes.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-modes.ts
@@ -342,7 +342,10 @@ export async function reconcileSessionMode(session: AgentSession): Promise<void>
 			return;
 		}
 		session.setGoalModeState({ enabled: mode === "goal", mode: "active", goal });
-		const restored = await session.goalRuntime.onThreadResumed({});
+		// Preserve an active goal across in-process switches (the TUI's switch
+		// reconciler passes preserveActiveGoal: true too); without it an active
+		// goal is converted to goal_paused and persisted as such.
+		const restored = await session.goalRuntime.onThreadResumed({ preserveActiveGoal: true });
 		if (restored?.goal) {
 			const previousTools = session.getEnabledToolNames().filter(name => name !== "goal");
 			await session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -62,6 +62,9 @@ export type RpcCommand =
 	| { id?: string; type: "set_follow_up_mode"; mode: "all" | "one-at-a-time" }
 	| { id?: string; type: "set_interrupt_mode"; mode: "immediate" | "wait" }
 
+	// Session modes (plan / vibe / goal — see rpc-modes.ts)
+	| { id?: string; type: "set_mode"; mode: RpcSetModeTarget; objective?: string }
+
 	// Compaction
 	| { id?: string; type: "compact"; customInstructions?: string }
 	| { id?: string; type: "set_auto_compaction"; enabled: boolean }
@@ -96,11 +99,23 @@ export type RpcCommand =
 // RPC State
 // ============================================================================
 
+/**
+ * Active session special mode. `get_state.mode` reports the live state;
+ * `plan_paused` / `goal_paused` are only ever *reported* (they are TUI
+ * intermediate states a headless client cannot enter directly).
+ */
+export type RpcSessionMode = "none" | "plan" | "plan_paused" | "vibe" | "goal" | "goal_paused";
+
+/** Modes a client may request via `set_mode`. */
+export type RpcSetModeTarget = "none" | "plan" | "vibe" | "goal";
+
 export interface RpcSessionState {
 	model?: Model;
 	thinkingLevel: ThinkingLevel | undefined;
 	isStreaming: boolean;
 	isCompacting: boolean;
+	/** Active special mode (plan / vibe / goal) or "none". */
+	mode: RpcSessionMode;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
 	interruptMode: "immediate" | "wait";
@@ -289,6 +304,9 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "set_steering_mode"; success: true }
 	| { id?: string; type: "response"; command: "set_follow_up_mode"; success: true }
 	| { id?: string; type: "response"; command: "set_interrupt_mode"; success: true }
+
+	// Session modes
+	| { id?: string; type: "response"; command: "set_mode"; success: true; data: { mode: RpcSessionMode } }
 
 	// Compaction
 	| { id?: string; type: "response"; command: "compact"; success: true; data: CompactionResult }

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -319,6 +319,7 @@ describe("RpcInputDispatcher", () => {
 						thinkingLevel: undefined,
 						isStreaming: false,
 						isCompacting: false,
+						mode: "none",
 						steeringMode: "all",
 						followUpMode: "all",
 						interruptMode: "immediate",

--- a/packages/coding-agent/test/rpc-modes.test.ts
+++ b/packages/coding-agent/test/rpc-modes.test.ts
@@ -37,7 +37,7 @@ describe("rpc session modes (headless controller)", () => {
 	let ctx: TestSessionContext;
 
 	beforeEach(async () => {
-		ctx = await createTestSession({ vibeTools: true });
+		ctx = await createTestSession({ vibeTools: true, wireToolRegistry: true });
 	});
 
 	afterEach(async () => {
@@ -92,6 +92,24 @@ describe("rpc session modes (headless controller)", () => {
 		expect(await setSessionMode(ctx.session, "none")).toBe("none");
 		expect(ctx.session.getVibeModeState()).toBeUndefined();
 		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("none");
+	});
+
+	test("re-entering the same mode is idempotent (does not corrupt tool restore)", async () => {
+		// Plan mode augments the toolset with `write`; re-entering while active
+		// must not re-capture the augmented set, or exit would leave `write` on.
+		const prePlanTools = ctx.session.getEnabledToolNames().slice();
+		await setSessionMode(ctx.session, "plan");
+		await setSessionMode(ctx.session, "plan");
+		expect(await setSessionMode(ctx.session, "plan")).toBe("plan");
+		await setSessionMode(ctx.session, "none");
+		expect(ctx.session.getEnabledToolNames()).toEqual(prePlanTools);
+
+		// Vibe mode replaces the toolset with read-only; same guard.
+		const preVibeTools = ctx.session.getEnabledToolNames().slice();
+		await setSessionMode(ctx.session, "vibe");
+		await setSessionMode(ctx.session, "vibe");
+		await setSessionMode(ctx.session, "none");
+		expect(ctx.session.getEnabledToolNames()).toEqual(preVibeTools);
 	});
 
 	test("switch_session restores the persisted mode (reconcile hooks)", async () => {

--- a/packages/coding-agent/test/rpc-modes.test.ts
+++ b/packages/coding-agent/test/rpc-modes.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { getSessionMode, reconcileSessionMode, setSessionMode, suspendSessionMode } from "../src/modes/rpc/rpc-modes";
+import { createTestSession, type TestSessionContext } from "./utilities";
+import type { SessionEntry } from "../src/session/session-entries";
+
+const isModeChangeEntry = (entry: SessionEntry): entry is Extract<SessionEntry, { type: "mode_change" }> =>
+	entry.type === "mode_change";
+
+/** Minimal persisted session file: header + one mode_change entry. */
+function writeSessionFile(dir: string, name: string, mode: "plan" | "vibe" | "goal" | "none"): string {
+	const sessionId = Snowflake.next().toString();
+	const header = {
+		type: "session",
+		version: 3,
+		id: sessionId,
+		timestamp: new Date().toISOString(),
+		cwd: dir,
+	};
+	const entryId = Snowflake.next().slice(0, 8);
+	const modeChange = {
+		type: "mode_change",
+		id: entryId,
+		parentId: sessionId,
+		timestamp: new Date().toISOString(),
+		mode,
+		...(mode === "plan" ? { data: { planFilePath: "local://PLAN.md" } } : {}),
+	};
+	const file = path.join(dir, name);
+	fs.writeFileSync(file, `${JSON.stringify(header)}\n${JSON.stringify(modeChange)}\n`, "utf8");
+	return file;
+}
+
+describe("rpc session modes (headless controller)", () => {
+	let ctx: TestSessionContext;
+
+	beforeEach(async () => {
+		ctx = await createTestSession({ vibeTools: true });
+	});
+
+	afterEach(async () => {
+		await ctx.cleanup();
+	});
+
+	test("starts in none mode", () => {
+		expect(getSessionMode(ctx.session)).toBe("none");
+	});
+
+	test("set_mode plan enters plan mode, persists mode_change, and resets on none", async () => {
+		expect(await setSessionMode(ctx.session, "plan")).toBe("plan");
+		expect(getSessionMode(ctx.session)).toBe("plan");
+		expect(ctx.session.getPlanModeState()?.enabled).toBe(true);
+		expect(ctx.session.peekPlanProposalHandler()).toBeDefined();
+
+		const modeEntries = ctx.sessionManager.getEntries().filter(isModeChangeEntry);
+		expect(modeEntries.at(-1)?.mode).toBe("plan");
+
+		expect(await setSessionMode(ctx.session, "none")).toBe("none");
+		expect(ctx.session.getPlanModeState()).toBeUndefined();
+		expect(ctx.session.peekPlanProposalHandler()).toBeUndefined();
+		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("none");
+	});
+
+	test("set_mode enforces mutual exclusion (exit-first semantics)", async () => {
+		await setSessionMode(ctx.session, "plan");
+		await expect(setSessionMode(ctx.session, "goal", "Ship it")).rejects.toThrow(/Exit plan mode first/);
+		await expect(setSessionMode(ctx.session, "vibe")).rejects.toThrow(/Exit plan mode first/);
+		expect(getSessionMode(ctx.session)).toBe("plan");
+
+		await setSessionMode(ctx.session, "none");
+		await setSessionMode(ctx.session, "vibe");
+		await expect(setSessionMode(ctx.session, "plan")).rejects.toThrow(/Exit vibe mode first/);
+		expect(getSessionMode(ctx.session)).toBe("vibe");
+	});
+
+	test("set_mode goal requires an objective", async () => {
+		await expect(setSessionMode(ctx.session, "goal")).rejects.toThrow(/requires an objective/);
+		expect(getSessionMode(ctx.session)).toBe("none");
+
+		expect(await setSessionMode(ctx.session, "goal", "Write a haiku")).toBe("goal");
+		expect(ctx.session.getGoalModeState()?.goal.objective).toBe("Write a haiku");
+		expect(getSessionMode(ctx.session)).toBe("goal");
+	});
+
+	test("set_mode vibe enters and exits vibe mode", async () => {
+		expect(await setSessionMode(ctx.session, "vibe")).toBe("vibe");
+		expect(ctx.session.getVibeModeState()?.enabled).toBe(true);
+		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("vibe");
+
+		expect(await setSessionMode(ctx.session, "none")).toBe("none");
+		expect(ctx.session.getVibeModeState()).toBeUndefined();
+		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("none");
+	});
+
+	test("switch_session restores the persisted mode (reconcile hooks)", async () => {
+		// Plan session file and a fresh "none" file.
+		const planFile = writeSessionFile(ctx.tempDir, `plan-${Snowflake.next()}.jsonl`, "plan");
+		const freshFile = writeSessionFile(ctx.tempDir, `fresh-${Snowflake.next()}.jsonl`, "none");
+
+		// Install the same hooks rpc-mode.ts installs.
+		ctx.session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(ctx.session));
+		ctx.session.setSessionSwitchReconciler(() => reconcileSessionMode(ctx.session));
+
+		await ctx.session.switchSession(freshFile);
+		expect(getSessionMode(ctx.session)).toBe("none");
+
+		await ctx.session.switchSession(planFile);
+		expect(getSessionMode(ctx.session)).toBe("plan");
+		expect(ctx.session.getPlanModeState()?.enabled).toBe(true);
+
+		await ctx.session.switchSession(freshFile);
+		expect(getSessionMode(ctx.session)).toBe("none");
+		expect(ctx.session.getPlanModeState()).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/rpc-modes.test.ts
+++ b/packages/coding-agent/test/rpc-modes.test.ts
@@ -11,7 +11,7 @@ const isModeChangeEntry = (entry: SessionEntry): entry is Extract<SessionEntry, 
 
 /** Minimal persisted session file: header + one mode_change entry. */
 function writeSessionFile(dir: string, name: string, mode: "plan" | "vibe" | "goal" | "none"): string {
-	const sessionId = Snowflake.next().toString();
+	const sessionId = Snowflake.next().slice(0, 16);
 	const header = {
 		type: "session",
 		version: 3,
@@ -27,6 +27,21 @@ function writeSessionFile(dir: string, name: string, mode: "plan" | "vibe" | "go
 		timestamp: new Date().toISOString(),
 		mode,
 		...(mode === "plan" ? { data: { planFilePath: "local://PLAN.md" } } : {}),
+		...(mode === "goal"
+			? {
+					data: {
+						goal: {
+							id: Snowflake.next(),
+							objective: "Do the thing",
+							status: "active",
+							tokensUsed: 0,
+							timeUsedSeconds: 0,
+							createdAt: Date.now(),
+							updatedAt: Date.now(),
+						},
+					},
+				}
+			: {}),
 	};
 	const file = path.join(dir, name);
 	fs.writeFileSync(file, `${JSON.stringify(header)}\n${JSON.stringify(modeChange)}\n`, "utf8");
@@ -131,5 +146,25 @@ describe("rpc session modes (headless controller)", () => {
 		await ctx.session.switchSession(freshFile);
 		expect(getSessionMode(ctx.session)).toBe("none");
 		expect(ctx.session.getPlanModeState()).toBeUndefined();
+	});
+
+	test("switch_session preserves an active goal instead of pausing it", async () => {
+		const goalFile = writeSessionFile(ctx.tempDir, `goal-${Snowflake.next()}.jsonl`, "goal");
+		const freshFile = writeSessionFile(ctx.tempDir, `fresh-${Snowflake.next()}.jsonl`, "none");
+
+		ctx.session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(ctx.session));
+		ctx.session.setSessionSwitchReconciler(() => reconcileSessionMode(ctx.session));
+
+		await ctx.session.switchSession(goalFile);
+		expect(getSessionMode(ctx.session)).toBe("goal");
+		expect(ctx.session.getGoalModeState()?.goal.status).toBe("active");
+
+		// Switching away and back must not convert the active goal to goal_paused
+		// (GoalRuntime.onThreadResumed without preserveActiveGoal does exactly that).
+		await ctx.session.switchSession(freshFile);
+		expect(getSessionMode(ctx.session)).toBe("none");
+		await ctx.session.switchSession(goalFile);
+		expect(getSessionMode(ctx.session)).toBe("goal");
+		expect(ctx.session.getGoalModeState()?.goal.status).toBe("active");
 	});
 });

--- a/packages/coding-agent/test/rpc-set-mode.test.ts
+++ b/packages/coding-agent/test/rpc-set-mode.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { e2eApiKey } from "./utilities";
+
+/**
+ * RPC `set_mode` end-to-end: the client drives a real `--mode rpc` CLI
+ * process. Skipped without ANTHROPIC_API_KEY (same as the rest of rpc.test.ts).
+ */
+describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("RPC set_mode", () => {
+	let client: RpcClient;
+	let sessionDir: string;
+
+	beforeEach(() => {
+		sessionDir = path.join(os.tmpdir(), `omp-rpc-set-mode-${Snowflake.next()}`);
+		client = new RpcClient({
+			cliPath: path.join(import.meta.dir, "..", "dist", "cli.js"),
+			cwd: path.join(import.meta.dir, ".."),
+			env: { PI_CODING_AGENT_DIR: sessionDir },
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+		});
+	});
+
+	afterEach(async () => {
+		client.stop();
+		if (sessionDir && fs.existsSync(sessionDir)) {
+			removeSyncWithRetries(sessionDir);
+		}
+	});
+
+	test("set_mode toggles plan mode and persists mode_change entries", async () => {
+		await client.start();
+		expect((await client.getState()).mode).toBe("none");
+
+		expect(await client.setMode("plan")).toBe("plan");
+		const state = await client.getState();
+		expect(state.mode).toBe("plan");
+		expect(state.sessionFile).toBeDefined();
+
+		expect(await client.setMode("none")).toBe("none");
+		expect((await client.getState()).mode).toBe("none");
+	}, 60000);
+
+	test("set_mode rejects goal without an objective and enforces mutual exclusion", async () => {
+		await client.start();
+
+		await expect(client.setMode("goal")).rejects.toThrow(/requires an objective/);
+		expect(await client.setMode("goal", "Write a haiku")).toBe("goal");
+		expect((await client.getState()).mode).toBe("goal");
+
+		await expect(client.setMode("plan")).rejects.toThrow(/Exit goal mode first/);
+		expect((await client.getState()).mode).toBe("goal");
+
+		expect(await client.setMode("none")).toBe("none");
+		expect((await client.getState()).mode).toBe("none");
+	}, 60000);
+
+	test("switch_session restores the persisted mode", async () => {
+		await client.start();
+		expect(await client.setMode("plan")).toBe("plan");
+		const planSessionFile = (await client.getState()).sessionFile!;
+
+		// A fresh session has no mode chain.
+		await client.newSession();
+		expect((await client.getState()).mode).toBe("none");
+
+		// Switching back to the plan session restores plan mode.
+		await client.switchSession(planSessionFile);
+		expect((await client.getState()).mode).toBe("plan");
+	}, 60000);
+});

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -14,6 +14,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { createVibeTools } from "@oh-my-pi/pi-coding-agent/tools/vibe";
 import { Snowflake } from "@oh-my-pi/pi-utils";
 import { e2eApiKey } from "../../ai/test/oauth";
 
@@ -31,6 +32,8 @@ export interface TestSessionOptions {
 	settingsOverrides?: Record<string, unknown>;
 	/** Extension runner to wire into the session (e.g. to stub `session_before_tree`/etc. hooks) */
 	extensionRunner?: ExtensionRunner;
+	/** Wire the ephemeral vibe tool factory (`vibe_spawn` etc.), needed to enter vibe mode. */
+	vibeTools?: boolean;
 	/** Secret obfuscator to wire into the session (e.g. to test deobfuscation of persisted tool arguments) */
 	obfuscator?: SecretObfuscator;
 }
@@ -116,6 +119,7 @@ export async function createTestSession(options: TestSessionOptions = {}): Promi
 		modelRegistry,
 		extensionRunner: options.extensionRunner,
 		obfuscator: options.obfuscator,
+		createVibeTools: options.vibeTools ? () => createVibeTools(toolSession) : undefined,
 	});
 
 	// Must subscribe to enable session persistence

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -34,6 +34,9 @@ export interface TestSessionOptions {
 	extensionRunner?: ExtensionRunner;
 	/** Wire the ephemeral vibe tool factory (`vibe_spawn` etc.), needed to enter vibe mode. */
 	vibeTools?: boolean;
+	/** Populate the session's tool registry from the created tools, so
+	 *  `setActiveToolsByName` / `activateVibeTools` can restore toolsets. */
+	wireToolRegistry?: boolean;
 	/** Secret obfuscator to wire into the session (e.g. to test deobfuscation of persisted tool arguments) */
 	obfuscator?: SecretObfuscator;
 }
@@ -94,6 +97,7 @@ export async function createTestSession(options: TestSessionOptions = {}): Promi
 		settings: Settings.isolated(options.settingsOverrides),
 	};
 	const tools = await createTools(toolSession);
+	const toolRegistry = options.wireToolRegistry ? new Map(tools.map(tool => [tool.name, tool])) : undefined;
 
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 	const agent = new Agent({
@@ -119,6 +123,8 @@ export async function createTestSession(options: TestSessionOptions = {}): Promi
 		modelRegistry,
 		extensionRunner: options.extensionRunner,
 		obfuscator: options.obfuscator,
+		toolRegistry,
+		builtInToolNames: options.wireToolRegistry ? tools.map(tool => tool.name) : undefined,
 		createVibeTools: options.vibeTools ? () => createVibeTools(toolSession) : undefined,
 	});
 


### PR DESCRIPTION
## Summary

Exposes the `plan` / `vibe` / `goal` session modes to pi-RPC hosts, closing [#8171](https://github.com/can1357/oh-my-pi/issues/8171). Today these modes are only reachable from the TUI (`/plan`, `/vibe`, `/goal` — all `handleTui`-only commands, filtered out of the RPC `get_available_commands` registry) and ACP (`session/set_mode`, which only toggles plan). Desktop hosts driving `--mode rpc-ui` have no way to enter, exit, or observe them.

The TUI's mode handlers live on `InteractiveModeContext`, which headless hosts cannot reach. This PR adds a headless controller (`src/modes/rpc/rpc-modes.ts`) that mirrors those session-level effects — mode state, toolset changes, the plan-proposal handler, persisted `mode_change` entries, and mutual exclusion — using only public `AgentSession` APIs.

## Changes

- **`set_mode` RPC command** — `{ type: "set_mode", mode: "none" | "plan" | "vibe" | "goal", objective?: string }` with the same exit-first mutual-exclusion semantics as the TUI commands (entering a mode while another is active fails with `Exit <mode> mode first.` and the current mode stays). `goal` requires an `objective`; `none` exits whichever mode is active. The response reports the resulting live mode.
- **`get_state.mode`** — reports the live mode (`none | plan | plan_paused | vibe | goal | goal_paused`).
- **`switch_session` mode restoration** — installs before/after switch reconcilers (mirroring `InteractiveMode.#clearTransientModeState` / `#reconcileModeFromSession`) so a session persisted with `mode_change` entries restores its plan/vibe/goal mode on resume.
- **`RpcClient.setMode()`** — TypeScript client wrapper.
- **Docs & tests** — `docs/rpc.md` updated; headless-controller unit tests (`test/rpc-modes.test.ts`, no API key required) plus client e2e tests (`test/rpc-set-mode.test.ts`, skipped without `ANTHROPIC_API_KEY` like the rest of `rpc.test.ts`).

## Notes / deliberate choices

- **No model-role switching on plan entry**, matching ACP's `session/set_mode`: the RPC client already addresses the model via `set_model`, and a server-side switch would fight the client's selection. (The TUI switches to the plan-role model; print-mode does too.) Happy to add it server-side if you'd rather the runtime own that contract.
- **`plan_paused` is only ever *reported*** by `get_state`, never accepted as a `set_mode` target — it is an interactive intermediate toggle state (exit-with-confirm), which has no headless equivalent.
- **Vibe-exit persistence**: the controller appends a `mode_change: none` on explicit vibe exit (the TUI relies on the worker-tombstone path), so a headless client's explicit exit is not resurrected by a later switch/restart.
- **Known boundary (matches TUI)**: a brand-new session that never produces an assistant message isn't written to disk (session-manager's lazy file gate), so `mode_change` entries for it aren't persisted until the first message. Mode restoration works for any session that has produced output.

## Verification

- `tsgo -p tsconfig.json --noEmit` — clean
- `biome check` — clean on all touched files
- `bun test test/rpc-modes.test.ts` — 6/6 pass (headless controller: plan/vibe/goal enter/exit, mutual exclusion, objective validation, switch-restore)
- Live protocol smoke against a real `--mode rpc` process (12 assertions): `set_mode` plan/vibe/goal, `get_state.mode` transitions, mutual-exclusion errors, objective validation, and `switch_session` restore from a persisted `mode_change: plan` session file
