### PR TITLE
feat(coding-agent): add skill catalog visibility control

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -105,6 +105,7 @@ Dedup key is skill name. First item with a given name wins.
 - `disabledExtensions` entries with `skill:<name>`
 - `ignoredSkills` (exclude; glob patterns)
 - `includeSkills` (include allowlist; glob patterns; empty means include all)
+- `hideSkills` (keep loaded but omit from the model-visible catalog; glob patterns)
 
 Filter order is:
 
@@ -112,6 +113,7 @@ Filter order is:
 2. source enabled
 3. not ignored
 4. included (if include list present)
+5. hidden from the model-visible catalog (if a `hideSkills` pattern matches)
 
 The `agents` provider (`.agent[s]/skills`) is the canonical OMP-native location and has its own `enableAgentsUser`/`enableAgentsProject` toggles — disabling Claude/Codex/Pi does **not** turn it off. Providers without a dedicated toggle (`claude-plugins`, `opencode`, `github`, …) are enabled if **any** named third-party source toggle is enabled.
 
@@ -135,7 +137,7 @@ System prompt construction (`src/system-prompt.ts`) uses discovered skills as fo
 - otherwise:
   - omit discovered list
 
-`hide: true` does not disable the skill. Hidden skills are still loaded and remain reachable through `skill://<name>` and `/skill:<name>` when skill commands are enabled.
+`hide: true` and configured `hideSkills` do not disable a skill. Hidden skills are still loaded and remain reachable through `skill://<name>` and `/skill:<name>` when skill commands are enabled.
 
 Task tool subagents receive the session's discovered/provided skills list via normal session creation; there is no per-task skill pinning override.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `skills.hideSkills` for keeping selected skills manually reachable without listing them in the model prompt.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4805,6 +4805,8 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.ignoredSkills": { type: "array", default: [] as string[] },
 
+	"skills.hideSkills": { type: "array", default: [] as string[] },
+
 	"skills.includeSkills": { type: "array", default: [] as string[] },
 
 	// Commands
@@ -5739,6 +5741,7 @@ export interface SkillsSettings {
 	enableAgentsProject?: boolean;
 	customDirectories?: string[];
 	ignoredSkills?: string[];
+	hideSkills?: string[];
 	includeSkills?: string[];
 	disabledExtensions?: string[];
 }

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -139,6 +139,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		enableAgentsProject = true,
 		customDirectories = [],
 		ignoredSkills = [],
+		hideSkills = [],
 		includeSkills = [],
 		disabledExtensions = [],
 	} = options;
@@ -392,6 +393,9 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	}
 
 	const skills = Array.from(skillMap.values());
+	for (const skill of skills) {
+		if (hideSkills.some(pattern => new Bun.Glob(pattern).match(skill.name))) skill.hide = true;
+	}
 	// Deterministic ordering for prompt stability (case-insensitive, then exact name, then path).
 	skills.sort((a, b) => compareSkillOrder(a.name, a.filePath, b.name, b.filePath));
 	return {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -374,6 +374,20 @@ describe("skills", () => {
 			expect(skills.every(s => !s.name.startsWith("valid-"))).toBe(true);
 		});
 
+		it("should keep hideSkills loaded but hide them from the model catalog", async () => {
+			const { skills } = await loadSkills({
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [fixturesDir],
+				hideSkills: ["valid-*"],
+			});
+			const hidden = skills.find(s => s.name === "valid-skill");
+			const visible = skills.find(s => s.name === "unknown-field");
+
+			expect(hidden).toBeDefined();
+			expect(hidden?.hide).toBe(true);
+			expect(visible?.hide).not.toBe(true);
+		});
+
 		it("should skip skills disabled via frontmatter", async () => {
 			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-disabled-skill-"));
 			const skillDir = path.join(tempDir, "disabled-skill");


### PR DESCRIPTION
## What

Add `skills.hideSkills`, a list of skill-name globs that hides matching skills from the model-visible catalog while keeping them loaded and available through `skill://` and `/skill:<name>`.

The default remains an empty list, preserving existing behavior.

## Why

I reviewed the skill discovery flow, and this change lets users keep selected skills manually available without exposing them to the model.

Today, `ignoredSkills` removes a skill entirely. There is no config-level equivalent of a skill's existing `hide: true` frontmatter for users who do not control an imported skill file. This reuses that established visibility behavior rather than adding another discovery mechanism.

The setting is also a deterministic, cache-stable manual complement to the broader semantic pre-selection discussed in #5964.

## Testing

- `bun --cwd=packages/coding-agent run check`
- `bun test test/skills.test.ts -t "hideSkills"`
- Runtime smoke test against the installed skill registry confirmed that `hideSkills: ["troubleshooting"]` leaves the skill loaded with `hide: true` and its original `SKILL.md` path.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
