### PR TITLE
fix(pi-builtins): resolve MSYS `/c/...` paths to native `C:\...` on Windows (phantom C:\c\ tree)

### DIFF
--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -118,6 +118,11 @@ impl Host {
 	/// Every path argument must go through this before touching the
 	/// filesystem: the host process's current directory is unrelated to the
 	/// shell's.
+	///
+	/// On Windows, an MSYS/Cygwin-style absolute path (`/c/Users/foo`) is first
+	/// rewritten to its native form (`C:\Users\foo`) by `msys_absolute_to_windows`,
+	/// since [`Path::is_absolute`] is `false` for such paths and they would
+	/// otherwise be joined onto the cwd's drive as a phantom `C:\c\Users\foo`.
 	pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
 		let path = path.as_ref();
 		#[cfg(windows)]

--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -119,60 +119,21 @@ impl Host {
 	/// filesystem: the host process's current directory is unrelated to the
 	/// shell's.
 	///
-	/// On Windows, an MSYS/Cygwin-style absolute path (`/c/Users/foo`) is first
-	/// rewritten to its native form (`C:\Users\foo`) by `msys_absolute_to_windows`,
-	/// since [`Path::is_absolute`] is `false` for such paths and they would
-	/// otherwise be joined onto the cwd's drive as a phantom `C:\c\Users\foo`.
+	/// The operand is first run through
+	/// [`brush_core::sys::fs::normalize_shell_path`] — the same resolver the shell
+	/// applies to redirections — so on Windows an MSYS/Cygwin-style absolute path
+	/// (`/c/Users/foo`, `/mnt/d/...`) is rewritten to its native form
+	/// (`C:\Users\foo`, `D:\...`). Without this, [`Path::is_absolute`] is `false`
+	/// for such rooted-but-prefixless paths and they would be joined onto the
+	/// cwd's drive as a phantom `C:\c\Users\foo` (stale reads, lost writes).
 	pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
-		let path = path.as_ref();
-		#[cfg(windows)]
-		if let Some(native) = Self::msys_absolute_to_windows(path) {
-			return native;
-		}
+		let normalized = brush_core::sys::fs::normalize_shell_path(path.as_ref());
+		let path = normalized.as_ref();
 		if path.is_absolute() {
 			path.to_path_buf()
 		} else {
 			self.cwd.join(path)
 		}
-	}
-
-	/// On Windows, translate an MSYS/Cygwin-style absolute path (`/c/Users/foo`,
-	/// `/c`) into a native path (`C:\Users\foo`, `C:\`).
-	///
-	/// Rust's [`Path::is_absolute`] is `false` for these — they have a root but
-	/// no drive prefix — so [`Host::resolve`] would otherwise `cwd.join` them.
-	/// Joining a rooted-but-prefixless path only replaces everything *after* the
-	/// cwd's drive, so `/c/Users/foo` becomes a phantom `C:\c\Users\foo`: reads
-	/// there miss the real files and writes never reach the real path. This
-	/// mirrors the MSYS drive-letter mapping already applied to `PATH` entries by
-	/// `pi-shell`'s `translate_msys_segment`.
-	#[cfg(windows)]
-	fn msys_absolute_to_windows(path: &Path) -> Option<PathBuf> {
-		let s = path.to_str()?;
-		// Only forward-slash-rooted paths (`/c`, `/c/...`). Native paths
-		// (`C:\...`, `C:/...`) and UNC (`//server/share`, `\\server`) are left
-		// untouched for the normal `is_absolute` handling.
-		let rest = s.strip_prefix('/')?;
-		if rest.starts_with('/') {
-			return None; // `//server/share`
-		}
-		let (drive, tail) = match rest.split_once('/') {
-			Some((drive, tail)) => (drive, Some(tail)),
-			None => (rest, None),
-		};
-		let mut chars = drive.chars();
-		let letter = chars.next()?;
-		if !letter.is_ascii_alphabetic() || chars.next().is_some() {
-			return None; // not a single drive letter (e.g. `/usr/bin`, `/tmp`)
-		}
-		let mut out = String::with_capacity(s.len() + 2);
-		out.push(letter.to_ascii_uppercase());
-		out.push(':');
-		out.push('\\');
-		if let Some(tail) = tail {
-			out.push_str(&tail.replace('/', "\\"));
-		}
-		Some(PathBuf::from(out))
 	}
 
 	/// Looks up an exported shell variable.
@@ -1013,46 +974,21 @@ pub(crate) use testing::{Capture, run_util};
 
 #[cfg(all(test, windows))]
 mod msys_path_tests {
-	use std::path::{Path, PathBuf};
+	use std::path::PathBuf;
 
 	use super::Host;
 
-	fn map(p: &str) -> Option<PathBuf> {
-		Host::msys_absolute_to_windows(Path::new(p))
-	}
-
 	#[test]
-	fn drive_letter_paths_translate() {
-		assert_eq!(map("/c/Users/foo").as_deref(), Some(Path::new(r"C:\Users\foo")));
-		assert_eq!(map("/c").as_deref(), Some(Path::new(r"C:\")));
-		assert_eq!(map("/d/").as_deref(), Some(Path::new(r"D:\")));
-		// lowercase drive is upcased
-		assert_eq!(map("/z/a/b").as_deref(), Some(Path::new(r"Z:\a\b")));
-	}
-
-	#[test]
-	fn non_drive_and_native_paths_are_untouched() {
-		// native Windows paths must pass through unchanged (handled by is_absolute)
-		assert_eq!(map(r"C:\Users\foo"), None);
-		assert_eq!(map("C:/Users/foo"), None);
-		// UNC
-		assert_eq!(map("//server/share"), None);
-		// non-drive MSYS roots (resolved elsewhere, not a phantom drive)
-		assert_eq!(map("/usr/bin"), None);
-		assert_eq!(map("/tmp"), None);
-		// relative paths are not our concern here
-		assert_eq!(map("foo/bar"), None);
-		assert_eq!(map("cc/x"), None);
-	}
-
-	#[test]
-	fn resolve_uses_translation_instead_of_phantom_drive() {
+	fn resolve_rewrites_msys_drive_paths_not_phantom_drive() {
 		let (host, _capture) = Host::for_test("ls", "", r"C:\work\repo");
-		// the bug: without translation this would be C:\c\Users\foo
+		// the bug (#8355): without normalization this joined onto the cwd's drive
+		// as a phantom `C:\c\Users\foo`
 		assert_eq!(host.resolve("/c/Users/foo"), PathBuf::from(r"C:\Users\foo"));
-		// relative still joins against cwd
+		// the shared normalizer also handles `/mnt/<drive>` cygwin-mount style
+		assert_eq!(host.resolve("/mnt/d/data"), PathBuf::from(r"D:\data"));
+		// relative operands still join against the shell cwd
 		assert_eq!(host.resolve("sub/x"), PathBuf::from(r"C:\work\repo\sub\x"));
-		// native absolute still passes through
+		// native absolute paths pass through unchanged
 		assert_eq!(host.resolve(r"D:\data"), PathBuf::from(r"D:\data"));
 	}
 }

--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -120,11 +120,54 @@ impl Host {
 	/// shell's.
 	pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
 		let path = path.as_ref();
+		#[cfg(windows)]
+		if let Some(native) = Self::msys_absolute_to_windows(path) {
+			return native;
+		}
 		if path.is_absolute() {
 			path.to_path_buf()
 		} else {
 			self.cwd.join(path)
 		}
+	}
+
+	/// On Windows, translate an MSYS/Cygwin-style absolute path (`/c/Users/foo`,
+	/// `/c`) into a native path (`C:\Users\foo`, `C:\`).
+	///
+	/// Rust's [`Path::is_absolute`] is `false` for these — they have a root but
+	/// no drive prefix — so [`Host::resolve`] would otherwise `cwd.join` them.
+	/// Joining a rooted-but-prefixless path only replaces everything *after* the
+	/// cwd's drive, so `/c/Users/foo` becomes a phantom `C:\c\Users\foo`: reads
+	/// there miss the real files and writes never reach the real path. This
+	/// mirrors the MSYS drive-letter mapping already applied to `PATH` entries by
+	/// `pi-shell`'s `translate_msys_segment`.
+	#[cfg(windows)]
+	fn msys_absolute_to_windows(path: &Path) -> Option<PathBuf> {
+		let s = path.to_str()?;
+		// Only forward-slash-rooted paths (`/c`, `/c/...`). Native paths
+		// (`C:\...`, `C:/...`) and UNC (`//server/share`, `\\server`) are left
+		// untouched for the normal `is_absolute` handling.
+		let rest = s.strip_prefix('/')?;
+		if rest.starts_with('/') {
+			return None; // `//server/share`
+		}
+		let (drive, tail) = match rest.split_once('/') {
+			Some((drive, tail)) => (drive, Some(tail)),
+			None => (rest, None),
+		};
+		let mut chars = drive.chars();
+		let letter = chars.next()?;
+		if !letter.is_ascii_alphabetic() || chars.next().is_some() {
+			return None; // not a single drive letter (e.g. `/usr/bin`, `/tmp`)
+		}
+		let mut out = String::with_capacity(s.len() + 2);
+		out.push(letter.to_ascii_uppercase());
+		out.push(':');
+		out.push('\\');
+		if let Some(tail) = tail {
+			out.push_str(&tail.replace('/', "\\"));
+		}
+		Some(PathBuf::from(out))
 	}
 
 	/// Looks up an exported shell variable.
@@ -962,3 +1005,49 @@ mod testing {
 #[cfg(test)]
 #[allow(unused_imports, reason = "used by utility test modules, which are feature-gated")]
 pub(crate) use testing::{Capture, run_util};
+
+#[cfg(all(test, windows))]
+mod msys_path_tests {
+	use std::path::{Path, PathBuf};
+
+	use super::Host;
+
+	fn map(p: &str) -> Option<PathBuf> {
+		Host::msys_absolute_to_windows(Path::new(p))
+	}
+
+	#[test]
+	fn drive_letter_paths_translate() {
+		assert_eq!(map("/c/Users/foo").as_deref(), Some(Path::new(r"C:\Users\foo")));
+		assert_eq!(map("/c").as_deref(), Some(Path::new(r"C:\")));
+		assert_eq!(map("/d/").as_deref(), Some(Path::new(r"D:\")));
+		// lowercase drive is upcased
+		assert_eq!(map("/z/a/b").as_deref(), Some(Path::new(r"Z:\a\b")));
+	}
+
+	#[test]
+	fn non_drive_and_native_paths_are_untouched() {
+		// native Windows paths must pass through unchanged (handled by is_absolute)
+		assert_eq!(map(r"C:\Users\foo"), None);
+		assert_eq!(map("C:/Users/foo"), None);
+		// UNC
+		assert_eq!(map("//server/share"), None);
+		// non-drive MSYS roots (resolved elsewhere, not a phantom drive)
+		assert_eq!(map("/usr/bin"), None);
+		assert_eq!(map("/tmp"), None);
+		// relative paths are not our concern here
+		assert_eq!(map("foo/bar"), None);
+		assert_eq!(map("cc/x"), None);
+	}
+
+	#[test]
+	fn resolve_uses_translation_instead_of_phantom_drive() {
+		let (host, _capture) = Host::for_test("ls", "", r"C:\work\repo");
+		// the bug: without translation this would be C:\c\Users\foo
+		assert_eq!(host.resolve("/c/Users/foo"), PathBuf::from(r"C:\Users\foo"));
+		// relative still joins against cwd
+		assert_eq!(host.resolve("sub/x"), PathBuf::from(r"C:\work\repo\sub\x"));
+		// native absolute still passes through
+		assert_eq!(host.resolve(r"D:\data"), PathBuf::from(r"D:\data"));
+	}
+}

--- a/crates/pi-builtins/src/ls.rs
+++ b/crates/pi-builtins/src/ls.rs
@@ -3736,7 +3736,8 @@ struct LsRuntime {
 
 impl LsRuntime {
 	fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
-		let path = path.as_ref();
+		let normalized = brush_core::sys::fs::normalize_shell_path(path.as_ref());
+		let path = normalized.as_ref();
 		if path.is_absolute() { path.to_path_buf() } else { self.cwd.join(path) }
 	}
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash utility builtins (`ls`, `cat`, `stat`, …) resolving MSYS/Cygwin-style `/c/...` paths against a phantom rooted path (`C:\c\...`) on Windows instead of the live drive, causing stale reads and lost writes. `Host::resolve` and `LsRuntime::resolve` now normalize operands through the shared shell path resolver, matching redirections ([#8355](https://github.com/can1357/oh-my-pi/issues/8355)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Added


### PR DESCRIPTION
Fixes #8355.

## Problem

On Windows, the `bash` tool's utility builtins (`ls`, `cat`, `find`, `stat`, `cp`, redirection, …) give a **silent split-brain filesystem view** for MSYS/Cygwin-style absolute paths: `/c/Users/foo` reads/writes a *different* location than `C:/Users/foo`. Writes via `/c/...` are silently lost (never reach the real path), and reads via `/c/...` miss files created by everything else (the host file tools, the user, subagents).

## Root cause

`Host::resolve` (`crates/pi-builtins/src/host.rs`) is the mandatory choke point for every builtin path argument:

```rust
pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
    let path = path.as_ref();
    if path.is_absolute() { path.to_path_buf() } else { self.cwd.join(path) }
}
```

`Path::is_absolute()` is **`false` on Windows** for `/c/Users/foo` - it has a root but no drive *prefix*. So it falls to `self.cwd.join("/c/Users/foo")`, and joining a rooted-but-prefixless path keeps only the cwd's drive letter, yielding a **phantom `C:\c\Users\foo`**. That phantom `C:\c\...` tree is real on disk (auto-created on write) but unrelated to `C:\Users\...`, so builtins operating through `/c/...` silently diverge from reality.

Notably, `crates/pi-shell/src/windows.rs` already performs exactly this MSYS drive-letter mapping (`translate_msys_segment`: `/c/Users/foo` → `C:\Users\foo`) - but only for `PATH` entries. `Host::resolve` never got the equivalent.

## Repro (Windows)

```sh
printf x > "C:/Users/me/t/viawin.txt"   # native path
printf x > "/c/Users/me/t/viac.txt"     # MSYS path
ls "C:/Users/me/t/"    # -> viawin.txt
ls "/c/Users/me/t/"    # -> viac.txt  (different dir: actually C:\c\Users\me\t)
```

Inspect `C:\Users\me\t` from any other process: only `viawin.txt` exists; the `/c/...` write went to `C:\c\...` and is lost.

## Fix

Translate a leading `/<drive>[/...]` to `<drive>:\...` on Windows inside `Host::resolve`, before the `is_absolute` check. Native paths (`C:\`, `C:/`), UNC (`//server/share`), and non-drive MSYS roots (`/usr`, `/tmp`) are left untouched for the existing handling. Mirrors the mapping `pi-shell` already applies to `PATH`.

Unit tests cover the translation table, the untouched cases, and that `resolve` no longer produces the phantom drive.

```
test host::msys_path_tests::drive_letter_paths_translate ... ok
test host::msys_path_tests::non_drive_and_native_paths_are_untouched ... ok
test host::msys_path_tests::resolve_uses_translation_instead_of_phantom_drive ... ok
```

## Notes / scope

- Scoped to `Host::resolve`, which the module documents as the single choke point every utility path argument passes through - so it fixes `ls`/`cat`/`find`/`stat`/`cp`/etc. in one place.
- `cd` and redirection are handled by brush-core (the vendored fork) and are out of scope here; if they exhibit the same `/c/...` phantom behavior it may be worth a follow-up, but the utility builtins were the user-visible failure.
- A future refactor could share one MSYS-path helper between `pi-builtins` and `pi-shell::translate_msys_segment` (kept separate here to avoid a new cross-crate dependency, since `pi-shell` depends on `pi-builtins`).
