### PR TITLE
fix(mnemopi): contain lifecycle hook failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Contained Mnemopi bank failures at agent lifecycle boundaries so optional recall and retention cannot terminate the host session ([#8351](https://github.com/can1357/oh-my-pi/issues/8351)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -574,10 +574,25 @@ export class MnemopiSessionState {
 		this.unsubscribe?.();
 		this.unsubscribe = this.session.subscribe((event: AgentSessionEvent) => {
 			if (event.type === "agent_start") {
-				void this.maybeRecallOnAgentStart();
+				void this.maybeRecallOnAgentStart().catch(error => {
+					this.#logLifecycleFailure(
+						"agent_start recall",
+						this.scoped.recall.map(target => target.bank),
+						error,
+					);
+				});
 			} else if (event.type === "agent_end") {
-				void this.maybeRetainOnAgentEnd(event.messages);
+				void this.maybeRetainOnAgentEnd(event.messages).catch(error => {
+					this.#logLifecycleFailure("agent_end retention", [this.scoped.retain.bank], error);
+				});
 			}
+		});
+	}
+	#logLifecycleFailure(operation: string, banks: readonly string[], error: unknown): void {
+		logger.warn("Mnemopi: lifecycle hook failed", {
+			banks,
+			operation,
+			error: toError(error).message,
 		});
 	}
 

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -32,7 +32,7 @@ import { MemoryRecallTool } from "@oh-my-pi/pi-coding-agent/tools/memory-recall"
 import { MemoryReflectTool } from "@oh-my-pi/pi-coding-agent/tools/memory-reflect";
 import { MemoryRetainTool } from "@oh-my-pi/pi-coding-agent/tools/memory-retain";
 import { resetMemoryForTests } from "@oh-my-pi/pi-mnemopi";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
 
 // Mnemopi is lazy-loaded at runtime; preload it for synchronous state construction.
 await Promise.all([loadMnemopi(), loadMnemopiCore()]);
@@ -481,6 +481,56 @@ describe("Mnemopi backend lifecycle", () => {
 
 		await expect(state.maybeRecallOnAgentStart()).resolves.toBeUndefined();
 		expect(state.hasRecalledForFirstTurn).toBe(false);
+	});
+
+	it("contains unavailable-bank failures from agent-end retention", async () => {
+		const listeners = new Set<AgentSessionEventListener>();
+		const entries = [{ type: "message", message: { role: "user", content: "turn one" } }];
+		const state = registerMnemopiState(makeMnemopiConfig({ retainEveryNTurns: 1 }), {
+			entries: () => entries,
+			listeners,
+		});
+		state.attachSessionListeners();
+		state.memory.beam.db.close();
+		const warning = Promise.withResolvers<void>();
+		const warn = vi.spyOn(logger, "warn").mockImplementation((message, context) => {
+			if (message === "Mnemopi: lifecycle hook failed") warning.resolve();
+			void context;
+		});
+
+		for (const listener of listeners) listener({ type: "agent_end", messages: [] } as never);
+		await warning.promise;
+
+		expect(warn).toHaveBeenCalledWith("Mnemopi: lifecycle hook failed", {
+			banks: ["test-bank"],
+			operation: "agent_end retention",
+			error: "Cannot use a closed database",
+		});
+	});
+
+	it("contains failures before agent-start recall reaches its internal bank guard", async () => {
+		const listeners = new Set<AgentSessionEventListener>();
+		const state = registerMnemopiState(makeMnemopiConfig(), {
+			entries: () => {
+				throw new Error("session journal unavailable");
+			},
+			listeners,
+		});
+		state.attachSessionListeners();
+		const warning = Promise.withResolvers<void>();
+		const warn = vi.spyOn(logger, "warn").mockImplementation((message, context) => {
+			if (message === "Mnemopi: lifecycle hook failed") warning.resolve();
+			void context;
+		});
+
+		for (const listener of listeners) listener({ type: "agent_start" } as never);
+		await warning.promise;
+
+		expect(warn).toHaveBeenCalledWith("Mnemopi: lifecycle hook failed", {
+			banks: ["test-bank"],
+			operation: "agent_start recall",
+			error: "session journal unavailable",
+		});
 	});
 	it("auto-retain stores only the not-yet-retained suffix", async () => {
 		const entries = Array.from({ length: 4 }, (_, index) => ({


### PR DESCRIPTION
## Repro
With Mnemopi auto-retention enabled, make the active bank unavailable after session-state initialization and dispatch an `agent_end` event; `bun /tmp/repro-8351.ts` previously emitted an unhandled `RangeError: Cannot use a closed database` from `#restoreRetainedTurnCursor()` and exited 1.

## Cause
`MnemopiSessionState.attachSessionListeners()` in `packages/coding-agent/src/mnemopi/state.ts` discarded the promises returned by `maybeRecallOnAgentStart()` and `maybeRetainOnAgentEnd()` without attaching rejection handlers, so failures outside the methods' narrower internal guards escaped the optional memory subsystem.

## Fix
- Attach rejection handlers to both fire-and-forget lifecycle operations at the session-event boundary.
- Log the operation, affected bank or banks, and normalized error without modifying or replacing the bank.
- Cover unavailable-bank `agent_end` retention and pre-recall `agent_start` failures through the actual listener dispatch.
- Document the fix in the coding-agent changelog.

## Verification
`bun test test/memory-tools.test.ts` — 59 passed, 0 failed. `bun /tmp/repro-8351.ts` — `no unhandled rejection`, exit 0. Pre-publish `bun run fix` and `bun check` completed successfully. Fixes #8351