### PR TITLE
feat(coding-agent): preview pasted images in prompt

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -675,6 +675,7 @@ tui:
 | `statusLine.transparent`    | boolean | `false`          | Use the terminal background for the status line.                          |
 | `statusLine.showHookStatus` | boolean | `true`           | Show hook status messages.                                                |
 | `terminal.showImages`       | boolean | `true`           | Render images inline (when the terminal supports it).                     |
+| `tui.pastedImagePreview`    | boolean | `false`          | Preview the latest pasted image inside the prompt composer.               |
 | `images.autoResize`         | boolean | `true`           | Resize large images for model compatibility.                              |
 | `images.blockImages`        | boolean | `false`          | Never send images to providers.                                           |
 | `tui.hyperlinks`            | enum    | `auto`           | `off`, `auto`, `always`.                                                  |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in previews for pasted images inside the prompt composer on graphics-capable terminals via `tui.pastedImagePreview`. ([#1628](https://github.com/can1357/oh-my-pi/issues/1628))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -843,6 +843,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tui.pastedImagePreview": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Images",
+			label: "Preview Pasted Images",
+			description: "Show the most recently pasted image above the prompt while it is attached",
+			condition: "hasImageProtocol",
+		},
+	},
+
 	"images.autoResize": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -507,6 +507,7 @@ class PendingImagePreview implements Component {
 				{
 					budget: this.#budget,
 					imageKey,
+					countTowardsBudget: false,
 					maxWidthCells: COMPOSER_IMAGE_PREVIEW_MAX_COLUMNS,
 					maxHeightCells: this.#maxImageRows,
 				},

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -2,17 +2,23 @@ import { fileURLToPath } from "node:url";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import {
 	addKeyAliases,
+	type Component,
 	canonicalKeyId,
 	Editor,
 	type EditorTheme,
+	Image,
+	type ImageBudget,
+	ImageProtocol,
 	type KeyId,
 	parseKey,
 	parseKittySequence,
+	TERMINAL,
 	TUI,
 } from "@oh-my-pi/pi-tui";
 import { BracketedPasteHandler } from "@oh-my-pi/pi-tui/bracketed-paste";
 import type { AppKeybinding } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
+import { convertImageToPng } from "../../utils/image-loading";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
 import { hasMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
 import { isQueuedMessageList, parseQueueShorthand, QUEUE_LIST_MARKER_RE } from "../queue-input";
@@ -376,15 +382,161 @@ function isEditorTheme(value: unknown): value is EditorTheme {
 	);
 }
 
+const COMPOSER_IMAGE_PREVIEW_MAX_COLUMNS = 28;
+const COMPOSER_IMAGE_PREVIEW_MAX_ROWS = 6;
+let nextComposerImagePreviewKey = 0;
+
+/**
+ * Ephemeral preview of the most recently attached draft image.
+ *
+ * A single bounded preview keeps the composer compact when a prompt has several
+ * attachments; the editor's existing `[Image #N]` chips retain the full list.
+ */
+class PendingImagePreview implements Component {
+	#enabled = false;
+	#maxImageRows = COMPOSER_IMAGE_PREVIEW_MAX_ROWS;
+	#budget: ImageBudget | undefined;
+	#currentImage: ImageContent | undefined;
+	#displayImage: ImageContent | undefined;
+	#currentImageProtocol: typeof TERMINAL.imageProtocol = null;
+	#currentImageComponent: Image | undefined;
+	#currentImageKey: string | undefined;
+	#conversionVersion = 0;
+	#requestRender: (() => void) | undefined;
+
+	constructor(readImages: () => readonly ImageContent[]) {
+		this.#readImages = readImages;
+	}
+
+	readonly #readImages: () => readonly ImageContent[];
+
+	setEnabled(enabled: boolean): void {
+		if (this.#enabled === enabled) return;
+		this.#enabled = enabled;
+		if (!enabled) this.clear();
+	}
+
+	setBudget(budget: ImageBudget | undefined): void {
+		if (this.#budget === budget) return;
+		this.clear();
+		this.#budget = budget;
+	}
+
+	setRequestRender(requestRender: (() => void) | undefined): void {
+		this.#requestRender = requestRender;
+	}
+
+	setEditorMaxHeight(maxHeight: number | undefined): void {
+		const next = Math.max(
+			0,
+			Math.min(
+				COMPOSER_IMAGE_PREVIEW_MAX_ROWS,
+				maxHeight === undefined ? COMPOSER_IMAGE_PREVIEW_MAX_ROWS : maxHeight - 4,
+			),
+		);
+		if (this.#maxImageRows === next) return;
+		this.clear();
+		this.#maxImageRows = next;
+	}
+
+	clear(): void {
+		this.#conversionVersion++;
+		if (this.#currentImageKey !== undefined) this.#budget?.releaseKey(this.#currentImageKey);
+		this.#currentImage = undefined;
+		this.#displayImage = undefined;
+		this.#currentImageProtocol = null;
+		this.#currentImageComponent = undefined;
+		this.#currentImageKey = undefined;
+	}
+
+	#selectImage(image: ImageContent, protocol: typeof TERMINAL.imageProtocol): void {
+		this.clear();
+		this.#currentImage = image;
+		this.#currentImageProtocol = protocol;
+		if (protocol !== ImageProtocol.Kitty || image.mimeType === "image/png") {
+			this.#displayImage = image;
+			return;
+		}
+
+		const version = this.#conversionVersion;
+		void convertImageToPng(image)
+			.then(converted => {
+				if (version !== this.#conversionVersion || this.#currentImage !== image) return;
+				this.#displayImage = converted;
+				this.#requestRender?.();
+			})
+			.catch(() => {
+				if (version !== this.#conversionVersion || this.#currentImage !== image) return;
+				this.#displayImage = undefined;
+				this.#requestRender?.();
+			});
+	}
+
+	invalidate(): void {
+		this.#currentImageComponent?.invalidate();
+	}
+
+	render(width: number): readonly string[] {
+		const images = this.#readImages();
+		const image = images.at(-1);
+		const protocol = TERMINAL.imageProtocol;
+		if (
+			!this.#enabled ||
+			this.#budget === undefined ||
+			protocol === null ||
+			this.#maxImageRows === 0 ||
+			image === undefined
+		) {
+			this.clear();
+			return [];
+		}
+
+		if (this.#currentImage !== image || this.#currentImageProtocol !== protocol) {
+			this.#selectImage(image, protocol);
+		}
+		const displayImage = this.#displayImage;
+		if (displayImage === undefined) return [];
+
+		if (this.#currentImageComponent === undefined) {
+			const imageKey = `composer-preview:${++nextComposerImagePreviewKey}`;
+			this.#currentImageKey = imageKey;
+			this.#currentImageComponent = new Image(
+				displayImage.data,
+				displayImage.mimeType,
+				{ fallbackColor: text => fgOrPlain("muted", text) },
+				{
+					budget: this.#budget,
+					imageKey,
+					maxWidthCells: COMPOSER_IMAGE_PREVIEW_MAX_COLUMNS,
+					maxHeightCells: this.#maxImageRows,
+				},
+			);
+		}
+
+		return [...this.#currentImageComponent.render(width), ""];
+	}
+}
+
 /**
  * Custom editor that handles configurable app-level shortcuts for coding-agent.
  */
 export class CustomEditor extends Editor {
 	imageLinks?: readonly (string | undefined)[];
 
+	#pendingImages: ImageContent[] = [];
+	#imagePreview = new PendingImagePreview(() => this.#pendingImages);
+
 	/** Draft images pasted into the composer, consumed on submit. Co-located with
 	 *  {@link imageLinks} so every piece of draft-image state lives on the editor. */
-	pendingImages: ImageContent[] = [];
+	get pendingImages(): ImageContent[] {
+		return this.#pendingImages;
+	}
+
+	set pendingImages(images: ImageContent[]) {
+		this.#pendingImages = images;
+		if (images.length === 0) this.#imagePreview.clear();
+	}
+
 	/** Per-image source links (file:// targets) parallel to {@link pendingImages};
 	 *  `undefined` entries are images without a backing reference yet. */
 	pendingImageLinks: (string | undefined)[] = [];
@@ -412,8 +564,32 @@ export class CustomEditor extends Editor {
 	 * keep working.
 	 */
 	constructor(...args: readonly unknown[]) {
-		super(pickEditorTheme(args));
-		if (args[0] instanceof TUI) this.tui = args[0];
+		const editorTheme = pickEditorTheme(args);
+		super(editorTheme);
+		this.setHeaderComponent(this.#imagePreview);
+		const tui = args[0] instanceof TUI ? args[0] : undefined;
+		if (tui) {
+			this.tui = tui;
+			this.#imagePreview.setBudget(tui.imageBudget);
+			this.#imagePreview.setRequestRender(() => tui.requestRender());
+		}
+	}
+
+	setImagePreviewEnabled(enabled: boolean): void {
+		this.#imagePreview.setEnabled(enabled);
+	}
+
+	setImagePreviewBudget(budget: ImageBudget): void {
+		this.#imagePreview.setBudget(budget);
+	}
+
+	setImagePreviewRepaintHandler(requestRender: (() => void) | undefined): void {
+		this.#imagePreview.setRequestRender(requestRender);
+	}
+
+	override setMaxHeight(maxHeight: number | undefined): void {
+		super.setMaxHeight(maxHeight);
+		this.#imagePreview.setEditorMaxHeight(maxHeight);
 	}
 
 	/** Clear the composer draft: optionally commit `historyText` to history, then

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -400,7 +400,6 @@ class PendingImagePreview implements Component {
 	#displayImage: ImageContent | undefined;
 	#currentImageProtocol: typeof TERMINAL.imageProtocol = null;
 	#currentImageComponent: Image | undefined;
-	#currentImageKey: string | undefined;
 	#conversionVersion = 0;
 	#requestRender: (() => void) | undefined;
 
@@ -441,12 +440,11 @@ class PendingImagePreview implements Component {
 
 	clear(): void {
 		this.#conversionVersion++;
-		if (this.#currentImageKey !== undefined) this.#budget?.releaseKey(this.#currentImageKey);
+		this.#currentImageComponent?.dispose();
 		this.#currentImage = undefined;
 		this.#displayImage = undefined;
 		this.#currentImageProtocol = null;
 		this.#currentImageComponent = undefined;
-		this.#currentImageKey = undefined;
 	}
 
 	#selectImage(image: ImageContent, protocol: typeof TERMINAL.imageProtocol): void {
@@ -499,7 +497,6 @@ class PendingImagePreview implements Component {
 
 		if (this.#currentImageComponent === undefined) {
 			const imageKey = `composer-preview:${++nextComposerImagePreviewKey}`;
-			this.#currentImageKey = imageKey;
 			this.#currentImageComponent = new Image(
 				displayImage.data,
 				displayImage.mimeType,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -506,6 +506,7 @@ export class SelectorController {
 			case "terminal.showImages":
 			case "showImages": {
 				const visible = value as boolean;
+				this.ctx.editor.setImagePreviewEnabled(visible && this.ctx.settings.get("tui.pastedImagePreview"));
 				for (const child of this.ctx.chatContainer.children) {
 					if (child instanceof ToolExecutionComponent) {
 						child.setShowImages(visible);
@@ -517,6 +518,10 @@ export class SelectorController {
 				this.ctx.ui.resetDisplay();
 				break;
 			}
+			case "tui.pastedImagePreview":
+				this.ctx.editor.setImagePreviewEnabled((value as boolean) && this.ctx.settings.get("terminal.showImages"));
+				this.ctx.ui.requestRender();
+				break;
 			case "hideThinkingBlock":
 				this.ctx.hideThinkingBlock = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -506,6 +506,7 @@ export class SelectorController {
 			case "terminal.showImages":
 			case "showImages": {
 				const visible = value as boolean;
+				if (!visible) this.ctx.ui.clearInlineImages();
 				this.ctx.editor.setImagePreviewEnabled(visible && this.ctx.settings.get("tui.pastedImagePreview"));
 				for (const child of this.ctx.chatContainer.children) {
 					if (child instanceof ToolExecutionComponent) {
@@ -514,7 +515,6 @@ export class SelectorController {
 						child.setImagesVisible(visible);
 					}
 				}
-				if (!visible) this.ctx.ui.clearInlineImages();
 				this.ctx.ui.resetDisplay();
 				break;
 			}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -730,6 +730,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.errorBannerContainer = new AnchoredLiveContainer();
 		this.modelCycleContainer = new AnchoredLiveContainer();
 		this.editor = new CustomEditor(getEditorTheme());
+		this.editor.setImagePreviewBudget(this.ui.imageBudget);
+		this.editor.setImagePreviewRepaintHandler(() => this.ui.requestRender());
+		this.editor.setImagePreviewEnabled(settings.get("terminal.showImages") && settings.get("tui.pastedImagePreview"));
 		this.ui.enableScopedInputRender(this.editor);
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setImeSafeCursorLayout(settings.get("tui.imeSafeCursor"));
@@ -4101,6 +4104,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		nextEditor.setImeSafeCursorLayout(this.settings.get("tui.imeSafeCursor"));
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
+		nextEditor.setImagePreviewBudget(this.ui.imageBudget);
+		nextEditor.setImagePreviewEnabled(
+			this.settings.get("terminal.showImages") && this.settings.get("tui.pastedImagePreview"),
+		);
+		nextEditor.setImagePreviewRepaintHandler(() => this.ui.requestRender());
 		nextEditor.onAutocompleteCancel = () => {
 			this.ui.requestRender(true);
 		};

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4122,6 +4122,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			nextEditor.setHistoryStorage(this.historyStorage);
 		}
 		nextEditor.setText(previousText);
+		previousEditor.setImagePreviewEnabled(false);
 
 		this.editorContainer.clear();
 		this.editor = nextEditor;

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -9,6 +9,7 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { ImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 class TestModalEditor extends CustomEditor {}
@@ -72,5 +73,34 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(mode.editor.onSubmit).toBeDefined();
 		expect(mode.editor.onEscape).toBeDefined();
 		expect(refreshSpy).toHaveBeenCalled();
+	});
+
+	it("retires the previous editor preview before replacing it", () => {
+		const terminal = TERMINAL as unknown as { imageProtocol: ImageProtocol | null };
+		const originalProtocol = terminal.imageProtocol;
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		try {
+			const previousEditor = mode.editor;
+			previousEditor.setImagePreviewEnabled(true);
+			previousEditor.setMaxHeight(10);
+			previousEditor.pendingImages = [
+				{
+					type: "image",
+					data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+					mimeType: "image/png",
+				},
+			];
+
+			mode.ui.imageBudget.beginPass();
+			previousEditor.render(50);
+			mode.ui.imageBudget.endPass();
+			expect(mode.ui.imageBudget.takeTransmits()).toHaveLength(1);
+
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+
+			expect(mode.ui.imageBudget.takePurgeIds()).toHaveLength(1);
+		} finally {
+			terminal.imageProtocol = originalProtocol;
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
-import { CURSOR_MARKER } from "@oh-my-pi/pi-tui";
+import { CURSOR_MARKER, ImageBudget, ImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 import { setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
 import { $ } from "bun";
 import { getDefaultPasteImageKeys } from "../../../src/config/keybindings";
@@ -105,6 +105,80 @@ describe("CustomEditor restored image drafts", () => {
 			text: "Inspect [Image #1, 1x1]",
 			images: [image],
 		});
+	});
+});
+
+describe("CustomEditor pasted image preview", () => {
+	const originalProtocol = TERMINAL.imageProtocol;
+	const terminal = TERMINAL as unknown as { imageProtocol: ImageProtocol | null };
+	const image: ImageContent = {
+		type: "image",
+		data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+		mimeType: "image/png",
+	};
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(() => {
+		terminal.imageProtocol = ImageProtocol.Kitty;
+	});
+
+	afterEach(() => {
+		terminal.imageProtocol = originalProtocol;
+	});
+
+	it("renders an opt-in preview above the image marker and retires it when the draft clears", () => {
+		const budget = new ImageBudget(8, () => {});
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setImagePreviewBudget(budget);
+		editor.setMaxHeight(10);
+		editor.pendingImages = [image];
+		editor.setText("[Image #1, 1x1] describe this");
+
+		budget.beginPass();
+		const disabledRender = editor.render(50).join("\n");
+		budget.endPass();
+		expect(disabledRender).not.toContain("\x1b_Ga=p");
+
+		editor.setImagePreviewEnabled(true);
+		budget.beginPass();
+		const enabledRender = editor.render(50).join("\n");
+		budget.endPass();
+		expect(enabledRender).toContain("\x1b_Ga=p");
+		expect(enabledRender.indexOf("\x1b_Ga=p")).toBeLessThan(enabledRender.indexOf("[Image #1"));
+		expect(budget.takeTransmits()).toHaveLength(1);
+
+		editor.pendingImages = [];
+		expect(budget.takePurgeIds()).toHaveLength(1);
+		budget.beginPass();
+		const clearedRender = editor.render(50).join("\n");
+		budget.endPass();
+		expect(clearedRender).not.toContain("\x1b_Ga=p");
+	});
+
+	it("converts resized non-PNG drafts before rendering them with Kitty", async () => {
+		const budget = new ImageBudget(8, () => {});
+		const repaint = Promise.withResolvers<void>();
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setImagePreviewBudget(budget);
+		editor.setImagePreviewRepaintHandler(() => repaint.resolve());
+		editor.setImagePreviewEnabled(true);
+		editor.setMaxHeight(10);
+		editor.pendingImages = [{ ...image, mimeType: "image/webp" }];
+
+		budget.beginPass();
+		expect(editor.render(50).join("\n")).not.toContain("\x1b_Ga=p");
+		budget.endPass();
+
+		await repaint.promise;
+		budget.beginPass();
+		const convertedRender = editor.render(50).join("\n");
+		budget.endPass();
+
+		expect(convertedRender).toContain("\x1b_Ga=p");
+		expect(budget.takeTransmits()).toHaveLength(1);
 	});
 });
 

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -126,6 +126,9 @@ describe("selector setting side effects", () => {
 					expect(clearInlineImages.mock.invocationCallOrder[0]).toBeLessThan(
 						resetDisplay.mock.invocationCallOrder[0],
 					);
+					expect(clearInlineImages.mock.invocationCallOrder[0]).toBeLessThan(
+						setImagePreviewEnabled.mock.invocationCallOrder[0],
+					);
 				}
 			});
 		}

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -99,6 +99,8 @@ describe("selector setting side effects", () => {
 		for (const visible of [false, true]) {
 			it(`updates every image owner and rebuilds the transcript when ${id}=${visible}`, () => {
 				const setShowImages = vi.fn();
+				const setImagePreviewEnabled = vi.fn();
+				Settings.instance.override("tui.pastedImagePreview", true);
 				const setImagesVisible = vi.fn();
 				const clearInlineImages = vi.fn();
 				const resetDisplay = vi.fn();
@@ -107,6 +109,8 @@ describe("selector setting side effects", () => {
 				const assistant = Object.create(AssistantMessageComponent.prototype) as AssistantMessageComponent;
 				assistant.setImagesVisible = setImagesVisible;
 				const controller = new SelectorController({
+					editor: { setImagePreviewEnabled },
+					settings: Settings.instance,
 					chatContainer: { children: [tool, assistant] },
 					ui: { clearInlineImages, resetDisplay },
 				} as unknown as InteractiveModeContext);
@@ -114,6 +118,7 @@ describe("selector setting side effects", () => {
 				controller.handleSettingChange(id, visible);
 
 				expect(setShowImages).toHaveBeenCalledWith(visible);
+				expect(setImagePreviewEnabled).toHaveBeenCalledWith(visible);
 				expect(setImagesVisible).toHaveBeenCalledWith(visible);
 				expect(clearInlineImages).toHaveBeenCalledTimes(visible ? 0 : 1);
 				expect(resetDisplay).toHaveBeenCalledTimes(1);
@@ -124,6 +129,24 @@ describe("selector setting side effects", () => {
 				}
 			});
 		}
+	}
+
+	for (const showImages of [false, true]) {
+		it(`gates tui.pastedImagePreview by terminal.showImages=${showImages}`, () => {
+			const setImagePreviewEnabled = vi.fn();
+			const requestRender = vi.fn();
+			Settings.instance.override("terminal.showImages", showImages);
+			const controller = new SelectorController({
+				editor: { setImagePreviewEnabled },
+				settings: Settings.instance,
+				ui: { requestRender },
+			} as unknown as InteractiveModeContext);
+
+			controller.handleSettingChange("tui.pastedImagePreview", true);
+
+			expect(setImagePreviewEnabled).toHaveBeenCalledWith(showImages);
+			expect(requestRender).toHaveBeenCalledTimes(1);
+		});
 	}
 
 	for (const hidden of [true, false]) {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -397,6 +397,12 @@ describe("Settings", () => {
 			expect(settings.get("tui.maxInlineImages")).toBe(8);
 		});
 
+		it("keeps pasted image previews opt-in", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("tui.pastedImagePreview")).toBe(false);
+			expect(getDefault("tui.pastedImagePreview")).toBe(false);
+		});
+
 		it("keeps native terminal progress disabled by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			expect(settings.get("terminal.showProgress")).toBe(false);

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an editor header slot for bounded inline content such as pasted-image previews, with explicit cleanup for ephemeral Kitty image ids. ([#1628](https://github.com/can1357/oh-my-pi/issues/1628))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -516,6 +516,8 @@ export class Editor implements Component, Focusable {
 	#topBorderContent?: EditorTopBorder;
 	#topBorderProvider?: (availableWidth: number) => EditorTopBorder | undefined;
 	#borderVisible = true;
+	/** Optional content rendered inside the editor chrome above the text buffer. */
+	#headerComponent?: Component;
 
 	constructor(theme: EditorTheme) {
 		this.#theme = theme;
@@ -551,6 +553,16 @@ export class Editor implements Component, Focusable {
 	 */
 	setTopBorderProvider(provider: ((availableWidth: number) => EditorTopBorder | undefined) | undefined): void {
 		this.#topBorderProvider = provider;
+	}
+
+	/**
+	 * Render a component inside the editor border above the text buffer.
+	 *
+	 * Header rows count toward {@link #maxHeight}, so the text buffer keeps at
+	 * least one visible row while previews or other composer chrome are shown.
+	 */
+	setHeaderComponent(component: Component | undefined): void {
+		this.#headerComponent = component;
 	}
 
 	/**
@@ -694,7 +706,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	invalidate(): void {
-		// No cached state to invalidate currently
+		this.#headerComponent?.invalidate?.();
 	}
 
 	#getEditorPaddingX(): number {
@@ -739,10 +751,10 @@ export class Editor implements Component, Focusable {
 		return Math.max(1, contentWidth - cursorReserve);
 	}
 
-	#getVisibleContentHeight(contentLines: number): number {
+	#getVisibleContentHeight(contentLines: number, headerRows = 0): number {
 		if (this.#maxHeight === undefined) return contentLines;
 		const verticalChrome = this.#borderVisible ? 2 : 0;
-		return Math.max(1, this.#maxHeight - verticalChrome);
+		return Math.max(1, this.#maxHeight - verticalChrome - headerRows);
 	}
 
 	/** Apply the optional input decorator to a plain (ANSI-free) text segment.
@@ -870,9 +882,10 @@ export class Editor implements Component, Focusable {
 		const bottomLeft = this.borderColor(`${box.bottomLeft}${box.horizontal}${padding(Math.max(0, paddingX - 1))}`);
 		const horizontal = this.borderColor(box.horizontal);
 
+		const headerLines = this.#headerComponent?.render(contentAreaWidth) ?? [];
 		// Layout the text
 		const layoutLines = this.#layoutText(layoutWidth);
-		const visibleContentHeight = this.#getVisibleContentHeight(layoutLines.length);
+		const visibleContentHeight = this.#getVisibleContentHeight(layoutLines.length, headerLines.length);
 		this.#updateScrollOffset(layoutWidth, layoutLines, visibleContentHeight);
 		const visibleLayoutLines = layoutLines.slice(this.#scrollOffset, this.#scrollOffset + visibleContentHeight);
 
@@ -917,6 +930,23 @@ export class Editor implements Component, Focusable {
 			} else {
 				result.push(topLeft + horizontal.repeat(topFillWidth) + topRight);
 			}
+		}
+
+		// Header rows share the editor's side chrome and horizontal padding. This
+		// keeps terminal image placements anchored inside the composer instead of
+		// creating a separate box above it.
+		for (const rawLine of headerLines) {
+			const rawWidth = visibleWidth(rawLine);
+			const displayText = rawWidth > contentAreaWidth ? sliceByColumn(rawLine, 0, contentAreaWidth, true) : rawLine;
+			const displayWidth = rawWidth > contentAreaWidth ? visibleWidth(displayText) : rawWidth;
+			const linePad = padding(Math.max(0, contentAreaWidth - displayWidth));
+			if (!borderVisible) {
+				result.push((promptGutter?.continuation ?? "") + displayText + linePad);
+				continue;
+			}
+			const leftBorder = this.borderColor(`${box.vertical}${padding(paddingX)}`);
+			const rightBorder = this.borderColor(`${padding(paddingX)}${box.vertical}`);
+			result.push(leftBorder + displayText + linePad + rightBorder);
 		}
 
 		// Render each layout line

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -518,6 +518,7 @@ export class Editor implements Component, Focusable {
 	#borderVisible = true;
 	/** Optional content rendered inside the editor chrome above the text buffer. */
 	#headerComponent?: Component;
+	#lastHeaderRows = 0;
 
 	constructor(theme: EditorTheme) {
 		this.#theme = theme;
@@ -757,6 +758,12 @@ export class Editor implements Component, Focusable {
 		return Math.max(1, this.#maxHeight - verticalChrome - headerRows);
 	}
 
+	#getVisibleHeaderHeight(headerRows: number): number {
+		if (this.#maxHeight === undefined) return headerRows;
+		const verticalChrome = this.#borderVisible ? 2 : 0;
+		return Math.min(headerRows, Math.max(0, this.#maxHeight - verticalChrome - 1));
+	}
+
 	/** Apply the optional input decorator to a plain (ANSI-free) text segment.
 	 *  Decoration only adds zero-width SGR codes, so visible width is unchanged.
 	 *  Splits around CURSOR_MARKER so each user-text segment is decorated in
@@ -844,7 +851,9 @@ export class Editor implements Component, Focusable {
 
 	#getPageScrollStep(totalVisualLines: number): number {
 		const visibleHeight =
-			this.#maxHeight === undefined ? DEFAULT_PAGE_SCROLL_LINES : this.#getVisibleContentHeight(totalVisualLines);
+			this.#maxHeight === undefined
+				? DEFAULT_PAGE_SCROLL_LINES
+				: this.#getVisibleContentHeight(totalVisualLines, this.#lastHeaderRows);
 		return Math.max(1, visibleHeight - 1);
 	}
 
@@ -882,10 +891,13 @@ export class Editor implements Component, Focusable {
 		const bottomLeft = this.borderColor(`${box.bottomLeft}${box.horizontal}${padding(Math.max(0, paddingX - 1))}`);
 		const horizontal = this.borderColor(box.horizontal);
 
-		const headerLines = this.#headerComponent?.render(contentAreaWidth) ?? [];
+		const renderedHeaderLines = this.#headerComponent?.render(contentAreaWidth) ?? [];
+		const headerRows = this.#getVisibleHeaderHeight(renderedHeaderLines.length);
+		const headerLines = renderedHeaderLines.slice(0, headerRows);
+		this.#lastHeaderRows = headerRows;
 		// Layout the text
 		const layoutLines = this.#layoutText(layoutWidth);
-		const visibleContentHeight = this.#getVisibleContentHeight(layoutLines.length, headerLines.length);
+		const visibleContentHeight = this.#getVisibleContentHeight(layoutLines.length, headerRows);
 		this.#updateScrollOffset(layoutWidth, layoutLines, visibleContentHeight);
 		const visibleLayoutLines = layoutLines.slice(this.#scrollOffset, this.#scrollOffset + visibleContentHeight);
 

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -143,16 +143,10 @@ export class ImageBudget {
 		return id;
 	}
 
-	/**
-	 * Release a keyed image that has left the component tree.
-	 *
-	 * Kitty keeps transmitted image data after text rows disappear, so ephemeral
-	 * placements such as composer previews must explicitly retire their id.
-	 */
-	releaseKey(key: string): void {
-		const id = this.#keyToId.get(key);
-		if (id === undefined) return;
-		this.#keyToId.delete(key);
+	/** Release an image id that has left the component tree. */
+	releaseId(id: number): void {
+		const key = this.#idToKey.get(id);
+		if (key !== undefined) this.#keyToId.delete(key);
 		this.#idToKey.delete(id);
 		this.#suppressedIds.delete(id);
 		if (this.#transmitted.delete(id) && !this.#purgeIds.includes(id)) {
@@ -375,6 +369,19 @@ export class Image implements Component {
 	invalidate(): void {
 		this.#cachedLines = undefined;
 		this.#cachedWidth = undefined;
+	}
+
+	/**
+	 * Retire this image's terminal data before removing the component.
+	 *
+	 * Releasing by id remains valid after a global terminal-image clear resets
+	 * the budget's keyed lookup tables and the component later retransmits.
+	 */
+	dispose(): void {
+		if (this.#imageId === undefined) return;
+		this.#budget?.releaseId(this.#imageId);
+		this.#imageId = undefined;
+		this.invalidate();
 	}
 
 	render(width: number): readonly string[] {

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -142,6 +142,24 @@ export class ImageBudget {
 	}
 
 	/**
+	 * Release a keyed image that has left the component tree.
+	 *
+	 * Kitty keeps transmitted image data after text rows disappear, so ephemeral
+	 * placements such as composer previews must explicitly retire their id.
+	 */
+	releaseKey(key: string): void {
+		const id = this.#keyToId.get(key);
+		if (id === undefined) return;
+		this.#keyToId.delete(key);
+		this.#idToKey.delete(id);
+		this.#suppressedIds.delete(id);
+		if (this.#transmitted.delete(id) && !this.#purgeIds.includes(id)) {
+			this.#purgeIds.push(id);
+		}
+		this.#requestRender();
+	}
+
+	/**
 	 * Begin a render pass. Called by the renderer before composing the frame.
 	 * Pass `stable: true` for a partial/throwaway pass that does not walk the
 	 * whole tree in display order (the resize viewport fast path): {@link observe}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -19,6 +19,8 @@ export interface ImageOptions {
 	filename?: string;
 	/** Shared budget that caps how many inline images render as live graphics. */
 	budget?: ImageBudget;
+	/** Whether this image participates in the shared live-image cap. Defaults to true. */
+	countTowardsBudget?: boolean;
 	/**
 	 * Stable identity for the underlying image (e.g. `toolCallId:index`). Lets the
 	 * budget hand back the same graphics id across component re-creations so a
@@ -181,7 +183,8 @@ export class ImageBudget {
 	 * are not authoritative, so the decision is the committed on-terminal split
 	 * (`#suppressedIds`) keyed by id — order- and partiality-independent.
 	 */
-	observe(imageId: number): boolean {
+	observe(imageId: number, countTowardsBudget = true): boolean {
+		if (!countTowardsBudget) return false;
 		if (this.#stablePass) {
 			const suppressed = this.#cap > 0 && this.#suppressedIds.has(imageId);
 			if (suppressed) this.#forgetKeyForId(imageId);
@@ -383,7 +386,10 @@ export class Image implements Component {
 		// its display-order slot in the budget. Only graphics-capable frames count
 		// toward (and are demoted by) the budget; without a protocol every image is
 		// already text.
-		const suppressed = hasProtocol && this.#budget !== undefined ? this.#budget.observe(this.#imageId ?? 0) : false;
+		const suppressed =
+			hasProtocol && this.#budget !== undefined
+				? this.#budget.observe(this.#imageId ?? 0, this.#options.countTowardsBudget)
+				: false;
 
 		if (
 			this.#cachedLines &&

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2748,4 +2748,26 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("single line");
 		});
 	});
+	describe("header component", () => {
+		it("renders header rows inside the editor border above the draft", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setHeaderComponent({ render: () => ["preview"] });
+			editor.setText("draft");
+
+			const lines = editor.render(24).map(line => stripVTControlCharacters(line));
+
+			expect(lines).toHaveLength(3);
+			expect(lines[1]).toMatch(/^\| {2}preview/);
+			expect(lines[2]).toContain("draft");
+		});
+
+		it("counts header rows against the editor height cap", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setHeaderComponent({ render: () => ["preview 1", "preview 2"] });
+			editor.setMaxHeight(5);
+			editor.setText("one\ntwo\nthree");
+
+			expect(editor.render(24)).toHaveLength(4);
+		});
+	});
 });

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2080,6 +2080,18 @@ describe("Editor component", () => {
 			expect(editor.getCursor()).toEqual({ line: 6, col: 2 });
 		});
 
+		it("accounts for rendered header rows in PageUp/PageDown steps", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setHeaderComponent({ render: () => ["preview 1", "preview 2"] });
+			editor.setMaxHeight(6);
+			editor.setText("l0\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9");
+			editor.render(24);
+
+			editor.handleInput("\x1b[5~"); // PageUp
+
+			expect(editor.getCursor()).toEqual({ line: 8, col: 2 });
+		});
+
 		it("PageUp/PageDown on an idle editor never step prompt history (#4754)", () => {
 			const editor = new Editor(defaultEditorTheme);
 
@@ -2768,6 +2780,23 @@ describe("Editor component", () => {
 			editor.setText("one\ntwo\nthree");
 
 			expect(editor.render(24)).toHaveLength(4);
+		});
+
+		it("clamps header rows to leave room for the draft within the height cap", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setHeaderComponent({
+				render: () => ["preview 1", "preview 2", "preview 3", "preview 4"],
+			});
+			editor.setMaxHeight(5);
+			editor.setText("draft");
+
+			const lines = editor.render(24).map(line => stripVTControlCharacters(line));
+
+			expect(lines).toHaveLength(4);
+			expect(lines.join("\n")).toContain("preview 1");
+			expect(lines.join("\n")).toContain("preview 2");
+			expect(lines.join("\n")).not.toContain("preview 3");
+			expect(lines.at(-1)).toContain("draft");
 		});
 	});
 });

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -408,6 +408,32 @@ describe("Image budget integration", () => {
 		expect([...budget.takeTransmits()]).toEqual([]);
 	});
 
+	it("purges a disposed image after a global clear and retransmit", () => {
+		const budget = new ImageBudget(3, () => {});
+		const image = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 4, maxHeightCells: 4, budget, imageKey: "k" },
+		);
+
+		budget.beginPass();
+		image.render(20);
+		budget.endPass();
+		expect(budget.takeTransmits()).toHaveLength(1);
+		const [imageId] = budget.takeAllTransmittedIds();
+		expect(imageId).toBeDefined();
+
+		image.invalidate();
+		budget.beginPass();
+		image.render(20);
+		budget.endPass();
+		expect(budget.takeTransmits()).toHaveLength(1);
+
+		image.dispose();
+		expect(budget.takePurgeIds()).toEqual([imageId]);
+	});
+
 	it("moves back up before multi-row direct Kitty placements and restores the cursor below them", () => {
 		const budget = new ImageBudget(3, () => {});
 		const id = budget.acquireId("k");

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -70,6 +70,19 @@ describe("ImageBudget", () => {
 		expect(second.purge).toEqual([]);
 	});
 
+	it("keeps cap-exempt images live without evicting counted images", () => {
+		const budget = new ImageBudget(2, () => {});
+
+		for (let frame = 0; frame < 2; frame++) {
+			budget.beginPass();
+			expect(budget.observe(1)).toBe(false);
+			expect(budget.observe(2)).toBe(false);
+			expect(budget.observe(3, false)).toBe(false);
+			expect(budget.endPass()).toBe(false);
+			expect([...budget.takePurgeIds()]).toEqual([]);
+		}
+	});
+
 	it("demotes the oldest image on the frame after the cap is exceeded, purging its graphics id", () => {
 		let renders = 0;
 		const budget = new ImageBudget(2, () => {


### PR DESCRIPTION
## What

This adds an optional preview of the most recently pasted image inside the prompt composer, making it easier to confirm the correct attachment before sending.

Adds an opt-in `tui.pastedImagePreview` setting that renders the most recently pasted image above its existing `[Image #N, WxH]` marker inside the prompt composer. The preview stays within 28 columns and 6 rows, follows the editor height cap, and releases its terminal image when the draft is cleared or replaced.

## Why

Pasted images currently appear only as text markers until submission. A compact inline preview confirms that OMP attached the intended image without changing the default composer layout for users who prefer text-only prompts.

Related to #1628.

## Testing

- `bun test packages/tui/test/editor.test.ts packages/tui/test/image-render.test.ts packages/coding-agent/test/modes/components/custom-editor.test.ts`
- `bun test packages/coding-agent/test/settings-manager.test.ts -t "keeps pasted image previews opt-in"`
- `bun check`
- Launched OMP in Ghostty with Kitty graphics enabled, pasted `assets/hero.png`, and confirmed the thumbnail rendered inside the composer above the image marker.

## Screenshots

![Pasted image preview rendered in the OMP prompt composer in Ghostty](https://github.com/user-attachments/assets/f92e7eb6-a535-4042-8beb-5e0eb3178c6b)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
