### PR TITLE
fix(nix): install writable home-manager config instead of store symlink

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
                   type = pkgs.lib.types.listOf pkgs.lib.types.package;
                   default = [ ];
                 };
-                options.home.file = pkgs.lib.mkOption {
+                options.home.activation = pkgs.lib.mkOption {
                   type = pkgs.lib.types.attrsOf pkgs.lib.types.anything;
                   default = { };
                 };
@@ -152,7 +152,7 @@
           };
           modulesEvaluate =
             assert builtins.elem self.packages.${system}.default homeManagerEvaluation.config.home.packages;
-            assert homeManagerEvaluation.config.home.file ? ".omp/agent/config.yml";
+            assert homeManagerEvaluation.config.home.activation ? ompConfig;
             assert builtins.elem self.packages.${system}.default
               nixosEvaluation.config.environment.systemPackages;
             pkgs.runCommand "omp-module-evaluation" { } "touch $out";

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -8,6 +8,7 @@
 let
   cfg = config.programs.omp;
   yaml = pkgs.formats.yaml { };
+  configFile = yaml.generate "omp-config.yml" cfg.settings;
 in
 {
   options.programs.omp = {
@@ -25,8 +26,11 @@ in
       default = null;
       description = ''
         Settings written declaratively to {file}`~/.omp/agent/config.yml`.
-        The file is a read-only store symlink: changes made from inside OMP
-        (`/settings`, onboarding) replace it but revert on the next
+        On each `home-manager switch` the declared settings are copied into
+        place as a writable regular file (not a read-only store symlink), so
+        OMP can acquire its config lock and rewrite the file when persisting
+        runtime changes (`/settings`, onboarding). Those runtime changes are
+        overwritten by the declared values again on the next
         `home-manager switch`.
       '';
       example = {
@@ -38,8 +42,21 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    home.file.".omp/agent/config.yml" = lib.mkIf (cfg.settings != null) {
-      source = yaml.generate "omp-config.yml" cfg.settings;
+
+    # OMP rewrites its config at runtime and acquires an advisory lock on it
+    # first; on macOS the lock backend creates an flock sidecar next to the
+    # target file. A `home.file` store symlink is read-only and lives under
+    # /nix/store, so both the lock and the atomic rewrite fail with EACCES and
+    # break every launch. Copy a writable regular file instead. The DAG entry
+    # is written literally (rather than via `lib.hm.dag.entryAfter`) so the
+    # home-manager-free module evaluation in `flake.nix` keeps working.
+    home.activation.ompConfig = lib.mkIf (cfg.settings != null) {
+      before = [ ];
+      after = [ "writeBoundary" ];
+      data = ''
+        run mkdir -p "$HOME/.omp/agent"
+        run install -m 600 ${configFile} "$HOME/.omp/agent/config.yml"
+      '';
     };
   };
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Home Manager module (`programs.omp.settings`) breaking every launch on macOS with `Failed to acquire native file lock … Permission denied (os error 13)`. The declared config is now copied into `~/.omp/agent/config.yml` as a writable file via `home.activation` instead of a read-only `/nix/store` symlink, so OMP can acquire its config lock and persist runtime changes; `home-manager switch` still reapplies the declared settings ([#8775](https://github.com/can1357/oh-my-pi/issues/8775)).
+
 ## [17.3.5] - 2026-08-16
 
 ### Added


### PR DESCRIPTION
## Repro
With the flake's Home Manager module and any `programs.omp.settings` set on macOS:
```nix
imports = [ inputs.omp.homeManagerModules.default ];
programs.omp = { enable = true; settings.startup.quiet = true; };
```
`home-manager switch` then `omp` fails on every launch with `Failed to acquire native file lock for /nix/store/<hash>-omp-config.yml.lock: Permission denied (os error 13)`.

## Cause
`nix/home-manager.nix` installed `~/.omp/agent/config.yml` as a read-only `/nix/store` symlink via `home.file … source = yaml.generate …`. OMP persists runtime settings changes by acquiring an advisory lock on and atomically rewriting its config, resolving the path through `realpath()` — which lands inside the immutable store. On macOS the advisory-lock backend (`crates/pi-natives/src/file_lock/unix.rs`) creates an `flock` sidecar `${target}.lock` beside the store path, so the first startup save fails with `EACCES`. The atomic-write temp file in `Settings.#writeYamlAtomically` (`packages/coding-agent/src/config/settings.ts`) would fail the same way. The module docstring even promised `/settings`/onboarding changes "replace it but revert on the next home-manager switch", which a read-only store symlink can never satisfy.

## Fix
- `nix/home-manager.nix`: replace the `home.file` store symlink with a `home.activation.ompConfig` entry that copies the generated config into `~/.omp/agent/config.yml` as a writable regular file (`install -m 600`) after `writeBoundary`. OMP can now acquire its lock and rewrite the file; the next `home-manager switch` reapplies the declared settings. The DAG entry is written literally (matching `lib.hm.dag.entryAfter`'s `{ data; before; after; }` shape) so the home-manager-free module evaluation in `flake.nix` keeps working.
- `nix/home-manager.nix`: rewrite the `settings` option docstring to describe the writable-copy behavior.
- `flake.nix`: the module-evaluation check now stubs the `home.activation` option and asserts `config.home.activation ? ompConfig` (was `home.file ? ".omp/agent/config.yml"`).
- `packages/coding-agent/CHANGELOG.md`: added a `Fixed` entry under `[Unreleased]`.

## Verification
This CI host is Linux without Nix, and the crash is macOS/BSD-specific (Linux file locks use abstract sockets, so no filesystem sidecar is created and the failure does not reproduce there), so I could not run a live `home-manager switch` repro. I verified the fix by tracing the failing code paths (`file_lock/unix.rs` flock sidecar + `settings.ts` `#withYamlWriteLock`/`#writeYamlAtomically` on the `realpath`-resolved store path) and confirmed the emitted DAG entry `{ data; before = []; after = ["writeBoundary"]; }` is exactly `hm.dag.entryAfter ["writeBoundary"]` and satisfies home-manager's `isEntry`/`dagOf types.str` contract (nix-community/home-manager `modules/lib/dag.nix`). `bun check` passed via the pre-publish gate; my diff touches only `.nix` and `CHANGELOG.md`, which it does not cover.

Fixes #8775