### PR TITLE
fix(tui): refresh token usage rows when toggled

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed toggling `display.showTokenUsage` from `/settings` leaving existing token-usage rows stale until the transcript was rebuilt.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -562,6 +562,12 @@ export class SelectorController {
 				this.ctx.rebuildChatFromMessages();
 				this.ctx.ui.resetDisplay();
 				break;
+			case "display.showTokenUsage":
+				// Rebuild reruns usage-row detection under the new setting; resetDisplay
+				// retires rows already committed to native scrollback.
+				this.ctx.rebuildChatFromMessages();
+				this.ctx.ui.resetDisplay();
+				break;
 			case "tui.tight":
 				setTuiTight(value as boolean);
 				this.ctx.ui.invalidate();

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -166,6 +166,25 @@ describe("selector setting side effects", () => {
 		});
 	}
 
+	for (const enabled of [false, true]) {
+		it(`rebuilds the transcript when display.showTokenUsage=${enabled} changes in /settings`, () => {
+			const rebuildChatFromMessages = vi.fn();
+			const resetDisplay = vi.fn();
+			const controller = new SelectorController({
+				rebuildChatFromMessages,
+				ui: { resetDisplay },
+			} as unknown as InteractiveModeContext);
+
+			controller.handleSettingChange("display.showTokenUsage", enabled);
+
+			expect(rebuildChatFromMessages).toHaveBeenCalledTimes(1);
+			expect(resetDisplay).toHaveBeenCalledTimes(1);
+			expect(rebuildChatFromMessages.mock.invocationCallOrder[0]).toBeLessThan(
+				resetDisplay.mock.invocationCallOrder[0],
+			);
+		});
+	}
+
 	it("clears stale default role thinking when auto is selected", async () => {
 		const testTheme = await getThemeByName("dark");
 		if (!testTheme) throw new Error("Failed to load dark theme for model selector test");


### PR DESCRIPTION
## What

Refresh the transcript immediately when `display.showTokenUsage` changes from `/settings`.

## Why

目前如果在 session 对话中途去 `/settings` 界面把 `display.showTokenUsage` 设置成 true，当前已经存在的对话历史不是立刻渲染 token usage 状态条。只有设置完成后新产生的消息才会显示 token usage 状态条。如果此时把 `display.showTokenUsage` 设置成 false，已经渲染出来的 token usage 状态条不会消失，只有新产生的消息才会不渲染状态条。

Translated for this PR: when `display.showTokenUsage` was changed in the middle of a session, existing transcript history kept its old token-usage-row state until another rebuild or restart. This change rebuilds the transcript and resets native scrollback so both toggle directions update immediately.

Related: #2527
Similar `SelectorController.handleSettingChange` toggle precedent: #6701

## Testing

- `bun test test/selector-settings-side-effects.test.ts --test-name-pattern "display.showTokenUsage"` — 2 pass / 0 fail.
- `bun test test/selector-settings-side-effects.test.ts --test-name-pattern "^(?!.*persists project and global defaults shadowed).*$"` — 28 pass / 0 fail.
- `bun run check` — Biome and `tsgo --noEmit` pass.
- `bun scripts/fix-changelogs.ts --check` — changelogs clean.
- Manual Windows TUI verification in `C:\tmp`: enabling the setting immediately displayed the existing historical usage row; disabling it immediately removed the row; enabling it again immediately restored the row without a restart or resize; the original setting value was restored to `false`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
