### PR TITLE
fix(ai): preserve streamed thinking start content

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2333,7 +2333,7 @@ const streamAnthropicOnce = (
 								streamedReplayUnsafeContent = true;
 								const block: Block = {
 									type: "thinking",
-									thinking: "",
+									thinking: event.content_block.thinking ?? "",
 									thinkingSignature: "",
 									[kStreamingBlockIndex]: event.index,
 								};

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -902,6 +902,31 @@ describe("anthropic stream envelope handling", () => {
 		]);
 	});
 
+	it("preserves signed thinking content from content_block_start", async () => {
+		const events = createThinkingSuccessEvents(" summary tail");
+		events[1] = {
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "thinking", thinking: "Summary prefix" },
+		};
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(() => createMockRequest(events) as never);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		for await (const _ of stream) {
+			// drain stream
+		}
+		const result = await stream.result();
+
+		expect(result.content).toHaveLength(1);
+		const block = result.content[0];
+		expect(block?.type).toBe("thinking");
+		if (block?.type !== "thinking") {
+			throw new Error("Expected thinking content from content_block_start");
+		}
+		expect(block.thinking).toBe("Summary prefix summary tail");
+		expect(block.thinkingSignature).toBe("sig_thinking");
+	});
+
 	it("drops replayed closed blocks after a duplicate message_start instead of duplicating content", async () => {
 		const events: MockAnthropicEvent[] = [
 			{


### PR DESCRIPTION
## What

Initialize Anthropic thinking blocks with any thinking bytes carried by the content_block_start event instead of discarding them.

Add a stream regression test covering content split across content_block_start and thinking_delta before a signature_delta.

## Why

Anthropic requires signed thinking blocks to be replayed byte-for-byte. If a compatible endpoint emits an initial thinking prefix in content_block_start, dropping that prefix leaves the stored thinking text inconsistent with its signature and the next request fails with a thinking blocks cannot be modified 400.

## Testing

- bun test packages/ai/test/anthropic-stream-envelope.test.ts --test-name-pattern "preserves signed thinking content from content_block_start"
- bun --cwd=packages/ai run check
- Built an isolated darwin-arm64 omp binary and completed a claude-opus-5 max-thinking smoke request through the configured Anthropic route

---

- [ ] bun check passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)