### PR TITLE
fix(smoke-test): use private runtime root and add daemon-scope guard

### DIFF
--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -516,8 +516,11 @@ export async function closeDaemonClients(): Promise<void> {
 
 /** Exercise worker-host broker startup and authenticated RPC for distribution smoke tests. */
 export async function smokeTestDaemonBroker(): Promise<void> {
-	const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-daemon-smoke-project-"));
-	const runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-daemon-smoke-run-"));
+	const smokeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-daemon-smoke-"));
+	const projectDir = path.join(smokeRoot, "project");
+	const runtimeDir = path.join(smokeRoot, "run");
+	await fs.mkdir(projectDir, { recursive: true });
+	await fs.mkdir(runtimeDir, { recursive: true });
 	const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
 	try {
 		const ping = await client.request({ op: "ping" });
@@ -525,7 +528,6 @@ export async function smokeTestDaemonBroker(): Promise<void> {
 		await client.request({ op: "shutdown" });
 	} finally {
 		client.close();
-		await fs.rm(projectDir, { recursive: true, force: true });
-		await fs.rm(runtimeDir, { recursive: true, force: true });
+		await fs.rm(smokeRoot, { recursive: true, force: true });
 	}
 }

--- a/packages/coding-agent/src/launch/presence.ts
+++ b/packages/coding-agent/src/launch/presence.ts
@@ -120,6 +120,27 @@ async function hasLiveDaemonBroker(runtimeDir: string): Promise<boolean> {
  * for {@link DAEMON_RUNTIME_STALE_GRACE_MS}. The caller's own `currentRuntimeDir`
  * and the machine-global daemon container are always skipped.
  */
+/** Whether a directory looks like a daemon runtime scope, guarding against
+ * accidental deletion of unrelated directories during sibling sweep.
+ * Checks for the presence of broker.pid or the clients/ subdirectory. */
+async function isDaemonRuntimeDir(dir: string): Promise<boolean> {
+	try {
+		const hasBrokerPid = await fs.stat(path.join(dir, BROKER_PID_FILE)).then(
+			() => true,
+			() => false,
+		);
+		if (hasBrokerPid) return true;
+		const hasClients = await fs.stat(path.join(dir, CLIENTS_DIR)).then(
+			() => true,
+			() => false,
+		);
+		if (hasClients) return true;
+		return false;
+	} catch {
+		return false;
+	}
+}
+
 export async function pruneDeadDaemonRuntimeDirs(currentRuntimeDir: string): Promise<void> {
 	const root = path.dirname(currentRuntimeDir);
 	if (path.basename(root) === GLOBAL_DAEMON_DIR) return;
@@ -146,6 +167,10 @@ export async function pruneDeadDaemonRuntimeDirs(currentRuntimeDir: string): Pro
 			if (now - stat.mtimeMs < DAEMON_RUNTIME_STALE_GRACE_MS) continue;
 			if (await hasLiveDaemonBroker(dir)) continue;
 			if (await hasLiveDaemonProjectPresence(dir)) continue;
+			// Defense in depth: only delete directories that look like daemon scopes.
+			// Without this check, a smoke-test runtime dir under os.tmpdir() causes
+			// the sweep to rm -rf arbitrary neighbouring directories (issue #8721).
+			if (!(await isDaemonRuntimeDir(dir))) continue;
 			await fs.rm(dir, { recursive: true, force: true });
 		} catch (error) {
 			if (isEnoent(error)) continue;


### PR DESCRIPTION
Two complementary fixes for the `omp --smoke-test` directory deletion bug (issue #8721):

### Fix 1: Private smoke-test runtime root (`client.ts`)

`smokeTestDaemonBroker` now creates a single private root directory under `os.tmpdir()` and places both `projectDir` and `runtimeDir` inside it. This keeps `path.dirname(runtimeDir)` scoped to the smoke-owned root instead of `os.tmpdir()` itself, preventing the daemon lifecycle sweep from inspecting unrelated directories in `/tmp`.

### Fix 2: Daemon-scope guard in `pruneDeadDaemonRuntimeDirs` (`presence.ts`)

Adds an `isDaemonRuntimeDir` guard that checks for the presence of `broker.pid` or `clients/` markers before deleting a directory. Without this, any directory adjacent to the current runtime dir that happens to be old, broker-less, and presence-less gets recursively removed — providing defense in depth for any future caller that passes a runtime dir from outside the state root.

Fixes #8721