### PR TITLE
fix(coding-agent): watch git dir so branch display tracks switches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the status-line git branch display freezing on the previous branch after the first branch switch, caused by the HEAD watcher binding to a file inode that git unlinks on its atomic HEAD rename ([#8412](https://github.com/can1357/oh-my-pi/issues/8412)).
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -665,13 +665,25 @@ export class StatusLineComponent implements Component {
 			return;
 		}
 
-		const watchPath = git.repo.isReftableSync(repository)
-			? path.join(repository.gitDir, "reftable")
-			: repository.headPath;
+		// Watch the *directory* holding the ref state, not the HEAD file itself.
+		// git rewrites HEAD via a lock file + atomic rename (`HEAD.lock` → `HEAD`),
+		// which unlinks the original inode. An `fs.watch` bound to that file inode
+		// dies after the first branch switch and never fires again, freezing the
+		// displayed branch (issue #8412). A directory watch tracks the stable
+		// gitDir inode and survives the rename.
+		const isReftable = git.repo.isReftableSync(repository);
+		const watchPath = isReftable ? path.join(repository.gitDir, "reftable") : repository.gitDir;
 
 		try {
-			const watcher = fs.watch(watchPath, () => {
+			const watcher = fs.watch(watchPath, (_event, filename) => {
 				if (this.#disposed || this.#gitWatcher !== watcher) return;
+				// The gitDir sees churn from many entries (index, ORIG_HEAD, config,
+				// …); only HEAD moves change the branch. The rename surfaces as a
+				// `HEAD.lock` event, so match the `HEAD` prefix. The reftable dir
+				// holds only ref storage, so every change there is ref-relevant.
+				// `filename` may be null/undefined on some platforms or coalesced
+				// events — react rather than risk missing a HEAD move.
+				if (!isReftable && filename != null && !String(filename).startsWith("HEAD")) return;
 				this.invalidateGitCaches();
 				this.#onBranchChange?.();
 			});

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -740,3 +740,61 @@ describe("StatusLineComponent applyCwdChange re-points watcher ownership", () =>
 		component.dispose();
 	});
 });
+
+describe("StatusLineComponent git watcher survives atomic HEAD renames", () => {
+	let repoDir: string;
+
+	beforeAll(async () => {
+		repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "status-line-headwatch-"));
+		const run = (...args: string[]) => Bun.spawnSync(["git", ...args], { cwd: repoDir });
+		run("init", "-q");
+		run("config", "user.email", "t@example.com");
+		run("config", "user.name", "Test");
+		run("commit", "--allow-empty", "-q", "-m", "init");
+	});
+
+	afterAll(async () => {
+		setProjectDir(originalProjectDir);
+		await fs.rm(repoDir, { recursive: true, force: true });
+	});
+
+	// git rewrites HEAD via a lock file + atomic rename (HEAD.lock → HEAD), which
+	// unlinks the inode. The pre-fix watcher bound `fs.watch` to the HEAD file, so
+	// it fired for the first switch and then died on the stale inode — freezing the
+	// displayed branch on every subsequent switch (issue #8412). Watching the git
+	// directory instead keeps the watch alive across renames.
+	it("keeps firing #onBranchChange across consecutive branch switches", async () => {
+		vi.spyOn(git.branch, "default").mockReturnValue(Promise.withResolvers<string | null>().promise);
+		vi.spyOn(git.status, "summary").mockReturnValue(Promise.withResolvers<GitStatus | null>().promise);
+		vi.spyOn(jj.repo, "rootSync").mockReturnValue(null);
+
+		setProjectDir(repoDir);
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+
+		// Await the watcher's own #onBranchChange signal rather than a wall-clock
+		// delay: a fresh resolver is armed before each switch and awaited after it,
+		// so a frozen watcher surfaces as the test-runner timeout, not a flake.
+		let branchChanged = Promise.withResolvers<void>();
+		component.watchBranch(() => branchChanged.resolve());
+		// Prime the branch cache off the initial HEAD. The status/default mocks
+		// never resolve, so this cold paint cannot fire #onBranchChange itself.
+		component.getTopBorder(80);
+
+		const switchTo = async (branchName: string) => {
+			const fired = branchChanged.promise;
+			await git.branch.checkoutNew(repoDir, branchName);
+			await fired;
+			branchChanged = Promise.withResolvers<void>();
+		};
+
+		await switchTo("first");
+		expect(component.getTopBorder(80).content).toContain("first");
+
+		// Regression: the second switch must still reach the display.
+		await switchTo("second");
+		expect(component.getTopBorder(80).content).toContain("second");
+
+		component.dispose();
+	});
+});


### PR DESCRIPTION
## Repro
In a git repo, launch `omp` and switch branches from the shell tool (`!git switch -c test`, then `!git switch -c main`). The status-line git segment shows `test` and never advances to `main`, while `!git branch --show-current` reports `main` (#8412). A minimal harness watching the exact path the component does confirms it:

```
watcher fired for: ["ref: refs/heads/test"]
actual HEAD:       "ref: refs/heads/main"
displayed branch:  "ref: refs/heads/test"
```

## Cause
`StatusLineComponent.#setupGitWatcher` (`packages/coding-agent/src/modes/components/status-line/component.ts`) bound `fs.watch` to `repository.headPath` (`.git/HEAD`). `git switch`/`checkout` rewrite HEAD via a lock file plus an atomic rename (`HEAD.lock` -> `HEAD`), which unlinks the inode the watch is bound to. On Linux the inotify watch then dies: it fires for the first switch and never again, so `invalidateGitCaches()` + the repaint stop happening and the cached branch freezes on the previous value.

## Fix
- Watch the containing git directory (`repository.gitDir`) instead of the `HEAD` file, so the watch tracks the stable directory inode and survives HEAD's atomic rename. Reftable repos keep watching the `reftable` directory as before.
- Filter directory events to HEAD moves for the non-reftable path: react when the changed entry name starts with `HEAD` (the rename surfaces as a `HEAD.lock` event), or when the platform reports no filename. Reftable events are all ref-relevant, so they still react unconditionally.
- Added a real-filesystem regression test in `test/status-line-vcs-refresh.test.ts` that switches branches twice through `git.branch.checkoutNew` and awaits the component's `#onBranchChange` after each switch.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/status-line-vcs-refresh.test.ts` -> 15 pass / 0 fail. The new test times out (fails) when the watch target is reverted to `repository.headPath`, and passes with the directory watch, confirming it catches the regression. Existing watcher-lifecycle and cwd-repoint tests still pass. Skipped pre-publish gate with `skip_checks=true`: `bun check` fails on this environment for an unrelated reason (`check:rs` aborts because `cmake` is not installed; `which cmake` exits non-zero), which is independent of this TypeScript-only diff; `check:ts` for `@oh-my-pi/pi-coding-agent` passes cleanly. Fixes #8412