### PR TITLE
feat: add per-session MCP server allowlists

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a per-session `--mcp-servers` allowlist for exact discovered MCP connector names, including an explicit empty selection, and exposed the currently connected server names through RPC `get_state`.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -78,6 +78,11 @@ export interface Args {
 	export?: string;
 	noSkills?: boolean;
 	skills?: string[];
+	/**
+	 * Exact discovered MCP server names to connect. Present and empty means
+	 * connect no discovered MCP servers.
+	 */
+	mcpServers?: string[];
 	noRules?: boolean;
 	noTitle?: boolean;
 	autoApprove?: boolean;

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -223,6 +223,12 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--skills": (result, value) => {
 		result.skills = value.split(",").map(s => s.trim());
 	},
+	"--mcp-servers": (result, value) => {
+		result.mcpServers = value
+			.split(",")
+			.map(name => name.trim())
+			.filter(Boolean);
+	},
 	"--approval-mode": (result, value, deps) => {
 		if (value === "always-ask" || value === "write" || value === "yolo") {
 			result.approvalMode = value;

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -91,6 +91,9 @@ export const launchHelp = {
 		}),
 		"no-skills": Flags.boolean({ description: "Disable skills discovery and loading" }),
 		skills: Flags.string({ description: "Comma-separated glob patterns to filter skills (e.g., git-*,docker)" }),
+		"mcp-servers": Flags.string({
+			description: "Comma-separated discovered MCP server names to connect (empty connects none)",
+		}),
 		"no-rules": Flags.boolean({ description: "Disable rules discovery and loading" }),
 		export: Flags.string({ description: "Export session file to HTML and exit" }),
 		"no-title": Flags.boolean({ description: "Disable title auto-generation" }),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -906,6 +906,7 @@ export async function buildSessionOptions(
 	const options: CreateAgentSessionOptions = {
 		cwd: parsed.cwd ?? getProjectDir(),
 		autoApprove: parsed.autoApprove ?? false,
+		mcpServerNames: parsed.mcpServers,
 	};
 	const restoringSession = Boolean(parsed.continue || parsed.resume || isForeignSessionImport(parsed));
 	if (parsed.serviceTier !== undefined) {
@@ -949,7 +950,8 @@ export async function buildSessionOptions(
 			parsed.systemPrompt !== undefined ||
 			parsed.appendSystemPrompt !== undefined ||
 			parsed.tools !== undefined ||
-			parsed.noTools === true;
+			parsed.noTools === true ||
+			parsed.mcpServers !== undefined;
 		if (!forkCacheShapeChanged && header?.providerPromptCacheKey) {
 			options.providerPromptCacheKey = header.providerPromptCacheKey;
 			options.providerPromptCacheKeySource = "fork";

--- a/packages/coding-agent/src/mcp/loader.ts
+++ b/packages/coding-agent/src/mcp/loader.ts
@@ -35,6 +35,11 @@ export interface MCPToolsLoadOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/**
+	 * Exact discovered server names to connect. `undefined` preserves normal
+	 * discovery; an empty list connects no discovered servers.
+	 */
+	serverNames?: readonly string[];
 	/** SQLite storage for MCP tool cache (null disables cache) */
 	cacheStorage?: AgentStorage | null;
 	/** Auth storage used to resolve OAuth credentials before initial MCP connect */
@@ -61,7 +66,7 @@ async function resolveToolCache(storage: AgentStorage | null | undefined): Promi
  */
 export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoadOptions): Promise<MCPToolsLoadResult> {
 	const toolCache = await resolveToolCache(options?.cacheStorage);
-	const manager = new MCPManager(cwd, toolCache);
+	const manager = new MCPManager(cwd, toolCache, options?.serverNames);
 	if (options?.authStorage) {
 		manager.setAuthStorage(options.authStorage);
 	}
@@ -73,6 +78,7 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 			enableProjectConfig: options?.enableProjectConfig,
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,
+			serverNames: options?.serverNames,
 		});
 	} catch (error) {
 		// If discovery fails entirely, return empty result

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -172,6 +172,11 @@ export interface MCPDiscoverOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/**
+	 * Exact discovered server names to connect. `undefined` preserves normal
+	 * discovery; an empty list connects no discovered servers.
+	 */
+	serverNames?: readonly string[];
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
 }
@@ -210,6 +215,7 @@ export class MCPManager {
 	#authStorage: AuthStorage | null = null;
 	#authHandler?: MCPAuthHandler;
 	#notificationListeners = new Set<(serverName: string, method: string, params: unknown) => void>();
+	readonly #serverNames: ReadonlySet<string> | undefined;
 	/**
 	 * Notifications received before any listener attached, to be drained on
 	 * the first {@link addNotificationListener} call. Bounded by
@@ -237,7 +243,10 @@ export class MCPManager {
 	constructor(
 		private cwd: string,
 		private toolCache: MCPToolCache | null = null,
-	) {}
+		serverNames?: readonly string[],
+	) {
+		this.#serverNames = serverNames === undefined ? undefined : new Set(serverNames);
+	}
 
 	/**
 	 * Register a listener for server-initiated MCP notifications.
@@ -411,7 +420,23 @@ export class MCPManager {
 			throw error;
 		}
 		const { configs, exaApiKeys, sources } = loadedConfigs;
-		const result = await this.connectServers(configs, sources, options?.onStatus);
+		const requestedNames = options?.serverNames;
+		const effectiveNames =
+			this.#serverNames === undefined
+				? requestedNames
+				: requestedNames === undefined
+					? this.#serverNames
+					: requestedNames.filter(name => this.#serverNames?.has(name));
+		const allowedNames = effectiveNames === undefined ? undefined : new Set(effectiveNames);
+		const selectedConfigs =
+			allowedNames === undefined
+				? configs
+				: Object.fromEntries(Object.entries(configs).filter(([name]) => allowedNames.has(name)));
+		const selectedSources =
+			allowedNames === undefined
+				? sources
+				: Object.fromEntries(Object.entries(sources).filter(([name]) => allowedNames.has(name)));
+		const result = await this.connectServers(selectedConfigs, selectedSources, options?.onStatus);
 		result.exaApiKeys = exaApiKeys;
 		return result;
 	}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1092,6 +1092,7 @@ export async function runRpcMode(
 					tokensPerSecond: calculateTokensPerSecond(session.messages, session.isStreaming),
 					fastModeActive: session.isFastModeActive(),
 					messageCount: session.messages.length,
+					mcpServers: [...session.connectedMcpServers],
 					systemPrompt: session.systemPrompt,
 					dumpTools: session.agent.state.tools.map(tool => ({
 						name: tool.name,

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -117,6 +117,8 @@ export interface RpcSessionState {
 	/** For session dump / export (plain-text parity with /dump). */
 	systemPrompt?: string[];
 	dumpTools?: Array<{ name: string; description: string; parameters: unknown; examples?: readonly ToolExample[] }>;
+	/** Names of MCP servers currently connected to this session. */
+	mcpServers: string[];
 	/** Current context window usage. */
 	contextUsage?: ContextUsage;
 }

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -484,6 +484,12 @@ export interface CreateAgentSessionOptions {
 	enableMCP?: boolean;
 	/** Existing MCP manager to reuse when MCP is enabled (skips discovery, propagates to toolSession). */
 	mcpManager?: MCPManager;
+	/**
+	 * Exact discovered MCP server names to connect. `undefined` preserves
+	 * normal discovery; an empty list connects no discovered servers.
+	 * Ignored when an existing `mcpManager` is supplied.
+	 */
+	mcpServerNames?: readonly string[];
 
 	/** Enable LSP integration (tool, formatting, diagnostics, warmup). Default: true */
 	enableLsp?: boolean;
@@ -1844,11 +1850,16 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			filterExa: true,
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
+			serverNames: options.mcpServerNames,
 		};
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {
 				const cacheStorage = settings.getStorage();
-				mcpManager = new MCPManager(cwd, cacheStorage ? new MCPToolCache(cacheStorage) : null);
+				mcpManager = new MCPManager(
+					cwd,
+					cacheStorage ? new MCPToolCache(cacheStorage) : null,
+					options.mcpServerNames,
+				);
 				mcpManager.setAuthStorage(authStorage);
 				toolSession.mcpManager = mcpManager;
 
@@ -3443,6 +3454,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						return out;
 					}
 				: undefined,
+			getConnectedMcpServers: () => mcpManager?.getConnectedServers() ?? [],
 			disconnectOwnedMcpManager: ownedMcpManager ? () => ownedMcpManager.disconnectAll() : undefined,
 			ttsrManager,
 			obfuscator,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -221,6 +221,8 @@ export interface AgentSessionConfig {
 	presentationPinnedToolNames?: ReadonlySet<string>;
 	/** Accessor for live MCP server instructions. */
 	getMcpServerInstructions?: () => Map<string, string> | undefined;
+	/** Accessor for the names of MCP servers currently connected to this session. */
+	getConnectedMcpServers?: () => string[];
 	/** Time-traveling stream-rule manager. */
 	ttsrManager?: TtsrManager;
 	/** Secret obfuscator for provider and edit content. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -610,6 +610,7 @@ export class AgentSession {
 	#preferWebsockets: boolean | undefined;
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
+	#getConnectedMcpServers: () => string[];
 
 	readonly #ttsr: TtsrCoordinator;
 	readonly #stats: SessionStatsTracker;
@@ -1306,6 +1307,7 @@ export class AgentSession {
 			skillsReloadable: config.skillsReloadable,
 		});
 		this.#disconnectOwnedMcpManager = config.disconnectOwnedMcpManager;
+		this.#getConnectedMcpServers = config.getConnectedMcpServers ?? (() => []);
 		const ttsrHost: TtsrCoordinatorHost = {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
@@ -6333,6 +6335,11 @@ export class AgentSession {
 	/** Skill loading warnings captured by SDK */
 	get skillWarnings(): readonly SkillWarning[] {
 		return this.#tools.skillWarnings;
+	}
+
+	/** MCP server names currently connected to this session. */
+	get connectedMcpServers(): readonly string[] {
+		return this.#getConnectedMcpServers();
 	}
 
 	getTodoPhases(): TodoPhase[] {

--- a/packages/coding-agent/test/flag-tables.test.ts
+++ b/packages/coding-agent/test/flag-tables.test.ts
@@ -171,6 +171,19 @@ describe("parseArgs @file parsing with quotes", () => {
 	});
 });
 
+describe("--mcp-servers", () => {
+	it("parses, trims, and preserves exact connector names", () => {
+		const result = parseArgs(["--mcp-servers", " alpha, beta ,,alpha ", "prompt"]);
+
+		expect(result.mcpServers).toEqual(["alpha", "beta", "alpha"]);
+		expect(result.messages).toEqual(["prompt"]);
+	});
+
+	it("preserves an explicit empty selection", () => {
+		expect(parseArgs(["--mcp-servers="]).mcpServers).toEqual([]);
+	});
+});
+
 describe("foreign session import flags", () => {
 	it("parses each source flag without consuming the initial message", () => {
 		const claude = parseArgs(["--from-claude", "continue this session"]);

--- a/packages/coding-agent/test/mcp-server-allowlist.test.ts
+++ b/packages/coding-agent/test/mcp-server-allowlist.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import type { SourceMeta } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { type MCPLoadResult, MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { getConfigRootDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import "@oh-my-pi/pi-coding-agent/discovery/builtin";
+
+const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+class CapturingMCPManager extends MCPManager {
+	lastConfigNames: string[] = [];
+	lastSourceNames: string[] = [];
+
+	override async connectServers(
+		configs: Record<string, MCPServerConfig>,
+		sources: Record<string, SourceMeta>,
+	): Promise<MCPLoadResult> {
+		this.lastConfigNames = Object.keys(configs);
+		this.lastSourceNames = Object.keys(sources);
+		return {
+			tools: [],
+			errors: new Map(),
+			connectedServers: [...this.lastConfigNames],
+			exaApiKeys: [],
+		};
+	}
+}
+
+describe("MCP discovered-server allowlist", () => {
+	let projectDir = "";
+	let agentDir = "";
+
+	beforeEach(async () => {
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-allowlist-project-"));
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-allowlist-agent-"));
+		setAgentDir(agentDir);
+		clearFsCache();
+		await fs.mkdir(path.join(projectDir, ".omp"), { recursive: true });
+		await fs.writeFile(
+			path.join(projectDir, ".omp", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					alpha: { type: "http", url: "https://alpha.example/mcp" },
+					beta: { type: "http", url: "https://beta.example/mcp" },
+				},
+			}),
+		);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		clearFsCache();
+		if (originalAgentDirEnv) setAgentDir(originalAgentDirEnv);
+		else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		await removeWithRetries(projectDir);
+		await removeWithRetries(agentDir);
+	});
+
+	test("preserves normal discovery when omitted", async () => {
+		const manager = new CapturingMCPManager(projectDir);
+		const result = await manager.discoverAndConnect({ filterExa: false });
+
+		expect(result.connectedServers).toEqual(["alpha", "beta"]);
+		expect(manager.lastSourceNames).toEqual(["alpha", "beta"]);
+	});
+
+	test("connects only exact selected names before connection", async () => {
+		const manager = new CapturingMCPManager(projectDir);
+		const result = await manager.discoverAndConnect({ filterExa: false, serverNames: ["beta"] });
+
+		expect(result.connectedServers).toEqual(["beta"]);
+		expect(manager.lastSourceNames).toEqual(["beta"]);
+	});
+
+	test("keeps a session policy across rediscovery and narrower requests", async () => {
+		const manager = new CapturingMCPManager(projectDir, null, ["beta"]);
+
+		expect((await manager.discoverAndConnect({ filterExa: false })).connectedServers).toEqual(["beta"]);
+		expect(
+			(await manager.discoverAndConnect({ filterExa: false, serverNames: ["alpha", "beta"] })).connectedServers,
+		).toEqual(["beta"]);
+	});
+
+	test("treats empty and unknown selections as no connectors", async () => {
+		for (const serverNames of [[], ["missing"]]) {
+			const manager = new CapturingMCPManager(projectDir);
+			const result = await manager.discoverAndConnect({ filterExa: false, serverNames });
+			expect(result.connectedServers).toEqual([]);
+			expect(manager.lastSourceNames).toEqual([]);
+		}
+	});
+});

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -328,6 +328,7 @@ describe("RpcInputDispatcher", () => {
 						tokensPerSecond: null,
 						messageCount: 0,
 						queuedMessageCount: 0,
+						mcpServers: [],
 						todoPhases: [],
 					},
 				};


### PR DESCRIPTION
## Summary
- add an exact per-session MCP server allowlist to the SDK and `--mcp-servers` CLI
- enforce the policy before connection and across MCP rediscovery
- expose currently connected MCP server names through RPC `get_state`

## Verification
- `bun test test/mcp-server-allowlist.test.ts test/sdk-mcp-defer.test.ts test/reload-plugins-mcp.test.ts test/rpc-input-frame.test.ts test/flag-tables.test.ts` (78 passed)
- `bun run check:ts` (all TypeScript workspaces passed)
- full coding-agent test run: 12,303 passed; 14 environment-only failures because this Nyx dev shell lacks Python and ssh