### PR TITLE
fix(ai): classify Bailian/DashScope 429 TPM throttle as transient rate limit

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bailian (Alibaba Model Studio / DashScope compatible-mode) transient per-minute token throttles (HTTP 429 with OpenAI's `insufficient_quota` wording) being misclassified as persistent quota exhaustion, which blocked the credential for 30 minutes instead of retrying within the throttle's recovery window; the `error-code#token-limit` doc anchor now classifies these as retryable rate limits while OpenAI's genuine account-quota error (same wording, no anchor) stays a quota block ([#8496](https://github.com/can1357/oh-my-pi/issues/8496)).
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -8,6 +8,7 @@ import {
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
 import {
+	BAILIAN_TOKEN_THROTTLE_PATTERN,
 	isAccountScopedCapText,
 	isOpaqueStatusBody,
 	isUsageLimitStatus,
@@ -431,7 +432,10 @@ export function classify(error: unknown, api?: Api): number {
 		} else if (link instanceof ProviderHttpError) {
 			let linkKinds = 0;
 			const { status: codeStatus, code } = link;
-			if (code === "usage_limit_reached" || code === "insufficient_quota") {
+			if (
+				code === "usage_limit_reached" ||
+				(code === "insufficient_quota" && !BAILIAN_TOKEN_THROTTLE_PATTERN.test(link.message))
+			) {
 				linkKinds |= Flag.UsageLimit;
 			}
 			if (code === "overloaded_error" || code === "rate_limit_error") {

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -29,6 +29,16 @@ const SUBSCRIPTION_CAP_PATTERN =
 	/\b(?:subscription|plan|membership)\b[^\n]{0,80}\b(?:rate.?limits?|quota|cap)\b|\b(?:rate.?limits?|quota|cap)\b[^\n]{0,80}\b(?:subscription|plan|membership)\b/i;
 const TRANSIENT_INTERVAL_RATE_LIMIT_PATTERN = /\bper\s+(?:second|minute)\b/i;
 
+/**
+ * Bailian (Alibaba Model Studio / DashScope compatible-mode) reports its
+ * transient per-minute token throttle (429 `Throttling.AllocationQuota`) using
+ * OpenAI's exact `insufficient_quota` billing wording, but embeds a link to its
+ * `error-code#token-limit` doc anchor. That anchor is the reliable
+ * discriminator: OpenAI's genuine account-quota error carries the same text
+ * without it, so the transient reclassification gates on the anchor alone.
+ */
+export const BAILIAN_TOKEN_THROTTLE_PATTERN = /error-code#token-limit/i;
+
 function matchesSubscriptionCapText(errorMessage: string): boolean {
 	return SUBSCRIPTION_CAP_PATTERN.test(errorMessage) && !TRANSIENT_INTERVAL_RATE_LIMIT_PATTERN.test(errorMessage);
 }
@@ -145,6 +155,13 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	const lowerWithStatus = errorMessage.toLowerCase();
 	const lower = lowerWithStatus.replace(RESOURCE_EXHAUSTED_PATTERN, "");
 	const hasResourceExhaustedStatus = lower !== lowerWithStatus;
+
+	// Bailian's transient TPM/TPS throttle mimics OpenAI's `insufficient_quota`
+	// wording; its `error-code#token-limit` doc anchor keeps it a retryable rate
+	// limit instead of a 30-minute quota block.
+	if (BAILIAN_TOKEN_THROTTLE_PATTERN.test(errorMessage)) {
+		return "RATE_LIMIT_EXCEEDED";
+	}
 
 	// Antigravity / Cloud Code Assist surface multi-hour daily-quota exhaustion as
 	// "You have exhausted your capacity on this model. Your quota will reset after …".
@@ -340,6 +357,9 @@ export function isOpaqueStatusBody(message: string): boolean {
  * {@link isUsageLimitOutcome} uses it for the account-rotation decision.
  */
 export function matchesUsageLimitText(errorMessage: string): boolean {
+	// Bailian's transient TPM throttle carries `insufficient_quota` wording but is
+	// not a credential-rotatable usage cap (see BAILIAN_TOKEN_THROTTLE_PATTERN).
+	if (BAILIAN_TOKEN_THROTTLE_PATTERN.test(errorMessage)) return false;
 	const structuredReason = parseGoogleRpcRateLimitReason(errorMessage);
 	if (structuredReason !== undefined) return isQuotaExhaustedReason(structuredReason);
 	return (

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -10,6 +10,14 @@ import {
 	parseRateLimitReason,
 } from "@oh-my-pi/pi-ai/error/rate-limit";
 
+// Bailian/DashScope transient TPM throttle: OpenAI `insufficient_quota` wording
+// with the `error-code#token-limit` doc anchor discriminator (issue #8496).
+const BAILIAN_THROTTLE_BODY =
+	"429 You exceeded your current quota, please check your plan and billing details. For details, see: https://help.aliyun.com/zh/model-studio/error-code#token-limit (type=insufficient_quota param=insufficient_quota)";
+// OpenAI's genuine account-quota error: identical wording, no aliyun anchor.
+const OPENAI_QUOTA_BODY =
+	"429 You exceeded your current quota, please check your plan and billing details. (type=insufficient_quota param=insufficient_quota)";
+
 function googleRpc429(reason: string, retryDelay?: string, message = "Resource exhausted"): string {
 	const details: Array<Record<string, string>> = [
 		{
@@ -242,6 +250,18 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason(body)).toBe("RATE_LIMIT_EXCEEDED");
 		expect(isUsageLimitOutcome(429, body)).toBe(false);
 	});
+
+	// Bailian/DashScope's transient TPM throttle reuses OpenAI's
+	// `insufficient_quota` wording; the `error-code#token-limit` doc anchor keeps
+	// it a retryable 30s rate limit instead of a 30-min quota block. OpenAI's
+	// genuine account quota (same wording, no anchor) must stay QUOTA_EXHAUSTED.
+	// Regression for #8496.
+	it("classifies Bailian TPM throttle as RATE_LIMIT_EXCEEDED via the doc anchor", () => {
+		expect(parseRateLimitReason(BAILIAN_THROTTLE_BODY)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(calculateRateLimitBackoffMs(parseRateLimitReason(BAILIAN_THROTTLE_BODY))).toBe(30_000);
+		expect(parseRateLimitReason(OPENAI_QUOTA_BODY)).toBe("QUOTA_EXHAUSTED");
+		expect(calculateRateLimitBackoffMs(parseRateLimitReason(OPENAI_QUOTA_BODY))).toBe(30 * 60 * 1000);
+	});
 });
 
 describe("isUsageLimit", () => {
@@ -355,6 +375,19 @@ describe("isUsageLimit", () => {
 		expect(isUsageLimit(new ProviderHttpError("Generic provider failure", 429, { code: "rate_limit_error" }))).toBe(
 			false,
 		);
+	});
+
+	// Bailian's throttle carries the OpenAI `insufficient_quota` payload code but
+	// is transient — it must classify as a retryable rate limit (Flag.Transient),
+	// never a credential-rotatable usage cap. OpenAI's genuine `insufficient_quota`
+	// (no anchor) stays a usage limit. Regression for #8496.
+	it("treats Bailian insufficient_quota throttle as transient, not a usage limit", () => {
+		const bailian = new ProviderHttpError(BAILIAN_THROTTLE_BODY, 429, { code: "insufficient_quota" });
+		expect(isUsageLimit(bailian)).toBe(false);
+		expect(retriable(classify(bailian))).toBe(true);
+		expect(is(classify(bailian), Flag.Transient)).toBe(true);
+		const openai = new ProviderHttpError(OPENAI_QUOTA_BODY, 429, { code: "insufficient_quota" });
+		expect(isUsageLimit(openai)).toBe(true);
 	});
 });
 
@@ -567,6 +600,14 @@ describe("isUsageLimitOutcome", () => {
 		// 429 concurrency cap: shed-and-backoff, do not rotate.
 		expect(isUsageLimitOutcome(429, message)).toBe(false);
 		expect(isUsageLimit(Object.assign(new Error(message), { status: 429 }))).toBe(false);
+	});
+
+	// Bailian's transient TPM throttle must not burn/rotate the credential; the
+	// `error-code#token-limit` anchor keeps the 429 in the provider backoff lane.
+	// Regression for #8496.
+	it("does not rotate credentials on Bailian TPM throttle", () => {
+		expect(isUsageLimitOutcome(429, BAILIAN_THROTTLE_BODY)).toBe(false);
+		expect(isUsageLimitOutcome(429, OPENAI_QUOTA_BODY)).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Repro
Bailian (Alibaba Model Studio / DashScope compatible-mode) reports its transient per-minute token throttle as HTTP `429` carrying OpenAI's exact `insufficient_quota` billing wording and payload code, plus a link to its `error-code#token-limit` doc anchor. Classifying that exact body on current `main` (deterministic, no network):

```
=== Bailian TPM throttle ===
parseRateLimitReason: QUOTA_EXHAUSTED
calculateRateLimitBackoffMs: 1800000 ms   # 30 min
classify(msg) UsageLimit: true
classify(ProviderHttpError code=insufficient_quota) UsageLimit: true
isUsageLimitOutcome(429, msg): true
```

The throttle clears within its ~60s window, but omp blocks the credential for 30 minutes (or fails fast with `exceeds retry.maxDelayMs`), and `retry.*` settings cannot shorten it because the delay comes from the classification bucket, not the delay ladder.

## Cause
Three paths in `packages/ai/src/error/` treat the body as persistent account-quota exhaustion:
1. `matchesSubscriptionCapText` in `rate-limit.ts` (the `quota … plan` proximity arm of `SUBSCRIPTION_CAP_PATTERN`),
2. the generic `quota`/`insufficient_quota` arms of `parseRateLimitReason` and `USAGE_LIMIT_PATTERN`,
3. the `ProviderHttpError.code === "insufficient_quota"` arm of `classify()` in `flags.ts`, which sets `Flag.UsageLimit` regardless of message text.

Result: `parseRateLimitReason` → `QUOTA_EXHAUSTED` → `QUOTA_EXHAUSTED_BACKOFF_MS` (30min), `Flag.UsageLimit`, and `isUsageLimitOutcome` → rotate/block the credential. Same provider-quirk misclassification family as #3172.

## Fix
- Added `BAILIAN_TOKEN_THROTTLE_PATTERN` (`/error-code#token-limit/i`) in `rate-limit.ts` — Bailian's own discriminator for the transient TPS/TPM throttle. OpenAI's genuine account-quota error uses identical wording *without* the aliyun anchor.
- `parseRateLimitReason`: early-return `RATE_LIMIT_EXCEEDED` when the anchor is present (→ 30s backoff via `calculateRateLimitBackoffMs`).
- `matchesUsageLimitText`: early-return `false` on the anchor so `classifyText`/`isUsageLimitOutcome` never set `Flag.UsageLimit` or rotate the credential.
- `classify()` (`flags.ts`): gate the `insufficient_quota` → `Flag.UsageLimit` arm on the anchor's absence; a 429 without `UsageLimit` then falls through to `Flag.Transient` (retryable).
- Added regression tests and a CHANGELOG entry.

## Verification
`bun test packages/ai/test/rate-limit-utils.test.ts` → 64 pass / 0 fail. Also ran `error-aierr`, `error-id`, `github-copilot-error`, `auth-gateway-classify-error` → 54 pass / 0 fail. Post-fix classification of the exact body: `parseRateLimitReason` → `RATE_LIMIT_EXCEEDED`, backoff 30000ms, `UsageLimit` false on all paths, `isUsageLimitOutcome(429,…)` false; OpenAI's identical wording without the anchor still classifies `QUOTA_EXHAUSTED`/usage-limit. Fixes #8496