### PR TITLE
fix(agent): park subagents on shutdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed handled OMP shutdown persisting running subagents as terminally aborted instead of restoring their transcripts as parked and revivable. ([#8216](https://github.com/can1357/oh-my-pi/issues/8216))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -5,6 +5,8 @@ const DELIVERY_RETRY_MAX_MS = 30_000;
 const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
+/** Abort reason used only when the owning session shuts down the entire manager. */
+export const ASYNC_JOB_MANAGER_SHUTDOWN_REASON = Symbol("AsyncJobManager shutdown");
 
 /**
  * Adaptive ("smart") `hub` poll-wait ladder (ms). A tight poll loop climbs
@@ -416,9 +418,13 @@ export class AsyncJobManager {
 	 * (used by `dispose()` to nuke the manager's state).
 	 */
 	cancelAll(filter?: AsyncJobFilter): void {
+		this.#cancelJobs(filter);
+	}
+
+	#cancelJobs(filter?: AsyncJobFilter, reason?: unknown): void {
 		for (const job of this.getRunningJobs(filter)) {
 			job.status = "cancelled";
-			job.abortController.abort();
+			job.abortController.abort(reason);
 			this.#scheduleEviction(job.id);
 		}
 	}
@@ -584,7 +590,7 @@ export class AsyncJobManager {
 	async dispose(options?: { timeoutMs?: number }): Promise<boolean> {
 		this.#disposed = true;
 		this.#clearEvictionTimers();
-		this.cancelAll();
+		this.#cancelJobs(undefined, ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
 		const timeoutMs = Math.max(options?.timeoutMs ?? 3_000, 0);
 		const deadline = Date.now() + timeoutMs;
 		const jobsSettled = await this.#waitForAllUntil(deadline);

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -416,9 +416,14 @@ export class AsyncJobManager {
 	 * Cancel running jobs. With `filter.ownerId` set, cancels only jobs the
 	 * matching agent registered; with no filter, cancels every running job
 	 * (used by `dispose()` to nuke the manager's state).
+	 *
+	 * `reason` is forwarded to each job's `AbortController.abort`, so a session
+	 * teardown can tag its owned jobs with {@link ASYNC_JOB_MANAGER_SHUTDOWN_REASON}
+	 * before `dispose()` runs — the task executor reads it to park (not
+	 * tombstone) a subagent interrupted purely by process shutdown.
 	 */
-	cancelAll(filter?: AsyncJobFilter): void {
-		this.#cancelJobs(filter);
+	cancelAll(filter?: AsyncJobFilter, reason?: unknown): void {
+		this.#cancelJobs(filter, reason);
 	}
 
 	#cancelJobs(filter?: AsyncJobFilter, reason?: unknown): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3743,10 +3743,14 @@ export class AgentSession {
 		// dead-letter rather than enqueue a follow-up into a disposing session.
 		this.#unregisterAsyncDeliverySink?.();
 		this.#unregisterAsyncDeliverySink = undefined;
-		// Process shutdown, not an explicit kill: tag owned jobs so the task
-		// executor parks (rather than tombstones) any subagent interrupted here.
-		this.#cancelOwnAsyncJobs(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
 		const manager = this.#ownedAsyncJobManager;
+		// The shutdown reason is reserved for the top-level session that OWNS the
+		// manager — the genuine process/handled-shutdown path — so the task
+		// executor parks (rather than tombstones) interrupted subagents. A
+		// subagent session dispose (e.g. `release({ tombstone: true })` during an
+		// explicit hard kill) leaves `#ownedAsyncJobManager` undefined and must
+		// propagate a generic cancellation so its nested children stay terminal.
+		this.#cancelOwnAsyncJobs(manager ? ASYNC_JOB_MANAGER_SHUTDOWN_REASON : undefined);
 		if (!manager) return;
 
 		try {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -98,7 +98,7 @@ import {
 	withTimeout,
 } from "@oh-my-pi/pi-utils";
 import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
-import { type AsyncJob, AsyncJobManager } from "../async";
+import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, type AsyncJob, AsyncJobManager } from "../async";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
 import type { ResolvedModelRoleValue } from "../config/model-resolver";
@@ -1783,10 +1783,10 @@ export class AgentSession {
 	 *
 	 * No-op when no manager is reachable or this session has no agent id.
 	 */
-	#cancelOwnAsyncJobs(): void {
+	#cancelOwnAsyncJobs(reason?: unknown): void {
 		if (!this.#agentId) return;
 		const manager = this.#asyncJobManager;
-		manager?.cancelAll({ ownerId: this.#agentId });
+		manager?.cancelAll({ ownerId: this.#agentId }, reason);
 		manager?.evictCompletedJobs({ ownerId: this.#agentId });
 		// Invalidate this owner's in-flight/drained deliveries against the new
 		// generation, then drop any async-result follow-up already queued, so a
@@ -3743,7 +3743,9 @@ export class AgentSession {
 		// dead-letter rather than enqueue a follow-up into a disposing session.
 		this.#unregisterAsyncDeliverySink?.();
 		this.#unregisterAsyncDeliverySink = undefined;
-		this.#cancelOwnAsyncJobs();
+		// Process shutdown, not an explicit kill: tag owned jobs so the task
+		// executor parks (rather than tombstones) any subagent interrupted here.
+		this.#cancelOwnAsyncJobs(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
 		const manager = this.#ownedAsyncJobManager;
 		if (!manager) return;
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -9,7 +9,7 @@ import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } fr
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
-import { AsyncJobManager } from "../async";
+import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
 import { ModelRegistry } from "../config/model-registry";
 import {
@@ -895,7 +895,7 @@ export function createSubagentSettings(
 	);
 }
 
-export type AbortReason = "signal" | "terminate" | "timeout" | "budget";
+export type AbortReason = "signal" | "shutdown" | "terminate" | "timeout" | "budget";
 
 const MAX_YIELD_TOOL_ERRORS = 6;
 
@@ -1158,7 +1158,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		signal.addEventListener(
 			"abort",
 			() => {
-				if (!resolved) requestAbort("signal");
+				if (!resolved) requestAbort(signal.reason === ASYNC_JOB_MANAGER_SHUTDOWN_REASON ? "shutdown" : "signal");
 			},
 			{ once: true, signal: listenerSignal },
 		);
@@ -1183,6 +1183,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	}
 
 	const resolveSignalAbortReason = (): string => {
+		if (signal?.reason === ASYNC_JOB_MANAGER_SHUTDOWN_REASON) return "Async job manager shutdown";
 		const reason = signal?.reason;
 		if (reason instanceof Error) {
 			const message = reason.message.trim();
@@ -1751,7 +1752,11 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		runtimeLimitExceeded: () => runtimeLimitExceeded,
 		terminalError: () => terminalError,
 		hasExplicitAbortReason: () =>
-			abortReason === "signal" || runtimeLimitExceeded || budgetLimitExceeded || budgetStopRequested,
+			abortReason === "signal" ||
+			abortReason === "shutdown" ||
+			runtimeLimitExceeded ||
+			budgetLimitExceeded ||
+			budgetStopRequested,
 		budgetStopRequested: () => budgetStopRequested,
 		waitForBudgetStop: () => budgetStopAbortPromise ?? Promise.resolve(),
 		yieldInvalidatedByAsync: () => yieldInvalidatedByAsync,
@@ -1777,7 +1782,11 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		// the lifecycle can park the agent as resumable instead of killing it.
 		abortKind: () => abortReason ?? (budgetStopRequested ? "budget" : undefined),
 		isAbortedRun: () =>
-			abortReason === "signal" || runtimeLimitExceeded || budgetLimitExceeded || abortReason === undefined,
+			abortReason === "signal" ||
+			abortReason === "shutdown" ||
+			runtimeLimitExceeded ||
+			budgetLimitExceeded ||
+			abortReason === undefined,
 		requestAbort,
 		failWithError,
 		abortActiveSession,
@@ -2416,23 +2425,37 @@ export async function finalizeSubagentLifecycle(args: {
 		}
 	};
 
-	// A budget abort leaves a consistent session with its transcript on disk;
-	// caller signals, wall-clock timeouts (possible stream hang), and internal
+	// A budget abort leaves a consistent session with its transcript on disk.
+	// Manager shutdown also preserves the transcript, but disposes and unregisters
+	// the process-local session. Caller signals, wall-clock timeouts, and internal
 	// terminations are genuine kills and stay terminal.
 	const resumableAbort =
 		args.abortKind === "budget" && args.keepAlive && !args.isolated && args.reviveSession !== null;
 	if (args.aborted && !resumableAbort) {
 		if (ref && ownsRef) {
-			// Route hard kills through the lifecycle owner so the terminal
-			// decision is durable and a restart cannot rediscover the transcript
-			// as a revivable parked agent.
-			try {
-				await AgentLifecycleManager.global().release(args.id, ref, { tombstone: true });
-			} catch (error) {
-				logger.warn("runSubagent: failed to persist kill tombstone", { id: args.id, error: String(error) });
-				registry.setStatus(args.id, "aborted", ref);
-				registry.detachSession(args.id, ref);
-				await disposeSession();
+			if (args.abortKind === "shutdown") {
+				try {
+					await AgentLifecycleManager.global().release(args.id, ref);
+				} catch (error) {
+					logger.warn("runSubagent: failed to release session during manager shutdown", {
+						id: args.id,
+						error: String(error),
+					});
+					await disposeSession();
+					registry.unregister(args.id, ref);
+				}
+			} else {
+				// Route hard kills through the lifecycle owner so the terminal
+				// decision is durable and a restart cannot rediscover the transcript
+				// as a revivable parked agent.
+				try {
+					await AgentLifecycleManager.global().release(args.id, ref, { tombstone: true });
+				} catch (error) {
+					logger.warn("runSubagent: failed to persist kill tombstone", { id: args.id, error: String(error) });
+					registry.setStatus(args.id, "aborted", ref);
+					registry.detachSession(args.id, ref);
+					await disposeSession();
+				}
 			}
 		} else {
 			await disposeSession();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1095,7 +1095,21 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			budgetLimitExceeded = true;
 		}
 		if (abortSent) {
-			if (reason === "signal" && abortReason !== "signal" && abortReason !== "timeout") {
+			// Shutdown is a superseding external abort: a process teardown that
+			// races a self-inflicted budget hard-abort must still follow the
+			// shutdown release path (dispose + unregister) instead of the
+			// budget-resumable path, which would leave the subagent adopted and
+			// alive past AgentLifecycleManager.dispose(). Genuine kills
+			// (signal/timeout/terminate) already dispose terminally, and shutdown
+			// is never downgraded back to signal.
+			if (reason === "shutdown" && abortReason === "budget") {
+				abortReason = "shutdown";
+			} else if (
+				reason === "signal" &&
+				abortReason !== "signal" &&
+				abortReason !== "timeout" &&
+				abortReason !== "shutdown"
+			) {
 				abortReason = "signal";
 			}
 			return;

--- a/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
@@ -60,6 +60,33 @@ describe("AgentSession concurrent disposal", () => {
 		});
 		return session;
 	}
+
+	it("marks owned async job cancellation as manager shutdown", async () => {
+		const owned = new AsyncJobManager({ maxRunningJobs: 1 });
+		const started = Promise.withResolvers<void>();
+		let abortReason: unknown;
+		owned.register("task", "running subagent", async ({ signal }) => {
+			const aborted = Promise.withResolvers<void>();
+			signal.addEventListener(
+				"abort",
+				() => {
+					abortReason = signal.reason;
+					aborted.resolve();
+				},
+				{ once: true },
+			);
+			started.resolve();
+			await aborted.promise;
+			return "stopped";
+		});
+		const current = createSession(owned);
+
+		await started.promise;
+		await current.dispose();
+		session = undefined;
+
+		expect(abortReason).toBe(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
+	});
 
 	it("starts independent writers together and closes persistence after their barrier", async () => {
 		const owned = new AsyncJobManager({ maxRunningJobs: 1, retentionMs: 1_000, onJobComplete: () => {} });

--- a/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
@@ -41,7 +41,10 @@ describe("AgentSession concurrent disposal", () => {
 		tempDir.removeSync();
 	});
 
-	function createSession(ownedAsyncJobManager?: AsyncJobManager): AgentSession {
+	function createSession(
+		ownedAsyncJobManager?: AsyncJobManager,
+		options?: { agentId?: string; asyncJobManager?: AsyncJobManager },
+	): AgentSession {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("expected bundled model");
 		const mock = createMockModel({ handler: () => ({ content: ["ok"] }) });
@@ -56,7 +59,8 @@ describe("AgentSession concurrent disposal", () => {
 			settings: Settings.isolated(),
 			modelRegistry: new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml")),
 			ownedAsyncJobManager,
-			agentId: "Main",
+			asyncJobManager: options?.asyncJobManager,
+			agentId: options?.agentId ?? "Main",
 		});
 		return session;
 	}
@@ -95,6 +99,44 @@ describe("AgentSession concurrent disposal", () => {
 		session = undefined;
 
 		expect(abortReason).toBe(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
+	});
+
+	it("propagates a generic cancellation for a subagent dispose so nested children stay terminal", async () => {
+		// A subagent session leaves `ownedAsyncJobManager` undefined and inherits
+		// the shared manager. Its dispose (e.g. `release({ tombstone: true })`
+		// during an explicit hard kill) must NOT tag its owned jobs as shutdown,
+		// or nested children would be rediscovered as parked instead of terminal.
+		const shared = new AsyncJobManager({ maxRunningJobs: 1 });
+		const started = Promise.withResolvers<void>();
+		let abortReason: unknown;
+		shared.register(
+			"task",
+			"nested child",
+			async ({ signal }) => {
+				const aborted = Promise.withResolvers<void>();
+				signal.addEventListener(
+					"abort",
+					() => {
+						abortReason = signal.reason;
+						aborted.resolve();
+					},
+					{ once: true },
+				);
+				started.resolve();
+				await aborted.promise;
+				return "stopped";
+			},
+			{ ownerId: "Sub", agentId: "NestedChild" },
+		);
+		const current = createSession(undefined, { agentId: "Sub", asyncJobManager: shared });
+
+		await started.promise;
+		await current.dispose();
+		session = undefined;
+
+		expect(abortReason).not.toBe(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
+		expect(abortReason).toBeInstanceOf(DOMException);
+		await shared.dispose({ timeoutMs: 1_000 });
 	});
 
 	it("starts independent writers together and closes persistence after their barrier", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
@@ -61,24 +61,33 @@ describe("AgentSession concurrent disposal", () => {
 		return session;
 	}
 
-	it("marks owned async job cancellation as manager shutdown", async () => {
+	it("tags an owner's jobs with the shutdown reason before disposing the manager", async () => {
+		// Regression: `#disposeOwnedAsyncJobs` pre-cancels the owner's jobs via
+		// `#cancelOwnAsyncJobs` BEFORE `manager.dispose()`. If that pre-cancel
+		// dropped the shutdown reason, the owned subagent job saw a generic
+		// caller signal and was tombstoned instead of parked.
 		const owned = new AsyncJobManager({ maxRunningJobs: 1 });
 		const started = Promise.withResolvers<void>();
 		let abortReason: unknown;
-		owned.register("task", "running subagent", async ({ signal }) => {
-			const aborted = Promise.withResolvers<void>();
-			signal.addEventListener(
-				"abort",
-				() => {
-					abortReason = signal.reason;
-					aborted.resolve();
-				},
-				{ once: true },
-			);
-			started.resolve();
-			await aborted.promise;
-			return "stopped";
-		});
+		owned.register(
+			"task",
+			"running subagent",
+			async ({ signal }) => {
+				const aborted = Promise.withResolvers<void>();
+				signal.addEventListener(
+					"abort",
+					() => {
+						abortReason = signal.reason;
+						aborted.resolve();
+					},
+					{ once: true },
+				);
+				started.resolve();
+				await aborted.promise;
+				return "stopped";
+			},
+			{ ownerId: "Main", agentId: "Sub" },
+		);
 		const current = createSession(owned);
 
 		await started.promise;

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
@@ -342,6 +342,52 @@ describe("runSubprocess soft request budget", () => {
 		await revivedTerminal;
 		expectRpcTurn();
 		rpcRegistry.dispose();
+	});
+
+	it("a shutdown racing a budget hard-abort follows the shutdown release path", async () => {
+		// Regression: a process shutdown that lands right after the soft-budget
+		// grace hard-aborts must supersede the budget reason, so the subagent is
+		// released (disposed + unregistered, restorable as parked) instead of
+		// being left adopted and alive past AgentLifecycleManager.dispose().
+		const id = "RacedScout";
+		const rootSessionFile = `${tempDir.path()}/main.jsonl`;
+		const workerSessionFile = `${tempDir.path()}/main/${id}.jsonl`;
+		await Bun.write(rootSessionFile, "");
+		await Bun.write(workerSessionFile, "");
+		const controller = new AbortController();
+		// abort #1 = budget soft-stop (abortSent still false); abort #2 =
+		// budget hard-abort's abortActiveSession (abortReason already "budget").
+		// Fire the shutdown only on #2 so it must supersede the budget reason.
+		let abortInvocations = 0;
+		const handle = createMockSession(
+			({ promptIndex, emit, pushMessage }) => {
+				if (promptIndex !== 1) return;
+				// Never yields: budget 2 → stop at 3, grace exhausted at 8.
+				for (let i = 1; i <= 8; i++) {
+					const message = assistantText(`burning request ${i}`);
+					pushMessage(message);
+					emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+				}
+			},
+			() => {
+				abortInvocations += 1;
+				if (abortInvocations >= 2 && !controller.signal.aborted) {
+					controller.abort(ASYNC_JOB_MANAGER_SHUTDOWN_REASON);
+				}
+			},
+		);
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session, workerSessionFile);
+
+		const result = await runSubprocess({ ...baseOptions(id), signal: controller.signal });
+
+		expect(result.aborted).toBe(true);
+		expect(AgentRegistry.global().get(id)).toBeUndefined();
+		expect(handle.disposeCalls()).toBeGreaterThanOrEqual(1);
+		expect(await Bun.file(`${workerSessionFile}.tombstone`).exists()).toBe(false);
+		const restored = new AgentRegistry();
+		await registerPersistedSubagents(restored, rootSessionFile);
+		expect(restored.get(id)?.status).toBe("parked");
 	});
 
 	it("manager shutdown restores a running kept-alive agent as parked without a tombstone", async () => {

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
@@ -7,6 +8,7 @@ import { RpcSubagentRegistry } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-sub
 import type { RpcSubagentFrame } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/persisted-agents";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -46,7 +48,8 @@ function createMockSession(
 		promptIndex: number;
 		emit: (event: AgentSessionEvent) => void;
 		pushMessage: (message: unknown) => void;
-	}) => void,
+	}) => void | Promise<void>,
+	onAbort?: () => void | Promise<void>,
 ): MockSessionHandle {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const messages: unknown[] = [];
@@ -81,7 +84,7 @@ function createMockSession(
 		prompt: async (text: string, options?: PromptOptions) => {
 			promptIndex += 1;
 			prompts.push({ text, options });
-			onPrompt({ promptIndex, emit, pushMessage: message => messages.push(message) });
+			await onPrompt({ promptIndex, emit, pushMessage: message => messages.push(message) });
 			return true;
 		},
 		waitForIdle: async () => {},
@@ -132,6 +135,7 @@ function createMockSession(
 		},
 		abort: async () => {
 			abortCount += 1;
+			await onAbort?.();
 		},
 		dispose: async () => {
 			disposeCount += 1;
@@ -169,12 +173,14 @@ describe("runSubprocess soft request budget", () => {
 	beforeEach(() => {
 		AgentRegistry.resetGlobalForTests();
 		AgentLifecycleManager.resetGlobalForTests();
+		AsyncJobManager.resetForTests();
 		tempDir = TempDir.createSync("@pi-soft-budget-");
 	});
 	afterEach(() => {
 		vi.restoreAllMocks();
 		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
+		AsyncJobManager.resetForTests();
 		tempDir[Symbol.dispose]();
 	});
 
@@ -193,13 +199,13 @@ describe("runSubprocess soft request budget", () => {
 		};
 	}
 
-	function registerRunning(id: string, session: AgentSession) {
+	function registerRunning(id: string, session: AgentSession, sessionFile: string | null = null) {
 		AgentRegistry.global().register({
 			id,
 			displayName: id,
 			kind: "sub",
 			session,
-			sessionFile: null,
+			sessionFile,
 			status: "running",
 		});
 	}
@@ -336,6 +342,47 @@ describe("runSubprocess soft request budget", () => {
 		await revivedTerminal;
 		expectRpcTurn();
 		rpcRegistry.dispose();
+	});
+
+	it("manager shutdown restores a running kept-alive agent as parked without a tombstone", async () => {
+		const id = "ShutdownScout";
+		const rootSessionFile = `${tempDir.path()}/main.jsonl`;
+		const workerSessionFile = `${tempDir.path()}/main/${id}.jsonl`;
+		await Bun.write(rootSessionFile, "");
+		await Bun.write(workerSessionFile, "");
+		const promptStarted = Promise.withResolvers<void>();
+		const promptStopped = Promise.withResolvers<void>();
+		const handle = createMockSession(
+			async ({ promptIndex }) => {
+				if (promptIndex !== 1) return;
+				promptStarted.resolve();
+				await promptStopped.promise;
+			},
+			() => promptStopped.resolve(),
+		);
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session, workerSessionFile);
+		const manager = new AsyncJobManager({ maxRunningJobs: 1 });
+		AsyncJobManager.setInstance(manager);
+		manager.register(
+			"task",
+			"shutdown regression",
+			async ({ signal }) => {
+				const result = await runSubprocess({ ...baseOptions(id), signal });
+				return result.output;
+			},
+			{ ownerId: "Main", agentId: id },
+		);
+
+		await promptStarted.promise;
+		await manager.dispose({ timeoutMs: 1_000 });
+		AsyncJobManager.setInstance(undefined);
+
+		expect(await Bun.file(`${workerSessionFile}.tombstone`).exists()).toBe(false);
+		expect(AgentRegistry.global().get(id)).toBeUndefined();
+		const restoredRegistry = new AgentRegistry();
+		await registerPersistedSubagents(restoredRegistry, rootSessionFile);
+		expect(restoredRegistry.get(id)?.status).toBe("parked");
 	});
 
 	it("a caller-signal abort stays terminal and irc names the aborted agent precisely", async () => {


### PR DESCRIPTION
## Repro
Disposing an owning `AsyncJobManager` while a kept-alive task is running reproduces the handled OMP shutdown path: `bun test packages/coding-agent/test/task/executor-soft-budget.test.ts` previously created `<child>.jsonl.tombstone` and failed the parked-recovery assertion with `Expected: false, Received: true`.

## Cause
`AsyncJobManager.dispose()` in `packages/coding-agent/src/async/job-manager.ts` aborted every job without a distinct reason. `createSubagentRunMonitor()` in `packages/coding-agent/src/task/executor.ts` therefore classified owner shutdown as a caller signal, and `finalizeSubagentLifecycle()` persisted the same terminal tombstone used for explicit kills.

## Fix
- Mark manager-wide disposal with an identity-stable shutdown abort reason while leaving explicit `cancel`/`cancelAll` behavior unchanged.
- Propagate that reason as the `shutdown` task abort kind and release its live registry ref without writing a tombstone.
- Cover owning-session disposal, no-tombstone restart recovery to `parked`, and the existing explicit-cancellation terminal path.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/task/executor-soft-budget.test.ts packages/coding-agent/test/agent-session-dispose-concurrent.test.ts packages/coding-agent/test/registry/agent-lifecycle.test.ts` — 36 passed, 0 failed. `bun --cwd=packages/coding-agent run check` — passed.

Fixes #8216