### PR TITLE
feat(hashline): response-side renumber deltas + replaced-range boundary echoes (#8603)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Hashline edit responses now surface per-hunk `Renumber:` line-shift deltas and first/last-line boundary echoes for every `PUT N.=M` replacement, so models can re-anchor subsequent edits without re-reading the file (#8603).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -12,14 +12,18 @@
  */
 import {
 	type BlockResolution,
+	buildCompactDiffPreview,
 	type Clipboard,
 	commitClipboard,
 	forkClipboard,
+	formatReplaceHeader,
 	MismatchError as HashlineMismatchError,
 	Patch,
 	Patcher,
 	type PatchSectionResult,
 	type PreparedSection,
+	type RenumberDelta,
+	type ReplacementEcho,
 	startClipboardBatch,
 } from "@oh-my-pi/hashline";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
@@ -145,6 +149,85 @@ function formatBlockResolution(resolution: BlockResolution): string {
 	return `${op} → resolved ${span} (${lines} line${lines === 1 ? "" : "s"})${suffix}`;
 }
 
+/**
+ * Per-hunk renumber confirmation (issue #8603): every hunk whose line count
+ * changed shifts the original lines below it. Emitted against ORIGINAL
+ * numbering so the per-hunk deltas are independent and composable — an edit
+ * below every hunk uses the `net` line, an edit strictly between two hunks
+ * applies only the deltas of hunks above its anchor.
+ *
+ * The `net` line covers the whole file: emitted when more than one hunk
+ * shifted (a single hunk already says it all), and additionally whenever the
+ * net disagrees with the sum of the emitted per-hunk deltas — a hunk with no
+ * original anchor (a contextless pure-add run from an external diff producer)
+ * is dropped from `renumbers` but still counts toward `net`.
+ *
+ * Coordinate note: `fromLine` is diff-aligned, not hunk-header-aligned. When a
+ * replaced range's trailing line is kept as diff context (its new content is
+ * identical), the renumber line anchors below that line while the boundary
+ * echo still names the full authored range. Both statements are true in their
+ * own coordinates; the shifted content is identical either way.
+ */
+function formatRenumberLines(renumbers: readonly RenumberDelta[], netDelta: number): string[] {
+	const lines = renumbers.map(
+		renumber => `Renumber: lines >${renumber.fromLine} shifted ${formatSigned(renumber.delta)}`,
+	);
+	const emittedSum = renumbers.reduce((sum, renumber) => sum + renumber.delta, 0);
+	if (netDelta !== 0 && (renumbers.length > 1 || netDelta !== emittedSum)) {
+		lines.push(`Renumber: net ${formatSigned(netDelta)}`);
+	}
+	return lines;
+}
+
+function formatSigned(delta: number): string {
+	return `${delta >= 0 ? "+" : "-"}${Math.abs(delta)}`;
+}
+
+/** Truncation cap for each side of a boundary echo (~40 chars + ellipsis). */
+const ECHO_MAX_CHARS = 40;
+
+function formatEchoSide(text: string): string {
+	// Truncate on code points BEFORE escaping: slicing the escaped string
+	// could split an escape pair (dangling backslash) or a surrogate pair.
+	// The truncation never materializes the line: whether the cap is
+	// exceeded and where the keep-boundary sits both resolve within the
+	// first cap+1 code points, so the scan touches ~cap+2 UTF-16 units
+	// however long the boundary line is.
+	let truncated = text;
+	if (text.length > ECHO_MAX_CHARS) {
+		let units = 0;
+		let codePoints = 0;
+		let boundary = 0;
+		while (units < text.length && codePoints <= ECHO_MAX_CHARS) {
+			if (codePoints === ECHO_MAX_CHARS - 1) boundary = units;
+			const unit = text.charCodeAt(units);
+			// A high surrogate counts as one code point together with its low
+			// half; a lone surrogate (high not followed by low, or any low)
+			// counts alone — exactly Array.from's code-point iteration, so
+			// the bounded scan matches the naive implementation on every
+			// input, ill-formed strings included.
+			const paired = unit >= 0xd800 && unit <= 0xdbff && units + 1 < text.length ? text.charCodeAt(units + 1) : NaN;
+			units += paired >= 0xdc00 && paired <= 0xdfff ? 2 : 1;
+			codePoints++;
+		}
+		if (codePoints > ECHO_MAX_CHARS) truncated = `${text.slice(0, boundary)}…`;
+	}
+	const escaped = truncated.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	return `"${escaped}"`;
+}
+
+/**
+ * Boundary echo for one concrete `PUT N.=M` replacement: the first and last
+ * ORIGINAL line the range covered, so the model can cross-check the scope
+ * before the compiler does. Single-line ranges echo once (first === last).
+ */
+function formatReplacementEcho(echo: ReplacementEcho): string {
+	const header = formatReplaceHeader(echo.start, echo.end);
+	return echo.start === echo.end
+		? `${header} replaced ${formatEchoSide(echo.first)}`
+		: `${header} replaced ${formatEchoSide(echo.first)}…${formatEchoSide(echo.last)}`;
+}
+
 function renderSection(
 	result: PatchSectionResult,
 	diagnostics: FileDiagnosticsResult | undefined,
@@ -178,7 +261,21 @@ function renderSection(
 	}
 
 	const diff = generateDiffString(result.before, result.after, undefined, { path: result.path });
+	const preview = buildCompactDiffPreview(diff.diff);
 	const firstChangedLine = result.firstChangedLine ?? diff.firstChangedLine;
+	const blockBlock =
+		result.blockResolutions && result.blockResolutions.length > 0
+			? `\n${result.blockResolutions.map(formatBlockResolution).join("\n")}`
+			: "";
+	const echoBlock =
+		result.replacementEchoes && result.replacementEchoes.length > 0
+			? `\n${result.replacementEchoes.map(formatReplacementEcho).join("\n")}`
+			: "";
+	const renumberLines = formatRenumberLines(preview.renumbers, preview.addedLines - preview.removedLines);
+	const renumberBlock = renumberLines.length > 0 ? `\n${renumberLines.join("\n")}` : "";
+	const previewBlock = preview.preview ? `\n${preview.preview}` : "";
+	const moveBlock = result.moveDest ? `\nMoved to ${result.moveDest}` : "";
+	const warningsBlock = result.warnings.length > 0 ? `\n\nWarnings:\n${result.warnings.join("\n")}` : "";
 	const editResult = createEditResult({
 		displayPath: result.moveDest ?? result.path,
 		resultPath: result.moveDest ?? result.path,
@@ -193,6 +290,7 @@ function renderSection(
 		newText: result.after,
 		beforePreview: result.blockResolutions?.map(formatBlockResolution),
 		warnings: result.warnings,
+		text: `${result.header}${blockBlock}${moveBlock}${echoBlock}${previewBlock}${renumberBlock}${warningsBlock}`,
 	});
 	return {
 		toolResult: toEditToolResult(editResult),

--- a/packages/coding-agent/test/edit/edit-response-confirmations.test.ts
+++ b/packages/coding-agent/test/edit/edit-response-confirmations.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { type ExecuteHashlineSingleOptions, executeHashlineSingle } from "@oh-my-pi/pi-coding-agent/edit";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+function createSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => path.join(cwd, "session.jsonl"),
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		allocateOutputArtifact: async () => ({ id: "artifact-1", path: path.join(cwd, "artifact-1.log") }),
+		settings: Settings.isolated(),
+		enableLsp: false,
+	} as ToolSession;
+}
+
+function execOptions(input: string, session: ToolSession): ExecuteHashlineSingleOptions {
+	return {
+		session,
+		input,
+		writethrough: async (targetPath, content) => {
+			await Bun.write(targetPath, content);
+			return undefined;
+		},
+		beginDeferredDiagnosticsForPath: () => ({
+			onDeferredDiagnostics: () => {},
+			signal: new AbortController().signal,
+			finalize: () => {},
+		}),
+	};
+}
+
+function resultText(result: { content: { type: string; text?: string }[] }): string {
+	return result.content
+		.filter((b): b is { type: "text"; text: string } => b.type === "text" && typeof b.text === "string")
+		.map(b => b.text)
+		.join("\n");
+}
+
+const HEADER = /^\[([^#\r\n]+)#([0-9A-F]{4})\]$/m;
+
+function tagFromOutput(text: string): string {
+	const match = HEADER.exec(text);
+	if (!match) throw new Error(`no hashline header in read output:\n${text}`);
+	return match[2];
+}
+
+const LINES = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`);
+const CONTENT = `${LINES.join("\n")}\n`;
+
+async function editResponse(input: string, content: string = CONTENT): Promise<string> {
+	const file = path.join(tmpDir, "notes.txt");
+	await Bun.write(file, content);
+	const session = createSession(tmpDir);
+	const read = await new ReadTool(session).execute("r1", { path: file });
+	const tag = tagFromOutput(resultText(read));
+	const result = await executeHashlineSingle(execOptions(`[notes.txt#${tag}]\n${input}`, session));
+	return resultText(result);
+}
+
+let tmpDir: string;
+
+describe("edit response confirmations (issue #8603)", () => {
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+	});
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "edit-response-confirmations-"));
+	});
+	afterEach(async () => {
+		await removeWithRetries(tmpDir);
+	});
+
+	describe("renumber deltas", () => {
+		it("reports a positive shift for a hunk that grows the file", async () => {
+			const text = await editResponse("PUT 3-3:\n+A\n+B");
+			expect(text).toContain("Renumber: lines >3 shifted +1");
+			// A single hunk already says it all — no net line.
+			expect(text).not.toContain("Renumber: net");
+		});
+
+		it("reports a negative shift for a hunk that shrinks the file", async () => {
+			const text = await editResponse("PUT 4-6:\n+X");
+			expect(text).toContain("Renumber: lines >6 shifted -2");
+		});
+
+		it("emits no renumber line for a zero-delta replacement", async () => {
+			const text = await editResponse("PUT 5-5:\n+X");
+			expect(text).not.toContain("Renumber:");
+		});
+
+		it("composes two hunks against original numbering and sums the net", async () => {
+			const text = await editResponse("PUT 2-2:\n+A\n+B\nPUT 9-9:\n+Z\n+Y");
+			// Both anchors are ORIGINAL line numbers; the net line frees the
+			// model from summing them for a below-all-hunks edit.
+			expect(text).toContain("Renumber: lines >2 shifted +1");
+			expect(text).toContain("Renumber: lines >9 shifted +1");
+			expect(text).toContain("Renumber: net +2");
+		});
+
+		it("omits the net line when interacting deltas cancel out", async () => {
+			const text = await editResponse("PUT 2-2:\n+A\n+B\nPUT 9-10:\n+Z");
+			expect(text).toContain("Renumber: lines >2 shifted +1");
+			expect(text).toContain("Renumber: lines >10 shifted -1");
+			expect(text).not.toContain("Renumber: net");
+		});
+	});
+
+	describe("replaced-range boundary echoes", () => {
+		it("echoes the first and last original line of a multi-line range", async () => {
+			const text = await editResponse("PUT 3-5:\n+A\n+B\n+C");
+			expect(text).toContain('PUT 3.=5: replaced "line 3"…"line 5"');
+		});
+
+		it("echoes a single-line range once", async () => {
+			const text = await editResponse("PUT 4-4:\n+A");
+			// Exact-line assertion: the two-side form would render
+			// `PUT 4.=4: replaced "line 4"…"line 4"` and fail.
+			expect(text.split("\n")).toContain('PUT 4.=4: replaced "line 4"');
+		});
+
+		it("truncates each echoed side to ~40 chars with an ellipsis", async () => {
+			const long = `${"x".repeat(80)}-first`;
+			const longLast = `${"y".repeat(80)}-last`;
+			const content = ["short", long, "mid", longLast, "tail"].join("\n") + "\n";
+			const text = await editResponse("PUT 2-4:\n+A\n+B\n+C", content);
+			expect(text).toContain(`PUT 2.=4: replaced "${"x".repeat(39)}…"`);
+			expect(text).toContain(`"${"y".repeat(39)}…"`);
+			expect(text).not.toContain("x".repeat(40));
+		});
+
+		it("escapes quotes inside echoed content", async () => {
+			const content = ['say "hi"', "plain", 'end "quote"'].join("\n") + "\n";
+			const text = await editResponse("PUT 1-3:\n+A\n+B\n+C", content);
+			expect(text).toContain('PUT 1.=3: replaced "say \\"hi\\""…"end \\"quote\\""');
+		});
+
+		it("does not split an escape pair or surrogate pair at the truncation boundary", async () => {
+			// 38 a's + a quote: the 40-unit cut lands on the quote, which must
+			// arrive escaped (not as a dangling backslash before the ellipsis).
+			const content =
+				[`${"a".repeat(38)}"${"b".repeat(25)}`, "mid", `${"x".repeat(36)}${"😀".repeat(5)}`].join("\n") + "\n";
+			const text = await editResponse("PUT 1-3:\n+A\n+B\n+C", content);
+			expect(text).toContain(`PUT 1.=3: replaced "${"a".repeat(38)}\\"…"`);
+			// 36 x's + emoji: the cut must fall between emoji, never inside one.
+			expect(text).toContain(`"${"x".repeat(36)}😀😀😀…"`);
+		});
+	});
+
+	describe("op-kind coverage", () => {
+		it("emits a renumber delta but no boundary echo for a CUT-only edit", async () => {
+			const text = await editResponse("CUT 5-6");
+			expect(text).toContain("Renumber: lines >6 shifted -2");
+			expect(text).not.toContain("replaced");
+		});
+
+		it("emits neither for a pure insertion with no line-count context below", async () => {
+			// Pure insert grows the file, so a renumber line appears; no range
+			// was replaced, so no echo does.
+			const text = await editResponse("PUT >2:\n+inserted");
+			expect(text).toContain("Renumber: lines >2 shifted +1");
+			expect(text).not.toContain("replaced");
+		});
+
+		it("skips the boundary echo for block ops (resolution echo covers them)", async () => {
+			const ts = ["function f() {", "  return 1;", "}", "let done = true;"].join("\n") + "\n";
+			const file = path.join(tmpDir, "block.ts");
+			await Bun.write(file, ts);
+			const session = createSession(tmpDir);
+			const read = await new ReadTool(session).execute("r1", { path: file });
+			const tag = tagFromOutput(resultText(read));
+			const result = await executeHashlineSingle(
+				execOptions(`[block.ts#${tag}]\nPUT 1*:\n+function g() {\n+  return 2;\n+}`, session),
+			);
+			const text = resultText(result);
+			expect(text).toMatch(/PUT 1\*: → resolved/);
+			expect(text).not.toContain("replaced");
+			// Three lines replaced by three: zero net shift, no renumber line.
+			expect(text).not.toContain("Renumber:");
+			expect(await Bun.file(file).text()).toBe("function g() {\n  return 2;\n}\nlet done = true;\n");
+		});
+	});
+});

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `buildCompactDiffPreview` now reports per-hunk `renumbers` (original-line anchors + deltas) alongside the existing preview text (#8603).
+- Patcher results carry `replacementEchoes` (first/last original line of each `PUT N.=M` range) for response-side boundary confirmation (#8603).
+
 ## [18.0.4] - 2026-08-24
 
 ### Changed

--- a/packages/hashline/src/diff-preview.ts
+++ b/packages/hashline/src/diff-preview.ts
@@ -10,7 +10,7 @@
  * This is intentionally decoupled from the diff producer: anything that
  * emits the `<sign><lineNum>|<content>` shape works.
  */
-import type { CompactDiffOptions, CompactDiffPreview } from "./types";
+import type { CompactDiffOptions, CompactDiffPreview, RenumberDelta } from "./types";
 
 const DEFAULT_ADDED_RUN_CONTEXT_LINES = 2;
 
@@ -86,6 +86,38 @@ export function buildCompactDiffPreview(diff: string, options: CompactDiffOption
 		addedRun.length = 0;
 	};
 
+	// Per-hunk renumber tracking (issue #8603): a "hunk" is a maximal
+	// contiguous run of `+`/`-` rows; context rows separate hunks. Each hunk
+	// reports one delta keyed to ORIGINAL numbering so the entries are
+	// independent and composable (see RenumberDelta): a consumer below every
+	// hunk sums them, a consumer between two hunks applies only the deltas
+	// above its anchor.
+	//
+	// Anchor resolution for a hunk's `fromLine` (the last original line after
+	// which nothing in that hunk sits): the last `-` row's pre-edit number
+	// when the hunk removes anything; otherwise (pure insertion) the
+	// pre-edit number of the context row immediately BEFORE the run, or the
+	// row immediately AFTER minus 1, whichever the diff exposes. A pure-add
+	// run with neither (diff produced no context at all) has no original
+	// anchor and is skipped — its shift still counts toward `addedLines -
+	// removedLines`, and the renderer's `net` line fires whenever that total
+	// disagrees with the sum of the emitted per-hunk deltas.
+	const renumbers: RenumberDelta[] = [];
+	let runAdded = 0;
+	let runRemoved = 0;
+	let runLastRemovedLine: number | undefined;
+	let contextBeforeRun: number | undefined;
+	const flushRenumberRun = (contextAfterRun: number | undefined): void => {
+		if (runAdded === 0 && runRemoved === 0) return;
+		const delta = runAdded - runRemoved;
+		const fromLine =
+			runLastRemovedLine ?? contextBeforeRun ?? (contextAfterRun !== undefined ? contextAfterRun - 1 : undefined);
+		if (delta !== 0 && fromLine !== undefined) renumbers.push({ fromLine, delta });
+		runAdded = 0;
+		runRemoved = 0;
+		runLastRemovedLine = undefined;
+	};
+
 	// External diff producers number `+` lines with the post-edit line number,
 	// `-` lines with the pre-edit line number, and context lines with the
 	// pre-edit line number. To emit fresh line numbers usable for follow-up
@@ -95,6 +127,11 @@ export function buildCompactDiffPreview(diff: string, options: CompactDiffOption
 		const parsed = parseNumberedDiffLine(line);
 		if (!parsed) {
 			flushAddedRun();
+			// Unparsed rows (elision markers, gap rows) break contiguity and
+			// carry no original line number, so they also break hunk runs
+			// without contributing an anchor.
+			flushRenumberRun(undefined);
+			contextBeforeRun = undefined;
 			appendPreviewLine(formatted, line);
 			continue;
 		}
@@ -102,15 +139,20 @@ export function buildCompactDiffPreview(diff: string, options: CompactDiffOption
 		switch (parsed.kind) {
 			case "+": {
 				addedLines++;
+				runAdded++;
 				addedRun.push(`${parsed.lineNumber}:${parsed.content}`);
 				break;
 			}
 			case "-":
 				flushAddedRun();
 				removedLines++;
+				runRemoved++;
+				runLastRemovedLine = parsed.lineNumber;
 				break;
 			default: {
 				flushAddedRun();
+				flushRenumberRun(parsed.lineNumber);
+				contextBeforeRun = parsed.lineNumber;
 				const newLineNumber = parsed.lineNumber + addedLines - removedLines;
 				appendPreviewLine(formatted, `${newLineNumber}:${parsed.content}`);
 				break;
@@ -118,7 +160,8 @@ export function buildCompactDiffPreview(diff: string, options: CompactDiffOption
 		}
 	}
 	flushAddedRun();
+	flushRenumberRun(undefined);
 	while (formatted.length > 0 && isPreviewSeparator(formatted[formatted.length - 1])) formatted.pop();
 
-	return { preview: formatted.join("\n"), addedLines, removedLines };
+	return { preview: formatted.join("\n"), addedLines, removedLines, renumbers };
 }

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -15,7 +15,7 @@ import { HL_FILE_HASH_EXAMPLES, HL_FILE_HASH_LENGTH, HL_FILE_HASH_SEP, HL_FILE_P
 import { CLIPBOARD_INTERLEAVED_SECTIONS } from "./messages";
 import { parsePatch, parsePatchStreaming } from "./parser";
 import { Tokenizer } from "./tokenizer";
-import type { ApplyResult, BlockResolver, Clipboard, Edit, FileOp, SplitOptions } from "./types";
+import type { ApplyResult, BlockResolver, Clipboard, Edit, FileOp, ParsedRange, SplitOptions } from "./types";
 
 // Pure classification — single shared tokenizer is safe.
 const TOKENIZER = new Tokenizer();
@@ -247,7 +247,7 @@ export class PatchSection {
 	readonly path: string;
 	readonly fileHash: string | undefined;
 	readonly diff: string;
-	#parsed: { edits: Edit[]; fileOp?: FileOp; warnings: string[] } | undefined;
+	#parsed: { edits: Edit[]; fileOp?: FileOp; warnings: string[]; replacements: ParsedRange[] } | undefined;
 
 	#interleavedMerge: boolean;
 
@@ -263,7 +263,12 @@ export class PatchSection {
 	 * same `{ edits, fileOp?, warnings }` object so callers can safely call this from
 	 * multiple paths (preflight, apply, diff-preview).
 	 */
-	parse(): { edits: Edit[]; fileOp?: FileOp; warnings: readonly string[] } {
+	parse(): {
+		edits: Edit[];
+		fileOp?: FileOp;
+		warnings: readonly string[];
+		replacements: readonly ParsedRange[];
+	} {
 		this.#parsed ??= parsePatch(this.diff);
 		const parsed = this.#parsed;
 		// Same-path sections merge into their first occurrence; when that merge
@@ -280,7 +285,12 @@ export class PatchSection {
 					: parsed.fileOp;
 		return fileOp === parsed.fileOp
 			? parsed
-			: { edits: parsed.edits, ...(fileOp === undefined ? {} : { fileOp }), warnings: parsed.warnings };
+			: {
+					edits: parsed.edits,
+					...(fileOp === undefined ? {} : { fileOp }),
+					warnings: parsed.warnings,
+					replacements: parsed.replacements,
+				};
 	}
 
 	/** Parsed edits for this section. */
@@ -291,6 +301,11 @@ export class PatchSection {
 	/** Optional whole-file operation (`REM` / `MV`). */
 	get fileOp(): FileOp | undefined {
 		return this.parse().fileOp;
+	}
+
+	/** Concrete replacement ranges (`PUT N.=M`-shaped hunks) in authored order. */
+	get replacements(): readonly ParsedRange[] {
+		return this.parse().replacements;
 	}
 
 	/** Warnings emitted during parsing of this section. */

--- a/packages/hashline/src/parser.ts
+++ b/packages/hashline/src/parser.ts
@@ -211,9 +211,18 @@ export class Executor {
 	#pending: Pending | undefined;
 	#fileOp: FileOp | undefined;
 	#terminated = false;
-	#skippableComments: PendingComment[] = [];
 	/** Source lines already recovered from top-level `N:TEXT` rows in this section. */
 	#recoveredSnapshotLines = new Set<number>();
+	#skippableComments: PendingComment[] = [];
+	/**
+	 * Concrete replacement ranges (`PUT N.=M:` bodies and `PUT N.=M @reg`
+	 * span pastes) in hunk order, keyed by hunk header line so
+	 * `#normalizeOverlappingRanges` can drop coalesced duplicates. Feeds the
+	 * response-side boundary echo (issue #8603); block ops, gap inserts, and
+	 * `CUT`s are excluded — they have no authored concrete range (or none
+	 * worth echoing).
+	 */
+	#replacements: { lineNum: number; range: ParsedRange }[] = [];
 
 	#discardPendingSkippableComments(): void {
 		this.#skippableComments = [];
@@ -300,7 +309,7 @@ export class Executor {
 		}
 	}
 
-	end(): { edits: Edit[]; fileOp?: FileOp; warnings: string[] } {
+	end(): { edits: Edit[]; fileOp?: FileOp; warnings: string[]; replacements: ParsedRange[] } {
 		this.#consumePendingSkippableComments();
 		this.#flushPending();
 		this.#validateFileOp();
@@ -309,10 +318,11 @@ export class Executor {
 			edits: this.#edits,
 			...(this.#fileOp === undefined ? {} : { fileOp: this.#fileOp }),
 			warnings: this.#warnings,
+			replacements: this.#replacements.map(replacement => replacement.range),
 		};
 	}
 
-	endStreaming(): { edits: Edit[]; fileOp?: FileOp; warnings: string[] } {
+	endStreaming(): { edits: Edit[]; fileOp?: FileOp; warnings: string[]; replacements: ParsedRange[] } {
 		this.#consumePendingSkippableComments();
 		const pending = this.#pending;
 		if (pending && (pending.payloads.length > 0 || this.#isCompleteBodylessOp(pending))) this.#flushPending();
@@ -323,6 +333,7 @@ export class Executor {
 			edits: this.#edits,
 			...(this.#fileOp === undefined ? {} : { fileOp: this.#fileOp }),
 			warnings: this.#warnings,
+			replacements: this.#replacements.map(replacement => replacement.range),
 		};
 	}
 
@@ -354,6 +365,7 @@ export class Executor {
 		this.#pending = undefined;
 		this.#fileOp = undefined;
 		this.#skippableComments = [];
+		this.#replacements = [];
 		this.#terminated = false;
 	}
 
@@ -447,7 +459,10 @@ export class Executor {
 					"Issue ONE hunk per range; payload is only the final desired content, never a before/after pair.",
 			);
 		}
-		if (dropped.size > 0) this.#edits = this.#edits.filter(edit => !dropped.has(edit.lineNum));
+		if (dropped.size > 0) {
+			this.#edits = this.#edits.filter(edit => !dropped.has(edit.lineNum));
+			this.#replacements = this.#replacements.filter(replacement => !dropped.has(replacement.lineNum));
+		}
 	}
 
 	#handleLiteralPayload(text: string, lineNum: number): void {
@@ -538,6 +553,7 @@ export class Executor {
 				"replacement",
 			);
 			this.#pushDeleteRange(range, lineNum);
+			this.#replacements.push({ lineNum, range });
 			if (!this.#warnings.includes(SNAPSHOT_ROWS_AUTO_PUT_WARNING)) {
 				this.#warnings.push(SNAPSHOT_ROWS_AUTO_PUT_WARNING);
 			}
@@ -728,6 +744,7 @@ export class Executor {
 					target.register,
 					lineNum,
 				);
+				this.#replacements.push({ lineNum, range: target.range });
 				return;
 			}
 			if (payloads.length === 0) {
@@ -741,6 +758,7 @@ export class Executor {
 			const cursor: Cursor = { kind: "before_anchor", anchor: { ...target.range.start } };
 			this.#emitPayloadRows(cursor, payloads, lineNum, "replacement");
 			this.#pushDeleteRange(target.range, lineNum);
+			this.#replacements.push({ lineNum, range: target.range });
 			return;
 		}
 		if (target.kind === "block") {
@@ -787,19 +805,32 @@ export class Executor {
 	}
 }
 
-function drain(executor: Executor, tokenizer: Tokenizer): { edits: Edit[]; fileOp?: FileOp; warnings: string[] } {
+function drain(
+	executor: Executor,
+	tokenizer: Tokenizer,
+): { edits: Edit[]; fileOp?: FileOp; warnings: string[]; replacements: ParsedRange[] } {
 	for (const token of tokenizer.end()) executor.feed(token);
 	return executor.end();
 }
 
-export function parsePatch(diff: string): { edits: Edit[]; fileOp?: FileOp; warnings: string[] } {
+export function parsePatch(diff: string): {
+	edits: Edit[];
+	fileOp?: FileOp;
+	warnings: string[];
+	replacements: ParsedRange[];
+} {
 	const tokenizer = new Tokenizer();
 	const executor = new Executor();
 	for (const token of tokenizer.feed(diff)) executor.feed(token);
 	return drain(executor, tokenizer);
 }
 
-export function parsePatchStreaming(diff: string): { edits: Edit[]; fileOp?: FileOp; warnings: string[] } {
+export function parsePatchStreaming(diff: string): {
+	edits: Edit[];
+	fileOp?: FileOp;
+	warnings: string[];
+	replacements: ParsedRange[];
+} {
 	const tokenizer = new Tokenizer();
 	const executor = new Executor();
 	for (const token of tokenizer.feed(diff)) executor.feed(token);

--- a/packages/hashline/src/patcher.ts
+++ b/packages/hashline/src/patcher.ts
@@ -43,7 +43,17 @@ import { detectLineEnding, type LineEnding, normalizeToLF, restoreLineEndings, s
 import { InvalidAbsoluteRangeError } from "./parser";
 import { Recovery, type RecoveryResult } from "./recovery";
 import type { Snapshot, SnapshotStore } from "./snapshots";
-import type { ApplyResult, BlockResolution, BlockResolver, BlockSpan, Clipboard, Edit, FileOp } from "./types";
+import type {
+	ApplyResult,
+	BlockResolution,
+	BlockResolver,
+	BlockSpan,
+	Clipboard,
+	Edit,
+	FileOp,
+	ParsedRange,
+	ReplacementEcho,
+} from "./types";
 
 /**
  * Upper bound on the number of unseen anchor lines whose actual file content
@@ -127,6 +137,13 @@ export interface PatchSectionResult {
 	 * content. Undefined for patches with no block ops and for drift recovery.
 	 */
 	blockResolutions?: BlockResolution[];
+	/**
+	 * Boundary echoes (original first/last line) for each concrete
+	 * `PUT N.=M` replacement, in patch order. Present only when the apply
+	 * matched the tagged content; undefined for drift recovery and for
+	 * patches with no concrete replacements.
+	 */
+	replacementEchoes?: ReplacementEcho[];
 }
 
 export interface PatcherApplyResult {
@@ -181,6 +198,22 @@ function recoveryToApplyResult(result: RecoveryResult): ApplyResult {
 		firstChangedLine: result.firstChangedLine,
 		warnings: result.warnings,
 	};
+}
+
+/**
+ * Materialize {@link ReplacementEcho} entries for a section's concrete
+ * replacement ranges against the text the edits were validated to apply on.
+ * Out-of-range boundary lines (a phantom trailing line, say) echo as empty
+ * strings rather than throwing — the echo is advisory.
+ */
+function buildReplacementEchoes(replacements: readonly ParsedRange[], text: string): ReplacementEcho[] {
+	const lines = text.split("\n");
+	return replacements.map(({ start, end }) => ({
+		start: start.line,
+		end: end.line,
+		first: lines[start.line - 1] ?? "",
+		last: lines[end.line - 1] ?? "",
+	}));
 }
 function mergeWarnings(...sources: ReadonlyArray<readonly string[] | undefined>): string[] {
 	const out: string[] = [];
@@ -403,6 +436,7 @@ export class Patcher {
 						exists: read.exists,
 						normalized,
 						edits: [],
+						replacements: [],
 						clipboard: register,
 					})
 				: this.#applyWithRecovery({
@@ -411,6 +445,7 @@ export class Patcher {
 						exists: read.exists,
 						normalized,
 						edits: parsed.edits,
+						replacements: parsed.replacements,
 						clipboard: register,
 					});
 
@@ -526,6 +561,7 @@ export class Patcher {
 				header: formatHashlineHeader(moveDest, fileHash),
 				firstChangedLine: applyResult.firstChangedLine,
 				blockResolutions: applyResult.blockResolutions,
+				replacementEchoes: applyResult.replacementEchoes,
 				moveDest,
 				warnings,
 			};
@@ -570,6 +606,7 @@ export class Patcher {
 			header: formatHashlineHeader(section.path, fileHash),
 			firstChangedLine: applyResult.firstChangedLine,
 			blockResolutions: applyResult.blockResolutions,
+			replacementEchoes: applyResult.replacementEchoes,
 			warnings: allWarnings,
 		};
 	}
@@ -676,9 +713,11 @@ export class Patcher {
 		exists: boolean;
 		normalized: string;
 		edits: readonly Edit[];
+		/** Concrete replacement ranges from the section parse, for boundary echoes. */
+		replacements: readonly ParsedRange[];
 		clipboard: Clipboard;
 	}): ApplyResult {
-		const { section, canonicalPath, exists, normalized, edits, clipboard } = args;
+		const { section, canonicalPath, exists, normalized, edits, replacements, clipboard } = args;
 		const expected = exists ? section.fileHash : undefined;
 		// The 4-hex tag is content-derived: when the live text hashes to it,
 		// trust the match and apply directly. `storedSnapshotForTag` feeds the
@@ -733,7 +772,14 @@ export class Patcher {
 				this.#assertSeenLines(section, expected, matchedSnapshot);
 			}
 			const result = applyEdits(normalized, resolved, { clipboard, path: canonicalPath });
-			return withResolveWarnings(blockResolutions.length > 0 ? { ...result, blockResolutions } : result);
+			// Concrete replacement ranges echo the original boundary lines so
+			// the model can catch a mis-scoped range; keyed to the matched
+			// content, so (like block resolutions) they are dropped on drift.
+			const withEchoes =
+				replacements.length > 0
+					? { ...result, replacementEchoes: buildReplacementEchoes(replacements, normalized) }
+					: result;
+			return withResolveWarnings(blockResolutions.length > 0 ? { ...withEchoes, blockResolutions } : withEchoes);
 		}
 		// Head/tail-only inserts are position-stable: "start"/"end" cannot move
 		// with content drift, so a stale tag is non-fatal. Apply onto the live

--- a/packages/hashline/src/types.ts
+++ b/packages/hashline/src/types.ts
@@ -114,6 +114,13 @@ export interface ApplyResult {
 	 * what the caller read. Absent when there were no block ops.
 	 */
 	blockResolutions?: BlockResolution[];
+	/**
+	 * Boundary echoes for each concrete replacement range in this apply, in
+	 * patch order. Present only when the apply matched the tagged content,
+	 * so the echoed lines match what the caller read. Absent when there were
+	 * no concrete replacements.
+	 */
+	replacementEchoes?: ReplacementEcho[];
 }
 
 /** A parsed `A-B` inclusive line range. */
@@ -144,11 +151,33 @@ export interface StreamOptions {
 	maxChunkBytes?: number;
 }
 
+/**
+ * One hunk's line-count shift, keyed to ORIGINAL (pre-edit) numbering: every
+ * original line beyond `fromLine` now sits `delta` lines away from where it
+ * was. Surfaced on {@link CompactDiffPreview} so the edit response can back
+ * the "take next numbers from the edit response" promise for lines below the
+ * edited window.
+ *
+ * Composition rule: hunks are reported top-down and each `fromLine`/`delta`
+ * pair is expressed against the ORIGINAL file, so the deltas are independent
+ * — a consumer editing below every hunk applies the SUM of the deltas, while
+ * a consumer editing between two hunks applies only the deltas of hunks
+ * strictly above its anchor. Only non-zero deltas are reported.
+ */
+export interface RenumberDelta {
+	/** Last original (pre-edit) line the hunk touched or preceded: original lines `> fromLine` shifted. */
+	fromLine: number;
+	/** `added - removed` within the hunk; never `0`. */
+	delta: number;
+}
+
 /** Result of {@link buildCompactDiffPreview}. */
 export interface CompactDiffPreview {
 	preview: string;
 	addedLines: number;
 	removedLines: number;
+	/** Per-hunk line-shift info in patch order; empty when no hunk changed the line count. */
+	renumbers: RenumberDelta[];
 }
 
 /** Optional knobs for {@link buildCompactDiffPreview}. */
@@ -157,6 +186,25 @@ export interface CompactDiffOptions {
 	maxAddedRunContext?: number;
 	/** Back-compat alias for {@link maxAddedRunContext}. */
 	maxUnchangedRun?: number;
+}
+
+/**
+ * Boundary echo of one concrete replacement range (`PUT N.=M:` or
+ * `PUT N.=M @reg`): the first and last ORIGINAL line the range actually
+ * covered, so the model can catch a mis-scoped range before anything else
+ * does. Surfaced on {@link ApplyResult} alongside {@link BlockResolution};
+ * like block resolutions, dropped on drift-recovery paths where line numbers
+ * were remapped.
+ */
+export interface ReplacementEcho {
+	/** First line of the replaced range (1-indexed, inclusive, original numbering). */
+	start: number;
+	/** Last line of the replaced range (1-indexed, inclusive, original numbering). */
+	end: number;
+	/** Original content of line {@link start} (untruncated). */
+	first: string;
+	/** Original content of line {@link end} (untruncated). */
+	last: string;
 }
 
 /** Resolved 1-indexed inclusive line span of a block target. */

--- a/packages/hashline/test/diff-preview.test.ts
+++ b/packages/hashline/test/diff-preview.test.ts
@@ -9,6 +9,7 @@ describe("buildCompactDiffPreview", () => {
 			preview: ["1:alpha", "2:DELTA", "3:EPSILON", "4:gamma"].join("\n"),
 			addedLines: 2,
 			removedLines: 1,
+			renumbers: [{ fromLine: 2, delta: 1 }],
 		});
 	});
 
@@ -16,8 +17,8 @@ describe("buildCompactDiffPreview", () => {
 		const diff = [" 1|a1", " 2|a2", "-3|a3", "-4|a4", "+3|X", "+4|Y", "+5|Z", " 5|a5", " 6|a6", " 7|a7"].join("\n");
 
 		const preview = buildCompactDiffPreview(diff);
-
 		expect(preview.preview.split("\n")).toEqual(["1:a1", "2:a2", "3:X", "4:Y", "5:Z", "6:a5", "7:a6", "8:a7"]);
+		expect(preview.renumbers).toEqual([{ fromLine: 4, delta: 1 }]);
 	});
 	it("collapses long contiguous added runs to head, marker, and tail", () => {
 		const diff = Array.from({ length: 7 }, (_, index) => `+${10 + index}|line ${index + 1}`).join("\n");
@@ -45,5 +46,69 @@ describe("buildCompactDiffPreview", () => {
 		// one stranded at the end (after `-12` is dropped) are trimmed.
 		expect(preview.preview).toBe(["1:alpha", "", "8:gamma"].join("\n"));
 		expect(preview.removedLines).toBe(2);
+	});
+
+	describe("renumber deltas", () => {
+		it("reports a positive delta for a hunk that grows the file", () => {
+			const diff = [" 1|a", "-2|b", "+2|B", "+3|EXTRA", " 3|c"].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([{ fromLine: 2, delta: 1 }]);
+		});
+
+		it("reports a negative delta for a hunk that shrinks the file", () => {
+			const diff = [" 1|a", "-2|b", "-3|c", " 4|d"].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([{ fromLine: 3, delta: -2 }]);
+		});
+
+		it("omits hunks whose net line-count change is zero", () => {
+			const diff = [" 1|a", "-2|b", "-3|c", "+2|B", "+3|C", " 4|d"].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([]);
+		});
+
+		it("anchors a pure insertion after the preceding context line", () => {
+			const diff = [" 5|ctx", "+6|new", " 6|ctx2"].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([{ fromLine: 5, delta: 1 }]);
+		});
+
+		it("anchors a leading pure insertion before the following context line", () => {
+			const diff = ["+1|new", " 1|first"].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([{ fromLine: 0, delta: 1 }]);
+		});
+
+		it("keeps per-hunk deltas keyed to ORIGINAL numbering across interacting hunks", () => {
+			// Hunk A replaces original line 2 (+1); hunk B replaces original
+			// lines 8-9 with one line (-1). Both `fromLine`s index the ORIGINAL
+			// file, so the deltas compose independently: an edit below both
+			// hunks applies +1 + -1 = 0, an edit between them applies only +1.
+			const diff = [
+				" 1|a",
+				"-2|b",
+				"+2|B",
+				"+3|EXTRA",
+				" 3|c",
+				" 4|d",
+				" 5|e",
+				"-8|h",
+				"-9|i",
+				"+7|H",
+				" 10|j",
+			].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([
+				{ fromLine: 2, delta: 1 },
+				{ fromLine: 9, delta: -1 },
+			]);
+		});
+
+		it("breaks hunk runs at unparsed rows and skips unanchored pure adds", () => {
+			// No context row anywhere: the pure-add run has no original anchor.
+			const diff = ["+10|line 1", "+11|line 2"].join("\n");
+
+			expect(buildCompactDiffPreview(diff).renumbers).toEqual([]);
+		});
 	});
 });

--- a/packages/hashline/test/patcher.test.ts
+++ b/packages/hashline/test/patcher.test.ts
@@ -531,3 +531,64 @@ describe("Patcher tag-based path recovery", () => {
 		await expect(patcher.apply(Patch.parse(`[file.ts#ABCD]\nPUT 1-1:\n+X`))).rejects.toThrow(/write gate/);
 	});
 });
+
+describe("Patcher replacement boundary echoes", () => {
+	const CONTENT = ["l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9", "l10"].join("\n") + "\n";
+
+	async function applyPatch(input: string, blockResolver?: ConstructorParameters<typeof Patcher>[0]["blockResolver"]) {
+		const fs = new InMemoryFilesystem([[PATH, CONTENT]]);
+		const snapshots = new InMemorySnapshotStore();
+		const tag = snapshots.record(PATH, CONTENT);
+		const patcher = new Patcher({ fs, snapshots, ...(blockResolver ? { blockResolver } : {}) });
+		return { result: await patcher.apply(Patch.parse(input.replace("#TAG", `#${tag}`))), fs };
+	}
+
+	it("echoes the original first/last line of each concrete replacement range", async () => {
+		const { result } = await applyPatch(`[${PATH}#TAG]\nPUT 2-4:\n+X\n+Y\nPUT 7-8:\n+Z`);
+
+		expect(result.sections[0]?.replacementEchoes).toEqual([
+			{ start: 2, end: 4, first: "l2", last: "l4" },
+			{ start: 7, end: 8, first: "l7", last: "l8" },
+		]);
+	});
+
+	it("echoes a single-line replacement once with the same first/last content", async () => {
+		const { result } = await applyPatch(`[${PATH}#TAG]\nPUT 3-3:\n+L3`);
+
+		expect(result.sections[0]?.replacementEchoes).toEqual([{ start: 3, end: 3, first: "l3", last: "l3" }]);
+	});
+
+	it("emits no echo for a CUT-only edit", async () => {
+		const { result } = await applyPatch(`[${PATH}#TAG]\nCUT 5-6`);
+
+		expect(result.sections[0]?.replacementEchoes).toBeUndefined();
+	});
+
+	it("emits no echo for a pure insertion", async () => {
+		const { result } = await applyPatch(`[${PATH}#TAG]\nPUT >2:\n+inserted`);
+
+		expect(result.sections[0]?.replacementEchoes).toBeUndefined();
+	});
+
+	it("emits no echo for block ops (block resolutions cover them)", async () => {
+		const stub = () => ({ start: 2, end: 4 });
+		const { result } = await applyPatch(`[${PATH}#TAG]\nPUT 2*:\n+B1\n+B2`, stub);
+
+		expect(result.sections[0]?.replacementEchoes).toBeUndefined();
+		expect(result.sections[0]?.blockResolutions?.[0]).toMatchObject({ start: 2, end: 4 });
+	});
+	it("echoes a register span paste over a concrete range", async () => {
+		const { result } = await applyPatch(`[${PATH}#TAG]\nCUT 8-9 @reg\nPUT 2-3 @reg`);
+
+		// The span paste replaces lines 2-3 with the captured register content;
+		// the echo names what the target range covered.
+		expect(result.sections[0]?.replacementEchoes).toEqual([{ start: 2, end: 3, first: "l2", last: "l3" }]);
+	});
+
+	it("drops the echo of a coalesced duplicate range hunk", async () => {
+		const { result, fs } = await applyPatch(`[${PATH}#TAG]\nPUT 2-2:\n+first\nPUT 2-2:\n+second`);
+
+		expect(result.sections[0]?.replacementEchoes).toEqual([{ start: 2, end: 2, first: "l2", last: "l2" }]);
+		expect(fs.get(PATH)).toBe(["l1", "second", "l3", "l4", "l5", "l6", "l7", "l8", "l9", "l10"].join("\n") + "\n");
+	});
+});


### PR DESCRIPTION
Fixes #8603

## Summary
Two additive response-side confirmations for hashline edit responses:

- **Per-hunk renumber deltas**: `Renumber: lines >M shifted +K` keyed to ORIGINAL numbering (independent, composable); net line emitted only when >1 hunk shifts and net ≠ sum of already-emitted deltas.
- **PUT N.=M boundary echo**: `PUT N.=M: replaced "首行…末行"` — first/last ORIGINAL line of each concrete replaced range, each side truncated to 40 chars (code-point-safe). CUT/inserts/block ops emit no echo.

Changes are purely response-surface; guards unchanged (recovery.ts / mismatch.ts zero diff, `#applyWithRecovery` control flow additive-only, guard timing byte-identical).

## Review
6-angle fan-out review (3× reviewer, scout, security-reviewer, spec-compare) over `HEAD~1..HEAD`; no angle judged incorrect. Fixes applied:
- **P2** net-line loss when an unanchored hunk is dropped (its shift vanished from the response) — net line now emitted on disagreement rule.
- **P3** truncation splitting escapes/surrogate pairs in `formatEchoSide` — truncate by code points first, then escape.
- P3 docs: fromLine (diff-aligned) vs echo range (authored `N.=M`) coordinate divergence documented in `formatRenumberLines`.
- P3 test hardening: exact-line assertions for single-line echo, negative assertion for single-hunk net gate, escape/surrogate truncation regressions ×2.

## Verification
- `bun test packages/hashline/test/` — 316 pass / 0 fail
- `bun test packages/coding-agent/test/edit/` — 56 pass / 0 fail (+3 hardened/regression cases)
- `bun check` both packages pass

## Open design calls (left to maintainer)
- Streaming preview (hashline/diff.ts) does not carry confirmation lines — transient display vs final-response contract; adding renumber there widens surface beyond "additive response text".
- Guard-skip path echo bounded leakage (≤2×40 chars pre-edit content): skip condition pre-existing; echo same trust level as post-edit preview.