### PR TITLE
fix(coding-agent): emit clap-compatible CI=true and honor PI_BASH_NO_CI

### DIFF
--- a/docs/bash-tool-runtime.md
+++ b/docs/bash-tool-runtime.md
@@ -140,7 +140,7 @@ The per-command child environment is then built by `buildNonInteractiveEnv()` (`
 
 - pagers disabled (`PAGER=cat`, `GIT_PAGER=cat`, … and `LESS=FRX`),
 - editor prompts disabled (`GIT_EDITOR=true`, `EDITOR=true`, `VISUAL=true`),
-- terminal/credential prompts reduced (`TERM=dumb`, `GIT_TERMINAL_PROMPT=0`, `SSH_ASKPASS=/usr/bin/false`, `NO_COLOR=1`, `CI=1`),
+- terminal/credential prompts reduced (`TERM=dumb`, `GIT_TERMINAL_PROMPT=0`, `SSH_ASKPASS=/usr/bin/false`, `NO_COLOR=1`, `CI=true` unless `PI_BASH_NO_CI`/`CLAUDE_BASH_NO_CI` is set),
 - package-manager/tooling automation flags for non-interactive behavior (npm/pnpm/yarn/pip/cargo/terraform/gh, …),
 - on Windows, UTF-8 locale/codepage defaults are added when absent.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash-tool commands receiving an unguarded `CI=1`, which broke clap-based CLIs (e.g. `tauri android build`) that parse `CI` as a strict boolean, and ignored the documented `PI_BASH_NO_CI` opt-out. The per-command env now injects clap-compatible `CI=true` and honors `PI_BASH_NO_CI`/`CLAUDE_BASH_NO_CI` ([#8229](https://github.com/can1357/oh-my-pi/issues/8229)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/exec/non-interactive-env.ts
+++ b/packages/coding-agent/src/exec/non-interactive-env.ts
@@ -23,7 +23,7 @@ export const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
 	EDITOR: "true",
 	GIT_TERMINAL_PROMPT: "0",
 	SSH_ASKPASS: "/usr/bin/false",
-	CI: "1",
+	CI: "true",
 	AGENT: "1",
 	// Package manager defaults for unattended execution.
 	npm_config_yes: "true",
@@ -96,17 +96,28 @@ function hasEnvGroupValue(
 	return false;
 }
 
+/** Copy of the base env with `CI` removed, for the `PI_BASH_NO_CI` opt-out. */
+function withoutCI(env: Readonly<Record<string, string>>): Record<string, string> {
+	const { CI: _ci, ...rest } = env;
+	return rest;
+}
+
 /** Builds the per-command environment for non-interactive child processes. */
 export function buildNonInteractiveEnv(
 	overrides?: Record<string, string>,
 	baseEnv: Record<string, string | undefined> = Bun.env,
 	platform: NodeJS.Platform = process.platform,
 ): Record<string, string> {
+	// `PI_BASH_NO_CI` (and its legacy alias) opts out of the automatic `CI=true`
+	// injection. Mirrors the session-env gate in `procmgr.ts` so the opt-out
+	// reaches the per-command env, which otherwise overrides the session value.
+	const base =
+		baseEnv.PI_BASH_NO_CI || baseEnv.CLAUDE_BASH_NO_CI ? withoutCI(NON_INTERACTIVE_ENV) : NON_INTERACTIVE_ENV;
 	if (platform !== "win32") {
-		return overrides ? { ...NON_INTERACTIVE_ENV, ...overrides } : NON_INTERACTIVE_ENV;
+		return overrides ? { ...base, ...overrides } : base;
 	}
 
-	const env: Record<string, string> = { ...NON_INTERACTIVE_ENV };
+	const env: Record<string, string> = { ...base };
 	for (const group of WINDOWS_UTF8_ENV_DEFAULT_GROUPS) {
 		if (hasEnvGroupValue(baseEnv, group, platform) || hasEnvGroupValue(overrides, group, platform)) {
 			continue;

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -59,6 +59,21 @@ describe("buildNonInteractiveEnv", () => {
 
 		expect(env.GPG_TTY).toBe("/dev/pts/7");
 	});
+
+	it("injects clap-compatible CI=true by default", () => {
+		expect(buildNonInteractiveEnv(undefined, {}, "linux").CI).toBe("true");
+		expect(buildNonInteractiveEnv(undefined, {}, "win32").CI).toBe("true");
+	});
+
+	it("drops CI when PI_BASH_NO_CI or its legacy alias is set", () => {
+		expect(buildNonInteractiveEnv(undefined, { PI_BASH_NO_CI: "1" }, "linux")).not.toHaveProperty("CI");
+		expect(buildNonInteractiveEnv(undefined, { CLAUDE_BASH_NO_CI: "1" }, "linux")).not.toHaveProperty("CI");
+		expect(buildNonInteractiveEnv(undefined, { PI_BASH_NO_CI: "1" }, "win32")).not.toHaveProperty("CI");
+	});
+
+	it("lets a per-command CI override win over the opt-out", () => {
+		expect(buildNonInteractiveEnv({ CI: "0" }, { PI_BASH_NO_CI: "1" }, "linux").CI).toBe("0");
+	});
 });
 
 it("filters expanded dotenv values while preserving matching launcher values", async () => {


### PR DESCRIPTION
## Repro
Every bash-tool command inherits an unguarded `CI=1`. clap (the Rust CLI framework) parses `CI` as a strict boolean and accepts only `true`/`false`, so clap-based CLIs fail to start (`npx tauri android build --apk --target aarch64` → `error: invalid value '1' for '--ci'`). Root-cause repro at the env layer:

```
$ bun -e 'import { buildNonInteractiveEnv } from "./packages/coding-agent/src/exec/non-interactive-env.ts"; console.log("default CI =", JSON.stringify(buildNonInteractiveEnv(undefined, {}, "linux").CI)); console.log("with PI_BASH_NO_CI CI =", JSON.stringify(buildNonInteractiveEnv(undefined, { PI_BASH_NO_CI: "1" }, "linux").CI));'
default CI = "1"
with PI_BASH_NO_CI CI = "1"
```

## Cause
Two env-construction paths disagree. `packages/coding-agent/src/exec/non-interactive-env.ts` hardcoded `CI: "1"` in `NON_INTERACTIVE_ENV` with no opt-out, and `bash-executor.ts` passes that per-command env straight to the command. `packages/utils/src/procmgr.ts` `buildSpawnEnv` sets the documented, clap-compatible `CI: "true"` gated on `PI_BASH_NO_CI`/`CLAUDE_BASH_NO_CI`, but only on the *session* env, which the per-command env overrides. So the guarded `"true"` never reached commands and the documented `PI_BASH_NO_CI` opt-out (environment-variables.md §7) had no effect on bash-tool commands.

## Fix
- `NON_INTERACTIVE_ENV.CI` changed from `"1"` to `"true"` (clap-compatible; matches `procmgr.ts` and the documented value).
- `buildNonInteractiveEnv` now strips `CI` when `PI_BASH_NO_CI`/`CLAUDE_BASH_NO_CI` is set on the base env, mirroring `buildSpawnEnv`; explicit per-command `CI` overrides still win.
- Updated `docs/bash-tool-runtime.md` (`CI=1` → `CI=true` unless the opt-out is set).
- Added tests for the default value, both opt-out aliases (linux + win32), and override precedence.

## Verification
`bun test packages/coding-agent/test/non-interactive-env.test.ts` → 12 pass / 0 fail. Manual re-run of the repro now prints `default CI = "true"` and `with PI_BASH_NO_CI CI = undefined`. Fixes #8229