### PR TITLE
feat(ai): support Kimi API-key usage reports

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Kimi Code usage reports for API-key credentials, including status-line, `/usage`, and usage-aware routing support ([#8504](https://github.com/can1357/oh-my-pi/issues/8504)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Fixed

--- a/packages/ai/src/usage/kimi.ts
+++ b/packages/ai/src/usage/kimi.ts
@@ -231,22 +231,25 @@ function parseUsagePayload(payload: unknown, nowMs: number): { rows: KimiUsageRo
 export const kimiUsageProvider: UsageProvider = {
 	id: "kimi-code",
 	supports(params: UsageFetchParams): boolean {
-		return params.provider === "kimi-code" && params.credential.type === "oauth";
+		return (
+			params.provider === "kimi-code" &&
+			(params.credential.type === "oauth"
+				? Boolean(params.credential.accessToken)
+				: Boolean(params.credential.apiKey))
+		);
 	},
 	async fetchUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
 		if (params.provider !== "kimi-code") return null;
 		const { credential } = params;
-		if (credential.type !== "oauth") return null;
-
-		const accessToken = credential.accessToken;
-		if (!accessToken) return null;
+		const token = credential.type === "oauth" ? credential.accessToken : credential.apiKey;
+		if (!token) return null;
 
 		const nowMs = Date.now();
 		// AuthStorage refreshes OAuth credentials pre-emptively (60s skew). If the
 		// usage probe lands with an expired token, short-circuit rather than POST
 		// the broker sentinel back to Kimi — the next cycle will carry a freshly
-		// refreshed credential.
-		if (credential.expiresAt !== undefined && credential.expiresAt <= nowMs) {
+		// refreshed credential. API keys do not expire through this flow.
+		if (credential.type === "oauth" && credential.expiresAt !== undefined && credential.expiresAt <= nowMs) {
 			ctx.logger?.debug("Kimi usage token expired; skipping probe", { provider: params.provider });
 			return null;
 		}
@@ -258,7 +261,7 @@ export const kimiUsageProvider: UsageProvider = {
 			const response = await ctx.fetch(url, {
 				headers: {
 					...getKimiCommonHeaders(),
-					Authorization: `Bearer ${accessToken}`,
+					Authorization: `Bearer ${token}`,
 				},
 				signal: params.signal,
 			});

--- a/packages/ai/test/kimi-usage.test.ts
+++ b/packages/ai/test/kimi-usage.test.ts
@@ -20,6 +20,60 @@ function makeCtx(payload: unknown): UsageFetchContext {
 }
 
 describe("kimi usage provider", () => {
+	it("fetches usage with an API key as a bearer token", async () => {
+		const requests: Array<{ url: string; authorization: string | null }> = [];
+		const credential: UsageFetchParams["credential"] = {
+			type: "api_key",
+			apiKey: "sk-kimi-test",
+		};
+		const params: UsageFetchParams = {
+			provider: "kimi-code",
+			credential,
+			baseUrl: "https://api.kimi.com/coding/v1/",
+			signal: undefined,
+		};
+		const fetch: FetchImpl = async (input, init) => {
+			requests.push({
+				url: String(input),
+				authorization: new Headers(init?.headers).get("Authorization"),
+			});
+			return new Response(
+				JSON.stringify({
+					usage: { limit: "100", used: "2", remaining: "98", resetTime: "2026-08-20T07:05:56Z" },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		};
+
+		expect(kimiUsageProvider.supports!(params)).toBe(true);
+		const report = await kimiUsageProvider.fetchUsage!(params, { fetch });
+
+		expect(requests).toEqual([
+			{
+				url: "https://api.kimi.com/coding/v1/usages",
+				authorization: "Bearer sk-kimi-test",
+			},
+		]);
+		expect(report?.limits[0]?.amount.remainingFraction).toBe(0.98);
+	});
+
+	it("supports populated API-key and OAuth credentials only", () => {
+		expect(
+			kimiUsageProvider.supports!({
+				provider: "kimi-code",
+				credential: { type: "api_key", apiKey: "sk-kimi-test" },
+			}),
+		).toBe(true);
+		expect(
+			kimiUsageProvider.supports!({
+				provider: "kimi-code",
+				credential: { type: "oauth", accessToken: "kimi-oauth-token" },
+			}),
+		).toBe(true);
+		expect(kimiUsageProvider.supports!({ provider: "kimi-code", credential: { type: "api_key" } })).toBe(false);
+		expect(kimiUsageProvider.supports!({ provider: "kimi-code", credential: { type: "oauth" } })).toBe(false);
+	});
+
 	it("surfaces the 5h limit reset time from the limit detail onto the window", async () => {
 		// Live payload shape: `resetTime` lives on `detail`, while `window`
 		// carries only duration/timeUnit. The 5h row must still render


### PR DESCRIPTION
## What

- Allow the built-in `kimi-code` usage provider to use either OAuth access tokens or console API keys.
- Send both credential kinds through the existing Bearer-authenticated `/coding/v1/usages` request while keeping expiry checks OAuth-specific.
- Cover API-key request construction, response parsing, both supported credential kinds, and empty-token rejection.

## Why

Fixes #8504.

Kimi Code accepts console-issued `sk-kimi-…` keys on the same usage endpoint, but OMP rejected every non-OAuth credential before making the request. API-key sessions therefore could not populate the status line, `/usage`, or usage-aware routing. This change keeps `models.yml` config-pinned credential collection out of scope, as discussed on the issue.

## Testing

- `bun test test/kimi-usage.test.ts` in `packages/ai`: 5 passed, 0 failed
- `bun run check` in `packages/ai`: passed
- Request URL, Bearer header, and report conversion tested with a mocked fetch boundary; not tested against the live Kimi API because I do not have an active Kimi API key.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)