### PR TITLE
feat(tui): runtime-probe Hangul Compatibility Jamo width via DSR/CPR

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Runtime-probe the terminal's Hangul Compatibility Jamo (U+3131..U+318E) cell width at startup via a DSR/CPR cursor-position query, so the hardware cursor (and IME preedit anchor) lands on the actual glyph instead of 1 cell early per jamo when the static macOS "platform" fallback mismatches the terminal's font (e.g. Terminal.app 2.15 + SF Mono renders these at 2 cells, not 1). Falls back to the static width table after 750 ms when the terminal ignores the query.
+
 ## [17.3.4] - 2026-08-14
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -594,6 +594,9 @@ export class ProcessTerminal implements Terminal {
 	> = [];
 	#appearance: TerminalAppearance | undefined;
 	#osc11Pending = false;
+	/** Outstanding runtime Hangul Compatibility Jamo width CPR probe. */
+	#jamoWidthPending = false;
+	#jamoWidthTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
 	#osc11ActiveToken?: TerminalAppearanceRequestToken;
 	#osc11QueuedQuery?: { route: Osc11QueryRoute; token?: TerminalAppearanceRequestToken };
 	#nextAppearanceRequestToken = 1;
@@ -782,6 +785,13 @@ export class ProcessTerminal implements Terminal {
 		// data handler are installed. Keep this false throughout temporary stops.
 		this.#active = true;
 		setHangulCompatibilityJamoWidth(TERMINAL.hangulJamoWidth);
+		// Runtime Hangul Compatibility Jamo width: the static table cannot know
+		// the client font's real width (Terminal.app 2.15 with SF Mono renders
+		// Compatibility Jamo at 2 cells via CPR; some Korean fonts render 1).
+		// Measure once at startup; the first frame paint erases the probe glyph.
+		if (this.#shouldQueryHangulJamoWidth()) {
+			this.#queryHangulJamoWidth();
+		}
 
 		// Query terminal background color via OSC 11 for dark/light detection.
 		// Uses DA1 (Primary Device Attributes) as a sentinel: terminals process
@@ -912,6 +922,9 @@ export class ProcessTerminal implements Terminal {
 		// DECRPM private-mode report (DECRQM reply): \x1b[?<mode>;<status>$y
 		const decrpmResponsePattern = /^\x1b\[\?(\d+);(\d+)\$y$/;
 
+		// Cursor Position Report (DSR reply to `CSI 6 n`): \x1b[<row>;<col>R
+		const cprResponsePattern = /^\x1b\[(\d+);(\d+)R$/;
+
 		// In-band resize report (DEC mode 2048): \x1b[48;rows;cols;yPixels;xPixels t
 		// Any field may carry `:`-separated subparameters, which clients MUST
 		// ignore per spec (#4748): capture the leading digits of each field and
@@ -1035,6 +1048,18 @@ export class ProcessTerminal implements Terminal {
 			const decrpmMatch = sequence.match(decrpmResponsePattern);
 			if (decrpmMatch) {
 				this.#handlePrivateModeReport(parseInt(decrpmMatch[1]!, 10), decrpmMatch[2]!);
+				return;
+			}
+
+			// Cursor Position Report (DSR `CSI 6 n` reply): `\x1b[{row};{col}R`.
+			// Exclusively a terminal->host report, so swallow it even with no
+			// outstanding probe (late replies must never reach the composer).
+			// Resolves the runtime Hangul Compatibility Jamo width probe.
+			const cprMatch = sequence.match(cprResponsePattern);
+			if (cprMatch) {
+				if (this.#jamoWidthPending) {
+					this.#resolveJamoWidth(Number(cprMatch[2]));
+				}
 				return;
 			}
 
@@ -1383,6 +1408,59 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	/**
+	 * Measure the terminal's real Hangul Compatibility Jamo (U+3131..U+318E)
+	 * cell width with a Cursor Position Report (DSR `CSI 6 n`): write one
+	 * visible jamo (`ㅁ`, U+3141 — never the zero-width U+3164 filler), query
+	 * the cursor column, derive the width from the column delta (1-based start
+	 * col 1): col 3 → 2 cells, col 2 → 1 cell. A terminal that ignores DSR
+	 * resolves as `null` (keep the static fallback) after the timeout; the
+	 * probe glyph is erased by the first frame paint.
+	 *
+	 * The probe deliberately does NOT ride the DA1 sentinel FIFO: the other
+	 * capability probes fuse a sentinel because their responses are optional
+	 * (a no-answer terminal would otherwise hang the startup), while a CPR
+	 * reply is answered by far more terminals and a plain timeout is enough.
+	 * Keeping the FIFO untouched also leaves the OSC 11/DECRQM queue ordering
+	 * tests deterministic.
+	 *
+	 * The static width table cannot know the client font's real width —
+	 * Terminal.app 2.15 with SF Mono renders Compatibility Jamo at 2 cells
+	 * (UAX#11), Ghostty at 2, Warp at 1, and fonts without full-width jamo
+	 * glyphs at 1 — so the cursor column (and the IME preedit anchor) drifts
+	 * 1 cell per jamo whenever the static value mismatches the terminal.
+	 */
+	#shouldQueryHangulJamoWidth(): boolean {
+		// Like the OSC 99 probe: off under the test runtime unless the test
+		// opts in, so probe-driven suites keep deterministic write/timer state.
+		return !isBunTestRuntime() || $env.PI_TUI_JAMO_WIDTH_PROBE === "1";
+	}
+
+	#queryHangulJamoWidth(): void {
+		if (this.#dead || this.#jamoWidthPending) return;
+		this.#jamoWidthPending = true;
+		this.#safeWrite("\u3141\x1b[6n");
+		this.#jamoWidthTimeout = setTimeout(() => {
+			this.#jamoWidthTimeout = undefined;
+			this.#resolveJamoWidth(null);
+		}, 750);
+	}
+
+	#resolveJamoWidth(cursorCol: number | null): void {
+		if (!this.#jamoWidthPending) return;
+		this.#jamoWidthPending = false;
+		if (this.#jamoWidthTimeout) {
+			clearTimeout(this.#jamoWidthTimeout);
+			this.#jamoWidthTimeout = undefined;
+		}
+		if (cursorCol !== null) {
+			const measured = cursorCol === 3 ? 2 : cursorCol === 2 ? 1 : null;
+			if (measured !== null) {
+				setHangulCompatibilityJamoWidth(measured);
+			}
+		}
+	}
+
+	/**
 	 * Record DECRQM support for a private mode (idempotent — first result wins)
 	 * and notify subscribers. `confirmed` distinguishes an explicit DECRPM
 	 * unsupported response from an absent response followed by the DA1 sentinel.
@@ -1597,6 +1675,11 @@ export class ProcessTerminal implements Terminal {
 		this.#osc99ResponseBuffer = "";
 		this.#osc99Capabilities.clear();
 		setOsc99Supported(false);
+		this.#jamoWidthPending = false;
+		if (this.#jamoWidthTimeout) {
+			clearTimeout(this.#jamoWidthTimeout);
+			this.#jamoWidthTimeout = undefined;
+		}
 		this.#privateCsiResponseBuffer = "";
 		this.#inBandResizeBuffer = "";
 		this.#da1SentinelOwners.length = 0;

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -263,6 +263,9 @@ function hangulCompatibilityJamoTargetWidth(): 1 | 2 | null {
 			return null;
 		default:
 			// "platform": macOS terminals historically render these narrow.
+			// NOTE: Terminal.app 2.15 (macOS 26.5, SF Mono 12 pt) measures 2 cells
+			// via CPR — the static table cannot be right for every font/build, so
+			// the runtime probe in ProcessTerminal.start() overrides this.
 			return process.platform === "darwin" ? 1 : null;
 	}
 }

--- a/packages/tui/test/terminal-jamo-width-probe.test.ts
+++ b/packages/tui/test/terminal-jamo-width-probe.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
 import { detectTerminalId, getTerminalInfo } from "@oh-my-pi/pi-tui/terminal-capabilities";
+import { getHangulCompatibilityJamoWidth, resetHangulCompatibilityJamoWidthForTests } from "@oh-my-pi/pi-tui/utils";
+import { setTerminalHeadless } from "@oh-my-pi/pi-utils";
 
 function jamoWidthFor(env: NodeJS.ProcessEnv): "platform" | "unicode" | 1 | 2 {
 	return getTerminalInfo(detectTerminalId(env)).hangulJamoWidth;
@@ -20,5 +23,122 @@ describe("Hangul Compatibility Jamo width terminal capability", () => {
 		expect(jamoWidthFor({ TERM_PROGRAM: "iTerm.app" })).toBe("platform");
 		expect(jamoWidthFor({ TERM_PROGRAM: "Apple_Terminal" })).toBe("platform");
 		expect(jamoWidthFor({})).toBe("platform");
+	});
+});
+
+// The runtime CPR probe must correct the static table (e.g. Apple_Terminal
+// resolves "platform", but Terminal.app 2.15 with SF Mono actually renders
+// Compatibility Jamo at 2 cells — measured via DSR/CPR col 3 after `ㅁ`).
+// These suites drive the real ProcessTerminal start() probe pipeline, so they
+// opt out of the test-default headless suppression and opt into the probe.
+const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
+const originalProbeEnv = Bun.env.PI_TUI_JAMO_WIDTH_PROBE;
+let previousHeadless = false;
+
+function restoreProperty(target: object, key: string, descriptor: PropertyDescriptor | undefined): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+		return;
+	}
+	delete (target as Record<string, unknown>)[key];
+}
+
+describe("ProcessTerminal runtime Hangul Compatibility Jamo width CPR probe", () => {
+	beforeEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdin, "setRawMode", { value: vi.fn(), configurable: true });
+		previousHeadless = setTerminalHeadless(false);
+		Bun.env.PI_TUI_JAMO_WIDTH_PROBE = "1";
+		resetHangulCompatibilityJamoWidthForTests();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		setTerminalHeadless(previousHeadless);
+		resetHangulCompatibilityJamoWidthForTests();
+		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
+		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
+		if (originalProbeEnv === undefined) delete Bun.env.PI_TUI_JAMO_WIDTH_PROBE;
+		else Bun.env.PI_TUI_JAMO_WIDTH_PROBE = originalProbeEnv;
+	});
+
+	function setupTerminal() {
+		const writes: string[] = [];
+		vi.spyOn(process, "kill").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			() => {},
+			() => {},
+		);
+		return { terminal, writes };
+	}
+
+	it("writes the probe glyph + CPR query and applies the measured 2-cell width", () => {
+		vi.useFakeTimers();
+		const { terminal, writes } = setupTerminal();
+
+		// Probe payload: visible jamo ㅁ (U+3141) followed by DSR `CSI 6 n`.
+		expect(writes.some(w => w.includes("\u3141\x1b[6n"))).toBe(true);
+
+		// CPR reply: cursor at col 3 → the jamo occupies 2 cells.
+		process.stdin.emit("data", "\x1b[1;3R");
+		expect(getHangulCompatibilityJamoWidth()).toBe(2);
+
+		// The late DA1 sentinel from other probes must not disturb the result.
+		process.stdin.emit("data", "\x1b[?1;2c");
+		expect(getHangulCompatibilityJamoWidth()).toBe(2);
+
+		terminal.stop();
+	});
+
+	it("applies the measured 1-cell width when the terminal reports col 2", () => {
+		vi.useFakeTimers();
+		const { terminal } = setupTerminal();
+
+		process.stdin.emit("data", "\x1b[1;2R");
+		expect(getHangulCompatibilityJamoWidth()).toBe(1);
+
+		terminal.stop();
+	});
+
+	it("keeps the static fallback when the terminal never answers CPR", () => {
+		vi.useFakeTimers();
+		const { terminal } = setupTerminal();
+
+		expect(getHangulCompatibilityJamoWidth()).toBe("platform");
+		vi.advanceTimersByTime(800); // probe timeout (750 ms)
+		expect(getHangulCompatibilityJamoWidth()).toBe("platform");
+
+		terminal.stop();
+	});
+
+	it("swallows a late CPR reply so it never reaches the composer", () => {
+		vi.useFakeTimers();
+		const received: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			data => received.push(data),
+			() => {},
+		);
+		// Answer CPR before the 750 ms timeout fires, then after stop() a
+		// stray reply must be dropped (exclusively a terminal->host report).
+		process.stdin.emit("data", "\x1b[1;3R");
+		terminal.stop();
+		process.stdin.emit("data", "\x1b[1;4R");
+		expect(received).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What

Runtime-probe the terminal's real Hangul Compatibility Jamo (U+3131..U+318E) cell width at startup, instead of trusting the static per-terminal table.

At `ProcessTerminal.start()` the TUI now writes one visible jamo (`ㅁ`, U+3141) and queries the cursor column via DSR/CPR (`CSI 6 n`); the reported column derives the width (col 3 → 2 cells, col 2 → 1 cell) and is applied to the width engine through `setHangulCompatibilityJamoWidth`. Terminals that ignore DSR keep the static fallback after a 750 ms timeout. The probe deliberately does not ride the DA1 sentinel FIFO (CPR is answered by far more terminals than the optional probes need a sentinel for, and a plain timeout suffices), which keeps the OSC 11/DECRQM queue-ordering tests deterministic. It is gated off under the test runtime unless `PI_TUI_JAMO_WIDTH_PROBE=1`, mirroring the OSC 99 probe.

## Why

The static macOS "platform" fallback assumes Compatibility Jamo is 1 cell wide (commit `d9f9216`, later refined for Ghostty in `82ef6c0a`), but the real width is decided by the client terminal's font, not the terminal identity. Measured live with DSR/CPR in Terminal.app 2.15 (macOS 26.5.2, SF Mono 12 pt): `ㅎ` → cursor col 3, `ㅎㅎㅎ` → col 7 — i.e. **2 cells**, matching UAX#11; Ghostty also renders 2, Warp 1, and Korean fonts without full-width jamo glyphs render 1. When the static value mismatches the terminal, the hardware cursor (and therefore the IME preedit/candidate anchor) lands 1 cell early per jamo during Korean composition — the same drift class as #3431/#5563/#6153, and the runtime-probe follow-up explicitly deferred in `82ef6c0a` ("A runtime DSR/CPR probe that auto-detects the width on unknown terminals is tracked in a follow-up").

This does **not** fix the separate Terminal.app IME marked-text corruption (blank "holes" during rapid Korean composition) documented with full evidence in https://github.com/can1357/oh-my-pi/issues/6153#issuecomment-5302055954 — that race reproduces in plain zsh without OMP and is outside the TUI's control. This change fixes the measurable cursor-anchor defect on the OMP side.

## Testing

- **Live probe (Terminal.app 2.15, real TTY):** `PROBE_RESULT=2`; after applying, `visibleWidth("ㅌ")=2`, `visibleWidth("ㅌㅌㅌ")=6`, `visibleWidth("안녕하세요ㅌ")=12` — exactly matching the terminal's real cell accounting (the static darwin model returns 11 for the last case, 1 cell short per jamo).
- **Source build with the probe active:** ran the TUI in Terminal.app end-to-end (Korean input + typing exercise); no crash, no probe leak into input.
- **New regression tests** (`test/terminal-jamo-width-probe.test.ts`, 5 tests): 2-cell CPR reply applies width 2; 1-cell reply applies width 1; timeout keeps the static fallback; a late CPR reply is swallowed and never reaches the composer; the probe payload (`ㅁ` + `CSI 6 n`) is written at startup.
- **Suites:** `test/visible-width.test.ts` + `test/terminal-jamo-width-probe.test.ts` — 49 pass / 0 fail; `test/editor.test.ts` — 164 pass / 0 fail; full `packages/tui` suite — 1511 pass, 3 skip, 2 fail (both pre-existing `test/issue-8318-repro.test.ts` failures, scaled OSC 66 headings, unrelated to this change). `bunx biome check` clean; `bunx tsc --noEmit` clean.

I'm a Korean user who kept running into broken Korean input in Terminal.app, so I asked an AI to investigate the root cause and draft this fix; I did the final review myself before submitting.

- [x] `bun check` passes (biome + tsc on changed files; full workspace check not run)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
