### PR TITLE
fix(ai): synthesize reasoning_text on DeepSeek Responses replay after prewalk/compaction

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DeepSeek Responses targets (opencode-go) rejecting a thinking-mode continuation with `400 The reasoning_text in the thinking mode must be passed back to the API` after a prewalk hand-off plus mid-run compaction: the Responses input builder re-encoded replayed assistant turns without a reasoning item, so the request enabled reasoning but shipped no `reasoning_text`. The encoder now synthesizes a `reasoning_text` reasoning item for every replayed assistant turn when the target requires reasoning replay in thinking mode (`requiresReasoningContentForAllAssistantTurns` / `requiresReasoningContentForToolCalls`), mirroring the chat-completions `reasoning_content` safety net ([#8248](https://github.com/can1357/oh-my-pi/issues/8248)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1113,6 +1113,10 @@ export function buildParams(
 			filterReasoning: policy.reasoning.filterReasoningHistory,
 		},
 		includeThinkingSignatures: shouldReplayNativeHistory && !policy.reasoning.filterReasoningHistory,
+		requiresReasoningReplayForAllTurns:
+			policy.reasoning.enabled && policy.reasoning.requiresReasoningContentForAllAssistantTurns,
+		requiresReasoningReplayForToolCalls:
+			policy.reasoning.enabled && policy.reasoning.requiresReasoningContentForToolCalls,
 		repairOrphanOutputs: true,
 	});
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1635,6 +1635,14 @@ export interface BuildResponsesInputOptions<TApi extends Api> {
 	repairOrphanOutputs?: boolean;
 	/** Preserve assistant message item IDs from text signatures during fallback replay. */
 	preserveAssistantMessageIds?: boolean;
+	/**
+	 * Synthesize a reasoning item for every replayed assistant turn that carries
+	 * content but no reasoning item. Set for DeepSeek-family Responses targets
+	 * that reject a thinking-mode continuation lacking `reasoning_text`.
+	 */
+	requiresReasoningReplayForAllTurns?: boolean;
+	/** As {@link requiresReasoningReplayForAllTurns}, but only for turns that contain a tool call. */
+	requiresReasoningReplayForToolCalls?: boolean;
 }
 
 /**
@@ -1861,6 +1869,8 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 				supportsCustomToolCalls,
 				customToolWireNameMap,
 				computerCallIds,
+				options.requiresReasoningReplayForAllTurns ?? false,
+				options.requiresReasoningReplayForToolCalls ?? false,
 			);
 			const outputItems = suppressHiddenEmptyFallback
 				? sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(convertedOutputItems)
@@ -1914,6 +1924,8 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 	supportsCustomToolCalls = true,
 	customToolWireNameMap?: ReadonlyMap<string, string>,
 	computerCallIds?: Set<string>,
+	requiresReasoningReplayForAllTurns = false,
+	requiresReasoningReplayForToolCalls = false,
 ): ResponseInput {
 	const outputItems: ResponseInput = [];
 	let unsignedTextBlocks = 0;
@@ -1925,14 +1937,36 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 		);
 	const isDifferentModel =
 		assistantMsg.model !== model.id && assistantMsg.provider === model.provider && assistantMsg.api === model.api;
+	// DeepSeek-family Responses targets (e.g. opencode-go) reject a thinking-mode
+	// continuation whose replayed assistant turns carry no reasoning item: "The
+	// reasoning_text in the thinking mode must be passed back to the API." After a
+	// cross-model prewalk hand-off or a compaction that drops the native replay
+	// payload, the block re-encode below demotes reasoning to text and emits no
+	// reasoning item. Track reasoning emission so a placeholder can be synthesized,
+	// mirroring the chat-completions `requiresReasoningContentForAllAssistantTurns`
+	// empty-`reasoning_content` safety net.
+	const requiresReasoningItem =
+		assistantMsg.stopReason !== "error" &&
+		(requiresReasoningReplayForAllTurns ||
+			(requiresReasoningReplayForToolCalls && assistantMsg.content.some(block => block.type === "toolCall")));
+	let reasoningItemEmitted = false;
+	const carriedReasoningTexts: string[] = [];
+	let synthesizedReasoningItemId: string | undefined;
 
 	for (const block of assistantMsg.content) {
 		if (block.type === "thinking" && assistantMsg.stopReason !== "error") {
+			if (requiresReasoningItem) {
+				if (block.itemId) synthesizedReasoningItemId ??= block.itemId;
+				if (block.thinking.trim().length > 0) carriedReasoningTexts.push(block.thinking);
+			}
 			if (!includeThinkingSignatures) {
 				continue;
 			}
 			const reasoningItem = parseResponseReasoningReplayItem(block.thinkingSignature);
-			if (reasoningItem) outputItems.push(reasoningItem);
+			if (reasoningItem) {
+				outputItems.push(reasoningItem);
+				reasoningItemEmitted = true;
+			}
 			continue;
 		}
 
@@ -2031,6 +2065,26 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 			name: functionName,
 			arguments: stringifyJson(block.arguments) ?? "null",
 		});
+	}
+
+	if (requiresReasoningItem && !reasoningItemEmitted && outputItems.length > 0) {
+		// Replay the demoted reasoning (already present in `content` as visible
+		// text) as a structured reasoning item so the thinking-mode continuation
+		// carries the `reasoning_text` the provider requires. The text may be empty
+		// when the source turn was minted by another model and its reasoning is
+		// already folded into the message text; the item's presence is what
+		// satisfies the provider contract, mirroring the empty `reasoning_content`
+		// placeholder used on the chat-completions path.
+		const reasoningText = carriedReasoningTexts.join("\n");
+		const reasoningId =
+			synthesizedReasoningItemId ?? `rs_${Bun.hash(`${model.id}:${msgIndex}:${reasoningText}`).toString(36)}`;
+		const reasoningItem: ResponseReasoningItem = {
+			type: "reasoning",
+			id: reasoningId,
+			summary: [],
+			content: [{ type: "reasoning_text", text: reasoningText }],
+		};
+		outputItems.unshift(reasoningItem);
 	}
 
 	return outputItems;

--- a/packages/ai/test/issue-8248-repro.test.ts
+++ b/packages/ai/test/issue-8248-repro.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+// Issue #8248: with prewalk enabled, OMP switches into a DeepSeek Responses
+// target (opencode-go) after mid-run compaction. The replayed assistant turns
+// were minted by the previous model, so the Responses input builder re-encodes
+// them and demotes their reasoning to plain text, emitting no reasoning item.
+// DeepSeek then rejects the thinking-mode continuation:
+//   400 The reasoning_text in the thinking mode must be passed back to the API.
+// The encoder must synthesize a reasoning item carrying `reasoning_text` for
+// each replayed assistant turn when the target requires it in thinking mode.
+
+interface ReasoningTextPart {
+	type: string;
+	text: string;
+}
+
+interface ResponsesInputItem {
+	type?: string;
+	role?: string;
+	content?: unknown;
+}
+
+interface ResponsesPayload {
+	reasoning?: { effort?: string };
+	input?: ResponsesInputItem[];
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function capture(
+	model: Model<"openai-responses">,
+	context: Context,
+	overrides: { reasoning?: Effort; disableReasoning?: boolean } = {},
+): Promise<ResponsesPayload> {
+	const { promise, resolve } = Promise.withResolvers<ResponsesPayload>();
+	streamOpenAIResponses(model, context, {
+		apiKey: "sk-test",
+		reasoning: "reasoning" in overrides ? overrides.reasoning : Effort.XHigh,
+		disableReasoning: overrides.disableReasoning,
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload as ResponsesPayload),
+	});
+	return promise;
+}
+
+function reasoningItems(payload: ResponsesPayload): ResponsesInputItem[] {
+	return (payload.input ?? []).filter(item => item.type === "reasoning");
+}
+
+function reasoningTextOf(item: ResponsesInputItem): string {
+	const content = Array.isArray(item.content) ? (item.content as ReasoningTextPart[]) : [];
+	return content
+		.filter(part => part.type === "reasoning_text")
+		.map(part => part.text)
+		.join("");
+}
+
+const deepseek = getBundledModel("opencode-go", "deepseek-v4-flash") as Model<"openai-responses">;
+
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+describe("issue #8248: DeepSeek Responses reasoning replay after prewalk/compaction", () => {
+	it("targets a reasoning Responses model that requires reasoning replay", () => {
+		expect(deepseek.api).toBe("openai-responses");
+		expect(deepseek.compat.requiresReasoningContentForAllAssistantTurns).toBe(true);
+	});
+
+	it("synthesizes a reasoning item for a foreign assistant turn replayed after a prewalk switch", async () => {
+		// Kept-tail turn minted by the previous model (prewalk hopped gpt-5.6-sol
+		// -> deepseek). Same api, different provider+model -> block re-encode.
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "github-copilot",
+			model: "gpt-5.6-sol",
+			stopReason: "stop",
+			usage,
+			content: [
+				{
+					type: "thinking",
+					thinking: "Refactor plan for foo.",
+					thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_prev" }),
+				},
+				{ type: "text", text: "Refactored bar.ts." },
+			],
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Refactor foo", timestamp: Date.now() },
+				prior,
+				{ role: "user", content: "Now update the tests", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capture(deepseek, context);
+		expect(payload.reasoning?.effort).toBeDefined();
+
+		const input = payload.input ?? [];
+		const reasoning = reasoningItems(payload);
+		expect(reasoning).toHaveLength(1);
+		// The reasoning item must precede the assistant message it belongs to.
+		const reasoningIdx = input.findIndex(item => item.type === "reasoning");
+		const assistantIdx = input.findIndex(item => item.type === "message" && item.role === "assistant");
+		expect(reasoningIdx).toBeGreaterThanOrEqual(0);
+		expect(reasoningIdx).toBeLessThan(assistantIdx);
+		// It carries a reasoning_text content part (the field DeepSeek requires).
+		const content = Array.isArray(reasoning[0]!.content) ? (reasoning[0]!.content as ReasoningTextPart[]) : [];
+		expect(content.some(part => part.type === "reasoning_text")).toBe(true);
+	});
+
+	it("carries the actual reasoning text when a same-model thinking block survives replay", async () => {
+		// Same provider/model (deepseek) but no native providerPayload (dropped by
+		// compaction). The thinking block survives transform with no native
+		// Responses signature, so its text must ride in the synthesized item.
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "opencode-go",
+			model: "deepseek-v4-flash",
+			stopReason: "stop",
+			usage,
+			content: [
+				{ type: "thinking", thinking: "Inspect bar.ts before editing." },
+				{ type: "text", text: "Edited bar.ts." },
+			],
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Edit bar", timestamp: Date.now() },
+				prior,
+				{ role: "user", content: "Run the tests", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capture(deepseek, context);
+		const reasoning = reasoningItems(payload);
+		expect(reasoning).toHaveLength(1);
+		expect(reasoningTextOf(reasoning[0]!)).toBe("Inspect bar.ts before editing.");
+	});
+
+	it("does not synthesize a reasoning item when reasoning is disabled for the turn", async () => {
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "github-copilot",
+			model: "gpt-5.6-sol",
+			stopReason: "stop",
+			usage,
+			content: [
+				{
+					type: "thinking",
+					thinking: "Refactor plan for foo.",
+					thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_prev" }),
+				},
+				{ type: "text", text: "Refactored bar.ts." },
+			],
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Refactor foo", timestamp: Date.now() },
+				prior,
+				{ role: "user", content: "Now update the tests", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capture(deepseek, context, { reasoning: undefined, disableReasoning: true });
+		expect(reasoningItems(payload)).toHaveLength(0);
+	});
+
+	it("does not synthesize reasoning items for non-DeepSeek Responses targets", async () => {
+		const openai = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+		expect(openai.compat.requiresReasoningContentForAllAssistantTurns).toBe(false);
+
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage,
+			content: [
+				{ type: "thinking", thinking: "Cross-provider reasoning." },
+				{ type: "text", text: "Answer." },
+			],
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Question", timestamp: Date.now() },
+				prior,
+				{ role: "user", content: "Follow up", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capture(openai, context);
+		expect(reasoningItems(payload)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Repro
With prewalk enabled, OMP hands off to a DeepSeek Responses target (`opencode-go/deepseek-v4-flash`, `api: openai-responses`, `reasoning: true`) at the first edit, then compacts mid-run. The kept-tail assistant turns were minted by the previous model (e.g. `gpt-5.6-sol`), so on the next request the `openai-responses` input builder re-encodes them and demotes their reasoning to `<think>` `output_text`, emitting no reasoning item. The request still enables reasoning (`reasoning: { effort: "xhigh" }`, `include: ["reasoning.encrypted_content"]`), so DeepSeek rejects it with `400 The reasoning_text in the thinking mode must be passed back to the API` and OMP loops on the unchanged request. Reproduced at the request-construction layer: `bun test packages/ai/test/issue-8248-repro.test.ts` — pre-fix the built `input` was `[user, message, message, user]` (no `reasoning` item) while `reasoning.effort` was set.

## Cause
`convertResponsesAssistantMessage` in `packages/ai/src/providers/openai-shared.ts` only emits a reasoning item when a thinking block carries a native OpenAI reasoning-item JSON signature (`parseResponseReasoningReplayItem`). After a cross-model prewalk hand-off, `transformMessages` demotes the foreign thinking block to text (stripping its signature) before it reaches the encoder, so no reasoning item survives. Native `providerPayload` replay is also skipped because the kept turn's `api`/`model` no longer match the active model. The chat-completions path already guards this exact DeepSeek requirement via `requiresReasoningContentForAllAssistantTurns` / `requiresReasoningContentForToolCalls` (synthesizing `reasoning_content`); the Responses path had no equivalent, so the built compat flags (already `true` for this model) were never consulted.

## Fix
- `convertResponsesAssistantMessage` now takes `requiresReasoningReplayForAllTurns` / `requiresReasoningReplayForToolCalls`. When set and the re-encoded turn produces content but no reasoning item, it prepends a `{ type: "reasoning", content: [{ type: "reasoning_text", text }] }` item, carrying surviving thinking text when present (empty otherwise, mirroring the completions empty-`reasoning_content` placeholder). Position is before the turn's message/tool-call items.
- `buildResponsesInput` threads the two flags into the converter (defaults `false`, so other callers are unchanged).
- `buildParams` (`openai-responses.ts`) sets the flags from `policy.reasoning.requiresReasoningContentForAllAssistantTurns` / `...ForToolCalls`, gated on `policy.reasoning.enabled` — non-DeepSeek Responses targets and reasoning-disabled turns are unaffected.

## Verification
`bun test packages/ai/test/issue-8248-repro.test.ts` (5 tests): foreign-turn replay now carries a `reasoning_text` item ordered before the assistant message; a surviving same-model thinking block carries its actual text; reasoning-disabled turns and non-DeepSeek Responses targets synthesize nothing. Broader regression: `bun test` across the responses/openai/reasoning/handoff/codex suites — 1014 pass, 5 e2e-skipped, 0 fail. `bun check` (tsgo) passes for `@oh-my-pi/pi-ai`. Live opencode-go/DeepSeek wire verification was not possible without provider credentials; the synthesized item mirrors the canonical Responses reasoning-item shape and the completions-path placeholder already validated against the same backend. Fixes #8248