### PR TITLE
fix(natives): stop detached internal shell jobs

### DIFF
--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -101,6 +101,14 @@ pub(crate) struct Host {
 	stdin_is_search_input: bool,
 }
 
+struct CancelOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+	fn drop(&mut self) {
+		self.0.store(true, Ordering::Relaxed);
+	}
+}
+
 impl Host {
 	/// The name the utility was invoked as. Differs from [`Utility::NAME`] when
 	/// one implementation backs several builtins (`grep` and `rg`).
@@ -578,6 +586,7 @@ async fn run_utility<U: Utility, SE: ShellExtensions>(
 	let mut host = build_host(&context, U::NAME)?;
 	let cancel = context.cancel_token();
 	let cancel_flag = host.cancel_flag();
+	let _cancel_on_drop = CancelOnDrop(Arc::clone(&cancel_flag));
 	drop(context);
 
 	let mut handle = tokio::task::spawn_blocking(move || {

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -4458,7 +4458,13 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 		)
 		.await
 		.expect("one-shot shell execution");
-		time::sleep(Duration::from_millis(100)).await;
+		// `execute_shell` returns after its short post-exit idle drain (~250ms),
+		// while the background job cannot write the marker until its 1s sleep
+		// elapses. Wait well past that delay so a job that outlived the dropped
+		// session has demonstrably had its chance to run — the pre-fix leak fires
+		// at ~1s and is caught here; the fixed path aborts the task on drop and the
+		// marker never appears.
+		time::sleep(Duration::from_millis(2000)).await;
 
 		assert!(
 			!marker.path().exists(),

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -38,6 +38,12 @@ struct ShellSessionCore {
 	shell: BrushShell,
 }
 
+impl Drop for ShellSessionCore {
+	fn drop(&mut self) {
+		terminate_internal_background_jobs(&mut self.shell);
+	}
+}
+
 #[derive(Clone, Default)]
 struct ShellAbortState(Arc<TokioMutex<Option<AbortToken>>>);
 
@@ -1408,10 +1414,16 @@ async fn terminate_run(registry: &process::SpawnRegistry) {
 		}
 	}
 }
-fn terminate_background_jobs(shell: &mut BrushShell) {
-	let mut targets = process::TerminationTargets::new();
+fn terminate_internal_background_jobs(shell: &mut BrushShell) {
 	for job in &mut shell.jobs_mut().jobs {
 		job.abort_internal_tasks();
+	}
+}
+
+fn terminate_background_jobs(shell: &mut BrushShell) {
+	let mut targets = process::TerminationTargets::new();
+	terminate_internal_background_jobs(shell);
+	for job in &shell.jobs().jobs {
 		if let Some(pgid) = job.process_group_id() {
 			targets.add_pgid(pgid);
 		}
@@ -4430,6 +4442,28 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 			max_capture_bytes,
 			..Default::default()
 		}
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn one_shot_completion_aborts_internal_background_jobs() {
+		let marker = tempfile::NamedTempFile::new().expect("marker file");
+		let marker_path = marker.path().to_string_lossy();
+		std::fs::remove_file(marker.path()).expect("remove initial marker");
+		let command = format!("{{ sleep 1; echo leaked > {}; }} &", quote_arg(&marker_path));
+
+		execute_shell(
+			ShellExecuteOptions { command, ..Default::default() },
+			None,
+			CancelToken::default(),
+		)
+		.await
+		.expect("one-shot shell execution");
+		time::sleep(Duration::from_millis(100)).await;
+
+		assert!(
+			!marker.path().exists(),
+			"an internal background job outlived its one-shot shell session"
+		);
 	}
 
 	/// `live_background_job_count` reports 0 when the session has no live

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed shell-internal background jobs such as `yes >/dev/null &` surviving a one-shot shell session and consuming CPU indefinitely after the command returned ([#8341](https://github.com/can1357/oh-my-pi/issues/8341)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Changed


### PR DESCRIPTION
## Repro
Running `bun -e 'import { Shell } from "./packages/natives/native/index.js"; const shell=new Shell(); console.log(await shell.run({command:"yes >/dev/null &"})); const a=process.cpuUsage(); await Bun.sleep(1000); console.log(process.cpuUsage(a));'` returns success while the following idle second consumes 1.027 seconds of CPU.

## Cause
`crates/vendor/brush-core/src/interp.rs` represents background builtins as Tokio `Internal` job tasks. Dropping `ShellSessionCore` dropped their `JoinHandle`s without aborting them, and aborting an async utility task detached its `spawn_blocking` body because `crates/pi-builtins/src/host.rs::run_utility` only raised its host cancellation flag when the shell token fired normally.

## Fix
- Abort all internal job tasks when their owning `ShellSessionCore` is dropped, while preserving external background-process retention.
- Raise a blocking utility's host cancellation flag when its async adapter is dropped, allowing infinite loops such as `yes` to unwind.
- Add a regression proving a one-shot shell's internal background job cannot perform work after the shell returns, plus an Unreleased changelog entry.

## Verification
`cargo test -p pi-shell one_shot_completion_aborts_internal_background_jobs`, `cargo test -p pi-builtins cancellation_stops_loop_promptly`, and `cargo fmt --check` pass. `cargo test -p pi-shell --lib` passed 863 tests once; a later rerun hit the existing timing-sensitive `kill_builtin_signals_every_process_in_a_jobspec_pipeline`, whose focused rerun passed. Local N-API smoke rebuild was unavailable because this workstation lacks Bazel and CMake; the Rust fixed-path regression exercises the same implementation. Pre-publish `bun check` passed through `gh_push_branch`. Fixes #8341