### PR TITLE
fix(ai): encode empty successful tool_result content as empty string

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic-compatible endpoints with strict prompt validation (e.g. Z.AI GLM `api.z.ai/api/anthropic`, which rejects the whole request with `400 code 1213 "The prompt parameter was not received normally"`) failing sessions once a tool returned empty output on a vision-capable model: empty successful `tool_result` blocks now encode as `content: ""` instead of `content: []`, which both the official API and strict compatible endpoints accept.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3548,6 +3548,12 @@ function buildToolResultBlock(
 		}
 		content = content.filter(block => block.type === "text");
 	}
+	// An empty array is valid for the official API, but strict Anthropic-compatible
+	// endpoints (Z.AI GLM: 400 code 1213 "The prompt parameter was not received
+	// normally") reject it; the empty-string form is accepted by both.
+	if (Array.isArray(content) && content.length === 0) {
+		content = "";
+	}
 	content = ensureErrorToolResultWireContent(content, msg.isError);
 	const block: ContentBlockParam = {
 		type: "tool_result",

--- a/packages/ai/test/anthropic-empty-error-tool-result.test.ts
+++ b/packages/ai/test/anthropic-empty-error-tool-result.test.ts
@@ -20,6 +20,13 @@ const anthropicModel: Model<"anthropic-messages"> = buildModel({
 	baseUrl: "https://api.anthropic.com",
 });
 
+const visionModel: Model<"anthropic-messages"> = buildModel({
+	...baseModel,
+	input: ["text", "image"],
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+});
+
 const user: UserMessage = {
 	role: "user",
 	content: "run the tool",
@@ -92,6 +99,26 @@ describe("anthropic empty error tool_result encoding", () => {
 		};
 
 		const block = getToolResultBlock(anthropicModel, toolResult);
+		expect(block.is_error).toBe(false);
+		expect(block.content).toBe("");
+	});
+
+	it("encodes empty successful tool results as empty string, not empty array, on image-capable models", () => {
+		// Regression: vision-capable models serialize whitespace-only successful
+		// tool results as `content: []` on the wire. Official Anthropic accepts it,
+		// but strict Anthropic-compatible endpoints (Z.AI GLM, api.z.ai/api/anthropic)
+		// reject the whole request with 400 code 1213 ("The prompt parameter was
+		// not received normally"). `content: ""` is accepted by both.
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "toolu_empty_error",
+			toolName: "write",
+			content: [{ type: "text", text: "" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		const block = getToolResultBlock(visionModel, toolResult);
 		expect(block.is_error).toBe(false);
 		expect(block.content).toBe("");
 	});


### PR DESCRIPTION
## Problem

Vision-capable models serialize a successful tool result whose content is empty after trimming (e.g. a `write` that produces no output) as a wire `tool_result` block with `content: []`. Text-only models already encode the joined empty string, so this shape only appears when `model.input` includes images.

The official Anthropic API accepts `content: []`, but strict Anthropic-compatible endpoints reject the **whole request**. Z.AI GLM (`api.z.ai/api/anthropic`, also reached through Anthropic-compatible proxies in front of it) returns:

```
400 code 1213 "The prompt parameter was not received normally"
```

The session then fails on every subsequent turn until history is compacted past the offending block, which looks like a mystery "context too large" failure — it is actually a wire-shape rejection.

I hit this live on GLM-5.3 through an Anthropic-compatible proxy and bisected it: replaying the exact captured 400 body with only the two `content: []` tool_result blocks changed to `""` returns HTTP 200; the untouched body returns 400 1213 every time. Removing thinking blocks or `context_management`, or truncating history before those blocks, does not help — the empty array is the sole trigger.

Same failure class externally: earendil-works/pi#3365 (GLM-5 via ZAI rejecting requests with empty content, same 1213), and #814 established that Z.AI's Anthropic layer needs client-side accommodation on this exact block type (`requiresToolResultId`).

## Fix

In `buildToolResultBlock` (packages/ai), normalize an empty **array** content to `""` before building the wire block, right next to the existing error-placeholder normalization from #2250. Both `""` and `[]` are valid for the official API; `""` is additionally accepted by strict compatible endpoints, so this is strictly a compatibility widening with no behavior change for the official API beyond the literal wire shape.

## Tests

- New regression case in `packages/ai/test/anthropic-empty-error-tool-result.test.ts`: an empty successful tool result on an image-capable model must encode as `content: ""`, not `[]`. Red on the pre-fix encoder, green after.
- Full `packages/ai` suite: 4240 tests, 0 fail. `bun check` clean.

## Verification

- Bisect of the live captured failure: original body → 400 1213; same body with `[]` → `""` on the two empty blocks → 200 (via the Z.AI upstream through an Anthropic-compatible proxy, model GLM-5.3).
- Minimal live repro: `tool_use` + `tool_result` with `content: []` → 400 1213; with `content: ""` → 200.
- Drove omp's own encoder on the repro message list post-fix: the wire block now carries `content: ""`.

I reviewed the full diff; this change makes omp's empty successful tool_result encoding match the string form it already uses for text-only models, so strict Anthropic-compatible endpoints stop rejecting whole sessions over an empty tool output.