### PR TITLE
fix(ai): resolve AWS role_arn/source_profile role chains for Bedrock

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the AWS credential resolver ignoring `role_arn` profiles: shared-config role chaining (`source_profile` recursion, `web_identity_token_file`, `credential_source`) now resolves via STS `AssumeRole`/`AssumeRoleWithWebIdentity`, honoring `role_session_name`/`duration_seconds`/`external_id`, so Bedrock is detected on EKS/IRSA and multi-account setups instead of reporting "No models available" ([#8209](https://github.com/can1357/oh-my-pi/issues/8209)).
+- Fixed Bedrock availability being under-detected on Nitro/EKS hosts: the EC2 metadata probe now recognizes Nitro DMI markers (`board_asset_tag` instance ids, `Amazon EC2` vendor fields) in addition to the Xen `ec2` UUID prefix ([#8209](https://github.com/can1357/oh-my-pi/issues/8209)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/ai/src/error/aws.ts
+++ b/packages/ai/src/error/aws.ts
@@ -13,7 +13,11 @@ export type AwsCredentialsErrorKind =
 	/** STS web-identity exchange failed or returned malformed credentials. */
 	| "web-identity"
 	/** ECS/container credential endpoint failed or returned malformed credentials. */
-	| "container";
+	| "container"
+	/** Shared-config role chain is misconfigured (cycle, missing source_profile, unsupported credential_source). */
+	| "profile"
+	/** STS `AssumeRole` call failed or returned malformed credentials. */
+	| "assume-role";
 
 /** A failure resolving AWS credentials for the Bedrock provider. */
 export class AwsCredentialsError extends Error {

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -5,8 +5,9 @@
  *  1. Static credentials from the environment
  *     (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` [+ `AWS_SESSION_TOKEN`]).
  *  2. Web identity (`AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`).
- *  3. Profile in `~/.aws/credentials` (and `~/.aws/config` for SSO):
- *      - static keys, SSO, or `credential_process`.
+ *  3. Profile in `~/.aws/credentials` (and `~/.aws/config` for SSO/roles):
+ *      - static keys, SSO, `credential_process`, or `role_arn` role chaining
+ *        (`source_profile` recursion, `web_identity_token_file`, `credential_source`).
  *  4. ECS/container credentials from `AWS_CONTAINER_CREDENTIALS_*`.
  *  5. EC2 IMDSv2 when metadata is enabled.
  *
@@ -29,7 +30,7 @@ import {
 	shouldLoadAwsSharedConfig,
 } from "../utils/aws-profile";
 import { isLocalOrMetadataHost } from "../utils/proxy";
-import type { AwsCredentials } from "./aws-sigv4";
+import { type AwsCredentials, signRequest } from "./aws-sigv4";
 
 export interface ResolvedCredentials extends AwsCredentials {
 	/** Absolute expiration timestamp in ms. `undefined` for non-expiring static creds. */
@@ -60,8 +61,8 @@ const SHARED_RESOLVE_TIMEOUT_MS = 30_000;
 
 function requireDynamicCredentialExpiration(
 	value: string | undefined,
-	source: "AWS web identity" | "AWS container credential",
-	kind: "web-identity" | "container",
+	source: string,
+	kind: AIError.AwsCredentialsErrorKind,
 ): number {
 	const expiresAt = value ? Date.parse(value) : Number.NaN;
 	if (Number.isFinite(expiresAt)) return expiresAt;
@@ -179,7 +180,16 @@ async function readIniFile(p: string): Promise<AwsIniFile | undefined> {
 	}
 }
 
-// ---------- Profile / SSO ----------
+// ---------- Profile / SSO / role chaining ----------
+
+/** Shared-config view and resolution context threaded through role-chain recursion. */
+interface ProfileResolveContext {
+	credentialsIni: AwsIniFile | undefined;
+	configIni: AwsIniFile | undefined;
+	region: string;
+	signal: AbortSignal | undefined;
+	fetchImpl: FetchImpl;
+}
 
 async function readProfileCredentials(
 	profile: string,
@@ -195,10 +205,35 @@ async function readProfileCredentials(
 	const credentialsIni = await readIniFile(credentialsPath);
 	const configIni = loadSharedConfig ? await readIniFile(configPath) : undefined;
 
-	// Static credentials live in ~/.aws/credentials; SSO config lives in
+	return resolveProfileChain(profile, { credentialsIni, configIni, region, signal, fetchImpl }, new Set());
+}
+
+/**
+ * Resolve one profile, following `role_arn` chains. A `role_arn` profile derives
+ * base credentials from `source_profile` (recursive), `web_identity_token_file`,
+ * or `credential_source`, then exchanges them via STS. Non-role profiles resolve
+ * directly from static keys, SSO, or `credential_process`. `seen` guards against
+ * `source_profile` cycles.
+ */
+async function resolveProfileChain(
+	profile: string,
+	ctx: ProfileResolveContext,
+	seen: Set<string>,
+): Promise<ResolvedCredentials | undefined> {
+	if (seen.has(profile)) {
+		throw new AIError.AwsCredentialsError(`AWS profile role chain contains a cycle at '${profile}'.`, "profile");
+	}
+	seen.add(profile);
+
+	// Static credentials live in ~/.aws/credentials; SSO/role config lives in
 	// ~/.aws/config under `[profile foo]`. Merge into a single view.
-	const merged: Record<string, string> = { ...(configIni?.[profile] ?? {}), ...(credentialsIni?.[profile] ?? {}) };
+	const merged: Record<string, string> = {
+		...(ctx.configIni?.[profile] ?? {}),
+		...(ctx.credentialsIni?.[profile] ?? {}),
+	};
 	if (Object.keys(merged).length === 0) return undefined;
+
+	if (merged.role_arn) return assumeRoleFromProfile(profile, merged, ctx, seen);
 
 	if (merged.aws_access_key_id && merged.aws_secret_access_key) {
 		const out: ResolvedCredentials = {
@@ -215,14 +250,156 @@ async function readProfileCredentials(
 	}
 
 	if (merged.sso_account_id && merged.sso_role_name) {
-		return readSsoCredentials(merged, configIni, region, signal, fetchImpl);
+		return readSsoCredentials(merged, ctx.configIni, ctx.region, ctx.signal, ctx.fetchImpl);
 	}
 
 	if (merged.credential_process) {
-		return readCredentialProcess(profile, merged.credential_process, signal);
+		return readCredentialProcess(profile, merged.credential_process, ctx.signal);
 	}
 
 	return undefined;
+}
+
+/**
+ * Resolve base credentials for a `role_arn` profile and exchange them for the
+ * target role. `web_identity_token_file` is a self-contained
+ * AssumeRoleWithWebIdentity; otherwise the base comes from `source_profile`
+ * (recursive) or `credential_source`, followed by an STS `AssumeRole`.
+ */
+async function assumeRoleFromProfile(
+	profile: string,
+	merged: Record<string, string>,
+	ctx: ProfileResolveContext,
+	seen: Set<string>,
+): Promise<ResolvedCredentials> {
+	const roleArn = merged.role_arn;
+	const region = ctx.region;
+
+	if (merged.web_identity_token_file) {
+		return assumeRoleWithWebIdentity(
+			{ roleArn, tokenFile: merged.web_identity_token_file, sessionName: merged.role_session_name },
+			region,
+			ctx.signal,
+			ctx.fetchImpl,
+		);
+	}
+
+	if (merged.mfa_serial) {
+		// MFA-gated roles need an interactive token code, which a non-interactive
+		// resolver cannot supply. Fail with a clear message instead of a confusing
+		// STS AccessDenied.
+		throw new AIError.AwsCredentialsError(
+			`AWS profile '${profile}' requires MFA (mfa_serial), which is not supported for non-interactive credential resolution.`,
+			"profile",
+		);
+	}
+
+	let base: ResolvedCredentials | undefined;
+	if (merged.source_profile) {
+		base = await resolveProfileChain(merged.source_profile, ctx, seen);
+		if (!base) {
+			throw new AIError.AwsCredentialsError(
+				`AWS profile '${profile}' references source_profile '${merged.source_profile}', which has no usable credentials.`,
+				"profile",
+			);
+		}
+	} else if (merged.credential_source) {
+		base = await resolveCredentialSource(merged.credential_source, region, ctx.signal, ctx.fetchImpl);
+		if (!base) {
+			throw new AIError.AwsCredentialsError(
+				`AWS profile '${profile}' credential_source '${merged.credential_source}' produced no credentials.`,
+				"profile",
+			);
+		}
+	} else {
+		throw new AIError.AwsCredentialsError(
+			`AWS profile '${profile}' sets role_arn without source_profile, credential_source, or web_identity_token_file.`,
+			"profile",
+		);
+	}
+
+	return stsAssumeRole(
+		base,
+		roleArn,
+		region,
+		{
+			sessionName: merged.role_session_name,
+			durationSeconds: merged.duration_seconds,
+			externalId: merged.external_id,
+		},
+		ctx.signal,
+		ctx.fetchImpl,
+	);
+}
+
+/** Resolve the base credentials named by a profile `credential_source` directive. */
+async function resolveCredentialSource(
+	source: string,
+	_region: string,
+	signal: AbortSignal | undefined,
+	fetchImpl: FetchImpl,
+): Promise<ResolvedCredentials | undefined> {
+	switch (source) {
+		case "Environment":
+			return readEnvCredentials();
+		case "Ec2InstanceMetadata":
+			return $env.AWS_EC2_METADATA_DISABLED?.toLowerCase() === "true"
+				? undefined
+				: readImdsCredentials(signal, fetchImpl);
+		case "EcsContainer":
+			return readContainerCredentials(signal, fetchImpl);
+		default:
+			throw new AIError.AwsCredentialsError(`Unsupported AWS credential_source '${source}'.`, "profile");
+	}
+}
+
+/**
+ * Exchange base credentials for a target role via STS `AssumeRole`. The request
+ * is SigV4-signed with the base credentials.
+ */
+async function stsAssumeRole(
+	base: ResolvedCredentials,
+	roleArn: string,
+	region: string,
+	opts: { sessionName?: string; durationSeconds?: string; externalId?: string },
+	signal: AbortSignal | undefined,
+	fetchImpl: FetchImpl,
+): Promise<ResolvedCredentials> {
+	const body = new URLSearchParams({
+		Action: "AssumeRole",
+		Version: "2011-06-15",
+		RoleArn: roleArn,
+		RoleSessionName: opts.sessionName || `omp-${process.pid}`,
+	});
+	if (opts.durationSeconds) body.set("DurationSeconds", opts.durationSeconds);
+	if (opts.externalId) body.set("ExternalId", opts.externalId);
+	const payload = new TextEncoder().encode(body.toString());
+	const endpoint = new URL(stsEndpoint(region));
+	const contentType = "application/x-www-form-urlencoded";
+	const signed = await signRequest({
+		method: "POST",
+		host: endpoint.host,
+		path: endpoint.pathname,
+		body: payload,
+		region,
+		service: "sts",
+		credentials: base,
+		headers: { "content-type": contentType },
+	});
+	const response = await fetchImpl(endpoint, {
+		method: "POST",
+		headers: { ...signed, "content-type": contentType },
+		body: payload,
+		signal,
+	});
+	const xml = await response.text();
+	if (!response.ok) {
+		throw new AIError.AwsCredentialsError(
+			`AWS AssumeRole failed: ${response.status} ${xmlTag(xml, "Message") ?? xml.slice(0, 200)}`,
+			"assume-role",
+		);
+	}
+	return parseStsCredentials(xml, "AWS AssumeRole", "assume-role");
 }
 
 interface SsoCachedToken {
@@ -543,6 +720,18 @@ function stsEndpoint(region: string): string {
 	return `https://sts.${region}.${dnsSuffix}/`;
 }
 
+/** Parse `<Credentials>` from an STS AssumeRole/WithWebIdentity XML response. */
+function parseStsCredentials(xml: string, source: string, kind: AIError.AwsCredentialsErrorKind): ResolvedCredentials {
+	const accessKeyId = xmlTag(xml, "AccessKeyId");
+	const secretAccessKey = xmlTag(xml, "SecretAccessKey");
+	const sessionToken = xmlTag(xml, "SessionToken");
+	if (!accessKeyId || !secretAccessKey || !sessionToken) {
+		throw new AIError.AwsCredentialsError(`${source} response is missing credentials.`, kind);
+	}
+	const expiresAt = requireDynamicCredentialExpiration(xmlTag(xml, "Expiration"), source, kind);
+	return { accessKeyId, secretAccessKey, sessionToken, expiresAt };
+}
+
 async function readWebIdentityCredentials(
 	region: string,
 	signal: AbortSignal | undefined,
@@ -551,9 +740,28 @@ async function readWebIdentityCredentials(
 	const tokenFile = $env.AWS_WEB_IDENTITY_TOKEN_FILE;
 	const roleArn = $env.AWS_ROLE_ARN;
 	if (!tokenFile || !roleArn) return undefined;
+	return assumeRoleWithWebIdentity(
+		{ roleArn, tokenFile, sessionName: $env.AWS_ROLE_SESSION_NAME },
+		region,
+		signal,
+		fetchImpl,
+	);
+}
+
+/**
+ * Exchange a web-identity token file for role credentials via STS
+ * `AssumeRoleWithWebIdentity`. Used by the env chain (`AWS_WEB_IDENTITY_TOKEN_FILE`)
+ * and by `role_arn` + `web_identity_token_file` profiles.
+ */
+async function assumeRoleWithWebIdentity(
+	params: { roleArn: string; tokenFile: string; sessionName?: string },
+	region: string,
+	signal: AbortSignal | undefined,
+	fetchImpl: FetchImpl,
+): Promise<ResolvedCredentials> {
 	let token: string;
 	try {
-		token = (await Bun.file(tokenFile).text()).trim();
+		token = (await Bun.file(params.tokenFile).text()).trim();
 	} catch (err) {
 		throw new AIError.AwsCredentialsError(
 			`Unable to read AWS web identity token file: ${String(err)}`,
@@ -569,8 +777,8 @@ async function readWebIdentityCredentials(
 	const body = new URLSearchParams({
 		Action: "AssumeRoleWithWebIdentity",
 		Version: "2011-06-15",
-		RoleArn: roleArn,
-		RoleSessionName: $env.AWS_ROLE_SESSION_NAME || `omp-${process.pid}`,
+		RoleArn: params.roleArn,
+		RoleSessionName: params.sessionName || `omp-${process.pid}`,
 		WebIdentityToken: token,
 	});
 	const response = await fetchImpl(stsEndpoint(region), {
@@ -586,22 +794,7 @@ async function readWebIdentityCredentials(
 			"web-identity",
 		);
 	}
-	const accessKeyId = xmlTag(xml, "AccessKeyId");
-	const secretAccessKey = xmlTag(xml, "SecretAccessKey");
-	const sessionToken = xmlTag(xml, "SessionToken");
-	if (!accessKeyId || !secretAccessKey || !sessionToken) {
-		throw new AIError.AwsCredentialsError(
-			"AWS AssumeRoleWithWebIdentity response is missing credentials.",
-			"web-identity",
-		);
-	}
-	const expiresAt = requireDynamicCredentialExpiration(xmlTag(xml, "Expiration"), "AWS web identity", "web-identity");
-	return {
-		accessKeyId,
-		secretAccessKey,
-		sessionToken,
-		expiresAt,
-	};
+	return parseStsCredentials(xml, "AWS web identity", "web-identity");
 }
 
 // ---------- ECS/container credentials ----------

--- a/packages/ai/src/registry/aws.ts
+++ b/packages/ai/src/registry/aws.ts
@@ -13,14 +13,21 @@ export interface AwsBedrockProviderOptions extends Readonly<Record<string, unkno
 }
 
 function isEc2Host(): boolean {
-	for (const candidate of [
-		"/sys/hypervisor/uuid",
-		"/sys/devices/virtual/dmi/id/product_uuid",
-		"/sys/devices/virtual/dmi/id/board_asset_tag",
-	]) {
+	// Xen instances tag DMI/hypervisor UUIDs with an `ec2` prefix. Nitro instances
+	// (EKS, modern EC2) expose the instance id in board_asset_tag (`i-...`) and
+	// "Amazon EC2" in the DMI vendor fields; cover both so Nitro/EKS hosts aren't
+	// misread as non-EC2 (product_uuid is often mode 0400 and unreadable there).
+	const checks: Array<[path: string, matches: (value: string) => boolean]> = [
+		["/sys/hypervisor/uuid", v => v.startsWith("ec2")],
+		["/sys/devices/virtual/dmi/id/product_uuid", v => v.startsWith("ec2")],
+		["/sys/devices/virtual/dmi/id/board_asset_tag", v => v.startsWith("ec2") || v.startsWith("i-")],
+		["/sys/devices/virtual/dmi/id/sys_vendor", v => v.includes("amazon ec2")],
+		["/sys/devices/virtual/dmi/id/bios_vendor", v => v.includes("amazon ec2")],
+	];
+	for (const [candidate, matches] of checks) {
 		try {
 			const value = fs.readFileSync(candidate, "utf8").trim().toLowerCase();
-			if (value.startsWith("ec2")) return true;
+			if (matches(value)) return true;
 		} catch {
 			// Missing/unreadable DMI metadata means this probe is inconclusive.
 		}

--- a/packages/ai/src/utils/aws-profile.ts
+++ b/packages/ai/src/utils/aws-profile.ts
@@ -78,7 +78,34 @@ export function hasConfiguredAwsProfile(profile?: string): boolean {
 	const configPath = $env.AWS_CONFIG_FILE || path.join(os.homedir(), ".aws", "config");
 	const credentialsIni = readAwsIniSync(credentialsPath);
 	const configIni = shouldLoadAwsSharedConfig(profile) ? readAwsIniSync(configPath) : undefined;
-	const merged = { ...(configIni?.[selectedProfile] ?? {}), ...(credentialsIni?.[selectedProfile] ?? {}) };
+	return profileHasCredentialSource(selectedProfile, credentialsIni, configIni, new Set());
+}
+
+/**
+ * Whether a profile terminates in a usable credential source. Mirrors the
+ * resolver's per-profile dispatch (static keys, SSO, `credential_process`,
+ * `role_arn` chaining) so the availability probe never diverges from what
+ * `resolveAwsCredentials` can actually resolve. `role_arn` chains follow
+ * `source_profile` recursively (cycle-guarded by `seen`); MFA-gated roles are
+ * treated as unusable because non-interactive resolution cannot supply a token.
+ */
+function profileHasCredentialSource(
+	profile: string,
+	credentialsIni: AwsIniFile | undefined,
+	configIni: AwsIniFile | undefined,
+	seen: Set<string>,
+): boolean {
+	if (seen.has(profile)) return false;
+	seen.add(profile);
+	const merged = { ...(configIni?.[profile] ?? {}), ...(credentialsIni?.[profile] ?? {}) };
+	if (merged.role_arn) {
+		if (merged.web_identity_token_file) return true;
+		if (merged.mfa_serial) return false;
+		if (merged.credential_source) return true;
+		if (merged.source_profile)
+			return profileHasCredentialSource(merged.source_profile, credentialsIni, configIni, seen);
+		return false;
+	}
 	if (merged.aws_access_key_id && merged.aws_secret_access_key) return true;
 	if (merged.credential_process) return true;
 	if (!merged.sso_account_id || !merged.sso_role_name) return false;

--- a/packages/ai/src/utils/aws-profile.ts
+++ b/packages/ai/src/utils/aws-profile.ts
@@ -101,7 +101,18 @@ function profileHasCredentialSource(
 	if (merged.role_arn) {
 		if (merged.web_identity_token_file) return true;
 		if (merged.mfa_serial) return false;
-		if (merged.credential_source) return true;
+		if (merged.credential_source) {
+			switch (merged.credential_source) {
+				case "Environment":
+					return !!($env.AWS_ACCESS_KEY_ID && $env.AWS_SECRET_ACCESS_KEY);
+				case "EcsContainer":
+					return !!($env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || $env.AWS_CONTAINER_CREDENTIALS_FULL_URI);
+				case "Ec2InstanceMetadata":
+					return $env.AWS_EC2_METADATA_DISABLED?.toLowerCase() !== "true";
+				default:
+					return false;
+			}
+		}
 		if (merged.source_profile)
 			return profileHasCredentialSource(merged.source_profile, credentialsIni, configIni, seen);
 		return false;

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -128,6 +128,37 @@ describe("resolveAwsCredentials", () => {
 		Bun.env.AWS_SHARED_CREDENTIALS_FILE = sharedPath;
 	}
 
+	async function writeRawConfig(body: string): Promise<void> {
+		const cfg = path.join(tmp, "config");
+		await Bun.write(cfg, body);
+		Bun.env.AWS_CONFIG_FILE = cfg;
+		const sharedPath = path.join(tmp, "credentials");
+		await Bun.write(sharedPath, "");
+		Bun.env.AWS_SHARED_CREDENTIALS_FILE = sharedPath;
+	}
+
+	/** Mock STS: web-identity + AssumeRole exchanges, capturing each request body. */
+	function stsMock(captured: Array<Record<string, string>>): FetchImpl {
+		const decoder = new TextDecoder();
+		return Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				const raw = typeof init?.body === "string" ? init.body : decoder.decode(init?.body as Uint8Array);
+				const params = Object.fromEntries(new URLSearchParams(raw));
+				captured.push(params);
+				const tag = params.Action === "AssumeRoleWithWebIdentity" ? "AssumeRoleWithWebIdentity" : "AssumeRole";
+				const akid = params.Action === "AssumeRoleWithWebIdentity" ? "AKIABASE" : "AKIAFINAL";
+				return new Response(
+					`<${tag}Response><${tag}Result><Credentials>
+						<AccessKeyId>${akid}</AccessKeyId><SecretAccessKey>${akid}-secret</SecretAccessKey>
+						<SessionToken>${akid}-token</SessionToken><Expiration>2099-01-01T00:00:00Z</Expiration>
+					</Credentials></${tag}Result></${tag}Response>`,
+					{ headers: { "content-type": "text/xml" } },
+				);
+			},
+			{ preconnect: fetch.preconnect },
+		);
+	}
+
 	test("parses a Version 1 envelope and honors Expiration", async () => {
 		const script = await writeFixture(
 			"good.js",
@@ -413,5 +444,76 @@ describe("resolveAwsCredentials", () => {
 		await expect(resolveAwsCredentials({ region: "us-east-1", fetch: fetchImpl })).rejects.toThrow(
 			/missing or invalid Expiration/,
 		);
+	});
+
+	test("chains role_arn + source_profile through web identity then AssumeRole", async () => {
+		const tokenPath = path.join(tmp, "sa-token");
+		await Bun.write(tokenPath, "irsa-jwt\n");
+		await writeRawConfig(
+			`[profile irsa]\nrole_arn = arn:aws:iam::111122223333:role/workspace\nweb_identity_token_file = ${tokenPath}\n\n` +
+				`[profile app]\nrole_arn = arn:aws:iam::111122223333:role/user\nrole_session_name = someone@example.com\n` +
+				`source_profile = irsa\nexternal_id = ext-1\nduration_seconds = 1800\n`,
+		);
+		const captured: Array<Record<string, string>> = [];
+
+		const creds = await resolveAwsCredentials({ profile: "app", region: "us-east-1", fetch: stsMock(captured) });
+
+		expect(captured).toHaveLength(2);
+		expect(captured[0].Action).toBe("AssumeRoleWithWebIdentity");
+		expect(captured[0].RoleArn).toBe("arn:aws:iam::111122223333:role/workspace");
+		expect(captured[0].WebIdentityToken).toBe("irsa-jwt");
+		expect(captured[1].Action).toBe("AssumeRole");
+		expect(captured[1].RoleArn).toBe("arn:aws:iam::111122223333:role/user");
+		// role_session_name must survive the second hop for per-user CloudTrail attribution.
+		expect(captured[1].RoleSessionName).toBe("someone@example.com");
+		expect(captured[1].ExternalId).toBe("ext-1");
+		expect(captured[1].DurationSeconds).toBe("1800");
+		expect(creds).toEqual({
+			accessKeyId: "AKIAFINAL",
+			secretAccessKey: "AKIAFINAL-secret",
+			sessionToken: "AKIAFINAL-token",
+			expiresAt: Date.parse("2099-01-01T00:00:00Z"),
+		});
+	});
+
+	test("SigV4-signs the AssumeRole hop with the source profile's credentials", async () => {
+		await writeRawConfig(
+			`[profile base]\naws_access_key_id = AKIASOURCE\naws_secret_access_key = source-secret\n\n` +
+				`[profile role]\nrole_arn = arn:aws:iam::111122223333:role/target\nsource_profile = base\n`,
+		);
+		let authorization: string | null = null;
+		const fetchImpl: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				authorization = new Headers(init?.headers).get("authorization");
+				return new Response(
+					`<AssumeRoleResponse><AssumeRoleResult><Credentials>
+						<AccessKeyId>AKIAROLE</AccessKeyId><SecretAccessKey>role-secret</SecretAccessKey>
+						<SessionToken>role-token</SessionToken><Expiration>2099-01-01T00:00:00Z</Expiration>
+					</Credentials></AssumeRoleResult></AssumeRoleResponse>`,
+					{ headers: { "content-type": "text/xml" } },
+				);
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const creds = await resolveAwsCredentials({ profile: "role", region: "us-east-1", fetch: fetchImpl });
+
+		expect(authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIASOURCE\//);
+		expect(creds.accessKeyId).toBe("AKIAROLE");
+	});
+
+	test("rejects role_arn without a base credential source", async () => {
+		await writeRawConfig(`[profile orphan]\nrole_arn = arn:aws:iam::111122223333:role/target\n`);
+		await expect(resolveAwsCredentials({ profile: "orphan", region: "us-east-1" })).rejects.toThrow(
+			/sets role_arn without source_profile/,
+		);
+	});
+
+	test("detects source_profile cycles", async () => {
+		await writeRawConfig(
+			`[profile a]\nrole_arn = arn:aws:iam::1:role/a\nsource_profile = b\n\n` +
+				`[profile b]\nrole_arn = arn:aws:iam::1:role/b\nsource_profile = a\n`,
+		);
+		await expect(resolveAwsCredentials({ profile: "a", region: "us-east-1" })).rejects.toThrow(/cycle/);
 	});
 });

--- a/packages/ai/test/aws-registry.test.ts
+++ b/packages/ai/test/aws-registry.test.ts
@@ -139,6 +139,57 @@ describe("AWS provider availability", () => {
 		}
 	});
 
+	test("gates role profile credential_source by source readiness", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "aws-registry-credential-source-"));
+		try {
+			const credentialsPath = path.join(tmp, "credentials");
+			const configPath = path.join(tmp, "config");
+			await Bun.write(credentialsPath, "");
+			const baseEnv = {
+				...EMPTY_AWS_ENV,
+				AWS_PROFILE: "default",
+				AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
+				AWS_CONFIG_FILE: configPath,
+				AWS_EC2_METADATA_DISABLED: "true",
+			};
+
+			for (const credentialSource of ["Environment", "EcsContainer", "Ec2InstanceMetadata", "Unknown"]) {
+				await Bun.write(
+					configPath,
+					`[default]\nrole_arn = arn:aws:iam::111122223333:role/user\ncredential_source = ${credentialSource}\n`,
+				);
+				await withEnv(baseEnv, async () => expect(getEnvApiKey("bedrock-mantle")).toBeUndefined());
+			}
+
+			await Bun.write(
+				configPath,
+				"[default]\nrole_arn = arn:aws:iam::111122223333:role/user\ncredential_source = Environment\n",
+			);
+			await withEnv(
+				{ ...baseEnv, AWS_ACCESS_KEY_ID: "AKIAREADY", AWS_SECRET_ACCESS_KEY: "ready-secret" },
+				async () => expect(getEnvApiKey("bedrock-mantle")).toBeDefined(),
+			);
+
+			await Bun.write(
+				configPath,
+				"[default]\nrole_arn = arn:aws:iam::111122223333:role/user\ncredential_source = EcsContainer\n",
+			);
+			await withEnv({ ...baseEnv, AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/test" }, async () =>
+				expect(getEnvApiKey("bedrock-mantle")).toBeDefined(),
+			);
+
+			await Bun.write(
+				configPath,
+				"[default]\nrole_arn = arn:aws:iam::111122223333:role/user\ncredential_source = Ec2InstanceMetadata\n",
+			);
+			await withEnv({ ...baseEnv, AWS_EC2_METADATA_DISABLED: "false" }, async () =>
+				expect(getEnvApiKey("bedrock-mantle")).toBeDefined(),
+			);
+		} finally {
+			await removeWithRetries(tmp);
+		}
+	});
+
 	test("recognizes an explicitly configured EC2 metadata endpoint", async () => {
 		await withEnv(
 			{

--- a/packages/ai/test/aws-registry.test.ts
+++ b/packages/ai/test/aws-registry.test.ts
@@ -86,6 +86,59 @@ describe("AWS provider availability", () => {
 			await removeWithRetries(tmp);
 		}
 	});
+	test("recognizes a role_arn/source_profile role chain", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "aws-registry-chain-"));
+		try {
+			const credentialsPath = path.join(tmp, "credentials");
+			const configPath = path.join(tmp, "config");
+			await Promise.all([
+				Bun.write(credentialsPath, ""),
+				Bun.write(
+					configPath,
+					`[profile irsa]\nrole_arn = arn:aws:iam::111122223333:role/workspace\n` +
+						`web_identity_token_file = /var/run/secrets/token\n\n` +
+						`[default]\nrole_arn = arn:aws:iam::111122223333:role/user\nsource_profile = irsa\n`,
+				),
+			]);
+			await withEnv(
+				{
+					...EMPTY_AWS_ENV,
+					AWS_PROFILE: "default",
+					AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
+					AWS_CONFIG_FILE: configPath,
+					AWS_EC2_METADATA_DISABLED: "true",
+				},
+				async () => expect(getEnvApiKey("bedrock-mantle")).toBeDefined(),
+			);
+		} finally {
+			await removeWithRetries(tmp);
+		}
+	});
+
+	test("ignores a role_arn profile with no resolvable base", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "aws-registry-orphan-role-"));
+		try {
+			const credentialsPath = path.join(tmp, "credentials");
+			const configPath = path.join(tmp, "config");
+			await Promise.all([
+				Bun.write(credentialsPath, ""),
+				Bun.write(configPath, "[default]\nrole_arn = arn:aws:iam::111122223333:role/user\n"),
+			]);
+			await withEnv(
+				{
+					...EMPTY_AWS_ENV,
+					AWS_PROFILE: "default",
+					AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
+					AWS_CONFIG_FILE: configPath,
+					AWS_EC2_METADATA_DISABLED: "true",
+				},
+				async () => expect(getEnvApiKey("bedrock-mantle")).toBeUndefined(),
+			);
+		} finally {
+			await removeWithRetries(tmp);
+		}
+	});
+
 	test("recognizes an explicitly configured EC2 metadata endpoint", async () => {
 		await withEnv(
 			{


### PR DESCRIPTION
## Repro
On a host whose `~/.aws/config` uses profile-based role chaining (the standard EKS/IRSA shape) — `[default]` with `role_arn` + `source_profile = irsa`, chaining to `[profile irsa]` with `role_arn` + `web_identity_token_file`, and `AWS_PROFILE=default` — omp reports "No models available" while `aws sts get-caller-identity`, Claude Code, and OpenCode all work on the same box. Reproduced against the worktree: with that config, `hasAwsCredentialSource()` returns `false`, so `amazon-bedrock` is dropped before any request.

## Cause
The availability probe and the resolver only understood a subset of profile shapes. `hasConfiguredAwsProfile` (`packages/ai/src/utils/aws-profile.ts`) accepted a profile only with static keys, `credential_process`, or SSO. `readProfileCredentials` (`packages/ai/src/providers/aws-credentials.ts`) had no `AssumeRole`/`source_profile` path, and `readWebIdentityCredentials` read `AWS_WEB_IDENTITY_TOKEN_FILE`/`AWS_ROLE_ARN` only from the environment, never from a config profile. Separately, the registry's EC2-host probe (`packages/ai/src/registry/aws.ts` `isEc2Host`) gated IMDS behind a DMI `"ec2"`-prefix heuristic that false-negatives on Nitro/EKS (`product_uuid` is mode 0400, `board_asset_tag` starts with `i-`, `/sys/hypervisor/uuid` absent), making detection stricter than the resolver's unconditional IMDS attempt.

## Fix
- `aws-credentials.ts`: `readProfileCredentials` now delegates to a `resolveProfileChain` that follows `role_arn` profiles — `web_identity_token_file` self-contained `AssumeRoleWithWebIdentity`, `source_profile` recursion (cycle-guarded), and `credential_source` (`Environment`/`Ec2InstanceMetadata`/`EcsContainer`) — then exchanges the base credentials via a SigV4-signed STS `AssumeRole`, honoring `role_session_name`/`duration_seconds`/`external_id`. Web-identity handling was extracted into a shared `assumeRoleWithWebIdentity` + `parseStsCredentials`; MFA-gated roles fail with a clear message (non-interactive resolution cannot supply a token code).
- `aws-profile.ts`: `hasConfiguredAwsProfile` now mirrors that dispatch via `profileHasCredentialSource`, so the availability probe never diverges from what the resolver can actually resolve.
- `registry/aws.ts`: `isEc2Host` recognizes Nitro/EKS DMI markers (`board_asset_tag` instance ids, `Amazon EC2` vendor fields) in addition to the Xen `ec2` UUID prefix.
- `error/aws.ts`: added `profile` and `assume-role` error kinds.
- Tests added for role-chain detection (registry) and resolution (web-identity→AssumeRole ordering, SigV4 base-credential signing, `role_session_name` propagation, missing-base and cycle errors).

Note: this fixes the broken contract (Bedrock undetected on valid role-chain config). The reporter's third point — surfacing an explicit "profile found but unsupported shape" message at registration time instead of the generic "no models" text — is a separate UX change to a maintainer-owned surface and is not included here; resolution-time errors for unsupported shapes were improved.

## Verification
`bun test test/aws-credentials.test.ts test/aws-registry.test.ts test/aws-sigv4.test.ts` → 36 pass, 0 fail. `bun run check` (biome + tsgo) clean. Manually verified end-to-end with a mocked STS: `[default]`(role_arn+source_profile) → `[irsa]`(role_arn+web_identity_token_file) resolves through `AssumeRoleWithWebIdentity` then a SigV4-signed `AssumeRole`, with `RoleSessionName=someone@example.com` preserved on the second hop (per-user CloudTrail attribution intact).

Fixes #8209