### PR TITLE
fix: stats accepts a --host parameter, drop unused

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `omp stats` and `/stats` accept a `--host` bind interface (default `127.0.0.1`), so the dashboard can be exposed beyond the host, e.g. from a container with `--host 0.0.0.0`.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -5,7 +5,7 @@
  */
 
 import { truncateToWidth } from "@oh-my-pi/pi-tui/utils";
-import { APP_NAME, formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
+import { formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { openPath } from "../utils/open";
 
@@ -57,43 +57,9 @@ function shortenSessionFile(p: string): string {
 
 export interface StatsCommandArgs {
 	port: number;
+	host?: string;
 	json: boolean;
 	summary: boolean;
-}
-
-// =============================================================================
-// Argument Parser
-// =============================================================================
-
-/**
- * Parse stats subcommand arguments.
- * Returns undefined if not a stats command.
- */
-export function parseStatsArgs(args: string[]): StatsCommandArgs | undefined {
-	if (args.length === 0 || args[0] !== "stats") {
-		return undefined;
-	}
-
-	const result: StatsCommandArgs = {
-		port: 3847,
-		json: false,
-		summary: false,
-	};
-
-	for (let i = 1; i < args.length; i++) {
-		const arg = args[i];
-		if (arg === "--json" || arg === "-j") {
-			result.json = true;
-		} else if (arg === "--summary" || arg === "-s") {
-			result.summary = true;
-		} else if ((arg === "--port" || arg === "-p") && i + 1 < args.length) {
-			result.port = parseInt(args[++i], 10);
-		} else if (arg.startsWith("--port=")) {
-			result.port = parseInt(arg.split("=")[1], 10);
-		}
-	}
-
-	return result;
 }
 
 function formatCost(n: number): string {
@@ -136,7 +102,7 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 	}
 
 	// Start the dashboard server
-	const { hostname, port } = await startServer(cmd.port);
+	const { hostname, port } = await startServer(cmd.port, cmd.host);
 	const url = `http://${hostname}:${port}`;
 	console.log(chalk.green(`Dashboard available at: ${url}`));
 
@@ -196,35 +162,4 @@ async function printStatsSummary(): Promise<void> {
 	}
 
 	console.log("");
-}
-
-// =============================================================================
-// Help
-// =============================================================================
-
-export function printStatsHelp(): void {
-	console.log(`${chalk.bold(`${APP_NAME} stats`)} - AI Usage Statistics Dashboard
-
-${chalk.bold("Usage:")}
-  ${APP_NAME} stats [options]
-
-${chalk.bold("Options:")}
-  -p, --port <port>  Port for the dashboard server (default: 3847)
-  -j, --json         Output stats as JSON and exit
-  -s, --summary      Print summary to console and exit
-  -h, --help         Show this help message
-
-${chalk.bold("Examples:")}
-  ${APP_NAME} stats              # Start dashboard server
-  ${APP_NAME} stats --json       # Print stats as JSON
-  ${APP_NAME} stats --summary    # Print summary to console
-  ${APP_NAME} stats --port 8080  # Start on custom port
-
-${chalk.bold("Metrics:")}
-  - Total requests and error rate
-  - Token usage (input, output, cache)
-  - Cost breakdown
-  - Average duration and time to first token (TTFT)
-  - Tokens per second throughput
-`);
 }

--- a/packages/coding-agent/src/commands/stats.ts
+++ b/packages/coding-agent/src/commands/stats.ts
@@ -11,6 +11,7 @@ export default class Stats extends Command {
 	static description = commandHelp.description;
 	static flags = {
 		port: Flags.integer({ char: "p", description: "Port for the dashboard server", default: 3847 }),
+		host: Flags.string({ description: "Host for the dashboard server", default: "127.0.0.1" }),
 		json: Flags.boolean({ char: "j", description: "Output stats as JSON", default: false }),
 		summary: Flags.boolean({ char: "s", description: "Print summary to console", default: false }),
 	};
@@ -21,6 +22,7 @@ export default class Stats extends Command {
 		const cmd: StatsCommandArgs = {
 			port: flags.port,
 			json: flags.json,
+			host: flags.host,
 			summary: flags.summary,
 		};
 

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -336,7 +336,7 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "stats",
 		description: "Launch the local stats dashboard",
-		inlineHint: "[--port <port>] [--host <ip>]",
+		inlineHint: "[--port=<port>] [--host=<ip>]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			const parsed = parseStatsDashboardArgs(command.args);

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -336,7 +336,7 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "stats",
 		description: "Launch the local stats dashboard",
-		inlineHint: "[--port <port>]",
+		inlineHint: "[--port <port>] [--host <ip>]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			const parsed = parseStatsDashboardArgs(command.args);

--- a/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
@@ -50,13 +50,9 @@ export function parseStatsDashboardArgs(args: string): StatsDashboardArgs | { er
 			port = parsed;
 			continue;
 		}
-		if (token === "--host") {
-			host = tokens[++i];
-			if (!host) return { error: `Missing host. ${STATS_DASHBOARD_USAGE}` };
-			continue;
-		}
-		if (token.startsWith("--host=")) {
+		if (token.startsWith("--host")) {
 			host = token.slice("--host=".length);
+			if (!host) return { error: `Missing host. ${STATS_DASHBOARD_USAGE}` };
 			continue;
 		}
 		return { error: `Unknown option: ${token}. ${STATS_DASHBOARD_USAGE}` };

--- a/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
@@ -11,6 +11,7 @@ interface StatsDashboardServer {
 
 export interface StatsDashboardArgs {
 	port: number;
+	host?: string;
 }
 
 export interface StatsDashboardLaunchResult {
@@ -20,7 +21,7 @@ export interface StatsDashboardLaunchResult {
 
 let activeStatsServer: StatsDashboardServer | undefined;
 
-const STATS_DASHBOARD_USAGE = "Usage: /stats [--port <port>]";
+const STATS_DASHBOARD_USAGE = "Usage: /stats [--port <port>] [--host <ip>]";
 
 function parsePort(value: string | undefined): number | string {
 	if (!value) return `Missing port. ${STATS_DASHBOARD_USAGE}`;
@@ -33,6 +34,7 @@ function parsePort(value: string | undefined): number | string {
 export function parseStatsDashboardArgs(args: string): StatsDashboardArgs | { error: string } {
 	const tokens = args.split(/\s+/).filter(Boolean);
 	let port = DEFAULT_STATS_DASHBOARD_PORT;
+	let host: string | undefined;
 
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
@@ -48,10 +50,19 @@ export function parseStatsDashboardArgs(args: string): StatsDashboardArgs | { er
 			port = parsed;
 			continue;
 		}
+		if (token === "--host") {
+			host = tokens[++i];
+			if (!host) return { error: `Missing host. ${STATS_DASHBOARD_USAGE}` };
+			continue;
+		}
+		if (token.startsWith("--host=")) {
+			host = token.slice("--host=".length);
+			continue;
+		}
 		return { error: `Unknown option: ${token}. ${STATS_DASHBOARD_USAGE}` };
 	}
 
-	return { port };
+	return { port, host };
 }
 
 export async function launchStatsDashboard(args: StatsDashboardArgs): Promise<StatsDashboardLaunchResult> {
@@ -60,7 +71,7 @@ export async function launchStatsDashboard(args: StatsDashboardArgs): Promise<St
 	let requestedPortIgnored = false;
 
 	if (!activeStatsServer) {
-		activeStatsServer = await stats.startServer(args.port);
+		activeStatsServer = await stats.startServer(args.port, args.host);
 	} else if (args.port !== activeStatsServer.port) {
 		requestedPortIgnored = true;
 	}

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Made the dashboard bind interface configurable via `--host` (default `127.0.0.1`), so the server can be exposed beyond the host, e.g. from a container with `--host 0.0.0.0`.
+
 ## [17.3.0] - 2026-08-13
 
 ### Added

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -4,6 +4,7 @@ import { parseArgs } from "node:util";
 import { formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
 import { getDashboardStats, getTotalMessageCount, syncAllSessions } from "./aggregator";
 import { closeDb } from "./db";
+import { STATS_DASHBOARD_HOSTNAME } from "./port-conflict";
 import { startServer } from "./server";
 
 export {
@@ -103,6 +104,7 @@ async function main(): Promise<void> {
 	const { values } = parseArgs({
 		options: {
 			port: { type: "string", short: "p", default: "3847" },
+			host: { type: "string", default: STATS_DASHBOARD_HOSTNAME },
 			json: { type: "boolean", short: "j", default: false },
 			sync: { type: "boolean", short: "s", default: false },
 			help: { type: "boolean", short: "h", default: false },
@@ -119,6 +121,7 @@ Usage:
 
 Options:
   -p, --port <port>  Port for the dashboard server (default: 3847)
+      --host <ip>    Interface to bind (default: 127.0.0.1; use 0.0.0.0 to expose)
   -j, --json         Output stats as JSON and exit
   -s, --sync         Sync session files and show summary
   -h, --help         Show this help message
@@ -127,6 +130,7 @@ Examples:
   omp-stats              # Start dashboard server
   omp-stats --json       # Print stats as JSON
   omp-stats --port 8080  # Start on custom port
+  omp-stats --host 0.0.0.0  # Expose beyond the host (e.g. from a container)
   omp-stats --sync       # Sync and show summary
 `);
 		return;
@@ -172,7 +176,7 @@ Examples:
 
 		// Start server
 		const port = parseInt(values.port || "3847", 10);
-		const { hostname, port: actualPort } = await startServer(port);
+		const { hostname, port: actualPort } = await startServer(port, values.host);
 		console.log(`Dashboard available at: http://${hostname}:${actualPort}`);
 		console.log("Press Ctrl+C to stop\n");
 

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -306,10 +306,10 @@ async function handleStatic(requestPath: string): Promise<Response> {
 	return new Response("Not Found", { status: 404 });
 }
 
-function createDashboardServer(port: number) {
+function createDashboardServer(port: number, hostname: string) {
 	const server = Bun.serve({
 		port,
-		hostname: STATS_DASHBOARD_HOSTNAME,
+		hostname,
 		async fetch(req) {
 			const url = new URL(req.url);
 			const path = url.pathname;
@@ -357,18 +357,25 @@ function createDashboardServer(port: number) {
 
 /**
  * Start the HTTP server, reusing a live dashboard or reclaiming a stale omp listener.
+ *
+ * The bind hostname defaults to the loopback interface so the dashboard stays
+ * private; pass `0.0.0.0` or a specific interface (e.g. a container bridge) to
+ * expose it beyond the host.
  */
-export async function startServer(port = 3847): Promise<{ hostname: string; port: number; stop: () => void }> {
+export async function startServer(
+	port = 3847,
+	hostname: string = STATS_DASHBOARD_HOSTNAME,
+): Promise<{ hostname: string; port: number; stop: () => void }> {
 	await ensureClientBuild();
 	const preparation = await prepareStatsPort(port);
 	if (preparation === "reuse") {
-		return { hostname: STATS_DASHBOARD_HOSTNAME, port, stop: () => {} };
+		return { hostname, port, stop: () => {} };
 	}
 
 	try {
-		const server = createDashboardServer(port);
+		const server = createDashboardServer(port, hostname);
 		return {
-			hostname: STATS_DASHBOARD_HOSTNAME,
+			hostname,
 			port: server.port ?? port,
 			stop: () => server.stop(),
 		};
@@ -377,13 +384,13 @@ export async function startServer(port = 3847): Promise<{ hostname: string; port
 
 		const recovery = await recoverStatsPort(port);
 		if (recovery === "reuse") {
-			return { hostname: STATS_DASHBOARD_HOSTNAME, port, stop: () => {} };
+			return { hostname, port, stop: () => {} };
 		}
 
 		try {
-			const server = createDashboardServer(port);
+			const server = createDashboardServer(port, hostname);
 			return {
-				hostname: STATS_DASHBOARD_HOSTNAME,
+				hostname,
 				port: server.port ?? port,
 				stop: () => server.stop(),
 			};

--- a/packages/stats/test/server-port-conflict.test.ts
+++ b/packages/stats/test/server-port-conflict.test.ts
@@ -101,6 +101,35 @@ describe("startServer access", () => {
 			server.stop();
 		}
 	});
+
+	it("binds to a configurable non-loopback hostname when requested", async () => {
+		let nonLoopbackHostname: string | undefined;
+		const interfaces = networkInterfaces();
+		for (const name in interfaces) {
+			const addresses = interfaces[name] ?? [];
+			for (const address of addresses) {
+				if (address.family === "IPv4" && !address.internal) {
+					nonLoopbackHostname = address.address;
+					break;
+				}
+			}
+			if (nonLoopbackHostname) break;
+		}
+		// No external interface to bind (e.g. isolated CI); nothing to assert.
+		if (!nonLoopbackHostname) return;
+
+		const server = await startServer(0, nonLoopbackHostname);
+		try {
+			expect(server.hostname).toBe(nonLoopbackHostname);
+			expect(await tcpConnects(nonLoopbackHostname, server.port)).toBe(true);
+			const response = await fetch(`http://${nonLoopbackHostname}:${server.port}/api/stats/models`);
+			expect(response.status).toBe(200);
+			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe(STATS_DASHBOARD_SECURITY_VERSION);
+			await response.body?.cancel();
+		} finally {
+			server.stop();
+		}
+	});
 });
 
 describe("startServer port conflicts", () => {


### PR DESCRIPTION
## What
https://github.com/can1357/oh-my-pi/pull/7634 made the default behavior safer, by binding explictly to localhost, but unfortunately this breaks some containerized workflows.

Solves by adding an optional `--host <ip>` parameter, such that we can request it binds to a specific network interface, or `0.0.0.0` as previously possible.

## Why
I run `omp` in a docker container a isolation mechanism, but I want to be able to access the stats dashboard from the host.

## Testing
- Tested using `bun dev` inside my container harness, observed the ability to now access dashboard as expected
- Without the `host` parameter, I cannot access the dashboard as expected
- Also tested the slash command using `bun dev`

```
bun dev -- stats --port 3847 --host 0.0.0.0
$ bun --cwd=packages/coding-agent src/cli.ts stats --port "3847" --host "0.0.0.0"
Syncing session files...
Synced 19 new entries from 1 files (8323 total)

Dashboard available at: http://0.0.0.0:3847
Press Ctrl+C to stop
```
---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
