### PR TITLE
fix(ai): honor Fable/Mythos tier usage in usage-reserve health

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `retry.usageReservePct` (Reserve Margin) ignoring Claude Fable/Mythos weekly tier usage until it hit 100%, so a Fable model kept serving turns past the configured reserve; reserve health now honors the mapped tier row while credential-wide hard blocks still require confirmed exhaustion ([#8773](https://github.com/can1357/oh-my-pi/issues/8773)).
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3961,7 +3961,12 @@ export class AuthStorage {
 				}
 				if (!report) return { credentialId: entry.id, credentialType, state: "unknown" };
 
-				const limits = this.#getScopedUsageLimits(strategy, report, rankingContext);
+				// Reserve health is opt-in and non-destructive: prefer the strategy's
+				// reserve scoping, which may expose mapped model/tier rows that the
+				// hard-block scoper withholds until confirmed exhaustion.
+				const limits =
+					strategy.scopeLimitsForReserve?.(report, rankingContext) ??
+					this.#getScopedUsageLimits(strategy, report, rankingContext);
 				if (limits.length === 0) return { credentialId: entry.id, credentialType, state: "unknown" };
 
 				const currentLimits = limits.filter(limit => {

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -366,6 +366,16 @@ export interface CredentialRankingStrategy {
 	 */
 	scopeLimits?(report: UsageReport, context?: CredentialRankingContext): UsageLimit[];
 	/**
+	 * Restrict limits for the opt-in, non-destructive usage-reserve health
+	 * check ({@link AuthStorage.getModelUsageHealth}). Distinct from
+	 * {@link scopeLimits}, which gates credential-wide hard blocks: a provider
+	 * whose model/tier counters are trusted only at confirmed exhaustion for
+	 * hard-blocking can still expose them here so the reserve margin protects
+	 * the mapped quota before it hits the cap. Falls back to {@link scopeLimits}
+	 * when omitted.
+	 */
+	scopeLimitsForReserve?(report: UsageReport, context?: CredentialRankingContext): UsageLimit[];
+	/**
 	 * Return a provider-local backoff scope for the requested model. Providers
 	 * with backend-specific quotas use this so one exhausted model family does
 	 * not block unrelated families on the same OAuth credential.

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -713,7 +713,9 @@ function getClaudeModelKind(context: CredentialRankingContext | undefined): Clau
  * Claude model-scoped rows are only relevant to the matching model family.
  * Credential-wide exhaustion checks stay on shared umbrella windows unless the
  * request model parses to a concrete Anthropic kind, preventing a Fable cap from
- * suppressing unrelated Opus/Sonnet traffic.
+ * suppressing unrelated Opus/Sonnet traffic. Feeds ranking pressure and the
+ * opt-in reserve-health scope (`scopeLimitsForReserve`); credential-wide hard
+ * blocks use {@link scopeClaudeLimitsForModelHardBlock} instead.
  */
 function scopeClaudeLimitsForModel(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
 	const kind = getClaudeModelKind(context);
@@ -742,7 +744,7 @@ function isConfirmedExhaustedTierRow(limit: UsageLimit, nowMs: number): boolean 
  * weekly caps participate only when {@link isConfirmedExhaustedTierRow}
  * confirms them, so a confirmed-dead account is skipped up front and a
  * reactive 429 block extends to the tier reset in markUsageLimitReached,
- * while unconfirmed rows remain ranking pressure only via
+ * while unconfirmed rows remain ranking pressure and opt-in reserve health via
  * scopeClaudeLimitsForModel.
  */
 function scopeClaudeLimitsForModelHardBlock(
@@ -810,6 +812,11 @@ export const claudeRankingStrategy: CredentialRankingStrategy = {
 		return { primary, secondary };
 	},
 	scopeLimits: scopeClaudeLimitsForModelHardBlock,
+	// Reserve health is a non-destructive fallback, not a credential hard
+	// block, so it trusts the mapped tier row before confirmed exhaustion: a
+	// Fable/Mythos weekly cap inside the reserve margin should move the turn to
+	// a healthy candidate rather than serve until 100%.
+	scopeLimitsForReserve: scopeClaudeLimitsForModel,
 	/**
 	 * Fable/Mythos usage-limit errors map to tier-local weekly counters. Scope
 	 * reactive backoff blocks for those tiers, mirroring the per-counter

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -7,6 +7,7 @@ import {
 	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import type { CredentialRankingStrategy, UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { claudeRankingStrategy } from "@oh-my-pi/pi-ai/usage/claude";
 import { logger } from "@oh-my-pi/pi-utils";
 
 interface CacheEntry {
@@ -607,5 +608,110 @@ describe("AuthStorage corrupt persisted block store", () => {
 			expect(calls, scenario.name).toBe(1);
 		}
 		expect(errorSpy).toHaveBeenCalledTimes(scenarios.length);
+	});
+});
+
+describe("AuthStorage Claude tier reserve health", () => {
+	const storages: AuthStorage[] = [];
+	afterEach(() => {
+		for (const storage of storages) storage.close();
+		storages.length = 0;
+	});
+
+	const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+	const HOUR_MS = 60 * 60 * 1000;
+
+	function claudeLimit(opts: {
+		id: string;
+		windowId: "5h" | "7d";
+		usedFraction: number;
+		shared?: boolean;
+		tier?: string;
+		exhausted?: boolean;
+	}): UsageLimit {
+		const resetsAt = Date.now() + 3 * 24 * 60 * 60 * 1000;
+		return {
+			id: opts.id,
+			label: opts.id,
+			scope: {
+				provider: "anthropic",
+				windowId: opts.windowId,
+				...(opts.tier !== undefined ? { tier: opts.tier } : {}),
+				...(opts.shared !== undefined ? { shared: opts.shared } : {}),
+			},
+			window: {
+				id: opts.windowId,
+				label: opts.windowId,
+				durationMs: opts.windowId === "5h" ? 5 * HOUR_MS : WEEK_MS,
+				resetsAt,
+			},
+			amount: { usedFraction: opts.usedFraction, unit: "percent" },
+			status: opts.exhausted ? "exhausted" : "ok",
+		};
+	}
+
+	async function createClaudeStorage(reports: Record<string, UsageReport | null>): Promise<AuthStorage> {
+		const storage = new AuthStorage(makeStore([oauthRow(1)]), {
+			usageProviderResolver: provider => (provider === "anthropic" ? makeUsageProvider(reports) : undefined),
+			rankingStrategyResolver: provider => (provider === "anthropic" ? claudeRankingStrategy : undefined),
+			configValueResolver: async value => value,
+		});
+		await storage.reload();
+		storages.push(storage);
+		return storage;
+	}
+
+	function tieredReport(fableUsedFraction: number, exhausted = false): UsageReport {
+		return report("account-1", [
+			claudeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1, shared: true }),
+			claudeLimit({ id: "anthropic:7d", windowId: "7d", usedFraction: 0.72, shared: true }),
+			claudeLimit({
+				id: "anthropic:7d:fable",
+				windowId: "7d",
+				usedFraction: fableUsedFraction,
+				tier: "fable",
+				exhausted,
+			}),
+		]);
+	}
+
+	it("reports reserve when the mapped Fable tier row is inside the reserve margin", async () => {
+		const storage = await createClaudeStorage({ "account-1": tieredReport(0.96) });
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5",
+			reserveFraction: 0.1,
+		});
+		expect(health.state).toBe("reserve");
+		expect(health.accounts[0]?.remainingFraction).toBeCloseTo(0.04);
+	});
+
+	it("keeps a Fable model healthy while its tier row stays outside the reserve margin", async () => {
+		const storage = await createClaudeStorage({ "account-1": tieredReport(0.85) });
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5",
+			reserveFraction: 0.1,
+		});
+		expect(health.state).toBe("healthy");
+		expect(health.accounts[0]?.remainingFraction).toBeCloseTo(0.15);
+	});
+
+	it("does not let a Fable-only tier row pull unrelated Opus traffic into reserve", async () => {
+		const storage = await createClaudeStorage({ "account-1": tieredReport(0.96) });
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude-opus-4-8",
+			reserveFraction: 0.1,
+		});
+		expect(health.state).toBe("healthy");
+		expect(health.accounts[0]?.remainingFraction).toBeCloseTo(0.28);
+	});
+
+	it("still depletes a Fable model on a confirmed 100% tier row", async () => {
+		const storage = await createClaudeStorage({ "account-1": tieredReport(1, true) });
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5",
+			reserveFraction: 0.1,
+		});
+		expect(health.state).toBe("depleted");
+		expect(health.accounts[0]?.resetsAt).toBeGreaterThan(Date.now());
 	});
 });


### PR DESCRIPTION
## Repro
With `retry.usageAwareFallback` on and `retry.usageReservePct: 10`, a Claude Fable model kept serving turns after the reserve boundary. Driving `getModelUsageHealth("anthropic", …)` through the real `claudeRankingStrategy` — shared 5h 10%, shared 7d 72%, Fable 7d tier 96% (future reset), `modelId: claude-fable-5`, `reserveFraction: 0.10` — returns `state: "healthy"` instead of `"reserve"`; at Fable 85% the reported `remainingFraction` is 0.28 (the shared 7d row) rather than 0.15, confirming the tier row is excluded before health is computed. Reproduce: `bun test test/auth-storage-model-usage-health.test.ts -t "Claude tier reserve health"` in `packages/ai`.

## Cause
`AuthStorage.getModelUsageHealth` (`packages/ai/src/auth-storage.ts`) scoped its limits through `strategy.scopeLimits`, which for Anthropic is `scopeClaudeLimitsForModelHardBlock` (`packages/ai/src/usage/claude.ts`). For Fable/Mythos that function keeps the mapped tier row only when `isConfirmedExhaustedTierRow` passes (server `exhausted` or utilization >= 1, with a future reset). A 96% tier row is therefore dropped before reserve health runs, leaving only the shared 72% weekly row, so `remainingFraction` (0.28) exceeds the 0.10 reserve and the model is classified `healthy`. The confirmed-exhaustion guard is correct for a credential-wide hard block but was being reused for the opt-in, non-destructive reserve fallback.

## Fix
- Added `scopeLimitsForReserve?` to `CredentialRankingStrategy` (`packages/ai/src/usage.ts`), documented as the reserve-only scope that may expose mapped tier rows the hard-block scope withholds.
- `getModelUsageHealth` now prefers `strategy.scopeLimitsForReserve` and falls back to `scopeLimits` when unset, so every other provider is unchanged.
- Pointed the Claude strategy's `scopeLimitsForReserve` at the existing `scopeClaudeLimitsForModel`, which includes the mapped tier row regardless of confirmed exhaustion; `scopeLimits` (hard block) still uses `scopeClaudeLimitsForModelHardBlock`.
- Updated the surrounding doc comments to reflect the split.

## Verification
`bun test test/auth-storage-model-usage-health.test.ts` (25 pass) — new `AuthStorage Claude tier reserve health` block asserts: Fable tier at 96% -> `reserve`; below the margin (85%) stays `healthy` with `remainingFraction` 0.15 from the tier row; a Fable-only 96% tier row does not pull `claude-opus-4-8` into reserve (stays `healthy`, 0.28); a confirmed 100% Fable tier row still `depleted` with a future reset. Also ran `test/claude-usage-headers.test.ts` (59 pass) and `test/auth-storage-codex-selection.test.ts` (62 pass). Full `packages/ai` suite is green except a pre-existing env-pollution flake in `test/proxy.test.ts` that passes in isolation and is unrelated to usage scoping.

Fixes #8773