### PR TITLE
fix(builtins): handle empty xargs replace input

### DIFF
--- a/crates/pi-builtins/src/xargs.rs
+++ b/crates/pi-builtins/src/xargs.rs
@@ -741,7 +741,7 @@ fn process_input(
 		return Ok(result);
 	}
 
-	if !options.no_run_if_empty || have_pending_command {
+	if have_pending_command || (!options.no_run_if_empty && builder_options.replace.is_none()) {
 		result.combine(current_builder.execute(host)?);
 	}
 
@@ -1466,6 +1466,12 @@ mod tests {
 		let (code, out, _) = run_simple(&[], "");
 		assert_eq!(code, 0);
 		assert_eq!(out, "\n");
+	}
+
+	#[test]
+	fn replace_mode_skips_empty_input_without_r() {
+		let result = run_simple(&["-I", "{}", "echo", "{}"], "");
+		assert_eq!(result, (0, String::new(), String::new()));
 	}
 
 	#[test]

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the native `xargs` builtin panicking in `-I`/`-i` replace mode when stdin is empty; it now exits successfully without running the command, matching GNU behavior ([#8595](https://github.com/can1357/oh-my-pi/issues/8595)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Added


### PR DESCRIPTION
## Repro

With the regression test in place, `cargo test -p pi-builtins replace_mode_skips_empty_input_without_r -- --nocapture` reproduced empty stdin with `-I {}` as an index-out-of-bounds panic at `crates/pi-builtins/src/xargs.rs:379`; the native harness observed exit 1 and `xargs: internal error` instead of exit 0 with no output.

## Cause

`process_input()` executed the trailing `CommandBuilder` whenever `-r` was absent, even when no stdin argument had been read. In replace mode, `CommandBuilder::execute()` assumes its single replacement argument exists and indexed `extra_args[0]`, so the empty trailing builder panicked.

## Fix

- Skip trailing execution when replace mode has no pending stdin argument, while preserving default mode’s existing empty-input invocation.
- Add a regression test for the GNU-compatible replace-mode no-op behavior.
- Document the native builtin fix in `packages/natives/CHANGELOG.md`.

## Verification

`cargo test -p pi-builtins replace_mode_skips_empty_input_without_r -- --nocapture` passed (1/1); `cargo test -p pi-builtins xargs::tests` passed (27/27); `cargo fmt --all -- --check` passed; the publish gate’s `bun check` passed. A full `cargo test -p pi-builtins` run passed 979/980 tests, with the unrelated existing `pgrep::tests::quiet_suppresses_matching_output` failure.

Fixes #8595