### PR TITLE
Share Mnemopi embedding workers across sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Shared each local embedding model worker across concurrent OMP sessions through an authenticated machine-global broker, while retaining private-worker fallback both when broker acquisition fails and when an established broker connection is lost.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -34,6 +34,7 @@ import type { WorkerInbound as JsWorkerInbound, WorkerOutbound as JsWorkerOutbou
 import { DAEMON_BROKER_WORKER_ARG } from "./launch/protocol";
 import { TERMINAL_OUTPUT_WORKER_ARG } from "./launch/terminal-output-worker-protocol";
 import { LSP_MUX_WORKER_ARG } from "./lsp/mux/protocol";
+import { MNEMOPI_EMBED_BROKER_WORKER_ARG } from "./mnemopi/embed-broker";
 import { COMPUTER_WORKER_ARG } from "./tools/computer/protocol";
 import { smokeTestComputerWorker } from "./tools/computer/supervisor";
 import { startComputerWorker } from "./tools/computer/worker-entry";
@@ -203,6 +204,12 @@ async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	if (arg === MNEMOPI_EMBED_WORKER_ARG) {
 		const { startMnemopiEmbedWorker } = await import("./mnemopi/embed-worker");
 		await runIpcSubprocessWorker(startMnemopiEmbedWorker);
+		return true;
+	}
+	if (arg === MNEMOPI_EMBED_BROKER_WORKER_ARG) {
+		// The broker owns the native embedding workers, so load it only after hidden-worker dispatch.
+		const { startMnemopiEmbedBrokerFromEnvironment } = await import("./mnemopi/embed-broker-server");
+		await startMnemopiEmbedBrokerFromEnvironment();
 		return true;
 	}
 	if (arg === TERMINAL_OUTPUT_WORKER_ARG) {

--- a/packages/coding-agent/src/mnemopi/embed-broker-protocol.ts
+++ b/packages/coding-agent/src/mnemopi/embed-broker-protocol.ts
@@ -1,0 +1,164 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "./embed-protocol";
+
+/** Wire protocol major. Bump when an updated client cannot safely reuse an older broker. */
+export const MNEMOPI_EMBED_BROKER_PROTOCOL = 2;
+
+export interface MnemopiEmbedBrokerRequest {
+	protocol: typeof MNEMOPI_EMBED_BROKER_PROTOCOL;
+	id: string;
+	message: MnemopiEmbedWorkerInbound;
+	mac: string;
+}
+
+export type MnemopiEmbedBrokerResponse =
+	| {
+			protocol: typeof MNEMOPI_EMBED_BROKER_PROTOCOL;
+			id: string;
+			ok: true;
+			message: MnemopiEmbedWorkerOutbound;
+			mac: string;
+	  }
+	| {
+			protocol: typeof MNEMOPI_EMBED_BROKER_PROTOCOL;
+			id: string;
+			ok: false;
+			error: string;
+			mac: string;
+	  };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown, label: string): string {
+	if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+	return value;
+}
+
+function payloadMac(token: string, payload: unknown): string {
+	return createHmac("sha256", token).update(JSON.stringify(payload)).digest("hex");
+}
+
+function verifyMac(token: string, payload: unknown, received: unknown): void {
+	const mac = nonEmptyString(received, "mac");
+	const expected = payloadMac(token, payload);
+	const receivedBytes = Buffer.from(mac, "hex");
+	const expectedBytes = Buffer.from(expected, "hex");
+	if (receivedBytes.length !== expectedBytes.length || !timingSafeEqual(receivedBytes, expectedBytes)) {
+		throw new Error("Mnemopi embed broker authentication failed");
+	}
+}
+
+export function parseMnemopiEmbedWorkerInbound(value: unknown): MnemopiEmbedWorkerInbound {
+	if (!isRecord(value)) throw new Error("message must be an object");
+	const type = nonEmptyString(value.type, "message.type");
+	const id = nonEmptyString(value.id, "message.id");
+	if (type === "ping") return { type, id };
+	const model = nonEmptyString(value.model, "message.model");
+	const cacheDir = value.cacheDir === undefined ? undefined : nonEmptyString(value.cacheDir, "message.cacheDir");
+	if (type === "init") return { type, id, model, cacheDir };
+	if (type !== "embed") throw new Error(`unsupported message.type: ${type}`);
+	if (!Array.isArray(value.texts) || !value.texts.every(text => typeof text === "string")) {
+		throw new Error("message.texts must be an array of strings");
+	}
+	const batchSize = value.batchSize;
+	if (batchSize !== undefined && (!Number.isSafeInteger(batchSize) || Number(batchSize) <= 0)) {
+		throw new Error("message.batchSize must be a positive integer");
+	}
+	return { type, id, model, cacheDir, texts: value.texts, batchSize: batchSize as number | undefined };
+}
+
+export function parseMnemopiEmbedWorkerOutbound(value: unknown): MnemopiEmbedWorkerOutbound {
+	if (!isRecord(value)) throw new Error("message must be an object");
+	const type = nonEmptyString(value.type, "message.type");
+	if (type === "log") {
+		if (value.level !== "debug" && value.level !== "warn" && value.level !== "error") {
+			throw new Error("message.level is invalid");
+		}
+		const msg = nonEmptyString(value.msg, "message.msg");
+		if (value.meta !== undefined && !isRecord(value.meta)) throw new Error("message.meta must be an object");
+		return { type, level: value.level, msg, meta: value.meta };
+	}
+	const id = nonEmptyString(value.id, "message.id");
+	if (type === "pong" || type === "ready") return { type, id };
+	if (type === "error") return { type, id, error: nonEmptyString(value.error, "message.error") };
+	if (type !== "vectors") throw new Error(`unsupported message.type: ${type}`);
+	if (
+		!Array.isArray(value.vectors) ||
+		!value.vectors.every(
+			row =>
+				Array.isArray(row) && row.every(component => typeof component === "number" && Number.isFinite(component)),
+		)
+	) {
+		throw new Error("message.vectors must be an array of finite number arrays");
+	}
+	return { type, id, vectors: value.vectors as number[][] };
+}
+
+export function encodeMnemopiEmbedBrokerRequest(
+	token: string,
+	id: string,
+	message: MnemopiEmbedWorkerInbound,
+): MnemopiEmbedBrokerRequest {
+	const payload = { protocol: MNEMOPI_EMBED_BROKER_PROTOCOL, id, message } as const;
+	return { ...payload, mac: payloadMac(token, payload) };
+}
+
+export function parseMnemopiEmbedBrokerRequest(value: unknown, token: string): MnemopiEmbedBrokerRequest {
+	if (!isRecord(value)) throw new Error("broker request must be an object");
+	if (value.protocol !== MNEMOPI_EMBED_BROKER_PROTOCOL) {
+		throw new Error(`unsupported mnemopi embed broker protocol: ${String(value.protocol)}`);
+	}
+	const id = nonEmptyString(value.id, "id");
+	const payload = { protocol: MNEMOPI_EMBED_BROKER_PROTOCOL, id, message: value.message } as const;
+	verifyMac(token, payload, value.mac);
+	return {
+		protocol: MNEMOPI_EMBED_BROKER_PROTOCOL,
+		id,
+		message: parseMnemopiEmbedWorkerInbound(value.message),
+		mac: nonEmptyString(value.mac, "mac"),
+	};
+}
+
+export function encodeMnemopiEmbedBrokerResponse(
+	token: string,
+	response: { id: string; ok: true; message: MnemopiEmbedWorkerOutbound } | { id: string; ok: false; error: string },
+): MnemopiEmbedBrokerResponse {
+	const normalized =
+		response.ok && response.message.type === "vectors"
+			? {
+					...response,
+					message: { ...response.message, vectors: response.message.vectors.map(row => Array.from(row)) },
+				}
+			: response;
+	const payload = { protocol: MNEMOPI_EMBED_BROKER_PROTOCOL, ...normalized } as const;
+	return { ...payload, mac: payloadMac(token, payload) };
+}
+
+export function parseMnemopiEmbedBrokerResponse(value: unknown, token: string): MnemopiEmbedBrokerResponse {
+	if (!isRecord(value)) throw new Error("broker response must be an object");
+	if (value.protocol !== MNEMOPI_EMBED_BROKER_PROTOCOL) {
+		throw new Error(`unsupported mnemopi embed broker protocol: ${String(value.protocol)}`);
+	}
+	const id = nonEmptyString(value.id, "id");
+	if (value.ok === false) {
+		const rawError = value.error;
+		const payload = { protocol: MNEMOPI_EMBED_BROKER_PROTOCOL, id, ok: false as const, error: rawError } as const;
+		verifyMac(token, payload, value.mac);
+		return {
+			...payload,
+			error: nonEmptyString(rawError, "error"),
+			mac: nonEmptyString(value.mac, "mac"),
+		};
+	}
+	if (value.ok !== true) throw new Error("broker response is malformed");
+	const rawMessage = value.message;
+	const payload = { protocol: MNEMOPI_EMBED_BROKER_PROTOCOL, id, ok: true as const, message: rawMessage } as const;
+	verifyMac(token, payload, value.mac);
+	return {
+		...payload,
+		message: parseMnemopiEmbedWorkerOutbound(rawMessage),
+		mac: nonEmptyString(value.mac, "mac"),
+	};
+}

--- a/packages/coding-agent/src/mnemopi/embed-broker-server.ts
+++ b/packages/coding-agent/src/mnemopi/embed-broker-server.ts
@@ -1,0 +1,30 @@
+import { postmortem, setProcessName } from "@oh-my-pi/pi-utils";
+import {
+	MNEMOPI_EMBED_BROKER_ENDPOINT_ENV,
+	MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV,
+	MnemopiEmbedBroker,
+	mnemopiEmbedBrokerReadyBanner,
+} from "./embed-broker";
+import { spawnMnemopiEmbedWorker } from "./embed-client";
+
+/** Start the machine-global embedding broker selected by the hidden CLI worker entrypoint. */
+export async function startMnemopiEmbedBrokerFromEnvironment(): Promise<void> {
+	const endpoint = process.env[MNEMOPI_EMBED_BROKER_ENDPOINT_ENV];
+	const tokenFile = process.env[MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV];
+	if (!endpoint || !tokenFile) throw new Error("Mnemopi embed broker environment is incomplete");
+	delete process.env[MNEMOPI_EMBED_BROKER_ENDPOINT_ENV];
+	delete process.env[MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV];
+	const token = (await Bun.file(tokenFile).text()).trim();
+	if (!token) throw new Error("Mnemopi embed broker token is empty");
+	setProcessName("omp mnemopi embed broker");
+	const broker = new MnemopiEmbedBroker({ token, spawnWorker: spawnMnemopiEmbedWorker });
+	const cancelCleanup = postmortem.register("mnemopi-embed-broker", () => broker.shutdown());
+	try {
+		await broker.listen(endpoint);
+		process.stdout.write(`${mnemopiEmbedBrokerReadyBanner(endpoint)}\n`);
+		await Promise.withResolvers<never>().promise;
+	} finally {
+		cancelCleanup();
+		await broker.shutdown();
+	}
+}

--- a/packages/coding-agent/src/mnemopi/embed-broker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-broker.ts
@@ -119,10 +119,13 @@ export class MnemopiEmbedBroker {
 	#accept(socket: net.Socket): void {
 		this.#sockets.add(socket);
 		let buffer = "";
+		let bufferBytes = 0;
 		socket.setEncoding("utf8");
 		socket.on("data", chunk => {
-			buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
-			if (Buffer.byteLength(buffer) > MAX_LINE_BYTES) {
+			const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+			buffer += text;
+			bufferBytes += Buffer.byteLength(text);
+			if (bufferBytes > MAX_LINE_BYTES) {
 				socket.destroy(new Error("Mnemopi embed broker request exceeds size limit"));
 				return;
 			}
@@ -130,6 +133,7 @@ export class MnemopiEmbedBroker {
 				const newline = buffer.indexOf("\n");
 				if (newline < 0) break;
 				const line = buffer.slice(0, newline);
+				bufferBytes -= Buffer.byteLength(line) + 1;
 				buffer = buffer.slice(newline + 1);
 				if (line) void this.#handleLine(socket, line);
 			}
@@ -244,12 +248,6 @@ export class MnemopiEmbedBroker {
 	#reply(socket: net.Socket, id: string, message: MnemopiEmbedWorkerOutbound): void {
 		if (socket.destroyed) return;
 		const response = encodeMnemopiEmbedBrokerResponse(this.#token, { id, ok: true, message });
-		socket.write(`${JSON.stringify(response)}\n`);
-	}
-
-	#reject(socket: net.Socket, id: string, error: string): void {
-		if (socket.destroyed) return;
-		const response = encodeMnemopiEmbedBrokerResponse(this.#token, { id, ok: false, error });
 		socket.write(`${JSON.stringify(response)}\n`);
 	}
 }

--- a/packages/coding-agent/src/mnemopi/embed-broker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-broker.ts
@@ -1,0 +1,359 @@
+import { createHmac } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import * as path from "node:path";
+import {
+	encodeMnemopiEmbedBrokerRequest,
+	encodeMnemopiEmbedBrokerResponse,
+	MNEMOPI_EMBED_BROKER_PROTOCOL,
+	parseMnemopiEmbedBrokerRequest,
+	parseMnemopiEmbedBrokerResponse,
+} from "./embed-broker-protocol";
+import type { MnemopiEmbedWorkerHandle } from "./embed-client";
+import type { MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "./embed-protocol";
+
+const MAX_LINE_BYTES = 16 * 1024 * 1024;
+
+const DEFAULT_WORKER_REQUEST_TIMEOUT_MS = 120_000;
+
+export const MNEMOPI_EMBED_BROKER_SCOPE = `mnemopi-embed-v${MNEMOPI_EMBED_BROKER_PROTOCOL}`;
+export const MNEMOPI_EMBED_BROKER_DAEMON_NAME = `omp.mnemopi.embed.v${MNEMOPI_EMBED_BROKER_PROTOCOL}`;
+export const MNEMOPI_EMBED_BROKER_WORKER_ARG = "__omp_worker_mnemopi_embed_broker";
+export const MNEMOPI_EMBED_BROKER_ENDPOINT_ENV = "OMP_MNEMOPI_EMBED_BROKER_ENDPOINT";
+export const MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV = "OMP_MNEMOPI_EMBED_BROKER_TOKEN_FILE";
+export const MNEMOPI_EMBED_BROKER_READY_PATTERN = String.raw`omp mnemopi embed broker listening on \S+`;
+
+export function mnemopiEmbedBrokerPipeName(token: string): string {
+	const key = createHmac("sha256", token).update(MNEMOPI_EMBED_BROKER_SCOPE).digest("hex").slice(0, 32);
+	return `omp-mnemopi-embed-v${MNEMOPI_EMBED_BROKER_PROTOCOL}-${key}`;
+}
+
+export function mnemopiEmbedBrokerEndpoint(runtimeDir: string, token: string): string {
+	if (process.platform === "win32") return `\\\\.\\pipe\\${mnemopiEmbedBrokerPipeName(token)}`;
+	return path.join(runtimeDir, `mnemopi-embed-v${MNEMOPI_EMBED_BROKER_PROTOCOL}.sock`);
+}
+
+export function mnemopiEmbedBrokerReadyBanner(endpoint: string): string {
+	return `omp mnemopi embed broker listening on ${endpoint}`;
+}
+interface PendingWorkerRequest {
+	socket: net.Socket;
+	resolve: (message: MnemopiEmbedWorkerOutbound) => void;
+	reject: (error: Error) => void;
+}
+
+interface WorkerSlot {
+	worker: MnemopiEmbedWorkerHandle;
+	queue: Promise<void>;
+	pending: Map<string, PendingWorkerRequest>;
+	retired: boolean;
+	unsubscribeMessage: () => void;
+	unsubscribeError: () => void;
+}
+
+export interface MnemopiEmbedBrokerOptions {
+	token: string;
+	spawnWorker: () => MnemopiEmbedWorkerHandle;
+	workerRequestTimeoutMs?: number;
+}
+
+function cacheKey(message: Extract<MnemopiEmbedWorkerInbound, { type: "init" | "embed" }>): string {
+	const cacheDir = message.cacheDir === undefined ? "" : path.resolve(message.cacheDir);
+	return `${message.model}\u0000${cacheDir}`;
+}
+
+/** Owns one disposable embedding worker per model/cache key and multiplexes independent OMP clients onto it. */
+export class MnemopiEmbedBroker {
+	readonly #token: string;
+	readonly #spawnWorker: () => MnemopiEmbedWorkerHandle;
+	readonly #workerRequestTimeoutMs: number;
+	readonly #slots = new Map<string, WorkerSlot>();
+	readonly #sockets = new Set<net.Socket>();
+	#server: net.Server | undefined;
+	#endpoint: string | undefined;
+	#nextWorkerRequestId = 0;
+	#shuttingDown = false;
+
+	constructor(options: MnemopiEmbedBrokerOptions) {
+		if (!options.token) throw new Error("Mnemopi embed broker token is empty");
+		this.#token = options.token;
+		this.#spawnWorker = options.spawnWorker;
+		this.#workerRequestTimeoutMs = options.workerRequestTimeoutMs ?? DEFAULT_WORKER_REQUEST_TIMEOUT_MS;
+	}
+
+	get workerCount(): number {
+		return this.#slots.size;
+	}
+
+	async listen(endpoint: string): Promise<void> {
+		if (this.#server) throw new Error("Mnemopi embed broker is already listening");
+		if (process.platform !== "win32") await fs.rm(endpoint, { force: true });
+		const server = net.createServer(socket => this.#accept(socket));
+		this.#server = server;
+		this.#endpoint = endpoint;
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		server.once("listening", resolve);
+		server.once("error", reject);
+		server.listen(endpoint);
+		await promise;
+		if (process.platform !== "win32") await fs.chmod(endpoint, 0o600);
+	}
+
+	async shutdown(): Promise<void> {
+		if (this.#shuttingDown) return;
+		this.#shuttingDown = true;
+		for (const socket of this.#sockets) socket.destroy();
+		this.#sockets.clear();
+		await Promise.all([...this.#slots.values()].map(slot => this.#retireSlot(slot, new Error("broker shutdown"))));
+		this.#slots.clear();
+		const server = this.#server;
+		this.#server = undefined;
+		if (server) {
+			const { promise, resolve } = Promise.withResolvers<void>();
+			server.close(() => resolve());
+			await promise;
+		}
+		if (process.platform !== "win32" && this.#endpoint) await fs.rm(this.#endpoint, { force: true });
+	}
+
+	#accept(socket: net.Socket): void {
+		this.#sockets.add(socket);
+		let buffer = "";
+		socket.setEncoding("utf8");
+		socket.on("data", chunk => {
+			buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+			if (Buffer.byteLength(buffer) > MAX_LINE_BYTES) {
+				socket.destroy(new Error("Mnemopi embed broker request exceeds size limit"));
+				return;
+			}
+			for (;;) {
+				const newline = buffer.indexOf("\n");
+				if (newline < 0) break;
+				const line = buffer.slice(0, newline);
+				buffer = buffer.slice(newline + 1);
+				if (line) void this.#handleLine(socket, line);
+			}
+		});
+		socket.on("error", () => {});
+		socket.on("close", () => this.#clientDisconnected(socket));
+	}
+
+	#clientDisconnected(socket: net.Socket): void {
+		this.#sockets.delete(socket);
+		for (const slot of this.#slots.values()) {
+			if ([...slot.pending.values()].some(pending => pending.socket === socket)) {
+				void this.#dropSlot(slot, new Error("Embedding client disconnected"));
+			}
+		}
+	}
+	async #handleLine(socket: net.Socket, line: string): Promise<void> {
+		let wireId = "unknown";
+		let callerId = "unknown";
+		try {
+			const request = parseMnemopiEmbedBrokerRequest(JSON.parse(line) as unknown, this.#token);
+			wireId = request.id;
+			callerId = request.message.id;
+			const message = request.message;
+			if (message.type === "ping") {
+				this.#reply(socket, wireId, { type: "pong", id: message.id });
+				return;
+			}
+			const response = await this.#dispatch(socket, message);
+			if (response.type === "log") throw new Error("Mnemopi embed worker returned an uncorrelated log response");
+			this.#reply(socket, wireId, { ...response, id: message.id });
+		} catch (error) {
+			if (callerId === "unknown") {
+				socket.destroy();
+				return;
+			}
+			const detail = error instanceof Error ? error.message : String(error);
+			this.#reply(socket, wireId, { type: "error", id: callerId, error: detail });
+		}
+	}
+	#dispatch(
+		socket: net.Socket,
+		message: Extract<MnemopiEmbedWorkerInbound, { type: "init" | "embed" }>,
+	): Promise<MnemopiEmbedWorkerOutbound> {
+		const key = cacheKey(message);
+		const slot = this.#slot(key);
+		const { promise, resolve, reject } = Promise.withResolvers<MnemopiEmbedWorkerOutbound>();
+		slot.queue = slot.queue
+			.then(async () => {
+				if (socket.destroyed) throw new Error("Embedding client disconnected");
+				if (slot.retired) return this.#dispatch(socket, message).then(resolve, reject);
+				const id = `broker:${++this.#nextWorkerRequestId}`;
+				const response = Promise.withResolvers<MnemopiEmbedWorkerOutbound>();
+				slot.pending.set(id, { socket, resolve: response.resolve, reject: response.reject });
+				const timer =
+					message.type === "embed"
+						? setTimeout(
+								() => void this.#dropSlot(slot, new Error("Mnemopi embed worker request timed out")),
+								this.#workerRequestTimeoutMs,
+							)
+						: undefined;
+				timer?.unref();
+				try {
+					slot.worker.send({ ...message, id });
+					resolve(await response.promise);
+				} finally {
+					if (timer) clearTimeout(timer);
+					slot.pending.delete(id);
+				}
+			})
+			.catch(reject);
+		return promise;
+	}
+
+	#slot(key: string): WorkerSlot {
+		const existing = this.#slots.get(key);
+		if (existing && !existing.retired) return existing;
+		const worker = this.#spawnWorker();
+		const slot: WorkerSlot = {
+			worker,
+			queue: Promise.resolve(),
+			pending: new Map(),
+			retired: false,
+			unsubscribeMessage: () => {},
+			unsubscribeError: () => {},
+		};
+		slot.unsubscribeMessage = worker.onMessage(message => {
+			if (message.type === "log") return;
+			const pending = slot.pending.get(message.id);
+			if (pending) pending.resolve(message);
+		});
+		slot.unsubscribeError = worker.onError(error => void this.#dropSlot(slot, error));
+		this.#slots.set(key, slot);
+		return slot;
+	}
+
+	async #dropSlot(slot: WorkerSlot, error: Error): Promise<void> {
+		for (const [key, candidate] of this.#slots) if (candidate === slot) this.#slots.delete(key);
+		await this.#retireSlot(slot, error);
+	}
+
+	async #retireSlot(slot: WorkerSlot, error: Error): Promise<void> {
+		if (slot.retired) return;
+		slot.retired = true;
+		slot.unsubscribeMessage();
+		slot.unsubscribeError();
+		for (const pending of slot.pending.values()) pending.reject(error);
+		slot.pending.clear();
+		await slot.worker.terminate();
+	}
+
+	#reply(socket: net.Socket, id: string, message: MnemopiEmbedWorkerOutbound): void {
+		if (socket.destroyed) return;
+		const response = encodeMnemopiEmbedBrokerResponse(this.#token, { id, ok: true, message });
+		socket.write(`${JSON.stringify(response)}\n`);
+	}
+
+	#reject(socket: net.Socket, id: string, error: string): void {
+		if (socket.destroyed) return;
+		const response = encodeMnemopiEmbedBrokerResponse(this.#token, { id, ok: false, error });
+		socket.write(`${JSON.stringify(response)}\n`);
+	}
+}
+
+class SocketMnemopiEmbedHandle implements MnemopiEmbedWorkerHandle {
+	readonly #socket: net.Socket;
+	readonly #token: string;
+	readonly #listeners = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
+	readonly #errors = new Set<(error: Error) => void>();
+	#buffer = "";
+	#nextWireId = 0;
+	#closed = false;
+
+	constructor(socket: net.Socket, token: string) {
+		this.#socket = socket;
+		this.#token = token;
+		socket.setEncoding("utf8");
+		socket.on("data", chunk => this.#onData(typeof chunk === "string" ? chunk : chunk.toString("utf8")));
+		socket.on("error", error => this.#emitError(error));
+		socket.on("close", () => {
+			if (!this.#closed) this.#emitError(new Error("Mnemopi embed broker connection closed"));
+		});
+	}
+
+	send(message: MnemopiEmbedWorkerInbound): void {
+		if (this.#closed || this.#socket.destroyed) throw new Error("Mnemopi embed broker connection is closed");
+		const request = encodeMnemopiEmbedBrokerRequest(this.#token, String(++this.#nextWireId), message);
+		this.#socket.write(`${JSON.stringify(request)}\n`);
+	}
+
+	onMessage(handler: (message: MnemopiEmbedWorkerOutbound) => void): () => void {
+		this.#listeners.add(handler);
+		return () => this.#listeners.delete(handler);
+	}
+
+	onError(handler: (error: Error) => void): () => void {
+		this.#errors.add(handler);
+		return () => this.#errors.delete(handler);
+	}
+
+	async terminate(): Promise<void> {
+		this.#closed = true;
+		this.#socket.destroy();
+		this.#listeners.clear();
+		this.#errors.clear();
+	}
+
+	#onData(chunk: string): void {
+		this.#buffer += chunk;
+		for (;;) {
+			const newline = this.#buffer.indexOf("\n");
+			if (newline < 0) return;
+			const line = this.#buffer.slice(0, newline);
+			this.#buffer = this.#buffer.slice(newline + 1);
+			if (!line) continue;
+			try {
+				const response = parseMnemopiEmbedBrokerResponse(JSON.parse(line) as unknown, this.#token);
+				if (!response.ok) {
+					for (const listener of this.#listeners)
+						listener({ type: "error", id: response.id, error: response.error });
+					continue;
+				}
+				for (const listener of this.#listeners) listener(response.message);
+			} catch (error) {
+				this.#emitError(error instanceof Error ? error : new Error(String(error)));
+			}
+		}
+	}
+
+	#emitError(error: Error): void {
+		for (const listener of this.#errors) listener(error);
+	}
+}
+
+export async function connectMnemopiEmbedBroker(options: {
+	endpoint: string;
+	token: string;
+	timeoutMs?: number;
+}): Promise<MnemopiEmbedWorkerHandle> {
+	const { promise, resolve, reject } = Promise.withResolvers<net.Socket>();
+	const socket = net.createConnection({ path: options.endpoint });
+	const timer = setTimeout(() => {
+		socket.destroy();
+		reject(new Error(`Timed out connecting to Mnemopi embed broker at ${options.endpoint}`));
+	}, options.timeoutMs ?? 1_000);
+	const cleanup = (): void => {
+		clearTimeout(timer);
+		socket.off("connect", onConnect);
+		socket.off("error", onError);
+	};
+	const onConnect = (): void => {
+		cleanup();
+		resolve(socket);
+	};
+	const onError = (error: Error): void => {
+		cleanup();
+		socket.destroy();
+		reject(error);
+	};
+	socket.once("connect", onConnect);
+	socket.once("error", onError);
+	return new SocketMnemopiEmbedHandle(await promise, options.token);
+}
+
+export async function removeStaleMnemopiEmbedEndpoint(endpoint: string): Promise<void> {
+	if (process.platform !== "win32") await fs.rm(endpoint, { force: true });
+}

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -13,14 +13,16 @@ import {
 	workerEnvFromParent,
 } from "../subprocess/worker-client";
 import type { MnemopiEmbedModelId, MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "./embed-protocol";
+import { connectSharedMnemopiEmbedWorker } from "./embed-shared-client";
+import { acquireGlobalMnemopiEmbedWorker } from "./embed-shared-daemon";
 
 /**
- * Parent-side handle for the mnemopi embeddings subprocess. The runtime
- * implementation is a Bun child process so `onnxruntime-node`'s NAPI
- * constructor + finalizer never run inside the main agent address space —
- * those destructors segfault Bun on Windows when mnemopi's local embedding
- * provider loads fastembed in the main process (issue #3031; the mnemopi
- * sibling of the tiny-model fix from #1606 / #1607).
+ * Client-side handle for the mnemopi embedding transport. Production uses a
+ * machine-global broker that owns one Bun child per model/cache key; broker
+ * failure falls back to a private child owned by this process. Both paths keep
+ * `onnxruntime-node`'s NAPI constructor + finalizer outside the main agent
+ * address space, whose Windows shutdown path otherwise segfaults Bun (issue
+ * #3031; the mnemopi sibling of the tiny-model fix from #1606 / #1607).
  */
 export type MnemopiEmbedWorkerHandle = WorkerHandle<MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound>;
 
@@ -65,7 +67,7 @@ function wrapSubprocess(spawned: SpawnedSubprocess<MnemopiEmbedWorkerOutbound>):
 	});
 }
 
-function spawnMnemopiEmbedWorker(): MnemopiEmbedWorkerHandle {
+export function spawnMnemopiEmbedWorker(): MnemopiEmbedWorkerHandle {
 	return spawnWorkerOrUnavailable(
 		() => wrapSubprocess(createMnemopiEmbedSubprocess()),
 		createUnavailableWorker<MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound>,
@@ -73,12 +75,14 @@ function spawnMnemopiEmbedWorker(): MnemopiEmbedWorkerHandle {
 	);
 }
 
+type MnemopiEmbedWorkerFactory = () => MnemopiEmbedWorkerHandle | Promise<MnemopiEmbedWorkerHandle>;
+
 /**
  * Per-model wrapper produced by {@link MnemopiEmbedClient.initialize}.
- * `embed()` round-trips one batch of texts through the worker subprocess and
- * yields the resulting vectors in a single asynchronous batch — fastembed's
- * own iterator was emitting batches that we collect on the child side anyway,
- * and serializing per-batch over IPC would not improve throughput.
+ * `embed()` round-trips one batch through the selected transport and yields
+ * the resulting vectors in one asynchronous batch. Fastembed's iterator is
+ * already collected on the child side, so serializing each native batch over
+ * the broker or private IPC path would not improve throughput.
  */
 export interface MnemopiSubprocessEmbeddingModel {
 	embed(texts: string[], batchSize?: number): AsyncIterable<number[][]>;
@@ -102,15 +106,17 @@ const REQUEST_TIMED_OUT = Symbol("mnemopi.embed.timedOut");
 
 export class MnemopiEmbedClient {
 	#worker: MnemopiEmbedWorkerHandle | null = null;
+	#workerPromise: Promise<MnemopiEmbedWorkerHandle> | null = null;
 	#unsubscribeMessage: (() => void) | null = null;
 	#unsubscribeError: (() => void) | null = null;
 	#pending = new Map<string, PendingRequest>();
 	#nextRequestId = 0;
-	#spawnWorker: () => MnemopiEmbedWorkerHandle;
+	#workerGeneration = 0;
+	#spawnWorker: MnemopiEmbedWorkerFactory;
 	#requestTimeoutMs: number;
 
 	constructor(
-		spawnWorker: () => MnemopiEmbedWorkerHandle = spawnMnemopiEmbedWorker,
+		spawnWorker: MnemopiEmbedWorkerFactory = spawnMnemopiEmbedWorker,
 		requestTimeoutMs: number = EMBED_REQUEST_TIMEOUT_MS,
 	) {
 		this.#spawnWorker = spawnWorker;
@@ -118,19 +124,22 @@ export class MnemopiEmbedClient {
 	}
 
 	/**
-	 * Load the named fastembed model inside the subprocess. Resolves to a
-	 * thin wrapper whose `embed()` round-trips through the same worker, or
-	 * `null` when the worker cannot init the model (missing peer, native
-	 * load failure, etc.). Multiple calls with the same model reuse the
-	 * single in-flight worker; calling with a different model loads it on
-	 * the child without restarting the process.
+	 * Load the named fastembed model through the selected transport. Resolves to
+	 * a thin wrapper whose `embed()` uses the same broker connection or private
+	 * worker, or `null` when model initialization fails. One client reuses its
+	 * transport; the broker independently keys native children by resolved
+	 * (model, cacheDir).
 	 */
 	async initialize(
 		model: MnemopiEmbedModelId,
 		cacheDir: string | undefined,
 	): Promise<MnemopiSubprocessEmbeddingModel | null> {
 		try {
-			const worker = this.#ensureWorker();
+			const generation = this.#workerGeneration;
+			const worker = await this.#ensureWorker();
+			if (generation !== this.#workerGeneration || worker !== this.#worker) {
+				throw new Error("mnemopi embed worker terminated during startup");
+			}
 			const id = String(++this.#nextRequestId);
 			const { promise, resolve } = Promise.withResolvers<boolean>();
 			this.#pending.set(id, { kind: "init", model, resolve });
@@ -152,8 +161,10 @@ export class MnemopiEmbedClient {
 	}
 
 	async terminate(): Promise<void> {
+		this.#workerGeneration += 1;
 		const worker = this.#worker;
 		this.#worker = null;
+		this.#workerPromise = null;
 		this.#unsubscribeMessage?.();
 		this.#unsubscribeMessage = null;
 		this.#unsubscribeError?.();
@@ -176,7 +187,11 @@ export class MnemopiEmbedClient {
 		texts: string[],
 		batchSize: number | undefined,
 	): Promise<number[][]> {
-		const worker = this.#ensureWorker();
+		const generation = this.#workerGeneration;
+		const worker = await this.#ensureWorker();
+		if (generation !== this.#workerGeneration || worker !== this.#worker) {
+			throw new Error("mnemopi embed worker terminated during startup");
+		}
 		const id = String(++this.#nextRequestId);
 		const { promise, resolve } = Promise.withResolvers<number[][] | Error>();
 		this.#pending.set(id, { kind: "embed", model, resolve });
@@ -235,13 +250,26 @@ export class MnemopiEmbedClient {
 		yield vectors;
 	}
 
-	#ensureWorker(): MnemopiEmbedWorkerHandle {
+	async #ensureWorker(): Promise<MnemopiEmbedWorkerHandle> {
 		if (this.#worker) return this.#worker;
-		const worker = this.#spawnWorker();
-		this.#worker = worker;
-		this.#unsubscribeMessage = worker.onMessage(message => this.#handleMessage(message));
-		this.#unsubscribeError = worker.onError(error => this.#handleWorkerError(error));
-		return worker;
+		if (this.#workerPromise) return this.#workerPromise;
+		const generation = this.#workerGeneration;
+		const pending = Promise.resolve(this.#spawnWorker()).then(async worker => {
+			if (generation !== this.#workerGeneration) {
+				await worker.terminate().catch(() => {});
+				throw new Error("mnemopi embed worker terminated during startup");
+			}
+			this.#worker = worker;
+			this.#unsubscribeMessage = worker.onMessage(message => this.#handleMessage(message));
+			this.#unsubscribeError = worker.onError(error => this.#handleWorkerError(error));
+			return worker;
+		});
+		this.#workerPromise = pending;
+		try {
+			return await pending;
+		} finally {
+			if (this.#workerPromise === pending) this.#workerPromise = null;
+		}
 	}
 
 	#handleMessage(message: MnemopiEmbedWorkerOutbound): void {
@@ -249,22 +277,25 @@ export class MnemopiEmbedClient {
 			logWorkerMessage(message);
 			return;
 		}
-		if (message.type === "pong") return;
 
 		const pending = this.#pending.get(message.id);
 		if (!pending) return;
 		this.#pending.delete(message.id);
-		if (message.type === "ready") {
-			if (pending.kind === "init") pending.resolve(true);
+		if (pending.kind === "init") {
+			if (message.type === "ready") pending.resolve(true);
+			else {
+				if (message.type === "error")
+					logger.debug("mnemopi-embed: worker returned error", { error: message.error });
+				else logger.debug("mnemopi-embed: unexpected response to init", { response: message.type });
+				pending.resolve(false);
+			}
 			return;
 		}
-		if (message.type === "vectors") {
-			if (pending.kind === "embed") pending.resolve(message.vectors);
-			return;
-		}
-		logger.debug("mnemopi-embed: worker returned error", { error: message.error });
-		if (pending.kind === "init") pending.resolve(false);
-		else pending.resolve(new Error(message.error));
+		if (message.type === "vectors") pending.resolve(message.vectors);
+		else if (message.type === "error") {
+			logger.debug("mnemopi-embed: worker returned error", { error: message.error });
+			pending.resolve(new Error(message.error));
+		} else pending.resolve(new Error(`mnemopi embed worker returned unexpected ${message.type} response`));
 	}
 
 	#handleWorkerError(error: Error): void {
@@ -278,7 +309,9 @@ export class MnemopiEmbedClient {
 	}
 }
 
-export const mnemopiEmbedClient = new MnemopiEmbedClient();
+export const mnemopiEmbedClient = new MnemopiEmbedClient(() =>
+	connectSharedMnemopiEmbedWorker(spawnMnemopiEmbedWorker, acquireGlobalMnemopiEmbedWorker),
+);
 
 export async function shutdownMnemopiEmbedClient(): Promise<void> {
 	await mnemopiEmbedClient.terminate();

--- a/packages/coding-agent/src/mnemopi/embed-protocol.ts
+++ b/packages/coding-agent/src/mnemopi/embed-protocol.ts
@@ -1,12 +1,12 @@
 /**
- * Wire types between the parent (`MnemopiEmbedClient`) and the local
- * embeddings subprocess. The parent owns the subprocess lifecycle (graceful
- * work, hard `SIGKILL` on shutdown); the protocol carries no explicit close
- * handshake — once the parent decides to terminate, it signals the OS to reap
- * the child so `onnxruntime-node`'s NAPI finalizer never runs in the main
- * agent address space (it crashes Bun on Windows shutdown — issue #3031, the
- * mnemopi sibling of the tiny-model fix from #1606/#1607). See
- * `embed-client.ts` for the spawn/kill glue.
+ * Wire types between a parent handle and the local embeddings subprocess.
+ * The machine-global broker normally owns that subprocess; an agent owns it
+ * only when broker acquisition falls back to a private worker. The protocol
+ * carries no explicit close handshake: either parent hard-reaps the child so
+ * `onnxruntime-node`'s NAPI finalizer never runs in the parent address space
+ * (it crashes Bun on Windows shutdown, issue #3031, the mnemopi sibling of
+ * the tiny-model fix from #1606/#1607). See `embed-client.ts` for the
+ * spawn/kill glue.
  */
 
 /** Identifier of the fastembed model the worker should load (e.g. `fast-bge-base-en-v1.5`). */

--- a/packages/coding-agent/src/mnemopi/embed-shared-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-shared-client.ts
@@ -1,0 +1,95 @@
+import type { MnemopiEmbedWorkerHandle } from "./embed-client";
+import type { MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "./embed-protocol";
+
+export type SharedMnemopiEmbedWorkerAcquire = () => Promise<MnemopiEmbedWorkerHandle>;
+
+class SharedFallbackMnemopiEmbedWorker implements MnemopiEmbedWorkerHandle {
+	readonly #spawnPrivate: () => MnemopiEmbedWorkerHandle;
+	readonly #pending = new Map<string, MnemopiEmbedWorkerInbound>();
+	readonly #messageListeners = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
+	readonly #errorListeners = new Set<(error: Error) => void>();
+	readonly #retiring: Promise<void>[] = [];
+	#active: MnemopiEmbedWorkerHandle;
+	#unsubscribeMessage: () => void = () => {};
+	#unsubscribeError: () => void = () => {};
+	#usingPrivate = false;
+	#terminated = false;
+
+	constructor(shared: MnemopiEmbedWorkerHandle, spawnPrivate: () => MnemopiEmbedWorkerHandle) {
+		this.#active = shared;
+		this.#spawnPrivate = spawnPrivate;
+		this.#attach(shared);
+	}
+
+	send(message: MnemopiEmbedWorkerInbound): void {
+		if (this.#terminated) throw new Error("mnemopi embed worker terminated");
+		this.#pending.set(message.id, message);
+		try {
+			this.#active.send(message);
+		} catch (error) {
+			this.#handleError(error instanceof Error ? error : new Error(String(error)), this.#active);
+		}
+	}
+
+	onMessage(handler: (message: MnemopiEmbedWorkerOutbound) => void): () => void {
+		this.#messageListeners.add(handler);
+		return () => this.#messageListeners.delete(handler);
+	}
+
+	onError(handler: (error: Error) => void): () => void {
+		this.#errorListeners.add(handler);
+		return () => this.#errorListeners.delete(handler);
+	}
+
+	async terminate(): Promise<void> {
+		if (this.#terminated) return;
+		this.#terminated = true;
+		this.#unsubscribeMessage();
+		this.#unsubscribeError();
+		this.#pending.clear();
+		await Promise.all([this.#active.terminate(), ...this.#retiring]);
+		this.#messageListeners.clear();
+		this.#errorListeners.clear();
+	}
+
+	#attach(worker: MnemopiEmbedWorkerHandle): void {
+		this.#unsubscribeMessage = worker.onMessage(message => {
+			if (message.type !== "log") this.#pending.delete(message.id);
+			for (const listener of this.#messageListeners) listener(message);
+		});
+		this.#unsubscribeError = worker.onError(error => this.#handleError(error, worker));
+	}
+
+	#handleError(error: Error, worker: MnemopiEmbedWorkerHandle): void {
+		if (this.#terminated || worker !== this.#active) return;
+		if (this.#usingPrivate) {
+			for (const listener of this.#errorListeners) listener(error);
+			return;
+		}
+		this.#usingPrivate = true;
+		this.#unsubscribeMessage();
+		this.#unsubscribeError();
+		this.#retiring.push(worker.terminate().catch(() => {}));
+		try {
+			const fallback = this.#spawnPrivate();
+			this.#active = fallback;
+			this.#attach(fallback);
+			for (const message of this.#pending.values()) fallback.send(message);
+		} catch (fallbackError) {
+			const failure = fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError));
+			for (const listener of this.#errorListeners) listener(failure);
+		}
+	}
+}
+
+/** Prefer the machine-global broker, falling back privately at acquisition or after a broker transport failure. */
+export async function connectSharedMnemopiEmbedWorker(
+	spawnPrivate: () => MnemopiEmbedWorkerHandle,
+	acquireShared: SharedMnemopiEmbedWorkerAcquire,
+): Promise<MnemopiEmbedWorkerHandle> {
+	try {
+		return new SharedFallbackMnemopiEmbedWorker(await acquireShared(), spawnPrivate);
+	} catch {
+		return spawnPrivate();
+	}
+}

--- a/packages/coding-agent/src/mnemopi/embed-shared-daemon.ts
+++ b/packages/coding-agent/src/mnemopi/embed-shared-daemon.ts
@@ -1,0 +1,145 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getGlobalDaemonRuntimeDir, isEexist, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { daemonClientForGlobal } from "../launch/client";
+import { describeQuietly, stopQuietly, waitReady } from "../launch/ensure";
+import { resolveWorkerSpawnCmd } from "../subprocess/worker-client";
+import {
+	connectMnemopiEmbedBroker,
+	MNEMOPI_EMBED_BROKER_DAEMON_NAME,
+	MNEMOPI_EMBED_BROKER_ENDPOINT_ENV,
+	MNEMOPI_EMBED_BROKER_READY_PATTERN,
+	MNEMOPI_EMBED_BROKER_SCOPE,
+	MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV,
+	MNEMOPI_EMBED_BROKER_WORKER_ARG,
+	mnemopiEmbedBrokerEndpoint,
+} from "./embed-broker";
+import type { MnemopiEmbedWorkerHandle } from "./embed-client";
+
+const TOKEN_FILE = "mnemopi-embed.token";
+const READY_TIMEOUT_MS = 15_000;
+const PROBE_TIMEOUT_MS = 1_500;
+const ENSURE_ATTEMPTS = 3;
+
+async function readOrCreateToken(runtimeDir: string): Promise<{ path: string; token: string }> {
+	await fs.mkdir(runtimeDir, { recursive: true, mode: 0o700 });
+	const tokenPath = path.join(runtimeDir, TOKEN_FILE);
+	for (let attempt = 0; attempt < 100; attempt++) {
+		try {
+			const token = (await fs.readFile(tokenPath, "utf8")).trim();
+			if (token) return { path: tokenPath, token };
+		} catch (error) {
+			if (!isEnoent(error)) throw error;
+		}
+		try {
+			const handle = await fs.open(tokenPath, "wx", 0o600);
+			try {
+				const token = crypto.randomUUID().replaceAll("-", "") + crypto.randomUUID().replaceAll("-", "");
+				await handle.writeFile(token, "utf8");
+				return { path: tokenPath, token };
+			} finally {
+				await handle.close();
+			}
+		} catch (error) {
+			if (!isEexist(error)) throw error;
+		}
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out initializing Mnemopi embed broker token in ${runtimeDir}`);
+}
+
+async function connectVerified(endpoint: string, token: string): Promise<MnemopiEmbedWorkerHandle> {
+	const worker = await connectMnemopiEmbedBroker({ endpoint, token, timeoutMs: PROBE_TIMEOUT_MS });
+	const id = `probe:${crypto.randomUUID()}`;
+	const result = Promise.withResolvers<void>();
+	const timer = setTimeout(() => result.reject(new Error("Mnemopi embed broker ping timed out")), PROBE_TIMEOUT_MS);
+	timer.unref();
+	const unsubscribeMessage = worker.onMessage(message => {
+		if (message.type === "log" || message.id !== id) return;
+		if (message.type === "pong") result.resolve();
+		else result.reject(new Error(message.type === "error" ? message.error : "Mnemopi embed broker ping mismatch"));
+	});
+	const unsubscribeError = worker.onError(result.reject);
+	try {
+		worker.send({ type: "ping", id });
+		await result.promise;
+		return worker;
+	} catch (error) {
+		await worker.terminate();
+		throw error;
+	} finally {
+		clearTimeout(timer);
+		unsubscribeMessage();
+		unsubscribeError();
+	}
+}
+
+async function tryConnect(endpoint: string, token: string): Promise<MnemopiEmbedWorkerHandle | undefined> {
+	try {
+		return await connectVerified(endpoint, token);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Acquire one authenticated link to the machine-global, protocol-versioned embedding broker. */
+export async function acquireGlobalMnemopiEmbedWorker(): Promise<MnemopiEmbedWorkerHandle> {
+	const runtimeDir = getGlobalDaemonRuntimeDir(MNEMOPI_EMBED_BROKER_SCOPE);
+	const credentials = await readOrCreateToken(runtimeDir);
+	const endpoint = mnemopiEmbedBrokerEndpoint(runtimeDir, credentials.token);
+	const client = await daemonClientForGlobal(MNEMOPI_EMBED_BROKER_SCOPE);
+	// Establish the launch-broker lease before probing or starting its child.
+	await client.request({ op: "ping" });
+	const connected = await tryConnect(endpoint, credentials.token);
+	if (connected) return connected;
+
+	const spawn = resolveWorkerSpawnCmd(MNEMOPI_EMBED_BROKER_WORKER_ARG);
+	for (let attempt = 0; attempt < ENSURE_ATTEMPTS; attempt++) {
+		const raced = await tryConnect(endpoint, credentials.token);
+		if (raced) return raced;
+		const existing = await describeQuietly(client, MNEMOPI_EMBED_BROKER_DAEMON_NAME, "Mnemopi embed broker");
+		if (existing && existing.state !== "exited" && existing.state !== "failed") {
+			if (existing.readyAt === undefined) {
+				await waitReady(
+					client,
+					MNEMOPI_EMBED_BROKER_DAEMON_NAME,
+					"Mnemopi embed broker",
+					undefined,
+					READY_TIMEOUT_MS,
+				);
+			}
+			const adopted = await tryConnect(endpoint, credentials.token);
+			if (adopted) return adopted;
+			await stopQuietly(client, MNEMOPI_EMBED_BROKER_DAEMON_NAME, "Mnemopi embed broker");
+			continue;
+		}
+		try {
+			await client.request({
+				op: "start",
+				spec: {
+					name: MNEMOPI_EMBED_BROKER_DAEMON_NAME,
+					application: spawn.cmd[0]!,
+					args: spawn.cmd.slice(1),
+					env: {
+						[MNEMOPI_EMBED_BROKER_ENDPOINT_ENV]: endpoint,
+						[MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV]: credentials.path,
+					},
+					cwd: spawn.cwd ?? client.projectDir,
+					pty: false,
+					ready: { log: MNEMOPI_EMBED_BROKER_READY_PATTERN, timeoutMs: READY_TIMEOUT_MS },
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+			});
+			const started = await tryConnect(endpoint, credentials.token);
+			if (started) return started;
+			await stopQuietly(client, MNEMOPI_EMBED_BROKER_DAEMON_NAME, "Mnemopi embed broker");
+		} catch (error) {
+			logger.debug("Mnemopi embed broker start contention", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+	throw new Error("Mnemopi embed broker could not be started");
+}

--- a/packages/coding-agent/src/mnemopi/embed-worker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-worker.ts
@@ -1,12 +1,11 @@
 /**
  * Mnemopi local-embeddings worker. Loaded inside the dedicated subprocess
- * spawned by `embed-client.ts` (re-entered through the agent CLI's hidden
- * `__omp_worker_mnemopi_embed` selector). The whole point of this module is
- * that `loadFastembed()` — and therefore `onnxruntime-node`'s NAPI
- * constructor + finalizer — only ever runs in this child address space. The
- * parent `SIGKILL`s us on shutdown so the destructor that crashes Bun on
- * Windows shutdown (issue #3031, mnemopi sibling of #1606/#1607) never runs
- * in either process.
+ * selected by `__omp_worker_mnemopi_embed`. Its parent is normally the
+ * machine-global embedding broker and is the agent process only on private
+ * fallback. `loadFastembed()` and `onnxruntime-node` run solely in this child;
+ * either parent hard-reaps it on retirement so the destructor that crashes
+ * Bun on Windows shutdown (issue #3031, mnemopi sibling of #1606/#1607) never
+ * runs in the parent address space.
  */
 
 import { defaultLocalModelInitializer, type StandardEmbeddingModel } from "@oh-my-pi/pi-mnemopi/core";

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -42,8 +42,8 @@ function installLocalModelInitializer(setInitializer: (initializer: LocalModelIn
 
 /**
  * Lazily load `@oh-my-pi/pi-mnemopi` (memoized) and route fastembed loads
- * through the dedicated embeddings subprocess. The override is installed once
- * — before any consumer gets the chance to call `embed()` — so
+ * through the shared embedding broker, with a private subprocess fallback.
+ * The override is installed before any consumer can call `embed()`, so
  * `onnxruntime-node`'s NAPI constructor + finalizer never run inside the
  * agent's address space (issue #3031). Test seams that swap the initializer
  * with `setLocalModelInitializerForTests` still win because both go through

--- a/packages/coding-agent/test/issue-3031-repro.test.ts
+++ b/packages/coding-agent/test/issue-3031-repro.test.ts
@@ -8,12 +8,12 @@
  *     session start, before any prompt rendered.
  *   - NPM install: NAPI finalizer segfault at process teardown.
  *
- * The fix relocates the embeddings stack into a Bun.spawn child process. The
- * agent's main process hands `mnemopi.setLocalModelInitializer` a wrapper that
- * round-trips through `__omp_worker_mnemopi_embed`, and `SIGKILL`s the child
- * on dispose so the destructor never runs in either address space. These tests
- * pin the three pieces of that contract so a future refactor cannot quietly
- * re-introduce the crash.
+ * The fix keeps the embeddings stack in a Bun.spawn child process and now
+ * places that child behind an authenticated machine-global broker. Concurrent
+ * OMP sessions share one child per (model, cacheDir) key; the agent process
+ * retains a private subprocess fallback if broker startup fails. The broker
+ * still SIGKILLs children on disposal so the native destructor never runs in
+ * an agent or broker address space. These tests pin the client/subprocess seam.
  */
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
@@ -163,5 +163,177 @@ describe("issue #3031 — mnemopi embeddings live in an isolated subprocess", ()
 		}
 
 		await client.terminate();
+	});
+	it("accepts asynchronous worker acquisition for shared-daemon startup", async () => {
+		let messageHandler: ((message: MnemopiEmbedWorkerOutbound) => void) | undefined;
+		let acquisitions = 0;
+		const client = new MnemopiEmbedClient(async () => {
+			acquisitions += 1;
+			return {
+				send(message) {
+					queueMicrotask(() => {
+						if (message.type === "init") messageHandler?.({ type: "ready", id: message.id });
+						else if (message.type === "embed") {
+							messageHandler?.({ type: "vectors", id: message.id, vectors: [[1, 2, 3]] });
+						}
+					});
+				},
+				onMessage(handler) {
+					messageHandler = handler;
+					return () => {
+						if (messageHandler === handler) messageHandler = undefined;
+					};
+				},
+				onError() {
+					return () => {};
+				},
+				async terminate() {
+					messageHandler = undefined;
+				},
+			};
+		});
+		try {
+			const model = await client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+			expect(model).not.toBeNull();
+			const batches: number[][][] = [];
+			for await (const batch of model!.embed(["hello"])) batches.push(batch);
+			expect(batches).toEqual([[[1, 2, 3]]]);
+			expect(acquisitions).toBe(1);
+		} finally {
+			await client.terminate();
+		}
+	});
+	it("reaps a shared worker acquired after client termination", async () => {
+		const acquired = Promise.withResolvers<MnemopiEmbedWorkerHandle>();
+		const sent: MnemopiEmbedWorkerInbound[] = [];
+		let terminations = 0;
+		const worker: MnemopiEmbedWorkerHandle = {
+			send(message) {
+				sent.push(message);
+			},
+			onMessage() {
+				return () => {};
+			},
+			onError() {
+				return () => {};
+			},
+			async terminate() {
+				terminations += 1;
+			},
+		};
+		const client = new MnemopiEmbedClient(() => acquired.promise);
+		const initializing = client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+
+		await client.terminate();
+		acquired.resolve(worker);
+
+		expect(await initializing).toBeNull();
+		expect(terminations).toBe(1);
+		expect(sent).toEqual([]);
+	});
+
+	it("settles operations terminated after reusing an established worker", async () => {
+		let messageHandler: ((message: MnemopiEmbedWorkerOutbound) => void) | undefined;
+		let terminated = false;
+		const worker: MnemopiEmbedWorkerHandle = {
+			send(message) {
+				if (terminated) return;
+				queueMicrotask(() => {
+					if (message.type === "init") messageHandler?.({ type: "ready", id: message.id });
+					else if (message.type === "embed") {
+						messageHandler?.({ type: "vectors", id: message.id, vectors: [[1, 2, 3]] });
+					}
+				});
+			},
+			onMessage(handler) {
+				messageHandler = handler;
+				return () => {
+					if (messageHandler === handler) messageHandler = undefined;
+				};
+			},
+			onError() {
+				return () => {};
+			},
+			async terminate() {
+				terminated = true;
+				messageHandler = undefined;
+			},
+		};
+		const client = new MnemopiEmbedClient(() => worker, 20);
+		const model = await client.initialize("fast-test", undefined);
+		expect(model).not.toBeNull();
+
+		const initializing = client.initialize("fast-test", undefined);
+		await client.terminate();
+		expect(await Promise.race([initializing, Bun.sleep(100).then(() => "hung")])).toBeNull();
+
+		terminated = false;
+		const replacement = await client.initialize("fast-test", undefined);
+		expect(replacement).not.toBeNull();
+		const embedding = replacement!.embed(["hello"])[Symbol.asyncIterator]().next();
+		await client.terminate();
+		await expect(embedding).rejects.toThrow("terminated");
+	});
+
+	it("resolves response-kind mismatches instead of stranding requests", async () => {
+		let messageHandler: ((message: MnemopiEmbedWorkerOutbound) => void) | undefined;
+		const client = new MnemopiEmbedClient(
+			() => ({
+				send(message) {
+					queueMicrotask(() => {
+						if (message.type === "init") messageHandler?.({ type: "vectors", id: message.id, vectors: [[1]] });
+						else if (message.type === "embed") messageHandler?.({ type: "ready", id: message.id });
+					});
+				},
+				onMessage(handler) {
+					messageHandler = handler;
+					return () => {
+						if (messageHandler === handler) messageHandler = undefined;
+					};
+				},
+				onError() {
+					return () => {};
+				},
+				async terminate() {},
+			}),
+			50,
+		);
+		try {
+			expect(await client.initialize("fast-test", undefined)).toBeNull();
+
+			messageHandler = undefined;
+			const validClient = new MnemopiEmbedClient(
+				() => ({
+					send(message) {
+						queueMicrotask(() => {
+							if (message.type === "init") messageHandler?.({ type: "ready", id: message.id });
+							else if (message.type === "embed") messageHandler?.({ type: "ready", id: message.id });
+						});
+					},
+					onMessage(handler) {
+						messageHandler = handler;
+						return () => {};
+					},
+					onError() {
+						return () => {};
+					},
+					async terminate() {},
+				}),
+				50,
+			);
+			try {
+				const model = await validClient.initialize("fast-test", undefined);
+				expect(model).not.toBeNull();
+				await expect(async () => {
+					for await (const _ of model!.embed(["hello"])) {
+						/* drain */
+					}
+				}).toThrow("unexpected ready response");
+			} finally {
+				await validClient.terminate();
+			}
+		} finally {
+			await client.terminate();
+		}
 	});
 });

--- a/packages/coding-agent/test/mnemopi-embed-broker.test.ts
+++ b/packages/coding-agent/test/mnemopi-embed-broker.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	connectMnemopiEmbedBroker,
+	MNEMOPI_EMBED_BROKER_DAEMON_NAME,
+	MnemopiEmbedBroker,
+	type MnemopiEmbedBrokerOptions,
+	mnemopiEmbedBrokerEndpoint,
+	mnemopiEmbedBrokerPipeName,
+} from "../src/mnemopi/embed-broker";
+import {
+	encodeMnemopiEmbedBrokerResponse,
+	parseMnemopiEmbedBrokerResponse,
+} from "../src/mnemopi/embed-broker-protocol";
+import type { MnemopiEmbedWorkerHandle } from "../src/mnemopi/embed-client";
+import type { MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "../src/mnemopi/embed-protocol";
+
+class FakeEmbedWorker implements MnemopiEmbedWorkerHandle {
+	readonly messages: MnemopiEmbedWorkerInbound[] = [];
+	readonly #listeners = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
+	readonly #errors = new Set<(error: Error) => void>();
+	terminated = false;
+	respond = true;
+	readonly terminatedSignal = Promise.withResolvers<void>();
+	blockInit = false;
+	readonly initBlocked = Promise.withResolvers<void>();
+	readonly blockedInits: Array<() => void> = [];
+
+	send(message: MnemopiEmbedWorkerInbound): void {
+		this.messages.push(message);
+		if (message.type === "init" && this.blockInit) {
+			this.blockedInits.push(() => this.#emit({ type: "ready", id: message.id }));
+			this.initBlocked.resolve();
+			return;
+		}
+		if (!this.respond) return;
+		queueMicrotask(() => {
+			if (message.type === "ping") this.#emit({ type: "pong", id: message.id });
+			else if (message.type === "init") this.#emit({ type: "ready", id: message.id });
+			else {
+				const vectors = message.texts.map((_, index) => new Float32Array([index, 1]));
+				this.#emit({ type: "vectors", id: message.id, vectors: vectors as unknown as number[][] });
+			}
+		});
+	}
+
+	onMessage(handler: (message: MnemopiEmbedWorkerOutbound) => void): () => void {
+		this.#listeners.add(handler);
+		return () => this.#listeners.delete(handler);
+	}
+
+	onError(handler: (error: Error) => void): () => void {
+		this.#errors.add(handler);
+		return () => this.#errors.delete(handler);
+	}
+
+	async terminate(): Promise<void> {
+		this.terminated = true;
+		this.terminatedSignal.resolve();
+	}
+
+	#emit(message: MnemopiEmbedWorkerOutbound): void {
+		for (const listener of this.#listeners) listener(message);
+	}
+}
+
+function responseFor(
+	handle: MnemopiEmbedWorkerHandle,
+	message: MnemopiEmbedWorkerInbound,
+): Promise<MnemopiEmbedWorkerOutbound> {
+	const { promise, resolve } = Promise.withResolvers<MnemopiEmbedWorkerOutbound>();
+	const unsubscribe = handle.onMessage(response => {
+		if (response.type === "log" || response.id !== message.id) return;
+		unsubscribe();
+		resolve(response);
+	});
+	handle.send(message);
+	return promise;
+}
+
+async function responseErrorFor(handle: MnemopiEmbedWorkerHandle, message: MnemopiEmbedWorkerInbound): Promise<string> {
+	const response = await responseFor(handle, message);
+	if (response.type !== "error") throw new Error(`Expected error response, received ${response.type}`);
+	return response.error;
+}
+
+describe("MnemopiEmbedBroker", () => {
+	const brokers: MnemopiEmbedBroker[] = [];
+	const clients: MnemopiEmbedWorkerHandle[] = [];
+
+	afterEach(async () => {
+		await Promise.all(clients.splice(0).map(client => client.terminate()));
+		await Promise.all(brokers.splice(0).map(broker => broker.shutdown()));
+	});
+
+	async function start(
+		tempDir: string,
+		options: Partial<MnemopiEmbedBrokerOptions> = {},
+	): Promise<{ broker: MnemopiEmbedBroker; endpoint: string; token: string; workers: FakeEmbedWorker[] }> {
+		const endpoint = path.join(tempDir, "embed.sock");
+		const token = "test-token";
+		const workers: FakeEmbedWorker[] = [];
+		const broker = new MnemopiEmbedBroker({
+			token,
+			spawnWorker: () => {
+				const worker = new FakeEmbedWorker();
+				workers.push(worker);
+				return worker;
+			},
+			...options,
+		});
+		brokers.push(broker);
+		await broker.listen(endpoint);
+		return { broker, endpoint, token, workers };
+	}
+
+	async function connect(endpoint: string, token: string): Promise<MnemopiEmbedWorkerHandle> {
+		const client = await connectMnemopiEmbedBroker({ endpoint, token });
+		clients.push(client);
+		return client;
+	}
+	it("versions the daemon identity and endpoint with the authenticated wire protocol", () => {
+		expect(MNEMOPI_EMBED_BROKER_DAEMON_NAME).toBe("omp.mnemopi.embed.v2");
+		expect(mnemopiEmbedBrokerEndpoint("/tmp/runtime", "first-token")).toBe(
+			process.platform === "win32"
+				? `\\\\.\\pipe\\${mnemopiEmbedBrokerPipeName("first-token")}`
+				: "/tmp/runtime/mnemopi-embed-v2.sock",
+		);
+		expect(mnemopiEmbedBrokerPipeName("first-token")).not.toBe(mnemopiEmbedBrokerPipeName("second-token"));
+		expect(mnemopiEmbedBrokerPipeName("first-token")).not.toContain("first-token");
+	});
+	it("rejects a correctly signed outbound message with an unsupported variant", () => {
+		const token = "test-token";
+		const response = encodeMnemopiEmbedBrokerResponse(token, {
+			id: "wire-1",
+			ok: true,
+			message: { type: "mystery", id: "caller-1" } as unknown as MnemopiEmbedWorkerOutbound,
+		});
+		expect(() => parseMnemopiEmbedBrokerResponse(response, token)).toThrow("unsupported message.type");
+	});
+
+	it("authenticates error responses before validating their fields", () => {
+		expect(() =>
+			parseMnemopiEmbedBrokerResponse(
+				{
+					protocol: 2,
+					id: "wire-1",
+					ok: false,
+					error: 42,
+					mac: "00".repeat(32),
+				},
+				"test-token",
+			),
+		).toThrow("authentication failed");
+	});
+
+	it("authenticates success responses before validating their message", () => {
+		expect(() =>
+			parseMnemopiEmbedBrokerResponse(
+				{
+					protocol: 2,
+					id: "wire-1",
+					ok: true,
+					message: 42,
+					mac: "00".repeat(32),
+				},
+				"test-token",
+			),
+		).toThrow("authentication failed");
+	});
+
+	it("shares one keyed worker across independent clients and preserves equal request ids", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { endpoint, token, workers } = await start(tempDir);
+		const first = await connect(endpoint, token);
+		const second = await connect(endpoint, token);
+
+		const [firstReady, secondReady] = await Promise.all([
+			responseFor(first, { type: "init", id: "same-id", model: "fast-test", cacheDir: tempDir }),
+			responseFor(second, { type: "init", id: "same-id", model: "fast-test", cacheDir: tempDir }),
+		]);
+
+		expect(firstReady).toEqual({ type: "ready", id: "same-id" });
+		expect(secondReady).toEqual({ type: "ready", id: "same-id" });
+		expect(workers).toHaveLength(1);
+		expect(workers[0]?.messages).toHaveLength(2);
+	});
+
+	it("isolates distinct model and cache keys", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const firstCache = path.join(tempDir, "one");
+		const secondCache = path.join(tempDir, "two");
+		await Promise.all([fs.mkdir(firstCache), fs.mkdir(secondCache)]);
+		const { endpoint, token, workers } = await start(tempDir);
+		const first = await connect(endpoint, token);
+		const second = await connect(endpoint, token);
+
+		await Promise.all([
+			responseFor(first, { type: "init", id: "1", model: "fast-test", cacheDir: firstCache }),
+			responseFor(second, { type: "init", id: "2", model: "fast-test", cacheDir: secondCache }),
+			responseFor(second, { type: "init", id: "3", model: "fast-other", cacheDir: firstCache }),
+		]);
+
+		expect(workers).toHaveLength(3);
+	});
+
+	it("disconnecting clients leaves the shared worker alive until broker shutdown", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { broker, endpoint, token, workers } = await start(tempDir);
+		const first = await connect(endpoint, token);
+		const second = await connect(endpoint, token);
+		await responseFor(first, { type: "init", id: "1", model: "fast-test" });
+
+		await first.terminate();
+		expect(
+			await Promise.race([
+				workers[0]!.terminatedSignal.promise.then(() => "terminated"),
+				Bun.sleep(50).then(() => "alive"),
+			]),
+		).toBe("alive");
+		expect(await responseFor(second, { type: "init", id: "2", model: "fast-test" })).toEqual({
+			type: "ready",
+			id: "2",
+		});
+		expect(workers).toHaveLength(1);
+		expect(workers[0]?.terminated).toBe(false);
+		await broker.shutdown();
+		expect(workers[0]?.terminated).toBe(true);
+	});
+
+	it("rejects a client with the wrong key as a transport failure", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { endpoint } = await start(tempDir);
+		const client = await connect(endpoint, "wrong-token");
+		const failure = Promise.withResolvers<Error>();
+		client.onError(failure.resolve);
+
+		client.send({ type: "init", id: "caller-id", model: "fast-test" });
+		expect((await failure.promise).message).toContain("connection closed");
+	}, 1_000);
+
+	it("never sends the bearer token and rejects an unsigned fake broker response", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-hostile-"));
+		const endpoint = path.join(tempDir, "hostile.sock");
+		const token = "secret-bearer-token";
+		const captured = Promise.withResolvers<string>();
+		const server = net.createServer(socket => {
+			socket.setEncoding("utf8");
+			socket.once("data", chunk => {
+				const line = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+				captured.resolve(line);
+				const request = JSON.parse(line) as { id: string; message: { id: string } };
+				socket.write(
+					`${JSON.stringify({
+						protocol: 2,
+						id: request.id,
+						ok: true,
+						message: { type: "pong", id: request.message.id },
+						mac: "00",
+					})}\n`,
+				);
+			});
+		});
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(endpoint, resolve);
+		});
+		try {
+			const client = await connect(endpoint, token);
+			const failure = Promise.withResolvers<Error>();
+			client.onError(failure.resolve);
+			client.send({ type: "ping", id: "challenge" });
+			const frame = await captured.promise;
+			expect(frame).not.toContain(token);
+			expect((await failure.promise).message).toContain("authentication failed");
+			await client.terminate();
+		} finally {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	}, 1_000);
+
+	it("allows model initialization to outlive the steady-state request deadline", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { endpoint, token, workers } = await start(tempDir, { workerRequestTimeoutMs: 20 });
+		const client = await connect(endpoint, token);
+		await responseFor(client, { type: "init", id: "warm-init", model: "fast-other" });
+		workers[0]!.blockInit = true;
+		const slowInitializing = responseFor(client, { type: "init", id: "slower-init", model: "fast-other" });
+		await workers[0].initBlocked.promise;
+		const deadlinePassed = Promise.withResolvers<void>();
+		setTimeout(deadlinePassed.resolve, 40);
+		await deadlinePassed.promise;
+		expect(workers[0].terminated).toBe(false);
+		workers[0].blockedInits.shift()?.();
+		expect(await slowInitializing).toEqual({ type: "ready", id: "slower-init" });
+	}, 1_000);
+	it("reaps a worker when its client disconnects during unbounded initialization", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { endpoint, token, workers } = await start(tempDir);
+		const client = await connect(endpoint, token);
+		await responseFor(client, { type: "init", id: "warm-init", model: "fast-test" });
+		workers[0]!.blockInit = true;
+		client.send({ type: "init", id: "abandoned-init", model: "fast-test" });
+		await workers[0]!.initBlocked.promise;
+
+		await client.terminate();
+		await workers[0]!.terminatedSignal.promise;
+		expect(workers[0]?.terminated).toBe(true);
+	}, 1_000);
+
+	it("reaps a hung keyed worker and uses a fresh worker for the next request", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { endpoint, token, workers } = await start(tempDir, { workerRequestTimeoutMs: 20 });
+		const client = await connect(endpoint, token);
+		await responseFor(client, { type: "init", id: "ready", model: "fast-test" });
+		workers[0]!.respond = false;
+
+		expect(
+			await responseErrorFor(client, { type: "embed", id: "hung", model: "fast-test", texts: ["one"] }),
+		).toContain("timed out");
+		expect(workers[0]?.terminated).toBe(true);
+
+		expect(await responseFor(client, { type: "embed", id: "retry", model: "fast-test", texts: ["two"] })).toEqual({
+			type: "vectors",
+			id: "retry",
+			vectors: [[0, 1]],
+		});
+		expect(workers).toHaveLength(2);
+	}, 1_000);
+});

--- a/packages/coding-agent/test/mnemopi-embed-broker.test.ts
+++ b/packages/coding-agent/test/mnemopi-embed-broker.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
@@ -12,6 +12,7 @@ import {
 	mnemopiEmbedBrokerPipeName,
 } from "../src/mnemopi/embed-broker";
 import {
+	encodeMnemopiEmbedBrokerRequest,
 	encodeMnemopiEmbedBrokerResponse,
 	parseMnemopiEmbedBrokerResponse,
 } from "../src/mnemopi/embed-broker-protocol";
@@ -170,6 +171,47 @@ describe("MnemopiEmbedBroker", () => {
 				"test-token",
 			),
 		).toThrow("authentication failed");
+	});
+
+	it("accounts for fragmented request bytes in linear work", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-broker-"));
+		const { endpoint, token } = await start(tempDir);
+		const request = encodeMnemopiEmbedBrokerRequest(token, "wire-fragmented", {
+			type: "ping",
+			id: "x".repeat(64 * 1024),
+		});
+		const frame = `${JSON.stringify(request)}\n`;
+		const frameBytes = Buffer.byteLength(frame);
+		const originalByteLength = Buffer.byteLength;
+		let bytesScanned = 0;
+		let observed = Promise.withResolvers<void>();
+		const byteLengthSpy = spyOn(Buffer, "byteLength").mockImplementation((value, encoding) => {
+			bytesScanned += typeof value === "string" ? value.length : value.byteLength;
+			const result = originalByteLength(value, encoding);
+			observed.resolve();
+			return result;
+		});
+		const socket = net.createConnection(endpoint);
+		try {
+			await new Promise<void>((resolve, reject) => {
+				socket.once("connect", resolve);
+				socket.once("error", reject);
+			});
+			const response = Promise.withResolvers<void>();
+			socket.once("data", () => response.resolve());
+			for (let offset = 0; offset < frame.length; offset += 1024) {
+				observed = Promise.withResolvers<void>();
+				await new Promise<void>((resolve, reject) => {
+					socket.write(frame.slice(offset, offset + 1024), error => (error ? reject(error) : resolve()));
+				});
+				await observed.promise;
+			}
+			await response.promise;
+			expect(bytesScanned).toBeLessThanOrEqual(frameBytes * 3);
+		} finally {
+			byteLengthSpy.mockRestore();
+			socket.destroy();
+		}
 	});
 
 	it("shares one keyed worker across independent clients and preserves equal request ids", async () => {

--- a/packages/coding-agent/test/mnemopi-embed-shared.test.ts
+++ b/packages/coding-agent/test/mnemopi-embed-shared.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "bun:test";
+import { MnemopiEmbedClient, type MnemopiEmbedWorkerHandle } from "../src/mnemopi/embed-client";
+import type { MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "../src/mnemopi/embed-protocol";
+import { connectSharedMnemopiEmbedWorker } from "../src/mnemopi/embed-shared-client";
+
+function inertWorker(): MnemopiEmbedWorkerHandle {
+	return {
+		send() {},
+		onMessage() {
+			return () => {};
+		},
+		onError() {
+			return () => {};
+		},
+		async terminate() {},
+	};
+}
+
+function controlledWorker(): {
+	worker: MnemopiEmbedWorkerHandle;
+	messages: MnemopiEmbedWorkerInbound[];
+	firstMessage: PromiseWithResolvers<MnemopiEmbedWorkerInbound>;
+	emitMessage: (message: MnemopiEmbedWorkerOutbound) => void;
+	emitError: (error: Error) => void;
+} {
+	const messages: MnemopiEmbedWorkerInbound[] = [];
+	const messageListeners = new Set<(message: MnemopiEmbedWorkerOutbound) => void>();
+	const errorListeners = new Set<(error: Error) => void>();
+	const firstMessage = Promise.withResolvers<MnemopiEmbedWorkerInbound>();
+	return {
+		messages,
+		firstMessage,
+		emitMessage: message => {
+			for (const listener of messageListeners) listener(message);
+		},
+		emitError: error => {
+			for (const listener of errorListeners) listener(error);
+		},
+		worker: {
+			send(message) {
+				messages.push(message);
+				firstMessage.resolve(message);
+			},
+			onMessage(handler) {
+				messageListeners.add(handler);
+				return () => messageListeners.delete(handler);
+			},
+			onError(handler) {
+				errorListeners.add(handler);
+				return () => errorListeners.delete(handler);
+			},
+			async terminate() {
+				messageListeners.clear();
+				errorListeners.clear();
+			},
+		},
+	};
+}
+
+describe("shared Mnemopi embed client", () => {
+	it("falls back to a private worker when shared acquisition fails", async () => {
+		const fallback = inertWorker();
+		let fallbackCalls = 0;
+		const worker = await connectSharedMnemopiEmbedWorker(
+			() => {
+				fallbackCalls += 1;
+				return fallback;
+			},
+			async () => {
+				throw new Error("global daemon unavailable");
+			},
+		);
+
+		expect(worker).toBe(fallback);
+		expect(fallbackCalls).toBe(1);
+	});
+
+	it("replays interrupted initialization on a private worker", async () => {
+		const shared = controlledWorker();
+		const fallback = controlledWorker();
+		const worker = await connectSharedMnemopiEmbedWorker(
+			() => fallback.worker,
+			async () => shared.worker,
+		);
+		const responses: MnemopiEmbedWorkerOutbound[] = [];
+		worker.onMessage(message => responses.push(message));
+
+		const init = { type: "init", id: "init-1", model: "fast-test" } as const;
+		worker.send(init);
+		shared.emitError(new Error("broker connection closed"));
+		fallback.emitMessage({ type: "ready", id: init.id });
+
+		expect(shared.messages).toEqual([init]);
+		expect(fallback.messages).toEqual([init]);
+		expect(responses).toEqual([{ type: "ready", id: init.id }]);
+		await worker.terminate();
+	});
+
+	it("does not replay requests completed before the shared worker fails", async () => {
+		const shared = controlledWorker();
+		const fallback = controlledWorker();
+		const worker = await connectSharedMnemopiEmbedWorker(
+			() => fallback.worker,
+			async () => shared.worker,
+		);
+		const init: MnemopiEmbedWorkerInbound = { type: "init", id: "init-1", model: "fast-test" };
+		worker.send(init);
+		shared.emitMessage({ type: "ready", id: init.id });
+
+		shared.emitError(new Error("broker connection closed"));
+
+		expect(fallback.messages).toEqual([]);
+		await worker.terminate();
+	});
+
+	it("surfaces private-worker failure after failover", async () => {
+		const shared = controlledWorker();
+		const fallback = controlledWorker();
+		const worker = await connectSharedMnemopiEmbedWorker(
+			() => fallback.worker,
+			async () => shared.worker,
+		);
+		const errors: string[] = [];
+		worker.onError(error => errors.push(error.message));
+
+		shared.emitError(new Error("broker connection closed"));
+		fallback.emitError(new Error("private worker failed"));
+
+		expect(errors).toEqual(["private worker failed"]);
+		await worker.terminate();
+	});
+
+	it("settles an interrupted client request when private fallback creation fails", async () => {
+		const firstShared = controlledWorker();
+		const replacementShared = controlledWorker();
+		let acquisitions = 0;
+		const client = new MnemopiEmbedClient(
+			() =>
+				connectSharedMnemopiEmbedWorker(
+					() => {
+						throw new Error("private worker unavailable");
+					},
+					async () => (++acquisitions === 1 ? firstShared.worker : replacementShared.worker),
+				),
+			1_000,
+		);
+
+		const interrupted = client.initialize("fast-test", undefined);
+		await firstShared.firstMessage.promise;
+		firstShared.emitError(new Error("broker connection closed"));
+		expect(await Promise.race([interrupted, Bun.sleep(50).then(() => "still pending" as const)])).toBeNull();
+		expect(await interrupted).toBeNull();
+
+		const retried = client.initialize("fast-test", undefined);
+		const retryRequest = await replacementShared.firstMessage.promise;
+		replacementShared.emitMessage({ type: "ready", id: retryRequest.id });
+		expect(await retried).not.toBeNull();
+		expect(acquisitions).toBe(2);
+		await client.terminate();
+	});
+
+	it("replays an interrupted embed on a private worker", async () => {
+		const shared = controlledWorker();
+		const fallback = controlledWorker();
+		const worker = await connectSharedMnemopiEmbedWorker(
+			() => fallback.worker,
+			async () => shared.worker,
+		);
+		const responses: MnemopiEmbedWorkerOutbound[] = [];
+		worker.onMessage(message => responses.push(message));
+
+		const embed: MnemopiEmbedWorkerInbound = {
+			type: "embed",
+			id: "embed-1",
+			model: "fast-test",
+			texts: ["hello"],
+		};
+		worker.send(embed);
+		shared.emitError(new Error("broker connection closed"));
+		fallback.emitMessage({ type: "vectors", id: embed.id, vectors: [[1, 2, 3]] });
+
+		expect(shared.messages).toEqual([embed]);
+		expect(fallback.messages).toEqual([embed]);
+		expect(responses).toEqual([{ type: "vectors", id: embed.id, vectors: [[1, 2, 3]] }]);
+		await worker.terminate();
+	});
+});

--- a/packages/coding-agent/test/worker-selector.test.ts
+++ b/packages/coding-agent/test/worker-selector.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { runCli } from "../src/cli";
+import {
+	connectMnemopiEmbedBroker,
+	MNEMOPI_EMBED_BROKER_ENDPOINT_ENV,
+	MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV,
+	MNEMOPI_EMBED_BROKER_WORKER_ARG,
+	mnemopiEmbedBrokerEndpoint,
+	mnemopiEmbedBrokerReadyBanner,
+} from "../src/mnemopi/embed-broker";
+import type { MnemopiEmbedWorkerOutbound } from "../src/mnemopi/embed-protocol";
 import * as computerWorkerEntry from "../src/tools/computer/worker-entry";
 
 // The worker-host re-entry seam dispatches any `__omp_worker_*` selector to
@@ -36,6 +48,59 @@ describe("worker selector dispatch", () => {
 		expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("unknown worker selector"));
 	});
 });
+
+it("starts the authenticated embedding broker through the real CLI entry", async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mnemopi-selector-"));
+	const token = "selector-test-token";
+	const tokenFile = path.join(tempDir, "token");
+	const endpoint = mnemopiEmbedBrokerEndpoint(tempDir, token);
+	await fs.writeFile(tokenFile, token, { mode: 0o600 });
+	const cliEntry = path.resolve(import.meta.dir, "../src/cli.ts");
+	const proc = Bun.spawn([process.execPath, cliEntry, MNEMOPI_EMBED_BROKER_WORKER_ARG], {
+		env: {
+			...process.env,
+			[MNEMOPI_EMBED_BROKER_ENDPOINT_ENV]: endpoint,
+			[MNEMOPI_EMBED_BROKER_TOKEN_FILE_ENV]: tokenFile,
+		},
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const reader = proc.stdout.getReader();
+	try {
+		const expectedBanner = mnemopiEmbedBrokerReadyBanner(endpoint);
+		const ready = Promise.withResolvers<void>();
+		const timer = setTimeout(() => ready.reject(new Error("embedding broker ready banner timed out")), 5_000);
+		timer.unref();
+		void (async () => {
+			const decoder = new TextDecoder();
+			let output = "";
+			for (;;) {
+				const chunk = await reader.read();
+				if (chunk.done) throw new Error(`embedding broker exited before ready: ${output}`);
+				output += decoder.decode(chunk.value, { stream: true });
+				if (output.includes(expectedBanner)) return ready.resolve();
+			}
+		})().catch(ready.reject);
+		await ready.promise.finally(() => clearTimeout(timer));
+
+		const client = await connectMnemopiEmbedBroker({ endpoint, token });
+		try {
+			const response = Promise.withResolvers<MnemopiEmbedWorkerOutbound>();
+			const unsubscribe = client.onMessage(response.resolve);
+			client.send({ type: "ping", id: "selector-ping" });
+			expect(await response.promise).toEqual({ type: "pong", id: "selector-ping" });
+			unsubscribe();
+		} finally {
+			await client.terminate();
+		}
+	} finally {
+		await reader.cancel();
+		proc.kill("SIGTERM");
+		await proc.exited;
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+}, 15_000);
 
 describe("computer worker entry", () => {
 	it("is side-effect-free to import outside a worker and exposes a named start function", () => {


### PR DESCRIPTION
## Summary

- share one isolated Mnemopi embedding worker per `(model, cacheDir)` across concurrent OMP sessions
- authenticate and version broker envelopes before semantic parsing
- fall back one-way to a private worker when broker startup or an established transport fails, replaying only unresolved side-effect-free requests
- preserve issue #3031 native-runtime isolation and forceful worker teardown

## Verification

- `bun test test/issue-3031-repro.test.ts test/mnemopi-embed-broker.test.ts test/mnemopi-embed-shared.test.ts test/worker-selector.test.ts --parallel=1 --timeout=30000`: 30 passed, 0 failed, 72 assertions
- `bun run check`: Biome checked 2607 files; `tsgo -p tsconfig.json --noEmit` passed
- `bun run build`: passed
- mutation checks confirmed guards fail for duplicate keyed workers, premature disconnect teardown, late-acquired worker leaks, suppressed fallback errors, and missing CLI broker dispatch
- independent correctness and security reviews approved the complete diff

## Caveat

The repository-wide suite has an unrelated existing failure in `streaming-preview-height.test.ts` caused by stale native scrollback. It reproduces independently of this change.
