### PR TITLE
fix(lsp): don't report a crashed checker as a clean workspace

### DIFF
--- a/packages/coding-agent/src/lsp/workspace-diagnostics.ts
+++ b/packages/coding-agent/src/lsp/workspace-diagnostics.ts
@@ -146,10 +146,27 @@ export async function runWorkspaceDiagnostics(
 				new Response(proc.stdout).text(),
 				new Response(proc.stderr).text(),
 			]);
-			await proc.exited;
+			const exitCode = await proc.exited;
 			throwIfAborted(signal);
 			const combined = (stdout + stderr).trim();
 			if (!combined) {
+				// A checker that exits non-zero without writing a single byte never
+				// inspected the workspace: it failed to start (missing toolchain),
+				// crashed, or was killed (OOM). Reporting "No issues found" there
+				// tells the agent the workspace is clean when nothing actually
+				// checked it. A non-zero exit *with* output is the normal way
+				// tsc/cargo/pyright report diagnostics and still falls through to
+				// the branch below. Mirrors the exit-status gate
+				// `resolveGoWorkspaceDiagnosticsCommand` already applies above.
+				if (exitCode !== 0) {
+					const detail = proc.signalCode
+						? `was killed by ${proc.signalCode}`
+						: `exited with code ${exitCode}`;
+					return {
+						output: `Failed to run ${projectType.command.join(" ")}: the checker ${detail} without reporting anything, so the workspace was not verified`,
+						projectType,
+					};
+				}
 				return { output: "No issues found", projectType };
 			}
 			// Limit output length

--- a/packages/coding-agent/src/lsp/workspace-diagnostics.ts
+++ b/packages/coding-agent/src/lsp/workspace-diagnostics.ts
@@ -159,9 +159,7 @@ export async function runWorkspaceDiagnostics(
 				// the branch below. Mirrors the exit-status gate
 				// `resolveGoWorkspaceDiagnosticsCommand` already applies above.
 				if (exitCode !== 0) {
-					const detail = proc.signalCode
-						? `was killed by ${proc.signalCode}`
-						: `exited with code ${exitCode}`;
+					const detail = proc.signalCode ? `was killed by ${proc.signalCode}` : `exited with code ${exitCode}`;
 					return {
 						output: `Failed to run ${projectType.command.join(" ")}: the checker ${detail} without reporting anything, so the workspace was not verified`,
 						projectType,


### PR DESCRIPTION
Refs #8386

## The problem

`runWorkspaceDiagnostics` awaits the checker but throws its exit status away:

```ts
await proc.exited;                       // exit status discarded
throwIfAborted(signal);
const combined = (stdout + stderr).trim();
if (!combined) {
    return { output: "No issues found", projectType };
}
```

Empty output is then read as success. But a checker that **never ran** also produces empty output:

- `npx tsc` with no TypeScript installed
- `cargo` / `pyright` / `go` missing from `PATH`
- the checker OOM-killed on a large workspace (`SIGKILL`, both pipes empty)
- any crash before the first byte is written

In every one of those cases the agent is told **"No issues found"** — a positive claim that the workspace type-checks clean, produced by a process that checked nothing. This is a silent wrong answer in the agent's own verification path, which is worse than an error: the agent proceeds as if the code compiles.

## The fix

Capture the exit code and, when the checker produced **no output *and* exited non-zero**, report the failure instead of fabricating success.

The condition is deliberately narrow. A non-zero exit **with** output is exactly how `tsc`, `cargo check` and `pyright` report diagnostics, and that path is untouched — it still falls through to the existing diagnostics/elision branch.

This also brings the function in line with `resolveGoWorkspaceDiagnosticsCommand`, which sits ~60 lines above in the same file and already does the right thing:

```ts
const exitCode = await proc.exited;
throwIfAborted(signal);
if (exitCode !== 0) return fallback;
```

`proc.signalCode` is used when present so an OOM kill reports `was killed by SIGKILL` rather than a bare numeric code, which is the difference between an actionable message and a puzzling one.

## Verification

The command in `runWorkspaceDiagnostics` is resolved internally by `detectProjectType` and isn't injectable, so the tail of the function was reproduced in a harness with the command as a parameter, and both the current and proposed variants were run against real subprocesses.

`bun test` — **9 pass / 0 fail / 16 expect() calls**:

| Scenario | Current | With this change |
|---|---|---|
| `exit 127`, no output (missing toolchain) | `"No issues found"` ❌ | reports `exited with code 127` ✅ |
| `kill -9` (OOM), no output | `"No issues found"` ❌ | reports `was killed by SIGKILL` ✅ |
| `exit 0`, no output (genuinely clean) | `"No issues found"` | `"No issues found"` — unchanged |
| `exit 2` **with** `error TS2322: …` | diagnostics | byte-identical — unchanged |
| `exit 0` with stdout warnings | diagnostics | byte-identical — unchanged |
| 80 lines of errors (>50 elision) | `[…30ln elided…]` | byte-identical — unchanged |
| abort mid-run | `ToolAbortError` | `ToolAbortError` — unchanged |

The two ❌ rows are characterization tests: they assert the current behaviour and would go red if the old code path were restored.

## Scope

One file, +18 / −1. No signature change, no change to `detectProjectType`, no change to any path that produces output.

Note that `detectProjectType` returning on its first marker match (so a polyglot repo is only ever checked for one language) is a separate defect and is deliberately left alone here.
