### PR TITLE
fix(auto-thinking): clear proxy thinking budget in online classifiers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `auto` thinking classifier failing every turn on Anthropic models served through LiteLLM/Vertex with `max_tokens must be greater than thinking.budget_tokens`. The classifier's disabled-reasoning request is downgraded to the lowest reasoning effort on the `openai-completions` transport, which the proxy translates to an Anthropic thinking budget of at least 1024 tokens; the classifier now reserves enough output room (4096) to clear that budget instead of capping at exactly 1024 ([#8610](https://github.com/can1357/oh-my-pi/issues/8610)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/auto-thinking/classifier.ts
+++ b/packages/coding-agent/src/auto-thinking/classifier.ts
@@ -60,14 +60,24 @@ function difficultySystemPromptFor(ceiling: Effort): string {
 
 /** Local classifiers occasionally need more room for chat-template boilerplate. */
 const LOCAL_ANSWER_MAX_TOKENS = 16;
+/** On-device reasoning classifiers need room for the bucket keyword after the `<think>` preamble. */
+const LOCAL_REASONING_MAX_TOKENS = 1024;
 /**
- * Online classifier budget. Sized to survive backends that ignore
- * `disableReasoning` (e.g. Qwen3 via llama.cpp catalogued `reasoning: false`
- * but still emitting thinking): the classifier keyword needs to land after any
- * unavoidable thinking preamble. `maxTokens` is a hard cap — non-thinking
- * completions still return in a handful of tokens (issue #4355).
+ * Online classifier budget. Sized against two independent constraints:
+ *   - Backends that ignore `disableReasoning` still emit a thinking preamble
+ *     (e.g. Qwen3 via llama.cpp catalogued `reasoning: false` but still thinking;
+ *     Anthropic via LiteLLM/Vertex, whose `openai-completions` route downgrades a
+ *     disabled request to the lowest reasoning effort instead of turning thinking
+ *     off). The classifier keyword must have room to land after that preamble
+ *     (issue #4355).
+ *   - Anthropic-dialect proxies reject `max_tokens <= thinking.budget_tokens`. The
+ *     pinned lowest effort maps to at least Anthropic's 1024-token minimum budget,
+ *     so the cap MUST comfortably exceed 1024 or every classifier call 400s with
+ *     `max_tokens must be greater than thinking.budget_tokens` (issue #8610).
+ * `maxTokens` is a hard cap — non-thinking completions still return in a handful
+ * of tokens.
  */
-const REASONING_SAFE_MAX_TOKENS = 1024;
+const ONLINE_REASONING_SAFE_MAX_TOKENS = 4096;
 
 export interface ClassifyDifficultyDeps {
 	settings: Settings;
@@ -113,7 +123,7 @@ async function classifyOnline(input: string, deps: ClassifyDifficultyDeps, ceili
 	}
 	// Resolve metadata after getApiKey so the session-sticky credential is recorded first.
 	const metadata = deps.metadataResolver?.(model.provider);
-	const maxTokens = REASONING_SAFE_MAX_TOKENS;
+	const maxTokens = ONLINE_REASONING_SAFE_MAX_TOKENS;
 
 	const response = await completeSimple(
 		model,
@@ -147,7 +157,7 @@ async function classifyLocal(input: string, modelKey: string, deps: ClassifyDiff
 		throw new Error(`auto-thinking: unsupported local classifier model: ${modelKey}`);
 	}
 	const maxTokens = isTinyMemoryReasoningModelKey(modelKey)
-		? Math.max(LOCAL_ANSWER_MAX_TOKENS, REASONING_SAFE_MAX_TOKENS)
+		? Math.max(LOCAL_ANSWER_MAX_TOKENS, LOCAL_REASONING_MAX_TOKENS)
 		: LOCAL_ANSWER_MAX_TOKENS;
 	const builtPrompt = prompt.render(difficultyLocalPrompt, { prompt: input });
 	const text = await tinyModelClient.complete(modelKey, builtPrompt, {

--- a/packages/coding-agent/src/session/unexpected-stop-classifier.ts
+++ b/packages/coding-agent/src/session/unexpected-stop-classifier.ts
@@ -16,13 +16,21 @@ const CLASSIFIER_SYSTEM_PROMPT = prompt.render(unexpectedStopClassifierPrompt);
  */
 const ANSWER_MAX_TOKENS = 16;
 /**
- * Online classifier budget. Sized to survive backends that ignore
- * `disableReasoning` (e.g. Qwen3 via llama.cpp catalogued `reasoning: false`
- * but still emitting thinking): the yes/no keyword needs to land after any
- * unavoidable thinking preamble. `maxTokens` is a hard cap — non-thinking
- * completions still return in a single word (issue #4355).
+ * Online classifier budget. Sized against two independent constraints:
+ *   - Backends that ignore `disableReasoning` still emit a thinking preamble
+ *     (e.g. Qwen3 via llama.cpp catalogued `reasoning: false` but still thinking;
+ *     Anthropic via LiteLLM/Vertex, whose `openai-completions` route downgrades a
+ *     disabled request to the lowest reasoning effort instead of turning thinking
+ *     off). The yes/no keyword must have room to land after that preamble
+ *     (issue #4355).
+ *   - Anthropic-dialect proxies reject `max_tokens <= thinking.budget_tokens`. The
+ *     pinned lowest effort maps to at least Anthropic's 1024-token minimum budget,
+ *     so the cap MUST comfortably exceed 1024 or the request 400s with
+ *     `max_tokens must be greater than thinking.budget_tokens` (issue #8610).
+ * `maxTokens` is a hard cap — non-thinking completions still return in a single
+ * word.
  */
-const REASONING_SAFE_MAX_TOKENS = 1024;
+const ONLINE_REASONING_SAFE_MAX_TOKENS = 4096;
 
 export interface ClassifyUnexpectedStopDeps {
 	settings: Settings;
@@ -86,7 +94,7 @@ async function classifyOnline(text: string, deps: ClassifyUnexpectedStopDeps): P
 		throw new Error(`unexpected-stop: no API key for ${model.provider}/${model.id}`);
 	}
 	const metadata = deps.metadataResolver?.(model.provider);
-	const maxTokens = REASONING_SAFE_MAX_TOKENS;
+	const maxTokens = ONLINE_REASONING_SAFE_MAX_TOKENS;
 
 	const response = await completeSimple(
 		model,

--- a/packages/coding-agent/test/auto-thinking-classifier.test.ts
+++ b/packages/coding-agent/test/auto-thinking-classifier.test.ts
@@ -176,7 +176,13 @@ describe("auto thinking classifier helpers", () => {
 			| undefined;
 
 		expect(effort).toBe(Effort.High);
-		expect(options).toMatchObject({ disableReasoning: true, maxTokens: 1024 });
+		// The cap must exceed Anthropic's 1024-token minimum thinking budget so an
+		// Anthropic-dialect proxy (LiteLLM/Vertex) that downgrades the disabled
+		// request to the lowest reasoning effort still satisfies
+		// `max_tokens > thinking.budget_tokens` (issue #8610).
+		expect(options?.disableReasoning).toBe(true);
+		expect(options?.maxTokens).toBe(4096);
+		expect(options?.maxTokens).toBeGreaterThan(1024);
 	});
 
 	function createOnlineFixture(targetModel: Model, answer: string, maxEffort: "xhigh" | "max" = "xhigh") {

--- a/packages/coding-agent/test/unexpected-stop-classifier.test.ts
+++ b/packages/coding-agent/test/unexpected-stop-classifier.test.ts
@@ -139,7 +139,12 @@ describe("classifyUnexpectedStop", () => {
 			| undefined;
 
 		expect(result).toBe(true);
-		expect(options).toMatchObject({ disableReasoning: true, maxTokens: 1024 });
+		// Must exceed Anthropic's 1024-token minimum thinking budget so a LiteLLM/Vertex
+		// Anthropic route (which downgrades the disabled request to the lowest reasoning
+		// effort) still satisfies `max_tokens > thinking.budget_tokens` (issue #8610).
+		expect(options?.disableReasoning).toBe(true);
+		expect(options?.maxTokens).toBe(4096);
+		expect(options?.maxTokens).toBeGreaterThan(1024);
 	});
 });
 


### PR DESCRIPTION
## Repro
With `auto` thinking enabled and the tiny/smol model served through a LiteLLM proxy fronting Vertex/Anthropic (Claude Haiku), every prompt that triggers difficulty classification fails with `{"type":"invalid_request_error","message":"max_tokens must be greater than thinking.budget_tokens"}` (request_id `req_vrtx_...`). Reproduced by capturing the wire request omp builds for a LiteLLM Claude route: `{ "max_completion_tokens": 1024, "reasoning_effort": "minimal" }`.

## Cause
The online classifiers (`packages/coding-agent/src/auto-thinking/classifier.ts` and `packages/coding-agent/src/session/unexpected-stop-classifier.ts`) call `completeSimple` with `{ disableReasoning: true, maxTokens: 1024 }`. On the `openai-completions` transport LiteLLM uses, `disableReasoning` on a reasoning-capable model does not turn thinking off — the default `reasoningDisableMode: "lowest-effort"` (`packages/catalog/src/compat/openai.ts`) pins the lowest reasoning effort, so omp still emits `reasoning_effort`. LiteLLM then maps `max_completion_tokens` → `max_tokens` (1024) and `reasoning_effort` → Anthropic `thinking.budget_tokens` (≥ Anthropic's 1024-token minimum). `1024` is not `> 1024`, so Vertex/Anthropic 400s. The classifiers' `REASONING_SAFE_MAX_TOKENS = 1024` was sized only for the thinking-preamble case and happened to equal the minimum thinking budget, leaving zero headroom.

## Fix
- Split the classifier budget constants into a local reasoning budget (unchanged, 1024) and an online budget, and raise the online budget to 4096 so the request clears a proxy-injected minimum thinking budget and leaves room for the classification keyword to land.
- Applied to both online classifiers (auto-thinking difficulty and unexpected-stop); the local subprocess paths are untouched (no proxy budget constraint).
- Updated both classifier tests to assert the online budget exceeds Anthropic's 1024-token minimum; documented the `#8610` contract inline.
- Added a CHANGELOG entry.

## Verification
`cd packages/coding-agent && bun test test/auto-thinking-classifier.test.ts test/unexpected-stop-classifier.test.ts` → 36 pass / 0 fail. Also confirmed via a scratch wire-capture that omp sends `reasoning_effort` + `max_completion_tokens` on the openai-completions path, so raising `max_completion_tokens` above the injected budget resolves the 400.

Fixes #8610