### PR TITLE
fix(tui): preserve welcome columns for long model names

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept the welcome screen's Tips, LSP Servers, and Recent sessions visible when a long model name still leaves enough terminal width for both columns ([#8657](https://github.com/can1357/oh-my-pi/issues/8657)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -248,7 +248,10 @@ export class WelcomeComponent implements Component {
 			visibleWidth(this.modelName),
 			visibleWidth(this.providerName),
 		);
-		const desiredLeftCol = Math.min(preferredLeftCol, Math.max(minLeftCol, Math.floor(dualContentWidth * 0.35)));
+		const desiredLeftCol = Math.max(
+			Math.min(preferredLeftCol, Math.max(minLeftCol, Math.floor(dualContentWidth * 0.35))),
+			leftMinContentWidth,
+		);
 		const dualLeftCol =
 			dualContentWidth >= minRightCol + 1
 				? Math.min(desiredLeftCol, dualContentWidth - minRightCol)

--- a/packages/coding-agent/test/modes/components/welcome.test.ts
+++ b/packages/coding-agent/test/modes/components/welcome.test.ts
@@ -3,7 +3,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { pickWeightedTip, WelcomeComponent } from "@oh-my-pi/pi-coding-agent/modes/components/welcome";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
-describe("WelcomeComponent tips", () => {
+describe("WelcomeComponent", () => {
 	beforeAll(async () => {
 		await Settings.init({ inMemory: true });
 		await initTheme(false);
@@ -60,5 +60,13 @@ describe("WelcomeComponent tips", () => {
 		expect(newMax).toBeGreaterThan(0);
 		expect(newMax).toBeGreaterThan(ordinaryMax);
 		expect(pickWeightedTip([], 0.5)).toBe("");
+	});
+
+	it("keeps the right column visible when a long model name fits", () => {
+		const modelName = "DeepSeek V4 Flash (2x usage)";
+		const output = new WelcomeComponent("17.3.4", modelName, "opencode-go").render(55).join("\n");
+
+		expect(output).toContain(modelName);
+		expect(output).toContain("Recent sessions");
 	});
 });


### PR DESCRIPTION
## Repro

At a 120-column terminal, `WelcomeComponent` rendered the right column for `DeepSeek V4 Flash` but dropped it for the shipped 28-column name `DeepSeek V4 Flash (2x usage)`. Reproduced with `bun -e 'import { Settings } from "./packages/coding-agent/src/config/settings.ts"; import { WelcomeComponent } from "./packages/coding-agent/src/modes/components/welcome.ts"; import { initTheme } from "./packages/coding-agent/src/modes/theme/theme.ts"; await Settings.init({ inMemory: true }); await initTheme(false); for (const model of ["DeepSeek V4 Flash", "DeepSeek V4 Flash (2x usage)"]) { const lines = new WelcomeComponent("17.3.4", model, "opencode-go").render(120); console.log(`${model}: Tips=${lines.some(line => line.includes("Tips"))}, Recent=${lines.some(line => line.includes("Recent sessions"))}`); }'`.

## Cause

`WelcomeComponent.#renderLines()` in `packages/coding-agent/src/modes/components/welcome.ts` capped `desiredLeftCol` at 26 columns while requiring it to be at least the full model/provider display width. Any label wider than 26 columns therefore made `showRightColumn` permanently false, even when the terminal had ample room.

## Fix

- Let the preferred left-column width grow to the minimum width required by its labels.
- Continue capping the actual left column so the right column retains its 20-column minimum.
- Add a regression test using the reported model name at the 55-column boundary.
- Record the user-visible fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/modes/components/welcome.test.ts` passed: 4 tests, 0 failures. The original 120-column rendering probe now reports `Tips=true, Recent=true` for both short and long names. The pre-publish `bun check` gate passed.

Fixes #8657