### PR TITLE
feat(tui): add message boundary keybindings

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable message-boundary editor actions, with Super+Up and Super+Down defaults for native macOS prompt navigation.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1472,6 +1472,12 @@ export class Editor implements Component, Focusable {
 		else if (kb.matchesCanonical(canonical, "tui.editor.deleteCharBackward") || matchesKey(data, "shift+backspace")) {
 			this.#handleBackspace();
 		}
+		// Message navigation shortcuts (Cmd+Up/Down on macOS terminals)
+		else if (kb.matchesCanonical(canonical, "tui.editor.cursorMessageStart")) {
+			this.#moveToMessageStart();
+		} else if (kb.matchesCanonical(canonical, "tui.editor.cursorMessageEnd")) {
+			this.#moveToMessageEnd();
+		}
 		// Line navigation shortcuts (Home/End keys)
 		else if (kb.matchesCanonical(canonical, "tui.editor.cursorLineStart")) {
 			this.#moveToLineStart();

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -14,6 +14,8 @@ export interface Keybindings {
 	"tui.editor.cursorWordRight": true;
 	"tui.editor.cursorLineStart": true;
 	"tui.editor.cursorLineEnd": true;
+	"tui.editor.cursorMessageStart": true;
+	"tui.editor.cursorMessageEnd": true;
 	"tui.editor.jumpForward": true;
 	"tui.editor.jumpBackward": true;
 	"tui.editor.pageUp": true;
@@ -80,6 +82,14 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.cursorLineEnd": {
 		defaultKeys: ["end", "ctrl+e"],
 		description: "Move to line end",
+	},
+	"tui.editor.cursorMessageStart": {
+		defaultKeys: "super+up",
+		description: "Move to message start",
+	},
+	"tui.editor.cursorMessageEnd": {
+		defaultKeys: "super+down",
+		description: "Move to message end",
 	},
 	"tui.editor.jumpForward": {
 		defaultKeys: "ctrl+]",

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -42,6 +42,19 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("Message boundary keybindings", () => {
+		it("moves to the whole message boundaries with Super+Up and Super+Down", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("first line\nsecond line\nthird");
+
+			editor.handleInput("\x1b[1;9A"); // Kitty Super+Up
+			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+
+			editor.handleInput("\x1b[1;9B"); // Kitty Super+Down
+			expect(editor.getCursor()).toEqual({ line: 2, col: 5 });
+		});
+	});
+
 	describe("Prompt history navigation", () => {
 		it("does nothing on Up arrow when history is empty", () => {
 			const editor = new Editor(defaultEditorTheme);


### PR DESCRIPTION
## Summary

- add configurable `tui.editor.cursorMessageStart` and `tui.editor.cursorMessageEnd` actions
- bind Super+Up and Super+Down by default for native macOS message-composer navigation
- route the actions through the editor's existing whole-message boundary operations

## Verification

- `bun run --cwd packages/tui check` — passed
- `bun test packages/tui/test/editor.test.ts packages/tui/test/keybindings.test.ts` — 165 passed
- `bun run --cwd packages/tui test` — 1,433 passed, 3 skipped

The full root `bun check` could not run its Rust leg because `cargo` is absent in this checkout environment; the affected TUI package's Biome and type checks passed.