### PR TITLE
feat(coding-agent): add tool aggregates to omp stats JSON output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added all-time tool-call aggregates to `omp stats -j` under `tooling.byTool` ([#8522](https://github.com/can1357/oh-my-pi/issues/8522)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -4,6 +4,14 @@
  * Handles `omp stats` subcommand for viewing AI usage statistics.
  */
 
+import {
+	closeDb,
+	getDashboardStats,
+	getToolDashboardStats,
+	getTotalMessageCount,
+	startServer,
+	syncAllSessions,
+} from "@oh-my-pi/omp-stats";
 import { truncateToWidth } from "@oh-my-pi/pi-tui/utils";
 import { APP_NAME, formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -111,11 +119,6 @@ function normalizePremiumRequests(n: number): number {
 // =============================================================================
 
 export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
-	// Lazy import to avoid loading stats module when not needed
-	const { getDashboardStats, syncAllSessions, getTotalMessageCount, startServer, closeDb } = await import(
-		"@oh-my-pi/omp-stats"
-	);
-
 	// Sync session files first
 	const progress = createSyncProgressReporter();
 	process.stderr.write("Syncing session files...\n");
@@ -126,7 +129,17 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 
 	if (cmd.json) {
 		const stats = await getDashboardStats();
-		console.log(JSON.stringify(stats, null, 2));
+		const toolStats = await getToolDashboardStats();
+		console.log(
+			JSON.stringify(
+				{
+					...stats,
+					tooling: { byTool: toolStats.byTool },
+				},
+				null,
+				2,
+			),
+		);
 		return;
 	}
 
@@ -157,7 +170,6 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 }
 
 async function printStatsSummary(): Promise<void> {
-	const { getDashboardStats } = await import("@oh-my-pi/omp-stats");
 	const stats = await getDashboardStats();
 	const { overall, byModel, byFolder } = stats;
 

--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -7,7 +7,7 @@
 import {
 	closeDb,
 	getDashboardStats,
-	getToolDashboardStats,
+	getToolUsageStats,
 	getTotalMessageCount,
 	startServer,
 	syncAllSessions,
@@ -129,12 +129,12 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 
 	if (cmd.json) {
 		const stats = await getDashboardStats();
-		const toolStats = await getToolDashboardStats();
+		const byTool = await getToolUsageStats("all");
 		console.log(
 			JSON.stringify(
 				{
 					...stats,
-					tooling: { byTool: toolStats.byTool },
+					tooling: { byTool },
 				},
 				null,
 				2,

--- a/packages/coding-agent/test/stats-cli-json.test.ts
+++ b/packages/coding-agent/test/stats-cli-json.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 });
 
 async function writeSessionFixture(agentDir: string): Promise<void> {
-	const timestamp = new Date().toISOString();
+	const timestamp = "2020-01-02T03:04:05.000Z";
 	const timestampMs = Date.parse(timestamp);
 	const entries = [
 		{
@@ -112,7 +112,6 @@ describe("stats CLI JSON", () => {
 		expect(jsonStart).toBeGreaterThanOrEqual(0);
 		const payload = JSON.parse(result.stdout.slice(jsonStart));
 
-		expect(payload.overall.totalRequests).toBe(1);
 		expect(payload.tooling.byTool).toEqual([
 			expect.objectContaining({
 				tool: toolName,

--- a/packages/coding-agent/test/stats-cli-json.test.ts
+++ b/packages/coding-agent/test/stats-cli-json.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const cliEntry = path.join(import.meta.dir, "..", "src", "cli.ts");
+const toolName = "mcp__fixture";
+const toolArguments = { query: "docs" };
+const toolResult = "fixture response";
+
+let tempRoot: TempDir | undefined;
+
+beforeEach(() => {
+	tempRoot = TempDir.createSync("@omp-stats-cli-json-");
+});
+
+afterEach(async () => {
+	await tempRoot?.remove();
+	tempRoot = undefined;
+});
+
+async function writeSessionFixture(agentDir: string): Promise<void> {
+	const timestamp = new Date().toISOString();
+	const timestampMs = Date.parse(timestamp);
+	const entries = [
+		{
+			type: "session",
+			version: 3,
+			id: "stats-cli-fixture",
+			timestamp,
+			cwd: "/tmp/stats-cli-fixture",
+		},
+		{
+			type: "message",
+			id: "assistant-1",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Using the fixture tool." },
+					{ type: "toolCall", id: "call-1", name: toolName, arguments: toolArguments },
+				],
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-5.4",
+				usage: {
+					input: 10,
+					output: 5,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 15,
+					cost: { input: 0.001, output: 0.001, cacheRead: 0, cacheWrite: 0, total: 0.002 },
+				},
+				stopReason: "toolUse",
+				timestamp: timestampMs,
+				duration: 10,
+				ttft: 5,
+			},
+		},
+		{
+			type: "message",
+			id: "tool-result-1",
+			parentId: "assistant-1",
+			timestamp,
+			message: {
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName,
+				content: [{ type: "text", text: toolResult }],
+				isError: false,
+				timestamp: timestampMs,
+			},
+		},
+	];
+	const sessionFile = path.join(agentDir, "sessions", "--tmp--stats-cli-fixture", "session.jsonl");
+	await Bun.write(sessionFile, `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
+}
+
+async function runStatsJson(agentDir: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const homeDir = path.dirname(path.dirname(agentDir));
+	const proc = Bun.spawn([process.execPath, cliEntry, "stats", "-j"], {
+		cwd: path.join(import.meta.dir, ".."),
+		env: {
+			...process.env,
+			HOME: homeDir,
+			PI_CODING_AGENT_DIR: agentDir,
+			XDG_DATA_HOME: path.join(homeDir, "xdg-data"),
+			XDG_STATE_HOME: path.join(homeDir, "xdg-state"),
+			XDG_CACHE_HOME: path.join(homeDir, "xdg-cache"),
+			NO_COLOR: "1",
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+describe("stats CLI JSON", () => {
+	it("includes all-time tool aggregates without the larger dashboard series", async () => {
+		if (!tempRoot) throw new Error("Temporary stats root was not initialized");
+		const agentDir = tempRoot.join(".omp", "agent");
+		await writeSessionFixture(agentDir);
+
+		const result = await runStatsJson(agentDir);
+		expect(result.exitCode).toBe(0);
+		const jsonStart = result.stdout.indexOf("{");
+		expect(jsonStart).toBeGreaterThanOrEqual(0);
+		const payload = JSON.parse(result.stdout.slice(jsonStart));
+
+		expect(payload.overall.totalRequests).toBe(1);
+		expect(payload.tooling.byTool).toEqual([
+			expect.objectContaining({
+				tool: toolName,
+				calls: 1,
+				errors: 0,
+				argsChars: JSON.stringify(toolArguments).length,
+				resultChars: toolResult.length,
+			}),
+		]);
+		expect(payload.tooling).not.toHaveProperty("byToolModel");
+		expect(payload.tooling).not.toHaveProperty("series");
+	});
+});

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -47,6 +47,7 @@ import type {
 	ProviderDashboardStats,
 	RequestDetails,
 	ToolDashboardStats,
+	ToolUsageStats,
 } from "./types";
 import { computeUsageWindowStats, fetchUsageSnapshots } from "./usage-windows";
 
@@ -524,6 +525,16 @@ export async function getBehaviorDashboardStats(range?: string | null): Promise<
 		byModel: getBehaviorByModel(cutoff),
 		behaviorSeries: getBehaviorTimeSeries(cutoff),
 	};
+}
+
+/**
+ * Get per-tool usage totals for the requested range without computing the
+ * dashboard's per-model breakdown or time series.
+ */
+export async function getToolUsageStats(range?: string | null): Promise<ToolUsageStats[]> {
+	await initDb();
+	const { cutoff } = getTimeRangeConfig(range);
+	return getToolStats(cutoff ?? undefined);
 }
 
 /**

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -9,6 +9,7 @@ import { startServer } from "./server";
 export {
 	getDashboardStats,
 	getToolDashboardStats,
+	getToolUsageStats,
 	getTotalMessageCount,
 	type SyncOptions,
 	type SyncProgress,


### PR DESCRIPTION
## What

`omp stats -j` now includes all-time tool-call aggregates under an extensible `tooling` parent:

```json
{
  "overall": { ... },
  "byModel": [ ... ],
  "byFolder": [ ... ],
  "tooling": {
    "byTool": [
      {
        "tool": "...",
        "calls": 1,
        "errors": 0,
        "argsChars": 16,
        "resultChars": 16
      }
    ]
  }
}
```

The JSON deliberately excludes `byToolModel` and the time `series` to keep the payload compact. Those fields can be added under `tooling` later without changing the top-level contract.

A CLI-level regression test exercises `stats -j` against an isolated fixture session and verifies both the aggregate values and the excluded fields.

## Why

Fixes #8522.

Tool-call statistics were already persisted and available through the stats package, but `omp stats -j` only serialized the existing usage dashboard data. This exposes the all-time per-tool aggregates following the established `byModel` and `byFolder` pattern.

I chose `tooling.byTool` to expose the all-time per-tool statistics requested in #8522 without including the larger per-model and time-series datasets in every JSON response.

## Testing

- `bun run check` in `packages/coding-agent`: passed.
- `bun test test/stats-cli-json.test.ts`: 1 passed, 0 failed.
- `bun src/cli.ts stats -j`: exited 0 and returned `tooling.byTool` with 28 rows from a real local stats database.
- Confirmed `tooling` contains neither `byToolModel` nor `series`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)