### PR TITLE
fix(ai): fail over antigravity thinking-only STOP to sandbox

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Antigravity `auto` mode not failing over to the sandbox endpoint when the daily endpoint returned a thinking-only `STOP`, which caused Advisor turns to be falsely recorded as empty-response failures ([#8480](https://github.com/can1357/oh-my-pi/issues/8480)).
+
 ## [17.3.0] - 2026-08-13
 
 ### Breaking Changes

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -635,6 +635,11 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			const isFlashLeakModel = model.id.includes("flash");
 
 			let started = false;
+			// Tracks whether *visible* content (text delta or tool call) has been
+			// pushed downstream. `started` alone is a poor failover guard because a
+			// hidden thought part also flips it (via `ensureStarted`); a thinking-only
+			// STOP must still fail over to the alternate Antigravity endpoint (#8480).
+			let emittedVisibleContent = false;
 			let sawFinishReason = false;
 			let lastResponseId: string | undefined;
 			const ensureStarted = () => {
@@ -713,6 +718,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 
 				const emitVisibleText = (delta: string, thoughtSignature?: string): void => {
 					if (!delta) return;
+					emittedVisibleContent = true;
 					const block = startTextBlock();
 					block.text += delta;
 					block.textSignature = retainThoughtSignature(block.textSignature, thoughtSignature);
@@ -871,6 +877,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 								};
 
 								output.content.push(toolCall);
+								emittedVisibleContent = true;
 								ensureStarted();
 								pushToolCallEvents(toolCall, blockIndex(), output, stream);
 							}
@@ -944,6 +951,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				const isLastEndpoint = i === endpoints.length - 1;
 				try {
 					started = false;
+					emittedVisibleContent = false;
 					resetOutput();
 
 					// Per attempt: arm a pre-response (TTFT) timer, cleared the instant
@@ -1086,7 +1094,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					const status = extractHttpStatusFromError(error);
 					if (
 						!isLastEndpoint &&
-						!started &&
+						!emittedVisibleContent &&
 						(AIError.isTransientStatus(status) ||
 							(status === undefined &&
 								!(error instanceof AIError.ProviderResponseError && error.kind === "output") &&

--- a/packages/ai/test/google-empty-response-retry.test.ts
+++ b/packages/ai/test/google-empty-response-retry.test.ts
@@ -27,6 +27,24 @@ function ccaChunk(text: string): Record<string, unknown> {
 	return { response: genaiChunk(text) };
 }
 
+/**
+ * `{ response: { candidates } }` envelope carrying only a thinking part with `finishReason: STOP` —
+ * the intentional-silence Advisor case (#8480): no visible text and no tool call.
+ */
+function ccaThinkingOnlyChunk(thinking: string): Record<string, unknown> {
+	return {
+		response: {
+			candidates: [{ content: { parts: [{ text: thinking, thought: true }] }, finishReason: "STOP" }],
+			usageMetadata: {
+				promptTokenCount: 10,
+				candidatesTokenCount: 0,
+				thoughtsTokenCount: 5,
+				totalTokenCount: 15,
+			},
+		},
+	};
+}
+
 async function drain(stream: AsyncIterable<AssistantMessageEvent>) {
 	const events: AssistantMessageEvent[] = [];
 	for await (const event of stream) events.push(event);
@@ -382,6 +400,72 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 
 		// Daily still burns its empty-response budget and fails over; only the
 		// last (sandbox) endpoint records the empty STOP as valid silence.
+		expect(requestedEndpoints).toEqual([
+			ANTIGRAVITY_DAILY_ENDPOINT,
+			ANTIGRAVITY_DAILY_ENDPOINT,
+			ANTIGRAVITY_DAILY_ENDPOINT,
+			ANTIGRAVITY_SANDBOX_ENDPOINT,
+		]);
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+	});
+
+	it("fails over before accepting Advisor silence when daily returns a thinking-only STOP", async () => {
+		const requestedEndpoints: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const endpoint = endpointFromInput(input);
+			requestedEndpoints.push(endpoint);
+			const response =
+				endpoint === ANTIGRAVITY_SANDBOX_ENDPOINT
+					? sse(ccaChunk("Recovered."))
+					: sse(ccaThinkingOnlyChunk("No concrete risk. I will stay silent."));
+			return withResponseUrl(response, endpoint);
+		};
+
+		const stream = streamGoogleGeminiCli(antigravityModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			antigravityEndpointMode: "auto",
+			acceptEmptyResponse: true,
+			fetch: fetchMock,
+		});
+		const result = await stream.result();
+
+		expect({
+			requestedEndpoints,
+			stopReason: result.stopReason,
+			errorMessage: result.errorMessage,
+			text: textOf(result),
+		}).toEqual({
+			requestedEndpoints: [
+				ANTIGRAVITY_DAILY_ENDPOINT,
+				ANTIGRAVITY_DAILY_ENDPOINT,
+				ANTIGRAVITY_DAILY_ENDPOINT,
+				ANTIGRAVITY_SANDBOX_ENDPOINT,
+			],
+			stopReason: "stop",
+			errorMessage: undefined,
+			text: "Recovered.",
+		});
+	});
+
+	it("accepts thinking-only silence on the final endpoint when both endpoints stay silent", async () => {
+		const requestedEndpoints: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const endpoint = endpointFromInput(input);
+			requestedEndpoints.push(endpoint);
+			return withResponseUrl(sse(ccaThinkingOnlyChunk("Nothing to add. Staying silent.")), endpoint);
+		};
+
+		const stream = streamGoogleGeminiCli(antigravityModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			antigravityEndpointMode: "auto",
+			acceptEmptyResponse: true,
+			fetch: fetchMock,
+		});
+		const result = await stream.result();
+
+		// Daily burns its empty budget and fails over; the sandbox (final) endpoint
+		// records the thinking-only STOP as valid Advisor silence.
 		expect(requestedEndpoints).toEqual([
 			ANTIGRAVITY_DAILY_ENDPOINT,
 			ANTIGRAVITY_DAILY_ENDPOINT,


### PR DESCRIPTION
## Repro
Using `gemini-3.6-flash` as the Advisor through `google-antigravity` in `auto` mode, an intentional-silence turn (thinking-only text, `finishReason: STOP`, no visible content or tool call) on the daily endpoint was recorded as `advisor turn failed: Cloud Code Assist API returned an empty response` and the sandbox endpoint was never tried. Deterministic, network-free repro:
```
bun test packages/ai/test/google-empty-response-retry.test.ts --test-name-pattern 'thinking-only'
```
Before the fix this produced `requestedEndpoints = [daily, daily, daily]`, `stopReason = error`, `text = ""`.

## Cause
In `packages/ai/src/providers/google-gemini-cli.ts`, a thought part calls `startThinkingBlock()` → `ensureStarted()`, flipping `started = true`. The endpoint-failover catch guard gated on `!started`, so once the daily endpoint exhausted its empty-response budget the guard refused to fall over to the sandbox endpoint even though nothing visible or tool-call had been emitted. This is the gap left by #8226, whose `acceptEmptyResponse` failover only exercised a truly-empty daily response (where `started` stays `false`).

## Fix
- Added an `emittedVisibleContent` flag, set only when a visible text delta (`emitVisibleText`) or a tool call is pushed downstream — hidden thinking never sets it.
- Reset it per endpoint alongside `started`.
- Changed the failover catch guard from `!started` to `!emittedVisibleContent`, so a thinking-only STOP fails over while genuine partial visible output still blocks failover (terminal SAFETY/`kind:"output"` and HTTP-error paths are unaffected by the existing sub-conditions).

## Verification
`bun test packages/ai/test/google-empty-response-retry.test.ts` → 21 pass (including the reporter's `[daily, daily, daily, sandbox]` failover test plus a both-endpoints-silent case accepting sandbox silence). Also ran the related provider suites (`google-gemini-cli-3x-thinking`, `google-antigravity-usage`, `google-gemini-cli-first-event-timeout`, `google-thinking-signature`, `google-gemini-cli-alignment`, `google-gemini-cli-429`) → 77 pass. Fixes #8480