### PR TITLE
feat(catalog): add GLM-5.3 to zai and zhipu-coding-plan

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for the `glm-5.3` model on the `zai` and `zhipu-coding-plan` (GLM Coding Plan) catalogs with the published 1M context / 131,072 output limits, pinned at catalog generation so discovery cannot regress them to 200k. GLM-5.3's official `low`/`high`/`max` reasoning-effort ladder is exposed on the official Z.ai/Zhipu endpoints only; reseller routes that mirror the zai dialect second-hand (Ollama Cloud, Baseten) keep the verified `high`/`max` pair until their 5.3 ladders are confirmed. ([#8518](https://github.com/can1357/oh-my-pi/issues/8518))
+
 ## [17.3.4] - 2026-08-14
 
 ### Added

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -367,9 +367,12 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 		model.omitMaxOutputTokens = true;
 	}
 
-	// GLM Coding Plan: GLM-5.2 is the selectable 1M served id; pin it so
-	// endpoint discovery or older bundled fallbacks cannot regress to 200k.
-	if ((model.provider === "zai" || model.provider === "zhipu-coding-plan") && model.id === "glm-5.2") {
+	// GLM Coding Plan: GLM-5.2/5.3 are the selectable 1M served ids; pin them
+	// so endpoint discovery or older bundled fallbacks cannot regress to 200k.
+	if (
+		(model.provider === "zai" || model.provider === "zhipu-coding-plan") &&
+		(model.id === "glm-5.2" || model.id === "glm-5.3")
+	) {
 		model.contextWindow = 1_000_000;
 		model.maxTokens = 131_072;
 	}

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -251,6 +251,22 @@ export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => 
 	return semverGte(glm.version, "5.2");
 });
 
+/**
+ * GLM-5.3+ coding SKUs add the `low` reasoning-effort tier beneath GLM-5.2's
+ * `high`/`max` pair (official docs: `low`/`high`/`max`, default `max`). Version
+ * floor like {@link isGlm52ReasoningEffortModelId} so future integers inherit.
+ */
+export const isGlm53ModelId = memo((modelId: string): boolean => {
+	const glm = parseGlmModel(bareModelId(modelId));
+	if (!glm || glm.vision) {
+		return false;
+	}
+	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+		return false;
+	}
+	return semverGte(glm.version, "5.3");
+});
+
 /** GLM vision SKUs — the `v` that attaches to the version (`glm-4v`, `glm-4.5v`). */
 export const isGlmVisionModelId = memo((modelId: string): boolean => {
 	return parseGlmModel(bareModelId(modelId))?.vision === true;

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -26,6 +26,7 @@ import {
 	isDeepseekModelIdOrName,
 	isDeepseekV4FlashModelId,
 	isGlm52ReasoningEffortModelId,
+	isGlm53ModelId,
 	isKimiK3ModelId,
 	isMimoModelIdOrName,
 	isMinimaxM2FamilyModelId,
@@ -63,9 +64,9 @@ const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, E
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
 const LOW_MEDIUM_HIGH_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High];
-/** Wire-exact `low`/`high`/`max` scale used by Kimi K3 and DeepSeek V4 (Flash and Pro, direct API and aggregators). */
+/** Wire-exact `low`/`high`/`max` scale used by Kimi K3, DeepSeek V4 (Flash and Pro, direct API and aggregators), and GLM-5.3+ on the zai dialect. */
 const LOW_HIGH_MAX_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High, Effort.Max];
-/** Wire-exact two-tier scale (`high`/`max`): GLM-5.2 on Z.ai/Umans/Ollama Cloud/Baseten, Sakana Fugu, older DeepSeek reasoners (V3.x/R1). */
+/** Wire-exact two-tier scale (`high`/`max`): GLM-5.2 on Z.ai/Umans/Ollama Cloud/Baseten, Sakana Fugu, older DeepSeek reasoners (V3.x/R1). GLM-5.3+ moves to the `low`/`high`/`max` scale above. */
 const HIGH_MAX_REASONING_EFFORTS: readonly Effort[] = [Effort.High, Effort.Max];
 /** OpenRouter's DeepSeek route accepts only `high`. */
 const HIGH_ONLY_REASONING_EFFORTS: readonly Effort[] = [Effort.High];
@@ -327,12 +328,23 @@ function getModelDefinedEfforts<TApi extends Api>(
 		if (isOpenRouterThinkingFormat(compat)) {
 			return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
 		}
+		// GLM-5.3 adds a genuine `low` tier beneath the pair, but only on the
+		// official endpoints (Zhipu docs + models.dev: low/high/max, default
+		// max). Reseller routes (Umans, Ollama Cloud, Baseten) mirror the
+		// zai dialect second-hand; keep them at the verified high/max pair
+		// until their 5.3 ladders are confirmed.
 		if (
 			isZaiThinkingFormat(compat) ||
 			isAnthropicMessagesGlm52ReasoningEffortModel(spec) ||
 			isOllamaCloudGlm52ReasoningEffortModel(spec) ||
 			spec.provider === "baseten"
 		) {
+			if (
+				isGlm53ModelId(spec.id) &&
+				(isZaiThinkingFormat(compat) || (spec.provider === "zai" && spec.api === "anthropic-messages"))
+			) {
+				return LOW_HIGH_MAX_REASONING_EFFORTS;
+			}
 			return HIGH_MAX_REASONING_EFFORTS;
 		}
 		if (isOpenAICompatReasoningApi(spec.api)) {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -105719,6 +105719,33 @@
 				]
 			}
 		},
+		"glm-5.3": {
+			"id": "glm-5.3",
+			"name": "GLM-5.3",
+			"api": "anthropic-messages",
+			"provider": "zai",
+			"baseUrl": "https://api.z.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
 		"glm-5v-turbo": {
 			"id": "glm-5v-turbo",
 			"name": "GLM-5V-Turbo",
@@ -111956,6 +111983,38 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"high",
+					"max"
+				]
+			}
+		},
+		"glm-5.3": {
+			"id": "glm-5.3",
+			"name": "GLM-5.3",
+			"api": "openai-completions",
+			"provider": "zhipu-coding-plan",
+			"baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
 					"high",
 					"max"
 				]

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -223,7 +223,7 @@ describe("generated model policies", () => {
 		]);
 	});
 
-	it("pins zai glm-5.2 base id to 1M context", () => {
+	it("pins zai/zhipu glm-5.2 and glm-5.3 coding-plan ids to 1M context", () => {
 		const models = [
 			createSpec({
 				id: "glm-5.2",
@@ -232,12 +232,28 @@ describe("generated model policies", () => {
 				contextWindow: 200_000,
 				maxTokens: 8192,
 			}),
+			createSpec({
+				id: "glm-5.3",
+				api: "anthropic-messages",
+				provider: "zai",
+				contextWindow: 200_000,
+				maxTokens: 8192,
+			}),
+			createSpec({
+				id: "glm-5.3",
+				api: "openai-completions",
+				provider: "zhipu-coding-plan",
+				contextWindow: 200_000,
+				maxTokens: 8192,
+			}),
 		];
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.contextWindow).toBe(1_000_000);
-		expect(models[0]?.maxTokens).toBe(131_072);
+		for (const model of models) {
+			expect(model.contextWindow).toBe(1_000_000);
+			expect(model.maxTokens).toBe(131_072);
+		}
 	});
 
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -3,6 +3,7 @@ import {
 	hasOpus47ApiRestrictions,
 	isClaudeModelId,
 	isGeminiModelId,
+	isGlm53ModelId,
 	isGlmVisionModelId,
 	isGrokModelId,
 	isGrokReasoningEffortCapable,
@@ -244,7 +245,6 @@ describe("isReasoningGlmModelId", () => {
 		expect(isReasoningGlmModelId("glm-4.5v")).toBe(false);
 		expect(isReasoningGlmModelId("qwen3.5")).toBe(false);
 	});
-
 	test("matches uppercase provider-prefixed GLM ids", () => {
 		// Baseten, CoreWeave, HuggingFace, etc. serve GLM under uppercase ids.
 		expect(isReasoningGlmModelId("zai-org/GLM-5.2")).toBe(true);
@@ -254,6 +254,23 @@ describe("isReasoningGlmModelId", () => {
 		expect(isReasoningGlmModelId("zai-org/GLM-5-Turbo")).toBe(true);
 		// Vision SKUs are still excluded even in uppercase.
 		expect(isReasoningGlmModelId("zai-org/GLM-4.5V")).toBe(false);
+	});
+});
+
+describe("isGlm53ModelId", () => {
+	test("matches glm-5.3 and later integers on the reasoning lines", () => {
+		expect(isGlm53ModelId("glm-5.3")).toBe(true);
+		expect(isGlm53ModelId("glm-5.3-air")).toBe(true);
+		// Version floor: future integers inherit the low/high/max ladder.
+		expect(isGlm53ModelId("glm-6")).toBe(true);
+		expect(isGlm53ModelId("z-ai/glm-5.3")).toBe(true);
+	});
+
+	test("excludes GLM-5.2 and the non-reasoning or vision SKUs", () => {
+		expect(isGlm53ModelId("glm-5.2")).toBe(false);
+		expect(isGlm53ModelId("glm-5.3-flash")).toBe(false);
+		expect(isGlm53ModelId("glm-5.3v")).toBe(false);
+		expect(isGlm53ModelId("glm-5-preview")).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -275,6 +275,55 @@ describe("model thinking derivation", () => {
 		expect(openRouter.thinking?.effortMap).toBeUndefined();
 	});
 
+	it("maps GLM-5.3 to the low/high/max ladder on the official endpoints only", () => {
+		// GLM-5.3 adds a genuine `low` effort tier beneath 5.2's high/max pair
+		// (official docs: low/high/max, default max) on the official Z.ai and
+		// Zhipu coding-plan endpoints. Resellers that mirror the zai dialect
+		// second-hand (Ollama Cloud, Baseten, Umans) keep the verified high/max
+		// pair until their 5.3 ladders are confirmed. The anthropic-messages
+		// coding proxy stays budget-effort mode; only the ladder widens.
+		const zaiCompletions = createModel({
+			id: "glm-5.3",
+			api: "openai-completions",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/paas/v4",
+		});
+		const zhipuCompletions = createModel({
+			id: "glm-5.3",
+			api: "openai-completions",
+			provider: "zhipu-coding-plan",
+			baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+		});
+		const zaiAnthropic = createModel({
+			id: "glm-5.3",
+			api: "anthropic-messages",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/anthropic",
+		});
+		const ollamaCloud = createModel({
+			id: "glm-5.3",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+		const baseten = createModel({
+			id: "glm-5.3",
+			api: "openai-completions",
+			provider: "baseten",
+			baseUrl: "https://api.baseten.co/v1",
+		});
+
+		expect(getSupportedEfforts(zaiCompletions)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(getSupportedEfforts(zhipuCompletions)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(zaiAnthropic.thinking?.mode).toBe("anthropic-budget-effort");
+		expect(getSupportedEfforts(zaiAnthropic)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(getSupportedEfforts(ollamaCloud)).toEqual([Effort.High, Effort.Max]);
+		expect(getSupportedEfforts(baseten)).toEqual([Effort.High, Effort.Max]);
+		for (const model of [zaiCompletions, zhipuCompletions, zaiAnthropic, ollamaCloud, baseten]) {
+			expect(model.thinking?.effortMap).toBeUndefined();
+		}
+	});
+
 	it("applies the DeepSeek effort contract to Ollama Cloud ollama-chat models (issue #8334)", () => {
 		const flash = createModel({
 			id: "deepseek-v4-flash",

--- a/packages/catalog/test/zai-bundled-catalog.test.ts
+++ b/packages/catalog/test/zai-bundled-catalog.test.ts
@@ -5,8 +5,12 @@ interface BundledModel {
 	api: string;
 	provider: string;
 	baseUrl: string;
+	reasoning: boolean;
+	input: string[];
+	cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	contextWindow: number | null;
 	maxTokens: number | null;
+	thinking?: { mode: string; efforts: string[] };
 }
 
 describe("zai bundled catalog", () => {
@@ -21,5 +25,38 @@ describe("zai bundled catalog", () => {
 		expect(model.contextWindow).toBe(1_000_000);
 		expect(model.maxTokens).toBe(131_072);
 		expect(Object.keys(zaiModels)).not.toContain("glm-5.2[1m]");
+	});
+
+	it("ships glm-5.3 with 1M context and the low/high/max ladder", () => {
+		const zaiModels = modelsJson.zai as Record<string, BundledModel>;
+		const model = zaiModels["glm-5.3"];
+
+		expect(model).toBeDefined();
+		expect(model.provider).toBe("zai");
+		expect(model.api).toBe("anthropic-messages");
+		expect(model.baseUrl).toBe("https://api.z.ai/api/anthropic");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text"]);
+		expect(model.contextWindow).toBe(1_000_000);
+		expect(model.maxTokens).toBe(131_072);
+		expect(model.thinking).toEqual({ mode: "anthropic-budget-effort", efforts: ["low", "high", "max"] });
+	});
+});
+
+describe("zhipu-coding-plan bundled catalog", () => {
+	it("ships glm-5.3 with 1M context and the low/high/max ladder", () => {
+		const zhipuModels = modelsJson["zhipu-coding-plan"] as Record<string, BundledModel>;
+		const model = zhipuModels["glm-5.3"];
+
+		expect(model).toBeDefined();
+		expect(model.provider).toBe("zhipu-coding-plan");
+		expect(model.api).toBe("openai-completions");
+		expect(model.baseUrl).toBe("https://open.bigmodel.cn/api/coding/paas/v4");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text"]);
+		expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(model.contextWindow).toBe(1_000_000);
+		expect(model.maxTokens).toBe(131_072);
+		expect(model.thinking).toEqual({ mode: "effort", efforts: ["low", "high", "max"] });
 	});
 });


### PR DESCRIPTION
Closes #8518
Closes #8540

I reviewed the full diff and exercised the change against the live endpoint myself: with this catalog, `resolveProviderModels` on `zhipu-coding-plan` merges a bare `{id: glm-5.3}` discovery row into 1M context / 131,072 max output / `low,high,max` efforts with the zai thinking format, and a real call to `https://open.bigmodel.cn/api/coding/paas/v4/chat/completions` with `model=glm-5.3` returned HTTP 200 for each of `reasoning_effort: low|high|max` (replying `PONG` at `low`).

## What changed

- **`packages/catalog/src/models.json`** — bundled `glm-5.3` rows for `zai` (anthropic-messages, `anthropic-budget-effort` mode) and `zhipu-coding-plan` (openai-completions, zai thinking format), with the published 1M context / 131,072 output limits, text-only input, and the official `low`/`high`/`max` effort ladder. zai carries the PAYG rates models.dev publishes for the same SKU (1.4 / 4.4 / 0.26); the coding-plan row is all-$0 subscription.
- **`packages/catalog/src/identity/family.ts`** — new `isGlm53ModelId` version-floor predicate (≥ 5.3) beside the existing `isGlm52ReasoningEffortModelId`, so future integers (`glm-6`, …) inherit the widened ladder without per-id edits.
- **`packages/catalog/src/model-thinking.ts`** — GLM-5.3+ on the official endpoints (zai thinking format, or zai anthropic-messages) derives `LOW_HIGH_MAX_REASONING_EFFORTS`. Resellers that mirror the zai dialect second-hand (Ollama Cloud, Baseten, Umans) keep the live-verified `high`/`max` pair until their 5.3 ladders are confirmed — say the word if you'd rather widen those too.
- **`packages/catalog/scripts/generated-policies.ts`** — the 1M/131,072 pin now covers `glm-5.3` on both coding-plan providers, same as the GLM-5.2 pin.

## Scope decisions (deliberately left alone)

- `zai` default model stays `glm-5.2` and `zhipu-coding-plan` stays `glm-5.1` — per the 5.2 rollout, moving the zai default needs maintainer sign-off.
- No `fetchDynamicModels` wiring for `zai` (#2446 concern) — separate change, not part of this rollout.
- `packages/ai/src/registry/zai.ts` `VALIDATION_MODEL` stays `glm-5.2` — the probe bump was its own change in the 5.2 cycle.

## Known runtime caveat

`zhipu-coding-plan` discovery is `dynamicModelsAuthoritative`, and the live `/models` endpoint does not list `glm-5.3` yet (it already serves it on `/chat/completions`). Until the endpoint catches up, the bundled row is pruned for logged-in zhipu users — the same transient the 5.2 rollout would have had. `zai` has no dynamic fetcher, so its bundled row surfaces immediately.

## Verification

- `bun test` in `packages/catalog`: 568 pass / 0 fail (new assertions: identity family, model-thinking dialects, generated-policy pin, bundled catalog rows on both providers).
- `bun run check` (biome + tsgo) clean in `packages/catalog` and `packages/ai`.
- Live endpoint: `glm-5.3` accepts `low` / `high` / `max` `reasoning_effort` (all HTTP 200), confirming the ladder from #8540 against the docs.
- Merge simulation: `resolveProviderModels` with a mocked `/models` returning bare `{id: "glm-5.3"}` resolves `ctx=1000000 max=131072 efforts=["low","high","max"]`.