### PR TITLE
fix: retry transient Anthropic failures at oneshot LLM call sites

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -19,6 +19,14 @@
 ### Fixed
 
 - Preserved queued steering and follow-up messages when a continuation is cancelled before or during pre-dequeue hooks, and propagated the caller's cancellation signal through every continuation model-call loop.
+### Added
+
+- Added an opt-in `retry` option to `instrumentedCompleteSimple` (`InstrumentedChatSpanOptions.retry`) that re-issues a oneshot completion on transient Anthropic failures. Opt-in rather than default-on because `oneshotKind` is free-form and callers may pass arbitrary `ctx.tools`, so the funnel cannot itself prove a request is replay-safe. Response headers are captured per attempt and cleared between attempts, so a stale `retry-after` can never be reused for a later failure.
+
+### Fixed
+
+- Fixed `/handoff`, branch summarization and manual `/compact` aborting on the first transient provider blip. Each is a single, side-effect-free completion whose result is parsed after it resolves, so an Anthropic `overloaded_error` / 429 / 529 now retries instead of failing the whole operation — previously one blip left the user's context full.
+- Added `SummaryOptions.oneshotRetry` so the compaction summarization oneshots can be retried by the caller that needs it without inflating the caller that does not. Manual `/compact` has no outer loop and gets retry by default; auto-compaction passes `false` because `session-maintenance` already retries the whole attempt, and nesting would multiply the request budget (10 outer x 3 inner) while stacking each outer wait on an inner backoff.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -338,7 +338,7 @@ export async function generateBranchSummary(
 		model,
 		{ systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT], messages: summarizationMessages },
 		{ apiKey, signal, maxTokens: 2048, metadata },
-		{ telemetry: options.telemetry, oneshotKind: "branch_summary", completeImpl: options.completeImpl },
+		{ telemetry: options.telemetry, oneshotKind: "branch_summary", completeImpl: options.completeImpl, retry: {} },
 	);
 
 	// Check if aborted or errored

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -16,6 +16,7 @@ import {
 	type Message,
 	type MessageAttribution,
 	type Model,
+	type OneshotRetryOptions,
 	type ProviderSessionState,
 	type SimpleStreamOptions,
 	type Tool,
@@ -831,6 +832,31 @@ export interface SummaryOptions {
 		ctx: Context,
 		options: SimpleStreamOptions,
 	) => Promise<AssistantMessage>;
+	/**
+	 * Transient-failure retry for the summarization oneshots (`generateSummary`,
+	 * `generateShortSummary`, `generateTurnPrefixSummary`).
+	 *
+	 * Defaults to enabled, which is what a one-shot caller such as manual
+	 * `/compact` needs: a single Anthropic `overloaded_error` / 429 / 529 should
+	 * not abort compaction and leave the context full.
+	 *
+	 * Pass `false` when the CALLER already owns a retry loop around the whole
+	 * compaction attempt — auto-compaction does — otherwise the two budgets
+	 * multiply (10 outer attempts x 3 inner = 30 requests) and each outer wait
+	 * stacks on top of the inner backoff.
+	 */
+	oneshotRetry?: OneshotRetryOptions | false;
+}
+
+/**
+ * Resolve the oneshot retry policy for a summarization call. Enabled by default
+ * so a lone transient blip cannot abort compaction; `false` opts out for callers
+ * that already retry the whole attempt (see `SummaryOptions.oneshotRetry`).
+ */
+function summaryOneshotRetry(options: SummaryOptions | undefined): OneshotRetryOptions | undefined {
+	const configured = options?.oneshotRetry;
+	if (configured === false) return undefined;
+	return configured ?? {};
 }
 
 function localCodexCompaction(options: SummaryOptions | undefined) {
@@ -935,7 +961,12 @@ export async function generateSummary(
 			providerSessionState: options?.providerSessionState,
 			codexCompaction: localCodexCompaction(options),
 		},
-		{ telemetry: options?.telemetry, oneshotKind: "compaction_summary", completeImpl: options?.completeImpl },
+		{
+			telemetry: options?.telemetry,
+			oneshotKind: "compaction_summary",
+			completeImpl: options?.completeImpl,
+			retry: summaryOneshotRetry(options),
+		},
 	);
 
 	if (response.stopReason === "error") {
@@ -1034,13 +1065,14 @@ export async function generateHandoffFromContext(
 		telemetry: options.telemetry,
 		oneshotKind: "handoff",
 		completeImpl: options.completeImpl,
+		retry: {},
 	});
 	if (response.stopReason === "error" && shouldRetryHandoffWithAutoToolChoice(response)) {
 		response = await instrumentedCompleteSimple(
 			model,
 			context,
 			{ ...requestOptions, toolChoice: "auto" },
-			{ telemetry: options.telemetry, oneshotKind: "handoff", completeImpl: options.completeImpl },
+			{ telemetry: options.telemetry, oneshotKind: "handoff", completeImpl: options.completeImpl, retry: {} },
 		);
 	}
 
@@ -1143,7 +1175,12 @@ async function generateShortSummary(
 			providerSessionState: options?.providerSessionState,
 			codexCompaction: localCodexCompaction(options),
 		},
-		{ telemetry: options?.telemetry, oneshotKind: "compaction_short_summary", completeImpl: options?.completeImpl },
+		{
+			telemetry: options?.telemetry,
+			oneshotKind: "compaction_short_summary",
+			completeImpl: options?.completeImpl,
+			retry: summaryOneshotRetry(options),
+		},
 	);
 
 	if (response.stopReason === "error") {
@@ -1719,7 +1756,12 @@ async function generateTurnPrefixSummary(
 			providerSessionState: options?.providerSessionState,
 			codexCompaction: localCodexCompaction(options),
 		},
-		{ telemetry: options?.telemetry, oneshotKind: "compaction_turn_prefix", completeImpl: options?.completeImpl },
+		{
+			telemetry: options?.telemetry,
+			oneshotKind: "compaction_turn_prefix",
+			completeImpl: options?.completeImpl,
+			retry: summaryOneshotRetry(options),
+		},
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -30,6 +30,8 @@ import {
 	completeSimple,
 	type Message,
 	type Model,
+	type OneshotRetryOptions,
+	retryTransientCompletion,
 	type ServiceTier,
 	type SimpleStreamOptions,
 	type StopReason,
@@ -1663,6 +1665,23 @@ export interface InstrumentedChatSpanOptions {
 		ctx: Context,
 		options: SimpleStreamOptions,
 	) => Promise<AssistantMessage>;
+	/**
+	 * Opt in to transient-failure retry for this oneshot (Anthropic
+	 * `overloaded_error`, `rate_limit_error`, 429/500/502/503/529). Omitted or
+	 * `undefined` means **no retry** — the failure is surfaced exactly as before.
+	 *
+	 * Deliberately opt-in rather than default-on: `oneshotKind` is free-form and
+	 * callers may pass arbitrary `ctx.tools` / `options.toolChoice`, so this
+	 * funnel cannot itself prove a given request is replay-safe. Re-issuing is
+	 * only safe when the call performs no side effect and nothing consumed
+	 * partial output — true for summaries, titles, handoffs and image
+	 * descriptions, which parse a complete response after it resolves. Enable it
+	 * per call site, as a reviewed decision.
+	 *
+	 * Pass `{}` to accept the {@link retryTransientCompletion} defaults
+	 * (3 attempts, 500ms base backoff, `retry-after` honored).
+	 */
+	readonly retry?: OneshotRetryOptions;
 }
 
 /**
@@ -1723,10 +1742,26 @@ export async function instrumentedCompleteSimple<TApi extends Api>(
 	try {
 		return await runInActiveSpan(chatSpan, async () => {
 			const complete = span.completeImpl ?? completeSimple;
-			const message = await complete(model, ctx, {
-				...options,
-				onResponse: captureOnResponse,
-			});
+			// Opt-in only (see `retry` on InstrumentedChatSpanOptions): each attempt
+			// re-issues the whole request, which is safe only for replay-safe
+			// oneshots. `getResponseHeaders` hands the failed attempt's headers to
+			// the retry layer — an AssistantMessage carries none, so this is what
+			// makes `retry-after` on a real 429/529 actually honored.
+			const runOnce = () => {
+				// Clear first so a previous attempt's `retry-after` can never be
+				// reused for a later failure that arrived without headers.
+				capturedHeaders = undefined;
+				return complete(model, ctx, { ...options, onResponse: captureOnResponse });
+			};
+			const message = span.retry
+				? await retryTransientCompletion(runOnce, {
+						...span.retry,
+						// Framework-owned: the caller must not be able to detach the
+						// abort signal or the header source by passing them itself.
+						signal: options.signal,
+						getResponseHeaders: () => capturedHeaders,
+					})
+				: await runOnce();
 			await finishChatSpan(telemetry, chatSpan, message, {
 				stepNumber,
 				serviceTier: options.serviceTier,

--- a/packages/agent/test/compaction-oneshot-retry.test.ts
+++ b/packages/agent/test/compaction-oneshot-retry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { generateSummary } from "@oh-my-pi/pi-agent-core/compaction";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core/types";
+import type { AssistantMessage, Model, Usage } from "@oh-my-pi/pi-ai/types";
+
+/**
+ * Defends `SummaryOptions.oneshotRetry`, the split that lets manual `/compact`
+ * survive a transient provider blip without inflating auto-compaction's budget.
+ *
+ * Both paths call the same `generateSummary`, so the policy cannot be a constant
+ * inside it. Auto-compaction wraps the whole attempt in its own retry loop
+ * (`session-maintenance.ts`), and a nested inner loop would multiply requests
+ * (10 outer x 3 inner) while stacking each outer wait on an inner backoff.
+ * Manual `/compact` has no outer loop: without retry, one `overloaded_error`
+ * aborts compaction and leaves the user's context full.
+ *
+ * A transient failure arrives as a **resolved** `AssistantMessage` with
+ * `stopReason: "error"`, which is why `completeImpl` returning that value —
+ * rather than throwing — is the realistic stub here.
+ */
+
+const emptyUsage = (): Usage =>
+	({
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	}) as unknown as Usage;
+
+const model = {
+	id: "claude-sonnet-4-6",
+	provider: "anthropic",
+	api: "anthropic-messages",
+	baseUrl: "https://api.anthropic.com",
+	maxTokens: 8192,
+} as unknown as Model;
+
+// `ApiKey` is `string | ApiKeyResolver`; the stubbed `completeImpl` never uses it.
+const apiKey = "test-key";
+
+const messages = [{ role: "user", content: "summarize this session", timestamp: 0 }] as unknown as AgentMessage[];
+
+function overloaded(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "" }],
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: emptyUsage(),
+		stopReason: "error",
+		errorMessage: "overloaded_error: Overloaded",
+		errorStatus: 529,
+		timestamp: 0,
+	} as unknown as AssistantMessage;
+}
+
+function summary(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: emptyUsage(),
+		stopReason: "stop",
+		timestamp: 0,
+	} as unknown as AssistantMessage;
+}
+
+describe("SummaryOptions.oneshotRetry", () => {
+	it("retries a transient failure by default, so manual /compact survives a blip", async () => {
+		let calls = 0;
+		const text = await generateSummary(messages, model, 10_000, apiKey, undefined, undefined, undefined, {
+			// No `oneshotRetry`: the manual `/compact` shape. The one real backoff
+			// wait (default 500ms) is the price of asserting the DEFAULT rather than
+			// a value this test picked for itself.
+			completeImpl: () => {
+				calls += 1;
+				return Promise.resolve(calls === 1 ? overloaded() : summary("recovered summary"));
+			},
+		});
+
+		expect(calls).toBe(2);
+		expect(text).toContain("recovered summary");
+	});
+
+	it("makes exactly one attempt when the caller owns the retry loop", async () => {
+		let calls = 0;
+		const attempt = generateSummary(messages, model, 10_000, apiKey, undefined, undefined, undefined, {
+			// What auto-compaction passes: its own loop re-runs the whole attempt.
+			oneshotRetry: false,
+			completeImpl: () => {
+				calls += 1;
+				return Promise.resolve(overloaded());
+			},
+		});
+
+		// The failure must surface for the outer loop to classify and retry.
+		await expect(attempt).rejects.toThrow();
+		expect(calls).toBe(1);
+	});
+});

--- a/packages/agent/test/instrumented-oneshot-retry.test.ts
+++ b/packages/agent/test/instrumented-oneshot-retry.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "bun:test";
+import { instrumentedCompleteSimple } from "@oh-my-pi/pi-agent-core/telemetry";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@oh-my-pi/pi-ai/types";
+
+/**
+ * Defends the opt-in contract of the oneshot retry funnel.
+ *
+ * `instrumentedCompleteSimple` is the single entry point for every oneshot LLM
+ * call in the agent (compaction summaries, handoff, branch summary, image
+ * inspection). A transient Anthropic failure surfaces as a **resolved**
+ * `AssistantMessage` with `stopReason: "error"`, so retry has to be decided
+ * here rather than by a try/catch anywhere above.
+ *
+ * Retry is deliberately opt-in: `oneshotKind` is free-form and callers may pass
+ * arbitrary `ctx.tools`, so the funnel cannot prove an arbitrary request is
+ * replay-safe. These tests pin both halves of that contract — omitted means one
+ * attempt, `{}` means the transient failure is re-issued — plus the
+ * attempt-local header reset that keeps a stale `retry-after` from leaking into
+ * a later attempt.
+ */
+
+const emptyUsage = (): Usage =>
+	({
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	}) as unknown as Usage;
+
+const model = {
+	id: "claude-sonnet-4-6",
+	provider: "anthropic",
+	api: "anthropic-messages",
+	baseUrl: "https://api.anthropic.com",
+} as unknown as Model<Api>;
+
+const ctx = { systemPrompt: "s", messages: [] } as unknown as Context;
+
+function reply(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: emptyUsage(),
+		stopReason: "stop",
+		timestamp: 0,
+		...overrides,
+	} as AssistantMessage;
+}
+
+const overloaded = (): AssistantMessage =>
+	reply({
+		stopReason: "error",
+		errorStatus: 529,
+		errorMessage: "Anthropic stream error (overloaded_error): Overloaded",
+	});
+
+describe("instrumentedCompleteSimple transient retry", () => {
+	it("does not retry when `retry` is omitted", async () => {
+		let calls = 0;
+		const result = await instrumentedCompleteSimple(model, ctx, {} as SimpleStreamOptions, {
+			telemetry: undefined,
+			oneshotKind: "test_no_retry",
+			completeImpl: () => {
+				calls += 1;
+				return Promise.resolve(overloaded());
+			},
+		});
+
+		expect(calls).toBe(1);
+		expect(result.stopReason).toBe("error");
+	});
+
+	it("re-issues a transient failure when `retry: {}` is set", async () => {
+		let calls = 0;
+		const result = await instrumentedCompleteSimple(model, ctx, {} as SimpleStreamOptions, {
+			telemetry: undefined,
+			oneshotKind: "test_retry",
+			retry: { baseDelayMs: 1 },
+			completeImpl: () => {
+				calls += 1;
+				return Promise.resolve(calls === 1 ? overloaded() : reply());
+			},
+		});
+
+		expect(calls).toBe(2);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("keeps the caller's failure contract once attempts are exhausted", async () => {
+		let calls = 0;
+		const result = await instrumentedCompleteSimple(model, ctx, {} as SimpleStreamOptions, {
+			telemetry: undefined,
+			oneshotKind: "test_exhausted",
+			retry: { baseDelayMs: 1, maxAttempts: 2 },
+			completeImpl: () => {
+				calls += 1;
+				return Promise.resolve(overloaded());
+			},
+		});
+
+		expect(calls).toBe(2);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("overloaded_error");
+	});
+
+	it("does not reuse a previous attempt's retry-after header", async () => {
+		// Attempt 1 fails WITH a retry-after header; attempt 2 fails WITHOUT one.
+		// If headers were not cleared per attempt, the stale hint would be applied
+		// again and the second wait would jump from ~1ms backoff back to 300ms.
+		const waits: number[] = [];
+		let calls = 0;
+		await instrumentedCompleteSimple(model, ctx, {} as SimpleStreamOptions, {
+			telemetry: undefined,
+			oneshotKind: "test_header_reset",
+			retry: { baseDelayMs: 1, maxAttempts: 3, onRetry: info => waits.push(info.delayMs) },
+			completeImpl: (_model, _ctx, options) => {
+				calls += 1;
+				if (calls === 1) {
+					options.onResponse?.({ status: 429, headers: { "retry-after-ms": "300" } }, undefined as never);
+				}
+				return Promise.resolve(calls < 3 ? overloaded() : reply());
+			},
+		});
+
+		expect(calls).toBe(3);
+		expect(waits).toHaveLength(2);
+		expect(waits[0]).toBe(300);
+		// Second failure carried no header, so it must fall back to plain backoff.
+		expect(waits[1]).toBeLessThan(50);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -74,6 +74,9 @@
 - Fixed OpenAI Codex usage telemetry blocking explicitly allowed ChatGPT Team credentials when a weekly `used_percent` rounded to 100, which could route multi-account sessions to an actually exhausted sibling instead ([#7617](https://github.com/can1357/oh-my-pi/issues/7617)).
 - Fixed OpenAI Codex GPT-5.x requests sending optional `reasoning.summary`, `reasoning.context`, and `text.verbosity` controls by default, reducing Codex `server_error` disconnects from unsupported request shapes. ([#4949](https://github.com/can1357/oh-my-pi/issues/4949))
 - Classified concurrent-request caps separately from quota exhaustion so they use a short retry backoff without burning a credential, and rotate credentials for account-scoped 403 caps such as Devin's overall message limit.
+### Added
+
+- Added `retryTransientCompletion` for oneshot (non-agent-loop) LLM calls. `completeSimple` reports a transient provider failure — Anthropic `overloaded_error` / `rate_limit_error`, HTTP 429/500/502/503/529 — by **resolving** with `stopReason: "error"` rather than throwing, so callers that wrapped it in a try/catch-based retry never actually retried. The helper handles both shapes (resolved error-stop and thrown error), classifies with the existing `AIError` predicates so the retryable set stays defined in one place, honors `retry-after` / `x-ratelimit-reset*` from response headers (supplied via `getResponseHeaders`, since an `AssistantMessage` carries none) or from the error text, and returns/rethrows the failure unchanged once attempts are exhausted so existing caller fallbacks keep working. Aborts surface immediately.
 
 ## [17.2.7] - 2026-08-03
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -6,6 +6,7 @@ export * from "./auth-gateway/types";
 export * from "./auth-retry";
 export * from "./auth-storage";
 export * from "./error/rate-limit";
+export * from "./oneshot-retry";
 export * from "./provider-details";
 export * from "./providers/anthropic";
 export * from "./providers/anthropic-client";

--- a/packages/ai/src/oneshot-retry.ts
+++ b/packages/ai/src/oneshot-retry.ts
@@ -1,0 +1,213 @@
+import { extractRetryHint } from "@oh-my-pi/pi-utils";
+import * as AIError from "./error";
+import type { AssistantMessage } from "./types";
+import { getHeadersFromError, getRetryAfterMsFromHeaders, type HeadersLike } from "./utils/retry-after";
+
+/**
+ * Transient-failure retry for **oneshot** (non-agent-loop) completions.
+ *
+ * Why this exists: `streamSimple`/`completeSimple` retry *auth* failures
+ * (credential rotation) but deliberately surface *transient* provider failures
+ * — Anthropic `overloaded_error`, `rate_limit_error`, HTTP 429/500/502/503/529
+ * — as a **resolved** `AssistantMessage` with `stopReason: "error"`. For the
+ * main agent turn that is correct: `TurnRecovery` owns recovery there, and it
+ * must refuse to replay once tool calls or visible text have streamed.
+ *
+ * Oneshots have no such hazard. A summary, title, handoff, or image
+ * description produces no side effects, so re-issuing the whole request is
+ * safe and is almost always what the caller wants. Before this helper every
+ * oneshot call site had to re-implement that decision, and most did not —
+ * failing on the first blip, or swallowing it into `null` so a transient
+ * overload was indistinguishable from a legitimate empty result.
+ *
+ * Classification reuses the existing provider predicates (`AIError`), so the
+ * set of retryable Anthropic failures stays defined in exactly one place.
+ * Usage limits are included: unlike the provider loop — which excludes them so
+ * credential rotation can own them — a oneshot has no rotation layer above it,
+ * and the retry hint the provider supplies (`retry-after`, "try again in ~5m")
+ * is honored, so waiting is the correct response.
+ */
+export interface OneshotRetryOptions {
+	/** Total attempts, including the first. Default 3. Values < 1 are treated as 1. */
+	maxAttempts?: number;
+	/** First backoff step in ms; doubles per attempt. Default 500. */
+	baseDelayMs?: number;
+	/**
+	 * Upper bound for a single wait. Default 30_000. A provider retry hint
+	 * longer than this aborts the retry instead of parking the caller — the
+	 * error surfaces so higher-level recovery (or the user) can decide.
+	 */
+	maxDelayMs?: number;
+	/**
+	 * Stops further attempts. Two distinct paths, both preserving the caller's
+	 * intent: an abort already visible when an attempt settles surfaces that
+	 * attempt's own result (`completeSimple` reports `stopReason: "aborted"`),
+	 * while an abort that lands during the backoff wait rejects with the abort
+	 * reason — a user cancel stays a cancel and is never relabelled as the
+	 * provider failure we happened to be waiting on.
+	 *
+	 * This helper does NOT pass the signal into `run` — cancelling the in-flight
+	 * request is the closure's job, because a per-attempt deadline must be
+	 * rebuilt on every attempt. Construct it inside `run`
+	 * (`signal: AbortSignal.timeout(MS)`, or `AbortSignal.any([outer, perAttempt])`);
+	 * a deadline captured outside would fire once and then abort every retry,
+	 * silently turning this helper into a single attempt.
+	 */
+	signal?: AbortSignal;
+	/**
+	 * Headers of the attempt that just failed, used to honor `retry-after`.
+	 *
+	 * Load-bearing: a transient Anthropic failure arrives as a **resolved**
+	 * `AssistantMessage`, and `AssistantMessage` carries no headers — so without
+	 * this the real `retry-after` / `x-ratelimit-reset` values on a 429/529 are
+	 * invisible and only the (usually hint-free) error text is available.
+	 * Callers that already capture headers via `SimpleStreamOptions.onResponse`
+	 * should return the latest capture here; it is read once per failed attempt.
+	 * Thrown errors need no wiring — headers are recovered from the error itself.
+	 */
+	getResponseHeaders?: () => HeadersLike;
+	/** Observability hook. Fires immediately before sleeping. */
+	onRetry?: (info: OneshotRetryInfo) => void;
+}
+
+export interface OneshotRetryInfo {
+	/** 1-based index of the attempt that just failed. */
+	attempt: number;
+	maxAttempts: number;
+	delayMs: number;
+	/** True when `delayMs` came from a provider retry hint rather than backoff. */
+	fromRetryHint: boolean;
+	errorMessage: string;
+	/** `AIError` classification bits of the failure. */
+	errorId: number;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+/** Cap on pure backoff growth. A provider hint may still exceed this, up to `maxDelayMs`. */
+const BACKOFF_CEILING_MS = 8_000;
+
+function backoffDelayMs(attempt: number, baseDelayMs: number): number {
+	const growth = Math.min(baseDelayMs * 2 ** (attempt - 1), BACKOFF_CEILING_MS);
+	// 75-100% jitter, matching the provider loop and TurnRecovery, so a fleet of
+	// concurrent oneshots does not re-converge on the same instant.
+	return Math.round(growth * (0.75 + Math.random() * 0.25));
+}
+
+/** Retryable when the provider says transient, or when it says "wait, then retry". */
+function isRetryableOneshotFailure(errorId: number): boolean {
+	return (
+		AIError.is(errorId, AIError.Flag.Transient) ||
+		AIError.is(errorId, AIError.Flag.UsageLimit) ||
+		AIError.retriable(errorId)
+	);
+}
+
+function sleep(delayMs: number, signal?: AbortSignal): Promise<void> {
+	if (delayMs <= 0) return Promise.resolve();
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const timer = setTimeout(() => {
+		signal?.removeEventListener("abort", onAbort);
+		resolve();
+	}, delayMs);
+	const onAbort = () => {
+		clearTimeout(timer);
+		reject(signal?.reason ?? new AIError.AbortError("oneshot retry aborted"));
+	};
+	if (signal) {
+		if (signal.aborted) {
+			clearTimeout(timer);
+			return Promise.reject(signal.reason ?? new AIError.AbortError("oneshot retry aborted"));
+		}
+		signal.addEventListener("abort", onAbort, { once: true });
+	}
+	return promise;
+}
+
+/**
+ * Run a oneshot completion, retrying transient provider failures.
+ *
+ * Handles both failure shapes: a resolved `AssistantMessage` carrying
+ * `stopReason: "error"` (what `completeSimple` produces) and a thrown error
+ * (what the raw HTTP helpers produce). A non-retryable failure is returned or
+ * rethrown unchanged, so existing caller error handling keeps working — this
+ * only removes the *first-blip* failure mode.
+ */
+export async function retryTransientCompletion(
+	run: (attempt: number) => Promise<AssistantMessage>,
+	options?: OneshotRetryOptions,
+): Promise<AssistantMessage> {
+	const maxAttempts = Math.max(1, options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+	const baseDelayMs = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+	const maxDelayMs = options?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+	const signal = options?.signal;
+
+	for (let attempt = 1; ; attempt++) {
+		let message: AssistantMessage | undefined;
+		let thrown: unknown;
+		try {
+			message = await run(attempt);
+			if (message.stopReason !== "error") return message;
+		} catch (error) {
+			thrown = error;
+		}
+		// A caller abort is never a transient failure — surface it immediately so
+		// cancellation stays responsive.
+		if (signal?.aborted) {
+			if (thrown !== undefined) throw thrown;
+			return message as AssistantMessage;
+		}
+
+		const errorId =
+			thrown !== undefined ? AIError.classify(thrown) : AIError.classifyMessage(message as AssistantMessage);
+		if (AIError.is(errorId, AIError.Flag.Abort) || AIError.is(errorId, AIError.Flag.UserInterrupt)) {
+			if (thrown !== undefined) throw thrown;
+			return message as AssistantMessage;
+		}
+		const errorMessage =
+			thrown !== undefined
+				? thrown instanceof Error
+					? thrown.message
+					: String(thrown)
+				: ((message as AssistantMessage).errorMessage ?? "unknown error");
+		const lastAttempt = attempt >= maxAttempts;
+		if (lastAttempt || !isRetryableOneshotFailure(errorId)) {
+			if (thrown !== undefined) throw thrown;
+			return message as AssistantMessage;
+		}
+
+		// Headers first: a real Anthropic 429/529 carries `retry-after` /
+		// `x-ratelimit-reset*` in the response, and the resolved AssistantMessage
+		// has none — the caller supplies them via `getResponseHeaders`. Thrown
+		// errors (e.g. AnthropicApiError) carry their own headers.
+		const headers: HeadersLike = thrown !== undefined ? getHeadersFromError(thrown) : options?.getResponseHeaders?.();
+		const headerHintMs = getRetryAfterMsFromHeaders(headers);
+		const textHintMs = extractRetryHint(undefined, errorMessage);
+		const hintMs =
+			headerHintMs === undefined && textHintMs === undefined
+				? undefined
+				: Math.max(headerHintMs ?? 0, textHintMs ?? 0);
+		// An over-cap hint means "come back much later"; parking a oneshot that
+		// long is worse than surfacing the failure to the caller.
+		if (hintMs !== undefined && hintMs > maxDelayMs) {
+			if (thrown !== undefined) throw thrown;
+			return message as AssistantMessage;
+		}
+		const backoff = backoffDelayMs(attempt, baseDelayMs);
+		const delayMs = Math.min(Math.max(hintMs ?? 0, backoff), maxDelayMs);
+
+		options?.onRetry?.({
+			attempt,
+			maxAttempts,
+			delayMs,
+			fromRetryHint: hintMs !== undefined && hintMs >= backoff,
+			errorMessage,
+			errorId,
+		});
+		// Aborting mid-backoff rejects with the caller's abort reason: a user
+		// cancel must stay a cancel, not get relabelled as the provider failure we
+		// happened to be waiting on.
+		await sleep(delayMs, signal);
+	}
+}

--- a/packages/ai/test/oneshot-retry.test.ts
+++ b/packages/ai/test/oneshot-retry.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "bun:test";
+import { retryTransientCompletion } from "@oh-my-pi/pi-ai/oneshot-retry";
+import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai/types";
+
+/**
+ * Defends the contract every oneshot LLM call site now depends on:
+ * `completeSimple` reports a transient provider failure by RESOLVING with
+ * `stopReason: "error"` rather than throwing, so a retry layer that only
+ * catches exceptions silently never fires. Before this helper, an Anthropic
+ * `overloaded_error` / 429 / 529 on a summary, title, handoff or image
+ * description failed on the first blip — or was swallowed into `null`, making a
+ * transient overload indistinguishable from a legitimate empty result.
+ *
+ * These tests pin the four properties the call sites rely on: transient
+ * error-stops are re-issued, non-transient ones are not, the final failure is
+ * handed back unchanged (so existing `null`/throw fallbacks still work), and a
+ * caller abort wins immediately.
+ */
+
+const emptyUsage = (): Usage =>
+	({
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	}) as unknown as Usage;
+
+function message(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: emptyUsage(),
+		stopReason: "stop",
+		timestamp: 0,
+		...overrides,
+	} as AssistantMessage;
+}
+
+const overloaded = (): AssistantMessage =>
+	message({
+		stopReason: "error",
+		errorStatus: 529,
+		errorMessage: "Anthropic stream error (overloaded_error): Overloaded",
+	});
+
+const rateLimited = (): AssistantMessage =>
+	message({ stopReason: "error", errorStatus: 429, errorMessage: "rate_limit_error: too many requests" });
+
+// Keep the suite fast: the helper's real backoff floor is 500ms.
+const fast = { baseDelayMs: 1, maxAttempts: 3 } as const;
+
+describe("retryTransientCompletion", () => {
+	it("re-issues an Anthropic 529 error-stop and returns the eventual success", async () => {
+		const results = [overloaded(), overloaded(), message({ stopReason: "stop" })];
+		let calls = 0;
+		const final = await retryTransientCompletion(() => {
+			calls += 1;
+			return Promise.resolve(results.shift()!);
+		}, fast);
+
+		expect(calls).toBe(3);
+		expect(final.stopReason).toBe("stop");
+	});
+
+	it("re-issues a 429 rate-limit error-stop", async () => {
+		let calls = 0;
+		const final = await retryTransientCompletion(() => {
+			calls += 1;
+			return Promise.resolve(calls === 1 ? rateLimited() : message());
+		}, fast);
+
+		expect(calls).toBe(2);
+		expect(final.stopReason).toBe("stop");
+	});
+
+	it("returns the failing message unchanged once attempts are exhausted, so caller fallbacks still apply", async () => {
+		let calls = 0;
+		const final = await retryTransientCompletion(() => {
+			calls += 1;
+			return Promise.resolve(overloaded());
+		}, fast);
+
+		expect(calls).toBe(3);
+		expect(final.stopReason).toBe("error");
+		expect(final.errorMessage).toContain("overloaded_error");
+	});
+
+	it("does not retry a non-transient provider error", async () => {
+		let calls = 0;
+		const final = await retryTransientCompletion(
+			() => {
+				calls += 1;
+				return Promise.resolve(
+					message({
+						stopReason: "error",
+						errorStatus: 400,
+						errorMessage: "invalid_request_error: messages: at least one message is required",
+					}),
+				);
+			},
+			{ ...fast, maxAttempts: 5 },
+		);
+
+		expect(calls).toBe(1);
+		expect(final.stopReason).toBe("error");
+	});
+
+	it("retries a thrown transient error and rethrows the last one when exhausted", async () => {
+		let calls = 0;
+		const attempt = retryTransientCompletion(() => {
+			calls += 1;
+			const error = new Error("529 overloaded_error: Overloaded") as Error & { status?: number };
+			error.status = 529;
+			throw error;
+		}, fast);
+
+		await expect(attempt).rejects.toThrow(/overloaded_error/);
+		expect(calls).toBe(3);
+	});
+
+	it("does not retry a thrown non-transient error", async () => {
+		let calls = 0;
+		const attempt = retryTransientCompletion(() => {
+			calls += 1;
+			throw new Error("invalid_request_error: bad tool schema");
+		}, fast);
+
+		await expect(attempt).rejects.toThrow(/invalid_request_error/);
+		expect(calls).toBe(1);
+	});
+
+	it("stops immediately when the caller aborts", async () => {
+		const controller = new AbortController();
+		let calls = 0;
+		const final = await retryTransientCompletion(
+			() => {
+				calls += 1;
+				controller.abort();
+				return Promise.resolve(overloaded());
+			},
+			{ ...fast, signal: controller.signal },
+		);
+
+		expect(calls).toBe(1);
+		expect(final.stopReason).toBe("error");
+	});
+
+	it("rejects with the abort reason when the caller cancels during backoff", async () => {
+		// The cancel lands while we are waiting, not while an attempt is in flight:
+		// it must stay a cancellation rather than being reported as the provider
+		// failure we happened to be sleeping on.
+		const controller = new AbortController();
+		const reason = new Error("user pressed escape");
+		let calls = 0;
+		const attempt = retryTransientCompletion(
+			() => {
+				calls += 1;
+				setTimeout(() => controller.abort(reason), 5);
+				return Promise.resolve(overloaded());
+			},
+			{ maxAttempts: 3, baseDelayMs: 200, signal: controller.signal },
+		);
+
+		await expect(attempt).rejects.toThrow("user pressed escape");
+		expect(calls).toBe(1);
+	});
+
+	it("reports each retry through onRetry so callers can log the wait", async () => {
+		const seen: number[] = [];
+		let calls = 0;
+		await retryTransientCompletion(
+			() => {
+				calls += 1;
+				return Promise.resolve(calls === 1 ? overloaded() : message());
+			},
+			{ ...fast, onRetry: info => seen.push(info.attempt) },
+		);
+
+		expect(seen).toEqual([1]);
+	});
+
+	it("surfaces the failure instead of parking when the provider asks for longer than maxDelayMs", async () => {
+		let calls = 0;
+		const final = await retryTransientCompletion(
+			() => {
+				calls += 1;
+				return Promise.resolve(
+					message({
+						stopReason: "error",
+						errorStatus: 429,
+						errorMessage: "rate_limit_error: please retry in 600s",
+					}),
+				);
+			},
+			{ ...fast, maxDelayMs: 1_000 },
+		);
+
+		expect(calls).toBe(1);
+		expect(final.stopReason).toBe("error");
+	});
+
+	it("honors a retry-after-ms response header over the backoff floor", async () => {
+		// The header is the only place a real Anthropic 429 carries its wait: the
+		// resolved AssistantMessage has no headers, so a helper that reads only the
+		// error text would silently fall back to plain backoff.
+		let calls = 0;
+		let observedDelay = -1;
+		await retryTransientCompletion(
+			() => {
+				calls += 1;
+				return Promise.resolve(calls === 1 ? rateLimited() : message());
+			},
+			{
+				maxAttempts: 2,
+				baseDelayMs: 1,
+				getResponseHeaders: () => ({ "retry-after-ms": "120" }),
+				onRetry: info => {
+					observedDelay = info.delayMs;
+				},
+			},
+		);
+
+		expect(calls).toBe(2);
+		expect(observedDelay).toBe(120);
+	});
+
+	it("surfaces the failure when a retry-after header exceeds maxDelayMs", async () => {
+		let calls = 0;
+		const final = await retryTransientCompletion(
+			() => {
+				calls += 1;
+				return Promise.resolve(rateLimited());
+			},
+			{
+				maxAttempts: 3,
+				baseDelayMs: 1,
+				maxDelayMs: 1_000,
+				getResponseHeaders: () => ({ "retry-after": "300" }),
+			},
+		);
+
+		expect(calls).toBe(1);
+		expect(final.stopReason).toBe("error");
+	});
+
+	it("recovers retry-after from a thrown provider error's own headers", async () => {
+		let calls = 0;
+		let observedDelay = -1;
+		const attempt = retryTransientCompletion(
+			() => {
+				calls += 1;
+				const error = new Error("529 overloaded_error: Overloaded") as Error & {
+					status?: number;
+					headers?: Record<string, string>;
+				};
+				error.status = 529;
+				error.headers = { "retry-after-ms": "90" };
+				throw error;
+			},
+			{
+				maxAttempts: 2,
+				baseDelayMs: 1,
+				onRetry: info => {
+					observedDelay = info.delayMs;
+				},
+			},
+		);
+
+		await expect(attempt).rejects.toThrow(/overloaded_error/);
+		expect(calls).toBe(2);
+		expect(observedDelay).toBe(90);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -240,6 +240,12 @@
 ### Changed
 
 - Upgraded the bundled omptype schema engine: intersection and pipe operators, bigint and RegExp literals in the string DSL, Standard Schema V1 interop, JSON Schema import via fromJsonSchema(), and richer union/collection error reporting.
+### Fixed
+
+- Fixed manual `/compact` failing outright when a summarization request hit a transient provider overload. The auto-compaction path is unchanged: it keeps its own retry loop and now explicitly opts out of the inner one.
+- Fixed transient Anthropic failures (`overloaded_error`, `rate_limit_error`, 429/500/502/503/529) aborting or silently degrading side-effect-free oneshot LLM calls. Session title generation, TTS speech enhancement, commit-message generation, the auto-thinking and unexpected-stop classifiers, memory extraction/consolidation, the commit analysis/summary/changelog/map/reduce passes, and the mnemopi LLM callback now retry with backoff that honors `retry-after`, instead of failing on the first blip or returning `null` — which made a transient overload indistinguishable from a legitimate empty result.
+- Fixed the commit analysis, summary, changelog and reduce passes feeding a provider error message straight into their response parsers: they never checked `stopReason`, so a failed request produced garbage output instead of surfacing the error.
+- Fixed the commit map phase never retrying transient failures: its retry helper only caught thrown errors, so a `stopReason: "error"` response bypassed it entirely.
 
 ## [17.2.7] - 2026-08-03
 

--- a/packages/coding-agent/src/auto-thinking/classifier.ts
+++ b/packages/coding-agent/src/auto-thinking/classifier.ts
@@ -14,7 +14,7 @@
  * Throws on any failure (no model, no key, unparseable output, abort/timeout);
  * the caller falls back to a concrete level and continues the turn.
  */
-import { type AssistantMessage, completeSimple, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { type AssistantMessage, completeSimple, Effort, type Model, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { prompt } from "@oh-my-pi/pi-utils";
 
@@ -115,19 +115,23 @@ async function classifyOnline(input: string, deps: ClassifyDifficultyDeps, ceili
 	const metadata = deps.metadataResolver?.(model.provider);
 	const maxTokens = REASONING_SAFE_MAX_TOKENS;
 
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [difficultySystemPromptFor(ceiling)],
-			messages: [{ role: "user", content: input, timestamp: Date.now() }],
-		},
-		{
-			apiKey: deps.registry.resolver(model, deps.sessionId),
-			maxTokens,
-			disableReasoning: true,
-			metadata,
-			signal: deps.signal,
-		},
+	const response = await retryTransientCompletion(
+		() =>
+			completeSimple(
+				model,
+				{
+					systemPrompt: [difficultySystemPromptFor(ceiling)],
+					messages: [{ role: "user", content: input, timestamp: Date.now() }],
+				},
+				{
+					apiKey: deps.registry.resolver(model, deps.sessionId),
+					maxTokens,
+					disableReasoning: true,
+					metadata,
+					signal: deps.signal,
+				},
+			),
+		{ signal: deps.signal },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/commit/analysis/conventional.ts
+++ b/packages/coding-agent/src/commit/analysis/conventional.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, ApiKey, Model } from "@oh-my-pi/pi-ai";
-import { completeSimple } from "@oh-my-pi/pi-ai";
+import { completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import analysisSystemPrompt from "../../commit/prompts/analysis-system.md" with { type: "text" };
 import analysisUserPrompt from "../../commit/prompts/analysis-user.md" with { type: "text" };
@@ -50,15 +50,21 @@ export async function generateConventionalAnalysis({
 		diff,
 	});
 
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [prompt.render(analysisSystemPrompt)],
-			messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
-			tools: [ConventionalAnalysisTool],
-		},
-		{ apiKey, maxTokens: 2400, reasoning: toReasoningEffort(thinkingLevel) },
+	const response = await retryTransientCompletion(() =>
+		completeSimple(
+			model,
+			{
+				systemPrompt: [prompt.render(analysisSystemPrompt)],
+				messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
+				tools: [ConventionalAnalysisTool],
+			},
+			{ apiKey, maxTokens: 2400, reasoning: toReasoningEffort(thinkingLevel) },
+		),
 	);
+
+	if (response.stopReason === "error") {
+		throw new Error(response.errorMessage ?? "provider error");
+	}
 
 	return parseConventionalAnalysisResponse(response, ConventionalAnalysisTool);
 }

--- a/packages/coding-agent/src/commit/analysis/summary.ts
+++ b/packages/coding-agent/src/commit/analysis/summary.ts
@@ -1,7 +1,7 @@
 import { type } from "@oh-my-pi/omptype";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, ApiKey, AssistantMessage, Model } from "@oh-my-pi/pi-ai";
-import { completeSimple, validateToolCall } from "@oh-my-pi/pi-ai";
+import { completeSimple, retryTransientCompletion, validateToolCall } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import summarySystemPrompt from "../../commit/prompts/summary-system.md" with { type: "text" };
 import summaryUserPrompt from "../../commit/prompts/summary-user.md" with { type: "text" };
@@ -52,15 +52,21 @@ export async function generateSummary({
 		stat,
 	});
 
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [systemPrompt],
-			messages: [{ role: "user", content: userPrompt, timestamp: Date.now() }],
-			tools: [SummaryTool],
-		},
-		{ apiKey, maxTokens: 200, reasoning: toReasoningEffort(thinkingLevel) },
+	const response = await retryTransientCompletion(() =>
+		completeSimple(
+			model,
+			{
+				systemPrompt: [systemPrompt],
+				messages: [{ role: "user", content: userPrompt, timestamp: Date.now() }],
+				tools: [SummaryTool],
+			},
+			{ apiKey, maxTokens: 200, reasoning: toReasoningEffort(thinkingLevel) },
+		),
 	);
+
+	if (response.stopReason === "error") {
+		throw new Error(response.errorMessage ?? "provider error");
+	}
 
 	return parseSummaryFromResponse(response, commitType, scope);
 }

--- a/packages/coding-agent/src/commit/changelog/generate.ts
+++ b/packages/coding-agent/src/commit/changelog/generate.ts
@@ -1,7 +1,7 @@
 import { type } from "@oh-my-pi/omptype";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, ApiKey, AssistantMessage, Model } from "@oh-my-pi/pi-ai";
-import { completeSimple, validateToolCall } from "@oh-my-pi/pi-ai";
+import { completeSimple, retryTransientCompletion, validateToolCall } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import changelogSystemPrompt from "../../commit/prompts/changelog-system.md" with { type: "text" };
 import changelogUserPrompt from "../../commit/prompts/changelog-user.md" with { type: "text" };
@@ -55,15 +55,21 @@ export async function generateChangelogEntries({
 		stat,
 		diff,
 	});
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [prompt.render(changelogSystemPrompt)],
-			messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
-			tools: [changelogTool],
-		},
-		{ apiKey, maxTokens: 1200, reasoning: toReasoningEffort(thinkingLevel) },
+	const response = await retryTransientCompletion(() =>
+		completeSimple(
+			model,
+			{
+				systemPrompt: [prompt.render(changelogSystemPrompt)],
+				messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
+				tools: [changelogTool],
+			},
+			{ apiKey, maxTokens: 1200, reasoning: toReasoningEffort(thinkingLevel) },
+		),
 	);
+
+	if (response.stopReason === "error") {
+		throw new Error(response.errorMessage ?? "provider error");
+	}
 
 	const parsed = parseChangelogResponse(response);
 	return { entries: dedupeEntries(parsed.entries) };

--- a/packages/coding-agent/src/commit/map-reduce/map-phase.ts
+++ b/packages/coding-agent/src/commit/map-reduce/map-phase.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, ApiKey, AssistantMessage, Message, Model } from "@oh-my-pi/pi-ai";
-import { completeSimple } from "@oh-my-pi/pi-ai";
+import { completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import fileObserverSystemPrompt from "../../commit/prompts/file-observer-system.md" with { type: "text" };
 import fileObserverUserPrompt from "../../commit/prompts/file-observer-user.md" with { type: "text" };
@@ -66,7 +66,7 @@ export async function runMapPhase({
 			messages: [{ role: "user", content: userContent, timestamp: Date.now() }] as Message[],
 		};
 
-		const response = await withRetry(
+		const response = await retryTransientCompletion(
 			() =>
 				completeSimple(model, request, {
 					apiKey,
@@ -74,8 +74,7 @@ export async function runMapPhase({
 					reasoning: toReasoningEffort(thinkingLevel),
 					signal: AbortSignal.timeout(timeoutMs),
 				}),
-			maxRetries,
-			retryBackoffMs,
+			{ maxAttempts: maxRetries, baseDelayMs: retryBackoffMs },
 		);
 
 		const observations = parseObservations(response);
@@ -175,19 +174,4 @@ async function runWithConcurrency<T, R>(
 	});
 	await Promise.all(runners);
 	return results;
-}
-
-async function withRetry<T>(fn: () => Promise<T>, attempts: number, backoffMs: number): Promise<T> {
-	let lastError: unknown;
-	for (let attempt = 0; attempt < attempts; attempt += 1) {
-		try {
-			return await fn();
-		} catch (error) {
-			lastError = error;
-			if (attempt < attempts - 1) {
-				await Bun.sleep(backoffMs * (attempt + 1));
-			}
-		}
-	}
-	throw lastError;
 }

--- a/packages/coding-agent/src/commit/map-reduce/reduce-phase.ts
+++ b/packages/coding-agent/src/commit/map-reduce/reduce-phase.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, ApiKey, Model } from "@oh-my-pi/pi-ai";
-import { completeSimple } from "@oh-my-pi/pi-ai";
+import { completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import reduceSystemPrompt from "../../commit/prompts/reduce-system.md" with { type: "text" };
 import reduceUserPrompt from "../../commit/prompts/reduce-user.md" with { type: "text" };
@@ -35,15 +35,21 @@ export async function runReducePhase({
 		stat,
 		scope_candidates: scopeCandidates,
 	});
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [prompt.render(reduceSystemPrompt)],
-			messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
-			tools: [ReduceTool],
-		},
-		{ apiKey, maxTokens: 2400, reasoning: toReasoningEffort(thinkingLevel) },
+	const response = await retryTransientCompletion(() =>
+		completeSimple(
+			model,
+			{
+				systemPrompt: [prompt.render(reduceSystemPrompt)],
+				messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
+				tools: [ReduceTool],
+			},
+			{ apiKey, maxTokens: 2400, reasoning: toReasoningEffort(thinkingLevel) },
+		),
 	);
+
+	if (response.stopReason === "error") {
+		throw new Error(response.errorMessage ?? "provider error");
+	}
 
 	return parseConventionalAnalysisResponse(response, ReduceTool);
 }

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -134,6 +134,10 @@ export const getModels = getBundledModels;
  *
  * Legacy `/compat` callers pass {@link SimpleStreamOptions}; routing through
  * `streamSimple` preserves option normalization before provider dispatch.
+ *
+ * Transient-failure retry (overload, rate-limit, 5xx) is the **caller's
+ * responsibility**. Oneshot callers that collect the full result before acting
+ * should wrap with `retryTransientCompletion` from `@oh-my-pi/pi-ai`.
  */
 export function streamSimpleOpenAIResponses(
 	model: Model<"openai-responses">,

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -3,7 +3,7 @@ import type * as fsNode from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { type ApiKey, completeSimple, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { type ApiKey, completeSimple, Effort, type Model, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getAgentDbPath, getMemoriesDir, isEnoent, logger, parseJsonlLenient, prompt } from "@oh-my-pi/pi-utils";
 
@@ -750,18 +750,20 @@ async function runStage1Job(options: {
 			response_items_json: truncatedItems,
 		});
 
-		const response = await completeSimple(
-			model,
-			{
-				systemPrompt: [stageOneSystemTemplate],
-				messages: [{ role: "user", content: [{ type: "text", text: inputPrompt }], timestamp: Date.now() }],
-			},
-			{
-				apiKey,
-				metadata: options.metadata,
-				maxTokens: Math.max(1024, Math.min(4096, Math.floor(modelMaxTokens * 0.2))),
-				reasoning: clampThinkingLevelForModel(model, Effort.Low),
-			},
+		const response = await retryTransientCompletion(() =>
+			completeSimple(
+				model,
+				{
+					systemPrompt: [stageOneSystemTemplate],
+					messages: [{ role: "user", content: [{ type: "text", text: inputPrompt }], timestamp: Date.now() }],
+				},
+				{
+					apiKey,
+					metadata: options.metadata,
+					maxTokens: Math.max(1024, Math.min(4096, Math.floor(modelMaxTokens * 0.2))),
+					reasoning: clampThinkingLevelForModel(model, Effort.Low),
+				},
+			),
 		);
 
 		if (response.stopReason === "error") {
@@ -887,18 +889,20 @@ async function runConsolidationModel(options: {
 		rollout_summaries: truncateByApproxTokens(rolloutSummaries, 12_000),
 	});
 
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [consolidationSystemTemplate],
-			messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
-		},
-		{
-			apiKey,
-			metadata: options.metadata,
-			maxTokens: 8192,
-			reasoning: clampThinkingLevelForModel(model, Effort.Medium),
-		},
+	const response = await retryTransientCompletion(() =>
+		completeSimple(
+			model,
+			{
+				systemPrompt: [consolidationSystemTemplate],
+				messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
+			},
+			{
+				apiKey,
+				metadata: options.metadata,
+				maxTokens: 8192,
+				reasoning: clampThinkingLevelForModel(model, Effort.Medium),
+			},
+		),
 	);
 	if (response.stopReason === "error") {
 		throw new Error(response.errorMessage || "phase2 model error");

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -1,6 +1,6 @@
 import { rm } from "node:fs/promises";
 import * as path from "node:path";
-import { type ApiKeyResolver, completeSimple } from "@oh-my-pi/pi-ai";
+import { type ApiKeyResolver, completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { hostMatchesUrl } from "@oh-my-pi/pi-catalog/hosts";
 import type { Mnemopi } from "@oh-my-pi/pi-mnemopi";
 import type * as MnemopiDiagnoseNs from "@oh-my-pi/pi-mnemopi/diagnose";
@@ -545,16 +545,18 @@ async function resolveMnemopiProviderOptions(
 					});
 					return null;
 				}
-				const message = await completeSimple(
-					model,
-					{
-						messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
-					},
-					{
-						apiKey: modelRegistry.resolver(model, sessionId),
-						maxTokens: opts?.maxTokens,
-						temperature: opts?.temperature,
-					},
+				const message = await retryTransientCompletion(() =>
+					completeSimple(
+						model,
+						{
+							messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
+						},
+						{
+							apiKey: modelRegistry.resolver(model, sessionId),
+							maxTokens: opts?.maxTokens,
+							temperature: opts?.temperature,
+						},
+					),
 				);
 				return message.content
 					.filter(

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2625,6 +2625,11 @@ export class SessionMaintenance {
 									providerSessionState: this.#host.providerSessionState,
 									preferWebsockets: this.#host.preferWebsockets,
 									codexCompaction,
+									// This loop already retries the whole compaction attempt on
+									// transient errors, so the summarization oneshots must not
+									// retry too — the budgets would multiply and each outer
+									// wait would stack on top of an inner backoff.
+									oneshotRetry: false,
 								},
 							);
 							break;

--- a/packages/coding-agent/src/session/unexpected-stop-classifier.ts
+++ b/packages/coding-agent/src/session/unexpected-stop-classifier.ts
@@ -1,4 +1,4 @@
-import { type AssistantMessage, completeSimple } from "@oh-my-pi/pi-ai";
+import { type AssistantMessage, completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 
 import type { ModelRegistry } from "../config/model-registry";
@@ -88,19 +88,23 @@ async function classifyOnline(text: string, deps: ClassifyUnexpectedStopDeps): P
 	const metadata = deps.metadataResolver?.(model.provider);
 	const maxTokens = REASONING_SAFE_MAX_TOKENS;
 
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: [CLASSIFIER_SYSTEM_PROMPT],
-			messages: [{ role: "user", content: text, timestamp: Date.now() }],
-		},
-		{
-			apiKey: deps.registry.resolver(model, deps.sessionId),
-			maxTokens,
-			disableReasoning: true,
-			metadata,
-			signal: deps.signal,
-		},
+	const response = await retryTransientCompletion(
+		() =>
+			completeSimple(
+				model,
+				{
+					systemPrompt: [CLASSIFIER_SYSTEM_PROMPT],
+					messages: [{ role: "user", content: text, timestamp: Date.now() }],
+				},
+				{
+					apiKey: deps.registry.resolver(model, deps.sessionId),
+					maxTokens,
+					disableReasoning: true,
+					metadata,
+					signal: deps.signal,
+				},
+			),
+		{ signal: deps.signal },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/tts/speech-enhancer.ts
+++ b/packages/coding-agent/src/tts/speech-enhancer.ts
@@ -15,7 +15,7 @@
  *   mechanical {@link SpeakableStream} cleanup — speech never blocks on the
  *   model.
  */
-import { type AssistantMessage, completeSimple } from "@oh-my-pi/pi-ai";
+import { type AssistantMessage, completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { getModelMatchPreferences, resolveModelRoleValue } from "../config/model-resolver";
@@ -82,20 +82,25 @@ export class SpeechEnhancer {
 			if (!apiKey) return null;
 			// Resolve metadata after getApiKey so the session-sticky credential is recorded first.
 			const metadata = this.#deps.metadataResolver?.(model.provider);
-			const timeout = AbortSignal.timeout(REWRITE_TIMEOUT_MS);
-			const response = await completeSimple(
-				model,
-				{
-					systemPrompt: [SYSTEM_PROMPT],
-					messages: [{ role: "user", content: boundBlock(block), timestamp: Date.now() }],
+			const response = await retryTransientCompletion(
+				() => {
+					const timeout = AbortSignal.timeout(REWRITE_TIMEOUT_MS);
+					return completeSimple(
+						model,
+						{
+							systemPrompt: [SYSTEM_PROMPT],
+							messages: [{ role: "user", content: boundBlock(block), timestamp: Date.now() }],
+						},
+						{
+							apiKey: registry.resolver(model, sessionId),
+							maxTokens: ANSWER_MAX_TOKENS,
+							disableReasoning: true,
+							metadata,
+							signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+						},
+					);
 				},
-				{
-					apiKey: registry.resolver(model, sessionId),
-					maxTokens: ANSWER_MAX_TOKENS,
-					disableReasoning: true,
-					metadata,
-					signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
-				},
+				{ signal },
 			);
 			if (response.stopReason === "error") {
 				logger.debug("speech-enhancer: rewrite errored", { error: response.errorMessage });

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -4,7 +4,7 @@
  */
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
-import { completeSimple } from "@oh-my-pi/pi-ai";
+import { completeSimple, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 
 import type { ModelRegistry } from "../config/model-registry";
@@ -106,17 +106,19 @@ export async function generateCommitMessage(
 
 		try {
 			const maxTokens = COMMIT_MAX_TOKENS;
-			const response = await completeSimple(
-				candidate.model,
-				{
-					systemPrompt: [COMMIT_SYSTEM_PROMPT],
-					messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
-				},
-				{
-					apiKey: registry.resolver(candidate.model, sessionId),
-					maxTokens,
-					reasoning: toReasoningEffort(candidate.thinkingLevel),
-				},
+			const response = await retryTransientCompletion(() =>
+				completeSimple(
+					candidate.model,
+					{
+						systemPrompt: [COMMIT_SYSTEM_PROMPT],
+						messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
+					},
+					{
+						apiKey: registry.resolver(candidate.model, sessionId),
+						maxTokens,
+						reasoning: toReasoningEffort(candidate.thinkingLevel),
+					},
+				),
 			);
 
 			if (response.stopReason === "error") {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -4,7 +4,7 @@
 import { dlopen, FFIType, ptr } from "bun:ffi";
 import * as path from "node:path";
 
-import { type Api, type AssistantMessage, completeSimple, type Model } from "@oh-my-pi/pi-ai";
+import { type Api, type AssistantMessage, completeSimple, type Model, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { StreamMarkupHealing } from "@oh-my-pi/pi-ai/utils/stream-markup-healing";
 import { isConPTYHosted } from "@oh-my-pi/pi-tui";
 import { isTerminalHeadless, logger, prompt } from "@oh-my-pi/pi-utils";
@@ -254,19 +254,23 @@ export async function generateTitleOnline(
 		const maxTokens = TITLE_MAX_TOKENS;
 		logger.debug("title-generator: request", { ...modelContext, maxTokens });
 
-		const response = await completeSimple(
-			model,
-			{
-				systemPrompt,
-				messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
-			},
-			{
-				apiKey: registry.resolver(model, sessionId),
-				maxTokens,
-				disableReasoning: true,
-				metadata,
-				signal,
-			},
+		const response = await retryTransientCompletion(
+			() =>
+				completeSimple(
+					model,
+					{
+						systemPrompt,
+						messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
+					},
+					{
+						apiKey: registry.resolver(model, sessionId),
+						maxTokens,
+						disableReasoning: true,
+						metadata,
+						signal,
+					},
+				),
+			{ signal },
 		);
 
 		if (response.stopReason === "error") {

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Changed
 
 - Updated internal LRU cache implementation.
+### Fixed
+
+- Fixed transient provider failures collapsing to `null` in the configured-completion and remote-LLM paths, which made an Anthropic overload or rate limit indistinguishable from "the model returned nothing". Both now retry transient failures before falling back.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/mnemopi/src/core/local-llm.ts
+++ b/packages/mnemopi/src/core/local-llm.ts
@@ -5,9 +5,11 @@ import {
 	completeSimple,
 	type FetchImpl,
 	type Model,
+	retryTransientCompletion,
 	withAuth,
 } from "@oh-my-pi/pi-ai";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import { fetchWithRetry } from "@oh-my-pi/pi-utils";
 import { type CompleteOptions, callHostLlm, getHostLlmBackend } from "./llm-backends";
 import {
 	getMnemopiRuntimeOptions,
@@ -186,16 +188,18 @@ export async function callConfiguredCompletion(
 		return null;
 	}
 	try {
-		const message = await completeSimple(
-			model,
-			{
-				messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
-			},
-			{
-				apiKey: llmApiKey() || undefined,
-				maxTokens: opts.maxTokens ?? llmMaxTokens(),
-				temperature,
-			},
+		const message = await retryTransientCompletion(() =>
+			completeSimple(
+				model,
+				{
+					messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
+				},
+				{
+					apiKey: llmApiKey() || undefined,
+					maxTokens: opts.maxTokens ?? llmMaxTokens(),
+					temperature,
+				},
+			),
 		);
 		return assistantText(message).trim() || null;
 	} catch {
@@ -350,11 +354,12 @@ export async function callRemoteLlm(
 			if (key !== "") {
 				headers.Authorization = `Bearer ${key}`;
 			}
-			const res = await fetchImpl(`${baseUrl}/chat/completions`, {
+			const res = await fetchWithRetry(`${baseUrl}/chat/completions`, {
 				method: "POST",
 				headers,
 				body,
 				signal: AbortSignal.timeout(60000),
+				fetch: fetchImpl,
 			});
 			if (res.status === 401) {
 				throw new ProviderHttpError("mnemopi remote LLM request unauthorized (401)", 401, { headers: res.headers });


### PR DESCRIPTION
## Problem

`completeSimple` / `streamSimple` retry auth failures, but a **transient** provider failure — Anthropic `overloaded_error` / `rate_limit_error`, HTTP 429/500/502/503/529 — is reported by **resolving** with `stopReason: "error"` instead of throwing (`packages/ai/src/stream.ts`).

Every oneshot caller that wrapped the call in a try/catch-based retry therefore never retried. ~25 call sites each had to notice this; most did not. Consequences:

- `/handoff`, branch summarization and manual `/compact` aborted on the first blip — for `/compact` that leaves the user's context full.
- Several sites returned `null`, making a provider overload **indistinguishable from a legitimate empty result** (title generation, memories, mnemopi).
- The commit analysis / summary / changelog / reduce passes fed the provider's error message straight into their response parsers — they never checked `stopReason`, so a failed request produced garbage output.
- The commit map phase had its own retry helper, but it only caught *thrown* errors, so a resolved error-stop bypassed it entirely.

## Change

**`packages/ai` — `retryTransientCompletion`**

Handles both shapes (resolved error-stop and thrown), classifies with the existing `AIError` predicates so the retryable set stays defined in one place, honors `retry-after` / `x-ratelimit-reset*`, and returns/rethrows the failure **unchanged** once attempts are exhausted so existing caller fallbacks keep working.

Cancellation is preserved rather than absorbed: a cancel visible when an attempt settles surfaces that attempt's own result, and a cancel during backoff rejects with the abort reason — a user ESC is never relabelled as the provider failure we happened to be waiting on.

The helper deliberately does **not** pass `signal` into the closure. A per-attempt deadline must be rebuilt per attempt; a deadline captured outside would fire once and then abort every retry, silently turning the helper into a single attempt. The JSDoc states this.

**`packages/agent` — funnel, opt-in**

`instrumentedCompleteSimple` gains `retry`. Opt-in rather than default-on: `oneshotKind` is free-form and callers may pass arbitrary `ctx.tools`, so the funnel cannot itself prove a request is replay-safe. Headers are captured per attempt and cleared between attempts, so a stale `retry-after` cannot leak into a later failure.

**`SummaryOptions.oneshotRetry`** — both compaction paths call the same `generateSummary`, so the policy cannot be a constant inside it:

| path | value | why |
|---|---|---|
| manual `/compact` | omitted → on | no outer loop; one blip kills compaction |
| auto-compaction | `false` | `session-maintenance` already retries the whole attempt; nesting multiplies the budget (10 × 3) and stacks waits |

**14 call sites** wrapped across `coding-agent` and `mnemopi`.

## Deliberately NOT wrapped

- **Anthropic `web_search` provider** — server-side execution, **billed per search**. A re-request duplicates a real side effect.
- **`legacy-pi-ai-shim`** — `streamSimple` passthrough; already-emitted events would duplicate. Comment only.
- **auth-gateway health probe** — a probe must report the state it observed, and per-attempt timeout semantics would break.
- **3 script loops + `rewrite-system-prompt`** — already retry, and wrapping would break per-attempt usage accounting or discard smarter logic that re-requests only the failed subset.

## Verification

```
bun run check:ts   → clean (biome 4090 files + every workspace tsgo)
bun test packages/ai/test/oneshot-retry.test.ts \
         packages/agent/test/instrumented-oneshot-retry.test.ts \
         packages/agent/test/compaction-oneshot-retry.test.ts
                   → 19 pass / 0 fail
```

**RED evidence** — the default-on test discriminates. Reverting `summaryOneshotRetry` to pre-fix behaviour (`configured ?? undefined`):

```
(fail) SummaryOptions.oneshotRetry > retries a transient failure by default
       ProviderHttpError: Summarization failed: overloaded_error: Overloaded
1 pass 1 fail        # the `oneshotRetry: false` test still passes → it discriminates
```

Call-level check across the change set: **14/14 `completeSimple(` calls wrapped, 0 bare.**

Two latent bugs surfaced only because the typechecker was run: a `{headers}` fixture cast `as unknown as Response` where the real parameter is `ProviderResponseMetadata` (`status` + `headers`), and `apiKey` cast to an object when `ApiKey` is `string | ApiKeyResolver`. Both were hidden by `as unknown as`; both fixtures now use real values with no cast.

## Known gaps

- Tokens from failed attempts are not recorded in `finishChatSpan`, so cost is under-counted on a retried oneshot. Not a safety issue.
- `check:rs` fails locally because cargo is not on PATH — pre-existing, unrelated to this change.
