### PR TITLE
fix(coding-agent): resolve --models/enabledModels scope against discovery-backed providers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--models`/`enabledModels` scopes matching only discovery-backed providers (models.yml `discovery:` endpoints, Ollama, proxies) silently collapsing to "unscoped" on startup: the `/model` hub, alt+p picker, and Ctrl+P cycle showed the full catalog, `omp models` ignored the allow-list, and a transiently empty first discovery pass left the session on "no model" without recovering. Scope resolution now retries after a discovery refresh, `omp models` applies the `enabledModels` allow-list, and a session that starts without a model re-resolves the configured default once discovery completes instead of surfacing a false "No model available matching enabledModels" warning.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -16,6 +16,7 @@ import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { ModelRegistry } from "../config/model-registry";
+import { filterAvailableModelsByEnabledPatterns } from "../config/model-resolver";
 import { Settings } from "../config/settings";
 import { discoverAndLoadExtensions, ExtensionRunner, emitSessionShutdownEvent } from "../extensibility/extensions";
 import { discoverAuthStorage } from "../sdk";
@@ -171,8 +172,14 @@ function renderProviderModels(
 	action: ModelsAction,
 	pattern: string | undefined,
 	json: boolean,
+	settings?: Settings,
 ): void {
-	const available = modelRegistry.getAvailable();
+	const allAvailable = modelRegistry.getAvailable();
+	const enabledModels = settings?.get("enabledModels");
+	const available =
+		enabledModels && enabledModels.length > 0
+			? filterAvailableModelsByEnabledPatterns(allAvailable, enabledModels, settings)
+			: allAvailable;
 	const needle = pattern?.toLowerCase();
 	let filtered = available;
 
@@ -280,6 +287,8 @@ export interface RunModelsListingOptions {
 	disabledExtensionIds?: string[];
 	/** When true, exclude ambient factories and resolve only `additionalExtensionPaths`. */
 	disableExtensionDiscovery?: boolean;
+	/** Effective settings used to apply the `enabledModels` allow-list. */
+	settings?: Settings;
 }
 
 export async function runModelsListing(options: RunModelsListingOptions): Promise<void> {
@@ -293,6 +302,7 @@ export async function runModelsListing(options: RunModelsListingOptions): Promis
 		settingsExtensions = [],
 		disabledExtensionIds = [],
 		disableExtensionDiscovery = false,
+		settings,
 	} = options;
 
 	const eventBus = new EventBus();
@@ -335,7 +345,7 @@ export async function runModelsListing(options: RunModelsListingOptions): Promis
 		// Discover runtime (extension) provider catalogs now that they are registered.
 		await modelRegistry.refreshRuntimeProviders(action === "refresh" ? "online" : "online-if-uncached");
 
-		renderProviderModels(modelRegistry, action, pattern, json);
+		renderProviderModels(modelRegistry, action, pattern, json, settings);
 	} finally {
 		await emitSessionShutdownEvent(extensionRunner);
 	}
@@ -377,6 +387,7 @@ export async function runModelsCommand(command: ModelsCommandArgs): Promise<void
 			additionalExtensionPaths: cliExtensionPaths,
 			settingsExtensions: settings.get("extensions") ?? [],
 			disabledExtensionIds: settings.get("disabledExtensions") ?? [],
+			settings,
 			disableExtensionDiscovery: Boolean(command.flags.noExtensions),
 		});
 	} finally {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -691,16 +691,33 @@ async function switchToResumedProject(
  * failing that, the active project's `enabledModels`. Re-run after a resume
  * switches projects so the destination project's settings-derived scope wins
  * over the launch directory's.
+ *
+ * Startup calls this before `createSession` kicks off the background discovery
+ * refresh, so patterns that only match discovery-backed providers (proxies,
+ * Ollama, ...) would resolve against an empty registry and silently collapse
+ * to "unscoped" — the /model hub, alt+p picker, and Ctrl+P cycle then fall
+ * back to the full catalog. Mirror the initial-model discovery fallback:
+ * refresh once (cache-guided), then retry the same patterns.
  */
-async function resolveScopedModels(
+export async function resolveScopedModels(
 	parsed: Args,
-	modelRegistry: ModelRegistry,
+	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getDiscoverableProviders" | "refresh">,
 	activeSettings: Settings,
 ): Promise<ScopedModel[]> {
 	const modelPatterns = parsed.models ?? activeSettings.get("enabledModels");
 	if (!modelPatterns || modelPatterns.length === 0) {
 		return [];
 	}
+	const scopedModels = await resolveModelScope(
+		modelPatterns,
+		modelRegistry,
+		getModelMatchPreferences(activeSettings),
+		activeSettings,
+	);
+	if (scopedModels.length > 0 || modelRegistry.getDiscoverableProviders().length === 0) {
+		return scopedModels;
+	}
+	await logger.time("resolveModelScopeDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
 	return await resolveModelScope(
 		modelPatterns,
 		modelRegistry,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -58,6 +58,7 @@ import {
 	resolveCliModel,
 	resolveConfiguredModelPatterns,
 	resolveModelRoleValue,
+	resolveModelScope,
 } from "./config/model-resolver";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { applyProviderGlobalsFromSettings } from "./config/provider-globals";
@@ -2461,7 +2462,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					modelRegistry.getDiscoverableProviders().length > 0
 				) {
 					await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
-					if (!(await tryResolveDefaultRole()) && !model) {
+					const defaultRoleResolved = await tryResolveDefaultRole();
+					if (!defaultRoleResolved && !model) {
 						const refreshedCandidates = await resolveAllowedModels(
 							modelRegistry,
 							settings,
@@ -3757,6 +3759,56 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				unsubscribeMcpNotifications?.(),
 			);
 		}
+		let lateModelRecoveryScheduled = false;
+		const configuredProviderIds = new Set<string>();
+		for (const selector of [settings.getModelRole("default"), ...(settings.get("enabledModels") ?? [])]) {
+			for (const pattern of resolveConfiguredModelPatterns(selector, settings)) {
+				const slashIndex = pattern.indexOf("/");
+				if (slashIndex > 0) configuredProviderIds.add(pattern.slice(0, slashIndex));
+			}
+		}
+		const lateModelRecoveryProviders = modelRegistry
+			.getDiscoverableProviders()
+			.filter(provider => configuredProviderIds.has(provider));
+		if (!session.model && !hasExplicitModel && lateModelRecoveryProviders.length > 0) {
+			lateModelRecoveryScheduled = true;
+			const configuredPatterns = settings.get("enabledModels");
+			const defaultRole = settings.getModelRole("default");
+			const defaultThinkingLevel = defaultRoleSpec.thinkingLevel;
+			void (async () => {
+				await Bun.sleep(0);
+				await modelRegistry.refresh("online");
+				if (session.model) return;
+				const matchPreferences = getModelMatchPreferences(settings);
+				let candidate = resolveModelRoleValue(defaultRole, modelRegistry.getAvailable(), {
+					settings,
+					matchPreferences,
+				}).model;
+				if (!candidate) {
+					const allowed = await resolveAllowedModels(modelRegistry, settings, matchPreferences);
+					candidate = pickDefaultAvailableModel(allowed.filter(hasModelAuth));
+				}
+				if (!candidate || session.model) return;
+				if (configuredPatterns && configuredPatterns.length > 0) {
+					const scoped = await resolveModelScope(configuredPatterns, modelRegistry, matchPreferences, settings);
+					session.setScopedModels(
+						scoped.map(entry => ({ model: entry.model, thinkingLevel: entry.thinkingLevel })),
+					);
+				}
+				await session.setModel(candidate, "default", {
+					thinkingLevel: defaultThinkingLevel === AUTO_THINKING ? undefined : defaultThinkingLevel,
+				});
+				session.emitNotice(
+					"info",
+					`Model discovery completed; selected ${candidate.provider}/${candidate.id}.`,
+					"models",
+				);
+			})().catch(error => {
+				logger.warn("late startup model discovery failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		}
 
 		startDeferredMCPDiscovery?.(session);
 
@@ -3765,7 +3817,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			extensionsResult,
 			setToolUIContext,
 			mcpManager,
-			modelFallbackMessage,
+			modelFallbackMessage: lateModelRecoveryScheduled ? undefined : modelFallbackMessage,
 			lspServers,
 			eventBus,
 		};

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4589,6 +4589,11 @@ export class AgentSession {
 		return this.#models.scopedModels;
 	}
 
+	/** Replace the session's cycle scope after late model discovery. */
+	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
+		this.#models.setScopedModels(scopedModels);
+	}
+
 	/** Prompt templates */
 	getPlanModeState(): PlanModeState | undefined {
 		return this.#planModeState;

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -138,6 +138,11 @@ export class ModelControls {
 		return this.#scopedModels;
 	}
 
+	/** Replace the session's cycle scope after late model discovery. */
+	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
+		this.#scopedModels = scopedModels;
+	}
+
 	/** Live per-provider-family service-tier selection. */
 	get serviceTierByFamily(): ServiceTierByFamily {
 		return this.#serviceTierByFamily;

--- a/packages/coding-agent/test/issue-905-repro.test.ts
+++ b/packages/coding-agent/test/issue-905-repro.test.ts
@@ -17,6 +17,7 @@ import * as fs from "node:fs/promises";
 import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { runModelsListing } from "@oh-my-pi/pi-coding-agent/cli/models-cli";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 let tmp: TempDir;
@@ -148,6 +149,62 @@ test("omp models surfaces extension-registered providers (issue #905)", async ()
 	}
 });
 
+test("omp models applies enabledModels to the listed catalog", async () => {
+	const authStorage = await AuthStorage.create(":memory:");
+	try {
+		const modelRegistry = new ModelRegistry(authStorage);
+		modelRegistry.registerProvider("scoped-gw", {
+			baseUrl: "https://scoped.example.com/v1",
+			apiKey: "literal-test-key",
+			api: "openai-completions",
+			models: [
+				{
+					id: "gpt-allowed",
+					name: "GPT Allowed",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128_000,
+					maxTokens: 4_096,
+				},
+				{
+					id: "claude-hidden",
+					name: "Claude Hidden",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128_000,
+					maxTokens: 4_096,
+				},
+			],
+		});
+		const settings = Settings.isolated({ enabledModels: ["scoped-gw/gpt-*"] });
+		const captured: string[] = [];
+		const originalWrite = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stdout.write;
+
+		try {
+			await runModelsListing({
+				modelRegistry,
+				cwd: tmp.path(),
+				action: "ls",
+				settings,
+				disableExtensionDiscovery: true,
+			});
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+
+		const output = captured.join("");
+		expect(output).toContain("gpt-allowed");
+		expect(output).not.toContain("claude-hidden");
+	} finally {
+		authStorage.close();
+	}
+});
 test("omp models emits extension shutdown after listing (issue #6297)", async () => {
 	const authStorage = await AuthStorage.create(":memory:");
 	try {

--- a/packages/coding-agent/test/main-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-project-resume.test.ts
@@ -219,10 +219,11 @@ describe("runRootCommand — cross-project --resume", () => {
 			await resumedManager?.close();
 		}
 
-		// Launch scope had no patterns, so the only resolution is the post-switch
-		// one; the pre-fix code never recomputed and would not call it at all.
-		expect(resolveModelScope).toHaveBeenCalledTimes(1);
-		expect(resolveModelScope.mock.calls[0]?.[0]).toEqual(["model-resumed"]);
+		// Launch scope had no patterns, so every resolution is post-switch and must
+		// use the destination settings. The empty first result triggers the
+		// discovery-backed scope retry before session options are built.
+		expect(resolveModelScope).toHaveBeenCalledTimes(2);
+		expect(resolveModelScope.mock.calls.map(call => call[0])).toEqual([["model-resumed"], ["model-resumed"]]);
 	}, 15_000);
 });
 

--- a/packages/coding-agent/test/main-resolve-scoped-models.test.ts
+++ b/packages/coding-agent/test/main-resolve-scoped-models.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import type { ScopedModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveScopedModels } from "@oh-my-pi/pi-coding-agent/main";
+
+type ScopeRegistry = Pick<ModelRegistry, "getAvailable" | "getDiscoverableProviders" | "refresh">;
+
+function makeModel(provider: string, id: string): Model<Api> {
+	return buildModel({
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: "https://proxy.example/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	});
+}
+
+/**
+ * Registry double for the startup ordering: `before` is what `getAvailable()`
+ * serves prior to any refresh (discovery-backed providers are absent), `after`
+ * replaces it once `refresh()` runs — mirroring the background discovery
+ * populating the catalog.
+ */
+function fakeRegistry(options: {
+	before?: Model<Api>[];
+	after?: Model<Api>[];
+	discoverable?: string[];
+}): ScopeRegistry & { refreshCalls: string[] } {
+	let models = options.before ?? [];
+	const refreshCalls: string[] = [];
+	return {
+		refreshCalls,
+		getAvailable: () => models,
+		getDiscoverableProviders: () => options.discoverable ?? [],
+		refresh: async (strategy = "online-if-uncached") => {
+			refreshCalls.push(strategy);
+			models = options.after ?? models;
+		},
+	};
+}
+
+const gpt = makeModel("cliproxy", "gpt-5.5");
+const claudeOnGptProvider = makeModel("cliproxy", "claude-opus-4-8");
+const claude = makeModel("cliproxy-claude", "claude-fable-5");
+
+function scopedIds(scoped: ScopedModel[]): string[] {
+	return scoped.map(entry => `${entry.model.provider}/${entry.model.id}`);
+}
+
+describe("resolveScopedModels", () => {
+	it("retries via a discovery refresh when the scope only matches discovery-backed providers", async () => {
+		const registry = fakeRegistry({
+			before: [],
+			after: [gpt, claudeOnGptProvider, claude],
+			discoverable: ["cliproxy", "cliproxy-claude"],
+		});
+		const settings = Settings.isolated({ enabledModels: ["cliproxy/gpt-*", "cliproxy-claude/claude-*"] });
+
+		const scoped = await resolveScopedModels(parseArgs([]), registry, settings);
+
+		expect(registry.refreshCalls).toEqual(["online-if-uncached"]);
+		expect(scopedIds(scoped).sort()).toEqual(["cliproxy-claude/claude-fable-5", "cliproxy/gpt-5.5"]);
+	});
+
+	it("does not refresh when the scope resolves against the startup catalog", async () => {
+		const registry = fakeRegistry({
+			before: [gpt, claude],
+			discoverable: ["cliproxy"],
+		});
+		const settings = Settings.isolated({ enabledModels: ["cliproxy/gpt-*"] });
+
+		const scoped = await resolveScopedModels(parseArgs([]), registry, settings);
+
+		expect(registry.refreshCalls).toEqual([]);
+		expect(scopedIds(scoped)).toEqual(["cliproxy/gpt-5.5"]);
+	});
+
+	it("does not refresh when no discoverable providers exist", async () => {
+		const registry = fakeRegistry({ before: [], discoverable: [] });
+		const settings = Settings.isolated({ enabledModels: ["cliproxy/gpt-*"] });
+
+		const scoped = await resolveScopedModels(parseArgs([]), registry, settings);
+
+		expect(registry.refreshCalls).toEqual([]);
+		expect(scoped).toEqual([]);
+	});
+
+	it("refreshes exactly once when the patterns never match", async () => {
+		const registry = fakeRegistry({
+			before: [],
+			after: [claude],
+			discoverable: ["cliproxy-claude"],
+		});
+		const settings = Settings.isolated({ enabledModels: ["typo-provider/nope-*"] });
+
+		const scoped = await resolveScopedModels(parseArgs([]), registry, settings);
+
+		expect(registry.refreshCalls).toEqual(["online-if-uncached"]);
+		expect(scoped).toEqual([]);
+	});
+
+	it("prefers an explicit --models scope over enabledModels", async () => {
+		const registry = fakeRegistry({ before: [gpt, claudeOnGptProvider, claude] });
+		const settings = Settings.isolated({ enabledModels: ["cliproxy-claude/claude-*"] });
+
+		const scoped = await resolveScopedModels(parseArgs(["--models", "cliproxy/gpt-*"]), registry, settings);
+
+		expect(scopedIds(scoped)).toEqual(["cliproxy/gpt-5.5"]);
+	});
+
+	it("returns an empty scope without touching the registry when nothing is configured", async () => {
+		const registry = fakeRegistry({ before: [gpt] });
+		const settings = Settings.isolated({});
+
+		const scoped = await resolveScopedModels(parseArgs([]), registry, settings);
+
+		expect(registry.refreshCalls).toEqual([]);
+		expect(scoped).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/sdk-default-role-discovery-config-provider.test.ts
+++ b/packages/coding-agent/test/sdk-default-role-discovery-config-provider.test.ts
@@ -25,15 +25,18 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { Snowflake } from "@oh-my-pi/pi-utils";
+import { getConfigRootDir, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
 
 describe("issue #6162 fresh launch default role from models.yml discovery provider", () => {
 	let tempDir: string;
 	const authStoragesToClose: AuthStorage[] = [];
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 	beforeEach(() => {
 		tempDir = path.join(os.tmpdir(), `pi-sdk-default-role-config-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
+		setAgentDir(tempDir);
 	});
 
 	afterEach(() => {
@@ -41,6 +44,8 @@ describe("issue #6162 fresh launch default role from models.yml discovery provid
 			authStorage.close();
 		}
 		authStoragesToClose.length = 0;
+		if (originalAgentDir !== undefined) setAgentDir(originalAgentDir);
+		else setAgentDir(fallbackAgentDir);
 		if (tempDir && fs.existsSync(tempDir)) {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -112,6 +117,123 @@ describe("issue #6162 fresh launch default role from models.yml discovery provid
 		try {
 			expect(session.model?.provider).toBe("my-provider");
 			expect(session.model?.id).toBe("some-model");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("selects an allowed discovery default without a false enabledModels warning", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		fs.writeFileSync(
+			modelsPath,
+			[
+				"providers:",
+				"  my-provider:",
+				`    baseUrl: ${baseUrl}`,
+				"    api: openai-completions",
+				"    apiKey: MY_API_KEY",
+				"    discovery:",
+				"      type: openai-models-list",
+				"",
+			].join("\n"),
+		);
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey("my-provider", "test-provider-key");
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath, {
+			fetch: mockDiscovery(["some-model"]),
+		});
+		const settings = Settings.isolated({ enabledModels: ["my-provider/*"] });
+		settings.setModelRole("default", "my-provider/some-model");
+
+		const { session, modelFallbackMessage } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("my-provider");
+			expect(session.model?.id).toBe("some-model");
+			expect(modelFallbackMessage).toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("late discovery selects the configured default when the first pass is empty", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		fs.writeFileSync(
+			modelsPath,
+			[
+				"providers:",
+				"  my-provider:",
+				`    baseUrl: ${baseUrl}`,
+				"    api: openai-completions",
+				"    apiKey: MY_API_KEY",
+				"    discovery:",
+				"      type: openai-models-list",
+				"",
+			].join("\n"),
+		);
+
+		let discoveryCalls = 0;
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey("my-provider", "test-provider-key");
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath, {
+			fetch: async input => {
+				if (String(input) !== `${baseUrl}/models`) return new Response("not found", { status: 404 });
+				discoveryCalls += 1;
+				return Response.json({ data: discoveryCalls === 1 ? [] : [{ id: "some-model" }] });
+			},
+		});
+		const settings = Settings.isolated({ enabledModels: ["my-provider/*"] });
+		settings.setModelRole("default", "my-provider/some-model");
+
+		const { session, modelFallbackMessage } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		expect(modelFallbackMessage).toBeUndefined();
+
+		try {
+			if (!session.model) {
+				await new Promise<void>(resolve => {
+					const unsubscribe = session.subscribe(event => {
+						if (event.type !== "model_changed") return;
+						unsubscribe();
+						resolve();
+					});
+				});
+			}
+			expect(session.model?.provider).toBe("my-provider");
+			expect(session.model?.id).toBe("some-model");
+			expect(session.scopedModels.map(entry => entry.model.id)).toEqual(["some-model"]);
 		} finally {
 			await session.dispose();
 		}


### PR DESCRIPTION
## What

- `resolveScopedModels` (main.ts) retries scope resolution once after a cache-guided discovery refresh when the configured `--models`/`enabledModels` patterns resolve to zero models and discoverable providers exist — mirroring the SDK's existing `resolveModelDiscoveryFallback` pattern.
- `omp models` now applies the `enabledModels` allow-list (effective `Settings` passed into `runModelsListing`).
- `createAgentSession` schedules a late recovery when startup ends with no model, no explicit `--model`, and the configured default/`enabledModels` reference a discovery-backed provider: after an online refresh it re-resolves the default role, updates the session's scoped models (`AgentSession.setScopedModels`), selects the model, and emits a notice. The stale "No model available matching enabledModels … " warning is suppressed while that recovery is pending.

## Why

For providers whose models only materialize through discovery (models.yml `discovery:` endpoints, Ollama, proxies), startup resolved the scope against a not-yet-refreshed registry (`resolveScopedModels` runs before `createSession` kicks off `refreshInBackground`). The scope silently collapsed to "unscoped": the `/model` hub, alt+p picker, and Ctrl+P cycle showed the full catalog, `omp models` ignored the allow-list, and a transiently empty first discovery response stranded the session on "no model" with a misleading credentials warning.

I hit this using a CLIProxyAPI-backed models.yml provider: enabledModels had no effect on /model or omp models. While testing the fix we also found a cold-startup race where an empty first discovery pass left the session with no model and it never picked my default, so that's handled too. I reviewed the diff and tested the patched build against my setup — the scope now applies everywhere and the default is selected once discovery completes.

## Testing

- Reproduced against a real openai-models-list discovery provider (CLIProxyAPI on `127.0.0.1:8317`) with `enabledModels: ["cliproxy/gpt-*", "cliproxy-claude/claude-*"]`:
  - pre-fix: `/model` hub showed all 48 catalog models and no scope marker; `omp models` listed all 48; a cold start printed "No model available matching enabledModels (…) with usable credentials" and stayed on no-model.
  - post-fix: `/model` shows `All models 23 · --models scope` (cliproxy 8 gpt-*, cliproxy-claude 15 claude-*); `omp models --json` returns the same 23; a cold start with an empty first discovery pass selects `cliproxy/gpt-5.6-luna` once discovery completes and emits a "Model discovery completed" notice with no false warning.
- New/updated tests (all passing, 173 across the focused model suites):
  - `test/main-resolve-scoped-models.test.ts` — discovery retry fires only on total scope collapse with discoverable providers; no refresh for static scopes, missing discoverables, or empty config; `--models` precedence.
  - `test/sdk-default-role-discovery-config-provider.test.ts` — allow-listed discovery default resolves without a false warning; late recovery selects the configured default and scope after an empty first discovery pass.
  - `test/issue-905-repro.test.ts` — `omp models` applies `enabledModels`.
  - `test/main-cross-project-resume.test.ts` — updated call-count expectation for the post-switch retry.
- `bun check` (biome + tsgo) passes in `packages/coding-agent`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
