### PR TITLE
feat(acp): export auto-reasoning and settled async-job metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added namespaced `omp.sh/reasoning` ACP metadata that reports the concrete effort selected for an Auto-classified top-level turn while preserving Auto as the configured thinking option.
+- Added namespaced `omp.sh/async-result` ACP metadata on settled background jobs, so a client can render task/bash completions (id, type, terminal status, label, duration) even when the owning prompt turn has already ended.
+
 ## [17.3.3] - 2026-08-14
 
 ### Fixed
@@ -29,11 +34,6 @@
 - Fixed omp plugin install failing with cloning errors for legacy Pi extensions whose tool schemas use legacy-typebox builders.
 - Fixed omp update aborting with chmod ENOENT when concurrent update runs overlapped by using unique download temporary paths.
 - Fixed the browser tool executable probe launching the user's installed GUI Chromium on Windows: the `--version` version probe from ecb22957 was Linux-scoped but ran for every platform candidate, so on Windows it could hand off to a running `chrome.exe`, open a normal browser window, then reject the candidate and fall back to cached Chrome for Testing. The probe is now confined to Linux ([#8445](https://github.com/can1357/oh-my-pi/issues/8445)).
-### Added
-
-- Added namespaced `omp.sh/reasoning` ACP metadata that reports the concrete effort selected for an Auto-classified top-level turn while preserving Auto as the configured thinking option.
-- Added namespaced `omp.sh/async-result` ACP metadata on settled background jobs, so a client can render task/bash completions (id, type, terminal status, label, duration) even when the owning prompt turn has already ended.
-- Added opt-in ambient MCP discovery for ACP sessions via `omp.sh/ambient-mcp-discovery`, letting a client mount host-configured MCP servers alongside its own while reserving bridge server names.
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Fixed omp plugin install failing with cloning errors for legacy Pi extensions whose tool schemas use legacy-typebox builders.
 - Fixed omp update aborting with chmod ENOENT when concurrent update runs overlapped by using unique download temporary paths.
 - Fixed the browser tool executable probe launching the user's installed GUI Chromium on Windows: the `--version` version probe from ecb22957 was Linux-scoped but ran for every platform candidate, so on Windows it could hand off to a running `chrome.exe`, open a normal browser window, then reject the candidate and fall back to cached Chrome for Testing. The probe is now confined to Linux ([#8445](https://github.com/can1357/oh-my-pi/issues/8445)).
+### Added
+
+- Added namespaced `omp.sh/reasoning` ACP metadata that reports the concrete effort selected for an Auto-classified top-level turn while preserving Auto as the configured thinking option.
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,8 @@
 ### Added
 
 - Added namespaced `omp.sh/reasoning` ACP metadata that reports the concrete effort selected for an Auto-classified top-level turn while preserving Auto as the configured thinking option.
+- Added namespaced `omp.sh/async-result` ACP metadata on settled background jobs, so a client can render task/bash completions (id, type, terminal status, label, duration) even when the owning prompt turn has already ended.
+- Added opt-in ambient MCP discovery for ACP sessions via `omp.sh/ambient-mcp-discovery`, letting a client mount host-configured MCP servers alongside its own while reserving bridge server names.
 
 ## [17.3.0] - 2026-08-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added namespaced `omp.sh/reasoning` ACP metadata that reports the concrete effort selected for an Auto-classified top-level turn while preserving Auto as the configured thinking option.
 - Added namespaced `omp.sh/async-result` ACP metadata on settled background jobs, so a client can render task/bash completions (id, type, terminal status, label, duration) even when the owning prompt turn has already ended.
+- Both `omp.sh` ACP extensions are advertised from `initialize.agentCapabilities._meta`, so clients can feature-detect them at handshake time instead of waiting for an event to carry the keys.
 
 ## [17.3.3] - 2026-08-14
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -85,6 +85,7 @@ import { createAcpClientBridge } from "./acp-client-bridge";
 import {
 	extractAssistantMessageText,
 	mapAgentSessionEventToAcpSessionUpdates,
+	mapThinkingLevelChangeToAcpConfigUpdate,
 	normalizeReplayToolArguments,
 } from "./acp-event-mapper";
 import { ACP_TERMINAL_AUTH_FLAG } from "./terminal-auth";
@@ -112,6 +113,16 @@ export const ACP_BOOTSTRAP_RACE_GUARD_MS = 50;
 const ACP_CANCEL_CLEANUP_TIMEOUT_MS = 5_000;
 const ACP_ASYNC_DELIVERY_DRAIN_TIMEOUT_MS = 250;
 const ACP_ASYNC_DELIVERY_DRAIN_MAX_PASSES = 3;
+
+type ThinkingLevelChangedEvent = Extract<AgentSessionEvent, { type: "thinking_level_changed" }>;
+type AutoThinkingResolutionEvent = ThinkingLevelChangedEvent & {
+	configured: typeof AUTO_THINKING;
+	resolved: NonNullable<ThinkingLevelChangedEvent["resolved"]>;
+};
+
+function isAutoThinkingResolutionEvent(event: AgentSessionEvent): event is AutoThinkingResolutionEvent {
+	return event.type === "thinking_level_changed" && event.configured === AUTO_THINKING && event.resolved !== undefined;
+}
 
 type AgentImageContent = {
 	type: "image";
@@ -1170,8 +1181,13 @@ export class AcpAgent implements Agent {
 		if (event.type !== "thinking_level_changed" && event.type !== "model_changed") {
 			return;
 		}
+		// Resolutions belong to the active top-level prompt subscription. It is
+		// installed before prompt execution, unlike this bootstrap-delayed listener.
+		if (isAutoThinkingResolutionEvent(event)) {
+			return;
+		}
 		try {
-			await this.#pushConfigOptionUpdate(record);
+			await this.#pushConfigOptionUpdate(record, event.type === "thinking_level_changed" ? event : undefined);
 		} catch (error) {
 			logger.warn("Failed to push config_option_update after a lifetime event", {
 				sessionId: record.session.sessionId,
@@ -1221,6 +1237,11 @@ export class AcpAgent implements Agent {
 	async #handlePromptEvent(record: ManagedSessionRecord, event: AgentSessionEvent): Promise<void> {
 		const promptTurn = record.promptTurn;
 		if (!promptTurn || promptTurn.settled || promptTurn.cancelRequested) {
+			return;
+		}
+
+		if (isAutoThinkingResolutionEvent(event)) {
+			await this.#pushConfigOptionUpdate(record, event);
 			return;
 		}
 
@@ -1528,18 +1549,16 @@ export class AcpAgent implements Agent {
 		};
 	}
 
-	async #pushConfigOptionUpdate(record: ManagedSessionRecord): Promise<void> {
-		await this.#pushConfigOptionUpdateForSession(record.session);
+	async #pushConfigOptionUpdate(record: ManagedSessionRecord, event?: ThinkingLevelChangedEvent): Promise<void> {
+		await this.#pushConfigOptionUpdateForSession(record.session, event);
 	}
 
-	async #pushConfigOptionUpdateForSession(session: AgentSession): Promise<void> {
-		await this.#connection.sessionUpdate({
-			sessionId: session.sessionId,
-			update: {
-				sessionUpdate: "config_option_update",
-				configOptions: this.#buildConfigOptions(session),
-			},
-		});
+	async #pushConfigOptionUpdateForSession(session: AgentSession, event?: ThinkingLevelChangedEvent): Promise<void> {
+		const configOptions = this.#buildConfigOptions(session);
+		const update: SessionUpdate = event
+			? mapThinkingLevelChangeToAcpConfigUpdate(event, configOptions)
+			: { sessionUpdate: "config_option_update", configOptions };
+		await this.#connection.sessionUpdate({ sessionId: session.sessionId, update });
 	}
 
 	#buildConfigOptions(session: AgentSession): SessionConfigOption[] {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -195,6 +195,7 @@ type ManagedSessionRecord = {
 
 type ReplayableMessage = {
 	role: string;
+	customType?: string;
 	content?: unknown;
 	errorMessage?: string;
 	toolCallId?: string;
@@ -1178,6 +1179,26 @@ export class AcpAgent implements Agent {
 	}
 
 	async #handleLifetimeEvent(record: ManagedSessionRecord, event: AgentSessionEvent): Promise<void> {
+		if (event.type === "message_start") {
+			// The active prompt subscription owns in-turn events. Once it has
+			// settled, the lifetime subscription is the only ACP path left for an
+			// agent-initiated async-result follow-up.
+			if (isPromptTurnInFlight(record.promptTurn)) return;
+			try {
+				for (const notification of mapAgentSessionEventToAcpSessionUpdates(event, record.session.sessionId, {
+					cwd: record.session.sessionManager.getCwd(),
+				})) {
+					await this.#connection.sessionUpdate(notification);
+				}
+			} catch (error) {
+				logger.warn("Failed to push async-result metadata after a lifetime event", {
+					sessionId: record.session.sessionId,
+					eventType: event.type,
+					error,
+				});
+			}
+			return;
+		}
 		if (event.type !== "thinking_level_changed" && event.type !== "model_changed") {
 			return;
 		}
@@ -2094,6 +2115,24 @@ export class AcpAgent implements Agent {
 	): SessionNotification[] {
 		if (message.role === "assistant") {
 			return this.#replayAssistantMessage(sessionId, message, cwd, replayedToolCallIds, replayedToolCallArgs);
+		}
+		if (message.role === "custom" && message.customType === "async-result" && typeof message.content === "string") {
+			return mapAgentSessionEventToAcpSessionUpdates(
+				{
+					type: "message_start",
+					message: {
+						role: "custom",
+						customType: message.customType,
+						content: message.content,
+						display: true,
+						attribution: "agent",
+						details: message.details,
+						timestamp: Date.now(),
+					},
+				},
+				sessionId,
+				{ cwd },
+			);
 		}
 		if (
 			message.role === "user" ||

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -87,6 +87,9 @@ import {
 	mapAgentSessionEventToAcpSessionUpdates,
 	mapThinkingLevelChangeToAcpConfigUpdate,
 	normalizeReplayToolArguments,
+	OMP_ACP_EXTENSION_VERSION,
+	OMP_ASYNC_RESULT_META_KEY,
+	OMP_REASONING_META_KEY,
 } from "./acp-event-mapper";
 import { ACP_TERMINAL_AUTH_FLAG } from "./terminal-auth";
 
@@ -530,6 +533,10 @@ export class AcpAgent implements Agent {
 			},
 			authMethods,
 			agentCapabilities: {
+				_meta: {
+					[OMP_REASONING_META_KEY]: { version: OMP_ACP_EXTENSION_VERSION },
+					[OMP_ASYNC_RESULT_META_KEY]: { version: OMP_ACP_EXTENSION_VERSION },
+				},
 				loadSession: true,
 				mcpCapabilities: {
 					http: true,

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -1,4 +1,5 @@
 import type {
+	SessionConfigOption,
 	SessionNotification,
 	SessionUpdate,
 	ToolCall,
@@ -128,6 +129,7 @@ interface TextMessageLike {
 }
 
 const ACP_TEXT_LIMIT = 4_000;
+const OMP_REASONING_META_KEY = "omp.sh/reasoning";
 
 /**
  * Device name when the call is an `xd://` device dispatch riding the
@@ -206,6 +208,17 @@ export function mapToolKind(toolName: string, args?: unknown): ToolKind {
 		default:
 			return "other";
 	}
+}
+
+export function mapThinkingLevelChangeToAcpConfigUpdate(
+	event: Extract<AgentSessionEvent, { type: "thinking_level_changed" }>,
+	configOptions: SessionConfigOption[],
+): SessionUpdate {
+	const update: SessionUpdate = { sessionUpdate: "config_option_update", configOptions };
+	if (event.configured === "auto" && event.resolved !== undefined) {
+		update._meta = { [OMP_REASONING_META_KEY]: { configured: event.configured, resolved: event.resolved } };
+	}
+	return update;
 }
 
 export function mapAgentSessionEventToAcpSessionUpdates(

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -129,8 +129,10 @@ interface TextMessageLike {
 }
 
 const ACP_TEXT_LIMIT = 4_000;
-const OMP_REASONING_META_KEY = "omp.sh/reasoning";
-const OMP_ASYNC_RESULT_META_KEY = "omp.sh/async-result";
+export const OMP_REASONING_META_KEY = "omp.sh/reasoning";
+export const OMP_ASYNC_RESULT_META_KEY = "omp.sh/async-result";
+/** Version advertised for both `omp.sh/*` extensions in `initialize.agentCapabilities._meta`. */
+export const OMP_ACP_EXTENSION_VERSION = 1;
 
 /**
  * Device name when the call is an `xd://` device dispatch riding the

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -130,6 +130,7 @@ interface TextMessageLike {
 
 const ACP_TEXT_LIMIT = 4_000;
 const OMP_REASONING_META_KEY = "omp.sh/reasoning";
+const OMP_ASYNC_RESULT_META_KEY = "omp.sh/async-result";
 
 /**
  * Device name when the call is an `xd://` device dispatch riding the
@@ -221,12 +222,75 @@ export function mapThinkingLevelChangeToAcpConfigUpdate(
 	return update;
 }
 
+function legacyAsyncResultStatus(content: unknown, jobId: string): "completed" | "failed" | "cancelled" | undefined {
+	if (typeof content !== "string") return undefined;
+	for (const match of content.matchAll(/<task-result\b[^>]*>/g)) {
+		const tag = match[0];
+		if (!tag.includes(`id="${jobId}"`)) continue;
+		const status = /\bstatus="(completed|failed|cancelled)"/.exec(tag)?.[1];
+		if (status === "completed" || status === "failed" || status === "cancelled") return status;
+	}
+	return undefined;
+}
+
+function mapAsyncResultMessageToAcpUpdate(event: AgentSessionEvent): SessionUpdate | undefined {
+	if (event.type !== "message_start") return undefined;
+	const message = event.message;
+	if (message.role !== "custom" || !("customType" in message) || message.customType !== "async-result") {
+		return undefined;
+	}
+	if (!("details" in message) || typeof message.details !== "object" || message.details === null) {
+		return undefined;
+	}
+	if (!("jobs" in message.details) || !Array.isArray(message.details.jobs)) return undefined;
+
+	const jobs: Array<{
+		id: string;
+		type: "bash" | "task";
+		status: "completed" | "failed" | "cancelled";
+		label?: string;
+		durationMs?: number;
+	}> = [];
+	for (const job of message.details.jobs) {
+		if (typeof job !== "object" || job === null || !("jobId" in job) || typeof job.jobId !== "string") {
+			continue;
+		}
+		if (!("type" in job) || (job.type !== "bash" && job.type !== "task")) continue;
+		const explicitStatus = "status" in job ? job.status : undefined;
+		const status =
+			explicitStatus === "completed" || explicitStatus === "failed" || explicitStatus === "cancelled"
+				? explicitStatus
+				: legacyAsyncResultStatus(message.content, job.jobId);
+		if (!status) continue;
+		const label = "label" in job && typeof job.label === "string" ? job.label : undefined;
+		const durationMs = "durationMs" in job && typeof job.durationMs === "number" ? job.durationMs : undefined;
+		jobs.push({
+			id: job.jobId,
+			type: job.type,
+			status,
+			...(label ? { label } : {}),
+			...(durationMs !== undefined ? { durationMs } : {}),
+		});
+	}
+	if (jobs.length === 0) return undefined;
+
+	return {
+		sessionUpdate: "agent_message_chunk",
+		content: { type: "text", text: "" },
+		_meta: { [OMP_ASYNC_RESULT_META_KEY]: { jobs } },
+	};
+}
+
 export function mapAgentSessionEventToAcpSessionUpdates(
 	event: AgentSessionEvent,
 	sessionId: string,
 	options: AcpEventMapperOptions = {},
 ): SessionNotification[] {
 	switch (event.type) {
+		case "message_start": {
+			const update = mapAsyncResultMessageToAcpUpdate(event);
+			return update ? [toSessionNotification(sessionId, update)] : [];
+		}
 		case "message_update":
 			return mapAssistantMessageUpdate(event, sessionId, options);
 		case "message_end":

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5567,11 +5567,17 @@ export class AgentSession {
 				return;
 			}
 
-			// Auto thinking: classify this real user turn and set the effective level
-			// before the model request. Synthetic/tool-continuation turns (developer/
-			// custom roles) and non-auto sessions are skipped. Never blocks the turn —
+			// Auto thinking: classify real user turns before the model request. Skill
+			// prompts keep their user attribution in a custom message; other custom and
+			// developer/tool-continuation turns remain excluded. Never blocks the turn —
 			// failures fall back to a concrete level inside the helper.
-			if (this.isAutoThinking && message.role === "user") {
+			if (
+				this.isAutoThinking &&
+				(message.role === "user" ||
+					(message.role === "custom" &&
+						message.customType === SKILL_PROMPT_MESSAGE_TYPE &&
+						message.attribution === "user"))
+			) {
 				await this.#models.applyAutoThinkingLevel(expandedText, generation);
 				if (this.#promptGeneration !== generation) {
 					return;

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -42,6 +42,7 @@ export interface AsyncResultEntry {
 type AsyncResultJobDetails = {
 	jobId: string;
 	type?: "bash" | "task";
+	status?: AsyncJob["status"];
 	label?: string;
 	durationMs?: number;
 };
@@ -56,6 +57,7 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 		jobId: entry.jobId,
 		result: entry.result,
 		type: entry.job?.type,
+		status: entry.job?.status,
 		label: entry.job?.label,
 		durationMs: entry.durationMs,
 	}));
@@ -63,6 +65,7 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 		jobs: jobs.map(job => ({
 			jobId: job.jobId,
 			type: job.type,
+			status: job.status,
 			label: job.label,
 			durationMs: job.durationMs,
 		})),

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Model } from "@oh-my-pi/pi-ai";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
@@ -122,6 +122,7 @@ class FakeAgentSession {
 	agent: { sessionId: string; waitForIdle: () => Promise<void> };
 	model: Model | undefined;
 	thinkingLevel: string | undefined;
+	configuredThinking: string | undefined;
 	customCommands: [] = [];
 	extensionRunner = undefined;
 	isStreaming = false;
@@ -182,8 +183,13 @@ class FakeAgentSession {
 		return ["low", "medium", "high"];
 	}
 
+	configuredThinkingLevel(): string | undefined {
+		return this.configuredThinking ?? this.thinkingLevel;
+	}
+
 	setThinkingLevel(level: string | undefined): void {
 		const isChanging = this.thinkingLevel !== level;
+		this.configuredThinking = level;
 		this.thinkingLevel = level;
 		if (isChanging) {
 			for (const listener of this.#listeners) {
@@ -192,6 +198,19 @@ class FakeAgentSession {
 					thinkingLevel: level,
 				} as AgentSessionEvent);
 			}
+		}
+	}
+
+	emitAutoResolution(effort: Effort): void {
+		this.configuredThinking = "auto";
+		this.thinkingLevel = effort;
+		for (const listener of this.#listeners) {
+			listener({
+				type: "thinking_level_changed",
+				thinkingLevel: effort,
+				configured: "auto",
+				resolved: effort,
+			});
 		}
 	}
 
@@ -777,6 +796,60 @@ describe("ACP agent", () => {
 					notification.update.currentModeId === "default",
 			),
 		).toBe(false);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("exports one Auto resolution before assistant output with both listeners active", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await waitForBootstrapGuard();
+		session.prompt = async (prompt: string): Promise<boolean> => {
+			session.promptCalls.push(prompt);
+			session.isStreaming = true;
+			session.emitAutoResolution(Effort.High);
+			const assistantMessage = makeAssistantMessage("pong");
+			for (const listener of session.listeners()) {
+				listener({
+					type: "message_update",
+					message: assistantMessage,
+					assistantMessageEvent: { type: "text_delta", delta: "pong" },
+				} as AgentSessionEvent);
+			}
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+			return true;
+		};
+
+		const updatesBefore = harness.updates.length;
+		await harness.agent.prompt({ sessionId: created.sessionId, prompt: [{ type: "text", text: "think" }] });
+
+		const turnUpdates = harness.updates.slice(updatesBefore);
+		const resolutionIndexes = turnUpdates.flatMap((notification, index) =>
+			notification.sessionId === created.sessionId &&
+			notification.update.sessionUpdate === "config_option_update" &&
+			notification.update._meta?.["omp.sh/reasoning"] !== undefined
+				? [index]
+				: [],
+		);
+		expect(resolutionIndexes).toHaveLength(1);
+		const assistantIndex = turnUpdates.findIndex(
+			notification => notification.update.sessionUpdate === "agent_message_chunk",
+		);
+		expect(assistantIndex).toBeGreaterThan(resolutionIndexes[0]!);
+		expectAcpNotifications(turnUpdates);
+		const resolutionUpdate = turnUpdates[resolutionIndexes[0]!]!.update;
+		if (resolutionUpdate.sessionUpdate !== "config_option_update") {
+			throw new Error("expected config_option_update");
+		}
+		expect(resolutionUpdate.configOptions.find(option => option.id === "thinking")?.currentValue).toBe("auto");
+		expect(resolutionUpdate._meta).toEqual({
+			"omp.sh/reasoning": { configured: "auto", resolved: "high" },
+		});
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -804,9 +804,13 @@ describe("ACP agent", () => {
 
 	it("exports one Auto resolution before assistant output with both listeners active", async () => {
 		const harness = await createHarness();
+		vi.useFakeTimers();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
-		await waitForBootstrapGuard();
+		// Install the session-lifetime subscription, then hand the turn back to
+		// real timers: the prompt path below awaits genuine async work.
+		await advanceBootstrapGuard();
+		vi.useRealTimers();
 		session.prompt = async (prompt: string): Promise<boolean> => {
 			session.promptCalls.push(prompt);
 			session.isStreaming = true;
@@ -903,9 +907,13 @@ describe("ACP agent", () => {
 
 	it("pushes settled async task metadata after the owning prompt has ended", async () => {
 		const harness = await createHarness();
+		vi.useFakeTimers();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
-		await waitForBootstrapGuard();
+		// The lifetime subscription is the only path left once the prompt turn
+		// has settled, so install it before dispatching the async-result event.
+		await advanceBootstrapGuard();
+		vi.useRealTimers();
 
 		const asyncMessage = buildAsyncResultBatchMessage([
 			{

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -17,6 +17,7 @@ import type {
 	AgentSessionEvent,
 	UsageFallbackConfirmation,
 } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { buildAsyncResultBatchMessage } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "@oh-my-pi/pi-coding-agent/stt/models";
@@ -896,6 +897,63 @@ describe("ACP agent", () => {
 		expect(harness.updates.length).toBe(updatesBeforeRedundant);
 
 		vi.useRealTimers();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("pushes settled async task metadata after the owning prompt has ended", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await waitForBootstrapGuard();
+
+		const asyncMessage = buildAsyncResultBatchMessage([
+			{
+				jobId: "BoutiqueRefreshFacts",
+				result: "done",
+				job: {
+					id: "BoutiqueRefreshFacts",
+					type: "task",
+					status: "completed",
+					startTime: Date.now() - 114_551,
+					label: "Retry Banner for Boutique Refresh",
+					abortController: new AbortController(),
+					promise: Promise.resolve(),
+				},
+				durationMs: 114_551,
+				epoch: 0,
+			},
+		]);
+		if (!asyncMessage) throw new Error("expected async result message");
+
+		const updatesBefore = harness.updates.length;
+		for (const listener of session.listeners()) {
+			listener({ type: "message_start", message: asyncMessage });
+		}
+		await Bun.sleep(0);
+
+		const asyncUpdate = harness.updates
+			.slice(updatesBefore)
+			.find(
+				notification =>
+					notification.sessionId === created.sessionId &&
+					notification.update.sessionUpdate === "agent_message_chunk" &&
+					notification.update._meta?.["omp.sh/async-result"] !== undefined,
+			);
+		expect(asyncUpdate).toBeDefined();
+		expect(asyncUpdate?.update._meta?.["omp.sh/async-result"]).toEqual({
+			jobs: [
+				{
+					id: "BoutiqueRefreshFacts",
+					type: "task",
+					status: "completed",
+					label: "Retry Banner for Boutique Refresh",
+					durationMs: 114_551,
+				},
+			],
+		});
+		if (asyncUpdate) expectAcpNotifications([asyncUpdate]);
+
 		harness.abortController.abort();
 		await Bun.sleep(0);
 	});

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -613,6 +613,23 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("advertises the omp.sh extensions from initialize", async () => {
+		// A client can only feature-detect `omp.sh/reasoning` /
+		// `omp.sh/async-result` from the handshake — the keys otherwise appear
+		// only once an event happens to carry them.
+		const harness = await createHarness();
+		const response = await harness.agent.initialize({
+			protocolVersion: 1,
+			clientCapabilities: {},
+		} as Parameters<typeof harness.agent.initialize>[0]);
+		expect(response.agentCapabilities?._meta).toEqual({
+			"omp.sh/reasoning": { version: 1 },
+			"omp.sh/async-result": { version: 1 },
+		});
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("advertises plan mode and emits schema-valid mode updates", async () => {
 		const harness = await createHarness();
 		Settings.instance.set("plan.enabled", true);
@@ -961,6 +978,74 @@ describe("ACP agent", () => {
 			],
 		});
 		if (asyncUpdate) expectAcpNotifications([asyncUpdate]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("forwards an in-turn async result exactly once with both subscriptions active", async () => {
+		// Regression guard for `#handleLifetimeEvent`'s isPromptTurnInFlight
+		// check: when a background job settles while a prompt turn is still in
+		// flight, both the session-lifetime and the prompt subscriptions see
+		// the `message_start` — only the prompt subscription may forward it,
+		// or one job completion duplicates on the wire.
+		const harness = await createHarness();
+		vi.useFakeTimers();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		// Install the session-lifetime subscription, then hand back to real
+		// timers: the prompt path below awaits genuine async work.
+		await advanceBootstrapGuard();
+		vi.useRealTimers();
+
+		const asyncMessage = buildAsyncResultBatchMessage([
+			{
+				jobId: "InFlightJob",
+				result: "done",
+				job: {
+					id: "InFlightJob",
+					type: "bash",
+					status: "completed",
+					label: "sleep 1",
+					startTime: Date.now() - 1_000,
+					abortController: new AbortController(),
+					promise: Promise.resolve(),
+				},
+				durationMs: 1_000,
+				epoch: 0,
+			},
+		]);
+		if (!asyncMessage) throw new Error("expected async result message");
+
+		session.prompt = async (prompt: string): Promise<boolean> => {
+			session.promptCalls.push(prompt);
+			session.isStreaming = true;
+			// The job settles mid-turn: every listener — lifetime AND prompt
+			// subscription — receives the same event.
+			for (const listener of session.listeners()) {
+				listener({ type: "message_start", message: asyncMessage });
+			}
+			const assistantMessage = makeAssistantMessage("pong");
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+			return true;
+		};
+
+		const updatesBefore = harness.updates.length;
+		await harness.agent.prompt({ sessionId: created.sessionId, prompt: [{ type: "text", text: "run" }] });
+
+		const asyncUpdates = harness.updates
+			.slice(updatesBefore)
+			.filter(
+				notification =>
+					notification.sessionId === created.sessionId &&
+					notification.update.sessionUpdate === "agent_message_chunk" &&
+					notification.update._meta?.["omp.sh/async-result"] !== undefined,
+			);
+		expect(asyncUpdates).toHaveLength(1);
+		expectAcpNotifications(asyncUpdates);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -1248,4 +1248,45 @@ describe("ACP event mapper", () => {
 		});
 		expectAcpStructureRejects(arkSessionNotification, { ...notification, sessionId: 42 });
 	});
+	it("recovers terminal status from persisted async-result task tags", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "message_start",
+				message: {
+					role: "custom",
+					customType: "async-result",
+					content:
+						'<system-notice><task-result id="BoutiqueRefreshFacts" agent="scout" status="completed">done</task-result></system-notice>',
+					display: true,
+					attribution: "agent",
+					details: {
+						jobs: [
+							{
+								jobId: "BoutiqueRefreshFacts",
+								type: "task",
+								label: "Retry Banner for Boutique Refresh",
+								durationMs: 114_551,
+							},
+						],
+					},
+					timestamp: Date.now(),
+				},
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expect(updates[0]?.update._meta?.["omp.sh/async-result"]).toEqual({
+			jobs: [
+				{
+					id: "BoutiqueRefreshFacts",
+					type: "task",
+					status: "completed",
+					label: "Retry Banner for Boutique Refresh",
+					durationMs: 114_551,
+				},
+			],
+		});
+		expectAcpNotifications(updates);
+	});
 });

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
 import { type } from "@oh-my-pi/omptype";
-import type { AgentSideConnection, SessionNotification } from "@oh-my-pi/pi-utils/acp";
+import type { AgentSideConnection, SessionConfigOption, SessionNotification } from "@oh-my-pi/pi-utils/acp";
 
 const arkSessionNotification = type({
 	sessionId: "string",
@@ -13,12 +13,14 @@ const arkSessionNotification = type({
 	},
 });
 
-import type { Model } from "@oh-my-pi/pi-ai";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { AcpAgent } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
 import {
 	buildToolCallStartUpdate,
 	mapAgentSessionEventToAcpSessionUpdates,
+	mapThinkingLevelChangeToAcpConfigUpdate,
 	normalizeReplayToolArguments,
 } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-event-mapper";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -105,7 +107,67 @@ class ReplayTestSession {
 	async refreshMCPTools(_tools: unknown): Promise<void> {}
 }
 
+function thinkingConfigOptions(currentValue: string): SessionConfigOption[] {
+	return [
+		{
+			id: "thinking",
+			name: "Thinking",
+			category: "thought_level",
+			type: "select",
+			currentValue,
+			options: [
+				{ value: "auto", name: "Auto" },
+				{ value: "high", name: "high" },
+			],
+		},
+	];
+}
+
 describe("ACP event mapper", () => {
+	it("does not claim an Auto resolution for explicit or incomplete changes", () => {
+		const cases = [
+			{
+				event: { type: "thinking_level_changed", thinkingLevel: ThinkingLevel.High },
+				currentValue: "high",
+			},
+			{
+				event: { type: "thinking_level_changed", thinkingLevel: ThinkingLevel.Medium, configured: "auto" },
+				currentValue: "auto",
+			},
+		] satisfies Array<{ event: AgentSessionEvent; currentValue: string }>;
+
+		for (const { event, currentValue } of cases) {
+			const configOptions = thinkingConfigOptions(currentValue);
+
+			const update = mapThinkingLevelChangeToAcpConfigUpdate(event, configOptions);
+
+			expect(update).toEqual({ sessionUpdate: "config_option_update", configOptions });
+			expectAcpNotifications([{ sessionId: "session-1", update }]);
+		}
+	});
+
+	it("preserves Auto while exporting its resolved effort through ACP metadata", () => {
+		const configOptions = thinkingConfigOptions("auto");
+		const update = mapThinkingLevelChangeToAcpConfigUpdate(
+			{
+				type: "thinking_level_changed",
+				thinkingLevel: ThinkingLevel.High,
+				configured: "auto",
+				resolved: Effort.High,
+			},
+			configOptions,
+		);
+
+		expect(update).toEqual({
+			sessionUpdate: "config_option_update",
+			configOptions,
+			_meta: {
+				"omp.sh/reasoning": { configured: "auto", resolved: "high" },
+			},
+		});
+		expectAcpNotifications([{ sessionId: "session-1", update }]);
+	});
+
 	it("attaches a stable messageId to live assistant chunks", () => {
 		const assistantMessage = makeAssistantMessage("chunk");
 		const getMessageId = (message: unknown): string | undefined =>

--- a/packages/coding-agent/test/agent-session-skill-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-skill-keywords.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Effort } from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -157,6 +158,10 @@ describe("AgentSession skill prompt keyword steering", () => {
 
 		expect(resolutions).toHaveLength(1);
 		expect(resolutions[0]?.configured).toBe("auto");
-		expect(resolutions[0]?.resolved).toBeTruthy();
+		// The fixture args contain `ultrathink`, which classifies to the model's
+		// highest supported effort (xhigh for claude-sonnet-4-5); if the
+		// user-authored skill args stop reaching Auto classification, the
+		// fallback effort surfaces here instead.
+		expect(resolutions[0]?.resolved).toBe(Effort.XHigh);
 	});
 });

--- a/packages/coding-agent/test/agent-session-skill-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-skill-keywords.test.ts
@@ -128,4 +128,35 @@ describe("AgentSession skill prompt keyword steering", () => {
 		expect(observedTurn.texts).toContain(WORKFLOW_NOTICE);
 		expect(session.sessionManager.getTurnBudget()).toEqual({ total: 500_000, spent: 0, hard: true });
 	});
+	it("exports an Auto reasoning resolution for user-authored skill prompts", async () => {
+		session.setThinkingLevel("auto");
+		const resolutions: Array<{ configured?: string; resolved?: string }> = [];
+		const unsubscribe = session.subscribe(event => {
+			if (event.type === "thinking_level_changed" && event.resolved !== undefined) {
+				resolutions.push({ configured: event.configured, resolved: event.resolved });
+			}
+		});
+		const skillPath = path.join(tempDir.path(), "reasoning.md");
+
+		try {
+			await session.promptCustomMessage({
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: `Skill body\n\n---\n\nSkill: ${skillPath}\nUser: ultrathink reply done`,
+				display: true,
+				details: {
+					name: "reasoning",
+					path: skillPath,
+					args: "ultrathink reply done",
+					lineCount: 1,
+				},
+				attribution: "user",
+			});
+		} finally {
+			unsubscribe();
+		}
+
+		expect(resolutions).toHaveLength(1);
+		expect(resolutions[0]?.configured).toBe("auto");
+		expect(resolutions[0]?.resolved).toBeTruthy();
+	});
 });


### PR DESCRIPTION
Two ACP gaps where the agent knows something the client cannot see, both fixed with namespaced `_meta` so no existing field changes shape.

## 1. `omp.sh/reasoning` — which effort Auto actually chose

With `thinking: auto`, the client's config option stays `auto` for the whole session, so a client rendering "reasoning: auto" can never show what the turn really ran at. The agent resolves a concrete effort per top-level turn and then drops it.

Now a single `config_option_update` per turn carries `_meta["omp.sh/reasoning"] = { configured: "auto", resolved: "high" }`, emitted **before** the first assistant chunk so a client can label the turn as it streams. `currentValue` stays `"auto"` — the configured option is unchanged, this is observability only.

Also fixed here: skill-prompt turns bypassed Auto resolution, so a `/skill`-initiated turn ran at the fallback effort instead of the classified one (`packages/coding-agent/src/session/agent-session.ts`).

## 2. `omp.sh/async-result` — background jobs that settle after the turn ends

A backgrounded `bash` block or `task` subagent usually finishes *after* the prompt turn that spawned it. Delivery is an `async-result` custom message, and in ACP that message had no path to the client once the owning prompt subscription had settled: the in-turn subscription is gone, and the session-lifetime subscription only forwarded `thinking_level_changed` / `model_changed`. Clients were left parsing `<task-result …>` tags out of prose, or showing nothing.

- The lifetime subscription now forwards `message_start` for settled async results, guarded by `isPromptTurnInFlight` so an in-flight turn still owns its own events (no duplicates).
- `_meta["omp.sh/async-result"] = { jobs: [{ id, type, status, label?, durationMs? }] }`, with `type: "bash" | "task"` and `status: "completed" | "failed" | "cancelled"`.
- `buildAsyncResultBatchMessage` now carries `job.status` in the message details, so status is structured data rather than something recovered from prose.
- Transcript rebuilds go through the same mapper, and for messages persisted **before** this change the status is recovered from the `<task-result id=… status=…>` tags in the stored content, matched by job id. Jobs with no recoverable status are omitted rather than guessed.
- The chunk carries empty text: it is metadata, so a client that ignores `_meta` renders nothing new.

## Test note

Upstream replaced the real-sleep `waitForBootstrapGuard` helper with fake-timer `advanceBootstrapGuard`; the two tests added here use the new helper, advancing the 50 ms bootstrap guard and then returning to real timers for the parts that await genuine async work.

## Verification

`bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/agent-session-skill-keywords.test.ts` → 108 pass / 0 fail. `tsgo --noEmit` clean.

New tests assert: exactly one resolution update per turn and that it precedes the first assistant chunk; the resolved-effort payload with `currentValue` still `"auto"`; settled async metadata pushed after the owning turn ended; status recovery from persisted `<task-result>` tags; skill-prompt Auto resolution. Every notification is validated against the ACP schema via `expectAcpNotifications`.

End-to-end check against a built CLI (`omp acp` over stdio): `initialize` advertises the metadata, and a settled `task` job produces `{"omp.sh/async-result":{"jobs":[{"id":"…","type":"task","status":"completed","label":"…","durationMs":…}]}}`.
