### PR TITLE
feat(coding-agent): timestamp streaming extension updates

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -251,7 +251,7 @@ Cancelable pre-events:
 - `agent_start` / `agent_end` — agent loop lifecycle notification; `agent_end` remains notification-only
 - `session_stop` — main-session stop hook, awaited before settle; may continue with `{ continue: true, additionalContext }` or `{ decision: "block", reason }`; capped at 8 consecutive continuations and never fires for task/subagent sessions
 - `turn_start` / `turn_end`
-- `message_start` / `message_update` / `message_end` — lifecycle notifications; `message_end` receives a detached message snapshot, so use `tool_result` or `context` when an extension needs to change provider context
+- `message_start` / `message_update` / `message_end` — lifecycle notifications; `message_update.timestamp` is the epoch-millisecond time when the session observed the update, captured before asynchronous extension delivery, and `message_end` receives a detached message snapshot, so use `tool_result` or `context` when an extension needs to change provider context
 
 ### Tool lifecycle
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added emission timestamps to streaming `message_update` session and extension events, including `--mode json` output, so consumers can measure thinking, text, and tool-call block timing without asynchronous listener delay.
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -736,6 +736,8 @@ export interface MessageUpdateEvent {
 	type: "message_update";
 	message: AgentMessage;
 	assistantMessageEvent: AssistantMessageEvent;
+	/** Epoch milliseconds captured when the session observed this update, before the extension delivery queue. */
+	timestamp?: number;
 }
 
 /**

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -62,11 +62,16 @@ export function printableEvent(event: AgentSessionEvent): unknown {
 			if (streamEvent.type === "done" || streamEvent.type === "error") {
 				return {
 					type: "message_update",
+					timestamp: event.timestamp,
 					assistantMessageEvent: { type: streamEvent.type, reason: streamEvent.reason },
 				};
 			}
 			const { partial: _partial, ...rest } = streamEvent;
-			return { type: "message_update", assistantMessageEvent: rest };
+			return {
+				type: "message_update",
+				timestamp: event.timestamp,
+				assistantMessageEvent: rest,
+			};
 		}
 		case "message_start":
 		case "message_end":

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -10,7 +10,11 @@ import type { CustomMessage } from "./messages";
 
 /** Session-specific events that extend the core AgentEvent. */
 export type AgentSessionEvent =
-	| Exclude<AgentEvent, { type: "agent_end" }>
+	| Exclude<AgentEvent, { type: "agent_end" | "message_update" }>
+	| (Extract<AgentEvent, { type: "message_update" }> & {
+			/** Epoch milliseconds captured before asynchronous extension delivery. */
+			timestamp?: number;
+	  })
 	| (Extract<AgentEvent, { type: "agent_end" }> & {
 			/** False when an async delivery will resume the session before its true final settle. */
 			isTerminal?: boolean;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2065,8 +2065,12 @@ export class AgentSession {
 
 	async #emitSessionEvent(event: AgentSessionEvent): Promise<void> {
 		if (event.type === "message_update") {
-			this.#emit(event);
-			void this.#queueExtensionEvent(event);
+			const timestampedEvent =
+				typeof event.timestamp === "number" && Number.isFinite(event.timestamp)
+					? event
+					: { ...event, timestamp: Date.now() };
+			this.#emit(timestampedEvent);
+			void this.#queueExtensionEvent(timestampedEvent);
 			return;
 		}
 		// Take a FIFO ticket before the extension emit: extension deliveries for
@@ -3478,6 +3482,7 @@ export class AgentSession {
 				type: "message_update",
 				message: event.message,
 				assistantMessageEvent: event.assistantMessageEvent,
+				timestamp: event.timestamp,
 			};
 			await this.#extensionRunner.emit(extensionEvent);
 		} else if (event.type === "message_end") {

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, setSystemTime } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
@@ -103,11 +103,18 @@ afterEach(async () => {
 function signedThinking(thinking: string, thinkingSignature: string): MockContent {
 	return { type: "thinking", thinking, thinkingSignature } as unknown as MockContent;
 }
+type CapturedMessageUpdateEvent = {
+	timestamp?: number;
+	assistantMessageEvent: { type: string };
+};
 
 async function createHarness(
 	responses: MockResponse[],
 	tools: AgentTool[] = [checkpointTool as AgentTool, rewindTool as AgentTool],
-	options?: { onAgentEnd?: (willContinue: boolean | undefined) => void },
+	options?: {
+		onAgentEnd?: (willContinue: boolean | undefined) => void;
+		onMessageUpdate?: (event: CapturedMessageUpdateEvent) => void | Promise<void>;
+	},
 ): Promise<Harness & { mock: MockModel }> {
 	const tempDir = TempDir.createSync("@pi-checkpoint-rewind-branch-");
 	const authStorage = await AuthStorage.create(":memory:");
@@ -137,16 +144,21 @@ async function createHarness(
 
 	const sessionManager = SessionManager.inMemory(tempDir.path());
 	let extensionRunner: ExtensionRunner | undefined;
-	if (options?.onAgentEnd) {
+	if (options?.onAgentEnd || options?.onMessageUpdate) {
 		const runtime = new ExtensionRuntime();
 		const extension = await loadExtensionFromFactory(
 			pi => {
-				pi.on("agent_end", event => options.onAgentEnd?.(event.willContinue));
+				if (options.onAgentEnd) {
+					pi.on("agent_end", event => options.onAgentEnd?.(event.willContinue));
+				}
+				if (options.onMessageUpdate) {
+					pi.on("message_update", event => options.onMessageUpdate?.(event));
+				}
 			},
 			tempDir.path(),
 			new EventBus(),
 			runtime,
-			"capture-agent-end",
+			"capture-session-events",
 		);
 		extensionRunner = new ExtensionRunner([extension], runtime, tempDir.path(), sessionManager, modelRegistry);
 	}
@@ -203,6 +215,88 @@ async function expectNoActiveCheckpointError(session: AgentSession): Promise<voi
 }
 
 describe("AgentSession checkpoint rewind branch context", () => {
+	it("timestamps queued thinking updates at emission rather than extension receipt", async () => {
+		const emissionAt = 1_700_000_000_000;
+		const delayedReceiptAt = emissionAt + 5_000;
+		const releaseExtensionQueue = Promise.withResolvers<void>();
+		const thinkingQueued = Promise.withResolvers<void>();
+		const thinkingDelivered = Promise.withResolvers<void>();
+		const updates: Array<{
+			type: "thinking_start" | "thinking_delta" | "thinking_end";
+			timestamp: number | undefined;
+			receivedAt: number;
+		}> = [];
+		let unsubscribe: (() => void) | undefined;
+
+		setSystemTime(emissionAt);
+		try {
+			const { session } = await createHarness(
+				[
+					{
+						content: ["queue extension delivery", signedThinking("measure this block", "sig_timing")],
+						stopReason: "stop",
+					},
+				],
+				[],
+				{
+					onMessageUpdate: async event => {
+						const eventType = event.assistantMessageEvent.type;
+						if (eventType === "text_start") {
+							await releaseExtensionQueue.promise;
+							return;
+						}
+						if (
+							eventType !== "thinking_start" &&
+							eventType !== "thinking_delta" &&
+							eventType !== "thinking_end"
+						) {
+							return;
+						}
+						updates.push({ type: eventType, timestamp: event.timestamp, receivedAt: Date.now() });
+						if (eventType === "thinking_end") thinkingDelivered.resolve();
+					},
+				},
+			);
+			unsubscribe = session.subscribe(event => {
+				if (event.type === "message_update" && event.assistantMessageEvent.type === "thinking_end") {
+					thinkingQueued.resolve();
+				}
+			});
+
+			const prompt = session.prompt("think before answering");
+			await Promise.race([
+				thinkingQueued.promise,
+				prompt.then(() => {
+					throw new Error("Prompt completed before the thinking stream was observed");
+				}),
+			]);
+			setSystemTime(delayedReceiptAt);
+			releaseExtensionQueue.resolve();
+			await thinkingDelivered.promise;
+			await prompt;
+
+			expect(updates.map(update => update.type)).toEqual(["thinking_start", "thinking_delta", "thinking_end"]);
+			for (const update of updates) {
+				expect(Number.isFinite(update.timestamp)).toBe(true);
+				expect(update.timestamp).toBe(emissionAt);
+				expect(update.receivedAt).toBe(delayedReceiptAt);
+				expect(update.timestamp).toBeLessThan(update.receivedAt);
+			}
+			const startAt = updates[0]?.timestamp;
+			const endAt = updates[2]?.timestamp;
+			expect(typeof startAt).toBe("number");
+			expect(typeof endAt).toBe("number");
+			if (typeof startAt !== "number" || typeof endAt !== "number") {
+				throw new Error("Expected finite thinking boundary timestamps");
+			}
+			expect(endAt - startAt).toBeGreaterThanOrEqual(0);
+		} finally {
+			unsubscribe?.();
+			releaseExtensionQueue.resolve();
+			setSystemTime();
+		}
+	});
+
 	it("rebuilds active history through branch_summary before the post-rewind assistant turn", async () => {
 		const report = "findings: kept checkpoint; risks: stale signed thinking";
 		const { session, mock } = await createHarness([

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -775,9 +775,9 @@ describe("AgentSession message pipeline", () => {
 		);
 	});
 
-	it("emits message_update to session listeners before slow extension handlers finish", async () => {
+	it("preserves source timestamps and emits message_update before slow extension handlers finish", async () => {
 		const { promise, resolve } = Promise.withResolvers<void>();
-		const extensionEmit = vi.fn(async (event: { type: string }) => {
+		const extensionEmit = vi.fn(async (event: { type: string; timestamp?: number }) => {
 			if (event.type === "message_update") {
 				await promise;
 			}
@@ -824,8 +824,10 @@ describe("AgentSession message pipeline", () => {
 			timestamp: Date.now(),
 		} as const;
 
+		const sourceTimestamp = 1_700_000_000_123;
 		session.agent.emitExternalEvent({
 			type: "message_update",
+			timestamp: sourceTimestamp,
 			message: assistantMessage as never,
 			assistantMessageEvent: {
 				type: "toolcall_delta",
@@ -838,6 +840,9 @@ describe("AgentSession message pipeline", () => {
 
 		expect(events.some(event => event.type === "message_update")).toBe(true);
 		expect(extensionEmit).toHaveBeenCalledTimes(1);
+		const sessionUpdate = events.find(event => event.type === "message_update");
+		expect(sessionUpdate?.timestamp).toBe(sourceTimestamp);
+		expect(extensionEmit.mock.calls[0]?.[0].timestamp).toBe(sourceTimestamp);
 
 		resolve();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/modes/print-mode.test.ts
+++ b/packages/coding-agent/test/modes/print-mode.test.ts
@@ -25,12 +25,14 @@ describe("printableEvent", () => {
 	it("emits only the incremental delta for message_update", () => {
 		const event: AgentSessionEvent = {
 			type: "message_update",
+			timestamp: 1_700_000_000_123,
 			message: assistant,
 			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hel", partial: assistant },
 		};
 		const printed = JSON.parse(JSON.stringify(printableEvent(event)));
 		expect(printed).toEqual({
 			type: "message_update",
+			timestamp: 1_700_000_000_123,
 			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hel" },
 		});
 	});
@@ -38,11 +40,16 @@ describe("printableEvent", () => {
 	it("drops the done-variant message snapshot from message_update", () => {
 		const event: AgentSessionEvent = {
 			type: "message_update",
+			timestamp: 1_700_000_000_456,
 			message: assistant,
 			assistantMessageEvent: { type: "done", reason: "stop", message: assistant },
 		};
 		const printed = JSON.parse(JSON.stringify(printableEvent(event)));
-		expect(printed).toEqual({ type: "message_update", assistantMessageEvent: { type: "done", reason: "stop" } });
+		expect(printed).toEqual({
+			type: "message_update",
+			timestamp: 1_700_000_000_456,
+			assistantMessageEvent: { type: "done", reason: "stop" },
+		});
 	});
 
 	it("strips providerPayload from message_end but keeps the message content", () => {


### PR DESCRIPTION
I need this timestamp because extension callbacks are queued, so calling `Date.now()` inside a listener can make a thinking block look slower than it really was.

## What changed

- Add an optional epoch-millisecond `timestamp` to `message_update` session and extension events.
- Capture it once when `AgentSession` observes the update, before asynchronous extension delivery.
- Preserve a finite timestamp supplied by an earlier producer; a focused external-event regression test covers that path.
- Keep the timestamp in compact `omp --mode json` `message_update` output while still stripping cumulative message snapshots.
- Document the field and add real mock-provider and JSON-output regressions.

This is intentionally small and source-compatible. It gives extensions and JSON-stream consumers reliable `thinking_start` / `thinking_end`, text, and tool-call boundary times without requiring timestamps on every event type.

## Why it is useful

Accurate block times make it possible to separate model thinking time from extension queue delay. That helps compare devloops, custom tools, and pipeline changes using wall-clock evidence instead of guesses.

## Verification

- `bun test packages/coding-agent/test/modes/print-mode.test.ts packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts --timeout 30000` — 41 passed.
- `bun run check` in `packages/coding-agent` — Biome and typecheck passed.
- Ran the local 17.3.2 CLI with a temporary extension against `openai-codex/gpt-5.6-sol` at high thinking. The extension observed `thinking_start` at `1786667383346` and `thinking_end` at `1786667383942` (596 ms); callback receipt was equal or 1 ms later, proving the timestamp survives real extension delivery.