### PR TITLE
fix(catalog): grant low/high/max to OpenRouter deepseek-v4-pro-0813

### DIFF
--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -1110,7 +1110,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 
 	test("broker invalidation drops server-side last-good usage reports", async () => {
 		const credential = serverStore!.listAuthCredentials("anthropic")[0];
-		if (!credential || credential.credential.type !== "oauth") throw new Error("expected OAuth credential");
+		if (credential?.credential.type !== "oauth") throw new Error("expected OAuth credential");
 		serverStore!.updateAuthCredential(credential.id, {
 			...credential.credential,
 			expires: Date.now() + 3_600_000,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the OpenRouter `deepseek/deepseek-v4-pro-0813` route silently clamping the reasoning effort to `high`: the dated SKU advertises (and accepts) the wire-exact `low`/`high`/`max` ladder, so its effort override no longer collapses to `high`-only. The undated `deepseek/deepseek-v4-pro` OpenRouter route stays `high`-only. ([#8517](https://github.com/can1357/oh-my-pi/issues/8517))
+
 ## [17.3.2] - 2026-08-13
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -374,13 +374,20 @@ function getModelDefinedEfforts<TApi extends Api>(
 		// on every first-party/aggregator host — the direct API, aggregators, and
 		// Ollama Cloud alike (medium/xhigh fold into high, max is a real wire
 		// tier). See https://api-docs.deepseek.com/api/create-chat-completion.
-		// OpenRouter's non-Flash V4 route still exposes only high; the older
-		// reasoners (V3.x, R1, deepseek-reasoner) top out at high/max.
+		// OpenRouter's non-Flash V4 route exposes only high, except the dated
+		// `deepseek-v4-pro-0813` SKU: its /models metadata advertises (and the
+		// route accepts) the full low/high/max ladder like every other host.
+		// The older reasoners (V3.x, R1, deepseek-reasoner) top out at high/max.
 		if (isDeepseekV4FlashModelId(spec.id)) {
 			return LOW_HIGH_MAX_REASONING_EFFORTS;
 		}
 		if (bareModelId(spec.id).toLowerCase().includes("deepseek-v4")) {
-			return isOpenRouterThinkingFormat(compat) ? HIGH_ONLY_REASONING_EFFORTS : LOW_HIGH_MAX_REASONING_EFFORTS;
+			if (!isOpenRouterThinkingFormat(compat)) {
+				return LOW_HIGH_MAX_REASONING_EFFORTS;
+			}
+			return bareModelId(spec.id).toLowerCase() === "deepseek-v4-pro-0813"
+				? LOW_HIGH_MAX_REASONING_EFFORTS
+				: HIGH_ONLY_REASONING_EFFORTS;
 		}
 		return isOpenRouterThinkingFormat(compat) ? HIGH_ONLY_REASONING_EFFORTS : HIGH_MAX_REASONING_EFFORTS;
 	}

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -314,6 +314,34 @@ describe("model thinking derivation", () => {
 		expect(getSupportedEfforts(v32)).toEqual([Effort.High, Effort.Max]);
 	});
 
+	it("grants the low/high/max ladder to OpenRouter deepseek-v4-pro-0813 but not the undated route (issue #8517)", () => {
+		// OpenRouter's /models advertises reasoning.supported_efforts
+		// [low, high, max] for the dated SKU; the discovered ladder is baked
+		// into thinking.efforts.
+		const discovered = { mode: "effort" as const, efforts: [Effort.Low, Effort.High, Effort.Max] };
+		const dated = createModel({
+			id: "deepseek/deepseek-v4-pro-0813",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			thinking: discovered,
+		});
+		const bare = createModel({
+			id: "deepseek/deepseek-v4-pro",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			thinking: discovered,
+		});
+
+		// The dated SKU keeps its advertised ladder; :max no longer clamps.
+		expect(getSupportedEfforts(dated)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(clampThinkingLevelForModel(dated, Effort.Max)).toBe(Effort.Max);
+		// The undated OpenRouter route stays high-only.
+		expect(getSupportedEfforts(bare)).toEqual([Effort.High]);
+		expect(clampThinkingLevelForModel(bare, Effort.Max)).toBe(Effort.High);
+	});
+
 	it("encodes the Gemini 3 Pro effort gap and mandatory reasoning in metadata", () => {
 		const model = createModel({
 			id: "gemini-3-pro-preview",


### PR DESCRIPTION
## Repro
Configuring `openrouter/deepseek/deepseek-v4-pro-0813:max` silently resolves to `high`, and the effort picker offers only `[high]`, even though OpenRouter's `/models` advertises `reasoning.supported_efforts: [low, high, max]` for the dated SKU and the route accepts them. Building the model with the discovered ladder reproduces it:

```
$ bun run repro.ts   # openrouter deepseek-v4-pro-0813, thinking.efforts=[low,high,max]
-0813 supported efforts: [ "high" ]
-0813 clamp(max) -> high
bare  supported efforts: [ "high" ]
bare  clamp(max) -> high
```

## Cause
`getModelDefinedEfforts` in `packages/catalog/src/model-thinking.ts` returns `HIGH_ONLY_REASONING_EFFORTS` for every OpenRouter (`isOpenRouterThinkingFormat`) non-Flash DeepSeek V4 id. `fillThinkingWireDefaults` uses this code override in preference to the discovered `thinking.efforts` (`normalizedEfforts = getModelDefinedEfforts(spec, compat) ?? thinking.efforts`), so the discovered `[low, high, max]` ladder is overwritten with `[high]` and `clampThinkingLevelForModel(model, Effort.Max)` returns `Effort.High`. Every other route of the identical SKU (direct API, kilo, nanogpt) already exposes the full ladder — OpenRouter was the lone `high`-only case.

## Fix
- In the OpenRouter branch of `getModelDefinedEfforts`, carve out `bareModelId(spec.id) === "deepseek-v4-pro-0813"` to `LOW_HIGH_MAX_REASONING_EFFORTS`; all other OpenRouter non-Flash V4 ids (including the undated `deepseek-v4-pro`) stay `HIGH_ONLY_REASONING_EFFORTS`.
- Updated the branch comment to document the dated-SKU exception.
- Added a regression test in `model-thinking.test.ts` asserting `[low, high, max]` + `clamp(max) == max` for `-0813` and `[high]` + `clamp(max) == high` for the undated route.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test` in `packages/catalog` — 561 pass, 0 fail. Manually verified against the bundled catalog via `getBundledModel("openrouter", "deepseek/deepseek-v4-pro-0813")`: efforts `[low, high, max]`, `clamp(max) -> max`; undated `deepseek/deepseek-v4-pro` stays `[high]`, `clamp(max) -> high` (bundled rows are re-derived through `buildModel` at load, so the stale baked `["high"]` in `models.json` is corrected without a regen). Fixes #8517