### PR TITLE
feat(coding-agent): add display-only assistant text transformers

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -470,6 +470,17 @@ pi.registerAssistantThinkingRenderer((context, theme) => {
 
 Used by interactive rendering to add display-only supplemental UI below each visible assistant thinking block. The renderer receives the already-visible thinking text, content/thinking indexes, theme, and a `requestRender()` callback for async renderers. All registered renderers that return a component are appended in registration order. Renderers must not mutate messages; the original thinking block remains the provider/session source of truth.
 
+## Assistant text transformer
+
+```ts
+pi.registerAssistantTextTransformer((text, { isStreaming }) => {
+  return isStreaming ? text : transformFinalMarkdownForDisplay(text);
+});
+```
+
+Assistant text transformers run in extension load order immediately before Markdown rendering. Each receives the prior transformer's output and whether the message is still streaming. Returned text is display-only: OMP never writes it to the session, provider context, exports, or subsequent turns. A transformer failure preserves the prior display text and is logged once for that extension.
+
+
 ## Tool call/result renderer
 
 Provide `renderCall` / `renderResult` on `registerTool` definitions for custom tool visualization in TUI.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added display-only assistant text transformers for extensions, composed in extension load order without mutating persisted messages or model context.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -35,6 +35,7 @@ import { getAllPluginExtensionPaths } from "../plugins/loader";
 
 import { resolvePath, withHostGuard } from "../utils";
 import type {
+	AssistantTextTransformer,
 	AssistantThinkingRenderer,
 	Extension,
 	ExtensionAPI,
@@ -226,6 +227,28 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		this.extension.assistantThinkingRenderers.push(renderer);
 	}
 
+	registerAssistantTextTransformer(transformer: AssistantTextTransformer): void {
+		let reportedFailure = false;
+		this.extension.assistantTextTransformers.push((text, context) => {
+			try {
+				const transformed = transformer(text, context);
+				if (typeof transformed !== "string") {
+					throw new TypeError("Assistant text transformer must return a string");
+				}
+				return transformed;
+			} catch (error) {
+				if (!reportedFailure) {
+					reportedFailure = true;
+					logger.warn("Assistant text transformer failed; preserving prior display text", {
+						extension: this.extension.path,
+						error: String(error),
+					});
+				}
+				return text;
+			}
+		});
+	}
+
 	getFlag(name: string): boolean | string | undefined {
 		if (!this.extension.flags.has(name)) return undefined;
 		return this.runtime.flagValues.get(name);
@@ -320,6 +343,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		tools: new Map(),
 		toolRegistrationListeners: new Set(),
 		assistantThinkingRenderers: [],
+		assistantTextTransformers: [],
 		messageRenderers: new Map(),
 		commands: new Map(),
 		flags: new Map(),

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -24,6 +24,7 @@ import { ManagedTimers } from "./managed-timers";
 import { createExtensionModelQuery } from "./model-api";
 import type {
 	AfterProviderResponseEvent,
+	AssistantTextTransformer,
 	AssistantThinkingRenderer,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
@@ -896,6 +897,10 @@ export class ExtensionRunner {
 
 	getAssistantThinkingRenderers(): AssistantThinkingRenderer[] {
 		return this.extensions.flatMap(ext => ext.assistantThinkingRenderers);
+	}
+
+	getAssistantTextTransformers(): AssistantTextTransformer[] {
+		return this.extensions.flatMap(ext => ext.assistantTextTransformers);
 	}
 
 	getRegisteredCommands(reserved?: ReadonlySet<string>): RegisteredCommand[] {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1134,6 +1134,18 @@ export type AssistantThinkingRenderer = (
 	theme: Theme,
 ) => Component | undefined;
 
+export interface AssistantTextTransformContext {
+	/** Whether the assistant message is still streaming. */
+	isStreaming: boolean;
+}
+
+/**
+ * Transform assistant Markdown for display only.
+ *
+ * The returned text is never written to the session or provider context.
+ */
+export type AssistantTextTransformer = (text: string, context: AssistantTextTransformContext) => string;
+
 // ============================================================================
 // Command Registration
 // ============================================================================
@@ -1302,6 +1314,9 @@ export interface ExtensionAPI {
 
 	/** Register a renderer for assistant thinking blocks. Rendered after the original thinking text. */
 	registerAssistantThinkingRenderer(renderer: AssistantThinkingRenderer): void;
+
+	/** Register a display-only transformer for assistant Markdown. Transformers run in extension load order. */
+	registerAssistantTextTransformer(transformer: AssistantTextTransformer): void;
 
 	// =========================================================================
 	// Actions
@@ -1630,6 +1645,7 @@ export interface Extension {
 	tools: Map<string, RegisteredTool<any, any>>;
 	toolRegistrationListeners?: Set<ToolRegistrationListener>;
 	assistantThinkingRenderers: AssistantThinkingRenderer[];
+	assistantTextTransformers: AssistantTextTransformer[];
 	messageRenderers: Map<string, MessageRenderer>;
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -29,7 +29,7 @@ import {
 import { formatAge, formatNumber, getProjectDir, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
 import type { Settings } from "../../config/settings";
-import type { MessageRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextTransformer, MessageRenderer } from "../../extensibility/extensions/types";
 import { IrcBus } from "../../irc/bus";
 import { AgentLifecycleManager } from "../../registry/agent-lifecycle";
 import { type AgentRef, AgentRegistry, type AgentStatus, MAIN_AGENT_ID } from "../../registry/agent-registry";
@@ -128,6 +128,7 @@ export interface AgentHubDeps {
 	isBuiltInTool?: (name: string) => boolean;
 	/** Extension message renderers for custom messages in the transcript. */
 	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getAssistantTextTransformers?: () => readonly AssistantTextTransformer[];
 	/** Cwd used by tool renderers for path shortening; defaults to the project dir. */
 	cwd?: string;
 	/** Mirrors the main transcript's thinking-block visibility. */
@@ -211,6 +212,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#getTool: ((name: string) => AgentTool | undefined) | undefined;
 	#isBuiltInTool: ((name: string) => boolean) | undefined;
 	#getMessageRenderer: ((customType: string) => MessageRenderer | undefined) | undefined;
+	#getAssistantTextTransformers: (() => readonly AssistantTextTransformer[]) | undefined;
 	#cwd: string;
 	#hideThinkingBlock: (() => boolean) | undefined;
 	#proseOnlyThinking: (() => boolean) | undefined;
@@ -244,6 +246,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#getTool = deps.getTool;
 		this.#isBuiltInTool = deps.isBuiltInTool;
 		this.#getMessageRenderer = deps.getMessageRenderer;
+		this.#getAssistantTextTransformers = deps.getAssistantTextTransformers;
 		this.#cwd = deps.cwd ?? getProjectDir();
 		this.#hideThinkingBlock = deps.hideThinkingBlock;
 		this.#proseOnlyThinking = deps.proseOnlyThinking;
@@ -371,6 +374,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			getTool: this.#getTool,
 			isBuiltInTool: this.#isBuiltInTool,
 			getMessageRenderer: this.#getMessageRenderer,
+			getAssistantTextTransformers: this.#getAssistantTextTransformers,
 			cwd: this.#cwd,
 			hideThinkingBlock: this.#hideThinkingBlock,
 			proseOnlyThinking: this.#proseOnlyThinking,

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -18,7 +18,7 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { type Component, Editor, matchesKey, routeSgrMouseInput, ScrollView, type TUI } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
-import type { MessageRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextTransformer, MessageRenderer } from "../../extensibility/extensions/types";
 import type { AgentLifecycleManager } from "../../registry/agent-lifecycle";
 import type { AgentRegistry, AgentStatus } from "../../registry/agent-registry";
 import type { FileEntry, SessionMessageEntry } from "../../session/session-entries";
@@ -46,6 +46,7 @@ export interface AgentTranscriptViewerDeps {
 	/** Whether the active registry entry came from a built-in factory. */
 	isBuiltInTool?: (name: string) => boolean;
 	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getAssistantTextTransformers?: () => readonly AssistantTextTransformer[];
 	cwd: string;
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
@@ -165,6 +166,7 @@ export class AgentTranscriptViewer implements Component {
 			getTool: deps.getTool,
 			isBuiltInTool: deps.isBuiltInTool,
 			getMessageRenderer: deps.getMessageRenderer,
+			getAssistantTextTransformers: deps.getAssistantTextTransformers,
 			cwd: deps.cwd,
 			hideThinkingBlock: deps.hideThinkingBlock,
 			proseOnlyThinking: deps.proseOnlyThinking,

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -12,7 +12,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
-import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextTransformer, AssistantThinkingRenderer } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { expandKeyHint, getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { convertImageToPng } from "../../utils/image-loading";
@@ -31,6 +31,8 @@ const MAX_TRANSCRIPT_ERROR_LINES = 8;
 
 /** Opening or closing fence of a code block: ≥3 backticks/tildes plus info string. */
 const CODE_FENCE_LINE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+const STREAMING_ASSISTANT_TEXT_CONTEXT = { isStreaming: true } as const;
+const FINAL_ASSISTANT_TEXT_CONTEXT = { isStreaming: false } as const;
 
 type ThinkingContentBlock = Extract<AssistantMessage["content"][number], { type: "thinking" }>;
 type DisplayThinkingContentBlock = ThinkingContentBlock & { rawThinking?: string };
@@ -275,6 +277,7 @@ export class AssistantMessageComponent extends Container {
 		private readonly thinkingRenderers: readonly AssistantThinkingRenderer[] = [],
 		private readonly imageBudget?: ImageBudget,
 		private proseOnlyThinking = true,
+		private readonly textTransformers: readonly AssistantTextTransformer[] = [],
 	) {
 		super();
 		this.#transcriptBlockFinalized = message !== undefined;
@@ -736,6 +739,22 @@ export class AssistantMessageComponent extends Container {
 		return true;
 	}
 
+	#transformAssistantText(text: string): string {
+		if (this.textTransformers.length === 0) return text;
+		let transformed = text;
+		const context = this.#lastUpdateTransient ? STREAMING_ASSISTANT_TEXT_CONTEXT : FINAL_ASSISTANT_TEXT_CONTEXT;
+		for (const transformer of this.textTransformers) {
+			try {
+				const next = transformer(transformed, context);
+				if (typeof next === "string") transformed = next;
+			} catch {
+				// Extension registration normally wraps failures. Keep direct
+				// construction equally safe for SDK hosts and tests.
+			}
+		}
+		return transformed;
+	}
+
 	#tryFastPathUpdate(message: AssistantMessage, opts?: { transient?: boolean }): boolean {
 		if (!this.#fastPathKey || !this.#fastPathItems) return false;
 		if (!this.#canFastPath(message)) {
@@ -761,7 +780,7 @@ export class AssistantMessageComponent extends Container {
 			}
 			let newText: string;
 			if (item.blockType === "text" && content.type === "text") {
-				newText = content.text.trim();
+				newText = this.#transformAssistantText(content.text).trim();
 			} else if (item.blockType === "thinking" && content.type === "thinking") {
 				newText = resolveThinkingDisplay(content, this.proseOnlyThinking).text;
 			} else {
@@ -875,7 +894,7 @@ export class AssistantMessageComponent extends Container {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				const trimmed = content.text.trim();
+				const trimmed = this.#transformAssistantText(content.text).trim();
 				const mdOptions = this.#textColorTransform ? { color: this.#textColorTransform } : undefined;
 				const md = new Markdown(trimmed, 1, 0, getMarkdownTheme(), mdOptions, 0);
 				this.#contentContainer.addChild(md);

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -17,7 +17,7 @@ import type { TUI } from "@oh-my-pi/pi-tui";
 import type { AdvisorMessageDetails } from "../../advisor";
 import { COLLAB_PROMPT_MESSAGE_TYPE, type CollabPromptDetails } from "../../collab/protocol";
 import { settings } from "../../config/settings";
-import type { MessageRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextTransformer, MessageRenderer } from "../../extensibility/extensions/types";
 import { LAUNCH_COMPLETION_MESSAGE_TYPE } from "../../session/launch-completion";
 import {
 	BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE,
@@ -66,6 +66,7 @@ export interface ChatTranscriptBuilderDeps {
 	/** Whether the active registry entry came from a built-in factory. */
 	isBuiltInTool?: (name: string) => boolean;
 	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getAssistantTextTransformers?: () => readonly AssistantTextTransformer[];
 	cwd: string;
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
@@ -325,6 +326,7 @@ export class ChatTranscriptBuilder {
 			this.deps.getMessageRenderer ? undefined : [], // placeholder for thinkingRenderers
 			this.deps.ui.imageBudget,
 			proseOnlyThinking,
+			this.deps.getAssistantTextTransformers?.(),
 		);
 		assistantComponent.setImagesVisible(settings.get("terminal.showImages"));
 		assistantComponent.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));
@@ -358,6 +360,7 @@ export class ChatTranscriptBuilder {
 				this.deps.getMessageRenderer ? undefined : [],
 				undefined,
 				proseOnlyThinking,
+				this.deps.getAssistantTextTransformers?.(),
 			);
 			component.setImagesVisible(settings.get("terminal.showImages"));
 			component.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2035,6 +2035,7 @@ export class SelectorController {
 			getTool: name => this.ctx.session.getToolByName(name),
 			isBuiltInTool: name => this.ctx.session.hasBuiltInTool(name),
 			getMessageRenderer: type => this.ctx.session.extensionRunner?.getMessageRenderer(type),
+			getAssistantTextTransformers: () => this.ctx.session.extensionRunner?.getAssistantTextTransformers() ?? [],
 			cwd: this.ctx.sessionManager.getCwd(),
 			hideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			proseOnlyThinking: () => this.ctx.proseOnlyThinking,

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -23,6 +23,7 @@ export function createAssistantMessageComponent(
 		ctx.viewSession.extensionRunner?.getAssistantThinkingRenderers(),
 		ctx.ui.imageBudget,
 		ctx.proseOnlyThinking,
+		ctx.viewSession.extensionRunner?.getAssistantTextTransformers(),
 	);
 	component.setImagesVisible(ctx.settings.get("terminal.showImages"));
 	component.setToolResultImagesVisible(!ctx.hideToolActivity);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -488,6 +488,31 @@ describe("ExtensionRunner", () => {
 
 			expect(runner.getAssistantThinkingRenderers().length).toBe(1);
 		});
+
+		it("collects assistant text transformers in extension load order", async () => {
+			fs.writeFileSync(
+				path.join(extensionsDir, "a-text-transformer.ts"),
+				`export default pi => pi.registerAssistantTextTransformer(text => text + "A");`,
+			);
+			fs.writeFileSync(
+				path.join(extensionsDir, "b-text-transformer.ts"),
+				`export default pi => pi.registerAssistantTextTransformer(text => text + "B");`,
+			);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			const transformed = runner
+				.getAssistantTextTransformers()
+				.reduce((text, transformer) => transformer(text, { isStreaming: false }), "");
+			expect(transformed).toBe("AB");
+		});
 	});
 
 	describe("flags", () => {
@@ -3484,6 +3509,7 @@ describe("ExtensionRunner", () => {
 				handlers: new Map([["input", [async (...args: unknown[]) => handler(args[0] as InputEvent)]]]),
 				tools: new Map(),
 				assistantThinkingRenderers: [],
+				assistantTextTransformers: [],
 				messageRenderers: new Map(),
 				commands: new Map(),
 				flags: new Map(),

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
@@ -122,6 +122,27 @@ Average Latency: 1,240 ms
 		expect(finalized).toContain("1/1 Running");
 	});
 
+	it("applies assistant text transformers only to the display copy", () => {
+		const message = msg([{ type: "text", text: "original" }]);
+		const finality: boolean[] = [];
+		const component = new AssistantMessageComponent(undefined, false, undefined, [], undefined, true, [
+			(text, context) => {
+				finality.push(context.isStreaming);
+				return context.isStreaming ? text : "[linked](https://example.com)";
+			},
+		]);
+
+		component.updateContent(message, { transient: true });
+		expect(Bun.stripANSI(component.render(W).join("\n"))).toContain("original");
+
+		component.updateContent(message);
+		const finalized = Bun.stripANSI(component.render(W).join("\n"));
+		expect(finalized).toContain("linked");
+		expect(finalized).not.toContain("original");
+		expect(message.content[0]).toEqual({ type: "text", text: "original" });
+		expect(finality).toEqual([true, false]);
+	});
+
 	// Regression: theme/symbol changes reach the component via invalidate()
 	// (InteractiveMode clears the markdown render cache and invalidates the
 	// tree). Reused fast-path children captured getMarkdownTheme() at

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -506,6 +506,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 				]),
 				tools: new Map(),
 				assistantThinkingRenderers: [],
+				assistantTextTransformers: [],
 				messageRenderers: new Map(),
 				commands: new Map(),
 				flags: new Map(),


### PR DESCRIPTION
## Problem

Extensions can render custom messages and thinking blocks, but they cannot transform finalized assistant Markdown for display without mutating persisted messages or relying on detached `message_end` snapshots. This blocks display-only features such as resolving local paths into clickable absolute file links.

## Decision

Add a narrow, synchronous `registerAssistantTextTransformer` extension seam. Transformers:

- compose in extension load order;
- receive `{ isStreaming }`;
- affect rendering only, leaving session history and provider context unchanged;
- preserve prior display text and log once if an extension throws or returns a non-string.

The live transcript, rebuilt transcript, and agent transcript viewer all consume the same runner-owned transformer list. The assistant component keeps a zero-transformer fast path and reuses immutable streaming/final context objects.

## Checks

- `bun run check:ts`
- `bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts` (97 passed)

`bun check` was also attempted; TypeScript completed after fixes, but the Rust phase cannot run on this workstation because `cargo` is not installed.