### PR TITLE
perf(session): store snapcompact frames in the blob store

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Snapcompact frame archives now persist as blob references instead of inline base64, so a resumed session no longer materializes the frames of every past compaction. Only the archive the rebuilt context injects is read back, and within it only the frames the per-request byte budget keeps: a frame is priced from its stored blob size and read only if it fits. The gain scales with how frame-heavy a journal is. On a real 557 MiB journal whose frames are 41.7% of its bytes: journal 557 -> 325 MiB (-42%), retained JSC heap 1115 -> 653 MiB (-41%), resume 2.18 -> 0.99 s (-54%), and its 2454 frames store as 1640 unique blobs (117 MiB, so 442 MiB on disk in total); the extra 6 ms this moves into the context rebuild buys the 1.2 s saved on resume. A lighter 171.7 MiB journal with 30k entries shows journal -24%, heap 642.9 -> 479.9 MiB (-25%), resume 564 -> 374 ms (-34%). Journals written before this change keep working and convert on their next full rewrite.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent, logger } from "@oh-my-pi/pi-utils";
+import type { LazyFrameData } from "@oh-my-pi/snapcompact";
 
 const BLOB_PREFIX = "blob:sha256:";
 
@@ -166,6 +167,16 @@ export class BlobStore {
 		}
 	}
 
+	/** Stored byte length without reading the blob; null when it is absent. */
+	sizeSync(hash: string): number | null {
+		try {
+			return fs.statSync(path.join(this.dir, hash)).size;
+		} catch (err) {
+			if (isEnoent(err)) return null;
+			throw err;
+		}
+	}
+
 	/** Check if a blob exists. */
 	async has(hash: string): Promise<boolean> {
 		try {
@@ -292,4 +303,27 @@ export function resolveImageDataSync(blobStore: BlobStore, data: string): string
 		return data;
 	}
 	return buffer.toString("base64");
+}
+
+/** Base64 length of `bytes` raw bytes, including padding. */
+function base64Length(bytes: number): number {
+	return Math.ceil(bytes / 3) * 4;
+}
+
+/**
+ * Price a persisted frame payload for snapcompact's byte budget without reading
+ * it, and read it only when the budget keeps the frame. A blob-backed payload is
+ * priced from its stored size; an inline payload prices and reads as itself.
+ * Returns undefined when the blob is gone, so the caller drops the frame instead
+ * of handing a `blob:sha256:…` string to a provider as if it were an image.
+ */
+export function lazyImageDataSync(blobStore: BlobStore, data: string): LazyFrameData | undefined {
+	const hash = parseBlobRef(data);
+	if (!hash) return { bytes: data.length, read: () => data };
+	const size = blobStore.sizeSync(hash);
+	if (size === null) {
+		logger.warn("Blob not found for image reference", { hash });
+		return undefined;
+	}
+	return { bytes: base64Length(size), read: () => resolveImageDataSync(blobStore, data) };
 }

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -26,10 +26,29 @@ function hasLegacySnapcompactFrames(archive: snapcompact.Archive): boolean {
 	return archive.frames.some(frame => frame.font === undefined && frame.variant === undefined);
 }
 
-function hasCrashRiskSnapcompactFramePayload(archive: snapcompact.Archive): boolean {
+/**
+ * Frame payload bytes as they will reach a provider. Externalized frames carry a
+ * short `blob:sha256:…` reference, so measuring `frame.data.length` would price a
+ * rewritten legacy archive at a few hundred bytes and let it slip past the crash
+ * guard below; the resolver prices each frame from its stored blob size instead.
+ */
+function framePayloadBytes(
+	archive: snapcompact.Archive,
+	resolveFrameData: BuildSessionContextOptions["resolveFrameData"],
+): number {
+	if (!resolveFrameData) return snapcompact.frameDataBytes(archive.frames);
+	let total = 0;
+	for (const frame of archive.frames) total += resolveFrameData(frame.data)?.bytes ?? frame.data.length;
+	return total;
+}
+
+function hasCrashRiskSnapcompactFramePayload(
+	archive: snapcompact.Archive,
+	resolveFrameData: BuildSessionContextOptions["resolveFrameData"],
+): boolean {
 	return (
 		archive.frames.length >= LEGACY_SNAPCOMPACT_FRAME_COUNT_GUARD ||
-		snapcompact.frameDataBytes(archive.frames) >= snapcompact.FRAME_DATA_BYTES_BUDGET
+		framePayloadBytes(archive, resolveFrameData) >= snapcompact.FRAME_DATA_BYTES_BUDGET
 	);
 }
 
@@ -41,10 +60,13 @@ function hasCrashRiskSnapcompactArchiveSize(archive: snapcompact.Archive): boole
 	);
 }
 
-function isCrashRiskLegacySnapcompactArchive(archive: snapcompact.Archive): boolean {
+function isCrashRiskLegacySnapcompactArchive(
+	archive: snapcompact.Archive,
+	resolveFrameData: BuildSessionContextOptions["resolveFrameData"],
+): boolean {
 	return (
 		hasLegacySnapcompactFrames(archive) &&
-		hasCrashRiskSnapcompactFramePayload(archive) &&
+		hasCrashRiskSnapcompactFramePayload(archive, resolveFrameData) &&
 		hasCrashRiskSnapcompactArchiveSize(archive)
 	);
 }
@@ -52,10 +74,12 @@ function isCrashRiskLegacySnapcompactArchive(archive: snapcompact.Archive): bool
 function snapcompactHistoryBlockOptions(
 	archive: snapcompact.Archive,
 	options: BuildSessionContextOptions | undefined,
-): snapcompact.HistoryBlockOptions | undefined {
-	if (options?.transcript) return undefined;
-	if (isCrashRiskLegacySnapcompactArchive(archive)) return { maxFrameDataBytes: 0 };
-	return { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET };
+): snapcompact.HistoryBlockOptions {
+	const resolveFrameData = options?.resolveFrameData;
+	const lazy = resolveFrameData ? { resolveFrameData } : {};
+	if (options?.transcript) return lazy;
+	if (isCrashRiskLegacySnapcompactArchive(archive, resolveFrameData)) return { ...lazy, maxFrameDataBytes: 0 };
+	return { ...lazy, maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET };
 }
 
 export interface SessionContext {
@@ -129,6 +153,15 @@ export interface BuildSessionContextOptions {
 	 * hides the call the agent is still waiting on.
 	 */
 	keepDanglingToolCalls?: boolean;
+	/**
+	 * Price and read a persisted snapcompact frame payload. Frames live in the
+	 * blob store, so only the archive a rebuilt context actually injects is
+	 * touched — and within it, only the frames the byte budget keeps: the
+	 * resolver is called in newest-first budget order and prices a frame from its
+	 * stored size, so an omitted frame is never read. Superseded archives stay as
+	 * references and cost nothing to keep around.
+	 */
+	resolveFrameData?: (data: string) => snapcompact.LazyFrameData | undefined;
 }
 
 /**

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
-import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./blob-store";
+import { BlobStore, isBlobRef, lazyImageDataSync, resolveImageData, resolveImageDataUrl } from "./blob-store";
 import { buildSessionContext } from "./session-context";
 import type { FileEntry, RawFileEntry, SessionEntry, SessionHeader } from "./session-entries";
 import { migrateToCurrentVersion } from "./session-migrations";
@@ -395,10 +395,12 @@ export async function loadSessionMessagesReadOnly(filePath: string): Promise<Age
 	const entries = await loadEntriesFromFile(filePath);
 	if (entries.length === 0) return [];
 	migrateToCurrentVersion(entries);
-	await resolveBlobRefsInEntries(entries, new BlobStore(getBlobsDir()));
+	const blobs = new BlobStore(getBlobsDir());
+	await resolveBlobRefsInEntries(entries, blobs);
 	const sessionEntries = entries.filter((e): e is SessionEntry => e.type !== "session");
 	return buildSessionContext(sessionEntries, undefined, undefined, {
 		transcript: true,
 		collapseCompactedHistory: true,
+		resolveFrameData: data => lazyImageDataSync(blobs, data),
 	}).messages;
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -20,7 +20,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import type { StructuredSubagentSchemaMode } from "../task/types";
 import { ArtifactManager } from "./artifacts";
-import { type BlobPutOptions, type BlobPutResult, BlobStore } from "./blob-store";
+import { type BlobPutOptions, type BlobPutResult, BlobStore, lazyImageDataSync } from "./blob-store";
 import type { CompactionMethod } from "./compaction-methods";
 import {
 	type BashExecutionMessage,
@@ -2446,7 +2446,12 @@ export class SessionManager {
 	 * the full-history display transcript, from the current leaf path.
 	 */
 	buildSessionContext(options?: BuildSessionContextOptions): SessionContext {
-		return buildSessionContext(this.#entries, this.#index.leafId(), this.#index.entriesById(), options);
+		return buildSessionContext(this.#entries, this.#index.leafId(), this.#index.entriesById(), {
+			// Snapcompact frames persist as blob refs; only the archive this context
+			// injects is read back, and only the frames its byte budget keeps.
+			resolveFrameData: data => lazyImageDataSync(this.#blobs, data),
+			...options,
+		});
 	}
 
 	/** Strip stale OpenAI Responses assistant replay metadata from loaded entries. */

--- a/packages/coding-agent/src/session/session-persistence.ts
+++ b/packages/coding-agent/src/session/session-persistence.ts
@@ -1,4 +1,5 @@
 import { isAnthropicServerToolHistoryBlock } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
+import { PRESERVE_KEY as SNAPCOMPACT_PRESERVE_KEY } from "@oh-my-pi/snapcompact";
 import {
 	type BlobStore,
 	externalizeImageDataSync,
@@ -58,6 +59,48 @@ function shouldExternalizeImagePayload(
 	if (!isImageDataPayload(value)) return false;
 	if (isBlobRef(value.data) || value.data.length < BLOB_EXTERNALIZE_THRESHOLD) return false;
 	return (key === TEXT_CONTENT_KEY && isImageBlock(value)) || key === "images";
+}
+
+/**
+ * Rendered snapcompact frames are the heaviest thing a session persists: every
+ * compaction archives its own set of base64 PNGs, and a long-lived journal ends
+ * up carrying (and re-parsing on every resume) tens of megabytes that only the
+ * newest archive on the active path is ever asked for.
+ *
+ * They are image payloads like any other, so they belong in the blob store.
+ */
+function externalizeSnapcompactFrames(archive: object, blobStore: BlobStore): object {
+	if (!("frames" in archive)) return archive;
+	const frames = archive.frames;
+	if (!Array.isArray(frames)) return archive;
+
+	let changed = false;
+	const externalized = frames.map(frame => {
+		if (!isImageDataPayload(frame) || isBlobRef(frame.data) || frame.data.length < BLOB_EXTERNALIZE_THRESHOLD) {
+			return frame;
+		}
+		changed = true;
+		return { ...frame, data: externalizeImageDataSync(blobStore, frame.data, frame.mimeType) };
+	});
+	return changed ? { ...archive, frames: externalized } : archive;
+}
+
+/**
+ * Externalize the frames of a compaction's snapcompact archive.
+ *
+ * Deliberately scoped to `CompactionEntry.preserveData[PRESERVE_KEY]` rather
+ * than keyed off the property name during the generic walk: only that slot is
+ * resolved back on the context-rebuild path, so a same-named field anywhere else
+ * — an extension detail, a structured tool payload — would keep a reference
+ * nothing knows how to read.
+ */
+function externalizeCompactionArchive(entry: FileEntry, blobStore: BlobStore): FileEntry {
+	if (entry.type !== "compaction" || !entry.preserveData) return entry;
+	const archive = entry.preserveData[SNAPCOMPACT_PRESERVE_KEY];
+	if (!archive || typeof archive !== "object") return entry;
+	const externalized = externalizeSnapcompactFrames(archive, blobStore);
+	if (externalized === archive) return entry;
+	return { ...entry, preserveData: { ...entry.preserveData, [SNAPCOMPACT_PRESERVE_KEY]: externalized } };
 }
 
 /** True for a non-empty string — marks signature/encrypted fields whose block must persist verbatim. */
@@ -289,5 +332,6 @@ function stripReplayedReasoningSignatures(entry: FileEntry): FileEntry {
 }
 
 export function prepareEntryForPersistence(entry: FileEntry, blobStore: BlobStore): FileEntry {
-	return truncateForPersistence(stripReplayedReasoningSignatures(entry), blobStore) as FileEntry;
+	const prepared = externalizeCompactionArchive(stripReplayedReasoningSignatures(entry), blobStore);
+	return truncateForPersistence(prepared, blobStore) as FileEntry;
 }

--- a/packages/coding-agent/test/session-manager/snapcompact-frame-blobs.test.ts
+++ b/packages/coding-agent/test/session-manager/snapcompact-frame-blobs.test.ts
@@ -1,0 +1,395 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Buffer } from "node:buffer";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { BlobStore, resolveImageDataSync } from "@oh-my-pi/pi-coding-agent/session/blob-store";
+import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getAgentDir, getBlobsDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import * as snapcompact from "@oh-my-pi/snapcompact";
+
+/** Under the 500k persistence truncation limit, over the 1 KiB blob threshold. */
+const FRAME_DATA = "Zm".repeat(60_000);
+const FRAMES_PER_ARCHIVE = 4;
+/** Ten of these overflow `FRAME_DATA_BYTES_BUDGET` (3 MB) with room to spare. */
+const WIDE_FRAME_COUNT = 10;
+
+/**
+ * A distinct 400 KB base64 payload per frame, so each frame lands in its own
+ * content-addressed blob. Appending a suffix to one shared base64 string would
+ * not do: the trailing partial group decodes away and every frame collapses onto
+ * the same blob.
+ */
+function wideFrameData(index: number): string {
+	return Buffer.alloc(300_000, index + 1).toString("base64");
+}
+
+function makeAssistantMessage(text: string) {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected built-in anthropic model to exist");
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: 2,
+	};
+}
+
+function makeArchive(marker: string) {
+	return {
+		[snapcompact.PRESERVE_KEY]: {
+			frames: Array.from({ length: FRAMES_PER_ARCHIVE }, () => ({
+				data: FRAME_DATA,
+				mimeType: "image/png",
+				cols: 196,
+				rows: 71,
+				chars: 13_916,
+				font: "8x13",
+				variant: "bw",
+			})),
+			totalChars: 13_916,
+			truncatedChars: 0,
+			text: `${marker}-source`,
+			textHead: `${marker}-head`,
+			textTail: `${marker}-tail`,
+		},
+		openaiRemoteCompaction: {
+			provider: "openai",
+			replacementHistory: [
+				{ type: "message", role: "user", content: [{ type: "input_text", text: `preserved ${marker}` }] },
+			],
+		},
+	};
+}
+
+function archiveFrames(session: SessionManager, entryId: string): snapcompact.Frame[] {
+	const entry = session.getEntry(entryId);
+	if (entry?.type !== "compaction") throw new Error(`Expected compaction ${entryId}`);
+	const archive = snapcompact.getPreservedArchive(entry.preserveData);
+	if (!archive) throw new Error(`Expected an archive on ${entryId}`);
+	return archive.frames;
+}
+
+function imageDataIn(messages: readonly unknown[]): string[] {
+	const found: string[] = [];
+	const walk = (value: unknown): void => {
+		if (Array.isArray(value)) {
+			for (const item of value) walk(item);
+			return;
+		}
+		if (!value || typeof value !== "object") return;
+		if ("type" in value && value.type === "image" && "data" in value && typeof value.data === "string") {
+			found.push(value.data);
+			return;
+		}
+		for (const item of Object.values(value)) walk(item);
+	};
+	walk(messages);
+	return found;
+}
+
+describe("snapcompact frames in the blob store", () => {
+	const tempDirs: string[] = [];
+
+	// `SessionManager` and its blob store resolve through the process-global agent
+	// dir. Point it at a temp dir for this file: a run must never write to (or
+	// delete out of) `~/.omp/agent/blobs`, and two concurrent runs must not be
+	// able to remove each other's fixtures. `setAgentDir` also stamps
+	// `PI_CODING_AGENT_DIR` and clears the profile keys, so teardown puts all
+	// three back exactly as they were — including their original absence.
+	const originalAgentDir = getAgentDir();
+	const originalEnv = {
+		PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+		OMP_PROFILE: process.env.OMP_PROFILE,
+		PI_PROFILE: process.env.PI_PROFILE,
+	};
+	beforeAll(async () => {
+		setAgentDir(await makeTempDir());
+	});
+	afterAll(() => {
+		setAgentDir(originalAgentDir);
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	async function makeTempDir(): Promise<string> {
+		const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-frame-blobs-"));
+		tempDirs.push(dir);
+		return dir;
+	}
+
+	async function writeJournal(): Promise<{
+		sessionFile: string;
+		sessionDir: string;
+		firstId: string;
+		secondId: string;
+	}> {
+		const dir = await makeTempDir();
+		const sessionDir = path.join(dir, "sessions");
+		const session = SessionManager.create(dir, sessionDir);
+		const anchor = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+		const firstId = session.appendCompaction("first", undefined, anchor, 1000, {
+			preserveData: makeArchive("first"),
+		});
+		const between = session.appendMessage({ role: "user", content: "between", timestamp: 3 });
+		const secondId = session.appendCompaction("second", undefined, between, 2000, {
+			preserveData: makeArchive("second"),
+		});
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file");
+		await session.close();
+		return { sessionFile, sessionDir, firstId, secondId };
+	}
+
+	function reopen(sessionFile: string, sessionDir: string): Promise<SessionManager> {
+		return SessionManager.open(sessionFile, sessionDir, undefined, { suppressBreadcrumb: true });
+	}
+
+	afterEach(async () => {
+		await Promise.all(tempDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })));
+		tempDirs.length = 0;
+	});
+
+	it("persists frames as blob references instead of inline base64", async () => {
+		const { sessionFile } = await writeJournal();
+		const body = await Bun.file(sessionFile).text();
+
+		expect(body).not.toContain(FRAME_DATA);
+		expect(body).toContain("blob:sha256:");
+		// Two archives of identical frames collapse onto one content-addressed blob.
+		const refs = new Set(body.match(/blob:sha256:[0-9a-f]{64}/g) ?? []);
+		expect(refs.size).toBe(1);
+		expect(body.length).toBeLessThan(FRAME_DATA.length);
+	});
+
+	it("keeps frame payloads out of memory after a resume", async () => {
+		const { sessionFile, sessionDir, firstId, secondId } = await writeJournal();
+		const reopened = await reopen(sessionFile, sessionDir);
+
+		for (const id of [firstId, secondId]) {
+			for (const frame of archiveFrames(reopened, id)) {
+				expect(frame.data.startsWith("blob:sha256:")).toBe(true);
+			}
+		}
+		// Everything else in preserveData is untouched by this change.
+		const entry = reopened.getEntry(firstId);
+		if (entry?.type !== "compaction") throw new Error("Expected compaction");
+		expect(entry.preserveData?.openaiRemoteCompaction).toEqual(makeArchive("first").openaiRemoteCompaction);
+
+		await reopened.close();
+	});
+
+	it("builds the same context as inline frames, before and after a rewind", async () => {
+		const { sessionFile, sessionDir, firstId } = await writeJournal();
+		const reopened = await reopen(sessionFile, sessionDir);
+		const blobs = new BlobStore(getBlobsDir());
+
+		/** Control: the same entries with every frame ref resolved back inline. */
+		const inlineContext = (leafId: string | undefined) => {
+			const entries = reopened.getEntries().map(entry => {
+				if (entry.type !== "compaction") return entry;
+				const archive = snapcompact.getPreservedArchive(entry.preserveData);
+				if (!archive) return entry;
+				return {
+					...entry,
+					preserveData: {
+						...entry.preserveData,
+						[snapcompact.PRESERVE_KEY]: {
+							...archive,
+							frames: archive.frames.map(frame => ({ ...frame, data: resolveImageDataSync(blobs, frame.data) })),
+						},
+					},
+				} satisfies SessionEntry;
+			});
+			return buildSessionContext(entries, leafId, undefined, {}).messages;
+		};
+
+		const newestLeaf = reopened.getLeafId() ?? undefined;
+		expect(imageDataIn(inlineContext(newestLeaf))).toContain(FRAME_DATA);
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toEqual(imageDataIn(inlineContext(newestLeaf)));
+
+		reopened.branch(firstId);
+		expect(imageDataIn(inlineContext(firstId))).toContain(FRAME_DATA);
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toEqual(imageDataIn(inlineContext(firstId)));
+
+		await reopened.close();
+	});
+
+	it("drops a frame whose blob went missing instead of sending the reference", async () => {
+		const { sessionFile, sessionDir } = await writeJournal();
+		const body = await Bun.file(sessionFile).text();
+		const ref = body.match(/blob:sha256:([0-9a-f]{64})/);
+		if (!ref) throw new Error("Expected a frame blob reference");
+		await fsp.rm(path.join(getBlobsDir(), ref[1]!), { force: true });
+
+		const reopened = await reopen(sessionFile, sessionDir);
+		const images = imageDataIn(reopened.buildSessionContext().messages);
+		expect(images.some(data => data.startsWith("blob:sha256:"))).toBe(false);
+		expect(images).not.toContain(FRAME_DATA);
+
+		await reopened.close();
+	});
+
+	it("reads only the frames the byte budget keeps", async () => {
+		const dir = await makeTempDir();
+		const sessionDir = path.join(dir, "sessions");
+		const session = SessionManager.create(dir, sessionDir);
+		const anchor = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+		// Distinct payloads so each frame is its own blob, and enough of them that
+		// the budget must omit some.
+		session.appendCompaction("wide", undefined, anchor, 1000, {
+			preserveData: {
+				[snapcompact.PRESERVE_KEY]: {
+					frames: Array.from({ length: WIDE_FRAME_COUNT }, (_unused, index) => ({
+						data: wideFrameData(index),
+						mimeType: "image/png",
+						cols: 196,
+						rows: 71,
+						chars: 13_916,
+					})),
+					totalChars: 13_916,
+					truncatedChars: 0,
+					textHead: "head",
+					textTail: "tail",
+				},
+			},
+		});
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file");
+		await session.close();
+
+		const reads: string[] = [];
+		const readBlob = BlobStore.prototype.getSync;
+		BlobStore.prototype.getSync = function trackedGetSync(this: BlobStore, hash: string) {
+			reads.push(hash);
+			return readBlob.call(this, hash);
+		};
+		try {
+			const reopened = await reopen(sessionFile, sessionDir);
+			reads.length = 0;
+			const kept = new Set(imageDataIn(reopened.buildSessionContext().messages));
+			expect(kept.size).toBeGreaterThan(0);
+			expect(kept.size).toBeLessThan(WIDE_FRAME_COUNT);
+			// One blob read per kept frame: a frame the budget omits is priced from
+			// its stored size and never materialized.
+			expect(new Set(reads).size).toBe(kept.size);
+			await reopened.close();
+		} finally {
+			BlobStore.prototype.getSync = readBlob;
+		}
+	});
+
+	it("still reads a legacy journal that stored frames inline", async () => {
+		const { sessionFile, firstId } = await writeJournal();
+		const legacyDir = await makeTempDir();
+		const legacySessionDir = path.join(legacyDir, "sessions");
+		await fsp.mkdir(legacySessionDir, { recursive: true });
+		const legacyFile = path.join(legacySessionDir, path.basename(sessionFile));
+		const blobs = new BlobStore(getBlobsDir());
+		// Rewrite the journal the way pre-change OMP wrote it: frames inline.
+		const legacyBody = (await Bun.file(sessionFile).text()).replaceAll(/blob:sha256:[0-9a-f]{64}/g, match =>
+			resolveImageDataSync(blobs, match),
+		);
+		await Bun.write(legacyFile, legacyBody);
+
+		const reopened = await reopen(legacyFile, legacySessionDir);
+		expect(archiveFrames(reopened, firstId)[0]?.data).toBe(FRAME_DATA);
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toContain(FRAME_DATA);
+
+		await reopened.close();
+
+		// A rewrite of that legacy journal externalizes the frames it had inline.
+		const rewriting = await reopen(legacyFile, legacySessionDir);
+		await rewriting.rewriteEntries();
+		await rewriting.close();
+		const rewritten = await Bun.file(legacyFile).text();
+		expect(rewritten).not.toContain(FRAME_DATA);
+		expect(rewritten).toContain("blob:sha256:");
+	});
+
+	it("keeps the legacy crash guard firing once frames are externalized", async () => {
+		const dir = await makeTempDir();
+		const sessionDir = path.join(dir, "sessions");
+		const session = SessionManager.create(dir, sessionDir);
+		const anchor = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+		// A legacy archive: no `font`/`variant` on the frames, a payload over the
+		// 3 MB budget, and a truncated-chars count over the size guard. Inline, this
+		// trips `maxFrameDataBytes: 0`; the references it persists as are a few
+		// hundred bytes, so pricing them by string length would wave it through.
+		session.appendCompaction("legacy", undefined, anchor, 1000, {
+			preserveData: {
+				[snapcompact.PRESERVE_KEY]: {
+					frames: Array.from({ length: WIDE_FRAME_COUNT }, (_unused, index) => ({
+						data: wideFrameData(index),
+						mimeType: "image/png",
+						cols: 196,
+						rows: 71,
+						chars: 13_916,
+					})),
+					totalChars: 13_916,
+					truncatedChars: 1_500_000,
+					textHead: "head",
+					textTail: "tail",
+				},
+			},
+		});
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file");
+		await session.close();
+
+		const reopened = await reopen(sessionFile, sessionDir);
+		expect(
+			archiveFrames(reopened, reopened.getEntries().filter(entry => entry.type === "compaction")[0]!.id)[0]?.data,
+		).toStartWith("blob:sha256:");
+		expect(imageDataIn(reopened.buildSessionContext().messages)).toEqual([]);
+
+		await reopened.close();
+	});
+
+	it("leaves a same-named payload outside preserveData inline", async () => {
+		const dir = await makeTempDir();
+		const sessionDir = path.join(dir, "sessions");
+		const session = SessionManager.create(dir, sessionDir);
+		const anchor = session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage("hi"));
+		// Only `preserveData[PRESERVE_KEY]` is resolved back on the rebuild path, so
+		// an archive-shaped payload parked anywhere else must stay inline — a
+		// reference there would be unreadable after resume.
+		session.appendCompaction("details", undefined, anchor, 1000, {
+			details: { [snapcompact.PRESERVE_KEY]: { frames: [{ data: FRAME_DATA, mimeType: "image/png" }] } },
+			preserveData: makeArchive("scoped"),
+		});
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file");
+		await session.close();
+
+		const body = await Bun.file(sessionFile).text();
+		// The compaction's own archive still externalizes...
+		expect(body).toContain("blob:sha256:");
+		// ...while the look-alike under `details` keeps its payload.
+		expect(body).toContain(FRAME_DATA);
+	});
+});

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -1763,10 +1763,25 @@ export function renderabilityProbeText(
 	return serialized;
 }
 
+/** Lazily priced frame payload: `bytes` is the base64 length the frame will
+ *  contribute, `read` materializes it. Lets a caller whose frames live outside
+ *  the entry (e.g. a blob store) pay only for the frames a budget keeps. */
+export interface LazyFrameData {
+	readonly bytes: number;
+	read(): string;
+}
+
 /** Options for reconstructing a persisted snapcompact archive into prompt blocks. */
 export interface HistoryBlockOptions {
 	/** Hard cap on image base64 bytes attached to one rebuilt provider request. */
 	maxFrameDataBytes?: number;
+	/**
+	 * Resolve an externally stored frame payload. Called once per frame in
+	 * newest-first budget order, so a frame the budget omits is never read.
+	 * `undefined` drops the frame: its payload is gone, and a storage reference
+	 * is not an image.
+	 */
+	resolveFrameData?: (data: string) => LazyFrameData | undefined;
 }
 
 function formatFrameDataBytes(bytes: number): string {
@@ -1777,9 +1792,10 @@ function formatFrameDataBytes(bytes: number): string {
 
 function imagesWithinBudget(
 	archive: Archive,
-	maxFrameDataBytes: number | undefined,
+	options: HistoryBlockOptions,
 ): { images: ImageContent[]; omittedFrames: number; omittedBytes: number } {
-	if (maxFrameDataBytes === undefined) {
+	const { maxFrameDataBytes, resolveFrameData } = options;
+	if (maxFrameDataBytes === undefined && !resolveFrameData) {
 		return { images: images(archive), omittedFrames: 0, omittedBytes: 0 };
 	}
 
@@ -1790,14 +1806,18 @@ function imagesWithinBudget(
 	for (let index = archive.frames.length - 1; index >= 0; index--) {
 		const frame = archive.frames[index];
 		if (!frame) continue;
-		const bytes = frame.data.length;
-		if (usedBytes + bytes > maxFrameDataBytes) {
+		const lazy = resolveFrameData?.(frame.data);
+		// Resolver present but payload gone: drop the frame outright. It is not
+		// an omitted-by-budget frame, so it stays out of the gap notice.
+		if (resolveFrameData && !lazy) continue;
+		const bytes = lazy ? lazy.bytes : frame.data.length;
+		if (maxFrameDataBytes !== undefined && usedBytes + bytes > maxFrameDataBytes) {
 			omittedFrames++;
 			omittedBytes += bytes;
 			continue;
 		}
 		usedBytes += bytes;
-		keptNewestFirst.push(frame);
+		keptNewestFirst.push(lazy ? { ...frame, data: lazy.read() } : frame);
 	}
 	keptNewestFirst.reverse();
 	return { images: images({ ...archive, frames: keptNewestFirst }), omittedFrames, omittedBytes };
@@ -1826,7 +1846,7 @@ export function images(archive: Archive): ImageContent[] {
  *  instead of persisted on the session entry. */
 export function historyBlocks(archive: Archive, options: HistoryBlockOptions = {}): (TextContent | ImageContent)[] {
 	const blocks: (TextContent | ImageContent)[] = [];
-	const budgeted = imagesWithinBudget(archive, options.maxFrameDataBytes);
+	const budgeted = imagesWithinBudget(archive, options);
 	const hasImages = budgeted.images.length > 0;
 	const hasOmittedImages = budgeted.omittedFrames > 0;
 	if (archive.textHead) {


### PR DESCRIPTION
My own sessions run for hours, and OMP's memory kept climbing until I gave up and restarted it. Chasing that is what led here: the frame archives were the heaviest thing the journal carried, and on my own 557 MiB journal moving them out cut the retained heap by 41% and halved the resume time.

## What

Every compaction archives its rendered snapcompact frames as base64 inside its own
journal line, but only the archive that is newest on the active path is ever injected
into a rebuilt context (`session-context.ts:449`); superseded ones already render as
`SUPERSEDED_COMPACTION_SUMMARY`. A month-old journal therefore carries tens of megabytes
of base64 that gets re-parsed on every resume and then never read.

Frames are image payloads, and this repository already has one answer for large image
payloads: the content-addressed blob store. So this change

- persists `preserveData[snapcompact].frames[].data` through `externalizeImageDataSync`
  (`session-persistence.ts`), recognized only inside the snapcompact archive slot so
  arbitrary extension `frames` keep persisting inline;
- leaves those refs unresolved while loading — the generic resolver only restores image
  blocks under `content`/`images` (`session-loader.ts:316-319`), so nothing extra is
  needed to keep them out of memory;
- resolves exactly the archive a context injects, at the two places that read one
  (`session-context.ts`), via a `resolveFrameData` option the session manager fills from
  its blob store.

A content-addressed reference cannot go stale, so there is nothing to track: no byte
offsets, no relocation handling, no rewrite invalidation, no rescan fallback. The
snapcompact package keeps its synchronous API and stays unaware of the blob store.

## Measurements

Real journal, 171.7 MiB, 30 257 entries, 113 compactions. Retained heap is `bun:jsc`
`heapStats()` (heapSize + extraMemorySize) after a full GC.

| | before | after |
|---|---|---|
| journal on disk | 171.7 MiB | **130.9 MiB (-24%)** |
| retained JSC heap after resume | 642.9 MiB | **479.9 MiB (-25%)** |
| process RSS | 658 MiB | **527.8 MiB** |
| resume (`SessionManager.open`) | 564 ms | **374 ms (-34%)** |
| context build | 8 ms | 8 ms |

Frame dedup is a bonus: 40.8 MiB of frames occupy 19.8 MiB in the blob store, because
foveated re-renders repeat frames across compactions and content addressing collapses
them.

## Compatibility

- Journals written before this change keep their inline frames and still load; the
  resolver is a no-op for non-refs. They convert on their next full-body rewrite.
- Blob GC scans journal text (including archived `.jsonl.gz`) for `blob:sha256:`
  (`cli/gc-cli.ts:21-24,250-275,325-354`), so refs inside `preserveData` are retained;
  `test/gc-cli.test.ts:1700-1732` already covers the archived case.
- The blob store is agent-global, so `moveTo`, fork, handoff and cold archiving do not
  invalidate a ref.
- If a frame's blob is missing, the frame is dropped from the history blocks instead of
  being handed to a provider as a `blob:sha256:…` string.

## Tests

`packages/coding-agent/test/session-manager/snapcompact-frame-blobs.test.ts` (5 tests):
frames persist as refs with dedup and no inline base64, a resume keeps refs in memory
while the rest of `preserveData` is untouched, contexts are equal to the same session
with every frame resolved inline (before and after a rewind onto an older compaction), a
missing blob degrades to a dropped frame, and a legacy inline journal still loads.

`bun run check` clean; 610 tests pass across `test/session-manager`, `test/session`,
`test/compaction`, `test/export`, `test/gc-cli.test.ts`.

## Note on history

This replaces #8762, which was opened with a different implementation of the same goal
(lazy accessors over journal byte spans) and force-pushed to this one; opening a fresh
pull request so the review thread matches the code.

## Why this shape and not the earlier one

An earlier revision of this PR solved the same problem by giving superseded archives a
lazy accessor over their journal line, with byte spans, relocation retargeting and
rewrite re-arming — 325 lines of new machinery. This revision replaces it: the blob store
already does content addressing, so the whole class of staleness disappears, the diff is
87 lines over four existing files, the journal shrinks on disk as well, and resume gets
faster instead of paying for an extra scan.

Refs #3789, #4090

## Relationship to the new blob broker

`BlobBrokerService.frameSink` (`src/blob-broker/service.ts`) is a different mechanism and does not
cover this. It hands the *provider-bound context* URL-bearing placeholders (`data: ""`), and it
returns `null` — so the transformer renders eagerly — when no backend supports lazy blobs, in
uploader mode, or when a provider-file source leads. It never touches
`preserveData[PRESERVE_KEY].frames`, which is what the journal persists.

`snapcompact.stripPreservedArchive` drops a superseded archive once its frames have migrated into a
newer compaction's text. That keeps stale frames out of the rebuilt context, but the journal is
append-only: every archive already written stays on disk and is re-parsed on every resume.

Measured on pristine `upstream/main` (this PR's test file, source changes reverted): `persists frames
as blob references instead of inline base64` fails because the journal body still contains the raw
base64, and `keeps frame payloads out of memory after a resume` fails because the reopened archive
returns inline data. With the PR all five tests pass.

The two are sequential stages of one pipeline, not competing designs: this PR governs what the journal
stores, `decorateContext` governs how context images reach the provider, and archived frames pass from
the first to the second through `resolveArchiveFrames`. The natural convergence — keeping an archived
frame a reference the whole way, so the broker publishes a URL backed by the blob store and a resumed
session never materializes PNG bytes — is deliberately out of scope here: it couples session storage to
a new subsystem and belongs in its own change after discussion.

## Measurements on a frame-heavy journal

The numbers above come from a 171.7 MiB journal. The gain scales with how much of a journal is frame
base64, so here is the same measurement on a real 557 MiB journal (76,591 lines, 2454 frames, 41.7% of
its bytes). Median of three runs, each in a fresh process, isolated agent dir, same code on both sides
— only the on-disk format differs, since the reader still accepts inline frames:

| | inline frames | blob refs | delta |
|---|---|---|---|
| journal | 557 MiB | 325 MiB | **-41.6%** |
| blobs on disk | — | 117 MiB (1640 unique of 2454 frames) | |
| total on disk | 557 MiB | 442 MiB | -20.6% |
| resume (`SessionManager.open`) | 2181 ms | 993 ms | **-54%** |
| retained JSC heap after `Bun.gc(true)` | 1115.4 MiB | 652.6 MiB | **-41.5%** |
| RSS | 1577.5 MiB | 1080.8 MiB | -31.5% |
| `buildSessionContext` | 26 ms | 32 ms | +6 ms |

The +6 ms is the lazy read of the frames the byte budget keeps; it buys the 1.2 s saved on resume.

Across the 104 journals on this machine that carry frames (6.88 GiB total), inline frames are 2.47 GiB
— 35.9% of all journal bytes — and only 1.06 GiB of that is unique, so content addressing removes a
further 57% of frame bytes.