### PR TITLE
feat(extensions): add interactive /quota dashboard extension

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the interactive `/quota` provider quota dashboard extension example under `packages/coding-agent/examples/extensions/quota/`.
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -43,6 +43,7 @@ cp permission-gate.ts ~/.omp/agent/extensions/
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors      |
 | `thinking-note.ts` | Adds display-only supplemental UI below assistant thinking blocks              |
 | `snake.ts`       | Snake game with custom UI, keyboard handling, and session persistence          |
+| `quota/`         | Interactive provider quota dashboard (`/quota`) with health indicators, collapsible accounts, and snapshot mode |
 
 ### Git Integration
 

--- a/packages/coding-agent/examples/extensions/quota/README.md
+++ b/packages/coding-agent/examples/extensions/quota/README.md
@@ -1,0 +1,134 @@
+# OMP Quota Dashboard (`omp-quota`)
+
+An interactive, theme-aware quota dashboard extension for [Oh My Pi (OMP)](https://omp.sh).
+
+Provides the `/quota` slash command to inspect your remaining rate limits and quota windows across all authenticated providers, accounts, and model pools in an attention-first, collapsible TUI interface.
+
+```text
+QUOTA                                                                      refreshed now
+✓ 12 healthy   ⚠ 1 low   ✕ 2 exhausted
+
+ATTENTION
+──────────────────────────────────────────────────
+
+⚠ Anthropic · kareem.jalal@jethur.com · Claude 7 Day
+  28%                                           ↻ 2d
+
+✕ Google Antigravity · osama.m.eid15@gmail.com · Google · Weekly
+  0%                                            ↻ 6d
+
+✕ OpenAI Codex · osama.m.eid1@gmail.com · 7 days
+  0%                                            ↻ 5d
+
+
+ANTHROPIC                                                                      1 account
+────────────────────────────────────────────────────
+❯ ▾ ● kareem.jalal@jethur.com                                                     ACTIVE
+    Organization
+    Claude 5 Hour           ███████████░   91%   ✓   ↻ 4h
+    Claude 7 Day            ███░░░░░░░░░   28%   ⚠   ↻ 2d
+    Claude 7 Day (Fable)    ████████████  100%   ✓
+
+GOOGLE ANTIGRAVITY                                                            3 accounts
+────────────────────────────────────────────────────
+  ▾ osama.m.eid15@gmail.com
+    ▾ Google
+      Weekly                  ░░░░░░░░░░░░    0%   ✕   ↻ 6d
+      Daily                   ████████████  100%   ✓
+    ▾ OpenAI
+      Weekly                  ████████████  100%   ✓   ↻ 7d
+    ▾ Anthropic
+      Weekly                  ████████████  100%   ✓   ↻ 7d
+
+  ▸ adel.mhalees@gmail.com                                                   all healthy
+
+  ▸ osama.m.eid17@gmail.com                                                  all healthy
+
+OPENAI CODEX                                                                   1 account
+────────────────────────────────────────────────────
+  ▾ osama.m.eid1@gmail.com                                                          PLUS
+    7 days                  ░░░░░░░░░░░░    0%   ✕   ↻ 5d
+
+↑↓ navigate   enter expand   a attention   h healthy   r refresh   q close
+```
+
+---
+
+## Installation
+
+### Option 1: Direct Extension Install (Recommended)
+
+Clone directly into your OMP extensions directory:
+
+```bash
+git clone https://github.com/osamam-eid/omp-quota.git ~/.omp/agent/extensions/quota
+```
+
+Start or restart `omp`, then type `/quota`.
+
+### Option 2: Via npm (when published to npm registry)
+
+```bash
+omp plugin install omp-quota
+```
+
+---
+
+## Usage
+
+### Interactive Dashboard
+```text
+/quota
+```
+Launches the full-screen interactive TUI dashboard.
+
+#### Keyboard Controls
+| Key | Action |
+| --- | --- |
+| `↑` / `↓` / `k` / `j` | Navigate selectable accounts and pools |
+| `Enter` | Expand / collapse selected account or pool |
+| `a` | Toggle **Attention-only mode** (filter out all healthy accounts) |
+| `h` | Toggle **Hide/Show healthy quotas** |
+| `r` | Live re-fetch from OMP's `AuthStorage` |
+| `q` / `Esc` | Close dashboard and return to prompt |
+
+### Snapshot Mode (Text Transcript)
+```text
+/quota snapshot
+```
+Prints a compact, non-interactive plain-text quota summary directly into your chat transcript. This mode is also used automatically as a headless fallback when running in non-interactive environments.
+
+---
+
+## Key Features
+
+* **Account-First Hierarchy**: Clean `Provider → Account → Pool → Window` nesting. Accounts never get mixed horizontally across columns.
+* **Remaining Quota Semantics**: Bars and percentages represent **remaining capacity** (not used capacity), with filled cells indicating available quota.
+* **4-Tier Health Palette**:
+  * `51–100%`: **Healthy** (`✓`, theme success color)
+  * `21–50%`: **Low** (`⚠`, theme warning color)
+  * `1–20%`: **Critical** (`!`, theme error color)
+  * `0%` / Exhausted: **Exhausted** (`✕`, theme error color / empty bar)
+  * Unknown: `?` with dotted placeholder
+* **Attention Section**: Surfaces low, critical, and exhausted quotas at the top of the dashboard for instant triage. Automatically omitted when everything is healthy.
+* **Google Antigravity Multi-Pool Support**: Preserves independent `Google`, `Anthropic`, and `OpenAI` backend quota pools per account.
+* **Clean Organization Formatting**: Eliminates redundant metadata like `user@example.com's Organization` while preserving real team/workspace names.
+* **Zero Core Modifications**: Pure standalone runtime extension using OMP's built-in `AuthStorage` and `UsageReport` APIs.
+
+---
+
+## Development & Testing
+
+Run the test suite with [Bun](https://bun.sh):
+
+```bash
+bun test
+```
+
+All 31 unit tests run standalone with zero external runtime dependencies.
+
+---
+
+## License
+
+[MIT](LICENSE) © Osama Eid

--- a/packages/coding-agent/examples/extensions/quota/index.ts
+++ b/packages/coding-agent/examples/extensions/quota/index.ts
@@ -1,24 +1,5 @@
-// /quota — OMP Quota Dashboard extension entry point.
-//
-// Registers `/quota`, an interactive, theme-aware TUI dashboard rendering
-// every authenticated provider's quota data:
-//
-//   Provider
-//     Account
-//       Quota Pool (Antigravity Google/Anthropic/OpenAI backend counters)
-//         Window
-//
-// Features:
-//   - Theme-aware semantic colors (accent, success, warning, error, dim, muted)
-//   - 12-cell health-colored remaining quota bars
-//   - ATTENTION section for low/critical/exhausted quotas
-//   - Keyboard navigation (↑/↓, Enter expand/collapse, a attention, h healthy, r refresh, q/Esc close)
-//   - Clean organization names without redundant email prefixes
-//   - Non-interactive snapshot mode: `/quota snapshot` (also headless fallback)
-//
-// Reuses OMP's existing AuthStorage/UsageReport infrastructure. Never modifies core.
-
 import type { ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
+
 import { QuotaDashboardComponent } from "./src/dashboard-component";
 import {
 	buildQuotaDashboardModel,
@@ -28,8 +9,13 @@ import {
 } from "./src/hierarchy";
 import { renderQuotaSnapshot } from "./src/render-plain";
 
-async function fetchModel(ctx: ExtensionCommandContext): Promise<QuotaDashboardModel | null> {
+async function fetchModel(ctx: ExtensionCommandContext, forceRefresh = false): Promise<QuotaDashboardModel | null> {
 	const authStorage = ctx.modelRegistry.authStorage;
+
+	if (forceRefresh) {
+		await authStorage.invalidateUsageCache();
+	}
+
 	const reports = (await authStorage.fetchUsageReports({
 		baseUrlResolver: provider => ctx.modelRegistry.getProviderBaseUrl(provider),
 	})) as LocalUsageReport[] | null;
@@ -76,14 +62,13 @@ export default function quotaExtension(pi: ExtensionAPI): void {
 				return;
 			}
 
-			// Interactive TUI Dashboard via ctx.ui.custom
 			await ctx.ui.custom((tui, theme, _keybindings, done) => {
 				return new QuotaDashboardComponent({
 					model: initialModel!,
 					theme,
 					requestRender: () => tui.requestRender(),
 					onRefresh: async () => {
-						return await fetchModel(ctx);
+						return await fetchModel(ctx, true);
 					},
 					onClose: () => {
 						done(undefined);

--- a/packages/coding-agent/examples/extensions/quota/index.ts
+++ b/packages/coding-agent/examples/extensions/quota/index.ts
@@ -1,0 +1,95 @@
+// /quota — OMP Quota Dashboard extension entry point.
+//
+// Registers `/quota`, an interactive, theme-aware TUI dashboard rendering
+// every authenticated provider's quota data:
+//
+//   Provider
+//     Account
+//       Quota Pool (Antigravity Google/Anthropic/OpenAI backend counters)
+//         Window
+//
+// Features:
+//   - Theme-aware semantic colors (accent, success, warning, error, dim, muted)
+//   - 12-cell health-colored remaining quota bars
+//   - ATTENTION section for low/critical/exhausted quotas
+//   - Keyboard navigation (↑/↓, Enter expand/collapse, a attention, h healthy, r refresh, q/Esc close)
+//   - Clean organization names without redundant email prefixes
+//   - Non-interactive snapshot mode: `/quota snapshot` (also headless fallback)
+//
+// Reuses OMP's existing AuthStorage/UsageReport infrastructure. Never modifies core.
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
+import { QuotaDashboardComponent } from "./src/dashboard-component";
+import {
+	buildQuotaDashboardModel,
+	type LocalActiveIdentity,
+	type LocalUsageReport,
+	type QuotaDashboardModel,
+} from "./src/hierarchy";
+import { renderQuotaSnapshot } from "./src/render-plain";
+
+async function fetchModel(ctx: ExtensionCommandContext): Promise<QuotaDashboardModel | null> {
+	const authStorage = ctx.modelRegistry.authStorage;
+	const reports = (await authStorage.fetchUsageReports({
+		baseUrlResolver: provider => ctx.modelRegistry.getProviderBaseUrl(provider),
+	})) as LocalUsageReport[] | null;
+
+	if (!reports || reports.length === 0) return null;
+
+	const activeByProvider = new Map<string, LocalActiveIdentity>();
+	const currentProvider = ctx.model?.provider;
+	if (currentProvider) {
+		const identity = authStorage.getOAuthAccountIdentity(currentProvider, ctx.sessionManager.getSessionId());
+		if (identity) activeByProvider.set(currentProvider, identity);
+	}
+
+	return buildQuotaDashboardModel(reports, Date.now(), activeByProvider);
+}
+
+export default function quotaExtension(pi: ExtensionAPI): void {
+	pi.setLabel("Quota");
+
+	pi.registerCommand("quota", {
+		description: "Interactive provider quota dashboard (/quota snapshot for text report)",
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
+			const isSnapshotMode = args.trim().toLowerCase() === "snapshot";
+			const hasInteractiveUi = ctx.hasUI && typeof ctx.ui?.custom === "function";
+
+			let initialModel: QuotaDashboardModel | null = null;
+			try {
+				initialModel = await fetchModel(ctx);
+			} catch (error) {
+				ctx.ui.notify(
+					`Failed to fetch quota data: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
+				return;
+			}
+
+			if (!initialModel) {
+				ctx.ui.notify("No quota data available.", "warning");
+				return;
+			}
+
+			if (isSnapshotMode || !hasInteractiveUi) {
+				ctx.ui.notify(renderQuotaSnapshot(initialModel), "info");
+				return;
+			}
+
+			// Interactive TUI Dashboard via ctx.ui.custom
+			await ctx.ui.custom((tui, theme, _keybindings, done) => {
+				return new QuotaDashboardComponent({
+					model: initialModel!,
+					theme,
+					requestRender: () => tui.requestRender(),
+					onRefresh: async () => {
+						return await fetchModel(ctx);
+					},
+					onClose: () => {
+						done(undefined);
+					},
+				});
+			});
+		},
+	});
+}

--- a/packages/coding-agent/examples/extensions/quota/package.json
+++ b/packages/coding-agent/examples/extensions/quota/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@omp-agent/quota",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local OMP extension: /quota — provider → account → pool → window quota report using OMP's existing AuthStorage/UsageReport infrastructure.",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": { "test": "bun test" },
+  "devDependencies": { "bun-types": "latest" }
+}

--- a/packages/coding-agent/examples/extensions/quota/package.json
+++ b/packages/coding-agent/examples/extensions/quota/package.json
@@ -1,10 +1,45 @@
 {
-  "name": "@omp-agent/quota",
-  "version": "0.1.0",
-  "private": true,
-  "description": "Local OMP extension: /quota — provider → account → pool → window quota report using OMP's existing AuthStorage/UsageReport infrastructure.",
+  "name": "omp-quota",
+  "version": "1.0.0",
+  "description": "Interactive provider quota dashboard for Oh My Pi (OMP) with health indicators, collapsible accounts, and snapshot mode",
   "type": "module",
   "main": "index.ts",
-  "scripts": { "test": "bun test" },
-  "devDependencies": { "bun-types": "latest" }
+  "homepage": "https://github.com/osamam-eid/omp-quota",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/osamam-eid/omp-quota.git"
+  },
+  "omp": {
+    "name": "omp-quota",
+    "description": "Interactive provider quota dashboard for Oh My Pi (OMP)",
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "pi": {
+    "name": "omp-quota",
+    "description": "Interactive provider quota dashboard for Oh My Pi (OMP)",
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "keywords": [
+    "omp",
+    "oh-my-pi",
+    "omp-extension",
+    "omp-plugin",
+    "quota",
+    "anthropic",
+    "google-antigravity",
+    "openai-codex",
+    "dashboard"
+  ],
+  "author": "osamam-eid",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
 }

--- a/packages/coding-agent/examples/extensions/quota/src/dashboard-component.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/dashboard-component.ts
@@ -1,6 +1,3 @@
-// Interactive TUI Component for the Quota Dashboard.
-// Implements pi-tui Component interface with keyboard navigation, collapse/expand, filtering, and refresh.
-
 import type { MinimalTheme } from "./format";
 import type { QuotaDashboardModel } from "./hierarchy";
 import { matchActionKey } from "./keys";
@@ -20,33 +17,29 @@ export interface QuotaDashboardOptions {
 }
 
 export class QuotaDashboardComponent {
-	private model: QuotaDashboardModel;
-	private readonly theme: MinimalTheme;
-	private readonly requestRender: () => void;
-	private readonly onRefreshCallback: () => Promise<QuotaDashboardModel | null>;
-	private readonly onCloseCallback: () => void;
+	#model: QuotaDashboardModel;
+	readonly #theme: MinimalTheme;
+	readonly #requestRender: () => void;
+	readonly #onRefreshCallback: () => Promise<QuotaDashboardModel | null>;
+	readonly #onCloseCallback: () => void;
 
-	private viewState: DashboardViewState;
-	private selectables: SelectableTarget[] = [];
-	private cachedRender: readonly string[] = [];
-	private lastWidth = 0;
-	private isDisposed = false;
+	#viewState: DashboardViewState;
+	#selectables: SelectableTarget[] = [];
+	#cachedRender: readonly string[] = [];
+	#lastWidth = 0;
+	#isDisposed = false;
 
 	constructor(options: QuotaDashboardOptions) {
-		this.model = options.model;
-		this.theme = options.theme;
-		this.requestRender = options.requestRender;
-		this.onRefreshCallback = options.onRefresh;
-		this.onCloseCallback = options.onClose;
+		this.#model = options.model;
+		this.#theme = options.theme;
+		this.#requestRender = options.requestRender;
+		this.#onRefreshCallback = options.onRefresh;
+		this.#onCloseCallback = options.onClose;
 
-		// Initial collapse state:
-		// Accounts with issues or active accounts default to expanded.
-		// Accounts in single-account providers default to expanded.
-		// Completely healthy accounts in multi-account providers default to collapsed.
 		const collapsedAccounts = new Set<string>();
 		const collapsedPools = new Set<string>();
 
-		for (const provider of this.model.providers) {
+		for (const provider of this.#model.providers) {
 			const isMultiAccount = provider.accounts.length > 1;
 			for (const account of provider.accounts) {
 				if (isMultiAccount && !account.healthSummary.hasIssues && !account.isActive) {
@@ -55,7 +48,7 @@ export class QuotaDashboardComponent {
 			}
 		}
 
-		this.viewState = {
+		this.#viewState = {
 			selectedIndex: 0,
 			collapsedAccounts,
 			collapsedPools,
@@ -64,166 +57,169 @@ export class QuotaDashboardComponent {
 			isRefreshing: false,
 		};
 
-		this.refreshSelectables();
+		this.#refreshSelectables();
 	}
 
-	private refreshSelectables(): void {
-		this.selectables = collectSelectables(this.model, this.viewState);
-		if (this.viewState.selectedIndex >= this.selectables.length) {
-			this.viewState.selectedIndex = Math.max(0, this.selectables.length - 1);
+	#refreshSelectables(): void {
+		this.#selectables = collectSelectables(this.#model, this.#viewState);
+		if (this.#viewState.selectedIndex >= this.#selectables.length) {
+			this.#viewState.selectedIndex = Math.max(0, this.#selectables.length - 1);
 		}
 	}
 
-	public updateModel(newModel: QuotaDashboardModel): void {
-		this.model = newModel;
-		this.viewState.isRefreshing = false;
-		this.viewState.refreshError = undefined;
-		this.refreshSelectables();
+	updateModel(newModel: QuotaDashboardModel): void {
+		this.#model = newModel;
+		this.#viewState.isRefreshing = false;
+		this.#viewState.refreshError = undefined;
+		this.#refreshSelectables();
 		this.invalidate();
-		this.requestRender();
+		this.#requestRender();
 	}
 
-	public render(width: number): readonly string[] {
-		if (this.cachedRender.length > 0 && this.lastWidth === width) {
-			return this.cachedRender;
+	render(width: number): readonly string[] {
+		if (this.#cachedRender.length > 0 && this.#lastWidth === width) {
+			return this.#cachedRender;
 		}
-		this.lastWidth = width;
-		this.cachedRender = Object.freeze(renderDashboard(this.model, this.viewState, this.theme, width));
-		return this.cachedRender;
+		this.#lastWidth = width;
+		this.#cachedRender = Object.freeze(renderDashboard(this.#model, this.#viewState, this.#theme, width));
+		return this.#cachedRender;
 	}
 
-	public handleInput(data: string): void {
-		if (this.isDisposed) return;
+	handleInput(data: string): void {
+		if (this.#isDisposed) return;
 
 		const action = matchActionKey(data);
 		switch (action) {
 			case "close":
 			case "escape":
-				this.onCloseCallback();
+				this.#onCloseCallback();
 				break;
 
 			case "up":
-				if (this.selectables.length > 0) {
-					this.viewState.selectedIndex = Math.max(0, this.viewState.selectedIndex - 1);
+				if (this.#selectables.length > 0) {
+					this.#viewState.selectedIndex = Math.max(0, this.#viewState.selectedIndex - 1);
 					this.invalidate();
-					this.requestRender();
+					this.#requestRender();
 				}
 				break;
 
 			case "down":
-				if (this.selectables.length > 0) {
-					this.viewState.selectedIndex = Math.min(this.selectables.length - 1, this.viewState.selectedIndex + 1);
+				if (this.#selectables.length > 0) {
+					this.#viewState.selectedIndex = Math.min(
+						this.#selectables.length - 1,
+						this.#viewState.selectedIndex + 1,
+					);
 					this.invalidate();
-					this.requestRender();
+					this.#requestRender();
 				}
 				break;
 
 			case "home":
-				this.viewState.selectedIndex = 0;
+				this.#viewState.selectedIndex = 0;
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 				break;
 
 			case "end":
-				this.viewState.selectedIndex = Math.max(0, this.selectables.length - 1);
+				this.#viewState.selectedIndex = Math.max(0, this.#selectables.length - 1);
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 				break;
 
 			case "page_up":
-				this.viewState.selectedIndex = Math.max(0, this.viewState.selectedIndex - 5);
+				this.#viewState.selectedIndex = Math.max(0, this.#viewState.selectedIndex - 5);
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 				break;
 
 			case "page_down":
-				this.viewState.selectedIndex = Math.min(this.selectables.length - 1, this.viewState.selectedIndex + 5);
+				this.#viewState.selectedIndex = Math.min(this.#selectables.length - 1, this.#viewState.selectedIndex + 5);
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 				break;
 
 			case "enter":
-				this.toggleSelected();
+				this.#toggleSelected();
 				break;
 
 			case "toggle_attention":
-				this.viewState.attentionOnly = !this.viewState.attentionOnly;
-				this.viewState.selectedIndex = 0;
-				this.refreshSelectables();
+				this.#viewState.attentionOnly = !this.#viewState.attentionOnly;
+				this.#viewState.selectedIndex = 0;
+				this.#refreshSelectables();
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 				break;
 
 			case "toggle_healthy":
-				this.viewState.hideHealthy = !this.viewState.hideHealthy;
-				this.refreshSelectables();
+				this.#viewState.hideHealthy = !this.#viewState.hideHealthy;
+				this.#refreshSelectables();
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 				break;
 
 			case "refresh":
-				this.triggerRefresh();
+				this.#triggerRefresh();
 				break;
 		}
 	}
 
-	private toggleSelected(): void {
-		const current = this.selectables[this.viewState.selectedIndex];
+	#toggleSelected(): void {
+		const current = this.#selectables[this.#viewState.selectedIndex];
 		if (!current) return;
 
 		if (current.kind === "account") {
-			if (this.viewState.collapsedAccounts.has(current.id)) {
-				this.viewState.collapsedAccounts.delete(current.id);
+			if (this.#viewState.collapsedAccounts.has(current.id)) {
+				this.#viewState.collapsedAccounts.delete(current.id);
 			} else {
-				this.viewState.collapsedAccounts.add(current.id);
+				this.#viewState.collapsedAccounts.add(current.id);
 			}
 		} else if (current.kind === "pool") {
-			if (this.viewState.collapsedPools.has(current.id)) {
-				this.viewState.collapsedPools.delete(current.id);
+			if (this.#viewState.collapsedPools.has(current.id)) {
+				this.#viewState.collapsedPools.delete(current.id);
 			} else {
-				this.viewState.collapsedPools.add(current.id);
+				this.#viewState.collapsedPools.add(current.id);
 			}
 		}
 
-		this.refreshSelectables();
+		this.#refreshSelectables();
 		this.invalidate();
-		this.requestRender();
+		this.#requestRender();
 	}
 
-	private triggerRefresh(): void {
-		if (this.viewState.isRefreshing) return;
-		this.viewState.isRefreshing = true;
-		this.viewState.refreshError = undefined;
+	#triggerRefresh(): void {
+		if (this.#viewState.isRefreshing) return;
+		this.#viewState.isRefreshing = true;
+		this.#viewState.refreshError = undefined;
 		this.invalidate();
-		this.requestRender();
+		this.#requestRender();
 
-		Promise.resolve(this.onRefreshCallback())
+		Promise.resolve(this.#onRefreshCallback())
 			.then(freshModel => {
-				if (this.isDisposed) return;
+				if (this.#isDisposed) return;
 				if (freshModel) {
 					this.updateModel(freshModel);
 				} else {
-					this.viewState.isRefreshing = false;
-					this.viewState.refreshError = "No data returned";
+					this.#viewState.isRefreshing = false;
+					this.#viewState.refreshError = "No data returned";
 					this.invalidate();
-					this.requestRender();
+					this.#requestRender();
 				}
 			})
 			.catch(err => {
-				if (this.isDisposed) return;
-				this.viewState.isRefreshing = false;
-				this.viewState.refreshError = err instanceof Error ? err.message : String(err);
+				if (this.#isDisposed) return;
+				this.#viewState.isRefreshing = false;
+				this.#viewState.refreshError = err instanceof Error ? err.message : String(err);
 				this.invalidate();
-				this.requestRender();
+				this.#requestRender();
 			});
 	}
 
-	public invalidate(): void {
-		this.cachedRender = [];
+	invalidate(): void {
+		this.#cachedRender = [];
 	}
 
-	public dispose(): void {
-		this.isDisposed = true;
-		this.cachedRender = [];
+	dispose(): void {
+		this.#isDisposed = true;
+		this.#cachedRender = [];
 	}
 }

--- a/packages/coding-agent/examples/extensions/quota/src/dashboard-component.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/dashboard-component.ts
@@ -1,0 +1,229 @@
+// Interactive TUI Component for the Quota Dashboard.
+// Implements pi-tui Component interface with keyboard navigation, collapse/expand, filtering, and refresh.
+
+import type { MinimalTheme } from "./format";
+import type { QuotaDashboardModel } from "./hierarchy";
+import { matchActionKey } from "./keys";
+import {
+	collectSelectables,
+	type DashboardViewState,
+	renderDashboard,
+	type SelectableTarget,
+} from "./render-dashboard";
+
+export interface QuotaDashboardOptions {
+	model: QuotaDashboardModel;
+	theme: MinimalTheme;
+	requestRender: () => void;
+	onRefresh: () => Promise<QuotaDashboardModel | null>;
+	onClose: () => void;
+}
+
+export class QuotaDashboardComponent {
+	private model: QuotaDashboardModel;
+	private readonly theme: MinimalTheme;
+	private readonly requestRender: () => void;
+	private readonly onRefreshCallback: () => Promise<QuotaDashboardModel | null>;
+	private readonly onCloseCallback: () => void;
+
+	private viewState: DashboardViewState;
+	private selectables: SelectableTarget[] = [];
+	private cachedRender: readonly string[] = [];
+	private lastWidth = 0;
+	private isDisposed = false;
+
+	constructor(options: QuotaDashboardOptions) {
+		this.model = options.model;
+		this.theme = options.theme;
+		this.requestRender = options.requestRender;
+		this.onRefreshCallback = options.onRefresh;
+		this.onCloseCallback = options.onClose;
+
+		// Initial collapse state:
+		// Accounts with issues or active accounts default to expanded.
+		// Accounts in single-account providers default to expanded.
+		// Completely healthy accounts in multi-account providers default to collapsed.
+		const collapsedAccounts = new Set<string>();
+		const collapsedPools = new Set<string>();
+
+		for (const provider of this.model.providers) {
+			const isMultiAccount = provider.accounts.length > 1;
+			for (const account of provider.accounts) {
+				if (isMultiAccount && !account.healthSummary.hasIssues && !account.isActive) {
+					collapsedAccounts.add(account.id);
+				}
+			}
+		}
+
+		this.viewState = {
+			selectedIndex: 0,
+			collapsedAccounts,
+			collapsedPools,
+			attentionOnly: false,
+			hideHealthy: false,
+			isRefreshing: false,
+		};
+
+		this.refreshSelectables();
+	}
+
+	private refreshSelectables(): void {
+		this.selectables = collectSelectables(this.model, this.viewState);
+		if (this.viewState.selectedIndex >= this.selectables.length) {
+			this.viewState.selectedIndex = Math.max(0, this.selectables.length - 1);
+		}
+	}
+
+	public updateModel(newModel: QuotaDashboardModel): void {
+		this.model = newModel;
+		this.viewState.isRefreshing = false;
+		this.viewState.refreshError = undefined;
+		this.refreshSelectables();
+		this.invalidate();
+		this.requestRender();
+	}
+
+	public render(width: number): readonly string[] {
+		if (this.cachedRender.length > 0 && this.lastWidth === width) {
+			return this.cachedRender;
+		}
+		this.lastWidth = width;
+		this.cachedRender = Object.freeze(renderDashboard(this.model, this.viewState, this.theme, width));
+		return this.cachedRender;
+	}
+
+	public handleInput(data: string): void {
+		if (this.isDisposed) return;
+
+		const action = matchActionKey(data);
+		switch (action) {
+			case "close":
+			case "escape":
+				this.onCloseCallback();
+				break;
+
+			case "up":
+				if (this.selectables.length > 0) {
+					this.viewState.selectedIndex = Math.max(0, this.viewState.selectedIndex - 1);
+					this.invalidate();
+					this.requestRender();
+				}
+				break;
+
+			case "down":
+				if (this.selectables.length > 0) {
+					this.viewState.selectedIndex = Math.min(this.selectables.length - 1, this.viewState.selectedIndex + 1);
+					this.invalidate();
+					this.requestRender();
+				}
+				break;
+
+			case "home":
+				this.viewState.selectedIndex = 0;
+				this.invalidate();
+				this.requestRender();
+				break;
+
+			case "end":
+				this.viewState.selectedIndex = Math.max(0, this.selectables.length - 1);
+				this.invalidate();
+				this.requestRender();
+				break;
+
+			case "page_up":
+				this.viewState.selectedIndex = Math.max(0, this.viewState.selectedIndex - 5);
+				this.invalidate();
+				this.requestRender();
+				break;
+
+			case "page_down":
+				this.viewState.selectedIndex = Math.min(this.selectables.length - 1, this.viewState.selectedIndex + 5);
+				this.invalidate();
+				this.requestRender();
+				break;
+
+			case "enter":
+				this.toggleSelected();
+				break;
+
+			case "toggle_attention":
+				this.viewState.attentionOnly = !this.viewState.attentionOnly;
+				this.viewState.selectedIndex = 0;
+				this.refreshSelectables();
+				this.invalidate();
+				this.requestRender();
+				break;
+
+			case "toggle_healthy":
+				this.viewState.hideHealthy = !this.viewState.hideHealthy;
+				this.refreshSelectables();
+				this.invalidate();
+				this.requestRender();
+				break;
+
+			case "refresh":
+				this.triggerRefresh();
+				break;
+		}
+	}
+
+	private toggleSelected(): void {
+		const current = this.selectables[this.viewState.selectedIndex];
+		if (!current) return;
+
+		if (current.kind === "account") {
+			if (this.viewState.collapsedAccounts.has(current.id)) {
+				this.viewState.collapsedAccounts.delete(current.id);
+			} else {
+				this.viewState.collapsedAccounts.add(current.id);
+			}
+		} else if (current.kind === "pool") {
+			if (this.viewState.collapsedPools.has(current.id)) {
+				this.viewState.collapsedPools.delete(current.id);
+			} else {
+				this.viewState.collapsedPools.add(current.id);
+			}
+		}
+
+		this.refreshSelectables();
+		this.invalidate();
+		this.requestRender();
+	}
+
+	private triggerRefresh(): void {
+		if (this.viewState.isRefreshing) return;
+		this.viewState.isRefreshing = true;
+		this.viewState.refreshError = undefined;
+		this.invalidate();
+		this.requestRender();
+
+		Promise.resolve(this.onRefreshCallback())
+			.then(freshModel => {
+				if (this.isDisposed) return;
+				if (freshModel) {
+					this.updateModel(freshModel);
+				} else {
+					this.viewState.isRefreshing = false;
+					this.viewState.refreshError = "No data returned";
+					this.invalidate();
+					this.requestRender();
+				}
+			})
+			.catch(err => {
+				if (this.isDisposed) return;
+				this.viewState.isRefreshing = false;
+				this.viewState.refreshError = err instanceof Error ? err.message : String(err);
+				this.invalidate();
+				this.requestRender();
+			});
+	}
+
+	public invalidate(): void {
+		this.cachedRender = [];
+	}
+
+	public dispose(): void {
+		this.isDisposed = true;
+		this.cachedRender = [];
+	}
+}

--- a/packages/coding-agent/examples/extensions/quota/src/format.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/format.ts
@@ -1,0 +1,148 @@
+// Formatting and presentational helpers for the Quota Dashboard.
+// Zero external dependencies so it works identically in tests and runtime.
+
+export type HealthStatus = "healthy" | "low" | "critical" | "exhausted" | "unknown" | "neutral";
+
+export interface HealthInfo {
+	status: HealthStatus;
+	symbol: string;
+	color: "success" | "warning" | "error" | "muted" | "dim";
+	label: string;
+}
+
+export function classifyHealth(remainingFraction: number | undefined, isExhaustedFlag?: boolean): HealthInfo {
+	if (remainingFraction === undefined) {
+		return {
+			status: "unknown",
+			symbol: "?",
+			color: "muted",
+			label: "unknown",
+		};
+	}
+
+	const clamped = Math.min(Math.max(remainingFraction, 0), 1);
+	const pct = Math.round(clamped * 100);
+
+	if (isExhaustedFlag || clamped <= 0 || pct === 0) {
+		return {
+			status: "exhausted",
+			symbol: "✕",
+			color: "error",
+			label: "exhausted",
+		};
+	}
+	if (pct <= 20) {
+		return {
+			status: "critical",
+			symbol: "!",
+			color: "error",
+			label: "critical",
+		};
+	}
+	if (pct <= 50) {
+		return {
+			status: "low",
+			symbol: "⚠",
+			color: "warning",
+			label: "low",
+		};
+	}
+	return {
+		status: "healthy",
+		symbol: "✓",
+		color: "success",
+		label: "healthy",
+	};
+}
+
+/** Coarse duration string, e.g. "6d", "4h", "32m", "45s". */
+export function formatDuration(ms: number): string {
+	const seconds = Math.max(0, Math.round(ms / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 48) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	return `${days}d`;
+}
+
+/** Percent string: e.g. "100%", "93%", "29%", "0%". */
+export function formatPercent(fraction: number): string {
+	const pct = Math.min(Math.max(fraction, 0), 1) * 100;
+	return `${pct.toFixed(1).replace(/\.0$/, "")}%`;
+}
+
+export const BAR_WIDTH = 12;
+
+/**
+ * 12-cell bar representing REMAINING quota.
+ * Plain-text version (for snapshot/fallback).
+ */
+export function renderRemainingBarPlain(fraction: number | undefined, width = BAR_WIDTH): string {
+	if (fraction === undefined) return "·".repeat(width);
+	const clamped = Math.min(Math.max(fraction, 0), 1);
+	const filled = Math.round(clamped * width);
+	return `${"█".repeat(filled)}${"░".repeat(Math.max(0, width - filled))}`;
+}
+
+export interface MinimalTheme {
+	fg(color: string, text: string): string;
+	bold(text: string): string;
+}
+
+/**
+ * 12-cell bar representing REMAINING quota with semantic theme styling.
+ */
+export function renderRemainingBarStyled(
+	fraction: number | undefined,
+	health: HealthInfo,
+	theme: MinimalTheme,
+	width = BAR_WIDTH,
+): string {
+	if (fraction === undefined) {
+		return theme.fg("muted", "·".repeat(width));
+	}
+	const clamped = Math.min(Math.max(fraction, 0), 1);
+	const filled = Math.round(clamped * width);
+	const empty = Math.max(0, width - filled);
+
+	if (health.status === "exhausted" || filled === 0) {
+		return theme.fg("dim", "░".repeat(width));
+	}
+
+	const filledStr = theme.fg(health.color, "█".repeat(filled));
+	const emptyStr = empty > 0 ? theme.fg("dim", "░".repeat(empty)) : "";
+	return `${filledStr}${emptyStr}`;
+}
+
+export function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+export function visibleWidth(text: string): number {
+	if (typeof Bun !== "undefined" && typeof (Bun as any).stringWidth === "function") {
+		return (Bun as any).stringWidth(text);
+	}
+	return stripAnsi(text).length;
+}
+
+export function padEndVisible(text: string, targetWidth: number): string {
+	const current = visibleWidth(text);
+	if (current >= targetWidth) return text;
+	return text + " ".repeat(targetWidth - current);
+}
+
+export function truncateVisible(text: string, maxWidth: number, ellipsis = "…"): string {
+	const current = visibleWidth(text);
+	if (current <= maxWidth) return text;
+	const ellipsisW = visibleWidth(ellipsis);
+	if (maxWidth <= ellipsisW) return ellipsis.slice(0, maxWidth);
+
+	let result = "";
+	for (const char of text) {
+		if (visibleWidth(result + char) + ellipsisW > maxWidth) break;
+		result += char;
+	}
+	return result + ellipsis;
+}

--- a/packages/coding-agent/examples/extensions/quota/src/format.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/format.ts
@@ -1,6 +1,3 @@
-// Formatting and presentational helpers for the Quota Dashboard.
-// Zero external dependencies so it works identically in tests and runtime.
-
 export type HealthStatus = "healthy" | "low" | "critical" | "exhausted" | "unknown" | "neutral";
 
 export interface HealthInfo {
@@ -21,9 +18,8 @@ export function classifyHealth(remainingFraction: number | undefined, isExhauste
 	}
 
 	const clamped = Math.min(Math.max(remainingFraction, 0), 1);
-	const pct = Math.round(clamped * 100);
 
-	if (isExhaustedFlag || clamped <= 0 || pct === 0) {
+	if (isExhaustedFlag || clamped <= 0) {
 		return {
 			status: "exhausted",
 			symbol: "✕",
@@ -31,7 +27,7 @@ export function classifyHealth(remainingFraction: number | undefined, isExhauste
 			label: "exhausted",
 		};
 	}
-	if (pct <= 20) {
+	if (clamped <= 0.2) {
 		return {
 			status: "critical",
 			symbol: "!",
@@ -39,7 +35,7 @@ export function classifyHealth(remainingFraction: number | undefined, isExhauste
 			label: "critical",
 		};
 	}
-	if (pct <= 50) {
+	if (clamped <= 0.5) {
 		return {
 			status: "low",
 			symbol: "⚠",
@@ -67,7 +63,7 @@ export function formatDuration(ms: number): string {
 	return `${days}d`;
 }
 
-/** Percent string: e.g. "100%", "93%", "29%", "0%". */
+/** Percent string: e.g. "100%", "93%", "29%", "0.4%". */
 export function formatPercent(fraction: number): string {
 	const pct = Math.min(Math.max(fraction, 0), 1) * 100;
 	return `${pct.toFixed(1).replace(/\.0$/, "")}%`;
@@ -116,13 +112,15 @@ export function renderRemainingBarStyled(
 	return `${filledStr}${emptyStr}`;
 }
 
+const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
 export function stripAnsi(text: string): string {
-	return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+	return text.replace(ANSI_REGEX, "");
 }
 
 export function visibleWidth(text: string): number {
-	if (typeof Bun !== "undefined" && typeof (Bun as any).stringWidth === "function") {
-		return (Bun as any).stringWidth(text);
+	if (typeof Bun !== "undefined" && typeof Bun.stringWidth === "function") {
+		return Bun.stringWidth(text);
 	}
 	return stripAnsi(text).length;
 }
@@ -133,7 +131,15 @@ export function padEndVisible(text: string, targetWidth: number): string {
 	return text + " ".repeat(targetWidth - current);
 }
 
-export function truncateVisible(text: string, maxWidth: number, ellipsis = "…"): string {
+export function replaceTabs(text: string): string {
+	return text.replaceAll("\t", "   ");
+}
+
+export function sanitizeText(text: string): string {
+	return text.replace(/[\x00-\x1f\x7f-\x9f]/g, " ");
+}
+
+export function truncateToWidth(text: string, maxWidth: number, ellipsis = "…"): string {
 	const current = visibleWidth(text);
 	if (current <= maxWidth) return text;
 	const ellipsisW = visibleWidth(ellipsis);

--- a/packages/coding-agent/examples/extensions/quota/src/hierarchy.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/hierarchy.ts
@@ -1,6 +1,3 @@
-// Quota hierarchy data model, grouping, health aggregation, and organization cleanup.
-// Zero external dependencies so it remains 100% testable standalone.
-
 import { classifyHealth, formatDuration, type HealthInfo } from "./format";
 
 export interface LocalUsageWindow {
@@ -356,12 +353,10 @@ export function buildQuotaDashboardModel(
 	activeIdentityByProvider: Map<string, LocalActiveIdentity>,
 ): QuotaDashboardModel {
 	const byProvider = new Map<string, LocalUsageReport[]>();
-	let latestFetchedAt = nowMs;
+	const reportsFetched = reports.map(r => r.fetchedAt).filter((t): t is number => typeof t === "number" && t > 0);
+	const latestFetchedAt = reportsFetched.length > 0 ? Math.max(...reportsFetched) : nowMs;
 
 	for (const report of reports) {
-		if (report.fetchedAt && report.fetchedAt > 0) {
-			latestFetchedAt = Math.max(latestFetchedAt, report.fetchedAt);
-		}
 		let bucket = byProvider.get(report.provider);
 		if (!bucket) {
 			bucket = [];
@@ -477,8 +472,12 @@ export function buildQuotaDashboardModel(
 				summaryText = "no limits";
 			}
 
+			const orgId = typeof metadata.orgId === "string" ? metadata.orgId : undefined;
+			const projectId = typeof metadata.projectId === "string" ? metadata.projectId : undefined;
+			const uniqueAccountId = `${provider}:${accountLabel}:${orgId ?? projectId ?? index}`;
+
 			return {
-				id: `${provider}:${accountLabel}`,
+				id: uniqueAccountId,
 				label: accountLabel,
 				cleanOrgName: cleanOrg,
 				planBadge,
@@ -515,11 +514,11 @@ export function buildQuotaDashboardModel(
 			exhaustedCount: totalExhausted,
 			unknownCount: totalUnknown,
 			totalCount,
-			allHealthy: totalCount > 0 && totalLow === 0 && totalCritical === 0 && totalExhausted === 0,
+			allHealthy:
+				totalHealthy > 0 && totalUnknown === 0 && totalLow === 0 && totalCritical === 0 && totalExhausted === 0,
 		},
 		attentionItems,
 	};
 }
 
-// Backwards compatibility re-export
 export { buildQuotaDashboardModel as buildQuotaHierarchy };

--- a/packages/coding-agent/examples/extensions/quota/src/hierarchy.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/hierarchy.ts
@@ -1,0 +1,525 @@
+// Quota hierarchy data model, grouping, health aggregation, and organization cleanup.
+// Zero external dependencies so it remains 100% testable standalone.
+
+import { classifyHealth, formatDuration, type HealthInfo } from "./format";
+
+export interface LocalUsageWindow {
+	id?: string;
+	label?: string;
+	resetsAt?: number;
+}
+
+export interface LocalUsageAmount {
+	used?: number;
+	limit?: number;
+	remaining?: number;
+	usedFraction?: number;
+	remainingFraction?: number;
+	/** "percent" | "tokens" | "requests" | "usd" | "minutes" | "bytes" | "unknown" */
+	unit: string;
+}
+
+export interface LocalUsageScope {
+	accountId?: string;
+	projectId?: string;
+	orgId?: string;
+	tier?: string;
+	windowId?: string;
+}
+
+export interface LocalUsageLimit {
+	id: string;
+	label: string;
+	scope: LocalUsageScope;
+	window?: LocalUsageWindow;
+	amount: LocalUsageAmount;
+	status?: "ok" | "warning" | "exhausted" | "unknown";
+}
+
+export interface LocalResetCreditDetail {
+	expiresAt?: string;
+}
+
+export interface LocalUsageReport {
+	provider: string;
+	fetchedAt: number;
+	limits: LocalUsageLimit[];
+	resetCredits?: { availableCount: number; credits?: LocalResetCreditDetail[] };
+	metadata?: Record<string, unknown>;
+}
+
+export interface LocalActiveIdentity {
+	email?: string;
+	accountId?: string;
+	projectId?: string;
+	orgId?: string;
+}
+
+export function resolveUsedFraction(limit: LocalUsageLimit): number | undefined {
+	const amount = limit.amount;
+	if (amount.usedFraction !== undefined) return amount.usedFraction;
+	if (amount.used !== undefined && amount.limit !== undefined && amount.limit > 0) {
+		return amount.used / amount.limit;
+	}
+	if (amount.unit === "percent" && amount.used !== undefined) return amount.used / 100;
+	if (amount.remainingFraction !== undefined) return Math.max(0, 1 - amount.remainingFraction);
+	return undefined;
+}
+
+export interface QuotaWindowRow {
+	id: string;
+	label: string;
+	health: HealthInfo;
+	remainingFraction?: number;
+	usedText?: string;
+	resetCountdown?: string;
+}
+
+export interface QuotaPoolGroup {
+	id: string;
+	/** undefined => flat under account */
+	label?: string;
+	rows: QuotaWindowRow[];
+}
+
+export interface QuotaAccountGroup {
+	id: string;
+	label: string;
+	cleanOrgName?: string;
+	planBadge?: string;
+	isActive: boolean;
+	savedResets?: { count: number; detailLines: string[] };
+	pools: QuotaPoolGroup[];
+	noLimits: boolean;
+	healthSummary: {
+		exhaustedCount: number;
+		criticalCount: number;
+		lowCount: number;
+		healthyCount: number;
+		unknownCount: number;
+		summaryText: string;
+		hasIssues: boolean;
+	};
+}
+
+export interface QuotaProviderGroup {
+	provider: string;
+	label: string;
+	accounts: QuotaAccountGroup[];
+}
+
+export interface AttentionItem {
+	providerLabel: string;
+	accountLabel: string;
+	poolLabel?: string;
+	windowLabel: string;
+	health: HealthInfo;
+	remainingFraction?: number;
+	resetCountdown?: string;
+}
+
+export interface QuotaDashboardModel {
+	providers: QuotaProviderGroup[];
+	refreshedAt: number;
+	summary: {
+		healthyCount: number;
+		lowCount: number;
+		criticalCount: number;
+		exhaustedCount: number;
+		unknownCount: number;
+		totalCount: number;
+		allHealthy: boolean;
+	};
+	attentionItems: AttentionItem[];
+}
+
+const ANTIGRAVITY_PROVIDER = "google-antigravity";
+
+const KNOWN_COUNTER_LABELS: Record<string, string> = {
+	google: "Google",
+	anthropic: "Anthropic",
+	openai: "OpenAI",
+};
+
+function titleCase(s: string): string {
+	return s.replace(/(^|[\s-])([a-z])/g, (_, sep, ch) => `${sep}${ch.toUpperCase()}`);
+}
+
+const KNOWN_PROVIDER_WORDS: Record<string, string> = {
+	openai: "OpenAI",
+};
+
+export function formatProviderName(provider: string): string {
+	return provider
+		.split(/[-_]/)
+		.filter(part => part.length > 0)
+		.map(part => KNOWN_PROVIDER_WORDS[part.toLowerCase()] ?? part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+function derivePoolLabel(provider: string, limit: LocalUsageLimit): string | undefined {
+	if (provider !== ANTIGRAVITY_PROVIDER) return undefined;
+	const parts = limit.id.split(":");
+	if (parts.length >= 4 && parts[0] === provider && parts[1] && parts[1] !== "default") {
+		return KNOWN_COUNTER_LABELS[parts[1].toLowerCase()] ?? titleCase(parts[1]);
+	}
+	const match = /^Usage \(([^)]+)\)$/.exec(limit.label);
+	if (match) return match[1];
+	return "Other";
+}
+
+function isNeutral(limit: LocalUsageLimit): boolean {
+	const amount = limit.amount;
+	return (
+		amount.used !== undefined &&
+		amount.unit !== "percent" &&
+		amount.unit !== "unknown" &&
+		amount.limit === undefined &&
+		amount.remaining === undefined &&
+		resolveUsedFraction(limit) === undefined
+	);
+}
+
+function buildRowLabel(limit: LocalUsageLimit, underPool: boolean): string {
+	let base = underPool ? (limit.window?.label ?? limit.scope.windowId ?? limit.label) : limit.label;
+	const tier = limit.scope.tier;
+	if (tier && !base.toLowerCase().includes(tier.toLowerCase())) {
+		base = `${base} (${tier})`;
+	}
+	return base;
+}
+
+export function buildWindowRow(limit: LocalUsageLimit, nowMs: number, underPool: boolean): QuotaWindowRow {
+	const label = buildRowLabel(limit, underPool);
+
+	if (isNeutral(limit)) {
+		const amount = limit.amount;
+		const usedText =
+			amount.unit === "usd" ? `$${amount.used!.toFixed(2)} used` : `${amount.used} ${amount.unit} used`;
+		return {
+			id: limit.id,
+			label,
+			health: { status: "neutral", symbol: "", color: "dim", label: "neutral" },
+			usedText,
+		};
+	}
+
+	const usedFraction = resolveUsedFraction(limit);
+	const rawRemaining =
+		limit.amount.remainingFraction ?? (usedFraction !== undefined ? Math.max(0, 1 - usedFraction) : undefined);
+
+	const resetsAt = limit.window?.resetsAt;
+	const resetCountdown = resetsAt !== undefined && resetsAt > nowMs ? formatDuration(resetsAt - nowMs) : undefined;
+
+	const isExhaustedFlag = limit.status === "exhausted";
+	const health = classifyHealth(rawRemaining, isExhaustedFlag);
+
+	return {
+		id: limit.id,
+		label,
+		health,
+		remainingFraction: rawRemaining !== undefined ? Math.min(Math.max(rawRemaining, 0), 1) : undefined,
+		resetCountdown,
+	};
+}
+
+/**
+ * Clean up redundant organization names.
+ * e.g. "kareem.jalal@jethur.com's Organization" -> "Organization"
+ * Returns undefined if the org is entirely identical to the email/account ID.
+ */
+export function cleanOrgName(rawOrg: string | undefined, emailOrAccount: string | undefined): string | undefined {
+	if (!rawOrg) return undefined;
+	const trimmed = rawOrg.trim();
+	if (!trimmed) return undefined;
+
+	if (emailOrAccount) {
+		const cleanAccount = emailOrAccount.trim().toLowerCase();
+		const cleanRaw = trimmed.toLowerCase();
+		if (cleanRaw === cleanAccount) return undefined;
+
+		const aposIdx = cleanRaw.lastIndexOf("'s ");
+		if (aposIdx > 0) {
+			const prefix = cleanRaw.slice(0, aposIdx).trim();
+			const orgType = trimmed.slice(aposIdx + 3).trim();
+			const userPart = cleanAccount.split("@")[0]!;
+			if (prefix === cleanAccount || prefix === userPart) {
+				return titleCase(orgType);
+			}
+		}
+	}
+
+	return trimmed;
+}
+
+export function buildAccountLabel(report: LocalUsageReport, indexWithinProvider: number): string {
+	const metadata = report.metadata ?? {};
+	const email = typeof metadata.email === "string" && metadata.email ? metadata.email : undefined;
+	const accountId = typeof metadata.accountId === "string" && metadata.accountId ? metadata.accountId : undefined;
+	const projectId = typeof metadata.projectId === "string" && metadata.projectId ? metadata.projectId : undefined;
+
+	return email ?? accountId ?? projectId ?? `account ${indexWithinProvider + 1}`;
+}
+
+export function extractPlanBadge(report: LocalUsageReport): string | undefined {
+	const metadata = report.metadata ?? {};
+	const planType = typeof metadata.planType === "string" && metadata.planType ? metadata.planType : undefined;
+	if (planType && planType.toLowerCase() !== "default") {
+		return planType.toUpperCase();
+	}
+	return undefined;
+}
+
+export function isActiveAccount(report: LocalUsageReport, identity: LocalActiveIdentity | undefined): boolean {
+	if (!identity) return false;
+	const metadata = report.metadata ?? {};
+	const metaEmail = typeof metadata.email === "string" ? metadata.email.toLowerCase() : undefined;
+	const metaAccountId = typeof metadata.accountId === "string" ? metadata.accountId.toLowerCase() : undefined;
+	const metaProjectId = typeof metadata.projectId === "string" ? metadata.projectId.toLowerCase() : undefined;
+	const metaOrgId = typeof metadata.orgId === "string" ? metadata.orgId.toLowerCase() : undefined;
+
+	const idEmail = typeof identity.email === "string" ? identity.email.toLowerCase() : undefined;
+	const idAccountId = typeof identity.accountId === "string" ? identity.accountId.toLowerCase() : undefined;
+	const idProjectId = typeof identity.projectId === "string" ? identity.projectId.toLowerCase() : undefined;
+	const idOrgId = typeof identity.orgId === "string" ? identity.orgId.toLowerCase() : undefined;
+
+	if (idOrgId !== undefined && metaOrgId !== undefined && idOrgId !== metaOrgId) {
+		return false;
+	}
+
+	if (idEmail !== undefined && metaEmail !== undefined && idEmail === metaEmail) return true;
+	if (idAccountId !== undefined && metaAccountId !== undefined && idAccountId === metaAccountId) return true;
+	if (idProjectId !== undefined && metaProjectId !== undefined && idProjectId === metaProjectId) return true;
+	return false;
+}
+
+export function buildSavedResets(
+	report: LocalUsageReport,
+	nowMs: number,
+): { count: number; detailLines: string[] } | undefined {
+	const resetCredits = report.resetCredits;
+	if (!resetCredits || resetCredits.availableCount <= 0) return undefined;
+
+	const detailLines: string[] = [];
+	for (const credit of resetCredits.credits ?? []) {
+		const expiresAt = credit.expiresAt;
+		if (!expiresAt) continue;
+		const expiryMs = new Date(expiresAt).getTime();
+		if (Number.isFinite(expiryMs) && expiryMs > nowMs) {
+			detailLines.push(`expires in ${formatDuration(expiryMs - nowMs)} (${expiresAt.slice(0, 10)})`);
+		} else {
+			detailLines.push(`expired (${expiresAt.slice(0, 10)})`);
+		}
+	}
+
+	return { count: resetCredits.availableCount, detailLines };
+}
+
+export function buildPools(provider: string, report: LocalUsageReport, nowMs: number): QuotaPoolGroup[] {
+	const limits = report.limits;
+	const poolLabels = limits.map(limit => derivePoolLabel(provider, limit));
+	const anyPooled = poolLabels.some(label => label !== undefined);
+
+	if (!anyPooled) {
+		return [
+			{
+				id: `${provider}:flat`,
+				label: undefined,
+				rows: limits.map(limit => buildWindowRow(limit, nowMs, false)),
+			},
+		];
+	}
+
+	const order: string[] = [];
+	const buckets = new Map<string, LocalUsageLimit[]>();
+	for (let i = 0; i < limits.length; i++) {
+		const label = poolLabels[i] ?? "Other";
+		let bucket = buckets.get(label);
+		if (!bucket) {
+			bucket = [];
+			buckets.set(label, bucket);
+			order.push(label);
+		}
+		bucket.push(limits[i]!);
+	}
+
+	return order.map(label => ({
+		id: `${provider}:${label.toLowerCase()}`,
+		label,
+		rows: buckets.get(label)!.map(limit => buildWindowRow(limit, nowMs, true)),
+	}));
+}
+
+export function buildQuotaDashboardModel(
+	reports: LocalUsageReport[],
+	nowMs: number,
+	activeIdentityByProvider: Map<string, LocalActiveIdentity>,
+): QuotaDashboardModel {
+	const byProvider = new Map<string, LocalUsageReport[]>();
+	let latestFetchedAt = nowMs;
+
+	for (const report of reports) {
+		if (report.fetchedAt && report.fetchedAt > 0) {
+			latestFetchedAt = Math.max(latestFetchedAt, report.fetchedAt);
+		}
+		let bucket = byProvider.get(report.provider);
+		if (!bucket) {
+			bucket = [];
+			byProvider.set(report.provider, bucket);
+		}
+		bucket.push(report);
+	}
+
+	const providersSorted = Array.from(byProvider.keys()).sort((a, b) => a.localeCompare(b));
+
+	let totalHealthy = 0;
+	let totalLow = 0;
+	let totalCritical = 0;
+	let totalExhausted = 0;
+	let totalUnknown = 0;
+	let totalCount = 0;
+
+	const attentionItems: AttentionItem[] = [];
+
+	const providers: QuotaProviderGroup[] = providersSorted.map(provider => {
+		const providerReports = byProvider.get(provider)!;
+		const providerLabel = formatProviderName(provider);
+		const identity = activeIdentityByProvider.get(provider);
+
+		const accounts: QuotaAccountGroup[] = providerReports.map((report, index) => {
+			const accountLabel = buildAccountLabel(report, index);
+			const metadata = report.metadata ?? {};
+			const rawOrg =
+				typeof metadata.orgName === "string"
+					? metadata.orgName
+					: typeof metadata.orgId === "string"
+						? metadata.orgId
+						: undefined;
+			const cleanOrg = cleanOrgName(rawOrg, accountLabel);
+			const planBadge = extractPlanBadge(report);
+			const noLimits = report.limits.length === 0;
+
+			const pools = noLimits ? [] : buildPools(provider, report, nowMs);
+
+			let exhaustedCount = 0;
+			let criticalCount = 0;
+			let lowCount = 0;
+			let healthyCount = 0;
+			let unknownCount = 0;
+
+			for (const pool of pools) {
+				for (const row of pool.rows) {
+					if (row.health.status === "neutral") continue;
+					totalCount++;
+					switch (row.health.status) {
+						case "exhausted":
+							exhaustedCount++;
+							totalExhausted++;
+							attentionItems.push({
+								providerLabel,
+								accountLabel,
+								poolLabel: pool.label,
+								windowLabel: row.label,
+								health: row.health,
+								remainingFraction: row.remainingFraction,
+								resetCountdown: row.resetCountdown,
+							});
+							break;
+						case "critical":
+							criticalCount++;
+							totalCritical++;
+							attentionItems.push({
+								providerLabel,
+								accountLabel,
+								poolLabel: pool.label,
+								windowLabel: row.label,
+								health: row.health,
+								remainingFraction: row.remainingFraction,
+								resetCountdown: row.resetCountdown,
+							});
+							break;
+						case "low":
+							lowCount++;
+							totalLow++;
+							attentionItems.push({
+								providerLabel,
+								accountLabel,
+								poolLabel: pool.label,
+								windowLabel: row.label,
+								health: row.health,
+								remainingFraction: row.remainingFraction,
+								resetCountdown: row.resetCountdown,
+							});
+							break;
+						case "healthy":
+							healthyCount++;
+							totalHealthy++;
+							break;
+						case "unknown":
+							unknownCount++;
+							totalUnknown++;
+							break;
+					}
+				}
+			}
+
+			const hasIssues = exhaustedCount > 0 || criticalCount > 0 || lowCount > 0;
+			let summaryText = "all healthy";
+			if (exhaustedCount > 0) {
+				summaryText = `${exhaustedCount} exhausted`;
+			} else if (criticalCount > 0) {
+				summaryText = `${criticalCount} critical`;
+			} else if (lowCount > 0) {
+				summaryText = `${lowCount} low`;
+			} else if (unknownCount > 0 && healthyCount === 0) {
+				summaryText = "unknown";
+			} else if (noLimits) {
+				summaryText = "no limits";
+			}
+
+			return {
+				id: `${provider}:${accountLabel}`,
+				label: accountLabel,
+				cleanOrgName: cleanOrg,
+				planBadge,
+				isActive: isActiveAccount(report, identity),
+				savedResets: buildSavedResets(report, nowMs),
+				pools,
+				noLimits,
+				healthSummary: {
+					exhaustedCount,
+					criticalCount,
+					lowCount,
+					healthyCount,
+					unknownCount,
+					summaryText,
+					hasIssues,
+				},
+			};
+		});
+
+		return {
+			provider,
+			label: providerLabel,
+			accounts,
+		};
+	});
+
+	return {
+		providers,
+		refreshedAt: latestFetchedAt,
+		summary: {
+			healthyCount: totalHealthy,
+			lowCount: totalLow,
+			criticalCount: totalCritical,
+			exhaustedCount: totalExhausted,
+			unknownCount: totalUnknown,
+			totalCount,
+			allHealthy: totalCount > 0 && totalLow === 0 && totalCritical === 0 && totalExhausted === 0,
+		},
+		attentionItems,
+	};
+}
+
+// Backwards compatibility re-export
+export { buildQuotaDashboardModel as buildQuotaHierarchy };

--- a/packages/coding-agent/examples/extensions/quota/src/keys.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/keys.ts
@@ -1,0 +1,57 @@
+// Portable key event matching for interactive TUI components.
+// Zero external dependencies so it runs identically under `bun test` and inside OMP.
+
+export type ActionKey =
+	| "up"
+	| "down"
+	| "enter"
+	| "escape"
+	| "close"
+	| "toggle_attention"
+	| "toggle_healthy"
+	| "refresh"
+	| "page_up"
+	| "page_down"
+	| "home"
+	| "end"
+	| "unknown";
+
+export function matchActionKey(data: string): ActionKey {
+	if (data === "\x03" || data === "q" || data === "Q") {
+		return "close";
+	}
+	if (data === "\x1b" || data === "\x1b\x1b") {
+		return "escape";
+	}
+	if (data === "\x0d" || data === "\x0a" || data === "\x1bOM") {
+		return "enter";
+	}
+	if (data === "\x1b[A" || data === "\x1bOA" || data === "k") {
+		return "up";
+	}
+	if (data === "\x1b[B" || data === "\x1bOB" || data === "j") {
+		return "down";
+	}
+	if (data === "a" || data === "A") {
+		return "toggle_attention";
+	}
+	if (data === "h" || data === "H") {
+		return "toggle_healthy";
+	}
+	if (data === "r" || data === "R") {
+		return "refresh";
+	}
+	if (data === "\x1b[5~") {
+		return "page_up";
+	}
+	if (data === "\x1b[6~") {
+		return "page_down";
+	}
+	if (data === "\x1b[H" || data === "\x1b[1~") {
+		return "home";
+	}
+	if (data === "\x1b[F" || data === "\x1b[4~") {
+		return "end";
+	}
+	return "unknown";
+}

--- a/packages/coding-agent/examples/extensions/quota/src/render-dashboard.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/render-dashboard.ts
@@ -1,12 +1,11 @@
-// Theme-aware TUI dashboard renderer for /quota.
-// Implements full semantic coloring, attention section, collapsible hierarchy, and responsive layout.
-
 import {
 	formatDuration,
 	formatPercent,
 	type MinimalTheme,
 	padEndVisible,
 	renderRemainingBarStyled,
+	replaceTabs,
+	sanitizeText,
 	visibleWidth,
 } from "./format";
 import type {
@@ -32,7 +31,7 @@ export type SelectableKind = "account" | "pool";
 export interface SelectableTarget {
 	index: number;
 	kind: SelectableKind;
-	id: string; // account.id or pool.id
+	id: string;
 }
 
 const DEFAULT_WIDTH = 80;
@@ -95,7 +94,6 @@ function renderHeader(
 	const spaceBetween = Math.max(2, width - titleLen - timeLen);
 	lines.push(`${title}${" ".repeat(spaceBetween)}${timeFormatted}`);
 
-	// Summary counts line
 	const { healthyCount, lowCount, criticalCount, exhaustedCount, allHealthy } = model.summary;
 	if (allHealthy) {
 		lines.push(theme.fg("success", "✓ All reported quotas healthy"));
@@ -119,7 +117,8 @@ function renderHeader(
 	if (viewState.isRefreshing) {
 		lines.push(theme.fg("accent", "↻ Refreshing quota data…"));
 	} else if (viewState.refreshError) {
-		lines.push(theme.fg("error", `Refresh failed: ${viewState.refreshError}`));
+		const sanitizedError = sanitizeText(replaceTabs(viewState.refreshError));
+		lines.push(theme.fg("error", `Refresh failed: ${sanitizedError}`));
 	}
 
 	if (viewState.attentionOnly) {
@@ -141,36 +140,43 @@ function renderAttentionSection(items: AttentionItem[], theme: MinimalTheme, wid
 
 	for (const item of items) {
 		const symbolStr = theme.fg(item.health.color, item.health.symbol);
-		const itemPath = `${item.providerLabel} · ${item.accountLabel}${item.poolLabel ? ` · ${item.poolLabel}` : ""} · ${item.windowLabel}`;
+		const sanitizedProvider = sanitizeText(replaceTabs(item.providerLabel));
+		const sanitizedAccount = sanitizeText(replaceTabs(item.accountLabel));
+		const sanitizedPool = item.poolLabel ? ` · ${sanitizeText(replaceTabs(item.poolLabel))}` : "";
+		const sanitizedWindow = sanitizeText(replaceTabs(item.windowLabel));
+		const itemPath = `${sanitizedProvider} · ${sanitizedAccount}${sanitizedPool} · ${sanitizedWindow}`;
 		lines.push(`${symbolStr} ${theme.fg("text", itemPath)}`);
 
 		const pctStr = item.remainingFraction !== undefined ? formatPercent(item.remainingFraction) : "0%";
 		const pctStyled = theme.fg(item.health.color, padEndVisible(pctStr, 6));
 		const resetStr = item.resetCountdown ? theme.fg("dim", `↻ ${item.resetCountdown}`) : "";
 
-		lines.push(`  ${pctStyled}                                        ${resetStr}`.trimEnd());
+		const detailLine = `  ${pctStyled}                                        ${resetStr}`.trimEnd();
+		lines.push(detailLine);
 		lines.push("");
 	}
 
 	return lines;
 }
 
-function renderWindowRow(
+function renderWindowRows(
 	row: QuotaWindowRow,
 	theme: MinimalTheme,
 	indent: string,
 	labelColWidth: number,
 	isNarrow: boolean,
-): string {
-	const label = padEndVisible(row.label, labelColWidth);
+): string[] {
+	const sanitizedLabel = sanitizeText(replaceTabs(row.label));
+	const paddedLabel = padEndVisible(sanitizedLabel, labelColWidth);
 
 	if (row.health.status === "neutral") {
-		return `${indent}${label}  ${theme.fg("dim", row.usedText ?? "")}`;
+		const usedText = row.usedText ? sanitizeText(replaceTabs(row.usedText)) : "";
+		return [`${indent}${paddedLabel}  ${theme.fg("dim", usedText)}`];
 	}
 
 	if (row.health.status === "unknown") {
 		const bar = renderRemainingBarStyled(undefined, row.health, theme);
-		return `${indent}${label}  ${bar}   ?   ${theme.fg("muted", "unknown")}`;
+		return [`${indent}${paddedLabel}  ${bar}   ?   ${theme.fg("muted", "unknown")}`];
 	}
 
 	const bar = renderRemainingBarStyled(row.remainingFraction, row.health, theme);
@@ -179,11 +185,10 @@ function renderWindowRow(
 	const resetStr = row.resetCountdown ? `   ${theme.fg("dim", `↻ ${row.resetCountdown}`)}` : "";
 
 	if (isNarrow) {
-		// Narrow layout: label on top, bar below
-		return `${indent}${row.label}\n${indent}  ${bar}  ${pctStr}  ${symbol}${resetStr}`;
+		return [`${indent}${sanitizedLabel}`, `${indent}  ${bar}  ${pctStr}  ${symbol}${resetStr}`];
 	}
 
-	return `${indent}${label}  ${bar}  ${pctStr}   ${symbol}${resetStr}`;
+	return [`${indent}${paddedLabel}  ${bar}  ${pctStr}   ${symbol}${resetStr}`];
 }
 
 function renderAccountBlock(
@@ -203,18 +208,19 @@ function renderAccountBlock(
 	const cursor = isSelected ? theme.fg("accent", "❯ ") : "  ";
 	const disclosure = isCollapsed ? theme.fg("dim", "▸ ") : theme.fg("dim", "▾ ");
 
-	let accountLabel = account.label;
+	const sanitizedAccountLabel = sanitizeText(replaceTabs(account.label));
+	let styledAccountLabel = "";
 	if (account.isActive) {
-		accountLabel = `${theme.fg("accent", "● ")}${theme.bold(account.label)}`;
+		styledAccountLabel = `${theme.fg("accent", "● ")}${theme.bold(sanitizedAccountLabel)}`;
 	} else {
-		accountLabel = theme.bold(account.label);
+		styledAccountLabel = theme.bold(sanitizedAccountLabel);
 	}
 
 	let rightTag = "";
 	if (account.isActive) {
 		rightTag = theme.fg("accent", theme.bold("ACTIVE"));
 	} else if (account.planBadge) {
-		rightTag = theme.fg("muted", account.planBadge);
+		rightTag = theme.fg("muted", sanitizeText(replaceTabs(account.planBadge)));
 	}
 
 	if (isCollapsed) {
@@ -230,7 +236,7 @@ function renderAccountBlock(
 		rightTag = rightTag ? `${rightTag}   ${summaryStyled}` : summaryStyled;
 	}
 
-	const leftPart = `${cursor}${disclosure}${accountLabel}`;
+	const leftPart = `${cursor}${disclosure}${styledAccountLabel}`;
 	const leftW = visibleWidth(leftPart);
 	const rightW = visibleWidth(rightTag);
 	const gap = Math.max(2, width - leftW - rightW);
@@ -238,7 +244,8 @@ function renderAccountBlock(
 	lines.push(`${leftPart}${" ".repeat(gap)}${rightTag}`.trimEnd());
 
 	if (account.cleanOrgName) {
-		lines.push(`    ${theme.fg("muted", account.cleanOrgName)}`);
+		const sanitizedOrg = sanitizeText(replaceTabs(account.cleanOrgName));
+		lines.push(`    ${theme.fg("muted", sanitizedOrg)}`);
 	}
 
 	if (isCollapsed) {
@@ -267,7 +274,8 @@ function renderAccountBlock(
 		if (pool.label !== undefined) {
 			const poolCursor = isPoolSelected ? theme.fg("accent", "❯ ") : "  ";
 			const poolDisclosure = isPoolCollapsed ? theme.fg("dim", "▸ ") : theme.fg("dim", "▾ ");
-			lines.push(`  ${poolCursor}${poolDisclosure}${theme.fg("text", theme.bold(pool.label))}`);
+			const sanitizedPoolLabel = sanitizeText(replaceTabs(pool.label));
+			lines.push(`  ${poolCursor}${poolDisclosure}${theme.fg("text", theme.bold(sanitizedPoolLabel))}`);
 		}
 
 		if (isPoolCollapsed && pool.label !== undefined) {
@@ -276,7 +284,7 @@ function renderAccountBlock(
 
 		const rowIndent = pool.label !== undefined ? "      " : "    ";
 		for (const row of visibleRows) {
-			lines.push(renderWindowRow(row, theme, rowIndent, labelColWidth, isNarrow));
+			lines.push(...renderWindowRows(row, theme, rowIndent, labelColWidth, isNarrow));
 		}
 	}
 
@@ -286,7 +294,8 @@ function renderAccountBlock(
 			`    ${theme.fg("accent", "✦")} ${theme.fg("dim", `${count} saved rate-limit reset${count === 1 ? "" : "s"} available`)}`,
 		);
 		for (const detail of detailLines) {
-			lines.push(`        ${theme.fg("dim", detail)}`);
+			const sanitizedDetail = sanitizeText(replaceTabs(detail));
+			lines.push(`        ${theme.fg("dim", sanitizedDetail)}`);
 		}
 	}
 
@@ -308,11 +317,12 @@ function renderProviderSection(
 		if (visibleAccounts.length === 0) return [];
 	}
 
-	const titleLeft = theme.bold(theme.fg("accent", provider.label.toUpperCase()));
+	const sanitizedProviderLabel = sanitizeText(replaceTabs(provider.label.toUpperCase()));
+	const titleLeft = theme.bold(theme.fg("accent", sanitizedProviderLabel));
 	const acctCountStr = `${provider.accounts.length} ${provider.accounts.length === 1 ? "account" : "accounts"}`;
 	const acctCountStyled = theme.fg("muted", acctCountStr);
 
-	const leftW = visibleWidth(provider.label.toUpperCase());
+	const leftW = visibleWidth(sanitizedProviderLabel);
 	const rightW = visibleWidth(acctCountStr);
 	const gap = Math.max(2, width - leftW - rightW);
 
@@ -337,20 +347,17 @@ export function renderDashboard(
 	theme: MinimalTheme,
 	width = DEFAULT_WIDTH,
 ): string[] {
-	const safeWidth = Math.max(40, width);
+	const safeWidth = width;
 	const selectables = collectSelectables(model, viewState);
 
 	const lines: string[] = [];
 
-	// Header
 	lines.push(...renderHeader(model, viewState, theme, safeWidth));
 
-	// Attention Section (only if not empty)
 	if (!viewState.attentionOnly) {
 		lines.push(...renderAttentionSection(model.attentionItems, theme, safeWidth));
 	}
 
-	// Provider Sections
 	for (const provider of model.providers) {
 		const providerLines = renderProviderSection(provider, viewState, selectables, theme, safeWidth);
 		if (providerLines.length > 0) {
@@ -359,7 +366,6 @@ export function renderDashboard(
 		}
 	}
 
-	// Footer
 	lines.push("");
 	lines.push(renderFooter(theme));
 

--- a/packages/coding-agent/examples/extensions/quota/src/render-dashboard.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/render-dashboard.ts
@@ -1,0 +1,367 @@
+// Theme-aware TUI dashboard renderer for /quota.
+// Implements full semantic coloring, attention section, collapsible hierarchy, and responsive layout.
+
+import {
+	formatDuration,
+	formatPercent,
+	type MinimalTheme,
+	padEndVisible,
+	renderRemainingBarStyled,
+	visibleWidth,
+} from "./format";
+import type {
+	AttentionItem,
+	QuotaAccountGroup,
+	QuotaDashboardModel,
+	QuotaProviderGroup,
+	QuotaWindowRow,
+} from "./hierarchy";
+
+export interface DashboardViewState {
+	selectedIndex: number;
+	collapsedAccounts: Set<string>;
+	collapsedPools: Set<string>;
+	attentionOnly: boolean;
+	hideHealthy: boolean;
+	isRefreshing?: boolean;
+	refreshError?: string;
+}
+
+export type SelectableKind = "account" | "pool";
+
+export interface SelectableTarget {
+	index: number;
+	kind: SelectableKind;
+	id: string; // account.id or pool.id
+}
+
+const DEFAULT_WIDTH = 80;
+const MIN_LABEL_WIDTH = 12;
+const MAX_LABEL_WIDTH = 22;
+
+export function collectSelectables(model: QuotaDashboardModel, viewState: DashboardViewState): SelectableTarget[] {
+	const items: SelectableTarget[] = [];
+	let currentIndex = 0;
+
+	for (const provider of model.providers) {
+		for (const account of provider.accounts) {
+			if (viewState.attentionOnly && !account.healthSummary.hasIssues) {
+				continue;
+			}
+			items.push({
+				index: currentIndex++,
+				kind: "account",
+				id: account.id,
+			});
+
+			const isAccountCollapsed = viewState.collapsedAccounts.has(account.id);
+			if (!isAccountCollapsed && !account.noLimits) {
+				for (const pool of account.pools) {
+					if (viewState.hideHealthy) {
+						const hasVisibleRows = pool.rows.some(r => r.health.status !== "healthy");
+						if (!hasVisibleRows) continue;
+					}
+					if (pool.label !== undefined) {
+						items.push({
+							index: currentIndex++,
+							kind: "pool",
+							id: `${account.id}#${pool.id}`,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	return items;
+}
+
+function renderHeader(
+	model: QuotaDashboardModel,
+	viewState: DashboardViewState,
+	theme: MinimalTheme,
+	width: number,
+): string[] {
+	const lines: string[] = [];
+
+	const title = theme.bold(theme.fg("accent", "QUOTA"));
+	const now = Date.now();
+	const ageMs = Math.max(0, now - model.refreshedAt);
+	const timeStr = ageMs < 5000 ? "refreshed now" : `refreshed ${formatDuration(ageMs)} ago`;
+	const timeFormatted = theme.fg("dim", timeStr);
+
+	const titleLen = visibleWidth("QUOTA");
+	const timeLen = visibleWidth(timeStr);
+	const spaceBetween = Math.max(2, width - titleLen - timeLen);
+	lines.push(`${title}${" ".repeat(spaceBetween)}${timeFormatted}`);
+
+	// Summary counts line
+	const { healthyCount, lowCount, criticalCount, exhaustedCount, allHealthy } = model.summary;
+	if (allHealthy) {
+		lines.push(theme.fg("success", "✓ All reported quotas healthy"));
+	} else {
+		const parts: string[] = [];
+		if (healthyCount > 0) {
+			parts.push(theme.fg("success", `✓ ${healthyCount} healthy`));
+		}
+		if (lowCount > 0) {
+			parts.push(theme.fg("warning", `⚠ ${lowCount} low`));
+		}
+		if (criticalCount > 0) {
+			parts.push(theme.fg("error", `! ${criticalCount} critical`));
+		}
+		if (exhaustedCount > 0) {
+			parts.push(theme.fg("error", `✕ ${exhaustedCount} exhausted`));
+		}
+		lines.push(parts.join("   "));
+	}
+
+	if (viewState.isRefreshing) {
+		lines.push(theme.fg("accent", "↻ Refreshing quota data…"));
+	} else if (viewState.refreshError) {
+		lines.push(theme.fg("error", `Refresh failed: ${viewState.refreshError}`));
+	}
+
+	if (viewState.attentionOnly) {
+		lines.push(theme.fg("warning", theme.bold("[ATTENTION ONLY MODE — press 'a' to show all]")));
+	} else if (viewState.hideHealthy) {
+		lines.push(theme.fg("muted", "[HIDING HEALTHY — press 'h' to show]"));
+	}
+
+	return lines;
+}
+
+function renderAttentionSection(items: AttentionItem[], theme: MinimalTheme, width: number): string[] {
+	if (items.length === 0) return [];
+
+	const lines: string[] = [""];
+	lines.push(theme.bold(theme.fg("error", "ATTENTION")));
+	lines.push(theme.fg("dim", "─".repeat(Math.min(width, 50))));
+	lines.push("");
+
+	for (const item of items) {
+		const symbolStr = theme.fg(item.health.color, item.health.symbol);
+		const itemPath = `${item.providerLabel} · ${item.accountLabel}${item.poolLabel ? ` · ${item.poolLabel}` : ""} · ${item.windowLabel}`;
+		lines.push(`${symbolStr} ${theme.fg("text", itemPath)}`);
+
+		const pctStr = item.remainingFraction !== undefined ? formatPercent(item.remainingFraction) : "0%";
+		const pctStyled = theme.fg(item.health.color, padEndVisible(pctStr, 6));
+		const resetStr = item.resetCountdown ? theme.fg("dim", `↻ ${item.resetCountdown}`) : "";
+
+		lines.push(`  ${pctStyled}                                        ${resetStr}`.trimEnd());
+		lines.push("");
+	}
+
+	return lines;
+}
+
+function renderWindowRow(
+	row: QuotaWindowRow,
+	theme: MinimalTheme,
+	indent: string,
+	labelColWidth: number,
+	isNarrow: boolean,
+): string {
+	const label = padEndVisible(row.label, labelColWidth);
+
+	if (row.health.status === "neutral") {
+		return `${indent}${label}  ${theme.fg("dim", row.usedText ?? "")}`;
+	}
+
+	if (row.health.status === "unknown") {
+		const bar = renderRemainingBarStyled(undefined, row.health, theme);
+		return `${indent}${label}  ${bar}   ?   ${theme.fg("muted", "unknown")}`;
+	}
+
+	const bar = renderRemainingBarStyled(row.remainingFraction, row.health, theme);
+	const pctStr = row.remainingFraction !== undefined ? formatPercent(row.remainingFraction).padStart(4) : "  0%";
+	const symbol = theme.fg(row.health.color, row.health.symbol);
+	const resetStr = row.resetCountdown ? `   ${theme.fg("dim", `↻ ${row.resetCountdown}`)}` : "";
+
+	if (isNarrow) {
+		// Narrow layout: label on top, bar below
+		return `${indent}${row.label}\n${indent}  ${bar}  ${pctStr}  ${symbol}${resetStr}`;
+	}
+
+	return `${indent}${label}  ${bar}  ${pctStr}   ${symbol}${resetStr}`;
+}
+
+function renderAccountBlock(
+	account: QuotaAccountGroup,
+	_provider: QuotaProviderGroup,
+	viewState: DashboardViewState,
+	selectables: SelectableTarget[],
+	theme: MinimalTheme,
+	width: number,
+): string[] {
+	const lines: string[] = [];
+
+	const isCollapsed = viewState.collapsedAccounts.has(account.id);
+	const target = selectables.find(s => s.kind === "account" && s.id === account.id);
+	const isSelected = target !== undefined && target.index === viewState.selectedIndex;
+
+	const cursor = isSelected ? theme.fg("accent", "❯ ") : "  ";
+	const disclosure = isCollapsed ? theme.fg("dim", "▸ ") : theme.fg("dim", "▾ ");
+
+	let accountLabel = account.label;
+	if (account.isActive) {
+		accountLabel = `${theme.fg("accent", "● ")}${theme.bold(account.label)}`;
+	} else {
+		accountLabel = theme.bold(account.label);
+	}
+
+	let rightTag = "";
+	if (account.isActive) {
+		rightTag = theme.fg("accent", theme.bold("ACTIVE"));
+	} else if (account.planBadge) {
+		rightTag = theme.fg("muted", account.planBadge);
+	}
+
+	if (isCollapsed) {
+		const { exhaustedCount, criticalCount, lowCount, summaryText } = account.healthSummary;
+		let summaryStyled = theme.fg("success", "all healthy");
+		if (exhaustedCount > 0 || criticalCount > 0) {
+			summaryStyled = theme.fg("error", summaryText);
+		} else if (lowCount > 0) {
+			summaryStyled = theme.fg("warning", summaryText);
+		} else if (account.noLimits) {
+			summaryStyled = theme.fg("dim", "no limits");
+		}
+		rightTag = rightTag ? `${rightTag}   ${summaryStyled}` : summaryStyled;
+	}
+
+	const leftPart = `${cursor}${disclosure}${accountLabel}`;
+	const leftW = visibleWidth(leftPart);
+	const rightW = visibleWidth(rightTag);
+	const gap = Math.max(2, width - leftW - rightW);
+
+	lines.push(`${leftPart}${" ".repeat(gap)}${rightTag}`.trimEnd());
+
+	if (account.cleanOrgName) {
+		lines.push(`    ${theme.fg("muted", account.cleanOrgName)}`);
+	}
+
+	if (isCollapsed) {
+		return lines;
+	}
+
+	if (account.noLimits) {
+		lines.push(`    ${theme.fg("dim", "no limits reported")}`);
+		return lines;
+	}
+
+	const isNarrow = width < 60;
+	const labelColWidth = isNarrow
+		? MIN_LABEL_WIDTH
+		: Math.min(MAX_LABEL_WIDTH, Math.max(MIN_LABEL_WIDTH, Math.floor(width * 0.25)));
+
+	for (const pool of account.pools) {
+		const visibleRows = viewState.hideHealthy ? pool.rows.filter(r => r.health.status !== "healthy") : pool.rows;
+		if (visibleRows.length === 0) continue;
+
+		const poolKey = `${account.id}#${pool.id}`;
+		const isPoolCollapsed = viewState.collapsedPools.has(poolKey);
+		const poolTarget = selectables.find(s => s.kind === "pool" && s.id === poolKey);
+		const isPoolSelected = poolTarget !== undefined && poolTarget.index === viewState.selectedIndex;
+
+		if (pool.label !== undefined) {
+			const poolCursor = isPoolSelected ? theme.fg("accent", "❯ ") : "  ";
+			const poolDisclosure = isPoolCollapsed ? theme.fg("dim", "▸ ") : theme.fg("dim", "▾ ");
+			lines.push(`  ${poolCursor}${poolDisclosure}${theme.fg("text", theme.bold(pool.label))}`);
+		}
+
+		if (isPoolCollapsed && pool.label !== undefined) {
+			continue;
+		}
+
+		const rowIndent = pool.label !== undefined ? "      " : "    ";
+		for (const row of visibleRows) {
+			lines.push(renderWindowRow(row, theme, rowIndent, labelColWidth, isNarrow));
+		}
+	}
+
+	if (account.savedResets) {
+		const { count, detailLines } = account.savedResets;
+		lines.push(
+			`    ${theme.fg("accent", "✦")} ${theme.fg("dim", `${count} saved rate-limit reset${count === 1 ? "" : "s"} available`)}`,
+		);
+		for (const detail of detailLines) {
+			lines.push(`        ${theme.fg("dim", detail)}`);
+		}
+	}
+
+	return lines;
+}
+
+function renderProviderSection(
+	provider: QuotaProviderGroup,
+	viewState: DashboardViewState,
+	selectables: SelectableTarget[],
+	theme: MinimalTheme,
+	width: number,
+): string[] {
+	const lines: string[] = [];
+
+	let visibleAccounts = provider.accounts;
+	if (viewState.attentionOnly) {
+		visibleAccounts = provider.accounts.filter(a => a.healthSummary.hasIssues);
+		if (visibleAccounts.length === 0) return [];
+	}
+
+	const titleLeft = theme.bold(theme.fg("accent", provider.label.toUpperCase()));
+	const acctCountStr = `${provider.accounts.length} ${provider.accounts.length === 1 ? "account" : "accounts"}`;
+	const acctCountStyled = theme.fg("muted", acctCountStr);
+
+	const leftW = visibleWidth(provider.label.toUpperCase());
+	const rightW = visibleWidth(acctCountStr);
+	const gap = Math.max(2, width - leftW - rightW);
+
+	lines.push(`${titleLeft}${" ".repeat(gap)}${acctCountStyled}`);
+	lines.push(theme.fg("borderMuted", "─".repeat(Math.min(width, 52))));
+
+	for (let i = 0; i < visibleAccounts.length; i++) {
+		if (i > 0) lines.push("");
+		lines.push(...renderAccountBlock(visibleAccounts[i]!, provider, viewState, selectables, theme, width));
+	}
+
+	return lines;
+}
+
+function renderFooter(theme: MinimalTheme): string {
+	return theme.fg("dim", "↑↓ navigate   enter expand   a attention   h healthy   r refresh   q close");
+}
+
+export function renderDashboard(
+	model: QuotaDashboardModel,
+	viewState: DashboardViewState,
+	theme: MinimalTheme,
+	width = DEFAULT_WIDTH,
+): string[] {
+	const safeWidth = Math.max(40, width);
+	const selectables = collectSelectables(model, viewState);
+
+	const lines: string[] = [];
+
+	// Header
+	lines.push(...renderHeader(model, viewState, theme, safeWidth));
+
+	// Attention Section (only if not empty)
+	if (!viewState.attentionOnly) {
+		lines.push(...renderAttentionSection(model.attentionItems, theme, safeWidth));
+	}
+
+	// Provider Sections
+	for (const provider of model.providers) {
+		const providerLines = renderProviderSection(provider, viewState, selectables, theme, safeWidth);
+		if (providerLines.length > 0) {
+			lines.push("");
+			lines.push(...providerLines);
+		}
+	}
+
+	// Footer
+	lines.push("");
+	lines.push(renderFooter(theme));
+
+	return lines;
+}

--- a/packages/coding-agent/examples/extensions/quota/src/render-plain.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/render-plain.ts
@@ -1,0 +1,76 @@
+// Plain text renderer for /quota snapshot and headless fallback mode.
+// Zero external dependencies.
+
+import { formatPercent } from "./format";
+import type { QuotaAccountGroup, QuotaDashboardModel, QuotaProviderGroup, QuotaWindowRow } from "./hierarchy";
+
+function renderPlainRow(row: QuotaWindowRow): string {
+	if (row.health.status === "neutral") {
+		return `${row.label.padEnd(16)} ${row.usedText ?? ""}`;
+	}
+	if (row.health.status === "unknown") {
+		return `${row.label.padEnd(16)} ············   ?   unknown`;
+	}
+	const pctStr = row.remainingFraction !== undefined ? formatPercent(row.remainingFraction).padStart(4) : "  0%";
+	const resetStr = row.resetCountdown ? ` ↻${row.resetCountdown}` : "";
+	return `${row.label.padEnd(16)} ${pctStr} ${row.health.symbol}${resetStr}`;
+}
+
+function renderPlainAccount(account: QuotaAccountGroup): string[] {
+	const lines: string[] = [];
+
+	let header = account.isActive ? `● ${account.label}   ACTIVE` : account.label;
+	if (account.planBadge) {
+		header += `   ${account.planBadge}`;
+	}
+	lines.push(`  ${header}`);
+
+	if (account.cleanOrgName) {
+		lines.push(`    ${account.cleanOrgName}`);
+	}
+
+	if (account.noLimits) {
+		lines.push("    no limits reported");
+		return lines;
+	}
+
+	for (const pool of account.pools) {
+		if (pool.label !== undefined) {
+			lines.push(`    ${pool.label}`);
+			for (const row of pool.rows) {
+				lines.push(`      ${renderPlainRow(row)}`);
+			}
+		} else {
+			for (const row of pool.rows) {
+				lines.push(`    ${renderPlainRow(row)}`);
+			}
+		}
+	}
+
+	if (account.savedResets) {
+		const { count, detailLines } = account.savedResets;
+		lines.push(`    ✦ ${count} saved rate-limit reset${count === 1 ? "" : "s"} available`);
+		for (const detail of detailLines) {
+			lines.push(`        ${detail}`);
+		}
+	}
+
+	return lines;
+}
+
+function renderPlainProvider(provider: QuotaProviderGroup): string[] {
+	const lines: string[] = [provider.label];
+	for (const account of provider.accounts) {
+		lines.push(...renderPlainAccount(account));
+	}
+	return lines;
+}
+
+export function renderQuotaSnapshot(model: QuotaDashboardModel): string {
+	const lines: string[] = ["Quota", ""];
+	for (let i = 0; i < model.providers.length; i++) {
+		if (i > 0) lines.push("");
+		lines.push(...renderPlainProvider(model.providers[i]!));
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/examples/extensions/quota/src/render.ts
+++ b/packages/coding-agent/examples/extensions/quota/src/render.ts
@@ -1,0 +1,2 @@
+export * from "./render-plain";
+export { renderQuotaSnapshot as renderQuotaReport } from "./render-plain";

--- a/packages/coding-agent/examples/extensions/quota/tests/format.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/format.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import {
+	classifyHealth,
+	formatDuration,
+	formatPercent,
+	padEndVisible,
+	renderRemainingBarPlain,
+	renderRemainingBarStyled,
+	stripAnsi,
+	truncateVisible,
+	visibleWidth,
+} from "../src/format";
+
+const mockTheme = {
+	fg: (color: string, text: string) => `[fg:${color}]${text}[/fg]`,
+	bold: (text: string) => `[bold]${text}[/bold]`,
+};
+
+describe("format helpers", () => {
+	describe("classifyHealth", () => {
+		it("1. classifies 51-100% as healthy (✓, success)", () => {
+			const h100 = classifyHealth(1.0);
+			expect(h100.status).toBe("healthy");
+			expect(h100.symbol).toBe("✓");
+			expect(h100.color).toBe("success");
+
+			const h51 = classifyHealth(0.51);
+			expect(h51.status).toBe("healthy");
+			expect(h51.symbol).toBe("✓");
+			expect(h51.color).toBe("success");
+		});
+
+		it("2. classifies 21-50% as low (⚠, warning)", () => {
+			const h50 = classifyHealth(0.5);
+			expect(h50.status).toBe("low");
+			expect(h50.symbol).toBe("⚠");
+			expect(h50.color).toBe("warning");
+
+			const h21 = classifyHealth(0.21);
+			expect(h21.status).toBe("low");
+			expect(h21.symbol).toBe("⚠");
+		});
+
+		it("3. classifies 1-20% as critical (!, error)", () => {
+			const h20 = classifyHealth(0.2);
+			expect(h20.status).toBe("critical");
+			expect(h20.symbol).toBe("!");
+			expect(h20.color).toBe("error");
+
+			const h1 = classifyHealth(0.01);
+			expect(h1.status).toBe("critical");
+			expect(h1.symbol).toBe("!");
+			expect(h1.color).toBe("error");
+		});
+
+		it("4. classifies 0% as exhausted (✕, error)", () => {
+			const h0 = classifyHealth(0);
+			expect(h0.status).toBe("exhausted");
+			expect(h0.symbol).toBe("✕");
+			expect(h0.color).toBe("error");
+		});
+
+		it("4b. treats explicit isExhaustedFlag as exhausted even with positive fraction", () => {
+			const h = classifyHealth(0.15, true);
+			expect(h.status).toBe("exhausted");
+			expect(h.symbol).toBe("✕");
+			expect(h.color).toBe("error");
+		});
+
+		it("5. classifies undefined fraction as unknown (?, muted)", () => {
+			const h = classifyHealth(undefined);
+			expect(h.status).toBe("unknown");
+			expect(h.symbol).toBe("?");
+			expect(h.color).toBe("muted");
+		});
+	});
+
+	describe("renderRemainingBarPlain (12 cells)", () => {
+		it("14. renders 100%, partial, and 0% bars accurately", () => {
+			expect(renderRemainingBarPlain(1.0, 12)).toBe("████████████");
+			expect(renderRemainingBarPlain(0.93, 12)).toBe("███████████░");
+			expect(renderRemainingBarPlain(0.42, 12)).toBe("█████░░░░░░░");
+			expect(renderRemainingBarPlain(0.25, 12)).toBe("███░░░░░░░░░");
+			expect(renderRemainingBarPlain(0.12, 12)).toBe("█░░░░░░░░░░░");
+			expect(renderRemainingBarPlain(0, 12)).toBe("░░░░░░░░░░░░");
+			expect(renderRemainingBarPlain(undefined, 12)).toBe("············");
+		});
+	});
+
+	describe("renderRemainingBarStyled", () => {
+		it("styles filled portion with health color and empty portion with dim", () => {
+			const health = classifyHealth(0.5); // low => warning
+			const bar = renderRemainingBarStyled(0.5, health, mockTheme, 12);
+			expect(bar).toBe("[fg:warning]██████[/fg][fg:dim]░░░░░░[/fg]");
+		});
+
+		it("renders exhausted bar with all dim cells", () => {
+			const health = classifyHealth(0); // exhausted => error
+			const bar = renderRemainingBarStyled(0, health, mockTheme, 12);
+			expect(bar).toBe("[fg:dim]░░░░░░░░░░░░[/fg]");
+		});
+
+		it("renders unknown bar with all muted dots", () => {
+			const health = classifyHealth(undefined);
+			const bar = renderRemainingBarStyled(undefined, health, mockTheme, 12);
+			expect(bar).toBe("[fg:muted]············[/fg]");
+		});
+	});
+
+	describe("formatPercent", () => {
+		it("formats percentages with clean rounding", () => {
+			expect(formatPercent(1.0)).toBe("100%");
+			expect(formatPercent(0.93)).toBe("93%");
+			expect(formatPercent(0.29)).toBe("29%");
+			expect(formatPercent(0.667)).toBe("66.7%");
+			expect(formatPercent(0)).toBe("0%");
+		});
+	});
+
+	describe("formatDuration", () => {
+		it("13. formats countdown durations compactly", () => {
+			expect(formatDuration(45_000)).toBe("45s");
+			expect(formatDuration(32 * 60_000)).toBe("32m");
+			expect(formatDuration(4 * 3600_000)).toBe("4h");
+			expect(formatDuration(6 * 24 * 3600_000)).toBe("6d");
+		});
+	});
+
+	describe("visibleWidth and padding", () => {
+		it("measures visible width ignoring ANSI codes", () => {
+			const text = "[32mhello[0m";
+			expect(stripAnsi(text)).toBe("hello");
+			expect(visibleWidth(text)).toBe(5);
+		});
+
+		it("pads strings to target visual width", () => {
+			const padded = padEndVisible("[32mhi[0m", 6);
+			expect(visibleWidth(padded)).toBe(6);
+		});
+
+		it("truncates strings exceeding max visual width", () => {
+			expect(truncateVisible("LongAccountName@example.com", 10)).toBe("LongAccou…");
+		});
+	});
+});

--- a/packages/coding-agent/examples/extensions/quota/tests/format.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/format.test.ts
@@ -6,8 +6,6 @@ import {
 	padEndVisible,
 	renderRemainingBarPlain,
 	renderRemainingBarStyled,
-	stripAnsi,
-	truncateVisible,
 	visibleWidth,
 } from "../src/format";
 
@@ -51,6 +49,12 @@ describe("format helpers", () => {
 			expect(h1.status).toBe("critical");
 			expect(h1.symbol).toBe("!");
 			expect(h1.color).toBe("error");
+
+			// Sub-0.5% boundary: must be critical (!), not exhausted (✕)
+			const hSubHalf = classifyHealth(0.004);
+			expect(hSubHalf.status).toBe("critical");
+			expect(hSubHalf.symbol).toBe("!");
+			expect(hSubHalf.color).toBe("error");
 		});
 
 		it("4. classifies 0% as exhausted (✕, error)", () => {
@@ -89,13 +93,13 @@ describe("format helpers", () => {
 
 	describe("renderRemainingBarStyled", () => {
 		it("styles filled portion with health color and empty portion with dim", () => {
-			const health = classifyHealth(0.5); // low => warning
+			const health = classifyHealth(0.5);
 			const bar = renderRemainingBarStyled(0.5, health, mockTheme, 12);
 			expect(bar).toBe("[fg:warning]██████[/fg][fg:dim]░░░░░░[/fg]");
 		});
 
 		it("renders exhausted bar with all dim cells", () => {
-			const health = classifyHealth(0); // exhausted => error
+			const health = classifyHealth(0);
 			const bar = renderRemainingBarStyled(0, health, mockTheme, 12);
 			expect(bar).toBe("[fg:dim]░░░░░░░░░░░░[/fg]");
 		});
@@ -113,6 +117,7 @@ describe("format helpers", () => {
 			expect(formatPercent(0.93)).toBe("93%");
 			expect(formatPercent(0.29)).toBe("29%");
 			expect(formatPercent(0.667)).toBe("66.7%");
+			expect(formatPercent(0.004)).toBe("0.4%");
 			expect(formatPercent(0)).toBe("0%");
 		});
 	});
@@ -127,19 +132,9 @@ describe("format helpers", () => {
 	});
 
 	describe("visibleWidth and padding", () => {
-		it("measures visible width ignoring ANSI codes", () => {
-			const text = "[32mhello[0m";
-			expect(stripAnsi(text)).toBe("hello");
-			expect(visibleWidth(text)).toBe(5);
-		});
-
 		it("pads strings to target visual width", () => {
-			const padded = padEndVisible("[32mhi[0m", 6);
+			const padded = padEndVisible("\x1b[32mhi\x1b[0m", 6);
 			expect(visibleWidth(padded)).toBe(6);
-		});
-
-		it("truncates strings exceeding max visual width", () => {
-			expect(truncateVisible("LongAccountName@example.com", 10)).toBe("LongAccou…");
 		});
 	});
 });

--- a/packages/coding-agent/examples/extensions/quota/tests/hierarchy.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/hierarchy.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildQuotaDashboardModel,
+	cleanOrgName,
+	formatProviderName,
+	type LocalActiveIdentity,
+	type LocalUsageLimit,
+	type LocalUsageReport,
+} from "../src/hierarchy";
+
+const NOW = 1_700_000_000_000;
+
+function limit(overrides: Partial<LocalUsageLimit> = {}): LocalUsageLimit {
+	return {
+		id: "test:limit",
+		label: "7 Day",
+		scope: { provider: "test" },
+		amount: { unit: "percent", remainingFraction: 1.0 },
+		...overrides,
+	};
+}
+
+function report(overrides: Partial<LocalUsageReport> = {}): LocalUsageReport {
+	return {
+		provider: "test-provider",
+		fetchedAt: NOW,
+		limits: [limit()],
+		metadata: { email: "user@example.com" },
+		...overrides,
+	};
+}
+
+describe("hierarchy data model and grouping", () => {
+	describe("cleanOrgName", () => {
+		it("12. cleans redundant organization names without corrupting real ones", () => {
+			expect(cleanOrgName("kareem.jalal@jethur.com's Organization", "kareem.jalal@jethur.com")).toBe("Organization");
+			expect(cleanOrgName("kareem's Workspace", "kareem@jethur.com")).toBe("Workspace");
+			expect(cleanOrgName("user@example.com", "user@example.com")).toBeUndefined();
+			expect(cleanOrgName("Jethur Corp", "kareem.jalal@jethur.com")).toBe("Jethur Corp");
+			expect(cleanOrgName("Team Workspace", "osama@example.com")).toBe("Team Workspace");
+		});
+	});
+
+	describe("formatProviderName", () => {
+		it("formats provider identifiers with proper casing including OpenAI acronym", () => {
+			expect(formatProviderName("anthropic")).toBe("Anthropic");
+			expect(formatProviderName("google-antigravity")).toBe("Google Antigravity");
+			expect(formatProviderName("openai-codex")).toBe("OpenAI Codex");
+		});
+	});
+
+	describe("buildQuotaDashboardModel", () => {
+		it("8. groups multiple accounts under each provider cleanly", () => {
+			const reports = [
+				report({
+					provider: "google-antigravity",
+					metadata: { email: "osama15@gmail.com" },
+					limits: [
+						limit({
+							id: "google-antigravity:google:default:weekly",
+							label: "Usage (Google)",
+							amount: { unit: "percent", remainingFraction: 0 },
+						}),
+					],
+				}),
+				report({
+					provider: "google-antigravity",
+					metadata: { email: "adel@gmail.com" },
+					limits: [
+						limit({
+							id: "google-antigravity:google:default:daily",
+							label: "Usage (Google)",
+							amount: { unit: "percent", remainingFraction: 1 },
+						}),
+					],
+				}),
+			];
+
+			const model = buildQuotaDashboardModel(reports, NOW, new Map());
+			expect(model.providers).toHaveLength(1);
+			expect(model.providers[0]!.accounts).toHaveLength(2);
+			expect(model.providers[0]!.accounts[0]!.label).toBe("osama15@gmail.com");
+			expect(model.providers[0]!.accounts[1]!.label).toBe("adel@gmail.com");
+		});
+
+		it("9. preserves Antigravity independent Google / Anthropic / OpenAI pools", () => {
+			const reports = [
+				report({
+					provider: "google-antigravity",
+					metadata: { email: "osama@gmail.com" },
+					limits: [
+						limit({
+							id: "google-antigravity:google:default:weekly",
+							label: "Usage (Google)",
+							window: { id: "weekly", label: "Weekly" },
+							amount: { unit: "percent", remainingFraction: 0 },
+						}),
+						limit({
+							id: "google-antigravity:google:default:daily",
+							label: "Usage (Google)",
+							window: { id: "daily", label: "Daily" },
+							amount: { unit: "percent", remainingFraction: 1 },
+						}),
+						limit({
+							id: "google-antigravity:anthropic:default:weekly",
+							label: "Usage (Anthropic)",
+							window: { id: "weekly", label: "Weekly" },
+							amount: { unit: "percent", remainingFraction: 1 },
+						}),
+						limit({
+							id: "google-antigravity:openai:default:weekly",
+							label: "Usage (OpenAI)",
+							window: { id: "weekly", label: "Weekly" },
+							amount: { unit: "percent", remainingFraction: 1 },
+						}),
+					],
+				}),
+			];
+
+			const model = buildQuotaDashboardModel(reports, NOW, new Map());
+			const account = model.providers[0]!.accounts[0]!;
+			expect(account.pools).toHaveLength(3);
+			expect(account.pools.map(p => p.label)).toEqual(["Google", "Anthropic", "OpenAI"]);
+			expect(account.pools[0]!.rows).toHaveLength(2); // Weekly + Daily
+			expect(account.pools[1]!.rows).toHaveLength(1); // Weekly
+			expect(account.pools[2]!.rows).toHaveLength(1); // Weekly
+		});
+
+		it("10. marks the active account correctly and exclusively", () => {
+			const reports = [
+				report({ provider: "anthropic", metadata: { email: "active@jethur.com" } }),
+				report({ provider: "anthropic", metadata: { email: "inactive@jethur.com" } }),
+			];
+
+			const activeMap = new Map<string, LocalActiveIdentity>([["anthropic", { email: "active@jethur.com" }]]);
+
+			const model = buildQuotaDashboardModel(reports, NOW, activeMap);
+			const accounts = model.providers[0]!.accounts;
+			expect(accounts[0]!.isActive).toBe(true);
+			expect(accounts[1]!.isActive).toBe(false);
+		});
+
+		it("6 & 7. calculates summary counts and derives attention items correctly", () => {
+			const reports = [
+				report({
+					provider: "anthropic",
+					metadata: { email: "kareem@jethur.com" },
+					limits: [
+						limit({ id: "5h", label: "5 Hour", amount: { unit: "percent", remainingFraction: 0.93 } }), // healthy
+						limit({ id: "7d", label: "7 Day", amount: { unit: "percent", remainingFraction: 0.29 } }), // low
+					],
+				}),
+				report({
+					provider: "google-antigravity",
+					metadata: { email: "osama@gmail.com" },
+					limits: [
+						limit({
+							id: "google-antigravity:google:default:weekly",
+							label: "Usage (Google)",
+							amount: { unit: "percent", remainingFraction: 0 },
+						}), // exhausted
+						limit({
+							id: "google-antigravity:google:default:daily",
+							label: "Usage (Google)",
+							amount: { unit: "percent", remainingFraction: 0.12 },
+						}), // critical
+					],
+				}),
+			];
+
+			const model = buildQuotaDashboardModel(reports, NOW, new Map());
+			expect(model.summary.totalCount).toBe(4);
+			expect(model.summary.healthyCount).toBe(1);
+			expect(model.summary.lowCount).toBe(1);
+			expect(model.summary.criticalCount).toBe(1);
+			expect(model.summary.exhaustedCount).toBe(1);
+			expect(model.summary.allHealthy).toBe(false);
+
+			// Attention items should contain low, critical, exhausted items (not healthy)
+			expect(model.attentionItems).toHaveLength(3);
+			expect(model.attentionItems.map(item => item.health.status)).toEqual(["low", "exhausted", "critical"]);
+		});
+
+		it("11. computes account health summaries for collapsed states", () => {
+			const r = report({
+				provider: "openai-codex",
+				metadata: { email: "osama@gmail.com" },
+				limits: [limit({ id: "7d", label: "7 Day", amount: { unit: "percent", remainingFraction: 0 } })],
+			});
+
+			const model = buildQuotaDashboardModel([r], NOW, new Map());
+			const account = model.providers[0]!.accounts[0]!;
+			expect(account.healthSummary.hasIssues).toBe(true);
+			expect(account.healthSummary.exhaustedCount).toBe(1);
+			expect(account.healthSummary.summaryText).toBe("1 exhausted");
+		});
+
+		it("15. handles accounts with no reported limits cleanly", () => {
+			const r = report({
+				provider: "anthropic",
+				metadata: { email: "unlimited@example.com" },
+				limits: [],
+			});
+
+			const model = buildQuotaDashboardModel([r], NOW, new Map());
+			const account = model.providers[0]!.accounts[0]!;
+			expect(account.noLimits).toBe(true);
+			expect(account.pools).toHaveLength(0);
+			expect(account.healthSummary.summaryText).toBe("no limits");
+		});
+
+		it("16. handles absolute-usage only (neutral) limits", () => {
+			const r = report({
+				provider: "anthropic",
+				metadata: { email: "spend@example.com" },
+				limits: [limit({ id: "extra", label: "Claude Extra Usage", amount: { used: 123.45, unit: "usd" } })],
+			});
+
+			const model = buildQuotaDashboardModel([r], NOW, new Map());
+			const account = model.providers[0]!.accounts[0]!;
+			expect(account.pools[0]!.rows[0]!.health.status).toBe("neutral");
+			expect(account.pools[0]!.rows[0]!.usedText).toBe("$123.45 used");
+		});
+	});
+});

--- a/packages/coding-agent/examples/extensions/quota/tests/keys.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/keys.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { matchActionKey } from "../src/keys";
+
+describe("matchActionKey", () => {
+	it("matches navigation and action keys accurately", () => {
+		// Up / Down
+		expect(matchActionKey("\x1b[A")).toBe("up");
+		expect(matchActionKey("\x1bOA")).toBe("up");
+		expect(matchActionKey("k")).toBe("up");
+
+		expect(matchActionKey("\x1b[B")).toBe("down");
+		expect(matchActionKey("\x1bOB")).toBe("down");
+		expect(matchActionKey("j")).toBe("down");
+
+		// Enter
+		expect(matchActionKey("\r")).toBe("enter");
+		expect(matchActionKey("\n")).toBe("enter");
+
+		// Toggles
+		expect(matchActionKey("a")).toBe("toggle_attention");
+		expect(matchActionKey("A")).toBe("toggle_attention");
+		expect(matchActionKey("h")).toBe("toggle_healthy");
+		expect(matchActionKey("H")).toBe("toggle_healthy");
+		expect(matchActionKey("r")).toBe("refresh");
+		expect(matchActionKey("R")).toBe("refresh");
+
+		// Close / Escape
+		expect(matchActionKey("q")).toBe("close");
+		expect(matchActionKey("Q")).toBe("close");
+		expect(matchActionKey("\x03")).toBe("close");
+		expect(matchActionKey("\x1b")).toBe("escape");
+
+		// Paging
+		expect(matchActionKey("\x1b[5~")).toBe("page_up");
+		expect(matchActionKey("\x1b[6~")).toBe("page_down");
+		expect(matchActionKey("\x1b[H")).toBe("home");
+		expect(matchActionKey("\x1b[F")).toBe("end");
+
+		// Unknown
+		expect(matchActionKey("z")).toBe("unknown");
+	});
+});

--- a/packages/coding-agent/examples/extensions/quota/tests/render-dashboard.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/render-dashboard.test.ts
@@ -221,7 +221,7 @@ describe("renderDashboard", () => {
 		expect(hideHealthyText).toContain("Exhausted Limit");
 	});
 
-	it("adapts layout on narrow terminal widths without breaking", () => {
+	it("adapts layout on narrow terminal widths without embedding newlines inside rows", () => {
 		const reports = [
 			report({
 				provider: "openai-codex",
@@ -248,9 +248,7 @@ describe("renderDashboard", () => {
 
 		const narrowLines = renderDashboard(model, viewState, mockTheme, 45);
 		expect(narrowLines.length).toBeGreaterThan(0);
-		const narrowText = narrowLines.join("\n");
-		expect(narrowText).toContain("7 Day");
-		expect(narrowText).toContain("50%");
-		expect(narrowText).toContain("⚠");
+		// Invariant: no physical row element returned by render() may contain an embedded \n
+		expect(narrowLines.every(line => !line.includes("\n"))).toBe(true);
 	});
 });

--- a/packages/coding-agent/examples/extensions/quota/tests/render-dashboard.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/render-dashboard.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "bun:test";
+import { buildQuotaDashboardModel, type LocalUsageLimit, type LocalUsageReport } from "../src/hierarchy";
+import { type DashboardViewState, renderDashboard } from "../src/render-dashboard";
+
+const NOW = Date.now();
+const HOUR = 3_600_000;
+
+const mockTheme = {
+	fg: (color: string, text: string) => `[${color}]${text}[/${color}]`,
+	bold: (text: string) => `[bold]${text}[/bold]`,
+};
+
+function limit(overrides: Partial<LocalUsageLimit> = {}): LocalUsageLimit {
+	return {
+		id: "test:limit",
+		label: "7 Day",
+		scope: { provider: "test" },
+		amount: { unit: "percent", remainingFraction: 1.0 },
+		...overrides,
+	};
+}
+
+function report(overrides: Partial<LocalUsageReport> = {}): LocalUsageReport {
+	return {
+		provider: "test-provider",
+		fetchedAt: NOW,
+		limits: [limit()],
+		metadata: { email: "user@example.com" },
+		...overrides,
+	};
+}
+
+describe("renderDashboard", () => {
+	it("renders full dashboard with header, attention section, providers and footer", () => {
+		const reports = [
+			report({
+				provider: "anthropic",
+				metadata: { email: "kareem.jalal@jethur.com", orgName: "kareem.jalal@jethur.com's Organization" },
+				limits: [
+					limit({
+						id: "5h",
+						label: "5 Hour",
+						amount: { unit: "percent", remainingFraction: 0.96 },
+						window: { resetsAt: NOW + 4 * HOUR },
+					}),
+					limit({
+						id: "7d",
+						label: "7 Day",
+						amount: { unit: "percent", remainingFraction: 0.29 },
+						window: { resetsAt: NOW + 48 * HOUR },
+					}),
+				],
+			}),
+			report({
+				provider: "google-antigravity",
+				metadata: { email: "osama15@gmail.com" },
+				limits: [
+					limit({
+						id: "google-antigravity:google:default:weekly",
+						label: "Usage (Google)",
+						window: { id: "weekly", label: "Weekly" },
+						amount: { unit: "percent", remainingFraction: 0 },
+					}),
+					limit({
+						id: "google-antigravity:google:default:daily",
+						label: "Usage (Google)",
+						window: { id: "daily", label: "Daily" },
+						amount: { unit: "percent", remainingFraction: 1.0 },
+					}),
+				],
+			}),
+		];
+
+		const model = buildQuotaDashboardModel(
+			reports,
+			NOW,
+			new Map([["anthropic", { email: "kareem.jalal@jethur.com" }]]),
+		);
+		const viewState: DashboardViewState = {
+			selectedIndex: 0,
+			collapsedAccounts: new Set(),
+			collapsedPools: new Set(),
+			attentionOnly: false,
+			hideHealthy: false,
+		};
+
+		const lines = renderDashboard(model, viewState, mockTheme, 80);
+		const fullText = lines.join("\n");
+
+		// Header
+		expect(fullText).toContain("[bold][accent]QUOTA[/accent][/bold]");
+		expect(fullText).toContain("refreshed now");
+		expect(fullText).toContain("[success]✓ 2 healthy[/success]");
+		expect(fullText).toContain("[warning]⚠ 1 low[/warning]");
+		expect(fullText).toContain("[error]✕ 1 exhausted[/error]");
+
+		// Attention section
+		expect(fullText).toContain("[bold][error]ATTENTION[/error][/bold]");
+		expect(fullText).toContain("Anthropic · kareem.jalal@jethur.com · 7 Day");
+		expect(fullText).toContain("Google Antigravity · osama15@gmail.com · Google · Weekly");
+
+		// Provider headings
+		expect(fullText).toContain("[bold][accent]ANTHROPIC[/accent][/bold]");
+		expect(fullText).toContain("[bold][accent]GOOGLE ANTIGRAVITY[/accent][/bold]");
+
+		// Active marker
+		expect(fullText).toContain("[accent]● [/accent]");
+		expect(fullText).toContain("[accent][bold]ACTIVE[/bold][/accent]");
+
+		// Organization cleanup
+		expect(fullText).toContain("Organization");
+		expect(fullText).not.toContain("kareem.jalal@jethur.com's Organization");
+
+		// Footer
+		expect(fullText).toContain("↑↓ navigate   enter expand   a attention   h healthy   r refresh   q close");
+	});
+
+	it("omits attention section when all reported quotas are healthy", () => {
+		const reports = [
+			report({
+				provider: "anthropic",
+				metadata: { email: "healthy@example.com" },
+				limits: [limit({ id: "7d", label: "7 Day", amount: { unit: "percent", remainingFraction: 1.0 } })],
+			}),
+		];
+
+		const model = buildQuotaDashboardModel(reports, NOW, new Map());
+		const viewState: DashboardViewState = {
+			selectedIndex: 0,
+			collapsedAccounts: new Set(),
+			collapsedPools: new Set(),
+			attentionOnly: false,
+			hideHealthy: false,
+		};
+
+		const lines = renderDashboard(model, viewState, mockTheme, 80);
+		const fullText = lines.join("\n");
+
+		expect(fullText).toContain("✓ All reported quotas healthy");
+		expect(fullText).not.toContain("ATTENTION");
+	});
+
+	it("renders collapsed account with summary badge and hides inner pools", () => {
+		const reports = [
+			report({
+				provider: "google-antigravity",
+				metadata: { email: "osama15@gmail.com" },
+				limits: [
+					limit({
+						id: "google-antigravity:google:default:weekly",
+						label: "Usage (Google)",
+						amount: { unit: "percent", remainingFraction: 0 },
+					}),
+				],
+			}),
+		];
+
+		const model = buildQuotaDashboardModel(reports, NOW, new Map());
+		const accountId = model.providers[0]!.accounts[0]!.id;
+
+		const viewState: DashboardViewState = {
+			selectedIndex: 0,
+			collapsedAccounts: new Set([accountId]),
+			collapsedPools: new Set(),
+			attentionOnly: false,
+			hideHealthy: false,
+		};
+
+		const lines = renderDashboard(model, viewState, mockTheme, 80);
+		const fullText = lines.join("\n");
+
+		// Collapsed disclosure icon and summary
+		expect(fullText).toContain("▸ ");
+		expect(fullText).toContain("[error]1 exhausted[/error]");
+		// Inner window rows should be hidden
+		expect(fullText).not.toContain("0%   ✕");
+	});
+
+	it("supports attention-only mode and hide-healthy mode", () => {
+		const reports = [
+			report({
+				provider: "anthropic",
+				metadata: { email: "healthy@example.com" },
+				limits: [limit({ id: "h1", label: "Healthy Limit", amount: { unit: "percent", remainingFraction: 1.0 } })],
+			}),
+			report({
+				provider: "openai-codex",
+				metadata: { email: "issues@example.com" },
+				limits: [limit({ id: "i1", label: "Exhausted Limit", amount: { unit: "percent", remainingFraction: 0 } })],
+			}),
+		];
+
+		const model = buildQuotaDashboardModel(reports, NOW, new Map());
+
+		// Attention only
+		const attentionState: DashboardViewState = {
+			selectedIndex: 0,
+			collapsedAccounts: new Set(),
+			collapsedPools: new Set(),
+			attentionOnly: true,
+			hideHealthy: false,
+		};
+
+		const attentionText = renderDashboard(model, attentionState, mockTheme, 80).join("\n");
+		expect(attentionText).toContain("ATTENTION ONLY MODE");
+		expect(attentionText).toContain("issues@example.com");
+		expect(attentionText).not.toContain("healthy@example.com");
+
+		// Hide healthy
+		const hideHealthyState: DashboardViewState = {
+			selectedIndex: 0,
+			collapsedAccounts: new Set(),
+			collapsedPools: new Set(),
+			attentionOnly: false,
+			hideHealthy: true,
+		};
+
+		const hideHealthyText = renderDashboard(model, hideHealthyState, mockTheme, 80).join("\n");
+		expect(hideHealthyText).toContain("HIDING HEALTHY");
+		expect(hideHealthyText).not.toContain("Healthy Limit");
+		expect(hideHealthyText).toContain("Exhausted Limit");
+	});
+
+	it("adapts layout on narrow terminal widths without breaking", () => {
+		const reports = [
+			report({
+				provider: "openai-codex",
+				metadata: { email: "user@example.com" },
+				limits: [
+					limit({
+						id: "7d",
+						label: "7 Day",
+						amount: { unit: "percent", remainingFraction: 0.5 },
+						window: { resetsAt: NOW + 5 * HOUR },
+					}),
+				],
+			}),
+		];
+
+		const model = buildQuotaDashboardModel(reports, NOW, new Map());
+		const viewState: DashboardViewState = {
+			selectedIndex: 0,
+			collapsedAccounts: new Set(),
+			collapsedPools: new Set(),
+			attentionOnly: false,
+			hideHealthy: false,
+		};
+
+		const narrowLines = renderDashboard(model, viewState, mockTheme, 45);
+		expect(narrowLines.length).toBeGreaterThan(0);
+		const narrowText = narrowLines.join("\n");
+		expect(narrowText).toContain("7 Day");
+		expect(narrowText).toContain("50%");
+		expect(narrowText).toContain("⚠");
+	});
+});

--- a/packages/coding-agent/examples/extensions/quota/tests/render-plain.test.ts
+++ b/packages/coding-agent/examples/extensions/quota/tests/render-plain.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { buildQuotaDashboardModel, type LocalUsageLimit, type LocalUsageReport } from "../src/hierarchy";
+import { renderQuotaSnapshot } from "../src/render-plain";
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+function limit(overrides: Partial<LocalUsageLimit> = {}): LocalUsageLimit {
+	return {
+		id: "test:limit",
+		label: "7 Day",
+		scope: { provider: "test" },
+		amount: { unit: "percent", remainingFraction: 1.0 },
+		...overrides,
+	};
+}
+
+function report(overrides: Partial<LocalUsageReport> = {}): LocalUsageReport {
+	return {
+		provider: "test-provider",
+		fetchedAt: NOW,
+		limits: [limit()],
+		metadata: { email: "user@example.com" },
+		...overrides,
+	};
+}
+
+describe("renderQuotaSnapshot", () => {
+	it("renders a clean plain-text snapshot with provider -> account -> pool -> window hierarchy", () => {
+		const reports = [
+			report({
+				provider: "anthropic",
+				metadata: { email: "kareem@jethur.com" },
+				limits: [
+					limit({
+						id: "5h",
+						label: "5 Hour",
+						amount: { unit: "percent", remainingFraction: 0.93 },
+						window: { resetsAt: NOW + 4 * HOUR },
+					}),
+					limit({
+						id: "7d",
+						label: "7 Day",
+						amount: { unit: "percent", remainingFraction: 0.29 },
+						window: { resetsAt: NOW + 48 * HOUR },
+					}),
+				],
+			}),
+			report({
+				provider: "google-antigravity",
+				metadata: { email: "osama@gmail.com" },
+				limits: [
+					limit({
+						id: "google-antigravity:google:default:weekly",
+						label: "Usage (Google)",
+						window: { id: "weekly", label: "Weekly", resetsAt: NOW + 6 * 24 * HOUR },
+						amount: { unit: "percent", remainingFraction: 0 },
+					}),
+					limit({
+						id: "google-antigravity:google:default:daily",
+						label: "Usage (Google)",
+						window: { id: "daily", label: "Daily" },
+						amount: { unit: "percent", remainingFraction: 1.0 },
+					}),
+				],
+			}),
+		];
+
+		const model = buildQuotaDashboardModel(reports, NOW, new Map([["anthropic", { email: "kareem@jethur.com" }]]));
+		const snapshot = renderQuotaSnapshot(model);
+
+		expect(snapshot).toContain("Quota");
+		expect(snapshot).toContain("Anthropic");
+		expect(snapshot).toContain("● kareem@jethur.com   ACTIVE");
+		expect(snapshot).toContain("5 Hour");
+		expect(snapshot).toContain("93% ✓ ↻4h");
+		expect(snapshot).toContain("7 Day");
+		expect(snapshot).toContain("29% ⚠ ↻2d");
+		expect(snapshot).toContain("Google Antigravity");
+		expect(snapshot).toContain("osama@gmail.com");
+		expect(snapshot).toContain("Google");
+		expect(snapshot).toContain("Weekly");
+		expect(snapshot).toContain("0% ✕ ↻6d");
+		expect(snapshot).toContain("Daily");
+		expect(snapshot).toContain("100% ✓");
+	});
+});

--- a/packages/coding-agent/examples/extensions/quota/tsconfig.json
+++ b/packages/coding-agent/examples/extensions/quota/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "include": ["src", "tests", "index.ts"]
+}


### PR DESCRIPTION
## Summary

Adds an interactive, theme-aware `/quota` extension example under `packages/coding-agent/examples/extensions/quota/`.

### Features
- **Account-first hierarchy**: Renders usage data as `Provider -> Account -> Pool (when applicable) -> Window`.
- **Theme-aware semantic styling**: Uses OMP's `Theme` palette (`accent`, `success`, `warning`, `error`, `dim`, `muted`) with 12-cell remaining quota bars.
- **4-tier health classification**:
  - `51–100%`: healthy (`✓`, success)
  - `21–50%`: low (`⚠`, warning)
  - `1–20%`: critical (`!`, error)
  - `0%` / exhausted: exhausted (`✕`, error)
- **Top ATTENTION section**: Surfaces low, critical, and exhausted limits at a glance.
- **Interactive keyboard controls (`ctx.ui.custom`)**:
  - `↑` / `↓` / `k` / `j`: Navigate selectable accounts & pools
  - `Enter`: Expand/collapse selected account or pool
  - `a`: Toggle attention-only mode
  - `h`: Toggle hide/show healthy quotas
  - `r`: Live refresh from `AuthStorage`
  - `q` / `Esc`: Close dashboard
- **Clean organization names**: Strips redundant `${email}'s Organization` metadata while preserving real company/team names.
- **Non-interactive snapshot mode**: `/quota snapshot` (and headless fallback when `ctx.hasUI === false`).
- **Tests**: Includes 31 standalone unit tests across 5 test files (`format.test.ts`, `hierarchy.test.ts`, `render-dashboard.test.ts`, `render-plain.test.ts`, `keys.test.ts`).