### PR TITLE
fix(settings): respect project scope in /settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/settings` silently writing project-shadowed edits to the global profile by adding explicit project/global scopes and project override inheritance. ([#8208](https://github.com/can1357/oh-my-pi/issues/8208))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -65,6 +65,9 @@ export interface RawSettings {
 	[key: string]: unknown;
 }
 
+/** Persistent configuration layer edited by the settings UI. */
+export type SettingsScope = "global" | "project";
+
 type YamlLoadResult =
 	| { kind: "missing" }
 	| { kind: "loaded"; settings: RawSettings }
@@ -122,6 +125,31 @@ function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
 		current = current[segment] as RawSettings;
 	}
 	current[segments[segments.length - 1]] = value;
+}
+
+/**
+ * Delete a nested value and prune empty parent objects.
+ */
+function deleteByPath(obj: RawSettings, segments: readonly string[]): boolean {
+	const parents: Array<{ parent: RawSettings; segment: string }> = [];
+	let current = obj;
+	for (let i = 0; i < segments.length - 1; i++) {
+		const segment = segments[i];
+		const child = current[segment];
+		if (!isRecord(child)) return false;
+		parents.push({ parent: current, segment });
+		current = child;
+	}
+	const leaf = segments[segments.length - 1];
+	if (!Object.hasOwn(current, leaf)) return false;
+	delete current[leaf];
+	for (let i = parents.length - 1; i >= 0; i--) {
+		const { parent, segment } = parents[i];
+		const child = parent[segment];
+		if (!isRecord(child) || Object.keys(child).length > 0) break;
+		delete parent[segment];
+	}
+	return true;
 }
 
 export function normalizeProviderMaxInFlightRequests(value: unknown): Record<string, number> {
@@ -331,6 +359,10 @@ export class Settings {
 	#project: RawSettings = {};
 	/** Last successfully loaded native .omp/config.yml contents. */
 	#projectFileSettings: RawSettings = {};
+	/** Project settings excluding the native .omp/config.yml layer. */
+	#projectWithoutNative: RawSettings = {};
+	/** Whether the current project already has a native .omp/config.yml. */
+	#projectConfigExists = false;
 	/** Logical config paths whose malformed targets were moved aside. */
 	#quarantinedYamlTargets = new Map<string, string>();
 	/** Extra config.yml-style overlays passed by CLI */
@@ -349,6 +381,8 @@ export class Settings {
 
 	/** Paths modified during this session (for partial save) */
 	#modified = new Set<string>();
+	/** Native project setting paths modified during this session. */
+	#modifiedProject = new Set<string>();
 	/** Individual project model roles modified during this session */
 	#modifiedProjectModelRoles = new Set<string>();
 	/** Individual global model roles modified during this session (for partial save) */
@@ -495,20 +529,50 @@ export class Settings {
 	}
 
 	/**
-	 * Set a setting value (sync).
-	 * Updates global settings and queues a background save.
-	 * Triggers hooks for settings that have side effects.
+	 * Set a setting value in a persistent layer.
+	 * Updates the global layer by default and triggers effective-value hooks.
 	 */
-	set<P extends SettingPath>(path: P, value: SettingValue<P>): void {
+	set<P extends SettingPath>(path: P, value: SettingValue<P>, scope: SettingsScope = "global"): void {
 		const prev = this.get(path);
 		const segments = path.split(".");
-		setByPath(this.#global, segments, value);
-		this.#modified.add(path);
+		if (scope === "project") {
+			setByPath(this.#projectFileSettings, segments, value);
+			setByPath(this.#project, segments, value);
+			this.#projectConfigExists = true;
+			this.#modifiedProject.add(path);
+			this.#queueProjectSave();
+		} else {
+			setByPath(this.#global, segments, value);
+			this.#modified.add(path);
+			this.#queueSave();
+		}
+		this.#applySettingChange(path, prev);
+	}
+
+	/**
+	 * Remove a native project override so lower-precedence settings become effective.
+	 */
+	clearProject<P extends SettingPath>(path: P): boolean {
+		const segments = SETTING_PATH_SEGMENTS[path];
+		if (getByPath(this.#projectFileSettings, segments) === undefined) return false;
+
+		const prev = this.get(path);
+		deleteByPath(this.#projectFileSettings, segments);
+		const fallback = getByPath(this.#projectWithoutNative, segments);
+		if (fallback === undefined) {
+			deleteByPath(this.#project, segments);
+		} else {
+			setByPath(this.#project, [...segments], fallback);
+		}
+		this.#modifiedProject.add(path);
+		this.#queueProjectSave();
+		this.#applySettingChange(path, prev);
+		return true;
+	}
+
+	#applySettingChange<P extends SettingPath>(path: P, prev: SettingValue<P>): void {
 		this.#rebuildMerged();
 		const next = this.get(path);
-		this.#queueSave();
-
-		// Trigger hook if exists
 		const hook = SETTING_HOOKS[path];
 		if (hook) {
 			hook(next, prev);
@@ -599,7 +663,7 @@ export class Settings {
 		if (this.#modified.size > 0 || this.#modifiedGlobalModelRoles.size > 0) {
 			await this.#saveNow();
 		}
-		if (this.#modifiedProjectModelRoles.size > 0) {
+		if (this.#modifiedProject.size > 0 || this.#modifiedProjectModelRoles.size > 0) {
 			await this.#saveProjectNow();
 		}
 	}
@@ -613,8 +677,15 @@ export class Settings {
 		cloned.#storage = this.#storage;
 		cloned.#configPath = this.#configPath;
 		cloned.#global = structuredClone(this.#global);
-		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
-		if (!this.#persist) cloned.#projectShellPathSource = this.#projectShellPathSource;
+		if (this.#persist) {
+			cloned.#project = await cloned.#loadProjectSettings();
+		} else {
+			cloned.#project = structuredClone(this.#project);
+			cloned.#projectWithoutNative = structuredClone(this.#projectWithoutNative);
+			cloned.#projectFileSettings = structuredClone(this.#projectFileSettings);
+			cloned.#projectConfigExists = this.#projectConfigExists;
+			cloned.#projectShellPathSource = this.#projectShellPathSource;
+		}
 		cloned.#configFiles = [...this.#configFiles];
 		cloned.#configOverlay = structuredClone(this.#configOverlay);
 		cloned.#overlayShellPathSource = this.#overlayShellPathSource;
@@ -665,6 +736,11 @@ export class Settings {
 
 	getAgentDir(): string {
 		return this.#agentDir;
+	}
+
+	/** Whether the current project has a native .omp/config.yml. */
+	hasProjectConfig(): boolean {
+		return this.#projectConfigExists;
 	}
 
 	getPlansDirectory(): string {
@@ -1231,23 +1307,30 @@ export class Settings {
 
 	async #loadProjectSettings(): Promise<RawSettings> {
 		this.#projectShellPathSource = undefined;
+		const projectConfigPath = path.join(this.#cwd, ".omp", "config.yml");
 		let merged: RawSettings = {};
+		let withoutNative: RawSettings = {};
 		try {
 			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
 			for (const item of result.items as SettingsCapabilityItem[]) {
-				if (item.level === "project") {
-					merged = this.#deepMerge(merged, item.data as RawSettings);
-					if (Object.hasOwn(item.data, "shellPath")) this.#projectShellPathSource = item.path;
+				if (item.level !== "project") continue;
+				const data = item.data as RawSettings;
+				merged = this.#deepMerge(merged, data);
+				if (path.normalize(item.path) !== path.normalize(projectConfigPath)) {
+					withoutNative = this.#deepMerge(withoutNative, data);
 				}
+				if (Object.hasOwn(data, "shellPath")) this.#projectShellPathSource = item.path;
 			}
 		} catch {
 			this.#projectShellPathSource = undefined;
 			// Capability discovery is best-effort; the native project config below
 			// remains authoritative for its model-role layer and must not be hidden.
 		}
-		const projectConfigPath = path.join(this.#cwd, ".omp", "config.yml");
-		const nativeProject = await this.#loadYaml(projectConfigPath);
+		const loadedNativeProject = await this.#loadYamlIfPresentForStartup(projectConfigPath);
+		this.#projectConfigExists = loadedNativeProject !== null;
+		const nativeProject = loadedNativeProject ?? {};
 		this.#projectFileSettings = structuredClone(nativeProject);
+		this.#projectWithoutNative = this.#migrateRawSettings(withoutNative);
 		const nativeModelRoles = getByPath(nativeProject, ["modelRoles"]);
 		if (nativeModelRoles !== undefined) {
 			merged = this.#deepMerge(merged, { modelRoles: nativeModelRoles });
@@ -2137,10 +2220,19 @@ export class Settings {
 	}
 
 	async #saveProjectNow(): Promise<void> {
-		if (this.#savesCancelled || !this.#persist || this.#modifiedProjectModelRoles.size === 0) return;
+		if (
+			this.#savesCancelled ||
+			!this.#persist ||
+			(this.#modifiedProject.size === 0 && this.#modifiedProjectModelRoles.size === 0)
+		)
+			return;
 
 		const projectConfigPath = path.join(this.#cwd, ".omp", "config.yml");
+		const modifiedPaths = [...this.#modifiedProject];
 		const modifiedModelRoles = [...this.#modifiedProjectModelRoles];
+		const projectFileAtStart = structuredClone(this.#projectFileSettings);
+		const projectRolesAtStart = this.#modelRolesFromLayer(this.#project);
+		this.#modifiedProject.clear();
 		this.#modifiedProjectModelRoles.clear();
 
 		try {
@@ -2149,20 +2241,55 @@ export class Settings {
 				const loaded = await this.#loadYamlIfPresentForWriteLocked(projectConfigPath, writePath);
 				const projectSettings =
 					loaded ??
-					(this.#quarantinedYamlTargets.has(projectConfigPath) ? structuredClone(this.#projectFileSettings) : {});
+					(this.#quarantinedYamlTargets.has(projectConfigPath) ? structuredClone(projectFileAtStart) : {});
 
-				const projectRoles = getByPath(this.#project, ["modelRoles"]);
+				for (const modifiedPath of modifiedPaths) {
+					const segments = modifiedPath.split(".");
+					const value = getByPath(projectFileAtStart, segments);
+					if (value === undefined) {
+						deleteByPath(projectSettings, segments);
+					} else {
+						setByPath(projectSettings, segments, value);
+					}
+				}
 				for (const role of modifiedModelRoles) {
-					const value = isRecord(projectRoles) ? projectRoles[role] : undefined;
-					setByPath(projectSettings, ["modelRoles", role], value);
+					if (Object.hasOwn(projectRolesAtStart, role)) {
+						setByPath(projectSettings, ["modelRoles", role], projectRolesAtStart[role]);
+					} else {
+						deleteByPath(projectSettings, ["modelRoles", role]);
+					}
 				}
 
 				await this.#writeYamlAtomically(writePath, projectSettings);
-				this.#projectFileSettings = structuredClone(projectSettings);
+				this.#projectConfigExists = true;
 				this.#quarantinedYamlTargets.delete(projectConfigPath);
+
+				// Retain changes queued while the write lock was pending in the
+				// in-memory source for the follow-up save.
+				for (const pendingPath of this.#modifiedProject) {
+					const segments = pendingPath.split(".");
+					const value = getByPath(this.#projectFileSettings, segments);
+					if (value === undefined) {
+						deleteByPath(projectSettings, segments);
+					} else {
+						setByPath(projectSettings, segments, value);
+					}
+				}
+				const latestProjectRoles = this.#modelRolesFromLayer(this.#project);
+				for (const role of this.#modifiedProjectModelRoles) {
+					if (Object.hasOwn(latestProjectRoles, role)) {
+						setByPath(projectSettings, ["modelRoles", role], latestProjectRoles[role]);
+					} else {
+						deleteByPath(projectSettings, ["modelRoles", role]);
+					}
+				}
+				this.#projectFileSettings = structuredClone(projectSettings);
 			});
 			invalidateCapabilityFsCache(projectConfigPath);
 		} catch (error) {
+			for (const modifiedPath of modifiedPaths) {
+				this.#modifiedProject.add(modifiedPath);
+			}
 			for (const role of modifiedModelRoles) {
 				this.#modifiedProjectModelRoles.add(role);
 			}

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -521,6 +521,19 @@ export class Settings {
 	}
 
 	/**
+	 * Resolve a setting from only the global layer plus schema defaults,
+	 * ignoring the project/overlay/runtime layers. The settings UI uses this to
+	 * show and edit the global fallback while in global scope, so a project
+	 * override never masks the value being written.
+	 */
+	getGlobalValue<P extends SettingPath>(path: P): SettingValue<P> {
+		const value = getByPath(this.#global, SETTING_PATH_SEGMENTS[path]);
+		const resolved =
+			value !== undefined ? (resolvePathScopedStringArray(path, value, this.#cwd) ?? value) : getDefault(path);
+		return resolved as SettingValue<P>;
+	}
+
+	/**
 	 * Whether `path` has an explicitly configured value (global config, project
 	 * config, or runtime override) rather than falling back to the schema default.
 	 */

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1121,7 +1121,7 @@ export class SettingsSelectorComponent implements Component {
 			value => {
 				const effective = this.#setSettingValue(def.path, value);
 				this.callbacks.onChange(def.path, effective);
-				done(this.#getSubmenuCurrentValue(def.path, effective));
+				done(this.#getSubmenuCurrentValue(def.path, this.#scopedValue(def.path)));
 			},
 			() => {
 				onPreviewCancel?.();
@@ -1156,7 +1156,7 @@ export class SettingsSelectorComponent implements Component {
 				// store "" which the browser.ts expandPath ignores (no-op fallback).
 				const effective = this.#setSettingValue(def.path, value);
 				this.callbacks.onChange(def.path, effective);
-				wrappedDone(this.#formatTextInputValue(def, effective));
+				wrappedDone(this.#formatTextInputValue(def, this.#scopedValue(def.path)));
 			},
 			() => wrappedDone(),
 		);
@@ -1169,7 +1169,7 @@ export class SettingsSelectorComponent implements Component {
 			value => {
 				const effective = this.#persistSetting("providers.maxInFlightRequests", value);
 				this.callbacks.onChange("providers.maxInFlightRequests", effective);
-				done(this.#formatProviderLimitsValue(effective));
+				done(this.#formatProviderLimitsValue(this.#scopedValue("providers.maxInFlightRequests")));
 			},
 			() => done(),
 			this.context.requestRender,
@@ -1229,13 +1229,13 @@ export class SettingsSelectorComponent implements Component {
 	}
 
 	/**
-	 * Persist a setting in the selected scope and return the value that scope
-	 * now resolves to, so callbacks and row summaries reflect the layer written
-	 * rather than a higher-precedence layer that may shadow it.
+	 * Persist a setting in the selected scope and return the recomputed merged
+	 * effective value. Row display reads {@link #scopedValue} separately, while
+	 * runtime callbacks must stay aligned with the active project configuration.
 	 */
 	#persistSetting(path: SettingPath, value: unknown): unknown {
 		settings.set(path, value as never, this.#scope);
-		return this.#scopedValue(path);
+		return settings.get(path);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -31,6 +31,7 @@ import {
 	getType,
 	normalizeProviderMaxInFlightRequests,
 	type SettingPath,
+	type SettingsScope,
 	settings,
 	validateProviderMaxInFlightRequests,
 } from "../../config/settings";
@@ -397,7 +398,6 @@ class ProviderLimitsSubmenu extends Container {
 		this.#selectList = new SelectList(items, Math.min(Math.max(items.length, 1), 12), getSelectListTheme());
 		this.#selectList.onSelect = item => {
 			if (item.value === "__clear_all") {
-				settings.set("providers.maxInFlightRequests", {});
 				this.onChange({});
 				this.#showProviderList();
 				this.requestRender?.();
@@ -432,7 +432,6 @@ class ProviderLimitsSubmenu extends Container {
 						next[provider] = Math.max(1, Math.floor(limit));
 					}
 					const normalized = validateProviderMaxInFlightRequests(next);
-					settings.set("providers.maxInFlightRequests", normalized);
 					this.onChange(normalized);
 					this.#showProviderList();
 					this.requestRender?.();
@@ -543,6 +542,7 @@ export class SettingsSelectorComponent implements Component {
 	#searchList: SettingsList | null = null;
 	#pluginComponent: PluginSettingsComponent | null = null;
 	#currentTabId: SettingTab | "plugins" = "appearance";
+	#scope: SettingsScope;
 	#preSearchTabId: SettingTab | "plugins" = "appearance";
 	#searchQuery = "";
 	/** Single-line editor backing the search banner (cursor, word ops, paste). */
@@ -563,6 +563,7 @@ export class SettingsSelectorComponent implements Component {
 		private readonly context: SettingsRuntimeContext,
 		private readonly callbacks: SettingsCallbacks,
 	) {
+		this.#scope = settings.hasProjectConfig() ? "project" : "global";
 		// No label prefix (the frame title already says Settings) and no
 		// "(tab to cycle)" hint (folded into the footer hint line).
 		this.#tabBar = new TabBar("", getSettingsTabs(), getTabBarTheme());
@@ -610,16 +611,17 @@ export class SettingsSelectorComponent implements Component {
 
 	#footerHintText(): string {
 		if (this.#searchList) {
-			return "Enter to change · Tab to jump tabs · Esc to exit search";
+			return "Enter to change · Tab to jump tabs · Alt+S to switch scope · Esc to exit search";
 		}
 		if (this.#currentTabId === "plugins") {
 			return "Tab to switch tabs · Esc to close";
 		}
+		const scope = this.#scope === "project" ? "Alt+S to switch scope · Del to inherit" : "Alt+S to switch scope";
 		if (this.#currentList?.sectionFocused) {
-			return "↑/↓ to jump sections · Tab/Enter to settings · ←/→ to switch tabs · Esc to close";
+			return `↑/↓ to jump sections · Tab/Enter to settings · ←/→ to switch tabs · ${scope} · Esc to close`;
 		}
 		const nav = this.#hasSectionJump ? "Tab to jump sections · ←/→ to switch tabs" : "Tab to switch tabs";
-		return `Enter/Space to change · ${nav} · Type to search · Esc to close`;
+		return `Enter/Space to change · ${nav} · ${scope} · Type to search · Esc to close`;
 	}
 
 	/** Single-line search banner: accent icon, editable query with live cursor, right-aligned match count. */
@@ -666,7 +668,7 @@ export class SettingsSelectorComponent implements Component {
 		}
 
 		const out: string[] = [];
-		out.push(topBorder(width, "Settings"));
+		out.push(topBorder(width, this.#currentTabId === "plugins" ? "Settings" : `Settings · ${this.#scope}`));
 		this.#tabRowStart = out.length;
 		this.#tabRowCount = tabLines.length;
 		for (const line of tabLines) {
@@ -902,11 +904,11 @@ export class SettingsSelectorComponent implements Component {
 		if (!def) return;
 		if (def.type === "boolean") {
 			const boolValue = newValue === "true";
-			settings.set(path, boolValue as never);
-			this.callbacks.onChange(path, boolValue);
+			const effective = this.#persistSetting(path, boolValue);
+			this.callbacks.onChange(path, effective);
 		} else if (def.type === "enum") {
-			settings.set(path, newValue as never);
-			this.callbacks.onChange(path, newValue);
+			const effective = this.#persistSetting(path, newValue);
+			this.callbacks.onChange(path, effective);
 		}
 		// Submenu/text types already persisted inside their own done callbacks.
 		if (def.tab === "appearance") {
@@ -1106,9 +1108,9 @@ export class SettingsSelectorComponent implements Component {
 			options,
 			currentValue,
 			value => {
-				this.#setSettingValue(def.path, value);
-				this.callbacks.onChange(def.path, value);
-				done(value);
+				const effective = this.#setSettingValue(def.path, value);
+				this.callbacks.onChange(def.path, effective);
+				done(this.#getSubmenuCurrentValue(def.path, effective));
 			},
 			() => {
 				onPreviewCancel?.();
@@ -1141,9 +1143,9 @@ export class SettingsSelectorComponent implements Component {
 			value => {
 				// Empty string clears the setting; undefined-typed string settings
 				// store "" which the browser.ts expandPath ignores (no-op fallback).
-				this.#setSettingValue(def.path, value);
-				this.callbacks.onChange(def.path, settings.get(def.path));
-				wrappedDone(this.#formatTextInputValue(def, settings.get(def.path)));
+				const effective = this.#setSettingValue(def.path, value);
+				this.callbacks.onChange(def.path, effective);
+				wrappedDone(this.#formatTextInputValue(def, effective));
 			},
 			() => wrappedDone(),
 		);
@@ -1153,8 +1155,9 @@ export class SettingsSelectorComponent implements Component {
 		return new ProviderLimitsSubmenu(
 			this.context.providers,
 			value => {
-				this.callbacks.onChange("providers.maxInFlightRequests", value);
-				done(this.#formatProviderLimitsValue(value));
+				const effective = this.#persistSetting("providers.maxInFlightRequests", value);
+				this.callbacks.onChange("providers.maxInFlightRequests", effective);
+				done(this.#formatProviderLimitsValue(effective));
 			},
 			() => done(),
 			this.context.requestRender,
@@ -1188,8 +1191,8 @@ export class SettingsSelectorComponent implements Component {
 			initial,
 			def.ordered,
 			value => {
-				settings.set(def.path, value as never);
-				this.callbacks.onChange(def.path, value);
+				const effective = this.#persistSetting(def.path, value);
+				this.callbacks.onChange(def.path, effective);
 			},
 			() => done(this.#formatMultiSelectValue(def, settings.get(def.path))),
 		);
@@ -1214,16 +1217,26 @@ export class SettingsSelectorComponent implements Component {
 	}
 
 	/**
+	 * Persist a setting in the selected scope and return its recomputed effective value.
+	 */
+	#persistSetting(path: SettingPath, value: unknown): unknown {
+		settings.set(path, value as never, this.#scope);
+		return settings.get(path);
+	}
+
+	/**
 	 * Set a setting value, handling type conversion.
 	 */
-	#setSettingValue(path: SettingPath, value: string): void {
+	#setSettingValue(path: SettingPath, value: string): unknown {
 		const currentValue = settings.get(path);
 		const schemaType = getType(path);
 		if (path === "compaction.thresholdPercent" && value === "default") {
-			settings.set(path, -1 as never);
-		} else if (path === "compaction.thresholdTokens" && value === "default") {
-			settings.set(path, -1 as never);
-		} else if (schemaType === "record") {
+			return this.#persistSetting(path, -1);
+		}
+		if (path === "compaction.thresholdTokens" && value === "default") {
+			return this.#persistSetting(path, -1);
+		}
+		if (schemaType === "record") {
 			let parsed: unknown;
 			try {
 				parsed = JSON.parse(value || "{}");
@@ -1236,14 +1249,15 @@ export class SettingsSelectorComponent implements Component {
 			if (path === "providers.maxInFlightRequests") {
 				parsed = validateProviderMaxInFlightRequests(parsed);
 			}
-			settings.set(path, parsed as never);
-		} else if (typeof currentValue === "number") {
-			settings.set(path, Number(value) as never);
-		} else if (typeof currentValue === "boolean") {
-			settings.set(path, (value === "true") as never);
-		} else {
-			settings.set(path, value as never);
+			return this.#persistSetting(path, parsed);
 		}
+		if (typeof currentValue === "number") {
+			return this.#persistSetting(path, Number(value));
+		}
+		if (typeof currentValue === "boolean") {
+			return this.#persistSetting(path, value === "true");
+		}
+		return this.#persistSetting(path, value);
 	}
 
 	/**
@@ -1271,15 +1285,15 @@ export class SettingsSelectorComponent implements Component {
 
 				if (def.type === "boolean") {
 					const boolValue = newValue === "true";
-					settings.set(path, boolValue as never);
-					this.callbacks.onChange(path, boolValue);
+					const effective = this.#persistSetting(path, boolValue);
+					this.callbacks.onChange(path, effective);
 
 					if (tabId === "appearance") {
 						this.#triggerStatusLinePreview();
 					}
 				} else if (def.type === "enum") {
-					settings.set(path, newValue as never);
-					this.callbacks.onChange(path, newValue);
+					const effective = this.#persistSetting(path, newValue);
+					this.callbacks.onChange(path, effective);
 				}
 				// Submenu/text types already persisted the value inside their own
 				// done callbacks before SettingsList re-dispatches here. Re-run the
@@ -1353,6 +1367,31 @@ export class SettingsSelectorComponent implements Component {
 		});
 	}
 
+	#switchScope(): void {
+		this.#scope = this.#scope === "project" ? "global" : "project";
+		if (this.#searchList) {
+			this.#setSearchQuery(this.#searchQuery);
+		} else if (this.#currentTabId !== "plugins") {
+			const selectedId = this.#currentList?.getSelectedItem()?.id;
+			this.#switchToTab(this.#currentTabId);
+			if (selectedId) this.#currentList?.selectItem(selectedId);
+		}
+		this.context.requestRender?.();
+	}
+
+	#inheritSelectedSetting(): void {
+		const item = this.#currentList?.getSelectedItem();
+		const def = item ? getSettingDef(item.id as SettingPath) : undefined;
+		if (!def || !settings.clearProject(def.path)) return;
+		const effective = settings.get(def.path);
+		this.callbacks.onChange(def.path, effective);
+		if (def.tab === "appearance") {
+			this.#triggerStatusLinePreview();
+		}
+		this.#refreshCurrentTabItems(getSettingsForTab(def.tab));
+		this.context.requestRender?.();
+	}
+
 	handleInput(data: string): void {
 		// SGR mouse reports (the fullscreen overlay enables tracking).
 		if (data.startsWith("\x1b[<")) {
@@ -1372,6 +1411,15 @@ export class SettingsSelectorComponent implements Component {
 		// An open submenu owns input entirely — Tab/arrows/typing belong to it.
 		if (activeList?.hasOpenSubmenu()) {
 			activeList.handleInput(data);
+			return;
+		}
+
+		if (this.#currentTabId !== "plugins" && matchesKey(data, "alt+s")) {
+			this.#switchScope();
+			return;
+		}
+		if (!this.#searchList && this.#scope === "project" && matchesKey(data, "delete")) {
+			this.#inheritSelectedSetting();
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -352,6 +352,7 @@ class ProviderLimitsSubmenu extends Container {
 
 	constructor(
 		private readonly providers: readonly string[],
+		private readonly getLimits: () => Record<string, number>,
 		private readonly onChange: (value: Record<string, number>) => void,
 		private readonly onCancel: () => void,
 		private readonly requestRender?: () => void,
@@ -361,7 +362,7 @@ class ProviderLimitsSubmenu extends Container {
 	}
 
 	#providerIds(): string[] {
-		const limits = normalizeProviderMaxInFlightRequests(settings.get("providers.maxInFlightRequests"));
+		const limits = this.getLimits();
 		return [...new Set([...this.providers, ...Object.keys(limits)])].sort((a, b) => a.localeCompare(b));
 	}
 
@@ -381,7 +382,7 @@ class ProviderLimitsSubmenu extends Container {
 		);
 		this.addChild(new Spacer(1));
 
-		const limits = normalizeProviderMaxInFlightRequests(settings.get("providers.maxInFlightRequests"));
+		const limits = this.getLimits();
 		const providerItems = this.#providerIds().map((provider): SelectItem => {
 			const limit = limits[provider];
 			return {
@@ -412,7 +413,7 @@ class ProviderLimitsSubmenu extends Container {
 	}
 
 	#showProviderEditor(provider: string): void {
-		const limits = normalizeProviderMaxInFlightRequests(settings.get("providers.maxInFlightRequests"));
+		const limits = this.getLimits();
 		this.clear();
 		this.#selectList = undefined;
 		this.addChild(
@@ -995,10 +996,20 @@ export class SettingsSelectorComponent implements Component {
 	}
 
 	/**
+	 * Value shown and edited for a setting in the active persistence scope:
+	 * the global-layer value (plus defaults) in global scope, or the merged
+	 * effective value in project scope. Reading the global layer directly keeps
+	 * a project override from masking the value a global-scope edit writes.
+	 */
+	#scopedValue(path: SettingPath): unknown {
+		return this.#scope === "global" ? settings.getGlobalValue(path) : settings.get(path);
+	}
+
+	/**
 	 * Get the current value for a setting.
 	 */
 	#getCurrentValue(def: SettingDef): unknown {
-		return settings.get(def.path);
+		return this.#scopedValue(def.path);
 	}
 
 	#isChanged(def: SettingDef, currentValue: unknown): boolean {
@@ -1138,7 +1149,7 @@ export class SettingsSelectorComponent implements Component {
 		return new TextInputSubmenu(
 			def.label,
 			def.description,
-			this.#formatTextInputEditValue(def.path, settings.get(def.path)),
+			this.#formatTextInputEditValue(def.path, this.#scopedValue(def.path)),
 			def.secret,
 			value => {
 				// Empty string clears the setting; undefined-typed string settings
@@ -1154,6 +1165,7 @@ export class SettingsSelectorComponent implements Component {
 	#createProviderLimitsInput(done: (value?: string) => void): Container {
 		return new ProviderLimitsSubmenu(
 			this.context.providers,
+			() => normalizeProviderMaxInFlightRequests(this.#scopedValue("providers.maxInFlightRequests")),
 			value => {
 				const effective = this.#persistSetting("providers.maxInFlightRequests", value);
 				this.callbacks.onChange("providers.maxInFlightRequests", effective);
@@ -1180,7 +1192,7 @@ export class SettingsSelectorComponent implements Component {
 			}
 		}
 
-		const current: unknown = settings.get(def.path);
+		const current: unknown = this.#scopedValue(def.path);
 		const initial = Array.isArray(current)
 			? current.filter((entry): entry is string => typeof entry === "string")
 			: [];
@@ -1194,7 +1206,7 @@ export class SettingsSelectorComponent implements Component {
 				const effective = this.#persistSetting(def.path, value);
 				this.callbacks.onChange(def.path, effective);
 			},
-			() => done(this.#formatMultiSelectValue(def, settings.get(def.path))),
+			() => done(this.#formatMultiSelectValue(def, this.#scopedValue(def.path))),
 		);
 	}
 
@@ -1217,11 +1229,13 @@ export class SettingsSelectorComponent implements Component {
 	}
 
 	/**
-	 * Persist a setting in the selected scope and return its recomputed effective value.
+	 * Persist a setting in the selected scope and return the value that scope
+	 * now resolves to, so callbacks and row summaries reflect the layer written
+	 * rather than a higher-precedence layer that may shadow it.
 	 */
 	#persistSetting(path: SettingPath, value: unknown): unknown {
 		settings.set(path, value as never, this.#scope);
-		return settings.get(path);
+		return this.#scopedValue(path);
 	}
 
 	/**

--- a/packages/coding-agent/test/modes/components/settings-scope.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-scope.test.ts
@@ -58,26 +58,30 @@ describe("SettingsSelectorComponent persistence scope", () => {
 		);
 	}
 
-	it("writes the global layer in global scope even when a project override shadows it", async () => {
+	it("writes the global layer while callbacks receive the shadowing effective value", async () => {
+		// Start both layers at true, then toggle only the global fallback to
+		// false. The persisted scope and active effective value must diverge.
+		settings.set("ask.enabled", true, "global");
 		const selector = createSelector();
 		expect(selector.render(120).join("\n")).toContain("Settings · project");
+		expect(settings.getGlobalValue("ask.enabled")).toBe(true);
 		expect(settings.get("ask.enabled")).toBe(true);
 
-		// Alt+S switches to global scope; the row now reflects the global layer
-		// (false), not the project-shadowed effective value.
+		// Alt+S switches to global scope; the row reflects the global layer
+		// (true), so Enter writes false even though project remains true.
 		selector.handleInput("\x1bs");
 		expect(selector.render(120).join("\n")).toContain("Settings · global");
 		for (const char of "ask tool interactive") selector.handleInput(char);
 		selector.handleInput("\n");
 
-		// The toggle set the global fallback to true; the project override still
-		// determines the effective value, so the session is untouched.
-		expect(settings.getGlobalValue("ask.enabled")).toBe(true);
+		expect(settings.getGlobalValue("ask.enabled")).toBe(false);
 		expect(settings.get("ask.enabled")).toBe(true);
+		// Side-effect handlers receive the merged effective value, not the
+		// global fallback displayed in the row.
 		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: true });
 
 		await settings.flush();
-		expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toEqual({ ask: { enabled: true } });
+		expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toEqual({ ask: { enabled: false } });
 		expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({
 			ask: { enabled: true },
 			custom: { keep: true },

--- a/packages/coding-agent/test/modes/components/settings-scope.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-scope.test.ts
@@ -15,10 +15,23 @@ beforeAll(async () => {
 describe("SettingsSelectorComponent persistence scope", () => {
 	let settingsState: SettingsTestState | undefined;
 	let tempDir: TempDir;
+	let projectDir: string;
+	let agentDir: string;
+	let projectConfigPath: string;
+	let changes: Array<{ path: string; value: unknown }>;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		settingsState = beginSettingsTest();
 		tempDir = TempDir.createSync("@pi-settings-scope-test-");
+		projectDir = tempDir.join("project");
+		agentDir = tempDir.join("agent");
+		projectConfigPath = path.join(projectDir, ".omp", "config.yml");
+		// Global fallback disagrees with the project override so a shadowed
+		// global edit is observable: effective (project) stays true.
+		await Bun.write(path.join(agentDir, "config.yml"), YAML.stringify({ ask: { enabled: false } }, null, 2));
+		await Bun.write(projectConfigPath, YAML.stringify({ ask: { enabled: true }, custom: { keep: true } }, null, 2));
+		await Settings.init({ cwd: projectDir, agentDir });
+		changes = [];
 	});
 
 	afterEach(async () => {
@@ -29,14 +42,8 @@ describe("SettingsSelectorComponent persistence scope", () => {
 		await tempDir.remove();
 	});
 
-	it("defaults to project scope, exposes scope switching, and inherits the effective fallback", async () => {
-		const projectDir = tempDir.join("project");
-		const agentDir = tempDir.join("agent");
-		const projectConfigPath = path.join(projectDir, ".omp", "config.yml");
-		await Bun.write(projectConfigPath, YAML.stringify({ ask: { enabled: true }, custom: { keep: true } }, null, 2));
-		await Settings.init({ cwd: projectDir, agentDir });
-		const changes: Array<{ path: string; value: unknown }> = [];
-		const selector = new SettingsSelectorComponent(
+	function createSelector(): SettingsSelectorComponent {
+		return new SettingsSelectorComponent(
 			{
 				availableThinkingLevels: [],
 				thinkingLevel: undefined,
@@ -49,28 +56,47 @@ describe("SettingsSelectorComponent persistence scope", () => {
 				onCancel: () => {},
 			},
 		);
+	}
 
+	it("writes the global layer in global scope even when a project override shadows it", async () => {
+		const selector = createSelector();
 		expect(selector.render(120).join("\n")).toContain("Settings · project");
-		for (const char of "ask tool interactive") selector.handleInput(char);
-		selector.handleInput("\n");
-		expect(settings.get("ask.enabled")).toBe(false);
-		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: false });
+		expect(settings.get("ask.enabled")).toBe(true);
 
+		// Alt+S switches to global scope; the row now reflects the global layer
+		// (false), not the project-shadowed effective value.
 		selector.handleInput("\x1bs");
 		expect(selector.render(120).join("\n")).toContain("Settings · global");
+		for (const char of "ask tool interactive") selector.handleInput(char);
 		selector.handleInput("\n");
-		expect(settings.get("ask.enabled")).toBe(false);
-		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: false });
-		await settings.flush();
-		expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toEqual({ ask: { enabled: true } });
 
-		selector.handleInput("\x1b");
-		selector.handleInput("\x1bs");
-		expect(selector.render(120).join("\n")).toContain("Settings · project");
-		selector.handleInput("\x1b[3~");
+		// The toggle set the global fallback to true; the project override still
+		// determines the effective value, so the session is untouched.
+		expect(settings.getGlobalValue("ask.enabled")).toBe(true);
 		expect(settings.get("ask.enabled")).toBe(true);
 		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: true });
+
+		await settings.flush();
+		expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toEqual({ ask: { enabled: true } });
+		expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({
+			ask: { enabled: true },
+			custom: { keep: true },
+		});
+	});
+
+	it("inherits the global fallback when removing a project override", async () => {
+		const selector = createSelector();
+		// Locate the Ask row via search, then Esc lands on its tab with the row
+		// selected so Delete can remove the project override in list mode.
+		for (const char of "ask tool interactive") selector.handleInput(char);
+		selector.handleInput("\x1b");
+		selector.handleInput("\x1b[3~");
+
+		expect(settings.get("ask.enabled")).toBe(false);
+		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: false });
+
 		await settings.flush();
 		expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({ custom: { keep: true } });
+		expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toEqual({ ask: { enabled: false } });
 	});
 });

--- a/packages/coding-agent/test/modes/components/settings-scope.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-scope.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SettingsSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/settings-selector";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "../../helpers/settings-test-state";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("SettingsSelectorComponent persistence scope", () => {
+	let settingsState: SettingsTestState | undefined;
+	let tempDir: TempDir;
+
+	beforeEach(() => {
+		settingsState = beginSettingsTest();
+		tempDir = TempDir.createSync("@pi-settings-scope-test-");
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		AgentStorage.resetInstance();
+		restoreSettingsTestState(settingsState);
+		settingsState = undefined;
+		await tempDir.remove();
+	});
+
+	it("defaults to project scope, exposes scope switching, and inherits the effective fallback", async () => {
+		const projectDir = tempDir.join("project");
+		const agentDir = tempDir.join("agent");
+		const projectConfigPath = path.join(projectDir, ".omp", "config.yml");
+		await Bun.write(projectConfigPath, YAML.stringify({ ask: { enabled: true }, custom: { keep: true } }, null, 2));
+		await Settings.init({ cwd: projectDir, agentDir });
+		const changes: Array<{ path: string; value: unknown }> = [];
+		const selector = new SettingsSelectorComponent(
+			{
+				availableThinkingLevels: [],
+				thinkingLevel: undefined,
+				availableThemes: ["dark-one", "titanium"],
+				providers: [],
+				cwd: projectDir,
+			},
+			{
+				onChange: (settingPath, value) => changes.push({ path: settingPath, value }),
+				onCancel: () => {},
+			},
+		);
+
+		expect(selector.render(120).join("\n")).toContain("Settings · project");
+		for (const char of "ask tool interactive") selector.handleInput(char);
+		selector.handleInput("\n");
+		expect(settings.get("ask.enabled")).toBe(false);
+		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: false });
+
+		selector.handleInput("\x1bs");
+		expect(selector.render(120).join("\n")).toContain("Settings · global");
+		selector.handleInput("\n");
+		expect(settings.get("ask.enabled")).toBe(false);
+		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: false });
+		await settings.flush();
+		expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toEqual({ ask: { enabled: true } });
+
+		selector.handleInput("\x1b");
+		selector.handleInput("\x1bs");
+		expect(selector.render(120).join("\n")).toContain("Settings · project");
+		selector.handleInput("\x1b[3~");
+		expect(settings.get("ask.enabled")).toBe(true);
+		expect(changes.at(-1)).toEqual({ path: "ask.enabled", value: true });
+		await settings.flush();
+		expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({ custom: { keep: true } });
+	});
+});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -128,6 +128,52 @@ describe("Settings", () => {
 		});
 	});
 
+	describe("project setting scope", () => {
+		it("persists scoped edits to the native project config without modifying the global layer", async () => {
+			const projectConfigPath = path.join(projectDir, ".omp", "config.yml");
+			await Bun.write(
+				projectConfigPath,
+				YAML.stringify({ theme: { dark: "dark-one" }, ask: { enabled: true }, custom: { keep: true } }, null, 2),
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.hasProjectConfig()).toBe(true);
+			settings.set("theme.dark", "titanium", "project");
+			settings.set("ask.enabled", false, "project");
+			expect(settings.get("theme.dark")).toBe("titanium");
+			expect(settings.get("ask.enabled")).toBe(false);
+			await settings.flush();
+
+			expect(await readSettings()).toEqual({});
+			expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({
+				theme: { dark: "titanium" },
+				ask: { enabled: false },
+				custom: { keep: true },
+			});
+		});
+
+		it("removes a project override and immediately restores the global fallback", async () => {
+			await writeSettings({ ask: { enabled: false } });
+			const projectConfigPath = path.join(projectDir, ".omp", "config.yml");
+			await Bun.write(
+				projectConfigPath,
+				YAML.stringify({ theme: { dark: "dark-one" }, ask: { enabled: true } }, null, 2),
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("ask.enabled")).toBe(true);
+			expect(settings.clearProject("ask.enabled")).toBe(true);
+			expect(settings.get("ask.enabled")).toBe(false);
+			expect(settings.clearProject("ask.enabled")).toBe(false);
+			await settings.flush();
+
+			expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({
+				theme: { dark: "dark-one" },
+			});
+			expect(await readSettings()).toEqual({ ask: { enabled: false } });
+		});
+	});
+
 	describe("shell configuration errors", () => {
 		it("points to the selected global config in the active agent directory", async () => {
 			const configPath = path.join(agentDir, "config.yaml");

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -151,6 +151,24 @@ describe("Settings", () => {
 				custom: { keep: true },
 			});
 		});
+		it("resolves the global layer independently of a shadowing project override", async () => {
+			await writeSettings({ ask: { enabled: false } });
+			const projectConfigPath = path.join(projectDir, ".omp", "config.yml");
+			await Bun.write(projectConfigPath, YAML.stringify({ ask: { enabled: true } }, null, 2));
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			// Effective view is the project override; the global getter ignores it.
+			expect(settings.get("ask.enabled")).toBe(true);
+			expect(settings.getGlobalValue("ask.enabled")).toBe(false);
+
+			settings.set("ask.enabled", true, "global");
+			expect(settings.getGlobalValue("ask.enabled")).toBe(true);
+			expect(settings.get("ask.enabled")).toBe(true);
+			await settings.flush();
+
+			expect(await readSettings()).toEqual({ ask: { enabled: true } });
+			expect(YAML.parse(await Bun.file(projectConfigPath).text())).toEqual({ ask: { enabled: true } });
+		});
 
 		it("removes a project override and immediately restores the global fallback", async () => {
 			await writeSettings({ ask: { enabled: false } });


### PR DESCRIPTION
## Repro
A Bun evaluation harness loaded a profile config plus a project `.omp/config.yml` containing `theme.dark=dark-one` and `ask.enabled=true`, then invoked the same `Settings.set()` path used by `/settings`; after `flush()`, the effective values and project file were unchanged while the profile config contained `theme.dark=titanium` and `ask.enabled=false`. The regression is encoded by `bun test packages/coding-agent/test/modes/components/settings-scope.test.ts`.

## Cause
`SettingsSelectorComponent` rendered `Settings.get()` values from the merged global/project view but persisted every control through global-only `Settings.set()` in `packages/coding-agent/src/config/settings.ts`. Theme previews and `onChange` callbacks also received the selected raw value rather than the recomputed effective value, so a project-shadowed global edit could affect the live TUI temporarily.

## Fix
- Added explicit global/project persistence to `Settings`, including partial native project writes and project override removal.
- Defaulted `/settings` to project scope when `.omp/config.yml` exists, displayed the active scope, added Alt+S scope switching, and added Delete-to-inherit for project overrides.
- Routed every settings control through the selected scope and passed recomputed effective values to runtime callbacks.
- Added manager and TUI regression coverage plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/modes/components/settings-scope.test.ts packages/coding-agent/test/modes/components/settings-multiselect.test.ts` passed 90 tests with 257 assertions. A post-fix Bun evaluation updated only `.omp/config.yml`, returned effective `theme.dark=titanium` and `ask.enabled=false`, and created no global config. `bun run check:ts` passed. Skipped the full pre-publish gate: `bun run fix:rs` fails identically on a clean `origin/main` worktree because this runner lacks CMake while building `audiopus_sys`.

Fixes #8208