### PR TITLE
fix(coding-agent): restore Windows external editor launch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+G external editors failing to launch on Windows because Bun re-quoted the embedded `cmd.exe /c` command line ([#8544](https://github.com/can1357/oh-my-pi/issues/8544)).
+
 ## [17.3.3] - 2026-08-14
 
 ### Fixed

--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -33,6 +33,27 @@ export interface OpenInEditorOptions {
 	trimTrailingNewline?: boolean;
 }
 
+/** Subprocess argv and Windows quoting mode used to launch an external editor. */
+export interface EditorSpawnCommand {
+	cmd: string[];
+	windowsVerbatimArguments: boolean;
+}
+
+/** Resolves shell argv without letting the host runtime re-quote the editor command. */
+export function resolveEditorSpawnCommand(
+	editorCmd: string,
+	tmpFile: string,
+	platform: NodeJS.Platform = process.platform,
+): EditorSpawnCommand {
+	const windows = platform === "win32";
+	// cmd.exe strips the outer /s /c quote pair; Bun must pass the embedded
+	// editor/path quotes verbatim instead of applying argv escaping to them.
+	const cmd = windows
+		? ["cmd.exe", "/d", "/s", "/c", `"${editorCmd} "${tmpFile}""`]
+		: [$which("sh") ?? "sh", "-c", `${editorCmd} "$1"`, "sh", tmpFile];
+	return { cmd, windowsVerbatimArguments: windows };
+}
+
 /**
  * Opens `content` in the user's external editor and returns the edited text.
  * Returns `null` if the editor exits with a non-zero code.
@@ -50,15 +71,13 @@ export async function openInEditor(
 	try {
 		await Bun.write(tmpFile, content);
 
+		const spawnCommand = resolveEditorSpawnCommand(editorCmd, tmpFile);
 		const [stdin, stdout, stderr] = options?.stdio ?? ["inherit", "inherit", "inherit"];
-		const cmd =
-			process.platform === "win32"
-				? ["cmd", "/c", `${editorCmd} "${tmpFile}"`]
-				: [$which("sh") ?? "sh", "-c", `${editorCmd} "$1"`, "sh", tmpFile];
-		const child = Bun.spawn(cmd, {
+		const child = Bun.spawn(spawnCommand.cmd, {
 			stdin,
 			stdout,
 			stderr,
+			windowsVerbatimArguments: spawnCommand.windowsVerbatimArguments,
 		});
 		const exitCode = await child.exited;
 		if (exitCode === 0) {

--- a/packages/coding-agent/test/external-editor.test.ts
+++ b/packages/coding-agent/test/external-editor.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { TempDir } from "@oh-my-pi/pi-utils";
-import { getEditorCommand, openInEditor } from "../src/utils/external-editor";
+import { getEditorCommand, openInEditor, resolveEditorSpawnCommand } from "../src/utils/external-editor";
 
 interface MutableProcess {
 	platform: NodeJS.Platform;
@@ -66,6 +66,21 @@ describe("getEditorCommand", () => {
 });
 
 describe("openInEditor", () => {
+	it("passes the cmd.exe command line verbatim on Windows", () => {
+		const tmpFile = String.raw`C:\Users\Example User\AppData\Local\Temp\omp-editor-123.omp.md`;
+
+		expect(resolveEditorSpawnCommand('"C:\\Program Files\\Code.exe" --wait', tmpFile, "win32")).toEqual({
+			cmd: [
+				"cmd.exe",
+				"/d",
+				"/s",
+				"/c",
+				String.raw`""C:\Program Files\Code.exe" --wait "C:\Users\Example User\AppData\Local\Temp\omp-editor-123.omp.md""`,
+			],
+			windowsVerbatimArguments: true,
+		});
+	});
+
 	it.skipIf(process.platform === "win32")("supports quoted editor paths containing spaces", async () => {
 		const tempDir = TempDir.createSync("@external-editor-");
 		try {


### PR DESCRIPTION
## Repro
On Windows, Ctrl+G reaches `openInEditor()` with `notepad` (or a configured editor). The current construction can be isolated with `bun -e 'console.log(JSON.stringify(["cmd", "/c", "notepad \"C:\\Users\\Example User\\AppData\\Local\\Temp\\omp-editor.omp.md\""]))'`, which emits one shell-command argv element containing embedded quotes; Bun re-quotes that element before `cmd.exe` parses it, and the editor never launches.

## Cause
`openInEditor()` in `packages/coding-agent/src/utils/external-editor.ts` migrated from shell-backed `child_process.spawn` to `Bun.spawn`, but kept the complete Windows `cmd.exe /c` command in one normal argv element. Bun's Windows argv escaping then transformed the embedded editor/file quotes for `CommandLineToArgvW`, not `cmd.exe`'s parser.

## Fix
- Build the canonical outer-quoted `cmd.exe /d /s /c` command line for configured editor commands and temporary paths.
- Set `windowsVerbatimArguments` on Windows so Bun passes that line to `cmd.exe` unchanged.
- Add regression coverage for a quoted editor path, editor arguments, and a temporary path containing spaces; record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/external-editor.test.ts`: 8 passed, 0 failed. `cd packages/coding-agent && bun run check`: passed. Skipped the pre-publish gate because `bun run fix` fails identically on clean `origin/main`: this workstation lacks CMake while `audiopus_sys` builds vendored Opus. Fixes #8544