### PR TITLE
Default autoResume to true on startup

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -689,7 +689,7 @@ For a custom status line, set `statusLine.preset: custom` and configure `statusL
 | `followUpMode`       | enum    | `one-at-a-time` | `all`, `one-at-a-time`.                                                                                 |
 | `interruptMode`      | enum    | `immediate`     | `immediate`, `wait`.                                                                                    |
 | `doubleEscapeAction` | enum    | `tree`          | `branch`, `tree`, `none`.                                                                               |
-| `autoResume`         | boolean | `false`         | Auto-resume the most recent session in the cwd.                                                         |
+| `autoResume`         | boolean | `true`          | Auto-resume the most recent session in the cwd.                                                         |
 | `ask.timeout`        | number  | `0`             | Seconds before an `ask` prompt times out; `0` = no timeout. (Legacy ms values are migrated to seconds.) |
 | `ask.notify`         | enum    | `on`            | `on`, `off`.                                                                                            |
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -402,7 +402,7 @@ export const SETTINGS_SCHEMA = {
 
 	autoResume: {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "interaction",
 			group: "Startup & Updates",


### PR DESCRIPTION
## Summary
- Change the `autoResume` setting default from `false` to `true` (`/settings` → Startup & Updates).
- Update `docs/settings.md` to match the new default.

This makes a plain `omp` launch resume the most recent session in the current directory (same behavior as `omp --continue`), so users no longer need to copy the resume path after `/quit`. Opt out remains available via `/settings` or `omp config set autoResume false`.

## Test plan
- [ ] Fresh install / empty config: `omp` in a directory with a prior session resumes it
- [ ] `omp config get autoResume` reports `true` by default
- [ ] Setting `autoResume: false` still starts a new session
- [ ] Explicit `--resume` / `--continue` / `--no-session` still override as before