### PR TITLE
fix(browser): suppress blank shared startup window

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed broker-owned headless Chromium opening and retaining an unowned blank foreground window on Windows ([#8615](https://github.com/can1357/oh-my-pi/issues/8615)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -430,8 +430,8 @@ export interface SharedBrowserLaunchSpec {
  * Resolve the executable and complete argv for a shared Chromium the daemon
  * broker spawns directly (no puppeteer inside the broker). Mirrors
  * `launchHeadlessBrowser` flag assembly — puppeteer's default args minus the
- * stealth-suppressed set — plus `--remote-debugging-port=0` so every client
- * attaches over CDP. Returns null when no Chromium executable resolves;
+ * stealth-suppressed set — suppresses Puppeteer's unowned startup window, and
+ * exposes CDP on an ephemeral port. Returns null when no executable resolves;
  * callers fall back to a process-local launch.
  */
 export async function resolveSharedBrowserLaunchSpec(opts: {
@@ -451,7 +451,7 @@ export async function resolveSharedBrowserLaunchSpec(opts: {
 	});
 	return {
 		executablePath,
-		args: [...defaults.filter(arg => !ignored.has(arg)), "--remote-debugging-port=0"],
+		args: [...defaults.filter(arg => !ignored.has(arg)), "--no-startup-window", "--remote-debugging-port=0"],
 	};
 }
 

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
 	chromiumExecutableProbeForTest,
+	resolveSharedBrowserLaunchSpec,
 	stealthIgnoreDefaultArgsForTest,
 	systemChromiumCandidatesForTest,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
@@ -40,6 +41,24 @@ describe("browser launch stealth defaults", () => {
 			const ignoreDefaultArgs = stealthIgnoreDefaultArgsForTest(executablePath);
 
 			expect(ignoreDefaultArgs).toContain(AUTOMATION_FLAG);
+		}
+	});
+});
+
+describe("shared browser launch", () => {
+	it("suppresses the broker-owned blank startup window", async () => {
+		const previousExecutable = process.env.PUPPETEER_EXECUTABLE_PATH;
+		process.env.PUPPETEER_EXECUTABLE_PATH = "/test/chrome";
+		try {
+			const launch = await resolveSharedBrowserLaunchSpec({
+				headless: true,
+				userDataDir: "/test/profile",
+			});
+
+			expect(launch?.args).toContain("--no-startup-window");
+		} finally {
+			if (previousExecutable === undefined) delete process.env.PUPPETEER_EXECUTABLE_PATH;
+			else process.env.PUPPETEER_EXECUTABLE_PATH = previousExecutable;
 		}
 	});
 });


### PR DESCRIPTION
## Repro
On Windows under a VS Code terminal, opening the default headless browser routes Chromium through the launch broker. The broker-side trigger is reproduced with `bun -e 'import { resolveDaemonSpawnOptions } from "./packages/coding-agent/src/launch/spawn-options.ts"; console.log(JSON.stringify(resolveDaemonSpawnOptions({ platform: "win32", hostHasInheritableConsole: true })));'`, which prints `{"detached":false,"windowsHide":false}`; Puppeteer's shared-browser argv also creates an initial `about:blank` target that is not owned by a session tab.

## Cause
`resolveSharedBrowserLaunchSpec()` in `packages/coding-agent/src/tools/browser/launch.ts` used `puppeteer.defaultArgs()`, which creates an initial blank startup target. The broker-owned Chromium intentionally survives individual tab/session cleanup, so that unowned target could surface as the reported blank foreground window on Windows and remain for the shared browser's lifetime.

## Fix
- Add Chromium's `--no-startup-window` switch to broker-owned browser launches so only session-owned pages are created.
- Cover the resolved shared Chromium argv with a regression test.
- Document the Windows fix in the coding-agent changelog.

## Verification
`bun run gen:tool-views && bun test test/tools/browser-launch.test.ts test/tools/browser-lifecycle-leak.test.ts` passes 16 tests. The `gh_push_branch` pre-publish gate completed `bun run fix` and `bun check`; native Windows focus behavior was structurally reproduced because this worker runs Linux. Fixes #8615