### PR TITLE
fix(agent): support array model overrides in dashboard

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed Agent Control Center failing to open when an agent model override is configured as a YAML array. ([#8201](https://github.com/can1357/oh-my-pi/issues/8201))
+
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -926,7 +926,8 @@ function getModelRoleAlias(value: string, settings?: ModelRoleLookup): string | 
 	return undefined;
 }
 
-function normalizeModelPatternList(value: string | string[] | undefined): string[] {
+/** Normalize comma-separated or array model selectors into an ordered pattern list. */
+export function normalizeModelPatternList(value: string | string[] | undefined): string[] {
 	if (!value) return [];
 	const patterns = Array.isArray(value) ? value.flatMap(pattern => pattern.split(",")) : value.split(",");
 	return patterns.map(pattern => pattern.trim()).filter(Boolean);

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -385,6 +385,8 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	},
 ];
 
+const DEFAULT_AGENT_MODEL_OVERRIDES: Record<string, string | string[]> = {};
+
 export const SETTINGS_SCHEMA = {
 	// ────────────────────────────────────────────────────────────────────────
 	// General settings (no UI)
@@ -4724,7 +4726,7 @@ export const SETTINGS_SCHEMA = {
 
 	"task.agentModelOverrides": {
 		type: "record",
-		default: {} as Record<string, string>,
+		default: DEFAULT_AGENT_MODEL_OVERRIDES,
 	},
 	"task.agentPrewalk": {
 		type: "record",

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -39,6 +39,7 @@ import { getConfigDirs } from "../../config";
 import type { ModelRegistry } from "../../config/model-registry";
 import {
 	formatModelString,
+	normalizeModelPatternList,
 	resolveAgentModelPatterns,
 	resolveAgentPrewalkPattern,
 	resolveConfiguredModelPatterns,
@@ -447,7 +448,7 @@ export class AgentDashboard extends Container {
 				.map(agent => ({
 					...agent,
 					disabled: disabled.has(agent.name),
-					overrideModel: overrides[agent.name]?.trim() || undefined,
+					overrideModel: normalizeModelPatternList(overrides[agent.name]).join(",") || undefined,
 					prewalkOverride: prewalkOverrides[agent.name]?.trim() || undefined,
 				}));
 

--- a/packages/coding-agent/test/agent-dashboard-create-editor.test.ts
+++ b/packages/coding-agent/test/agent-dashboard-create-editor.test.ts
@@ -237,6 +237,28 @@ describe("AgentDashboard tab navigation", () => {
 	});
 });
 
+describe("AgentDashboard model overrides", () => {
+	test("opens with an array model chain from settings", async () => {
+		await initTheme(false);
+		vi.spyOn(discovery, "discoverAgents").mockResolvedValue({
+			projectAgentsDir: null,
+			agents: [{ name: "dev", description: "Development agent", systemPrompt: "", source: "project" }],
+		});
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": {
+				dev: ["opencode-go/deepseek:high", "bailian/deepseek:high"],
+			},
+		});
+
+		const dashboard = await AgentDashboard.create(await makeTempCwd(), settings, 24, {});
+		const rendered = dashboard.render(120).join("\n").replace(ANSI_PATTERN, "");
+
+		expect(rendered).toContain("dev");
+		expect(rendered).toContain("Override: opencode-go/deepseek:high,bailian/deepseek:high");
+		expect(rendered).not.toContain("Failed to load agents");
+	});
+});
+
 describe("AgentDashboard prewalk", () => {
 	test("shows the bundled task prewalk default when task.prewalk is enabled", async () => {
 		await initTheme(false);


### PR DESCRIPTION
## Repro
Configure `task.agentModelOverrides.dev` as a YAML array, then open `/agents`. The focused reproduction is `bun test packages/coding-agent/test/agent-dashboard-create-editor.test.ts`; before the fix it rendered `All (0)` and `Failed to load agents: overrides[agent.name]?.trim is not a function`.

## Cause
`AgentDashboard.#reloadData()` in `packages/coding-agent/src/modes/components/agent-dashboard.ts` called `.trim()` on the raw override even though `resolveAgentModelPatterns()` in `packages/coding-agent/src/config/model-resolver.ts` accepts both strings and string arrays. The settings schema also inferred `Record<string, string>`, leaving the dashboard contract narrower than task model resolution.

## Fix
- Export and reuse the model-pattern normalizer when loading dashboard overrides.
- Align `task.agentModelOverrides` with the resolver's `string | string[]` value contract.
- Add dashboard regression coverage and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/agent-dashboard-create-editor.test.ts` passes: 10 tests, 38 assertions. `bun run check:types` passes in `packages/coding-agent`. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #8201