### PR TITLE
feat(coding-agent): add permanent contribution reminders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a permanent self-fix contribution reminder to every welcome screen and after startup changelog output following updates.
+
 ## [17.2.14] - 2026-08-11
 
 ### Added

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -9,6 +9,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import { theme } from "../../modes/theme/theme";
+import { CONTRIBUTION_REMINDER } from "../../utils/contribution";
 import tipsText from "./tips.txt" with { type: "text" };
 
 /** Tips embedded at build time, one per line; blanks dropped. */
@@ -82,14 +83,28 @@ function renderNewTag(phase: number, encoding: ColorEncoding): string {
 	}
 	return out + reset;
 }
-export function renderWelcomeTip(tip: string, boxWidth: number, phase = 0): string[] {
-	const label = "Tip: ";
+const MIN_LABELED_BODY_WIDTH = 8;
+const MIN_INLINE_LABELED_BODY_WIDTH = 10;
+
+function renderLabeledMessage(label: string, body: string, boxWidth: number, stackLabelWhenNarrow = false): string[] {
 	const labelWidth = visibleWidth(label);
 	const bodyBudget = boxWidth - 1 - labelWidth; // 1 = leading indent
-	if (bodyBudget < 8) return [];
+	const requiresStackedLabel = stackLabelWhenNarrow && bodyBudget < MIN_INLINE_LABELED_BODY_WIDTH;
+	if (bodyBudget < MIN_LABELED_BODY_WIDTH || requiresStackedLabel) {
+		if (!stackLabelWhenNarrow) return [];
 
-	const isNew = NEW_TIP_MARKER.test(tip);
-	const body = isNew ? tip.replace(NEW_TIP_MARKER, "") : tip;
+		const stackedLabel = label.trimEnd();
+		const stackedBodyBudget = boxWidth - 1; // 1 = leading indent
+		if (stackedBodyBudget < MIN_LABELED_BODY_WIDTH || visibleWidth(stackedLabel) > stackedBodyBudget) return [];
+
+		const wrappedBody = wrapTextWithAnsi(replaceTabs(body), stackedBodyBudget);
+		if (wrappedBody.length === 0) return [];
+
+		return [
+			` ${theme.italic(theme.fg("customMessageLabel", stackedLabel))}`,
+			...wrappedBody.map(line => ` ${theme.italic(theme.fg("muted", line))}`),
+		];
+	}
 
 	const wrappedBody = wrapTextWithAnsi(replaceTabs(body), bodyBudget);
 	if (wrappedBody.length === 0) return [];
@@ -100,11 +115,19 @@ export function renderWelcomeTip(tip: string, boxWidth: number, phase = 0): stri
 	const continuationIndent = padding(labelWidth);
 	const styledLabel = theme.fg("customMessageLabel", label);
 
-	const lines = wrappedBody.map((line, index) => {
+	return wrappedBody.map((line, index) => {
 		const styledBody = theme.fg("muted", line);
 		const content = index === 0 ? `${styledLabel}${styledBody}` : `${continuationIndent}${styledBody}`;
 		return ` ${theme.italic(content)}`;
 	});
+}
+
+export function renderWelcomeTip(tip: string, boxWidth: number, phase = 0): string[] {
+	const label = "Tip: ";
+	const isNew = NEW_TIP_MARKER.test(tip);
+	const body = isNew ? tip.replace(NEW_TIP_MARKER, "") : tip;
+	const lines = renderLabeledMessage(label, body, boxWidth);
+	if (lines.length === 0) return [];
 
 	if (isNew) {
 		// Append the rainbow tag to the final body line when it fits within the
@@ -117,7 +140,7 @@ export function renderWelcomeTip(tip: string, boxWidth: number, phase = 0): stri
 		if (lastLine !== undefined && visibleWidth(lastLine) + tagWidth <= boxWidth) {
 			lines[lines.length - 1] = `${lastLine} ${tag}`;
 		} else {
-			lines.push(` ${continuationIndent}${tag}`);
+			lines.push(` ${padding(visibleWidth(label))}${tag}`);
 		}
 	}
 
@@ -383,8 +406,9 @@ export class WelcomeComponent implements Component {
 			lines.push(bl + h.repeat(leftCol) + br);
 		}
 
-		// Randomly picked tip, rendered directly beneath the box.
+		// Randomly picked tip with the permanent contribution reminder directly beneath it.
 		lines.push(...this.#renderTip(boxWidth));
+		lines.push(...renderLabeledMessage("Contribute: ", CONTRIBUTION_REMINDER, boxWidth, true));
 
 		return lines;
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -131,7 +131,7 @@ import {
 } from "../tools/todo";
 import { vocalizer } from "../tts/vocalizer";
 import { renderTreeList } from "../tui/tree-list";
-import { formatStartupChangelogSummary, type StartupChangelogSelection } from "../utils/changelog";
+import { formatStartupChangelogForDisplay, type StartupChangelogSelection } from "../utils/changelog";
 import { copyToClipboard } from "../utils/clipboard";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
@@ -1015,18 +1015,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 
 			// Add changelog if provided
-			if (this.#startupChangelog && settings.get("startup.changelogMode") !== "hidden") {
+			const changelogMode = settings.get("startup.changelogMode");
+			if (this.#startupChangelog && changelogMode !== "hidden") {
 				this.ui.addChild(new DynamicBorder());
 				this.ui.addChild(new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0));
 				this.ui.addChild(new Spacer(1));
-				if (settings.get("startup.changelogMode") === "summary") {
-					const summary = formatStartupChangelogSummary(this.#startupChangelog).replace(
-						/\/changelog(?: full)?/g,
-						command => theme.bold(command),
-					);
+				const changelog = formatStartupChangelogForDisplay(this.#startupChangelog, changelogMode);
+				if (changelogMode === "summary") {
+					const summary = changelog.replace(/\/changelog(?: full)?/g, command => theme.bold(command));
 					this.ui.addChild(new Text(summary, 1, 0));
 				} else {
-					this.ui.addChild(new Markdown(this.#startupChangelog.markdown?.trim() ?? "", 1, 0, getMarkdownTheme()));
+					this.ui.addChild(new Markdown(changelog, 1, 0, getMarkdownTheme()));
 				}
 				this.ui.addChild(new Spacer(1));
 				this.ui.addChild(new DynamicBorder());

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { getLastChangelogVersionPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import bundledChangelogPath from "../../CHANGELOG.md" with { type: "file" };
 import type { SettingValue } from "../config/settings";
+import { appendContributionReminder } from "./contribution";
 
 export interface ChangelogEntry {
 	major: number;
@@ -124,6 +125,15 @@ export function formatStartupChangelogSummary(selection: StartupChangelogSelecti
 			: "Use /changelog for details.";
 
 	return breakdown ? `${firstLine}\n${breakdown} · ${detailHint}` : `${firstLine}\n${detailHint}`;
+}
+
+/** Format the selected startup changelog mode with the permanent contribution reminder. */
+export function formatStartupChangelogForDisplay(
+	selection: StartupChangelogSelection,
+	mode: "summary" | "expanded",
+): string {
+	const content = mode === "summary" ? formatStartupChangelogSummary(selection) : (selection.markdown ?? "");
+	return appendContributionReminder(content);
 }
 
 /**

--- a/packages/coding-agent/src/utils/contribution.ts
+++ b/packages/coding-agent/src/utils/contribution.ts
@@ -1,0 +1,9 @@
+export const CONTRIBUTION_REMINDER = "Something broken? Ask your agent to fix it and submit a PR.";
+
+export function appendContributionReminder(content: string): string {
+	const trimmedContent = content.trimEnd();
+	if (trimmedContent.endsWith(CONTRIBUTION_REMINDER)) {
+		return trimmedContent;
+	}
+	return `${trimmedContent}\n\n${CONTRIBUTION_REMINDER}`;
+}

--- a/packages/coding-agent/src/utils/contribution.ts
+++ b/packages/coding-agent/src/utils/contribution.ts
@@ -1,7 +1,7 @@
 export const CONTRIBUTION_REMINDER = "Something broken? Ask your agent to fix it and submit a PR.";
 
 export function appendContributionReminder(content: string): string {
-	const trimmedContent = content.trimEnd();
+	const trimmedContent = content.trim();
 	if (trimmedContent.endsWith(CONTRIBUTION_REMINDER)) {
 		return trimmedContent;
 	}

--- a/packages/coding-agent/test/modes/components/welcome.test.ts
+++ b/packages/coding-agent/test/modes/components/welcome.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { pickWeightedTip, WelcomeComponent } from "@oh-my-pi/pi-coding-agent/modes/components/welcome";
+import {
+	pickWeightedTip,
+	renderWelcomeTip,
+	WelcomeComponent,
+} from "@oh-my-pi/pi-coding-agent/modes/components/welcome";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { appendContributionReminder, CONTRIBUTION_REMINDER } from "@oh-my-pi/pi-coding-agent/utils/contribution";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 
 describe("WelcomeComponent tips", () => {
 	beforeAll(async () => {
@@ -36,6 +42,40 @@ describe("WelcomeComponent tips", () => {
 		expect(welcomeRegular.tip).toBeDefined();
 	});
 
+	it("keeps the complete contribution reminder directly after the rotating tip at boundary widths", () => {
+		vi.spyOn(theme, "getSymbolPreset").mockReturnValue("nerd");
+		const random = vi.spyOn(Math, "random");
+
+		for (const termWidth of [16, 22, 23, 80]) {
+			for (const sample of [0, 0.25, 0.5, 0.75, 0.999_999]) {
+				random.mockReturnValue(sample);
+				const welcome = new WelcomeComponent("1.0.0", "model", "provider");
+				const lines = welcome.render(termWidth);
+				const plain = lines.map(line => Bun.stripANSI(line));
+				const tipStart = plain.findIndex(line => /^\s*Tip: /.test(line));
+				const contributionStart = plain.findIndex(line => line.includes("Contribute:"));
+
+				expect(tipStart).toBeGreaterThanOrEqual(0);
+				expect(contributionStart).toBeGreaterThan(tipStart);
+
+				const expectedTip = renderWelcomeTip(welcome.tip ?? "", termWidth - 2).map(line => Bun.stripANSI(line));
+				expect(plain.slice(tipStart, contributionStart)).toEqual(expectedTip);
+				expect(
+					plain
+						.slice(contributionStart)
+						.map(line => line.trim())
+						.join(" "),
+				).toBe(`Contribute: ${CONTRIBUTION_REMINDER}`);
+				if (termWidth === 80) {
+					expect(plain[contributionStart]).toMatch(/^\s*Contribute: Something broken\?/);
+				}
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(termWidth);
+				}
+			}
+		}
+	});
+
 	it("weights [NEW] tips above ordinary tips in selection", () => {
 		// Data-independent: tips.txt may legitimately carry zero "[NEW]" tips, so
 		// exercise the weighting contract on a synthetic list.
@@ -60,5 +100,17 @@ describe("WelcomeComponent tips", () => {
 		expect(newMax).toBeGreaterThan(0);
 		expect(newMax).toBeGreaterThan(ordinaryMax);
 		expect(pickWeightedTip([], 0.5)).toBe("");
+	});
+});
+
+describe("contribution reminder", () => {
+	it("exposes the exact shared reminder text", () => {
+		expect(CONTRIBUTION_REMINDER).toBe("Something broken? Ask your agent to fix it and submit a PR.");
+	});
+
+	it("trims only trailing whitespace before appending a blank line and the reminder", () => {
+		expect(appendContributionReminder("  Startup changes stay indented.  \n\t")).toBe(
+			`  Startup changes stay indented.\n\n${CONTRIBUTION_REMINDER}`,
+		);
 	});
 });

--- a/packages/coding-agent/test/modes/components/welcome.test.ts
+++ b/packages/coding-agent/test/modes/components/welcome.test.ts
@@ -104,13 +104,9 @@ describe("WelcomeComponent tips", () => {
 });
 
 describe("contribution reminder", () => {
-	it("exposes the exact shared reminder text", () => {
-		expect(CONTRIBUTION_REMINDER).toBe("Something broken? Ask your agent to fix it and submit a PR.");
-	});
-
-	it("trims only trailing whitespace before appending a blank line and the reminder", () => {
-		expect(appendContributionReminder("  Startup changes stay indented.  \n\t")).toBe(
-			`  Startup changes stay indented.\n\n${CONTRIBUTION_REMINDER}`,
+	it("trims leading and trailing whitespace before appending a blank line and the reminder", () => {
+		expect(appendContributionReminder("  Startup changes.  \n\t")).toBe(
+			`Startup changes.\n\n${CONTRIBUTION_REMINDER}`,
 		);
 	});
 });

--- a/packages/coding-agent/test/utils/changelog.test.ts
+++ b/packages/coding-agent/test/utils/changelog.test.ts
@@ -18,6 +18,7 @@ import { removeWithRetries, VERSION } from "@oh-my-pi/pi-utils";
 import { SETTINGS_SCHEMA, Settings } from "../../src/config/settings";
 import {
 	type ChangelogEntry,
+	formatStartupChangelogForDisplay,
 	formatStartupChangelogSummary,
 	getNewEntries,
 	parseChangelog,
@@ -30,6 +31,7 @@ import {
 	selectStartupChangelog,
 	writeLastChangelogVersion,
 } from "../../src/utils/changelog";
+import { appendContributionReminder, CONTRIBUTION_REMINDER } from "../../src/utils/contribution";
 
 const CURRENT_VERSION = "2.0.0";
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
@@ -225,6 +227,43 @@ describe("formatStartupChangelogSummary", () => {
 		expect(formatStartupChangelogSummary(selection)).toBe(
 			["Updated to v2.0.0 · 1 change in 1 release", "1 breaking change · Use /changelog for details."].join("\n"),
 		);
+	});
+});
+
+describe("formatStartupChangelogForDisplay", () => {
+	test("ends summary startup output with the shared reminder exactly once", () => {
+		const selection = selectStartupChangelog([release(2, 0, 0, "### Added\n\n- Current release.")], "1.0.0", "2.0.0");
+
+		const output = formatStartupChangelogForDisplay(selection, "summary");
+
+		expect(output).toBe(
+			[
+				"Updated to v2.0.0 · 1 change in 1 release",
+				"1 added · Use /changelog for details.",
+				"",
+				CONTRIBUTION_REMINDER,
+			].join("\n"),
+		);
+		expect(output.split(CONTRIBUTION_REMINDER)).toHaveLength(2);
+	});
+
+	test("ends expanded startup output with the shared reminder exactly once", () => {
+		const selection = selectStartupChangelog([release(2, 0, 0, "### Added\n\n- Current release.")], "1.0.0", "2.0.0");
+
+		const output = formatStartupChangelogForDisplay(selection, "expanded");
+
+		expect(output).toBe(`${selection.markdown}\n\n${CONTRIBUTION_REMINDER}`);
+		expect(output.split(CONTRIBUTION_REMINDER)).toHaveLength(2);
+	});
+
+	test("keeps exactly one shared reminder after repeated application", () => {
+		const selection = selectStartupChangelog([release(2, 0, 0, "### Added\n\n- Current release.")], "1.0.0", "2.0.0");
+		const formatted = formatStartupChangelogForDisplay(selection, "expanded");
+
+		const repeated = appendContributionReminder(formatted);
+
+		expect(repeated).toBe(formatted);
+		expect(repeated.split(CONTRIBUTION_REMINDER)).toHaveLength(2);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Add a permanent `Contribute:` reminder beneath the rotating welcome tip.
- Repeat the reminder after startup release notes in summary and expanded modes.
- Keep hidden startup changelogs and explicit `/changelog` output unchanged.
- Preserve the complete reminder on narrow terminals with a stacked label layout.

## Rationale

OMP changes quickly. Users who find broken behavior should have a continuous reminder that they can ask their agent to fix it and submit a pull request immediately. A permanent reminder is more reliable than adding one more rotating tip.

## Maintainer decision

This intentionally changes the default welcome and post-update experience without an opt-out. Review requested from @can1357: should this reminder remain always on, or should it be gated behind a setting?

## Validation

- `bun test packages/coding-agent/test/modes/components/welcome.test.ts packages/coding-agent/test/welcome-tip.test.ts packages/coding-agent/test/utils/changelog.test.ts` — 29 passed, 1 skipped, 0 failed
- `bun --cwd=packages/coding-agent run check:types` — passed
- Biome check on all changed TypeScript files — passed
