### PR TITLE
fix(coding-agent): suppress circular plan-yolo startup note

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed print mode claiming `plan.defaultOnStartup` was ignored and recommending `--plan-yolo` when that headless plan flow was already active ([#8312](https://github.com/can1357/oh-my-pi/issues/8312)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1787,6 +1787,7 @@ export async function runRootCommand(
 				initialMessage,
 				initialImages,
 				printThoughts: initialArgs.printThoughts,
+				planYolo: parsedArgs.planYolo,
 			});
 			if ($env.PI_TIMING) {
 				logger.printTimings();

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -27,6 +27,8 @@ export interface PrintModeOptions {
 	initialImages?: ImageContent[];
 	/** If true, include thinking blocks in text output */
 	printThoughts?: boolean;
+	/** Whether the caller explicitly started the headless plan flow. */
+	planYolo?: boolean;
 }
 
 /** Matches the longest built-in provider request deadline while bounding tool-loop stalls. */
@@ -87,7 +89,7 @@ export function printableEvent(event: AgentSessionEvent): unknown {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
-	const { mode, messages = [], initialMessage, initialImages, printThoughts } = options;
+	const { mode, messages = [], initialMessage, initialImages, printThoughts, planYolo = false } = options;
 
 	// process.stdout.write is fire-and-forget: a large final record (e.g. a
 	// multi-MB agent_end) can be dropped when the process exits before the pipe
@@ -138,7 +140,8 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		session.settings.get("plan.defaultOnStartup") &&
 		session.settings.get("plan.enabled") &&
 		session.sessionManager.buildSessionContext().messages.length === 0 &&
-		!session.sessionManager.getEntries().some(entry => entry.type === "mode_change");
+		!session.sessionManager.getEntries().some(entry => entry.type === "mode_change") &&
+		!planYolo;
 	if (planStartupIgnored) {
 		process.stderr.write(
 			"Note: plan.defaultOnStartup is ignored in print mode (no interactive surface to review the plan). Use --plan-yolo for a headless plan flow.\n",

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -198,6 +198,23 @@ describe("print mode working indicator", () => {
 		expect(stdoutOutput.join("")).toBe("final answer\n");
 	});
 
+	it("suppresses the startup-default note when the headless plan flow is already active", async () => {
+		const delayed = createDelayedSession(makeAssistantMessage("final answer"), { defaultPlanMode: true });
+		const run = runPrintMode(delayed.session, {
+			mode: "text",
+			initialMessage: "Reply with exactly: OK",
+			planYolo: true,
+		});
+
+		await delayed.promptStarted;
+		try {
+			expect(stderrOutput.join("")).not.toContain("plan.defaultOnStartup");
+		} finally {
+			delayed.resolvePrompt();
+			await run;
+		}
+	});
+
 	it("writes a text-mode working indicator before the prompt resolves and prints the final answer afterward", async () => {
 		const delayed = createDelayedSession(makeAssistantMessage("final answer"));
 		const run = runPrintMode(delayed.session, { mode: "text", initialMessage: "hello" });


### PR DESCRIPTION
## Repro
With `plan.defaultOnStartup: true`, run `omp -p --plan-yolo --no-session --max-time 90 "Reply with exactly: OK"`; print mode incorrectly writes a note claiming the startup plan is ignored and recommends the already-active `--plan-yolo` flow. The focused reproduction is `bun test packages/coding-agent/test/print-mode-working-indicator.test.ts`.

## Cause
`runPrintMode` in `packages/coding-agent/src/modes/print-mode.ts` based the startup-default notice only on settings and session history. `packages/coding-agent/src/main.ts` did not pass the parsed `planYolo` state, so print mode could not distinguish a bare print run from the explicit headless plan flow.

## Fix
- Carry the parsed `--plan-yolo` state through `PrintModeOptions`.
- Suppress the startup-default note while that explicit headless plan flow is active.
- Add regression coverage for the explicit-plan-yolo case and record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/print-mode-working-indicator.test.ts packages/coding-agent/test/print-mode-plan-startup-hang.test.ts` passed: 8 tests, 27 assertions. `bun run check` in `packages/coding-agent` passed. The publish gate also completed `bun run fix` and `bun check`.

Fixes #8312