### PR TITLE
feat(ui): add reduce-motion setting to freeze terminal animations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -57,6 +57,9 @@
 ### Changed
 
 - Upgraded the bundled omptype schema engine: intersection and pipe operators, bigint and RegExp literals in the string DSL, Standard Schema V1 interop, JSON Schema import via fromJsonSchema(), and richer union/collection error reporting.
+### Added
+
+- Added the `display.reduceMotion` setting (`off` | `on` | `strict`) and the `--reduce-motion` launch flag for accessibility and low-bandwidth/remote sessions: `on` freezes cosmetic TUI animation (spinners, shimmer, thinking pulse, terminal-title spinner, welcome intro, splash, codex fireworks, live-mic hue, todo strikethrough sweep) while content repaints normally; `strict` additionally caps repaints at ~4fps (250ms minimum render interval).
 
 ## [17.2.7] - 2026-08-03
 

--- a/packages/coding-agent/src/autoresearch/dashboard.ts
+++ b/packages/coding-agent/src/autoresearch/dashboard.ts
@@ -1,4 +1,5 @@
 import { matchesKey, replaceTabs, ScrollView, Text, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import { isReduceMotion } from "../config/reduce-motion";
 import type { Theme } from "../modes/theme/theme";
 import { formatElapsed, formatNum, isBetter } from "./helpers";
 import { currentResults, findBaselineMetric, findBaselineRunNumber, findBaselineSecondary } from "./state";
@@ -57,7 +58,7 @@ export function createDashboardController(): DashboardController {
 			await ctx.ui.custom<void>(
 				(tui, theme, _keybindings, done) => {
 					overlayTui = tui;
-					if (!spinnerTimer) {
+					if (!spinnerTimer && !isReduceMotion()) {
 						spinnerTimer = setInterval(() => {
 							spinnerFrame += 1;
 							requestRender();

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -45,6 +45,7 @@ export interface Args {
 	appendSystemPrompt?: string;
 	thinking?: ConfiguredThinkingLevel;
 	serviceTier?: ServiceTierOpenAISettingValue;
+	reduceMotion?: "off" | "on" | "strict";
 	hideThinking?: boolean;
 	advisor?: boolean;
 	continue?: boolean;

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -250,6 +250,20 @@ export const OPTIONAL_FLAGS: Record<string, OptionalFlagConfig> = {
 	"--resume": { set: setResume, rejectEmpty: true },
 	"-r": { set: setResume, rejectEmpty: true },
 	"--session": { set: setResume, rejectEmpty: true },
+	"--reduce-motion": {
+		set: (result, value) => {
+			if (value === undefined) {
+				result.reduceMotion = "on";
+				return;
+			}
+			if (value === "off" || value === "on" || value === "strict") {
+				result.reduceMotion = value;
+				return;
+			}
+			throw new CliUsageError(`--reduce-motion accepts "on", "strict", or "off" (got "${value}")`);
+		},
+		rejectEmpty: true,
+	},
 };
 
 /**

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -71,6 +71,11 @@ export const launchHelp = {
 			description: "OpenAI service tier for this session (none omits service_tier)",
 			options: [...SERVICE_TIER_OPENAI_VALUES],
 		}),
+		"reduce-motion": Flags.string({
+			description:
+				"Reduce cosmetic TUI animation: on freezes spinners/shimmer/pulses, strict also caps repaints (~4fps) for low-bandwidth links",
+			options: ["on", "strict", "off"],
+		}),
 		"hide-thinking": Flags.boolean({
 			description: "Hide thinking blocks in TUI output (display only, does not disable model thinking)",
 		}),

--- a/packages/coding-agent/src/config/reduce-motion.ts
+++ b/packages/coding-agent/src/config/reduce-motion.ts
@@ -1,0 +1,16 @@
+import { isSettingsInitialized, settings } from "./settings";
+
+export type ReduceMotionLevel = "off" | "on" | "strict";
+
+/** Strict mode's TUI minimum render interval (~4fps). */
+export const REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS = 250;
+
+/** Current reduce-motion level; "off" before settings init (early boot, tests). */
+export function reduceMotionLevel(): ReduceMotionLevel {
+	if (!isSettingsInitialized()) return "off";
+	return settings.get("display.reduceMotion");
+}
+
+export function isReduceMotion(): boolean {
+	return reduceMotionLevel() !== "off";
+}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1007,6 +1007,31 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"display.reduceMotion": {
+		type: "enum",
+		values: ["off", "on", "strict"] as const,
+		default: "off",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Reduce Motion",
+			description: "Reduce or eliminate cosmetic TUI animation (accessibility, remote/low-bandwidth sessions)",
+			options: [
+				{ value: "off", label: "Off", description: "Full animations" },
+				{
+					value: "on",
+					label: "On",
+					description: "Freeze spinners, shimmer, and pulses; content repaints normally",
+				},
+				{
+					value: "strict",
+					label: "Strict",
+					description: "Also cap repaints at ~4fps to minimize bytes over remote links",
+				},
+			],
+		},
+	},
+
 	"display.smoothStreaming": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/live/visualizer.ts
+++ b/packages/coding-agent/src/live/visualizer.ts
@@ -8,6 +8,7 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
+import { isReduceMotion } from "../config/reduce-motion";
 import { type ThemeColor, theme } from "../modes/theme/theme";
 
 /** Distinct states of a realtime call connection. */
@@ -173,7 +174,10 @@ export class LiveVisualizer implements Component {
 			muted: "×",
 			error: "!",
 		};
-		const icon = this.#phase === "working" ? spinners[this.#frame % spinners.length] : staticIcons[this.#phase];
+		const icon =
+			this.#phase === "working" && !isReduceMotion()
+				? spinners[this.#frame % spinners.length]
+				: staticIcons[this.#phase];
 		const phaseColors: Record<LivePhase, ThemeColor> = {
 			connecting: "dim",
 			listening: "success",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -41,6 +41,7 @@ import {
 	type ScopedModel,
 } from "./config/model-resolver";
 import { ModelsConfigFile } from "./config/models-config";
+import { isReduceMotion } from "./config/reduce-motion";
 import { serviceTierSettingToTier } from "./config/service-tier";
 import { getDefault, type SettingPath, Settings, type SettingValue, settings } from "./config/settings";
 import { initializeWithSettings } from "./discovery";
@@ -456,7 +457,7 @@ async function runInteractiveMode(
 	const playStartupSplash = showStartupSplash && setupScenes.length === 0;
 
 	await mode.init({
-		suppressWelcomeIntro: resuming || setupScenes.length > 0 || playStartupSplash,
+		suppressWelcomeIntro: resuming || setupScenes.length > 0 || playStartupSplash || isReduceMotion(),
 		clearInitialTerminalHistory: true,
 	});
 
@@ -1599,6 +1600,7 @@ export async function runRootCommand(
 			timing: Boolean($env.PI_TIMING),
 			stdinIsTTY: process.stdin.isTTY,
 			stdoutIsTTY: process.stdout.isTTY,
+			reduceMotion: isReduceMotion(),
 		});
 
 		// Startup changelog is only consumed by interactive mode below; kick the

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1271,6 +1271,10 @@ export async function runRootCommand(
 	if (parsedArgs.hideThinking) {
 		settingsInstance.override("hideThinkingBlock", true);
 	}
+	// Apply --reduce-motion CLI flag (ephemeral, not persisted)
+	if (parsedArgs.reduceMotion) {
+		settingsInstance.override("display.reduceMotion", parsedArgs.reduceMotion);
+	}
 	// Apply --advisor CLI flag (ephemeral, not persisted)
 	if (parsedArgs.advisor) {
 		settingsInstance.override("advisor.enabled", true);

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -12,6 +12,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
+import { isReduceMotion } from "../../config/reduce-motion";
 import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { expandKeyHint, getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
@@ -384,7 +385,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#startThinkingAnimation(): void {
-		if (this.#thinkingDotsTimer) return;
+		if (this.#thinkingDotsTimer || isReduceMotion()) return;
 		this.#scheduleThinkingFrame();
 	}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -12,6 +12,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { BracketedPasteHandler } from "@oh-my-pi/pi-tui/bracketed-paste";
 import type { AppKeybinding } from "../../config/keybindings";
+import { isReduceMotion } from "../../config/reduce-motion";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
 import { hasMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
@@ -468,7 +469,7 @@ export class CustomEditor extends Editor {
 	 *  item markers use the accent color so separate follow-ups remain visible while composing. */
 	override decorateText = (text: string): string => {
 		const editorText = this.getText();
-		const animated = this.focused && this.#shimmerEnabled() && hasMagicKeyword(editorText);
+		const animated = this.focused && this.#shimmerEnabled() && !isReduceMotion() && hasMagicKeyword(editorText);
 		const phase = animated ? (Date.now() % CustomEditor.SHIMMER_PERIOD_MS) / CustomEditor.SHIMMER_PERIOD_MS : 0;
 		if (animated) this.#scheduleShimmerFrame();
 		if (this.#queueDecorationText !== editorText) {

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -1223,13 +1223,19 @@ export class MCPAddWizard extends Container {
 			this.#contentContainer.addChild(healthText);
 
 			let spinnerIndex = 0;
-			const spinner = setInterval(() => {
-				healthText.setText(
-					theme.fg("muted", `${spinnerFrames[spinnerIndex % spinnerFrames.length]} Checking server connection...`),
-				);
-				spinnerIndex++;
-				this.#requestRender();
-			}, 80);
+			const spinner =
+				spinnerFrames.length > 1
+					? setInterval(() => {
+							healthText.setText(
+								theme.fg(
+									"muted",
+									`${spinnerFrames[spinnerIndex % spinnerFrames.length]} Checking server connection...`,
+								),
+							);
+							spinnerIndex++;
+							this.#requestRender();
+						}, 80)
+					: undefined;
 
 			let healthPassed = true;
 			let healthError = "";

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -630,6 +630,9 @@ export class ModelHubComponent implements Component {
 
 	#startRefreshSpinner(): void {
 		if (this.#refreshSpinnerInterval) return;
+		// A frozen single-frame spinner (reduce-motion) never advances; skip the
+		// tick — it would only drive full requestRender() wakeups for nothing.
+		if (theme.spinnerFrames.length <= 1) return;
 		this.#refreshSpinnerInterval = setInterval(() => {
 			const frameCount = theme.spinnerFrames.length;
 			if (frameCount > 0) {

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -199,6 +199,9 @@ export class OAuthSelectorComponent extends Container {
 
 	#startSpinner(): void {
 		if (this.#spinnerInterval) return;
+		// A frozen single-frame spinner (reduce-motion) never advances; skip the
+		// tick and keep the initial static frame.
+		if (theme.spinnerFrames.length <= 1) return;
 		this.#spinnerInterval = setInterval(() => {
 			const frameCount = theme.spinnerFrames.length;
 			if (frameCount > 0) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -4,6 +4,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
+import { isReduceMotion } from "../../../config/reduce-motion";
 import { settings } from "../../../config/settings";
 import type { AgentSession } from "../../../session/agent-session";
 import type { OAuthAccountIdentity } from "../../../session/auth-storage";
@@ -1264,7 +1265,7 @@ export class StatusLineComponent implements Component {
 		const contextKey = this.#formatUsageContextKey(activeProvider, activeIdentity);
 		const previous = this.#codexResetSnapshots.get(contextKey);
 		this.#codexResetSnapshots.set(contextKey, resetSnapshot);
-		if (!previous || !settings.get("tui.codexResetFireworks")) return;
+		if (!previous || !settings.get("tui.codexResetFireworks") || isReduceMotion()) return;
 		const event = detectCodexResetFireworks(previous, resetSnapshot);
 		if (event) this.#onCodexResetFireworks?.(event);
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -704,19 +704,23 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			const frame = sharedSpinnerFrame(frameCount);
 			this.#spinnerFrame = frame;
 			this.#renderState.spinnerFrame = frame;
-			this.#spinnerInterval = setInterval(() => {
-				// If a detached task interval from an older render path is still live,
-				// stop it the instant the block leaves the repaintable region.
-				if (this.#maybeFreezeBackgroundTask()) return;
-				const now = performance.now();
-				const frameCount = theme.spinnerFrames.length;
-				this.#spinnerFrame = sharedSpinnerFrame(frameCount, now);
-				this.#renderState.spinnerFrame = this.#spinnerFrame;
-				// Component-scoped: a spinner tick only changes this tool block, so
-				// the TUI reuses every other root subtree instead of walking the
-				// whole tree (issue #4377).
-				this.#ui.requestComponentRender(this);
-			}, SPINNER_RENDER_INTERVAL_MS);
+			// A frozen single-frame spinner (reduce-motion) never advances; skip
+			// the interval and keep the initial static frame.
+			if (theme.spinnerFrames.length > 1) {
+				this.#spinnerInterval = setInterval(() => {
+					// If a detached task interval from an older render path is still live,
+					// stop it the instant the block leaves the repaintable region.
+					if (this.#maybeFreezeBackgroundTask()) return;
+					const now = performance.now();
+					const frameCount = theme.spinnerFrames.length;
+					this.#spinnerFrame = sharedSpinnerFrame(frameCount, now);
+					this.#renderState.spinnerFrame = this.#spinnerFrame;
+					// Component-scoped: a spinner tick only changes this tool block, so
+					// the TUI reuses every other root subtree instead of walking the
+					// whole tree (issue #4377).
+					this.#ui.requestComponentRender(this);
+				}, SPINNER_RENDER_INTERVAL_MS);
+			}
 		} else if (!needsSpinner && this.#spinnerInterval) {
 			clearInterval(this.#spinnerInterval);
 			this.#spinnerInterval = undefined;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -15,6 +15,7 @@ import {
 	type TUI,
 } from "@oh-my-pi/pi-tui";
 import { getProjectDir, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { isReduceMotion } from "../../config/reduce-motion";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
 import type { Theme } from "../../modes/theme/theme";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
@@ -769,6 +770,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		}
 		const completedTasks = (this.#result?.details as { completedTasks?: unknown[] } | undefined)?.completedTasks;
 		if (!completedTasks || completedTasks.length === 0) {
+			this.#stopTodoStrikeAnimation();
+			return;
+		}
+		// Reduce motion: skip the strikethrough sweep; completed lines render
+		// fully struck (the terminal state of the animation) right away.
+		if (isReduceMotion()) {
 			this.#stopTodoStrikeAnimation();
 			return;
 		}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -5,6 +5,7 @@ import { type Component, Loader, TERMINAL } from "@oh-my-pi/pi-tui";
 import { logger, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import { extractTextContent } from "../../commit/utils";
+import { isReduceMotion } from "../../config/reduce-motion";
 import { settings } from "../../config/settings";
 import { getEditClipboard } from "../../edit/edit-clipboard";
 import { getFileSnapshotStore } from "../../edit/file-snapshot-store";
@@ -208,13 +209,13 @@ export class EventController {
 				: null,
 		);
 		this.#streamingReveal = new StreamingRevealController({
-			getSmoothStreaming: () => this.ctx.settings.get("display.smoothStreaming"),
+			getSmoothStreaming: () => this.ctx.settings.get("display.smoothStreaming") && !isReduceMotion(),
 			getHideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			getProseOnlyThinking: () => this.ctx.proseOnlyThinking,
 			requestRender: component => this.ctx.ui.requestComponentRender(component),
 		});
 		this.#toolArgsReveal = new ToolArgsRevealController({
-			getSmoothStreaming: () => this.ctx.settings.get("display.smoothStreaming"),
+			getSmoothStreaming: () => this.ctx.settings.get("display.smoothStreaming") && !isReduceMotion(),
 			requestRender: component => this.ctx.ui.requestComponentRender(component),
 		});
 		this.#handlers = {

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -183,14 +183,18 @@ class McpConnectingBlock extends ChatBlock {
 	protected override onMount(): void {
 		const frames = theme.spinnerFrames;
 		let frame = 0;
-		const interval = setInterval(() => {
-			frame++;
-			this.#text.setText(
-				theme.fg("muted", `${frames[frame % frames.length] ?? "|"} Connecting to "${this.serverName}"...`),
-			);
-			this.requestRender();
-		}, 80);
-		this.onCleanup(() => clearInterval(interval));
+		// A frozen single-frame spinner (reduce-motion) never advances; the
+		// initial static frame set in the constructor is the final state.
+		if (frames.length > 1) {
+			const interval = setInterval(() => {
+				frame++;
+				this.#text.setText(
+					theme.fg("muted", `${frames[frame % frames.length] ?? "|"} Connecting to "${this.serverName}"...`),
+				);
+				this.requestRender();
+			}, 80);
+			this.onCleanup(() => clearInterval(interval));
+		}
 	}
 
 	/** Replace the spinner line with a terminal status; pair with {@link finish}. */

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -20,6 +20,7 @@ import {
 	resolveModelRoleValue,
 } from "../../config/model-resolver";
 import { getRoleInfo } from "../../config/model-roles";
+import { REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS } from "../../config/reduce-motion";
 import { settings } from "../../config/settings";
 import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -554,6 +555,12 @@ export class SelectorController {
 
 			case "tui.scrollbackRebuild":
 				this.ctx.ui.setScrollbackRebuild(value as boolean);
+				break;
+
+			case "display.reduceMotion":
+				this.ctx.ui.setMinRenderInterval(value === "strict" ? REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS : undefined);
+				this.ctx.ui.invalidate();
+				this.ctx.ui.requestRender();
 				break;
 
 			case "tui.renderMermaid":

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -59,7 +59,7 @@ import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
 import { formatModelString, type ResolvedModelRoleValue } from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
-import { REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS, reduceMotionLevel } from "../config/reduce-motion";
+import { isReduceMotion, REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS, reduceMotionLevel } from "../config/reduce-motion";
 import {
 	isSettingsInitialized,
 	onModelRolesChanged,
@@ -4608,6 +4608,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.#voiceAnimationInterval) return;
 		this.#voiceHue = 0;
 		this.#updateMicIcon();
+		// Reduce motion: keep the static first hue; no color sweep.
+		if (isReduceMotion()) return;
 		this.#voiceAnimationInterval = setInterval(() => {
 			this.#voiceHue = (this.#voiceHue + 8) % 360;
 			this.#updateMicIcon();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -59,6 +59,7 @@ import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
 import { formatModelString, type ResolvedModelRoleValue } from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
+import { REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS, reduceMotionLevel } from "../config/reduce-motion";
 import {
 	isSettingsInitialized,
 	onModelRolesChanged,
@@ -716,6 +717,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setMaxInlineImages(settings.get("tui.maxInlineImages"));
 		this.ui.setScrollbackRebuild(settings.get("tui.scrollbackRebuild"));
+		if (reduceMotionLevel() === "strict") {
+			this.ui.setMinRenderInterval(REDUCE_MOTION_STRICT_RENDER_INTERVAL_MS);
+		}
 		// OSC 66 text-sizing is Kitty-only; resolve the setting against the terminal's
 		// capability (`TERMINAL.textSizing` defaults on for Kitty) so it stays off
 		// unless the user opts in, and never emits raw escapes on other terminals.

--- a/packages/coding-agent/src/modes/theme/shimmer.ts
+++ b/packages/coding-agent/src/modes/theme/shimmer.ts
@@ -1,3 +1,4 @@
+import { isReduceMotion } from "../../config/reduce-motion";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import type { Theme, ThemeColor } from "./theme";
 
@@ -154,6 +155,7 @@ function tierFor(intensity: number): Tier {
 }
 
 function resolveMode(): ShimmerMode {
+	if (isReduceMotion()) return "disabled";
 	if (!isSettingsInitialized()) return "classic";
 	return settings.get("display.shimmer");
 }

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -22,6 +22,7 @@ import type {
 import { adjustHsv, colorLuma, getCustomThemesDir, isEnoent, logger, relativeLuminance } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { LRUCache } from "lru-cache/raw";
+import { isReduceMotion } from "../../config/reduce-motion";
 // Embed theme JSON files at build time
 import darkThemeJson from "./dark.json" with { type: "json" };
 import { defaultThemes } from "./defaults";
@@ -1488,6 +1489,8 @@ export class Theme {
 	readonly #hexBgColors: Record<ThemeBg, string>;
 	#symbols: SymbolMap;
 	#spinnerFramesOverrides: Partial<Record<SpinnerType, string[]>>;
+	/** Frozen single-frame spinner arrays, memoized per source identity (reduce-motion). */
+	#frozenSpinnerFrames = new Map<string[], string[]>();
 	/**
 	 * Perceptual luma (0..1) of the status-line background — used to classify the
 	 * theme light/dark. Undefined when it can't be resolved. Classified against the
@@ -1931,7 +1934,14 @@ export class Theme {
 	 * Get spinner frames by type.
 	 */
 	getSpinnerFrames(type: SpinnerType = "status"): string[] {
-		return this.#spinnerFramesOverrides[type] ?? SPINNER_FRAMES[this.symbolPreset][type];
+		const source = this.#spinnerFramesOverrides[type] ?? SPINNER_FRAMES[this.symbolPreset][type];
+		if (!isReduceMotion() || source.length <= 1) return source;
+		let frozen = this.#frozenSpinnerFrames.get(source);
+		if (frozen === undefined) {
+			frozen = [source[0]];
+			this.#frozenSpinnerFrames.set(source, frozen);
+		}
+		return frozen;
 	}
 
 	/**

--- a/packages/coding-agent/src/startup-splash.ts
+++ b/packages/coding-agent/src/startup-splash.ts
@@ -7,13 +7,14 @@ export interface StartupSplashDecisionOptions {
 	readonly timing: boolean;
 	readonly stdinIsTTY: boolean | undefined;
 	readonly stdoutIsTTY: boolean | undefined;
+	readonly reduceMotion: boolean;
 }
 
 /** Returns true only for explicitly enabled, normal interactive TTY startup. */
 export function shouldShowStartupSplash(options: StartupSplashDecisionOptions): boolean {
 	if (!options.configured) return false;
 	if (!options.isInteractive) return false;
-	if (options.resuming || options.quiet) return false;
+	if (options.resuming || options.quiet || options.reduceMotion) return false;
 	if (options.timing) return false;
 	return options.stdinIsTTY === true && options.stdoutIsTTY === true;
 }

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -10,6 +10,7 @@ import { isTerminalHeadless, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 
 import { resolveRoleSelection } from "../config/model-resolver";
+import { isReduceMotion } from "../config/reduce-motion";
 import type { Settings } from "../config/settings";
 import titleMarkerInstruction from "../prompts/system/title-marker-instruction.md" with { type: "text" };
 import titleSystemPrompt from "../prompts/system/title-system.md" with { type: "text" };
@@ -510,11 +511,12 @@ export function buildTerminalTitleWithState(
 	frame: number,
 	enabled: boolean,
 	platform: NodeJS.Platform = process.platform,
+	staticSpinner: boolean = isReduceMotion(),
 ): string {
 	if (!enabled) return label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
 	const separator =
 		state === "working"
-			? platform === "win32"
+			? platform === "win32" || staticSpinner
 				? WINDOWS_TITLE_WORKING_SEPARATOR
 				: TITLE_SPINNER_FRAMES[frame % TITLE_SPINNER_FRAMES.length]
 			: state === "attention"
@@ -543,7 +545,7 @@ function stopTerminalTitleSpinner(): void {
 }
 
 function startTerminalTitleSpinner(): void {
-	if (process.platform === "win32" || terminalTitleRuntime.timer || !process.stdout.isTTY) return;
+	if (process.platform === "win32" || isReduceMotion() || terminalTitleRuntime.timer || !process.stdout.isTTY) return;
 	terminalTitleRuntime.timer = setInterval(() => {
 		terminalTitleRuntime.frame = (terminalTitleRuntime.frame + 1) % TITLE_SPINNER_FRAMES.length;
 		emitTerminalTitle();

--- a/packages/coding-agent/test/cli-reduce-motion-flag.test.ts
+++ b/packages/coding-agent/test/cli-reduce-motion-flag.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+
+describe("parseArgs — --reduce-motion flag", () => {
+	it("parses the bare form as on", () => {
+		const result = parseArgs(["--reduce-motion"]);
+		expect(result.reduceMotion).toBe("on");
+	});
+
+	it("parses a space-separated value", () => {
+		const result = parseArgs(["--reduce-motion", "strict"]);
+		expect(result.reduceMotion).toBe("strict");
+	});
+
+	it("parses an equals-form value", () => {
+		const result = parseArgs(["--reduce-motion=strict"]);
+		expect(result.reduceMotion).toBe("strict");
+	});
+
+	it("accepts off", () => {
+		const result = parseArgs(["--reduce-motion=off"]);
+		expect(result.reduceMotion).toBe("off");
+	});
+
+	it("rejects unknown values", () => {
+		expect(() => parseArgs(["--reduce-motion", "bogus"])).toThrow(
+			'--reduce-motion accepts "on", "strict", or "off" (got "bogus")',
+		);
+	});
+
+	it("defaults reduceMotion to undefined when flag is not provided", () => {
+		const result = parseArgs([]);
+		expect(result.reduceMotion).toBeUndefined();
+	});
+
+	it("releases flag-looking tokens back to their own handlers", () => {
+		const result = parseArgs(["--reduce-motion", "--print", "hello"]);
+		expect(result.reduceMotion).toBe("on");
+		expect(result.print).toBe(true);
+		expect(result.messages).toEqual(["hello"]);
+	});
+
+	it("treats an empty-string token as the bare form", () => {
+		const result = parseArgs(["--reduce-motion", ""]);
+		expect(result.reduceMotion).toBe("on");
+		expect(result.messages).toEqual([""]);
+	});
+});

--- a/packages/coding-agent/test/startup-splash.test.ts
+++ b/packages/coding-agent/test/startup-splash.test.ts
@@ -19,6 +19,7 @@ describe("startup splash", () => {
 			timing: false,
 			stdinIsTTY: true,
 			stdoutIsTTY: true,
+			reduceMotion: false,
 		};
 
 		expect(shouldShowStartupSplash(base)).toBe(true);
@@ -26,6 +27,7 @@ describe("startup splash", () => {
 		expect(shouldShowStartupSplash({ ...base, isInteractive: false })).toBe(false);
 		expect(shouldShowStartupSplash({ ...base, resuming: true })).toBe(false);
 		expect(shouldShowStartupSplash({ ...base, quiet: true })).toBe(false);
+		expect(shouldShowStartupSplash({ ...base, reduceMotion: true })).toBe(false);
 		expect(shouldShowStartupSplash({ ...base, timing: true })).toBe(false);
 		expect(shouldShowStartupSplash({ ...base, stdinIsTTY: false })).toBe(false);
 		expect(shouldShowStartupSplash({ ...base, stdoutIsTTY: false })).toBe(false);

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -3,6 +3,7 @@ import type { Api, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import {
+	buildTerminalTitleWithState,
 	disposeTerminalTitleState,
 	generateSessionTitle,
 	setExtensionTerminalTitle,
@@ -745,5 +746,18 @@ describe("terminal title runtime", () => {
 		} finally {
 			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
 		}
+	});
+});
+
+describe("buildTerminalTitleWithState static separator (reduce-motion)", () => {
+	it("renders a static ':' working separator instead of braille frames", () => {
+		const title = buildTerminalTitleWithState("proj", "working", 3, true, "linux", true);
+		expect(title).toContain(":");
+		for (const frame of SPINNER_FRAMES) expect(title).not.toContain(frame);
+	});
+
+	it("keeps the animated braille frame when staticSpinner is false", () => {
+		const title = buildTerminalTitleWithState("proj", "working", 3, true, "linux", false);
+		expect(SPINNER_FRAMES.some(frame => title.includes(frame))).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -149,6 +149,20 @@ it("renders completed tasks as checked before revealing strikethrough", async ()
 	expect(revealFrame).toContain("\x1b[9m");
 });
 
+it("renders completed tasks fully struck when no animation frame is set (reduce-motion)", async () => {
+	// Under reduce-motion the strike sweep never runs, so the renderer sees no
+	// frame and must land on the terminal state: full strikethrough, no sweep.
+	const tool = new TodoTool(createSession());
+	await tool.execute("call-1", { op: "init", list: [{ phase: "Execution", items: ["finish"] }] });
+	const result = await tool.execute("call-2", { op: "done", task: "finish" });
+	const options = { expanded: true, isPartial: false, spinnerFrame: undefined };
+	const component = todoToolRenderer.renderResult(result, options, theme);
+
+	const staticFrame = component.render(120).join("\n");
+	expect(Bun.stripANSI(staticFrame)).toContain("finish");
+	expect(staticFrame).toContain("\x1b[9m");
+});
+
 describe("TodoTool operations", () => {
 	it("jumps to a specific task out of order", async () => {
 		const tool = new TodoTool(createSession());

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Fixed table borders (and adjacent cells) inheriting an open inline-code color when a cell's content wraps mid-code-span, by terminating each wrapped cell line's SGR state before the border glyphs ([#7575](https://github.com/can1357/oh-my-pi/issues/7575)).
 - Fixed inline images not rendering under WSL + Windows Terminal: the SIXEL capability probe gated on `process.platform === "win32"`, but WSL reports `linux`, so the probe never ran and images fell back to the text placeholder even on Sixel-capable Windows Terminal. The probe now runs on any ConPTY host (native win32 or WSL) ([#6009](https://github.com/can1357/oh-my-pi/issues/6009)).
+### Added
+
+- Added `TUI.setMinRenderInterval()` to raise the minimum throttled-render interval per instance, and stopped Loader tick scheduling for single-frame spinners with static colorizers (used by reduce-motion to freeze spinners and cap repaint rates).
 
 ## [17.2.5] - 2026-08-03
 

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -99,6 +99,10 @@ export class Loader extends Text {
 		this.#lastSpinnerTick = performance.now();
 		this.#syncText();
 		this.#requestPaint();
+		// A single-frame spinner with a static colorizer can never change;
+		// scheduling a tick would just burn idle wakeups (setMessage/stop
+		// repaint and tear down independently).
+		if (this.#frames.length <= 1 && this.messageColorFn.animated !== true) return;
 		const intervalMs = this.messageColorFn.animated === true ? RENDER_INTERVAL_MS : SPINNER_ADVANCE_MS;
 		this.#scheduleTick(intervalMs, intervalMs);
 	}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -913,6 +913,8 @@ export function findCommittedPrefixResync(
 /**
  * TUI - Main class for managing terminal UI with differential rendering
  */
+const MIN_RENDER_INTERVAL_MS = 1000 / 30;
+
 export class TUI extends Container {
 	terminal: Terminal;
 	#previousFrameLength = 0;
@@ -937,8 +939,9 @@ export class TUI extends Container {
 	 * fire the next frame immediately (see #4145).
 	 */
 	#lastFrameCostMs = 0;
-	static readonly #MIN_RENDER_INTERVAL_MS = 1000 / 30;
-	static readonly #INPUT_RENDER_GRACE_MS = TUI.#MIN_RENDER_INTERVAL_MS;
+	/** Minimum interval between throttled renders; raise it to cap repaint rate. */
+	#minRenderIntervalMs = MIN_RENDER_INTERVAL_MS;
+	static readonly #INPUT_RENDER_GRACE_MS = MIN_RENDER_INTERVAL_MS;
 	/**
 	 * Cap on the adaptive floor derived from `#lastFrameCostMs`. Bounds the UI
 	 * responsiveness at ~5 fps under sustained heavy renders — anything slower
@@ -1406,6 +1409,11 @@ export class TUI extends Container {
 	 */
 	setScrollbackRebuild(enabled: boolean): void {
 		this.#scrollbackRebuildEnabled = enabled;
+	}
+
+	/** Set the minimum interval between throttled renders; undefined restores the 30fps default. */
+	setMinRenderInterval(ms: number | undefined): void {
+		this.#minRenderIntervalMs = ms ?? MIN_RENDER_INTERVAL_MS;
 	}
 
 	getShowHardwareCursor(): boolean {
@@ -2367,7 +2375,7 @@ export class TUI extends Container {
 		}
 		const now = this.#renderScheduler.now();
 		const elapsed = now - this.#lastRenderAt;
-		const cadenceDelay = Math.max(0, TUI.#MIN_RENDER_INTERVAL_MS - elapsed);
+		const cadenceDelay = Math.max(0, this.#minRenderIntervalMs - elapsed);
 		// Adaptive backpressure — target ~50% render duty cycle: the next frame
 		// starts no sooner than `last_frame_end + last_frame_cost`, i.e.
 		// `last_frame_start + 2 × last_frame_cost`. So `elapsed` (which counts

--- a/packages/tui/test/adaptive-render-backpressure.test.ts
+++ b/packages/tui/test/adaptive-render-backpressure.test.ts
@@ -172,4 +172,44 @@ describe("TUI adaptive render backpressure (#4145)", () => {
 			tui.stop();
 		}
 	});
+
+	it("raises the render floor via setMinRenderInterval and restores it with undefined", () => {
+		const term = new VirtualTerminal(20, 4);
+		const scheduler = new DeferredRenderScheduler();
+		const probe = new ScriptedFrameCost();
+		probe.scheduler = scheduler;
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.addChild(probe);
+
+		try {
+			tui.start();
+			stepRender(scheduler);
+			scheduler.timers.length = 0;
+
+			// Raised floor: each scheduled render idles at (at least) the
+			// configured 250ms minus whatever elapsed since the last frame.
+			tui.setMinRenderInterval(250);
+			probe.scheduleCost(1);
+			tui.requestRender();
+			const firstDelay = stepRender(scheduler);
+			expect(firstDelay).not.toBeNull();
+			expect(firstDelay!).toBeGreaterThanOrEqual(250);
+
+			probe.scheduleCost(1);
+			tui.requestRender();
+			const secondDelay = stepRender(scheduler);
+			expect(secondDelay).not.toBeNull();
+			expect(secondDelay!).toBeGreaterThanOrEqual(250 - firstDelay!);
+
+			// Restoring the default returns the ~30fps floor.
+			tui.setMinRenderInterval(undefined);
+			probe.scheduleCost(1);
+			tui.requestRender();
+			const restoredDelay = stepRender(scheduler);
+			expect(restoredDelay).not.toBeNull();
+			expect(restoredDelay!).toBeLessThanOrEqual(MIN_RENDER_INTERVAL_MS + 1);
+		} finally {
+			tui.stop();
+		}
+	});
 });

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -49,6 +49,32 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("does not schedule ticks for a single-frame spinner with a static colorizer", () => {
+		vi.useFakeTimers();
+		const ui = { requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
+		const loader = new Loader(
+			ui as unknown as TUI,
+			text => text,
+			text => text,
+			"Checking",
+			["•"],
+		);
+
+		// Exactly the initial paint; the frozen loader never ticks.
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(400);
+
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
+
+		// setMessage still repaints independently.
+		loader.setMessage("Still checking");
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+
+		loader.stop();
+	});
+
 	it("falls back to component-scoped renders for lightweight TUI stubs", () => {
 		vi.useFakeTimers();
 		const ui = { requestComponentRender: vi.fn() };


### PR DESCRIPTION
## What

Adds a `display.reduceMotion` setting (`off` | `on` | `strict`, default `off`) and a matching `--reduce-motion` launch flag that freezes cosmetic terminal animations:

- `on` freezes theme-driven spinners (via a single-frame freeze at the `Theme.getSpinnerFrames` choke point, covering every `theme.spinnerFrames` / `getSymbolTheme().spinnerFrames` consumer), disables shimmer and smooth streaming, and stops the terminal-title spinner, welcome intro, startup splash, codex fireworks, live-mic hue rotation, and todo-strike sweep.
- `strict` additionally caps TUI repaint rate at ~4fps via `TUI.setMinRenderInterval(250)`.
- `--reduce-motion` (with optional `on`/`strict`/`off` value) is a session-only override; the setting is live-reapplied when changed in `/config`.

Central helper: `src/config/reduce-motion.ts` (`isReduceMotion()`, `reduceMotionLevel()`). The freeze point is memoized per source-array identity, so it costs nothing when reduce-motion is off.

## Why

Accessibility (photosensitive users, vestibular motion sensitivity) and low-bandwidth/remote sessions where continuous repaint churn is wasteful. This was previously only partially possible via `display.shimmer: disabled`, which does not freeze spinners or title animation.

## Testing

- `bun check` passes in `packages/coding-agent` (biome + tsgo) and `packages/tui`.
- `bun test` green: `test/cli-reduce-motion-flag.test.ts`, `test/title-generator.test.ts`, `test/startup-splash.test.ts` (48 tests), `test/tools/todo.test.ts` (73 tests), and `packages/tui/test/loader.test.ts` (14 tests).
- Smoke-tested interactively in a PTY: spinners freeze to a single frame under `on`; `strict` caps repaint cadence.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
