### PR TITLE
use /v1/ APIs for llama.cpp for better compatibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Fixed llama.cpp model discovery producing `baseUrl` without the `/v1` prefix for non-Qwen models, causing 404 errors on OpenAI-compatible endpoints (`/v1/responses`, `/v1/chat/completions`). The fix ensures all discovered llama.cpp models include `/v1` in their `baseUrl`, matching the behavior already applied to Qwen models.
 
 ## [17.3.1] - 2026-08-13
 

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -1018,7 +1018,7 @@ export async function discoverProxyModels(
 	return discovered;
 }
 
-function normalizeLlamaCppBaseUrl(baseUrl?: string): string {
+export function normalizeLlamaCppBaseUrl(baseUrl?: string): string {
 	const defaultBaseUrl = "http://127.0.0.1:8080";
 	const raw = baseUrl || defaultBaseUrl;
 	try {
@@ -1033,7 +1033,7 @@ function normalizeLlamaCppBaseUrl(baseUrl?: string): string {
 // ensureLlamaCppV1BaseUrl appends the OpenAI-compatible `/v1` prefix a
 // chat-completions request needs; native discovery keeps the bare root, which
 // serves `/models` and `/props` but not `/chat/completions`.
-function ensureLlamaCppV1BaseUrl(baseUrl: string): string {
+export function ensureLlamaCppV1BaseUrl(baseUrl: string): string {
 	return baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
 }
 

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -645,7 +645,7 @@ export async function discoverLlamaCppModels(
 					name: id,
 					api: providerConfig.api,
 					provider: providerConfig.provider,
-					baseUrl,
+					baseUrl: ensureLlamaCppV1BaseUrl(baseUrl),
 					reasoning: false,
 					input: item.input ?? serverMetadata?.input ?? ["text"],
 					imageInputDecoder: "stb",

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -577,7 +577,7 @@ export class ModelRegistry {
 		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, select(this.#customModelOverlays));
 		const combined = this.#mergeCustomModels(withConfigModels, select(this.#runtimeModelOverlays));
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		return this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides));
+		return this.#applyLlamaCppModelFixups(this.#applyRuntimeProviderOverrides(withModelOverrides));
 	}
 
 	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
@@ -1064,9 +1064,7 @@ export class ModelRegistry {
 		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		this.#unprojectedModels = this.#applyLlamaCppQwenThinkingToModels(
-			this.#applyRuntimeProviderOverrides(withModelOverrides),
-		);
+		this.#unprojectedModels = this.#applyLlamaCppModelFixups(this.#applyRuntimeProviderOverrides(withModelOverrides));
 		this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
 	}
 
@@ -1446,20 +1444,25 @@ export class ModelRegistry {
 		});
 	}
 
-	// #applyLlamaCppQwenThinkingToModels re-runs applyLlamaCppQwenThinking as the
-	// outermost transform for llama.cpp-provider models, after discovery merges,
-	// cache fallbacks, and provider/transport overrides have run. It is
-	// idempotent, so it restores the routed Qwen model's chat-completions api,
-	// `/v1` runtime base URL, and disable dialect even when a configured `baseUrl`
-	// override (which wins in mergeDiscoveredModel) or a fallback to a pre-fix
-	// cached row would otherwise leave the old spec in place.
-	#applyLlamaCppQwenThinkingToModels(models: Model<Api>[]): Model<Api>[] {
+	// #applyLlamaCppModelFixups is the outermost transform for llama.cpp-provider
+	// models, after discovery merges, cache fallbacks, and provider/transport
+	// overrides have run. It applies Qwen-specific fixes (api, reasoning, compat)
+	// and ensures all non-transport models have the `/v1` prefix in their baseUrl,
+	// even when a configured override or stale cache row would strip it.
+	#applyLlamaCppModelFixups(models: Model<Api>[]): Model<Api>[] {
 		const llamaCppProviders = new Set<string>();
 		for (const provider of this.#discoverableProviders) {
 			if (provider.discovery.type === "llama.cpp") llamaCppProviders.add(provider.provider);
 		}
 		if (llamaCppProviders.size === 0) return models;
-		return models.map(model => (llamaCppProviders.has(model.provider) ? applyLlamaCppQwenThinking(model) : model));
+		return models.map(model => {
+			if (!llamaCppProviders.has(model.provider)) return model;
+			const withFixups = applyLlamaCppQwenThinking(model);
+			if (!withFixups.transport && !withFixups.baseUrl.endsWith("/v1")) {
+				return buildModel({ ...withFixups, baseUrl: `${withFixups.baseUrl}/v1` });
+			}
+			return withFixups;
+		});
 	}
 
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
@@ -2097,7 +2100,7 @@ export class ModelRegistry {
 				transportOverride,
 			);
 			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
-			this.#unprojectedModels = this.#applyLlamaCppQwenThinkingToModels(
+			this.#unprojectedModels = this.#applyLlamaCppModelFixups(
 				this.#unprojectedModels.map(model => {
 					if (model.provider !== providerName) return model;
 					return this.#applyProviderTransportOverrideToModel(model, transportOverride);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -61,9 +61,11 @@ import {
 	type DiscoveryProviderConfig,
 	discoverLlamaCppModelRuntimeMetadata,
 	discoverModelsByProviderType,
+	ensureLlamaCppV1BaseUrl,
 	getImplicitOllamaBaseUrl,
 	getOllamaContextLengthOverride,
 	normalizeLiteLLMDiscoveryBaseUrl,
+	normalizeLlamaCppBaseUrl,
 } from "./model-discovery";
 import {
 	AUTHORITATIVE_RUNTIME_CATALOG_PROVIDERS,
@@ -1459,7 +1461,10 @@ export class ModelRegistry {
 			if (!llamaCppProviders.has(model.provider)) return model;
 			const withFixups = applyLlamaCppQwenThinking(model);
 			if (!withFixups.transport && !withFixups.baseUrl.endsWith("/v1")) {
-				return buildModel({ ...withFixups, baseUrl: `${withFixups.baseUrl}/v1` });
+				return buildModel({
+					...withFixups,
+					baseUrl: ensureLlamaCppV1BaseUrl(normalizeLlamaCppBaseUrl(withFixups.baseUrl)),
+				});
 			}
 			return withFixups;
 		});

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1158,7 +1158,7 @@ describe("ModelRegistry runtime discovery", () => {
 		const plain = registry.find("llama.cpp", "llama-3.1-8b");
 		expect(plain?.reasoning).toBe(false);
 		expect(plain?.api).toBe("openai-responses");
-		expect(plain?.baseUrl).toBe("http://127.0.0.1:8080");
+		expect(plain?.baseUrl).toBe("http://127.0.0.1:8080/v1");
 		expect((plain?.compat as DialectFields | undefined)?.reasoningDisableMode).not.toBe("qwen-template-false");
 	});
 


### PR DESCRIPTION


## What

Use /v1/ apis for llama.cpp instead of / for better compatibility with older versions of llama.cpp and forks

eg. use /v1/responses instead of /responses

## Why

Llama.cpp mirrors its /v1/ apis to / which omp currently uses, however
this change is somewhat recent of only a few months ago, so omp's
llama.cpp provider does not work with older versions of llama.cpp and
some forks.

to improve compatibility use /v1/ apis for requests. model discovery
still uses /models and /props directly without v1.

because modern versions of llama.cpp mirror these, people using recent
versions should see no impact from this, while people using older
version should see improved compatibility.

## Testing

test with llama-swap (which does not implement these mirrored apis on /) verify after change that we don't see any 404 errors when messaging a gemma4 model.


### before

```
bun run omp -p "hello"
Working...
404 404 page not found
error: "omp" exited with code 1 
```

### after
```
bun run omp -p "hello"
Working...
Hello. I am ready to assist with the Oh My Pi coding harness. Please provide a task or specify a target area for investigation.
```




---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
