### PR TITLE
fix(tui): stop inline code color bleed at soft wraps

### DIFF
--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -1000,7 +1000,12 @@ fn split_into_tokens_with_ansi(line: &[u16]) -> SmallVec<[Vec<u16>; 4]> {
 		if line[i] == ESC
 			&& let Some(seq_len) = ansi_seq_len_u16(line, i)
 		{
-			pending_ansi.extend_from_slice(&line[i..i + seq_len]);
+			let seq = &line[i..i + seq_len];
+			if current.is_empty() {
+				pending_ansi.extend_from_slice(seq);
+			} else {
+				current.extend_from_slice(seq);
+			}
 			i += seq_len;
 			continue;
 		}
@@ -2001,6 +2006,18 @@ mod tests {
 		assert!(first.starts_with("\x1b[38;2;156;163;176m"));
 		assert!(second.starts_with("\x1b[38;2;156;163;176m"));
 		assert!(second.contains("world"));
+	}
+
+	#[test]
+	fn test_wrap_text_with_ansi_keeps_trailing_color_reset_before_soft_wrap() {
+		let data = to_u16("plain \x1b[33mcode\x1b[39m next");
+		let lines = wrap_text_with_ansi_impl(&data, 10, DEFAULT_TAB_WIDTH);
+		let actual: Vec<String> = lines
+			.iter()
+			.map(|line| String::from_utf16_lossy(line))
+			.collect();
+
+		assert_eq!(actual, ["plain \x1b[33mcode\x1b[39m", "next"]);
 	}
 
 	#[test]

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inline-code foreground color carrying into plain text when a Markdown codespan ended exactly at a soft-wrap boundary ([#8582](https://github.com/can1357/oh-my-pi/issues/8582)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Added


### PR DESCRIPTION
## Repro
Render the reporter's single-paragraph Markdown through `new Markdown(text, 0, 0, getMarkdownTheme()).render(112)`. Before the fix, the first row ended with `ESC[38;5;183mP6.S2` without `ESC[39m`, and the second row began `ESC[38;5;183mStarting a retry…`, so plain continuation text used `mdCode` foreground. The minimal native reproduction is `wrapTextWithAnsi("plain \x1b[33mcode\x1b[39m next", 10, 4)`, which returned `["plain \x1b[33mcode", "\x1b[33mnext"]`.

## Cause
`split_into_tokens_with_ansi` in `crates/pi-natives/src/text.rs` buffered every ANSI sequence until the next visible character. The foreground reset immediately after a codespan therefore moved onto the following whitespace token; when that whitespace triggered a soft wrap, row finalization still saw the code foreground active and restored it on the continuation row.

## Fix
- Keep ANSI sequences encountered after visible content byte-owned by the current wrap token; retain pending buffering only for leading ANSI before a token's first visible character.
- Add a native regression asserting a codespan ending exactly at the wrap width closes on row 1 and leaves row 2 plain.
- Document the fix in `packages/natives/CHANGELOG.md`.

## Verification
- `cargo test -p pi-natives wrap_text_with_ansi` — 6 passed.
- `cargo fmt --check -p pi-natives && bun test packages/natives/test/native.test.ts` — 52 passed.
- Rebuilt the addon via the cargo backend and reran the reporter's exact width-112 paragraph: row 1 now ends `P6.S2\x1b[39m`; row 2 starts plain `Starting a retry…`.

Fixes #8582