### PR TITLE
feat(rpc): add cancel_subagent command to stop a background subagent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added an RPC `cancel_subagent` command to stop a running background subagent ([#8666](https://github.com/can1357/oh-my-pi/pull/8666) by [@13kparkin](https://github.com/13kparkin)).
+- Added an RPC `cancel_subagent` command (and the `RpcClient.cancelSubagent()` client method) to stop a running background subagent ([#8666](https://github.com/can1357/oh-my-pi/pull/8666) by [@13kparkin](https://github.com/13kparkin)).
 
 ## [17.3.4] - 2026-08-14
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an RPC `cancel_subagent` command to stop a running background subagent ([#8666](https://github.com/can1357/oh-my-pi/pull/8666) by [@13kparkin](https://github.com/13kparkin)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -660,6 +660,16 @@ export class RpcClient {
 		});
 		return this.#getData<RpcSubagentMessagesResult>(response);
 	}
+	/**
+	 * Cancel a running background subagent spawned via the task tool. Routes its run
+	 * signal through the abort path so the subagent finalizes as aborted. Idempotent:
+	 * resolves to `false` for an unknown or already-finished subagent, or one owned by
+	 * a different agent.
+	 */
+	async cancelSubagent(subagentId: string): Promise<boolean> {
+		const response = await this.#send({ type: "cancel_subagent", subagentId });
+		return this.#getData<{ cancelled: boolean }>(response).cancelled;
+	}
 
 	/**
 	 * Set model by provider and ID.

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1178,6 +1178,18 @@ export async function runRpcMode(
 				}
 			}
 
+			case "cancel_subagent": {
+				if (typeof command.subagentId !== "string" || command.subagentId.length === 0) {
+					return error(id, "cancel_subagent", "subagentId must be a non-empty string");
+				}
+				try {
+					const cancelled = session.cancelSubagent(command.subagentId);
+					return success(id, "cancel_subagent", { cancelled });
+				} catch (err) {
+					return error(id, "cancel_subagent", err instanceof Error ? err.message : String(err));
+				}
+			}
+
 			// =================================================================
 			// Model
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -47,6 +47,7 @@ export type RpcCommand =
 	| { id?: string; type: "set_subagent_subscription"; level: RpcSubagentSubscriptionLevel }
 	| { id?: string; type: "get_subagents" }
 	| { id?: string; type: "get_subagent_messages"; subagentId?: string; sessionFile?: string; fromByte?: number }
+	| { id?: string; type: "cancel_subagent"; subagentId: string }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -250,6 +251,13 @@ export type RpcResponse =
 			command: "get_subagent_messages";
 			success: true;
 			data: RpcSubagentMessagesResult;
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "cancel_subagent";
+			success: true;
+			data: { cancelled: boolean };
 	  }
 
 	// Model

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1631,6 +1631,24 @@ export class AgentSession {
 		return this.#agentId;
 	}
 
+	/**
+	 * Cancel one running background subagent job owned by this agent, routing
+	 * the job's run signal through the normal abort path so the subagent
+	 * finalizes as aborted (salvaged result + lifecycle event). Idempotent:
+	 * returns whether a running job was found and cancelled; an already-finished
+	 * or unknown subagent is a no-op returning false, so hosts can treat a
+	 * cancel of a vanished subagent as success.
+	 */
+	cancelSubagent(subagentId: string): boolean {
+		const manager = this.#asyncJobManager;
+		if (!manager || !this.#agentId) return false;
+		const job = manager
+			.getRunningJobs({ ownerId: this.#agentId })
+			.find(job => job.id === subagentId || job.agentId === subagentId);
+		if (!job) return false;
+		return manager.cancel(job.id, { ownerId: this.#agentId });
+	}
+
 	/** Dequeue the next HARD forced tool choice for the upcoming LLM call, dropping
 	 *  (and rejecting) one whose named tool is no longer active. */
 	#nextHardToolChoice(): ToolChoice | undefined {

--- a/packages/coding-agent/test/agent-session-cancel-subagent.test.ts
+++ b/packages/coding-agent/test/agent-session-cancel-subagent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
@@ -9,14 +9,33 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
+import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
+import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition, SingleResult, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 // cancel_subagent routes a detached background subagent's run signal through
 // the normal abort path (AsyncJobManager.cancel aborts the job's
-// AbortController), so the subagent finalizes aborted instead of running to
-// completion. Idempotent: unknown/already-finished subagents and jobs owned by
-// another agent are no-ops.
+// AbortController), so the subagent finalizes as aborted (salvaged result +
+// lifecycle event) instead of running to completion. Idempotent:
+// unknown/already-finished subagents and jobs owned by another agent are
+// no-ops.
+const TASK_AGENT: AgentDefinition = {
+	name: "task",
+	description: "General-purpose task agent",
+	systemPrompt: "Do the assigned work.",
+	source: "bundled",
+	tools: [],
+};
+
+/** Output the real executor salvages for a cancelled run that produced nothing
+ *  (kept free of HTML-escapable characters so it survives the summary render
+ *  verbatim). */
+const SALVAGED_OUTPUT = "[cancelled after 1 req, 0 tok - last activity: partway]";
+
 describe("AgentSession.cancelSubagent", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -51,14 +70,90 @@ describe("AgentSession.cancelSubagent", () => {
 		session = undefined;
 		authStorage.close();
 		AsyncJobManager.resetForTests();
+		vi.restoreAllMocks();
 		tempDir.removeSync();
 	});
 
-	/** Register a task job whose id/agentId is `id`, owned by `ownerId` ("Main" unless overridden). */
-	function registerTaskJob(id: string, ownerId = "Main"): string {
-		return manager.register(
+	it("cancels a running background subagent through the real task spawn path and finalizes it as aborted", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TASK_AGENT], projectAgentsDir: null });
+		// Mirror the executor's abort contract: hold until the run signal
+		// aborts, then return an aborted SingleResult with salvaged output.
+		const abortObserved = Promise.withResolvers<boolean>();
+		const runSubprocess = vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			const { promise, resolve } = Promise.withResolvers<void>();
+			if (options.signal?.aborted) resolve();
+			else options.signal?.addEventListener("abort", () => resolve(), { once: true });
+			await promise;
+			abortObserved.resolve(options.signal?.aborted === true);
+			return {
+				index: options.index,
+				id: options.id,
+				agent: options.agent.name,
+				agentSource: options.agent.source,
+				task: options.task,
+				exitCode: 1,
+				aborted: true,
+				output: SALVAGED_OUTPUT,
+				stderr: "",
+				truncated: false,
+				durationMs: 12,
+				tokens: 0,
+				requests: 1,
+			} satisfies SingleResult;
+		});
+
+		const toolSession: ToolSession = {
+			cwd: tempDir.path(),
+			hasUI: false,
+			settings: Settings.isolated({
+				"async.enabled": true,
+				"task.isolation.mode": "none",
+				"task.enableLsp": false,
+			}),
+			asyncJobManager: manager,
+			getAgentId: () => "Main",
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getPlanModeState: () => undefined,
+		};
+		const tool = await TaskTool.create(toolSession);
+		const updates: TaskToolDetails[] = [];
+		const result = await tool.execute("tool-call", { task: "long-running work" }, undefined, update => {
+			if (update.details) updates.push(update.details);
+		});
+
+		const jobId = result.details?.async?.jobId;
+		expect(jobId).toBeDefined();
+		const job = manager.getJob(jobId!);
+		expect(job).toBeDefined();
+		expect(job!.status).toBe("running");
+		expect(job!.ownerId).toBe("Main");
+
+		expect(session!.cancelSubagent(jobId!)).toBe(true);
+		await manager.waitForAll();
+
+		// The run signal reached the executor boundary: the subagent run
+		// resolved because its signal aborted, not because it finished.
+		expect(await abortObserved.promise).toBe(true);
+		expect(runSubprocess).toHaveBeenCalledTimes(1);
+		// The job settled as cancelled carrying the salvaged output the real
+		// finalize path produced from the aborted run.
+		expect(job!.status).toBe("cancelled");
+		expect(job!.errorText).toContain(SALVAGED_OUTPUT);
+		// The real task job body stamped progress.status = "aborted" from the
+		// aborted SingleResult, surfaced through the tool's progress updates.
+		expect(updates.at(-1)?.progress?.[0]?.status).toBe("aborted");
+	});
+
+	it("is an idempotent no-op for an unknown subagent", () => {
+		expect(session!.cancelSubagent("ghost-agent")).toBe(false);
+		expect(manager.getRunningJobs()).toHaveLength(0);
+	});
+
+	it("does not cancel a job owned by a different agent", () => {
+		const jobId = manager.register(
 			"task",
-			id,
+			"other agent's job",
 			async ({ signal }) => {
 				const { promise, resolve } = Promise.withResolvers<void>();
 				if (signal.aborted) {
@@ -69,30 +164,8 @@ describe("AgentSession.cancelSubagent", () => {
 				await promise;
 				return "done";
 			},
-			{ id, ownerId, agentId: id },
+			{ id: "agent-2", ownerId: "OtherAgent", agentId: "agent-2" },
 		);
-	}
-
-	it("cancels a running background subagent owned by this session's agent", () => {
-		const jobId = registerTaskJob("agent-1");
-		const job = manager.getJob(jobId)!;
-		expect(job.status).toBe("running");
-		expect(job.abortController.signal.aborted).toBe(false);
-
-		const cancelled = session!.cancelSubagent("agent-1");
-
-		expect(cancelled).toBe(true);
-		expect(manager.getJob(jobId)?.status).toBe("cancelled");
-		expect(manager.getJob(jobId)?.abortController.signal.aborted).toBe(true);
-	});
-
-	it("is an idempotent no-op for an unknown subagent", () => {
-		expect(session!.cancelSubagent("ghost-agent")).toBe(false);
-		expect(manager.getRunningJobs()).toHaveLength(0);
-	});
-
-	it("does not cancel a job owned by a different agent", () => {
-		const jobId = registerTaskJob("agent-2", "OtherAgent");
 		expect(session!.cancelSubagent("agent-2")).toBe(false);
 		expect(manager.getJob(jobId)?.status).toBe("running");
 		expect(manager.getJob(jobId)?.abortController.signal.aborted).toBe(false);

--- a/packages/coding-agent/test/agent-session-cancel-subagent.test.ts
+++ b/packages/coding-agent/test/agent-session-cancel-subagent.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+// cancel_subagent routes a detached background subagent's run signal through
+// the normal abort path (AsyncJobManager.cancel aborts the job's
+// AbortController), so the subagent finalizes aborted instead of running to
+// completion. Idempotent: unknown/already-finished subagents and jobs owned by
+// another agent are no-ops.
+describe("AgentSession.cancelSubagent", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+	let manager: AsyncJobManager;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@omp-cancel-subagent-");
+		authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected bundled model");
+		const mock = createMockModel({ handler: () => ({ content: ["ok"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml")),
+			agentId: "Main",
+			asyncJobManager: manager,
+		});
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		session = undefined;
+		authStorage.close();
+		AsyncJobManager.resetForTests();
+		tempDir.removeSync();
+	});
+
+	/** Register a task job whose id/agentId is `id`, owned by `ownerId` ("Main" unless overridden). */
+	function registerTaskJob(id: string, ownerId = "Main"): string {
+		return manager.register(
+			"task",
+			id,
+			async ({ signal }) => {
+				await new Promise<void>((resolve) => {
+					if (signal.aborted) {
+						resolve();
+						return;
+					}
+					signal.addEventListener("abort", () => resolve(), { once: true });
+				});
+				return "done";
+			},
+			{ id, ownerId, agentId: id },
+		);
+	}
+
+	it("cancels a running background subagent owned by this session's agent", () => {
+		const jobId = registerTaskJob("agent-1");
+		const job = manager.getJob(jobId)!;
+		expect(job.status).toBe("running");
+		expect(job.abortController.signal.aborted).toBe(false);
+
+		const cancelled = session!.cancelSubagent("agent-1");
+
+		expect(cancelled).toBe(true);
+		expect(manager.getJob(jobId)?.status).toBe("cancelled");
+		expect(manager.getJob(jobId)?.abortController.signal.aborted).toBe(true);
+	});
+
+	it("is an idempotent no-op for an unknown subagent", () => {
+		expect(session!.cancelSubagent("ghost-agent")).toBe(false);
+		expect(manager.getRunningJobs()).toHaveLength(0);
+	});
+
+	it("does not cancel a job owned by a different agent", () => {
+		const jobId = registerTaskJob("agent-2", "OtherAgent");
+		expect(session!.cancelSubagent("agent-2")).toBe(false);
+		expect(manager.getJob(jobId)?.status).toBe("running");
+		expect(manager.getJob(jobId)?.abortController.signal.aborted).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/agent-session-cancel-subagent.test.ts
+++ b/packages/coding-agent/test/agent-session-cancel-subagent.test.ts
@@ -60,13 +60,13 @@ describe("AgentSession.cancelSubagent", () => {
 			"task",
 			id,
 			async ({ signal }) => {
-				await new Promise<void>((resolve) => {
-					if (signal.aborted) {
-						resolve();
-						return;
-					}
+				const { promise, resolve } = Promise.withResolvers<void>();
+				if (signal.aborted) {
+					resolve();
+				} else {
 					signal.addEventListener("abort", () => resolve(), { once: true });
-				});
+				}
+				await promise;
 				return "done";
 			},
 			{ id, ownerId, agentId: id },

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -411,6 +411,10 @@ function handle(frame) {
 		write({ id: frame.id, type: "response", command: "get_subagent_messages", success: true, data: { sessionFile: frame.sessionFile || "/tmp/subagent.jsonl", fromByte: frame.fromByte || 0, nextByte: 0, reset: false, entries: [], messages: [] } });
 		return;
 	}
+	if (frame.type === "cancel_subagent") {
+		write({ id: frame.id, type: "response", command: "cancel_subagent", success: true, data: { cancelled: frame.subagentId === "SubagentA" } });
+		return;
+	}
 	if (frame.type === "prompt") {
 		write({ id: frame.id, type: "response", command: "prompt", success: true });
 		write({ type: "notice", level: "info", message: "subagent test" });
@@ -445,5 +449,10 @@ function handle(frame) {
 		expect(progressTasks).toEqual(["Do work"]);
 		expect(rawEventTypes).toEqual(["agent_start"]);
 		expect(sessionEventTypes).toContain("notice");
+
+		// Wire round trip for the cancel command: accepted for a known
+		// subagent, idempotent false for an unknown one.
+		await expect(client.cancelSubagent("SubagentA")).resolves.toBe(true);
+		await expect(client.cancelSubagent("ghost-agent")).resolves.toBe(false);
 	});
 });


### PR DESCRIPTION
This adds the cancel_subagent RPC command so hosts can stop a background subagent without aborting the session.

## What

Adds a `cancel_subagent` RPC command so hosts can stop a single running background subagent spawned by the task tool, without aborting the session.

## Why

`abort` is turn-level by design: when a host stops the main agent, its background subagents keep running on their own decoupled `runSignal` (async jobs) so they can keep delivering into a live session. That leaves hosts with no way to stop the subagents when the main agent is interrupted — the motivating case is stopping everything a stopped turn spawned. `cancel_subagent` is the surgical complement: it routes one detached subagent's run signal through the existing abort path (AsyncJobManager.cancel), so the subagent finalizes as aborted (salvaged result + lifecycle event) instead of running to completion. This is the enhancement path raised in #8660.

## How

- `rpc-types.ts`: `{ id?, type: "cancel_subagent", subagentId: string }` command + `{ cancelled: boolean }` response.
- `agent-session.ts`: `cancelSubagent(subagentId)` — finds the running job owned by this session's agent (matching job `id` or `agentId`) and routes its run signal through the existing abort path via `AsyncJobManager.cancel`. Idempotent: an unknown or already-finished subagent, or a job owned by a different agent, is a no-op returning `false` (`cancelled: false` on the wire) so hosts can treat cancelling a vanished subagent as success.
- `rpc-mode.ts`: dispatch case.

## Verification

- `packages/coding-agent/test/agent-session-cancel-subagent.test.ts`: cancel, unknown-id no-op, and cross-owner rejection (3 tests).
- End-to-end against a source-run omp: spawn a `task` subagent running `sleep 120`, send `cancel_subagent`, the subagent emits `subagent_lifecycle aborted` in ~0s instead of running to completion.
- `bun run check` clean in `packages/coding-agent` (biome + tsgo).
