### PR TITLE
feat(acp): expose typed OMP runtime extensions

### DIFF
--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -379,6 +379,10 @@ export class AdvisorRuntime {
 	get backlog(): number {
 		return this.#backlog;
 	}
+	/** True only while this runtime is actively draining or awaiting an advisor prompt. */
+	get inFlight(): boolean {
+		return this.#busy || this.#promptInFlight !== undefined;
+	}
 	get quotaExhausted(): boolean {
 		return this.#quotaExhausted;
 	}

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -58,9 +58,6 @@ export class AutoLearnController {
 	#turnStartedInGoalMode = false;
 	/** Prevent overlapping private capture runs while real primary turns continue. */
 	#captureInFlight = false;
-	/** One newer eligible primary stop arrived while capture was running. */
-	#capturePending = false;
-
 	constructor(options: AutoLearnControllerOptions) {
 		this.#session = options.session;
 		this.#settings = options.settings;
@@ -130,7 +127,7 @@ export class AutoLearnController {
 		if (!autoContinue) return;
 
 		if (this.#captureInFlight) {
-			this.#capturePending = true;
+			this.#session.setAutolearnCapturePending(true);
 			return;
 		}
 		this.#startCapture();
@@ -144,8 +141,7 @@ export class AutoLearnController {
 			})
 			.finally(() => {
 				this.#captureInFlight = false;
-				if (!this.#capturePending) return;
-				this.#capturePending = false;
+				if (!this.#session.consumeAutolearnCapturePending()) return;
 				this.#startCapture();
 			});
 	}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -87,6 +87,8 @@ import {
 	mapAgentSessionEventToAcpSessionUpdates,
 	normalizeReplayToolArguments,
 } from "./acp-event-mapper";
+import { isOmpTypedExtensionMethod } from "./omp-extension-protocol";
+import { OmpAcpExtensionRuntime } from "./omp-extension-runtime";
 import { ACP_TERMINAL_AUTH_FLAG } from "./terminal-auth";
 
 const ACP_DEFAULT_MODE_ID = "default";
@@ -474,6 +476,7 @@ export class AcpAgent implements Agent {
 	#initialSession: AgentSession | undefined;
 	#createSession: CreateAcpSession;
 	#sessions = new Map<string, ManagedSessionRecord>();
+	#ompExtensions: OmpAcpExtensionRuntime;
 	#disposePromise: Promise<void> | undefined;
 	#cleanupRegistered = false;
 	#clientCapabilities: ClientCapabilities | undefined;
@@ -484,6 +487,10 @@ export class AcpAgent implements Agent {
 		this.#connection = connection;
 		this.#initialSession = initialSession;
 		this.#createSession = createSession;
+		this.#ompExtensions = new OmpAcpExtensionRuntime({
+			connection,
+			getSession: sessionId => this.#sessions.get(sessionId)?.session,
+		});
 	}
 
 	setCancelCleanupTimeoutForTesting(timeoutMs: number): void {
@@ -950,6 +957,7 @@ export class AcpAgent implements Agent {
 	}
 
 	async extMethod(method: string, params: { [key: string]: unknown }): Promise<{ [key: string]: unknown }> {
+		if (isOmpTypedExtensionMethod(method)) return await this.#ompExtensions.handleMethod(method, params);
 		switch (method) {
 			case SPEECH_MODELS_LIST_METHOD:
 				return buildAcpSpeechModelsCatalog();
@@ -1141,6 +1149,7 @@ export class AcpAgent implements Agent {
 			await this.#configureExtensions(record);
 			await this.#configureMcpServers(record, mcpServers);
 			this.#sessions.set(session.sessionId, record);
+			this.#ompExtensions.attachSession(session);
 			return record;
 		} catch (error) {
 			await this.#disposeSessionRecord(record);
@@ -2529,6 +2538,7 @@ export class AcpAgent implements Agent {
 	async #closeManagedSession(sessionId: string, record: ManagedSessionRecord): Promise<void> {
 		record.closedError ??= this.#createPromptLifecycleError("ACP session closed before queued prompt could run");
 		this.#sessions.delete(sessionId);
+		this.#ompExtensions.detachSession(sessionId);
 		await this.#cancelPromptForClose(record);
 		await this.#disposeSessionRecord(record);
 	}
@@ -2581,6 +2591,7 @@ export class AcpAgent implements Agent {
 		this.#disposePromise = (async () => {
 			const records = Array.from(this.#sessions.entries());
 			this.#sessions.clear();
+			this.#ompExtensions.detachAll();
 			await Promise.all(
 				records.map(async ([sessionId, record]) => {
 					try {

--- a/packages/coding-agent/src/modes/acp/omp-extension-protocol.ts
+++ b/packages/coding-agent/src/modes/acp/omp-extension-protocol.ts
@@ -30,6 +30,15 @@ export const OMP_EXTENSION_EVENTS = {
 	launchLifecycle: "_omp/launch/lifecycle",
 } as const;
 
+export const OMP_LAUNCH_LIFECYCLE_EVENTS = {
+	completed: "completed",
+	sent: "sent",
+	stopped: "stopped",
+	restarted: "restarted",
+} as const;
+
+export type OmpLaunchLifecycleEvent = (typeof OMP_LAUNCH_LIFECYCLE_EVENTS)[keyof typeof OMP_LAUNCH_LIFECYCLE_EVENTS];
+
 const METHOD_SET = new Set<string>(Object.values(OMP_EXTENSION_METHODS));
 
 export type OmpExtensionFeatureName = "advisor" | "autolearn" | "memory" | "launch" | "managedSkills";

--- a/packages/coding-agent/src/modes/acp/omp-extension-protocol.ts
+++ b/packages/coding-agent/src/modes/acp/omp-extension-protocol.ts
@@ -1,0 +1,222 @@
+import { VERSION } from "@oh-my-pi/pi-utils";
+
+export const OMP_EXTENSION_SCHEMA_VERSION = 1;
+export const OMP_EXTENSION_MAX_TEXT_BYTES = 16 * 1024;
+export const OMP_EXTENSION_MAX_TIMEOUT_MS = 15_000;
+
+export const OMP_EXTENSION_METHODS = {
+	capabilities: "_omp/capabilities",
+	advisorStatus: "_omp/advisor/status",
+	advisorSet: "_omp/advisor/set",
+	advisorDrain: "_omp/advisor/drain",
+	autolearnStatus: "_omp/autolearn/status",
+	autolearnDrain: "_omp/autolearn/drain",
+	memoryStatus: "_omp/memory/status",
+	memoryStats: "_omp/memory/stats",
+	memoryDiagnose: "_omp/memory/diagnose",
+	memoryEnqueue: "_omp/memory/enqueue",
+	memoryClear: "_omp/memory/clear",
+	launchList: "_omp/launch/list",
+	launchDescribe: "_omp/launch/describe",
+	launchLogs: "_omp/launch/logs",
+	launchSend: "_omp/launch/send",
+	launchStop: "_omp/launch/stop",
+	launchRestart: "_omp/launch/restart",
+} as const;
+
+export const OMP_EXTENSION_EVENTS = {
+	advisorNote: "_omp/advisor/note",
+	autolearnLifecycle: "_omp/autolearn/lifecycle",
+	launchLifecycle: "_omp/launch/lifecycle",
+} as const;
+
+const METHOD_SET = new Set<string>(Object.values(OMP_EXTENSION_METHODS));
+
+export type OmpExtensionFeatureName = "advisor" | "autolearn" | "memory" | "launch" | "managedSkills";
+
+export interface OmpExtensionFeatureCapability {
+	available: boolean;
+	enabled: boolean;
+	observable: boolean;
+	controllable: boolean;
+	recoverable: boolean;
+	methods: string[];
+	events: string[];
+	reason?: string;
+}
+
+export interface OmpExtensionError {
+	code: string;
+	message: string;
+	recoverable: boolean;
+	detail?: Record<string, unknown>;
+}
+
+export interface OmpExtensionEnvelope<T extends Record<string, unknown> = Record<string, unknown>> {
+	schemaVersion: typeof OMP_EXTENSION_SCHEMA_VERSION;
+	ompVersion: string;
+	sessionId: string;
+	generation: string;
+	sequence: number;
+	timestamp: string;
+	correlationId?: string;
+	data?: T;
+	error?: OmpExtensionError;
+}
+
+export interface OmpExtensionRequestContext {
+	sessionId: string;
+	correlationId?: string;
+	timeoutMs: number;
+}
+
+export interface OmpExtensionSequenceState {
+	generation: string;
+	sequence: number;
+}
+
+export function isOmpTypedExtensionMethod(method: string): boolean {
+	return METHOD_SET.has(method);
+}
+
+export function parseOmpExtensionRequest(params: Record<string, unknown>): OmpExtensionRequestContext {
+	const sessionId = requiredString(params.sessionId, "sessionId", 512);
+	const correlationId = optionalString(params.correlationId, "correlationId", 512);
+	const requestedTimeout = optionalInteger(params.timeoutMs, "timeoutMs");
+	return {
+		sessionId,
+		correlationId,
+		timeoutMs: Math.max(1, Math.min(OMP_EXTENSION_MAX_TIMEOUT_MS, requestedTimeout ?? 5_000)),
+	};
+}
+
+export function requiredString(value: unknown, label: string, maxBytes = OMP_EXTENSION_MAX_TEXT_BYTES): string {
+	if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+	if (Buffer.byteLength(value, "utf8") > maxBytes) throw new Error(`${label} exceeds ${maxBytes} bytes`);
+	return value;
+}
+
+export function optionalString(
+	value: unknown,
+	label: string,
+	maxBytes = OMP_EXTENSION_MAX_TEXT_BYTES,
+): string | undefined {
+	if (value === undefined) return undefined;
+	return requiredString(value, label, maxBytes);
+}
+
+export function requiredBoolean(value: unknown, label: string): boolean {
+	if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+	return value;
+}
+
+export function optionalBoolean(value: unknown, label: string): boolean | undefined {
+	if (value === undefined) return undefined;
+	return requiredBoolean(value, label);
+}
+
+export function optionalInteger(value: unknown, label: string): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "number" || !Number.isSafeInteger(value)) throw new Error(`${label} must be an integer`);
+	return value;
+}
+
+export function boundedInteger(value: unknown, label: string, fallback: number, min: number, max: number): number {
+	const parsed = optionalInteger(value, label) ?? fallback;
+	return Math.max(min, Math.min(max, parsed));
+}
+
+export function createOmpExtensionSequenceState(): OmpExtensionSequenceState {
+	return { generation: crypto.randomUUID(), sequence: 0 };
+}
+
+export function createOmpExtensionEnvelope<T extends Record<string, unknown>>(
+	state: OmpExtensionSequenceState,
+	context: Pick<OmpExtensionRequestContext, "sessionId" | "correlationId">,
+	data: T,
+): OmpExtensionEnvelope<T> {
+	state.sequence += 1;
+	return {
+		schemaVersion: OMP_EXTENSION_SCHEMA_VERSION,
+		ompVersion: VERSION,
+		sessionId: context.sessionId,
+		generation: state.generation,
+		sequence: state.sequence,
+		timestamp: new Date().toISOString(),
+		...(context.correlationId === undefined ? {} : { correlationId: context.correlationId }),
+		data,
+	};
+}
+
+export function createOmpExtensionCapabilities(
+	enabled: Pick<Record<OmpExtensionFeatureName, boolean>, "advisor" | "autolearn" | "memory" | "launch">,
+): Record<string, unknown> {
+	const feature = (
+		name: Exclude<OmpExtensionFeatureName, "managedSkills">,
+		methods: string[],
+		events: string[],
+		recoverable: boolean,
+	): OmpExtensionFeatureCapability => ({
+		available: true,
+		enabled: enabled[name],
+		observable: true,
+		controllable: methods.some(method => !method.endsWith("/status") && !method.endsWith("/list")),
+		recoverable,
+		methods,
+		events,
+	});
+	return {
+		protocol: "omp-acp-extensions",
+		supportedSchemaVersions: [OMP_EXTENSION_SCHEMA_VERSION],
+		selectedSchemaVersion: OMP_EXTENSION_SCHEMA_VERSION,
+		features: {
+			advisor: feature(
+				"advisor",
+				[OMP_EXTENSION_METHODS.advisorStatus, OMP_EXTENSION_METHODS.advisorSet, OMP_EXTENSION_METHODS.advisorDrain],
+				[OMP_EXTENSION_EVENTS.advisorNote],
+				true,
+			),
+			autolearn: feature(
+				"autolearn",
+				[OMP_EXTENSION_METHODS.autolearnStatus, OMP_EXTENSION_METHODS.autolearnDrain],
+				[OMP_EXTENSION_EVENTS.autolearnLifecycle],
+				true,
+			),
+			memory: feature(
+				"memory",
+				[
+					OMP_EXTENSION_METHODS.memoryStatus,
+					OMP_EXTENSION_METHODS.memoryStats,
+					OMP_EXTENSION_METHODS.memoryDiagnose,
+					OMP_EXTENSION_METHODS.memoryEnqueue,
+					OMP_EXTENSION_METHODS.memoryClear,
+				],
+				[],
+				true,
+			),
+			launch: feature(
+				"launch",
+				[
+					OMP_EXTENSION_METHODS.launchList,
+					OMP_EXTENSION_METHODS.launchDescribe,
+					OMP_EXTENSION_METHODS.launchLogs,
+					OMP_EXTENSION_METHODS.launchSend,
+					OMP_EXTENSION_METHODS.launchStop,
+					OMP_EXTENSION_METHODS.launchRestart,
+				],
+				[OMP_EXTENSION_EVENTS.launchLifecycle],
+				true,
+			),
+			managedSkills: {
+				available: false,
+				enabled: false,
+				observable: false,
+				controllable: false,
+				recoverable: false,
+				methods: [],
+				events: [],
+				reason: "No stable typed managed-skills owner is exposed by the ACP runtime.",
+			} satisfies OmpExtensionFeatureCapability,
+		},
+	};
+}

--- a/packages/coding-agent/src/modes/acp/omp-extension-runtime.ts
+++ b/packages/coding-agent/src/modes/acp/omp-extension-runtime.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { getAgentDir, logger, VERSION } from "@oh-my-pi/pi-utils";
 import type { AgentSideConnection } from "@oh-my-pi/pi-utils/acp";
 import type { Settings } from "../../config/settings";
-import { daemonClientForProject, type DaemonBrokerClient } from "../../launch/client";
+import { type DaemonBrokerClient, daemonClientForProject } from "../../launch/client";
 import type { DaemonOperation, DaemonRpcResult, DaemonSnapshot } from "../../launch/protocol";
 import { resolveMemoryBackend } from "../../memory-backend/resolve";
 import type { MemoryBackend, MemoryBackendStatus } from "../../memory-backend/types";
@@ -16,14 +16,14 @@ import {
 	OMP_EXTENSION_MAX_TEXT_BYTES,
 	OMP_EXTENSION_METHODS,
 	OMP_EXTENSION_SCHEMA_VERSION,
+	type OmpExtensionEnvelope,
+	type OmpExtensionRequestContext,
+	type OmpExtensionSequenceState,
 	optionalBoolean,
 	optionalString,
 	parseOmpExtensionRequest,
 	requiredBoolean,
 	requiredString,
-	type OmpExtensionEnvelope,
-	type OmpExtensionRequestContext,
-	type OmpExtensionSequenceState,
 } from "./omp-extension-protocol";
 
 type ExtensionConnection = Pick<AgentSideConnection, "extNotification">;
@@ -316,11 +316,11 @@ export class OmpAcpExtensionRuntime {
 			enabled: stats.configured,
 			active: stats.active,
 			model: formatModel(stats.model),
-				advisors: advisors.map(advisor => ({
-					id: advisor.name,
-					status: advisor.status,
-					backlog: advisor.backlog,
-					inFlight: advisor.inFlight,
+			advisors: advisors.map(advisor => ({
+				id: advisor.name,
+				status: advisor.status,
+				backlog: advisor.backlog,
+				inFlight: advisor.inFlight,
 				model: formatModel(advisor.model),
 				usage: advisor.tokens,
 				cost: advisor.cost,
@@ -329,8 +329,8 @@ export class OmpAcpExtensionRuntime {
 			advisorsTruncated: stats.advisors.length > advisors.length,
 			usage: stats.tokens,
 			cost: stats.cost,
-				backlog: stats.advisors.reduce((sum, advisor) => sum + advisor.backlog, 0),
-				inFlight: stats.advisors.some(advisor => advisor.inFlight),
+			backlog: stats.advisors.reduce((sum, advisor) => sum + advisor.backlog, 0),
+			inFlight: stats.advisors.some(advisor => advisor.inFlight),
 			lastFailure: stats.advisors.some(advisor => advisor.status === "error")
 				? { available: true, message: "One or more advisors report an error." }
 				: { available: false },

--- a/packages/coding-agent/src/modes/acp/omp-extension-runtime.ts
+++ b/packages/coding-agent/src/modes/acp/omp-extension-runtime.ts
@@ -1,0 +1,692 @@
+import * as path from "node:path";
+import { getAgentDir, logger, VERSION } from "@oh-my-pi/pi-utils";
+import type { AgentSideConnection } from "@oh-my-pi/pi-utils/acp";
+import type { Settings } from "../../config/settings";
+import { daemonClientForProject, type DaemonBrokerClient } from "../../launch/client";
+import type { DaemonOperation, DaemonRpcResult, DaemonSnapshot } from "../../launch/protocol";
+import { resolveMemoryBackend } from "../../memory-backend/resolve";
+import type { MemoryBackend, MemoryBackendStatus } from "../../memory-backend/types";
+import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
+import {
+	boundedInteger,
+	createOmpExtensionCapabilities,
+	createOmpExtensionEnvelope,
+	createOmpExtensionSequenceState,
+	OMP_EXTENSION_EVENTS,
+	OMP_EXTENSION_MAX_TEXT_BYTES,
+	OMP_EXTENSION_METHODS,
+	OMP_EXTENSION_SCHEMA_VERSION,
+	optionalBoolean,
+	optionalString,
+	parseOmpExtensionRequest,
+	requiredBoolean,
+	requiredString,
+	type OmpExtensionEnvelope,
+	type OmpExtensionRequestContext,
+	type OmpExtensionSequenceState,
+} from "./omp-extension-protocol";
+
+type ExtensionConnection = Pick<AgentSideConnection, "extNotification">;
+type SessionResolver = (sessionId: string) => AgentSession | undefined;
+type MemoryResolver = (settings: Settings) => Promise<MemoryBackend>;
+type DaemonClientResolver = (cwd: string) => Promise<DaemonBrokerClient>;
+
+export interface OmpAcpExtensionRuntimeOptions {
+	connection: ExtensionConnection;
+	getSession: SessionResolver;
+	getAgentDir?: () => string;
+	resolveMemoryBackend?: MemoryResolver;
+	daemonClientForProject?: DaemonClientResolver;
+}
+
+interface ManagedExtensionState extends OmpExtensionSequenceState {
+	session: AgentSession;
+	sessionId: string;
+	aliases: Set<string>;
+	negotiated: boolean;
+	droppedNotifications: number;
+	unsubscribe: () => void;
+}
+
+interface MemoryClearChallenge {
+	id: string;
+	expiresAt: number;
+	backend: string;
+}
+
+const WRITE_OR_EXEC_TOOLS = new Set(["bash", "edit", "write", "delete", "apply_patch", "python"]);
+const MEMORY_TEXT_LIMIT = 16 * 1024;
+const MEMORY_CLEAR_CHALLENGE_TTL_MS = 60_000;
+const MAX_STATUS_ITEMS = 256;
+const MAX_PENDING_NOTIFICATIONS = 256;
+
+function asRecord<T extends Record<string, unknown>>(envelope: OmpExtensionEnvelope<T>): Record<string, unknown> {
+	return { ...envelope };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatModel(model: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(model)) return undefined;
+	const provider = typeof model.provider === "string" ? model.provider : undefined;
+	const id = typeof model.id === "string" ? model.id : undefined;
+	if (!provider && !id) return undefined;
+	return { ...(provider ? { provider } : {}), ...(id ? { id } : {}) };
+}
+
+function sanitizeError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.length > 2_000 ? `${message.slice(0, 1_997)}...` : message;
+}
+
+function boundedText(value: string | undefined, limit = MEMORY_TEXT_LIMIT): string | undefined {
+	if (value === undefined) return undefined;
+	if (Buffer.byteLength(value, "utf8") <= limit) return value;
+	let end = Math.min(value.length, limit);
+	while (end > 0 && Buffer.byteLength(value.slice(0, end), "utf8") > limit) end--;
+	return `${value.slice(0, end)}...`;
+}
+
+function redactText(session: AgentSession, value: string | undefined, limit = MEMORY_TEXT_LIMIT): string | undefined {
+	const bounded = boundedText(value, limit);
+	if (!bounded) return bounded;
+	return session.obfuscator?.hasSecrets() === true ? session.obfuscator.obfuscate(bounded) : bounded;
+}
+
+function safeMemoryStatus(status: MemoryBackendStatus): Record<string, unknown> {
+	return {
+		backend: status.backend,
+		active: status.active,
+		writable: status.writable,
+		searchable: status.searchable,
+		scope: status.scope,
+		storage: {
+			kind: status.database ? "database" : status.backend === "off" ? "none" : "backend-managed",
+			pathId: status.database ? path.basename(status.database) : undefined,
+		},
+		queue: {
+			workingCount: status.workingCount,
+			episodicCount: status.episodicCount,
+			tripleCount: status.tripleCount,
+		},
+		lastRecall: status.lastRecall,
+		message: status.message,
+		error: status.error,
+	};
+}
+
+function publicDaemonSnapshot(daemon: DaemonSnapshot): Record<string, unknown> {
+	return {
+		serviceId: daemon.id,
+		name: daemon.name,
+		state: daemon.state,
+		pid: daemon.pid,
+		startedAt: daemon.startedAt === 0 ? undefined : new Date(daemon.startedAt).toISOString(),
+		exitedAt: daemon.exitedAt === undefined ? undefined : new Date(daemon.exitedAt).toISOString(),
+		exitCode: daemon.exitCode,
+		failure: daemon.exitReason,
+		restartCount: daemon.restartCount,
+		outputBytes: daemon.outputBytes,
+		owner: daemon.owner,
+		persist: daemon.persist,
+		detached: daemon.detached,
+	};
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+	const timeout = Promise.withResolvers<T>();
+	const timer = setTimeout(() => timeout.reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+	return Promise.race([promise, timeout.promise]).finally(() => clearTimeout(timer));
+}
+
+export class OmpAcpExtensionRuntime {
+	readonly #connection: ExtensionConnection;
+	readonly #getSession: SessionResolver;
+	readonly #getAgentDir: () => string;
+	readonly #resolveMemoryBackend: MemoryResolver;
+	readonly #daemonClientForProject: DaemonClientResolver;
+	readonly #states = new Map<string, ManagedExtensionState>();
+	readonly #memoryClearChallenges = new Map<string, MemoryClearChallenge>();
+	#notificationQueue = Promise.resolve();
+	#pendingNotifications = 0;
+
+	constructor(options: OmpAcpExtensionRuntimeOptions) {
+		this.#connection = options.connection;
+		this.#getSession = options.getSession;
+		this.#getAgentDir = options.getAgentDir ?? getAgentDir;
+		this.#resolveMemoryBackend = options.resolveMemoryBackend ?? resolveMemoryBackend;
+		this.#daemonClientForProject = options.daemonClientForProject ?? daemonClientForProject;
+	}
+
+	attachSession(session: AgentSession): void {
+		const existing = this.#states.get(session.sessionId);
+		if (existing?.session === session) return;
+		existing?.unsubscribe();
+		const sequence = createOmpExtensionSequenceState();
+		const state: ManagedExtensionState = {
+			...sequence,
+			session,
+			sessionId: session.sessionId,
+			aliases: new Set([session.sessionId]),
+			negotiated: false,
+			droppedNotifications: 0,
+			unsubscribe: () => {},
+		};
+		const unsubscribeEvents = session.subscribe(event => this.#onSessionEvent(state, event));
+		const unsubscribeSessionChange = session.registerSessionChangeCallback(() => this.#rotateSessionState(state));
+		state.unsubscribe = () => {
+			unsubscribeEvents();
+			unsubscribeSessionChange();
+		};
+		this.#states.set(session.sessionId, state);
+	}
+
+	detachSession(sessionId: string): void {
+		const state =
+			this.#states.get(sessionId) ?? [...this.#states.values()].find(candidate => candidate.aliases.has(sessionId));
+		if (!state) return;
+		state.negotiated = false;
+		state.generation = crypto.randomUUID();
+		state.unsubscribe();
+		this.#states.delete(state.sessionId);
+		for (const alias of state.aliases) this.#memoryClearChallenges.delete(alias);
+	}
+
+	detachAll(): void {
+		for (const sessionId of [...this.#states.keys()]) this.detachSession(sessionId);
+	}
+
+	async handleMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const context = parseOmpExtensionRequest(params);
+		const state = this.#resolveState(context.sessionId);
+		try {
+			const data = await withTimeout(
+				this.#handleMethodData(method, params, context, state),
+				context.timeoutMs,
+				method,
+			);
+			if (method === OMP_EXTENSION_METHODS.capabilities) state.negotiated = true;
+			return asRecord(createOmpExtensionEnvelope(state, context, data));
+		} catch (error) {
+			state.sequence += 1;
+			return {
+				schemaVersion: OMP_EXTENSION_SCHEMA_VERSION,
+				ompVersion: VERSION,
+				sessionId: context.sessionId,
+				generation: state.generation,
+				sequence: state.sequence,
+				timestamp: new Date().toISOString(),
+				...(context.correlationId === undefined ? {} : { correlationId: context.correlationId }),
+				error: {
+					code: this.#errorCode(error),
+					message: redactText(state.session, sanitizeError(error), 2_000),
+					recoverable: this.#isRecoverable(error),
+					detail: { method },
+				},
+			};
+		}
+	}
+
+	#resolveState(sessionId: string): ManagedExtensionState {
+		const existing = this.#states.get(sessionId);
+		if (existing) return existing;
+		const session = this.#getSession(sessionId);
+		if (!session) throw new Error(`Unsupported ACP session: ${sessionId}`);
+		this.attachSession(session);
+		const attached = this.#states.get(sessionId);
+		if (!attached) throw new Error(`Failed to attach ACP session: ${sessionId}`);
+		return attached;
+	}
+
+	async #handleMethodData(
+		method: string,
+		params: Record<string, unknown>,
+		context: OmpExtensionRequestContext,
+		state: ManagedExtensionState,
+	): Promise<Record<string, unknown>> {
+		switch (method) {
+			case OMP_EXTENSION_METHODS.capabilities:
+				return this.#capabilities(state.session, params);
+			case OMP_EXTENSION_METHODS.advisorStatus:
+				return this.#advisorStatus(state.session);
+			case OMP_EXTENSION_METHODS.advisorSet:
+				return this.#advisorSet(state.session, params);
+			case OMP_EXTENSION_METHODS.advisorDrain:
+				return await this.#advisorDrain(state, context.timeoutMs);
+			case OMP_EXTENSION_METHODS.autolearnStatus:
+				return this.#autolearnStatus(state.session);
+			case OMP_EXTENSION_METHODS.autolearnDrain: {
+				const result = await state.session.drainAutolearnCaptureForAcp({
+					timeoutMs: context.timeoutMs,
+					cancel: optionalBoolean(params.cancel, "cancel") ?? false,
+				});
+				return {
+					...result,
+					...(typeof result.failure === "string" ? { failure: redactText(state.session, result.failure) } : {}),
+					status: this.#autolearnStatus(state.session),
+				};
+			}
+			case OMP_EXTENSION_METHODS.memoryStatus:
+				return await this.#memoryStatus(state.session);
+			case OMP_EXTENSION_METHODS.memoryStats:
+				return await this.#memoryText(state.session, "stats");
+			case OMP_EXTENSION_METHODS.memoryDiagnose:
+				return await this.#memoryText(state.session, "diagnose");
+			case OMP_EXTENSION_METHODS.memoryEnqueue:
+				return await this.#memoryEnqueue(state.session);
+			case OMP_EXTENSION_METHODS.memoryClear:
+				return await this.#memoryClear(state.session, params);
+			case OMP_EXTENSION_METHODS.launchList:
+			case OMP_EXTENSION_METHODS.launchDescribe:
+			case OMP_EXTENSION_METHODS.launchLogs:
+			case OMP_EXTENSION_METHODS.launchSend:
+			case OMP_EXTENSION_METHODS.launchStop:
+			case OMP_EXTENSION_METHODS.launchRestart:
+				return await this.#launch(state, method, params, context.timeoutMs);
+			default:
+				throw new Error(`Unknown OMP typed extension method: ${method}`);
+		}
+	}
+
+	#capabilities(session: AgentSession, params: Record<string, unknown>): Record<string, unknown> {
+		if (params.supportedSchemaVersions !== undefined) {
+			if (
+				!Array.isArray(params.supportedSchemaVersions) ||
+				!params.supportedSchemaVersions.includes(OMP_EXTENSION_SCHEMA_VERSION)
+			) {
+				throw new Error("Unsupported OMP typed extension schema version");
+			}
+		}
+		return createOmpExtensionCapabilities({
+			advisor: session.settings.get("advisor.enabled") === true,
+			autolearn: session.settings.get("autolearn.enabled") === true,
+			memory: session.settings.get("memory.backend") !== "off",
+			launch: true,
+		});
+	}
+
+	#advisorStatus(session: AgentSession): Record<string, unknown> {
+		const stats = session.getAdvisorStats();
+		const grantedTools = session.getAdvisorAvailableToolNames();
+		const toolRisk = grantedTools.some(tool => WRITE_OR_EXEC_TOOLS.has(tool)) ? "write-or-exec" : "read-only";
+		const advisors = stats.advisors.slice(0, MAX_STATUS_ITEMS);
+		return {
+			enabled: stats.configured,
+			active: stats.active,
+			model: formatModel(stats.model),
+				advisors: advisors.map(advisor => ({
+					id: advisor.name,
+					status: advisor.status,
+					backlog: advisor.backlog,
+					inFlight: advisor.inFlight,
+				model: formatModel(advisor.model),
+				usage: advisor.tokens,
+				cost: advisor.cost,
+				messages: advisor.messages,
+			})),
+			advisorsTruncated: stats.advisors.length > advisors.length,
+			usage: stats.tokens,
+			cost: stats.cost,
+				backlog: stats.advisors.reduce((sum, advisor) => sum + advisor.backlog, 0),
+				inFlight: stats.advisors.some(advisor => advisor.inFlight),
+			lastFailure: stats.advisors.some(advisor => advisor.status === "error")
+				? { available: true, message: "One or more advisors report an error." }
+				: { available: false },
+			grantedTools,
+			toolRisk,
+		};
+	}
+
+	#autolearnStatus(session: AgentSession): Record<string, unknown> {
+		const status = session.getAutolearnStatus();
+		return {
+			...status,
+			...(typeof status.lastFailure === "string" ? { lastFailure: redactText(session, status.lastFailure) } : {}),
+		};
+	}
+
+	#advisorSet(session: AgentSession, params: Record<string, unknown>): Record<string, unknown> {
+		const enabled = requiredBoolean(params.enabled, "enabled");
+		const active = session.setAdvisorEnabled(enabled);
+		return { enabled, active, status: this.#advisorStatus(session) };
+	}
+
+	async #advisorDrain(state: ManagedExtensionState, timeoutMs: number): Promise<Record<string, unknown>> {
+		const deadline = Date.now() + timeoutMs;
+		const advisorSettled = await state.session.waitForAdvisorCatchup(timeoutMs);
+		const notificationsSettled = await this.#waitForNotifications(Math.max(0, deadline - Date.now()));
+		const droppedNotifications = state.droppedNotifications;
+		return {
+			settled: advisorSettled && notificationsSettled && droppedNotifications === 0,
+			advisorSettled,
+			notificationsSettled,
+			notificationBackpressure: { dropped: droppedNotifications, recoverable: false },
+			timeoutMs,
+			status: this.#advisorStatus(state.session),
+		};
+	}
+
+	async #waitForNotifications(timeoutMs: number): Promise<boolean> {
+		if (this.#pendingNotifications === 0) return true;
+		if (timeoutMs <= 0) return false;
+		const pending = this.#notificationQueue.then(() => true as const);
+		const { promise: timedOut, resolve } = Promise.withResolvers<false>();
+		const timer = setTimeout(() => resolve(false), timeoutMs);
+		try {
+			return await Promise.race([pending, timedOut]);
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	async #memoryContext(session: AgentSession): Promise<{
+		backend: MemoryBackend;
+		agentDir: string;
+		cwd: string;
+	}> {
+		return {
+			backend: await this.#resolveMemoryBackend(session.settings),
+			agentDir: this.#getAgentDir(),
+			cwd: session.sessionManager.getCwd(),
+		};
+	}
+
+	async #memoryStatus(session: AgentSession): Promise<Record<string, unknown>> {
+		const { backend, agentDir, cwd } = await this.#memoryContext(session);
+		const raw = backend.status
+			? await backend.status({ agentDir, cwd, session })
+			: ({
+					backend: backend.id,
+					active: backend.id !== "off",
+					writable: backend.id !== "off",
+					searchable: backend.id !== "off",
+				} satisfies MemoryBackendStatus);
+		const safe = safeMemoryStatus(raw);
+		if (typeof safe.message === "string") safe.message = redactText(session, safe.message);
+		if (typeof safe.error === "string") safe.error = redactText(session, safe.error);
+		return safe;
+	}
+
+	async #memoryText(session: AgentSession, operation: "stats" | "diagnose"): Promise<Record<string, unknown>> {
+		const { backend, agentDir, cwd } = await this.#memoryContext(session);
+		const handler = operation === "stats" ? backend.stats : backend.diagnose;
+		if (!handler) return { available: false, backend: backend.id };
+		const text = await handler.call(backend, agentDir, cwd, session);
+		return { available: text !== undefined, backend: backend.id, text: redactText(session, text) };
+	}
+
+	async #memoryEnqueue(session: AgentSession): Promise<Record<string, unknown>> {
+		const { backend, agentDir, cwd } = await this.#memoryContext(session);
+		await backend.enqueue(agentDir, cwd, session);
+		return { enqueued: true, backend: backend.id, status: await this.#memoryStatus(session) };
+	}
+
+	async #memoryClear(session: AgentSession, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const { backend, agentDir, cwd } = await this.#memoryContext(session);
+		const supplied = optionalString(params.confirmationId, "confirmationId", 512);
+		const existing = this.#memoryClearChallenges.get(session.sessionId);
+		if (
+			!supplied ||
+			!existing ||
+			existing.id !== supplied ||
+			existing.backend !== backend.id ||
+			existing.expiresAt < Date.now()
+		) {
+			const challenge: MemoryClearChallenge = {
+				id: crypto.randomUUID(),
+				expiresAt: Date.now() + MEMORY_CLEAR_CHALLENGE_TTL_MS,
+				backend: backend.id,
+			};
+			this.#memoryClearChallenges.set(session.sessionId, challenge);
+			return {
+				cleared: false,
+				confirmationRequired: true,
+				confirmationId: challenge.id,
+				expiresAt: new Date(challenge.expiresAt).toISOString(),
+				backend: backend.id,
+				scope: path.basename(session.sessionManager.getCwd()),
+			};
+		}
+		this.#memoryClearChallenges.delete(session.sessionId);
+		await backend.clear(agentDir, cwd, session);
+		return { cleared: true, confirmationRequired: false, backend: backend.id };
+	}
+
+	async #launch(
+		state: ManagedExtensionState,
+		method: string,
+		params: Record<string, unknown>,
+		timeoutMs: number,
+	): Promise<Record<string, unknown>> {
+		const session = state.session;
+		const client = await this.#daemonClientForProject(session.sessionManager.getCwd());
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		try {
+			if (method === OMP_EXTENSION_METHODS.launchList) {
+				const result = await client.request({ op: "list" }, controller.signal);
+				if (result.op !== "list") throw new Error(`Unexpected launch result: ${result.op}`);
+				const owned = this.#ownedDaemons(session, result.daemons);
+				return {
+					authority: "omp",
+					services: owned.slice(0, MAX_STATUS_ITEMS).map(publicDaemonSnapshot),
+					servicesTruncated: owned.length > MAX_STATUS_ITEMS,
+				};
+			}
+			const name = requiredString(params.name, "name", 512);
+			await this.#assertOwnedDaemon(client, session, name, controller.signal);
+			const operation = this.#launchOperation(method, params, name, timeoutMs);
+			const result = await client.request(operation, controller.signal);
+			const data = this.#launchResult(session, result);
+			if (
+				"daemon" in result &&
+				(method === OMP_EXTENSION_METHODS.launchSend ||
+					method === OMP_EXTENSION_METHODS.launchStop ||
+					method === OMP_EXTENSION_METHODS.launchRestart)
+			) {
+				await this.#enqueueNotification(state, OMP_EXTENSION_EVENTS.launchLifecycle, {
+					event: method.slice(method.lastIndexOf("/") + 1),
+					service: publicDaemonSnapshot(result.daemon),
+				});
+			}
+			return data;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	#launchOperation(method: string, params: Record<string, unknown>, name: string, timeoutMs: number): DaemonOperation {
+		switch (method) {
+			case OMP_EXTENSION_METHODS.launchDescribe:
+				return { op: "describe", name };
+			case OMP_EXTENSION_METHODS.launchLogs:
+				return {
+					op: "logs",
+					name,
+					lines: boundedInteger(params.lines, "lines", 100, 1, 1_000),
+					head: optionalBoolean(params.head, "head") ?? false,
+					grep: optionalString(params.grep, "grep", 1_024),
+					follow: false,
+					cursor: boundedInteger(params.cursor, "cursor", 0, 0, Number.MAX_SAFE_INTEGER),
+					renderTerminalRows: true,
+					timeoutMs,
+				};
+			case OMP_EXTENSION_METHODS.launchSend: {
+				const data = optionalString(params.data, "data", OMP_EXTENSION_MAX_TEXT_BYTES);
+				const signal = optionalString(params.signal, "signal", 16);
+				if (!data && !signal) throw new Error("data or signal required");
+				if (signal && !["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT", "SIGKILL"].includes(signal)) {
+					throw new Error(`Unsupported signal: ${signal}`);
+				}
+				return {
+					op: "send",
+					name,
+					data,
+					signal: signal as "SIGINT" | "SIGTERM" | "SIGHUP" | "SIGQUIT" | "SIGKILL",
+				};
+			}
+			case OMP_EXTENSION_METHODS.launchStop:
+				return { op: "stop", name, timeoutMs };
+			case OMP_EXTENSION_METHODS.launchRestart:
+				return { op: "restart", name };
+			default:
+				throw new Error(`Unsupported launch method: ${method}`);
+		}
+	}
+
+	#launchResult(session: AgentSession, result: DaemonRpcResult): Record<string, unknown> {
+		switch (result.op) {
+			case "describe":
+				return {
+					authority: "omp",
+					service: publicDaemonSnapshot(result.daemon),
+					command: redactText(session, [result.spec.application, ...result.spec.args].join(" ")),
+					cwd: result.spec.cwd,
+					restart: result.spec.restart,
+				};
+			case "logs":
+				return {
+					authority: "omp",
+					name: result.name,
+					state: result.state,
+					cursor: result.cursor,
+					timedOut: result.timedOut,
+					text: redactText(session, result.terminalRows?.join("\n") ?? result.text),
+				};
+			case "send":
+			case "stop":
+			case "restart":
+				return { authority: "omp", service: publicDaemonSnapshot(result.daemon) };
+			default:
+				throw new Error(`Unexpected launch result: ${result.op}`);
+		}
+	}
+
+	async #assertOwnedDaemon(
+		client: DaemonBrokerClient,
+		session: AgentSession,
+		name: string,
+		signal: AbortSignal,
+	): Promise<void> {
+		const listed = await client.request({ op: "list" }, signal);
+		if (listed.op !== "list") throw new Error(`Unexpected launch result: ${listed.op}`);
+		const daemon = listed.daemons.find(candidate => candidate.name === name);
+		if (!daemon) throw new Error(`Unknown OMP service: ${name}`);
+		if (daemon.owner !== session.sessionId)
+			throw new Error(`OMP service is not owned by session ${session.sessionId}`);
+	}
+
+	#ownedDaemons(session: AgentSession, daemons: DaemonSnapshot[]): DaemonSnapshot[] {
+		return daemons.filter(daemon => daemon.owner === session.sessionId);
+	}
+
+	#onSessionEvent(state: ManagedExtensionState, event: AgentSessionEvent): void {
+		if (!state.negotiated) return;
+		let method: string | undefined;
+		let data: Record<string, unknown> | undefined;
+		switch (event.type) {
+			case "omp_advisor_note":
+				method = OMP_EXTENSION_EVENTS.advisorNote;
+				data = {
+					advisorId: event.advisorId,
+					severity: event.severity,
+					delivery: event.delivery,
+					content: redactText(state.session, event.content),
+					turn: event.turn,
+				};
+				break;
+			case "omp_autolearn_lifecycle":
+				method = OMP_EXTENSION_EVENTS.autolearnLifecycle;
+				data = {
+					event: event.event,
+					captureGeneration: event.captureGeneration,
+					turn: event.turn,
+					failure: redactText(state.session, event.failure),
+				};
+				break;
+			case "omp_launch_lifecycle":
+				method = OMP_EXTENSION_EVENTS.launchLifecycle;
+				data = { event: event.event, service: publicDaemonSnapshot(event.daemon) };
+				break;
+			default:
+				return;
+		}
+		void this.#enqueueNotification(state, method, data);
+	}
+
+	#rotateSessionState(state: ManagedExtensionState): void {
+		const nextSessionId = state.session.sessionId;
+		if (nextSessionId === state.sessionId) return;
+		this.#states.delete(state.sessionId);
+		this.#memoryClearChallenges.delete(state.sessionId);
+		state.aliases.add(nextSessionId);
+		state.sessionId = nextSessionId;
+		state.generation = crypto.randomUUID();
+		state.sequence = 0;
+		state.negotiated = false;
+		state.droppedNotifications = 0;
+		this.#states.set(nextSessionId, state);
+	}
+
+	#enqueueNotification(state: ManagedExtensionState, method: string, data: Record<string, unknown>): Promise<void> {
+		if (this.#pendingNotifications >= MAX_PENDING_NOTIFICATIONS) {
+			state.droppedNotifications++;
+			logger.warn("OMP typed ACP notification queue full; dropping event", { method, sessionId: state.sessionId });
+			return Promise.resolve();
+		}
+		const expectedSessionId = state.sessionId;
+		const expectedGeneration = state.generation;
+		this.#pendingNotifications++;
+		const send = this.#notificationQueue.then(() =>
+			this.#publish(state, method, data, expectedSessionId, expectedGeneration),
+		);
+		this.#notificationQueue = send
+			.catch(() => {})
+			.finally(() => {
+				this.#pendingNotifications--;
+			});
+		return send;
+	}
+
+	async #publish(
+		state: ManagedExtensionState,
+		method: string,
+		data: Record<string, unknown>,
+		expectedSessionId: string,
+		expectedGeneration: string,
+	): Promise<void> {
+		try {
+			if (
+				this.#states.get(expectedSessionId) !== state ||
+				state.sessionId !== expectedSessionId ||
+				state.generation !== expectedGeneration
+			)
+				return;
+			const envelope = createOmpExtensionEnvelope(state, { sessionId: expectedSessionId }, data);
+			await this.#connection.extNotification(method, asRecord(envelope));
+		} catch (error) {
+			if (
+				this.#states.get(expectedSessionId) === state &&
+				state.sessionId === expectedSessionId &&
+				state.generation === expectedGeneration
+			)
+				state.droppedNotifications++;
+			logger.debug("OMP typed ACP notification failed", { method, error: sanitizeError(error) });
+		}
+	}
+
+	#errorCode(error: unknown): string {
+		const message = sanitizeError(error).toLowerCase();
+		if (message.includes("timed out") || message.includes("aborted")) return "TIMEOUT";
+		if (message.includes("owned by") || message.includes("confirmation")) return "PERMISSION_DENIED";
+		if (message.includes("unsupported") || message.includes("unknown")) return "UNSUPPORTED";
+		return "OPERATION_FAILED";
+	}
+
+	#isRecoverable(error: unknown): boolean {
+		const message = sanitizeError(error).toLowerCase();
+		return message.includes("timed out") || message.includes("unavailable") || message.includes("connect");
+	}
+}

--- a/packages/coding-agent/src/modes/acp/omp-extension-runtime.ts
+++ b/packages/coding-agent/src/modes/acp/omp-extension-runtime.ts
@@ -16,9 +16,11 @@ import {
 	OMP_EXTENSION_MAX_TEXT_BYTES,
 	OMP_EXTENSION_METHODS,
 	OMP_EXTENSION_SCHEMA_VERSION,
+	OMP_LAUNCH_LIFECYCLE_EVENTS,
 	type OmpExtensionEnvelope,
 	type OmpExtensionRequestContext,
 	type OmpExtensionSequenceState,
+	type OmpLaunchLifecycleEvent,
 	optionalBoolean,
 	optionalString,
 	parseOmpExtensionRequest,
@@ -141,6 +143,11 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
 	return Promise.race([promise, timeout.promise]).finally(() => clearTimeout(timer));
 }
 
+function safeRequestString(value: unknown, maxBytes = 512): string | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	return Buffer.byteLength(value, "utf8") <= maxBytes ? value : undefined;
+}
+
 export class OmpAcpExtensionRuntime {
 	readonly #connection: ExtensionConnection;
 	readonly #getSession: SessionResolver;
@@ -199,9 +206,11 @@ export class OmpAcpExtensionRuntime {
 	}
 
 	async handleMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
-		const context = parseOmpExtensionRequest(params);
-		const state = this.#resolveState(context.sessionId);
+		let context: OmpExtensionRequestContext | undefined;
+		let state: ManagedExtensionState | undefined;
 		try {
+			context = parseOmpExtensionRequest(params);
+			state = this.#resolveState(context.sessionId);
 			const data = await withTimeout(
 				this.#handleMethodData(method, params, context, state),
 				context.timeoutMs,
@@ -210,20 +219,26 @@ export class OmpAcpExtensionRuntime {
 			if (method === OMP_EXTENSION_METHODS.capabilities) state.negotiated = true;
 			return asRecord(createOmpExtensionEnvelope(state, context, data));
 		} catch (error) {
-			state.sequence += 1;
+			const sessionId = context?.sessionId ?? safeRequestString(params.sessionId) ?? "_omp/invalid-request";
+			const correlationId = context?.correlationId ?? safeRequestString(params.correlationId);
+			const errorState = state ?? this.#states.get(sessionId);
+			if (errorState) errorState.sequence += 1;
+			const operationMayContinue = this.#operationMayContinue(method, error);
 			return {
 				schemaVersion: OMP_EXTENSION_SCHEMA_VERSION,
 				ompVersion: VERSION,
-				sessionId: context.sessionId,
-				generation: state.generation,
-				sequence: state.sequence,
+				sessionId,
+				generation: errorState?.generation ?? crypto.randomUUID(),
+				sequence: errorState?.sequence ?? 1,
 				timestamp: new Date().toISOString(),
-				...(context.correlationId === undefined ? {} : { correlationId: context.correlationId }),
+				...(correlationId === undefined ? {} : { correlationId }),
 				error: {
 					code: this.#errorCode(error),
-					message: redactText(state.session, sanitizeError(error), 2_000),
-					recoverable: this.#isRecoverable(error),
-					detail: { method },
+					message: errorState
+						? redactText(errorState.session, sanitizeError(error), 2_000)
+						: sanitizeError(error).slice(0, 2_000),
+					recoverable: operationMayContinue ? false : this.#isRecoverable(error),
+					detail: { method, ...(operationMayContinue ? { operationMayContinue: true } : {}) },
 				},
 			};
 		}
@@ -486,8 +501,14 @@ export class OmpAcpExtensionRuntime {
 					method === OMP_EXTENSION_METHODS.launchStop ||
 					method === OMP_EXTENSION_METHODS.launchRestart)
 			) {
+				const event: OmpLaunchLifecycleEvent =
+					method === OMP_EXTENSION_METHODS.launchSend
+						? OMP_LAUNCH_LIFECYCLE_EVENTS.sent
+						: method === OMP_EXTENSION_METHODS.launchStop
+							? OMP_LAUNCH_LIFECYCLE_EVENTS.stopped
+							: OMP_LAUNCH_LIFECYCLE_EVENTS.restarted;
 				await this.#enqueueNotification(state, OMP_EXTENSION_EVENTS.launchLifecycle, {
-					event: method.slice(method.lastIndexOf("/") + 1),
+					event,
 					service: publicDaemonSnapshot(result.daemon),
 				});
 			}
@@ -682,7 +703,14 @@ export class OmpAcpExtensionRuntime {
 		if (message.includes("timed out") || message.includes("aborted")) return "TIMEOUT";
 		if (message.includes("owned by") || message.includes("confirmation")) return "PERMISSION_DENIED";
 		if (message.includes("unsupported") || message.includes("unknown")) return "UNSUPPORTED";
+		if (message.includes("must be") || message.includes("exceeds") || message.includes("required"))
+			return "INVALID_REQUEST";
 		return "OPERATION_FAILED";
+	}
+
+	#operationMayContinue(method: string, error: unknown): boolean {
+		if (this.#errorCode(error) !== "TIMEOUT") return false;
+		return method === OMP_EXTENSION_METHODS.memoryEnqueue || method === OMP_EXTENSION_METHODS.memoryClear;
 	}
 
 	#isRecoverable(error: unknown): boolean {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -251,6 +251,9 @@ export class EventController {
 			todo_reminder: e => this.#handleTodoReminder(e),
 			todo_auto_clear: e => this.#handleTodoAutoClear(e),
 			irc_message: e => this.#handleIrcMessage(e),
+			omp_advisor_note: async () => {},
+			omp_autolearn_lifecycle: async () => {},
+			omp_launch_lifecycle: async () => {},
 			notice: e => this.#handleNotice(e),
 			model_changed: async () => {
 				this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -4,6 +4,7 @@ import type { Effort } from "@oh-my-pi/pi-ai";
 import type { Rule } from "../capability/rule";
 import type { RetryErrorUpdate } from "../extensibility/shared-events";
 import type { Goal, GoalModeState } from "../goals/state";
+import type { DaemonSnapshot } from "../launch/protocol";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { TodoItem } from "../tools/todo";
 import type { CustomMessage } from "./messages";
@@ -52,6 +53,22 @@ export type AgentSessionEvent =
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }
 	| { type: "todo_auto_clear" }
 	| { type: "irc_message"; message: CustomMessage }
+	| {
+			type: "omp_advisor_note";
+			advisorId: string;
+			severity: "nit" | "concern" | "blocker";
+			delivery: "aside" | "steer" | "preserve";
+			content: string;
+			turn: number;
+	  }
+	| {
+			type: "omp_autolearn_lifecycle";
+			event: "started" | "completed" | "failed" | "cancelled";
+			captureGeneration: number;
+			turn: number;
+			failure?: string;
+	  }
+	| { type: "omp_launch_lifecycle"; event: "completed"; daemon: DaemonSnapshot }
 	| { type: "notice"; level: "info" | "warning" | "error"; message: string; source?: string }
 	| {
 			type: "thinking_level_changed";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -344,6 +344,17 @@ export * from "./agent-session-events";
 export * from "./agent-session-types";
 export type { AdvisorStats, PerAdvisorStat } from "./session-advisors";
 
+export interface AutolearnRuntimeStatus extends Record<string, unknown> {
+	enabled: boolean;
+	autoContinue: boolean;
+	state: "idle" | "running" | "pending" | "completed" | "failed" | "cancelled";
+	captureGeneration: number;
+	turn?: number;
+	pending: boolean;
+	lastResult?: "completed" | "failed" | "cancelled";
+	lastFailure?: string;
+}
+
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
 import { LoopGuards, type StreamGuardsHost, StreamingEditGuard } from "./stream-guards";
@@ -571,6 +582,11 @@ export class AgentSession {
 	#inheritedProviderPromptCacheKey: string | undefined;
 	#autolearnCaptureAbortController: AbortController | undefined;
 	#autolearnCaptureTask: Promise<void> | undefined;
+	#autolearnCaptureGeneration = 0;
+	#autolearnCaptureTurn: number | undefined;
+	#autolearnCapturePending = false;
+	#autolearnLastResult: "completed" | "failed" | "cancelled" | undefined;
+	#autolearnLastFailure: string | undefined;
 	#isDisposed = false;
 	/** Process-wide by default (double-spend safety across sessions); injectable for tests. */
 	#codexResetCoordinator: CodexAutoRedeemCoordinator;
@@ -1456,6 +1472,7 @@ export class AgentSession {
 			planModeState: () => this.#planModeState,
 			clientBridge: () => this.#clientBridge,
 			emitSessionEvent: event => this.#emitSessionEvent(event),
+			emitOmpObservation: event => this.emitOmpObservation(event),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),
 			sendCustomMessage: (message, options) => this.sendCustomMessage(message, options),
 			extractQueuedAdvisorCards: () => this.#extractQueuedAdvisorCards(),
@@ -1979,6 +1996,20 @@ export class AgentSession {
 	 */
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void {
 		this.#emit({ type: "notice", level, message, source });
+	}
+
+	/**
+	 * Publish an internal, typed OMP observation directly to session subscribers.
+	 * These events are not extension hooks and must not queue behind potentially
+	 * long-running plugin handlers before the ACP owner can serialize them.
+	 */
+	emitOmpObservation(
+		event: Extract<
+			AgentSessionEvent,
+			{ type: "omp_advisor_note" | "omp_autolearn_lifecycle" | "omp_launch_lifecycle" }
+		>,
+	): void {
+		this.#emit(event);
 	}
 
 	#recordToolExecutionStart(event: Extract<AgentEvent, { type: "tool_execution_start" }>): void {
@@ -3731,12 +3762,54 @@ export class AgentSession {
 	async runAutolearnCapture(capture: (signal: AbortSignal) => Promise<void>): Promise<void> {
 		if (this.#autolearnCaptureTask || this.#isDisposed) return;
 		const controller = new AbortController();
+		const captureGeneration = ++this.#autolearnCaptureGeneration;
+		const turn = Math.max(0, this.#turnIndex - 1);
+		this.#autolearnCaptureTurn = turn;
 		this.#autolearnCaptureAbortController = controller;
 		const task = (async () => {
+			await this.#emitSessionEvent({ type: "omp_autolearn_lifecycle", event: "started", captureGeneration, turn });
 			try {
 				await capture(controller.signal);
+				if (controller.signal.aborted) {
+					this.#autolearnLastResult = "cancelled";
+					await this.#emitSessionEvent({
+						type: "omp_autolearn_lifecycle",
+						event: "cancelled",
+						captureGeneration,
+						turn,
+					});
+				} else {
+					this.#autolearnLastResult = "completed";
+					this.#autolearnLastFailure = undefined;
+					await this.#emitSessionEvent({
+						type: "omp_autolearn_lifecycle",
+						event: "completed",
+						captureGeneration,
+						turn,
+					});
+				}
 			} catch (error) {
-				if (!controller.signal.aborted) throw error;
+				if (controller.signal.aborted) {
+					this.#autolearnLastResult = "cancelled";
+					await this.#emitSessionEvent({
+						type: "omp_autolearn_lifecycle",
+						event: "cancelled",
+						captureGeneration,
+						turn,
+					});
+					return;
+				}
+				const failure = error instanceof Error ? error.message : String(error);
+				this.#autolearnLastResult = "failed";
+				this.#autolearnLastFailure = failure;
+				await this.#emitSessionEvent({
+					type: "omp_autolearn_lifecycle",
+					event: "failed",
+					captureGeneration,
+					turn,
+					failure,
+				});
+				throw error;
 			} finally {
 				if (this.#autolearnCaptureAbortController === controller) {
 					this.#autolearnCaptureAbortController = undefined;
@@ -3748,6 +3821,71 @@ export class AgentSession {
 			await task;
 		} finally {
 			if (this.#autolearnCaptureTask === task) this.#autolearnCaptureTask = undefined;
+		}
+	}
+
+	/** Mark whether the auto-learn controller has coalesced one newer eligible capture. */
+	setAutolearnCapturePending(pending: boolean): void {
+		this.#autolearnCapturePending = pending;
+	}
+
+	/** Atomically consume the controller's coalesced capture marker. */
+	consumeAutolearnCapturePending(): boolean {
+		const pending = this.#autolearnCapturePending;
+		this.#autolearnCapturePending = false;
+		return pending;
+	}
+
+	/** Typed auto-learn state for ACP clients; no transcript inference is involved. */
+	getAutolearnStatus(): AutolearnRuntimeStatus {
+		const running = this.#autolearnCaptureTask !== undefined;
+		return {
+			enabled: this.settings.get("autolearn.enabled") === true,
+			autoContinue: this.settings.get("autolearn.autoContinue") === true,
+			state: running
+				? this.#autolearnCapturePending
+					? "pending"
+					: "running"
+				: (this.#autolearnLastResult ?? "idle"),
+			captureGeneration: this.#autolearnCaptureGeneration,
+			turn: this.#autolearnCaptureTurn,
+			pending: this.#autolearnCapturePending,
+			lastResult: this.#autolearnLastResult,
+			lastFailure: this.#autolearnLastFailure,
+		};
+	}
+
+	/** Bounded ACP drain/control surface for the real capture task owner. */
+	async drainAutolearnCaptureForAcp(options: {
+		timeoutMs: number;
+		cancel: boolean;
+	}): Promise<Record<string, unknown>> {
+		const deadline = Date.now() + options.timeoutMs;
+		if (options.cancel) {
+			this.#autolearnCapturePending = false;
+			this.#abortAutolearnCapture();
+		}
+		try {
+			while (true) {
+				const task = this.#autolearnCaptureTask;
+				if (!task && !this.#autolearnCapturePending) {
+					return { settled: true, cancelled: options.cancel, status: this.getAutolearnStatus() };
+				}
+				if (!task) {
+					await new Promise(resolve => setTimeout(resolve, 0));
+					continue;
+				}
+				const remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) throw new Error("Timed out draining auto-learn capture for ACP");
+				await withTimeout(task, remainingMs, "Timed out draining auto-learn capture for ACP");
+			}
+		} catch (error) {
+			return {
+				settled: false,
+				cancelled: options.cancel,
+				failure: error instanceof Error ? error.message : String(error),
+				status: this.getAutolearnStatus(),
+			};
 		}
 	}
 
@@ -5939,6 +6077,7 @@ export class AgentSession {
 
 	queueLaunchCompletion(notification: DaemonCompletionNotification): Promise<void> {
 		if (this.#isDisposed) return Promise.reject(new Error("Session disposed before launch completion delivery"));
+		void this.#emitSessionEvent({ type: "omp_launch_lifecycle", event: "completed", daemon: notification.daemon });
 		const delivered = this.yieldQueue.enqueueWithReceipt<LaunchCompletionEntry>(
 			LAUNCH_COMPLETION_MESSAGE_TYPE,
 			notification,

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -129,6 +129,8 @@ export interface AdvisorStats {
 export interface PerAdvisorStat {
 	name: string;
 	status: AdvisorRuntimeStatus;
+	backlog: number;
+	inFlight: boolean;
 	model?: Model;
 	contextWindow: number;
 	contextTokens: number;
@@ -248,6 +250,12 @@ export interface SessionAdvisorsHost {
 	planModeState(): PlanModeState | undefined;
 	clientBridge(): ClientBridge | undefined;
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
+	emitOmpObservation(
+		event: Extract<
+			AgentSessionEvent,
+			{ type: "omp_advisor_note" | "omp_autolearn_lifecycle" | "omp_launch_lifecycle" }
+		>,
+	): void;
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
 	sendCustomMessage(message: CustomMessagePayload, options?: AdvisorMessageDeliveryOptions): Promise<boolean>;
 	extractQueuedAdvisorCards(): CustomMessage[];
@@ -449,7 +457,7 @@ export class SessionAdvisors {
 		this.#advisorAutoResumeSuppressed = value;
 	}
 
-	/** Tracks persistence of a visible advisor card emitted outside the primary loop. */
+	/** Tracks visible-card persistence outside the primary loop. */
 	trackCardEvent(processing: Promise<void>): void {
 		this.#pendingAdvisorCardEvents.add(processing);
 		void processing.finally(() => this.#pendingAdvisorCardEvents.delete(processing)).catch(() => {});
@@ -1018,6 +1026,18 @@ export class SessionAdvisors {
 			aborting: this.#host.abortInProgress(),
 			terminalAnswerNoQueuedWork: this.#hasTerminalTextAnswerWithoutQueuedWork(),
 			interruptImmuneTurnActive: interrupting && this.#isAdvisorInterruptImmuneTurnActive(),
+		});
+		// Typed OMP observations bypass extension hooks and the general subscriber
+		// FIFO. Advisor notes can be produced while a long-running turn_end plugin
+		// still owns that FIFO; routing through it would let ACP drain time out and
+		// close the transport before the already-accepted note reached the client.
+		this.#host.emitOmpObservation({
+			type: "omp_advisor_note",
+				advisorId: advisor.slug || "default",
+				severity: severity ?? "nit",
+				delivery: channel,
+			content: note,
+			turn: this.#advisorPrimaryTurnsCompleted,
 		});
 		if (channel === "aside") {
 			this.#host.yieldQueue.enqueue("advisor", { note, severity, advisor: source });
@@ -1699,9 +1719,11 @@ export class SessionAdvisors {
 			if (live) {
 				roster.push(live);
 			} else {
-				roster.push({
-					name: entry.name,
-					status: entry.status,
+					roster.push({
+						name: entry.name,
+						status: entry.status,
+						backlog: 0,
+						inFlight: false,
 					contextWindow: 0,
 					contextTokens: 0,
 					tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
@@ -1780,13 +1802,15 @@ export class SessionAdvisors {
 				totalTokens += assistantMsg.usage.totalTokens;
 			}
 		}
-		return {
-			name: advisor.name,
+			return {
+				name: advisor.name,
 			status: advisor.runtime.quotaExhausted
 				? "quota_exhausted"
 				: advisor.runtime.failureNotified
-					? "error"
-					: "running",
+						? "error"
+						: "running",
+				backlog: advisor.runtime.backlog,
+				inFlight: advisor.runtime.inFlight,
 			model,
 			contextWindow: model.contextWindow ?? 0,
 			contextTokens,

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1033,9 +1033,9 @@ export class SessionAdvisors {
 		// close the transport before the already-accepted note reached the client.
 		this.#host.emitOmpObservation({
 			type: "omp_advisor_note",
-				advisorId: advisor.slug || "default",
-				severity: severity ?? "nit",
-				delivery: channel,
+			advisorId: advisor.slug || "default",
+			severity: severity ?? "nit",
+			delivery: channel,
 			content: note,
 			turn: this.#advisorPrimaryTurnsCompleted,
 		});
@@ -1719,11 +1719,11 @@ export class SessionAdvisors {
 			if (live) {
 				roster.push(live);
 			} else {
-					roster.push({
-						name: entry.name,
-						status: entry.status,
-						backlog: 0,
-						inFlight: false,
+				roster.push({
+					name: entry.name,
+					status: entry.status,
+					backlog: 0,
+					inFlight: false,
 					contextWindow: 0,
 					contextTokens: 0,
 					tokens: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
@@ -1802,15 +1802,15 @@ export class SessionAdvisors {
 				totalTokens += assistantMsg.usage.totalTokens;
 			}
 		}
-			return {
-				name: advisor.name,
+		return {
+			name: advisor.name,
 			status: advisor.runtime.quotaExhausted
 				? "quota_exhausted"
 				: advisor.runtime.failureNotified
-						? "error"
-						: "running",
-				backlog: advisor.runtime.backlog,
-				inFlight: advisor.runtime.inFlight,
+					? "error"
+					: "running",
+			backlog: advisor.runtime.backlog,
+			inFlight: advisor.runtime.inFlight,
 			model,
 			contextWindow: model.contextWindow ?? 0,
 			contextTokens,

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -18,6 +18,7 @@ class FakeSession {
 	goalEnabled = false;
 	captureGate: Promise<void> | undefined;
 	captureError: Error | undefined;
+	autolearnCapturePending = false;
 
 	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
 		this.listeners.push(listener);
@@ -38,6 +39,16 @@ class FakeSession {
 
 	getGoalModeState(): { enabled: boolean } | undefined {
 		return this.goalEnabled ? { enabled: true } : undefined;
+	}
+
+	setAutolearnCapturePending(pending: boolean): void {
+		this.autolearnCapturePending = pending;
+	}
+
+	consumeAutolearnCapturePending(): boolean {
+		const pending = this.autolearnCapturePending;
+		this.autolearnCapturePending = false;
+		return pending;
 	}
 
 	emit(event: AgentSessionEvent): void {

--- a/packages/coding-agent/test/omp-acp-extension-protocol.test.ts
+++ b/packages/coding-agent/test/omp-acp-extension-protocol.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { DaemonBrokerClient } from "@oh-my-pi/pi-coding-agent/launch/client";
+import type { DaemonSnapshot } from "@oh-my-pi/pi-coding-agent/launch/protocol";
+import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
 import {
 	createOmpExtensionCapabilities,
 	createOmpExtensionEnvelope,
@@ -8,10 +10,8 @@ import {
 	parseOmpExtensionRequest,
 } from "@oh-my-pi/pi-coding-agent/modes/acp/omp-extension-protocol";
 import { OmpAcpExtensionRuntime } from "@oh-my-pi/pi-coding-agent/modes/acp/omp-extension-runtime";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AgentSideConnection } from "@oh-my-pi/pi-utils/acp";
-import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
-import type { DaemonBrokerClient } from "@oh-my-pi/pi-coding-agent/launch/client";
-import type { DaemonSnapshot } from "@oh-my-pi/pi-coding-agent/launch/protocol";
 
 describe("OMP ACP extension protocol", () => {
 	it("bounds requests and emits monotonic versioned envelopes", () => {
@@ -87,19 +87,19 @@ class FakeExtensionSession {
 			tokens: { input: 1, output: 1, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
 			cost: 0,
 			messages: { user: 1, assistant: 1, total: 2 },
-				advisors: [
-					{
-						name: "reviewer",
-						status: "running",
-						contextWindow: 10,
-						contextTokens: 2,
-						tokens: { input: 1, output: 1, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
-						cost: 0,
-						messages: { user: 1, assistant: 1, total: 2 },
-						backlog: 0,
-						inFlight: false,
-					},
-				],
+			advisors: [
+				{
+					name: "reviewer",
+					status: "running",
+					contextWindow: 10,
+					contextTokens: 2,
+					tokens: { input: 1, output: 1, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
+					cost: 0,
+					messages: { user: 1, assistant: 1, total: 2 },
+					backlog: 0,
+					inFlight: false,
+				},
+			],
 		};
 	}
 
@@ -174,7 +174,9 @@ describe("OMP ACP extension runtime", () => {
 		const event = notifications[0]?.params;
 		expect(event?.generation).toBe(negotiated.generation);
 		expect(event?.sequence).toBe((negotiated.sequence as number) + 1);
-		expect((event?.data as Record<string, unknown>).content).toBe("typed note");
+		const eventData = event?.data;
+		expect(eventData).toBeDefined();
+		expect((eventData as Record<string, unknown>).content).toBe("typed note");
 
 		session.changeSession("session-2");
 		session.emit({
@@ -237,10 +239,10 @@ describe("OMP ACP extension runtime", () => {
 			sessionId: session.sessionId,
 			cancel: true,
 		});
-			expect((advisorSet.data as Record<string, unknown>).active).toBe(true);
-			expect((advisorDrain.data as Record<string, unknown>).settled).toBe(true);
-			expect(((advisorDrain.data as Record<string, unknown>).status as Record<string, unknown>).backlog).toBe(0);
-			expect(((advisorDrain.data as Record<string, unknown>).status as Record<string, unknown>).inFlight).toBe(false);
+		expect((advisorSet.data as Record<string, unknown>).active).toBe(true);
+		expect((advisorDrain.data as Record<string, unknown>).settled).toBe(true);
+		expect(((advisorDrain.data as Record<string, unknown>).status as Record<string, unknown>).backlog).toBe(0);
+		expect(((advisorDrain.data as Record<string, unknown>).status as Record<string, unknown>).inFlight).toBe(false);
 		expect((autolearnStatus.data as Record<string, unknown>).state).toBe("idle");
 		expect((autolearnDrain.data as Record<string, unknown>).settled).toBe(true);
 
@@ -251,8 +253,11 @@ describe("OMP ACP extension runtime", () => {
 			turn: 3,
 		} as AgentSessionEvent);
 		await Promise.resolve();
-		expect(notifications.at(-1)?.method).toBe("_omp/autolearn/lifecycle");
-		expect((notifications.at(-1)?.params.data as Record<string, unknown>).captureGeneration).toBe(2);
+		const notification = notifications.at(-1);
+		expect(notification?.method).toBe("_omp/autolearn/lifecycle");
+		const notificationData = notification?.params.data;
+		expect(notificationData).toBeDefined();
+		expect((notificationData as Record<string, unknown>).captureGeneration).toBe(2);
 	});
 
 	it("does not report Advisor drain settled before an accepted typed note reaches the ACP connection", async () => {
@@ -345,8 +350,12 @@ describe("OMP ACP extension runtime", () => {
 			}),
 			stats: async () => "two memories",
 			diagnose: async () => "healthy",
-			enqueue: async () => void (enqueued += 1),
-			clear: async () => void (cleared += 1),
+			enqueue: async () => {
+				enqueued += 1;
+			},
+			clear: async () => {
+				cleared += 1;
+			},
 		};
 		const session = new FakeExtensionSession();
 		const runtime = new OmpAcpExtensionRuntime({

--- a/packages/coding-agent/test/omp-acp-extension-protocol.test.ts
+++ b/packages/coding-agent/test/omp-acp-extension-protocol.test.ts
@@ -464,7 +464,13 @@ describe("OMP ACP extension runtime", () => {
 			});
 			expect(response.error).toBeUndefined();
 		}
-		expect(notifications.filter(item => item.method === "_omp/launch/lifecycle")).toHaveLength(3);
+		const lifecycle = notifications.filter(item => item.method === "_omp/launch/lifecycle");
+		expect(lifecycle).toHaveLength(3);
+		expect(lifecycle.map(item => (item.params.data as { event: string }).event)).toEqual([
+			"sent",
+			"stopped",
+			"restarted",
+		]);
 
 		const denied = await runtime.handleMethod(OMP_EXTENSION_METHODS.launchStop, {
 			sessionId: session.sessionId,
@@ -473,7 +479,7 @@ describe("OMP ACP extension runtime", () => {
 		expect((denied.error as Record<string, unknown>).code).toBe("PERMISSION_DENIED");
 	});
 
-	it("returns structured recoverable errors for bounded handler timeouts", async () => {
+	it("returns bounded non-retryable errors when a memory mutation may continue after timeout", async () => {
 		const session = new FakeExtensionSession();
 		const runtime = new OmpAcpExtensionRuntime({
 			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
@@ -491,9 +497,27 @@ describe("OMP ACP extension runtime", () => {
 			sessionId: session.sessionId,
 			timeoutMs: 1,
 		});
-		expect(response.error).toMatchObject({ code: "TIMEOUT", recoverable: true });
+		expect(response.error).toMatchObject({ code: "TIMEOUT", recoverable: false });
 		expect((response.error as Record<string, unknown>).detail).toEqual({
 			method: OMP_EXTENSION_METHODS.memoryEnqueue,
+			operationMayContinue: true,
+		});
+	});
+
+	it("returns a bounded typed error when request parameters are malformed", async () => {
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
+			getSession: () => undefined,
+		});
+		const response = await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, {
+			sessionId: "",
+			timeoutMs: "slow",
+		});
+		expect(response).toMatchObject({
+			schemaVersion: 1,
+			sessionId: "_omp/invalid-request",
+			sequence: 1,
+			error: { code: "INVALID_REQUEST", recoverable: false },
 		});
 	});
 });

--- a/packages/coding-agent/test/omp-acp-extension-protocol.test.ts
+++ b/packages/coding-agent/test/omp-acp-extension-protocol.test.ts
@@ -1,0 +1,490 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import {
+	createOmpExtensionCapabilities,
+	createOmpExtensionEnvelope,
+	createOmpExtensionSequenceState,
+	OMP_EXTENSION_METHODS,
+	parseOmpExtensionRequest,
+} from "@oh-my-pi/pi-coding-agent/modes/acp/omp-extension-protocol";
+import { OmpAcpExtensionRuntime } from "@oh-my-pi/pi-coding-agent/modes/acp/omp-extension-runtime";
+import type { AgentSideConnection } from "@oh-my-pi/pi-utils/acp";
+import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
+import type { DaemonBrokerClient } from "@oh-my-pi/pi-coding-agent/launch/client";
+import type { DaemonSnapshot } from "@oh-my-pi/pi-coding-agent/launch/protocol";
+
+describe("OMP ACP extension protocol", () => {
+	it("bounds requests and emits monotonic versioned envelopes", () => {
+		const request = parseOmpExtensionRequest({ sessionId: "session-1", correlationId: "turn-7", timeoutMs: 99_000 });
+		expect(request.timeoutMs).toBe(15_000);
+		const state = createOmpExtensionSequenceState();
+		const first = createOmpExtensionEnvelope(state, request, { state: "running" });
+		const second = createOmpExtensionEnvelope(state, request, { state: "idle" });
+		expect(first.schemaVersion).toBe(1);
+		expect(first.generation).toBe(second.generation);
+		expect(second.sequence).toBe(first.sequence + 1);
+		expect(second.correlationId).toBe("turn-7");
+	});
+
+	it("advertises only implemented methods and marks managed skills unavailable", () => {
+		const capabilities = createOmpExtensionCapabilities({
+			advisor: true,
+			autolearn: true,
+			memory: true,
+			launch: true,
+		});
+		const features = capabilities.features as Record<string, Record<string, unknown>>;
+		expect(features.advisor.methods).toContain(OMP_EXTENSION_METHODS.advisorDrain);
+		expect(features.launch.observable).toBe(true);
+		expect(features.managedSkills.available).toBe(false);
+	});
+
+	it("rejects malformed session identity instead of guessing a target", () => {
+		expect(() => parseOmpExtensionRequest({})).toThrow("sessionId");
+		expect(() => parseOmpExtensionRequest({ sessionId: "" })).toThrow("sessionId");
+	});
+});
+
+class FakeExtensionSession {
+	sessionId = "session-1";
+	readonly sessionManager = { getCwd: () => "C:/isolated/project" };
+	readonly settings = {
+		get: (key: string): unknown => {
+			if (key === "advisor.enabled" || key === "autolearn.enabled" || key === "autolearn.autoContinue") return true;
+			if (key === "memory.backend") return "off";
+			return undefined;
+		},
+	};
+	readonly obfuscator = undefined;
+	readonly #listeners = new Set<(event: AgentSessionEvent) => void>();
+	readonly #sessionChangeListeners = new Set<() => void>();
+
+	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	emit(event: AgentSessionEvent): void {
+		for (const listener of this.#listeners) listener(event);
+	}
+
+	registerSessionChangeCallback(listener: () => void): () => void {
+		this.#sessionChangeListeners.add(listener);
+		return () => this.#sessionChangeListeners.delete(listener);
+	}
+
+	changeSession(sessionId: string): void {
+		this.sessionId = sessionId;
+		for (const listener of this.#sessionChangeListeners) listener();
+	}
+
+	getAdvisorStats(): Record<string, unknown> {
+		return {
+			configured: true,
+			active: true,
+			contextWindow: 10,
+			contextTokens: 2,
+			tokens: { input: 1, output: 1, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
+			cost: 0,
+			messages: { user: 1, assistant: 1, total: 2 },
+				advisors: [
+					{
+						name: "reviewer",
+						status: "running",
+						contextWindow: 10,
+						contextTokens: 2,
+						tokens: { input: 1, output: 1, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
+						cost: 0,
+						messages: { user: 1, assistant: 1, total: 2 },
+						backlog: 0,
+						inFlight: false,
+					},
+				],
+		};
+	}
+
+	getAdvisorAvailableToolNames(): string[] {
+		return ["read", "bash"];
+	}
+
+	setAdvisorEnabled(enabled: boolean): boolean {
+		return enabled;
+	}
+
+	waitForAdvisorCatchup(): Promise<boolean> {
+		return Promise.resolve(true);
+	}
+
+	getAutolearnStatus(): Record<string, unknown> {
+		return { enabled: true, autoContinue: true, state: "idle", captureGeneration: 0, pending: false };
+	}
+
+	drainAutolearnCaptureForAcp(): Promise<Record<string, unknown>> {
+		return Promise.resolve({ settled: true, cancelled: false });
+	}
+}
+
+describe("OMP ACP extension runtime", () => {
+	it("fails closed when a client offers only an unknown breaking schema", async () => {
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+		});
+		const response = await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, {
+			sessionId: session.sessionId,
+			supportedSchemaVersions: [2],
+		});
+		expect(response.error).toMatchObject({ code: "UNSUPPORTED", recoverable: false });
+	});
+
+	it("negotiates effective capabilities and publishes correlated typed events", async () => {
+		const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const connection = {
+			extNotification: async (method: string, params: Record<string, unknown>) => {
+				notifications.push({ method, params });
+			},
+		} as unknown as AgentSideConnection;
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection,
+			getSession: sessionId => (sessionId === session.sessionId ? (session as unknown as AgentSession) : undefined),
+		});
+		runtime.attachSession(session as unknown as AgentSession);
+
+		const negotiated = await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, {
+			sessionId: session.sessionId,
+			correlationId: "start-1",
+			supportedSchemaVersions: [1],
+		});
+		expect(negotiated.schemaVersion).toBe(1);
+		expect((negotiated.data as Record<string, unknown>).protocol).toBe("omp-acp-extensions");
+
+		session.emit({
+			type: "omp_advisor_note",
+			advisorId: "reviewer",
+			severity: "concern",
+			delivery: "steer",
+			content: "typed note",
+			turn: 4,
+		} as AgentSessionEvent);
+		await Promise.resolve();
+		expect(notifications).toHaveLength(1);
+		expect(notifications[0]?.method).toBe("_omp/advisor/note");
+		const event = notifications[0]?.params;
+		expect(event?.generation).toBe(negotiated.generation);
+		expect(event?.sequence).toBe((negotiated.sequence as number) + 1);
+		expect((event?.data as Record<string, unknown>).content).toBe("typed note");
+
+		session.changeSession("session-2");
+		session.emit({
+			type: "omp_advisor_note",
+			advisorId: "reviewer",
+			severity: "nit",
+			delivery: "aside",
+			content: "must wait for renegotiation",
+			turn: 5,
+		} as AgentSessionEvent);
+		await Promise.resolve();
+		expect(notifications).toHaveLength(1);
+		const resumed = await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, {
+			sessionId: session.sessionId,
+		});
+		expect(resumed.generation).not.toBe(negotiated.generation);
+		expect(resumed.sequence).toBe(1);
+	});
+
+	it("reports advisor mutation risk from the real granted tool set", async () => {
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+		});
+		runtime.attachSession(session as unknown as AgentSession);
+		const response = await runtime.handleMethod(OMP_EXTENSION_METHODS.advisorStatus, {
+			sessionId: session.sessionId,
+		});
+		const data = response.data as Record<string, unknown>;
+		expect(data.toolRisk).toBe("write-or-exec");
+		expect(data.grantedTools).toEqual(["read", "bash"]);
+	});
+
+	it("controls and drains Advisor and Auto-Learn from their real session owners", async () => {
+		const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: {
+				extNotification: async (method: string, params: Record<string, unknown>) =>
+					void notifications.push({ method, params }),
+			} as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+		});
+		runtime.attachSession(session as unknown as AgentSession);
+		await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, { sessionId: session.sessionId });
+
+		const advisorSet = await runtime.handleMethod(OMP_EXTENSION_METHODS.advisorSet, {
+			sessionId: session.sessionId,
+			enabled: true,
+		});
+		const advisorDrain = await runtime.handleMethod(OMP_EXTENSION_METHODS.advisorDrain, {
+			sessionId: session.sessionId,
+			timeoutMs: 25,
+		});
+		const autolearnStatus = await runtime.handleMethod(OMP_EXTENSION_METHODS.autolearnStatus, {
+			sessionId: session.sessionId,
+		});
+		const autolearnDrain = await runtime.handleMethod(OMP_EXTENSION_METHODS.autolearnDrain, {
+			sessionId: session.sessionId,
+			cancel: true,
+		});
+			expect((advisorSet.data as Record<string, unknown>).active).toBe(true);
+			expect((advisorDrain.data as Record<string, unknown>).settled).toBe(true);
+			expect(((advisorDrain.data as Record<string, unknown>).status as Record<string, unknown>).backlog).toBe(0);
+			expect(((advisorDrain.data as Record<string, unknown>).status as Record<string, unknown>).inFlight).toBe(false);
+		expect((autolearnStatus.data as Record<string, unknown>).state).toBe("idle");
+		expect((autolearnDrain.data as Record<string, unknown>).settled).toBe(true);
+
+		session.emit({
+			type: "omp_autolearn_lifecycle",
+			event: "completed",
+			captureGeneration: 2,
+			turn: 3,
+		} as AgentSessionEvent);
+		await Promise.resolve();
+		expect(notifications.at(-1)?.method).toBe("_omp/autolearn/lifecycle");
+		expect((notifications.at(-1)?.params.data as Record<string, unknown>).captureGeneration).toBe(2);
+	});
+
+	it("does not report Advisor drain settled before an accepted typed note reaches the ACP connection", async () => {
+		const { promise: notificationGate, resolve: releaseNotification } = Promise.withResolvers<void>();
+		const { promise: notificationStarted, resolve: markNotificationStarted } = Promise.withResolvers<void>();
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: {
+				extNotification: async () => {
+					markNotificationStarted();
+					await notificationGate;
+				},
+			} as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+		});
+		runtime.attachSession(session as unknown as AgentSession);
+		await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, { sessionId: session.sessionId });
+
+		session.emit({
+			type: "omp_advisor_note",
+			advisorId: "reviewer",
+			severity: "concern",
+			delivery: "steer",
+			content: "must be delivered before drain settles",
+			turn: 1,
+		} as AgentSessionEvent);
+		await notificationStarted;
+
+		let drainResolved = false;
+		const draining = runtime
+			.handleMethod(OMP_EXTENSION_METHODS.advisorDrain, { sessionId: session.sessionId, timeoutMs: 1_000 })
+			.then(response => {
+				drainResolved = true;
+				return response;
+			});
+		await Promise.resolve();
+		expect(drainResolved).toBe(false);
+
+		releaseNotification();
+		const response = await draining;
+		expect((response.data as Record<string, unknown>).settled).toBe(true);
+		expect((response.data as Record<string, unknown>).notificationsSettled).toBe(true);
+	});
+
+	it("reports notification backpressure instead of settling after a typed event is dropped", async () => {
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+		});
+		runtime.attachSession(session as unknown as AgentSession);
+		await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, { sessionId: session.sessionId });
+
+		for (let index = 0; index < 257; index++) {
+			session.emit({
+				type: "omp_advisor_note",
+				advisorId: "reviewer",
+				severity: "concern",
+				delivery: "steer",
+				content: `typed note ${index}`,
+				turn: index,
+			} as AgentSessionEvent);
+		}
+
+		const response = await runtime.handleMethod(OMP_EXTENSION_METHODS.advisorDrain, {
+			sessionId: session.sessionId,
+			timeoutMs: 1_000,
+		});
+		const data = response.data as Record<string, unknown>;
+		expect(data.notificationsSettled).toBe(true);
+		expect(data.settled).toBe(false);
+		expect(data.notificationBackpressure).toEqual({ dropped: 1, recoverable: false });
+	});
+
+	it("requires a typed confirmation challenge before clearing isolated memory", async () => {
+		let enqueued = 0;
+		let cleared = 0;
+		const backend: MemoryBackend = {
+			id: "local",
+			start: () => {},
+			buildDeveloperInstructions: async () => undefined,
+			status: async () => ({
+				backend: "local",
+				active: true,
+				writable: true,
+				searchable: true,
+				scope: "isolated",
+				database: "C:/temp/omp-phase3/memory.sqlite",
+				workingCount: 2,
+			}),
+			stats: async () => "two memories",
+			diagnose: async () => "healthy",
+			enqueue: async () => void (enqueued += 1),
+			clear: async () => void (cleared += 1),
+		};
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+			getAgentDir: () => "C:/temp/omp-phase3/agent",
+			resolveMemoryBackend: async () => backend,
+		});
+
+		const status = await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryStatus, { sessionId: session.sessionId });
+		const stats = await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryStats, { sessionId: session.sessionId });
+		const diagnose = await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryDiagnose, {
+			sessionId: session.sessionId,
+		});
+		await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryEnqueue, { sessionId: session.sessionId });
+		const challenge = await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryClear, { sessionId: session.sessionId });
+		const challengeData = challenge.data as Record<string, unknown>;
+		expect((status.data as Record<string, unknown>).storage).toEqual({ kind: "database", pathId: "memory.sqlite" });
+		expect((stats.data as Record<string, unknown>).text).toBe("two memories");
+		expect((diagnose.data as Record<string, unknown>).text).toBe("healthy");
+		expect(challengeData.confirmationRequired).toBe(true);
+		expect(challengeData.scope).toBe("project");
+		expect(cleared).toBe(0);
+
+		const confirmed = await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryClear, {
+			sessionId: session.sessionId,
+			confirmationId: challengeData.confirmationId,
+		});
+		expect((confirmed.data as Record<string, unknown>).cleared).toBe(true);
+		expect(enqueued).toBe(1);
+		expect(cleared).toBe(1);
+	});
+
+	it("bounds Launch access to the session owner and exposes every typed control", async () => {
+		const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const owned: DaemonSnapshot = {
+			name: "fixture-service",
+			id: "service-1",
+			state: "ready",
+			pid: 4242,
+			createdAt: 1,
+			startedAt: 2,
+			restartCount: 0,
+			outputBytes: 12,
+			owner: "session-1",
+			persist: false,
+			detached: false,
+		};
+		const foreign = { ...owned, id: "service-2", name: "foreign", owner: "other-session" };
+		const client = {
+			request: async (operation: { op: string }) => {
+				if (operation.op === "list") return { op: "list", daemons: [owned, foreign] };
+				if (operation.op === "describe") {
+					return {
+						op: "describe",
+						daemon: owned,
+						spec: {
+							application: "bun",
+							args: ["server.ts"],
+							env: {},
+							cwd: "C:/temp/omp-phase3",
+							pty: true,
+							restart: "no",
+							persist: false,
+							detached: false,
+						},
+					};
+				}
+				if (operation.op === "logs")
+					return {
+						op: "logs",
+						name: owned.name,
+						text: "ready",
+						terminalRows: ["ready"],
+						cursor: 12,
+						timedOut: false,
+						state: "ready",
+					};
+				return { op: operation.op, daemon: owned };
+			},
+		} as unknown as DaemonBrokerClient;
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: {
+				extNotification: async (method: string, params: Record<string, unknown>) =>
+					void notifications.push({ method, params }),
+			} as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+			daemonClientForProject: async () => client,
+		});
+		await runtime.handleMethod(OMP_EXTENSION_METHODS.capabilities, { sessionId: session.sessionId });
+
+		const list = await runtime.handleMethod(OMP_EXTENSION_METHODS.launchList, { sessionId: session.sessionId });
+		expect((list.data as { services: unknown[] }).services).toHaveLength(1);
+		for (const method of [
+			OMP_EXTENSION_METHODS.launchDescribe,
+			OMP_EXTENSION_METHODS.launchLogs,
+			OMP_EXTENSION_METHODS.launchSend,
+			OMP_EXTENSION_METHODS.launchStop,
+			OMP_EXTENSION_METHODS.launchRestart,
+		]) {
+			const response = await runtime.handleMethod(method, {
+				sessionId: session.sessionId,
+				name: owned.name,
+				...(method === OMP_EXTENSION_METHODS.launchSend ? { data: "status\n" } : {}),
+			});
+			expect(response.error).toBeUndefined();
+		}
+		expect(notifications.filter(item => item.method === "_omp/launch/lifecycle")).toHaveLength(3);
+
+		const denied = await runtime.handleMethod(OMP_EXTENSION_METHODS.launchStop, {
+			sessionId: session.sessionId,
+			name: foreign.name,
+		});
+		expect((denied.error as Record<string, unknown>).code).toBe("PERMISSION_DENIED");
+	});
+
+	it("returns structured recoverable errors for bounded handler timeouts", async () => {
+		const session = new FakeExtensionSession();
+		const runtime = new OmpAcpExtensionRuntime({
+			connection: { extNotification: async () => {} } as unknown as AgentSideConnection,
+			getSession: () => session as unknown as AgentSession,
+			resolveMemoryBackend: async () =>
+				({
+					id: "local",
+					start: () => {},
+					buildDeveloperInstructions: async () => undefined,
+					enqueue: async () => await new Promise(() => {}),
+					clear: async () => {},
+				}) as MemoryBackend,
+		});
+		const response = await runtime.handleMethod(OMP_EXTENSION_METHODS.memoryEnqueue, {
+			sessionId: session.sessionId,
+			timeoutMs: 1,
+		});
+		expect(response.error).toMatchObject({ code: "TIMEOUT", recoverable: true });
+		expect((response.error as Record<string, unknown>).detail).toEqual({
+			method: OMP_EXTENSION_METHODS.memoryEnqueue,
+		});
+	});
+});


### PR DESCRIPTION
## Problem and user value

OMP already owns Advisor, Auto-Learn, Memory, and Launch state, but ACP clients cannot observe or control those owners without guessing from text or logs. This adds a versioned typed ACP extension on the existing connection so clients can show real runtime state, preserve OMP authority, and degrade safely when the extension is unavailable.

> User-authored compatibility requirement: “Synara继续支持stock 17.3.2 method-not-found -> configured-only。”

## Protocol v1

- Namespace/protocol: `omp-acp-extensions`, `schemaVersion: 1`.
- Capability negotiation: `_omp/capabilities` advertises availability, enablement, observability, controllability, recoverability, methods, and events.
- Advisor: `status`, `set`, `drain`, and typed `note` events.
- Auto-Learn: `status`, `drain`, and lifecycle events.
- Memory: `status`, `stats`, `diagnose`, `enqueue`, and two-step `clear` challenge/confirmation.
- Launch: `list`, `describe`, bounded `logs`, `send`, `stop`, `restart`, and explicit `completed/sent/stopped/restarted` lifecycle events.

Every envelope carries the OMP version, ACP session, generation, monotonic sequence, timestamp, optional correlation ID, and exactly one of typed data or a typed error. Additive fields remain ignorable; unsupported breaking schema versions fail closed.

## Compatibility and safety

- Ordinary ACP behavior is unchanged when the client never negotiates these methods.
- The extension reads from the real `AgentSession`, Advisor, Auto-Learn, Memory backend, and daemon broker owners; it does not parse transcript/tool text or create a second transport.
- Memory clear requires an expiring, backend-bound confirmation challenge.
- Launch controls only services owned by the ACP session, keeps OMP as authority, and bounds names, input, log lines, cursor, and text.
- Error text and notifications use existing session redaction and size limits.
- Malformed parameters return a bounded typed `INVALID_REQUEST` envelope instead of escaping the protocol boundary.
- A timed-out Memory mutation is marked `operationMayContinue: true` and `recoverable: false`, so clients do not retry a side effect whose owner API is not cancellable.

## Backpressure and lifecycle correctness

- Generation rotates and sequence resets on ACP session change.
- Notification drop/send-failure counts are generation-local.
- Advisor drain waits for both the real Advisor owner and the notification queue.
- Any lost typed event forces `settled: false` with `notificationBackpressure.recoverable: false`.
- The regression suite covers the 257th event overflowing the bounded 256-event queue.

## Verification

- `bun run check:ts` — PASS across all workspaces.
- Focused protocol/runtime, Advisor, and Auto-Learn tests — 212/212 PASS.
- Formal Windows native source build — PASS at this PR head with pinned `nightly-2026-07-28` and Bun `1.3.14`; fresh `win32-x64-modern` addon SHA-256 `866fdd41656b2d6bbbeb104c9a9e56d5398b8f94cb6815fd36d3c08f52762620`.
- `PI_NATIVE_VARIANT=modern bun --cwd=packages/coding-agent run build` — PASS; built `dist/omp.exe` SHA-256 `1bc8b659b89659cc3d0dcd9d63a09d829e1d23dc2f7e53fa83b9aa4cd75d6ccb`.
- `git diff --check origin/main...HEAD` — PASS.
- The official CI/Nix workflows remain required before merge/release; their current fork runs ended `action_required` before creating jobs and need upstream approval.

## Breaking-change assessment

No intended breaking change. The methods/events are additive, provider-namespaced, and inactive until requested. No tag or release is created by this PR.

## Downstream integration

- Synara consumer Draft: [NLN6666/NilCode#1](https://github.com/NLN6666/NilCode/pull/1), with stock configured-only fallback while this PR remains unreleased.
