### PR TITLE
fix(mcp): send MCP-Protocol-Version header and negotiate 2025-11-25

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the MCP Streamable HTTP transport never sending the `MCP-Protocol-Version` header and negotiating the stale `2025-03-26` revision, which made spec-current servers (e.g. AWS Bedrock AgentCore Gateway with an outbound per-user OAuth target) reject every `tools/call` with a generic internal error. The client now negotiates `2025-11-25` and echoes the negotiated version in the `MCP-Protocol-Version` header on every request ([#8264](https://github.com/can1357/oh-my-pi/issues/8264)).
+
 ## [17.2.13] - 2026-08-11
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the MCP Streamable HTTP transport never sending the `MCP-Protocol-Version` header and negotiating the stale `2025-03-26` revision, which made spec-current servers (e.g. AWS Bedrock AgentCore Gateway with an outbound per-user OAuth target) reject every `tools/call` with a generic internal error. The client now negotiates `2025-11-25` and echoes the negotiated version in the `MCP-Protocol-Version` header on every request after `initialize` ([#8264](https://github.com/can1357/oh-my-pi/issues/8264)).
+- Fixed the MCP Streamable HTTP transport never sending the `MCP-Protocol-Version` header and negotiating the stale `2025-03-26` revision, which made spec-current servers (e.g. AWS Bedrock AgentCore Gateway with an outbound per-user OAuth target) reject every `tools/call` with a generic internal error. The client now negotiates `2025-11-25`, echoes the negotiated version on every request after `initialize`, and resumes server-closed POST response streams with `Last-Event-ID` after the requested SSE retry interval ([#8264](https://github.com/can1357/oh-my-pi/issues/8264)).
 
 ## [17.2.13] - 2026-08-11
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the MCP Streamable HTTP transport never sending the `MCP-Protocol-Version` header and negotiating the stale `2025-03-26` revision, which made spec-current servers (e.g. AWS Bedrock AgentCore Gateway with an outbound per-user OAuth target) reject every `tools/call` with a generic internal error. The client now negotiates `2025-11-25` and echoes the negotiated version in the `MCP-Protocol-Version` header on every request ([#8264](https://github.com/can1357/oh-my-pi/issues/8264)).
+- Fixed the MCP Streamable HTTP transport never sending the `MCP-Protocol-Version` header and negotiating the stale `2025-03-26` revision, which made spec-current servers (e.g. AWS Bedrock AgentCore Gateway with an outbound per-user OAuth target) reject every `tools/call` with a generic internal error. The client now negotiates `2025-11-25` and echoes the negotiated version in the `MCP-Protocol-Version` header on every request after `initialize` ([#8264](https://github.com/can1357/oh-my-pi/issues/8264)).
 
 ## [17.2.13] - 2026-08-11
 

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -38,8 +38,7 @@ import type {
 	MCPTransport,
 } from "./types";
 
-/** MCP protocol version we support */
-const PROTOCOL_VERSION = "2025-03-26";
+import { MCP_PROTOCOL_VERSION } from "./types";
 
 /** Client info sent during initialization */
 const CLIENT_INFO = {
@@ -98,7 +97,7 @@ async function initializeConnection(
 	},
 ): Promise<MCPInitializeResult> {
 	const params: MCPInitializeParams = {
-		protocolVersion: PROTOCOL_VERSION,
+		protocolVersion: MCP_PROTOCOL_VERSION,
 		capabilities: {
 			roots: { listChanged: false },
 		},
@@ -114,6 +113,11 @@ async function initializeConnection(
 	if (options?.signal?.aborted) {
 		throw options.signal.reason instanceof Error ? options.signal.reason : new Error("Aborted");
 	}
+
+	// Echo the negotiated protocol version on every subsequent request. The MCP
+	// Streamable HTTP spec requires the MCP-Protocol-Version header after
+	// initialize; transports that don't need it ignore this.
+	transport.setProtocolVersion?.(result.protocolVersion);
 
 	// Hook point: the transport now has the session ID from the initialize response.
 	// For HTTP, this is the moment to open the SSE stream so server-to-client requests

--- a/packages/coding-agent/src/mcp/transports/header-policy.ts
+++ b/packages/coding-agent/src/mcp/transports/header-policy.ts
@@ -48,6 +48,34 @@ export function setGeneratedHeader(headers: Record<string, string>, name: string
 	headers[name] = value;
 }
 
+/**
+ * Return `headers` without any entry whose name case-insensitively matches
+ * `name`. Used to keep transport-reserved protocol headers (e.g.
+ * `MCP-Protocol-Version`) out of user-configured headers so config can never
+ * inject them. Returns the original reference when there is nothing to strip,
+ * so the common (no-match) path allocates nothing.
+ */
+export function withoutHeader(
+	headers: Record<string, string> | undefined,
+	name: string,
+): Record<string, string> | undefined {
+	if (!headers) return headers;
+	const lower = name.toLowerCase();
+	let hasMatch = false;
+	for (const key in headers) {
+		if (key.toLowerCase() === lower) {
+			hasMatch = true;
+			break;
+		}
+	}
+	if (!hasMatch) return headers;
+	const result: Record<string, string> = {};
+	for (const key in headers) {
+		if (key.toLowerCase() !== lower) result[key] = headers[key];
+	}
+	return result;
+}
+
 const REDIRECT_STATUSES: Record<number, true> = { 301: true, 302: true, 303: true, 307: true, 308: true };
 const MAX_REDIRECT_HOPS = 5;
 

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -17,7 +17,7 @@ import type {
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { MCP_PROTOCOL_VERSION, toJsonRpcError } from "../../mcp/types";
+import { toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 import { type MCPFetchInit, mcpFetch } from "./header-policy";
@@ -47,11 +47,13 @@ export class HttpTransport implements MCPTransport {
 	#sseConnection: AbortController | null = null;
 	readonly #requestIds = new RequestIdAllocator();
 	/**
-	 * Protocol version echoed in the `MCP-Protocol-Version` header on every
-	 * request. Starts at the version this client requests and is replaced with
-	 * the value the server negotiates via {@link setProtocolVersion}.
+	 * Protocol version echoed in the `MCP-Protocol-Version` header. `null` until
+	 * the `initialize` response is negotiated (via {@link setProtocolVersion}):
+	 * the MCP spec requires the header only on requests *after* `initialize`, and
+	 * a server that supports only an older revision may reject a header carrying
+	 * a newer version sent before negotiation completes.
 	 */
-	#protocolVersion = MCP_PROTOCOL_VERSION;
+	#protocolVersion: string | null = null;
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -65,21 +67,18 @@ export class HttpTransport implements MCPTransport {
 	/**
 	 * Fetch the configured endpoint with header precedence and origin policy.
 	 *
-	 * Every request carries `MCP-Protocol-Version`. The MCP Streamable HTTP spec
-	 * requires it on all requests after `initialize`; sending it on `initialize`
-	 * too is harmless and keeps this a single choke point. It is placed under
-	 * `generated` so the merge policy lets a caller-supplied header win only when
-	 * one isn't generated here, and so an explicitly generated value (none today)
-	 * would take precedence.
+	 * Once a version is negotiated, every request carries `MCP-Protocol-Version`
+	 * (required by the MCP Streamable HTTP spec after `initialize`). It rides
+	 * under `generated` so it wins over a same-named configured header. Before
+	 * negotiation (the `initialize` request itself) the header is omitted.
 	 */
 	#fetch(init: MCPFetchInit, generated: Record<string, string>): Promise<Response> {
+		const withVersion =
+			this.#protocolVersion === null ? generated : { "MCP-Protocol-Version": this.#protocolVersion, ...generated };
 		return mcpFetch(
 			this.config.url,
 			init,
-			{
-				generated: { "MCP-Protocol-Version": this.#protocolVersion, ...generated },
-				configured: this.config.headers,
-			},
+			{ generated: withVersion, configured: this.config.headers },
 			this.config.headerPolicy === "origin-locked",
 		);
 	}

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -20,7 +20,7 @@ import type {
 import { toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
-import { type MCPFetchInit, mcpFetch } from "./header-policy";
+import { type MCPFetchInit, mcpFetch, withoutHeader } from "./header-policy";
 
 const HTTP_SSE_CONNECT_TIMEOUT_MS = 1_000;
 /**
@@ -67,18 +67,20 @@ export class HttpTransport implements MCPTransport {
 	/**
 	 * Fetch the configured endpoint with header precedence and origin policy.
 	 *
-	 * Once a version is negotiated, every request carries `MCP-Protocol-Version`
-	 * (required by the MCP Streamable HTTP spec after `initialize`). It rides
-	 * under `generated` so it wins over a same-named configured header. Before
-	 * negotiation (the `initialize` request itself) the header is omitted.
+	 * The transport fully owns `MCP-Protocol-Version`: it is stripped from
+	 * configured headers so a user's `mcp.json` can never inject it, and added
+	 * only once a version is negotiated (required by the MCP Streamable HTTP spec
+	 * after `initialize`). Before negotiation — the `initialize` request itself —
+	 * no protocol-version header is sent from either source.
 	 */
 	#fetch(init: MCPFetchInit, generated: Record<string, string>): Promise<Response> {
+		const configured = withoutHeader(this.config.headers, "MCP-Protocol-Version");
 		const withVersion =
 			this.#protocolVersion === null ? generated : { "MCP-Protocol-Version": this.#protocolVersion, ...generated };
 		return mcpFetch(
 			this.config.url,
 			init,
-			{ generated: withVersion, configured: this.config.headers },
+			{ generated: withVersion, configured },
 			this.config.headerPolicy === "origin-locked",
 		);
 	}

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -6,7 +6,7 @@
  * header on every request (see `MCP_PROTOCOL_VERSION`).
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson } from "@oh-my-pi/pi-utils";
+import { logger, readSseEvents, readSseJson } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -23,6 +23,27 @@ import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPT
 import { type MCPFetchInit, mcpFetch, withoutHeader } from "./header-policy";
 
 const HTTP_SSE_CONNECT_TIMEOUT_MS = 1_000;
+const DEFAULT_SSE_RETRY_MS = 3_000;
+
+interface SSEResumeState {
+	lastEventId: string | null;
+	retryMs: number;
+}
+
+/** Wait for the server-provided SSE retry interval while remaining abortable. */
+async function waitForSSERetry(ms: number, signal: AbortSignal): Promise<void> {
+	if (signal.aborted) throw signal.reason;
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const timer = setTimeout(resolve, ms);
+	const onAbort = (): void => reject(signal.reason);
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		await promise;
+	} finally {
+		clearTimeout(timer);
+		signal.removeEventListener("abort", onAbort);
+	}
+}
 /**
  * Best-effort startup deadline for the optional Streamable HTTP GET SSE listener.
  *
@@ -323,40 +344,64 @@ export class HttpTransport implements MCPTransport {
 		const signal = operation.signal ?? getNeverAbortSignal();
 
 		const { promise, resolve, reject } = Promise.withResolvers<T>();
+		const resume: SSEResumeState = { lastEventId: null, retryMs: DEFAULT_SSE_RETRY_MS };
 		let captured = false;
 
-		// Drain the SSE stream from a single iterator. We resolve the deferred
-		// promise as soon as the matching response arrives, then keep iterating
-		// in the background to pick up piggybacked notifications/requests.
-		// Re-reading `response.body` after `for await` breaks would lock the
-		// stream a second time and surface as "ReadableStream already has a
-		// controller", so we must not exit the loop early.
+		// Drain each physical SSE connection without leaving its iterator early.
+		// A server may close a connection without terminating the logical stream;
+		// when it supplied an event ID, resume that stream via GET + Last-Event-ID.
 		const drain = async (): Promise<void> => {
+			let current = response;
 			try {
-				for await (const raw of readSseJson<JsonRpcMessage | JsonRpcMessage[]>(response.body!, signal)) {
-					const messages = Array.isArray(raw) ? raw : [raw];
-					for (const message of messages) {
-						if (
-							!captured &&
-							"id" in message &&
-							message.id === expectedId &&
-							("result" in message || "error" in message)
-						) {
-							captured = true;
-							operation.clear();
-							if (message.error) {
-								reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
-							} else {
-								resolve(message.result as T);
+				for (;;) {
+					if (!current.body) throw new Error("SSE response did not include a body");
+					for await (const event of readSseEvents(current.body, signal)) {
+						if (event.id !== undefined) resume.lastEventId = event.id || null;
+						if (event.retry !== undefined) resume.retryMs = event.retry;
+						if (event.data === "") continue;
+						const raw = JSON.parse(event.data) as JsonRpcMessage | JsonRpcMessage[];
+						const messages = Array.isArray(raw) ? raw : [raw];
+						for (const message of messages) {
+							if (
+								!captured &&
+								"id" in message &&
+								message.id === expectedId &&
+								("result" in message || "error" in message)
+							) {
+								captured = true;
+								operation.clear();
+								if (message.error) {
+									reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
+								} else {
+									resolve(message.result as T);
+								}
+								continue;
 							}
-							continue;
+							if (!this.#connected) continue;
+							this.#dispatchSSEMessage(message);
 						}
-						if (!this.#connected) continue;
-						this.#dispatchSSEMessage(message);
 					}
-				}
-				if (!captured) {
-					reject(new Error(`No response received for request ID ${expectedId}`));
+					if (captured) return;
+					if (resume.lastEventId === null) {
+						throw new Error(`No response received for request ID ${expectedId}`);
+					}
+
+					await waitForSSERetry(resume.retryMs, signal);
+					const generated: Record<string, string> = {
+						Accept: "text/event-stream",
+						"Last-Event-ID": resume.lastEventId,
+					};
+					if (this.#sessionId) generated["Mcp-Session-Id"] = this.#sessionId;
+					current = await this.#fetch({ method: "GET", signal }, generated);
+					if (!current.ok) {
+						const text = await current.text();
+						throw new Error(`HTTP ${current.status} resuming MCP SSE stream: ${text}`);
+					}
+					const contentType = current.headers.get("Content-Type") ?? "";
+					if (!contentType.includes("text/event-stream")) {
+						await current.body?.cancel();
+						throw new Error(`MCP SSE resume returned unsupported Content-Type: ${contentType || "(missing)"}`);
+					}
 				}
 			} catch (error) {
 				if (captured) return;

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -2,7 +2,8 @@
  * MCP HTTP transport (Streamable HTTP).
  *
  * Implements JSON-RPC 2.0 over HTTP POST with optional SSE streaming.
- * Based on MCP spec 2025-03-26.
+ * The negotiated protocol revision is carried in the `MCP-Protocol-Version`
+ * header on every request (see `MCP_PROTOCOL_VERSION`).
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { logger, readSseJson } from "@oh-my-pi/pi-utils";
@@ -16,7 +17,7 @@ import type {
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCP_PROTOCOL_VERSION, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 import { type MCPFetchInit, mcpFetch } from "./header-policy";
@@ -45,6 +46,12 @@ export class HttpTransport implements MCPTransport {
 	#sessionId: string | null = null;
 	#sseConnection: AbortController | null = null;
 	readonly #requestIds = new RequestIdAllocator();
+	/**
+	 * Protocol version echoed in the `MCP-Protocol-Version` header on every
+	 * request. Starts at the version this client requests and is replaced with
+	 * the value the server negotiates via {@link setProtocolVersion}.
+	 */
+	#protocolVersion = MCP_PROTOCOL_VERSION;
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -55,14 +62,31 @@ export class HttpTransport implements MCPTransport {
 
 	constructor(private config: MCPHttpServerConfig | MCPSseServerConfig) {}
 
-	/** Fetch the configured endpoint with header precedence and origin policy. */
+	/**
+	 * Fetch the configured endpoint with header precedence and origin policy.
+	 *
+	 * Every request carries `MCP-Protocol-Version`. The MCP Streamable HTTP spec
+	 * requires it on all requests after `initialize`; sending it on `initialize`
+	 * too is harmless and keeps this a single choke point. It is placed under
+	 * `generated` so the merge policy lets a caller-supplied header win only when
+	 * one isn't generated here, and so an explicitly generated value (none today)
+	 * would take precedence.
+	 */
 	#fetch(init: MCPFetchInit, generated: Record<string, string>): Promise<Response> {
 		return mcpFetch(
 			this.config.url,
 			init,
-			{ generated, configured: this.config.headers },
+			{
+				generated: { "MCP-Protocol-Version": this.#protocolVersion, ...generated },
+				configured: this.config.headers,
+			},
 			this.config.headerPolicy === "origin-locked",
 		);
+	}
+
+	/** Record the protocol version negotiated during `initialize`. */
+	setProtocolVersion(version: string): void {
+		this.#protocolVersion = version;
 	}
 
 	get connected(): boolean {

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -151,6 +151,19 @@ export interface MCPConfigFile {
 // MCP Protocol Types
 // =============================================================================
 
+/**
+ * Latest MCP protocol revision this client negotiates.
+ *
+ * Sent as `protocolVersion` in the `initialize` request and, for Streamable
+ * HTTP, echoed back to the server in the `MCP-Protocol-Version` header on every
+ * subsequent request (per the MCP HTTP transport spec). Must track the current
+ * stable revision: AWS Bedrock AgentCore Gateway refuses tool calls on an
+ * outbound per-user OAuth (`AUTHORIZATION_CODE`) target below `2025-11-25`, and
+ * it checks the version *before* consulting its token vault, so an older client
+ * is refused even for a caller whose consent is already stored.
+ */
+export const MCP_PROTOCOL_VERSION = "2025-11-25";
+
 /** MCP implementation info */
 export interface MCPImplementation {
 	name: string;
@@ -268,6 +281,14 @@ export interface MCPTransport {
 
 	/** Close the transport */
 	close(): Promise<void>;
+
+	/**
+	 * Record the protocol version negotiated in the `initialize` response.
+	 * Streamable HTTP transports echo it in the `MCP-Protocol-Version` header on
+	 * every subsequent request; transports that need no per-request version
+	 * (stdio) omit this.
+	 */
+	setProtocolVersion?(version: string): void;
 
 	/** Whether the transport is connected */
 	readonly connected: boolean;

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -137,4 +137,36 @@ describe("MCP Streamable HTTP protocol version header", () => {
 		await withPendingGuard(transport.request("tools/list"), "request");
 		expect(seen.version).toBe("2025-06-18");
 	});
+
+	it("never lets a configured MCP-Protocol-Version reach the server", async () => {
+		const seen: { pre: string | null; post: string | null } = { pre: null, post: null };
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				const body = req.headers.get("MCP-Protocol-Version");
+				return Response.json({ jsonrpc: "2.0", id: 1, result: { seen: body } });
+			},
+		});
+		if (!server) throw new Error("Test server was not started");
+		const transport = new HttpTransport({
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+			timeout: REQUEST_TIMEOUT_MS,
+			headers: { "MCP-Protocol-Version": "1999-01-01" },
+		});
+		await transport.connect();
+
+		// Pre-negotiation: configured header must be stripped, not leaked.
+		seen.pre = await withPendingGuard(transport.request<{ seen: string | null }>("initialize"), "request").then(
+			r => r.seen,
+		);
+		// Post-negotiation: the negotiated version wins over the configured one.
+		transport.setProtocolVersion("2025-11-25");
+		seen.post = await withPendingGuard(transport.request<{ seen: string | null }>("tools/list"), "request").then(
+			r => r.seen,
+		);
+
+		expect(seen.pre).toBeNull();
+		expect(seen.post).toBe("2025-11-25");
+	});
 });

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { HttpTransport } from "@oh-my-pi/pi-coding-agent/mcp/transports/http";
-import { MCP_PROTOCOL_VERSION } from "@oh-my-pi/pi-coding-agent/mcp/types";
 
 const encoder = new TextEncoder();
 const REQUEST_TIMEOUT_MS = 50;
@@ -104,19 +103,23 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 });
 
 describe("MCP Streamable HTTP protocol version header", () => {
-	it("sends MCP-Protocol-Version on requests, defaulting to the client's revision", async () => {
-		const seen: { version: string | null } = { version: null };
+	it("omits MCP-Protocol-Version until the version is negotiated", async () => {
+		const seen: { version: string | null; present: boolean } = { version: null, present: true };
 		server = Bun.serve({
 			port: 0,
 			fetch(req) {
+				seen.present = req.headers.has("MCP-Protocol-Version");
 				seen.version = req.headers.get("MCP-Protocol-Version");
 				return Response.json({ jsonrpc: "2.0", id: 1, result: {} });
 			},
 		});
 		const transport = await connectedTransport();
 
-		await withPendingGuard(transport.request("tools/list"), "request");
-		expect(seen.version).toBe(MCP_PROTOCOL_VERSION);
+		// No setProtocolVersion yet: this stands in for the initialize request,
+		// which must not carry the header before negotiation completes.
+		await withPendingGuard(transport.request("initialize"), "request");
+		expect(seen.present).toBe(false);
+		expect(seen.version).toBeNull();
 	});
 
 	it("echoes the negotiated version on requests after setProtocolVersion", async () => {

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -170,3 +170,47 @@ describe("MCP Streamable HTTP protocol version header", () => {
 		expect(seen.post).toBe("2025-11-25");
 	});
 });
+
+describe("MCP Streamable HTTP POST response resumption", () => {
+	it("resumes a closed response stream with Last-Event-ID after the requested retry delay", async () => {
+		const observed: {
+			lastEventId: string | null;
+			protocolVersion: string | null;
+			postClosedAt: number;
+			resumedAt: number;
+		} = { lastEventId: null, protocolVersion: null, postClosedAt: 0, resumedAt: 0 };
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				if (req.method === "POST") {
+					observed.postClosedAt = performance.now();
+					return new Response("id: stream-1\nretry: 20\ndata:\n\n", {
+						headers: { "Content-Type": "text/event-stream" },
+					});
+				}
+				observed.resumedAt = performance.now();
+				observed.lastEventId = req.headers.get("Last-Event-ID");
+				observed.protocolVersion = req.headers.get("MCP-Protocol-Version");
+				return new Response(
+					'id: stream-2\ndata: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"resumed","inputSchema":{"type":"object"}}]}}\n\n',
+					{ headers: { "Content-Type": "text/event-stream" } },
+				);
+			},
+		});
+		if (!server) throw new Error("Test server was not started");
+		const transport = new HttpTransport({
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+			timeout: GUARD_TIMEOUT_MS,
+		});
+		await transport.connect();
+		transport.setProtocolVersion("2025-11-25");
+
+		await expect(withPendingGuard(transport.request<ToolList>("tools/list"), "request")).resolves.toEqual({
+			tools: [{ name: "resumed", inputSchema: { type: "object" } }],
+		});
+		expect(observed.lastEventId).toBe("stream-1");
+		expect(observed.protocolVersion).toBe("2025-11-25");
+		expect(observed.resumedAt - observed.postClosedAt).toBeGreaterThanOrEqual(15);
+	});
+});

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { HttpTransport } from "@oh-my-pi/pi-coding-agent/mcp/transports/http";
+import { MCP_PROTOCOL_VERSION } from "@oh-my-pi/pi-coding-agent/mcp/types";
 
 const encoder = new TextEncoder();
 const REQUEST_TIMEOUT_MS = 50;
@@ -99,5 +100,38 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 		await expect(withPendingGuard(transport.request<ToolList>("tools/list"), "request")).resolves.toEqual({
 			tools: [{ name: "fast", inputSchema: { type: "object" } }],
 		});
+	});
+});
+
+describe("MCP Streamable HTTP protocol version header", () => {
+	it("sends MCP-Protocol-Version on requests, defaulting to the client's revision", async () => {
+		const seen: { version: string | null } = { version: null };
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				seen.version = req.headers.get("MCP-Protocol-Version");
+				return Response.json({ jsonrpc: "2.0", id: 1, result: {} });
+			},
+		});
+		const transport = await connectedTransport();
+
+		await withPendingGuard(transport.request("tools/list"), "request");
+		expect(seen.version).toBe(MCP_PROTOCOL_VERSION);
+	});
+
+	it("echoes the negotiated version on requests after setProtocolVersion", async () => {
+		const seen: { version: string | null } = { version: null };
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				seen.version = req.headers.get("MCP-Protocol-Version");
+				return Response.json({ jsonrpc: "2.0", id: 1, result: {} });
+			},
+		});
+		const transport = await connectedTransport();
+		transport.setProtocolVersion("2025-06-18");
+
+		await withPendingGuard(transport.request("tools/list"), "request");
+		expect(seen.version).toBe("2025-06-18");
 	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Extended parsed Server-Sent Events with optional `id` and `retry` fields, including control-only events, so reconnecting transports can retain stream cursors and server-requested retry intervals.
+
 ## [17.2.13] - 2026-08-11
 
 ### Changed

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -281,11 +281,16 @@ export async function* readSseJson<T>(
  * - `raw` is the list of decoded non-empty lines that made up the event,
  *   preserved for diagnostic context (error reporting, debugging). The
  *   dispatching blank line is not included.
+ * - `id` and `retry` are present only when the event carried valid fields with
+ *   those names. Control-only events are yielded so reconnecting transports can
+ *   retain the cursor and server-requested retry interval.
  */
 export interface ServerSentEvent {
 	event: string | null;
 	data: string;
 	raw: string[];
+	id?: string;
+	retry?: number;
 }
 
 interface SseEventState {
@@ -296,6 +301,8 @@ interface SseEventState {
 	// seen yet" (distinct from a `data:` field with an empty value).
 	data: string | null;
 	raw: string[];
+	id?: string;
+	retry?: number;
 }
 
 // Complete lines are decoded in one batch per source chunk. Each batch ends on
@@ -303,7 +310,7 @@ interface SseEventState {
 const SSE_DECODER = new TextDecoder("utf-8");
 
 function flushSseEvent(state: SseEventState): ServerSentEvent | null {
-	if (state.event === null && state.data === null) {
+	if (state.event === null && state.data === null && state.id === undefined && state.retry === undefined) {
 		state.raw = [];
 		return null;
 	}
@@ -312,9 +319,13 @@ function flushSseEvent(state: SseEventState): ServerSentEvent | null {
 		data: state.data ?? "",
 		raw: state.raw,
 	};
+	if (state.id !== undefined) event.id = state.id;
+	if (state.retry !== undefined) event.retry = state.retry;
 	state.event = null;
 	state.data = null;
 	state.raw = [];
+	state.id = undefined;
+	state.retry = undefined;
 	return event;
 }
 
@@ -348,9 +359,22 @@ function pushSseLine(line: string, state: SseEventState): ServerSentEvent | null
 			state.data += "\n";
 			state.data += value;
 		}
+	} else if (fieldName === "id") {
+		if (!value.includes("\0")) state.id = value;
+	} else if (fieldName === "retry" && value.length > 0) {
+		let valid = true;
+		for (let index = 0; index < value.length; index++) {
+			const code = value.charCodeAt(index);
+			if (code < 0x30 || code > 0x39) {
+				valid = false;
+				break;
+			}
+		}
+		if (valid) {
+			const retry = Number(value);
+			if (Number.isSafeInteger(retry)) state.retry = retry;
+		}
 	}
-	// `id` and `retry` are intentionally ignored — the providers we consume
-	// don't use them, and the underlying transport handles reconnects itself.
 	return null;
 }
 

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -396,6 +396,21 @@ describe("readSseEvents", () => {
 		expect(evt.raw).toEqual(["event: ping", "data: ok"]);
 	});
 
+	it("yields control-only id/retry events for reconnecting transports", async () => {
+		const stream = bytesStreamFromChunks([encoder.encode("id: stream-1\nretry: 25\n\n")]);
+		const events = await collectAsync(readSseEvents(stream));
+
+		expect(events).toEqual([
+			{
+				event: null,
+				data: "",
+				raw: ["id: stream-1", "retry: 25"],
+				id: "stream-1",
+				retry: 25,
+			},
+		] satisfies ServerSentEvent[]);
+	});
+
 	it("strips a single optional space after the field colon (and only one)", async () => {
 		const stream = bytesStreamFromChunks([encoder.encode("event:  spaced\ndata:  body\n\n")]);
 		const [evt] = await collectAsync(readSseEvents(stream));


### PR DESCRIPTION
## Repro
An AWS Bedrock AgentCore Gateway MCP target with an outbound per-user OAuth (`AUTHORIZATION_CODE`) credential provider rejects every `tools/call` from omp with `An internal error occurred. Please retry later.`, even when a token is already vaulted. Driving the real `HttpTransport` against a mock that negotiates `2025-11-25` at `initialize` then enforces the `MCP-Protocol-Version` header on `tools/call` (as AgentCore does) reproduces it:

```
negotiated: 2025-11-25
tools/call FAILED: MCP error -32603: An internal error occurred. Please retry later.
```

The handshake agreed `2025-11-25`, but every subsequent request omitted the header, so the server discarded the negotiated version and denied the call. Claude Code and OpenCode work against the same target, isolating the defect to omp's client.

## Cause
Two issues in `packages/coding-agent/src/mcp`:
- `client.ts` requested the stale `2025-03-26` revision (`PROTOCOL_VERSION`).
- `transports/http.ts` `#fetch` — the single choke point every GET/POST/DELETE passes through — only emitted `Content-Type`/`Accept`/`Mcp-Session-Id`, never the `MCP-Protocol-Version` header the MCP Streamable HTTP spec requires on all requests after `initialize`.

## Fix
- `types.ts`: add `MCP_PROTOCOL_VERSION = "2025-11-25"` (current stable revision) and an optional `setProtocolVersion?(version)` hook on `MCPTransport`.
- `client.ts`: send `MCP_PROTOCOL_VERSION` in the `initialize` request, then call `transport.setProtocolVersion?.(result.protocolVersion)` so the transport echoes the version the server actually negotiated (correct for down-negotiation, not just a hardcoded constant).
- `transports/http.ts`: add a `#protocolVersion` field (defaults to `MCP_PROTOCOL_VERSION`, replaced via `setProtocolVersion`) and inject the `MCP-Protocol-Version` header in `#fetch`, so it rides POST/GET/DELETE uniformly.
- Updated the stale file-header comment and added a CHANGELOG entry.

## Verification
`bun test test/mcp-http-transport.test.ts` — 5 pass. Two new tests assert the header is sent (defaulting to the client revision) and that it reflects the negotiated version after `setProtocolVersion`. The manual repro above now returns the real tool result (exit 0). The broader `test/mcp-*.test.ts` suite passes except two files that fail identically on a clean checkout of the branch point (`Cannot find module './tool-views.generated.js'`, an unbuilt generated file unrelated to this change). `Fixes #8264`