### PR TITLE
feat(coding-agent): expose goal mode in ACP and RPC via shared GoalModeController

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `/goal` and `/guided-goal` in ACP and RPC modes. The goal-mode lifecycle (enter/resume/pause/drop/budget, tool-set recording/restoration, continuation, and restore-on-session-switch) was extracted into a shared `GoalModeController` that the TUI and the headless modes both drive, so ACP/RPC clients can now create and manage goals. Headless goal auto-continuation is opt-in via `goal.continuationModes` (add `"acp"`/`"rpc"`); it routes through the central agent-initiated-turn path so ACP's `deferAgentInitiatedTurns` contract is respected.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -354,6 +354,15 @@ export class ExtensionRunner {
 	#commandDiagnostics: Array<{ type: string; message: string; path: string }> = [];
 	#initialized = false;
 	/**
+	 * While true, `credential_disabled` / `mcp_notification` events are buffered
+	 * instead of delivered — including ones that arrive AFTER {@link initialize}
+	 * has run — until {@link resumeRuntimeEventDelivery} drains them. RPC startup
+	 * engages this gate between initialize and the persisted-goal restore so a
+	 * notification handler that calls `pi.sendUserMessage` starts its turn only
+	 * once goal mode is restored (see {@link resumeRuntimeEventDelivery}).
+	 */
+	#runtimeEventDeliveryPaused = false;
+	/**
 	 * Buffer for `credential_disabled` events received via {@link emitCredentialDisabled}
 	 * before {@link initialize} has run. Drained through {@link emit} once initialize sets
 	 * up the runtime context, so extension handlers see a populated UI/runtime context
@@ -514,6 +523,7 @@ export class ExtensionRunner {
 		contextActions: ExtensionContextActions,
 		commandContextActions?: ExtensionCommandContextActions,
 		uiContext?: ExtensionUIContext,
+		options?: { pauseRuntimeEventDelivery?: boolean },
 	): void {
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
@@ -560,56 +570,122 @@ export class ExtensionRunner {
 		this.#uiContext = uiContext ?? noOpUIContext;
 		this.#initialized = true;
 
-		// Drain events buffered by emitCredentialDisabled() before initialize ran. The
-		// spread adds the `type` discriminator — `event` is the pi-ai shape (no `type`).
-		// Deferred by one microtask so callers that register an onError listener
-		// synchronously after initialize() see handler errors routed through it.
-		const pending = this.#pendingCredentialDisabled.splice(0);
-		queueMicrotask(() => {
-			for (const event of pending) {
-				this.emit({ type: "credential_disabled", ...event }).catch((error: unknown) => {
-					logger.warn("credential_disabled handler threw during initialize flush", {
-						provider: event.provider,
-						error: error instanceof Error ? error.message : String(error),
+		if (options?.pauseRuntimeEventDelivery) {
+			// Hold the pre-initialize buffers (and any credential_disabled /
+			// mcp_notification that arrive while paused — see the broadened
+			// buffer conditions in emitCredentialDisabled/emitMcpNotification)
+			// for resumeRuntimeEventDelivery(). RPC uses this to defer startup
+			// notification delivery until the persisted goal is restored, so a
+			// handler that sends a message starts its turn in goal mode.
+			this.#runtimeEventDeliveryPaused = true;
+		} else {
+			// Drain events buffered by emitCredentialDisabled() before initialize ran. The
+			// spread adds the `type` discriminator — `event` is the pi-ai shape (no `type`).
+			// Deferred by one microtask so callers that register an onError listener
+			// synchronously after initialize() see handler errors routed through it.
+			const pending = this.#pendingCredentialDisabled.splice(0);
+			queueMicrotask(() => {
+				for (const event of pending) {
+					this.emit({ type: "credential_disabled", ...event }).catch((error: unknown) => {
+						logger.warn("credential_disabled handler threw during initialize flush", {
+							provider: event.provider,
+							error: error instanceof Error ? error.message : String(error),
+						});
 					});
-				});
-			}
-		});
+				}
+			});
 
-		// Drain events buffered by emitMcpNotification() before initialize ran, using the
-		// same deferred-microtask ordering as the credential-disabled drain above so any
-		// onError listener registered synchronously after initialize() still catches
-		// handler errors during flush.
-		const pendingMcp = this.#pendingMcpNotifications.splice(0);
-		queueMicrotask(() => {
-			for (const event of pendingMcp) {
-				this.emit({ type: "mcp_notification", ...event }).catch((error: unknown) => {
-					logger.warn("mcp_notification handler threw during initialize flush", {
-						server: event.server,
-						method: event.method,
-						error: error instanceof Error ? error.message : String(error),
+			// Drain events buffered by emitMcpNotification() before initialize ran, using the
+			// same deferred-microtask ordering as the credential-disabled drain above so any
+			// onError listener registered synchronously after initialize() still catches
+			// handler errors during flush.
+			const pendingMcp = this.#pendingMcpNotifications.splice(0);
+			queueMicrotask(() => {
+				for (const event of pendingMcp) {
+					this.emit({ type: "mcp_notification", ...event }).catch((error: unknown) => {
+						logger.warn("mcp_notification handler threw during initialize flush", {
+							server: event.server,
+							method: event.method,
+							error: error instanceof Error ? error.message : String(error),
+						});
 					});
+				}
+			});
+		}
+	}
+
+	/**
+	 * Resume delivery of `credential_disabled` / `mcp_notification` events
+	 * buffered while {@link initialize} ran with `pauseRuntimeEventDelivery`
+	 * (see {@link ExtensionRunner.initialize}).
+	 *
+	 * The gate exists so startup notification delivery can be deferred until
+	 * persisted session state is restored: RPC restores the persisted goal
+	 * between initialize and this call, so a notification handler that starts a
+	 * turn via `pi.sendUserMessage` runs it in goal mode. Only
+	 * `credential_disabled` and `mcp_notification` are gated — `goal_updated`
+	 * (and every other event) delivers immediately, so the restore's
+	 * `goal_updated` still reaches initialized handlers while the gate is held.
+	 *
+	 * Drains `credential_disabled` then `mcp_notification`, in the same order
+	 * as the initialize drains, emitting each through {@link emit} with the
+	 * same per-event error isolation (handler errors are logged and routed
+	 * through {@link onError}; a throw here never escapes). No-op when the
+	 * gate is not engaged. Unlike the initialize drains, no one-microtask
+	 * deferral is needed: callers engage the gate only after their onError
+	 * listener is registered.
+	 */
+	async resumeRuntimeEventDelivery(): Promise<void> {
+		if (!this.#runtimeEventDeliveryPaused) return;
+		// Release the gate BEFORE draining so an event a handler surfaces mid-drain
+		// (the SDK bridges are fire-and-forget — a fresh credential_disabled /
+		// mcp_notification can arrive during an await here) delivers inline instead
+		// of buffering into a queue this drain no longer re-reads (which would
+		// strand it, since RPC has no second resume).
+		this.#runtimeEventDeliveryPaused = false;
+
+		const pendingCredential = this.#pendingCredentialDisabled.splice(0);
+		for (const event of pendingCredential) {
+			await this.emit({ type: "credential_disabled", ...event }).catch((error: unknown) => {
+				logger.warn("credential_disabled handler threw during resume", {
+					provider: event.provider,
+					error: error instanceof Error ? error.message : String(error),
 				});
-			}
-		});
+			});
+		}
+
+		const pendingMcp = this.#pendingMcpNotifications.splice(0);
+		for (const event of pendingMcp) {
+			await this.emit({ type: "mcp_notification", ...event }).catch((error: unknown) => {
+				logger.warn("mcp_notification handler threw during resume", {
+					server: event.server,
+					method: event.method,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		}
 	}
 
 	/**
 	 * Forward a `credential_disabled` event from `AuthStorage` to extension handlers.
 	 *
-	 * If {@link initialize} has not yet run, the event is buffered and replayed once
-	 * initialize wires the runtime/UI context. This matters because mode controllers
-	 * (interactive, RPC, ACP, print, subagent) call `initialize()` AFTER `createAgentSession`
-	 * returns, but `AuthStorage` can fire `credential_disabled` during startup model probes
-	 * inside `createAgentSession()`. Without deferral, extension handlers would observe
-	 * `hasUI=false`, an unset model, and no-op runtime actions on exactly the headline
-	 * "OAuth invalid_grant during startup" path the event was designed to surface.
+	 * If {@link initialize} has not yet run — or the runtime event delivery gate
+	 * is engaged (`pauseRuntimeEventDelivery`, see
+	 * {@link resumeRuntimeEventDelivery}) — the event is buffered and replayed
+	 * once initialize wires the runtime/UI context (or the gate is resumed).
+	 * This matters because mode controllers (interactive, RPC, ACP, print,
+	 * subagent) call `initialize()` AFTER `createAgentSession` returns, but
+	 * `AuthStorage` can fire `credential_disabled` during startup model probes
+	 * inside `createAgentSession()`. Without deferral, extension handlers would
+	 * observe `hasUI=false`, an unset model, and no-op runtime actions on
+	 * exactly the headline "OAuth invalid_grant during startup" path the event
+	 * was designed to surface.
 	 *
 	 * Always returns; never throws. Errors from handlers are routed through
 	 * {@link onError} via {@link emit}'s normal isolation.
 	 */
 	async emitCredentialDisabled(event: CredentialDisabledEvent): Promise<void> {
-		if (!this.#initialized) {
+		if (!this.#initialized || this.#runtimeEventDeliveryPaused) {
 			if (this.#pendingCredentialDisabled.length >= MAX_PENDING_CREDENTIAL_DISABLED) {
 				this.#pendingCredentialDisabled.shift();
 			}
@@ -622,20 +698,23 @@ export class ExtensionRunner {
 	/**
 	 * Forward an MCP server notification to extension handlers.
 	 *
-	 * If {@link initialize} has not yet run, the notification is buffered and replayed
-	 * once initialize wires the runtime/UI context. Matches the credential-disabled
-	 * deferral above: the sdk.ts bridge registers `MCPManager.addNotificationListener`
-	 * inside `createAgentSession` — BEFORE the mode controller calls `initialize()` on
+	 * If {@link initialize} has not yet run — or the runtime event delivery gate
+	 * is engaged (`pauseRuntimeEventDelivery`, see
+	 * {@link resumeRuntimeEventDelivery}) — the notification is buffered and
+	 * replayed once initialize wires the runtime/UI context (or the gate is
+	 * resumed). Matches the credential-disabled deferral above: the sdk.ts
+	 * bridge registers `MCPManager.addNotificationListener` inside
+	 * `createAgentSession` — BEFORE the mode controller calls `initialize()` on
 	 * this runner — so notification frames drained by the manager (either fresh
-	 * arrivals or replay from its own startup buffer) can reach us pre-init. Without
-	 * this buffer they would evaporate for a second time here.
+	 * arrivals or replay from its own startup buffer) can reach us pre-init.
+	 * Without this buffer they would evaporate for a second time here.
 	 *
 	 * Bounded at {@link MAX_PENDING_MCP_NOTIFICATIONS}; oldest entries drop under
 	 * pressure. Never throws; per-handler errors are routed through {@link onError}
 	 * via {@link emit}'s normal isolation.
 	 */
 	async emitMcpNotification(event: Omit<McpNotificationEvent, "type">): Promise<void> {
-		if (!this.#initialized) {
+		if (!this.#initialized || this.#runtimeEventDeliveryPaused) {
 			if (this.#pendingMcpNotifications.length >= MAX_PENDING_MCP_NOTIFICATIONS) {
 				this.#pendingMcpNotifications.shift();
 			}

--- a/packages/coding-agent/src/goals/goal-mode-controller.ts
+++ b/packages/coding-agent/src/goals/goal-mode-controller.ts
@@ -175,11 +175,10 @@ export class GoalModeController {
 		// /goal resume re-adds it. Own the restore here so headless adapters (which
 		// don't run a TUI #exitGoalMode) get it; the TUI's subsequent
 		// #exitGoalMode({paused}) sees #previousTools already cleared and no-ops.
-		// resume() re-captures the then-current toolset as previousTools.
-		if (this.#previousTools !== undefined) {
-			await this.#session.setActiveToolsByName(this.#previousTools);
-			this.#previousTools = undefined;
-		}
+		// The restore merges in tools enabled after the snapshot (e.g. late MCP
+		// tools), so pausing can never disable a client tool. resume() re-captures
+		// the then-current toolset as previousTools.
+		await this.#restoreGoalTools();
 		return { ok: true };
 	}
 
@@ -191,14 +190,12 @@ export class GoalModeController {
 		} catch (error) {
 			return { ok: false, error: error instanceof Error ? error.message : String(error) };
 		}
-		// Drop is terminal: restore the pre-goal toolset here so standalone adapters
-		// (headless) get the restore without an exit call. In the TUI the
+		// Drop is terminal: restore the merged pre-goal toolset here so standalone
+		// adapters (headless) get the restore without an exit call. In the TUI the
 		// `goal_updated`(dropped) event already restored via onGoalUpdated, so this
-		// is a no-op there.
-		if (this.#previousTools !== undefined) {
-			await this.#session.setActiveToolsByName(this.#previousTools);
-			this.#previousTools = undefined;
-		}
+		// is a no-op there. The merge preserves tools that arrived after the
+		// snapshot (e.g. late MCP tools).
+		await this.#restoreGoalTools();
 		return { ok: true };
 	}
 
@@ -235,7 +232,8 @@ export class GoalModeController {
 	 * Guided-goal interview setup: records the pre-interview toolset and exposes
 	 * the goal tool so the agent can finish the interview with `goal create`
 	 * (which turns goal mode on via `goal_updated`). The eventual goal exit
-	 * restores the recorded set.
+	 * restores the recorded set merged with whatever is enabled then (so tools
+	 * that arrive after this snapshot, e.g. late MCP tools, are never dropped).
 	 */
 	async exposeGoalTool(): Promise<void> {
 		const enabledTools = this.#session.getEnabledToolNames();
@@ -287,12 +285,27 @@ export class GoalModeController {
 		return restored;
 	}
 
-	/** Restore the pre-goal tool set recorded by enter/resume/exposeGoalTool.
-	 *  Shared by every goal exit path so all of them clean up the `goal` tool
-	 *  identically; no-op when no snapshot exists. */
+	/**
+	 * Restore the pre-goal tool set recorded by enter/resume/exposeGoalTool,
+	 * MERGED with the currently-enabled non-goal tools. Goal mode only ever
+	 * ADDS the `goal` tool — it never removes or restricts other tools — so the
+	 * union is a strict superset of the snapshot-only restore: every tool that
+	 * should remain enabled is kept, and only `goal` is dropped.
+	 *
+	 * The merge matters because the snapshot is point-in-time: MCP servers can
+	 * enable tools AFTER it was taken (`MCPManager.connectServers` resolves via
+	 * `Promise.race` at `STARTUP_TIMEOUT_MS`, so slow servers register their
+	 * tools later through the background `onToolsChanged` -> `refreshMCPTools`
+	 * path). A full replace with the stale snapshot would disable those late
+	 * tools when the goal is paused/dropped/completed. The merge guarantees
+	 * ending a goal never disables a client MCP tool. Shared by every goal exit
+	 * path so all of them clean up the `goal` tool identically; no-op when no
+	 * snapshot exists. */
 	async #restoreGoalTools(): Promise<void> {
 		if (this.#previousTools === undefined) return;
-		await this.#session.setActiveToolsByName(this.#previousTools);
+		const currentNonGoal = this.#session.getEnabledToolNames().filter(name => name !== "goal");
+		const merged = [...new Set([...this.#previousTools, ...currentNonGoal])];
+		await this.#session.setActiveToolsByName(merged);
 		this.#previousTools = undefined;
 	}
 
@@ -310,9 +323,11 @@ export class GoalModeController {
 	 * is preserved; `completed` records the goal-completion journal entry.
 	 */
 	async deactivate(options?: { restoreTools?: boolean; completed?: boolean; clearState?: boolean }): Promise<void> {
-		if (options?.restoreTools && this.#previousTools !== undefined) {
-			await this.#session.setActiveToolsByName(this.#previousTools);
+		if (options?.restoreTools) {
+			await this.#restoreGoalTools();
 		}
+		// #restoreGoalTools() clears the snapshot itself; this unconditional clear
+		// covers the restoreTools===false case so the snapshot never leaks.
 		this.#previousTools = undefined;
 		if (options?.completed) {
 			const currentState = this.#session.getGoalModeState();
@@ -346,13 +361,12 @@ export class GoalModeController {
 		}
 	}
 
-	/** Adapter hook for `goal_updated` session events. Drop restores the previous tool set. */
+	/** Adapter hook for `goal_updated` session events. Drop restores the merged
+	 *  pre-goal tool set (snapshot ∪ currently-enabled non-goal tools) so late
+	 *  MCP tools survive the goal exit. */
 	async onGoalUpdated(state: GoalModeState | undefined): Promise<void> {
 		if (state?.goal?.status !== "dropped") return;
-		if (this.#previousTools !== undefined) {
-			await this.#session.setActiveToolsByName(this.#previousTools);
-			this.#previousTools = undefined;
-		}
+		await this.#restoreGoalTools();
 	}
 
 	/**
@@ -366,9 +380,10 @@ export class GoalModeController {
 			this.#goalContinuationTurnInFlight = false;
 		}
 		if (this.#session.getGoalModeState()?.mode === "exiting") {
-			// Completion exit must re-apply the pre-goal tool set; deactivate()
-			// clears #previousTools after restoring, so gate on the snapshot
-			// still being present (F1).
+			// Completion exit must re-apply the pre-goal tool set (merged with
+			// currently-enabled non-goal tools, so late MCP tools survive);
+			// deactivate() clears #previousTools after restoring, so gate on the
+			// snapshot still being present (F1).
 			await this.deactivate({ restoreTools: this.#previousTools !== undefined, completed: true });
 			return null;
 		}

--- a/packages/coding-agent/src/goals/goal-mode-controller.ts
+++ b/packages/coding-agent/src/goals/goal-mode-controller.ts
@@ -2,6 +2,7 @@ import type { AgentSession } from "../session/agent-session";
 import type { SessionContext } from "../session/session-context";
 import type { SessionManager } from "../session/session-manager";
 import type { Goal, GoalModeState } from "./state";
+import { formatDuration } from "../slash-commands/helpers/duration";
 
 /**
  * Shared session-level goal lifecycle, used by BOTH the TUI (InteractiveMode)
@@ -20,22 +21,6 @@ import type { Goal, GoalModeState } from "./state";
 export type GoalContinuationDecision = { prompt: string } | null;
 
 export type GoalControllerResult = { ok: true; prompt?: string } | { ok: false; error: string };
-
-/**
- * Duration formatter mirroring `formatDuration` in
- * `slash-commands/helpers/format.ts` — kept local so the core does not pull the
- * TUI theme module graph into goals/. Both must stay in lockstep.
- */
-function formatGoalDuration(ms: number): string {
-	const seconds = Math.max(0, Math.round(ms / 1000));
-	if (seconds < 60) return `${seconds}s`;
-	const minutes = Math.round(seconds / 60);
-	if (minutes < 60) return `${minutes}m`;
-	const hours = Math.round(minutes / 60);
-	if (hours < 48) return `${hours}h`;
-	const days = Math.round(hours / 24);
-	return `${days}d`;
-}
 
 /** Validates a persisted `mode_change` goal payload (mirrors the TUI's #goalFromModeData). */
 function goalFromModeData(modeData: SessionContext["modeData"]): Goal | undefined {
@@ -242,7 +227,7 @@ export class GoalModeController {
 			`Objective: ${goal.objective}`,
 			`Status: ${goal.status}${state?.enabled ? "" : " (paused)"}`,
 			`Tokens: ${budgetLine}`,
-			`Time spent: ${formatGoalDuration(goal.timeUsedSeconds * 1000)}`,
+			`Time spent: ${formatDuration(goal.timeUsedSeconds * 1000)}`,
 		].join("\n");
 	}
 
@@ -267,15 +252,18 @@ export class GoalModeController {
 		if (!goalEnabled && (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused")) {
 			this.#session.goalRuntime.clearAccounting();
 			this.#sessionManager.appendModeChange("none");
+			this.#clearGoalModeState();
 			return undefined;
 		}
 		if (sessionContext.mode !== "goal" && sessionContext.mode !== "goal_paused") {
 			this.#session.goalRuntime.clearAccounting();
+			this.#clearGoalModeState();
 			return undefined;
 		}
 		const goal = goalFromModeData(sessionContext.modeData);
 		if (!goal) {
 			this.#sessionManager.appendModeChange("none");
+			this.#clearGoalModeState();
 			return undefined;
 		}
 		this.#session.setGoalModeState({
@@ -294,6 +282,14 @@ export class GoalModeController {
 			await this.#session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
 		}
 		return restored;
+	}
+
+	/** Clear in-memory goal state + continuation flags (early-return branches of restore()). */
+	#clearGoalModeState(): void {
+		this.#session.setGoalModeState(undefined);
+		this.#goalTurnHadToolCalls = false;
+		this.#goalContinuationTurnInFlight = false;
+		this.#goalSuppressNextContinuation = false;
 	}
 
 	/**

--- a/packages/coding-agent/src/goals/goal-mode-controller.ts
+++ b/packages/coding-agent/src/goals/goal-mode-controller.ts
@@ -1,8 +1,8 @@
 import type { AgentSession } from "../session/agent-session";
 import type { SessionContext } from "../session/session-context";
 import type { SessionManager } from "../session/session-manager";
-import type { Goal, GoalModeState } from "./state";
 import { formatDuration } from "../slash-commands/helpers/duration";
+import type { Goal, GoalModeState } from "./state";
 
 /**
  * Shared session-level goal lifecycle, used by BOTH the TUI (InteractiveMode)
@@ -250,18 +250,21 @@ export class GoalModeController {
 		const sessionContext = this.#sessionManager.buildSessionContext();
 		const goalEnabled = this.#session.settings.get("goal.enabled");
 		if (!goalEnabled && (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused")) {
+			await this.#restoreGoalTools();
 			this.#session.goalRuntime.clearAccounting();
 			this.#sessionManager.appendModeChange("none");
 			this.#clearGoalModeState();
 			return undefined;
 		}
 		if (sessionContext.mode !== "goal" && sessionContext.mode !== "goal_paused") {
+			await this.#restoreGoalTools();
 			this.#session.goalRuntime.clearAccounting();
 			this.#clearGoalModeState();
 			return undefined;
 		}
 		const goal = goalFromModeData(sessionContext.modeData);
 		if (!goal) {
+			await this.#restoreGoalTools();
 			this.#sessionManager.appendModeChange("none");
 			this.#clearGoalModeState();
 			return undefined;
@@ -282,6 +285,15 @@ export class GoalModeController {
 			await this.#session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
 		}
 		return restored;
+	}
+
+	/** Restore the pre-goal tool set recorded by enter/resume/exposeGoalTool.
+	 *  Shared by every goal exit path so all of them clean up the `goal` tool
+	 *  identically; no-op when no snapshot exists. */
+	async #restoreGoalTools(): Promise<void> {
+		if (this.#previousTools === undefined) return;
+		await this.#session.setActiveToolsByName(this.#previousTools);
+		this.#previousTools = undefined;
 	}
 
 	/** Clear in-memory goal state + continuation flags (early-return branches of restore()). */
@@ -354,7 +366,10 @@ export class GoalModeController {
 			this.#goalContinuationTurnInFlight = false;
 		}
 		if (this.#session.getGoalModeState()?.mode === "exiting") {
-			await this.deactivate({ completed: true });
+			// Completion exit must re-apply the pre-goal tool set; deactivate()
+			// clears #previousTools after restoring, so gate on the snapshot
+			// still being present (F1).
+			await this.deactivate({ restoreTools: this.#previousTools !== undefined, completed: true });
 			return null;
 		}
 		return this.buildContinuationForSubmission();

--- a/packages/coding-agent/src/goals/goal-mode-controller.ts
+++ b/packages/coding-agent/src/goals/goal-mode-controller.ts
@@ -1,0 +1,406 @@
+import type { AgentSession } from "../session/agent-session";
+import type { SessionContext } from "../session/session-context";
+import type { SessionManager } from "../session/session-manager";
+import type { Goal, GoalModeState } from "./state";
+
+/**
+ * Shared session-level goal lifecycle, used by BOTH the TUI (InteractiveMode)
+ * and the headless ACP/RPC path. Extracted so enter/exit/restore/continuation
+ * are implemented once instead of forked per mode.
+ *
+ * The controller is DRIVEN by its adapters — it never subscribes to session
+ * events itself (mirroring how AgentSession drives GoalRuntime). Adapters call
+ * the event hooks (`onAgentStart`/`onToolStart`/`onGoalUpdated`/`onAgentEnd`)
+ * from their own session subscribers, and apply their own run-mode gate
+ * (`goal.continuationModes`) before submitting a continuation prompt.
+ *
+ * Pure logic: imports AgentSession/SessionManager as TYPES only (the core is
+ * constructed BY AgentSession), so there is no module cycle.
+ */
+export type GoalContinuationDecision = { prompt: string } | null;
+
+export type GoalControllerResult = { ok: true; prompt?: string } | { ok: false; error: string };
+
+/**
+ * Duration formatter mirroring `formatDuration` in
+ * `slash-commands/helpers/format.ts` — kept local so the core does not pull the
+ * TUI theme module graph into goals/. Both must stay in lockstep.
+ */
+function formatGoalDuration(ms: number): string {
+	const seconds = Math.max(0, Math.round(ms / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 48) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	return `${days}d`;
+}
+
+/** Validates a persisted `mode_change` goal payload (mirrors the TUI's #goalFromModeData). */
+function goalFromModeData(modeData: SessionContext["modeData"]): Goal | undefined {
+	const goal = modeData?.goal;
+	if (!goal || typeof goal !== "object") return undefined;
+	const value = goal as Record<string, unknown>;
+	if (
+		typeof value.id !== "string" ||
+		typeof value.objective !== "string" ||
+		typeof value.status !== "string" ||
+		typeof value.tokensUsed !== "number" ||
+		typeof value.timeUsedSeconds !== "number" ||
+		typeof value.createdAt !== "number" ||
+		typeof value.updatedAt !== "number"
+	) {
+		return undefined;
+	}
+	return {
+		id: value.id,
+		objective: value.objective,
+		status: value.status as Goal["status"],
+		tokenBudget: typeof value.tokenBudget === "number" ? value.tokenBudget : undefined,
+		tokensUsed: value.tokensUsed,
+		timeUsedSeconds: value.timeUsedSeconds,
+		createdAt: value.createdAt,
+		updatedAt: value.updatedAt,
+	};
+}
+
+export class GoalModeController {
+	readonly #session: AgentSession;
+	readonly #sessionManager: SessionManager;
+	#previousTools: string[] | undefined;
+	#goalTurnHadToolCalls = false;
+	#goalContinuationTurnInFlight = false;
+	#goalSuppressNextContinuation = false;
+
+	constructor(session: AgentSession, sessionManager: SessionManager) {
+		this.#session = session;
+		this.#sessionManager = sessionManager;
+	}
+
+	/** Tool set recorded before the goal tool was exposed; restored on exit/drop/disable. */
+	get previousTools(): string[] | undefined {
+		return this.#previousTools;
+	}
+
+	/** True when the next continuation must be skipped (a continuation turn made no tool calls). */
+	isContinuationSuppressed(): boolean {
+		return this.#goalSuppressNextContinuation;
+	}
+
+	/** Shared enter guards: `goal.enabled` setting + plan-mode exclusivity (active OR paused). */
+	#guardGoalUsable(): GoalControllerResult | null {
+		if (!this.#session.settings.get("goal.enabled")) {
+			return { ok: false, error: "Goal mode is disabled. Enable it in settings (goal.enabled)." };
+		}
+		// Active plan is held in live session state; a PAUSED plan clears that
+		// state but persists as a "plan_paused" mode entry — block both, matching
+		// the TUI (interactive-mode.ts planModeEnabled || planModePaused guard).
+		const planMode = this.#sessionManager.buildSessionContext().mode;
+		if (this.#session.getPlanModeState()?.enabled || planMode === "plan" || planMode === "plan_paused") {
+			return { ok: false, error: "Exit plan mode first." };
+		}
+		return null;
+	}
+
+	/** Public entry guard for handlers that expose the goal tool out-of-band
+	 *  (e.g. `/guided-goal` interview) so they reject disabled / plan(active or
+	 * paused) states before the agent can call `goal create`, which itself has no
+	 * plan guard. */
+	entryGuard(): GoalControllerResult | null {
+		return this.#guardGoalUsable();
+	}
+
+	/** Requires an active or budget-limited goal for pause / setBudget — a paused
+	 * goal must be resumed first (matches the TUI: pause needs goalModeEnabled,
+	 * budget is rejected while paused per fix #5). */
+	#requireActiveGoal(): GoalControllerResult | null {
+		const goal = this.#session.getGoalModeState()?.goal;
+		if (!goal || (goal.status !== "active" && goal.status !== "budget-limited")) {
+			return { ok: false, error: "No active goal." };
+		}
+		return null;
+	}
+
+	/** Requires any goal record (active or paused) for drop. */
+	#requireAnyGoal(): GoalControllerResult | null {
+		const goal = this.#session.getGoalModeState()?.goal;
+		if (!goal || goal.status === "dropped") {
+			return { ok: false, error: "No goal to drop." };
+		}
+		return null;
+	}
+
+	async enter(objective: string, tokenBudget?: number): Promise<GoalControllerResult> {
+		const guard = this.#guardGoalUsable();
+		if (guard) return guard;
+		const previousTools = this.#session.getEnabledToolNames().filter(name => name !== "goal");
+		const goalTools = [...new Set([...previousTools, "goal"])];
+		this.#previousTools = previousTools;
+		try {
+			const state = await this.#session.goalRuntime.createGoal({ objective, tokenBudget });
+			await this.#session.setActiveToolsByName(goalTools);
+			this.#session.setGoalModeState(state);
+		} catch (error) {
+			this.#previousTools = undefined;
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+		return { ok: true, prompt: objective };
+	}
+
+	async resume(): Promise<GoalControllerResult> {
+		const guard = this.#guardGoalUsable();
+		if (guard) return guard;
+		const previousTools = this.#session.getEnabledToolNames().filter(name => name !== "goal");
+		const goalTools = [...new Set([...previousTools, "goal"])];
+		this.#previousTools = previousTools;
+		try {
+			const state = await this.#session.goalRuntime.resumeGoal();
+			await this.#session.setActiveToolsByName(goalTools);
+			this.#session.setGoalModeState(state);
+		} catch (error) {
+			this.#previousTools = undefined;
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+		return { ok: true };
+	}
+
+	async replaceObjective(objective: string, tokenBudget?: number): Promise<GoalControllerResult> {
+		const guard = this.#guardGoalUsable();
+		if (guard) return guard;
+		try {
+			const state = await this.#session.goalRuntime.replaceGoal({ objective, tokenBudget });
+			this.#session.setGoalModeState(state);
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+		return { ok: true, prompt: objective };
+	}
+
+	async pause(): Promise<GoalControllerResult> {
+		const active = this.#requireActiveGoal();
+		if (active) return active;
+		try {
+			await this.#session.goalRuntime.pauseGoal();
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+		// Pause keeps the goal record (status "paused") but removes the goal tool
+		// from the active set — the agent must not operate on a paused goal until
+		// /goal resume re-adds it. Own the restore here so headless adapters (which
+		// don't run a TUI #exitGoalMode) get it; the TUI's subsequent
+		// #exitGoalMode({paused}) sees #previousTools already cleared and no-ops.
+		// resume() re-captures the then-current toolset as previousTools.
+		if (this.#previousTools !== undefined) {
+			await this.#session.setActiveToolsByName(this.#previousTools);
+			this.#previousTools = undefined;
+		}
+		return { ok: true };
+	}
+
+	async drop(): Promise<GoalControllerResult> {
+		const any = this.#requireAnyGoal();
+		if (any) return any;
+		try {
+			await this.#session.goalRuntime.dropGoal();
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+		// Drop is terminal: restore the pre-goal toolset here so standalone adapters
+		// (headless) get the restore without an exit call. In the TUI the
+		// `goal_updated`(dropped) event already restored via onGoalUpdated, so this
+		// is a no-op there.
+		if (this.#previousTools !== undefined) {
+			await this.#session.setActiveToolsByName(this.#previousTools);
+			this.#previousTools = undefined;
+		}
+		return { ok: true };
+	}
+
+	async setBudget(value: number | undefined): Promise<GoalControllerResult> {
+		const active = this.#requireActiveGoal();
+		if (active) return active;
+		try {
+			await this.#session.goalRuntime.onBudgetMutated(value);
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+		return { ok: true };
+	}
+
+	/** Multi-line goal summary for display; "No goal set." when no goal record exists. */
+	show(): string {
+		const state = this.#session.getGoalModeState();
+		const goal = state?.goal;
+		if (!goal) return "No goal set.";
+		const used = goal.tokensUsed.toLocaleString();
+		const budgetLine =
+			goal.tokenBudget !== undefined
+				? `${used} / ${goal.tokenBudget.toLocaleString()} (${Math.max(0, goal.tokenBudget - goal.tokensUsed).toLocaleString()} left)`
+				: `${used} (no budget)`;
+		return [
+			`Objective: ${goal.objective}`,
+			`Status: ${goal.status}${state?.enabled ? "" : " (paused)"}`,
+			`Tokens: ${budgetLine}`,
+			`Time spent: ${formatGoalDuration(goal.timeUsedSeconds * 1000)}`,
+		].join("\n");
+	}
+
+	/**
+	 * Guided-goal interview setup: records the pre-interview toolset and exposes
+	 * the goal tool so the agent can finish the interview with `goal create`
+	 * (which turns goal mode on via `goal_updated`). The eventual goal exit
+	 * restores the recorded set.
+	 */
+	async exposeGoalTool(): Promise<void> {
+		const enabledTools = this.#session.getEnabledToolNames();
+		this.#previousTools = enabledTools.filter(name => name !== "goal");
+		if (!enabledTools.includes("goal")) {
+			await this.#session.setActiveToolsByName([...enabledTools, "goal"]);
+		}
+	}
+
+	/** Reconcile goal mode from persisted session entries on resume/switch. */
+	async restore(options?: { preserveActiveGoal?: boolean }): Promise<GoalModeState | undefined> {
+		const sessionContext = this.#sessionManager.buildSessionContext();
+		const goalEnabled = this.#session.settings.get("goal.enabled");
+		if (!goalEnabled && (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused")) {
+			this.#session.goalRuntime.clearAccounting();
+			this.#sessionManager.appendModeChange("none");
+			return undefined;
+		}
+		if (sessionContext.mode !== "goal" && sessionContext.mode !== "goal_paused") {
+			this.#session.goalRuntime.clearAccounting();
+			return undefined;
+		}
+		const goal = goalFromModeData(sessionContext.modeData);
+		if (!goal) {
+			this.#sessionManager.appendModeChange("none");
+			return undefined;
+		}
+		this.#session.setGoalModeState({
+			enabled: sessionContext.mode === "goal",
+			mode: "active",
+			goal,
+		});
+		const restored = await this.#session.goalRuntime.onThreadResumed({
+			preserveActiveGoal: options?.preserveActiveGoal,
+		});
+		// sdk.ts excludes "goal" from the initial active tool set unconditionally.
+		// Re-add it now so the agent can call resume, complete, or drop on this goal.
+		if (restored?.goal) {
+			const previousTools = this.#session.getEnabledToolNames().filter(name => name !== "goal");
+			this.#previousTools = previousTools;
+			await this.#session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+		}
+		return restored;
+	}
+
+	/**
+	 * Session-level exit. The ADAPTER gates `restoreTools` with its own
+	 * "goal mode active" flag so the exact tool-restore condition of each mode
+	 * is preserved; `completed` records the goal-completion journal entry.
+	 */
+	async deactivate(options?: { restoreTools?: boolean; completed?: boolean; clearState?: boolean }): Promise<void> {
+		if (options?.restoreTools && this.#previousTools !== undefined) {
+			await this.#session.setActiveToolsByName(this.#previousTools);
+		}
+		this.#previousTools = undefined;
+		if (options?.completed) {
+			const currentState = this.#session.getGoalModeState();
+			this.#session.setGoalModeState(undefined);
+			this.#sessionManager.appendModeChange("none");
+			this.#sessionManager.appendCustomEntry("goal-completed", {
+				objective: currentState?.goal?.objective,
+				tokensUsed: currentState?.goal?.tokensUsed,
+				tokenBudget: currentState?.goal?.tokenBudget,
+				timeUsedSeconds: currentState?.goal?.timeUsedSeconds,
+			});
+		}
+		if (options?.clearState) {
+			this.#session.setGoalModeState(undefined);
+		}
+		this.#goalTurnHadToolCalls = false;
+		this.#goalContinuationTurnInFlight = false;
+		this.#goalSuppressNextContinuation = false;
+	}
+
+	// --- Continuation state (driven by adapter session subscribers) ---
+
+	onAgentStart(): void {
+		this.#goalTurnHadToolCalls = false;
+	}
+
+	onToolStart(): void {
+		this.#goalTurnHadToolCalls = true;
+		if (!this.#goalContinuationTurnInFlight) {
+			this.#goalSuppressNextContinuation = false;
+		}
+	}
+
+	/** Adapter hook for `goal_updated` session events. Drop restores the previous tool set. */
+	async onGoalUpdated(state: GoalModeState | undefined): Promise<void> {
+		if (state?.goal?.status !== "dropped") return;
+		if (this.#previousTools !== undefined) {
+			await this.#session.setActiveToolsByName(this.#previousTools);
+			this.#previousTools = undefined;
+		}
+	}
+
+	/**
+	 * Adapter hook for `agent_end`. Computes the anti-talk-loop suppression from
+	 * the just-finished continuation turn, performs the completion cleanup when
+	 * the goal is exiting, and returns the continuation decision otherwise.
+	 */
+	async onAgentEnd(): Promise<GoalContinuationDecision> {
+		if (this.#goalContinuationTurnInFlight) {
+			this.#goalSuppressNextContinuation = !this.#goalTurnHadToolCalls;
+			this.#goalContinuationTurnInFlight = false;
+		}
+		if (this.#session.getGoalModeState()?.mode === "exiting") {
+			await this.deactivate({ completed: true });
+			return null;
+		}
+		return this.buildContinuationForSubmission();
+	}
+
+	/**
+	 * Continuation DECISION: prompt when the goal is active and no suppression is
+	 * armed. Suppression is armed ONLY by a continuation turn that made no tool
+	 * calls (see {@link onAgentEnd}); a normal/user turn never suppresses here even
+	 * if it made no tool calls — matching the original #scheduleGoalContinuation
+	 * semantics. The ADAPTER applies its own run-mode gate
+	 * (`goal.continuationModes` includes its mode id) before submitting — the TUI
+	 * additionally checks editor/pending-input/streaming.
+	 */
+	buildContinuationForSubmission(): GoalContinuationDecision {
+		const state = this.#session.getGoalModeState();
+		if (!state?.enabled || state.goal.status !== "active") return null;
+		if (this.#goalSuppressNextContinuation) return null;
+		const prompt = this.#session.goalRuntime.buildContinuationPrompt();
+		if (!prompt) return null;
+		return { prompt };
+	}
+
+	/** Clears the next-continuation suppression (user input, tool activity, fresh goal ops). */
+	resetContinuationSuppression(): void {
+		this.#goalSuppressNextContinuation = false;
+	}
+
+	/** Adapter marks that it submitted a goal continuation (arms suppression accounting). */
+	markContinuationInFlight(): void {
+		this.#goalContinuationTurnInFlight = true;
+	}
+
+	/** Adapter marks that a goal-continuation submission was cancelled/finished without an agent_end. */
+	noteContinuationSubmissionEnded(): void {
+		this.#goalContinuationTurnInFlight = false;
+	}
+
+	dispose(): void {
+		this.#previousTools = undefined;
+		this.#goalTurnHadToolCalls = false;
+		this.#goalContinuationTurnInFlight = false;
+		this.#goalSuppressNextContinuation = false;
+	}
+}

--- a/packages/coding-agent/src/goals/headless-goal-adapter.ts
+++ b/packages/coding-agent/src/goals/headless-goal-adapter.ts
@@ -1,0 +1,134 @@
+import { logger } from "@oh-my-pi/pi-utils";
+import type { AgentSession } from "../session/agent-session";
+
+/**
+ * Headless (ACP/RPC) goal-mode driver.
+ *
+ * Subscribes to session events and drives the shared `GoalModeController` the
+ * same way InteractiveMode does for the TUI: forward agent/tool/goal lifecycle
+ * events to the controller hooks, then at `agent_end` submit the continuation
+ * prompt the controller computed via the central agent-initiated-turn path
+ * (`sendCustomMessage` `triggerTurn`), so the session's `deferAgentInitiatedTurns`
+ * gate applies: RPC runs the continuation turn immediately; ACP queues it to
+ * drain on the next explicit client turn (ACP v1 clients cannot show a
+ * server-initiated turn as busy after a prompt response). Submission is gated
+ * on the run-mode setting (`goal.continuationModes` includes `modeId`) and on
+ * the goal still being active after a short settle delay. Continuation is
+ * opt-in: the default `goal.continuationModes = ["interactive"]` keeps headless
+ * continuation off, while the first turn always runs (the /goal set handler
+ * returns the kickoff prompt).
+ *
+ * Lifecycle: `attachHeadlessGoalAdapter` is async — it awaits an initial
+ * `controller.restore()` (race-free reconciliation of any persisted goal before
+ * the first user op) and registers itself as the session's switch reconciler so
+ * an in-process `switchSession` (RPC `handleRpcSessionChange`) re-reconciles
+ * instead of leaking the prior goal state into the new transcript. The returned
+ * detach clears the reconciler and unsubscribes.
+ *
+ * The subscriber never throws: every async branch is caught and logged so an
+ * adapter failure cannot propagate into the session's event dispatch.
+ */
+export async function attachHeadlessGoalAdapter(session: AgentSession, modeId: "acp" | "rpc"): Promise<() => void> {
+	const controller = session.goalModeController;
+	// Real AgentSessions always construct a GoalModeController + expose the
+	// switch-reconciler slot. Test doubles that don't model the goal surface are
+	// skipped inertly (the wiring is exercised against full stubs in
+	// headless-goal-adapter.test.ts).
+	if (!controller || typeof session.setSessionSwitchReconciler !== "function") {
+		return () => {};
+	}
+	const reconcile = async (): Promise<void> => {
+		await controller.restore();
+	};
+	session.setSessionSwitchReconciler(reconcile);
+	const unsubscribe = session.subscribe(event => {
+		try {
+			switch (event.type) {
+				case "agent_start":
+					controller.onAgentStart();
+					return;
+				case "tool_execution_start":
+					controller.onToolStart();
+					return;
+				case "message_start":
+					// A real (non-synthetic) user message clears continuation
+					// suppression, mirroring InteractiveMode — the user retook
+					// control, so a prior talk-only continuation must not block the
+					// next auto-continue.
+					if (event.message.role === "user" && !event.message.synthetic) {
+						controller.resetContinuationSuppression();
+					}
+					return;
+				case "goal_updated":
+					void controller
+						.onGoalUpdated(event.state)
+						.catch(error => logger.error("Headless goal adapter: goal_updated handler failed", { error }));
+					return;
+				case "agent_end":
+					void submitContinuationIfDue(session, modeId).catch(error =>
+						logger.error("Headless goal adapter: agent_end handler failed", { error }),
+					);
+					return;
+				default:
+					return;
+			}
+		} catch (error) {
+			logger.error("Headless goal adapter: subscriber threw", { error });
+		}
+	});
+	// Race-free initial reconciliation of a persisted goal before any user op.
+	try {
+		await controller.restore();
+	} catch (error) {
+		logger.error("Headless goal adapter: initial restore failed", { error });
+	}
+	return () => {
+		session.setSessionSwitchReconciler(null);
+		unsubscribe();
+	};
+}
+
+async function submitContinuationIfDue(session: AgentSession, modeId: "acp" | "rpc"): Promise<void> {
+	const decision = await session.goalModeController.onAgentEnd();
+	if (!decision) return;
+	const continuationModes: readonly string[] = session.settings.get("goal.continuationModes");
+	if (!continuationModes.includes(modeId)) return;
+	if (session.isStreaming) return;
+	// Let the just-finished turn's tail events (message_end, async deliveries)
+	// settle so the follow-up queues behind a settled agent state.
+	await Bun.sleep(50);
+	if (session.isStreaming) return;
+	const state = session.getGoalModeState();
+	if (!state?.enabled || state.goal.status !== "active") return;
+	// Route through the central agent-initiated-turn path (sendCustomMessage
+	// triggerTurn) so the session's deferAgentInitiatedTurns gate applies.
+	//  - RPC (no client bridge): the turn runs synchronously INSIDE sendCustomMessage
+	//    (it awaits the whole turn), so its own agent_end fires — and is handled
+	//    recursively right here — BEFORE this await resolves. The continuation
+	//    mark MUST therefore precede the call so that agent_end's suppression
+	//    accounting sees this as a continuation turn; marking after would miss it
+	//    and let a talk-only continuation loop forever. Roll back on failure.
+	//  - ACP (deferAgentInitiatedTurns): the continuation is QUEUED to drain on
+	//    the next explicit client turn — a client-driven turn, not an
+	//    agent-initiated continuation — so do NOT mark. A bare mark or followUp()
+	//    would bypass the gate and start a server-initiated turn the ACP v1
+	//    client cannot display as busy (#5628).
+	if (modeId === "rpc") {
+		session.goalModeController.markContinuationInFlight();
+		try {
+			await session.sendCustomMessage(
+				{ customType: "goal-continuation", content: decision.prompt },
+				{ triggerTurn: true },
+			);
+		} catch (error) {
+			// Turn didn't run — undo the mark so it isn't counted against the next turn.
+			session.goalModeController.noteContinuationSubmissionEnded();
+			throw error;
+		}
+	} else {
+		await session.sendCustomMessage(
+			{ customType: "goal-continuation", content: decision.prompt },
+			{ triggerTurn: true },
+		);
+	}
+}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -55,6 +55,7 @@ import { runExtensionCompact } from "../../extensibility/extensions/compact-hand
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
+import { attachHeadlessGoalAdapter } from "../../goals/headless-goal-adapter";
 import { resolveLocalUrlToPath } from "../../internal-urls";
 import { MCPManager } from "../../mcp/manager";
 import type { MCPServerConfig } from "../../mcp/types";
@@ -177,6 +178,9 @@ type ManagedSessionRecord = {
 	// Installed inside `#scheduleBootstrapUpdates` (post-race-guard); released
 	// in `#disposeSessionRecord`. Lives independent of any prompt turn.
 	lifetimeUnsubscribe: (() => void) | undefined;
+	// Headless goal-mode adapter (drives GoalModeController from session events).
+	// Installed in `#registerPreparedSession`; released in `#disposeSessionRecord`.
+	goalAdapterUnsubscribe: (() => void) | undefined;
 	closedError: PromptLifecycleError | undefined;
 	promptEventHandlers: Set<Promise<void>>;
 	extensionUserMessageTasks: Set<Promise<void>>;
@@ -1134,6 +1138,9 @@ export class AcpAgent implements Agent {
 
 	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
+		// Drive goal-mode lifecycle for this headless ACP session (enter/resume/
+		// drop + opt-in auto-continuation). Released in `#disposeSessionRecord`.
+		record.goalAdapterUnsubscribe = await attachHeadlessGoalAdapter(session, "acp");
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
@@ -1163,6 +1170,7 @@ export class AcpAgent implements Agent {
 			promptEventHandlers: new Set(),
 			extensionUserMessageTasks: new Set(),
 			lifetimeUnsubscribe: undefined,
+			goalAdapterUnsubscribe: undefined,
 		};
 	}
 
@@ -2547,6 +2555,7 @@ export class AcpAgent implements Agent {
 
 	async #disposeSessionRecord(record: ManagedSessionRecord, reason?: postmortem.Reason): Promise<void> {
 		record.lifetimeUnsubscribe?.();
+		record.goalAdapterUnsubscribe?.();
 		if (record.mcpManager) {
 			try {
 				await record.mcpManager.disconnectAll();

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -189,6 +189,7 @@ type ManagedSessionRecord = {
 type ReplayableMessage = {
 	role: string;
 	content?: unknown;
+	attribution?: string;
 	errorMessage?: string;
 	toolCallId?: string;
 	toolName?: string;
@@ -843,7 +844,12 @@ export class AcpAgent implements Agent {
 		});
 		if (builtinResult !== false) {
 			if ("prompt" in builtinResult) {
-				await record.session.prompt(builtinResult.prompt, { images });
+				// Synthetic residual prompts (guided-goal interview kickoff) are
+				// delivered as hidden developer messages, matching the TUI path.
+				await record.session.prompt(builtinResult.prompt, {
+					images,
+					synthetic: builtinResult.synthetic === true,
+				});
 				return;
 			}
 			const promptTurn = record.promptTurn;
@@ -2090,6 +2096,17 @@ export class AcpAgent implements Agent {
 			message.role === "custom" ||
 			message.role === "hookMessage"
 		) {
+			// Synthetic prompts persist as developer-role messages with agent
+			// attribution (see AgentSession.prompt). They are hidden steering —
+			// the guided-goal interview kickoff among them — not user-authored
+			// content, so replaying them as a user_message_chunk would expose
+			// internal instructions as if the user had typed them. Keep them
+			// hidden from ACP clients, matching the TUI's hidden-developer
+			// treatment. User-attributed developer messages (e.g. file mentions)
+			// still replay.
+			if (message.role === "developer" && message.attribution === "agent") {
+				return [];
+			}
 			return this.#wrapReplayContent(
 				sessionId,
 				this.#extractReplayContent(message.content, undefined),

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1144,15 +1144,22 @@ export class AcpAgent implements Agent {
 
 	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
-		// Drive goal-mode lifecycle for this headless ACP session (enter/resume/
-		// drop + opt-in auto-continuation). Released in `#disposeSessionRecord`.
-		record.goalAdapterUnsubscribe = await attachHeadlessGoalAdapter(session, "acp");
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
 		try {
-			await this.#configureExtensions(record);
 			await this.#configureMcpServers(record, mcpServers);
+			// Drive goal-mode lifecycle for this headless ACP session (enter/resume/
+			// drop + opt-in auto-continuation). Released in `#disposeSessionRecord`.
+			// Attach AFTER MCP config and BEFORE extensions' `session_start`: the
+			// attach-time `controller.restore()` snapshots `#previousTools` from the
+			// enabled tool set (so MCP tools must already be enabled — otherwise a
+			// later pause/drop/complete restores a stale snapshot and deactivates
+			// them), and the adapter must be subscribed before `session_start` so an
+			// extension that sends a message there starts its turn with goal state
+			// restored and lifecycle events forwarded.
+			record.goalAdapterUnsubscribe = await attachHeadlessGoalAdapter(session, "acp");
+			await this.#configureExtensions(record);
 			this.#sessions.set(session.sessionId, record);
 			return record;
 		} catch (error) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -79,7 +79,7 @@ import type {
 import type { CompactOptions } from "../extensibility/extensions/types";
 import type { Skill } from "../extensibility/skills";
 import { loadSlashCommands } from "../extensibility/slash-commands";
-import type { Goal, GoalModeState } from "../goals/state";
+import type { GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
 import type { MCPManager } from "../mcp";
@@ -111,7 +111,6 @@ import { getRecentSessions } from "../session/session-listing";
 import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
-import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { formatTaskId } from "../task/render";
@@ -566,14 +565,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	readonly #version: string;
 	readonly #startupChangelog: StartupChangelogSelection | undefined;
 	#planModePreviousTools: string[] | undefined;
-	#goalModePreviousTools: string[] | undefined;
 	#vibeModePreviousTools: string[] | undefined;
 	#vibeModeOwnerScope: VibeOwnerScope | undefined;
 	#vibeScopeSuspendedForSwitch = false;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
-	#goalTurnHadToolCalls = false;
-	#goalContinuationTurnInFlight = false;
-	#goalSuppressNextContinuation = false;
 	#planModePreviousModelState: { model: Model; thinkingLevel?: ConfiguredThinkingLevel } | undefined;
 	#pendingModelSwitch: { model: Model; thinkingLevel?: ConfiguredThinkingLevel } | undefined;
 	/** Whether #pendingModelSwitch was queued by the live plan-role reconciler. */
@@ -1376,7 +1371,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!this.session.settings.get("goal.continuationModes").includes("interactive")) return;
 		if (this.planModeEnabled || this.planModePaused) return;
 		if (!this.goalModeEnabled || this.goalModePaused) return;
-		if (this.#goalSuppressNextContinuation) return;
+		if (this.session.goalModeController.isContinuationSuppressed()) return;
 		if (this.#pendingSubmittedInput) return;
 		if (this.editor.getText().trim().length > 0) return;
 		if ((this.editor.pendingImages?.length ?? 0) > 0) return;
@@ -1401,7 +1396,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			if ((this.editor.pendingImages?.length ?? 0) > 0) return;
 			const latestState = this.session.getGoalModeState();
 			if (!latestState?.enabled || latestState.goal.status !== "active") return;
-			this.#goalContinuationTurnInFlight = true;
+			this.session.goalModeController.markContinuationInFlight();
 			this.onInputCallback(
 				this.startPendingSubmission({
 					text: prompt,
@@ -1604,7 +1599,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 		this.#pendingSubmittedInput = submission;
 		if (!submission.customType) {
-			this.#resetGoalContinuationSuppression();
+			this.session.goalModeController.resetContinuationSuppression();
 			const imageCount = submission.images?.length ?? 0;
 			this.optimisticUserMessageSignature = `${submission.text}\u0000${imageCount}`;
 			this.#pendingSubmissionDispose = this.recordLocalSubmission(submission.text, imageCount);
@@ -1640,7 +1635,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.clearOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (submission.customType === "goal-continuation") {
-			this.#goalContinuationTurnInFlight = false;
+			this.session.goalModeController.noteContinuationSubmissionEnded();
 		}
 		if (this.loadingAnimation) {
 			this.#stopLoadingAnimation(true);
@@ -1678,7 +1673,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#pendingSubmissionDispose = undefined;
 		}
 		if (input.customType === "goal-continuation") {
-			this.#goalContinuationTurnInFlight = false;
+			this.session.goalModeController.noteContinuationSubmissionEnded();
 		}
 
 		if (wasPendingSubmission && !this.session.isStreaming && !this.streamingComponent) {
@@ -2257,10 +2252,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.requestRender();
 	}
 
-	#resetGoalContinuationSuppression(): void {
-		this.#goalSuppressNextContinuation = false;
-	}
-
 	#getPausedGoalState(): GoalModeState | undefined {
 		const state = this.session.getGoalModeState();
 		if (!state?.goal || state.enabled || state.goal.status !== "paused") {
@@ -2269,54 +2260,25 @@ export class InteractiveMode implements InteractiveModeContext {
 		return state;
 	}
 
-	#goalFromModeData(modeData: SessionContext["modeData"]): Goal | undefined {
-		const goal = modeData?.goal;
-		if (!goal || typeof goal !== "object") return undefined;
-		const value = goal as Record<string, unknown>;
-		if (
-			typeof value.id !== "string" ||
-			typeof value.objective !== "string" ||
-			typeof value.status !== "string" ||
-			typeof value.tokensUsed !== "number" ||
-			typeof value.timeUsedSeconds !== "number" ||
-			typeof value.createdAt !== "number" ||
-			typeof value.updatedAt !== "number"
-		) {
-			return undefined;
-		}
-		return {
-			id: value.id,
-			objective: value.objective,
-			status: value.status as Goal["status"],
-			tokenBudget: typeof value.tokenBudget === "number" ? value.tokenBudget : undefined,
-			tokensUsed: value.tokensUsed,
-			timeUsedSeconds: value.timeUsedSeconds,
-			createdAt: value.createdAt,
-			updatedAt: value.updatedAt,
-		};
-	}
-
 	async #handleGoalSessionEvent(event: AgentSessionEvent): Promise<void> {
 		if (event.type === "agent_start") {
-			this.#goalTurnHadToolCalls = false;
+			this.session.goalModeController.onAgentStart();
 			this.#cancelGoalContinuation();
 			return;
 		}
 		if (event.type === "tool_execution_start") {
-			this.#goalTurnHadToolCalls = true;
-			if (!this.#goalContinuationTurnInFlight) {
-				this.#resetGoalContinuationSuppression();
-			}
+			this.session.goalModeController.onToolStart();
 			return;
 		}
 		if (event.type === "message_start" && event.message.role === "user" && !event.message.synthetic) {
-			this.#resetGoalContinuationSuppression();
+			this.session.goalModeController.resetContinuationSuppression();
 			return;
 		}
 		if (event.type === "goal_updated") {
-			// Handle drop before clearing goalModeEnabled so #exitGoalMode can
+			// Handle drop before clearing goalModeEnabled so the controller can
 			// still restore the previous tool set while the flag is true.
 			if (event.state?.goal?.status === "dropped") {
+				await this.session.goalModeController.onGoalUpdated(event.state);
 				await this.#exitGoalMode({ reason: "dropped", silent: true });
 				return;
 			}
@@ -2331,12 +2293,13 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (event.type !== "agent_end") {
 			return;
 		}
-		if (this.#goalContinuationTurnInFlight) {
-			this.#goalSuppressNextContinuation = !this.#goalTurnHadToolCalls;
-			this.#goalContinuationTurnInFlight = false;
-		}
-		if (this.session.getGoalModeState()?.mode === "exiting") {
-			await this.#exitGoalMode({ reason: "completed", silent: true });
+		const wasExiting = this.session.getGoalModeState()?.mode === "exiting";
+		await this.session.goalModeController.onAgentEnd();
+		if (wasExiting) {
+			this.goalModeEnabled = false;
+			this.goalModePaused = false;
+			this.#cancelGoalContinuation();
+			this.#updateGoalModeStatus();
 			return;
 		}
 		this.#scheduleGoalContinuation();
@@ -2456,16 +2419,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (this.goalModeEnabled || this.goalModePaused) {
-			if (this.#goalModePreviousTools !== undefined) {
-				await this.session.setActiveToolsByName(this.#goalModePreviousTools);
-			}
-			this.session.setGoalModeState(undefined);
+			await this.session.goalModeController.deactivate({
+				restoreTools: this.session.goalModeController.previousTools !== undefined,
+				clearState: true,
+			});
 			this.goalModeEnabled = false;
 			this.goalModePaused = false;
-			this.#goalModePreviousTools = undefined;
-			this.#goalTurnHadToolCalls = false;
-			this.#goalContinuationTurnInFlight = false;
-			this.#goalSuppressNextContinuation = false;
 			this.#cancelGoalContinuation();
 			this.#updateGoalModeStatus();
 		}
@@ -2504,36 +2463,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#vibeModeOwnerScope.parentSessionFile === targetVibeScope.parentSessionFile;
 		await this.#clearTransientModeState({ preserveVibe, vibeScopeAlreadySuspended });
 		await VibeSessionRegistry.global().rehydrate(vibeSession);
-		const goalEnabled = this.session.settings.get("goal.enabled");
-		if (!goalEnabled && (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused")) {
-			this.session.goalRuntime.clearAccounting();
-			this.sessionManager.appendModeChange("none");
-			return;
-		}
 		if (sessionContext.mode === "goal" || sessionContext.mode === "goal_paused") {
-			const goal = this.#goalFromModeData(sessionContext.modeData);
-			if (!goal) {
-				this.sessionManager.appendModeChange("none");
-				return;
-			}
-			this.session.setGoalModeState({
-				enabled: sessionContext.mode === "goal",
-				mode: "active",
-				goal,
-			});
-			const restored = await this.session.goalRuntime.onThreadResumed({
+			const restored = await this.session.goalModeController.restore({
 				preserveActiveGoal: options?.preserveActiveGoal,
 			});
-			this.goalModeEnabled = restored?.enabled === true;
-			this.goalModePaused = restored?.enabled !== true && restored?.goal.status === "paused";
-			// sdk.ts excludes "goal" from the initial active tool set unconditionally.
-			// Re-add it now so the agent can call resume, complete, or drop on this goal.
-			if (restored?.goal) {
-				const previousTools = this.session.getEnabledToolNames().filter(name => name !== "goal");
-				this.#goalModePreviousTools = previousTools;
-				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+			if (restored) {
+				this.goalModeEnabled = restored.enabled === true;
+				this.goalModePaused = restored.enabled !== true && restored.goal.status === "paused";
+				this.#updateGoalModeStatus();
 			}
-			this.#updateGoalModeStatus();
 			return;
 		}
 		this.session.goalRuntime.clearAccounting();
@@ -2745,17 +2683,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit vibe mode first.");
 			return;
 		}
-		const previousTools = this.session.getEnabledToolNames().filter(name => name !== "goal");
-		const goalTools = [...new Set([...previousTools, "goal"])];
-		this.#goalModePreviousTools = previousTools;
+		const result = options.resume
+			? await this.session.goalModeController.resume()
+			: await this.session.goalModeController.enter(options.objective ?? "");
+		if (!result.ok) {
+			throw new Error(result.error);
+		}
 		this.goalModePaused = false;
-		const state = options.resume
-			? await this.session.goalRuntime.resumeGoal()
-			: await this.session.goalRuntime.createGoal({ objective: options.objective ?? "" });
-		await this.session.setActiveToolsByName(goalTools);
-		this.session.setGoalModeState(state);
 		this.goalModeEnabled = true;
-		this.#resetGoalContinuationSuppression();
+		this.session.goalModeController.resetContinuationSuppression();
 		this.#updateGoalModeStatus();
 		if (this.session.isStreaming) {
 			await this.session.sendGoalModeContext({ deliverAs: "steer" });
@@ -2770,25 +2706,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		paused?: boolean;
 		reason?: "completed" | "paused" | "dropped";
 	}): Promise<void> {
-		const previousTools = this.#goalModePreviousTools;
-		if (this.goalModeEnabled && previousTools) {
-			await this.session.setActiveToolsByName(previousTools);
-		}
-		const currentState = this.session.getGoalModeState();
-		if (options?.reason === "completed") {
-			this.session.setGoalModeState(undefined);
-			this.sessionManager.appendModeChange("none");
-			this.sessionManager.appendCustomEntry("goal-completed", {
-				objective: currentState?.goal?.objective,
-				tokensUsed: currentState?.goal?.tokensUsed,
-				tokenBudget: currentState?.goal?.tokenBudget,
-				timeUsedSeconds: currentState?.goal?.timeUsedSeconds,
-			});
-		}
+		await this.session.goalModeController.deactivate({
+			restoreTools: this.goalModeEnabled && this.session.goalModeController.previousTools !== undefined,
+			completed: options?.reason === "completed",
+		});
 		this.goalModeEnabled = false;
 		this.goalModePaused = options?.paused ?? false;
-		this.#goalModePreviousTools = undefined;
-		this.#goalContinuationTurnInFlight = false;
 		this.#cancelGoalContinuation();
 		this.#updateGoalModeStatus();
 		if (!options?.silent) {
@@ -3428,8 +3351,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 			nextBudget = parsed;
 		}
-		await this.session.goalRuntime.onBudgetMutated(nextBudget);
-		this.#resetGoalContinuationSuppression();
+		const result = await this.session.goalModeController.setBudget(nextBudget);
+		if (!result.ok) {
+			throw new Error(result.error);
+		}
+		this.session.goalModeController.resetContinuationSuppression();
 		this.#scheduleGoalContinuation();
 		this.showStatus(nextBudget === undefined ? "Goal budget cleared." : `Goal budget set to ${nextBudget}.`);
 	}
@@ -3510,11 +3436,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			// calling `goal create`. Record the pre-interview toolset first: the
 			// tool-driven create flips goalModeEnabled via `goal_updated`, and the
 			// eventual goal exit restores this set (dropping the goal tool again).
-			const enabledTools = this.session.getEnabledToolNames();
-			this.#goalModePreviousTools = enabledTools.filter(name => name !== "goal");
-			if (!enabledTools.includes("goal")) {
-				await this.session.setActiveToolsByName([...enabledTools, "goal"]);
-			}
+			await this.session.goalModeController.exposeGoalTool();
 
 			// The interview is a normal conversation: the kickoff rides in as a
 			// hidden developer message, the agent asks its questions as regular
@@ -3600,24 +3522,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	#showGoalDetails(): void {
-		const state = this.session.getGoalModeState();
-		const goal = state?.goal;
-		if (!goal) {
-			this.showStatus("No goal set.");
-			return;
-		}
-		const used = goal.tokensUsed.toLocaleString();
-		const budgetLine =
-			goal.tokenBudget !== undefined
-				? `${used} / ${goal.tokenBudget.toLocaleString()} (${Math.max(0, goal.tokenBudget - goal.tokensUsed).toLocaleString()} left)`
-				: `${used} (no budget)`;
-		const lines = [
-			`Objective: ${goal.objective}`,
-			`Status: ${goal.status}${state?.enabled ? "" : " (paused)"}`,
-			`Tokens: ${budgetLine}`,
-			`Time spent: ${formatDuration(goal.timeUsedSeconds * 1000)}`,
-		];
-		this.showStatus(lines.join("\n"));
+		this.showStatus(this.session.goalModeController.show());
 	}
 
 	async #promptGoalBudgetEdit(): Promise<void> {
@@ -3637,7 +3542,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("No active goal to pause.");
 			return;
 		}
-		await this.session.goalRuntime.pauseGoal();
+		const result = await this.session.goalModeController.pause();
+		if (!result.ok) {
+			throw new Error(result.error);
+		}
 		await this.#exitGoalMode({ paused: true, reason: "paused" });
 	}
 
@@ -3661,24 +3569,29 @@ export class InteractiveMode implements InteractiveModeContext {
 			"This removes the goal record. Accumulated usage stays in the session log.",
 		);
 		if (!confirmed) return;
-		await this.session.goalRuntime.dropGoal();
+		const result = await this.session.goalModeController.drop();
+		if (!result.ok) {
+			throw new Error(result.error);
+		}
 		await this.#exitGoalMode({ reason: "dropped" });
 	}
 
 	async #startGoalFromObjective(objective: string): Promise<void> {
 		await this.#enterGoalMode({ objective, silent: true });
-		this.#resetGoalContinuationSuppression();
+		this.session.goalModeController.resetContinuationSuppression();
 		if (!this.session.isStreaming && this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective }));
 		}
 	}
 
 	async #replaceGoalFromObjective(objective: string): Promise<void> {
-		const state = await this.session.goalRuntime.replaceGoal({ objective });
-		this.session.setGoalModeState(state);
+		const result = await this.session.goalModeController.replaceObjective(objective);
+		if (!result.ok) {
+			throw new Error(result.error);
+		}
 		this.goalModeEnabled = true;
 		this.goalModePaused = false;
-		this.#resetGoalContinuationSuppression();
+		this.session.goalModeController.resetContinuationSuppression();
 		this.#updateGoalModeStatus();
 		if (this.session.isStreaming) {
 			await this.session.sendGoalModeContext({ deliverAs: "steer" });

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -25,7 +25,6 @@ import {
 } from "../../extensibility/extensions";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
-import { attachHeadlessGoalAdapter } from "../../goals/headless-goal-adapter";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
@@ -34,12 +33,12 @@ import { buildAvailableSlashCommands } from "../../slash-commands/available-comm
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import type { EventBus } from "../../utils/event-bus";
 import { calculateTokensPerSecond } from "../../utils/token-rate";
-import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
+import { runRpcSessionStartup } from "./rpc-session-init";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -932,8 +931,10 @@ export async function runRpcMode(
 	const rpcUiContext = new RpcExtensionUIContext(pendingExtensionRequests, output);
 	setToolUIContext?.(rpcUiContext, true);
 
-	// Set up extensions with RPC-based UI context
-	await initializeExtensions(session, {
+	// Run the ordering-critical RPC startup sequence — subscribe -> deferred
+	// extension init -> goal restore -> session_start — through the shared
+	// helper so the production wiring and the ordering test bind to one place.
+	const detachGoalAdapter = await runRpcSessionStartup(session, output, {
 		reportSendError: (action, err) => {
 			output(error(undefined, action, err.message));
 		},
@@ -948,16 +949,6 @@ export async function runRpcMode(
 		},
 		uiContext: rpcUiContext,
 	});
-
-	// Output all agent events as JSON
-	session.subscribe(event => {
-		output(event);
-	});
-
-	// Drive goal-mode lifecycle for this headless RPC session (enter/resume/
-	// drop + opt-in auto-continuation). Detached at shutdown so no continuation
-	// can be submitted after session.dispose().
-	const detachGoalAdapter = await attachHeadlessGoalAdapter(session, "rpc");
 
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
 	const reloadPluginState = async () => {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1016,7 +1016,11 @@ export async function runRpcMode(
 					if ("prompt" in builtinResult) {
 						watchAndReportLocalOnlyPromptResult({
 							id,
-							startPrompt: () => session.prompt(builtinResult.prompt, { images: command.images }),
+							startPrompt: () =>
+								session.prompt(builtinResult.prompt, {
+									images: command.images,
+									synthetic: builtinResult.synthetic === true,
+								}),
 							output,
 							onError: promptError => output(error(id, "prompt", promptError.message)),
 							extensionUserMessageTracker,

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -25,6 +25,7 @@ import {
 } from "../../extensibility/extensions";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
+import { attachHeadlessGoalAdapter } from "../../goals/headless-goal-adapter";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
@@ -953,6 +954,11 @@ export async function runRpcMode(
 		output(event);
 	});
 
+	// Drive goal-mode lifecycle for this headless RPC session (enter/resume/
+	// drop + opt-in auto-continuation). Detached at shutdown so no continuation
+	// can be submitted after session.dispose().
+	const detachGoalAdapter = await attachHeadlessGoalAdapter(session, "rpc");
+
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
 	const reloadPluginState = async () => {
 		const cwd = session.sessionManager.getCwd();
@@ -1460,6 +1466,7 @@ export async function runRpcMode(
 			// the process exits. dispose() also emits `session_shutdown`, so we
 			// must NOT emit it separately here or the event fires twice. Skipping
 			// dispose left OMP-owned Chromium alive after RPC shutdown (#5643).
+			detachGoalAdapter();
 			await session.dispose();
 			process.exit(0);
 		},
@@ -1514,6 +1521,7 @@ export async function runRpcMode(
 	// bounded teardown run on the stdin-EOF path too (#5643). Idempotent: a
 	// prior pi.shutdown() through the coordinator makes this await settle
 	// immediately.
+	detachGoalAdapter();
 	await session.dispose();
 	process.exit(0);
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-session-init.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-session-init.ts
@@ -1,0 +1,104 @@
+/**
+ * Ordering-critical RPC session startup.
+ *
+ * RPC mode must start a resuming session in this exact order:
+ *   1. install the output subscriber,
+ *   2. initializeExtensions with `emitSessionStart: false` and the runtime
+ *      event delivery gate engaged (`pauseRuntimeEventDelivery: true`),
+ *   3. attachHeadlessGoalAdapter (its initial `controller.restore()`),
+ *   4. resumeRuntimeEventDelivery (buffered credential_disabled /
+ *      mcp_notification deliver now that the goal is restored),
+ *   5. emitExtensionSessionStart.
+ *
+ * Restore() is what reconciles a persisted goal: it sets goal-mode state,
+ * exposes the `goal` tool, and emits `goal_updated`. That event must reach
+ * (a) the output subscriber installed BEFORE restore (get_state has no goal
+ * field — the event is the only client signal) and (b) an INITIALIZED
+ * extension runner (an uninitialized runtime throws on tool access). And
+ * `session_start` must fire only AFTER restore so a session_start handler that
+ * inspects tools or starts a turn observes goal-mode state.
+ *
+ * The runtime event delivery gate covers the second turn-starting hazard:
+ * `credential_disabled` / `mcp_notification` handlers may call
+ * `pi.sendUserMessage` and start a turn. The runner must be initialized
+ * BEFORE restore (so restore's `goal_updated` reaches initialized handlers),
+ * but if notifications buffered before initialize were drained during
+ * initialize — or if fresh ones delivered immediately — the resulting turn
+ * would run with NO goal restored. The gate holds those two event types
+ * buffered from initialize until step 4, so a notification handler that sends
+ * a message starts its turn in goal mode. `goal_updated` is deliberately NOT
+ * gated: restore's `goal_updated` reaches initialized handlers while the gate
+ * is still held.
+ *
+ * The whole sequence lives here — not inline in runRpcMode — so the ordering
+ * test binds to the same production wiring it guards.
+ */
+import { attachHeadlessGoalAdapter } from "../../goals/headless-goal-adapter";
+import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
+import { emitExtensionSessionStart, type InitializeExtensionsOptions, initializeExtensions } from "../runtime-init";
+
+/**
+ * Run the RPC startup sequence: install the event subscriber, initialize the
+ * extension runner WITHOUT emitting `session_start` and with runtime event
+ * delivery paused, restore any persisted goal via the headless goal adapter,
+ * resume runtime event delivery (buffered notifications now deliver with the
+ * goal restored), then emit `session_start` last.
+ *
+ * @param output Event sink for agent session events (RPC stdout in production).
+ * @param options Extension init options; `emitSessionStart` is forced to false
+ *   and `pauseRuntimeEventDelivery` defaults to true (pass `false` only to
+ *   prove the gate is load-bearing) so `session_start` can never precede the
+ *   goal restore and no startup notification can start a turn before it.
+ * @returns The goal-adapter detach function (unsubscribes + clears the switch
+ *   reconciler). Call it at shutdown before `session.dispose()`.
+ */
+export async function runRpcSessionStartup(
+	session: AgentSession,
+	output: (event: AgentSessionEvent) => void,
+	options: Omit<InitializeExtensionsOptions, "emitSessionStart">,
+): Promise<() => void> {
+	// Output all agent events as JSON. Installed BEFORE the goal adapter's
+	// initial restore so the `goal_updated` a resumed goal emits during restore
+	// reaches the client (get_state has no goal field — the event is the only
+	// signal). The steps below that precede restore (runner.initialize/onError)
+	// emit no agent events, so nothing spurious is forwarded during init.
+	session.subscribe(event => {
+		output(event);
+	});
+
+	// Set up extensions with RPC-based UI context, deferring `session_start`:
+	// a session_start handler may inspect tools or start a turn, so it must run
+	// AFTER the goal adapter has restored a persisted goal. The runner itself
+	// is still initialized here so the `goal_updated` emitted by restore()
+	// reaches initialized extension handlers — and runtime event delivery is
+	// paused so buffered/fresh credential_disabled / mcp_notification cannot
+	// start a turn before the restore (a handler that calls pi.sendUserMessage
+	// would run outside goal mode).
+	await initializeExtensions(session, {
+		...options,
+		emitSessionStart: false,
+		pauseRuntimeEventDelivery: options.pauseRuntimeEventDelivery ?? true,
+	});
+
+	// Drive goal-mode lifecycle for this headless RPC session (enter/resume/
+	// drop + opt-in auto-continuation). The initial restore reconciles a
+	// persisted goal and emits `goal_updated` — which must reach BOTH the
+	// output subscriber installed above AND the initialized extension runner
+	// (goal_updated is not gated). Detached at shutdown so no continuation can
+	// be submitted after session.dispose().
+	const detachGoalAdapter = await attachHeadlessGoalAdapter(session, "rpc");
+
+	// Deliver notifications held by the delivery gate: buffered (pre-init and
+	// during the pause) credential_disabled / mcp_notification now reach their
+	// handlers with the goal restored, so a handler that calls sendUserMessage
+	// starts its turn in goal mode. runner.onError was already registered by
+	// initializeExtensions, so the direct drain needs no microtask deferral.
+	await session.extensionRunner?.resumeRuntimeEventDelivery();
+
+	// Extensions now observe the restored session: any session_start handler
+	// that inspects tools or starts a turn sees goal-mode state. Emitted last
+	// so session_start can never precede the goal restore.
+	await emitExtensionSessionStart(session);
+
+	return detachGoalAdapter;
+}

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -28,11 +28,32 @@ export interface InitializeExtensionsOptions {
 	markAgentInvokingMessage?: () => void;
 	/** Optional lifecycle hook for extension-originated sends whose success/failure determines turn ownership. */
 	trackAgentInvokingMessage?: (task: Promise<unknown>) => void;
+	/**
+	 * Whether `initializeExtensions` emits the extension `session_start` event
+	 * once the runner is initialized. Defaults to true. Callers that must
+	 * restore session state (e.g. a persisted goal) before extensions observe
+	 * the session should pass `false` and emit the event themselves via
+	 * {@link emitExtensionSessionStart} after restoring.
+	 */
+	emitSessionStart?: boolean;
+	/**
+	 * When true, the runner holds `credential_disabled` / `mcp_notification`
+	 * delivery — buffering them, even after initialize — until
+	 * {@link ExtensionRunner.resumeRuntimeEventDelivery} is called. RPC sets
+	 * this so a startup notification handler that sends a message cannot start
+	 * a turn before the persisted goal is restored.
+	 */
+	pauseRuntimeEventDelivery?: boolean;
 }
 
 /**
  * Initialize the session's extension runner with the standard action set
  * shared by non-interactive modes, then emit `session_start`.
+ *
+ * Emits `session_start` unless `emitSessionStart: false` is passed; callers
+ * that need session state (e.g. a restored goal) visible to `session_start`
+ * handlers must defer the event with {@link emitExtensionSessionStart} until
+ * after that state is in place.
  *
  * No-op when the session was constructed without an extension runner.
  */
@@ -47,6 +68,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 		uiContext,
 		markAgentInvokingMessage,
 		trackAgentInvokingMessage,
+		pauseRuntimeEventDelivery,
 	} = options;
 	const shutdown = onShutdown ?? (() => {});
 
@@ -137,8 +159,23 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
 		},
 		uiContext,
+		{ pauseRuntimeEventDelivery },
 	);
 
 	runner.onError(reportRuntimeError);
-	await runner.emit({ type: "session_start" });
+	if (options.emitSessionStart !== false) {
+		await runner.emit({ type: "session_start" });
+	}
+}
+
+/**
+ * Emit the extension `session_start` event. Use with
+ * {@link initializeExtensions} `emitSessionStart: false` when `session_start`
+ * must observe state that is only available after initialization — e.g. a
+ * persisted goal restored by the goal-mode adapter, which emits `goal_updated`
+ * during restore. No-op when the session was constructed without an extension
+ * runner.
+ */
+export async function emitExtensionSessionStart(session: AgentSession): Promise<void> {
+	await session.extensionRunner?.emit({ type: "session_start" });
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -140,6 +140,7 @@ import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
 import { normalizeToolEventInput, resolveToolEventInput } from "../extensibility/tool-event-input";
+import { GoalModeController } from "../goals/goal-mode-controller";
 import { GoalRuntime } from "../goals/runtime";
 import type { GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
@@ -468,6 +469,7 @@ export class AgentSession {
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
+	#goalModeController: GoalModeController;
 	readonly #advisors: SessionAdvisors;
 	#goalTurnCounter = 0;
 	#planReferenceSent = false;
@@ -1376,6 +1378,7 @@ export class AgentSession {
 				);
 			},
 		});
+		this.#goalModeController = new GoalModeController(this, this.sessionManager);
 		this.#cancelExitRecorder = postmortem.register(`agent-session:${this.sessionManager.getSessionId()}`, reason => {
 			this.#recordSessionExit(reason);
 		});
@@ -4637,6 +4640,10 @@ export class AgentSession {
 
 	get goalRuntime(): GoalRuntime {
 		return this.#goalRuntime;
+	}
+
+	get goalModeController(): GoalModeController {
+		return this.#goalModeController;
 	}
 
 	markPlanReferenceSent(): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6478,6 +6478,19 @@ export class AgentSession {
 				});
 			}
 
+			// Reconcile session-scoped mode (e.g. goal mode) against the new
+			// transcript now that the transition is committed, mirroring
+			// switchSession(). Non-fatal: a reconciler failure must not roll
+			// back a successful new session.
+			try {
+				await this.#sessionSwitchReconciler?.();
+			} catch (error) {
+				logger.warn("Failed to reconcile session mode after new session", {
+					previousSessionFile,
+					error: String(error),
+				});
+			}
+
 			return true;
 		} finally {
 			if (advisorRecordersDetached) {
@@ -7828,6 +7841,20 @@ export class AgentSession {
 
 			this.#advisors.reattachRecorderFeeds();
 			advisorRecordersDetached = false;
+
+			// Reconcile session-scoped mode (e.g. goal mode) against the
+			// branched transcript now that the transition is committed,
+			// mirroring switchSession(). Non-fatal: a reconciler failure must
+			// not roll back a successful branch.
+			try {
+				await this.#sessionSwitchReconciler?.();
+			} catch (error) {
+				logger.warn("Failed to reconcile session mode after branch", {
+					previousSessionFile,
+					error: String(error),
+				});
+			}
+
 			return { selectedText, selectedImages, cancelled: false };
 		} finally {
 			if (advisorRecordersDetached) {

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -12,6 +12,7 @@ import type { AgentSession } from "../session/agent-session";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
+import { handleGoalAcp, handleGuidedGoalAcp } from "./helpers/goal";
 import { commandConsumed, errorMessage, usage } from "./helpers/parse";
 import { handleSecurityCommand } from "./helpers/security";
 import type { SlashCommandSpec } from "./types";
@@ -225,6 +226,9 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		],
 		inlineHint: "[objective]",
 		allowArgs: true,
+		acpDescription: "Manage goal mode",
+		acpInputHint: "[set <objective>|show|pause|resume|drop|budget <N|off>]",
+		handle: handleGoalAcp,
 		getTuiAutocompleteDescription: runtime => {
 			if (!runtime.ctx.settings.get("goal.enabled" as SettingPath)) return "Goal: disabled in settings";
 			if (runtime.ctx.planModeEnabled) return "Goal: blocked by plan mode";
@@ -241,6 +245,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		description: "Have the agent interview you in chat, then set up goal mode",
 		inlineHint: "[rough objective]",
 		allowArgs: true,
+		handle: handleGuidedGoalAcp,
 		handleTui: async (command, runtime) => {
 			// Clear the slash draft BEFORE the await: the handler blocks for the
 			// whole kickoff turn, and a post-await clear would wipe an answer the

--- a/packages/coding-agent/src/slash-commands/helpers/duration.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/duration.ts
@@ -1,0 +1,11 @@
+/** Format a millisecond duration as a coarse-grained human label. */
+export function formatDuration(ms: number): string {
+	const seconds = Math.max(0, Math.round(ms / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 48) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	return `${days}d`;
+}

--- a/packages/coding-agent/src/slash-commands/helpers/format.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/format.ts
@@ -1,17 +1,7 @@
 import { shimmerText } from "../../modes/theme/shimmer";
 import { theme as currentTheme, type Theme } from "../../modes/theme/theme";
 
-/** Format a millisecond duration as a coarse-grained human label. */
-export function formatDuration(ms: number): string {
-	const seconds = Math.max(0, Math.round(ms / 1000));
-	if (seconds < 60) return `${seconds}s`;
-	const minutes = Math.round(seconds / 60);
-	if (minutes < 60) return `${minutes}m`;
-	const hours = Math.round(minutes / 60);
-	if (hours < 48) return `${hours}h`;
-	const days = Math.round(hours / 24);
-	return `${days}d`;
-}
+export { formatDuration } from "./duration";
 
 type ProgressBarTheme = Pick<Theme, "bold" | "fg" | "getFgAnsi">;
 

--- a/packages/coding-agent/src/slash-commands/helpers/goal.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/goal.ts
@@ -98,5 +98,8 @@ export async function handleGuidedGoalAcp(
 	// feeds it as model input WITHIN the current client request — calling
 	// session.prompt() directly would nest an agent-initiated turn and break the
 	// ACP lifecycle (mirrors how /goal set returns {prompt} for its first turn).
-	return { prompt: interviewPrompt };
+	// Mark it synthetic (mirroring the TUI kickoff) so the dispatcher delivers
+	// it as a hidden developer message instead of recording the internal
+	// interview instructions as user-authored chat content.
+	return { prompt: interviewPrompt, synthetic: true };
 }

--- a/packages/coding-agent/src/slash-commands/helpers/goal.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/goal.ts
@@ -1,0 +1,102 @@
+import { prompt } from "@oh-my-pi/pi-utils";
+import type { GoalControllerResult } from "../../goals/goal-mode-controller";
+import guidedGoalInterviewPrompt from "../../prompts/goals/guided-goal-interview.md" with { type: "text" };
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
+import { commandConsumed, parseSubcommand, usage } from "./parse";
+
+const GOAL_SET_USAGE = "Usage: /goal set <objective>";
+const GOAL_BUDGET_USAGE = "Usage: /goal budget <N|off>";
+const GOAL_UNKNOWN_VERB_USAGE = "Unknown /goal subcommand. Use set|show|pause|resume|drop|budget";
+
+async function mapGoalResult(result: GoalControllerResult, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
+	if (!result.ok) return usage(result.error, runtime);
+	if (result.prompt !== undefined) return { prompt: result.prompt };
+	return commandConsumed();
+}
+
+/** ACP/text-mode `/goal` handler. Shared by both dispatchers via the spec. */
+export async function handleGoalAcp(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const { verb, rest } = parseSubcommand(command.args);
+	const controller = runtime.session.goalModeController;
+	const hasActiveGoal = runtime.session.getGoalModeState()?.goal !== undefined;
+
+	switch (verb) {
+		case "set": {
+			const objective = rest.trim();
+			if (!objective) return usage(GOAL_SET_USAGE, runtime);
+			const result = hasActiveGoal
+				? await controller.replaceObjective(objective)
+				: await controller.enter(objective);
+			return await mapGoalResult(result, runtime);
+		}
+		case "show": {
+			await runtime.output(controller.show());
+			return commandConsumed();
+		}
+		case "pause":
+			return await mapGoalResult(await controller.pause(), runtime);
+		case "resume":
+			return await mapGoalResult(await controller.resume(), runtime);
+		case "drop":
+			return await mapGoalResult(await controller.drop(), runtime);
+		case "budget": {
+			const raw = rest.trim();
+			if (!raw) return usage(GOAL_BUDGET_USAGE, runtime);
+			let budget: number | undefined;
+			if (raw === "off") {
+				budget = undefined;
+			} else {
+				const parsed = Number(raw);
+				if (!Number.isFinite(parsed)) return usage(GOAL_BUDGET_USAGE, runtime);
+				budget = parsed;
+			}
+			return await mapGoalResult(await controller.setBudget(budget), runtime);
+		}
+		case "": {
+			// Bare /goal = status query.
+			await runtime.output(controller.show());
+			return commandConsumed();
+		}
+		default: {
+			// `/goal <objective>` with an unrecognized verb sets a goal when none
+			// is active (TUI parity); with an active goal it's a typo.
+			if (!hasActiveGoal) {
+				const result = await controller.enter(command.args.trim());
+				return await mapGoalResult(result, runtime);
+			}
+			return usage(GOAL_UNKNOWN_VERB_USAGE, runtime);
+		}
+	}
+}
+
+/** ACP/text-mode `/guided-goal` handler: expose the goal tool and run the interview kickoff. */
+export async function handleGuidedGoalAcp(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const controller = runtime.session.goalModeController;
+	// Reuse the controller's entry guard (goal.enabled + plan active OR paused)
+	// so a persisted plan_paused session can't start a guided goal whose interview
+	// would then call `goal create` — the goal tool itself has no plan guard.
+	const guard = controller.entryGuard();
+	if (guard && !guard.ok) return usage(guard.error, runtime);
+	const existing = runtime.session.getGoalModeState();
+	if (existing?.goal && existing.goal.status !== "dropped" && existing.goal.status !== "complete") {
+		return usage(
+			existing.goal.status === "paused"
+				? "Resume the current goal first, or drop it before starting a guided goal."
+				: "Goal mode is already active. Use /goal to manage it, or /goal drop to start over.",
+			runtime,
+		);
+	}
+	await controller.exposeGoalTool();
+	const interviewPrompt = prompt.render(guidedGoalInterviewPrompt, { initial: command.args?.trim() || undefined });
+	// Return the interview kickoff as a residual prompt so the slash dispatcher
+	// feeds it as model input WITHIN the current client request — calling
+	// session.prompt() directly would nest an agent-initiated turn and break the
+	// ACP lifecycle (mirrors how /goal set returns {prompt} for its first turn).
+	return { prompt: interviewPrompt };
+}

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -44,8 +44,13 @@ export interface ParsedSlashCommand {
  * - `{ consumed: true }` — explicit equivalent of the above (ACP shape).
  * - `{ prompt: string }` — command handled, pass `prompt` through as the new
  *   user input (e.g. `/force <tool> <prompt>` keeps `<prompt>` as the message).
+ * - `{ prompt: string; synthetic?: true }` — like above, but deliver the
+ *   residual prompt as a hidden synthetic (developer-role) message instead of
+ *   a user-authored one. Used by `/guided-goal` so the internal interview
+ *   kickoff is not recorded/exposed as user chat content. Dispatchers that
+ *   lack a synthetic channel fall back to a plain user prompt.
  */
-export type SlashCommandResult = undefined | { consumed: true } | { prompt: string };
+export type SlashCommandResult = undefined | { consumed: true } | { prompt: string; synthetic?: boolean };
 
 /**
  * Runtime visible to slash-command handlers that run in text/ACP mode.
@@ -136,4 +141,4 @@ export interface SlashCommandSpec extends BuiltinSlashCommand {
 }
 
 /** Result returned by `executeAcpBuiltinSlashCommand`. */
-export type AcpBuiltinSlashCommandResult = false | { consumed: true } | { prompt: string };
+export type AcpBuiltinSlashCommandResult = false | { consumed: true } | { prompt: string; synthetic?: boolean };

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2,26 +2,30 @@ import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
+import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import {
 	ACP_BOOTSTRAP_RACE_GUARD_MS,
 	AcpAgent,
 	createAcpExtensionUiContext,
 } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
 import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
-import type {
-	AgentSession,
-	AgentSessionEvent,
-	UsageFallbackConfirmation,
-} from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AgentSessionEvent, UsageFallbackConfirmation } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "@oh-my-pi/pi-coding-agent/stt/models";
 import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
-import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	DEFAULT_TTS_LOCAL_MODEL_KEY,
 	DEFAULT_TTS_VOICE,
@@ -476,7 +480,10 @@ afterEach(async () => {
 });
 
 async function createHarness(
-	options: { elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse> } = {},
+	options: {
+		elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse>;
+		sessionFactory?: (cwd: string) => Promise<AgentSession>;
+	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
 	cleanupRoots.push(root);
@@ -506,6 +513,9 @@ async function createHarness(
 	const initialSession = new FakeAgentSession(cwdA);
 	sessions.push(initialSession);
 	const factory = async (cwd: string): Promise<AgentSession> => {
+		if (options.sessionFactory) {
+			return await options.sessionFactory(cwd);
+		}
 		const session = new FakeAgentSession(cwd);
 		sessions.push(session);
 		return session as unknown as AgentSession;
@@ -2914,4 +2924,220 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 			refreshSpy.mockRestore();
 		}
 	}, 15_000);
+});
+
+describe("ACP goal-mode restore ordering (MCP tools in the pre-goal snapshot)", () => {
+	// Regression for the PR #8225 Codex P2: `#registerPreparedSession` used to
+	// attach the headless goal adapter BEFORE `#configureMcpServers`, so the
+	// attach-time `controller.restore()` snapshotted `#previousTools` from a
+	// toolset that had no MCP tools yet. A later pause/drop/complete then
+	// restored that stale set and deactivated every client MCP tool for the
+	// rest of the session.
+	//
+	// The test drives the real AgentSession + GoalModeController + session tool
+	// registry through the real ACP registration path; only the MCP transport
+	// (subprocess protocol) is stubbed via per-test prototype spies so the
+	// ordering is exercised deterministically regardless of server latency.
+	const FIXTURE_MCP_TOOL: CustomTool = {
+		name: "mcp__fixture_notes_list",
+		label: "fixture/notes_list",
+		description: "Fixture MCP tool.",
+		parameters: type({}),
+		strict: true,
+		mcpServerName: "fixture",
+		mcpToolName: "notes_list",
+		async execute() {
+			return { content: [{ type: "text", text: "ok" }] };
+		},
+	};
+
+	// Real delayed-MCP fixture (test/fixtures/delayed-tool-mcp.ts): answers
+	// `initialize` only after `MCPManager`'s 250ms startup race, so its tool
+	// lands via the background `onToolsChanged` -> `refreshMCPTools` path —
+	// strictly AFTER the attach-time `controller.restore()` snapshot.
+	const DELAYED_FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "delayed-tool-mcp.ts");
+	const DELAYED_SERVER_NAME = "delayed";
+	const LATE_MCP_TOOL_NAME = `mcp__${DELAYED_SERVER_NAME}_${DELAYED_MCP_TOOL_NAME}`;
+
+	// Real polling, not fake timers: the fixture is a genuine child process
+	// racing MCPManager's own `Bun.sleep`-based 250ms startup window, and a
+	// subprocess's timers cannot be advanced from this test's fake-timer clock.
+	async function pollUntil(predicate: () => boolean, timeoutMs = 3_000): Promise<void> {
+		const deadline = Date.now() + timeoutMs;
+		while (!predicate()) {
+			if (Date.now() >= deadline) throw new Error("pollUntil timed out");
+			await Bun.sleep(5);
+		}
+	}
+
+	async function createGoalAwareSession(
+		cwd: string,
+		shared: { authStorage: AuthStorage; modelRegistry: ModelRegistry; model: Model },
+		root: string,
+	): Promise<AgentSession> {
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"goal.enabled": true,
+			"plan.enabled": true,
+		});
+		const bootstrapToolSession = {
+			...createTaskSession(cwd),
+			settings,
+		} as ToolSession;
+		const initialTools = await createTools(bootstrapToolSession, ["read", "edit"]);
+		const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
+		const session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: shared.model,
+					systemPrompt: ["Test"],
+					tools: initialTools,
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(cwd, root),
+			settings,
+			modelRegistry: shared.modelRegistry,
+			toolRegistry,
+			rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+		});
+		const goalToolSession = {
+			...bootstrapToolSession,
+			getGoalModeState: () => session.getGoalModeState(),
+			getGoalRuntime: () => session.goalRuntime,
+		} as ToolSession;
+		toolRegistry.set("goal", new GoalTool(goalToolSession) as unknown as Tool);
+		// Persisted active goal in the transcript: the headless adapter's initial
+		// `controller.restore()` must reconcile this entry and snapshot the
+		// currently-enabled toolset (the contract under test).
+		session.sessionManager.appendModeChange("goal", {
+			goal: {
+				id: "restore-ordering-fixture",
+				objective: "Persisted goal from a resumed ACP session",
+				status: "active",
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		});
+		return session;
+	}
+
+	it("snapshots MCP tools during the attach-time restore so a goal drop keeps them enabled", async () => {
+		const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-goal-order-"));
+		cleanupRoots.push(root);
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		const shared = { authStorage, modelRegistry, model };
+
+		// Stub the MCP transport only: `connectServers` reports success and
+		// `getTools` reports the fixture tool, so `#configureMcpServers` runs its
+		// full session-enablement path deterministically (no subprocess, no
+		// 250ms startup race).
+		const connectSpy = spyOn(MCPManager.prototype, "connectServers").mockResolvedValue({
+			tools: [],
+			errors: new Map<string, string>(),
+			connectedServers: [],
+			exaApiKeys: [],
+		});
+		const getToolsSpy = spyOn(MCPManager.prototype, "getTools").mockReturnValue([FIXTURE_MCP_TOOL]);
+
+		let registeredSession: AgentSession | undefined;
+		const harness = await createHarness({
+			sessionFactory: async cwd => {
+				const session = await createGoalAwareSession(cwd, shared, root);
+				registeredSession = session;
+				return session;
+			},
+		});
+
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [{ name: "fixture", command: process.execPath, args: [], env: [] }],
+			});
+			expectAcpStructure(zNewSessionResponse, created);
+
+			const session = registeredSession;
+			if (!session) throw new Error("expected the session factory to have created a session");
+			const controller = session.goalModeController;
+
+			// Precondition: MCP config ran and enabled the client's tool on the
+			// session (true both before and after the ordering fix).
+			expect(session.getEnabledToolNames()).toContain(FIXTURE_MCP_TOOL.name);
+
+			// Contract: the attach-time restore snapshot must include the MCP tool.
+			// Fails pre-fix because the snapshot was taken before MCP config.
+			expect(controller.previousTools).toEqual(expect.arrayContaining(["read", "edit", FIXTURE_MCP_TOOL.name]));
+
+			// Observable outcome: ending the goal restores that snapshot, so the MCP
+			// tool stays enabled for the rest of the session.
+			const dropped = await controller.drop();
+			expect(dropped.ok).toBe(true);
+			expect(session.getEnabledToolNames()).toContain(FIXTURE_MCP_TOOL.name);
+		} finally {
+			await harness.agent.dispose();
+			connectSpy.mockRestore();
+			getToolsSpy.mockRestore();
+			authStorage.close();
+		}
+	}, 20_000);
+
+	it("keeps a late-connecting MCP tool enabled when the goal is dropped (merge, not snapshot replace)", async () => {
+		const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-goal-late-mcp-"));
+		cleanupRoots.push(root);
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		const shared = { authStorage, modelRegistry, model };
+
+		let registeredSession: AgentSession | undefined;
+		const harness = await createHarness({
+			sessionFactory: async cwd => {
+				const session = await createGoalAwareSession(cwd, shared, root);
+				registeredSession = session;
+				return session;
+			},
+		});
+
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [
+					{ name: DELAYED_SERVER_NAME, command: process.execPath, args: [DELAYED_FIXTURE_PATH], env: [] },
+				],
+			});
+			expectAcpStructure(zNewSessionResponse, created);
+
+			const session = registeredSession;
+			if (!session) throw new Error("expected the session factory to have created a session");
+			const controller = session.goalModeController;
+
+			// The real delayed subprocess answers `initialize` only after the
+			// manager's 250ms startup race, so `late_tool` lands via the
+			// background onToolsChanged -> refreshMCPTools path — after the
+			// attach-time snapshot. Poll with a bounded retry (the latency is
+			// the real subprocess's, so no fixed sleeps).
+			await pollUntil(() => session.getEnabledToolNames().includes(LATE_MCP_TOOL_NAME), 15_000);
+
+			// Precondition proving the snapshot is stale: the late tool was not
+			// enabled when controller.restore() recorded #previousTools.
+			expect(session.getEnabledToolNames()).toContain(LATE_MCP_TOOL_NAME);
+			expect(controller.previousTools).not.toContain(LATE_MCP_TOOL_NAME);
+
+			// Contract: ending a goal must never disable a client MCP tool.
+			// Pre-merge, drop() full-replaced the active set with the stale
+			// snapshot and removed the late tool; the merge restore keeps it.
+			const dropped = await controller.drop();
+			expect(dropped.ok).toBe(true);
+			expect(session.getEnabledToolNames()).toContain(LATE_MCP_TOOL_NAME);
+		} finally {
+			await harness.agent.dispose();
+			authStorage.close();
+		}
+	}, 20_000);
 });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -36,6 +36,7 @@ import type {
 	CreateElicitationResponse,
 	PromptRequest,
 	SessionNotification,
+	SessionUpdate,
 	Validator,
 } from "@oh-my-pi/pi-utils/acp";
 import {
@@ -143,6 +144,15 @@ class FakeAgentSession {
 		this.refreshSkillsCalls++;
 	}
 	planModeState: PlanModeState | undefined;
+	// Minimal goal-mode surface so builtin `/goal` / `/guided-goal` handlers
+	// run through the real ACP dispatch without a real GoalModeController.
+	goalModeController = {
+		entryGuard: () => null,
+		exposeGoalTool: async () => {},
+	};
+	getGoalModeState(): undefined {
+		return undefined;
+	}
 	waitForIdleCalls = 0;
 	waitForIdleBlocker: (() => Promise<void>) | undefined;
 	asyncJobDrain: ((options?: { timeoutMs?: number }) => Promise<boolean>) | undefined;
@@ -1480,6 +1490,52 @@ describe("ACP agent", () => {
 		harness.abortController.abort();
 	});
 
+	it("does not replay a synthetic guided-goal kickoff as user content", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		// A synthetic prompt persists as a developer-role message with agent
+		// attribution (see AgentSession.prompt) — the exact shape of the
+		// guided-goal interview kickoff delivered via `synthetic: true`.
+		stored.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "Build a widget" }],
+			timestamp: Date.now(),
+		});
+		stored.sessionManager.appendMessage({
+			role: "developer",
+			content: [{ type: "text", text: "Hidden guided-goal interview kickoff" }],
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		stored.sessionManager.appendMessage(makeAssistantMessage("widget done"));
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		await harness.agent.loadSession({
+			sessionId: stored.sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+
+		const userChunkTexts = harness.updates
+			.filter(update => update.sessionId === stored.sessionId)
+			.map(notification => notification.update)
+			.filter(
+				(update): update is SessionUpdate & { sessionUpdate: "user_message_chunk" } =>
+					update.sessionUpdate === "user_message_chunk",
+			)
+			.map(update => update.content)
+			.filter((block): block is { type: "text"; text: string } => block.type === "text")
+			.map(block => block.text);
+		// The real user message still replays; the synthetic kickoff must not
+		// surface as user-authored content.
+		expect(userChunkTexts).toContain("Build a widget");
+		expect(userChunkTexts.some(text => text.includes("guided-goal interview"))).toBe(false);
+
+		harness.abortController.abort();
+	});
+
 	it("preserves tool_use input payloads when replaying assistant tool calls", async () => {
 		const harness = await createHarness();
 		const stored = new FakeAgentSession(harness.cwdA);
@@ -1857,6 +1913,33 @@ describe("ACP agent", () => {
 		expect(customMessage.content).toContain(`[Skill directory: ${skillDir}]`);
 		expect(customMessage.content).toContain("User: extra context");
 		expect(session.customMessageOptions[0]).toEqual({ streamingBehavior: "steer" });
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("dispatches a /guided-goal residual prompt to session.prompt with synthetic:true", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId);
+		if (!session) throw new Error("expected ACP session to exist after newSession");
+		const promptSpy = spyOn(session, "prompt");
+
+		const response = await harness.agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "/guided-goal rough idea" }],
+		} as PromptRequest);
+		expectAcpStructure(zPromptResponse, response);
+
+		// The guided-goal handler returns the interview as a residual prompt;
+		// the ACP dispatcher must feed it to session.prompt as a hidden
+		// synthetic message so the internal instructions are not recorded as
+		// user-authored chat content.
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		const [text, options] = promptSpy.mock.calls[0] as [text: string, options?: unknown];
+		expect(text).toBeTypeOf("string");
+		expect(text).toContain("rough idea");
+		expect(options).toEqual(expect.objectContaining({ synthetic: true }));
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/agent-session-switch-reconciler.test.ts
+++ b/packages/coding-agent/test/agent-session-switch-reconciler.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests that a registered session-switch reconciler (set via
+ * `setSessionSwitchReconciler`, e.g. the headless goal-mode adapter's
+ * `controller.restore()`) is invoked once after each SUCCESSFUL newSession()
+ * and branch() transition — mirroring switchSession() — and never on
+ * cancel paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
+
+describe("AgentSession session-switch reconciler on newSession/branch", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	const authStorages: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-session-reconciler-");
+	});
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			for (const authStorage of authStorages.splice(0)) authStorage.close();
+			await tempDir?.remove();
+		}
+	});
+
+	async function createSession(extensionRunner?: ExtensionRunner): Promise<void> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			handler: async () => ({ content: ["ok"], stopReason: "stop" }),
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry, extensionRunner });
+	}
+
+	async function seedUserMessage(): Promise<string> {
+		await session.prompt("hello");
+		await session.agent.waitForIdle();
+		const userMessages = session.getUserMessagesForBranching();
+		expect(userMessages.length).toBeGreaterThan(0);
+		return userMessages[0].entryId;
+	}
+
+	it("invokes a registered reconciler once after a successful newSession()", async () => {
+		await createSession();
+		let calls = 0;
+		session.setSessionSwitchReconciler(async () => {
+			calls++;
+		});
+
+		await expect(session.newSession()).resolves.toBe(true);
+		expect(calls).toBe(1);
+	});
+
+	it("invokes a registered reconciler once after a successful branch()", async () => {
+		await createSession();
+		const entryId = await seedUserMessage();
+		let calls = 0;
+		session.setSessionSwitchReconciler(async () => {
+			calls++;
+		});
+
+		const result = await session.branch(entryId);
+		expect(result.cancelled).toBe(false);
+		expect(calls).toBe(1);
+	});
+
+	it("does not invoke the reconciler when newSession() is cancelled by a hook", async () => {
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "session_before_switch"),
+			emit: vi.fn(async (event: { type: string }) =>
+				event.type === "session_before_switch" ? { cancel: true } : undefined,
+			),
+		} as unknown as ExtensionRunner;
+		await createSession(extensionRunner);
+		let calls = 0;
+		session.setSessionSwitchReconciler(async () => {
+			calls++;
+		});
+
+		await expect(session.newSession()).resolves.toBe(false);
+		expect(calls).toBe(0);
+	});
+
+	it("does not invoke the reconciler when branch() is cancelled by a hook", async () => {
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "session_before_branch"),
+			emit: vi.fn(async (event: { type: string }) =>
+				event.type === "session_before_branch" ? { cancel: true } : undefined,
+			),
+			// prompt() calls this unconditionally when an extension runner is set.
+			emitBeforeAgentStart: vi.fn(async () => undefined),
+		} as unknown as ExtensionRunner;
+		await createSession(extensionRunner);
+		const entryId = await seedUserMessage();
+		let calls = 0;
+		session.setSessionSwitchReconciler(async () => {
+			calls++;
+		});
+
+		const result = await session.branch(entryId);
+		expect(result.cancelled).toBe(true);
+		expect(calls).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -123,4 +123,23 @@ describe("buildAvailableSlashCommands", () => {
 
 		expect(commands.find(command => command.name === "legacy")?.source).toBe("custom");
 	});
+
+	test("exposes /goal and /guided-goal to RPC clients (regression: handle required for visibility)", async () => {
+		// Root cause of the original gap: ACP/RPC advertise only specs with a
+		// `handle`. /goal + /guided-goal now carry one, so they MUST appear in the
+		// RPC command list with their ACP hints — assert the actual contract.
+		const commands = await buildAvailableSlashCommands(
+			{ customCommands: [], skills: [], sessionManager: { getCwd: () => process.cwd() }, setSlashCommands() {} } as never,
+			async () => [],
+		);
+		const byName = Object.fromEntries(commands.map(command => [command.name, command]));
+
+		expect(byName.goal).toBeDefined();
+		expect(byName.goal.source).toBe("builtin");
+		expect(byName.goal.description).toBe("Manage goal mode");
+		expect(byName.goal.input?.hint).toBe("[set <objective>|show|pause|resume|drop|budget <N|off>]");
+
+		expect(byName["guided-goal"]).toBeDefined();
+		expect(byName["guided-goal"].source).toBe("builtin");
+	});
 });

--- a/packages/coding-agent/test/goals/goal-mode-controller.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-controller.test.ts
@@ -214,6 +214,29 @@ describe("GoalModeController", () => {
 		}
 	});
 
+	it("restore() clears goal state when switching to a non-goal session (headless reconciler)", async () => {
+		// Headless ACP/RPC drives goal↔non-goal switches via restore() ALONE.
+		// On a goal→none switch, restore() must clear the in-memory goal state
+		// and reset the continuation flags — otherwise goal prompts and
+		// continuations fire in a goal-less session.
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship it");
+			expect(harness.session.getGoalModeState()?.goal).toBeDefined();
+			expect(harness.session.getGoalModeState()?.goal.status).toBe("active");
+
+			harness.sessionManager.appendModeChange("none");
+			await harness.controller.restore();
+
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+			expect(harness.controller.isContinuationSuppressed()).toBe(false);
+			expect(harness.controller.buildContinuationForSubmission()).toBeNull();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
 	it("rejects pause and budget on a paused goal (must resume first)", async () => {
 		// Contract (matches TUI fix #5): a paused goal is not actionable for
 		// pause/budget — resume first. Headless adapters rely on the controller

--- a/packages/coding-agent/test/goals/goal-mode-controller.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-controller.test.ts
@@ -1,0 +1,472 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { GoalModeController } from "@oh-my-pi/pi-coding-agent/goals/goal-mode-controller";
+import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function createToolSession(cwd: string, settings: Settings, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings,
+		...overrides,
+	};
+}
+
+type Harness = {
+	session: AgentSession;
+	controller: GoalModeController;
+	sessionManager: SessionManager;
+	toolSession: ToolSession;
+	tempDir: TempDir;
+	cleanup: () => Promise<void>;
+};
+
+type SharedFixture = {
+	authStorage: AuthStorage;
+	modelRegistry: ModelRegistry;
+	model: Model;
+	baseDir: TempDir;
+};
+
+async function createSharedFixture(): Promise<SharedFixture> {
+	const baseDir = TempDir.createSync("@pi-goal-controller-");
+	const authStorage = await AuthStorage.create(path.join(baseDir.path(), "testauth.db"));
+	const modelRegistry = new ModelRegistry(authStorage);
+	const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+	if (!model) {
+		throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+	}
+	return { authStorage, modelRegistry, model, baseDir };
+}
+
+async function createHarness(shared: SharedFixture, options: { goalEnabled?: boolean } = {}): Promise<Harness> {
+	resetSettingsForTest();
+	const tempDir = TempDir.createSync("@pi-goal-controller-");
+	await Settings.init({ inMemory: true, cwd: tempDir.path() });
+	const goalEnabled = options.goalEnabled ?? true;
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"goal.enabled": goalEnabled,
+		"plan.enabled": true,
+	});
+	const bootstrapToolSession = createToolSession(tempDir.path(), settings);
+	const initialTools = await createTools(bootstrapToolSession, ["read", "edit"]);
+	const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
+	const session = new AgentSession({
+		agent: new Agent({
+			initialState: {
+				model: shared.model,
+				systemPrompt: ["Test"],
+				tools: initialTools,
+				messages: [],
+			},
+		}),
+		sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+		settings,
+		modelRegistry: shared.modelRegistry,
+		toolRegistry,
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+	});
+	const toolSession = createToolSession(tempDir.path(), settings, {
+		getGoalModeState: () => session.getGoalModeState(),
+		getGoalRuntime: () => session.goalRuntime,
+	});
+	if (goalEnabled) {
+		toolRegistry.set("goal", new GoalTool(toolSession) as unknown as Tool);
+	}
+	return {
+		session,
+		controller: session.goalModeController,
+		sessionManager: session.sessionManager,
+		toolSession,
+		tempDir,
+		cleanup: async () => {
+			await session.dispose();
+			tempDir.removeSync();
+			resetSettingsForTest();
+		},
+	};
+}
+
+describe("GoalModeController", () => {
+	let shared: SharedFixture;
+
+	beforeAll(async () => {
+		shared = await createSharedFixture();
+	});
+
+	afterAll(() => {
+		shared.authStorage.close();
+		shared.baseDir.removeSync();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("enter toggles the goal tool, sets enabled state, and returns {ok:true,prompt:objective}", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("goal");
+
+			const result = await harness.controller.enter("Ship the release");
+
+			expect(result).toEqual({ ok: true, prompt: "Ship the release" });
+			expect(harness.session.getGoalModeState()?.enabled).toBe(true);
+			expect(harness.session.getGoalModeState()?.goal.objective).toBe("Ship the release");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+			expect(harness.controller.previousTools).toEqual(["read", "edit"]);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("enter rejects when goal.enabled is false", async () => {
+		const harness = await createHarness(shared, { goalEnabled: false });
+		try {
+			const result = await harness.controller.enter("Ship the release");
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toBe("Goal mode is disabled. Enable it in settings (goal.enabled).");
+			}
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("enter rejects while plan mode is active on the session", async () => {
+		const harness = await createHarness(shared);
+		try {
+			harness.session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+
+			const result = await harness.controller.enter("Ship the release");
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toBe("Exit plan mode first.");
+			}
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("drop restores the previous tool set and clears the goal state", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship the release");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+
+			const result = await harness.controller.drop();
+
+			expect(result.ok).toBe(true);
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+			expect(harness.session.getActiveToolNames()).toEqual(["read", "edit"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("goal");
+			expect(harness.controller.previousTools).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("pause removes the goal tool, then resume re-adds it", async () => {
+		// Contract (shared with headless adapters): pause keeps the goal record
+		// but drops the goal tool from the active set; resume re-adds it. The
+		// core owns this so ACP/RPC `/goal pause` does not strand the goal tool.
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship the release");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+			expect(harness.controller.previousTools).toEqual(["read", "edit"]);
+
+			const paused = await harness.controller.pause();
+
+			expect(paused.ok).toBe(true);
+			expect(harness.session.getGoalModeState()?.goal.status).toBe("paused");
+			expect(harness.session.getActiveToolNames()).not.toContain("goal");
+			expect(harness.session.getActiveToolNames()).toEqual(["read", "edit"]);
+			expect(harness.controller.previousTools).toBeUndefined();
+
+			const resumed = await harness.controller.resume();
+
+			expect(resumed.ok).toBe(true);
+			expect(harness.session.getGoalModeState()?.goal.status).toBe("active");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+			expect(harness.controller.previousTools).toEqual(["read", "edit"]);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("rejects pause and budget on a paused goal (must resume first)", async () => {
+		// Contract (matches TUI fix #5): a paused goal is not actionable for
+		// pause/budget — resume first. Headless adapters rely on the controller
+		// guard since they don't run the TUI's own paused checks.
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship the release");
+			await harness.controller.pause();
+			expect(harness.session.getGoalModeState()?.goal.status).toBe("paused");
+
+			const rePause = await harness.controller.pause();
+			expect(rePause.ok).toBe(false);
+
+			const budget = await harness.controller.setBudget(100);
+			expect(budget.ok).toBe(false);
+			// Budget must not have been mutated while paused.
+			expect(harness.session.getGoalModeState()?.goal.tokenBudget).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("replaceObjective requires an active goal", async () => {
+		const harness = await createHarness(shared);
+		try {
+			const result = await harness.controller.replaceObjective("Replace the objective");
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toContain("cannot replace goal");
+			}
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("resume re-adds the goal tool after a deactivated exit", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship the release");
+			await harness.controller.deactivate({ restoreTools: true });
+			expect(harness.session.getActiveToolNames()).not.toContain("goal");
+
+			const result = await harness.controller.resume();
+
+			expect(result.ok).toBe(true);
+			expect(harness.session.getGoalModeState()?.enabled).toBe(true);
+			expect(harness.session.getGoalModeState()?.goal.objective).toBe("Ship the release");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("setBudget delegates to the runtime and preserves accumulated usage", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+			const goal = harness.session.getGoalModeState()?.goal;
+			if (!goal) throw new Error("expected active goal");
+			goal.tokensUsed = 42;
+			goal.timeUsedSeconds = 5;
+			const onBudgetMutated = vi.spyOn(harness.session.goalRuntime, "onBudgetMutated");
+
+			const result = await harness.controller.setBudget(123);
+
+			expect(result.ok).toBe(true);
+			expect(onBudgetMutated).toHaveBeenCalledWith(123);
+			const after = harness.session.getGoalModeState();
+			expect(after?.goal.tokenBudget).toBe(123);
+			expect(after?.goal.tokensUsed).toBe(42);
+			expect(after?.goal.timeUsedSeconds).toBe(5);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("show() reflects the active goal state and reports 'No goal set.' otherwise", async () => {
+		const harness = await createHarness(shared);
+		try {
+			expect(harness.controller.show()).toBe("No goal set.");
+
+			await harness.controller.enter("Ship the release");
+			const text = harness.controller.show();
+
+			expect(text).toContain("Objective: Ship the release");
+			expect(text).toContain("Status: active");
+			expect(text).toContain("Tokens:");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("buildContinuationForSubmission returns a prompt when active and the turn made tool calls", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+			harness.controller.onToolStart();
+
+			const decision = harness.controller.buildContinuationForSubmission();
+
+			expect(decision).not.toBeNull();
+			expect(decision?.prompt).toBeTruthy();
+			expect(decision?.prompt).toContain("Ship the release");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("buildContinuationForSubmission returns a prompt even when a normal turn made no tool calls", async () => {
+		// A non-continuation turn never arms suppression, so the decision stays
+		// live regardless of whether the turn made tool calls. Only a CONTINUATION
+		// turn with no tool calls suppresses (covered below).
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+
+			const decision = harness.controller.buildContinuationForSubmission();
+
+			expect(decision).not.toBeNull();
+			expect(decision?.prompt).toContain("Ship the release");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("buildContinuationForSubmission returns null when a no-tool-call continuation is suppressed", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+			// A continuation turn that made no tool calls arms the suppression.
+			harness.controller.markContinuationInFlight();
+			await harness.controller.onAgentEnd();
+			expect(harness.controller.isContinuationSuppressed()).toBe(true);
+
+			expect(harness.controller.buildContinuationForSubmission()).toBeNull();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("buildContinuationForSubmission returns null while the goal is paused", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+			harness.controller.onToolStart();
+			await harness.controller.pause();
+
+			expect(harness.controller.buildContinuationForSubmission()).toBeNull();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("restore reconstructs goal mode from a persisted mode_change entry", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			const now = Date.now();
+			harness.sessionManager.appendModeChange("goal", {
+				goal: {
+					id: "g1",
+					objective: "Persisted objective",
+					status: "active",
+					tokensUsed: 7,
+					timeUsedSeconds: 3,
+					createdAt: now,
+					updatedAt: now,
+				},
+			});
+
+			const restored = await harness.controller.restore({ preserveActiveGoal: true });
+
+			expect(restored?.goal.objective).toBe("Persisted objective");
+			expect(harness.session.getGoalModeState()?.goal.objective).toBe("Persisted objective");
+			expect(harness.session.getGoalModeState()?.goal.tokensUsed).toBe(7);
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+			expect(harness.controller.previousTools).toEqual(["read", "edit"]);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("restore pauses a persisted active goal unless preserveActiveGoal is set", async () => {
+		const harness = await createHarness(shared);
+		try {
+			const now = Date.now();
+			harness.sessionManager.appendModeChange("goal", {
+				goal: {
+					id: "g2",
+					objective: "Paused on restore",
+					status: "active",
+					tokensUsed: 0,
+					timeUsedSeconds: 0,
+					createdAt: now,
+					updatedAt: now,
+				},
+			});
+
+			const restored = await harness.controller.restore();
+
+			expect(restored?.enabled).toBe(false);
+			expect(restored?.goal.status).toBe("paused");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("schedules continuation after a normal turn that made no tool calls", async () => {
+		// Contract: a user-initiated (non-continuation) turn that yields without any
+		// tool calls must NOT suppress the next continuation. Only a CONTINUATION turn
+		// with no tool calls arms suppression (anti-talk-loop). Mirrors the original
+		// #scheduleGoalContinuation / #goalContinuationTurnInFlight semantics.
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+
+			harness.controller.onAgentStart();
+			// (no onToolStart — the agent talked but did not act)
+			const decision = await harness.controller.onAgentEnd();
+
+			expect(decision).not.toBeNull();
+			if (decision) expect(decision.prompt).toContain("Ship the release");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("suppresses the next continuation only after a continuation turn with no tool calls", async () => {
+		const harness = await createHarness(shared);
+		try {
+			await harness.controller.enter("Ship the release");
+
+			// A continuation turn that makes no tool calls arms suppression and
+			// returns no continuation decision.
+			harness.controller.markContinuationInFlight();
+			harness.controller.onAgentStart();
+			const stalled = await harness.controller.onAgentEnd();
+			expect(stalled).toBeNull();
+
+			// After reset, a continuation turn that DOES make tool calls keeps
+			// continuation live.
+			harness.controller.resetContinuationSuppression();
+			harness.controller.markContinuationInFlight();
+			harness.controller.onAgentStart();
+			harness.controller.onToolStart();
+			const progressing = await harness.controller.onAgentEnd();
+			expect(progressing).not.toBeNull();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/goals/goal-mode-controller.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-controller.test.ts
@@ -4,7 +4,7 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { GoalModeController } from "@oh-my-pi/pi-coding-agent/goals/goal-mode-controller";
+import type { GoalModeController } from "@oh-my-pi/pi-coding-agent/goals/goal-mode-controller";
 import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -237,6 +237,30 @@ describe("GoalModeController", () => {
 		}
 	});
 
+	it("restore() re-applies the pre-goal tool set when switching to a non-goal session", async () => {
+		// F2 regression: restore()'s non-goal early return cleared goal state but
+		// never re-applied #previousTools, so the `goal` tool stayed active after
+		// a headless switch (AgentSession.switchSession does not reload the
+		// target's active tool set).
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship it");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+			expect(harness.controller.previousTools).toEqual(["read", "edit"]);
+
+			harness.sessionManager.appendModeChange("none");
+			await harness.controller.restore();
+
+			expect(harness.session.getActiveToolNames()).toEqual(["read", "edit"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("goal");
+			expect(harness.controller.previousTools).toBeUndefined();
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
 	it("rejects pause and budget on a paused goal (must resume first)", async () => {
 		// Contract (matches TUI fix #5): a paused goal is not actionable for
 		// pause/budget — resume first. Headless adapters rely on the controller
@@ -270,6 +294,28 @@ describe("GoalModeController", () => {
 				expect(result.error).toContain("cannot replace goal");
 			}
 			expect(harness.session.getGoalModeState()).toBeUndefined();
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("completion restores the pre-goal tool set and clears goal state on agent end", async () => {
+		// F1 regression: onAgentEnd()'s exiting branch deactivated WITHOUT
+		// restoreTools, so the `goal` tool stayed advertised after a goal
+		// completed from the goal tool.
+		const harness = await createHarness(shared);
+		try {
+			await harness.session.setActiveToolsByName(["read", "edit"]);
+			await harness.controller.enter("Ship the release");
+			expect(harness.session.getActiveToolNames()).toContain("goal");
+
+			await harness.session.goalRuntime.completeGoalFromTool();
+			await harness.controller.onAgentEnd();
+
+			expect(harness.session.getActiveToolNames()).toEqual(["read", "edit"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("goal");
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+			expect(harness.controller.previousTools).toBeUndefined();
 		} finally {
 			await harness.cleanup();
 		}

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -489,4 +489,41 @@ describe("InteractiveMode goal mode integration", () => {
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
 		await nextTurn;
 	});
+	it("drops a goal via the bare /goal menu and restores the previous toolset", async () => {
+		await harness.session.setActiveToolsByName(["read", "edit"]);
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		expect(await toolNamesFor(harness)).toContain("goal");
+
+		vi.spyOn(harness.mode, "showHookSelector").mockResolvedValue("Drop");
+		vi.spyOn(harness.mode, "showHookConfirm").mockResolvedValue(true);
+
+		await harness.mode.handleGoalModeCommand();
+
+		expect(harness.mode.goalModeEnabled).toBe(false);
+		expect(harness.mode.goalModePaused).toBe(false);
+		expect(harness.session.getGoalModeState()).toBeUndefined();
+		expect(await toolNamesFor(harness)).not.toContain("goal");
+	});
+
+	it("fires the goal continuation prompt when idle and active", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+
+		vi.useFakeTimers();
+		const waiter = await armInputWaiter(harness.mode);
+
+		// Not streaming, goal active, editor empty, continuationModes includes
+		// "interactive" (default) — the armed 800ms continuation should fire and
+		// resolve getUserInput with the continuation prompt.
+		vi.advanceTimersByTime(800);
+		await waitForMicrotasks();
+
+		const text = waiter.getResolvedText();
+		expect(text).toBeTruthy();
+		// The continuation prompt is rendered from the goal-continuation template;
+		// it carries the live objective.
+		expect(text).toContain("Ship the release");
+
+		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "done" }));
+		await waiter.inputPromise;
+	});
 });

--- a/packages/coding-agent/test/goals/headless-goal-adapter.test.ts
+++ b/packages/coding-agent/test/goals/headless-goal-adapter.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { attachHeadlessGoalAdapter } from "@oh-my-pi/pi-coding-agent/goals/headless-goal-adapter";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+/**
+ * Adapter-level contracts for attachHeadlessGoalAdapter:
+ *  - lifecycle wiring (async attach, initial restore, switch reconciler, detach)
+ *  - continuation timing (RPC marks before submit; ACP does not mark)
+ *
+ * The shared GoalModeController unit-tests the suppression DECISION; these pin
+ * the adapter WIRING. The adapter's Bun.sleep settle delay is spied to resolve
+ * instantly (nothing real to settle against stubbed sessions) and the async
+ * chain is driven via microtask flushes — no wall-clock, no fake timers.
+ */
+
+function createStubSession(options: { continuationModes: string[]; decision: { prompt: string } | null }) {
+	let listener: ((event: { type: string; message?: { role: string; synthetic?: boolean } }) => void) | undefined;
+	const controller = {
+		onAgentEnd: vi.fn(async () => options.decision),
+		onAgentStart: vi.fn(),
+		onToolStart: vi.fn(),
+		onGoalUpdated: vi.fn(async () => {}),
+		markContinuationInFlight: vi.fn(),
+		noteContinuationSubmissionEnded: vi.fn(),
+		resetContinuationSuppression: vi.fn(),
+		restore: vi.fn(async () => undefined),
+	};
+	const setSessionSwitchReconciler = vi.fn();
+	const sendCustomMessage = vi.fn(async (): Promise<boolean> => true);
+	const session = {
+		subscribe: vi.fn((fn: (event: { type: string }) => void) => {
+			listener = fn;
+			return () => {
+				listener = undefined;
+			};
+		}),
+		setSessionSwitchReconciler,
+		goalModeController: controller,
+		settings: {
+			get: vi.fn((key: string) => (key === "goal.continuationModes" ? options.continuationModes : undefined)),
+		},
+		isStreaming: false,
+		getGoalModeState: () => ({ enabled: true, mode: "active", goal: { status: "active" } }),
+		sendCustomMessage,
+	} as unknown as AgentSession;
+	return { session, controller, sendCustomMessage, setSessionSwitchReconciler, emit: (event: { type: string; message?: { role: string; synthetic?: boolean } }) => listener?.(event) };
+}
+
+async function settle() {
+	for (let i = 0; i < 12; i++) await Promise.resolve();
+}
+
+describe("attachHeadlessGoalAdapter lifecycle", () => {
+	beforeEach(() => {
+		vi.spyOn(Bun, "sleep").mockResolvedValue(undefined);
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("awaits an initial restore and registers as the session switch reconciler", async () => {
+		const h = createStubSession({ continuationModes: ["rpc"], decision: null });
+		const detach = await attachHeadlessGoalAdapter(h.session, "rpc");
+
+		// Race-free initial reconciliation of any persisted goal.
+		expect(h.controller.restore).toHaveBeenCalledTimes(1);
+		// In-process switchSession re-reconciles instead of leaking goal state.
+		expect(h.setSessionSwitchReconciler).toHaveBeenCalledTimes(1);
+		const reconciler = h.setSessionSwitchReconciler.mock.calls[0]?.[0];
+		expect(typeof reconciler).toBe("function");
+		await reconciler();
+		expect(h.controller.restore).toHaveBeenCalledTimes(2);
+
+		detach();
+		expect(h.setSessionSwitchReconciler).toHaveBeenLastCalledWith(null);
+	});
+
+	it("RPC arms the continuation mark BEFORE submitting the turn", async () => {
+		const h = createStubSession({ continuationModes: ["rpc"], decision: { prompt: "CONTINUATION" } });
+		const order: string[] = [];
+		h.controller.markContinuationInFlight.mockImplementation(() => {
+			order.push("mark");
+		});
+		h.sendCustomMessage.mockImplementation(async () => {
+			order.push("send");
+			return true;
+		});
+		await attachHeadlessGoalAdapter(h.session, "rpc");
+
+		h.emit({ type: "agent_end" });
+		await settle();
+
+		expect(order).toEqual(["mark", "send"]);
+		expect(h.sendCustomMessage).toHaveBeenCalledWith(
+			{ customType: "goal-continuation", content: "CONTINUATION" },
+			{ triggerTurn: true },
+		);
+	});
+
+	it("RPC rolls back the mark when the submit throws", async () => {
+		const h = createStubSession({ continuationModes: ["rpc"], decision: { prompt: "CONTINUATION" } });
+		h.sendCustomMessage.mockRejectedValue(new Error("boom"));
+		await attachHeadlessGoalAdapter(h.session, "rpc");
+
+		h.emit({ type: "agent_end" });
+		await settle();
+
+		expect(h.controller.markContinuationInFlight).toHaveBeenCalledTimes(1);
+		expect(h.controller.noteContinuationSubmissionEnded).toHaveBeenCalledTimes(1);
+	});
+
+	it("ACP does NOT mark and submits via the central trigger path", async () => {
+		const h = createStubSession({ continuationModes: ["acp"], decision: { prompt: "CONTINUATION" } });
+		await attachHeadlessGoalAdapter(h.session, "acp");
+
+		h.emit({ type: "agent_end" });
+		await settle();
+
+		expect(h.controller.markContinuationInFlight).not.toHaveBeenCalled();
+		expect(h.sendCustomMessage).toHaveBeenCalledWith(
+			{ customType: "goal-continuation", content: "CONTINUATION" },
+			{ triggerTurn: true },
+		);
+	});
+
+	it("clears continuation suppression on a real user message", async () => {
+		const h = createStubSession({ continuationModes: ["rpc"], decision: null });
+		await attachHeadlessGoalAdapter(h.session, "rpc");
+
+		h.emit({ type: "message_start", message: { role: "user", synthetic: false } });
+		h.emit({ type: "message_start", message: { role: "assistant" } });
+		h.emit({ type: "message_start", message: { role: "user", synthetic: true } });
+		await settle();
+
+		// Only the non-synthetic user message resets suppression.
+		expect(h.controller.resetContinuationSuppression).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not submit when the run mode is absent from continuationModes", async () => {
+		const h = createStubSession({ continuationModes: ["interactive"], decision: { prompt: "CONTINUATION" } });
+		await attachHeadlessGoalAdapter(h.session, "rpc");
+
+		h.emit({ type: "agent_end" });
+		await settle();
+
+		expect(h.sendCustomMessage).not.toHaveBeenCalled();
+		expect(h.controller.markContinuationInFlight).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/goals/rpc-goal-startup-ordering.test.ts
+++ b/packages/coding-agent/test/goals/rpc-goal-startup-ordering.test.ts
@@ -1,0 +1,438 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type { GoalModeState } from "@oh-my-pi/pi-coding-agent/goals/state";
+import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
+import { runRpcSessionStartup } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-session-init";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const GOAL_ID = "restore-ordering-fixture";
+
+/**
+ * RPC goal-mode startup ordering contract, bound to the PRODUCTION wiring.
+ *
+ * The ordering lives in {@link runRpcSessionStartup} (called by runRpcMode),
+ * not in this test: this test drives that helper with a real AgentSession +
+ * real ExtensionRunner, so it fails whenever the helper's internal order
+ * regresses (session_start emitted before restore, or the output subscriber
+ * installed after restore) — the manual reproduction this file replaces
+ * stayed green under the old buggy order.
+ *
+ * The contract the helper must satisfy:
+ *   1. install the output subscriber,
+ *   2. initializeExtensions with `emitSessionStart: false`,
+ *   3. attachHeadlessGoalAdapter (its initial `controller.restore()`),
+ *   4. emitExtensionSessionStart.
+ *
+ * Restore() reconciles a persisted goal: it sets goal-mode state, exposes the
+ * `goal` tool, and emits `goal_updated`. That event must reach (a) the output
+ * subscriber installed BEFORE restore (get_state has no goal field — the event
+ * is the only client signal) and (b) an INITIALIZED extension runner (an
+ * uninitialized runtime throws on tool access). `session_start` must fire only
+ * AFTER restore so a session_start handler that inspects tools or starts a
+ * turn observes goal-mode state.
+ */
+describe("RPC goal-mode startup ordering", () => {
+	let tempDir: TempDir;
+	const cleanups: Array<() => void | Promise<void>> = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-rpc-goal-ordering-");
+		cleanups.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const cleanup of cleanups) await cleanup();
+		cleanups.length = 0;
+		tempDir.removeSync();
+	});
+
+	it("delivers restore's goal_updated to the pre-restore subscriber and defers session_start until after restore", async () => {
+		const root = tempDir.path();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		cleanups.push(async () => {
+			authStorage.close();
+		});
+		// Runtime override so the session's own API-key gate passes: the turn
+		// below runs through the canned mock provider (no network, no key).
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"goal.enabled": true,
+			"plan.enabled": true,
+		});
+		const bootstrapToolSession = {
+			cwd: root,
+			hasUI: false,
+			settings,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+		} as unknown as ToolSession;
+		const initialTools = await createTools(bootstrapToolSession, ["read", "edit"]);
+		const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
+
+		// Extension runner whose handlers capture (1) what a session_start
+		// handler observes — the state a turn started from session_start would
+		// read — and (2) the extension-stream ordering of restore's goal_updated
+		// vs the deferred session_start. Handlers close over `session`, which is
+		// assigned below.
+		let session: AgentSession | undefined;
+		const extensionEventOrder: string[] = [];
+		const observed = {
+			sessionStartRuns: 0,
+			goalAtSessionStart: undefined as GoalModeState | undefined,
+			activeToolsAtSessionStart: [] as string[],
+			goalUpdatedRuns: 0,
+			goalIdAtGoalUpdated: undefined as string | undefined,
+			runtimeErrors: [] as string[],
+		};
+		const extensionRuntime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => {
+				pi.on("goal_updated", (_event, _ctx) => {
+					extensionEventOrder.push("goal_updated");
+					observed.goalUpdatedRuns++;
+					// The goal mode state is set before restore emits goal_updated.
+					observed.goalIdAtGoalUpdated = session?.getGoalModeState()?.goal?.id;
+				});
+				pi.on("session_start", (_event, _ctx) => {
+					extensionEventOrder.push("session_start");
+					observed.sessionStartRuns++;
+					observed.goalAtSessionStart = session?.getGoalModeState();
+					// getActiveTools in the RPC init wiring reads
+					// session.getEnabledToolNames(); observe the same contract.
+					observed.activeToolsAtSessionStart = session?.getEnabledToolNames() ?? [];
+				});
+			},
+			root,
+			new EventBus(),
+			extensionRuntime,
+			"rpc-goal-ordering",
+		);
+		const sessionManager = SessionManager.create(root, root);
+		const extensionRunner = new ExtensionRunner([extension], extensionRuntime, root, sessionManager, modelRegistry);
+
+		// Canned model: lets the session run a REAL turn below without an API
+		// key, so agent_start can be observed with goal mode active.
+		const mock = createMockModel({
+			responses: [{ content: ["working on the persisted goal"], stopReason: "stop" }],
+		});
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: initialTools,
+					messages: [],
+				},
+				streamFn: mock.stream,
+			}),
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+			extensionRunner,
+		});
+		cleanups.push(async () => {
+			await session?.dispose();
+		});
+
+		const goalToolSession = {
+			...bootstrapToolSession,
+			getGoalModeState: () => session?.getGoalModeState(),
+			getGoalRuntime: () => session?.goalRuntime,
+		} as unknown as ToolSession;
+		toolRegistry.set("goal", new GoalTool(goalToolSession) as unknown as Tool);
+
+		// Persisted active goal in the transcript: the adapter's initial
+		// controller.restore() must reconcile this entry before session_start.
+		session.sessionManager.appendModeChange("goal", {
+			goal: {
+				id: GOAL_ID,
+				objective: "Persisted goal from a resumed RPC session",
+				status: "active",
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		});
+
+		// Drive the PRODUCTION startup sequence. The output sink is the helper's
+		// subscriber; the init options mirror runRpcMode's (minus the deferred
+		// emitSessionStart flag, which the helper forces to false).
+		const receivedEvents: AgentSessionEvent[] = [];
+		const detachGoalAdapter = await runRpcSessionStartup(
+			session,
+			event => {
+				receivedEvents.push(event);
+			},
+			{
+				reportSendError: (_action, error) => {
+					observed.runtimeErrors.push(error.message);
+				},
+				reportRuntimeError: error => {
+					observed.runtimeErrors.push(error.error);
+				},
+			},
+		);
+		cleanups.push(detachGoalAdapter);
+
+		// (a) Client-signal contract: the subscriber is installed BEFORE
+		// restore, so restore's goal_updated is the FIRST event the client sees
+		// — nothing spurious precedes it (runner.initialize schedules only
+		// extension-handler drains, never agent events), and the goal id proves
+		// it is the restored goal's event.
+		expect(receivedEvents[0]?.type).toBe("goal_updated");
+		const goalUpdatedEvents = receivedEvents.filter(event => event.type === "goal_updated");
+		expect(goalUpdatedEvents[0]?.goal?.id).toBe(GOAL_ID);
+
+		// Restore ran between init and session_start: state set + goal tool
+		// exposed the moment the adapter attached.
+		expect(session.getGoalModeState()?.goal?.id).toBe(GOAL_ID);
+		expect(session.getEnabledToolNames()).toContain("goal");
+
+		// (b) + (c) session_start fires exactly once, from the helper's FINAL
+		// emit step (never during initializeExtensions), and its handler
+		// observes the restored session. The extension event order proves
+		// restore's goal_updated precedes session_start in the extension stream;
+		// a reverted order (session_start during init, or attach after
+		// session_start) fails these assertions.
+		expect(extensionEventOrder).toEqual(["goal_updated", "session_start"]);
+		expect(observed.sessionStartRuns).toBe(1);
+		expect(observed.goalAtSessionStart?.goal?.id).toBe(GOAL_ID);
+		expect(observed.activeToolsAtSessionStart).toContain("goal");
+
+		// The runner was initialized before restore (initializeExtensions ran
+		// first), so the goal_updated handler executed against the restored
+		// session with no runtime errors.
+		expect(observed.goalUpdatedRuns).toBeGreaterThan(0);
+		expect(observed.goalIdAtGoalUpdated).toBe(GOAL_ID);
+		expect(observed.runtimeErrors).toEqual([]);
+
+		// A session_start-triggered turn would run in goal mode. A full turn
+		// needs a model, so the state observation above (goal state + enabled
+		// `goal` tool — exactly what a turn reads) is the proxy; in addition,
+		// drive a REAL no-API turn through the canned mock provider the
+		// AgentSession supports and confirm agent_start fires with goal mode
+		// active.
+		const goalAtAgentStart: Array<{ goalId: string | undefined; tools: string[] }> = [];
+		const turnProbe = session.subscribe(event => {
+			if (event.type === "agent_start") {
+				goalAtAgentStart.push({
+					goalId: session.getGoalModeState()?.goal?.id,
+					tools: session.getEnabledToolNames(),
+				});
+			}
+		});
+		cleanups.push(turnProbe);
+
+		await session.sendUserMessage("Continue working toward the persisted goal");
+		await session.waitForIdle();
+
+		expect(mock.calls.length).toBeGreaterThan(0);
+		expect(goalAtAgentStart).toHaveLength(1);
+		expect(goalAtAgentStart[0]?.goalId).toBe(GOAL_ID);
+		expect(goalAtAgentStart[0]?.tools).toContain("goal");
+	});
+
+	it("holds buffered mcp_notification until the goal is restored so a handler-sent turn runs in goal mode", async () => {
+		const root = tempDir.path();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		cleanups.push(async () => {
+			authStorage.close();
+		});
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"goal.enabled": true,
+			"plan.enabled": true,
+		});
+		const bootstrapToolSession = {
+			cwd: root,
+			hasUI: false,
+			settings,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+		} as unknown as ToolSession;
+		const initialTools = await createTools(bootstrapToolSession, ["read", "edit"]);
+		const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
+
+		// Extension whose mcp_notification handler does exactly what the gate
+		// must protect against: it starts a turn via pi.sendUserMessage. The
+		// handler records the goal state it observes; the extension event order
+		// proves the notification delivered only after restore's goal_updated.
+		let session: AgentSession | undefined;
+		const extensionEventOrder: string[] = [];
+		const observed = {
+			notificationRuns: 0,
+			goalIdAtNotification: undefined as string | undefined,
+			sendErrors: [] as string[],
+			runtimeErrors: [] as string[],
+		};
+		const extensionRuntime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => {
+				pi.on("goal_updated", (_event, _ctx) => {
+					extensionEventOrder.push("goal_updated");
+				});
+				pi.on("mcp_notification", (_event, _ctx) => {
+					extensionEventOrder.push("mcp_notification");
+					observed.notificationRuns++;
+					// The gate must deliver this only AFTER the persisted goal is
+					// restored; the goal state the handler observes is the proof.
+					observed.goalIdAtNotification = session?.getGoalModeState()?.goal?.id;
+					pi.sendUserMessage("A notification-driven turn");
+				});
+				pi.on("session_start", (_event, _ctx) => {
+					extensionEventOrder.push("session_start");
+				});
+			},
+			root,
+			new EventBus(),
+			extensionRuntime,
+			"rpc-goal-ordering-notification",
+		);
+		const sessionManager = SessionManager.create(root, root);
+		const extensionRunner = new ExtensionRunner([extension], extensionRuntime, root, sessionManager, modelRegistry);
+
+		const mock = createMockModel({
+			responses: [{ content: ["handled the notification"], stopReason: "stop" }],
+		});
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: initialTools,
+					messages: [],
+				},
+				streamFn: mock.stream,
+			}),
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+			extensionRunner,
+		});
+		cleanups.push(async () => {
+			await session?.dispose();
+		});
+
+		const goalToolSession = {
+			...bootstrapToolSession,
+			getGoalModeState: () => session?.getGoalModeState(),
+			getGoalRuntime: () => session?.goalRuntime,
+		} as unknown as ToolSession;
+		toolRegistry.set("goal", new GoalTool(goalToolSession) as unknown as Tool);
+
+		session.sessionManager.appendModeChange("goal", {
+			goal: {
+				id: GOAL_ID,
+				objective: "Persisted goal from a resumed RPC session",
+				status: "active",
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		});
+
+		// Buffer a notification BEFORE initialize: the runner is uninitialized
+		// at this point, so emitMcpNotification buffers it. With the delivery
+		// gate engaged, initialize must NOT drain it (the notification survives
+		// to resumeRuntimeEventDelivery, after the restore).
+		await session.extensionRunner!.emitMcpNotification({
+			server: "test-server",
+			method: "notifications/custom_event",
+			params: {},
+		});
+
+		// agent_start probe installed BEFORE startup: the notification
+		// handler's turn fires during startup (inside resume), so the probe
+		// must already be subscribed. Same for the agent_end signal below —
+		// pi.sendUserMessage is fire-and-forget, so the turn completes
+		// asynchronously and waitForIdle() alone can return while the prompt is
+		// still in pre-stream setup.
+		const goalAtAgentStart: Array<{ goalId: string | undefined; tools: string[] }> = [];
+		const { promise: turnEnded, resolve: resolveTurnEnded } = Promise.withResolvers<void>();
+		const turnProbe = session.subscribe(event => {
+			if (event.type === "agent_start") {
+				goalAtAgentStart.push({
+					goalId: session.getGoalModeState()?.goal?.id,
+					tools: session.getEnabledToolNames(),
+				});
+			} else if (event.type === "agent_end") {
+				resolveTurnEnded();
+			}
+		});
+		cleanups.push(turnProbe);
+
+		const receivedEvents: AgentSessionEvent[] = [];
+		const detachGoalAdapter = await runRpcSessionStartup(
+			session,
+			event => {
+				receivedEvents.push(event);
+			},
+			{
+				reportSendError: (_action, error) => {
+					observed.sendErrors.push(error.message);
+				},
+				reportRuntimeError: error => {
+					observed.runtimeErrors.push(error.error);
+				},
+			},
+		);
+		cleanups.push(detachGoalAdapter);
+
+		// The turn the notification handler started runs asynchronously
+		// (pi.sendUserMessage is fire-and-forget); wait for its agent_end, then
+		// settle post-prompt recovery before asserting on it.
+		await turnEnded;
+		await session.waitForIdle();
+
+		// The gate delivered the buffered notification only after restore: the
+		// handler ran exactly once, observed the restored goal, and the turn it
+		// started fired agent_start with goal mode ACTIVE (goal tool enabled +
+		// goalModeState.goal.id === the persisted goal id).
+		expect(observed.notificationRuns).toBe(1);
+		expect(observed.goalIdAtNotification).toBe(GOAL_ID);
+		expect(mock.calls.length).toBeGreaterThan(0);
+		expect(goalAtAgentStart).toHaveLength(1);
+		expect(goalAtAgentStart[0]?.goalId).toBe(GOAL_ID);
+		expect(goalAtAgentStart[0]?.tools).toContain("goal");
+		expect(observed.sendErrors).toEqual([]);
+		expect(observed.runtimeErrors).toEqual([]);
+
+		// goal_updated is NOT gated: restore delivered it during attach, ahead
+		// of the gated mcp_notification, which itself precedes session_start.
+		expect(extensionEventOrder).toEqual(["goal_updated", "mcp_notification", "session_start"]);
+		expect(receivedEvents[0]?.type).toBe("goal_updated");
+	});
+});

--- a/packages/coding-agent/test/slash-commands/goal-acp.test.ts
+++ b/packages/coding-agent/test/slash-commands/goal-acp.test.ts
@@ -1,9 +1,9 @@
-import { type Mock, afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, type Mock, vi } from "bun:test";
 import type { GoalControllerResult } from "@oh-my-pi/pi-coding-agent/goals/goal-mode-controller";
 import type { Goal } from "@oh-my-pi/pi-coding-agent/goals/state";
-import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { handleGoalAcp, handleGuidedGoalAcp } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/goal";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 
 /**
  * handleGoalAcp / handleGuidedGoalAcp dispatch tests. The runtime is stubbed
@@ -210,9 +210,7 @@ describe("handleGoalAcp", () => {
 		const result = await handleGoalAcp(command("frobnicate"), runtime);
 
 		expect(controller.enter).not.toHaveBeenCalled();
-		expect(output).toHaveBeenCalledWith(
-			"Unknown /goal subcommand. Use set|show|pause|resume|drop|budget",
-		);
+		expect(output).toHaveBeenCalledWith("Unknown /goal subcommand. Use set|show|pause|resume|drop|budget");
 		expect(result).toEqual({ consumed: true });
 	});
 
@@ -243,7 +241,9 @@ describe("handleGuidedGoalAcp", () => {
 		// Must NOT call session.prompt() directly — that would nest an
 		// agent-initiated turn. The interview is returned as a residual prompt.
 		expect(prompt).not.toHaveBeenCalled();
-		expect(result).toEqual({ prompt: expect.any(String) });
+		// The kickoff is marked synthetic so the dispatcher delivers it as a
+		// hidden developer message instead of user-authored chat content.
+		expect(result).toEqual({ prompt: expect.any(String), synthetic: true });
 		if (result && typeof result === "object" && "prompt" in result) {
 			// The interview kickoff is rendered from the guided-goal template and
 			// carries the supplied rough objective.

--- a/packages/coding-agent/test/slash-commands/goal-acp.test.ts
+++ b/packages/coding-agent/test/slash-commands/goal-acp.test.ts
@@ -1,0 +1,306 @@
+import { type Mock, afterEach, describe, expect, it, vi } from "bun:test";
+import type { GoalControllerResult } from "@oh-my-pi/pi-coding-agent/goals/goal-mode-controller";
+import type { Goal } from "@oh-my-pi/pi-coding-agent/goals/state";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { handleGoalAcp, handleGuidedGoalAcp } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/goal";
+
+/**
+ * handleGoalAcp / handleGuidedGoalAcp dispatch tests. The runtime is stubbed
+ * with a vi.fn-backed goalModeController shaped to the controller's public
+ * surface — no module mocking, so the suite stays isolated and restoreAllMocks
+ * keeps it safe.
+ */
+
+/** Stub controller surface used by handleGoalAcp (Mock-typed, not ReturnType). */
+interface StubController {
+	enter: Mock<(objective: string) => Promise<GoalControllerResult>>;
+	replaceObjective: Mock<(objective: string) => Promise<GoalControllerResult>>;
+	show: Mock<() => string>;
+	pause: Mock<() => Promise<GoalControllerResult>>;
+	resume: Mock<() => Promise<GoalControllerResult>>;
+	drop: Mock<() => Promise<GoalControllerResult>>;
+	setBudget: Mock<(value: number | undefined) => Promise<GoalControllerResult>>;
+	exposeGoalTool: Mock<() => Promise<void>>;
+	entryGuard: Mock<() => GoalControllerResult | null>;
+}
+
+const ACTIVE_GOAL: Goal = {
+	id: "goal-1",
+	objective: "Build a widget",
+	status: "active",
+	tokenBudget: 1000,
+	tokensUsed: 120,
+	timeUsedSeconds: 45,
+	createdAt: 0,
+	updatedAt: 0,
+};
+
+const GOAL_DETAILS = [
+	"Objective: Build a widget",
+	"Status: active",
+	"Tokens: 120 / 1,000 (880 left)",
+	"Time spent: 45s",
+].join("\n");
+
+function createStubController(): StubController {
+	return {
+		enter: vi.fn(async (_objective: string): Promise<GoalControllerResult> => ({ ok: true })),
+		replaceObjective: vi.fn(async (_objective: string): Promise<GoalControllerResult> => ({ ok: true })),
+		show: vi.fn((): string => GOAL_DETAILS),
+		pause: vi.fn(async (): Promise<GoalControllerResult> => ({ ok: true })),
+		resume: vi.fn(async (): Promise<GoalControllerResult> => ({ ok: true })),
+		drop: vi.fn(async (): Promise<GoalControllerResult> => ({ ok: true })),
+		setBudget: vi.fn(async (_value: number | undefined): Promise<GoalControllerResult> => ({ ok: true })),
+		exposeGoalTool: vi.fn(async (): Promise<void> => {}),
+		entryGuard: vi.fn((): GoalControllerResult | null => null),
+	};
+}
+
+function createRuntime(controller: StubController, options: { activeGoal?: boolean } = {}) {
+	const prompt = vi.fn(async (_text: string): Promise<boolean> => true);
+	const output = vi.fn(async () => {});
+	const runtime = {
+		session: {
+			goalModeController: controller,
+			getGoalModeState: () =>
+				options.activeGoal ? { enabled: true, mode: "active", goal: ACTIVE_GOAL } : undefined,
+			getPlanModeState: () => undefined,
+			settings: { get: vi.fn((key: string) => (key === "goal.enabled" ? true : undefined)) },
+			prompt,
+		},
+		sessionManager: {},
+		settings: { get: vi.fn() },
+		cwd: "/tmp",
+		output,
+		refreshCommands: vi.fn(async () => {}),
+		reloadPlugins: vi.fn(async () => {}),
+	} as unknown as SlashCommandRuntime;
+	return { runtime, output, prompt };
+}
+
+function command(args: string) {
+	return { name: "goal", args, text: args ? `/goal ${args}` : "/goal" };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("handleGoalAcp", () => {
+	it("'set X' with no active goal calls enter and returns the kickoff prompt", async () => {
+		const controller = createStubController();
+		controller.enter.mockResolvedValue({ ok: true, prompt: "X" });
+		const { runtime } = createRuntime(controller, { activeGoal: false });
+
+		const result = await handleGoalAcp(command("set X"), runtime);
+
+		expect(controller.enter).toHaveBeenCalledTimes(1);
+		expect(controller.enter).toHaveBeenCalledWith("X");
+		expect(controller.replaceObjective).not.toHaveBeenCalled();
+		expect(result).toEqual({ prompt: "X" });
+	});
+
+	it("'set Y' with an active goal calls replaceObjective instead of enter", async () => {
+		const controller = createStubController();
+		controller.replaceObjective.mockResolvedValue({ ok: true, prompt: "Y" });
+		const { runtime } = createRuntime(controller, { activeGoal: true });
+
+		const result = await handleGoalAcp(command("set Y"), runtime);
+
+		expect(controller.replaceObjective).toHaveBeenCalledTimes(1);
+		expect(controller.replaceObjective).toHaveBeenCalledWith("Y");
+		expect(controller.enter).not.toHaveBeenCalled();
+		expect(result).toEqual({ prompt: "Y" });
+	});
+
+	it("'set' without an objective returns a usage error", async () => {
+		const controller = createStubController();
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command("set"), runtime);
+
+		expect(controller.enter).not.toHaveBeenCalled();
+		expect(controller.replaceObjective).not.toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith("Usage: /goal set <objective>");
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("'show' outputs the goal details and consumes", async () => {
+		const controller = createStubController();
+		controller.show.mockReturnValue(GOAL_DETAILS);
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command("show"), runtime);
+
+		expect(controller.show).toHaveBeenCalledTimes(1);
+		expect(output).toHaveBeenCalledWith(GOAL_DETAILS);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("bare /goal outputs show() and consumes", async () => {
+		const controller = createStubController();
+		controller.show.mockReturnValue(GOAL_DETAILS);
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command(""), runtime);
+
+		expect(controller.show).toHaveBeenCalledTimes(1);
+		expect(output).toHaveBeenCalledWith(GOAL_DETAILS);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("'drop' calls controller.drop and consumes", async () => {
+		const controller = createStubController();
+		const { runtime } = createRuntime(controller, { activeGoal: true });
+
+		const result = await handleGoalAcp(command("drop"), runtime);
+
+		expect(controller.drop).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("'pause' and 'resume' consume on success", async () => {
+		const controller = createStubController();
+		const { runtime } = createRuntime(controller);
+
+		expect(await handleGoalAcp(command("pause"), runtime)).toEqual({ consumed: true });
+		expect(await handleGoalAcp(command("resume"), runtime)).toEqual({ consumed: true });
+		expect(controller.pause).toHaveBeenCalledTimes(1);
+		expect(controller.resume).toHaveBeenCalledTimes(1);
+	});
+
+	it("'budget 100' calls setBudget(100)", async () => {
+		const controller = createStubController();
+		const { runtime } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command("budget 100"), runtime);
+
+		expect(controller.setBudget).toHaveBeenCalledTimes(1);
+		expect(controller.setBudget).toHaveBeenCalledWith(100);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("'budget off' calls setBudget(undefined)", async () => {
+		const controller = createStubController();
+		const { runtime } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command("budget off"), runtime);
+
+		expect(controller.setBudget).toHaveBeenCalledTimes(1);
+		expect(controller.setBudget).toHaveBeenCalledWith(undefined);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("'budget' without a value returns a usage error", async () => {
+		const controller = createStubController();
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command("budget"), runtime);
+
+		expect(controller.setBudget).not.toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith("Usage: /goal budget <N|off>");
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("unknown verb with an active goal returns a usage error", async () => {
+		const controller = createStubController();
+		const { runtime, output } = createRuntime(controller, { activeGoal: true });
+
+		const result = await handleGoalAcp(command("frobnicate"), runtime);
+
+		expect(controller.enter).not.toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith(
+			"Unknown /goal subcommand. Use set|show|pause|resume|drop|budget",
+		);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("controller errors surface via usage", async () => {
+		const controller = createStubController();
+		controller.enter.mockResolvedValue({ ok: false, error: "Goal mode is disabled." });
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await handleGoalAcp(command("set X"), runtime);
+
+		expect(output).toHaveBeenCalledWith("Goal mode is disabled.");
+		expect(result).toEqual({ consumed: true });
+	});
+});
+
+describe("handleGuidedGoalAcp", () => {
+	it("exposes the goal tool and returns the interview as a residual prompt without calling session.prompt", async () => {
+		// Contract: the guided-goal handler MUST return { prompt } so the slash
+		// dispatcher feeds the interview kickoff as model input within the
+		// current client request. Calling session.prompt() directly would nest an
+		// agent-initiated turn and break the ACP lifecycle.
+		const controller = createStubController();
+		const { runtime, prompt } = createRuntime(controller);
+
+		const result = await handleGuidedGoalAcp(command("rough idea"), runtime);
+
+		expect(controller.exposeGoalTool).toHaveBeenCalledTimes(1);
+		// Must NOT call session.prompt() directly — that would nest an
+		// agent-initiated turn. The interview is returned as a residual prompt.
+		expect(prompt).not.toHaveBeenCalled();
+		expect(result).toEqual({ prompt: expect.any(String) });
+		if (result && typeof result === "object" && "prompt" in result) {
+			// The interview kickoff is rendered from the guided-goal template and
+			// carries the supplied rough objective.
+			expect(result.prompt).toContain("rough idea");
+		}
+	});
+
+	it("rejects /guided-goal in a plan_paused session via the controller entry guard (dispatcher-level)", async () => {
+		// Regression: the goal tool's createGoal has no plan guard, so a guided-goal
+		// interview started in a plan_paused session could create a goal that
+		// replaces the paused plan. The handler must block via entryGuard BEFORE
+		// exposing the tool.
+		const controller = createStubController();
+		controller.entryGuard.mockReturnValue({ ok: false, error: "Exit plan mode first." });
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await executeAcpBuiltinSlashCommand("/guided-goal plan an idea", runtime);
+
+		expect(controller.exposeGoalTool).not.toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith("Exit plan mode first.");
+		expect(result).toEqual({ consumed: true });
+	});
+});
+
+describe("executeAcpBuiltinSlashCommand /goal dispatch", () => {
+	// The original gap: ACP advertises + executes only specs with `handle`. These
+	// assert the ACTUAL dispatcher-level execution path (not just the helper).
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("dispatches `/goal show` through the ACP builtin dispatcher and consumes", async () => {
+		const controller = createStubController();
+		const { runtime, output } = createRuntime(controller);
+
+		const result = await executeAcpBuiltinSlashCommand("/goal show", runtime);
+
+		expect(output).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("dispatches `/goal set <objective>` and returns the residual prompt", async () => {
+		const controller = createStubController();
+		controller.enter.mockResolvedValue({ ok: true, prompt: "ship it" });
+		const { runtime } = createRuntime(controller);
+
+		const result = await executeAcpBuiltinSlashCommand("/goal set ship it", runtime);
+
+		expect(result).toEqual({ prompt: "ship it" });
+	});
+
+	it("returns false for an unknown command (not consumed by a builtin)", async () => {
+		const controller = createStubController();
+		const { runtime } = createRuntime(controller);
+
+		const result = await executeAcpBuiltinSlashCommand("/not-a-builtin", runtime);
+
+		expect(result).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
Exposes `/goal` and `/guided-goal` to ACP and RPC headless clients by extracting a shared `GoalModeController` that both the TUI and the new headless adapter drive, so there is a single source of truth for the goal lifecycle.

Closes #8224.

## What changed
- `src/goals/goal-mode-controller.ts` (new): shared lifecycle core — enter/resume/pause/drop/budget, tool-set recording & restoration, continuation decisions, restore-on-session-switch, entry/active-goal guards (`goal.enabled` + plan active/paused exclusivity; paused goals rejected for pause/budget).
- `src/goals/headless-goal-adapter.ts` (new): drives the controller from ACP/RPC session events; initial restore on attach; `setSessionSwitchReconciler` so prior goal state doesn't leak into a switched transcript; resets continuation suppression on a real user turn.
- `src/slash-commands/helpers/goal.ts` (new): `handleGoalAcp` / `handleGuidedGoalAcp`.
- `src/slash-commands/builtin-modes.ts`: add `handle` to `/goal` and `/guided-goal`.
- `src/modes/acp/acp-agent.ts` / `src/modes/rpc/rpc-mode.ts`: `await attachHeadlessGoalAdapter`.
- `src/session/agent-session.ts`: construct & expose the controller.
- `src/modes/interactive-mode.ts`: TUI delegates to the controller (behavior preserved).
- CHANGELOG entry.

## Continuation is opt-in
Headless goal auto-continuation stays off by default. Add `"acp"`/`"rpc"` to `goal.continuationModes` to enable. It routes through the central agent-initiated-turn path, so ACP's `deferAgentInitiatedTurns` contract is respected.

## Verification
- `bun run check:types` clean; biome clean.
- 1192 tests pass across goals/slash/modes/ACP/RPC (+ new contract tests: exposure via `buildAvailableSlashCommands`, dispatcher, paused pause/budget rejection, plan_paused guided-goal block, continuation timing).
- TUI characterization tests unchanged in behavior.
