### PR TITLE
feat(coding-agent): add shortcuts for fast mode and advisor toggles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Alt+Shift+F` (`app.fast.toggle`) and `Alt+Shift+A` (`app.advisor.toggle`) keyboard shortcuts to toggle fast mode (`/fast`) and advisor (`/advisor`) without losing active prompt input.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -55,6 +55,8 @@ interface AppKeybindings {
 	"app.history.search": true;
 	"app.stt.toggle": true;
 	"app.live.toggle": true;
+	"app.fast.toggle": true;
+	"app.advisor.toggle": true;
 }
 
 export type AppKeybinding = keyof AppKeybindings;
@@ -234,6 +236,14 @@ export const KEYBINDINGS = {
 		defaultKeys: "ctrl+l",
 		description: "Start or stop live voice mode (/live)",
 	},
+	"app.fast.toggle": {
+		defaultKeys: "alt+shift+f",
+		description: "Toggle fast mode",
+	},
+	"app.advisor.toggle": {
+		defaultKeys: "alt+shift+a",
+		description: "Toggle advisor",
+	},
 } as const satisfies KeybindingDefinitions;
 
 /**
@@ -269,6 +279,8 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	resume: "app.session.resume",
 	observeSessions: "app.session.observe",
 	toggleSTT: "app.stt.toggle",
+	toggleFastMode: "app.fast.toggle",
+	toggleAdvisor: "app.advisor.toggle",
 	// TUI editor (old names for backward compatibility)
 	cursorUp: "tui.editor.cursorUp",
 	cursorDown: "tui.editor.cursorDown",

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -39,6 +39,8 @@ type ConfigurableEditorAction = Extract<
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.pasteTextRaw"
 	| "app.clipboard.copyPrompt"
+	| "app.fast.toggle"
+	| "app.advisor.toggle"
 >;
 
 const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
@@ -61,6 +63,8 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],
 	"app.clipboard.copyPrompt": ["alt+shift+c"],
+	"app.fast.toggle": ["alt+shift+f"],
+	"app.advisor.toggle": ["alt+shift+a"],
 };
 
 function buildMatchKeys(keys: readonly KeyId[]): Set<string> {
@@ -551,6 +555,8 @@ export class CustomEditor extends Editor {
 	onSelectModel?: () => void;
 	onToggleToolActivity?: () => void;
 	onToggleThinking?: () => void;
+	onToggleFastMode?: () => void;
+	onToggleAdvisor?: () => void;
 	onExternalEditor?: () => void;
 	onHistorySearch?: () => void;
 	onSuspend?: () => void;
@@ -907,6 +913,17 @@ export class CustomEditor extends Editor {
 			// Intercept configured tool activity visibility toggle
 			if (this.#matchesAction(canonical, "app.tools.toggleVisibility") && this.onToggleToolActivity) {
 				this.onToggleToolActivity();
+				return;
+			}
+			// Intercept configured fast mode toggle
+			if (this.#matchesAction(canonical, "app.fast.toggle") && this.onToggleFastMode) {
+				this.onToggleFastMode();
+				return;
+			}
+
+			// Intercept configured advisor toggle
+			if (this.#matchesAction(canonical, "app.advisor.toggle") && this.onToggleAdvisor) {
+				this.onToggleAdvisor();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -850,6 +850,17 @@ export class CustomEditor extends Editor {
 		// Space-hold push-to-talk: a sustained space bar starts/stops STT instead of typing spaces.
 		if (this.#handleSpaceHold(data, canonical)) return;
 
+		// Route legacy ESC+uppercase F (\x1bF) for Alt+Shift+F on non-Kitty terminals
+		// without stealing \x1bf (lowercase, Alt+F word-right navigation).
+		if (
+			data === "\x1bF" &&
+			this.onToggleFastMode &&
+			this.#actionKeys.get("app.fast.toggle")?.some(k => k === "alt+shift+f" || k === "shift+alt+f")
+		) {
+			this.onToggleFastMode();
+			return;
+		}
+
 		// One union probe decides whether any per-action interception below can
 		// match — plain typing then skips the ~20 per-action set lookups per key.
 		if (

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -459,6 +459,10 @@ export class InputController {
 		this.ctx.editor.onToggleThinking = () => this.ctx.toggleThinkingBlockVisibility();
 		this.ctx.editor.setActionKeys("app.editor.external", this.ctx.keybindings.getKeys("app.editor.external"));
 		this.ctx.editor.onExternalEditor = () => void this.openExternalEditor();
+		this.ctx.editor.setActionKeys("app.fast.toggle", this.ctx.keybindings.getKeys("app.fast.toggle"));
+		this.ctx.editor.onToggleFastMode = () => this.toggleFastMode();
+		this.ctx.editor.setActionKeys("app.advisor.toggle", this.ctx.keybindings.getKeys("app.advisor.toggle"));
+		this.ctx.editor.onToggleAdvisor = () => this.toggleAdvisor();
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.pasteImage",
 			this.ctx.keybindings.getKeys("app.clipboard.pasteImage"),
@@ -491,6 +495,12 @@ export class InputController {
 		const planModeKeys = this.ctx.keybindings.getKeys("app.plan.toggle");
 		for (const key of planModeKeys) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handlePlanModeCommand());
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.fast.toggle")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.toggleFastMode());
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.advisor.toggle")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.toggleAdvisor());
 		}
 
 		for (const key of this.ctx.keybindings.getKeys("app.session.new")) {
@@ -1991,8 +2001,36 @@ export class InputController {
 		// snapshots (it invalidates every block) and forces a full clear + replay
 		// of the whole transcript, matching setToolsExpanded()'s redraw.
 		this.ctx.ui.resetDisplay();
-
 		this.ctx.showStatus(`Thinking blocks: ${this.ctx.hideThinkingBlock ? "hidden" : "visible"}`);
+	}
+
+	toggleFastMode(): void {
+		if (this.ctx.focusedAgentId) {
+			this.ctx.showStatus("Fast mode applies to the main session — press ←← to return first");
+			return;
+		}
+		const enabled = this.ctx.session.toggleFastMode();
+		this.ctx.statusLine?.invalidate();
+		this.ctx.ui.requestRender();
+		this.ctx.showStatus(`Fast mode ${enabled ? "enabled" : "disabled"}.`);
+	}
+
+	toggleAdvisor(): void {
+		if (this.ctx.focusedAgentId) {
+			this.ctx.showStatus("Advisor applies to the main session — press ←← to return first");
+			return;
+		}
+		const active = this.ctx.session.toggleAdvisorEnabled();
+		const configured = this.ctx.session.isAdvisorEnabled();
+		if (active) {
+			this.ctx.showStatus("Advisor enabled.");
+		} else if (configured) {
+			this.ctx.showStatus("Advisor setting enabled, but no model is assigned to the 'advisor' role.");
+		} else {
+			this.ctx.showStatus("Advisor disabled.");
+		}
+		this.ctx.statusLine?.invalidate();
+		this.ctx.ui.requestRender();
 	}
 
 	#getEditorTerminalPath(): string | null {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -5123,14 +5123,6 @@ export class InteractiveMode implements InteractiveModeContext {
 	toggleThinkingBlockVisibility(): void {
 		this.#inputController.toggleThinkingBlockVisibility();
 	}
-	toggleFastMode(): void {
-		this.#inputController.toggleFastMode();
-	}
-
-	toggleAdvisor(): void {
-		this.#inputController.toggleAdvisor();
-	}
-
 	toggleTodoExpansion(): void {
 		this.todoExpanded = !this.todoExpanded;
 		this.#renderTodoList();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -5123,6 +5123,13 @@ export class InteractiveMode implements InteractiveModeContext {
 	toggleThinkingBlockVisibility(): void {
 		this.#inputController.toggleThinkingBlockVisibility();
 	}
+	toggleFastMode(): void {
+		this.#inputController.toggleFastMode();
+	}
+
+	toggleAdvisor(): void {
+		this.#inputController.toggleAdvisor();
+	}
 
 	toggleTodoExpansion(): void {
 		this.todoExpanded = !this.todoExpanded;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -444,8 +444,6 @@ export interface InteractiveModeContext {
 	toggleToolOutputExpansion(): void;
 	setToolsExpanded(expanded: boolean): void;
 	toggleThinkingBlockVisibility(): void;
-	toggleFastMode(): void;
-	toggleAdvisor(): void;
 	handlePlanModeCommand(
 		initialPrompt?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -444,6 +444,8 @@ export interface InteractiveModeContext {
 	toggleToolOutputExpansion(): void;
 	setToolsExpanded(expanded: boolean): void;
 	toggleThinkingBlockVisibility(): void;
+	toggleFastMode(): void;
+	toggleAdvisor(): void;
 	handlePlanModeCommand(
 		initialPrompt?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -52,6 +52,8 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.tools.expand")}\` | Toggle tool output expansion |`,
 		`| \`${appKey(bindings, "app.tools.toggleVisibility")}\` | Toggle tool activity visibility |`,
 		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,
+		`| \`${appKey(bindings, "app.fast.toggle")}\` | Toggle fast mode (/fast) |`,
+		`| \`${appKey(bindings, "app.advisor.toggle")}\` | Toggle advisor (/advisor) |`,
 		`| \`${appKey(bindings, "app.editor.external")}\` | Edit message in external editor |`,
 		`| \`${appKey(bindings, "app.retry")}\` | Retry last failed assistant turn |`,
 		`| \`${appKey(bindings, "app.clipboard.pasteImage")}\` | Paste image or text from clipboard |`,

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -30,14 +30,27 @@ describe("CustomEditor keybindings", () => {
 		expect(onToggleToolActivity).toHaveBeenCalledTimes(1);
 	});
 
-	it("routes the fast mode toggle chord (Alt+Shift+F) to onToggleFastMode", () => {
+	it("routes the fast mode toggle chord (Alt+Shift+F) across CSI u, modifyOtherKeys, and legacy \\x1bF", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onToggleFastMode = vi.fn();
 
 		editor.onToggleFastMode = onToggleFastMode;
-		editor.handleInput("\x1b[102;4u"); // Alt+Shift+F (CSI u format)
+		editor.handleInput("\x1b[102;4u"); // CSI u (Kitty)
+		editor.handleInput("\x1b[27;4;102~"); // modifyOtherKeys (xterm)
+		editor.handleInput("\x1bF"); // Legacy ESC + uppercase F
 
-		expect(onToggleFastMode).toHaveBeenCalledTimes(1);
+		expect(onToggleFastMode).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not steal \\x1bf (Alt+F word right) when Alt+Shift+F is configured", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onToggleFastMode = vi.fn();
+
+		editor.onToggleFastMode = onToggleFastMode;
+		editor.setText("hello world");
+		editor.handleInput("\x1bf"); // Alt+F (lowercase f)
+
+		expect(onToggleFastMode).not.toHaveBeenCalled();
 	});
 
 	it("routes the advisor toggle chord (Alt+Shift+A) to onToggleAdvisor", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -30,6 +30,27 @@ describe("CustomEditor keybindings", () => {
 		expect(onToggleToolActivity).toHaveBeenCalledTimes(1);
 	});
 
+	it("routes the fast mode toggle chord (Alt+Shift+F) to onToggleFastMode", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onToggleFastMode = vi.fn();
+
+		editor.onToggleFastMode = onToggleFastMode;
+		editor.handleInput("\x1b[102;4u"); // Alt+Shift+F (CSI u format)
+
+		expect(onToggleFastMode).toHaveBeenCalledTimes(1);
+	});
+
+	it("routes the advisor toggle chord (Alt+Shift+A) to onToggleAdvisor", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onToggleAdvisor = vi.fn();
+
+		editor.onToggleAdvisor = onToggleAdvisor;
+		editor.handleInput("\x1bA"); // Alt+Shift+A (legacy ESC + uppercase)
+		editor.handleInput("\x1b[97;4u"); // Alt+Shift+A (CSI u format)
+
+		expect(onToggleAdvisor).toHaveBeenCalledTimes(2);
+	});
+
 	it("lets custom handlers keep precedence over the default retry chord", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onRetry = vi.fn();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -340,6 +340,22 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showStatus).toHaveBeenCalledWith("Advisor enabled.");
 	});
 
+	it("guards fast mode and advisor toggles when a subagent session is focused", async () => {
+		const { InputController, ctx, editor, spies, session } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		ctx.focusedAgentId = "subagent-1";
+
+		editor.onToggleFastMode?.();
+		expect(session.toggleFastMode).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledWith("Fast mode applies to the main session — press ←← to return first");
+
+		editor.onToggleAdvisor?.();
+		expect(session.toggleAdvisorEnabled).not.toHaveBeenCalled();
+		expect(spies.showStatus).toHaveBeenCalledWith("Advisor applies to the main session — press ←← to return first");
+	});
+
 	it("does not mark pasted shell prompts as Python mode while editing", async () => {
 		const { InputController, ctx, editor } = await createContext();
 		const controller = new InputController(ctx);

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -25,6 +25,8 @@ type FakeEditor = {
 	onExpandTools?: () => void;
 	onToggleToolActivity?: () => void;
 	onToggleThinking?: () => void;
+	onToggleFastMode?: () => void;
+	onToggleAdvisor?: () => void;
 	onExternalEditor?: () => void;
 	onRetry?: () => void;
 	onChange?: (text: string) => void;
@@ -68,6 +70,8 @@ async function createContext() {
 		"app.clipboard.pasteImage": ["ctrl+v"],
 		"app.tools.toggleVisibility": ["ctrl+shift+o"],
 		"app.tools.expand": ["ctrl+o"],
+		"app.fast.toggle": ["alt+shift+f"],
+		"app.advisor.toggle": ["alt+shift+a"],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -108,6 +112,9 @@ async function createContext() {
 		queuedMessageCount: 0,
 		abort,
 		retry,
+		toggleFastMode: vi.fn(() => true),
+		toggleAdvisorEnabled: vi.fn(() => true),
+		isAdvisorEnabled: vi.fn(() => true),
 	};
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBtwBranchKey = vi.fn(async () => true);
@@ -205,6 +212,7 @@ async function createContext() {
 		hideToolActivity: false,
 		toolOutputExpanded: false,
 		settings: { set: vi.fn() },
+		statusLine: { invalidate: vi.fn() },
 		chatContainer: { children: [], setToolActivityVisible: vi.fn() },
 		handleHotkeysCommand: vi.fn(),
 		handlePlanModeCommand: vi.fn(),
@@ -232,6 +240,7 @@ async function createContext() {
 		InputController,
 		ctx,
 		editor,
+		session,
 		customHandlers,
 		setFocused(target: unknown) {
 			focused = target;
@@ -262,6 +271,7 @@ async function createContext() {
 			handleBtwCopyKey,
 			canCopyBtw,
 			showError,
+			showStatus: ctx.showStatus,
 		},
 	};
 }
@@ -306,6 +316,28 @@ describe("InputController keybinding setup", () => {
 		expect(spies.clearInlineImages).toHaveBeenCalledTimes(1);
 		expect(spies.resetDisplay).toHaveBeenCalledTimes(1);
 		expect(ctx.chatContainer.setToolActivityVisible).toHaveBeenCalledWith(false);
+	});
+
+	it("registers fast mode and advisor toggle actions", async () => {
+		const { InputController, ctx, editor, spies, session } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.fast.toggle", ["alt+shift+f"]);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.advisor.toggle", ["alt+shift+a"]);
+		expect(editor.onToggleFastMode).toBeDefined();
+		expect(editor.onToggleAdvisor).toBeDefined();
+
+		editor.onToggleFastMode?.();
+		expect(session.toggleFastMode).toHaveBeenCalledTimes(1);
+		expect(ctx.statusLine.invalidate).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus).toHaveBeenCalledWith("Fast mode enabled.");
+
+		editor.onToggleAdvisor?.();
+		expect(session.toggleAdvisorEnabled).toHaveBeenCalledTimes(1);
+		expect(ctx.statusLine.invalidate).toHaveBeenCalledTimes(2);
+		expect(spies.showStatus).toHaveBeenCalledWith("Advisor enabled.");
 	});
 
 	it("does not mark pasted shell prompts as Python mode while editing", async () => {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -25,6 +25,13 @@ describe("KeybindingsManager.getDisplayString", () => {
 		expect(keybindings.getDisplayString("app.retry")).toBe("Alt+R");
 	});
 
+	it("defaults fast mode toggle to Alt+Shift+F and advisor toggle to Alt+Shift+A", () => {
+		const keybindings = KeybindingsManager.inMemory();
+
+		expect(keybindings.getDisplayString("app.fast.toggle")).toBe("Alt+Shift+F");
+		expect(keybindings.getDisplayString("app.advisor.toggle")).toBe("Alt+Shift+A");
+	});
+
 	it("formats multiple bindings with the existing separator", () => {
 		const keybindings = KeybindingsManager.inMemory({
 			"app.clipboard.copyPrompt": ["alt+shift+c", "ctrl+shift+c"],

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -279,12 +279,14 @@ describe("KeybindingsManager.create", () => {
 		}
 	});
 
-	it("defaults model selection to Alt+M, display reset to Alt+L, and live toggle to Ctrl+L", () => {
+	it("defaults model selection to Alt+M, display reset to Alt+L, live toggle to Ctrl+L, fast toggle to Alt+Shift+F, and advisor toggle to Alt+Shift+A", () => {
 		const manager = KeybindingsManager.inMemory();
 
 		expect(manager.getKeys("app.model.select")).toEqual(["alt+m"]);
 		expect(manager.getKeys("app.display.reset")).toEqual(["alt+l"]);
 		expect(manager.getKeys("app.live.toggle")).toEqual(["ctrl+l"]);
+		expect(manager.getKeys("app.fast.toggle")).toEqual(["alt+shift+f"]);
+		expect(manager.getKeys("app.advisor.toggle")).toEqual(["alt+shift+a"]);
 	});
 
 	it("keeps the Ctrl+L live toggle default when an old model remap still claims Ctrl+L", () => {

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -29,6 +29,8 @@ describe("buildHotkeysMarkdown", () => {
 			"app.clipboard.pasteImage": "Ctrl+V",
 			"app.stt.toggle": "Alt+H",
 			"app.live.toggle": "Ctrl+L",
+			"app.fast.toggle": "Alt+Shift+F",
+			"app.advisor.toggle": "Alt+Shift+A",
 		};
 		const markdown = buildHotkeysMarkdown({
 			keybindings: {
@@ -48,6 +50,8 @@ describe("buildHotkeysMarkdown", () => {
 		expect(markdown).toContain("| `Alt+R` | Retry last failed assistant turn |");
 		expect(markdown).toContain("| `Alt+Shift+P` | Toggle plan mode |");
 		expect(markdown).toContain("| `Ctrl+Shift+O` | Toggle tool activity visibility |");
+		expect(markdown).toContain("| `Alt+Shift+F` | Toggle fast mode (/fast) |");
+		expect(markdown).toContain("| `Alt+Shift+A` | Toggle advisor (/advisor) |");
 		expect(markdown).toContain("| `#<number>` | GitHub issue/PR reference");
 		expect(markdown).toContain("| `#` / `#<text>` | Prompt actions");
 		for (const line of lines) {


### PR DESCRIPTION
## Problem

While model selection and thinking modes have dedicated keyboard shortcuts (`Ctrl+P`, `Shift+Ctrl+P`, `Alt+M`, `Alt+P`, `Shift+Tab`, `Ctrl+T`), toggling fast mode (`/fast`) and advisor (`/advisor`) required typing slash commands. Typing `/fast` or `/advisor` clears or interrupts active prompt input in the editor.

Additionally, assigning single-chord shortcuts like `Alt+F`, `Ctrl+F`, `Alt+A`, or `Ctrl+A` creates severe collisions with standard Readline/Emacs cursor navigation (`Alt+F` word-forward, `Ctrl+F` char-right, `Ctrl+A` line-start) and the existing Agent Hub shortcut (`Alt+A`).

## Solution

Add dedicated `Alt+Shift+<letter>` keyboard shortcuts for fast mode and advisor toggles, following the established mode-toggle chord convention (`Alt+Shift+P` for `/plan`):

- **`Alt+Shift+F` (`app.fast.toggle`)**: Toggles fast mode (`/fast` priority service tier).
- **`Alt+Shift+A` (`app.advisor.toggle`)**: Toggles advisor review mode (`/advisor`).

Both shortcuts:
- Can be triggered at any time while typing in the prompt editor without clearing or corrupting the draft text.
- Update the status line immediately (showing the fast icon and advisor badge).
- Surface clear status messages (`Fast mode enabled/disabled.`, `Advisor enabled/disabled.`).
- Guard against accidental mutations when focused on subagents.
- Route across all terminal protocols (Kitty, modifyOtherKeys, and legacy escape sequences).
- Are documented in `/hotkeys` and fully configurable via user keybindings.

## Safety details

- `Alt+Shift+F` and `Alt+Shift+A` avoid shadowing Readline navigation keys (`Alt+F`, `Ctrl+F`, `Ctrl+A`) and existing application shortcuts (`Alt+A` for Agent Hub).
- Works reliably across terminal protocols: Kitty keyboard protocol (`\x1b[102;4u`, `\x1b[97;4u`), xterm `modifyOtherKeys` (`\x1b[27;4;102~`, `\x1b[27;4;97~`), and legacy ESC sequences (`\x1bF`, `\x1bA`).
- Legacy `\x1bF` is explicitly routed to `onToggleFastMode` without stealing lowercase `\x1bf` (Alt+F word-forward navigation).
- Subagent focus guard: If pressed while viewing a subagent, warns the user to return to the main session first (`←←`/`Esc`) rather than mutating main session state invisibly.

## Changes

**Keybindings & Configuration**
- Register `"app.fast.toggle"` (`Alt+Shift+F`) and `"app.advisor.toggle"` (`Alt+Shift+A`) in `KEYBINDINGS` and `AppKeybindings`.
- Add migration aliases `toggleFastMode` and `toggleAdvisor`.

**Editor & Input Controller**
- Add `onToggleFastMode` and `onToggleAdvisor` to `CustomEditor` with `handleInput` action interception and legacy `\x1bF` support.
- Wire toggle methods in `InputController` directly to `CustomEditor` callbacks.
- List both shortcuts under the `/hotkeys` help table.

**Tests**
- Add unit tests for `CustomEditor` chord handling for `Alt+Shift+F` and `Alt+Shift+A` across CSI u, modifyOtherKeys, and legacy `\x1bF` escape formats, and verify `\x1bf` word-forward navigation is preserved.
- Add regression test coverage for `InputController` key handler registration, session dispatch, and subagent focus guards.
- Add display string and default key assertions in `keybindings-display.test.ts`, `keybindings-migration.test.ts`, and `command-controller-hotkeys.test.ts`.

## Verification

I reviewed the full diff and verified that pressing `Alt+Shift+F` and `Alt+Shift+A` toggles fast mode and advisor cleanly across Kitty, modifyOtherKeys, and legacy terminals while preserving active prompt input and word navigation in the editor.

- [x] `bun test test/input-controller-keybindings.test.ts test/custom-editor-keybindings.test.ts test/keybindings-display.test.ts test/keybindings-migration.test.ts test/modes/controllers/command-controller-hotkeys.test.ts test/keybindings-escape-components.test.ts test/keybindings-selector-navigation.test.ts test/extensions-runner.test.ts` (161 pass, 0 fail)
- [x] `bunx @biomejs/biome check packages/coding-agent/src/config/keybindings.ts packages/coding-agent/src/modes/components/custom-editor.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/types.ts packages/coding-agent/src/modes/utils/hotkeys-markdown.ts packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/keybindings-display.test.ts packages/coding-agent/test/keybindings-migration.test.ts packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts` (11 files checked, 0 errors)
- [x] CHANGELOG updated under `## [Unreleased]` -> `### Added`
