### PR TITLE
feat(telemetry): stamp langfuse trace name/tags/user.id on spans

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -92,6 +92,7 @@ import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
+import { createLangfuseAttributeConfig } from "./telemetry-attributes";
 import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
 import { getChangelogPath, resolveStartupChangelogForDisplay, type StartupChangelogSelection } from "./utils/changelog";
@@ -1576,7 +1577,16 @@ export async function runRootCommand(
 	// remains governed by OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT.
 	await logger.time("initTelemetryExport", initTelemetryExport);
 	if (isTelemetryExportEnabled()) {
-		sessionOptions.telemetry = createTelemetryExportConfig(sessionOptions.telemetry);
+		sessionOptions.telemetry = createTelemetryExportConfig({
+			...createLangfuseAttributeConfig({
+				cwd,
+				prompt: parsedArgs.messages[0],
+				mode: isInteractive ? "interactive" : "headless",
+				modelRoles: settingsInstance.get("modelRoles"),
+				defaultModel: sessionOptions.model?.id,
+			}),
+			...sessionOptions.telemetry,
+		});
 	}
 
 	// Handle CLI --api-key as runtime override (not persisted)

--- a/packages/coding-agent/src/telemetry-attributes.ts
+++ b/packages/coding-agent/src/telemetry-attributes.ts
@@ -1,0 +1,84 @@
+/**
+ * Langfuse-facing trace attributes.
+ *
+ * Stamps trace-level context (name, tags, user) that the OTel GenAI semantic
+ * conventions do not cover, so backends honoring the `langfuse.*` attribute
+ * namespace (https://langfuse.com/integrations/native/opentelemetry) can name,
+ * tag, and filter traces. These attributes are inert on other OTLP backends.
+ *
+ * The agent core's TelemetryAttributeContext carries only span-local facts
+ * (kind, model, agent identity), so session-level values are captured in a
+ * closure at config-build time in main.ts, where cwd/argv/settings exist.
+ */
+import { hostname } from "node:os";
+import path from "node:path";
+import type { AgentTelemetryConfig, TelemetryAttributeContext } from "@oh-my-pi/pi-agent-core";
+
+const MAX_TRACE_NAME_CHARS = 80;
+
+export interface LangfuseAttributeConfigOptions {
+	readonly cwd: string;
+	/** Headless prompt (print mode); undefined for interactive sessions. */
+	readonly prompt?: string | undefined;
+	readonly mode: "interactive" | "headless";
+	/** The `modelRoles` setting (role -> model string, possibly provider-prefixed). */
+	readonly modelRoles: Record<string, string>;
+	/** Default-role model id when already resolved at startup. */
+	readonly defaultModel?: string | undefined;
+}
+
+export function createLangfuseAttributeConfig(options: LangfuseAttributeConfigOptions): AgentTelemetryConfig {
+	const project = path.basename(options.cwd);
+	const host = hostname();
+	const user = process.env.USER ?? process.env.LOGNAME;
+	const traceName = options.prompt ? truncate(firstLine(options.prompt), MAX_TRACE_NAME_CHARS) : `omp:${project}`;
+	const roleByModelId = invertModelRoles(options.modelRoles);
+
+	return {
+		resolveAttributes: (ctx: TelemetryAttributeContext) => {
+			switch (ctx.kind) {
+				case "invoke_agent": {
+					const tags = [`project:${project}`, `mode:${options.mode}`, `host:${host}`];
+					const model = ctx.model?.id ?? options.defaultModel;
+					if (model) tags.push(`model:${model}`);
+					if (ctx.agent?.name) tags.push(`agent:${ctx.agent.name}`);
+					return {
+						"langfuse.trace.name": traceName,
+						"langfuse.trace.tags": tags,
+						...(user ? { "user.id": user } : {}),
+						"langfuse.trace.metadata.project": project,
+					};
+				}
+				case "chat": {
+					const tags: string[] = [];
+					if (ctx.model?.provider) tags.push(`provider:${ctx.model.provider}`);
+					const role = ctx.model ? roleByModelId.get(ctx.model.id) : undefined;
+					if (role) tags.push(`role:${role}`);
+					return tags.length > 0 ? { "langfuse.trace.tags": tags } : undefined;
+				}
+				default:
+					return undefined;
+			}
+		},
+	};
+}
+
+/** modelRoles maps role -> "provider/model[:effort]"; index by bare model id. */
+function invertModelRoles(modelRoles: Record<string, string>): Map<string, string> {
+	const byId = new Map<string, string>();
+	for (const [role, modelString] of Object.entries(modelRoles)) {
+		const noProvider = modelString.includes("/") ? modelString.slice(modelString.lastIndexOf("/") + 1) : modelString;
+		const id = noProvider.split(":", 1)[0];
+		if (id) byId.set(id, role);
+	}
+	return byId;
+}
+
+function firstLine(text: string): string {
+	const line = text.split("\n", 1)[0]?.trim();
+	return line && line.length > 0 ? line : text.trim();
+}
+
+function truncate(text: string, max: number): string {
+	return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}

--- a/packages/coding-agent/test/telemetry-attributes.test.ts
+++ b/packages/coding-agent/test/telemetry-attributes.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { hostname } from "node:os";
+import type { TelemetryAttributeContext } from "@oh-my-pi/pi-agent-core";
+import { createLangfuseAttributeConfig, type LangfuseAttributeConfigOptions } from "../src/telemetry-attributes";
+
+const baseCtx: TelemetryAttributeContext = {
+	kind: "invoke_agent",
+	model: undefined,
+	agent: undefined,
+	conversationId: "conv-1",
+};
+
+function config(overrides?: Partial<LangfuseAttributeConfigOptions>) {
+	return createLangfuseAttributeConfig({
+		cwd: "/Users/jacob/.local/share/chezmoi",
+		prompt: undefined,
+		mode: "headless",
+		modelRoles: { default: "kimi-code/k3-256k:high", smol: "openrouter/gpt-5-mini:low" },
+		defaultModel: "k3-256k",
+		...overrides,
+	});
+}
+
+describe("createLangfuseAttributeConfig", () => {
+	test("invoke_agent stamps trace name, tags, user, project metadata", () => {
+		const attrs = config().resolveAttributes?.(baseCtx);
+		expect(attrs?.["langfuse.trace.name"]).toBe("omp:chezmoi");
+		expect(attrs?.["langfuse.trace.tags"]).toEqual([
+			"project:chezmoi",
+			"mode:headless",
+			`host:${hostname()}`,
+			"model:k3-256k",
+		]);
+		expect(typeof attrs?.["user.id"]).toBe("string");
+		expect(attrs?.["langfuse.trace.metadata.project"]).toBe("chezmoi");
+	});
+
+	test("headless prompt becomes the trace name, first line, truncated", () => {
+		const long = `${"x".repeat(100)}\nsecond line`;
+		const attrs = config({ prompt: long }).resolveAttributes?.(baseCtx);
+		expect(attrs?.["langfuse.trace.name"]).toBe(`${"x".repeat(79)}…`);
+	});
+
+	test("subagent invoke_agent adds agent tag", () => {
+		const attrs = config().resolveAttributes?.({ ...baseCtx, agent: { name: "fast-generic" } });
+		expect(attrs?.["langfuse.trace.tags"]).toContain("agent:fast-generic");
+	});
+
+	test("chat span tags provider and role from model", () => {
+		const attrs = config().resolveAttributes?.({
+			...baseCtx,
+			kind: "chat",
+			model: { id: "gpt-5-mini", provider: "openrouter" } as never,
+		});
+		expect(attrs?.["langfuse.trace.tags"]).toEqual(["provider:openrouter", "role:smol"]);
+	});
+
+	test("chat span without role match tags provider only; tool spans get nothing", () => {
+		const chat = config().resolveAttributes?.({
+			...baseCtx,
+			kind: "chat",
+			model: { id: "unconfigured-model", provider: "kimi-code" } as never,
+		});
+		expect(chat?.["langfuse.trace.tags"]).toEqual(["provider:kimi-code"]);
+		expect(config().resolveAttributes?.({ ...baseCtx, kind: "execute_tool" })).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

When OMP exports OTLP traces to Langfuse, every trace is named `invoke_agent` (the constant root-span name), and the Trace Tags / User columns are always empty. The agent core already exposes `AgentTelemetryConfig.resolveAttributes` for exactly this, but the CLI never wires it.

## Change

New `packages/coding-agent/src/telemetry-attributes.ts` composing a `resolveAttributes` closure (built in `main.ts`, where cwd/argv/settings are in scope) into the telemetry config:

- **`invoke_agent` spans**: `langfuse.trace.name` (headless prompt, first line, truncated to 80 chars; `omp:{cwd basename}` fallback), `langfuse.trace.tags` (`project:`, `mode:interactive|headless`, `host:`, `model:`, plus `agent:<name>` on subagent runs), `user.id` (`$USER`), and `langfuse.trace.metadata.project` (top-level, filterable)
- **`chat` spans**: `provider:<gen_ai.provider.name>` and `role:<model role>` tags; role is resolved by inverting the `modelRoles` setting (provider prefix and `:effort` suffix stripped), so tags only fire when the span's model matches a configured role

Langfuse unions tags across spans into the trace, so multi-provider/multi-role turns carry several accurate values. The `langfuse.*` attributes are inert on other OTLP backends.

## Verification

- `bun test test/telemetry-attributes.test.ts` — 5/5 (name truncation, role inversion incl. `:effort` suffix, subagent agent tag, provider-only fallback, non-chat spans untouched)
- Headless `src/cli.ts -p "say ok"` against a self-hosted Langfuse: trace shows name `say ok`, tags `project/mode/host/model`, `userId: jacob`, chat span tagged `provider:kimi-code`

## Deliberately out of scope

- Generated session titles as interactive trace names (needs a session→telemetry seam; follow-up)
- Baggage propagation for observation-level tag filtering (new dep; trace-level filtering already works)
- `thinking:` tag (per-call effort isn't in the resolver ctx; already on spans as `pi.gen_ai.request.reasoning.effort`)