### PR TITLE
feat(coding-agent): detail LSP rename previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,26 @@
 ## [Unreleased]
 
 ## [17.3.1] - 2026-08-13
+### Added
+
+- Added Astral `ty` as a built-in Python primary LSP server (`ty server`), ordered behind `pyright`/`basedpyright`/`pylsp` so it becomes the primary Python LSP only when the existing servers are unavailable. `ruff` remains the Python linter and coexists alongside `ty` ([#4617](https://github.com/can1357/oh-my-pi/issues/4617)).
+- Added first-party Nix support with reproducible source builds for Linux and macOS on x86-64 and ARM64, a pinned development shell, an overlay, NixOS and Home Manager modules, offline Bun dependencies, and lightweight flake evaluation in CI. Nix-managed installs now direct updates back through Nix instead of replacing store-managed executables.
+- `omp update` and the startup version check now follow an `omp.rename` pointer in the published npm manifest, preparing existing installs for the upcoming npm package rename. Migration is transactional: the renamed agent/natives packages are installed first (npm uses `--force` to take over the `omp` bin), so an install failure leaves the old install untouched; the old-name globals are removed only afterwards, and a broken bin link is restored by re-running the idempotent install before verification decides the outcome.
+- Added per-agent advisors: agent definitions accept an `advisor` frontmatter field (`true` = advise with the `advisor`-role model, `"<pattern>"` = an explicit advisor model with optional `:level` suffix), overridable via the `task.agentAdvisor` settings record. An explicit pattern lands on the spawned session's `modelRoles.advisor`, so different agents can be advised by different models; the effective opt-in is persisted in `session_init` and restored on cold revival, and each subagent advisor keeps its own `<session>/<SubId>/__advisor[.<slug>].jsonl` transcript.
+- Redesigned `/agents` as a fullscreen hub in the `/models` idiom: a scope sidebar (All / Project / User / Bundled / New agent), type-to-filter agent rows with effective model/prewalk/advisor annotations, a pinned detail pane, and mouse support. Enter on an agent opens a property chip strip (enable, model, prewalk, advisor); each property is picked — on/off chips, the real model browser, or a raw pattern input — replacing the old `P`/`A`/`N` letter hotkeys.
+
+### Breaking Changes
+
+- Removed the `advisor.subagents` setting; subagent advisors are now configured per agent (frontmatter `advisor` / `task.agentAdvisor`). An existing `advisor.subagents: true` migrates to `task.agentAdvisor: { task: "on" }` — the bundled generic `task` agent keeps its advisor, other agents start unadvised.
+
+### Changed
+
+- `/usage`, `omp usage`, and the status line now show authoritative OpenCode Go quota from the official `GET /zen/go/v1/usage` endpoint — including usage made outside OMP — instead of dollar estimates summed from OMP-observed request costs. The status line renders all three windows (`5h` / `7d` / `mo`), and the per-turn cost recording special case for `opencode-go` sessions is gone along with the "OMP-observed spend only" disclaimer ([#8337](https://github.com/can1357/oh-my-pi/pull/8337) by [@will-bogusz](https://github.com/will-bogusz)).
+- LSP rename previews now include bounded text-edit positions and replacement text instead of only per-file edit counts, and explicitly mark incomplete large previews.
+- Clarified that the production collab relay source and binaries are not currently published, and documented the source-available local protocol relay ([#8165](https://github.com/can1357/oh-my-pi/issues/8165)).
+- Enabled bounded Anthropic prompt-cache refreshes for the main agent loop while keeping advisor and side-channel requests from taking over the shared refresh timer.
+- Fixed snapcompact compaction shipping its redundant frame archive out of `SessionMaintenance.compact()` on both the manual RPC response (which hard-failed protocol v1 with a transport error after the compaction had already persisted) and the `auto_compaction_end` event payload (which forced the shrink ladder on every unattended pass); the archive is now stripped from both exits while the persisted compaction entry keeps it ([#8168](https://github.com/can1357/oh-my-pi/issues/8168)).
+- Fixed the edit tool showing no diff preview in `apply_patch` mode: the built-in `edit` tool presents on the wire as `apply_patch`, but the renderer-provenance gate did not resolve that alias to its built-in owner, so the edit renderer was skipped ([#8184](https://github.com/can1357/oh-my-pi/issues/8184)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/lsp/utils.ts
+++ b/packages/coding-agent/src/lsp/utils.ts
@@ -323,10 +323,8 @@ const WORKSPACE_EDIT_PREVIEW_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
  */
 export function formatTextEdit(edit: TextEdit, maxLength = TRUNCATE_LENGTHS.TITLE): string {
 	const range = `${edit.range.start.line + 1}:${edit.range.start.character + 1}`;
-	const preview =
-		edit.newText.length > maxLength
-			? `${edit.newText.slice(0, maxLength).replace(/\n/g, "\\n")}…`
-			: edit.newText.replace(/\n/g, "\\n");
+	const escapedText = edit.newText.replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+	const preview = escapedText.length > maxLength ? `${escapedText.slice(0, maxLength)}…` : escapedText;
 	return `line ${range} ${theme?.nav.cursor ?? "→"} "${replaceTabs(preview)}"`;
 }
 

--- a/packages/coding-agent/src/lsp/utils.ts
+++ b/packages/coding-agent/src/lsp/utils.ts
@@ -316,8 +316,6 @@ export function formatPosition(line: number, col: number): string {
 // WorkspaceEdit Formatting
 // =============================================================================
 
-const WORKSPACE_EDIT_PREVIEW_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
-
 /**
  * Format a text edit as a preview.
  */
@@ -341,7 +339,7 @@ export function formatWorkspaceEdit(edit: WorkspaceEdit, cwd: string): string[] 
 		results.push(`${file}: ${textEdits.length} edit${textEdits.length > 1 ? "s" : ""}`);
 		textEditCount += textEdits.length;
 		for (const textEdit of textEdits) {
-			if (shownTextEdits >= WORKSPACE_EDIT_PREVIEW_LIMIT) continue;
+			if (shownTextEdits >= PREVIEW_LIMITS.COLLAPSED_ITEMS) continue;
 			results.push(`  ${formatTextEdit(textEdit)}`);
 			shownTextEdits++;
 		}

--- a/packages/coding-agent/src/lsp/utils.ts
+++ b/packages/coding-agent/src/lsp/utils.ts
@@ -6,6 +6,7 @@ import { isEnoent } from "@oh-my-pi/pi-utils";
 import { type Theme, theme } from "../modes/theme/theme";
 import { formatGroupedFiles } from "../tools/grouped-file-output";
 import { formatPathRelativeToCwd, resolveToCwd } from "../tools/path-utils";
+import { PREVIEW_LIMITS, replaceTabs, TRUNCATE_LENGTHS } from "../tools/render-utils";
 import type {
 	CodeAction,
 	Command,
@@ -315,26 +316,49 @@ export function formatPosition(line: number, col: number): string {
 // WorkspaceEdit Formatting
 // =============================================================================
 
+const WORKSPACE_EDIT_PREVIEW_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
+
 /**
- * Format a workspace edit as a summary of changes.
+ * Format a text edit as a preview.
+ */
+export function formatTextEdit(edit: TextEdit, maxLength = TRUNCATE_LENGTHS.TITLE): string {
+	const range = `${edit.range.start.line + 1}:${edit.range.start.character + 1}`;
+	const preview =
+		edit.newText.length > maxLength
+			? `${edit.newText.slice(0, maxLength).replace(/\n/g, "\\n")}…`
+			: edit.newText.replace(/\n/g, "\\n");
+	return `line ${range} ${theme?.nav.cursor ?? "→"} "${replaceTabs(preview)}"`;
+}
+
+/**
+ * Format a workspace edit with bounded text-edit details.
  */
 export function formatWorkspaceEdit(edit: WorkspaceEdit, cwd: string): string[] {
 	const results: string[] = [];
+	let textEditCount = 0;
+	let shownTextEdits = 0;
 
-	// Handle changes map (legacy format)
+	const addTextEdits = (uri: string, textEdits: TextEdit[]): void => {
+		const file = formatPathRelativeToCwd(uriToFile(uri), cwd);
+		results.push(`${file}: ${textEdits.length} edit${textEdits.length > 1 ? "s" : ""}`);
+		textEditCount += textEdits.length;
+		for (const textEdit of textEdits) {
+			if (shownTextEdits >= WORKSPACE_EDIT_PREVIEW_LIMIT) continue;
+			results.push(`  ${formatTextEdit(textEdit)}`);
+			shownTextEdits++;
+		}
+	};
+
 	if (edit.changes) {
 		for (const [uri, textEdits] of Object.entries(edit.changes)) {
-			const file = formatPathRelativeToCwd(uriToFile(uri), cwd);
-			results.push(`${file}: ${textEdits.length} edit${textEdits.length > 1 ? "s" : ""}`);
+			addTextEdits(uri, textEdits);
 		}
 	}
 
-	// Handle documentChanges array (modern format)
 	if (edit.documentChanges) {
 		for (const change of edit.documentChanges) {
 			if ("edits" in change && change.textDocument) {
-				const file = formatPathRelativeToCwd(uriToFile(change.textDocument.uri), cwd);
-				results.push(`${file}: ${change.edits.length} edit${change.edits.length > 1 ? "s" : ""}`);
+				addTextEdits(change.textDocument.uri, change.edits);
 			} else if ("kind" in change) {
 				switch (change.kind) {
 					case "create":
@@ -353,19 +377,12 @@ export function formatWorkspaceEdit(edit: WorkspaceEdit, cwd: string): string[] 
 		}
 	}
 
+	if (shownTextEdits < textEditCount) {
+		results.push(
+			`INCOMPLETE preview: showing ${shownTextEdits}/${textEditCount} text edits; ${textEditCount - shownTextEdits} omitted`,
+		);
+	}
 	return results;
-}
-
-/**
- * Format a text edit as a preview.
- */
-export function formatTextEdit(edit: TextEdit, maxLength = 50): string {
-	const range = `${edit.range.start.line + 1}:${edit.range.start.character + 1}`;
-	const preview =
-		edit.newText.length > maxLength
-			? `${edit.newText.slice(0, maxLength).replace(/\n/g, "\\n")}…`
-			: edit.newText.replace(/\n/g, "\\n");
-	return `line ${range} ${theme.nav.cursor} "${preview}"`;
 }
 
 // =============================================================================

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2358,7 +2358,7 @@ describe("lsp regressions", () => {
 							start: { line: index, character: 13 },
 							end: { line: index, character: 18 },
 						},
-						newText: `renamedValue${index + 1}`,
+						newText: index === 0 ? "renamed\r\nValue\rTail\nEnd" : `renamedValue${index + 1}`,
 					})),
 				},
 			});
@@ -2378,7 +2378,8 @@ describe("lsp regressions", () => {
 				.join("\n");
 			expect(output).toContain("old.ts: 9 edits");
 			expect(output).toContain("line 1:14");
-			expect(output).toContain('"renamedValue1"');
+			expect(output).toContain('"renamed\\r\\nValue\\rTail\\nEnd"');
+			expect(output).not.toContain("\r");
 			expect(output).toContain("INCOMPLETE preview: showing 8/9 text edits; 1 omitted");
 			expect(output).not.toContain('"renamedValue9"');
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2352,18 +2352,35 @@ describe("lsp regressions", () => {
 			});
 			vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
 			vi.spyOn(lspClient, "sendRequest").mockResolvedValue({
-				documentChanges: [],
+				changes: {
+					[fileToUri(sourceFile)]: Array.from({ length: 9 }, (_, index) => ({
+						range: {
+							start: { line: index, character: 13 },
+							end: { line: index, character: 18 },
+						},
+						newText: `renamedValue${index + 1}`,
+					})),
+				},
 			});
 			const notifySpy = vi.spyOn(lspClient, "sendNotification").mockResolvedValue();
 
 			const tool = new LspTool(makeLspSession(tempDir.path()));
-			await tool.execute("rename-file-preview", {
+			const result = await tool.execute("rename-file-preview", {
 				action: "rename_file",
 				file: sourceFile,
 				new_name: destFile,
 				apply: false,
 				timeout: 5,
 			});
+			const output = result.content
+				.filter(block => block.type === "text")
+				.map(block => block.text)
+				.join("\n");
+			expect(output).toContain("old.ts: 9 edits");
+			expect(output).toContain("line 1:14");
+			expect(output).toContain('"renamedValue1"');
+			expect(output).toContain("INCOMPLETE preview: showing 8/9 text edits; 1 omitted");
+			expect(output).not.toContain('"renamedValue9"');
 
 			expect(fs.existsSync(sourceFile)).toBe(true);
 			expect(fs.existsSync(destFile)).toBe(false);


### PR DESCRIPTION
## What

Include line, column, and replacement text beneath each file in LSP `rename` and `rename_file` previews. The output shows up to the shared eight-item preview limit and explicitly reports the shown, total, and omitted edit counts when a preview is incomplete.

Replacement text uses the existing terminal sanitization and centralized truncation limits.

## Why

`apply: false` currently reports only per-file edit counts such as `old.ts: 3 edits`. That does not let an agent or user inspect what the language server intends to replace before the default mutating operation.

I reviewed the full diff; this adds bounded decision-relevant detail without changing apply behavior or issuing additional LSP requests.

## Testing

- `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts --test-name-pattern 'rename_file with apply:false previews edits without filesystem changes'`
  - Result: one passing focused test. The preview showed positions and replacement text for 8/9 edits, explicitly reported one omission, omitted the ninth replacement, and left the filesystem unchanged.
- `bun --cwd=packages/coding-agent check`
  - Result: Biome and `tsgo` passed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.