### PR TITLE
feat: add configured shell completion

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -530,6 +530,8 @@ Computer settings are captured when the desktop controller is created. A model s
 ### Shell, eval, and LSP
 
 ```yaml
+shellPath: /bin/zsh # optional
+
 bash:
   enabled: true
   autoBackground:
@@ -569,7 +571,18 @@ lsp:
 | `lsp.diagnosticsOnEdit`           | boolean | `false`   | Run diagnostics after an edit.                                                                                                                              |
 | `lsp.formatOnWrite`               | boolean | `false`   | Format files on write.                                                                                                                                      |
 | `lsp.diagnosticsDeduplicate`      | boolean | `true`    | Collapse duplicate diagnostics.                                                                                                                             |
-| `shellPath`                       | string  | _(unset)_ | Override the shell binary used by bash.                                                                                                                     |
+| `shellPath`                       | string  | _(unset)_ | Override the shell binary used by shell shortcuts and the bash tool.                                                                                                    |
+
+Shell shortcuts use the configured user shell:
+
+- Enter bare `!` to leave the OMP interface temporarily and open the full interactive shell. The shell owns the terminal, so its native line editor and Tab completion work normally.
+- Enter `! command` to run one quick shell command and include its result in the session context.
+- Enter `!! command` to run one quick shell command and exclude its result from the session context.
+- While editing `! command` or `!! command`, press Tab to show executable or filesystem-path candidates. Press Tab again to apply the selected candidate.
+
+`shellPath` has priority. If it is unset, OMP uses an executable path from `$SHELL`, then the existing supported-shell fallback. Zsh starts as an interactive login shell with `-il`, so login files such as `.zprofile` and `.zlogin` are part of the session. Fish and other supported shells keep their established interactive startup policy.
+
+When a zsh interactive shell exits, OMP adopts its final working directory if the shell reports a bounded, absolute path that still exists and is a directory. OMP then reloads directory-scoped settings, skills, slash commands, todos, and related session state. A missing or invalid directory record leaves the prior OMP working directory unchanged. Bash, fish, and other shells do not currently synchronize their final working directory back to OMP. OMP does not modify shell startup files to provide zsh synchronization.
 
 ### Files: editing and reading
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Fixed omp plugin install failing with cloning errors for legacy Pi extensions whose tool schemas use legacy-typebox builders.
 - Fixed omp update aborting with chmod ENOENT when concurrent update runs overlapped by using unique download temporary paths.
 - Fixed the browser tool executable probe launching the user's installed GUI Chromium on Windows: the `--version` version probe from ecb22957 was Linux-scoped but ran for every platform candidate, so on Windows it could hand off to a running `chrome.exe`, open a normal browser window, then reject the candidate and fall back to cached Chrome for Testing. The probe is now confined to Linux ([#8445](https://github.com/can1357/oh-my-pi/issues/8445)).
+### Added
+
+- Added practical executable and path completion for `!` and `!!` shell shortcuts, plus bare `!` interactive configured-shell sessions with native shell completion and zsh working-directory synchronization ([#3179](https://github.com/can1357/oh-my-pi/issues/3179)).
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -674,7 +674,7 @@ export class Settings {
 	/**
 	 * Get shell configuration based on settings.
 	 */
-	getShellConfig() {
+	getShellConfig(env?: Record<string, string | undefined>) {
 		const shell = this.get("shellPath");
 		let configSource = this.#configPath ?? path.join(this.#agentDir, MAIN_CONFIG_FILENAMES[0]);
 		if (Object.hasOwn(this.#project, "shellPath")) {
@@ -686,7 +686,7 @@ export class Settings {
 		if (Object.hasOwn(this.#overrides, "shellPath")) {
 			configSource = "the runtime settings override";
 		}
-		return procmgr.getShellConfig(shell, { configSource });
+		return procmgr.getShellConfig(shell, { configSource, env });
 	}
 
 	/**

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -5,7 +5,8 @@
  */
 import { ExponentialYield } from "@oh-my-pi/pi-agent-core/utils/yield";
 import { type MinimizerOptions, Shell, type ShellRunResult } from "@oh-my-pi/pi-natives";
-import { isCmdShell, isExecutable, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
+import { filterChildShellEnv } from "@oh-my-pi/pi-utils/env";
+import { isCmdShell, isExecutable, isSafeShellEnvValue, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
@@ -61,6 +62,7 @@ export interface BashResult {
  *  command line, so a hostile `.envrc` can't smuggle shell syntax through
  *  `unset`. `.envrc` never produces non-identifier names in practice. */
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const BASH_EXECUTOR_LAUNCH_CWD = process.cwd();
 
 export interface DirenvPreflightOptions {
 	/** Caller-supplied env overlay; these values win over direnv-provided ones. */
@@ -320,13 +322,17 @@ function buildUserShellCommand(shell: string, args: string[], command: string): 
 	return [shell, ...ensureInteractiveShellArgs(shell, args), command].map(quoteShellArg).join(" ");
 }
 
-function resolveUserShellConfig(settings: Settings, baseConfig: ShellConfig): ShellConfig {
+function resolveUserShellConfig(
+	settings: Settings,
+	baseConfig: ShellConfig,
+	env: Record<string, string | undefined>,
+): ShellConfig {
 	const customShellPath = settings.get("shellPath");
-	const envShell = Bun.env.SHELL;
+	const envShell = env.SHELL;
 	if (customShellPath || process.platform === "win32" || !envShell || envShell === baseConfig.shell) {
 		return baseConfig;
 	}
-	if (!supportsAutoUserShell(envShell) || !isExecutable(envShell)) {
+	if (!isSafeShellEnvValue(envShell) || !supportsAutoUserShell(envShell) || !isExecutable(envShell)) {
 		return baseConfig;
 	}
 
@@ -342,9 +348,10 @@ function resolveUserShellConfig(settings: Settings, baseConfig: ShellConfig): Sh
 
 export async function executeBash(command: string, options?: BashExecutorOptions): Promise<BashResult> {
 	const settings = await Settings.init();
-	const baseShellConfig = settings.getShellConfig();
+	const trustedEnv = filterChildShellEnv(Bun.env, BASH_EXECUTOR_LAUNCH_CWD);
+	const baseShellConfig = settings.getShellConfig(trustedEnv);
 	const shellConfig =
-		options?.useUserShell === true ? resolveUserShellConfig(settings, baseShellConfig) : baseShellConfig;
+		options?.useUserShell === true ? resolveUserShellConfig(settings, baseShellConfig, trustedEnv) : baseShellConfig;
 	const { shell, args, env: shellEnv, prefix } = shellConfig;
 	const bashShell = isBashShell(shell);
 	const snapshotPath = bashShell ? await getOrCreateSnapshot(shell, shellEnv) : null;

--- a/packages/coding-agent/src/exec/interactive-shell.ts
+++ b/packages/coding-agent/src/exec/interactive-shell.ts
@@ -1,0 +1,227 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { filterChildShellEnv } from "@oh-my-pi/pi-utils/env";
+import { getShellArgs, isExecutable, isSafeShellEnvValue, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
+
+const MAX_CWD_RECORD_BYTES = 4096;
+const TERMINAL_CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const ZSH_CWD_RECORD_NAME = "cwd";
+const ZSH_BOOTSTRAP_NAME = ".zshenv";
+const ORIGINAL_ZDOTDIR_ENV = "OMP_INTERACTIVE_SHELL_ORIGINAL_ZDOTDIR";
+const HAS_ORIGINAL_ZDOTDIR_ENV = "OMP_INTERACTIVE_SHELL_HAS_ORIGINAL_ZDOTDIR";
+const INTERACTIVE_SHELL_LAUNCH_CWD = process.cwd();
+const CWD_RECORD_ENV = "OMP_INTERACTIVE_SHELL_CWD_RECORD";
+
+interface InteractiveShellSettings {
+	get(path: "shellPath"): string | undefined;
+	getShellConfig(env?: Record<string, string | undefined>): ShellConfig;
+}
+
+interface InteractiveShellSpawnOptions {
+	cwd: string;
+	env: Record<string, string | undefined>;
+	stdin: "inherit";
+	stdout: "inherit";
+	stderr: "inherit";
+}
+
+interface InteractiveShellProcess {
+	exited: Promise<number>;
+}
+
+type InteractiveShellSpawn = (command: string[], options: InteractiveShellSpawnOptions) => InteractiveShellProcess;
+
+export interface InteractiveShellOptions {
+	shellPath: string;
+	cwd: string;
+	env: Record<string, string | undefined>;
+	/** Test seam for the inherited-stdio process launch. */
+	spawn?: InteractiveShellSpawn;
+}
+
+export interface InteractiveShellResult {
+	exitCode: number;
+	/** A validated final cwd. Only zsh supports cwd synchronization. */
+	workingDir?: string;
+}
+
+interface ZshBootstrap {
+	temporaryZdotdir: string;
+	recordPath: string;
+	env: Record<string, string | undefined>;
+}
+
+const defaultSpawn: InteractiveShellSpawn = (command, options) => Bun.spawn(command, options);
+
+function shellBasename(shellPath: string): string {
+	return shellPath.replaceAll("\\", "/").split("/").pop()?.toLowerCase() ?? "";
+}
+
+function interactiveShellArgs(shellPath: string, env: Record<string, string | undefined>): string[] {
+	const basename = shellBasename(shellPath);
+	if (basename.includes("zsh")) return ["-il"];
+	if (basename.includes("fish")) return ["-i"];
+
+	return getShellArgs(shellPath, env).filter(
+		arg => arg !== "-c" && arg !== "--command" && arg !== "-Command" && arg.toLowerCase() !== "/c",
+	);
+}
+
+function buildZshBootstrap(token: string): string {
+	const recordVariable = `_omp_cwd_record_${token}`;
+	const originalZshenvVariable = `_omp_original_zshenv_${token}`;
+	const chpwdHook = `_omp_chpwd_${token}`;
+	const zshexitHook = `_omp_zshexit_${token}`;
+	const setupFunction = `_omp_setup_${token}`;
+	return `function ${setupFunction} {
+emulate -L zsh
+setopt no_aliases
+typeset -g ${recordVariable}="$${CWD_RECORD_ENV}"
+if [[ "$${HAS_ORIGINAL_ZDOTDIR_ENV}" == "1" ]]; then
+	ZDOTDIR="$${ORIGINAL_ZDOTDIR_ENV}"
+	export ZDOTDIR
+else
+	unset ZDOTDIR
+fi
+unset ${CWD_RECORD_ENV} ${HAS_ORIGINAL_ZDOTDIR_ENV} ${ORIGINAL_ZDOTDIR_ENV}
+}
+${setupFunction}
+unfunction ${setupFunction}
+typeset ${originalZshenvVariable}
+if (( \${+ZDOTDIR} )); then
+	${originalZshenvVariable}="\${ZDOTDIR}/.zshenv"
+else
+	${originalZshenvVariable}="\${HOME}/.zshenv"
+fi
+if [[ -r "$${originalZshenvVariable}" ]]; then
+	builtin source -- "$${originalZshenvVariable}"
+fi
+unset ${originalZshenvVariable}
+builtin autoload -Uz add-zsh-hook
+function ${chpwdHook} {
+	builtin print -rn -- "$PWD" >| "$${recordVariable}" 2>/dev/null
+	return 0
+}
+function ${zshexitHook} {
+	builtin print -rn -- "$PWD" >| "$${recordVariable}" 2>/dev/null
+	return 0
+}
+add-zsh-hook chpwd ${chpwdHook}
+add-zsh-hook zshexit ${zshexitHook}
+\${chpwdHook}
+`;
+}
+
+async function createZshBootstrap(env: Record<string, string | undefined>): Promise<ZshBootstrap> {
+	let temporaryZdotdir: string | undefined;
+	try {
+		temporaryZdotdir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-zsh-"));
+		await fs.chmod(temporaryZdotdir, 0o700);
+		const recordPath = path.join(temporaryZdotdir, ZSH_CWD_RECORD_NAME);
+		const recordHandle = await fs.open(recordPath, "wx", 0o600);
+		await recordHandle.close();
+		await fs.chmod(recordPath, 0o600);
+
+		const token = crypto.randomUUID().replaceAll("-", "");
+		const bootstrapPath = path.join(temporaryZdotdir, ZSH_BOOTSTRAP_NAME);
+		const bootstrapHandle = await fs.open(bootstrapPath, "wx", 0o600);
+		try {
+			await bootstrapHandle.writeFile(buildZshBootstrap(token), "utf8");
+		} finally {
+			await bootstrapHandle.close();
+		}
+		await fs.chmod(bootstrapPath, 0o600);
+
+		const originalZdotdir = env.ZDOTDIR;
+		return {
+			temporaryZdotdir,
+			recordPath,
+			env: {
+				...env,
+				ZDOTDIR: temporaryZdotdir,
+				[ORIGINAL_ZDOTDIR_ENV]: originalZdotdir ?? "",
+				[HAS_ORIGINAL_ZDOTDIR_ENV]: originalZdotdir === undefined ? "0" : "1",
+				[CWD_RECORD_ENV]: recordPath,
+			},
+		};
+	} catch (error) {
+		if (temporaryZdotdir) await fs.rm(temporaryZdotdir, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+async function readValidatedWorkingDir(recordPath: string): Promise<string | undefined> {
+	let recordHandle: fs.FileHandle | undefined;
+	try {
+		recordHandle = await fs.open(recordPath, "r");
+		const recordStat = await recordHandle.stat();
+		if (!recordStat.isFile() || recordStat.size === 0 || recordStat.size > MAX_CWD_RECORD_BYTES) return undefined;
+
+		const bytes = Buffer.allocUnsafe(MAX_CWD_RECORD_BYTES + 1);
+		const { bytesRead } = await recordHandle.read(bytes, 0, bytes.byteLength, 0);
+		if (bytesRead === 0 || bytesRead > MAX_CWD_RECORD_BYTES) return undefined;
+		const encodedPath = bytes.subarray(0, bytesRead);
+		const workingDir = encodedPath.toString("utf8");
+		if (
+			!Buffer.from(workingDir).equals(encodedPath) ||
+			!path.isAbsolute(workingDir) ||
+			TERMINAL_CONTROL_CHARACTER_PATTERN.test(workingDir)
+		) {
+			return undefined;
+		}
+
+		const workingDirStat = await fs.stat(workingDir);
+		return workingDirStat.isDirectory() ? workingDir : undefined;
+	} catch {
+		return undefined;
+	} finally {
+		await recordHandle?.close();
+	}
+}
+
+export function resolveInteractiveShellPath(
+	settings: InteractiveShellSettings,
+	env: Record<string, string | undefined> = Bun.env,
+): string {
+	const trustedEnv = filterChildShellEnv(env, INTERACTIVE_SHELL_LAUNCH_CWD);
+	const envShell = trustedEnv.SHELL;
+	if (!settings.get("shellPath") && isSafeShellEnvValue(envShell) && path.isAbsolute(envShell)) {
+		const shellName = path.basename(envShell).toLowerCase();
+		if (["bash", "zsh", "fish"].some(name => shellName.includes(name)) && isExecutable(envShell)) {
+			return envShell;
+		}
+	}
+	return settings.getShellConfig(trustedEnv).shell;
+}
+
+export async function runInteractiveShell(options: InteractiveShellOptions): Promise<InteractiveShellResult> {
+	const spawn = options.spawn ?? defaultSpawn;
+	const baseEnv = {
+		...filterChildShellEnv(filterChildShellEnv(options.env, INTERACTIVE_SHELL_LAUNCH_CWD), options.cwd),
+		SHELL: options.shellPath,
+	};
+	const command = [options.shellPath, ...interactiveShellArgs(options.shellPath, baseEnv)];
+	const spawnOptions: InteractiveShellSpawnOptions = {
+		cwd: options.cwd,
+		env: baseEnv,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	};
+
+	if (!shellBasename(options.shellPath).includes("zsh")) {
+		const child = spawn(command, spawnOptions);
+		return { exitCode: await child.exited };
+	}
+
+	const bootstrap = await createZshBootstrap(baseEnv);
+	try {
+		const child = spawn(command, { ...spawnOptions, env: bootstrap.env });
+		const exitCode = await child.exited;
+		const workingDir = await readValidatedWorkingDir(bootstrap.recordPath);
+		return workingDir === undefined ? { exitCode } : { exitCode, workingDir };
+	} finally {
+		await fs.rm(bootstrap.temporaryZdotdir, { recursive: true, force: true });
+	}
+}

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -154,6 +154,7 @@ export class WelcomeComponent implements Component {
 		private providerName: string,
 		private recentSessions: RecentSession[] = [],
 		private lspServers: LspServerInfo[] = [],
+		private readonly shellName = "shell",
 	) {}
 	get tip(): string | undefined {
 		if (this.#selectedTip === undefined) {
@@ -330,7 +331,7 @@ export class WelcomeComponent implements Component {
 			` ${theme.bold(theme.fg("accent", "Tips"))}`,
 			` ${theme.fg("dim", "#")}${theme.fg("muted", " for prompt actions")}`,
 			` ${theme.fg("dim", "/")}${theme.fg("muted", " for commands")}`,
-			` ${theme.fg("dim", "!")}${theme.fg("muted", " to run bash")}`,
+			` ${theme.fg("dim", "!")}${theme.fg("muted", ` for shell (${this.shellName})`)}`,
 			` ${theme.fg("dim", "$")}${theme.fg("muted", " to run python")}`,
 			separator,
 			` ${theme.bold(theme.fg("accent", "LSP Servers"))}`,

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -11,9 +11,10 @@ import {
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
 import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi/pi-tui";
-import { formatDuration, logger, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, logger, postmortem, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
 import { shouldEnableAppendOnlyContext } from "../../config/append-only-context-mode";
 import { type BashResult, isPersistentShellCdCommand } from "../../exec/bash-executor";
+import { resolveInteractiveShellPath, runInteractiveShell } from "../../exec/interactive-shell";
 import { type LoadedCustomShare, loadCustomShare } from "../../export/custom-share";
 import { parseExportArgs } from "../../export/html/args";
 import { shareSession } from "../../export/share";
@@ -582,7 +583,15 @@ export class CommandController {
 	}
 
 	handleHotkeysCommand(): void {
-		const hotkeys = buildHotkeysMarkdown({ keybindings: this.ctx.keybindings });
+		let shellName: string | undefined;
+		try {
+			shellName = path.basename(resolveInteractiveShellPath(this.ctx.settings));
+		} catch (error) {
+			logger.debug("Failed to resolve shell name for hotkeys", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+		const hotkeys = buildHotkeysMarkdown({ keybindings: this.ctx.keybindings, shellName });
 		showMarkdownPanel(this.ctx, "Keyboard Shortcuts", hotkeys);
 	}
 
@@ -1135,6 +1144,81 @@ export class CommandController {
 		}
 	}
 
+	async handleInteractiveShell(): Promise<void> {
+		if (this.ctx.session.isStreaming || this.ctx.session.isBashRunning || this.ctx.session.isEvalRunning) {
+			this.ctx.showWarning("Wait for active work to finish or abort it before opening a shell.");
+			return;
+		}
+
+		let shellPath: string;
+		try {
+			shellPath = resolveInteractiveShellPath(this.ctx.settings);
+		} catch (error) {
+			this.ctx.showError(`Failed to resolve shell: ${error instanceof Error ? error.message : "Unknown error"}`);
+			return;
+		}
+
+		const shellName = path.basename(shellPath);
+		this.ctx.showStatus(`Opening shell (${shellName})...`);
+		this.ctx.ui.requestRender();
+
+		let exitCode: number | undefined;
+		let workingDir: string | undefined;
+		let spawnFailed = false;
+		let spawnError: unknown;
+		let stopBegan = false;
+		const resumeParentSigintCleanup = process.platform === "win32" ? postmortem.suspendSigintCleanup() : undefined;
+		try {
+			stopBegan = true;
+			this.ctx.ui.stop();
+			const result = await runInteractiveShell({
+				shellPath,
+				cwd: this.ctx.sessionManager.getCwd(),
+				env: process.env,
+			});
+			exitCode = result.exitCode;
+			workingDir = result.workingDir;
+		} catch (error) {
+			spawnFailed = true;
+			spawnError = error;
+		} finally {
+			try {
+				if (stopBegan) {
+					this.ctx.ui.start();
+					this.ctx.ui.requestRender(true);
+				}
+			} finally {
+				resumeParentSigintCleanup?.();
+			}
+		}
+
+		if (spawnFailed) {
+			this.ctx.showError(
+				`Failed to open shell (${shellName}): ${spawnError instanceof Error ? spawnError.message : "Unknown error"}`,
+			);
+			return;
+		}
+
+		if (workingDir && path.resolve(workingDir) !== path.resolve(this.ctx.sessionManager.getCwd())) {
+			try {
+				await this.#moveInteractiveCwd(workingDir);
+				this.ctx.ui.requestRender();
+			} catch (error) {
+				this.ctx.showError(
+					`Shell returned to "${workingDir}", but OMP failed to update its working directory: ${
+						error instanceof Error ? error.message : "Unknown error"
+					}`,
+				);
+				return;
+			}
+		}
+		if (exitCode !== undefined && exitCode !== 0) {
+			this.ctx.showWarning(`Shell (${shellName}) exited with code ${exitCode}.`);
+		} else {
+			this.ctx.showStatus(`Returned from shell (${shellName}).`);
+		}
+	}
+
 	async handleBashCommand(command: string, excludeFromContext = false): Promise<void> {
 		const isDeferred = this.ctx.session.isStreaming;
 		const shouldPersistCwd = isPersistentShellCdCommand(command);
@@ -1174,7 +1258,7 @@ export class CommandController {
 				if (shouldPersistCwd) await this.#applyBashResultCwd(result);
 			} catch (error) {
 				this.ctx.showError(
-					`Bash command completed, but OMP failed to update its working directory: ${
+					`Shell command completed, but OMP failed to update its working directory: ${
 						error instanceof Error ? error.message : "Unknown error"
 					}`,
 				);
@@ -1183,7 +1267,7 @@ export class CommandController {
 			if (this.ctx.bashComponent) {
 				this.ctx.bashComponent.setComplete(undefined, false);
 			}
-			this.ctx.showError(`Bash command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+			this.ctx.showError(`Shell command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
 
 		this.ctx.bashComponent = undefined;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -789,13 +789,20 @@ export class InputController {
 				}
 			}
 
-			// Handle bash command (! for normal, !! for excluded from context)
+			if (text === "!") {
+				await this.ctx.handleInteractiveShell();
+				this.ctx.isBashMode = false;
+				this.ctx.updateEditorBorderColor();
+				return;
+			}
+
+			// Handle quick shell commands (! includes the result; !! excludes it from context).
 			if (text.startsWith("!")) {
 				const isExcluded = text.startsWith("!!");
 				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
 				if (command) {
 					if (this.ctx.session.isBashRunning) {
-						this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
+						this.ctx.showWarning("A shell command is already running. Press Esc to cancel it first.");
 						this.ctx.editor.setText(text);
 						return;
 					}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -67,6 +67,7 @@ import {
 	settings,
 } from "../config/settings";
 import { clearClaudePluginRootsCache } from "../discovery/helpers";
+import { resolveInteractiveShellPath } from "../exec/interactive-shell";
 import type {
 	AutocompleteProviderFactory,
 	ContextUsage,
@@ -997,6 +998,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Get current model info for welcome screen
 		const modelName = this.session.model?.name ?? "Unknown";
 		const providerName = this.session.model?.provider ?? "Unknown";
+		let shellName = "shell";
+		try {
+			shellName = path.basename(resolveInteractiveShellPath(this.settings));
+		} catch (error) {
+			logger.debug("Failed to resolve shell name for welcome", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 
 		// Get recent sessions
 		const recentSessions = await logger.time("InteractiveMode.init:recentSessions", () =>
@@ -1024,6 +1033,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				providerName,
 				recentSessions,
 				this.#getWelcomeLspServers(),
+				shellName,
 			);
 
 			// Setup UI layout
@@ -4851,6 +4861,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	resetObserverRegistry(): void {
 		this.#observerRegistry.resetSessions();
 		this.#observerRegistry.setMainSession(this.sessionManager.getSessionFile() ?? undefined);
+	}
+
+	handleInteractiveShell(): Promise<void> {
+		return this.#commandController.handleInteractiveShell();
 	}
 
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void> {

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
@@ -6,6 +8,8 @@ import {
 	getKeybindings,
 	type SlashCommand,
 } from "@oh-my-pi/pi-tui";
+import { filterChildShellEnv } from "@oh-my-pi/pi-utils/env";
+import { isSafeShellEnvValue } from "@oh-my-pi/pi-utils/procmgr";
 import { formatKeyHints, type KeybindingsManager } from "../config/keybindings";
 import { isSettingsInitialized, settings } from "../config/settings";
 import { applyEmojiCompletion, getEmojiSuggestions, isEmojiPrefix, tryEmojiInlineReplace } from "./emoji-autocomplete";
@@ -15,6 +19,107 @@ import {
 	getInternalUrlSuggestions,
 	isInternalUrlPrefix,
 } from "./internal-url-autocomplete";
+
+interface ExecutableCandidateCache {
+	key: string;
+	candidates: Promise<AutocompleteItem[]>;
+}
+
+interface BangCommandCompletionContext {
+	commandPrefix: string | null;
+}
+
+let executableCandidateCache: ExecutableCandidateCache | undefined;
+const SAFE_EXECUTABLE_NAME_RE = /^[A-Za-z0-9_+.,:@%=-]+$(?![\s\S])/;
+const PROMPT_ACTION_LAUNCH_CWD = process.cwd();
+
+function getBangCommandCompletionContext(
+	lines: string[],
+	cursorLine: number,
+	cursorCol: number,
+): BangCommandCompletionContext | null {
+	if (cursorLine !== 0) return null;
+	const textBeforeCursor = (lines[0] || "").slice(0, cursorCol);
+	let index = 0;
+	while (textBeforeCursor[index] === " " || textBeforeCursor[index] === "\t") index += 1;
+	if (textBeforeCursor[index] !== "!") return null;
+	index += textBeforeCursor[index + 1] === "!" ? 2 : 1;
+	while (textBeforeCursor[index] === " " || textBeforeCursor[index] === "\t") index += 1;
+	const commandStart = index;
+	let quote: "'" | '"' | null = null;
+	let escaped = false;
+
+	for (; index < textBeforeCursor.length; index += 1) {
+		const char = textBeforeCursor[index] ?? "";
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (char === "\\" && quote !== "'") {
+			escaped = true;
+			continue;
+		}
+		if (quote) {
+			if (char === quote) quote = null;
+			continue;
+		}
+		if (char === "'" || char === '"') {
+			quote = char;
+			continue;
+		}
+		if (char === " " || char === "\t") return { commandPrefix: null };
+	}
+
+	return { commandPrefix: textBeforeCursor.slice(commandStart) };
+}
+
+async function discoverExecutableCandidates(searchPath: string, pathExt: string): Promise<AutocompleteItem[]> {
+	const executableNames = new Set<string>();
+	const windowsExtensions = new Set(
+		(pathExt || ".COM;.EXE;.BAT;.CMD")
+			.split(";")
+			.filter(Boolean)
+			.map(extension => extension.toLowerCase()),
+	);
+	const directories = [...new Set(searchPath.split(path.delimiter).map(directory => directory || "."))];
+
+	await Promise.all(
+		directories.map(async directory => {
+			const entries = await fs.readdir(directory, { withFileTypes: true }).catch(() => null);
+			if (!entries) return;
+			await Promise.all(
+				entries.map(async entry => {
+					if (!SAFE_EXECUTABLE_NAME_RE.test(entry.name)) return;
+					if (!entry.isFile() && !entry.isSymbolicLink()) return;
+					if (process.platform === "win32") {
+						if (windowsExtensions.has(path.extname(entry.name).toLowerCase())) executableNames.add(entry.name);
+						return;
+					}
+					try {
+						const stats = await fs.stat(path.join(directory, entry.name));
+						if (stats.isFile() && (stats.mode & 0o111) !== 0) executableNames.add(entry.name);
+					} catch {
+						// Ignore entries that disappear or become inaccessible during discovery.
+					}
+				}),
+			);
+		}),
+	);
+
+	return [...executableNames].sort().map(value => ({ value, label: value }));
+}
+
+function getExecutableCandidates(): Promise<AutocompleteItem[]> {
+	const trustedEnv = filterChildShellEnv(process.env, PROMPT_ACTION_LAUNCH_CWD);
+	const searchPath = trustedEnv.PATH;
+	if (!isSafeShellEnvValue(searchPath) || searchPath.length === 0) return Promise.resolve([]);
+	const pathExt = trustedEnv.PATHEXT ?? "";
+	const key = `${process.platform}\0${searchPath}\0${pathExt}`;
+	if (executableCandidateCache?.key === key) return executableCandidateCache.candidates;
+	const candidates = discoverExecutableCandidates(searchPath, pathExt);
+	executableCandidateCache = { key, candidates };
+	return candidates;
+}
 
 interface PromptActionDefinition {
 	id: string;
@@ -145,6 +250,19 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
+		const bangContext = getBangCommandCompletionContext(lines, cursorLine, cursorCol);
+		if (bangContext) {
+			if (bangContext.commandPrefix === null) {
+				return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+			}
+			const commandPrefix = bangContext.commandPrefix;
+			const items = (await getExecutableCandidates()).filter(item =>
+				process.platform === "win32"
+					? item.value.toLowerCase().startsWith(commandPrefix.toLowerCase())
+					: item.value.startsWith(commandPrefix),
+			);
+			return items.length > 0 ? { items, prefix: commandPrefix } : null;
+		}
 		const leadingSlashStart = findLeadingSlashCommandStart(textBeforeCursor);
 		const hasPromptTextBeforeCursorLine = lines.slice(0, cursorLine).some(line => (line || "").trim() !== "");
 		const commandText =
@@ -248,6 +366,28 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			return applyEmojiCompletion(lines, cursorLine, cursorCol, item, prefix);
 		}
 		return this.#baseProvider.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+	}
+
+	async getForceFileSuggestions(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		const bangContext = getBangCommandCompletionContext(lines, cursorLine, cursorCol);
+		if (bangContext && bangContext.commandPrefix !== null) {
+			const commandPrefix = bangContext.commandPrefix;
+			const isPathLike =
+				commandPrefix.startsWith('"') ||
+				commandPrefix.startsWith("'") ||
+				commandPrefix.includes("/") ||
+				commandPrefix.includes("\\");
+			if (!isPathLike) return this.getSuggestions(lines, cursorLine, cursorCol);
+		}
+		return this.#baseProvider.getForceFileSuggestions(lines, cursorLine, cursorCol);
+	}
+
+	shouldTriggerFileCompletion(lines: string[], cursorLine: number, cursorCol: number): boolean {
+		return this.#baseProvider.shouldTriggerFileCompletion(lines, cursorLine, cursorCol);
 	}
 
 	getInlineHint(lines: string[], cursorLine: number, cursorCol: number): string | null {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -361,6 +361,7 @@ export interface InteractiveModeContext {
 	handleResetContextCommand(): Promise<void>;
 	handleDropCommand(): Promise<void>;
 	handleForkCommand(): Promise<void>;
+	handleInteractiveShell(): Promise<void>;
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;
 	handlePythonCommand(code: string, excludeFromContext?: boolean): Promise<void>;
 	handleMCPCommand(text: string): Promise<void>;

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -2,6 +2,7 @@ import { type AppKeybinding, type KeybindingsManager, keyHintPlatform, modifierL
 
 export interface HotkeysMarkdownBindings {
 	keybindings: Pick<KeybindingsManager, "getDisplayString">;
+	shellName?: string;
 }
 
 function appKey(bindings: HotkeysMarkdownBindings, action: AppKeybinding): string {
@@ -13,6 +14,9 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 	const isMac = platform === "darwin";
 	const alt = modifierLabel("alt", platform);
 	const cmd = modifierLabel("super", platform);
+	const interactiveShellLabel = bindings.shellName
+		? `Open interactive shell (${bindings.shellName})`
+		: "Open interactive shell";
 	return [
 		"**Navigation**",
 		"| Key | Action |",
@@ -61,8 +65,9 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| `#<number>` | GitHub issue/PR reference (e.g. `#3164` → `pr://`/`issue://`) |",
 		"| `#` / `#<text>` | Prompt actions (copy / undo / move cursor) |",
 		"| `/` | Slash commands |",
-		"| `!` | Run bash command |",
-		"| `!!` | Run bash command (excluded from context) |",
+		`| \`!\` | ${interactiveShellLabel} |`,
+		"| `! command` | Run shell command |",
+		"| `!! command` | Run shell command (excluded from context) |",
 		"| `$` | Run Python in shared kernel |",
 		"| `$$` | Run Python (excluded from context) |",
 	].join("\n");

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -416,6 +416,70 @@ exit 64
 		}
 	});
 
+	it("ignores launch-project dotenv SHELL and PATH for user-shell shortcut commands", async () => {
+		if (process.platform === "win32") return;
+		const launchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omp-hostile-shell-env-"));
+		const binDir = path.join(launchRoot, "bin");
+		const agentDir = path.join(launchRoot, "agent");
+		const marker = path.join(launchRoot, "attacker-shell-ran");
+		fs.mkdirSync(binDir);
+		fs.mkdirSync(agentDir);
+		const attackerShell = path.join(launchRoot, "bash");
+		fs.writeFileSync(
+			attackerShell,
+			`#!/bin/sh
+printf pwn > ${JSON.stringify(marker)}
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-c" ]; then
+		shift
+		exec /bin/sh -c "$1"
+	fi
+	shift
+done
+exit 64
+`,
+		);
+		fs.chmodSync(attackerShell, 0o755);
+		fs.writeFileSync(path.join(launchRoot, ".env"), `PATH=${binDir}\nSHELL=${attackerShell}\n`);
+		const executorPath = path.resolve(import.meta.dir, "../src/exec/bash-executor.ts");
+		const script = `
+			const { executeBash } = await import(${JSON.stringify(executorPath)});
+			const result = await executeBash("printf quick-safe", {
+				cwd: ${JSON.stringify(launchRoot)},
+				timeout: 5000,
+				sessionKey: "hostile-launch-dotenv",
+				useUserShell: true,
+			});
+			console.log(JSON.stringify({ exitCode: result.exitCode, output: result.output.trim() }));
+		`;
+		const childEnv: Record<string, string | undefined> = {
+			...process.env,
+			HOME: launchRoot,
+			PI_CODING_AGENT_DIR: agentDir,
+		};
+		delete childEnv.PATH;
+		delete childEnv.SHELL;
+		const child = Bun.spawn([process.execPath, "-e", script], {
+			cwd: launchRoot,
+			env: childEnv,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+
+		try {
+			expect(exitCode, stderr).toBe(0);
+			expect(JSON.parse(stdout.trim())).toEqual({ exitCode: 0, output: "quick-safe" });
+			expect(fs.existsSync(marker)).toBe(false);
+		} finally {
+			removeSyncWithRetries(launchRoot);
+		}
+	});
+
 	it("loads zshrc aliases for user-shell shortcut commands", async () => {
 		if (process.platform === "win32") {
 			return;

--- a/packages/coding-agent/test/input-controller-shell-dispatch.test.ts
+++ b/packages/coding-agent/test/input-controller-shell-dispatch.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+type FakeEditor = {
+	onSubmit?: (text: string) => Promise<void>;
+	imageLinks?: readonly (string | undefined)[];
+	setText(text: string): void;
+	addToHistory(text: string): void;
+	pendingImages: ImageContent[];
+	pendingImageLinks: (string | undefined)[];
+};
+
+function createContext() {
+	const handleInteractiveShell = vi.fn(async () => {});
+	const handleBashCommand = vi.fn(async (_command: string, _isExcluded: boolean) => {});
+	const onInputCallback = vi.fn();
+	const editor: FakeEditor = {
+		setText: vi.fn(),
+		addToHistory: vi.fn(),
+		pendingImages: [],
+		pendingImageLinks: [],
+	};
+	const ctx = {
+		editor: editor as unknown as InteractiveModeContext["editor"],
+		ui: { requestRender: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		session: {
+			isStreaming: false,
+			isCompacting: false,
+			isBashRunning: false,
+			isEvalRunning: false,
+			extensionRunner: undefined,
+			maybeStartTitleGeneration: vi.fn(),
+			prompt: vi.fn(async () => {}),
+			queuedMessageCount: 0,
+			getQueuedMessages: () => ({ steering: [], followUp: [] }),
+		} as unknown as InteractiveModeContext["session"],
+		sessionManager: { getSessionName: () => "shell-test" } as unknown as InteractiveModeContext["sessionManager"],
+		compactionQueuedMessages: [],
+		locallySubmittedUserSignatures: new Set<string>(),
+		onInputCallback,
+		startPendingSubmission: vi.fn((submission: unknown) => submission),
+		updatePendingMessagesDisplay: vi.fn(),
+		flushPendingBashComponents: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		showError: vi.fn(),
+		showWarning: vi.fn(),
+		showStatus: vi.fn(),
+		isBashMode: false,
+		isPythonMode: false,
+		fileSlashCommands: new Set<string>(),
+		isKnownSlashCommand: () => false,
+		handleInteractiveShell,
+		handleBashCommand,
+		handlePythonCommand: vi.fn(async () => {}),
+		withLocalSubmission: async (_text: string, fn: () => Promise<unknown>) => fn(),
+	} as unknown as InteractiveModeContext;
+	return { ctx, editor, handleBashCommand, handleInteractiveShell, onInputCallback };
+}
+
+describe("InputController shell shortcuts", () => {
+	it("dispatches trimmed exact bang to the interactive shell", async () => {
+		const { ctx, editor, handleBashCommand, handleInteractiveShell, onInputCallback } = createContext();
+		new InputController(ctx).setupEditorSubmitHandler();
+
+		await editor.onSubmit?.(" \n!\t ");
+
+		expect(handleInteractiveShell).toHaveBeenCalledTimes(1);
+		expect(handleBashCommand).not.toHaveBeenCalled();
+		expect(onInputCallback).not.toHaveBeenCalled();
+	});
+
+	it("keeps quick bang and double-bang command dispatch unchanged", async () => {
+		const { ctx, editor, handleBashCommand, handleInteractiveShell, onInputCallback } = createContext();
+		new InputController(ctx).setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("! printf one");
+		await editor.onSubmit?.("!! printf two");
+
+		expect(handleBashCommand.mock.calls).toEqual([
+			["printf one", false],
+			["printf two", true],
+		]);
+		expect(handleInteractiveShell).not.toHaveBeenCalled();
+		expect(onInputCallback).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
@@ -127,4 +127,14 @@ describe("InteractiveMode LSP startup welcome banner", () => {
 		} satisfies LspStartupEvent);
 		expect(showWarningSpy).not.toHaveBeenCalled();
 	});
+
+	it("uses generic shell display text when the configured shell path is invalid", async () => {
+		session.settings.set("shellPath", path.join(tempDir.path(), "missing-shell"));
+
+		await expect(mode.init({ suppressWelcomeIntro: true })).resolves.toBeUndefined();
+
+		const rendered = Bun.stripANSI(mode.ui.render(120).join("\n"));
+		expect(rendered).toContain("for shell (shell)");
+		expect(rendered).not.toContain("missing-shell");
+	});
 });

--- a/packages/coding-agent/test/interactive-shell.test.ts
+++ b/packages/coding-agent/test/interactive-shell.test.ts
@@ -1,0 +1,507 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getShellConfig as getProcessShellConfig } from "@oh-my-pi/pi-utils/procmgr";
+import {
+	type InteractiveShellResult,
+	resolveInteractiveShellPath,
+	runInteractiveShell,
+} from "../src/exec/interactive-shell";
+
+interface CapturedSpawnOptions {
+	cwd: string;
+	env: Record<string, string | undefined>;
+	stdin: "inherit";
+	stdout: "inherit";
+	stderr: "inherit";
+}
+
+const testRoots = new Set<string>();
+
+async function makeTestRoot(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-interactive-shell-test-"));
+	testRoots.add(root);
+	return root;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.stat(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function findRecordPath(zdotdir: string): Promise<string> {
+	const entries = await fs.readdir(zdotdir);
+	const record = entries.find(entry => entry !== ".zshenv");
+	if (!record) throw new Error("cwd record was not created");
+	return path.join(zdotdir, record);
+}
+
+async function runZshWithRecord(
+	cwd: string,
+	writeRecord: (recordPath: string) => Promise<void>,
+): Promise<InteractiveShellResult> {
+	return runInteractiveShell({
+		shellPath: "/bin/zsh",
+		cwd,
+		env: { HOME: cwd, ZDOTDIR: path.join(cwd, "original-zdotdir") },
+		spawn: (_command, options) => ({
+			exited: (async () => {
+				const recordPath = await findRecordPath(options.env.ZDOTDIR as string);
+				await writeRecord(recordPath);
+				return 0;
+			})(),
+		}),
+	});
+}
+
+afterEach(async () => {
+	await Promise.all([...testRoots].map(root => fs.rm(root, { recursive: true, force: true })));
+	testRoots.clear();
+});
+
+describe("runInteractiveShell", () => {
+	it.each([
+		["/bin/zsh", ["/bin/zsh", "-il"]],
+		["/opt/homebrew/bin/fish", ["/opt/homebrew/bin/fish", "-i"]],
+		["/bin/bash", ["/bin/bash", "-l"]],
+		["/bin/dash", ["/bin/dash", "-l"]],
+		["C:\\Windows\\System32\\cmd.exe", ["C:\\Windows\\System32\\cmd.exe"]],
+		["C:\\Program Files\\PowerShell\\7\\pwsh.exe", ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo"]],
+	] as const)("uses the native interactive argv policy for %s", async (shellPath, expectedCommand) => {
+		let command: readonly string[] | undefined;
+		await runInteractiveShell({
+			shellPath,
+			cwd: "/workspace",
+			env: {},
+			spawn: (spawnCommand, _options) => {
+				command = spawnCommand;
+				return { exited: Promise.resolve(0) };
+			},
+		});
+
+		expect(command).toEqual(expectedCommand);
+	});
+
+	it("keeps zsh login-interactive and fish interactive when command-shell login is disabled", async () => {
+		const commands: string[][] = [];
+		for (const shellPath of ["/bin/zsh", "/usr/bin/fish"]) {
+			await runInteractiveShell({
+				shellPath,
+				cwd: "/workspace",
+				env: { PI_BASH_NO_LOGIN: "1" },
+				spawn: (command, _options) => {
+					commands.push(command);
+					return { exited: Promise.resolve(0) };
+				},
+			});
+		}
+
+		expect(commands).toEqual([
+			["/bin/zsh", "-il"],
+			["/usr/bin/fish", "-i"],
+		]);
+	});
+
+	it("launches the shell with direct inherited stdio", async () => {
+		let launch: CapturedSpawnOptions | undefined;
+		const result = await runInteractiveShell({
+			shellPath: "/bin/bash",
+			cwd: "/workspace",
+			env: { HOME: "/home/test", SHELL: "/bin/sh" },
+			spawn: (_command, options) => {
+				launch = options;
+				return { exited: Promise.resolve(23) };
+			},
+		});
+
+		expect(launch).toEqual({
+			cwd: "/workspace",
+			env: { HOME: "/home/test", SHELL: "/bin/bash" },
+			stdin: "inherit",
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+		expect(result).toEqual({ exitCode: 23 });
+	});
+
+	it("removes launch-cwd dotenv values while preserving launcher environment", async () => {
+		const root = await makeTestRoot();
+		await Bun.write(path.join(root, ".env"), "DOTENV_ONLY_SECRET=dotenv-secret\n");
+		let launch: CapturedSpawnOptions | undefined;
+
+		await runInteractiveShell({
+			shellPath: "/bin/zsh",
+			cwd: root,
+			env: {
+				DOTENV_ONLY_SECRET: "dotenv-secret",
+				HOME: root,
+				LAUNCHER_ONLY: "from-launcher",
+			},
+			spawn: (_command, options) => {
+				launch = options;
+				return { exited: Promise.resolve(0) };
+			},
+		});
+
+		expect(launch?.env.DOTENV_ONLY_SECRET).toBeUndefined();
+		expect(launch?.env.LAUNCHER_ONLY).toBe("from-launcher");
+		expect(launch?.env.OMP_INTERACTIVE_SHELL_CWD_RECORD).toBeDefined();
+	});
+
+	it("removes launch-project dotenv values after the session cwd changes", async () => {
+		const launchRoot = await makeTestRoot();
+		const sessionRoot = await makeTestRoot();
+		await Bun.write(
+			path.join(launchRoot, ".env"),
+			'OLD_PROJECT_SECRET=launch-project-secret\nMULTILINE_SECRET="first\nsecond"\n',
+		);
+		const modulePath = path.resolve(import.meta.dir, "../src/exec/interactive-shell.ts");
+		// A subprocess import is required so the module captures launchRoot before the test changes cwd.
+		const script = `
+			const { runInteractiveShell } = await import(${JSON.stringify(modulePath)});
+			const loadedSecret = process.env.OLD_PROJECT_SECRET;
+			const loadedMultilineSecret = process.env.MULTILINE_SECRET;
+			process.chdir(${JSON.stringify(sessionRoot)});
+			let childEnv;
+			await runInteractiveShell({
+				shellPath: "/bin/bash",
+				cwd: ${JSON.stringify(sessionRoot)},
+				env: { ...process.env, LAUNCHER_ONLY: "from-launcher" },
+				spawn: (_command, options) => {
+					childEnv = options.env;
+					return { exited: Promise.resolve(0) };
+				},
+			});
+			console.log(JSON.stringify({
+				loadedSecret,
+				childSecret: childEnv?.OLD_PROJECT_SECRET,
+				loadedMultilineSecret,
+				childMultilineSecret: childEnv?.MULTILINE_SECRET,
+				launcher: childEnv?.LAUNCHER_ONLY,
+			}));
+		`;
+		const child = Bun.spawn([process.execPath, "-e", script], {
+			cwd: launchRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(JSON.parse(stdout.trim())).toEqual({
+			loadedSecret: "launch-project-secret",
+			loadedMultilineSecret: "first\nsecond",
+			launcher: "from-launcher",
+		});
+	});
+
+	it("creates a private zsh bootstrap that restores ZDOTDIR and sources the original .zshenv once", async () => {
+		const root = await makeTestRoot();
+		const originalZdotdir = path.join(root, "original-zdotdir");
+		await fs.mkdir(originalZdotdir);
+		const originalZshenv = path.join(originalZdotdir, ".zshenv");
+		const originalContents = "typeset -g OMP_TEST_ZSHENV=loaded\n";
+		await Bun.write(originalZshenv, originalContents);
+		let temporaryZdotdir: string | undefined;
+
+		await runInteractiveShell({
+			shellPath: "/bin/zsh",
+			cwd: root,
+			env: { HOME: root, ZDOTDIR: originalZdotdir },
+			spawn: (_command, options) => ({
+				exited: (async () => {
+					temporaryZdotdir = options.env.ZDOTDIR;
+					expect(temporaryZdotdir).not.toBe(originalZdotdir);
+					const recordPath = await findRecordPath(temporaryZdotdir as string);
+					const bootstrapPath = path.join(temporaryZdotdir as string, ".zshenv");
+					const [directoryStat, recordStat, bootstrapStat, bootstrap] = await Promise.all([
+						fs.stat(temporaryZdotdir as string),
+						fs.stat(recordPath),
+						fs.stat(bootstrapPath),
+						Bun.file(bootstrapPath).text(),
+					]);
+					if (process.platform !== "win32") {
+						expect(directoryStat.mode & 0o777).toBe(0o700);
+						expect(recordStat.mode & 0o777).toBe(0o600);
+						expect(bootstrapStat.mode & 0o777).toBe(0o600);
+					}
+					expect(options.env.OMP_INTERACTIVE_SHELL_ORIGINAL_ZDOTDIR).toBe(originalZdotdir);
+					expect(bootstrap.match(/builtin source/g)).toHaveLength(1);
+					expect(bootstrap).toMatch(/add-zsh-hook chpwd _omp_chpwd_[a-f0-9]+/);
+					expect(bootstrap).toMatch(/add-zsh-hook zshexit _omp_zshexit_[a-f0-9]+/);
+					expect(bootstrap).toContain("export ZDOTDIR");
+					return 0;
+				})(),
+			}),
+		});
+
+		expect(await Bun.file(originalZshenv).text()).toBe(originalContents);
+		expect(temporaryZdotdir).toBeDefined();
+		expect(await pathExists(temporaryZdotdir as string)).toBe(false);
+	});
+
+	it("preserves normal zsh alias and option behavior after bootstrap", async () => {
+		if (!(await Bun.file("/bin/zsh").exists())) return;
+		const root = await makeTestRoot();
+		const originalZdotdir = path.join(root, "original-zdotdir");
+		await fs.mkdir(originalZdotdir);
+		await Bun.write(
+			path.join(originalZdotdir, ".zshenv"),
+			"setopt extendedglob\ntypeset OMP_TYPESET_VALUE=kept\nOMP_ASSIGN_VALUE=kept\n",
+		);
+		await Bun.write(
+			path.join(originalZdotdir, ".zshrc"),
+			[
+				"alias omp_alias='print -r -- alias-ok'",
+				`print -r -- "aliases=\${options[aliases]} localoptions=\${options[localoptions]}"`,
+				`print -r -- "extendedglob=\${options[extendedglob]} typeset=\${OMP_TYPESET_VALUE-unset} assign=\${OMP_ASSIGN_VALUE-unset}"`,
+				"omp_alias",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		let shellOutput = "";
+
+		const result = await runInteractiveShell({
+			shellPath: "/bin/zsh",
+			cwd: root,
+			env: { HOME: root, ZDOTDIR: originalZdotdir },
+			spawn: (command, options) => ({
+				exited: (async () => {
+					const child = Bun.spawn(command, { ...options, stdout: "pipe", stderr: "pipe" });
+					const [stdout, stderr, exitCode] = await Promise.all([
+						new Response(child.stdout).text(),
+						new Response(child.stderr).text(),
+						child.exited,
+					]);
+					shellOutput = stdout;
+					expect(stderr).toBe("");
+					return exitCode;
+				})(),
+			}),
+		});
+
+		expect(shellOutput).toContain("extendedglob=on typeset=kept assign=kept");
+		expect(result.exitCode).toBe(0);
+		expect(shellOutput).toContain("aliases=on localoptions=off");
+		expect(shellOutput).toContain("alias-ok");
+	});
+
+	it("returns a validated final zsh working directory with ordinary non-ASCII characters", async () => {
+		const root = await makeTestRoot();
+		const finalCwd = path.join(root, "final-café-日本語");
+		await fs.mkdir(finalCwd);
+
+		const result = await runZshWithRecord(root, recordPath => Bun.write(recordPath, finalCwd).then(() => {}));
+
+		expect(result).toEqual({ exitCode: 0, workingDir: finalCwd });
+	});
+
+	it.each([
+		["C0 U+0001", "\u0001"],
+		["C0 U+001F", "\u001f"],
+		["DEL U+007F", "\u007f"],
+		["C1 U+0080", "\u0080"],
+		["C1 U+009F", "\u009f"],
+	] as const)(
+		"rejects an existing absolute zsh cwd containing %s before adoption",
+		async (_name, controlCharacter) => {
+			if (process.platform === "win32") return;
+			const root = await makeTestRoot();
+			const unsafeCwd = path.join(root, `unsafe-${controlCharacter}-directory`);
+			await fs.mkdir(unsafeCwd);
+
+			const result = await runZshWithRecord(root, recordPath => Bun.write(recordPath, unsafeCwd).then(() => {}));
+
+			expect(result).toEqual({ exitCode: 0 });
+		},
+	);
+
+	it("rejects a missing zsh cwd record", async () => {
+		const root = await makeTestRoot();
+		const result = await runZshWithRecord(root, recordPath => fs.rm(recordPath));
+		expect(result).toEqual({ exitCode: 0 });
+	});
+
+	it("rejects a relative zsh cwd record", async () => {
+		const root = await makeTestRoot();
+		const result = await runZshWithRecord(root, recordPath => Bun.write(recordPath, "relative/path").then(() => {}));
+		expect(result).toEqual({ exitCode: 0 });
+	});
+
+	it("rejects an oversized zsh cwd record", async () => {
+		const root = await makeTestRoot();
+		const result = await runZshWithRecord(root, recordPath =>
+			Bun.write(recordPath, Buffer.alloc(4097, 0x61)).then(() => {}),
+		);
+		expect(result).toEqual({ exitCode: 0 });
+	});
+
+	it("rejects a zsh cwd record that names a non-directory", async () => {
+		const root = await makeTestRoot();
+		const regularFile = path.join(root, "regular-file");
+		await Bun.write(regularFile, "content");
+		const result = await runZshWithRecord(root, recordPath => Bun.write(recordPath, regularFile).then(() => {}));
+		expect(result).toEqual({ exitCode: 0 });
+	});
+
+	it("removes zsh temporary files after a normal exit", async () => {
+		const root = await makeTestRoot();
+		let temporaryZdotdir: string | undefined;
+		await runInteractiveShell({
+			shellPath: "/bin/zsh",
+			cwd: root,
+			env: { HOME: root },
+			spawn: (_command, options) => {
+				temporaryZdotdir = options.env.ZDOTDIR;
+				return { exited: Promise.resolve(0) };
+			},
+		});
+		expect(await pathExists(temporaryZdotdir as string)).toBe(false);
+	});
+
+	it("removes zsh temporary files when spawning fails", async () => {
+		const root = await makeTestRoot();
+		let temporaryZdotdir: string | undefined;
+		const result = runInteractiveShell({
+			shellPath: "/bin/zsh",
+			cwd: root,
+			env: { HOME: root },
+			spawn: (_command, options) => {
+				temporaryZdotdir = options.env.ZDOTDIR;
+				throw new Error("spawn failed");
+			},
+		});
+
+		await expect(result).rejects.toThrow("spawn failed");
+		expect(await pathExists(temporaryZdotdir as string)).toBe(false);
+	});
+});
+
+describe("resolveInteractiveShellPath", () => {
+	it("keeps the configured shellPath ahead of an executable SHELL", () => {
+		const configuredShell = "/configured/custom-shell";
+		const settings = {
+			get: (_key: "shellPath") => configuredShell,
+			getShellConfig: () => ({ shell: configuredShell, args: ["-l", "-c"], env: {}, prefix: undefined }),
+		};
+
+		expect(resolveInteractiveShellPath(settings, { SHELL: "/bin/zsh" })).toBe(configuredShell);
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"uses an executable supported SHELL when shellPath is not configured",
+		async () => {
+			const root = await makeTestRoot();
+			const envShell = path.join(root, "fish");
+			await Bun.write(envShell, "#!/bin/sh\nexit 0\n");
+			await fs.chmod(envShell, 0o700);
+			const settings = {
+				get: (_key: "shellPath") => undefined,
+				getShellConfig: (env?: Record<string, string | undefined>) => getProcessShellConfig(undefined, { env }),
+			};
+
+			expect(resolveInteractiveShellPath(settings, { SHELL: envShell })).toBe(envShell);
+		},
+	);
+
+	it.skipIf(process.platform === "win32")("keeps the settings fallback when SHELL is not executable", async () => {
+		const root = await makeTestRoot();
+		const envShell = path.join(root, "zsh");
+		await Bun.write(envShell, "not executable\n");
+		await fs.chmod(envShell, 0o600);
+		const settings = {
+			get: (_key: "shellPath") => undefined,
+			getShellConfig: (env?: Record<string, string | undefined>) => getProcessShellConfig(undefined, { env }),
+		};
+
+		expect(resolveInteractiveShellPath(settings, { SHELL: envShell })).toBe("/bin/bash");
+	});
+
+	it("does not resolve the shell from a launch-project dotenv PATH", async () => {
+		if (process.platform === "win32") return;
+		const launchRoot = await makeTestRoot();
+		const binDir = path.join(launchRoot, "bin");
+		await fs.mkdir(binDir);
+		const attackerShell = path.join(launchRoot, "bash");
+		await Bun.write(attackerShell, "#!/bin/sh\nexit 0\n");
+		await fs.chmod(attackerShell, 0o700);
+		await Bun.write(path.join(launchRoot, ".env"), `# ignored="\nPATH=${binDir}\nSHELL=${attackerShell}\n`);
+		const modulePath = path.resolve(import.meta.dir, "../src/exec/interactive-shell.ts");
+		const procmgrPath = path.resolve(import.meta.dir, "../../utils/src/procmgr.ts");
+		const script = `
+			const { resolveInteractiveShellPath } = await import(${JSON.stringify(modulePath)});
+			const { getShellConfig } = await import(${JSON.stringify(procmgrPath)});
+			const settings = {
+				get: () => undefined,
+				getShellConfig: env => getShellConfig(undefined, { env }),
+			};
+			console.log(resolveInteractiveShellPath(settings));
+		`;
+		const childEnv = { ...process.env };
+		delete childEnv.PATH;
+		delete childEnv.SHELL;
+		const child = Bun.spawn([process.execPath, "-e", script], {
+			cwd: launchRoot,
+			env: childEnv,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(stdout.trim()).not.toBe(attackerShell);
+		expect(stdout.trim()).toMatch(/^\/(?:usr\/)?bin\/(?:ba)?sh$/);
+	});
+
+	it("rejects multiline launch-project dotenv shell selection values", async () => {
+		if (process.platform === "win32") return;
+		const launchRoot = await makeTestRoot();
+		const attackerShell = path.join(launchRoot, "bash\npayload");
+		await Bun.write(attackerShell, "#!/bin/sh\nexit 0\n");
+		await fs.chmod(attackerShell, 0o700);
+		await Bun.write(path.join(launchRoot, ".env"), `SHELL="${attackerShell}"\nPATH="${launchRoot}\npayload"\n`);
+		const modulePath = path.resolve(import.meta.dir, "../src/exec/interactive-shell.ts");
+		const procmgrPath = path.resolve(import.meta.dir, "../../utils/src/procmgr.ts");
+		const script = `
+			const { resolveInteractiveShellPath } = await import(${JSON.stringify(modulePath)});
+			const { getShellConfig } = await import(${JSON.stringify(procmgrPath)});
+			const settings = {
+				get: () => undefined,
+				getShellConfig: env => getShellConfig(undefined, { env }),
+			};
+			console.log(resolveInteractiveShellPath(settings));
+		`;
+		const childEnv = { ...process.env };
+		delete childEnv.PATH;
+		delete childEnv.SHELL;
+		const child = Bun.spawn([process.execPath, "-e", script], {
+			cwd: launchRoot,
+			env: childEnv,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(stdout.trim()).not.toBe(attackerShell);
+		expect(stdout.trim()).toMatch(/^\/(?:usr\/)?bin\/(?:ba)?sh$/);
+	});
+});

--- a/packages/coding-agent/test/modes/components/welcome.test.ts
+++ b/packages/coding-agent/test/modes/components/welcome.test.ts
@@ -36,6 +36,15 @@ describe("WelcomeComponent tips", () => {
 		expect(welcomeRegular.tip).toBeDefined();
 	});
 
+	it("labels the shortcut as a shell and shows the resolved shell name", () => {
+		const welcome = new WelcomeComponent("1.0.0", "model", "provider", [], [], "zsh");
+
+		const rendered = Bun.stripANSI(welcome.render(120).join("\n"));
+
+		expect(rendered).toContain("! for shell (zsh)");
+		expect(rendered).not.toContain("run bash");
+	});
+
 	it("weights [NEW] tips above ordinary tips in selection", () => {
 		// Data-independent: tips.txt may legitimately carry zero "[NEW]" tips, so
 		// exercise the weighting contract on a synthetic list.

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -79,6 +79,18 @@ describe("buildHotkeysMarkdown", () => {
 		expect(markdown).toContain("| `Alt+M` | Select model (set roles) |");
 	});
 
+	it("describes interactive and quick shortcuts as configured-shell operations", () => {
+		const markdown = buildHotkeysMarkdown({
+			keybindings: { getDisplayString: () => "Disabled" },
+			shellName: "zsh",
+		});
+
+		expect(markdown).toContain("| `!` | Open interactive shell (zsh) |");
+		expect(markdown).toContain("| `! command` | Run shell command |");
+		expect(markdown).toContain("| `!! command` | Run shell command (excluded from context) |");
+		expect(markdown).not.toContain("Run bash");
+	});
+
 	it("renders macOS static navigation rows on darwin", () => {
 		setKeyHintPlatform("darwin");
 		const markdown = buildHotkeysMarkdown({ keybindings: { getDisplayString: () => "Disabled" } });

--- a/packages/coding-agent/test/modes/controllers/interactive-shell-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/interactive-shell-command.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as interactiveShell from "@oh-my-pi/pi-coding-agent/exec/interactive-shell";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+function createContext(options: { isStreaming?: boolean; isBashRunning?: boolean; isEvalRunning?: boolean } = {}) {
+	const order: string[] = [];
+	const moveTo = vi.fn(async () => {});
+	const applyCwdChange = vi.fn(async () => {});
+	const reloadTodos = vi.fn(async () => {});
+	const stop = vi.fn(() => {
+		order.push("stop");
+	});
+	const start = vi.fn(() => {
+		order.push("start");
+	});
+	const ctx = {
+		ui: { stop, start, requestRender: vi.fn() },
+		settings: {},
+		session: {
+			isStreaming: options.isStreaming ?? false,
+			isBashRunning: options.isBashRunning ?? false,
+			isEvalRunning: options.isEvalRunning ?? false,
+		},
+		sessionManager: {
+			getCwd: () => "/repo/current",
+			moveTo,
+		},
+		applyCwdChange,
+		updateEditorBorderColor: vi.fn(),
+		reloadTodos,
+		showStatus: vi.fn(),
+		showWarning: vi.fn(),
+		showError: vi.fn(),
+	} as unknown as InteractiveModeContext;
+	return { ctx, order, moveTo, applyCwdChange, reloadTodos, start, stop };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("CommandController interactive shell", () => {
+	it("hands terminal ownership to the shell and restores the TUI once after success", async () => {
+		const { ctx, order, start, stop } = createContext();
+		vi.spyOn(interactiveShell, "resolveInteractiveShellPath").mockReturnValue("/bin/zsh");
+		vi.spyOn(interactiveShell, "runInteractiveShell").mockImplementation(async () => {
+			order.push("run");
+			return { exitCode: 0 };
+		});
+
+		await new CommandController(ctx).handleInteractiveShell();
+
+		expect(order).toEqual(["stop", "run", "start"]);
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(start).toHaveBeenCalledTimes(1);
+		expect(ctx.showStatus).toHaveBeenCalledWith("Opening shell (zsh)...");
+	});
+
+	it("restores the TUI once and reports a spawn failure", async () => {
+		const { ctx, start, stop } = createContext();
+		vi.spyOn(interactiveShell, "resolveInteractiveShellPath").mockReturnValue("/bin/zsh");
+		vi.spyOn(interactiveShell, "runInteractiveShell").mockRejectedValue(new Error("spawn denied"));
+
+		await new CommandController(ctx).handleInteractiveShell();
+
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(start).toHaveBeenCalledTimes(1);
+		expect(ctx.showError).toHaveBeenCalledWith("Failed to open shell (zsh): spawn denied");
+	});
+
+	it("restores the TUI once when stopping it throws after partial teardown", async () => {
+		const { ctx, order, start, stop } = createContext();
+		vi.spyOn(interactiveShell, "resolveInteractiveShellPath").mockReturnValue("/bin/zsh");
+		const run = vi.spyOn(interactiveShell, "runInteractiveShell");
+		stop.mockImplementation(() => {
+			order.push("stop");
+			throw new Error("stop failed");
+		});
+
+		await new CommandController(ctx).handleInteractiveShell();
+
+		expect(order).toEqual(["stop", "start"]);
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(start).toHaveBeenCalledTimes(1);
+		expect(run).not.toHaveBeenCalled();
+		expect(ctx.showError).toHaveBeenCalledWith("Failed to open shell (zsh): stop failed");
+	});
+
+	it("adopts the validated shell cwd through the existing cwd reload flow", async () => {
+		const { ctx, moveTo, applyCwdChange, reloadTodos } = createContext();
+		vi.spyOn(interactiveShell, "resolveInteractiveShellPath").mockReturnValue("/bin/zsh");
+		vi.spyOn(interactiveShell, "runInteractiveShell").mockResolvedValue({
+			exitCode: 0,
+			workingDir: "/repo/next",
+		});
+
+		await new CommandController(ctx).handleInteractiveShell();
+
+		expect(moveTo).toHaveBeenCalledWith("/repo/next");
+		expect(applyCwdChange).toHaveBeenCalledWith("/repo/next");
+		expect(ctx.updateEditorBorderColor).toHaveBeenCalledTimes(1);
+		expect(reloadTodos).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not transfer terminal ownership while session work is active", async () => {
+		const { ctx, start, stop } = createContext({ isBashRunning: true });
+		vi.spyOn(interactiveShell, "resolveInteractiveShellPath").mockReturnValue("/bin/zsh");
+		const run = vi.spyOn(interactiveShell, "runInteractiveShell");
+
+		await new CommandController(ctx).handleInteractiveShell();
+
+		expect(run).not.toHaveBeenCalled();
+		expect(stop).not.toHaveBeenCalled();
+		expect(start).not.toHaveBeenCalled();
+		expect(ctx.showWarning).toHaveBeenCalledWith(
+			"Wait for active work to finish or abort it before opening a shell.",
+		);
+	});
+});

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -1,10 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	KeybindingsManager as AppKeybindingsManager,
 	setKeyHintPlatform,
 } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { createPromptActionAutocompleteProvider } from "@oh-my-pi/pi-coding-agent/modes/prompt-action-autocomplete";
-import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui";
+import { Editor, KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui";
+import { defaultEditorTheme } from "../../tui/test/test-themes.js";
+
+function onceAutocompleteUpdate(editor: Editor): Promise<void> {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	const previous = editor.onAutocompleteUpdate;
+	editor.onAutocompleteUpdate = () => {
+		editor.onAutocompleteUpdate = previous;
+		previous?.();
+		resolve();
+	};
+	return promise;
+}
 
 describe("prompt action autocomplete", () => {
 	beforeEach(() => {
@@ -275,5 +290,261 @@ describe("prompt action autocomplete", () => {
 		});
 
 		expect(provider.trySyncSlashCompletion("hello")).toBeNull();
+	});
+
+	describe("bang command completion", () => {
+		let originalPath: string | undefined;
+		let tempDir: string;
+		let binDir: string;
+		let duplicateBinDir: string;
+		let executableName: string;
+
+		beforeEach(() => {
+			originalPath = process.env.PATH;
+			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "prompt-action-bang-autocomplete-"));
+			binDir = path.join(tempDir, "bin");
+			duplicateBinDir = path.join(tempDir, "duplicate-bin");
+			fs.mkdirSync(binDir);
+			fs.mkdirSync(duplicateBinDir);
+			executableName = process.platform === "win32" ? "alpha-tool.cmd" : "alpha-tool";
+
+			const sentinelPath = path.join(tempDir, "should-not-exist");
+			for (const directory of [binDir, duplicateBinDir]) {
+				const executablePath = path.join(directory, executableName);
+				const executableBody =
+					process.platform === "win32"
+						? `@echo off\r\ntype nul > "${sentinelPath}"\r\n`
+						: `#!/bin/sh\ntouch ${JSON.stringify(sentinelPath)}\n`;
+				fs.writeFileSync(executablePath, executableBody);
+				if (process.platform !== "win32") fs.chmodSync(executablePath, 0o755);
+			}
+			const otherExecutable = path.join(binDir, process.platform === "win32" ? "alpine-tool.cmd" : "alpine-tool");
+			fs.writeFileSync(otherExecutable, "#!/bin/sh\nexit 0\n");
+			if (process.platform !== "win32") fs.chmodSync(otherExecutable, 0o755);
+			const nonExecutable = path.join(binDir, "alpha-disabled");
+			fs.writeFileSync(nonExecutable, "#!/bin/sh\nexit 0\n");
+			if (process.platform !== "win32") fs.chmodSync(nonExecutable, 0o644);
+			process.env.PATH = [binDir, duplicateBinDir].join(path.delimiter);
+		});
+
+		afterEach(() => {
+			if (originalPath === undefined) {
+				delete process.env.PATH;
+			} else {
+				process.env.PATH = originalPath;
+			}
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		function createProvider() {
+			return createPromptActionAutocompleteProvider({
+				commands: [],
+				basePath: tempDir,
+				keybindings: AppKeybindingsManager.inMemory(),
+				copyCurrentLine: () => {},
+				copyPrompt: () => {},
+				undo: () => {},
+				moveCursorToMessageEnd: () => {},
+				moveCursorToMessageStart: () => {},
+				moveCursorToLineStart: () => {},
+				moveCursorToLineEnd: () => {},
+			});
+		}
+
+		it("delegates forced file completion for bare arguments and path-like executable tokens", async () => {
+			fs.writeFileSync(path.join(tempDir, "input.txt"), "content\n");
+			fs.writeFileSync(path.join(tempDir, "script.sh"), "#!/bin/sh\nexit 0\n");
+			const provider = createProvider();
+			const cases = [
+				{ line: "! cat inp", prefix: "inp", value: "input.txt" },
+				{ line: "! ./scr", prefix: "./scr", value: "./script.sh" },
+			];
+
+			for (const { line, prefix, value } of cases) {
+				expect(provider.shouldTriggerFileCompletion([line], 0, line.length)).toBe(true);
+				const suggestions = await provider.getForceFileSuggestions([line], 0, line.length);
+				expect(suggestions?.prefix).toBe(prefix);
+				expect(suggestions?.items.map(item => item.value)).toContain(value);
+			}
+
+			const slashCommand = "/set";
+			expect(provider.shouldTriggerFileCompletion([slashCommand], 0, slashCommand.length)).toBe(false);
+		});
+
+		it("opens filesystem candidates on first Tab and applies them on second Tab", async () => {
+			fs.writeFileSync(path.join(tempDir, "input.txt"), "content\n");
+			fs.writeFileSync(path.join(tempDir, "script.sh"), "#!/bin/sh\nexit 0\n");
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+			const cases = [
+				{ line: "! cat inp", completed: "! cat input.txt" },
+				{ line: "! ./scr", completed: "! ./script.sh" },
+			];
+
+			for (const { line, completed } of cases) {
+				const editor = new Editor(defaultEditorTheme);
+				editor.setAutocompleteProvider(createProvider());
+				editor.setText(line);
+
+				const autocompleteOpened = onceAutocompleteUpdate(editor);
+				editor.handleInput("\t");
+				await autocompleteOpened;
+				expect(editor.isShowingAutocomplete()).toBe(true);
+				expect(editor.getText()).toBe(line);
+
+				editor.handleInput("\t");
+				expect(editor.isShowingAutocomplete()).toBe(false);
+				expect(editor.getText()).toBe(completed);
+			}
+		});
+
+		it("applies a unique PATH executable after two Tab inputs through Editor", async () => {
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(createProvider());
+			const prefix = "alpha-t";
+			editor.setText(`! ${prefix}`);
+
+			const autocompleteOpened = onceAutocompleteUpdate(editor);
+			editor.handleInput("\t");
+			await autocompleteOpened;
+			expect(editor.isShowingAutocomplete()).toBe(true);
+			expect(editor.getText()).toBe(`! ${prefix}`);
+
+			editor.handleInput("\t");
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.getText()).toBe(`! ${executableName}`);
+		});
+
+		it("completes empty and partial first words for ! and !! from PATH without duplicates or execution", async () => {
+			const provider = createProvider();
+
+			for (const sigil of ["!", "!!"]) {
+				const emptyLine = `${sigil} `;
+				const emptySuggestions = await provider.getSuggestions([emptyLine], 0, emptyLine.length);
+				expect(emptySuggestions?.prefix).toBe("");
+				expect(emptySuggestions?.items.filter(item => item.value === executableName)).toHaveLength(1);
+
+				const partialLine = `${sigil} alp`;
+				const partialSuggestions = await provider.getSuggestions([partialLine], 0, partialLine.length);
+				expect(partialSuggestions?.prefix).toBe("alp");
+				expect(partialSuggestions?.items.map(item => item.value)).toEqual(
+					process.platform === "win32" ? ["alpha-tool.cmd", "alpine-tool.cmd"] : ["alpha-tool", "alpine-tool"],
+				);
+				expect(partialSuggestions?.items.some(item => item.value === "alpha-disabled")).toBe(false);
+			}
+
+			expect(fs.existsSync(path.join(tempDir, "should-not-exist"))).toBe(false);
+		});
+
+		it("excludes executable names that would change shell syntax or terminal display", async () => {
+			if (process.platform === "win32") return;
+			const unsafeNames = [
+				"safe$(touch pwn)",
+				"safe;touch-pwn",
+				"safe\nline",
+				"safe\n",
+				"safe\r",
+				"safe\u001bescape",
+			];
+			for (const name of unsafeNames) {
+				const executablePath = path.join(binDir, name);
+				fs.writeFileSync(executablePath, "#!/bin/sh\nexit 0\n");
+				fs.chmodSync(executablePath, 0o755);
+			}
+			const provider = createProvider();
+			const line = "! safe";
+			const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+			expect(suggestions?.items.filter(item => unsafeNames.includes(item.value)) ?? []).toEqual([]);
+		});
+
+		it("does not expose executables from a launch-project dotenv PATH", async () => {
+			if (process.platform === "win32") return;
+			const launchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omp-hostile-completion-env-"));
+			const launchBin = path.join(launchRoot, "bin");
+			fs.mkdirSync(launchBin);
+			const attackerName = "project-pwn";
+			const attackerPath = path.join(launchRoot, attackerName);
+			fs.writeFileSync(attackerPath, "#!/bin/sh\nexit 0\n");
+			fs.chmodSync(attackerPath, 0o755);
+			fs.writeFileSync(path.join(launchRoot, ".env"), `PATH=${launchBin}\n`);
+			const modulePath = path.resolve(import.meta.dir, "../src/modes/prompt-action-autocomplete.ts");
+			const script = `
+				const { PromptActionAutocompleteProvider } = await import(${JSON.stringify(modulePath)});
+				const provider = new PromptActionAutocompleteProvider([], ${JSON.stringify(launchRoot)}, []);
+				const line = "! project";
+				const suggestions = await provider.getSuggestions([line], 0, line.length);
+				console.log(JSON.stringify(suggestions?.items.map(item => item.value) ?? []));
+			`;
+			const childEnv = { ...process.env };
+			delete childEnv.PATH;
+			const child = Bun.spawn([process.execPath, "-e", script], {
+				cwd: launchRoot,
+				env: childEnv,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited,
+			]);
+
+			try {
+				expect(exitCode, stderr).toBe(0);
+				expect(JSON.parse(stdout.trim())).toEqual([]);
+			} finally {
+				fs.rmSync(launchRoot, { recursive: true, force: true });
+			}
+		});
+
+		it("reuses filesystem completion for later unquoted and quoted path tokens", async () => {
+			fs.writeFileSync(path.join(tempDir, "input.ts"), "export {};\n");
+			fs.writeFileSync(path.join(tempDir, "input file.txt"), "content\n");
+			const provider = createProvider();
+
+			const pathLine = `! ${executableName} ./inp`;
+			const pathSuggestions = await provider.getSuggestions([pathLine], 0, pathLine.length);
+			expect(pathSuggestions?.prefix).toBe("./inp");
+			const pathItem = pathSuggestions?.items.find(item => item.value === "./input.ts");
+			expect(pathItem).toBeDefined();
+			if (!pathSuggestions || !pathItem) throw new Error("expected path suggestion");
+			expect(
+				provider.applyCompletion([pathLine], 0, pathLine.length, pathItem, pathSuggestions.prefix).lines,
+			).toEqual([`! ${executableName} ./input.ts`]);
+
+			const quotedLine = `!! ${executableName} "input f`;
+			const quotedSuggestions = await provider.getSuggestions([quotedLine], 0, quotedLine.length);
+			expect(quotedSuggestions?.prefix).toBe('"input f');
+			const quotedItem = quotedSuggestions?.items.find(item => item.value === '"input file.txt"');
+			expect(quotedItem).toBeDefined();
+			if (!quotedSuggestions || !quotedItem) throw new Error("expected quoted path suggestion");
+			expect(
+				provider.applyCompletion([quotedLine], 0, quotedLine.length, quotedItem, quotedSuggestions.prefix).lines,
+			).toEqual([`!! ${executableName} "input file.txt"`]);
+		});
+
+		it("replaces only the first command word at a cursor in the middle", async () => {
+			const provider = createProvider();
+			const line = "! alp --version";
+			const cursorCol = "! alp".length;
+			const suggestions = await provider.getSuggestions([line], 0, cursorCol);
+			const item = suggestions?.items.find(entry => entry.value === executableName);
+			expect(suggestions?.prefix).toBe("alp");
+			expect(item).toBeDefined();
+			if (!suggestions || !item) throw new Error("expected executable suggestion");
+
+			const result = provider.applyCompletion([line], 0, cursorCol, item, suggestions.prefix);
+			expect(result.lines).toEqual([`! ${executableName} --version`]);
+			expect(result.cursorCol).toBe(`! ${executableName}`.length);
+		});
+
+		it("does not expose PATH executables to normal prompts or embedded bangs", async () => {
+			const provider = createProvider();
+
+			expect(await provider.getSuggestions(["alp"], 0, 3)).toBeNull();
+			const prose = "please run ! alp";
+			expect(await provider.getSuggestions([prose], 0, prose.length)).toBeNull();
+		});
 	});
 });

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -36,8 +36,13 @@ export function isMacosMallocStackLoggingEnvName(name: string): boolean {
 	return name === "MallocStackLogging" || name === "MallocStackLoggingNoCompact";
 }
 
+function normalizedEnvName(name: string, platform: NodeJS.Platform = process.platform): string {
+	return platform === "win32" ? name.toUpperCase() : name;
+}
+
 export function filterProcessEnv(env: Record<string, string | undefined>): Record<string, string> {
 	const result: Record<string, string> = {};
+	const platform = process.platform;
 	for (const key in env) {
 		const value = env[key];
 		if (
@@ -48,21 +53,28 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 		) {
 			continue;
 		}
-		result[key] = value;
+		const normalizedName = normalizedEnvName(key, platform);
+		const outputName =
+			platform === "win32" && (normalizedName === "PATH" || normalizedName === "PATHEXT") ? normalizedName : key;
+		result[outputName] = value;
 	}
 	return result;
 }
+
 // Bun autoloads the project's dotenv files into `process.env` before user code
-// runs — including inside `bun build --compile` binaries — so a snapshot of
-// `Bun.env` is only pre-dotenv when autoloading was explicitly disabled. Linux
-// keeps the original exec environment in procfs, which is authoritative.
+// runs — including inside `bun build --compile` binaries. Linux retains the
+// immutable launch environment in procfs. On other platforms, `Bun.env` is a
+// trustworthy pre-dotenv snapshot only when autoloading was explicitly disabled.
 function readLaunchEnv(): ReadonlyMap<string, string> | undefined {
-	if (process.platform === "linux") {
+	const platform = process.platform;
+	if (platform === "linux") {
 		try {
 			const values = new Map<string, string>();
 			for (const entry of fs.readFileSync("/proc/self/environ", "utf8").split("\0")) {
 				const separator = entry.indexOf("=");
-				if (separator > 0) values.set(entry.slice(0, separator), entry.slice(separator + 1));
+				if (separator > 0) {
+					values.set(normalizedEnvName(entry.slice(0, separator), platform), entry.slice(separator + 1));
+				}
 			}
 			return values;
 		} catch {}
@@ -71,31 +83,20 @@ function readLaunchEnv(): ReadonlyMap<string, string> | undefined {
 	const values = new Map<string, string>();
 	for (const key in Bun.env) {
 		const value = Bun.env[key];
-		if (value !== undefined) values.set(key, value);
+		if (value !== undefined) values.set(normalizedEnvName(key, platform), value);
 	}
 	return values;
 }
 
 const launchEnvValues = readLaunchEnv();
-const projectEnvNamesLoadedByOmp = new Set<string>();
 
-function expandDotenvValues(values: Record<string, string>, env: Record<string, string>): Record<string, string> {
-	const expanded: Record<string, string> = {};
-	for (const key in values) {
-		expanded[key] = values[key].replace(
-			/(\\)?\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
-			(match, escaped: string | undefined, braced: string | undefined, bare: string | undefined) => {
-				if (escaped) return match.slice(1);
-				const name = braced ?? bare;
-				if (!name) return match;
-				return env[name] ?? expanded[name] ?? "";
-			},
-		);
-	}
-	return expanded;
-}
-
-/** Filters process env for child shells without launch-cwd dotenv values. */
+/**
+ * Filters process env for child shells without launch-cwd dotenv values.
+ *
+ * Dotenv-owned names use only the authoritative pre-dotenv launch snapshot.
+ * When no trustworthy snapshot exists, those names are removed rather than
+ * reconstructed from an environment Bun has already mutated.
+ */
 export function filterChildShellEnv(
 	env: Record<string, string | undefined>,
 	cwd: string = process.cwd(),
@@ -105,49 +106,43 @@ export function filterChildShellEnv(
 	const nodeEnvName = `.env.${env.NODE_ENV || "development"}`;
 	const modeEnv = parseEnvFile(path.join(cwd, nodeEnvName));
 	const localEnv = parseEnvFile(path.join(cwd, ".env.local"));
-	const launchEnv = { ...projectEnv, ...modeEnv, ...localEnv };
-	const expandedLaunchEnv = {
-		...expandDotenvValues(projectEnv, result),
-		...expandDotenvValues(modeEnv, result),
-		...expandDotenvValues(localEnv, result),
-	};
-	for (const key in launchEnv) {
-		const launchValue = launchEnvValues?.get(key);
-		if (launchValue !== undefined) {
-			// Launcher-owned name: it keeps the launcher's own value. Bun overwrites
-			// an empty launcher value with the dotenv one, so restore the launcher
-			// value whenever what survived is exactly what the dotenv file defines.
-			if (
-				result[key] !== launchValue &&
-				(result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key])
-			) {
-				result[key] = launchValue;
-			}
-			continue;
-		}
-		if (launchEnvValues || projectEnvNamesLoadedByOmp.has(key)) {
-			// Strong provenance: the launch environment is known and this name is
-			// absent from it, or OMP itself injected the value — either way it came
-			// from a project dotenv file, not the parent shell.
+	const platform = process.platform;
+	const dotenvNames = new Set<string>();
+	for (const file of [projectEnv, modeEnv, localEnv]) {
+		for (const key in file) dotenvNames.add(normalizedEnvName(key, platform));
+	}
+	for (const key in result) {
+		const name = normalizedEnvName(key, platform);
+		if (!dotenvNames.has(name)) continue;
+		const launchValue = launchEnvValues?.get(name);
+		if (launchValue === undefined) {
 			delete result[key];
-		} else if (result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key]) {
-			// No launch-env snapshot (dotenv autoloaded without procfs): best-effort
-			// value match against the Bun-parsed dotenv.
-			delete result[key];
+		} else {
+			result[key] = launchValue;
 		}
 	}
 	return result;
 }
 
+function findClosingEnvQuote(value: string, quote: string): number {
+	for (let index = 1; index < value.length; index++) {
+		if (value[index] !== quote) continue;
+		let backslashes = 0;
+		for (let previous = index - 1; previous >= 0 && value[previous] === "\\"; previous--) backslashes++;
+		if (backslashes % 2 === 0) return index;
+	}
+	return -1;
+}
+
 /**
- * Parse one dotenv line with Bun-compatible semantics: an optional `export`
- * prefix, full-line `#` comments, inline `#` comments after whitespace on
- * unquoted values, and single/double/backtick quoting (a `#` inside quotes
- * stays literal). Returns undefined for blank lines, comments, and malformed
- * names.
+ * Parse one dotenv assignment with Bun-compatible semantics: an optional
+ * `export` prefix, full-line `#` comments, inline `#` comments after
+ * whitespace on unquoted values, and single/double/backtick quoting. Quoted
+ * values can contain newlines. Returns undefined for blank lines, comments,
+ * and malformed names.
  */
 function parseEnvLine(line: string): { key: string; value: string } | undefined {
-	const trimmed = line.trim();
+	const trimmed = line.trimStart();
 	if (!trimmed || trimmed.startsWith("#")) return undefined;
 	const eqIndex = trimmed.indexOf("=");
 	if (eqIndex === -1) return undefined;
@@ -158,8 +153,7 @@ function parseEnvLine(line: string): { key: string; value: string } | undefined 
 	const raw = trimmed.slice(eqIndex + 1).replace(/^[ \t]+/, "");
 	const quote = raw[0];
 	if (quote === '"' || quote === "'" || quote === "`") {
-		let close = raw.indexOf(quote, 1);
-		while (close !== -1 && raw[close - 1] === "\\") close = raw.indexOf(quote, close + 1);
+		const close = findClosingEnvQuote(raw, quote);
 		return { key, value: close === -1 ? raw.slice(1) : raw.slice(1, close) };
 	}
 	const commentIndex = raw.search(/[ \t]#/);
@@ -168,15 +162,36 @@ function parseEnvLine(line: string): { key: string; value: string } | undefined 
 
 /**
  * Parses a .env file synchronously into key-value string pairs using
- * {@link parseEnvLine} for Bun-compatible line semantics, then mirrors valid
- * `OMP_` variables to their `PI_` aliases.
+ * {@link parseEnvLine} for Bun-compatible assignment semantics, including
+ * multiline quoted values, then mirrors valid `OMP_` variables to their
+ * `PI_` aliases.
  */
 export function parseEnvFile(filePath: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	try {
-		const content = fs.readFileSync(filePath, "utf-8");
-		for (const line of content.split("\n")) {
-			const parsed = parseEnvLine(line);
+		const lines = fs.readFileSync(filePath, "utf-8").split(/\r?\n/);
+		for (let index = 0; index < lines.length; index++) {
+			let assignment = lines[index];
+			const trimmed = assignment.trimStart();
+			if (!trimmed || trimmed.startsWith("#")) continue;
+			const eqIndex = trimmed.indexOf("=");
+			if (eqIndex !== -1) {
+				let key = trimmed.slice(0, eqIndex).trim();
+				const exported = key.match(/^export[ \t]+(.*)$/);
+				if (exported) key = exported[1].trim();
+				if (isValidEnvName(key)) {
+					let raw = trimmed.slice(eqIndex + 1).replace(/^[ \t]+/, "");
+					const quote = raw[0];
+					if (quote === '"' || quote === "'" || quote === "`") {
+						while (findClosingEnvQuote(raw, quote) === -1 && index + 1 < lines.length) {
+							const continuation = lines[++index];
+							assignment += `\n${continuation}`;
+							raw += `\n${continuation}`;
+						}
+					}
+				}
+			}
+			const parsed = parseEnvLine(assignment);
 			if (parsed && isSafeEnvValue(parsed.value)) result[parsed.key] = parsed.value;
 		}
 	} catch {
@@ -210,7 +225,6 @@ for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
 	for (const key in file) {
 		if (!isMacosMallocStackLoggingEnvName(key) && !Bun.env[key]) {
 			Bun.env[key] = file[key];
-			if (file === projectEnv) projectEnvNamesLoadedByOmp.add(key);
 		}
 	}
 }

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -66,6 +66,21 @@ function exitProcess(code: number): never {
 }
 let cleanupPromise: Promise<void> | undefined;
 let stdioDisconnectRegistrations = 0;
+let sigintCleanupSuspensions = 0;
+
+/**
+ * Temporarily let an inherited-console child own Ctrl+C without triggering
+ * OMP's process-wide cleanup. The returned function is idempotent.
+ */
+export function suspendSigintCleanup(): () => void {
+	sigintCleanupSuspensions++;
+	let active = true;
+	return () => {
+		if (!active) return;
+		active = false;
+		sigintCleanupSuspensions = Math.max(0, sigintCleanupSuspensions - 1);
+	};
+}
 
 /** User-facing command printed before fatal cleanup so interrupted work can be resumed. */
 export interface FatalRecoveryHint {
@@ -268,6 +283,7 @@ async function exitAfterFatal(label: string, logMessage: string, err: Error, rea
 if (isMainThread) {
 	process
 		.on("SIGINT", async () => {
+			if (sigintCleanupSuspensions > 0) return;
 			await runCleanup(Reason.SIGINT);
 			exitProcess(130); // 128 + SIGINT (2)
 		})

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -17,6 +17,8 @@ export interface ShellConfig {
 export interface ShellConfigOptions {
 	/** File path or runtime layer that supplied the active shell setting. */
 	configSource?: string;
+	/** Environment used for shell selection and the spawned shell. Supplying it bypasses the process-global cache. */
+	env?: Record<string, string | undefined>;
 }
 let cachedShellConfig: ShellConfig | null = null;
 
@@ -31,14 +33,20 @@ export function isExecutable(path: string): boolean {
 		return false;
 	}
 }
+const SHELL_ENV_CONTROL_RE = /[\u0000-\u001f\u007f-\u009f]/;
+
+/** Whether a shell-selection environment value is safe to use as a path or PATH list. */
+export function isSafeShellEnvValue(value: string | undefined): value is string {
+	return value !== undefined && !SHELL_ENV_CONTROL_RE.test(value);
+}
 
 /**
  * Build the spawn environment (cached).
  */
-function buildSpawnEnv(shell: string): Record<string, string> {
-	const noCI = $env.PI_BASH_NO_CI || $env.CLAUDE_BASH_NO_CI;
+function buildSpawnEnv(shell: string, env: Record<string, string | undefined> = Bun.env): Record<string, string> {
+	const noCI = env.PI_BASH_NO_CI || env.CLAUDE_BASH_NO_CI;
 	return {
-		...filterChildShellEnv(Bun.env),
+		...filterChildShellEnv(env),
 		SHELL: shell,
 		GIT_EDITOR: "true",
 		GPG_TTY: "not a tty",
@@ -85,28 +93,33 @@ export function isPowerShell(shell: string): boolean {
 /**
  * Get shell prefix for wrapping commands (profilers, strace, etc.).
  */
-function getShellPrefix(): string | undefined {
-	return $env.PI_SHELL_PREFIX || $env.CLAUDE_CODE_SHELL_PREFIX;
+function getShellPrefix(env: Record<string, string | undefined> = Bun.env): string | undefined {
+	return env.PI_SHELL_PREFIX || env.CLAUDE_CODE_SHELL_PREFIX;
 }
 
 /**
  * Build full shell config from a shell path.
  */
-function buildConfig(shell: string): ShellConfig {
+function buildConfig(shell: string, env: Record<string, string | undefined> = Bun.env): ShellConfig {
 	return {
 		shell,
-		args: getShellArgs(shell),
-		env: buildSpawnEnv(shell),
-		prefix: getShellPrefix(),
+		args: getShellArgs(shell, env),
+		env: buildSpawnEnv(shell, env),
+		prefix: getShellPrefix(env),
 	};
 }
 
 /**
  * Resolve a basic shell (bash or sh) as fallback.
  */
-export function resolveBasicShell(): string | undefined {
+export function resolveBasicShell(searchPath?: string): string | undefined {
 	for (const name of ["bash", "bash.exe", "sh", "sh.exe"]) {
-		const resolved = $which(name);
+		const resolved =
+			searchPath === undefined
+				? $which(name)
+				: searchPath.length > 0 && isSafeShellEnvValue(searchPath)
+					? $which(name, { PATH: searchPath })
+					: null;
 		if (resolved) return resolved;
 	}
 
@@ -155,21 +168,22 @@ export function resolveWindowsShell(env: Record<string, string | undefined> = Bu
 		env.USERPROFILE && path.join(env.USERPROFILE, "scoop", "apps", "git", "current"),
 	];
 	for (const root of gitRoots) {
-		if (!root) continue;
+		if (!root || !isSafeShellEnvValue(root)) continue;
 		const candidate = path.join(root, "bin", "bash.exe");
 		if (fs.existsSync(candidate)) return candidate;
 	}
-
-	const bashOnPath = $which("bash.exe");
+	const trustedPath = isSafeShellEnvValue(env.PATH) ? env.PATH : "";
+	const bashOnPath = trustedPath.length > 0 ? $which("bash.exe", { PATH: trustedPath }) : null;
 	if (bashOnPath) return bashOnPath;
 
-	const shOnPath = $which("sh.exe");
+	const shOnPath = trustedPath.length > 0 ? $which("sh.exe", { PATH: trustedPath }) : null;
 	if (shOnPath) {
 		const siblingBash = path.join(path.dirname(shOnPath), "bash.exe");
 		return fs.existsSync(siblingBash) ? siblingBash : shOnPath;
 	}
 
-	return env.ComSpec || env.COMSPEC || "C:\\Windows\\System32\\cmd.exe";
+	const commandShell = env.ComSpec || env.COMSPEC;
+	return isSafeShellEnvValue(commandShell) ? commandShell : "C:\\Windows\\System32\\cmd.exe";
 }
 
 /**
@@ -182,44 +196,55 @@ export function resolveWindowsShell(env: Record<string, string | undefined> = Bu
  * 4. Fallback: sh
  */
 export function getShellConfig(customShellPath?: string, options: ShellConfigOptions = {}): ShellConfig {
+	const env = options.env ?? Bun.env;
+	const cacheable = options.env === undefined;
 	const configSource = options.configSource ?? path.join(getAgentDir(), MAIN_CONFIG_FILENAMES[0]);
 	// 1. Check user-specified shell path. Validated even on the cached path so a
 	// broken shellPath surfaces its guidance error instead of being masked by an
 	// earlier successful resolution in the same process.
 	if (customShellPath) {
+		if (!isSafeShellEnvValue(customShellPath)) {
+			throw new Error(
+				"Custom shell path contains control characters. Please update shellPath in your OMP settings.",
+			);
+		}
 		if (!fs.existsSync(customShellPath)) {
 			throw new Error(`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ${configSource}`);
 		}
+		if (!cacheable) return buildConfig(customShellPath, env);
 		if (cachedShellConfig?.shell !== customShellPath) {
-			cachedShellConfig = buildConfig(customShellPath);
+			cachedShellConfig = buildConfig(customShellPath, env);
 		}
 		return cachedShellConfig;
 	}
-	if (cachedShellConfig) {
+	if (cacheable && cachedShellConfig) {
 		return cachedShellConfig;
 	}
 
 	if (process.platform === "win32") {
-		cachedShellConfig = buildConfig(resolveWindowsShell());
-		return cachedShellConfig;
+		const config = buildConfig(resolveWindowsShell(env), env);
+		if (cacheable) cachedShellConfig = config;
+		return config;
 	}
 
-	// Unix: prefer user's shell from $SHELL if it's bash/zsh and executable
-	const userShell = Bun.env.SHELL;
-	const isValidShell = userShell && (userShell.includes("bash") || userShell.includes("zsh"));
+	// Unix: prefer the user's absolute bash/zsh path from $SHELL.
+	const userShell = env.SHELL;
+	const shellName = userShell ? path.basename(userShell).toLowerCase() : "";
+	const isValidShell =
+		isSafeShellEnvValue(userShell) &&
+		path.isAbsolute(userShell) &&
+		(shellName.includes("bash") || shellName.includes("zsh"));
 	if (isValidShell && isExecutable(userShell)) {
-		cachedShellConfig = buildConfig(userShell);
-		return cachedShellConfig;
+		const config = buildConfig(userShell, env);
+		if (cacheable) cachedShellConfig = config;
+		return config;
 	}
 
-	// 4. Fallback: use basic shell
-	const basicShell = resolveBasicShell();
-	if (basicShell) {
-		cachedShellConfig = buildConfig(basicShell);
-		return cachedShellConfig;
-	}
-	cachedShellConfig = buildConfig("sh");
-	return cachedShellConfig;
+	// 4. Fallback: use a basic shell from the selected environment.
+	const basicShell = resolveBasicShell(options.env === undefined ? undefined : (env.PATH ?? ""));
+	const config = buildConfig(basicShell ?? "sh", env);
+	if (cacheable) cachedShellConfig = config;
+	return config;
 }
 
 /**

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -27,6 +27,55 @@ function writeTempEnv(content: string): string {
 	return filePath;
 }
 
+interface ChildEnvFilterProbeOptions {
+	dotenv: string;
+	env: Record<string, string | undefined>;
+	names: string[];
+	noEnvFile?: boolean;
+	platform: NodeJS.Platform;
+}
+
+async function runChildEnvFilterProbe(options: ChildEnvFilterProbeOptions): Promise<Record<string, string>> {
+	const cwd = path.dirname(writeTempEnv(options.dotenv));
+	const probePath = path.join(cwd, "filter-child-env-probe.ts");
+	const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
+	fs.writeFileSync(
+		probePath,
+		[
+			`Object.defineProperty(process, "platform", { value: ${JSON.stringify(options.platform)}, configurable: true });`,
+			"// Dynamic import lets this probe set the platform before env.ts snapshots the launch environment.",
+			`const { filterChildShellEnv } = await import(${JSON.stringify(envModulePath)});`,
+			"const filtered = filterChildShellEnv(process.env, process.cwd());",
+			`const names = new Set(${JSON.stringify(options.names)}.map(name => name.toLowerCase()));`,
+			"const selected = Object.fromEntries(Object.entries(filtered).filter(([name]) => names.has(name.toLowerCase())));",
+			"process.stdout.write(JSON.stringify(selected));",
+		].join("\n"),
+	);
+	const proc = Bun.spawn([process.execPath, ...(options.noEnvFile ? ["--no-env-file"] : []), probePath], {
+		cwd,
+		env: { ...process.env, ...options.env },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return JSON.parse(stdout) as Record<string, string>;
+}
+
+function withPlatform<T>(platform: NodeJS.Platform, action: () => T): T {
+	const originalPlatform = process.platform;
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+	try {
+		return action();
+	} finally {
+		Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+	}
+}
+
 describe("getDbBusyTimeoutMs", () => {
 	it("defaults to the bounded headless timeout", () => {
 		const previous = setInteractiveHost(false);
@@ -122,6 +171,36 @@ describe("parseEnvFile", () => {
 			SINGLE: "it\\'s",
 		});
 	});
+
+	it("parses multiline quoted values with Bun-compatible newlines", () => {
+		const filePath = writeTempEnv(
+			[
+				'MULTILINE_DOUBLE="first',
+				'second"',
+				"MULTILINE_SINGLE='third",
+				"fourth'",
+				"MULTILINE_BACKTICK=`fifth",
+				"sixth`",
+				"AFTER=value",
+			].join("\n"),
+		);
+
+		expect(parseEnvFile(filePath)).toEqual({
+			MULTILINE_DOUBLE: "first\nsecond",
+			MULTILINE_SINGLE: "third\nfourth",
+			MULTILINE_BACKTICK: "fifth\nsixth",
+			AFTER: "value",
+		});
+	});
+
+	it("does not let an unclosed quote in a comment consume later assignments", () => {
+		const filePath = writeTempEnv('# ignored="\nPATH=/tmp/pwn\nSHELL=/tmp/pwn/bash\n');
+
+		expect(parseEnvFile(filePath)).toEqual({
+			PATH: "/tmp/pwn",
+			SHELL: "/tmp/pwn/bash",
+		});
+	});
 });
 
 describe("filterProcessEnv", () => {
@@ -165,6 +244,101 @@ describe("filterProcessEnv", () => {
 			"ProgramFiles(x86)": "C:\\Program Files (x86)",
 			"CommonProgramFiles(x86)": "C:\\Program Files (x86)\\Common Files",
 		});
+	});
+
+	it("canonicalizes Windows Path keys for case-sensitive consumers", () => {
+		expect(
+			withPlatform("win32", () =>
+				filterProcessEnv(
+					windowsLikeEnv({
+						Path: "C:\\Windows\\System32",
+						PathExt: ".COM;.EXE;.BAT;.CMD",
+					}),
+				),
+			),
+		).toEqual({
+			PATH: "C:\\Windows\\System32",
+			PATHEXT: ".COM;.EXE;.BAT;.CMD",
+		});
+	});
+});
+
+describe("filterChildShellEnv", () => {
+	it("fails closed for self-referential dotenv PATH and ZDOTDIR without a launch snapshot", async () => {
+		const filtered = await runChildEnvFilterProbe({
+			dotenv: ["PATH=/tmp/omp-hostile:$PATH", "ZDOTDIR=$ZDOTDIR$PWD/.omp-hostile-zdot"].join("\n"),
+			env: { PATH: undefined, ZDOTDIR: undefined },
+			names: ["PATH", "ZDOTDIR"],
+			platform: "darwin",
+		});
+
+		expect(filtered).toEqual({});
+	});
+
+	it("deletes same-named parent values when no snapshot can prove their provenance", async () => {
+		const filtered = await runChildEnvFilterProbe({
+			dotenv: ["PATH=/tmp/project-bin", "SHELL=/tmp/project-shell"].join("\n"),
+			env: {
+				PATH: "/usr/bin",
+				SHELL: "/bin/zsh",
+			},
+			names: ["PATH", "SHELL"],
+			platform: "darwin",
+		});
+
+		expect(filtered).toEqual({});
+	});
+
+	it("preserves launcher-only values while failing closed without a snapshot", async () => {
+		const filtered = await runChildEnvFilterProbe({
+			dotenv: "ZDOTDIR=$ZDOTDIR$PWD/.omp-hostile-zdot\n",
+			env: {
+				OMP_PARENT_ONLY: "trusted",
+				ZDOTDIR: undefined,
+			},
+			names: ["OMP_PARENT_ONLY", "ZDOTDIR"],
+			platform: "darwin",
+		});
+
+		expect(filtered).toEqual({ OMP_PARENT_ONLY: "trusted" });
+	});
+
+	it("filters a differently-cased dotenv-owned Path on Windows", async () => {
+		const filtered = await runChildEnvFilterProbe({
+			dotenv: "PATH=C:\\omp-hostile\n",
+			env: { PATH: undefined, Path: "C:\\omp-hostile" },
+			names: ["PATH"],
+			platform: "win32",
+		});
+
+		expect(filtered).toEqual({});
+	});
+
+	it("restores a differently-cased trusted Windows Path under canonical PATH", async () => {
+		const filtered = await runChildEnvFilterProbe({
+			dotenv: "PATH=C:\\omp-hostile\n",
+			env: {
+				PATH: undefined,
+				Path: "C:\\Windows\\System32",
+			},
+			names: ["PATH"],
+			noEnvFile: true,
+			platform: "win32",
+		});
+
+		expect(filtered).toEqual({ PATH: "C:\\Windows\\System32" });
+	});
+
+	it("restores an empty authoritative launch value", async () => {
+		const filtered = await runChildEnvFilterProbe({
+			dotenv: "PATH=/tmp/omp-hostile:$PATH\n",
+			env: { PATH: "" },
+			names: ["PATH"],
+			noEnvFile: true,
+			platform: "darwin",
+		});
+
+		expect(filtered).toEqual({ PATH: "" });
 	});
 });
 

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -196,4 +196,19 @@ describe("postmortem expected cleanup errors", () => {
 		expect(result.stdout).toContain("cleanup deadline released");
 		expect(result.stderr).not.toContain("cleanup stayed pending after the deadline");
 	});
+
+	it("can scope SIGINT cleanup to an inherited-console child", async () => {
+		const result = await runPostmortemProbe(`
+			import { postmortem } from "${postmortemModuleUrl}";
+
+			const resume = postmortem.suspendSigintCleanup();
+			process.emit("SIGINT");
+			resume();
+			resume();
+			console.log("survived delegated SIGINT");
+		`);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("survived delegated SIGINT");
+	});
 });

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, MAIN_CONFIG_FILENAMES } from "../src/dirs";
-import { getShellArgs, getShellConfig, resolveWindowsShell } from "../src/procmgr";
+import { getShellArgs, getShellConfig, resolveBasicShell, resolveWindowsShell } from "../src/procmgr";
 
 describe("getShellConfig", () => {
 	it("directs invalid custom shell paths to the canonical config file", () => {
@@ -12,6 +12,41 @@ describe("getShellConfig", () => {
 		expect(() => getShellConfig(missingShell)).toThrow(
 			`Custom shell path not found: ${missingShell}\nPlease update shellPath in ${configPath}`,
 		);
+	});
+
+	it("rejects control characters in custom shell paths without rendering them", () => {
+		const unsafeShell = `${path.join(os.tmpdir(), "omp-shell")}\u009b2J`;
+		let message = "";
+
+		try {
+			getShellConfig(unsafeShell);
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toBe(
+			"Custom shell path contains control characters. Please update shellPath in your OMP settings.",
+		);
+		expect(message).not.toContain("\u009b");
+	});
+
+	it.skipIf(process.platform === "win32")("does not search the current directory when trusted PATH is empty", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "omp-empty-shell-path-"));
+		const previousCwd = process.cwd();
+		try {
+			const attackerShell = path.join(root, "bash");
+			fs.writeFileSync(attackerShell, "#!/bin/sh\nexit 0\n");
+			fs.chmodSync(attackerShell, 0o755);
+			process.chdir(root);
+
+			const resolved = resolveBasicShell("");
+
+			expect(resolved).not.toBe(attackerShell);
+			expect(resolved ? path.isAbsolute(resolved) : true).toBe(true);
+		} finally {
+			process.chdir(previousCwd);
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -87,5 +122,19 @@ describe("resolveWindowsShell", () => {
 	it.skipIf(process.platform === "win32")("falls back to cmd.exe instead of failing when no bash exists", () => {
 		expect(resolveWindowsShell({})).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(resolveWindowsShell({ ComSpec: "D:\\win\\cmd.exe" })).toBe("D:\\win\\cmd.exe");
+	});
+
+	it.skipIf(process.platform === "win32")("does not search the current directory when Windows PATH is empty", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "omp-empty-windows-shell-path-"));
+		tempDirs.push(root);
+		const previousCwd = process.cwd();
+		try {
+			fs.writeFileSync(path.join(root, "bash.exe"), "");
+			process.chdir(root);
+
+			expect(resolveWindowsShell({ PATH: "", ComSpec: "D:\\win\\cmd.exe" })).toBe("D:\\win\\cmd.exe");
+		} finally {
+			process.chdir(previousCwd);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- add practical Tab completion for executable names and filesystem paths in quick `! command` and `!! command` input
- make bare `!` open the configured interactive shell with native startup files, aliases, and completion
- return zsh's final working directory to OMP and restore the TUI safely after any shell exits or fails
- replace bash-specific user-facing labels with the resolved shell name
- harden shell selection and child environments against project dotenv, untrusted PATH, multiline value, and terminal-control injection

Closes #3179.

## Behavior

- `! command` remains the normal quick command path
- `!! command` remains the context-excluded quick command path
- bare `!` opens the configured shell
- zsh runs as an interactive login shell and preserves normal `.zshenv` and `.zshrc` effects
- bash, fish, and other shells do not currently synchronize their final working directory back to OMP
- completion is deliberately practical rather than a nested ZLE/compinit implementation

## Verification

- Biome: 24 changed code files pass
- focused tests: 170 pass, 0 fail across 11 suites
- `packages/utils` TypeScript check passes
- `packages/coding-agent` TypeScript check passes
- `git diff --check` passes
- mandatory code and security review remediation completed
