### PR TITLE
fix(agent): deemphasize rewind guard, make new-checkpoint affordance explicit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Deemphasized the `rewind` guard in the rewind report prompt: "NEVER call `rewind` again" → "Do not call `rewind` again for THIS checkpoint", and made the new-checkpoint affordance explicit ("Need explore again → new `checkpoint`") so agents don't over-read the guard as a ban on further checkpoint cycles ([#8499](https://github.com/can1357/oh-my-pi/issues/8499)).
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/prompts/system/rewind-report.md
+++ b/packages/coding-agent/src/prompts/system/rewind-report.md
@@ -1,6 +1,6 @@
 Checkpoint: complete; exploratory branch rewound.
 Context: branch summary and retained report below.
-NEVER call `rewind` again for this checkpoint; continue from retained report.
+Do not call `rewind` again for THIS checkpoint. Continue from retained report. Need explore again → new `checkpoint`.
 
 Report:
 {{report}}


### PR DESCRIPTION
## Summary

The rewind report prompt told agents `NEVER call \`rewind\` again for this checkpoint; continue from retained report.` Models eg (gpt 5.6)  over-read the blanket "NEVER" as a ban on the whole checkpoint mechanism, which defeats repeated checkpoint→rewind cycles (reported in #8499).

## Change

Deemphasize the guard and make the affordance explicit in `packages/coding-agent/src/prompts/system/rewind-report.md`:

> ~~NEVER call `rewind` again for this checkpoint; continue from retained report.~~
> **Do not call `rewind` again for THIS checkpoint. Continue from retained report. Need explore again → new `checkpoint`.**

- "NEVER" → "Do not", scoped to **THIS** checkpoint — the guard still prevents repeat `rewind` on a closed checkpoint, but no longer reads as a blanket ban.
- The new-checkpoint affordance is now stated explicitly, so agents know a fresh `checkpoint` re-enables `rewind`.

Plus a changelog entry. Single commit, based on current upstream `main`.

Closes #8499