### PR TITLE
feat(coding-agent): expose live voice activity to extensions

### DIFF
--- a/docs/live-activity-events.md
+++ b/docs/live-activity-events.md
@@ -1,0 +1,43 @@
+# Live activity events
+
+Interactive extensions can observe the semantic state of OMP's built-in `/live` session through the shared extension event bus. The event is intended for local presence indicators, accessibility surfaces, and other displays that do not need audio or transcript content.
+
+## Subscribe
+
+```ts
+import {
+  isLiveActivityEvent,
+  LIVE_ACTIVITY_EVENT_CHANNEL,
+  type ExtensionAPI,
+} from "@oh-my-pi/pi-coding-agent";
+
+export default function liveIndicator(pi: ExtensionAPI): void {
+  const unsubscribe = pi.events.on(LIVE_ACTIVITY_EVENT_CHANNEL, value => {
+    if (!isLiveActivityEvent(value)) return;
+    renderVoiceState(value.phase, value.inputLevel, value.outputLevel);
+  });
+
+  pi.on("session_shutdown", unsubscribe);
+}
+```
+
+`LIVE_ACTIVITY_EVENT_CHANNEL` is `live:activity`. The payload implements `LiveActivityEvent`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `phase` | `"inactive" \| "connecting" \| "listening" \| "working" \| "speaking" \| "muted" \| "error"` | Current semantic state of the live session. |
+| `inputLevel` | `number` | Normalized microphone RMS level in the inclusive range `0..1`. |
+| `outputLevel` | `number` | Normalized speaker RMS level in the inclusive range `0..1`. |
+
+## Delivery semantics
+
+- Session start publishes `connecting`.
+- Phase changes publish immediately.
+- Level changes are coalesced onto the live visualizer's 80 ms animation cadence; consumers must not expect one event per audio frame.
+- Unchanged snapshots are suppressed.
+- Session teardown publishes `inactive` with both levels set to zero.
+- Delivery is local and best-effort through `ExtensionAPI.events`; consumers should render the latest event rather than treating the stream as an audit log.
+
+## Privacy and failure isolation
+
+The payload contains scalar RMS levels only. It never includes audio samples, transcripts, session identifiers, or user identifiers. Event handlers run through the shared `EventBus` error boundary, so an observer failure cannot interrupt the live audio path.

--- a/docs/live-activity-events.md
+++ b/docs/live-activity-events.md
@@ -35,6 +35,7 @@ export default function liveIndicator(pi: ExtensionAPI): void {
 - Phase changes publish immediately.
 - Level changes are coalesced onto the live visualizer's 80 ms animation cadence; consumers must not expect one event per audio frame.
 - Unchanged snapshots are suppressed.
+- Delivery is serialized independently per observer. While a handler is busy, intermediate snapshots are replaced by one latest pending snapshot, preventing concurrent callbacks and stale backlogs.
 - Session teardown publishes `inactive` with both levels set to zero.
 - Delivery is local and best-effort through `ExtensionAPI.events`; consumers should render the latest event rather than treating the stream as an audit log.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a privacy-bounded `live:activity` extension event exposing the built-in `/live` session's semantic phase and normalized microphone and speaker RMS levels.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -28,6 +28,7 @@ export * from "./extensibility/extensions";
 export * from "./extensibility/skills";
 // Slash commands
 export { type FileSlashCommand, loadSlashCommands as discoverSlashCommands } from "./extensibility/slash-commands";
+export * from "./live/activity-events";
 export type * from "./lsp";
 // Main entry point
 export * from "./main";

--- a/packages/coding-agent/src/live/activity-events.ts
+++ b/packages/coding-agent/src/live/activity-events.ts
@@ -1,0 +1,46 @@
+import type { LivePhase } from "./visualizer";
+
+/** Shared EventBus channel for privacy-bounded realtime voice activity. */
+export const LIVE_ACTIVITY_EVENT_CHANNEL = "live:activity";
+
+/** Semantic state of the realtime voice session. */
+export type LiveActivityPhase = LivePhase | "inactive";
+const LIVE_ACTIVITY_PHASES: Record<LiveActivityPhase, true> = {
+	inactive: true,
+	connecting: true,
+	listening: true,
+	working: true,
+	speaking: true,
+	muted: true,
+	error: true,
+};
+
+/**
+ * Realtime voice activity exposed to local extensions.
+ *
+ * Levels are normalized scalar RMS values in the inclusive range 0..1.
+ * The payload intentionally excludes audio samples, transcripts, and identifiers.
+ */
+export interface LiveActivityEvent {
+	phase: LiveActivityPhase;
+	inputLevel: number;
+	outputLevel: number;
+}
+
+/** Narrow an unknown shared-bus payload to the public live activity contract. */
+export function isLiveActivityEvent(value: unknown): value is LiveActivityEvent {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Partial<LiveActivityEvent>;
+	return (
+		typeof candidate.phase === "string" &&
+		Object.hasOwn(LIVE_ACTIVITY_PHASES, candidate.phase) &&
+		typeof candidate.inputLevel === "number" &&
+		Number.isFinite(candidate.inputLevel) &&
+		candidate.inputLevel >= 0 &&
+		candidate.inputLevel <= 1 &&
+		typeof candidate.outputLevel === "number" &&
+		Number.isFinite(candidate.outputLevel) &&
+		candidate.outputLevel >= 0 &&
+		candidate.outputLevel <= 1
+	);
+}

--- a/packages/coding-agent/src/live/activity-events.ts
+++ b/packages/coding-agent/src/live/activity-events.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
 import type { LivePhase } from "./visualizer";
 
 /** Shared EventBus channel for privacy-bounded realtime voice activity. */
@@ -29,18 +30,17 @@ export interface LiveActivityEvent {
 
 /** Narrow an unknown shared-bus payload to the public live activity contract. */
 export function isLiveActivityEvent(value: unknown): value is LiveActivityEvent {
-	if (!value || typeof value !== "object") return false;
-	const candidate = value as Partial<LiveActivityEvent>;
+	if (!isRecord(value)) return false;
 	return (
-		typeof candidate.phase === "string" &&
-		Object.hasOwn(LIVE_ACTIVITY_PHASES, candidate.phase) &&
-		typeof candidate.inputLevel === "number" &&
-		Number.isFinite(candidate.inputLevel) &&
-		candidate.inputLevel >= 0 &&
-		candidate.inputLevel <= 1 &&
-		typeof candidate.outputLevel === "number" &&
-		Number.isFinite(candidate.outputLevel) &&
-		candidate.outputLevel >= 0 &&
-		candidate.outputLevel <= 1
+		typeof value.phase === "string" &&
+		Object.hasOwn(LIVE_ACTIVITY_PHASES, value.phase) &&
+		typeof value.inputLevel === "number" &&
+		Number.isFinite(value.inputLevel) &&
+		value.inputLevel >= 0 &&
+		value.inputLevel <= 1 &&
+		typeof value.outputLevel === "number" &&
+		Number.isFinite(value.outputLevel) &&
+		value.outputLevel >= 0 &&
+		value.outputLevel <= 1
 	);
 }

--- a/packages/coding-agent/src/modes/controllers/live-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/live-command-controller.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
+import { LIVE_ACTIVITY_EVENT_CHANNEL, type LiveActivityEvent } from "../../live/activity-events";
 import { LiveSessionController, type LiveSessionControllerOptions, type LiveTranscript } from "../../live/controller";
 import { LIVE_MODEL } from "../../live/protocol";
 import { LiveVisualizer } from "../../live/visualizer";
@@ -24,6 +25,10 @@ const LIVE_MESSAGE_USAGE: AssistantMessage["usage"] = {
 function errorFrom(cause: unknown): Error {
 	return cause instanceof Error ? cause : new Error(String(cause));
 }
+function normalizeLiveActivityLevel(level: number): number {
+	if (!Number.isFinite(level) || level <= 0) return 0;
+	return Math.min(1, level);
+}
 
 /** Owns the editor-replacing visualizer and realtime session lifecycle for `/live`. */
 export class LiveCommandController {
@@ -41,6 +46,10 @@ export class LiveCommandController {
 	#assistantTranscriptComponent: AssistantMessageComponent | undefined;
 	#assistantTranscriptTurn = 0;
 	#assistantTranscriptStartedAt = 0;
+	#livePhase: LiveActivityEvent["phase"] = "connecting";
+	#inputLevel = 0;
+	#outputLevel = 0;
+	#lastLiveActivity: LiveActivityEvent | undefined;
 
 	constructor(ctx: InteractiveModeContext, createSession?: LiveSessionFactory) {
 		this.#ctx = ctx;
@@ -94,6 +103,9 @@ export class LiveCommandController {
 	async #start(): Promise<void> {
 		this.#assistantTranscriptTurn = 0;
 		this.#assistantTranscriptStartedAt = 0;
+		this.#livePhase = "connecting";
+		this.#inputLevel = 0;
+		this.#outputLevel = 0;
 		const visualizer = new LiveVisualizer({
 			onStop: () => {
 				void this.stop().catch(cause => this.#ctx.showError(errorFrom(cause).message));
@@ -111,11 +123,15 @@ export class LiveCommandController {
 			callbacks: {
 				onPhase: phase => {
 					if (this.#visualizer !== visualizer) return;
+					this.#livePhase = phase;
+					this.#publishLiveActivity();
 					visualizer.setPhase(phase);
 					this.#ctx.ui.requestComponentRender(visualizer);
 				},
-				onLevels: input => {
+				onLevels: (input, output) => {
 					if (this.#visualizer !== visualizer) return;
+					this.#inputLevel = normalizeLiveActivityLevel(input);
+					this.#outputLevel = normalizeLiveActivityLevel(output);
 					visualizer.setInputLevel(input);
 					this.#ctx.ui.requestComponentRender(visualizer);
 				},
@@ -136,6 +152,7 @@ export class LiveCommandController {
 		};
 		session = this.#createSession ? this.#createSession(options) : new LiveSessionController(options);
 		this.#session = session;
+		this.#publishLiveActivity();
 
 		try {
 			await session.start();
@@ -215,6 +232,7 @@ export class LiveCommandController {
 			frame += 1;
 			visualizer.setFrame(frame);
 			this.#ctx.ui.requestComponentRender(visualizer);
+			this.#publishLiveActivity();
 		}, ANIMATION_INTERVAL_MS);
 		this.#ctx.ui.requestRender();
 	}
@@ -222,6 +240,10 @@ export class LiveCommandController {
 	#finish(session: LiveSessionController, error?: Error): void {
 		if (this.#session !== session) return;
 		this.#session = undefined;
+		this.#livePhase = "inactive";
+		this.#inputLevel = 0;
+		this.#outputLevel = 0;
+		this.#publishLiveActivity();
 		this.#restoreEditor();
 		if (error) this.#ctx.showError(error.message);
 		const settling = session.stop().catch(cause => {
@@ -231,6 +253,26 @@ export class LiveCommandController {
 		void settling.finally(() => {
 			if (this.#settling === settling) this.#settling = undefined;
 		});
+	}
+
+	#publishLiveActivity(): void {
+		const eventBus = this.#ctx.eventBus;
+		if (!eventBus) return;
+		const previous = this.#lastLiveActivity;
+		if (
+			previous?.phase === this.#livePhase &&
+			previous.inputLevel === this.#inputLevel &&
+			previous.outputLevel === this.#outputLevel
+		) {
+			return;
+		}
+		const next: LiveActivityEvent = {
+			phase: this.#livePhase,
+			inputLevel: this.#inputLevel,
+			outputLevel: this.#outputLevel,
+		};
+		this.#lastLiveActivity = next;
+		eventBus.emit(LIVE_ACTIVITY_EVENT_CHANNEL, next);
 	}
 
 	#restoreEditor(): void {

--- a/packages/coding-agent/src/modes/controllers/live-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/live-command-controller.ts
@@ -272,7 +272,7 @@ export class LiveCommandController {
 			outputLevel: this.#outputLevel,
 		};
 		this.#lastLiveActivity = next;
-		eventBus.emit(LIVE_ACTIVITY_EVENT_CHANNEL, next);
+		eventBus.emitLatest(LIVE_ACTIVITY_EVENT_CHANNEL, next);
 	}
 
 	#restoreEditor(): void {

--- a/packages/coding-agent/src/utils/event-bus.ts
+++ b/packages/coding-agent/src/utils/event-bus.ts
@@ -1,33 +1,97 @@
 import { logger } from "@oh-my-pi/pi-utils";
 
+type EventHandler = (data: unknown) => void | Promise<void>;
+type SafeEventHandler = (data: unknown) => Promise<void>;
+
+interface LatestDelivery {
+	active: boolean;
+	subscribed: boolean;
+	hasPending: boolean;
+	pending: unknown;
+}
+
 export class EventBus {
-	readonly #listeners = new Map<string, Set<(data: unknown) => void>>();
+	readonly #listeners = new Map<string, Set<SafeEventHandler>>();
+	readonly #latestDeliveries = new WeakMap<SafeEventHandler, LatestDelivery>();
 
 	emit(channel: string, data: unknown): void {
 		const handlers = this.#listeners.get(channel);
-		if (handlers) {
-			for (const handler of handlers) {
-				handler(data);
+		if (!handlers) return;
+		for (const handler of handlers) void handler(data);
+	}
+
+	/**
+	 * Deliver state snapshots serially per observer.
+	 *
+	 * While an observer is busy, newer snapshots replace its single pending
+	 * snapshot so slow observers cannot accumulate stale concurrent work.
+	 */
+	emitLatest(channel: string, data: unknown): void {
+		const handlers = this.#listeners.get(channel);
+		if (!handlers) return;
+		for (const handler of handlers) {
+			let delivery = this.#latestDeliveries.get(handler);
+			if (!delivery) {
+				delivery = { active: false, subscribed: true, hasPending: false, pending: undefined };
+				this.#latestDeliveries.set(handler, delivery);
 			}
+			delivery.pending = data;
+			delivery.hasPending = true;
+			if (delivery.active) continue;
+			delivery.active = true;
+			void this.#drainLatest(handler, delivery);
 		}
 	}
 
-	on(channel: string, handler: (data: unknown) => void): () => void {
-		if (!this.#listeners.has(channel)) {
-			this.#listeners.set(channel, new Set());
+	on(channel: string, handler: EventHandler): () => void {
+		let handlers = this.#listeners.get(channel);
+		if (!handlers) {
+			handlers = new Set();
+			this.#listeners.set(channel, handlers);
 		}
-		const safeHandler = async (data: unknown) => {
+		const safeHandler: SafeEventHandler = async data => {
 			try {
 				await handler(data);
 			} catch (err) {
 				logger.error("Event handler error", { channel, error: String(err) });
 			}
 		};
-		this.#listeners.get(channel)!.add(safeHandler);
-		return () => this.#listeners.get(channel)?.delete(safeHandler);
+		handlers.add(safeHandler);
+		return () => {
+			handlers.delete(safeHandler);
+			const delivery = this.#latestDeliveries.get(safeHandler);
+			if (delivery) {
+				delivery.subscribed = false;
+				delivery.hasPending = false;
+				delivery.pending = undefined;
+			}
+			if (handlers.size === 0) this.#listeners.delete(channel);
+		};
 	}
 
 	clear(): void {
+		for (const handlers of this.#listeners.values()) {
+			for (const handler of handlers) {
+				const delivery = this.#latestDeliveries.get(handler);
+				if (!delivery) continue;
+				delivery.subscribed = false;
+				delivery.hasPending = false;
+				delivery.pending = undefined;
+			}
+		}
 		this.#listeners.clear();
+	}
+
+	async #drainLatest(handler: SafeEventHandler, delivery: LatestDelivery): Promise<void> {
+		try {
+			while (delivery.subscribed && delivery.hasPending) {
+				const data = delivery.pending;
+				delivery.pending = undefined;
+				delivery.hasPending = false;
+				await handler(data);
+			}
+		} finally {
+			delivery.active = false;
+		}
 	}
 }

--- a/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
@@ -99,6 +99,8 @@ describe("LiveCommandController", () => {
 			activity.push(value);
 		});
 		expect(isLiveActivityEvent({ phase: "listening", inputLevel: 2, outputLevel: 0 })).toBe(false);
+		const arrayPayload = Object.assign([], { phase: "listening", inputLevel: 0, outputLevel: 0 });
+		expect(isLiveActivityEvent(arrayPayload)).toBe(false);
 		let callbacks: LiveSessionCallbacks | undefined;
 		const controller = new LiveCommandController(ctx, options => {
 			callbacks = options.callbacks;
@@ -147,6 +149,54 @@ describe("LiveCommandController", () => {
 			}
 		} finally {
 			unsubscribe();
+			await controller.stop();
+		}
+	});
+
+	it("coalesces changing levels while an extension observer is busy", async () => {
+		vi.useFakeTimers();
+		const { ctx, eventBus } = createContext();
+		const releaseObserver = Promise.withResolvers<void>();
+		const receivedLatest = Promise.withResolvers<void>();
+		const activity: LiveActivityEvent[] = [];
+		let first = true;
+		const unsubscribe = eventBus.on(LIVE_ACTIVITY_EVENT_CHANNEL, async value => {
+			if (!isLiveActivityEvent(value)) throw new Error("invalid live activity event");
+			activity.push(value);
+			if (first) {
+				first = false;
+				await releaseObserver.promise;
+			} else {
+				receivedLatest.resolve();
+			}
+		});
+		let callbacks: LiveSessionCallbacks | undefined;
+		const controller = new LiveCommandController(ctx, options => {
+			callbacks = options.callbacks;
+			const session = new LiveSessionController(options);
+			vi.spyOn(session, "start").mockResolvedValue();
+			vi.spyOn(session, "stop").mockResolvedValue();
+			return session;
+		});
+
+		try {
+			await controller.handleCommand();
+			if (!callbacks) throw new Error("expected live session callbacks");
+			callbacks.onLevels(0.1, 0.2);
+			vi.advanceTimersByTime(80);
+			callbacks.onLevels(0.3, 0.4);
+			vi.advanceTimersByTime(80);
+
+			expect(activity).toEqual([{ phase: "connecting", inputLevel: 0, outputLevel: 0 }]);
+			releaseObserver.resolve();
+			await receivedLatest.promise;
+			expect(activity).toEqual([
+				{ phase: "connecting", inputLevel: 0, outputLevel: 0 },
+				{ phase: "connecting", inputLevel: 0.3, outputLevel: 0.4 },
+			]);
+		} finally {
+			unsubscribe();
+			releaseObserver.resolve();
 			await controller.stop();
 		}
 	});

--- a/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { LiveSessionController } from "@oh-my-pi/pi-coding-agent/live/controller";
+import {
+	isLiveActivityEvent,
+	LIVE_ACTIVITY_EVENT_CHANNEL,
+	type LiveActivityEvent,
+} from "@oh-my-pi/pi-coding-agent/live/activity-events";
+import { type LiveSessionCallbacks, LiveSessionController } from "@oh-my-pi/pi-coding-agent/live/controller";
 import { LiveVisualizer } from "@oh-my-pi/pi-coding-agent/live/visualizer";
 import { LiveCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/live-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
 /** Fake InteractiveModeContext plus typed capture channels for focus/mount traffic. */
 interface ContextHarness {
@@ -16,6 +22,8 @@ interface ContextHarness {
 	mounted: unknown[];
 	/** Resolves when `ui.setFocus` sees the original editor again. */
 	editorRefocused: Promise<void>;
+	/** Extension event channel receiving privacy-bounded live activity. */
+	eventBus: EventBus;
 }
 
 function createContext(): ContextHarness {
@@ -26,7 +34,9 @@ function createContext(): ContextHarness {
 	const focused: unknown[] = [];
 	const mounted: unknown[] = [];
 	const refocused = Promise.withResolvers<void>();
+	const eventBus = new EventBus();
 	const ctx = {
+		eventBus,
 		settings: Settings.isolated({ "live.voice": "vale" }),
 		keybindings: { getKeys: vi.fn(() => ["ctrl+l"]) },
 		session: {},
@@ -52,10 +62,11 @@ function createContext(): ContextHarness {
 		chatContainer: { children: [] },
 		present: vi.fn(),
 	} as unknown as InteractiveModeContext;
-	return { ctx, editor, focused, mounted, editorRefocused: refocused.promise };
+	return { ctx, editor, focused, mounted, editorRefocused: refocused.promise, eventBus };
 }
 
 afterEach(() => {
+	vi.useRealTimers();
 	vi.restoreAllMocks();
 });
 
@@ -75,6 +86,67 @@ describe("LiveCommandController", () => {
 			await controller.handleCommand();
 			expect(receivedVoice).toBe("vale");
 		} finally {
+			await controller.stop();
+		}
+	});
+
+	it("publishes bounded live activity without exposing realtime audio data", async () => {
+		vi.useFakeTimers();
+		const { ctx, eventBus } = createContext();
+		const activity: LiveActivityEvent[] = [];
+		const unsubscribe = eventBus.on(LIVE_ACTIVITY_EVENT_CHANNEL, value => {
+			if (!isLiveActivityEvent(value)) throw new Error("invalid live activity event");
+			activity.push(value);
+		});
+		expect(isLiveActivityEvent({ phase: "listening", inputLevel: 2, outputLevel: 0 })).toBe(false);
+		let callbacks: LiveSessionCallbacks | undefined;
+		const controller = new LiveCommandController(ctx, options => {
+			callbacks = options.callbacks;
+			const session = new LiveSessionController(options);
+			vi.spyOn(session, "start").mockResolvedValue();
+			vi.spyOn(session, "stop").mockResolvedValue();
+			return session;
+		});
+
+		try {
+			await controller.handleCommand();
+			expect(activity).toEqual([{ phase: "connecting", inputLevel: 0, outputLevel: 0 }]);
+			if (!callbacks) throw new Error("expected live session callbacks");
+
+			callbacks.onLevels(0.25, 2);
+			vi.advanceTimersByTime(79);
+			expect(activity).toHaveLength(1);
+			vi.advanceTimersByTime(1);
+			expect(activity.at(-1)).toEqual({
+				phase: "connecting",
+				inputLevel: 0.25,
+				outputLevel: 1,
+			});
+
+			callbacks.onPhase("speaking");
+			expect(activity.at(-1)).toEqual({
+				phase: "speaking",
+				inputLevel: 0.25,
+				outputLevel: 1,
+			});
+			callbacks.onLevels(Number.NaN, Number.POSITIVE_INFINITY);
+			vi.advanceTimersByTime(80);
+			expect(activity.at(-1)).toEqual({
+				phase: "speaking",
+				inputLevel: 0,
+				outputLevel: 0,
+			});
+			const settledCount = activity.length;
+			vi.advanceTimersByTime(80);
+			expect(activity).toHaveLength(settledCount);
+
+			await controller.stop();
+			expect(activity.at(-1)).toEqual({ phase: "inactive", inputLevel: 0, outputLevel: 0 });
+			for (const event of activity) {
+				expect(Object.keys(event).sort()).toEqual(["inputLevel", "outputLevel", "phase"]);
+			}
+		} finally {
+			unsubscribe();
 			await controller.stop();
 		}
 	});

--- a/packages/coding-agent/test/utils/event-bus.test.ts
+++ b/packages/coding-agent/test/utils/event-bus.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { logger } from "@oh-my-pi/pi-utils";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("EventBus", () => {
+	it("serializes and coalesces latest-state delivery independently per observer", async () => {
+		const eventBus = new EventBus();
+		const releaseSlow = Promise.withResolvers<void>();
+		const slowReachedLatest = Promise.withResolvers<void>();
+		const fastReachedLatest = Promise.withResolvers<void>();
+		const slowCalls: number[] = [];
+		const fastCalls: number[] = [];
+		let slowActive = 0;
+		let maxSlowActive = 0;
+
+		eventBus.on("state", async value => {
+			if (typeof value !== "number") throw new Error("expected numeric state");
+			slowCalls.push(value);
+			slowActive += 1;
+			maxSlowActive = Math.max(maxSlowActive, slowActive);
+			try {
+				if (value === 1) await releaseSlow.promise;
+				if (value === 3) slowReachedLatest.resolve();
+			} finally {
+				slowActive -= 1;
+			}
+		});
+		eventBus.on("state", value => {
+			if (typeof value !== "number") throw new Error("expected numeric state");
+			fastCalls.push(value);
+			if (value === 3) fastReachedLatest.resolve();
+		});
+
+		eventBus.emitLatest("state", 1);
+		eventBus.emitLatest("state", 2);
+		eventBus.emitLatest("state", 3);
+
+		expect(slowCalls).toEqual([1]);
+		await fastReachedLatest.promise;
+		expect(fastCalls).toEqual([1, 3]);
+		expect(slowCalls).toEqual([1]);
+
+		releaseSlow.resolve();
+		await slowReachedLatest.promise;
+		expect(slowCalls).toEqual([1, 3]);
+		expect(maxSlowActive).toBe(1);
+	});
+
+	it("drops a pending latest-state snapshot when its observer unsubscribes", async () => {
+		const eventBus = new EventBus();
+		const release = Promise.withResolvers<void>();
+		const finished = Promise.withResolvers<void>();
+		const calls: number[] = [];
+		const unsubscribe = eventBus.on("state", async value => {
+			if (typeof value !== "number") throw new Error("expected numeric state");
+			calls.push(value);
+			if (value === 1) await release.promise;
+			finished.resolve();
+		});
+
+		eventBus.emitLatest("state", 1);
+		eventBus.emitLatest("state", 2);
+		unsubscribe();
+		release.resolve();
+		await finished.promise;
+		await Promise.resolve();
+
+		expect(calls).toEqual([1]);
+	});
+
+	it("continues latest-state delivery after an observer failure", async () => {
+		const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const eventBus = new EventBus();
+		const delivered = Promise.withResolvers<void>();
+		const calls: number[] = [];
+		eventBus.on("state", value => {
+			if (typeof value !== "number") throw new Error("expected numeric state");
+			calls.push(value);
+			if (value === 1) throw new Error("observer failed");
+			delivered.resolve();
+		});
+
+		eventBus.emitLatest("state", 1);
+		eventBus.emitLatest("state", 2);
+		await delivered.promise;
+
+		expect(calls).toEqual([1, 2]);
+		expect(error).toHaveBeenCalledWith("Event handler error", {
+			channel: "state",
+			error: "Error: observer failed",
+		});
+	});
+
+	it("preserves normal emit delivery without coalescing", () => {
+		const eventBus = new EventBus();
+		const calls: number[] = [];
+		eventBus.on("event", value => {
+			if (typeof value !== "number") throw new Error("expected numeric event");
+			calls.push(value);
+		});
+
+		eventBus.emit("event", 1);
+		eventBus.emit("event", 2);
+
+		expect(calls).toEqual([1, 2]);
+	});
+});


### PR DESCRIPTION
## What

- Add a typed `live:activity` channel to the shared extension EventBus.
- Publish the built-in `/live` session phase plus normalized microphone and speaker RMS levels.
- Emit phase transitions immediately, coalesce level updates onto the existing 80 ms visualizer cadence, suppress duplicate snapshots, and publish `inactive` during teardown.
- Serialize latest-state delivery independently per observer, retaining at most one replaceable pending snapshot while a handler is busy so slow observers cannot accumulate stale concurrent work.
- Export the channel, payload types, and assertion-free runtime payload guard from `@oh-my-pi/pi-coding-agent`.
- Document the public contract and add an Unreleased changelog entry.

## Why

Extensions can now access OMP’s live voice state in a consistent way, without getting access to the actual audio or transcripts. This makes it easier to build things like visualizers, accessibility indicators, or hardware integrations without having to recreate /live.

The shared EventBus keeps this bounded telemetry out of the asynchronous extension lifecycle pipeline while preserving OMP’s ownership of the live session. The payload contains only `phase`, `inputLevel`, and `outputLevel`; it contains no audio samples, transcript content, session identifiers, or user identifiers.

## Testing

- `bun run check` from `packages/coding-agent`: passed (`biome check` across 2,602 files and `tsgo --noEmit`).
- `bun test test/utils/event-bus.test.ts test/modes/controllers/live-command-controller.test.ts`: 8 passed, 0 failed, 31 assertions.
- Latest-state delivery coverage verifies per-observer serialization, replacement of intermediate pending snapshots, observer isolation, unsubscribe behavior, failure isolation, unchanged normal-event delivery, and controller-level live activity coalescing.
- `bun run --cwd packages/coding-agent build`: passed; patched binary launched as `omp/17.3.4`.
- Exercised `/live` end to end with a temporary local observer extension. It received 299 valid events across `connecting → listening → speaking → listening → speaking → inactive`, including nonzero input and output levels; the final event was `inactive` with both levels zero. The temporary observer and capture file were removed after verification.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)