### PR TITLE
fix(ai): release provider permit before stream completion

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed completed model streams retaining their provider concurrency permit until after completion became observable, without replacing provider results when lease cleanup fails ([#8284](https://github.com/can1357/oh-my-pi/pull/8284) by [@ethancawse](https://github.com/ethancawse)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Fixed
 
 - Fixed an issue where AWS_BEDROCK_SKIP_AUTH failed to expose Amazon Bedrock models when AWS credential files were unavailable.
 - Fixed an issue where forceReasoningOff was ignored by Anthropic and Google transports, which allowed native thinking alongside a caller-supplied external scratchpad.
-### Fixed
-
-- Fixed completed model streams retaining their provider concurrency permit until after completion became observable, without replacing provider results when lease cleanup fails ([#8284](https://github.com/can1357/oh-my-pi/pull/8284) by [@ethancawse](https://github.com/ethancawse)).
 
 ## [17.2.14] - 2026-08-11
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Fixed an issue where AWS_BEDROCK_SKIP_AUTH failed to expose Amazon Bedrock models when AWS credential files were unavailable.
 - Fixed an issue where forceReasoningOff was ignored by Anthropic and Google transports, which allowed native thinking alongside a caller-supplied external scratchpad.
+### Fixed
+
+- Fixed completed model streams retaining their provider concurrency permit until after completion became observable ([#8284](https://github.com/can1357/oh-my-pi/pull/8284) by [@ethancawse](https://github.com/ethancawse)).
 
 ## [17.2.14] - 2026-08-11
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed an issue where forceReasoningOff was ignored by Anthropic and Google transports, which allowed native thinking alongside a caller-supplied external scratchpad.
 ### Fixed
 
-- Fixed completed model streams retaining their provider concurrency permit until after completion became observable ([#8284](https://github.com/can1357/oh-my-pi/pull/8284) by [@ethancawse](https://github.com/ethancawse)).
+- Fixed completed model streams retaining their provider concurrency permit until after completion became observable, without replacing provider results when lease cleanup fails ([#8284](https://github.com/can1357/oh-my-pi/pull/8284) by [@ethancawse](https://github.com/ethancawse)).
 
 ## [17.2.14] - 2026-08-11
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -442,7 +442,10 @@ async function tryAcquireProviderInFlightLease(
 			heartbeatFlush = heartbeatFlush
 				.then(async () => {
 					if (!heartbeatActive) return;
-					const write = () => writeProviderInFlightInfo(leaseDir, token);
+					const write = () => {
+						if (!heartbeatActive) return Promise.resolve();
+						return writeProviderInFlightInfo(leaseDir, token);
+					};
 					if (providerInFlightHeartbeatWriterOverride) {
 						await providerInFlightHeartbeatWriterOverride(write);
 					} else {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -658,7 +658,9 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 			try {
 				await releaseOnce();
 			} catch (releaseError) {
-				// The lease has stopped heartbeating and stale cleanup will reap it.
+				// The lease has stopped heartbeating and stale cleanup will reap it
+				// within PROVIDER_INFLIGHT_LEASE_STALE_MS. Until then, its slot may
+				// remain unavailable and waiters rely on the fallback poll.
 				// Never replace a completed response or the provider's original error
 				// with a coordination-directory cleanup failure.
 				logger.warn("Provider in-flight permit release failed", {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -186,6 +186,7 @@ let providerInFlightHeartbeatFlushTimeoutMsOverride: number | undefined;
 let providerInFlightHeartbeatWriterOverride:
 	| ((writeProviderInFlightInfo: () => Promise<void>) => Promise<void>)
 	| undefined;
+let providerInFlightLeaseRemoverOverride: ((leasePath: string) => Promise<void>) | undefined;
 
 export function configureProviderMaxInFlightRequests(limits: Record<string, number> | undefined): void {
 	configuredProviderMaxInFlightRequests = limits ?? {};
@@ -566,7 +567,8 @@ async function releaseProviderInFlightLease(lease: ProviderInFlightLease): Promi
 	);
 	releaseTimer.unref?.();
 	try {
-		await Promise.race([removeProviderInFlightLeaseDir(lease.path), releaseTimeout.promise]);
+		const removeLease = providerInFlightLeaseRemoverOverride ?? removeProviderInFlightLeaseDir;
+		await Promise.race([removeLease(lease.path), releaseTimeout.promise]);
 	} finally {
 		clearTimeout(releaseTimer);
 	}
@@ -604,6 +606,9 @@ export const __providerInFlightForTesting = {
 	},
 	setHeartbeatWriter(writer: ((writeProviderInFlightInfo: () => Promise<void>) => Promise<void>) | undefined): void {
 		providerInFlightHeartbeatWriterOverride = writer;
+	},
+	setLeaseRemover(remover: ((leasePath: string) => Promise<void>) | undefined): void {
+		providerInFlightLeaseRemoverOverride = remover;
 	},
 	providerDir(provider: string): string {
 		return providerInFlightDir(provider);
@@ -649,6 +654,19 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 			releasePromise ??= release();
 			return releasePromise;
 		};
+		const releaseBestEffort = async () => {
+			try {
+				await releaseOnce();
+			} catch (releaseError) {
+				// The lease has stopped heartbeating and stale cleanup will reap it.
+				// Never replace a completed response or the provider's original error
+				// with a coordination-directory cleanup failure.
+				logger.warn("Provider in-flight permit release failed", {
+					provider: model.provider,
+					error: String(releaseError),
+				});
+			}
+		};
 		try {
 			const startedWaitingAt = Date.now();
 			release = await acquireProviderInFlightSlot(model.provider, limit, options?.signal);
@@ -663,11 +681,11 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 			for await (const event of inner) {
 				if (event.type === "done" || event.type === "error") {
 					terminalEvent = event;
-					continue;
+					break;
 				}
 				outer.push(event);
 				if (outer.done) {
-					await releaseOnce();
+					await releaseBestEffort();
 					return;
 				}
 			}
@@ -675,23 +693,14 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 			// Releasing the permit is part of request completion. Publishing the
 			// result first lets an immediate follow-up turn contend with its own
 			// still-live lease, which is particularly costly on Windows.
-			await releaseOnce();
+			await releaseBestEffort();
 			if (!outer.done) {
 				if (terminalEvent) outer.push(terminalEvent);
 				else outer.end(result);
 			}
 		} catch (error) {
-			let failure = error;
-			try {
-				await releaseOnce();
-			} catch (releaseError) {
-				logger.warn("Provider in-flight permit release failed", {
-					provider: model.provider,
-					error: String(releaseError),
-				});
-				failure = releaseError;
-			}
-			if (!outer.done) outer.fail(failure);
+			await releaseBestEffort();
+			if (!outer.done) outer.fail(error);
 		}
 	})();
 	return outer;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -161,8 +161,7 @@ function healLeakedThinking(model: Model<Api>, inner: AssistantMessageEventStrea
 
 type ProviderInFlightLease = {
 	path: string;
-	heartbeat: NodeJS.Timeout;
-	flushHeartbeat: () => Promise<void>;
+	stopHeartbeat: () => Promise<void>;
 };
 
 type ProviderInFlightLeaseInfo = {
@@ -182,6 +181,11 @@ const PROVIDER_INFLIGHT_RELEASE_TIMEOUT_MS = 5_000;
 
 let configuredProviderMaxInFlightRequests: Record<string, number> = {};
 let providerInFlightRootOverride: string | undefined;
+let providerInFlightHeartbeatMsOverride: number | undefined;
+let providerInFlightHeartbeatFlushTimeoutMsOverride: number | undefined;
+let providerInFlightHeartbeatWriterOverride:
+	| ((writeProviderInFlightInfo: () => Promise<void>) => Promise<void>)
+	| undefined;
 
 export function configureProviderMaxInFlightRequests(limits: Record<string, number> | undefined): void {
 	configuredProviderMaxInFlightRequests = limits ?? {};
@@ -248,7 +252,9 @@ async function writeProviderInFlightInfo(dir: string, token: string): Promise<vo
 	const infoPath = path.join(dir, "info.json");
 	const tempPath = path.join(dir, `.info-${process.pid}-${crypto.randomUUID()}.tmp`);
 	try {
-		await Bun.write(tempPath, JSON.stringify(info));
+		// Unlike Bun.write, fs.writeFile does not recreate a lease directory that
+		// was removed while a timed-out heartbeat was still pending.
+		await fs.writeFile(tempPath, JSON.stringify(info), "utf8");
 		await fs.rename(tempPath, infoPath);
 	} catch (error) {
 		await fs.rm(tempPath, { force: true }).catch(() => {});
@@ -428,18 +434,35 @@ async function tryAcquireProviderInFlightLease(
 			await removeProviderInFlightLeaseDir(leaseDir).catch(() => {});
 			throw error;
 		}
+		let heartbeatActive = true;
 		let heartbeatFlush = Promise.resolve();
 		const touchHeartbeat = () => {
+			if (!heartbeatActive) return;
 			heartbeatFlush = heartbeatFlush
-				.then(
-					() => writeProviderInFlightInfo(leaseDir, token),
-					() => writeProviderInFlightInfo(leaseDir, token),
-				)
+				.then(async () => {
+					if (!heartbeatActive) return;
+					const write = () => writeProviderInFlightInfo(leaseDir, token);
+					if (providerInFlightHeartbeatWriterOverride) {
+						await providerInFlightHeartbeatWriterOverride(write);
+					} else {
+						await write();
+					}
+				})
 				.catch(() => {});
 		};
-		const heartbeat = setInterval(touchHeartbeat, PROVIDER_INFLIGHT_HEARTBEAT_MS);
+		const heartbeat = setInterval(
+			touchHeartbeat,
+			providerInFlightHeartbeatMsOverride ?? PROVIDER_INFLIGHT_HEARTBEAT_MS,
+		);
 		heartbeat.unref?.();
-		return { path: leaseDir, heartbeat, flushHeartbeat: () => heartbeatFlush };
+		return {
+			path: leaseDir,
+			stopHeartbeat: () => {
+				heartbeatActive = false;
+				clearInterval(heartbeat);
+				return heartbeatFlush;
+			},
+		};
 	} finally {
 		await releaseLock();
 	}
@@ -520,12 +543,15 @@ async function removeProviderInFlightLeaseDir(leasePath: string): Promise<void> 
 // the in-flight root has been repointed (only the test seam does that) must not
 // write `.wakeup` into an unrelated provider directory.
 async function releaseProviderInFlightLease(lease: ProviderInFlightLease): Promise<void> {
-	clearInterval(lease.heartbeat);
+	const heartbeatFlush = lease.stopHeartbeat();
 	const flushTimeout = Promise.withResolvers<"timeout">();
-	const flushTimer = setTimeout(() => flushTimeout.resolve("timeout"), PROVIDER_INFLIGHT_HEARTBEAT_FLUSH_TIMEOUT_MS);
+	const flushTimer = setTimeout(
+		() => flushTimeout.resolve("timeout"),
+		providerInFlightHeartbeatFlushTimeoutMsOverride ?? PROVIDER_INFLIGHT_HEARTBEAT_FLUSH_TIMEOUT_MS,
+	);
 	flushTimer.unref?.();
 	try {
-		const outcome = await Promise.race([lease.flushHeartbeat().then(() => "flushed" as const), flushTimeout.promise]);
+		const outcome = await Promise.race([heartbeatFlush.then(() => "flushed" as const), flushTimeout.promise]);
 		if (outcome === "timeout") {
 			logger.warn("Provider in-flight heartbeat flush timed out; forcing lease cleanup", { path: lease.path });
 		}
@@ -571,6 +597,13 @@ async function acquireProviderInFlightSlot(
 export const __providerInFlightForTesting = {
 	setRoot(root: string | undefined): void {
 		providerInFlightRootOverride = root;
+	},
+	setHeartbeatTimings(timings: { heartbeatMs?: number; heartbeatFlushTimeoutMs?: number } | undefined): void {
+		providerInFlightHeartbeatMsOverride = timings?.heartbeatMs;
+		providerInFlightHeartbeatFlushTimeoutMsOverride = timings?.heartbeatFlushTimeoutMs;
+	},
+	setHeartbeatWriter(writer: ((writeProviderInFlightInfo: () => Promise<void>) => Promise<void>) | undefined): void {
+		providerInFlightHeartbeatWriterOverride = writer;
 	},
 	providerDir(provider: string): string {
 		return providerInFlightDir(provider);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -177,6 +177,8 @@ const PROVIDER_INFLIGHT_LOCK_STALE_MS = 10_000;
 const PROVIDER_INFLIGHT_LEASE_STALE_MS = 30_000;
 const PROVIDER_INFLIGHT_HEARTBEAT_MS = 5_000;
 const PROVIDER_INFLIGHT_SIGNAL_FALLBACK_MS = 250;
+const PROVIDER_INFLIGHT_HEARTBEAT_FLUSH_TIMEOUT_MS = 1_000;
+const PROVIDER_INFLIGHT_RELEASE_TIMEOUT_MS = 5_000;
 
 let configuredProviderMaxInFlightRequests: Record<string, number> = {};
 let providerInFlightRootOverride: string | undefined;
@@ -519,9 +521,32 @@ async function removeProviderInFlightLeaseDir(leasePath: string): Promise<void> 
 // write `.wakeup` into an unrelated provider directory.
 async function releaseProviderInFlightLease(lease: ProviderInFlightLease): Promise<void> {
 	clearInterval(lease.heartbeat);
-	await lease.flushHeartbeat();
-	await removeProviderInFlightLeaseDir(lease.path);
-	await signalProviderInFlightWaitersInDir(path.dirname(lease.path));
+	const flushTimeout = Promise.withResolvers<"timeout">();
+	const flushTimer = setTimeout(() => flushTimeout.resolve("timeout"), PROVIDER_INFLIGHT_HEARTBEAT_FLUSH_TIMEOUT_MS);
+	flushTimer.unref?.();
+	try {
+		const outcome = await Promise.race([lease.flushHeartbeat().then(() => "flushed" as const), flushTimeout.promise]);
+		if (outcome === "timeout") {
+			logger.warn("Provider in-flight heartbeat flush timed out; forcing lease cleanup", { path: lease.path });
+		}
+	} finally {
+		clearTimeout(flushTimer);
+	}
+
+	const releaseTimeout = Promise.withResolvers<never>();
+	const releaseTimer = setTimeout(
+		() => releaseTimeout.reject(new Error("Provider in-flight lease cleanup timed out")),
+		PROVIDER_INFLIGHT_RELEASE_TIMEOUT_MS,
+	);
+	releaseTimer.unref?.();
+	try {
+		await Promise.race([removeProviderInFlightLeaseDir(lease.path), releaseTimeout.promise]);
+	} finally {
+		clearTimeout(releaseTimer);
+	}
+	// Wake-up is an optimization: waiters also poll every 250 ms. Do not let a
+	// notification-file stall keep a completed provider request open.
+	void signalProviderInFlightWaitersInDir(path.dirname(lease.path));
 }
 
 async function acquireProviderInFlightSlot(
@@ -585,11 +610,11 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 	const outer = new AssistantMessageEventStream();
 	void (async () => {
 		let release: (() => Promise<void>) | undefined;
-		let released = false;
-		const releaseOnce = async () => {
-			if (!release || released) return;
-			released = true;
-			await release();
+		let releasePromise: Promise<void> | undefined;
+		const releaseOnce = () => {
+			if (!release) return Promise.resolve();
+			releasePromise ??= release();
+			return releasePromise;
 		};
 		try {
 			const startedWaitingAt = Date.now();
@@ -601,18 +626,39 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 				throw options.signal.reason ?? new AIError.AbortError("Provider request aborted before dispatch");
 			}
 			const inner = healLeakedThinking(model, dispatch());
-			try {
-				for await (const event of inner) {
-					outer.push(event);
-					if (outer.done) return;
+			let terminalEvent: AssistantMessageEvent | undefined;
+			for await (const event of inner) {
+				if (event.type === "done" || event.type === "error") {
+					terminalEvent = event;
+					continue;
 				}
-				if (!outer.done) outer.end(await inner.result());
-			} finally {
-				await releaseOnce();
+				outer.push(event);
+				if (outer.done) {
+					await releaseOnce();
+					return;
+				}
+			}
+			const result = await inner.result();
+			// Releasing the permit is part of request completion. Publishing the
+			// result first lets an immediate follow-up turn contend with its own
+			// still-live lease, which is particularly costly on Windows.
+			await releaseOnce();
+			if (!outer.done) {
+				if (terminalEvent) outer.push(terminalEvent);
+				else outer.end(result);
 			}
 		} catch (error) {
-			await releaseOnce();
-			if (!outer.done) outer.fail(error);
+			let failure = error;
+			try {
+				await releaseOnce();
+			} catch (releaseError) {
+				logger.warn("Provider in-flight permit release failed", {
+					provider: model.provider,
+					error: String(releaseError),
+				});
+				failure = releaseError;
+			}
+			if (!outer.done) outer.fail(failure);
 		}
 	})();
 	return outer;

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -85,6 +85,18 @@ describe("provider in-flight request limits", () => {
 		expect(mock.calls).toHaveLength(2);
 	});
 
+	test("releases its provider lease before reporting stream completion", async () => {
+		registerMockApi();
+		const mock = createMockModel({ provider: "tests", responses: [{ content: ["reply"] }] });
+
+		const stream = streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } });
+		const result = await stream.result();
+
+		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+		const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
+		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
+	});
+
 	test("removes an aborted queued request without dispatching it", async () => {
 		registerMockApi();
 		const firstStarted = Promise.withResolvers<void>();

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -26,6 +26,7 @@ afterEach(async () => {
 	__providerInFlightForTesting.setRoot(undefined);
 	__providerInFlightForTesting.setHeartbeatTimings(undefined);
 	__providerInFlightForTesting.setHeartbeatWriter(undefined);
+	__providerInFlightForTesting.setLeaseRemover(undefined);
 	if (limiterRoot !== undefined) {
 		await fs.rm(limiterRoot, { recursive: true, force: true });
 		limiterRoot = undefined;
@@ -87,16 +88,60 @@ describe("provider in-flight request limits", () => {
 		expect(mock.calls).toHaveLength(2);
 	});
 
-	test("releases its provider lease before reporting stream completion", async () => {
+	test("releases its provider lease before reporting terminal completion", async () => {
 		registerMockApi();
 		const mock = createMockModel({ provider: "tests", responses: [{ content: ["reply"] }] });
 
 		const stream = streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } });
-		const result = await stream.result();
+		const terminalObservation = (async () => {
+			for await (const event of stream) {
+				if (event.type !== "done" && event.type !== "error") continue;
+				const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
+				return entries.filter(entry => entry.isDirectory()).length;
+			}
+			return undefined;
+		})();
+		const [result, leasesAtTerminal] = await Promise.all([stream.result(), terminalObservation]);
+
+		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+		expect(leasesAtTerminal).toBe(0);
+	});
+
+	test("keeps a completed response when provider lease removal fails", async () => {
+		registerMockApi();
+		__providerInFlightForTesting.setLeaseRemover(async () => {
+			throw Object.assign(new Error("simulated lease removal failure"), { code: "EBUSY" });
+		});
+		const mock = createMockModel({ provider: "tests", responses: [{ content: ["reply"] }] });
+
+		const result = await streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } }).result();
 
 		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
 		const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
-		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
+		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(1);
+	});
+
+	test("preserves a provider failure when provider lease removal also fails", async () => {
+		registerMockApi();
+		__providerInFlightForTesting.setLeaseRemover(async () => {
+			throw Object.assign(new Error("simulated lease removal failure"), { code: "EBUSY" });
+		});
+		const mock = createMockModel({
+			provider: "tests",
+			handler: async () => {
+				throw new Error("PROVIDER-ORIGINAL-ERROR");
+			},
+		});
+
+		const outcome = await streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } })
+			.result()
+			.then(
+				message => message.errorMessage ?? JSON.stringify(message.content),
+				error => String(error),
+			);
+
+		expect(outcome).toContain("PROVIDER-ORIGINAL-ERROR");
+		expect(outcome).not.toContain("simulated lease removal failure");
 	});
 
 	test("does not recreate a released lease when a heartbeat outlives its flush timeout", async () => {

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -90,21 +90,51 @@ describe("provider in-flight request limits", () => {
 
 	test("releases its provider lease before reporting terminal completion", async () => {
 		registerMockApi();
+		const removalStarted = Promise.withResolvers<void>();
+		const allowRemoval = Promise.withResolvers<void>();
+		__providerInFlightForTesting.setLeaseRemover(async leasePath => {
+			removalStarted.resolve();
+			await allowRemoval.promise;
+			await fs.rm(leasePath, { recursive: true, force: true });
+		});
 		const mock = createMockModel({ provider: "tests", responses: [{ content: ["reply"] }] });
 
 		const stream = streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } });
+		const terminalObserved = Promise.withResolvers<"done" | "error">();
 		const terminalObservation = (async () => {
 			for await (const event of stream) {
 				if (event.type !== "done" && event.type !== "error") continue;
-				const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
-				return entries.filter(entry => entry.isDirectory()).length;
+				terminalObserved.resolve(event.type);
+				return event.type;
 			}
 			return undefined;
 		})();
-		const [result, leasesAtTerminal] = await Promise.all([stream.result(), terminalObservation]);
+		const resultPromise = stream.result();
+		const removalOutcome = await Promise.race([
+			removalStarted.promise.then(() => "started" as const),
+			Bun.sleep(2_000).then(() => "blocked" as const),
+		]);
+		if (removalOutcome === "blocked") {
+			allowRemoval.resolve();
+			throw new Error("Provider lease removal did not start");
+		}
+		let completionBeforeRelease: "terminal" | "result" | "pending";
+		try {
+			completionBeforeRelease = await Promise.race([
+				terminalObserved.promise.then(() => "terminal" as const),
+				resultPromise.then(() => "result" as const),
+				Bun.sleep(20).then(() => "pending" as const),
+			]);
+		} finally {
+			allowRemoval.resolve();
+		}
+		const [result, terminalType] = await Promise.all([resultPromise, terminalObservation]);
 
+		expect(completionBeforeRelease).toBe("pending");
 		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
-		expect(leasesAtTerminal).toBe(0);
+		expect(terminalType).toBe("done");
+		const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
+		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
 	});
 
 	test("keeps a completed response when provider lease removal fails", async () => {
@@ -193,6 +223,61 @@ describe("provider in-flight request limits", () => {
 		expect(heartbeatWrites).toBe(1);
 		const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
 		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
+	});
+
+	test("does not refresh a surviving lease after heartbeat shutdown", async () => {
+		registerMockApi();
+		const requestStarted = Promise.withResolvers<void>();
+		const finishRequest = Promise.withResolvers<void>();
+		const heartbeatStarted = Promise.withResolvers<void>();
+		const resumeHeartbeat = Promise.withResolvers<void>();
+		const heartbeatSettled = Promise.withResolvers<void>();
+		__providerInFlightForTesting.setHeartbeatTimings({ heartbeatMs: 5, heartbeatFlushTimeoutMs: 20 });
+		__providerInFlightForTesting.setHeartbeatWriter(async writeProviderInFlightInfo => {
+			heartbeatStarted.resolve();
+			await resumeHeartbeat.promise;
+			try {
+				await writeProviderInFlightInfo();
+			} finally {
+				heartbeatSettled.resolve();
+			}
+		});
+		__providerInFlightForTesting.setLeaseRemover(async () => {
+			throw Object.assign(new Error("simulated lease removal failure"), { code: "EBUSY" });
+		});
+		const mock = createMockModel({
+			provider: "tests",
+			handler: async () => {
+				requestStarted.resolve();
+				await finishRequest.promise;
+				return { content: ["reply"] };
+			},
+		});
+
+		const stream = streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } });
+		const resultPromise = stream.result();
+		const keepAlive = setInterval(() => {}, 1_000);
+		let infoPath: string;
+		let infoBeforeLateHeartbeat: string;
+		try {
+			await requestStarted.promise;
+			await heartbeatStarted.promise;
+			finishRequest.resolve();
+			const result = await resultPromise;
+			expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+			const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
+			const lease = entries.find(entry => entry.isDirectory());
+			if (!lease) throw new Error("Expected failed cleanup to leave a provider lease");
+			infoPath = path.join(limiterDir("tests"), lease.name, "info.json");
+			infoBeforeLateHeartbeat = await Bun.file(infoPath).text();
+		} finally {
+			clearInterval(keepAlive);
+			finishRequest.resolve();
+			resumeHeartbeat.resolve();
+		}
+		await heartbeatSettled.promise;
+
+		expect(await Bun.file(infoPath).text()).toBe(infoBeforeLateHeartbeat);
 	});
 
 	test("removes an aborted queued request without dispatching it", async () => {

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -24,6 +24,8 @@ afterEach(async () => {
 	clearCustomApis();
 	configureProviderMaxInFlightRequests(undefined);
 	__providerInFlightForTesting.setRoot(undefined);
+	__providerInFlightForTesting.setHeartbeatTimings(undefined);
+	__providerInFlightForTesting.setHeartbeatWriter(undefined);
 	if (limiterRoot !== undefined) {
 		await fs.rm(limiterRoot, { recursive: true, force: true });
 		limiterRoot = undefined;
@@ -93,6 +95,57 @@ describe("provider in-flight request limits", () => {
 		const result = await stream.result();
 
 		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+		const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
+		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
+	});
+
+	test("does not recreate a released lease when a heartbeat outlives its flush timeout", async () => {
+		registerMockApi();
+		const requestStarted = Promise.withResolvers<void>();
+		const finishRequest = Promise.withResolvers<void>();
+		const heartbeatStarted = Promise.withResolvers<void>();
+		const resumeHeartbeat = Promise.withResolvers<void>();
+		const heartbeatSettled = Promise.withResolvers<void>();
+		let heartbeatWrites = 0;
+		__providerInFlightForTesting.setHeartbeatTimings({ heartbeatMs: 5, heartbeatFlushTimeoutMs: 20 });
+		__providerInFlightForTesting.setHeartbeatWriter(async writeProviderInFlightInfo => {
+			heartbeatWrites++;
+			heartbeatStarted.resolve();
+			await resumeHeartbeat.promise;
+			try {
+				await writeProviderInFlightInfo();
+			} finally {
+				heartbeatSettled.resolve();
+			}
+		});
+		const mock = createMockModel({
+			provider: "tests",
+			handler: async () => {
+				requestStarted.resolve();
+				await finishRequest.promise;
+				return { content: ["reply"] };
+			},
+		});
+
+		const stream = streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } });
+		const resultPromise = stream.result();
+		const keepAlive = setInterval(() => {}, 1_000);
+		try {
+			await requestStarted.promise;
+			await heartbeatStarted.promise;
+			finishRequest.resolve();
+			const result = await resultPromise;
+			expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+			const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
+			expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
+		} finally {
+			clearInterval(keepAlive);
+			finishRequest.resolve();
+			resumeHeartbeat.resolve();
+		}
+		await heartbeatSettled.promise;
+
+		expect(heartbeatWrites).toBe(1);
 		const entries = await fs.readdir(limiterDir("tests"), { withFileTypes: true });
 		expect(entries.filter(entry => entry.isDirectory())).toHaveLength(0);
 	});


### PR DESCRIPTION
## Summary

Fix permit collision where model stream could be marked as completed before releasing its provider concurrency permit.

- Withhold terminal stream completion until the provider lease has been removed.
- Bound heartbeat flushing to 1 second and lease removal to 5 seconds.
- Make the best-effort waiter notification non-blocking.
- Surface permit-release failures instead of leaving the outer stream pending.
- Add a regression test asserting that no provider lease remains when `stream.result()` resolves.

## Verification

- `bun test packages/ai/test/provider-inflight.test.ts` — 12 passed
- `bun check` — passed on current upstream `main`
- Reproduced the old ordering by observing a live lease immediately after stream completion; the same check reports no lease after this change.
- Built the native Windows binary and completed a real Qwen 3.6 27B Q6 request through the local OpenAI-compatible runtime.