### PR TITLE
fix(catalog): add Grok 4.6 xAI OAuth effort support

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1575,7 +1575,7 @@ function buildParams(
 		if (options?.minP !== undefined) {
 			params.min_p = options.minP;
 		}
-		if (options?.presencePenalty !== undefined) {
+		if (initialCompat.supportsPresencePenalty !== false && options?.presencePenalty !== undefined) {
 			params.presence_penalty = options.presencePenalty;
 		}
 		if (options?.repetitionPenalty !== undefined) {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3308,7 +3308,7 @@ export function applyCommonResponsesSamplingParams<P extends CommonResponsesPara
 	params: P,
 	options: CommonSamplingOptions | undefined,
 	model: Pick<Model, "provider" | "api" | "id" | "omitMaxOutputTokens" | "maxTokens"> & {
-		compat: Pick<ResolvedOpenAISharedCompat, "supportsSamplingParams">;
+		compat: Pick<ResolvedOpenAISharedCompat, "supportsSamplingParams" | "supportsPresencePenalty">;
 	},
 ): void {
 	if (options?.maxTokens && !model.omitMaxOutputTokens) {
@@ -3325,7 +3325,9 @@ export function applyCommonResponsesSamplingParams<P extends CommonResponsesPara
 		if (options?.topP !== undefined) params.top_p = options.topP;
 		if (options?.topK !== undefined) params.top_k = options.topK;
 		if (options?.minP !== undefined) params.min_p = options.minP;
-		if (options?.presencePenalty !== undefined) params.presence_penalty = options.presencePenalty;
+		if (model.compat.supportsPresencePenalty !== false && options?.presencePenalty !== undefined) {
+			params.presence_penalty = options.presencePenalty;
+		}
 		if (options?.repetitionPenalty !== undefined) params.repetition_penalty = options.repetitionPenalty;
 	}
 	applyOpenAIServiceTier(params, options?.serviceTier, model);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1808,9 +1808,10 @@ function resolveGoogleThinkingOff<TApi extends Api>(model: Model<TApi>): NonNull
 const castApi = <TApi extends Api>(api: OptionsForApi<TApi>): OptionsForApi<Api> => api as OptionsForApi<Api>;
 
 /**
- * Mandatory-reasoning endpoints (`thinking.requiresEffort`) reject disabled
- * or omitted thinking ("Reasoning is mandatory for this endpoint and cannot
- * be disabled") — clamp to the lowest supported effort instead.
+ * Mandatory-reasoning models (`thinking.requiresEffort`) cannot honor
+ * thinking-off requests. Omitted reasoning uses the model's declared default
+ * when available, while explicit off requests and models without a default
+ * clamp to the lowest supported effort.
  * `suppressWhenOff` models handle off provider-side via explicit wire
  * suppression. Collapsed pairs interplay: pair derivation strips member
  * flags (off routes to a bare SKU that CAN disable), while identity backfill
@@ -1821,17 +1822,20 @@ function normalizeMandatoryReasoningOptions<TApi extends Api>(
 	model: Model<TApi>,
 	options?: SimpleStreamOptions,
 ): SimpleStreamOptions | undefined {
+	const explicitlyDisabled = options?.disableReasoning === true || options?.forceReasoningOff === true;
+	const defaultLevel = model.thinking?.defaultLevel;
 	if (
 		!model.reasoning ||
 		!model.thinking?.requiresEffort ||
 		model.thinking.suppressWhenOff ||
-		(options?.reasoning !== undefined && !options.disableReasoning && !options.forceReasoningOff)
+		(options?.reasoning !== undefined && !explicitlyDisabled)
 	) {
 		return options;
 	}
 	const floor = minimumSupportedEffort(model);
-	if (floor === undefined) return options;
-	return { ...options, reasoning: floor, disableReasoning: undefined, forceReasoningOff: undefined };
+	const effort = explicitlyDisabled ? floor : (defaultLevel ?? floor);
+	if (effort === undefined) return options;
+	return { ...options, reasoning: effort, disableReasoning: undefined, forceReasoningOff: undefined };
 }
 
 function supportsExplicitOpenAIResponsesPromptCache(compat: unknown): boolean {

--- a/packages/ai/test/xai-oauth-effort-strip.test.ts
+++ b/packages/ai/test/xai-oauth-effort-strip.test.ts
@@ -67,4 +67,15 @@ describe("xAI OAuth Responses reasoning payload (regression)", () => {
 
 		expect(params.reasoning).toEqual({ effort: "high" });
 	});
+
+	test("xai-oauth/grok-4.6 clamps minimal to low and sends xhigh verbatim", () => {
+		const grok46 = getBundledModel<"openai-responses">("xai-oauth", "grok-4.6");
+		if (!grok46) throw new Error("xai-oauth/grok-4.6 must be in bundled models.json");
+
+		const minimal = buildParams(grok46, singleUserContext, { reasoning: Effort.Minimal }, undefined);
+		const xhigh = buildParams(grok46, singleUserContext, { reasoning: Effort.XHigh }, undefined);
+
+		expect(minimal.params.reasoning).toEqual({ effort: "low" });
+		expect(xhigh.params.reasoning).toEqual({ effort: "xhigh" });
+	});
 });

--- a/packages/ai/test/xai-oauth-effort-strip.test.ts
+++ b/packages/ai/test/xai-oauth-effort-strip.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { buildParams } from "@oh-my-pi/pi-ai/providers/openai-responses";
-import type { Context } from "@oh-my-pi/pi-ai/types";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -49,6 +50,26 @@ const singleUserContext: Context = {
 	messages: [{ role: "user", content: "hello", timestamp: 0 }],
 };
 
+interface ResponsesPayload {
+	reasoning?: { effort?: string };
+}
+
+function createAbortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function captureSimpleResponsesPayload(model: Model<"openai-responses">): Promise<ResponsesPayload> {
+	const { promise, resolve } = Promise.withResolvers<ResponsesPayload>();
+	streamSimple(model, singleUserContext, {
+		apiKey: "test-key",
+		signal: createAbortedSignal(),
+		onPayload: payload => resolve(payload as ResponsesPayload),
+	});
+	return promise;
+}
+
 describe("xAI OAuth Responses reasoning payload (regression)", () => {
 	test("xai-oauth/grok-4.5 leaves reasoning unset when no reasoning was requested", () => {
 		const grok45 = getBundledModel<"openai-responses">("xai-oauth", "grok-4.5");
@@ -57,6 +78,17 @@ describe("xAI OAuth Responses reasoning payload (regression)", () => {
 		const { params } = buildParams(grok45, singleUserContext, undefined, undefined);
 
 		expect(params.reasoning).toBeUndefined();
+	});
+
+	test("streamSimple applies the documented high default for Grok 4.5 and 4.6", async () => {
+		for (const modelId of ["grok-4.5", "grok-4.6"] as const) {
+			const model = getBundledModel<"openai-responses">("xai-oauth", modelId);
+			if (!model) throw new Error(`xai-oauth/${modelId} must be in bundled models.json`);
+
+			const payload = await captureSimpleResponsesPayload(model);
+
+			expect(payload.reasoning).toEqual({ effort: "high" });
+		}
 	});
 
 	test("xai-oauth/grok-4.5 omits unsupported reasoning summary", () => {

--- a/packages/ai/test/xai-oauth-effort-strip.test.ts
+++ b/packages/ai/test/xai-oauth-effort-strip.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { buildParams } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
-import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import type { Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai/types";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -52,6 +52,9 @@ const singleUserContext: Context = {
 
 interface ResponsesPayload {
 	reasoning?: { effort?: string };
+	temperature?: number;
+	top_p?: number;
+	presence_penalty?: number;
 }
 
 function createAbortedSignal(): AbortSignal {
@@ -60,9 +63,15 @@ function createAbortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-function captureSimpleResponsesPayload(model: Model<"openai-responses">): Promise<ResponsesPayload> {
+type CapturedStreamOptions = Pick<SimpleStreamOptions, "reasoning" | "temperature" | "topP" | "presencePenalty">;
+
+function captureSimpleResponsesPayload(
+	model: Model<"openai-responses">,
+	options?: CapturedStreamOptions,
+): Promise<ResponsesPayload> {
 	const { promise, resolve } = Promise.withResolvers<ResponsesPayload>();
 	streamSimple(model, singleUserContext, {
+		...options,
 		apiKey: "test-key",
 		signal: createAbortedSignal(),
 		onPayload: payload => resolve(payload as ResponsesPayload),
@@ -100,6 +109,15 @@ describe("xAI OAuth Responses reasoning payload (regression)", () => {
 		expect(params.reasoning).toEqual({ effort: "high" });
 	});
 
+	test("xai-oauth/grok-4.5 maps programmatic xhigh requests to high", async () => {
+		const grok45 = getBundledModel<"openai-responses">("xai-oauth", "grok-4.5");
+		if (!grok45) throw new Error("xai-oauth/grok-4.5 must be in bundled models.json");
+
+		const payload = await captureSimpleResponsesPayload(grok45, { reasoning: Effort.XHigh });
+
+		expect(payload.reasoning).toEqual({ effort: "high" });
+	});
+
 	test("xai-oauth/grok-4.6 clamps minimal to low and sends xhigh verbatim", () => {
 		const grok46 = getBundledModel<"openai-responses">("xai-oauth", "grok-4.6");
 		if (!grok46) throw new Error("xai-oauth/grok-4.6 must be in bundled models.json");
@@ -109,5 +127,23 @@ describe("xAI OAuth Responses reasoning payload (regression)", () => {
 
 		expect(minimal.params.reasoning).toEqual({ effort: "low" });
 		expect(xhigh.params.reasoning).toEqual({ effort: "xhigh" });
+	});
+
+	test("xai-oauth Grok reasoning omits presence penalty without dropping supported sampling controls", async () => {
+		for (const modelId of ["grok-4.5", "grok-4.6"] as const) {
+			const model = getBundledModel<"openai-responses">("xai-oauth", modelId);
+			if (!model) throw new Error(`xai-oauth/${modelId} must be in bundled models.json`);
+
+			const payload = await captureSimpleResponsesPayload(model, {
+				reasoning: Effort.High,
+				temperature: 0.25,
+				topP: 0.75,
+				presencePenalty: 0.5,
+			});
+
+			expect(payload).not.toHaveProperty("presence_penalty");
+			expect(payload.temperature).toBe(0.25);
+			expect(payload.top_p).toBe(0.75);
+		}
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -52,7 +52,7 @@
 - Fixed first-party OpenAI GPT-5.6 aliases to preserve wire-level `off` through generated pro aliases and to price requests above 272K input at each SKU's documented long-context rates.
 ### Fixed
 
-- Fixed xAI OAuth support for `grok-4.6` with its 500K context window, text-and-image input, and reasoning-effort controls. `grok-4.5` and `grok-4.6` now expose only their documented effort ladders, default to `high`, and cannot disable reasoning ([#8369](https://github.com/can1357/oh-my-pi/pull/8369) by [@dendritic](https://github.com/dendritic)).
+- Fixed xAI OAuth support for `grok-4.6` with its 500K context window, text-and-image input, and reasoning-effort controls. `grok-4.5` and `grok-4.6` now expose only their documented effort ladders, default to `high`, cannot disable reasoning, normalize Grok 4.5 `xhigh` requests to `high`, and omit unsupported presence penalties ([#8369](https://github.com/can1357/oh-my-pi/pull/8369) by [@dendritic](https://github.com/dendritic)).
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -50,6 +50,9 @@
 - Bounded OpenAI-compatible model discovery with a default request timeout so a stalled provider `/models` endpoint can no longer hang startup indefinitely in `resolveModelDiscoveryFallback` ([#8315](https://github.com/can1357/oh-my-pi/issues/8315)).
 - Fixed Codex-discovered `gpt-daybreak-*` aliases being treated as unknown models, restoring the GPT-5.6 `low`/`medium`/`high`/`xhigh`/`max` effort ladder and its 372K fallback only when the Codex registry omits `context_window`.
 - Fixed first-party OpenAI GPT-5.6 aliases to preserve wire-level `off` through generated pro aliases and to price requests above 272K input at each SKU's documented long-context rates.
+### Fixed
+
+- Fixed xAI OAuth support for `grok-4.6` with its 500K context window, text-and-image input, and reasoning-effort controls. `grok-4.5` and `grok-4.6` now expose only their documented effort ladders, default to `high`, and cannot disable reasoning ([#8369](https://github.com/can1357/oh-my-pi/pull/8369) by [@dendritic](https://github.com/dendritic)).
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -471,6 +471,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
 		// temperature/top_p/… with a 400 on every serving host (#5606).
 		supportsSamplingParams: !isOpenAISamplingRestrictedModelId(spec.id),
+		supportsPresencePenalty: spec.compat?.supportsPresencePenalty,
 		reasoningEffortMap: {},
 		supportsUsageInStreaming: !isCerebras,
 		// Kimi (including via OpenRouter and Fireworks router-form IDs such as
@@ -707,6 +708,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		// OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
 		// temperature/top_p/… with a 400 on every serving host (#5606).
 		supportsSamplingParams: !isOpenAISamplingRestrictedModelId(id),
+		supportsPresencePenalty: spec.compat?.supportsPresencePenalty,
 		thinkingFormat,
 		reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
 		omitReasoningEffort: false,

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -110,7 +110,13 @@ export const isGrokModelId = memo((modelId: string): boolean => {
 	return /(?:^|[./_-])grok(?:[-.]|$)/i.test(modelId);
 });
 
-const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
+const GROK_EFFORT_CAPABLE_PREFIXES = [
+	"grok-3-mini",
+	"grok-4.20-multi-agent",
+	"grok-4.3",
+	"grok-4.5",
+	"grok-4.6",
+] as const;
 
 /**
  * Grok SKUs that expose the wire `reasoning.effort` dial. Other Grok reasoners

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -60,7 +60,12 @@ const DEFAULT_REASONING_EFFORTS_WITH_XHIGH: readonly Effort[] = [
 ];
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
-const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+const LOW_MEDIUM_HIGH_XHIGH_REASONING_EFFORTS: readonly Effort[] = [
+	Effort.Low,
+	Effort.Medium,
+	Effort.High,
+	Effort.XHigh,
+];
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
 const LOW_MEDIUM_HIGH_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High];
 /** Wire-exact `low`/`high`/`max` scale used by Kimi K3 and DeepSeek V4 (Flash and Pro, direct API and aggregators). */
@@ -177,8 +182,9 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		thinking.supportsDisplay === undefined &&
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
-	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec.id);
-	const needsDefaultLevel = thinking.defaultLevel === undefined && isKimiK3ModelId(spec.id);
+	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec);
+	const inferredDefaultLevel = inferDefaultEffort(spec);
+	const needsDefaultLevel = thinking.defaultLevel === undefined && inferredDefaultLevel !== undefined;
 	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort && !needsDefaultLevel) {
 		return thinking;
 	}
@@ -197,7 +203,7 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		filled.supportsDisplay = true;
 	}
 	if (needsDefaultLevel) {
-		filled.defaultLevel = Effort.Max;
+		filled.defaultLevel = inferredDefaultLevel;
 	}
 	if (needsRequiresEffort) {
 		filled.requiresEffort = true;
@@ -216,8 +222,9 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 		mode: inferThinkingControlMode(spec, parsed),
 		efforts,
 	};
-	if (isKimiK3ModelId(spec.id)) {
-		config.defaultLevel = Effort.Max;
+	const defaultLevel = inferDefaultEffort(spec);
+	if (defaultLevel !== undefined) {
+		config.defaultLevel = defaultLevel;
 	}
 	const effortMap = inferEffortMap(spec, compat, config.mode, config.efforts);
 	if (effortMap !== undefined) {
@@ -229,7 +236,7 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 	) {
 		config.supportsDisplay = true;
 	}
-	if (impliesMandatoryReasoning(parsed, spec.id)) {
+	if (impliesMandatoryReasoning(parsed, spec)) {
 		config.requiresEffort = true;
 	}
 	return config;
@@ -308,10 +315,36 @@ function isGpt56PlusWireEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): bo
 	return parsed !== null && semverGte(parsed.version, "5.6");
 }
 
+/**
+ * OAuth reasoning policy versions documented by xAI. Keep this provider-scoped:
+ * other Grok gateways may expose different effort vocabularies.
+ * See https://docs.x.ai/developers/model-capabilities/text/reasoning.
+ */
+function xaiOAuthGrokThinkingVersion<TApi extends Api>(spec: ModelSpec<TApi>): "4.5" | "4.6" | undefined {
+	if (spec.provider !== "xai-oauth") return undefined;
+	const id = bareModelId(spec.id).toLowerCase();
+	if (id.startsWith("grok-4.6")) return "4.6";
+	if (id.startsWith("grok-4.5")) return "4.5";
+	return undefined;
+}
+
+function inferDefaultEffort<TApi extends Api>(spec: ModelSpec<TApi>): Effort | undefined {
+	if (isKimiK3ModelId(spec.id)) return Effort.Max;
+	if (xaiOAuthGrokThinkingVersion(spec) !== undefined) return Effort.High;
+	return undefined;
+}
+
 function getModelDefinedEfforts<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): readonly Effort[] | undefined {
+	const xaiOAuthGrokVersion = xaiOAuthGrokThinkingVersion(spec);
+	if (xaiOAuthGrokVersion === "4.6") {
+		return LOW_MEDIUM_HIGH_XHIGH_REASONING_EFFORTS;
+	}
+	if (xaiOAuthGrokVersion === "4.5") {
+		return LOW_MEDIUM_HIGH_REASONING_EFFORTS;
+	}
 	if (isGlm52ReasoningEffortModelId(spec.id)) {
 		// GLM-5.2's reasoning_effort dialect is host-specific (verified against
 		// live endpoints):
@@ -540,7 +573,7 @@ function inferOpenAISupportedEfforts(model: OpenAIModel): readonly Effort[] {
 		return FIVE_TIER_EFFORTS_LOW_TO_MAX;
 	}
 	if (semverGte(model.version, "5.2")) {
-		return GPT_5_2_PLUS_EFFORTS;
+		return LOW_MEDIUM_HIGH_XHIGH_REASONING_EFFORTS;
 	}
 	return DEFAULT_REASONING_EFFORTS;
 }
@@ -560,21 +593,23 @@ const OPENAI_O_SERIES_RE = /^o[134](?:$|[-:.])/i;
  * lowest effort, never off:
  * - Gemini 3.x exposes levels only; Gemini 2.5 Pro floors thinkingBudget at
  *   128 and rejects 0 (2.5 Flash/Flash-Lite keep the off switch).
+ * - xAI OAuth Grok 4.5/4.6 default to high reasoning and cannot disable it.
  * - OpenAI o-series and MiniMax M2 are reasoning-first architectures.
  * - Thinking-variant SKUs (`*-thinking`, `*-reasoner`, `*-reasoning`) ARE the
  *   thinking checkpoint; live bare twins pair-collapse away
  *   (variant-collapse) and the collapsed entry owns off — this floor protects
  *   the orphans.
  */
-function impliesMandatoryReasoning(parsed: ParsedModel, modelId: string): boolean {
+function impliesMandatoryReasoning<TApi extends Api>(parsed: ParsedModel, spec: ModelSpec<TApi>): boolean {
+	if (xaiOAuthGrokThinkingVersion(spec) !== undefined) return true;
 	if (parsed.family === "gemini") {
 		if (semverGte(parsed.version, "3.0")) return true;
 		if (parsed.kind === "pro" && semverGte(parsed.version, "2.5")) return true;
 	}
-	if (isKimiK3ModelId(modelId)) return true;
-	if (isMinimaxM2FamilyModelId(modelId)) return true;
-	if (OPENAI_O_SERIES_RE.test(bareModelId(modelId))) return true;
-	return findThinkingVariantToken(modelId) !== undefined;
+	if (isKimiK3ModelId(spec.id)) return true;
+	if (isMinimaxM2FamilyModelId(spec.id)) return true;
+	if (OPENAI_O_SERIES_RE.test(bareModelId(spec.id))) return true;
+	return findThinkingVariantToken(spec.id) !== undefined;
 }
 
 function inferAnthropicSupportedEfforts<TApi extends Api>(

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -104633,15 +104633,12 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				],
-				"effortMap": {
-					"minimal": "low"
-				}
+				"defaultLevel": "high",
+				"requiresEffort": true
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false,
@@ -104675,13 +104672,28 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"defaultLevel": "high",
+				"requiresEffort": true
+			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false,
 			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
 				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": true
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
 			}
 		},
 		"grok-build": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -104644,13 +104644,15 @@
 			"supportsComputerUseConfig": false,
 			"compat": {
 				"reasoningEffortMap": {
-					"minimal": "low"
+					"minimal": "low",
+					"xhigh": "high"
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
 				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
+				"supportsReasoningEffort": true,
+				"supportsPresencePenalty": false
 			}
 		},
 		"grok-4.6": {
@@ -104693,7 +104695,8 @@
 				"filterReasoningHistory": true,
 				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
+				"supportsReasoningEffort": true,
+				"supportsPresencePenalty": false
 			}
 		},
 		"grok-build": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1289,7 +1289,8 @@ interface XAICuratedModel {
 }
 
 // Source of truth for the xai-oauth chat picker. Top of list = headline.
-// Context windows from hermes-agent/agent/model_metadata.py:205-220
+// Grok 4.6 metadata: https://docs.x.ai/developers/models/grok-4.6.
+// Other context windows from hermes-agent/agent/model_metadata.py:205-220
 // ("Values sourced from models.dev (2026-04)"). grok-build is xAI's
 // coding-fine-tuned chat model; 512K context per user spec (2026-05-17).
 //
@@ -1298,6 +1299,7 @@ interface XAICuratedModel {
 // omit/include/history replay defaults live in catalog compat so every
 // OpenAI-family endpoint consumes the same constraint.
 export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
+	{ id: "grok-4.6", contextWindow: 500_000, name: "Grok 4.6", input: ["text", "image"] },
 	{
 		id: "grok-build",
 		contextWindow: 512_000,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1279,6 +1279,10 @@ interface XAICuratedModel {
 	 * single allowlist shared by this curated layer and the compat builder.
 	 */
 	supportsReasoningEffort?: boolean;
+	/** Model-specific wire aliases layered over the shared `minimal -> low` clamp. */
+	reasoningEffortMap?: OpenAICompat["reasoningEffortMap"];
+	/** Whether reasoning requests accept `presence_penalty`. Defaults to true. */
+	supportsPresencePenalty?: boolean;
 	/**
 	 * Input modalities this model accepts. Defaults to `["text"]` when absent.
 	 * Vision-capable Grok models MUST list `"image"` here so the curated layer
@@ -1299,7 +1303,13 @@ interface XAICuratedModel {
 // omit/include/history replay defaults live in catalog compat so every
 // OpenAI-family endpoint consumes the same constraint.
 export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
-	{ id: "grok-4.6", contextWindow: 500_000, name: "Grok 4.6", input: ["text", "image"] },
+	{
+		id: "grok-4.6",
+		contextWindow: 500_000,
+		name: "Grok 4.6",
+		input: ["text", "image"],
+		supportsPresencePenalty: false,
+	},
 	{
 		id: "grok-build",
 		contextWindow: 512_000,
@@ -1315,7 +1325,14 @@ export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
 		input: ["text", "image"],
 	},
 	{ id: "grok-4.3", contextWindow: 1_000_000, name: "Grok 4.3", input: ["text", "image"] },
-	{ id: "grok-4.5", contextWindow: 500_000, name: "Grok 4.5", input: ["text", "image"] },
+	{
+		id: "grok-4.5",
+		contextWindow: 500_000,
+		name: "Grok 4.5",
+		input: ["text", "image"],
+		reasoningEffortMap: { xhigh: "high" },
+		supportsPresencePenalty: false,
+	},
 	// grok-4.20-multi-agent-0309 is text-only per the bundled catalog; omit `input` for the default.
 	{ id: "grok-4.20-multi-agent-0309", contextWindow: 2_000_000, name: "Grok 4.20 (Multi-Agent)" },
 	{
@@ -1360,12 +1377,12 @@ function withXaiOAuthCompatDefaults(model: ModelSpec<"openai-responses">): Model
 	return { ...model, compat };
 }
 
-// Hermes-agent parity: only the `minimal -> low` clamp is applied (see
-// hermes-agent/agent/transports/codex.py:92 `_effort_clamp = {"minimal":
-// "low"}`). Hermes sends `xhigh` to xAI verbatim and we match that contract
-// — let xAI decide if the level is valid for the specific Grok model.
-// `resolveModelThinking` folds this into `model.thinking.effortMap`, downstream
-// of the omitReasoningEffort gate in pi-ai's stream.ts.
+// xAI does not expose `minimal`, so clamp it to `low` for every curated
+// reasoning model. Curated entries layer model-specific compatibility aliases:
+// xAI documents `xhigh` on Grok 4.5 as equivalent to `high`, while Grok 4.6
+// accepts `xhigh` verbatim.
+// `resolveModelThinking` folds visible mappings into `model.thinking.effortMap`;
+// hidden aliases remain in compat for stream-level request normalization.
 const XAI_REASONING_EFFORT_MAP = { minimal: "low" } as const;
 
 // xai-oauth's /v1/models exposes no per-request output limit on the OAuth
@@ -1394,12 +1411,17 @@ function mergeCuratedIntoModel(
 	const effortCapable = curated.supportsReasoningEffort ?? isGrokReasoningEffortCapable(curated.id);
 	const compat = {
 		...(base.compat ?? {}),
-		reasoningEffortMap: { ...XAI_REASONING_EFFORT_MAP, ...(base.compat?.reasoningEffortMap ?? {}) },
+		reasoningEffortMap: {
+			...XAI_REASONING_EFFORT_MAP,
+			...curated.reasoningEffortMap,
+			...(base.compat?.reasoningEffortMap ?? {}),
+		},
 		includeEncryptedReasoning: base.compat?.includeEncryptedReasoning ?? false,
 		filterReasoningHistory: base.compat?.filterReasoningHistory ?? true,
 		supportsImageDetailOriginal: base.compat?.supportsImageDetailOriginal ?? false,
 		omitReasoningEffort: !effortCapable,
 		supportsReasoningEffort: effortCapable,
+		supportsPresencePenalty: curated.supportsPresencePenalty ?? base.compat?.supportsPresencePenalty,
 	};
 	return {
 		...base,

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -76,11 +76,11 @@ export interface ThinkingConfig {
 	 */
 	suppressWhenOff?: boolean;
 	/**
-	 * Reasoning is mandatory upstream: the endpoint rejects disabled or
-	 * omitted thinking (e.g. OpenRouter Gemini 3.x — "Reasoning is mandatory
-	 * for this endpoint and cannot be disabled"). Request mapping clamps
-	 * thinking-off to the lowest supported effort unless `suppressWhenOff`
-	 * provides an explicit wire off-path.
+	 * Reasoning is mandatory upstream and cannot be disabled. Request mapping
+	 * applies `defaultLevel` when reasoning is omitted, falls back to the lowest
+	 * supported effort when no default exists, and clamps explicit thinking-off
+	 * requests to that same lowest effort unless `suppressWhenOff` provides an
+	 * explicit wire off-path.
 	 */
 	requiresEffort?: boolean;
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -363,6 +363,12 @@ export interface OpenAICompat {
 	 * model id. Default: true. Issue #5606.
 	 */
 	supportsSamplingParams?: boolean;
+	/**
+	 * Whether the endpoint accepts `presence_penalty` when other sampling
+	 * parameters remain supported. Defaults to true; xAI reasoning models
+	 * reject this field while still accepting controls such as `temperature`.
+	 */
+	supportsPresencePenalty?: boolean;
 	/** Always send a max-token field when the caller did not provide one. Default: auto-detected (Kimi-family models derive TPM limits from max_tokens). */
 	alwaysSendMaxTokens?: boolean;
 	/** Whether Responses-API tool-call/result history must be strictly paired. Default: auto-detected (Azure OpenAI, GitHub Copilot). */
@@ -578,6 +584,7 @@ export interface ResolvedOpenAISharedCompat {
 	reasoningEffortMap: Partial<Record<Effort, string>>;
 	supportsReasoningParams: boolean;
 	supportsSamplingParams: boolean;
+	supportsPresencePenalty?: boolean;
 	thinkingFormat: OpenAIReasoningFormat;
 	/** Kimi Code transport selected by live per-model protocol metadata. */
 	kimiApiFormat?: OpenAICompat["kimiApiFormat"];
@@ -643,6 +650,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "reasoningEffortMap"
 			| "supportsReasoningParams"
 			| "supportsSamplingParams"
+			| "supportsPresencePenalty"
 			| "thinkingFormat"
 			| "kimiApiFormat"
 			| "reasoningDisableMode"

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -10,8 +10,12 @@ import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { openrouterModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { Model, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import {
+	buildXaiOAuthStaticSeed,
+	openrouterModelManagerOptions,
+	xaiOAuthModelManagerOptions,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 function completionsSpec(overrides: Partial<ModelSpec<"openai-completions">> = {}): ModelSpec<"openai-completions"> {
 	return {
@@ -235,6 +239,80 @@ describe("xAI-OAuth Responses reasoning-effort suppression", () => {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 512_000,
 		maxTokens: 512_000,
+	});
+
+	it("curates a dynamically discovered grok-4.6 ahead of uncurated models", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{ id: "grok-future-unlisted", object: "model" },
+						{ id: "grok-4.6", object: "model" },
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const discovered = await xaiOAuthModelManagerOptions({
+			apiKey: "xai-oauth-test-token",
+			fetch: fetchMock,
+		}).fetchDynamicModels?.();
+
+		expect(discovered?.[0]).toMatchObject({
+			id: "grok-4.6",
+			name: "Grok 4.6",
+			contextWindow: 500_000,
+			maxTokens: 500_000,
+			reasoning: true,
+			input: ["text", "image"],
+			compat: {
+				supportsReasoningEffort: true,
+				omitReasoningEffort: false,
+			},
+		});
+		expect(discovered?.find(model => model.id === "grok-future-unlisted")?.compat?.omitReasoningEffort).toBe(true);
+	});
+
+	it("pins Grok 4.5 and 4.6 OAuth metadata and reasoning contracts", () => {
+		const seed = buildXaiOAuthStaticSeed();
+		const grok45 = seed.find(model => model.id === "grok-4.5");
+		const grok46 = seed.find(model => model.id === "grok-4.6");
+		if (!grok45 || !grok46) {
+			throw new Error("Grok 4.5 and 4.6 must be in the xAI OAuth curated seed");
+		}
+
+		const thinking45 = {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+			defaultLevel: Effort.High,
+			requiresEffort: true,
+		} as const;
+		const thinking46 = {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			defaultLevel: Effort.High,
+			requiresEffort: true,
+		} as const;
+
+		expect(seed[0]?.id).toBe("grok-4.6");
+		expect(grok46).toMatchObject({
+			name: "Grok 4.6",
+			contextWindow: 500_000,
+			maxTokens: 500_000,
+			reasoning: true,
+			input: ["text", "image"],
+		});
+		expect(buildModel(grok45).thinking).toEqual(thinking45);
+		expect(buildModel(grok46).thinking).toEqual(thinking46);
+		expect(getBundledModel("xai-oauth", "grok-4.5")?.thinking).toEqual(thinking45);
+		expect(getBundledModel("xai-oauth", "grok-4.6")).toMatchObject({
+			name: "Grok 4.6",
+			contextWindow: 500_000,
+			maxTokens: 500_000,
+			reasoning: true,
+			input: ["text", "image"],
+			thinking: thinking46,
+		});
 	});
 
 	it("omits the effort dial for a custom grok-build spec (off the allowlist)", () => {

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -268,6 +268,7 @@ describe("xAI-OAuth Responses reasoning-effort suppression", () => {
 			compat: {
 				supportsReasoningEffort: true,
 				omitReasoningEffort: false,
+				supportsPresencePenalty: false,
 			},
 		});
 		expect(discovered?.find(model => model.id === "grok-future-unlisted")?.compat?.omitReasoningEffort).toBe(true);
@@ -301,6 +302,14 @@ describe("xAI-OAuth Responses reasoning-effort suppression", () => {
 			maxTokens: 500_000,
 			reasoning: true,
 			input: ["text", "image"],
+		});
+		expect(grok45.compat).toMatchObject({
+			reasoningEffortMap: { minimal: "low", xhigh: "high" },
+			supportsPresencePenalty: false,
+		});
+		expect(grok46.compat).toMatchObject({
+			reasoningEffortMap: { minimal: "low" },
+			supportsPresencePenalty: false,
 		});
 		expect(buildModel(grok45).thinking).toEqual(thinking45);
 		expect(buildModel(grok46).thinking).toEqual(thinking46);

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -339,6 +339,7 @@ describe("isGrokReasoningEffortCapable", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.20-multi-agent")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.3")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.5")).toBe(true);
+		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.6")).toBe(true);
 		expect(isGrokReasoningEffortCapable("openrouter/xai/grok-3-mini")).toBe(true);
 	});
 


### PR DESCRIPTION
## What

The newly released Grok 4.6 does not expose reasoning-effort controls through xAI OAuth in OMP, while Grok 4.5 exposes an incorrect generic effort ladder. This PR fixes both models and aligns their request behavior with xAI’s documented constraints.

- Adds `grok-4.6` to the Grok reasoning-effort allowlist.
- Curates `grok-4.6` first in `XAI_OAUTH_CURATED_MODELS` with 500K context and text/image input.
- Corrects the visible xAI OAuth effort ladders:
  - `grok-4.5`: `low | medium | high`
  - `grok-4.6`: `low | medium | high | xhigh`
- Defaults both models to `high` and marks reasoning as mandatory.
- Retains `minimal → low` as a compatibility clamp without exposing `minimal` in the picker.
- Normalizes programmatic Grok 4.5 `xhigh` requests to `high`, matching xAI’s documented fallback.
- Omits unsupported `presence_penalty` from Grok 4.5/4.6 requests while preserving supported sampling controls such as `temperature` and `top_p`.
- Regenerates the corresponding bundled `xai-oauth` metadata and updates the catalog changelog.

## Why

xAI OAuth discovery returns the `grok-4.6` model ID but does not provide the context, modality, or reasoning metadata required by the catalog. Because `grok-4.6` was neither curated nor included in the effort-capable allowlist, OMP hid the effort picker and omitted `reasoning.effort` from requests.

The generic OpenAI Responses effort ladder also exposed levels that do not match Grok’s documented model-specific controls. In addition, xAI rejects `presencePenalty`, `frequencyPenalty`, and `stop` for reasoning models. The Responses adapter already omits the latter two; this PR adds a granular presence-penalty compatibility gate without unnecessarily suppressing supported sampling controls.

The resulting behavior follows xAI’s documentation:

- [Grok 4.6 model metadata](https://docs.x.ai/developers/models/grok-4.6)
- [Reasoning effort levels and request constraints](https://docs.x.ai/developers/model-capabilities/text/reasoning)

## Model behavior

| Model | Context | Input | Visible efforts | Default | Programmatic compatibility |
|---|---:|---|---|---|---|
| `grok-4.5` | 500K | text, image | `low`, `medium`, `high` | `high` | `minimal → low`, `xhigh → high` |
| `grok-4.6` | 500K | text, image | `low`, `medium`, `high`, `xhigh` | `high` | `minimal → low` |

Both models require reasoning and cannot be disabled.

## Testing

```sh
bun test packages/catalog/test/build.test.ts \
  packages/catalog/test/model-thinking.test.ts \
  packages/ai/test/xai-oauth-effort-strip.test.ts \
  packages/ai/test/openai-responses-sampling-params.test.ts \
  packages/ai/test/openai-completions-compat.test.ts
```

Result: **166 passed, 0 failed**.

Regression coverage includes:

- Static and dynamically discovered xAI OAuth curation.
- Grok 4.5/4.6 visible effort ladders, mandatory reasoning, and `high` defaults.
- Grok 4.5 programmatic `xhigh → high` request normalization.
- Grok 4.6 `minimal → low` and native `xhigh` wire behavior.
- Omission of `presence_penalty` while `temperature` and `top_p` remain forwarded.
- Bundled catalog parity for the new compatibility metadata.

Additional verification:

- `bun check`: passed.
- `git diff --check`: passed.
- Credentialed xAI OAuth discovery reported:
  - `grok-4.5`: 500K, image-capable, `low | medium | high`
  - `grok-4.6`: 500K, image-capable, `low | medium | high | xhigh`
- Live OAuth effort requests succeeded:
  - `grok-4.5`: `low`, `medium`, `high`
  - `grok-4.6`: `low`, `medium`, `high`, `xhigh`

## Out of scope

- Changing the xAI OAuth default model.
- Changing paid `xai` API routing or effort behavior.
- The broader paid-xAI Responses migration in #7454.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated