### PR TITLE
feat(extensions): Extension `deliverAs: "aside"` - mid-turn non-interrupting inject

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -183,14 +183,55 @@ Also exposed:
 
 ### Message delivery semantics
 
-`pi.sendMessage(message, options)` supports:
+`pi.sendMessage(message, options)` delivers custom messages (`customType`, `content`, optional `display`). Choose `deliverAs` based on **when** the message should land and whether it may interrupt in-flight work.
 
-- `deliverAs: "steer"` (default) — interrupts current run
-- `deliverAs: "followUp"` — queued to run after current run
-- `deliverAs: "nextTurn"` — stored and injected on the next user prompt
-- `triggerTurn: true` — starts a turn when idle (also honored with `deliverAs: "nextTurn"`: idle prompts immediately; while streaming the queued message schedules an internal continuation)
+Omitting `deliverAs` while the agent is streaming is equivalent to `"steer"`. While idle, a message without `triggerTurn` appends to context and persists without starting a turn.
 
-`pi.sendUserMessage(content, { deliverAs })` always goes through prompt flow. Omit `deliverAs` to start a normal prompt when idle; while streaming, omitted `deliverAs` queues the message as a steer. Set `deliverAs: "followUp"` to wait until the current run finishes.
+#### `deliverAs` modes
+
+| Mode | While streaming | Idle (no `triggerTurn`) | Idle + `triggerTurn: true` | Interrupts tools? | Wakes on strand? |
+| --- | --- | --- | --- | --- | --- |
+| `steer` (default mid-stream) | Steer queue (abortive) | Queue / start per existing rules | — | **Yes** | N/A (steer path) |
+| `followUp` | End-of-**run** queue | Queue | — | No | N/A |
+| `nextTurn` | Hidden until next **user prompt** | Append / optional trigger | Starts turn | No | N/A |
+| `aside` | Next **agent step** boundary | Append + persist | Starts turn | No | **No** |
+
+- **`steer`** — Aborts the current stream and in-flight tools, then injects the message. Use when the user (or an extension) must redirect the agent immediately.
+- **`followUp`** — Waits until the current **run** finishes (no more tool calls in this turn). The message is processed as a continuation after the run ends. Does not fold in mid-turn.
+- **`nextTurn`** — Held until the **user** sends the next prompt. Not the same as the next model step or tool round — it survives across idle gaps and is injected only when a new user message arrives (unless `triggerTurn` starts a turn while idle).
+- **`aside`** — Folds hidden context at the next **agent step boundary** (after tool results, before the next model call) without canceling tools or aborting the stream. While streaming, `triggerTurn` is ignored — the message is queued for step-boundary delivery. While idle without `triggerTurn`, the message appends and persists like other passive context; in plan mode this is the same — append and persist with no autonomous wake. **Does not wake** when stranded (queued near end-of-turn but missed the last step-boundary poll): content is flushed into context only, with no surprise model call. Use `triggerTurn: true` while idle, or `followUp` / `steer`, when a reaction is required.
+
+Set `display: false` on aside payloads when the content is machine/context-only (background jobs, peer notifications, diagnostics) and should not appear as a visible chat card.
+
+#### Streaming vs idle
+
+| State | `steer` | `followUp` | `nextTurn` | `aside` |
+| --- | --- | --- | --- | --- |
+| **Streaming** | Interrupt + steer queue | End-of-run queue | Hidden next-turn queue | Step-boundary aside queue; `triggerTurn` ignored |
+| **Idle** | Append or queue per steer rules | Queue for next continuation | Append; optional `triggerTurn` starts turn | Append + persist; optional `triggerTurn` starts turn |
+| **Stranded** (turn ended before drain) | Per steer/followUp rules | Per followUp rules | Persists for next user prompt | Context-only flush; **no wake** |
+| **Compacting / disconnected** | Queue | Queue | Queue | Queue; flush after reconnect |
+
+Session switch, `newSession`, and `fork` drop pending aside queues — they are not carried into the new session.
+
+#### `triggerTurn`
+
+`triggerTurn: true` starts a turn when idle. It is also honored with `deliverAs: "nextTurn"`: idle prompts immediately; while streaming, the queued message schedules an internal continuation.
+
+`triggerTurn` is **ignored** for `deliverAs: "aside"` while streaming — the aside is always queued for the next step boundary.
+
+#### Anti-patterns
+
+- **`followUp` is not mid-turn inject.** It waits until the entire run completes (no further tool calls). For step-boundary context while tools are still running, use `aside`.
+- **`nextTurn` is not the next model step.** It is held until the **user** sends the next prompt. For context that should fold before the next model call within the current turn, use `aside`.
+- **Do not use `followUp` for background notifications during a busy turn** when you only need the agent to see the note on its next step — that piles up until end-of-run. Use `aside` instead.
+- **Do not expect `aside` to wake a stranded session.** If the agent has gone idle with a queued aside that missed the last poll, the content is persisted but no model call is started. Use `triggerTurn: true` while idle, or `followUp` / `steer`, when a response is required.
+
+See `packages/coding-agent/examples/extensions/aside-delivery.ts` for a minimal busy-path aside pattern.
+
+#### `sendUserMessage`
+
+`pi.sendUserMessage(content, { deliverAs })` always goes through prompt flow. Supported values are `"steer"` and `"followUp"` only. Omit `deliverAs` to start a normal prompt when idle; while streaming, omitted `deliverAs` queues the message as a steer. Set `deliverAs: "followUp"` to wait until the current run finishes. For custom mid-turn aside injection, use `pi.sendMessage` with `deliverAs: "aside"`.
 
 ## 2) Handler context (`ExtensionContext`)
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed Codex remote compaction requests failing for region-pinned enterprise ChatGPT workspaces when requests egress from a different region.
 ### Added
 
 - Exported `resolveAsides` for evaluating aside thunks at injection boundaries.
 
 ### Fixed
 
+- Fixed Codex remote compaction requests failing for region-pinned enterprise ChatGPT workspaces when requests egress from a different region.
 - Fixed `continue()` sending a queued follow-up or steer without pending asides, so stranded asides arrived one model call later than the in-loop yield drain.
 - Fixed `continue()` omitting pending asides on `toolResult` tails, so a queued follow-up or steer after a terminal tool result still sent the aside one model call late.
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -48,6 +48,13 @@
 ### Fixed
 
 - Fixed Codex-compatible V2 remote compaction with an explicit `v2Endpoint` by sending the required feature-negotiation header ([#8524](https://github.com/can1357/oh-my-pi/issues/8524)).
+### Added
+
+- Exported `resolveAsides` for evaluating aside thunks at injection boundaries.
+
+### Fixed
+
+- Fixed `continue()` sending a queued follow-up or steer without pending asides, so stranded asides arrived one model call later than the in-loop yield drain.
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Fixed
 
 - Fixed Codex remote compaction requests failing for region-pinned enterprise ChatGPT workspaces when requests egress from a different region.
+### Added
+
+- Exported `resolveAsides` for evaluating aside thunks at injection boundaries.
+
+### Fixed
+
+- Fixed `continue()` sending a queued follow-up or steer without pending asides, so stranded asides arrived one model call later than the in-loop yield drain.
 
 ## [17.4.0] - 2026-08-20
 
@@ -48,13 +55,6 @@
 ### Fixed
 
 - Fixed Codex-compatible V2 remote compaction with an explicit `v2Endpoint` by sending the required feature-negotiation header ([#8524](https://github.com/can1357/oh-my-pi/issues/8524)).
-### Added
-
-- Exported `resolveAsides` for evaluating aside thunks at injection boundaries.
-
-### Fixed
-
-- Fixed `continue()` sending a queued follow-up or steer without pending asides, so stranded asides arrived one model call later than the in-loop yield drain.
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Fixed `continue()` sending a queued follow-up or steer without pending asides, so stranded asides arrived one model call later than the in-loop yield drain.
+- Fixed `continue()` omitting pending asides on `toolResult` tails, so a queued follow-up or steer after a terminal tool result still sent the aside one model call late.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -963,7 +963,7 @@ function emitInputMessages(stream: EventStream<AgentEvent, AgentMessage[]>, mess
  * up-to-the-injection state — e.g. dropping late diagnostics a newer edit
  * superseded. Kept sync so it can never stall the loop.
  */
-function resolveAsides(entries: AsideMessage[] | undefined): AgentMessage[] {
+export function resolveAsides(entries: AsideMessage[] | undefined): AgentMessage[] {
 	if (!entries || entries.length === 0) return [];
 	const out: AgentMessage[] = [];
 	try {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -33,6 +33,7 @@ import {
 	createSyntheticToolResultMessage,
 	normalizeMessagesForProvider,
 	normalizeTools,
+	resolveAsides,
 	resolveOwnedDialectFromEnv,
 } from "./agent-loop";
 import type { AppendOnlyContextManager } from "./append-only-context";
@@ -1212,6 +1213,39 @@ export class Agent {
 		return signals.length === 1 ? signals[0] : AbortSignal.any(signals);
 	}
 
+	/**
+	 * After a successful steer/follow-up dequeue, fold pending asides into the
+	 * same continuation so settle resume matches in-loop yield drain. Follow-up
+	 * mode is one-at-a-time by default, so asides must not go on that queue.
+	 * Re-enqueue the dequeued batch if aside resolution throws.
+	 */
+	async #runQueuedContinuation(
+		queued: AgentMessage[],
+		kind: "steering" | "followUp",
+		options: (AgentPromptOptions & { skipInitialSteeringPoll?: boolean }) | undefined,
+		runSignal: AbortSignal | undefined,
+		dequeueSignal: AbortSignal | undefined,
+	): Promise<void> {
+		let initial = queued;
+		if (!dequeueSignal?.aborted && !runSignal?.aborted) {
+			try {
+				const asides = resolveAsides(await this.#asideMessageProvider?.());
+				if (asides.length > 0) {
+					// Match yield drain: steering, then asides, then follow-up.
+					initial = kind === "steering" ? [...queued, ...asides] : [...asides, ...queued];
+				}
+			} catch (error) {
+				if (kind === "steering") {
+					this.#steeringQueue = [...queued, ...this.#steeringQueue];
+				} else {
+					this.#followUpQueue = [...queued, ...this.#followUpQueue];
+				}
+				throw error;
+			}
+		}
+		await this.#runLoop(initial, options, runSignal, true);
+	}
+
 	async continue(signal?: AbortSignal) {
 		if (this.#state.isStreaming) {
 			throw new AgentBusyError();
@@ -1238,12 +1272,18 @@ export class Agent {
 				// allocation loop until OOM (issue #6344).
 				const queuedSteering = await this.#dequeueSteeringMessagesAfterHooks(dequeueSignal);
 				if (queuedSteering.length > 0) {
-					await this.#runLoop(queuedSteering, { skipInitialSteeringPoll: true }, signal, true);
+					await this.#runQueuedContinuation(
+						queuedSteering,
+						"steering",
+						{ skipInitialSteeringPoll: true },
+						signal,
+						dequeueSignal,
+					);
 					return;
 				}
 				const queuedFollowUp = await this.#dequeueFollowUpMessagesAfterHooks(dequeueSignal);
 				if (queuedFollowUp.length > 0) {
-					await this.#runLoop(queuedFollowUp, undefined, signal, true);
+					await this.#runQueuedContinuation(queuedFollowUp, "followUp", undefined, signal, dequeueSignal);
 					return;
 				}
 				throw new Error("No messages to continue from");
@@ -1251,13 +1291,19 @@ export class Agent {
 			if (messages[messages.length - 1].role === "assistant") {
 				const queuedSteering = await this.#dequeueSteeringMessagesAfterHooks(dequeueSignal);
 				if (queuedSteering.length > 0) {
-					await this.#runLoop(queuedSteering, { skipInitialSteeringPoll: true }, signal, true);
+					await this.#runQueuedContinuation(
+						queuedSteering,
+						"steering",
+						{ skipInitialSteeringPoll: true },
+						signal,
+						dequeueSignal,
+					);
 					return;
 				}
 
 				const queuedFollowUp = await this.#dequeueFollowUpMessagesAfterHooks(dequeueSignal);
 				if (queuedFollowUp.length > 0) {
-					await this.#runLoop(queuedFollowUp, undefined, signal, true);
+					await this.#runQueuedContinuation(queuedFollowUp, "followUp", undefined, signal, dequeueSignal);
 					return;
 				}
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1263,13 +1263,12 @@ export class Agent {
 		try {
 			const dequeueSignal = this.#continuationDequeueSignal(signal);
 			const messages = this.#state.messages;
-			if (messages.length === 0) {
-				// An empty transcript has nothing to resume, but a queued steer/follow-up
-				// must still be delivered as the opening turn — mirroring the assistant-tail
-				// branch below. Throwing here leaves the message undeliverable, and idle-drain
-				// callers (AgentSession#scheduleQueuedMessageDrain) re-arm continue() on every
-				// microtask because hasQueuedMessages() never clears, spinning an unbounded
-				// allocation loop until OOM (issue #6344).
+			const lastRole = messages.at(-1)?.role;
+			// Empty, assistant, and toolResult tails can resume from a queued
+			// steer/follow-up. Prefix pending asides onto that continuation so
+			// skip-flush asides land in the first provider request. Bare
+			// toolResult (no queue) still falls through to #runLoop(undefined).
+			if (messages.length === 0 || lastRole === "assistant" || lastRole === "toolResult") {
 				const queuedSteering = await this.#dequeueSteeringMessagesAfterHooks(dequeueSignal);
 				if (queuedSteering.length > 0) {
 					await this.#runQueuedContinuation(
@@ -1286,28 +1285,16 @@ export class Agent {
 					await this.#runQueuedContinuation(queuedFollowUp, "followUp", undefined, signal, dequeueSignal);
 					return;
 				}
-				throw new Error("No messages to continue from");
-			}
-			if (messages[messages.length - 1].role === "assistant") {
-				const queuedSteering = await this.#dequeueSteeringMessagesAfterHooks(dequeueSignal);
-				if (queuedSteering.length > 0) {
-					await this.#runQueuedContinuation(
-						queuedSteering,
-						"steering",
-						{ skipInitialSteeringPoll: true },
-						signal,
-						dequeueSignal,
-					);
-					return;
+				if (messages.length === 0) {
+					// Throwing here leaves the message undeliverable, and idle-drain
+					// callers (AgentSession#scheduleQueuedMessageDrain) re-arm continue()
+					// on every microtask because hasQueuedMessages() never clears,
+					// spinning an unbounded allocation loop until OOM (issue #6344).
+					throw new Error("No messages to continue from");
 				}
-
-				const queuedFollowUp = await this.#dequeueFollowUpMessagesAfterHooks(dequeueSignal);
-				if (queuedFollowUp.length > 0) {
-					await this.#runQueuedContinuation(queuedFollowUp, "followUp", undefined, signal, dequeueSignal);
-					return;
+				if (lastRole === "assistant") {
+					throw new Error("Cannot continue from message role: assistant");
 				}
-
-				throw new Error("Cannot continue from message role: assistant");
 			}
 
 			await this.#runLoop(undefined, undefined, signal, true);

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -523,6 +523,54 @@ describe("Agent", () => {
 		expect(firstCallText).toContain("Queued follow-up");
 	});
 
+	it("continue() batches pending asides into the first queued follow-up request from a toolResult tail", async () => {
+		const mock = createMockModel({ responses: [{ content: ["Processed both"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.replaceMessages([
+			{
+				role: "user",
+				content: [{ type: "text", text: "Initial" }],
+				timestamp: Date.now() - 20,
+			},
+			createAssistantMessage([{ type: "toolCall", id: "tool-1", name: "work", arguments: {} }]),
+			{
+				role: "toolResult",
+				toolCallId: "tool-1",
+				toolName: "work",
+				content: [{ type: "text", text: "tool done" }],
+				isError: false,
+				timestamp: Date.now() - 10,
+			},
+		]);
+
+		let drained = false;
+		agent.setAsideMessageProvider(() => {
+			if (drained) return [];
+			drained = true;
+			return [
+				{
+					role: "user",
+					content: [{ type: "text", text: "stranded aside" }],
+					timestamp: Date.now(),
+				},
+			];
+		});
+		agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "Queued follow-up" }],
+			timestamp: Date.now(),
+		});
+
+		await expect(agent.continue()).resolves.toBeUndefined();
+
+		expect(mock.calls.length).toBe(1);
+		const firstCallText = JSON.stringify(mock.calls[0].context.messages);
+		expect(firstCallText).toContain("stranded aside");
+		expect(firstCallText).toContain("Queued follow-up");
+		expect(firstCallText.indexOf("stranded aside")).toBeLessThan(firstCallText.indexOf("Queued follow-up"));
+	});
+
 	it("continue() should keep one-at-a-time steering semantics from assistant tail", async () => {
 		const mock = createMockModel({
 			responses: [{ content: ["Processed 1"] }, { content: ["Processed 2"] }],

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -484,6 +484,45 @@ describe("Agent", () => {
 		expect(agent.state.messages[agent.state.messages.length - 1].role).toBe("assistant");
 	});
 
+	it("continue() batches pending asides into the first queued follow-up request", async () => {
+		const mock = createMockModel({ responses: [{ content: ["Processed both"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.replaceMessages([
+			{
+				role: "user",
+				content: [{ type: "text", text: "Initial" }],
+				timestamp: Date.now() - 10,
+			},
+			createAssistantMessage([{ type: "text", text: "Initial response" }]),
+		]);
+
+		let drained = false;
+		agent.setAsideMessageProvider(() => {
+			if (drained) return [];
+			drained = true;
+			return [
+				{
+					role: "user",
+					content: [{ type: "text", text: "stranded aside" }],
+					timestamp: Date.now(),
+				},
+			];
+		});
+		agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "Queued follow-up" }],
+			timestamp: Date.now(),
+		});
+
+		await expect(agent.continue()).resolves.toBeUndefined();
+
+		expect(mock.calls.length).toBe(1);
+		const firstCallText = JSON.stringify(mock.calls[0].context.messages);
+		expect(firstCallText).toContain("stranded aside");
+		expect(firstCallText).toContain("Queued follow-up");
+	});
+
 	it("continue() should keep one-at-a-time steering semantics from assistant tail", async () => {
 		const mock = createMockModel({
 			responses: [{ content: ["Processed 1"] }, { content: ["Processed 2"] }],

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -334,6 +334,10 @@
 
 - Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
 
+### Fixed
+
+- Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
 - Fixed stranded extension asides arriving one model call after a queued follow-up resume instead of in the same continuation request.
 - Fixed RPC `prompt_result { agentInvoked: false }` after a streaming `triggerTurn` send that queued a continuation (`nextTurn` / steer / follow-up), not only a parked aside.
+- Fixed RPC `prompt_result { agentInvoked: false }` when `triggerTurn` send started idle but queued after image normalization because another prompt began streaming.
 - Fixed `deliverAs: "aside"` with `triggerTurn` starting a surprise turn when the primary stream settled during image normalization.
 - Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -288,6 +288,14 @@
 - Fixed omp plugin install failing with cloning errors for legacy Pi extensions whose tool schemas use legacy-typebox builders.
 - Fixed omp update aborting with chmod ENOENT when concurrent update runs overlapped by using unique download temporary paths.
 - Fixed the browser tool executable probe launching the user's installed GUI Chromium on Windows: the `--version` version probe from ecb22957 was Linux-scoped but ran for every platform candidate, so on Windows it could hand off to a running `chrome.exe`, open a normal browser window, then reject the candidate and fall back to cached Chrome for Testing. The probe is now confined to Linux ([#8445](https://github.com/can1357/oh-my-pi/issues/8445)).
+### Added
+
+- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
+
+### Fixed
+
+- Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
+- Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 
 ## [17.3.0] - 2026-08-13
 
@@ -330,13 +338,6 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
-### Added
-
-- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
-
-### Fixed
-
-- Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1375,6 +1375,9 @@
 - Fixed the Cursor-backed advisor losing entire turns when it selected server-native tools (`bash`, `grep`, etc.) outside its grant: exec-resolved native blocks are already rejected in-band by the advisor-scoped bridge, so they no longer trip the unavailable-tool quarantine and discard the `advise` emitted in the same turn ([#5900](https://github.com/can1357/oh-my-pi/issues/5900)).
 - Fixed custom `anthropic-messages` OAuth providers being unable to opt into configured Claude Code fingerprint header overrides. ([#5888](https://github.com/can1357/oh-my-pi/issues/5888))
 - Fixed authoritative providers (e.g. `openai-codex`) keeping unsupported bundled models selectable when a fresh model cache and an expired OAuth token coincided: built-in discovery now forces the OAuth refresh so the provider's model manager is constructed and prunes stale bundled entries (e.g. `gpt-5.4-nano`) instead of waiting out the cache TTL. ([#5364](https://github.com/can1357/oh-my-pi/issues/5364))
+### Added
+
+- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -295,6 +295,7 @@
 ### Fixed
 
 - Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
+- Fixed stranded extension asides arriving one model call after a queued follow-up resume instead of in the same continuation request.
 - Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 
 ## [17.3.0] - 2026-08-13

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 - Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
 - Fixed stranded extension asides arriving one model call after a queued follow-up resume instead of in the same continuation request.
+- Fixed RPC `prompt_result { agentInvoked: false }` after a streaming `triggerTurn` send that queued a continuation (`nextTurn` / steer / follow-up), not only a parked aside.
 - Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 
 ## [17.4.0] - 2026-08-20

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
 - Fixed stranded extension asides arriving one model call after a queued follow-up resume instead of in the same continuation request.
 - Fixed RPC `prompt_result { agentInvoked: false }` after a streaming `triggerTurn` send that queued a continuation (`nextTurn` / steer / follow-up), not only a parked aside.
+- Fixed `deliverAs: "aside"` with `triggerTurn` starting a surprise turn when the primary stream settled during image normalization.
 - Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 
 ## [17.4.0] - 2026-08-20

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -330,6 +330,9 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
+### Added
+
+- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
 
 ## [17.2.15] - 2026-08-12
 
@@ -1375,9 +1378,6 @@
 - Fixed the Cursor-backed advisor losing entire turns when it selected server-native tools (`bash`, `grep`, etc.) outside its grant: exec-resolved native blocks are already rejected in-band by the advisor-scoped bridge, so they no longer trip the unavailable-tool quarantine and discard the `advise` emitted in the same turn ([#5900](https://github.com/can1357/oh-my-pi/issues/5900)).
 - Fixed custom `anthropic-messages` OAuth providers being unable to opt into configured Claude Code fingerprint header overrides. ([#5888](https://github.com/can1357/oh-my-pi/issues/5888))
 - Fixed authoritative providers (e.g. `openai-codex`) keeping unsupported bundled models selectable when a fresh model cache and an expired OAuth token coincided: built-in discovery now forces the OAuth refresh so the provider's model manager is constructed and prunes stale bundled entries (e.g. `gpt-5.4-nano`) instead of waiting out the cache TTL. ([#5364](https://github.com/can1357/oh-my-pi/issues/5364))
-### Added
-
-- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,13 @@
 - Fixed prompt guidance and descriptions for Task tools and SSH usage.
 - ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
+
+### Fixed
+
+- Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
+- Fixed stranded extension asides arriving one model call after a queued follow-up resume instead of in the same continuation request.
+- Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 
 ## [17.4.0] - 2026-08-20
 
@@ -288,15 +295,6 @@
 - Fixed omp plugin install failing with cloning errors for legacy Pi extensions whose tool schemas use legacy-typebox builders.
 - Fixed omp update aborting with chmod ENOENT when concurrent update runs overlapped by using unique download temporary paths.
 - Fixed the browser tool executable probe launching the user's installed GUI Chromium on Windows: the `--version` version probe from ecb22957 was Linux-scoped but ran for every platform candidate, so on Windows it could hand off to a running `chrome.exe`, open a normal browser window, then reject the candidate and fall back to cached Chrome for Testing. The probe is now confined to Linux ([#8445](https://github.com/can1357/oh-my-pi/issues/8445)).
-### Added
-
-- Added `deliverAs: "aside"` to extension `pi.sendMessage` for mid-turn custom message injection at the next agent step boundary without interrupting tools or aborting the stream; idle appends unless `triggerTurn`, stranded content persists with no wake. See `examples/extensions/aside-delivery.ts`.
-
-### Fixed
-
-- Fixed stranded extension asides flushed at settle blocking queued follow-up auto-resume by poisoning the transcript tail before the follow-up drain.
-- Fixed stranded extension asides arriving one model call after a queued follow-up resume instead of in the same continuation request.
-- Fixed `/clear` and `/btw` leaving stranded extension asides that could re-enter the rewritten conversation on the next prompt.
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/coding-agent/examples/extensions/aside-delivery.ts
+++ b/packages/coding-agent/examples/extensions/aside-delivery.ts
@@ -1,0 +1,44 @@
+/**
+ * Aside Delivery Extension
+ *
+ * Demonstrates mid-turn injection via deliverAs: "aside" — folds hidden context
+ * at the next agent step boundary without interrupting tools or aborting the stream.
+ *
+ * Busy-path only: aside does not wake idle or stranded sessions. Use triggerTurn
+ * while idle, or followUp / steer, when a model response is required.
+ */
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+	const { z } = pi.zod;
+
+	pi.registerTool({
+		name: "queue_aside_note",
+		label: "Queue Aside Note",
+		description: "Queue hidden context for the next agent step boundary (deliverAs: aside)",
+		parameters: z.object({
+			note: z.string().describe("Hidden context to fold at the next step boundary"),
+		}),
+
+		async execute(_toolCallId, params) {
+			pi.sendMessage(
+				{
+					customType: "aside-delivery-demo",
+					content: params.note,
+					display: false,
+				},
+				{ deliverAs: "aside" },
+			);
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: "Queued aside for next agent step boundary (non-interrupting).",
+					},
+				],
+				details: { note: params.note },
+			};
+		},
+	});
+}

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -38,6 +38,7 @@ import { resolvePath, withHostGuard } from "../utils";
 import type {
 	AssistantThinkingRenderer,
 	ComposerShapeDefinition,
+	CustomMessageDeliverAs,
 	Extension,
 	ExtensionAPI,
 	ExtensionContext,
@@ -257,7 +258,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	sendMessage<T = unknown>(
 		message: CustomMessagePayload<T>,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		options?: { triggerTurn?: boolean; deliverAs?: CustomMessageDeliverAs },
 	): void {
 		this.runtime.sendMessage(message, options);
 	}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -124,6 +124,9 @@ export type { AppKeybinding, KeybindingsManager } from "../../config/keybindings
 export type { ExecOptions, ExecResult } from "../../exec/exec";
 export type { AgentToolResult, AgentToolUpdateCallback };
 
+/** Delivery mode for `sendMessage` / `sendCustomMessage`. */
+export type CustomMessageDeliverAs = "steer" | "followUp" | "nextTurn" | "aside";
+
 // ============================================================================
 // UI Context
 // ============================================================================
@@ -1405,13 +1408,13 @@ export interface ExtensionAPI {
 	/**
 	 * Send a custom message to the session.
 	 *
-	 * `deliverAs: "nextTurn"` keeps the message hidden from the editable pending-message UI.
-	 * If `triggerTurn` is also true while the current turn is still unwinding, the session schedules
-	 * an internal continuation that consumes the message on the next turn.
+	 * Delivery: omit `deliverAs` mid-stream steers (interrupting). `followUp` waits until end-of-run.
+	 * `nextTurn` hides until the next user prompt. `aside` folds at the next agent step boundary
+	 * without interrupting tools; idle appends unless `triggerTurn`, stranded content persists with no wake.
 	 */
 	sendMessage<T = unknown>(
 		message: CustomMessagePayload<T>,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		options?: { triggerTurn?: boolean; deliverAs?: CustomMessageDeliverAs },
 	): void;
 
 	/** Send a user prompt: idle starts a turn; streaming queues as steer unless deliverAs is set. */
@@ -1623,11 +1626,11 @@ type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 export type SendMessageHandler = <T = unknown>(
 	message: CustomMessagePayload<T>,
 	/**
-	 * `deliverAs: "nextTurn"` queues hidden custom context for the next turn.
-	 * When paired with `triggerTurn: true` during prompt teardown, the session schedules
-	 * an internal continuation without surfacing the message in the editable pending queue.
+	 * Delivery: omit `deliverAs` mid-stream steers (interrupting). `followUp` waits until end-of-run.
+	 * `nextTurn` hides until the next user prompt. `aside` folds at the next agent step boundary
+	 * without interrupting tools; idle appends unless `triggerTurn`, stranded content persists with no wake.
 	 */
-	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	options?: { triggerTurn?: boolean; deliverAs?: CustomMessageDeliverAs },
 ) => void;
 
 export type SendUserMessageHandler = (

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -187,7 +187,8 @@ export class RpcExtensionUserMessageTracker {
 
 	#trackAgentMessageTaskForScope(scope: RpcExtensionUserMessageScope, task: Promise<unknown>): void {
 		const scopedTask = task.then(
-			() => {
+			result => {
+				if (result === false) return;
 				scope.hasAgentMessageTask = true;
 			},
 			() => {},

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -17,6 +17,7 @@ import { $env, isRecord, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
+	type CustomMessageDeliverAs,
 	type ExtensionUIContext,
 	type ExtensionUIDialogOptions,
 	type ExtensionUISelectItem,
@@ -164,6 +165,23 @@ type RpcExtensionUserMessageScope = {
 	pendingAgentMessageTasks: Set<Promise<void>>;
 };
 
+/** Context for deciding whether a false sendCustomMessage still scheduled agent work. */
+export interface RpcAgentMessageTaskHint {
+	deliverAs?: CustomMessageDeliverAs;
+	isStreaming?: boolean;
+}
+
+/**
+ * `sendCustomMessage` returns false whenever it did not synchronously
+ * `agent.prompt`. Parked asides and idle appends are local-only; streaming
+ * steer/follow-up/nextTurn queues still invoke the agent.
+ */
+function isAgentInvokingSendResult(result: unknown, hint: RpcAgentMessageTaskHint | undefined): boolean {
+	if (result !== false) return true;
+	if (hint?.deliverAs === "aside") return false;
+	return hint?.isStreaming === true;
+}
+
 /**
  * Tracks extension-originated messages while an RPC prompt is executing.
  * A slash command can resolve the outer prompt as local-only while also
@@ -179,16 +197,20 @@ export class RpcExtensionUserMessageTracker {
 		}
 	}
 
-	trackAgentMessageTask(task: Promise<unknown>): void {
+	trackAgentMessageTask(task: Promise<unknown>, hint?: RpcAgentMessageTaskHint): void {
 		for (const scope of this.#activePromptScopes) {
-			this.#trackAgentMessageTaskForScope(scope, task);
+			this.#trackAgentMessageTaskForScope(scope, task, hint);
 		}
 	}
 
-	#trackAgentMessageTaskForScope(scope: RpcExtensionUserMessageScope, task: Promise<unknown>): void {
+	#trackAgentMessageTaskForScope(
+		scope: RpcExtensionUserMessageScope,
+		task: Promise<unknown>,
+		hint: RpcAgentMessageTaskHint | undefined,
+	): void {
 		const scopedTask = task.then(
 			result => {
-				if (result === false) return;
+				if (!isAgentInvokingSendResult(result, hint)) return;
 				scope.hasAgentMessageTask = true;
 			},
 			() => {},
@@ -944,8 +966,8 @@ export async function runRpcMode(
 		onShutdown: () => {
 			shutdownState.requested = true;
 		},
-		trackAgentInvokingMessage: task => {
-			extensionUserMessageTracker.trackAgentMessageTask(task);
+		trackAgentInvokingMessage: (task, hint) => {
+			extensionUserMessageTracker.trackAgentMessageTask(task, hint);
 		},
 		uiContext: rpcUiContext,
 	});

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -168,7 +168,13 @@ type RpcExtensionUserMessageScope = {
 /** Context for deciding whether a false sendCustomMessage still scheduled agent work. */
 export interface RpcAgentMessageTaskHint {
 	deliverAs?: CustomMessageDeliverAs;
-	isStreaming?: boolean;
+	/** Read at send-task settlement so image-normalize races see post-delivery streaming. */
+	isStreaming?: boolean | (() => boolean);
+}
+
+function hintIsStreaming(hint: RpcAgentMessageTaskHint | undefined): boolean {
+	const value = hint?.isStreaming;
+	return typeof value === "function" ? value() : value === true;
 }
 
 /**
@@ -179,7 +185,7 @@ export interface RpcAgentMessageTaskHint {
 function isAgentInvokingSendResult(result: unknown, hint: RpcAgentMessageTaskHint | undefined): boolean {
 	if (result !== false) return true;
 	if (hint?.deliverAs === "aside") return false;
-	return hint?.isStreaming === true;
+	return hintIsStreaming(hint);
 }
 
 /**

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -8,7 +8,12 @@
  */
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
-import type { ExtensionError, ExtensionMode, ExtensionUIContext } from "../extensibility/extensions/types";
+import type {
+	CustomMessageDeliverAs,
+	ExtensionError,
+	ExtensionMode,
+	ExtensionUIContext,
+} from "../extensibility/extensions/types";
 import type { AgentSession } from "../session/agent-session";
 import { USER_INTERRUPT_LABEL } from "../session/messages";
 
@@ -29,7 +34,10 @@ export interface InitializeExtensionsOptions {
 	/** Optional lifecycle hook for extension-originated messages that can start an agent turn. */
 	markAgentInvokingMessage?: () => void;
 	/** Optional lifecycle hook for extension-originated sends whose success/failure determines turn ownership. */
-	trackAgentInvokingMessage?: (task: Promise<unknown>) => void;
+	trackAgentInvokingMessage?: (
+		task: Promise<unknown>,
+		hint?: { deliverAs?: CustomMessageDeliverAs; isStreaming?: boolean },
+	) => void;
 }
 
 /**
@@ -60,7 +68,10 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 				const sendTask = session.sendCustomMessage(message, sendOptions);
 				if (sendOptions?.triggerTurn) {
 					if (trackAgentInvokingMessage) {
-						trackAgentInvokingMessage(sendTask);
+						trackAgentInvokingMessage(sendTask, {
+							deliverAs: sendOptions.deliverAs,
+							isStreaming: session.isStreaming,
+						});
 					} else {
 						markAgentInvokingMessage?.();
 					}
@@ -72,7 +83,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			sendUserMessage: (content, sendOptions) => {
 				const sendTask = session.sendUserMessage(content, sendOptions);
 				if (trackAgentInvokingMessage) {
-					trackAgentInvokingMessage(sendTask);
+					trackAgentInvokingMessage(sendTask, { isStreaming: session.isStreaming });
 				} else {
 					markAgentInvokingMessage?.();
 				}

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -36,7 +36,7 @@ export interface InitializeExtensionsOptions {
 	/** Optional lifecycle hook for extension-originated sends whose success/failure determines turn ownership. */
 	trackAgentInvokingMessage?: (
 		task: Promise<unknown>,
-		hint?: { deliverAs?: CustomMessageDeliverAs; isStreaming?: boolean },
+		hint?: { deliverAs?: CustomMessageDeliverAs; isStreaming?: boolean | (() => boolean) },
 	) => void;
 }
 
@@ -70,7 +70,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 					if (trackAgentInvokingMessage) {
 						trackAgentInvokingMessage(sendTask, {
 							deliverAs: sendOptions.deliverAs,
-							isStreaming: session.isStreaming,
+							isStreaming: () => session.isStreaming,
 						});
 					} else {
 						markAgentInvokingMessage?.();
@@ -83,7 +83,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			sendUserMessage: (content, sendOptions) => {
 				const sendTask = session.sendUserMessage(content, sendOptions);
 				if (trackAgentInvokingMessage) {
-					trackAgentInvokingMessage(sendTask, { isStreaming: session.isStreaming });
+					trackAgentInvokingMessage(sendTask, { isStreaming: () => session.isStreaming });
 				} else {
 					markAgentInvokingMessage?.();
 				}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6990,6 +6990,7 @@ export class AgentSession {
 			this.#planReferencePath = "local://PLAN.md";
 			this.#advisors.resetSessionState();
 			advisorRecordersDetached = false;
+			this.#clearPendingExtensionAsides();
 			this.#reconnectToAgent();
 			// The workspace-roots block must reflect the new session's directory set,
 			// not the previous session's — refresh before the next turn goes out.
@@ -8198,6 +8199,7 @@ export class AgentSession {
 			if (switchingToDifferentSession || didReloadConversationChange) {
 				this.#clearSessionScopedToolState();
 			}
+			this.#clearPendingExtensionAsides();
 			this.#reconnectToAgent();
 			try {
 				await this.#sessionSwitchReconciler?.();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8043,6 +8043,7 @@ export class AgentSession {
 		const previousSteeringMessages = [...this.agent.peekSteeringQueue()];
 		const previousFollowUpMessages = [...this.agent.peekFollowUpQueue()];
 		const previousPendingNextTurnMessages = [...this.#pendingNextTurnMessages];
+		const previousPendingExtensionAsides = [...this.#pendingExtensionAsides];
 		const previousScheduledHiddenNextTurnGeneration = this.#scheduledHiddenNextTurnGeneration;
 		const previousQueuedMessageDrainBlocked = this.#queuedMessageDrainBlocked;
 		const previousUsagePreflightReadyForNextModelCall = this.#usagePreflightReadyForNextModelCall;
@@ -8242,6 +8243,7 @@ export class AgentSession {
 			this.agent.replaceMessages(previousAgentMessages);
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;
+			this.#pendingExtensionAsides = previousPendingExtensionAsides;
 			this.#scheduledHiddenNextTurnGeneration = previousScheduledHiddenNextTurnGeneration;
 			this.#queuedMessageDrainBlocked = previousQueuedMessageDrainBlocked;
 			this.#usagePreflightReadyForNextModelCall = previousUsagePreflightReadyForNextModelCall;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7044,7 +7044,6 @@ export class AgentSession {
 			}
 		}
 
-		this.#clearPendingExtensionAsides();
 		await this.#bash.flushPending();
 		// Flush current session to ensure all entries are written
 		await this.sessionManager.flush();
@@ -7068,6 +7067,7 @@ export class AgentSession {
 				this.#bash.finishSessionTransition(bashTransition, false);
 				return false;
 			}
+			this.#clearPendingExtensionAsides();
 			this.#bash.markSessionTransition(bashTransition);
 			this.#bash.finishSessionTransition(bashTransition, true);
 			// The fork clones the transcript and keeps this recovery state running

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -34,6 +34,8 @@ import {
 	type AgentToolResult,
 	type AgentTurnEndContext,
 	AppendOnlyContextManager,
+	ASIDE_MESSAGE_COMMIT,
+	ASIDE_MESSAGE_DISCARD,
 	type AsideMessage,
 	type BeforeToolCallContext,
 	type BeforeToolCallResult,
@@ -1317,7 +1319,7 @@ export class AgentSession {
 			const thunks: AsideMessage[] = this.#irc.drainPending().map(record => () => record);
 			const pendingExtension = [...this.#pendingExtensionAsides];
 			this.#pendingExtensionAsides = [];
-			thunks.push(...pendingExtension.map(record => () => record));
+			thunks.push(...pendingExtension.map(record => this.#createExtensionAsideThunk(record)));
 			thunks.push(...this.yieldQueue.drainLazy());
 			// Mid-run todo reconciliation — evaluated at injection time so a turn
 			// that flips a todo just before this poll suppresses the nudge.
@@ -7979,6 +7981,32 @@ export class AgentSession {
 		const records = [...this.#pendingExtensionAsides];
 		this.#pendingExtensionAsides = [];
 		emitPersistedCustomMessages(this.agent, records);
+	}
+
+	/** Single-shot thunk for a drained extension aside. COMMIT marks settled only
+	 *  (loop already inserted + emits); DISCARD persists without waking a turn. */
+	#createExtensionAsideThunk(record: CustomMessage): AsideMessage {
+		let settled = false;
+		return () => {
+			Object.defineProperties(record, {
+				[ASIDE_MESSAGE_COMMIT]: {
+					configurable: true,
+					value: () => {
+						if (settled) return;
+						settled = true;
+					},
+				},
+				[ASIDE_MESSAGE_DISCARD]: {
+					configurable: true,
+					value: (_error: Error) => {
+						if (settled) return;
+						settled = true;
+						emitPersistedCustomMessages(this.agent, [record]);
+					},
+				},
+			});
+			return record;
+		};
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7270,8 +7270,10 @@ export class AgentSession {
 	 * @param options Handoff execution options
 	 * @returns The handoff document text, or undefined if cancelled/failed
 	 */
-	handoff(customInstructions?: string, options?: SessionHandoffOptions): Promise<HandoffResult | undefined> {
-		return this.#maintenance.handoff(customInstructions, options);
+	async handoff(customInstructions?: string, options?: SessionHandoffOptions): Promise<HandoffResult | undefined> {
+		const result = await this.#maintenance.handoff(customInstructions, options);
+		if (result) this.#clearPendingExtensionAsides();
+		return result;
 	}
 
 	#isTerminalYieldToolResult(event: { toolName: string; isError?: boolean; result?: { details?: unknown } }): boolean {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -792,7 +792,9 @@ export class AgentSession {
 				this.#preserveAdvisorCard(card);
 			}
 		}
-		if (!this.#isDisposed) {
+		// Skip flush when a queued steer/follow-up will resume — a custom tail
+		// blocks follow-up-only auto-continue. Same gate as #resumeStrandedIrcAsides.
+		if (!this.#isDisposed && !(this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages())) {
 			this.#flushPendingExtensionAsides();
 		}
 		this.#scheduleQueuedMessageDrain();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -794,6 +794,7 @@ export class AgentSession {
 		}
 		// Skip flush when a queued steer/follow-up will resume — a custom tail
 		// blocks follow-up-only auto-continue. Same gate as #resumeStrandedIrcAsides.
+		// Agent.continue() prefixes pending asides onto that queued continuation.
 		if (!this.#isDisposed && !(this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages())) {
 			this.#flushPendingExtensionAsides();
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6464,6 +6464,7 @@ export class AgentSession {
 			attribution: normalizedPayload.attribution,
 			timestamp: Date.now(),
 		};
+		const arrivedWhileBusy = options?.deliverAs === "aside" && this.#shouldParkExtensionAside();
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
 		if (this.#isDisposed) {
 			return false;
@@ -6474,7 +6475,7 @@ export class AgentSession {
 				this.#pendingExtensionAsides.push(normalizedAppMessage);
 				return false;
 			}
-			if (options?.triggerTurn) {
+			if (options?.triggerTurn && !arrivedWhileBusy) {
 				if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 					this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
 					return false;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -140,7 +140,7 @@ import type {
 import { emitSessionShutdownEvent } from "../extensibility/extensions";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
-import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
+import type { CompactOptions, ContextUsage, CustomMessageDeliverAs } from "../extensibility/extensions/types";
 import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
@@ -580,6 +580,8 @@ export class AgentSession {
 	#ircWakeTurnObserver:
 		| ((records: CustomMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined)
 		| undefined;
+	// Extension asides queued while a turn is streaming; drained at step boundaries.
+	#pendingExtensionAsides: CustomMessage[] = [];
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
@@ -787,6 +789,9 @@ export class AgentSession {
 				this.#preserveAdvisorCard(card);
 			}
 		}
+		if (!this.#isDisposed) {
+			this.#flushPendingExtensionAsides();
+		}
 		this.#scheduleQueuedMessageDrain();
 		this.#resumeStrandedIrcAsides();
 	}
@@ -921,8 +926,32 @@ export class AgentSession {
 			this.#pendingNextTurnMessages.push(card);
 			return;
 		}
-		this.agent.emitExternalEvent({ type: "message_start", message: card });
-		this.agent.emitExternalEvent({ type: "message_end", message: card });
+		this.#emitPersistedCustomMessages([card]);
+	}
+
+	#emitPersistedCustomMessages(records: CustomMessage[]): void {
+		for (const record of records) {
+			// emitExternalEvent on message_end appends to agent state and dispatches
+			// to all session listeners, which in turn handle TUI rendering and
+			// sessionManager persistence via #handleAgentEvent.
+			this.agent.emitExternalEvent({ type: "message_start", message: record });
+			this.agent.emitExternalEvent({ type: "message_end", message: record });
+		}
+	}
+
+	#appendAndPersistCustomMessage(message: CustomMessage): void {
+		this.agent.appendMessage(message);
+		this.sessionManager.appendCustomMessageEntry(
+			message.customType,
+			message.content,
+			message.display,
+			message.details,
+			message.attribution,
+		);
+	}
+
+	#clearPendingExtensionAsides(): void {
+		this.#pendingExtensionAsides = [];
 	}
 
 	#resetInFlight(): void {
@@ -1295,6 +1324,9 @@ export class AgentSession {
 		this.agent.hasIrcInterrupts = () => this.#irc.hasInterrupts();
 		this.agent.setAsideMessageProvider(() => {
 			const thunks: AsideMessage[] = this.#irc.drainPending().map(record => () => record);
+			const pendingExtension = [...this.#pendingExtensionAsides];
+			this.#pendingExtensionAsides = [];
+			thunks.push(...pendingExtension.map(record => () => record));
 			thunks.push(...this.yieldQueue.drainLazy());
 			// Mid-run todo reconciliation — evaluated at injection time so a turn
 			// that flips a todo just before this poll suppresses the nudge.
@@ -3920,7 +3952,7 @@ export class AgentSession {
 
 	/**
 	 * Synchronously mark the session as disposing so new work is rejected
-	 * immediately: eval starts throw, queued asides are dropped, and the
+	 * immediately: eval starts throw, pending asides are flushed, and the
 	 * aside provider is detached. Idempotent; `dispose()` runs it first.
 	 *
 	 * Wrappers that await other teardown before delegating to `dispose()` MUST
@@ -3939,6 +3971,7 @@ export class AgentSession {
 		this.#titleGenerationAbortController.abort();
 		this.#abortAutolearnCapture();
 		this.#irc.flushPending();
+		this.#flushPendingExtensionAsides();
 		this.yieldQueue.clear();
 		this.agent.setAsideMessageProvider(undefined);
 		this.agent.hasIrcInterrupts = undefined;
@@ -5672,6 +5705,7 @@ export class AgentSession {
 			await this.#bash.flushPending();
 			this.#eval.flushPending();
 			this.#irc.flushPending();
+			this.#flushPendingExtensionAsides();
 
 			this.#todo.resetCycle();
 			this.#resetPromptMaintenanceState();
@@ -6387,10 +6421,17 @@ export class AgentSession {
 	/**
 	 * Send a custom message to the session. Creates a CustomMessageEntry.
 	 *
-	 * Handles three cases:
-	 * - Streaming: queue as steer/follow-up or store for next turn
-	 * - Not streaming + triggerTurn: appends to state/session, starts new turn unless the client cannot own it
-	 * - Not streaming + no trigger: appends to state/session, no turn
+	 * Delivery (`deliverAs`):
+	 * - omitted / `"steer"` while streaming: steer queue (interrupting)
+	 * - `"followUp"`: end-of-run queue
+	 * - `"nextTurn"`: hidden until the next user prompt (optional `triggerTurn`)
+	 * - `"aside"`: non-interrupting fold at the next agent step boundary while
+	 *   streaming/compacting/disconnected; idle append/persist unless
+	 *   `triggerTurn` starts a turn; stranded flush persists with no wake
+	 *
+	 * Idle without an explicit mid-stream queue path: `triggerTurn` starts a
+	 * turn (unless the client defers agent-initiated turns); otherwise append
+	 * to state/session with no turn.
 	 *
 	 * @returns true iff this call synchronously started a new turn (awaited
 	 * `agent.prompt`); false when the message was queued/appended without a turn
@@ -6402,7 +6443,7 @@ export class AgentSession {
 		message: CustomMessagePayload<T>,
 		options?: {
 			triggerTurn?: boolean;
-			deliverAs?: "steer" | "followUp" | "nextTurn";
+			deliverAs?: CustomMessageDeliverAs;
 			queueChipText?: string;
 			acceptTerminalEmptyStop?: boolean;
 		},
@@ -6427,6 +6468,28 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		if (this.#isDisposed) {
+			return false;
+		}
+
+		if (options?.deliverAs === "aside") {
+			// Agent disconnected / not subscribed — park until reconnect or flush.
+			if (this.isStreaming || this.isCompacting || this.#unsubscribeAgent === undefined) {
+				this.#pendingExtensionAsides.push(normalizedAppMessage);
+				return false;
+			}
+			if (options?.triggerTurn) {
+				if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
+					this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+					return false;
+				}
+				await this.#promptAgentInitiatedMessage(normalizedAppMessage);
+				return true;
+			}
+			this.#appendAndPersistCustomMessage(normalizedAppMessage);
+			return false;
+		}
+
 		if (this.isStreaming) {
 			if (options?.deliverAs === "nextTurn") {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, options?.triggerTurn ?? false);
@@ -6454,14 +6517,7 @@ export class AgentSession {
 				});
 				return true;
 			}
-			this.agent.appendMessage(normalizedAppMessage);
-			this.sessionManager.appendCustomMessageEntry(
-				normalizedAppMessage.customType,
-				normalizedAppMessage.content,
-				normalizedAppMessage.display,
-				normalizedAppMessage.details,
-				normalizedAppMessage.attribution,
-			);
+			this.#appendAndPersistCustomMessage(normalizedAppMessage);
 			return false;
 		}
 
@@ -6474,14 +6530,7 @@ export class AgentSession {
 			return true;
 		}
 
-		this.agent.appendMessage(normalizedAppMessage);
-		this.sessionManager.appendCustomMessageEntry(
-			normalizedAppMessage.customType,
-			normalizedAppMessage.content,
-			normalizedAppMessage.display,
-			normalizedAppMessage.details,
-			normalizedAppMessage.attribution,
-		);
+		this.#appendAndPersistCustomMessage(normalizedAppMessage);
 		return false;
 	}
 
@@ -6939,6 +6988,7 @@ export class AgentSession {
 			await this.#memory.resetContextForNewTranscript();
 			this.#pendingNextTurnMessages = [];
 			this.#scheduledHiddenNextTurnGeneration = undefined;
+			this.#clearPendingExtensionAsides();
 			this.#queuedMessageDrainBlocked = false;
 			this.#usagePreflightReadyForNextModelCall = false;
 
@@ -7004,6 +7054,7 @@ export class AgentSession {
 			}
 		}
 
+		this.#clearPendingExtensionAsides();
 		await this.#bash.flushPending();
 		// Flush current session to ensure all entries are written
 		await this.sessionManager.flush();
@@ -7923,6 +7974,15 @@ export class AgentSession {
 		return messages;
 	}
 
+	/** Persist extension asides that missed step-boundary injection (stranded at
+	 *  turn tail, next prompt, or dispose). Never wakes a turn — unlike IRC. */
+	#flushPendingExtensionAsides(): void {
+		if (this.#pendingExtensionAsides.length === 0) return;
+		const records = [...this.#pendingExtensionAsides];
+		this.#pendingExtensionAsides = [];
+		this.#emitPersistedCustomMessages(records);
+	}
+
 	// =========================================================================
 	// Session Management
 	// =========================================================================
@@ -8016,6 +8076,7 @@ export class AgentSession {
 		this.agent.clearAllQueues();
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
+		this.#clearPendingExtensionAsides();
 		this.#queuedMessageDrainBlocked = false;
 		this.#usagePreflightReadyForNextModelCall = false;
 		this.#usagePreflightReadyModel = undefined;
@@ -8278,6 +8339,7 @@ export class AgentSession {
 		// Clear pending messages (bound to old session state)
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
+		this.#clearPendingExtensionAsides();
 		this.#queuedMessageDrainBlocked = false;
 		this.#usagePreflightReadyForNextModelCall = false;
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4304,6 +4304,7 @@ export class AgentSession {
 		this.agent.reset();
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
+		this.#clearPendingExtensionAsides();
 		// Reset the session_stop continuation chain: the queued continuation
 		// message is gone with the conversation, but the counters would otherwise
 		// carry over, so the next post-reset turn is reported to hooks as part of
@@ -8499,6 +8500,7 @@ export class AgentSession {
 
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
+		this.#clearPendingExtensionAsides();
 		this.agent.replaceQueues([], []);
 		this.#queuedMessageDrainBlocked = false;
 		this.#usagePreflightReadyForNextModelCall = false;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -272,6 +272,7 @@ import {
 	shouldPromptCodexAutoRedeem,
 } from "./codex-auto-reset";
 import { recordCredentialPin, seedCredentialPins } from "./credential-pin";
+import { emitPersistedCustomMessages } from "./custom-message-delivery";
 import { EvalRunner, type EvalRunnerHost } from "./eval-runner";
 import {
 	collectPendingToolCalls,
@@ -917,7 +918,7 @@ export class AgentSession {
 	/** Record a suppressed advisor concern as visible, persisted advice without
 	 *  triggering a turn. When the agent is idle (the normal post-interrupt case,
 	 *  including the post-prompt unwind window where the core loop has ended), emit
-	 *  message_start/message_end like #flushPendingIrcAsides so #handleAgentEvent
+	 *  message_start/message_end like IrcBridge.flushPending so #handleAgentEvent
 	 *  renders it live (TUI/ACP) and persists it as a CustomMessageEntry. Only while
 	 *  an abort is still tearing a live turn down do we park it hidden, so abort's
 	 *  settle step replays it once idle — never appended into a live streamMessage. */
@@ -926,17 +927,7 @@ export class AgentSession {
 			this.#pendingNextTurnMessages.push(card);
 			return;
 		}
-		this.#emitPersistedCustomMessages([card]);
-	}
-
-	#emitPersistedCustomMessages(records: CustomMessage[]): void {
-		for (const record of records) {
-			// emitExternalEvent on message_end appends to agent state and dispatches
-			// to all session listeners, which in turn handle TUI rendering and
-			// sessionManager persistence via #handleAgentEvent.
-			this.agent.emitExternalEvent({ type: "message_start", message: record });
-			this.agent.emitExternalEvent({ type: "message_end", message: record });
-		}
+		emitPersistedCustomMessages(this.agent, [card]);
 	}
 
 	#appendAndPersistCustomMessage(message: CustomMessage): void {
@@ -6473,8 +6464,7 @@ export class AgentSession {
 		}
 
 		if (options?.deliverAs === "aside") {
-			// Agent disconnected / not subscribed — park until reconnect or flush.
-			if (this.isStreaming || this.isCompacting || this.#unsubscribeAgent === undefined) {
+			if (this.#shouldParkExtensionAside()) {
 				this.#pendingExtensionAsides.push(normalizedAppMessage);
 				return false;
 			}
@@ -7974,13 +7964,18 @@ export class AgentSession {
 		return messages;
 	}
 
+	/** True when aside must queue: streaming, compacting, or agent disconnected. */
+	#shouldParkExtensionAside(): boolean {
+		return this.isStreaming || this.isCompacting || this.#unsubscribeAgent === undefined;
+	}
+
 	/** Persist extension asides that missed step-boundary injection (stranded at
 	 *  turn tail, next prompt, or dispose). Never wakes a turn — unlike IRC. */
 	#flushPendingExtensionAsides(): void {
 		if (this.#pendingExtensionAsides.length === 0) return;
 		const records = [...this.#pendingExtensionAsides];
 		this.#pendingExtensionAsides = [];
-		this.#emitPersistedCustomMessages(records);
+		emitPersistedCustomMessages(this.agent, records);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/session/custom-message-delivery.ts
+++ b/packages/coding-agent/src/session/custom-message-delivery.ts
@@ -1,0 +1,13 @@
+import type { Agent } from "@oh-my-pi/pi-agent-core";
+import type { CustomMessage } from "./messages";
+
+/**
+ * Persist custom messages via message_start/end so session listeners render
+ * (TUI/ACP) and SessionManager appends CustomMessageEntry on message_end.
+ */
+export function emitPersistedCustomMessages(agent: Agent, records: CustomMessage[]): void {
+	for (const record of records) {
+		agent.emitExternalEvent({ type: "message_start", message: record });
+		agent.emitExternalEvent({ type: "message_end", message: record });
+	}
+}

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -7,6 +7,7 @@ import ircAutoReplyTemplate from "../prompts/system/irc-autoreply.md" with { typ
 import ircIncomingTemplate from "../prompts/system/irc-incoming.md" with { type: "text" };
 import { AgentRegistry } from "../registry/agent-registry";
 import type { AgentSessionEvent } from "./agent-session-events";
+import { emitPersistedCustomMessages } from "./custom-message-delivery";
 import type { CustomMessage } from "./messages";
 import type { SessionManager } from "./session-manager";
 
@@ -169,10 +170,7 @@ export class IrcBridge {
 
 	/** Persists queued IRC records that missed their step-boundary injection. */
 	flushPending(): void {
-		for (const record of this.drainPending()) {
-			this.#host.agent.emitExternalEvent({ type: "message_start", message: record });
-			this.#host.agent.emitExternalEvent({ type: "message_end", message: record });
-		}
+		emitPersistedCustomMessages(this.#host.agent, this.drainPending());
 	}
 
 	async #runAutoReply(msg: IrcMessage): Promise<void> {

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -477,6 +477,59 @@ describe("AgentSession extension deliverAs aside", () => {
 		expect(mock.calls.length).toBe(1);
 	});
 
+	it("does not flush a stranded aside ahead of a queued follow-up drain (case 8b)", async () => {
+		const { session: stopSession, mock } = await createMockSession([
+			{ content: ["first answer"], stopReason: "stop" },
+			{ content: ["continued after follow-up"] },
+			{ content: ["folded aside"] },
+		]);
+
+		let injected = false;
+		stopSession.agent.setOnBeforeYield(async () => {
+			if (injected) return;
+			injected = true;
+			await stopSession.sendCustomMessage(asidePayload("settle aside"), { deliverAs: "aside" });
+			const inner = asideProvider;
+			if (!inner) throw new Error("aside provider was never captured");
+			let skippedYieldPoll = false;
+			stopSession.agent.setAsideMessageProvider(() => {
+				if (!skippedYieldPoll) {
+					skippedYieldPoll = true;
+					return [];
+				}
+				return inner();
+			});
+		});
+
+		const resumed = Promise.withResolvers<void>();
+		let agentEnds = 0;
+		stopSession.subscribe(event => {
+			if (event.type !== "agent_end") return;
+			agentEnds += 1;
+			if (agentEnds === 1) {
+				stopSession.agent.followUp({
+					role: "user",
+					content: [{ type: "text", text: "then add the test" }],
+					attribution: "user",
+					timestamp: Date.now(),
+				});
+				return;
+			}
+			resumed.resolve();
+		});
+
+		await stopSession.prompt("hello");
+		await resumed.promise;
+		await stopSession.waitForIdle();
+
+		expect(mock.calls.length).toBeGreaterThanOrEqual(2);
+		expect(userMessageText(stopSession.agent.state.messages)).toContain("then add the test");
+		expect(userMessageText([...stopSession.agent.peekFollowUpQueue()])).not.toContain("then add the test");
+		expect(stopSession.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toContain(
+			"settle aside",
+		);
+	});
+
 	it("still flushes a stranded aside when a follow-up is queued (case 8)", async () => {
 		const { session: parked, mock, streamStarted } = await createParkedSession();
 		const running = parked.prompt("do work");

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -594,6 +594,49 @@ describe("AgentSession extension deliverAs aside", () => {
 		).toBe(false);
 	});
 
+	it("drops asides injected after the first switchSession clear and before reconnect (case 9f)", async () => {
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		captureAsideProvider(agent);
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const active = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		session = active;
+
+		sessionManager.appendMessage({ role: "user", content: "previous", timestamp: 1 });
+		await sessionManager.flush();
+
+		const otherManager = SessionManager.create(tempDir.path(), tempDir.path());
+		otherManager.appendMessage({ role: "user", content: "target", timestamp: 2 });
+		await otherManager.flush();
+		const targetSessionFile = otherManager.getSessionFile();
+		if (!targetSessionFile) throw new Error("expected target session file");
+		await otherManager.close();
+
+		Object.defineProperty(active, "isStreaming", { value: true, configurable: true });
+
+		const setSessionFile = sessionManager.setSessionFile.bind(sessionManager);
+		vi.spyOn(sessionManager, "setSessionFile").mockImplementation(async file => {
+			await setSessionFile(file);
+			await active.sendCustomMessage(asidePayload("must not leak after clear"), { deliverAs: "aside" });
+		});
+
+		const switched = await active.switchSession(targetSessionFile);
+		expect(switched).toBe(true);
+		await active.waitForIdle();
+
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(await drainExtensionAsides()).toEqual([]);
+	});
+
 	it("restores pending asides when switchSession rolls back after clear (case 9d)", async () => {
 		const { session: active, sessionManager } = await createIdleSession();
 		Object.defineProperty(active, "isStreaming", { value: true, configurable: true });

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -1,0 +1,592 @@
+/**
+ * Contract tests for extension `deliverAs: "aside"` on AgentSession.sendCustomMessage.
+ *
+ * Extension asides queue mid-turn, drain at agent step boundaries via the aside
+ * provider, and flush stranded content without waking (unlike peer IRC).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent, type AgentMessage, type AgentTool, type AsideMessage } from "@oh-my-pi/pi-agent-core";
+import type { ToolCall } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+const ASIDE_TYPE = "extension-aside-test";
+
+interface ParkedHarness {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	mock: MockModel;
+	streamStarted: Promise<void>;
+}
+
+const mockYieldParameters = type({
+	result: "unknown",
+	"type?": "unknown",
+});
+
+interface MockYieldDetails {
+	status: "success";
+	data?: unknown;
+	type?: string | string[];
+}
+
+function asidePayload(content: string): {
+	customType: string;
+	content: string;
+	display: boolean;
+} {
+	return { customType: ASIDE_TYPE, content, display: false };
+}
+
+function isExtensionAside(message: AgentMessage): boolean {
+	return message.role === "custom" && (message as { customType?: string }).customType === ASIDE_TYPE;
+}
+
+function asideContent(message: AgentMessage): string | undefined {
+	if (!isExtensionAside(message)) return undefined;
+	const content = (message as CustomMessage).content;
+	return typeof content === "string" ? content : undefined;
+}
+
+describe("AgentSession extension deliverAs aside", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	const authStorages: AuthStorage[] = [];
+	let asideProvider: (() => AsideMessage[] | Promise<AsideMessage[]>) | undefined;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-extension-aside-");
+		asideProvider = undefined;
+	});
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			for (const authStorage of authStorages.splice(0)) authStorage.close();
+			await Bun.sleep(0);
+			await tempDir?.remove();
+			vi.restoreAllMocks();
+		}
+	});
+
+	function captureAsideProvider(agent: Agent): void {
+		asideProvider = undefined;
+		const originalSet = agent.setAsideMessageProvider.bind(agent);
+		agent.setAsideMessageProvider = (fn): void => {
+			if (fn !== undefined && asideProvider === undefined) asideProvider = fn;
+			originalSet(fn);
+		};
+	}
+
+	async function drainExtensionAsides(): Promise<CustomMessage[]> {
+		if (!asideProvider) throw new Error("aside provider was never captured");
+		const thunks = await asideProvider();
+		const out: CustomMessage[] = [];
+		for (const entry of thunks) {
+			const message = typeof entry === "function" ? entry() : entry;
+			if (!message) continue;
+			if (message.role !== "custom") continue;
+			if ((message as CustomMessage).customType !== ASIDE_TYPE) continue;
+			out.push(message as CustomMessage);
+		}
+		return out;
+	}
+
+	function capturePersistedAsides(sessionManager: SessionManager): string[] {
+		const persisted: string[] = [];
+		sessionManager.onEntryAppended = entry => {
+			if (entry.type === "custom_message" && entry.customType === ASIDE_TYPE) {
+				persisted.push(typeof entry.content === "string" ? entry.content : JSON.stringify(entry.content));
+			}
+		};
+		return persisted;
+	}
+
+	async function createMockSession(
+		responses: MockResponse[],
+	): Promise<{ session: AgentSession; sessionManager: SessionManager; mock: MockModel }> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ responses });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		captureAsideProvider(agent);
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const mockSession = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		session = mockSession;
+		return { session: mockSession, sessionManager, mock };
+	}
+
+	async function createIdleSession(): Promise<{ session: AgentSession; sessionManager: SessionManager }> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		captureAsideProvider(agent);
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const idleSession = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		session = idleSession;
+		return { session: idleSession, sessionManager };
+	}
+
+	async function createParkedSession(
+		tailResponses: MockResponse[] = [],
+		sessionManager: SessionManager = SessionManager.inMemory(),
+	): Promise<ParkedHarness> {
+		const started = Promise.withResolvers<void>();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				...tailResponses,
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		captureAsideProvider(agent);
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		return { session, sessionManager, mock, streamStarted: started.promise };
+	}
+
+	function readYieldResultData(result: unknown): unknown {
+		if (!result || typeof result !== "object" || !("data" in result)) return undefined;
+		return result.data;
+	}
+
+	function isYieldType(value: unknown): value is string | string[] {
+		return (
+			typeof value === "string" ||
+			(Array.isArray(value) && value.length > 0 && value.every(item => typeof item === "string"))
+		);
+	}
+
+	function userMessageText(messages: AgentMessage[]): string[] {
+		const out: string[] = [];
+		for (const message of messages) {
+			if (message.role !== "user") continue;
+			const content = message.content;
+			if (typeof content === "string") {
+				out.push(content);
+			} else {
+				for (const part of content) if (part.type === "text") out.push(part.text);
+			}
+		}
+		return out;
+	}
+
+	function createMockYieldTool(opts?: {
+		onExecute?: () => void;
+		gate?: Promise<void>;
+	}): AgentTool<typeof mockYieldParameters, MockYieldDetails> {
+		return {
+			name: "work",
+			label: "Work",
+			description: "Mock non-terminal work tool",
+			parameters: mockYieldParameters,
+			execute: async (_toolCallId, params) => {
+				opts?.onExecute?.();
+				if (opts?.gate) await opts.gate;
+				const details: MockYieldDetails = { status: "success", data: readYieldResultData(params.result) };
+				if (isYieldType(params.type)) details.type = params.type;
+				return {
+					content: [{ type: "text", text: "Result submitted." }],
+					details,
+				};
+			},
+		};
+	}
+
+	function createWorkMockResponse(args: { result: { data: unknown }; type?: string | string[] }): MockResponse {
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: `call_work_${Snowflake.next()}`,
+			name: "work",
+			arguments: args,
+		};
+		return {
+			content: [toolCall],
+			stopReason: "toolUse",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		};
+	}
+
+	async function createToolCycleSession(opts: {
+		toolGate?: Promise<void>;
+		onToolExecute?: () => void;
+	}): Promise<{ session: AgentSession; sessionManager: SessionManager; mock: MockModel; toolStarted: Promise<void> }> {
+		const toolStarted = Promise.withResolvers<void>();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [
+				createWorkMockResponse({ result: { data: { ok: true } } }),
+				{ content: ["done after aside fold"], stopReason: "stop" },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [
+					createMockYieldTool({
+						onExecute: () => {
+							toolStarted.resolve();
+							opts.onToolExecute?.();
+						},
+						gate: opts.toolGate,
+					}),
+				],
+			},
+			streamFn: mock.stream,
+		});
+		captureAsideProvider(agent);
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		return { session, sessionManager, mock, toolStarted: toolStarted.promise };
+	}
+
+	it("queues a streaming aside without steering, following up, or waking prompt (case 1)", async () => {
+		const { session: idleSession } = await createIdleSession();
+		const promptSpy = vi.spyOn(idleSession.agent, "prompt").mockResolvedValue(undefined);
+		const steerSpy = vi.spyOn(idleSession.agent, "steer");
+		const followUpSpy = vi.spyOn(idleSession.agent, "followUp");
+		Object.defineProperty(idleSession, "isStreaming", { value: true, configurable: true });
+
+		await idleSession.sendCustomMessage(asidePayload("busy-path note"), { deliverAs: "aside" });
+
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(steerSpy).not.toHaveBeenCalled();
+		expect(followUpSpy).not.toHaveBeenCalled();
+		expect(idleSession.agent.peekSteeringQueue()).toEqual([]);
+		expect(idleSession.agent.peekFollowUpQueue()).toEqual([]);
+		expect(await idleSession.agent.hasIrcInterrupts?.()).toBe(false);
+
+		const drained = await drainExtensionAsides();
+		expect(drained).toHaveLength(1);
+		expect(asideContent(drained[0]!)).toBe("busy-path note");
+		expect(idleSession.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+	});
+
+	it("ignores triggerTurn while streaming and keeps the aside on the provider drain (case 1b)", async () => {
+		const { session: parked, streamStarted } = await createParkedSession();
+		const promptSpy = vi.spyOn(parked.agent, "prompt");
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("mid-turn aside"), {
+			deliverAs: "aside",
+			triggerTurn: true,
+		});
+
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(parked.agent.peekSteeringQueue()).toEqual([]);
+		expect(parked.agent.peekFollowUpQueue()).toEqual([]);
+		const drained = await drainExtensionAsides();
+		expect(drained.map(message => asideContent(message))).toEqual(["mid-turn aside"]);
+
+		await parked.abort();
+		await parked.waitForIdle();
+		await running.catch(() => {});
+	});
+
+	it("folds a queued aside at a stop yield boundary without steering (case 3)", async () => {
+		const { session: stopSession, mock } = await createMockSession([
+			{ content: ["first answer"], stopReason: "stop" },
+			{ content: ["continued after aside"] },
+		]);
+		const steerSpy = vi.spyOn(stopSession.agent, "steer");
+
+		let streamingAtInject: boolean | undefined;
+		let injected = false;
+		stopSession.agent.setOnBeforeYield(async () => {
+			if (injected) return;
+			injected = true;
+			streamingAtInject = stopSession.isStreaming;
+			await stopSession.sendCustomMessage(asidePayload("stop boundary aside"), { deliverAs: "aside" });
+		});
+
+		await stopSession.prompt("hello");
+
+		expect(streamingAtInject).toBe(true);
+		expect(mock.calls.length).toBe(2);
+		expect(steerSpy).not.toHaveBeenCalled();
+		expect(stopSession.agent.peekSteeringQueue()).toEqual([]);
+		expect(stopSession.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toContain(
+			"stop boundary aside",
+		);
+	});
+
+	it("folds a queued aside into context at a step boundary without steering or aborting tools (case 2)", async () => {
+		const toolGate = Promise.withResolvers<void>();
+		const { session: toolSession, mock, toolStarted } = await createToolCycleSession({ toolGate: toolGate.promise });
+		const steerSpy = vi.spyOn(toolSession.agent, "steer");
+		const abortSpy = vi.spyOn(toolSession.agent, "abort");
+
+		const running = toolSession.prompt("run the yield tool");
+		await toolStarted;
+		await toolSession.sendCustomMessage(asidePayload("fold at boundary"), { deliverAs: "aside" });
+		expect(steerSpy).not.toHaveBeenCalled();
+		expect(abortSpy).not.toHaveBeenCalled();
+
+		toolGate.resolve();
+		await running;
+		await toolSession.waitForIdle();
+
+		expect(mock.calls.length).toBe(2);
+		expect(toolSession.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toContain(
+			"fold at boundary",
+		);
+	});
+
+	it("appends and persists an idle aside without starting a turn (case 4)", async () => {
+		const { session: idleSession, sessionManager } = await createIdleSession();
+		const persisted = capturePersistedAsides(sessionManager);
+		const promptSpy = vi.spyOn(idleSession.agent, "prompt").mockResolvedValue(undefined);
+
+		await idleSession.sendCustomMessage(asidePayload("idle context"), { deliverAs: "aside" });
+
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(idleSession.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"idle context",
+		]);
+		expect(persisted).toEqual(["idle context"]);
+		expect(await drainExtensionAsides()).toEqual([]);
+	});
+
+	it("starts a turn when idle aside is sent with triggerTurn (case 5)", async () => {
+		const { session: idleSession } = await createIdleSession();
+		const promptSpy = vi.spyOn(idleSession.agent, "prompt").mockResolvedValue(undefined);
+
+		const started = await idleSession.sendCustomMessage(asidePayload("wake me"), {
+			deliverAs: "aside",
+			triggerTurn: true,
+		});
+
+		expect(started).toBe(true);
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		const promptedArg = promptSpy.mock.calls[0]?.[0];
+		const prompted = Array.isArray(promptedArg) ? promptedArg[0] : promptedArg;
+		expect(prompted && typeof prompted === "object" && "role" in prompted ? prompted.role : undefined).toBe("custom");
+		if (prompted && typeof prompted === "object" && "role" in prompted && prompted.role === "custom") {
+			expect(prompted.customType).toBe(ASIDE_TYPE);
+			expect(asideContent(prompted)).toBe("wake me");
+		}
+	});
+
+	it("flushes a stranded streaming aside into context without waking prompt (case 6)", async () => {
+		const { session: parked, sessionManager, mock, streamStarted } = await createParkedSession();
+		const persisted = capturePersistedAsides(sessionManager);
+		const promptSpy = vi.spyOn(parked.agent, "prompt");
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("stranded aside"), { deliverAs: "aside" });
+		await parked.abort({ reason: USER_INTERRUPT_LABEL });
+		await parked.waitForIdle();
+		await running.catch(() => {});
+
+		expect(parked.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"stranded aside",
+		]);
+		expect(persisted).toEqual(["stranded aside"]);
+		expect(
+			sessionManager.getEntries().some(entry => entry.type === "custom_message" && entry.customType === ASIDE_TYPE),
+		).toBe(true);
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(mock.calls.length).toBe(1);
+	});
+
+	it("flushes a pending aside after Esc settle without waking (case 7)", async () => {
+		const { session: parked, mock, streamStarted } = await createParkedSession();
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("survives interrupt"), { deliverAs: "aside" });
+		await parked.abort({ reason: USER_INTERRUPT_LABEL });
+		await parked.waitForIdle();
+		await running.catch(() => {});
+
+		expect(parked.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"survives interrupt",
+		]);
+		expect(mock.calls.length).toBe(1);
+	});
+
+	it("still flushes a stranded aside when a follow-up is queued (case 8)", async () => {
+		const { session: parked, mock, streamStarted } = await createParkedSession();
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.prompt("then add the test", { streamingBehavior: "followUp" });
+		await parked.sendCustomMessage(asidePayload("independent aside"), { deliverAs: "aside" });
+		await parked.abort({ reason: USER_INTERRUPT_LABEL });
+		await parked.waitForIdle();
+		await running.catch(() => {});
+
+		expect(parked.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"independent aside",
+		]);
+		expect(userMessageText([...parked.agent.peekFollowUpQueue()])).toContain("then add the test");
+		expect(mock.calls.length).toBe(1);
+	});
+
+	it("drops pending asides on newSession without flushing into the fresh transcript (case 9)", async () => {
+		const { session: parked, sessionManager, streamStarted } = await createParkedSession();
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("must not survive /new"), { deliverAs: "aside" });
+		expect(parked.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+
+		await parked.newSession();
+		await parked.waitForIdle();
+		await running.catch(() => {});
+
+		expect(parked.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(
+			sessionManager.getEntries().some(entry => entry.type === "custom_message" && entry.customType === ASIDE_TYPE),
+		).toBe(false);
+	});
+
+	it("queues an idle aside while compacting instead of appending immediately", async () => {
+		const { session: idleSession } = await createIdleSession();
+		let compacting = true;
+		Object.defineProperty(idleSession, "isCompacting", { get: () => compacting, configurable: true });
+
+		await idleSession.sendCustomMessage(asidePayload("compacting queued"), { deliverAs: "aside" });
+
+		expect(idleSession.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		const drained = await drainExtensionAsides();
+		expect(drained.map(message => asideContent(message))).toEqual(["compacting queued"]);
+
+		compacting = false;
+		await idleSession.sendCustomMessage(asidePayload("idle after compacting"), { deliverAs: "aside" });
+		expect(idleSession.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"idle after compacting",
+		]);
+	});
+
+	it("drops pending asides on fork without flushing into the forked transcript (case 9c)", async () => {
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const { session: parked, streamStarted } = await createParkedSession([], sessionManager);
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("must not survive fork"), { deliverAs: "aside" });
+		expect(parked.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+
+		const forked = await parked.fork();
+		expect(forked).toBe(true);
+		await parked.abort();
+		await parked.waitForIdle();
+		await running.catch(() => {});
+
+		expect(parked.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(
+			sessionManager.getEntries().some(entry => entry.type === "custom_message" && entry.customType === ASIDE_TYPE),
+		).toBe(false);
+	});
+
+	it("drops pending asides on switchSession without flushing into the target transcript (case 9b)", async () => {
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		captureAsideProvider(agent);
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const active = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+		session = active;
+
+		sessionManager.appendMessage({ role: "user", content: "previous", timestamp: 1 });
+		await sessionManager.flush();
+		const previousSessionFile = sessionManager.getSessionFile();
+		if (!previousSessionFile) throw new Error("expected a session file after seed message");
+
+		const otherManager = SessionManager.create(tempDir.path(), tempDir.path());
+		otherManager.appendMessage({ role: "user", content: "target", timestamp: 2 });
+		await otherManager.flush();
+		const targetSessionFile = otherManager.getSessionFile();
+		if (!targetSessionFile) throw new Error("expected target session file");
+		await otherManager.close();
+
+		Object.defineProperty(active, "isStreaming", { value: true, configurable: true });
+		await active.sendCustomMessage(asidePayload("must not leak on switch"), { deliverAs: "aside" });
+
+		const switched = await active.switchSession(targetSessionFile);
+		expect(switched).toBe(true);
+		await active.waitForIdle();
+
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(
+			sessionManager.getEntries().some(entry => entry.type === "custom_message" && entry.customType === ASIDE_TYPE),
+		).toBe(false);
+	});
+
+	it("flushes a pending aside on beginDispose instead of dropping it (case 10)", async () => {
+		const { session: parked, streamStarted } = await createParkedSession();
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("dispose flush"), { deliverAs: "aside" });
+		parked.beginDispose();
+
+		expect(parked.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"dispose flush",
+		]);
+		running.catch(() => {});
+	});
+});

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -6,7 +6,14 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
-import { Agent, type AgentMessage, type AgentTool, type AsideMessage } from "@oh-my-pi/pi-agent-core";
+import {
+	Agent,
+	type AgentMessage,
+	type AgentTool,
+	ASIDE_MESSAGE_DISCARD,
+	type AsideMessage,
+	type CommittableAsideMessage,
+} from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { ToolCall } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
@@ -56,6 +63,16 @@ function asideContent(message: AgentMessage): string | undefined {
 	if (!isExtensionAside(message)) return undefined;
 	const content = (message as CustomMessage).content;
 	return typeof content === "string" ? content : undefined;
+}
+
+function takeDrainedExtensionAside(thunks: AsideMessage[]): CommittableAsideMessage {
+	for (const entry of thunks) {
+		const message = typeof entry === "function" ? entry() : entry;
+		if (message?.role === "custom" && (message as CustomMessage).customType === ASIDE_TYPE) {
+			return message;
+		}
+	}
+	throw new Error("expected a drained extension aside");
 }
 
 describe("AgentSession extension deliverAs aside", () => {
@@ -707,5 +724,28 @@ describe("AgentSession extension deliverAs aside", () => {
 			"dispose flush",
 		]);
 		running.catch(() => {});
+	});
+
+	it("persists a drained-but-uncommitted aside on DISCARD without waking (case 11)", async () => {
+		const { session: active, sessionManager } = await createIdleSession();
+		const persisted = capturePersistedAsides(sessionManager);
+		const promptSpy = vi.spyOn(active.agent, "prompt");
+		Object.defineProperty(active, "isStreaming", { value: true, configurable: true });
+
+		await active.sendCustomMessage(asidePayload("polled then discarded"), { deliverAs: "aside" });
+
+		if (!asideProvider) throw new Error("aside provider was never captured");
+		const extensionMessage = takeDrainedExtensionAside(await asideProvider());
+		extensionMessage[ASIDE_MESSAGE_DISCARD]?.(
+			new Error("Aside message was not committed before the agent loop ended"),
+		);
+		await Bun.sleep(0);
+
+		expect(active.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toEqual([
+			"polled then discarded",
+		]);
+		expect(persisted).toEqual(["polled then discarded"]);
+		expect(await drainExtensionAsides()).toEqual([]);
+		expect(promptSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -22,8 +22,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { type CustomMessage, convertToLlm, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
 
@@ -139,6 +138,7 @@ describe("AgentSession extension deliverAs aside", () => {
 			getApiKey: () => "test-key",
 			initialState: { model, systemPrompt: ["Test"], tools: [] },
 			streamFn: mock.stream,
+			convertToLlm,
 		});
 		captureAsideProvider(agent);
 		const sessionManager = SessionManager.inMemory();
@@ -481,22 +481,18 @@ describe("AgentSession extension deliverAs aside", () => {
 		const { session: stopSession, mock } = await createMockSession([
 			{ content: ["first answer"], stopReason: "stop" },
 			{ content: ["continued after follow-up"] },
-			{ content: ["folded aside"] },
 		]);
 
 		let injected = false;
+		let allowAsideDrain = false;
 		stopSession.agent.setOnBeforeYield(async () => {
 			if (injected) return;
 			injected = true;
 			await stopSession.sendCustomMessage(asidePayload("settle aside"), { deliverAs: "aside" });
 			const inner = asideProvider;
 			if (!inner) throw new Error("aside provider was never captured");
-			let skippedYieldPoll = false;
 			stopSession.agent.setAsideMessageProvider(() => {
-				if (!skippedYieldPoll) {
-					skippedYieldPoll = true;
-					return [];
-				}
+				if (!allowAsideDrain) return [];
 				return inner();
 			});
 		});
@@ -507,6 +503,7 @@ describe("AgentSession extension deliverAs aside", () => {
 			if (event.type !== "agent_end") return;
 			agentEnds += 1;
 			if (agentEnds === 1) {
+				allowAsideDrain = true;
 				stopSession.agent.followUp({
 					role: "user",
 					content: [{ type: "text", text: "then add the test" }],
@@ -522,12 +519,21 @@ describe("AgentSession extension deliverAs aside", () => {
 		await resumed.promise;
 		await stopSession.waitForIdle();
 
-		expect(mock.calls.length).toBeGreaterThanOrEqual(2);
-		expect(userMessageText(stopSession.agent.state.messages)).toContain("then add the test");
+		expect(mock.calls.length).toBe(2);
+		const continuationText = JSON.stringify(mock.calls[1].context.messages);
+		expect(continuationText).toContain("settle aside");
+		expect(continuationText).toContain("then add the test");
+		const messages = stopSession.agent.state.messages;
+		const asideIndex = messages.findIndex(message => asideContent(message) === "settle aside");
+		const followUpIndex = messages.findIndex(message => {
+			if (message.role !== "user") return false;
+			const content = message.content;
+			if (typeof content === "string") return content === "then add the test";
+			return content.some(part => part.type === "text" && part.text === "then add the test");
+		});
+		expect(asideIndex).toBeGreaterThanOrEqual(0);
+		expect(followUpIndex).toBeGreaterThan(asideIndex);
 		expect(userMessageText([...stopSession.agent.peekFollowUpQueue()])).not.toContain("then add the test");
-		expect(stopSession.agent.state.messages.filter(isExtensionAside).map(message => asideContent(message))).toContain(
-			"settle aside",
-		);
 	});
 
 	it("still flushes a stranded aside when a follow-up is queued (case 8)", async () => {

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -576,6 +576,22 @@ describe("AgentSession extension deliverAs aside", () => {
 		).toBe(false);
 	});
 
+	it("restores pending asides when switchSession rolls back after clear (case 9d)", async () => {
+		const { session: active, sessionManager } = await createIdleSession();
+		Object.defineProperty(active, "isStreaming", { value: true, configurable: true });
+		await active.sendCustomMessage(asidePayload("survive rollback"), { deliverAs: "aside" });
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+
+		const failure = new Error("switch failed");
+		vi.spyOn(sessionManager, "setSessionFile").mockRejectedValueOnce(failure);
+
+		await expect(active.switchSession(tempDir.join("missing-target.jsonl"))).rejects.toBe(failure);
+
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		const drained = await drainExtensionAsides();
+		expect(drained.map(message => asideContent(message))).toEqual(["survive rollback"]);
+	});
+
 	it("flushes a pending aside on beginDispose instead of dropping it (case 10)", async () => {
 		const { session: parked, streamStarted } = await createParkedSession();
 		const running = parked.prompt("do work");

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -360,15 +360,14 @@ describe("AgentSession extension deliverAs aside", () => {
 		const enteredNormalize = Promise.withResolvers<void>();
 		let delayNormalize = false;
 		const original = SessionProviderBoundary.prototype.normalizeAgentMessageImages;
-		vi.spyOn(SessionProviderBoundary.prototype, "normalizeAgentMessageImages").mockImplementation(async function (
-			this: SessionProviderBoundary,
-			message,
-		) {
+		vi.spyOn(SessionProviderBoundary.prototype, "normalizeAgentMessageImages").mockImplementation(async function <
+			T extends AgentMessage,
+		>(this: SessionProviderBoundary, message: T): Promise<T> {
 			if (delayNormalize) {
 				enteredNormalize.resolve();
 				await normalizeGate.promise;
 			}
-			return original.call(this, message);
+			return original.call(this, message) as Promise<T>;
 		});
 
 		const { session: parked, streamStarted } = await createParkedSession();

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -24,6 +24,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { type CustomMessage, convertToLlm, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { SessionProviderBoundary } from "@oh-my-pi/pi-coding-agent/session/session-provider-boundary";
 import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
 
 const ASIDE_TYPE = "extension-aside-test";
@@ -351,6 +352,45 @@ describe("AgentSession extension deliverAs aside", () => {
 
 		await parked.abort();
 		await parked.waitForIdle();
+		await running.catch(() => {});
+	});
+
+	it("ignores triggerTurn when the turn settles during aside image normalize (case 1c)", async () => {
+		const normalizeGate = Promise.withResolvers<void>();
+		const enteredNormalize = Promise.withResolvers<void>();
+		let delayNormalize = false;
+		const original = SessionProviderBoundary.prototype.normalizeAgentMessageImages;
+		vi.spyOn(SessionProviderBoundary.prototype, "normalizeAgentMessageImages").mockImplementation(async function (
+			this: SessionProviderBoundary,
+			message,
+		) {
+			if (delayNormalize) {
+				enteredNormalize.resolve();
+				await normalizeGate.promise;
+			}
+			return original.call(this, message);
+		});
+
+		const { session: parked, streamStarted } = await createParkedSession();
+		const promptSpy = vi.spyOn(parked.agent, "prompt");
+		const running = parked.prompt("do work");
+		await streamStarted;
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+
+		delayNormalize = true;
+		const sendPromise = parked.sendCustomMessage(asidePayload("late aside"), {
+			deliverAs: "aside",
+			triggerTurn: true,
+		});
+		await enteredNormalize.promise;
+		await parked.abort();
+		await parked.waitForIdle();
+		normalizeGate.resolve();
+		await sendPromise;
+
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(parked.agent.state.messages.filter(isExtensionAside).map(asideContent)).toContain("late aside");
+
 		await running.catch(() => {});
 	});
 

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -534,6 +534,24 @@ describe("AgentSession extension deliverAs aside", () => {
 		).toBe(false);
 	});
 
+	it("preserves pending asides when fork returns false without persisting (case 9e)", async () => {
+		const { session: parked, streamStarted } = await createParkedSession();
+		const running = parked.prompt("do work");
+		await streamStarted;
+
+		await parked.sendCustomMessage(asidePayload("survive failed fork"), { deliverAs: "aside" });
+		expect(parked.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+
+		expect(await parked.fork()).toBe(false);
+
+		const drained = await drainExtensionAsides();
+		expect(drained.map(message => asideContent(message))).toEqual(["survive failed fork"]);
+
+		await parked.abort();
+		await parked.waitForIdle();
+		await running.catch(() => {});
+	});
+
 	it("drops pending asides on switchSession without flushing into the target transcript (case 9b)", async () => {
 		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool, type AsideMessage } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { ToolCall } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -651,6 +652,47 @@ describe("AgentSession extension deliverAs aside", () => {
 		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
 		const drained = await drainExtensionAsides();
 		expect(drained.map(message => asideContent(message))).toEqual(["survive rollback"]);
+	});
+
+	function seedHandoffMessages(sessionManager: SessionManager): void {
+		sessionManager.appendMessage({ role: "user", content: "seed", timestamp: 1 });
+		sessionManager.appendMessage({ role: "user", content: "seed-2", timestamp: 2 });
+	}
+
+	it("drops pending asides on successful handoff without flushing into the replacement transcript (case 9g)", async () => {
+		const { session: active, sessionManager } = await createIdleSession();
+		seedHandoffMessages(sessionManager);
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockResolvedValue("## Goal\nContinue");
+
+		Object.defineProperty(active, "isCompacting", { value: true, configurable: true });
+		await active.sendCustomMessage(asidePayload("must not leak on handoff"), { deliverAs: "aside" });
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+
+		const result = await active.handoff();
+		expect(result?.document).toBe("## Goal\nContinue");
+
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(await drainExtensionAsides()).toEqual([]);
+		expect(
+			sessionManager.getEntries().some(entry => entry.type === "custom_message" && entry.customType === ASIDE_TYPE),
+		).toBe(false);
+	});
+
+	it("preserves pending asides when handoff is cancelled before the replacement session commits (case 9h)", async () => {
+		const { session: active, sessionManager } = await createIdleSession();
+		seedHandoffMessages(sessionManager);
+
+		Object.defineProperty(active, "isCompacting", { value: true, configurable: true });
+		await active.sendCustomMessage(asidePayload("survive cancelled handoff"), { deliverAs: "aside" });
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+
+		const controller = new AbortController();
+		controller.abort();
+		await expect(active.handoff(undefined, { signal: controller.signal })).rejects.toThrow("Handoff cancelled");
+
+		expect(active.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		const drained = await drainExtensionAsides();
+		expect(drained.map(message => asideContent(message))).toEqual(["survive cancelled handoff"]);
 	});
 
 	it("flushes a pending aside on beginDispose instead of dropping it (case 10)", async () => {

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -5,6 +5,7 @@
  * provider, and flush stranded content without waking (unlike peer IRC).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool, type AsideMessage } from "@oh-my-pi/pi-agent-core";
 import type { ToolCall } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
@@ -17,7 +18,6 @@ import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
-import { type } from "arktype";
 
 const ASIDE_TYPE = "extension-aside-test";
 
@@ -29,8 +29,8 @@ interface ParkedHarness {
 }
 
 const mockYieldParameters = type({
-	result: "unknown",
-	"type?": "unknown",
+	result: type("unknown"),
+	"type?": type("unknown"),
 });
 
 interface MockYieldDetails {

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -758,6 +758,18 @@ describe("AgentSession extension deliverAs aside", () => {
 	function seedHandoffMessages(sessionManager: SessionManager): void {
 		sessionManager.appendMessage({ role: "user", content: "seed", timestamp: 1 });
 		sessionManager.appendMessage({ role: "user", content: "seed-2", timestamp: 2 });
+		const lastEntryId = sessionManager.getBranch().at(-1)?.id;
+		if (!lastEntryId) throw new Error("expected seeded entry id");
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue({
+			firstKeptEntryId: lastEntryId,
+			messagesToSummarize: [{ role: "user", content: [{ type: "text", text: "old" }], timestamp: 1 }],
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: compactionModule.DEFAULT_COMPACTION_SETTINGS,
+		});
 	}
 
 	it("drops pending asides on successful handoff without flushing into the replacement transcript (case 9g)", async () => {

--- a/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts
@@ -566,6 +566,31 @@ describe("AgentSession extension deliverAs aside", () => {
 		).toBe(false);
 	});
 
+	it("drops pending asides on resetSessionContext without flushing into the cleared transcript (case 9i)", async () => {
+		const {
+			session: idleSession,
+			sessionManager,
+			mock,
+		} = await createMockSession([{ content: ["fresh after clear"] }]);
+		Object.defineProperty(idleSession, "isStreaming", { value: true, configurable: true });
+		await idleSession.sendCustomMessage(asidePayload("must not survive /clear"), { deliverAs: "aside" });
+		expect(idleSession.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		delete (idleSession as { isStreaming?: boolean }).isStreaming;
+
+		const result = await idleSession.resetSessionContext();
+		expect(result).toBeDefined();
+		expect(await drainExtensionAsides()).toEqual([]);
+		expect(idleSession.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(
+			sessionManager.getEntries().some(entry => entry.type === "custom_message" && entry.customType === ASIDE_TYPE),
+		).toBe(false);
+
+		await idleSession.prompt("fresh");
+		await idleSession.waitForIdle();
+		expect(idleSession.agent.state.messages.filter(isExtensionAside)).toEqual([]);
+		expect(mock.calls.length).toBe(1);
+	});
+
 	it("queues an idle aside while compacting instead of appending immediately", async () => {
 		const { session: idleSession } = await createIdleSession();
 		let compacting = true;

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -4,7 +4,7 @@ import {
 	reportLocalOnlyPromptResult,
 	watchAndReportLocalOnlyPromptResult,
 } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
-import type { ExtensionActions } from "../src/extensibility/extensions/types";
+import type { CustomMessageDeliverAs, ExtensionActions } from "../src/extensibility/extensions/types";
 import { initializeExtensions } from "../src/modes/runtime-init";
 import type { AgentSession } from "../src/session/agent-session";
 
@@ -30,11 +30,16 @@ const triggerTurnCustomMessage = {
 	attribution: "agent",
 } as const;
 
-async function reportTriggerTurnCustomMessage(sendResult: boolean, id: string): Promise<object[]> {
+async function reportTriggerTurnCustomMessage(
+	sendResult: boolean,
+	id: string,
+	options?: { deliverAs?: CustomMessageDeliverAs; isStreaming?: boolean },
+): Promise<object[]> {
 	let extensionActions: ExtensionActions | undefined;
 	const output: object[] = [];
 	const extensionUserMessages = new RpcExtensionUserMessageTracker();
 	const session = {
+		isStreaming: options?.isStreaming === true,
 		extensionRunner: {
 			initialize: (actions: ExtensionActions) => {
 				extensionActions = actions;
@@ -52,14 +57,17 @@ async function reportTriggerTurnCustomMessage(sendResult: boolean, id: string): 
 		reportRuntimeError: error => {
 			throw error.error;
 		},
-		trackAgentInvokingMessage: task => {
-			extensionUserMessages.trackAgentMessageTask(task);
+		trackAgentInvokingMessage: (task, hint) => {
+			extensionUserMessages.trackAgentMessageTask(task, hint);
 		},
 	});
 
 	const trackedPrompt = extensionUserMessages.watchPrompt(() => {
 		if (!extensionActions) throw new Error("extensions not initialized");
-		extensionActions.sendMessage(triggerTurnCustomMessage, { triggerTurn: true, deliverAs: "aside" });
+		extensionActions.sendMessage(triggerTurnCustomMessage, {
+			triggerTurn: true,
+			deliverAs: options?.deliverAs ?? "aside",
+		});
 		return Promise.resolve(false);
 	});
 	reportLocalOnlyPromptResult({
@@ -206,6 +214,14 @@ describe("reportLocalOnlyPromptResult", () => {
 	test("emits prompt_result when triggerTurn sendCustomMessage resolves false", async () => {
 		const output = await reportTriggerTurnCustomMessage(false, "req_parked_aside");
 		expect(output).toEqual([{ type: "prompt_result", id: "req_parked_aside", agentInvoked: false }]);
+	});
+
+	test("suppresses prompt_result when triggerTurn nextTurn sendCustomMessage resolves false while streaming", async () => {
+		const output = await reportTriggerTurnCustomMessage(false, "req_next_turn", {
+			deliverAs: "nextTurn",
+			isStreaming: true,
+		});
+		expect(output).toEqual([]);
 	});
 
 	test("suppresses prompt_result when triggerTurn sendCustomMessage resolves true", async () => {

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -23,6 +23,59 @@ async function waitForTrackedPromptHandlers(trackedPrompt: {
 	await Promise.resolve();
 }
 
+const triggerTurnCustomMessage = {
+	customType: "test",
+	content: "aside",
+	display: false,
+	attribution: "agent",
+} as const;
+
+async function reportTriggerTurnCustomMessage(sendResult: boolean, id: string): Promise<object[]> {
+	let extensionActions: ExtensionActions | undefined;
+	const output: object[] = [];
+	const extensionUserMessages = new RpcExtensionUserMessageTracker();
+	const session = {
+		extensionRunner: {
+			initialize: (actions: ExtensionActions) => {
+				extensionActions = actions;
+			},
+			onError: () => {},
+			emit: async () => {},
+		},
+		sendCustomMessage: async () => sendResult,
+	} as unknown as AgentSession;
+
+	await initializeExtensions(session, {
+		reportSendError: (_action, error) => {
+			throw error;
+		},
+		reportRuntimeError: error => {
+			throw error.error;
+		},
+		trackAgentInvokingMessage: task => {
+			extensionUserMessages.trackAgentMessageTask(task);
+		},
+	});
+
+	const trackedPrompt = extensionUserMessages.watchPrompt(() => {
+		if (!extensionActions) throw new Error("extensions not initialized");
+		extensionActions.sendMessage(triggerTurnCustomMessage, { triggerTurn: true, deliverAs: "aside" });
+		return Promise.resolve(false);
+	});
+	reportLocalOnlyPromptResult({
+		id,
+		prompt: trackedPrompt.prompt,
+		output: frame => output.push(frame),
+		onError: error => {
+			throw error;
+		},
+		hasExtensionAgentMessageTask: trackedPrompt.hasAgentMessageTask,
+		waitForExtensionAgentMessageTasks: trackedPrompt.waitForAgentMessageTasks,
+	});
+	await waitForTrackedPromptHandlers(trackedPrompt);
+	return output;
+}
+
 describe("reportLocalOnlyPromptResult", () => {
 	test("emits prompt_result when prompt resolves without invoking the agent or extension user message", async () => {
 		const output: object[] = [];
@@ -148,6 +201,16 @@ describe("reportLocalOnlyPromptResult", () => {
 
 		expect(markCount).toBe(1);
 		expect(sentOptions).toEqual({ triggerTurn: true });
+	});
+
+	test("emits prompt_result when triggerTurn sendCustomMessage resolves false", async () => {
+		const output = await reportTriggerTurnCustomMessage(false, "req_parked_aside");
+		expect(output).toEqual([{ type: "prompt_result", id: "req_parked_aside", agentInvoked: false }]);
+	});
+
+	test("suppresses prompt_result when triggerTurn sendCustomMessage resolves true", async () => {
+		const output = await reportTriggerTurnCustomMessage(true, "req_aside_turn");
+		expect(output).toEqual([]);
 	});
 
 	test("suppresses prompt_result when extension sendUserMessage succeeds", async () => {

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -224,6 +224,62 @@ describe("reportLocalOnlyPromptResult", () => {
 		expect(output).toEqual([]);
 	});
 
+	test("suppresses prompt_result when triggerTurn nextTurn send becomes streaming during sendCustomMessage", async () => {
+		let extensionActions: ExtensionActions | undefined;
+		const output: object[] = [];
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		let streaming = false;
+		const session = {
+			get isStreaming() {
+				return streaming;
+			},
+			extensionRunner: {
+				initialize: (actions: ExtensionActions) => {
+					extensionActions = actions;
+				},
+				onError: () => {},
+				emit: async () => {},
+			},
+			sendCustomMessage: async () => {
+				streaming = true;
+				return false;
+			},
+		} as unknown as AgentSession;
+
+		await initializeExtensions(session, {
+			reportSendError: (_action, error) => {
+				throw error;
+			},
+			reportRuntimeError: error => {
+				throw error.error;
+			},
+			trackAgentInvokingMessage: (task, hint) => {
+				extensionUserMessages.trackAgentMessageTask(task, hint);
+			},
+		});
+
+		const trackedPrompt = extensionUserMessages.watchPrompt(() => {
+			if (!extensionActions) throw new Error("extensions not initialized");
+			extensionActions.sendMessage(triggerTurnCustomMessage, {
+				triggerTurn: true,
+				deliverAs: "nextTurn",
+			});
+			return Promise.resolve(false);
+		});
+		reportLocalOnlyPromptResult({
+			id: "req_normalize_race",
+			prompt: trackedPrompt.prompt,
+			output: frame => output.push(frame),
+			onError: error => {
+				throw error;
+			},
+			hasExtensionAgentMessageTask: trackedPrompt.hasAgentMessageTask,
+			waitForExtensionAgentMessageTasks: trackedPrompt.waitForAgentMessageTasks,
+		});
+		await waitForTrackedPromptHandlers(trackedPrompt);
+		expect(output).toEqual([]);
+	});
+
 	test("suppresses prompt_result when triggerTurn sendCustomMessage resolves true", async () => {
 		const output = await reportTriggerTurnCustomMessage(true, "req_aside_turn");
 		expect(output).toEqual([]);


### PR DESCRIPTION
This is my PR and implementation of the prior suggested extensions expansion I received a vouch for.
I re-used much of the existing delivery code, hence why the actual implementation  is just around ~150 lines; 
the remaining bulk comes from the tests covering 14 cases, example and doc updates. 

## Summary
Adds `deliverAs: "aside"` to extension `pi.sendMessage` / `AgentSession.sendCustomMessage` so plugins can inject mid-turn context at the **next agent step boundary** without aborting tools or steering the stream.

Requested / discussed / received vouch in: https://github.com/can1357/oh-my-pi/discussions/6062

### Motivation
Extensions (notably multi-agent relays like **hcom**) often need to fold peer or background context into an in-flight turn while tools are still running. As is, the closest options are a poor fit:

- **`steer`** — interrupts tools and aborts the stream
- **`followUp`** — waits until the entire run finishes (no further tool calls)
- **`nextTurn`** — waits for the *user's* next prompt, not the next model step

`aside` fills that gap: non-interrupting, step-boundary inject while busy; idle append/persist (optional `triggerTurn`); stranded content flushes into context with **no autonomous wake**.

### Advantages / PoC
- Mid-turn context without canceling bash/tools or derailing the current plan
- Predictable lifecycle: queue while streaming/compacting/disconnected; drop on session new/switch/fork; flush on dispose / stranded settle
- Reuses the existing aside-provider / step-boundary injection path (same seam as IRC asides), with a **dedicated** extension queue so stranded semantics stay distinct (IRC may wake; extension asides do not)

**hcom PoC (consumer branch):** 
https://github.com/mmkzer0/hcom/commit/4657b1f1a21ebf9f01d14b8c05afc1602961b169  
Busy-path delivery uses `deliverAs: "aside"`; idle stays on the normal user-message path.

Validated end-to-end:
1. **omp ↔ omp** (recorded) — peer ping while the other was in a long `sleep` tool call: delivery over live tool context, tool completed, then step-boundary fold + reply
2. **omp ↔ opencode** (not recorded) — same busy-path delivery into an active omp session also worked

### Implementation size
Actual change is small (~types + docs + example + a focused `AgentSession` branch + shared persist-emit helper). Most of the diff is the contract test file.

Shared with IRC: `emitPersistedCustomMessages` for flush-via-`message_start`/`message_end`; provider drain order remains IRC → extension asides → yield queue.

### Tests
`packages/coding-agent/test/agent-session-extension-aside-delivery.test.ts` (14 cases) covers:

- Streaming queue without steer/followUp/wake; `triggerTurn` ignored mid-stream
- Fold at tool / stop-yield step boundaries without aborting tools
- Idle append+persist; idle `triggerTurn` starts a turn
- Stranded flush with no wake (including with a queued follow-up)
- Drop on `newSession` / `switchSession` / `fork`
- Queue while compacting; flush on `beginDispose`

### Verification

- [x] `bun run check` / `bun run lint` / format — green (`packages/coding-agent`)
- [x] Aside contract tests (14) + adjacent advisor session tests — pass
- Full `bun run test` (`coding-agent-heavy --full`) on this machine: 3 unrelated chunk failures (`omfg-controller` path wrap, `skills.test.ts` / `createAgentSession` manage_skill picking up host skills). None of those files are in this PR’s diff; I treated them as local env noise, not regressions from `aside`.

### Demo

https://github.com/user-attachments/assets/39d23852-880f-461f-832c-5966b14d07b7

hcom omp↔omp PoC video: busy-path `deliverAs: "aside"` against this branch + normal delivery both working