### PR TITLE
fix(task): inherit mounted xdev tools in subagents

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -157,6 +157,10 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 	) {
 		applyToolProxy(tool, this);
 	}
+	/** Returns the wrapped tool for cross-session rebinding. */
+	unwrap(): AgentTool<TParameters, TDetails> {
+		return this.tool;
+	}
 
 	/**
 	 * Forward browser mode changes when available.

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -153,6 +153,7 @@ export class TanCommandController {
 							task: trimmedWork,
 							tools: clone.getActiveToolNames ? clone.getActiveToolNames() : toolNames,
 							mountedTools: clone.getMountedXdevToolNames(),
+							enableMCP: false,
 						});
 						const abortClone = () => {
 							void clone?.abort();

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -152,6 +152,7 @@ export class TanCommandController {
 							systemPrompt: clone.systemPrompt ? clone.systemPrompt.join("\n\n") : systemPrompt.join("\n\n"),
 							task: trimmedWork,
 							tools: clone.getActiveToolNames ? clone.getActiveToolNames() : toolNames,
+							mountedTools: clone.getMountedXdevToolNames(),
 						});
 						const abortClone = () => {
 							void clone?.abort();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1706,6 +1706,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getMnemopiSessionState: () => session?.getMnemopiSessionState(),
 			getAgentId: () => resolvedAgentId,
 			getToolByName: name => session?.getToolByName(name),
+			getRpcHostTools: () => session?.getRpcHostTools() ?? [],
+			getMountedXdevToolNames: () => session?.getMountedXdevToolNames() ?? [],
+			hasBuiltInTool: name => session?.hasBuiltInTool(name) ?? false,
 			agentRegistry,
 			// The global lifecycle releases through AgentRegistry.global(); wiring it
 			// onto a caller-supplied registry would report a cancel while releasing an

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4295,6 +4295,11 @@ export class AgentSession {
 		return this.#tools.getMountedXdevToolNames();
 	}
 
+	/** Current host-owned RPC tools, for child-session reconstruction. */
+	getRpcHostTools(): AgentTool[] {
+		return this.#tools.getRpcHostTools();
+	}
+
 	/** Whether the edit tool is registered in this session. */
 	get hasEditTool(): boolean {
 		return this.#tools.hasEditTool;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4295,7 +4295,7 @@ export class AgentSession {
 		return this.#tools.getMountedXdevToolNames();
 	}
 
-	/** Current host-owned RPC tools, for child-session reconstruction. */
+	/** Enabled host-owned RPC tools, for child-session reconstruction. */
 	getRpcHostTools(): AgentTool[] {
 		return this.#tools.getRpcHostTools();
 	}

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -209,6 +209,10 @@ export interface SessionInitEntry extends SessionEntryBase {
 	task: string;
 	/** Tools available to the agent */
 	tools: string[];
+	/** Tools mounted under `xd://` when the subagent session started. */
+	mountedTools?: string[];
+	/** Whether MCP capabilities were enabled for this subagent. */
+	enableMCP?: boolean;
 	/** Agent definition name (for example `scout` or `reviewer`). */
 	agent?: string;
 	/** Semantic model role declared by the agent, retained even after concrete model resolution. */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2133,6 +2133,8 @@ export class SessionManager {
 		systemPrompt: string;
 		task: string;
 		tools: string[];
+		mountedTools?: string[];
+		enableMCP?: boolean;
 		agent?: string;
 		modelRole?: string;
 		resolvedModel?: string;
@@ -2626,6 +2628,8 @@ export class SessionManager {
 			systemPrompt: string;
 			task: string;
 			tools: string[];
+			mountedTools?: string[];
+			enableMCP?: boolean;
 			agent?: string;
 			modelRole?: string;
 			resolvedModel?: string;
@@ -2649,6 +2653,8 @@ export class SessionManager {
 			systemPrompt: string;
 			task: string;
 			tools: string[];
+			mountedTools?: string[];
+			enableMCP?: boolean;
 			agent?: string;
 			modelRole?: string;
 			resolvedModel?: string;
@@ -2665,6 +2671,8 @@ export class SessionManager {
 					systemPrompt: entry.systemPrompt,
 					task: entry.task,
 					tools: entry.tools,
+					mountedTools: entry.mountedTools,
+					enableMCP: entry.enableMCP,
 					agent: entry.agent,
 					modelRole: entry.modelRole,
 					resolvedModel: entry.resolvedModel,

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -398,11 +398,12 @@ export class SessionTools {
 		return this.#rpcHostToolNames.has(name);
 	}
 
-	/** Current host-owned RPC tools, for child-session reconstruction. */
+	/** Enabled host-owned RPC tools, for child-session reconstruction. */
 	getRpcHostTools(): AgentTool[] {
+		const enabledToolNames = new Set(this.getEnabledToolNames());
 		return [...this.#rpcHostToolNames].flatMap(name => {
 			const tool = this.#toolRegistry.get(name);
-			return tool ? [tool] : [];
+			return tool && enabledToolNames.has(name) ? [tool] : [];
 		});
 	}
 

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -398,6 +398,14 @@ export class SessionTools {
 		return this.#rpcHostToolNames.has(name);
 	}
 
+	/** Current host-owned RPC tools, for child-session reconstruction. */
+	getRpcHostTools(): AgentTool[] {
+		return [...this.#rpcHostToolNames].flatMap(name => {
+			const tool = this.#toolRegistry.get(name);
+			return tool ? [tool] : [];
+		});
+	}
+
 	/** Whether the current MCP entry came from the manager snapshot. */
 	hasMCPManagerTool(name: string): boolean {
 		return this.#mcpManagerToolNames.has(name);

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -398,12 +398,13 @@ export class SessionTools {
 		return this.#rpcHostToolNames.has(name);
 	}
 
-	/** Enabled host-owned RPC tools, for child-session reconstruction. */
+	/** Enabled host-owned RPC tools, unwrapped for child-session reconstruction. */
 	getRpcHostTools(): AgentTool[] {
 		const enabledToolNames = new Set(this.getEnabledToolNames());
 		return [...this.#rpcHostToolNames].flatMap(name => {
 			const tool = this.#toolRegistry.get(name);
-			return tool && enabledToolNames.has(name) ? [tool] : [];
+			if (!tool || !enabledToolNames.has(name)) return [];
+			return [tool instanceof ExtensionToolWrapper ? tool.unwrap() : tool];
 		});
 	}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3142,6 +3142,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				void sessionPromise.then(created => created.session.dispose()).catch(() => {});
 				throw err;
 			}
+			monitor.setActiveSession(session);
 			const missingHostTools = inheritedHostTools.filter(tool => !session.getToolByName(tool.name));
 			if (missingHostTools.length > 0) {
 				await session.refreshRpcHostTools(missingHostTools);
@@ -3155,8 +3156,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				);
 			}
 			sessionCreatedAt = performance.now();
-
-			monitor.setActiveSession(session);
 			installRegistryStatusSync(session);
 
 			// Emit lifecycle start event

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3146,28 +3146,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			monitor.setActiveSession(session);
 			installRegistryStatusSync(session);
-			if (sessionFile !== null && worktree === undefined) {
-				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
-				// the single-writer lock cleanly and restores the full message history
-				// (createAgentSession → agent.replaceMessages). Isolated runs are not
-				// resumable (worktree is merged + cleaned) and never get a reviver.
-				reviveSession = async expectedAgentRef => {
-					const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
-						suppressBreadcrumb: true,
-					});
-					if (options.parentArtifactManager) {
-						reopened.adoptArtifactManager(options.parentArtifactManager);
-					}
-					const { session: revived } = await createAgentSession(
-						buildSubagentSessionOptions(reopened, expectedAgentRef),
-					);
-					const missingHostTools = inheritedHostTools.filter(tool => !revived.getToolByName(tool.name));
-					if (missingHostTools.length > 0) await revived.refreshRpcHostTools(missingHostTools);
-					installRegistryStatusSync(revived);
-					installIrcWakeTurnMonitor(revived);
-					return revived;
-				};
-			}
 
 			// Emit lifecycle start event
 			if (options.eventBus) {
@@ -3198,7 +3176,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				systemPrompt: session.agent.state.systemPrompt.join("\n\n"),
 				task,
 				tools: session.getActiveToolNames(),
+				mountedTools: session.getMountedXdevToolNames(),
 				agent: agent.name,
+				enableMCP,
 				modelRole: modelRole ?? resolveExplicitModelRole(modelOverride ?? agent.model, subagentSettings),
 				resolvedModel: progress.resolvedModel,
 				readOnly: isReadOnlyAgent(agent),
@@ -3208,6 +3188,34 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,
 			});
+			const revivalTopLevelToolNames = session.getActiveToolNames();
+			const revivalMountedToolNames = session.getMountedXdevToolNames();
+			if (sessionFile !== null && worktree === undefined) {
+				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
+				// the single-writer lock cleanly and restores the full message history
+				// (createAgentSession → agent.replaceMessages). Isolated runs are not
+				// resumable (worktree is merged + cleaned) and never get a reviver.
+				reviveSession = async expectedAgentRef => {
+					const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
+						suppressBreadcrumb: true,
+					});
+					if (options.parentArtifactManager) {
+						reopened.adoptArtifactManager(options.parentArtifactManager);
+					}
+					const { session: revived } = await createAgentSession(
+						buildSubagentSessionOptions(reopened, expectedAgentRef),
+					);
+					const missingHostTools = inheritedHostTools.filter(tool => !revived.getToolByName(tool.name));
+					if (missingHostTools.length > 0) await revived.refreshRpcHostTools(missingHostTools);
+					await revived.setActiveToolPresentation(
+						[...revivalTopLevelToolNames, ...revivalMountedToolNames],
+						revivalMountedToolNames,
+					);
+					installRegistryStatusSync(revived);
+					installIrcWakeTurnMonitor(revived);
+					return revived;
+				};
+			}
 
 			abortSignal.addEventListener(
 				"abort",

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3214,18 +3214,27 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					if (options.parentArtifactManager) {
 						reopened.adoptArtifactManager(options.parentArtifactManager);
 					}
+					const registry = AgentRegistry.global();
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
-					const missingHostTools = inheritedHostTools.filter(tool => !revived.getToolByName(tool.name));
-					if (missingHostTools.length > 0) await revived.refreshRpcHostTools(missingHostTools);
-					await revived.setActiveToolPresentation(
-						[...revivalTopLevelToolNames, ...revivalMountedToolNames],
-						revivalMountedToolNames,
-					);
-					installRegistryStatusSync(revived);
-					installIrcWakeTurnMonitor(revived);
-					return revived;
+					try {
+						const missingHostTools = inheritedHostTools.filter(tool => !revived.getToolByName(tool.name));
+						if (missingHostTools.length > 0) await revived.refreshRpcHostTools(missingHostTools);
+						await revived.setActiveToolPresentation(
+							[...revivalTopLevelToolNames, ...revivalMountedToolNames],
+							revivalMountedToolNames,
+						);
+						installRegistryStatusSync(revived);
+						installIrcWakeTurnMonitor(revived);
+						return revived;
+					} catch (error) {
+						if (registry.detachSession(id, expectedAgentRef)) {
+							registry.setStatus(id, "parked", expectedAgentRef);
+						}
+						await revived.dispose();
+						throw error;
+					}
 				};
 			}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3161,7 +3161,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
-					if (inheritedHostTools.length > 0) await revived.refreshRpcHostTools(inheritedHostTools);
+					const missingHostTools = inheritedHostTools.filter(tool => !revived.getToolByName(tool.name));
+					if (missingHostTools.length > 0) await revived.refreshRpcHostTools(missingHostTools);
 					installRegistryStatusSync(revived);
 					installIrcWakeTurnMonitor(revived);
 					return revived;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3145,12 +3145,13 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			monitor.setActiveSession(session);
 			const missingHostTools = inheritedHostTools.filter(tool => !session.getToolByName(tool.name));
 			if (missingHostTools.length > 0) {
+				const preRefreshMountedToolNames = session.getMountedXdevToolNames();
 				await session.refreshRpcHostTools(missingHostTools);
 				const mountedHostToolNames = new Set(options.parentMountedHostToolNames);
 				await session.setActiveToolPresentation(
 					[...session.getEnabledToolNames(), ...missingHostTools.map(tool => tool.name)],
 					[
-						...session.getMountedXdevToolNames(),
+						...preRefreshMountedToolNames,
 						...missingHostTools.filter(tool => mountedHostToolNames.has(tool.name)).map(tool => tool.name),
 					],
 				);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -446,6 +446,8 @@ export interface ExecutorOptions {
 	preloadedCustomToolPaths?: ToolPathWithSource[];
 	/** Parent host-provided tools proxied into this child and its live revivals. */
 	parentHostTools?: AgentTool[];
+	/** Subset of {@link parentHostTools} presented under `xd://` in the parent. */
+	parentMountedHostToolNames?: string[];
 	mcpManager?: MCPManager;
 	authStorage?: AuthStorage;
 	modelRegistry?: ModelRegistry;
@@ -3141,7 +3143,17 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				throw err;
 			}
 			const missingHostTools = inheritedHostTools.filter(tool => !session.getToolByName(tool.name));
-			if (missingHostTools.length > 0) await session.refreshRpcHostTools(missingHostTools);
+			if (missingHostTools.length > 0) {
+				await session.refreshRpcHostTools(missingHostTools);
+				const mountedHostToolNames = new Set(options.parentMountedHostToolNames);
+				await session.setActiveToolPresentation(
+					[...session.getEnabledToolNames(), ...missingHostTools.map(tool => tool.name)],
+					[
+						...session.getMountedXdevToolNames(),
+						...missingHostTools.filter(tool => mountedHostToolNames.has(tool.name)).map(tool => tool.name),
+					],
+				);
+			}
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -5,7 +5,7 @@
  */
 
 import path from "node:path";
-import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
+import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
@@ -444,6 +444,8 @@ export interface ExecutorOptions {
 	 * tool against its own `CustomToolAPI` (cwd, exec, pushPendingAction, UI).
 	 */
 	preloadedCustomToolPaths?: ToolPathWithSource[];
+	/** Parent host-provided tools proxied into this child and its live revivals. */
+	parentHostTools?: AgentTool[];
 	mcpManager?: MCPManager;
 	authStorage?: AuthStorage;
 	modelRegistry?: ModelRegistry;
@@ -3005,6 +3007,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const enableMCP = !restrictToolNames && (options.enableMCP ?? true);
 			const mcpManager = enableMCP ? options.mcpManager : undefined;
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
+			const inheritedHostTools = restrictToolNames ? [] : (options.parentHostTools ?? []);
 
 			// Derive subagent-scoped telemetry from the parent's config so the
 			// child loop's spans nest under the parent's active execute_tool span
@@ -3137,6 +3140,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				void sessionPromise.then(created => created.session.dispose()).catch(() => {});
 				throw err;
 			}
+			const missingHostTools = inheritedHostTools.filter(tool => !session.getToolByName(tool.name));
+			if (missingHostTools.length > 0) await session.refreshRpcHostTools(missingHostTools);
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);
@@ -3156,6 +3161,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
+					if (inheritedHostTools.length > 0) await revived.refreshRpcHostTools(inheritedHostTools);
 					installRegistryStatusSync(revived);
 					installIrcWakeTurnMonitor(revived);
 					return revived;

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -138,10 +138,23 @@ export function createPersistedSubagentReviverFactory(
 							customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
 						}),
 			});
+			if (!restrictToolNames) {
+				const inheritedHostTools = [
+					...ctx.session.getRpcHostTools(),
+					...[...new Set([...init.tools, ...ctx.session.getMountedXdevToolNames()])].flatMap(name => {
+						const tool = ctx.session.getToolByName(name);
+						return tool ? [tool] : [];
+					}),
+				].filter(tool => !session.getToolByName(tool.name));
+				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
+			}
 			// Clamp the active set to the persisted list: createAgentSession's
 			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools
-			// the original run didn't carry. Unknown/missing names are ignored.
-			await session.setActiveToolsByName([...init.tools, ...session.getMountedXdevToolNames()]);
+			await session.setActiveToolsByName([
+				...init.tools,
+				...ctx.session.getMountedXdevToolNames(),
+				...session.getMountedXdevToolNames(),
+			]);
 			// Cold revives must drive registry status themselves — createAgentSession
 			// doesn't wire this generically (the live path does it in the executor).
 			// Without it the idle-TTL timer never clears on a turn and the lifecycle

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -9,6 +9,7 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
+import { BUILTIN_TOOLS } from "../tools";
 import { isMCPToolName } from "../tools/builtin-names";
 import type { EventBus } from "../utils/event-bus";
 import { attachIrcWakeTurnMonitor, createMCPProxyTools, createSubagentSettings } from "./executor";
@@ -109,7 +110,7 @@ export function createPersistedSubagentReviverFactory(
 				: (init.mountedTools ?? []).filter(
 						name =>
 							(enableMCP || !isMCPToolName(name)) &&
-							(ctx.session.hasBuiltInTool(name) || parentRpcHostToolNames.has(name)),
+							(Object.hasOwn(BUILTIN_TOOLS, name) || parentRpcHostToolNames.has(name)),
 					);
 			const persistedToolNames = new Set([...init.tools, ...persistedMountedTools]);
 			const mcpManager = enableMCP ? MCPManager.instance() : undefined;
@@ -166,8 +167,19 @@ export function createPersistedSubagentReviverFactory(
 					);
 					if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
 				}
-				const restoredToolNames = [...persistedToolNames].filter(name => !localHostToolCollisions.has(name));
-				const restoredMountedTools = persistedMountedTools.filter(name => !localHostToolCollisions.has(name));
+				const restoredMountedTools = persistedMountedTools.filter(
+					name =>
+						!localHostToolCollisions.has(name) &&
+						(parentRpcHostToolNames.has(name)
+							? session.hasRpcHostTool(name)
+							: session.hasBuiltInTool(name) && session.getToolByName(name) !== undefined),
+				);
+				const restoredMountedToolNames = new Set(restoredMountedTools);
+				const restoredToolNames = [...persistedToolNames].filter(
+					name =>
+						!localHostToolCollisions.has(name) &&
+						(!persistedMountedTools.includes(name) || restoredMountedToolNames.has(name)),
+				);
 				// Restore the child's exact top-level versus mounted snapshot.
 				await session.setActiveToolPresentation(restoredToolNames, restoredMountedTools);
 				// Cold revives must drive registry status themselves — createAgentSession

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -104,15 +104,12 @@ export function createPersistedSubagentReviverFactory(
 				? []
 				: ctx.session.getRpcHostTools().filter(tool => enableMCP || !isMCPToolName(tool.name));
 			const parentRpcHostToolNames = new Set(parentRpcHostTools.map(tool => tool.name));
-			const parentMountedTools = new Set(ctx.session.getMountedXdevToolNames());
 			const persistedMountedTools = restrictToolNames
 				? []
 				: (init.mountedTools ?? []).filter(
 						name =>
 							(enableMCP || !isMCPToolName(name)) &&
-							(ctx.session.hasBuiltInTool(name) ||
-								parentRpcHostToolNames.has(name) ||
-								(parentMountedTools.has(name) && ctx.session.getToolByName(name) !== undefined)),
+							(ctx.session.hasBuiltInTool(name) || parentRpcHostToolNames.has(name)),
 					);
 			const persistedToolNames = new Set([...init.tools, ...persistedMountedTools]);
 			const mcpManager = enableMCP ? MCPManager.instance() : undefined;
@@ -153,12 +150,25 @@ export function createPersistedSubagentReviverFactory(
 						}
 					: {}),
 			});
+			const localHostToolCollisions = new Set(
+				parentRpcHostTools.flatMap(tool =>
+					persistedToolNames.has(tool.name) &&
+					session.getToolByName(tool.name) !== undefined &&
+					!session.hasRpcHostTool(tool.name)
+						? [tool.name]
+						: [],
+				),
+			);
 			if (!restrictToolNames) {
-				const inheritedHostTools = parentRpcHostTools.filter(tool => persistedToolNames.has(tool.name));
+				const inheritedHostTools = parentRpcHostTools.filter(
+					tool => persistedToolNames.has(tool.name) && !localHostToolCollisions.has(tool.name),
+				);
 				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
 			}
+			const restoredToolNames = [...persistedToolNames].filter(name => !localHostToolCollisions.has(name));
+			const restoredMountedTools = persistedMountedTools.filter(name => !localHostToolCollisions.has(name));
 			// Restore the child's exact top-level versus mounted snapshot.
-			await session.setActiveToolPresentation([...persistedToolNames], persistedMountedTools);
+			await session.setActiveToolPresentation(restoredToolNames, restoredMountedTools);
 			// Cold revives must drive registry status themselves — createAgentSession
 			// doesn't wire this generically (the live path does it in the executor).
 			// Without it the idle-TTL timer never clears on a turn and the lifecycle

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -9,6 +9,7 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
+import { isMCPToolName } from "../tools/builtin-names";
 import type { EventBus } from "../utils/event-bus";
 import { attachIrcWakeTurnMonitor, createMCPProxyTools, createSubagentSettings } from "./executor";
 import type { AgentDefinition } from "./types";
@@ -98,7 +99,12 @@ export function createPersistedSubagentReviverFactory(
 			// A restricted persisted contract must not consult process-global MCP
 			// state: same-name MCP tools are untrusted capability sources.
 			const restrictToolNames = init.restrictToolNames === true;
-			const mcpManager = restrictToolNames ? undefined : MCPManager.instance();
+			const enableMCP = !restrictToolNames && (init.enableMCP ?? true);
+			const persistedMountedTools = restrictToolNames
+				? []
+				: (init.mountedTools ?? []).filter(name => enableMCP || !isMCPToolName(name));
+			const persistedToolNames = new Set([...init.tools, ...persistedMountedTools]);
+			const mcpManager = enableMCP ? MCPManager.instance() : undefined;
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
 			const { session } = await createAgentSession({
 				cwd: ctx.session.sessionManager.getCwd(),
@@ -114,7 +120,7 @@ export function createPersistedSubagentReviverFactory(
 				parentAgentId: ref.parentId,
 				expectedAgentRef: expectedRef,
 				taskDepth,
-				toolNames: init.tools,
+				toolNames: [...persistedToolNames],
 				outputSchema: init.outputSchema,
 				outputSchemaMode: init.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,
@@ -125,29 +131,27 @@ export function createPersistedSubagentReviverFactory(
 				spawns: init.spawns ?? "",
 				hasUI: false,
 				enableLsp: restrictToolNames ? false : ctx.enableLsp,
+				enableMCP,
+				mcpManager,
+				customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
 				...(restrictToolNames
 					? {
 							enableIrc: false,
-							enableMCP: false,
 							preloadedExtensionPaths: [],
 							preloadedCustomToolPaths: [],
 						}
-					: {
-							enableMCP: !mcpManager,
-							mcpManager,
-							customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
-						}),
+					: {}),
 			});
-			const parentMountedXdevToolNames = restrictToolNames
-				? []
-				: ctx.session.getMountedXdevToolNames().filter(name => !ctx.session.hasBuiltInTool(name));
+			const parentMountedTools = new Set(ctx.session.getMountedXdevToolNames());
 			if (!restrictToolNames) {
 				const inheritedHostTools = [
 					...new Map(
 						[
-							...ctx.session.getRpcHostTools(),
-							...[...new Set([...init.tools, ...parentMountedXdevToolNames])].flatMap(name => {
-								if (ctx.session.hasBuiltInTool(name)) return [];
+							...ctx.session
+								.getRpcHostTools()
+								.filter(tool => persistedToolNames.has(tool.name) && (enableMCP || !isMCPToolName(tool.name))),
+							...persistedMountedTools.flatMap(name => {
+								if (!parentMountedTools.has(name) || ctx.session.hasBuiltInTool(name)) return [];
 								const tool = ctx.session.getToolByName(name);
 								return tool ? [tool] : [];
 							}),
@@ -156,15 +160,8 @@ export function createPersistedSubagentReviverFactory(
 				].filter(tool => !session.getToolByName(tool.name));
 				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
 			}
-			// Clamp the active set to the persisted list: createAgentSession's
-			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools.
-			const mountedXdevToolNames = restrictToolNames
-				? []
-				: [
-						...parentMountedXdevToolNames,
-						...session.getMountedXdevToolNames().filter(name => !session.hasBuiltInTool(name)),
-					];
-			await session.setActiveToolsByName([...new Set([...init.tools, ...mountedXdevToolNames])]);
+			// Restore the child's exact top-level versus mounted snapshot.
+			await session.setActiveToolPresentation([...persistedToolNames], persistedMountedTools);
 			// Cold revives must drive registry status themselves — createAgentSession
 			// doesn't wire this generically (the live path does it in the executor).
 			// Without it the idle-TTL timer never clears on a turn and the lifecycle

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -100,9 +100,20 @@ export function createPersistedSubagentReviverFactory(
 			// state: same-name MCP tools are untrusted capability sources.
 			const restrictToolNames = init.restrictToolNames === true;
 			const enableMCP = !restrictToolNames && (init.enableMCP ?? true);
+			const parentRpcHostTools = restrictToolNames
+				? []
+				: ctx.session.getRpcHostTools().filter(tool => enableMCP || !isMCPToolName(tool.name));
+			const parentRpcHostToolNames = new Set(parentRpcHostTools.map(tool => tool.name));
+			const parentMountedTools = new Set(ctx.session.getMountedXdevToolNames());
 			const persistedMountedTools = restrictToolNames
 				? []
-				: (init.mountedTools ?? []).filter(name => enableMCP || !isMCPToolName(name));
+				: (init.mountedTools ?? []).filter(
+						name =>
+							(enableMCP || !isMCPToolName(name)) &&
+							(ctx.session.hasBuiltInTool(name) ||
+								parentRpcHostToolNames.has(name) ||
+								(parentMountedTools.has(name) && ctx.session.getToolByName(name) !== undefined)),
+					);
 			const persistedToolNames = new Set([...init.tools, ...persistedMountedTools]);
 			const mcpManager = enableMCP ? MCPManager.instance() : undefined;
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
@@ -142,14 +153,11 @@ export function createPersistedSubagentReviverFactory(
 						}
 					: {}),
 			});
-			const parentMountedTools = new Set(ctx.session.getMountedXdevToolNames());
 			if (!restrictToolNames) {
 				const inheritedHostTools = [
 					...new Map(
 						[
-							...ctx.session
-								.getRpcHostTools()
-								.filter(tool => persistedToolNames.has(tool.name) && (enableMCP || !isMCPToolName(tool.name))),
+							...parentRpcHostTools.filter(tool => persistedToolNames.has(tool.name)),
 							...persistedMountedTools.flatMap(name => {
 								if (!parentMountedTools.has(name) || ctx.session.hasBuiltInTool(name)) return [];
 								const tool = ctx.session.getToolByName(name);
@@ -157,7 +165,7 @@ export function createPersistedSubagentReviverFactory(
 							}),
 						].map(tool => [tool.name, tool]),
 					).values(),
-				].filter(tool => !session.getToolByName(tool.name));
+				].filter(tool => persistedToolNames.has(tool.name));
 				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
 			}
 			// Restore the child's exact top-level versus mounted snapshot.

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -138,23 +138,33 @@ export function createPersistedSubagentReviverFactory(
 							customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
 						}),
 			});
+			const parentMountedXdevToolNames = restrictToolNames
+				? []
+				: ctx.session.getMountedXdevToolNames().filter(name => !ctx.session.hasBuiltInTool(name));
 			if (!restrictToolNames) {
 				const inheritedHostTools = [
-					...ctx.session.getRpcHostTools(),
-					...[...new Set([...init.tools, ...ctx.session.getMountedXdevToolNames()])].flatMap(name => {
-						const tool = ctx.session.getToolByName(name);
-						return tool ? [tool] : [];
-					}),
+					...new Map(
+						[
+							...ctx.session.getRpcHostTools(),
+							...[...new Set([...init.tools, ...parentMountedXdevToolNames])].flatMap(name => {
+								if (ctx.session.hasBuiltInTool(name)) return [];
+								const tool = ctx.session.getToolByName(name);
+								return tool ? [tool] : [];
+							}),
+						].map(tool => [tool.name, tool]),
+					).values(),
 				].filter(tool => !session.getToolByName(tool.name));
 				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
 			}
 			// Clamp the active set to the persisted list: createAgentSession's
-			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools
-			await session.setActiveToolsByName([
-				...init.tools,
-				...ctx.session.getMountedXdevToolNames(),
-				...session.getMountedXdevToolNames(),
-			]);
+			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools.
+			const mountedXdevToolNames = restrictToolNames
+				? []
+				: [
+						...parentMountedXdevToolNames,
+						...session.getMountedXdevToolNames().filter(name => !session.hasBuiltInTool(name)),
+					];
+			await session.setActiveToolsByName([...new Set([...init.tools, ...mountedXdevToolNames])]);
 			// Cold revives must drive registry status themselves — createAgentSession
 			// doesn't wire this generically (the live path does it in the executor).
 			// Without it the idle-TTL timer never clears on a turn and the lifecycle

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -150,51 +150,59 @@ export function createPersistedSubagentReviverFactory(
 						}
 					: {}),
 			});
-			const localHostToolCollisions = new Set(
-				parentRpcHostTools.flatMap(tool =>
-					persistedToolNames.has(tool.name) &&
-					session.getToolByName(tool.name) !== undefined &&
-					!session.hasRpcHostTool(tool.name)
-						? [tool.name]
-						: [],
-				),
-			);
-			if (!restrictToolNames) {
-				const inheritedHostTools = parentRpcHostTools.filter(
-					tool => persistedToolNames.has(tool.name) && !localHostToolCollisions.has(tool.name),
+			try {
+				const localHostToolCollisions = new Set(
+					parentRpcHostTools.flatMap(tool =>
+						persistedToolNames.has(tool.name) &&
+						session.getToolByName(tool.name) !== undefined &&
+						!session.hasRpcHostTool(tool.name)
+							? [tool.name]
+							: [],
+					),
 				);
-				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
+				if (!restrictToolNames) {
+					const inheritedHostTools = parentRpcHostTools.filter(
+						tool => persistedToolNames.has(tool.name) && !localHostToolCollisions.has(tool.name),
+					);
+					if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
+				}
+				const restoredToolNames = [...persistedToolNames].filter(name => !localHostToolCollisions.has(name));
+				const restoredMountedTools = persistedMountedTools.filter(name => !localHostToolCollisions.has(name));
+				// Restore the child's exact top-level versus mounted snapshot.
+				await session.setActiveToolPresentation(restoredToolNames, restoredMountedTools);
+				// Cold revives must drive registry status themselves — createAgentSession
+				// doesn't wire this generically (the live path does it in the executor).
+				// Without it the idle-TTL timer never clears on a turn and the lifecycle
+				// could park the agent mid-run.
+				session.subscribe(event => {
+					if (event.type === "agent_start") registry.setStatus(ref.id, "running", session);
+					else if (event.type === "agent_end") registry.setStatus(ref.id, "idle", session);
+				});
+				// Persisted files predate an agent-source field, so cold-revived frames
+				// report the runtime-neutral `user` source; name comes from the ref.
+				const wakeAgent: AgentDefinition = {
+					name: ref.displayName,
+					description: "",
+					systemPrompt: init.systemPrompt,
+					source: "user",
+				};
+				attachIrcWakeTurnMonitor(session, {
+					id: ref.id,
+					agent: wakeAgent,
+					eventBus: ctx.eventBus,
+					sessionFile,
+					outputSchema: init.outputSchema,
+					outputSchemaMode: init.outputSchemaMode,
+					artifactsDir: ctx.session.sessionFile?.slice(0, -6),
+				});
+				return session;
+			} catch (error) {
+				if (registry.detachSession(ref.id, expectedRef)) {
+					registry.setStatus(ref.id, "parked", expectedRef);
+				}
+				await session.dispose();
+				throw error;
 			}
-			const restoredToolNames = [...persistedToolNames].filter(name => !localHostToolCollisions.has(name));
-			const restoredMountedTools = persistedMountedTools.filter(name => !localHostToolCollisions.has(name));
-			// Restore the child's exact top-level versus mounted snapshot.
-			await session.setActiveToolPresentation(restoredToolNames, restoredMountedTools);
-			// Cold revives must drive registry status themselves — createAgentSession
-			// doesn't wire this generically (the live path does it in the executor).
-			// Without it the idle-TTL timer never clears on a turn and the lifecycle
-			// could park the agent mid-run.
-			session.subscribe(event => {
-				if (event.type === "agent_start") registry.setStatus(ref.id, "running", session);
-				else if (event.type === "agent_end") registry.setStatus(ref.id, "idle", session);
-			});
-			// Persisted files predate an agent-source field, so cold-revived frames
-			// report the runtime-neutral `user` source; name comes from the ref.
-			const wakeAgent: AgentDefinition = {
-				name: ref.displayName,
-				description: "",
-				systemPrompt: init.systemPrompt,
-				source: "user",
-			};
-			attachIrcWakeTurnMonitor(session, {
-				id: ref.id,
-				agent: wakeAgent,
-				eventBus: ctx.eventBus,
-				sessionFile,
-				outputSchema: init.outputSchema,
-				outputSchemaMode: init.outputSchemaMode,
-				artifactsDir: ctx.session.sessionFile?.slice(0, -6),
-			});
-			return session;
 		};
 	};
 }

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -154,18 +154,7 @@ export function createPersistedSubagentReviverFactory(
 					: {}),
 			});
 			if (!restrictToolNames) {
-				const inheritedHostTools = [
-					...new Map(
-						[
-							...parentRpcHostTools.filter(tool => persistedToolNames.has(tool.name)),
-							...persistedMountedTools.flatMap(name => {
-								if (!parentMountedTools.has(name) || ctx.session.hasBuiltInTool(name)) return [];
-								const tool = ctx.session.getToolByName(name);
-								return tool ? [tool] : [];
-							}),
-						].map(tool => [tool.name, tool]),
-					).values(),
-				].filter(tool => persistedToolNames.has(tool.name));
+				const inheritedHostTools = parentRpcHostTools.filter(tool => persistedToolNames.has(tool.name));
 				if (inheritedHostTools.length > 0) await session.refreshRpcHostTools(inheritedHostTools);
 			}
 			// Restore the child's exact top-level versus mounted snapshot.

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -385,13 +385,14 @@ function buildExecutorOptions(
 	};
 	const restrictToolNames = policy.planMode || session.restrictToolNames === true;
 	const enableMCP = !restrictToolNames && (session.enableMCP ?? true);
+	const parentMountedHostToolNames = session.getMountedXdevToolNames?.() ?? [];
 	const parentHostTools = new Map(
 		(session.getRpcHostTools?.() ?? [])
 			.filter(tool => enableMCP || !isMCPToolName(tool.name))
 			.map(tool => [tool.name, tool]),
 	);
 	if (!restrictToolNames) {
-		for (const name of session.getMountedXdevToolNames?.() ?? []) {
+		for (const name of parentMountedHostToolNames) {
 			if ((!enableMCP && isMCPToolName(name)) || session.hasBuiltInTool?.(name) || parentHostTools.has(name)) {
 				continue;
 			}
@@ -460,6 +461,7 @@ function buildExecutorOptions(
 		parentMnemopiSessionState: session.getMnemopiSessionState?.(),
 		parentTelemetry: session.getTelemetry?.(),
 		parentEvalSessionId: request.shareEvalSession === false ? undefined : (session.getEvalSessionId?.() ?? undefined),
+		parentMountedHostToolNames: parentMountedHostToolNames.filter(name => parentHostTools.has(name)),
 		parentAgentId: session.getAgentId?.() ?? MAIN_AGENT_ID,
 		parentServiceTier: session.getServiceTierByFamily ? (session.getServiceTierByFamily() ?? null) : undefined,
 	};

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -385,21 +385,11 @@ function buildExecutorOptions(
 	};
 	const restrictToolNames = policy.planMode || session.restrictToolNames === true;
 	const enableMCP = !restrictToolNames && (session.enableMCP ?? true);
-	const parentMountedHostToolNames = session.getMountedXdevToolNames?.() ?? [];
-	const parentHostTools = new Map(
-		(session.getRpcHostTools?.() ?? [])
-			.filter(tool => enableMCP || !isMCPToolName(tool.name))
-			.map(tool => [tool.name, tool]),
-	);
-	if (!restrictToolNames) {
-		for (const name of parentMountedHostToolNames) {
-			if ((!enableMCP && isMCPToolName(name)) || session.hasBuiltInTool?.(name) || parentHostTools.has(name)) {
-				continue;
-			}
-			const tool = session.getToolByName?.(name);
-			if (tool) parentHostTools.set(name, tool);
-		}
-	}
+	const parentHostTools = (session.getRpcHostTools?.() ?? []).filter(tool => enableMCP || !isMCPToolName(tool.name));
+	const parentHostToolNames = new Set(parentHostTools.map(tool => tool.name));
+	const parentMountedHostToolNames = restrictToolNames
+		? []
+		: (session.getMountedXdevToolNames?.() ?? []).filter(name => parentHostToolNames.has(name));
 	return {
 		cwd: session.cwd,
 		additionalDirectories: session.additionalDirectories,
@@ -454,14 +444,14 @@ function buildExecutorOptions(
 		rules: session.rules,
 		preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,
-		parentHostTools: restrictToolNames ? [] : [...parentHostTools.values()],
+		parentHostTools: restrictToolNames ? [] : parentHostTools,
 		localProtocolOptions,
 		parentArtifactManager: session.getArtifactManager?.() ?? undefined,
 		parentHindsightSessionState: session.getHindsightSessionState?.(),
 		parentMnemopiSessionState: session.getMnemopiSessionState?.(),
 		parentTelemetry: session.getTelemetry?.(),
 		parentEvalSessionId: request.shareEvalSession === false ? undefined : (session.getEvalSessionId?.() ?? undefined),
-		parentMountedHostToolNames: parentMountedHostToolNames.filter(name => parentHostTools.has(name)),
+		parentMountedHostToolNames,
 		parentAgentId: session.getAgentId?.() ?? MAIN_AGENT_ID,
 		parentServiceTier: session.getServiceTierByFamily ? (session.getServiceTierByFamily() ?? null) : undefined,
 	};

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -384,6 +384,14 @@ function buildExecutorOptions(
 	};
 	const restrictToolNames = policy.planMode || session.restrictToolNames === true;
 	const enableMCP = !restrictToolNames && (session.enableMCP ?? true);
+	const parentHostTools = new Map((session.getRpcHostTools?.() ?? []).map(tool => [tool.name, tool]));
+	if (!restrictToolNames) {
+		for (const name of session.getMountedXdevToolNames?.() ?? []) {
+			if (session.hasBuiltInTool?.(name) || parentHostTools.has(name)) continue;
+			const tool = session.getToolByName?.(name);
+			if (tool) parentHostTools.set(name, tool);
+		}
+	}
 	return {
 		cwd: session.cwd,
 		additionalDirectories: session.additionalDirectories,
@@ -438,13 +446,7 @@ function buildExecutorOptions(
 		rules: session.rules,
 		preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,
-		parentHostTools: restrictToolNames
-			? []
-			: (session.getMountedXdevToolNames?.() ?? []).flatMap(name => {
-					if (session.hasBuiltInTool?.(name)) return [];
-					const tool = session.getToolByName?.(name);
-					return tool ? [tool] : [];
-				}),
+		parentHostTools: restrictToolNames ? [] : [...parentHostTools.values()],
 		localProtocolOptions,
 		parentArtifactManager: session.getArtifactManager?.() ?? undefined,
 		parentHindsightSessionState: session.getHindsightSessionState?.(),

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -18,6 +18,7 @@ import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.m
 import { MAIN_AGENT_ID } from "../registry/agent-registry";
 import type { TaskEffort } from "../thinking";
 import type { ToolSession } from "../tools";
+import { isMCPToolName } from "../tools/builtin-names";
 import { isIrcEnabled } from "../tools/hub";
 import { buildOutputValidator } from "../tools/output-schema-validator";
 import { trackLateCleanup } from "../utils/late-cleanup";
@@ -384,10 +385,16 @@ function buildExecutorOptions(
 	};
 	const restrictToolNames = policy.planMode || session.restrictToolNames === true;
 	const enableMCP = !restrictToolNames && (session.enableMCP ?? true);
-	const parentHostTools = new Map((session.getRpcHostTools?.() ?? []).map(tool => [tool.name, tool]));
+	const parentHostTools = new Map(
+		(session.getRpcHostTools?.() ?? [])
+			.filter(tool => enableMCP || !isMCPToolName(tool.name))
+			.map(tool => [tool.name, tool]),
+	);
 	if (!restrictToolNames) {
 		for (const name of session.getMountedXdevToolNames?.() ?? []) {
-			if (session.hasBuiltInTool?.(name) || parentHostTools.has(name)) continue;
+			if ((!enableMCP && isMCPToolName(name)) || session.hasBuiltInTool?.(name) || parentHostTools.has(name)) {
+				continue;
+			}
 			const tool = session.getToolByName?.(name);
 			if (tool) parentHostTools.set(name, tool);
 		}

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -438,6 +438,13 @@ function buildExecutorOptions(
 		rules: session.rules,
 		preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,
+		parentHostTools: restrictToolNames
+			? []
+			: (session.getMountedXdevToolNames?.() ?? []).flatMap(name => {
+					if (session.hasBuiltInTool?.(name)) return [];
+					const tool = session.getToolByName?.(name);
+					return tool ? [tool] : [];
+				}),
 		localProtocolOptions,
 		parentArtifactManager: session.getArtifactManager?.() ?? undefined,
 		parentHindsightSessionState: session.getHindsightSessionState?.(),

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -251,7 +251,7 @@ export interface ToolSession {
 	getAgentId?: () => string | null;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
 	getToolByName?: (name: string) => AgentTool | undefined;
-	/** Host-provided RPC tools that child sessions must inherit. */
+	/** Enabled host-provided RPC tools that child sessions must inherit. */
 	getRpcHostTools?: () => AgentTool[];
 	/** Names of dynamic tools mounted under `xd://`. */
 	getMountedXdevToolNames?: () => string[];

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -251,6 +251,12 @@ export interface ToolSession {
 	getAgentId?: () => string | null;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
 	getToolByName?: (name: string) => AgentTool | undefined;
+	/** Host-provided RPC tools that child sessions must inherit. */
+	getRpcHostTools?: () => AgentTool[];
+	/** Names of dynamic tools mounted under `xd://`. */
+	getMountedXdevToolNames?: () => string[];
+	/** Whether the named registry entry came from a built-in factory. */
+	hasBuiltInTool?: (name: string) => boolean;
 	/** Return whether a built-in tool is active in this turn's tool set. */
 	isToolActive?: (name: string) => boolean;
 	/** Update the active built-in tool predicate when a session changes tools mid-run. */

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -32,6 +32,7 @@ import { generateTaskName } from "../task/name-generator";
 import { AgentOutputManager } from "../task/output-manager";
 import { type AgentDefinition, type AgentProgress, oneLineLabel, type SingleResult } from "../task/types";
 import type { ToolSession } from "../tools";
+import { isMCPToolName } from "../tools/builtin-names";
 import { formatDuration } from "../tools/render-utils";
 import { ToolError } from "../tools/tool-errors";
 import { calculateTokensPerSecond } from "../utils/token-rate";
@@ -1405,6 +1406,15 @@ export class VibeSessionRegistry {
 		signal: AbortSignal,
 		onProgress: (progress: AgentProgress) => void,
 	): Promise<ExecutorOptions> {
+		const restrictToolNames = session.restrictToolNames === true;
+		const enableMCP = !restrictToolNames && (session.enableMCP ?? true);
+		const parentHostTools = (session.getRpcHostTools?.() ?? []).filter(
+			tool => enableMCP || !isMCPToolName(tool.name),
+		);
+		const parentHostToolNames = new Set(parentHostTools.map(tool => tool.name));
+		const parentMountedHostToolNames = restrictToolNames
+			? []
+			: (session.getMountedXdevToolNames?.() ?? []).filter(name => parentHostToolNames.has(name));
 		const sessionFile = session.getSessionFile();
 		const sessionArtifactsDir = sessionFile ? sessionFile.slice(0, -6) : null;
 		const artifactsDir = sessionArtifactsDir ?? path.join(os.tmpdir(), `omp-vibe-${Snowflake.next()}`);
@@ -1438,14 +1448,18 @@ export class VibeSessionRegistry {
 			authStorage: session.authStorage,
 			modelRegistry: session.modelRegistry,
 			settings: session.settings,
-			mcpManager: session.mcpManager ?? MCPManager.instance(),
+			mcpManager: enableMCP ? (session.mcpManager ?? MCPManager.instance()) : undefined,
 			contextFiles: session.contextFiles?.filter(file => path.basename(file.path).toLowerCase() !== "agents.md"),
 			skills: [...(session.skills ?? [])],
 			workspaceTree: session.workspaceTree,
 			promptTemplates: session.promptTemplates,
 			rules: session.rules,
-			preloadedExtensionPaths: session.extensionPaths,
-			preloadedCustomToolPaths: session.customToolPaths,
+			preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
+			preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,
+			restrictToolNames,
+			enableMCP,
+			parentHostTools: restrictToolNames ? [] : parentHostTools,
+			parentMountedHostToolNames,
 			localProtocolOptions,
 			parentArtifactManager: session.getArtifactManager?.() ?? undefined,
 			parentHindsightSessionState: session.getHindsightSessionState?.(),

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1295,6 +1295,17 @@ These tools became available:
 		expect(session.getMountedXdevToolNames()).toContain(newTool.name);
 	});
 
+	it("excludes disabled RPC host tools from child inheritance", async () => {
+		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`);
+		const hostTool = { ...createBasicTool("rpc_host", "RPC Host"), loadMode: "essential" as const };
+		await session.refreshRpcHostTools([hostTool]);
+		expect(session.getRpcHostTools().map(tool => tool.name)).toEqual([hostTool.name]);
+
+		await session.setActiveToolsByName(["read"]);
+
+		expect(session.getRpcHostTools()).toEqual([]);
+	});
+
 	it("rolls back RPC catalog replacement when prompt rebuild fails", async () => {
 		let failRebuild = false;
 		let date = "2026-07-16";

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1296,10 +1296,14 @@ These tools became available:
 	});
 
 	it("excludes disabled RPC host tools from child inheritance", async () => {
-		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`);
+		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			beforeAgentStartSystemPrompt: ["initial"],
+		});
 		const hostTool = { ...createBasicTool("rpc_host", "RPC Host"), loadMode: "essential" as const };
 		await session.refreshRpcHostTools([hostTool]);
 		expect(session.getRpcHostTools().map(tool => tool.name)).toEqual([hostTool.name]);
+		expect(session.getRpcHostTools()[0]).toBe(hostTool);
+		expect(session.getRpcHostTools()[0]).not.toBe(session.getToolByName(hostTool.name));
 
 		await session.setActiveToolsByName(["read"]);
 

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -61,6 +61,8 @@ function createCloneStub(overrides?: {
 		agent: { appendMessage },
 		sessionManager: overrides?.sessionManager,
 		setTodoPhases: vi.fn(),
+		getActiveToolNames: () => ["read", "bash"],
+		getMountedXdevToolNames: () => [],
 		subscribe: vi.fn((l: (event: TanSessionEvent) => void) => {
 			listener = l;
 			return () => {
@@ -377,6 +379,7 @@ describe("TanCommandController", () => {
 			systemPrompt: "system prompt",
 			task: "park me",
 			tools: ["read", "bash"],
+			mountedTools: [],
 		});
 		// Parked (not unregistered) before dispose, then the disposed session is nulled
 		// out — the hub keeps the ref and reads its transcript from the session file.

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -380,6 +380,7 @@ describe("TanCommandController", () => {
 			task: "park me",
 			tools: ["read", "bash"],
 			mountedTools: [],
+			enableMCP: false,
 		});
 		// Parked (not unregistered) before dispose, then the disposed session is nulled
 		// out — the hub keeps the ref and reads its transcript from the session file.

--- a/packages/coding-agent/test/session/peek-session-init.test.ts
+++ b/packages/coding-agent/test/session/peek-session-init.test.ts
@@ -50,6 +50,8 @@ describe("SessionManager.peekSessionInit", () => {
 			systemPrompt: "second",
 			task: "t2",
 			tools: ["read", "bash", "yield"],
+			mountedTools: ["ida_execute_python"],
+			enableMCP: false,
 			spawns: "task",
 			readSummarize: false,
 			restrictToolNames: true,
@@ -62,6 +64,8 @@ describe("SessionManager.peekSessionInit", () => {
 		// Latest init wins — the reviver must rebuild from the most recent contract.
 		expect(peek?.init?.systemPrompt).toBe("second");
 		expect(peek?.init?.tools).toEqual(["read", "bash", "yield"]);
+		expect(peek?.init?.mountedTools).toEqual(["ida_execute_python"]);
+		expect(peek?.init?.enableMCP).toBe(false);
 		expect(peek?.init?.spawns).toBe("task");
 		expect(peek?.init?.readSummarize).toBe(false);
 		expect(peek?.init?.restrictToolNames).toBe(true);

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -14,6 +14,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolPathWithSource } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -116,6 +117,7 @@ function createModelRegistry(model: Model): ModelRegistry {
 
 describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
 		vi.restoreAllMocks();
 	});
 
@@ -280,6 +282,35 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 			["read", "yield", hiddenTopLevel.name, hiddenMounted.name],
 			[hiddenMounted.name],
 		);
+	});
+
+	it("disposes a newly created session when inherited host-tool refresh fails", async () => {
+		const session = yieldEmittingSession();
+		const dispose = vi.fn(async () => {});
+		session.dispose = dispose;
+		session.refreshRpcHostTools = async () => {
+			throw new Error("host refresh failed");
+		};
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const id = "host-refresh-failure";
+		AgentRegistry.global().register({
+			id,
+			displayName: id,
+			kind: "sub",
+			session,
+			status: "running",
+		});
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id,
+			keepAlive: false,
+			parentHostTools: [{ name: "ida_execute_python" } as AgentTool],
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(AgentRegistry.global().get(id)).toBeUndefined();
 	});
 
 	it("preserves the legacy result shape when no output schema is selected", async () => {

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -4,7 +4,7 @@
  * paid for. Regression guard for issue #2190.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -35,6 +35,8 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
+		getToolByName: () => undefined,
+		refreshRpcHostTools: async () => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -226,14 +228,21 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		const mcpManager = {
 			getTools: () => [{ name: "mcp__private_read", label: "private/read" }],
 		} as unknown as MCPManager;
+		const hostTool = { name: "ida_execute_python" } as AgentTool;
 
-		const result = await runSubprocess({ ...baseOptions, id: "normal-child", mcpManager });
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "normal-child",
+			mcpManager,
+			parentHostTools: [hostTool],
+		});
 
 		expect(result.exitCode).toBe(0);
 		const forwarded = spy.mock.calls[0]?.[0];
 		expect(forwarded?.enableMCP).toBe(true);
 		expect(forwarded?.mcpManager).toBe(mcpManager);
 		expect(forwarded?.customTools?.map(tool => tool.name)).toEqual(["mcp__private_read"]);
+		expect(forwarded?.toolNames).toBeUndefined();
 	});
 
 	it("preserves the legacy result shape when no output schema is selected", async () => {

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -284,6 +284,27 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		);
 	});
 
+	it("keeps an inherited top-level discoverable host tool out of xd:// after refresh", async () => {
+		const session = yieldEmittingSession();
+		let mountedToolNames: string[] = [];
+		session.getMountedXdevToolNames = () => mountedToolNames;
+		session.refreshRpcHostTools = async tools => {
+			mountedToolNames = tools.map(tool => tool.name);
+		};
+		const presentation = vi.spyOn(session, "setActiveToolPresentation");
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const topLevelHostTool = { name: "top_level_host", loadMode: "discoverable" } as AgentTool;
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "top-level-host-tool",
+			parentHostTools: [topLevelHostTool],
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(presentation).toHaveBeenCalledWith(["read", "yield", topLevelHostTool.name], []);
+	});
+
 	it("disposes a newly created session when inherited host-tool refresh fails", async () => {
 		const session = yieldEmittingSession();
 		const dispose = vi.fn(async () => {});

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -21,7 +21,10 @@ import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
-function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void): AgentSession {
+function createMockSession(
+	onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void,
+	refreshedHostTools: string[][] = [],
+): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const emit = (event: AgentSessionEvent) => {
 		for (const listener of listeners) listener(event);
@@ -36,7 +39,9 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		getEnabledToolNames: () => ["read", "yield"],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
 		getToolByName: () => undefined,
-		refreshRpcHostTools: async () => {},
+		refreshRpcHostTools: async (tools: AgentTool[]) => {
+			refreshedHostTools.push(tools.map(tool => tool.name));
+		},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -56,7 +61,7 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 	return session as unknown as AgentSession;
 }
 
-function yieldEmittingSession(): AgentSession {
+function yieldEmittingSession(refreshedHostTools: string[][] = []): AgentSession {
 	return createMockSession(({ emit }) => {
 		emit({
 			type: "tool_execution_end",
@@ -68,7 +73,7 @@ function yieldEmittingSession(): AgentSession {
 			},
 			isError: false,
 		});
-	});
+	}, refreshedHostTools);
 }
 
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
@@ -223,7 +228,8 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 	});
 
 	it("retains inherited MCP proxy tools for normal children", async () => {
-		const session = yieldEmittingSession();
+		const refreshedHostTools: string[][] = [];
+		const session = yieldEmittingSession(refreshedHostTools);
 		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
 		const mcpManager = {
 			getTools: () => [{ name: "mcp__private_read", label: "private/read" }],
@@ -243,6 +249,7 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.mcpManager).toBe(mcpManager);
 		expect(forwarded?.customTools?.map(tool => tool.name)).toEqual(["mcp__private_read"]);
 		expect(forwarded?.toolNames).toBeUndefined();
+		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
 	});
 
 	it("preserves the legacy result shape when no output schema is selected", async () => {

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -37,6 +37,7 @@ function createMockSession(
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
+		getMountedXdevToolNames: () => [],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
 		getToolByName: () => undefined,
 		refreshRpcHostTools: async (tools: AgentTool[]) => {
@@ -230,6 +231,12 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 	it("retains inherited MCP proxy tools for normal children", async () => {
 		const refreshedHostTools: string[][] = [];
 		const session = yieldEmittingSession(refreshedHostTools);
+		session.getMountedXdevToolNames = () => ["ida_execute_python"];
+		const persistedInits: Array<{ mountedTools?: string[] }> = [];
+		vi.spyOn(session.sessionManager, "appendSessionInit").mockImplementation(init => {
+			persistedInits.push(init);
+			return "session-init";
+		});
 		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
 		const mcpManager = {
 			getTools: () => [{ name: "mcp__private_read", label: "private/read" }],
@@ -250,6 +257,7 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.customTools?.map(tool => tool.name)).toEqual(["mcp__private_read"]);
 		expect(forwarded?.toolNames).toBeUndefined();
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
+		expect(persistedInits).toEqual([expect.objectContaining({ mountedTools: ["ida_execute_python"] })]);
 	});
 
 	it("preserves the legacy result shape when no output schema is selected", async () => {

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -14,10 +14,12 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolPathWithSource } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
@@ -117,6 +119,7 @@ function createModelRegistry(model: Model): ModelRegistry {
 
 describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 	afterEach(() => {
+		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
 		vi.restoreAllMocks();
 	});
@@ -332,6 +335,59 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(result.exitCode).toBe(1);
 		expect(dispose).toHaveBeenCalledTimes(1);
 		expect(AgentRegistry.global().get(id)).toBeUndefined();
+	});
+
+	it("retries a warm revive after post-create host refresh cleanup", async () => {
+		const id = "warm-revive-refresh-failure";
+		const registry = AgentRegistry.global();
+		const initial = yieldEmittingSession();
+		const failed = createMockSession(() => {});
+		const failedDispose = vi.fn(async () => {});
+		failed.dispose = failedDispose;
+		failed.refreshRpcHostTools = async () => {
+			throw new Error("host refresh failed");
+		};
+		const recovered = createMockSession(() => {});
+		let reviveAttempts = 0;
+		vi.spyOn(SessionManager, "open").mockResolvedValue({} as SessionManager);
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected session options");
+			if (!options.expectedAgentRef) {
+				registry.register({
+					id,
+					displayName: id,
+					kind: "sub",
+					session: initial,
+					sessionFile: "warm-revive.jsonl",
+					status: "running",
+				});
+				return createSessionResult(initial);
+			}
+
+			const revived = reviveAttempts++ === 0 ? failed : recovered;
+			if (!registry.attachSession(id, revived, options.expectedAgentRef.sessionFile, options.expectedAgentRef)) {
+				throw new Error("failed to attach revived session");
+			}
+			registry.setStatus(id, "running", options.expectedAgentRef);
+			return createSessionResult(revived);
+		});
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id,
+			artifactsDir: "/tmp",
+			parentHostTools: [{ name: "ida_execute_python" } as AgentTool],
+		});
+		expect(result.exitCode).toBe(0);
+		await AgentLifecycleManager.global().park(id);
+
+		await expect(AgentLifecycleManager.global().ensureLive(id)).rejects.toThrow("host refresh failed");
+		expect(failedDispose).toHaveBeenCalledTimes(1);
+		expect(registry.get(id)).toMatchObject({ status: "parked", session: null, sessionFile: "warm-revive.jsonl" });
+
+		expect(await AgentLifecycleManager.global().ensureLive(id)).toBe(recovered);
+		expect(reviveAttempts).toBe(2);
+		expect(registry.get(id)).toMatchObject({ status: "idle", session: recovered });
 	});
 
 	it("preserves the legacy result shape when no output schema is selected", async () => {

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -39,6 +39,7 @@ function createMockSession(
 		getEnabledToolNames: () => ["read", "yield"],
 		getMountedXdevToolNames: () => [],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
+		setActiveToolPresentation: async (_toolNames: string[], _mountedToolNames: string[]) => {},
 		getToolByName: () => undefined,
 		refreshRpcHostTools: async (tools: AgentTool[]) => {
 			refreshedHostTools.push(tools.map(tool => tool.name));
@@ -258,6 +259,27 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.toolNames).toBeUndefined();
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
 		expect(persistedInits).toEqual([expect.objectContaining({ mountedTools: ["ida_execute_python"] })]);
+	});
+
+	it("preserves explicitly enabled hidden host tools and their mounted presentation", async () => {
+		const session = yieldEmittingSession();
+		const presentation = vi.spyOn(session, "setActiveToolPresentation");
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const hiddenTopLevel = { name: "hidden_top_level", hidden: true } as AgentTool;
+		const hiddenMounted = { name: "hidden_mounted", hidden: true } as AgentTool;
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "hidden-host-tools",
+			parentHostTools: [hiddenTopLevel, hiddenMounted],
+			parentMountedHostToolNames: [hiddenMounted.name],
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(presentation).toHaveBeenCalledWith(
+			["read", "yield", hiddenTopLevel.name, hiddenMounted.name],
+			[hiddenMounted.name],
+		);
 	});
 
 	it("preserves the legacy result shape when no output schema is selected", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -52,6 +52,7 @@ function createRevivedSession(
 	refreshedHostTools: string[][] = [],
 	mountedToolNames: string[][] = [],
 	registeredToolNames: string[] = [],
+	builtInToolNames: string[] = registeredToolNames,
 ): RevivedSessionHandle {
 	let observer: IrcWakeObserver | undefined;
 	const session = {
@@ -60,7 +61,8 @@ function createRevivedSession(
 			refreshedHostTools.push(tools.map(tool => tool.name));
 		},
 		getToolByName: (name: string) => (registeredToolNames.includes(name) ? ({ name } as AgentTool) : undefined),
-		hasRpcHostTool: () => false,
+		hasRpcHostTool: (name: string) => refreshedHostTools.some(names => names.includes(name)),
+		hasBuiltInTool: (name: string) => builtInToolNames.includes(name),
 		setActiveToolPresentation: async (names: string[], mountedNames: string[]) => {
 			activeToolNames.push(names);
 			mountedToolNames.push(mountedNames);
@@ -121,6 +123,7 @@ function createFactory(
 	mountedTools: AgentTool[] = [],
 	rpcHostTools: AgentTool[] = [],
 	registeredTools: AgentTool[] = mountedTools,
+	builtInToolNames = ["read", "bash", "browser"],
 ) {
 	const parentSession = {
 		sessionManager: {
@@ -130,7 +133,7 @@ function createFactory(
 		getMountedXdevToolNames: () => mountedTools.map(tool => tool.name),
 		getToolByName: (name: string) => registeredTools.find(tool => tool.name === name),
 		getRpcHostTools: () => rpcHostTools,
-		hasBuiltInTool: (name: string) => name === "read" || name === "bash" || name === "browser",
+		hasBuiltInTool: (name: string) => builtInToolNames.includes(name),
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");
 		},
@@ -207,7 +210,7 @@ describe("persisted subagent revival", () => {
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			capturedOptions = options;
 			return {
-				session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames).session,
+				session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames, ["browser"]).session,
 			} as CreateAgentSessionResult;
 		});
 
@@ -281,6 +284,61 @@ describe("persisted subagent revival", () => {
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
 		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
 		expect(mountedToolNames).toEqual([["ida_execute_python"]]);
+	});
+
+	it("rebuilds a mounted browser locally instead of inheriting a same-name parent custom tool", async () => {
+		const cwd = makeTempDir("@pi-local-browser-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, ["browser"]);
+		const parentCustomBrowser = { name: "browser" } as AgentTool;
+		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return {
+				session: createRevivedSession(activeToolNames, [], mountedToolNames, ["browser"]).session,
+			} as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, undefined, [], [], [parentCustomBrowser], ["read", "bash"])(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "browser"]);
+		expect(capturedOptions?.customTools).toBeUndefined();
+		expect(activeToolNames).toEqual([["read", "yield", "browser"]]);
+		expect(mountedToolNames).toEqual([["browser"]]);
+	});
+
+	it("does not restore a same-name custom as a mounted built-in", async () => {
+		const cwd = makeTempDir("@pi-local-custom-browser-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, ["browser"]);
+		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return {
+				session: createRevivedSession(activeToolNames, [], mountedToolNames, ["browser"], []).session,
+			} as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(
+			cwd,
+			undefined,
+			[],
+			[],
+			[{ name: "browser" } as AgentTool],
+			["read", "bash"],
+		)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "browser"]);
+		expect(activeToolNames).toEqual([["read", "yield"]]);
+		expect(mountedToolNames).toEqual([[]]);
 	});
 
 	it("disposes a failed cold revive and leaves its parked ref retryable", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -228,6 +228,36 @@ describe("persisted subagent revival", () => {
 		expect(mountedToolNames).toEqual([["ida_execute_python", "browser"]]);
 	});
 
+	it("does not cold-forward parent-bound mounted custom tools", async () => {
+		const cwd = makeTempDir("@pi-parent-bound-custom-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, [
+			"ida_execute_python",
+			"inline_parent_custom",
+		]);
+		const rpcHostTool = { name: "ida_execute_python" } as AgentTool;
+		const parentBoundCustomTool = { name: "inline_parent_custom" } as AgentTool;
+		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
+		const refreshedHostTools: string[][] = [];
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return {
+				session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames).session,
+			} as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, undefined, [rpcHostTool, parentBoundCustomTool], [rpcHostTool])(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "ida_execute_python", "inline_parent_custom"]);
+		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
+		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python", "inline_parent_custom"]]);
+		expect(mountedToolNames).toEqual([["ida_execute_python", "inline_parent_custom"]]);
+	});
+
 	it("keeps MCP disabled while restoring non-MCP mounted tools", async () => {
 		const cwd = makeTempDir("@pi-mcp-disabled-revive-");
 		const sessionFile = await createPersistedSession(

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -51,6 +51,7 @@ function createRevivedSession(
 	activeToolNames: string[][],
 	refreshedHostTools: string[][] = [],
 	mountedToolNames: string[][] = [],
+	registeredToolNames: string[] = [],
 ): RevivedSessionHandle {
 	let observer: IrcWakeObserver | undefined;
 	const session = {
@@ -58,7 +59,7 @@ function createRevivedSession(
 		refreshRpcHostTools: async (tools: AgentTool[]) => {
 			refreshedHostTools.push(tools.map(tool => tool.name));
 		},
-		getToolByName: () => undefined,
+		getToolByName: (name: string) => (registeredToolNames.includes(name) ? ({ name } as AgentTool) : undefined),
 		setActiveToolPresentation: async (names: string[], mountedNames: string[]) => {
 			activeToolNames.push(names);
 			mountedToolNames.push(mountedNames);
@@ -274,7 +275,8 @@ describe("persisted subagent revival", () => {
 		const mountedToolNames: string[][] = [];
 		const refreshedHostTools: string[][] = [];
 		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
-			session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames).session,
+			session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames, ["ida_execute_python"])
+				.session,
 		} as CreateAgentSessionResult);
 
 		const ref = createRef(sessionFile);
@@ -283,8 +285,8 @@ describe("persisted subagent revival", () => {
 		await reviver(ref);
 
 		expect(refreshedHostTools).toEqual([]);
-		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
-		expect(mountedToolNames).toEqual([["ida_execute_python"]]);
+		expect(activeToolNames).toEqual([["read", "yield"]]);
+		expect(mountedToolNames).toEqual([[]]);
 	});
 
 	it("restores the persisted custom model role before reopening the session", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -100,15 +100,21 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean, 
 	return sessionFile;
 }
 
-function createFactory(cwd: string, eventBus?: EventBus, hostTools: AgentTool[] = []) {
+function createFactory(
+	cwd: string,
+	eventBus?: EventBus,
+	mountedTools: AgentTool[] = [],
+	rpcHostTools: AgentTool[] = [],
+) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
 			getArtifactManager: () => undefined,
 		},
-		getMountedXdevToolNames: () => hostTools.map(tool => tool.name),
-		getToolByName: (name: string) => hostTools.find(tool => tool.name === name),
-		getRpcHostTools: () => [],
+		getMountedXdevToolNames: () => mountedTools.map(tool => tool.name),
+		getToolByName: (name: string) => mountedTools.find(tool => tool.name === name),
+		getRpcHostTools: () => rpcHostTools,
+		hasBuiltInTool: (name: string) => name === "read" || name === "bash",
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");
 		},
@@ -173,15 +179,19 @@ describe("persisted subagent revival", () => {
 		} as unknown as MCPManager;
 		MCPManager.setInstance(hostileMcp);
 		const hostTool = { name: "ida_execute_python" } as AgentTool;
+		const builtInTool = { name: "bash" } as AgentTool;
+		const activeToolNames: string[][] = [];
 		const refreshedHostTools: string[][] = [];
 		let capturedOptions: CreateAgentSessionOptions | undefined;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			capturedOptions = options;
-			return { session: createRevivedSession([], refreshedHostTools).session } as CreateAgentSessionResult;
+			return {
+				session: createRevivedSession(activeToolNames, refreshedHostTools).session,
+			} as CreateAgentSessionResult;
 		});
 
 		const ref = createRef(sessionFile);
-		const reviver = await createFactory(cwd, undefined, [hostTool])(ref);
+		const reviver = await createFactory(cwd, undefined, [hostTool, builtInTool], [hostTool])(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
@@ -190,6 +200,7 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
+		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
 	});
 
 	it("restores the persisted custom model role before reopening the session", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -148,6 +148,8 @@ function createFactory(
 afterEach(async () => {
 	vi.restoreAllMocks();
 	MCPManager.resetForTests();
+	AgentLifecycleManager.resetGlobalForTests();
+	AgentRegistry.resetGlobalForTests();
 	await Promise.all(tempDirs.splice(0).map(dir => dir.remove()));
 });
 
@@ -279,6 +281,45 @@ describe("persisted subagent revival", () => {
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
 		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
 		expect(mountedToolNames).toEqual([["ida_execute_python"]]);
+	});
+
+	it("disposes a failed cold revive and leaves its parked ref retryable", async () => {
+		const cwd = makeTempDir("@pi-revive-restoration-failure-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, ["ida_execute_python"]);
+		const hostTool = { name: "ida_execute_python" } as AgentTool;
+		const registry = AgentRegistry.global();
+		const ref = registry.register({
+			...createRef(sessionFile),
+			session: null,
+			status: "parked",
+		});
+		const failed = createRevivedSession([]).session;
+		const failedDispose = vi.fn(async () => {});
+		failed.refreshRpcHostTools = async () => {
+			throw new Error("host refresh failed");
+		};
+		failed.dispose = failedDispose;
+		const recovered = createRevivedSession([]).session;
+		let attempts = 0;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			const session = attempts++ === 0 ? failed : recovered;
+			if (!registry.attachSession(ref.id, session, ref.sessionFile, ref)) {
+				throw new Error("failed to attach revived session");
+			}
+			registry.setStatus(ref.id, "running", ref);
+			return { session } as CreateAgentSessionResult;
+		});
+		const factory = createFactory(cwd, undefined, [hostTool], [hostTool]);
+		const lifecycle = AgentLifecycleManager.global();
+		lifecycle.setPersistedSubagentReviverFactory(factory, 0);
+
+		await expect(lifecycle.ensureLive(ref.id)).rejects.toThrow("host refresh failed");
+
+		expect(failedDispose).toHaveBeenCalledTimes(1);
+		expect(registry.get(ref.id)).toMatchObject({ status: "parked", session: null, sessionFile });
+		expect(await lifecycle.ensureLive(ref.id)).toBe(recovered);
+		expect(attempts).toBe(2);
+		expect(registry.get(ref.id)).toMatchObject({ status: "idle", session: recovered });
 	});
 
 	it("keeps MCP disabled while restoring non-MCP mounted tools", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -47,7 +47,11 @@ interface RevivedSessionHandle {
 	observer: () => IrcWakeObserver | undefined;
 }
 
-function createRevivedSession(activeToolNames: string[][], refreshedHostTools: string[][] = []): RevivedSessionHandle {
+function createRevivedSession(
+	activeToolNames: string[][],
+	refreshedHostTools: string[][] = [],
+	mountedToolNames: string[][] = [],
+): RevivedSessionHandle {
 	let observer: IrcWakeObserver | undefined;
 	const session = {
 		getMountedXdevToolNames: () => [],
@@ -55,8 +59,9 @@ function createRevivedSession(activeToolNames: string[][], refreshedHostTools: s
 			refreshedHostTools.push(tools.map(tool => tool.name));
 		},
 		getToolByName: () => undefined,
-		setActiveToolsByName: async (names: string[]) => {
+		setActiveToolPresentation: async (names: string[], mountedNames: string[]) => {
 			activeToolNames.push(names);
+			mountedToolNames.push(mountedNames);
 		},
 		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
 		setIrcWakeTurnObserver: (next: IrcWakeObserver | undefined) => {
@@ -67,7 +72,13 @@ function createRevivedSession(activeToolNames: string[][], refreshedHostTools: s
 	return { session, observer: () => observer };
 }
 
-async function createPersistedSession(cwd: string, restrictToolNames?: boolean, modelRole?: string): Promise<string> {
+async function createPersistedSession(
+	cwd: string,
+	restrictToolNames?: boolean,
+	modelRole?: string,
+	mountedTools: string[] = [],
+	enableMCP?: boolean,
+): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
 	if (!sessionFile) throw new Error("Expected a persisted session file");
@@ -75,7 +86,9 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean, 
 		systemPrompt: "persisted prompt",
 		task: "persisted task",
 		tools: ["read", "yield"],
+		mountedTools,
 		restrictToolNames,
+		enableMCP,
 		modelRole,
 		resolvedModel: modelRole ? "anthropic/claude-sonnet-4-5" : undefined,
 	});
@@ -105,6 +118,7 @@ function createFactory(
 	eventBus?: EventBus,
 	mountedTools: AgentTool[] = [],
 	rpcHostTools: AgentTool[] = [],
+	registeredTools: AgentTool[] = mountedTools,
 ) {
 	const parentSession = {
 		sessionManager: {
@@ -112,9 +126,9 @@ function createFactory(
 			getArtifactManager: () => undefined,
 		},
 		getMountedXdevToolNames: () => mountedTools.map(tool => tool.name),
-		getToolByName: (name: string) => mountedTools.find(tool => tool.name === name),
+		getToolByName: (name: string) => registeredTools.find(tool => tool.name === name),
 		getRpcHostTools: () => rpcHostTools,
-		hasBuiltInTool: (name: string) => name === "read" || name === "bash",
+		hasBuiltInTool: (name: string) => name === "read" || name === "bash" || name === "browser",
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");
 		},
@@ -173,25 +187,33 @@ describe("persisted subagent revival", () => {
 
 	it("preserves normal revival capability wiring for contracts without the marker", async () => {
 		const cwd = makeTempDir("@pi-normal-revive-");
-		const sessionFile = await createPersistedSession(cwd);
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, ["ida_execute_python", "browser"]);
 		const hostileMcp = {
 			getTools: () => [{ name: "mcp__server_read", label: "server/read" }],
 		} as unknown as MCPManager;
 		MCPManager.setInstance(hostileMcp);
 		const hostTool = { name: "ida_execute_python" } as AgentTool;
+		const laterHostTool = { name: "later_host_tool" } as AgentTool;
 		const builtInTool = { name: "bash" } as AgentTool;
+		const mountedBuiltInTool = { name: "browser" } as AgentTool;
 		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
 		const refreshedHostTools: string[][] = [];
 		let capturedOptions: CreateAgentSessionOptions | undefined;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			capturedOptions = options;
 			return {
-				session: createRevivedSession(activeToolNames, refreshedHostTools).session,
+				session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames).session,
 			} as CreateAgentSessionResult;
 		});
 
 		const ref = createRef(sessionFile);
-		const reviver = await createFactory(cwd, undefined, [hostTool, builtInTool], [hostTool])(ref);
+		const reviver = await createFactory(
+			cwd,
+			undefined,
+			[hostTool, laterHostTool, builtInTool, mountedBuiltInTool],
+			[hostTool, laterHostTool],
+		)(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
@@ -199,8 +221,70 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
+		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "ida_execute_python", "browser"]);
+		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
+		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python", "browser"]]);
+		expect(mountedToolNames).toEqual([["ida_execute_python", "browser"]]);
+	});
+
+	it("keeps MCP disabled while restoring non-MCP mounted tools", async () => {
+		const cwd = makeTempDir("@pi-mcp-disabled-revive-");
+		const sessionFile = await createPersistedSession(
+			cwd,
+			undefined,
+			undefined,
+			["mcp__server_read", "ida_execute_python"],
+			false,
+		);
+		const mcpGetTools = vi.fn(() => [{ name: "mcp__server_read" }]);
+		MCPManager.setInstance({ getTools: mcpGetTools } as unknown as MCPManager);
+		const mcpTool = { name: "mcp__server_read" } as AgentTool;
+		const hostTool = { name: "ida_execute_python" } as AgentTool;
+		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
+		const refreshedHostTools: string[][] = [];
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return {
+				session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames).session,
+			} as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, undefined, [mcpTool, hostTool], [mcpTool, hostTool])(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.enableMCP).toBe(false);
+		expect(capturedOptions?.mcpManager).toBeUndefined();
+		expect(capturedOptions?.customTools).toBeUndefined();
+		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "ida_execute_python"]);
+		expect(mcpGetTools).not.toHaveBeenCalled();
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
 		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
+		expect(mountedToolNames).toEqual([["ida_execute_python"]]);
+	});
+
+	it("does not restore a mounted snapshot from a same-name unmounted parent tool", async () => {
+		const cwd = makeTempDir("@pi-mounted-source-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, ["ida_execute_python"]);
+		const sameNameTool = { name: "ida_execute_python" } as AgentTool;
+		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
+		const refreshedHostTools: string[][] = [];
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+			session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames).session,
+		} as CreateAgentSessionResult);
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, undefined, [], [], [sameNameTool])(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(refreshedHostTools).toEqual([]);
+		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
+		expect(mountedToolNames).toEqual([["ida_execute_python"]]);
 	});
 
 	it("restores the persisted custom model role before reopening the session", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -60,6 +60,7 @@ function createRevivedSession(
 			refreshedHostTools.push(tools.map(tool => tool.name));
 		},
 		getToolByName: (name: string) => (registeredToolNames.includes(name) ? ({ name } as AgentTool) : undefined),
+		hasRpcHostTool: () => false,
 		setActiveToolPresentation: async (names: string[], mountedNames: string[]) => {
 			activeToolNames.push(names);
 			mountedToolNames.push(mountedNames);
@@ -228,7 +229,29 @@ describe("persisted subagent revival", () => {
 		expect(mountedToolNames).toEqual([["ida_execute_python", "browser"]]);
 	});
 
-	it("does not cold-forward parent-bound mounted custom tools", async () => {
+	it("drops a same-name local tool instead of activating it as a parent RPC host tool", async () => {
+		const cwd = makeTempDir("@pi-local-host-collision-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, ["ida_execute_python"]);
+		const parentHostTool = { name: "ida_execute_python" } as AgentTool;
+		const activeToolNames: string[][] = [];
+		const mountedToolNames: string[][] = [];
+		const refreshedHostTools: string[][] = [];
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+			session: createRevivedSession(activeToolNames, refreshedHostTools, mountedToolNames, [parentHostTool.name])
+				.session,
+		} as CreateAgentSessionResult);
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, undefined, [parentHostTool], [parentHostTool])(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(refreshedHostTools).toEqual([]);
+		expect(activeToolNames).toEqual([["read", "yield"]]);
+		expect(mountedToolNames).toEqual([[]]);
+	});
+
+	it("drops parent-bound mounted custom tools from cold revival", async () => {
 		const cwd = makeTempDir("@pi-parent-bound-custom-revive-");
 		const sessionFile = await createPersistedSession(cwd, undefined, undefined, [
 			"ida_execute_python",
@@ -252,10 +275,10 @@ describe("persisted subagent revival", () => {
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
-		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "ida_execute_python", "inline_parent_custom"]);
+		expect(capturedOptions?.toolNames).toEqual(["read", "yield", "ida_execute_python"]);
 		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
-		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python", "inline_parent_custom"]]);
-		expect(mountedToolNames).toEqual([["ida_execute_python", "inline_parent_custom"]]);
+		expect(activeToolNames).toEqual([["read", "yield", "ida_execute_python"]]);
+		expect(mountedToolNames).toEqual([["ida_execute_python"]]);
 	});
 
 	it("keeps MCP disabled while restoring non-MCP mounted tools", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
@@ -46,10 +47,14 @@ interface RevivedSessionHandle {
 	observer: () => IrcWakeObserver | undefined;
 }
 
-function createRevivedSession(activeToolNames: string[][]): RevivedSessionHandle {
+function createRevivedSession(activeToolNames: string[][], refreshedHostTools: string[][] = []): RevivedSessionHandle {
 	let observer: IrcWakeObserver | undefined;
 	const session = {
 		getMountedXdevToolNames: () => [],
+		refreshRpcHostTools: async (tools: AgentTool[]) => {
+			refreshedHostTools.push(tools.map(tool => tool.name));
+		},
+		getToolByName: () => undefined,
 		setActiveToolsByName: async (names: string[]) => {
 			activeToolNames.push(names);
 		},
@@ -95,12 +100,15 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean, 
 	return sessionFile;
 }
 
-function createFactory(cwd: string, eventBus?: EventBus) {
+function createFactory(cwd: string, eventBus?: EventBus, hostTools: AgentTool[] = []) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
 			getArtifactManager: () => undefined,
 		},
+		getMountedXdevToolNames: () => hostTools.map(tool => tool.name),
+		getToolByName: (name: string) => hostTools.find(tool => tool.name === name),
+		getRpcHostTools: () => [],
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");
 		},
@@ -164,14 +172,16 @@ describe("persisted subagent revival", () => {
 			getTools: () => [{ name: "mcp__server_read", label: "server/read" }],
 		} as unknown as MCPManager;
 		MCPManager.setInstance(hostileMcp);
+		const hostTool = { name: "ida_execute_python" } as AgentTool;
+		const refreshedHostTools: string[][] = [];
 		let capturedOptions: CreateAgentSessionOptions | undefined;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			capturedOptions = options;
-			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+			return { session: createRevivedSession([], refreshedHostTools).session } as CreateAgentSessionResult;
 		});
 
 		const ref = createRef(sessionFile);
-		const reviver = await createFactory(cwd)(ref);
+		const reviver = await createFactory(cwd, undefined, [hostTool])(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
@@ -179,6 +189,7 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
+		expect(refreshedHostTools).toEqual([["ida_execute_python"]]);
 	});
 
 	it("restores the persisted custom model role before reopening the session", async () => {

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -437,7 +437,15 @@ describe("structured subagent primitive", () => {
 		const nonPlanSession = session();
 		Object.assign(nonPlanSession, { mcpManager, extensionPaths, customToolPaths });
 		const mcpDisabledSession = session();
-		mcpDisabledSession.enableMCP = false;
+		const disabledMcpTool = { name: "mcp__server_read" } as AgentTool;
+		const enabledHostTool = { name: "ida_execute_python" } as AgentTool;
+		Object.assign(mcpDisabledSession, {
+			enableMCP: false,
+			getRpcHostTools: () => [disabledMcpTool, enabledHostTool],
+			getMountedXdevToolNames: () => [disabledMcpTool.name, enabledHostTool.name],
+			hasBuiltInTool: () => false,
+			getToolByName: (name: string) => [disabledMcpTool, enabledHostTool].find(tool => tool.name === name),
+		});
 		const restrictedSession = session();
 		const getApiKey = async () => "exact-account-key";
 		Object.assign(restrictedSession, {
@@ -476,6 +484,7 @@ describe("structured subagent primitive", () => {
 		expect(options[1]?.restrictToolNames).toBe(false);
 		expect(options[2]).toMatchObject({ enableMCP: false });
 		expect(options[2]?.mcpManager).toBeUndefined();
+		expect(options[2]?.parentHostTools).toEqual([enabledHostTool]);
 		expect(options[3]).toMatchObject({
 			enableMCP: false,
 			restrictToolNames: true,

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	artifactsDirsFromRegistry,
@@ -400,6 +401,28 @@ describe("structured subagent primitive", () => {
 		expect(ids.sort()).toEqual(["Worker", "Worker-2"]);
 		expect(sharedSession.agentOutputManager).toBeDefined();
 		for (const run of settled) await fs.rm(run.artifactsDir, { recursive: true, force: true });
+	});
+
+	it("forwards top-level RPC host tools once", async () => {
+		mockDiscovery();
+		const essentialTool = { name: "essential_host" } as AgentTool;
+		const mountedTool = { name: "mounted_host" } as AgentTool;
+		const parentSession = session();
+		Object.assign(parentSession, {
+			getRpcHostTools: () => [essentialTool, mountedTool],
+			getMountedXdevToolNames: () => [mountedTool.name],
+			hasBuiltInTool: () => false,
+			getToolByName: (name: string) => (name === mountedTool.name ? mountedTool : undefined),
+		});
+		let parentHostTools: AgentTool[] | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			parentHostTools = options.parentHostTools;
+			return result();
+		});
+
+		await runStructuredSubagent(request({ session: parentSession }));
+
+		expect(parentHostTools).toEqual([essentialTool, mountedTool]);
 	});
 
 	it("suppresses plan capability sources while preserving non-plan propagation", async () => {

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -415,14 +415,40 @@ describe("structured subagent primitive", () => {
 			getToolByName: (name: string) => (name === mountedTool.name ? mountedTool : undefined),
 		});
 		let parentHostTools: AgentTool[] | undefined;
+		let parentMountedHostToolNames: string[] | undefined;
 		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
 			parentHostTools = options.parentHostTools;
+			parentMountedHostToolNames = options.parentMountedHostToolNames;
 			return result();
 		});
 
 		await runStructuredSubagent(request({ session: parentSession }));
 
 		expect(parentHostTools).toEqual([essentialTool, mountedTool]);
+		expect(parentMountedHostToolNames).toEqual([mountedTool.name]);
+	});
+
+	it("does not forward parent-bound mounted custom tools", async () => {
+		mockDiscovery();
+		const rpcHostTool = { name: "ida_execute_python" } as AgentTool;
+		const parentBoundCustomTool = { name: "inline_parent_custom" } as AgentTool;
+		const parentSession = session();
+		Object.assign(parentSession, {
+			getRpcHostTools: () => [rpcHostTool],
+			getMountedXdevToolNames: () => [rpcHostTool.name, parentBoundCustomTool.name],
+			hasBuiltInTool: () => false,
+			getToolByName: (name: string) => (name === parentBoundCustomTool.name ? parentBoundCustomTool : undefined),
+		});
+		let options: executorModule.ExecutorOptions | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async executorOptions => {
+			options = executorOptions;
+			return result();
+		});
+
+		await runStructuredSubagent(request({ session: parentSession }));
+
+		expect(options?.parentHostTools).toEqual([rpcHostTool]);
+		expect(options?.parentMountedHostToolNames).toEqual([rpcHostTool.name]);
 	});
 
 	it("suppresses plan capability sources while preserving non-plan propagation", async () => {

--- a/packages/coding-agent/test/vibe/spawn-model-role.test.ts
+++ b/packages/coding-agent/test/vibe/spawn-model-role.test.ts
@@ -9,6 +9,7 @@
  * chain and vibe children silently retry on the `default` role's chain.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
@@ -18,7 +19,17 @@ import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { type VibeCli, VibeSessionRegistry } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
 
-function makeParentSession(settings: Settings): ToolSession {
+type ParentOptions = {
+	hostTools?: AgentTool[];
+	mountedNames?: string[];
+	enableMCP?: boolean;
+	restrictToolNames?: boolean;
+	mcpManager?: unknown;
+	extensionPaths?: string[];
+	customToolPaths?: unknown[];
+};
+
+function makeParentSession(settings: Settings, options: ParentOptions = {}): ToolSession {
 	return {
 		cwd: "/tmp",
 		settings,
@@ -27,13 +38,24 @@ function makeParentSession(settings: Settings): ToolSession {
 		// No session file: spawn skips lifecycle persistence and stays in-memory.
 		getSessionFile: () => null,
 		getArtifactsDir: () => null,
+		getRpcHostTools: () => options.hostTools ?? [],
+		getMountedXdevToolNames: () => options.mountedNames ?? [],
+		enableMCP: options.enableMCP,
+		restrictToolNames: options.restrictToolNames,
+		mcpManager: options.mcpManager,
+		extensionPaths: options.extensionPaths,
+		customToolPaths: options.customToolPaths,
 		taskDepth: 0,
 		enableLsp: false,
 	} as unknown as ToolSession;
 }
 
 /** Spawn one worker and capture the ExecutorOptions the vibe path hands the executor. */
-async function spawnAndCaptureOptions(cli: VibeCli, settings: Settings): Promise<ExecutorOptions> {
+async function spawnAndCaptureOptions(
+	cli: VibeCli,
+	settings: Settings,
+	parentOptions: ParentOptions = {},
+): Promise<ExecutorOptions> {
 	const captured = Promise.withResolvers<ExecutorOptions>();
 	vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
 		captured.resolve(options);
@@ -54,7 +76,7 @@ async function spawnAndCaptureOptions(cli: VibeCli, settings: Settings): Promise
 	});
 
 	const registry = VibeSessionRegistry.global();
-	await registry.spawn(makeParentSession(settings), { cli, prompt: "work" });
+	await registry.spawn(makeParentSession(settings, parentOptions), { cli, prompt: "work" });
 	return captured.promise;
 }
 
@@ -103,5 +125,60 @@ describe("vibe worker spawn model role", () => {
 
 		expect(options.modelOverride).toEqual(["openai-codex/sol"]);
 		expect(options.modelRole).toBeUndefined();
+	});
+
+	it("forwards parent host tools with their mounted presentation", async () => {
+		let idaCalls = 0;
+		const ida = {
+			name: "ida_execute_python",
+			execute: async () => {
+				idaCalls++;
+				return { content: [{ type: "text", text: "ok" }] };
+			},
+		} as unknown as AgentTool;
+		const browser = { name: "browser", execute: async () => ({ content: [] }) } as unknown as AgentTool;
+
+		const options = await spawnAndCaptureOptions("good", Settings.isolated(), {
+			hostTools: [ida, browser],
+			mountedNames: [ida.name],
+		});
+
+		expect(options.parentHostTools).toEqual([ida, browser]);
+		expect(options.parentMountedHostToolNames).toEqual([ida.name]);
+		await options.parentHostTools?.[0]?.execute("call", {}, undefined, () => {});
+		expect(idaCalls).toBe(1);
+	});
+
+	it("does not forward MCP host tools when the parent disables MCP", async () => {
+		const options = await spawnAndCaptureOptions("good", Settings.isolated(), {
+			enableMCP: false,
+			hostTools: [{ name: "mcp__poe_native_query" } as AgentTool],
+			mountedNames: ["mcp__poe_native_query"],
+			mcpManager: {} as unknown,
+		});
+
+		expect(options.enableMCP).toBe(false);
+		expect(options.mcpManager).toBeUndefined();
+		expect(options.parentHostTools).toEqual([]);
+		expect(options.parentMountedHostToolNames).toEqual([]);
+	});
+
+	it("does not forward any host capability to a restricted worker", async () => {
+		const options = await spawnAndCaptureOptions("good", Settings.isolated(), {
+			restrictToolNames: true,
+			hostTools: [{ name: "ida_execute_python" } as AgentTool, { name: "mcp__poe_native_query" } as AgentTool],
+			mountedNames: ["ida_execute_python", "mcp__poe_native_query"],
+			mcpManager: {} as unknown,
+			extensionPaths: ["/parent/extensions.ts"],
+			customToolPaths: [{ path: "/parent/tool.ts" }],
+		});
+
+		expect(options.restrictToolNames).toBe(true);
+		expect(options.enableMCP).toBe(false);
+		expect(options.mcpManager).toBeUndefined();
+		expect(options.parentHostTools).toEqual([]);
+		expect(options.parentMountedHostToolNames).toEqual([]);
+		expect(options.preloadedExtensionPaths).toEqual([]);
+		expect(options.preloadedCustomToolPaths).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What
Forward mounted dynamic `xd://` host tools into fresh, live-revived, and cold-revived subagent sessions. Host tools are registered after normal child-session creation through `refreshRpcHostTools()`, preserving built-in ownership and avoiding same-name collisions.

## Why
Dynamic host tools available in a parent session were absent from child tool inventories. Passing their names through the initial `toolNames` list also caused incorrect ownership and collisions with existing built-ins.

## Testing
- `bun test test/task/executor-pass-through.test.ts test/task/persisted-revive.test.ts` — 18 passed, 0 failed
- `bun run check:types` — passed
- End-to-end smoke test after rebuilding the CLI: a fresh subagent directly invoked an inherited host tool successfully
- Full `bun check`: TypeScript/Biome passed; Rust Clippy remains blocked by eight pre-existing `pi-worker` warnings promoted to errors