### PR TITLE
fix(hub): prevent stale agent refs from blocking wait

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed adopted keep-alive agents remaining `running` in the registry after deferred turn settlement, and prevented stale detached or non-streaming refs from sustaining bare `hub wait` calls indefinitely ([#8634](https://github.com/can1357/oh-my-pi/issues/8634)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -276,7 +276,7 @@ export class IrcBus {
 		if (liveness) {
 			const { registry, senderId } = liveness;
 			const hasRunningSender = (from?: string): boolean =>
-				registry.listVisibleTo(senderId).some(ref => ref.status === "running" && (!from || ref.id === from));
+				registry.listVisibleTo(senderId).some(ref => registry.isRunning(ref) && (!from || ref.id === from));
 			const check = filter.from ? () => hasRunningSender(filter.from) : () => hasRunningSender();
 			unsubscribeLiveness = registry.onChange(() => {
 				if (!check()) {

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -9,6 +9,7 @@
  * revival) and are only removed on explicit release/teardown.
  */
 
+import { logger } from "@oh-my-pi/pi-utils";
 import type { AgentSession } from "../session/agent-session";
 import { oneLineLabel } from "../task/types";
 
@@ -135,6 +136,11 @@ export class AgentRegistry {
 		return expected === undefined || ref === expected || ref.session === expected;
 	}
 
+	#rejectStatusUpdate(id: string, status: AgentStatus, reason: string): false {
+		logger.debug("Agent registry status update rejected", { id, status, reason });
+		return false;
+	}
+
 	register(input: RegisterInput): AgentRef {
 		const now = Date.now();
 		const ref: AgentRef = {
@@ -181,10 +187,15 @@ export class AgentRegistry {
 
 	setStatus(id: string, status: AgentStatus, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
-		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		if (!ref) return this.#rejectStatusUpdate(id, status, "missing-ref");
+		if (!this.#matchesExpected(ref, expected)) {
+			return this.#rejectStatusUpdate(id, status, "session-ownership-changed");
+		}
 		// `aborted` is terminal: delayed progress/revival work from the killed
 		// generation must never transition the tombstone back to a live status.
-		if (ref.status === "aborted") return status === "aborted";
+		if (ref.status === "aborted") {
+			return status === "aborted" || this.#rejectStatusUpdate(id, status, "aborted-is-terminal");
+		}
 		if (ref.status === status) return true;
 		ref.status = status;
 		// Activity describes current work; it is meaningless once the agent
@@ -268,6 +279,20 @@ export class AgentRegistry {
 		return this.list().filter(
 			ref => ref.id !== id && ref.kind !== "advisor" && (ref.status === "running" || ref.status === "idle"),
 		);
+	}
+
+	/** Whether a ref's claimed running state is corroborated by its attached live session. */
+	isRunning(ref: AgentRef): boolean {
+		if (ref.status !== "running") return false;
+		return ref.session?.isStreaming === true;
+	}
+
+	/** Mirror a session's authoritative run-state notifications into its owned registry ref. */
+	syncSessionStatus(id: string, session: AgentSession): () => void {
+		const unsubscribe = session.subscribeRunState(status => {
+			this.setStatus(id, status, session);
+		});
+		return unsubscribe;
 	}
 
 	onChange(listener: RegistryListener): () => void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -488,6 +488,7 @@ export class AgentSession {
 	/** Last (enable, providerId) tuple resolved by `#syncAppendOnlyContext` — used to skip no-op invalidations. */
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
 	#eventListeners: AgentSessionEventListener[] = [];
+	#runStateListeners = new Set<(state: "running" | "idle") => void>();
 	#commandMetadataChangedListeners: CommandMetadataChangedListener[] = [];
 	#sessionChangeCallbacks = new Set<() => void>();
 	#observedSessionId: string | undefined;
@@ -1968,6 +1969,18 @@ export class AgentSession {
 		}
 	}
 
+	#emitRunState(state: "running" | "idle"): void {
+		for (const listener of this.#runStateListeners) {
+			try {
+				listener(state);
+			} catch (error) {
+				logger.warn("AgentSession run-state listener threw", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+	}
+
 	/**
 	 * Emit a UI-only notice to the session. Surfaces in interactive mode as a
 	 * `showWarning` / `showError` / `showStatus` line; non-interactive modes
@@ -2438,6 +2451,7 @@ export class AgentSession {
 		// turn: state-based lookups take over again.
 		if (event.type === "agent_start") {
 			this.#prunedTerminalRefusal = undefined;
+			this.#emitRunState("running");
 		}
 		// Step the mid-run todo counter synchronously, BEFORE any await in this
 		// handler. The agent loop's next-turn `getAsideMessages` poll can run
@@ -2733,6 +2747,7 @@ export class AgentSession {
 			// maintenance can emit agent_end, so preserve the state at settle entry.
 			const ttsrAbortPendingAtAgentEnd = this.#ttsr.abortPending;
 			const emitAgentEndNotification = async (options?: { willContinue?: boolean }) => {
+				this.#emitRunState("idle");
 				// Public agent_end is held out of the eager display pass and emitted
 				// here after maintenance routing, tagged isTerminal so subscribers can
 				// tell final settles from scheduled continuations.
@@ -3608,6 +3623,15 @@ export class AgentSession {
 		};
 	}
 
+	/**
+	 * Observe authoritative run-state transitions before public `agent_end`
+	 * deferral, for lifecycle owners that must not remain stale while prompts unwind.
+	 */
+	subscribeRunState(listener: (state: "running" | "idle") => void): () => void {
+		this.#runStateListeners.add(listener);
+		return () => this.#runStateListeners.delete(listener);
+	}
+
 	/** Register cleanup that runs when this AgentSession adopts a different session ID. */
 	registerSessionChangeCallback(callback: () => void): () => void {
 		this.#sessionChangeCallbacks.add(callback);
@@ -3970,6 +3994,7 @@ export class AgentSession {
 			this.#unsubscribeModelRoles = undefined;
 		}
 		this.#eventListeners = [];
+		this.#runStateListeners.clear();
 		this.#sessionChangeCallbacks.clear();
 
 		// A dispose triggered mid-turn (Ctrl-C / timeout / hard-killed subagent)

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2803,19 +2803,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	const progress = monitor.progress;
 	let unsubscribe: (() => void) | null = null;
 	let reviveSession: AgentReviver | null = null;
-	// Adopted (kept-alive) subagents flip registry status from session events on
-	// later turns: revive/wake → running, turn drained → idle. The subscription
-	// intentionally survives this run; a disposed session emits nothing, so it
-	// needs no teardown.
-	const installRegistryStatusSync = (target: AgentSession): void => {
-		target.subscribe(event => {
-			if (event.type === "agent_start") {
-				AgentRegistry.global().setStatus(id, "running", target);
-			} else if (event.type === "agent_end") {
-				AgentRegistry.global().setStatus(id, "idle", target);
-			}
-		});
-	};
 	const installIrcWakeTurnMonitor = (target: AgentSession): void => {
 		attachIrcWakeTurnMonitor(target, {
 			id,
@@ -3162,7 +3149,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);
-			installRegistryStatusSync(session);
+			// Run-state notifications precede deferrable wire-level `agent_end`,
+			// so adopted keep-alive lifecycle cannot get stuck during prompt unwind.
+			AgentRegistry.global().syncSessionStatus(id, session);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
 				// the single-writer lock cleanly and restores the full message history
@@ -3178,7 +3167,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
-					installRegistryStatusSync(revived);
+					AgentRegistry.global().syncSessionStatus(id, revived);
 					installIrcWakeTurnMonitor(revived);
 					return revived;
 				};

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -155,12 +155,9 @@ export function createPersistedSubagentReviverFactory(
 			await session.setActiveToolsByName([...init.tools, ...session.getMountedXdevToolNames()]);
 			// Cold revives must drive registry status themselves — createAgentSession
 			// doesn't wire this generically (the live path does it in the executor).
-			// Without it the idle-TTL timer never clears on a turn and the lifecycle
-			// could park the agent mid-run.
-			session.subscribe(event => {
-				if (event.type === "agent_start") registry.setStatus(ref.id, "running", session);
-				else if (event.type === "agent_end") registry.setStatus(ref.id, "idle", session);
-			});
+			// The internal run-state signal precedes deferrable public `agent_end`,
+			// keeping idle-TTL ownership synchronized even while prompts unwind.
+			registry.syncSessionStatus(ref.id, session);
 			// Persisted files predate an agent-source field, so cold-revived frames
 			// report the runtime-neutral `user` source; name comes from the ref.
 			const wakeAgent: AgentDefinition = {

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -377,7 +377,7 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 				// instead of blocking a full message-timeout window.
 				const hasRunningPeer = messaging.registry
 					.listVisibleTo(messaging.senderId)
-					.some(ref => ref.status === "running");
+					.some(ref => messaging.registry.isRunning(ref));
 				if (!hasRunningPeer) return nothingToWaitForResult(this.session);
 			}
 			return executeMessageWait(messaging, { from, timeoutMs: params.timeoutMs }, signal);

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -106,7 +106,7 @@ export function runningAgentsOutsideJobs(session: ToolSession): AgentActivitySna
 	const now = Date.now();
 	const out: AgentActivitySnapshot[] = [];
 	for (const ref of registry.list()) {
-		if (ref.kind !== "sub" || ref.status !== "running") continue;
+		if (ref.kind !== "sub" || !registry.isRunning(ref)) continue;
 		if (ref.id === selfId || covered.has(ref.id)) continue;
 		out.push({
 			id: ref.id,

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -845,8 +845,12 @@ describe("AgentSession concurrent prompt guard", () => {
 
 		const observedIsStreamingAtAgentEnd: boolean[] = [];
 		const reentrantPromptResults: Array<"resolved" | { error: string }> = [];
+		const observedIsStreamingAtRunIdle: boolean[] = [];
 		let reentrantPrompted = false;
 
+		session.subscribeRunState(state => {
+			if (state === "idle") observedIsStreamingAtRunIdle.push(session.isStreaming);
+		});
 		session.subscribe(event => {
 			if (event.type !== "agent_end") return;
 			observedIsStreamingAtAgentEnd.push(session.isStreaming);
@@ -863,6 +867,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		await session.waitForIdle();
 
 		expect(observedIsStreamingAtAgentEnd).not.toContain(true);
+		expect(observedIsStreamingAtRunIdle).toContain(true);
 		expect(reentrantPromptResults).toEqual(["resolved"]);
 	});
 

--- a/packages/coding-agent/test/tools/hub-wait.test.ts
+++ b/packages/coding-agent/test/tools/hub-wait.test.ts
@@ -109,4 +109,24 @@ describe("hub unified wait", () => {
 		expect(text).toContain("No running background jobs to wait for.");
 		expect(result.useless).toBe(true);
 	});
+
+	test("bare wait ignores a detached ref whose running status is stale", async () => {
+		const registry = AgentRegistry.global();
+		registry.register({ id: SELF_ID, displayName: "main", kind: "main", session: null });
+		registry.register({
+			id: "Zombie",
+			displayName: "stale task",
+			kind: "sub",
+			parentId: SELF_ID,
+			session: null,
+			status: "running",
+		});
+
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const result = await new HubTool(makeSession(manager)).execute("call_4", { op: "wait", timeoutMs: 0 });
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain("No running background jobs to wait for.");
+		expect(result.useless).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -32,6 +32,7 @@ function makeFakeSession(): FakeSession {
 	const delivered: IrcMessage[] = [];
 	const relayed: CustomMessage[] = [];
 	const session = {
+		isStreaming: true,
 		deliverIrcMessage: async (msg: IrcMessage) => {
 			if (nextError) {
 				const err = nextError;


### PR DESCRIPTION
## Repro
A zero-job `HubTool` session with a visible subagent ref in `{ status: "running", session: null }` leaves bare `hub wait { timeoutMs: 0 }` pending indefinitely on the base revision; the regression is exercised with `bun test packages/coding-agent/test/tools/hub-wait.test.ts -t "bare wait ignores a detached ref whose running status is stale"`.

## Cause
`AgentSession.#emitSessionEvent` deferred public `agent_end` while prompts unwound, but `installRegistryStatusSync` in `packages/coding-agent/src/task/executor.ts` relied on that deferrable event to move adopted agents to `idle`. Separately, `HubTool.#executeWait` and `IrcBus.wait` treated the uncorroborated registry status string as sufficient liveness, so a missed lifecycle write could sustain the wait forever.

## Fix
- Added pre-wire run-state notifications to `AgentSession` and mirrored them through `AgentRegistry.syncSessionStatus` for live and persisted keep-alive agents.
- Logged rejected guarded status writes and required an attached, streaming session before a registry ref counts as running for hub waits, IRC liveness, or jobless-agent snapshots.
- Added regression coverage for deferred `agent_end`, stale detached refs, and IRC liveness; documented the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/hub-wait.test.ts packages/coding-agent/test/tools/irc.test.ts packages/coding-agent/test/registry/agent-lifecycle.test.ts packages/coding-agent/test/agent-session-concurrent.test.ts` passed: 114 tests, 0 failures. `bun run check` in `packages/coding-agent` passed. The original in-process zero-job probe now settles within 50 ms with `No running background jobs to wait for.`

Fixes #8634