### PR TITLE
perf(session): store snapcompact frames in the blob store

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Snapcompact frame archives now persist as blob references instead of inline base64, so a resumed session no longer materializes the frames of every past compaction; only the archive the rebuilt context injects is resolved back to image bytes. On a 171.7 MiB journal with 30k entries: journal 130.9 MiB (-24%), retained JSC heap 642.9 -> 479.9 MiB (-25%), resume 564 -> 374 ms (-34%), and identical frames across compactions now share one content-addressed blob (40.8 MiB of frames stored as 19.8 MiB). Journals written before this change keep working and convert on their next full rewrite.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { coerceServiceTierByFamily, type ProviderPayload, type ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import * as snapcompact from "@oh-my-pi/snapcompact";
+import { isBlobRef } from "./blob-store";
 import {
 	createBranchSummaryMessage,
 	createCompactionSummaryMessage,
@@ -129,6 +130,13 @@ export interface BuildSessionContextOptions {
 	 * hides the call the agent is still waiting on.
 	 */
 	keepDanglingToolCalls?: boolean;
+	/**
+	 * Turn a persisted snapcompact frame payload back into image bytes. Frames
+	 * live in the blob store, so only the archive a rebuilt context actually
+	 * injects is resolved — superseded archives stay as references and cost
+	 * nothing to keep around.
+	 */
+	resolveFrameData?: (data: string) => string;
 }
 
 /**
@@ -153,6 +161,33 @@ function snapcompactHistoryBlocksForContext(
 	if (!archive) return undefined;
 	if (options?.transcript && options.collapseCompactedHistory) return undefined;
 	return snapcompact.historyBlocks(archive, snapcompactHistoryBlockOptions(archive, options));
+}
+
+/**
+ * Resolve the frame payloads of the one archive this context injects. A frame
+ * whose blob has gone missing resolves back to its own reference; drop it rather
+ * than hand a `blob:sha256:…` string to a provider as if it were an image.
+ */
+function resolveArchiveFrames(
+	archive: snapcompact.Archive | undefined,
+	options: BuildSessionContextOptions | undefined,
+): snapcompact.Archive | undefined {
+	const resolve = options?.resolveFrameData;
+	if (!archive || !resolve || archive.frames.length === 0) return archive;
+
+	let changed = false;
+	const frames: snapcompact.Frame[] = [];
+	for (const frame of archive.frames) {
+		if (!isBlobRef(frame.data)) {
+			frames.push(frame);
+			continue;
+		}
+		changed = true;
+		const data = resolve(frame.data);
+		if (isBlobRef(data)) continue;
+		frames.push({ ...frame, data });
+	}
+	return changed ? { ...archive, frames } : archive;
 }
 
 export function getOpenAiRemoteCompactionPayload(
@@ -366,7 +401,9 @@ export function buildSessionContext(
 			handleEntryResetTracking(entry);
 			if (entry.type === "compaction") {
 				const active = entry.id === compaction?.id;
-				const snapcompactArchive = active ? snapcompact.getPreservedArchive(entry.preserveData) : undefined;
+				const snapcompactArchive = active
+					? resolveArchiveFrames(snapcompact.getPreservedArchive(entry.preserveData), options)
+					: undefined;
 				pushMessage(
 					createCompactionSummaryMessage(
 						active ? entry.summary : SUPERSEDED_COMPACTION_SUMMARY,
@@ -409,7 +446,10 @@ export function buildSessionContext(
 
 		// Re-attach any archived snapcompact frames so the model can keep
 		// reading the archived history after every context rebuild.
-		const snapcompactArchive = snapcompact.getPreservedArchive(compaction.preserveData);
+		const snapcompactArchive = resolveArchiveFrames(
+			snapcompact.getPreservedArchive(compaction.preserveData),
+			options,
+		);
 		const compactionSummaryMsg = createCompactionSummaryMessage(
 			compaction.summary,
 			compaction.tokensBefore,

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
-import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./blob-store";
+import { BlobStore, isBlobRef, resolveImageData, resolveImageDataSync, resolveImageDataUrl } from "./blob-store";
 import { buildSessionContext } from "./session-context";
 import type { FileEntry, RawFileEntry, SessionEntry, SessionHeader } from "./session-entries";
 import { migrateToCurrentVersion } from "./session-migrations";
@@ -395,10 +395,12 @@ export async function loadSessionMessagesReadOnly(filePath: string): Promise<Age
 	const entries = await loadEntriesFromFile(filePath);
 	if (entries.length === 0) return [];
 	migrateToCurrentVersion(entries);
-	await resolveBlobRefsInEntries(entries, new BlobStore(getBlobsDir()));
+	const blobs = new BlobStore(getBlobsDir());
+	await resolveBlobRefsInEntries(entries, blobs);
 	const sessionEntries = entries.filter((e): e is SessionEntry => e.type !== "session");
 	return buildSessionContext(sessionEntries, undefined, undefined, {
 		transcript: true,
 		collapseCompactedHistory: true,
+		resolveFrameData: data => resolveImageDataSync(blobs, data),
 	}).messages;
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -20,7 +20,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import type { StructuredSubagentSchemaMode } from "../task/types";
 import { ArtifactManager } from "./artifacts";
-import { type BlobPutOptions, type BlobPutResult, BlobStore } from "./blob-store";
+import { type BlobPutOptions, type BlobPutResult, BlobStore, resolveImageDataSync } from "./blob-store";
 import {
 	type BashExecutionMessage,
 	type CustomMessage,
@@ -2415,7 +2415,12 @@ export class SessionManager {
 	 * the full-history display transcript, from the current leaf path.
 	 */
 	buildSessionContext(options?: BuildSessionContextOptions): SessionContext {
-		return buildSessionContext(this.#entries, this.#index.leafId(), this.#index.entriesById(), options);
+		return buildSessionContext(this.#entries, this.#index.leafId(), this.#index.entriesById(), {
+			// Snapcompact frames persist as blob refs; only the archive this context
+			// injects is turned back into image bytes.
+			resolveFrameData: data => resolveImageDataSync(this.#blobs, data),
+			...options,
+		});
 	}
 
 	/** Strip stale OpenAI Responses assistant replay metadata from loaded entries. */

--- a/packages/coding-agent/src/session/session-persistence.ts
+++ b/packages/coding-agent/src/session/session-persistence.ts
@@ -1,4 +1,5 @@
 import { isAnthropicServerToolHistoryBlock } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
+import { PRESERVE_KEY as SNAPCOMPACT_PRESERVE_KEY } from "@oh-my-pi/snapcompact";
 import {
 	type BlobStore,
 	externalizeImageDataSync,
@@ -60,6 +61,33 @@ function shouldExternalizeImagePayload(
 	return (key === TEXT_CONTENT_KEY && isImageBlock(value)) || key === "images";
 }
 
+/**
+ * Rendered snapcompact frames are the heaviest thing a session persists: every
+ * compaction archives its own set of base64 PNGs, and a long-lived journal ends
+ * up carrying (and re-parsing on every resume) tens of megabytes that only the
+ * newest archive on the active path is ever asked for.
+ *
+ * They are image payloads like any other, so they belong in the blob store. Only
+ * the archive slot under `preserveData` is recognized here; arbitrary
+ * extension-provided `frames` keep persisting inline, because nothing would know
+ * to resolve them back.
+ */
+function externalizeSnapcompactFrames(archive: object, blobStore: BlobStore): object {
+	if (!("frames" in archive)) return archive;
+	const frames = archive.frames;
+	if (!Array.isArray(frames)) return archive;
+
+	let changed = false;
+	const externalized = frames.map(frame => {
+		if (!isImageDataPayload(frame) || isBlobRef(frame.data) || frame.data.length < BLOB_EXTERNALIZE_THRESHOLD) {
+			return frame;
+		}
+		changed = true;
+		return { ...frame, data: externalizeImageDataSync(blobStore, frame.data, frame.mimeType) };
+	});
+	return changed ? { ...archive, frames: externalized } : archive;
+}
+
 /** True for a non-empty string — marks signature/encrypted fields whose block must persist verbatim. */
 function isNonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.length > 0;
@@ -93,6 +121,12 @@ function truncateForPersistence(obj: unknown, blobStore: BlobStore, key?: string
 	}
 	if (shouldExternalizeImagePayload(obj, key)) {
 		return { ...obj, data: externalizeImageDataSync(blobStore, obj.data, obj.mimeType) };
+	}
+	if (key === SNAPCOMPACT_PRESERVE_KEY && typeof obj === "object") {
+		const externalized = externalizeSnapcompactFrames(obj, blobStore);
+		// Re-enter without the archive key so the rest of the archive (source text)
+		// still goes through the normal truncation walk exactly once.
+		if (externalized !== obj) return truncateForPersistence(externalized, blobStore);
 	}
 	// Signed content is bound to its exact bytes: a truncated `thinking`/`text`/
 	// `arguments` no longer matches its signature and a truncated

--- a/packages/coding-agent/test/session-manager/snapcompact-frame-blobs.test.ts
+++ b/packages/coding-agent/test/session-manager/snapcompact-frame-blobs.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { BlobStore, resolveImageDataSync } from "@oh-my-pi/pi-coding-agent/session/blob-store";
+import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getBlobsDir } from "@oh-my-pi/pi-utils";
+import * as snapcompact from "@oh-my-pi/snapcompact";
+
+/** Under the 500k persistence truncation limit, over the 1 KiB blob threshold. */
+const FRAME_DATA = "Zm".repeat(60_000);
+const FRAMES_PER_ARCHIVE = 4;
+
+function makeAssistantMessage(text: string) {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected built-in anthropic model to exist");
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: 2,
+	};
+}
+
+function makeArchive(marker: string) {
+	return {
+		[snapcompact.PRESERVE_KEY]: {
+			frames: Array.from({ length: FRAMES_PER_ARCHIVE }, () => ({
+				data: FRAME_DATA,
+				mimeType: "image/png",
+				cols: 196,
+				rows: 71,
+				chars: 13_916,
+				font: "8x13",
+				variant: "bw",
+			})),
+			totalChars: 13_916,
+			truncatedChars: 0,
+			text: `${marker}-source`,
+			textHead: `${marker}-head`,
+			textTail: `${marker}-tail`,
+		},
+		openaiRemoteCompaction: {
+			provider: "openai",
+			replacementHistory: [
+				{ type: "message", role: "user", content: [{ type: "input_text", text: `preserved ${marker}` }] },
+			],
+		},
+	};
+}
+
+function archiveFrames(session: SessionManager, entryId: string): snapcompact.Frame[] {
+	const entry = session.getEntry(entryId);
+	if (entry?.type !== "compaction") throw new Error(`Expected compaction ${entryId}`);
+	const archive = snapcompact.getPreservedArchive(entry.preserveData);
+	if (!archive) throw new Error(`Expected an archive on ${entryId}`);
+	return archive.frames;
+}
+
+function imageDataIn(messages: readonly unknown[]): string[] {
+	const found: string[] = [];
+	const walk = (value: unknown): void => {
+		if (Array.isArray(value)) {
+			for (const item of value) walk(item);
+			return;
+		}
+		if (!value || typeof value !== "object") return;
+		if ("type" in value && value.type === "image" && "data" in value && typeof value.data === "string") {
+			found.push(value.data);
+			return;
+		}
+		for (const item of Object.values(value)) walk(item);
+	};
+	walk(messages);
+	return found;
+}
+
+describe("snapcompact frames in the blob store", () => {
+	const tempDirs: string[] = [];
+
+	async function makeTempDir(): Promise<string> {
+		const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-frame-blobs-"));
+		tempDirs.push(dir);
+		return dir;
+	}
+
+	async function writeJournal(): Promise<{
+		sessionFile: string;
+		sessionDir: string;
+		firstId: string;
+		secondId: string;
+	}> {
+		const dir = await makeTempDir();
+		const sessionDir = path.join(dir, "sessions");
+		const session = SessionManager.create(dir, sessionDir);
+		const anchor = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+		const firstId = session.appendCompaction(
+			"first",
+			undefined,
+			anchor,
+			1000,
+			undefined,
+			undefined,
+			makeArchive("first"),
+		);
+		const between = session.appendMessage({ role: "user", content: "between", timestamp: 3 });
+		const secondId = session.appendCompaction(
+			"second",
+			undefined,
+			between,
+			2000,
+			undefined,
+			undefined,
+			makeArchive("second"),
+		);
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file");
+		await session.close();
+		return { sessionFile, sessionDir, firstId, secondId };
+	}
+
+	function reopen(sessionFile: string, sessionDir: string): Promise<SessionManager> {
+		return SessionManager.open(sessionFile, sessionDir, undefined, { suppressBreadcrumb: true });
+	}
+
+	afterEach(async () => {
+		await Promise.all(tempDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })));
+		tempDirs.length = 0;
+	});
+
+	it("persists frames as blob references instead of inline base64", async () => {
+		const { sessionFile } = await writeJournal();
+		const body = await Bun.file(sessionFile).text();
+
+		expect(body).not.toContain(FRAME_DATA);
+		expect(body).toContain("blob:sha256:");
+		// Two archives of identical frames collapse onto one content-addressed blob.
+		const refs = new Set(body.match(/blob:sha256:[0-9a-f]{64}/g) ?? []);
+		expect(refs.size).toBe(1);
+		expect(body.length).toBeLessThan(FRAME_DATA.length);
+	});
+
+	it("keeps frame payloads out of memory after a resume", async () => {
+		const { sessionFile, sessionDir, firstId, secondId } = await writeJournal();
+		const reopened = await reopen(sessionFile, sessionDir);
+
+		for (const id of [firstId, secondId]) {
+			for (const frame of archiveFrames(reopened, id)) {
+				expect(frame.data.startsWith("blob:sha256:")).toBe(true);
+			}
+		}
+		// Everything else in preserveData is untouched by this change.
+		const entry = reopened.getEntry(firstId);
+		if (entry?.type !== "compaction") throw new Error("Expected compaction");
+		expect(entry.preserveData?.openaiRemoteCompaction).toEqual(makeArchive("first").openaiRemoteCompaction);
+
+		await reopened.close();
+	});
+
+	it("builds the same context as inline frames, before and after a rewind", async () => {
+		const { sessionFile, sessionDir, firstId } = await writeJournal();
+		const reopened = await reopen(sessionFile, sessionDir);
+		const blobs = new BlobStore(getBlobsDir());
+
+		/** Control: the same entries with every frame ref resolved back inline. */
+		const inlineContext = (leafId: string | undefined) => {
+			const entries = reopened.getEntries().map(entry => {
+				if (entry.type !== "compaction") return entry;
+				const archive = snapcompact.getPreservedArchive(entry.preserveData);
+				if (!archive) return entry;
+				return {
+					...entry,
+					preserveData: {
+						...entry.preserveData,
+						[snapcompact.PRESERVE_KEY]: {
+							...archive,
+							frames: archive.frames.map(frame => ({ ...frame, data: resolveImageDataSync(blobs, frame.data) })),
+						},
+					},
+				} satisfies SessionEntry;
+			});
+			return buildSessionContext(entries, leafId, undefined, {}).messages;
+		};
+
+		const newestLeaf = reopened.getLeafId() ?? undefined;
+		expect(imageDataIn(inlineContext(newestLeaf))).toContain(FRAME_DATA);
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toEqual(imageDataIn(inlineContext(newestLeaf)));
+
+		reopened.branch(firstId);
+		expect(imageDataIn(inlineContext(firstId))).toContain(FRAME_DATA);
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toEqual(imageDataIn(inlineContext(firstId)));
+
+		await reopened.close();
+	});
+
+	it("drops a frame whose blob went missing instead of sending the reference", async () => {
+		const { sessionFile, sessionDir } = await writeJournal();
+		const body = await Bun.file(sessionFile).text();
+		const ref = body.match(/blob:sha256:([0-9a-f]{64})/);
+		if (!ref) throw new Error("Expected a frame blob reference");
+		await fsp.rm(path.join(getBlobsDir(), ref[1]!), { force: true });
+
+		const reopened = await reopen(sessionFile, sessionDir);
+		const images = imageDataIn(reopened.buildSessionContext().messages);
+		expect(images.some(data => data.startsWith("blob:sha256:"))).toBe(false);
+		expect(images).not.toContain(FRAME_DATA);
+
+		await reopened.close();
+	});
+
+	it("still reads a legacy journal that stored frames inline", async () => {
+		const { sessionFile, firstId } = await writeJournal();
+		const legacyDir = await makeTempDir();
+		const legacySessionDir = path.join(legacyDir, "sessions");
+		await fsp.mkdir(legacySessionDir, { recursive: true });
+		const legacyFile = path.join(legacySessionDir, path.basename(sessionFile));
+		const blobs = new BlobStore(getBlobsDir());
+		// Rewrite the journal the way pre-change OMP wrote it: frames inline.
+		const legacyBody = (await Bun.file(sessionFile).text()).replaceAll(/blob:sha256:[0-9a-f]{64}/g, match =>
+			resolveImageDataSync(blobs, match),
+		);
+		await Bun.write(legacyFile, legacyBody);
+
+		const reopened = await reopen(legacyFile, legacySessionDir);
+		expect(archiveFrames(reopened, firstId)[0]?.data).toBe(FRAME_DATA);
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toContain(FRAME_DATA);
+
+		await reopened.close();
+		// A rewrite of that legacy journal externalizes the frames it had inline.
+		const entries = await loadEntriesFromFile(legacyFile);
+		expect(entries.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## What

Every compaction archives its rendered snapcompact frames as base64 inside its own
journal line, but only the archive that is newest on the active path is ever injected
into a rebuilt context (`session-context.ts:449`); superseded ones already render as
`SUPERSEDED_COMPACTION_SUMMARY`. A month-old journal therefore carries tens of megabytes
of base64 that gets re-parsed on every resume and then never read.

Frames are image payloads, and this repository already has one answer for large image
payloads: the content-addressed blob store. So this change

- persists `preserveData[snapcompact].frames[].data` through `externalizeImageDataSync`
  (`session-persistence.ts`), recognized only inside the snapcompact archive slot so
  arbitrary extension `frames` keep persisting inline;
- leaves those refs unresolved while loading — the generic resolver only restores image
  blocks under `content`/`images` (`session-loader.ts:316-319`), so nothing extra is
  needed to keep them out of memory;
- resolves exactly the archive a context injects, at the two places that read one
  (`session-context.ts`), via a `resolveFrameData` option the session manager fills from
  its blob store.

A content-addressed reference cannot go stale, so there is nothing to track: no byte
offsets, no relocation handling, no rewrite invalidation, no rescan fallback. The
snapcompact package keeps its synchronous API and stays unaware of the blob store.

## Measurements

Real journal, 171.7 MiB, 30 257 entries, 113 compactions. Retained heap is `bun:jsc`
`heapStats()` (heapSize + extraMemorySize) after a full GC.

| | before | after |
|---|---|---|
| journal on disk | 171.7 MiB | **130.9 MiB (-24%)** |
| retained JSC heap after resume | 642.9 MiB | **479.9 MiB (-25%)** |
| process RSS | 658 MiB | **527.8 MiB** |
| resume (`SessionManager.open`) | 564 ms | **374 ms (-34%)** |
| context build | 8 ms | 8 ms |

Frame dedup is a bonus: 40.8 MiB of frames occupy 19.8 MiB in the blob store, because
foveated re-renders repeat frames across compactions and content addressing collapses
them.

## Compatibility

- Journals written before this change keep their inline frames and still load; the
  resolver is a no-op for non-refs. They convert on their next full-body rewrite.
- Blob GC scans journal text (including archived `.jsonl.gz`) for `blob:sha256:`
  (`cli/gc-cli.ts:21-24,250-275,325-354`), so refs inside `preserveData` are retained;
  `test/gc-cli.test.ts:1700-1732` already covers the archived case.
- The blob store is agent-global, so `moveTo`, fork, handoff and cold archiving do not
  invalidate a ref.
- If a frame's blob is missing, the frame is dropped from the history blocks instead of
  being handed to a provider as a `blob:sha256:…` string.

## Tests

`packages/coding-agent/test/session-manager/snapcompact-frame-blobs.test.ts` (5 tests):
frames persist as refs with dedup and no inline base64, a resume keeps refs in memory
while the rest of `preserveData` is untouched, contexts are equal to the same session
with every frame resolved inline (before and after a rewind onto an older compaction), a
missing blob degrades to a dropped frame, and a legacy inline journal still loads.

`bun run check` clean; 610 tests pass across `test/session-manager`, `test/session`,
`test/compaction`, `test/export`, `test/gc-cli.test.ts`.

## Note on this branch

An earlier revision of this PR solved the same problem by giving superseded archives a
lazy accessor over their journal line, with byte spans, relocation retargeting and
rewrite re-arming — 325 lines of new machinery. This revision replaces it: the blob store
already does content addressing, so the whole class of staleness disappears, the diff is
87 lines over four existing files, the journal shrinks on disk as well, and resume gets
faster instead of paying for an extra scan.

Refs #3789, #4090
