### PR TITLE
feat(antigravity): add Gemini 3.7 Flash model support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `gemini-3.7-flash` and `gemini-3.6-flash` to the `3-Flash` Gemini usage tier (`GEMINI_TIER_MAP`).
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/ai/src/usage/gemini.ts
+++ b/packages/ai/src/usage/gemini.ts
@@ -17,7 +17,7 @@ const DEFAULT_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const GEMINI_TIER_MAP: Array<{ tier: string; models: string[] }> = [
 	{
 		tier: "3-Flash",
-		models: ["gemini-3-flash-preview", "gemini-3-flash", "gemini-3.5-flash"],
+		models: ["gemini-3-flash-preview", "gemini-3-flash", "gemini-3.5-flash", "gemini-3.6-flash", "gemini-3.7-flash"],
 	},
 	{
 		tier: "Flash",
@@ -61,7 +61,7 @@ function getProjectId(payload: LoadCodeAssistResponse | undefined): string | und
 	return undefined;
 }
 
-function getModelTier(modelId: string): string | undefined {
+export function getModelTier(modelId: string): string | undefined {
 	for (const entry of GEMINI_TIER_MAP) {
 		if (entry.models.includes(modelId)) {
 			return entry.tier;

--- a/packages/ai/test/google-gemini-cli-variant-routing.test.ts
+++ b/packages/ai/test/google-gemini-cli-variant-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { Effort, type FetchImpl } from "@oh-my-pi/pi-ai";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { getModelTier } from "@oh-my-pi/pi-ai/usage/gemini";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
@@ -49,6 +50,33 @@ function collapsedFlashModel(): Model<"google-gemini-cli"> {
 				[Effort.High]: "gemini-3-flash-agent",
 			},
 			suppressWhenOff: true,
+		},
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_048_576,
+		maxTokens: 65_536,
+	} satisfies ModelSpec<"google-gemini-cli">);
+}
+
+function collapsedGemini37FlashModel(): Model<"google-gemini-cli"> {
+	return buildModel({
+		id: "gemini-3.7-flash",
+		requestModelId: "gemini-3.7-flash-low",
+		name: "Gemini 3.7 Flash",
+		api: "google-gemini-cli",
+		provider: "google-antigravity",
+		baseUrl: "https://daily-cloudcode-pa.googleapis.com",
+		reasoning: true,
+		thinking: {
+			mode: "google-level",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+			requiresEffort: true,
+			effortRouting: {
+				[Effort.Minimal]: "gemini-3.7-flash-low",
+				[Effort.Low]: "gemini-3.7-flash-low",
+				[Effort.Medium]: "gemini-3.7-flash-medium",
+				[Effort.High]: "gemini-3.7-flash-high",
+			},
 		},
 		input: ["text", "image"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -140,7 +168,19 @@ describe("google-gemini-cli effort-tier variant routing", () => {
 		expect(low.body.model).toBe("gemini-3.5-flash-extra-low");
 		expect(low.body.request?.generationConfig?.thinkingConfig?.thinkingBudget).toBe(1000);
 	});
+	it("routes gemini-3.7-flash to per-effort backing wire ids using level mode", async () => {
+		const high = await captureRequest(collapsedGemini37FlashModel(), Effort.High);
+		expect(high.body.model).toBe("gemini-3.7-flash-high");
+		expect(high.attributedModel).toBe("gemini-3.7-flash");
 
+		const medium = await captureRequest(collapsedGemini37FlashModel(), Effort.Medium);
+		expect(medium.body.model).toBe("gemini-3.7-flash-medium");
+	});
+
+	it("maps gemini-3.7-flash and gemini-3.6-flash to the 3-Flash tier in getModelTier", () => {
+		expect(getModelTier("gemini-3.7-flash")).toBe("3-Flash");
+		expect(getModelTier("gemini-3.6-flash")).toBe("3-Flash");
+	});
 	it("suppresses thinking with a zero budget on the wire when off and suppressWhenOff is set", async () => {
 		const off = await captureRequest(collapsedFlashModel(), undefined);
 		expect(off.body.model).toBe("gemini-3.5-flash-extra-low");

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `google-antigravity` bundled model spec for Gemini 3.7 Flash (`gemini-3.7-flash`).
+
 ## [17.3.2] - 2026-08-13
 
 ### Added

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -659,6 +659,7 @@ describe("Devin tier routing", () => {
 describe("variant aliases", () => {
 	it("resolves members and recycled ids per provider", () => {
 		expect(resolveVariantAlias("google-antigravity", "gemini-3.5-flash-low")).toBe("gemini-3.5-flash");
+		expect(resolveVariantAlias("google-antigravity", "gemini-3.7-flash-low")).toBe("gemini-3.7-flash");
 		expect(resolveVariantAlias("google-gemini-cli", "gemini-pro-agent")).toBe("gemini-3.1-pro");
 		expect(resolveVariantAlias("google-antigravity", "gemini-3-flash")).toBe("gemini-3.5-flash");
 		expect(resolveVariantAlias("google-antigravity", "gemini-2.5-flash-thinking")).toBe("gemini-2.5-flash");
@@ -679,9 +680,10 @@ describe("variant aliases", () => {
 		expect(sources).toContain("gemini-3.5-flash-extra-low");
 		expect(sources).toContain("gemini-3.5-flash-low");
 		expect(sources).toContain("gemini-3-flash");
+		const gemini37Sources = getVariantAliasSources("google-antigravity", "gemini-3.7-flash");
+		expect(gemini37Sources).toEqual(["gemini-3.7-flash-low", "gemini-3.7-flash-medium", "gemini-3.7-flash-high"]);
 		expect(getVariantAliasSources("openai", "gpt-4o")).toEqual([]);
 	});
-
 	it("scopes collapsed-spec detection to routing and hand-table families", () => {
 		const collapsed = collapseEffortVariants(
 			[memberSpec("gemini-3.5-flash-low")],


### PR DESCRIPTION
## Summary

Adds support for Gemini 3.7 Flash (`gemini-3.7-flash`) to the `google-antigravity` provider and updates Gemini usage tiering.

### Changes
- Updated `GEMINI_TIER_MAP` in `packages/ai/src/usage/gemini.ts` to map `gemini-3.7-flash` and `gemini-3.6-flash` to tier `3-Flash` and exported `getModelTier` for testability.
- Added unit test assertions covering `getModelTier` for `gemini-3.7-flash` and `gemini-3.6-flash` in `packages/ai/test/google-gemini-cli-variant-routing.test.ts`.
- Updated variant collapse tests in `packages/catalog/test/variant-collapse.test.ts` to test `resolveVariantAlias` and `getVariantAliasSources` for `gemini-3.7-flash`.
- Added `## [Unreleased]` changelog entries in `packages/catalog` and `packages/ai`.
- Rebased onto latest `main`.