### PR TITLE
refactor(coding-agent): update pi logo shape and gradient

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -480,8 +480,7 @@ export class WelcomeComponent implements Component {
 	}
 }
 
-/** Block-grid brand mark shared by the welcome and setup surfaces. */
-export const PI_LOGO = ["████████████", "   ██  ██   ", "   ██  ██   ", "   ▒▒  ██   ", "       ██   "];
+export const PI_LOGO = ["████████████", "  ██   ██   ", "  ██   ██   ", "  ██   ██   ", "       ██   "];
 
 /** Multi-stop palette for the diagonal gradient. */
 const GRADIENT_STOPS: ReadonlyArray<readonly [number, number, number]> = [

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -566,10 +566,9 @@ export function gradientLogo(lines: readonly string[], phase = 0, shine?: ShineC
 				result += char;
 				continue;
 			}
-			// SVG's (0,0) → (1,1) gradient projects both normalized axes
-			// equally: top-right and bottom-left land on the purple midpoint.
-			const base = (x / xSpan + y / ySpan) / 2;
-			const t = normalizedPhase === 0 ? base : (base + normalizedPhase) % 1;
+			// Diagonal: top-left (x=0, y=0) → bottom-right (x=cols-1, y=rows-1)
+			const base = (x + y) / span;
+			const t = (((base + phase) % 1) + 1) % 1;
 			result += gradientEscape(t, shine) + char + reset;
 		}
 		return result;

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/outro.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/outro.ts
@@ -21,7 +21,13 @@ export function renderSetupOutro(width: number, height: number, elapsedMs: numbe
 	const frame = Math.floor(elapsedMs / SETUP_TICK_MS);
 	const lines = renderStarfield(width, height, frame + 1000);
 	const progress = Math.max(0, Math.min(1, elapsedMs / SETUP_OUTRO_MS));
-	const logo = gradientLogo(PI_LOGO, progress * 1.2, { pos: (progress * 2) % 1, strength: 1 - progress });
+	// Ease-out cubic so the spin decelerates into rest; phase is driven by
+	// (1 - eased), which hits exactly 0 at progress=1 (same convergence
+	// policy as welcome.ts's introLogoFrame and the setup splash), so the
+	// settled frame never wraps mid-glyph.
+	const eased = 1 - (1 - progress) ** 3;
+	const phase = ((((1 - eased) * 1.2) % 1) + 1) % 1;
+	const logo = gradientLogo(PI_LOGO, phase, { pos: (progress * 2) % 1, strength: 1 - progress });
 	const title = theme.bold(theme.fg("success", `${theme.status.success} Setup saved`));
 	const subtitle = theme.fg("muted", "Handing off to the normal CLI…");
 	const sweepWidth = Math.max(1, Math.min(width - 8, Math.floor((width - 8) * progress)));

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/splash.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/splash.ts
@@ -117,6 +117,14 @@ function waterAmplitude(
 }
 
 /**
+ * Number of full gradient rotations the intro sweep performs before settling
+ * into the resting orientation (phase 0 — same convention as welcome.ts's
+ * introLogoFrame). Converging to exactly 0 keeps the settled frame's `base`
+ * (always < 1 by construction) from ever wrapping mid-glyph.
+ */
+const SPLASH_SWEEPS = 1.8;
+
+/**
  * Animated setup splash, in the spirit of the omp landing page: the brand π
  * mark rendered with the live diagonal gradient + shine sweep, rising out of a
  * rippling, gradient-lit water surface, under a faint twinkling starfield. The
@@ -127,8 +135,12 @@ export function renderSetupSplash(width: number, height: number, elapsedMs: numb
 	const w = Math.max(1, width);
 	const h = Math.max(1, height);
 	const progress = Math.max(0, Math.min(1, elapsedMs / SETUP_SPLASH_MS));
-	const phase = progress * 1.8;
-	const shine: ShineConfig = { pos: (progress * 2.5) % 1, strength: Math.max(0, 1 - progress * 0.35) };
+	// Ease-out cubic so the spin decelerates into rest; phase is driven by
+	// (1 - eased), which hits exactly 0 at progress=1, so the settled frame
+	// never wraps mid-glyph and matches the app's canonical resting gradient.
+	const eased = 1 - (1 - progress) ** 3;
+	const phase = ((((1 - eased) * SPLASH_SWEEPS) % 1) + 1) % 1;
+	const shine: ShineConfig = { pos: (progress * 2.5) % 1, strength: (1 - eased) ** 1.5 };
 
 	if (w < MIN_SCENE_WIDTH || h < MIN_SCENE_HEIGHT) return renderCompactSplash(w, h, phase, shine);
 

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/splash.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/splash.ts
@@ -63,10 +63,10 @@ export function renderStarfield(width: number, height: number, frame: number): s
 	return lines;
 }
 
-/** Continuous diagonal gradient position (bottom-left → top-right) across the whole screen. */
+/** Continuous diagonal gradient position (top-left → bottom-right) across the whole screen. */
 function screenGradientT(x: number, y: number, width: number, height: number, phase: number): number {
 	const span = Math.max(1, width + height - 1);
-	const base = (x + (height - 1 - y)) / span;
+	const base = (x + y) / span;
 	return (((base + phase) % 1) + 1) % 1;
 }
 


### PR DESCRIPTION
## Summary

Updated the animated startup logo shape and gradient direction to match the new design on [omp.sh](https://omp.sh). The pi symbol now has cleaner, more uniform styling.

## Changes

- Adjusted pi logo shape
- Rotated pi logo gradient direction from bottom-left→top-right to top-left→bottom-right

## Screenshot

<img width="130" height="112" alt="Screenshot 2026-08-13 at 9 39 09 PM" src="https://github.com/user-attachments/assets/d765ad27-57a1-4d08-831f-273bdd4411e0" />

I love the new logo. This doesn't match it exactly, but it's about as close as you can get with ASCII.