### PR TITLE
fix(ai): honor Bedrock skip-auth during model discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `AWS_BEDROCK_SKIP_AUTH` failing to expose Amazon Bedrock models when AWS credential files are unavailable; the registry now recognizes the transport's explicit auth bypass without enabling the separate Bedrock Mantle provider ([#8267](https://github.com/can1357/oh-my-pi/issues/8267)).
+
 ## [17.2.13] - 2026-08-11
 
 ### Changed

--- a/packages/ai/src/registry/amazon-bedrock.ts
+++ b/packages/ai/src/registry/amazon-bedrock.ts
@@ -5,7 +5,7 @@ export const amazonBedrockProvider = {
 	id: "amazon-bedrock",
 	name: "Amazon Bedrock",
 	// Amazon Bedrock accepts bearer tokens, IAM keys, profiles, ECS/IRSA credential chains.
-	envKeys: resolveAwsRegistryApiKey,
+	envKeys: () => resolveAwsRegistryApiKey({ allowSkipAuth: true }),
 	mapSimpleOptions: options => {
 		const awsOptions = options.providerOptions as AwsBedrockProviderOptions | undefined;
 		return {

--- a/packages/ai/src/registry/aws.ts
+++ b/packages/ai/src/registry/aws.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { $env } from "@oh-my-pi/pi-utils";
+import { $env, $flag } from "@oh-my-pi/pi-utils";
 import { hasConfiguredAwsProfile } from "../utils/aws-profile";
 import { AUTHENTICATED_SENTINEL } from "./types";
 
@@ -53,7 +53,8 @@ export function hasAwsCredentialSource(): boolean {
 }
 
 /** Registry key marker for AWS transports that resolve their own bearer/IAM credentials. */
-export function resolveAwsRegistryApiKey(): string | undefined {
+export function resolveAwsRegistryApiKey(options?: { allowSkipAuth?: boolean }): string | undefined {
+	if (options?.allowSkipAuth && $flag("AWS_BEDROCK_SKIP_AUTH")) return AUTHENTICATED_SENTINEL;
 	return hasAwsCredentialSource() ? AUTHENTICATED_SENTINEL : undefined;
 }
 

--- a/packages/ai/test/aws-registry.test.ts
+++ b/packages/ai/test/aws-registry.test.ts
@@ -10,6 +10,7 @@ const EMPTY_AWS_ENV = {
 	AWS_ACCESS_KEY_ID: undefined,
 	AWS_SECRET_ACCESS_KEY: undefined,
 	AWS_BEARER_TOKEN_BEDROCK: undefined,
+	AWS_BEDROCK_SKIP_AUTH: undefined,
 	AWS_PROFILE: undefined,
 	AWS_SDK_LOAD_CONFIG: undefined,
 	AWS_WEB_IDENTITY_TOKEN_FILE: undefined,
@@ -21,6 +22,22 @@ const EMPTY_AWS_ENV = {
 };
 
 describe("AWS provider availability", () => {
+	test("recognizes the Bedrock auth bypass without AWS credentials", async () => {
+		await withEnv(
+			{
+				...EMPTY_AWS_ENV,
+				AWS_BEDROCK_SKIP_AUTH: "1",
+				AWS_SHARED_CREDENTIALS_FILE: "/missing/aws-credentials",
+				AWS_CONFIG_FILE: "/missing/aws-config",
+				AWS_EC2_METADATA_DISABLED: "true",
+			},
+			async () => {
+				expect(getEnvApiKey("amazon-bedrock")).toBeDefined();
+				expect(getEnvApiKey("bedrock-mantle")).toBeUndefined();
+			},
+		);
+	});
+
 	test("recognizes the default shared credentials file", async () => {
 		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "aws-registry-"));
 		try {


### PR DESCRIPTION
## Repro

With no AWS credentials or readable shared AWS config, run `env -i HOME=/tmp/omp-8267 AWS_BEDROCK_SKIP_AUTH=1 /opt/bun/bin/bun -e 'import { resolveAwsRegistryApiKey } from "./packages/ai/src/registry/aws.ts"; console.log(resolveAwsRegistryApiKey())'`; before the fix it prints `undefined`, so `amazon-bedrock` is filtered from the available model list.

## Cause

`packages/ai/src/registry/amazon-bedrock.ts` used the generic `resolveAwsRegistryApiKey` credential-source probe, while only the request transport recognized `AWS_BEDROCK_SKIP_AUTH`. `hasAwsCredentialSource` therefore probed shared AWS files and returned false before model selection could reach the skip-auth transport path.

## Fix

- Allow `resolveAwsRegistryApiKey` callers to opt into the explicit Bedrock auth bypass before shared-config probing.
- Enable that option only for `amazon-bedrock`, leaving `bedrock-mantle` gated on real AWS credentials.
- Cover both provider outcomes and document the fix in the AI changelog.

## Verification

`bun test packages/ai/test/aws-registry.test.ts` passes 8 tests with 16 assertions. `bun run --cwd packages/ai check` passes. The isolated availability probe now prints `<authenticated>`. Skipped the pre-publish gate: `bun run fix` and `bun check` both fail identically on `main` because `audiopus_sys` cannot invoke the missing `cmake` binary; TypeScript formatting completed without changes.

Fixes #8267