### PR TITLE
fix(nix): remove build-time Bun closure reference

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,6 +11,7 @@
   ninja,
   pipewire,
   pkg-config,
+  removeReferencesTo,
   rustPlatform,
   rustToolchain,
   source,
@@ -85,6 +86,7 @@ stdenv.mkDerivation {
     cmake
     ninja
     pkg-config
+    removeReferencesTo
     rustPlatform.bindgenHook
     rustPlatform.cargoSetupHook
     rustToolchain
@@ -185,6 +187,15 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  # Bun serializes the build interpreter path into the bundled entrypoint's
+  # inert shebang. Remove its hash before Nix scans output references; this
+  # runs before Darwin's binary-signing fixup hook.
+  preFixup = ''
+    remove-references-to -t ${bun} "$out/bin/omp"
+  '';
+
+  disallowedReferences = [ bun ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Nix standalone binaries retaining Bun's build-time package in their runtime closure.
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes


### PR DESCRIPTION
## What

Remove Bun's build-time store reference from the compiled Nix `omp` binary during `preFixup`, and reject any future Bun runtime reference with `disallowedReferences`.

## Why

Bun embeds the build interpreter path in the bundled entrypoint's inert shebang. Nix's reference scanner treats that path as a runtime dependency even though the standalone binary embeds and executes its own Bun runtime.

The false reference pulls `bun-1.3.14` into every `omp` closure. On `x86_64-linux`, removing it reduces the closure from 354.9 MiB to 267.3 MiB (87.6 MiB / 24.7%).

### Why the rewrite is safe

`remove-references-to` replaces only the fixed-width, 32-character Nix store hash in place. The binary length and all subsequent offsets remain unchanged; the embedded Bun runtime and bundle layout are untouched.

The target string is the shebang of a JavaScript module in Bun's `/$bunfs/root` virtual filesystem, not native executable metadata. The kernel executes the outer standalone binary; its embedded Bun runtime loads the module and ignores that shebang. The build also uses `disallowedReferences = [ bun ];`, so any remaining or future Bun reference fails the build.

## Testing

- `nix build .#omp --no-link --print-out-paths`
- `nix-store -q --references <result>` — no Bun reference remains
- `nix path-info --human-readable --closure-size <result>` — 267.3 MiB
- `HOME=$(mktemp -d) <result>/bin/omp --smoke-test` — `smoke-test: ok`
- `HOME=$(mktemp -d) BUN_BE_BUN=1 <result>/bin/omp -e 'console.log(`${Bun.version} ${typeof Bun.Image}`)'` — `1.3.14 function`
- `HOME=$(mktemp -d) <result>/bin/omp --version` — `omp/17.3.0`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
