### PR TITLE
fix(coding-agent): route foreign aliases to binary updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp update` routing foreign npm/bun bin-directory alias symlinks through the package manager, causing npm EEXIST instead of updating the aliased standalone binary ([#8468](https://github.com/can1357/oh-my-pi/issues/8468)).
+
 ## [17.3.1] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -481,6 +481,11 @@ interface UpdateMethodResolutionOptions {
 	 * target directory.
 	 */
 	ompIsRegularFile?: boolean;
+	/**
+	 * Resolved symlink target. npm/bun own links into their manager root;
+	 * targets elsewhere are foreign aliases that must update as binaries.
+	 */
+	ompRealpath?: string;
 }
 
 type UpdateTarget =
@@ -496,7 +501,7 @@ function resolveUpdateMethod(
 	bunBinDir: string | undefined,
 	options: UpdateMethodResolutionOptions = {},
 ): UpdateMethod {
-	const { homebrewPrefix, miseBinDirs = [], miseDataDir, npmBinDir, ompIsRegularFile = false } = options;
+	const { homebrewPrefix, miseBinDirs = [], miseDataDir, npmBinDir, ompIsRegularFile = false, ompRealpath } = options;
 	const launcherExtension = path.extname(ompPath).toLowerCase();
 	const isWindowsScriptLauncher =
 		launcherExtension === ".cmd" || launcherExtension === ".ps1" || launcherExtension === ".bat";
@@ -514,9 +519,31 @@ function resolveUpdateMethod(
 	// (bun's .exe launcher, npm's .cmd/.ps1), so a regular file is NOT evidence
 	// of a standalone install and the override would hijack managed installs.
 	const isStandaloneRegularFile = ompIsRegularFile && process.platform !== "win32";
-	if (bunBinDir && isPathInDirectory(ompPath, bunBinDir) && !isStandaloneRegularFile) return "bun";
-	if ((npmBinDir && isPathInDirectory(ompPath, npmBinDir) && !isStandaloneRegularFile) || isWindowsScriptLauncher)
+	if (
+		bunBinDir &&
+		isPathInDirectory(ompPath, bunBinDir) &&
+		!isStandaloneRegularFile &&
+		(!ompRealpath ||
+			isPathInDirectoryLexical(
+				ompRealpath,
+				tryRealpath(path.dirname(bunBinDir)) ?? path.dirname(path.resolve(bunBinDir)),
+			))
+	) {
+		return "bun";
+	}
+	if (
+		npmBinDir &&
+		isPathInDirectory(ompPath, npmBinDir) &&
+		!isStandaloneRegularFile &&
+		(!ompRealpath ||
+			isPathInDirectoryLexical(
+				ompRealpath,
+				tryRealpath(path.dirname(npmBinDir)) ?? path.dirname(path.resolve(npmBinDir)),
+			))
+	) {
 		return "npm";
+	}
+	if (isWindowsScriptLauncher) return "npm";
 	return "binary";
 }
 
@@ -526,6 +553,33 @@ export function resolveUpdateMethodForTest(
 	options: UpdateMethodResolutionOptions = {},
 ): UpdateMethod {
 	return resolveUpdateMethod(ompPath, bunBinDir, options);
+}
+
+/** Resolve an install target from a concrete PATH entry without probing package managers. */
+export function resolveUpdateTargetFromPathForTest(
+	ompPath: string,
+	bunBinDir: string | undefined,
+	options: UpdateMethodResolutionOptions & { allowPackageManagers: boolean },
+): UpdateTarget {
+	let ompIsRegularFile = false;
+	let ompIsSymlink = false;
+	let ompRealpath: string | undefined;
+	try {
+		const stat = fs.lstatSync(ompPath);
+		ompIsRegularFile = stat.isFile() && !stat.isSymbolicLink();
+		ompIsSymlink = stat.isSymbolicLink();
+		if (ompIsSymlink) ompRealpath = tryRealpath(ompPath);
+	} catch {}
+	const method = resolveUpdateMethod(ompPath, bunBinDir, { ...options, ompIsRegularFile, ompRealpath });
+	if (method === "binary") {
+		// Preserve a foreign alias and replace the standalone binary it
+		// resolves to. Binary-only releases still replace manager launchers
+		// in place because package-manager detection is intentionally off.
+		const binaryPath = options.allowPackageManagers ? (ompRealpath ?? ompPath) : ompPath;
+		return { method, path: binaryPath, replacesSymlink: ompIsSymlink && binaryPath === ompPath };
+	}
+	if (method === "bun" || method === "npm") return { method, path: ompPath };
+	return { method };
 }
 /**
  * Resolve how the running install should be updated.
@@ -546,27 +600,13 @@ async function resolveUpdateTarget(options: { allowPackageManagers: boolean }): 
 	const ompPath = resolveOmpPath();
 
 	if (ompPath) {
-		// Package-manager installs symlink the bin entry into node_modules; the
-		// standalone installer writes a plain executable. When the global bin dir
-		// overlaps the installer's default (~/.local/bin), that file type — not
-		// directory containment — distinguishes a binary install from npm/bun.
-		let ompIsRegularFile = false;
-		let ompIsSymlink = false;
-		try {
-			const stat = fs.lstatSync(ompPath);
-			ompIsRegularFile = stat.isFile() && !stat.isSymbolicLink();
-			ompIsSymlink = stat.isSymbolicLink();
-		} catch {}
-		const method = resolveUpdateMethod(ompPath, bunBinDir, {
+		return resolveUpdateTargetFromPathForTest(ompPath, bunBinDir, {
+			allowPackageManagers: options.allowPackageManagers,
 			homebrewPrefix,
 			miseBinDirs,
 			miseDataDir,
 			npmBinDir,
-			ompIsRegularFile,
 		});
-		if (method === "binary") return { method, path: ompPath, replacesSymlink: ompIsSymlink };
-		if (method === "bun" || method === "npm") return { method, path: ompPath };
-		return { method };
 	}
 
 	if (bunBinDir) return { method: "bun" };

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -26,6 +26,7 @@ import {
 	resolveReleaseDist,
 	resolveReleaseRename,
 	resolveUpdateMethodForTest,
+	resolveUpdateTargetFromPathForTest,
 	shouldForceBinaryUpdate,
 	sweepStaleUpdateArtifacts,
 	updateViaBinaryAt,
@@ -185,6 +186,50 @@ describe("update-cli install target detection", () => {
 		});
 
 		expect(method).toBe("npm");
+	});
+
+	it("updates the resolved standalone binary behind a foreign npm-bin alias", async () => {
+		const dir = await makeTempDir();
+		const npmBinDir = path.join(dir, ".npm-global", "bin");
+		const standalonePath = path.join(dir, ".local", "bin", "omp");
+		const aliasPath = path.join(npmBinDir, "omp");
+		await fs.mkdir(npmBinDir, { recursive: true });
+		await fs.mkdir(path.dirname(standalonePath), { recursive: true });
+		await Bun.write(standalonePath, "binary");
+		await fs.symlink(standalonePath, aliasPath);
+
+		const target = resolveUpdateTargetFromPathForTest(aliasPath, undefined, {
+			allowPackageManagers: true,
+			npmBinDir,
+		});
+
+		expect(target).toEqual({ method: "binary", path: standalonePath, replacesSymlink: false });
+		expect(await fs.readlink(aliasPath)).toBe(standalonePath);
+	});
+
+	it("uses npm update when the bin symlink resolves into npm's global install tree", () => {
+		const method = resolveUpdateMethodForTest("/home/u/.npm-global/bin/omp", undefined, {
+			npmBinDir: "/home/u/.npm-global/bin",
+			ompRealpath: "/home/u/.npm-global/lib/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js",
+		});
+
+		expect(method).toBe("npm");
+	});
+
+	it("uses binary update when the bun global bin entry is a foreign alias symlink", () => {
+		const method = resolveUpdateMethodForTest("/home/u/.bun/bin/omp", "/home/u/.bun/bin", {
+			ompRealpath: "/home/u/.local/bin/omp",
+		});
+
+		expect(method).toBe("binary");
+	});
+
+	it("uses bun update when the bin symlink resolves into bun's global install tree", () => {
+		const method = resolveUpdateMethodForTest("/home/u/.bun/bin/omp", "/home/u/.bun/bin", {
+			ompRealpath: "/home/u/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js",
+		});
+
+		expect(method).toBe("bun");
 	});
 
 	it("uses binary update when prioritized omp is outside bun global bin", () => {


### PR DESCRIPTION
## Repro

Create a standalone `~/.local/bin/omp`, link `~/.npm-global/bin/omp` to it, put the npm bin first in PATH, then run `omp update`; the resolver selected npm and `npm install -g` failed with EEXIST. The focused reproduction constructed those paths and called `resolveUpdateMethodForTest()`, which returned `npm` before this change.

## Cause

`packages/coding-agent/src/cli/update-cli.ts` classified npm/bun ownership from lexical bin-directory containment. `isPathInDirectory()` therefore accepted a user-created alias before considering that its resolved target lived outside the package-manager root.

## Fix

- Resolve PATH-entry symlinks and require manager-owned aliases to target the npm/bun manager root.
- Route foreign aliases to binary replacement at their resolved target, preserving the alias.
- Add regression coverage for foreign and manager-owned npm/bun links and document the fix.

## Verification

`bun test test/update-cli.test.ts` from `packages/coding-agent`: 69 passed, 0 failed. The pre-publish gate also completed successfully.

Fixes #8468