### PR TITLE
feat(coding-agent): annotate 401/403 failures with the selected credential source

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- 401/403 authentication failures now annotate the error with the selected credential source (e.g. `local store · api_key #3`), so users with multiple stored keys can tell which credential was used without digging through `agent.db` ([#8640](https://github.com/can1357/oh-my-pi/issues/8640)).
 - Routed paid xAI models (`XAI_API_KEY` / `xai/…`) through the Responses API used by SuperGrok OAuth instead of Chat Completions.
 - Changed the default model for `XAI_API_KEY` (`xai`) from `grok-4-fast-non-reasoning` to `grok-4.5`.
 - Changed the default model for SuperGrok OAuth (`xai-oauth`) from `grok-4.3` to `grok-4.5`.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -283,6 +283,7 @@ import {
 	type LaunchCompletionEntry,
 } from "./launch-completion";
 import {
+	appendCredentialSourceDiagnostic,
 	type BashExecutionMessage,
 	buildReplanTitleContext,
 	type CustomMessage,
@@ -2793,6 +2794,9 @@ export class AgentSession {
 			// repeatedly on provider errors otherwise leaves no actionable trace
 			// outside the session transcript (issue #6177).
 			logProviderTurnError(msg);
+			appendCredentialSourceDiagnostic(msg, () =>
+				this.#modelRegistry.authStorage.describeCredentialSource(msg.provider, this.sessionId),
+			);
 
 			// Invalidate GitHub Copilot credentials on a hard auth failure (401, or an
 			// expired/revoked token) so stale tokens aren't reused on the next request.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2461,6 +2461,15 @@ export class AgentSession {
 		// toolUse) assistant message and skipping settle-only work.
 		if (event.type === "message_end" && event.message.role === "assistant") {
 			this.#lastAssistantMessage = event.message;
+			// Annotate the credential source on auth failures BEFORE the display
+			// copy is made below, so the eager TUI render and the persisted
+			// transcript both carry it (issue #8640). The mutation is in-place on
+			// `event.message`, mirroring the `SILENT_ABORT_MARKER` path; the
+			// display spread below inherits it via `{ ...message }`.
+			const settledAssistant = event.message as AssistantMessage;
+			appendCredentialSourceDiagnostic(settledAssistant, () =>
+				this.#modelRegistry.authStorage.describeCredentialSource(settledAssistant.provider, this.sessionId),
+			);
 		}
 		// Plan-mode internal transition: stamp `SILENT_ABORT_MARKER` on the
 		// persisted message BEFORE the obfuscator's display-side copy below.
@@ -2794,9 +2803,6 @@ export class AgentSession {
 			// repeatedly on provider errors otherwise leaves no actionable trace
 			// outside the session transcript (issue #6177).
 			logProviderTurnError(msg);
-			appendCredentialSourceDiagnostic(msg, () =>
-				this.#modelRegistry.authStorage.describeCredentialSource(msg.provider, this.sessionId),
-			);
 
 			// Invalidate GitHub Copilot credentials on a hard auth failure (401, or an
 			// expired/revoked token) so stale tokens aren't reused on the next request.

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -59,6 +59,22 @@ export function logProviderTurnError(msg: AssistantMessage): void {
 	});
 }
 
+/**
+ * Appends which stored credential a 401/403 failure was sent under, so users
+ * with multiple stored keys can tell the new key from a stale/rotated one
+ * without digging through `agent.db` (#8640).
+ *
+ * Only touches auth failures (401/403) with a resolvable source; every other
+ * error path keeps its message byte-identical. The source string comes from
+ * {@link AuthStorage.describeCredentialSource} and is fully sanitized.
+ */
+export function appendCredentialSourceDiagnostic(msg: AssistantMessage, resolveSource: () => string | undefined): void {
+	if (msg.stopReason !== "error" || (msg.errorStatus !== 401 && msg.errorStatus !== 403)) return;
+	const source = resolveSource();
+	if (!source) return;
+	msg.errorMessage = `${msg.errorMessage ?? ""}\n\n(selected credential: ${source})`;
+}
+
 const EPHEMERAL_REPLY_MAX_BYTES = 4096;
 const REPLAN_TITLE_CONTEXT_TURN_LIMIT = 6;
 

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -64,12 +64,18 @@ export function logProviderTurnError(msg: AssistantMessage): void {
  * with multiple stored keys can tell the new key from a stale/rotated one
  * without digging through `agent.db` (#8640).
  *
- * Only touches auth failures (401/403) with a resolvable source; every other
- * error path keeps its message byte-identical. The source string comes from
+ * Only touches auth failures (401/403, classified via {@link AIError.Flag.AuthFailed})
+ * with a resolvable source; every other error path keeps its message
+ * byte-identical. Idempotent: re-running over an already-annotated message is a
+ * no-op, so both the eager display copy and the persisted transcript can pass
+ * through it without double-appending. The source string comes from
  * {@link AuthStorage.describeCredentialSource} and is fully sanitized.
  */
 export function appendCredentialSourceDiagnostic(msg: AssistantMessage, resolveSource: () => string | undefined): void {
-	if (msg.stopReason !== "error" || (msg.errorStatus !== 401 && msg.errorStatus !== 403)) return;
+	if (msg.stopReason !== "error") return;
+	if (msg.errorMessage?.includes("(selected credential: ")) return;
+	const errorId = AIError.classifyMessage(msg);
+	if (!AIError.is(errorId, AIError.Flag.AuthFailed) || AIError.is(errorId, AIError.Flag.UsageLimit)) return;
 	const source = resolveSource();
 	if (!source) return;
 	msg.errorMessage = `${msg.errorMessage ?? ""}\n\n(selected credential: ${source})`;

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -1629,7 +1629,7 @@ describe("AgentSession message pipeline", () => {
 		expect(result.assistantMessage.content.every(block => block.type !== "toolCall")).toBe(true);
 	});
 
-	it("annotates a 401 turn with the selected credential source (#8640)", async () => {
+	it("annotates a 401 turn and persists the annotation to the transcript (#8640)", async () => {
 		using tempDir = TempDir.createSync("@pi-credential-diag-");
 		const api = "test-credential-diag";
 		registerCustomApi(api, (_model, _context, options) => {
@@ -1664,10 +1664,12 @@ describe("AgentSession message pipeline", () => {
 		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const sessionDir = tempDir.join("session");
+		const sessionManager = SessionManager.create(tempDir.path(), sessionDir);
 		const { session } = await createAgentSession({
 			cwd: tempDir.path(),
 			agentDir: tempDir.path(),
-			sessionManager: SessionManager.inMemory(tempDir.path()),
+			sessionManager,
 			authStorage,
 			modelRegistry,
 			settings: Settings.isolated({ "compaction.enabled": false }),
@@ -1686,13 +1688,24 @@ describe("AgentSession message pipeline", () => {
 		try {
 			await session.sendUserMessage("please fail with 401");
 
+			// In-memory state carries the annotation.
 			const last = session.agent.state.messages.at(-1);
 			expect(last?.role).toBe("assistant");
 			if (last?.role !== "assistant") return;
-			expect(last.errorMessage).toContain("HTTP 401 from https://ollama.com/api/chat\nUnauthorized");
 			expect(last.errorMessage).toContain("(selected credential: runtime override (--api-key))");
+
+			// The persisted transcript must reflect it too, not just the in-place
+			// state mutation — the annotation runs before the display copy, so the
+			// eager TUI render and the on-disk history agree (#8640 roboomp review).
+			await sessionManager.ensureOnDisk();
+			const sessionFile = sessionManager.getSessionFile();
+			expect(sessionFile).toBeTruthy();
+			const transcript = await Bun.file(sessionFile!).text();
+			expect(transcript).toContain("HTTP 401 from https://ollama.com/api/chat\\nUnauthorized");
+			expect(transcript).toContain("(selected credential: runtime override (--api-key))");
 		} finally {
 			await session.dispose();
+			sessionManager.close();
 			authStorage.close();
 		}
 	});

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -1628,4 +1628,139 @@ describe("AgentSession message pipeline", () => {
 		expect(result.assistantMessage.content.some(block => block.type === "toolCall")).toBe(false);
 		expect(result.assistantMessage.content.every(block => block.type !== "toolCall")).toBe(true);
 	});
+
+	it("annotates a 401 turn with the selected credential source (#8640)", async () => {
+		using tempDir = TempDir.createSync("@pi-credential-diag-");
+		const api = "test-credential-diag";
+		registerCustomApi(api, (_model, _context, options) => {
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("");
+				message.content = [];
+				message.stopReason = "error";
+				message.errorMessage = "HTTP 401 from https://ollama.com/api/chat\nUnauthorized";
+				message.errorStatus = 401;
+				stream.push({ type: "start", partial: message });
+				stream.push({ type: "error", reason: "error", error: message });
+			});
+			return stream;
+		});
+
+		const model = buildModel({
+			id: "credential-diag-model",
+			name: "Credential Diag Model",
+			api,
+			// The custom-API path normalizes the provider to the default
+			// "anthropic"; describeCredentialSource must still resolve for it.
+			provider: "anthropic",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			taskDepth: 1,
+			agentId: "SubAgent",
+		});
+		try {
+			await session.sendUserMessage("please fail with 401");
+
+			const last = session.agent.state.messages.at(-1);
+			expect(last?.role).toBe("assistant");
+			if (last?.role !== "assistant") return;
+			expect(last.errorMessage).toContain("HTTP 401 from https://ollama.com/api/chat\nUnauthorized");
+			expect(last.errorMessage).toContain("(selected credential: runtime override (--api-key))");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("leaves a 500 turn without a credential annotation (#8640)", async () => {
+		using tempDir = TempDir.createSync("@pi-credential-diag-500-");
+		const api = "test-credential-diag-500";
+		registerCustomApi(api, (_model, _context, options) => {
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("");
+				message.content = [];
+				message.stopReason = "error";
+				message.errorMessage = "HTTP 500 internal";
+				message.errorStatus = 500;
+				stream.push({ type: "start", partial: message });
+				stream.push({ type: "error", reason: "error", error: message });
+			});
+			return stream;
+		});
+
+		const model = buildModel({
+			id: "credential-diag-500-model",
+			name: "Credential Diag 500 Model",
+			api,
+			provider: "ollama-cloud",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("ollama-cloud", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		vi.spyOn(authStorage, "describeCredentialSource").mockReturnValue("local store · api_key #3 (cred 3)");
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false, "retry.maxRetries": 0 }),
+			model,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			taskDepth: 1,
+			agentId: "SubAgent",
+		});
+		try {
+			await session.sendUserMessage("please fail with 500");
+
+			const last = session.agent.state.messages.at(-1);
+			expect(last?.role).toBe("assistant");
+			if (last?.role !== "assistant") return;
+			expect(last.errorMessage).toContain("HTTP 500 internal");
+			expect(last.errorMessage).not.toContain("selected credential");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
 });

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { type AgentMessage, filterProviderReplayMessages } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, Message, TextContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent, Message, TextContent } from "@oh-my-pi/pi-ai";
 import { inferCopilotInitiator } from "@oh-my-pi/pi-ai/providers/github-copilot-headers";
 import {
+	appendCredentialSourceDiagnostic,
 	convertToLlm,
 	SKILL_PROMPT_MESSAGE_TYPE,
 	wrapSteeringForModel,
@@ -478,5 +479,60 @@ describe("wrapSteeringForModel", () => {
 		expect(wrapped[1]).not.toBe(second);
 		expect(getUserText(wrapped[0])).toContain("first steer");
 		expect(getUserText(wrapped[1])).toContain("second steer");
+	});
+});
+
+describe("appendCredentialSourceDiagnostic (#8640)", () => {
+	function errorMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [],
+			api: "openai",
+			provider: "ollama-cloud",
+			model: "qwen3",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				reasoningTokens: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "HTTP 401 from https://ollama.com/api/chat\nUnauthorized",
+			timestamp: 1,
+			...overrides,
+		};
+	}
+
+	it("appends the selected credential source to a 401 failure", () => {
+		const msg = errorMessage({ errorStatus: 401 });
+		appendCredentialSourceDiagnostic(msg, () => "local store · api_key #3 (cred 3)");
+		expect(msg.errorMessage).toContain("(selected credential: local store · api_key #3 (cred 3))");
+	});
+
+	it("appends the selected credential source to a 403 failure", () => {
+		const msg = errorMessage({ errorStatus: 403 });
+		appendCredentialSourceDiagnostic(msg, () => "config override (models.yml)");
+		expect(msg.errorMessage).toContain("(selected credential: config override (models.yml))");
+	});
+
+	it("leaves non-auth provider errors untouched", () => {
+		const msg = errorMessage({ errorStatus: 500, errorMessage: "HTTP 500 internal" });
+		appendCredentialSourceDiagnostic(msg, () => "local store · api_key #3 (cred 3)");
+		expect(msg.errorMessage).toBe("HTTP 500 internal");
+	});
+
+	it("leaves the message untouched when no credential source resolves", () => {
+		const msg = errorMessage();
+		appendCredentialSourceDiagnostic(msg, () => undefined);
+		expect(msg.errorMessage).toBe("HTTP 401 from https://ollama.com/api/chat\nUnauthorized");
+	});
+
+	it("leaves non-error stops untouched even on 401", () => {
+		const msg = errorMessage({ stopReason: "stop", errorStatus: 401 });
+		appendCredentialSourceDiagnostic(msg, () => "local store");
+		expect(msg.errorMessage).toBe("HTTP 401 from https://ollama.com/api/chat\nUnauthorized");
 	});
 });

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -525,9 +525,30 @@ describe("appendCredentialSourceDiagnostic (#8640)", () => {
 	});
 
 	it("leaves the message untouched when no credential source resolves", () => {
-		const msg = errorMessage();
+		const msg = errorMessage({ errorStatus: 401 });
 		appendCredentialSourceDiagnostic(msg, () => undefined);
 		expect(msg.errorMessage).toBe("HTTP 401 from https://ollama.com/api/chat\nUnauthorized");
+	});
+
+	it("annotates an auth failure without a numeric errorStatus", () => {
+		// roboomp review #8640: the numeric-only guard missed status-less
+		// 401/403 bodies. Classification now uses the AuthFailed flag.
+		const msg = errorMessage(); // no errorStatus set
+		appendCredentialSourceDiagnostic(msg, () => "local store · api_key #3 (cred 3)");
+		expect(msg.errorMessage).toContain("(selected credential: local store · api_key #3 (cred 3))");
+	});
+
+	it("is idempotent so display and persisted passes do not double-append", () => {
+		const msg = errorMessage({ errorStatus: 401 });
+		appendCredentialSourceDiagnostic(msg, () => "local store · api_key #3 (cred 3)");
+		appendCredentialSourceDiagnostic(msg, () => "local store · api_key #3 (cred 3)");
+		expect(msg.errorMessage!.match(/\(selected credential:/g)).toHaveLength(1);
+	});
+
+	it("leaves usage-limit failures untouched", () => {
+		const msg = errorMessage({ errorStatus: 429, errorMessage: "HTTP 429 rate limit" });
+		appendCredentialSourceDiagnostic(msg, () => "local store");
+		expect(msg.errorMessage).toBe("HTTP 429 rate limit");
 	});
 
 	it("leaves non-error stops untouched even on 401", () => {


### PR DESCRIPTION
When a provider request fails with 401/403 and multiple credentials are stored for the provider, the error now appends which credential was selected (e.g. `local store · api_key #3`), so users can tell a new key from a stale or rotated one without digging through `agent.db`.

Fixes #8640

## What

Adds a sanitized credential-source annotation to auth-failure errors:

- `appendCredentialSourceDiagnostic` in `session/messages.ts` appends `(selected credential: …)` to an assistant error message when the turn failed with 401/403 and a source resolves. Every other error path keeps its message byte-identical.
- `AgentSession` calls it in the provider-error maintenance branch, resolving the source via the existing `AuthStorage.describeCredentialSource(provider, sessionId)` — the same sanitized description already shown by `/session` and `/models`.

## Why

Diagnosing a 401/403 with multiple stored keys (e.g. `ollama-cloud`, see #8637) currently requires runtime request tracing or inspecting `agent.db` to tell which credential OMP selected — the newly entered key, an older stored key, an env override, or a rotated sibling. This surfaces it directly on the failing request.

## Testing

- Unit tests in `session-messages.test.ts`: 401/403 append the source; 500 and non-error stops are untouched; missing source leaves the message unchanged.
- Integration test in `agent-session-message-pipeline.test.ts` drives a real 401 turn through `AgentSession` and asserts the final persisted message carries `(selected credential: runtime override (--api-key))`.
- `bun run check` and `bun test` pass in `packages/coding-agent`.

---

I am a full-stack developer intern contributing to this project. Please review and let me know if any changes are needed.

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)