### PR TITLE
fix(ai): update Alibaba China console URL

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Stopped treating `XAI_API_KEY` as SuperGrok (`xai-oauth`) sign-in for availability, so paid-key-only setups default to `xai/grok-4.5` instead of the zero-cost SuperGrok catalog path. Explicit `xai-oauth/…` selectors still accept the paid key via the existing env fallback.
 - Omitted unsupported `reasoning.summary` on paid xAI Responses requests (`xai/grok-4.5`), matching SuperGrok, so a thinking level no longer serializes `summary: "auto"`.
 - Omitted presence/frequency penalties on all first-party xAI Responses models, including non-reasoning ids such as `xai/grok-2`.
+- Updated the Alibaba Coding Plan China login to open Bailian API-key management after the DashScope console was retired ([#8691](https://github.com/can1357/oh-my-pi/issues/8691)).
 
 ## [17.3.4] - 2026-08-14
 

--- a/packages/ai/src/registry/alibaba-coding-plan.ts
+++ b/packages/ai/src/registry/alibaba-coding-plan.ts
@@ -4,7 +4,7 @@ import type { OAuthController, OAuthCredentials, OAuthLoginCallbacks } from "./o
 import type { ProviderDefinition } from "./types";
 
 const DEFAULT_AUTH_URL = "https://modelstudio.console.alibabacloud.com/";
-const CHINA_AUTH_URL = "https://dashscope.console.aliyun.com/";
+const CHINA_AUTH_URL = "https://bailian.console.aliyun.com/?tab=model#/api-key";
 const DEFAULT_API_BASE_URL = "https://coding-intl.dashscope.aliyuncs.com/v1";
 const CHINA_API_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1";
 const VALIDATION_MODEL = "qwen3.5-plus";
@@ -32,7 +32,7 @@ export async function loginAlibabaCodingPlan(options: OAuthController): Promise<
 	if (choice === "2") {
 		baseUrl = CHINA_API_BASE_URL;
 		authUrl = CHINA_AUTH_URL;
-		instructions = "Copy your API key from the Alibaba Cloud DashScope console (China mainland)";
+		instructions = "Copy your API key from the Alibaba Cloud Bailian console (China mainland)";
 	} else if (choice === "3") {
 		const customUrl = await options.onPrompt({
 			message: "Enter custom base URL",

--- a/packages/ai/test/alibaba-endpoint-selection.test.ts
+++ b/packages/ai/test/alibaba-endpoint-selection.test.ts
@@ -69,8 +69,10 @@ describe("alibaba-coding-plan endpoint selection", () => {
 		expect(result.access).toBe("sk-cn-key");
 		expect(result.refresh).toBe("sk-cn-key");
 		expect(result.enterpriseUrl).toBe("https://coding.dashscope.aliyuncs.com/v1");
-		expect(capturedAuth?.url).toBe("https://dashscope.console.aliyun.com/");
-		expect(capturedAuth?.instructions).toContain("China mainland");
+		expect(capturedAuth?.url).toBe("https://bailian.console.aliyun.com/?tab=model#/api-key");
+		expect(capturedAuth?.instructions).toBe(
+			"Copy your API key from the Alibaba Cloud Bailian console (China mainland)",
+		);
 
 		expect(validateSpy).toHaveBeenCalledWith({
 			provider: "Alibaba Coding Plan",


### PR DESCRIPTION
## Repro
Selecting endpoint `2` in the Alibaba Coding Plan login passes `https://dashscope.console.aliyun.com/` to `onAuth`, but Alibaba retired that domain on 2026-08-01. Reproduced with `bun -e '<invoke loginAlibabaCodingPlan with endpoint choice 2 and print onAuth payload>'`; the payload contained the decommissioned URL and stale DashScope guidance.

## Cause
`loginAlibabaCodingPlan()` in `packages/ai/src/registry/alibaba-coding-plan.ts` still used the old `CHINA_AUTH_URL` and DashScope-specific China instructions after the console migrated to Bailian.

## Fix
- Point the China login directly at Bailian API-key management.
- Refer to the Bailian console in the China login instructions.
- Update endpoint-selection regression coverage and the AI package changelog.

## Verification
`bun test packages/ai/test/alibaba-endpoint-selection.test.ts` passes: 12 tests, 0 failures. A direct invocation of `loginAlibabaCodingPlan()` with choice `2` now emits `https://bailian.console.aliyun.com/?tab=model#/api-key` and the updated Bailian instructions. The pre-publish `bun check` gate also passed.

Fixes #8691