### PR TITLE
fix(ai): preserve opaque Chat Completions tool-call IDs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved opaque Chat Completions tool-call IDs during same-model replay so custom gateways retain provider correlation state ([#8641](https://github.com/can1357/oh-my-pi/issues/8641)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1808,16 +1808,19 @@ export function convertMessages(
 			? 40
 			: undefined;
 	const duplicateToolCallIdSuffixPrefix = compat.requiresMistralToolIds ? "dup" : undefined;
-	const normalizeToolCallId = (id: string): string => {
+	const normalizeToolCallId = (id: string, source?: AssistantMessage): string => {
 		if (compat.requiresMistralToolIds) return normalizeMistralToolId(id, true);
 
-		// Handle pipe-separated IDs from OpenAI Responses API
-		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
-		// These come from providers like github-copilot, openai-codex, opencode
-		// Extract just the call_id part and normalize it
-		if (id.includes("|")) {
+		const isSameModelSource =
+			source !== undefined &&
+			source.provider === model.provider &&
+			source.api === model.api &&
+			source.model === model.id;
+		// Cross-model replay converts OpenAI Responses composite IDs from
+		// `{call_id}|{item_id}` to the Chat Completions `call_id`. Same-model
+		// Chat Completions IDs are provider-issued opaque correlation tokens.
+		if (!isSameModelSource && id.includes("|")) {
 			const [callId] = id.split("|");
-			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
 			return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
 		}
 
@@ -1827,7 +1830,7 @@ export function convertMessages(
 	const transformedMessages = transformMessages(
 		context.messages,
 		model,
-		id => normalizeToolCallId(id),
+		(id, _target, source) => normalizeToolCallId(id, source),
 		maxNormalizedToolCallIdLength,
 		duplicateToolCallIdSuffixPrefix,
 		compat,
@@ -1859,8 +1862,8 @@ export function convertMessages(
 		return nextId;
 	};
 
-	const ensureToolCallId = (rawId: string, seed: string): string => {
-		const normalized = normalizeToolCallId(rawId);
+	const ensureToolCallId = (rawId: string, seed: string, source?: AssistantMessage): string => {
+		const normalized = normalizeToolCallId(rawId, source);
 		if (normalized.trim().length > 0) return normalized;
 		return generateFallbackToolCallId(seed);
 	};
@@ -2142,7 +2145,7 @@ export function convertMessages(
 			}
 			if (toolCalls.length > 0) {
 				assistantMsg.tool_calls = toolCalls.map((tc, toolCallIndex) => {
-					const toolCallId = ensureToolCallId(tc.id, `${i}:${toolCallIndex}:${tc.name}`);
+					const toolCallId = ensureToolCallId(tc.id, `${i}:${toolCallIndex}:${tc.name}`, msg);
 					rememberToolCallId(tc.id, toolCallId);
 					return {
 						id: normalizeMistralToolId(toolCallId, compat.requiresMistralToolIds),

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -628,6 +628,79 @@ describe("openai-completions compatibility", () => {
 		expect(result.usage.totalTokens).toBe(15);
 	});
 
+	it("preserves opaque tool-call IDs when replaying a custom Chat Completions turn", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			id: "gateway-model",
+			name: "Gateway Model",
+			api: "openai-completions",
+			provider: "custom-gateway",
+			baseUrl: "https://gateway.example/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+		} satisfies ModelSpec<"openai-completions">);
+		const toolCallId = "call_abc||gateway_state||opaque";
+		const assistant = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: createMockFetch([
+				{
+					id: "chatcmpl-opaque-tool-id",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [
+						{
+							index: 0,
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										id: toolCallId,
+										type: "function",
+										function: { name: "read", arguments: '{"path":"README.md"}' },
+									},
+								],
+							},
+						},
+					],
+				},
+				{
+					id: "chatcmpl-opaque-tool-id",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+				},
+				"[DONE]",
+			]),
+		}).result();
+		const streamedToolCall = assistant.content.find(content => content.type === "toolCall");
+		expect(streamedToolCall?.id).toBe(toolCallId);
+
+		const payload = await captureOpenAICompletionsPayload(model, {
+			messages: [
+				{ role: "user", content: "Read README", timestamp: 1 },
+				assistant,
+				{
+					role: "toolResult",
+					toolCallId,
+					toolName: "read",
+					content: [{ type: "text", text: "done" }],
+					isError: false,
+					timestamp: 2,
+				},
+			],
+		});
+		const replayMessages = getPayloadMessages(payload);
+		const assistantPayload = replayMessages.find(message => message.role === "assistant");
+		const toolCalls = assistantPayload?.tool_calls;
+		if (!Array.isArray(toolCalls)) throw new Error("assistant tool_calls missing");
+		expect(toObject(toolCalls[0])?.id).toBe(toolCallId);
+		expect(replayMessages.find(message => message.role === "tool")?.tool_call_id).toBe(toolCallId);
+	});
+
 	it("keeps unindexed batched tool-call arguments isolated", async () => {
 		const model: Model<"openai-completions"> = buildModel({
 			...gpt4oMiniSpec,

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -227,7 +227,7 @@ describe("openai-completions convertMessages", () => {
 		const assistantMessage: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "toolCall", id: emptyNormalizingId, name: "read", arguments: { path: "README.md" } }],
-			api: model.api,
+			api: "openai-responses",
 			provider: model.provider,
 			model: model.id,
 			usage: emptyUsage,


### PR DESCRIPTION
## Repro
A custom `openai-completions` model streams `tool_calls[].id = call_abc||gateway_state||opaque`, then OMP replays that assistant turn with its tool result. Before the fix, `bun test packages/ai/test/openai-completions-compat.test.ts --test-name-pattern "preserves opaque tool-call IDs"` failed because the follow-up assistant ID was `call_abc`.

## Cause
`convertMessages` in `packages/ai/src/providers/openai-completions.ts` unconditionally treated every pipe-containing ID as an OpenAI Responses `{call_id}|{item_id}` composite inside `normalizeToolCallId`, including IDs issued by the same Chat Completions provider/model. SSE ingestion preserved the bytes; outbound replay destroyed them.

## Fix
- Preserve provider-issued opaque IDs when the assistant source matches the target provider, API, and model.
- Keep Responses composite-ID extraction for cross-model/cross-API replay and existing target-specific Mistral/OpenAI limits.
- Cover the full mocked SSE-to-follow-up-payload path and retain the malformed Responses composite fallback regression.
- Document the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/openai-completions-tool-result-images.test.ts` — 80 pass, 0 fail. `bun check` passed through the pre-publish gate. Fixes #8641