### PR TITLE
fix(utils): normalize aborts that land during fetchWithRetry backoff

### DIFF
--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -220,7 +220,7 @@ export async function fetchWithRetry(
 			if (signal?.aborted) throw new Error("Request was aborted");
 			const wrapped = wrapNetworkError(error);
 			if (attempt + 1 >= maxAttempts) throw wrapped;
-			await scheduler.wait(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), { signal });
+			await sleepBeforeRetry(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), signal);
 			continue;
 		}
 
@@ -234,7 +234,25 @@ export async function fetchWithRetry(
 		if (hint !== undefined && hint > maxDelayMs) return response;
 
 		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
+		await sleepBeforeRetry(delayMs, signal);
+	}
+}
+
+/**
+ * Sleep between retry attempts, honouring `signal`.
+ *
+ * `scheduler.wait` rejects with its own `AbortError` ("The operation was aborted."),
+ * which neither carries the structural abort flag this codebase attaches nor matches
+ * the `"Request was aborted"` text `fetchWithRetry` documents and every other abort
+ * path here throws. Left unwrapped, a cancellation that lands while we are backing
+ * off escapes as an unclassified failure instead of an abort.
+ */
+async function sleepBeforeRetry(delayMs: number, signal: AbortSignal | undefined): Promise<void> {
+	try {
 		await scheduler.wait(delayMs, { signal });
+	} catch (error) {
+		if (signal?.aborted) throw new Error("Request was aborted");
+		throw error;
 	}
 }
 


### PR DESCRIPTION
Refs #8450

## What

`fetchWithRetry` documents that "Aborts on `init.signal` propagate as `"Request was aborted"`", and every abort path in the function honours that — except the two backoff sleeps, which sit outside any `try`/`catch`:

```ts
await scheduler.wait(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), { signal }); // network-error retry
...
await scheduler.wait(delayMs, { signal });                                                  // retryable-status retry
```

This routes both sleeps through a small `sleepBeforeRetry` helper that rethrows the documented error when the signal is aborted, and propagates anything else verbatim. One file, +19 / −1, no API or signature changes.

## Why

`scheduler.wait` rejects with its own `AbortError: The operation was aborted.`. The retry loop spends nearly all of its wall-clock time asleep — default backoff is `500ms * 2 ** attempt`, and 429 `Retry-After` hints are honoured up to 60 s — so this is the *likely* window for a user cancellation to land, not an edge case.

The escaped error then fails **both** of the repo's error classifiers, so Ctrl+C during a rate-limit backoff is reported as an unclassified hard error rather than a cancellation:

- **Structural flag** — `Flag.Abort` is attached only by the `AbortError` constructor in `packages/ai/src/error/abort.ts` (`attach(this, create(Flag.Abort))`). The scheduler's own DOMException-style `AbortError` never passes through it, so it carries no flag.
- **Text matcher** — `classifyText()` in `packages/ai/src/error/flags.ts` has no abort pattern at all; `TIMEOUT_PATTERN`, `TRANSIENT_TRANSPORT_PATTERN` and `AUTH_FAILURE_PATTERN` all return `false` for `"The operation was aborted."`.

With neither path matching, `classify()` returns `0` and `stringify()` yields `"none"`.

This is also the contract `abort.ts` already relies on: its docstring notes the message is kept byte-identical "so any remaining text-based matchers keep working" — which only holds if aborts actually flow through that constructor or produce that text.

## Testing

Ran the patched module and the unmodified upstream module side by side under `bun test` — 9 pass / 0 fail / 22 `expect()`:

| test | result |
| --- | --- |
| 429 backoff abort → `Request was aborted` (patched) | pass |
| 429 backoff abort → `AbortError`, message ≠ `Request was aborted` (**unpatched**) | pass — characterizes the bug |
| network-error backoff abort → `Request was aborted` (patched) | pass |
| network-error backoff abort → `AbortError` (**unpatched**) | pass — characterizes the bug |
| abort during `fetch` itself → `Request was aborted` (both) | pass — unchanged |
| pre-aborted signal throws before any fetch, 0 calls (both) | pass — unchanged |
| retry-then-succeed: 503, 503, 200 → 3 calls (both) | pass — unchanged |
| attempts exhausted → last 429 returned, 3 calls (both) | pass — unchanged |
| non-abort rejection still propagates verbatim (patched) | pass |

The two characterization tests fail against upstream `main` and pass against this branch, which is what isolates the change to the abort path. Every non-abort assertion is run against both versions to show the retry semantics are untouched.

Happy to fold these into `packages/utils/test/` in this PR if you'd prefer them committed rather than just used as evidence.

---

- [x] Tested locally
- [ ] `bun check` passes (relying on CI)
- [ ] CHANGELOG updated (if user-facing)
