### PR TITLE
fix(coding-agent): route foreign bin-dir alias symlinks to binary update

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp update` failing with npm EEXIST when the npm global bin directory contains a foreign alias symlink named `omp` (for example a user-created link to a standalone binary in `~/.local/bin`): the alias was misclassified as an npm-managed install, and `npm install -g` refused to clobber it. Symlinked bin entries now count as manager-managed only when their target resolves under that manager's root; foreign aliases fall through to a binary update of the resolved target ([#8468](https://github.com/can1357/oh-my-pi/issues/8468)).
+
 ## [17.3.1] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -481,6 +481,14 @@ interface UpdateMethodResolutionOptions {
 	 * target directory.
 	 */
 	ompIsRegularFile?: boolean;
+	/**
+	 * Realpath of the resolved omp path when it is a symlink. npm/bun global
+	 * installs link the bin entry into their own install tree (node_modules
+	 * under the manager root); a symlink whose target lives outside that root
+	 * is a foreign alias (e.g. a user-created link into another bin dir) that
+	 * the manager will refuse to clobber (npm EEXIST).
+	 */
+	ompRealpath?: string;
 }
 
 type UpdateTarget =
@@ -491,12 +499,26 @@ type UpdateTarget =
 	| { method: "npm"; path?: string }
 	| { method: "binary"; path: string; replacesSymlink: boolean };
 
+/**
+ * Whether a symlinked bin entry belongs to the package manager whose global
+ * bin dir is {@link binDir}. Manager-owned links on POSIX resolve into the
+ * manager's install tree (node_modules under the manager root); anything else
+ * is a foreign alias the manager did not create and will not overwrite.
+ * Without a realpath (not a symlink, or unresolvable) ownership is assumed so
+ * legacy detection is unchanged.
+ */
+function managerOwnsBinEntry(realpath: string | undefined, binDir: string): boolean {
+	if (!realpath) return true;
+	const managerRoot = tryRealpath(path.dirname(binDir)) ?? path.dirname(path.resolve(binDir));
+	return isPathInDirectoryLexical(realpath, managerRoot);
+}
+
 function resolveUpdateMethod(
 	ompPath: string,
 	bunBinDir: string | undefined,
 	options: UpdateMethodResolutionOptions = {},
 ): UpdateMethod {
-	const { homebrewPrefix, miseBinDirs = [], miseDataDir, npmBinDir, ompIsRegularFile = false } = options;
+	const { homebrewPrefix, miseBinDirs = [], miseDataDir, npmBinDir, ompIsRegularFile = false, ompRealpath } = options;
 	const launcherExtension = path.extname(ompPath).toLowerCase();
 	const isWindowsScriptLauncher =
 		launcherExtension === ".cmd" || launcherExtension === ".ps1" || launcherExtension === ".bat";
@@ -514,9 +536,19 @@ function resolveUpdateMethod(
 	// (bun's .exe launcher, npm's .cmd/.ps1), so a regular file is NOT evidence
 	// of a standalone install and the override would hijack managed installs.
 	const isStandaloneRegularFile = ompIsRegularFile && process.platform !== "win32";
-	if (bunBinDir && isPathInDirectory(ompPath, bunBinDir) && !isStandaloneRegularFile) return "bun";
-	if ((npmBinDir && isPathInDirectory(ompPath, npmBinDir) && !isStandaloneRegularFile) || isWindowsScriptLauncher)
+	// A symlinked bin entry only counts as manager-managed when its target
+	// lives under that manager's root. A foreign alias (user-created link to a
+	// standalone binary elsewhere) must fall through to binary replacement:
+	// routing it through npm/bun makes their install collide with the alias
+	// (npm EEXIST) and would replace the link instead of the real binary.
+	if (bunBinDir && isPathInDirectory(ompPath, bunBinDir) && !isStandaloneRegularFile) {
+		if (managerOwnsBinEntry(ompRealpath, bunBinDir)) return "bun";
+	}
+	if (npmBinDir && isPathInDirectory(ompPath, npmBinDir) && !isStandaloneRegularFile) {
+		if (managerOwnsBinEntry(ompRealpath, npmBinDir)) return "npm";
+	} else if (isWindowsScriptLauncher) {
 		return "npm";
+	}
 	return "binary";
 }
 
@@ -552,10 +584,14 @@ async function resolveUpdateTarget(options: { allowPackageManagers: boolean }): 
 		// directory containment — distinguishes a binary install from npm/bun.
 		let ompIsRegularFile = false;
 		let ompIsSymlink = false;
+		let ompRealpath: string | undefined;
 		try {
 			const stat = fs.lstatSync(ompPath);
 			ompIsRegularFile = stat.isFile() && !stat.isSymbolicLink();
 			ompIsSymlink = stat.isSymbolicLink();
+			if (ompIsSymlink) {
+				ompRealpath = tryRealpath(ompPath);
+			}
 		} catch {}
 		const method = resolveUpdateMethod(ompPath, bunBinDir, {
 			homebrewPrefix,
@@ -563,8 +599,18 @@ async function resolveUpdateTarget(options: { allowPackageManagers: boolean }): 
 			miseDataDir,
 			npmBinDir,
 			ompIsRegularFile,
+			ompRealpath,
 		});
-		if (method === "binary") return { method, path: ompPath, replacesSymlink: ompIsSymlink };
+		// A binary install reached through an alias symlink replaces the
+		// resolved binary, not the link: writing to the alias path would strand
+		// the real binary at the old version and drop a second copy at the
+		// alias path. When package managers are off the table (binary-only
+		// release) the launcher itself is replaced in place instead, keeping
+		// the same PATH entry live.
+		if (method === "binary") {
+			const binaryPath = options.allowPackageManagers ? (ompRealpath ?? ompPath) : ompPath;
+			return { method, path: binaryPath, replacesSymlink: ompIsSymlink && binaryPath === ompPath };
+		}
 		if (method === "bun" || method === "npm") return { method, path: ompPath };
 		return { method };
 	}

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -187,6 +187,44 @@ describe("update-cli install target detection", () => {
 		expect(method).toBe("npm");
 	});
 
+	it("uses binary update when the npm global bin entry is a foreign alias symlink to a standalone binary", () => {
+		// Regression: a user-created alias (`~/.npm-global/bin/omp` ->
+		// `~/.local/bin/omp`) was classified as npm-managed by directory
+		// containment, so `npm install -g` failed with EEXIST refusing to
+		// clobber a bin entry it does not own.
+		const method = resolveUpdateMethodForTest("/home/u/.npm-global/bin/omp", undefined, {
+			npmBinDir: "/home/u/.npm-global/bin",
+			ompRealpath: "/home/u/.local/bin/omp",
+		});
+
+		expect(method).toBe("binary");
+	});
+
+	it("uses npm update when the bin symlink resolves into the npm global install tree", () => {
+		const method = resolveUpdateMethodForTest("/home/u/.npm-global/bin/omp", undefined, {
+			npmBinDir: "/home/u/.npm-global/bin",
+			ompRealpath: "/home/u/.npm-global/lib/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js",
+		});
+
+		expect(method).toBe("npm");
+	});
+
+	it("uses binary update when the bun global bin entry is a foreign alias symlink", () => {
+		const method = resolveUpdateMethodForTest("/home/u/.bun/bin/omp", "/home/u/.bun/bin", {
+			ompRealpath: "/home/u/.local/bin/omp",
+		});
+
+		expect(method).toBe("binary");
+	});
+
+	it("uses bun update when the bin symlink resolves into the bun global install tree", () => {
+		const method = resolveUpdateMethodForTest("/home/u/.bun/bin/omp", "/home/u/.bun/bin", {
+			ompRealpath: "/home/u/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js",
+		});
+
+		expect(method).toBe("bun");
+	});
+
 	it("uses binary update when prioritized omp is outside bun global bin", () => {
 		const method = resolveUpdateMethodForTest("/Users/test/.local/bin/omp", "/Users/test/.bun/bin");
 


### PR DESCRIPTION
Closes #8468.

## Changes

- A symlinked `omp` entry in the npm/bun global bin dir now counts as manager-managed only when its target resolves under that manager's root (npm prefix / bun root). Previously directory containment alone decided, so a user-created alias such as `~/.npm-global/bin/omp -> ~/.local/bin/omp` was routed to `npm install -g`, which refuses to clobber the foreign link (npm EEXIST).
- Foreign aliases fall through to a binary update of the **resolved** target, replacing the real binary and leaving the alias working, instead of overwriting the link and stranding the real binary at the old version.
- Forced binary-only releases (`allowPackageManagers: false`) keep replacing the launcher in place, preserving the same PATH entry.
- Added regression tests for foreign vs manager-owned symlinks in both npm and bun bin dirs.

## Verification

- `bun test test/update-cli.test.ts test/cli/update-cli.test.ts test/issue-845-repro.test.ts` — 74 passed, 0 failed (includes 5 new cases).
- `bun test test/cli/update-rename-migration.integration.test.ts` — 2 passed.
- `bun run check:types` clean in `packages/coding-agent`.
- Live repro on the reporter's setup (alias symlink ahead of the standalone binary in PATH, npm and bun both present): before the fix, `omp update` died with npm EEXIST; with the fix, `omp update --force` downloads `omp-linux-x64`, verifies the release SHA-256, replaces `~/.local/bin/omp`, and the alias reports the new version.