### PR TITLE
fix(coding-agent): reclaim dead parked agent corpses on respawn

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a parked, session-less agent-registry entry with no reviver permanently poisoning its agent id for the process lifetime: a fresh subagent spawn reusing that id died post-registration with `already owned by another session generation`, and messages to it failed with `is parked and cannot be revived`. Such dead corpses (left by an isolated run's park or an interrupted construction) are now reclaimed on a fresh-spawn collision so the id becomes reusable; the corpse's transcript remains readable at `history://<id>` ([#8490](https://github.com/can1357/oh-my-pi/issues/8490)).
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -176,21 +176,35 @@ export class AgentLifecycleManager {
 
 	/**
 	 * Reclaim a provably-dead parked corpse so a fresh spawn can reuse its id.
-	 * A ref qualifies only when it still resolves to `expected`, is `parked`
-	 * with no live session, this manager does not own it (no in-memory reviver
-	 * adoption), and no park/revive is in flight. Such a ref cannot be revived
-	 * — {@link ensureLive} throws for it — yet {@link AgentRegistry.registerIfAvailable}
-	 * refuses to overwrite it, so one construction failure or isolated-run park
-	 * would otherwise poison the id for the whole process (#8490).
+	 * Refuses live, adopted, in-flight, or cold-revivable refs. For a parked ref
+	 * restored from disk, the persisted factory is consulted before removal
+	 * because cold revivers are created lazily by {@link ensureLive}.
 	 *
 	 * Only refs in the registry this manager owns are touched; the transcript
 	 * stays readable at `history://<id>`. Returns true when the corpse was
 	 * unregistered.
 	 */
-	reclaimDeadCorpse(id: string, expected: AgentRef): boolean {
+	async reclaimDeadCorpse(id: string, expected: AgentRef): Promise<boolean> {
 		const ref = this.#registry.get(id);
 		if (ref !== expected || ref.status !== "parked" || ref.session) return false;
 		if (this.#adopted.has(id) || this.#parks.has(id) || this.#revivals.has(id)) return false;
+
+		const persistedFactory = ref.sessionFile ? this.#persistedReviverFactory : undefined;
+		if (persistedFactory) {
+			try {
+				if (await persistedFactory(ref)) return false;
+			} catch (error) {
+				logger.warn("AgentLifecycleManager.reclaimDeadCorpse: persisted reviver probe failed", {
+					id,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return false;
+			}
+			// The factory awaited I/O; another lifecycle operation may now own or
+			// have replaced this ref. Revalidate every reclaim invariant.
+			if (this.#registry.get(id) !== ref || ref.status !== "parked" || ref.session) return false;
+			if (this.#adopted.has(id) || this.#parks.has(id) || this.#revivals.has(id)) return false;
+		}
 		return this.#registry.unregister(id, ref);
 	}
 

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -175,6 +175,26 @@ export class AgentLifecycleManager {
 	}
 
 	/**
+	 * Reclaim a provably-dead parked corpse so a fresh spawn can reuse its id.
+	 * A ref qualifies only when it still resolves to `expected`, is `parked`
+	 * with no live session, this manager does not own it (no in-memory reviver
+	 * adoption), and no park/revive is in flight. Such a ref cannot be revived
+	 * — {@link ensureLive} throws for it — yet {@link AgentRegistry.registerIfAvailable}
+	 * refuses to overwrite it, so one construction failure or isolated-run park
+	 * would otherwise poison the id for the whole process (#8490).
+	 *
+	 * Only refs in the registry this manager owns are touched; the transcript
+	 * stays readable at `history://<id>`. Returns true when the corpse was
+	 * unregistered.
+	 */
+	reclaimDeadCorpse(id: string, expected: AgentRef): boolean {
+		const ref = this.#registry.get(id);
+		if (ref !== expected || ref.status !== "parked" || ref.session) return false;
+		if (this.#adopted.has(id) || this.#parks.has(id) || this.#revivals.has(id)) return false;
+		return this.#registry.unregister(id, ref);
+	}
+
+	/**
 	 * True when this manager owns `registry` — i.e. its adopt/park/revive state
 	 * describes that registry's refs. Lets a caller holding a specific registry
 	 * (e.g. a custom-registry {@link IrcBus} that fell back to the global

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3044,7 +3044,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// registry it manages; the corpse's transcript stays at history://.
 			const stale = agentRegistry.get(resolvedAgentId);
 			const lifecycle = AgentLifecycleManager.global();
-			if (stale && lifecycle.manages(agentRegistry) && lifecycle.reclaimDeadCorpse(resolvedAgentId, stale)) {
+			if (stale && lifecycle.manages(agentRegistry) && (await lifecycle.reclaimDeadCorpse(resolvedAgentId, stale))) {
 				registeredAgentRef = agentRegistry.registerIfAvailable(registrationInput, null);
 			}
 		}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3034,6 +3034,20 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			options.expectedAgentRef === undefined
 				? agentRegistry.register(registrationInput)
 				: agentRegistry.registerIfAvailable(registrationInput, options.expectedAgentRef);
+		if (!registeredAgentRef && options.expectedAgentRef === null) {
+			// A fresh spawn collided with an existing id. If that id is held by a
+			// provably-dead parked corpse — no live session, no reviver — reclaim it
+			// so this new generation can take the id instead of failing forever at
+			// construction. Without this, one such corpse (isolated-run park,
+			// interrupted construction) poisons the id for the whole process (#8490).
+			// The reclaim is gated by the lifecycle owner and only touches the
+			// registry it manages; the corpse's transcript stays at history://.
+			const stale = agentRegistry.get(resolvedAgentId);
+			const lifecycle = AgentLifecycleManager.global();
+			if (stale && lifecycle.manages(agentRegistry) && lifecycle.reclaimDeadCorpse(resolvedAgentId, stale)) {
+				registeredAgentRef = agentRegistry.registerIfAvailable(registrationInput, null);
+			}
+		}
 		if (!registeredAgentRef) {
 			throw new Error(`Agent "${resolvedAgentId}" is already owned by another session generation.`);
 		}

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -145,6 +145,60 @@ describe("AgentLifecycleManager", () => {
 		expect(ref?.sessionFile).toBe("/tmp/3-Sub.jsonl");
 	});
 
+	it("reclaimDeadCorpse frees a parked, session-less, unadopted id and refuses live/adopted refs (#8490)", async () => {
+		// A corpse: registered running, then parked with no session and no adoption
+		// (the isolated-run finalize / interrupted-construction outcome). It cannot
+		// be revived and would otherwise poison its id for the process lifetime.
+		const corpse = registry.register({
+			id: "Corpse-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Corpse-Sub.jsonl",
+			status: "running",
+		});
+		registry.setStatus("Corpse-Sub", "parked", corpse);
+		await expect(lifecycle.ensureLive("Corpse-Sub")).rejects.toThrow(/parked and cannot be revived/);
+
+		// A live ref is never reclaimed.
+		const live = makeSessionStub();
+		registry.register({
+			id: "Live-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: live.session,
+			status: "running",
+		});
+		expect(lifecycle.reclaimDeadCorpse("Live-Sub", registry.get("Live-Sub")!)).toBe(false);
+		expect(registry.get("Live-Sub")?.session).toBe(live.session);
+
+		// An adopted (revivable) parked agent is never reclaimed.
+		const adopted = registry.register({
+			id: "Adopted-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Adopted-Sub.jsonl",
+			status: "parked",
+		});
+		lifecycle.adopt("Adopted-Sub", { idleTtlMs: 0, revive: async () => makeSessionStub().session }, adopted);
+		expect(lifecycle.reclaimDeadCorpse("Adopted-Sub", adopted)).toBe(false);
+		expect(registry.get("Adopted-Sub")).toBe(adopted);
+
+		// A stale expected ref (points at a different agent) is never reclaimed.
+		expect(lifecycle.reclaimDeadCorpse("Corpse-Sub", adopted)).toBe(false);
+
+		// The corpse is reclaimed, and its id becomes registerable again.
+		expect(lifecycle.reclaimDeadCorpse("Corpse-Sub", corpse)).toBe(true);
+		expect(registry.get("Corpse-Sub")).toBeUndefined();
+		const respawn = registry.registerIfAvailable(
+			{ id: "Corpse-Sub", displayName: "task", kind: "sub", session: null, status: "running" },
+			null,
+		);
+		expect(respawn?.status).toBe("running");
+		expect(registry.get("Corpse-Sub")).toBe(respawn);
+	});
+
 	it("concurrent ensureLive calls during a slow revive coalesce into one reviver run", async () => {
 		const gate = deferred();
 		const revived = makeSessionStub();

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -169,7 +169,7 @@ describe("AgentLifecycleManager", () => {
 			session: live.session,
 			status: "running",
 		});
-		expect(lifecycle.reclaimDeadCorpse("Live-Sub", registry.get("Live-Sub")!)).toBe(false);
+		expect(await lifecycle.reclaimDeadCorpse("Live-Sub", registry.get("Live-Sub")!)).toBe(false);
 		expect(registry.get("Live-Sub")?.session).toBe(live.session);
 
 		// An adopted (revivable) parked agent is never reclaimed.
@@ -182,14 +182,14 @@ describe("AgentLifecycleManager", () => {
 			status: "parked",
 		});
 		lifecycle.adopt("Adopted-Sub", { idleTtlMs: 0, revive: async () => makeSessionStub().session }, adopted);
-		expect(lifecycle.reclaimDeadCorpse("Adopted-Sub", adopted)).toBe(false);
+		expect(await lifecycle.reclaimDeadCorpse("Adopted-Sub", adopted)).toBe(false);
 		expect(registry.get("Adopted-Sub")).toBe(adopted);
 
 		// A stale expected ref (points at a different agent) is never reclaimed.
-		expect(lifecycle.reclaimDeadCorpse("Corpse-Sub", adopted)).toBe(false);
+		expect(await lifecycle.reclaimDeadCorpse("Corpse-Sub", adopted)).toBe(false);
 
 		// The corpse is reclaimed, and its id becomes registerable again.
-		expect(lifecycle.reclaimDeadCorpse("Corpse-Sub", corpse)).toBe(true);
+		expect(await lifecycle.reclaimDeadCorpse("Corpse-Sub", corpse)).toBe(true);
 		expect(registry.get("Corpse-Sub")).toBeUndefined();
 		const respawn = registry.registerIfAvailable(
 			{ id: "Corpse-Sub", displayName: "task", kind: "sub", session: null, status: "running" },
@@ -197,6 +197,32 @@ describe("AgentLifecycleManager", () => {
 		);
 		expect(respawn?.status).toBe("running");
 		expect(registry.get("Corpse-Sub")).toBe(respawn);
+	});
+
+	it("reclaimDeadCorpse preserves an unadopted parked ref when its persisted session can cold-revive", async () => {
+		const revived = makeSessionStub();
+		const cold = registry.register({
+			id: "Cold-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Cold-Sub.jsonl",
+			status: "parked",
+		});
+		let factoryCalls = 0;
+		lifecycle.setPersistedSubagentReviverFactory(async ref => {
+			factoryCalls++;
+			expect(ref).toBe(cold);
+			return async () => revived.session;
+		}, 0);
+
+		expect(await lifecycle.reclaimDeadCorpse("Cold-Sub", cold)).toBe(false);
+		expect(registry.get("Cold-Sub")).toBe(cold);
+		expect(factoryCalls).toBe(1);
+
+		// The preserved ref remains messageable through the normal cold-revive path.
+		expect(await lifecycle.ensureLive("Cold-Sub")).toBe(revived.session);
+		expect(registry.get("Cold-Sub")?.session).toBe(revived.session);
 	});
 
 	it("concurrent ensureLive calls during a slow revive coalesce into one reviver run", async () => {


### PR DESCRIPTION
## Repro
A subagent spawn that fails after registration (or an isolated run that parks) leaves a `parked` entry in the per-process `AgentRegistry` with `session: null` and no reviver. That entry permanently poisons its agent id: any later fresh spawn reusing the id dies at construction, and messages to it fail. Reproduced with a focused test against the live `AgentRegistry` + `AgentLifecycleManager`: a parked, session-less, unadopted ref makes `lifecycle.ensureLive(id)` throw `parked and cannot be revived` and `registry.registerIfAvailable(respawn, null)` return `undefined`. Command: `bun test packages/coding-agent/test/registry/agent-lifecycle.test.ts`.

## Cause
`AgentRegistry.registerIfAvailable(input, null)` (`packages/coding-agent/src/registry/agent-registry.ts:166`) refuses **any** existing entry, and the fresh-spawn path in `createAgentSession` (`packages/coding-agent/src/sdk.ts:3033-3039`, `expectedAgentRef === null`) turns that into a hard throw (`already owned by another session generation`). Dead corpses — a `parked`, session-less, non-adopted ref left by an isolated run's park (`task/executor.ts:2506`) or an interrupted construction — are never reclaimed and never GC'd, so one such entry bricks the id for the whole process. `ensureLive` also refuses it (`is parked and cannot be revived`), matching the reported symptoms.

## Fix
- Add `AgentLifecycleManager.reclaimDeadCorpse(id, expected)` (`registry/agent-lifecycle.ts`): unregisters a ref only when it still resolves to `expected`, is `parked` with no live session, this manager does not own it (no in-memory reviver adoption), and no park/revive is in flight. The transcript stays readable at `history://<id>`.
- In the fresh-spawn path (`sdk.ts`), on an `expectedAgentRef === null` collision, reclaim the corpse via the lifecycle owner (gated by `manages(agentRegistry)`) and retry `registerIfAvailable`. The registry's strict CAS contract is untouched — `registerIfAvailable` still never reclaims on its own.
- Regression test in `test/registry/agent-lifecycle.test.ts` covering: corpse reclaim frees the id for re-registration; live refs, adopted (revivable) parked agents, and stale expected refs are never reclaimed.
- CHANGELOG entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/registry/agent-lifecycle.test.ts` → 28 pass, 0 fail (145 expect() calls), including the new reclaim regression. `bun --cwd=packages/coding-agent run check` (biome + tsgo) exits 0. Root `bun check` fails only on the workspace Rust step (`check:rs`) due to missing `cmake` (`which cmake` is empty) — a pre-existing environmental failure unrelated to this TS/CHANGELOG-only diff; pre-publish gate skipped for that reason.

Fixes #8490