### PR TITLE
feat(coding-agent): add automatic compaction precommit event

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Added an awaited, extension-only `session_compaction_precommit` event for normal automatic summary and snapcompact commits, allowing durable listeners to cancel before session history is rewritten.
+
 - Routed paid xAI models (XAI_API_KEY / xai/…) through the Responses API used by SuperGrok OAuth instead of Chat Completions, including reliable replay of encrypted reasoning content on follow-up turns.
 - Updated the default model for XAI_API_KEY (xai) to grok-4.5, and the default SuperGrok OAuth (xai-oauth) model to grok-4.5. Automatic model selection continues to prefer paid xai/grok-4.5 when only XAI_API_KEY is set, with xai-oauth/grok-4.5 still available explicitly.
 - Stopped sending presence/frequency penalties and stop sequences to xAI reasoning models such as grok-4.5, which reject them.

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -60,6 +60,7 @@ import type {
 	SessionBeforeSwitchResult,
 	SessionBeforeTreeResult,
 	SessionCompactingResult,
+	SessionCompactionPrecommitResult,
 	SessionStopEvent,
 	SessionStopEventResult,
 	ToolCallEvent,
@@ -358,13 +359,15 @@ type RunnerEmitResult<TEvent extends RunnerEmitEvent> = TEvent extends { type: "
 		? SessionBeforeBranchResult | undefined
 		: TEvent extends { type: "session_before_compact" }
 			? SessionBeforeCompactResult | undefined
-			: TEvent extends { type: "session_before_tree" }
-				? SessionBeforeTreeResult | undefined
-				: TEvent extends { type: "session.compacting" }
-					? SessionCompactingResult | undefined
-					: TEvent extends { type: "session_stop" }
-						? SessionStopEventResult | undefined
-						: undefined;
+			: TEvent extends { type: "session_compaction_precommit" }
+				? SessionCompactionPrecommitResult | undefined
+				: TEvent extends { type: "session_before_tree" }
+					? SessionBeforeTreeResult | undefined
+					: TEvent extends { type: "session.compacting" }
+						? SessionCompactingResult | undefined
+						: TEvent extends { type: "session_stop" }
+							? SessionStopEventResult | undefined
+							: undefined;
 
 // Session-lifecycle handler types live once in session-handler-types (imported
 // above for local use); re-exported here to keep this module's public API stable.
@@ -1215,7 +1218,7 @@ export class ExtensionRunner {
 		// subscribed; building `ctx` for a zero-handler event is pure waste.
 		let ctx: ExtensionContext | undefined;
 		let result: SessionBeforeEventResult | SessionCompactingResult | SessionStopEventResult | undefined;
-
+		let precommitResult: SessionCompactionPrecommitResult | undefined;
 		if (this.#isSessionShutdownEvent(event)) {
 			const timeoutMs = handlerTimeoutForEvent(event.type);
 			const promises: Promise<unknown>[] = [];
@@ -1243,9 +1246,23 @@ export class ExtensionRunner {
 					ctx,
 					ext,
 					handlerTimeoutForEvent(event.type),
+					event.type === "session_compaction_precommit"
+						? (kind, reason) => ({
+								cancel: true,
+								reason: `compaction precommit handler ${kind}: ${reason}`,
+							})
+						: undefined,
 				);
 
-				if (this.#isSessionBeforeEvent(event) && handlerResult) {
+				// A precommit cancellation must not skip other handlers: each listener
+				// may own a separate durable write that must settle before this attempt
+				// can be reported as failed.
+				if (event.type === "session_compaction_precommit") {
+					const candidate = handlerResult as SessionCompactionPrecommitResult | undefined;
+					if (candidate?.cancel && !precommitResult) {
+						precommitResult = candidate;
+					}
+				} else if (this.#isSessionBeforeEvent(event) && handlerResult) {
 					result = handlerResult as SessionBeforeEventResult;
 					if (result.cancel) {
 						return result as RunnerEmitResult<TEvent>;
@@ -1266,6 +1283,10 @@ export class ExtensionRunner {
 					}
 				}
 			}
+		}
+
+		if (event.type === "session_compaction_precommit") {
+			return precommitResult as RunnerEmitResult<TEvent>;
 		}
 
 		return result as RunnerEmitResult<TEvent>;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -100,6 +100,8 @@ import type {
 	SessionCompactEvent,
 	SessionCompactingEvent,
 	SessionCompactingResult,
+	SessionCompactionPrecommitEvent,
+	SessionCompactionPrecommitResult,
 	SessionEvent,
 	SessionShutdownEvent,
 	SessionStartEvent,
@@ -674,10 +676,12 @@ export interface ResourcesDiscoverResult {
 }
 
 // ============================================================================
-// Session Events (shared with hooks subsystem)
+// Session Events
 // ============================================================================
 
+/** Session lifecycle events shared with the hooks subsystem. */
 export type {
+	ReadonlyCompactionResult,
 	SessionBeforeBranchEvent,
 	SessionBeforeCompactEvent,
 	SessionBeforeSwitchEvent,
@@ -685,6 +689,7 @@ export type {
 	SessionBranchEvent,
 	SessionCompactEvent,
 	SessionCompactingEvent,
+	SessionCompactionPrecommitEvent,
 	SessionEvent,
 	SessionShutdownEvent,
 	SessionStartEvent,
@@ -1026,6 +1031,7 @@ export function isToolCallEventType(toolName: string, event: ToolCallEvent): boo
 export type ExtensionEvent =
 	| ResourcesDiscoverEvent
 	| SessionEvent
+	| SessionCompactionPrecommitEvent
 	| ContextEvent
 	| BeforeProviderRequestEvent
 	| AfterProviderResponseEvent
@@ -1094,21 +1100,21 @@ export interface UserPythonEventResult {
 	result?: PythonResult;
 }
 
-export type { ToolResultEventResult } from "../shared-events";
-
-export interface BeforeAgentStartEventResult {
-	message?: CustomMessagePayload;
-	/** Replace the system prompt for this turn. If multiple extensions return this, they are chained. */
-	systemPrompt?: string[];
-}
-
 export type {
 	SessionBeforeBranchResult,
 	SessionBeforeCompactResult,
 	SessionBeforeSwitchResult,
 	SessionBeforeTreeResult,
 	SessionCompactingResult,
+	SessionCompactionPrecommitResult,
+	ToolResultEventResult,
 } from "../shared-events";
+
+export interface BeforeAgentStartEventResult {
+	message?: CustomMessagePayload;
+	/** Replace the system prompt for this turn. If multiple extensions return this, they are chained. */
+	systemPrompt?: string[];
+}
 
 // ============================================================================
 // Message Rendering
@@ -1206,6 +1212,10 @@ export interface ExtensionAPI {
 	on(
 		event: "session_before_compact",
 		handler: ExtensionHandler<SessionBeforeCompactEvent, SessionBeforeCompactResult>,
+	): void;
+	on(
+		event: "session_compaction_precommit",
+		handler: ExtensionHandler<SessionCompactionPrecommitEvent, SessionCompactionPrecommitResult>,
 	): void;
 	on(event: "session.compacting", handler: ExtensionHandler<SessionCompactingEvent, SessionCompactingResult>): void;
 	on(event: "session_compact", handler: ExtensionHandler<SessionCompactEvent>): void;

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -73,6 +73,49 @@ export interface SessionBeforeCompactEvent {
 	signal: AbortSignal;
 }
 
+type DeepReadonly<T> = T extends readonly (infer Item)[]
+	? readonly DeepReadonly<Item>[]
+	: T extends object
+		? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+		: T;
+
+/** Compile-time view of the deeply frozen automatic compaction candidate. */
+export type ReadonlyCompactionResult<T = unknown> = DeepReadonly<CompactionResult<T>>;
+
+/**
+ * Extension-only gate for the normal automatic compaction commit.
+ *
+ * The candidate comes from the main `prepareCompaction` summary/snapcompact
+ * pipeline. Automatic handoff, shake/elide, image-drop, and dead-end recovery
+ * rewrites are separate maintenance operations and do not emit this event.
+ * The gate fires after a candidate exists and before its `CompactionEntry` is
+ * appended or installed as active history.
+ */
+export interface SessionCompactionPrecommitEvent {
+	readonly type: "session_compaction_precommit";
+	/** Resolved user instructions for the compaction, when the trigger provides them. */
+	readonly customInstructions?: string;
+	/** The automatic maintenance trigger that requested this compaction. */
+	readonly trigger: "auto";
+	/** The condition that initiated automatic compaction. */
+	readonly reason: "threshold" | "overflow" | "idle" | "incomplete";
+	/** The strategy that produced the proposed compaction entry. */
+	readonly action: "context-full" | "snapcompact";
+	/** Whether this precommit belongs to automatic maintenance. */
+	readonly automatic: true;
+	/** Monotonic precommit attempt number for this session's automatic compactions. */
+	readonly autoCompactionIteration: number;
+	/** Wall-clock time when the proposed compaction entered the precommit boundary. */
+	readonly timestamp: string;
+	/** Cancels the listener when the automatic compaction attempt is superseded or aborted. */
+	readonly signal: AbortSignal;
+	/**
+	 * Exact deeply immutable compaction data passed to `appendCompaction()` if
+	 * every listener settles successfully.
+	 */
+	readonly compaction: ReadonlyCompactionResult;
+}
+
 /** Fired before compaction summarization to customize prompts/context */
 export interface SessionCompactingEvent {
 	type: "session.compacting";
@@ -378,6 +421,14 @@ export interface SessionBeforeCompactResult {
 	cancel?: boolean;
 	/** Custom compaction result - SessionManager adds id/parentId */
 	compaction?: CompactionResult;
+}
+
+/** Return type for `session_compaction_precommit` handlers */
+export interface SessionCompactionPrecommitResult {
+	/** Abort the automatic compaction before it changes session history. */
+	cancel?: boolean;
+	/** Optional explanation surfaced through the automatic compaction queue. */
+	reason?: string;
 }
 
 /** Return type for `session.compacting` handlers */

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -56,7 +56,12 @@ import type { ModelRegistry } from "../config/model-registry";
 import { MODEL_ROLE_IDS } from "../config/model-roles";
 import type { Settings } from "../config/settings";
 import { getDefault } from "../config/settings";
-import type { ExtensionRunner, SessionBeforeCompactResult } from "../extensibility/extensions";
+import type {
+	ExtensionRunner,
+	SessionBeforeCompactResult,
+	SessionCompactionPrecommitEvent,
+	SessionCompactionPrecommitResult,
+} from "../extensibility/extensions";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
 import type { GoalModeState } from "../goals/state";
 import { resolveMemoryBackend } from "../memory-backend/resolve";
@@ -173,6 +178,44 @@ function mergeLlmCompactionPreserveData(
 	return snapcompact.stripPreservedArchive(Object.keys(preserveData).length > 0 ? preserveData : undefined);
 }
 
+type AutoCompactionCommitAction = SessionCompactionPrecommitEvent["action"];
+
+/**
+ * Freeze the plain structured data accepted by CompactionEntry persistence.
+ * The event's AbortSignal is deliberately not part of this clone/freeze walk.
+ */
+function deepFreezeCompactionData(value: unknown, seen = new WeakSet<object>()): void {
+	if (value === null || typeof value !== "object") return;
+	if (seen.has(value)) return;
+	seen.add(value);
+
+	if (!Array.isArray(value)) {
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) {
+			throw new TypeError("Compaction candidates may contain only plain structured data");
+		}
+	}
+
+	for (const child of Object.values(value)) deepFreezeCompactionData(child, seen);
+	Object.freeze(value);
+}
+
+/** Clone once, freeze deeply, then use this same object for listeners and commit. */
+function immutableCompactionCandidate(result: CompactionResult): CompactionResult {
+	const candidate = structuredClone(result);
+	deepFreezeCompactionData(candidate);
+	return candidate;
+}
+
+/**
+ * Preserve the historical public end-event payload: frame archives remain
+ * durable in CompactionEntry but are not repeated through auto_compaction_end.
+ */
+function projectAutoCompactionEndResult(result: CompactionResult): CompactionResult {
+	const preserveData = snapcompact.stripPreservedArchive(result.preserveData);
+	return preserveData === result.preserveData ? result : { ...result, preserveData };
+}
+
 /** Capabilities borrowed from the owning AgentSession. */
 export interface SessionMaintenanceHost {
 	agent: Agent;
@@ -272,6 +315,7 @@ export interface SessionMaintenanceHost {
 export class SessionMaintenance {
 	#compactionAbortController: AbortController | undefined;
 	#autoCompactionAbortController: AbortController | undefined;
+	#autoCompactionIteration = 0;
 	/**
 	 * Live tool-loop contexts parked after mid-turn maintenance hit a no-progress
 	 * dead end. Membership suppresses the repeated rescue + warning while no cut
@@ -2799,6 +2843,15 @@ export class SessionMaintenance {
 				preserveData = mergeLlmCompactionPreserveData(compactionPrep.preserveData, compactResult.preserveData);
 			}
 
+			const result: CompactionResult = {
+				summary,
+				shortSummary,
+				firstKeptEntryId,
+				tokensBefore,
+				details,
+				preserveData,
+			};
+
 			if (autoCompactionSignal.aborted) {
 				await this.#emitLifecycleEvent(
 					{
@@ -2813,14 +2866,47 @@ export class SessionMaintenance {
 				return COMPACTION_CHECK_NONE;
 			}
 
-			this.#host.sessionManager.appendCompaction(
-				summary,
-				shortSummary,
-				firstKeptEntryId,
-				tokensBefore,
-				details,
+			const autoCompactionIteration = ++this.#autoCompactionIteration;
+			const commitAction: AutoCompactionCommitAction = action === "snapcompact" ? "snapcompact" : "context-full";
+			const extensionRunner = this.#host.extensionRunner;
+			const hasPrecommitHandlers = extensionRunner?.hasHandlers("session_compaction_precommit") ?? false;
+			const compactionCandidate = hasPrecommitHandlers ? immutableCompactionCandidate(result) : result;
+			let precommitResult: SessionCompactionPrecommitResult | undefined;
+			if (extensionRunner && hasPrecommitHandlers) {
+				const precommitEvent: SessionCompactionPrecommitEvent = Object.freeze({
+					type: "session_compaction_precommit",
+					customInstructions: undefined,
+					trigger: "auto",
+					reason,
+					action: commitAction,
+					automatic: true,
+					autoCompactionIteration,
+					timestamp: new Date().toISOString(),
+					signal: autoCompactionSignal,
+					compaction: compactionCandidate,
+				});
+				precommitResult = await extensionRunner.emit(precommitEvent);
+			}
+			if (precommitResult?.cancel || autoCompactionSignal.aborted) {
+				await this.#host.emitSessionEvent({
+					type: "auto_compaction_end",
+					action,
+					result: undefined,
+					aborted: true,
+					willRetry: false,
+					errorMessage: precommitResult?.reason,
+				});
+				return COMPACTION_CHECK_NONE;
+			}
+
+			const savedCompactionEntryId = this.#host.sessionManager.appendCompaction(
+				compactionCandidate.summary,
+				compactionCandidate.shortSummary,
+				compactionCandidate.firstKeptEntryId,
+				compactionCandidate.tokensBefore,
+				compactionCandidate.details,
 				fromExtension,
-				preserveData,
+				compactionCandidate.preserveData,
 			);
 			const newEntries = this.#host.sessionManager.getEntries();
 			const sessionContext = this.#host.buildDisplaySessionContext();
@@ -2838,8 +2924,8 @@ export class SessionMaintenance {
 				this.#host.closeCodexProviderSessionsForHistoryRewrite();
 			}
 
-			// Get the saved compaction entry for the hook
-			const savedCompactionEntry = newEntries.find(e => e.type === "compaction" && e.summary === summary) as
+			// Resolve by the returned id: summaries are not unique across a session.
+			const savedCompactionEntry = newEntries.find(e => e.id === savedCompactionEntryId) as
 				| CompactionEntry
 				| undefined;
 
@@ -2859,15 +2945,7 @@ export class SessionMaintenance {
 					await compactEmit;
 				}
 			}
-
-			const result: CompactionResult = {
-				summary,
-				shortSummary,
-				firstKeptEntryId,
-				tokensBefore,
-				details,
-				preserveData: snapcompact.stripPreservedArchive(preserveData),
-			};
+			const endEventResult = projectAutoCompactionEndResult(compactionCandidate);
 			// Post-maintenance progress guard — evaluated BEFORE emitting
 			// auto_compaction_end so the TUI rebuild triggered by that event
 			// already reflects any rescue rewrite (elide / image-drop) and the
@@ -2960,7 +3038,7 @@ export class SessionMaintenance {
 			}
 
 			await this.#emitLifecycleEvent(
-				{ type: "auto_compaction_end", action, result, aborted: false, willRetry },
+				{ type: "auto_compaction_end", action, result: endEventResult, aborted: false, willRetry },
 				options.detachPostCommit === true,
 			);
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -1,13 +1,23 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { scheduler } from "node:timers/promises";
 import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type {
+	SessionCompactionPrecommitEvent,
+	SessionCompactionPrecommitResult,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
-import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import {
+	EXTENSION_HANDLER_TIMEOUT_MS,
+	ExtensionRunner,
+	testSetExtensionHandlerTimeoutMs,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as unexpectedStopClassifier from "@oh-my-pi/pi-coding-agent/session/unexpected-stop-classifier";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
@@ -15,8 +25,18 @@ import { TempDir, withTimeout } from "@oh-my-pi/pi-utils";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 
 const runtimeSignalStoreKey = "__ompRuntimeSignals";
-
-type RuntimeSignalGlobal = typeof globalThis & { [runtimeSignalStoreKey]?: string[] };
+type RuntimeSignalGlobal = typeof globalThis & {
+	[runtimeSignalStoreKey]?: string[];
+	__ompManualCompactGate?: Promise<void>;
+	__ompPrecommitGate?: Promise<void>;
+	__ompPrecommitResult?: SessionCompactionPrecommitResult;
+	__ompPrecommitError?: Error;
+	__ompPrecommitEntered?: (event: SessionCompactionPrecommitEvent) => void;
+	__ompPrecommitFollower?: (event: SessionCompactionPrecommitEvent) => void;
+	__ompCompactionDetails?: unknown;
+	__ompCompactionPreserveData?: Record<string, unknown>;
+	__ompPrecommitMutation?: (event: SessionCompactionPrecommitEvent) => void;
+};
 
 function getRuntimeSignals(): string[] {
 	const globalWithSignals = globalThis as RuntimeSignalGlobal;
@@ -36,6 +56,8 @@ describe("AgentSession auto-compaction queue resume", () => {
 	let sessionManager: SessionManager;
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
+	let extensionRunner: ExtensionRunner;
+	let reportedExtensionErrors: Array<{ event: string; error: string }>;
 	beforeAll(async () => {
 		tempDir = TempDir.createSync("@pi-auto-compaction-queue-");
 		authStorage = await AuthStorage.create(":memory:");
@@ -43,9 +65,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		modelRegistry = new ModelRegistry(authStorage);
 	});
 
-	beforeEach(async () => {
-		vi.useFakeTimers();
-
+	async function setupSession(includePrecommitHandlers = true): Promise<void> {
 		// Install the short-circuit extension directly. Loading a generated
 		// TypeScript file here used to compile the same fixture for every test.
 		const runtime = new ExtensionRuntime();
@@ -53,21 +73,38 @@ describe("AgentSession auto-compaction queue resume", () => {
 			pi => {
 				pi.on("session_before_compact", async event => {
 					getRuntimeSignals().push("before_compact:enter");
-					const gate = (globalThis as typeof globalThis & { __ompManualCompactGate?: Promise<void> })
-						.__ompManualCompactGate;
+					const gate = (globalThis as RuntimeSignalGlobal).__ompManualCompactGate;
 					if (gate) await gate;
-					return {
-						compaction: {
-							summary: "compacted",
-							shortSummary: undefined,
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
-							tokensBefore: event.preparation.tokensBefore,
-							details: {},
-						},
+					const compaction: CompactionResult = {
+						summary: "compacted",
+						shortSummary: undefined,
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+						details: (globalThis as RuntimeSignalGlobal).__ompCompactionDetails ?? {},
+						preserveData: (globalThis as RuntimeSignalGlobal).__ompCompactionPreserveData,
 					};
+					return { compaction };
 				});
+				if (includePrecommitHandlers) {
+					pi.on("session_compaction_precommit", async event => {
+						const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+						getRuntimeSignals().push(`compaction:precommit:${event.reason}`);
+						runtimeGlobal.__ompPrecommitMutation?.(event);
+						runtimeGlobal.__ompPrecommitEntered?.(event);
+						if (runtimeGlobal.__ompPrecommitGate) await runtimeGlobal.__ompPrecommitGate;
+						if (runtimeGlobal.__ompPrecommitError) throw runtimeGlobal.__ompPrecommitError;
+						return runtimeGlobal.__ompPrecommitResult;
+					});
+					pi.on("session_compaction_precommit", event => {
+						const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+						runtimeGlobal.__ompPrecommitFollower?.(event);
+					});
+				}
 				pi.on("auto_compaction_start", event => {
 					getRuntimeSignals().push(`compaction:start:${event.reason}`);
+				});
+				pi.on("session_compact", () => {
+					getRuntimeSignals().push("compaction:post");
 				});
 				pi.on("auto_compaction_end", event => {
 					getRuntimeSignals().push(`compaction:end:${event.aborted ? "aborted" : "ok"}`);
@@ -85,7 +122,11 @@ describe("AgentSession auto-compaction queue resume", () => {
 		sessionManager = SessionManager.inMemory(tempDir.path());
 		getRuntimeSignals().length = 0;
 
-		const extensionRunner = new ExtensionRunner([extension], runtime, tempDir.path(), sessionManager, modelRegistry);
+		extensionRunner = new ExtensionRunner([extension], runtime, tempDir.path(), sessionManager, modelRegistry);
+		reportedExtensionErrors = [];
+		extensionRunner.onError(error => {
+			reportedExtensionErrors.push({ event: error.event, error: error.error });
+		});
 
 		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!bundled) {
@@ -117,13 +158,70 @@ describe("AgentSession auto-compaction queue resume", () => {
 			sessionManager,
 			settings: Settings.isolated({
 				"compaction.autoContinue": false,
+				"compaction.strategy": "context-full",
 				"todo.reminders": true,
 				"todo.remindersMax": 3,
 			}),
 			modelRegistry,
 			extensionRunner,
 		});
+	}
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		await setupSession();
 	});
+
+	function triggerThresholdAutoCompaction(): void {
+		const assistantMsg = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "Done." }],
+			api: "anthropic-messages" as const,
+			provider: "anthropic" as const,
+			model: "claude-sonnet-4-5",
+			stopReason: "stop" as const,
+			usage: {
+				input: 190000,
+				output: 1000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 191000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+	}
+
+	function observeAutoCompactionEnd(): Promise<Extract<AgentSessionEvent, { type: "auto_compaction_end" }>> {
+		const { promise, resolve } = Promise.withResolvers<Extract<AgentSessionEvent, { type: "auto_compaction_end" }>>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") resolve(event);
+		});
+		return promise;
+	}
+
+	async function waitForFakeTimerBounded<T>(event: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+		let settled = false;
+		void event.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+		const observed = withTimeout(event, timeoutMs, message);
+		const timerStepMs = 10;
+		for (let elapsed = 0; elapsed < timeoutMs && !settled; elapsed += timerStepMs) {
+			for (let flush = 0; flush < 10 && !settled; flush++) await Promise.resolve();
+			if (!settled) vi.advanceTimersByTime(Math.min(timerStepMs, timeoutMs - elapsed));
+		}
+		for (let flush = 0; flush < 10 && !settled; flush++) await Promise.resolve();
+		return observed;
+	}
 
 	afterEach(async () => {
 		try {
@@ -134,8 +232,17 @@ describe("AgentSession auto-compaction queue resume", () => {
 				await Bun.sleep(0);
 			} finally {
 				getRuntimeSignals().length = 0;
-				(globalThis as typeof globalThis & { __ompManualCompactGate?: Promise<void> }).__ompManualCompactGate =
-					undefined;
+				const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+				runtimeGlobal.__ompManualCompactGate = undefined;
+				runtimeGlobal.__ompPrecommitGate = undefined;
+				runtimeGlobal.__ompPrecommitResult = undefined;
+				runtimeGlobal.__ompPrecommitError = undefined;
+				runtimeGlobal.__ompPrecommitEntered = undefined;
+				runtimeGlobal.__ompPrecommitFollower = undefined;
+				runtimeGlobal.__ompCompactionDetails = undefined;
+				runtimeGlobal.__ompCompactionPreserveData = undefined;
+				runtimeGlobal.__ompPrecommitMutation = undefined;
+				testSetExtensionHandlerTimeoutMs(EXTENSION_HANDLER_TIMEOUT_MS);
 				vi.restoreAllMocks();
 			}
 		}
@@ -955,6 +1062,304 @@ describe("AgentSession auto-compaction queue resume", () => {
 		await compactionDone;
 
 		expect(capturedIsCompacting).toBe(true);
+	});
+
+	it("awaits automatic precommit before appending or replacing compaction context", async () => {
+		const appendCompactionSpy = vi.spyOn(sessionManager, "appendCompaction");
+		const replaceMessagesSpy = vi.spyOn(session.agent, "replaceMessages");
+		const precommitGate = Promise.withResolvers<void>();
+		const precommitEntered = Promise.withResolvers<SessionCompactionPrecommitEvent>();
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		runtimeGlobal.__ompPrecommitGate = precommitGate.promise;
+		runtimeGlobal.__ompPrecommitEntered = precommitEntered.resolve;
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+		const event = await waitForFakeTimerBounded(precommitEntered.promise, 1000, "Precommit event timed out");
+
+		try {
+			expect(event).toMatchObject({
+				type: "session_compaction_precommit",
+				trigger: "auto",
+				reason: "threshold",
+				action: "context-full",
+				automatic: true,
+				autoCompactionIteration: 1,
+				compaction: { summary: "compacted", details: {} },
+			});
+			expect(new Date(event.timestamp).toISOString()).toBe(event.timestamp);
+			expect(event.customInstructions).toBeUndefined();
+			expect(event.signal.aborted).toBe(false);
+			expect(appendCompactionSpy).not.toHaveBeenCalled();
+			expect(replaceMessagesSpy).not.toHaveBeenCalled();
+			expect(getRuntimeSignals()).toContain("compaction:precommit:threshold");
+			expect(getRuntimeSignals()).not.toContain("compaction:post");
+		} finally {
+			precommitGate.resolve();
+		}
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Auto-compaction end timed out");
+		expect(end.aborted).toBe(false);
+		expect(end.result).toBe(event.compaction);
+		expect(getRuntimeSignals().filter(signal => signal === "compaction:precommit:threshold")).toHaveLength(1);
+		expect(appendCompactionSpy).toHaveBeenCalledTimes(1);
+		expect(replaceMessagesSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("emits automatic precommit before session_compact after a successful commit", async () => {
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Auto-compaction end timed out");
+		const signals = getRuntimeSignals();
+		const precommitIndex = signals.indexOf("compaction:precommit:threshold");
+		const postCommitIndex = signals.indexOf("compaction:post");
+
+		expect(end.aborted).toBe(false);
+		expect(precommitIndex).toBeGreaterThanOrEqual(0);
+		expect(postCommitIndex).toBeGreaterThan(precommitIndex);
+		expect(signals.filter(signal => signal === "compaction:precommit:threshold")).toHaveLength(1);
+	});
+
+	it("fails closed when automatic precommit explicitly cancels", async () => {
+		const branchBefore = sessionManager.getBranch();
+		const appendCompactionSpy = vi.spyOn(sessionManager, "appendCompaction");
+		const replaceMessagesSpy = vi.spyOn(session.agent, "replaceMessages");
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		const follower = vi.fn();
+		runtimeGlobal.__ompPrecommitFollower = follower;
+		runtimeGlobal.__ompPrecommitResult = { cancel: true, reason: "test cancellation" };
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Cancelled auto-compaction end timed out");
+		expect(end).toMatchObject({ aborted: true, result: undefined });
+		expect(appendCompactionSpy).not.toHaveBeenCalled();
+		expect(replaceMessagesSpy).not.toHaveBeenCalled();
+		const branchAfter = sessionManager.getBranch();
+		expect(branchAfter.slice(0, branchBefore.length)).toEqual(branchBefore);
+		expect(branchAfter).toHaveLength(branchBefore.length + 1);
+		expect(branchAfter.some(entry => entry.type === "compaction")).toBe(false);
+		expect(follower).toHaveBeenCalledTimes(1);
+		expect(getRuntimeSignals()).toContain("compaction:precommit:threshold");
+		expect(end.errorMessage).toBe("test cancellation");
+		expect(getRuntimeSignals()).not.toContain("compaction:post");
+	});
+
+	it("fails closed when an automatic precommit handler throws", async () => {
+		const branchBefore = sessionManager.getBranch();
+		const appendCompactionSpy = vi.spyOn(sessionManager, "appendCompaction");
+		const replaceMessagesSpy = vi.spyOn(session.agent, "replaceMessages");
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		const follower = vi.fn();
+		runtimeGlobal.__ompPrecommitFollower = follower;
+		runtimeGlobal.__ompPrecommitError = new Error("precommit fixture failure");
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Failed auto-compaction end timed out");
+		expect(end).toMatchObject({
+			aborted: true,
+			result: undefined,
+			errorMessage: "compaction precommit handler error: precommit fixture failure",
+		});
+		expect(appendCompactionSpy).not.toHaveBeenCalled();
+		expect(replaceMessagesSpy).not.toHaveBeenCalled();
+		const branchAfter = sessionManager.getBranch();
+		expect(branchAfter.slice(0, branchBefore.length)).toEqual(branchBefore);
+		expect(branchAfter).toHaveLength(branchBefore.length + 1);
+		expect(branchAfter.some(entry => entry.type === "compaction")).toBe(false);
+		expect(follower).toHaveBeenCalledTimes(1);
+		expect(reportedExtensionErrors).toContainEqual({
+			event: "session_compaction_precommit",
+			error: "precommit fixture failure",
+		});
+		expect(getRuntimeSignals()).toContain("compaction:precommit:threshold");
+		expect(getRuntimeSignals()).not.toContain("compaction:post");
+	});
+
+	it("fails closed on precommit timeout, reports the error, and still settles later listeners", async () => {
+		const branchBefore = sessionManager.getBranch();
+		const appendCompactionSpy = vi.spyOn(sessionManager, "appendCompaction");
+		const replaceMessagesSpy = vi.spyOn(session.agent, "replaceMessages");
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		const follower = vi.fn();
+		testSetExtensionHandlerTimeoutMs(20);
+		runtimeGlobal.__ompPrecommitFollower = follower;
+		runtimeGlobal.__ompPrecommitGate = new Promise<void>(() => {});
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Timed-out auto-compaction end timed out");
+		expect(end).toMatchObject({
+			aborted: true,
+			result: undefined,
+			errorMessage: "compaction precommit handler timeout: handler timed out after 20ms",
+		});
+		expect(appendCompactionSpy).not.toHaveBeenCalled();
+		expect(replaceMessagesSpy).not.toHaveBeenCalled();
+		const branchAfter = sessionManager.getBranch();
+		expect(branchAfter.slice(0, branchBefore.length)).toEqual(branchBefore);
+		expect(branchAfter).toHaveLength(branchBefore.length + 1);
+		expect(branchAfter.some(entry => entry.type === "compaction")).toBe(false);
+		expect(follower).toHaveBeenCalledTimes(1);
+		expect(reportedExtensionErrors).toContainEqual({
+			event: "session_compaction_precommit",
+			error: "handler timed out after 20ms",
+		});
+		expect(getRuntimeSignals()).not.toContain("compaction:post");
+	});
+
+	it("appends the original unfrozen candidate without precommit handlers", async () => {
+		const details = { files: { read: ["src/a.ts"] } };
+		const preserveData = { audit: { marker: "kept" } };
+
+		await session.dispose();
+		await setupSession(false);
+
+		const emitSpy = vi.spyOn(extensionRunner, "emit");
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		runtimeGlobal.__ompCompactionDetails = details;
+		runtimeGlobal.__ompCompactionPreserveData = preserveData;
+		const compactionEnd = observeAutoCompactionEnd();
+
+		expect(extensionRunner.hasHandlers("session_compaction_precommit")).toBe(false);
+		triggerThresholdAutoCompaction();
+
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "No-handler auto-compaction end timed out");
+		const persisted = sessionManager
+			.getBranch()
+			.filter((entry): entry is CompactionEntry => entry.type === "compaction")
+			.at(-1);
+
+		expect(emitSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "session_compaction_precommit" }));
+		expect(getRuntimeSignals()).not.toContain("compaction:precommit:threshold");
+		expect(Object.isFrozen(details)).toBe(false);
+		expect(Object.isFrozen(details.files)).toBe(false);
+		expect(Object.isFrozen(preserveData)).toBe(false);
+		expect(Object.isFrozen(preserveData.audit)).toBe(false);
+		expect(persisted).toMatchObject({
+			summary: "compacted",
+			details,
+			preserveData,
+		});
+		expect(persisted?.details).toBe(details);
+		expect(persisted?.preserveData).toBe(preserveData);
+		expect(end).toMatchObject({
+			action: "context-full",
+			aborted: false,
+			result: { details, preserveData },
+		});
+	});
+
+	it("freezes one exact snapcompact proposal and strips only the post-commit end projection", async () => {
+		const details = { files: { read: ["src/a.ts"] } };
+		const preserveData = {
+			snapcompact: {
+				frames: [{ data: "frame-1", mimeType: "image/png", cols: 4, rows: 2, chars: 8 }],
+				text: "archived conversation",
+				totalChars: 21,
+				truncatedChars: 0,
+			},
+			audit: { marker: "kept" },
+		};
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		const { promise: precommitEntered, resolve: onPrecommitEntered } =
+			Promise.withResolvers<SessionCompactionPrecommitEvent>();
+		let followerEvent: SessionCompactionPrecommitEvent | undefined;
+		let blockedMutations = 0;
+		runtimeGlobal.__ompCompactionDetails = details;
+		runtimeGlobal.__ompCompactionPreserveData = preserveData;
+		runtimeGlobal.__ompPrecommitEntered = onPrecommitEntered;
+		runtimeGlobal.__ompPrecommitFollower = event => {
+			followerEvent = event;
+		};
+		runtimeGlobal.__ompPrecommitMutation = event => {
+			// The listener intentionally violates the public readonly contract to
+			// prove the runtime boundary protects later listeners and persistence.
+			const mutableEvent = event as unknown as { timestamp: string; autoCompactionIteration: number };
+			const mutableDetails = event.compaction.details as { files: { read: string[] } };
+			const mutablePreserveData = event.compaction.preserveData as typeof preserveData;
+			const mutations = [
+				() => {
+					mutableEvent.timestamp = "mutated";
+				},
+				() => {
+					mutableEvent.autoCompactionIteration = 99;
+				},
+				() => {
+					mutableDetails.files.read[0] = "mutated.ts";
+				},
+				() => {
+					mutablePreserveData.snapcompact.frames[0].data = "mutated-frame";
+				},
+			];
+			for (const mutate of mutations) {
+				try {
+					mutate();
+				} catch {
+					blockedMutations++;
+				}
+			}
+		};
+		session.agent.setModel({ ...session.agent.state.model, input: ["text", "image"] });
+		session.settings.override("compaction.strategy", "snapcompact");
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+
+		const proposal = await waitForFakeTimerBounded(precommitEntered, 1000, "Snapcompact precommit timed out");
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Snapcompact end timed out");
+		const persisted = sessionManager
+			.getBranch()
+			.filter((entry): entry is CompactionEntry => entry.type === "compaction")
+			.at(-1);
+
+		expect(blockedMutations).toBe(4);
+		expect(Object.isFrozen(proposal)).toBe(true);
+		expect(Object.isFrozen(proposal.compaction)).toBe(true);
+		expect(Object.isFrozen(proposal.compaction.details)).toBe(true);
+		expect(Object.isFrozen(proposal.compaction.preserveData?.snapcompact)).toBe(true);
+		expect(followerEvent).toBe(proposal);
+		expect(followerEvent?.compaction).toBe(proposal.compaction);
+		expect(proposal.action).toBe("snapcompact");
+		expect(proposal.compaction.details).toEqual(details);
+		expect(proposal.compaction.preserveData).toEqual(preserveData);
+		expect(persisted).toMatchObject(proposal.compaction);
+		expect(persisted?.details).toBe(proposal.compaction.details);
+		expect(persisted?.preserveData).toBe(proposal.compaction.preserveData);
+		expect(end).toMatchObject({
+			action: "snapcompact",
+			aborted: false,
+			result: { preserveData: { audit: { marker: "kept" } } },
+		});
+		expect(end.result).not.toBe(proposal.compaction);
+	});
+
+	it("does not advertise automatic shake maintenance as a compaction precommit", async () => {
+		const precommit = vi.fn();
+		const appendCompactionSpy = vi.spyOn(sessionManager, "appendCompaction");
+		const runtimeGlobal = globalThis as RuntimeSignalGlobal;
+		runtimeGlobal.__ompPrecommitEntered = precommit;
+		session.settings.override("compaction.strategy", "shake");
+		vi.spyOn(session, "shake").mockResolvedValue({
+			mode: "elide",
+			toolResultsDropped: 1,
+			blocksDropped: 0,
+			tokensFreed: 100_000,
+		});
+		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 1000, contextWindow: 200_000, percent: 0.5 });
+		const compactionEnd = observeAutoCompactionEnd();
+
+		triggerThresholdAutoCompaction();
+
+		const end = await waitForFakeTimerBounded(compactionEnd, 1000, "Auto-shake end timed out");
+		expect(end).toMatchObject({ action: "shake", result: undefined, aborted: false });
+		expect(precommit).not.toHaveBeenCalled();
+		expect(appendCompactionSpy).not.toHaveBeenCalled();
 	});
 
 	it("forwards todo reminder lifecycle signals to extensions", async () => {


### PR DESCRIPTION
## What

Add an awaited, extension-only `session_compaction_precommit` event for normal automatic summary and snapcompact commits.

The event exposes one deeply immutable candidate after summarization and before `appendCompaction()` or live-context replacement. Every listener settles; cancellation, handler errors, and handler timeouts fail closed without committing the candidate. The exact proposal, including snapcompact `preserveData`, is persisted on success, while the existing stripped `auto_compaction_end` projection remains unchanged.

Automatic handoff, shake/elide, image-drop, and dead-end recovery rewrites remain explicitly outside this event rather than pretending they share the same transaction boundary.

## Why

Extensions that durably preserve knowledge or audit data need a real happens-before boundary. `session_compact` is post-commit, so a failed durable write there cannot prevent session history from being replaced.

## Testing

- `bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts` — 20 passed, 103 assertions
- `bun run ci:check:full` — passed
- `bun run check` — TypeScript and Rust checks passed
- `bun --cwd=packages/coding-agent run build` — passed
- `packages/coding-agent/dist/omp --version` — `omp/17.3.4`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing extension API)