### PR TITLE
daemon: presence records carry an optional session identity

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Daemon project presence records now carry the live session's id and name, and follow it across session transitions such as `/new` ([#8682](https://github.com/can1357/oh-my-pi/pull/8682) by [@jwaldrip](https://github.com/jwaldrip)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/launch/presence.ts
+++ b/packages/coding-agent/src/launch/presence.ts
@@ -2,6 +2,7 @@ import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent, logger, postmortem } from "@oh-my-pi/pi-utils";
+import { replaceFileAtomically } from "../utils/atomic-file";
 import { canonicalProjectDir, daemonRuntimeDir } from "./paths";
 
 const CLIENTS_DIR = "clients";
@@ -29,13 +30,20 @@ const DAEMON_RUNTIME_STALE_GRACE_MS = 5 * 60_000;
 
 /** Handle keeping one omp process registered in a project daemon scope. */
 export interface DaemonProjectPresence {
+	update(session: DaemonProjectPresenceSession | undefined): Promise<void>;
 	close(): Promise<void>;
 }
 
+/** Session identity this presence record may carry, if the caller has one open. */
+export interface DaemonProjectPresenceSession {
+	sessionId: string;
+	title?: string;
+}
 /** Register this omp process so project daemons survive while it remains alive. */
 export async function registerDaemonProjectPresence(
 	projectDir: string,
 	runtimeOverride?: string,
+	session?: DaemonProjectPresenceSession,
 ): Promise<DaemonProjectPresence> {
 	const canonical = await canonicalProjectDir(projectDir);
 	const runtimeDir = runtimeOverride ?? daemonRuntimeDir(canonical);
@@ -43,17 +51,59 @@ export async function registerDaemonProjectPresence(
 	await fs.mkdir(clientsDir, { recursive: true, mode: 0o700 });
 	const id = `${process.pid}-${crypto.randomUUID()}`;
 	const presencePath = path.join(clientsDir, `${id}.json`);
-	await Bun.write(presencePath, JSON.stringify({ pid: process.pid, id, projectDir: canonical }));
-	await fs.chmod(presencePath, 0o600);
 	let closed = false;
+	const writeRecord = async (currentSession?: DaemonProjectPresenceSession): Promise<void> => {
+		if (closed) return;
+		const tempPath = `${presencePath}.${crypto.randomUUID()}.tmp`;
+		try {
+			await Bun.write(
+				tempPath,
+				JSON.stringify({
+					pid: process.pid,
+					id,
+					projectDir: canonical,
+					// Optional: an older omp on this machine never writes these, and any
+					// reader must treat their absence as "alive, session unknown" rather
+					// than as a malformed record (see hasLiveDaemonProjectPresence below,
+					// which never inspects them).
+					...(currentSession?.sessionId ? { sessionId: currentSession.sessionId } : {}),
+					...(currentSession?.title ? { title: currentSession.title } : {}),
+				}),
+			);
+			await fs.chmod(tempPath, 0o600);
+			if (closed) {
+				await fs.rm(tempPath, { force: true });
+				return;
+			}
+			await replaceFileAtomically(tempPath, presencePath);
+		} catch (error) {
+			await fs.rm(tempPath, { force: true }).catch(() => {});
+			throw error;
+		}
+	};
+
+	let writeChain = Promise.resolve();
+	const update = async (nextSession?: DaemonProjectPresenceSession): Promise<void> => {
+		if (closed) return;
+		writeChain = writeChain.catch(() => {}).then(() => writeRecord(nextSession));
+		return writeChain;
+	};
+
+	await writeRecord(session);
+
 	const close = async (): Promise<void> => {
 		if (closed) return;
 		closed = true;
 		cancelCleanup();
+		try {
+			await writeChain;
+		} catch {
+			// ignore
+		}
 		await fs.rm(presencePath, { force: true });
 	};
 	const cancelCleanup = postmortem.register(`daemon-presence:${id}`, () => close());
-	return { close };
+	return { update, close };
 }
 
 /** Return whether a registered omp process in this runtime directory is still alive. */

--- a/packages/coding-agent/src/launch/presence.ts
+++ b/packages/coding-agent/src/launch/presence.ts
@@ -20,10 +20,17 @@ async function canonicalProjectDir(projectDir: string): Promise<string> {
 	}
 }
 
+/** Session identity this presence record may carry, if the caller has one open. */
+export interface DaemonProjectPresenceSession {
+	sessionId: string;
+	title?: string;
+}
+
 /** Register this omp process so project daemons survive while it remains alive. */
 export async function registerDaemonProjectPresence(
 	projectDir: string,
 	runtimeOverride?: string,
+	session?: DaemonProjectPresenceSession,
 ): Promise<DaemonProjectPresence> {
 	const canonical = await canonicalProjectDir(projectDir);
 	const runtimeDir = runtimeOverride ?? daemonRuntimeDir(canonical);
@@ -31,7 +38,20 @@ export async function registerDaemonProjectPresence(
 	await fs.mkdir(clientsDir, { recursive: true, mode: 0o700 });
 	const id = `${process.pid}-${crypto.randomUUID()}`;
 	const presencePath = path.join(clientsDir, `${id}.json`);
-	await Bun.write(presencePath, JSON.stringify({ pid: process.pid, id, projectDir: canonical }));
+	await Bun.write(
+		presencePath,
+		JSON.stringify({
+			pid: process.pid,
+			id,
+			projectDir: canonical,
+			// Optional: an older omp on this machine never writes these, and any
+			// reader must treat their absence as "alive, session unknown" rather
+			// than as a malformed record (see hasLiveDaemonProjectPresence below,
+			// which never inspects them).
+			...(session?.sessionId ? { sessionId: session.sessionId } : {}),
+			...(session?.title ? { title: session.title } : {}),
+		}),
+	);
 	await fs.chmod(presencePath, 0o600);
 	let closed = false;
 	const close = async (): Promise<void> => {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1547,7 +1547,17 @@ export async function runRootCommand(
 
 	await pluginPreloadPromise;
 	if (deps === DEFAULT_RUN_ROOT_DEPENDENCIES) {
-		await logger.time("registerDaemonProjectPresence", registerDaemonProjectPresence, cwd);
+		const presenceSessionId = sessionManager?.getSessionId();
+		const presenceSession = presenceSessionId
+			? { sessionId: presenceSessionId, title: sessionManager?.getSessionName() }
+			: undefined;
+		await logger.time(
+			"registerDaemonProjectPresence",
+			registerDaemonProjectPresence,
+			cwd,
+			undefined,
+			presenceSession,
+		);
 	}
 
 	scheduleMarketplaceAutoUpdate({

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -59,7 +59,11 @@ import { loadExtensions } from "./extensibility/extensions/loader";
 import { ExtensionRunner } from "./extensibility/extensions/runner";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import { scheduleMarketplaceAutoUpdate } from "./extensibility/plugins/marketplace-auto-update";
-import { registerDaemonProjectPresence } from "./launch/presence";
+import {
+	type DaemonProjectPresence,
+	type DaemonProjectPresenceSession,
+	registerDaemonProjectPresence,
+} from "./launch/presence";
 import { discoverStartupLspServers } from "./lsp/servers";
 import type { MCPManager } from "./mcp";
 import { InteractiveMode } from "./modes/interactive-mode";
@@ -1414,6 +1418,8 @@ interface RunRootCommandDependencies {
 	createForeignSessionStore?: (source: ForeignSessionSource) => ForeignSessionStore;
 	settings?: Settings;
 	forceSetupWizard?: boolean;
+	registerDaemonProjectPresence?: typeof registerDaemonProjectPresence;
+	runInteractiveMode?: typeof runInteractiveMode;
 }
 const DEFAULT_RUN_ROOT_DEPENDENCIES: RunRootCommandDependencies = {};
 
@@ -1829,8 +1835,22 @@ export async function runRootCommand(
 			}
 		}
 		await pluginPreloadPromise;
-		if (deps === DEFAULT_RUN_ROOT_DEPENDENCIES) {
-			await logger.time("registerDaemonProjectPresence", registerDaemonProjectPresence, cwd);
+		let daemonPresence: DaemonProjectPresence | undefined;
+		const registerPresence =
+			deps.registerDaemonProjectPresence ??
+			(deps === DEFAULT_RUN_ROOT_DEPENDENCIES ? registerDaemonProjectPresence : undefined);
+		if (registerPresence) {
+			const presenceSessionId = sessionManager?.getSessionId();
+			const initialSession: DaemonProjectPresenceSession | undefined = presenceSessionId
+				? { sessionId: presenceSessionId, title: sessionManager?.getSessionName() }
+				: undefined;
+			daemonPresence = await logger.time(
+				"registerDaemonProjectPresence",
+				registerPresence,
+				cwd,
+				undefined,
+				initialSession,
+			);
 		}
 
 		scheduleMarketplaceAutoUpdate({
@@ -1996,6 +2016,21 @@ export async function runRootCommand(
 				subagentEventBus,
 				preloadedExtensions: extensionsResult,
 			});
+			if (daemonPresence) {
+				const syncPresence = (): void => {
+					const sessionId = session.sessionManager.getSessionId();
+					const title = session.sessionManager.getSessionName();
+					void daemonPresence?.update({ sessionId, title }).catch(error => {
+						logger.warn("Failed to update daemon project presence", { error: String(error) });
+					});
+				};
+				await daemonPresence.update({
+					sessionId: session.sessionManager.getSessionId(),
+					title: session.sessionManager.getSessionName(),
+				});
+				session.registerSessionChangeCallback(syncPresence);
+				session.sessionManager.onSessionNameChanged(syncPresence);
+			}
 
 			try {
 				validateToolNames(initialArgs.tools, session.getAllToolNames());
@@ -2094,7 +2129,8 @@ export async function runRootCommand(
 				try {
 					stopStartupWatchdog();
 					logger.endTiming();
-					await runInteractiveMode(
+					const runInteractiveModeImpl = deps.runInteractiveMode ?? runInteractiveMode;
+					await runInteractiveModeImpl(
 						session,
 						VERSION,
 						startupChangelog,

--- a/packages/coding-agent/test/tools/presence-session-field.test.ts
+++ b/packages/coding-agent/test/tools/presence-session-field.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { hasLiveDaemonProjectPresence, registerDaemonProjectPresence } from "../../src/launch/presence";
+
+/**
+ * The `sessionId`/`title` fields added to the presence record must be purely
+ * additive: an older `omp` on the same machine never writes them, and a
+ * reader that only understands `{pid, id, projectDir}` (the pre-existing
+ * shape `hasLiveDaemonProjectPresence` itself parses) must keep working
+ * against both an old-format record and a new one that carries them.
+ */
+describe("daemon presence session identity field", () => {
+	const dirs: string[] = [];
+
+	afterEach(async () => {
+		while (dirs.length) {
+			await fs.rm(dirs.pop() ?? "", { recursive: true, force: true });
+		}
+	});
+
+	async function tmpProject(): Promise<{ projectDir: string; runtimeDir: string }> {
+		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-presence-session-"));
+		dirs.push(projectDir);
+		return { projectDir, runtimeDir: path.join(projectDir, "runtime") };
+	}
+
+	it("writes sessionId and title when a session is supplied", async () => {
+		const { projectDir, runtimeDir } = await tmpProject();
+		const presence = await registerDaemonProjectPresence(projectDir, runtimeDir, {
+			sessionId: "019fee60-2c7a-7000-9fd5-7439c7bf3dd2",
+			title: "Refactor the launcher",
+		});
+		try {
+			const clientsDir = path.join(runtimeDir, "clients");
+			const [entry] = await fs.readdir(clientsDir);
+			const record = (await Bun.file(path.join(clientsDir, entry!)).json()) as Record<string, unknown>;
+			expect(record.sessionId).toBe("019fee60-2c7a-7000-9fd5-7439c7bf3dd2");
+			expect(record.title).toBe("Refactor the launcher");
+			expect(record.pid).toBe(process.pid);
+		} finally {
+			await presence.close();
+		}
+	});
+
+	it("omits sessionId and title entirely when no session is supplied, matching the pre-field record shape", async () => {
+		const { projectDir, runtimeDir } = await tmpProject();
+		const presence = await registerDaemonProjectPresence(projectDir, runtimeDir);
+		try {
+			const clientsDir = path.join(runtimeDir, "clients");
+			const [entry] = await fs.readdir(clientsDir);
+			const record = (await Bun.file(path.join(clientsDir, entry!)).json()) as Record<string, unknown>;
+			expect("sessionId" in record).toBe(false);
+			expect("title" in record).toBe(false);
+			expect(Object.keys(record).sort()).toEqual(["id", "pid", "projectDir"]);
+		} finally {
+			await presence.close();
+		}
+	});
+
+	it("hasLiveDaemonProjectPresence reports liveness from a legacy record with no sessionId/title field at all", async () => {
+		const { runtimeDir } = await tmpProject();
+		const clientsDir = path.join(runtimeDir, "clients");
+		await fs.mkdir(clientsDir, { recursive: true });
+		// Simulated write from an omp build that predates this field: exactly the
+		// old three-key shape, nothing more.
+		await Bun.write(
+			path.join(clientsDir, `${process.pid}-legacy.json`),
+			JSON.stringify({ pid: process.pid, id: `${process.pid}-legacy`, projectDir: runtimeDir }),
+		);
+
+		// Degrades to "alive, session unknown": liveness still reads correctly
+		// from the pid alone, and no exception is thrown reading a record that
+		// lacks the newer fields.
+		await expect(hasLiveDaemonProjectPresence(runtimeDir)).resolves.toBe(true);
+	});
+});

--- a/packages/coding-agent/test/tools/presence-session-field.test.ts
+++ b/packages/coding-agent/test/tools/presence-session-field.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseArgs } from "../../src/cli/args";
+import { Settings } from "../../src/config/settings";
+import { hasLiveDaemonProjectPresence, registerDaemonProjectPresence } from "../../src/launch/presence";
+import { runRootCommand } from "../../src/main";
+import type { AgentSession } from "../../src/session/agent-session";
+import { AuthStorage } from "../../src/session/auth-storage";
+
+/**
+ * The `sessionId`/`title` fields added to the presence record must be purely
+ * additive: an older `omp` on the same machine never writes them, and a
+ * reader that only understands `{pid, id, projectDir}` (the pre-existing
+ * shape `hasLiveDaemonProjectPresence` itself parses) must keep working
+ * against both an old-format record and a new one that carries them.
+ */
+describe("daemon presence session identity field", () => {
+	const dirs: string[] = [];
+
+	afterEach(async () => {
+		while (dirs.length) {
+			await fs.rm(dirs.pop() ?? "", { recursive: true, force: true });
+		}
+	});
+
+	async function tmpProject(): Promise<{ projectDir: string; runtimeDir: string }> {
+		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-presence-session-"));
+		dirs.push(projectDir);
+		return { projectDir, runtimeDir: path.join(projectDir, "runtime") };
+	}
+
+	it("writes sessionId and title when a session is supplied", async () => {
+		const { projectDir, runtimeDir } = await tmpProject();
+		const presence = await registerDaemonProjectPresence(projectDir, runtimeDir, {
+			sessionId: "019fee60-2c7a-7000-9fd5-7439c7bf3dd2",
+			title: "Refactor the launcher",
+		});
+		try {
+			const clientsDir = path.join(runtimeDir, "clients");
+			const [entry] = await fs.readdir(clientsDir);
+			const record = await Bun.file(path.join(clientsDir, entry!)).json();
+			expect(record).toMatchObject({
+				sessionId: "019fee60-2c7a-7000-9fd5-7439c7bf3dd2",
+				title: "Refactor the launcher",
+				pid: process.pid,
+			});
+		} finally {
+			await presence.close();
+		}
+	});
+
+	it("omits sessionId and title entirely when no session is supplied, matching the pre-field record shape", async () => {
+		const { projectDir, runtimeDir } = await tmpProject();
+		const presence = await registerDaemonProjectPresence(projectDir, runtimeDir);
+		try {
+			const clientsDir = path.join(runtimeDir, "clients");
+			const [entry] = await fs.readdir(clientsDir);
+			const record = await Bun.file(path.join(clientsDir, entry!)).json();
+			expect(record).not.toHaveProperty("sessionId");
+			expect(record).not.toHaveProperty("title");
+			expect(record).toEqual({
+				id: expect.any(String),
+				pid: process.pid,
+				projectDir: expect.any(String),
+			});
+		} finally {
+			await presence.close();
+		}
+	});
+
+	it("hasLiveDaemonProjectPresence reports liveness from a legacy record with no sessionId/title field at all", async () => {
+		const { runtimeDir } = await tmpProject();
+		const clientsDir = path.join(runtimeDir, "clients");
+		await fs.mkdir(clientsDir, { recursive: true });
+		// Simulated write from an omp build that predates this field: exactly the
+		// old three-key shape, nothing more.
+		await Bun.write(
+			path.join(clientsDir, `${process.pid}-legacy.json`),
+			JSON.stringify({ pid: process.pid, id: `${process.pid}-legacy`, projectDir: runtimeDir }),
+		);
+
+		// Degrades to "alive, session unknown": liveness still reads correctly
+		// from the pid alone, and no exception is thrown reading a record that
+		// lacks the newer fields.
+		await expect(hasLiveDaemonProjectPresence(runtimeDir)).resolves.toBe(true);
+	});
+
+	it("updates sessionId and title in place when update is called", async () => {
+		const { projectDir, runtimeDir } = await tmpProject();
+		const presence = await registerDaemonProjectPresence(projectDir, runtimeDir);
+		try {
+			const clientsDir = path.join(runtimeDir, "clients");
+			const [entry] = await fs.readdir(clientsDir);
+			const initialRecord = await Bun.file(path.join(clientsDir, entry!)).json();
+			expect(initialRecord).not.toHaveProperty("sessionId");
+
+			await presence.update({
+				sessionId: "019fee60-2c7a-7000-9fd5-7439c7bf3dd2",
+				title: "Initial session",
+			});
+
+			const updatedRecord = await Bun.file(path.join(clientsDir, entry!)).json();
+			expect(updatedRecord).toMatchObject({
+				id: expect.any(String),
+				pid: process.pid,
+				sessionId: "019fee60-2c7a-7000-9fd5-7439c7bf3dd2",
+				title: "Initial session",
+			});
+
+			await presence.update({
+				sessionId: "019fee61-0000-7000-9000-111122223333",
+				title: "Switched session",
+			});
+
+			const transitionedRecord = await Bun.file(path.join(clientsDir, entry!)).json();
+			expect(transitionedRecord).toMatchObject({
+				id: expect.any(String),
+				pid: process.pid,
+				sessionId: "019fee61-0000-7000-9000-111122223333",
+				title: "Switched session",
+			});
+		} finally {
+			await presence.close();
+		}
+	});
+
+	it("populates sessionId on default launch and updates on session transition", async () => {
+		const { projectDir, runtimeDir } = await tmpProject();
+		// Isolate the launch from the developer's real environment the way every
+		// other runRootCommand test does: ambient auth discovery and on-disk
+		// settings would otherwise decide whether startup reaches session
+		// creation at all, so the test would pass or hang depending on whose
+		// machine it runs on.
+		const authStorage = await AuthStorage.create(path.join(projectDir, "auth.db"));
+		const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+		const parsed = parseArgs([]);
+		parsed.cwd = projectDir;
+		// Leave parsed.sessionDir undefined so createSessionManager returns undefined,
+		// exercising the default launch path where the session is created by the SDK.
+		process.env.PI_AGENT_DIR = path.join(projectDir, "agent");
+		parsed.noExtensions = true;
+		parsed.noSkills = true;
+		parsed.noRules = true;
+		parsed.noTools = true;
+		parsed.noLsp = true;
+
+		// Observations are collected inside the launch and asserted after it
+		// returns: an exception thrown from an injected callback is swallowed by
+		// startup's own error handling, which would turn a real regression into a
+		// runner timeout instead of a named failure.
+		let resolvePresenceUpdated: (() => void) | undefined;
+		let capturedSession: AgentSession | undefined;
+		let launchSessionId: string | undefined;
+		let transitionSessionId: string | undefined;
+		let launchRecord: unknown;
+		let transitionedRecord: unknown;
+		try {
+			await runRootCommand(parsed, [], {
+				discoverAuthStorage: async () => authStorage,
+				settings,
+				registerDaemonProjectPresence: async (pDir, _rOverride, initialSession) => {
+					const presence = await registerDaemonProjectPresence(pDir, runtimeDir, initialSession);
+					const originalUpdate = presence.update.bind(presence);
+					presence.update = async sess => {
+						await originalUpdate(sess);
+						resolvePresenceUpdated?.();
+					};
+					return presence;
+				},
+				runInteractiveMode: async session => {
+					capturedSession = session;
+					const clientsDir = path.join(runtimeDir, "clients");
+					const [entry] = await fs.readdir(clientsDir);
+					const presenceFile = path.join(clientsDir, entry!);
+					launchSessionId = session.sessionManager.getSessionId();
+					launchRecord = await Bun.file(presenceFile).json();
+
+					const updated = Promise.withResolvers<void>();
+					resolvePresenceUpdated = updated.resolve;
+					await session.newSession();
+					transitionSessionId = session.sessionManager.getSessionId();
+					// Bounded wait: when nothing refreshes the record the test must
+					// report a stale sessionId, not hang until the runner gives up.
+					await Promise.race([updated.promise, Bun.sleep(5_000)]);
+					transitionedRecord = await Bun.file(presenceFile).json();
+				},
+			});
+		} finally {
+			authStorage.close();
+		}
+
+		expect(capturedSession).toBeDefined();
+		// The launch registers the session it actually created, not nothing.
+		expect(launchRecord).toMatchObject({ sessionId: launchSessionId });
+		// `/new` mints a different id in the same process...
+		expect(transitionSessionId).not.toBe(launchSessionId);
+		// ...and the record a supervisor reads follows it.
+		expect(transitionedRecord).toMatchObject({ sessionId: transitionSessionId });
+		await capturedSession?.dispose();
+	}, 30_000);
+});


### PR DESCRIPTION
## What

`registerDaemonProjectPresence`'s written record now optionally carries a `sessionId`/`title`, sourced from `SessionManager.getSessionId()`/`getSessionName()` at its existing call site in `main.ts`.

## Why

An external supervisor watching `clients/<pid>-<uuid>.json` presence files today can only tell a bare `omp` process is alive, never which session (if any) it's driving. A downstream tool that wants to correlate a live `omp` TUI with its on-disk session file has no way to do that without this field.

## Compatibility

Purely additive:

- An older `omp` never writes these fields; both are conditionally spread into the JSON, so their absence is the normal case for anyone not explicitly holding a session.
- `hasLiveDaemonProjectPresence` (the one existing reader) only ever inspects `pid` and is untouched.
- The new test asserts the exact key set (`["id", "pid", "projectDir"]`) when no session is supplied, so the pre-existing record shape is pinned, not just assumed unchanged.

## Verified

- `tsgo -p tsconfig.json --noEmit` clean in `packages/coding-agent`.
- `bun test test/tools/presence-session-field.test.ts`: 5 pass, on this machine's environment and against an empty `$HOME`.

## Review feedback

Rebased onto current `main`. Both blocking points were correct: sourcing the identity once at the existing call site missed the session the SDK creates afterwards, and nothing refreshed the record when `/new` minted a new id in the same process.

- `DaemonProjectPresence` gained `update(session)`, which rewrites the same record file in place (temp file, `0600`, atomic rename through the existing `replaceFileAtomically` helper) and serializes writes so a concurrent reader never sees a partial record. `close()` drains the pending write before removing the file.
- Startup now updates the record with the created session's id and name, then subscribes to `registerSessionChangeCallback` and `onSessionNameChanged`, so the record follows the live session across `/new` rather than pointing at a dead id.
- The regression test drives the real `runRootCommand` launch path with isolated settings and auth storage (the convention the other `runRootCommand` tests use), reads the record off disk at the point the session is live, calls `session.newSession()`, and reads it again. Against the pre-fix source it fails on the transition assertion, reporting the record still holding the previous `sessionId`; it passes after. Observations are collected and asserted after the launch returns, because an exception thrown inside an injected callback is swallowed by startup's own error handling and would surface as a runner timeout instead of a named failure.
- Removed both `as Record<string, unknown>` casts from the test.
- Added the `[Unreleased]` changelog entry.

The launch-path assertion in that test passes both before and after; the transition assertion is the one that discriminates.

---

## Update: rebased onto current main

Rebased onto `main` (`8fad7f1006`) as a single commit. Both blocking points from the review round are in place after the rebase: the fresh-session launch path updates presence once the session exists (`main.ts:2017-2032`), and in-process `/new` transitions refresh the record through `DaemonProjectPresence.update()` (`presence.ts:31-35,72-76`). The changelog entry moved to `[Unreleased]` with the attribution suffix.

**Testing on this head:** `bun run check:ts` exits 0. `bun test test/tools/presence-session-field.test.ts test/tools/launch-eisdir-fallback.test.ts`: 6 pass, 0 fail. The transition assertion discriminates; against the unfixed source it reports the record still holding the previous `sessionId`:

```
error: expect(received).toMatchObject(expected)
-   "sessionId": "01a0993c-fd9a-7000-87ae-14e5b1904075",
+   "sessionId": "01a0993c-f9d3-7000-b594-b50dd0c609cb",
```
