### PR TITLE
fix(ai): continue after answerless hosted search

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses turns ending silently after a provider-hosted web search that produced no visible answer: the turn is now classified as `pause_turn` so the agent automatically continues with the search results instead of stopping.
+
 ## [17.2.15] - 2026-08-12
 
 ### Fixed
@@ -14,9 +18,6 @@
 ### Added
 
 - Added `forceReasoningOff` and `disableReasoning` options to disable reasoning in OpenAI and Azure OpenAI models
-### Fixed
-
-- Fixed OpenAI Responses turns ending silently after a provider-hosted web search that produced no visible answer: the turn is now classified as `pause_turn` so the agent automatically continues with the search results instead of stopping.
 
 ## [17.2.13] - 2026-08-11
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### Added
 
 - Added `forceReasoningOff` and `disableReasoning` options to disable reasoning in OpenAI and Azure OpenAI models
+### Fixed
+
+- Fixed OpenAI Responses turns ending silently after a provider-hosted web search that produced no visible answer: the turn is now classified as `pause_turn` so the agent automatically continues with the search results instead of stopping.
 
 ## [17.2.13] - 2026-08-11
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -77,6 +77,7 @@ import {
 	kStreamingLastParseLen,
 	kStreamingPartialJson,
 } from "../utils/block-symbols";
+import { hasVisibleAssistantContent } from "../utils/empty-completion-retry";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
 import {
 	escapeHarmonyControlTokens,
@@ -2773,6 +2774,10 @@ export async function processResponsesStream<TApi extends Api>(
 		output.content.indexOf(block);
 
 	let sawFirstToken = false;
+	// Whether the current stream produced a completed native `web_search_call`
+	// output item. A provider-hosted search that finishes without yield is
+	// progress evidence: the turn should pause for continuation rather than end.
+	let sawCompletedWebSearchCall = false;
 
 	for await (const event of openaiStream) {
 		const terminalEvent = getOpenAIResponsesTerminalEvent(event);
@@ -3059,6 +3064,10 @@ export async function processResponsesStream<TApi extends Api>(
 				}
 				closeOpenItem(event.output_index, item.id, entry, item.call_id, prefixedFunctionCallItemKey(item.call_id));
 				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
+			} else if (item.type === "web_search_call" && item.status === "completed") {
+				// A completed provider-hosted web search is progress evidence even when
+				// the model never surfaced an answer; the agent loop continues from it.
+				sawCompletedWebSearchCall = true;
 			} else if (item.type === "image_generation_call" && item.status === "completed" && item.result) {
 				appendResponsesImageResult(output, stream, item.result);
 			}
@@ -3109,6 +3118,14 @@ export async function processResponsesStream<TApi extends Api>(
 				(response as { end_turn?: boolean } | undefined)?.end_turn,
 				shouldPromoteIncompleteToolUse,
 			);
+			// A completed provider-hosted web search that yielded no visible answer
+			// (no text, image, or client tool call) is progress, not a dead end:
+			// pause the turn so the agent loop re-samples with the search results
+			// instead of silently ending. Reasoning/native output items are preserved
+			// for replay. A search followed by visible output stays a normal stop.
+			if (sawCompletedWebSearchCall && output.stopReason === "stop" && !hasVisibleAssistantContent(output)) {
+				output.stopDetails = { type: "pause_turn" };
+			}
 			options?.onCompleted?.();
 			// `response.completed`/`response.incomplete`/`response.done` is the last event of a
 			// Responses stream. Stop pulling instead of waiting for the server to

--- a/packages/ai/src/utils/empty-completion-retry.ts
+++ b/packages/ai/src/utils/empty-completion-retry.ts
@@ -120,6 +120,7 @@ export function withEmptyCompletionRetry<M, O extends EmptyCompletionRetryOption
 				!committed &&
 				message !== undefined &&
 				message.stopReason === "stop" &&
+				message.stopDetails?.type !== "pause_turn" &&
 				!message.errorMessage &&
 				(message.usage?.output ?? 0) <= 1 &&
 				!hasVisibleAssistantContent(message);

--- a/packages/ai/test/empty-completion-retry.test.ts
+++ b/packages/ai/test/empty-completion-retry.test.ts
@@ -135,6 +135,28 @@ describe("withEmptyCompletionRetry", () => {
 		expect(result.content).toEqual([]);
 	});
 
+	it("does not retry an empty pause_turn completion", async () => {
+		let attempts = 0;
+		const waits: number[] = [];
+		const stream = withEmptyCompletionRetry({}, CTX, { providerRetryWait: async ms => void waits.push(ms) }, () => {
+			attempts++;
+			const message = assistant();
+			message.stopDetails = { type: "pause_turn" };
+			return streamFromEvents([
+				{ type: "start", partial: message },
+				{ type: "done", reason: "stop", message },
+			] as unknown as AssistantMessageEvent[]);
+		});
+
+		const events = await drain(stream);
+		const result = await stream.result();
+
+		expect(attempts).toBe(1);
+		expect(waits).toEqual([]);
+		expect(events.filter(event => event.type === "start")).toHaveLength(1);
+		expect(result.stopDetails).toEqual({ type: "pause_turn" });
+	});
+
 	it("does not retry when the first attempt streams content", async () => {
 		let attempts = 0;
 		let waited = false;

--- a/packages/ai/test/openai-responses-stream-terminal.test.ts
+++ b/packages/ai/test/openai-responses-stream-terminal.test.ts
@@ -650,6 +650,61 @@ describe("processResponsesStream: terminal events", () => {
 		expect(finished.stopReason).toBe("stop");
 		expect(finished.stopDetails).toBeUndefined();
 	});
+
+	test("pauses a completed hosted web search that has no visible assistant output", async () => {
+		const output = makeOutput();
+		const stream = { push: () => {}, end: () => {} } as never;
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: { type: "web_search_call", id: "ws_1", status: "completed", action: { type: "search" } },
+				},
+				{ type: "response.completed", response: { id: "resp_search", status: "completed" } },
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		expect(output.stopReason).toBe("stop");
+		expect(output.stopDetails).toEqual({ type: "pause_turn" });
+	});
+
+	test("finishes a hosted web search when the response includes visible output", async () => {
+		const output = makeOutput();
+		const stream = { push: () => {}, end: () => {} } as never;
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "web_search_call", id: "ws_1", status: "completed", action: { type: "search" } },
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: {
+						type: "message",
+						id: "msg_search",
+						role: "assistant",
+						status: "completed",
+						content: [{ type: "output_text", text: "Search complete", annotations: [] }],
+					},
+				},
+				{ type: "response.completed", response: { id: "resp_search", status: "completed" } },
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		expect(output.content).toEqual([expect.objectContaining({ type: "text", text: "Search complete" })]);
+		expect(output.stopDetails).toBeUndefined();
+	});
 });
 
 describe("processResponsesStream: lost output_item.added recovery", () => {
@@ -835,6 +890,7 @@ describe("processResponsesStream: lost output_item.added recovery", () => {
 		if (block?.type !== "thinking") throw new Error("expected a thinking block");
 		expect(block.thinking).toBe("streamed thinking");
 		expect(block.thinkingSignature).toBeDefined();
+		expect(output.stopDetails).toBeUndefined();
 	});
 
 	test("treats content_filter incomplete responses as errors, not length", async () => {


### PR DESCRIPTION
## What

- Detect a completed native `web_search_call` that reaches `response.completed` without non-whitespace text, an image, or a client tool call.
- Mark that response as `pause_turn`, preserving reasoning and the native search item so the bounded agent loop re-samples instead of ending the run.
- Exclude `pause_turn` completions from the generic empty-completion retry wrapper so the paid hosted search is not re-issued before continuation.
- Add regression coverage for answerless search completion, visible search answers, ordinary reasoning-only stops, and empty `pause_turn` retry behavior.

## Why

> User report (verbatim): “paseo中 omp 使用 deepseek-v4-flash-0731 调用 web_search 失败时,会导致整个 paseo 流程中断。”

A DeepSeek Responses stream was observed completing with reasoning plus native `web_search_call` items but no final message. OMP accepted the signed reasoning-only `stop` as terminal, so Paseo correctly settled the agent even though the task had no visible answer. Replaying the preserved native search result through the existing bounded `pause_turn` path matches the successful manual `continue` recovery without changing ordinary signed-thinking semantics.

Related: #7794

## Testing

- Pre-fix regression: `bun test packages/ai/test/openai-responses-stream-terminal.test.ts` — 26 pass, 1 fail (`stopDetails` was `undefined`).
- `bun test packages/ai/test/openai-responses-stream-terminal.test.ts packages/ai/test/empty-completion-retry.test.ts` — 37 pass, 0 fail.
- `bun test packages/agent/test/agent-loop.test.ts -t pause_turn` — 2 pass, 0 fail.
- `bun --cwd=packages/ai run check` — passed.
- `bun run check:ts` — passed across all TypeScript packages.
- Full `packages/ai/test` run: 3767 pass, 337 skip, 1 process-environment assertion failure in `proxy.test.ts`; the same file passes 40/40 in isolation.
- `bun run check`: TypeScript checks passed; Rust check could not start because rustup timed out downloading `channel-rust-nightly.toml.sha256`.

The full changed-file diff and the post-fix retry interaction were reviewed independently; no blocking or material findings remain.

---

- [ ] `bun check` passes (Rust toolchain download timed out; `bun run check:ts` and the AI package check pass)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)