### PR TITLE
test(coding-agent): stabilize activation timeout coverage

### DIFF
--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -1248,12 +1248,12 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			const unsubscribe = runner.onError(error => {
 				errors.push(error.error);
 			});
-			testSetExtensionHandlerTimeoutMs(10);
+			testSetExtensionHandlerTimeoutMs(250);
 
 			await runner.emit({ type: "session_start" });
 			unsubscribe();
 
-			expect(errors).toContain("handler timed out after 10ms");
+			expect(errors).toContain("handler timed out after 250ms");
 			expect(session.getToolByName("stalled_registration_tool")).toBeUndefined();
 			expect(session.getToolByName("recovered_registration_tool")?.label).toBe("recovered_registration_tool");
 			expect(session.getEnabledToolNames()).toContain("recovered_registration_tool");
@@ -1450,7 +1450,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 					await originalSetPresentation(toolNames, mountedToolNames, forcePromptRefresh, signal);
 					if (toolNames.includes("recovered_detached_tool")) recoveredActivation.resolve();
 				});
-			testSetExtensionHandlerTimeoutMs(10);
+			testSetExtensionHandlerTimeoutMs(250);
 
 			releaseStalledRegistration.resolve();
 			const failure = await detachedFailure.promise;


### PR DESCRIPTION
## What

- Restore the 250 ms timeout budget for the two SDK tool-activation recovery tests.
- Keep the asserted timeout message aligned with that budget.

## Why

The tests intentionally stall one activation, then require a healthy registration to succeed. Reducing their previously stabilized 250 ms budget to 10 ms also gave the healthy recovery path only 10 ms, so loaded CI could time out and roll back the valid registration. In the detached case, that left the success-only resolver pending until the test's 30-second timeout.

This restores the earlier test margin without changing the production 30-second handler timeout or runtime behavior.

## Testing

- Repeated both affected tests 50 times each: 100 passed, 0 failed.
- Ran the complete `sdk-tool-activation.test.ts`: 47 passed, 0 failed.
- Ran `bun --silent run check` in `packages/coding-agent`; Biome and `tsgo` passed.

I checked current issues and pull requests; no duplicate fix exists.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG not required (test-only)