### PR TITLE
fix(mnemopi): keep global rows recallable under channelId filter

### DIFF
--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -1110,7 +1110,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 
 	test("broker invalidation drops server-side last-good usage reports", async () => {
 		const credential = serverStore!.listAuthCredentials("anthropic")[0];
-		if (!credential || credential.credential.type !== "oauth") throw new Error("expected OAuth credential");
+		if (credential?.credential.type !== "oauth") throw new Error("expected OAuth credential");
 		serverStore!.updateAuthCredential(credential.id, {
 			...credential.credential,
 			expires: Date.now() + 3_600_000,

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `recall()` silently dropping `scope='global'` rows whenever a `channelId` filter was active: `buildWhere()` appended a redundant hard `channel_id = ?` clause on top of the `(session_id = ? OR scope = 'global' OR channel_id = ?)` visibility clause, so global rows whose `channel_id` didn't match (e.g. imported rows with `channel_id NULL`) were excluded. Channel isolation is preserved by the visibility clause alone. This made imported/global episodic memory permanently unrecallable through callers that always pass a channel (such as the coding-agent memory backend). ([#8525](https://github.com/can1357/oh-my-pi/issues/8525))
+
 ## [17.2.11] - 2026-08-07
 
 ### Fixed

--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -527,10 +527,6 @@ function buildWhere(
 		clauses.push(`${prefix}author_type = ?`);
 		params.push(authorType);
 	}
-	if (channelId !== null && channelId !== "") {
-		clauses.push(`${prefix}channel_id = ?`);
-		params.push(channelId);
-	}
 	return { where: clauses.join(" AND "), params };
 }
 

--- a/packages/mnemopi/test/beam-recall-unit.test.ts
+++ b/packages/mnemopi/test/beam-recall-unit.test.ts
@@ -116,6 +116,28 @@ describe("beam recall free functions", () => {
 		expect(new Set(results.map(result => result.tier_label))).toEqual(new Set(["working", "episodic"]));
 	});
 
+	it("keeps global episodic rows visible when a channelId filter is active while still isolating other channels", async () => {
+		const beam = makeBeam();
+		// Global row with channel_id NULL — the shape produced by importFromDict()
+		// and by any cross-channel/global memory. Must survive a channelId filter.
+		insertEpisodic(beam, "em-global", "quokka migration protocol uses base64 snapshots");
+		// Non-global row owned by a different channel/session — must stay hidden.
+		beam.db.run(
+			"INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope, channel_id, veracity, memory_type) VALUES ('em-other-channel', 'quokka migration protocol for team beta', 'test', ?, 'other-session', 0.5, 'session', 'other-bank', 'unknown', 'general')",
+			["2026-05-30T12:00:00.000Z"],
+		);
+
+		const results = await recall(beam, "quokka migration protocol", 5, {
+			queryTime: "2026-05-30T12:00:00.000Z",
+			channelId: "project-bank",
+			includeWorking: false,
+		});
+
+		const ids = results.map(result => result.id);
+		expect(ids).toContain("em-global");
+		expect(ids).not.toContain("em-other-channel");
+	});
+
 	it("boosts memories near the requested temporal target", async () => {
 		const beam = makeBeam();
 		insertEpisodic(beam, "em-old", "incident alpha resolved by rotating credentials", {


### PR DESCRIPTION
## Repro
Insert a single episodic row with `scope='global'` and `channel_id NULL` (the exact shape produced by `importFromDict()` / the export-import round trip), confirm it via `fts_episodes MATCH`, then call `recall()`. Plain `recall(query)` returns the row; `recall(query, { channelId })` returns nothing. The coding-agent memory backend passes `channelId: target.bank` on every recall (`packages/coding-agent/src/mnemopi/state.ts`), so imported/global episodic memory is permanently invisible through the product surface. Command: a `bun` script inserting the row and calling `recall()` with and without `channelId` — `plain=1 withChannelId=0` before the fix, `plain=1 withChannelId=1` after.

## Cause
`buildWhere()` in `packages/mnemopi/src/core/beam/recall.ts` first builds the visibility clause `(session_id = ? OR scope = 'global' OR channel_id = ?)`, then unconditionally appended a second, hard `AND channel_id = ?` filter. That hard clause nullifies the `scope='global'` (and `session_id`) disjuncts: a global row whose `channel_id` isn't exactly the recall's `channelId` — every imported row, which has `channel_id NULL` — fails `channel_id = ?` and is dropped. Locally consolidated episodics happened to survive only because `consolidateToEpisodic()` stamps `channel_id = beam.channelId` (the bank).

## Fix
- Removed the redundant hard `channel_id = ?` clause from `buildWhere()`. The visibility OR-clause already isolates channels correctly: other-channel, non-global, cross-session rows fail all three disjuncts and stay hidden, while global rows remain visible regardless of the active channel — matching the semantics the `scope='global'` disjunct exists to provide.
- Added a regression test in `test/beam-recall-unit.test.ts` asserting a global row (channel_id NULL) is recalled under an active `channelId` while a different-channel non-global row is excluded.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/beam-recall-unit.test.ts test/identity-memory-parity.test.ts test/polyphonic-recall.test.ts test/temporal-recall.test.ts test/recall-precision-regressions.test.ts test/memory-facade.test.ts` — 53 pass, 0 fail. The new regression test fails on the unpatched `buildWhere()` (`Received: []`) and passes with the fix; the existing `identity-memory-parity` channel-isolation test remains green. Fixes #8525