### PR TITLE
fix(coding-agent): keep suspended sessions alive for fg

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+Z jobs exiting successfully after `fg` instead of restarting the TUI because terminal teardown left Bun without a referenced event-loop handle while waiting for `SIGCONT` ([#8585](https://github.com/can1357/oh-my-pi/issues/8585)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).
 - Codex turns interrupted before terminal completion now auto-continue after resolved tool calls instead of stopping ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
 - `/handoff` no longer leaves the TUI in a running state when completion races with delayed session events ([#11263](https://github.com/can1357/oh-my-pi/issues/11263)).
+- Fixed Ctrl+Z jobs exiting successfully after `fg` instead of restarting the TUI because terminal teardown left Bun without a referenced event-loop handle while waiting for `SIGCONT` ([#8585](https://github.com/can1357/oh-my-pi/issues/8585)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1073,11 +1073,19 @@ export class InputController {
 			return;
 		}
 
+		// TUI teardown pauses stdin, which leaves Bun with no referenced handles
+		// while the editor waits on an unresolved Promise. Keep the event loop
+		// alive across SIGSTOP so it can deliver SIGCONT; without this handle Bun
+		// exits successfully immediately after `fg` instead of restarting the TUI
+		// (issue #8585).
+		const suspendKeepalive = setInterval(() => {}, 2 ** 30);
+
 		// Capture the listener so we can detach it if the signal never fires;
 		// otherwise a failed suspend would leave a stale SIGCONT handler that
 		// fires on the next unrelated continue and tries to re-`start()` an
 		// already-running TUI.
 		const onResume = (): void => {
+			clearInterval(suspendKeepalive);
 			this.ctx.ui.start();
 			this.ctx.ui.requestRender(true);
 		};
@@ -1120,6 +1128,7 @@ export class InputController {
 			// their own sessions, so pgid=0 does not reach them.
 			process.kill(0, "SIGSTOP");
 		} catch (err) {
+			clearInterval(suspendKeepalive);
 			// The runtime refused the signal (e.g. seccomp filter blocks SIGSTOP
 			// delivery to the process group). Tear the resume hook down and
 			// bring the TUI back so the user is not stranded on a frozen prompt.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1185,11 +1185,19 @@ export class InputController {
 			return;
 		}
 
+		// TUI teardown pauses stdin, which leaves Bun with no referenced handles
+		// while the editor waits on an unresolved Promise. Keep the event loop
+		// alive across SIGSTOP so it can deliver SIGCONT; without this handle Bun
+		// exits successfully immediately after `fg` instead of restarting the TUI
+		// (issue #8585).
+		const suspendKeepalive = setInterval(() => {}, 2 ** 30);
+
 		// Capture the listener so we can detach it if the signal never fires;
 		// otherwise a failed suspend would leave a stale SIGCONT handler that
 		// fires on the next unrelated continue and tries to re-`start()` an
 		// already-running TUI.
 		const onResume = (): void => {
+			clearInterval(suspendKeepalive);
 			this.ctx.ui.start();
 			this.ctx.ui.requestRender(true);
 		};
@@ -1232,6 +1240,7 @@ export class InputController {
 			// their own sessions, so pgid=0 does not reach them.
 			process.kill(0, "SIGSTOP");
 		} catch (err) {
+			clearInterval(suspendKeepalive);
 			// The runtime refused the signal (e.g. seccomp filter blocks SIGSTOP
 			// delivery to the process group). Tear the resume hook down and
 			// bring the TUI back so the user is not stranded on a frozen prompt.

--- a/packages/coding-agent/test/input-controller-suspend.test.ts
+++ b/packages/coding-agent/test/input-controller-suspend.test.ts
@@ -68,6 +68,8 @@ describe("InputController.handleCtrlZ", () => {
 		setPlatform("linux");
 		const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 		const onceSpy = vi.spyOn(process, "once");
+		const intervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 		const { ctx, ui, showError } = createCtx();
 
 		const controller = new InputController(ctx);
@@ -87,10 +89,15 @@ describe("InputController.handleCtrlZ", () => {
 		expect(ui.start).not.toHaveBeenCalled();
 		expect(showError).not.toHaveBeenCalled();
 
-		// Simulating the kernel-delivered SIGCONT drives the TUI back up.
+		// Simulating the kernel-delivered SIGCONT releases the referenced
+		// suspend handle before bringing the TUI back up.
+		expect(intervalSpy).toHaveBeenCalledTimes(1);
+		const suspendKeepalive = intervalSpy.mock.results[0]?.value;
+		expect(clearIntervalSpy).not.toHaveBeenCalled();
 		sigcontListener = onceSpy.mock.calls.find(([sig]) => sig === "SIGCONT")?.[1] as (() => void) | undefined;
 		expect(sigcontListener).toBeDefined();
 		sigcontListener?.();
+		expect(clearIntervalSpy).toHaveBeenCalledWith(suspendKeepalive);
 		expect(ui.start).toHaveBeenCalledTimes(1);
 		expect(ui.requestRender).toHaveBeenCalledWith(true);
 	});
@@ -102,6 +109,8 @@ describe("InputController.handleCtrlZ", () => {
 		});
 		const onceSpy = vi.spyOn(process, "once");
 		const removeSpy = vi.spyOn(process, "removeListener");
+		const intervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 		const { ctx, ui, showError, showStatus } = createCtx();
 
 		const controller = new InputController(ctx);
@@ -116,6 +125,8 @@ describe("InputController.handleCtrlZ", () => {
 		sigcontListener = onceSpy.mock.calls.find(([sig]) => sig === "SIGCONT")?.[1] as (() => void) | undefined;
 		expect(sigcontListener).toBeDefined();
 		expect(removeSpy).toHaveBeenCalledWith("SIGCONT", sigcontListener);
+		expect(intervalSpy).toHaveBeenCalledTimes(1);
+		expect(clearIntervalSpy).toHaveBeenCalledWith(intervalSpy.mock.results[0]?.value);
 
 		expect(killSpy).toHaveBeenCalledTimes(1);
 		expect(ui.stop).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/input-controller-suspend.test.ts
+++ b/packages/coding-agent/test/input-controller-suspend.test.ts
@@ -74,6 +74,8 @@ describe("InputController.handleCtrlZ", () => {
 		setPlatform("linux");
 		const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 		const onceSpy = spyOnProcessOnce();
+		const intervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 		const { ctx, ui, showError } = createCtx();
 
 		const controller = new InputController(ctx);
@@ -93,10 +95,15 @@ describe("InputController.handleCtrlZ", () => {
 		expect(ui.start).not.toHaveBeenCalled();
 		expect(showError).not.toHaveBeenCalled();
 
-		// Simulating the kernel-delivered SIGCONT drives the TUI back up.
+		// Simulating the kernel-delivered SIGCONT releases the referenced
+		// suspend handle before bringing the TUI back up.
+		expect(intervalSpy).toHaveBeenCalledTimes(1);
+		const suspendKeepalive = intervalSpy.mock.results[0]?.value;
+		expect(clearIntervalSpy).not.toHaveBeenCalled();
 		sigcontListener = onceSpy.mock.calls.find(([sig]) => sig === "SIGCONT")?.[1];
 		expect(sigcontListener).toBeDefined();
 		sigcontListener?.();
+		expect(clearIntervalSpy).toHaveBeenCalledWith(suspendKeepalive);
 		expect(ui.start).toHaveBeenCalledTimes(1);
 		expect(ui.requestRender).toHaveBeenCalledWith(true);
 	});
@@ -108,6 +115,8 @@ describe("InputController.handleCtrlZ", () => {
 		});
 		const onceSpy = spyOnProcessOnce();
 		const removeSpy = vi.spyOn(process, "removeListener");
+		const intervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 		const { ctx, ui, showError, showStatus } = createCtx();
 
 		const controller = new InputController(ctx);
@@ -122,6 +131,8 @@ describe("InputController.handleCtrlZ", () => {
 		sigcontListener = onceSpy.mock.calls.find(([sig]) => sig === "SIGCONT")?.[1];
 		expect(sigcontListener).toBeDefined();
 		expect(removeSpy).toHaveBeenCalledWith("SIGCONT", sigcontListener);
+		expect(intervalSpy).toHaveBeenCalledTimes(1);
+		expect(clearIntervalSpy).toHaveBeenCalledWith(intervalSpy.mock.results[0]?.value);
 
 		expect(killSpy).toHaveBeenCalledTimes(1);
 		expect(ui.stop).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Repro

In an interactive Bash PTY, run `PI_CODING_AGENT_DIR=/tmp/omp-8585-resume PATH=/opt/bun/bin:$PATH bunx @oh-my-pi/pi-coding-agent@17.3.4`, press Ctrl+Z in the TUI, then run `fg`. Bash reports `[1]+ Stopped ...` and foregrounds the job, but omp immediately returns to the shell with exit status 0 instead of redrawing the TUI.

## Cause

`InputController.handleCtrlZ` in `packages/coding-agent/src/modes/controllers/input-controller.ts` called `ui.stop()` before `SIGSTOP`; `ProcessTerminal.stop()` pauses stdin, leaving Bun with no referenced event-loop handle while the interactive loop waits on an unresolved Promise. After `fg` sends `SIGCONT`, Bun can exit successfully before dispatching the one-shot resume callback that restarts the TUI.

## Fix

- Hold a referenced event-loop timer across the stopped interval, then clear it before restarting the TUI on `SIGCONT`.
- Clear the same handle when signal delivery fails, alongside the existing SIGCONT listener cleanup and TUI restoration.
- Extend suspend lifecycle coverage and document the fix in the coding-agent changelog.

## Verification

- `bun test test/input-controller-suspend.test.ts` → 3 pass, 33 expect() calls.
- `bun run check` in `packages/coding-agent` → passed, including Biome and type checking.
- Manual interactive smoke against current source: Ctrl+Z produced `[1]+ Stopped ...`; `fg` redrew the TUI; typing `resume-probe` updated the resumed editor.
- Pre-publish `bun check` passed.

Fixes #8585