### PR TITLE
fix(ai): restore Kimi multi-account quota recovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Kimi Code multi-account routing to rank OAuth credentials by 5-hour and 7-day quota headroom, retain usage-limit blocks until reset, and preserve JWT account identity across token refreshes for stable usage labels and history ([#8630](https://github.com/can1357/oh-my-pi/issues/8630)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -53,7 +53,7 @@ import { cursorUsageProvider } from "./usage/cursor";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
-import { kimiUsageProvider } from "./usage/kimi";
+import { kimiRankingStrategy, kimiUsageProvider } from "./usage/kimi";
 import { minimaxCodeUsageProvider } from "./usage/minimax-code";
 import { ollamaCloudUsageProvider, ollamaUsageProvider } from "./usage/ollama";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
@@ -1082,6 +1082,7 @@ const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>(
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
 	["google-antigravity", antigravityRankingStrategy],
+	["kimi-code", kimiRankingStrategy],
 	["zai", zaiRankingStrategy],
 	["opencode-go", opencodeGoRankingStrategy],
 ]);

--- a/packages/ai/src/registry/oauth/kimi.ts
+++ b/packages/ai/src/registry/oauth/kimi.ts
@@ -10,6 +10,7 @@ import { scheduler } from "node:timers/promises";
 import { $env, getAgentDir } from "@oh-my-pi/pi-utils";
 import packageJson from "../../../package.json" with { type: "json" };
 import * as AIError from "../../error";
+import { isRecord } from "../../utils";
 import type { OAuthController, OAuthCredentials } from "./types";
 
 const CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
@@ -172,10 +173,29 @@ function parseTokenPayload(payload: TokenResponse, refreshTokenFallback?: string
 		});
 	}
 
+	let accountId: string | undefined;
+	const tokenParts = payload.access_token.split(".");
+	const jwtPayloadPart = tokenParts.length === 3 ? tokenParts[1] : undefined;
+	if (jwtPayloadPart) {
+		try {
+			const jwtPayload: unknown = JSON.parse(
+				new TextDecoder("utf-8").decode(Uint8Array.fromBase64(jwtPayloadPart, { alphabet: "base64url" })),
+			);
+			if (isRecord(jwtPayload)) {
+				const userId = typeof jwtPayload.user_id === "string" ? jwtPayload.user_id.trim() : "";
+				const subject = typeof jwtPayload.sub === "string" ? jwtPayload.sub.trim() : "";
+				accountId = userId || subject || undefined;
+			}
+		} catch {
+			// Opaque access tokens remain valid credentials without account metadata.
+		}
+	}
+
 	return {
 		access: payload.access_token,
 		refresh,
 		expires: Date.now() + payload.expires_in * 1000 - OAUTH_EXPIRY_SKEW_MS,
+		accountId,
 	};
 }
 

--- a/packages/ai/src/usage/kimi.ts
+++ b/packages/ai/src/usage/kimi.ts
@@ -2,6 +2,7 @@ import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import { $env } from "@oh-my-pi/pi-utils";
 import { getKimiCommonHeaders } from "../registry/oauth/kimi";
 import type {
+	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
 	UsageFetchParams,
@@ -285,11 +286,25 @@ export const kimiUsageProvider: UsageProvider = {
 			fetchedAt: nowMs,
 			limits,
 			metadata: {
+				accountId: credential.accountId,
 				endpoint: url,
 			},
 			raw: parsed.raw,
 		};
 
 		return report;
+	},
+};
+
+/** Ranks Kimi OAuth accounts by the canonical 5-hour and 7-day quota windows. */
+export const kimiRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits: report => ({
+		primary: report.limits.find(limit => limit.window?.id === "5h"),
+		secondary: report.limits.find(limit => limit.window?.id === "7d"),
+	}),
+	scopeLimits: report => report.limits.filter(limit => limit.window?.id === "5h" || limit.window?.id === "7d"),
+	windowDefaults: {
+		primaryMs: 5 * HOUR_MS,
+		secondaryMs: 7 * DAY_MS,
 	},
 };

--- a/packages/ai/test/kimi-multi-account.test.ts
+++ b/packages/ai/test/kimi-multi-account.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import * as kimiOauth from "@oh-my-pi/pi-ai/registry/oauth/kimi";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const HOUR_MS = 60 * 60 * 1000;
+const WEEK_MS = 7 * 24 * HOUR_MS;
+
+function createCredential(accountId: string): OAuthCredentials {
+	return {
+		access: `access-${accountId}`,
+		refresh: `refresh-${accountId}`,
+		expires: Date.now() + HOUR_MS,
+		accountId,
+	};
+}
+
+function createUsageReport(accountId: string, fiveHourUsed: number, weeklyUsed: number): UsageReport {
+	const now = Date.now();
+	const limits: UsageLimit[] = [
+		{
+			id: "kimi-code:7d",
+			label: "7d limit",
+			scope: { provider: "kimi-code", accountId, windowId: "7d", shared: true },
+			window: { id: "7d", label: "7d limit", durationMs: WEEK_MS, resetsAt: now + WEEK_MS },
+			amount: {
+				unit: "percent",
+				usedFraction: weeklyUsed,
+				remainingFraction: 1 - weeklyUsed,
+			},
+			status: weeklyUsed >= 1 ? "exhausted" : weeklyUsed >= 0.9 ? "warning" : "ok",
+		},
+		{
+			id: "kimi-code:5h",
+			label: "5h limit",
+			scope: { provider: "kimi-code", accountId, windowId: "5h", shared: true },
+			window: { id: "5h", label: "5h limit", durationMs: 5 * HOUR_MS, resetsAt: now + 5 * HOUR_MS },
+			amount: {
+				unit: "percent",
+				usedFraction: fiveHourUsed,
+				remainingFraction: 1 - fiveHourUsed,
+			},
+			status: fiveHourUsed >= 1 ? "exhausted" : fiveHourUsed >= 0.9 ? "warning" : "ok",
+		},
+	];
+	return { provider: "kimi-code", fetchedAt: now, limits, metadata: { accountId } };
+}
+
+describe("AuthStorage Kimi OAuth ranking", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	const usageByAccount = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "kimi-code",
+		async fetchUsage(params) {
+			const accountId = params.credential.accountId;
+			return accountId ? (usageByAccount.get(accountId) ?? null) : null;
+		},
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-kimi-selection-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "kimi-code" ? usageProvider : undefined),
+		});
+		usageByAccount.clear();
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials["kimi-code"] as OAuthCredentials | undefined;
+			if (!credential) return null;
+			return { apiKey: credential.access, newCredentials: credential };
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("new sessions choose the Kimi account with more 5h and 7d headroom", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set("kimi-code", [
+			{ type: "oauth", ...createCredential("loaded") },
+			{ type: "oauth", ...createCredential("fresh") },
+		]);
+		usageByAccount.set("loaded", createUsageReport("loaded", 0.92, 0.8));
+		usageByAccount.set("fresh", createUsageReport("fresh", 0.01, 0.02));
+
+		const selected = new Set<string>();
+		for (let index = 0; index < 20; index += 1) {
+			const apiKey = await authStorage.getApiKey("kimi-code", `kimi-ranking-${index}`);
+			if (apiKey) selected.add(apiKey);
+		}
+
+		expect(selected).toEqual(new Set(["access-fresh"]));
+	});
+
+	test("usage-limit blocks last until the exhausted Kimi window resets", async () => {
+		if (!authStorage || !store?.getCredentialBlock) throw new Error("test setup failed");
+		await authStorage.set("kimi-code", [
+			{ type: "oauth", ...createCredential("exhausted") },
+			{ type: "oauth", ...createCredential("sibling") },
+		]);
+		const exhaustedReport = createUsageReport("exhausted", 1, 0.7);
+		usageByAccount.set("exhausted", exhaustedReport);
+		usageByAccount.set("sibling", createUsageReport("sibling", 0, 0));
+		const exhaustedRow = store.listAuthCredentials("kimi-code").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "exhausted";
+		});
+		if (!exhaustedRow) throw new Error("expected exhausted Kimi credential");
+
+		const result = await authStorage.markUsageLimitReached("kimi-code", undefined, {
+			credentialId: exhaustedRow.id,
+		});
+
+		expect(result.switched).toBe(true);
+		const resetAt = exhaustedReport.limits.find(limit => limit.window?.id === "5h")?.window?.resetsAt;
+		expect(store.getCredentialBlock(exhaustedRow.id, "kimi-code:oauth", "")).toBe(resetAt);
+	});
+});
+
+describe("Kimi OAuth account identity", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("keeps the JWT user id across token refresh", async () => {
+		const accessToken = `header.${Buffer.from(JSON.stringify({ user_id: "kimi-user-42", sub: "kimi-user-42" })).toString("base64url")}.signature`;
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: accessToken,
+							refresh_token: "refresh-1",
+							expires_in: 60 * 60,
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				{ preconnect: fetch.preconnect },
+			),
+		);
+
+		const refreshed = await kimiOauth.refreshKimiToken("refresh-0");
+
+		expect(refreshed.accountId).toBe("kimi-user-42");
+	});
+});

--- a/packages/ai/test/kimi-usage.test.ts
+++ b/packages/ai/test/kimi-usage.test.ts
@@ -3,10 +3,11 @@ import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import type { UsageFetchContext, UsageFetchParams } from "@oh-my-pi/pi-ai/usage";
 import { kimiUsageProvider } from "@oh-my-pi/pi-ai/usage/kimi";
 
-function makeCredential(): UsageFetchParams["credential"] {
+function makeCredential(accountId?: string): UsageFetchParams["credential"] {
 	return {
 		type: "oauth",
 		accessToken: "kimi-test-token",
+		accountId,
 	};
 }
 
@@ -101,5 +102,14 @@ describe("kimi usage provider", () => {
 		expect(report!.limits).toHaveLength(2);
 		expect(report!.limits[0]!.window?.id).toBe("7d");
 		expect(report!.limits[1]!.window?.id).toBe("90m");
+	});
+
+	it("attaches the credential account id used by stable usage labels", async () => {
+		const report = await kimiUsageProvider.fetchUsage!(
+			{ provider: "kimi-code", credential: makeCredential("kimi-user-42"), signal: undefined },
+			makeCtx({ usage: { limit: "100", used: "28", remaining: "72" } }),
+		);
+
+		expect(report?.metadata?.accountId).toBe("kimi-user-42");
 	});
 });


### PR DESCRIPTION
## Repro
With two stored `kimi-code` OAuth credentials, one at 92%/80% 5h/7d usage and one at 1%/2%, new sessions selected both accounts; marking an exhausted credential blocked it for only 60 seconds, and refreshing a JWT containing `user_id` returned no `accountId`. Reproduced with `bun test packages/ai/test/kimi-multi-account.test.ts` (0 pass, 3 fail before the fix).

## Cause
`DEFAULT_RANKING_STRATEGIES` in `packages/ai/src/auth-storage.ts` did not register Kimi, so `AuthStorage.#resolveOAuthSelection` skipped usage ranking and `markUsageLimitReached` could not use Kimi reset windows; separately, `parseTokenPayload` in `packages/ai/src/registry/oauth/kimi.ts` discarded the access-token `user_id`/`sub` claim, leaving usage cache identity and account labels token-derived or positional.

## Fix
- Add `kimiRankingStrategy` for canonical 5-hour and 7-day windows and register it for `kimi-code`.
- Decode Kimi JWT account identity on login and refresh, and attach it to usage report metadata.
- Add integration coverage for first-pick ranking, reset-length blocking, refresh identity, and stable usage labels.
- Document the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/kimi-multi-account.test.ts packages/ai/test/kimi-usage.test.ts packages/ai/test/issue-957-repro.test.ts` — 9 pass, 0 fail. `bun check` — passed.

Fixes #8630