### PR TITLE
fix(agent): optimize checkpoint/rewind prompt rendering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Optimized checkpoint/rewind prompt rendering: the rewind instruction moved from the permanent checkpoint tool result (stale after rewind) into a transient `<system-notice>` that is branch-cut away on rewind, leaving only the goal; the rewind-report prompt is now forward-looking with no negation guard; the rewind tool description collapsed to one line. ([#8499](https://github.com/can1357/oh-my-pi/issues/8499))
+
 ## [17.3.3] - 2026-08-14
 
 ### Fixed

--- a/packages/coding-agent/src/prompts/system/checkpoint-active-notice.md
+++ b/packages/coding-agent/src/prompts/system/checkpoint-active-notice.md
@@ -1,0 +1,5 @@
+<system-notice>
+Exploration checkpoint active.
+- MUST `rewind` with findings once exploration is done.
+- MUST `rewind` before yielding.
+</system-notice>

--- a/packages/coding-agent/src/prompts/system/rewind-report.md
+++ b/packages/coding-agent/src/prompts/system/rewind-report.md
@@ -1,6 +1,4 @@
-Checkpoint: complete; exploratory branch rewound.
-Context: branch summary and retained report below.
-NEVER call `rewind` again for this checkpoint; continue from retained report.
+Checkpoint called and rewound. Report retained below. Need explore again → new `checkpoint`.
 
 Report:
 {{report}}

--- a/packages/coding-agent/src/prompts/tools/rewind.md
+++ b/packages/coding-agent/src/prompts/tools/rewind.md
@@ -1,1 +1,1 @@
-End the active checkpoint; rewind context to it, replacing intermediate exploration with your report. MUST call before yielding if a checkpoint is active.
+End the active checkpoint; rewind context to it, replacing intermediate exploration with your report.

--- a/packages/coding-agent/src/prompts/tools/rewind.md
+++ b/packages/coding-agent/src/prompts/tools/rewind.md
@@ -1,13 +1,1 @@
-End active checkpoint; rewind context to it, replacing intermediate exploration with your report.
-
-Call immediately after investigative work started by `checkpoint`.
-
-Requirements:
-- `report` MUST be concise, factual, actionable; include key findings, decisions, unresolved risks.
-- AVOID raw scratch logs unless essential.
-- MUST call before yielding if checkpoint active.
-
-Behavior:
-- No active checkpoint → error. Checkpoint already rewound → continue from retained report; NEVER retry.
-- Success → session rewinds, retains your report as context, closes checkpoint.
-- Successful rewind final for that checkpoint; repeat calls error.
+End the active checkpoint; rewind context to it, replacing intermediate exploration with your report. MUST call before yielding if a checkpoint is active.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2713,6 +2713,37 @@ export class AgentSession {
 					};
 					this.#pendingRewindReport = undefined;
 					this.#lastCompletedRewind = undefined;
+					const goal = semanticDetails ? stringProperty(semanticDetails, "goal") : undefined;
+					const reminderText = [
+						"<system-notice>",
+						"Exploration checkpoint active.",
+						"- MUST `rewind` with findings once exploration is done.",
+						"- MUST `rewind` before yielding.",
+						"</system-notice>",
+					].join("\n");
+					// Direct append (not the queued nextTurn seam): message_end for the
+					// checkpoint result fires mid-turn while streaming, so a queued
+					// reminder would only surface at the next user prompt — after the
+					// checkpoint may already be rewound. Appending here puts the notice
+					// in the very next model call, and the rewind branch cut
+					// (branchWithSummary(checkpointEntryId)) drops it from the active
+					// path automatically since it sits after the checkpoint entry.
+					this.agent.appendMessage({
+						role: "custom",
+						customType: "checkpoint-active-reminder",
+						content: reminderText,
+						display: false,
+						details: { goal },
+						attribution: "agent",
+						timestamp: Date.now(),
+					});
+					this.sessionManager.appendCustomMessageEntry(
+						"checkpoint-active-reminder",
+						reminderText,
+						false,
+						{ goal },
+						"agent",
+					);
 				}
 				if (semanticResult?.toolName === "rewind" && !isError && this.#checkpointState) {
 					const detailReport = semanticDetails ? (stringProperty(semanticDetails, "report")?.trim() ?? "") : "";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -161,6 +161,7 @@ import type { PlanModeState } from "../plan-mode/state";
 import goalModeContextPrompt from "../prompts/goals/goal-mode-context.md" with { type: "text" };
 import goalTodoContextPrompt from "../prompts/goals/goal-todo-context.md" with { type: "text" };
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
+import checkpointActiveNoticeTemplate from "../prompts/system/checkpoint-active-notice.md" with { type: "text" };
 import interruptedThinkingTemplate from "../prompts/system/interrupted-thinking.md" with { type: "text" };
 import planModeActivePrompt from "../prompts/system/plan-mode-active.md" with { type: "text" };
 import planModeReferencePrompt from "../prompts/system/plan-mode-reference.md" with { type: "text" };
@@ -285,6 +286,7 @@ import {
 import {
 	type BashExecutionMessage,
 	buildReplanTitleContext,
+	CHECKPOINT_ACTIVE_REMINDER_TYPE,
 	type CustomMessage,
 	type CustomMessagePayload,
 	convertToLlm,
@@ -2341,6 +2343,31 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Builds the transient checkpoint-active reminder for a successful
+	 * checkpoint tool result, or undefined otherwise. The reminder is appended
+	 * to agent.state synchronously in the message_end handler (before any
+	 * await) so the next provider call within the same tool loop sees it, and
+	 * is persisted via #persistMessageEnd. Because the entry sits after the
+	 * checkpoint entry, the rewind branch cut drops it from the active path.
+	 */
+	#checkpointActiveReminderFor(message: AgentMessage): CustomMessage<{ goal?: string }> | undefined {
+		if (message.role !== "toolResult" || message.isError) return undefined;
+		const semanticResult = semanticToolResult(message.toolName, message);
+		if (semanticResult?.toolName !== "checkpoint") return undefined;
+		const details = isRecord(semanticResult.details) ? semanticResult.details : undefined;
+		const goal = details ? stringProperty(details, "goal") : undefined;
+		return {
+			role: "custom",
+			customType: CHECKPOINT_ACTIVE_REMINDER_TYPE,
+			content: prompt.render(checkpointActiveNoticeTemplate),
+			display: false,
+			details: { goal },
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+	}
+
 	#persistMessageEnd(message: AgentMessage): void {
 		if (message.role === "hookMessage" || message.role === "custom") {
 			// Prewalk's plan nudge is a one-run steering instruction. Persisting it would
@@ -2498,6 +2525,23 @@ export class AgentSession {
 			this.agent.appendMessage(interruptedThinkingMessage);
 		}
 
+		// Same pre-await visibility requirement as the interrupted-thinking
+		// message: agent-core invokes message_end listeners fire-and-forget, so
+		// the next provider call can start before any awaited session-event
+		// emission or persistence below settles. The checkpoint-active reminder
+		// must already be in agent.state for that call — append it synchronously
+		// here and persist it later (see #persistMessageEnd). It sits after the
+		// checkpoint entry, so the rewind branch cut
+		// (branchWithSummary(checkpointEntryId)) drops it from the active path
+		// automatically.
+		const checkpointReminder =
+			event.type === "message_end" && event.message.role === "toolResult"
+				? this.#checkpointActiveReminderFor(event.message)
+				: undefined;
+		if (checkpointReminder) {
+			this.agent.appendMessage(checkpointReminder);
+		}
+
 		const messageEndPersistence =
 			event.type === "message_end" ? this.#createMessageEndPersistenceSlot(event.message) : undefined;
 
@@ -2617,6 +2661,15 @@ export class AgentSession {
 					interruptedThinkingMessage.attribution,
 				);
 			}
+			if (checkpointReminder) {
+				this.sessionManager.appendCustomMessageEntry(
+					checkpointReminder.customType,
+					checkpointReminder.content,
+					checkpointReminder.display,
+					checkpointReminder.details,
+					checkpointReminder.attribution,
+				);
+			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
 			if (event.message.role === "assistant") {
@@ -2704,7 +2757,19 @@ export class AgentSession {
 					);
 				}
 				if (semanticResult?.toolName === "checkpoint" && !isError) {
-					const checkpointEntryId = this.sessionManager.getEntries().at(-1)?.id ?? null;
+					// Locate the checkpoint toolResult's own entry by identity: the
+					// transient checkpoint-active reminder is persisted right after
+					// it, so "last entry" would branch-cut the reminder instead of
+					// leaving it on the active path.
+					const entries = this.sessionManager.getEntries();
+					let checkpointEntryId: string | null = null;
+					for (let i = entries.length - 1; i >= 0; i--) {
+						const entry = entries[i];
+						if (entry.type === "message" && entry.message === event.message) {
+							checkpointEntryId = entry.id;
+							break;
+						}
+					}
 					this.#checkpointState = {
 						checkpointMessageCount: this.agent.state.messages.length,
 						checkpointEntryId,
@@ -2713,37 +2778,6 @@ export class AgentSession {
 					};
 					this.#pendingRewindReport = undefined;
 					this.#lastCompletedRewind = undefined;
-					const goal = semanticDetails ? stringProperty(semanticDetails, "goal") : undefined;
-					const reminderText = [
-						"<system-notice>",
-						"Exploration checkpoint active.",
-						"- MUST `rewind` with findings once exploration is done.",
-						"- MUST `rewind` before yielding.",
-						"</system-notice>",
-					].join("\n");
-					// Direct append (not the queued nextTurn seam): message_end for the
-					// checkpoint result fires mid-turn while streaming, so a queued
-					// reminder would only surface at the next user prompt — after the
-					// checkpoint may already be rewound. Appending here puts the notice
-					// in the very next model call, and the rewind branch cut
-					// (branchWithSummary(checkpointEntryId)) drops it from the active
-					// path automatically since it sits after the checkpoint entry.
-					this.agent.appendMessage({
-						role: "custom",
-						customType: "checkpoint-active-reminder",
-						content: reminderText,
-						display: false,
-						details: { goal },
-						attribution: "agent",
-						timestamp: Date.now(),
-					});
-					this.sessionManager.appendCustomMessageEntry(
-						"checkpoint-active-reminder",
-						reminderText,
-						false,
-						{ goal },
-						"agent",
-					);
 				}
 				if (semanticResult?.toolName === "rewind" && !isError && this.#checkpointState) {
 					const detailReport = semanticDetails ? (stringProperty(semanticDetails, "report")?.trim() ?? "") : "";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2351,18 +2351,21 @@ export class AgentSession {
 	 * is persisted via #persistMessageEnd. Because the entry sits after the
 	 * checkpoint entry, the rewind branch cut drops it from the active path.
 	 */
-	#checkpointActiveReminderFor(message: AgentMessage): CustomMessage<{ goal?: string }> | undefined {
+	#checkpointActiveReminderFor(
+		message: AgentMessage,
+	): CustomMessage<{ goal?: string; startedAt?: string }> | undefined {
 		if (message.role !== "toolResult" || message.isError) return undefined;
 		const semanticResult = semanticToolResult(message.toolName, message);
 		if (semanticResult?.toolName !== "checkpoint") return undefined;
 		const details = isRecord(semanticResult.details) ? semanticResult.details : undefined;
 		const goal = details ? stringProperty(details, "goal") : undefined;
+		const startedAt = details ? stringProperty(details, "startedAt") : undefined;
 		return {
 			role: "custom",
 			customType: CHECKPOINT_ACTIVE_REMINDER_TYPE,
 			content: prompt.render(checkpointActiveNoticeTemplate),
 			display: false,
-			details: { goal },
+			details: { goal, startedAt },
 			attribution: "agent",
 			timestamp: Date.now(),
 		};
@@ -2533,12 +2536,26 @@ export class AgentSession {
 		// here and persist it later (see #persistMessageEnd). It sits after the
 		// checkpoint entry, so the rewind branch cut
 		// (branchWithSummary(checkpointEntryId)) drops it from the active path
-		// automatically.
 		const checkpointReminder =
 			event.type === "message_end" && event.message.role === "toolResult"
 				? this.#checkpointActiveReminderFor(event.message)
 				: undefined;
 		if (checkpointReminder) {
+			// Set #checkpointState synchronously too: the reminder is now visible to
+			// the very next provider call, so a model that immediately calls `rewind`
+			// must find an active checkpoint in RewindTool.execute(). The entry id is
+			// backfilled post-await (see the toolResult handler) once the checkpoint
+			// toolResult entry is persisted; #applyRewind runs on a later rewind turn,
+			// never before that backfill.
+			this.#checkpointState = {
+				checkpointMessageCount: this.agent.state.messages.length,
+				checkpointEntryId: null,
+				startedAt:
+					(checkpointReminder.details && stringProperty(checkpointReminder.details, "startedAt")) ??
+					new Date().toISOString(),
+			};
+			this.#pendingRewindReport = undefined;
+			this.#lastCompletedRewind = undefined;
 			this.agent.appendMessage(checkpointReminder);
 		}
 
@@ -2757,10 +2774,12 @@ export class AgentSession {
 					);
 				}
 				if (semanticResult?.toolName === "checkpoint" && !isError) {
-					// Locate the checkpoint toolResult's own entry by identity: the
-					// transient checkpoint-active reminder is persisted right after
-					// it, so "last entry" would branch-cut the reminder instead of
-					// leaving it on the active path.
+					// Backfill the checkpoint entry id now that the toolResult entry is
+					// persisted. #checkpointState was set synchronously pre-await (with a
+					// null entry id) so an immediate `rewind` still finds an active
+					// checkpoint; locate the toolResult's own entry by identity since the
+					// transient reminder entry follows it (last-entry would branch-cut the
+					// reminder instead of leaving it on the active path).
 					const entries = this.sessionManager.getEntries();
 					let checkpointEntryId: string | null = null;
 					for (let i = entries.length - 1; i >= 0; i--) {
@@ -2770,14 +2789,9 @@ export class AgentSession {
 							break;
 						}
 					}
-					this.#checkpointState = {
-						checkpointMessageCount: this.agent.state.messages.length,
-						checkpointEntryId,
-						startedAt:
-							(semanticDetails && stringProperty(semanticDetails, "startedAt")) ?? new Date().toISOString(),
-					};
-					this.#pendingRewindReport = undefined;
-					this.#lastCompletedRewind = undefined;
+					if (this.#checkpointState) {
+						this.#checkpointState.checkpointEntryId = checkpointEntryId;
+					}
 				}
 				if (semanticResult?.toolName === "rewind" && !isError && this.#checkpointState) {
 					const detailReport = semanticDetails ? (stringProperty(semanticDetails, "report")?.trim() ?? "") : "";

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -328,6 +328,9 @@ export type NormalizedCustomMessagePayload<T = unknown> = Pick<
 /** Custom message type for hidden interrupted-thinking continuity context. */
 export const INTERRUPTED_THINKING_MESSAGE_TYPE = "interrupted-thinking";
 
+/** Custom message type for the transient checkpoint-active reminder. */
+export const CHECKPOINT_ACTIVE_REMINDER_TYPE = "checkpoint-active-reminder";
+
 /** Metadata persisted with a hidden interrupted-thinking continuity message. */
 export interface InterruptedThinkingDetails {
 	interruptedAt: number;

--- a/packages/coding-agent/src/tools/checkpoint.ts
+++ b/packages/coding-agent/src/tools/checkpoint.ts
@@ -81,13 +81,7 @@ export class CheckpointTool implements AgentTool<typeof checkpointSchema, Checkp
 		}
 		const startedAt = new Date().toISOString();
 		return toolResult<CheckpointToolDetails>({ goal: params.goal, startedAt })
-			.text(
-				[
-					"Checkpoint created.",
-					`Goal: ${params.goal}`,
-					"Run your investigation, then call rewind with a concise report.",
-				].join("\n"),
-			)
+			.text([`Checkpoint: ${params.goal}`, "Finish exploration and formulate findings."].join("\n"))
 			.done();
 	}
 }

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -312,6 +312,9 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		);
 		expect(reminder).toBeDefined();
 		expect(reminder?.content).toContain("MUST `rewind` before yielding");
+		// #checkpointState is set synchronously with the reminder (pre-await), so an
+		// immediate rewind would find an active checkpoint, not "No active checkpoint".
+		expect(session.getCheckpointState()).toBeDefined();
 		proceed.resolve();
 		await promptPromise;
 

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -12,7 +12,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { RewindTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { CheckpointTool, RewindTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -250,7 +250,9 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		const reportMessage = finalCall.context.messages[reportIndex];
 		if (!reportMessage) throw new Error("Expected rewind report context");
 		const reportText = messageText(reportMessage);
-		expect(reportText).toContain("`rewind`");
+		expect(reportText).toContain(
+			"Checkpoint called and rewound. Report retained below. Need explore again → new `checkpoint`.",
+		);
 		expect(reportText).toContain(report);
 
 		expect(
@@ -265,6 +267,83 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		const finalThinking = finalAssistant.content.find((block): block is ThinkingContent => block.type === "thinking");
 		expect(finalThinking?.thinking).toBe("answer after rewind");
 		expect(finalThinking?.thinkingSignature).toBe("sig_after_rewind");
+	});
+
+	it("shows a transient checkpoint-active reminder that is branch-cut away on rewind", async () => {
+		const report = "findings: transient reminder";
+		const proceed = Promise.withResolvers<void>();
+		const { session, mock } = await createHarness(
+			(async function* () {
+				yield {
+					content: [
+						{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } },
+					],
+					stopReason: "toolUse",
+				};
+				await proceed.promise;
+				yield {
+					content: [{ type: "toolCall", id: "call_rewind", name: "rewind", arguments: { report } }],
+					stopReason: "toolUse",
+				};
+				yield { content: ["DONE"], stopReason: "stop" };
+			})(),
+		);
+
+		const promptPromise = session.prompt("investigate with a checkpoint");
+		// Pause the model between the checkpoint and rewind calls to observe the
+		// active-checkpoint state: the transient notice must be in the active path.
+		const deadline = Date.now() + 5000;
+		while (
+			!session.messages.some(
+				message => message.role === "custom" && message.customType === "checkpoint-active-reminder",
+			)
+		) {
+			if (Date.now() > deadline) throw new Error("checkpoint-active-reminder never appeared");
+			await Bun.sleep(10);
+		}
+		const reminder = session.messages.find(
+			message => message.role === "custom" && message.customType === "checkpoint-active-reminder",
+		);
+		expect(messageText(reminder!)).toContain("MUST `rewind` before yielding");
+		proceed.resolve();
+		await promptPromise;
+
+		// After rewind the branch cut dropped the reminder from the active path.
+		expect(
+			session.messages.some(
+				message => message.role === "custom" && message.customType === "checkpoint-active-reminder",
+			),
+		).toBe(false);
+
+		// No negation guard anywhere in the model-visible context.
+		const finalCall = mock.calls.at(-1);
+		if (!finalCall) throw new Error("Expected final post-rewind provider call");
+		for (const message of finalCall.context.messages) {
+			const text = messageText(message);
+			expect(text).not.toContain("NEVER call");
+			expect(text).not.toContain("Do not call `rewind` again");
+		}
+
+		// Exactly one developer message carries the forward-looking rewind report.
+		const reportMessages = finalCall.context.messages.filter(
+			message => message.role === "developer" && messageText(message).includes("Checkpoint called and rewound."),
+		);
+		expect(reportMessages).toHaveLength(1);
+		expect(messageText(reportMessages[0]!)).toContain("Need explore again → new `checkpoint`.");
+		expect(messageText(reportMessages[0]!)).toContain(report);
+	});
+
+	it("checkpoint tool result carries only the goal and a forward-looking line", async () => {
+		const tool = new CheckpointTool(
+			createToolSession({
+				getCheckpointState: () => undefined,
+			}),
+		);
+		const result = await tool.execute("call_checkpoint", { goal: "inspect" });
+		const text = result.content.find(part => part.type === "text")?.text;
+		expect(text).toBe("Checkpoint: inspect\nFinish exploration and formulate findings.");
+		expect(text).not.toContain("Run your investigation");
+		expect(text).not.toContain("call rewind");
 	});
 
 	it("ignores a completed cycle's rewind result after rebuilding context", async () => {

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -3,7 +3,12 @@ import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Message, ThinkingContent } from "@oh-my-pi/pi-ai";
-import { createMockModel, type MockContent, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import {
+	createMockModel,
+	type MockContent,
+	type MockModel,
+	type MockResponseSource,
+} from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
@@ -105,7 +110,7 @@ function signedThinking(thinking: string, thinkingSignature: string): MockConten
 }
 
 async function createHarness(
-	responses: MockResponse[],
+	responses: MockResponseSource,
 	tools: AgentTool[] = [checkpointTool as AgentTool, rewindTool as AgentTool],
 	options?: { onAgentEnd?: (willContinue: boolean | undefined) => void },
 ): Promise<Harness & { mock: MockModel }> {
@@ -286,7 +291,7 @@ describe("AgentSession checkpoint rewind branch context", () => {
 					stopReason: "toolUse",
 				};
 				yield { content: ["DONE"], stopReason: "stop" };
-			})(),
+			})() as MockResponseSource,
 		);
 
 		const promptPromise = session.prompt("investigate with a checkpoint");
@@ -302,9 +307,11 @@ describe("AgentSession checkpoint rewind branch context", () => {
 			await Bun.sleep(10);
 		}
 		const reminder = session.messages.find(
-			message => message.role === "custom" && message.customType === "checkpoint-active-reminder",
+			(message): message is Extract<AgentMessage, { role: "custom" }> =>
+				message.role === "custom" && message.customType === "checkpoint-active-reminder",
 		);
-		expect(messageText(reminder!)).toContain("MUST `rewind` before yielding");
+		expect(reminder).toBeDefined();
+		expect(reminder?.content).toContain("MUST `rewind` before yielding");
 		proceed.resolve();
 		await promptPromise;
 


### PR DESCRIPTION
## Context

After a successful rewind the agent still saw the checkpoint tool result saying "Run your investigation, then call rewind" (instructions for a state already closed) and a rewind-report message opening with "NEVER call `rewind` again". The rewind tool description restated code-enforced logic across 13 lines. The rendered prompt didn't match what the agent needs to do next.

This is a more comprehensive solution to [#8499](https://github.com/can1357/oh-my-pi/issues/8499) than the earlier one-line affordance change: it removes the stale pre-rewind steering from the permanent checkpoint result, moves the "must rewind" rule into a transient notice that disappears on rewind, and drops the negation-heavy guard from the post-rewind report.

## Changes

- **Checkpoint tool result** (`checkpoint.ts`): now carries only the goal + a forward-looking line "Finish exploration and formulate findings." — no "call rewind". The rewind instruction moved out of the permanent result.
- **Transient post-checkpoint notice** (`agent-session.ts`): appends a `<system-notice>` "Exploration checkpoint active. MUST rewind with findings once exploration done; MUST rewind before yielding." right after the checkpoint result. It persists as a `custom_message` entry *after* the checkpoint entry, so the rewind branch-cut (`branchWithSummary(checkpointEntryId)`) drops it from the active path automatically — no cleanup code needed.
- **Rewind-report prompt** (`rewind-report.md`): forward-looking — "Checkpoint called and rewound. Report retained below. Need explore again → new `checkpoint`." — no "NEVER call rewind" negation (the repeat-rewind guard still executes in code).
- **Rewind tool description** (`rewind.md`): collapsed to one line.

The checkpoint tool description (`checkpoint.md`) is unchanged.

Closes #8499