### PR TITLE
feat(slash): add /compact-edit to edit the compaction summary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/compact-edit` to open the current compaction summary in a text editor; the saved text becomes the summary used by subsequent turns, persisted so a resume keeps it ([#8281](https://github.com/can1357/oh-my-pi/issues/8281)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4566,6 +4566,24 @@ export class AgentSession {
 	}
 
 	/**
+	 * Rebuild the live agent context after an in-place compaction-summary edit.
+	 *
+	 * `updateLatestCompactionSummary` mutates the SessionManager entry, but the
+	 * running agent's `state.messages` still hold the CompactionSummaryMessage
+	 * built before the edit — without this, the next provider request replays
+	 * the original summary. Mirrors the post-compaction/prune rebuild
+	 * (`buildDisplaySessionContext` + `agent.replaceMessages`) and closes any
+	 * cached provider-session history so the edited text actually ships (#8281).
+	 */
+	rebuildContextAfterCompactionEdit(): void {
+		const sessionContext = this.buildDisplaySessionContext();
+		this.agent.replaceMessages(sessionContext.messages);
+		this.#advisors.resetSessionState({ preserveCost: true });
+		this.#todo.syncFromBranch();
+		this.#closeCodexProviderSessionsForHistoryRewrite();
+	}
+
+	/**
 	 * Transcript for TUI display. Full history is kept for export/resume-style
 	 * callers; live chat can collapse compacted history to keep the hot render
 	 * surface bounded. Display-only — NEVER feed the result to

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -31,7 +31,12 @@ import {
 	sanitizeRehydratedOpenAIResponsesAssistantMessage,
 	stripInternalDetailsFields,
 } from "./messages";
-import { type BuildSessionContextOptions, buildSessionContext, type SessionContext } from "./session-context";
+import {
+	type BuildSessionContextOptions,
+	buildSessionContext,
+	getLatestCompactionEntry,
+	type SessionContext,
+} from "./session-context";
 import {
 	type BranchSummaryEntry,
 	type CompactionEntry,
@@ -2197,6 +2202,21 @@ export class SessionManager {
 	async rewriteEntries(): Promise<void> {
 		if (!this.#persist || !this.#sessionFile) return;
 		await this.#rewriteAtomically();
+	}
+
+	/**
+	 * Replace the summary of the most recent compaction entry. The live model
+	 * context and the TUI transcript both read summaries from the entry, so
+	 * the edit propagates everywhere, and the session file is rewritten in
+	 * place so a resume keeps the edited text (#8281). Returns the edited
+	 * entry id, or null when the session has no compaction entry yet.
+	 */
+	async updateLatestCompactionSummary(summary: string): Promise<string | null> {
+		const entry = getLatestCompactionEntry(this.getBranch());
+		if (!entry) return null;
+		entry.summary = summary;
+		await this.rewriteEntries();
+		return entry.id;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2210,11 +2210,16 @@ export class SessionManager {
 	 * the edit propagates everywhere, and the session file is rewritten in
 	 * place so a resume keeps the edited text (#8281). Returns the edited
 	 * entry id, or null when the session has no compaction entry yet.
+	 *
+	 * Also rewrites the preserved OpenAI remote-compaction replay payload so a
+	 * provider that replays `replacementHistory` sends the edited text instead
+	 * of the original remote summary (#8281 review).
 	 */
 	async updateLatestCompactionSummary(summary: string): Promise<string | null> {
 		const entry = getLatestCompactionEntry(this.getBranch());
 		if (!entry) return null;
 		entry.summary = summary;
+		updateOpenAiRemoteCompactionSummary(entry, summary);
 		await this.rewriteEntries();
 		return entry.id;
 	}
@@ -2831,5 +2836,24 @@ export async function cleanupEmptyMoveSession(
 		await sessionManager.dropSession(sessionFile);
 	} catch (err) {
 		logger.warn("Failed to clean up empty move session", { sessionFile, error: String(err) });
+	}
+}
+
+/**
+ * Rewrite the preserved OpenAI remote-compaction summary item to match an
+ * in-place summary edit. Providers that replay `replacementHistory` (see
+ * `getOpenAiRemoteCompactionPayload`) ship the item verbatim, so editing only
+ * `entry.summary` leaves the wire input on the original remote summary (#8281).
+ */
+function updateOpenAiRemoteCompactionSummary(entry: CompactionEntry, summary: string): void {
+	const remote = entry.preserveData?.openaiRemoteCompaction;
+	if (!remote || typeof remote !== "object") return;
+	const typed = remote as { replacementHistory?: unknown };
+	if (!Array.isArray(typed.replacementHistory)) return;
+	for (const item of typed.replacementHistory) {
+		if (!item || typeof item !== "object") continue;
+		const candidate = item as { type?: unknown; summary?: unknown };
+		if (candidate.type !== "compaction_summary") continue;
+		candidate.summary = summary;
 	}
 }

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -187,6 +187,10 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 			const edited = await runtime.ctx.showHookEditor("Edit compaction summary", entry.summary);
 			if (edited === undefined || edited === entry.summary) return;
 			await runtime.ctx.sessionManager.updateLatestCompactionSummary(edited);
+			// Rebuild the live agent context so the next provider request carries
+			// the edited summary, not the CompactionSummaryMessage built pre-edit
+			// (#8281 review). Non-interactive runtimes may lack the live session.
+			runtime.ctx.session?.rebuildContextAfterCompactionEdit();
 			runtime.ctx.showStatus("Compaction summary updated.");
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -5,6 +5,7 @@ import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
 import type { FreshSessionResult } from "../session/agent-session";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
+import { getLatestCompactionEntry } from "../session/session-context";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { resolveToCwd } from "../tools/path-utils";
@@ -164,6 +165,29 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 				return;
 			}
 			await runtime.ctx.handleCompactCommand(parsed.instructions, parsed.mode);
+		},
+	},
+	{
+		name: "compact-edit",
+		description: "Edit the current compaction summary in a text editor",
+		acpDescription: "Edit the current compaction summary",
+		handle: async (_command, runtime) => {
+			// The editor is interactive-only; ACP callers get a pointer to the
+			// TUI command instead of a silent no-op.
+			const entry = getLatestCompactionEntry(runtime.sessionManager.getBranch());
+			if (!entry) return usage("No compaction summary to edit yet.", runtime);
+			return usage("Compaction summary editing is interactive-only; run /compact-edit in the TUI.", runtime);
+		},
+		handleTui: async (_command, runtime) => {
+			const entry = getLatestCompactionEntry(runtime.ctx.sessionManager.getBranch());
+			if (!entry) {
+				runtime.ctx.showWarning("No compaction summary to edit yet.");
+				return;
+			}
+			const edited = await runtime.ctx.showHookEditor("Edit compaction summary", entry.summary);
+			if (edited === undefined || edited === entry.summary) return;
+			await runtime.ctx.sessionManager.updateLatestCompactionSummary(edited);
+			runtime.ctx.showStatus("Compaction summary updated.");
 		},
 	},
 	{

--- a/packages/coding-agent/test/compact-summary-edit.test.ts
+++ b/packages/coding-agent/test/compact-summary-edit.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it, vi } from "bun:test";
-import * as path from "node:path";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
-import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { getLatestCompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-context";
-import {
-	executeAcpBuiltinSlashCommand,
-} from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import type { SlashCommandRuntime, TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -29,6 +26,32 @@ describe("compaction summary editing (issue #8281)", () => {
 	it("returns null when the session has no compaction entry", async () => {
 		const manager = SessionManager.inMemory();
 		expect(await manager.updateLatestCompactionSummary("edited summary")).toBeNull();
+	});
+
+	it("rewrites the OpenAI remote-compaction replay summary on edit (#8281 review)", async () => {
+		const manager = SessionManager.inMemory();
+		const remote = {
+			provider: "openai",
+			replacementHistory: [
+				{ type: "compaction_summary", summary: "original remote summary" },
+				{ type: "message", role: "user", content: [{ type: "input_text", text: "kept" }] },
+			],
+		};
+		manager.appendCompaction("original summary", "orig", "entry-1", 100, undefined, undefined, {
+			openaiRemoteCompaction: remote,
+		});
+
+		await manager.updateLatestCompactionSummary("edited summary");
+
+		const entry = getLatestCompactionEntry(manager.getBranch());
+		const payload = entry?.preserveData?.openaiRemoteCompaction as {
+			replacementHistory?: Array<{ type?: string; summary?: string }>;
+		};
+		const summaryItem = payload?.replacementHistory?.find(item => item.type === "compaction_summary");
+		expect(summaryItem?.summary).toBe("edited summary");
+		// Non-summary replay items are untouched.
+		const messageItem = payload?.replacementHistory?.find(item => item.type === "message");
+		expect(messageItem?.summary).toBeUndefined();
 	});
 
 	it("persists the edit so a resume keeps it", async () => {
@@ -63,11 +86,14 @@ describe("/compact-edit dispatch (issue #8281)", () => {
 		const manager = SessionManager.inMemory();
 		manager.appendCompaction("original summary", "orig", "entry-1", 100);
 		const h = tuiRuntime(manager, "edited summary");
+		const rebuildContextAfterCompactionEdit = vi.fn();
+		h.runtime.ctx.session = { rebuildContextAfterCompactionEdit } as never;
 
 		await executeBuiltinSlashCommand("/compact-edit", h.runtime);
 
 		expect(h.showHookEditor).toHaveBeenCalledWith("Edit compaction summary", "original summary");
 		expect(getLatestCompactionEntry(manager.getBranch())?.summary).toBe("edited summary");
+		expect(rebuildContextAfterCompactionEdit).toHaveBeenCalled();
 		expect(h.showStatus).toHaveBeenCalledWith("Compaction summary updated.");
 		expect(h.showWarning).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/compact-summary-edit.test.ts
+++ b/packages/coding-agent/test/compact-summary-edit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getLatestCompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import {
+	executeAcpBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { SlashCommandRuntime, TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("compaction summary editing (issue #8281)", () => {
+	it("updates the latest compaction summary in memory and in rebuilt context", async () => {
+		const manager = SessionManager.inMemory();
+		const id = manager.appendCompaction("original summary", "orig", "entry-1", 100);
+
+		const editedId = await manager.updateLatestCompactionSummary("edited summary");
+
+		expect(editedId).toBe(id);
+		expect(getLatestCompactionEntry(manager.getBranch())?.summary).toBe("edited summary");
+		// The live model context is rebuilt from entries, so the edit shows up
+		// in the next turn's context without any extra synchronization.
+		const serialized = JSON.stringify(manager.buildSessionContext());
+		expect(serialized).toContain("edited summary");
+		expect(serialized).not.toContain("original summary");
+	});
+
+	it("returns null when the session has no compaction entry", async () => {
+		const manager = SessionManager.inMemory();
+		expect(await manager.updateLatestCompactionSummary("edited summary")).toBeNull();
+	});
+
+	it("persists the edit so a resume keeps it", async () => {
+		using tempDir = TempDir.createSync("@omp-compact-edit-");
+		const manager = SessionManager.create(tempDir.path(), tempDir.path());
+		// Brand-new sessions only write a file once they have an assistant
+		// message; append one so the lazy gate lets entries reach disk.
+		manager.appendMessage({ role: "assistant", content: "hi", timestamp: 1 } as never);
+		manager.appendCompaction("original summary", "orig", "entry-1", 100);
+		await manager.updateLatestCompactionSummary("edited summary");
+		await manager.flush();
+		const sessionFile = manager.getSessionFile();
+		if (!sessionFile) throw new Error("expected a persisted session file");
+
+		const reopened = await SessionManager.open(sessionFile, tempDir.path());
+		expect(getLatestCompactionEntry(reopened.getBranch())?.summary).toBe("edited summary");
+	});
+});
+
+describe("/compact-edit dispatch (issue #8281)", () => {
+	function tuiRuntime(manager: SessionManager, edited?: string) {
+		const showHookEditor = vi.fn(async () => edited);
+		const showStatus = vi.fn();
+		const showWarning = vi.fn();
+		const runtime = {
+			ctx: { sessionManager: manager, showHookEditor, showStatus, showWarning } as unknown as InteractiveModeContext,
+		} as TuiSlashCommandRuntime;
+		return { showHookEditor, showStatus, showWarning, runtime };
+	}
+
+	it("opens the editor with the current summary and persists the edit", async () => {
+		const manager = SessionManager.inMemory();
+		manager.appendCompaction("original summary", "orig", "entry-1", 100);
+		const h = tuiRuntime(manager, "edited summary");
+
+		await executeBuiltinSlashCommand("/compact-edit", h.runtime);
+
+		expect(h.showHookEditor).toHaveBeenCalledWith("Edit compaction summary", "original summary");
+		expect(getLatestCompactionEntry(manager.getBranch())?.summary).toBe("edited summary");
+		expect(h.showStatus).toHaveBeenCalledWith("Compaction summary updated.");
+		expect(h.showWarning).not.toHaveBeenCalled();
+	});
+
+	it("warns when the session has no compaction summary yet", async () => {
+		const manager = SessionManager.inMemory();
+		const h = tuiRuntime(manager, "edited summary");
+
+		await executeBuiltinSlashCommand("/compact-edit", h.runtime);
+
+		expect(h.showWarning).toHaveBeenCalledWith("No compaction summary to edit yet.");
+		expect(h.showHookEditor).not.toHaveBeenCalled();
+	});
+
+	it("keeps the summary when the editor is cancelled", async () => {
+		const manager = SessionManager.inMemory();
+		manager.appendCompaction("original summary", "orig", "entry-1", 100);
+		const h = tuiRuntime(manager, undefined);
+
+		await executeBuiltinSlashCommand("/compact-edit", h.runtime);
+
+		expect(getLatestCompactionEntry(manager.getBranch())?.summary).toBe("original summary");
+		expect(h.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("reports interactive-only over ACP instead of mutating silently", async () => {
+		const manager = SessionManager.inMemory();
+		manager.appendCompaction("original summary", "orig", "entry-1", 100);
+		const output = vi.fn();
+		const runtime = { sessionManager: manager, output } as unknown as SlashCommandRuntime;
+
+		await executeAcpBuiltinSlashCommand("/compact-edit", runtime);
+
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("interactive-only"));
+		expect(getLatestCompactionEntry(manager.getBranch())?.summary).toBe("original summary");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `/compact-edit` command that opens the current compaction summary in the multi-line editor (Ctrl+G for `$VISUAL`/`$EDITOR`). The saved text replaces the latest compaction entry's summary in place, so the next turn's rebuilt model context and the TUI transcript both pick it up; the session file is rewritten atomically so a resume keeps the edited text.

The ACP/text-mode handler reports the command as interactive-only instead of mutating silently; a cancelled edit leaves the summary untouched.

## Changes

- `packages/coding-agent/src/session/session-manager.ts`: `updateLatestCompactionSummary()` — replaces the latest compaction entry's summary and rewrites the session file in place.
- `packages/coding-agent/src/slash-commands/builtin-lifecycle.ts`: the `/compact-edit` command (TUI: editor flow; ACP: interactive-only notice).

## Test plan

- In-memory propagation: edit lands on the latest entry and shows up in the rebuilt model context.
- Resume persistence: edit survives a reopen of the session file.
- No compaction entry: warns instead of crashing.
- Cancelled edit: summary unchanged.
- ACP dispatch: reports interactive-only, no silent mutation.

All slash-command tests pass (128); `tsgo` typecheck and Biome clean.

Fixes #8281

I am a full-stack developer intern, passionate about contributing to the open-source community and giving back to the tools I love. I have reviewed and understood all the code changes in this PR, which I verified with unit tests, type checks, and lint.