### PR TITLE
docs: correct /hotkeys Ctrl+D copy to match save-draft-and-exit

### DIFF
--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -1110,7 +1110,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 
 	test("broker invalidation drops server-side last-good usage reports", async () => {
 		const credential = serverStore!.listAuthCredentials("anthropic")[0];
-		if (!credential || credential.credential.type !== "oauth") throw new Error("expected OAuth credential");
+		if (credential?.credential.type !== "oauth") throw new Error("expected OAuth credential");
 		serverStore!.updateAuthCredential(credential.id, {
 			...credential.credential,
 			expires: Date.now() + 3_600_000,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `/hotkeys` table describing Ctrl+D (`app.exit`) as "Exit (when editor is empty)" when it actually exits unconditionally and saves the current prompt as a resumable draft ([#8530](https://github.com/can1357/oh-my-pi/issues/8530)).
+
 ## [17.3.3] - 2026-08-14
 
 ### Fixed

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -39,7 +39,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| `Tab` | Path completion / accept autocomplete |",
 		`| \`${appKey(bindings, "app.interrupt")}\` | Cancel autocomplete / interrupt active work |`,
 		`| \`${appKey(bindings, "app.clear")}\` | Clear editor (first) / exit (second) |`,
-		`| \`${appKey(bindings, "app.exit")}\` | Exit (when editor is empty) |`,
+		`| \`${appKey(bindings, "app.exit")}\` | Exit (saves current prompt as draft) |`,
 		`| \`${appKey(bindings, "app.suspend")}\` | Suspend to background |`,
 		`| \`${appKey(bindings, "app.display.reset")}\` | Reset terminal display |`,
 		`| \`${appKey(bindings, "app.thinking.cycle")}\` | Cycle thinking level |`,


### PR DESCRIPTION
## Repro
Open the interactive TUI and run `/hotkeys`. The `app.exit` row reads `Exit (when editor is empty)`, implying Ctrl+D only exits when the prompt is empty (readline/EOF semantics). In practice Ctrl+D exits regardless of editor content and snapshots the current prompt as a resumable draft, so a mid-edit Ctrl+D drops the user to the shell — the copy contradicts the behavior.

## Cause
The help table is generated in `packages/coding-agent/src/modes/utils/hotkeys-markdown.ts:42`. The actual handler is unconditional: `custom-editor.ts` fires `onExit` for `app.exit` with no empty-editor check (`custom-editor.ts:952-955`), and `input-controller.ts` `handleCtrlD()` calls `this.ctx.shutdown()` unconditionally (`input-controller.ts:1059-1064`), which persists the editor text (empty or not) as a draft via `session-teardown.ts` `saveDraft`. The `(when editor is empty)` copy was never accurate.

## Fix
- `hotkeys-markdown.ts:42`: change the `app.exit` row from `Exit (when editor is empty)` to `Exit (saves current prompt as draft)`.
- Added an `[Unreleased]` changelog entry under coding-agent.

## Verification
`bun check` passes (run by the pre-publish gate). No test asserted the previous copy string (`command-controller-hotkeys.test.ts` only asserts key labels, not this description), so no test change was needed; the doc line is the artifact and matches the verified handler behavior. Fixes #8530