### PR TITLE
feat(catalog): add GLM-5.3 to Z.AI and Zhipu Coding Plans

### DIFF
--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -601,7 +601,7 @@ export interface ResolveOpenAIOutputTokenInput {
  *    upstream's cap makes OpenRouter skip that upstream. Omit catalog defaults
  *    (explicit caller caps still win) so `provider.order`/`only` is honored.
  *  - model/provider clamp: never exceed `model.maxTokens` or the provider clamp
- *    (`OPENAI_MAX_OUTPUT_TOKENS`, raised for GLM-5.2 reasoning by the caller).
+ *    (`OPENAI_MAX_OUTPUT_TOKENS`, raised for GLM-5.2+ reasoning by the caller).
  *  - `omitMaxOutputTokens`: proxies (Ollama) with unknown upstream caps drop it.
  */
 export function resolveOpenAIOutputTokenParam(
@@ -1105,11 +1105,11 @@ export function disableChatCompletionsReasoningForDialect(
 }
 
 /**
- * Z.AI/GLM-5.2 reasoning-effort dialect predicate. GLM-5.2 models served on a
+ * Z.AI/GLM-5.2+ reasoning-effort dialect predicate. GLM-5.2+ models served on a
  * Z.AI-format host (thinkingFormat "zai") accept `reasoning_effort`, stream tool
  * calls via `tool_stream`, and clamp output to the model cap. Moonshot Kimi and
  * Xiaomi MiMo also resolve to thinkingFormat "zai" with supportsReasoningEffort
- * true but are NOT GLM-5.2, so the model-id check is load-bearing — never swap it
+ * true but are NOT GLM-5.2+, so the model-id check is load-bearing — never swap it
  * for `compat.supportsReasoningEffort`.
  */
 function isZaiReasoningEffortDialect(model: Model<"openai-completions">, compat: ResolvedOpenAICompat): boolean {
@@ -1120,7 +1120,7 @@ function isZaiReasoningEffortDialect(model: Model<"openai-completions">, compat:
  * Provider-specific Chat Completions output clamp.
  *
  * Most OpenAI-compatible endpoints retain the conservative 64k ceiling from
- * {@link resolveOpenAIOutputTokenParam}. Z.AI/GLM-5.2 reasoning and native
+ * {@link resolveOpenAIOutputTokenParam}. Z.AI/GLM-5.2+ reasoning and native
  * Moonshot K3 explicitly accept their full advertised model caps, so those
  * routes clamp to `model.maxTokens` instead.
  */
@@ -1152,8 +1152,8 @@ export function resolveOpenAIResponsesOutputClamp(model: Pick<Model, "provider" 
 }
 
 /**
- * Enable `tool_stream` for Z.AI/GLM-5.2 reasoning models when tools are present
- * (GLM-5.2 streams tool-call arguments incrementally and needs the flag to do so).
+ * Enable `tool_stream` for Z.AI/GLM-5.2+ reasoning models when tools are present
+ * (these models stream tool-call arguments incrementally and need the flag to do so).
  */
 export function applyChatCompletionsToolStream(
 	params: OpenAICompletionsParams,

--- a/packages/ai/test/glm-5.3-coding-plan.test.ts
+++ b/packages/ai/test/glm-5.3-coding-plan.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+import type { Api, Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	ZAI_CODING_PLAN_STATIC_MODELS,
+	ZHIPU_CODING_PLAN_STATIC_MODELS,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: 0 }],
+};
+
+function createAbortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+async function captureSimplePayload<TApi extends Api>(
+	model: Model<TApi>,
+	options: Pick<SimpleStreamOptions, "disableReasoning" | "reasoning">,
+): Promise<Record<string, unknown>> {
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	streamSimple(model, context, {
+		apiKey: "test-key",
+		signal: createAbortedSignal(),
+		...options,
+		onPayload: payload => resolve(payload),
+	});
+	const payload = await promise;
+	if (typeof payload !== "object" || payload === null) {
+		throw new Error("Expected captured request payload");
+	}
+	return payload as Record<string, unknown>;
+}
+
+const zaiSpec = ZAI_CODING_PLAN_STATIC_MODELS.find(model => model.id === "glm-5.3");
+const zhipuSpec = ZHIPU_CODING_PLAN_STATIC_MODELS.find(model => model.id === "glm-5.3");
+if (!zaiSpec || !zhipuSpec) {
+	throw new Error("GLM-5.3 Coding Plan seeds are required for wire-contract tests");
+}
+const zaiGlm53 = buildModel(zaiSpec);
+const zhipuGlm53 = buildModel(zhipuSpec);
+
+describe("GLM-5.3 official Coding Plan wire mapping", () => {
+	it("floors thinking-off to low on the Z.AI Anthropic endpoint", async () => {
+		const payload = await captureSimplePayload(zaiGlm53, { disableReasoning: true });
+
+		expect(payload).toMatchObject({
+			thinking: { type: "enabled" },
+			output_config: { effort: "low" },
+		});
+	});
+
+	it("floors thinking-off to low on the Zhipu OpenAI endpoint", async () => {
+		const payload = await captureSimplePayload(zhipuGlm53, { disableReasoning: true });
+
+		expect(payload).toMatchObject({
+			thinking: { type: "enabled" },
+			reasoning_effort: "low",
+		});
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added GLM-5.3 to the Z.AI and Zhipu Coding Plan catalogs with the documented 1M context, 131,072-token output, and official `low`/`high`/`max` effort contract. Thinking defaults to `max`, while thinking-off requests floor to `low` on those first-party providers ([#8518](https://github.com/can1357/oh-my-pi/issues/8518)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Added

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added GLM-5.3 to the Z.AI and Zhipu Coding Plan catalogs with the documented 1M context, 131,072-token output, and official `low`/`high`/`max` effort contract. Thinking defaults to `max`, while thinking-off requests floor to `low` on those first-party providers ([#8518](https://github.com/can1357/oh-my-pi/issues/8518)).
+- Added GLM-5.3 to the Z.AI and Zhipu Coding Plan catalogs and made it the default for both providers, with the documented 1M context, 131,072-token output, and official `low`/`high`/`max` effort contract. Thinking defaults to `max`, while thinking-off requests floor to `low` on those first-party providers ([#8518](https://github.com/can1357/oh-my-pi/issues/8518)).
 
 ## [17.3.4] - 2026-08-14
 

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -49,6 +49,8 @@ import {
 	projectOpenAIProReasoningAliases,
 	SAKANA_FUGU_STATIC_MODELS,
 	stripFireworksDeepSeekThinkingToggle,
+	ZAI_CODING_PLAN_STATIC_MODELS,
+	ZHIPU_CODING_PLAN_STATIC_MODELS,
 } from "../src/provider-models/openai-compat";
 import { type OpenAICodexAccount, openaiCodexModelManagerOptions } from "../src/provider-models/special";
 import type { Api, ModelSpec } from "../src/types";
@@ -555,6 +557,13 @@ async function generateModels() {
 	// Mythos 5). Deduped behind upstream entries; metadata is pinned in
 	// applyAnthropicCatalogPolicy.
 	allModels.push(...ANTHROPIC_CURATED_FALLBACK_MODELS);
+	// GLM-5.3 launched on Z.AI Coding Plan before the PAYG catalog used for
+	// comparison pricing listed it. Earlier upstream rows still win once the
+	// general API advertises the model.
+	allModels.push(...ZAI_CODING_PLAN_STATIC_MODELS);
+	// Zhipu's authoritative `/models` response can lag the Coding Plan rollout;
+	// the model-manager fallback and this seed keep the documented model present.
+	allModels.push(...ZHIPU_CODING_PLAN_STATIC_MODELS);
 	// Seed Meta's documented Muse model so first-run selection does not depend on
 	// credentials or live discovery.
 	allModels.push(...META_MUSE_STATIC_MODELS);

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -367,9 +367,12 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 		model.omitMaxOutputTokens = true;
 	}
 
-	// GLM Coding Plan: GLM-5.2 is the selectable 1M served id; pin it so
-	// endpoint discovery or older bundled fallbacks cannot regress to 200k.
-	if ((model.provider === "zai" || model.provider === "zhipu-coding-plan") && model.id === "glm-5.2") {
+	// GLM Coding Plan: GLM-5.2/5.3 are the selectable 1M served ids; pin them
+	// so endpoint discovery or older bundled fallbacks cannot regress to 200k.
+	if (
+		(model.provider === "zai" || model.provider === "zhipu-coding-plan") &&
+		(model.id === "glm-5.2" || model.id === "glm-5.3")
+	) {
 		model.contextWindow = 1_000_000;
 		model.maxTokens = 131_072;
 	}

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -251,6 +251,22 @@ export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => 
 	return semverGte(glm.version, "5.2");
 });
 
+/**
+ * GLM-5.3+ coding SKUs add a native `low` tier beneath `high`/`max`.
+ * Provider-specific policy (including whether thinking-off floors to `low`)
+ * is resolved in model-thinking rather than assumed for every reseller.
+ */
+export const isGlm53ReasoningEffortModelId = memo((modelId: string): boolean => {
+	const glm = parseGlmModel(bareModelId(modelId));
+	if (!glm || glm.vision) {
+		return false;
+	}
+	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+		return false;
+	}
+	return semverGte(glm.version, "5.3");
+});
+
 /** GLM vision SKUs — the `v` that attaches to the version (`glm-4v`, `glm-4.5v`). */
 export const isGlmVisionModelId = memo((modelId: string): boolean => {
 	return parseGlmModel(bareModelId(modelId))?.vision === true;

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -221,6 +221,17 @@ export const isOpenAISamplingRestrictedModelId = memo((modelId: string): boolean
 	return isOpenAIWireGen5Plus(modelId) || O_SERIES_REASONING_RE.test(bare);
 });
 
+function isReasoningGlmModelAtLeast(modelId: string, minimumVersion: string): boolean {
+	const glm = parseGlmModel(bareModelId(modelId));
+	if (!glm || glm.vision) {
+		return false;
+	}
+	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+		return false;
+	}
+	return semverGte(glm.version, minimumVersion);
+}
+
 /**
  * Reasoning-capable GLM coding SKUs: glm-4.5 and up on the base / `-air` /
  * `-turbo` lines. Excludes the vision (`…v`) shape, the non-reasoning
@@ -229,26 +240,12 @@ export const isOpenAISamplingRestrictedModelId = memo((modelId: string): boolean
  * allowlist.
  */
 export const isReasoningGlmModelId = memo((modelId: string): boolean => {
-	const glm = parseGlmModel(bareModelId(modelId));
-	if (!glm || glm.vision) {
-		return false;
-	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
-		return false;
-	}
-	return semverGte(glm.version, "4.5");
+	return isReasoningGlmModelAtLeast(modelId, "4.5");
 });
 
 /** GLM-5.2+ coding SKUs accept `reasoning_effort` in addition to binary thinking. */
 export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => {
-	const glm = parseGlmModel(bareModelId(modelId));
-	if (!glm || glm.vision) {
-		return false;
-	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
-		return false;
-	}
-	return semverGte(glm.version, "5.2");
+	return isReasoningGlmModelAtLeast(modelId, "5.2");
 });
 
 /**
@@ -257,14 +254,7 @@ export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => 
  * is resolved in model-thinking rather than assumed for every reseller.
  */
 export const isGlm53ReasoningEffortModelId = memo((modelId: string): boolean => {
-	const glm = parseGlmModel(bareModelId(modelId));
-	if (!glm || glm.vision) {
-		return false;
-	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
-		return false;
-	}
-	return semverGte(glm.version, "5.3");
+	return isReasoningGlmModelAtLeast(modelId, "5.3");
 });
 
 /** GLM vision SKUs — the `v` that attaches to the version (`glm-4v`, `glm-4.5v`). */

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -26,6 +26,7 @@ import {
 	isDeepseekModelIdOrName,
 	isDeepseekV4FlashModelId,
 	isGlm52ReasoningEffortModelId,
+	isGlm53ReasoningEffortModelId,
 	isKimiK3ModelId,
 	isMimoModelIdOrName,
 	isMinimaxM2FamilyModelId,
@@ -177,8 +178,11 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		thinking.supportsDisplay === undefined &&
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
-	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec.id);
-	const needsDefaultLevel = thinking.defaultLevel === undefined && isKimiK3ModelId(spec.id);
+	const officialGlm53CodingPlan = isOfficialGlm53CodingPlanModel(spec);
+	const needsRequiresEffort =
+		thinking.requiresEffort === undefined && (impliesMandatoryReasoning(parsed, spec.id) || officialGlm53CodingPlan);
+	const needsDefaultLevel =
+		thinking.defaultLevel === undefined && (isKimiK3ModelId(spec.id) || officialGlm53CodingPlan);
 	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort && !needsDefaultLevel) {
 		return thinking;
 	}
@@ -216,7 +220,8 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 		mode: inferThinkingControlMode(spec, parsed),
 		efforts,
 	};
-	if (isKimiK3ModelId(spec.id)) {
+	const officialGlm53CodingPlan = isOfficialGlm53CodingPlanModel(spec);
+	if (isKimiK3ModelId(spec.id) || officialGlm53CodingPlan) {
 		config.defaultLevel = Effort.Max;
 	}
 	const effortMap = inferEffortMap(spec, compat, config.mode, config.efforts);
@@ -229,7 +234,7 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 	) {
 		config.supportsDisplay = true;
 	}
-	if (impliesMandatoryReasoning(parsed, spec.id)) {
+	if (impliesMandatoryReasoning(parsed, spec.id) || officialGlm53CodingPlan) {
 		config.requiresEffort = true;
 	}
 	return config;
@@ -312,6 +317,13 @@ function getModelDefinedEfforts<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): readonly Effort[] | undefined {
+	if (isOfficialGlm53CodingPlanModel(spec)) {
+		// Z.AI documents low/high/max for GLM-5.3 on its Coding Plan
+		// transports. Keep this scoped to the two first-party providers: the
+		// same family on reseller routes retains its independently verified
+		// host ladder.
+		return LOW_HIGH_MAX_REASONING_EFFORTS;
+	}
 	if (isGlm52ReasoningEffortModelId(spec.id)) {
 		// GLM-5.2's reasoning_effort dialect is host-specific (verified against
 		// live endpoints):
@@ -433,6 +445,14 @@ function isAnthropicMessagesGlm52ReasoningEffortModel<TApi extends Api>(spec: Mo
 		spec.api === "anthropic-messages" &&
 		(spec.provider === "umans" || spec.provider === "zai") &&
 		isGlm52ReasoningEffortModelId(spec.id)
+	);
+}
+
+function isOfficialGlm53CodingPlanModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	if (!isGlm53ReasoningEffortModelId(spec.id)) return false;
+	return (
+		(spec.api === "anthropic-messages" && spec.provider === "zai") ||
+		(spec.api === "openai-completions" && spec.provider === "zhipu-coding-plan")
 	);
 }
 

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -105719,6 +105719,35 @@
 				]
 			}
 		},
+		"glm-5.3": {
+			"id": "glm-5.3",
+			"name": "GLM-5.3",
+			"api": "anthropic-messages",
+			"provider": "zai",
+			"baseUrl": "https://api.z.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			}
+		},
 		"glm-5v-turbo": {
 			"id": "glm-5v-turbo",
 			"name": "GLM-5V-Turbo",
@@ -111959,6 +111988,40 @@
 					"high",
 					"max"
 				]
+			}
+		},
+		"glm-5.3": {
+			"id": "glm-5.3",
+			"name": "GLM-5.3",
+			"api": "openai-completions",
+			"provider": "zhipu-coding-plan",
+			"baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
 			}
 		},
 		"glm-5v-turbo": {

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -522,7 +522,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "zai",
-		defaultModel: "glm-5.2",
+		defaultModel: "glm-5.3",
 		envVars: ["ZAI_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => zaiModelManagerOptions(config),
 		catalogDiscovery: { label: "zAI" },
@@ -537,7 +537,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "zhipu-coding-plan",
-		defaultModel: "glm-5.1",
+		defaultModel: "glm-5.3",
 		envVars: ["ZHIPU_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => zhipuCodingPlanModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1761,8 +1761,61 @@ export function siliconflowCnModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
-// 6.7 Zhipu Coding Plan
+// 6.7 GLM Coding Plans
 // ---------------------------------------------------------------------------
+
+/**
+ * GLM-5.3 is live for Z.AI Coding Plan subscribers before the general Z.AI
+ * API catalog advertises it. Keep a generated-catalog fallback so the model is
+ * selectable without depending on that upstream rollout. The comparison cost
+ * follows the existing PAYG display policy from issue #5598; the same rates
+ * are published for the GLM-5.3 OpenCode Go route and Z.AI's GLM-5.2 row.
+ * https://docs.z.ai/guides/llm/glm-5.3
+ */
+export const ZAI_CODING_PLAN_STATIC_MODELS: readonly ModelSpec<"anthropic-messages">[] = [
+	{
+		id: "glm-5.3",
+		name: "GLM-5.3",
+		api: "anthropic-messages",
+		provider: "zai",
+		baseUrl: "https://api.z.ai/api/anthropic",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+	},
+];
+
+/**
+ * The Zhipu Coding Plan `/models` endpoint can lag model availability during a
+ * rollout. Z.AI documents GLM-5.3 as available to every plan, so keep it in the
+ * authoritative discovery result even before the endpoint enumerates it.
+ * https://docs.bigmodel.cn/cn/guide/models/text/glm-5.3
+ */
+function buildZhipuCodingPlanGlm53(baseUrl: string): ModelSpec<"openai-completions"> {
+	return {
+		id: "glm-5.3",
+		name: "GLM-5.3",
+		api: "openai-completions",
+		provider: "zhipu-coding-plan",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
+		},
+	};
+}
+
+export const ZHIPU_CODING_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	buildZhipuCodingPlanGlm53("https://open.bigmodel.cn/api/coding/paas/v4"),
+];
 
 export interface ZhipuCodingPlanModelManagerConfig {
 	apiKey?: string;
@@ -1774,13 +1827,13 @@ export function zhipuCodingPlanModelManagerOptions(
 	config?: ZhipuCodingPlanModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = config?.baseUrl ?? "https://open.bigmodel.cn/api/coding/paas/v4";
+	const baseUrl = normalizeAnthropicBaseUrl(config?.baseUrl, "https://open.bigmodel.cn/api/coding/paas/v4");
 	return {
 		providerId: "zhipu-coding-plan",
 		dynamicModelsAuthoritative: true,
 		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels({
+			fetchDynamicModels: async () => {
+				const discovered = await fetchOpenAICompatibleModels({
 					api: "openai-completions",
 					provider: "zhipu-coding-plan",
 					baseUrl,
@@ -1803,7 +1856,12 @@ export function zhipuCodingPlanModelManagerOptions(
 						};
 					},
 					fetch: config?.fetch,
-				}),
+				});
+				if (discovered === null || discovered.some(model => model.id === "glm-5.3")) {
+					return discovered;
+				}
+				return [...discovered, buildZhipuCodingPlanGlm53(baseUrl)];
+			},
 		}),
 	};
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -320,7 +320,7 @@ function mapWithBundledReference<TApi extends Api>(
 	};
 }
 
-function normalizeAnthropicBaseUrl(baseUrl: string | undefined, fallback: string): string {
+function normalizeProviderBaseUrl(baseUrl: string | undefined, fallback: string): string {
 	const value = baseUrl?.trim();
 	if (!value) {
 		return fallback;
@@ -664,7 +664,7 @@ function createSimpleAnthropicProviderOptions(
 	config?: SimpleProviderConfig,
 ): ModelManagerOptions<"anthropic-messages"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = normalizeAnthropicBaseUrl(config?.baseUrl, defaultBaseUrlFallback);
+	const baseUrl = normalizeProviderBaseUrl(config?.baseUrl, defaultBaseUrlFallback);
 	const discoveryBaseUrl = toAnthropicDiscoveryBaseUrl(baseUrl);
 	const references = createBundledReferenceMap<"anthropic-messages">(providerId);
 	return {
@@ -721,7 +721,7 @@ interface UmansModelInfo {
 }
 
 function normalizeUmansBaseUrl(baseUrl: string | undefined): string {
-	const normalized = normalizeAnthropicBaseUrl(baseUrl, UMANS_BASE_URL);
+	const normalized = normalizeProviderBaseUrl(baseUrl, UMANS_BASE_URL);
 	return normalized.endsWith("/v1") ? normalized.slice(0, -3) : normalized;
 }
 
@@ -1764,6 +1764,9 @@ export function siliconflowCnModelManagerOptions(
 // 6.7 GLM Coding Plans
 // ---------------------------------------------------------------------------
 
+const ZAI_CODING_PLAN_BASE_URL = "https://api.z.ai/api/anthropic";
+const ZHIPU_CODING_PLAN_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/v4";
+
 /**
  * GLM-5.3 is live for Z.AI Coding Plan subscribers before the general Z.AI
  * API catalog advertises it. Keep a generated-catalog fallback so the model is
@@ -1778,7 +1781,7 @@ export const ZAI_CODING_PLAN_STATIC_MODELS: readonly ModelSpec<"anthropic-messag
 		name: "GLM-5.3",
 		api: "anthropic-messages",
 		provider: "zai",
-		baseUrl: "https://api.z.ai/api/anthropic",
+		baseUrl: ZAI_CODING_PLAN_BASE_URL,
 		reasoning: true,
 		input: ["text"],
 		cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
@@ -1814,7 +1817,7 @@ function buildZhipuCodingPlanGlm53(baseUrl: string): ModelSpec<"openai-completio
 }
 
 export const ZHIPU_CODING_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
-	buildZhipuCodingPlanGlm53("https://open.bigmodel.cn/api/coding/paas/v4"),
+	buildZhipuCodingPlanGlm53(ZHIPU_CODING_PLAN_BASE_URL),
 ];
 
 export interface ZhipuCodingPlanModelManagerConfig {
@@ -1827,7 +1830,7 @@ export function zhipuCodingPlanModelManagerOptions(
 	config?: ZhipuCodingPlanModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = normalizeAnthropicBaseUrl(config?.baseUrl, "https://open.bigmodel.cn/api/coding/paas/v4");
+	const baseUrl = normalizeProviderBaseUrl(config?.baseUrl, ZHIPU_CODING_PLAN_BASE_URL);
 	return {
 		providerId: "zhipu-coding-plan",
 		dynamicModelsAuthoritative: true,
@@ -2441,7 +2444,7 @@ export interface OpenCodeModelManagerConfig {
 }
 
 function normalizeOpenCodeBasePath(baseUrl: string | undefined, fallbackBasePath: string): string {
-	const value = normalizeAnthropicBaseUrl(baseUrl, fallbackBasePath);
+	const value = normalizeProviderBaseUrl(baseUrl, fallbackBasePath);
 	return value.endsWith("/v1") ? value.slice(0, -3) : value;
 }
 
@@ -5446,7 +5449,7 @@ export function anthropicModelManagerOptions(
 	// bundled Anthropic rows use both `https://api.anthropic.com` and `.../v1`.
 	// Discovery must always hit `/v1/models`, so the `/v1` suffix is enforced on
 	// the discovery URL while model rows keep the provider base (#6563).
-	const baseUrl = normalizeAnthropicBaseUrl(config?.baseUrl, ANTHROPIC_BASE_URL);
+	const baseUrl = normalizeProviderBaseUrl(config?.baseUrl, ANTHROPIC_BASE_URL);
 	const discoveryBaseUrl = toAnthropicDiscoveryBaseUrl(baseUrl);
 	return {
 		providerId: "anthropic",
@@ -5931,7 +5934,7 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	// SKU as "Free" in `/models`. The PAYG key carries the real per-token rates for
 	// the identical model ids, so the enumerated token costs line up with the other
 	// subscription providers for comparison (issue #5598).
-	anthropicMessagesDescriptor("zai", "zai", "https://api.z.ai/api/anthropic"),
+	anthropicMessagesDescriptor("zai", "zai", ZAI_CODING_PLAN_BASE_URL),
 	// --- Umans AI ---
 	// Source the pay-as-you-go catalog: the coding-plan key publishes subscription
 	// costs as zero, while `/models/info` omits pricing entirely. The generator
@@ -5978,18 +5981,13 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 		},
 	),
 	// --- Zhipu Coding Plan ---
-	openAiCompletionsDescriptor(
-		"zhipuai-coding-plan",
-		"zhipu-coding-plan",
-		"https://open.bigmodel.cn/api/coding/paas/v4",
-		{
-			compat: {
-				thinkingFormat: "zai",
-				reasoningContentField: "reasoning_content",
-				supportsDeveloperRole: false,
-			},
+	openAiCompletionsDescriptor("zhipuai-coding-plan", "zhipu-coding-plan", ZHIPU_CODING_PLAN_BASE_URL, {
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
 		},
-	),
+	}),
 ];
 
 const filterActiveToolCallModels = (_id: string, m: ModelsDevModel): boolean => {

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -223,7 +223,7 @@ describe("generated model policies", () => {
 		]);
 	});
 
-	it("pins zai glm-5.2 base id to 1M context", () => {
+	it("pins GLM-5.2 and GLM-5.3 Coding Plan ids to 1M context", () => {
 		const models = [
 			createSpec({
 				id: "glm-5.2",
@@ -232,12 +232,29 @@ describe("generated model policies", () => {
 				contextWindow: 200_000,
 				maxTokens: 8192,
 			}),
+			createSpec({
+				id: "glm-5.3",
+				api: "anthropic-messages",
+				provider: "zai",
+				contextWindow: 200_000,
+				maxTokens: 8192,
+			}),
+			createSpec({
+				id: "glm-5.3",
+				api: "openai-completions",
+				provider: "zhipu-coding-plan",
+				contextWindow: 200_000,
+				maxTokens: 8192,
+			}),
 		];
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.contextWindow).toBe(1_000_000);
-		expect(models[0]?.maxTokens).toBe(131_072);
+		expect(models.map(model => [model.contextWindow, model.maxTokens])).toEqual([
+			[1_000_000, 131_072],
+			[1_000_000, 131_072],
+			[1_000_000, 131_072],
+		]);
 	});
 
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -3,6 +3,7 @@ import {
 	hasOpus47ApiRestrictions,
 	isClaudeModelId,
 	isGeminiModelId,
+	isGlm53ReasoningEffortModelId,
 	isGlmVisionModelId,
 	isGrokModelId,
 	isGrokReasoningEffortCapable,
@@ -254,6 +255,18 @@ describe("isReasoningGlmModelId", () => {
 		expect(isReasoningGlmModelId("zai-org/GLM-5-Turbo")).toBe(true);
 		// Vision SKUs are still excluded even in uppercase.
 		expect(isReasoningGlmModelId("zai-org/GLM-4.5V")).toBe(false);
+	});
+});
+
+describe("isGlm53ReasoningEffortModelId", () => {
+	test("matches the 5.3+ coding lines without widening to older or non-reasoning variants", () => {
+		expect(isGlm53ReasoningEffortModelId("glm-5.3")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("z-ai/GLM-5.3-Turbo")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("glm-6")).toBe(true);
+
+		expect(isGlm53ReasoningEffortModelId("glm-5.2")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3-flash")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3v")).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -275,6 +275,55 @@ describe("model thinking derivation", () => {
 		expect(openRouter.thinking?.effortMap).toBeUndefined();
 	});
 
+	it("applies the GLM-5.3 low/high/max mandatory-thinking contract only to official Coding Plan providers", () => {
+		const zai = createModel({
+			id: "glm-5.3",
+			api: "anthropic-messages",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/anthropic",
+		});
+		const zhipu = createModel({
+			id: "glm-5.3",
+			api: "openai-completions",
+			provider: "zhipu-coding-plan",
+			baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+		});
+		const fireworks = createModel({
+			id: "glm-5.3",
+			api: "openai-completions",
+			provider: "fireworks",
+			baseUrl: "https://api.fireworks.ai/inference/v1",
+		});
+		const ollamaCloud = createModel({
+			id: "glm-5.3",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+		});
+
+		expect(zai.thinking).toEqual({
+			mode: "anthropic-budget-effort",
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			defaultLevel: Effort.Max,
+			requiresEffort: true,
+		});
+		expect(zhipu.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			defaultLevel: Effort.Max,
+			requiresEffort: true,
+		});
+		expect(fireworks.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.Max],
+			effortMap: { minimal: "none" },
+		});
+		expect(ollamaCloud.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.High, Effort.Max],
+		});
+	});
+
 	it("applies the DeepSeek effort contract to Ollama Cloud ollama-chat models (issue #8334)", () => {
 		const flash = createModel({
 			id: "deepseek-v4-flash",

--- a/packages/catalog/test/zhipu-compat.test.ts
+++ b/packages/catalog/test/zhipu-compat.test.ts
@@ -154,7 +154,7 @@ describe("openai-completions compat — GLM coding-plan stream idle timeout", ()
 });
 
 describe("zhipu-coding-plan model discovery", () => {
-	it("uses the dedicated Coding Plan endpoint by default", async () => {
+	it("uses the dedicated endpoint and retains GLM-5.3 when `/models` lags availability", async () => {
 		let requestedUrl = "";
 		const mockFetch: FetchImpl = Object.assign(
 			async (input: string | Request | URL): Promise<Response> => {
@@ -172,7 +172,44 @@ describe("zhipu-coding-plan model discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(requestedUrl).toBe("https://open.bigmodel.cn/api/coding/paas/v4/models");
-		expect(models?.[0]?.id).toBe("glm-5.1");
-		expect(models?.[0]?.baseUrl).toBe("https://open.bigmodel.cn/api/coding/paas/v4");
+		expect(models?.map(model => model.id)).toEqual(["glm-5.1", "glm-5.3"]);
+		const glm53 = models?.find(model => model.id === "glm-5.3");
+		expect(glm53?.baseUrl).toBe("https://open.bigmodel.cn/api/coding/paas/v4");
+		expect(glm53?.contextWindow).toBe(1_000_000);
+		expect(glm53?.maxTokens).toBe(131_072);
+	});
+
+	it("keeps a lagging-catalog GLM-5.3 fallback on the configured endpoint", async () => {
+		const mockFetch: FetchImpl = Object.assign(
+			async (): Promise<Response> =>
+				new Response(JSON.stringify({ data: [{ id: "glm-5.1", name: "GLM-5.1" }] }), {
+					headers: { "content-type": "application/json" },
+				}),
+			{ preconnect: fetch.preconnect },
+		);
+		const options = zhipuCodingPlanModelManagerOptions({
+			apiKey: "test-key",
+			baseUrl: "https://proxy.example.test/zhipu/",
+			fetch: mockFetch,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models?.find(model => model.id === "glm-5.3")?.baseUrl).toBe("https://proxy.example.test/zhipu");
+	});
+
+	it("keeps the endpoint's GLM-5.3 row authoritative once discovery lists it", async () => {
+		const mockFetch: FetchImpl = Object.assign(
+			async (): Promise<Response> =>
+				new Response(JSON.stringify({ data: [{ id: "glm-5.3", name: "GLM-5.3 Live" }] }), {
+					headers: { "content-type": "application/json" },
+				}),
+			{ preconnect: fetch.preconnect },
+		);
+		const options = zhipuCodingPlanModelManagerOptions({ apiKey: "test-key", fetch: mockFetch });
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models?.map(model => [model.id, model.name])).toEqual([["glm-5.3", "GLM-5.3 Live"]]);
 	});
 });

--- a/packages/catalog/test/zhipu-compat.test.ts
+++ b/packages/catalog/test/zhipu-compat.test.ts
@@ -61,9 +61,9 @@ function zhipuGlm52ByOfficialBaseUrl(): ModelSpec<"openai-completions"> {
 }
 
 describe("zhipu-coding-plan descriptor", () => {
-	it("defaults to the same Zhipu-hosted model used by login validation", () => {
-		expect(DEFAULT_MODEL_PER_PROVIDER["zhipu-coding-plan"]).toBe("glm-5.1");
-		expect(DEFAULT_MODEL_PER_PROVIDER.zai).toBe("glm-5.2");
+	it("defaults both official Coding Plan providers to GLM-5.3", () => {
+		expect(DEFAULT_MODEL_PER_PROVIDER["zhipu-coding-plan"]).toBe("glm-5.3");
+		expect(DEFAULT_MODEL_PER_PROVIDER.zai).toBe("glm-5.3");
 	});
 });
 


### PR DESCRIPTION
## Summary

- add GLM-5.3 to the international Z.AI and domestic Zhipu Coding Plan catalogs
- make GLM-5.3 the default for both providers
- encode the 1M context, 131,072-token output, and low/high/max mandatory-thinking contract on the two first-party transports
- retain GLM-5.3 when Zhipu's authoritative `/models` response lags rollout, while allowing a live row to remain authoritative

## Why

GLM-5.3 is available in both Coding Plan regions, but the catalogs used by generation and discovery may not enumerate it yet. A generated seed is sufficient for non-authoritative Z.AI discovery; Zhipu needs an additional runtime supplement because its dynamic model list is authoritative and would otherwise prune a static-only row.

The effort policy is intentionally scoped to the first-party Z.AI Anthropic and Zhipu OpenAI-compatible transports. Existing reseller ladders remain unchanged unless their own wire contracts are independently verified.

Related: #8520. This implementation also covers `zhipu-coding-plan`, preserves provider-specific reseller behavior, and defaults both official providers to GLM-5.3.

Closes #8518.

## Validation

- `cd packages/catalog && bun run check`
- `cd packages/ai && bun run check`
- `cd packages/catalog && bun test test/zhipu-compat.test.ts test/model-thinking.test.ts test/generated-policies.test.ts test/identity-family.test.ts` (94 pass)
- `cd packages/ai && bun test test/glm-5.3-coding-plan.test.ts test/glm-5.2-reasoning-effort.test.ts` (4 pass)
