### PR TITLE
feat(coding-agent): collapse fully-covered /usage model list into a one-line summary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Fixed Streamable HTTP MCP sessions being invalidated by opening the optional GET SSE stream before sending `notifications/initialized`, which prevented Figma Dev Mode MCP from connecting ([#8514](https://github.com/can1357/oh-my-pi/issues/8514)).
 - Fixed the `/hotkeys` table describing Ctrl+D (`app.exit`) as "Exit (when editor is empty)" when it actually exits unconditionally and saves the current prompt as a resumable draft ([#8530](https://github.com/can1357/oh-my-pi/issues/8530)).
 - Fixed Ctrl+G external editors failing to launch on Windows because Bun re-quoted the embedded `cmd.exe /c` command line ([#8544](https://github.com/can1357/oh-my-pi/issues/8544)).
+### Changed
+
+- `/usage` now collapses the per-provider "Models with usage data" list into a one-line summary when usage data covers every available model — the common case for account-wide coding-plan quotas — so the quota bars stay visible in the height-capped mid-turn preview. The explicit per-model list still renders when only a subset of available models reports usage data.
 
 ## [17.3.3] - 2026-08-14
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `/usage` now collapses the per-provider "Models with usage data" list into a one-line summary when usage data covers every available model — the common case for account-wide coding-plan quotas — so the quota bars stay visible in the height-capped mid-turn preview. The explicit per-model list still renders when only a subset of available models reports usage data.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed
@@ -14,9 +18,6 @@
 - Fixed Streamable HTTP MCP sessions being invalidated by opening the optional GET SSE stream before sending `notifications/initialized`, which prevented Figma Dev Mode MCP from connecting ([#8514](https://github.com/can1357/oh-my-pi/issues/8514)).
 - Fixed the `/hotkeys` table describing Ctrl+D (`app.exit`) as "Exit (when editor is empty)" when it actually exits unconditionally and saves the current prompt as a resumable draft ([#8530](https://github.com/can1357/oh-my-pi/issues/8530)).
 - Fixed Ctrl+G external editors failing to launch on Windows because Bun re-quoted the embedded `cmd.exe /c` command line ([#8544](https://github.com/can1357/oh-my-pi/issues/8544)).
-### Changed
-
-- `/usage` now collapses the per-provider "Models with usage data" list into a one-line summary when usage data covers every available model — the common case for account-wide coding-plan quotas — so the quota bars stay visible in the height-capped mid-turn preview. The explicit per-model list still renders when only a subset of available models reports usage data.
 
 ## [17.3.3] - 2026-08-14
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -40,7 +40,7 @@ import type { InteractiveModeContext } from "../../modes/types";
 import { computeContextBreakdown, renderContextUsage } from "../../modes/utils/context-usage";
 import { buildHotkeysMarkdown } from "../../modes/utils/hotkeys-markdown";
 import { buildToolsMarkdown } from "../../modes/utils/tools-markdown";
-import type { AsyncJobSnapshotItem } from "../../session/agent-session";
+import type { AsyncJobSnapshotItem, UsageModelCoverage } from "../../session/agent-session";
 import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-storage";
 import type { CompactMode } from "../../session/compact-modes";
 import type { NewSessionOptions } from "../../session/session-entries";
@@ -549,14 +549,14 @@ export class CommandController {
 					this.ctx.session.sessionId,
 				)
 			: undefined;
-		const usageModelSelectors = this.ctx.session.getUsageReportingModelSelectors(usageReports);
+		const usageModelCoverage = this.ctx.session.getUsageReportingModelCoverage(usageReports);
 		const output = renderUsageReports(
 			usageReports,
 			theme,
 			Date.now(),
 			availableWidth,
 			provider => (provider === currentProvider ? activeAccount : undefined),
-			usageModelSelectors,
+			usageModelCoverage,
 		);
 		this.ctx.presentCommandOutput([new Spacer(1), new Text(output, 1, 0)]);
 	}
@@ -1829,7 +1829,7 @@ export function renderUsageReports(
 	nowMs: number,
 	availableWidth: number,
 	resolveActiveAccount?: (provider: string) => OAuthAccountIdentity | undefined,
-	usageModelSelectors: readonly string[] = [],
+	usageModelCoverage: ReadonlyMap<string, UsageModelCoverage> = new Map(),
 ): string {
 	const lines: string[] = [];
 	const latestFetchedAt = Math.max(...reports.map(report => report.fetchedAt ?? 0));
@@ -1883,11 +1883,17 @@ export function renderUsageReports(
 		if (activeAccountLabel) {
 			lines.push(`  ${uiTheme.fg("accent", "in use by this session:")} ${activeAccountLabel}`);
 		}
-		const reportingModels = usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`));
-		if (reportingModels.length > 0) {
-			lines.push(`  ${uiTheme.fg("accent", "Models with usage data")}`);
-			for (const selector of reportingModels) {
-				lines.push(`    ${replaceTabs(truncateToWidth(sanitizeText(selector), availableWidth - 4))}`);
+		const coverage = usageModelCoverage.get(provider);
+		if (coverage && coverage.reporting.length > 0) {
+			if (coverage.reporting.length >= coverage.availableCount) {
+				const count = coverage.availableCount;
+				const summary = `Usage data covers all ${count} available model${count === 1 ? "" : "s"}`;
+				lines.push(`  ${uiTheme.fg("dim", truncateToWidth(summary, availableWidth - 2))}`);
+			} else {
+				lines.push(`  ${uiTheme.fg("accent", "Models with usage data")}`);
+				for (const selector of coverage.reporting) {
+					lines.push(`    ${replaceTabs(truncateToWidth(sanitizeText(selector), availableWidth - 4))}`);
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -106,6 +106,14 @@ export interface UsageFallbackConfirmation {
  */
 export type UsageFallbackConfirmer = (confirmation: UsageFallbackConfirmation, signal: AbortSignal) => Promise<boolean>;
 
+/** Per-provider coverage of available models by live quantitative usage data. */
+export interface UsageModelCoverage {
+	/** Sorted `provider/modelId` selectors whose usage maps to a quantitative scope. */
+	reporting: string[];
+	/** Distinct available models for the provider in the model registry. */
+	availableCount: number;
+}
+
 /** Identifies a retry fallback chain already entered during startup model resolution. */
 export interface InitialRetryFallbackState {
 	/** Role whose configured primary was unavailable. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -339,6 +339,7 @@ import type { ShakeMode, ShakeResult } from "./shake-types";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { planTurnPersistence, sameMessageContent, sessionMessagePersistenceKey } from "./turn-persistence";
 import { TurnRecovery, type TurnRecoveryHost } from "./turn-recovery";
+import { buildUsageModelCoverage } from "./usage-model-coverage";
 import { YieldQueue } from "./yield-queue";
 
 export * from "./agent-session-events";
@@ -8646,26 +8647,9 @@ export class AgentSession {
 
 	/** Per-provider coverage of available models by live quantitative `/usage` scopes. */
 	getUsageReportingModelCoverage(reports: readonly UsageReport[]): Map<string, UsageModelCoverage> {
-		const modelIdsByProvider = new Map<string, Set<string>>();
-		for (const model of this.#modelRegistry.getAvailable()) {
-			const modelIds = modelIdsByProvider.get(model.provider) ?? new Set<string>();
-			modelIds.add(model.id);
-			modelIdsByProvider.set(model.provider, modelIds);
-		}
-		const coverage = new Map<string, UsageModelCoverage>();
-		for (const [provider, modelIds] of modelIdsByProvider) {
-			const reportingIds = this.#modelRegistry.authStorage.getUsageReportingModelIds(
-				provider,
-				[...modelIds],
-				reports,
-			);
-			if (reportingIds.length === 0) continue;
-			const reporting = [...new Set(reportingIds)]
-				.map(modelId => `${provider}/${modelId}`)
-				.sort((left, right) => left.localeCompare(right));
-			coverage.set(provider, { reporting, availableCount: modelIds.size });
-		}
-		return coverage;
+		return buildUsageModelCoverage(this.#modelRegistry.getAvailable(), (provider, modelIds) =>
+			this.#modelRegistry.authStorage.getUsageReportingModelIds(provider, modelIds, reports),
+		);
 	}
 
 	/** List stored OAuth accounts for the current model provider and mark this session's active account. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -234,6 +234,7 @@ import type {
 	SessionOAuthAccountList,
 	SessionStats,
 	UsageFallbackConfirmer,
+	UsageModelCoverage,
 } from "./agent-session-types";
 import {
 	ASYNC_INLINE_RESULT_MAX_CHARS,
@@ -8643,24 +8644,28 @@ export class AgentSession {
 		return reports;
 	}
 
-	/** Models whose live `/usage` reports map to a quantitative provider scope. */
-	getUsageReportingModelSelectors(reports: readonly UsageReport[]): string[] {
-		const modelsByProvider = new Map<string, Model[]>();
+	/** Per-provider coverage of available models by live quantitative `/usage` scopes. */
+	getUsageReportingModelCoverage(reports: readonly UsageReport[]): Map<string, UsageModelCoverage> {
+		const modelIdsByProvider = new Map<string, Set<string>>();
 		for (const model of this.#modelRegistry.getAvailable()) {
-			const models = modelsByProvider.get(model.provider) ?? [];
-			models.push(model);
-			modelsByProvider.set(model.provider, models);
+			const modelIds = modelIdsByProvider.get(model.provider) ?? new Set<string>();
+			modelIds.add(model.id);
+			modelIdsByProvider.set(model.provider, modelIds);
 		}
-		const selectors = new Set<string>();
-		for (const [provider, models] of modelsByProvider) {
-			const modelIds = this.#modelRegistry.authStorage.getUsageReportingModelIds(
+		const coverage = new Map<string, UsageModelCoverage>();
+		for (const [provider, modelIds] of modelIdsByProvider) {
+			const reportingIds = this.#modelRegistry.authStorage.getUsageReportingModelIds(
 				provider,
-				models.map(model => model.id),
+				[...modelIds],
 				reports,
 			);
-			for (const modelId of modelIds) selectors.add(`${provider}/${modelId}`);
+			if (reportingIds.length === 0) continue;
+			const reporting = [...new Set(reportingIds)]
+				.map(modelId => `${provider}/${modelId}`)
+				.sort((left, right) => left.localeCompare(right));
+			coverage.set(provider, { reporting, availableCount: modelIds.size });
 		}
-		return [...selectors].sort((left, right) => left.localeCompare(right));
+		return coverage;
 	}
 
 	/** List stored OAuth accounts for the current model provider and mark this session's active account. */

--- a/packages/coding-agent/src/session/usage-model-coverage.ts
+++ b/packages/coding-agent/src/session/usage-model-coverage.ts
@@ -1,0 +1,31 @@
+import type { UsageModelCoverage } from "./agent-session-types";
+
+/**
+ * Build the per-provider coverage of available models by live quantitative
+ * usage data. `resolveReportingIds` returns the subset of `modelIds` whose
+ * usage maps to a quantitative scope for the provider (AuthStorage's
+ * `getUsageReportingModelIds`). Providers with no reporting model are omitted;
+ * duplicate registry entries and duplicate reporting ids count once, so a
+ * fully-covered provider cannot be misread as partially covered.
+ */
+export function buildUsageModelCoverage<P extends string>(
+	models: ReadonlyArray<{ provider: P; id: string }>,
+	resolveReportingIds: (provider: P, modelIds: string[]) => readonly string[],
+): Map<string, UsageModelCoverage> {
+	const modelIdsByProvider = new Map<P, Set<string>>();
+	for (const model of models) {
+		const modelIds = modelIdsByProvider.get(model.provider) ?? new Set<string>();
+		modelIds.add(model.id);
+		modelIdsByProvider.set(model.provider, modelIds);
+	}
+	const coverage = new Map<string, UsageModelCoverage>();
+	for (const [provider, modelIds] of modelIdsByProvider) {
+		const reportingIds = resolveReportingIds(provider, [...modelIds]);
+		if (reportingIds.length === 0) continue;
+		const reporting = [...new Set(reportingIds)]
+			.map(modelId => `${provider}/${modelId}`)
+			.sort((left, right) => left.localeCompare(right));
+		coverage.set(provider, { reporting, availableCount: modelIds.size });
+	}
+	return coverage;
+}

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -1,5 +1,6 @@
 import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
+import type { UsageModelCoverage } from "../../session/agent-session-types";
 import type { OAuthAccountIdentity } from "../../session/auth-storage";
 import type { SlashCommandRuntime } from "../types";
 import { reportMatchesActiveAccount } from "./active-oauth-account";
@@ -63,7 +64,7 @@ function renderUsageReports(
 	reports: UsageReport[],
 	nowMs: number,
 	resolveActiveAccount?: (provider: string) => OAuthAccountIdentity | undefined,
-	usageModelSelectors: readonly string[] = [],
+	usageModelCoverage: ReadonlyMap<string, UsageModelCoverage> = new Map(),
 ): string {
 	const latestFetchedAt = Math.max(...reports.map(report => report.fetchedAt ?? 0));
 	const lines = [`Usage${latestFetchedAt ? ` (${formatDuration(nowMs - latestFetchedAt)} ago)` : ""}`];
@@ -78,10 +79,15 @@ function renderUsageReports(
 		left.localeCompare(right),
 	)) {
 		lines.push("", formatProviderName(provider));
-		const reportingModels = usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`));
-		if (reportingModels.length > 0) {
-			lines.push("  Models with usage data");
-			for (const selector of reportingModels) lines.push(`    ${sanitizeText(selector)}`);
+		const coverage = usageModelCoverage.get(provider);
+		if (coverage && coverage.reporting.length > 0) {
+			if (coverage.reporting.length >= coverage.availableCount) {
+				const count = coverage.availableCount;
+				lines.push(`  Usage data covers all ${count} available model${count === 1 ? "" : "s"}`);
+			} else {
+				lines.push("  Models with usage data");
+				for (const selector of coverage.reporting) lines.push(`    ${sanitizeText(selector)}`);
+			}
 		}
 		const activeAccount = resolveActiveAccount?.(provider);
 		// Provider-wide disclaimers render once per provider, not per limit.
@@ -160,7 +166,7 @@ function renderUsageReports(
 export async function buildUsageReportText(runtime: SlashCommandRuntime): Promise<string> {
 	const provider = runtime.session as SlashCommandRuntime["session"] & {
 		fetchUsageReports?: () => Promise<UsageReport[] | null>;
-		getUsageReportingModelSelectors?: (reports: readonly UsageReport[]) => string[];
+		getUsageReportingModelCoverage?: (reports: readonly UsageReport[]) => Map<string, UsageModelCoverage>;
 	};
 	if (provider.fetchUsageReports) {
 		const reports = await provider.fetchUsageReports();
@@ -172,12 +178,13 @@ export async function buildUsageReportText(runtime: SlashCommandRuntime): Promis
 						runtime.session.sessionId,
 					)
 				: undefined;
-			const usageModelSelectors = provider.getUsageReportingModelSelectors?.(reports) ?? [];
+			const usageModelCoverage =
+				provider.getUsageReportingModelCoverage?.(reports) ?? new Map<string, UsageModelCoverage>();
 			return renderUsageReports(
 				reports,
 				Date.now(),
 				providerId => (providerId === currentProvider ? activeAccount : undefined),
-				usageModelSelectors,
+				usageModelCoverage,
 			);
 		}
 	}

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -21,7 +21,7 @@ function renderPresentedBlocks(value: unknown): string {
 }
 
 function createUsageSessionDouble() {
-	return { getUsageReportingModelSelectors: () => [] };
+	return { getUsageReportingModelCoverage: () => new Map() };
 }
 
 describe("CommandController /usage", () => {

--- a/packages/coding-agent/test/pr-3318-repro.test.ts
+++ b/packages/coding-agent/test/pr-3318-repro.test.ts
@@ -21,7 +21,8 @@ describe("PR 3318 repro", () => {
 			session: {
 				model: undefined,
 				fetchUsageReports: async () => [report],
-				getUsageReportingModelSelectors: () => ["test-provider/coding-plan-model"],
+				getUsageReportingModelCoverage: () =>
+					new Map([["test-provider", { reporting: ["test-provider/coding-plan-model"], availableCount: 2 }]]),
 			},
 		} as never);
 

--- a/packages/coding-agent/test/usage-model-coverage.test.ts
+++ b/packages/coding-agent/test/usage-model-coverage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { buildUsageModelCoverage } from "@oh-my-pi/pi-coding-agent/session/usage-model-coverage";
+
+describe("buildUsageModelCoverage", () => {
+	it("maps full and partial coverage per provider and omits non-reporting providers", () => {
+		const models = [
+			{ provider: "anthropic", id: "claude-a" },
+			{ provider: "anthropic", id: "claude-b" },
+			{ provider: "antigravity", id: "claude-x" },
+			{ provider: "antigravity", id: "gemini-y" },
+			{ provider: "keyless", id: "local-model" },
+		];
+		const coverage = buildUsageModelCoverage(models, (provider, modelIds) => {
+			if (provider === "anthropic") return modelIds; // account-wide quota: every model reports
+			if (provider === "antigravity") return modelIds.filter(id => id.startsWith("claude-"));
+			return []; // no usage endpoint
+		});
+
+		// Full coverage: reporting length equals availableCount, so renderers collapse.
+		expect(coverage.get("anthropic")).toEqual({
+			reporting: ["anthropic/claude-a", "anthropic/claude-b"],
+			availableCount: 2,
+		});
+		// Partial coverage: the uncovered model keeps the provider below full coverage.
+		expect(coverage.get("antigravity")).toEqual({
+			reporting: ["antigravity/claude-x"],
+			availableCount: 2,
+		});
+		// A provider with no quantitative mapping is omitted, not reported as empty.
+		expect(coverage.has("keyless")).toBe(false);
+	});
+
+	it("counts duplicate registry entries once and dedupes/sorts duplicate reporting ids", () => {
+		// A duplicate registry row must not inflate availableCount past the
+		// reporting set — that would misrender a fully-covered provider as
+		// partial and resurrect the model-list dump.
+		const models = [
+			{ provider: "openai-codex", id: "gpt-a" },
+			{ provider: "openai-codex", id: "gpt-a" },
+			{ provider: "openai-codex", id: "gpt-b" },
+		];
+		const coverage = buildUsageModelCoverage(models, (_provider, modelIds) => [
+			...[...modelIds].reverse(),
+			...modelIds,
+		]);
+
+		expect(coverage.get("openai-codex")).toEqual({
+			reporting: ["openai-codex/gpt-a", "openai-codex/gpt-b"],
+			availableCount: 2,
+		});
+	});
+});

--- a/packages/coding-agent/test/usage-report-acp-coverage.test.ts
+++ b/packages/coding-agent/test/usage-report-acp-coverage.test.ts
@@ -23,7 +23,10 @@ describe("buildUsageReportText model coverage", () => {
 				fetchUsageReports: async () => [report],
 				getUsageReportingModelCoverage: () =>
 					new Map([
-						["test-provider", { reporting: ["test-provider/model-a", "test-provider/model-b"], availableCount: 2 }],
+						[
+							"test-provider",
+							{ reporting: ["test-provider/model-a", "test-provider/model-b"], availableCount: 2 },
+						],
 					]),
 			},
 		} as never);

--- a/packages/coding-agent/test/usage-report-acp-coverage.test.ts
+++ b/packages/coding-agent/test/usage-report-acp-coverage.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import type { UsageReport } from "@oh-my-pi/pi-ai";
+import { buildUsageReportText } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/usage-report";
+
+describe("buildUsageReportText model coverage", () => {
+	it("collapses to a one-line summary when usage data covers every available model", async () => {
+		const report: UsageReport = {
+			provider: "test-provider",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "daily",
+					label: "Daily",
+					scope: { provider: "test-provider" },
+					amount: { used: 1, usedFraction: 0.1, unit: "requests" },
+				},
+			],
+			metadata: { email: "acct@example.test" },
+		};
+		const text = await buildUsageReportText({
+			session: {
+				model: undefined,
+				fetchUsageReports: async () => [report],
+				getUsageReportingModelCoverage: () =>
+					new Map([
+						["test-provider", { reporting: ["test-provider/model-a", "test-provider/model-b"], availableCount: 2 }],
+					]),
+			},
+		} as never);
+
+		expect(text).toContain("Usage data covers all 2 available models");
+		expect(text).not.toContain("Models with usage data");
+		expect(text).not.toContain("test-provider/model-a");
+	});
+});

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -69,15 +69,36 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(occurrences).toBe(1);
 	});
 
-	it("lists every model mapped to the provider's live usage data", () => {
+	it("lists mapped models only while some available models lack usage data", () => {
 		const reports = [
 			report("github-copilot", "acct@example.test", [limit("Copilot", "monthly", 30 * 24 * HOUR, 0.4)]),
 		];
-		const models = ["github-copilot/gpt-5.6", "github-copilot/claude-sonnet-4.6"];
-		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120, undefined, models));
+		const coverage = new Map([
+			[
+				"github-copilot",
+				{ reporting: ["github-copilot/claude-sonnet-4.6", "github-copilot/gpt-5.6"], availableCount: 3 },
+			],
+		]);
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120, undefined, coverage));
 		expect(text).toContain("Models with usage data");
-		expect(text).toContain(models[0]);
-		expect(text).toContain(models[1]);
+		expect(text).toContain("github-copilot/claude-sonnet-4.6");
+		expect(text).toContain("github-copilot/gpt-5.6");
+	});
+
+	it("collapses to a one-line summary when usage data covers every available model", () => {
+		const reports = [
+			report("github-copilot", "acct@example.test", [limit("Copilot", "monthly", 30 * 24 * HOUR, 0.4)]),
+		];
+		const coverage = new Map([
+			[
+				"github-copilot",
+				{ reporting: ["github-copilot/claude-sonnet-4.6", "github-copilot/gpt-5.6"], availableCount: 2 },
+			],
+		]);
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120, undefined, coverage));
+		expect(text).toContain("Usage data covers all 2 available models");
+		expect(text).not.toContain("Models with usage data");
+		expect(text).not.toContain("github-copilot/gpt-5.6");
 	});
 
 	it("deduplicates identical per-limit notes when accounts share one window group", () => {


### PR DESCRIPTION
## What

`/usage` currently renders a per-provider **"Models with usage data"** list above the quota bars. For providers whose quota is account-wide (e.g. Anthropic coding plans), every available model maps to the same quota, so the list degenerates into a full model-catalog dump (26 lines on a current Claude plan — see below) that carries zero discriminating information.

This change collapses the list into a single dim summary line — `Usage data covers all N available models` — whenever usage data covers **every** available model of a provider. When only a **subset** of models reports usage data (the informative case: Codex Spark meter vs chat windows, Antigravity per-family counters, label-only tiers excluded by `getUsageReportingModelIds`), the explicit per-model list renders exactly as before. Providers with no mapped models render nothing, as before.

Internals: `AgentSession.getUsageReportingModelSelectors(reports): string[]` is replaced by `getUsageReportingModelCoverage(reports): Map<string, UsageModelCoverage>` (`{ reporting: string[]; availableCount: number }`, new interface in `session/agent-session-types.ts`), so both renderers (TUI `renderUsageReports` in `modes/controllers/command-controller.ts`, ACP text builder in `slash-commands/helpers/usage-report.ts`) can compare coverage against the provider's available-model count. Clean cutover — no callers of the old method remain.

## Why

The main reason people run `/usage` mid-turn is the quota bars. Since #6768, command panels invoked while the agent streams render as a height-capped preview above the editor (min 6 rows, 40% of viewport), with the full panel deferred to the next settle. The fully-covered model list eats that preview budget from the top: with two providers the catalog lines alone (8 + 26 below) can push every quota bar out of the preview, leaving the user with the least useful part of the report.

The list itself was introduced alongside usage-aware model fallback (#5018) to show which models the fallback machinery can actually see quota for. That purpose only requires showing the list when it discriminates — "all models covered" is fully conveyed by one line, and partial coverage keeps the exact same list as today. The summary line stays intentionally, rather than rendering nothing, so full coverage remains distinguishable from "no usage mapping at all".

## Before / after

Real `/usage` renders from the same accounts, this branch vs its base commit (bars abridged to one row each, emails redacted, `…` marks elided lines):

**Before** — 34 catalog lines sit above the bars; in the mid-turn preview (~33 rows at an 80-row terminal) everything below the first bar group is cut, so every Anthropic bar is pushed out — matching the session that motivated this change:

```
Usage (4.4s ago)

Openai Codex
  Models with usage data
    openai-codex/gpt-5.3-codex-spark
    openai-codex/gpt-5.4
    openai-codex/gpt-5.4-mini
    openai-codex/gpt-5.5
    openai-codex/gpt-5.6-luna
    openai-codex/gpt-5.6-sol
    openai-codex/gpt-5.6-terra
    openai-codex/gpt-daybreak-blue-latest
⚠ 7 days
  …
✔ 7 days (Spark)
  …

Anthropic
  Models with usage data
    anthropic/claude-3-5-sonnet-20240620
    anthropic/claude-3-5-sonnet-20241022
    … (22 more model lines)
    anthropic/claude-sonnet-4-6
    anthropic/claude-sonnet-5
✔ Claude 5 Hour
  …
✔ Claude 7 Day
  …
⚠ Claude 7 Day (Fable)
  …
✔ Claude Extra Usage
  …
```

**After** — one dim line per provider; every bar is immediately visible, in the preview too:

```
Usage (1.8s ago)

Openai Codex
  Usage data covers all 8 available models
⚠ 7 days
  ████████████████████████   ░░░░░░░░░░░░░░░░░░░░░░░░   50% free
✔ 7 days (Spark)
  ░░░░░░░░░░░░░░░░░░░░░░░░   100% free

Anthropic
  Usage data covers all 26 available models
✔ Claude 5 Hour
  ░░░░░░░░░░░░░░░░░░░░░░░░   ████▒░░░░░░░░░░░░░░░░░░░   90.5% free
✔ Claude 7 Day
  ████████████░░░░░░░░░░░░   ███████▓░░░░░░░░░░░░░░░░   58.5% free
⚠ Claude 7 Day (Fable)
  ████████████████████████   ███████████████▒░░░░░░░░   18% free
✔ Claude Extra Usage
  ███████▒░░░░░░░░░░░░░░░░   $1321.20 used              2 accts
```

**Partial coverage (unchanged)** — the explicit list still renders whenever some available models lack usage data, and that is exactly when it carries information. Both live accounts above resolve to full coverage, so this one is rendered through the same TUI renderer from a synthetic report: an Antigravity account whose usage API returns rows only for the Anthropic backend counter. Per `scopeAntigravityLimitsForModel`, `claude-*` models map to that counter while `gemini-*`/`gpt-*`/tab models resolve to absent counters — so only 4 of the 18 catalog models are covered:

```
Usage (0ms ago)

Google Antigravity
  Models with usage data
    google-antigravity/claude-opus-4-5
    google-antigravity/claude-opus-4-6
    google-antigravity/claude-sonnet-4-5
    google-antigravity/claude-sonnet-4-6
⏳ Usage (Anthropic) (daily)
  user@example.com                              (5h)
  █████████████████░░░░░░░                            28% free
  resets in 5h
⏳ Usage (Anthropic) (weekly)
  user@example.com                              (3d)
  █████████▓░░░░░░░░░░░░░░                            59% free
  resets in 3d
```

Here the list is the only thing telling you that the bars govern just these four models — usage of the other 14 (all Gemini and GPT-OSS backends) is invisible to usage-aware fallback (#5018). Collapsing would destroy that signal, which is why the summary only replaces the list at 100% coverage.

## Testing

- `bun test test/usage-report-tui-notes.test.ts test/pr-3318-repro.test.ts test/modes/controllers/usage-command.test.ts test/usage-report-column-align.test.ts test/usage-report-acp-coverage.test.ts` — 17 pass, 0 fail. Three new contract tests: full coverage collapses to the summary (TUI and ACP text paths, suppressing the list + selectors), partial coverage preserves the explicit list.
- `bun run check:ts` — clean (biome + tsgo across workspaces). `check:rs` not run: no Rust toolchain in this environment and the change is TS-only.
- **End-to-end**: launched the TUI from this branch (`bun --cwd=packages/coding-agent src/cli.ts`) against real credentials and ran `/usage`. Anthropic rendered `Usage data covers all 26 available models` and Openai Codex `Usage data covers all 8 available models`, each as one dim line directly above their quota bars; the old multi-line catalog is gone and the bars are immediately visible.

**From the submitter** (written in Korean, translated to English with AI assistance):

> The reason I use /usage is to see my remaining quota. At some point it started dumping a long list of models that carries no information, and by now the usage bars — the part with actual value — go unshown just to display that list. This needs to be set right.

> 원문: usage를 쓰는 이유는 남은 쿼터를 보기 위함인데, 언제부턴가 정보량이 없는 모델 리스트가 잔뜩 뜨기 시작했고, 이제는 그걸 표시하기 위해 실질적인 가치가 있는 사용량 그래프를 보여주지 못하고 있다. 정상화가 필요하다.

**Review gate (pre-PR)**: 2 independent review rounds. Round 1: one P2 (summary line missed the `truncateToWidth` guard the sibling branch applies; could wrap below 44 columns) — adopted and fixed. Round 2: clean, no findings. Post-gate addition: one test (`usage-report-acp-coverage.test.ts`, ACP-path collapse contract) was added after round 2 during self-review; no production code changed after the gate.

---

- [x] `bun check` passes (`check:ts`; `check:rs` skipped — TS-only change, no cargo in env)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)