### PR TITLE
fix(ai): name selected provider in opencode login prompt

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the OpenCode Go login prompting for an "OpenCode Zen API key": the shared login flow now names the provider you selected, so connecting OpenCode Go asks for an OpenCode Go key (the `opencode.ai/auth` console is still shared, as documented upstream) ([#8738](https://github.com/can1357/oh-my-pi/issues/8738)).
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/ai/src/registry/oauth/opencode.ts
+++ b/packages/ai/src/registry/oauth/opencode.ts
@@ -1,11 +1,12 @@
 /**
- * OpenCode Zen login flow.
+ * OpenCode login flow, shared by the OpenCode Zen and OpenCode Go providers.
  *
- * OpenCode Zen is a subscription service that provides access to various AI models
- * (GPT-5.x, Claude 4.x, Gemini 3, etc.) through a unified API at opencode.ai/zen.
- * This is not OAuth - it's a simple API key flow:
+ * Both are subscription services whose API keys are issued from the same
+ * OpenCode Zen console at https://opencode.ai/auth — OpenCode Go keys are
+ * minted there after subscribing to Go (see https://opencode.ai/docs/go).
+ * This is not OAuth; it's a simple paste-the-API-key flow:
  * 1. Open browser to https://opencode.ai/auth
- * 2. User logs in and copies their API key
+ * 2. User logs in (and subscribes to Go, for OpenCode Go) and copies the key
  * 3. User pastes the API key back into the CLI
  */
 
@@ -14,26 +15,39 @@ import type { OAuthController } from "./types";
 
 const AUTH_URL = "https://opencode.ai/auth";
 
+/** Fallback display name when a provider doesn't pass its own. */
+const DEFAULT_PROVIDER_NAME = "OpenCode Zen";
+
 /**
- * Login to OpenCode Zen.
+ * Log in to an OpenCode subscription provider.
  *
- * Opens browser to auth page, prompts user to paste their API key.
- * Returns the API key directly (not OAuthCredentials - this isn't OAuth).
+ * Opens the browser to the OpenCode Zen console, prompts the user to paste
+ * their API key, and returns it directly (not OAuthCredentials — this isn't
+ * OAuth).
+ *
+ * @param providerName Display name of the provider being connected
+ *   ("OpenCode Zen" or "OpenCode Go"). Used verbatim in the paste prompt so
+ *   the CLI reflects the provider the user actually selected instead of always
+ *   asking for a Zen key.
  */
-export async function loginOpenCode(options: OAuthController): Promise<string> {
+export async function loginOpenCode(
+	options: OAuthController,
+	providerName: string = DEFAULT_PROVIDER_NAME,
+): Promise<string> {
 	if (!options.onPrompt) {
-		throw new AIError.OnPromptRequiredError("OpenCode Zen");
+		throw new AIError.OnPromptRequiredError(providerName);
 	}
 
-	// Open browser to auth page
+	// Open browser to auth page. Go keys are minted from the same Zen console
+	// after subscribing to Go, so the URL is identical for both providers.
 	options.onAuth?.({
 		url: AUTH_URL,
-		instructions: "Log in and copy your API key",
+		instructions: `Log in to the OpenCode Zen console and copy your ${providerName} API key`,
 	});
 
 	// Prompt user to paste their API key
 	const apiKey = await options.onPrompt({
-		message: "Paste your OpenCode Zen API key",
+		message: `Paste your ${providerName} API key`,
 		placeholder: "sk-...",
 	});
 

--- a/packages/ai/src/registry/opencode-go.ts
+++ b/packages/ai/src/registry/opencode-go.ts
@@ -7,6 +7,6 @@ export const opencodeGoProvider = {
 	login: async (cb: OAuthLoginCallbacks) => {
 		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
 		const { loginOpenCode } = await import("./oauth/opencode");
-		return loginOpenCode(cb);
+		return loginOpenCode(cb, "OpenCode Go");
 	},
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/opencode-zen.ts
+++ b/packages/ai/src/registry/opencode-zen.ts
@@ -7,6 +7,6 @@ export const opencodeZenProvider = {
 	login: async (cb: OAuthLoginCallbacks) => {
 		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
 		const { loginOpenCode } = await import("./oauth/opencode");
-		return loginOpenCode(cb);
+		return loginOpenCode(cb, "OpenCode Zen");
 	},
 } as const satisfies ProviderDefinition;

--- a/packages/ai/test/opencode-login.test.ts
+++ b/packages/ai/test/opencode-login.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import type { OAuthAuthInfo, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/registry/oauth/types";
+import { opencodeGoProvider } from "@oh-my-pi/pi-ai/registry/opencode-go";
+import { opencodeZenProvider } from "@oh-my-pi/pi-ai/registry/opencode-zen";
+
+/**
+ * Regression for #8738: `opencode-go` and `opencode-zen` share the same
+ * `loginOpenCode` helper. It used to hardcode "OpenCode Zen" in the paste
+ * prompt, so selecting OpenCode Go asked the user for an OpenCode Zen key.
+ * The prompt (and browser instructions) must name the provider the user
+ * actually selected.
+ */
+function captureLogin(): { callbacks: OAuthLoginCallbacks; seen: { auth?: OAuthAuthInfo; message?: string } } {
+	const seen: { auth?: OAuthAuthInfo; message?: string } = {};
+	const callbacks: OAuthLoginCallbacks = {
+		onAuth: info => {
+			seen.auth = info;
+		},
+		onPrompt: async prompt => {
+			seen.message = prompt.message;
+			return "sk-test-key";
+		},
+	};
+	return { callbacks, seen };
+}
+
+describe("OpenCode login prompt (#8738)", () => {
+	it("asks for an OpenCode Go key when connecting OpenCode Go", async () => {
+		const { callbacks, seen } = captureLogin();
+		const key = await opencodeGoProvider.login(callbacks);
+
+		expect(key).toBe("sk-test-key");
+		expect(seen.message).toBe("Paste your OpenCode Go API key");
+		expect(seen.message).not.toContain("Zen");
+		// Go keys are minted from the same Zen console, so the URL is shared,
+		// but the instructions must still reference the selected provider.
+		expect(seen.auth?.url).toBe("https://opencode.ai/auth");
+		expect(seen.auth?.instructions).toContain("OpenCode Go API key");
+	});
+
+	it("asks for an OpenCode Zen key when connecting OpenCode Zen", async () => {
+		const { callbacks, seen } = captureLogin();
+		const key = await opencodeZenProvider.login(callbacks);
+
+		expect(key).toBe("sk-test-key");
+		expect(seen.message).toBe("Paste your OpenCode Zen API key");
+		expect(seen.auth?.url).toBe("https://opencode.ai/auth");
+	});
+
+	it("rejects an empty pasted key", async () => {
+		const callbacks: OAuthLoginCallbacks = {
+			onAuth: () => {},
+			onPrompt: async () => "   ",
+		};
+		await expect(opencodeGoProvider.login(callbacks)).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## Repro
Connecting the **OpenCode Go** provider prompts for an **OpenCode Zen** API key. Invoking the flow directly (`opencodeGoProvider.login`) shows the mismatch:

```
provider selected: OpenCode Go (opencode-go)
redirect url     : https://opencode.ai/auth
prompt message   : "Paste your OpenCode Zen API key"
```

The redirect to `opencode.ai/auth` is correct and upstream-documented — Go keys are minted from the OpenCode Zen console after subscribing to Go (https://opencode.ai/docs/go/#how-it-works). Only the prompt label was wrong.

## Cause
`opencodeGoProvider` and `opencodeZenProvider` (`packages/ai/src/registry/opencode-go.ts`, `opencode-zen.ts`) both delegate to the shared `loginOpenCode` helper in `packages/ai/src/registry/oauth/opencode.ts`, which hardcoded `message: "Paste your OpenCode Zen API key"` and generic instructions. The helper had no knowledge of which provider called it, so OpenCode Go always displayed the Zen label.

## Fix
- `loginOpenCode` now takes a `providerName` argument (defaulting to `"OpenCode Zen"`) and interpolates it into both the paste prompt and the browser instructions.
- `opencodeGoProvider` passes `"OpenCode Go"`; `opencodeZenProvider` passes `"OpenCode Zen"` explicitly for symmetry.
- Instructions now clarify the shared console: `Log in to the OpenCode Zen console and copy your <provider> API key`.
- Added `packages/ai/test/opencode-login.test.ts` asserting each provider prompts for its own key (and that Go's prompt never says "Zen"), plus the empty-key rejection.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test test/opencode-login.test.ts` → 3 pass, 0 fail. `bun check` → all packages exit 0. Manual: driving `opencodeGoProvider.login` now yields `prompt="Paste your OpenCode Go API key"` while `opencodeZenProvider.login` yields `"Paste your OpenCode Zen API key"`, both opening `https://opencode.ai/auth`.

Fixes #8738