### PR TITLE
fix(pi-natives): guard DeviceCheck token generation on GUI session

### DIFF
--- a/crates/pi-natives/src/devicecheck.rs
+++ b/crates/pi-natives/src/devicecheck.rs
@@ -99,6 +99,43 @@ mod platform {
 		static _NSConcreteStackBlock: *const c_void;
 	}
 
+	// `SessionGetInfo` reports the caller's login-session attributes; consulted
+	// to detect a GUI/graphic session before touching the GUI-only DeviceCheck
+	// daemon.
+	#[link(name = "Security", kind = "framework")]
+	unsafe extern "C" {
+		fn SessionGetInfo(session: u32, session_id: *mut u32, attributes: *mut u32) -> i32;
+	}
+
+	/// `callerSecuritySession` — query the session hosting the current process.
+	const CALLER_SECURITY_SESSION: u32 = u32::MAX;
+	/// `sessionHasGraphicAccess` attribute bit from `Security/AuthSession.h`.
+	const SESSION_HAS_GRAPHIC_ACCESS: u32 = 0x0010;
+
+	/// Whether the caller's security session has GUI/graphic access.
+	///
+	/// `DCDevice.isSupported` synchronously opens an XPC connection to the
+	/// per-user DeviceCheck metadata daemon, which exists only in an
+	/// interactive GUI login session. From a session without graphic access
+	/// (SSH, a launchd `LaunchDaemon`, a CI runner, a service account, a
+	/// sandbox) the connection setup hits `_xpc_api_misuse` and aborts the
+	/// whole process with `SIGTRAP` before the completion handler can run — so
+	/// there is no error to return, only a dead process. Gating on the
+	/// documented session attribute keeps the call out of that trapping path.
+	///
+	/// Returns `false` when graphic access is absent *or* the session cannot be
+	/// queried: degrading to "unsupported" merely drops the attestation header
+	/// (exactly as on every non-macOS host), whereas optimistically assuming
+	/// "supported" risks the process-killing trap.
+	fn session_has_graphic_access() -> bool {
+		let mut attributes: u32 = 0;
+		// SAFETY: `SessionGetInfo` writes the caller session's attribute bits
+		// through the out-pointer; the session-id slot is unused, so it is null.
+		let status =
+			unsafe { SessionGetInfo(CALLER_SECURITY_SESSION, ptr::null_mut(), &mut attributes) };
+		status == 0 && attributes & SESSION_HAS_GRAPHIC_ACCESS != 0
+	}
+
 	/// Outcome delivered once from the completion block to the waiting worker.
 	enum Completion {
 		Token(String),
@@ -289,6 +326,10 @@ mod platform {
 			error:        None,
 			latency_ms:   0.0,
 		};
+		if !session_has_graphic_access() {
+			result.error = Some("DeviceCheck unavailable without a GUI login session".to_owned());
+			return result;
+		}
 		// SAFETY: `c"DCDevice"` is a valid null-terminated class name.
 		let class = unsafe { objc_getClass(c"DCDevice".as_ptr()) };
 		if class.is_null() {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `deviceCheckGenerateToken` aborting the whole process with `SIGTRAP` when called from a macOS session without GUI/graphic access (SSH, a launchd `LaunchDaemon`, a CI runner, a service account, a sandbox), which made every `openai-codex/*` OAuth model unusable for such accounts. `-[DCDevice isSupported]` synchronously opens an XPC connection to the per-user DeviceCheck metadata daemon, which exists only in an interactive GUI login session; without one the connection setup hits `_xpc_api_misuse` and traps before any completion handler runs, so the promise never rejects. The binding now checks the caller's security session for the `sessionHasGraphicAccess` attribute first and resolves `{ supported: false, error: … }` instead of touching DeviceCheck when it is absent ([#8353](https://github.com/can1357/oh-my-pi/issues/8353)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Changed


### PR DESCRIPTION
## Repro
On macOS arm64, calling `deviceCheckGenerateToken()` from `@oh-my-pi/pi-natives` in a session without GUI/graphic access (SSH, a launchd `LaunchDaemon`, a CI runner, a service account, a sandbox) aborts the whole process with `SIGTRAP` (exit 133) — no promise rejection, no error object. Because the codex attestation provider is gated on OAuth credentials, this makes every `openai-codex/*` model unusable for such accounts (`omp` dies mid-startup with `zsh: trace trap`). Minimal repro, no omp involved:

```js
const m = require(".../@oh-my-pi/pi-natives-darwin-arm64/pi_natives.darwin-arm64.node");
Promise.resolve(m.deviceCheckGenerateToken()).then(r => console.log("RESULT:", r));
```

Run as a user with no GUI login session → exit 133. Reproduces under both node v24.13.0 and bun 1.3.14. Reporter's LLDB backtrace (issue #8353) pins the trap.

## Cause
`crates/pi-natives/src/devicecheck.rs::platform::generate_token_inner` calls `-[DCDevice isSupported]`, which synchronously opens an XPC connection to the per-user DeviceCheck metadata daemon: `-[DCDeviceMetadataDaemonConnection connection]` → `xpc_connection_set_target_uid` → `_xpc_api_misuse`. That daemon exists only in an interactive GUI login session; from a session without graphic access the connection setup hits the XPC misuse precondition and traps on the libuv worker thread, taking the process down before any completion handler (or even `isSupported`'s own error path) can run. The completion block's `catch_unwind` cannot help — this is a CPU trap, not a Rust panic.

## Fix
- Add a `Security`-framework FFI binding for `SessionGetInfo` plus the `callerSecuritySession` / `sessionHasGraphicAccess` constants.
- New `session_has_graphic_access()` helper queries the caller's security session and returns `false` when graphic access is absent *or* the session cannot be queried (degrading only drops the attestation header, as on every non-macOS host; guessing "supported" risks the trap).
- `generate_token_inner` returns `{ supported: false, error: "DeviceCheck unavailable without a GUI login session" }` before touching DeviceCheck when graphic access is absent — the same graceful shape the non-macOS stub already produces. `generateCodexAttestation` then emits an error-coded envelope, exactly as a GUI account does on timeout, rather than crashing.
- Changelog entry under `packages/natives/CHANGELOG.md` `[Unreleased]`.

## Verification
The macOS-native trap cannot be reproduced on the Linux triage host (the binding takes its non-macOS stub there and returns `{ supported: false, latencyMs: 0 }`), and the full crate cannot be cross-compiled for `aarch64-apple-darwin` on Linux because a C build-dependency (`onig_sys`) has no cross toolchain. Verified instead:
- Cross-typechecked the new `SessionGetInfo` FFI + `session_has_graphic_access` + gated `generate_token_inner` for `aarch64-apple-darwin` in isolation (`rustc --target aarch64-apple-darwin --emit=metadata`) → clean.
- `bun test packages/natives/test/devicecheck.test.ts` → 1 pass (stub path unchanged).
- Pre-publish gate (`bun run fix` + `bun check`) → clean.

Headless macOS CI is required to confirm the trap is gone end-to-end. Fixes #8353