### PR TITLE
fix(ai): stop stripping images from multimodal qwen3.8-max on DashScope

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the DashScope compatible-mode text-only Qwen override (issue #1859) stripping images from `qwen3.8-max`, which became multimodal in the bundled catalog (image input, #8019). The `-max` guard now only vetoes image content for pre-3.8 SKUs, so `qwen3.8-max`/`qwen3.8-max-preview` and later flagships send `image_url` content — restoring `inspect_image` on those models configured against `dashscope.aliyuncs.com/compatible-mode/v1` ([#8305](https://github.com/can1357/oh-my-pi/issues/8305)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Fixed

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -39,7 +39,11 @@ export function joinTextWithImagePlaceholder(text: string, omittedImages: boolea
  * multimodal content arrays for. The compatible-mode endpoint also serves
  * multimodal Qwen SKUs without `vl` in the id (e.g. `qwen3.7-plus`), so this
  * guard only covers families verified to be text-only for issue #1859:
- * `qwen*-max` and `qwen*-coder*`.
+ * `qwen*-coder*` and `qwen*-max` up to and including `qwen3.7-max`.
+ *
+ * Qwen-Max became multimodal at `qwen3.8-max` (image input, issue #8019), so
+ * `-max` SKUs at version 3.8 or newer are excluded — otherwise the override
+ * would strip images from a genuinely vision-capable flagship (issue #8305).
  *
  * Used as a defensive override in `convertMessages` so a misconfigured custom
  * provider (issue #1859) can't drive the request into an unrecoverable 400.
@@ -48,7 +52,13 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 	if (!isDashscopeCompatibleModeUrl(model.baseUrl)) {
 		return false;
 	}
-	const id = model.id.toLowerCase();
 	if (!isQwenModelId(model.id)) return false;
-	return /\bqwen(?:[\d.]+)?-max\b/.test(id) || /\bqwen(?:[\d.]+)?-coder\b/.test(id);
+	const id = model.id.toLowerCase();
+	if (/\bqwen(?:[\d.]+)?-coder\b/.test(id)) return true;
+	const maxMatch = id.match(/\bqwen(\d+(?:\.\d+)?)?-max\b/);
+	if (!maxMatch) return false;
+	// Bare `qwen-max` (undefined version) is the text-only 2.5-era flagship;
+	// treat missing/pre-3.8 versions as text-only, 3.8+ as multimodal.
+	const version = maxMatch[1] ? Number.parseFloat(maxMatch[1]) : 0;
+	return version < 3.8;
 }

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -55,10 +55,12 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 	if (!isQwenModelId(model.id)) return false;
 	const id = model.id.toLowerCase();
 	if (/\bqwen(?:[\d.]+)?-coder\b/.test(id)) return true;
-	const maxMatch = id.match(/\bqwen(\d+(?:\.\d+)?)?-max\b/);
+	const maxMatch = id.match(/\bqwen(?:(\d+)(?:\.(\d+))?)?-max\b/);
 	if (!maxMatch) return false;
-	// Bare `qwen-max` (undefined version) is the text-only 2.5-era flagship;
-	// treat missing/pre-3.8 versions as text-only, 3.8+ as multimodal.
-	const version = maxMatch[1] ? Number.parseFloat(maxMatch[1]) : 0;
-	return version < 3.8;
+	// Bare `qwen-max` (no version) is the text-only 2.5-era flagship. Compare
+	// major/minor component-wise, not as a decimal float, so `qwen3.10-max`
+	// sorts after `qwen3.8-max`: text-only through 3.7, multimodal from 3.8 on.
+	const major = maxMatch[1] ? Number.parseInt(maxMatch[1], 10) : 0;
+	const minor = maxMatch[2] ? Number.parseInt(maxMatch[2], 10) : 0;
+	return major < 3 || (major === 3 && minor < 8);
 }

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -394,9 +394,11 @@ describe("openai-completions convertMessages", () => {
 	it("preserves image_url for DashScope compatible-mode multimodal Qwen models", () => {
 		// Counter-cases for the issue #1859 guard: DashScope also exposes
 		// genuinely multimodal Qwen ids without `vl` in the name (`qwen3.7-plus`),
-		// and Qwen-Max is multimodal from `qwen3.8-max` onward (issue #8305), so
-		// the text-only override must be limited to known text-only families.
-		for (const id of ["qwen3.7-plus", "qwen-vl-max", "qwen3.8-max", "qwen3.8-max-preview"]) {
+		// and Qwen-Max is multimodal from `qwen3.8-max` onward (issue #8305) —
+		// including `qwen3.10-max`, which a decimal-float compare would wrongly
+		// sort below 3.8 — so the text-only override must stay limited to the
+		// known text-only families.
+		for (const id of ["qwen3.7-plus", "qwen-vl-max", "qwen3.8-max", "qwen3.8-max-preview", "qwen3.10-max"]) {
 			const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
 			const model: Model<"openai-completions"> = {
 				...baseModel,

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -394,8 +394,9 @@ describe("openai-completions convertMessages", () => {
 	it("preserves image_url for DashScope compatible-mode multimodal Qwen models", () => {
 		// Counter-cases for the issue #1859 guard: DashScope also exposes
 		// genuinely multimodal Qwen ids without `vl` in the name (`qwen3.7-plus`),
-		// so the text-only override must be limited to known text-only families.
-		for (const id of ["qwen3.7-plus", "qwen-vl-max"]) {
+		// and Qwen-Max is multimodal from `qwen3.8-max` onward (issue #8305), so
+		// the text-only override must be limited to known text-only families.
+		for (const id of ["qwen3.7-plus", "qwen-vl-max", "qwen3.8-max", "qwen3.8-max-preview"]) {
 			const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
 			const model: Model<"openai-completions"> = {
 				...baseModel,


### PR DESCRIPTION
## Repro
A custom DashScope provider (`baseUrl: https://dashscope.aliyuncs.com/compatible-mode/v1`) exposing `qwen3.8-max` with `input: [text, image]` and used as the vision role drops the image on the `inspect_image` path: the model receives the `[image omitted: model does not support vision]` placeholder and replies "no image provided". Driving the guard directly against a `qwen3.8-max` model at that base URL:

```
qwen3.8-max            textOnlyGuard=true  -> imagesSent=false   (bug)
qwen3.8-max-preview    textOnlyGuard=true  -> imagesSent=false   (bug)
qwen3.7-max            textOnlyGuard=true  -> imagesSent=false   (correct)
qwen-max               textOnlyGuard=true  -> imagesSent=false   (correct)
qwen3-coder-plus       textOnlyGuard=true  -> imagesSent=false   (correct)
qwen-vl-max            textOnlyGuard=false -> imagesSent=true    (correct)
qwen3.7-plus           textOnlyGuard=false -> imagesSent=true    (correct)
```

## Cause
`isDashscopeCompatibleModeTextOnlyQwen` in `packages/ai/src/providers/vision-guard.ts` is the #1859 defensive override that strips `image_url` content for text-only Qwen SKUs on the consumer DashScope `compatible-mode` endpoint (which 400s on multimodal arrays). It matched `-max` with `/\bqwen(?:[\d.]+)?-max\b/`, catching every version. `qwen3.8-max` became multimodal in the bundled catalog (image input, #8019), so the override over-matched the newer flagship and vetoed its images in `convertMessages` (`openai-completions.ts:1915` for user content and `:2205` for tool-result batching).

## Fix
- `vision-guard.ts`: split the `-max`/`-coder` handling. Coder families stay text-only. For `-max`, parse the version and only treat missing (bare `qwen-max`) or pre-3.8 versions as text-only; `qwen3.8-max`/`qwen3.8-max-preview` and later send `image_url` content.
- Extended the existing DashScope multimodal counter-case test to cover `qwen3.8-max` and `qwen3.8-max-preview`, asserting `image_url` parts survive `convertMessages`.
- Added a `packages/ai` changelog entry under `[Unreleased]`.

## Verification
`bun test test/openai-completions-tool-result-images.test.ts` in `packages/ai` — 7 pass / 0 fail. The #1859 text-only strip test still passes (pre-3.8 `-max`, coder families unchanged); the new counter-cases confirm `qwen3.8-max`/`-preview` retain their image blocks. Pre-publish gate (`bun run fix` + `bun check`) passed on push. Fixes #8305