### PR TITLE
fix : support the coding plan of the Volcano supplier (volcengine.com)

### DIFF
--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -65,6 +65,8 @@ import { umansProvider } from "./umans";
 import { veniceProvider } from "./venice";
 import { vercelAiGatewayProvider } from "./vercel-ai-gateway";
 import { vllmProvider } from "./vllm";
+import { volcengineAgentPlanProvider } from "./volcengine-agent-plan";
+import { volcengineCodingPlanProvider } from "./volcengine-coding-plan";
 import { waferServerlessProvider } from "./wafer-serverless";
 import { xaiProvider } from "./xai";
 import { xaiOauthProvider } from "./xai-oauth";
@@ -75,8 +77,6 @@ import { xiaomiTokenPlanSgpProvider } from "./xiaomi-token-plan-sgp";
 import { zaiCodingPlanProvider, zaiProvider } from "./zai";
 import { zenmuxProvider } from "./zenmux";
 import { zhipuCodingPlanProvider } from "./zhipu-coding-plan";
-import {volcengineCodingPlanProvider} from "./volcengine-coding-plan";
-import {volcengineAgentPlanProvider} from "./volcengine-agent-plan";
 
 /**
  * The single per-provider list. Adding a provider = create `./providers/<id>.ts`
@@ -162,8 +162,8 @@ const ALL = [
 	amazonBedrockProvider,
 	bedrockMantleProvider,
 	gmiCloudProvider,
-    volcengineAgentPlanProvider,
-    volcengineCodingPlanProvider,
+	volcengineAgentPlanProvider,
+	volcengineCodingPlanProvider,
 ];
 
 export type RegistryDef = (typeof ALL)[number];

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -75,6 +75,8 @@ import { xiaomiTokenPlanSgpProvider } from "./xiaomi-token-plan-sgp";
 import { zaiCodingPlanProvider, zaiProvider } from "./zai";
 import { zenmuxProvider } from "./zenmux";
 import { zhipuCodingPlanProvider } from "./zhipu-coding-plan";
+import {volcengineCodingPlanProvider} from "./volcengine-coding-plan";
+import {volcengineAgentPlanProvider} from "./volcengine-agent-plan";
 
 /**
  * The single per-provider list. Adding a provider = create `./providers/<id>.ts`
@@ -160,6 +162,8 @@ const ALL = [
 	amazonBedrockProvider,
 	bedrockMantleProvider,
 	gmiCloudProvider,
+    volcengineAgentPlanProvider,
+    volcengineCodingPlanProvider,
 ];
 
 export type RegistryDef = (typeof ALL)[number];

--- a/packages/ai/src/registry/volcengine-agent-plan.ts
+++ b/packages/ai/src/registry/volcengine-agent-plan.ts
@@ -1,24 +1,23 @@
-import {createApiKeyLogin} from "./api-key-login";
-import type {OAuthLoginCallbacks} from "./oauth/types";
-import type {ProviderDefinition} from "./types";
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
 
 const loginVolcengineAgentPlan = createApiKeyLogin({
-    providerLabel: "Volcengine Agent Plan",
-    authUrl: "https://console.volcengine.com/ark/region:cn-beijing/subscription/agent-plan",
-    instructions: "Create or copy your API key from the Volcengine Agent Plan dashboard",
-    promptMessage: "Paste your Volcengine Agent Plan API key",
-    placeholder: "ark-...",
-    validation: {
-        kind: "chat-completions",
-        provider: "Volcengine Agent Plan",
-        baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
-        model: "ark-code-latest",
-    },
+	providerLabel: "Volcengine Agent Plan",
+	authUrl: "https://console.volcengine.com/ark/region:cn-beijing/subscription/agent-plan",
+	instructions: "Create or copy your API key from the Volcengine Agent Plan dashboard",
+	promptMessage: "Paste your Volcengine Agent Plan API key",
+	placeholder: "ark-...",
+	validation: {
+		kind: "chat-completions",
+		provider: "Volcengine Agent Plan",
+		baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
+		model: "ark-code-latest",
+	},
 });
 
-
 export const volcengineAgentPlanProvider = {
-    id: "volcengine-agent-plan",
-    name: "Volcengine Agent Plan",
-    login: (cb: OAuthLoginCallbacks) => loginVolcengineAgentPlan(cb),
+	id: "volcengine-agent-plan",
+	name: "Volcengine Agent Plan",
+	login: (cb: OAuthLoginCallbacks) => loginVolcengineAgentPlan(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/volcengine-agent-plan.ts
+++ b/packages/ai/src/registry/volcengine-agent-plan.ts
@@ -1,0 +1,24 @@
+import {createApiKeyLogin} from "./api-key-login";
+import type {OAuthLoginCallbacks} from "./oauth/types";
+import type {ProviderDefinition} from "./types";
+
+const loginVolcengineAgentPlan = createApiKeyLogin({
+    providerLabel: "Volcengine Agent Plan",
+    authUrl: "https://console.volcengine.com/ark/region:cn-beijing/subscription/agent-plan",
+    instructions: "Create or copy your API key from the Volcengine Agent Plan dashboard",
+    promptMessage: "Paste your Volcengine Agent Plan API key",
+    placeholder: "ark-...",
+    validation: {
+        kind: "chat-completions",
+        provider: "Volcengine Agent Plan",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
+        model: "ark-code-latest",
+    },
+});
+
+
+export const volcengineAgentPlanProvider = {
+    id: "volcengine-agent-plan",
+    name: "Volcengine Agent Plan",
+    login: (cb: OAuthLoginCallbacks) => loginVolcengineAgentPlan(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/volcengine-coding-plan.ts
+++ b/packages/ai/src/registry/volcengine-coding-plan.ts
@@ -1,0 +1,24 @@
+import {createApiKeyLogin} from "./api-key-login";
+import type {OAuthLoginCallbacks} from "./oauth/types";
+import type {ProviderDefinition} from "./types";
+
+const loginVolcengineCodingPlan = createApiKeyLogin({
+	providerLabel: "Volcengine Coding Plan",
+	authUrl: "https://console.volcengine.com/ark/region:cn-beijing/subscription/coding-plan",
+	instructions: "Create or copy your API key from the Volcengine Coding Plan dashboard",
+	promptMessage: "Paste your Volcengine Coding Plan API key",
+	placeholder: "ark-...",
+	validation: {
+		kind: "chat-completions",
+		provider: "Volcengine Coding Plan",
+		baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+		model: "ark-code-latest",
+	},
+});
+
+
+export const volcengineCodingPlanProvider = {
+	id: "volcengine-coding-plan",
+	name: "Volcengine Coding Plan",
+	login: (cb: OAuthLoginCallbacks) => loginVolcengineCodingPlan(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/volcengine-coding-plan.ts
+++ b/packages/ai/src/registry/volcengine-coding-plan.ts
@@ -1,6 +1,6 @@
-import {createApiKeyLogin} from "./api-key-login";
-import type {OAuthLoginCallbacks} from "./oauth/types";
-import type {ProviderDefinition} from "./types";
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
 
 const loginVolcengineCodingPlan = createApiKeyLogin({
 	providerLabel: "Volcengine Coding Plan",
@@ -15,7 +15,6 @@ const loginVolcengineCodingPlan = createApiKeyLogin({
 		model: "ark-code-latest",
 	},
 });
-
 
 export const volcengineCodingPlanProvider = {
 	id: "volcengine-coding-plan",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -111995,5 +111995,522 @@
 				]
 			}
 		}
-	}
+	},
+
+  "volcengine-agent-plan": {
+    "doubao-seed-evolving": {
+      "id": "doubao-seed-evolving",
+      "name": "Doubao-Seed-Evolving",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.8848,
+        "output": 4.424,
+        "cacheRead": 0.177,
+        "cacheWrite": 0.0025
+      },
+      "contextWindow": 256000,
+      "maxTokens": null,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "doubao-seed-2.1-turbo": {
+      "id": "doubao-seed-2.1-turbo",
+      "name": "Doubao-Seed-2.1-turbo",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.4424,
+        "output": 2.212,
+        "cacheRead": 0.0885,
+        "cacheWrite": 0.0025
+      },
+      "contextWindow": 256000,
+      "maxTokens": null,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "doubao-seed-2.0-lite": {
+      "id": "doubao-seed-2.0-lite",
+      "name": "Doubao-Seed-2.0-lite",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.09,
+        "output": 0.51,
+        "cacheRead": 0.02,
+        "cacheWrite": 0.0024
+      },
+      "contextWindow": 256000,
+      "maxTokens": 64000,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "doubao-seed-2.0-mini": {
+      "id": "doubao-seed-2.0-mini",
+      "name": "Doubao-Seed-2.0-mini",
+      "api": "openai-completions",
+      "provider": "zenmux",
+      "baseUrl": "https://zenmux.ai/api/v1",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.03,
+        "output": 0.28,
+        "cacheRead": 0.01,
+        "cacheWrite": 0.0024
+      },
+      "contextWindow": 256000,
+      "maxTokens": 64000,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "deepseek-v4-flash": {
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek-V4-Flash",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text"
+      ],
+      "cost": {
+        "input": 0.15,
+        "output": 0.25,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 393216,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "low",
+          "high",
+          "max"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "kimi-k3": {
+      "id": "kimi-k3",
+      "name": "Kimi-K3",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 3,
+        "output": 12.5,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 131072,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "low",
+          "high",
+          "max"
+        ],
+        "defaultLevel": "max",
+        "effortMap": {
+          "max": "max"
+        },
+        "requiresEffort": true
+      },
+      "supportsComputerUse": false
+    },
+    "glm-5.2": {
+      "id": "glm-5.2",
+      "name": "GLM-5.2",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text"
+      ],
+      "cost": {
+        "input": 1,
+        "output": 4,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 131072,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "kimi-k2.7-code": {
+      "id": "kimi-k2.7-code",
+      "name": "Kimi-K2.7-Code",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.75,
+        "output": 3.5,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 262144,
+      "maxTokens": 262144,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "minimax-m3": {
+      "id": "minimax-m3",
+      "name": "MiniMax-M3",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 512000,
+      "maxTokens": 128000,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    "deepseek-v4-pro": {
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek-V4-Pro",
+      "api": "openai-completions",
+      "provider": "volcengine-agent-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/plan/v3",
+      "reasoning": true,
+      "input": [
+        "text"
+      ],
+      "cost": {
+        "input": 1,
+        "output": 2.5,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 393216,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "high",
+          "max"
+        ]
+      },
+      "supportsComputerUse": false
+    }
+  },
+  "volcengine-coding-plan": {
+    "doubao-seed-2.1-turbo": {
+      "id": "doubao-seed-2.1-turbo",
+      "name": "Doubao-Seed-2.1-turbo",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.4424,
+        "output": 2.212,
+        "cacheRead": 0.0885,
+        "cacheWrite": 0.0025
+      },
+      "contextWindow": 256000,
+      "maxTokens": null,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "doubao-seed-2.0-lite": {
+      "id": "doubao-seed-2.0-lite",
+      "name": "Doubao-Seed-2.0-lite",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.09,
+        "output": 0.51,
+        "cacheRead": 0.02,
+        "cacheWrite": 0.0024
+      },
+      "contextWindow": 256000,
+      "maxTokens": 64000,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "deepseek-v4-flash": {
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek-V4-Flash",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text"
+      ],
+      "cost": {
+        "input": 0.15,
+        "output": 0.25,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 393216,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "low",
+          "high",
+          "max"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "glm-5.2": {
+      "id": "glm-5.2",
+      "name": "GLM-5.2",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text"
+      ],
+      "cost": {
+        "input": 1,
+        "output": 4,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 131072,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "kimi-k2.7-code": {
+      "id": "kimi-k2.7-code",
+      "name": "Kimi-K2.7-Code",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0.75,
+        "output": 3.5,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 262144,
+      "maxTokens": 262144,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      "supportsComputerUse": false
+    },
+    "minimax-m3": {
+      "id": "minimax-m3",
+      "name": "MiniMax-M3",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text",
+        "image"
+      ],
+      "cost": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 512000,
+      "maxTokens": 128000,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    "deepseek-v4-pro": {
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek-V4-Pro",
+      "api": "openai-completions",
+      "provider": "volcengine-coding-plan",
+      "baseUrl": "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "reasoning": true,
+      "input": [
+        "text"
+      ],
+      "cost": {
+        "input": 1,
+        "output": 2.5,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "contextWindow": 1048576,
+      "maxTokens": 393216,
+      "thinking": {
+        "mode": "effort",
+        "efforts": [
+          "high",
+          "max"
+        ]
+      },
+      "supportsComputerUse": false
+    }
+  }
 }

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -460,6 +460,18 @@ export const CATALOG_PROVIDERS = [
 		catalogDiscovery: { label: "vLLM", allowUnauthenticated: true },
 	},
 	{
+		id: "volcengine-agent-plan",
+		defaultModel: "ark-code-latest",
+		envVars: ["VOLCENGINE_AGENT_PLAN_API_KEY"],
+		catalogDiscovery: { label: "Volcengine Agent Plan", oauthProvider: "volcengine-agent-plan" },
+	},
+	{
+		id: "volcengine-coding-plan",
+		defaultModel: "ark-code-latest",
+		envVars: ["VOLCENGINE_CODING_PLAN_API_KEY"],
+		catalogDiscovery: { label: "Volcengine Coding Plan", oauthProvider: "volcengine-coding-plan" },
+	},
+	{
 		id: "wafer-serverless",
 		defaultModel: "GLM-5.1",
 		envVars: ["WAFER_SERVERLESS_API_KEY"],


### PR DESCRIPTION
## What

provider add [Volcengine Agent Plan] and [ Volcengine Coding Plan]

## Why

fix : [Hope to support the coding plan of the Volcano supplier (volcengine.com) #4201](https://github.com/can1357/oh-my-pi/issues/4201)

## Testing
-  <b> bun check </b>
<img width="1685" height="628" alt="image" src="https://github.com/user-attachments/assets/30370f1d-f905-4703-a4a3-037257ad133b" />

- Tested locally 
   1.  bun run dev
   2.  "/login", choose [Volcengine Agent Plan] or [ Volcengine Coding Plan], can open auth page, paste api_key 
   3. "/model", can choose model.json default model
   4. Sending a message can be replied to.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
