### PR TITLE
fix(coding-agent): confine browser executable probe to Linux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the browser tool executable probe launching the user's installed GUI Chromium on Windows: the `--version` version probe from ecb22957 was Linux-scoped but ran for every platform candidate, so on Windows it could hand off to a running `chrome.exe`, open a normal browser window, then reject the candidate and fall back to cached Chrome for Testing. The probe is now confined to Linux ([#8445](https://github.com/can1357/oh-my-pi/issues/8445)).
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -204,6 +204,15 @@ function isExecutableFile(p: string): boolean {
 
 async function isChromiumExecutable(p: string): Promise<boolean> {
 	if (!isExecutableFile(p)) return false;
+	// The version probe below launches the candidate. It exists to reject
+	// non-Chromium `chrome`/`chromium` wrapper scripts that appear on a Linux
+	// PATH (ecb22957, "validate Linux browser executables"). On Windows and
+	// macOS the candidates are fixed GUI application paths, not PATH wrappers,
+	// and executing them is harmful: a GUI `chrome.exe --version` does not print
+	// to a detached stdout and can hand off to the user's running instance,
+	// opening/activating a normal browser window (#8445). Confine the probe to
+	// Linux and trust the executable-file check elsewhere.
+	if (process.platform !== "linux") return true;
 	try {
 		const probeTimeoutMs = 3000;
 		const proc = Bun.spawn([p, "--version"], {

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -138,6 +138,30 @@ describe("browser executable selection", () => {
 		}
 	});
 
+	it("does not launch the candidate to probe its version on Windows (#8445)", async () => {
+		const tempDir = TempDir.createSync("@browser-probe-win32-");
+		try {
+			const marker = path.join(tempDir.path(), "gui-launched");
+			const fakeChrome = path.join(tempDir.path(), "chrome.exe");
+			// A GUI chrome.exe handoff: executing it has a side effect (this marker)
+			// but prints nothing a console version probe would accept.
+			await Bun.write(fakeChrome, `#!/bin/sh\ntouch "${marker}"\necho "activating existing window"\n`);
+			fs.chmodSync(fakeChrome, 0o755);
+
+			const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+			Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+			try {
+				await expect(chromiumExecutableProbeForTest(fakeChrome)).resolves.toBe(true);
+			} finally {
+				if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+			}
+
+			expect(fs.existsSync(marker)).toBe(false);
+		} finally {
+			await tempDir.remove();
+		}
+	});
+
 	it("honors PUPPETEER_EXECUTABLE_PATH before a detected Windows system Chrome", async () => {
 		const tempDir = TempDir.createSync("@browser-executable-");
 		try {


### PR DESCRIPTION
## Repro
On native Windows, invoking the `browser` tool for the first time opens/activates the user's installed Ungoogled Chromium window and then launches cached Chrome for Testing as the automation browser. Reproduced by forcing `process.platform` to `win32` and pointing `chromiumExecutableProbeForTest()` at a fake `chrome.exe` whose execution has a side effect (a marker file) but whose stdout does not look like a console version print:

```
bun tmp-repro-8445.ts   # inside packages/coding-agent
# before fix: { "platform": "win32", "executed": true,  "accepted": false }
# after fix:  { "platform": "win32", "executed": false, "accepted": true  }
```

`executed: true` is the GUI-window activation the reporter sees; `accepted: false` is the subsequent rejection that triggers the Chrome for Testing fallback.

## Cause
`ecb22957` ("validate Linux browser executables") replaced the executable-file check in `resolveSystemChromium()` with `isChromiumExecutable()` (`packages/coding-agent/src/tools/browser/launch.ts`), which runs `Bun.spawn([p, "--version"])` for **every** platform candidate, including the win32 `chrome.exe`/`msedge.exe` paths. On Windows `chrome.exe` is a GUI-subsystem binary: `--version` does not print to a detached stdout and can hand the command to an already-running Chromium instance, opening/activating a normal browser window. The probe then sees no matching version stdout, rejects the installed candidate, and falls back to cached Chrome for Testing.

## Fix
- `isChromiumExecutable()` now returns after the executable-file check on any non-Linux platform (`if (process.platform !== "linux") return true;`), confining the `--version` spawn probe to Linux — its intended target, where non-Chromium `chrome`/`chromium` PATH wrappers are the real risk. Windows and macOS use fixed GUI application paths and are restored to the pre-`ecb22957` file-check behavior.
- Added a regression test (`browser-launch.test.ts`) asserting the probe accepts a candidate under `win32` **without** executing it (no marker file), with `process.platform` overridden and restored locally.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/tools/browser-launch.test.ts` → 10 pass / 0 fail (includes the new win32 test and the existing Linux wrapper-rejection tests that still exercise the spawn probe). Manual in-repo repro confirms `executed: false, accepted: true` after the fix.

Fixes #8445