### PR TITLE
fix(extensions): lower embedded omptype schemas in Type.Unsafe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp plugin install` failing with `The object can not be cloned.` for legacy Pi extensions whose tool schemas embed or spread omptype builders through the legacy-typebox shim (e.g. `pi-subagents`). `Type.Unsafe` now lowers nested schema builders to plain wire JSON and reconstructs spread schemas from their copied self-reference before serializing ([#8420](https://github.com/can1357/oh-my-pi/issues/8420)).
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/legacy-typebox.ts
+++ b/packages/coding-agent/src/extensibility/legacy-typebox.ts
@@ -40,6 +40,44 @@ function isRuntimeSchema(value: unknown): value is AnySchema {
 	return typeof value === "function";
 }
 
+/**
+ * Deep-copy a legacy `Type.Unsafe` document into a plain, structured-cloneable
+ * JSON Schema, lowering any embedded omptype schema to its wire JSON. Legacy
+ * Pi extensions were written against real TypeBox, whose `Type.*` builders
+ * return plain JSON-Schema objects; omptype's builders return callable schema
+ * values instead, which breaks two idioms extensions use inside raw documents:
+ *
+ *  - Direct embedding — `Type.Unsafe({ anyOf: [Type.Array(...), Other] })`.
+ *    The nested schema is a function; `structuredClone` throws
+ *    `DataCloneError: The object can not be cloned.` (issue #8420) and omptype
+ *    would drop its `toJsonSchema()` override during composition anyway.
+ *  - Spreading — `Type.Unsafe({ ...Schema, description })`. Spreading a
+ *    callable copies omptype's internal fields (`ir`, `run`, `$`, …) instead
+ *    of JSON keywords. The copied `run` is a self-reference to the original
+ *    schema, so its `toJsonSchema()` recovers the real wire document; the
+ *    caller's own additions (everything not an omptype internal) are overlaid.
+ */
+function lowerEmbeddedSchemas(value: unknown): unknown {
+	if (isRuntimeSchema(value)) return value.toJsonSchema();
+	if (Array.isArray(value)) return value.map(lowerEmbeddedSchemas);
+	if (value !== null && typeof value === "object") {
+		const source = value as Record<string, unknown>;
+		const canonical = source.run;
+		if (isRuntimeSchema(canonical)) {
+			const base = canonical.toJsonSchema();
+			const internalKeys = new Set(Object.keys(canonical));
+			for (const key in source) {
+				if (!internalKeys.has(key)) base[key] = lowerEmbeddedSchemas(source[key]);
+			}
+			return base;
+		}
+		const result: Record<string, unknown> = {};
+		for (const key in source) result[key] = lowerEmbeddedSchemas(source[key]);
+		return result;
+	}
+	return value;
+}
+
 function defineHidden(target: object, key: PropertyKey, value: unknown): void {
 	Object.defineProperty(target, key, {
 		value,
@@ -50,12 +88,14 @@ function defineHidden(target: object, key: PropertyKey, value: unknown): void {
 
 function unsafe<T = unknown>(jsonSchema: Record<string, unknown> = {}): LegacyUnsafeSchema<T> {
 	// `document` is the verbatim wire schema; keep it isolated from the validator.
+	// `lowerEmbeddedSchemas` returns a fresh plain-JSON copy (lowering any nested
+	// omptype builder to its wire form), so it doubles as the detaching clone.
 	// `upgradeJsonSchemaTo202012` returns its input untouched when no upgrade is
 	// needed, and `validateJsonSchemaValue` then annotates that object with JIT
 	// epoch metadata and normalized keywords — which would leak into emission if
-	// the two shared a reference.
-	const document = structuredClone(jsonSchema);
-	const upgradedSchema = upgradeJsonSchemaTo202012(structuredClone(jsonSchema));
+	// the two shared a reference, so give the validator its own structured clone.
+	const document = lowerEmbeddedSchemas(jsonSchema) as Record<string, unknown>;
+	const upgradedSchema = upgradeJsonSchemaTo202012(structuredClone(document));
 	const validate = (data: unknown): T | ValidationFailure => {
 		const result = validateJsonSchemaValue(upgradedSchema, data);
 		if (result.success) return data as T;
@@ -125,7 +165,7 @@ const object = ((properties: Record<string, unknown>, opts?: ObjectOpts) => {
 		const document = OmpType.Object(normalizedProperties, objectOpts).toJsonSchema();
 		document.additionalProperties = isRuntimeSchema(additionalProperties)
 			? additionalProperties.toJsonSchema()
-			: structuredClone(additionalProperties);
+			: lowerEmbeddedSchemas(additionalProperties);
 		return unsafe(document);
 	}
 	return OmpType.Object(normalizedProperties, normalizedOpts);

--- a/packages/coding-agent/src/extensibility/legacy-typebox.ts
+++ b/packages/coding-agent/src/extensibility/legacy-typebox.ts
@@ -1,4 +1,5 @@
 import { type } from "@oh-my-pi/omptype";
+import { IR_BRAND } from "@oh-my-pi/omptype/ir";
 import {
 	type AnySchema,
 	type ObjectOpts,
@@ -63,7 +64,7 @@ function lowerEmbeddedSchemas(value: unknown): unknown {
 	if (value !== null && typeof value === "object") {
 		const source = value as Record<string, unknown>;
 		const canonical = source.run;
-		if (isRuntimeSchema(canonical)) {
+		if (IR_BRAND in value && isRuntimeSchema(canonical)) {
 			const base = canonical.toJsonSchema();
 			const internalKeys = new Set(Object.keys(canonical));
 			for (const key in source) {

--- a/packages/coding-agent/test/extensibility/typebox-shim.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-shim.test.ts
@@ -225,4 +225,65 @@ describe("pi.typebox compatibility shim", () => {
 			}
 		});
 	});
+
+	// Issue #8420: legacy extensions build raw documents that embed omptype
+	// schema builders. Those builders are callable values, so a document that
+	// nests or spreads them is neither structured-cloneable nor a plain TypeBox
+	// object; `Type.Unsafe` must lower them to wire JSON before use.
+	describe("lowers embedded omptype schemas inside Type.Unsafe documents", () => {
+		it("embeds sibling schema builders in an anyOf branch", () => {
+			const item = Type.Object({ agent: Type.String() });
+			const template = Type.Object({ agent: Type.String() }, { additionalProperties: false });
+			const schema = Type.Unsafe({
+				anyOf: [Type.Array(item, { minItems: 1 }), template],
+				description: "static array or single template",
+			});
+
+			const document = schema.toJsonSchema();
+			expect(() => structuredClone(document)).not.toThrow();
+			expect(document).toEqual({
+				anyOf: [
+					{
+						type: "array",
+						minItems: 1,
+						items: { type: "object", properties: { agent: { type: "string" } }, required: ["agent"] },
+					},
+					{
+						type: "object",
+						properties: { agent: { type: "string" } },
+						required: ["agent"],
+						additionalProperties: false,
+					},
+				],
+				description: "static array or single template",
+			});
+			expect(schema.safeParse([{ agent: "scout" }]).success).toBe(true);
+			expect(schema.safeParse({ agent: "scout" }).success).toBe(true);
+			expect(schema.safeParse(42).success).toBe(false);
+		});
+
+		it("recovers the wire schema when a builder is spread into a new document", () => {
+			const base = Type.Unsafe({
+				anyOf: [
+					{ type: "object", additionalProperties: true },
+					{ type: "boolean", enum: [false] },
+				],
+			});
+			// `{ ...base, description }` copies omptype's internal fields, not JSON
+			// keywords; the shim must recover `anyOf` from the copied self-reference
+			// and overlay the caller's added `description`.
+			const schema = Type.Unsafe({ ...base, description: "mission object or false" });
+
+			expect(schema.toJsonSchema()).toEqual({
+				anyOf: [
+					{ type: "object", additionalProperties: true },
+					{ type: "boolean", enum: [false] },
+				],
+				description: "mission object or false",
+			});
+			expect(schema.safeParse(false).success).toBe(true);
+			expect(schema.safeParse({ objective: "ship" }).success).toBe(true);
+			expect(schema.safeParse("nope").success).toBe(false);
+		});
+	});
 });

--- a/packages/coding-agent/test/extensibility/typebox-shim.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-shim.test.ts
@@ -262,6 +262,24 @@ describe("pi.typebox compatibility shim", () => {
 			expect(schema.safeParse(42).success).toBe(false);
 		});
 
+		it("preserves a legitimate run property containing a schema builder", () => {
+			const schema = Type.Unsafe({
+				type: "object",
+				properties: { run: Type.Boolean() },
+				required: ["run"],
+				additionalProperties: false,
+			});
+
+			expect(schema.toJsonSchema()).toEqual({
+				type: "object",
+				properties: { run: { type: "boolean" } },
+				required: ["run"],
+				additionalProperties: false,
+			});
+			expect(schema.safeParse({ run: true }).success).toBe(true);
+			expect(schema.safeParse(true).success).toBe(false);
+		});
+
 		it("recovers the wire schema when a builder is spread into a new document", () => {
 			const base = Type.Unsafe({
 				anyOf: [

--- a/packages/coding-agent/test/extensibility/typebox-shim.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-shim.test.ts
@@ -280,6 +280,31 @@ describe("pi.typebox compatibility shim", () => {
 			expect(schema.safeParse(true).success).toBe(false);
 		});
 
+		it("preserves wire-only constraints on embedded schema builders", () => {
+			const schema = Type.Unsafe({
+				type: "object",
+				properties: {
+					code: Type.String({ pattern: "^x" }),
+					count: Type.Number({ multipleOf: 2 }),
+				},
+				required: ["code", "count"],
+				additionalProperties: false,
+			});
+
+			expect(schema.toJsonSchema()).toEqual({
+				type: "object",
+				properties: {
+					code: { type: "string", pattern: "^x" },
+					count: { type: "number", multipleOf: 2 },
+				},
+				required: ["code", "count"],
+				additionalProperties: false,
+			});
+			expect(schema.safeParse({ code: "xray", count: 4 }).success).toBe(true);
+			expect(schema.safeParse({ code: "bad", count: 4 }).success).toBe(false);
+			expect(schema.safeParse({ code: "xray", count: 3 }).success).toBe(false);
+		});
+
 		it("recovers the wire schema when a builder is spread into a new document", () => {
 			const base = Type.Unsafe({
 				anyOf: [

--- a/packages/omptype/CHANGELOG.md
+++ b/packages/omptype/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the TypeBox adapter omitting `pattern`, non-URL `format`, and `multipleOf` from emitted JSON Schema even though runtime validation enforced them ([#8425](https://github.com/can1357/oh-my-pi/pull/8425)).
+
 ## [17.3.0] - 2026-08-13
 
 ### Added

--- a/packages/omptype/src/typebox.ts
+++ b/packages/omptype/src/typebox.ts
@@ -220,7 +220,11 @@ function tString(opts?: StringOpts): TString {
 		const valid = formatPredicate(format);
 		schema = schema.narrow((value, ctx) => valid(value) || ctx.mustBe(`a string in ${format} format`));
 	}
-	return applyMeta(schema, opts);
+	const result = applyMeta(schema, opts);
+	const keywords: Record<string, unknown> = {};
+	if (opts?.pattern !== undefined) keywords.pattern = opts.pattern;
+	if (opts?.format !== undefined) keywords.format = opts.format === "url" ? "uri" : opts.format;
+	return opts?.pattern !== undefined || opts?.format !== undefined ? withJsonSchemaKeywords(result, keywords) : result;
 }
 
 function formatPredicate(format: string): (value: string) => boolean {
@@ -290,7 +294,8 @@ function tNumber(opts?: NumberOpts, integer = false): TNumber {
 			);
 		});
 	}
-	return applyMeta(schema, opts);
+	const result = applyMeta(schema, opts);
+	return opts?.multipleOf !== undefined ? withJsonSchemaKeywords(result, { multipleOf: opts.multipleOf }) : result;
 }
 
 function tLiteral<const V extends string | number | boolean | null>(value: V, opts?: Meta): TLiteral<V> {

--- a/packages/omptype/test/typebox.test.ts
+++ b/packages/omptype/test/typebox.test.ts
@@ -46,11 +46,17 @@ describe("TypeBox adapter", () => {
 		expect(valid(Type.String({ format: "email" }), "a@b.co")).toBe(true);
 		expect(valid(Type.String({ format: "email" }), "nope")).toBe(false);
 		expect(Type.String({ format: "url" }).toJsonSchema()).toEqual({ type: "string", format: "uri" });
+		expect(Type.String({ pattern: "^[a-z]+$", format: "email" }).toJsonSchema()).toEqual({
+			type: "string",
+			pattern: "^[a-z]+$",
+			format: "email",
+		});
 
 		const number = Type.Number({ minimum: 1, maximum: 10, multipleOf: 2 });
 		expect(valid(number, 4)).toBe(true);
 		expect(valid(number, 0)).toBe(false);
 		expect(valid(number, 3)).toBe(false);
+		expect(number.toJsonSchema()).toEqual({ type: "number", minimum: 1, maximum: 10, multipleOf: 2 });
 		const exclusive = Type.Number({ exclusiveMinimum: 1, exclusiveMaximum: 3 });
 		expect(valid(exclusive, 2)).toBe(true);
 		expect(valid(exclusive, 1)).toBe(false);


### PR DESCRIPTION
## Repro
`omp plugin install pi-subagents` fails validation with `Failed to load extension: The object can not be cloned.` and rolls the install back, while the same package loads and runs when linked. Reproduced against the current tree by driving the exact path `PluginManager.#validateInstalledExtensions` runs — `loadExtensions([pi-subagents/index.ts])` — which returns `errors: [{ error: "Failed to load extension: The object can not be cloned." }]`. An instrumented catch put the throw at `structuredClone` inside the legacy-typebox shim's `unsafe()`, triggered while evaluating `pi-subagents/src/extension/schemas.ts`.

## Cause
Legacy Pi extensions build raw tool-parameter documents against real TypeBox, whose `Type.*` builders return plain JSON-Schema objects. omptype's builders return *callable* schema values, so a legacy document that embeds them (`Type.Unsafe({ anyOf: [Type.Array(...), Other] })`) or spreads them (`Type.Unsafe({ ...MissionLaunchOverride, description })`) ends up carrying functions and omptype internal fields (`ir`, `run`, `$`, …). `unsafe()` in `packages/coding-agent/src/extensibility/legacy-typebox.ts` then `structuredClone`d that document, which throws `DataCloneError` on the embedded functions. Even without the clone, the spread form would emit a garbage wire schema because the JSON keywords were replaced by omptype internals.

## Fix
- Added `lowerEmbeddedSchemas()` in `legacy-typebox.ts`, a deep copy that lowers any embedded omptype builder to its wire JSON via `toJsonSchema()`, and — when a document is a spread of a builder — recovers the real schema from the copied `run` self-reference and overlays the caller's added keywords (e.g. `description`).
- `unsafe()` now builds its `document` through `lowerEmbeddedSchemas` (which doubles as the detaching copy) and structured-clones that plain document for the validator, instead of cloning the raw input.
- Routed the raw-`additionalProperties` path through the same lowering.
- Added regression coverage for the embed and spread idioms in `test/extensibility/typebox-shim.test.ts`.

## Verification
`bun test test/extensibility/typebox-shim.test.ts test/plugin-install-validation.test.ts` → 24 pass (17 shim incl. 2 new + 7 install-validation). `bun run check:types` clean. Manually confirmed `loadExtensions` now loads `pi-subagents` and registers the `subagent`/`subagent_wait` tools, and that the recovered spread schema equals `{ anyOf: [...], description }` (accepts `false`/objects, rejects strings). Fixes #8420