### PR TITLE
fix(agent): add new-checkpoint affordance to rewind report

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added an explicit affordance to the rewind report prompt that a new `checkpoint` may be started after a completed rewind, so agents don't over-read the "do not rewind again" guard as a ban on further checkpoint cycles ([#8499](https://github.com/can1357/oh-my-pi/issues/8499)).
 - Added `--agent <name>` CLI flag, `/agent <name>`, and `/switch-agent` slash commands to apply a discovered agent definition's frontmatter (tools, model, thinking, spawns, system prompt) as the main-session persona; explicit `--model`/`--tools`/`--thinking` flags take precedence. Persona identity persists via `mode_change` and is re-applied from the current agent definition on resume, falling back to model+thinking with a warning when the agent is unavailable. OpenCode `mode: primary|subagent|all` and Copilot `user-invocable`/`disable-model-invocation` frontmatter control availability. Closes [#6836](https://github.com/can1357/oh-my-pi/issues/6836), [#5306](https://github.com/can1357/oh-my-pi/issues/5306), [#7056](https://github.com/can1357/oh-my-pi/issues/7056), [#2694](https://github.com/can1357/oh-my-pi/issues/2694).
 
 ## [17.2.12] - 2026-08-08

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--agent <name>` CLI flag, `/agent <name>`, and `/switch-agent` slash commands to apply a discovered agent definition's frontmatter (tools, model, thinking, spawns, system prompt) as the main-session persona; explicit `--model`/`--tools`/`--thinking` flags take precedence. Persona identity persists via `mode_change` and is re-applied from the current agent definition on resume, falling back to model+thinking with a warning when the agent is unavailable. OpenCode `mode: primary|subagent|all` and Copilot `user-invocable`/`disable-model-invocation` frontmatter control availability. Closes [#6836](https://github.com/can1357/oh-my-pi/issues/6836), [#5306](https://github.com/can1357/oh-my-pi/issues/5306), [#7056](https://github.com/can1357/oh-my-pi/issues/7056), [#2694](https://github.com/can1357/oh-my-pi/issues/2694).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -31,6 +31,7 @@ export interface Args {
 	allowHome?: boolean;
 	provider?: string;
 	model?: string;
+	agent?: string;
 	config?: string[];
 	smol?: string;
 	slow?: string;

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -135,6 +135,9 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--model": (result, value) => {
 		result.model = value;
 	},
+	"--agent": (result, value) => {
+		result.agent = value;
+	},
 	"--smol": (result, value) => {
 		result.smol = value;
 	},

--- a/packages/coding-agent/src/discovery/availability.test.ts
+++ b/packages/coding-agent/src/discovery/availability.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Agent availability parsing from frontmatter.
+ *
+ * OpenCode `mode` and Copilot `user-invocable` / `disable-model-invocation`
+ * frontmatter control which session roles an agent may serve. Absent both →
+ * "all" (backward compatible); when both schemas are present the more
+ * restrictive wins (Copilot fields take precedence over OpenCode `mode`).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { enableProvider } from "@oh-my-pi/pi-coding-agent/capability";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { clearOmpExtensionCliRoots } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
+import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
+import {
+	resolveEffectiveSubagentPolicy,
+	type StructuredSubagentRequest,
+} from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+function agentMd(name: string, extraFrontmatter: string[] = []): string {
+	return ["---", `name: ${name}`, `description: ${name}`, ...extraFrontmatter, "---", `You are ${name}.`].join("\n");
+}
+
+describe("agent availability", () => {
+	let tempHome: string;
+	let projectDir: string;
+
+	beforeEach(async () => {
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agent-availability-"));
+		projectDir = path.join(tempHome, "project");
+		await fs.mkdir(path.join(projectDir, ".omp", "agents"), { recursive: true });
+
+		const agentsDir = path.join(projectDir, ".omp", "agents");
+		await fs.writeFile(path.join(agentsDir, "subagent-mode.md"), agentMd("subagent-mode", ["mode: subagent"]));
+		await fs.writeFile(
+			path.join(agentsDir, "copilot-subagent.md"),
+			agentMd("copilot-subagent", ["user-invocable: false"]),
+		);
+		await fs.writeFile(
+			path.join(agentsDir, "copilot-primary.md"),
+			agentMd("copilot-primary", ["disable-model-invocation: true"]),
+		);
+		await fs.writeFile(path.join(agentsDir, "primary-mode.md"), agentMd("primary-mode", ["mode: primary"]));
+		await fs.writeFile(path.join(agentsDir, "no-availability.md"), agentMd("no-availability"));
+		await fs.writeFile(
+			path.join(agentsDir, "restrictive-wins.md"),
+			agentMd("restrictive-wins", ["mode: all", "user-invocable: false"]),
+		);
+	});
+
+	afterEach(async () => {
+		enableProvider("omp-plugins");
+		clearOmpExtensionCliRoots();
+		clearFsCache();
+		await removeWithRetries(tempHome);
+	});
+
+	async function discovered(name: string) {
+		const { agents } = await discoverAgents(projectDir, tempHome);
+		const agent = agents.find(candidate => candidate.name === name);
+		expect(agent).toBeDefined();
+		return agent;
+	}
+
+	test("parses OpenCode mode: subagent", async () => {
+		expect((await discovered("subagent-mode"))?.availability).toBe("subagent");
+	});
+
+	test("parses Copilot user-invocable: false", async () => {
+		expect((await discovered("copilot-subagent"))?.availability).toBe("subagent");
+	});
+
+	test("parses Copilot disable-model-invocation: true", async () => {
+		expect((await discovered("copilot-primary"))?.availability).toBe("primary");
+	});
+
+	test("parses OpenCode mode: primary", async () => {
+		expect((await discovered("primary-mode"))?.availability).toBe("primary");
+	});
+
+	test("defaults to all when no availability frontmatter is present", async () => {
+		expect((await discovered("no-availability"))?.availability).toBe("all");
+	});
+
+	test("restrictive wins when both schemas are present", async () => {
+		expect((await discovered("restrictive-wins"))?.availability).toBe("subagent");
+	});
+
+	test("rejects primary agents from subagent spawning", async () => {
+		const session = {
+			cwd: projectDir,
+			hasUI: false,
+			settings: Settings.isolated({
+				"task.maxRecursionDepth": 2,
+				"task.isolation.mode": "none",
+				"task.enableLsp": true,
+			}),
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getPlanModeState: () => undefined,
+		} as unknown as ToolSession;
+		const request: StructuredSubagentRequest = {
+			session,
+			invocationKind: "task",
+			assignment: "Inspect the target.",
+			agent: "primary-mode",
+		};
+
+		await expect(resolveEffectiveSubagentPolicy(request)).rejects.toThrow(
+			'Agent "primary-mode" is primary/main-session-only and cannot be spawned as a subagent.',
+		);
+	});
+});

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -17,6 +17,7 @@ import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 import type { MCPRequestIdFormat } from "../mcp/types";
+import type { AgentAvailability } from "../task/types";
 import { type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../thinking";
 import { normalizeToolNames } from "../tools/builtin-names";
 
@@ -235,6 +236,7 @@ export function parseModelList(value: unknown): string[] | undefined {
 export interface ParsedAgentFields {
 	name: string;
 	description: string;
+	availability?: AgentAvailability;
 	tools?: string[];
 	spawns?: string[] | "*";
 	model?: string[];
@@ -245,6 +247,25 @@ export interface ParsedAgentFields {
 	blocking?: boolean;
 	/** `true` = prewalk into the default target; string = prewalk into that model pattern. */
 	prewalk?: boolean | string;
+}
+
+/**
+ * Parse agent availability from frontmatter.
+ *
+ * OpenCode `mode`: "primary" → primary, "subagent" → subagent, "all"/absent → all.
+ * Copilot `user-invocable: false` → subagent; `disable-model-invocation: true` → primary.
+ * When both schemas are present the more restrictive wins (Copilot fields take
+ * precedence over OpenCode `mode`). Absent both → "all" (backward compatible).
+ */
+function parseAgentAvailability(frontmatter: Record<string, unknown>): AgentAvailability {
+	const userInvocable = parseBoolean(frontmatter.userInvocable);
+	const disableModelInvocation = parseBoolean(frontmatter.disableModelInvocation);
+	if (userInvocable === false) return "subagent";
+	if (disableModelInvocation === true) return "primary";
+
+	const mode = frontmatter.mode;
+	if (mode === "primary" || mode === "subagent") return mode;
+	return "all";
 }
 
 /**
@@ -311,6 +332,7 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 	return {
 		name,
 		description,
+		availability: parseAgentAvailability(frontmatter),
 		tools,
 		spawns,
 		model,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -88,8 +88,10 @@ import { SessionManager } from "./session/session-manager";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
+import { mainSessionTools, spawnsToString } from "./task/agent-tools";
 import { discoverAgents, getAgent } from "./task/discovery";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
+import type { AgentDefinition } from "./task/types";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
 import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
@@ -360,7 +362,7 @@ export interface AcpSessionFactoryOptions {
 	sessionDir?: string;
 	authStorage: AuthStorage;
 	modelRegistry: ModelRegistry;
-	parsedArgs: Pick<Args, "apiKey" | "trustedExtensions">;
+	parsedArgs: Pick<Args, "apiKey" | "trustedExtensions" | "agent" | "tools" | "noTools">;
 	rawArgs: string[];
 	createSession: (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
 }
@@ -417,8 +419,24 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 				`Trusted extension failed to load: ${trustedExtensions.errors.map(item => item.error).join("; ")}`,
 			);
 		}
+		// `--agent` persona: re-resolve against THIS session's cwd (an ACP host
+		// can open any workspace); if the agent is not found there, fall back to
+		// no persona rather than failing the session. Applied to the per-session
+		// options BEFORE creation so this session actually gets the persona.
+		const sessionOptions: CreateAgentSessionOptions = { ...args.baseOptions };
+		if (args.parsedArgs.agent) {
+			const { agents } = await discoverAgents(cwd);
+			const agent = getAgent(agents, args.parsedArgs.agent);
+			if (agent && agent.availability !== "subagent") {
+				applyAgentPersonaOptions(sessionOptions, agent, {
+					modelSet: Boolean(sessionOptions.model || sessionOptions.modelPattern),
+					thinkingSet: sessionOptions.thinkingLevel !== undefined,
+					toolsSet: Boolean(args.parsedArgs.tools || args.parsedArgs.noTools),
+				});
+			}
+		}
 		const { session: nextSession } = await args.createSession({
-			...args.baseOptions,
+			...sessionOptions,
 			cwd,
 			sessionManager: nextSessionManager,
 			settings: nextSettings,
@@ -433,7 +451,11 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			eventBus,
 			preloadedExtensions: trustedExtensions,
 		});
-		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
+		// Persist the persona identity so resume re-applies the current definition.
+		if (args.parsedArgs.agent) {
+			nextSessionManager.appendModeChange("agent", { name: args.parsedArgs.agent });
+		}
+		if (args.parsedArgs.apiKey && !sessionOptions.model && nextSession.model) {
 			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
 		}
 		applyExtensionFlags(nextSession.extensionRunner, args.rawArgs);
@@ -885,6 +907,32 @@ export function applyResolvedSystemPromptInputs(
 	}
 }
 
+/**
+ * Fill session options from an agent definition's frontmatter, honoring
+ * explicit CLI precedence: agent fields fill only what the CLI didn't set.
+ * Shared by the launch path (`--agent`) and the ACP per-`session/new` factory
+ * (which re-resolves the persona against the target cwd).
+ */
+export function applyAgentPersonaOptions(
+	options: CreateAgentSessionOptions,
+	agent: AgentDefinition,
+	explicit: { modelSet: boolean; thinkingSet: boolean; toolsSet: boolean },
+): void {
+	if (!explicit.modelSet && agent.model) options.modelPattern = agent.model; // agent.model is string[]; modelPattern accepts string | string[]
+	if (!explicit.thinkingSet && agent.thinkingLevel) options.thinkingLevel = agent.thinkingLevel;
+	if (!explicit.toolsSet && agent.tools) {
+		// `mainSessionTools` strips the subagent-only `yield`/`goal` tools
+		// `parseAgentFields` appends. The list is passed WITHOUT
+		// restrictToolNames: restriction would disable MCP, LSP, extensions,
+		// and memory for the main session, which the live-switch and subagent
+		// paths do not do (plan contingency).
+		options.toolNames = mainSessionTools(agent.tools);
+	}
+	if (agent.systemPrompt)
+		options.appendSystemPrompt = [options.appendSystemPrompt, agent.systemPrompt].filter(Boolean).join("\n\n");
+	options.spawns = spawnsToString(agent.spawns);
+}
+
 /** Builds startup session options from parsed CLI flags, scoped models, and resolved session lineage. */
 export async function buildSessionOptions(
 	parsed: Args,
@@ -1152,21 +1200,11 @@ export async function buildSessionOptions(
 			process.stderr.write(`${chalk.red(`Agent "${parsed.agent}" is disabled in settings.`)}\n`);
 			process.exit(1);
 		}
-		// CLI flags take precedence — agent fields fill only what CLI didn't set:
-		if (!options.model && !options.modelPattern && agent.model) options.modelPattern = agent.model; // agent.model is string[]; modelPattern accepts string | string[]
-		if (!options.thinkingLevel && agent.thinkingLevel) options.thinkingLevel = agent.thinkingLevel;
-		if (!parsed.tools && !parsed.noTools && agent.tools) {
-			// `parseAgentFields` appends `yield` to every explicit tool list because
-			// subagents need it to submit results. The main session has no parent
-			// executor to consume a yield — exposing it would prompt the model to
-			// "submit subagent output" and end its turn early. Strip it (and the
-			// goal-mode-only tool) before applying the persona's toolset.
-			options.toolNames = agent.tools.filter(name => name !== "yield" && name !== "goal");
-			options.restrictToolNames = true;
-		}
-		if (agent.systemPrompt)
-			options.appendSystemPrompt = [options.appendSystemPrompt, agent.systemPrompt].filter(Boolean).join("\n\n");
-		options.spawns = agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*";
+		applyAgentPersonaOptions(options, agent, {
+			modelSet: Boolean(options.model || options.modelPattern),
+			thinkingSet: options.thinkingLevel !== undefined,
+			toolsSet: Boolean(parsed.tools || parsed.noTools),
+		});
 	}
 
 	if (parsed.noLsp) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1156,7 +1156,12 @@ export async function buildSessionOptions(
 		if (!options.model && !options.modelPattern && agent.model) options.modelPattern = agent.model; // agent.model is string[]; modelPattern accepts string | string[]
 		if (!options.thinkingLevel && agent.thinkingLevel) options.thinkingLevel = agent.thinkingLevel;
 		if (!parsed.tools && !parsed.noTools && agent.tools) {
-			options.toolNames = agent.tools;
+			// `parseAgentFields` appends `yield` to every explicit tool list because
+			// subagents need it to submit results. The main session has no parent
+			// executor to consume a yield — exposing it would prompt the model to
+			// "submit subagent output" and end its turn early. Strip it (and the
+			// goal-mode-only tool) before applying the persona's toolset.
+			options.toolNames = agent.tools.filter(name => name !== "yield" && name !== "goal");
 			options.restrictToolNames = true;
 		}
 		if (agent.systemPrompt)

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -88,6 +88,7 @@ import { SessionManager } from "./session/session-manager";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
+import { discoverAgents, getAgent } from "./task/discovery";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
 import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
@@ -1131,6 +1132,38 @@ export async function buildSessionOptions(
 		options.toolNames = parsed.tools;
 	}
 
+	// Agent persona from --agent. CLI flags take precedence — agent frontmatter
+	// fills only what the CLI didn't set.
+	if (parsed.agent) {
+		const { agents } = await discoverAgents(parsed.cwd ?? getProjectDir());
+		const agent = getAgent(agents, parsed.agent);
+		if (!agent) {
+			process.stderr.write(`${chalk.red(`Unknown agent: ${parsed.agent}`)}\n`);
+			process.exit(1);
+		}
+		if (agent.availability === "subagent") {
+			process.stderr.write(
+				`${chalk.red(`Agent "${parsed.agent}" is subagent-only and cannot be used as the main-session persona.`)}\n`,
+			);
+			process.exit(1);
+		}
+		const disabledAgents = (activeSettings.get("task.disabledAgents") as string[] | undefined) ?? [];
+		if (disabledAgents.includes(parsed.agent)) {
+			process.stderr.write(`${chalk.red(`Agent "${parsed.agent}" is disabled in settings.`)}\n`);
+			process.exit(1);
+		}
+		// CLI flags take precedence — agent fields fill only what CLI didn't set:
+		if (!options.model && !options.modelPattern && agent.model) options.modelPattern = agent.model; // agent.model is string[]; modelPattern accepts string | string[]
+		if (!options.thinkingLevel && agent.thinkingLevel) options.thinkingLevel = agent.thinkingLevel;
+		if (!parsed.tools && !parsed.noTools && agent.tools) {
+			options.toolNames = agent.tools;
+			options.restrictToolNames = true;
+		}
+		if (agent.systemPrompt)
+			options.appendSystemPrompt = [options.appendSystemPrompt, agent.systemPrompt].filter(Boolean).join("\n\n");
+		options.spawns = agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*";
+	}
+
 	if (parsed.noLsp) {
 		options.enableLsp = false;
 	}
@@ -1679,6 +1712,16 @@ export async function runRootCommand(
 			eventBus,
 			preloadedExtensions: extensionsResult,
 		});
+
+		// Persist the persona identity. `initialArgs` (post-extension reparse)
+		// may be a different object than `parsedArgs`; prefer it when it carries
+		// the flag, falling back to the startup parse. `session.sessionManager`
+		// is the manager the session actually uses (the outer `sessionManager`
+		// may be undefined for fresh sessions, where the SDK creates its own).
+		const personaName = initialArgs.agent ?? parsedArgs.agent;
+		if (personaName) {
+			session.sessionManager.appendModeChange("agent", { name: personaName });
+		}
 
 		// Cold-revive support: a `parked` subagent ref restored from disk (Agent Hub
 		// scan, collab mirror, resumed process) has a sessionFile but no in-memory

--- a/packages/coding-agent/src/modes/components/agent-persona-picker.ts
+++ b/packages/coding-agent/src/modes/components/agent-persona-picker.ts
@@ -1,0 +1,78 @@
+/**
+ * `/switch-agent` persona picker: a bottom-anchored floating overlay listing
+ * main-selectable discovered agents (availability !== "subagent", not in
+ * `task.disabledAgents`). Selecting an entry live-switches the main-session
+ * persona via `switchAgentPersona`; Esc closes without changes. Keyboard-only,
+ * since mouse tracking is reserved for fullscreen overlays.
+ */
+import { type Component, type SelectItem, SelectList, type TUI } from "@oh-my-pi/pi-tui";
+import type { AgentDefinition } from "../../task/types";
+import { getSelectListTheme, theme } from "../theme/theme";
+import { bottomBorder, row, topBorder } from "./overlay-box";
+
+const STATUS_HINT = "Select an agent to switch the main-session persona";
+const FOOTER_HINT = "↑/↓ agents · Enter switch persona · Esc close";
+/** Fixed chrome rows: top border, status row, footer hint, bottom border. */
+const CHROME_ROWS = 4;
+/** Maximum list rows on short terminals. */
+const MAX_VISIBLE = 20;
+
+export interface AgentPersonaPickerCallbacks {
+	onPick: (agent: AgentDefinition) => void;
+	onCancel: () => void;
+}
+
+export class AgentPersonaPickerComponent implements Component {
+	#tui: TUI;
+	#list: SelectList;
+
+	constructor(tui: TUI, agents: AgentDefinition[], callbacks: AgentPersonaPickerCallbacks) {
+		this.#tui = tui;
+
+		const items: SelectItem[] = agents.map(agent => ({
+			value: agent.name,
+			label: agent.name,
+			description: agent.description,
+		}));
+		if (items.length === 0) {
+			items.push({
+				value: "__empty__",
+				label: "No main-selectable agents",
+				description: "All discovered agents are subagent-only or disabled",
+			});
+		}
+
+		this.#list = new SelectList(items, Math.min(items.length, MAX_VISIBLE), getSelectListTheme());
+		this.#list.onSelect = item => {
+			if (item.value === "__empty__") return;
+			const agent = agents.find(a => a.name === item.value);
+			if (agent) callbacks.onPick(agent);
+		};
+		this.#list.onCancel = () => callbacks.onCancel();
+	}
+
+	invalidate(): void {}
+
+	handleInput(data: string): void {
+		// Mouse tracking is off outside fullscreen overlays; drop any stray SGR
+		// reports instead of feeding them to the list.
+		if (data.startsWith("\x1b[<")) return;
+		this.#list.handleInput(data);
+	}
+
+	render(width: number): string[] {
+		const termRows = Math.max(16, this.#tui.terminal?.rows || process.stdout.rows || 40);
+		this.#list.setMaxVisible(Math.max(3, Math.min(MAX_VISIBLE, termRows - CHROME_ROWS - 2)));
+
+		const inner = Math.max(1, width - 4);
+		const out: string[] = [];
+		out.push(topBorder(width, "Switch Agent"));
+		out.push(row(theme.fg("muted", ` ${STATUS_HINT}`), width));
+		for (const line of this.#list.render(inner)) {
+			out.push(row(line, width));
+		}
+		out.push(row(theme.fg("dim", FOOTER_HINT), width));
+		out.push(bottomBorder(width));
+		return out;
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -60,6 +60,7 @@ import {
 	toResetUsageAccounts,
 } from "../../slash-commands/helpers/reset-usage";
 import { toSessionPinAccounts } from "../../slash-commands/helpers/session-pin";
+import { discoverAgents } from "../../task/discovery";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -82,6 +83,7 @@ import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { type AdvisorConfigDeps, AdvisorConfigOverlayComponent } from "../components/advisor-config";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
+import { AgentPersonaPickerComponent } from "../components/agent-persona-picker";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { CopySelectorComponent } from "../components/copy-selector";
 import { ExtensionDashboard } from "../components/extensions";
@@ -699,6 +701,43 @@ export class SelectorController {
 			return;
 		}
 		this.#showModelHub({});
+	}
+
+	/**
+	 * `/switch-agent` persona picker: a bottom-anchored overlay listing
+	 * main-selectable discovered agents (availability !== "subagent", not in
+	 * `task.disabledAgents`). Selecting an entry live-switches the persona;
+	 * Esc closes without changes.
+	 */
+	async showAgentPersonaSelector(): Promise<void> {
+		const { agents } = await discoverAgents(this.ctx.sessionManager.getCwd());
+		const disabled = new Set((this.ctx.settings.get("task.disabledAgents") as string[] | undefined) ?? []);
+		const selectable = agents.filter(agent => agent.availability !== "subagent" && !disabled.has(agent.name));
+
+		let overlayHandle: OverlayHandle | undefined;
+		let closed = false;
+		const done = () => {
+			if (closed) return;
+			closed = true;
+			overlayHandle?.hide();
+			this.focusActiveEditorArea();
+			this.ctx.ui.requestRender();
+		};
+		const picker = new AgentPersonaPickerComponent(this.ctx.ui, selectable, {
+			onPick: agent => {
+				done();
+				void this.ctx.switchAgentPersona(agent.name);
+			},
+			onCancel: done,
+		});
+		overlayHandle = this.ctx.ui.showOverlay(picker, {
+			anchor: "bottom-center",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+		this.ctx.ui.setFocus(picker);
+		this.ctx.ui.requestRender();
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -116,6 +116,7 @@ import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { discoverAgents, getAgent } from "../task/discovery";
 import { formatTaskId } from "../task/render";
+import type { AgentDefinition } from "../task/types";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import { tinyTitleClient } from "../tiny/title-client";
 import type { LspStartupServerInfo } from "../tools";
@@ -2542,6 +2543,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (!preserveVibe) await this.#enterVibeMode({ persistModeChange: false });
 			return;
 		}
+		if (sessionContext.mode === "agent") {
+			await this.#reconcilePersonaFromSession(sessionContext.modeData);
+			return;
+		}
 		if (!this.session.settings.get("plan.enabled")) {
 			// Clear stale plan/plan_paused mode so re-enabling the setting
 			// later doesn't unexpectedly restore an old plan session.
@@ -2557,6 +2562,55 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.planModePaused = true;
 			this.#planModeHasEntered = true;
 			this.#updatePlanModeStatus();
+		}
+	}
+
+	/**
+	 * Re-apply a persisted agent persona on resume/switch. The persona is
+	 * re-discovered fresh and its CURRENT definition is applied (tools, model,
+	 * thinking, spawns, system-prompt append). When the agent is gone, changed to
+	 * `subagent`, or disabled, the launch baseline tools/prompt are left untouched
+	 * and only a warning is emitted — model+thinking are already restored by the
+	 * existing `model_change`/`thinking_level_change` flow in switchSession.
+	 */
+	async #reconcilePersonaFromSession(data: Record<string, unknown> | undefined): Promise<void> {
+		const name = data?.name as string | undefined;
+		if (!name) return;
+		let agent: AgentDefinition | undefined;
+		try {
+			const { agents } = await discoverAgents(this.sessionManager.getCwd());
+			agent = getAgent(agents, name);
+		} catch (error) {
+			logger.warn("Failed to discover agents during persona restore", { error: String(error) });
+			return;
+		}
+		const disabledAgents = (this.session.settings.get("task.disabledAgents") as string[] | undefined) ?? [];
+		if (agent && agent.availability !== "subagent" && !disabledAgents.includes(name)) {
+			if (agent.tools) {
+				// `parseAgentFields` appends `yield` to every explicit tool list for
+				// subagent result submission; the main session has no parent executor
+				// to consume it. Strip it (and the goal-mode-only tool) before applying.
+				await this.session.setActiveToolsByName(
+					agent.tools.filter(toolName => toolName !== "yield" && toolName !== "goal"),
+				);
+			}
+			if (agent.thinkingLevel) {
+				this.session.setThinkingLevel(agent.thinkingLevel);
+			}
+			this.session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+			this.session.setPersonaAppendPrompt(agent.systemPrompt);
+			if (agent.model) {
+				const resolved = resolveModelOverride(agent.model, this.session.modelRegistry, this.session.settings);
+				if (resolved.model) {
+					await this.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+				}
+			}
+			await this.session.refreshBaseSystemPrompt();
+		} else {
+			this.session.emitNotice(
+				"warning",
+				`Agent "${name}" is no longer available. Restored model and thinking level.`,
+			);
 		}
 	}
 
@@ -2658,12 +2712,22 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		try {
 			if (agent.tools) {
-				await this.session.setActiveToolsByName(agent.tools);
+				// `parseAgentFields` appends `yield` to every explicit tool list for
+				// subagent result submission; the main session has no parent executor
+				// to consume it. Strip it (and the goal-mode-only tool) before applying.
+				await this.session.setActiveToolsByName(agent.tools.filter(name => name !== "yield" && name !== "goal"));
 			}
 			if (agent.model) {
 				const resolved = resolveModelOverride(agent.model, this.session.modelRegistry, this.session.settings);
 				if (resolved.model) {
-					await this.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+					if (this.session.isStreaming) {
+						// Mirror plan mode: never reset provider sessions under an
+						// in-flight turn — queue the switch and flush on agent_end.
+						this.#pendingModelSwitch = { model: resolved.model, thinkingLevel: resolved.thinkingLevel };
+						this.#pendingPlanModelSwitch = false;
+					} else {
+						await this.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+					}
 				} else {
 					this.showWarning(`Agent "${name}" model pattern did not resolve; keeping current model.`);
 				}
@@ -2676,9 +2740,18 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.session.refreshBaseSystemPrompt();
 		} catch (error) {
 			try {
+				// A queued persona model switch must not survive a failed apply —
+				// otherwise flushPendingModelSwitch would clobber the restored model.
+				this.#pendingModelSwitch = undefined;
+				this.#pendingPlanModelSwitch = false;
 				await this.session.setActiveToolsByName(previousTools);
 				if (previousModel) {
-					await this.session.setModelTemporary(previousModel, previousThinking);
+					if (this.session.isStreaming) {
+						this.#pendingModelSwitch = { model: previousModel, thinkingLevel: previousThinking };
+						this.#pendingPlanModelSwitch = false;
+					} else {
+						await this.session.setModelTemporary(previousModel, previousThinking);
+					}
 				}
 				this.session.setThinkingLevel(previousThinking);
 				this.session.setSessionSpawns(previousSpawns);
@@ -4802,6 +4875,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {
 		this.#selectorController.showModelSelector(options);
+	}
+
+	showAgentPersonaSelector(): void {
+		void this.#selectorController.showAgentPersonaSelector();
 	}
 
 	showPluginSelector(mode?: "install" | "uninstall"): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -114,6 +114,7 @@ import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } fr
 import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
+import { mainSessionTools, spawnsToString } from "../task/agent-tools";
 import { discoverAgents, getAgent } from "../task/discovery";
 import { formatTaskId } from "../task/render";
 import type { AgentDefinition } from "../task/types";
@@ -2587,17 +2588,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		const disabledAgents = (this.session.settings.get("task.disabledAgents") as string[] | undefined) ?? [];
 		if (agent && agent.availability !== "subagent" && !disabledAgents.includes(name)) {
 			if (agent.tools) {
-				// `parseAgentFields` appends `yield` to every explicit tool list for
-				// subagent result submission; the main session has no parent executor
-				// to consume it. Strip it (and the goal-mode-only tool) before applying.
-				await this.session.setActiveToolsByName(
-					agent.tools.filter(toolName => toolName !== "yield" && toolName !== "goal"),
-				);
+				await this.session.setActiveToolsByName(mainSessionTools(agent.tools));
 			}
 			if (agent.thinkingLevel) {
 				this.session.setThinkingLevel(agent.thinkingLevel);
 			}
-			this.session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+			this.session.setSessionSpawns(spawnsToString(agent.spawns));
 			this.session.setPersonaAppendPrompt(agent.systemPrompt);
 			if (agent.model) {
 				const resolved = resolveModelOverride(agent.model, this.session.modelRegistry, this.session.settings);
@@ -2689,6 +2685,18 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * applied change is rolled back (mirrors plan-mode rollback).
 	 */
 	async switchAgentPersona(name: string): Promise<void> {
+		if (this.planModeEnabled || this.planModePaused) {
+			this.showWarning("Exit plan mode first.");
+			return;
+		}
+		if (this.goalModeEnabled || this.goalModePaused) {
+			this.showWarning("Exit goal mode first.");
+			return;
+		}
+		if (this.vibeModeEnabled) {
+			this.showWarning("Exit vibe mode first.");
+			return;
+		}
 		const { agents } = await discoverAgents(this.sessionManager.getCwd());
 		const agent = getAgent(agents, name);
 		if (!agent) {
@@ -2712,10 +2720,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		try {
 			if (agent.tools) {
-				// `parseAgentFields` appends `yield` to every explicit tool list for
-				// subagent result submission; the main session has no parent executor
-				// to consume it. Strip it (and the goal-mode-only tool) before applying.
-				await this.session.setActiveToolsByName(agent.tools.filter(name => name !== "yield" && name !== "goal"));
+				await this.session.setActiveToolsByName(mainSessionTools(agent.tools));
 			}
 			if (agent.model) {
 				const resolved = resolveModelOverride(agent.model, this.session.modelRegistry, this.session.settings);
@@ -2735,7 +2740,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (agent.thinkingLevel) {
 				this.session.setThinkingLevel(agent.thinkingLevel);
 			}
-			this.session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+			this.session.setSessionSpawns(spawnsToString(agent.spawns));
 			this.session.setPersonaAppendPrompt(agent.systemPrompt);
 			await this.session.refreshBaseSystemPrompt();
 		} catch (error) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -57,7 +57,7 @@ import { reset as resetCapabilities } from "../capability";
 import type { CollabGuestLink } from "../collab/guest";
 import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
-import { formatModelString, type ResolvedModelRoleValue } from "../config/model-resolver";
+import { formatModelString, type ResolvedModelRoleValue, resolveModelOverride } from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import {
 	isSettingsInitialized,
@@ -114,6 +114,7 @@ import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } fr
 import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
+import { discoverAgents, getAgent } from "../task/discovery";
 import { formatTaskId } from "../task/render";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import { tinyTitleClient } from "../tiny/title-client";
@@ -2624,6 +2625,77 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#updatePlanModeStatus();
 		this.sessionManager.appendModeChange("plan", { planFilePath });
 		this.showStatus(`Plan mode enabled. Plan file: ${planFilePath}`);
+	}
+
+	/**
+	 * Live-switch the main session to a discovered agent persona: tools, model,
+	 * thinking level, spawns, and system-prompt append all come from the agent's
+	 * current definition. Persists a `mode_change` entry (`mode: "agent"`,
+	 * `data: { name }`) so resume re-applies the persona. On failure, every
+	 * applied change is rolled back (mirrors plan-mode rollback).
+	 */
+	async switchAgentPersona(name: string): Promise<void> {
+		const { agents } = await discoverAgents(this.sessionManager.getCwd());
+		const agent = getAgent(agents, name);
+		if (!agent) {
+			this.showError(`Unknown agent: ${name}`);
+			return;
+		}
+		if (agent.availability === "subagent") {
+			this.showError(`Agent "${name}" is subagent-only and cannot be used as the main-session persona.`);
+			return;
+		}
+		if ((this.session.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
+			this.showError(`Agent "${name}" is disabled in settings (task.disabledAgents).`);
+			return;
+		}
+
+		const previousTools = this.session.getEnabledToolNames();
+		const previousModel = this.session.model;
+		const previousThinking = this.session.configuredThinkingLevel();
+		const previousSpawns = this.session.getSessionSpawns();
+		const previousPrompt = this.session.getPersonaAppendPrompt();
+
+		try {
+			if (agent.tools) {
+				await this.session.setActiveToolsByName(agent.tools);
+			}
+			if (agent.model) {
+				const resolved = resolveModelOverride(agent.model, this.session.modelRegistry, this.session.settings);
+				if (resolved.model) {
+					await this.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+				} else {
+					this.showWarning(`Agent "${name}" model pattern did not resolve; keeping current model.`);
+				}
+			}
+			if (agent.thinkingLevel) {
+				this.session.setThinkingLevel(agent.thinkingLevel);
+			}
+			this.session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+			this.session.setPersonaAppendPrompt(agent.systemPrompt);
+			await this.session.refreshBaseSystemPrompt();
+		} catch (error) {
+			try {
+				await this.session.setActiveToolsByName(previousTools);
+				if (previousModel) {
+					await this.session.setModelTemporary(previousModel, previousThinking);
+				}
+				this.session.setThinkingLevel(previousThinking);
+				this.session.setSessionSpawns(previousSpawns);
+				this.session.setPersonaAppendPrompt(previousPrompt);
+				await this.session.refreshBaseSystemPrompt();
+			} catch (rollbackError) {
+				logger.warn("Failed to roll back agent persona switch", { error: String(rollbackError) });
+			}
+			this.showError(
+				`Failed to switch to agent persona "${name}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return;
+		}
+
+		this.sessionManager.appendModeChange("agent", { name });
+		this.showStatus(`Switched to agent persona: ${name}`);
+		this.statusLine.invalidate();
 	}
 
 	async #restorePlanPreviousModel(prev: { model: Model; thinkingLevel?: ConfiguredThinkingLevel }): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -387,6 +387,8 @@ export interface InteractiveModeContext {
 	showExtensionsDashboard(): void;
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
+	/** Live-switch the main session to a discovered agent persona. */
+	switchAgentPersona(name: string): Promise<void>;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
 	showUserMessageSelector(): void;
 	showCopySelector(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -387,6 +387,8 @@ export interface InteractiveModeContext {
 	showExtensionsDashboard(): void;
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
+	/** Open the `/switch-agent` persona picker overlay. */
+	showAgentPersonaSelector(): void;
 	/** Live-switch the main session to a discovered agent persona. */
 	switchAgentPersona(name: string): Promise<void>;
 	showPluginSelector(mode?: "install" | "uninstall"): void;

--- a/packages/coding-agent/src/prompts/system/rewind-report.md
+++ b/packages/coding-agent/src/prompts/system/rewind-report.md
@@ -1,6 +1,6 @@
 Checkpoint completed. The checkpoint's exploratory branch was rewound; the branch summary and retained report below are now the context.
 
-Do not call `rewind` again for this checkpoint. Continue from this retained report. You may start a new `checkpoint` to explore again.
+Do not call `rewind` again for THIS checkpoint. Continue from retained report. New `checkpoint` → explore again.
 
 Report:
 {{report}}

--- a/packages/coding-agent/src/prompts/system/rewind-report.md
+++ b/packages/coding-agent/src/prompts/system/rewind-report.md
@@ -1,6 +1,6 @@
 Checkpoint completed. The checkpoint's exploratory branch was rewound; the branch summary and retained report below are now the context.
 
-Do not call `rewind` again for this checkpoint. Continue from this retained report.
+Do not call `rewind` again for this checkpoint. Continue from this retained report. You may start a new `checkpoint` to explore again.
 
 Report:
 {{report}}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1708,7 +1708,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// unrelated global ref. With no lifecycle, hub cancel falls back to
 			// dispose + unregister on the session's own registry.
 			agentLifecycle: options.agentRegistry ? undefined : () => AgentLifecycleManager.global(),
-			getSessionSpawns: () => options.spawns ?? "*",
+			getSessionSpawns: () => session?.getSessionSpawns?.() ?? options.spawns ?? "*",
 			getModelString: () => (hasExplicitModel && model ? formatModelString(model) : undefined),
 			getActiveModelString,
 			getActiveModel: () => agent?.state.model ?? model,
@@ -2860,10 +2860,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				tools,
 				nativeTools && !inlineToolDescriptors ? { mode: "compact", toolNames } : { mode: "full" },
 			);
-			if (options.appendSystemPrompt) {
-				appendPrompt = appendPrompt
-					? `${appendPrompt}\n\n${options.appendSystemPrompt}`
-					: options.appendSystemPrompt;
+			const personaAppend = session?.getPersonaAppendPrompt?.() ?? options.appendSystemPrompt;
+			if (personaAppend) {
+				appendPrompt = appendPrompt ? `${appendPrompt}\n\n${personaAppend}` : personaAppend;
 			}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd: promptCwd,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1686,6 +1686,28 @@ export class AgentSession {
 		this.#sessionSwitchReconciler = reconciler ?? undefined;
 	}
 
+	/** Live persona spawn policy (`"*"`, a comma list, or null for the launch default). */
+	#sessionSpawns: string | null | undefined;
+
+	/** Live persona system-prompt append, overriding the launch-time `appendSystemPrompt`. */
+	#personaAppendPrompt: string | undefined;
+
+	getSessionSpawns(): string | null {
+		return this.#sessionSpawns ?? null;
+	}
+
+	setSessionSpawns(spawns: string | null): void {
+		this.#sessionSpawns = spawns;
+	}
+
+	getPersonaAppendPrompt(): string | undefined {
+		return this.#personaAppendPrompt;
+	}
+
+	setPersonaAppendPrompt(prompt: string | undefined): void {
+		this.#personaAppendPrompt = prompt;
+	}
+
 	/** Provider-scoped mutable state store for transport/session caches. */
 	get providerSessionState(): Map<string, ProviderSessionState> {
 		return this.#providerSessionState;

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -4,11 +4,13 @@ import {
 	formatModelString,
 	getModelMatchPreferences,
 	resolveCliModel,
+	resolveModelOverride,
 } from "../config/model-resolver";
 import type { SettingPath } from "../config/settings";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import type { InteractiveModeContext } from "../modes/types";
 import type { AgentSession } from "../session/agent-session";
+import { discoverAgents, getAgent } from "../task/discovery";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
@@ -320,6 +322,57 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showModelSelector();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "agent",
+		description: "Switch the main-session agent persona",
+		inlineHint: "<name>",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const name = command.args.trim();
+			if (!name) {
+				return usage("Usage: /agent <name>", runtime);
+			}
+			const { agents } = await discoverAgents(runtime.cwd);
+			const agent = getAgent(agents, name);
+			if (!agent) {
+				return usage(`Unknown agent: ${name}`, runtime);
+			}
+			if (agent.availability === "subagent") {
+				return usage(`Agent "${name}" is subagent-only and cannot be used as the main-session persona.`, runtime);
+			}
+			if ((runtime.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
+				return usage(`Agent "${name}" is disabled in settings (task.disabledAgents).`, runtime);
+			}
+			try {
+				if (agent.tools) {
+					await runtime.session.setActiveToolsByName(agent.tools);
+				}
+				if (agent.model) {
+					const resolved = resolveModelOverride(agent.model, runtime.session.modelRegistry, runtime.settings);
+					if (resolved.model) {
+						await runtime.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+					} else {
+						await runtime.output(`Agent "${name}" model pattern did not resolve; keeping current model.`);
+					}
+				}
+				if (agent.thinkingLevel) {
+					runtime.session.setThinkingLevel(agent.thinkingLevel);
+				}
+				runtime.session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+				runtime.session.setPersonaAppendPrompt(agent.systemPrompt);
+				await runtime.session.refreshBaseSystemPrompt();
+			} catch (err) {
+				return usage(`Failed to switch to agent persona "${name}": ${errorMessage(err)}`, runtime);
+			}
+			runtime.sessionManager.appendModeChange("agent", { name });
+			await runtime.output(`Switched to agent persona: ${name}`);
+			return commandConsumed();
+		},
+		handleTui: async (command, runtime) => {
+			await runtime.ctx.switchAgentPersona(command.args.trim());
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -11,6 +11,7 @@ import type { SettingPath } from "../config/settings";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import type { InteractiveModeContext } from "../modes/types";
 import type { AgentSession } from "../session/agent-session";
+import { mainSessionTools, spawnsToString } from "../task/agent-tools";
 import { discoverAgents, getAgent } from "../task/discovery";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { ComputerTool } from "../tools/computer";
@@ -18,7 +19,7 @@ import { computerExposureMode } from "../tools/computer/exposure";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
 import { commandConsumed, errorMessage, usage } from "./helpers/parse";
 import { handleSecurityCommand } from "./helpers/security";
-import type { SlashCommandSpec } from "./types";
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime, SlashCommandSpec } from "./types";
 
 export function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
@@ -52,17 +53,17 @@ async function applyAgentPersonaToSession(
 	const previousPrompt = session.getPersonaAppendPrompt();
 	try {
 		if (agent.tools) {
-			// `parseAgentFields` appends `yield` to every explicit tool list for
-			// subagent result submission; the main session has no parent executor
-			// to consume it. Strip it (and the goal-mode-only tool) before applying.
-			await session.setActiveToolsByName(
-				agent.tools.filter(toolName => toolName !== "yield" && toolName !== "goal"),
-			);
+			await session.setActiveToolsByName(mainSessionTools(agent.tools));
 		}
 		if (agent.model) {
 			const resolved = resolveModelOverride(agent.model, session.modelRegistry, session.settings);
 			if (resolved.model) {
-				await session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+				// ACP has no #pendingModelSwitch queue (that is an InteractiveMode
+				// field); guard the reset instead so an in-flight turn is not
+				// clobbered. The switch applies on the next turn.
+				if (!session.isStreaming) {
+					await session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+				}
 			} else {
 				await output(`Agent "${name}" model pattern did not resolve; keeping current model.`);
 			}
@@ -70,13 +71,13 @@ async function applyAgentPersonaToSession(
 		if (agent.thinkingLevel) {
 			session.setThinkingLevel(agent.thinkingLevel);
 		}
-		session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+		session.setSessionSpawns(spawnsToString(agent.spawns));
 		session.setPersonaAppendPrompt(agent.systemPrompt);
 		await session.refreshBaseSystemPrompt();
 	} catch (error) {
 		try {
 			await session.setActiveToolsByName(previousTools);
-			if (previousModel) {
+			if (previousModel && !session.isStreaming) {
 				await session.setModelTemporary(previousModel, previousThinking);
 			}
 			session.setThinkingLevel(previousThinking);
@@ -89,6 +90,39 @@ async function applyAgentPersonaToSession(
 		return `Failed to switch to agent persona "${name}": ${errorMessage(error)}`;
 	}
 	return null;
+}
+
+/**
+ * Shared ACP/text-mode handler for `/agent` and `/switch-agent`: validate the
+ * named agent, apply the persona with rollback, and persist the identity.
+ */
+async function switchAgentPersonaAcp(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+	usageText: string,
+): Promise<SlashCommandResult> {
+	const name = command.args.trim();
+	if (!name) {
+		return usage(usageText, runtime);
+	}
+	const { agents } = await discoverAgents(runtime.cwd);
+	const agent = getAgent(agents, name);
+	if (!agent) {
+		return usage(`Unknown agent: ${name}`, runtime);
+	}
+	if (agent.availability === "subagent") {
+		return usage(`Agent "${name}" is subagent-only and cannot be used as the main-session persona.`, runtime);
+	}
+	if ((runtime.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
+		return usage(`Agent "${name}" is disabled in settings (task.disabledAgents).`, runtime);
+	}
+	const failure = await applyAgentPersonaToSession(runtime.session, agent, name, runtime.output);
+	if (failure) {
+		return usage(failure, runtime);
+	}
+	runtime.sessionManager.appendModeChange("agent", { name });
+	await runtime.output(`Switched to agent persona: ${name}`);
+	return commandConsumed();
 }
 
 /** `/fast status` label for the active model: "on" when its family is priority, else "off". */
@@ -398,30 +432,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		description: "Switch the main-session agent persona",
 		inlineHint: "<name>",
 		allowArgs: true,
-		handle: async (command, runtime) => {
-			const name = command.args.trim();
-			if (!name) {
-				return usage("Usage: /agent <name>", runtime);
-			}
-			const { agents } = await discoverAgents(runtime.cwd);
-			const agent = getAgent(agents, name);
-			if (!agent) {
-				return usage(`Unknown agent: ${name}`, runtime);
-			}
-			if (agent.availability === "subagent") {
-				return usage(`Agent "${name}" is subagent-only and cannot be used as the main-session persona.`, runtime);
-			}
-			if ((runtime.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
-				return usage(`Agent "${name}" is disabled in settings (task.disabledAgents).`, runtime);
-			}
-			const failure = await applyAgentPersonaToSession(runtime.session, agent, name, runtime.output);
-			if (failure) {
-				return usage(failure, runtime);
-			}
-			runtime.sessionManager.appendModeChange("agent", { name });
-			await runtime.output(`Switched to agent persona: ${name}`);
-			return commandConsumed();
-		},
+		handle: (command, runtime) => switchAgentPersonaAcp(command, runtime, "Usage: /agent <name>"),
 		handleTui: async (command, runtime) => {
 			const name = command.args.trim();
 			if (!name) {
@@ -438,30 +449,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		description: "Switch the main-session agent persona",
 		inlineHint: "[name]",
 		allowArgs: true,
-		handle: async (command, runtime) => {
-			const name = command.args.trim();
-			if (!name) {
-				return usage("Usage: /switch-agent [name]", runtime);
-			}
-			const { agents } = await discoverAgents(runtime.cwd);
-			const agent = getAgent(agents, name);
-			if (!agent) {
-				return usage(`Unknown agent: ${name}`, runtime);
-			}
-			if (agent.availability === "subagent") {
-				return usage(`Agent "${name}" is subagent-only and cannot be used as the main-session persona.`, runtime);
-			}
-			if ((runtime.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
-				return usage(`Agent "${name}" is disabled in settings (task.disabledAgents).`, runtime);
-			}
-			const failure = await applyAgentPersonaToSession(runtime.session, agent, name, runtime.output);
-			if (failure) {
-				return usage(failure, runtime);
-			}
-			runtime.sessionManager.appendModeChange("agent", { name });
-			await runtime.output(`Switched to agent persona: ${name}`);
-			return commandConsumed();
-		},
+		handle: (command, runtime) => switchAgentPersonaAcp(command, runtime, "Usage: /switch-agent [name]"),
 		handleTui: (command, runtime) => {
 			const name = command.args.trim();
 			if (name) {

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
 import {
 	expandRoleAlias,
 	formatModelString,
@@ -11,6 +12,7 @@ import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import type { InteractiveModeContext } from "../modes/types";
 import type { AgentSession } from "../session/agent-session";
 import { discoverAgents, getAgent } from "../task/discovery";
+import type { ConfiguredThinkingLevel } from "../thinking";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
@@ -21,6 +23,72 @@ import type { SlashCommandSpec } from "./types";
 export function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
 	ctx.ui.requestRender();
+}
+
+/**
+ * Apply a discovered agent's frontmatter to a session (tools, model, thinking,
+ * spawns, system-prompt append) with snapshot/rollback, mirroring
+ * `InteractiveMode.switchAgentPersona`. Shared by the `/agent` and
+ * `/switch-agent` ACP/text handlers so both paths get the same atomicity.
+ * Returns a human-readable error message on failure (state already rolled back),
+ * or `null` on success.
+ */
+async function applyAgentPersonaToSession(
+	session: AgentSession,
+	agent: {
+		tools?: string[];
+		model?: string[];
+		thinkingLevel?: ConfiguredThinkingLevel;
+		spawns?: string[] | "*";
+		systemPrompt: string;
+	},
+	name: string,
+	output: (text: string) => Promise<void> | void,
+): Promise<string | null> {
+	const previousTools = session.getEnabledToolNames();
+	const previousModel = session.model;
+	const previousThinking = session.configuredThinkingLevel();
+	const previousSpawns = session.getSessionSpawns();
+	const previousPrompt = session.getPersonaAppendPrompt();
+	try {
+		if (agent.tools) {
+			// `parseAgentFields` appends `yield` to every explicit tool list for
+			// subagent result submission; the main session has no parent executor
+			// to consume it. Strip it (and the goal-mode-only tool) before applying.
+			await session.setActiveToolsByName(
+				agent.tools.filter(toolName => toolName !== "yield" && toolName !== "goal"),
+			);
+		}
+		if (agent.model) {
+			const resolved = resolveModelOverride(agent.model, session.modelRegistry, session.settings);
+			if (resolved.model) {
+				await session.setModelTemporary(resolved.model, resolved.thinkingLevel);
+			} else {
+				await output(`Agent "${name}" model pattern did not resolve; keeping current model.`);
+			}
+		}
+		if (agent.thinkingLevel) {
+			session.setThinkingLevel(agent.thinkingLevel);
+		}
+		session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
+		session.setPersonaAppendPrompt(agent.systemPrompt);
+		await session.refreshBaseSystemPrompt();
+	} catch (error) {
+		try {
+			await session.setActiveToolsByName(previousTools);
+			if (previousModel) {
+				await session.setModelTemporary(previousModel, previousThinking);
+			}
+			session.setThinkingLevel(previousThinking);
+			session.setSessionSpawns(previousSpawns);
+			session.setPersonaAppendPrompt(previousPrompt);
+			await session.refreshBaseSystemPrompt();
+		} catch (rollbackError) {
+			logger.warn("Failed to roll back agent persona switch", { error: String(rollbackError) });
+		}
+		return `Failed to switch to agent persona "${name}": ${errorMessage(error)}`;
+	}
+	return null;
 }
 
 /** `/fast status` label for the active model: "on" when its family is priority, else "off". */
@@ -346,33 +414,61 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			if ((runtime.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
 				return usage(`Agent "${name}" is disabled in settings (task.disabledAgents).`, runtime);
 			}
-			try {
-				if (agent.tools) {
-					await runtime.session.setActiveToolsByName(agent.tools);
-				}
-				if (agent.model) {
-					const resolved = resolveModelOverride(agent.model, runtime.session.modelRegistry, runtime.settings);
-					if (resolved.model) {
-						await runtime.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
-					} else {
-						await runtime.output(`Agent "${name}" model pattern did not resolve; keeping current model.`);
-					}
-				}
-				if (agent.thinkingLevel) {
-					runtime.session.setThinkingLevel(agent.thinkingLevel);
-				}
-				runtime.session.setSessionSpawns(agent.spawns === "*" ? "*" : agent.spawns ? agent.spawns.join(",") : "*");
-				runtime.session.setPersonaAppendPrompt(agent.systemPrompt);
-				await runtime.session.refreshBaseSystemPrompt();
-			} catch (err) {
-				return usage(`Failed to switch to agent persona "${name}": ${errorMessage(err)}`, runtime);
+			const failure = await applyAgentPersonaToSession(runtime.session, agent, name, runtime.output);
+			if (failure) {
+				return usage(failure, runtime);
 			}
 			runtime.sessionManager.appendModeChange("agent", { name });
 			await runtime.output(`Switched to agent persona: ${name}`);
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {
-			await runtime.ctx.switchAgentPersona(command.args.trim());
+			const name = command.args.trim();
+			if (!name) {
+				runtime.ctx.showWarning("Usage: /agent <name>");
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			await runtime.ctx.switchAgentPersona(name);
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "switch-agent",
+		description: "Switch the main-session agent persona",
+		inlineHint: "[name]",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const name = command.args.trim();
+			if (!name) {
+				return usage("Usage: /switch-agent [name]", runtime);
+			}
+			const { agents } = await discoverAgents(runtime.cwd);
+			const agent = getAgent(agents, name);
+			if (!agent) {
+				return usage(`Unknown agent: ${name}`, runtime);
+			}
+			if (agent.availability === "subagent") {
+				return usage(`Agent "${name}" is subagent-only and cannot be used as the main-session persona.`, runtime);
+			}
+			if ((runtime.settings.get("task.disabledAgents") as string[] | undefined)?.includes(name)) {
+				return usage(`Agent "${name}" is disabled in settings (task.disabledAgents).`, runtime);
+			}
+			const failure = await applyAgentPersonaToSession(runtime.session, agent, name, runtime.output);
+			if (failure) {
+				return usage(failure, runtime);
+			}
+			runtime.sessionManager.appendModeChange("agent", { name });
+			await runtime.output(`Switched to agent persona: ${name}`);
+			return commandConsumed();
+		},
+		handleTui: (command, runtime) => {
+			const name = command.args.trim();
+			if (name) {
+				void runtime.ctx.switchAgentPersona(name);
+			} else {
+				runtime.ctx.showAgentPersonaSelector();
+			}
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/task/agent-tools.ts
+++ b/packages/coding-agent/src/task/agent-tools.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared conversions for applying an agent definition's frontmatter to the
+ * MAIN session (as opposed to a subagent spawn). `parseAgentFields` appends
+ * `yield` to every explicit tool list because subagents need it to submit
+ * results; the main session has no parent executor to consume a yield, so the
+ * subagent-only tools are stripped before the persona's toolset is applied.
+ */
+export function mainSessionTools(tools: string[]): string[] {
+	return tools.filter(name => name !== "yield" && name !== "goal");
+}
+
+/** Serialize an agent's `spawns` frontmatter to the session's spawn string. */
+export function spawnsToString(spawns: string[] | "*" | undefined): string {
+	return spawns === "*" ? "*" : spawns ? spawns.join(",") : "*";
+}

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -257,6 +257,12 @@ export async function resolveEffectiveSubagentPolicy(
 		const available = discovery.agents.map(candidate => candidate.name).join(", ") || "none";
 		throw new StructuredSubagentError("preflight", `Unknown agent "${agentName}". Available: ${available}`);
 	}
+	if (agent.availability === "primary") {
+		throw new StructuredSubagentError(
+			"preflight",
+			`Agent "${agentName}" is primary/main-session-only and cannot be spawned as a subagent.`,
+		);
+	}
 	const disabledAgents = request.session.settings.get("task.disabledAgents") as string[];
 	if (disabledAgents.includes(agentName)) {
 		const enabled = discovery.agents

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -359,6 +359,11 @@ export interface ReviewData {
 export interface AgentDefinition {
 	name: string;
 	description: string;
+	/**
+	 * Which session roles this agent may serve. Defaults to `"all"` when the
+	 * frontmatter carries no availability fields (backward compatible).
+	 */
+	availability?: AgentAvailability;
 	systemPrompt: string;
 	tools?: string[];
 	spawns?: string[] | "*";
@@ -374,6 +379,9 @@ export interface AgentDefinition {
 	source: AgentSource;
 	filePath?: string;
 }
+
+/** Which session roles an agent definition may serve. */
+export type AgentAvailability = "primary" | "subagent" | "all";
 
 /** Details extracted from a subagent `yield` tool call for final-result assembly and task rendering. */
 export interface YieldItem {

--- a/packages/coding-agent/test/agent-persona-switch.test.ts
+++ b/packages/coding-agent/test/agent-persona-switch.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Live `/agent` persona switching: mutable session state (spawns + persona
+ * prompt), the `/agent` slash-command spec, and `InteractiveMode.switchAgentPersona`
+ * applying tools/model/thinking/spawns/prompt from a discovered agent definition
+ * with a persisted `mode_change` entry (`mode: "agent"`, `data: { name }`).
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Effort } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { BUILTIN_MODE_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-modes";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+
+function makeTool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `Fake ${name}`,
+		parameters: type({}),
+		async execute() {
+			return { content: [{ type: "text" as const, text: "ok" }] };
+		},
+	};
+}
+
+function agentMd(name: string, extraFrontmatter: string[] = []): string {
+	return ["---", `name: ${name}`, `description: ${name}`, ...extraFrontmatter, "---", `You are ${name}.`].join("\n");
+}
+
+describe("AgentSession persona state", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-persona-state-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled anthropic/claude-sonnet-4-5 to exist");
+		const toolRegistry = new Map<string, AgentTool>();
+		toolRegistry.set("read", makeTool("read"));
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [makeTool("read")],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+			}),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: registry,
+			toolRegistry,
+			builtInToolNames: ["read"],
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		session = undefined;
+		resetSettingsForTest();
+	});
+
+	it("round-trips session spawns (fresh session → null)", () => {
+		expect(session?.getSessionSpawns()).toBeNull();
+		session?.setSessionSpawns("a,b");
+		expect(session?.getSessionSpawns()).toBe("a,b");
+		session?.setSessionSpawns(null);
+		expect(session?.getSessionSpawns()).toBeNull();
+	});
+
+	it("round-trips the persona append prompt", () => {
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+		session?.setPersonaAppendPrompt("You are the persona.");
+		expect(session?.getPersonaAppendPrompt()).toBe("You are the persona.");
+		session?.setPersonaAppendPrompt(undefined);
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+	});
+});
+
+describe("BUILTIN_MODE_SLASH_COMMANDS /agent", () => {
+	it("registers /agent with allowArgs", () => {
+		const spec = BUILTIN_MODE_SLASH_COMMANDS.find(command => command.name === "agent");
+		expect(spec).toBeDefined();
+		expect(spec?.allowArgs).toBe(true);
+		expect(spec?.description).toBe("Switch the main-session agent persona");
+	});
+});
+
+describe("InteractiveMode.switchAgentPersona", () => {
+	let tempHome: string;
+	let projectDir: string;
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode | undefined;
+	let session: AgentSession | undefined;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-persona-switch-"));
+		projectDir = path.join(tempHome, "project");
+		await fs.mkdir(path.join(projectDir, ".omp", "agents"), { recursive: true });
+		const agentsDir = path.join(projectDir, ".omp", "agents");
+		await fs.writeFile(
+			path.join(agentsDir, "persona-test.md"),
+			agentMd("persona-test", [
+				"tools: [read, write]",
+				"model: anthropic/claude-haiku-4-5",
+				"thinkingLevel: high",
+				"spawns: [scout]",
+			]),
+		);
+		await fs.writeFile(
+			path.join(agentsDir, "persona-unresolvable.md"),
+			agentMd("persona-unresolvable", ["model: nonexistent/model"]),
+		);
+		await fs.writeFile(path.join(agentsDir, "persona-subagent.md"), agentMd("persona-subagent", ["mode: subagent"]));
+		await fs.writeFile(path.join(agentsDir, "persona-minimal.md"), agentMd("persona-minimal"));
+
+		await Settings.init({ inMemory: true, cwd: projectDir });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempHome, "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		await fs.rm(tempHome, { recursive: true, force: true });
+		mode = undefined;
+		session = undefined;
+		resetSettingsForTest();
+	});
+
+	function createHarness(settings: Settings): InteractiveMode {
+		const registry = new ModelRegistry(authStorage, path.join(tempHome, `models-${Bun.nanoseconds()}.yml`));
+		const initialModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!initialModel) throw new Error("Expected bundled anthropic/claude-sonnet-4-5 to exist");
+		const readTool = makeTool("read");
+		const writeTool = makeTool("write");
+		const toolRegistry = new Map<string, AgentTool>();
+		toolRegistry.set(readTool.name, readTool);
+		toolRegistry.set(writeTool.name, writeTool);
+		const manager = SessionManager.create(projectDir, path.join(tempHome, `active-${Bun.nanoseconds()}`));
+		const createdSession = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: initialModel,
+					systemPrompt: ["Test"],
+					tools: [readTool],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+			}),
+			sessionManager: manager,
+			settings,
+			modelRegistry: registry,
+			toolRegistry,
+			builtInToolNames: ["read", "write"],
+		});
+		session = createdSession;
+		mode = new InteractiveMode(createdSession, "test");
+		return mode;
+	}
+
+	it("applies tools, model, thinking, spawns, and prompt from the agent definition", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		await created.switchAgentPersona("persona-test");
+
+		expect(session?.getEnabledToolNames()).toEqual(["read", "write"]);
+		expect(session?.model?.id).toBe("claude-haiku-4-5");
+		expect(session?.configuredThinkingLevel()).toBe(Effort.High);
+		expect(session?.getSessionSpawns()).toBe("scout");
+		expect(session?.getPersonaAppendPrompt()).toBe("You are persona-test.");
+
+		const entries = session?.sessionManager.getEntries() ?? [];
+		const modeChange = entries.find(
+			(entry): entry is Extract<typeof entry, { type: "mode_change" }> =>
+				entry.type === "mode_change" && entry.mode === "agent",
+		);
+		expect(modeChange).toBeDefined();
+		expect(modeChange?.data).toEqual({ name: "persona-test" });
+	});
+
+	it("keeps current model with a warning when the agent model pattern does not resolve", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		const warning = vi.spyOn(created, "showWarning");
+		await created.switchAgentPersona("persona-unresolvable");
+
+		expect(session?.model?.id).toBe("claude-sonnet-4-5");
+		expect(warning).toHaveBeenCalledWith(
+			'Agent "persona-unresolvable" model pattern did not resolve; keeping current model.',
+		);
+		// The rest of the switch still applies and persists.
+		expect(session?.getPersonaAppendPrompt()).toBe("You are persona-unresolvable.");
+		const entries = session?.sessionManager.getEntries() ?? [];
+		expect(entries.some(entry => entry.type === "mode_change" && entry.mode === "agent")).toBe(true);
+	});
+
+	it("keeps current tools/model/thinking when the agent omits those fields", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		await created.switchAgentPersona("persona-minimal");
+
+		expect(session?.getEnabledToolNames()).toEqual(["read"]);
+		expect(session?.model?.id).toBe("claude-sonnet-4-5");
+		expect(session?.configuredThinkingLevel()).toBeUndefined();
+		expect(session?.getSessionSpawns()).toBe("*");
+		expect(session?.getPersonaAppendPrompt()).toBe("You are persona-minimal.");
+	});
+
+	it("rejects subagent-only agents", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		const error = vi.spyOn(created, "showError");
+		await created.switchAgentPersona("persona-subagent");
+
+		expect(error).toHaveBeenCalledWith(
+			'Agent "persona-subagent" is subagent-only and cannot be used as the main-session persona.',
+		);
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+	});
+
+	it("rejects unknown agents", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		const error = vi.spyOn(created, "showError");
+		await created.switchAgentPersona("does-not-exist");
+
+		expect(error).toHaveBeenCalledWith("Unknown agent: does-not-exist");
+	});
+
+	it("rolls back all applied state when the model switch fails mid-apply", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		const error = vi.spyOn(created, "showError");
+		// First setModelTemporary (the apply) throws; the rollback call uses the real implementation.
+		vi.spyOn(session!, "setModelTemporary").mockImplementationOnce(async () => {
+			throw new Error("no API key");
+		});
+		await created.switchAgentPersona("persona-test");
+
+		expect(error).toHaveBeenCalledWith(expect.stringContaining('Failed to switch to agent persona "persona-test"'));
+		expect(session?.getEnabledToolNames()).toEqual(["read"]);
+		expect(session?.model?.id).toBe("claude-sonnet-4-5");
+		expect(session?.configuredThinkingLevel()).toBeUndefined();
+		expect(session?.getSessionSpawns()).toBeNull();
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+		// No mode_change persisted on failure.
+		const entries = session?.sessionManager.getEntries() ?? [];
+		expect(entries.some(entry => entry.type === "mode_change" && entry.mode === "agent")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/agent-persona-switch.test.ts
+++ b/packages/coding-agent/test/agent-persona-switch.test.ts
@@ -17,7 +17,9 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { BUILTIN_MODE_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-modes";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { InteractiveMode } from "../src/modes/interactive-mode";
@@ -269,6 +271,135 @@ describe("InteractiveMode.switchAgentPersona", () => {
 		expect(session?.getSessionSpawns()).toBeNull();
 		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
 		// No mode_change persisted on failure.
+		const entries = session?.sessionManager.getEntries() ?? [];
+		expect(entries.some(entry => entry.type === "mode_change" && entry.mode === "agent")).toBe(false);
+	});
+});
+
+describe("ACP /agent and /switch-agent handle paths", () => {
+	let tempHome: string;
+	let projectDir: string;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-persona-acp-"));
+		projectDir = path.join(tempHome, "project");
+		await fs.mkdir(path.join(projectDir, ".omp", "agents"), { recursive: true });
+		const agentsDir = path.join(projectDir, ".omp", "agents");
+		await fs.writeFile(
+			path.join(agentsDir, "persona-test.md"),
+			agentMd("persona-test", [
+				"tools: [read, write]",
+				"model: anthropic/claude-haiku-4-5",
+				"thinkingLevel: high",
+				"spawns: [scout]",
+			]),
+		);
+		await fs.writeFile(path.join(agentsDir, "persona-subagent.md"), agentMd("persona-subagent", ["mode: subagent"]));
+
+		await Settings.init({ inMemory: true, cwd: projectDir });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempHome, "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		await fs.rm(tempHome, { recursive: true, force: true });
+		session = undefined;
+		resetSettingsForTest();
+	});
+
+	function createAcpRuntime(): SlashCommandRuntime {
+		const registry = new ModelRegistry(authStorage, path.join(tempHome, `models-${Bun.nanoseconds()}.yml`));
+		const initialModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!initialModel) throw new Error("Expected bundled anthropic/claude-sonnet-4-5 to exist");
+		const readTool = makeTool("read");
+		const writeTool = makeTool("write");
+		const toolRegistry = new Map<string, AgentTool>();
+		toolRegistry.set(readTool.name, readTool);
+		toolRegistry.set(writeTool.name, writeTool);
+		const manager = SessionManager.create(projectDir, path.join(tempHome, `active-${Bun.nanoseconds()}`));
+		const createdSession = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: initialModel,
+					systemPrompt: ["Test"],
+					tools: [readTool],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+			}),
+			sessionManager: manager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: registry,
+			toolRegistry,
+			builtInToolNames: ["read", "write"],
+		});
+		session = createdSession;
+		const output = vi.fn();
+		return {
+			session: createdSession,
+			sessionManager: manager,
+			settings: createdSession.settings,
+			cwd: projectDir,
+			output,
+			refreshCommands: vi.fn(),
+			reloadPlugins: vi.fn(),
+		} as unknown as SlashCommandRuntime;
+	}
+
+	it("applies the persona and persists mode_change via the ACP handle", async () => {
+		const runtime = createAcpRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/agent persona-test", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session?.getEnabledToolNames()).toEqual(["read", "write"]);
+		expect(session?.model?.id).toBe("claude-haiku-4-5");
+		expect(session?.configuredThinkingLevel()).toBe(Effort.High);
+		expect(session?.getSessionSpawns()).toBe("scout");
+		expect(session?.getPersonaAppendPrompt()).toBe("You are persona-test.");
+		const entries = session?.sessionManager.getEntries() ?? [];
+		const modeChange = entries.find(
+			(entry): entry is Extract<typeof entry, { type: "mode_change" }> =>
+				entry.type === "mode_change" && entry.mode === "agent",
+		);
+		expect(modeChange?.data).toEqual({ name: "persona-test" });
+	});
+
+	it("rejects subagent-only agents via the ACP handle", async () => {
+		const runtime = createAcpRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/agent persona-subagent", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+		const entries = session?.sessionManager.getEntries() ?? [];
+		expect(entries.some(entry => entry.type === "mode_change" && entry.mode === "agent")).toBe(false);
+	});
+
+	it("rejects unknown agents via the ACP handle", async () => {
+		const runtime = createAcpRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/agent does-not-exist", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+	});
+
+	it("rolls back partial apply failures via the ACP handle", async () => {
+		const runtime = createAcpRuntime();
+		vi.spyOn(session!, "setModelTemporary").mockImplementationOnce(async () => {
+			throw new Error("no API key");
+		});
+		const result = await executeAcpBuiltinSlashCommand("/agent persona-test", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session?.getEnabledToolNames()).toEqual(["read"]);
+		expect(session?.model?.id).toBe("claude-sonnet-4-5");
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
 		const entries = session?.sessionManager.getEntries() ?? [];
 		expect(entries.some(entry => entry.type === "mode_change" && entry.mode === "agent")).toBe(false);
 	});

--- a/packages/coding-agent/test/cli-agent-flag.test.ts
+++ b/packages/coding-agent/test/cli-agent-flag.test.ts
@@ -156,7 +156,7 @@ describe("--agent CLI flag", () => {
 
 		expect(options.modelPattern).toEqual(["anthropic/claude-sonnet-4-5"]);
 		expect(options.thinkingLevel).toBe(Effort.High);
-		expect(options.toolNames).toEqual(["read", "bash", "yield"]);
+		expect(options.toolNames).toEqual(["read", "bash"]);
 		expect(options.restrictToolNames).toBe(true);
 		expect(options.spawns).toBe("scout");
 		expect(options.appendSystemPrompt).toContain("You are the myagent persona for the main session.");

--- a/packages/coding-agent/test/cli-agent-flag.test.ts
+++ b/packages/coding-agent/test/cli-agent-flag.test.ts
@@ -157,7 +157,7 @@ describe("--agent CLI flag", () => {
 		expect(options.modelPattern).toEqual(["anthropic/claude-sonnet-4-5"]);
 		expect(options.thinkingLevel).toBe(Effort.High);
 		expect(options.toolNames).toEqual(["read", "bash"]);
-		expect(options.restrictToolNames).toBe(true);
+		expect(options.restrictToolNames).toBeUndefined();
 		expect(options.spawns).toBe("scout");
 		expect(options.appendSystemPrompt).toContain("You are the myagent persona for the main session.");
 	});

--- a/packages/coding-agent/test/cli-agent-flag.test.ts
+++ b/packages/coding-agent/test/cli-agent-flag.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { clearOmpExtensionCliRoots } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
+import { buildSessionOptions } from "@oh-my-pi/pi-coding-agent/main";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+const MYAGENT_MD = [
+	"---",
+	"name: myagent",
+	"description: Test main-session persona agent.",
+	"model: anthropic/claude-sonnet-4-5",
+	"tools: read, bash",
+	"spawns: scout",
+	"thinkingLevel: high",
+	"---",
+	"You are the myagent persona for the main session.",
+].join("\n");
+
+const SUBAGENT_ONLY_MD = [
+	"---",
+	"name: subagentOnlyAgent",
+	"description: Subagent-only test agent.",
+	"mode: subagent",
+	"---",
+	"You are a subagent-only agent.",
+].join("\n");
+
+describe("--agent CLI flag", () => {
+	let tempDir: string;
+	const authStoragesToClose: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-cli-agent-${Snowflake.next()}`);
+		fs.mkdirSync(path.join(tempDir, ".omp", "agents"), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, ".omp", "agents", "myagent.md"), MYAGENT_MD);
+		fs.writeFileSync(path.join(tempDir, ".omp", "agents", "subagentOnlyAgent.md"), SUBAGENT_ONLY_MD);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		for (const authStorage of authStoragesToClose) authStorage.close();
+		authStoragesToClose.length = 0;
+		clearOmpExtensionCliRoots();
+		clearFsCache();
+		if (tempDir && fs.existsSync(tempDir)) removeSyncWithRetries(tempDir);
+	});
+
+	async function newRegistry(name: string): Promise<{ authStorage: AuthStorage; modelRegistry: ModelRegistry }> {
+		const authStorage = await AuthStorage.create(path.join(tempDir, `${name}.db`));
+		authStoragesToClose.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, `${name}.yml`));
+		return { authStorage, modelRegistry };
+	}
+
+	function spyExit() {
+		return vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("process.exit called");
+		});
+	}
+
+	test("parseArgs records --agent", () => {
+		const parsed = parseArgs(["--agent", "myagent"]);
+
+		expect(parsed.agent).toBe("myagent");
+	});
+
+	test("--model CLI flag wins over agent.model", async () => {
+		const { modelRegistry } = await newRegistry("cli-model");
+		const settings = Settings.isolated();
+		const parsed = parseArgs(["--cwd", tempDir, "--agent", "myagent", "--model", "anthropic/claude-sonnet-4-5"]);
+
+		const options = await buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings);
+
+		expect(options.model?.provider).toBe("anthropic");
+		expect(options.model?.id).toBe("claude-sonnet-4-5");
+		expect(options.modelPattern).toBeUndefined();
+	});
+
+	test("--tools CLI flag wins over agent.tools", async () => {
+		const { modelRegistry } = await newRegistry("cli-tools");
+		const settings = Settings.isolated();
+		const parsed = parseArgs(["--cwd", tempDir, "--agent", "myagent", "--tools", "read"]);
+
+		const options = await buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings);
+
+		expect(options.toolNames).toEqual(["read"]);
+		expect(options.restrictToolNames).toBeUndefined();
+	});
+
+	test("--agent unknown exits 1", async () => {
+		const { modelRegistry } = await newRegistry("unknown");
+		const settings = Settings.isolated();
+		const parsed = parseArgs(["--cwd", tempDir, "--agent", "unknown"]);
+		const exitSpy = spyExit();
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		try {
+			await expect(
+				buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings),
+			).rejects.toThrow("process.exit called");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		} finally {
+			exitSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+	});
+
+	test("--agent subagent-only agent exits 1", async () => {
+		const { modelRegistry } = await newRegistry("subagent");
+		const settings = Settings.isolated();
+		const parsed = parseArgs(["--cwd", tempDir, "--agent", "subagentOnlyAgent"]);
+		const exitSpy = spyExit();
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		try {
+			await expect(
+				buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings),
+			).rejects.toThrow("process.exit called");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		} finally {
+			exitSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+	});
+
+	test("--agent disabled in settings exits 1", async () => {
+		const { modelRegistry } = await newRegistry("disabled");
+		const settings = Settings.isolated({ "task.disabledAgents": ["myagent"] });
+		const parsed = parseArgs(["--cwd", tempDir, "--agent", "myagent"]);
+		const exitSpy = spyExit();
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		try {
+			await expect(
+				buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings),
+			).rejects.toThrow("process.exit called");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		} finally {
+			exitSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+	});
+
+	test("--agent applies agent frontmatter when CLI flags are absent", async () => {
+		const { modelRegistry } = await newRegistry("persona");
+		const settings = Settings.isolated();
+		const parsed = parseArgs(["--cwd", tempDir, "--agent", "myagent"]);
+
+		const options = await buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings);
+
+		expect(options.modelPattern).toEqual(["anthropic/claude-sonnet-4-5"]);
+		expect(options.thinkingLevel).toBe(Effort.High);
+		expect(options.toolNames).toEqual(["read", "bash", "yield"]);
+		expect(options.restrictToolNames).toBe(true);
+		expect(options.spawns).toBe("scout");
+		expect(options.appendSystemPrompt).toContain("You are the myagent persona for the main session.");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-persona-restore.test.ts
+++ b/packages/coding-agent/test/interactive-mode-persona-restore.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Persona session restore: `#reconcileModeFromSession` re-applies a persisted
+ * `mode_change` (`mode: "agent"`, `data: { name }`) persona from its CURRENT
+ * agent definition on resume, and falls back to a warning (leaving the launch
+ * baseline tools/prompt untouched) when the agent is gone, subagent-only, or
+ * disabled. Model + thinking are restored by the existing
+ * `model_change`/`thinking_level_change` flow in `createAgentSession` and must
+ * not be touched by the fallback path.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Effort } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { ModelRegistry } from "../src/config/model-registry";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+import * as discovery from "../src/task/discovery";
+
+function agentMd(name: string, extraFrontmatter: string[] = []): string {
+	return ["---", `name: ${name}`, `description: ${name}`, ...extraFrontmatter, "---", `You are ${name}.`].join("\n");
+}
+
+/** Session file carrying a restored model/thinking plus an `agent` mode_change. */
+async function writePersonaSession(
+	sessionFile: string,
+	cwd: string,
+	data: Record<string, unknown> | undefined,
+): Promise<void> {
+	const timestamp = "2026-06-01T00:00:00.000Z";
+	const entries = [
+		{ type: "session", version: 3, id: "persona-session", timestamp, cwd },
+		{
+			type: "model_change",
+			id: "m1",
+			parentId: null,
+			timestamp,
+			model: "anthropic/claude-sonnet-4-5",
+			role: "default",
+		},
+		{
+			type: "thinking_level_change",
+			id: "t1",
+			parentId: "m1",
+			timestamp,
+			thinkingLevel: "medium",
+			configured: "medium",
+		},
+		{ type: "mode_change", id: "mc1", parentId: "t1", timestamp, mode: "agent", data },
+	];
+	await Bun.write(sessionFile, `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
+}
+
+describe("InteractiveMode persona session restore", () => {
+	let tempHome: string;
+	let projectDir: string;
+	let agentsDir: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let mode: InteractiveMode | undefined;
+	let session: AgentSession | undefined;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-persona-restore-"));
+		projectDir = path.join(tempHome, "project");
+		agentsDir = path.join(projectDir, ".omp", "agents");
+		await fs.mkdir(agentsDir, { recursive: true });
+		await fs.mkdir(path.join(tempHome, "startup"), { recursive: true });
+		await Settings.init({ inMemory: true, cwd: projectDir });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempHome, "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempHome, "models.yml"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		await fs.rm(tempHome, { recursive: true, force: true });
+		mode = undefined;
+		session = undefined;
+		resetSettingsForTest();
+	});
+
+	/** Resume a persisted persona session through the real startup path. */
+	async function resumePersonaSession(
+		settings: Settings,
+		sessionFile: string,
+	): Promise<{ mode: InteractiveMode; session: AgentSession }> {
+		const sessionManager = await SessionManager.open(sessionFile, path.join(tempHome, "startup"));
+		const result = await createAgentSession({
+			cwd: projectDir,
+			agentDir: tempHome,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			toolNames: ["read", "write"],
+		});
+		const created = new InteractiveMode(result.session, "test");
+		return { mode: created, session: result.session };
+	}
+
+	function collectNotices(target: AgentSession): Array<Extract<AgentSessionEvent, { type: "notice" }>> {
+		const notices: Array<Extract<AgentSessionEvent, { type: "notice" }>> = [];
+		target.subscribe(event => {
+			if (event.type === "notice") notices.push(event);
+		});
+		return notices;
+	}
+
+	it(
+		"re-applies the persona from its current definition on resume",
+		async () => {
+			await fs.writeFile(
+				path.join(agentsDir, "persona-test.md"),
+				agentMd("persona-test", [
+					"tools: [read, write]",
+					"model: anthropic/claude-haiku-4-5",
+					"thinkingLevel: high",
+					"spawns: [scout]",
+				]),
+			);
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+			const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+			mode = created.mode;
+			session = created.session;
+			await created.mode.init({ suppressWelcomeIntro: true });
+
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+			expect(session.model?.id).toBe("claude-haiku-4-5");
+			expect(session.configuredThinkingLevel()).toBe(Effort.High);
+			expect(session.getSessionSpawns()).toBe("scout");
+			expect(session.getPersonaAppendPrompt()).toBe("You are persona-test.");
+		},
+		{ timeout: 30_000 },
+	);
+
+	it(
+		"applies the edited agent definition (not the old snapshot) on resume",
+		async () => {
+			await fs.writeFile(
+				path.join(agentsDir, "persona-test.md"),
+				agentMd("persona-test", [
+					"tools: [read, write]",
+					"model: anthropic/claude-haiku-4-5",
+					"thinkingLevel: high",
+					"spawns: [scout]",
+				]),
+			);
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+			const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+			mode = created.mode;
+			session = created.session;
+			await created.mode.init({ suppressWelcomeIntro: true });
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+
+			// Edit the agent file: tools change from [read, write] to [read].
+			await fs.writeFile(
+				path.join(agentsDir, "persona-test.md"),
+				agentMd("persona-test", [
+					"tools: [read]",
+					"model: anthropic/claude-haiku-4-5",
+					"thinkingLevel: high",
+					"spawns: [scout]",
+				]),
+			);
+
+			// Re-resume the same session file: the persona must be re-discovered
+			// fresh and the CURRENT definition applied.
+			await expect(session.switchSession(sessionFile)).resolves.toBe(true);
+
+			expect(session.getEnabledToolNames()).toEqual(["read"]);
+			expect(session.getPersonaAppendPrompt()).toBe("You are persona-test.");
+		},
+		{ timeout: 30_000 },
+	);
+
+	it(
+		"emits a warning and keeps the launch baseline when the agent is gone",
+		async () => {
+			await fs.writeFile(
+				path.join(agentsDir, "persona-test.md"),
+				agentMd("persona-test", [
+					"tools: [read, write]",
+					"model: anthropic/claude-haiku-4-5",
+					"thinkingLevel: high",
+					"spawns: [scout]",
+				]),
+			);
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+			// Delete the agent file before resume.
+			await fs.rm(path.join(agentsDir, "persona-test.md"));
+
+			const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+			mode = created.mode;
+			session = created.session;
+			const notices = collectNotices(session);
+
+			await created.mode.init({ suppressWelcomeIntro: true });
+
+			expect(
+				notices.some(
+					notice =>
+						notice.level === "warning" && notice.message.includes('Agent "persona-test" is no longer available'),
+				),
+			).toBe(true);
+			// Launch baseline tools/prompt untouched.
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+			expect(session.getPersonaAppendPrompt()).toBeUndefined();
+			expect(session.getSessionSpawns()).toBeNull();
+			// Model + thinking restored from the session log.
+			expect(session.model?.id).toBe("claude-sonnet-4-5");
+			expect(session.configuredThinkingLevel()).toBe(Effort.Medium);
+		},
+		{ timeout: 30_000 },
+	);
+
+	it(
+		"returns silently when the mode data has no agent name",
+		async () => {
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, undefined);
+
+			const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+			mode = created.mode;
+			session = created.session;
+			const notices = collectNotices(session);
+
+			await created.mode.init({ suppressWelcomeIntro: true });
+
+			expect(notices.some(notice => notice.message.includes("no longer available"))).toBe(false);
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+			expect(session.getPersonaAppendPrompt()).toBeUndefined();
+		},
+		{ timeout: 30_000 },
+	);
+
+	it(
+		"warns and keeps the baseline when the agent became subagent-only",
+		async () => {
+			await fs.writeFile(path.join(agentsDir, "persona-test.md"), agentMd("persona-test", ["mode: subagent"]));
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+			const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+			mode = created.mode;
+			session = created.session;
+			const notices = collectNotices(session);
+
+			await created.mode.init({ suppressWelcomeIntro: true });
+
+			expect(
+				notices.some(
+					notice =>
+						notice.level === "warning" && notice.message.includes('Agent "persona-test" is no longer available'),
+				),
+			).toBe(true);
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+			expect(session.getPersonaAppendPrompt()).toBeUndefined();
+		},
+		{ timeout: 30_000 },
+	);
+
+	it(
+		"warns and keeps the baseline when the agent is disabled in settings",
+		async () => {
+			await fs.writeFile(
+				path.join(agentsDir, "persona-test.md"),
+				agentMd("persona-test", [
+					"tools: [read, write]",
+					"model: anthropic/claude-haiku-4-5",
+					"thinkingLevel: high",
+					"spawns: [scout]",
+				]),
+			);
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+			const created = await resumePersonaSession(
+				Settings.isolated({ "compaction.enabled": false, "task.disabledAgents": ["persona-test"] }),
+				sessionFile,
+			);
+			mode = created.mode;
+			session = created.session;
+			const notices = collectNotices(session);
+
+			await created.mode.init({ suppressWelcomeIntro: true });
+
+			expect(
+				notices.some(
+					notice =>
+						notice.level === "warning" && notice.message.includes('Agent "persona-test" is no longer available'),
+				),
+			).toBe(true);
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+			expect(session.getPersonaAppendPrompt()).toBeUndefined();
+		},
+		{ timeout: 30_000 },
+	);
+
+	it(
+		"keeps the restored model when the persona model pattern does not resolve",
+		async () => {
+			await fs.writeFile(
+				path.join(agentsDir, "persona-test.md"),
+				agentMd("persona-test", [
+					"tools: [read, write]",
+					"model: nonexistent/model",
+					"thinkingLevel: high",
+					"spawns: [scout]",
+				]),
+			);
+			const sessionFile = path.join(tempHome, "persona.jsonl");
+			await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+			const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+			mode = created.mode;
+			session = created.session;
+			const notices = collectNotices(session);
+
+			await created.mode.init({ suppressWelcomeIntro: true });
+
+			// Model stays the restored one; no warning on restore.
+			expect(session.model?.id).toBe("claude-sonnet-4-5");
+			expect(notices.some(notice => notice.level === "warning")).toBe(false);
+			// The rest of the persona still applies.
+			expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+			expect(session.configuredThinkingLevel()).toBe(Effort.High);
+			expect(session.getPersonaAppendPrompt()).toBe("You are persona-test.");
+		},
+		{ timeout: 30_000 },
+	);
+
+	it("swallows discovery failures and keeps the baseline", async () => {
+		await fs.writeFile(path.join(agentsDir, "persona-test.md"), agentMd("persona-test", ["tools: [read, write]"]));
+		const sessionFile = path.join(tempHome, "persona.jsonl");
+		await writePersonaSession(sessionFile, projectDir, { name: "persona-test" });
+
+		const created = await resumePersonaSession(Settings.isolated({ "compaction.enabled": false }), sessionFile);
+		mode = created.mode;
+		session = created.session;
+		const notices = collectNotices(session);
+
+		const spy = vi.spyOn(discovery, "discoverAgents").mockRejectedValue(new Error("boom"));
+		await created.mode.init({ suppressWelcomeIntro: true });
+		spy.mockRestore();
+
+		expect(notices).toEqual([]);
+		expect(session.getEnabledToolNames()).toEqual(["read", "write"]);
+		expect(session.getPersonaAppendPrompt()).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/switch-agent-picker.test.ts
+++ b/packages/coding-agent/test/switch-agent-picker.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `/switch-agent` TUI picker: the slash-command spec, and
+ * `SelectorController.showAgentPersonaSelector` mounting a bottom-anchored
+ * overlay that lists only main-selectable agents (availability !== "subagent",
+ * not in `task.disabledAgents`), wiring selection to `switchAgentPersona` and
+ * Esc to a no-op close.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Effort } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentPersonaPickerComponent } from "@oh-my-pi/pi-coding-agent/modes/components/agent-persona-picker";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { BUILTIN_MODE_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-modes";
+import { ModelRegistry } from "../src/config/model-registry";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+
+function makeTool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `Fake ${name}`,
+		parameters: type({}),
+		async execute() {
+			return { content: [{ type: "text" as const, text: "ok" }] };
+		},
+	};
+}
+
+function agentMd(name: string, extraFrontmatter: string[] = []): string {
+	return ["---", `name: ${name}`, `description: ${name}`, ...extraFrontmatter, "---", `You are ${name}.`].join("\n");
+}
+
+describe("BUILTIN_MODE_SLASH_COMMANDS /switch-agent", () => {
+	it("registers /switch-agent with allowArgs", () => {
+		const spec = BUILTIN_MODE_SLASH_COMMANDS.find(command => command.name === "switch-agent");
+		expect(spec).toBeDefined();
+		expect(spec?.allowArgs).toBe(true);
+		expect(spec?.description).toBe("Switch the main-session agent persona");
+	});
+});
+
+describe("SelectorController.showAgentPersonaSelector", () => {
+	let tempHome: string;
+	let projectDir: string;
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode | undefined;
+	let session: AgentSession | undefined;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-persona-picker-"));
+		projectDir = path.join(tempHome, "project");
+		await fs.mkdir(path.join(projectDir, ".omp", "agents"), { recursive: true });
+		const agentsDir = path.join(projectDir, ".omp", "agents");
+		await fs.writeFile(path.join(agentsDir, "persona-a.md"), agentMd("persona-a"));
+		await fs.writeFile(path.join(agentsDir, "persona-b.md"), agentMd("persona-b"));
+		await fs.writeFile(path.join(agentsDir, "persona-subagent.md"), agentMd("persona-subagent", ["mode: subagent"]));
+		await fs.writeFile(path.join(agentsDir, "persona-disabled.md"), agentMd("persona-disabled"));
+
+		await Settings.init({ inMemory: true, cwd: projectDir });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempHome, "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		await fs.rm(tempHome, { recursive: true, force: true });
+		mode = undefined;
+		session = undefined;
+		resetSettingsForTest();
+	});
+
+	function createHarness(settings: Settings): InteractiveMode {
+		const registry = new ModelRegistry(authStorage, path.join(tempHome, `models-${Bun.nanoseconds()}.yml`));
+		const initialModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!initialModel) throw new Error("Expected bundled anthropic/claude-sonnet-4-5 to exist");
+		const readTool = makeTool("read");
+		const toolRegistry = new Map<string, AgentTool>();
+		toolRegistry.set(readTool.name, readTool);
+		const manager = SessionManager.create(projectDir, path.join(tempHome, `active-${Bun.nanoseconds()}`));
+		const createdSession = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: initialModel,
+					systemPrompt: ["Test"],
+					tools: [readTool],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+			}),
+			sessionManager: manager,
+			settings,
+			modelRegistry: registry,
+			toolRegistry,
+			builtInToolNames: ["read"],
+		});
+		session = createdSession;
+		mode = new InteractiveMode(createdSession, "test");
+		return mode;
+	}
+
+	it("mounts an overlay listing only non-subagent, non-disabled agents", async () => {
+		const created = createHarness(
+			Settings.isolated({ "compaction.enabled": false, "task.disabledAgents": ["persona-disabled"] }),
+		);
+		const shown = Promise.withResolvers<AgentPersonaPickerComponent>();
+		const overlayHandle = { hide: vi.fn() };
+		vi.spyOn(created.ui, "showOverlay").mockImplementation(component => {
+			shown.resolve(component as AgentPersonaPickerComponent);
+			return overlayHandle as never;
+		});
+		const setFocus = vi.spyOn(created.ui, "setFocus");
+		const requestRender = vi.spyOn(created.ui, "requestRender");
+
+		created.showAgentPersonaSelector();
+		const picker = await shown.promise;
+
+		expect(setFocus).toHaveBeenCalledWith(picker);
+		expect(requestRender).toHaveBeenCalled();
+
+		const rendered = Bun.stripANSI(picker.render(120).join("\n"));
+		expect(rendered).toContain("Switch Agent");
+		expect(rendered).toContain("persona-a");
+		expect(rendered).toContain("persona-b");
+		expect(rendered).not.toContain("persona-subagent");
+		expect(rendered).not.toContain("persona-disabled");
+	});
+
+	it("selecting an agent fires the live persona switch and closes the overlay", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		const shown = Promise.withResolvers<AgentPersonaPickerComponent>();
+		const overlayHandle = { hide: vi.fn() };
+		vi.spyOn(created.ui, "showOverlay").mockImplementation(component => {
+			shown.resolve(component as AgentPersonaPickerComponent);
+			return overlayHandle as never;
+		});
+		const switchSpy = vi.spyOn(created, "switchAgentPersona").mockResolvedValue();
+
+		created.showAgentPersonaSelector();
+		const picker = await shown.promise;
+
+		picker.handleInput("\n");
+		expect(switchSpy).toHaveBeenCalledTimes(1);
+		expect(switchSpy).toHaveBeenCalledWith("persona-a");
+		expect(overlayHandle.hide).toHaveBeenCalledTimes(1);
+	});
+
+	it("Esc closes the overlay without switching the persona", async () => {
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
+		const shown = Promise.withResolvers<AgentPersonaPickerComponent>();
+		const overlayHandle = { hide: vi.fn() };
+		vi.spyOn(created.ui, "showOverlay").mockImplementation(component => {
+			shown.resolve(component as AgentPersonaPickerComponent);
+			return overlayHandle as never;
+		});
+		const switchSpy = vi.spyOn(created, "switchAgentPersona").mockResolvedValue();
+
+		created.showAgentPersonaSelector();
+		const picker = await shown.promise;
+
+		picker.handleInput("\x1b");
+		expect(switchSpy).not.toHaveBeenCalled();
+		expect(overlayHandle.hide).toHaveBeenCalledTimes(1);
+		expect(session?.getPersonaAppendPrompt()).toBeUndefined();
+	});
+
+	it("shows the empty state when no agents are selectable", () => {
+		const picker = new AgentPersonaPickerComponent({ terminal: { rows: 40 }, requestRender: vi.fn() } as never, [], {
+			onPick: vi.fn(),
+			onCancel: vi.fn(),
+		});
+		const rendered = Bun.stripANSI(picker.render(120).join("\n"));
+		expect(rendered).toContain("No main-selectable agents");
+		// Esc on the empty state cancels without picking.
+		const onCancel = vi.fn();
+		const onPick = vi.fn();
+		const empty = new AgentPersonaPickerComponent({ terminal: { rows: 40 }, requestRender: vi.fn() } as never, [], {
+			onPick,
+			onCancel,
+		});
+		empty.handleInput("\x1b");
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(onPick).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

The rewind report prompt told agents not to call `rewind` again for the just-closed checkpoint, but never made explicit that a fresh `checkpoint` may be started. Models can over-read the guard as a ban on the whole checkpoint mechanism, which defeats repeated checkpoint→rewind cycles (the reported issue).

## Change

One line in `packages/coding-agent/src/prompts/system/rewind-report.md`:

> Do not call `rewind` again for this checkpoint. Continue from this retained report. **You may start a new `checkpoint` to explore again.**

Keeps the per-checkpoint prohibition (the guard's intent from #4188) while closing the affordance gap. Plus a changelog entry.

Closes #8499