### PR TITLE
fix(tools): preserve workspace-relative path in read hashline headers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read` hashline headers collapsing nested in-workspace paths to the bare basename, which let a same-basename file at the session cwd capture a verbatim follow-up `edit` and deterministically reject it with `hash is not from this session`. Headers now retain the workspace-relative path (e.g. `[src/settings.json#0063]`) ([#8482](https://github.com/can1357/oh-my-pi/issues/8482)).
+
 ## [17.3.1] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/tools/read-format.ts
+++ b/packages/coding-agent/src/tools/read-format.ts
@@ -37,16 +37,17 @@ export interface HashlineHeaderContext {
 }
 
 export function formatReadHashlineHeader(displayPath: string, tag: string): string {
-	// In-workspace reads collapse to the bare filename for brevity: the edit
-	// tool's snapshot-tag recovery rebinds a bare `[name#tag]` onto the in-tree
-	// file it uniquely names. Out-of-workspace reads can't lean on that —
-	// recovery refuses to redirect a write outside the cwd/sandbox
-	// (HashlineFilesystem.allowTagPathRecovery) — so an absolute displayPath
-	// must stay directly resolvable, otherwise the basename resolves against
-	// cwd, misses, and the edit fails with "File not found" (e.g. ~/.claude/*).
-	// `shortenPath` keeps `~/.claude/...` (round-trips through resolveToCwd's ~
-	// expansion) instead of leaking the full home path into the read output.
-	const anchor = path.isAbsolute(displayPath) ? shortenPath(displayPath) : path.basename(displayPath);
+	// In-workspace reads keep their workspace-relative path (e.g.
+	// `src/settings.json`), not just the basename: collapsing to the bare name
+	// made a header ambiguous whenever another same-named file exists at cwd —
+	// the edit tool would resolve the bare name against cwd, hit the wrong
+	// file, and reject the valid edit via the snapshot-tag guard (the authored
+	// path exists, so Patcher's tag-path recovery never runs). The relative
+	// path stays directly resolvable against cwd and names the file uniquely.
+	// Out-of-workspace reads use an absolute displayPath; `shortenPath` keeps
+	// `~/.claude/...` (round-trips through resolveToCwd's ~ expansion) instead
+	// of leaking the full home path into the read output.
+	const anchor = path.isAbsolute(displayPath) ? shortenPath(displayPath) : displayPath;
 	return formatHashlineHeader(anchor, tag);
 }
 

--- a/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
+++ b/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
@@ -96,16 +96,24 @@ describe("read → edit round-trip for out-of-cwd files", () => {
 		expect(await Bun.file(outFile).text()).toBe("ALPHA\nbeta\n");
 	});
 
-	it("still collapses an in-cwd read header to the bare filename", async () => {
-		const inFile = path.join(cwdDir, "src", "settings.json");
-		await fs.mkdir(path.dirname(inFile), { recursive: true });
-		await fs.writeFile(inFile, "alpha\nbeta\n");
+	it("keeps an in-cwd relative path so an existing basename cannot capture a follow-up edit", async () => {
+		const rootFile = path.join(cwdDir, "settings.json");
+		const nestedFile = path.join(cwdDir, "src", "settings.json");
+		await fs.mkdir(path.dirname(nestedFile), { recursive: true });
+		await Promise.all([fs.writeFile(rootFile, "root\n"), fs.writeFile(nestedFile, "alpha\nbeta\n")]);
 
 		const session = createSession(cwdDir);
-		const header = textOutput(await new ReadTool(session).execute("read-in", { path: inFile })).split("\n")[0];
+		const header = textOutput(await new ReadTool(session).execute("read-in", { path: nestedFile })).split("\n")[0];
 
-		expect(header).toMatch(/^\[settings\.json#[0-9A-F]{4}\]$/);
-		expect(header).not.toContain("src");
+		// The header must retain the workspace-relative directory, not collapse
+		// to the bare `settings.json`, or the edit below resolves against the
+		// existing cwd file and the snapshot-tag guard rejects the valid edit.
+		expect(header).toBe(`[${path.join("src", "settings.json")}#${header.slice(-5, -1)}]`);
+
+		await executeHashlineSingle(editOptions(session, `${header}\nPUT 1.=1:\n+ALPHA\n`));
+
+		expect(await Bun.file(nestedFile).text()).toBe("ALPHA\nbeta\n");
+		expect(await Bun.file(rootFile).text()).toBe("root\n");
 	});
 
 	it("recovers a missing cwd path from the active approved local plan", async () => {

--- a/packages/coding-agent/test/read-multi-range.test.ts
+++ b/packages/coding-agent/test/read-multi-range.test.ts
@@ -53,7 +53,7 @@ describe("read tool multi-range selector", () => {
 		await removeWithRetries(tmpDir);
 	});
 
-	it("uses only the filename in hashline headers for nested files", async () => {
+	it("keeps the workspace-relative path in hashline headers for nested files", async () => {
 		const filePath = path.join(tmpDir, "src", "nested", "numbered.txt");
 		await fs.mkdir(path.dirname(filePath), { recursive: true });
 		await fs.writeFile(filePath, "alpha\nbeta\n");
@@ -62,8 +62,9 @@ describe("read tool multi-range selector", () => {
 		const text = textOutput(await tool.execute("call-filename-header", { path: filePath }));
 		const firstLine = text.split("\n")[0];
 
-		expect(firstLine).toMatch(/^\[numbered\.txt#[0-9A-F]{4}\]$/);
-		expect(firstLine).not.toContain("src");
+		// A same-basename file elsewhere in the tree must not capture a
+		// follow-up edit, so the header retains the workspace-relative path.
+		expect(firstLine).toBe(`[${path.join("src", "nested", "numbered.txt")}#${firstLine.slice(-5, -1)}]`);
 	});
 
 	it("returns both ranges separated by an elision marker", async () => {
@@ -75,7 +76,7 @@ describe("read tool multi-range selector", () => {
 		const result = await tool.execute("call-multi", { path: `${filePath}:3-5,20-22` });
 		const text = textOutput(result);
 		const firstLine = text.split("\n")[0];
-		expect(firstLine).toMatch(/^\[numbered\.txt#[0-9A-F]{4}\]$/);
+		expect(firstLine).toMatch(/^\[src\/numbered\.txt#[0-9A-F]{4}\]$/);
 
 		expect(text).toContain("line 3");
 		expect(text).toContain("line 4");

--- a/packages/coding-agent/test/read-summary.test.ts
+++ b/packages/coding-agent/test/read-summary.test.ts
@@ -74,7 +74,7 @@ describe("read summary", () => {
 		const result = await tool.execute("read-summary-ts", { path: fixture });
 		const text = textOutput(result);
 		const firstLine = text.split("\n")[0];
-		expect(firstLine).toMatch(/^\[fixture\.ts#[0-9A-F]{4}\]$/);
+		expect(firstLine).toMatch(/^\[src\/fixture\.ts#[0-9A-F]{4}\]$/);
 
 		expect(text).toContain("export function alpha(value: string): string { … }");
 		expect(text).toContain("export function beta(): number { … }");


### PR DESCRIPTION
## Repro
Reading an in-workspace nested file whose basename also exists at the session cwd, then applying a follow-up `edit` copied verbatim from the read output, fails. `$cwd/src/settings.json` is read, the model copies the emitted header unchanged into an `edit`, and the edit is deterministically rejected with `MismatchError: ... hash #0063 is not from this session`. Reproduce with:

```shell
bun test packages/coding-agent/test/read-edit-out-of-cwd.test.ts \
  --test-name-pattern 'existing basename cannot capture'
```

Before the fix, the read header is `[settings.json#0063]` instead of `[src/settings.json#0063]`.

## Cause
`formatReadHashlineHeader` (`packages/coding-agent/src/tools/read-format.ts:49`) collapsed every relative in-workspace `displayPath` via `path.basename`, so `src/settings.json` became `[settings.json#tag]`. When `$cwd/settings.json` also exists, the follow-up edit's bare authored path resolves to that cwd file. `Patcher.prepare` (`packages/hashline/src/patcher.ts:367`) only runs snapshot-tag path recovery when the authored path is missing on disk, so recovery is skipped and the tag (minted for the nested file) fails to validate against the cwd file — the valid edit is rejected.

## Fix
- `read-format.ts`: keep the workspace-relative path for relative in-workspace reads (`const anchor = path.isAbsolute(displayPath) ? shortenPath(displayPath) : displayPath;`). Out-of-workspace absolute paths remain shortened; root-level files are byte-identical to before (their relative path already equals the basename). Comment rewritten to explain the collision hazard.
- `read-edit-out-of-cwd.test.ts`: replaced the in-cwd basename test (which codified the lossy behavior) with an end-to-end regression asserting the header retains `src/settings.json` and the follow-up edit updates only the nested file, leaving the same-basename cwd file untouched.
- `read-multi-range.test.ts` / `read-summary.test.ts`: updated nested-read header assertions to expect the workspace-relative path.
- Added CHANGELOG entry.

## Verification
`bun test packages/coding-agent/test/read-multi-range.test.ts packages/coding-agent/test/read-summary.test.ts packages/coding-agent/test/read-edit-out-of-cwd.test.ts packages/coding-agent/test/read-tool-group.test.ts packages/coding-agent/test/read-tool-group-freeze.test.ts packages/coding-agent/test/read-acp-fs.test.ts packages/coding-agent/test/edit-acp-bridge.test.ts` → 84 pass, 0 fail. `bun test packages/hashline/test` → 300 pass, 0 fail. The regression test fails before the fix (`Received: "[settings.json#0063]"`) and passes after.

Fixes #8482