### PR TITLE
fix(status-line): recognized kimi-code subscription windows in the usage segment

### DIFF
--- a/packages/ai/src/usage/kimi.ts
+++ b/packages/ai/src/usage/kimi.ts
@@ -77,6 +77,23 @@ function formatDurationLabel(duration: number, timeUnit: string): string | undef
 	return undefined;
 }
 
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+/**
+ * Status-line and ranking consumers match on canonical window ids ("5h",
+ * "7d"), so derive the id from the reported span: the 300-minute burst window
+ * surfaces as "5h" instead of "300time_unit_minute". Mirrors the
+ * intervalWindowId convention in minimax-code.ts.
+ */
+function canonicalWindowId(durationMs: number): string {
+	if (durationMs > 0 && durationMs % DAY_MS === 0) return `${durationMs / DAY_MS}d`;
+	if (durationMs > 0 && durationMs % HOUR_MS === 0) return `${durationMs / HOUR_MS}h`;
+	const minutes = Math.round(durationMs / MINUTE_MS);
+	return minutes > 0 ? `${minutes}m` : "default";
+}
+
 function buildWindow(windowData: Record<string, unknown>, nowMs: number): UsageWindow | undefined {
 	const duration = toNumber(windowData.duration);
 	const timeUnit = typeof windowData.timeUnit === "string" ? windowData.timeUnit : "";
@@ -86,14 +103,15 @@ function buildWindow(windowData: Record<string, unknown>, nowMs: number): UsageW
 	if (duration === undefined && !label && !resetsAt) return undefined;
 	let durationMs: number | undefined;
 	if (duration !== undefined) {
-		if (timeUnit.toUpperCase().includes("MINUTE")) durationMs = duration * 60_000;
-		else if (timeUnit.toUpperCase().includes("HOUR")) durationMs = duration * 3_600_000;
-		else if (timeUnit.toUpperCase().includes("DAY")) durationMs = duration * 86_400_000;
+		if (timeUnit.toUpperCase().includes("MINUTE")) durationMs = duration * MINUTE_MS;
+		else if (timeUnit.toUpperCase().includes("HOUR")) durationMs = duration * HOUR_MS;
+		else if (timeUnit.toUpperCase().includes("DAY")) durationMs = duration * DAY_MS;
+		else if (timeUnit.toUpperCase().includes("WEEK")) durationMs = duration * 7 * DAY_MS;
 		else if (timeUnit.toUpperCase().includes("SECOND")) durationMs = duration * 1000;
 	}
 
 	return {
-		id: duration !== undefined && timeUnit ? `${duration}${timeUnit.toLowerCase()}` : "default",
+		id: durationMs !== undefined ? canonicalWindowId(durationMs) : "default",
 		label: label ?? "Usage window",
 		durationMs,
 		resetsAt,
@@ -177,7 +195,13 @@ function parseUsagePayload(payload: unknown, nowMs: number): { rows: KimiUsageRo
 
 	if (isRecord(data.usage)) {
 		const summary = buildUsageRow(data.usage, "Total quota", nowMs);
-		if (summary) rows.push(summary);
+		if (summary) {
+			// Kimi Code's aggregate quota resets weekly, but the payload carries
+			// only `resetTime` and no duration. Attach the canonical weekly
+			// window explicitly so status-line/ranking consumers recognize it.
+			summary.window = { id: "7d", label: "7 Day", resetsAt: summary.resetsAt };
+			rows.push(summary);
+		}
 	}
 
 	if (Array.isArray(data.limits)) {

--- a/packages/ai/test/kimi-usage.test.ts
+++ b/packages/ai/test/kimi-usage.test.ts
@@ -45,11 +45,19 @@ describe("kimi usage provider", () => {
 		const total = report!.limits[0]!;
 		expect(total.label).toBe("Total quota");
 		expect(total.window?.resetsAt).toBe(Date.parse(usageReset));
+		// The aggregate quota is the weekly subscription window; canonical id
+		// lets the status-line usage segment pick it up.
+		expect(total.window?.id).toBe("7d");
+		expect(total.scope?.windowId).toBe("7d");
 
 		const fiveHour = report!.limits[1]!;
 		expect(fiveHour.label).toBe("5h limit");
 		expect(fiveHour.window?.durationMs).toBe(5 * 60 * 60 * 1000);
 		expect(fiveHour.window?.resetsAt).toBe(Date.parse(detailReset));
+		// 300 minutes canonicalizes to "5h" so the status-line usage segment
+		// recognizes the burst window.
+		expect(fiveHour.window?.id).toBe("5h");
+		expect(fiveHour.scope?.windowId).toBe("5h");
 	});
 
 	it("keeps an explicit window resetTime authoritative over the detail one", async () => {
@@ -70,5 +78,28 @@ describe("kimi usage provider", () => {
 		expect(report).not.toBeNull();
 		expect(report!.limits).toHaveLength(1);
 		expect(report!.limits[0]!.window?.resetsAt).toBe(Date.parse(windowReset));
+	});
+
+	it("canonicalizes whole-day and non-standard window durations", async () => {
+		const report = await kimiUsageProvider.fetchUsage!(
+			{ provider: "kimi-code", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				limits: [
+					{
+						window: { duration: 7, timeUnit: "TIME_UNIT_DAY" },
+						detail: { limit: "100", remaining: "50" },
+					},
+					{
+						window: { duration: 90, timeUnit: "TIME_UNIT_MINUTE" },
+						detail: { limit: "100", remaining: "50" },
+					},
+				],
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits).toHaveLength(2);
+		expect(report!.limits[0]!.window?.id).toBe("7d");
+		expect(report!.limits[1]!.window?.id).toBe("90m");
 	});
 });

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1389,7 +1389,7 @@ export class StatusLineComponent implements Component {
 				}
 				const l = limit as {
 					scope?: { windowId?: string; tier?: string };
-					window?: { resetsAt?: number };
+					window?: { resetsAt?: number; durationMs?: number };
 					amount?: { usedFraction?: number };
 				};
 				const fraction = l.amount?.usedFraction;
@@ -1397,9 +1397,22 @@ export class StatusLineComponent implements Component {
 				const windowId = l.scope?.windowId;
 				const tier = l.scope?.tier;
 				const resetsAt = l.window?.resetsAt;
+				// Canonical window ids win. Fall back to the reported span (same
+				// tolerance as the 5h priority-boost check) so providers that emit
+				// non-canonical ids, and cache rows written before a provider was
+				// canonicalized, still map onto the two subscription windows.
+				const durationMs = l.window?.durationMs;
+				const windowClass =
+					windowId === "5h" || windowId === "7d"
+						? windowId
+						: durationMs !== undefined && Math.abs(durationMs - 5 * 3_600_000) <= 60_000
+							? "5h"
+							: durationMs !== undefined && Math.abs(durationMs - 7 * 86_400_000) <= 60_000
+								? "7d"
+								: undefined;
 				// Accept tiered limits, but prefer untiered (backward compat with Anthropic).
 				// An untiered limit always replaces a tiered one; among same-tieredness, first wins.
-				if (windowId === "5h" && (!fiveHour || (fiveHourTier !== undefined && !tier))) {
+				if (windowClass === "5h" && (!fiveHour || (fiveHourTier !== undefined && !tier))) {
 					fiveHour = {
 						percent: fraction * 100,
 						resetMinutes:
@@ -1407,7 +1420,7 @@ export class StatusLineComponent implements Component {
 					};
 					fiveHourTier = tier || undefined;
 				}
-				if (windowId === "7d" && (!sevenDay || (sevenDayTier !== undefined && !tier))) {
+				if (windowClass === "7d" && (!sevenDay || (sevenDayTier !== undefined && !tier))) {
 					sevenDay = {
 						percent: fraction * 100,
 						resetHours:

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -338,4 +338,80 @@ describe("usage status-line segment", () => {
 		expect(stripVTControlCharacters(highWithoutValue)).toBe(stripVTControlCharacters(lowWithoutValue));
 		expect(highWithoutValue).not.toBe(lowWithoutValue);
 	});
+
+	it("maps non-canonical window ids onto subscription windows by reported span", async () => {
+		// Kimi-shaped rows: the burst window reports duration/timeUnit instead
+		// of a canonical id, and rows written before canonicalization keep the
+		// old id. The reported span still identifies the window.
+		const now = Date.now();
+		const component = makeComponent([
+			{
+				limits: [
+					{
+						scope: { windowId: "300time_unit_minute" },
+						window: { durationMs: 5 * 3_600_000, resetsAt: now + 30 * 60_000 },
+						amount: { usedFraction: 0.24 },
+					},
+					{
+						scope: { windowId: "weekly" },
+						window: { durationMs: 7 * 86_400_000, resetsAt: now + 141 * 3_600_000 },
+						amount: { usedFraction: 0.08 },
+					},
+				],
+			},
+		]);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("5h");
+		expect(content).toContain("24%");
+		expect(content).toContain("7d");
+		expect(content).toContain("8%");
+	});
+
+	it("ignores non-canonical windows without a reported span", async () => {
+		const component = makeComponent([
+			{
+				limits: [
+					{ scope: { windowId: "default" }, window: {}, amount: { usedFraction: 0.24 } },
+					{
+						scope: { windowId: "monthly" },
+						window: { durationMs: 30 * 86_400_000 },
+						amount: { usedFraction: 0.5 },
+					},
+				],
+			},
+		]);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).not.toContain("24%");
+		expect(content).not.toContain("50%");
+	});
+
+	it("prefers canonical window ids over a conflicting reported span", async () => {
+		const component = makeComponent([
+			{
+				limits: [
+					{
+						scope: { windowId: "5h" },
+						window: { durationMs: 7 * 86_400_000 },
+						amount: { usedFraction: 0.24 },
+					},
+				],
+			},
+		]);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("5h");
+		expect(content).toContain("24%");
+		expect(content).not.toContain("7d");
+	});
 });


### PR DESCRIPTION
The status line's usage segment shows subscription quota for the 5h and 7d windows, but it never shows anything in kimi-code sessions. I'm on a Kimi Code subscription and wanted my meter.

The Kimi usage provider builds window ids from the API's raw duration and timeUnit, so the burst limit ends up as "300time_unit_minute" and the aggregate quota as "default". The status line only matches the canonical "5h" and "7d" ids, so every Kimi limit gets skipped. I switched the provider to derive ids from the reported span, where 300 minutes becomes "5h" and 7 days becomes "7d", the same convention minimax-code already uses. The aggregate quota has no duration in the payload, only a resetTime. My resets always land 5 to 6 days out mid week, which fits a weekly cycle, so I tag it "7d". That tag is an inference since the API doesn't say it outright.

Testing surfaced a mixed version wrinkle. The usage cache is shared between OMP processes, and rows written by older builds keep the old ids, so the meter flickered depending on which build wrote last. The aggregator now falls back to the reported span when the id isn't canonical, within a minute of 5h or 7d, the same tolerance the priority-boost check uses. The 5h meter stays alive during the transition.

Tests: kimi-usage.test.ts asserts the canonical ids and the weekly tag, and three new status-line-usage.test.ts cases cover span fallback, span-less non-canonical windows staying hidden, and canonical ids winning over a conflicting span. 18 tests pass across both files, biome clean, tsgo clean for packages/ai and packages/coding-agent.

I reviewed the full diff myself and verified it end to end on my own account. The segment isn't in any preset, so I ran statusLine.preset custom with usage in rightSegments and watched the status line render "5h 84% (43m) · 7d 48% (5d 3h)" off my live Kimi data, including from cache rows written by the unpatched build.
