### PR TITLE
fix(ai): support Daybreak Responses Lite

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex Responses Lite requests for opaque model codenames such as Daybreak omitting the required `reasoning.context: "all_turns"` value and failing with HTTP 400.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -443,13 +443,15 @@ export async function transformRequestBody(
 			...body.reasoning,
 			...reasoningConfig,
 		};
-		// Responses Lite requires `all_turns`; the full transport leaves context to the server unless explicitly set.
-		const context = responsesLite ? "all_turns" : options.reasoningContext;
-		if (context !== undefined) {
-			if (context === "all_turns" && !supportsAllTurnsReasoningContext(model.id)) {
+		// Lite requires `all_turns` even for opaque/codenamed model ids. Only explicit
+		// full-transport overrides are gated by the known model wire generation.
+		if (responsesLite) {
+			body.reasoning.context = "all_turns";
+		} else if (options.reasoningContext !== undefined) {
+			if (options.reasoningContext === "all_turns" && !supportsAllTurnsReasoningContext(model.id)) {
 				delete body.reasoning.context;
 			} else {
-				body.reasoning.context = context;
+				body.reasoning.context = options.reasoningContext;
 			}
 		}
 	} else {

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -661,8 +661,8 @@ describe("openai-codex Responses Lite and client metadata wire format", () => {
 		]);
 	});
 
-	it("sends the lite header when the model defaults to Responses Lite", async () => {
-		const model = createCodexModel("gpt-5.6-terra", { useResponsesLite: true });
+	it("sends required lite context for opaque model codenames", async () => {
+		const model = createCodexModel("gpt-daybreak-blue-latest", { useResponsesLite: true });
 		let captured: CapturedCodexRequest | undefined;
 		const fetchMock = createCodexFetchMock(createCodexSse(COMPLETED_CODEX_EVENTS), request => {
 			captured = request;


### PR DESCRIPTION
## What

- Force Responses Lite requests to send `reasoning.context: "all_turns"`, including for opaque or codenamed model IDs.
- Keep known-model gating for explicit full-transport `all_turns` overrides.

## Why

Daybreak Responses Lite rejects requests that omit the required `reasoning.context: "all_turns"` value with HTTP 400. Opaque model IDs do not pass the known model-generation classifier, so the shared gate removed the field that Lite requires.

## Testing

- `bun test packages/ai/test/openai-codex-responses-lite.test.ts` — 36 passed, 0 failed
- `bun run check:ts` — passed across the workspace
- `bun --cwd=packages/ai run check` — passed

---

- [ ] `bun check` passes (Rust toolchain unavailable locally; the TypeScript workspace check passes)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)