### PR TITLE
fix(utils): stop indented code interrupting paragraphs in the vendored marked lexer

### DIFF
--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -302,6 +302,27 @@ Average Latency: 1,240 ms
 			expect(plainLines.filter(line => line.includes("+"))).toHaveLength(0);
 		});
 
+		it("keeps a four-space-indented tree child inside its paragraph", () => {
+			const markdown = new Markdown(
+				`Two verified cases:
+
+├── **case 1** — first branch
+│   └── each family has its own counter
+└── **case 3: unnumbered limits**
+    └── limits that carry **only a label** are dropped from the list`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			// The attached indented line is a lazy paragraph continuation, never an
+			// indented code block: no fence border rows, no literal bold markers.
+			expect(plainLines.filter(line => line.includes("```"))).toHaveLength(0);
+			expect(plainLines.some(line => line.includes("only a label"))).toBe(true);
+			expect(plainLines.some(line => line.includes("**"))).toBe(false);
+		});
+
 		it("keeps an unfinished code block with a rule and heading literal when no table follows", () => {
 			const markdown = new Markdown(
 				`The process printed this

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the vendored Markdown lexer letting an indented code block interrupt a paragraph: a 4-space-indented line directly attached to paragraph text (e.g. a box-drawing tree child under a `└──` branch) now stays a lazy continuation of that paragraph, matching marked/CommonMark, instead of rendering the rest of the message section as a raw code block ([#8557](https://github.com/can1357/oh-my-pi/pull/8557) by [@chan1103](https://github.com/chan1103)).
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/utils/src/marked/core.ts
+++ b/packages/utils/src/marked/core.ts
@@ -1071,8 +1071,20 @@ function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 		}
 		let raw = line;
 		i++;
-		while (i < lines.length && !isBlockStart(lines, i)) {
-			raw += lines[i++]!;
+		// An indented code block cannot interrupt a paragraph (CommonMark lazy
+		// continuation): a 4-space-indented line directly attached to nonblank
+		// paragraph text stays inside the paragraph, bypassing every block-start
+		// probe — matching marked's paragraph rule. After a whitespace-padded
+		// blank line the indent is no longer attached, so it still opens an
+		// indented code block.
+		let prevBlankish = false;
+		while (i < lines.length) {
+			const next = lines[i]!;
+			const lazyIndent = !prevBlankish && /^ {4}\S/.test(next);
+			if (!lazyIndent && isBlockStart(lines, i)) break;
+			prevBlankish = next.trim() === "";
+			raw += next;
+			i++;
 		}
 		const text = stripFinalNewline(raw);
 		const tokens: Token[] = [];

--- a/packages/utils/test/fixtures/marked/goldens.json
+++ b/packages/utils/test/fixtures/marked/goldens.json
@@ -954,5 +954,35 @@
       }
     ],
     "html": "<div>\nraw *html*\n</div><p>inline <span>x</span> end</p>\n"
+  },
+  {
+    "name": "lazyContinuation",
+    "source": "tree root\n└── last branch\n    └── child under last branch\n\n    real indented code\n",
+    "tokens": [
+      {
+        "type": "paragraph",
+        "raw": "tree root\n└── last branch\n    └── child under last branch",
+        "text": "tree root\n└── last branch\n    └── child under last branch",
+        "tokens": [
+          {
+            "type": "text",
+            "raw": "tree root\n└── last branch\n    └── child under last branch",
+            "text": "tree root\n└── last branch\n    └── child under last branch",
+            "escaped": false
+          }
+        ]
+      },
+      {
+        "type": "space",
+        "raw": "\n\n"
+      },
+      {
+        "type": "code",
+        "raw": "    real indented code\n",
+        "codeBlockStyle": "indented",
+        "text": "real indented code\n"
+      }
+    ],
+    "html": "<p>tree root\n└── last branch\n    └── child under last branch</p>\n<pre><code>real indented code\n</code></pre>\n"
   }
 ]

--- a/packages/utils/test/marked.test.ts
+++ b/packages/utils/test/marked.test.ts
@@ -81,6 +81,37 @@ describe("marked compatibility", () => {
 		});
 	}
 
+	// Lazy-continuation boundary shapes (behavior cross-checked against marked
+	// v18): an indented code block cannot interrupt a paragraph, so an indented
+	// line directly attached to paragraph text stays in the paragraph even when
+	// a setext/hr lookahead matches downstream — while a whitespace-padded
+	// blank line detaches it, so the next indented run still opens indented
+	// code. Documented divergences from marked kept as-is: marked dedents the
+	// attached line inside `text` via its code-merge path, and it splits a
+	// padded blank into a `space` token where this lexer keeps the padded
+	// blank inside the paragraph raw.
+	const lazyBoundaryShapes: Array<[string, Array<[string, string]>]> = [
+		[
+			"lead\n   \n    code\n",
+			[
+				["paragraph", "lead\n   \n"],
+				["code", "    code\n"],
+			],
+		],
+		[
+			"lead\n    attached\n---\n",
+			[
+				["paragraph", "lead\n    attached\n"],
+				["hr", "---\n"],
+			],
+		],
+	];
+	for (const [source, shape] of lazyBoundaryShapes) {
+		test(`keeps the lazy-continuation boundary shape for ${JSON.stringify(source)}`, () => {
+			expect([...Lexer.lex(source)].map(token => [token.type, token.raw])).toEqual(shape);
+		});
+	}
+
 	test("runs block and inline tokenizer/renderer extensions", () => {
 		const latexBlock: TokenizerAndRendererExtension = {
 			name: "latexBlock",


### PR DESCRIPTION
## What

Restores marked/CommonMark lazy-continuation semantics in the vendored Markdown lexer (`packages/utils/src/marked/core.ts`): a nonblank 4-space-indented line directly attached to nonblank paragraph text now stays inside the paragraph instead of terminating it and opening an indented `code` block. The change is scoped to the paragraph consumer in `blockTokens`; `isBlockStart`'s signature and its other callers are untouched. A whitespace-padded blank line still detaches the continuation, so intentional indented code blocks after blank lines lex exactly as before.

## Why

Since the marked vendoring in v17.2.10 (e9888367d1), the replacement lexer diverges from marked@18.0.6 — the exact dependency it replaced — which treats an attached indented line as a lazy continuation ("an indented code block cannot interrupt a paragraph").

User-visible symptom: assistant messages that draw box-drawing trees break at the last top-level branch, because children under a `└──` node are indented with four plain spaces. Actual `Markdown` component renders (width 72, ANSI stripped) of the same source:

```markdown
Two verified cases:

├── **case 1** — first branch
│   └── each family has its own counter
└── **case 3: unnumbered limits**
    └── limits that carry **only a label** are dropped from the list
```

**Before** — the attached child is ripped out of the tree into a raw code box, with inline formatting left as literal `**` markers:

````text
Two verified cases:

├── case 1 — first branch
│   └── each family has its own counter
└── case 3: unnumbered limits

```
  └── limits that carry **only a label** are dropped from the list
```
````

**After** — one paragraph, matching marked@18.0.6; the tree stays whole and inline formatting applies:

````text
Two verified cases:

├── case 1 — first branch
│   └── each family has its own counter
└── case 3: unnumbered limits
    └── limits that carry only a label are dropped from the list
````

The fix also stops the setext/hr lookahead from stealing an attached indented line into a code token: `lead\n    attached\n---` now lexes as paragraph + hr, matching marked.

No linked issue — per CONTRIBUTING, no issue was opened for work submitted directly as a PR.

## Testing

- Reproduced the regression with the exact broken shape from real sessions, then confirmed the same reproduction renders correctly after the fix (before/after renders above are actual component output from this branch vs its base).
- New `lazyContinuation` golden generated with real marked@18.0.6 (tokens + HTML byte-exact): an attached indented line stays in the paragraph; a blank-separated indented block still lexes as `code`.
- New `lazyBoundaryShapes` raw-shape tests: indented code preserved after a whitespace-padded blank line; attached line kept in the paragraph when a setext/hr lookahead matches downstream. Documented pre-existing divergences from marked left unchanged (marked dedents the attached line inside `text` via its code-merge path and splits padded blanks into `space` tokens).
- New TUI render regression (`packages/tui/test/markdown.test.ts`): a tree with a 4-space-indented child renders as prose — no ``` border rows, no literal `**`.
- Suites: `packages/utils/test/marked.test.ts` 20 pass; TUI markdown suites (markdown, tree-wrap, incremental-lex, stream-prefix-cache, math) and `packages/coding-agent/test/export-html-markdown.test.ts` (the HTML-export consumer of this lexer) — 226 pass. The 3 OSC 8 link failures in `markdown.test.ts` also fail on pristine `main` in this environment.
- `bun run check:ts` (biome + tsgo) clean on the final rebased state (onto 17.3.4).

**From the submitter** (written in Korean, translated to English with AI assistance):

> I use tree-structured answer formatting heavily, and at some point the bottom of those trees started breaking. This PR restores the correct output.

> 원문: 나는 트리 구조의 답변 형식을 많이 사용하고 있는데, 언제부턴가 트리구조 하단이 깨지고 있다. 정상적인 출력으로 되돌리는 PR이다.

**Known adjacent gaps (intentionally out of scope)**:

- Blockquote lazy continuation (`> quote\n    lazy`) still splits into blockquote + code; marked merges the line into the quoted paragraph with dedented text. Exact parity needs the blockquote tokenizer to splice merged raw/text like marked's code-merge branch — follow-up material.
- `lead\n    a | b\n--- | ---` now lexes as one paragraph while marked emits two; that boundary comes from the vendored table-interrupt approximation, not from indent handling.

**Review gate (pre-PR)**: 2 independent review rounds. Round 1: (P1) padded-blank + indented-code swallowing, (P2) setext/table lookahead bypass — both verified and addressed; the table-boundary tail was declined as a pre-existing interrupt approximation (see gaps above). Round 2: clean, no findings. Post-gate: one test-comment wording fix only; no production code changed after the gate.

---

- [x] `bun check` passes (`check:ts`; `check:rs` skipped — TS-only change, no cargo in env)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
