### PR TITLE
feat(settings): accept free-form numeric values in preset submenus

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## [Unreleased]
 
+- The `/config` settings UI now accepts a free-form value for `compaction.thresholdPercent` and `compaction.thresholdTokens` via a "Custom…" entry, instead of only the preset options ([#8210](https://github.com/can1357/oh-my-pi/issues/8210)).
+
 ## [17.2.13] - 2026-08-11
 
 ### Added
 
 - Added `searxng.safesearch` setting option for SearXNG searches
-- The `/config` settings UI now accepts a free-form value for `compaction.thresholdPercent` and `compaction.thresholdTokens` via a "Custom…" entry, instead of only the preset options ([#8210](https://github.com/can1357/oh-my-pi/issues/8210)).
 - `omp update` now honors an `omp.dist` distribution field published in the release's npm manifest and treats major-version bumps without one as binary-only: bun/npm-managed installs are migrated to the standalone GitHub release binary in place instead of running a package-manager install that a non-npm release (e.g. a runtime change) would break. Windows script-shim installs (npm's `omp.cmd`/`omp.ps1`) are taken over seamlessly by installing `omp.exe` beside the shims and retiring them.
 - Added support for Cloudflare AI Gateway routing for Gemini search
 - Added support for Exa MCP search provider

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Added `searxng.safesearch` setting option for SearXNG searches
+- The `/config` settings UI now accepts a free-form value for `compaction.thresholdPercent` and `compaction.thresholdTokens` via a "Custom…" entry, instead of only the preset options ([#8210](https://github.com/can1357/oh-my-pi/issues/8210)).
 - `omp update` now honors an `omp.dist` distribution field published in the release's npm manifest and treats major-version bumps without one as binary-only: bun/npm-managed installs are migrated to the standalone GitHub release binary in place instead of running a package-manager install that a non-npm release (e.g. a runtime change) would break. Windows script-shim installs (npm's `omp.cmd`/`omp.ps1`) are taken over seamlessly by installing `omp.exe` beside the shims and retiring them.
 - Added support for Cloudflare AI Gateway routing for Gemini search
 - Added support for Exa MCP search provider

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -212,6 +212,11 @@ interface UiEnum<T extends readonly string[]> extends UiBase {
 interface UiNumber extends UiBase {
 	/** Submenu options. Without options, a numeric setting has no UI representation (intentional hide). */
 	options?: ReadonlyArray<SubmenuOption>;
+	/** Offer a free-form "Custom…" entry alongside the preset options. */
+	custom?: boolean;
+	/** Inclusive bounds enforced on the free-form entry (undefined = unbounded). */
+	min?: number;
+	max?: number;
 }
 
 interface UiString extends UiBase {
@@ -238,6 +243,9 @@ export type AnyUiMetadata = UiBase & {
 	options?: ReadonlyArray<SubmenuOption> | "runtime";
 	secret?: boolean;
 	ordered?: boolean;
+	custom?: boolean;
+	min?: number;
+	max?: number;
 };
 
 /**
@@ -2201,6 +2209,9 @@ export const SETTINGS_SCHEMA = {
 		type: "number",
 		default: -1,
 		ui: {
+			custom: true,
+			min: 1,
+			max: 100,
 			tab: "context",
 			group: "Compaction",
 			label: "Compaction Threshold",
@@ -2226,6 +2237,8 @@ export const SETTINGS_SCHEMA = {
 		type: "number",
 		default: -1,
 		ui: {
+			custom: true,
+			min: 1,
 			tab: "context",
 			group: "Compaction",
 			label: "Compaction Token Limit",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -217,6 +217,8 @@ interface UiNumber extends UiBase {
 	/** Inclusive bounds enforced on the free-form entry (undefined = unbounded). */
 	min?: number;
 	max?: number;
+	/** Value unit; gates which human-formatted suffixes the free-form entry accepts. */
+	unit?: "percent";
 }
 
 interface UiString extends UiBase {
@@ -246,6 +248,7 @@ export type AnyUiMetadata = UiBase & {
 	custom?: boolean;
 	min?: number;
 	max?: number;
+	unit?: "percent";
 };
 
 /**
@@ -2212,6 +2215,7 @@ export const SETTINGS_SCHEMA = {
 			custom: true,
 			min: 1,
 			max: 100,
+			unit: "percent",
 			tab: "context",
 			group: "Compaction",
 			label: "Compaction Threshold",

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -68,6 +68,8 @@ export interface SubmenuSettingDef extends BaseSettingDef {
 	/** Inclusive bounds for the free-form entry (undefined = unbounded). */
 	min?: number;
 	max?: number;
+	/** Value unit; gates which human-formatted suffixes the free-form entry accepts. */
+	unit?: "percent";
 }
 
 export interface TextInputSettingDef extends BaseSettingDef {
@@ -187,14 +189,14 @@ function pathToSettingDef(path: SettingPath): SettingDef | null {
 	if (schemaType === "number") {
 		// Numbers without options are intentionally hidden from the UI.
 		if (!options || options === "runtime") return null;
-		const ui = getUi(path);
 		return {
 			...base,
 			type: "submenu",
 			options,
-			...(ui?.custom ? { custom: true } : {}),
-			...(ui?.min !== undefined ? { min: ui.min } : {}),
-			...(ui?.max !== undefined ? { max: ui.max } : {}),
+			...(ui.custom ? { custom: true } : {}),
+			...(ui.min !== undefined ? { min: ui.min } : {}),
+			...(ui.max !== undefined ? { max: ui.max } : {}),
+			...(ui.unit !== undefined ? { unit: ui.unit } : {}),
 		};
 	}
 

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -63,6 +63,11 @@ export interface SubmenuSettingDef extends BaseSettingDef {
 	options: OptionList;
 	onPreview?: (value: string) => void;
 	onPreviewCancel?: (originalValue: string) => void;
+	/** Append a free-form "Custom…" entry that swaps into a validated text input. */
+	custom?: boolean;
+	/** Inclusive bounds for the free-form entry (undefined = unbounded). */
+	min?: number;
+	max?: number;
 }
 
 export interface TextInputSettingDef extends BaseSettingDef {
@@ -182,7 +187,15 @@ function pathToSettingDef(path: SettingPath): SettingDef | null {
 	if (schemaType === "number") {
 		// Numbers without options are intentionally hidden from the UI.
 		if (!options || options === "runtime") return null;
-		return { ...base, type: "submenu", options };
+		const ui = getUi(path);
+		return {
+			...base,
+			type: "submenu",
+			options,
+			...(ui?.custom ? { custom: true } : {}),
+			...(ui?.min !== undefined ? { min: ui.min } : {}),
+			...(ui?.max !== undefined ? { max: ui.max } : {}),
+		};
 	}
 
 	if (schemaType === "string") {

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -222,6 +222,56 @@ class SelectSubmenu extends Container {
 }
 
 /**
+ * Submenu for numeric settings that offer presets plus a free-form entry
+ * (compaction thresholds). Selecting the injected `__custom__` option swaps
+ * the preset list for a text input; Esc at any point returns to the caller.
+ */
+class ThresholdInputSubmenu extends Container {
+	constructor(
+		title: string,
+		description: string,
+		options: ReadonlyArray<SelectItem>,
+		currentValue: string,
+		onSubmit: (value: string) => void,
+		onCancel: () => void,
+	) {
+		super();
+		const showSelect = (): void => {
+			this.clear();
+			this.addChild(
+				new SelectSubmenu(
+					title,
+					description,
+					options,
+					currentValue,
+					value => {
+						if (value === "__custom__") {
+							showInput();
+							return;
+						}
+						onSubmit(value);
+					},
+					onCancel,
+				),
+			);
+			this.invalidate();
+		};
+		const showInput = (): void => {
+			this.clear();
+			this.addChild(new TextInputSubmenu(title, description, "", false, value => onSubmit(value), onCancel));
+			this.invalidate();
+		};
+		showSelect();
+	}
+
+	handleInput(data: string): void {
+		for (const child of this.children) {
+			child.handleInput?.(data);
+		}
+	}
+}
+
+/**
  * Submenu for array-of-enum settings: every option is a toggle row. Enter or
  * Space flips membership; ordered lists render 1-based positions and reorder
  * the highlighted member with ←/→. Changes apply live; Esc goes back.
@@ -460,6 +510,22 @@ let cachedSidebarWidth: number | undefined;
  * the visible tab), so the divider column never moves when switching tabs or
  * when condition-gated groups appear.
  */
+function parseNumericInput(raw: string): number | undefined {
+	const trimmed = raw.trim().replace(/,/g, "");
+	const percent = /^(\d+(?:\.\d+)?)%$/.exec(trimmed);
+	if (percent) {
+		const value = Number(percent[1]);
+		return Number.isFinite(value) ? value : undefined;
+	}
+	const kSuffix = /^(\d+(?:\.\d+)?)k$/i.exec(trimmed);
+	if (kSuffix) {
+		const value = Number(kSuffix[1]) * 1000;
+		return Number.isFinite(value) ? value : undefined;
+	}
+	const number = Number(trimmed);
+	return Number.isFinite(number) ? number : undefined;
+}
+
 function settingsSidebarWidth(): number {
 	if (cachedSidebarWidth === undefined) {
 		let nameWidth = 0;
@@ -1041,6 +1107,11 @@ export class SettingsSelectorComponent implements Component {
 			});
 		} else if (def.path === "theme.dark" || def.path === "theme.light") {
 			options = this.context.availableThemes.map(t => ({ value: t, label: t }));
+		} else if (def.custom) {
+			// Preset-only numbers can opt into a free-form entry via the schema's
+			// `custom` flag (#8210): append a "Custom…" row that swaps into a
+			// validated text input.
+			options = [...options, { value: "__custom__", label: "Custom…", description: "Type an arbitrary value" }];
 		}
 
 		// Preview handlers
@@ -1100,24 +1171,41 @@ export class SettingsSelectorComponent implements Component {
 		const isThemeSetting = def.path === "theme.dark" || def.path === "theme.light";
 		const getPreview = isThemeSetting ? this.callbacks.getStatusLinePreview : undefined;
 
-		return new SelectSubmenu(
-			def.label,
-			def.description,
-			options,
-			currentValue,
-			value => {
-				this.#setSettingValue(def.path, value);
-				this.callbacks.onChange(def.path, value);
-				done(value);
-			},
-			() => {
-				onPreviewCancel?.();
-				done();
-			},
-			onPreview,
-			getPreview,
-			footer,
-		);
+		const onSelect = (value: string): void => {
+			this.#setSettingValue(def.path, value);
+			this.callbacks.onChange(def.path, settings.get(def.path));
+			done(String(settings.get(def.path)));
+		};
+		const onCancel = (): void => {
+			onPreviewCancel?.();
+			done();
+		};
+
+		if (def.custom) {
+			const label = def.label.toLowerCase();
+			return new ThresholdInputSubmenu(def.label, def.description, options, currentValue, value => {
+				const trimmed = value.trim();
+				if (trimmed === "" || trimmed === "default") {
+					onSelect("default");
+					return;
+				}
+				const parsed = parseNumericInput(trimmed);
+				if (parsed === undefined) {
+					throw new Error(
+						`Invalid ${label} value: ${JSON.stringify(trimmed)}. Expected a number (e.g. 65, 35,000, 160K).`,
+					);
+				}
+				if (def.min !== undefined && parsed < def.min) {
+					throw new Error(`Invalid ${label} value: ${JSON.stringify(trimmed)}. Minimum is ${def.min}.`);
+				}
+				if (def.max !== undefined && parsed > def.max) {
+					throw new Error(`Invalid ${label} value: ${JSON.stringify(trimmed)}. Maximum is ${def.max}.`);
+				}
+				onSelect(String(parsed));
+			}, onCancel);
+		}
+
+		return new SelectSubmenu(def.label, def.description, options, currentValue, onSelect, onCancel, onPreview, getPreview, footer);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -27,6 +27,7 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { ShapeTarget } from "@oh-my-pi/snapcompact";
+import { logger } from "@oh-my-pi/pi-utils";
 import {
 	getDefault,
 	getType,
@@ -256,7 +257,11 @@ class ThresholdInputSubmenu extends Container {
 							// Presets are static schema data, so a failure here means the
 							// schema drifted out of bounds — log instead of letting it crash
 							// the key handler (the text-input path shows errors inline).
-							console.error(`settings: preset ${JSON.stringify(value)} for "${title}" rejected:`, error);
+							// The centralized logger keeps TUI stderr free of overlay
+							// corruption (#8271 review).
+							logger.error(`settings: preset ${JSON.stringify(value)} for "${title}" rejected`, {
+								error: error instanceof Error ? error.message : String(error),
+							});
 						}
 					},
 					onCancel,

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -9,6 +9,7 @@ import {
 	getSettingItemFilterText,
 	type ImageBudget,
 	Input,
+	type MouseRoutable,
 	matchesKey,
 	replaceTabs,
 	routeSelectListMouse,
@@ -249,7 +250,14 @@ class ThresholdInputSubmenu extends Container {
 							showInput();
 							return;
 						}
-						onSubmit(value);
+						try {
+							onSubmit(value);
+						} catch (error) {
+							// Presets are static schema data, so a failure here means the
+							// schema drifted out of bounds — log instead of letting it crash
+							// the key handler (the text-input path shows errors inline).
+							console.error(`settings: preset ${JSON.stringify(value)} for "${title}" rejected:`, error);
+						}
 					},
 					onCancel,
 				),
@@ -267,6 +275,13 @@ class ThresholdInputSubmenu extends Container {
 	handleInput(data: string): void {
 		for (const child of this.children) {
 			child.handleInput?.(data);
+		}
+	}
+
+	/** Forward mouse routing to the active child so wheel/hover/clicks reach the preset list. */
+	routeMouse(event: SgrMouseEvent, line: number, col: number): void {
+		for (const child of this.children) {
+			(child as Component & Partial<MouseRoutable>).routeMouse?.(event, line, col);
 		}
 	}
 }
@@ -510,9 +525,11 @@ let cachedSidebarWidth: number | undefined;
  * the visible tab), so the divider column never moves when switching tabs or
  * when condition-gated groups appear.
  */
-function parseNumericInput(raw: string): number | undefined {
+function parseNumericInput(raw: string, allowPercent = false): number | undefined {
 	const trimmed = raw.trim().replace(/,/g, "");
-	const percent = /^(\d+(?:\.\d+)?)%$/.exec(trimmed);
+	// The `%` suffix only means anything for percent-valued settings; for
+	// others it is rejected so "65%" cannot silently store 65 tokens (#8271).
+	const percent = allowPercent ? /^(\d+(?:\.\d+)?)%$/.exec(trimmed) : null;
 	if (percent) {
 		const value = Number(percent[1]);
 		return Number.isFinite(value) ? value : undefined;
@@ -1183,29 +1200,46 @@ export class SettingsSelectorComponent implements Component {
 
 		if (def.custom) {
 			const label = def.label.toLowerCase();
-			return new ThresholdInputSubmenu(def.label, def.description, options, currentValue, value => {
-				const trimmed = value.trim();
-				if (trimmed === "" || trimmed === "default") {
-					onSelect("default");
-					return;
-				}
-				const parsed = parseNumericInput(trimmed);
-				if (parsed === undefined) {
-					throw new Error(
-						`Invalid ${label} value: ${JSON.stringify(trimmed)}. Expected a number (e.g. 65, 35,000, 160K).`,
-					);
-				}
-				if (def.min !== undefined && parsed < def.min) {
-					throw new Error(`Invalid ${label} value: ${JSON.stringify(trimmed)}. Minimum is ${def.min}.`);
-				}
-				if (def.max !== undefined && parsed > def.max) {
-					throw new Error(`Invalid ${label} value: ${JSON.stringify(trimmed)}. Maximum is ${def.max}.`);
-				}
-				onSelect(String(parsed));
-			}, onCancel);
+			return new ThresholdInputSubmenu(
+				def.label,
+				def.description,
+				options,
+				currentValue,
+				value => {
+					const trimmed = value.trim();
+					if (trimmed === "" || trimmed === "default") {
+						onSelect("default");
+						return;
+					}
+					const parsed = parseNumericInput(trimmed, def.unit === "percent");
+					if (parsed === undefined) {
+						throw new Error(
+							`Invalid ${label} value: ${JSON.stringify(trimmed)}. Expected a number (e.g. 65, 35,000, 160K).`,
+						);
+					}
+					if (def.min !== undefined && parsed < def.min) {
+						throw new Error(`Invalid ${label} value: ${JSON.stringify(trimmed)}. Minimum is ${def.min}.`);
+					}
+					if (def.max !== undefined && parsed > def.max) {
+						throw new Error(`Invalid ${label} value: ${JSON.stringify(trimmed)}. Maximum is ${def.max}.`);
+					}
+					onSelect(String(parsed));
+				},
+				onCancel,
+			);
 		}
 
-		return new SelectSubmenu(def.label, def.description, options, currentValue, onSelect, onCancel, onPreview, getPreview, footer);
+		return new SelectSubmenu(
+			def.label,
+			def.description,
+			options,
+			currentValue,
+			onSelect,
+			onCancel,
+			onPreview,
+			getPreview,
+			footer,
+		);
 	}
 
 	/**

--- a/packages/coding-agent/test/modes/components/settings-compaction-input.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-compaction-input.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SettingsSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/settings-selector";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+let geometryStub: { restore(): void } | undefined;
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	geometryStub = stubStdoutGeometry(120);
+	// SelectList navigation resolves through the keybindings table; pin the
+	// arrow/confirm keys so DOWN/UP/Enter work without a global config.
+	setKeybindings(
+		KeybindingsManager.inMemory({
+			"tui.select.cancel": "ctrl+g",
+			"tui.select.down": "down",
+			"tui.select.up": "up",
+			"tui.select.confirm": "enter",
+		}),
+	);
+});
+
+afterEach(() => {
+	resetSettingsForTest();
+	geometryStub?.restore();
+	geometryStub = undefined;
+	setKeybindings(KeybindingsManager.inMemory());
+});
+
+function stubStdoutGeometry(cols: number): { restore(): void } {
+	const rowsDesc = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+	const colsDesc = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+	const rows = 40;
+	Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => rows, set: () => {} });
+	Object.defineProperty(process.stdout, "columns", { configurable: true, get: () => cols, set: () => {} });
+	const restoreOne = (key: "rows" | "columns", desc: PropertyDescriptor | undefined) => {
+		if (desc) Object.defineProperty(process.stdout, key, desc);
+	};
+	return {
+		restore() {
+			restoreOne("rows", rowsDesc);
+			restoreOne("columns", colsDesc);
+		},
+	};
+}
+
+function createSelector(): SettingsSelectorComponent {
+	return new SettingsSelectorComponent(
+		{
+			availableThinkingLevels: [],
+			thinkingLevel: undefined,
+			availableThemes: ["dark"],
+			providers: [],
+			cwd: process.cwd(),
+		},
+		{
+			onChange: () => {},
+			onCancel: () => {},
+		},
+	);
+}
+
+describe("compaction threshold free-form input (issue #8210)", () => {
+	it("offers a Custom… entry and persists a typed value for thresholdPercent", () => {
+		const comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		// The search cursor lands on the last match; walk back up to the
+		// "Compaction Threshold" row and open its submenu.
+		for (let i = 0; i < 4; i++) comp.handleInput("\x1b[A");
+		comp.handleInput("\n");
+
+		// Filter the preset list down to the Custom… entry and select it.
+		for (const ch of "custom") comp.handleInput(ch);
+		comp.handleInput("\n");
+
+		// Type a free-form value and confirm.
+		for (const ch of "63") comp.handleInput(ch);
+		comp.handleInput("\n");
+
+		expect(settings.get("compaction.thresholdPercent")).toBe(63);
+	});
+
+	it("persists a typed value for thresholdTokens", () => {
+		const comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		for (let i = 0; i < 2; i++) comp.handleInput("\x1b[A"); // up to "Compaction Token Limit"
+		comp.handleInput("\n");
+
+		// Default + 7 presets precede the Custom… entry (9 rows total, so the
+		// list search stays disabled and navigation must walk down).
+		for (let i = 0; i < 8; i++) comp.handleInput("\x1b[B");
+		comp.handleInput("\n");
+
+		for (const ch of "35000") comp.handleInput(ch);
+		comp.handleInput("\n");
+
+		expect(settings.get("compaction.thresholdTokens")).toBe(35_000);
+	});
+
+	it("accepts human-formatted input: percent, separators, and K suffix", () => {
+		// "65%" → 65 for thresholdPercent.
+		let comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		for (let i = 0; i < 4; i++) comp.handleInput("\x1b[A");
+		comp.handleInput("\n");
+		for (const ch of "custom") comp.handleInput(ch);
+		comp.handleInput("\n");
+		for (const ch of "65%") comp.handleInput(ch);
+		comp.handleInput("\n");
+		expect(settings.get("compaction.thresholdPercent")).toBe(65);
+
+		// "160K" → 160000 for thresholdTokens.
+		comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		for (let i = 0; i < 2; i++) comp.handleInput("\x1b[A");
+		comp.handleInput("\n");
+		for (let i = 0; i < 8; i++) comp.handleInput("\x1b[B");
+		comp.handleInput("\n");
+		for (const ch of "160K") comp.handleInput(ch);
+		comp.handleInput("\n");
+		expect(settings.get("compaction.thresholdTokens")).toBe(160_000);
+	});
+
+	it("rejects out-of-range percent values with an inline error", () => {
+		const comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		for (let i = 0; i < 4; i++) comp.handleInput("\x1b[A");
+		comp.handleInput("\n");
+		for (const ch of "custom") comp.handleInput(ch);
+		comp.handleInput("\n");
+
+		// 150 is above the percent max of 100: the error is shown inline and
+		// the setting stays at the previous value.
+		for (const ch of "150") comp.handleInput(ch);
+		comp.handleInput("\n");
+		expect(settings.get("compaction.thresholdPercent")).toBe(-1);
+
+		const rendered = comp.render(120).join("\n");
+		expect(rendered).toContain("Maximum is 100");
+	});
+});

--- a/packages/coding-agent/test/modes/components/settings-compaction-input.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-compaction-input.test.ts
@@ -128,6 +128,39 @@ describe("compaction threshold free-form input (issue #8210)", () => {
 		expect(settings.get("compaction.thresholdTokens")).toBe(160_000);
 	});
 
+	it("rejects a % suffix on the token-limit field instead of misreading it", () => {
+		const comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		for (let i = 0; i < 2; i++) comp.handleInput("\x1b[A"); // up to "Compaction Token Limit"
+		comp.handleInput("\n");
+		for (let i = 0; i < 8; i++) comp.handleInput("\x1b[B"); // down to "Custom…"
+		comp.handleInput("\n");
+
+		// "65%" would parse as 65 under the percent rule; for a token count the
+		// unit is meaningless, so the entry is rejected and nothing is stored.
+		for (const ch of "65%") comp.handleInput(ch);
+		comp.handleInput("\n");
+		expect(settings.get("compaction.thresholdTokens")).toBe(-1);
+
+		const rendered = comp.render(120).join("\n");
+		expect(rendered).toContain("Expected a number");
+	});
+
+	it("routes mouse clicks on preset rows through the threshold submenu", () => {
+		const comp = createSelector();
+		for (const ch of "compaction threshold") comp.handleInput(ch);
+		for (let i = 0; i < 4; i++) comp.handleInput("\x1b[A");
+		comp.handleInput("\n");
+
+		const lines = comp.render(120);
+		const row = lines.findIndex(l => l.includes("10%")) + 1; // SGR rows are 1-based
+		expect(row).toBeGreaterThan(0);
+
+		comp.handleInput(`\x1b[<0;3;${row}M`); // left-click on the "10%" preset row
+
+		expect(settings.get("compaction.thresholdPercent")).toBe(10);
+	});
+
 	it("rejects out-of-range percent values with an inline error", () => {
 		const comp = createSelector();
 		for (const ch of "compaction threshold") comp.handleInput(ch);

--- a/packages/coding-agent/test/modes/components/settings-compaction-input.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-compaction-input.test.ts
@@ -41,7 +41,11 @@ function stubStdoutGeometry(cols: number): { restore(): void } {
 	Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => rows, set: () => {} });
 	Object.defineProperty(process.stdout, "columns", { configurable: true, get: () => cols, set: () => {} });
 	const restoreOne = (key: "rows" | "columns", desc: PropertyDescriptor | undefined) => {
+		// An absent descriptor (non-TTY test environments) means the property
+		// was invented by the stub; delete it so later tests see the original
+		// state instead of a leaked 40x120 stub (#8271 review).
 		if (desc) Object.defineProperty(process.stdout, key, desc);
+		else Reflect.deleteProperty(process.stdout, key);
 	};
 	return {
 		restore() {


### PR DESCRIPTION
## Summary

The compaction threshold settings only offered preset options, so arbitrary values (e.g. 63% or 35,000 tokens) required editing config files by hand. This makes the free-form entry a reusable schema affordance:

- `UiNumber` gains `custom` / `min` / `max`; any preset-only number setting can opt in.
- The submenu appends a "Custom…" entry that swaps into the existing text-input widget.
- Values are validated against the declared bounds (percent 1-100, tokens >= 1); out-of-range input surfaces an inline error and leaves the setting unchanged.
- Human-formatted input is accepted: `65%`, `35,000`, `160K`.

`compaction.thresholdPercent` and `compaction.thresholdTokens` are wired up via the schema.

## Test plan

- Settings component tests: preset navigation, Custom… entry, typed persistence for both thresholds, human-format parsing (65% / 160K), and out-of-range rejection with inline error.
- Settings regression suite passes (20/20), plus oxlint and TypeScript.

Fixes #8210

I am a full-stack developer intern, passionate about contributing to the open-source community and giving back to the tools I love. I have reviewed and understood all the code changes in this PR, which I verified with unit tests, type checks, and lint.