### PR TITLE
chore: force refresh provider api key command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed command-backed provider API keys (`!command`) staying pinned to their process-cached value after HTTP 401; auth retry now reruns the command, updates live authorization headers, and retries with the refreshed bearer.
+
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/src/config/model-config-values.ts
+++ b/packages/coding-agent/src/config/model-config-values.ts
@@ -10,11 +10,19 @@ const commandValueCache = new Map<string, string>();
 const COMMAND_FAILURE_RETRY_MS = 30_000;
 const commandFailureRetryAt = new Map<string, number>();
 
+interface ResolveConfigValueOptions {
+	forceCommandRefresh?: boolean;
+}
+
 export function isCommandConfigValue(valueConfig: string | undefined): valueConfig is string {
 	return valueConfig?.startsWith("!") === true;
 }
 
-function resolveCommandConfig(command: string): string | undefined {
+function resolveCommandConfig(command: string, options?: ResolveConfigValueOptions): string | undefined {
+	if (options?.forceCommandRefresh === true) {
+		commandValueCache.delete(command);
+		commandFailureRetryAt.delete(command);
+	}
 	const cached = commandValueCache.get(command);
 	if (cached !== undefined) return cached;
 	const retryAt = commandFailureRetryAt.get(command);
@@ -44,8 +52,8 @@ export interface CommandApiKeyResolution {
  * `!cmd` runs a shell command and returns trimmed stdout, otherwise env vars are
  * checked first and the input falls back to a literal value.
  */
-export function resolveConfigValue(valueConfig: string): string | undefined {
-	if (valueConfig.startsWith("!")) return resolveCommandConfig(valueConfig.slice(1).trim());
+export function resolveConfigValue(valueConfig: string, options?: ResolveConfigValueOptions): string | undefined {
+	if (valueConfig.startsWith("!")) return resolveCommandConfig(valueConfig.slice(1).trim(), options);
 	const envValue = $envExact(valueConfig);
 	if (envValue) return envValue;
 	return valueConfig;

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -195,10 +195,10 @@ export class ModelRegistry {
 	#ignoreLocalModelConfig: boolean;
 	#fetch: FetchImpl;
 
-	#resolveCommandBackedApiKey(provider: string): CommandApiKeyResolution {
+	#resolveCommandBackedApiKey(provider: string, options?: { forceCommandRefresh?: boolean }): CommandApiKeyResolution {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
 		if (!isCommandConfigValue(keyConfig)) return { configured: false };
-		const value = resolveConfigValue(keyConfig);
+		const value = resolveConfigValue(keyConfig, options);
 		if (value) {
 			this.authStorage.setConfigApiKey(provider, value);
 			return { configured: true, value };
@@ -1791,7 +1791,10 @@ export class ModelRegistry {
 		sessionId?: string,
 		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined> {
-		const commandKey = this.#resolveCommandBackedApiKey(provider);
+		const commandKey = this.#resolveCommandBackedApiKey(
+			provider,
+			options?.forceRefresh ? { forceCommandRefresh: true } : undefined,
+		);
 		if (commandKey.configured) return commandKey.value;
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { withAuth } from "@oh-my-pi/pi-ai/auth-retry";
 import type { Api, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -10,6 +11,11 @@ import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 function stdoutCommand(value: string): string {
 	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(`process.stdout.write(${JSON.stringify(value)})`)}`;
+}
+
+function trackedTokenCommand(tokenFile: string, counterFile: string): string {
+	const script = `const fs=require("node:fs");fs.appendFileSync(${JSON.stringify(counterFile)}, "1");const token=fs.readFileSync(${JSON.stringify(tokenFile)}, "utf8").trim();if(token==="FAIL")process.exit(1);process.stdout.write(token);`;
+	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
 }
 
 describe("ModelRegistry command-resolved models.yml values", () => {
@@ -87,6 +93,88 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 		expect(model).toBeDefined();
 		expect(model?.headers?.["X-Model-Key"]).toBe("cmd-model-header");
 		expect(model?.headers?.Authorization).toBe("Bearer cmd-api-key");
+	});
+
+	test("401 reruns a command-backed API key and updates live auth headers", async () => {
+		const tokenFile = path.join(tempDir, "token.txt");
+		const counterFile = path.join(tempDir, "counter.txt");
+		fs.writeFileSync(tokenFile, "stale-key");
+		fs.writeFileSync(counterFile, "");
+		const command = trackedTokenCommand(tokenFile, counterFile);
+
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: `!${command}`,
+						authHeader: true,
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+		if (!model) throw new Error("Expected custom model");
+		fs.writeFileSync(tokenFile, "fresh-key");
+
+		const attemptedKeys: string[] = [];
+		const result = await withAuth(registry.resolver(model), async key => {
+			attemptedKeys.push(key);
+			if (key === "stale-key") {
+				throw Object.assign(new Error("401 authentication_error"), { status: 401 });
+			}
+			if (key === "fresh-key") return "ok";
+			throw new Error(`Unexpected API key: ${key}`);
+		});
+
+		expect(result).toBe("ok");
+		expect(attemptedKeys).toEqual(["stale-key", "fresh-key"]);
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("11");
+		expect(model.headers?.Authorization).toBe("Bearer fresh-key");
+	});
+
+	test("failed 401 refresh discards the rejected command-backed key", async () => {
+		const tokenFile = path.join(tempDir, "token.txt");
+		const counterFile = path.join(tempDir, "counter.txt");
+		fs.writeFileSync(tokenFile, "stale-key");
+		fs.writeFileSync(counterFile, "");
+		const command = trackedTokenCommand(tokenFile, counterFile);
+
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: `!${command}`,
+						authHeader: true,
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+		if (!model) throw new Error("Expected custom model");
+		fs.writeFileSync(tokenFile, "FAIL");
+
+		const refreshed = await registry.resolver(model)({
+			lastChance: false,
+			error: Object.assign(new Error("401 authentication_error"), { status: 401 }),
+			previousKey: "stale-key",
+		});
+
+		expect(refreshed).toBeUndefined();
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("11");
+		expect(await registry.getApiKey(model)).toBeUndefined();
+		expect(model.headers?.Authorization).toBeUndefined();
 	});
 
 	test("resolveCommandConfig caches failed executions so they do not retry", async () => {


### PR DESCRIPTION
## What

Force refreshes the provider api key command.

## Why

Depending on provider policy, generated API key tokens can require a periodic refresh.
This change executes the api key command whenever the provider returns a 401 status response.

## Testing

PR provides unit tests to ensure the change is working as expected.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
