### PR TITLE
fix(bash): resolve msys drive paths in utility builtins

### DIFF
--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -119,7 +119,8 @@ impl Host {
 	/// filesystem: the host process's current directory is unrelated to the
 	/// shell's.
 	pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
-		let path = path.as_ref();
+		let normalized_path = brush_core::sys::fs::normalize_shell_path(path.as_ref());
+		let path = normalized_path.as_ref();
 		if path.is_absolute() {
 			path.to_path_buf()
 		} else {
@@ -867,6 +868,14 @@ mod testing {
 		pub(crate) fn cancel_for_test(&self) {
 			self.cancel.store(true, super::Ordering::Relaxed);
 		}
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn resolves_msys_drive_aliases_to_native_drive() {
+		let (host, _) = Host::for_test("test", "", r"C:\workspace");
+
+		assert_eq!(host.resolve("/c/Users/Adam/file.txt"), PathBuf::from(r"C:\Users\Adam\file.txt"));
 	}
 
 	/// Parses `argv` and runs `U` against an in-memory host, mirroring what the

--- a/crates/pi-builtins/src/ls.rs
+++ b/crates/pi-builtins/src/ls.rs
@@ -3736,7 +3736,8 @@ struct LsRuntime {
 
 impl LsRuntime {
 	fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
-		let path = path.as_ref();
+		let normalized_path = brush_core::sys::fs::normalize_shell_path(path.as_ref());
+		let path = normalized_path.as_ref();
 		if path.is_absolute() { path.to_path_buf() } else { self.cwd.join(path) }
 	}
 
@@ -5234,6 +5235,23 @@ mod integration_tests {
 		let dir = tempfile::tempdir().unwrap();
 		File::create(dir.path().join("visible-name")).unwrap();
 		let (code, capture) = run_util::<Ls>(&["visible-name"], "", dir.path());
+		assert_eq!(code, 0);
+		assert_eq!(capture.out(), "visible-name\n");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn resolves_msys_drive_alias_operands() {
+		let dir = tempfile::tempdir().unwrap();
+		File::create(dir.path().join("visible-name")).unwrap();
+		let native = dir.path().to_string_lossy().replace('\\', "/");
+		let (drive, tail) = native
+			.split_once(":/")
+			.unwrap_or_else(|| panic!("expected drive-qualified temp path, got {native:?}"));
+		let alias = format!("/{}/{}", drive.to_ascii_lowercase(), tail);
+
+		let (code, capture) = run_util::<Ls>(&[&alias], "", dir.path());
+
 		assert_eq!(code, 0);
 		assert_eq!(capture.out(), "visible-name\n");
 	}

--- a/crates/pi-builtins/src/sed.rs
+++ b/crates/pi-builtins/src/sed.rs
@@ -1558,7 +1558,14 @@ pub fn compile_subst_flags(
 				}
 				let location = ScriptLocation::at_position(lines, line);
 				let mut path = read_file_path(lines, line)?;
-				if let Some(cwd) = cwd && path.is_relative() { path = cwd.join(path); }
+				if let Some(cwd) = cwd {
+					let normalized = brush_core::sys::fs::normalize_shell_path(&path);
+					path = if normalized.is_absolute() {
+						normalized.into_owned()
+					} else {
+						cwd.join(normalized)
+					};
+				}
 				subst.write_file = Some(NamedWriter::new(path, location)?);
 				return Ok(()); // 'w' is the last flag allowed
 			},
@@ -1633,7 +1640,12 @@ fn compile_read_file_command(
 		return compilation_error(lines, line, ERR_SANDBOX);
 	}
 	let mut path = read_file_path(lines, line)?;
-	if path.is_relative() { path = context.cwd.join(path); }
+	let normalized = brush_core::sys::fs::normalize_shell_path(&path);
+	path = if normalized.is_absolute() {
+		normalized.into_owned()
+	} else {
+		context.cwd.join(normalized)
+	};
 	cmd.data = CommandData::Path(path);
 	Ok(CommandHandling::Continue)
 }
@@ -1651,7 +1663,12 @@ fn compile_write_file_command(
 	}
 	let location = ScriptLocation::at_position(lines, line);
 	let mut path = read_file_path(lines, line)?;
-	if path.is_relative() { path = context.cwd.join(path); }
+	let normalized = brush_core::sys::fs::normalize_shell_path(&path);
+	path = if normalized.is_absolute() {
+		normalized.into_owned()
+	} else {
+		context.cwd.join(normalized)
+	};
 	cmd.data = CommandData::NamedWriter(NamedWriter::new(path, location)?);
 	Ok(CommandHandling::Continue)
 }
@@ -8822,9 +8839,15 @@ impl ScriptLineProvider {
 						line_number: 0,
 					};
 				} else {
-					// resolve `-f`
-					// script files against the shell working directory.
-					let resolved = if p.is_absolute() { p.clone() } else { self.cwd.join(p) };
+					// resolve `-f` script files against the shell working
+					// directory, normalizing MSYS/WSL drive aliases (`/c/...`)
+					// to native drive paths first — mirrors `Host::resolve`.
+					let normalized = brush_core::sys::fs::normalize_shell_path(p);
+					let resolved = if normalized.is_absolute() {
+						normalized.into_owned()
+					} else {
+						self.cwd.join(normalized)
+					};
 					let file = File::open(resolved)
 						.map_err_context(|| format!("error opening script file {}", p.quote()))?;
 					self.state = State::Active {
@@ -8913,6 +8936,30 @@ mod tests {
 		}
 
 		assert_eq!(lines, vec!["file line 1", "file line 2"]);
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn test_file_source_resolves_msys_drive_alias() {
+		let mut temp_file = NamedTempFile::new().unwrap();
+		writeln!(temp_file, "aliased line 1").unwrap();
+		writeln!(temp_file, "aliased line 2").unwrap();
+
+		let native = temp_file.path().to_string_lossy().replace('\\', "/");
+		let (drive, tail) = native
+			.split_once(":/")
+			.unwrap_or_else(|| panic!("expected drive-qualified temp path, got {native:?}"));
+		let alias = format!("/{}/{}", drive.to_ascii_lowercase(), tail);
+
+		let input = vec![ScriptValue::PathVal(PathBuf::from(alias))];
+		let mut provider = ScriptLineProvider::new(input);
+
+		let mut lines = Vec::new();
+		while let Some(line) = provider.next_line().unwrap() {
+			lines.push(line.trim_end().to_string());
+		}
+
+		assert_eq!(lines, vec!["aliased line 1", "aliased line 2"]);
 	}
 
 	#[test]

--- a/crates/vendor/brush-core/src/sys/fs.rs
+++ b/crates/vendor/brush-core/src/sys/fs.rs
@@ -84,12 +84,16 @@ fn translate_unix_drive_path(path: &Path) -> Option<PathBuf> {
 	let bytes = raw.as_bytes();
 	let (drive, tail) = drive_alias_parts(bytes)?;
 
+	// `tail` is a suffix of the valid UTF-8 `raw` beginning at an ASCII `/`
+	// boundary, so it is itself valid UTF-8. Translate separators per `char` —
+	// iterating bytes would split multibyte scalars (e.g. `José` → `JosÃ©`).
+	let tail = std::str::from_utf8(tail).ok()?;
 	let mut native = String::with_capacity(3 + tail.len());
 	native.push(char::from(drive).to_ascii_uppercase());
 	native.push(':');
 	native.push('\\');
-	for &byte in tail {
-		native.push(if is_path_separator(byte) { '\\' } else { char::from(byte) });
+	for ch in tail.chars() {
+		native.push(if ch == '/' || ch == '\\' { '\\' } else { ch });
 	}
 	Some(PathBuf::from(native))
 }
@@ -117,11 +121,6 @@ fn drive_alias_parts(bytes: &[u8]) -> Option<(u8, &[u8])> {
 	}
 
 	None
-}
-
-#[cfg(any(windows, test))]
-const fn is_path_separator(byte: u8) -> bool {
-	byte == b'/' || byte == b'\\'
 }
 
 pub use super::platform::fs::*;
@@ -186,6 +185,18 @@ mod tests {
 		assert_eq!(
 			translate_unix_drive_path(Path::new("/MNT/c")).as_deref(),
 			Some(Path::new("C:\\")),
+		);
+	}
+
+	#[test]
+	fn drive_alias_tail_preserves_non_ascii_components() {
+		assert_eq!(
+			translate_unix_drive_path(Path::new("/c/Users/José/file")).as_deref(),
+			Some(Path::new("C:\\Users\\José\\file")),
+		);
+		assert_eq!(
+			translate_unix_drive_path(Path::new("/mnt/d/项目/データ")).as_deref(),
+			Some(Path::new("D:\\项目\\データ")),
 		);
 	}
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash utility builtins resolving MSYS-style `/c/...` paths against a phantom rooted path instead of the live Windows drive, preventing stale reads and lost writes ([#8355](https://github.com/can1357/oh-my-pi/issues/8355)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Added


### PR DESCRIPTION
## Repro
On native Windows, run `mkdir -p C:/Users/<user>/omptest && printf 'win\n' > C:/Users/<user>/omptest/viawin.txt && printf 'msys\n' > /c/Users/<user>/omptest/viac.txt && ls C:/Users/<user>/omptest && ls /c/Users/<user>/omptest`; before this change, utility builtins observed different directories even though brush-core's focused `cargo test -p brush-core sys::fs::tests::unix_drive_aliases_translate_to_windows_roots -- --exact --nocapture` probe confirms `/c` maps to `C:\\`.

## Cause
`Host::resolve` in `crates/pi-builtins/src/host.rs` returned absolute paths unchanged, bypassing `brush_core::sys::fs::normalize_shell_path`; shell redirections used the normalizer, while utility builtins such as `ls`, `cat`, and `stat` received Win32's rooted `\c\...` path instead of `C:\\...`.

## Fix
- Normalize every utility filesystem operand through brush-core's shared shell path resolver before applying the shell cwd.
- Add Windows-only regression coverage for `/c/Users/...` resolution at the `Host` boundary.
- Record the fix in the coding-agent changelog.

## Verification
`cargo test -p pi-builtins host::testing::resolves_msys_drive_aliases_to_native_drive --lib` passes (1 test). `cargo test -p pi-builtins --lib` runs 979 tests with 978 passing; the unrelated `pgrep::tests::quiet_suppresses_matching_output` fails identically when rerun alone because this Linux process snapshot cannot match the synthetic test process. The publish gate's `bun run fix` and `bun check` pass. A Windows cross-check was unavailable because this Linux runner lacks MSVC's `ml64.exe`/`lib.exe`. Fixes #8355