### PR TITLE
fix(tui): wait for wire-aliased edit previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `always-ask` approval prompts bypassing edit preview readiness when a built-in tool executes under its wire-level alias, such as `edit` running as `apply_patch` ([#8607](https://github.com/can1357/oh-my-pi/issues/8607)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -265,7 +265,10 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 
 		if (approvalCheck.required) {
 			const scheduledCall = context?.toolCall?.toolCalls[context.toolCall.index];
-			if (scheduledCall?.id === toolCallId && scheduledCall.name === this.tool.name) {
+			if (
+				scheduledCall?.id === toolCallId &&
+				(scheduledCall.name === this.tool.name || scheduledCall.name === this.tool.customWireName)
+			) {
 				await untilAborted(signal, () => this.runner.waitForToolApprovalPreview(toolCallId));
 			}
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1988,54 +1988,64 @@ describe("ExtensionRunner", () => {
 			delete globalState.__approvalEvents;
 		});
 
-		it("does not present approval before the tool preview is ready", async () => {
-			const result = await loadTestExtensions();
-			const runner = new ExtensionRunner(
-				result.extensions,
-				result.runtime,
-				tempDir.path(),
-				sessionManager,
-				modelRegistry,
-			);
-			const preview = Promise.withResolvers<void>();
-			const order: string[] = [];
-			runner.setToolApprovalPreviewWaiter(async toolCallId => {
-				order.push(`preview_wait:${toolCallId}`);
-				await preview.promise;
-				order.push("preview_ready");
-			});
-			initializeRunner(
-				runner,
-				vi.fn(async () => {
-					order.push("ui_select");
-					return "Approve";
-				}),
-			);
-
-			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
-			const execution = (wrapper as ExtensionToolWrapper<any>).execute("call-preview", {}, undefined, undefined, {
-				sessionManager,
-				modelRegistry,
-				model: undefined,
-				isIdle: () => true,
-				hasQueuedMessages: () => false,
-				abort: () => {},
-				settings: {
-					get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}),
-				} as never,
-				toolCall: {
-					batchId: "batch-preview",
-					index: 0,
-					total: 1,
-					toolCalls: [{ id: "call-preview", name: "dangerous_tool" }],
+		it("does not present approval before canonical or wire-aliased tool previews are ready", async () => {
+			const cases = [
+				{ tool: approvalTool, wireName: "dangerous_tool", toolCallId: "call-preview" },
+				{
+					tool: { ...approvalTool, name: "edit", customWireName: "apply_patch" },
+					wireName: "apply_patch",
+					toolCallId: "call-aliased-preview",
 				},
-			});
-			await Promise.resolve();
-			expect(order).toEqual(["preview_wait:call-preview"]);
+			];
+			for (const { tool, wireName, toolCallId } of cases) {
+				const result = await loadTestExtensions();
+				const runner = new ExtensionRunner(
+					result.extensions,
+					result.runtime,
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				const preview = Promise.withResolvers<void>();
+				const order: string[] = [];
+				runner.setToolApprovalPreviewWaiter(async waitedToolCallId => {
+					order.push(`preview_wait:${waitedToolCallId}`);
+					await preview.promise;
+					order.push("preview_ready");
+				});
+				initializeRunner(
+					runner,
+					vi.fn(async () => {
+						order.push("ui_select");
+						return "Approve";
+					}),
+				);
 
-			preview.resolve();
-			await execution;
-			expect(order).toEqual(["preview_wait:call-preview", "preview_ready", "ui_select"]);
+				const wrapper = new ExtensionToolWrapper(tool, runner);
+				const execution = (wrapper as ExtensionToolWrapper<any>).execute(toolCallId, {}, undefined, undefined, {
+					sessionManager,
+					modelRegistry,
+					model: undefined,
+					isIdle: () => true,
+					hasQueuedMessages: () => false,
+					abort: () => {},
+					settings: {
+						get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}),
+					} as never,
+					toolCall: {
+						batchId: `batch-${toolCallId}`,
+						index: 0,
+						total: 1,
+						toolCalls: [{ id: toolCallId, name: wireName }],
+					},
+				});
+				await Promise.resolve();
+				expect(order).toEqual([`preview_wait:${toolCallId}`]);
+
+				preview.resolve();
+				await execution;
+				expect(order).toEqual([`preview_wait:${toolCallId}`, "preview_ready", "ui_select"]);
+			}
 		});
 
 		it("emits resolved false when approval is denied", async () => {


### PR DESCRIPTION
## Repro
With `tools.approvalMode: always-ask`, execute the built-in `edit` tool through its `apply_patch` wire alias. `bun test packages/coding-agent/test/extensions-runner.test.ts --test-name-pattern 'wire-aliased tool previews'` reached `ui_select` instead of `preview_wait`, allowing the approval dialog to open before the diff rendered.

## Cause
`ExtensionToolWrapper.execute()` in `packages/coding-agent/src/extensibility/extensions/wrapper.ts` recognized a model-scheduled call only when its wire-level name equaled the wrapped tool's canonical `name`. For `apply_patch`, the scheduled name is `apply_patch` while the wrapped built-in remains `edit`, so the approval path skipped `waitForToolApprovalPreview()`.

## Fix
- Match scheduled calls against both the built-in tool's canonical name and `customWireName`.
- Cover canonical and `apply_patch`-aliased approval ordering in `extensions-runner.test.ts`.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/modes/controllers/event-controller-args-reveal.test.ts` — 81 passed, 0 failed. Pre-publish `bun run fix` and `bun check` passed during push and PR creation.

Fixes #8607