### PR TITLE
feat(advisors): load configs from plugins

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -43,6 +43,32 @@ Model selectors use normal role/model resolution, including provider-prefixed id
 
 `tier.advisor` controls service tier for all advisors. It defaults to `none` (standard processing); `inherit` follows the primary's live per-family tier, including `/fast` changes. Concrete values (`auto`, `default`, `flex`, `scale`, `priority`) are applied only when the advisor model's provider family supports them.
 
+### Plugin-provided rosters
+
+An enabled plugin may declare advisor config files in `package.json`:
+
+```json
+{
+  "name": "review-council",
+  "version": "1.0.0",
+  "omp": {
+    "advisors": ["./WATCHDOG.yml"]
+  }
+}
+```
+
+Plugin files contribute advisor rows at the lowest precedence. User and project
+`WATCHDOG.yml` entries replace a plugin row with the same slug. Plugin top-level
+`instructions` are ignored, per-advisor `@import` references are not expanded,
+and plugin tool grants are restricted to `read`, `grep`, and `glob`. Declared
+paths must resolve to regular files inside the installed package; traversal and
+escaping symlinks are rejected.
+
+Installing a plugin never changes `advisor.enabled`. `/reload-plugins` rebuilds
+the live roster after install, upgrade, enable, disable, or uninstall, including
+ACP sessions. `/advisor configure` edits only user/project files but preserves
+plugin rows in the merged live roster.
+
 ### Headless runs
 
 Use `--advisor` to enable the advisor for one print-mode process without

--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -25,7 +25,7 @@ An advisor does not approve actions or mutate primary session state directly. It
 
 The subsystem requires `advisor.enabled: true`. Model selection then depends on the roster:
 
-- Without any discovered `WATCHDOG.yml` advisor entries, OMP creates the legacy/default advisor and resolves its model from `modelRoles.advisor`.
+- Without any discovered user, project, or plugin `WATCHDOG.yml` advisor entries, OMP creates the legacy/default advisor and resolves its model from `modelRoles.advisor`. Any discovered roster replaces that fallback, so installing a plugin-only roster does not add a fifth legacy advisor.
 - With a roster, each enabled entry uses its explicit `model` when present, otherwise `modelRoles.advisor`. An unresolvable entry is reported as `no_model` without preventing other entries from running.
 - `advisors[].enabled: false` keeps an entry visible as paused but does not build its runtime.
 

--- a/docs/plugin-manager-installer-plumbing.md
+++ b/docs/plugin-manager-installer-plumbing.md
@@ -61,7 +61,7 @@ Marketplace installs add registry and cache state alongside those runtime entrie
 - user plugins data root `installed_plugins.json` (`~/.omp/plugins/installed_plugins.json` by default) — user-scoped marketplace installs
 - `<anchor>/.omp/plugins/installed_plugins.json` — project-scoped marketplace installs
 - user plugins data root `cache/{marketplaces,plugins}/` — cached catalogs and plugin directories
-- `<scope>/plugins/node_modules/<package>` — symlink to the cached plugin, allowing its `package.json` `omp.extensions` and tools to load
+- `<scope>/plugins/node_modules/<package>` — symlink to the cached plugin, allowing its `package.json` `omp.extensions`, `omp.advisors`, and tools to load
 - `<scope>/plugins/omp-plugins.lock.json` — enablement and feature state shared with the runtime plugin loader
 
 ## Plugin spec parsing and metadata interpretation
@@ -94,6 +94,7 @@ Implications:
 - A package missing `omp`/`pi` is still installable and listable.
 - Runtime plugin loading (`getEnabledPlugins`) skips packages without `omp`/`pi` manifest.
 - `manifest.version` is always overwritten from package `version`.
+- `omp.advisors` entries are contained regular-file paths. Enabled plugins contribute those advisor rows below user/project `WATCHDOG.yml` precedence; plugin disable or removal takes effect when plugin state reloads.
 
 Malformed `package.json` JSON is a hard failure at read time; malformed manifest shape may fail later only when specific fields are consumed.
 

--- a/docs/skills/authoring-extensions.md
+++ b/docs/skills/authoring-extensions.md
@@ -131,6 +131,24 @@ Multiple entry points are supported:
 }
 ```
 
+Plugins may also provide advisor roster data without an executable extension:
+
+```json
+{
+  "name": "review-council",
+  "version": "1.0.0",
+  "omp": {
+    "advisors": ["./WATCHDOG.yml"]
+  }
+}
+```
+
+Each `advisors` entry must resolve to a regular file inside the package. OMP
+loads those rows below user/project `WATCHDOG.yml` precedence, ignores plugin
+top-level shared instructions and `@import` expansion, and restricts their tools
+to `read`, `grep`, and `glob`. The package does not enable the advisor subsystem;
+the session still requires `advisor.enabled: true` or `/advisor on`.
+
 Installed-plugin manifest entries may be `.ts`, `.js`, `.mjs`, or `.cjs`; a manifest entry naming a directory resolves `index.ts`, `index.js`, `index.mjs`, or `index.cjs`. Automatic scanning of native/configured extension directories remains limited to `.ts` and `.js`.
 
 ## Registering commands

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -4,6 +4,7 @@ import { type } from "@oh-my-pi/omptype";
 import { isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { expandAtImports } from "../discovery/at-imports";
+import { getAllPluginAdvisorPaths } from "../extensibility/plugins/loader";
 import { BUILTIN_TOOL_NAMES, normalizeToolNames } from "../tools/builtin-names";
 import { collectConfigCandidates } from "./watchdog";
 
@@ -107,6 +108,13 @@ export function getOrCreateAdvisorProviderSessionId(
 /** Built tool names, for validating an advisor's `tools` list. */
 const KNOWN_TOOL_NAMES = new Set<string>(BUILTIN_TOOL_NAMES);
 
+/** Plugin-provided advisors are always read-only, regardless of their YAML. */
+const PLUGIN_ADVISOR_TOOL_NAMES: Readonly<Record<string, true>> = {
+	read: true,
+	grep: true,
+	glob: true,
+};
+
 /**
  * Keep only valid tool names from an advisor's `tools` list, dropping unknowns
  * with a warning. The advisor is a full agent, so any built tool may be granted;
@@ -114,63 +122,104 @@ const KNOWN_TOOL_NAMES = new Set<string>(BUILTIN_TOOL_NAMES);
  * `undefined` means "use the default subset" (read/grep/glob); only an explicit
  * raw empty list means "no tools".
  */
-function filterAdvisorTools(tools: string[] | undefined, sourcePath: string): string[] | undefined {
+function filterAdvisorTools(
+	tools: string[] | undefined,
+	sourcePath: string,
+	pluginSource = false,
+): string[] | undefined {
 	if (tools === undefined) return undefined;
 	if (tools.length === 0) return [];
 	// Normalize legacy aliases (search→grep, find→glob) and dedupe before validating.
 	const filtered = normalizeToolNames(tools).filter(name => {
-		if (KNOWN_TOOL_NAMES.has(name)) return true;
-		logger.warn("Advisor config: dropping unknown tool", { path: sourcePath, tool: name });
+		if (KNOWN_TOOL_NAMES.has(name) && (!pluginSource || Object.hasOwn(PLUGIN_ADVISOR_TOOL_NAMES, name))) {
+			return true;
+		}
+		logger.warn(pluginSource ? "Advisor plugin: dropping disallowed tool" : "Advisor config: dropping unknown tool", {
+			path: sourcePath,
+			tool: name,
+		});
 		return false;
 	});
 	return filtered.length > 0 ? filtered : undefined;
 }
 
 /**
- * Discover advisor configs from `WATCHDOG.yml`/`WATCHDOG.yaml` files on the same
- * user + project search path as `WATCHDOG.md`. Advisors are keyed by slug; a
- * more-specific file (project leaf > project ancestor > user) replaces an earlier
- * entry with the same slug. Top-level `instructions` across all files concatenate
- * into the shared baseline. A malformed file is logged and skipped — never
- * thrown — so a bad project config can't kill the session.
+ * Discover advisor configs from enabled plugin manifests and
+ * `WATCHDOG.yml`/`WATCHDOG.yaml` files. Plugin files have lowest precedence
+ * and contribute advisor rows only: their top-level shared instructions are
+ * ignored, `@import` is not expanded, and tools are clamped to
+ * `read`/`grep`/`glob`. User and project files retain the existing search order,
+ * may grant any built-in tool, and replace plugin rows with the same slug.
+ *
+ * Pass `pluginAdvisorPaths` explicitly in isolated tests. Omitted paths are
+ * discovered from enabled plugins. Malformed or unreadable sources are logged
+ * and skipped so a broken plugin cannot kill session startup.
  */
-export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Promise<DiscoveredAdvisors> {
-	const items = await collectConfigCandidates(cwd, agentDir, ["WATCHDOG.yml", "WATCHDOG.yaml"]);
+export async function discoverAdvisorConfigs(
+	cwd: string,
+	agentDir?: string,
+	pluginAdvisorPaths?: readonly string[],
+): Promise<DiscoveredAdvisors> {
+	const pluginPathsPromise: Promise<readonly string[]> =
+		pluginAdvisorPaths === undefined
+			? getAllPluginAdvisorPaths(cwd).catch(err => {
+					logger.warn("Advisor config: failed to discover plugin sources", { error: String(err) });
+					return [];
+				})
+			: Promise.resolve(pluginAdvisorPaths);
+	const [items, pluginPaths] = await Promise.all([
+		collectConfigCandidates(cwd, agentDir, ["WATCHDOG.yml", "WATCHDOG.yaml"]),
+		pluginPathsPromise,
+	]);
+	const sources: Array<{ path: string; content: string; plugin: boolean }> = [];
+	for (const filePath of pluginPaths) {
+		try {
+			sources.push({ path: filePath, content: await fs.readFile(filePath, "utf8"), plugin: true });
+		} catch (err) {
+			logger.warn("Advisor config: failed to read plugin source", { path: filePath, error: String(err) });
+		}
+	}
+	for (const item of items) {
+		sources.push({ ...item, plugin: false });
+	}
+
 	const advisors = new Map<string, AdvisorConfig>();
 	const sharedParts: string[] = [];
-
-	for (const item of items) {
+	for (const source of sources) {
 		let parsed: unknown;
 		try {
-			parsed = YAML.parse(item.content);
+			parsed = YAML.parse(source.content);
 		} catch (err) {
-			logger.warn("Advisor config: failed to parse YAML", { path: item.path, error: String(err) });
+			logger.warn("Advisor config: failed to parse YAML", { path: source.path, error: String(err) });
 			continue;
 		}
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-			logger.warn("Advisor config: expected a YAML mapping", { path: item.path });
+			logger.warn("Advisor config: expected a YAML mapping", { path: source.path });
 			continue;
 		}
 		const result = watchdogYamlSchema(parsed);
 		if (result instanceof type.errors) {
-			logger.warn("Advisor config: invalid schema", { path: item.path, error: result.summary });
+			logger.warn("Advisor config: invalid schema", { path: source.path, error: result.summary });
 			continue;
 		}
 
-		if (result.instructions?.trim()) {
-			const expanded = (await expandAtImports(result.instructions, item.path)).trim();
+		if (!source.plugin && result.instructions?.trim()) {
+			const expanded = (await expandAtImports(result.instructions, source.path)).trim();
 			if (expanded) sharedParts.push(expanded);
 		}
 
 		for (const entry of result.advisors ?? []) {
 			const slug = slugifyAdvisorName(entry.name);
-			const instructions = entry.instructions?.trim()
-				? (await expandAtImports(entry.instructions, item.path)).trim() || undefined
+			const rawInstructions = entry.instructions?.trim();
+			const instructions = rawInstructions
+				? source.plugin
+					? rawInstructions
+					: (await expandAtImports(rawInstructions, source.path)).trim() || undefined
 				: undefined;
 			advisors.set(slug, {
 				name: entry.name,
 				model: entry.model?.trim() || undefined,
-				tools: filterAdvisorTools(entry.tools, item.path),
+				tools: filterAdvisorTools(entry.tools, source.path, source.plugin),
 				instructions,
 				enabled: entry.enabled,
 			});

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -6,7 +6,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getPluginsDir, getPluginsLockfile, isEnoent } from "@oh-my-pi/pi-utils";
+import { getPluginsDir, getPluginsLockfile, isEnoent, logger, pathIsWithin } from "@oh-my-pi/pi-utils";
 import { getConfigDirPaths } from "../../config";
 import { registerPluginCacheInvalidator, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
@@ -460,6 +460,58 @@ export function resolvePluginExtensionPaths(plugin: InstalledPlugin): string[] {
 	return resolvePluginPaths(plugin, "extensions");
 }
 
+/**
+ * Resolve every declared advisor configuration entry while preserving failures
+ * for install-time validation. Advisor entries are data files rather than
+ * executable modules, so directories are rejected. Both lexical and real paths
+ * must remain inside the plugin root.
+ */
+export function resolvePluginAdvisorManifestEntries(
+	plugin: InstalledPlugin,
+): Array<{ entry: unknown; resolvedPath: string | null }> {
+	const entries = plugin.manifest.advisors;
+	if (!Array.isArray(entries)) return [];
+
+	const pluginRoot = path.resolve(plugin.path);
+	let realPluginRoot: string;
+	try {
+		realPluginRoot = fs.realpathSync(pluginRoot);
+	} catch {
+		return entries.map(entry => ({ entry, resolvedPath: null }));
+	}
+
+	return entries.map(entry => {
+		if (typeof entry !== "string") return { entry, resolvedPath: null };
+		const candidate = path.resolve(pluginRoot, entry);
+		if (!pathIsWithin(pluginRoot, candidate)) return { entry, resolvedPath: null };
+		try {
+			const realCandidate = fs.realpathSync(candidate);
+			if (!pathIsWithin(realPluginRoot, realCandidate) || !fs.statSync(realCandidate).isFile()) {
+				return { entry, resolvedPath: null };
+			}
+			return { entry, resolvedPath: realCandidate };
+		} catch {
+			return { entry, resolvedPath: null };
+		}
+	});
+}
+
+/** Resolve loadable advisor configuration files declared by a plugin. */
+export function resolvePluginAdvisorPaths(plugin: InstalledPlugin): string[] {
+	const resolved: string[] = [];
+	for (const { entry, resolvedPath } of resolvePluginAdvisorManifestEntries(plugin)) {
+		if (resolvedPath) {
+			resolved.push(resolvedPath);
+		} else {
+			logger.warn("Plugin advisor entry is missing, unreadable, or outside the plugin root; skipping", {
+				plugin: plugin.name,
+				entry,
+			});
+		}
+	}
+	return resolved;
+}
+
 // =============================================================================
 // Aggregated Discovery
 // =============================================================================
@@ -515,6 +567,20 @@ export async function getAllPluginExtensionPaths(cwd: string): Promise<string[]>
 
 	for (const plugin of plugins) {
 		paths.push(...resolvePluginExtensionPaths(plugin));
+	}
+
+	return paths;
+}
+
+/**
+ * Get all advisor configuration paths from enabled plugins.
+ */
+export async function getAllPluginAdvisorPaths(cwd: string, opts: { home?: string } = {}): Promise<string[]> {
+	const plugins = await getEnabledPlugins(cwd, opts);
+	const paths: string[] = [];
+
+	for (const plugin of plugins) {
+		paths.push(...resolvePluginAdvisorPaths(plugin));
 	}
 
 	return paths;

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -470,7 +470,8 @@ export function resolvePluginAdvisorManifestEntries(
 	plugin: InstalledPlugin,
 ): Array<{ entry: unknown; resolvedPath: string | null }> {
 	const entries = plugin.manifest.advisors;
-	if (!Array.isArray(entries)) return [];
+	if (entries === undefined) return [];
+	if (!Array.isArray(entries)) return [{ entry: entries, resolvedPath: null }];
 
 	const pluginRoot = path.resolve(plugin.path);
 	let realPluginRoot: string;

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -14,7 +14,7 @@ import {
 import { loadExtensions } from "../extensions/loader";
 import { refreshBunGitCache } from "./bun-git-cache";
 import { type GitSource, parseGitUrl } from "./git-url";
-import { resolvePluginManifestEntries } from "./loader";
+import { resolvePluginAdvisorManifestEntries, resolvePluginManifestEntries } from "./loader";
 import { getInstalledPluginsRegistryPath, readInstalledPluginsRegistry } from "./marketplace/registry";
 import { parsePluginId } from "./marketplace/types";
 import { extractPackageName, parsePluginSpec } from "./parser";
@@ -346,31 +346,33 @@ export class PluginManager {
 		await fs.promises.cp(snapshot.backupPath, snapshot.packagePath, { recursive: true, verbatimSymlinks: true });
 	}
 
-	async #validateInstalledExtensions(plugin: InstalledPlugin): Promise<void> {
-		const declaredEntries = resolvePluginManifestEntries(plugin, "extensions");
-		if (declaredEntries.length === 0) {
-			return;
-		}
+	async #validateInstalledPlugin(plugin: InstalledPlugin): Promise<void> {
+		const extensionEntries = resolvePluginManifestEntries(plugin, "extensions");
+		const advisorEntries = resolvePluginAdvisorManifestEntries(plugin);
+		if (extensionEntries.length === 0 && advisorEntries.length === 0) return;
 
 		const errors: string[] = [];
-		const loadable: string[] = [];
-		for (const { entry, resolvedPath } of declaredEntries) {
+		const loadableExtensions: string[] = [];
+		for (const { entry, resolvedPath } of extensionEntries) {
 			if (resolvedPath === null) {
 				errors.push(`${entry}: declared extension entry not found on disk`);
 			} else {
-				loadable.push(resolvedPath);
+				loadableExtensions.push(resolvedPath);
 			}
 		}
+		for (const { entry, resolvedPath } of advisorEntries) {
+			if (resolvedPath === null) errors.push(`${entry}: declared advisor entry not found inside the plugin`);
+		}
 
-		if (loadable.length > 0) {
-			const result = await loadExtensions(loadable, this.#cwd);
+		if (loadableExtensions.length > 0) {
+			const result = await loadExtensions(loadableExtensions, this.#cwd);
 			for (const failure of result.errors) {
 				errors.push(`${failure.path}: ${failure.error}`);
 			}
 		}
 
 		if (errors.length > 0) {
-			throw new Error(`Plugin ${plugin.name} extension validation failed:\n${errors.join("\n")}`);
+			throw new Error(`Plugin ${plugin.name} validation failed:\n${errors.join("\n")}`);
 		}
 	}
 
@@ -577,7 +579,7 @@ export class PluginManager {
 				enabled: true,
 			};
 
-			await this.#validateInstalledExtensions(installedPlugin);
+			await this.#validateInstalledPlugin(installedPlugin);
 
 			// Update runtime config
 			const config = await this.#ensureConfigLoaded();

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -11,8 +11,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { isEnoent, logger, pathIsWithin } from "@oh-my-pi/pi-utils";
+import { resolvePluginAdvisorManifestEntries } from "../loader";
 import { normalizePluginRuntimeConfig } from "../runtime-config";
-import type { PluginRuntimeConfig } from "../types";
+import type { InstalledPlugin, PluginManifest, PluginRuntimeConfig } from "../types";
 
 import { cachePlugin } from "./cache";
 import { classifySource, fetchMarketplace, parseMarketplaceCatalog, promoteCloneToCache } from "./fetcher";
@@ -312,6 +313,7 @@ export class MarketplaceManager {
 		}
 
 		const packageName = await this.#resolvePluginPackageName(cachePath, name);
+		await this.#validateAdvisorManifest(cachePath, packageName, version);
 		const previousPackageNames = await this.#resolveInstalledPackageNames(existing ?? [], name);
 
 		// Only now clean up old entries — new cache succeeded, so it is safe to remove old ones.
@@ -788,6 +790,34 @@ export class MarketplaceManager {
 
 	async #writeRuntimeConfig(scope: "user" | "project", config: PluginRuntimeConfig): Promise<void> {
 		await Bun.write(this.#runtimeLockPath(scope), JSON.stringify(config, null, 2));
+	}
+
+	async #validateAdvisorManifest(installPath: string, packageName: string, fallbackVersion: string): Promise<void> {
+		let pkg: { version?: unknown; omp?: PluginManifest; pi?: PluginManifest };
+		try {
+			pkg = await Bun.file(path.join(installPath, "package.json")).json();
+		} catch (err) {
+			if (isEnoent(err)) return;
+			throw err;
+		}
+
+		const declaredManifest = pkg.omp ?? pkg.pi;
+		if (!declaredManifest) return;
+		const version = typeof pkg.version === "string" ? pkg.version : fallbackVersion;
+		const plugin: InstalledPlugin = {
+			name: packageName,
+			version,
+			path: installPath,
+			manifest: { ...declaredManifest, version },
+			enabledFeatures: null,
+			enabled: true,
+		};
+		const errors = resolvePluginAdvisorManifestEntries(plugin)
+			.filter(({ resolvedPath }) => resolvedPath === null)
+			.map(({ entry }) => `${entry}: declared advisor entry not found inside the plugin`);
+		if (errors.length > 0) {
+			throw new Error(`Plugin ${plugin.name} validation failed:\n${errors.join("\n")}`);
+		}
 	}
 
 	async #resolvePluginPackageName(installPath: string, fallbackName: string): Promise<string> {

--- a/packages/coding-agent/src/extensibility/plugins/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/types.ts
@@ -41,6 +41,9 @@ export interface PluginManifest {
 	/** Command files (relative paths from package root) */
 	commands?: string[];
 
+	/** Advisor configuration files (relative paths from package root) */
+	advisors?: string[];
+
 	/** Feature definitions for selective installation */
 	features?: Record<string, PluginFeature>;
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -43,6 +43,7 @@ import {
 	type SetSessionModeResponse,
 	type Usage,
 } from "@oh-my-pi/pi-utils/acp";
+import { discoverAdvisorConfigs } from "../../advisor";
 import { disableProvider, enableProvider, reset as resetCapabilities } from "../../capability";
 import { Settings } from "../../config/settings";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -1930,10 +1931,10 @@ export class AcpAgent implements Agent {
 
 	/**
 	 * Reload plugin/registry state for an ACP session. Mirrors the interactive
-	 * `/reload-plugins` and `/move` flows: invalidates the plugin-roots cache,
-	 * refreshes task agents, resets the capability cache, refreshes the
-	 * session's slash-command state, then re-advertises commands so the client
-	 * sees newly installed/disabled plugins.
+	 * `/reload-plugins` and `/move` flows: invalidates plugin caches; refreshes
+	 * task agents, advisors, skills, capabilities, and slash commands; then
+	 * re-advertises commands so the client sees newly installed or disabled
+	 * plugins.
 	 */
 	async #reloadPluginState(record: ManagedSessionRecord): Promise<void> {
 		const cwd = record.session.sessionManager.getCwd();
@@ -1941,6 +1942,8 @@ export class AcpAgent implements Agent {
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
 		await refreshAgentDiscovery(cwd);
 		resetCapabilities();
+		const discovered = await discoverAdvisorConfigs(cwd, record.session.settings.getAgentDir());
+		record.session.applyAdvisorConfigs(discovered.advisors, discovered.sharedInstructions);
 		await record.session.refreshSkills();
 		const fileCommands = await loadSlashCommands({ cwd });
 		record.session.setSlashCommands(fileCommands);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -103,6 +103,7 @@ import { TranscriptBlock } from "../components/transcript-container";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
+import { reloadTuiPluginState } from "../tui-plugin-reload";
 import { buildCopyTargets } from "../utils/copy-targets";
 
 const MANUAL_LOGIN_PROMPT = "Paste the authorization code (or full redirect URL), then press Enter:";
@@ -1085,6 +1086,7 @@ export class SelectorController {
 						this.ctx.ui.requestRender();
 						try {
 							await mgr.uninstallPlugin(pluginId, scope);
+							await reloadTuiPluginState(this.ctx);
 							this.ctx.showStatus(`Uninstalled ${pluginId}`);
 						} catch (err) {
 							this.ctx.showStatus(`Uninstall failed: ${err}`);
@@ -1122,6 +1124,7 @@ export class SelectorController {
 					try {
 						const force = installedIds.has(`${name}@${marketplace}`);
 						await mgr.installPlugin(name, marketplace, { force });
+						await reloadTuiPluginState(this.ctx);
 						this.ctx.showStatus(`Installed ${name} from ${marketplace}`);
 					} catch (err) {
 						this.ctx.showStatus(`Install failed: ${err}`);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -13,7 +13,6 @@ import {
 	resolveAdvisorConfigEditPath,
 	saveWatchdogConfigFile,
 } from "../../advisor";
-import { reset as resetCapabilities } from "../../capability";
 import {
 	formatModelSelectorValue,
 	resolveAdvisorRoleSelection,
@@ -235,11 +234,7 @@ export class SelectorController {
 						return this.ctx.statusLine.getTopBorder(availableWidth).content;
 					},
 					onPluginsChanged: async () => {
-						const projectPath = await resolveActiveProjectRegistryPath(this.ctx.sessionManager.getCwd());
-						clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-						await this.ctx.refreshSkillState();
-						await this.ctx.refreshSlashCommandState();
-						resetCapabilities();
+						await reloadTuiPluginState(this.ctx);
 						this.ctx.ui.requestRender();
 					},
 					onCancel: () => {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -53,7 +53,6 @@ import {
 	setProjectDir,
 } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
-import { reset as resetCapabilities } from "../capability";
 import type { CollabGuestLink } from "../collab/guest";
 import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
@@ -66,7 +65,6 @@ import {
 	Settings,
 	settings,
 } from "../config/settings";
-import { clearClaudePluginRootsCache } from "../discovery/helpers";
 import type {
 	AutocompleteProviderFactory,
 	ContextUsage,
@@ -213,6 +211,7 @@ import {
 	startMacOSAppearanceReprobeFallback,
 	theme,
 } from "./theme/theme";
+import { reloadTuiPluginState } from "./tui-plugin-reload";
 import type {
 	CompactionQueuedMessage,
 	InteractiveModeContext,
@@ -1381,13 +1380,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			// exclusions leak and newly-excluded providers are still used.
 			applyProviderGlobalsFromSettings(settings);
 		}
-		// Re-warm plugin roots, capabilities, slash commands, and the ssh tool so
-		// the next prompt sees everything scoped to the new project directory.
-		clearClaudePluginRootsCache();
+		// Refresh the destination project's title prompt and every plugin-provided
+		// runtime surface before accepting another turn.
 		await this.refreshTitleSystemPrompt(newCwd);
-		resetCapabilities();
-		await this.refreshSkillState();
-		await this.refreshSlashCommandState(newCwd);
+		await reloadTuiPluginState(this);
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
 		this.statusLine.applyCwdChange();
 	}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -14,6 +14,7 @@ import { once } from "node:events";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { $env, isRecord, readLines, Snowflake } from "@oh-my-pi/pi-utils";
+import { discoverAdvisorConfigs } from "../../advisor";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -655,6 +656,27 @@ export function requestRpcDialog<T>(
 	output({ type: "extension_ui_request", id, ...request } as RpcExtensionUIRequest);
 	return promise;
 }
+
+export type RpcPluginReloadSession = Pick<
+	AgentSession,
+	"applyAdvisorConfigs" | "refreshSkills" | "sessionManager" | "setSlashCommands" | "settings"
+>;
+
+/** Refresh every plugin-provided surface owned directly by an RPC session. */
+export async function refreshRpcPluginState(
+	session: RpcPluginReloadSession,
+	emitAvailableCommandsUpdate: () => Promise<void>,
+): Promise<void> {
+	const cwd = session.sessionManager.getCwd();
+	const projectPath = await resolveActiveProjectRegistryPath(cwd);
+	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+	resetCapabilities();
+	const discovered = await discoverAdvisorConfigs(cwd, session.settings.getAgentDir());
+	session.applyAdvisorConfigs(discovered.advisors, discovered.sharedInstructions);
+	await session.refreshSkills();
+	session.setSlashCommands(await loadSlashCommands({ cwd }));
+	await emitAvailableCommandsUpdate();
+}
 /**
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
@@ -954,18 +976,10 @@ export async function runRpcMode(
 	});
 
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
-	const reloadPluginState = async () => {
-		const cwd = session.sessionManager.getCwd();
-		const projectPath = await resolveActiveProjectRegistryPath(cwd);
-		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-		resetCapabilities();
-		await session.refreshSkills();
-		session.setSlashCommands(await loadSlashCommands({ cwd }));
-		await emitAvailableCommandsUpdate();
-	};
 	const emitAvailableCommandsUpdate = async () => {
 		output({ type: "available_commands_update", commands: await getAvailableCommands() });
 	};
+	const reloadPluginState = () => refreshRpcPluginState(session, emitAvailableCommandsUpdate);
 	session.subscribeCommandMetadataChanged(() => {
 		void emitAvailableCommandsUpdate();
 	});

--- a/packages/coding-agent/src/modes/tui-plugin-reload.ts
+++ b/packages/coding-agent/src/modes/tui-plugin-reload.ts
@@ -1,0 +1,24 @@
+import { discoverAdvisorConfigs } from "../advisor";
+import { reset as resetCapabilities } from "../capability";
+import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers";
+import { refreshAgentDiscovery } from "../task";
+import { MCPCommandController } from "./controllers/mcp-command-controller";
+import type { InteractiveModeContext } from "./types";
+
+/**
+ * Reload the interactive session's plugin runtime after a plugin mutation or
+ * cwd change. Every plugin-provided surface must move together so removed
+ * advisors cannot outlive their package and installed advisors start at once.
+ */
+export async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
+	const cwd = ctx.sessionManager.getCwd();
+	const projectPath = await resolveActiveProjectRegistryPath(cwd);
+	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+	await refreshAgentDiscovery(cwd);
+	await ctx.refreshSkillState();
+	await ctx.refreshSlashCommandState();
+	resetCapabilities();
+	const discovered = await discoverAdvisorConfigs(cwd, ctx.settings.getAgentDir());
+	ctx.session.applyAdvisorConfigs(discovered.advisors, discovered.sharedInstructions);
+	if (ctx.mcpManager) await new MCPCommandController(ctx).reloadServers();
+}

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1586,16 +1586,18 @@ export class SessionAdvisors {
 
 	/**
 	 * Replace the live advisor roster from an edited `WATCHDOG.yml` (the `/advisor
-	 * configure` save path). Swaps the configs + shared baseline, then rebuilds the
-	 * runtimes in place so the change applies without a restart. When the advisor is
-	 * disabled the new configs are simply stored for the next enable.
+	 * configure` save path). Swaps the configs + shared baseline, then rebuilds
+	 * runtimes only when their resolved inputs changed. When the advisor is disabled,
+	 * the new configs are simply stored for the next enable.
 	 *
 	 * @returns the number of advisors active after the rebuild.
 	 */
 	applyAdvisorConfigs(advisors: AdvisorConfig[], sharedInstructions: string | undefined): number {
+		const sharedInstructionsChanged = sharedInstructions !== this.#advisorSharedInstructions;
 		this.#advisorConfigs = advisors;
 		this.#advisorSharedInstructions = sharedInstructions;
 		if (!this.#advisorEnabled) return 0;
+		if (!sharedInstructionsChanged && this.#advisorRuntimeMatchesCurrentConfig()) return this.#advisors.length;
 		this.#stopAdvisorRuntime();
 		this.#buildAdvisorRuntime(true);
 		return this.#advisors.length;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -636,15 +636,15 @@ export class SessionAdvisors {
 	}
 
 	#advisorRuntimeSignature(config: AdvisorConfig, slug: string, model: Model, thinkingLevel: ThinkingLevel): string {
-		const tools = config.tools?.length ? config.tools.join("\u001e") : "";
+		const tools = config.tools === undefined ? "default" : `explicit:${config.tools.join("\u001e")}`;
 		const instructions = config.instructions?.trim() ?? "";
 		return [config.name, slug, formatModelStringWithRouting(model), thinkingLevel, tools, instructions].join(
 			"\u001f",
 		);
 	}
 
-	#advisorRuntimeMatchesCurrentConfig(): boolean {
-		const descriptors = this.#resolveAdvisorRuntimeDescriptors(false);
+	#advisorRuntimeMatchesCurrentConfig(emitWarnings = false): boolean {
+		const descriptors = this.#resolveAdvisorRuntimeDescriptors(emitWarnings);
 		if (descriptors.length !== this.#advisors.length) return false;
 		for (let i = 0; i < descriptors.length; i++) {
 			if (descriptors[i].signature !== this.#advisors[i].signature) return false;
@@ -1597,7 +1597,8 @@ export class SessionAdvisors {
 		this.#advisorConfigs = advisors;
 		this.#advisorSharedInstructions = sharedInstructions;
 		if (!this.#advisorEnabled) return 0;
-		if (!sharedInstructionsChanged && this.#advisorRuntimeMatchesCurrentConfig()) return this.#advisors.length;
+		this.#advisorStatuses.clear();
+		if (!sharedInstructionsChanged && this.#advisorRuntimeMatchesCurrentConfig(true)) return this.#advisors.length;
 		this.#stopAdvisorRuntime();
 		this.#buildAdvisorRuntime(true);
 		return this.#advisors.length;

--- a/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
@@ -1,9 +1,4 @@
-import { reset as resetCapabilities } from "../capability";
-import {
-	clearPluginRootsAndCaches,
-	resolveActiveProjectRegistryPath,
-	resolveOrDefaultProjectRegistryPath,
-} from "../discovery/helpers.js";
+import { clearPluginRootsAndCaches, resolveOrDefaultProjectRegistryPath } from "../discovery/helpers.js";
 import { PluginManager } from "../extensibility/plugins";
 import {
 	getInstalledPluginsRegistryPath,
@@ -12,32 +7,11 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../extensibility/plugins/marketplace";
-import { MCPCommandController } from "../modes/controllers/mcp-command-controller";
-import type { InteractiveModeContext } from "../modes/types";
-import { refreshAgentDiscovery } from "../task";
+import { reloadTuiPluginState } from "../modes/tui-plugin-reload";
 import { createMarketplaceManager } from "./helpers/marketplace-manager";
 import { commandConsumed, errorMessage, parseSubcommand, usage } from "./helpers/parse";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
 import type { SlashCommandSpec } from "./types";
-
-/**
- * Reload the interactive session's plugin runtime: invalidate fs/plugin-root
- * caches, rediscover skills, file slash commands, and task agents, reset the
- * capability cache, and reconnect MCP servers (rebinding the session's MCP
- * tools). Shared by `/reload-plugins`'s TUI handler and the `handle`-adapter's
- * `reloadPlugins` hook so both honor the command's documented reload scope.
- */
-export async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
-	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
-	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-	await refreshAgentDiscovery(ctx.sessionManager.getCwd());
-	await ctx.refreshSkillState();
-	await ctx.refreshSlashCommandState();
-	resetCapabilities();
-	if (ctx.mcpManager) {
-		await new MCPCommandController(ctx).reloadServers();
-	}
-}
 
 export const BUILTIN_MARKETPLACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
@@ -320,6 +294,7 @@ export const BUILTIN_MARKETPLACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec>
 						const name = parsed.installSpec.slice(0, atIdx);
 						const marketplace = parsed.installSpec.slice(atIdx + 1);
 						await mgr.installPlugin(name, marketplace, { force: parsed.force, scope: parsed.scope });
+						await reloadTuiPluginState(runtime.ctx);
 						runtime.ctx.showStatus(`Installed ${name} from ${marketplace}`);
 						break;
 					}
@@ -338,6 +313,7 @@ export const BUILTIN_MARKETPLACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec>
 							return;
 						}
 						await mgr.uninstallPlugin(uninstArgs.pluginId, uninstArgs.scope);
+						await reloadTuiPluginState(runtime.ctx);
 						runtime.ctx.showStatus(`Uninstalled ${uninstArgs.pluginId}`);
 						break;
 					}
@@ -364,12 +340,14 @@ export const BUILTIN_MARKETPLACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec>
 								return;
 							}
 							const result = await mgr.upgradePlugin(upArgs.pluginId, upArgs.scope);
+							await reloadTuiPluginState(runtime.ctx);
 							runtime.ctx.showStatus(`Upgraded ${upArgs.pluginId} to ${result.version}`);
 						} else {
 							const results = await mgr.upgradeAllPlugins();
 							if (results.length === 0) {
 								runtime.ctx.showStatus("All marketplace plugins are up to date");
 							} else {
+								await reloadTuiPluginState(runtime.ctx);
 								const lines = results.map(r => `  ${r.pluginId}: ${r.from} -> ${r.to}`);
 								runtime.ctx.showStatus(`Upgraded ${results.length} plugin(s):\n${lines.join("\n")}`);
 							}
@@ -508,6 +486,7 @@ export const BUILTIN_MARKETPLACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec>
 						}
 						const isEnable = sub === "enable";
 						await mgr.setPluginEnabled(parsed.pluginId, isEnable, parsed.scope);
+						await reloadTuiPluginState(runtime.ctx);
 						runtime.ctx.showStatus(`${isEnable ? "Enabled" : "Disabled"} ${parsed.pluginId}`);
 						break;
 					}
@@ -551,7 +530,7 @@ export const BUILTIN_MARKETPLACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec>
 	},
 	{
 		name: "reload-plugins",
-		description: "Reload all plugins (skills, commands, hooks, tools, agents, MCP)",
+		description: "Reload all plugins (skills, commands, hooks, tools, agents, advisors, MCP)",
 		acpDescription: "Reload all plugins",
 		handle: async (_command, runtime) => {
 			await runtime.reloadPlugins();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteItem } from "@oh-my-pi/pi-tui";
 import { COLLAB_GUEST_ALLOWED_COMMANDS } from "../collab/guest";
+import { reloadTuiPluginState } from "../modes/tui-plugin-reload";
 import { BUILTIN_COLLABORATION_SLASH_COMMANDS } from "./builtin-collaboration";
 import {
 	buildArgumentCompletions,
@@ -10,7 +11,7 @@ import {
 } from "./builtin-completions";
 import { BUILTIN_CONTROL_SLASH_COMMANDS } from "./builtin-control";
 import { BUILTIN_LIFECYCLE_SLASH_COMMANDS } from "./builtin-lifecycle";
-import { BUILTIN_MARKETPLACE_SLASH_COMMANDS, reloadTuiPluginState } from "./builtin-marketplace";
+import { BUILTIN_MARKETPLACE_SLASH_COMMANDS } from "./builtin-marketplace";
 import { BUILTIN_MODE_SLASH_COMMANDS } from "./builtin-modes";
 import { BUILTIN_SESSION_SLASH_COMMANDS } from "./builtin-session";
 import { parseSlashCommand } from "./helpers/parse";

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -401,6 +401,35 @@ describe("AgentSession advisor toggle", () => {
 		expect(session.applyAdvisorConfigs([{ ...advisors[0] }], "Shared baseline")).toBe(1);
 		expect(session.getAdvisorAgent()).toBe(advisor);
 	});
+	it("drops removed paused advisor statuses without restarting an unchanged live advisor", () => {
+		const active = { name: "Security", model: `${model.provider}/${model.id}` };
+		const paused = { name: "Dormant", model: `${model.provider}/${model.id}`, enabled: false };
+		expect(session.applyAdvisorConfigs([active, paused], "Shared baseline")).toBe(0);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		expect(advisor).toBeDefined();
+		expect(session.getAdvisorStatusOverview().advisors.map(entry => entry.name)).toEqual(["Security", "Dormant"]);
+
+		expect(session.applyAdvisorConfigs([{ ...active }], "Shared baseline")).toBe(1);
+		expect(session.getAdvisorAgent()).toBe(advisor);
+		expect(session.getAdvisorStatusOverview().advisors.map(entry => entry.name)).toEqual(["Security"]);
+		expect(session.getAdvisorStats().advisors.map(entry => entry.name)).toEqual(["Security"]);
+	});
+	it("rebuilds the live advisor runtime when tool permissions change between default and none", () => {
+		const base = { name: "Security", model: `${model.provider}/${model.id}` };
+		expect(session.applyAdvisorConfigs([base], "Shared baseline")).toBe(0);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const defaultToolsAdvisor = session.getAdvisorAgent();
+		expect(defaultToolsAdvisor).toBeDefined();
+
+		expect(session.applyAdvisorConfigs([{ ...base, tools: [] }], "Shared baseline")).toBe(1);
+		const noToolsAdvisor = session.getAdvisorAgent();
+		expect(noToolsAdvisor).toBeDefined();
+		expect(noToolsAdvisor).not.toBe(defaultToolsAdvisor);
+
+		expect(session.applyAdvisorConfigs([{ ...base }], "Shared baseline")).toBe(1);
+		expect(session.getAdvisorAgent()).not.toBe(noToolsAdvisor);
+	});
 	it("rebuilds the live advisor runtime when shared instructions change", () => {
 		const advisors = [{ name: "Security", model: `${model.provider}/${model.id}` }];
 		expect(session.applyAdvisorConfigs(advisors, "Initial baseline")).toBe(0);

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -391,6 +391,26 @@ describe("AgentSession advisor toggle", () => {
 		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 		expect(session.formatAdvisorStatus()).toContain("$0.5000");
 	});
+	it("keeps the live advisor runtime when reapplying an unchanged roster", () => {
+		const advisors = [{ name: "Security", model: `${model.provider}/${model.id}` }];
+		expect(session.applyAdvisorConfigs(advisors, "Shared baseline")).toBe(0);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		expect(advisor).toBeDefined();
+
+		expect(session.applyAdvisorConfigs([{ ...advisors[0] }], "Shared baseline")).toBe(1);
+		expect(session.getAdvisorAgent()).toBe(advisor);
+	});
+	it("rebuilds the live advisor runtime when shared instructions change", () => {
+		const advisors = [{ name: "Security", model: `${model.provider}/${model.id}` }];
+		expect(session.applyAdvisorConfigs(advisors, "Initial baseline")).toBe(0);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		expect(advisor).toBeDefined();
+
+		expect(session.applyAdvisorConfigs([{ ...advisors[0] }], "Updated baseline")).toBe(1);
+		expect(session.getAdvisorAgent()).not.toBe(advisor);
+	});
 	it("retains cumulative advisor cost after an in-session history rewrite", async () => {
 		const advisor = enableAdvisor();
 		appendAdvisorCost(advisor, 0.5, 1);

--- a/packages/coding-agent/test/advisor/config.test.ts
+++ b/packages/coding-agent/test/advisor/config.test.ts
@@ -41,7 +41,7 @@ describe("discoverAdvisorConfigs", () => {
 		].join("\n");
 		await Bun.write(path.join(tmp, "WATCHDOG.yml"), yaml);
 
-		const { advisors, sharedInstructions } = await discoverAdvisorConfigs(tmp, agentDir);
+		const { advisors, sharedInstructions } = await discoverAdvisorConfigs(tmp, agentDir, []);
 		expect(advisors).toHaveLength(2);
 		const [arch, sec] = advisors;
 		expect(arch.name).toBe("Architecture");
@@ -67,7 +67,7 @@ describe("discoverAdvisorConfigs", () => {
 		].join("\n");
 		await Bun.write(path.join(tmp, "WATCHDOG.yml"), yaml);
 
-		const { advisors } = await discoverAdvisorConfigs(tmp, agentDir);
+		const { advisors } = await discoverAdvisorConfigs(tmp, agentDir, []);
 		const noTools = advisors.find(a => a.name === "No Tools");
 		const defaultTools = advisors.find(a => a.name === "Default Tools");
 		const invalidOnly = advisors.find(a => a.name === "Invalid Only");
@@ -79,21 +79,67 @@ describe("discoverAdvisorConfigs", () => {
 
 	it("ignores a malformed YAML file without throwing", async () => {
 		await Bun.write(path.join(tmp, "WATCHDOG.yml"), "advisors: [unclosed bracket");
-		const result = await discoverAdvisorConfigs(tmp, agentDir);
+		const result = await discoverAdvisorConfigs(tmp, agentDir, []);
 		expect(result.advisors).toEqual([]);
 		expect(result.sharedInstructions).toBeUndefined();
 	});
 
 	it("skips a file whose shape fails the schema (advisors must be a list)", async () => {
 		await Bun.write(path.join(tmp, "WATCHDOG.yml"), "advisors: not-an-array");
-		const result = await discoverAdvisorConfigs(tmp, agentDir);
+		const result = await discoverAdvisorConfigs(tmp, agentDir, []);
 		expect(result.advisors).toEqual([]);
 	});
 
 	it("returns an empty roster when no config file exists", async () => {
-		const result = await discoverAdvisorConfigs(tmp, agentDir);
+		const result = await discoverAdvisorConfigs(tmp, agentDir, []);
 		expect(result.advisors).toEqual([]);
 		expect(result.sharedInstructions).toBeUndefined();
+	});
+
+	it("merges plugin advisors below project configs without importing plugin text or granting mutating tools", async () => {
+		const pluginDir = path.join(tmp, "plugin");
+		const pluginConfig = path.join(pluginDir, "WATCHDOG.yml");
+		await fsp.mkdir(pluginDir, { recursive: true });
+		await Bun.write(path.join(pluginDir, "plugin-extra.md"), "EXPANDED_PLUGIN_TEXT");
+		await Bun.write(
+			pluginConfig,
+			[
+				"instructions: Plugin-wide instructions must not enter the shared baseline.",
+				"advisors:",
+				"  - name: Plugin Grok",
+				"    model: cursor/cursor-grok-4.6-high-fast",
+				"    tools: [read, bash, write, glob]",
+				"    instructions: '@plugin-extra.md'",
+				"    enabled: true",
+				"  - name: Architecture",
+				"    model: plugin/model",
+			].join("\n"),
+		);
+		await Bun.write(
+			path.join(tmp, "WATCHDOG.yml"),
+			[
+				"instructions: Project shared baseline.",
+				"advisors:",
+				"  - name: Architecture",
+				"    model: project/model",
+			].join("\n"),
+		);
+
+		const result = await discoverAdvisorConfigs(tmp, agentDir, [pluginConfig]);
+		const pluginAdvisor = result.advisors.find(advisor => advisor.name === "Plugin Grok");
+		const architecture = result.advisors.find(advisor => advisor.name === "Architecture");
+
+		expect(pluginAdvisor).toEqual({
+			name: "Plugin Grok",
+			model: "cursor/cursor-grok-4.6-high-fast",
+			tools: ["read", "glob"],
+			instructions: "@plugin-extra.md",
+			enabled: true,
+		});
+		expect(pluginAdvisor?.instructions).not.toContain("EXPANDED_PLUGIN_TEXT");
+		expect(architecture?.model).toBe("project/model");
+		expect(result.sharedInstructions).toBe("Project shared baseline.");
+		expect(result.sharedInstructions).not.toContain("Plugin-wide instructions");
 	});
 });
 
@@ -229,7 +275,7 @@ describe("WATCHDOG.yml file round-trip", () => {
 		expect(text).toContain('instructions: |2-\n  Shared baseline.\n  \n  Second line with: a colon and "quotes".');
 		expect(text).toContain("    instructions: |2-\n      Watch module boundaries.\n      Report coupling.");
 		expect(text).not.toContain("\\n");
-		const { advisors, sharedInstructions } = await discoverAdvisorConfigs(tmp, tmp);
+		const { advisors, sharedInstructions } = await discoverAdvisorConfigs(tmp, tmp, []);
 		expect(advisors.map(a => a.name)).toEqual(["Architecture", "Security"]);
 		expect(sharedInstructions).toContain("Shared baseline.");
 	});
@@ -255,7 +301,7 @@ describe("WATCHDOG.yml file round-trip", () => {
 		const serializedDoc = await loadWatchdogConfigFile(file);
 		expect(serializedDoc).toEqual(explicitNoToolsDoc);
 
-		const { advisors } = await discoverAdvisorConfigs(tmp, tmp);
+		const { advisors } = await discoverAdvisorConfigs(tmp, tmp, []);
 		expect(advisors.find(a => a.name === "No Tools")?.tools).toEqual([]);
 		expect(advisors.find(a => a.name === "Default Tools")?.tools).toBeUndefined();
 	});
@@ -327,7 +373,7 @@ describe("per-advisor enabled field", () => {
 			const loaded = await loadWatchdogConfigFile(file);
 			expect(loaded.advisors.map(advisor => advisor.enabled)).toEqual([true, false, undefined]);
 
-			const { advisors } = await discoverAdvisorConfigs(tmp, tmp);
+			const { advisors } = await discoverAdvisorConfigs(tmp, tmp, []);
 			expect(advisors.map(advisor => advisor.enabled)).toEqual([true, false, undefined]);
 		} finally {
 			await fsp.rm(tmp, { recursive: true, force: true });

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -217,6 +217,40 @@ describe("MarketplaceManager", () => {
 		expect(installed).toHaveLength(1);
 		expect(installed[0].id).toBe("hello-plugin@test-marketplace");
 	});
+	it("installPlugin rejects a marketplace package whose manifest declares a missing advisor file", async () => {
+		const marketplaceDir = path.join(ctx.tmpDir, "bad-advisor-marketplace");
+		const pluginDir = path.join(marketplaceDir, "plugins", "bad-advisor");
+		fs.mkdirSync(path.join(marketplaceDir, ".claude-plugin"), { recursive: true });
+		fs.mkdirSync(pluginDir, { recursive: true });
+		await Bun.write(
+			path.join(marketplaceDir, ".claude-plugin", "marketplace.json"),
+			`${JSON.stringify(
+				{
+					name: "bad-advisor-marketplace",
+					owner: { name: "Test Author" },
+					plugins: [{ name: "bad-advisor", source: "./plugins/bad-advisor", version: "1.0.0" }],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		await Bun.write(
+			path.join(pluginDir, "package.json"),
+			`${JSON.stringify({
+				name: "bad-advisor",
+				version: "1.0.0",
+				omp: { advisors: ["./missing-WATCHDOG.yml"] },
+			})}\n`,
+		);
+
+		await ctx.manager.addMarketplace(marketplaceDir);
+		await expect(ctx.manager.installPlugin("bad-advisor", "bad-advisor-marketplace")).rejects.toThrow(
+			/missing-WATCHDOG\.yml: declared advisor entry not found inside the plugin/,
+		);
+
+		expect(await ctx.manager.listInstalledPlugins()).toEqual([]);
+		expect(fs.existsSync(path.join(ctx.tmpDir, "node_modules", "bad-advisor"))).toBe(false);
+	});
 
 	it("installPlugin rejects package names that escape node_modules", async () => {
 		const marketplaceDir = path.join(ctx.tmpDir, "bad-package-marketplace");

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -393,6 +393,55 @@ describe("PluginManager.install load validation", () => {
 		expect(await Bun.file(path.join(tmpRoot, "omp-plugins.lock.json")).exists()).toBe(false);
 	});
 
+	test("rejects an install whose manifest declares a missing advisor file", async () => {
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			expect(cmd).toEqual(["bun", "install", "advisor-plugin"]);
+
+			const prepare = (async () => {
+				await Bun.write(
+					pluginsPkgJson,
+					JSON.stringify(
+						{ name: "omp-plugins", private: true, dependencies: { "advisor-plugin": "1.0.0" } },
+						null,
+						2,
+					),
+				);
+				const installedDir = path.join(pluginsNodeModules, "advisor-plugin");
+				await fs.mkdir(path.join(installedDir, "dist"), { recursive: true });
+				await Bun.write(
+					path.join(installedDir, "package.json"),
+					JSON.stringify(
+						{
+							name: "advisor-plugin",
+							version: "1.0.0",
+							omp: { extensions: ["./dist/valid.ts"], advisors: ["./WATCHDOG.yml"] },
+						},
+						null,
+						2,
+					),
+				);
+				await Bun.write(
+					path.join(installedDir, "dist", "valid.ts"),
+					'export default function(pi) { pi.registerCommand("valid-ext", { handler: async () => {} }); }\n',
+				);
+			})();
+
+			return {
+				pid: 1,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		await expect(new PluginManager(tmpRoot).install("advisor-plugin")).rejects.toThrow(/WATCHDOG\.yml/);
+
+		const pluginsPackage = await Bun.file(pluginsPkgJson).json();
+		expect(pluginsPackage.dependencies ?? {}).toEqual({});
+		expect(await Bun.file(path.join(pluginsNodeModules, "advisor-plugin", "package.json")).exists()).toBe(false);
+		expect(await Bun.file(path.join(tmpRoot, "omp-plugins.lock.json")).exists()).toBe(false);
+	});
+
 	test("restores bun.lock when a git reinstall fails validation (#3069 follow-up)", async () => {
 		// Pre-existing valid v1 install plus a populated bun.lock pinning the
 		// original commit. The mock simulates `bun install` rewriting the lock

--- a/packages/coding-agent/test/plugin-manifest-paths.test.ts
+++ b/packages/coding-agent/test/plugin-manifest-paths.test.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	getAllPluginAdvisorPaths,
+	resolvePluginAdvisorPaths,
 	resolvePluginExtensionPaths,
 	resolvePluginToolPaths,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/loader";
@@ -45,6 +47,64 @@ describe("plugin manifest path resolution", () => {
 			expect(resolvePluginExtensionPaths(plugin)).toEqual([path.join(dir, "ext.ts")]);
 		} finally {
 			removeSyncWithRetries(dir);
+		}
+	});
+
+	it("resolves only advisor files contained by the plugin root", () => {
+		// macOS exposes os.tmpdir() through /var, while realpath resolves it under /private/var.
+		const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "omp-manifest-advisors-")));
+		const pluginDir = path.join(root, "plugin");
+		try {
+			fs.mkdirSync(pluginDir);
+			const advisorFile = path.join(pluginDir, "WATCHDOG.yml");
+			const outsideFile = path.join(root, "outside.yml");
+			fs.writeFileSync(advisorFile, "advisors: []\n");
+			fs.writeFileSync(outsideFile, "advisors: []\n");
+			const advisorEntries = ["./WATCHDOG.yml", "../outside.yml"];
+			if (process.platform !== "win32") {
+				fs.symlinkSync(outsideFile, path.join(pluginDir, "linked.yml"));
+				advisorEntries.push("./linked.yml");
+			}
+			advisorEntries.push(42 as never);
+			const plugin = makePlugin(pluginDir, {
+				name: "fixture-plugin",
+				version: "1.0.0",
+				advisors: advisorEntries,
+			});
+
+			expect(resolvePluginAdvisorPaths(plugin)).toEqual([advisorFile]);
+		} finally {
+			removeSyncWithRetries(root);
+		}
+	});
+
+	it("discovers advisor files from enabled plugins without reading the process home", async () => {
+		const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "omp-installed-advisors-")));
+		try {
+			const home = path.join(root, "home");
+			const cwd = path.join(root, "project");
+			const pluginsDir = path.join(home, ".omp", "plugins");
+			const pluginDir = path.join(pluginsDir, "node_modules", "fixture-plugin");
+			fs.mkdirSync(pluginDir, { recursive: true });
+			fs.mkdirSync(cwd, { recursive: true });
+			fs.writeFileSync(
+				path.join(pluginsDir, "package.json"),
+				JSON.stringify({ name: "omp-plugins", dependencies: { "fixture-plugin": "1.0.0" } }),
+			);
+			fs.writeFileSync(
+				path.join(pluginDir, "package.json"),
+				JSON.stringify({
+					name: "fixture-plugin",
+					version: "1.0.0",
+					omp: { advisors: ["./WATCHDOG.yml"] },
+				}),
+			);
+			const advisorFile = path.join(pluginDir, "WATCHDOG.yml");
+			fs.writeFileSync(advisorFile, "advisors: []\n");
+
+			expect(await getAllPluginAdvisorPaths(cwd, { home })).toEqual([advisorFile]);
+		} finally {
+			removeSyncWithRetries(root);
 		}
 	});
 });

--- a/packages/coding-agent/test/plugin-manifest-paths.test.ts
+++ b/packages/coding-agent/test/plugin-manifest-paths.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	getAllPluginAdvisorPaths,
+	resolvePluginAdvisorManifestEntries,
 	resolvePluginAdvisorPaths,
 	resolvePluginExtensionPaths,
 	resolvePluginToolPaths,
@@ -76,6 +77,15 @@ describe("plugin manifest path resolution", () => {
 		} finally {
 			removeSyncWithRetries(root);
 		}
+	});
+	it("marks a non-array advisor manifest as invalid instead of silently ignoring it", () => {
+		const plugin = makePlugin(process.cwd(), {
+			name: "fixture-plugin",
+			version: "1.0.0",
+			advisors: "./WATCHDOG.yml" as never,
+		});
+
+		expect(resolvePluginAdvisorManifestEntries(plugin)).toEqual([{ entry: "./WATCHDOG.yml", resolvedPath: null }]);
 	});
 
 	it("discovers advisor files from enabled plugins without reading the process home", async () => {

--- a/packages/coding-agent/test/reload-plugins-mcp.test.ts
+++ b/packages/coding-agent/test/reload-plugins-mcp.test.ts
@@ -8,7 +8,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { MarketplaceManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { refreshRpcPluginState } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { BUILTIN_MARKETPLACE_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-marketplace";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import type { TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
@@ -41,15 +45,20 @@ function createFakeCtx(cwd: string, settingsValues: Record<string, unknown> = {}
 	const session = {
 		refreshMCPTools: vi.fn(async (_tools: unknown) => {}),
 		setMCPPromptCommands: vi.fn((_commands: unknown) => {}),
+		applyAdvisorConfigs: vi.fn((_advisors: unknown[], _sharedInstructions: string | undefined) => 0),
 	};
 	const ctx = {
 		mcpManager,
 		session,
 		sessionManager: { getCwd: () => cwd },
-		settings: { get: (key: string): unknown => settingsValues[key] },
+		settings: {
+			get: (key: string): unknown => settingsValues[key],
+			getAgentDir: () => path.join(cwd, ".agent"),
+		},
 		refreshSkillState: vi.fn(async () => {}),
 		refreshSlashCommandState: vi.fn(async () => {}),
 		showStatus: vi.fn(() => {}),
+		ui: { requestRender: vi.fn(() => {}) },
 		editor: { setText: vi.fn(() => {}) },
 	} as never as InteractiveModeContext;
 	return { ctx, mcpManager, session, mcpTools };
@@ -81,6 +90,106 @@ describe("/reload-plugins runtime refresh", () => {
 		expect(session.refreshMCPTools).toHaveBeenCalledWith(mcpTools);
 		expect(session.setMCPPromptCommands).toHaveBeenCalledTimes(1);
 		expect(session.setMCPPromptCommands).toHaveBeenCalledWith([]);
+	});
+
+	test("rebuilds the live advisor roster when config files change", async () => {
+		const watchdogPath = path.join(projectDir, "WATCHDOG.yml");
+		await Bun.write(
+			watchdogPath,
+			["advisors:", "  - name: Live Reviewer", "    model: openai-codex/gpt-5.6-sol:max"].join("\n"),
+		);
+		const { ctx, session } = createFakeCtx(projectDir);
+		const runtime: TuiSlashCommandRuntime = { ctx };
+
+		await executeBuiltinSlashCommand("/reload-plugins", runtime);
+		const [initialAdvisors] = session.applyAdvisorConfigs.mock.calls.at(-1) ?? [];
+		expect(initialAdvisors).toEqual(expect.arrayContaining([expect.objectContaining({ name: "Live Reviewer" })]));
+
+		await fs.rm(watchdogPath);
+		await executeBuiltinSlashCommand("/reload-plugins", runtime);
+		const [reloadedAdvisors] = session.applyAdvisorConfigs.mock.calls.at(-1) ?? [];
+		expect(reloadedAdvisors).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ name: "Live Reviewer" })]),
+		);
+	});
+
+	test("rebuilds the RPC advisor roster when config files change", async () => {
+		const watchdogPath = path.join(projectDir, "WATCHDOG.yml");
+		await Bun.write(
+			watchdogPath,
+			["advisors:", "  - name: RPC Reviewer", "    model: openai-codex/gpt-5.6-sol:max"].join("\n"),
+		);
+		const applyAdvisorConfigs = vi.fn((_advisors: unknown[], _sharedInstructions: string | undefined) => 0);
+		const session = {
+			sessionManager: { getCwd: () => projectDir },
+			settings: { getAgentDir: () => path.join(projectDir, ".agent") },
+			refreshSkills: vi.fn(async () => {}),
+			setSlashCommands: vi.fn((_commands: unknown[]) => {}),
+			applyAdvisorConfigs,
+		} as never;
+		const emitAvailableCommandsUpdate = vi.fn(async () => {});
+
+		await refreshRpcPluginState(session, emitAvailableCommandsUpdate);
+		const [initialAdvisors] = applyAdvisorConfigs.mock.calls.at(-1) ?? [];
+		expect(initialAdvisors).toEqual(expect.arrayContaining([expect.objectContaining({ name: "RPC Reviewer" })]));
+
+		await fs.rm(watchdogPath);
+		await refreshRpcPluginState(session, emitAvailableCommandsUpdate);
+		const [reloadedAdvisors] = applyAdvisorConfigs.mock.calls.at(-1) ?? [];
+		expect(reloadedAdvisors).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: "RPC Reviewer" })]));
+	});
+
+	test.each([
+		["marketplace", "install fixture@test"],
+		["marketplace", "uninstall fixture@test"],
+		["marketplace", "upgrade fixture@test"],
+		["plugins", "enable fixture@test"],
+		["plugins", "disable fixture@test"],
+	])("refreshes advisors after TUI /%s %s", async (name: string, args: string) => {
+		vi.spyOn(MarketplaceManager.prototype, "installPlugin").mockResolvedValue({ version: "1.0.0" } as never);
+		vi.spyOn(MarketplaceManager.prototype, "uninstallPlugin").mockResolvedValue();
+		vi.spyOn(MarketplaceManager.prototype, "upgradePlugin").mockResolvedValue({ version: "2.0.0" } as never);
+		vi.spyOn(MarketplaceManager.prototype, "setPluginEnabled").mockResolvedValue();
+		const { ctx, session } = createFakeCtx(projectDir);
+		const command = BUILTIN_MARKETPLACE_SLASH_COMMANDS.find(candidate => candidate.name === name);
+		if (!command?.handleTui) throw new Error(`Expected /${name} TUI handler`);
+
+		await command.handleTui({ name, args, text: `/${name} ${args}` }, { ctx } as never);
+
+		expect(session.applyAdvisorConfigs).toHaveBeenCalledTimes(1);
+	});
+
+	test.each(["install", "uninstall"] as const)("refreshes advisors after selector %s", async mode => {
+		const applied = Promise.withResolvers<void>();
+		const { ctx, session } = createFakeCtx(projectDir);
+		session.applyAdvisorConfigs.mockImplementation(() => {
+			applied.resolve();
+			return 0;
+		});
+		vi.spyOn(MarketplaceManager.prototype, "listMarketplaces").mockResolvedValue([{ name: "test" }] as never);
+		vi.spyOn(MarketplaceManager.prototype, "listInstalledPlugins").mockResolvedValue(
+			mode === "uninstall"
+				? ([{ id: "fixture@test", scope: "user", entries: [{ version: "1.0.0" }] }] as never)
+				: [],
+		);
+		vi.spyOn(MarketplaceManager.prototype, "listAvailablePlugins").mockResolvedValue([{ name: "fixture" }] as never);
+		const installPlugin = vi
+			.spyOn(MarketplaceManager.prototype, "installPlugin")
+			.mockResolvedValue({ version: "1.0.0" } as never);
+		const uninstallPlugin = vi.spyOn(MarketplaceManager.prototype, "uninstallPlugin").mockResolvedValue();
+		const controller = new SelectorController(ctx);
+		let selection: { handleInput(input: string): void } | undefined;
+		controller.showSelector = create => {
+			const result = create(() => {});
+			selection = result.focus as { handleInput(input: string): void };
+		};
+
+		await controller.showPluginSelector(mode);
+		selection?.handleInput("\n");
+		await applied.promise;
+
+		expect(mode === "install" ? installPlugin : uninstallPlugin).toHaveBeenCalledTimes(1);
+		expect(session.applyAdvisorConfigs).toHaveBeenCalledTimes(1);
 	});
 
 	test("honors mcp.enableProjectConfig=false so opted-out project servers are not started on reload", async () => {

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -13,6 +13,7 @@ import { ReadToolGroupComponent } from "@oh-my-pi/pi-coding-agent/modes/componen
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as tuiPluginReload from "@oh-my-pi/pi-coding-agent/modes/tui-plugin-reload";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { ResolvedRoleModel } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
@@ -93,6 +94,45 @@ describe("selector setting side effects", () => {
 		expect(setAdvisorEnabled).toHaveBeenCalledWith(false);
 		expect(invalidate).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+	it("reloads every live plugin surface after a Plugins settings mutation", async () => {
+		const testTheme = await getThemeByName("dark");
+		if (!testTheme) throw new Error("Failed to load dark theme for plugin settings test");
+		setThemeInstance(testTheme);
+		const reload = vi.spyOn(tuiPluginReload, "reloadTuiPluginState").mockResolvedValue();
+		const overlayShown = Promise.withResolvers<void>();
+		const showOverlay = vi.fn((_component: unknown) => {
+			overlayShown.resolve();
+			return { hide: vi.fn() };
+		});
+		const ctx = {
+			session: {
+				getAvailableThinkingLevels: () => [],
+				getAvailableModels: () => [],
+				thinkingLevel: undefined,
+				model: undefined,
+			},
+			sessionManager: { getCwd: () => process.cwd() },
+			refreshSkillState: vi.fn(async () => {}),
+			refreshSlashCommandState: vi.fn(async () => {}),
+			ui: {
+				imageBudget: undefined,
+				showOverlay,
+				setFocus: vi.fn(),
+				requestRender: vi.fn(),
+			},
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showSettingsSelector();
+		await overlayShown.promise;
+		const selector = showOverlay.mock.calls[0][0] as unknown as {
+			callbacks: { onPluginsChanged?: () => void | Promise<void> };
+		};
+		await selector.callbacks.onPluginsChanged?.();
+
+		expect(reload).toHaveBeenCalledWith(ctx);
+		reload.mockRestore();
 	});
 
 	for (const id of ["terminal.showImages", "showImages"]) {


### PR DESCRIPTION
## Summary
- add an `omp.advisors` package-manifest entry and aggregate enabled plugin advisor configs into discovery
- validate advisor paths for direct and marketplace installs, including missing files, traversal, and symlink escapes
- refresh live advisor runtimes across TUI, ACP, RPC, `/move`, `/reload-plugins`, marketplace commands, and the Settings plugin panel
- preserve unchanged runtimes only when model, thinking level, tool permissions, and instructions match; prune removed advisor status rows
- document the plugin advisor contract

This is the OMP half of a two-repository change. The companion council-adversary package is https://gitlab-master.nvidia.com/mlpinf/mlperf-inference-skills/-/merge_requests/49.

## Verification
- `npx --yes bun@1.3.14 run check`
- `npx --yes bun@1.3.14 test packages/coding-agent/test/advisor/config.test.ts packages/coding-agent/test/advisor-watchdog.test.ts packages/coding-agent/test/advisor-toggle.test.ts packages/coding-agent/test/marketplace/manager.test.ts packages/coding-agent/test/plugin-install-validation.test.ts packages/coding-agent/test/plugin-manifest-paths.test.ts packages/coding-agent/test/reload-plugins-mcp.test.ts packages/coding-agent/test/selector-settings-side-effects.test.ts packages/coding-agent/test/modes/controllers/move-command.test.ts` (169 passed)