### PR TITLE
fix(coding-agent): preserve subagents across shutdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,19 +2,8 @@
 
 ## [Unreleased]
 
-### Added
-
-- Added `/delete` to remove the selected durable BTW thread.
-
-### Changed
-
-- Changed durable BTW knowledge sharing: `shareSummaryWithMain` now publishes a user-approved, source-attributed summary into Main as `btw:summary` inbound context instead of steering Main with a synthetic user message.
-- Changed durable BTW panes to open with the thread rail collapsed by default, provide a `+ New BTW` action that immediately creates a blank thread, and let `/new` omit its first question.
-
 ### Fixed
 
-- Fixed durable BTW panes diverging from Main's transcript rendering: live and completed side turns now use the same tool cards, runtime tool metadata, and streamed-argument decoding.
-- Fixed the durable BTW pane's `New BTW` action to render as a hoverable button, reuse the active blank thread, and delete untouched blank threads when the pane closes.
 - Fixed graceful OMP shutdown marking running subagents as hard-aborted; shutdown now closes their live sessions without tombstoning the transcripts, allowing them to return as parked agents after restart while explicit cancellation remains terminal.
 
 ## [17.2.12] - 2026-08-08

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/delete` to remove the selected durable BTW thread.
+
+### Changed
+
+- Changed durable BTW knowledge sharing: `shareSummaryWithMain` now publishes a user-approved, source-attributed summary into Main as `btw:summary` inbound context instead of steering Main with a synthetic user message.
+- Changed durable BTW panes to open with the thread rail collapsed by default, provide a `+ New BTW` action that immediately creates a blank thread, and let `/new` omit its first question.
+
+### Fixed
+
+- Fixed durable BTW panes diverging from Main's transcript rendering: live and completed side turns now use the same tool cards, runtime tool metadata, and streamed-argument decoding.
+- Fixed the durable BTW pane's `New BTW` action to render as a hoverable button, reuse the active blank thread, and delete untouched blank threads when the pane closes.
+- Fixed graceful OMP shutdown marking running subagents as hard-aborted; shutdown now closes their live sessions without tombstoning the transcripts, allowing them to return as parked agents after restart while explicit cancellation remains terminal.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -5,6 +5,8 @@ const DELIVERY_RETRY_MAX_MS = 30_000;
 const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
+/** AbortSignal reason used only when manager disposal interrupts a running job. */
+export const ASYNC_JOB_MANAGER_SHUTDOWN_REASON = Symbol("async-job-manager-shutdown");
 
 /**
  * Adaptive ("smart") `hub` poll-wait ladder (ms). A tight poll loop climbs
@@ -416,9 +418,13 @@ export class AsyncJobManager {
 	 * (used by `dispose()` to nuke the manager's state).
 	 */
 	cancelAll(filter?: AsyncJobFilter): void {
+		this.#cancelAll(filter);
+	}
+
+	#cancelAll(filter?: AsyncJobFilter, reason?: unknown): void {
 		for (const job of this.getRunningJobs(filter)) {
 			job.status = "cancelled";
-			job.abortController.abort();
+			job.abortController.abort(reason);
 			this.#scheduleEviction(job.id);
 		}
 	}
@@ -584,7 +590,7 @@ export class AsyncJobManager {
 	async dispose(options?: { timeoutMs?: number }): Promise<boolean> {
 		this.#disposed = true;
 		this.#clearEvictionTimers();
-		this.cancelAll();
+		this.#cancelAll(undefined, ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
 		const timeoutMs = Math.max(options?.timeoutMs ?? 3_000, 0);
 		const deadline = Date.now() + timeoutMs;
 		const jobsSettled = await this.#waitForAllUntil(deadline);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3743,9 +3743,14 @@ export class AgentSession {
 		// dead-letter rather than enqueue a follow-up into a disposing session.
 		this.#unregisterAsyncDeliverySink?.();
 		this.#unregisterAsyncDeliverySink = undefined;
-		this.#cancelOwnAsyncJobs();
 		const manager = this.#ownedAsyncJobManager;
-		if (!manager) return;
+		if (!manager) {
+			// Shared managers outlive this session, so cancel only this owner's
+			// jobs as an explicit teardown. The owning session disposes its manager
+			// below, which tags every cancellation as process shutdown.
+			this.#cancelOwnAsyncJobs();
+			return;
+		}
 
 		try {
 			const drained = await manager.dispose({ timeoutMs: 3_000 });

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -9,7 +9,7 @@ import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } fr
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
-import { AsyncJobManager } from "../async";
+import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
 import { ModelRegistry } from "../config/model-registry";
 import {
@@ -895,7 +895,7 @@ export function createSubagentSettings(
 	);
 }
 
-export type AbortReason = "signal" | "terminate" | "timeout" | "budget";
+export type AbortReason = "signal" | "shutdown" | "terminate" | "timeout" | "budget";
 
 const MAX_YIELD_TOOL_ERRORS = 6;
 
@@ -1158,7 +1158,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		signal.addEventListener(
 			"abort",
 			() => {
-				if (!resolved) requestAbort("signal");
+				if (!resolved) requestAbort(signal.reason === ASYNC_JOB_MANAGER_SHUTDOWN_REASON ? "shutdown" : "signal");
 			},
 			{ once: true, signal: listenerSignal },
 		);
@@ -1184,6 +1184,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 
 	const resolveSignalAbortReason = (): string => {
 		const reason = signal?.reason;
+		if (reason === ASYNC_JOB_MANAGER_SHUTDOWN_REASON) return "OMP shutdown interrupted the running subagent";
 		if (reason instanceof Error) {
 			const message = reason.message.trim();
 			if (message.length > 0) return message;
@@ -1751,7 +1752,11 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		runtimeLimitExceeded: () => runtimeLimitExceeded,
 		terminalError: () => terminalError,
 		hasExplicitAbortReason: () =>
-			abortReason === "signal" || runtimeLimitExceeded || budgetLimitExceeded || budgetStopRequested,
+			abortReason === "signal" ||
+			abortReason === "shutdown" ||
+			runtimeLimitExceeded ||
+			budgetLimitExceeded ||
+			budgetStopRequested,
 		budgetStopRequested: () => budgetStopRequested,
 		waitForBudgetStop: () => budgetStopAbortPromise ?? Promise.resolve(),
 		yieldInvalidatedByAsync: () => yieldInvalidatedByAsync,
@@ -1777,7 +1782,11 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		// the lifecycle can park the agent as resumable instead of killing it.
 		abortKind: () => abortReason ?? (budgetStopRequested ? "budget" : undefined),
 		isAbortedRun: () =>
-			abortReason === "signal" || runtimeLimitExceeded || budgetLimitExceeded || abortReason === undefined,
+			abortReason === "signal" ||
+			abortReason === "shutdown" ||
+			runtimeLimitExceeded ||
+			budgetLimitExceeded ||
+			abortReason === undefined,
 		requestAbort,
 		failWithError,
 		abortActiveSession,
@@ -2416,8 +2425,17 @@ export async function finalizeSubagentLifecycle(args: {
 		}
 	};
 
-	// A budget abort leaves a consistent session with its transcript on disk;
-	// caller signals, wall-clock timeouts (possible stream hang), and internal
+	// Process shutdown stops the live session and drops its in-memory ref, but
+	// deliberately leaves the transcript without a tombstone. The next process
+	// scan can therefore restore it as parked.
+	if (args.aborted && args.abortKind === "shutdown") {
+		await disposeSession();
+		if (ref && ownsRef) registry.unregister(args.id, ref);
+		return;
+	}
+
+	// A budget abort leaves a consistent live session that can keep serving IRC.
+	// Caller signals, wall-clock timeouts (possible stream hang), and internal
 	// terminations are genuine kills and stay terminal.
 	const resumableAbort =
 		args.abortKind === "budget" && args.keepAlive && !args.isolated && args.reviveSession !== null;

--- a/packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts
+++ b/packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
-import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
@@ -90,6 +90,33 @@ describe("AsyncJobManager singleton across concurrent top-level sessions", () =>
 		// Once the owning primary session disposes the singleton clears, matching
 		// the documented single-owner invariant.
 		expect(AsyncJobManager.instance()).toBeUndefined();
+	}, 60000);
+
+	it("classifies jobs interrupted by owning-session disposal as shutdown", async () => {
+		const session = await spawnTopLevelSession();
+		const manager = AsyncJobManager.instance();
+		expect(manager).toBeDefined();
+		const started = Promise.withResolvers<void>();
+		let abortReason: unknown;
+		manager!.register(
+			"task",
+			"running subagent",
+			async ({ signal }) => {
+				const aborted = Promise.withResolvers<void>();
+				signal.addEventListener("abort", () => aborted.resolve(), { once: true });
+				started.resolve();
+				if (signal.aborted) aborted.resolve();
+				await aborted.promise;
+				abortReason = signal.reason;
+				return "stopped";
+			},
+			{ ownerId: "Main" },
+		);
+
+		await started.promise;
+		await session.dispose();
+
+		expect(abortReason).toBe(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
 	}, 60000);
 
 	it("does not cancel the primary session's running jobs when a secondary session disposes", async () => {

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
@@ -7,12 +9,13 @@ import { RpcSubagentRegistry } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-sub
 import type { RpcSubagentFrame } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/persisted-agents";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { resolveSoftRequestBudget, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
-import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { AgentDefinition, SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -336,6 +339,46 @@ describe("runSubprocess soft request budget", () => {
 		await revivedTerminal;
 		expectRpcTurn();
 		rpcRegistry.dispose();
+	});
+
+	it("manager shutdown closes a running agent without tombstoning its resumable transcript", async () => {
+		const id = "ShutdownScout";
+		const manager = new AsyncJobManager({});
+		const shutdownStarted = Promise.withResolvers<void>();
+		const parentSessionFile = path.join(tempDir.path(), "main.jsonl");
+		let disposePromise: Promise<boolean> | undefined;
+		let result: SingleResult | undefined;
+		const handle = createMockSession(({ promptIndex, emit, pushMessage }) => {
+			if (promptIndex !== 1) return;
+			const message = assistantText("working");
+			pushMessage(message);
+			emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+			disposePromise = manager.dispose();
+			shutdownStarted.resolve();
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		manager.register("task", id, async ({ signal }) => {
+			result = await runSubprocess({
+				...baseOptions(id),
+				artifactsDir: parentSessionFile.slice(0, -6),
+				signal,
+			});
+			return result.output;
+		});
+		await shutdownStarted.promise;
+		expect(await disposePromise).toBe(true);
+
+		expect(result?.aborted).toBe(true);
+		expect(AgentRegistry.global().get(id)).toBeUndefined();
+		expect(AgentLifecycleManager.global().has(id)).toBe(false);
+		expect(handle.disposeCalls()).toBeGreaterThanOrEqual(1);
+
+		AgentLifecycleManager.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+		await registerPersistedSubagents(AgentRegistry.global(), parentSessionFile);
+		expect(AgentRegistry.global().get(id)?.status).toBe("parked");
 	});
 
 	it("a caller-signal abort stays terminal and irc names the aborted agent precisely", async () => {


### PR DESCRIPTION
## What

- Tag `AsyncJobManager` disposal with a dedicated shutdown abort reason.
- Propagate shutdown separately from caller cancellation through the task executor.
- Dispose and unregister shutdown-interrupted subagents without persisting a terminal tombstone, allowing their transcripts to rehydrate as `parked` after restart.
- Preserve terminal `aborted` behavior for explicit cancellation, timeouts, and internal termination.

## Why

Owning `AgentSession.dispose()` previously cancelled running async jobs through the same signal path as an explicit caller abort. `finalizeSubagentLifecycle()` therefore persisted a hard-kill tombstone, and resumed sessions could no longer revive or message the interrupted subagent.

Fixes #8216.

## Testing

- `bun test packages/coding-agent/test/async-job-manager.test.ts packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts packages/coding-agent/test/task/executor-soft-budget.test.ts packages/coding-agent/test/registry/agent-lifecycle.test.ts packages/coding-agent/test/tools/irc.test.ts` — 109 pass, 0 fail
- `bun check`
- `omp --smoke-test`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)