### PR TITLE
fix(ai): accept custom-role messages in cursor provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor provider dropping trailing `custom`-role messages: `buildGrpcRequest` now treats `custom` as an active user turn (previously degraded to `resumeAction`, dropping the real user message), and history builders (`buildRootPromptMessagesJson`, `buildConversationTurns`) include `custom` messages. Defensive for the coding-agent pipeline (which converts `custom` → `developer` upstream) and required for direct `streamCursor` consumers of this package.
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4301,7 +4301,7 @@ function buildRootPromptMessagesJson(
 	for (let i = 0; i < messages.length; i++) {
 		if (i === activeUserMessageIndex) break;
 		const msg = messages[i];
-		if (msg.role === "user" || msg.role === "developer") {
+		if (msg.role === "user" || msg.role === "developer" || (msg.role as string) === "custom") {
 			const content = buildCursorRootPromptContent(msg.content);
 			if (content.length === 0) continue;
 			pushJson({ role: "user", content });
@@ -4448,7 +4448,7 @@ function buildConversationTurns(
 	let i = 0;
 	while (i < messages.length) {
 		const msg = messages[i];
-		if (msg.role !== "user" && msg.role !== "developer") {
+		if (msg.role !== "user" && msg.role !== "developer" && (msg.role as string) !== "custom") {
 			i++;
 			continue;
 		}
@@ -4469,7 +4469,7 @@ function buildConversationTurns(
 		const stepBlobIds: Uint8Array[] = [];
 		i++;
 
-		while (i < messages.length && messages[i].role !== "user" && messages[i].role !== "developer") {
+		while (i < messages.length && messages[i].role !== "user" && messages[i].role !== "developer" && (messages[i].role as string) !== "custom") {
 			const stepMsg = messages[i];
 			if (stepMsg.role === "assistant") {
 				for (const item of stepMsg.content) {
@@ -4624,12 +4624,22 @@ function buildGrpcRequest(
 
 	const activeUserMessageIndex = context.messages.length - 1;
 	const activeMessage = context.messages[activeUserMessageIndex];
+	// Injections (before_agent_start custom messages, e.g. MEMORY context) land
+	// as trailing `custom`-role messages; treat them as the active user turn so
+	// they are actually sent via userMessageAction instead of silently dropping
+	// the real user message behind a resumeAction.
 	const activeUserMessage =
-		activeMessage?.role === "user" || activeMessage?.role === "developer" ? activeMessage : undefined;
+		activeMessage?.role === "user" || activeMessage?.role === "developer" || (activeMessage?.role as string) === "custom"
+			? activeMessage
+			: undefined;
 	let userContent: string | (TextContent | ImageContent)[] | undefined;
 	let userText = "";
 	let hasUserImages = false;
-	if (activeUserMessage?.role === "user" || activeUserMessage?.role === "developer") {
+	if (
+		activeUserMessage?.role === "user" ||
+		activeUserMessage?.role === "developer" ||
+		(activeUserMessage?.role as string) === "custom"
+	) {
 		userContent = activeUserMessage.content;
 		if (typeof userContent === "string") {
 			userText = userContent.trim();

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -552,6 +552,36 @@ describe("Cursor request action encoding", () => {
 		}
 		expect(Array.from(selectedImage.dataOrBlobId.value)).toEqual(Array.from(Buffer.from(imageData, "base64")));
 	});
+
+	it("uses a user message action for a trailing custom-role injection", async () => {
+		const payload = await captureCursorPayload({
+			messages: [
+				{ role: "user", content: "What is my name?", timestamp: 0 },
+				// before_agent_start injections land after the user message
+				{ role: "custom", content: "User is Doctor.", timestamp: 1 },
+			] as unknown as Context["messages"],
+		});
+
+		expect(payload.action?.action.case).toBe("userMessageAction");
+		const userMessage = payload.action?.action.case === "userMessageAction" ? payload.action.action.value.userMessage : undefined;
+		expect(userMessage?.text).toBe("User is Doctor.");
+	});
+
+	it("carries prior custom-role injections into root prompt history", async () => {
+		const messages: Context["messages"] = [
+			{ role: "user", content: "First turn", timestamp: 0 },
+			{ role: "assistant", content: "First answer", timestamp: 1 },
+			// previous turn's injection is now history
+			{ role: "custom", content: "User is Doctor.", timestamp: 2 },
+			{ role: "user", content: "Second turn", timestamp: 3 },
+		] as unknown as Context["messages"];
+
+		const payload = await captureCursorPayload({ messages });
+		expect(payload.action?.action.case).toBe("userMessageAction");
+
+		const history = buildCursorHistoryForTest(messages);
+		expect(history.rootPromptMessagesJson.some(entry => JSON.stringify(entry).includes("User is Doctor."))).toBe(true);
+	});
 });
 
 describe("Cursor history encoding", () => {

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -554,6 +554,9 @@ describe("Cursor request action encoding", () => {
 	});
 
 	it("uses a user message action for a trailing custom-role injection", async () => {
+		// Direct streamCursor path: the coding-agent pipeline converts custom →
+		// developer in convertToLlm before the provider, but this package is a
+		// standalone library whose direct consumers may pass custom-role messages.
 		const payload = await captureCursorPayload({
 			messages: [
 				{ role: "user", content: "What is my name?", timestamp: 0 },


### PR DESCRIPTION
## Problem

`before_agent_start` extension injections (e.g. MEMORY / AGENTS.md context delivered as trailing `custom`-role messages) never reached the Cursor server:

- `buildGrpcRequest` only recognized `user`/`developer` as the active user turn, so a trailing `custom` message made the request fall back to `resumeAction` — the real user message was silently dropped and the model answered without seeing the prompt.
- `buildRootPromptMessagesJson` and `buildConversationTurns` skipped `custom`-role messages entirely, so injected context was lost from history on subsequent turns.

Verified end-to-end with a local dev build: a `before_agent_start` plugin injecting `~/.codex/AGENTS.md` content into a Cursor session now reaches the model (previously the model had no knowledge of the injected instructions).

## Change

`packages/ai/src/providers/cursor.ts` — treat `custom` role as a user turn in:

1. `buildGrpcRequest` active-user-message detection (sends via `userMessageAction` instead of degrading to `resumeAction`)
2. `buildRootPromptMessagesJson` (prior injections survive in history)
3. `buildConversationTurns` (turn boundaries include `custom`)

Comparisons use `(role as string)` casts since `Message`'s role union has no `custom` member (runtime-only role).

## Tests

- Added 2 tests in `packages/ai/test/cursor-exec-handlers.test.ts`:
  - trailing `custom`-role injection → `userMessageAction` (not `resumeAction`)
  - prior `custom` injections carried into `rootPromptMessagesJson` history
- `bun test packages/ai/test/cursor-exec-handlers.test.ts`: 43/43 pass
- Full cursor suite (`packages/ai/test/cursor-*`): 227/227 pass