### PR TITLE
fix(tests): prune bazel convenience symlinks from bun test discovery

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -15,6 +15,11 @@ saveTextLockfile = true
 [test]
 # bun test does NOT honor .gitignore; prune robomp's repo clones and
 # scratch dirs so a root-level `bun test` doesn't walk into them.
+#
+# `bazel-*` are Bazel's convenience symlinks, and `bazel-oh-my-pi` points at
+# the workspace root itself: without this the scanner recurses through that
+# loop, exhausts file descriptors, and every test that pipes a child process's
+# stdio fails with empty output or EPIPE.
 pathIgnorePatterns = [
   "**/node_modules/**",
   "**/.git/**",
@@ -26,6 +31,8 @@ pathIgnorePatterns = [
   "python/robomp/data/**",
   ".wt/**",
   ".worktrees/**",
+  "bazel-*/**",
+  "**/bazel-out/**",
 ]
 
 [run]


### PR DESCRIPTION
`bun test` does not honor `.gitignore`, and Bazel's convenience symlinks at the workspace root include `bazel-oh-my-pi`, which points at the workspace root itself. Any developer who has run a Bazel target therefore gives `bun test`'s file scanner a symlink loop to walk.

The scanner burns file descriptors on that loop, and the consequence is not a slow run: piped child-process stdio breaks for the whole test process. Concretely, on macOS with Bun 1.3.14, after the loop is walked:

- `Bun.spawn([process.execPath, "--version"], { stdout: "pipe" })` yields empty stdout
- writing to a `stdin: "pipe"` child fails with `EPIPE` (`fd: 11903`)

So every test that speaks to a real subprocess fails, with errors that point nowhere near the cause. In `test/acp-agent.test.ts` this presented as 4 failures in the MCP stdio-transport tests (`Transport not connected`, `pollUntil timed out`) that reproduce on a clean checkout of `main` and disappear when the same file is run with a cwd outside the repo.

## Change

Add `bazel-*/**` and `**/bazel-out/**` to `[test] pathIgnorePatterns`, with a comment recording the failure mode so the entries are not "cleaned up" later.

## Verification

In a worktree with no Bazel output, `ln -s . bazel-<name>` reproduces the failure and the added patterns fix it:

| state | `bun test packages/coding-agent/test/acp-agent.test.ts` |
| --- | --- |
| no bazel symlink | 61 pass / 0 fail |
| symlink loop, before this change | 57 pass / 4 fail |
| symlink loop, after this change | 61 pass / 0 fail |

Also confirmed against a real Bazel-built checkout (`bazel-bin`, `bazel-out`, `bazel-testlogs`, `bazel-oh-my-pi` present): same suite goes from 4 failures to 0.
