### PR TITLE
feat(auth): add Kiro OAuth provider

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -568,6 +568,8 @@ Current no-op methods in this controller:
 
 `setEditorComponent` is wired to the live editor (`ctx.setEditorComponent(factory)`). `setWidget` renders real widget components above or below the editor via `setHookWidget(...)` (`placement: "aboveEditor" | "belowEditor"`; string-array content capped at 10 lines).
 
+`setStatusLine(key, text)` renders compact extension-owned billing/metering text inside the main top-border status line, beside the built-in cost segment. Unlike `setStatus`, it does not allocate a separate hook-status row. Pass `undefined` to clear the keyed value.
+
 ### RPC mode (`rpc-mode.ts`)
 
 `ctx.ui` is backed by RPC `extension_ui_request` events:
@@ -581,6 +583,7 @@ Unsupported/no-op in RPC implementation:
 - `custom`
 - `setFooter`, `setHeader`, `setEditorComponent`, `addAutocompleteProvider`
 - `setWorkingMessage`
+- `setStatusLine`
 - theme switching/loading (`setTheme` returns failure)
 - tool expansion controls are inert
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -145,6 +145,10 @@
 - Fixed `retry.usageReservePct` (Reserve Margin) ignoring Claude Fable/Mythos weekly tier usage until it hit 100%, so a Fable model kept serving turns past the configured reserve; reserve health now honors the mapped tier row while credential-wide hard blocks still require confirmed exhaustion ([#8773](https://github.com/can1357/oh-my-pi/issues/8773)).
 - Fixed `cursor-agent` streams stalling with "Provider stream stalled while waiting for the next event" when Cursor asked the client to approve a hosted WebFetch / web search (reproduced on `cursor-grok-4.6-xhigh` after "I'll fetch the page…"). Those `interaction_query` frames — including the newer WebFetch field 9 this proto did not name — were dropped, so the server waited forever and the idle watchdog aborted a live connection. Permission queries are now answered; hosted search/fetch is approved, unnamed permission fields get an `approved` reply on the same field number, and prompts this client cannot serve are rejected so the turn can continue.
 
+### Added
+
+- Added first-party Kiro support with AWS IAM Identity Center device-code login, token refresh, and native streaming ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 ### Fixed
 
 - Fixed thinking effort selections being ignored for local Qwen 3.8+ models on llama.cpp and vLLM: the Qwen chat-completions dialects only toggled `enable_thinking`, so the chat template always reasoned at its `xhigh` default no matter which level was selected. The encoder now routes the requested effort onto the template's `reasoning_effort` kwarg (`chat_template_kwargs` for both Qwen dialects, plus the top-level field newer llama.cpp builds map natively).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added first-party Kiro support with AWS IAM Identity Center device-code login, token refresh, native streaming, and a `credits` usage unit for account quota reporting ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added
@@ -144,10 +148,6 @@
 - Fixed Anthropic-compatible endpoints with strict prompt validation (e.g. Z.AI GLM `api.z.ai/api/anthropic`, which rejects the whole request with `400 code 1213 "The prompt parameter was not received normally"`) failing sessions once a tool returned empty output on a vision-capable model: empty successful `tool_result` blocks now encode as `content: ""` instead of `content: []`, which both the official API and strict compatible endpoints accept.
 - Fixed `retry.usageReservePct` (Reserve Margin) ignoring Claude Fable/Mythos weekly tier usage until it hit 100%, so a Fable model kept serving turns past the configured reserve; reserve health now honors the mapped tier row while credential-wide hard blocks still require confirmed exhaustion ([#8773](https://github.com/can1357/oh-my-pi/issues/8773)).
 - Fixed `cursor-agent` streams stalling with "Provider stream stalled while waiting for the next event" when Cursor asked the client to approve a hosted WebFetch / web search (reproduced on `cursor-grok-4.6-xhigh` after "I'll fetch the page…"). Those `interaction_query` frames — including the newer WebFetch field 9 this proto did not name — were dropped, so the server waited forever and the idle watchdog aborted a live connection. Permission queries are now answered; hosted search/fetch is approved, unnamed permission fields get an `approved` reply on the same field number, and prompts this client cannot serve are rejected so the turn can continue.
-
-### Added
-
-- Added first-party Kiro support with AWS IAM Identity Center device-code login, token refresh, and native streaming ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
 
 ### Fixed
 

--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -6,6 +6,7 @@
  */
 
 import * as AIError from "./error";
+import { streamKiro } from "./providers/kiro";
 import type {
 	Api,
 	AssistantMessageEventStream,
@@ -60,6 +61,16 @@ export interface RegisteredCustomApi {
 
 const customApiRegistry = new Map<string, RegisteredCustomApi>();
 
+const BUILTIN_CUSTOM_APIS: ReadonlyMap<string, RegisteredCustomApi> = new Map([
+	[
+		"kiro-api",
+		{
+			stream: streamKiro,
+			streamSimple: streamKiro,
+		},
+	],
+]);
+
 function assertCustomApiName(api: string): void {
 	if (BUILTIN_APIS.has(api as KnownApi)) {
 		throw new AIError.ConfigurationError(`Cannot register custom API "${api}": built-in API names are reserved.`);
@@ -87,7 +98,7 @@ export function registerCustomApi(
  * Get a custom API provider by API identifier.
  */
 export function getCustomApi(api: string): RegisteredCustomApi | undefined {
-	return customApiRegistry.get(api);
+	return customApiRegistry.get(api) ?? BUILTIN_CUSTOM_APIS.get(api);
 }
 
 /**

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -208,7 +208,7 @@ const usageAmountSchema = type({
 	"remaining?": "number",
 	"usedFraction?": "number",
 	"remainingFraction?": "number",
-	unit: "'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'unknown'",
+	unit: "'percent' | 'tokens' | 'requests' | 'credits' | 'usd' | 'minutes' | 'bytes' | 'unknown'",
 });
 
 const usageScopeSchema = type({

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5437,18 +5437,9 @@ export class AuthStorage {
 			}
 			if (!result) return undefined;
 			const updated: OAuthCredential = {
+				...selection.credential,
+				...result.newCredentials,
 				type: "oauth",
-				access: result.newCredentials.access,
-				refresh: result.newCredentials.refresh,
-				expires: result.newCredentials.expires,
-				accountId: result.newCredentials.accountId ?? selection.credential.accountId,
-				email: result.newCredentials.email ?? selection.credential.email,
-				projectId: result.newCredentials.projectId ?? selection.credential.projectId,
-				enterpriseUrl: result.newCredentials.enterpriseUrl ?? selection.credential.enterpriseUrl,
-				apiEndpoint: result.newCredentials.apiEndpoint ?? selection.credential.apiEndpoint,
-				orgId: result.newCredentials.orgId ?? selection.credential.orgId,
-				orgName: result.newCredentials.orgName ?? selection.credential.orgName,
-				authorizedAt: result.newCredentials.authorizedAt ?? selection.credential.authorizedAt,
 			};
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);
@@ -5557,6 +5548,17 @@ export class AuthStorage {
 						token: oauthSelection.credential.access,
 						enterpriseUrl: oauthSelection.credential.enterpriseUrl,
 						apiEndpoint: oauthSelection.credential.apiEndpoint,
+					});
+				}
+				if (provider === "kiro") {
+					const credential = oauthSelection.credential as OAuthCredentials & {
+						region?: string;
+						profileArn?: string;
+					};
+					return JSON.stringify({
+						token: credential.access,
+						region: credential.region,
+						profileArn: credential.profileArn,
 					});
 				}
 				return oauthSelection.credential.access;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5438,8 +5438,19 @@ export class AuthStorage {
 			if (!result) return undefined;
 			const updated: OAuthCredential = {
 				...selection.credential,
-				...result.newCredentials,
+				...(provider === "kiro" ? result.newCredentials : {}),
 				type: "oauth",
+				access: result.newCredentials.access,
+				refresh: result.newCredentials.refresh,
+				expires: result.newCredentials.expires,
+				accountId: result.newCredentials.accountId ?? selection.credential.accountId,
+				email: result.newCredentials.email ?? selection.credential.email,
+				projectId: result.newCredentials.projectId ?? selection.credential.projectId,
+				enterpriseUrl: result.newCredentials.enterpriseUrl ?? selection.credential.enterpriseUrl,
+				apiEndpoint: result.newCredentials.apiEndpoint ?? selection.credential.apiEndpoint,
+				orgId: result.newCredentials.orgId ?? selection.credential.orgId,
+				orgName: result.newCredentials.orgName ?? selection.credential.orgName,
+				authorizedAt: result.newCredentials.authorizedAt ?? selection.credential.authorizedAt,
 			};
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3600,6 +3600,7 @@ export class AuthStorage {
 
 	async #collectUsageRequests(options?: {
 		baseUrlResolver?: (provider: Provider) => string | undefined;
+		providers?: ReadonlySet<Provider>;
 	}): Promise<UsageRequestDescriptor[]> {
 		const requests: UsageRequestDescriptor[] = [];
 		const providers = new Set<string>([
@@ -3610,6 +3611,7 @@ export class AuthStorage {
 
 		for (const providerId of providers) {
 			const provider = providerId as Provider;
+			if (options?.providers && !options.providers.has(provider)) continue;
 			const providerImpl = this.#resolveUsageProvider(provider);
 			if (!providerImpl) continue;
 			const baseUrl = options?.baseUrlResolver?.(provider);
@@ -4155,7 +4157,26 @@ export class AuthStorage {
 				});
 				this.#usageReportsInFlight.set(overrideKey, shared);
 			}
-			const reports = await raceUsageWithSignal(shared, options?.signal);
+			const brokerReports = await raceUsageWithSignal(shared, options?.signal);
+			let reports = brokerReports;
+			if (
+				this.#fetchUsageReportsOverride === undefined &&
+				storeOverride !== undefined &&
+				this.#runtimeUsageProviderOverrides.size > 0
+			) {
+				const runtimeProviders = new Set(this.#runtimeUsageProviderOverrides.keys());
+				const runtimeRequests = await this.#collectUsageRequests({
+					...options,
+					providers: runtimeProviders,
+				});
+				const forcedRefresh = this.#usageForceRefresh(runtimeRequests);
+				const runtimeResults = await this.#fetchUsageRequests(runtimeRequests, forcedRefresh.providers);
+				this.#clearUsageForceRefresh(forcedRefresh);
+				reports = this.#dedupeUsageReports([
+					...(brokerReports ?? []),
+					...runtimeResults.filter((report): report is UsageReport => report !== null),
+				]);
+			}
 			if (shouldReconcileStoreHookReports && reports) this.#reconcileCodexUsageBlocksFromReports(reports);
 			return reports;
 		}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -114,6 +114,22 @@ export type OAuthCredential = {
 	type: "oauth";
 } & OAuthCredentials;
 
+function mergeOAuthCredential(current: OAuthCredential, refreshed: OAuthCredentials): OAuthCredential {
+	return {
+		...current,
+		...refreshed,
+		type: "oauth",
+		accountId: refreshed.accountId ?? current.accountId,
+		email: refreshed.email ?? current.email,
+		projectId: refreshed.projectId ?? current.projectId,
+		enterpriseUrl: refreshed.enterpriseUrl ?? current.enterpriseUrl,
+		apiEndpoint: refreshed.apiEndpoint ?? current.apiEndpoint,
+		orgId: refreshed.orgId ?? current.orgId,
+		orgName: refreshed.orgName ?? current.orgName,
+		authorizedAt: refreshed.authorizedAt ?? current.authorizedAt,
+	};
+}
+
 export type AuthCredential = ApiKeyCredential | OAuthCredential;
 
 export type AuthCredentialEntry = AuthCredential | AuthCredential[];
@@ -4940,11 +4956,7 @@ export class AuthStorage {
 						credentialId,
 						options?.signal,
 					);
-					const updated: OAuthCredential = {
-						...candidate.selection.credential,
-						...refreshedCredentials,
-						type: "oauth",
-					};
+					const updated = mergeOAuthCredential(candidate.selection.credential, refreshedCredentials);
 					candidate.selection.credential = updated;
 					if (credentialId !== undefined) {
 						const idx = this.#replaceCredentialById(provider, credentialId, updated);
@@ -5436,22 +5448,7 @@ export class AuthStorage {
 				result = await getOAuthApiKey(provider as OAuthProvider, oauthCreds);
 			}
 			if (!result) return undefined;
-			const updated: OAuthCredential = {
-				...selection.credential,
-				...(provider === "kiro" ? result.newCredentials : {}),
-				type: "oauth",
-				access: result.newCredentials.access,
-				refresh: result.newCredentials.refresh,
-				expires: result.newCredentials.expires,
-				accountId: result.newCredentials.accountId ?? selection.credential.accountId,
-				email: result.newCredentials.email ?? selection.credential.email,
-				projectId: result.newCredentials.projectId ?? selection.credential.projectId,
-				enterpriseUrl: result.newCredentials.enterpriseUrl ?? selection.credential.enterpriseUrl,
-				apiEndpoint: result.newCredentials.apiEndpoint ?? selection.credential.apiEndpoint,
-				orgId: result.newCredentials.orgId ?? selection.credential.orgId,
-				orgName: result.newCredentials.orgName ?? selection.credential.orgName,
-				authorizedAt: result.newCredentials.authorizedAt ?? selection.credential.authorizedAt,
-			};
+			const updated = mergeOAuthCredential(selection.credential, result.newCredentials);
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);
 				if (idx !== -1) selection.index = idx;
@@ -6702,20 +6699,7 @@ export class AuthStorage {
 				}
 				throw error;
 			}
-			const updated: OAuthCredential = {
-				type: "oauth",
-				access: refreshed.access,
-				refresh: refreshed.refresh,
-				expires: refreshed.expires,
-				accountId: refreshed.accountId ?? attempted.accountId,
-				email: refreshed.email ?? attempted.email,
-				projectId: refreshed.projectId ?? attempted.projectId,
-				enterpriseUrl: refreshed.enterpriseUrl ?? attempted.enterpriseUrl,
-				apiEndpoint: refreshed.apiEndpoint ?? attempted.apiEndpoint,
-				orgId: refreshed.orgId ?? attempted.orgId,
-				orgName: refreshed.orgName ?? attempted.orgName,
-				authorizedAt: refreshed.authorizedAt ?? attempted.authorizedAt,
-			};
+			const updated = mergeOAuthCredential(attempted, refreshed);
 			// Persist by id: the array may have been reordered/shrunk while the
 			// refresh was in flight, so the pre-await positional index is unsafe. A
 			// -1 means the row was disabled/removed mid-refresh — surface that as a

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -18,6 +18,7 @@ export type * from "./providers/google";
 export type * from "./providers/google-gemini-cli";
 export type * from "./providers/google-vertex";
 export * from "./providers/kimi";
+export * from "./providers/kiro";
 export * from "./providers/mock";
 export * from "./providers/ollama";
 export * from "./providers/openai-codex-responses";

--- a/packages/ai/src/providers/kiro-eventstream.ts
+++ b/packages/ai/src/providers/kiro-eventstream.ts
@@ -1,0 +1,169 @@
+const PRELUDE_LENGTH = 12;
+const MESSAGE_CRC_LENGTH = 4;
+const MIN_MESSAGE_LENGTH = PRELUDE_LENGTH + MESSAGE_CRC_LENGTH;
+
+export interface KiroEventStreamMessage {
+	headers: Record<string, string>;
+	payload: Uint8Array;
+}
+
+const CRC_TABLE = new Uint32Array(256);
+for (let index = 0; index < CRC_TABLE.length; index++) {
+	let value = index;
+	for (let bit = 0; bit < 8; bit++) value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+	CRC_TABLE[index] = value >>> 0;
+}
+
+export function crc32(bytes: Uint8Array): number {
+	let value = 0xffffffff;
+	for (const byte of bytes) value = CRC_TABLE[(value ^ byte) & 0xff] ^ (value >>> 8);
+	return (value ^ 0xffffffff) >>> 0;
+}
+
+export function decodeKiroEventStreamMessage(frame: Uint8Array): KiroEventStreamMessage {
+	if (frame.length < MIN_MESSAGE_LENGTH) throw new Error("Kiro event stream frame is too short");
+	const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+	const totalLength = view.getUint32(0, false);
+	const headersLength = view.getUint32(4, false);
+	if (totalLength !== frame.length) {
+		throw new Error(`Kiro event stream framed length ${totalLength} does not match ${frame.length}`);
+	}
+	if (headersLength > totalLength - MIN_MESSAGE_LENGTH) {
+		throw new Error("Kiro event stream header block exceeds frame");
+	}
+	if (crc32(frame.subarray(0, 8)) !== view.getUint32(8, false)) {
+		throw new Error("Kiro event stream prelude CRC mismatch");
+	}
+	if (crc32(frame.subarray(0, totalLength - MESSAGE_CRC_LENGTH)) !== view.getUint32(totalLength - 4, false)) {
+		throw new Error("Kiro event stream message CRC mismatch");
+	}
+
+	const headersStart = PRELUDE_LENGTH;
+	const headersEnd = headersStart + headersLength;
+	return {
+		headers: parseKiroEventStreamHeaders(frame.subarray(headersStart, headersEnd)),
+		payload: frame.subarray(headersEnd, totalLength - MESSAGE_CRC_LENGTH),
+	};
+}
+
+function parseKiroEventStreamHeaders(bytes: Uint8Array): Record<string, string> {
+	const result: Record<string, string> = {};
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const decoder = new TextDecoder();
+	let offset = 0;
+	const requireBytes = (count: number) => {
+		if (offset + count > bytes.length) throw new Error("Truncated Kiro event stream headers");
+	};
+	while (offset < bytes.length) {
+		requireBytes(1);
+		const nameLength = view.getUint8(offset++);
+		requireBytes(nameLength + 1);
+		const name = decoder.decode(bytes.subarray(offset, offset + nameLength));
+		offset += nameLength;
+		const type = view.getUint8(offset++);
+		switch (type) {
+			case 0:
+				result[name] = "true";
+				break;
+			case 1:
+				result[name] = "false";
+				break;
+			case 2:
+				requireBytes(1);
+				result[name] = String(view.getInt8(offset++));
+				break;
+			case 3:
+				requireBytes(2);
+				result[name] = String(view.getInt16(offset, false));
+				offset += 2;
+				break;
+			case 4:
+				requireBytes(4);
+				result[name] = String(view.getInt32(offset, false));
+				offset += 4;
+				break;
+			case 5:
+				requireBytes(8);
+				result[name] = readSignedBigEndian(bytes.subarray(offset, offset + 8)).toString();
+				offset += 8;
+				break;
+			case 6: {
+				requireBytes(2);
+				const length = view.getUint16(offset, false);
+				offset += 2;
+				requireBytes(length);
+				const headerBytes = bytes.subarray(offset, offset + length);
+				let binary = "";
+				for (const byte of headerBytes) binary += String.fromCharCode(byte);
+				result[name] = btoa(binary);
+				offset += length;
+				break;
+			}
+			case 7: {
+				requireBytes(2);
+				const length = view.getUint16(offset, false);
+				offset += 2;
+				requireBytes(length);
+				result[name] = decoder.decode(bytes.subarray(offset, offset + length));
+				offset += length;
+				break;
+			}
+			case 8:
+				requireBytes(8);
+				result[name] = new Date(Number(readSignedBigEndian(bytes.subarray(offset, offset + 8)))).toISOString();
+				offset += 8;
+				break;
+			case 9:
+				requireBytes(16);
+				result[name] = [...bytes.subarray(offset, offset + 16)]
+					.map(byte => byte.toString(16).padStart(2, "0"))
+					.join("");
+				offset += 16;
+				break;
+			default:
+				throw new Error(`Unknown Kiro event stream header type ${type}`);
+		}
+	}
+	return result;
+}
+
+function readSignedBigEndian(bytes: Uint8Array): bigint {
+	let value = 0n;
+	for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+	if (bytes.length === 8 && (bytes[0] & 0x80) !== 0) value -= 1n << 64n;
+	return value;
+}
+
+export async function* decodeKiroEventStream(
+	source: ReadableStream<Uint8Array>,
+): AsyncGenerator<KiroEventStreamMessage> {
+	const reader = source.getReader();
+	let buffer = new Uint8Array(0);
+	let completed = false;
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (value && value.length > 0) {
+				const next = new Uint8Array(buffer.length + value.length);
+				next.set(buffer);
+				next.set(value, buffer.length);
+				buffer = next;
+			}
+			let offset = 0;
+			while (buffer.length - offset >= 4) {
+				const totalLength = new DataView(buffer.buffer, buffer.byteOffset + offset, 4).getUint32(0, false);
+				if (totalLength < MIN_MESSAGE_LENGTH) throw new Error(`Invalid Kiro event stream length ${totalLength}`);
+				if (buffer.length - offset < totalLength) break;
+				yield decodeKiroEventStreamMessage(buffer.subarray(offset, offset + totalLength));
+				offset += totalLength;
+			}
+			if (offset > 0) buffer = buffer.slice(offset);
+			if (done) break;
+		}
+		if (buffer.length > 0) throw new Error("Truncated Kiro event stream message");
+		completed = true;
+	} finally {
+		if (!completed) await reader.cancel().catch(() => {});
+		reader.releaseLock();
+	}
+}

--- a/packages/ai/src/providers/kiro.ts
+++ b/packages/ai/src/providers/kiro.ts
@@ -551,6 +551,33 @@ export async function fetchKiroModelsForCredential(
 	return mapKiroCatalogToModelSpecs(response.models, region).map(model => ({ ...model, kiroProfileArn: profileArn }));
 }
 
+const INVALID_TOOL_USE_FORMAT = "invalid tool use format";
+
+function extractKiroErrorDetail(payload: unknown, token: string, profileArn: string): string {
+	const record = asRecord(payload);
+	if (!record) return "";
+	const candidate = [record.message, record.reason, record.error].find(
+		(value): value is string => typeof value === "string" && value.trim().length > 0,
+	);
+	if (!candidate) return "";
+	return candidate
+		.replace(/\s+/g, " ")
+		.split(token)
+		.join("[redacted]")
+		.split(profileArn)
+		.join("[redacted]")
+		.slice(0, 300);
+}
+
+async function readKiroErrorResponse(response: Response, token: string, profileArn: string): Promise<string> {
+	try {
+		return extractKiroErrorDetail(await response.json(), token, profileArn);
+	} catch {
+		// Some runtime errors return an empty or non-JSON body.
+		return "";
+	}
+}
+
 export function streamKiro(
 	model: Model<Api>,
 	context: Context,
@@ -592,47 +619,48 @@ export function streamKiro(
 			);
 			const payload = (await options.onPayload?.(request, model)) ?? request;
 			const endpoint = new URL("generateAssistantResponse", `https://runtime.${region}.kiro.dev/`).toString();
-			const requestId = crypto.randomUUID();
-			const userAgent = `${USER_AGENT} ${requestId}`;
-			const response = await fetchFn(endpoint, {
-				method: "POST",
-				headers: {
-					...(model.headers ?? {}),
-					...(options.headers ?? {}),
-					"Content-Type": "application/json",
-					Accept: "application/vnd.amazon.eventstream",
-					Authorization: `Bearer ${structured.token}`,
-					"x-amzn-kiro-profile-arn": profileArn,
-					"x-amzn-codewhisperer-optout": "true",
-					"amz-sdk-invocation-id": requestId,
-					"amz-sdk-request": "attempt=1; max=1",
-					"x-amzn-kiro-agent-mode": "vibe",
-					"x-amz-user-agent": userAgent,
-					"user-agent": userAgent,
-				},
-				body: JSON.stringify(payload),
-				signal: options.signal,
-			});
-			if (!response.ok) {
-				output.errorStatus = response.status;
-				let detail = "";
-				try {
-					const body = (await response.json()) as { message?: unknown; reason?: unknown; error?: unknown };
-					const candidate = [body.message, body.reason, body.error].find(
-						(value): value is string => typeof value === "string" && value.trim().length > 0,
-					);
-					if (candidate) {
-						detail = candidate
-							.replace(/\s+/g, " ")
-							.split(structured.token)
-							.join("[redacted]")
-							.split(profileArn)
-							.join("[redacted]")
-							.slice(0, 300);
-					}
-				} catch {
-					// Some runtime errors return an empty or non-JSON body.
+			const body = JSON.stringify(payload);
+			let response: Response;
+			for (let attempt = 1; ; attempt++) {
+				const requestId = crypto.randomUUID();
+				const userAgent = `${USER_AGENT} ${requestId}`;
+				response = await fetchFn(endpoint, {
+					method: "POST",
+					headers: {
+						...(model.headers ?? {}),
+						...(options.headers ?? {}),
+						"Content-Type": "application/json",
+						Accept: "application/vnd.amazon.eventstream",
+						Authorization: `Bearer ${structured.token}`,
+						"x-amzn-kiro-profile-arn": profileArn,
+						"x-amzn-codewhisperer-optout": "true",
+						"amz-sdk-invocation-id": requestId,
+						"amz-sdk-request": "attempt=1; max=1",
+						"x-amzn-kiro-agent-mode": "vibe",
+						"x-amz-user-agent": userAgent,
+						"user-agent": userAgent,
+					},
+					body,
+					signal: options.signal,
+				});
+				if (response.ok) break;
+				const detail = await readKiroErrorResponse(response, structured.token, profileArn);
+				// The runtime fleet occasionally rejects a fresh remote session's first request
+				// with HTTP 400 "Invalid tool use format." while the same payload succeeds on
+				// replay. Retry exactly once with a fresh request id and identical body;
+				// any other 400 (or an aborted caller) fails immediately.
+				if (
+					attempt === 1 &&
+					response.status === 400 &&
+					!options.signal?.aborted &&
+					detail
+						.trim()
+						.replace(/[.\s]+$/u, "")
+						.toLowerCase() === INVALID_TOOL_USE_FORMAT
+				) {
+					continue;
 				}
+				output.errorStatus = response.status;
 				throw new Error(`Kiro API request failed (HTTP ${response.status})${detail ? `: ${detail}` : ""}`);
 			}
 			if (!response.body) throw new Error("Kiro API returned no event stream body");
@@ -651,19 +679,7 @@ export function streamKiro(
 				if (messageType === "exception" || exceptionType) {
 					let detail = "";
 					try {
-						const parsed = JSON.parse(payloadText) as { message?: unknown; reason?: unknown; error?: unknown };
-						const candidate = [parsed.message, parsed.reason, parsed.error].find(
-							(value): value is string => typeof value === "string" && value.trim().length > 0,
-						);
-						if (candidate) {
-							detail = candidate
-								.replace(/\s+/g, " ")
-								.split(structured.token)
-								.join("[redacted]")
-								.split(profileArn)
-								.join("[redacted]")
-								.slice(0, 300);
-						}
+						detail = extractKiroErrorDetail(JSON.parse(payloadText), structured.token, profileArn);
 					} catch {
 						// Non-JSON exception payloads still surface the exception type below.
 					}

--- a/packages/ai/src/providers/kiro.ts
+++ b/packages/ai/src/providers/kiro.ts
@@ -1,0 +1,669 @@
+import { calculateCost } from "@oh-my-pi/pi-catalog/models";
+import {
+	fetchKiroModelCatalog,
+	getKiroRegionFromEndpoint,
+	type KiroModel,
+	type KiroModelSpec,
+	mapKiroCatalogToModelSpecs,
+	parseKiroApiKey,
+	resolveKiroApiRegion,
+	resolveKiroProfileArn,
+} from "@oh-my-pi/pi-catalog/provider-models/kiro";
+import type {
+	Api,
+	AssistantMessage,
+	Context,
+	ImageContent,
+	Message,
+	Model,
+	SimpleStreamOptions,
+	StreamOptions,
+	TextContent,
+	Tool,
+	ToolCall,
+	ToolResultMessage,
+	Usage,
+} from "../types";
+import { AssistantMessageEventStream } from "../utils/event-stream";
+import { decodeKiroEventStream } from "./kiro-eventstream";
+
+export const KIRO_API = "kiro-api" as const;
+const EMPTY_CONTENT_PLACEHOLDER = "Please proceed with the task.";
+const TOOL_RESULT_LIMIT = 250_000;
+const USER_AGENT = "omp-kiro/1.0";
+
+type KiroToolSpecification = {
+	toolSpecification: {
+		name: string;
+		description: string;
+		inputSchema: { json: Record<string, unknown> };
+	};
+};
+type KiroUserInputMessageContext = {
+	toolResults?: Array<{
+		content: Array<{ text: string }>;
+		status: "success" | "error";
+		toolUseId: string;
+	}>;
+	tools?: KiroToolSpecification[];
+};
+
+export interface KiroUserInputMessage {
+	content: string;
+	modelId: string;
+	origin: "KIRO_CLI";
+	images?: Array<{ format: string; source: { bytes: string } }>;
+	userInputMessageContext?: KiroUserInputMessageContext;
+}
+
+export interface KiroHistoryEntry {
+	userInputMessage?: KiroUserInputMessage;
+	assistantResponseMessage?: {
+		content: string;
+		toolUses?: Array<{ name: string; toolUseId: string; input: Record<string, unknown> }>;
+	};
+}
+
+export interface KiroRequest {
+	profileArn: string;
+	conversationState: {
+		chatTriggerType: "MANUAL";
+		agentTaskType: "vibe";
+		conversationId: string;
+		history?: KiroHistoryEntry[];
+		currentMessage: { userInputMessage: KiroUserInputMessage };
+	};
+	additionalModelRequestFields?: Record<string, unknown>;
+	agentMode: "vibe";
+}
+
+type KiroEvent =
+	| { type: "content"; data: string }
+	| { type: "thinkingText"; data: string }
+	| { type: "thinkingSignature"; data: string }
+	| { type: "toolUse"; data: { name: string; toolUseId: string; input: string; stop?: boolean } }
+	| { type: "toolUseInput"; data: { input: string } }
+	| { type: "toolUseStop"; data: { stop: boolean } }
+	| { type: "contextUsage"; data: { contextUsagePercentage: number } }
+	| { type: "usage"; data: { inputTokens?: number; outputTokens?: number } }
+	| { type: "error"; data: { error: string; message?: string } };
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+export function parseKiroEvent(payload: unknown): KiroEvent | undefined {
+	const parsed = asRecord(payload);
+	if (!parsed) return undefined;
+	if (typeof parsed.content === "string") return { type: "content", data: parsed.content };
+	if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
+	if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
+	if (typeof parsed.name === "string" && typeof parsed.toolUseId === "string") {
+		const inputRecord = asRecord(parsed.input);
+		const input =
+			typeof parsed.input === "string"
+				? parsed.input
+				: inputRecord && Object.keys(inputRecord).length > 0
+					? JSON.stringify(inputRecord)
+					: "";
+		return {
+			type: "toolUse",
+			data: { name: parsed.name, toolUseId: parsed.toolUseId, input, stop: parsed.stop === true },
+		};
+	}
+	if (parsed.input !== undefined && typeof parsed.name !== "string") {
+		return {
+			type: "toolUseInput",
+			data: { input: typeof parsed.input === "string" ? parsed.input : JSON.stringify(parsed.input) },
+		};
+	}
+	if (parsed.stop !== undefined && parsed.contextUsagePercentage === undefined) {
+		return { type: "toolUseStop", data: { stop: parsed.stop === true } };
+	}
+	if (typeof parsed.contextUsagePercentage === "number") {
+		return { type: "contextUsage", data: { contextUsagePercentage: parsed.contextUsagePercentage } };
+	}
+	const rawUsage = asRecord(parsed.usage);
+	if (rawUsage) {
+		return {
+			type: "usage",
+			data: {
+				inputTokens: typeof rawUsage.inputTokens === "number" ? rawUsage.inputTokens : undefined,
+				outputTokens: typeof rawUsage.outputTokens === "number" ? rawUsage.outputTokens : undefined,
+			},
+		};
+	}
+	if (parsed.error !== undefined || parsed.Error !== undefined) {
+		const rawError = parsed.error ?? parsed.Error ?? "unknown";
+		return {
+			type: "error",
+			data: {
+				error: typeof rawError === "string" ? rawError : JSON.stringify(rawError),
+				message:
+					typeof parsed.message === "string"
+						? parsed.message
+						: typeof parsed.reason === "string"
+							? parsed.reason
+							: undefined,
+			},
+		};
+	}
+	return undefined;
+}
+
+function textContent(message: Message): string {
+	if (message.role === "user" || message.role === "developer") {
+		return typeof message.content === "string"
+			? message.content
+			: message.content
+					.filter((block): block is TextContent => block.type === "text")
+					.map(block => block.text)
+					.join("");
+	}
+	if (message.role === "toolResult") {
+		return message.content
+			.filter(block => block.type === "text")
+			.map(block => block.text)
+			.join("");
+	}
+	return message.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map(block => block.text)
+		.join("");
+}
+
+function imagesFromMessage(message: Message): ImageContent[] {
+	if (message.role === "toolResult" || typeof message.content === "string") return [];
+	return message.content.filter((block): block is ImageContent => block.type === "image") as ImageContent[];
+}
+
+function toKiroImages(images: readonly ImageContent[]): Array<{ format: string; source: { bytes: string } }> {
+	return images.map(image => ({
+		format: image.mimeType.split("/", 2)[1] || "png",
+		source: { bytes: image.data },
+	}));
+}
+
+function toKiroTools(tools: readonly Tool[] | undefined): KiroToolSpecification[] | undefined {
+	return tools?.map(tool => ({
+		toolSpecification: {
+			name: tool.name,
+			description: tool.description,
+			inputSchema: { json: tool.parameters as Record<string, unknown> },
+		},
+	}));
+}
+
+function truncate(value: string): string {
+	return value.length <= TOOL_RESULT_LIMIT ? value : value.slice(0, TOOL_RESULT_LIMIT);
+}
+
+function toKiroToolUse(block: ToolCall): { name: string; toolUseId: string; input: Record<string, unknown> } {
+	let input: Record<string, unknown>;
+	if (typeof block.arguments === "string") {
+		try {
+			input = JSON.parse(block.arguments) as Record<string, unknown>;
+		} catch {
+			input = {};
+		}
+	} else {
+		input = block.arguments;
+	}
+	return { name: block.name, toolUseId: block.id, input };
+}
+
+function assistantHistoryEntry(message: Message): KiroHistoryEntry | undefined {
+	if (message.role !== "assistant") return undefined;
+	let content = "";
+	const toolUses: Array<{ name: string; toolUseId: string; input: Record<string, unknown> }> = [];
+	for (const block of message.content) {
+		if (block.type === "text") content += block.text;
+		if (block.type === "toolCall") toolUses.push(toKiroToolUse(block));
+	}
+	if (!content && toolUses.length === 0 && message.content.length === 0) return undefined;
+	return { assistantResponseMessage: { content, ...(toolUses.length > 0 ? { toolUses } : {}) } };
+}
+
+function addToolResults(
+	entry: KiroHistoryEntry | undefined,
+	messages: readonly ToolResultMessage[],
+	modelId: string,
+): KiroHistoryEntry {
+	const results = messages.map(message => ({
+		content: [{ text: truncate(textContent(message)) }],
+		status: message.isError ? ("error" as const) : ("success" as const),
+		toolUseId: message.toolCallId,
+	}));
+	if (entry?.userInputMessage) {
+		entry.userInputMessage.userInputMessageContext ??= {};
+		entry.userInputMessage.userInputMessageContext.toolResults = [
+			...(entry.userInputMessage.userInputMessageContext.toolResults ?? []),
+			...results,
+		];
+		return entry;
+	}
+	return {
+		userInputMessage: {
+			content: "",
+			modelId,
+			origin: "KIRO_CLI",
+			userInputMessageContext: { toolResults: results },
+		},
+	};
+}
+
+function buildHistory(
+	messages: readonly Message[],
+	modelId: string,
+	systemPrompt: readonly string[] | undefined,
+): { history: KiroHistoryEntry[]; currentMessages: Message[] } {
+	if (messages.length === 0) return { history: [], currentMessages: [] };
+	let currentStart = messages.length - 1;
+	while (currentStart > 0 && messages[currentStart]?.role === "toolResult") currentStart--;
+	const currentCandidate = messages[currentStart];
+	if (currentCandidate?.role === "assistant" && !currentCandidate.content.some(block => block.type === "toolCall")) {
+		currentStart++;
+	}
+
+	const historyMessages = messages.slice(0, currentStart);
+	const history: KiroHistoryEntry[] = [];
+	let systemAdded = false;
+	for (let index = 0; index < historyMessages.length; index++) {
+		const message = historyMessages[index];
+		if (!message) continue;
+		if (message.role === "user" || message.role === "developer") {
+			let content = textContent(message);
+			if (systemPrompt?.length && !systemAdded) {
+				content = `${systemPrompt.join("\n\n")}\n\n${content}`;
+				systemAdded = true;
+			}
+			const images = imagesFromMessage(message);
+			const previous = history.at(-1)?.userInputMessage;
+			if (previous) {
+				previous.content =
+					previous.content && content ? `${previous.content}\n\n${content}` : previous.content || content;
+				if (images.length > 0) previous.images = [...(previous.images ?? []), ...toKiroImages(images)];
+			} else {
+				history.push({
+					userInputMessage: {
+						content,
+						modelId,
+						origin: "KIRO_CLI",
+						...(images.length > 0 ? { images: toKiroImages(images) } : {}),
+					},
+				});
+			}
+		} else if (message.role === "assistant") {
+			const entry = assistantHistoryEntry(message);
+			if (entry) history.push(entry);
+		} else if (message.role === "toolResult") {
+			const results: ToolResultMessage[] = [message];
+			let next = index + 1;
+			while (next < historyMessages.length && historyMessages[next]?.role === "toolResult") {
+				results.push(historyMessages[next] as ToolResultMessage);
+				next++;
+			}
+			index = next - 1;
+			const previous = history.at(-1);
+			const carrier = previous?.userInputMessage ? previous : undefined;
+			const nextEntry = addToolResults(carrier, results, modelId);
+			if (!carrier) history.push(nextEntry);
+		}
+	}
+	return { history, currentMessages: messages.slice(currentStart) };
+}
+
+function buildAdditionalModelRequestFields(
+	model: KiroModel,
+	reasoning: SimpleStreamOptions["reasoning"],
+): Record<string, unknown> | undefined {
+	if (!reasoning || !model.reasoning) return undefined;
+	const schemaRecord = asRecord(model.additionalModelRequestFieldsSchema);
+	const properties = asRecord(schemaRecord?.properties);
+	const values = (field: string): string[] => {
+		const fieldSchema = asRecord(properties?.[field]);
+		const fieldProperties = asRecord(fieldSchema?.properties);
+		const effortSchema = asRecord(fieldProperties?.effort);
+		return Array.isArray(effortSchema?.enum)
+			? effortSchema.enum.filter((value): value is string => typeof value === "string")
+			: [];
+	};
+	const requested = reasoning === "minimal" ? "low" : reasoning;
+	const pick = (allowed: string[]) => (allowed.includes(requested) ? requested : (allowed.at(-1) ?? requested));
+	const reasoningValues = values("reasoning");
+	if (reasoningValues.length > 0) return { reasoning: { effort: pick(reasoningValues) } };
+	const outputValues = values("output_config");
+	if (outputValues.length > 0) {
+		return {
+			output_config: { effort: pick(outputValues) },
+			thinking: { type: "adaptive", display: "summarized" },
+		};
+	}
+	return undefined;
+}
+
+export function buildKiroRequest(
+	model: KiroModel,
+	context: Context,
+	profileArn: string,
+	conversationId: string,
+	reasoning?: SimpleStreamOptions["reasoning"],
+): KiroRequest {
+	const modelId = model.kiroModelId ?? model.id;
+	const { history, currentMessages } = buildHistory(context.messages, modelId, context.systemPrompt);
+	const first = currentMessages[0];
+	let content = "";
+	let images: ImageContent[] = [];
+	const toolResults: ToolResultMessage[] = [];
+	if (first?.role === "assistant") {
+		const entry = assistantHistoryEntry(first);
+		if (entry) history.push(entry);
+		for (const message of currentMessages.slice(1)) if (message.role === "toolResult") toolResults.push(message);
+	} else if (first?.role === "toolResult") {
+		for (const message of currentMessages) if (message.role === "toolResult") toolResults.push(message);
+	} else if (first?.role === "user" || first?.role === "developer") {
+		content = textContent(first);
+		images = imagesFromMessage(first);
+		if (context.systemPrompt?.length && history.length === 0)
+			content = `${context.systemPrompt.join("\n\n")}\n\n${content}`;
+	}
+	const tools = toKiroTools(context.tools);
+	const currentContext: KiroUserInputMessageContext = {};
+	if (tools && tools.length > 0) currentContext.tools = tools;
+	if (toolResults.length > 0) {
+		currentContext.toolResults = toolResults.map(message => ({
+			content: [{ text: truncate(textContent(message)) }],
+			status: message.isError ? "error" : "success",
+			toolUseId: message.toolCallId,
+		}));
+	}
+	if (!content && toolResults.length === 0) content = EMPTY_CONTENT_PLACEHOLDER;
+	const userInputMessage: KiroUserInputMessage = {
+		content,
+		modelId,
+		origin: "KIRO_CLI",
+		...(images.length > 0 ? { images: toKiroImages(images) } : {}),
+		...(Object.keys(currentContext).length > 0 ? { userInputMessageContext: currentContext } : {}),
+	};
+	const additionalModelRequestFields = buildAdditionalModelRequestFields(model, reasoning);
+	return {
+		profileArn,
+		conversationState: {
+			chatTriggerType: "MANUAL",
+			agentTaskType: "vibe",
+			conversationId,
+			...(history.length > 0 ? { history } : {}),
+			currentMessage: { userInputMessage },
+		},
+		...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
+		agentMode: "vibe",
+	};
+}
+
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function findHeader(headers: Record<string, string> | undefined, name: string): string | undefined {
+	if (!headers) return undefined;
+	const lower = name.toLowerCase();
+	return Object.entries(headers).find(([key]) => key.toLowerCase() === lower)?.[1];
+}
+
+function appendText(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	text: string,
+	state: { index?: number },
+): void {
+	if (!text) return;
+	if (state.index === undefined) {
+		state.index = output.content.length;
+		output.content.push({ type: "text", text: "" });
+		stream.push({ type: "text_start", contentIndex: state.index, partial: output });
+	}
+	const block = output.content[state.index];
+	if (block?.type !== "text") return;
+	block.text += text;
+	stream.push({ type: "text_delta", contentIndex: state.index, delta: text, partial: output });
+}
+
+function endText(output: AssistantMessage, stream: AssistantMessageEventStream, state: { index?: number }): void {
+	if (state.index === undefined) return;
+	const block = output.content[state.index];
+	if (block?.type === "text")
+		stream.push({ type: "text_end", contentIndex: state.index, content: block.text, partial: output });
+	state.index = undefined;
+}
+
+function appendThinking(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	text: string,
+	state: { index?: number },
+	textState: { index?: number },
+): void {
+	if (!text) return;
+	endText(output, stream, textState);
+	if (state.index === undefined) {
+		state.index = output.content.length;
+		output.content.push({ type: "thinking", thinking: "" });
+		stream.push({ type: "thinking_start", contentIndex: state.index, partial: output });
+	}
+	const block = output.content[state.index];
+	if (block?.type !== "thinking") return;
+	block.thinking += text;
+	stream.push({ type: "thinking_delta", contentIndex: state.index, delta: text, partial: output });
+}
+
+function endThinking(output: AssistantMessage, stream: AssistantMessageEventStream, state: { index?: number }): void {
+	if (state.index === undefined) return;
+	const block = output.content[state.index];
+	if (block?.type === "thinking") {
+		stream.push({ type: "thinking_end", contentIndex: state.index, content: block.thinking, partial: output });
+	}
+	state.index = undefined;
+}
+
+function emitToolCall(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	call: { name: string; toolUseId: string; input: string },
+): boolean {
+	const input = call.input.trim() || "{}";
+	let argumentsValue: Record<string, unknown>;
+	try {
+		argumentsValue = JSON.parse(input) as Record<string, unknown>;
+	} catch {
+		argumentsValue = {};
+	}
+	const toolCall: ToolCall = { type: "toolCall", id: call.toolUseId, name: call.name, arguments: argumentsValue };
+	const contentIndex = output.content.length;
+	output.content.push(toolCall);
+	stream.push({ type: "toolcall_start", contentIndex, partial: output });
+	stream.push({ type: "toolcall_delta", contentIndex, delta: input, partial: output });
+	stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
+	return true;
+}
+
+export async function fetchKiroModelsForCredential(
+	credential: { access: string; region?: string; profileArn?: string },
+	signal?: AbortSignal,
+): Promise<readonly KiroModelSpec[]> {
+	const region = resolveKiroApiRegion(credential.region);
+	const { response, profileArn } = await fetchKiroModelCatalog(
+		{ accessToken: credential.access, region },
+		credential.profileArn,
+		globalThis.fetch,
+		signal,
+	);
+	return mapKiroCatalogToModelSpecs(response.models, region).map(model => ({ ...model, kiroProfileArn: profileArn }));
+}
+
+export function streamKiro(
+	model: Model<Api>,
+	context: Context,
+	options: StreamOptions | SimpleStreamOptions = {},
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	void (async () => {
+		const output: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage(),
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		try {
+			const structured = parseKiroApiKey(typeof options.apiKey === "string" ? options.apiKey : undefined);
+			if (!structured.token) throw new Error("Kiro credentials not set. Run /login kiro.");
+			const kiroModel = model as KiroModel;
+			const region = resolveKiroApiRegion(
+				kiroModel.kiroRegion ?? structured.region ?? getKiroRegionFromEndpoint(model.baseUrl),
+			);
+			const fetchFn = options.fetch ?? globalThis.fetch;
+			const profileArn = await resolveKiroProfileArn(
+				{ accessToken: structured.token, region },
+				kiroModel.kiroProfileArn ?? structured.profileArn ?? findHeader(options.headers, "x-amzn-kiro-profile-arn"),
+				fetchFn,
+				options.signal,
+			);
+			const simpleOptions = options as SimpleStreamOptions;
+			const request = buildKiroRequest(
+				kiroModel,
+				context,
+				profileArn,
+				simpleOptions.sessionId ?? crypto.randomUUID(),
+				simpleOptions.reasoning,
+			);
+			const payload = (await options.onPayload?.(request, model)) ?? request;
+			const endpoint = new URL("generateAssistantResponse", `https://runtime.${region}.kiro.dev/`).toString();
+			const requestId = crypto.randomUUID();
+			const userAgent = `${USER_AGENT} ${requestId}`;
+			const response = await fetchFn(endpoint, {
+				method: "POST",
+				headers: {
+					...(model.headers ?? {}),
+					...(options.headers ?? {}),
+					"Content-Type": "application/json",
+					Accept: "application/vnd.amazon.eventstream",
+					Authorization: `Bearer ${structured.token}`,
+					"x-amzn-codewhisperer-optout": "true",
+					"amz-sdk-invocation-id": requestId,
+					"amz-sdk-request": "attempt=1; max=1",
+					"x-amzn-kiro-agent-mode": "vibe",
+					"x-amz-user-agent": userAgent,
+					"user-agent": userAgent,
+				},
+				body: JSON.stringify(payload),
+				signal: options.signal,
+			});
+			if (!response.ok) {
+				output.errorStatus = response.status;
+				throw new Error(`Kiro API request failed (HTTP ${response.status})`);
+			}
+			if (!response.body) throw new Error("Kiro API returned no event stream body");
+			stream.push({ type: "start", partial: output });
+			const textState: { index?: number } = {};
+			const thinkingState: { index?: number } = {};
+			let activeTool: { name: string; toolUseId: string; input: string } | undefined;
+			let emittedToolCalls = 0;
+			let receivedContextUsage = false;
+			let usageEvent: { inputTokens?: number; outputTokens?: number } | undefined;
+			for await (const frame of decodeKiroEventStream(response.body as ReadableStream<Uint8Array>)) {
+				const payloadText = new TextDecoder().decode(frame.payload);
+				let eventPayload: unknown;
+				try {
+					eventPayload = JSON.parse(payloadText);
+				} catch {
+					continue;
+				}
+				const event = parseKiroEvent(eventPayload);
+				if (!event) continue;
+				switch (event.type) {
+					case "content":
+						endThinking(output, stream, thinkingState);
+						appendText(output, stream, event.data, textState);
+						break;
+					case "thinkingText":
+						if (kiroModel.reasoning) appendThinking(output, stream, event.data, thinkingState, textState);
+						break;
+					case "thinkingSignature": {
+						const block = thinkingState.index !== undefined ? output.content[thinkingState.index] : undefined;
+						if (block?.type === "thinking") block.thinkingSignature = event.data;
+						endThinking(output, stream, thinkingState);
+						break;
+					}
+					case "toolUse":
+						if (!activeTool || activeTool.toolUseId !== event.data.toolUseId) {
+							if (activeTool) emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+							activeTool = { name: event.data.name, toolUseId: event.data.toolUseId, input: "" };
+						}
+						activeTool.input += event.data.input;
+						if (event.data.stop) {
+							emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+							activeTool = undefined;
+						}
+						break;
+					case "toolUseInput":
+						if (activeTool) activeTool.input += event.data.input;
+						break;
+					case "toolUseStop":
+						if (event.data.stop && activeTool) {
+							emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+							activeTool = undefined;
+						}
+						break;
+					case "contextUsage":
+						if (typeof model.contextWindow === "number") {
+							output.usage.input = Math.round((event.data.contextUsagePercentage / 100) * model.contextWindow);
+						}
+						receivedContextUsage = true;
+						break;
+					case "usage":
+						usageEvent = event.data;
+						break;
+					case "error":
+						throw new Error(
+							`Kiro API stream error: ${event.data.error}${event.data.message ? `: ${event.data.message}` : ""}`,
+						);
+				}
+			}
+			if (activeTool) emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+			endThinking(output, stream, thinkingState);
+			endText(output, stream, textState);
+			output.usage.input = usageEvent?.inputTokens ?? output.usage.input;
+			output.usage.output = usageEvent?.outputTokens ?? 0;
+			output.usage.totalTokens = output.usage.input + output.usage.output;
+			if (!receivedContextUsage && output.usage.input === 0) output.usage.input = context.messages.length;
+			calculateCost(model, output.usage);
+			output.stopReason = emittedToolCalls > 0 ? "toolUse" : "stop";
+			stream.push({ type: "done", reason: output.stopReason, message: output });
+		} catch (error) {
+			output.stopReason = options.signal?.aborted ? "aborted" : "error";
+			output.errorMessage = error instanceof Error ? error.message : String(error);
+			if (error instanceof Response) output.errorStatus = error.status;
+			stream.push({ type: "error", reason: output.stopReason, error: output });
+		} finally {
+			stream.end();
+		}
+	})();
+	return stream;
+}
+
+export const kiroApi = {
+	stream: streamKiro,
+	streamSimple: streamKiro,
+};
+
+export type { KiroModelSpec } from "@oh-my-pi/pi-catalog/provider-models/kiro";

--- a/packages/ai/src/providers/kiro.ts
+++ b/packages/ai/src/providers/kiro.ts
@@ -13,6 +13,7 @@ import type {
 	Api,
 	AssistantMessage,
 	Context,
+	FetchImpl,
 	ImageContent,
 	Message,
 	Model,
@@ -86,7 +87,29 @@ type KiroEvent =
 	| { type: "toolUseStop"; data: { stop: boolean } }
 	| { type: "contextUsage"; data: { contextUsagePercentage: number } }
 	| { type: "usage"; data: { inputTokens?: number; outputTokens?: number } }
+	| { type: "metering"; data: KiroMetering }
 	| { type: "error"; data: { error: string; message?: string } };
+export interface KiroMetering {
+	value: number;
+	unit: string;
+	unitPlural: string;
+}
+
+const meteringByMessageTimestamp = new Map<number, KiroMetering>();
+
+export function consumeKiroMetering(timestamp: number): KiroMetering | undefined {
+	const metering = meteringByMessageTimestamp.get(timestamp);
+	meteringByMessageTimestamp.delete(timestamp);
+	return metering;
+}
+
+export function recordKiroMetering(timestamp: number, metering: KiroMetering): void {
+	if (meteringByMessageTimestamp.size >= 32) {
+		const oldest = meteringByMessageTimestamp.keys().next().value;
+		if (oldest !== undefined) meteringByMessageTimestamp.delete(oldest);
+	}
+	meteringByMessageTimestamp.set(timestamp, metering);
+}
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
 	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
@@ -122,6 +145,16 @@ export function parseKiroEvent(payload: unknown): KiroEvent | undefined {
 	}
 	if (typeof parsed.contextUsagePercentage === "number") {
 		return { type: "contextUsage", data: { contextUsagePercentage: parsed.contextUsagePercentage } };
+	}
+	if (typeof parsed.usage === "number" && Number.isFinite(parsed.usage) && typeof parsed.unit === "string") {
+		return {
+			type: "metering",
+			data: {
+				value: parsed.usage,
+				unit: parsed.unit,
+				unitPlural: typeof parsed.unitPlural === "string" ? parsed.unitPlural : `${parsed.unit}s`,
+			},
+		};
 	}
 	const rawUsage = asRecord(parsed.usage);
 	if (rawUsage) {
@@ -411,10 +444,21 @@ function emptyUsage(): Usage {
 	};
 }
 
-function findHeader(headers: Record<string, string> | undefined, name: string): string | undefined {
-	if (!headers) return undefined;
-	const lower = name.toLowerCase();
-	return Object.entries(headers).find(([key]) => key.toLowerCase() === lower)?.[1];
+let resolvedProfileCache: { accessToken: string; region: string; profileArn: string } | undefined;
+
+async function resolveProfileForCredential(
+	auth: { accessToken: string; region: string },
+	providedProfileArn: string | undefined,
+	fetchFn: FetchImpl,
+	signal?: AbortSignal,
+): Promise<string> {
+	if (providedProfileArn) return providedProfileArn;
+	if (resolvedProfileCache?.accessToken === auth.accessToken && resolvedProfileCache.region === auth.region) {
+		return resolvedProfileCache.profileArn;
+	}
+	const profileArn = await resolveKiroProfileArn(auth, undefined, fetchFn, signal);
+	resolvedProfileCache = { ...auth, profileArn };
+	return profileArn;
 }
 
 function appendText(
@@ -529,12 +573,12 @@ export function streamKiro(
 			if (!structured.token) throw new Error("Kiro credentials not set. Run /login kiro.");
 			const kiroModel = model as KiroModel;
 			const region = resolveKiroApiRegion(
-				kiroModel.kiroRegion ?? structured.region ?? getKiroRegionFromEndpoint(model.baseUrl),
+				structured.region ?? kiroModel.kiroRegion ?? getKiroRegionFromEndpoint(model.baseUrl),
 			);
 			const fetchFn = options.fetch ?? globalThis.fetch;
-			const profileArn = await resolveKiroProfileArn(
+			const profileArn = await resolveProfileForCredential(
 				{ accessToken: structured.token, region },
-				kiroModel.kiroProfileArn ?? structured.profileArn ?? findHeader(options.headers, "x-amzn-kiro-profile-arn"),
+				structured.profileArn,
 				fetchFn,
 				options.signal,
 			);
@@ -558,6 +602,7 @@ export function streamKiro(
 					"Content-Type": "application/json",
 					Accept: "application/vnd.amazon.eventstream",
 					Authorization: `Bearer ${structured.token}`,
+					"x-amzn-kiro-profile-arn": profileArn,
 					"x-amzn-codewhisperer-optout": "true",
 					"amz-sdk-invocation-id": requestId,
 					"amz-sdk-request": "attempt=1; max=1",
@@ -570,7 +615,25 @@ export function streamKiro(
 			});
 			if (!response.ok) {
 				output.errorStatus = response.status;
-				throw new Error(`Kiro API request failed (HTTP ${response.status})`);
+				let detail = "";
+				try {
+					const body = (await response.json()) as { message?: unknown; reason?: unknown; error?: unknown };
+					const candidate = [body.message, body.reason, body.error].find(
+						(value): value is string => typeof value === "string" && value.trim().length > 0,
+					);
+					if (candidate) {
+						detail = candidate
+							.replace(/\s+/g, " ")
+							.split(structured.token)
+							.join("[redacted]")
+							.split(profileArn)
+							.join("[redacted]")
+							.slice(0, 300);
+					}
+				} catch {
+					// Some runtime errors return an empty or non-JSON body.
+				}
+				throw new Error(`Kiro API request failed (HTTP ${response.status})${detail ? `: ${detail}` : ""}`);
 			}
 			if (!response.body) throw new Error("Kiro API returned no event stream body");
 			stream.push({ type: "start", partial: output });
@@ -580,8 +643,34 @@ export function streamKiro(
 			let emittedToolCalls = 0;
 			let receivedContextUsage = false;
 			let usageEvent: { inputTokens?: number; outputTokens?: number } | undefined;
+			let meteringEvent: KiroMetering | undefined;
 			for await (const frame of decodeKiroEventStream(response.body as ReadableStream<Uint8Array>)) {
 				const payloadText = new TextDecoder().decode(frame.payload);
+				const messageType = frame.headers[":message-type"];
+				const exceptionType = frame.headers[":exception-type"];
+				if (messageType === "exception" || exceptionType) {
+					let detail = "";
+					try {
+						const parsed = JSON.parse(payloadText) as { message?: unknown; reason?: unknown; error?: unknown };
+						const candidate = [parsed.message, parsed.reason, parsed.error].find(
+							(value): value is string => typeof value === "string" && value.trim().length > 0,
+						);
+						if (candidate) {
+							detail = candidate
+								.replace(/\s+/g, " ")
+								.split(structured.token)
+								.join("[redacted]")
+								.split(profileArn)
+								.join("[redacted]")
+								.slice(0, 300);
+						}
+					} catch {
+						// Non-JSON exception payloads still surface the exception type below.
+					}
+					throw new Error(
+						`Kiro API stream exception${exceptionType ? `: ${exceptionType}` : ""}${detail ? `: ${detail}` : ""}`,
+					);
+				}
 				let eventPayload: unknown;
 				try {
 					eventPayload = JSON.parse(payloadText);
@@ -590,6 +679,12 @@ export function streamKiro(
 				}
 				const event = parseKiroEvent(eventPayload);
 				if (!event) continue;
+				if (
+					output.ttft === undefined &&
+					(event.type === "content" || event.type === "thinkingText" || event.type === "toolUse")
+				) {
+					output.ttft = Date.now() - output.timestamp;
+				}
 				switch (event.type) {
 					case "content":
 						endThinking(output, stream, thinkingState);
@@ -633,6 +728,9 @@ export function streamKiro(
 					case "usage":
 						usageEvent = event.data;
 						break;
+					case "metering":
+						meteringEvent = event.data;
+						break;
 					case "error":
 						throw new Error(
 							`Kiro API stream error: ${event.data.error}${event.data.message ? `: ${event.data.message}` : ""}`,
@@ -643,9 +741,23 @@ export function streamKiro(
 			endThinking(output, stream, thinkingState);
 			endText(output, stream, textState);
 			output.usage.input = usageEvent?.inputTokens ?? output.usage.input;
-			output.usage.output = usageEvent?.outputTokens ?? 0;
-			output.usage.totalTokens = output.usage.input + output.usage.output;
+			const estimatedOutputText = output.content
+				.map(block => {
+					if (block.type === "text") return block.text;
+					if (block.type === "thinking") return block.thinking;
+					if (block.type === "toolCall") return `${block.name}${JSON.stringify(block.arguments)}`;
+					return "";
+				})
+				.join("");
+			output.usage.output =
+				usageEvent?.outputTokens ??
+				(estimatedOutputText
+					? Math.max(1, Math.ceil(new TextEncoder().encode(estimatedOutputText).length / 4))
+					: 0);
 			if (!receivedContextUsage && output.usage.input === 0) output.usage.input = context.messages.length;
+			output.usage.totalTokens = output.usage.input + output.usage.output;
+			output.duration = Date.now() - output.timestamp;
+			if (meteringEvent) recordKiroMetering(output.timestamp, meteringEvent);
 			calculateCost(model, output.usage);
 			output.stopReason = emittedToolCalls > 0 ? "toolUse" : "stop";
 			stream.push({ type: "done", reason: output.stopReason, message: output });

--- a/packages/ai/src/registry/kiro.ts
+++ b/packages/ai/src/registry/kiro.ts
@@ -1,0 +1,19 @@
+import type { OAuthCredentials, OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const kiroProvider = {
+	id: "kiro",
+	name: "Kiro (AWS Builder ID / IAM Identity Center)",
+	login: async (cb: OAuthLoginCallbacks) => {
+		const { loginKiro } = await import("./oauth/kiro");
+		return loginKiro(cb);
+	},
+	refreshToken: async (credentials: OAuthCredentials) => {
+		const { refreshKiroToken } = await import("./oauth/kiro");
+		return refreshKiroToken(credentials);
+	},
+	getApiKey: (credentials: OAuthCredentials) => {
+		const kiro = credentials as OAuthCredentials & { region?: string; profileArn?: string };
+		return JSON.stringify({ token: credentials.access, region: kiro.region, profileArn: kiro.profileArn });
+	},
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -157,7 +157,8 @@ export async function getOAuthApiKey(
 		provider === "github-copilot" ||
 		provider === "google-gemini-cli" ||
 		provider === "google-antigravity" ||
-		provider === "alibaba-coding-plan";
+		provider === "alibaba-coding-plan" ||
+		provider === "kiro";
 	const apiKey = needsStructuredApiKey
 		? JSON.stringify({
 				apiEndpoint: creds.apiEndpoint,
@@ -168,6 +169,9 @@ export async function getOAuthApiKey(
 				expiresAt: creds.expires,
 				email: creds.email,
 				accountId: creds.accountId,
+				region: provider === "kiro" ? (creds as OAuthCredentials & { region?: string }).region : undefined,
+				profileArn:
+					provider === "kiro" ? (creds as OAuthCredentials & { profileArn?: string }).profileArn : undefined,
 			})
 		: creds.access;
 	return { newCredentials: creds, apiKey };

--- a/packages/ai/src/registry/oauth/kiro.ts
+++ b/packages/ai/src/registry/oauth/kiro.ts
@@ -19,8 +19,14 @@ const REGION_PROBES = [
 	"eu-west-2",
 	"eu-west-3",
 	"eu-north-1",
+	"eu-south-1",
+	"eu-south-2",
+	"eu-central-2",
 	"ap-southeast-1",
+	"ap-southeast-2",
 	"ap-northeast-1",
+	"ap-south-1",
+	"us-west-1",
 	"us-west-2",
 ] as const;
 const REQUEST_TIMEOUT_MS = 15_000;
@@ -51,6 +57,7 @@ type TokenResponse = {
 	expiresIn?: number;
 	expires_in?: number;
 	error?: string;
+	error_description?: string;
 };
 
 function withTimeout(signal: AbortSignal | undefined): AbortSignal {
@@ -262,7 +269,13 @@ export async function refreshKiroToken(credentials: OAuthCredentials): Promise<K
 		signal: withTimeout(undefined),
 	});
 	const data = await json<TokenResponse>(response);
-	if (!response.ok) throw new Error(`Kiro token refresh failed (HTTP ${response.status})`);
+	if (!response.ok) {
+		const detail = [data.error, data.error_description]
+			.filter((value): value is string => typeof value === "string" && value.length > 0)
+			.join(": ");
+		const safeDetail = detail ? detail.replace(/\s+/g, " ").split(token).join("[redacted]").slice(0, 200) : "";
+		throw new Error(`Kiro token refresh failed (HTTP ${response.status})${safeDetail ? `: ${safeDetail}` : ""}`);
+	}
 	const access = data.accessToken ?? data.access_token;
 	const refresh = data.refreshToken ?? data.refresh_token ?? token;
 	const expiresIn = Number(data.expiresIn ?? data.expires_in);

--- a/packages/ai/src/registry/oauth/kiro.ts
+++ b/packages/ai/src/registry/oauth/kiro.ts
@@ -1,0 +1,286 @@
+import type { FetchImpl } from "../../types";
+import { pollOAuthDeviceCodeFlow } from "./device-code";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "./types";
+
+const BUILDER_ID_START_URL = "https://view.awsapps.com/start";
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+const SSO_SCOPES = [
+	"codewhisperer:completions",
+	"codewhisperer:analysis",
+	"codewhisperer:conversations",
+	"codewhisperer:transformations",
+	"codewhisperer:taskassist",
+];
+const REGION_PROBES = [
+	"us-east-1",
+	"eu-west-1",
+	"eu-central-1",
+	"us-east-2",
+	"eu-west-2",
+	"eu-west-3",
+	"eu-north-1",
+	"ap-southeast-1",
+	"ap-northeast-1",
+	"us-west-2",
+] as const;
+const REQUEST_TIMEOUT_MS = 15_000;
+const EXPIRY_SKEW_MS = 5 * 60 * 1000;
+
+export type KiroCredentials = OAuthCredentials & {
+	clientId: string;
+	clientSecret: string;
+	region: string;
+	authMethod: "idc";
+	profileArn?: string;
+};
+
+type DeviceAuthorization = {
+	deviceCode: string;
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete: string;
+	interval: number;
+	expiresIn: number;
+};
+
+type TokenResponse = {
+	accessToken?: string;
+	access_token?: string;
+	refreshToken?: string;
+	refresh_token?: string;
+	expiresIn?: number;
+	expires_in?: number;
+	error?: string;
+};
+
+function withTimeout(signal: AbortSignal | undefined): AbortSignal {
+	const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function field<T>(value: Record<string, unknown>, camel: string, snake: string): T | undefined {
+	return (value[camel] ?? value[snake]) as T | undefined;
+}
+
+async function json<T>(response: Response): Promise<T> {
+	try {
+		return (await response.json()) as T;
+	} catch {
+		return {} as T;
+	}
+}
+
+async function registerAndAuthorize(
+	startUrl: string,
+	region: string,
+	fetchFn: FetchImpl,
+	signal?: AbortSignal,
+): Promise<{ clientId: string; clientSecret: string; device: DeviceAuthorization } | undefined> {
+	const endpoint = `https://oidc.${region}.amazonaws.com`;
+	const registered = await fetchFn(`${endpoint}/client/register`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "User-Agent": "omp" },
+		body: JSON.stringify({
+			clientName: "omp",
+			clientType: "public",
+			scopes: SSO_SCOPES,
+			grantTypes: [DEVICE_CODE_GRANT, "refresh_token"],
+		}),
+		signal: withTimeout(signal),
+	});
+	if (!registered.ok) return undefined;
+	const registration = await json<Record<string, unknown>>(registered);
+	const clientId = field<string>(registration, "clientId", "client_id");
+	const clientSecret = field<string>(registration, "clientSecret", "client_secret");
+	if (!clientId || !clientSecret) return undefined;
+
+	const authorized = await fetchFn(`${endpoint}/device_authorization`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "User-Agent": "omp" },
+		body: JSON.stringify({ clientId, clientSecret, startUrl }),
+		signal: withTimeout(signal),
+	});
+	if (!authorized.ok) return undefined;
+	const raw = await json<Record<string, unknown>>(authorized);
+	const deviceCode = field<string>(raw, "deviceCode", "device_code");
+	const userCode = field<string>(raw, "userCode", "user_code");
+	const verificationUri = field<string>(raw, "verificationUri", "verification_uri");
+	const verificationUriComplete = field<string>(raw, "verificationUriComplete", "verification_uri_complete");
+	const interval = Number(field<number | string>(raw, "interval", "interval") ?? 5);
+	const expiresIn = Number(field<number | string>(raw, "expiresIn", "expires_in") ?? 600);
+	if (
+		!deviceCode ||
+		!userCode ||
+		!verificationUri ||
+		!verificationUriComplete ||
+		!Number.isFinite(interval) ||
+		!Number.isFinite(expiresIn)
+	) {
+		return undefined;
+	}
+	return {
+		clientId,
+		clientSecret,
+		device: {
+			deviceCode,
+			userCode,
+			verificationUri,
+			verificationUriComplete,
+			interval: Math.max(1, interval),
+			expiresIn: Math.max(1, expiresIn),
+		},
+	};
+}
+
+async function beginDeviceAuthorization(
+	startUrl: string,
+	preferredRegion: string | undefined,
+	fetchFn: FetchImpl,
+	signal?: AbortSignal,
+): Promise<{ region: string; clientId: string; clientSecret: string; device: DeviceAuthorization }> {
+	const regions = preferredRegion ? [preferredRegion] : [...REGION_PROBES];
+	for (const region of regions) {
+		try {
+			const result = await registerAndAuthorize(startUrl, region, fetchFn, signal);
+			if (result) return { region, ...result };
+		} catch (error) {
+			if (signal?.aborted) throw error;
+		}
+	}
+	throw new Error("Could not find an AWS Identity Center region for the supplied Kiro start URL");
+}
+
+async function pollToken(
+	flow: { region: string; clientId: string; clientSecret: string; device: DeviceAuthorization },
+	fetchFn: FetchImpl,
+	signal?: AbortSignal,
+): Promise<KiroCredentials> {
+	return pollOAuthDeviceCodeFlow<KiroCredentials>({
+		intervalSeconds: flow.device.interval,
+		expiresInSeconds: flow.device.expiresIn,
+		signal,
+		poll: async () => {
+			const response = await fetchFn(`https://oidc.${flow.region}.amazonaws.com/token`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", "User-Agent": "omp" },
+				body: JSON.stringify({
+					clientId: flow.clientId,
+					clientSecret: flow.clientSecret,
+					deviceCode: flow.device.deviceCode,
+					grantType: DEVICE_CODE_GRANT,
+				}),
+				signal: withTimeout(signal),
+			});
+			const data = await json<TokenResponse>(response);
+			if (response.ok && !data.error) {
+				const access = data.accessToken ?? data.access_token;
+				const refresh = data.refreshToken ?? data.refresh_token;
+				const expiresIn = Number(data.expiresIn ?? data.expires_in);
+				if (!access || !refresh || !Number.isFinite(expiresIn)) {
+					return { status: "failed", message: "Kiro token response was missing required fields" };
+				}
+				return {
+					status: "complete",
+					value: {
+						access,
+						refresh: `${refresh}|${flow.clientId}|${flow.clientSecret}|idc|${flow.region}`,
+						expires: Date.now() + expiresIn * 1000 - EXPIRY_SKEW_MS,
+						clientId: flow.clientId,
+						clientSecret: flow.clientSecret,
+						region: flow.region,
+						authMethod: "idc",
+					},
+				};
+			}
+			if (data.error === "authorization_pending") return { status: "pending" };
+			if (data.error === "slow_down") return { status: "slow_down" };
+			return {
+				status: "failed",
+				message: `Kiro authorization failed${data.error ? `: ${data.error}` : ` (HTTP ${response.status})`}`,
+			};
+		},
+	});
+}
+
+export async function loginKiro(callbacks: OAuthLoginCallbacks): Promise<KiroCredentials> {
+	const startUrlInput =
+		(
+			await callbacks.onPrompt({
+				message: "Paste your IAM Identity Center start URL, or leave blank for AWS Builder ID",
+				placeholder: BUILDER_ID_START_URL,
+				allowEmpty: true,
+			})
+		)?.trim() ?? "";
+	if (callbacks.signal?.aborted) throw new Error("Login cancelled");
+	const startUrl = startUrlInput || BUILDER_ID_START_URL;
+	if (!/^https?:\/\//i.test(startUrl)) throw new Error("Kiro start URL must be an http(s) URL");
+
+	let preferredRegion: string | undefined;
+	if (startUrl !== BUILDER_ID_START_URL) {
+		preferredRegion =
+			(
+				(await callbacks.onPrompt({
+					message: "AWS Identity Center region (blank to auto-detect)",
+					placeholder: "us-east-1",
+				})) ?? ""
+			).trim() || undefined;
+	}
+	const fetchFn = callbacks.fetch ?? fetch;
+	const flow = await beginDeviceAuthorization(startUrl, preferredRegion, fetchFn, callbacks.signal);
+	callbacks.onAuth({
+		url: flow.device.verificationUriComplete,
+		instructions: `Open ${flow.device.verificationUri} and enter your code: ${flow.device.userCode}`,
+	});
+	callbacks.onProgress?.(`Waiting for Kiro authorization in ${flow.region}...`);
+	return pollToken(flow, fetchFn, callbacks.signal);
+}
+
+function parseRefreshMetadata(credentials: OAuthCredentials): {
+	token: string;
+	clientId: string;
+	clientSecret: string;
+	region: string;
+} {
+	const kiro = credentials as KiroCredentials;
+	const parts = credentials.refresh.split("|");
+	const token = parts[0];
+	const clientId = kiro.clientId ?? parts[1];
+	const clientSecret = kiro.clientSecret ?? parts[2];
+	const region = kiro.region ?? (parts[3] === "idc" ? parts[4] : undefined);
+	if (!token || !clientId || !clientSecret || !region) {
+		throw new Error("Kiro OAuth credential is missing Identity Center refresh metadata; run /login kiro again");
+	}
+	return { token, clientId, clientSecret, region };
+}
+
+export async function refreshKiroToken(credentials: OAuthCredentials): Promise<KiroCredentials> {
+	const { token, clientId, clientSecret, region } = parseRefreshMetadata(credentials);
+	const response = await fetch(`https://oidc.${region}.amazonaws.com/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "User-Agent": "omp" },
+		body: JSON.stringify({ clientId, clientSecret, refreshToken: token, grantType: "refresh_token" }),
+		signal: withTimeout(undefined),
+	});
+	const data = await json<TokenResponse>(response);
+	if (!response.ok) throw new Error(`Kiro token refresh failed (HTTP ${response.status})`);
+	const access = data.accessToken ?? data.access_token;
+	const refresh = data.refreshToken ?? data.refresh_token ?? token;
+	const expiresIn = Number(data.expiresIn ?? data.expires_in);
+	if (!access || !Number.isFinite(expiresIn))
+		throw new Error("Kiro token refresh response was missing required fields");
+	return {
+		access,
+		refresh: `${refresh}|${clientId}|${clientSecret}|idc|${region}`,
+		expires: Date.now() + expiresIn * 1000 - EXPIRY_SKEW_MS,
+		clientId,
+		clientSecret,
+		region,
+		authMethod: "idc",
+		profileArn: (credentials as KiroCredentials).profileArn,
+	};
+}
+
+export function getKiroApiKey(credentials: OAuthCredentials): string {
+	const kiro = credentials as KiroCredentials;
+	return JSON.stringify({ token: credentials.access, region: kiro.region, profileArn: kiro.profileArn });
+}

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -31,6 +31,7 @@ import { huggingfaceProvider } from "./huggingface";
 import { kagiProvider } from "./kagi";
 import { kiloProvider } from "./kilo";
 import { kimiCodeProvider } from "./kimi-code";
+import { kiroProvider } from "./kiro";
 import { litellmProvider } from "./litellm";
 import { llamaCppProvider } from "./llama-cpp";
 import { lmStudioProvider } from "./lm-studio";
@@ -98,6 +99,7 @@ const ALL = [
 	devinProvider,
 	googleAntigravityProvider,
 	googleGeminiCliProvider,
+	kiroProvider,
 	openaiCodexDeviceProvider,
 	xaiProvider,
 	xaiOauthProvider,

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -6,7 +6,7 @@
  */
 import { type } from "@oh-my-pi/omptype";
 import type { FetchImpl, Provider } from "./types";
-export type UsageUnit = "percent" | "tokens" | "requests" | "usd" | "minutes" | "bytes" | "unknown";
+export type UsageUnit = "percent" | "tokens" | "requests" | "credits" | "usd" | "minutes" | "bytes" | "unknown";
 
 export type UsageStatus = "ok" | "warning" | "exhausted" | "unknown";
 
@@ -224,7 +224,9 @@ export interface ClientUsageSummary {
 
 // ─── Zod schemas (wire-shape validation for the broker `/v1/usage` endpoint) ─
 
-export const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'unknown'");
+export const usageUnitSchema = type(
+	"'percent' | 'tokens' | 'requests' | 'credits' | 'usd' | 'minutes' | 'bytes' | 'unknown'",
+);
 export const usageStatusSchema = type("'ok' | 'warning' | 'exhausted' | 'unknown'");
 
 export const usageWindowSchema = type({

--- a/packages/ai/test/auth-broker-wire-schema-contract.test.ts
+++ b/packages/ai/test/auth-broker-wire-schema-contract.test.ts
@@ -263,5 +263,24 @@ describe("auth-broker public wire schemas", () => {
 			...response,
 			reports: [{ ...USAGE_REPORT, limits: [{ ...USAGE_REPORT.limits[0], status: "critical" }] }],
 		});
+		accept(wireSchemas.usageResponseSchema, {
+			...response,
+			reports: [
+				{
+					...USAGE_REPORT,
+					limits: [
+						{
+							...USAGE_REPORT.limits[0],
+							amount: {
+								used: 2,
+								limit: 10,
+								remaining: 8,
+								unit: "credits",
+							},
+						},
+					],
+				},
+			],
+		});
 	});
 });

--- a/packages/ai/test/auth-storage-broker-no-sentinel.test.ts
+++ b/packages/ai/test/auth-storage-broker-no-sentinel.test.ts
@@ -33,6 +33,7 @@ describe("AuthStorage broker sentinel refresh", () => {
 					accountId: "broker-account",
 					email: "broker@example.com",
 					projectId: "broker-project",
+					enterpriseUrl: undefined,
 				};
 			},
 		});
@@ -49,7 +50,7 @@ describe("AuthStorage broker sentinel refresh", () => {
 		}
 	});
 
-	test("getOAuthAccess refreshes expired broker credentials through the store hook only", async () => {
+	test("refreshes expired broker credentials without erasing undefined metadata", async () => {
 		if (!authStorage || !store) throw new Error("test setup failed");
 
 		await authStorage.set("anthropic", [
@@ -59,6 +60,7 @@ describe("AuthStorage broker sentinel refresh", () => {
 				refresh: REMOTE_REFRESH_SENTINEL,
 				expires: Date.now() - 60_000,
 				accountId: "broker-account-old",
+				enterpriseUrl: "https://broker.example.test",
 			},
 		]);
 
@@ -74,7 +76,7 @@ describe("AuthStorage broker sentinel refresh", () => {
 			accountId: "broker-account",
 			email: "broker@example.com",
 			projectId: "broker-project",
-			enterpriseUrl: undefined,
+			enterpriseUrl: "https://broker.example.test",
 		});
 		expect(brokerRefreshCalls).toBe(1);
 		expect(providerRefresh).not.toHaveBeenCalled();
@@ -84,6 +86,7 @@ describe("AuthStorage broker sentinel refresh", () => {
 		if (persisted[0]?.credential.type === "oauth") {
 			expect(persisted[0].credential.access).toBe("broker-access-rotated");
 			expect(persisted[0].credential.refresh).toBe(REMOTE_REFRESH_SENTINEL);
+			expect(persisted[0].credential.enterpriseUrl).toBe("https://broker.example.test");
 		}
 	});
 

--- a/packages/ai/test/auth-storage-broker-no-sentinel.test.ts
+++ b/packages/ai/test/auth-storage-broker-no-sentinel.test.ts
@@ -67,17 +67,23 @@ describe("AuthStorage broker sentinel refresh", () => {
 		const providerRefresh = vi.spyOn(oauthUtils, "refreshOAuthToken").mockImplementation(async () => {
 			throw new Error("provider-direct refresh must not be called");
 		});
-
-		const access = await authStorage.getOAuthAccess("anthropic", "broker-session");
-
-		expect(access).toEqual({
-			accessToken: "broker-access-rotated",
-			credentialId: expect.any(Number),
-			accountId: "broker-account",
-			email: "broker@example.com",
-			projectId: "broker-project",
-			enterpriseUrl: "https://broker.example.test",
+		const getOAuthApiKey = vi.spyOn(oauthUtils, "getOAuthApiKey").mockResolvedValue({
+			newCredentials: {
+				access: "broker-access-rotated",
+				refresh: REMOTE_REFRESH_SENTINEL,
+				expires: Date.now() + 60 * 60_000,
+				accountId: "broker-account",
+				email: "broker@example.com",
+				projectId: "broker-project",
+				enterpriseUrl: undefined,
+			},
+			apiKey: "broker-api-key",
 		});
+
+		const apiKey = await authStorage.getApiKey("anthropic", "broker-session");
+
+		expect(apiKey).toBe("broker-api-key");
+		expect(getOAuthApiKey).toHaveBeenCalledTimes(1);
 		expect(brokerRefreshCalls).toBe(1);
 		expect(providerRefresh).not.toHaveBeenCalled();
 		const persisted = store.listAuthCredentials("anthropic");

--- a/packages/ai/test/auth-storage-runtime-usage-broker.test.ts
+++ b/packages/ai/test/auth-storage-runtime-usage-broker.test.ts
@@ -1,0 +1,54 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth/sqlite-credential-store";
+import { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import type { UsageReport } from "@oh-my-pi/pi-ai/usage";
+
+function report(provider: string, id: string): UsageReport {
+	return {
+		provider,
+		fetchedAt: Date.now(),
+		limits: [
+			{
+				id,
+				label: id,
+				scope: { provider },
+				amount: { used: 2, limit: 10, remaining: 8, unit: "credits" },
+			},
+		],
+	};
+}
+
+class BrokerHookStore extends SqliteAuthCredentialStore {
+	async fetchUsageReports(): Promise<UsageReport[]> {
+		return [report("broker-provider", "broker-limit")];
+	}
+}
+
+describe("AuthStorage runtime usage with broker store hook", () => {
+	it("merges extension runtime reports with broker reports", async () => {
+		const store = new BrokerHookStore(new Database(":memory:"));
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: () => undefined,
+		});
+		await storage.reload();
+		await storage.set("fixture-usage", {
+			type: "oauth",
+			access: "fixture-access",
+			refresh: "fixture-refresh",
+			expires: Date.now() + 60_000,
+		});
+		storage.setRuntimeUsageProvider("fixture-usage", {
+			id: "fixture-usage",
+			fetchUsage: async () => report("fixture-usage", "runtime-limit"),
+		});
+
+		try {
+			const reports = await storage.fetchUsageReports();
+
+			expect(reports?.map(candidate => candidate.provider).sort()).toEqual(["broker-provider", "fixture-usage"]);
+		} finally {
+			storage.close();
+		}
+	});
+});

--- a/packages/ai/test/kiro.test.ts
+++ b/packages/ai/test/kiro.test.ts
@@ -495,4 +495,71 @@ describe("Kiro streamSimple dispatch", () => {
 		});
 		expect(new Headers(requests[1]?.init?.headers).get("x-amzn-kiro-profile-arn")).toBe("current-profile");
 	});
+
+	test("retries exactly once when the first request hits a transient Invalid tool use format 400", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = String(input);
+			requests.push({ url, init });
+			if (url.endsWith("/List-Available-Profiles")) {
+				return jsonResponse({ profiles: [{ arn: "profile-fixture" }] });
+			}
+			if (url.endsWith("/generateAssistantResponse")) {
+				const runtimeCalls = requests.filter(request => request.url.endsWith("/generateAssistantResponse")).length;
+				if (runtimeCalls === 1) {
+					return jsonResponse({ message: "Invalid tool use format." }, 400);
+				}
+				return new Response(eventStreamFrame(JSON.stringify({ content: "retried ok" })), { status: 200 });
+			}
+			throw new Error(`unexpected Kiro stream URL: ${url}`);
+		};
+		const result = await streamSimple(
+			KIRO_MODELS[0] as KiroModel,
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{
+				apiKey: JSON.stringify({ token: "access-fixture", region: "eu-central-1" }),
+				fetch: fetchMock,
+				sessionId: "conversation-fixture",
+			},
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "retried ok" }]);
+		const runtimeRequests = requests.filter(request => request.url.endsWith("/generateAssistantResponse"));
+		expect(runtimeRequests).toHaveLength(2);
+		expect(JSON.parse(String(runtimeRequests[0]?.init?.body))).toEqual(
+			JSON.parse(String(runtimeRequests[1]?.init?.body)),
+		);
+		expect(new Headers(runtimeRequests[0]?.init?.headers).get("amz-sdk-invocation-id")).not.toBe(
+			new Headers(runtimeRequests[1]?.init?.headers).get("amz-sdk-invocation-id"),
+		);
+	});
+
+	test("fails immediately without retrying for HTTP 400s other than Invalid tool use format", async () => {
+		let runtimeCalls = 0;
+		const result = await streamSimple(
+			KIRO_MODELS[0] as KiroModel,
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{
+				apiKey: JSON.stringify({ token: "access-fixture", region: "eu-central-1" }),
+				fetch: async input => {
+					const url = String(input);
+					if (url.endsWith("/List-Available-Profiles")) {
+						return jsonResponse({ profiles: [{ arn: "profile-fixture" }] });
+					}
+					if (url.endsWith("/generateAssistantResponse")) {
+						runtimeCalls++;
+						return jsonResponse({ message: "Model is not available" }, 400);
+					}
+					throw new Error(`unexpected Kiro stream URL: ${url}`);
+				},
+			},
+		).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(400);
+		expect(result.errorMessage).toContain("Kiro API request failed (HTTP 400)");
+		expect(result.errorMessage).toContain("Model is not available");
+		expect(runtimeCalls).toBe(1);
+	});
 });

--- a/packages/ai/test/kiro.test.ts
+++ b/packages/ai/test/kiro.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, test, vi } from "bun:test";
+import { buildKiroRequest, parseKiroEvent } from "@oh-my-pi/pi-ai/providers/kiro";
+import { crc32, decodeKiroEventStream, decodeKiroEventStreamMessage } from "@oh-my-pi/pi-ai/providers/kiro-eventstream";
+import { getOAuthApiKey } from "@oh-my-pi/pi-ai/registry/oauth";
+import { loginKiro, refreshKiroToken } from "@oh-my-pi/pi-ai/registry/oauth/kiro";
+import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import type { KiroModel } from "@oh-my-pi/pi-catalog/provider-models/kiro";
+import { fetchKiroModelCatalog, KIRO_MODELS } from "@oh-my-pi/pi-catalog/provider-models/kiro";
+
+function jsonResponse(value: unknown, status = 200): Response {
+	return new Response(JSON.stringify(value), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function eventStreamFrame(payload: string): Uint8Array {
+	const payloadBytes = new TextEncoder().encode(payload);
+	const totalLength = 12 + payloadBytes.length + 4;
+	const frame = new Uint8Array(totalLength);
+	const view = new DataView(frame.buffer);
+	view.setUint32(0, totalLength, false);
+	view.setUint32(4, 0, false);
+	view.setUint32(8, crc32(frame.subarray(0, 8)), false);
+	frame.set(payloadBytes, 12);
+	view.setUint32(totalLength - 4, crc32(frame.subarray(0, totalLength - 4)), false);
+	return frame;
+}
+
+describe("Kiro OAuth", () => {
+	test("runs device authorization and stores refresh metadata without printing token bytes", async () => {
+		const calls: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = String(input);
+			calls.push({ url, init });
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			if (url.endsWith("/token")) {
+				return jsonResponse({ accessToken: "access-fixture", refreshToken: "refresh-fixture", expiresIn: 3600 });
+			}
+			throw new Error(`unexpected Kiro test URL: ${url}`);
+		};
+		const onAuth = vi.fn();
+		const credentials = await loginKiro({
+			onAuth,
+			onPrompt: async () => "",
+			fetch: fetchMock,
+		});
+
+		expect(credentials.region).toBe("us-east-1");
+		expect(credentials.authMethod).toBe("idc");
+		expect(credentials.access).toBe("access-fixture");
+		expect(credentials.refresh).toContain("|us-east-1");
+		expect(onAuth).toHaveBeenCalledWith(
+			expect.objectContaining({ url: "https://device.example.test/verify?code=fixture" }),
+		);
+		expect(calls.map(call => call.url)).toEqual([
+			"https://oidc.us-east-1.amazonaws.com/client/register",
+			"https://oidc.us-east-1.amazonaws.com/device_authorization",
+			"https://oidc.us-east-1.amazonaws.com/token",
+		]);
+	});
+
+	test("refreshes with the device client and preserves profile metadata", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(jsonResponse({ accessToken: "access-refreshed", expiresIn: 1800 }));
+		try {
+			const refreshed = await refreshKiroToken({
+				access: "access-old",
+				refresh: "refresh-old|client-fixture|secret-fixture|idc|us-east-1",
+				expires: 0,
+				region: "us-east-1",
+				clientId: "client-fixture",
+				clientSecret: "secret-fixture",
+				authMethod: "idc",
+				profileArn: "profile-fixture",
+			} as never);
+			expect(refreshed.access).toBe("access-refreshed");
+			expect(refreshed.region).toBe("us-east-1");
+			expect(refreshed.profileArn).toBe("profile-fixture");
+			const request = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+			expect(JSON.parse(String(request.body))).toMatchObject({
+				clientId: "client-fixture",
+				refreshToken: "refresh-old",
+				grantType: "refresh_token",
+			});
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});
+
+describe("Kiro OAuth error handling", () => {
+	test("fails immediately for fatal HTTP 400 token errors", async () => {
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			return jsonResponse({ error: "access_denied" }, 400);
+		};
+
+		await expect(
+			loginKiro({
+				onAuth: () => {},
+				onPrompt: async () => "",
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Kiro authorization failed: access_denied");
+	});
+
+	test("reports slow_down instead of treating it as authorization_pending", async () => {
+		const controller = new AbortController();
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 1,
+				});
+			}
+			return jsonResponse({ error: "slow_down" }, 400);
+		};
+		await expect(
+			loginKiro({
+				onAuth: () => {},
+				onPrompt: async () => "",
+				signal: controller.signal,
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("after one or more slow_down responses");
+	});
+
+	test("uses an independent request-timeout signal for token polling", async () => {
+		const callerController = new AbortController();
+		let tokenRequestSignal: AbortSignal | undefined;
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			tokenRequestSignal = init?.signal ?? undefined;
+			return jsonResponse({ accessToken: "access-fixture", refreshToken: "refresh-fixture", expiresIn: 3600 });
+		};
+
+		const credentials = await loginKiro({
+			onAuth: () => {},
+			onPrompt: async () => "",
+			signal: callerController.signal,
+			fetch: fetchMock,
+		});
+		expect(credentials.access).toBe("access-fixture");
+		expect(tokenRequestSignal).toBeDefined();
+		expect(tokenRequestSignal).not.toBe(callerController.signal);
+	});
+});
+describe("Kiro management and request protocol", () => {
+	test("discovers a profile then fetches the profile-scoped model catalog", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchMock: FetchImpl = async (input, init) => {
+			requests.push({ url: String(input), init });
+			if (String(input).endsWith("/List-Available-Profiles")) {
+				return jsonResponse({ profiles: [{ arn: "profile-fixture" }] });
+			}
+			return jsonResponse({
+				models: [{ modelId: "model-fixture", displayName: "Fixture Model", tokenLimits: { maxInputTokens: 1234 } }],
+			});
+		};
+		const result = await fetchKiroModelCatalog(
+			{ accessToken: "access-fixture", region: "eu-central-1" },
+			undefined,
+			fetchMock,
+		);
+		expect(result.profileArn).toBe("profile-fixture");
+		expect(result.response.models[0]?.modelId).toBe("model-fixture");
+		expect(requests[0]?.init?.method).toBe("POST");
+		expect(requests[1]?.init?.method).toBe("GET");
+		expect(requests[1]?.url).toContain("origin=KIRO_CLI");
+		expect(requests[1]?.url).toContain("profileArn=profile-fixture");
+		const managementHeaders = requests[1]!.init!.headers as Record<string, string>;
+		expect(managementHeaders.Authorization).toBe("Bearer access-fixture");
+	});
+
+	test("maps system, tool, assistant, and tool-result history into a Kiro request", () => {
+		const model = KIRO_MODELS[0] as KiroModel;
+		const context: Context = {
+			systemPrompt: ["Use concise answers."],
+			tools: [
+				{
+					name: "lookup",
+					description: "Look something up",
+					parameters: { type: "object", properties: { query: { type: "string" } } },
+				},
+			],
+			messages: [
+				{ role: "user", content: "Earlier", timestamp: 1 },
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "tool-1", name: "lookup", arguments: { query: "x" } }],
+					api: "kiro-api",
+					provider: "kiro",
+					model: "auto",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "tool-1",
+					toolName: "lookup",
+					content: [{ type: "text", text: "result" }],
+					isError: false,
+					timestamp: 3,
+				},
+				{ role: "user", content: "Current", timestamp: 4 },
+			],
+		};
+		const request = buildKiroRequest(model, context, "profile-fixture", "conversation-fixture", Effort.High);
+		expect(request.profileArn).toBe("profile-fixture");
+		expect(request.conversationState.history?.[0]?.userInputMessage?.content).toContain("Earlier");
+		expect(request.conversationState.history?.[1]?.assistantResponseMessage?.toolUses?.[0]?.toolUseId).toBe("tool-1");
+		expect(
+			request.conversationState.history?.[2]?.userInputMessage?.userInputMessageContext?.toolResults?.[0]?.content[0]
+				?.text,
+		).toBe("result");
+		expect(request.conversationState.currentMessage.userInputMessage.content).toBe("Current");
+		expect(
+			request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.tools?.[0]
+				?.toolSpecification.name,
+		).toBe("lookup");
+	});
+});
+
+describe("Kiro event stream", () => {
+	test("parses native content, thinking, tools, usage, and errors", () => {
+		expect(parseKiroEvent({ content: "hello" })).toEqual({ type: "content", data: "hello" });
+		expect(parseKiroEvent({ text: "reason" })).toEqual({ type: "thinkingText", data: "reason" });
+		expect(parseKiroEvent({ name: "lookup", toolUseId: "tool-1", input: { query: "x" }, stop: true })).toEqual({
+			type: "toolUse",
+			data: { name: "lookup", toolUseId: "tool-1", input: JSON.stringify({ query: "x" }), stop: true },
+		});
+		expect(parseKiroEvent({ usage: { inputTokens: 10, outputTokens: 4 } })).toEqual({
+			type: "usage",
+			data: { inputTokens: 10, outputTokens: 4 },
+		});
+		expect(parseKiroEvent({ Error: "bad", reason: "fixture" })).toEqual({
+			type: "error",
+			data: { error: "bad", message: "fixture" },
+		});
+	});
+
+	test("validates CRCs and reassembles split AWS EventStream frames", async () => {
+		const frame = eventStreamFrame(JSON.stringify({ content: "hello" }));
+		const decoded = decodeKiroEventStreamMessage(frame);
+		expect(new TextDecoder().decode(decoded.payload)).toBe(JSON.stringify({ content: "hello" }));
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(frame.slice(0, 7));
+				controller.enqueue(frame.slice(7));
+				controller.close();
+			},
+		});
+		const messages = [];
+		for await (const message of decodeKiroEventStream(stream)) messages.push(message);
+		expect(messages).toHaveLength(1);
+		expect(new TextDecoder().decode(messages[0]!.payload)).toBe(JSON.stringify({ content: "hello" }));
+		const corrupt = frame.slice();
+		corrupt[8] ^= 1;
+		expect(() => decodeKiroEventStreamMessage(corrupt)).toThrow("prelude CRC");
+	});
+});
+
+describe("Kiro structured OAuth key", () => {
+	test("includes region and profile ARN for runtime routing", async () => {
+		const result = await getOAuthApiKey("kiro", {
+			kiro: {
+				access: "access-fixture",
+				refresh: "refresh-fixture",
+				expires: Date.now() + 60_000,
+				region: "eu-west-1",
+				profileArn: "profile-fixture",
+			} as never,
+		});
+		expect(JSON.parse(result!.apiKey)).toMatchObject({
+			token: "access-fixture",
+			refreshToken: "refresh-fixture",
+			expiresAt: expect.any(Number),
+			region: "eu-west-1",
+			profileArn: "profile-fixture",
+		});
+	});
+});
+
+describe("Kiro streamSimple dispatch", () => {
+	test("uses the built-in kiro-api handler with profile discovery and EventStream output", async () => {
+		const { streamSimple } = await import("@oh-my-pi/pi-ai/stream");
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = String(input);
+			requests.push({ url, init });
+			if (url.endsWith("/List-Available-Profiles")) {
+				return jsonResponse({ profiles: [{ arn: "profile-fixture" }] });
+			}
+			if (url.endsWith("/generateAssistantResponse")) {
+				return new Response(eventStreamFrame(JSON.stringify({ content: "streamSimple works" })), { status: 200 });
+			}
+			throw new Error(`unexpected Kiro stream URL: ${url}`);
+		};
+		const model = KIRO_MODELS[0] as KiroModel;
+		const result = await streamSimple(
+			model,
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{
+				apiKey: JSON.stringify({ token: "access-fixture", region: "eu-central-1" }),
+				fetch: fetchMock,
+				sessionId: "conversation-fixture",
+			},
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "streamSimple works" }]);
+		expect(requests.map(request => request.url)).toEqual([
+			"https://management.eu-central-1.kiro.dev/List-Available-Profiles",
+			"https://runtime.eu-central-1.kiro.dev/generateAssistantResponse",
+		]);
+		expect(JSON.parse(String(requests[1]?.init?.body))).toMatchObject({ profileArn: "profile-fixture" });
+	});
+});

--- a/packages/ai/test/kiro.test.ts
+++ b/packages/ai/test/kiro.test.ts
@@ -3,6 +3,7 @@ import { buildKiroRequest, parseKiroEvent } from "@oh-my-pi/pi-ai/providers/kiro
 import { crc32, decodeKiroEventStream, decodeKiroEventStreamMessage } from "@oh-my-pi/pi-ai/providers/kiro-eventstream";
 import { getOAuthApiKey } from "@oh-my-pi/pi-ai/registry/oauth";
 import { loginKiro, refreshKiroToken } from "@oh-my-pi/pi-ai/registry/oauth/kiro";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import type { KiroModel } from "@oh-my-pi/pi-catalog/provider-models/kiro";
@@ -12,15 +13,32 @@ function jsonResponse(value: unknown, status = 200): Response {
 	return new Response(JSON.stringify(value), { status, headers: { "Content-Type": "application/json" } });
 }
 
-function eventStreamFrame(payload: string): Uint8Array {
+function eventStreamFrame(payload: string, headers: Record<string, string> = {}): Uint8Array {
 	const payloadBytes = new TextEncoder().encode(payload);
-	const totalLength = 12 + payloadBytes.length + 4;
+	const headerParts = Object.entries(headers).map(([name, value]) => {
+		const nameBytes = new TextEncoder().encode(name);
+		const valueBytes = new TextEncoder().encode(value);
+		const bytes = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+		bytes[0] = nameBytes.length;
+		bytes.set(nameBytes, 1);
+		bytes[1 + nameBytes.length] = 7;
+		new DataView(bytes.buffer).setUint16(2 + nameBytes.length, valueBytes.length, false);
+		bytes.set(valueBytes, 4 + nameBytes.length);
+		return bytes;
+	});
+	const headerLength = headerParts.reduce((total, bytes) => total + bytes.length, 0);
+	const totalLength = 12 + headerLength + payloadBytes.length + 4;
 	const frame = new Uint8Array(totalLength);
 	const view = new DataView(frame.buffer);
 	view.setUint32(0, totalLength, false);
-	view.setUint32(4, 0, false);
+	view.setUint32(4, headerLength, false);
 	view.setUint32(8, crc32(frame.subarray(0, 8)), false);
-	frame.set(payloadBytes, 12);
+	let offset = 12;
+	for (const bytes of headerParts) {
+		frame.set(bytes, offset);
+		offset += bytes.length;
+	}
+	frame.set(payloadBytes, offset);
 	view.setUint32(totalLength - 4, crc32(frame.subarray(0, totalLength - 4)), false);
 	return frame;
 }
@@ -94,6 +112,29 @@ describe("Kiro OAuth", () => {
 				refreshToken: "refresh-old",
 				grantType: "refresh_token",
 			});
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	test("preserves definitive refresh error codes", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse(
+				{
+					error: "invalid_grant",
+					error_description: "Refresh token revoked",
+				},
+				400,
+			),
+		);
+		try {
+			await expect(
+				refreshKiroToken({
+					access: "access-old",
+					refresh: "refresh-old|client-fixture|secret-fixture|idc|us-east-1",
+					expires: 0,
+				} as never),
+			).rejects.toThrow("invalid_grant: Refresh token revoked");
 		} finally {
 			fetchSpy.mockRestore();
 		}
@@ -287,6 +328,16 @@ describe("Kiro event stream", () => {
 			type: "usage",
 			data: { inputTokens: 10, outputTokens: 4 },
 		});
+		expect(
+			parseKiroEvent({
+				usage: 0.006,
+				unit: "credit",
+				unitPlural: "credits",
+			}),
+		).toEqual({
+			type: "metering",
+			data: { value: 0.006, unit: "credit", unitPlural: "credits" },
+		});
 		expect(parseKiroEvent({ Error: "bad", reason: "fixture" })).toEqual({
 			type: "error",
 			data: { error: "bad", message: "fixture" },
@@ -337,7 +388,6 @@ describe("Kiro structured OAuth key", () => {
 
 describe("Kiro streamSimple dispatch", () => {
 	test("uses the built-in kiro-api handler with profile discovery and EventStream output", async () => {
-		const { streamSimple } = await import("@oh-my-pi/pi-ai/stream");
 		const requests: Array<{ url: string; init?: RequestInit }> = [];
 		const fetchMock: FetchImpl = async (input, init) => {
 			const url = String(input);
@@ -363,10 +413,86 @@ describe("Kiro streamSimple dispatch", () => {
 
 		expect(result.stopReason).toBe("stop");
 		expect(result.content).toEqual([{ type: "text", text: "streamSimple works" }]);
+		expect(result.usage.output).toBeGreaterThan(0);
+		expect(result.usage.totalTokens).toBe(result.usage.input + result.usage.output);
+		expect(result.duration).toBeGreaterThanOrEqual(0);
+		expect(result.ttft).toBeGreaterThanOrEqual(0);
 		expect(requests.map(request => request.url)).toEqual([
 			"https://management.eu-central-1.kiro.dev/List-Available-Profiles",
 			"https://runtime.eu-central-1.kiro.dev/generateAssistantResponse",
 		]);
-		expect(JSON.parse(String(requests[1]?.init?.body))).toMatchObject({ profileArn: "profile-fixture" });
+		expect(JSON.parse(String(requests[1]?.init?.body))).toMatchObject({
+			profileArn: "profile-fixture",
+		});
+		expect(new Headers(requests[1]?.init?.headers).get("x-amzn-kiro-profile-arn")).toBe("profile-fixture");
+	});
+
+	test("surfaces modeled AWS EventStream exceptions", async () => {
+		const result = await streamSimple(
+			KIRO_MODELS[0] as KiroModel,
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{
+				apiKey: JSON.stringify({
+					token: "access-fixture",
+					region: "us-east-1",
+					profileArn: "profile-fixture",
+				}),
+				fetch: async () =>
+					new Response(
+						eventStreamFrame(
+							JSON.stringify({
+								message: "Model is not available",
+							}),
+							{
+								":message-type": "exception",
+								":exception-type": "ValidationException",
+							},
+						),
+						{ status: 200 },
+					),
+			},
+		).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("ValidationException: Model is not available");
+	});
+
+	test("re-resolves profile scope instead of trusting stale model metadata", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const model = {
+			...KIRO_MODELS[0],
+			kiroRegion: "us-east-1",
+			kiroProfileArn: "stale-profile",
+		} as KiroModel;
+		const result = await streamSimple(
+			model,
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{
+				apiKey: JSON.stringify({
+					token: "new-access",
+					region: "eu-central-1",
+				}),
+				fetch: async (input, init) => {
+					const url = String(input);
+					requests.push({ url, init });
+					if (url.endsWith("/List-Available-Profiles")) {
+						return jsonResponse({
+							profiles: [{ arn: "current-profile" }],
+						});
+					}
+					return new Response(eventStreamFrame(JSON.stringify({ content: "ok" })), { status: 200 });
+				},
+			},
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(requests.map(request => request.url)).toEqual([
+			"https://management.eu-central-1.kiro.dev/List-Available-Profiles",
+			"https://runtime.eu-central-1.kiro.dev/generateAssistantResponse",
+		]);
+		expect(JSON.parse(String(requests[1]?.init?.body))).toMatchObject({
+			profileArn: "current-profile",
+		});
+		expect(new Headers(requests[1]?.init?.headers).get("x-amzn-kiro-profile-arn")).toBe("current-profile");
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Kiro profile and model discovery with an automatically resolved catalog entry ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added
@@ -101,10 +105,6 @@
 
 - Added a Cursor variant-collapse table folding the per-effort Grok siblings (`cursor-grok-4.5` low/medium/high and `cursor-grok-4.6` low/medium/high/xhigh, plus their `-fast` service-tier lanes) into one logical model per lane with effort routing onto the live wire ids, matching Devin's `grok-4-5` collapse ([#8803](https://github.com/can1357/oh-my-pi/issues/8803)).
 - Regenerated the Cursor agent protobufs to model hosted WebFetch permission queries (`interaction_query` / `interaction_response` field 9) and the matching `ToolCall` variant (field 37).
-
-### Added
-
-- Added Kiro profile and model discovery with an automatically resolved catalog entry ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
 
 ### Fixed
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -102,6 +102,10 @@
 - Added a Cursor variant-collapse table folding the per-effort Grok siblings (`cursor-grok-4.5` low/medium/high and `cursor-grok-4.6` low/medium/high/xhigh, plus their `-fast` service-tier lanes) into one logical model per lane with effort routing onto the live wire ids, matching Devin's `grok-4-5` collapse ([#8803](https://github.com/can1357/oh-my-pi/issues/8803)).
 - Regenerated the Cursor agent protobufs to model hosted WebFetch permission queries (`interaction_query` / `interaction_response` field 9) and the matching `ToolCall` variant (field 37).
 
+### Added
+
+- Added Kiro profile and model discovery with an automatically resolved catalog entry ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 ### Fixed
 
 - Fixed a physically corrupt `models.db` (`SQLITE_CORRUPT*` / `SQLITE_NOTADB`, "database disk image is malformed") permanently disabling the model cache. The shared read/write paths swallowed unrecoverable SQLite corruption as a best-effort miss and cached the broken handle, so a successful live catalog could never overwrite the corrupt cache and every later process repeated the miss — a runtime provider extension with no bundled catalog was left with only its bootstrap model. Corruption now self-heals: the cache closes the handle, quarantines `models.db`(+`-wal`/`-shm`) aside, recreates a fresh database, and retries the operation once; `SQLITE_BUSY`, permission, and unrelated errors keep their existing best-effort paths ([#8867](https://github.com/can1357/oh-my-pi/issues/8867)).

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -30,6 +30,7 @@ import {
 	isCatalogDescriptor,
 } from "../src/provider-models/descriptor-types";
 import { PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { KIRO_AUTO_MODEL } from "../src/provider-models/kiro";
 import {
 	AIAND_STATIC_MODELS,
 	ALIBABA_TOKEN_PLAN_STATIC_MODELS,
@@ -551,6 +552,10 @@ async function generateModels() {
 	// persisted `modelRoles.default = "xai-oauth/<id>"` is honored before the
 	// async refresh fires (interactive boot does not await refresh).
 	allModels.push(...buildXaiOAuthStaticSeed());
+	// Kiro uses a credential-scoped special model manager, so its descriptor is
+	// intentionally excluded above. Bundle only the stable `auto` route; runtime
+	// discovery replaces it with the authenticated profile catalog.
+	allModels.push(KIRO_AUTO_MODEL);
 	// Daybreak is separately provisioned and absent from stencil.so. Keep its
 	// documented aliases and current Cyber snapshot in every generated bundle.
 	allModels.push(...OPENAI_DAYBREAK_CURATED_FALLBACK_MODELS);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -112493,6 +112493,43 @@
 			"supportsComputerUseConfig": false
 		}
 	},
+	"kiro": {
+		"auto": {
+			"id": "auto",
+			"name": "Auto",
+			"api": "kiro-api",
+			"provider": "kiro",
+			"baseUrl": "https://runtime.us-east-1.kiro.dev/",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"supportsTools": true,
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "high"
+			},
+			"kiroModelId": "auto",
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false
+		}
+	},
 	"meta": {
 		"muse-spark-1.1": {
 			"id": "muse-spark-1.1",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -257,6 +257,11 @@ export const CATALOG_PROVIDERS = [
 		catalogDiscovery: { label: "Kilo Gateway", allowUnauthenticated: true },
 	},
 	{
+		id: "kiro",
+		defaultModel: "auto",
+		specialModelManager: true,
+	},
+	{
 		id: "kimi-code",
 		defaultModel: "kimi-for-coding",
 		createModelManagerOptions: (config: ModelManagerConfig) => kimiCodeModelManagerOptions(config),

--- a/packages/catalog/src/provider-models/index.ts
+++ b/packages/catalog/src/provider-models/index.ts
@@ -2,6 +2,7 @@ export * from "./cache-provider-id";
 export * from "./descriptor-types";
 export * from "./descriptors";
 export * from "./google";
+export * from "./kiro";
 export * from "./ollama";
 export * from "./openai-compat";
 export * from "./special";

--- a/packages/catalog/src/provider-models/kiro.ts
+++ b/packages/catalog/src/provider-models/kiro.ts
@@ -54,6 +54,8 @@ export function getKiroRegionFromEndpoint(endpoint: string | undefined): string 
 export interface KiroCatalogModel {
 	modelId: string;
 	displayName?: string;
+	modelName?: string;
+	supportedInputTypes?: string[];
 	tokenLimits?: {
 		maxInputTokens?: number;
 		maxOutputTokens?: number;
@@ -231,27 +233,26 @@ export const KIRO_AUTO_MODEL = createBootstrapModel("auto", {
 	thinking: KIRO_THINKING,
 });
 
-/** Safe offline bootstrap; authenticated discovery replaces it with the profile catalog. */
+/**
+ * Safe offline bootstrap matching the Kiro CLI 2.19.2 catalog. Once
+ * authenticated, List-Available-Models is authoritative because availability
+ * is account and profile scoped; omitted models must not be reintroduced from
+ * this list. `KIRO_AUTO_MODEL` stays independent: it is a generated-bundle
+ * entry, not part of the runtime fallback.
+ */
 export const KIRO_MODELS: readonly KiroModelSpec[] = [
-	KIRO_AUTO_MODEL,
-	createBootstrapModel("claude-opus-5", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-sonnet-5", { contextWindow: 1_000_000, maxTokens: 65_536, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-opus-4.8", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-opus-4.7", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-opus-4.6", { maxTokens: 32_768, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-sonnet-4.6", { maxTokens: 65_536, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-opus-4.5", { maxTokens: 65_536, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-sonnet-4.5", { maxTokens: 65_536, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-sonnet-4", { maxTokens: 65_536, thinking: KIRO_THINKING }),
-	createBootstrapModel("claude-haiku-4.5", { reasoning: false, maxTokens: 65_536 }),
-	createBootstrapModel("gpt-5.6-sol", { thinking: KIRO_THINKING }),
-	createBootstrapModel("gpt-5.6-terra", { thinking: KIRO_THINKING }),
-	createBootstrapModel("gpt-5.6-luna", { thinking: KIRO_THINKING }),
-	createBootstrapModel("deepseek-3.2", { thinking: KIRO_THINKING }),
-	createBootstrapModel("minimax-m2.5", { reasoning: false }),
-	createBootstrapModel("minimax-m2.1", { reasoning: false }),
-	createBootstrapModel("glm-5", { thinking: KIRO_THINKING }),
-	createBootstrapModel("qwen3-coder-next", { thinking: KIRO_THINKING }),
+	createBootstrapModel("gpt-5.6-sol", { contextWindow: 272_000, input: ["text", "image"], thinking: KIRO_THINKING }),
+	createBootstrapModel("gpt-5.6-terra", { contextWindow: 272_000, input: ["text", "image"], thinking: KIRO_THINKING }),
+	createBootstrapModel("gpt-5.6-luna", { contextWindow: 272_000, input: ["text", "image"], thinking: KIRO_THINKING }),
+	createBootstrapModel("deepseek-3.2", { contextWindow: 164_000, input: ["text", "image"], thinking: KIRO_THINKING }),
+	createBootstrapModel("minimax-m2.5", { reasoning: false, contextWindow: 196_000 }),
+	createBootstrapModel("minimax-m2.1", { reasoning: false, contextWindow: 196_000, input: ["text", "image"] }),
+	createBootstrapModel("glm-5", { contextWindow: 200_000, thinking: KIRO_THINKING }),
+	createBootstrapModel("qwen3-coder-next", {
+		contextWindow: 256_000,
+		input: ["text", "image"],
+		thinking: KIRO_THINKING,
+	}),
 ];
 
 function dynamicThinking(schema: Record<string, unknown> | null | undefined): ThinkingConfig | undefined {
@@ -270,13 +271,19 @@ export function mapKiroCatalogToModelSpecs(catalog: readonly KiroCatalogModel[],
 		return {
 			...(existing ?? createBootstrapModel(id)),
 			id,
-			name: model.displayName?.trim() || existing?.name || id,
+			name: model.modelName?.trim() || model.displayName?.trim() || existing?.name || id,
 			api: KIRO_API,
 			provider: "kiro",
 			baseUrl: getKiroEndpoints(region).runtime,
 			reasoning: schema !== undefined ? true : (existing?.reasoning ?? isReasoningModel(id)),
 			contextWindow: limits?.maxInputTokens ?? existing?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
 			maxTokens: limits?.maxOutputTokens ?? existing?.maxTokens ?? DEFAULT_MAX_TOKENS,
+			input:
+				model.supportedInputTypes !== undefined
+					? model.supportedInputTypes.some(type => type.toUpperCase() === "IMAGE")
+						? ["text", "image"]
+						: ["text"]
+					: (existing?.input ?? ["text"]),
 			supportsTools: true,
 			kiroModelId: id,
 			kiroRegion: region,
@@ -309,6 +316,14 @@ export function parseKiroApiKey(value: string | undefined): {
 export function kiroCacheProviderId(apiKey: string | undefined, baseUrl?: string): string {
 	const parsed = parseKiroApiKey(apiKey);
 	const region = resolveKiroApiRegion(parsed.region ?? getKiroRegionFromEndpoint(baseUrl));
-	const profileFingerprint = parsed.profileArn ? Bun.hash(parsed.profileArn).toString(36) : "default";
-	return `kiro:${region}:${profileFingerprint}`;
+	// Catalogs are account/profile scoped. With a profile ARN the cache is
+	// namespaced per ARN; without one, per bearer token. Only irreversible
+	// Bun.hash fingerprints are stored, so the raw token never appears in the
+	// cache namespace. Anonymous setups (no token at all) keep "default".
+	const scopeFingerprint = parsed.profileArn
+		? Bun.hash(parsed.profileArn).toString(36)
+		: parsed.token
+			? Bun.hash(parsed.token).toString(36)
+			: "default";
+	return `kiro:${region}:${scopeFingerprint}`;
 }

--- a/packages/catalog/src/provider-models/kiro.ts
+++ b/packages/catalog/src/provider-models/kiro.ts
@@ -1,0 +1,308 @@
+import type { Effort } from "../effort";
+import { Effort as EffortValue } from "../effort";
+import type { FetchImpl, Model, ModelSpec, ThinkingConfig } from "../types";
+
+const API_REGION_MAP: Record<string, string> = {
+	"us-west-1": "us-east-1",
+	"us-west-2": "us-east-1",
+	"us-east-2": "us-east-1",
+	"ap-southeast-1": "us-east-1",
+	"ap-southeast-2": "us-east-1",
+	"ap-northeast-1": "us-east-1",
+	"ap-south-1": "us-east-1",
+	"eu-west-1": "eu-central-1",
+	"eu-west-2": "eu-central-1",
+	"eu-west-3": "eu-central-1",
+	"eu-north-1": "eu-central-1",
+	"eu-south-1": "eu-central-1",
+	"eu-south-2": "eu-central-1",
+	"eu-central-2": "eu-central-1",
+};
+
+export const KIRO_API = "kiro-api" as const;
+
+export interface KiroEndpoints {
+	region: string;
+	management: string;
+	runtime: string;
+}
+
+export function resolveKiroApiRegion(ssoRegion?: string): string {
+	const normalized = ssoRegion?.trim();
+	return normalized ? (API_REGION_MAP[normalized] ?? normalized) : "us-east-1";
+}
+
+export function getKiroEndpoints(region: string): KiroEndpoints {
+	return {
+		region,
+		management: `https://management.${region}.kiro.dev/`,
+		runtime: `https://runtime.${region}.kiro.dev/`,
+	};
+}
+
+export function getKiroRegionFromEndpoint(endpoint: string | undefined): string | undefined {
+	if (!endpoint) return undefined;
+	try {
+		const [service, region, ...suffix] = new URL(endpoint).hostname.split(".");
+		if ((service === "management" || service === "runtime") && suffix.join(".") === "kiro.dev") return region;
+	} catch {
+		// A custom or incomplete base URL is handled by the default region.
+	}
+	return undefined;
+}
+
+export interface KiroCatalogModel {
+	modelId: string;
+	displayName?: string;
+	tokenLimits?: {
+		maxInputTokens?: number;
+		maxOutputTokens?: number;
+		[key: string]: unknown;
+	};
+	additionalModelRequestFieldsSchema?: Record<string, unknown> | null;
+	[key: string]: unknown;
+}
+
+export interface KiroListAvailableModelsResponse {
+	models: KiroCatalogModel[];
+	[key: string]: unknown;
+}
+
+export type KiroModelSpec = ModelSpec<typeof KIRO_API> & {
+	kiroModelId?: string;
+	kiroRegion?: string;
+	kiroProfileArn?: string;
+	additionalModelRequestFieldsSchema?: Record<string, unknown>;
+};
+
+export type KiroModel = Model<typeof KIRO_API> & {
+	kiroModelId?: string;
+	kiroRegion?: string;
+	kiroProfileArn?: string;
+	additionalModelRequestFieldsSchema?: Record<string, unknown>;
+};
+
+export class KiroManagementHttpError extends Error {
+	readonly status: number;
+
+	constructor(operation: string, region: string, status: number) {
+		super(`Kiro management ${operation} failed in ${region}: HTTP ${status}`);
+		this.name = "KiroManagementHttpError";
+		this.status = status;
+	}
+}
+
+async function managementRequest<TResponse>(
+	auth: { accessToken: string; region: string },
+	operation: string,
+	path: string,
+	method: "GET" | "POST",
+	params: Record<string, string | undefined>,
+	fetchFn: FetchImpl,
+	signal?: AbortSignal,
+): Promise<TResponse> {
+	const url = new URL(path, getKiroEndpoints(auth.region).management);
+	const headers: Record<string, string> = {
+		Accept: "application/json",
+		Authorization: `Bearer ${auth.accessToken}`,
+	};
+	const request: RequestInit = { method, headers, signal };
+	if (method === "GET") {
+		for (const [name, value] of Object.entries(params)) {
+			if (value !== undefined) url.searchParams.set(name, value);
+		}
+	} else {
+		headers["Content-Type"] = "application/json";
+		request.body = JSON.stringify(
+			Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined)),
+		);
+	}
+
+	let response: Response;
+	try {
+		response = await fetchFn(url, request);
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		throw new Error(`Kiro management ${operation} request failed in ${auth.region}`, { cause: error });
+	}
+	if (!response.ok) throw new KiroManagementHttpError(operation, auth.region, response.status);
+	try {
+		return (await response.json()) as TResponse;
+	} catch (error) {
+		throw new Error(`Kiro management ${operation} returned invalid JSON in ${auth.region}`, { cause: error });
+	}
+}
+
+export async function resolveKiroProfileArn(
+	auth: { accessToken: string; region: string },
+	providedProfileArn: string | undefined,
+	fetchFn: FetchImpl = globalThis.fetch,
+	signal?: AbortSignal,
+): Promise<string> {
+	if (providedProfileArn) return providedProfileArn;
+	const response = await managementRequest<{ profiles?: Array<{ arn?: string }> }>(
+		auth,
+		"ListAvailableProfiles",
+		"List-Available-Profiles",
+		"POST",
+		{},
+		fetchFn,
+		signal,
+	);
+	const profileArn = response.profiles?.find(
+		profile => typeof profile.arn === "string" && profile.arn.length > 0,
+	)?.arn;
+	if (!profileArn) throw new Error(`Kiro management ListAvailableProfiles returned no profile in ${auth.region}`);
+	return profileArn;
+}
+
+export async function fetchKiroModelCatalog(
+	auth: { accessToken: string; region: string },
+	providedProfileArn?: string,
+	fetchFn: FetchImpl = globalThis.fetch,
+	signal?: AbortSignal,
+): Promise<{ profileArn: string; response: KiroListAvailableModelsResponse }> {
+	const profileArn = await resolveKiroProfileArn(auth, providedProfileArn, fetchFn, signal);
+	const response = await managementRequest<KiroListAvailableModelsResponse>(
+		auth,
+		"ListAvailableModels",
+		"List-Available-Models",
+		"GET",
+		{ origin: "KIRO_CLI", profileArn },
+		fetchFn,
+		signal,
+	);
+	if (!Array.isArray(response.models) || response.models.length === 0) {
+		throw new Error(`Kiro management ListAvailableModels returned no models in ${auth.region}`);
+	}
+	if (response.models.some(model => !model || typeof model.modelId !== "string" || model.modelId.length === 0)) {
+		throw new Error(`Kiro management ListAvailableModels returned an invalid catalog in ${auth.region}`);
+	}
+	return { profileArn, response };
+}
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_MAX_TOKENS = 8_192;
+const KIRO_RUNTIME = getKiroEndpoints("us-east-1").runtime;
+const KIRO_THINKING: ThinkingConfig = {
+	mode: "effort",
+	efforts: [
+		EffortValue.Low,
+		EffortValue.Medium,
+		EffortValue.High,
+		EffortValue.XHigh,
+		EffortValue.Max,
+	] as readonly Effort[],
+	defaultLevel: EffortValue.High,
+};
+
+function isReasoningModel(id: string): boolean {
+	return /auto|claude-opus|claude-sonnet|deepseek|gpt|glm|qwen/i.test(id);
+}
+
+function createBootstrapModel(
+	id: string,
+	options: Partial<Pick<KiroModelSpec, "reasoning" | "input" | "contextWindow" | "maxTokens" | "thinking">> = {},
+): KiroModelSpec {
+	return {
+		id,
+		name: id
+			.split("-")
+			.map(part => part.charAt(0).toUpperCase() + part.slice(1))
+			.join(" "),
+		api: KIRO_API,
+		provider: "kiro",
+		baseUrl: KIRO_RUNTIME,
+		reasoning: options.reasoning ?? isReasoningModel(id),
+		input: options.input ?? (/^(auto|claude)/i.test(id) ? ["text", "image"] : ["text"]),
+		supportsTools: true,
+		cost: { ...ZERO_COST },
+		contextWindow: options.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+		maxTokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+		...(options.thinking ? { thinking: options.thinking } : {}),
+		kiroModelId: id,
+	};
+}
+
+/** Safe offline bootstrap; authenticated discovery replaces it with the profile catalog. */
+export const KIRO_MODELS: readonly KiroModelSpec[] = [
+	createBootstrapModel("auto", { contextWindow: 1_000_000, maxTokens: 65_536, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-opus-5", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-sonnet-5", { contextWindow: 1_000_000, maxTokens: 65_536, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-opus-4.8", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-opus-4.7", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-opus-4.6", { maxTokens: 32_768, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-sonnet-4.6", { maxTokens: 65_536, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-opus-4.5", { maxTokens: 65_536, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-sonnet-4.5", { maxTokens: 65_536, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-sonnet-4", { maxTokens: 65_536, thinking: KIRO_THINKING }),
+	createBootstrapModel("claude-haiku-4.5", { reasoning: false, maxTokens: 65_536 }),
+	createBootstrapModel("gpt-5.6-sol", { thinking: KIRO_THINKING }),
+	createBootstrapModel("gpt-5.6-terra", { thinking: KIRO_THINKING }),
+	createBootstrapModel("gpt-5.6-luna", { thinking: KIRO_THINKING }),
+	createBootstrapModel("deepseek-3.2", { thinking: KIRO_THINKING }),
+	createBootstrapModel("minimax-m2.5", { reasoning: false }),
+	createBootstrapModel("minimax-m2.1", { reasoning: false }),
+	createBootstrapModel("glm-5", { thinking: KIRO_THINKING }),
+	createBootstrapModel("qwen3-coder-next", { thinking: KIRO_THINKING }),
+];
+
+function dynamicThinking(schema: Record<string, unknown> | null | undefined): ThinkingConfig | undefined {
+	return schema ? KIRO_THINKING : undefined;
+}
+
+export function mapKiroCatalogToModelSpecs(catalog: readonly KiroCatalogModel[], region: string): KiroModelSpec[] {
+	const seen = new Set<string>();
+	return catalog.map(model => {
+		const id = model.modelId.trim();
+		if (!id || seen.has(id)) throw new Error(`Kiro management catalog contains duplicate model ID ${id}`);
+		seen.add(id);
+		const existing = KIRO_MODELS.find(candidate => candidate.kiroModelId === id || candidate.id === id);
+		const limits = model.tokenLimits;
+		const schema = model.additionalModelRequestFieldsSchema;
+		return {
+			...(existing ?? createBootstrapModel(id)),
+			id,
+			name: model.displayName?.trim() || existing?.name || id,
+			api: KIRO_API,
+			provider: "kiro",
+			baseUrl: getKiroEndpoints(region).runtime,
+			reasoning: schema !== undefined ? true : (existing?.reasoning ?? isReasoningModel(id)),
+			contextWindow: limits?.maxInputTokens ?? existing?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+			maxTokens: limits?.maxOutputTokens ?? existing?.maxTokens ?? DEFAULT_MAX_TOKENS,
+			supportsTools: true,
+			kiroModelId: id,
+			kiroRegion: region,
+			...(schema ? { additionalModelRequestFieldsSchema: schema, thinking: dynamicThinking(schema) } : {}),
+		};
+	});
+}
+
+export function parseKiroApiKey(value: string | undefined): {
+	token: string;
+	region?: string;
+	profileArn?: string;
+} {
+	if (!value?.startsWith("{")) return { token: value ?? "" };
+	try {
+		const parsed = JSON.parse(value) as { token?: unknown; region?: unknown; profileArn?: unknown };
+		if (typeof parsed.token === "string" && parsed.token.length > 0) {
+			return {
+				token: parsed.token,
+				region: typeof parsed.region === "string" ? parsed.region : undefined,
+				profileArn: typeof parsed.profileArn === "string" ? parsed.profileArn : undefined,
+			};
+		}
+	} catch {
+		// Treat malformed structured values as raw bearer values for compatibility.
+	}
+	return { token: value };
+}
+
+export function kiroCacheProviderId(apiKey: string | undefined, baseUrl?: string): string {
+	const parsed = parseKiroApiKey(apiKey);
+	const region = resolveKiroApiRegion(parsed.region ?? getKiroRegionFromEndpoint(baseUrl));
+	const profileFingerprint = parsed.profileArn ? Bun.hash(parsed.profileArn).toString(36) : "default";
+	return `kiro:${region}:${profileFingerprint}`;
+}

--- a/packages/catalog/src/provider-models/kiro.ts
+++ b/packages/catalog/src/provider-models/kiro.ts
@@ -225,9 +225,15 @@ function createBootstrapModel(
 	};
 }
 
+export const KIRO_AUTO_MODEL = createBootstrapModel("auto", {
+	contextWindow: 1_000_000,
+	maxTokens: 65_536,
+	thinking: KIRO_THINKING,
+});
+
 /** Safe offline bootstrap; authenticated discovery replaces it with the profile catalog. */
 export const KIRO_MODELS: readonly KiroModelSpec[] = [
-	createBootstrapModel("auto", { contextWindow: 1_000_000, maxTokens: 65_536, thinking: KIRO_THINKING }),
+	KIRO_AUTO_MODEL,
 	createBootstrapModel("claude-opus-5", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),
 	createBootstrapModel("claude-sonnet-5", { contextWindow: 1_000_000, maxTokens: 65_536, thinking: KIRO_THINKING }),
 	createBootstrapModel("claude-opus-4.8", { contextWindow: 1_000_000, maxTokens: 128_000, thinking: KIRO_THINKING }),

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -5,6 +5,14 @@ import { buildGitLabDuoWorkflowFallbackModel, fetchGitLabDuoWorkflowModels } fro
 import type { ModelManagerOptions } from "../model-manager";
 import type { FetchImpl, ModelSpec } from "../types";
 import { resolveModelCacheProviderId } from "./cache-provider-id";
+import {
+	fetchKiroModelCatalog,
+	KIRO_MODELS,
+	kiroCacheProviderId,
+	mapKiroCatalogToModelSpecs,
+	parseKiroApiKey,
+	resolveKiroApiRegion,
+} from "./kiro";
 
 // ---------------------------------------------------------------------------
 // OpenAI Codex
@@ -210,4 +218,45 @@ export interface ZaiModelManagerConfig {}
 
 export function zaiModelManagerOptions(_config: ZaiModelManagerConfig = {}): ModelManagerOptions<"anthropic-messages"> {
 	return { providerId: "zai" };
+}
+
+// ---------------------------------------------------------------------------
+// Kiro
+// ---------------------------------------------------------------------------
+
+export interface KiroModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+/**
+ * Kiro's catalog is profile- and region-scoped. The static bootstrap remains
+ * available offline; an authenticated List-Available-Models response replaces
+ * it for the current profile.
+ */
+export function kiroModelManagerOptions(config: KiroModelManagerConfig = {}): ModelManagerOptions<"kiro-api"> {
+	const parsed = parseKiroApiKey(config.apiKey);
+	const region = resolveKiroApiRegion(parsed.region);
+	return {
+		providerId: "kiro",
+		staticModels: KIRO_MODELS,
+		cacheProviderId: kiroCacheProviderId(config.apiKey, config.baseUrl),
+		dynamicModelsAuthoritative: true,
+		...(parsed.token
+			? {
+					fetchDynamicModels: async () => {
+						const { response, profileArn } = await fetchKiroModelCatalog(
+							{ accessToken: parsed.token, region },
+							parsed.profileArn,
+							config.fetch,
+						);
+						return mapKiroCatalogToModelSpecs(response.models, region).map(model => ({
+							...model,
+							kiroProfileArn: profileArn,
+						}));
+					},
+				}
+			: undefined),
+	};
 }

--- a/packages/catalog/test/kiro.test.ts
+++ b/packages/catalog/test/kiro.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { KiroCatalogModel } from "@oh-my-pi/pi-catalog/provider-models/kiro";
+import {
+	KIRO_AUTO_MODEL,
+	KIRO_MODELS,
+	kiroCacheProviderId,
+	mapKiroCatalogToModelSpecs,
+} from "@oh-my-pi/pi-catalog/provider-models/kiro";
+
+function catalogModel(overrides: Partial<KiroCatalogModel>): KiroCatalogModel {
+	return { modelId: "gpt-5.6-sol", ...overrides };
+}
+
+describe("mapKiroCatalogToModelSpecs", () => {
+	test("maps IMAGE in supportedInputTypes into image-capable input", () => {
+		const specs = mapKiroCatalogToModelSpecs([catalogModel({ supportedInputTypes: ["TEXT", "IMAGE"] })], "us-east-1");
+		expect(specs[0].input).toEqual(["text", "image"]);
+	});
+
+	test("maps text-only catalogs to text-only input", () => {
+		const specs = mapKiroCatalogToModelSpecs(
+			[catalogModel({ modelId: "glm-5", supportedInputTypes: ["TEXT"] })],
+			"us-east-1",
+		);
+		expect(specs[0].input).toEqual(["text"]);
+	});
+
+	test("falls back to the bootstrap input when supportedInputTypes is absent", () => {
+		const imageCapable = mapKiroCatalogToModelSpecs([catalogModel({ modelId: "gpt-5.6-sol" })], "us-east-1");
+		const textOnly = mapKiroCatalogToModelSpecs([catalogModel({ modelId: "glm-5" })], "us-east-1");
+		expect(imageCapable[0].input).toEqual(["text", "image"]);
+		expect(textOnly[0].input).toEqual(["text"]);
+	});
+
+	test("prefers modelName over displayName for the spec name", () => {
+		const specs = mapKiroCatalogToModelSpecs(
+			[catalogModel({ modelId: "deepseek-3.2", modelName: "DeepSeek V3.2", displayName: "Legacy Label" })],
+			"us-east-1",
+		);
+		expect(specs[0].name).toBe("DeepSeek V3.2");
+	});
+});
+
+describe("KIRO_MODELS runtime fallback", () => {
+	const EXPECTED = [
+		["gpt-5.6-sol", 272_000, ["text", "image"]],
+		["gpt-5.6-terra", 272_000, ["text", "image"]],
+		["gpt-5.6-luna", 272_000, ["text", "image"]],
+		["deepseek-3.2", 164_000, ["text", "image"]],
+		["minimax-m2.5", 196_000, ["text"]],
+		["minimax-m2.1", 196_000, ["text", "image"]],
+		["glm-5", 200_000, ["text"]],
+		["qwen3-coder-next", 256_000, ["text", "image"]],
+	] as const;
+
+	test("pins the eight Kiro CLI 2.19.2 models with accurate context and image support", () => {
+		expect(KIRO_MODELS.map(model => model.id)).toEqual(EXPECTED.map(([id]) => id));
+		for (const [id, contextWindow, input] of EXPECTED) {
+			const model = KIRO_MODELS.find(candidate => candidate.id === id);
+			if (!model) throw new Error(`missing ${id}`);
+			expect(model.contextWindow, id).toBe(contextWindow);
+			expect(model.input, id).toEqual([...input]);
+		}
+	});
+
+	test("keeps KIRO_AUTO_MODEL independent from the runtime fallback", () => {
+		expect(KIRO_AUTO_MODEL.id).toBe("auto");
+		expect(KIRO_MODELS.some(model => model.id === "auto")).toBe(false);
+		expect(KIRO_AUTO_MODEL.contextWindow).toBe(1_000_000);
+		expect(KIRO_AUTO_MODEL.input).toEqual(["text", "image"]);
+	});
+});
+
+describe("kiroCacheProviderId", () => {
+	test("namespaces anonymous setups under default", () => {
+		expect(kiroCacheProviderId(undefined)).toBe("kiro:us-east-1:default");
+		expect(kiroCacheProviderId("")).toBe("kiro:us-east-1:default");
+	});
+
+	test("scopes distinct bearer tokens to distinct cache namespaces without leaking the token", () => {
+		const first = kiroCacheProviderId("kiro-token-aaaa");
+		const second = kiroCacheProviderId("kiro-token-bbbb");
+		expect(first).not.toBe(second);
+		expect(first).toBe(kiroCacheProviderId("kiro-token-aaaa"));
+		expect(first).not.toContain("kiro-token-aaaa");
+		expect(second).not.toContain("kiro-token-bbbb");
+	});
+
+	test("scopes structured credentials by token and keeps the profile fingerprint", () => {
+		const key = kiroCacheProviderId(
+			JSON.stringify({ token: "struct-token", region: "eu-central-1", profileArn: "arn:kiro:profile:abc" }),
+		);
+		expect(key.startsWith("kiro:eu-central-1:")).toBe(true);
+		expect(key).not.toContain("struct-token");
+		expect(key).not.toContain("arn:kiro:profile:abc");
+		expect(key.endsWith(Bun.hash("arn:kiro:profile:abc").toString(36))).toBe(true);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -437,6 +437,8 @@
 
 ### Added
 
+- Added Kiro model availability and runtime routing to the coding agent ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 - Added `providers.cacheRetention` setting (`/settings` → Providers → Protocol) to control prompt-cache retention per request: `auto` keeps the provider default (Anthropic: 5m entries with idle keep-alive refreshes), `short` forces 5m, `long` restores 1h TTLs where supported and disables the keep-alive refresh loop, `none` disables prompt caching.
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -438,6 +438,8 @@
 ### Added
 
 - Added Kiro model availability and runtime routing to the coding agent ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+- Added `ProviderConfig.usage` so extensions can contribute standard usage reports to both `/usage` and `omp usage`; extension providers share the existing provider registration and cleanup lifecycle, while built-in usage providers remain the fallback ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+- Added optional `ExtensionUIContext.setStatusLine()` so provider extensions can render compact billing/metering text inside the main status line instead of consuming a separate hook-status row ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
 
 - Added `providers.cacheRetention` setting (`/settings` → Providers → Protocol) to control prompt-cache retention per request: `auto` keeps the provider default (Anthropic: 5m entries with idle keep-alive refreshes), `short` forces 5m, `long` restores 1h TTLs where supported and disables the keep-alive refresh loop, `none` disables prompt caching.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Kiro model availability and runtime routing to the coding agent, including extension-provided Credits in `omp usage` and inline provider billing through optional `ExtensionUIContext.setStatusLine()` ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added
@@ -437,9 +441,6 @@
 
 ### Added
 
-- Added Kiro model availability and runtime routing to the coding agent ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
-- Added `ProviderConfig.usage` so extensions can contribute standard usage reports to both `/usage` and `omp usage`; extension providers share the existing provider registration and cleanup lifecycle, while built-in usage providers remain the fallback ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
-- Added optional `ExtensionUIContext.setStatusLine()` so provider extensions can render compact billing/metering text inside the main status line instead of consuming a separate hook-status row ([#8758](https://github.com/can1357/oh-my-pi/pull/8758) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
 
 - Added `providers.cacheRetention` setting (`/settings` → Providers → Protocol) to control prompt-cache retention per request: `auto` keeps the provider default (Anthropic: 5m entries with idle keep-alive refreshes), `short` forces 5m, `long` restores 1h TTLs where supported and disables the keep-alive refresh loop, `none` disables prompt caching.
 

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -17,10 +17,11 @@ import {
 	type UsageReport,
 	type UsageUnit,
 } from "@oh-my-pi/pi-ai";
-import { formatDuration, formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, formatNumber, getProjectDir, sanitizeText } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { ModelRegistry } from "../config/model-registry";
-import { discoverAuthStorage } from "../sdk";
+import { Settings } from "../config/settings";
+import { discoverAuthStorage, loadCliExtensionProviders } from "../sdk";
 
 const BAR_WIDTH = 28;
 
@@ -33,6 +34,13 @@ export interface UsageCommandArgs {
 	history?: boolean;
 	/** History window in days (with `history`). */
 	days?: number;
+}
+
+export interface RunUsageCommandOptions {
+	agentDir?: string;
+	cwd?: string;
+	additionalExtensionPaths?: string[];
+	disableExtensionDiscovery?: boolean;
 }
 
 /** Identity slice of a stored credential, for "every account" coverage. */
@@ -210,6 +218,7 @@ function formatUnitValue(value: number, unit: UsageUnit): string {
 
 const UNIT_SUFFIX: Record<UsageUnit, string> = {
 	tokens: " tokens",
+	credits: " credits",
 	requests: " requests",
 	minutes: " min",
 	bytes: " bytes",
@@ -935,8 +944,8 @@ function redactReportForJson(
 	return { ...report, metadata, limits };
 }
 
-export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
-	const authStorage = await discoverAuthStorage();
+export async function runUsageCommand(cmd: UsageCommandArgs, options: RunUsageCommandOptions = {}): Promise<void> {
+	const authStorage = await discoverAuthStorage(options.agentDir);
 	try {
 		if (cmd.action === "invalidate") {
 			const provider = cmd.provider?.toLowerCase();
@@ -980,6 +989,12 @@ export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
 			return;
 		}
 		const modelRegistry = new ModelRegistry(authStorage);
+		const cwd = options.cwd ?? getProjectDir();
+		const settings = await Settings.init({ cwd });
+		await loadCliExtensionProviders(modelRegistry, settings, cwd, {
+			additionalExtensionPaths: options.additionalExtensionPaths,
+			disableExtensionDiscovery: options.disableExtensionDiscovery,
+		});
 		const reports =
 			(await authStorage.fetchUsageReports({
 				baseUrlResolver: provider => modelRegistry.getProviderBaseUrl(provider),

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -27,6 +27,7 @@ import {
 	googleAntigravityModelManagerOptions,
 	googleGeminiCliModelManagerOptions,
 	isCredentialScopedModelCacheProvider,
+	kiroModelManagerOptions,
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
 	resolveModelCacheProviderId,
@@ -1612,6 +1613,17 @@ export class ModelRegistry {
 						oauthToken,
 						projectId: extractGoogleOAuthProjectId(raw) ?? this.#resolveGeminiCliDiscoveryProjectId(oauthToken),
 						endpoint: this.#descriptorBaseUrl("google-gemini-cli"),
+						fetch: this.#fetch,
+					}),
+			},
+			{
+				providerId: "kiro",
+				authoritative: true,
+				resolveKey: value => value,
+				createOptions: apiKey =>
+					kiroModelManagerOptions({
+						apiKey,
+						baseUrl: this.#descriptorBaseUrl("kiro"),
 						fetch: this.#fetch,
 					}),
 			},

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -284,6 +284,12 @@ export interface ExtensionUIContext {
 	/** Set status text in the footer/status bar. Pass undefined to clear. */
 	setStatus(key: string, text: string | undefined): void;
 
+	/**
+	 * Set compact extension text inside the main status line. Use for provider
+	 * billing/metering that belongs beside the built-in cost segment.
+	 */
+	setStatusLine?(key: string, text: string | undefined): void;
+
 	/** Set the working/loading message shown during streaming. Call with no argument to restore default. */
 	setWorkingMessage(message?: string): void;
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1752,7 +1752,8 @@ export class StatusLineComponent implements Component {
 			usageStats,
 			inlineStatuses: Array.from(this.#inlineStatuses.entries())
 				.sort(([a], [b]) => a.localeCompare(b))
-				.map(([, text]) => sanitizeStatusText(text)),
+				.map(([, text]) => sanitizeStatusText(text))
+				.filter(text => visibleWidth(text) > 0),
 			contextPercent,
 			contextTokens,
 			contextWindow,

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -382,6 +382,7 @@ export class StatusLineComponent implements Component {
 	#speculationBlinkTimer: NodeJS.Timeout | undefined;
 	#speculationBlinkOn = true;
 	#hookStatuses: Map<string, string> = new Map();
+	#inlineStatuses: Map<string, string> = new Map();
 	#subagentCount: number = 0;
 	/**
 	 * Active-processing accounting for the `time_spent` segment, keyed per
@@ -695,6 +696,14 @@ export class StatusLineComponent implements Component {
 			this.#hookStatuses.delete(key);
 		} else {
 			this.#hookStatuses.set(key, text);
+		}
+	}
+
+	setInlineStatus(key: string, text: string | undefined): void {
+		if (text === undefined) {
+			this.#inlineStatuses.delete(key);
+		} else {
+			this.#inlineStatuses.set(key, text);
 		}
 	}
 
@@ -1741,6 +1750,9 @@ export class StatusLineComponent implements Component {
 			vibeMode: this.#vibeModeStatus,
 			collab: this.#collabStatus,
 			usageStats,
+			inlineStatuses: Array.from(this.#inlineStatuses.entries())
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([, text]) => sanitizeStatusText(text)),
 			contextPercent,
 			contextTokens,
 			contextWindow,

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -457,15 +457,16 @@ const costSegment: StatusLineSegment = {
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? (ctx.session.modelRegistry?.isUsingOAuth(state.model) ?? false) : false;
 		const advisorUsingSubscription = ctx.session.isAdvisorUsingSubscription?.() ?? false;
+		const inlineStatuses = ctx.inlineStatuses ?? [];
 
-		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
+		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests && inlineStatuses.length === 0) {
 			return { content: "", visible: false };
 		}
 
-		const billingParts: string[] = [];
+		const billingParts: string[] = [...inlineStatuses];
 		if (cost) {
 			billingParts.push(formatSpend(cost, usingSubscription, theme));
-		} else if (usingSubscription) {
+		} else if (usingSubscription && inlineStatuses.length === 0) {
 			billingParts.push(
 				theme.getSymbolPreset() === "nerd" && theme.icon.subscription ? theme.icon.subscription : "(sub)",
 			);

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -103,6 +103,8 @@ export interface SegmentContext {
 		cost: number;
 		tokensPerSecond: number | null;
 	};
+	/** Compact extension-provided text rendered beside built-in billing. */
+	inlineStatuses?: readonly string[];
 	/** Context usage percent, or null when unknown (e.g. right after compaction). */
 	contextPercent: number | null;
 	contextTokens: number;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1684,6 +1684,19 @@ function resolveAggregateStatus(limits: UsageLimit[]): AggregateDisplayStatus {
 }
 
 function formatAggregateAmount(limits: UsageLimit[]): string {
+	const creditAmounts = limits
+		.map(limit => limit.amount)
+		.filter(
+			amount =>
+				amount.unit === "credits" && amount.used !== undefined && amount.limit !== undefined && amount.limit > 0,
+		);
+	if (creditAmounts.length === limits.length && creditAmounts.length > 0) {
+		const used = creditAmounts.reduce((total, amount) => total + (amount.used ?? 0), 0);
+		const limit = creditAmounts.reduce((total, amount) => total + (amount.limit ?? 0), 0);
+		const remainingPct = Math.max(0, 100 - (used / limit) * 100);
+		return `${formatNumber(used, 2)} / ${formatNumber(limit, 2)} credits · ${formatNumber(remainingPct)}% free`;
+	}
+
 	const fractions = limits
 		.map(limit => resolveUsedFraction(limit))
 		.filter((value): value is number => value !== undefined);

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -108,6 +108,7 @@ export class ExtensionUiController {
 			notify: (message, type) => this.showHookNotify(message, type),
 			onTerminalInput: handler => this.addExtensionTerminalInputListener(handler),
 			setStatus: (key, text) => this.setHookStatus(key, text),
+			setStatusLine: (key, text) => this.setInlineStatus(key, text),
 			setWorkingMessage: message => this.ctx.setWorkingMessage(message),
 			setWidget: (key, content, options) => this.setHookWidget(key, content, options),
 			setTitle: title => setExtensionTerminalTitle(title),
@@ -574,6 +575,11 @@ export class ExtensionUiController {
 	 */
 	setHookStatus(key: string, text: string | undefined): void {
 		this.ctx.statusLine.setHookStatus(key, text);
+		this.ctx.ui.requestRender();
+	}
+
+	setInlineStatus(key: string, text: string | undefined): void {
+		this.ctx.statusLine.setInlineStatus(key, text);
 		this.ctx.ui.requestRender();
 	}
 

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -185,4 +185,18 @@ describe("StatusLineComponent", () => {
 			setThemeInstance(baseTheme);
 		}
 	});
+
+	it("renders extension billing inline instead of as a hook-status row", () => {
+		const statusLine = new StatusLineComponent(
+			makeSessionWithLastMessage(null, false, {
+				usingSubscription: true,
+			}) as unknown as AgentSession,
+		);
+		statusLine.setInlineStatus("kiro-credits", "0.006 credits");
+
+		const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(stripped).toContain("0.006 credits");
+		expect(stripped).not.toContain("(sub)");
+		expect(statusLine.render(WIDE_ENOUGH_FOR_COST_SEGMENT)).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -199,4 +199,16 @@ describe("StatusLineComponent", () => {
 		expect(stripped).not.toContain("(sub)");
 		expect(statusLine.render(WIDE_ENOUGH_FOR_COST_SEGMENT)).toEqual([]);
 	});
+
+	it("ignores empty inline status text and preserves the subscription marker", () => {
+		const statusLine = new StatusLineComponent(
+			makeSessionWithLastMessage(null, false, {
+				usingSubscription: true,
+			}) as unknown as AgentSession,
+		);
+		statusLine.setInlineStatus("empty", "");
+
+		const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(stripped).toContain("(sub)");
+	});
 });

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
-import type { UsageReport } from "@oh-my-pi/pi-ai";
+import { AuthStorage, type UsageReport } from "@oh-my-pi/pi-ai";
 import {
 	buildRedactionMap,
 	collectUnreportedAccounts,
 	computeProviderWindowStats,
 	formatUsageBreakdown,
 	formatUsageHistory,
+	runUsageCommand,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
 
@@ -610,5 +614,68 @@ describe("formatUsageHistory", () => {
 		const text = stripVTControlCharacters(formatUsageHistory(entries, SINCE, NOW, redaction));
 		expect(text).not.toContain("dummy.primary@example.test");
 		expect(text).toContain("du*");
+	});
+});
+
+describe.serial("runUsageCommand extension integration", () => {
+	it("loads an extension UsageProvider before fetching stored-account usage", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-usage-extension-"));
+		const agentDir = path.join(root, "agent");
+		const extensionPath = path.join(root, "usage-extension.mjs");
+		await fs.mkdir(agentDir, { recursive: true });
+		await fs.writeFile(
+			extensionPath,
+			[
+				"export default function register(pi) {",
+				'  pi.registerProvider("fixture-usage", {',
+				"    usage: {",
+				'      id: "fixture-usage",',
+				'      supports: params => params.credential.type === "api_key",',
+				"      async fetchUsage() {",
+				"        return {",
+				'          provider: "fixture-usage",',
+				"          fetchedAt: Date.now(),",
+				"          limits: [{",
+				'            id: "credits",',
+				'            label: "Credits",',
+				'            scope: { provider: "fixture-usage" },',
+				'            amount: { used: 2, limit: 10, remaining: 8, usedFraction: 0.2, unit: "credits" },',
+				"          }],",
+				"        };",
+				"      },",
+				"    },",
+				"  });",
+				"}",
+			].join("\n"),
+		);
+
+		const seed = await AuthStorage.create(path.join(agentDir, "agent.db"));
+		await seed.set("fixture-usage", { type: "api_key", key: "fixture-key" });
+		seed.close();
+
+		const originalWrite = process.stdout.write.bind(process.stdout);
+		let output = "";
+		process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+			output += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			await runUsageCommand(
+				{ provider: "fixture-usage" },
+				{
+					agentDir,
+					cwd: root,
+					additionalExtensionPaths: [extensionPath],
+					disableExtensionDiscovery: true,
+				},
+			);
+		} finally {
+			process.stdout.write = originalWrite;
+			await fs.rm(root, { recursive: true, force: true });
+		}
+
+		const text = stripVTControlCharacters(output);
+		expect(text).toContain("Fixture Usage");
+		expect(text).toContain("2 / 10 credits");
 	});
 });

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -139,6 +139,33 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(text).not.toContain("1 accts");
 	});
 
+	it("renders absolute credit usage alongside the remaining percentage", () => {
+		const reports: UsageReport[] = [
+			report("kiro", "kiro@example.test", [
+				{
+					id: "credits",
+					label: "Credits",
+					scope: { provider: "kiro", accountId: "kiro-account", tier: "KIRO PRO" },
+					window: { id: "billing-cycle", label: "Billing cycle" },
+					amount: {
+						used: 558.34,
+						limit: 1000,
+						remaining: 441.66,
+						usedFraction: 0.55834,
+						remainingFraction: 0.44166,
+						unit: "credits",
+					},
+					status: "ok",
+				},
+			]),
+		];
+
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 160));
+
+		expect(text).toContain("558.34 / 1,000 credits");
+		expect(text).toContain("44.2% free");
+	});
+
 	it("preserves capped aggregate status when a group mixes capped and used-only amounts", () => {
 		const reports: UsageReport[] = [
 			report("anthropic", "capped@example.test", [


### PR DESCRIPTION
## Summary

- Add first-party Kiro OAuth device-code login, refresh, current-account model discovery, and AWS EventStream runtime support.
- Preserve refresh metadata and definitive OAuth error codes without weakening existing providers.
- Track Kiro CLI 2.19.2's account-scoped eight-model catalog, including image capabilities, region/profile routing, and credential-scoped model-cache identity.
- Handle modeled EventStream exceptions, safe HTTP validation details, context usage, estimated output tokens/TTFT/duration, and native credit metering.
- Retry the transient fleet-only HTTP 400 `Invalid tool use format.` exactly once with an identical payload and fresh request identity; other validation errors remain terminal.
- Add a `credits` usage unit across local and auth-broker wire paths; load extension providers before `omp usage`, including broker-backed runtime-provider report merging.
- Add optional `ExtensionUIContext.setStatusLine()` so provider billing such as Kiro per-turn/session Credits can replace the bare `(sub)` marker in the main status line while old hosts keep the `setStatus` fallback.

## Validation

- Rebased onto `origin/main` (`18.0.6`); PR remains mergeable with no commits behind main.
- Targeted matrix: **85 passed, 372 assertions** across Kiro OAuth/protocol/EventStream/retry, catalog mapping/cache identity, local+broker usage, CLI extension loading, TUI usage, and inline status rendering.
- `packages/ai` typecheck passed.
- `packages/catalog` typecheck passed.
- `packages/coding-agent` typecheck passed.
- Targeted Biome checks passed; `git diff --check` passed.
- `models.json` is a minimal generated `kiro/auto` addition over current main (39-line diff), produced from `KIRO_AUTO_MODEL`/`buildModel` rather than hand-authored model data.
- Real local Kiro verification: current eight-model catalog; valid model request returns `OK`; TUI shows token speed and inline `Kiro <turn> credits · Σ <session total>`.
- Remote reproduction on `tsv40`, session `01a032c8-f82d-74d7-a951-9d2666564662`: original 400 captured; identical full history/tools payload now returns HTTP 200; interactive retry proceeds through read/task/web_search; `omp-kiro@1.2.5` tool-call-followup test completes with `OK`.
- Companion plugin: `omp-kiro@1.2.5`, **44 tests / 243 assertions**, with old-host status fallback retained.
