### PR TITLE
fix(tui): render platform-aware modifier labels on macOS

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed macOS key hints rendering the Linux/Windows modifier names `Alt` and `Super` across every hint surface (`/hotkeys`, status bar, autocomplete, pending-message bar, copy selector, ask dialog): `alt` now renders as `Option` and `super` as `Cmd` on darwin, and the static `/hotkeys` navigation rows are platform-aware instead of hardcoding macOS `Option`/`Cmd` names on every platform ([#8235](https://github.com/can1357/oh-my-pi/issues/8235)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -654,12 +654,52 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 
 /**
  * Key hint formatting utilities for UI labels.
+ *
+ * Modifier labels are platform-aware: macOS names the physical keys `Option`
+ * (`alt`) and `Cmd` (`super`), so rendering `Alt`/`Super` there would name keys
+ * absent from a Mac keyboard. Every other platform keeps `Alt`/`Super`.
  */
-const MODIFIER_LABELS: Record<string, string> = {
-	ctrl: "Ctrl",
-	shift: "Shift",
-	alt: "Alt",
-};
+
+/**
+ * Platform override for key-hint rendering; `undefined` resolves to the host
+ * `process.platform`. Mirrors `setKittyProtocolActive` in the TUI keys module:
+ * a single seam that keeps hint output deterministic in tests without mutating
+ * the global `process.platform`.
+ */
+let keyHintPlatformOverride: NodeJS.Platform | undefined;
+
+/** Pin the platform used to render modifier labels (test seam). */
+export function setKeyHintPlatform(platform: NodeJS.Platform | undefined): void {
+	keyHintPlatformOverride = platform;
+}
+
+/** Platform currently used for key-hint rendering. */
+export function keyHintPlatform(): NodeJS.Platform {
+	return keyHintPlatformOverride ?? process.platform;
+}
+
+type Modifier = "ctrl" | "shift" | "alt" | "super";
+
+function isModifier(part: string): part is Modifier {
+	return part === "ctrl" || part === "shift" || part === "alt" || part === "super";
+}
+
+/**
+ * Human label for a modifier, using each platform's own key names. `ctrl` and
+ * `shift` are the same everywhere; `alt`/`super` become `Option`/`Cmd` on macOS.
+ */
+export function modifierLabel(mod: Modifier, platform: NodeJS.Platform = keyHintPlatform()): string {
+	switch (mod) {
+		case "ctrl":
+			return "Ctrl";
+		case "shift":
+			return "Shift";
+		case "alt":
+			return platform === "darwin" ? "Option" : "Alt";
+		case "super":
+			return platform === "darwin" ? "Cmd" : "Super";
+	}
+}
 
 const KEY_LABELS: Record<string, string> = {
 	esc: "Esc",
@@ -680,10 +720,9 @@ const KEY_LABELS: Record<string, string> = {
 	right: "Right",
 };
 
-function formatKeyPart(part: string): string {
+function formatKeyPart(part: string, platform: NodeJS.Platform): string {
 	const lower = part.toLowerCase();
-	const modifier = MODIFIER_LABELS[lower];
-	if (modifier) return modifier;
+	if (isModifier(lower)) return modifierLabel(lower, platform);
 	const label = KEY_LABELS[lower];
 	if (label) return label;
 	if (part.length === 1) return part.toUpperCase();
@@ -691,7 +730,11 @@ function formatKeyPart(part: string): string {
 }
 
 export function formatKeyHint(key: KeyId): string {
-	return key.split("+").map(formatKeyPart).join("+");
+	const platform = keyHintPlatform();
+	return key
+		.split("+")
+		.map(part => formatKeyPart(part, platform))
+		.join("+");
 }
 
 export function formatKeyHints(keys: KeyId | KeyId[]): string {

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -1,4 +1,4 @@
-import type { AppKeybinding, KeybindingsManager } from "../../config/keybindings";
+import { type AppKeybinding, type KeybindingsManager, keyHintPlatform, modifierLabel } from "../../config/keybindings";
 
 export interface HotkeysMarkdownBindings {
 	keybindings: Pick<KeybindingsManager, "getDisplayString">;
@@ -9,21 +9,25 @@ function appKey(bindings: HotkeysMarkdownBindings, action: AppKeybinding): strin
 }
 
 export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string {
+	const platform = keyHintPlatform();
+	const isMac = platform === "darwin";
+	const alt = modifierLabel("alt", platform);
+	const cmd = modifierLabel("super", platform);
 	return [
 		"**Navigation**",
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Arrow keys` | Move cursor / browse history (Up when empty) |",
-		"| `Option+Left/Right` | Move by word |",
-		"| `Ctrl+A` / `Home` / `Cmd+Left` | Start of line |",
-		"| `Ctrl+E` / `End` / `Cmd+Right` | End of line |",
+		`| \`${alt}+Left/Right\` | Move by word |`,
+		isMac ? `| \`Ctrl+A\` / \`Home\` / \`${cmd}+Left\` | Start of line |` : "| `Ctrl+A` / `Home` | Start of line |",
+		isMac ? `| \`Ctrl+E\` / \`End\` / \`${cmd}+Right\` | End of line |` : "| `Ctrl+E` / `End` | End of line |",
 		"",
 		"**Editing**",
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Enter` | Send message |",
-		"| `Shift+Enter` / `Alt+Enter` | New line |",
-		"| `Ctrl+W` / `Option+Backspace` | Delete word backwards |",
+		`| \`Shift+Enter\` / \`${alt}+Enter\` | New line |`,
+		`| \`Ctrl+W\` / \`${alt}+Backspace\` | Delete word backwards |`,
 		"| `Ctrl+U` | Delete to start of line |",
 		"| `Ctrl+K` | Delete to end of line |",
 		`| \`${appKey(bindings, "app.clipboard.copyLine")}\` | Copy current line |`,

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { getDefaultPasteImageKeys, KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import {
+	getDefaultPasteImageKeys,
+	KeybindingsManager,
+	setKeyHintPlatform,
+} from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { keyText } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
 
 describe("KeybindingsManager.getDisplayString", () => {
+	beforeEach(() => setKeyHintPlatform("linux"));
+	afterEach(() => setKeyHintPlatform(undefined));
+
 	it("formats a single binding as a human-readable key hint", () => {
 		const keybindings = KeybindingsManager.inMemory({
 			"app.message.dequeue": "alt+up",
@@ -33,6 +40,28 @@ describe("KeybindingsManager.getDisplayString", () => {
 
 		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("");
 	});
+
+	it("renders macOS modifier labels for alt and super", () => {
+		setKeyHintPlatform("darwin");
+		const keybindings = KeybindingsManager.inMemory({
+			"app.display.reset": "alt+l",
+			"app.clipboard.pasteImage": ["ctrl+v", "super+v"],
+		});
+
+		expect(keybindings.getDisplayString("app.display.reset")).toBe("Option+L");
+		expect(keybindings.getDisplayString("app.clipboard.pasteImage")).toBe("Ctrl+V/Cmd+V");
+	});
+
+	it("keeps Alt and Super labels off macOS", () => {
+		setKeyHintPlatform("linux");
+		const keybindings = KeybindingsManager.inMemory({
+			"app.display.reset": "alt+l",
+			"app.clipboard.pasteImage": ["ctrl+v", "super+v"],
+		});
+
+		expect(keybindings.getDisplayString("app.display.reset")).toBe("Alt+L");
+		expect(keybindings.getDisplayString("app.clipboard.pasteImage")).toBe("Ctrl+V/Super+V");
+	});
 });
 
 describe("legacy keyText", () => {
@@ -40,10 +69,12 @@ describe("legacy keyText", () => {
 
 	beforeEach(() => {
 		previous = getKeybindings();
+		setKeyHintPlatform("linux");
 	});
 
 	afterEach(() => {
 		setKeybindings(previous);
+		setKeyHintPlatform(undefined);
 	});
 
 	it("formats the active binding for legacy extensions", () => {

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { setKeyHintPlatform } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { buildHotkeysMarkdown } from "@oh-my-pi/pi-coding-agent/modes/utils/hotkeys-markdown";
 
 describe("buildHotkeysMarkdown", () => {
+	afterEach(() => setKeyHintPlatform(undefined));
+
 	it("emits flush-left markdown and uses the configured temporary selector hint", () => {
 		const displayStrings: Record<string, string> = {
 			"app.clipboard.copyLine": "Alt+Shift+L",
@@ -74,5 +77,26 @@ describe("buildHotkeysMarkdown", () => {
 
 		expect(markdown).toContain("| `Disabled` | Select model (temporary) |");
 		expect(markdown).toContain("| `Alt+M` | Select model (set roles) |");
+	});
+
+	it("renders macOS static navigation rows on darwin", () => {
+		setKeyHintPlatform("darwin");
+		const markdown = buildHotkeysMarkdown({ keybindings: { getDisplayString: () => "Disabled" } });
+
+		expect(markdown).toContain("| `Option+Left/Right` | Move by word |");
+		expect(markdown).toContain("| `Ctrl+A` / `Home` / `Cmd+Left` | Start of line |");
+		expect(markdown).toContain("| `Ctrl+W` / `Option+Backspace` | Delete word backwards |");
+		expect(markdown).toContain("| `Shift+Enter` / `Option+Enter` | New line |");
+	});
+
+	it("drops Option/Cmd static navigation labels off darwin", () => {
+		setKeyHintPlatform("linux");
+		const markdown = buildHotkeysMarkdown({ keybindings: { getDisplayString: () => "Disabled" } });
+
+		expect(markdown).toContain("| `Alt+Left/Right` | Move by word |");
+		expect(markdown).toContain("| `Ctrl+A` / `Home` | Start of line |");
+		expect(markdown).toContain("| `Ctrl+W` / `Alt+Backspace` | Delete word backwards |");
+		expect(markdown).not.toContain("Option+");
+		expect(markdown).not.toContain("Cmd+");
 	});
 });

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { KeybindingsManager as AppKeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import {
+	KeybindingsManager as AppKeybindingsManager,
+	setKeyHintPlatform,
+} from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { createPromptActionAutocompleteProvider } from "@oh-my-pi/pi-coding-agent/modes/prompt-action-autocomplete";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui";
 
@@ -12,10 +15,12 @@ describe("prompt action autocomplete", () => {
 				"tui.editor.undo": { defaultKeys: "f8", description: "Undo" },
 			}),
 		);
+		setKeyHintPlatform("linux");
 	});
 
 	afterEach(() => {
 		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+		setKeyHintPlatform(undefined);
 	});
 
 	it("shows prompt actions with configured shortcut hints", async () => {

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
-import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { KeybindingsManager, setKeyHintPlatform } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { getThemeByName, initTheme, type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import {
 	dedupeParseErrors,
@@ -328,9 +328,11 @@ describe("formatExpandHint / expandKeyHint", () => {
 	let previous: TuiKeybindingsManager;
 	beforeEach(() => {
 		previous = getKeybindings();
+		setKeyHintPlatform("linux");
 	});
 	afterEach(() => {
 		setKeybindings(previous);
+		setKeyHintPlatform(undefined);
 	});
 
 	it("reports the default tool-output expand key", () => {


### PR DESCRIPTION
## Repro
On macOS, `/hotkeys` (and every other hint surface) rendered the Linux/Windows modifier names. Against the shipped `src` logic with the darwin-resolved defaults:

```
app.clipboard.pasteImage   => Ctrl+V/Super+V     (no 'Super' key on a Mac)
app.display.reset          => Alt+L              (should be Option)
app.model.select           => Alt+M
app.clipboard.copyPrompt   => Alt+Shift+C/Ctrl+Shift+C
formatKeyHints(["super+v"]) => Super+V
```

And the static `/hotkeys` rows were constant strings emitted identically on every platform, so Linux/Windows users saw macOS names:

```
| `Option+Left/Right` | Move by word |
| `Ctrl+A` / `Home` / `Cmd+Left` | Start of line |
| `Ctrl+W` / `Option+Backspace` | Delete word backwards |
```

Repro command: `bun -e` importing `KeybindingsManager`/`getDefaultPasteImageKeys`/`buildHotkeysMarkdown` from `src` and printing the display strings + static rows.

## Cause
`formatKeyPart` in `packages/coding-agent/src/config/keybindings.ts` looked modifier tokens up in a static, platform-agnostic `MODIFIER_LABELS` map that had **no `super` entry** and fixed `alt` to `Alt`. `super` fell through to the title-case fallback (`"Super"`), and darwin's shipped `getDefaultPasteImageKeys("darwin")` returns `["ctrl+v","super+v"]`, so the paste hint read `Ctrl+V/Super+V`. Every hint surface funnels through this via `getDisplayString` / `keybinding-hints.ts` / the legacy `keyText` shim. Separately, `packages/coding-agent/src/modes/utils/hotkeys-markdown.ts` hardcoded `Option+`/`Cmd+` navigation rows unconditionally, and the `cursorLineStart`/`cursorLineEnd` bindings (`["home","ctrl+a"]`/`["end","ctrl+e"]`) have no super binding, so those `Cmd+` fragments named a key with no binding on any platform.

## Fix
- `keybindings.ts`: replace the static `MODIFIER_LABELS` map with a platform-aware `modifierLabel(mod, platform)` — `alt`→`Option`, `super`→`Cmd` on darwin; `Alt`/`Super` elsewhere; `ctrl`/`shift` unchanged. `formatKeyPart` takes the resolved platform; only `alt`/`super` change, so `ctrl`/named-key labels are untouched.
- Add a single platform seam `setKeyHintPlatform`/`keyHintPlatform` (mirrors the TUI's `setKittyProtocolActive`) so `formatKeyHint`/`formatKeyHints` — and thus every downstream surface — resolve the platform through one place, keeping hint output deterministic in tests without mutating `process.platform`.
- `hotkeys-markdown.ts`: build the navigation rows from `modifierLabel`, and drop the macOS-only `Cmd+Left`/`Cmd+Right` line-start/end fragments off darwin (they map to no binding).
- Chose the platform-native **words** `Option`/`Cmd` (not glyphs `⌥`/`⌘`) to match the existing static-row convention and avoid East-Asian-ambiguous glyph-width misalignment in the status bar.
- Pin the platform via the seam in the label-asserting tests (`keybindings-display`, `prompt-action-autocomplete`, `render-utils`) so the suite stays host-independent.

## Verification
`bun test test/keybindings-display.test.ts test/prompt-action-autocomplete.test.ts test/tools/render-utils.test.ts test/modes/controllers/command-controller-hotkeys.test.ts` → 43 pass / 0 fail (includes new darwin/linux assertions for `getDisplayString` and the static `/hotkeys` rows). Manually confirmed via `bun -e`: darwin renders `Ctrl+V/Cmd+V`, `Option+L`, `Option+Shift+C/Ctrl+Shift+C` and Option/Cmd static rows; linux renders `Ctrl+V`, `Alt+L`, `Alt+Shift+C/Ctrl+Shift+C` and Alt-based rows with no `Cmd+`.

Fixes #8235