### PR TITLE
fix(eval): re-validate memoized runner script path before reuse

### DIFF
--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -44,7 +44,7 @@ const RUNNER_CACHE_DIR = path.join(os.tmpdir(), "omp-python-runner");
 let RUNNER_SCRIPT_PATH: string | null = null;
 
 async function ensureRunnerScript(): Promise<string> {
-	if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;
+	if (RUNNER_SCRIPT_PATH && fs.existsSync(RUNNER_SCRIPT_PATH)) return RUNNER_SCRIPT_PATH;
 	await fs.promises.mkdir(RUNNER_CACHE_DIR, { recursive: true });
 	const hash = Bun.hash(RUNNER_SCRIPT).toString(36);
 	const target = path.join(RUNNER_CACHE_DIR, `runner-${hash}.py`);


### PR DESCRIPTION
## Summary

Adds `fs.existsSync()` guard on the warm path of `ensureRunnerScript()` in the Python eval kernel. If `os.tmpdir()/omp-python-runner` is pruned mid-session (e.g., macOS `clean_tmps`), the memoized `RUNNER_SCRIPT_PATH` becomes stale and every subsequent `Bun.spawn` fails. The guard makes the warm path fall through to the existing re-stage logic when the file has gone missing.

## Changes

`packages/coding-agent/src/eval/py/kernel.ts`: Added `fs.existsSync()` check on memoized path.

```diff
-if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;
+if (RUNNER_SCRIPT_PATH \&\& fs.existsSync(RUNNER_SCRIPT_PATH)) return RUNNER_SCRIPT_PATH;
```

Fixes #8140