### PR TITLE
feat(ai): boost Codex accounts with expiring saved reset credits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Codex credential ranking now boosts accounts whose saved reset credits expire within the configured salvage horizon (`codexResets.salvageHorizonHours`), so new sessions steer toward the credit that would otherwise be lost before it expires ([#8342](https://github.com/can1357/oh-my-pi/issues/8342)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -808,6 +808,12 @@ type AuthApiKeyOptions = {
 	baseUrl?: string;
 	modelId?: string;
 	/**
+	 * Saved-reset salvage horizon (ms) for ranking. Providers that boost
+	 * credentials with expiring saved resets read this from the ranking
+	 * context; `<= 0` (or unset) disables the boost.
+	 */
+	salvageHorizonMs?: number;
+	/**
 	 * Caller's cancel signal. Threaded into any broker-bound OAuth refresh so
 	 * `ESC` / request abort actually kills a hung broker fetch instead of
 	 * stranding the caller for `timeoutMs * (maxRetries + 1)`.
@@ -1242,6 +1248,8 @@ type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 	blockedUntil?: number;
 	hasPriorityBoost: boolean;
 	planPriority: number;
+	/** Soonest saved-reset expiry within the salvage horizon (epoch ms), when the provider boosts such credits. */
+	resetCreditExpiryBoostMs?: number;
 	secondaryUsed: number;
 	secondaryRequiredDrain: number;
 	primaryUsed: number;
@@ -2166,7 +2174,10 @@ export class AuthStorage {
 			return fallback;
 		}
 
-		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const rankingContext: CredentialRankingContext = {
+			modelId: options?.modelId,
+			salvageHorizonMs: options?.salvageHorizonMs,
+		};
 		const blockScope = strategy.blockScope?.(rankingContext);
 		const blockScopes = strategy.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
 		const candidates = await this.#rankApiKeySelections({
@@ -4347,10 +4358,11 @@ export class AuthStorage {
 		provider: string,
 		credentialType: AuthCredential["type"],
 		modelId: string | undefined,
+		options?: AuthApiKeyOptions,
 	): CredentialBlockRouting {
 		const providerKey = this.#getProviderTypeKey(provider, credentialType);
 		const strategy = this.#rankingStrategyResolver?.(provider);
-		const rankingContext: CredentialRankingContext = { modelId };
+		const rankingContext: CredentialRankingContext = { modelId, salvageHorizonMs: options?.salvageHorizonMs };
 		const blockScope = strategy?.blockScope?.(rankingContext);
 		return {
 			providerKey,
@@ -4437,7 +4449,7 @@ export class AuthStorage {
 		const credentialType = sessionCredential.type;
 		const targetCredentialId = target.id;
 
-		const routing = this.#credentialBlockRouting(provider, credentialType, options?.modelId);
+		const routing = this.#credentialBlockRouting(provider, credentialType, options?.modelId, options);
 		const now = Date.now();
 		let blockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
 
@@ -4521,6 +4533,18 @@ export class AuthStorage {
 			return left.planPriority - right.planPriority;
 		}
 		if (left.hasPriorityBoost !== right.hasPriorityBoost) return left.hasPriorityBoost ? -1 : 1;
+		// Expiring saved-reset boost: an account whose reset would otherwise die
+		// inside the salvage horizon outranks siblings without one; among boosted
+		// candidates the soonest expiry wins, so work steers to the credit that
+		// is about to be lost. Blocked/exhausted/plan-ineligible filtering above
+		// still gates, so the boost never resurrects an unusable account.
+		const leftReset = left.resetCreditExpiryBoostMs;
+		const rightReset = right.resetCreditExpiryBoostMs;
+		if (leftReset !== rightReset) {
+			if (leftReset === undefined) return 1;
+			if (rightReset === undefined) return -1;
+			return leftReset - rightReset;
+		}
 		// Short-window guard: candidates whose primary (e.g. 5h) window is
 		// nearly exhausted rank behind cool ones regardless of drain urgency —
 		// overflow lands on the next-most-urgent cool account instead.
@@ -4674,6 +4698,9 @@ export class AuthStorage {
 				blocked,
 				blockedUntil,
 				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
+				resetCreditExpiryBoostMs: usage
+					? strategy.getResetCreditExpiryBoostMs?.(usage, args.rankingContext, nowMs)
+					: undefined,
 				planPriority: getOpenAICodexPlanPriority(usage, args.planRequirement),
 				secondaryUsed: this.#normalizeUsageFraction(secondary),
 				secondaryRequiredDrain: this.#computeWindowRequiredDrain(
@@ -4721,7 +4748,10 @@ export class AuthStorage {
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
 		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
 		const strategy = this.#rankingStrategyResolver?.(provider);
-		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const rankingContext: CredentialRankingContext = {
+			modelId: options?.modelId,
+			salvageHorizonMs: options?.salvageHorizonMs,
+		};
 		const blockScope = strategy?.blockScope?.(rankingContext);
 		// Reads honour every scope that applies; the scalar above is for args that persist.
 		const blockScopes = strategy?.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
@@ -6213,7 +6243,7 @@ export class AuthStorage {
 		if (!sessionCredential) return false;
 
 		if (AIError.isAccountPolicyError(error)) {
-			const routing = this.#credentialBlockRouting(provider, sessionCredential.type, options?.modelId);
+			const routing = this.#credentialBlockRouting(provider, sessionCredential.type, options?.modelId, options);
 			return this.#blockCredentialForRotation(
 				provider,
 				sessionCredential.type,

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -347,6 +347,12 @@ export interface UsageProvider {
 export interface CredentialRankingContext {
 	/** Provider model id, when the caller is selecting a credential for one model. */
 	modelId?: string;
+	/**
+	 * Saved-reset salvage horizon (ms) for providers that boost credentials
+	 * with use-it-or-lose-it resets (OpenAI Codex). Mirrors the expiry-salvage
+	 * horizon so routing and auto-redeem never disagree; `<= 0` disables the boost.
+	 */
+	salvageHorizonMs?: number;
 }
 
 /** Strategy for usage-based credential ranking. Providers implement this to opt into smart credential selection. */
@@ -388,4 +394,15 @@ export interface CredentialRankingStrategy {
 	};
 	/** Optional: priority boost for specific credential states (e.g., fresh 5h ticker start). */
 	hasPriorityBoost?(primary: UsageLimit | undefined): boolean;
+	/**
+	 * Optional: soonest epoch-ms expiry of a saved reset within the salvage
+	 * horizon, or undefined when no such credit exists. Smaller values rank
+	 * earlier, so an account whose reset would otherwise die is preferred for
+	 * new work before the credit expires.
+	 */
+	getResetCreditExpiryBoostMs?(
+		report: UsageReport,
+		context?: CredentialRankingContext,
+		nowMs?: number,
+	): number | undefined;
 }

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -582,6 +582,31 @@ function isCodexSparkRequest(context?: CredentialRankingContext): boolean {
 	return (context?.modelId ?? "").toLowerCase().includes("-spark");
 }
 
+/**
+ * Soonest saved-reset expiry (epoch ms) within the salvage horizon, or
+ * undefined when the account has no such credit. Credit details are consumed
+ * conservatively: aggregate-only, missing, invalid, or already-expired
+ * entries never produce a boost (#8342).
+ */
+function getCodexResetCreditExpiryBoostMs(
+	report: UsageReport,
+	context: CredentialRankingContext | undefined,
+	nowMs: number,
+): number | undefined {
+	const horizonMs = context?.salvageHorizonMs;
+	if (horizonMs === undefined || horizonMs <= 0) return undefined;
+	const credits = report.resetCredits;
+	if (!credits || credits.availableCount <= 0 || !credits.credits?.length) return undefined;
+	let soonestMs: number | undefined;
+	for (const credit of credits.credits) {
+		if ((credit.status ?? "available") !== "available" || !credit.expiresAt) continue;
+		const expiryMs = Date.parse(credit.expiresAt);
+		if (Number.isNaN(expiryMs) || expiryMs <= nowMs || expiryMs - nowMs > horizonMs) continue;
+		if (soonestMs === undefined || expiryMs < soonestMs) soonestMs = expiryMs;
+	}
+	return soonestMs;
+}
+
 export const codexRankingStrategy: CredentialRankingStrategy = {
 	scopeLimits: scopeCodexLimitsForRequest,
 	// A `usage_limit_reached` from a Spark request means the Spark meter is
@@ -623,5 +648,8 @@ export const codexRankingStrategy: CredentialRankingStrategy = {
 		if (!isFiveHourWindow) return false;
 		const usedFraction = primary.amount.usedFraction;
 		return typeof usedFraction === "number" && Number.isFinite(usedFraction) && usedFraction === 0;
+	},
+	getResetCreditExpiryBoostMs(report, context, nowMs = Date.now()) {
+		return getCodexResetCreditExpiryBoostMs(report, context, nowMs);
 	},
 };

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -13,7 +13,7 @@ import {
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
-import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import type { UsageLimit, UsageProvider, UsageReport, UsageResetCredits } from "@oh-my-pi/pi-ai/usage";
 import { removeWithRetries } from "../../utils/src/temp";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -125,6 +125,7 @@ function createCodexUsageReport(args: {
 	primaryWindow?: UsageWindowConfig;
 	secondaryWindow?: UsageWindowConfig;
 	metadata?: CodexUsageMetadata;
+	resetCredits?: UsageResetCredits;
 }): UsageReport {
 	const primaryWindow = args.primaryWindow ?? { windowId: "1h", windowLabel: "1 Hour", durationMs: HOUR_MS };
 	const secondaryWindow = args.secondaryWindow ?? { windowId: "7d", windowLabel: "7 Day", durationMs: WEEK_MS };
@@ -149,6 +150,7 @@ function createCodexUsageReport(args: {
 				resetInMs: args.secondary.resetInMs,
 			}),
 		],
+		...(args.resetCredits ? { resetCredits: args.resetCredits } : {}),
 		metadata: { accountId: args.accountId, ...args.metadata },
 	};
 }
@@ -217,10 +219,11 @@ async function countApiKeySelections(
 	provider: string,
 	sessionPrefix: string,
 	samples = 150,
+	options?: { salvageHorizonMs?: number },
 ): Promise<Map<string, number>> {
 	const counts = new Map<string, number>();
 	for (let index = 0; index < samples; index += 1) {
-		const apiKey = await authStorage.getApiKey(provider, `${sessionPrefix}-${index}`);
+		const apiKey = await authStorage.getApiKey(provider, `${sessionPrefix}-${index}`, options);
 		if (!apiKey) continue;
 		counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
 	}
@@ -389,6 +392,168 @@ describe("AuthStorage codex oauth ranking", () => {
 		const counts = await countApiKeySelections(authStorage, "openai-codex", "weighted-codex-zero");
 		expectExclusivePreference(counts, "api-acct-zero", "api-acct-progress");
 	});
+
+	// ── #8342: saved-reset expiry boost ─────────────────────────────────────────
+
+	function expiringResetCredits(expiresInMs: number): UsageResetCredits {
+		return {
+			availableCount: 1,
+			credits: [{ expiresAt: new Date(Date.now() + expiresInMs).toISOString(), status: "available" }],
+		};
+	}
+
+	test("prefers an account whose saved reset expires within the salvage horizon", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		// The #8342 fixture: A has little weekly quota left but a reset credit
+		// expiring in ~4h; B/C have more headroom and no saved resets. Pure
+		// required-drain ranks C first (0.46/160h), so the boost must steer
+		// new sessions to A before the credit dies.
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-a", "a@example.com") },
+			{ type: "oauth", ...createCredential("acct-b", "b@example.com") },
+			{ type: "oauth", ...createCredential("acct-c", "c@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-a",
+			createCodexUsageReport({
+				accountId: "acct-a",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.8, resetInMs: 141 * HOUR_MS }, // 20% left, 5d21h
+				resetCredits: expiringResetCredits(4 * HOUR_MS),
+			}),
+		);
+		usageByAccount.set(
+			"acct-b",
+			createCodexUsageReport({
+				accountId: "acct-b",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.56, resetInMs: 161 * HOUR_MS }, // 44% left, 6d17h
+			}),
+		);
+		usageByAccount.set(
+			"acct-c",
+			createCodexUsageReport({
+				accountId: "acct-c",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.54, resetInMs: 160 * HOUR_MS }, // 46% left, 6d16h
+			}),
+		);
+
+		const counts = await countApiKeySelections(authStorage, "openai-codex", "weighted-codex-reset", 20, {
+			salvageHorizonMs: 12 * HOUR_MS,
+		});
+		expect(countFor(counts, "api-acct-a")).toBeGreaterThan(0);
+		expect(countFor(counts, "api-acct-c")).toBe(0);
+	});
+
+	test("falls back to required-drain ranking when no reset credit is expiring", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-a", "a@example.com") },
+			{ type: "oauth", ...createCredential("acct-b", "b@example.com") },
+			{ type: "oauth", ...createCredential("acct-c", "c@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-a",
+			createCodexUsageReport({
+				accountId: "acct-a",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.8, resetInMs: 141 * HOUR_MS },
+			}),
+		);
+		usageByAccount.set(
+			"acct-b",
+			createCodexUsageReport({
+				accountId: "acct-b",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.56, resetInMs: 161 * HOUR_MS },
+			}),
+		);
+		usageByAccount.set(
+			"acct-c",
+			createCodexUsageReport({
+				accountId: "acct-c",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.54, resetInMs: 160 * HOUR_MS },
+			}),
+		);
+
+		const counts = await countApiKeySelections(authStorage, "openai-codex", "weighted-codex-no-reset", 20, {
+			salvageHorizonMs: 12 * HOUR_MS,
+		});
+		expect(countFor(counts, "api-acct-a")).toBe(0);
+		expect(countFor(counts, "api-acct-c")).toBeGreaterThan(0);
+	});
+
+	test("does not boost past a blocked account even with an expiring reset", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-a", "a@example.com") },
+			{ type: "oauth", ...createCredential("acct-b", "b@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-a",
+			createCodexUsageReport({
+				accountId: "acct-a",
+				primary: { usedFraction: 1, resetInMs: 30 * 60 * 1000 }, // exhausted
+				secondary: { usedFraction: 1, resetInMs: 30 * 60 * 1000 },
+				resetCredits: expiringResetCredits(4 * HOUR_MS),
+			}),
+		);
+		usageByAccount.set(
+			"acct-b",
+			createCodexUsageReport({
+				accountId: "acct-b",
+				primary: { usedFraction: 0.5, resetInMs: 20 * 60 * 1000 },
+				secondary: { usedFraction: 0.4, resetInMs: 3 * 24 * HOUR_MS },
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("openai-codex", "session-blocked-reset", {
+			salvageHorizonMs: 12 * HOUR_MS,
+		});
+		expect(apiKey).toBe("api-acct-b");
+	});
+
+	test("ignores reset credits expiring outside the salvage horizon", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-a", "a@example.com") },
+			{ type: "oauth", ...createCredential("acct-c", "c@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-a",
+			createCodexUsageReport({
+				accountId: "acct-a",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.8, resetInMs: 141 * HOUR_MS },
+				resetCredits: expiringResetCredits(3 * 24 * HOUR_MS), // 3d > 12h horizon
+			}),
+		);
+		usageByAccount.set(
+			"acct-c",
+			createCodexUsageReport({
+				accountId: "acct-c",
+				primary: { usedFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { usedFraction: 0.54, resetInMs: 160 * HOUR_MS },
+			}),
+		);
+
+		const counts = await countApiKeySelections(authStorage, "openai-codex", "weighted-codex-far-reset", 20, {
+			salvageHorizonMs: 12 * HOUR_MS,
+		});
+		expect(countFor(counts, "api-acct-a")).toBe(0);
+		expect(countFor(counts, "api-acct-c")).toBeGreaterThan(0);
+	});
+
 	test("skips exhausted weekly account even when reset is near", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -8,7 +8,10 @@
  */
 import { describe, expect, it } from "bun:test";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import type { CredentialRankingContext, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "@oh-my-pi/pi-ai/usage/openai-codex";
+
+const HOUR_MS = 60 * 60 * 1000;
 
 const accessTokenFixture = (() => {
 	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
@@ -388,5 +391,84 @@ describe("openai-codex usage parser", () => {
 		expect(codexRankingStrategy.blockScopes?.({ modelId: "gpt-5.3-codex-spark" })).toEqual(["spark", "shared"]);
 		// Reconciliation runs with no request context and must heal every scope.
 		expect(codexRankingStrategy.blockScopes?.()).toEqual(["chat", "spark", "shared"]);
+	});
+
+	describe("codexRankingStrategy.getResetCreditExpiryBoostMs (#8342)", () => {
+		const now = Date.parse("2026-08-15T12:00:00Z");
+		const inHours = (hours: number): string => new Date(now + hours * HOUR_MS).toISOString();
+		const baseReport = (): UsageReport => ({
+			provider: "openai-codex",
+			fetchedAt: now,
+			limits: [],
+			metadata: { accountId: "acct-1" },
+		});
+		const context = (salvageHorizonMs: number): CredentialRankingContext => ({
+			salvageHorizonMs,
+		});
+
+		it("returns the soonest expiry of an available credit inside the horizon", () => {
+			const report: UsageReport = {
+				...baseReport(),
+				resetCredits: {
+					availableCount: 2,
+					credits: [
+						{ expiresAt: inHours(8), status: "available" },
+						{ expiresAt: inHours(3), status: "available" },
+					],
+				},
+			};
+			const boost = codexRankingStrategy.getResetCreditExpiryBoostMs?.(report, context(12 * HOUR_MS), now);
+			expect(boost).toBe(now + 3 * HOUR_MS);
+		});
+
+		it("ignores redeemed or missing-expiry credits", () => {
+			const report: UsageReport = {
+				...baseReport(),
+				resetCredits: {
+					availableCount: 2,
+					credits: [{ expiresAt: inHours(3), status: "redeemed" }, { expiresAt: undefined }],
+				},
+			};
+			const boost = codexRankingStrategy.getResetCreditExpiryBoostMs?.(report, context(12 * HOUR_MS), now);
+			expect(boost).toBeUndefined();
+		});
+
+		it("skips expired credits and credits outside the horizon", () => {
+			const report: UsageReport = {
+				...baseReport(),
+				resetCredits: {
+					availableCount: 3,
+					credits: [
+						{ expiresAt: new Date(now - HOUR_MS).toISOString(), status: "available" },
+						{ expiresAt: inHours(3 * 24), status: "available" },
+						{ expiresAt: inHours(6), status: "available" },
+					],
+				},
+			};
+			const boost = codexRankingStrategy.getResetCreditExpiryBoostMs?.(report, context(12 * HOUR_MS), now);
+			expect(boost).toBe(now + 6 * HOUR_MS);
+		});
+
+		it("returns undefined without credits, a count of zero, or a disabled horizon", () => {
+			const noCredits: UsageReport = { ...baseReport(), resetCredits: { availableCount: 1 } };
+			expect(
+				codexRankingStrategy.getResetCreditExpiryBoostMs?.(noCredits, context(12 * HOUR_MS), now),
+			).toBeUndefined();
+
+			const zeroCount: UsageReport = {
+				...baseReport(),
+				resetCredits: { availableCount: 0, credits: [{ expiresAt: inHours(3), status: "available" }] },
+			};
+			expect(
+				codexRankingStrategy.getResetCreditExpiryBoostMs?.(zeroCount, context(12 * HOUR_MS), now),
+			).toBeUndefined();
+
+			const withCredit: UsageReport = {
+				...baseReport(),
+				resetCredits: { availableCount: 1, credits: [{ expiresAt: inHours(3), status: "available" }] },
+			};
+			expect(codexRankingStrategy.getResetCreditExpiryBoostMs?.(withCredit, context(0), now)).toBeUndefined();
+			expect(codexRankingStrategy.getResetCreditExpiryBoostMs?.(withCredit, undefined, now)).toBeUndefined();
+		});
 	});
 });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -130,6 +130,20 @@ interface CustomModelsResult {
  */
 type ModifyModelsHook = (models: Model<Api>[], credentials: OAuthCredentials) => Model<Api>[];
 
+/**
+ * Saved-reset salvage horizon (ms) shared with the expiry-salvage planner
+ * (`codex-auto-reset`), so credential ranking and auto-redeem never disagree
+ * about which credits are worth routing work toward (#8342).
+ */
+function codexResetSalvageHorizonMs(): number | undefined {
+	try {
+		const hours = settings.get("codexResets.salvageHorizonHours");
+		return typeof hours === "number" && hours > 0 ? hours * 3_600_000 : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function getDisabledProviderIdsFromSettings(): Set<string> {
 	try {
 		return new Set(settings.get("disabledProviders"));
@@ -1761,6 +1775,7 @@ export class ModelRegistry {
 		return this.authStorage.getApiKey(model.provider, sessionId, {
 			baseUrl: model.baseUrl,
 			modelId: model.id,
+			salvageHorizonMs: codexResetSalvageHorizonMs(),
 			signal: options?.signal,
 		});
 	}
@@ -1803,6 +1818,7 @@ export class ModelRegistry {
 			baseUrl: options?.baseUrl,
 			modelId: options?.modelId,
 			forceRefresh: options?.forceRefresh,
+			salvageHorizonMs: codexResetSalvageHorizonMs(),
 			signal: options?.signal,
 		});
 	}


### PR DESCRIPTION
Credential ranking now prefers accounts whose saved reset credits expire inside the salvage horizon (`codexResets.salvageHorizonHours`), ordered by soonest expiry, so new sessions steer to the credit that would otherwise be lost. Blocked/exhausted/plan-ineligible accounts stay unfiltered by the boost, and pinned sessions are never migrated.

Fixes #8342

## What

Adds an expiring saved-reset boost to Codex OAuth credential ranking:

- `CredentialRankingContext` gains `salvageHorizonMs`, sourced from the same `codexResets.salvageHorizonHours` setting the expiry-salvage planner uses, so routing and auto-redeem never disagree about a single horizon.
- `codexRankingStrategy.getResetCreditExpiryBoostMs` returns the soonest expiry of an available, future, within-horizon credit (aggregate-only / missing / invalid / expired credits are ignored conservatively).
- The comparator prefers boosted accounts, ordered by earliest expiry, after the blocked / plan-eligibility / priority-boost gates and before the hot-window guard and required-drain metrics.

## Why

A saved reset is use-it-or-lose-it. When one account's credit expires much sooner than every account's natural quota reset, required-drain ranking keeps routing new work to siblings, stranding the credit until it dies (or auto-redeem races a `nothing_to_reset`).

## Testing

- New integration tests in `auth-storage-codex-selection.test.ts` cover the #8342 A/B/C fixture: account A (20% quota left, 1 reset expiring in ~4h) wins while its credit is inside a 12h horizon; without a credit, ranking falls back to required-drain; a blocked account is never boosted; credits outside the horizon are ignored.
- New unit tests in `openai-codex-usage.test.ts` cover soonest-expiry selection, redeemed/missing-expiry credits, expired/out-of-horizon credits, and the no-credits / zero-count / disabled-horizon cases.
- `bun run check` passes in `packages/ai` and `packages/coding-agent`; `bun test` in `packages/ai` shows no new failures.

---

I am a full-stack developer intern contributing to this project. Please review and let me know if any changes are needed.

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)