### PR TITLE
fix(ask): wrap long option labels in the rich ask dialog instead of truncating

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed long `ask` option labels being hard-truncated at the terminal width with no way to read the clipped tail; the rich ask dialog now wraps labels onto indented continuation lines, matching the legacy selector ([#1243](https://github.com/can1357/oh-my-pi/issues/1243), [#8594](https://github.com/can1357/oh-my-pi/issues/8594)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -4,6 +4,7 @@ import {
 	Markdown,
 	type MarkdownTheme,
 	matchesKey,
+	padding,
 	renderInlineMarkdown,
 	replaceTabs,
 	ScrollView,
@@ -12,6 +13,7 @@ import {
 	Text,
 	type TUI,
 	truncateToWidth,
+	visibleWidth,
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
 import type {
@@ -315,8 +317,20 @@ function renderRowLabel(
 	const cursor = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
 	const label = renderInlineMarkdown(rowItem.label, mdTheme, t => theme.fg(color, t));
 	const noteMarker = state.note && state.noteRowKey === rowItem.key ? theme.fg("success", "  ✎ note") : "";
-	const firstLine = `${cursor}${marker}${label}${noteMarker}`;
-	const lines = [truncateToWidth(firstLine, width, Ellipsis.Unicode)];
+	// Wrap the label onto continuation lines indented under the marker so the
+	// cursor stays visually anchored and the full label stays readable (the
+	// body ScrollView carries vertical overflow). The note marker is reserved
+	// on the first line; the label wraps to the remaining width. The row()
+	// chrome (borders + insets) consumes 4 columns, so the label must fit
+	// `width - 4` or the outer fit() re-truncates it with an ellipsis.
+	const noteWidth = noteMarker ? visibleWidth(noteMarker) : 0;
+	const labelWidth = Math.max(1, width - 4 - visibleWidth(cursor) - visibleWidth(marker) - noteWidth);
+	const wrappedLabel = wrapTextWithAnsi(label, labelWidth);
+	const indent = padding(visibleWidth(cursor) + visibleWidth(marker));
+	const lines = [`${cursor}${marker}${wrappedLabel[0] ?? ""}${noteMarker}`];
+	for (let i = 1; i < wrappedLabel.length; i++) {
+		lines.push(`${indent}${wrappedLabel[i] ?? ""}`);
+	}
 	if (rowItem.kind === "option") {
 		const option = question.options[rowItem.optionIndex ?? -1];
 		if (option?.description?.trim()) {

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1250,6 +1250,36 @@ describe("AskDialogComponent", () => {
 		expect(matches?.length ?? 0).toBeLessThan(10);
 	});
 
+	it("wraps long option labels onto indented continuation lines instead of truncating", () => {
+		const onSubmit = vi.fn();
+		const longLabel = "This is a deliberately long option label ".repeat(4).trim();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Pick one?",
+				options: [{ label: longLabel }, { label: "Short" }],
+			},
+		];
+
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+
+		const output = render(component);
+		// The label tail must be present — no ellipsis truncation.
+		expect(output).toContain("deliberately long option label");
+		expect(output).not.toContain("…");
+		// The first line carries the cursor glyph; continuation lines are
+		// indented under the marker so the cursor stays visually anchored.
+		const lines = output.split("\n");
+		const first = lines.find(line => line.includes("This is a deliberately")) ?? "";
+		const continuation = lines.find(line => line.includes("option label") && !line.includes("❯")) ?? "";
+		expect(first).toMatch(/│ ❯/);
+		expect(continuation).toMatch(/│ {3}/);
+	});
+
 	it("Other editor cancel returns to the option list without submitting", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve(undefined));
 		const onSubmit = vi.fn();


### PR DESCRIPTION
## Summary

Long `ask` option labels are hard-truncated at the terminal width with an ellipsis; the clipped tail (the disambiguating part — justifications, paths, `org/repo#NN`) is unreachable. The rich ask dialog now wraps labels onto indented continuation lines, matching the legacy selector.

## Problem

Repro (from #1243, still present on 17.3.1 per #8594):

```
❯ Redirect + downstream read (most primitive): engine signs in and redirects to a configurable `after_sign_in_path` (default `/`). Host does user mapping wherever it needs it, by reading cur…
```

Every option row in the rich dialog (`AskDialogComponent`) was rendered via `truncateToWidth(firstLine, width, Ellipsis.Unicode)` in `renderRowLabel` — the tail is discarded before rendering, so no terminal feature (wrap, resize, copy) can recover it.

## Archaeology (why this is the last truncation path)

- **Legacy selector** (`HookSelectorComponent` + `OutlinedList`): labels have wrapped since **June 1** (commit `3c7d50d292`, "Improve ask option rendering") — `wrapTextWithAnsi` with continuation lines indented under the option glyph, row-count-aware windowing, scrollbar on visual rows.
- **Rich dialog** (`AskDialogComponent`, merged **July 11** in PR #4375): kept the pre-June truncation policy — `renderRowLabel` truncates the first line, and description rows are capped at 2 wrapped lines. This is the path the TUI uses today, so the June fix never reached it.
- The dialog already has the plumbing the legacy path proved out: per-option visual row counts feed `#measureHeight`, the width-1 overflow re-render, and `lineStartByRow` cursor-to-scroll mapping; the body scrolls via `ScrollView` (with `PgUp/PgDn` paging for single options taller than the viewport).

## Change

`renderRowLabel` in `packages/coding-agent/src/modes/components/ask-dialog.ts`:

- Wraps the label with the existing `wrapTextWithAnsi` primitive (same one `OutputBlock`, the legacy selector, and `Text` use).
- Continuation lines are indented under the radio/checkbox marker so the cursor stays visually anchored.
- The `✎ note` marker is reserved on the first line; the label wraps to the remaining width.
- Label width accounts for the `row()` chrome (borders + insets, 4 columns) **and** the `ScrollView` scrollbar column — without that, the outer `fit()`/`ScrollView` re-truncates the first line with an ellipsis the moment the list overflows (verified empirically with a 30-option list).
- No new keybindings, no new settings, no new UI surface. Keyboard navigation, submit semantics, previews, descriptions, and the `Other (type your own)` row are unchanged. Short labels render identically to before (single line).

## Verification

- `bun check` clean.
- `ask-dialog.test.ts` (39 tests) + `hook-selector-overflow.test.ts` (16) + `tools/ask.test.ts` (46) green.
- New regression test: long label renders in full (no `…`), continuation indented under the marker.
- Full package suite: 12310 pass; 2 failures pre-existing and unrelated (PDF extraction via native addon; collab tombstone test that passes in isolation).

Fixes #1243, #8594.
