### PR TITLE
feat(tui): add statusLine cost.showSubscription option to hide the (sub) marker

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -681,6 +681,8 @@ tui:
 
 For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`.
 
+Per-segment options: `model.showThinkingLevel`, `path.abbreviate`/`maxLength`/`stripWorkPrefix`, `git.showBranch`/`showStaged`/`showUnstaged`/`showUntracked`, `time.format`/`showSeconds`, and `cost.showSubscription` (default `true`) — the last shows or hides the `(sub)` marker rendered for OAuth/subscription-billed models in the cost segment and the classic footer.
+
 ### Interaction
 
 | Key                  | Type    | Default         | Values                                                                                                  |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `statusLine.segmentOptions.cost.showSubscription` (default `true`) to show or hide the `(sub)` OAuth/subscription billing marker in the status-line cost segment and the footer.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -9,6 +9,7 @@ import { shortenPath } from "../../tools/render-utils";
 import * as git from "../../utils/git";
 import { sanitizeStatusText } from "../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
+import type { StatusLineSegmentOptions } from "./status-line/types";
 
 /**
  * Footer component that shows pwd, token stats, and context usage
@@ -157,12 +158,15 @@ export class FooterComponent implements Component {
 
 		// Show billing summary with subscription and premium-request indicators
 		const usingSubscription = state.model ? this.session.modelRegistry.isUsingOAuth(state.model) : false;
+		const costOptions = (settings.getGroup("statusLine").segmentOptions as StatusLineSegmentOptions | undefined)
+			?.cost;
+		const showSubscriptionMarker = usingSubscription && costOptions?.showSubscription !== false;
 		const normalizedPremiumRequests = Math.round((totalPremiumRequests + Number.EPSILON) * 100) / 100;
-		if (totalCost || usingSubscription || normalizedPremiumRequests) {
+		if (totalCost || showSubscriptionMarker || normalizedPremiumRequests) {
 			const billingParts: string[] = [];
 			if (totalCost) billingParts.push(`$${totalCost.toFixed(3)}`);
 			if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
-			if (usingSubscription) billingParts.push("(sub)");
+			if (showSubscriptionMarker) billingParts.push("(sub)");
 			if (billingParts.length > 0) statsParts.push(billingParts.join(" "));
 		}
 

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -9,7 +9,8 @@ import { shortenPath } from "../../tools/render-utils";
 import * as git from "../../utils/git";
 import { sanitizeStatusText } from "../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
-import type { StatusLineSegmentOptions } from "./status-line/types";
+import { mergeSegmentOptions } from "./status-line/presets";
+import type { StatusLinePreset, StatusLineSettings } from "./status-line/types";
 
 /**
  * Footer component that shows pwd, token stats, and context usage
@@ -158,8 +159,10 @@ export class FooterComponent implements Component {
 
 		// Show billing summary with subscription and premium-request indicators
 		const usingSubscription = state.model ? this.session.modelRegistry.isUsingOAuth(state.model) : false;
-		const costOptions = (settings.getGroup("statusLine").segmentOptions as StatusLineSegmentOptions | undefined)
-			?.cost;
+		const costOptions = mergeSegmentOptions(
+			settings.getGroup("statusLine").preset as StatusLinePreset | undefined,
+			settings.getGroup("statusLine").segmentOptions as StatusLineSettings["segmentOptions"] | undefined,
+		).cost;
 		const showSubscriptionMarker = usingSubscription && costOptions?.showSubscription !== false;
 		const normalizedPremiumRequests = Math.round((totalPremiumRequests + Number.EPSILON) * 100) / 100;
 		if (totalCost || showSubscriptionMarker || normalizedPremiumRequests) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -20,16 +20,10 @@ import {
 	detectCodexResetFireworks,
 } from "../codex-reset-fireworks";
 import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
-import { getPreset } from "./presets";
+import { getPreset, mergeSegmentOptions } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
-import type {
-	CollabStatus,
-	EffectiveStatusLineSettings,
-	StatusLineSegmentId,
-	StatusLineSegmentOptions,
-	StatusLineSettings,
-} from "./types";
+import type { CollabStatus, EffectiveStatusLineSettings, StatusLineSegmentId, StatusLineSettings } from "./types";
 
 const JJ_REFRESH_TTL_MS = 5000;
 const WATCHER_FAILURE_POLL_TTL_MS = 5000;
@@ -1644,19 +1638,7 @@ export class StatusLineComponent implements Component {
 		const preset = this.#settings.preset ?? "default";
 		const presetDef = getPreset(preset);
 		const useCustomSegments = preset === "custom";
-		const mergedSegmentOptions: StatusLineSettings["segmentOptions"] = {};
-
-		for (const [segment, options] of Object.entries(presetDef.segmentOptions ?? {})) {
-			mergedSegmentOptions[segment as keyof StatusLineSegmentOptions] = { ...(options as Record<string, unknown>) };
-		}
-
-		for (const [segment, options] of Object.entries(this.#settings.segmentOptions ?? {})) {
-			const current = mergedSegmentOptions[segment as keyof StatusLineSegmentOptions] ?? {};
-			mergedSegmentOptions[segment as keyof StatusLineSegmentOptions] = {
-				...(current as Record<string, unknown>),
-				...(options as Record<string, unknown>),
-			};
-		}
+		const mergedSegmentOptions = mergeSegmentOptions(preset, this.#settings.segmentOptions);
 
 		const leftSegments = useCustomSegments
 			? (this.#settings.leftSegments ?? presetDef.leftSegments)

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -1,4 +1,31 @@
-import type { PresetDef, StatusLinePreset } from "./types";
+import type { PresetDef, StatusLinePreset, StatusLineSegmentOptions, StatusLineSettings } from "./types";
+
+/**
+ * Segment options effective for the given preset and user overrides — preset
+ * defaults on the bottom, user `statusLine.segmentOptions` merged on top,
+ * per segment. Shared by the status line and the footer so both renderers
+ * honor preset-level option changes identically.
+ */
+export function mergeSegmentOptions(
+	preset: StatusLinePreset | undefined,
+	user: StatusLineSettings["segmentOptions"] | undefined,
+): StatusLineSegmentOptions {
+	const merged: StatusLineSettings["segmentOptions"] = {};
+
+	for (const [segment, options] of Object.entries(getPreset(preset ?? "default").segmentOptions ?? {})) {
+		merged[segment as keyof StatusLineSegmentOptions] = { ...(options as Record<string, unknown>) };
+	}
+
+	for (const [segment, options] of Object.entries(user ?? {})) {
+		const current = merged[segment as keyof StatusLineSegmentOptions] ?? {};
+		merged[segment as keyof StatusLineSegmentOptions] = {
+			...(current as Record<string, unknown>),
+			...(options as Record<string, unknown>),
+		};
+	}
+
+	return merged;
+}
 
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -436,16 +436,18 @@ const costSegment: StatusLineSegment = {
 		const advisorCost = ctx.session.getAdvisorCost?.() ?? 0;
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
+		const opts = ctx.options.cost ?? {};
 		const usingSubscription = state.model ? ctx.session.modelRegistry.isUsingOAuth(state.model) : false;
+		const showSubscriptionMarker = usingSubscription && opts.showSubscription !== false;
 
-		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
+		if (!cost && !advisorCost && !showSubscriptionMarker && !normalizedPremiumRequests) {
 			return { content: "", visible: false };
 		}
 
 		const billingParts: string[] = [];
 		if (cost) billingParts.push(`$${cost.toFixed(2)}`);
 		if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
-		if (usingSubscription) billingParts.push("(sub)");
+		if (showSubscriptionMarker) billingParts.push("(sub)");
 		if (advisorCost) billingParts.push(`${billingParts.length ? "+ " : ""}$${advisorCost.toFixed(2)} (adv)`);
 
 		return { content: theme.fg("statusLineCost", billingParts.join(" ")), visible: true };

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -19,6 +19,7 @@ export interface StatusLineSegmentOptions {
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
+	cost?: { showSubscription?: boolean };
 }
 
 export interface StatusLineSettings {

--- a/packages/coding-agent/test/status-line-cost.test.ts
+++ b/packages/coding-agent/test/status-line-cost.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function createCostContext(oauth: boolean, costOptions: SegmentContext["options"]["cost"]): SegmentContext {
+	return {
+		session: {
+			state: { model: { id: "test-model", name: "Test Model" } },
+			modelRegistry: { isUsingOAuth: () => oauth },
+		} as unknown as SegmentContext["session"],
+		width: 120,
+		compactThinkingLevel: false,
+		options: { cost: costOptions },
+		planMode: null,
+		loopMode: null,
+		prewalk: null,
+		goalMode: null,
+		vibeMode: null,
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			orchestrationInput: 0,
+			orchestrationOutput: 0,
+			orchestrationCacheRead: 0,
+			premiumRequests: 0,
+			cost: 1.23,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		activeMs: 0,
+		activeRepo: null,
+		worktree: null,
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+describe("status line cost segment subscription marker", () => {
+	it("shows (sub) for OAuth-billed models by default", () => {
+		const rendered = renderSegment("cost", createCostContext(true, undefined));
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).toContain("(sub)");
+		expect(rendered.content).toContain("$1.23");
+	});
+
+	it("hides (sub) when cost.showSubscription is false, keeping the dollar figure", () => {
+		const rendered = renderSegment("cost", createCostContext(true, { showSubscription: false }));
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).not.toContain("(sub)");
+		expect(rendered.content).toContain("$1.23");
+	});
+
+	it("never shows (sub) for metered models, regardless of the option", () => {
+		const rendered = renderSegment("cost", createCostContext(false, { showSubscription: false }));
+		expect(rendered.content).not.toContain("(sub)");
+		expect(rendered.content).toContain("$1.23");
+	});
+
+	it("collapses to invisible when a zero-spend OAuth session hides the marker", () => {
+		const ctx = createCostContext(true, { showSubscription: false });
+		ctx.usageStats = { ...ctx.usageStats, cost: 0 };
+		const rendered = renderSegment("cost", ctx);
+		expect(rendered.visible).toBe(false);
+	});
+
+	it("keeps the marker-only segment visible with the default option", () => {
+		const ctx = createCostContext(true, undefined);
+		ctx.usageStats = { ...ctx.usageStats, cost: 0 };
+		const rendered = renderSegment("cost", ctx);
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).toContain("(sub)");
+	});
+});

--- a/packages/coding-agent/test/status-line-cost.test.ts
+++ b/packages/coding-agent/test/status-line-cost.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import { mergeSegmentOptions } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/presets";
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -82,5 +83,29 @@ describe("status line cost segment subscription marker", () => {
 		const rendered = renderSegment("cost", ctx);
 		expect(rendered.visible).toBe(true);
 		expect(rendered.content).toContain("(sub)");
+	});
+});
+
+describe("mergeSegmentOptions", () => {
+	it("merges user options over preset defaults per segment", () => {
+		const merged = mergeSegmentOptions("default", { cost: { showSubscription: false } });
+		expect(merged.cost?.showSubscription).toBe(false);
+		// Preset defaults survive alongside user overrides.
+		expect(merged.model?.showThinkingLevel).toBe(true);
+		expect(merged.git?.showStaged).toBe(true);
+	});
+
+	it("applies preset defaults when the user sets nothing", () => {
+		const merged = mergeSegmentOptions("minimal", undefined);
+		expect(merged.git?.showStaged).toBe(false);
+		expect(merged.path?.maxLength).toBe(30);
+		expect(merged.cost).toBeUndefined();
+	});
+
+	it("merges per option key, not per segment bag", () => {
+		const merged = mergeSegmentOptions("default", { git: { showStaged: false } });
+		expect(merged.git?.showStaged).toBe(false);
+		expect(merged.git?.showBranch).toBe(true);
+		expect(merged.git?.showUnstaged).toBe(true);
 	});
 });


### PR DESCRIPTION
## What

Adds `statusLine.segmentOptions.cost.showSubscription` (boolean, default `true`). When `false`, the `(sub)` OAuth/subscription billing marker is hidden in both places it renders — the status-line `cost` segment and the classic footer.

## Why

The marker is a hardcoded literal with no escape hatch: `costSegment` never consults `ctx.options.cost` (`StatusLineSegmentOptions` covers only `model`/`path`/`git`/`time`), it is not a theme `SymbolKey`, and the extension API cannot touch segment rendering, so users who find `(sub)` noise can only remove the whole `cost` segment. The toggle follows the existing `showThinkingLevel`/`showBranch` naming convention; when the marker is hidden on a zero-spend OAuth session with no premium requests or advisor cost, the segment now treats itself as empty and hides entirely instead of rendering a blank slot.

Related: #8247 wants a data-model split of subscription vs direct spend (dormant pending maintainer decisions) — this is display-only and composes with it. #5114 previously tried renaming `(sub)` to `(oauth)` and closed unmerged; this keeps the marker but makes it optional.

## Testing

- New `packages/coding-agent/test/status-line-cost.test.ts` (5 cases): default shows `(sub)` and the dollar figure; `showSubscription: false` hides `(sub)` but keeps `$`; metered (non-OAuth) models never show `(sub)` regardless of the option; a zero-spend OAuth session with the marker hidden renders the segment invisible; the default-option zero-spend case stays visible as today.
- `bun test packages/coding-agent/test/status-line-cost.test.ts packages/coding-agent/test/status-line-model.test.ts packages/coding-agent/test/status-line-settings-cache.test.ts` — 21 pass, 0 fail, 66 assertions.
- `bun run check` (biome + tsgo) clean for `packages/coding-agent`.
- Footer coverage mirrors the segment logic on purpose: main has no footer tests today, and the `settings.getGroup("statusLine").segmentOptions` read path is identical to the one `StatusLineComponent` already uses.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
