### PR TITLE
fix(launch): prune dead daemon runtime dirs on broker startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reclaimed abandoned daemon runtime directories under `~/.omp/run/daemons/`: each broker now prunes sibling scopes with a dead/absent `broker.pid`, no live client presence, and past a short stale grace on startup, removing the leftover Chromium profiles and broker state that grew unbounded from short-lived project directories ([#8674](https://github.com/can1357/oh-my-pi/issues/8674)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Changed

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -8,7 +8,7 @@ import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
 import { workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint } from "./paths";
-import { hasLiveDaemonProjectPresence } from "./presence";
+import { hasLiveDaemonProjectPresence, pruneDeadDaemonRuntimeDirs } from "./presence";
 import {
 	DAEMON_IDLE_GRACE_ENV,
 	DAEMON_PROJECT_DIR_ENV,
@@ -1384,6 +1384,13 @@ export async function startDaemonBrokerFromEnvironment(options: DaemonBrokerStar
 	const lease = await acquireBrokerLease(runtimeDir);
 	if (!lease) return;
 	setProcessName("omp daemon broker");
+	// Reclaim sibling daemon scopes left behind by dead brokers (issue #8674).
+	// Detached and non-throwing so it never delays clients connecting to us.
+	void pruneDeadDaemonRuntimeDirs(runtimeDir).catch(error => {
+		logger.warn("Daemon runtime prune failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	});
 	const token = (await Bun.file(path.join(runtimeDir, TOKEN_FILE)).text()).trim();
 	if (!token) throw new Error("Daemon broker token is empty");
 	const broker = new DaemonBroker(projectDir, runtimeDir, token, idleGraceMs, restartBackoffBaseMs);

--- a/packages/coding-agent/src/launch/presence.ts
+++ b/packages/coding-agent/src/launch/presence.ts
@@ -1,9 +1,19 @@
+import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { isEisdir, isEnoent, logger, postmortem } from "@oh-my-pi/pi-utils";
 import { daemonRuntimeDir } from "./paths";
 
 const CLIENTS_DIR = "clients";
+const BROKER_PID_FILE = "broker.pid";
+const GLOBAL_DAEMON_DIR = "global";
+/**
+ * Grace before a dead daemon runtime dir becomes prune-eligible. Guards against
+ * deleting a scope whose owning omp process is mid-startup (token written, broker
+ * not yet spawned, presence not yet registered). The leak this reclaims is a
+ * weeks-scale accumulation, so a few minutes of slack costs nothing.
+ */
+const DAEMON_RUNTIME_STALE_GRACE_MS = 5 * 60_000;
 
 /** Handle keeping one omp process registered in a project daemon scope. */
 export interface DaemonProjectPresence {
@@ -79,4 +89,69 @@ export async function hasLiveDaemonProjectPresence(runtimeDir: string): Promise<
 		}
 	}
 	return live;
+}
+
+/** Whether a runtime dir's recorded broker PID is still alive. */
+async function hasLiveDaemonBroker(runtimeDir: string): Promise<boolean> {
+	let raw: unknown;
+	try {
+		raw = await Bun.file(path.join(runtimeDir, BROKER_PID_FILE)).json();
+	} catch {
+		return false; // Missing or malformed broker.pid => no owning broker.
+	}
+	if (typeof raw !== "object" || raw === null || !("pid" in raw) || typeof raw.pid !== "number") {
+		return false;
+	}
+	try {
+		process.kill(raw.pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Remove sibling project daemon runtime directories whose broker is dead and
+ * whose client-presence set is empty, reclaiming the disk that short-lived
+ * project directories leave behind (issue #8674).
+ *
+ * Best-effort and non-throwing: a scope is deleted only when its `broker.pid`
+ * is absent/dead, no live client presence remains, and it has been untouched
+ * for {@link DAEMON_RUNTIME_STALE_GRACE_MS}. The caller's own `currentRuntimeDir`
+ * and the machine-global daemon container are always skipped.
+ */
+export async function pruneDeadDaemonRuntimeDirs(currentRuntimeDir: string): Promise<void> {
+	const root = path.dirname(currentRuntimeDir);
+	const current = path.resolve(currentRuntimeDir);
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(root, { withFileTypes: true });
+	} catch (error) {
+		if (!isEnoent(error)) {
+			logger.warn("Failed to scan daemon runtime root for pruning", {
+				root,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+		return;
+	}
+	const now = Date.now();
+	for (const entry of entries) {
+		if (!entry.isDirectory() || entry.name === GLOBAL_DAEMON_DIR) continue;
+		const dir = path.join(root, entry.name);
+		if (path.resolve(dir) === current) continue;
+		try {
+			const stat = await fs.stat(dir);
+			if (now - stat.mtimeMs < DAEMON_RUNTIME_STALE_GRACE_MS) continue;
+			if (await hasLiveDaemonBroker(dir)) continue;
+			if (await hasLiveDaemonProjectPresence(dir)) continue;
+			await fs.rm(dir, { recursive: true, force: true });
+		} catch (error) {
+			if (isEnoent(error)) continue;
+			logger.warn("Failed to prune dead daemon runtime dir", {
+				dir,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
 }

--- a/packages/coding-agent/test/launch/daemon-prune.test.ts
+++ b/packages/coding-agent/test/launch/daemon-prune.test.ts
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { pruneDeadDaemonRuntimeDirs } from "../../src/launch/presence";
+
+const STALE = new Date(Date.now() - 30 * 60_000);
+let deadPid = 0;
+
+async function scope(
+	root: string,
+	name: string,
+	init: { pid?: number | "dead"; clients?: number[]; stale?: boolean },
+): Promise<string> {
+	const dir = path.join(root, name);
+	await fs.mkdir(path.join(dir, "clients"), { recursive: true });
+	if (init.pid !== undefined) {
+		const pid = init.pid === "dead" ? deadPid : init.pid;
+		await Bun.write(path.join(dir, "broker.pid"), JSON.stringify({ pid, instanceId: name }));
+	}
+	for (const clientPid of init.clients ?? []) {
+		await Bun.write(
+			path.join(dir, "clients", `${clientPid}-x.json`),
+			JSON.stringify({ pid: clientPid, id: `${clientPid}-x`, projectDir: dir }),
+		);
+	}
+	if (init.stale) await fs.utimes(dir, STALE, STALE);
+	return dir;
+}
+
+describe("pruneDeadDaemonRuntimeDirs", () => {
+	beforeAll(async () => {
+		// A definitely-dead PID: spawn a process and reap it.
+		const proc = Bun.spawn(["true"]);
+		await proc.exited;
+		deadPid = proc.pid;
+	});
+
+	it("removes only scopes with a dead broker, no live clients, and past the stale grace", async () => {
+		using tempDir = TempDir.createSync("@omp-daemon-prune-");
+		const daemons = path.join(tempDir.path(), "run", "daemons");
+		await fs.mkdir(daemons, { recursive: true });
+
+		const current = await scope(daemons, "current000000000", { pid: "dead", stale: true });
+		await scope(daemons, "deadstale0000000", { pid: "dead", stale: true });
+		await scope(daemons, "livebroker000000", { pid: process.pid, stale: true });
+		await scope(daemons, "liveclient000000", { clients: [process.pid], stale: true });
+		await scope(daemons, "deadfresh0000000", { pid: "dead" });
+		// Machine-global daemon container must never be swept as a project scope.
+		await fs.mkdir(path.join(daemons, "global", "some-service"), { recursive: true });
+		await fs.utimes(path.join(daemons, "global"), STALE, STALE);
+
+		await pruneDeadDaemonRuntimeDirs(current);
+
+		const remaining = new Set(await fs.readdir(daemons));
+		expect(remaining.has("deadstale0000000")).toBe(false); // pruned
+		expect(remaining.has("current000000000")).toBe(true); // never prunes itself
+		expect(remaining.has("livebroker000000")).toBe(true); // live broker
+		expect(remaining.has("liveclient000000")).toBe(true); // live client presence
+		expect(remaining.has("deadfresh0000000")).toBe(true); // within stale grace
+		expect(remaining.has("global")).toBe(true); // global container skipped
+	});
+
+	it("does nothing when the runtime root does not exist", async () => {
+		using tempDir = TempDir.createSync("@omp-daemon-prune-missing-");
+		const current = path.join(tempDir.path(), "run", "daemons", "hash0000000000000");
+		await expect(pruneDeadDaemonRuntimeDirs(current)).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
After weeks of use, `~/.omp/run/daemons/` accumulates one `<hash>` directory per project directory and never reclaims any of them — the reporter measured 198 dirs / 1.3GB, dominated by abandoned `omp.browser.headless.profile` Chromium profiles owned by long-dead brokers. Reproduced by building a `run/daemons` tree with a dead-broker scope (`broker.pid` naming a reaped PID, empty `clients/`, a profile dir) alongside a live scope and observing that no code path removes the dead scope: `before: [ 'deadhash0000dead0', 'livehash0000live0' ]` / `dead dir still present (LEAK): true`.

## Cause
`DaemonBroker.shutdown()` in `packages/coding-agent/src/launch/broker.ts` removes only the socket endpoint, and `releaseBrokerLease` removes only `broker.pid`; the `<hash>` directory, `daemons/` subtree, logs, `meta.json`, and the deliberately-persistent `omp.browser.headless.profile` are left on disk. Nothing anywhere sweeps sibling scopes — `cli/gc-cli.ts` handles sessions/blobs/WAL but has no awareness of `run/daemons`. So every short-lived project directory permanently leaks a scope.

## Fix
- Add `pruneDeadDaemonRuntimeDirs(currentRuntimeDir)` to `packages/coding-agent/src/launch/presence.ts`: scans `path.dirname(currentRuntimeDir)` and `fs.rm`s a sibling scope only when its `broker.pid` is absent/dead (`process.kill(pid, 0)`), `hasLiveDaemonProjectPresence` is false, and the dir has been untouched for at least a 5-minute stale grace. The caller's own runtime dir and the machine-global `global/` container are always skipped.
- Call it (detached, non-throwing) from `startDaemonBrokerFromEnvironment` in `broker.ts` right after the broker acquires its lease, so a fresh broker reclaims its dead siblings without delaying client connects.
- The stale grace closes the narrow startup race where a scope has a token but has not yet registered presence or spawned its broker.

## Verification
`bun test test/launch/` (34 pass) including the new `test/launch/daemon-prune.test.ts`, which asserts distinct branches: dead+stale scope pruned; live-broker, live-client, current, `global`, and within-grace scopes all preserved. `bun check` passes. Manually exercised `pruneDeadDaemonRuntimeDirs` against the repro tree: dead scope removed, live and fresh scopes preserved. Fixes #8674