### PR TITLE
fix(discovery): honor non-recursive glob in loadFilesFromDir

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom-tool and other directory discovery recursing into subtrees despite a non-recursive default: `loadFilesFromDir` built a top-level-only glob pattern but never forwarded its `recursive` flag to the native glob (which defaults to recursive), so `~/.codex/tools` scans descended into a Python venv's `site-packages` and imported browser-only frontend assets as tools, crashing startup on an unhandled `window` rejection ([#8552](https://github.com/can1357/oh-my-pi/issues/8552)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -512,6 +512,11 @@ export async function loadFilesFromDir<T>(
 			gitignore: true,
 			hidden: false,
 			fileType: FileType.File,
+			// Thread the caller's non-recursive intent explicitly: the native glob
+			// defaults `recursive` to true and rewrites `*.{ts,js}` -> `**/*.{ts,js}`,
+			// which would walk the entire subtree (e.g. a venv's site-packages under
+			// ~/.codex/tools) and import arbitrary frontend assets as tools (#8552).
+			recursive,
 		});
 		matches = result.matches;
 	} catch {

--- a/packages/coding-agent/test/discovery/helpers.test.ts
+++ b/packages/coding-agent/test/discovery/helpers.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, test } from "bun:test";
-import { parseFrontmatter } from "@oh-my-pi/pi-utils";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import type { LoadContext } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { loadFilesFromDir } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { parseFrontmatter, removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 describe("parseFrontmatter", () => {
 	const parse = (content: string) => parseFrontmatter(content, { source: "tests:frontmatter", level: "off" });
@@ -145,5 +151,55 @@ Body content`;
 			nestedField: { innerKey: "value" },
 		});
 		expect(result.body).toBe("Body content");
+	});
+});
+
+describe("loadFilesFromDir recursion", () => {
+	let tempDir!: string;
+	let ctx!: LoadContext;
+
+	const write = (rel: string, content: string) => {
+		const full = path.join(tempDir, rel);
+		fs.mkdirSync(path.dirname(full), { recursive: true });
+		fs.writeFileSync(full, content);
+	};
+
+	beforeEach(() => {
+		clearCache();
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-loadfiles-recursion-"));
+		ctx = { cwd: tempDir, home: tempDir, repoRoot: tempDir };
+		// Top-level tool plus a Python-venv-style frontend asset nested below it,
+		// mirroring the ~/.codex/tools/mineru/Lib/site-packages layout from #8552.
+		write("my-tool.ts", "export default () => ({});\n");
+		write(
+			path.join("mineru", "Lib", "site-packages", "gradio", "assets", "svelte", "media-query-D37ajmZt.js"),
+			"window.matchMedia;\n",
+		);
+	});
+
+	afterEach(() => {
+		clearCache();
+		removeSyncWithRetries(tempDir);
+	});
+
+	const names = (dir: string, recursive?: boolean) =>
+		loadFilesFromDir<{ name: string }>(ctx, dir, "test", "user", {
+			extensions: ["ts", "js"],
+			recursive,
+			transform: (_name, _content, filePath) => ({ name: path.relative(dir, filePath) }),
+		}).then(r => r.items.map(i => i.name).sort());
+
+	// Regression for #8552: the non-recursive default must NOT descend into the
+	// venv subtree. The native glob defaults recursive=true, so before the fix
+	// `*.{ts,js}` was rewritten to `**/*.{ts,js}` and imported the Svelte asset.
+	test("default scan stays top-level and skips the venv subtree", async () => {
+		expect(await names(tempDir)).toEqual(["my-tool.ts"]);
+	});
+
+	test("recursive:true still walks the whole subtree", async () => {
+		expect(await names(tempDir, true)).toEqual([
+			path.join("mineru", "Lib", "site-packages", "gradio", "assets", "svelte", "media-query-D37ajmZt.js"),
+			"my-tool.ts",
+		]);
 	});
 });


### PR DESCRIPTION
## Repro
On a machine with the Codex integration enabled and a Python venv under `~/.codex/tools` (e.g. `py -m venv ~/.codex/tools/mineru` then `pip install gradio`), `omp` crashes before the TUI appears. Custom-tool discovery walks the venv's `Lib/site-packages/gradio/.../assets/svelte/*.js` and imports browser-only Svelte modules; one dereferences `window`, producing an unhandled rejection that kills startup. Minimal repro: call `loadFilesFromDir(root, { extensions: ['ts','js'] })` against a tree with a top-level `my-tool.ts` and a nested `mineru/Lib/site-packages/.../media-query-D37ajmZt.js` — the nested asset is discovered despite the non-recursive default.

## Cause
`packages/coding-agent/src/discovery/helpers.ts` `loadFilesFromDir` computes a `recursive` flag (documented default `false`) and builds a top-level-only glob pattern (`*.{ts,js}`), but never forwards `recursive` to the native `glob()` call. `crates/pi-natives/src/glob.rs:286` defaults `recursive` to `true` when omitted, and `glob_util.rs` `build_glob_pattern` then rewrites `*.{ts,js}` → `**/*.{ts,js}`, so every "non-recursive" discovery scan walks the entire subtree. For codex custom tools this descends into the venv and hands each `.js` to `custom-tools/loader.ts`, whose dynamic `import()` triggers the fatal `window` rejection (escapes the loader's try/catch as a floating async rejection, hits the postmortem handler).

## Fix
- Thread the caller's `recursive` flag through to the native `glob()` call in `loadFilesFromDir`, so the documented non-recursive default is honored across all discovery providers. Providers that need recursion (e.g. `github.ts`, `claude.ts` commands) already pass `recursive: true` explicitly and are unaffected.
- Added a regression test in `test/discovery/helpers.test.ts` asserting the default scan stays top-level (skips the `mineru/Lib/site-packages` subtree) while `recursive: true` still walks it.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/discovery test/extensibility/custom-tool-loader.test.ts` → 249 pass, 0 fail (after `bun run gen:tool-views` to produce the codegen artifact those suites import). New regression test fails before the fix (discovers the nested asset) and passes after. Fixes #8552