### PR TITLE
fix(coding-agent): filter Claude custom tool modules

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude Code custom tool discovery attempting to import non-module files from `.claude/tools`.
+
 ## [17.3.1] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Claude Code custom tool discovery attempting to import non-module files from `.claude/tools`.
+- Fixed Claude Code custom tool discovery attempting to import non-module files from `.claude/tools` ([#8471](https://github.com/can1357/oh-my-pi/pull/8471) by [@Kigbnajd](https://github.com/Kigbnajd)).
 
 ## [17.3.1] - 2026-08-13
 

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -406,8 +406,9 @@ async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
 	const userToolsDir = path.join(userBase, "tools");
 
 	const userResult = await loadFilesFromDir<CustomTool>(ctx, userToolsDir, PROVIDER_ID, "user", {
+		extensions: ["ts", "js"],
 		transform: (name, _content, path, source) => {
-			const toolName = name.replace(/\.(ts|js|sh|bash|py)$/, "");
+			const toolName = name.replace(/\.(ts|js)$/, "");
 			return {
 				name: toolName,
 				path,
@@ -425,8 +426,9 @@ async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
 	const projectToolsDir = path.join(projectBase, "tools");
 
 	const projectResult = await loadFilesFromDir<CustomTool>(ctx, projectToolsDir, PROVIDER_ID, "project", {
+		extensions: ["ts", "js"],
 		transform: (name, _content, path, source) => {
-			const toolName = name.replace(/\.(ts|js|sh|bash|py)$/, "");
+			const toolName = name.replace(/\.(ts|js)$/, "");
 			return {
 				name: toolName,
 				path,

--- a/packages/coding-agent/test/discovery/claude-tools.test.ts
+++ b/packages/coding-agent/test/discovery/claude-tools.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type CustomTool, toolCapability } from "@oh-my-pi/pi-coding-agent/capability/tool";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+describe("Claude Code custom tool discovery", () => {
+	let root = "";
+	let home = "";
+	let project = "";
+	let originalHome: string | undefined;
+	let originalClaudeConfigDir: string | undefined;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		originalHome = process.env.HOME;
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-claude-tools-"));
+		home = path.join(root, "home");
+		project = path.join(root, "project");
+		process.env.HOME = home;
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		await fs.mkdir(path.join(project, ".git"), { recursive: true });
+		const settings = await Settings.init({ inMemory: true, cwd: project });
+		initializeWithSettings(settings);
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		vi.restoreAllMocks();
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+		else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		await removeWithRetries(root);
+	});
+
+	test("discovers only JavaScript and TypeScript modules", async () => {
+		const userTools = path.join(home, ".claude", "tools");
+		const projectTools = path.join(project, ".claude", "tools");
+		await fs.mkdir(userTools, { recursive: true });
+		await fs.mkdir(projectTools, { recursive: true });
+		await Promise.all([
+			fs.writeFile(path.join(userTools, "user-tool.ts"), "export default () => ({});\n"),
+			fs.writeFile(path.join(projectTools, "project-tool.js"), "export default () => ({});\n"),
+			fs.writeFile(path.join(userTools, "helper.sh"), "#!/bin/sh\n"),
+			fs.writeFile(path.join(projectTools, "helper.bash"), "#!/bin/bash\n"),
+			fs.writeFile(path.join(projectTools, "helper.py"), "print('helper')\n"),
+			fs.writeFile(path.join(projectTools, "notes.md"), "# Notes\n"),
+		]);
+
+		const result = await loadCapability<CustomTool>(toolCapability.id, {
+			cwd: project,
+			providers: ["claude"],
+		});
+		const tools = result.items
+			.map(tool => ({ name: tool.name, level: tool.level }))
+			.sort((a, b) => a.name.localeCompare(b.name));
+
+		expect(result.warnings).toEqual([]);
+		expect(tools).toEqual([
+			{ name: "project-tool", level: "project" },
+			{ name: "user-tool", level: "user" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- restrict Claude Code custom tool discovery to TypeScript and JavaScript modules
- ignore shell, Python, Markdown, and other non-module files under `.claude/tools`
- add regression coverage for both user- and project-level discovery

## Contributor statement

only .ts/.js files in .claude/tools are discovered; shell/Python/Markdown files are ignored; the regression and coding-agent checks pass; the installed OMP startup smoke reached RPC ready without loader errors.

## Verification

- Before the fix: `bun test packages/coding-agent/test/discovery/claude-tools.test.ts` failed because `.sh`, `.bash`, `.py`, and `.md` files were surfaced as custom tools.
- After the fix: `bun test test/discovery/claude-tools.test.ts test/discovery/claude-commands.test.ts` — 4 passed, 0 failed.
- `bun run check` in `packages/coding-agent` — Biome checked 2,610 files; `tsgo -p tsconfig.json --noEmit` passed.
- Built and installed the corrected bundle, then launched OMP in RPC mode with `disabledExtensions: []` and both a valid `.ts` tool and a sibling `.sh` helper. Startup reached the RPC `ready` frame; process output and the process log contained no custom-tool loader error.