### PR TITLE
Notify on tool approval

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable terminal notifications for tool approval prompts via `approval.notify`.
+
 ## [17.2.14] - 2026-08-11
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1948,6 +1948,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"approval.notify": {
+		type: "enum",
+		values: ["on", "off"] as const,
+		default: "on",
+		ui: {
+			tab: "interaction",
+			group: "Notifications",
+			label: "Approval Notification",
+			description: "Notify when a tool is waiting for approval",
+		},
+	},
+
 	"ask.timeout": {
 		type: "number",
 		default: 0,

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -9,9 +9,11 @@ import type {
 	ToolLoadMode,
 } from "@oh-my-pi/pi-agent-core";
 import type { ComputerSafetyCheck, ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai";
-import { sanitizeText, untilAborted } from "@oh-my-pi/pi-utils";
+import { TERMINAL } from "@oh-my-pi/pi-tui";
+import { isInteractiveHost, sanitizeText, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
+import { isWarpCliAgentProtocolActive } from "../../modes/warp-events";
 import { type ApprovalMode, formatApprovalPrompt, resolveApproval, truncateForPrompt } from "../../tools/approval";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
@@ -312,6 +314,16 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 						`  2. Add tools.approval.${this.tool.name}: allow to config\n` +
 						`  3. Use an interactive UI to approve the tool call`,
 				);
+			}
+
+			if (isInteractiveHost() && !isWarpCliAgentProtocolActive() && settings?.get("approval.notify") !== "off") {
+				TERMINAL.sendNotification({
+					title: context?.sessionManager?.getSessionName() || "Oh My Pi",
+					body: `Permission required: ${this.tool.name}`,
+					type: "approval",
+					urgency: "normal",
+					actions: "focus",
+				});
 			}
 
 			const uiContext = this.runner.getUIContext();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1600,7 +1600,7 @@ export async function runRootCommand(
 		// string-flag value such as `--target @notes.md` is the flag's value, not a
 		// file — and the same result is handed to createAgentSession via
 		// `preloadedExtensions` so the discovery work is not repeated.
-		if (isInteractive && !parsedArgs.trustedExtensions?.length) {
+		if (isInteractive) {
 			sessionOptions.extensions = [...(sessionOptions.extensions ?? []), createWarpEventBridgeExtension()];
 		}
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -29,7 +29,11 @@ import type {
 import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
+import { TERMINAL } from "@oh-my-pi/pi-tui";
+import { getProjectAgentDir, isInteractiveHost, logger, setInteractiveHost, TempDir } from "@oh-my-pi/pi-utils";
+
+const originalInteractiveHost = isInteractiveHost();
+const originalWarpProtocolVersion = process.env.WARP_CLI_AGENT_PROTOCOL_VERSION;
 
 describe("ExtensionRunner", () => {
 	let tempDir: TempDir;
@@ -65,6 +69,12 @@ describe("ExtensionRunner", () => {
 		testSetExtensionHandlerTimeoutMs(EXTENSION_HANDLER_TIMEOUT_MS);
 		testSetSessionShutdownHandlerTimeoutMs(SESSION_SHUTDOWN_HANDLER_TIMEOUT_MS);
 		tempDir.removeSync();
+		setInteractiveHost(originalInteractiveHost);
+		if (originalWarpProtocolVersion === undefined) {
+			delete process.env.WARP_CLI_AGENT_PROTOCOL_VERSION;
+		} else {
+			process.env.WARP_CLI_AGENT_PROTOCOL_VERSION = originalWarpProtocolVersion;
+		}
 	});
 
 	const loadTestExtensions = async (configuredPaths: string[] = []) => {
@@ -1903,6 +1913,7 @@ describe("ExtensionRunner", () => {
 		};
 
 		it("emits requested before waiting and resolved after approval", async () => {
+			const notify = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
 			const events: Array<{ type: string; approved?: boolean }> = [];
 			const extCode = `
 				export default function(pi) {
@@ -1933,25 +1944,56 @@ describe("ExtensionRunner", () => {
 			initializeRunner(runner, select);
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
-			await (wrapper as ExtensionToolWrapper<any>).execute("call-approval", {}, undefined, undefined, {
+			let approvalNotification = "on";
+			const toolContext = {
 				sessionManager,
 				modelRegistry,
 				model: undefined,
 				isIdle: () => true,
 				hasQueuedMessages: () => false,
 				abort: () => {},
-				settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) } as never,
-			});
+				settings: {
+					get: (key: string) => {
+						if (key === "tools.approvalMode") return "always-ask";
+						if (key === "approval.notify") return approvalNotification;
+						return {};
+					},
+				},
+			} as never;
+			setInteractiveHost(true);
+			await wrapper.execute("call-approval", {} as never, undefined, undefined, toolContext);
 
 			expect(events).toEqual([
 				{ type: "tool_approval_requested" },
 				{ type: "ui_select" },
 				{ type: "tool_approval_resolved", approved: true },
 			]);
+			expect(notify).toHaveBeenCalledWith({
+				title: "Oh My Pi",
+				body: "Permission required: dangerous_tool",
+				type: "approval",
+				urgency: "normal",
+				actions: "focus",
+			});
+			expect(notify).toHaveBeenCalledTimes(1);
 			expect(select).toHaveBeenCalledWith(expect.stringContaining("Allow tool: dangerous_tool"), [
 				"Approve",
 				"Deny",
 			]);
+			notify.mockClear();
+			approvalNotification = "off";
+			await wrapper.execute("call-approval-notify-off", {} as never, undefined, undefined, toolContext);
+			expect(notify).not.toHaveBeenCalled();
+			notify.mockClear();
+			approvalNotification = "on";
+			setInteractiveHost(false);
+			await wrapper.execute("call-approval-non-terminal", {} as never, undefined, undefined, toolContext);
+			expect(notify).not.toHaveBeenCalled();
+			notify.mockClear();
+			setInteractiveHost(true);
+			process.env.WARP_CLI_AGENT_PROTOCOL_VERSION = "1";
+			await wrapper.execute("call-approval-warp", {} as never, undefined, undefined, toolContext);
+			expect(notify).not.toHaveBeenCalled();
 			delete globalState.__approvalEvents;
 		});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -68,6 +68,7 @@ describe("ExtensionRunner", () => {
 	afterEach(() => {
 		testSetExtensionHandlerTimeoutMs(EXTENSION_HANDLER_TIMEOUT_MS);
 		testSetSessionShutdownHandlerTimeoutMs(SESSION_SHUTDOWN_HANDLER_TIMEOUT_MS);
+		vi.restoreAllMocks();
 		tempDir.removeSync();
 		setInteractiveHost(originalInteractiveHost);
 		if (originalWarpProtocolVersion === undefined) {


### PR DESCRIPTION
Adds configurable terminal notifications when interactive tool approval prompts open.

`approval.notify` defaults to `on` alongside completion and ask notifications. Suppresses legacy notifications in non-terminal hosts and when Warp owns delivery.

Verified with approval and Warp event tests, the coding-agent type check, and a Ghostty smoke test.