### PR TITLE
perf(coding-agent): bound streaming diff previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Kept streaming edit previews responsive for large diffs by selecting and highlighting only the visible tail instead of scanning the discarded prefix on every update.
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -412,6 +412,42 @@ function renderPlainTextPreview(text: string, uiTheme: Theme, _filePath?: string
 	}
 	return preview.trimEnd();
 }
+
+interface StreamingDiffTail {
+	content: string;
+	hidden: boolean;
+}
+
+/**
+ * Select the trailing physical lines that fit the live preview budget.
+ *
+ * Walk backward from the end instead of splitting the complete diff. This keeps
+ * allocation and scanning proportional to the visible suffix. One physical line
+ * may exceed the budget, but it is still kept so the newest change is visible.
+ */
+function sliceStreamingDiffTail(diff: string, innerWidth: number, budget: number): StreamingDiffTail {
+	let end = diff.length;
+	while (end > 0 && diff.charCodeAt(end - 1) === 10) end--;
+	if (end === 0) return { content: "", hidden: false };
+
+	const rowLimit = Math.max(1, budget);
+	let start = end;
+	let cursor = end;
+	let visualRows = 0;
+	while (cursor >= 0) {
+		const newline = cursor > 0 ? diff.lastIndexOf("\n", cursor - 1) : -1;
+		const lineStart = newline + 1;
+		const lineRows = Math.max(1, wrapTextWithAnsi(replaceTabs(diff.slice(lineStart, cursor)), innerWidth).length);
+		if (visualRows > 0 && visualRows + lineRows > rowLimit) break;
+		visualRows += lineRows;
+		start = lineStart;
+		if (newline < 0) break;
+		cursor = newline;
+	}
+
+	return { content: diff.slice(start, end), hidden: start > 0 };
+}
+
 function formatStreamingDiff(
 	diff: string,
 	rawPath: string,
@@ -442,26 +478,14 @@ function formatStreamingDiff(
 		// its Myers alignment is not monotonic in payload length, so a hunk-aware
 		// window stutters as rows move between hunks. Expanded widens the window
 		// to the viewport; the full diff appears once the result finalizes.
-		const allLines = diff.replace(/\n+$/u, "").split("\n");
-		let visualUsed = 0;
-		let cut = allLines.length;
-		for (let i = allLines.length - 1; i >= 0; i--) {
-			const lineRows = Math.max(1, wrapTextWithAnsi(replaceTabs(allLines[i]!), innerWidth).length);
-			if (visualUsed + lineRows > budget && visualUsed > 0) break;
-			visualUsed += lineRows;
-			cut = i;
-		}
-		const hiddenLines = cut;
-		const visible = hiddenLines > 0 ? allLines.slice(hiddenLines) : allLines;
+		const tail = sliceStreamingDiffTail(diff, innerWidth, budget);
 		let rendered = "\n\n";
-		if (hiddenLines > 0) {
-			const hiddenHunks = getDiffStats(allLines.slice(0, hiddenLines).join("\n")).hunks;
-			const remainder: string[] = [];
-			if (hiddenHunks > 0) remainder.push(`${hiddenHunks} more hunks`);
-			remainder.push(`${hiddenLines} more lines`);
-			rendered += `${uiTheme.fg("dim", `… (${remainder.join(", ")} above)`)}\n`;
+		if (tail.hidden) {
+			// Exact hidden line/hunk counts require scanning the discarded prefix,
+			// which would make every streaming update scale with the complete diff.
+			rendered += `${uiTheme.fg("dim", "… (content above)")}\n`;
 		}
-		rendered += renderDiffColored(visible.join("\n"), { filePath: rawPath });
+		rendered += renderDiffColored(tail.content, { filePath: rawPath });
 		return rendered;
 	});
 	// The animated glyph rides this trailing line — inside the transcript's

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -84,14 +84,14 @@ describe("editToolRenderer", () => {
 			const collapsed = renderPreview(makeDiff(20), false);
 			expect(collapsed).toContain("tail-line-20");
 			expect(collapsed).not.toContain("head-line-1");
-			expect(collapsed).toContain("more lines above");
+			expect(collapsed).toContain("content above");
 			expect(collapsed).toContain("(preview)");
 
 			// Within the viewport window, expanded shows the whole diff.
 			const expanded = renderPreview(makeDiff(20), true);
 			expect(expanded).toContain("head-line-1");
 			expect(expanded).toContain("tail-line-20");
-			expect(expanded).not.toContain("more lines above");
+			expect(expanded).not.toContain("content above");
 			expect(expanded).not.toContain("(preview)");
 
 			// Beyond it, expanded stays a viewport-sized tail window: an unbounded
@@ -100,7 +100,7 @@ describe("editToolRenderer", () => {
 			const expandedTall = renderPreview(makeDiff(40), true);
 			expect(expandedTall).toContain("tail-line-40");
 			expect(expandedTall).not.toContain("head-line-1");
-			expect(expandedTall).toContain("more lines above");
+			expect(expandedTall).toContain("content above");
 		} finally {
 			if (originalRowsDescriptor) {
 				Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);
@@ -108,6 +108,52 @@ describe("editToolRenderer", () => {
 				Reflect.deleteProperty(process.stdout, "rows");
 			}
 		}
+	});
+
+	it("does not report a leading blank line as hidden content", async () => {
+		const uiTheme = await getUiTheme();
+		const rendered = Bun.stripANSI(
+			editToolRenderer
+				.renderCall(
+					{ file_path: "/tmp/leading-blank.ts", previewDiff: "\n+1|first-added\n+2|second-added" },
+					{ expanded: false, isPartial: true, spinnerFrame: 0, renderContext: { editMode: "replace" } },
+					uiTheme,
+				)
+				.render(200)
+				.join("\n"),
+		);
+
+		expect(rendered).toContain("first-added");
+		expect(rendered).toContain("second-added");
+		expect(rendered).not.toContain("content above");
+	});
+
+	it("uses a count-free marker for a discarded streaming prefix", async () => {
+		const uiTheme = await getUiTheme();
+		const diff = [
+			"@@ -1,10000 +1,12 @@",
+			...Array.from({ length: 10_000 }, (_, index) => `-hidden-line-${index + 1}`),
+			...Array.from({ length: 12 }, (_, index) => `+visible-tail-${index + 1}`),
+			"",
+			"",
+		].join("\n");
+
+		const rendered = Bun.stripANSI(
+			editToolRenderer
+				.renderCall(
+					{ file_path: "/tmp/large-preview.ts", previewDiff: diff },
+					{ expanded: false, isPartial: true, spinnerFrame: 0, renderContext: { editMode: "replace" } },
+					uiTheme,
+				)
+				.render(200)
+				.join("\n"),
+		);
+
+		expect(rendered).toContain("content above");
+		expect(rendered).toContain("visible-tail-12");
+		expect(rendered).not.toContain("hidden-line-10000");
+		expect(rendered).not.toContain("more hunks");
+		expect(rendered).not.toContain("more lines above");
 	});
 
 	it("uses hashline input headers for streaming call path without apply_patch errors", async () => {


### PR DESCRIPTION
## What

- Select the visible tail of a streaming edit diff before highlighting and wrapping it.
- Show a count-free marker when earlier diff content is not visible.
- Add regression coverage for a 10,000-line hidden prefix and a leading blank line.

## Why

Streaming edit previews processed the complete accumulated diff on every update, including content that the terminal could not show. Large diffs therefore made each update slower as the discarded prefix grew. This change bounds preview work by the visible row budget while keeping the newest diff content visible.

Measured local render-tail selection:

| Hidden lines | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 1,000 | 0.080 ms | 0.076 ms | 1.0x |
| 10,000 | 0.617 ms | 0.072 ms | 8.6x |
| 100,000 | 6.777 ms | 0.156 ms | 43.4x |

## Testing

- [x] `bun check`
- [x] `bun test packages/coding-agent/test/tools/edit-renderer.test.ts` (27 pass, 0 fail)
- [x] `bunx biome check packages/coding-agent/src/edit/renderer.ts packages/coding-agent/test/tools/edit-renderer.test.ts`
- [x] `bun run check:types` in `packages/coding-agent`
- [x] `bun packages/coding-agent/src/cli.ts gallery --plain --width 120`
- [x] Tested locally
- [x] CHANGELOG updated
