### PR TITLE
fix(coding-agent): classify user-invoked /skill turns under auto thinking

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `defaultThinkingLevel: auto` skipping classification for user-invoked `/skill:<name>` turns, which left the effort stuck on pending `auto`; user-attributed skill prompts now classify like any user turn while agent/autoload injections stay excluded ([#8554](https://github.com/can1357/oh-my-pi/issues/8554)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -297,6 +297,7 @@ import {
 	type InterruptedThinkingDetails,
 	isEmptyErrorTurn,
 	isUserInterruptAbort,
+	isUserInvokedSkillPrompt,
 	logProviderTurnError,
 	normalizeCustomMessagePayload,
 	type PythonExecutionMessage,
@@ -5568,10 +5569,14 @@ export class AgentSession {
 			}
 
 			// Auto thinking: classify this real user turn and set the effective level
-			// before the model request. Synthetic/tool-continuation turns (developer/
-			// custom roles) and non-auto sessions are skipped. Never blocks the turn —
-			// failures fall back to a concrete level inside the helper.
-			if (this.isAutoThinking && message.role === "user") {
+			// before the model request. A user-invoked `/skill:<name>` arrives as a
+			// user-attributed skill custom message whose expanded body is the task
+			// prompt, so it counts as a user turn. Synthetic/tool-continuation turns
+			// (developer roles), agent-originated or autoloaded skill injections, and
+			// non-auto sessions are skipped. Never blocks the turn — failures fall
+			// back to a concrete level inside the helper.
+			const isUserTurn = message.role === "user" || (message.role === "custom" && isUserInvokedSkillPrompt(message));
+			if (this.isAutoThinking && isUserTurn) {
 				await this.#models.applyAutoThinkingLevel(expandedText, generation);
 				if (this.#promptGeneration !== generation) {
 					return;

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -1085,7 +1085,8 @@ function customMessageContentToLlmContent(content: CustomMessage["content"]): (T
 	return typeof content === "string" ? [{ type: "text", text: content }] : content;
 }
 
-function isUserInvokedSkillPrompt(message: CustomMessage): boolean {
+/** True for a `/skill:<name>` prompt the user invoked directly (attribution `user`), as opposed to an agent/autoload injection. */
+export function isUserInvokedSkillPrompt(message: CustomMessage): boolean {
 	return message.customType === SKILL_PROMPT_MESSAGE_TYPE && message.attribution === "user";
 }
 

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -8,6 +8,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import {
 	AUTO_THINKING,
@@ -372,6 +373,63 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe(Effort.Medium);
 		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Medium);
 		expect(session.agent.state.thinkingLevel).toBe(Effort.Medium);
+	});
+
+	it("classifies a user-invoked /skill turn under auto (resolves concrete effort)", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		await createSession({
+			initialModelId: model.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: { default: `${model.provider}/${model.id}` },
+		});
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(Effort.Medium);
+
+		session.setThinkingLevel(AUTO_THINKING);
+		expect(session.autoResolvedThinkingLevel()).toBeUndefined();
+
+		// A /skill:<name> invocation reaches the session as a user-attributed
+		// custom message, not a `user` role. It is still a real user turn.
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Expanded SKILL.md body: implement the focused parser fix",
+			display: true,
+			details: { name: "implement", path: "/skills/implement/SKILL.md", args: "the parser" },
+			attribution: "user",
+		});
+
+		expect(classifierSpy).toHaveBeenCalledTimes(1);
+		expect(classifierSpy.mock.calls[0]?.[0]).toContain("implement the focused parser fix");
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(session.configuredThinkingLevel()).toBe(AUTO_THINKING);
+		expect(session.thinkingLevel).toBe(Effort.Medium);
+		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Medium);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.Medium);
+	});
+
+	it("does not classify an agent-originated skill custom message under auto", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		await createSession({
+			initialModelId: model.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: { default: `${model.provider}/${model.id}` },
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(Effort.Medium);
+
+		session.setThinkingLevel(AUTO_THINKING);
+
+		// Autoloaded / agent-originated skill injections must stay excluded.
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Autoloaded skill body",
+			display: false,
+			details: { name: "autoload", path: "/skills/autoload/SKILL.md" },
+			attribution: "agent",
+		});
+
+		expect(classifierSpy).not.toHaveBeenCalled();
+		expect(session.autoResolvedThinkingLevel()).toBeUndefined();
 	});
 
 	it("keeps auto active on resume (pending until the next turn reclassifies)", async () => {


### PR DESCRIPTION
## Repro
With `defaultThinkingLevel: auto` and a thinking-capable model, invoking a registered skill as the first turn (`/skill:implement <args>`) leaves the status line stuck on pending `auto` for the whole turn instead of resolving to a concrete effort. Covered by a new regression test:

```
bun test test/agent-session-role-thinking.test.ts -t "skill"
```

Against the unfixed code, `classifyDifficulty` is called 0 times for the user skill turn (`expect(classifierSpy).toHaveBeenCalledTimes(1)` fails).

## Cause
A user-invoked `/skill:<name>` reaches the session through `promptCustomMessage()` as a skill custom message (`role: "custom"`, `customType: SKILL_PROMPT_MESSAGE_TYPE`, `attribution: "user"`) whose expanded SKILL.md body is the actual task prompt. The auto-thinking gate in `AgentSession.#promptWithMessage` (`src/session/agent-session.ts`) only accepted `message.role === "user"`, so skill turns were dropped before `#models.applyAutoThinkingLevel()` / `classifyDifficulty()` ran, and `autoResolvedThinkingLevel()` stayed `undefined`. The codebase already treats these as user turns elsewhere (`convertToLlm` via `isUserInvokedSkillPrompt`), so the gate was inconsistent.

## Fix
- Exported the existing `isUserInvokedSkillPrompt` predicate from `src/session/messages.ts` (was a private helper; the same check was also inlined in `promptCustomMessage`).
- Broadened the auto-thinking gate in `#promptWithMessage` to accept a user turn OR a `custom`-role message that `isUserInvokedSkillPrompt`, so user-invoked skills classify while agent-originated / autoload skill injections (`attribution: "agent"`) stay excluded.
- Added two regression tests in `test/agent-session-role-thinking.test.ts`: a first-turn `/skill` invocation under `auto` now calls the classifier once and resolves a concrete effort; an agent-attributed skill injection stays unclassified.

## Verification
`bun test test/agent-session-role-thinking.test.ts` → 23 pass / 0 fail. Related suites green: `bun test test/session/messages.test.ts test/agent-session-magic-keywords.test.ts test/auto-thinking-classifier.test.ts test/agent-session-skill-keywords.test.ts` → 47 pass / 0 fail.

Fixes #8554