### PR TITLE
feat(acp): opt-in ambient MCP server discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in ambient MCP discovery for ACP sessions via the `omp.sh/ambient-mcp-discovery` capability: a client that requests it gets the host's configured MCP servers mounted alongside its own (client entries overlay same-named ambient ones), reserved bridge server names stay client-owned, and configuration or connection failures are recorded as redacted durable session diagnostics.
+
 ## [17.3.3] - 2026-08-14
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -30,6 +30,8 @@ export interface LoadMCPConfigsResult {
 	exaApiKeys: string[];
 	/** Source metadata for each server */
 	sources: Record<string, SourceMeta>;
+	/** Redactable discovery warnings from native configuration providers. */
+	warnings: string[];
 }
 
 /**
@@ -154,7 +156,7 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 		sources = browserResult.sources;
 	}
 
-	return { configs, exaApiKeys, sources };
+	return { configs, exaApiKeys, sources, warnings: result.warnings };
 }
 
 /** Pattern to match Exa MCP servers */

--- a/packages/coding-agent/src/mcp/loader.ts
+++ b/packages/coding-agent/src/mcp/loader.ts
@@ -29,6 +29,8 @@ export interface MCPToolsLoadResult {
 export interface MCPToolsLoadOptions {
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
+	/** Called for each warning produced by native MCP configuration discovery. */
+	onConfigWarning?: (warning: string) => void;
 	/** Whether to load project-level config (default: true) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
@@ -70,6 +72,7 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 	try {
 		result = await manager.discoverAndConnect({
 			onStatus: options?.onStatus,
+			onConfigWarning: options?.onConfigWarning,
 			enableProjectConfig: options?.enableProjectConfig,
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -174,6 +174,8 @@ export interface MCPDiscoverOptions {
 	filterBrowser?: boolean;
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
+	/** Called for each warning produced by native MCP configuration discovery. */
+	onConfigWarning?: (warning: string) => void;
 }
 
 /** Handles an MCP `WWW-Authenticate` challenge and returns refreshed config. */
@@ -410,7 +412,8 @@ export class MCPManager {
 			options?.onStatus?.({ type: "failed", serverName: ".mcp.json", error: message });
 			throw error;
 		}
-		const { configs, exaApiKeys, sources } = loadedConfigs;
+		const { configs, exaApiKeys, sources, warnings } = loadedConfigs;
+		for (const warning of warnings) options?.onConfigWarning?.(warning);
 		const result = await this.connectServers(configs, sources, options?.onStatus);
 		result.exaApiKeys = exaApiKeys;
 		return result;

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -437,7 +437,7 @@ export class MCPManager {
 
 		const errors = new Map<string, string>();
 		const connectedServers = new Set<string>();
-		const allTools: CustomTool<TSchema, MCPToolDetails>[] = [];
+		const allTools: CustomTool<TSchema, MCPToolDetails>[] = [...this.#tools];
 		const reportedErrors = new Set<string>();
 		let allowBackgroundLogging = false;
 		const statusServerNames: string[] = [];

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -56,6 +56,7 @@ import { getSessionSlashCommands } from "../../extensibility/extensions/get-comm
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../../internal-urls";
+import { discoverAndLoadMCPTools } from "../../mcp/loader";
 import { MCPManager } from "../../mcp/manager";
 import type { MCPServerConfig } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
@@ -112,6 +113,26 @@ export const ACP_BOOTSTRAP_RACE_GUARD_MS = 50;
 const ACP_CANCEL_CLEANUP_TIMEOUT_MS = 5_000;
 const ACP_ASYNC_DELIVERY_DRAIN_TIMEOUT_MS = 250;
 const ACP_ASYNC_DELIVERY_DRAIN_MAX_PASSES = 3;
+const AMBIENT_MCP_DISCOVERY_META_KEY = "omp.sh/ambient-mcp-discovery";
+const AMBIENT_MCP_DISCOVERY_VERSION = 1;
+const AMBIENT_MCP_DIAGNOSTIC_TYPE = "ambient-mcp-diagnostic";
+
+type AmbientMcpDiscoveryOptions = {
+	readonly reservedServerNames: ReadonlySet<string>;
+};
+
+function ambientMcpDiscoveryOptions(meta: NewSessionRequest["_meta"]): AmbientMcpDiscoveryOptions | undefined {
+	const request = meta?.[AMBIENT_MCP_DISCOVERY_META_KEY];
+	if (typeof request !== "object" || request === null || Array.isArray(request)) return undefined;
+	if (Reflect.get(request, "enabled") !== true) return undefined;
+	const rawReservedNames = Reflect.get(request, "reservedServerNames");
+	const reservedServerNames = new Set(
+		Array.isArray(rawReservedNames)
+			? rawReservedNames.filter((name): name is string => typeof name === "string" && name.length > 0)
+			: [],
+	);
+	return { reservedServerNames };
+}
 
 type AgentImageContent = {
 	type: "image";
@@ -518,6 +539,9 @@ export class AcpAgent implements Agent {
 			},
 			authMethods,
 			agentCapabilities: {
+				_meta: {
+					[AMBIENT_MCP_DISCOVERY_META_KEY]: { version: AMBIENT_MCP_DISCOVERY_VERSION },
+				},
 				loadSession: true,
 				mcpCapabilities: {
 					http: true,
@@ -551,7 +575,11 @@ export class AcpAgent implements Agent {
 
 	async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
 		this.#assertAbsoluteCwd(params.cwd);
-		const record = await this.#createNewSessionRecord(params.cwd, params.mcpServers);
+		const record = await this.#createNewSessionRecord(
+			params.cwd,
+			params.mcpServers,
+			ambientMcpDiscoveryOptions(params._meta),
+		);
 		const response: NewSessionResponse = {
 			sessionId: record.session.sessionId,
 			configOptions: this.#buildConfigOptions(record.session),
@@ -563,7 +591,12 @@ export class AcpAgent implements Agent {
 
 	async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
 		this.#assertAbsoluteCwd(params.cwd);
-		const record = await this.#loadManagedSession(params.sessionId, params.cwd, params.mcpServers);
+		const record = await this.#loadManagedSession(
+			params.sessionId,
+			params.cwd,
+			params.mcpServers,
+			ambientMcpDiscoveryOptions(params._meta),
+		);
 		await this.#replaySessionHistory(record);
 		const response: LoadSessionResponse = {
 			configOptions: this.#buildConfigOptions(record.session),
@@ -592,7 +625,12 @@ export class AcpAgent implements Agent {
 
 	async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
 		this.#assertAbsoluteCwd(params.cwd);
-		const record = await this.#resumeManagedSession(params.sessionId, params.cwd, params.mcpServers ?? []);
+		const record = await this.#resumeManagedSession(
+			params.sessionId,
+			params.cwd,
+			params.mcpServers ?? [],
+			ambientMcpDiscoveryOptions(params._meta),
+		);
 		const response: ResumeSessionResponse = {
 			configOptions: this.#buildConfigOptions(record.session),
 			modes: this.#buildModeState(record.session),
@@ -1053,7 +1091,11 @@ export class AcpAgent implements Agent {
 		);
 	}
 
-	async #createNewSessionRecord(cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
+	async #createNewSessionRecord(
+		cwd: string,
+		mcpServers: McpServer[],
+		ambientDiscovery: AmbientMcpDiscoveryOptions | undefined,
+	): Promise<ManagedSessionRecord> {
 		const session = await this.#createSession(path.resolve(cwd));
 		try {
 			await session.sessionManager.ensureOnDisk();
@@ -1061,14 +1103,19 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers);
+		return await this.#registerPreparedSession(session, mcpServers, ambientDiscovery);
 	}
 
-	async #loadManagedSession(sessionId: string, cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
+	async #loadManagedSession(
+		sessionId: string,
+		cwd: string,
+		mcpServers: McpServer[],
+		ambientDiscovery: AmbientMcpDiscoveryOptions | undefined,
+	): Promise<ManagedSessionRecord> {
 		const existing = this.#sessions.get(sessionId);
 		if (existing) {
 			this.#assertMatchingCwd(existing.session, cwd);
-			await this.#configureMcpServers(existing, mcpServers);
+			await this.#configureMcpServers(existing, mcpServers, ambientDiscovery);
 			return existing;
 		}
 
@@ -1076,14 +1123,19 @@ export class AcpAgent implements Agent {
 		if (!storedSession) {
 			throw new Error(`ACP session not found: ${sessionId}`);
 		}
-		return await this.#openStoredSession(storedSession.path, cwd, mcpServers, sessionId);
+		return await this.#openStoredSession(storedSession.path, cwd, mcpServers, sessionId, ambientDiscovery);
 	}
 
-	async #resumeManagedSession(sessionId: string, cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
+	async #resumeManagedSession(
+		sessionId: string,
+		cwd: string,
+		mcpServers: McpServer[],
+		ambientDiscovery: AmbientMcpDiscoveryOptions | undefined,
+	): Promise<ManagedSessionRecord> {
 		const existing = this.#sessions.get(sessionId);
 		if (existing) {
 			this.#assertMatchingCwd(existing.session, cwd);
-			await this.#configureMcpServers(existing, mcpServers);
+			await this.#configureMcpServers(existing, mcpServers, ambientDiscovery);
 			return existing;
 		}
 
@@ -1091,7 +1143,7 @@ export class AcpAgent implements Agent {
 		if (!storedSession) {
 			throw new Error(`ACP session not found: ${sessionId}`);
 		}
-		return await this.#openStoredSession(storedSession.path, cwd, mcpServers, sessionId);
+		return await this.#openStoredSession(storedSession.path, cwd, mcpServers, sessionId, ambientDiscovery);
 	}
 
 	async #forkManagedSession(params: ForkSessionRequest): Promise<ManagedSessionRecord> {
@@ -1110,7 +1162,11 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, params.mcpServers ?? []);
+		return await this.#registerPreparedSession(
+			session,
+			params.mcpServers ?? [],
+			ambientMcpDiscoveryOptions(params._meta),
+		);
 	}
 
 	async #openStoredSession(
@@ -1118,6 +1174,7 @@ export class AcpAgent implements Agent {
 		cwd: string,
 		mcpServers: McpServer[],
 		sessionId: string,
+		ambientDiscovery: AmbientMcpDiscoveryOptions | undefined,
 	): Promise<ManagedSessionRecord> {
 		const session = await this.#createSession(path.resolve(cwd));
 		try {
@@ -1129,17 +1186,21 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers);
+		return await this.#registerPreparedSession(session, mcpServers, ambientDiscovery);
 	}
 
-	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
+	async #registerPreparedSession(
+		session: AgentSession,
+		mcpServers: McpServer[],
+		ambientDiscovery: AmbientMcpDiscoveryOptions | undefined,
+	): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
 		try {
 			await this.#configureExtensions(record);
-			await this.#configureMcpServers(record, mcpServers);
+			await this.#configureMcpServers(record, mcpServers, ambientDiscovery);
 			this.#sessions.set(session.sessionId, record);
 			return record;
 		} catch (error) {
@@ -2425,7 +2486,24 @@ export class AcpAgent implements Agent {
 		record.extensionsConfigured = true;
 	}
 
-	async #configureMcpServers(record: ManagedSessionRecord, servers: McpServer[]): Promise<void> {
+	#recordAmbientMcpDiagnostic(record: ManagedSessionRecord, failedName: string): void {
+		const phase = failedName === ".mcp.json" ? "configuration" : "connection";
+		const serverName =
+			failedName === ".mcp.json" ? undefined : failedName.replace(/[^a-zA-Z0-9_.:-]/g, "?").slice(0, 128);
+		const details = {
+			scope: "ambient",
+			phase,
+			...(serverName ? { serverName } : {}),
+		};
+		record.session.sessionManager.appendCustomMessageEntry(AMBIENT_MCP_DIAGNOSTIC_TYPE, undefined, false, details);
+		logger.warn("Ambient MCP setup failed", details);
+	}
+
+	async #configureMcpServers(
+		record: ManagedSessionRecord,
+		servers: McpServer[],
+		ambientDiscovery: AmbientMcpDiscoveryOptions | undefined,
+	): Promise<void> {
 		if (record.mcpManager) {
 			await record.mcpManager.disconnectAll();
 		}
@@ -2434,21 +2512,36 @@ export class AcpAgent implements Agent {
 		// stale tool set after this reconfiguration installs the new one.
 		await record.mcpRefreshChain;
 		record.mcpRefreshChain = undefined;
-		if (servers.length === 0) {
-			record.mcpManager = undefined;
-			await record.session.refreshMCPTools([]);
-			return;
+
+		let manager: MCPManager;
+		if (ambientDiscovery) {
+			const settings = record.session.settings;
+			const ambient = await discoverAndLoadMCPTools(record.session.sessionManager.getCwd(), {
+				enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
+				filterExa: true,
+				filterBrowser: settings.get("browser.enabled") ?? false,
+				cacheStorage: settings.getStorage(),
+				authStorage: record.session.modelRegistry.authStorage,
+				onStatus: event => {
+					if (event.type === "failed") this.#recordAmbientMcpDiagnostic(record, event.serverName);
+				},
+				onConfigWarning: () => this.#recordAmbientMcpDiagnostic(record, ".mcp.json"),
+			});
+			manager = ambient.manager;
+		} else {
+			manager = new MCPManager(record.session.sessionManager.getCwd());
+		}
+		record.mcpManager = manager;
+
+		if (ambientDiscovery) {
+			for (const reservedName of ambientDiscovery.reservedServerNames) {
+				await manager.disconnectServer(reservedName);
+			}
+		}
+		if (record.session.settings.get("mcp.notifications")) {
+			manager.setNotificationsEnabled(true);
 		}
 
-		const manager = new MCPManager(record.session.sessionManager.getCwd());
-		// MCP servers connect and reconnect independently, so `onToolsChanged` can fire
-		// several times back to back. Each firing is chained onto `record.mcpRefreshChain`
-		// so refreshes apply in order, and each one re-reads `manager.getTools()` at the
-		// time it actually runs rather than the snapshot from when it was queued — so a
-		// refresh can never apply a stale, smaller tool set after a newer one already landed.
-		// The returned promise propagates failures (the initial awaited refresh below must
-		// fail session setup, as the pre-queue code did); the stored chain swallows them
-		// after logging so background firings only warn and the chain never rejects.
 		const enqueueMcpToolsRefresh = (): Promise<void> => {
 			const run = (record.mcpRefreshChain ?? Promise.resolve()).then(async () => {
 				if (record.mcpManager !== manager) return;
@@ -2462,12 +2555,14 @@ export class AcpAgent implements Agent {
 			return run;
 		};
 		manager.setOnToolsChanged(() => {
-			// Failures are logged once via the stored chain's catch above.
 			enqueueMcpToolsRefresh().catch(() => {});
 		});
+
 		const configs: MCPConfigMap = {};
 		const sources: MCPSourceMap = {};
 		for (const server of servers) {
+			// Client-supplied servers overlay ambient servers by name.
+			await manager.disconnectServer(server.name);
 			configs[server.name] = this.#toMcpConfig(server);
 			sources[server.name] = {
 				provider: "acp",
@@ -2477,17 +2572,36 @@ export class AcpAgent implements Agent {
 			};
 		}
 
-		const result = await manager.connectServers(configs, sources);
-		if (result.errors.size > 0) {
-			throw new Error(
-				Array.from(result.errors.entries())
-					.map(([name, message]) => `${name}: ${message}`)
-					.join("; "),
-			);
+		if (servers.length > 0) {
+			const requiredReadiness = new Map<string, ReturnType<typeof Promise.withResolvers<boolean>>>();
+			for (const server of servers) {
+				if (ambientDiscovery?.reservedServerNames.has(server.name)) {
+					requiredReadiness.set(server.name, Promise.withResolvers<boolean>());
+				}
+			}
+			const result = await manager.connectServers(configs, sources, event => {
+				if (event.type === "connecting") return;
+				const readiness = requiredReadiness.get(event.serverName);
+				if (readiness) readiness.resolve(event.type === "connected");
+			});
+			if (result.errors.size > 0) {
+				throw new Error(
+					Array.from(result.errors.entries())
+						.map(([name, message]) => `${name}: ${message}`)
+						.join("; "),
+				);
+			}
+			for (const [name, readiness] of requiredReadiness) {
+				if (!(await readiness.promise)) {
+					throw new Error(`Required client MCP server "${name}" failed to load tools`);
+				}
+			}
 		}
 
-		record.mcpManager = manager;
 		await enqueueMcpToolsRefresh();
+		if (!ambientDiscovery && servers.length === 0) {
+			record.mcpManager = undefined;
+		}
 	}
 
 	#toMcpConfig(server: McpServer): MCPServerConfig {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
-import { getBlobsDir, isEnoent, logger, type postmortem, VERSION } from "@oh-my-pi/pi-utils";
+import { getBlobsDir, isEnoent, logger, type postmortem, VERSION, withTimeout } from "@oh-my-pi/pi-utils";
 import {
 	type Agent,
 	type AgentSideConnection,
@@ -58,6 +58,7 @@ import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../../internal-urls";
 import { discoverAndLoadMCPTools } from "../../mcp/loader";
 import { MCPManager } from "../../mcp/manager";
+import { describeMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../../mcp/timeout";
 import type { MCPServerConfig } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
@@ -2486,10 +2487,15 @@ export class AcpAgent implements Agent {
 		record.extensionsConfigured = true;
 	}
 
-	#recordAmbientMcpDiagnostic(record: ManagedSessionRecord, failedName: string): void {
-		const phase = failedName === ".mcp.json" ? "configuration" : "connection";
-		const serverName =
-			failedName === ".mcp.json" ? undefined : failedName.replace(/[^a-zA-Z0-9_.:-]/g, "?").slice(0, 128);
+	/**
+	 * `failedName === undefined` means the `.mcp.json` config itself failed to
+	 * parse (phase "configuration"); a string is the server whose connection
+	 * failed. A dedicated undefined case — not a name sentinel — because dots
+	 * pass the sanitizer, so ".mcp.json" is a legal server name.
+	 */
+	#recordAmbientMcpDiagnostic(record: ManagedSessionRecord, failedName: string | undefined): void {
+		const phase = failedName === undefined ? "configuration" : "connection";
+		const serverName = failedName?.replace(/[^a-zA-Z0-9_.:-]/g, "?").slice(0, 128);
 		const details = {
 			scope: "ambient",
 			phase,
@@ -2525,7 +2531,7 @@ export class AcpAgent implements Agent {
 				onStatus: event => {
 					if (event.type === "failed") this.#recordAmbientMcpDiagnostic(record, event.serverName);
 				},
-				onConfigWarning: () => this.#recordAmbientMcpDiagnostic(record, ".mcp.json"),
+				onConfigWarning: () => this.#recordAmbientMcpDiagnostic(record, undefined),
 			});
 			manager = ambient.manager;
 		} else {
@@ -2573,7 +2579,7 @@ export class AcpAgent implements Agent {
 		}
 
 		if (servers.length > 0) {
-			const requiredReadiness = new Map<string, ReturnType<typeof Promise.withResolvers<boolean>>>();
+			const requiredReadiness = new Map<string, PromiseWithResolvers<boolean>>();
 			for (const server of servers) {
 				if (ambientDiscovery?.reservedServerNames.has(server.name)) {
 					requiredReadiness.set(server.name, Promise.withResolvers<boolean>());
@@ -2591,8 +2597,24 @@ export class AcpAgent implements Agent {
 						.join("; "),
 				);
 			}
+			// Readiness settles from the manager's background tools-load chain
+			// (`onStatus` fires "connected" or a startup failure only once
+			// `toolsPromise` settles). Each request in that chain is bounded by
+			// the per-request MCP timeout, but that guarantee is config-dependent
+			// (`OMP_MCP_TIMEOUT_MS=0` disables it), so bound the wait here: a
+			// hung reserved bridge must fail session start, not hang `newSession`.
+			// The explicit `0` opt-out stays unbounded, matching the rest of the
+			// MCP client stack.
+			const readinessTimeoutMs = resolveMCPTimeoutMs();
 			for (const [name, readiness] of requiredReadiness) {
-				if (!(await readiness.promise)) {
+				const ready = isMCPTimeoutEnabled(readinessTimeoutMs)
+					? await withTimeout(
+							readiness.promise,
+							readinessTimeoutMs,
+							`Required client MCP server "${name}" did not report readiness within ${describeMCPTimeout(readinessTimeoutMs)}`,
+						)
+					: await readiness.promise;
+				if (!ready) {
 					throw new Error(`Required client MCP server "${name}" failed to load tools`);
 				}
 			}

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -6,6 +6,7 @@ import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import {
 	ACP_BOOTSTRAP_RACE_GUARD_MS,
 	AcpAgent,
@@ -530,6 +531,14 @@ async function advanceBootstrapGuard(): Promise<void> {
 }
 
 describe("ACP agent", () => {
+	it("advertises versioned ambient MCP discovery support", async () => {
+		const harness = await createHarness();
+		const initialized = await harness.agent.initialize({ protocolVersion: 1 });
+		expect(initialized.agentCapabilities?._meta).toMatchObject({
+			"omp.sh/ambient-mcp-discovery": { version: 1 },
+		});
+	});
+
 	it("supports multiple live ACP sessions with model and lifecycle handlers", async () => {
 		const harness = await createHarness();
 		const first = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
@@ -2810,6 +2819,285 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 	 * `onToolsChanged` -> `refreshMCPTools` follow-up now runs through a
 	 * `refreshChain` queue so late connections still land in the session.
 	 */
+	it("discovers ambient servers only when the session boundary opts in", async () => {
+		const harness = await createHarness();
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+		await fs.promises.mkdir(path.join(harness.cwdA, ".omp"), { recursive: true });
+		await fs.promises.writeFile(
+			path.join(harness.cwdA, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					ambient: { command: BUN_EXEC, args: [FIXTURE_PATH] },
+				},
+			}),
+		);
+
+		try {
+			await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+			await Bun.sleep(600);
+			expect(refreshSpy.mock.calls.flatMap(call => namesOf(call[0] ?? []))).not.toContain(
+				`mcp__ambient_${DELAYED_MCP_TOOL_NAME}`,
+			);
+
+			await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": { enabled: true, reservedServerNames: ["t3-code"] },
+				},
+			});
+			await pollUntil(() =>
+				refreshSpy.mock.calls.some(call =>
+					namesOf(call[0] ?? []).includes(`mcp__ambient_${DELAYED_MCP_TOOL_NAME}`),
+				),
+			);
+		} finally {
+			await harness.agent.dispose();
+			refreshSpy.mockRestore();
+		}
+	}, 15_000);
+
+	it("lets a client server replace a failing ambient server with the same name", async () => {
+		const harness = await createHarness();
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+		await fs.promises.mkdir(path.join(harness.cwdA, ".omp"), { recursive: true });
+		await fs.promises.writeFile(
+			path.join(harness.cwdA, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					overlay: { command: path.join(harness.cwdA, "missing-ambient-command") },
+				},
+			}),
+		);
+
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [{ name: "overlay", command: BUN_EXEC, args: [FIXTURE_PATH], env: [] }],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": { enabled: true, reservedServerNames: ["t3-code"] },
+				},
+			});
+			await pollUntil(() =>
+				refreshSpy.mock.calls.some(call =>
+					namesOf(call[0] ?? []).includes(`mcp__overlay_${DELAYED_MCP_TOOL_NAME}`),
+				),
+			);
+			const session = harness.findSession(created.sessionId);
+			const diagnostic = session?.sessionManager
+				.getBranch()
+				.find(
+					entry =>
+						entry.type === "custom_message" &&
+						entry.customType === "ambient-mcp-diagnostic" &&
+						typeof entry.details === "object" &&
+						entry.details !== null &&
+						Reflect.get(entry.details, "serverName") === "overlay",
+				);
+			expect(diagnostic).toMatchObject({
+				content: "",
+				display: false,
+				details: { scope: "ambient", phase: "connection", serverName: "overlay" },
+			});
+		} finally {
+			await harness.agent.dispose();
+			refreshSpy.mockRestore();
+		}
+	}, 15_000);
+
+	it("records a redacted durable diagnostic for invalid ambient configuration", async () => {
+		const harness = await createHarness();
+		await fs.promises.mkdir(path.join(harness.cwdA, ".omp"), { recursive: true });
+		await fs.promises.writeFile(path.join(harness.cwdA, ".omp", "mcp.json"), "{");
+
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": { enabled: true, reservedServerNames: ["t3-code"] },
+				},
+			});
+			const session = harness.findSession(created.sessionId);
+			const diagnostic = session?.sessionManager
+				.getBranch()
+				.find(
+					entry =>
+						entry.type === "custom_message" &&
+						entry.customType === "ambient-mcp-diagnostic" &&
+						typeof entry.details === "object" &&
+						entry.details !== null &&
+						Reflect.get(entry.details, "phase") === "configuration",
+				);
+			expect(diagnostic).toMatchObject({
+				content: "",
+				display: false,
+				details: { scope: "ambient", phase: "configuration" },
+			});
+			if (diagnostic?.type !== "custom_message") throw new Error("Expected ambient MCP diagnostic");
+			expect(diagnostic.details).not.toHaveProperty("error");
+		} finally {
+			await harness.agent.dispose();
+		}
+	}, 15_000);
+
+	it("records a durable diagnostic when an ambient server fails after the startup race", async () => {
+		const harness = await createHarness();
+		await fs.promises.mkdir(path.join(harness.cwdA, ".omp"), { recursive: true });
+		await fs.promises.writeFile(
+			path.join(harness.cwdA, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					ambient: {
+						command: BUN_EXEC,
+						args: [FIXTURE_PATH],
+						env: { MCP_TEST_TOOLS_LIST_FAILURE: "1" },
+					},
+				},
+			}),
+		);
+
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": { enabled: true, reservedServerNames: ["t3-code"] },
+				},
+			});
+			const session = harness.findSession(created.sessionId);
+			if (!session) throw new Error("Expected created session");
+			const isAmbientFailure = (entry: ReturnType<typeof session.sessionManager.getBranch>[number]) =>
+				entry.type === "custom_message" &&
+				entry.customType === "ambient-mcp-diagnostic" &&
+				typeof entry.details === "object" &&
+				entry.details !== null &&
+				Reflect.get(entry.details, "serverName") === "ambient";
+			await pollUntil(() => session.sessionManager.getBranch().some(isAmbientFailure));
+			const diagnostic = session.sessionManager.getBranch().find(isAmbientFailure);
+			expect(diagnostic).toMatchObject({
+				content: "",
+				display: false,
+				details: { scope: "ambient", phase: "connection", serverName: "ambient" },
+			});
+		} finally {
+			await harness.agent.dispose();
+		}
+	}, 15_000);
+
+	it("blocks startup when the reserved client bridge cannot connect", async () => {
+		const harness = await createHarness();
+		await expect(
+			harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [
+					{
+						name: "t3-code",
+						command: path.join(harness.cwdA, "missing-t3-bridge"),
+						args: [],
+						env: [],
+					},
+				],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": {
+						enabled: true,
+						reservedServerNames: ["t3-code"],
+					},
+				},
+			}),
+		).rejects.toThrow(/t3-code/);
+	});
+
+	it("blocks startup when the reserved client bridge fails to load its tools", async () => {
+		const harness = await createHarness();
+		await expect(
+			harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [
+					{
+						name: "t3-code",
+						command: BUN_EXEC,
+						args: [FIXTURE_PATH],
+						env: [{ name: "MCP_TEST_TOOLS_LIST_FAILURE", value: "1" }],
+					},
+				],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": {
+						enabled: true,
+						reservedServerNames: ["t3-code"],
+					},
+				},
+			}),
+		).rejects.toThrow(/t3-code/);
+	}, 15_000);
+
+	it("disposes ambient servers when reserved-name cleanup fails", async () => {
+		const harness = await createHarness();
+		const originalDisconnectServer = MCPManager.prototype.disconnectServer;
+		const disconnectServerSpy = spyOn(MCPManager.prototype, "disconnectServer").mockImplementation(function (
+			this: MCPManager,
+			name,
+		) {
+			if (name === "t3-code") return Promise.reject(new Error("reserved cleanup failed"));
+			return originalDisconnectServer.call(this, name);
+		});
+		const disconnectAllSpy = spyOn(MCPManager.prototype, "disconnectAll");
+
+		try {
+			await expect(
+				harness.agent.newSession({
+					cwd: harness.cwdA,
+					mcpServers: [],
+					_meta: {
+						"omp.sh/ambient-mcp-discovery": {
+							enabled: true,
+							reservedServerNames: ["t3-code"],
+						},
+					},
+				}),
+			).rejects.toThrow("reserved cleanup failed");
+			expect(disconnectAllSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			disconnectAllSpy.mockRestore();
+			disconnectServerSpy.mockRestore();
+			await harness.agent.dispose();
+		}
+	}, 15_000);
+
+	it("keeps reserved ambient server names unavailable without a client bridge", async () => {
+		const harness = await createHarness();
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+		await fs.promises.mkdir(path.join(harness.cwdA, ".omp"), { recursive: true });
+		await fs.promises.writeFile(
+			path.join(harness.cwdA, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					"t3-code": { command: BUN_EXEC, args: [FIXTURE_PATH] },
+				},
+			}),
+		);
+
+		try {
+			await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": { enabled: true, reservedServerNames: ["t3-code"] },
+				},
+			});
+			await Bun.sleep(700);
+			expect(refreshSpy.mock.calls.flatMap(call => namesOf(call[0] ?? []))).not.toContain(
+				`mcp__t3-code_${DELAYED_MCP_TOOL_NAME}`,
+			);
+		} finally {
+			await harness.agent.dispose();
+			refreshSpy.mockRestore();
+		}
+	}, 15_000);
+
 	it("delivers a late-connecting server's tools via a queued refreshMCPTools call", async () => {
 		const harness = await createHarness();
 		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
@@ -2834,6 +3122,7 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 			await pollUntil(() => refreshSpy.mock.calls.length > 1);
 			expect(namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? [])).toEqual([`mcp__delayed_${DELAYED_MCP_TOOL_NAME}`]);
 		} finally {
+			await harness.agent.dispose();
 			refreshSpy.mockRestore();
 		}
 	}, 15_000);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2858,6 +2858,38 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 		}
 	}, 15_000);
 
+	it("keeps ambient tools when a client server is added", async () => {
+		const harness = await createHarness();
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+		const fixturePath = path.join(import.meta.dir, "fixtures", "instructions-mcp.ts");
+		await fs.promises.mkdir(path.join(harness.cwdA, ".omp"), { recursive: true });
+		await fs.promises.writeFile(
+			path.join(harness.cwdA, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					ambient: { command: BUN_EXEC, args: [fixturePath] },
+				},
+			}),
+		);
+
+		try {
+			await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [{ name: "client", command: BUN_EXEC, args: [fixturePath], env: [] }],
+				_meta: {
+					"omp.sh/ambient-mcp-discovery": { enabled: true, reservedServerNames: ["t3-code"] },
+				},
+			});
+			const latestTools = namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []);
+			expect(latestTools).toContain("mcp__ambient_do_thing");
+			expect(latestTools).toContain("mcp__client_do_thing");
+		} finally {
+			await harness.agent.dispose();
+			refreshSpy.mockRestore();
+		}
+	}, 15_000);
+
 	it("lets a client server replace a failing ambient server with the same name", async () => {
 		const harness = await createHarness();
 		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");

--- a/packages/coding-agent/test/fixtures/delayed-tool-mcp.ts
+++ b/packages/coding-agent/test/fixtures/delayed-tool-mcp.ts
@@ -2,7 +2,8 @@
 /**
  * Test fixture: a well-behaved stdio MCP server that answers `initialize`
  * only after a deliberate delay exceeding `MCPManager`'s `STARTUP_TIMEOUT_MS`
- * (250 ms), then responds normally to `tools/list`.
+ * (250 ms), then responds to `tools/list`. Set
+ * `MCP_TEST_TOOLS_LIST_FAILURE=1` to fail that request after initialization.
  *
  * Models a server that eventually connects successfully but not within the
  * manager's startup race window (`Promise.race([Promise.allSettled(...),
@@ -68,7 +69,14 @@ function startServer(): void {
 			if (msg.method === "initialize") {
 				await Bun.sleep(INITIALIZE_DELAY_MS);
 			}
-			const response = { jsonrpc: "2.0" as const, id: msg.id, result: buildResult(msg.method) };
+			const response =
+				msg.method === "tools/list" && process.env.MCP_TEST_TOOLS_LIST_FAILURE === "1"
+					? {
+							jsonrpc: "2.0" as const,
+							id: msg.id,
+							error: { code: -32603, message: "Fixture tools/list failure" },
+						}
+					: { jsonrpc: "2.0" as const, id: msg.id, result: buildResult(msg.method) };
 			process.stdout.write(`${JSON.stringify(response)}\n`);
 		})();
 	});


### PR DESCRIPTION
An ACP client that hosts its own MCP bridge (T3 Code, Zed-style hosts) currently gets *only* the servers it passes in `session/new.mcpServers`. Host-side configuration (`.omp/mcp.json`, user config, imported tool configs) is deliberately ignored in ACP mode — `enableMCP: false`, see #1234 — so a user's own MCP servers are invisible to any ACP session even though the same config works in the TUI.

This adds an **opt-in** path back, negotiated per session so the default stays exactly as it is today.

## Protocol

- `initialize` advertises `agentCapabilities._meta["omp.sh/ambient-mcp-discovery"] = { version: 1 }`.
- A client opts in per session with `_meta["omp.sh/ambient-mcp-discovery"] = { enabled: true, reservedServerNames: [...] }` on `session/new`, `session/load`, `session/resume`, and `unstable_session/fork`.
- Without that `_meta`, `#configureMcpServers` behaves as before: a bare `MCPManager` holding only client-supplied servers.

## Semantics

- Ambient servers are discovered through the existing `discoverAndLoadMCPTools`, so precedence, `enabled: false`, profiles, and `mcp.enableProjectConfig` all keep their normal meaning.
- Client-supplied servers **overlay** ambient ones by name (`disconnectServer(name)` before connecting), so a client bridge always wins over a same-named host entry — including when the ambient one failed to connect.
- `reservedServerNames` are names the client owns (e.g. its own bridge). They are disconnected from the ambient set, and a reserved server the client *did* supply must reach `connected` **and** load tools or session startup fails — a half-mounted bridge is worse than a refused session.
- Failures are durable, not silent: a redacted `ambient-mcp-diagnostic` custom entry is appended for a bad config (`phase: "configuration"`, no server name, no error text) or a failing server (`phase: "connection"`, sanitized name). Server names are filtered to `[A-Za-z0-9_.:-]` and capped at 128 chars, and the raw error is logged rather than persisted.
- Late-connecting servers still land: tool refreshes go through a `refreshChain` queue, and a reconfiguration drains the in-flight refresh before installing a new manager so a stale tool set cannot overwrite a newer one.

## `MCPManager` change worth reviewing

`connectServers` now seeds its accumulator with the already-connected tools (`const allTools = [...this.#tools]`) instead of an empty array. Without this, connecting a client server *after* ambient discovery replaced the tool set with only the newly connected servers' tools, silently unmounting every ambient tool. This affects all `MCPManager` consumers, not just ACP — it makes an incremental `connectServers` call additive, which is what the incremental call sites already assumed.

## Verification

`packages/coding-agent/test/acp-agent.test.ts` (7 new tests, real stdio subprocess fixtures, no fake timers):

- discovery happens only when the session boundary opts in
- ambient tools survive a client server being added
- a client server replaces a failing same-named ambient server, and the diagnostic is still recorded
- redacted diagnostic for invalid ambient configuration (asserts no `error` property)
- durable diagnostic when an ambient server fails *after* the startup race window
- startup is blocked when a reserved bridge cannot connect, and when it connects but fails `tools/list`
- ambient servers are disposed when reserved-name cleanup throws
- a reserved name stays unavailable when no client bridge supplies it

`bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-event-mapper.test.ts` → 111 pass / 0 fail. `tsgo --noEmit` clean.

Note for reviewers running locally: these tests need working piped subprocess stdio, which is broken by the Bazel symlink loop fixed in #8547.
