### PR TITLE
fix(catalog): bound openai-compatible model discovery with default timeout

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bounded OpenAI-compatible model discovery with a default request timeout so a stalled provider `/models` endpoint can no longer hang startup indefinitely in `resolveModelDiscoveryFallback` ([#8315](https://github.com/can1357/oh-my-pi/issues/8315)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Fixed

--- a/packages/catalog/src/discovery/openai-compatible.ts
+++ b/packages/catalog/src/discovery/openai-compatible.ts
@@ -5,6 +5,18 @@ import { discoveryFetch } from "../utils";
 const MODELS_PATH = "/models";
 
 /**
+ * Default hard deadline applied to an OpenAI-compatible `/models` probe when
+ * the caller supplies neither an `AbortSignal` nor an explicit `timeoutMs`.
+ *
+ * Built-in provider model managers (openrouter, xAI, DeepSeek, …) call
+ * {@link fetchOpenAICompatibleModels} with no timeout, so without this bound a
+ * stalled endpoint left the request pending forever and blocked startup's
+ * awaited `resolveModelDiscoveryFallback` discovery pass indefinitely
+ * (issue #8315). 10s matches the coding-agent's remote-discovery budget.
+ */
+export const DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS = 10_000;
+
+/**
  * Uses a cancellable timer rather than the native abort-timeout helper so
  * successful fast discovery requests do not leave armed timeout signals for
  * concurrent GC to trip over later.
@@ -96,7 +108,11 @@ export interface FetchOpenAICompatibleModelsOptions<TApi extends Api> {
 	headers?: Record<string, string>;
 	/** Optional AbortSignal for request cancellation; caller owns its lifecycle. */
 	signal?: AbortSignal;
-	/** Optional cancellable request timeout used when `signal` is omitted. */
+	/**
+	 * Optional cancellable request timeout used when `signal` is omitted.
+	 * Defaults to {@link DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS} so a
+	 * stalled endpoint can never hang discovery indefinitely.
+	 */
 	timeoutMs?: number;
 	/** Optional fetch implementation override for testing/custom runtimes. */
 	fetch?: FetchImpl;
@@ -164,9 +180,10 @@ export async function fetchOpenAICompatibleModels<TApi extends Api>(
 	const payload =
 		options.signal !== undefined
 			? await fetchPayload(options.signal)
-			: options.timeoutMs !== undefined
-				? await withOpenAICompatibleDiscoveryTimeout(options.timeoutMs, fetchPayload)
-				: await fetchPayload();
+			: await withOpenAICompatibleDiscoveryTimeout(
+					options.timeoutMs ?? DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS,
+					fetchPayload,
+				);
 	if (payload === null) {
 		return null;
 	}

--- a/packages/catalog/test/issue-8315-repro.test.ts
+++ b/packages/catalog/test/issue-8315-repro.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { fetchOpenAICompatibleModels } from "../src/discovery/openai-compatible";
+import type { FetchImpl } from "../src/types";
+
+// Issue #8315: `omp` hung at startup in `resolveModelDiscoveryFallback`.
+// Built-in OpenAI-compatible provider managers (openrouter, xAI, DeepSeek, …)
+// call `fetchOpenAICompatibleModels` with neither a `signal` nor a `timeoutMs`,
+// and the no-timeout branch issued the request with `signal: undefined` — so a
+// stalled `/models` endpoint left the fetch pending forever and blocked the
+// awaited discovery pass indefinitely.
+describe("issue #8315: OpenAI-compatible discovery must be bounded by default", () => {
+	it("arms an abort deadline when the caller supplies neither signal nor timeoutMs", async () => {
+		let received: AbortSignal | null | undefined = null;
+		const capturingFetch: FetchImpl = async (_url, init) => {
+			received = init?.signal;
+			return new Response(JSON.stringify({ data: [{ id: "m1" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const models = await fetchOpenAICompatibleModels({
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://stall.example/v1",
+			fetch: capturingFetch,
+		});
+
+		// Regression guard: previously the transport received `signal: undefined`
+		// (unbounded). It must now carry a default deadline.
+		expect(received).toBeInstanceOf(AbortSignal);
+		expect(models).not.toBeNull();
+		expect(models?.map(model => model.id)).toEqual(["m1"]);
+	});
+
+	it("resolves to null instead of hanging when the endpoint never responds", async () => {
+		// Honors the deadline signal by rejecting on abort; never resolves otherwise.
+		const stallingFetch: FetchImpl = (_url, init) => {
+			const { promise, reject } = Promise.withResolvers<Response>();
+			const signal = init?.signal;
+			signal?.addEventListener("abort", () => reject(signal.reason ?? new Error("aborted")));
+			return promise;
+		};
+
+		const models = await fetchOpenAICompatibleModels({
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://stall.example/v1",
+			fetch: stallingFetch,
+			timeoutMs: 50,
+		});
+
+		expect(models).toBeNull();
+	});
+});


### PR DESCRIPTION
## Repro
After a fresh install, `omp` never finished starting: the startup watchdog stayed stuck at `phase: createAgentSession > resolveModelDiscoveryFallback` past 10s and 20s. This is the online model-discovery pass. Against a socket that accepts the connection but never answers `GET /models`, `fetchOpenAICompatibleModels({ api, provider, baseUrl })` (no `timeoutMs`/`signal`) stays pending indefinitely (still hanging after 6s in a repro), whereas the same call with `timeoutMs: 800` resolves `null` in ~800ms.

## Cause
`fetchOpenAICompatibleModels` in `packages/catalog/src/discovery/openai-compatible.ts` only bounded the request when the caller passed a `signal` or a `timeoutMs`; otherwise it issued the fetch with `signal: undefined` — no deadline. Every built-in OpenAI-compatible provider manager (`openrouterModelManagerOptions`, xAI, DeepSeek, and the other `fetchOpenAICompatibleModels` callers) calls it with neither, so a stalled provider `/models` endpoint left the fetch pending forever. `createAgentSession` awaits that discovery through `resolveModelDiscoveryFallback` -> `modelRegistry.refresh("online-if-uncached")` (`sdk.ts`), so the whole boot blocked.

## Fix
- Add `DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS = 10_000` (matching the coding-agent's remote-discovery budget).
- When the caller supplies neither `signal` nor `timeoutMs`, run the probe under `withOpenAICompatibleDiscoveryTimeout` with that default instead of issuing an unbounded request. Callers that pass their own `signal` keep owning its lifecycle; explicit `timeoutMs` is still honored.
- Regression test `packages/catalog/test/issue-8315-repro.test.ts`: asserts the transport now receives an `AbortSignal` when no deadline is supplied (the exact regression), and that a stalled endpoint resolves to `null` rather than hanging.

## Verification
`bun test test/issue-8315-repro.test.ts` -> 2 pass. `bun test test/discovery-null-limits.test.ts test/lm-studio-provider.test.ts test/ollama-provider.test.ts test/siliconflow-provider.test.ts` -> 20 pass. Manual repro: unbounded call hung >6s before, now resolves `null` at ~10001ms (default deadline). `bun check` passes (pre-publish gate). Fixes #8315