### PR TITLE
Fix open browser behaviour on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed open browser behaviour on Windows, OMP console no longer disappears on commands such as `/stats`
+
 ## [17.2.14] - 2026-08-11
 
 ### Added

--- a/packages/coding-agent/src/utils/open.ts
+++ b/packages/coding-agent/src/utils/open.ts
@@ -69,8 +69,6 @@ function windowsOpenerCommand(target: string): string[] {
 		powershell,
 		"-NoProfile",
 		"-NonInteractive",
-		"-WindowStyle",
-		"Hidden",
 		"-EncodedCommand",
 		Buffer.from(script, "utf16le").toString("base64"),
 	];
@@ -93,7 +91,12 @@ export function openPath(urlOrPath: string): void {
 	}
 	let child: Bun.Subprocess | undefined;
 	try {
-		child = Bun.spawn(cmd, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+		child = Bun.spawn(cmd, {
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+			windowsHide: process.platform === "win32",
+		});
 	} catch (error) {
 		// Spawn threw synchronously (missing binary, denied exec, sandbox
 		// restriction, …). Best-effort: log so the failure isn't invisible while

--- a/packages/coding-agent/test/utils/open.test.ts
+++ b/packages/coding-agent/test/utils/open.test.ts
@@ -159,13 +159,8 @@ describe("openPath", () => {
 			// on Windows boxes where the machine PATH no longer references
 			// System32.
 			expect(call?.cmd[0]).toBe(powershellPath);
-			expect(call?.cmd.slice(1, -1)).toEqual([
-				"-NoProfile",
-				"-NonInteractive",
-				"-WindowStyle",
-				"Hidden",
-				"-EncodedCommand",
-			]);
+			expect(call?.cmd.slice(1, -1)).toEqual(["-NoProfile", "-NonInteractive", "-EncodedCommand"]);
+			expect(call?.options.windowsHide).toBe(true);
 			// The target rides inside the UTF-16LE payload: no cmd/PowerShell
 			// metacharacter parsing ever sees the `&` in the query string, and the
 			// terminating error preference makes Start-Process failures exit 1 so


### PR DESCRIPTION
Executing an OMP command that opens a browser window (such as `/stats`) hides the OMP terminal because `-WindowStyle Hidden` also affects the inherited console.

## What

Instead of `-WindowStyle Hidden`, use Bun's `windowsHide` option. This keeps the browser-launch helper hidden while leaving the main OMP console visible.

## Why

n/a

## Testing

- `bun test packages/coding-agent/test/utils/open.test.ts` (7 passed)
- `bun --cwd=packages/coding-agent run check` (passed)
- Manual Windows test: `/stats` command

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
