### PR TITLE
fix(ai): validated together login against models endpoint

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/login together` always failing key validation: it probed the hardcoded non-serverless model `moonshotai/Kimi-K2.5` via chat-completions, which returns `400 model_not_available` even for a valid key. Together now validates against its `/v1/models` listing, matching other plan-varying providers ([#8328](https://github.com/can1357/oh-my-pi/issues/8328)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Fixed

--- a/packages/ai/src/registry/together.ts
+++ b/packages/ai/src/registry/together.ts
@@ -8,10 +8,14 @@ export const loginTogether = createApiKeyLogin({
 	promptMessage: "Paste your Together API key",
 	placeholder: "sk-...",
 	validation: {
-		kind: "chat-completions",
+		// Together serves many models (e.g. moonshotai/Kimi-K2.5) only via dedicated
+		// non-serverless endpoints, so a chat-completions probe against any single
+		// model can 400 with `model_not_available` even for a valid key (#8328).
+		// Validate against the models listing instead — it verifies the key without
+		// depending on any one model's serverless availability.
+		kind: "models-endpoint",
 		provider: "together",
-		baseUrl: "https://api.together.xyz/v1",
-		model: "moonshotai/Kimi-K2.5",
+		modelsUrl: "https://api.together.xyz/v1/models",
 	},
 });
 

--- a/packages/ai/test/together-login.test.ts
+++ b/packages/ai/test/together-login.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "bun:test";
+import { loginTogether } from "@oh-my-pi/pi-ai/registry/together";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+describe("together login", () => {
+	it("validates against the models endpoint, not a specific-model chat probe", async () => {
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			// Regression guard for #8328: a chat-completions probe against a
+			// non-serverless model (moonshotai/Kimi-K2.5) 400s even for a valid
+			// key, so login must not depend on any single model's availability.
+			expect(url).toBe("https://api.together.xyz/v1/models");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-together-test" });
+			return new Response(JSON.stringify({ object: "list", data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const apiKey = await loginTogether({
+			onPrompt: async () => "sk-together-test",
+			fetch: fetchMock,
+		});
+
+		expect(apiKey).toBe("sk-together-test");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces validation errors from the models endpoint", async () => {
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			return new Response('{"error":{"code":"invalid_api_key"}}', {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await expect(
+			loginTogether({
+				onPrompt: async () => "sk-together-test",
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("together API key validation failed (401)");
+	});
+});


### PR DESCRIPTION
## Repro
`/login together` always fails with `HTTP 400 model_not_available` even with a valid key. Confirmed the premise at source: `packages/ai/src/registry/together.ts` hardcoded a chat-completions validation probe against `moonshotai/Kimi-K2.5`, which Together only serves via a dedicated non-serverless endpoint. A live unauthenticated probe returns `401` for both `GET /v1/models` and `POST /v1/chat/completions` (the models listing is real and auth-gated); the `model_not_available` failure only surfaces with a valid key (hence the reporter's `400`, not `401/403`). Driving Together's exact `400` body from the issue through the real `validateOpenAICompatibleApiKey` throws the login failure; the `models-endpoint` path passes.

## Cause
`together.ts` set `validation.kind = "chat-completions"` with `model: "moonshotai/Kimi-K2.5"`. `createApiKeyLogin` (`api-key-login.ts`) routes that to `validateOpenAICompatibleApiKey`, which POSTs a completion request naming that model. Together rejects non-serverless models with `400 model_not_available` regardless of key validity, so validation could never succeed.

## Fix
- `packages/ai/src/registry/together.ts`: switched `validation` to `kind: "models-endpoint"` against `https://api.together.xyz/v1/models`, matching peers with plan-varying model access (deepseek, baseten, gmi-cloud, nanogpt). This verifies the key via `validateApiKeyAgainstModelsEndpoint` without depending on any single model's serverless availability — exactly the case that path's doc describes.
- `packages/ai/test/together-login.test.ts`: new regression test asserting Together validates via a `GET /v1/models` call (not a specific-model chat probe) and surfaces endpoint errors.
- `packages/ai/CHANGELOG.md`: `[Unreleased] > Fixed` entry.

## Verification
`bun test test/together-login.test.ts` → 2 pass, 0 fail. Manual: the pre-fix repro throws the exact `400 model_not_available` from the issue; the post-fix `models-endpoint` config passes. Fixes #8328