### PR TITLE
fix(biome): add .css to default fileTypes for CSS language support

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added `providers.cacheRetention` setting (`/settings` → Providers → Protocol) to control prompt-cache retention per request: `auto` keeps the provider default (Anthropic: 5m entries with idle keep-alive refreshes), `short` forces 5m, `long` restores 1h TTLs where supported and disables the keep-alive refresh loop, `none` disables prompt caching.
 
+### Fixed
+
+- Added `.css` to the built-in Biome server `fileTypes` so CSS files route through Biome's linter/asserter by default instead of requiring a full per-project `fileTypes` override. ([#8741](https://github.com/can1357/oh-my-pi/pull/8741))
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -69,7 +69,7 @@
 	"biome": {
 		"command": "biome",
 		"args": ["lsp-proxy"],
-		"fileTypes": [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json", ".jsonc"],
+		"fileTypes": [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json", ".jsonc", ".css"],
 		"rootMarkers": ["biome.json", "biome.jsonc"],
 		"isLinter": true
 	},


### PR DESCRIPTION
Biome 2.x fully supports CSS parsing, formatting, linting, and assist actions via its CLI and LSP proxy. The built-in Biome client config did not include `.css` in its `fileTypes` array, causing OMP to skip Biome for CSS files even when the project's `biome.json` enables CSS rules.

This change adds `.css` to the default `fileTypes` so that projects with CSS files automatically route through Biome without needing a per-project override of the full `fileTypes` array.

Closes #8735