### PR TITLE
fix(catalog): apply DeepSeek effort contract on Ollama Cloud

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama Cloud DeepSeek V4 Flash (including dated/preview tags like `deepseek-v4-flash:0731`) exposing the generic `minimal`/`low`/`medium`/`high`/`xhigh` effort ladder without `max`; the `ollama-chat` transport now applies the DeepSeek effort contract (Flash → `low`/`high`/`max`, V4 Pro and older reasoners → `high`/`max`), matching the direct API and every other host ([#8334](https://github.com/can1357/oh-my-pi/issues/8334)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Fixed

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -366,10 +366,13 @@ function getModelDefinedEfforts<TApi extends Api>(
 	if (spec.provider === "ollama") {
 		return OLLAMA_REASONING_EFFORTS;
 	}
-	if (isOpenAICompatReasoningApi(spec.api) && isDeepseekReasoningModel(spec)) {
+	if (
+		(isOpenAICompatReasoningApi(spec.api) || (spec.api === "ollama-chat" && spec.provider === "ollama-cloud")) &&
+		isDeepseekReasoningModel(spec)
+	) {
 		// DeepSeek V4 Flash accepts the wire-exact low/high/max ladder on every
-		// host — the direct API and aggregators alike (medium/xhigh map to
-		// high). V4 Pro and the older reasoners top out at high/max, and
+		// host — the direct API, aggregators, and Ollama Cloud alike (medium/xhigh
+		// map to high). V4 Pro and the older reasoners top out at high/max, and
 		// OpenRouter's non-flash DeepSeek route exposes only high.
 		if (isDeepseekV4FlashModelId(spec.id)) {
 			return LOW_HIGH_MAX_REASONING_EFFORTS;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -70186,10 +70186,8 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
+					"high",
+					"max"
 				]
 			},
 			"supportsComputerUse": false,
@@ -70217,10 +70215,8 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
+					"high",
+					"max"
 				]
 			},
 			"supportsComputerUse": false,
@@ -70248,11 +70244,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			}
 		},
@@ -70278,10 +70272,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
-					"high"
+					"high",
+					"max"
 				]
 			}
 		},
@@ -70295,11 +70288,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			},
 			"input": [
@@ -70338,11 +70329,8 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			}
 		},

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -290,6 +290,44 @@ describe("model thinking derivation", () => {
 		expect(openRouter.thinking?.effortMap).toBeUndefined();
 	});
 
+	it("applies the DeepSeek effort contract to Ollama Cloud ollama-chat models (issue #8334)", () => {
+		const flash = createModel({
+			id: "deepseek-v4-flash",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+		const flashDated = createModel({
+			id: "deepseek-v4-flash:0731",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+		const pro = createModel({
+			id: "deepseek-v4-pro",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+		const v32 = createModel({
+			id: "deepseek-v3.2",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+
+		// V4 Flash keeps its low/high/max ladder over the ollama-chat transport
+		// instead of Ollama's generic minimal..xhigh scale (medium/xhigh fold
+		// into high, max is a real wire tier).
+		expect(getSupportedEfforts(flash)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(getSupportedEfforts(flashDated)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(flash.thinking?.effortMap).toBeUndefined();
+		// V4 Pro and the older reasoners top out at high/max, matching the
+		// direct DeepSeek API and every aggregator route.
+		expect(getSupportedEfforts(pro)).toEqual([Effort.High, Effort.Max]);
+		expect(getSupportedEfforts(v32)).toEqual([Effort.High, Effort.Max]);
+	});
+
 	it("encodes the Gemini 3 Pro effort gap and mandatory reasoning in metadata", () => {
 		const model = createModel({
 			id: "gemini-3-pro-preview",


### PR DESCRIPTION
## Repro
With an Ollama Cloud subscription, selecting `deepseek-v4-flash` / `deepseek-v4-flash:0731` surfaces the thinking-effort options `minimal`/`low`/`medium`/`high`/`xhigh` with no `max`, instead of DeepSeek's `low`/`high`/`max` ladder. Setting `max` in the config still displays as `xhigh`. Building the Ollama Cloud specs through the catalog and reading their ladders reproduces it:

```
cd packages/catalog && bun run repro.ts   # temp script
deepseek-v4-flash      => minimal, low, medium, high, xhigh
deepseek-v4-flash:0731 => minimal, low, medium, high
deepseek-v4-pro        => minimal, low, medium, high, xhigh
deepseek-v3.2          => minimal, low, medium, high
```

## Cause
Ollama Cloud serves the DeepSeek V4 family over the `ollama-chat` API. The DeepSeek effort-ladder branch in `getModelDefinedEfforts` (`packages/catalog/src/model-thinking.ts`) was gated on `isOpenAICompatReasoningApi(spec.api)` (`openai-completions`/`openrouter`) only, so `ollama-chat` specs fell through to the generic `minimal..xhigh` fallback in `inferFallbackEfforts`. Every other host — the direct DeepSeek API, Venice, Qianfan, and the aggregators — already resolves Flash to `low`/`high`/`max` and Pro/older reasoners to `high`/`max` via that branch.

## Fix
- Broadened the DeepSeek branch condition in `model-thinking.ts` to also match the `ollama-cloud` `ollama-chat` surface, so those specs get the DeepSeek contract: Flash → `low`/`high`/`max`, V4 Pro and older reasoners (V3.1/V3.2) → `high`/`max`. The wire layer (`packages/ai/src/providers/ollama.ts` `mapReasoning`) already maps `max` verbatim for Ollama Cloud, so no effort remapping is needed.
- Synced the affected bundled `ollama-cloud` entries in `models.json` (`deepseek-v3.1:671b`, `deepseek-v3.2`, `deepseek-v4-flash`, `deepseek-v4-flash:0731`, `deepseek-v4-flash:preview`, `deepseek-v4-pro`) to the generator output.
- Added a regression test in `model-thinking.test.ts` asserting the ladders for Flash, dated Flash, Pro, and V3.2 on the `ollama-chat` transport.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test packages/catalog/test/model-thinking.test.ts packages/catalog/test/generated-policies.test.ts` → 53 pass, 0 fail. Post-fix ladders: Flash/`:0731` → `low, high, max`; Pro → `high, max`; V3.2 → `high, max`. `bun check` passed via the push gate.

Fixes #8334