### PR TITLE
fix(lsp): correct workspace edit failure handling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the LSP client advertising transactional text edits despite applying multi-file workspace edits sequentially ([#8375](https://github.com/can1357/oh-my-pi/issues/8375)).
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -169,7 +169,7 @@ const CLIENT_CAPABILITIES = {
 		workspaceEdit: {
 			documentChanges: true,
 			resourceOperations: ["create", "rename", "delete"],
-			failureHandling: "textOnlyTransactional",
+			failureHandling: "abort",
 		},
 		configuration: true,
 		workspaceFolders: true,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -505,7 +505,7 @@ describe("lsp regressions", () => {
 		}
 	});
 
-	it("advertises workspace folder support during LSP initialization", async () => {
+	it("advertises workspace folder support and abort-on-failure workspace edits during LSP initialization", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-workspace-folders-");
 		try {
 			const server = installFakeLsp((message, srv) => {
@@ -528,11 +528,14 @@ describe("lsp regressions", () => {
 
 			const init = server.received.find(message => message.method === "initialize");
 			const params = init?.params as {
-				capabilities?: { workspace?: { workspaceFolders?: unknown } };
+				capabilities?: {
+					workspace?: { workspaceFolders?: unknown; workspaceEdit?: { failureHandling?: unknown } };
+				};
 				workspaceFolders?: unknown;
 			};
 
 			expect(params.capabilities?.workspace?.workspaceFolders).toBe(true);
+			expect(params.capabilities?.workspace?.workspaceEdit?.failureHandling).toBe("abort");
 			expect(params.workspaceFolders).toEqual([
 				{ uri: fileToUri(tempDir.path()), name: path.basename(tempDir.path()) },
 			]);


### PR DESCRIPTION
## Repro
A `WorkspaceEdit` with a valid insertion for an existing file followed by the same insertion for a missing file reproduces with `cd packages/coding-agent && bun /tmp/omp-8375-repro.ts`: the operation reports `ENOENT`, but the existing file has already changed from `abc` to `aXbc`.

## Cause
`packages/coding-agent/src/lsp/client.ts` advertised `workspace.workspaceEdit.failureHandling` as `textOnlyTransactional`, while `applyWorkspaceEdit()` in `packages/coding-agent/src/lsp/edits.ts` applies each text-edit batch sequentially and has no rollback path when a later file fails.

## Fix
- Advertise LSP `abort` failure handling, matching the existing sequential application behavior.
- Assert the capability in the fake-server initialization regression test.
- Add the issue-linked coding-agent changelog entry.

## Verification
`cd packages/coding-agent && bun test test/tools/lsp-regressions.test.ts` — 77 passed, 0 failed. The publish gate also completed `bun run fix` and `bun check`.

Fixes #8375