### PR TITLE
fix(agent): name billed output tokens on capped empty stops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the capped empty-stop failure always naming the context/`/shake images` hint even when the provider billed output tokens. A zero-block `stop` with `usage.output > 0` means content was generated and dropped downstream (a filter/refusal flattened to `finish_reason: "stop"` by a proxy, or a lossy API translation), so the message now reports the billed output-token count and points at a provider-side filter/translation instead of a context problem, and logs `outputTokens` alongside the existing warning fields ([#8511](https://github.com/can1357/oh-my-pi/issues/8511)).
+
 ## [17.3.3] - 2026-08-14
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the capped empty-stop failure always naming the context/`/shake images` hint even when the provider billed output tokens. A zero-block `stop` with `usage.output > 0` means content was generated and dropped downstream (a filter/refusal flattened to `finish_reason: "stop"` by a proxy, or a lossy API translation), so the message now reports the billed output-token count and points at a provider-side filter/translation instead of a context problem, and logs `outputTokens` alongside the existing warning fields ([#8511](https://github.com/can1357/oh-my-pi/issues/8511)).
+- Fixed the capped empty-stop failure always naming the context/`/shake images` hint even when the provider billed output tokens. A zero-block `stop` (no content blocks) with `usage.output > 0` means content was generated and dropped downstream (a filter/refusal flattened to `finish_reason: "stop"` by a proxy, or a lossy API translation), so the message now reports the billed output-token count and points at a provider-side filter/translation instead of a context problem, and logs `outputTokens` alongside the existing warning fields. Thinking-only stops keep a thinking block (and bill output for it), so they retain the context hint ([#8511](https://github.com/can1357/oh-my-pi/issues/8511)).
 
 ## [17.3.3] - 2026-08-14
 

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -678,11 +678,13 @@ export class TurnRecovery {
 			let finalError: string;
 			if (providerEmptyOutput) {
 				finalError = "Assistant returned no final output after retry cap; try switching models";
-			} else if (outputTokens > 0) {
-				// Billed output on a zero-block stop means content was generated and then
-				// dropped downstream (a filter/refusal flattened to `finish_reason: "stop"`
-				// by a proxy, or a lossy API translation) — the context/`/shake images`
-				// hint is wrong here, so name the billed output instead.
+			} else if (outputTokens > 0 && assistantMessage.content.length === 0) {
+				// Billed output on a truly zero-block stop means content was generated and
+				// then dropped downstream (a filter/refusal flattened to
+				// `finish_reason: "stop"` by a proxy, or a lossy API translation) — the
+				// context/`/shake images` hint is wrong here, so name the billed output
+				// instead. Thinking-only stops keep a thinking block (and bill output for
+				// it), so they fall through to the context hint rather than this path.
 				finalError = `Assistant returned an empty stop after retry cap, but the provider billed ${outputTokens} output token${outputTokens === 1 ? "" : "s"} for it; content was generated and then dropped before delivery, which usually points to a provider-side content filter or a lossy API translation rather than a context problem`;
 			} else {
 				finalError =

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -674,15 +674,27 @@ export class TurnRecovery {
 		this.#emptyStopRetryCount++;
 		if (this.#emptyStopRetryCount > EMPTY_STOP_MAX_RETRIES) {
 			const attempts = this.#emptyStopRetryCount - 1;
-			const finalError = providerEmptyOutput
-				? "Assistant returned no final output after retry cap; try switching models"
-				: "Assistant returned empty stop after retry cap; try switching models or `/shake images` to remove archived frames";
+			const outputTokens = assistantMessage.usage.output;
+			let finalError: string;
+			if (providerEmptyOutput) {
+				finalError = "Assistant returned no final output after retry cap; try switching models";
+			} else if (outputTokens > 0) {
+				// Billed output on a zero-block stop means content was generated and then
+				// dropped downstream (a filter/refusal flattened to `finish_reason: "stop"`
+				// by a proxy, or a lossy API translation) — the context/`/shake images`
+				// hint is wrong here, so name the billed output instead.
+				finalError = `Assistant returned an empty stop after retry cap, but the provider billed ${outputTokens} output token${outputTokens === 1 ? "" : "s"} for it; content was generated and then dropped before delivery, which usually points to a provider-side content filter or a lossy API translation rather than a context problem`;
+			} else {
+				finalError =
+					"Assistant returned empty stop after retry cap; try switching models or `/shake images` to remove archived frames";
+			}
 			assistantMessage.errorMessage = finalError;
 			if (providerEmptyOutput) assistantMessage.errorId = AIError.create();
 			logger.warn(finalError, {
 				attempts,
 				model: assistantMessage.model,
 				provider: assistantMessage.provider,
+				outputTokens,
 			});
 			await this.#host.emitSessionEvent({
 				type: "auto_retry_end",

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -499,6 +499,31 @@ describe("AgentSession empty stop guard", () => {
 		expect(finalError).not.toContain("/shake images");
 	});
 
+	it("keeps the context hint for a capped thinking-only stop even though it billed output", async () => {
+		const { session, mock } = await createHarness([
+			thinkingOnlyStop(),
+			thinkingOnlyStop(),
+			thinkingOnlyStop(),
+			thinkingOnlyStop(),
+		]);
+		const retryEndEvents: Array<Extract<AgentSessionEvent, { type: "auto_retry_end" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") {
+				retryEndEvents.push(event);
+			}
+		});
+
+		await expectPromptCompletes(session.prompt("think without answering"));
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(4);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]?.success).toBe(false);
+		const finalError = retryEndEvents[0]?.finalError ?? "";
+		expect(finalError).toContain("/shake images");
+		expect(finalError).not.toContain("billed");
+	});
+
 	it("ends auto-retry state when empty stop retries hit the cap", async () => {
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { session, mock } = await createHarness(

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -57,7 +57,18 @@ function emptyStop(): MockResponse {
 	return {
 		content: [],
 		stopReason: "stop",
-		usage: { output: 1, cacheRead: 100 },
+		usage: { output: 0, cacheRead: 100 },
+	};
+}
+
+// A zero-block `stop` for which the provider still billed output tokens: content
+// was generated and dropped downstream (e.g. a filter/refusal flattened to
+// `finish_reason: "stop"` by a proxy), so the context/`/shake images` hint is wrong.
+function filteredEmptyStop(): MockResponse {
+	return {
+		content: [],
+		stopReason: "stop",
+		usage: { output: 126, cacheRead: 100 },
 	};
 }
 
@@ -461,6 +472,31 @@ describe("AgentSession empty stop guard", () => {
 			attempt: 3,
 		});
 		expect(retryEndEvents[0]?.finalError).toContain("/shake images");
+	});
+
+	it("names billed output tokens instead of the context hint when a capped empty stop billed output", async () => {
+		const { session, mock } = await createHarness([
+			filteredEmptyStop(),
+			filteredEmptyStop(),
+			filteredEmptyStop(),
+			filteredEmptyStop(),
+		]);
+		const retryEndEvents: Array<Extract<AgentSessionEvent, { type: "auto_retry_end" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") {
+				retryEndEvents.push(event);
+			}
+		});
+
+		await expectPromptCompletes(session.prompt("answer that gets filtered"));
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(4);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]?.success).toBe(false);
+		const finalError = retryEndEvents[0]?.finalError ?? "";
+		expect(finalError).toContain("billed 126 output tokens");
+		expect(finalError).not.toContain("/shake images");
 	});
 
 	it("ends auto-retry state when empty stop retries hit the cap", async () => {


### PR DESCRIPTION
## Repro
An empty assistant `stop` that exhausts `EMPTY_STOP_MAX_RETRIES` always surfaces the same `try switching models or \`/shake images\` to remove archived frames` hint, blaming context/images. But a gateway can flatten an Anthropic `stop_reason: "refusal"` (or any filtered/lossy translation) to `finish_reason: "stop"` with empty content while still billing `completion_tokens: 126` — content was generated and dropped downstream, so the images hint is wrong. Repro via `cd packages/coding-agent && bun test test/agent-session-empty-stop-guard.test.ts -t "names billed output tokens instead of the context hint"`: before the fix the capped `finalError` for a zero-block stop with `usage.output = 126` still reads `...\`/shake images\`...`.

## Cause
`#handleEmptyAssistantStop` in `packages/coding-agent/src/session/turn-recovery.ts` builds the capped `finalError` from `providerEmptyOutput` alone (line ~677), never consulting `assistantMessage.usage.output`. Every non-`providerEmptyOutput` empty stop gets the images/context message regardless of whether the provider billed output tokens, so the two cases the reporter identified (`usage.output === 0` = nothing generated, context hint fits; `usage.output > 0` = content generated and dropped) collapse into one misleading message.

## Fix
- Branch the capped `finalError` on `assistantMessage.usage.output`: keep the `/shake images` context hint only when nothing was generated, and otherwise report the billed output-token count and point at a provider-side content filter or lossy API translation.
- Log `outputTokens` alongside the existing `attempts`/`model`/`provider` fields in the `logger.warn`.
- Test: added `filteredEmptyStop()` (zero-block `stop`, `usage.output = 126`) and a case asserting the capped `finalError` names `billed 126 output tokens` and no longer contains `/shake images`; set the shared `emptyStop()` fixture to `usage.output = 0` so it represents the genuine nothing-generated stop the context hint targets.

## Verification
`cd packages/coding-agent && bun test test/agent-session-empty-stop-guard.test.ts` → 16 pass / 0 fail (the new case fails on `main`, passes here). `bun test test/event-controller-error-banner.test.ts` → 21 pass / 0 fail (message-consuming banner test unaffected). Pre-publish `bun check` passed via the push gate.

Fixes #8511