### PR TITLE
fix(utils): normalize aborts during retry backoff

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `fetchWithRetry()` aborts during retry backoff to preserve the documented `"Request was aborted"` error contract ([#8450](https://github.com/can1357/oh-my-pi/issues/8450)).
+
 ## [17.3.0] - 2026-08-13
 
 ### Fixed

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -220,7 +220,7 @@ export async function fetchWithRetry(
 			if (signal?.aborted) throw new Error("Request was aborted");
 			const wrapped = wrapNetworkError(error);
 			if (attempt + 1 >= maxAttempts) throw wrapped;
-			await scheduler.wait(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), { signal });
+			await waitForRetry(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), signal);
 			continue;
 		}
 
@@ -234,7 +234,7 @@ export async function fetchWithRetry(
 		if (hint !== undefined && hint > maxDelayMs) return response;
 
 		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
-		await scheduler.wait(delayMs, { signal });
+		await waitForRetry(delayMs, signal);
 	}
 }
 
@@ -249,6 +249,15 @@ function mergeInit(base: RequestInit, overlay: RequestInit, timeout: number | fa
 		merged.headers = baseHeaders;
 	}
 	return merged;
+}
+
+async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): Promise<void> {
+	try {
+		await scheduler.wait(delayMs, { signal });
+	} catch (error) {
+		if (signal?.aborted) throw new Error("Request was aborted");
+		throw error;
+	}
 }
 
 function wrapNetworkError(error: unknown): Error {

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -78,6 +78,36 @@ describe("fetchWithRetry", () => {
 		expect(await response.text()).toBe("slow down");
 		expect(attempt).toBe(1);
 	});
+
+	it("normalizes aborts during response backoff", async () => {
+		const request = fetchWithRetry("https://example.invalid/response-backoff", {
+			fetch: async () => new Response("retry", { status: 503 }),
+			signal: AbortSignal.timeout(10),
+			defaultDelayMs: 1_000,
+			maxAttempts: 2,
+		});
+
+		await expect(request).rejects.toMatchObject({
+			name: "Error",
+			message: "Request was aborted",
+		});
+	});
+
+	it("normalizes aborts during network-error backoff", async () => {
+		const request = fetchWithRetry("https://example.invalid/network-backoff", {
+			fetch: async () => {
+				throw new TypeError("connection reset");
+			},
+			signal: AbortSignal.timeout(10),
+			defaultDelayMs: 1_000,
+			maxAttempts: 2,
+		});
+
+		await expect(request).rejects.toMatchObject({
+			name: "Error",
+			message: "Request was aborted",
+		});
+	});
 });
 
 describe("extractRetryHint", () => {


### PR DESCRIPTION
## Repro
A request that receives HTTP 503 or a transient network error enters `fetchWithRetry` backoff; aborting its signal during that wait reproduces with `bun /tmp/omp-8450-repro.ts`, yielding `AbortError | The operation was aborted.` on both paths instead of the documented message.

## Cause
Both `scheduler.wait` calls in `packages/utils/src/fetch-retry.ts` ran outside abort normalization, so their rejected promises bypassed the loop-top and fetch-error signal guards.

## Fix
- Route response and network-error backoff through a shared `waitForRetry` helper.
- Normalize a signal-triggered wait rejection to `Error("Request was aborted")` while preserving unrelated wait failures.
- Cover cancellation during both retry paths and record the fix in the utils changelog.

## Verification
`bun test packages/utils/test/fetch-retry.test.ts` — 10 pass, 0 fail. Manual reproduction after the fix returns `Error | Request was aborted` for both response and network-error backoff. Pre-publish `bun run fix` and `bun check` passed through the host publish gate. Fixes #8450