### PR TITLE
fix(ai): classify DashScope/Bailian 429 TPM throttle as transient instead of quota exhaustion

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Alibaba DashScope/Bailian per-minute token throttle (`429 Throttling.AllocationQuota`, "You exceeded your current quota, please check your plan and billing details. … error-code#token-limit", `type=insufficient_quota`) being misclassified as `QUOTA_EXHAUSTED`. The OpenAI-compatible billing wording (and the `insufficient_quota` payload code) matched the usage-limit classifier, so a transient TPM/TPS cap — which Bailian's docs document as clearing within the minute window — blocked the credential and stalled the session for the 30-minute quota backoff instead of retrying with a short backoff on the same credential. Bodies linking the `error-code#token-limit` anchor now classify as `RATE_LIMIT_EXCEEDED` and stay in the transient lane; the identical wording without the anchor (OpenAI's real account-quota error) is unchanged.
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -9,6 +9,7 @@ import {
 } from "./classes";
 import {
 	isAccountScopedCapText,
+	isDashScopeTokenLimitText,
 	isOpaqueStatusBody,
 	isUsageLimitStatus,
 	matchesUsageLimitText,
@@ -431,7 +432,10 @@ export function classify(error: unknown, api?: Api): number {
 		} else if (link instanceof ProviderHttpError) {
 			let linkKinds = 0;
 			const { status: codeStatus, code } = link;
-			if (code === "usage_limit_reached" || code === "insufficient_quota") {
+			if (
+				code === "usage_limit_reached" ||
+				(code === "insufficient_quota" && !isDashScopeTokenLimitText(link.message))
+			) {
 				linkKinds |= Flag.UsageLimit;
 			}
 			if (code === "overloaded_error" || code === "rate_limit_error") {

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -66,12 +66,30 @@ const CN_TRANSIENT_CAP_PATTERN =
 // isOpaqueStatusBody so CN transients stay in the provider backoff lane instead
 // of rotating through the opaque-429 fallback.
 const CN_THROTTLE_PATTERN = /速率(?:限制|过快)|频率(?:过高|过快)|过于频繁|稍后[重再]试/;
+// DashScope / Bailian (Alibaba Model Studio) reports its per-minute token
+// throttle (429 Throttling.AllocationQuota, type `insufficient_quota`) with
+// OpenAI-compatible billing wording — "You exceeded your current quota,
+// please check your plan and billing details. … (type=insufficient_quota
+// param=insufficient_quota)" — but links the error-code doc's `token-limit`
+// anchor. Per that doc section the error is a transient TPM/TPS cap that
+// clears within the minute window, not an account-local quota exhaustion.
+// Classified RATE_LIMIT_EXCEEDED and excluded from the usage-limit lane so
+// the session retries with a short backoff on the same credential instead of
+// the 30-minute QUOTA_EXHAUSTED credential block. The identical wording
+// WITHOUT the anchor stays quota-exhausted (OpenAI's real account-quota
+// error uses the same sentence).
+const DASHSCOPE_TOKEN_LIMIT_PATTERN = /model-studio\/error-code[^()\s]*#token-limit|error-code[^()\s]*#token-limit/i;
+/** True for DashScope/Bailian's TPM/TPS throttle wording (see {@link DASHSCOPE_TOKEN_LIMIT_PATTERN}). */
+export function isDashScopeTokenLimitText(errorMessage: string): boolean {
+	return DASHSCOPE_TOKEN_LIMIT_PATTERN.test(errorMessage);
+}
 
 /**
  * Classify a rate-limit error message into a reason category.
  * Priority order: explicit details in a resource-exhausted error > QUOTA
- * (Antigravity "quota will reset") > CONCURRENT_LIMIT > MODEL_CAPACITY >
- * QUOTA (account) > RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > bare resource-exhausted > UNKNOWN.
+ * (Antigravity "quota will reset") > CN quota > DASHSCOPE_TOKEN_LIMIT (TPM/TPS
+ * throttle) > CONCURRENT_LIMIT > MODEL_CAPACITY > QUOTA (account) > RATE_LIMIT >
+ * QUOTA (generic) > SERVER_ERROR > bare resource-exhausted > UNKNOWN.
  *
  * Bare "resource exhausted" / "resource_exhausted" maps to MODEL_CAPACITY (transient, short wait).
  * Explicit details such as "quota exceeded" retain their normal classification.
@@ -95,6 +113,13 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	// account-local cap rotates instead of backing off as a transient.
 	if (CN_QUOTA_EXHAUSTED_PATTERN.test(errorMessage) && !CN_TRANSIENT_CAP_PATTERN.test(errorMessage)) {
 		return "QUOTA_EXHAUSTED";
+	}
+
+	// DashScope/Bailian TPM/TPS throttle: billing-worded like OpenAI's account
+	// quota, but the doc anchor marks it a per-minute token cap that clears on
+	// its own — short backoff on the same credential, never rotation/block.
+	if (isDashScopeTokenLimitText(errorMessage)) {
+		return "RATE_LIMIT_EXCEEDED";
 	}
 
 	if (CONCURRENT_LIMIT_PATTERN.test(errorMessage)) {
@@ -272,6 +297,7 @@ export function isOpaqueStatusBody(message: string): boolean {
  * {@link isUsageLimitOutcome} uses it for the account-rotation decision.
  */
 export function matchesUsageLimitText(errorMessage: string): boolean {
+	if (isDashScopeTokenLimitText(errorMessage)) return false;
 	return (
 		USAGE_LIMIT_PATTERN.test(errorMessage) ||
 		(CN_QUOTA_EXHAUSTED_PATTERN.test(errorMessage) && !CN_TRANSIENT_CAP_PATTERN.test(errorMessage)) ||

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -130,6 +130,30 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("API 使用频率已达上限")).toBe("UNKNOWN");
 	});
 
+	it("keeps DashScope/Bailian TPM throttle in the transient lane", () => {
+		// Bailian reports its per-minute token throttle (429
+		// Throttling.AllocationQuota) with OpenAI-compatible billing wording,
+		// but links the error-code doc's #token-limit anchor, which documents
+		// the error as a transient TPM/TPS cap (clears within the minute
+		// window). Must retry on the same credential with a short backoff —
+		// previously classified QUOTA_EXHAUSTED, blocking the credential for
+		// 30 minutes and stalling the session.
+		const throttle =
+			"429 You exceeded your current quota, please check your plan and billing details. For details, see: https://help.aliyun.com/zh/model-studio/error-code#token-limit\nYou exceeded your current quota, please check your plan and billing details. For details, see: https://help.aliyun.com/zh/model-studio/error-code#token-limit (type=insufficient_quota param=insufficient_quota)";
+		expect(parseRateLimitReason(throttle)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(isUsageLimit(throttle)).toBe(false);
+		expect(isUsageLimit(Object.assign(new Error(throttle), { status: 429 }))).toBe(false);
+		expect(isUsageLimit(new ProviderHttpError(throttle, 429, { code: "insufficient_quota" }))).toBe(false);
+		expect(isUsageLimitOutcome(429, throttle)).toBe(false);
+
+		// The identical wording WITHOUT the doc anchor is OpenAI's real
+		// account-quota error and stays quota-exhausted.
+		const openaiQuota =
+			"429 You exceeded your current quota, please check your plan and billing details. For details, see: https://platform.openai.com/account/usage (type=insufficient_quota)";
+		expect(parseRateLimitReason(openaiQuota)).toBe("QUOTA_EXHAUSTED");
+		expect(isUsageLimitOutcome(429, openaiQuota)).toBe(true);
+	});
+
 	it("classifies Codex usage limit error as QUOTA_EXHAUSTED", () => {
 		expect(
 			parseRateLimitReason("Codex error event: The usage limit has been reached (code=usage_limit_reached)"),


### PR DESCRIPTION
Bailian (Alibaba Model Studio / DashScope compatible-mode) sends its per-minute token throttle as `429 Throttling.AllocationQuota` using OpenAI-compatible billing wording — "You exceeded your current quota, please check your plan and billing details. … (type=insufficient_quota param=insufficient_quota)". That wording, plus the `insufficient_quota` payload code, matched the usage-limit classifiers on three independent paths (`matchesSubscriptionCapText`, the `quota` keyword arm of `parseRateLimitReason`, and the `ProviderHttpError.code` arm in `flags.ts`), so the error classified as `QUOTA_EXHAUSTED`: the credential was blocked and the session sat on the 30-minute quota backoff for what is actually a throttle that clears on its own. Bailian's own error-code docs — which the error body links to via the `error-code#token-limit` anchor — describe this exact 429 as a transient TPM/TPS cap that recovers within the minute window, and their rate-limit guidance says to retry with short backoff.

I hit this repeatedly running omp against Bailian free-tier models: one 429 parked the session for 30 minutes even though the same request succeeds again ~60s later. I reproduced the classification against the exact production error text, then A/B-tested the fix end-to-end against a mock Bailian endpoint: the patched build retries through a burst of 8 consecutive 429s (transport backoff ladder, then a 30s reason backoff) and completes; the unpatched build exhausts the transport retries and dies on the quota path.

The fix gates on the `error-code#token-limit` doc anchor that Bailian embeds in the error body: bodies carrying it classify as `RATE_LIMIT_EXCEEDED` and are excluded from the usage-limit lane, so the session retries with the short 30s reason backoff on the same credential instead of blocking it. The identical wording without the anchor — OpenAI's real account-quota error — still classifies `QUOTA_EXHAUSTED`, and all existing rotation/quota tests pass unchanged.


Fixes #8496
