### PR TITLE
fix(config): make modelRoles updates atomic and non-destructive

### DIFF
--- a/packages/coding-agent/src/cli/config-cli.ts
+++ b/packages/coding-agent/src/cli/config-cli.ts
@@ -7,6 +7,7 @@
 
 import { APP_NAME, getAgentDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
+import { isModelRoleValue } from "../config/model-roles";
 import {
 	getDefault,
 	getEnumValues,
@@ -222,6 +223,27 @@ function parseAndSetValue(path: SettingPath, rawValue: string): void {
 			}
 			if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
 				throw new Error(`Invalid record JSON: ${rawValue}`);
+			}
+			if (path === "modelRoles") {
+				// `config set modelRoles` is a patch operation, not a destructive
+				// replacement. Validate the entire patch before mutating so one bad
+				// entry cannot partially update the table, then use the per-role
+				// setter so Settings' save-time merge preserves every unrelated role.
+				const normalizedEntries: Array<[string, string]> = [];
+				for (const [role, value] of Object.entries(parsed)) {
+					if (typeof value !== "string") {
+						throw new Error(`Invalid model role value for ${role}: expected string`);
+					}
+					const normalized = value.trim();
+					if (!isModelRoleValue(normalized)) {
+						throw new Error(`Invalid model role value for ${role}: ${JSON.stringify(value)}`);
+					}
+					normalizedEntries.push([role, normalized]);
+				}
+				for (const [role, value] of normalizedEntries) {
+					settings.setModelRole(role, value);
+				}
+				return;
 			}
 			if (path === "providers.maxInFlightRequests") {
 				parsed = validateProviderMaxInFlightRequests(parsed);

--- a/packages/coding-agent/src/cli/config-cli.ts
+++ b/packages/coding-agent/src/cli/config-cli.ts
@@ -7,7 +7,6 @@
 
 import { APP_NAME, getAgentDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
-import { isModelRoleValue } from "../config/model-roles";
 import {
 	getDefault,
 	getEnumValues,
@@ -231,14 +230,10 @@ function parseAndSetValue(path: SettingPath, rawValue: string): void {
 				// setter so Settings' save-time merge preserves every unrelated role.
 				const normalizedEntries: Array<[string, string]> = [];
 				for (const [role, value] of Object.entries(parsed)) {
-					if (typeof value !== "string") {
-						throw new Error(`Invalid model role value for ${role}: expected string`);
+					if (typeof value !== "string" || value.trim().length === 0) {
+						throw new Error(`Invalid model role value for ${role}: expected non-empty string`);
 					}
-					const normalized = value.trim();
-					if (!isModelRoleValue(normalized)) {
-						throw new Error(`Invalid model role value for ${role}: ${JSON.stringify(value)}`);
-					}
-					normalizedEntries.push([role, normalized]);
+					normalizedEntries.push([role, value.trim()]);
 				}
 				for (const [role, value] of normalizedEntries) {
 					settings.setModelRole(role, value);

--- a/packages/coding-agent/test/config-cli-modelroles-safety.test.ts
+++ b/packages/coding-agent/test/config-cli-modelroles-safety.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { runConfigCommand } from "@oh-my-pi/pi-coding-agent/cli/config-cli";
+import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { getConfigRootDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+
+let testAgentDir: TempDir | undefined;
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+beforeEach(() => {
+	resetSettingsForTest();
+	testAgentDir = TempDir.createSync("@omp-config-modelroles-");
+	setAgentDir(testAgentDir.path());
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	AgentStorage.resetInstance();
+	resetSettingsForTest();
+	if (originalAgentDir) {
+		setAgentDir(originalAgentDir);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
+	if (testAgentDir) {
+		try {
+			await testAgentDir.remove();
+		} catch {}
+		testAgentDir = undefined;
+	}
+});
+
+async function readModelRoles(): Promise<Record<string, string>> {
+	const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	try {
+		await runConfigCommand({ action: "get", key: "modelRoles", flags: { json: true } });
+		const payload = logSpy.mock.calls.at(-1)?.[0];
+		const parsed = JSON.parse(String(payload)) as { value: Record<string, string> };
+		return parsed.value;
+	} finally {
+		logSpy.mockRestore();
+	}
+}
+
+describe("config set modelRoles safety", () => {
+	it("patches named roles without deleting unrelated roles", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		await runConfigCommand({
+			action: "set",
+			key: "modelRoles",
+			value: '{"default":"anthropic/claude-opus-4-6","task":"meta/worker-old","smol":"openai/gpt-small"}',
+			flags: { json: true },
+		});
+		vi.restoreAllMocks();
+
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		await runConfigCommand({
+			action: "set",
+			key: "modelRoles",
+			value: '{"task":"meta/worker-new"}',
+			flags: { json: true },
+		});
+		vi.restoreAllMocks();
+
+		const roles = await readModelRoles();
+		expect(roles.default).toBe("anthropic/claude-opus-4-6");
+		expect(roles.task).toBe("meta/worker-new");
+		expect(roles.smol).toBe("openai/gpt-small");
+	});
+
+	it("validates the whole patch before mutating any role", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		await runConfigCommand({
+			action: "set",
+			key: "modelRoles",
+			value: '{"default":"anthropic/claude-opus-4-6","task":"meta/worker-old","smol":"openai/gpt-small"}',
+			flags: { json: true },
+		});
+		vi.restoreAllMocks();
+		const before = await readModelRoles();
+
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as typeof process.exit);
+
+		await expect(
+			runConfigCommand({
+				action: "set",
+				key: "modelRoles",
+				value: '{"task":"meta/worker-new","smol":17}',
+				flags: { json: true },
+			}),
+		).rejects.toThrow("process.exit");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Invalid model role value for smol"));
+		vi.restoreAllMocks();
+
+		const after = await readModelRoles();
+		expect(after).toEqual(before);
+	});
+
+	it("normalizes valid role values before persisting", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		await runConfigCommand({
+			action: "set",
+			key: "modelRoles",
+			value: '{"task":"  @slow  "}',
+			flags: { json: true },
+		});
+		vi.restoreAllMocks();
+
+		const roles = await readModelRoles();
+		expect(roles.task).toBe("@slow");
+	});
+});


### PR DESCRIPTION
## Problem

`omp config set modelRoles '<json>'` currently replaces the whole `modelRoles` record. A caller trying to change one role can silently delete every sibling role from the config. This surfaced while verifying a routing extension that correctly used read/merge/write to work around the behavior.

## Fix

- Treat `config set modelRoles <json>` as an atomic per-role patch.
- Validate the entire supplied patch before mutating anything.
- Require non-empty string values and normalize surrounding whitespace.
- Persist each named role through `Settings.setModelRole()`, which already has per-role save/merge semantics and preserves unrelated/concurrently-edited sibling roles.
- Leave whole-map replacement available through the Settings API for intentional use cases such as profile switching; this only changes the generic CLI `config set modelRoles` behavior.

## Regression coverage

Adds tests proving:
- updating one role preserves unrelated roles;
- a mixed valid/invalid patch fails without partially mutating the table;
- role values are normalized before persistence.

## Scope

This does not make the generic config CLI bootstrap the full model registry or reject arbitrary catalog selectors. Runtime model availability/auth validation remains with model resolution and higher-level routing tools. The bug fixed here is the destructive record replacement and partial-write hazard.

## Verification

CI on the fork passed completely at head `a95374d3fcb39e839ec11fcc928d0c2aef894e41`, including workspace typecheck, CLI smoke, and TS workspace tests.