### PR TITLE
feat(status-line): include descendant subagent spend

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Status-line cost now separates direct session, descendant subagent, and advisor spend.
 
 ## [17.3.4] - 2026-08-14
 

--- a/packages/coding-agent/src/modes/components/agent-hub-projection.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-projection.ts
@@ -34,8 +34,13 @@ function isDescendantOf(ownerId: string, ref: AgentRef, refsById: ReadonlyMap<st
 	return false;
 }
 
-function isCurrentSessionDescendant(ownerSessionFile: string | undefined, sessionFile: string | null): boolean {
-	if (!ownerSessionFile || !sessionFile) return false;
+function isCurrentSessionDescendant(
+	ownerSessionFile: string | undefined,
+	sessionFile: string | null,
+	allowUnscoped: boolean,
+): boolean {
+	if (!ownerSessionFile) return allowUnscoped && sessionFile === null;
+	if (!sessionFile) return false;
 	const ownerArtifactsDir = ownerSessionFile.endsWith(".jsonl")
 		? ownerSessionFile.slice(0, -".jsonl".length)
 		: ownerSessionFile;
@@ -50,6 +55,7 @@ function directCostForRef(ref: AgentRef): number | undefined {
 export function aggregateSubagentCost(args: {
 	ownerId: string;
 	ownerSessionFile?: string;
+	allowUnscoped?: boolean;
 	rows: readonly AgentRef[];
 	observedById: ReadonlyMap<string, ObservableSession>;
 }): number {
@@ -59,7 +65,7 @@ export function aggregateSubagentCost(args: {
 		if (
 			ref.kind !== "sub" ||
 			!isDescendantOf(args.ownerId, ref, refsById) ||
-			!isCurrentSessionDescendant(args.ownerSessionFile, ref.sessionFile)
+			!isCurrentSessionDescendant(args.ownerSessionFile, ref.sessionFile, args.allowUnscoped === true)
 		)
 			continue;
 		const durableCost = directCostForRef(ref);

--- a/packages/coding-agent/src/modes/components/agent-hub-projection.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-projection.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import type { AgentMetricsSummary, AgentRef, AgentStatus } from "../../registry/agent-registry";
 import { MAIN_AGENT_ID } from "../../registry/agent-registry";
 import type { ObservableSession } from "../session-observer-registry";
@@ -21,6 +22,55 @@ export const STATUS_ORDER: Record<AgentStatus, number> = { running: 0, idle: 1, 
 
 function finiteMetric(value: number | undefined): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+function isDescendantOf(ownerId: string, ref: AgentRef, refsById: ReadonlyMap<string, AgentRef>): boolean {
+	let parentId = ref.parentId;
+	const seen = new Set<string>();
+	while (parentId && !seen.has(parentId)) {
+		if (parentId === ownerId) return true;
+		seen.add(parentId);
+		parentId = refsById.get(parentId)?.parentId;
+	}
+	return false;
+}
+
+function isCurrentSessionDescendant(ownerSessionFile: string | undefined, sessionFile: string | null): boolean {
+	if (!ownerSessionFile || !sessionFile) return false;
+	const ownerArtifactsDir = ownerSessionFile.endsWith(".jsonl")
+		? ownerSessionFile.slice(0, -".jsonl".length)
+		: ownerSessionFile;
+	const relative = path.relative(path.resolve(ownerArtifactsDir), path.resolve(sessionFile));
+	return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function directCostForRef(ref: AgentRef): number | undefined {
+	return ref.session?.sessionManager?.getDirectUsageCost?.();
+}
+
+export function aggregateSubagentCost(args: {
+	ownerId: string;
+	ownerSessionFile?: string;
+	rows: readonly AgentRef[];
+	observedById: ReadonlyMap<string, ObservableSession>;
+}): number {
+	const refsById = new Map(args.rows.map(ref => [ref.id, ref]));
+	let total = 0;
+	for (const ref of args.rows) {
+		if (
+			ref.kind !== "sub" ||
+			!isDescendantOf(args.ownerId, ref, refsById) ||
+			!isCurrentSessionDescendant(args.ownerSessionFile, ref.sessionFile)
+		)
+			continue;
+		const durableCost = directCostForRef(ref);
+		const historyCost = ref.history?.metrics?.cost;
+		const observedCost = args.observedById.get(ref.id)?.progress?.cost;
+		const cost = [durableCost, historyCost, observedCost].find(
+			(value): value is number => typeof value === "number" && Number.isFinite(value),
+		);
+		if (cost !== undefined) total += cost;
+	}
+	return total;
 }
 
 /** Exact observer usage for one roster entry. */

--- a/packages/coding-agent/src/modes/components/agent-hub-projection.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-projection.ts
@@ -34,13 +34,8 @@ function isDescendantOf(ownerId: string, ref: AgentRef, refsById: ReadonlyMap<st
 	return false;
 }
 
-function isCurrentSessionDescendant(
-	ownerSessionFile: string | undefined,
-	sessionFile: string | null,
-	allowUnscoped: boolean,
-): boolean {
-	if (!ownerSessionFile) return allowUnscoped && sessionFile === null;
-	if (!sessionFile) return false;
+function isCurrentSessionDescendant(ownerSessionFile: string | undefined, sessionFile: string | null): boolean {
+	if (!ownerSessionFile || !sessionFile) return false;
 	const ownerArtifactsDir = ownerSessionFile.endsWith(".jsonl")
 		? ownerSessionFile.slice(0, -".jsonl".length)
 		: ownerSessionFile;
@@ -55,7 +50,6 @@ function directCostForRef(ref: AgentRef): number | undefined {
 export function aggregateSubagentCost(args: {
 	ownerId: string;
 	ownerSessionFile?: string;
-	allowUnscoped?: boolean;
 	rows: readonly AgentRef[];
 	observedById: ReadonlyMap<string, ObservableSession>;
 }): number {
@@ -65,7 +59,7 @@ export function aggregateSubagentCost(args: {
 		if (
 			ref.kind !== "sub" ||
 			!isDescendantOf(args.ownerId, ref, refsById) ||
-			!isCurrentSessionDescendant(args.ownerSessionFile, ref.sessionFile, args.allowUnscoped === true)
+			!isCurrentSessionDescendant(args.ownerSessionFile, ref.sessionFile)
 		)
 			continue;
 		const durableCost = directCostForRef(ref);

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1563,11 +1563,11 @@ export class StatusLineComponent implements Component {
 			premiumRequests: 0,
 			cost: 0,
 		};
-		const sessionCost =
-			this.#collabStatus?.role === "guest"
-				? aggregateUsageStats.cost
-				: this.#getDirectSessionCost(aggregateUsageStats.cost);
-		const providedSubagentCost = this.#subagentCostProvider?.(this.#focusedAgentId) ?? 0;
+		const isCollabGuest = this.#collabStatus?.role === "guest";
+		const sessionCost = isCollabGuest
+			? aggregateUsageStats.cost
+			: this.#getDirectSessionCost(aggregateUsageStats.cost);
+		const providedSubagentCost = isCollabGuest ? 0 : (this.#subagentCostProvider?.(this.#focusedAgentId) ?? 0);
 		const subagentCost = Number.isFinite(providedSubagentCost) ? Math.max(0, providedSubagentCost) : 0;
 		const usageStats = {
 			...aggregateUsageStats,

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -356,6 +356,7 @@ export class StatusLineComponent implements Component {
 	 * dependency graph; interactive-mode wires it to VibeSessionRegistry.
 	 */
 	#vibeWorkerTokenRate: (() => number | null) | null = null;
+	#subagentCostProvider: ((focusedAgentId?: string) => number) | null = null;
 	#collabStatus: CollabStatus | null = null;
 	#focusedAgentId: string | undefined;
 	#activeRepoCache: ActiveRepoCache | undefined;
@@ -620,6 +621,11 @@ export class StatusLineComponent implements Component {
 	 */
 	setVibeWorkerTokenRateProvider(provider: (() => number | null) | undefined): void {
 		this.#vibeWorkerTokenRate = provider ?? null;
+	}
+
+	setSubagentCostProvider(provider: ((focusedAgentId?: string) => number) | undefined): void {
+		this.#subagentCostProvider = provider ?? null;
+		this.invalidate();
 	}
 
 	setCollabStatus(status: CollabStatus | null): void {
@@ -1526,6 +1532,11 @@ export class StatusLineComponent implements Component {
 		return { usedTokens, contextWindow };
 	}
 
+	#getDirectSessionCost(fallback: number): number {
+		const directCost = this.session.sessionManager?.getDirectUsageCost?.();
+		return typeof directCost === "number" && Number.isFinite(directCost) ? directCost : fallback;
+	}
+
 	#buildSegmentContext(
 		width: number,
 		segmentOptions: StatusLineSettings["segmentOptions"],
@@ -1552,8 +1563,13 @@ export class StatusLineComponent implements Component {
 			premiumRequests: 0,
 			cost: 0,
 		};
+		const sessionCost = this.#getDirectSessionCost(aggregateUsageStats.cost);
+		const providedSubagentCost = this.#subagentCostProvider?.(this.#focusedAgentId) ?? 0;
+		const subagentCost = Number.isFinite(providedSubagentCost) ? Math.max(0, providedSubagentCost) : 0;
 		const usageStats = {
 			...aggregateUsageStats,
+			cost: sessionCost,
+			subagentCost,
 			tokensPerSecond: this.#getTokensPerSecond(),
 		};
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1563,7 +1563,10 @@ export class StatusLineComponent implements Component {
 			premiumRequests: 0,
 			cost: 0,
 		};
-		const sessionCost = this.#getDirectSessionCost(aggregateUsageStats.cost);
+		const sessionCost =
+			this.#collabStatus?.role === "guest"
+				? aggregateUsageStats.cost
+				: this.#getDirectSessionCost(aggregateUsageStats.cost);
 		const providedSubagentCost = this.#subagentCostProvider?.(this.#focusedAgentId) ?? 0;
 		const subagentCost = Number.isFinite(providedSubagentCost) ? Math.max(0, providedSubagentCost) : 0;
 		const usageStats = {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -432,7 +432,7 @@ const tokenRateSegment: StatusLineSegment = {
 const costSegment: StatusLineSegment = {
 	id: "cost",
 	render(ctx) {
-		const { cost, premiumRequests, subagentCost = 0 } = ctx.usageStats;
+		const { cost, premiumRequests, subagentCost } = ctx.usageStats;
 		const advisorCost = ctx.session.getAdvisorCost?.() ?? 0;
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -432,13 +432,13 @@ const tokenRateSegment: StatusLineSegment = {
 const costSegment: StatusLineSegment = {
 	id: "cost",
 	render(ctx) {
-		const { cost, premiumRequests } = ctx.usageStats;
+		const { cost, premiumRequests, subagentCost = 0 } = ctx.usageStats;
 		const advisorCost = ctx.session.getAdvisorCost?.() ?? 0;
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? ctx.session.modelRegistry.isUsingOAuth(state.model) : false;
 
-		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
+		if (!cost && !subagentCost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
 			return { content: "", visible: false };
 		}
 
@@ -446,6 +446,7 @@ const costSegment: StatusLineSegment = {
 		if (cost) billingParts.push(`$${cost.toFixed(2)}`);
 		if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
 		if (usingSubscription) billingParts.push("(sub)");
+		if (subagentCost) billingParts.push(`${billingParts.length ? "+ " : ""}$${subagentCost.toFixed(2)} (subagents)`);
 		if (advisorCost) billingParts.push(`${billingParts.length ? "+ " : ""}$${advisorCost.toFixed(2)} (adv)`);
 
 		return { content: theme.fg("statusLineCost", billingParts.join(" ")), visible: true };

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -90,6 +90,7 @@ export interface SegmentContext {
 		orchestrationCacheRead: number;
 		premiumRequests: number;
 		cost: number;
+		subagentCost?: number;
 		tokensPerSecond: number | null;
 	};
 	/** Context usage percent, or null when unknown (e.g. right after compaction). */

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -90,7 +90,7 @@ export interface SegmentContext {
 		orchestrationCacheRead: number;
 		premiumRequests: number;
 		cost: number;
-		subagentCost?: number;
+		subagentCost: number;
 		tokensPerSecond: number | null;
 	};
 	/** Context usage percent, or null when unknown (e.g. right after compaction). */

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -151,6 +151,7 @@ import {
 	type VibeParentSession,
 	VibeSessionRegistry,
 } from "../vibe/runtime";
+import { aggregateSubagentCost } from "./components/agent-hub-projection";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import { ChatBlock, type ChatBlockHost } from "./components/chat-block";
@@ -891,6 +892,20 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#focusController = new SessionFocusController(this);
 		this.#inputController = new InputController(this);
 		this.#observerRegistry = new SessionObserverRegistry();
+		this.statusLine.setSubagentCostProvider(focusedAgentId => {
+			const registry = getRunningSubagentBadgeRegistry(this.collabGuest);
+			const ownerSessionFile = focusedAgentId
+				? (registry.get(focusedAgentId)?.sessionFile ?? undefined)
+				: this.sessionManager.getSessionFile();
+			const observedById = new Map<string, ObservableSession>();
+			for (const observed of this.#observerRegistry.getSessions()) observedById.set(observed.id, observed);
+			return aggregateSubagentCost({
+				ownerId: focusedAgentId ?? MAIN_AGENT_ID,
+				ownerSessionFile,
+				rows: registry.list(),
+				observedById,
+			});
+		});
 	}
 
 	#handleMcpConnectionStatusEvent(event: McpConnectionStatusEvent): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -893,19 +893,16 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#inputController = new InputController(this);
 		this.#observerRegistry = new SessionObserverRegistry();
 		this.statusLine.setSubagentCostProvider(focusedAgentId => {
+			if (this.collabGuest) return 0;
 			const registry = getRunningSubagentBadgeRegistry(this.collabGuest);
-			const isCollabGuest = this.collabGuest !== undefined;
-			const ownerSessionFile = isCollabGuest
-				? undefined
-				: focusedAgentId
-					? (registry.get(focusedAgentId)?.sessionFile ?? undefined)
-					: this.sessionManager.getSessionFile();
+			const ownerSessionFile = focusedAgentId
+				? (registry.get(focusedAgentId)?.sessionFile ?? undefined)
+				: this.sessionManager.getSessionFile();
 			const observedById = new Map<string, ObservableSession>();
 			for (const observed of this.#observerRegistry.getSessions()) observedById.set(observed.id, observed);
 			return aggregateSubagentCost({
 				ownerId: focusedAgentId ?? MAIN_AGENT_ID,
 				ownerSessionFile,
-				allowUnscoped: isCollabGuest,
 				rows: registry.list(),
 				observedById,
 			});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -894,14 +894,18 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#observerRegistry = new SessionObserverRegistry();
 		this.statusLine.setSubagentCostProvider(focusedAgentId => {
 			const registry = getRunningSubagentBadgeRegistry(this.collabGuest);
-			const ownerSessionFile = focusedAgentId
-				? (registry.get(focusedAgentId)?.sessionFile ?? undefined)
-				: this.sessionManager.getSessionFile();
+			const isCollabGuest = this.collabGuest !== undefined;
+			const ownerSessionFile = isCollabGuest
+				? undefined
+				: focusedAgentId
+					? (registry.get(focusedAgentId)?.sessionFile ?? undefined)
+					: this.sessionManager.getSessionFile();
 			const observedById = new Map<string, ObservableSession>();
 			for (const observed of this.#observerRegistry.getSessions()) observedById.set(observed.id, observed);
 			return aggregateSubagentCost({
 				ownerId: focusedAgentId ?? MAIN_AGENT_ID,
 				ownerSessionFile,
+				allowUnscoped: isCollabGuest,
 				rows: registry.list(),
 				observedById,
 			});

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -204,6 +204,8 @@ class SessionEntryIndex {
 	#labels = new Map<string, string>();
 	#leaf: string | null = null;
 	#usage = emptyUsageStatistics();
+	#directCost = 0;
+	#hasAssistantUsage = false;
 
 	clear(): void {
 		this.#entriesById.clear();
@@ -211,6 +213,8 @@ class SessionEntryIndex {
 		this.#labels.clear();
 		this.#leaf = null;
 		this.#usage = emptyUsageStatistics();
+		this.#directCost = 0;
+		this.#hasAssistantUsage = false;
 	}
 
 	rebuild(entries: readonly SessionEntry[]): void {
@@ -232,6 +236,11 @@ class SessionEntryIndex {
 		}
 
 		addUsage(this.#usage, entryUsage(entry));
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			this.#hasAssistantUsage = true;
+			const cost = entry.message.usage.cost.total;
+			if (Number.isFinite(cost)) this.#directCost += cost;
+		}
 	}
 
 	has(id: string): boolean {
@@ -276,6 +285,10 @@ class SessionEntryIndex {
 
 	usageSnapshot(): UsageStatistics {
 		return { ...this.#usage };
+	}
+
+	directUsageCost(): number | undefined {
+		return this.#hasAssistantUsage ? this.#directCost : undefined;
 	}
 
 	pathTo(id: string | null | undefined = this.#leaf): SessionEntry[] {
@@ -1855,16 +1868,9 @@ export class SessionManager {
 	getUsageStatistics(): UsageStatistics {
 		return this.#index.usageSnapshot();
 	}
+
 	getDirectUsageCost(): number | undefined {
-		let total = 0;
-		let hasAssistantUsage = false;
-		for (const entry of this.#entries) {
-			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
-			hasAssistantUsage = true;
-			const cost = entry.message.usage.cost.total;
-			if (Number.isFinite(cost)) total += cost;
-		}
-		return hasAssistantUsage ? total : undefined;
+		return this.#index.directUsageCost();
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -343,6 +343,7 @@ export type ReadonlySessionManager = Pick<
 	| "getBranch"
 	| "getHeader"
 	| "getEntries"
+	| "getDirectUsageCost"
 	| "getTree"
 	| "getUsageStatistics"
 	| "putBlob"
@@ -1853,6 +1854,17 @@ export class SessionManager {
 
 	getUsageStatistics(): UsageStatistics {
 		return this.#index.usageSnapshot();
+	}
+	getDirectUsageCost(): number | undefined {
+		let total = 0;
+		let hasAssistantUsage = false;
+		for (const entry of this.#entries) {
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			hasAssistantUsage = true;
+			const cost = entry.message.usage.cost.total;
+			if (Number.isFinite(cost)) total += cost;
+		}
+		return hasAssistantUsage ? total : undefined;
 	}
 
 	/**

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1757,7 +1757,7 @@ describe("ACP agent", () => {
 		expect(names).not.toContain("loop");
 		expect(names).not.toContain("login");
 		expect(names).not.toContain("new");
-		expect(names).not.toContain("handoff");
+		expect(names).toContain("handoff");
 		expect(names).not.toContain("fork");
 		expect(names).not.toContain("btw");
 		expect(names).not.toContain("drop");

--- a/packages/coding-agent/test/collab/guest-subagent-badge.test.ts
+++ b/packages/coding-agent/test/collab/guest-subagent-badge.test.ts
@@ -8,10 +8,12 @@ import {
 	formatCollabLink,
 } from "@oh-my-pi/pi-coding-agent/collab/protocol";
 import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import { aggregateSubagentCost } from "@oh-my-pi/pi-coding-agent/modes/components/agent-hub-projection";
 import {
 	countRunningSubagentBadgeAgents,
 	getRunningSubagentBadgeRegistry,
 } from "@oh-my-pi/pi-coding-agent/modes/running-subagent-badge";
+import type { ObservableSession } from "@oh-my-pi/pi-coding-agent/modes/session-observer-registry";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
@@ -150,6 +152,32 @@ describe("collab guest running-subagents badge", () => {
 			expect(ctx.collabGuest).toBe(guest);
 			expect(counts).toEqual([0, 1]);
 			expect(ctx.statusLine.subagentCount).toBe(1);
+			const guestRegistry = getRunningSubagentBadgeRegistry(guest);
+			const mirrored = guestRegistry.get("remote-one");
+			if (!mirrored) throw new Error("Expected mirrored remote-one agent");
+			expect(mirrored.session).toBeNull();
+			expect(mirrored.sessionFile).toBeNull();
+			const observedById = new Map<string, ObservableSession>([
+				[
+					"remote-one",
+					{
+						id: "remote-one",
+						kind: "subagent",
+						label: "Remote 1",
+						status: "completed",
+						lastUpdate: 0,
+						progress: { cost: 0.6 } as never,
+					},
+				],
+			]);
+			expect(
+				aggregateSubagentCost({
+					ownerId: "Main",
+					ownerSessionFile: "/sessions/host.jsonl",
+					rows: guestRegistry.list(),
+					observedById,
+				}),
+			).toBe(0);
 
 			nextWelcomeAgents = makeAgents(["remote-one", "remote-two"]);
 			const secondSnapshot = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -9,9 +9,10 @@ function makeSessionWithLastMessage(
 	prewalkArmed: boolean = false,
 	{
 		cost = 0,
+		directCost,
 		advisorCost = 0,
 		usingSubscription = false,
-	}: { cost?: number; advisorCost?: number; usingSubscription?: boolean } = {},
+	}: { cost?: number; directCost?: number; advisorCost?: number; usingSubscription?: boolean } = {},
 ) {
 	return {
 		messages: lastMessage ? [lastMessage] : [],
@@ -40,6 +41,7 @@ function makeSessionWithLastMessage(
 				tokensPerSecond: null,
 			}),
 			getSessionName: () => "test-session",
+			getDirectUsageCost: () => directCost,
 		},
 		getPrewalkState: () => (prewalkArmed ? { target: { id: "cheap-model", provider: "openai" } } : undefined),
 		getAsyncJobSnapshot: () => undefined,
@@ -104,6 +106,28 @@ describe("StatusLineComponent", () => {
 
 		const stripped = statusLine.getTopBorder(120).content.replace(/\x1b\[[0-9;]*m/g, "");
 		expect(stripped).toContain("$2.67 (sub) + $0.41 (adv)");
+	});
+	it("renders descendant subagent cost separately from direct session cost", () => {
+		const statusLine = new StatusLineComponent(
+			makeSessionWithLastMessage(null, false, {
+				cost: 2.67,
+				directCost: 2.67,
+				advisorCost: 0.41,
+			}) as unknown as AgentSession,
+		);
+		statusLine.setSubagentCostProvider(() => 1.23);
+
+		const stripped = statusLine.getTopBorder(200).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(stripped).toContain("$2.67 + $1.23 (subagents) + $0.41 (adv)");
+	});
+	it("uses durable direct cost instead of aggregate task-inclusive cost", () => {
+		const statusLine = new StatusLineComponent(
+			makeSessionWithLastMessage(null, false, { cost: 5, directCost: 2 }) as unknown as AgentSession,
+		);
+
+		const stripped = statusLine.getTopBorder(120).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(stripped).toContain("$2.00");
+		expect(stripped).not.toContain("$5.00");
 	});
 
 	it("omits advisor cost when the advisor has never been active", () => {

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -134,10 +134,13 @@ describe("StatusLineComponent", () => {
 			makeSessionWithLastMessage(null, false, { cost: 5, directCost: 2 }) as unknown as AgentSession,
 		);
 		statusLine.setCollabStatus({ role: "guest", participantCount: 1 });
+		statusLine.setSubagentCostProvider(() => 3);
 
 		const stripped = statusLine.getTopBorder(200).content.replace(/\x1b\[[0-9;]*m/g, "");
 		expect(stripped).toContain("$5.00");
 		expect(stripped).not.toContain("$2.00");
+		expect(stripped).not.toContain("$3.00");
+		expect(stripped).not.toContain("(subagents)");
 	});
 
 	it("omits advisor cost when the advisor has never been active", () => {

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -129,6 +129,16 @@ describe("StatusLineComponent", () => {
 		expect(stripped).toContain("$2.00");
 		expect(stripped).not.toContain("$5.00");
 	});
+	it("preserves the task-inclusive aggregate for collab guests", () => {
+		const statusLine = new StatusLineComponent(
+			makeSessionWithLastMessage(null, false, { cost: 5, directCost: 2 }) as unknown as AgentSession,
+		);
+		statusLine.setCollabStatus({ role: "guest", participantCount: 1 });
+
+		const stripped = statusLine.getTopBorder(200).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(stripped).toContain("$5.00");
+		expect(stripped).not.toContain("$2.00");
+	});
 
 	it("omits advisor cost when the advisor has never been active", () => {
 		const statusLine = new StatusLineComponent(

--- a/packages/coding-agent/test/session-manager/usage-statistics.test.ts
+++ b/packages/coding-agent/test/session-manager/usage-statistics.test.ts
@@ -49,6 +49,49 @@ describe("SessionManager usage statistics", () => {
 		expect(usage.output).toBe(8);
 		expect(usage.premiumRequests).toBe(3);
 	});
+	it("separates direct assistant cost from embedded task cost", () => {
+		const session = SessionManager.inMemory();
+
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "hi" }],
+			api: "openai-completions",
+			provider: "openai",
+			model: "gpt-5",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 2.5, output: 0, cacheRead: 0, cacheWrite: 0, total: 2.5 },
+			},
+			stopReason: "stop",
+			timestamp: 2,
+		});
+		session.appendMessage({
+			role: "toolResult",
+			toolCallId: "task_1",
+			toolName: "task",
+			content: [{ type: "text", text: "task output" }],
+			details: {
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 1.25, output: 0, cacheRead: 0, cacheWrite: 0, total: 1.25 },
+				},
+			},
+			isError: false,
+			timestamp: 3,
+		});
+
+		expect(session.getUsageStatistics().cost).toBeCloseTo(3.75, 8);
+		expect(session.getDirectUsageCost()).toBeCloseTo(2.5, 8);
+	});
 
 	it("keeps orchestration usage out of ordinary input while preserving total tokens", () => {
 		const session = SessionManager.inMemory();

--- a/packages/coding-agent/test/session-manager/usage-statistics.test.ts
+++ b/packages/coding-agent/test/session-manager/usage-statistics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("SessionManager usage statistics", () => {
 	it("accumulates premium requests from assistant messages and task tool results", () => {
@@ -91,6 +92,61 @@ describe("SessionManager usage statistics", () => {
 
 		expect(session.getUsageStatistics().cost).toBeCloseTo(3.75, 8);
 		expect(session.getDirectUsageCost()).toBeCloseTo(2.5, 8);
+	});
+
+	it("rebuilds direct assistant cost on reopen and clears it for a new session", async () => {
+		using tempDir = TempDir.createSync("@pi-usage-direct-cost-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "hi" }],
+			api: "openai-completions",
+			provider: "openai",
+			model: "gpt-5",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 2.5, output: 0, cacheRead: 0, cacheWrite: 0, total: 2.5 },
+			},
+			stopReason: "stop",
+			timestamp: 2,
+		});
+		session.appendMessage({
+			role: "toolResult",
+			toolCallId: "task_1",
+			toolName: "task",
+			content: [{ type: "text", text: "task output" }],
+			details: {
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 1.25, output: 0, cacheRead: 0, cacheWrite: 0, total: 1.25 },
+				},
+			},
+			isError: false,
+			timestamp: 3,
+		});
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		await session.close();
+
+		const reopened = await SessionManager.open(sessionFile, tempDir.path());
+		try {
+			expect(reopened.getUsageStatistics().cost).toBeCloseTo(3.75, 8);
+			expect(reopened.getDirectUsageCost()).toBeCloseTo(2.5, 8);
+			await reopened.newSession();
+			expect(reopened.getDirectUsageCost()).toBeUndefined();
+		} finally {
+			await reopened.close();
+		}
 	});
 
 	it("keeps orchestration usage out of ordinary input while preserving total tokens", () => {

--- a/packages/coding-agent/test/status-line-cache-hit.test.ts
+++ b/packages/coding-agent/test/status-line-cache-hit.test.ts
@@ -21,6 +21,7 @@ function ctxWith(usage: Partial<SegmentContext["usageStats"]>): SegmentContext {
 			orchestrationCacheRead: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond: null,
 			...usage,
 		},

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -34,6 +34,7 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 			orchestrationCacheRead: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond: null,
 		},
 		contextPercent: 0,

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -41,6 +41,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 			orchestrationCacheRead: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond: null,
 		},
 		contextPercent: 0,

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -67,6 +67,7 @@ function createCtx(overrides?: {
 			orchestrationCacheRead: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond: null,
 		},
 		contextPercent: 0,

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -46,6 +46,7 @@ function createPathContext(): SegmentContext {
 			orchestrationCacheRead: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond: null,
 		},
 		contextPercent: 0,

--- a/packages/coding-agent/test/status-line-subagent-cost.test.ts
+++ b/packages/coding-agent/test/status-line-subagent-cost.test.ts
@@ -102,29 +102,4 @@ describe("aggregateSubagentCost", () => {
 			}),
 		).toBeCloseTo(0.5, 8);
 	});
-	it("includes mirrored descendants without host session paths", () => {
-		const rows = [makeRef("Remote", "Main", { sessionFile: null })];
-		const observedById = new Map<string, ObservableSession>([
-			[
-				"Remote",
-				{
-					id: "Remote",
-					kind: "subagent",
-					label: "Remote",
-					status: "active",
-					lastUpdate: 0,
-					progress: { cost: 0.6 } as never,
-				},
-			],
-		]);
-
-		expect(
-			aggregateSubagentCost({
-				ownerId: "Main",
-				allowUnscoped: true,
-				rows,
-				observedById,
-			}),
-		).toBeCloseTo(0.6, 8);
-	});
 });

--- a/packages/coding-agent/test/status-line-subagent-cost.test.ts
+++ b/packages/coding-agent/test/status-line-subagent-cost.test.ts
@@ -6,7 +6,7 @@ import type { AgentRef } from "../src/registry/agent-registry";
 function makeRef(
 	id: string,
 	parentId: string | undefined,
-	options: { sessionFile: string; historyCost?: number; session?: unknown },
+	options: { sessionFile: string | null; historyCost?: number; session?: unknown },
 ): AgentRef {
 	return {
 		id,
@@ -101,5 +101,30 @@ describe("aggregateSubagentCost", () => {
 				observedById,
 			}),
 		).toBeCloseTo(0.5, 8);
+	});
+	it("includes mirrored descendants without host session paths", () => {
+		const rows = [makeRef("Remote", "Main", { sessionFile: null })];
+		const observedById = new Map<string, ObservableSession>([
+			[
+				"Remote",
+				{
+					id: "Remote",
+					kind: "subagent",
+					label: "Remote",
+					status: "active",
+					lastUpdate: 0,
+					progress: { cost: 0.6 } as never,
+				},
+			],
+		]);
+
+		expect(
+			aggregateSubagentCost({
+				ownerId: "Main",
+				allowUnscoped: true,
+				rows,
+				observedById,
+			}),
+		).toBeCloseTo(0.6, 8);
 	});
 });

--- a/packages/coding-agent/test/status-line-subagent-cost.test.ts
+++ b/packages/coding-agent/test/status-line-subagent-cost.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { aggregateSubagentCost } from "../src/modes/components/agent-hub-projection";
+import type { ObservableSession } from "../src/modes/session-observer-registry";
+import type { AgentRef } from "../src/registry/agent-registry";
+
+function makeRef(
+	id: string,
+	parentId: string | undefined,
+	options: { sessionFile: string; historyCost?: number; session?: unknown },
+): AgentRef {
+	return {
+		id,
+		displayName: id,
+		kind: "sub",
+		parentId,
+		status: "idle",
+		session: (options.session as AgentRef["session"]) ?? null,
+		sessionFile: options.sessionFile,
+		createdAt: 0,
+		lastActivity: 0,
+		history:
+			options.historyCost === undefined
+				? undefined
+				: {
+						metrics: {
+							tokens: 0,
+							requests: 0,
+							tools: 0,
+							cost: options.historyCost,
+							durationMs: 0,
+						},
+					},
+	};
+}
+
+describe("aggregateSubagentCost", () => {
+	it("sums current-session descendants and ignores retained refs from other generations", () => {
+		const rows = [
+			makeRef("Child", "Main", { sessionFile: "/sessions/main/Child.jsonl" }),
+			makeRef("Nested", "Child", { sessionFile: "/sessions/main/Child/Nested.jsonl", historyCost: 0.75 }),
+			makeRef("Old", "Main", { sessionFile: "/sessions/old/Old.jsonl", historyCost: 8 }),
+			makeRef("OtherRoot", undefined, { sessionFile: "/sessions/main/OtherRoot.jsonl" }),
+			makeRef("Other", "OtherRoot", { sessionFile: "/sessions/main/Other.jsonl", historyCost: 9 }),
+		];
+		const observedById = new Map<string, ObservableSession>([
+			[
+				"Child",
+				{
+					id: "Child",
+					kind: "subagent",
+					label: "Child",
+					status: "completed",
+					lastUpdate: 0,
+					progress: { cost: 1.25 } as never,
+				},
+			],
+		]);
+
+		expect(
+			aggregateSubagentCost({
+				ownerId: "Main",
+				ownerSessionFile: "/sessions/main.jsonl",
+				rows,
+				observedById,
+			}),
+		).toBeCloseTo(2, 8);
+	});
+
+	it("uses the durable child ledger before a fresh observer snapshot", () => {
+		const session = {
+			sessionManager: { getDirectUsageCost: () => 0.5 },
+			agent: {
+				state: {
+					messages: [
+						{ role: "assistant", usage: { cost: { total: 0.5 } } },
+						{ role: "toolResult", toolName: "task", details: { usage: { cost: { total: 4 } } } },
+					],
+				},
+			},
+		};
+		const rows = [makeRef("Live", "Main", { sessionFile: "/sessions/main/Live.jsonl", session })];
+		const observedById = new Map<string, ObservableSession>([
+			[
+				"Live",
+				{
+					id: "Live",
+					kind: "subagent",
+					label: "Live",
+					status: "active",
+					lastUpdate: 0,
+					progress: { cost: 0.1 } as never,
+				},
+			],
+		]);
+
+		expect(
+			aggregateSubagentCost({
+				ownerId: "Main",
+				ownerSessionFile: "/sessions/main.jsonl",
+				rows,
+				observedById,
+			}),
+		).toBeCloseTo(0.5, 8);
+	});
+});

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -56,6 +56,7 @@ function createCtx(activeMs: number): SegmentContext {
 			orchestrationCacheRead: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond: null,
 		},
 		contextPercent: 0,

--- a/packages/coding-agent/test/status-line-token-rate.test.ts
+++ b/packages/coding-agent/test/status-line-token-rate.test.ts
@@ -40,6 +40,7 @@ function ctxWithTokenRate(tokensPerSecond: number | null): SegmentContext {
 			cacheWrite: 0,
 			premiumRequests: 0,
 			cost: 0,
+			subagentCost: 0,
 			tokensPerSecond,
 		},
 	} as unknown as SegmentContext;


### PR DESCRIPTION
## Summary

- Separate direct session cost from task-result usage in the status line.
- Show descendant subagent spend as `(subagents)` beside advisor spend.
- Prefer each child session’s durable ledger, then persisted history, then live progress.
- Scope aggregation to the current session-file generation.
- Align the ACP handoff assertion with the existing advertised builtin.

## Verification

- `bun --cwd=packages/coding-agent run check`
- Focused status-line, session-usage, aggregation, and ACP tests

The full suite was also exercised from `/tmp`; two existing `status-line-path` cases depend on a checkout outside `/tmp` because `/tmp` is treated as a scratch root by the path display contract.