### PR TITLE
fix(snapcompact): extend high-res frame tier to opus 5+

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -228,6 +228,7 @@
       "version": "17.2.13",
       "dependencies": {
         "@oh-my-pi/pi-ai": "catalog:",
+        "@oh-my-pi/pi-catalog": "catalog:",
         "@oh-my-pi/pi-natives": "catalog:",
         "@oh-my-pi/pi-utils": "catalog:",
         "@oh-my-pi/pi-wire": "catalog:",

--- a/packages/snapcompact/CHANGELOG.md
+++ b/packages/snapcompact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `claude-opus-5` (and later Opus lines) falling back to the 1568px frame instead of the 1932px high-res tier, so snapcompact archives for the current flagship Opus now retain ~33% more history at the same per-frame bill ([#8256](https://github.com/can1357/oh-my-pi/issues/8256)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Fixed

--- a/packages/snapcompact/package.json
+++ b/packages/snapcompact/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@oh-my-pi/pi-ai": "catalog:",
+    "@oh-my-pi/pi-catalog": "catalog:",
     "@oh-my-pi/pi-natives": "catalog:",
     "@oh-my-pi/pi-utils": "catalog:",
     "@oh-my-pi/pi-wire": "catalog:"

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -46,6 +46,7 @@
  */
 
 import type { Api, ImageContent, Message, TextContent } from "@oh-my-pi/pi-ai";
+import { isFableOrMythos, parseAnthropicModel, semverGte } from "@oh-my-pi/pi-catalog/identity";
 import { renderSnapcompactPng, snapcompactSupportedChars } from "@oh-my-pi/pi-natives";
 import { formatGroupedPaths, prompt } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -336,21 +337,13 @@ export interface IdealShape {
 	frameSize?: number;
 }
 
-/** Eval-winning format per model line, matched against the model id. The
- *  wire API only identifies the gateway — a Claude served through Vertex or
- *  OpenRouter still reads best with its own shape. Patterns cover the model
- *  lines the mono evals measured; everything else falls back to the API
- *  family's winner at the standard 1568px frame. First match wins. */
+/** Eval-winning format per model line. The wire API only identifies the
+ *  gateway — a Claude served through Vertex or OpenRouter still reads best
+ *  with its own shape. Classified Anthropic models use the shared catalog
+ *  identity parser; remaining model lines use first-match regex rules and fall
+ *  back to the API family's winner at the standard 1568px frame. */
+const HIGH_RES_ANTHROPIC_VARIANT = { variant: "11on16-bw", frameSize: 1932 } as const satisfies IdealShape;
 const MODEL_VARIANTS: readonly (readonly [RegExp, IdealShape])[] = [
-	// Opus 4.7+ and Fable/Mythos read high-res natively: same recall and cost as
-	// 1568, a third fewer frames. 1932 is the largest *square* not downscaled
-	// under Anthropic's 4,784 visual-token cap ((1932/28)² = 69² = 4,761 ≤ 4,784
-	// 28px patches), and staying below 2000px keeps frames clear of the stricter
-	// ≤2000px per-image dimension limit that applies once a request carries more
-	// than 20 image blocks. The cap is a family-wide Anthropic billing property,
-	// so every Opus line from 4.7 up (5.x and later included) belongs on this tier.
-	[/claude.*(fable|mythos)/i, { variant: "11on16-bw", frameSize: 1932 }],
-	[/claude-?opus-?(4[.-][7-9]|[5-9])/i, { variant: "11on16-bw", frameSize: 1932 }],
 	// Older Claude lines downscale past 1568px — keep the safe size.
 	[/claude/i, { variant: "11on16-bw" }],
 	// Gemini 3.x bills a fixed 1,120-token budget per image regardless of
@@ -367,6 +360,18 @@ const MODEL_VARIANTS: readonly (readonly [RegExp, IdealShape])[] = [
 
 /** Eval-ideal format for a model id, or undefined when unmeasured. */
 export function idealShapeVariant(modelId: string): IdealShape | undefined {
+	const anthropic = parseAnthropicModel(modelId);
+	if (
+		anthropic &&
+		(isFableOrMythos(anthropic.kind) || (anthropic.kind === "opus" && semverGte(anthropic.version, "4.7")))
+	) {
+		// Opus 4.7+ and Fable/Mythos read high-res natively: same recall and
+		// cost as 1568, a third fewer frames. 1932 is the largest *square* not
+		// downscaled under Anthropic's 4,784 visual-token cap ((1932/28)² =
+		// 69² = 4,761 ≤ 4,784 28px patches), and staying below 2000px clears
+		// the stricter ≤2000px limit for requests with more than 20 images.
+		return HIGH_RES_ANTHROPIC_VARIANT;
+	}
 	return MODEL_VARIANTS.find(([pattern]) => pattern.test(modelId))?.[1];
 }
 

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -342,11 +342,15 @@ export interface IdealShape {
  *  lines the mono evals measured; everything else falls back to the API
  *  family's winner at the standard 1568px frame. First match wins. */
 const MODEL_VARIANTS: readonly (readonly [RegExp, IdealShape])[] = [
-	// Opus 4.7+ and Fable/Mythos read high-res natively (2576px edge under a
-	// 4,784 visual-token cap → 1932px square sweet spot): same recall and
-	// cost as 1568, a third fewer frames.
+	// Opus 4.7+ and Fable/Mythos read high-res natively: same recall and cost as
+	// 1568, a third fewer frames. 1932 is the largest *square* not downscaled
+	// under Anthropic's 4,784 visual-token cap ((1932/28)² = 69² = 4,761 ≤ 4,784
+	// 28px patches), and staying below 2000px keeps frames clear of the stricter
+	// ≤2000px per-image dimension limit that applies once a request carries more
+	// than 20 image blocks. The cap is a family-wide Anthropic billing property,
+	// so every Opus line from 4.7 up (5.x and later included) belongs on this tier.
 	[/claude.*(fable|mythos)/i, { variant: "11on16-bw", frameSize: 1932 }],
-	[/claude-?opus-?4[.-][7-9]/i, { variant: "11on16-bw", frameSize: 1932 }],
+	[/claude-?opus-?(4[.-][7-9]|[5-9])/i, { variant: "11on16-bw", frameSize: 1932 }],
 	// Older Claude lines downscale past 1568px — keep the safe size.
 	[/claude/i, { variant: "11on16-bw" }],
 	// Gemini 3.x bills a fixed 1,120-token budget per image regardless of

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -344,6 +344,10 @@ export interface IdealShape {
  *  back to the API family's winner at the standard 1568px frame. */
 const HIGH_RES_ANTHROPIC_VARIANT = { variant: "11on16-bw", frameSize: 1932 } as const satisfies IdealShape;
 const MODEL_VARIANTS: readonly (readonly [RegExp, IdealShape])[] = [
+	// Versionless Fable/Mythos aliases (e.g. `claude-fable-latest`) never parse
+	// a numeric version, so keep them on the high-res tier by name — every
+	// Fable/Mythos line reads it natively.
+	[/claude.*(fable|mythos)/i, HIGH_RES_ANTHROPIC_VARIANT],
 	// Older Claude lines downscale past 1568px — keep the safe size.
 	[/claude/i, { variant: "11on16-bw" }],
 	// Gemini 3.x bills a fixed 1,120-token budget per image regardless of

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -299,6 +299,14 @@ describe("shape resolution", () => {
 		// High-res frames are reserved for the lines that read them natively;
 		// older Claude lines keep the safe 1568px family default.
 		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-4-8" }).frameSize).toBe(1932);
+		// Opus 5+ shares the Anthropic visual-token cap, so it stays on the
+		// high-res tier rather than falling back to the 1568px default (#8256).
+		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-5" }).frameSize).toBe(1932);
+		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-6" }).frameSize).toBe(1932);
+		// Opus lines below 4.7 downscale, so they keep the safe family default.
+		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-4-6" })).toBe(
+			snapcompact.SHAPES.anthropic,
+		);
 		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-3-5-sonnet" })).toBe(
 			snapcompact.SHAPES.anthropic,
 		);

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -299,6 +299,10 @@ describe("shape resolution", () => {
 		// High-res frames are reserved for the lines that read them natively;
 		// older Claude lines keep the safe 1568px family default.
 		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-4-8" }).frameSize).toBe(1932);
+		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "anthropic--claude-4.8-opus" }).frameSize).toBe(
+			1932,
+		);
+		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-4-10" }).frameSize).toBe(1932);
 		// Opus 5+ shares the Anthropic visual-token cap, so it stays on the
 		// high-res tier rather than falling back to the 1568px default (#8256).
 		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-5" }).frameSize).toBe(1932);

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -303,6 +303,14 @@ describe("shape resolution", () => {
 			1932,
 		);
 		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-4-10" }).frameSize).toBe(1932);
+		// Versionless Fable/Mythos aliases (bundled `claude-fable-latest`) never
+		// parse a numeric version but still read the high-res tier by name (#8257).
+		expect(
+			snapcompact.resolveShape({ api: "openai-completions", id: "anthropic/claude-fable-latest" }).frameSize,
+		).toBe(1932);
+		expect(
+			snapcompact.resolveShape({ api: "openai-completions", id: "~anthropic/claude-fable-latest" }).frameSize,
+		).toBe(1932);
 		// Opus 5+ shares the Anthropic visual-token cap, so it stays on the
 		// high-res tier rather than falling back to the 1568px default (#8256).
 		expect(snapcompact.resolveShape({ api: "anthropic-messages", id: "claude-opus-5" }).frameSize).toBe(1932);


### PR DESCRIPTION
## Repro
`resolveShape({ api: "anthropic-messages", id: "claude-opus-5" }).frameSize` returns `1568` while `claude-opus-4-8` returns `1932`. Reproduced on current `main`:

```
$ cd packages/snapcompact && bun -e 'import { resolveShape } from "./src/snapcompact.ts"; for (const id of ["claude-opus-4-8","claude-opus-4-9","claude-opus-5","claude-opus-5-0"]) { const s = resolveShape({ api: "anthropic-messages", id }); console.log(id, s.frameSize); }'
claude-opus-4-8    frameSize=1932
claude-opus-4-9    frameSize=1932
claude-opus-5      frameSize=1568
claude-opus-5-0    frameSize=1568
```

An Opus 5 snapcompact session therefore renders every archive frame at 1568px and carries ~33% less history per compaction at the same per-frame bill.

## Cause
`MODEL_VARIANTS` in `packages/snapcompact/src/snapcompact.ts` gated the 1932px tier on `/claude-?opus-?4[.-][7-9]/i`, which stops at 4.9. `claude-opus-5` matched neither that rule nor the Fable/Mythos rule, so `idealShapeVariant` fell through to the generic `/claude/i` entry — the 1568px default the adjacent comment reserves for *older* lines that downscale. The 1932px tier actually tracks the Anthropic 4,784 visual-token cap, a family-wide billing property `opus-5` shares with `opus-4-8`, so the version bound was stale rather than a per-version eval gap.

## Fix
- Widened the Opus high-res pattern to `/claude-?opus-?(4[.-][7-9]|[5-9])/i`, covering Opus 5+ while keeping 4.0–4.6 on the safe 1568px default.
- Updated the adjacent comment to state the tier applies to every Opus line from 4.7 up (5.x and later included).
- Added regression assertions in `test/snapcompact.test.ts`: `claude-opus-5`/`claude-opus-6` resolve to 1932px, `claude-opus-4-6` stays on the family default.
- Added a `CHANGELOG.md` `[Unreleased]` Fixed entry.

## Verification
`cd packages/snapcompact && bun test` → 82 pass / 0 fail (10 pass for the `shape resolution` filter). Manually re-ran the repro command: `claude-opus-5` and `claude-opus-5-0` now resolve to `frameSize=1932`.

Note: the reporter also flagged that `FRAME_DATA_BYTES_ESTIMATE` (~159 KB/frame) may undercount dense 1932px frames per #8168's measurements. That is a separate byte-budget tuning question affecting all models and is left out of this shape-selection fix.

Fixes #8256