### PR TITLE
fix(hindsight): retain final session turns on exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Hindsight auto-retention dropping the final partial turn window when a session exits before reaching its configured retention cadence.
+
 ## [17.3.1] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/hindsight/backend.ts
+++ b/packages/coding-agent/src/hindsight/backend.ts
@@ -17,6 +17,7 @@ import { createHindsightClient } from "./client";
 import { isHindsightConfigured, loadHindsightConfig } from "./config";
 import { type HindsightMessage, hasSubstantiveContent } from "./content";
 import { HindsightSessionState } from "./state";
+import { extractMessages } from "./transcript";
 
 const STATIC_INSTRUCTIONS = [
 	"# Memory",
@@ -236,7 +237,9 @@ async function installPrimaryState(
 		config,
 		session,
 		banksSet,
-		lastRetainedTurn: 0,
+		lastRetainedTurn:
+			previous?.lastRetainedTurn ??
+			extractMessages(session.sessionManager).filter(message => message.role === "user").length,
 		hasRecalledForFirstTurn: false,
 	});
 

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -369,12 +369,14 @@ export class HindsightSessionState {
 	}
 
 	/**
-	 * Wait for any turn-boundary retain, then persist the final partial cadence
-	 * window before the session state is detached during disposal.
+	 * Serialize the final partial-window retain with turn-boundary retains.
+	 * Disposal calls this only after the agent/event pipeline has drained, so
+	 * the snapshot includes the terminal assistant message.
 	 */
-	async flushAutoRetainOnDispose(): Promise<void> {
-		await this.#autoRetainTail;
-		await this.#retainIfDue(true);
+	flushAutoRetainOnDispose(): Promise<void> {
+		const run = this.#autoRetainTail.then(() => this.#retainIfDue(true));
+		this.#autoRetainTail = run;
+		return run;
 	}
 
 	async #retainIfDue(flushPartialWindow: boolean): Promise<void> {

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -246,6 +246,7 @@ export class HindsightSessionState {
 	/** Alias states delegate persistence config to a primary parent state. */
 	aliasOf?: HindsightSessionState;
 	readonly retainQueue: HindsightRetainQueue;
+	#autoRetainTail: Promise<void> = Promise.resolve();
 
 	constructor(options: HindsightSessionStateOptions) {
 		this.sessionId = options.sessionId;
@@ -361,12 +362,28 @@ export class HindsightSessionState {
 		}
 	}
 
-	async maybeRetainOnAgentEnd(): Promise<void> {
-		if (!this.config.autoRetain) return;
+	maybeRetainOnAgentEnd(): Promise<void> {
+		const run = this.#autoRetainTail.then(() => this.#retainIfDue(false));
+		this.#autoRetainTail = run;
+		return run;
+	}
+
+	/**
+	 * Wait for any turn-boundary retain, then persist the final partial cadence
+	 * window before the session state is detached during disposal.
+	 */
+	async flushAutoRetainOnDispose(): Promise<void> {
+		await this.#autoRetainTail;
+		await this.#retainIfDue(true);
+	}
+
+	async #retainIfDue(flushPartialWindow: boolean): Promise<void> {
+		if (!this.config.autoRetain || this.aliasOf) return;
 		const messages = extractMessages(this.session.sessionManager);
 		if (messages.length === 0) return;
 		const userTurns = messages.filter(m => m.role === "user").length;
-		if (userTurns - this.lastRetainedTurn < this.config.retainEveryNTurns) return;
+		const pendingTurns = userTurns - this.lastRetainedTurn;
+		if (pendingTurns <= 0 || (!flushPartialWindow && pendingTurns < this.config.retainEveryNTurns)) return;
 
 		try {
 			await this.retainSession(messages);
@@ -377,6 +394,7 @@ export class HindsightSessionState {
 					bankId: this.bankId,
 					userTurns,
 					messages: messages.length,
+					flushPartialWindow,
 				});
 			}
 		} catch (err) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3922,8 +3922,6 @@ export class AgentSession {
 			shutdownTinyTitleClient(),
 			this.#disconnectOwnedMcp(),
 			advisorRecorderClosed,
-			hindsightState?.flushAutoRetainOnDispose() ?? Promise.resolve(),
-			hindsightState?.flushRetainQueue() ?? Promise.resolve(),
 			this.#disposeMnemopi(mnemopiState, options.mnemopiConsolidateTimeoutMs),
 		]);
 		for (const result of results) {
@@ -3938,8 +3936,6 @@ export class AgentSession {
 		await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
 		this.#movedFromEmptySessionFile = undefined;
 		this.#closeAllProviderSessions("dispose");
-		this.setHindsightSessionState(undefined);
-		hindsightState?.dispose();
 		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();
@@ -3977,6 +3973,19 @@ export class AgentSession {
 		} catch (error) {
 			logger.warn("Active agent run still settling at dispose deadline", { error: String(error) });
 		}
+		const hindsightResults = await Promise.allSettled([
+			hindsightState?.flushAutoRetainOnDispose() ?? Promise.resolve(),
+			hindsightState?.flushRetainQueue() ?? Promise.resolve(),
+		]);
+		for (const result of hindsightResults) {
+			if (result.status === "rejected") {
+				logger.warn("Hindsight session finalization failed during dispose", {
+					error: String(result.reason),
+				});
+			}
+		}
+		this.setHindsightSessionState(undefined);
+		hindsightState?.dispose();
 
 		// Event handlers can reopen the append writer while they persist their
 		// terminal message; that pipeline has drained (or hit the deadline).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3922,6 +3922,7 @@ export class AgentSession {
 			shutdownTinyTitleClient(),
 			this.#disconnectOwnedMcp(),
 			advisorRecorderClosed,
+			hindsightState?.flushAutoRetainOnDispose() ?? Promise.resolve(),
 			hindsightState?.flushRetainQueue() ?? Promise.resolve(),
 			this.#disposeMnemopi(mnemopiState, options.mnemopiConsolidateTimeoutMs),
 		]);

--- a/packages/coding-agent/test/agent-session-dispose-releases-memory.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-releases-memory.test.ts
@@ -9,6 +9,8 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { hindsightBackend } from "@oh-my-pi/pi-coding-agent/hindsight/backend";
+import { HindsightApi } from "@oh-my-pi/pi-coding-agent/hindsight/client";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -268,6 +270,101 @@ describe("AgentSession dispose releases retained memory", () => {
 		expect(closeSpy).toHaveBeenCalledTimes(1);
 		expect(current.sessionManager.getEntries()).toHaveLength(0);
 		expect(current.agent.state.messages).toHaveLength(0);
+	});
+
+	it("retains the terminal assistant message after draining its persistence handler", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected bundled model");
+		const mock = createMockModel({ handler: () => ({ content: ["ok"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+			"hindsight.autoRetain": true,
+			"hindsight.retainEveryNTurns": 2,
+		});
+		const reached = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const runtime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => {
+				pi.on("message_end", async () => {
+					reached.resolve();
+					await release.promise;
+				});
+			},
+			tempDir.path(),
+			new EventBus(),
+			runtime,
+			"block-terminal-message-persistence",
+		);
+		const extensionRunner = new ExtensionRunner([extension], runtime, tempDir.path(), sessionManager, modelRegistry);
+		const current = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			agentId: "Main",
+			extensionRunner,
+		});
+		session = current;
+
+		const retainSpy = vi.spyOn(HindsightApi.prototype, "retain").mockResolvedValue({} as never);
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+		await hindsightBackend.start({
+			session: current,
+			settings,
+			modelRegistry,
+			agentDir: tempDir.path(),
+			taskDepth: 0,
+		});
+		current.sessionManager.appendMessage({
+			role: "user",
+			content: "retain this final interrupted turn",
+			timestamp: Date.now(),
+		});
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "terminal assistant content persisted during disposal" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			timestamp: Date.now(),
+		};
+		current.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+		await reached.promise;
+
+		const drainStarted = Promise.withResolvers<void>();
+		const detach = current.agent.setProviderResponseInterceptor.bind(current.agent);
+		vi.spyOn(current.agent, "setProviderResponseInterceptor").mockImplementation(interceptor => {
+			detach(interceptor);
+			if (interceptor === undefined) drainStarted.resolve();
+		});
+		const disposeP = current.dispose();
+		await drainStarted.promise;
+		expect(retainSpy).not.toHaveBeenCalled();
+
+		release.resolve();
+		await disposeP;
+		session = undefined;
+
+		expect(retainSpy).toHaveBeenCalledTimes(1);
+		expect(retainSpy.mock.calls[0]?.[1]).toContain("terminal assistant content persisted during disposal");
 	});
 
 	it("re-finalizes after the drain deadline so a late persist cannot repopulate the session", async () => {

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -866,6 +866,39 @@ describe("hindsightBackend retain queue flush on session teardown", () => {
 	// state. We defend the contract end-to-end by enqueuing a tool-initiated
 	// retain, then calling `flushRetainQueue` in the order
 	// `AgentSession.dispose` uses (flush → clear → state.dispose).
+	it("retains the final partial cadence window before session teardown", async () => {
+		const retainSpy = vi.spyOn(HindsightApi.prototype, "retain").mockResolvedValue({} as never);
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+			"hindsight.retainEveryNTurns": 2,
+		});
+		const entries = [
+			{ role: "user" as const, text: "one-turn sessions must still be retained on exit" },
+			{ role: "assistant" as const, text: "the partial cadence window is durable" },
+		];
+		const session = makeFakeSession({ sessionId: "s-dispose-auto-retain", settings, entries });
+
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = session.getHindsightSessionState();
+
+		session.emit({ type: "agent_end", messages: [] });
+		await state!.flushAutoRetainOnDispose();
+
+		expect(retainSpy).toHaveBeenCalledTimes(1);
+		expect(retainSpy.mock.calls[0]?.[0]).toBe(state!.bankId);
+		expect(retainSpy.mock.calls[0]?.[1]).toContain("one-turn sessions must still be retained on exit");
+		expect(state!.lastRetainedTurn).toBe(1);
+	});
+
 	it("flushes the retain queue to the server before the session pointer clears", async () => {
 		const retainBatchSpy = vi.spyOn(HindsightApi.prototype, "retainBatch").mockResolvedValue({} as never);
 		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -761,10 +761,7 @@ describe("hindsightBackend live bank routing", () => {
 		});
 		settings.set("hindsight.bankId", "omp");
 		settings.set("hindsight.scoping", "global");
-		const entries = [
-			{ role: "user" as const, text: "remember this routing coalesce fact" },
-			{ role: "assistant" as const, text: "acknowledged routing coalesce fact" },
-		];
+		const entries: Array<{ role: "user" | "assistant"; text: string }> = [];
 		const session = makeFakeSession({ sessionId: "s-coalesce", cwd: "/work/proj", entries, settings });
 
 		await hindsightBackend.start({
@@ -787,6 +784,10 @@ describe("hindsightBackend live bank routing", () => {
 		const next = session.getHindsightSessionState();
 		expect(next?.bankId).toBe("live-Minigames-proj");
 		expect(session.listenerCount()).toBe(1);
+		entries.push(
+			{ role: "user", text: "remember this routing coalesce fact" },
+			{ role: "assistant", text: "acknowledged routing coalesce fact" },
+		);
 
 		session.emit({ type: "agent_end", messages: [] });
 		await Bun.sleep(0);
@@ -875,10 +876,7 @@ describe("hindsightBackend retain queue flush on session teardown", () => {
 			"hindsight.apiUrl": "http://localhost:8888",
 			"hindsight.retainEveryNTurns": 2,
 		});
-		const entries = [
-			{ role: "user" as const, text: "one-turn sessions must still be retained on exit" },
-			{ role: "assistant" as const, text: "the partial cadence window is durable" },
-		];
+		const entries: Array<{ role: "user" | "assistant"; text: string }> = [];
 		const session = makeFakeSession({ sessionId: "s-dispose-auto-retain", settings, entries });
 
 		await hindsightBackend.start({
@@ -889,6 +887,10 @@ describe("hindsightBackend retain queue flush on session teardown", () => {
 			taskDepth: 0,
 		});
 		const state = session.getHindsightSessionState();
+		entries.push(
+			{ role: "user", text: "one-turn sessions must still be retained on exit" },
+			{ role: "assistant", text: "the partial cadence window is durable" },
+		);
 
 		session.emit({ type: "agent_end", messages: [] });
 		await state!.flushAutoRetainOnDispose();
@@ -897,6 +899,82 @@ describe("hindsightBackend retain queue flush on session teardown", () => {
 		expect(retainSpy.mock.calls[0]?.[0]).toBe(state!.bankId);
 		expect(retainSpy.mock.calls[0]?.[1]).toContain("one-turn sessions must still be retained on exit");
 		expect(state!.lastRetainedTurn).toBe(1);
+	});
+
+	it("does not re-retain a resumed transcript until a new user turn arrives", async () => {
+		const retainSpy = vi.spyOn(HindsightApi.prototype, "retain").mockResolvedValue({} as never);
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+			"hindsight.retainEveryNTurns": 2,
+		});
+		const entries = [
+			{ role: "user" as const, text: "historical user turn" },
+			{ role: "assistant" as const, text: "historical assistant reply" },
+		];
+		const session = makeFakeSession({ sessionId: "s-resumed-auto-retain", settings, entries });
+
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = session.getHindsightSessionState();
+
+		await state!.flushAutoRetainOnDispose();
+		expect(retainSpy).not.toHaveBeenCalled();
+
+		entries.push({ role: "user", text: "new user turn after resume" });
+		entries.push({ role: "assistant", text: "new assistant reply after resume" });
+		await state!.flushAutoRetainOnDispose();
+
+		expect(retainSpy).toHaveBeenCalledTimes(1);
+		expect(retainSpy.mock.calls[0]?.[1]).toContain("new assistant reply after resume");
+	});
+
+	it("serializes a disposal flush with a concurrently queued agent-end retain", async () => {
+		const retainStarted = Promise.withResolvers<void>();
+		const releaseRetain = Promise.withResolvers<void>();
+		const retainSpy = vi.spyOn(HindsightApi.prototype, "retain").mockImplementation(async () => {
+			retainStarted.resolve();
+			await releaseRetain.promise;
+			return {} as never;
+		});
+		vi.spyOn(HindsightApi.prototype, "createBank").mockResolvedValue({} as never);
+
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+			"hindsight.retainEveryNTurns": 2,
+		});
+		const entries: Array<{ role: "user" | "assistant"; text: string }> = [];
+		const session = makeFakeSession({ sessionId: "s-concurrent-auto-retain", settings, entries });
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+		const state = session.getHindsightSessionState();
+		entries.push(
+			{ role: "user", text: "first user turn" },
+			{ role: "assistant", text: "first assistant reply" },
+			{ role: "user", text: "second user turn" },
+			{ role: "assistant", text: "second assistant reply" },
+		);
+
+		const flushing = state!.flushAutoRetainOnDispose();
+		const cadence = state!.maybeRetainOnAgentEnd();
+		await retainStarted.promise;
+		expect(retainSpy).toHaveBeenCalledTimes(1);
+		releaseRetain.resolve();
+		await Promise.all([flushing, cadence]);
+		expect(retainSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("flushes the retain queue to the server before the session pointer clears", async () => {


### PR DESCRIPTION
## Problem

Hindsight auto-retain only runs after `hindsight.retainEveryNTurns` user turns. A session that exits with a partial cadence window silently drops those final turns. The `agent_end` listener is fire-and-forget, so disposal must wait for the terminal event/persistence pipeline and serialize the final retain with any cadence retain.

## Change

- drain the active agent run and in-flight event/persistence handlers before the final Hindsight retain
- serialize turn-boundary and disposal retains through one promise tail
- baseline resumed transcripts at their existing user-turn count so resume-and-exit does not duplicate historical windows
- retain a non-empty final partial cadence window before detaching the Hindsight state
- cover the real `AgentSession.dispose()` path with a terminal `message_end` blocked before persistence

## Verification

- `bun test packages/coding-agent/test/hindsight-backend.test.ts packages/coding-agent/test/agent-session-dispose-releases-memory.test.ts` — 37 passed
- `bun --cwd=packages/coding-agent run check` — Biome clean; `tsgo` clean
- mutation proof: restoring all three defects made the three focused regressions fail (0 passed, 3 failed); restoring the fix returned 37/37 green
