### PR TITLE
docs: reconcile session dir layout with the 17.2.9 hashed-scheme revert

### DIFF
--- a/docs/session-switching-and-recent-listing.md
+++ b/docs/session-switching-and-recent-listing.md
@@ -24,9 +24,9 @@ It focuses on current implementation behavior, including fallback paths and cave
 
 `SessionManager` stores file sessions under a canonical-cwd bucket by default:
 
-- `~/.omp/agent/sessions/<scope>-<project-basename>-<sha256(canonical-cwd)>/*.jsonl`
+- `~/.omp/agent/sessions/<encoded-cwd>/*.jsonl`
 
-`scope` is `home`, `tmp`, or `abs`. Legacy relative/absolute bucket names are migrated best-effort. `SessionManager.list(cwd, sessionDir?)` reads only the resolved bucket unless an explicit `sessionDir` is provided.
+`<encoded-cwd>` is the path-encoded canonical cwd (`-<relative>` under home, `-tmp-<relative>` under the temp root, `--<encoded-absolute>--` otherwise; see [session.md](session.md#on-disk-layout)). Buckets from the reverted 17.2.5-17.2.8 hashed scheme are migrated best-effort. `SessionManager.list(cwd, sessionDir?)` reads only the resolved bucket unless an explicit `sessionDir` is provided.
 
 ### Two listing paths with different payloads
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -37,12 +37,12 @@ Does not cover `/tree` UI rendering behavior beyond semantics that affect sessio
 Default file-session location:
 
 ```text
-~/.omp/agent/sessions/<scope>-<project-basename>-<sha256(canonical-cwd)>/<timestamp>_<sessionId>.jsonl
+~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<sessionId>.jsonl
 ```
 
-`<scope>` is `home`, `tmp`, or `abs`, chosen after canonicalizing cwd (so symlink aliases share a bucket). The readable basename is sanitized and capped at 80 characters; the full canonical cwd digest prevents the collisions possible with the old separator-replacement scheme.
+`<encoded-cwd>` is derived from the canonicalized cwd (so symlink aliases share a bucket): `-<relative>` for directories under home, `-tmp-<relative>` for directories under the temp root, and `--<encoded-absolute>--` for anything else, with path separators replaced by `-`.
 
-On access, the old home-relative (`-<relative>`), temp-relative (`-tmp-<relative>`), and absolute (`--<encoded-absolute>--`) buckets are migrated into the hashed bucket best-effort. Colliding legacy buckets are split by the cwd recorded in each session header before migration.
+On access, buckets written by the short-lived hashed scheme (`<scope>-<project-basename>-<sha256(canonical-cwd)>`, used in 17.2.5-17.2.8 and reverted in 17.2.9 by #7397) are migrated back into the path-encoded names best-effort, along with older `--<home-encoded>-*--` spellings of home-relative buckets.
 
 Blob store location:
 


### PR DESCRIPTION
## What

`docs/session.md` and `docs/session-switching-and-recent-listing.md` still describe the hashed session-dir scheme (`<scope>-<project-basename>-<sha256(canonical-cwd)>`) as the current default layout, with the path-encoded buckets migrating *into* it. Per `packages/coding-agent/src/session/session-paths.ts`, that scheme was only used in 17.2.5-17.2.8 and was reverted by #7397: since 17.2.9 the path-encoded names are current, and `migrateHashedSessionDir` migrates hashed buckets *back* (recovering sessions stranded per #7677). Updated both docs to match: path-encoded layout as the default, hashed scheme demoted to the historical migration note, migration direction corrected.

## Why

The docs describe both the layout and the migration direction backwards, which bites anyone building against the documented format.

I hit this while building an oh-my-pi adapter for [pond](https://github.com/tenequm/pond): I implemented the documented hashed layout first, and only running a real omp install against the adapter surfaced that it writes the path-encoded names instead.

## Testing

Cross-checked the new text against `session-paths.ts` on current main (`computeDefaultSessionDir`, `encodeRelativeSessionDirName`, `encodeLegacyAbsoluteSessionDirName`, `migrateHashedSessionDir`) and against the session dirs a real omp 17.2.15 install produced during the adapter work. Docs-only change, no code touched.

---

- [ ] `bun check` passes (not run - docs-only change)
- [x] Tested locally (verified against source and a real install's on-disk layout)
- [ ] CHANGELOG updated (if user-facing)