### PR TITLE
fix(cli): respect --dry-run flag in plugin uninstall

### DIFF
--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -464,7 +464,7 @@ async function handleInstall(
 async function handleUninstall(
 	manager: PluginManager,
 	packages: string[],
-	flags: { json?: boolean; scope?: "user" | "project" },
+	flags: { json?: boolean; dryRun?: boolean; scope?: "user" | "project" },
 ): Promise<void> {
 	if (packages.length === 0) {
 		console.error(chalk.red(`Usage: ${APP_NAME} plugin uninstall <package> ...`));
@@ -478,6 +478,12 @@ async function handleUninstall(
 
 	for (const name of packages) {
 		if (installedPlugins.has(name)) {
+			// Dry run: report without mutating
+			if (flags.dryRun) {
+				console.log(chalk.yellow(`${theme.status.warning} Would uninstall marketplace plugin: ${name}`));
+				continue;
+			}
+
 			// Exact match against installed marketplace plugin IDs (name@marketplace)
 			try {
 				await mktMgr.uninstallPlugin(name, flags.scope);
@@ -490,6 +496,16 @@ async function handleUninstall(
 		}
 
 		// npm path
+		// Dry run: report without mutating
+		if (flags.dryRun) {
+			if (flags.json) {
+				console.log(JSON.stringify({ uninstalled: name, dryRun: true }));
+			} else {
+				console.log(chalk.yellow(`${theme.status.warning} Would uninstall npm plugin: ${name}`));
+			}
+			continue;
+		}
+
 		try {
 			await manager.uninstall(name);
 			if (flags.json) {


### PR DESCRIPTION
## Summary

The `handleUninstall` function in `plugin-cli.ts` was not checking the `dryRun` flag before calling `mktMgr.uninstallPlugin()` or `manager.uninstall()`. The flag was parsed by `parsePluginArgs` but completely ignored in the uninstall handler, causing `--dry-run` to actually perform the uninstall.

## Changes

- Added `dryRun` to the flags type in `handleUninstall` signature
- Added early-return checks for both marketplace and npm paths:
  - Marketplace: logs "Would uninstall marketplace plugin: X" without calling `uninstallPlugin`
  - npm: logs "Would uninstall npm plugin: X" (or JSON with `{dryRun: true}`) without calling `manager.uninstall`

## Test

```sh
sandbox=$(mktemp -d)
env HOME="$sandbox" omp plugin install zmarketplace@0.7.8 --json
env HOME="$sandbox" omp plugin list --json > before.json
env HOME="$sandbox" omp plugin uninstall zmarketplace --dry-run --json
env HOME="$sandbox" omp plugin list --json > after.json
diff before.json after.json  # should be identical
```

Fixes #8178
