### PR TITLE
fix(agent): respect spawn depth in tool guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped `eval`, `glob`, `grep`, and `ast_grep` from advertising subagents after recursion depth or spawn policy disables task spawning. ([#8231](https://github.com/can1357/oh-my-pi/pull/8231)) by [@olegpulatov](https://github.com/olegpulatov)
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/prompts/tools/ast-grep.md
+++ b/packages/coding-agent/src/prompts/tools/ast-grep.md
@@ -15,5 +15,6 @@ Structural code search via ast-grep. Use when syntax shape matters more than tex
 <critical>
 - AVOID repo-root scans — narrow `path` first.
 - Parse issues = query failure, not absence: fix pattern or tighten `path` before concluding "no matches".
-- Broad cross-subsystem exploration → {{#if scoutAvailable}}Task tool + scout{{else}}Task tool{{/if}} subagent first.
+{{#if taskAvailable}}- Broad cross-subsystem exploration → {{#if scoutAvailable}}Task tool + scout{{else}}Task tool{{/if}} subagent first.
+{{/if}}
 </critical>

--- a/packages/coding-agent/src/prompts/tools/glob.md
+++ b/packages/coding-agent/src/prompts/tools/glob.md
@@ -11,6 +11,8 @@ Globs files, directories, and path-backed internal URLs with fast pattern matchi
 Matches are newest-first and grouped by directory; directories end in `/`.
 </output>
 
+{{#if taskAvailable}}
 <avoid>
 Open-ended multi-round discovery → {{#if scoutAvailable}}Task + scout.{{else}}Task.{{/if}}
 </avoid>
+{{/if}}

--- a/packages/coding-agent/src/prompts/tools/grep.md
+++ b/packages/coding-agent/src/prompts/tools/grep.md
@@ -9,5 +9,6 @@ Searches files and internal URLs with Rust regex plus PCRE2 fallback.
 
 <critical>
 - MUST use this instead of shell `grep`/`rg`.
-- Open-ended multi-round search MUST use {{#if scoutAvailable}}Task + scout,{{else}}Task,{{/if}} not chained calls.
+{{#if taskAvailable}}- Open-ended multi-round search MUST use {{#if scoutAvailable}}Task + scout,{{else}}Task,{{/if}} not chained calls.
+{{/if}}
 </critical>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -165,7 +165,7 @@ import {
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
 import { wrapStreamFnWithProviderConcurrency } from "./task/provider-concurrency";
-import { isScoutSpawnable } from "./task/spawn-policy";
+import { isAgentAllowedBySpawnPolicy, isScoutSpawnable } from "./task/spawn-policy";
 import type { StructuredSubagentSchemaMode } from "./task/types";
 import {
 	AUTO_THINKING,
@@ -2891,8 +2891,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				scoutAvailable: isScoutSpawnable(
 					settings.get("task.disabledAgents") as string[] | undefined,
 					options.spawns ?? "*",
+					settings.get("task.maxRecursionDepth") ?? 2,
+					options.taskDepth ?? 0,
 				),
-				taskIrcEnabled: !restrictToolNames && isIrcEnabled(settings, options.taskDepth ?? 0),
+				taskIrcEnabled: !restrictToolNames && isIrcEnabled(settings, options.taskDepth ?? 0, options.spawns ?? "*"),
 				autoQaEnabled: !restrictToolNames && isAutoQaEnabled(settings),
 				secretsEnabled,
 				workspaceTree: workspaceTreePromise,
@@ -3339,7 +3341,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			initialAdvisorCosts,
 			settings,
 			autoApprove: options.autoApprove,
-			scoutAllowedBySpawnPolicy: isScoutSpawnable(undefined, options.spawns ?? "*"),
+			scoutAllowedBySpawnPolicy: isAgentAllowedBySpawnPolicy("scout", undefined, options.spawns ?? "*"),
+			taskDepth: options.taskDepth,
 			evalKernelOwnerId,
 			// Defined only for top-level sessions (creation is gated above).
 			// AgentSession uses this to decide whether it may dispose the global

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -125,6 +125,8 @@ export interface AgentSessionConfig {
 	settings: Settings;
 	/** Whether the session spawn policy permits the read-only `scout` subagent. Defaults to true. */
 	scoutAllowedBySpawnPolicy?: boolean;
+	/** Current subagent recursion depth. Defaults to the top-level depth of zero. */
+	taskDepth?: number;
 	/** Whether the caller explicitly requested yolo/auto-approve behavior for this session. */
 	autoApprove?: boolean;
 	/** Models to cycle through with Ctrl+P (from --models flag). */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -176,6 +176,7 @@ import {
 	obfuscateProviderContext,
 } from "../secrets/message-transform";
 import type { SecretObfuscator } from "../secrets/obfuscator";
+import { canSpawnAtDepth } from "../task/types";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -532,6 +533,7 @@ export class AgentSession {
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
 	#scoutAllowedBySpawnPolicy = true;
+	#taskDepth = 0;
 	#providerSessionId: string | undefined;
 	#freshProviderSessionId: string | undefined;
 	#inheritedProviderPromptCacheKey: string | undefined;
@@ -1301,6 +1303,7 @@ export class AgentSession {
 		this.#agentId = config.agentId;
 		this.#agentKind = config.agentKind ?? "main";
 		this.#scoutAllowedBySpawnPolicy = config.scoutAllowedBySpawnPolicy ?? true;
+		this.#taskDepth = config.taskDepth ?? 0;
 		this.#providerSessionId = config.providerSessionId;
 		this.#inheritedProviderPromptCacheKey =
 			config.providerPromptCacheKeySource === "fork" ? this.agent.promptCacheKey : undefined;
@@ -4871,7 +4874,11 @@ export class AgentSession {
 
 	#isScoutAvailable(): boolean {
 		const disabledAgents = this.settings.get("task.disabledAgents") as string[] | undefined;
-		return this.#scoutAllowedBySpawnPolicy && !disabledAgents?.includes("scout");
+		return (
+			canSpawnAtDepth(this.settings.get("task.maxRecursionDepth") ?? 2, this.#taskDepth) &&
+			this.#scoutAllowedBySpawnPolicy &&
+			!disabledAgents?.includes("scout")
+		);
 	}
 
 	async #buildPlanModeMessage(): Promise<CustomMessage | null> {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -142,6 +142,8 @@ interface TaskDescriptionOptions {
 	asyncEnabled: boolean;
 	ircEnabled: boolean;
 	parentSpawns: string;
+	maxRecursionDepth: number;
+	taskDepth: number;
 }
 
 /** Render the tool description from a cached agent list and current settings. */
@@ -164,7 +166,12 @@ function renderDescription(options: TaskDescriptionOptions): string {
 		readOnly: isReadOnlyAgent(agent),
 		blocking: agent.blocking === true,
 	}));
-	const scoutAvailable = isScoutSpawnable(options.disabledAgents, options.parentSpawns);
+	const scoutAvailable = isScoutSpawnable(
+		options.disabledAgents,
+		options.parentSpawns,
+		options.maxRecursionDepth,
+		options.taskDepth,
+	);
 	return prompt.render(taskDescriptionTemplate, {
 		agents: renderedAgents,
 		scoutAvailable,
@@ -611,6 +618,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			asyncEnabled: this.session.settings.get("async.enabled"),
 			ircEnabled: isIrcEnabled(this.session.settings, this.session.taskDepth ?? 0),
 			parentSpawns: this.session.getSessionSpawns() ?? "*",
+			maxRecursionDepth: this.session.settings.get("task.maxRecursionDepth") ?? 2,
+			taskDepth: this.session.taskDepth ?? 0,
 		});
 	}
 	private constructor(
@@ -752,6 +761,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						scoutAvailable: isScoutSpawnable(
 							this.session.settings.get("task.disabledAgents") as string[] | undefined,
 							this.session.getSessionSpawns?.() ?? "*",
+							this.session.settings.get("task.maxRecursionDepth") ?? 2,
+							this.session.taskDepth ?? 0,
 						),
 					});
 			const result = await this.#executeSyncFanout(
@@ -789,6 +800,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					scoutAvailable: isScoutSpawnable(
 						this.session.settings.get("task.disabledAgents") as string[] | undefined,
 						this.session.getSessionSpawns?.() ?? "*",
+						this.session.settings.get("task.maxRecursionDepth") ?? 2,
+						this.session.taskDepth ?? 0,
 					),
 				});
 		// Returns a fresh result (copied content array, copied text part) rather

--- a/packages/coding-agent/src/task/spawn-policy.ts
+++ b/packages/coding-agent/src/task/spawn-policy.ts
@@ -1,3 +1,5 @@
+import { canSpawnAtDepth } from "./types";
+
 /** Default agent used when a session has unrestricted spawning. */
 export const DEFAULT_SPAWN_AGENT = "task";
 
@@ -56,17 +58,38 @@ export function resolveSpawnPolicy(parentSpawns: string | boolean | null | undef
 		allowedPromptText: allowedAgents.map(agent => `\`${agent}\``).join(", "),
 	};
 }
+/** Whether one agent is enabled and permitted by the session spawn policy. */
+export function isAgentAllowedBySpawnPolicy(
+	agent: string,
+	disabledAgents: readonly string[] | undefined,
+	spawns: string | boolean | null | undefined,
+): boolean {
+	if (disabledAgents?.includes(agent)) return false;
+	const policy = resolveSpawnPolicy(spawns);
+	return policy.enabled && (policy.allowedAgents === null || policy.allowedAgents.includes(agent));
+}
+
+/** Whether the session may spawn any subagent under both policy and depth limits. */
+export function canSpawnSubagents(
+	spawns: string | boolean | null | undefined,
+	maxRecursionDepth: number,
+	taskDepth: number,
+): boolean {
+	return canSpawnAtDepth(maxRecursionDepth, taskDepth) && resolveSpawnPolicy(spawns).enabled;
+}
 
 /**
- * Whether the `scout` agent is spawnable in a session: not disabled via
- * `task.disabledAgents`, and permitted by the session spawn policy.
+ * Whether the `scout` agent is spawnable in a session: not disabled, permitted
+ * by the session spawn policy, and within the recursion-depth limit.
  */
 export function isScoutSpawnable(
 	disabledAgents: readonly string[] | undefined,
 	spawns: string | boolean | null | undefined,
+	maxRecursionDepth: number,
+	taskDepth: number,
 ): boolean {
-	if (disabledAgents?.includes("scout")) return false;
-	const policy = resolveSpawnPolicy(spawns);
-	if (!policy.enabled) return false;
-	return policy.allowedAgents === null || policy.allowedAgents.includes("scout");
+	return (
+		canSpawnSubagents(spawns, maxRecursionDepth, taskDepth) &&
+		isAgentAllowedBySpawnPolicy("scout", disabledAgents, spawns)
+	);
 }

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -11,7 +11,7 @@ import { recordFileSnapshot, recordSeenLinesFromBody } from "../edit/file-snapsh
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import astGrepDescription from "../prompts/tools/ast-grep.md" with { type: "text" };
-import { isScoutSpawnable } from "../task/spawn-policy";
+import { canSpawnSubagents, isScoutSpawnable } from "../task/spawn-policy";
 import { Ellipsis, fileHyperlink, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
@@ -152,10 +152,16 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 	readonly label = "AST Grep";
 	readonly summary = "Search code with AST patterns (structural grep)";
 	get description(): string {
+		const spawns = this.session.getSessionSpawns?.() ?? "*";
+		const maxRecursionDepth = this.session.settings.get("task.maxRecursionDepth") ?? 2;
+		const taskDepth = this.session.taskDepth ?? 0;
 		return prompt.render(astGrepDescription, {
+			taskAvailable: canSpawnSubagents(spawns, maxRecursionDepth, taskDepth),
 			scoutAvailable: isScoutSpawnable(
 				this.session.settings.get("task.disabledAgents") as string[] | undefined,
-				this.session.getSessionSpawns?.() ?? "*",
+				spawns,
+				maxRecursionDepth,
+				taskDepth,
 			),
 		});
 	}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -10,7 +10,7 @@ import { defaultEvalSessionId } from "../eval/session-id";
 import type { EvalCellResult, EvalDisplayOutput, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
 import evalDescription from "../prompts/tools/eval.md" with { type: "text" };
 import { DEFAULT_MAX_BYTES, OutputSink, type OutputSummary, TailBuffer } from "../session/streaming-output";
-import { resolveSpawnPolicy } from "../task/spawn-policy";
+import { canSpawnSubagents, resolveSpawnPolicy } from "../task/spawn-policy";
 import { webpExclusionForModel } from "../utils/image-loading";
 import { formatDimensionNote, resizeImage } from "../utils/image-resize";
 import type { ToolSession } from ".";
@@ -296,12 +296,19 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		if (!this.session) return getEvalToolDescription();
 		const backends = resolveEvalBackends(this.session);
 		const sessionSpawns = this.session.getSessionSpawns?.() ?? "*";
+		const spawns = canSpawnSubagents(
+			sessionSpawns,
+			this.session.settings.get("task.maxRecursionDepth") ?? 2,
+			this.session.taskDepth ?? 0,
+		)
+			? sessionSpawns
+			: false;
 		return getEvalToolDescription({
 			py: backends.python,
 			js: backends.js,
 			rb: backends.ruby,
 			jl: backends.julia,
-			spawns: sessionSpawns,
+			spawns,
 		});
 	}
 	/** All reuse-chain examples; the `examples` getter filters by enabled languages. */

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -13,7 +13,7 @@ import { splitMemoryGlobPattern } from "../internal-urls/memory-protocol";
 import type { Theme } from "../modes/theme/theme";
 import globDescription from "../prompts/tools/glob.md" with { type: "text" };
 import { type TruncationResult, truncateHead } from "../session/streaming-output";
-import { isScoutSpawnable } from "../task/spawn-policy";
+import { canSpawnSubagents, isScoutSpawnable } from "../task/spawn-policy";
 import { Ellipsis, fileHyperlink, renderFileList, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import type { ToolSession } from ".";
 import { applyListLimit } from "./list-limit";
@@ -108,10 +108,16 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 	readonly loadMode = "essential";
 	readonly label = "Glob";
 	get description(): string {
+		const spawns = this.session.getSessionSpawns?.() ?? "*";
+		const maxRecursionDepth = this.session.settings.get("task.maxRecursionDepth") ?? 2;
+		const taskDepth = this.session.taskDepth ?? 0;
 		return prompt.render(globDescription, {
+			taskAvailable: canSpawnSubagents(spawns, maxRecursionDepth, taskDepth),
 			scoutAvailable: isScoutSpawnable(
 				this.session.settings.get("task.disabledAgents") as string[] | undefined,
-				this.session.getSessionSpawns?.() ?? "*",
+				spawns,
+				maxRecursionDepth,
+				taskDepth,
 			),
 		});
 	}

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -22,7 +22,7 @@ import type { InternalResource, ResolveContext } from "../internal-urls/types";
 import type { Theme } from "../modes/theme/theme";
 import grepDescription from "../prompts/tools/grep.md" with { type: "text" };
 import { DEFAULT_MAX_COLUMN, type TruncationResult, truncateHead, truncateLine } from "../session/streaming-output";
-import { isScoutSpawnable } from "../task/spawn-policy";
+import { canSpawnSubagents, isScoutSpawnable } from "../task/spawn-policy";
 import {
 	Ellipsis,
 	fileHyperlink,
@@ -912,12 +912,18 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 	readonly summary = "Grep file contents using ripgrep (fast regex search)";
 	get description(): string {
 		const displayMode = resolveFileDisplayMode(this.session);
+		const spawns = this.session.getSessionSpawns?.() ?? "*";
+		const maxRecursionDepth = this.session.settings.get("task.maxRecursionDepth") ?? 2;
+		const taskDepth = this.session.taskDepth ?? 0;
 		return prompt.render(grepDescription, {
 			IS_HL_MODE: displayMode.hashLines,
 			IS_LINE_NUMBER_MODE: !displayMode.hashLines && displayMode.lineNumbers,
+			taskAvailable: canSpawnSubagents(spawns, maxRecursionDepth, taskDepth),
 			scoutAvailable: isScoutSpawnable(
 				this.session.settings.get("task.disabledAgents") as string[] | undefined,
-				this.session.getSessionSpawns?.() ?? "*",
+				spawns,
+				maxRecursionDepth,
+				taskDepth,
 			),
 		});
 	}

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -18,7 +18,7 @@ import { IrcBus, type IrcDeliveryReceipt, type IrcMessage } from "../../irc/bus"
 import type { Theme } from "../../modes/theme/theme";
 import { type AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
 import { registerPersistedSubagents } from "../../registry/persisted-agents";
-import { canSpawnAtDepth } from "../../task/types";
+import { canSpawnSubagents } from "../../task/spawn-policy";
 import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import {
 	createCachedComponent,
@@ -39,12 +39,15 @@ export const DEFAULT_IRC_TIMEOUT_MS = 120_000;
  * session that can still spawn subagents through the task tool. Only a
  * top-level session with task spawning unavailable has no peers.
  */
-export function isIrcEnabled(settings: Settings, taskDepth: number): boolean {
+export function isIrcEnabled(
+	settings: Settings,
+	taskDepth: number,
+	spawns: string | boolean | null | undefined = "*",
+): boolean {
 	if (taskDepth > 0) return true;
 	// Top-level session: peers exist only if it can still spawn subagents — the
 	// same capacity gate the task tool uses, reused here to avoid drift.
-	const maxDepth = settings.get("task.maxRecursionDepth") ?? 2;
-	return canSpawnAtDepth(maxDepth, taskDepth);
+	return canSpawnSubagents(spawns, settings.get("task.maxRecursionDepth") ?? 2, taskDepth);
 }
 
 export function formatIncoming(msg: IrcMessage): string {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -31,7 +31,8 @@ import type { SessionManager } from "../session/session-manager";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
-import { canSpawnAtDepth, type StructuredSubagentSchemaMode } from "../task/types";
+import { canSpawnSubagents } from "../task/spawn-policy";
+import type { StructuredSubagentSchemaMode } from "../task/types";
 import type { EventBus } from "../utils/event-bus";
 import { type InspectImageMode, isInspectImageToolActive } from "../utils/inspect-image-mode";
 import { WebSearchTool } from "../web/search";
@@ -614,7 +615,9 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			);
 		if (name === "hub") {
 			return (
-				!restrictToolNames && session.enableIrc !== false && isIrcEnabled(session.settings, session.taskDepth ?? 0)
+				!restrictToolNames &&
+				session.enableIrc !== false &&
+				isIrcEnabled(session.settings, session.taskDepth ?? 0, session.getSessionSpawns())
 			);
 		}
 		if (name === "retain" || name === "recall" || name === "reflect") {
@@ -634,7 +637,11 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			);
 		}
 		if (name === "task") {
-			return canSpawnAtDepth(session.settings.get("task.maxRecursionDepth") ?? 2, session.taskDepth ?? 0);
+			return canSpawnSubagents(
+				session.getSessionSpawns(),
+				session.settings.get("task.maxRecursionDepth") ?? 2,
+				session.taskDepth ?? 0,
+			);
 		}
 		return true;
 	};

--- a/packages/coding-agent/test/task/spawn-policy.test.ts
+++ b/packages/coding-agent/test/task/spawn-policy.test.ts
@@ -3,7 +3,7 @@ import { Settings } from "../../src/config/settings";
 import initAgentPrompt from "../../src/prompts/agents/init.md" with { type: "text" };
 import * as taskDiscovery from "../../src/task/discovery";
 import { TaskTool } from "../../src/task/index";
-import { isScoutSpawnable } from "../../src/task/spawn-policy";
+import { canSpawnSubagents, isScoutSpawnable } from "../../src/task/spawn-policy";
 import type { AgentDefinition } from "../../src/task/types";
 import { getTaskSchema } from "../../src/task/types";
 import type { ToolSession } from "../../src/tools";
@@ -65,27 +65,42 @@ describe("task spawn policy surfaces", () => {
 
 describe("isScoutSpawnable", () => {
 	it("is true with no disabled agents and unrestricted spawns", () => {
-		expect(isScoutSpawnable(undefined, "*")).toBe(true);
-		expect(isScoutSpawnable([], "*")).toBe(true);
+		expect(isScoutSpawnable(undefined, "*", 1, 0)).toBe(true);
+		expect(isScoutSpawnable([], "*", 1, 0)).toBe(true);
 	});
 
 	it("is false when scout is disabled via task.disabledAgents", () => {
-		expect(isScoutSpawnable(["scout"], "*")).toBe(false);
-		expect(isScoutSpawnable(["scout", "reviewer"], "*")).toBe(false);
+		expect(isScoutSpawnable(["scout"], "*", 1, 0)).toBe(false);
+		expect(isScoutSpawnable(["scout", "reviewer"], "*", 1, 0)).toBe(false);
 	});
 
 	it("is false when spawning is disabled", () => {
-		expect(isScoutSpawnable(undefined, false)).toBe(false);
-		expect(isScoutSpawnable(undefined, "")).toBe(false);
+		expect(isScoutSpawnable(undefined, false, 1, 0)).toBe(false);
+		expect(isScoutSpawnable(undefined, "", 1, 0)).toBe(false);
 	});
 
 	it("is false when scout is not in the allowed spawn list", () => {
-		expect(isScoutSpawnable(undefined, "reviewer")).toBe(false);
+		expect(isScoutSpawnable(undefined, "reviewer", 1, 0)).toBe(false);
 	});
 
 	it("is true when scout is in the allowed spawn list", () => {
-		expect(isScoutSpawnable(undefined, "scout,reviewer")).toBe(true);
-		expect(isScoutSpawnable(["reviewer"], "scout")).toBe(true);
+		expect(isScoutSpawnable(undefined, "scout,reviewer", 1, 0)).toBe(true);
+		expect(isScoutSpawnable(["reviewer"], "scout", 1, 0)).toBe(true);
+	});
+
+	it("is false when recursion depth is exhausted", () => {
+		expect(isScoutSpawnable(undefined, "*", 0, 0)).toBe(false);
+		expect(isScoutSpawnable(undefined, "*", 1, 1)).toBe(false);
+	});
+});
+
+describe("canSpawnSubagents", () => {
+	it("requires both spawn-policy permission and recursion capacity", () => {
+		expect(canSpawnSubagents("*", 1, 0)).toBe(true);
+		expect(canSpawnSubagents("", 1, 0)).toBe(false);
+		expect(canSpawnSubagents("*", 0, 0)).toBe(false);
+		expect(canSpawnSubagents("*", 1, 1)).toBe(false);
+		expect(canSpawnSubagents("*", -1, 50)).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -5,15 +5,22 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { EvalTool, getEvalToolDescription } from "@oh-my-pi/pi-coding-agent/tools/eval";
 
-function makeSession(opts: { spawns?: string | null; backends?: Record<string, boolean> }): ToolSession {
+function makeSession(opts: {
+	spawns?: string | null;
+	backends?: Record<string, boolean>;
+	maxRecursionDepth?: number;
+	taskDepth?: number;
+}): ToolSession {
 	const settings = Settings.isolated();
 	for (const [key, value] of Object.entries(opts.backends ?? {})) settings.set(key as never, value);
+	settings.set("task.maxRecursionDepth", opts.maxRecursionDepth ?? 2);
 	return {
 		cwd: "/tmp/eval-test",
 		hasUI: false,
 		getSessionFile: () => null,
 		getSessionSpawns: () => opts.spawns ?? "*",
 		settings,
+		taskDepth: opts.taskDepth,
 	} as unknown as ToolSession;
 }
 
@@ -61,6 +68,13 @@ describe("eval tool description", () => {
 		const denied = new EvalTool(makeSession({ spawns: "" })).description;
 		expect(wildcard).toContain("agent(prompt");
 		expect(denied).not.toContain("agent(prompt");
+	});
+
+	it("omits agent() when recursion depth is exhausted", () => {
+		const disabled = new EvalTool(makeSession({ spawns: "*", maxRecursionDepth: 0 })).description;
+		const nested = new EvalTool(makeSession({ spawns: "*", maxRecursionDepth: 1, taskDepth: 1 })).description;
+		expect(disabled).not.toContain("agent(prompt");
+		expect(nested).not.toContain("agent(prompt");
 	});
 });
 

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -68,6 +68,23 @@ describe("createTools", () => {
 		expect(names).not.toContain("vim");
 	});
 
+	it("excludes task when recursion depth is exhausted", async () => {
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({ "task.maxRecursionDepth": 1 }),
+			taskDepth: 1,
+		});
+		const tools = await createTools(session, ["read", "task"]);
+
+		expect(tools.map(tool => tool.name)).toEqual(["read"]);
+	});
+
+	it("excludes task and hub when the session spawn policy disables spawning", async () => {
+		const session = createTestSession({ getSessionSpawns: () => "" });
+		const tools = await createTools(session, ["read", "task", "hub"]);
+
+		expect(tools.map(tool => tool.name)).toEqual(["read"]);
+	});
+
 	it("normalizes legacy explicit tool names", async () => {
 		const session = createTestSession({
 			settings: createSettingsWithOverrides({ "astGrep.enabled": false }),

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -572,6 +572,10 @@ describe("IRC", () => {
 			expect(isIrcEnabled(settings, 0)).toBe(false);
 		});
 
+		it("isIrcEnabled returns false when top-level spawn policy denies peers", () => {
+			expect(isIrcEnabled(Settings.isolated(), 0, "")).toBe(false);
+		});
+
 		it("isIrcEnabled returns true while the task tool is available", () => {
 			const settings = Settings.isolated();
 			// Default task.maxRecursionDepth (2) at depth 0: task can spawn, and a

--- a/packages/coding-agent/test/tools/search-description-spawn-capability.test.ts
+++ b/packages/coding-agent/test/tools/search-description-spawn-capability.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { AstGrepTool } from "@oh-my-pi/pi-coding-agent/tools/ast-grep";
+import { GlobTool } from "@oh-my-pi/pi-coding-agent/tools/glob";
+import { GrepTool } from "@oh-my-pi/pi-coding-agent/tools/grep";
+
+function searchDescriptions(options: { spawns?: string; maxRecursionDepth: number; taskDepth?: number }): string[] {
+	const settings = Settings.isolated({ "task.maxRecursionDepth": options.maxRecursionDepth });
+	const session = {
+		cwd: process.cwd(),
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => options.spawns ?? "*",
+		settings,
+		taskDepth: options.taskDepth,
+	} as ToolSession;
+	return [new GlobTool(session).description, new GrepTool(session).description, new AstGrepTool(session).description];
+}
+
+describe("search tool spawn capability guidance", () => {
+	it("advertises task and scout when spawning is available", () => {
+		for (const description of searchDescriptions({ maxRecursionDepth: 1 })) {
+			expect(description).toContain("Task");
+			expect(description).toContain("scout");
+		}
+	});
+
+	it("omits impossible task guidance when recursion depth is exhausted", () => {
+		const descriptions = [
+			...searchDescriptions({ maxRecursionDepth: 0 }),
+			...searchDescriptions({ maxRecursionDepth: 1, taskDepth: 1 }),
+		];
+		for (const description of descriptions) {
+			expect(description).not.toContain("Task");
+			expect(description).not.toContain("scout");
+		}
+	});
+
+	it("omits impossible task guidance when spawn policy disables spawning", () => {
+		for (const description of searchDescriptions({ spawns: "", maxRecursionDepth: 1 })) {
+			expect(description).not.toContain("Task");
+			expect(description).not.toContain("scout");
+		}
+	});
+});


### PR DESCRIPTION
## What

Centralize subagent capability gating across spawn policy and recursion depth. When spawning is unavailable, `eval` no longer advertises `agent()`, search tools omit impossible Task/scout guidance, and `task` is hidden. A top-level session also hides `hub` when spawn policy leaves it with no possible peers.

The change adds regression coverage for exhausted depth, disabled spawn policy, task/hub exposure, and affected model-facing descriptions.

## Why

Runtime spawning could be rejected while tool descriptions still told the model to delegate. The advertised tool surface should match the capability that can actually run.

> Draft workflow: the contributor will add their own explanation, complete manual verification, and perform final review in the GitHub UI before marking this PR ready.

## Testing

- `bun run check` in `packages/coding-agent` — passed with Bun 1.3.14.
- Focused tool exposure, IRC, spawn-policy, eval, and search-description tests — 105 passed, 0 failed with Bun 1.3.14.
- GitHub Actions — all executed jobs passed.
- Manual changed-path result: to be completed by the contributor in the GitHub UI before this draft is marked ready.

---

- [ ] `bun check` passes
- [ ] Tested locally
- [x] CHANGELOG updated
