### PR TITLE
fix(ai): fail truncated OpenAI-compatible streams instead of silently stopping

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Fixed OpenAI-compatible streams that close without a `finish_reason` chunk (connection dropped mid-generation, e.g. DeepSeek's `insufficient_system_resource` interruption) being silently finalized as a clean `stop`; the truncated turn now surfaces as a retryable incomplete-stream error instead of halting mid-sentence.
+- Fixed DeepSeek's `insufficient_system_resource` finish reason mapping to a non-retryable error; it now matches the session retry classifier's transient-transport pattern so the turn is auto-retried.
 - Fixed Ollama chat adapter to correctly forward sampling parameters like temperature and topP to the provider.
 - Fixed OpenAI agent turns ending prematurely after a web search with no visible answer, ensuring the agent continues processing the search results.
 - Fixed a resource leak where completed model streams retained provider concurrency permits longer than necessary.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1343,6 +1343,21 @@ const streamOpenAICompletionsOnce = (
 					kind: "runtime",
 				});
 			}
+			// Detect premature stream closure: the stream ended (EOF/`[DONE]`)
+			// without any chunk carrying a `finish_reason`, but content was
+			// produced — the connection died mid-generation (e.g. DeepSeek's
+			// `insufficient_system_resource` interruption). Finalizing the
+			// partial message as a clean "stop" would make the agent loop treat
+			// the truncated turn as complete (silent mid-sentence halt), so fail
+			// the turn. An empty stream without a finish_reason stays on the
+			// empty-completion retry path. Mirrors the Responses provider's
+			// `sawTerminalResponseEvent` guard.
+			if (streamFinishedAt === undefined && output.content.length > 0) {
+				throw new AIError.ProviderResponseError(
+					"OpenAI completions stream closed before a finish_reason was received",
+					{ provider: model.provider, kind: "incomplete-stream" },
+				);
+			}
 
 			output.errorMessage = undefined;
 			output.duration = performance.now() - startTime;
@@ -2380,6 +2395,16 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | str
 			// the message to match the session retry classifier's transient-transport
 			// pattern (`provider.?returned.?error`) and get the turn auto-retried.
 			return { stopReason: "error", errorMessage: "Provider returned error finish_reason" };
+		case "insufficient_system_resource":
+			// DeepSeek kills the generation mid-stream when its inference system runs
+			// out of resources (docs: "the request is interrupted due to insufficient
+			// resource of the inference system"). Server-side capacity failure — like
+			// the bare `error` case, word the message to match the transient-transport
+			// retry pattern so the turn is auto-retried instead of pinned as an error.
+			return {
+				stopReason: "error",
+				errorMessage: "Provider returned error finish_reason: insufficient_system_resource",
+			};
 		default:
 			return {
 				stopReason: "error",

--- a/packages/ai/test/openai-completions-error-finish-reason.test.ts
+++ b/packages/ai/test/openai-completions-error-finish-reason.test.ts
@@ -107,3 +107,88 @@ describe("finish_reason: error", () => {
 		expect(result.errorMessage).toMatch(RETRYABLE_PATTERN);
 	}, 10_000);
 });
+
+describe("finish_reason: insufficient_system_resource", () => {
+	// DeepSeek interrupts the generation mid-stream when its inference system
+	// runs out of resources; the terminal chunk carries
+	// `finish_reason: "insufficient_system_resource"`. It must surface as a
+	// retryable provider error — never as a clean `stop`.
+	it("maps to a retryable error message", async () => {
+		const fetchMock = createSseFetch([
+			completionChunk({ choices: [{ index: 0, delta: { role: "assistant", content: "Hel" } }] }),
+			completionChunk({ choices: [{ index: 0, delta: {}, finish_reason: "insufficient_system_resource" }] }),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toMatch(RETRYABLE_PATTERN);
+	}, 10_000);
+});
+
+describe("premature stream closure", () => {
+	// The connection dies mid-generation without any `finish_reason` chunk
+	// (DeepSeek insufficient-system-resource interruption, flaky gateway).
+	// Before the guard, the partial message finalized as a clean `stop` and
+	// the agent loop treated the truncated turn as complete — the silent
+	// mid-sentence halt. Now it must surface as an error turn.
+	it("fails the turn instead of silently stopping", async () => {
+		const fetchMock = createSseFetch([
+			completionChunk({ choices: [{ index: 0, delta: { role: "assistant", content: "Hel" } }] }),
+			completionChunk({ choices: [{ index: 0, delta: { content: "lo" } }] }),
+		]);
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("finish_reason");
+	}, 10_000);
+
+	it("still retries a genuinely empty close via the empty-completion path", async () => {
+		// Zero content + no finish_reason is the flaky-gateway empty completion:
+		// it stays a clean `stop` so withEmptyCompletionRetry can re-sample
+		// instead of failing outright.
+		let attempts = 0;
+		async function fetchMock(_input: string | URL | Request, _init?: RequestInit): Promise<Response> {
+			attempts++;
+			const events =
+				attempts === 1
+					? []
+					: [
+							completionChunk({ choices: [{ index: 0, delta: { role: "assistant", content: "Hi" } }] }),
+							completionChunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+							"[DONE]",
+						];
+			const encoder = new TextEncoder();
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					for (const event of events) {
+						const data = typeof event === "string" ? event : JSON.stringify(event);
+						controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+					}
+					controller.close();
+				},
+			});
+			return new Response(stream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		}
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock as typeof fetch,
+		}).result();
+
+		expect(attempts).toBeGreaterThan(1);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "Hi" }]);
+	}, 10_000);
+});


### PR DESCRIPTION
## Problem

DeepSeek's API (used for `deepseek-v4-flash` and others) interrupts mid-generation requests when its inference system runs out of resources. Per the [official docs](https://api-docs.deepseek.com/api/create-chat-completion), the terminal chunk carries `finish_reason: "insufficient_system_resource"`, or the connection simply dies mid-stream.

The OpenAI completions transport (`streamOpenAICompletions`, used by deepseek, opencode-go, OpenRouter, and every other OpenAI-compatible host) mishandled both manifestations:

1. **Stream closes without any `finish_reason` chunk** (connection dropped mid-generation) → the partial message was finalized as a clean `stop`, so the agent loop treated the truncated turn as complete. Symptom: the model stops streaming mid-work with **no error message and no retry**.
2. **Delivered `finish_reason: "insufficient_system_resource"`** → mapped to the generic error default, whose message matches neither the transient-transport pattern nor the provider-finish-error pattern → error surfaced but **no auto-retry**.

## Fix

Two generic fixes in the shared completions transport (no DeepSeek-specific casing — applies to every OpenAI-compatible provider):

1. **Premature-close guard**: after the stream loop, if no `finish_reason` chunk ever arrived *and* content was produced, throw `ProviderResponseError` with `kind: "incomplete-stream"` (transient → session auto-retry). Mirrors the existing guards in the Responses provider (`sawTerminalResponseEvent`) and Anthropic provider (`sawMessageStop`). Streams that close with zero content still follow the empty-completion retry path, so the flaky-gateway case is unchanged.
2. **`insufficient_system_resource` mapping**: worded to match the retry classifier's transient pattern (`provider.?returned.?error`), same trick as the existing bare `error` finish_reason case — the turn is now auto-retried instead of pinned as an error.

## Verification

- New regression tests in `packages/ai/test/openai-completions-error-finish-reason.test.ts`:
  - `insufficient_system_resource` maps to a retryable error message
  - a stream that closes mid-content without `finish_reason` fails the turn instead of silently stopping
  - an empty close-without-`finish_reason` still triggers the empty-completion retry
- Full `packages/ai` suite: 3805 pass, 9 fail — all 9 pre-existing on main (verified: proxy, anthropic-cache-refresh, auth-storage-oauth-refresh-race, openai-codex-responses-lite, deepseek-reasoning-content fail identically on the pristine checkout)
- `bun run check` (biome + tsgo) passes