### PR TITLE
feat(autolearn): project-scoped skill minting via autolearn.skillLocation

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -150,6 +150,25 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_follow_up_mode", mode: "all" | "one-at-a-time" }`
 - `{ id?, type: "set_interrupt_mode", mode: "immediate" | "wait" }`
 
+### Session modes (plan / vibe / goal)
+
+- `{ id?, type: "set_mode", mode: "none" | "plan" | "vibe" | "goal", objective?: string }`
+
+Activates or deactivates a session special mode, with the same mutual-exclusion
+semantics as the TUI's `/plan`, `/vibe` and `/goal` commands: entering a mode
+while another is active fails with `"Exit <mode> mode first."` and the current
+mode stays. `goal` requires an `objective`; `none` exits whichever mode is
+active. The response reports the resulting live mode:
+
+```json
+{ "type": "response", "command": "set_mode", "success": true, "data": { "mode": "plan" } }
+```
+
+Mode state is persisted as `mode_change` session entries, so switching back to
+a session (via `switch_session`) restores its mode automatically. Model-role
+switching on plan entry is intentionally left to the client (use `set_model`),
+matching ACP's `session/set_mode`.
+
 ### Compaction
 
 - `{ id?, type: "compact", customInstructions?: string }`
@@ -251,6 +270,7 @@ is re-armed.
   "thinkingLevel": "off|minimal|low|medium|high|xhigh|max",
   "isStreaming": false,
   "isCompacting": false,
+  "mode": "none|plan|plan_paused|vibe|goal|goal_paused",
   "steeringMode": "all|one-at-a-time",
   "followUpMode": "all|one-at-a-time",
   "interruptMode": "immediate|wait",

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -634,7 +634,8 @@ memory:
 | `memory.backend`              | enum    | `off`         | `off`, `local`, `hindsight`, `mnemopi`. Each backend has its own `hindsight.*` / `mnemopi.*` / `memories.*` tuning keys.                                                                                                                  |
 | `autolearn.enabled`           | boolean | `false`       | Experimental: after the agent stops, nudge it to capture lessons to memory and create/enhance isolated managed skills under `~/.omp/agent/managed-skills`. Enables the `manage_skill` tool (and `learn` when a memory backend is active). |
 | `autolearn.autoContinue`      | boolean | `false`       | When `autolearn.enabled`, auto-run one capture turn at stop (uses extra tokens). Off = a passive reminder rides your next turn.                                                                                                           |
-| `autolearn.minToolCalls`      | number  | `5`           | Only nudge after a turn that used at least this many tools.                                                                                                                                                                               |
+| `autolearn.minToolCalls`      | number  | `5`           | Only nudge after a turn that used at least this many tools.
+| `autolearn.skillLocation`     | enum    | `global`      | Where `learn`/`manage_skill` write skills: `global` (`~/.omp/agent/managed-skills`, loads everywhere) or `project` (`<repo>/.omp/skills` at the primary checkout — only sessions in that repo, including linked worktrees, load them). |                                                                                                                                                                               |
 
 `compaction` has additional tuning keys (idle compaction, supersede/drop heuristics) visible in `omp config list`. See [Compaction](./compaction.md) for the full strategy reference.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- RPC mode: new `set_mode` command to activate/deactivate the plan, vibe and goal session modes headlessly (mirroring the TUI's `/plan` / `/vibe` / `/goal` mutual-exclusion semantics), a `mode` field in `get_state`, and automatic mode restoration across `switch_session`. `RpcClient.setMode()` is available for TypeScript hosts. ([#8171](https://github.com/can1357/oh-my-pi/issues/8171))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/autolearn/managed-skills.ts
+++ b/packages/coding-agent/src/autolearn/managed-skills.ts
@@ -10,8 +10,9 @@
 import { constants as fsConstants, type Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
+import { CONFIG_DIR_NAME, getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
+import { repo } from "../utils/git";
 
 /** Provider id stamped on discovered managed skills (distinguishes them from authored). */
 export const MANAGED_SKILLS_PROVIDER_ID = "omp-managed";
@@ -24,6 +25,44 @@ const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 /** Resolve the isolated managed-skills directory (`~/.omp/agent/managed-skills`). */
 export function getManagedSkillsDir(agentDir: string = getAgentDir()): string {
 	return path.join(agentDir, "managed-skills");
+}
+
+/**
+ * Resolve the project skills root (`<primaryRoot>/.omp/skills`) used when
+ * `autolearn.skillLocation` is `"project"`. Anchors at the repo's primary
+ * checkout so a skill minted from a linked worktree lives with the project;
+ * falls back to `cwd` outside a repository.
+ */
+export async function resolveProjectSkillsDir(cwd: string): Promise<string> {
+	const root = (await repo.primaryRoot(cwd).catch(() => null)) ?? cwd;
+	return path.join(root, CONFIG_DIR_NAME, "skills");
+}
+
+/**
+ * Resolve the skills root a managed-skill mutation should target for the
+ * configured `autolearn.skillLocation`. `"global"` returns `undefined` (the
+ * default managed dir). `"project"` returns the project `.omp/skills` dir —
+ * except for update/delete of a skill that only exists globally, which follow
+ * the existing copy instead of failing or silently relocating it.
+ */
+export async function resolveSkillWriteRoot(
+	cwd: string,
+	location: "global" | "project",
+	name?: string,
+): Promise<string | undefined> {
+	if (location !== "project") return undefined;
+	const projectRoot = await resolveProjectSkillsDir(cwd);
+	if (!name) return projectRoot;
+	let safe: string;
+	try {
+		safe = sanitizeSkillName(name);
+	} catch {
+		return projectRoot;
+	}
+	const inProject = await fs.stat(path.join(projectRoot, safe)).catch(() => null);
+	if (inProject) return projectRoot;
+	const inGlobal = await fs.stat(path.join(getManagedSkillsDir(), safe)).catch(() => null);
+	return inGlobal ? undefined : projectRoot;
 }
 
 /**
@@ -86,6 +125,11 @@ export interface WriteManagedSkillInput {
 	name: string;
 	description: string;
 	body: string;
+	/**
+	 * Skills root to write under. Defaults to the global managed-skills dir;
+	 * `autolearn.skillLocation: "project"` passes the project `.omp/skills` dir.
+	 */
+	rootDir?: string;
 }
 
 /**
@@ -114,8 +158,8 @@ function serializeSkillMutation<T>(name: string, op: () => Promise<T>): Promise<
  * valid name write/delete outside the isolated directory (e.g. onto authored
  * skills). Checked before composing any child path.
  */
-async function assertManagedRootSafe(): Promise<void> {
-	const rootStat = await fs.lstat(getManagedSkillsDir()).catch(err => {
+async function assertManagedRootSafe(root: string): Promise<void> {
+	const rootStat = await fs.lstat(root).catch(err => {
 		if (isEnoent(err)) return null;
 		throw err;
 	});
@@ -172,8 +216,9 @@ export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<
 		);
 	}
 	return serializeSkillMutation(name, async () => {
-		await assertManagedRootSafe();
-		const dir = path.join(getManagedSkillsDir(), name);
+		const root = input.rootDir ?? getManagedSkillsDir();
+		await assertManagedRootSafe(root);
+		const dir = path.join(root, name);
 		const file = path.join(dir, "SKILL.md");
 		// Reject a symlinked skill directory: an intermediate symlink would let the
 		// write escape the isolated managed root. lstat does not follow the final
@@ -230,11 +275,12 @@ export async function writeManagedSkill(input: WriteManagedSkillInput): Promise<
 }
 
 /** Delete a managed skill directory. Throws when it does not exist. */
-export async function deleteManagedSkill(name: string): Promise<void> {
+export async function deleteManagedSkill(name: string, rootDir?: string): Promise<void> {
 	const safe = sanitizeSkillName(name);
 	await serializeSkillMutation(safe, async () => {
-		await assertManagedRootSafe();
-		const dir = path.join(getManagedSkillsDir(), safe);
+		const root = rootDir ?? getManagedSkillsDir();
+		await assertManagedRootSafe(root);
+		const dir = path.join(root, safe);
 		// Refuse to follow a symlinked skill directory (rm would delete the target).
 		const dirStat = await fs.lstat(dir).catch(err => {
 			if (isEnoent(err)) return null;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2664,6 +2664,29 @@ export const SETTINGS_SCHEMA = {
 	},
 	// Config-file-only knob (numbers without `options` are hidden from the UI).
 	"autolearn.minToolCalls": { type: "number", default: 5 },
+	// Where `learn`/`manage_skill` mint managed skills: the global
+	// managed-skills dir, or the project's `.omp/skills` (repo-scoped loading).
+	"autolearn.skillLocation": {
+		type: "enum",
+		values: ["global", "project"] as const,
+		default: "global",
+		ui: {
+			tab: "memory",
+			group: "Auto-Learn",
+			label: "Skill location",
+			description:
+				"Where auto-learned skills are written: global (every session) or the project's .omp/skills (only this repo)",
+			options: [
+				{ value: "global", label: "Global", description: "Load in every session (~/.omp/agent/managed-skills)" },
+				{
+					value: "project",
+					label: "Project",
+					description: "Write to <repo>/.omp/skills; only sessions in that repo load them",
+				},
+			],
+			condition: "autolearnActive",
+		},
+	},
 
 	// Mnemopi local SQLite memory backend.
 	"mnemopi.dbPath": {

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -24,6 +24,7 @@ import { type SystemPrompt, systemPromptCapability } from "../capability/system-
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import { expandTilde } from "../tools/path-utils";
+import { repo } from "../utils/git";
 import {
 	buildRuleFromMarkdown,
 	createSourceMeta,
@@ -290,6 +291,22 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 			requireDescription: true,
 		}),
 	);
+
+	// Linked worktrees are not ancestors of the primary checkout, so a project
+	// skill committed at the primary root (e.g. by `autolearn.skillLocation:
+	// "project"`) would be invisible here. Scan it explicitly unless the
+	// ancestor walk already covers it.
+	const primaryRoot = await repo.primaryRoot(ctx.cwd).catch(() => null);
+	if (primaryRoot && !ancestors.some(({ dir }) => path.resolve(dir) === path.resolve(primaryRoot))) {
+		projectScans.push(
+			scanSkillsFromDir(ctx, {
+				dir: path.join(primaryRoot, PATHS.projectDir, "skills"),
+				providerId: PROVIDER_ID,
+				level: "project",
+				requireDescription: true,
+			}),
+		);
+	}
 
 	// User-level scan from ~/.omp/agent/skills/
 	const userScan = scanSkillsFromDir(ctx, {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -603,6 +603,8 @@ export class RpcClient {
 		const state = this.#getData<RpcSessionState>(response);
 		return {
 			...state,
+			// Older servers predate the `mode` field; treat it as absent → "none".
+			mode: state.mode ?? "none",
 			fastModeEnabled: state.fastModeEnabled === true,
 			fastModeActive: state.fastModeActive === true,
 			tokensPerSecond:

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -32,7 +32,9 @@ import type {
 	RpcHostToolResult,
 	RpcHostToolUpdate,
 	RpcResponse,
+	RpcSessionMode,
 	RpcSessionState,
+	RpcSetModeTarget,
 	RpcSubagentEventFrame,
 	RpcSubagentLifecycleFrame,
 	RpcSubagentMessagesResult,
@@ -650,6 +652,19 @@ export class RpcClient {
 			fromByte: selector.fromByte,
 		});
 		return this.#getData<RpcSubagentMessagesResult>(response);
+	}
+
+	/**
+	 * Switch the session's special mode (plan / vibe / goal). `goal` requires
+	 * an `objective`. Returns the resulting live mode.
+	 */
+	async setMode(mode: RpcSetModeTarget, objective?: string): Promise<RpcSessionMode> {
+		const response = await this.#send({
+			type: "set_mode",
+			mode,
+			...(objective !== undefined ? { objective } : {}),
+		});
+		return this.#getData<{ mode: RpcSessionMode }>(response).mode;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -39,6 +39,7 @@ import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
+import { getSessionMode, reconcileSessionMode, setSessionMode, suspendSessionMode } from "./rpc-modes";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -953,6 +954,12 @@ export async function runRpcMode(
 		output(event);
 	});
 
+	// Restore plan/vibe/goal mode across switch_session like the TUI does: drop
+	// the previous session's live mode state before the switch, then reconcile
+	// the target file's mode_change chain afterwards.
+	session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(session));
+	session.setSessionSwitchReconciler(() => reconcileSessionMode(session));
+
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
 	const reloadPluginState = async () => {
 		const cwd = session.sessionManager.getCwd();
@@ -1078,6 +1085,7 @@ export async function runRpcMode(
 					thinkingLevel: session.thinkingLevel,
 					isStreaming: session.isStreaming,
 					isCompacting: session.isCompacting,
+					mode: getSessionMode(session),
 					steeringMode: session.steeringMode,
 					followUpMode: session.followUpMode,
 					interruptMode: session.interruptMode,
@@ -1250,6 +1258,19 @@ export async function runRpcMode(
 			case "set_interrupt_mode": {
 				session.setInterruptMode(command.mode);
 				return success(id, "set_interrupt_mode");
+			}
+
+			// =================================================================
+			// Session Modes (plan / vibe / goal)
+			// =================================================================
+
+			case "set_mode": {
+				try {
+					const mode = await setSessionMode(session, command.mode, command.objective);
+					return success(id, "set_mode", { mode });
+				} catch (err) {
+					return error(id, "set_mode", err instanceof Error ? err.message : String(err));
+				}
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -13,7 +13,7 @@
 import { once } from "node:events";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
-import { $env, isRecord, readLines, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, isRecord, logger, readLines, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -956,9 +956,21 @@ export async function runRpcMode(
 
 	// Restore plan/vibe/goal mode across switch_session like the TUI does: drop
 	// the previous session's live mode state before the switch, then reconcile
-	// the target file's mode_change chain afterwards.
+	// the target file's mode_change chain afterwards. Reconcile the *current*
+	// session once up front too, so a session resumed with a persisted mode
+	// (e.g. --session pointing at a plan-mode journal) starts with live mode
+	// state instead of reporting "none" until the first switch (mirrors
+	// InteractiveMode's startup reconcile).
 	session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(session));
 	session.setSessionSwitchReconciler(() => reconcileSessionMode(session));
+	try {
+		await reconcileSessionMode(session);
+	} catch (error) {
+		logger.warn("Failed to reconcile session mode on RPC startup", {
+			sessionFile: session.sessionManager.getSessionFile(),
+			error: String(error),
+		});
+	}
 
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
 	const reloadPluginState = async () => {

--- a/packages/coding-agent/src/modes/rpc/rpc-modes.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-modes.ts
@@ -61,6 +61,10 @@ export async function enterPlanMode(
 	session: AgentSession,
 	options?: { planFilePath?: string; persist?: boolean },
 ): Promise<void> {
+	// Idempotent: re-entering plan mode must not re-capture the write-augmented
+	// toolset into `previousToolsByMode` (a later exit would then leave `write`
+	// active). Mirrors InteractiveMode.#enterPlanMode.
+	if (session.getPlanModeState()?.enabled) return;
 	assertNoOtherMode(session, "plan");
 	if (!session.settings.get("plan.enabled")) {
 		throw new Error("Plan mode is disabled. Enable it in settings (plan.enabled).");
@@ -136,6 +140,8 @@ function vibeParentSession(session: AgentSession): VibeParentSession {
 }
 
 export async function enterVibeMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	// Idempotent: re-entering must not re-capture the read-only toolset (see enterPlanMode).
+	if (session.getVibeModeState()?.enabled) return;
 	assertNoOtherMode(session, "vibe");
 	const vibeRegistry = VibeSessionRegistry.global();
 	const parent = vibeParentSession(session);
@@ -182,6 +188,9 @@ export async function enterGoalMode(
 	objective: string,
 	_options?: { persist?: boolean },
 ): Promise<void> {
+	// Idempotent: re-entering must not re-capture the goal-augmented toolset
+	// (see enterPlanMode). Mirrors InteractiveMode.#enterGoalMode.
+	if (session.getGoalModeState()?.enabled) return;
 	assertNoOtherMode(session, "goal");
 	if (!session.settings.get("goal.enabled")) {
 		throw new Error("Goal mode is disabled. Enable it in settings (goal.enabled).");
@@ -303,9 +312,7 @@ export async function reconcileSessionMode(session: AgentSession): Promise<void>
 		if (!session.settings.get("plan.enabled")) {
 			// Clear stale plan/plan_paused mode so re-enabling the setting
 			// later doesn't unexpectedly restore an old plan session.
-			if (mode === "plan" || mode === "plan_paused") {
-				session.sessionManager.appendModeChange("none");
-			}
+			session.sessionManager.appendModeChange("none");
 			return;
 		}
 		if (mode === "plan") {
@@ -317,6 +324,9 @@ export async function reconcileSessionMode(session: AgentSession): Promise<void>
 		return;
 	}
 	if (mode === "vibe") {
+		// Rehydrate suspended workers scoped to this parent before re-entering,
+		// mirroring InteractiveMode.#reconcileModeFromSession.
+		await VibeSessionRegistry.global().rehydrate(vibeParentSession(session));
 		await enterVibeMode(session, { persist: false });
 		return;
 	}

--- a/packages/coding-agent/src/modes/rpc/rpc-modes.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-modes.ts
@@ -1,0 +1,343 @@
+/**
+ * Headless session-mode controller for RPC hosts.
+ *
+ * plan/vibe/goal activation lives in the TUI's `InteractiveModeContext`
+ * (`handlePlanModeCommand` & friends), which RPC hosts cannot reach. This
+ * module mirrors those session-level effects — mode state, toolset changes,
+ * the plan-proposal handler, persisted `mode_change` entries, and mutual
+ * exclusion — using only public `AgentSession` APIs, so `set_mode` behaves
+ * like the TUI's `/plan` / `/vibe` / `/goal` commands.
+ *
+ * Session-switch support mirrors `InteractiveMode.#reconcileModeFromSession`:
+ * `suspendSessionMode` drops live mode state before a switch (without writing
+ * to the target file's mode chain) and `reconcileSessionMode` restores the
+ * persisted mode from the target file's `mode_change` chain afterwards.
+ *
+ * Model-role switching on plan entry is deliberately omitted, matching ACP's
+ * `session/set_mode`: the RPC client already addresses the model via
+ * `set_model`, and a server-side switch would fight the client's selection.
+ */
+import { formatModelString } from "../../config/model-resolver";
+import type { Goal } from "../../goals/state";
+import type { AgentSession } from "../../session/agent-session";
+import { type VibeParentSession, VibeSessionRegistry } from "../../vibe/runtime";
+import type { RpcSessionMode, RpcSetModeTarget } from "./rpc-types";
+
+/**
+ * Pre-enter toolset per session, so exiting a mode restores exactly what was
+ * active before it (plan augments with `write`, vibe replaces with read-only,
+ * goal adds the `goal` tool).
+ */
+const previousToolsByMode = new WeakMap<AgentSession, { plan?: string[]; vibe?: string[]; goal?: string[] }>();
+
+function assertNoOtherMode(session: AgentSession, target: RpcSetModeTarget): void {
+	if (target !== "plan" && session.getPlanModeState()?.enabled) {
+		throw new Error("Exit plan mode first.");
+	}
+	if (target !== "vibe" && session.getVibeModeState()?.enabled) {
+		throw new Error("Exit vibe mode first.");
+	}
+	const goal = session.getGoalModeState();
+	if (target !== "goal" && (goal?.enabled || goal?.goal.status === "paused")) {
+		throw new Error("Exit goal mode first.");
+	}
+}
+
+/** Live session mode, mirroring the mode semantics of `buildSessionContext`. */
+export function getSessionMode(session: AgentSession): RpcSessionMode {
+	if (session.getPlanModeState()?.enabled) return "plan";
+	if (session.getVibeModeState()?.enabled) return "vibe";
+	const goal = session.getGoalModeState();
+	if (goal?.enabled) return "goal";
+	if (goal?.goal.status === "paused") return "goal_paused";
+	return "none";
+}
+
+// ---------------------------------------------------------------------------
+// Plan mode
+// ---------------------------------------------------------------------------
+
+export async function enterPlanMode(
+	session: AgentSession,
+	options?: { planFilePath?: string; persist?: boolean },
+): Promise<void> {
+	assertNoOtherMode(session, "plan");
+	if (!session.settings.get("plan.enabled")) {
+		throw new Error("Plan mode is disabled. Enable it in settings (plan.enabled).");
+	}
+	const planFilePath = options?.planFilePath ?? (session.getPlanReferencePath() || "local://PLAN.md");
+	const previousTools = session.getEnabledToolNames();
+	// Plan approval is a `write` to `xd://propose`; keep `write` in the active
+	// toolset so the agent can draft and submit the plan (mirrors
+	// InteractiveMode.#enterPlanMode and print-mode).
+	const planTools = session.hasBuiltInTool("write") ? [...new Set([...previousTools, "write"])] : previousTools;
+	await session.setActiveToolsByName(planTools);
+	previousToolsByMode.set(session, { ...previousToolsByMode.get(session), plan: previousTools });
+	const previous = session.getPlanModeState();
+	session.setPlanModeState({
+		enabled: true,
+		planFilePath: previous?.planFilePath ?? planFilePath,
+		workflow: previous?.workflow ?? "parallel",
+		reentry: previous !== undefined,
+	});
+	session.setPlanProposalHandler(async title => {
+		const result = await session.preparePlanForReview(title);
+		const details = result.details;
+		if (details) {
+			const state = session.getPlanModeState();
+			if (state?.enabled) {
+				session.setPlanModeState({ ...state, planFilePath: details.planFilePath });
+			}
+			session.sessionManager.appendModeChange("plan", { planFilePath: details.planFilePath });
+		}
+		return result;
+	});
+	if (session.isStreaming) {
+		await session.sendPlanModeContext({ deliverAs: "steer" });
+	}
+	if (options?.persist !== false) {
+		session.sessionManager.appendModeChange("plan", { planFilePath });
+	}
+}
+
+export async function exitPlanMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	if (!session.getPlanModeState()?.enabled) return;
+	const previous = previousToolsByMode.get(session)?.plan;
+	if (previous !== undefined) {
+		await session.setActiveToolsByName(previous);
+	}
+	session.setPlanModeState(undefined);
+	session.setPlanProposalHandler(null);
+	if (options?.persist !== false) {
+		session.sessionManager.appendModeChange("none");
+	}
+	const rest = previousToolsByMode.get(session);
+	if (rest) {
+		delete rest.plan;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Vibe mode
+// ---------------------------------------------------------------------------
+
+function vibeParentSession(session: AgentSession): VibeParentSession {
+	return {
+		getAgentId: () => session.getAgentId() ?? null,
+		getSessionId: () => session.sessionManager.getSessionId(),
+		getSessionFile: () => session.sessionManager.getSessionFile() ?? null,
+		sessionManager: session.sessionManager,
+		asyncJobManager: session.asyncJobManager,
+		settings: session.settings,
+		// Resolve workers against this session's active model (same as the
+		// spawn-path ToolSession), not the settings default.
+		getActiveModelString: () => (session.model ? formatModelString(session.model) : undefined),
+	};
+}
+
+export async function enterVibeMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	assertNoOtherMode(session, "vibe");
+	const vibeRegistry = VibeSessionRegistry.global();
+	const parent = vibeParentSession(session);
+	vibeRegistry.activateScope(vibeRegistry.ownerScope(parent));
+	const previousTools = session.getEnabledToolNames();
+	const vibeBaseTools = ["read"];
+	if (session.hasBuiltInTool("todo")) vibeBaseTools.push("todo");
+	await session.activateVibeTools(vibeBaseTools);
+	previousToolsByMode.set(session, { ...previousToolsByMode.get(session), vibe: previousTools });
+	session.setVibeModeState({ enabled: true });
+	if (session.isStreaming) {
+		await session.sendVibeModeContext({ deliverAs: "steer" });
+	}
+	if (options?.persist !== false) {
+		session.sessionManager.appendModeChange("vibe");
+	}
+}
+
+export async function exitVibeMode(session: AgentSession, options?: { persist?: boolean }): Promise<void> {
+	if (!session.getVibeModeState()?.enabled) return;
+	const parent = vibeParentSession(session);
+	const registry = VibeSessionRegistry.global();
+	await registry.killAll(parent, registry.ownerScope(parent));
+	await session.deactivateVibeTools(previousToolsByMode.get(session)?.vibe ?? ["read"]);
+	session.setVibeModeState(undefined);
+	if (options?.persist !== false) {
+		// Persist the exit: unlike the TUI (which relies on the worker-tombstone
+		// path), an explicit headless exit should leave a mode chain that says
+		// "none" so a later switch/restart doesn't resurrect vibe mode.
+		session.sessionManager.appendModeChange("none");
+	}
+	const rest = previousToolsByMode.get(session);
+	if (rest) {
+		delete rest.vibe;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Goal mode
+// ---------------------------------------------------------------------------
+
+export async function enterGoalMode(
+	session: AgentSession,
+	objective: string,
+	_options?: { persist?: boolean },
+): Promise<void> {
+	assertNoOtherMode(session, "goal");
+	if (!session.settings.get("goal.enabled")) {
+		throw new Error("Goal mode is disabled. Enable it in settings (goal.enabled).");
+	}
+	const trimmed = objective.trim();
+	if (!trimmed) {
+		throw new Error("Goal mode requires an objective (pass `objective` to set_mode).");
+	}
+	const previousTools = session.getEnabledToolNames().filter(name => name !== "goal");
+	// sdk.ts excludes "goal" from the initial active tool set unconditionally;
+	// re-add it so the agent can call resume, complete, or drop on this goal.
+	await session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+	const state = await session.goalRuntime.createGoal({ objective: trimmed });
+	session.setGoalModeState(state);
+	previousToolsByMode.set(session, { ...previousToolsByMode.get(session), goal: previousTools });
+	// mode_change persistence is handled by the goal runtime's persist callback.
+}
+
+export async function exitGoalMode(session: AgentSession, _options?: { persist?: boolean }): Promise<void> {
+	const goal = session.getGoalModeState();
+	if (!goal?.enabled && goal?.goal.status !== "paused") return;
+	const previous = previousToolsByMode.get(session)?.goal;
+	if (previous !== undefined) {
+		await session.setActiveToolsByName(previous);
+	}
+	await session.goalRuntime.dropGoal();
+	session.setGoalModeState(undefined);
+	const rest = previousToolsByMode.get(session);
+	if (rest) {
+		delete rest.goal;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/** Apply a mode change; returns the resulting live session mode. */
+export async function setSessionMode(
+	session: AgentSession,
+	mode: RpcSetModeTarget,
+	objective?: string,
+): Promise<RpcSessionMode> {
+	switch (mode) {
+		case "none":
+			await resetSessionMode(session);
+			break;
+		case "plan":
+			await enterPlanMode(session);
+			break;
+		case "vibe":
+			await enterVibeMode(session);
+			break;
+		case "goal":
+			await enterGoalMode(session, objective ?? "");
+			break;
+	}
+	return getSessionMode(session);
+}
+
+/** Exit whichever special mode is currently active (plan / vibe / goal). */
+export async function resetSessionMode(session: AgentSession): Promise<void> {
+	if (session.getPlanModeState()?.enabled) {
+		await exitPlanMode(session);
+	} else if (session.getVibeModeState()?.enabled) {
+		await exitVibeMode(session);
+	} else if (session.getGoalModeState()?.enabled || session.getGoalModeState()?.goal.status === "paused") {
+		await exitGoalMode(session);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session-switch hooks (mirror InteractiveMode.#clearTransientModeState /
+// #reconcileModeFromSession)
+// ---------------------------------------------------------------------------
+
+/**
+ * Drop live mode state before the session switches to another file, without
+ * persisting anything (the target file's mode chain is untouched). Vibe
+ * workers are suspended under their parent scope, not killed, so switching
+ * back to the session can resume them.
+ */
+export async function suspendSessionMode(session: AgentSession): Promise<void> {
+	if (session.getPlanModeState()?.enabled) {
+		const previous = previousToolsByMode.get(session)?.plan;
+		if (previous !== undefined) {
+			await session.setActiveToolsByName(previous);
+		}
+		session.setPlanModeState(undefined);
+		session.setPlanProposalHandler(null);
+	}
+	const goal = session.getGoalModeState();
+	if (goal?.enabled || goal?.goal.status === "paused") {
+		const previous = previousToolsByMode.get(session)?.goal;
+		if (previous !== undefined) {
+			await session.setActiveToolsByName(previous);
+		}
+		session.setGoalModeState(undefined);
+	}
+	if (session.getVibeModeState()?.enabled) {
+		const parent = vibeParentSession(session);
+		const registry = VibeSessionRegistry.global();
+		await registry.suspendScope(registry.ownerScope(parent));
+		await session.deactivateVibeTools(previousToolsByMode.get(session)?.vibe ?? ["read"]);
+		session.setVibeModeState(undefined);
+	}
+	previousToolsByMode.delete(session);
+}
+
+/**
+ * Restore the persisted mode after switching to a session file whose
+ * `mode_change` chain names a special mode. Mirrors
+ * `InteractiveMode.#reconcileModeFromSession` minus the TUI-only state.
+ */
+export async function reconcileSessionMode(session: AgentSession): Promise<void> {
+	const context = session.sessionManager.buildSessionContext();
+	const mode = context.mode;
+	if (mode === "plan" || mode === "plan_paused") {
+		if (!session.settings.get("plan.enabled")) {
+			// Clear stale plan/plan_paused mode so re-enabling the setting
+			// later doesn't unexpectedly restore an old plan session.
+			if (mode === "plan" || mode === "plan_paused") {
+				session.sessionManager.appendModeChange("none");
+			}
+			return;
+		}
+		if (mode === "plan") {
+			const planFilePath = context.modeData?.planFilePath as string | undefined;
+			await enterPlanMode(session, { planFilePath, persist: false });
+		}
+		// plan_paused is an interactive intermediate; headless restore stays in
+		// build mode (the plan file and model remain as persisted).
+		return;
+	}
+	if (mode === "vibe") {
+		await enterVibeMode(session, { persist: false });
+		return;
+	}
+	if (mode === "goal" || mode === "goal_paused") {
+		if (!session.settings.get("goal.enabled")) {
+			session.goalRuntime.clearAccounting();
+			session.sessionManager.appendModeChange("none");
+			return;
+		}
+		const goal = (context.modeData as { goal?: Goal } | undefined)?.goal;
+		if (!goal) {
+			session.sessionManager.appendModeChange("none");
+			return;
+		}
+		session.setGoalModeState({ enabled: mode === "goal", mode: "active", goal });
+		const restored = await session.goalRuntime.onThreadResumed({});
+		if (restored?.goal) {
+			const previousTools = session.getEnabledToolNames().filter(name => name !== "goal");
+			await session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+			previousToolsByMode.set(session, { ...previousToolsByMode.get(session), goal: previousTools });
+		}
+		return;
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-modes.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-modes.ts
@@ -342,7 +342,10 @@ export async function reconcileSessionMode(session: AgentSession): Promise<void>
 			return;
 		}
 		session.setGoalModeState({ enabled: mode === "goal", mode: "active", goal });
-		const restored = await session.goalRuntime.onThreadResumed({});
+		// Preserve an active goal across in-process switches (the TUI's switch
+		// reconciler passes preserveActiveGoal: true too); without it an active
+		// goal is converted to goal_paused and persisted as such.
+		const restored = await session.goalRuntime.onThreadResumed({ preserveActiveGoal: true });
 		if (restored?.goal) {
 			const previousTools = session.getEnabledToolNames().filter(name => name !== "goal");
 			await session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -62,6 +62,9 @@ export type RpcCommand =
 	| { id?: string; type: "set_follow_up_mode"; mode: "all" | "one-at-a-time" }
 	| { id?: string; type: "set_interrupt_mode"; mode: "immediate" | "wait" }
 
+	// Session modes (plan / vibe / goal — see rpc-modes.ts)
+	| { id?: string; type: "set_mode"; mode: RpcSetModeTarget; objective?: string }
+
 	// Compaction
 	| { id?: string; type: "compact"; customInstructions?: string }
 	| { id?: string; type: "set_auto_compaction"; enabled: boolean }
@@ -96,11 +99,23 @@ export type RpcCommand =
 // RPC State
 // ============================================================================
 
+/**
+ * Active session special mode. `get_state.mode` reports the live state;
+ * `plan_paused` / `goal_paused` are only ever *reported* (they are TUI
+ * intermediate states a headless client cannot enter directly).
+ */
+export type RpcSessionMode = "none" | "plan" | "plan_paused" | "vibe" | "goal" | "goal_paused";
+
+/** Modes a client may request via `set_mode`. */
+export type RpcSetModeTarget = "none" | "plan" | "vibe" | "goal";
+
 export interface RpcSessionState {
 	model?: Model;
 	thinkingLevel: ThinkingLevel | undefined;
 	isStreaming: boolean;
 	isCompacting: boolean;
+	/** Active special mode (plan / vibe / goal) or "none". */
+	mode: RpcSessionMode;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
 	interruptMode: "immediate" | "wait";
@@ -289,6 +304,9 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "set_steering_mode"; success: true }
 	| { id?: string; type: "response"; command: "set_follow_up_mode"; success: true }
 	| { id?: string; type: "response"; command: "set_interrupt_mode"; success: true }
+
+	// Session modes
+	| { id?: string; type: "response"; command: "set_mode"; success: true; data: { mode: RpcSessionMode } }
 
 	// Compaction
 	| { id?: string; type: "response"; command: "compact"; success: true; data: CompactionResult }

--- a/packages/coding-agent/src/tools/learn.ts
+++ b/packages/coding-agent/src/tools/learn.ts
@@ -1,6 +1,6 @@
 import { type } from "@oh-my-pi/omptype";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { sanitizeSkillName, writeManagedSkill } from "../autolearn/managed-skills";
+import { resolveSkillWriteRoot, sanitizeSkillName, writeManagedSkill } from "../autolearn/managed-skills";
 import { isNameClaimedByAuthoredSkill } from "../extensibility/skills";
 import { localBackend } from "../memory-backend/local-backend";
 import learnDescription from "../prompts/tools/learn.md" with { type: "text" };
@@ -121,7 +121,9 @@ export class LearnTool implements AgentTool<typeof learnSchema> {
 				};
 			}
 			try {
-				await writeManagedSkill(params.skill);
+				const location = this.session.settings.get("autolearn.skillLocation");
+				const rootDir = await resolveSkillWriteRoot(this.session.cwd, location, params.skill.name);
+				await writeManagedSkill({ ...params.skill, rootDir });
 			} catch (err) {
 				const reason = err instanceof Error ? err.message : String(err);
 				throw new Error(`${memoryMessage}, but the managed skill could not be written: ${reason}`);

--- a/packages/coding-agent/src/tools/manage-skill.ts
+++ b/packages/coding-agent/src/tools/manage-skill.ts
@@ -1,9 +1,11 @@
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { CONFIG_DIR_NAME } from "@oh-my-pi/pi-utils";
 import {
 	deleteManagedSkill,
 	getManagedSkillsDir,
+	resolveSkillWriteRoot,
 	sanitizeSkillName,
 	writeManagedSkill,
 } from "../autolearn/managed-skills";
@@ -45,17 +47,20 @@ export class ManageSkillTool implements AgentTool<typeof manageSkillSchema> {
 	readonly loadMode = "essential" as const;
 	readonly summary = "Create, update, or delete an isolated managed skill";
 
-	constructor(private readonly refreshSkills?: () => Promise<void>) {}
+	constructor(private readonly session: ToolSession) {}
 
 	static createIf(session: ToolSession): ManageSkillTool | null {
 		if (!session.settings.get("autolearn.enabled")) return null;
-		return new ManageSkillTool(session.refreshSkills);
+		return new ManageSkillTool(session);
 	}
 
 	async execute(_id: string, params: ManageSkillParams): Promise<AgentToolResult> {
+		const location = this.session.settings.get("autolearn.skillLocation");
+		const rootDir = await resolveSkillWriteRoot(this.session.cwd, location, params.name);
+		const refreshSkills = this.session.refreshSkills;
 		if (params.action === "delete") {
-			await deleteManagedSkill(params.name);
-			await this.refreshSkills?.();
+			await deleteManagedSkill(params.name, rootDir);
+			await refreshSkills?.();
 			return {
 				content: [{ type: "text", text: `Deleted managed skill "${params.name}".` }],
 				details: { action: "delete", name: params.name },
@@ -90,12 +95,14 @@ export class ManageSkillTool implements AgentTool<typeof manageSkillSchema> {
 			name: params.name,
 			description: params.description,
 			body: params.body,
+			rootDir,
 		});
-		await this.refreshSkills?.();
-		const relativePath = path.relative(getManagedSkillsDir(), skillPath);
+		await refreshSkills?.();
+		const relativePath = path.relative(rootDir ?? getManagedSkillsDir(), skillPath);
+		const rootLabel = rootDir ? path.join(CONFIG_DIR_NAME, "skills") : "managed-skills";
 		const verb = params.action === "create" ? "Created" : "Updated";
 		return {
-			content: [{ type: "text", text: `${verb} managed skill "${params.name}" (managed-skills/${relativePath}).` }],
+			content: [{ type: "text", text: `${verb} managed skill "${params.name}" (${rootLabel}/${relativePath}).` }],
 			details: { action: params.action, name: params.name },
 		};
 	}

--- a/packages/coding-agent/test/autolearn-managed-skills.test.ts
+++ b/packages/coding-agent/test/autolearn-managed-skills.test.ts
@@ -6,6 +6,8 @@ import {
 	deleteManagedSkill,
 	getManagedSkillsDir,
 	MAX_MANAGED_SKILL_BYTES,
+	resolveProjectSkillsDir,
+	resolveSkillWriteRoot,
 	sanitizeSkillName,
 	toSkillFrontmatter,
 	writeManagedSkill,
@@ -251,5 +253,103 @@ describe("managed-skills primitives", () => {
 				await removeWithRetries(outside);
 			}
 		});
+	});
+});
+
+describe("project skill location", () => {
+	// Managed-dir calls must hit a sandbox: without this mock the default
+	// agentDir is the real ~/.omp/agent.
+	let tempHome: string;
+	let originalAgentDir: string;
+	beforeEach(async () => {
+		originalAgentDir = getAgentDir();
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-managed-skills-proj-"));
+		spyOn(os, "homedir").mockReturnValue(tempHome);
+		setAgentDir(path.join(tempHome, ".omp", "agent"));
+	});
+	afterEach(async () => {
+		spyOn(os, "homedir").mockRestore();
+		setAgentDir(originalAgentDir);
+		await removeWithRetries(tempHome);
+	});
+
+	const git = (cwd: string, args: string[]) => {
+		const proc = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+		if (proc.exitCode !== 0) throw new Error(`git ${args[0]} failed: ${proc.stderr.toString()}`);
+		return proc.stdout.toString().trim();
+	};
+	const initRepo = async (dir: string) => {
+		await fs.mkdir(dir, { recursive: true });
+		git(dir, ["init", "-b", "main"]);
+		git(dir, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"]);
+	};
+
+	it("resolveProjectSkillsDir falls back to cwd outside a repository", async () => {
+		const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "omp-projskill-norepo-")));
+		try {
+			expect(await resolveProjectSkillsDir(dir)).toBe(path.join(dir, ".omp", "skills"));
+		} finally {
+			await removeWithRetries(dir);
+		}
+	});
+
+	it("resolveProjectSkillsDir anchors at the primary checkout from a linked worktree", async () => {
+		// realpath up front: git reports resolved paths, so keep both sides comparable.
+		const base = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "omp-projskill-")));
+		const main = path.join(base, "repo");
+		const worktree = path.join(base, "repo-wt");
+		try {
+			await initRepo(main);
+			git(main, ["worktree", "add", worktree, "-b", "wt"]);
+			expect(await resolveProjectSkillsDir(worktree)).toBe(path.join(main, ".omp", "skills"));
+			expect(await resolveProjectSkillsDir(main)).toBe(path.join(main, ".omp", "skills"));
+		} finally {
+			await removeWithRetries(base);
+		}
+	});
+
+	it("writeManagedSkill/deleteManagedSkill honor an explicit rootDir", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-projskill-root-"));
+		try {
+			const { path: file } = await writeManagedSkill({
+				action: "create",
+				name: "proj-skill",
+				description: "d",
+				body: "b",
+				rootDir: root,
+			});
+			expect(file).toBe(path.join(root, "proj-skill", "SKILL.md"));
+			expect(await Bun.file(file).exists()).toBe(true);
+			expect(await Bun.file(path.join(getManagedSkillsDir(), "proj-skill", "SKILL.md")).exists()).toBe(false);
+
+			await deleteManagedSkill("proj-skill", root);
+			expect(await Bun.file(file).exists()).toBe(false);
+		} finally {
+			await removeWithRetries(root);
+		}
+	});
+
+	it("resolveSkillWriteRoot returns undefined for global and the project dir for project", async () => {
+		const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "omp-projskill-scope-")));
+		try {
+			await initRepo(dir);
+			expect(await resolveSkillWriteRoot(dir, "global", "whatever")).toBeUndefined();
+			const projectRoot = path.join(dir, ".omp", "skills");
+			expect(await resolveSkillWriteRoot(dir, "project", "new-skill")).toBe(projectRoot);
+			// A skill that only exists globally is updated in place, not relocated.
+			await writeManagedSkill({ action: "create", name: "global-only", description: "d", body: "b" });
+			expect(await resolveSkillWriteRoot(dir, "project", "global-only")).toBeUndefined();
+			// A skill already in the project dir stays there.
+			await writeManagedSkill({
+				action: "create",
+				name: "proj-here",
+				description: "d",
+				body: "b",
+				rootDir: projectRoot,
+			});
+			expect(await resolveSkillWriteRoot(dir, "project", "proj-here")).toBe(projectRoot);
+		} finally {
+			await removeWithRetries(dir);
+		}
 	});
 });

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -319,6 +319,7 @@ describe("RpcInputDispatcher", () => {
 						thinkingLevel: undefined,
 						isStreaming: false,
 						isCompacting: false,
+						mode: "none",
 						steeringMode: "all",
 						followUpMode: "all",
 						interruptMode: "immediate",

--- a/packages/coding-agent/test/rpc-modes.test.ts
+++ b/packages/coding-agent/test/rpc-modes.test.ts
@@ -37,7 +37,7 @@ describe("rpc session modes (headless controller)", () => {
 	let ctx: TestSessionContext;
 
 	beforeEach(async () => {
-		ctx = await createTestSession({ vibeTools: true });
+		ctx = await createTestSession({ vibeTools: true, wireToolRegistry: true });
 	});
 
 	afterEach(async () => {
@@ -92,6 +92,24 @@ describe("rpc session modes (headless controller)", () => {
 		expect(await setSessionMode(ctx.session, "none")).toBe("none");
 		expect(ctx.session.getVibeModeState()).toBeUndefined();
 		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("none");
+	});
+
+	test("re-entering the same mode is idempotent (does not corrupt tool restore)", async () => {
+		// Plan mode augments the toolset with `write`; re-entering while active
+		// must not re-capture the augmented set, or exit would leave `write` on.
+		const prePlanTools = ctx.session.getEnabledToolNames().slice();
+		await setSessionMode(ctx.session, "plan");
+		await setSessionMode(ctx.session, "plan");
+		expect(await setSessionMode(ctx.session, "plan")).toBe("plan");
+		await setSessionMode(ctx.session, "none");
+		expect(ctx.session.getEnabledToolNames()).toEqual(prePlanTools);
+
+		// Vibe mode replaces the toolset with read-only; same guard.
+		const preVibeTools = ctx.session.getEnabledToolNames().slice();
+		await setSessionMode(ctx.session, "vibe");
+		await setSessionMode(ctx.session, "vibe");
+		await setSessionMode(ctx.session, "none");
+		expect(ctx.session.getEnabledToolNames()).toEqual(preVibeTools);
 	});
 
 	test("switch_session restores the persisted mode (reconcile hooks)", async () => {

--- a/packages/coding-agent/test/rpc-modes.test.ts
+++ b/packages/coding-agent/test/rpc-modes.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { getSessionMode, reconcileSessionMode, setSessionMode, suspendSessionMode } from "../src/modes/rpc/rpc-modes";
+import { createTestSession, type TestSessionContext } from "./utilities";
+import type { SessionEntry } from "../src/session/session-entries";
+
+const isModeChangeEntry = (entry: SessionEntry): entry is Extract<SessionEntry, { type: "mode_change" }> =>
+	entry.type === "mode_change";
+
+/** Minimal persisted session file: header + one mode_change entry. */
+function writeSessionFile(dir: string, name: string, mode: "plan" | "vibe" | "goal" | "none"): string {
+	const sessionId = Snowflake.next().toString();
+	const header = {
+		type: "session",
+		version: 3,
+		id: sessionId,
+		timestamp: new Date().toISOString(),
+		cwd: dir,
+	};
+	const entryId = Snowflake.next().slice(0, 8);
+	const modeChange = {
+		type: "mode_change",
+		id: entryId,
+		parentId: sessionId,
+		timestamp: new Date().toISOString(),
+		mode,
+		...(mode === "plan" ? { data: { planFilePath: "local://PLAN.md" } } : {}),
+	};
+	const file = path.join(dir, name);
+	fs.writeFileSync(file, `${JSON.stringify(header)}\n${JSON.stringify(modeChange)}\n`, "utf8");
+	return file;
+}
+
+describe("rpc session modes (headless controller)", () => {
+	let ctx: TestSessionContext;
+
+	beforeEach(async () => {
+		ctx = await createTestSession({ vibeTools: true });
+	});
+
+	afterEach(async () => {
+		await ctx.cleanup();
+	});
+
+	test("starts in none mode", () => {
+		expect(getSessionMode(ctx.session)).toBe("none");
+	});
+
+	test("set_mode plan enters plan mode, persists mode_change, and resets on none", async () => {
+		expect(await setSessionMode(ctx.session, "plan")).toBe("plan");
+		expect(getSessionMode(ctx.session)).toBe("plan");
+		expect(ctx.session.getPlanModeState()?.enabled).toBe(true);
+		expect(ctx.session.peekPlanProposalHandler()).toBeDefined();
+
+		const modeEntries = ctx.sessionManager.getEntries().filter(isModeChangeEntry);
+		expect(modeEntries.at(-1)?.mode).toBe("plan");
+
+		expect(await setSessionMode(ctx.session, "none")).toBe("none");
+		expect(ctx.session.getPlanModeState()).toBeUndefined();
+		expect(ctx.session.peekPlanProposalHandler()).toBeUndefined();
+		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("none");
+	});
+
+	test("set_mode enforces mutual exclusion (exit-first semantics)", async () => {
+		await setSessionMode(ctx.session, "plan");
+		await expect(setSessionMode(ctx.session, "goal", "Ship it")).rejects.toThrow(/Exit plan mode first/);
+		await expect(setSessionMode(ctx.session, "vibe")).rejects.toThrow(/Exit plan mode first/);
+		expect(getSessionMode(ctx.session)).toBe("plan");
+
+		await setSessionMode(ctx.session, "none");
+		await setSessionMode(ctx.session, "vibe");
+		await expect(setSessionMode(ctx.session, "plan")).rejects.toThrow(/Exit vibe mode first/);
+		expect(getSessionMode(ctx.session)).toBe("vibe");
+	});
+
+	test("set_mode goal requires an objective", async () => {
+		await expect(setSessionMode(ctx.session, "goal")).rejects.toThrow(/requires an objective/);
+		expect(getSessionMode(ctx.session)).toBe("none");
+
+		expect(await setSessionMode(ctx.session, "goal", "Write a haiku")).toBe("goal");
+		expect(ctx.session.getGoalModeState()?.goal.objective).toBe("Write a haiku");
+		expect(getSessionMode(ctx.session)).toBe("goal");
+	});
+
+	test("set_mode vibe enters and exits vibe mode", async () => {
+		expect(await setSessionMode(ctx.session, "vibe")).toBe("vibe");
+		expect(ctx.session.getVibeModeState()?.enabled).toBe(true);
+		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("vibe");
+
+		expect(await setSessionMode(ctx.session, "none")).toBe("none");
+		expect(ctx.session.getVibeModeState()).toBeUndefined();
+		expect(ctx.sessionManager.getEntries().filter(isModeChangeEntry).at(-1)?.mode).toBe("none");
+	});
+
+	test("switch_session restores the persisted mode (reconcile hooks)", async () => {
+		// Plan session file and a fresh "none" file.
+		const planFile = writeSessionFile(ctx.tempDir, `plan-${Snowflake.next()}.jsonl`, "plan");
+		const freshFile = writeSessionFile(ctx.tempDir, `fresh-${Snowflake.next()}.jsonl`, "none");
+
+		// Install the same hooks rpc-mode.ts installs.
+		ctx.session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(ctx.session));
+		ctx.session.setSessionSwitchReconciler(() => reconcileSessionMode(ctx.session));
+
+		await ctx.session.switchSession(freshFile);
+		expect(getSessionMode(ctx.session)).toBe("none");
+
+		await ctx.session.switchSession(planFile);
+		expect(getSessionMode(ctx.session)).toBe("plan");
+		expect(ctx.session.getPlanModeState()?.enabled).toBe(true);
+
+		await ctx.session.switchSession(freshFile);
+		expect(getSessionMode(ctx.session)).toBe("none");
+		expect(ctx.session.getPlanModeState()).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/rpc-modes.test.ts
+++ b/packages/coding-agent/test/rpc-modes.test.ts
@@ -11,7 +11,7 @@ const isModeChangeEntry = (entry: SessionEntry): entry is Extract<SessionEntry, 
 
 /** Minimal persisted session file: header + one mode_change entry. */
 function writeSessionFile(dir: string, name: string, mode: "plan" | "vibe" | "goal" | "none"): string {
-	const sessionId = Snowflake.next().toString();
+	const sessionId = Snowflake.next().slice(0, 16);
 	const header = {
 		type: "session",
 		version: 3,
@@ -27,6 +27,21 @@ function writeSessionFile(dir: string, name: string, mode: "plan" | "vibe" | "go
 		timestamp: new Date().toISOString(),
 		mode,
 		...(mode === "plan" ? { data: { planFilePath: "local://PLAN.md" } } : {}),
+		...(mode === "goal"
+			? {
+					data: {
+						goal: {
+							id: Snowflake.next(),
+							objective: "Do the thing",
+							status: "active",
+							tokensUsed: 0,
+							timeUsedSeconds: 0,
+							createdAt: Date.now(),
+							updatedAt: Date.now(),
+						},
+					},
+				}
+			: {}),
 	};
 	const file = path.join(dir, name);
 	fs.writeFileSync(file, `${JSON.stringify(header)}\n${JSON.stringify(modeChange)}\n`, "utf8");
@@ -131,5 +146,25 @@ describe("rpc session modes (headless controller)", () => {
 		await ctx.session.switchSession(freshFile);
 		expect(getSessionMode(ctx.session)).toBe("none");
 		expect(ctx.session.getPlanModeState()).toBeUndefined();
+	});
+
+	test("switch_session preserves an active goal instead of pausing it", async () => {
+		const goalFile = writeSessionFile(ctx.tempDir, `goal-${Snowflake.next()}.jsonl`, "goal");
+		const freshFile = writeSessionFile(ctx.tempDir, `fresh-${Snowflake.next()}.jsonl`, "none");
+
+		ctx.session.setSessionBeforeSwitchReconciler(() => suspendSessionMode(ctx.session));
+		ctx.session.setSessionSwitchReconciler(() => reconcileSessionMode(ctx.session));
+
+		await ctx.session.switchSession(goalFile);
+		expect(getSessionMode(ctx.session)).toBe("goal");
+		expect(ctx.session.getGoalModeState()?.goal.status).toBe("active");
+
+		// Switching away and back must not convert the active goal to goal_paused
+		// (GoalRuntime.onThreadResumed without preserveActiveGoal does exactly that).
+		await ctx.session.switchSession(freshFile);
+		expect(getSessionMode(ctx.session)).toBe("none");
+		await ctx.session.switchSession(goalFile);
+		expect(getSessionMode(ctx.session)).toBe("goal");
+		expect(ctx.session.getGoalModeState()?.goal.status).toBe("active");
 	});
 });

--- a/packages/coding-agent/test/rpc-set-mode.test.ts
+++ b/packages/coding-agent/test/rpc-set-mode.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { e2eApiKey } from "./utilities";
+
+/**
+ * RPC `set_mode` end-to-end: the client drives a real `--mode rpc` CLI
+ * process. Skipped without ANTHROPIC_API_KEY (same as the rest of rpc.test.ts).
+ */
+describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("RPC set_mode", () => {
+	let client: RpcClient;
+	let sessionDir: string;
+
+	beforeEach(() => {
+		sessionDir = path.join(os.tmpdir(), `omp-rpc-set-mode-${Snowflake.next()}`);
+		client = new RpcClient({
+			cliPath: path.join(import.meta.dir, "..", "dist", "cli.js"),
+			cwd: path.join(import.meta.dir, ".."),
+			env: { PI_CODING_AGENT_DIR: sessionDir },
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+		});
+	});
+
+	afterEach(async () => {
+		client.stop();
+		if (sessionDir && fs.existsSync(sessionDir)) {
+			removeSyncWithRetries(sessionDir);
+		}
+	});
+
+	test("set_mode toggles plan mode and persists mode_change entries", async () => {
+		await client.start();
+		expect((await client.getState()).mode).toBe("none");
+
+		expect(await client.setMode("plan")).toBe("plan");
+		const state = await client.getState();
+		expect(state.mode).toBe("plan");
+		expect(state.sessionFile).toBeDefined();
+
+		expect(await client.setMode("none")).toBe("none");
+		expect((await client.getState()).mode).toBe("none");
+	}, 60000);
+
+	test("set_mode rejects goal without an objective and enforces mutual exclusion", async () => {
+		await client.start();
+
+		await expect(client.setMode("goal")).rejects.toThrow(/requires an objective/);
+		expect(await client.setMode("goal", "Write a haiku")).toBe("goal");
+		expect((await client.getState()).mode).toBe("goal");
+
+		await expect(client.setMode("plan")).rejects.toThrow(/Exit goal mode first/);
+		expect((await client.getState()).mode).toBe("goal");
+
+		expect(await client.setMode("none")).toBe("none");
+		expect((await client.getState()).mode).toBe("none");
+	}, 60000);
+
+	test("switch_session restores the persisted mode", async () => {
+		await client.start();
+		expect(await client.setMode("plan")).toBe("plan");
+		const planSessionFile = (await client.getState()).sessionFile!;
+
+		// A fresh session has no mode chain.
+		await client.newSession();
+		expect((await client.getState()).mode).toBe("none");
+
+		// Switching back to the plan session restores plan mode.
+		await client.switchSession(planSessionFile);
+		expect((await client.getState()).mode).toBe("plan");
+	}, 60000);
+});

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -654,3 +654,44 @@ describe("parseSkillInvocation", () => {
 		});
 	});
 });
+
+describe("worktree project skills", () => {
+	// `autolearn.skillLocation: "project"` mints into the primary checkout's
+	// .omp/skills; sessions in linked worktrees must still discover them.
+	const git = (cwd: string, args: string[]) => {
+		const proc = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+		if (proc.exitCode !== 0) throw new Error(`git ${args[0]} failed: ${proc.stderr.toString()}`);
+	};
+
+	it("discovers primary-checkout .omp/skills from a linked worktree only", async () => {
+		// realpath: git reports resolved paths, macOS tmpdirs sit behind /var.
+		const base = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "omp-wt-skills-")));
+		const main = path.join(base, "repo");
+		const worktree = path.join(base, "repo-wt");
+		const outsider = path.join(base, "outsider");
+		try {
+			await fs.mkdir(main, { recursive: true });
+			git(main, ["init", "-b", "main"]);
+			git(main, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"]);
+			const skillDir = path.join(main, ".omp", "skills", "worktree-scoped");
+			await fs.mkdir(skillDir, { recursive: true });
+			await Bun.write(
+				path.join(skillDir, "SKILL.md"),
+				"---\nname: worktree-scoped\ndescription: scoped to the repo\n---\n\nbody\n",
+			);
+			git(main, ["worktree", "add", worktree, "-b", "wt"]);
+			await fs.mkdir(outsider, { recursive: true });
+			git(outsider, ["init", "-b", "main"]);
+
+			const onlyPiProject = { ...DISABLE_ALL_BUILTIN_SKILLS, enablePiProject: true };
+			const fromWorktree = await loadSkills({ ...onlyPiProject, cwd: worktree });
+			expect(fromWorktree.skills.some(s => s.name === "worktree-scoped")).toBe(true);
+			const fromMain = await loadSkills({ ...onlyPiProject, cwd: main });
+			expect(fromMain.skills.some(s => s.name === "worktree-scoped")).toBe(true);
+			const fromOutside = await loadSkills({ ...onlyPiProject, cwd: outsider });
+			expect(fromOutside.skills.some(s => s.name === "worktree-scoped")).toBe(false);
+		} finally {
+			await removeWithRetries(base);
+		}
+	});
+});

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -14,6 +14,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { createVibeTools } from "@oh-my-pi/pi-coding-agent/tools/vibe";
 import { Snowflake } from "@oh-my-pi/pi-utils";
 import { e2eApiKey } from "../../ai/test/oauth";
 
@@ -31,6 +32,8 @@ export interface TestSessionOptions {
 	settingsOverrides?: Record<string, unknown>;
 	/** Extension runner to wire into the session (e.g. to stub `session_before_tree`/etc. hooks) */
 	extensionRunner?: ExtensionRunner;
+	/** Wire the ephemeral vibe tool factory (`vibe_spawn` etc.), needed to enter vibe mode. */
+	vibeTools?: boolean;
 	/** Secret obfuscator to wire into the session (e.g. to test deobfuscation of persisted tool arguments) */
 	obfuscator?: SecretObfuscator;
 }
@@ -116,6 +119,7 @@ export async function createTestSession(options: TestSessionOptions = {}): Promi
 		modelRegistry,
 		extensionRunner: options.extensionRunner,
 		obfuscator: options.obfuscator,
+		createVibeTools: options.vibeTools ? () => createVibeTools(toolSession) : undefined,
 	});
 
 	// Must subscribe to enable session persistence

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -34,6 +34,9 @@ export interface TestSessionOptions {
 	extensionRunner?: ExtensionRunner;
 	/** Wire the ephemeral vibe tool factory (`vibe_spawn` etc.), needed to enter vibe mode. */
 	vibeTools?: boolean;
+	/** Populate the session's tool registry from the created tools, so
+	 *  `setActiveToolsByName` / `activateVibeTools` can restore toolsets. */
+	wireToolRegistry?: boolean;
 	/** Secret obfuscator to wire into the session (e.g. to test deobfuscation of persisted tool arguments) */
 	obfuscator?: SecretObfuscator;
 }
@@ -94,6 +97,7 @@ export async function createTestSession(options: TestSessionOptions = {}): Promi
 		settings: Settings.isolated(options.settingsOverrides),
 	};
 	const tools = await createTools(toolSession);
+	const toolRegistry = options.wireToolRegistry ? new Map(tools.map(tool => [tool.name, tool])) : undefined;
 
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 	const agent = new Agent({
@@ -119,6 +123,8 @@ export async function createTestSession(options: TestSessionOptions = {}): Promi
 		modelRegistry,
 		extensionRunner: options.extensionRunner,
 		obfuscator: options.obfuscator,
+		toolRegistry,
+		builtInToolNames: options.wireToolRegistry ? tools.map(tool => tool.name) : undefined,
 		createVibeTools: options.vibeTools ? () => createVibeTools(toolSession) : undefined,
 	});
 


### PR DESCRIPTION
## Summary

Partially addresses #4067 (the "relocate into `<repo>/.omp/skills`" mechanism, made first-class).

Auto-learn currently mints every managed skill into the global `~/.omp/agent/managed-skills`, which the unconditional `omp-managed` provider then injects into **every** session's system prompt. Users who auto-learn repo-specific procedures end up with a large, mostly-irrelevant skill list in every other repo.

This PR adds an opt-in `autolearn.skillLocation` setting (`global` | `project`, default `global`):

- **`project`**: `learn` / `manage_skill` mint into the repo's `.omp/skills` at the **primary checkout** (`repo.primaryRoot(cwd)`), so the skill is discovered by the existing native project-skill mechanism and only loads for sessions in that repository.
- **Worktree visibility**: `loadSkills` now also scans the primary checkout's `.omp/skills`, since linked worktrees are not ancestors of the primary root and would otherwise miss skills minted there (and vice versa).
- **Update/delete follow the existing copy**: `resolveSkillWriteRoot` returns the project dir for creates, but for update/delete of a skill that only exists globally it returns the global dir — editing in place instead of failing or silently relocating.

`global` (the default) is unchanged, so existing setups see zero behavior change.

## Test plan

- `test/autolearn-managed-skills.test.ts`: `rootDir` override honored by `writeManagedSkill`/`deleteManagedSkill`; `resolveProjectSkillsDir` anchors at the primary checkout from a linked worktree and falls back to cwd outside a repo; `resolveSkillWriteRoot` routing (global create, project create, global-only update stays global, project copy stays in project).
- `test/skills.test.ts`: end-to-end `loadSkills` from a linked worktree discovers the primary checkout's `.omp/skills`; an unrelated repo does not.
- `bunx tsc --noEmit` clean; biome clean.

Note: three pre-existing `skills.test.ts` failures (`loadSkills with options` leakage) reproduce on clean HEAD whenever the real `~/.omp/agent/managed-skills` is non-empty — unrelated to this change, and itself a symptom of #4067.
