### PR TITLE
Add fail-closed auth gateway and remote subagent seams

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added fail-closed auth-gateway policy hooks for pre-credential authorization, OAuth row allowlists, caller-identity stripping, and content-free request observations.
+- Added dependency-aware auth-gateway readiness probes so policy-backed gateways report unavailable dependencies without changing legacy health behavior.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added fail-closed auth-gateway policy hooks for pre-credential authorization, OAuth row allowlists, caller-identity stripping, and content-free request observations.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/ai/src/auth-gateway/http.ts
+++ b/packages/ai/src/auth-gateway/http.ts
@@ -19,6 +19,49 @@ export function json(status: number, body: unknown, headers?: Record<string, str
 	});
 }
 
+const JSON_DECODER = new TextDecoder();
+
+/** Read and parse a JSON request without permitting an unbounded policy preflight allocation. */
+export async function readBoundedJson(request: Request, maxBytes: number): Promise<unknown> {
+	const declaredLength = Number(request.headers.get("content-length"));
+	if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+		throw new Error("Request JSON body exceeds gateway policy limit");
+	}
+	if (!request.body) throw new Error("Request JSON body is empty");
+
+	const reader = request.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let totalBytes = 0;
+	try {
+		for (;;) {
+			const chunk = await reader.read();
+			if (chunk.done) break;
+			totalBytes += chunk.value.byteLength;
+			if (totalBytes > maxBytes) {
+				try {
+					await reader.cancel();
+				} catch {
+					// The bounded rejection below is authoritative.
+				}
+				throw new Error("Request JSON body exceeds gateway policy limit");
+			}
+			chunks.push(chunk.value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const bytes = chunks.length === 1 ? chunks[0]! : new Uint8Array(totalBytes);
+	if (chunks.length !== 1) {
+		let offset = 0;
+		for (const chunk of chunks) {
+			bytes.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+	}
+	return JSON.parse(JSON_DECODER.decode(bytes)) as unknown;
+}
+
 /**
  * Diagnostic response headers for translated inference requests, mirroring the
  * names existing gateway-aware clients already parse: `x-request-id` /
@@ -121,19 +164,44 @@ const PASSTHROUGH_HEADER_NAMES: Record<string, true> = {
 	"x-conversation-id": true,
 };
 
+/** Policy mode forwards only protocol feature/version headers with no identity semantics. */
+const POLICY_PASSTHROUGH_HEADER_NAMES: Record<string, true> = {
+	"anthropic-beta": true,
+	"anthropic-version": true,
+	"openai-beta": true,
+};
+
+/** Retain only explicitly safe protocol feature/version headers in policy mode. */
+export function stripPolicyIdentityHeaders(
+	headers: Readonly<Record<string, string>> | undefined,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [name, value] of Object.entries(headers ?? {})) {
+		const lower = name.toLowerCase();
+		if (!value || !POLICY_PASSTHROUGH_HEADER_NAMES[lower]) continue;
+		out[lower] = value;
+	}
+	return out;
+}
+
 /**
  * Extract allow-listed passthrough headers from an inbound request. Keys are
  * lowercased; empty values are dropped. Called once per request in
  * `handleFormatEndpoint`; parsers then read `options.headers`.
  */
-export function captureRequestHeaders(headers: Headers): Record<string, string> {
+export function captureRequestHeaders(
+	headers: Headers,
+	options?: { stripPolicyIdentity?: boolean },
+): Record<string, string> {
 	const out: Record<string, string> = {};
 	headers.forEach((value, key) => {
 		if (!value) return;
 		const lower = key.toLowerCase();
-		if (PASSTHROUGH_HEADER_NAMES[lower] || lower.startsWith("x-stainless-")) {
-			out[lower] = value;
+		if (options?.stripPolicyIdentity) {
+			if (POLICY_PASSTHROUGH_HEADER_NAMES[lower]) out[lower] = value;
+			return;
 		}
+		if (PASSTHROUGH_HEADER_NAMES[lower] || lower.startsWith("x-stainless-")) out[lower] = value;
 	});
 	return out;
 }

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -30,8 +30,9 @@ import * as openaiChat from "../providers/openai-chat-server";
 import * as openaiResponses from "../providers/openai-responses-server";
 import * as piNative from "../providers/pi-native-server";
 import { completeSimple, streamSimple } from "../stream";
-import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "../types";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "../types";
 import { deterministicUuid } from "../utils/deterministic-id";
+import { AssistantMessageEventStream } from "../utils/event-stream";
 import { parseBind } from "../utils/parse-bind";
 import {
 	captureRequestHeaders,
@@ -39,16 +40,22 @@ import {
 	gatewayResponseHeaders,
 	isAuthorized,
 	json,
+	readBoundedJson,
 	resolvePeer,
+	stripPolicyIdentityHeaders,
 	withCors,
 } from "./http";
 import type {
+	AuthGatewayAuthorizationDecision,
+	AuthGatewayAuthorizationGrant,
+	AuthGatewayObservation,
+	AuthGatewayPolicyObservationBase,
 	AuthGatewayServerHandle,
 	AuthGatewayServerOptions,
 	AuthGatewayFormatModule as FormatModule,
 	AuthGatewayParsedRequest as ParsedFormatRequest,
 } from "./types";
-import { DEFAULT_AUTH_GATEWAY_BIND } from "./types";
+import { AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER, DEFAULT_AUTH_GATEWAY_BIND } from "./types";
 
 // ParsedFormatRequest / ParsedFormatOptions / FormatModule come from ./types.
 
@@ -75,6 +82,271 @@ const FORMAT_ROUTES: Record<string, { module: FormatModule; label: string }> = {
 	"/v1/messages": { module: anthropicMessages, label: "anthropic-messages" },
 	"/v1/responses": { module: openaiResponses, label: "openai-responses" },
 };
+
+const MAX_POLICY_MODEL_SELECTOR_LENGTH = 512;
+const MAX_POLICY_SESSION_ID_LENGTH = 1024;
+const MAX_POLICY_AUTHORIZATION_ID_LENGTH = 512;
+const MAX_POLICY_CREDENTIAL_IDS = 256;
+const MAX_POLICY_AUTHORIZATION_INPUT_LENGTH = 4096;
+const MAX_POLICY_REQUEST_BODY_BYTES = 64 * 1024 * 1024;
+
+const AUTHORIZATION_DENIAL_FIELDS: Record<string, true> = {
+	authorized: true,
+	reasonCode: true,
+};
+const AUTHORIZATION_GRANT_FIELDS: Record<string, true> = {
+	authorized: true,
+	authorizationId: true,
+	requestedModelId: true,
+	resolvedModelId: true,
+	sessionId: true,
+	allowedOAuthCredentialIds: true,
+};
+
+class AuthGatewayObserverDeliveryError extends Error {
+	constructor() {
+		super("Gateway observer is unavailable");
+		this.name = "AuthGatewayObserverDeliveryError";
+	}
+}
+
+interface GatewayPolicy {
+	requestId: string;
+	format: string;
+	authorizationId: string;
+	requestedModelId: string;
+	resolvedModelId: string;
+	sessionId: string;
+	allowedOAuthCredentialIds: ReadonlySet<number>;
+}
+
+type GatewayAuthorizationResult = { ok: true; policy?: GatewayPolicy } | { ok: false; response: Response };
+type GatewayFormatError = (status: number, type: string, message: string) => Response;
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBoundedPolicyText(value: unknown, maxLength: number): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value.length <= maxLength &&
+		value.trim() === value &&
+		!/\p{Cc}/u.test(value)
+	);
+}
+
+function hasOnlyDecisionFields(value: Record<string, unknown>, allowed: Record<string, true>): boolean {
+	return Object.keys(value).every(key => allowed[key]);
+}
+
+function validateAuthorizationGrant(
+	decision: unknown,
+	requestedModelId: string,
+): AuthGatewayAuthorizationGrant | undefined {
+	if (!isUnknownRecord(decision) || decision.authorized !== true) return undefined;
+	if (!hasOnlyDecisionFields(decision, AUTHORIZATION_GRANT_FIELDS)) return undefined;
+	if (
+		!isBoundedPolicyText(decision.authorizationId, MAX_POLICY_AUTHORIZATION_ID_LENGTH) ||
+		!isBoundedPolicyText(decision.requestedModelId, MAX_POLICY_MODEL_SELECTOR_LENGTH) ||
+		decision.requestedModelId !== requestedModelId ||
+		!isBoundedPolicyText(decision.resolvedModelId, MAX_POLICY_MODEL_SELECTOR_LENGTH) ||
+		!isBoundedPolicyText(decision.sessionId, MAX_POLICY_SESSION_ID_LENGTH)
+	) {
+		return undefined;
+	}
+	const namespaceSeparator = decision.sessionId.indexOf(":");
+	if (namespaceSeparator <= 0 || namespaceSeparator === decision.sessionId.length - 1) return undefined;
+	if (
+		!Array.isArray(decision.allowedOAuthCredentialIds) ||
+		decision.allowedOAuthCredentialIds.length === 0 ||
+		decision.allowedOAuthCredentialIds.length > MAX_POLICY_CREDENTIAL_IDS
+	) {
+		return undefined;
+	}
+	const seen = new Set<number>();
+	for (const credentialId of decision.allowedOAuthCredentialIds) {
+		if (!Number.isSafeInteger(credentialId) || credentialId <= 0 || seen.has(credentialId)) return undefined;
+		seen.add(credentialId);
+	}
+	return decision as unknown as AuthGatewayAuthorizationGrant;
+}
+
+function validateAuthorizationDenial(decision: unknown): { reasonCode?: string } | undefined {
+	if (!isUnknownRecord(decision) || decision.authorized !== false) return undefined;
+	if (!hasOnlyDecisionFields(decision, AUTHORIZATION_DENIAL_FIELDS)) return undefined;
+	if (decision.reasonCode === undefined) return {};
+	if (
+		typeof decision.reasonCode !== "string" ||
+		decision.reasonCode.length === 0 ||
+		decision.reasonCode.length > 128 ||
+		!/^[a-z0-9][a-z0-9._-]*$/i.test(decision.reasonCode)
+	) {
+		return undefined;
+	}
+	return { reasonCode: decision.reasonCode };
+}
+
+async function emitGatewayObservation(
+	bootOpts: AuthGatewayBootOptions,
+	observation: AuthGatewayObservation,
+): Promise<void> {
+	if (!bootOpts.observer) return;
+	try {
+		await bootOpts.observer(observation);
+	} catch {
+		throw new AuthGatewayObserverDeliveryError();
+	}
+}
+
+function policyObservationBase(policy: GatewayPolicy): AuthGatewayPolicyObservationBase {
+	return {
+		requestId: policy.requestId,
+		format: policy.format,
+		authorizationId: policy.authorizationId,
+		requestedModelId: policy.requestedModelId,
+		resolvedModelId: policy.resolvedModelId,
+		sessionId: policy.sessionId,
+	};
+}
+
+function observerFailureResponse(formatError: GatewayFormatError): Response {
+	return formatError(503, "authorization_error", "Gateway policy observer is unavailable");
+}
+
+async function authorizeGatewayRequest(
+	bootOpts: AuthGatewayBootOptions,
+	req: Request,
+	input: {
+		requestId: string;
+		format: string;
+		requestedModelId: string;
+		requestedSessionId?: string;
+	},
+	formatError: GatewayFormatError,
+): Promise<GatewayAuthorizationResult> {
+	const authorizer = bootOpts.authorizeRequest;
+	if (!authorizer) return { ok: true };
+	if (
+		!isBoundedPolicyText(input.requestedModelId, MAX_POLICY_MODEL_SELECTOR_LENGTH) ||
+		(input.requestedSessionId !== undefined &&
+			!isBoundedPolicyText(input.requestedSessionId, MAX_POLICY_SESSION_ID_LENGTH))
+	) {
+		return {
+			ok: false,
+			response: formatError(400, "invalid_request_error", "Policy request identifiers exceed gateway limits"),
+		};
+	}
+	const authorization = req.headers.get(AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER);
+	if (!isBoundedPolicyText(authorization, MAX_POLICY_AUTHORIZATION_INPUT_LENGTH)) {
+		return {
+			ok: false,
+			response: formatError(401, "authorization_error", "Missing or invalid gateway policy authorization"),
+		};
+	}
+
+	let decision: AuthGatewayAuthorizationDecision;
+	try {
+		decision = await authorizer({
+			requestId: input.requestId,
+			format: input.format,
+			requestedModelId: input.requestedModelId,
+			requestedSessionId: input.requestedSessionId,
+			method: req.method,
+			path: new URL(req.url).pathname,
+			authorization,
+			signal: req.signal,
+		});
+	} catch {
+		try {
+			await emitGatewayObservation(bootOpts, {
+				type: "authorization",
+				requestId: input.requestId,
+				format: input.format,
+				requestedModelId: input.requestedModelId,
+				outcome: "error",
+			});
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return { ok: false, response: observerFailureResponse(formatError) };
+			}
+			throw error;
+		}
+		return {
+			ok: false,
+			response: formatError(503, "authorization_error", "Gateway authorization policy is unavailable"),
+		};
+	}
+
+	const denial = validateAuthorizationDenial(decision);
+	if (denial) {
+		try {
+			await emitGatewayObservation(bootOpts, {
+				type: "authorization",
+				requestId: input.requestId,
+				format: input.format,
+				requestedModelId: input.requestedModelId,
+				outcome: "denied",
+				reasonCode: denial.reasonCode,
+			});
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return { ok: false, response: observerFailureResponse(formatError) };
+			}
+			throw error;
+		}
+		return {
+			ok: false,
+			response: formatError(403, "authorization_error", "Request denied by gateway policy"),
+		};
+	}
+
+	const grant = validateAuthorizationGrant(decision, input.requestedModelId);
+	if (!grant) {
+		try {
+			await emitGatewayObservation(bootOpts, {
+				type: "authorization",
+				requestId: input.requestId,
+				format: input.format,
+				requestedModelId: input.requestedModelId,
+				outcome: "error",
+			});
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return { ok: false, response: observerFailureResponse(formatError) };
+			}
+			throw error;
+		}
+		return {
+			ok: false,
+			response: formatError(500, "authorization_error", "Gateway authorization policy returned an invalid decision"),
+		};
+	}
+
+	const policy: GatewayPolicy = {
+		requestId: input.requestId,
+		format: input.format,
+		authorizationId: grant.authorizationId,
+		requestedModelId: grant.requestedModelId,
+		resolvedModelId: grant.resolvedModelId,
+		sessionId: grant.sessionId,
+		allowedOAuthCredentialIds: new Set(grant.allowedOAuthCredentialIds),
+	};
+	try {
+		await emitGatewayObservation(bootOpts, {
+			type: "authorization",
+			...policyObservationBase(policy),
+			outcome: "authorized",
+		});
+	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return { ok: false, response: observerFailureResponse(formatError) };
+		}
+		throw error;
+	}
+	return { ok: true, policy };
+}
 
 // (passthrough fast-path removed — it bypassed pi-ai provider logic, in
 // particular the Anthropic Claude-Code OAuth system-prompt prefix injection.
@@ -229,31 +501,85 @@ function buildStreamOptions(parsed: ParsedFormatRequest, api: Api, signal: Abort
  * failure with a fresh credential. Returning `undefined` aborts the retry
  * and surfaces the original error to the caller.
  */
+interface GatewayResolvedCredential {
+	apiKey: string;
+	credentialId?: number;
+}
+
 async function refreshGatewayApiKeyAfterAuthError(
-	storage: AuthStorage,
+	bootOpts: AuthGatewayBootOptions,
 	model: Model<Api>,
 	sessionId: string,
-	provider: string,
-	oldKey: string,
+	oldCredential: GatewayResolvedCredential,
 	error: unknown,
 	signal: AbortSignal,
 	format: string,
 	peer: string,
-): Promise<string | undefined> {
+	policy?: GatewayPolicy,
+): Promise<GatewayResolvedCredential | undefined> {
 	const message = error instanceof Error ? error.message : String(error);
 	const status = extractHttpStatusFromError(error);
-	if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
+	const usageLimit = AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message);
+	if (policy) {
+		if (oldCredential.credentialId === undefined) return undefined;
+		const switched = await bootOpts.storage.rotateSessionCredential(model.provider, sessionId, {
+			error,
+			modelId: model.id,
+			credentialId: oldCredential.credentialId,
+			signal,
+			allowedOAuthCredentialIds: policy.allowedOAuthCredentialIds,
+			redactOAuthErrors: true,
+		});
+		if (!switched) {
+			await emitGatewayObservation(bootOpts, {
+				type: "error",
+				...policyObservationBase(policy),
+				stage: "credential_selection",
+				code: "credential_rotation_unavailable",
+			});
+			return undefined;
+		}
+		const access = await bootOpts.storage.getOAuthApiKeyFromCredentialIds(
+			model.provider,
+			sessionId,
+			policy.allowedOAuthCredentialIds,
+			{ modelId: model.id, signal },
+		);
+		if (
+			!access ||
+			access.credentialId === oldCredential.credentialId ||
+			!policy.allowedOAuthCredentialIds.has(access.credentialId)
+		) {
+			await emitGatewayObservation(bootOpts, {
+				type: "error",
+				...policyObservationBase(policy),
+				stage: "credential_selection",
+				code: "credential_rotation_unavailable",
+			});
+			return undefined;
+		}
+		await emitGatewayObservation(bootOpts, {
+			type: "credential_rotation",
+			...policyObservationBase(policy),
+			previousCredentialId: oldCredential.credentialId,
+			credentialId: access.credentialId,
+			reason: usageLimit ? "usage_limit" : "authentication_failure",
+		});
+		return access;
+	}
+
+	if (usageLimit) {
 		const retryAfterMs = extractRetryHint(undefined, message);
-		const { switched, retryAtMs } = await storage.markUsageLimitReached(provider, sessionId, {
+		const { switched, retryAtMs } = await bootOpts.storage.markUsageLimitReached(model.provider, sessionId, {
 			retryAfterMs,
 			baseUrl: model.baseUrl,
 			modelId: model.id,
-			apiKey: oldKey,
+			apiKey: oldCredential.apiKey,
 			signal,
 		});
 		logger.debug("auth-gateway retrying provider request after usage-limit block", {
 			format,
-			provider,
+			provider: model.provider,
 			peer,
 			switched,
 			retryAfterMs,
@@ -261,16 +587,18 @@ async function refreshGatewayApiKeyAfterAuthError(
 			error: message,
 		});
 		if (!switched) return undefined;
-		return storage.getApiKey(provider, sessionId, { modelId: model.id, signal });
+		const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, { modelId: model.id, signal });
+		return apiKey ? { apiKey } : undefined;
 	}
-	await storage.invalidateCredentialMatching(provider, oldKey, { sessionId, signal });
+	await bootOpts.storage.invalidateCredentialMatching(model.provider, oldCredential.apiKey, { sessionId, signal });
 	logger.debug("auth-gateway retrying provider request after credential invalidation", {
 		format,
-		provider,
+		provider: model.provider,
 		peer,
 		error: message,
 	});
-	return storage.getApiKey(provider, sessionId, { modelId: model.id, signal });
+	const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, { modelId: model.id, signal });
+	return apiKey ? { apiKey } : undefined;
 }
 
 /**
@@ -287,43 +615,70 @@ async function refreshGatewayApiKeyAfterAuthError(
  * credential that actually failed.
  */
 function buildGatewayApiKeyResolver(
-	storage: AuthStorage,
+	bootOpts: AuthGatewayBootOptions,
 	model: Model<Api>,
 	sessionId: string,
-	initialKey: string,
+	initialCredential: GatewayResolvedCredential,
 	requestSignal: AbortSignal,
 	format: string,
 	peer: string,
+	policy?: GatewayPolicy,
 ): ApiKeyResolver {
-	let lastKey = initialKey;
+	let currentCredential = initialCredential;
 	return async ({ lastChance, error, signal }) => {
 		const sig = signal ?? requestSignal;
 		if (error === undefined) {
-			lastKey = initialKey;
-			return initialKey;
+			currentCredential = initialCredential;
+			return initialCredential.apiKey;
 		}
 		if (!lastChance) {
-			const refreshed = await storage.getApiKey(model.provider, sessionId, {
+			if (policy) {
+				const credentialId = currentCredential.credentialId;
+				if (credentialId === undefined || !policy.allowedOAuthCredentialIds.has(credentialId)) return undefined;
+				const resolved = await bootOpts.storage.getOAuthApiKeyByCredentialId(model.provider, credentialId, {
+					modelId: model.id,
+					signal: sig,
+					forceRefresh: true,
+				});
+				if (!resolved || !policy.allowedOAuthCredentialIds.has(resolved.credentialId)) {
+					await emitGatewayObservation(bootOpts, {
+						type: "error",
+						...policyObservationBase(policy),
+						stage: "credential_selection",
+						code: "credential_rotation_unavailable",
+					});
+					return undefined;
+				}
+				currentCredential = resolved;
+				await emitGatewayObservation(bootOpts, {
+					type: "credential_selection",
+					...policyObservationBase(policy),
+					credentialId: resolved.credentialId,
+					phase: "force_refresh",
+				});
+				return resolved.apiKey;
+			}
+			const refreshed = await bootOpts.storage.getApiKey(model.provider, sessionId, {
 				modelId: model.id,
 				signal: sig,
 				forceRefresh: true,
 			});
-			lastKey = refreshed ?? lastKey;
+			if (refreshed) currentCredential = { apiKey: refreshed };
 			return refreshed;
 		}
 		const next = await refreshGatewayApiKeyAfterAuthError(
-			storage,
+			bootOpts,
 			model,
 			sessionId,
-			model.provider,
-			lastKey,
+			currentCredential,
 			error,
 			sig,
 			format,
 			peer,
+			policy,
 		);
-		lastKey = next ?? lastKey;
-		return next;
+		if (next) currentCredential = next;
+		return next?.apiKey;
 	};
 }
 
@@ -341,6 +696,108 @@ function mirrorRequestAbort(req: Request): AbortController {
 	return controller;
 }
 
+async function observePolicyFailure(
+	bootOpts: AuthGatewayBootOptions,
+	policy: GatewayPolicy,
+	stage: "model_resolution" | "credential_selection" | "upstream",
+	code:
+		| "model_unavailable"
+		| "credential_unavailable"
+		| "credential_rotation_unavailable"
+		| "request_aborted"
+		| "upstream_error",
+	outcome: "error" | "aborted" = "error",
+): Promise<void> {
+	await emitGatewayObservation(bootOpts, {
+		type: "error",
+		...policyObservationBase(policy),
+		stage,
+		code,
+	});
+	await emitGatewayObservation(bootOpts, {
+		type: "terminal",
+		...policyObservationBase(policy),
+		outcome,
+	});
+}
+
+function genericPolicyErrorMessage(message: AssistantMessage, reason: "error" | "aborted"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: message.api,
+		provider: message.provider,
+		model: message.model,
+		timestamp: message.timestamp,
+		usage: message.usage,
+		stopReason: reason,
+		errorMessage: reason === "aborted" ? "Request was aborted" : "Upstream request failed",
+		errorStatus: message.errorStatus,
+		errorId: message.errorId,
+	};
+}
+
+function withPolicyEventObservations(
+	events: AssistantMessageEventStream,
+	bootOpts: AuthGatewayBootOptions,
+	policy: GatewayPolicy,
+): AssistantMessageEventStream {
+	const observed = new AssistantMessageEventStream();
+	const pump = async (): Promise<void> => {
+		let terminal = false;
+		try {
+			for await (const event of events) {
+				if (event.type === "done") {
+					await emitGatewayObservation(bootOpts, {
+						type: "terminal",
+						...policyObservationBase(policy),
+						outcome: "success",
+					});
+					terminal = true;
+					observed.push(event);
+					return;
+				}
+				if (event.type === "error") {
+					const outcome = event.reason === "aborted" ? "aborted" : "error";
+					await observePolicyFailure(
+						bootOpts,
+						policy,
+						"upstream",
+						outcome === "aborted" ? "request_aborted" : "upstream_error",
+						outcome,
+					);
+					terminal = true;
+					observed.push({
+						type: "error",
+						reason: event.reason,
+						error: genericPolicyErrorMessage(event.error, event.reason),
+					});
+					return;
+				}
+				observed.push(event);
+			}
+			if (!terminal) {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				observed.fail(new Error("Gateway upstream stream failed"));
+			}
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				observed.fail(error);
+				return;
+			}
+			try {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+			} catch (observationError) {
+				observed.fail(observationError);
+				return;
+			}
+			observed.fail(new Error("Gateway upstream stream failed"));
+		}
+	};
+	void pump();
+	return observed;
+}
+
 // (handlePassthrough removed — see note above.)
 
 async function handleFormatEndpoint(
@@ -356,10 +813,11 @@ async function handleFormatEndpoint(
 
 	let body: unknown;
 	try {
-		body = await req.json();
+		body = bootOpts.authorizeRequest ? await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES) : await req.json();
 	} catch (error) {
 		if (controller.signal.aborted) return clientClosedResponse(route);
-		return route.module.formatError(400, "invalid_request_error", `Invalid JSON body: ${String(error)}`);
+		const message = bootOpts.authorizeRequest ? "Invalid JSON request body" : `Invalid JSON body: ${String(error)}`;
+		return route.module.formatError(400, "invalid_request_error", message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
 
@@ -374,11 +832,6 @@ async function handleFormatEndpoint(
 		return route.module.formatError(400, "invalid_request_error", "Missing top-level `model` field");
 	}
 
-	const model = bootOpts.resolveModel(modelId);
-	if (!model) {
-		return route.module.formatError(404, "invalid_request_error", `Unknown model: ${modelId}`);
-	}
-
 	// Parse the wire-format request BEFORE resolving the credential so we
 	// have a stable per-conversation `sessionId` to thread into AuthStorage.
 	// Sticky-credential tracking and `markUsageLimitReached` both key off
@@ -390,44 +843,121 @@ async function handleFormatEndpoint(
 		parsed = route.module.parseRequest(body, req.headers);
 	} catch (error) {
 		if (controller.signal.aborted) return clientClosedResponse(route);
-		const message = error instanceof Error ? error.message : String(error);
+		const message = bootOpts.authorizeRequest
+			? "Invalid provider-format request body"
+			: error instanceof Error
+				? error.message
+				: String(error);
 		return route.module.formatError(400, "invalid_request_error", message);
 	}
-	// Merge gateway-captured passthrough headers under the parser's own
-	// captures. Parsers that set `options.headers` themselves win (they may
-	// have stripped or normalized values); the gateway's allow-list fills in
-	// anything they didn't touch.
-	{
-		const captured = captureRequestHeaders(req.headers);
-		parsed.options.headers = { ...captured, ...(parsed.options.headers ?? {}) };
+	const authorization = await authorizeGatewayRequest(
+		bootOpts,
+		req,
+		{
+			requestId,
+			format: route.label,
+			requestedModelId: parsed.modelId,
+			requestedSessionId: parsed.options.promptCacheKey,
+		},
+		route.module.formatError,
+	);
+	if (!authorization.ok) return authorization.response;
+	const policy = authorization.policy;
+
+	const resolvedModelId = policy?.resolvedModelId ?? parsed.modelId;
+	const model = bootOpts.resolveModel(resolvedModelId);
+	if (!model) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "model_resolution", "model_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw error;
+			}
+			return route.module.formatError(404, "invalid_request_error", "Authorized model is unavailable");
+		}
+		return route.module.formatError(404, "invalid_request_error", `Unknown model: ${parsed.modelId}`);
+	}
+
+	// In policy mode parser-captured account, organization, project, client,
+	// and credential headers are discarded before provider options are built.
+	const captured = captureRequestHeaders(req.headers, { stripPolicyIdentity: policy !== undefined });
+	const parsedHeaders = policy ? stripPolicyIdentityHeaders(parsed.options.headers) : (parsed.options.headers ?? {});
+	parsed.options.headers = { ...captured, ...parsedHeaders };
+
+	const sessionId =
+		policy?.sessionId ?? parsed.options.promptCacheKey ?? deriveSessionId(parsed.modelId, parsed.context);
+	if (policy) {
+		parsed.options.promptCacheKey = sessionId;
+		delete parsed.options.user;
+		delete parsed.options.metadata;
+		delete parsed.options.previousResponseId;
+		delete parsed.options.extra;
+	} else {
+		parsed.options.promptCacheKey ??= sessionId;
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
 
-	// Sticky credential id: honour the client's `prompt_cache_key` when
-	// supplied (so external session ids align), otherwise derive from
-	// modelId + system + tools + first message. Mirrored into
-	// streamOpts.sessionId / promptCacheKey by `buildStreamOptions`.
-	const sessionId = parsed.options.promptCacheKey ?? deriveSessionId(parsed.modelId, parsed.context);
-	parsed.options.promptCacheKey ??= sessionId;
-
-	// pi-ai's stream() does NOT consult AuthStorage — the caller (us) is
-	// expected to resolve the credential and pass it as `options.apiKey`.
-	// For OAuth providers this returns the access token (refreshed via the
-	// broker override on AuthStorage when needed).
-	let apiKey: string | undefined;
+	let credential: GatewayResolvedCredential | undefined;
 	try {
-		apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
-			modelId: model.id,
-			signal: controller.signal,
-		});
+		if (policy) {
+			const access = await bootOpts.storage.getOAuthApiKeyFromCredentialIds(
+				model.provider,
+				sessionId,
+				policy.allowedOAuthCredentialIds,
+				{ modelId: model.id, signal: controller.signal },
+			);
+			if (access && policy.allowedOAuthCredentialIds.has(access.credentialId)) {
+				credential = access;
+				await emitGatewayObservation(bootOpts, {
+					type: "credential_selection",
+					...policyObservationBase(policy),
+					credentialId: access.credentialId,
+					phase: "initial",
+				});
+			}
+		} else {
+			const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
+				modelId: model.id,
+				signal: controller.signal,
+			});
+			if (apiKey) credential = { apiKey };
+		}
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(route.module.formatError);
+		}
 		if (controller.signal.aborted) return clientClosedResponse(route);
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw observationError;
+			}
+			return route.module.formatError(503, "authentication_error", "Authorized OAuth credential selection failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway getApiKey threw", { provider: model.provider, peer, error: classified.message });
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
-	if (!apiKey) {
+	if (!credential) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw error;
+			}
+			return route.module.formatError(401, "authentication_error", "No authorized OAuth credential is available");
+		}
 		return route.module.formatError(
 			401,
 			"authentication_error",
@@ -437,13 +967,14 @@ async function handleFormatEndpoint(
 
 	const streamOpts = buildStreamOptions(parsed, model.api, controller.signal);
 	streamOpts.apiKey = buildGatewayApiKeyResolver(
-		bootOpts.storage,
+		bootOpts,
 		model,
 		sessionId,
-		apiKey,
+		credential,
 		controller.signal,
 		route.label,
 		peer,
+		policy,
 	);
 
 	logger.info("auth-gateway request", {
@@ -458,12 +989,29 @@ async function handleFormatEndpoint(
 
 	if (!parsed.stream) {
 		try {
-			if (controller.signal.aborted) return clientClosedResponse(route);
+			if (controller.signal.aborted) {
+				if (policy) await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+				return clientClosedResponse(route);
+			}
 			const message = await completeSimple(model, parsed.context, streamOpts);
 			if (message.stopReason === "aborted" || message.stopReason === "error") {
 				const errorMessage =
 					message.errorMessage ??
 					(message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed");
+				if (policy) {
+					await observePolicyFailure(
+						bootOpts,
+						policy,
+						"upstream",
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "aborted" : "error",
+					);
+					return route.module.formatError(
+						message.stopReason === "aborted" ? 499 : 502,
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed",
+					);
+				}
 				logger.warn("auth-gateway non-streaming failed", {
 					format: route.label,
 					reason: message.stopReason,
@@ -476,13 +1024,46 @@ async function handleFormatEndpoint(
 				const classified = classifyGatewayError(errorMessage);
 				return route.module.formatError(classified.status, classified.type, errorMessage);
 			}
+			if (policy) {
+				await emitGatewayObservation(bootOpts, {
+					type: "terminal",
+					...policyObservationBase(policy),
+					outcome: "success",
+				});
+			}
 			return json(
 				200,
 				route.module.encodeResponse(message, parsed.modelId),
 				gatewayResponseHeaders(model, { requestId, message, startedAt }),
 			);
 		} catch (error) {
-			if (controller.signal.aborted) return clientClosedResponse(route);
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return observerFailureResponse(route.module.formatError);
+			}
+			if (controller.signal.aborted) {
+				if (policy) {
+					try {
+						await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+					} catch (observationError) {
+						if (observationError instanceof AuthGatewayObserverDeliveryError) {
+							return observerFailureResponse(route.module.formatError);
+						}
+						throw observationError;
+					}
+				}
+				return clientClosedResponse(route);
+			}
+			if (policy) {
+				try {
+					await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				} catch (observationError) {
+					if (observationError instanceof AuthGatewayObserverDeliveryError) {
+						return observerFailureResponse(route.module.formatError);
+					}
+					throw observationError;
+				}
+				return route.module.formatError(502, "upstream_error", "Upstream request failed");
+			}
 			const classified = classifyGatewayError(error);
 			logger.warn("auth-gateway non-streaming aborted", {
 				format: route.label,
@@ -498,12 +1079,27 @@ async function handleFormatEndpoint(
 		if (controller.signal.aborted) return clientClosedResponse(route);
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(route.module.formatError);
+		}
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw observationError;
+			}
+			return route.module.formatError(502, "upstream_error", "Upstream request failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway streamSimple threw", { format: route.label, error: classified.message, peer });
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
 
+	if (policy) events = withPolicyEventObservations(events, bootOpts, policy);
 	const sseStream = route.module.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
 		onCancel: reason => {
@@ -550,10 +1146,11 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	let body: unknown;
 	try {
-		body = await req.json();
+		body = bootOpts.authorizeRequest ? await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES) : await req.json();
 	} catch (error) {
 		if (controller.signal.aborted) return aborted();
-		return piNative.formatError(400, "invalid_request_error", `Invalid JSON body: ${String(error)}`);
+		const message = bootOpts.authorizeRequest ? "Invalid JSON request body" : `Invalid JSON body: ${String(error)}`;
+		return piNative.formatError(400, "invalid_request_error", message);
 	}
 	if (controller.signal.aborted) return aborted();
 
@@ -562,36 +1159,121 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		parsed = piNative.parseRequest(body, req.headers);
 	} catch (error) {
 		if (controller.signal.aborted) return aborted();
-		const message = error instanceof Error ? error.message : String(error);
+		const message = bootOpts.authorizeRequest
+			? "Invalid pi-native request body"
+			: error instanceof Error
+				? error.message
+				: String(error);
 		return piNative.formatError(400, "invalid_request_error", message);
 	}
 
-	const model = bootOpts.resolveModel(parsed.modelId);
+	const authorization = await authorizeGatewayRequest(
+		bootOpts,
+		req,
+		{
+			requestId,
+			format: "pi-native",
+			requestedModelId: parsed.modelId,
+			requestedSessionId: parsed.options.sessionId ?? parsed.options.promptCacheKey,
+		},
+		piNative.formatError,
+	);
+	if (!authorization.ok) return authorization.response;
+	const policy = authorization.policy;
+
+	const resolvedModelId = policy?.resolvedModelId ?? parsed.modelId;
+	const model = bootOpts.resolveModel(resolvedModelId);
 	if (!model) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "model_resolution", "model_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw error;
+			}
+			return piNative.formatError(404, "invalid_request_error", "Authorized model is unavailable");
+		}
 		return piNative.formatError(404, "invalid_request_error", `Unknown model: ${parsed.modelId}`);
 	}
-	// Pi-native already parsed `streamOpts.sessionId` (when set by the
-	// client); fall back to the derived key so credential-stickiness lines
-	// up with cache-prefix stickiness — same identity used for both means
-	// the next turn of this conversation reuses the same credential until
-	// it hits a usage cap, then markUsageLimitReached can hand off.
-	const sessionId = parsed.options.sessionId ?? deriveSessionId(parsed.modelId, parsed.context);
-	parsed.options.sessionId ??= sessionId;
 
-	let apiKey: string | undefined;
+	const sessionId =
+		policy?.sessionId ??
+		parsed.options.sessionId ??
+		parsed.options.promptCacheKey ??
+		deriveSessionId(parsed.modelId, parsed.context);
+	if (policy) {
+		parsed.options.sessionId = sessionId;
+		parsed.options.promptCacheKey = sessionId;
+		parsed.options.headers = stripPolicyIdentityHeaders(parsed.options.headers);
+		delete parsed.options.metadata;
+		delete parsed.options.initiatorOverride;
+		delete parsed.options.cachedContent;
+		delete parsed.options.openrouterVariant;
+		delete parsed.options.statefulResponses;
+	} else {
+		parsed.options.sessionId ??= sessionId;
+	}
+
+	let credential: GatewayResolvedCredential | undefined;
 	try {
-		apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
-			modelId: model.id,
-			signal: controller.signal,
-		});
+		if (policy) {
+			const access = await bootOpts.storage.getOAuthApiKeyFromCredentialIds(
+				model.provider,
+				sessionId,
+				policy.allowedOAuthCredentialIds,
+				{ modelId: model.id, signal: controller.signal },
+			);
+			if (access && policy.allowedOAuthCredentialIds.has(access.credentialId)) {
+				credential = access;
+				await emitGatewayObservation(bootOpts, {
+					type: "credential_selection",
+					...policyObservationBase(policy),
+					credentialId: access.credentialId,
+					phase: "initial",
+				});
+			}
+		} else {
+			const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
+				modelId: model.id,
+				signal: controller.signal,
+			});
+			if (apiKey) credential = { apiKey };
+		}
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(piNative.formatError);
+		}
 		if (controller.signal.aborted) return aborted();
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw observationError;
+			}
+			return piNative.formatError(503, "authentication_error", "Authorized OAuth credential selection failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway getApiKey threw", { provider: model.provider, peer, error: classified.message });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return aborted();
-	if (!apiKey) {
+	if (!credential) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw error;
+			}
+			return piNative.formatError(401, "authentication_error", "No authorized OAuth credential is available");
+		}
 		return piNative.formatError(
 			401,
 			"authentication_error",
@@ -603,15 +1285,16 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	// trust the client's options (already allow-listed by `parseRequest`) and
 	// only inject server-controlled fields. The codex sampling strip mirrors
 	// `buildStreamOptions` — Codex rejects every one with a 400 (#3117).
-	const streamOpts: SimpleStreamOptions = { ...parsed.options, apiKey, signal: controller.signal };
+	const streamOpts: SimpleStreamOptions = { ...parsed.options, signal: controller.signal };
 	streamOpts.apiKey = buildGatewayApiKeyResolver(
-		bootOpts.storage,
+		bootOpts,
 		model,
 		sessionId,
-		apiKey,
+		credential,
 		controller.signal,
 		"pi-native",
 		peer,
+		policy,
 	);
 	if (model.api === "openai-codex-responses") {
 		delete streamOpts.temperature;
@@ -624,10 +1307,17 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		delete streamOpts.repetitionPenalty;
 	}
 	// Merge gateway-captured passthrough headers under the client's own
-	// headers — the client's values win when they collide.
-	const captured = captureRequestHeaders(req.headers);
-	streamOpts.headers = { ...captured, ...(streamOpts.headers ?? {}) };
-	streamOpts.sessionId ??= sessionId;
+	// headers. Policy mode strips caller-controlled identity and auth values
+	// from both sources, and the authorized session always wins.
+	const captured = captureRequestHeaders(req.headers, { stripPolicyIdentity: policy !== undefined });
+	const optionHeaders = policy ? stripPolicyIdentityHeaders(streamOpts.headers) : (streamOpts.headers ?? {});
+	streamOpts.headers = { ...captured, ...optionHeaders };
+	if (policy) {
+		streamOpts.sessionId = sessionId;
+		streamOpts.promptCacheKey = sessionId;
+	} else {
+		streamOpts.sessionId ??= sessionId;
+	}
 
 	logger.info("auth-gateway request", {
 		requestId,
@@ -641,12 +1331,29 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	if (!parsed.stream) {
 		try {
-			if (controller.signal.aborted) return aborted();
+			if (controller.signal.aborted) {
+				if (policy) await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+				return aborted();
+			}
 			const message = await completeSimple(model, parsed.context, streamOpts);
 			if (message.stopReason === "aborted" || message.stopReason === "error") {
 				const errorMessage =
 					message.errorMessage ??
 					(message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed");
+				if (policy) {
+					await observePolicyFailure(
+						bootOpts,
+						policy,
+						"upstream",
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "aborted" : "error",
+					);
+					return piNative.formatError(
+						message.stopReason === "aborted" ? 499 : 502,
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed",
+					);
+				}
 				logger.warn("auth-gateway non-streaming failed", {
 					format: "pi-native",
 					reason: message.stopReason,
@@ -659,9 +1366,42 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 				const classified = classifyGatewayError(errorMessage);
 				return piNative.formatError(classified.status, classified.type, errorMessage);
 			}
+			if (policy) {
+				await emitGatewayObservation(bootOpts, {
+					type: "terminal",
+					...policyObservationBase(policy),
+					outcome: "success",
+				});
+			}
 			return json(200, { message }, gatewayResponseHeaders(model, { requestId, message, startedAt }));
 		} catch (error) {
-			if (controller.signal.aborted) return aborted();
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return observerFailureResponse(piNative.formatError);
+			}
+			if (controller.signal.aborted) {
+				if (policy) {
+					try {
+						await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+					} catch (observationError) {
+						if (observationError instanceof AuthGatewayObserverDeliveryError) {
+							return observerFailureResponse(piNative.formatError);
+						}
+						throw observationError;
+					}
+				}
+				return aborted();
+			}
+			if (policy) {
+				try {
+					await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				} catch (observationError) {
+					if (observationError instanceof AuthGatewayObserverDeliveryError) {
+						return observerFailureResponse(piNative.formatError);
+					}
+					throw observationError;
+				}
+				return piNative.formatError(502, "upstream_error", "Upstream request failed");
+			}
 			const classified = classifyGatewayError(error);
 			logger.warn("auth-gateway non-streaming aborted", { format: "pi-native", error: classified.message, peer });
 			return piNative.formatError(classified.status, classified.type, classified.message);
@@ -673,12 +1413,27 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		if (controller.signal.aborted) return aborted();
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(piNative.formatError);
+		}
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw observationError;
+			}
+			return piNative.formatError(502, "upstream_error", "Upstream request failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway streamSimple threw", { format: "pi-native", error: classified.message, peer });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return aborted();
 
+	if (policy) events = withPolicyEventObservations(events, bootOpts, policy);
 	const sseStream = piNative.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
 		onCancel: reason => {
@@ -778,6 +1533,9 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 				// Same shape as the broker's `/v1/usage`, so widget/llm-git speak to either with the
 				// same client struct.
 				if (req.method === "GET" && pathname === "/v1/usage") {
+					if (opts.authorizeRequest) {
+						return withCors(json(403, { error: "route unavailable in gateway policy mode" }), req);
+					}
 					return withCors(await handleUsage(opts.storage, req.signal), req);
 				}
 
@@ -785,6 +1543,9 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 				// pool is producing 401s. Aggregated `/v1/usage` silently drops failed
 				// credentials, so we need a separate endpoint that captures errors.
 				if (req.method === "GET" && pathname === "/v1/credentials/check") {
+					if (opts.authorizeRequest) {
+						return withCors(json(403, { error: "route unavailable in gateway policy mode" }), req);
+					}
 					return withCors(await handleCredentialsCheck(opts.storage, req.signal), req);
 				}
 

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -1522,6 +1522,15 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 			}
 			try {
 				if (req.method === "GET" && pathname === "/healthz") {
+					if (opts.readinessProbe) {
+						try {
+							if (!(await opts.readinessProbe(req.signal))) {
+								return withCors(json(503, { ok: false, version }), req);
+							}
+						} catch {
+							return withCors(json(503, { ok: false, version }), req);
+						}
+					}
 					return withCors(json(200, { ok: true, version }), req);
 				}
 				if (!isAuthorized(req, tokens)) {
@@ -1563,6 +1572,9 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 
 				// Model catalog.
 				if (req.method === "GET" && pathname === "/v1/models") {
+					if (opts.authorizeRequest) {
+						return withCors(json(403, { error: "route unavailable in gateway policy mode" }), req);
+					}
 					return withCors(handleModelsList(opts), req);
 				}
 

--- a/packages/ai/src/auth-gateway/types.ts
+++ b/packages/ai/src/auth-gateway/types.ts
@@ -260,6 +260,8 @@ export interface AuthGatewayServerOptions {
 	authorizeRequest?: AuthGatewayRequestAuthorizer;
 	/** Optional trusted sink for content-free policy observations. Rejection fails the request closed. */
 	observer?: AuthGatewayObserver;
+	/** Optional bounded dependency probe for `/healthz`; false or rejection returns 503. */
+	readinessProbe?: (signal: AbortSignal) => boolean | Promise<boolean>;
 	/** Version surfaced on `/healthz`. */
 	version?: string;
 }

--- a/packages/ai/src/auth-gateway/types.ts
+++ b/packages/ai/src/auth-gateway/types.ts
@@ -23,6 +23,9 @@ import type {
 /** Default bind. Loopback-only — front with reverse proxy for remote access. */
 export const DEFAULT_AUTH_GATEWAY_BIND = "127.0.0.1:4000";
 
+/** Sensitive one-time policy input. Never forwarded upstream, observed, or logged. */
+export const AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER = "x-omp-auth-gateway-authorization";
+
 export type AuthGatewayToolChoice = "auto" | "none" | "required" | { name: string } | { type: "computer" };
 
 export interface AuthGatewayParsedRequestOptions {
@@ -136,11 +139,127 @@ export interface AuthGatewayFormatModule {
 	formatError(status: number, type: string, message: string): Response;
 }
 
+/** Bounded, content-free request metadata handed to a gateway policy hook. */
+export interface AuthGatewayAuthorizationRequest {
+	/** Gateway-generated identity for this HTTP request. */
+	requestId: string;
+	/** Wire route being authorized (for example `openai-chat` or `pi-native`). */
+	format: string;
+	/** Exact model selector parsed from the caller's request. */
+	requestedModelId: string;
+	/** Optional caller-supplied conversation hint. A grant must replace this with its own namespaced session id. */
+	requestedSessionId?: string;
+	method: string;
+	path: string;
+	/**
+	 * Sensitive bounded one-time gateway authorization input from
+	 * {@link AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER}. Never forwarded,
+	 * observed, or logged.
+	 */
+	authorization: string;
+	signal: AbortSignal;
+}
+
+/** A fail-closed policy denial. `reasonCode` is observer metadata and is never reflected to the client. */
+export interface AuthGatewayAuthorizationDenial {
+	authorized: false;
+	reasonCode?: string;
+}
+
+/**
+ * A policy grant binding one request to an exact model, session, and ordered
+ * OAuth credential allowlist. Every field is validated by the gateway before
+ * model resolution or credential access.
+ */
+export interface AuthGatewayAuthorizationGrant {
+	authorized: true;
+	authorizationId: string;
+	requestedModelId: string;
+	resolvedModelId: string;
+	/** Namespaced durable identity, for example `workspace:conversation`. */
+	sessionId: string;
+	/** Durable OAuth credential row ids, in policy preference order. */
+	allowedOAuthCredentialIds: readonly number[];
+}
+
+export type AuthGatewayAuthorizationDecision = AuthGatewayAuthorizationDenial | AuthGatewayAuthorizationGrant;
+
+export type AuthGatewayRequestAuthorizer = (
+	request: AuthGatewayAuthorizationRequest,
+) => AuthGatewayAuthorizationDecision | Promise<AuthGatewayAuthorizationDecision>;
+
+export type AuthGatewayAuthorizationObservation = {
+	type: "authorization";
+	requestId: string;
+	format: string;
+	requestedModelId: string;
+	outcome: "authorized" | "denied" | "error";
+	authorizationId?: string;
+	resolvedModelId?: string;
+	sessionId?: string;
+	reasonCode?: string;
+};
+
+export interface AuthGatewayPolicyObservationBase {
+	requestId: string;
+	format: string;
+	authorizationId: string;
+	requestedModelId: string;
+	resolvedModelId: string;
+	sessionId: string;
+}
+
+export type AuthGatewayCredentialSelectionObservation = AuthGatewayPolicyObservationBase & {
+	type: "credential_selection";
+	credentialId: number;
+	phase: "initial" | "force_refresh";
+};
+
+export type AuthGatewayCredentialRotationObservation = AuthGatewayPolicyObservationBase & {
+	type: "credential_rotation";
+	previousCredentialId: number;
+	credentialId: number;
+	reason: "usage_limit" | "authentication_failure";
+};
+
+export type AuthGatewayErrorObservation = AuthGatewayPolicyObservationBase & {
+	type: "error";
+	stage: "model_resolution" | "credential_selection" | "upstream";
+	code:
+		| "model_unavailable"
+		| "credential_unavailable"
+		| "credential_rotation_unavailable"
+		| "request_aborted"
+		| "upstream_error";
+};
+
+export type AuthGatewayTerminalObservation = AuthGatewayPolicyObservationBase & {
+	type: "terminal";
+	outcome: "success" | "error" | "aborted";
+};
+
+/**
+ * Content-free gateway observation. Events contain durable identities and
+ * outcomes only: never bearer bytes, request prompts, or provider responses.
+ */
+export type AuthGatewayObservation =
+	| AuthGatewayAuthorizationObservation
+	| AuthGatewayCredentialSelectionObservation
+	| AuthGatewayCredentialRotationObservation
+	| AuthGatewayErrorObservation
+	| AuthGatewayTerminalObservation;
+
+export type AuthGatewayObserver = (event: AuthGatewayObservation) => void | Promise<void>;
+
 export interface AuthGatewayServerOptions {
 	/** Listen address. Default `127.0.0.1:4000`. */
 	bind?: string;
 	/** Accept any of these bearer tokens. Empty allows unauthenticated calls. */
-	bearerTokens: string[];
+	bearerTokens: readonly string[];
+	/** Enables fail-closed policy mode for inference routes when supplied. */
+	authorizeRequest?: AuthGatewayRequestAuthorizer;
+	/** Optional trusted sink for content-free policy observations. Rejection fails the request closed. */
+	observer?: AuthGatewayObserver;
 	/** Version surfaced on `/healthz`. */
 	version?: string;
 }

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -820,6 +820,12 @@ type AuthApiKeyOptions = {
 	 * that a peer/broker rotated out from under us is replaced before retrying.
 	 */
 	forceRefresh?: boolean;
+	/** Restrict OAuth ranking, refresh, and fallback to these durable row ids. */
+	allowedOAuthCredentialIds?: ReadonlySet<number>;
+	/** Resolve persisted OAuth even when a local API-key override exists. Strict policy paths only. */
+	ignoreApiKeyOverrides?: boolean;
+	/** Redact token-endpoint text from logs and durable disable causes. Strict policy paths only. */
+	redactOAuthErrors?: boolean;
 };
 type OAuthResolutionResult = { apiKey: string; credential: OAuthCredential; credentialId?: number };
 
@@ -842,6 +848,12 @@ export interface OAuthAccess {
 	/** Organization/workspace the credential is scoped to (Anthropic/ChatGPT multi-subscription). */
 	orgId?: string;
 	orgName?: string;
+}
+
+/** Provider-shaped OAuth authentication plus its durable credential row identity. */
+export interface OAuthApiKeySelection {
+	apiKey: string;
+	credentialId: number;
 }
 
 /**
@@ -3193,7 +3205,11 @@ export class AuthStorage {
 		});
 	}
 
-	async #fetchUsageUncached(request: UsageRequestDescriptor, timeoutMs?: number): Promise<UsageReport | null> {
+	async #fetchUsageUncached(
+		request: UsageRequestDescriptor,
+		timeoutMs?: number,
+		redactOAuthErrors = false,
+	): Promise<UsageReport | null> {
 		const resolver = this.#usageProviderResolver;
 		if (!resolver) return null;
 
@@ -3255,7 +3271,7 @@ export class AuthStorage {
 					// that token and never mutate credential state from this path.
 					this.#usageLogger?.debug("Usage credential refresh failed, using original credential", {
 						provider: request.provider,
-						error: errorMsg,
+						error: redactOAuthErrors ? "oauth_usage_refresh_failed" : errorMsg,
 					});
 				}
 			}
@@ -3266,7 +3282,7 @@ export class AuthStorage {
 		try {
 			const report = await providerImpl.fetchUsage(params, {
 				fetch: this.#usageFetch,
-				logger: this.#usageLogger,
+				logger: redactOAuthErrors ? undefined : this.#usageLogger,
 			});
 			// Attribute the report to the credential's organization. The orgId and
 			// orgName fallbacks apply independently: Claude's usage endpoint stamps
@@ -3297,7 +3313,7 @@ export class AuthStorage {
 			}
 			logger.debug("AuthStorage usage fetch failed", {
 				provider: request.provider,
-				error: String(error),
+				error: redactOAuthErrors ? "usage_fetch_failed" : String(error),
 			});
 			return null;
 		}
@@ -3305,7 +3321,7 @@ export class AuthStorage {
 
 	async #fetchUsageCached(
 		request: UsageRequestDescriptor,
-		options: { timeoutMs?: number; forceRefresh?: boolean } = {},
+		options: { timeoutMs?: number; forceRefresh?: boolean; redactOAuthErrors?: boolean } = {},
 	): Promise<UsageReport | null> {
 		const timeoutMs = options.timeoutMs;
 		const forceRefresh = options.forceRefresh ?? false;
@@ -3318,11 +3334,11 @@ export class AuthStorage {
 		}
 
 		const usageCacheEpoch = this.#usageCacheEpoch;
-		const inFlightKey = `${cacheKey}\0${usageCacheEpoch}`;
+		const inFlightKey = `${cacheKey}\0${usageCacheEpoch}\0${options.redactOAuthErrors ? "redacted" : "diagnostic"}`;
 		const inFlight = this.#usageRequestInFlight.get(inFlightKey);
 		if (inFlight) return inFlight;
 		const promise = (async () => {
-			const report = await this.#fetchUsageUncached(request, timeoutMs);
+			const report = await this.#fetchUsageUncached(request, timeoutMs, options.redactOAuthErrors);
 			if (usageCacheEpoch !== this.#usageCacheEpoch) return report;
 			const ttlJitter = USAGE_REPORT_TTL_MS * (Math.random() * 0.5 - 0.25);
 			if (report !== null) {
@@ -3802,7 +3818,7 @@ export class AuthStorage {
 	async #getUsageReport(
 		provider: Provider,
 		credential: AuthCredential,
-		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal },
+		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal; redactOAuthErrors?: boolean },
 	): Promise<UsageReport | null> {
 		// Store-level hook (e.g. `RemoteAuthCredentialStore`) is authoritative
 		// when present for OAuth: the broker already aggregates usage from a
@@ -3831,6 +3847,7 @@ export class AuthStorage {
 		}
 		return this.#fetchUsageCached(this.#buildUsageRequest(provider, usageCredential, options?.baseUrl), {
 			timeoutMs: options?.timeoutMs ?? this.#usageRequestTimeoutMs,
+			redactOAuthErrors: options?.redactOAuthErrors,
 		});
 	}
 
@@ -4398,16 +4415,19 @@ export class AuthStorage {
 		targetIndex: number,
 		blockedUntil: number,
 		routing: CredentialBlockRouting,
+		allowedCredentialIds?: ReadonlySet<number>,
 	): UsageLimitMarkResult {
 		if (targetIndex >= 0) {
 			this.#markCredentialBlocked(provider, routing.providerKey, targetIndex, blockedUntil, routing.blockScope);
 		}
 
-		const remainingCredentials = this.#getCredentialsForProvider(provider)
-			.map((credential, index) => ({ credential, index }))
+		const remainingCredentials = this.#getStoredCredentials(provider)
+			.map((entry, index) => ({ ...entry, index }))
 			.filter(
-				(entry): entry is { credential: AuthCredential; index: number } =>
-					entry.credential.type === credentialType && entry.index !== targetIndex,
+				entry =>
+					entry.credential.type === credentialType &&
+					entry.index !== targetIndex &&
+					(!allowedCredentialIds || allowedCredentialIds.has(entry.id)),
 			);
 
 		let retryAtMs: number | undefined;
@@ -4443,6 +4463,8 @@ export class AuthStorage {
 			apiKey?: string;
 			credentialId?: number;
 			signal?: AbortSignal;
+			allowedOAuthCredentialIds?: ReadonlySet<number>;
+			redactOAuthErrors?: boolean;
 		},
 	): Promise<UsageLimitMarkResult> {
 		let sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
@@ -4465,6 +4487,9 @@ export class AuthStorage {
 		if (!sessionCredential) return { switched: false };
 		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
 		if (!target || target.credential.type !== sessionCredential.type) return { switched: false };
+		if (options?.allowedOAuthCredentialIds && !options.allowedOAuthCredentialIds.has(target.id)) {
+			return { switched: false };
+		}
 		const credentialType = sessionCredential.type;
 		const targetCredentialId = target.id;
 
@@ -4494,7 +4519,14 @@ export class AuthStorage {
 		const targetIndex = this.#getStoredCredentials(provider).findIndex(
 			entry => entry.id === targetCredentialId && entry.credential.type === credentialType,
 		);
-		return this.#blockCredentialForRotation(provider, credentialType, targetIndex, blockedUntil, routing);
+		return this.#blockCredentialForRotation(
+			provider,
+			credentialType,
+			targetIndex,
+			blockedUntil,
+			routing,
+			options?.allowedOAuthCredentialIds,
+		);
 	}
 
 	#resolveWindowResetAt(window: UsageLimit["window"]): number | undefined {
@@ -4743,9 +4775,27 @@ export class AuthStorage {
 		sessionId?: string,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthResolutionResult | undefined> {
-		const credentials = this.#getCredentialsForProvider(provider)
-			.map((credential, index) => ({ credential, index }))
-			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
+		const stored = this.#getStoredCredentials(provider);
+		const allowedCredentialIds = options?.allowedOAuthCredentialIds;
+		let credentials: OAuthSelection[];
+		if (allowedCredentialIds) {
+			const selectionsById = new Map<number, OAuthSelection>();
+			for (let index = 0; index < stored.length; index++) {
+				const entry = stored[index];
+				if (entry?.credential.type === "oauth") {
+					selectionsById.set(entry.id, { credential: entry.credential, index });
+				}
+			}
+			credentials = [];
+			for (const credentialId of allowedCredentialIds) {
+				const selection = selectionsById.get(credentialId);
+				if (selection) credentials.push(selection);
+			}
+		} else {
+			credentials = stored
+				.map((entry, index) => ({ credential: entry.credential, index }))
+				.filter((entry): entry is OAuthSelection => entry.credential.type === "oauth");
+		}
 
 		if (credentials.length === 0) return undefined;
 
@@ -5106,9 +5156,13 @@ export class AuthStorage {
 		provider: string,
 		selection: { credential: OAuthCredential; index: number },
 		options: AuthApiKeyOptions | undefined,
+		requiredCredentialId?: number,
 	): Promise<boolean> {
 		const stored = this.#getStoredCredentials(provider);
-		const selected = stored[selection.index];
+		const selected =
+			requiredCredentialId === undefined
+				? stored[selection.index]
+				: stored.find(entry => entry.id === requiredCredentialId);
 		if (selected?.credential.type !== "oauth") return false;
 
 		const prepare = this.#store.prepareForRequest?.bind(this.#store);
@@ -5136,6 +5190,8 @@ export class AuthStorage {
 			rankingContext?: CredentialRankingContext;
 			blockScope?: string;
 			blockScopes?: readonly string[];
+			/** Durable row identity required by strict policy-scoped resolution. */
+			requiredCredentialId?: number;
 			/** When false, a definitive failure of THIS credential returns undefined instead of falling back to the ranked/round-robin selector (target-only resolution). */
 			allowFallback?: boolean;
 		},
@@ -5152,7 +5208,11 @@ export class AuthStorage {
 			blockScope,
 			blockScopes,
 			allowFallback = true,
+			requiredCredentialId,
 		} = usageOptions;
+		if (requiredCredentialId !== undefined) {
+			if (!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)) return undefined;
+		}
 		if (
 			!allowBlocked &&
 			this.#isCredentialBlocked(provider, providerKey, selection.index, blockScopes ?? blockScope)
@@ -5160,14 +5220,14 @@ export class AuthStorage {
 			return undefined;
 		}
 
-		if (!(await this.#prepareOAuthCredentialForRequest(provider, selection, options))) {
+		if (!(await this.#prepareOAuthCredentialForRequest(provider, selection, options, requiredCredentialId))) {
 			return undefined;
 		}
 		// Capture the row id once, immediately after #prepareOAuthCredentialForRequest
 		// resynced selection.index from the store. A concurrent disable during the
 		// usage/refresh awaits below can shift positional indices, so every later
 		// refresh / persist / CAS-disable addresses the row by this stable id.
-		const credentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
+		const credentialId = requiredCredentialId ?? this.#getStoredCredentials(provider)[selection.index]?.id;
 
 		const planRequirement = providedPlanRequirement ?? resolveOpenAICodexPlanRequirement(provider, options?.modelId);
 		const hasPlanRequirement = planRequirement !== "none";
@@ -5185,6 +5245,12 @@ export class AuthStorage {
 					timeoutMs: this.#usageRequestTimeoutMs,
 				});
 				usageChecked = true;
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 			}
 			if (applyPlanFilter && getOpenAICodexPlanEligibility(usage, planRequirement) !== true) {
 				return undefined;
@@ -5207,14 +5273,24 @@ export class AuthStorage {
 
 		try {
 			let result: { newCredentials: OAuthCredentials; apiKey: string } | null;
+			const refreshTarget =
+				options?.forceRefresh && requiredCredentialId !== undefined
+					? { ...selection.credential, expires: 0 }
+					: selection.credential;
 			const customProvider = getOAuthProvider(provider);
 			if (customProvider) {
 				const refreshedCredentials = await this.#refreshOAuthCredential(
 					provider,
-					selection.credential,
+					refreshTarget,
 					credentialId,
 					options?.signal,
 				);
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 				const apiKey = customProvider.getApiKey
 					? customProvider.getApiKey(refreshedCredentials)
 					: refreshedCredentials.access;
@@ -5227,14 +5303,26 @@ export class AuthStorage {
 				// auth failure and soft-disable a still-valid credential.
 				const refreshedCredentials = await this.#refreshOAuthCredential(
 					provider,
-					selection.credential,
+					refreshTarget,
 					credentialId,
 					options?.signal,
 				);
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 				const oauthCreds: Record<string, OAuthCredentials> = {
 					[provider]: refreshedCredentials,
 				};
 				result = await getOAuthApiKey(provider as OAuthProvider, oauthCreds);
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 			}
 			if (!result) return undefined;
 			const updated: OAuthCredential = {
@@ -5254,6 +5342,7 @@ export class AuthStorage {
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);
 				if (idx !== -1) selection.index = idx;
+				if (requiredCredentialId !== undefined && idx === -1) return undefined;
 			} else {
 				this.#replaceCredentialAt(provider, selection.index, updated);
 			}
@@ -5265,6 +5354,12 @@ export class AuthStorage {
 						timeoutMs: this.#usageRequestTimeoutMs,
 					});
 					usageChecked = true;
+					if (
+						requiredCredentialId !== undefined &&
+						!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+					) {
+						return undefined;
+					}
 				}
 				if (applyPlanFilter && getOpenAICodexPlanEligibility(usage, planRequirement) !== true) {
 					return undefined;
@@ -5284,6 +5379,12 @@ export class AuthStorage {
 					}
 				}
 			}
+			if (
+				requiredCredentialId !== undefined &&
+				!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+			) {
+				return undefined;
+			}
 			this.#recordOAuthBearerCredentialId(provider, result.apiKey, credentialId);
 			this.#recordSessionCredential(provider, sessionId, "oauth", selection.index);
 			return { apiKey: result.apiKey, credential: updated, credentialId };
@@ -5292,11 +5393,16 @@ export class AuthStorage {
 			// Only remove credentials for definitive auth failures
 			// Keep credentials for transient errors (network, 5xx) and block temporarily
 			const isDefinitiveFailure = AIError.isDefinitiveOAuthFailure(errorMsg);
+			const diagnosticError = options?.redactOAuthErrors
+				? isDefinitiveFailure
+					? "oauth_authorization_failed"
+					: "oauth_refresh_failed"
+				: errorMsg;
 
 			logger.warn("OAuth token refresh failed", {
 				provider,
 				index: selection.index,
-				error: errorMsg,
+				error: diagnosticError,
 				isDefinitiveFailure,
 			});
 
@@ -5319,6 +5425,7 @@ export class AuthStorage {
 						});
 						await this.reload();
 						if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
+						if (requiredCredentialId !== undefined) return undefined;
 					}
 				}
 				// Permanently disable invalid credentials with an explicit cause for inspection/debugging.
@@ -5331,13 +5438,13 @@ export class AuthStorage {
 								provider,
 								credentialId,
 								selection.credential,
-								`oauth refresh failed: ${errorMsg}`,
+								options?.redactOAuthErrors ? "oauth authorization failed" : `oauth refresh failed: ${errorMsg}`,
 							)
 						: this.#tryDisableCredentialAtIfMatches(
 								provider,
 								selection.index,
 								selection.credential,
-								`oauth refresh failed: ${errorMsg}`,
+								options?.redactOAuthErrors ? "oauth authorization failed" : `oauth refresh failed: ${errorMsg}`,
 							);
 				if (!disabled) {
 					logger.debug("OAuth refresh disable lost CAS; reloading after peer rotation", {
@@ -5346,12 +5453,19 @@ export class AuthStorage {
 					});
 					await this.reload();
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
+					if (requiredCredentialId !== undefined) return undefined;
 				}
 				if (this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")) {
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
 			} else {
 				// Block temporarily for transient failures (5 minutes)
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 				this.#markCredentialBlocked(provider, providerKey, selection.index, Date.now() + 5 * 60 * 1000);
 			}
 		}
@@ -5530,13 +5644,96 @@ export class AuthStorage {
 			.filter((entry): entry is StoredOAuthSelection => entry.credential.type === "oauth");
 	}
 
+	async #resolveStoredOAuthApiKey(
+		provider: string,
+		selection: StoredOAuthSelection,
+		sessionId: string | undefined,
+		options: AuthApiKeyOptions | undefined,
+		allowBlocked: boolean,
+	): Promise<OAuthApiKeySelection | undefined> {
+		const resolved = await this.#tryOAuthCredential(
+			provider,
+			{ credential: selection.credential, index: selection.index },
+			this.#getProviderTypeKey(provider, "oauth"),
+			sessionId,
+			options,
+			{
+				checkUsage: false,
+				planRequirement: "none",
+				enforcePlanRequirement: false,
+				allowBlocked,
+				allowFallback: false,
+				requiredCredentialId: selection.credentialId,
+			},
+		);
+		if (!resolved?.credentialId) return undefined;
+		return { apiKey: resolved.apiKey, credentialId: resolved.credentialId };
+	}
+
+	/**
+	 * Resolve provider-shaped OAuth authentication in exact allowlist order.
+	 * Unblocked rows are tried first; if every authorized row is blocked, the
+	 * same insertion order is retried without consulting any outside row or
+	 * static-key source.
+	 */
+	async getOAuthApiKeyFromCredentialIds(
+		provider: string,
+		sessionId: string,
+		allowedCredentialIds: ReadonlySet<number>,
+		options?: AuthApiKeyOptions,
+	): Promise<OAuthApiKeySelection | undefined> {
+		const orderedIds: number[] = [];
+		for (const credentialId of allowedCredentialIds) {
+			if (!Number.isSafeInteger(credentialId) || credentialId <= 0) return undefined;
+			orderedIds.push(credentialId);
+		}
+		if (orderedIds.length === 0) return undefined;
+		for (const allowBlocked of [false, true]) {
+			for (const credentialId of orderedIds) {
+				const selection = this.#getStoredOAuthSelections(provider).find(
+					candidate => candidate.credentialId === credentialId,
+				);
+				if (!selection) continue;
+				const resolved = await this.#resolveStoredOAuthApiKey(
+					provider,
+					selection,
+					sessionId,
+					{ ...options, ignoreApiKeyOverrides: true, redactOAuthErrors: true },
+					allowBlocked,
+				);
+				if (resolved) return resolved;
+			}
+		}
+		return undefined;
+	}
+
+	/** Force/resolve one exact OAuth row as provider-shaped authentication, without fallback. */
+	async getOAuthApiKeyByCredentialId(
+		provider: string,
+		credentialId: number,
+		options?: AuthApiKeyOptions,
+	): Promise<OAuthApiKeySelection | undefined> {
+		if (!Number.isSafeInteger(credentialId) || credentialId <= 0) return undefined;
+		const selection = this.#getStoredOAuthSelections(provider).find(
+			candidate => candidate.credentialId === credentialId,
+		);
+		if (!selection) return undefined;
+		return this.#resolveStoredOAuthApiKey(
+			provider,
+			selection,
+			undefined,
+			{ ...options, ignoreApiKeyOverrides: true, redactOAuthErrors: true },
+			true,
+		);
+	}
+
 	/** Refresh one stored OAuth selection and shape it as an {@link OAuthAccessResolution}. */
 	async #resolveStoredOAuthAccess(
 		provider: string,
 		selection: StoredOAuthSelection,
 		providerKey: string,
 		options: AuthApiKeyOptions | undefined,
-	): Promise<OAuthAccessResolution> {
+	): Promise<OAuthAccessResolution & { credentialId: number }> {
 		try {
 			const resolved = await this.#tryOAuthCredential(
 				provider,
@@ -5700,15 +5897,19 @@ export class AuthStorage {
 	 * requested row, preserving exact-account affinity for operations whose
 	 * provenance and policy boundary are tied to one workspace.
 	 *
-	 * Returns `undefined` when the row does not exist for `provider` or an
-	 * explicit runtime/config API-key override suppresses OAuth.
+	 * Returns `undefined` when the row does not exist for `provider`. Runtime
+	 * and config overrides suppress OAuth unless `options.ignoreApiKeyOverrides`
+	 * is set by a strict OAuth-only caller.
 	 */
 	async getOAuthAccessByCredentialId(
 		provider: string,
 		credentialId: number,
 		options?: AuthApiKeyOptions,
-	): Promise<OAuthAccessResolution | undefined> {
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+	): Promise<(OAuthAccessResolution & { credentialId: number }) | undefined> {
+		if (
+			!options?.ignoreApiKeyOverrides &&
+			(this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider))
+		) {
 			return undefined;
 		}
 		const selection = this.#getStoredOAuthSelections(provider).find(
@@ -6216,7 +6417,15 @@ export class AuthStorage {
 	async rotateSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { error?: unknown; modelId?: string; apiKey?: string; credentialId?: number; signal?: AbortSignal },
+		options?: {
+			error?: unknown;
+			modelId?: string;
+			apiKey?: string;
+			credentialId?: number;
+			signal?: AbortSignal;
+			allowedOAuthCredentialIds?: ReadonlySet<number>;
+			redactOAuthErrors?: boolean;
+		},
 	): Promise<boolean> {
 		const error = options?.error;
 		const status = AIError.status(error);
@@ -6233,6 +6442,8 @@ export class AuthStorage {
 					apiKey: options?.apiKey,
 					credentialId: options?.credentialId,
 					signal: options?.signal,
+					allowedOAuthCredentialIds: options?.allowedOAuthCredentialIds,
+					redactOAuthErrors: options?.redactOAuthErrors,
 				})
 			).switched;
 		}
@@ -6242,6 +6453,10 @@ export class AuthStorage {
 			apiKey: options?.apiKey,
 		});
 		if (!sessionCredential) return false;
+		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
+		if (options?.allowedOAuthCredentialIds && (!target || !options.allowedOAuthCredentialIds.has(target.id))) {
+			return false;
+		}
 
 		if (AIError.isAccountPolicyError(error)) {
 			const routing = this.#credentialBlockRouting(provider, sessionCredential.type, options?.modelId);
@@ -6251,19 +6466,21 @@ export class AuthStorage {
 				sessionCredential.index,
 				Date.now() + AuthStorage.#defaultBackoffMs,
 				routing,
+				options?.allowedOAuthCredentialIds,
 			).switched;
 		}
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);
 		// Snapshot sibling availability before mutating so a soft-deleting
 		// suspect hook can't reindex the answer out from under us.
-		const hasSibling = this.#getCredentialsForProvider(provider).some(
-			(credential, index) =>
-				credential.type === sessionCredential.type &&
+		const hasSibling = this.#getStoredCredentials(provider).some(
+			(entry, index) =>
+				entry.credential.type === sessionCredential.type &&
 				index !== sessionCredential.index &&
+				(!options?.allowedOAuthCredentialIds || options.allowedOAuthCredentialIds.has(entry.id)) &&
 				!this.#isCredentialBlocked(provider, providerKey, index),
 		);
-		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
+
 		const sticky = this.#getSessionCredential(provider, sessionId);
 		if (
 			!sessionCredential.explicit ||

--- a/packages/ai/test/auth-gateway-policy.test.ts
+++ b/packages/ai/test/auth-gateway-policy.test.ts
@@ -1,0 +1,625 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import {
+	AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER,
+	type AuthGatewayAuthorizationDecision,
+	type AuthGatewayAuthorizationRequest,
+	type AuthGatewayObservation,
+	startAuthGateway,
+} from "@oh-my-pi/pi-ai/auth-gateway";
+import { AuthStorage, type AuthStorageOptions, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { logger } from "@oh-my-pi/pi-utils";
+
+interface PolicyStorageFixture {
+	dir: string;
+	storage: AuthStorage;
+	credentialIds: number[];
+	oauthSource?: string;
+}
+
+function oauthCredential(access: string) {
+	return {
+		type: "oauth" as const,
+		access,
+		refresh: `${access}-refresh`,
+		expires: Date.now() + 60 * 60_000,
+	};
+}
+async function createPolicyStorage(
+	name: string,
+	accesses: readonly string[],
+	provider = "mock",
+	refreshAccess?: (access: string) => string,
+	options?: AuthStorageOptions,
+): Promise<PolicyStorageFixture> {
+	const oauthSource = provider === "mock" ? `auth-gateway-policy-${name}` : undefined;
+	if (oauthSource) {
+		registerOAuthProvider({
+			id: provider,
+			name: "Auth Gateway Policy Test",
+			sourceId: oauthSource,
+			async login() {
+				return { access: "login", refresh: "login-refresh", expires: Date.now() + 60 * 60_000 };
+			},
+			async refreshToken(credentials) {
+				return {
+					...credentials,
+					access: refreshAccess?.(credentials.access) ?? credentials.access,
+					expires: Date.now() + 60 * 60_000,
+				};
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+	}
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), `${name}-`));
+	const store = await SqliteAuthCredentialStore.open(path.join(dir, "auth.db"));
+	const storage = new AuthStorage(store, options);
+	await storage.set(provider, accesses.map(oauthCredential));
+	const credentialIds = store.listAuthCredentials(provider).map(row => row.id);
+	return { dir, storage, credentialIds, oauthSource };
+}
+
+async function closePolicyStorage(fixture: PolicyStorageFixture): Promise<void> {
+	if (fixture.oauthSource) unregisterOAuthProviders(fixture.oauthSource);
+	fixture.storage.close();
+	await fs.rm(fixture.dir, { recursive: true, force: true });
+}
+
+function policyGrant(
+	request: AuthGatewayAuthorizationRequest,
+	resolvedModelId: string,
+	sessionId: string,
+	allowedOAuthCredentialIds: readonly number[],
+) {
+	return {
+		authorized: true as const,
+		authorizationId: `authorization:${request.requestId}`,
+		requestedModelId: request.requestedModelId,
+		resolvedModelId,
+		sessionId,
+		allowedOAuthCredentialIds,
+	};
+}
+
+async function postOpenAIChat(url: string, model: string, extra?: Record<string, unknown>): Promise<Response> {
+	return fetch(`${url}/v1/chat/completions`, {
+		method: "POST",
+		headers: {
+			Authorization: "Bearer gateway-token",
+			[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+			"X-Client-Id": "caller-client",
+			"X-Workspace-Id": "caller-workspace",
+			"X-Stainless-Lang": "typescript",
+			"Content-Type": "application/json",
+			"OpenAI-Organization": "caller-org",
+			"OpenAI-Project": "caller-project",
+			"ChatGPT-Account-Id": "caller-account",
+			Session_Id: "caller-header-session",
+			"OpenAI-Beta": "responses=v1",
+		},
+		body: JSON.stringify({
+			model,
+			messages: [{ role: "user", content: "raw-policy-prompt" }],
+			stream: false,
+			prompt_cache_key: "caller-body-session",
+			metadata: { account_id: "caller-metadata-account" },
+			user: "caller-user",
+			...extra,
+		}),
+	});
+}
+
+describe("auth-gateway policy hooks", () => {
+	it("authorizes a provider-format request before model and credential access, then strips caller identity", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-order", ["oauth-a", "oauth-b"]);
+		fixture.storage.setRuntimeApiKey("mock", "runtime-key-must-not-win");
+		const allowedId = fixture.credentialIds[1]!;
+		const order: string[] = [];
+		const observations: AuthGatewayObservation[] = [];
+		let authorizationRequest: AuthGatewayAuthorizationRequest | undefined;
+		const originalAccess = fixture.storage.getOAuthApiKeyFromCredentialIds.bind(fixture.storage);
+		const accessSpy = spyOn(fixture.storage, "getOAuthApiKeyFromCredentialIds").mockImplementation(
+			async (provider, sessionId, allowedCredentialIds, options) => {
+				order.push("credential");
+				return originalAccess(provider, sessionId, allowedCredentialIds, options);
+			},
+		);
+		const mock = createMockModel({
+			provider: "mock",
+			id: "resolved-model",
+			handler: () => {
+				order.push("upstream");
+				return { content: ["ok"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request => {
+				order.push("authorize");
+				authorizationRequest = request;
+				return policyGrant(request, "resolved-model", "workspace:authorized-session", [allowedId]);
+			},
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: selector => {
+				order.push("model");
+				return selector === "resolved-model" ? mock : undefined;
+			},
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "caller-model");
+			expect(response.status).toBe(200);
+			expect(order).toEqual(["authorize", "model", "credential", "upstream"]);
+			expect(authorizationRequest?.requestedModelId).toBe("caller-model");
+			expect(authorizationRequest?.authorization).toBe("policy-input");
+			expect(authorizationRequest?.requestedSessionId).toBe("caller-body-session");
+			expect(mock.calls).toHaveLength(1);
+			const options = mock.calls[0]!.options;
+			expect(options?.apiKey).toBe("oauth-b");
+			expect(options?.sessionId).toBe("workspace:authorized-session");
+			expect(options?.promptCacheKey).toBe("workspace:authorized-session");
+			expect(options?.metadata).toBeUndefined();
+			expect(options?.headers).toEqual({ "openai-beta": "responses=v1" });
+			expect(observations.map(event => event.type)).toEqual(["authorization", "credential_selection", "terminal"]);
+			const serializedObservations = JSON.stringify(observations);
+			expect(serializedObservations).not.toContain("oauth-a");
+			expect(serializedObservations).not.toContain("oauth-b");
+			expect(serializedObservations).not.toContain("raw-policy-prompt");
+		} finally {
+			accessSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("preserves provider-shaped OAuth authentication and policy grant insertion order", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage(
+			"gw-policy-structured-oauth",
+			["structured-a", "structured-b"],
+			"github-copilot",
+		);
+		fixture.storage.setRuntimeApiKey("github-copilot", "outside-static-key");
+		let selectedToken: string | undefined;
+		const mock = createMockModel({
+			provider: "github-copilot",
+			id: "structured-model",
+			handler: (_context, options) => {
+				const structured = JSON.parse(String(options?.apiKey)) as { token?: unknown };
+				selectedToken = typeof structured.token === "string" ? structured.token : undefined;
+				return { content: ["ok"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "structured-model", "workspace:structured", [
+					fixture.credentialIds[1]!,
+					fixture.credentialIds[0]!,
+				]),
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "structured-alias");
+			expect(response.status).toBe(200);
+			expect(selectedToken).toBe("structured-b");
+			expect(mock.calls[0]!.options?.apiKey).not.toBe("outside-static-key");
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("rejects denied and malformed policy decisions without model or credential access", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-denial", ["oauth-a"]);
+		const accessSpy = spyOn(fixture.storage, "getOAuthApiKeyFromCredentialIds");
+		let modelResolutions = 0;
+		let authorizerCalls = 0;
+		const observations: AuthGatewayObservation[] = [];
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request => {
+				authorizerCalls++;
+				if (request.requestedModelId === "denied-model") {
+					return { authorized: false, reasonCode: "account_not_allowed" };
+				}
+				return {
+					authorized: true,
+					authorizationId: "authorization:malformed",
+					requestedModelId: request.requestedModelId,
+					resolvedModelId: "resolved-model",
+					sessionId: "workspace:malformed",
+					allowedOAuthCredentialIds: [],
+				} as AuthGatewayAuthorizationDecision;
+			},
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: () => {
+				modelResolutions++;
+				return undefined;
+			},
+		});
+		try {
+			const missingPolicyInput = await fetch(`${handle.url}/v1/chat/completions`, {
+				method: "POST",
+				headers: { Authorization: "Bearer gateway-token", "Content-Type": "application/json" },
+				body: JSON.stringify({
+					model: "missing-policy-input",
+					messages: [{ role: "user", content: "must not authorize" }],
+					stream: false,
+				}),
+			});
+			const denied = await postOpenAIChat(handle.url, "denied-model");
+			const malformed = await postOpenAIChat(handle.url, "malformed-model");
+			expect(missingPolicyInput.status).toBe(401);
+			expect(authorizerCalls).toBe(2);
+			expect(denied.status).toBe(403);
+			expect(malformed.status).toBe(500);
+			expect(modelResolutions).toBe(0);
+			expect(accessSpy).toHaveBeenCalledTimes(0);
+			expect(observations.map(event => (event.type === "authorization" ? event.outcome : event.type))).toEqual([
+				"denied",
+				"error",
+			]);
+			expect(await denied.text()).not.toContain("account_not_allowed");
+		} finally {
+			accessSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("keeps usage-limit rotation inside the authorized OAuth row set", async () => {
+		registerMockApi();
+		const privateUsageError = "private token-endpoint response";
+		const fixture = await createPolicyStorage(
+			"gw-policy-rotation",
+			["oauth-a", "oauth-b", "oauth-outside"],
+			"mock",
+			undefined,
+			{
+				usageProviderResolver: provider =>
+					provider === "mock"
+						? {
+								id: "mock",
+								async fetchUsage(_params, context) {
+									context.logger?.warn("private usage provider diagnostic", {
+										error: privateUsageError,
+									});
+									throw new Error(privateUsageError);
+								},
+							}
+						: undefined,
+				rankingStrategyResolver: provider =>
+					provider === "mock"
+						? {
+								findWindowLimits() {
+									return {};
+								},
+								windowDefaults: { primaryMs: 60_000, secondaryMs: 60_000 },
+							}
+						: undefined,
+			},
+		);
+		const debugSpy = spyOn(logger, "debug");
+		const allowedIds = fixture.credentialIds.slice(0, 2);
+		const observations: AuthGatewayObservation[] = [];
+		let attempts = 0;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "rotation-model",
+			handler: () => {
+				attempts++;
+				if (attempts === 1) {
+					throw new ProviderHttpError("quota reached", 429, { code: "insufficient_quota" });
+				}
+				return { content: ["ok"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request => policyGrant(request, "rotation-model", "workspace:rotation", allowedIds),
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "rotation-alias");
+			expect(response.status).toBe(200);
+			const attemptedKeys = mock.calls.map(call => call.options?.apiKey);
+			expect(attemptedKeys).toHaveLength(2);
+			expect(new Set(attemptedKeys).size).toBe(2);
+			for (const key of attemptedKeys) {
+				if (typeof key !== "string") throw new Error("expected OAuth API key");
+				expect(["oauth-a", "oauth-b"]).toContain(key);
+			}
+			expect(attemptedKeys).not.toContain("oauth-outside");
+			const rotation = observations.find(event => event.type === "credential_rotation");
+			expect(rotation?.type).toBe("credential_rotation");
+			if (rotation?.type !== "credential_rotation") throw new Error("expected credential rotation observation");
+			expect(allowedIds).toContain(rotation.previousCredentialId);
+			expect(allowedIds).toContain(rotation.credentialId);
+			expect(JSON.stringify(observations)).not.toContain("oauth-outside");
+			const diagnostics = JSON.stringify(debugSpy.mock.calls);
+			expect(diagnostics).toContain("usage_fetch_failed");
+			expect(diagnostics).not.toContain(privateUsageError);
+		} finally {
+			debugSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+	it("force-refreshes the same authorized OAuth row before rotating after an authentication failure", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage(
+			"gw-policy-force-refresh",
+			["fresh-but-stale", "authorized-sibling"],
+			"mock",
+			access => `${access}-reminted`,
+		);
+		const observations: AuthGatewayObservation[] = [];
+		let attempts = 0;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "force-refresh-model",
+			handler: (_context, options) => {
+				attempts++;
+				if (attempts === 1) throw new ProviderHttpError("invalid credential", 401);
+				return { content: [String(options?.apiKey)] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "force-refresh-model", "workspace:force-refresh", fixture.credentialIds),
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "force-refresh-alias");
+			expect(response.status).toBe(200);
+			expect(mock.calls.map(call => call.options?.apiKey)).toEqual(["fresh-but-stale", "fresh-but-stale-reminted"]);
+			expect(
+				observations.some(event => event.type === "credential_selection" && event.phase === "force_refresh"),
+			).toBe(true);
+			expect(observations.some(event => event.type === "credential_rotation")).toBe(false);
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("withholds the streaming terminal frame when the terminal observer fails", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-stream-observer", ["oauth-a"]);
+		const mock = createMockModel({
+			provider: "mock",
+			id: "stream-observer-model",
+			handler: () => ({ content: ["visible output"] }),
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "stream-observer-model", "workspace:stream-observer", [fixture.credentialIds[0]!]),
+			observer: event => {
+				if (event.type === "terminal") throw new Error("terminal-observer-private-failure");
+			},
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "stream-observer-alias", { stream: true });
+			expect(response.status).toBe(200);
+			const reader = response.body!.getReader();
+			const decoder = new TextDecoder();
+			let received = "";
+			for (;;) {
+				const chunk = await reader.read();
+				if (chunk.done) break;
+				received += decoder.decode(chunk.value, { stream: true });
+			}
+			received += decoder.decode();
+			expect(received).not.toContain("[DONE]");
+			expect(received).not.toContain("terminal-observer-private-failure");
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("strips pi-native overrides, refuses out-of-set policy selection, and preserves legacy resolution", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-pi", ["oauth-policy"]);
+		fixture.storage.setRuntimeApiKey("mock", "legacy-runtime-key");
+		const allowedId = fixture.credentialIds[0]!;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "pi-resolved",
+			responses: [{ content: ["policy"] }, { content: ["legacy"] }],
+		});
+		const policyHandle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(
+					request,
+					"pi-resolved",
+					"workspace:pi-authorized",
+					request.requestedModelId === "pi-missing" ? [999_999] : [allowedId],
+				),
+			resolveModel: () => mock,
+		});
+		try {
+			const policyResponse = await fetch(`${policyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer gateway-token",
+					"Content-Type": "application/json",
+					[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+				},
+				body: JSON.stringify({
+					modelId: "pi-policy",
+					context: { messages: [{ role: "user", content: "pi raw prompt", timestamp: 1 }] },
+					stream: false,
+					options: {
+						sessionId: "caller-session",
+						promptCacheKey: "caller-cache-key",
+						metadata: { project: "caller-project" },
+						initiatorOverride: "caller-provider-identity",
+						openrouterVariant: "caller-provider-route",
+						statefulResponses: true,
+						headers: {
+							Authorization: "caller-upstream-token",
+							"chatgpt-account-id": "caller-account",
+							"openai-project": "caller-project",
+							session_id: "caller-header-session",
+							"openai-beta": "responses=v1",
+							"x-client-id": "caller-client",
+							"x-user-id": "caller-user",
+							"x-tenant-id": "caller-tenant",
+							"x-workspace-id": "caller-workspace",
+							"x-device-id": "caller-device",
+							apikey: "caller-api-key",
+							"x-auth": "caller-auth",
+							"x-client-secret": "caller-secret",
+						},
+					},
+				}),
+			});
+			expect(policyResponse.status).toBe(200);
+			const policyOptions = mock.calls[0]!.options;
+			expect(policyOptions?.apiKey).toBe("oauth-policy");
+			expect(policyOptions?.sessionId).toBe("workspace:pi-authorized");
+			expect(policyOptions?.promptCacheKey).toBe("workspace:pi-authorized");
+			expect(policyOptions?.metadata).toBeUndefined();
+			expect(policyOptions?.initiatorOverride).toBeUndefined();
+			expect(policyOptions?.openrouterVariant).toBeUndefined();
+			expect(policyOptions?.statefulResponses).toBeUndefined();
+			expect(policyOptions?.headers).toEqual({ "openai-beta": "responses=v1" });
+
+			const missingResponse = await fetch(`${policyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer gateway-token",
+					"Content-Type": "application/json",
+					[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+				},
+				body: JSON.stringify({
+					modelId: "pi-missing",
+					context: { messages: [{ role: "user", content: "must not run", timestamp: 2 }] },
+					stream: false,
+				}),
+			});
+			expect(missingResponse.status).toBe(401);
+			expect(mock.calls).toHaveLength(1);
+		} finally {
+			await policyHandle.close();
+		}
+
+		const legacyHandle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			resolveModel: () => mock,
+		});
+		try {
+			const legacyResponse = await fetch(`${legacyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: { Authorization: "Bearer gateway-token", "Content-Type": "application/json" },
+				body: JSON.stringify({
+					modelId: "pi-legacy",
+					context: { messages: [{ role: "user", content: "legacy", timestamp: 3 }] },
+					stream: false,
+					options: { sessionId: "caller-legacy-session" },
+				}),
+			});
+			expect(legacyResponse.status).toBe(200);
+			expect(mock.calls[1]!.options?.apiKey).toBe("legacy-runtime-key");
+			expect(mock.calls[1]!.options?.sessionId).toBe("caller-legacy-session");
+		} finally {
+			await legacyHandle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("fails closed before model or credential access when the observer rejects authorization", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-observer", ["oauth-a"]);
+		const accessSpy = spyOn(fixture.storage, "getOAuthApiKeyFromCredentialIds");
+		let modelResolutions = 0;
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "pi-resolved", "workspace:observer", [fixture.credentialIds[0]!]),
+			observer: () => {
+				throw new Error("observer-private-failure");
+			},
+			resolveModel: () => {
+				modelResolutions++;
+				return undefined;
+			},
+		});
+		try {
+			const response = await fetch(`${handle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer gateway-token",
+					"Content-Type": "application/json",
+					[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+				},
+				body: JSON.stringify({
+					modelId: "pi-observer",
+					context: { messages: [{ role: "user", content: "must stay private", timestamp: 1 }] },
+					stream: false,
+				}),
+			});
+			const responseText = await response.text();
+			expect(response.status).toBe(503);
+			expect(responseText).not.toContain("observer-private-failure");
+			expect(responseText).not.toContain("must stay private");
+			expect(modelResolutions).toBe(0);
+			expect(accessSpy).toHaveBeenCalledTimes(0);
+		} finally {
+			accessSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added a trusted runtime backend seam for explicit, fail-closed remote structured-subagent execution without local-process fallback.
+- Added an explicit fail-closed Unix policy-socket mode to `auth-gateway serve`, with bounded authorization, observation acknowledgement, and readiness exchanges.
+- Added trusted, fail-closed remote agent-registry and peer-transport seams with generation-bound identities, controller-routed cancellation, and unchanged local hub delivery.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a trusted runtime backend seam for explicit, fail-closed remote structured-subagent execution without local-process fallback.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -14,6 +14,7 @@
  */
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as path from "node:path";
 import {
 	type Api,
@@ -30,7 +31,13 @@ import {
 	RemoteAuthCredentialStore,
 	type SnapshotResponse,
 } from "@oh-my-pi/pi-ai/auth-broker";
-import { DEFAULT_AUTH_GATEWAY_BIND, startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
+import {
+	type AuthGatewayAuthorizationDecision,
+	type AuthGatewayAuthorizationRequest,
+	type AuthGatewayObservation,
+	DEFAULT_AUTH_GATEWAY_BIND,
+	startAuthGateway,
+} from "@oh-my-pi/pi-ai/auth-gateway";
 import { type GeneratedProvider, getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { getConfigRootDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -44,6 +51,7 @@ export interface AuthGatewayCommandArgs {
 	flags: {
 		json?: boolean;
 		bind?: string;
+		policySocket?: string;
 		regenerate?: boolean;
 		/**
 		 * Disable bearer-token auth on inbound requests. Useful when the gateway
@@ -63,6 +71,289 @@ export interface AuthGatewayCommandArgs {
 }
 
 const ACTIONS: readonly AuthGatewayAction[] = ["serve", "token", "status", "check"];
+
+const AUTH_GATEWAY_POLICY_PROTOCOL_VERSION = 1;
+const DEFAULT_POLICY_SOCKET_TIMEOUT_MS = 2_000;
+const DEFAULT_POLICY_SOCKET_MAX_FRAME_BYTES = 64 * 1024;
+const MAX_POLICY_SOCKET_TIMEOUT_MS = 30_000;
+const MAX_POLICY_SOCKET_FRAME_BYTES = 1024 * 1024;
+
+interface AuthGatewayPolicySocketClientOptions {
+	timeoutMs?: number;
+	maxFrameBytes?: number;
+}
+
+export interface AuthGatewayPolicySocketClient {
+	authorizeRequest(request: AuthGatewayAuthorizationRequest): Promise<AuthGatewayAuthorizationDecision>;
+	observe(observation: AuthGatewayObservation): Promise<void>;
+	probe(signal?: AbortSignal): Promise<boolean>;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+	value: unknown,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): value is Record<string, unknown> {
+	if (!isJsonObject(value)) return false;
+	const allowed = new Set([...required, ...optional]);
+	const keys = Object.keys(value);
+	if (keys.length < required.length || keys.length > allowed.size) return false;
+	for (const key of required) {
+		if (!Object.hasOwn(value, key)) return false;
+	}
+	for (const key of keys) {
+		if (!allowed.has(key)) return false;
+	}
+	return true;
+}
+
+function parsePolicyDecision(value: unknown): AuthGatewayAuthorizationDecision {
+	if (hasExactKeys(value, ["authorized"], ["reasonCode"]) && value.authorized === false) {
+		return value as unknown as AuthGatewayAuthorizationDecision;
+	}
+	if (
+		hasExactKeys(value, [
+			"authorized",
+			"authorizationId",
+			"requestedModelId",
+			"resolvedModelId",
+			"sessionId",
+			"allowedOAuthCredentialIds",
+		]) &&
+		value.authorized === true
+	) {
+		return value as unknown as AuthGatewayAuthorizationDecision;
+	}
+	throw new Error("Gateway policy socket returned an invalid authorization decision");
+}
+
+function validatePositiveBoundedInteger(value: number, maximum: number, name: string): void {
+	if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+		throw new Error(`${name} must be a positive integer no greater than ${maximum}`);
+	}
+}
+
+export function validateAuthGatewayPolicySocketPath(socketPath: string): void {
+	if (socketPath.length === 0 || socketPath.includes("\0") || !path.isAbsolute(socketPath)) {
+		throw new Error("--policy-socket must be a non-empty absolute path without NUL bytes");
+	}
+	if (process.platform === "win32") {
+		throw new Error("--policy-socket is only supported on Unix platforms");
+	}
+}
+
+function exchangePolicySocketFrame(
+	socketPath: string,
+	request: Record<string, unknown>,
+	timeoutMs: number,
+	maxFrameBytes: number,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	if (signal?.aborted) throw new Error("Gateway policy socket exchange aborted");
+	const encoded = Buffer.from(`${JSON.stringify(request)}\n`, "utf8");
+	if (encoded.byteLength - 1 > maxFrameBytes) {
+		throw new Error("Gateway policy socket request exceeds the frame limit");
+	}
+
+	return new Promise<unknown>((resolve, reject) => {
+		const socket = new net.Socket();
+		const chunks: Buffer[] = [];
+		let payloadBytes = 0;
+		let settled = false;
+		const timer = setTimeout(() => {
+			fail(new Error("Gateway policy socket exchange timed out"));
+		}, timeoutMs);
+
+		const cleanup = (): void => {
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			socket.destroy();
+		};
+		const succeed = (value: unknown): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(value);
+		};
+		const fail = (error: Error): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(error);
+		};
+		const onAbort = (): void => {
+			fail(new Error("Gateway policy socket exchange aborted"));
+		};
+
+		signal?.addEventListener("abort", onAbort, { once: true });
+		socket.setNoDelay(true);
+		socket.once("connect", () => {
+			try {
+				socket.write(encoded);
+			} catch {
+				fail(new Error("Gateway policy socket write failed"));
+			}
+		});
+		socket.on("data", chunk => {
+			if (settled) return;
+			const chunkBytes = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+			const newline = chunkBytes.indexOf(0x0a);
+			if (newline === -1) {
+				payloadBytes += chunkBytes.byteLength;
+				if (payloadBytes > maxFrameBytes) {
+					fail(new Error("Gateway policy socket response exceeds the frame limit"));
+					return;
+				}
+				chunks.push(chunkBytes);
+				return;
+			}
+			if (payloadBytes + newline > maxFrameBytes) {
+				fail(new Error("Gateway policy socket response exceeds the frame limit"));
+				return;
+			}
+			if (newline !== chunkBytes.byteLength - 1) {
+				fail(new Error("Gateway policy socket returned trailing frame data"));
+				return;
+			}
+			chunks.push(chunkBytes.subarray(0, newline));
+			try {
+				const bytes = Buffer.concat(chunks, payloadBytes + newline);
+				const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+				succeed(JSON.parse(text));
+			} catch {
+				fail(new Error("Gateway policy socket returned malformed JSON"));
+			}
+		});
+		socket.once("error", () => {
+			fail(new Error("Gateway policy socket is unavailable"));
+		});
+		socket.once("end", () => {
+			fail(new Error("Gateway policy socket closed before a complete response"));
+		});
+		socket.once("close", () => {
+			fail(new Error("Gateway policy socket closed before a complete response"));
+		});
+		socket.connect({ path: socketPath });
+	});
+}
+
+export function createAuthGatewayPolicySocketClient(
+	socketPath: string,
+	options: AuthGatewayPolicySocketClientOptions = {},
+): AuthGatewayPolicySocketClient {
+	validateAuthGatewayPolicySocketPath(socketPath);
+	const timeoutMs = options.timeoutMs ?? DEFAULT_POLICY_SOCKET_TIMEOUT_MS;
+	const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_POLICY_SOCKET_MAX_FRAME_BYTES;
+	validatePositiveBoundedInteger(timeoutMs, MAX_POLICY_SOCKET_TIMEOUT_MS, "Policy socket timeout");
+	validatePositiveBoundedInteger(maxFrameBytes, MAX_POLICY_SOCKET_FRAME_BYTES, "Policy socket frame limit");
+
+	const exchange = (request: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> =>
+		exchangePolicySocketFrame(socketPath, request, timeoutMs, maxFrameBytes, signal);
+
+	return {
+		authorizeRequest: async request => {
+			const response = await exchange(
+				{
+					version: AUTH_GATEWAY_POLICY_PROTOCOL_VERSION,
+					type: "authorize",
+					request: {
+						requestId: request.requestId,
+						format: request.format,
+						requestedModelId: request.requestedModelId,
+						...(request.requestedSessionId === undefined
+							? {}
+							: { requestedSessionId: request.requestedSessionId }),
+						method: request.method,
+						path: request.path,
+						authorization: request.authorization,
+					},
+				},
+				request.signal,
+			);
+			if (
+				!hasExactKeys(response, ["version", "type", "decision"]) ||
+				response.version !== AUTH_GATEWAY_POLICY_PROTOCOL_VERSION ||
+				response.type !== "authorize_result"
+			) {
+				throw new Error("Gateway policy socket returned an invalid authorization response");
+			}
+			return parsePolicyDecision(response.decision);
+		},
+		observe: async observation => {
+			const response = await exchange({
+				version: AUTH_GATEWAY_POLICY_PROTOCOL_VERSION,
+				type: "observe",
+				observation,
+			});
+			if (
+				!hasExactKeys(response, ["version", "type", "ack"]) ||
+				response.version !== AUTH_GATEWAY_POLICY_PROTOCOL_VERSION ||
+				response.type !== "observe_ack" ||
+				response.ack !== true
+			) {
+				throw new Error("Gateway policy socket returned an invalid observation acknowledgement");
+			}
+		},
+		probe: async signal => {
+			const response = await exchange(
+				{
+					version: AUTH_GATEWAY_POLICY_PROTOCOL_VERSION,
+					type: "probe",
+				},
+				signal,
+			);
+			if (
+				!hasExactKeys(response, ["version", "type", "ack"]) ||
+				response.version !== AUTH_GATEWAY_POLICY_PROTOCOL_VERSION ||
+				response.type !== "probe_ack" ||
+				response.ack !== true
+			) {
+				throw new Error("Gateway policy socket returned an invalid readiness acknowledgement");
+			}
+			return true;
+		},
+	};
+}
+
+export interface AuthGatewayPolicyReadinessProbeOptions {
+	cacheMs?: number;
+	now?: () => number;
+}
+
+export function createAuthGatewayPolicyReadinessProbe(
+	client: AuthGatewayPolicySocketClient,
+	options: AuthGatewayPolicyReadinessProbeOptions = {},
+): (signal?: AbortSignal) => Promise<boolean> {
+	const cacheMs = options.cacheMs ?? 250;
+	const now = options.now ?? Date.now;
+	validatePositiveBoundedInteger(cacheMs, 10_000, "Policy readiness cache");
+	let cached = false;
+	let cacheExpiresAt = 0;
+	let inFlight: Promise<boolean> | undefined;
+
+	return async () => {
+		if (now() < cacheExpiresAt) return cached;
+		if (inFlight) return inFlight;
+
+		const probe = client
+			.probe()
+			.catch(() => false)
+			.then(result => {
+				cached = result;
+				cacheExpiresAt = now() + cacheMs;
+				return result;
+			})
+			.finally(() => {
+				if (inFlight === probe) inFlight = undefined;
+			});
+		inFlight = probe;
+		return probe;
+	};
+}
 
 function getTokenFilePath(): string {
 	return path.join(getConfigRootDir(), "auth-gateway.token");
@@ -169,6 +460,8 @@ export function indexModelsByRequestId(
 }
 
 async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
+	const policyClient = flags.policySocket ? createAuthGatewayPolicySocketClient(flags.policySocket) : undefined;
+	const policyReadinessProbe = policyClient ? createAuthGatewayPolicyReadinessProbe(policyClient) : undefined;
 	const brokerConfig = await resolveAuthBrokerConfig();
 	if (!brokerConfig) {
 		throw new Error(
@@ -222,6 +515,13 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 		version: VERSION,
 		resolveModel: (id: string) => modelById.get(id),
 		listModels: () => modelById.values(),
+		...(policyClient && policyReadinessProbe
+			? {
+					authorizeRequest: policyClient.authorizeRequest,
+					observer: policyClient.observe,
+					readinessProbe: policyReadinessProbe,
+				}
+			: {}),
 	});
 	process.stdout.write(`auth-gateway listening on ${handle.url}\n`);
 	if (gatewayToken) {
@@ -387,6 +687,12 @@ async function runStatus(flags: AuthGatewayCommandArgs["flags"]): Promise<void> 
 }
 
 export async function runAuthGatewayCommand(cmd: AuthGatewayCommandArgs): Promise<void> {
+	if (cmd.flags.policySocket !== undefined) {
+		validateAuthGatewayPolicySocketPath(cmd.flags.policySocket);
+		if (cmd.action !== "serve") {
+			throw new Error("--policy-socket is only valid with `auth-gateway serve`");
+		}
+	}
 	switch (cmd.action) {
 		case "serve":
 			await runServe(cmd.flags);

--- a/packages/coding-agent/src/commands/auth-gateway.ts
+++ b/packages/coding-agent/src/commands/auth-gateway.ts
@@ -25,6 +25,9 @@ export default class AuthGateway extends Command {
 	static flags = {
 		json: Flags.boolean({ description: "Output JSON (token/status/check)" }),
 		bind: Flags.string({ description: "Bind address for `serve` (host:port)", char: "b" }),
+		"policy-socket": Flags.string({
+			description: "Absolute Unix socket path for fail-closed gateway policy authorization and observation",
+		}),
 		regenerate: Flags.boolean({ description: "Regenerate the gateway bearer token (token)" }),
 		"no-auth": Flags.boolean({
 			description:
@@ -59,6 +62,7 @@ export default class AuthGateway extends Command {
 			flags: {
 				json: flags.json,
 				bind: flags.bind,
+				policySocket: flags["policy-socket"],
 				regenerate: flags.regenerate,
 				noAuth: flags["no-auth"],
 				strict: flags.strict,

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -17,7 +17,7 @@
 
 import { logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
-import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import { type AgentRef, AgentRegistry, MAIN_AGENT_ID, type RemoteAgentIdentity } from "../registry/agent-registry";
 import type { CustomMessage } from "../session/messages";
 
 export interface IrcMessage {
@@ -34,8 +34,47 @@ export interface IrcMessage {
 
 export interface IrcDeliveryReceipt {
 	to: string;
-	outcome: "injected" | "woken" | "revived" | "failed";
+	outcome: "injected" | "woken" | "revived" | "remote" | "failed";
 	error?: string;
+}
+
+export type PeerExecutionIdentity =
+	| { locality: "local"; agentId: string; generation: number }
+	| ({
+			locality: "remote";
+			agentId: string;
+	  } & RemoteAgentIdentity);
+
+export interface PeerTransportPayload {
+	body: string;
+	replyTo?: string;
+}
+
+export interface PeerTransportDelivery {
+	deliveryId: string;
+	sequence: number;
+	kind: "message";
+	sender: PeerExecutionIdentity;
+	recipient: PeerExecutionIdentity;
+	payload: PeerTransportPayload;
+}
+
+export interface PeerTransportResult {
+	deliveryId: string;
+	sequence: number;
+	sender: PeerExecutionIdentity;
+	recipient: PeerExecutionIdentity;
+	outcome: "accepted" | "rejected" | "duplicate" | "conflict";
+	error?: string;
+}
+
+/**
+ * Trusted transport adapter. Endpoint and capability material is captured by
+ * the implementation and is deliberately absent from every delivery payload.
+ */
+export interface PeerTransportBackend {
+	deliver(delivery: Readonly<PeerTransportDelivery>, signal?: AbortSignal): Promise<PeerTransportResult>;
+	cancel(delivery: Readonly<PeerTransportDelivery>): Promise<void>;
 }
 
 interface IrcWaiter {
@@ -56,6 +95,17 @@ export class IrcBus {
 		}
 		return IrcBus.#global;
 	}
+	/**
+	 * Install the trusted transport closure used by the process-global bus.
+	 * Runtime bootstrap calls this directly; no endpoint material is exposed to
+	 * settings, tool parameters, or messages.
+	 */
+	static installGlobalPeerTransport(transport: PeerTransportBackend): void {
+		const bus = IrcBus.global();
+		if (bus.#peerTransport === transport) return;
+		if (bus.#peerTransport) throw new Error("The global remote peer transport is already installed.");
+		bus.#peerTransport = transport;
+	}
 
 	/** Reset the global bus. Test-only. */
 	static resetGlobalForTests(): void {
@@ -66,12 +116,19 @@ export class IrcBus {
 	readonly #lifecycle: () => AgentLifecycleManager;
 	readonly #mailboxes = new Map<string, IrcMessage[]>();
 	readonly #waiters = new Map<string, IrcWaiter[]>();
+	readonly #transportSequences = new Map<string, number>();
+	#peerTransport: PeerTransportBackend | undefined;
 
-	constructor(registry: AgentRegistry = AgentRegistry.global(), lifecycle?: AgentLifecycleManager) {
+	constructor(
+		registry: AgentRegistry = AgentRegistry.global(),
+		lifecycle?: AgentLifecycleManager,
+		peerTransport?: PeerTransportBackend,
+	) {
 		this.#registry = registry;
 		// Lazy: the lifecycle global self-constructs against the global registry,
 		// so only touch it when a parked recipient actually needs reviving.
 		this.#lifecycle = () => lifecycle ?? AgentLifecycleManager.global();
+		this.#peerTransport = peerTransport;
 	}
 
 	/**
@@ -100,7 +157,7 @@ export class IrcBus {
 	 */
 	async send(
 		msg: Omit<IrcMessage, "id" | "ts">,
-		opts?: { expectsReply?: boolean; suppressRelay?: boolean },
+		opts?: { expectsReply?: boolean; suppressRelay?: boolean; signal?: AbortSignal },
 	): Promise<IrcDeliveryReceipt> {
 		const message: IrcMessage = { ...msg, id: Snowflake.next(), ts: Date.now() };
 		const ref = this.#registry.get(message.to);
@@ -125,6 +182,24 @@ export class IrcBus {
 				outcome: "failed",
 				error: `Agent "${message.to}" is a read-only advisor transcript and cannot be messaged.`,
 			};
+		}
+		const senderRef = this.#registry.get(message.from);
+		if (ref.locality === "remote" || senderRef?.locality === "remote") {
+			if (!senderRef) {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: `Unknown sender agent "${message.from}" for remote delivery.`,
+				};
+			}
+			if (senderRef.status === "aborted") {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: `Sender agent "${message.from}" was hard-aborted.`,
+				};
+			}
+			return this.#sendRemote(message, senderRef, ref, opts?.signal);
 		}
 
 		// A `parked` recipient always needs the lifecycle to revive it — this is
@@ -276,7 +351,9 @@ export class IrcBus {
 		if (liveness) {
 			const { registry, senderId } = liveness;
 			const hasRunningSender = (from?: string): boolean =>
-				registry.listVisibleTo(senderId).some(ref => registry.isRunning(ref) && (!from || ref.id === from));
+				registry
+					.listVisibleTo(senderId)
+					.some(ref => ref.locality !== "remote" && registry.isRunning(ref) && (!from || ref.id === from));
 			const check = filter.from ? () => hasRunningSender(filter.from) : () => hasRunningSender();
 			unsubscribeLiveness = registry.onChange(() => {
 				if (!check()) {
@@ -290,6 +367,10 @@ export class IrcBus {
 
 		return promise;
 	}
+	/** Consume the oldest already-buffered message without parking a future waiter. */
+	takePending(agentId: string, from?: string): IrcMessage | undefined {
+		return this.#takeFromMailbox(agentId, from);
+	}
 
 	/** Drain (or peek) pending messages for `agentId`. */
 	inbox(agentId: string, opts?: { peek?: boolean }): IrcMessage[] {
@@ -302,6 +383,132 @@ export class IrcBus {
 
 	unreadCount(agentId: string): number {
 		return this.#mailboxes.get(agentId)?.length ?? 0;
+	}
+
+	#executionIdentity(ref: AgentRef): PeerExecutionIdentity | undefined {
+		if (ref.locality === "remote") {
+			return Object.freeze({
+				locality: "remote",
+				agentId: ref.id,
+				controllerId: ref.remote.controllerId,
+				executionId: ref.remote.executionId,
+				generation: ref.remote.generation,
+			});
+		}
+		if (!Number.isSafeInteger(ref.generation) || (ref.generation ?? 0) <= 0) return undefined;
+		return Object.freeze({ locality: "local", agentId: ref.id, generation: ref.generation as number });
+	}
+
+	#sameExecution(left: PeerExecutionIdentity, right: PeerExecutionIdentity): boolean {
+		if (left.locality !== right.locality || left.agentId !== right.agentId || left.generation !== right.generation)
+			return false;
+		return (
+			left.locality === "local" ||
+			(right.locality === "remote" &&
+				left.controllerId === right.controllerId &&
+				left.executionId === right.executionId)
+		);
+	}
+
+	async #sendRemote(
+		message: IrcMessage,
+		senderRef: AgentRef,
+		recipientRef: AgentRef,
+		signal?: AbortSignal,
+	): Promise<IrcDeliveryReceipt> {
+		const transport = this.#peerTransport;
+		if (!transport) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: `Remote peer transport is unavailable for "${message.to}".`,
+			};
+		}
+		if (message.body.length > 131_072 || (message.replyTo?.length ?? 0) > 256) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: "Remote peer message exceeds the transport bounds.",
+			};
+		}
+		const sender = this.#executionIdentity(senderRef);
+		const recipient = this.#executionIdentity(recipientRef);
+		if (!sender || !recipient) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: "Remote peer delivery requires generation-bound local execution identities.",
+			};
+		}
+		const sequenceKey =
+			sender.locality === "remote"
+				? JSON.stringify(["remote", sender.controllerId, sender.executionId, sender.generation])
+				: JSON.stringify(["local", sender.agentId, sender.generation]);
+		const sequence = (this.#transportSequences.get(sequenceKey) ?? 0) + 1;
+		this.#transportSequences.set(sequenceKey, sequence);
+		const payload = Object.freeze({
+			body: message.body,
+			...(message.replyTo ? { replyTo: message.replyTo } : {}),
+		});
+		const delivery = Object.freeze({
+			deliveryId: message.id,
+			sequence,
+			kind: "message" as const,
+			sender,
+			recipient,
+			payload,
+		});
+		let removeAbort: (() => void) | undefined;
+		if (signal) {
+			const cancel = (): void => {
+				void transport.cancel(delivery).catch(error => {
+					logger.debug("IrcBus: remote delivery cancellation failed", {
+						deliveryId: delivery.deliveryId,
+						error: String(error),
+					});
+				});
+			};
+			if (signal.aborted) cancel();
+			else {
+				signal.addEventListener("abort", cancel, { once: true });
+				removeAbort = () => signal.removeEventListener("abort", cancel);
+			}
+		}
+		try {
+			const result = await transport.deliver(delivery, signal);
+			if (
+				!result ||
+				typeof result !== "object" ||
+				result.deliveryId !== delivery.deliveryId ||
+				result.sequence !== delivery.sequence ||
+				!this.#sameExecution(result.sender, delivery.sender) ||
+				!this.#sameExecution(result.recipient, delivery.recipient) ||
+				!["accepted", "rejected", "duplicate", "conflict"].includes(result.outcome) ||
+				(result.error !== undefined && (typeof result.error !== "string" || result.error.length > 4096))
+			) {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: "Remote peer transport returned a malformed or stale delivery result.",
+				};
+			}
+			if (result.outcome !== "accepted") {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: result.error ?? `Remote peer delivery was ${result.outcome}.`,
+				};
+			}
+			return { to: message.to, outcome: "remote" };
+		} catch (error) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: `Remote peer delivery failed: ${error instanceof Error ? error.message : String(error)}`,
+			};
+		} finally {
+			removeAbort?.();
+		}
 	}
 
 	#enqueue(message: IrcMessage): void {

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -155,8 +155,12 @@ export class AgentLifecycleManager {
 	adopt(id: string, opts: AdoptOptions, expected?: AgentRefExpectation): void {
 		if (id === MAIN_AGENT_ID) return;
 		const ref = this.#registry.get(id);
-		if (!ref || (expected !== undefined && ref !== expected && ref.session !== expected)) {
-			logger.warn("AgentLifecycleManager.adopt: unknown or replaced agent id", { id });
+		if (
+			!ref ||
+			ref.locality === "remote" ||
+			(expected !== undefined && ref !== expected && ref.session !== expected)
+		) {
+			logger.warn("AgentLifecycleManager.adopt: unknown, remote, or replaced agent id", { id });
 			return;
 		}
 		const existing = this.#adopted.get(id);
@@ -186,7 +190,7 @@ export class AgentLifecycleManager {
 	 */
 	async reclaimDeadCorpse(id: string, expected: AgentRef): Promise<boolean> {
 		const ref = this.#registry.get(id);
-		if (ref !== expected || ref.status !== "parked" || ref.session) return false;
+		if (ref !== expected || ref.locality === "remote" || ref.status !== "parked" || ref.session) return false;
 		if (this.#adopted.has(id) || this.#parks.has(id) || this.#revivals.has(id)) return false;
 
 		const persistedFactory = ref.sessionFile ? this.#persistedReviverFactory : undefined;
@@ -247,7 +251,7 @@ export class AgentLifecycleManager {
 		const adopted = this.#adopted.get(id);
 		if (!adopted) return;
 		const ref = this.#registry.get(id);
-		if (!ref || adopted.ref !== ref) return;
+		if (!ref || ref.locality === "remote" || adopted.ref !== ref) return;
 		const session = ref.session;
 		if (!session) return;
 
@@ -315,6 +319,10 @@ export class AgentLifecycleManager {
 	 * cancelled (session still live) or awaited to completion before revive.
 	 */
 	async ensureLive(id: string): Promise<AgentSession> {
+		const initialRef = this.#registry.get(id);
+		if (initialRef?.locality === "remote") {
+			throw new Error(`Remote agent "${id}" cannot be resumed by the local lifecycle manager.`);
+		}
 		const park = this.#parks.get(id);
 		if (park) {
 			const parked = this.#registry.get(id);
@@ -363,6 +371,9 @@ export class AgentLifecycleManager {
 	 * when the agent is not revivable or no reviver can be produced.
 	 */
 	async #resolveAndRevive(id: string, ref: AgentRef): Promise<AgentSession> {
+		if (ref.locality === "remote") {
+			throw new Error(`Remote agent "${id}" cannot be revived by the local lifecycle manager.`);
+		}
 		let adoption = this.#adopted.get(id);
 		let revive = adoption?.ref === ref ? adoption.revive : undefined;
 		let coldAdopted = false;
@@ -417,6 +428,7 @@ export class AgentLifecycleManager {
 	async release(id: string, expected?: AgentRefExpectation, options?: { tombstone?: boolean }): Promise<boolean> {
 		const adopted = this.#adopted.get(id);
 		const current = this.#registry.get(id);
+		if (current?.locality === "remote") return false;
 		const currentMatches =
 			current && (expected === undefined || current === expected || current.session === expected);
 		const adoptedMatches =

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -69,7 +69,15 @@ export interface AgentHistorySummary {
 	branchName?: string;
 }
 
-export interface AgentRef {
+export interface LocalAgentRef {
+	/**
+	 * Omitted local fields preserve source compatibility with historical
+	 * persisted/manual AgentRef fixtures. Registry-created refs always populate
+	 * both fields; only remote refs require the discriminant.
+	 */
+	locality?: "local";
+	/** Registry-owned generation, incremented whenever a local id is registered again. */
+	generation?: number;
 	id: string;
 	displayName: string;
 	kind: AgentKind;
@@ -85,8 +93,86 @@ export interface AgentRef {
 	/** Persisted identity and telemetry restored after the live observer is gone. */
 	history?: AgentHistorySummary;
 }
+export interface RegisteredLocalAgentRef extends LocalAgentRef {
+	locality: "local";
+	generation: number;
+}
+
+/** Immutable controller-owned execution identity. It contains no endpoint or capability material. */
+export interface RemoteAgentIdentity {
+	controllerId: string;
+	executionId: string;
+	generation: number;
+}
+
+export interface RemoteAgentRef {
+	readonly locality: "remote";
+	/** Controller-owned generation, mirrored for identity checks and roster consumers. */
+	readonly generation: number;
+	readonly id: string;
+	displayName: string;
+	kind: AgentKind;
+	parentId?: string;
+	status: AgentStatus;
+	readonly session: null;
+	readonly sessionFile: null;
+	createdAt: number;
+	lastActivity: number;
+	activity?: string;
+	history?: AgentHistorySummary;
+	/** Frozen at registration; backend responses must echo this identity exactly. */
+	readonly remote: Readonly<RemoteAgentIdentity>;
+}
+
+export type AgentRef = LocalAgentRef | RemoteAgentRef;
 
 export type AgentRefExpectation = AgentRef | AgentSession;
+
+export interface RemoteAgentProgress {
+	sequence: number;
+	message?: string;
+}
+
+export interface RemoteAgentResult {
+	outcome: "completed" | "failed" | "cancelled";
+	output?: unknown;
+	error?: string;
+}
+
+export interface RemoteRegistryResponse<T> {
+	identity: RemoteAgentIdentity;
+	value: T;
+}
+
+/**
+ * Trusted controller adapter. Endpoint and authority state belong in this
+ * closure; none of it is accepted from refs, settings, prompts, or payloads.
+ */
+export interface RemoteRegistryBackend {
+	status(identity: Readonly<RemoteAgentIdentity>, signal?: AbortSignal): Promise<RemoteRegistryResponse<AgentStatus>>;
+	progress(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<RemoteAgentProgress>>;
+	cancel(identity: Readonly<RemoteAgentIdentity>, signal?: AbortSignal): Promise<RemoteRegistryResponse<"cancelled">>;
+	result(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<RemoteAgentResult>>;
+}
+
+export interface RemoteRegisterInput {
+	id: string;
+	displayName: string;
+	kind: AgentKind;
+	parentId?: string;
+	status: AgentStatus;
+	identity: RemoteAgentIdentity;
+	createdAt?: number;
+	lastActivity?: number;
+	activity?: string;
+	history?: AgentHistorySummary;
+}
 
 export type RegistryEvent =
 	| { type: "registered"; ref: AgentRef }
@@ -123,6 +209,13 @@ export class AgentRegistry {
 		}
 		return AgentRegistry.#global;
 	}
+	/** Install the trusted controller closure used by the process-global registry. */
+	static installGlobalRemoteBackend(backend: RemoteRegistryBackend): void {
+		const registry = AgentRegistry.global();
+		if (registry.#remoteBackend === backend) return;
+		if (registry.#remoteBackend) throw new Error("The global remote agent backend is already installed.");
+		registry.#remoteBackend = backend;
+	}
 
 	/** Reset the global registry. Test-only. */
 	static resetGlobalForTests(): void {
@@ -131,6 +224,83 @@ export class AgentRegistry {
 
 	readonly #refs = new Map<string, AgentRef>();
 	readonly #listeners = new Set<RegistryListener>();
+	readonly #localGenerations = new Map<string, number>();
+	readonly #remoteProgress = new Map<string, RemoteAgentProgress>();
+	readonly #remoteIdentityOwners = new Map<string, string>();
+	#remoteBackend: RemoteRegistryBackend | undefined;
+
+	constructor(options?: { remoteBackend?: RemoteRegistryBackend }) {
+		this.#remoteBackend = options?.remoteBackend;
+	}
+
+	static #validIdentity(identity: unknown): identity is RemoteAgentIdentity {
+		if (!identity || typeof identity !== "object") return false;
+		const candidate = identity as Partial<RemoteAgentIdentity>;
+		return (
+			typeof candidate.controllerId === "string" &&
+			candidate.controllerId.length > 0 &&
+			candidate.controllerId.length <= 256 &&
+			candidate.controllerId === candidate.controllerId.trim() &&
+			typeof candidate.executionId === "string" &&
+			candidate.executionId.length > 0 &&
+			candidate.executionId.length <= 256 &&
+			candidate.executionId === candidate.executionId.trim() &&
+			Number.isSafeInteger(candidate.generation) &&
+			(candidate.generation ?? 0) > 0
+		);
+	}
+	static #sameIdentity(left: Readonly<RemoteAgentIdentity>, right: RemoteAgentIdentity): boolean {
+		return (
+			left.controllerId === right.controllerId &&
+			left.executionId === right.executionId &&
+			left.generation === right.generation
+		);
+	}
+	static #identityKey(identity: Readonly<RemoteAgentIdentity>): string {
+		return `${identity.controllerId.length}:${identity.controllerId}${identity.executionId.length}:${identity.executionId}:${identity.generation}`;
+	}
+
+	#remoteRef(id: string): RemoteAgentRef {
+		const ref = this.#refs.get(id);
+		if (!ref) throw new Error(`Unknown remote agent "${id}".`);
+		if (ref.locality !== "remote") throw new Error(`Agent "${id}" is local, not remote.`);
+		return ref;
+	}
+
+	async #remoteCall<T>(
+		id: string,
+		operation: keyof RemoteRegistryBackend,
+		signal?: AbortSignal,
+	): Promise<{ ref: RemoteAgentRef; value: T }> {
+		const ref = this.#remoteRef(id);
+		const backend = this.#remoteBackend;
+		if (!backend) throw new Error(`Remote agent backend is unavailable for "${id}".`);
+		let response: RemoteRegistryResponse<T>;
+		try {
+			const call = backend[operation] as (
+				identity: Readonly<RemoteAgentIdentity>,
+				callSignal?: AbortSignal,
+			) => Promise<RemoteRegistryResponse<T>>;
+			response = await call.call(backend, ref.remote, signal);
+		} catch (error) {
+			throw new Error(
+				`Remote agent ${operation} failed for "${id}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+		signal?.throwIfAborted();
+		if (
+			!response ||
+			typeof response !== "object" ||
+			!AgentRegistry.#validIdentity(response.identity) ||
+			!AgentRegistry.#sameIdentity(ref.remote, response.identity)
+		) {
+			throw new Error(`Remote agent ${operation} returned a stale or malformed identity for "${id}".`);
+		}
+		if (this.#refs.get(id) !== ref) {
+			throw new Error(`Remote agent "${id}" changed generation during ${operation}.`);
+		}
+		return { ref, value: response.value };
+	}
 
 	#matchesExpected(ref: AgentRef, expected?: AgentRefExpectation): boolean {
 		return expected === undefined || ref === expected || ref.session === expected;
@@ -141,9 +311,17 @@ export class AgentRegistry {
 		return false;
 	}
 
-	register(input: RegisterInput): AgentRef {
+	register(input: RegisterInput): RegisteredLocalAgentRef {
+		const existing = this.#refs.get(input.id);
+		if (existing?.locality === "remote") {
+			throw new Error(`Cannot register local agent "${input.id}" over a remote execution.`);
+		}
 		const now = Date.now();
-		const ref: AgentRef = {
+		const generation = (this.#localGenerations.get(input.id) ?? 0) + 1;
+		this.#localGenerations.set(input.id, generation);
+		const ref: RegisteredLocalAgentRef = {
+			locality: "local",
+			generation,
 			id: input.id,
 			displayName: input.displayName,
 			kind: input.kind,
@@ -161,16 +339,136 @@ export class AgentRegistry {
 		return ref;
 	}
 
+	/** Register a controller-owned execution without creating any local session or revival state. */
+	registerRemote(input: RemoteRegisterInput): RemoteAgentRef {
+		if (!AgentRegistry.#validIdentity(input.identity)) {
+			throw new Error(`Remote agent "${input.id}" has an invalid controller identity.`);
+		}
+		if (input.id.length === 0 || input.id !== input.id.trim()) {
+			throw new Error("Remote agent id must be a non-empty normalized string.");
+		}
+		if (this.#refs.has(input.id)) {
+			throw new Error(`Agent "${input.id}" is already registered; local and remote executions cannot overlap.`);
+		}
+		const identityKey = AgentRegistry.#identityKey(input.identity);
+		const identityOwner = this.#remoteIdentityOwners.get(identityKey);
+		if (identityOwner) {
+			throw new Error(`Remote execution identity is already registered as agent "${identityOwner}".`);
+		}
+		const now = Date.now();
+		const remote = Object.freeze({ ...input.identity });
+		const ref: RemoteAgentRef = {
+			locality: "remote",
+			generation: remote.generation,
+			id: input.id,
+			displayName: input.displayName,
+			kind: input.kind,
+			parentId: input.parentId,
+			status: input.status,
+			session: null,
+			sessionFile: null,
+			createdAt: input.createdAt ?? now,
+			lastActivity: input.lastActivity ?? now,
+			activity: input.activity ? oneLineLabel(input.activity) : undefined,
+			history: input.history,
+			remote,
+		};
+		Object.defineProperties(ref, {
+			id: { value: input.id, enumerable: true, writable: false, configurable: false },
+			locality: { value: "remote", enumerable: true, writable: false, configurable: false },
+			generation: { value: remote.generation, enumerable: true, writable: false, configurable: false },
+			remote: { value: remote, enumerable: true, writable: false, configurable: false },
+			session: { value: null, enumerable: true, writable: false, configurable: false },
+			sessionFile: { value: null, enumerable: true, writable: false, configurable: false },
+		});
+		this.#remoteIdentityOwners.set(identityKey, ref.id);
+		this.#refs.set(ref.id, ref);
+		this.#emit({ type: "registered", ref });
+		return ref;
+	}
+
+	/** Refresh controller-owned status and progress, rejecting stale generations and malformed state. */
+	async refreshRemote(id: string, signal?: AbortSignal): Promise<RemoteAgentRef> {
+		const statusResponse = await this.#remoteCall<AgentStatus>(id, "status", signal);
+		const status = statusResponse.value;
+		if (!["running", "idle", "parked", "aborted"].includes(status)) {
+			throw new Error(`Remote agent status returned a malformed value for "${id}".`);
+		}
+		const progressResponse = await this.#remoteCall<RemoteAgentProgress>(id, "progress", signal);
+		const progress = progressResponse.value;
+		if (
+			!progress ||
+			typeof progress !== "object" ||
+			!Number.isSafeInteger(progress.sequence) ||
+			progress.sequence < 0 ||
+			(progress.message !== undefined && typeof progress.message !== "string")
+		) {
+			throw new Error(`Remote agent progress returned a malformed value for "${id}".`);
+		}
+		const identityKey = AgentRegistry.#identityKey(progressResponse.ref.remote);
+		const priorProgress = this.#remoteProgress.get(identityKey);
+		if (priorProgress && progress.sequence < priorProgress.sequence) {
+			throw new Error(`Remote agent progress returned a stale sequence for "${id}".`);
+		}
+		if (priorProgress && progress.sequence === priorProgress.sequence && progress.message !== priorProgress.message) {
+			throw new Error(`Remote agent progress returned a conflicting duplicate sequence for "${id}".`);
+		}
+		const ref = progressResponse.ref;
+		if (statusResponse.ref !== ref) throw new Error(`Remote agent "${id}" changed generation during refresh.`);
+		this.#remoteProgress.set(identityKey, { sequence: progress.sequence, message: progress.message });
+		this.#applyRemoteStatus(ref, status);
+		if (progress.message !== undefined && status === "running") ref.activity = oneLineLabel(progress.message);
+		ref.lastActivity = Date.now();
+		this.#emit({ type: "metadata_changed", ref });
+		return ref;
+	}
+
+	/** Route cancellation to the controller. Missing/rejecting backends never fall back to local session control. */
+	async cancelRemote(id: string, signal?: AbortSignal): Promise<void> {
+		const { ref, value } = await this.#remoteCall<"cancelled">(id, "cancel", signal);
+		if (value !== "cancelled") throw new Error(`Remote agent cancel returned a malformed result for "${id}".`);
+		this.#applyRemoteStatus(ref, "aborted");
+	}
+
+	/** Read the controller's terminal result without executing or reviving anything locally. */
+	async resultRemote(id: string, signal?: AbortSignal): Promise<RemoteAgentResult> {
+		const { value } = await this.#remoteCall<RemoteAgentResult>(id, "result", signal);
+		if (
+			!value ||
+			typeof value !== "object" ||
+			!["completed", "failed", "cancelled"].includes(value.outcome) ||
+			(value.error !== undefined && typeof value.error !== "string") ||
+			(value.outcome === "completed" && value.error !== undefined) ||
+			(value.outcome === "failed" && !value.error)
+		) {
+			throw new Error(`Remote agent result returned a malformed value for "${id}".`);
+		}
+		return value;
+	}
+
+	#applyRemoteStatus(ref: RemoteAgentRef, status: AgentStatus): void {
+		if (ref.status === "aborted" && status !== "aborted") {
+			throw new Error(`Remote agent "${ref.id}" is aborted and cannot be revived.`);
+		}
+		if (ref.status === status) return;
+		ref.status = status;
+		if (status !== "running") ref.activity = undefined;
+		ref.lastActivity = Date.now();
+		this.#emit({ type: "status_changed", ref });
+	}
+
 	/**
 	 * Register a new id only when it is absent, or reuse the exact detached
 	 * `parked` ref a revival was authorized to revive. A missing, replaced, or
 	 * terminal expected ref is a failed CAS: delayed revivers must never claim an
 	 * id after its prior generation disappeared or was hard-killed.
 	 */
-	registerIfAvailable(input: RegisterInput, expected: AgentRef | null): AgentRef | undefined {
+	registerIfAvailable(input: RegisterInput, expected: AgentRef | null): LocalAgentRef | undefined {
 		const current = this.#refs.get(input.id);
 		if (expected === null) return current ? undefined : this.register(input);
-		return current === expected && current.status === "parked" && !current.session ? current : undefined;
+		return current === expected && current.locality !== "remote" && current.status === "parked" && !current.session
+			? current
+			: undefined;
 	}
 
 	/** Attach transcript-derived identity and telemetry without changing lifecycle state. */
@@ -188,6 +486,7 @@ export class AgentRegistry {
 	setStatus(id: string, status: AgentStatus, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
 		if (!ref) return this.#rejectStatusUpdate(id, status, "missing-ref");
+		if (ref.locality === "remote") return this.#rejectStatusUpdate(id, status, "remote-status-is-controller-owned");
 		if (!this.#matchesExpected(ref, expected)) {
 			return this.#rejectStatusUpdate(id, status, "session-ownership-changed");
 		}
@@ -222,7 +521,7 @@ export class AgentRegistry {
 	 */
 	setActivity(id: string, activity: string): void {
 		const ref = this.#refs.get(id);
-		if (!ref) return;
+		if (!ref || ref.locality === "remote") return;
 		if (ref.status !== "running") return;
 		const gist = oneLineLabel(activity);
 		ref.lastActivity = Date.now();
@@ -237,10 +536,10 @@ export class AgentRegistry {
 		expected?: AgentRefExpectation,
 	): boolean {
 		const ref = this.#refs.get(id);
-		// Never attach a late-created session to a hard-killed tombstone. This
-		// closes the race between a parked reviver claiming the ref and finishing
-		// createAgentSession after an explicit kill.
-		if (!ref || ref.status === "aborted" || !this.#matchesExpected(ref, expected)) return false;
+		// Remote executions never accept local sessions, including from delayed
+		// revivers racing a controller registration.
+		if (!ref || ref.locality === "remote" || ref.status === "aborted" || !this.#matchesExpected(ref, expected))
+			return false;
 		ref.session = session;
 		if (sessionFile !== undefined) ref.sessionFile = sessionFile;
 		ref.lastActivity = Date.now();
@@ -249,7 +548,7 @@ export class AgentRegistry {
 
 	detachSession(id: string, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
-		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		if (!ref || ref.locality === "remote" || !this.#matchesExpected(ref, expected)) return false;
 		ref.session = null;
 		return true;
 	}
@@ -257,6 +556,11 @@ export class AgentRegistry {
 	unregister(id: string, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
 		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		if (ref.locality === "remote") {
+			const identityKey = AgentRegistry.#identityKey(ref.remote);
+			this.#remoteProgress.delete(identityKey);
+			if (this.#remoteIdentityOwners.get(identityKey) === ref.id) this.#remoteIdentityOwners.delete(identityKey);
+		}
 		this.#refs.delete(id);
 		this.#emit({ type: "removed", ref });
 		return true;
@@ -281,10 +585,10 @@ export class AgentRegistry {
 		);
 	}
 
-	/** Whether a ref's claimed running state is corroborated by its attached live session. */
+	/** Whether a running claim is corroborated by its owning runtime. */
 	isRunning(ref: AgentRef): boolean {
 		if (ref.status !== "running") return false;
-		return ref.session?.isStreaming === true;
+		return ref.locality === "remote" || ref.session?.isStreaming === true;
 	}
 
 	/** Mirror a session's authoritative run-state notifications into its owned registry ref. */

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -145,6 +145,28 @@ export interface StructuredSubagentResult {
 	temporaryArtifacts: boolean;
 }
 
+/** Explicit execution mode selected by trusted runtime plumbing. */
+export type StructuredSubagentExecutionMode = "local" | "remote";
+
+/** Fully resolved input handed to a remotely executing backend. */
+export interface StructuredSubagentBackendContext {
+	readonly request: StructuredSubagentRequest;
+	readonly policy: EffectiveSubagentPolicy;
+	readonly outputSchema: StructuredSubagentSchemaResolution;
+	readonly signal?: AbortSignal;
+}
+
+/** Trusted runtime seam for executing a normalized structured subagent remotely. */
+export interface StructuredSubagentBackend {
+	run(context: StructuredSubagentBackendContext): Promise<StructuredSubagentResult>;
+}
+
+/** Launch-owned execution selection; this is deliberately separate from agent-authored request data. */
+export interface StructuredSubagentRuntimeOptions {
+	execution?: StructuredSubagentExecutionMode;
+	backend?: StructuredSubagentBackend;
+}
+
 /** Machine-readable failure category so adapters can retain their native errors. */
 export class StructuredSubagentError extends Error {
 	readonly kind: "preflight" | "isolation" | "execution";
@@ -540,12 +562,210 @@ function attachStructuredOutputMetadata(result: SingleResult, schema: Structured
 	result.structuredOutput = output;
 }
 
+function normalizeRemoteRequest(
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+): StructuredSubagentRequest {
+	const identity = request.identity
+		? {
+				id: trimToUndefined(request.identity.id),
+				label: trimToUndefined(request.identity.label),
+			}
+		: undefined;
+	return {
+		...request,
+		assignment: request.assignment.trim(),
+		context: request.context?.trim() || undefined,
+		agent: policy.agentName,
+		schemaMode: policy.schema.mode,
+		identity,
+		index: request.index ?? 0,
+		isolation: {
+			requested: policy.isIsolated,
+			merge: policy.mergeMode,
+			apply: policy.applyChanges,
+		},
+		enableLsp: policy.enableLsp,
+		enableIrc: policy.enableIrc,
+	};
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function validateRemoteResult(
+	value: unknown,
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+): string | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return "result envelope must be an object";
+	const envelope = value as Partial<StructuredSubagentResult>;
+	if (typeof envelope.result !== "object" || envelope.result === null || Array.isArray(envelope.result))
+		return "result must be an object";
+	if (typeof envelope.policy !== "object" || envelope.policy === null || Array.isArray(envelope.policy))
+		return "policy must be an object";
+	if (typeof envelope.mergeSummary !== "string") return "mergeSummary must be a string";
+	if (envelope.changesApplied !== null && typeof envelope.changesApplied !== "boolean")
+		return "changesApplied must be boolean or null";
+	if (typeof envelope.artifactsDir !== "string") return "artifactsDir must be a string";
+	if (typeof envelope.temporaryArtifacts !== "boolean") return "temporaryArtifacts must be boolean";
+
+	const result = envelope.result;
+	if (!Number.isInteger(result.index) || result.index !== (request.index ?? 0))
+		return "result index does not match the normalized request";
+	if (typeof result.id !== "string" || result.id.trim().length === 0) return "result id must be a non-empty string";
+	if (request.identity?.id !== undefined && result.id !== request.identity.id)
+		return "result id does not match the normalized preallocated id";
+	if (result.agent !== policy.agent.name) return "result agent does not match the resolved agent";
+	if (result.agentSource !== policy.agent.source) return "result agentSource does not match the resolved agent";
+	if (typeof result.task !== "string") return "result task must be a string";
+	if (result.assignment !== undefined && result.assignment !== request.assignment)
+		return "result assignment does not match the normalized request";
+	if (!Number.isInteger(result.exitCode)) return "result exitCode must be an integer";
+	if (typeof result.output !== "string") return "result output must be a string";
+	if (typeof result.stderr !== "string") return "result stderr must be a string";
+	if (typeof result.truncated !== "boolean") return "result truncated must be boolean";
+	if (!isFiniteNonNegativeNumber(result.durationMs)) return "result durationMs must be a non-negative number";
+	if (!isFiniteNonNegativeNumber(result.tokens)) return "result tokens must be a non-negative number";
+	if (!Number.isInteger(result.requests) || (result.requests as number) < 0)
+		return "result requests must be a non-negative integer";
+	if (result.error !== undefined && typeof result.error !== "string") return "result error must be a string";
+	if (result.aborted !== undefined && typeof result.aborted !== "boolean") return "result aborted must be boolean";
+	if (result.abortReason !== undefined && typeof result.abortReason !== "string")
+		return "result abortReason must be a string";
+
+	if (policy.schema.source === "none") {
+		if (result.structuredOutput !== undefined) return "schema-free result must not contain structuredOutput";
+		return undefined;
+	}
+	if (typeof result.structuredOutput !== "object" || result.structuredOutput === null)
+		return "schema-bearing result must contain structuredOutput";
+	const structuredOutput = result.structuredOutput;
+	if (structuredOutput.source !== policy.schema.source)
+		return "structuredOutput source does not match effective schema";
+	if (structuredOutput.mode !== policy.schema.mode) return "structuredOutput mode does not match effective schema";
+	if (
+		structuredOutput.status !== "valid" &&
+		structuredOutput.status !== "invalid" &&
+		structuredOutput.status !== "unavailable"
+	) {
+		return "structuredOutput status is invalid";
+	}
+	if (structuredOutput.error !== undefined && typeof structuredOutput.error !== "string")
+		return "structuredOutput error must be a string";
+	if (
+		policy.schema.mode === "strict" &&
+		structuredOutput.status !== "valid" &&
+		(result.exitCode === 0 || !result.stderr.includes("schema_violation"))
+	) {
+		return "strict invalid or unavailable structuredOutput must be a failed schema_violation";
+	}
+	if (structuredOutput.status === "valid") {
+		if (!Object.hasOwn(structuredOutput, "data")) return "valid structuredOutput must contain data";
+		const { validator, error } = buildOutputValidator(policy.schema.schema);
+		if (error) return "valid structuredOutput cannot satisfy an unusable effective schema";
+		const validation = validator?.validate(structuredOutput.data);
+		if (validation && !validation.success) return "structuredOutput data does not satisfy the effective schema";
+	}
+	return undefined;
+}
+
+function remoteAbortReason(signal: AbortSignal | undefined): string {
+	const reason = signal?.reason;
+	if (reason instanceof Error && reason.message.trim()) return reason.message.trim();
+	if (typeof reason === "string" && reason.trim()) return reason.trim();
+	return "Cancelled by caller";
+}
+
+function buildRemoteFailure(
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+	message: string,
+	startedAt: number,
+	aborted = false,
+): StructuredSubagentResult {
+	const id = trimToUndefined(request.identity?.id) ?? sanitizeAgentId(request.identity?.label) ?? "remote";
+	const result = buildFailureResult(request, policy, id, startedAt)(message);
+	if (aborted) {
+		result.aborted = true;
+		result.abortReason = message;
+	}
+	attachStructuredOutputMetadata(result, policy.schema);
+	return {
+		result,
+		policy,
+		mergeSummary: "",
+		changesApplied: null,
+		artifactsDir: "",
+		temporaryArtifacts: false,
+	};
+}
+
+const REMOTE_ABORTED = Symbol("remote structured subagent aborted");
+
+async function runRemoteStructuredSubagent(
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+	backend: StructuredSubagentBackend | undefined,
+): Promise<StructuredSubagentResult> {
+	const startedAt = Date.now();
+	if (!backend) {
+		return buildRemoteFailure(request, policy, "Remote structured subagent backend is unavailable.", startedAt);
+	}
+	const signal = request.signal;
+	if (signal?.aborted) {
+		return buildRemoteFailure(request, policy, remoteAbortReason(signal), startedAt, true);
+	}
+	const context: StructuredSubagentBackendContext = {
+		request,
+		policy,
+		outputSchema: policy.schema,
+		signal,
+	};
+	const cancellation = Promise.withResolvers<typeof REMOTE_ABORTED>();
+	const onAbort = () => cancellation.resolve(REMOTE_ABORTED);
+	signal?.addEventListener("abort", onAbort, { once: true });
+	try {
+		const backendRun = backend.run(context);
+		const candidate = signal ? await Promise.race([backendRun, cancellation.promise]) : await backendRun;
+		if (candidate === REMOTE_ABORTED || signal?.aborted) {
+			return buildRemoteFailure(request, policy, remoteAbortReason(signal), startedAt, true);
+		}
+		const malformed = validateRemoteResult(candidate, request, policy);
+		if (malformed) {
+			return buildRemoteFailure(
+				request,
+				policy,
+				`Remote structured subagent backend returned a malformed result: ${malformed}.`,
+				startedAt,
+			);
+		}
+		return { ...candidate, policy };
+	} catch (error) {
+		if (signal?.aborted) {
+			return buildRemoteFailure(request, policy, remoteAbortReason(signal), startedAt, true);
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		return buildRemoteFailure(request, policy, `Remote structured subagent execution failed: ${message}`, startedAt);
+	} finally {
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
 /**
- * Execute a validated subagent. Preflight errors occur before any artifact
- * lease or child dispatch; callers keep responsibility for their result text.
+ * Execute a validated subagent. Preflight errors occur before any dispatch.
+ * Explicit remote execution follows policy resolution and precedes every local
+ * artifact lease, isolation preparation, and subprocess path.
  */
-export async function runStructuredSubagent(request: StructuredSubagentRequest): Promise<StructuredSubagentResult> {
+export async function runStructuredSubagent(
+	request: StructuredSubagentRequest,
+	runtime?: StructuredSubagentRuntimeOptions,
+): Promise<StructuredSubagentResult> {
 	const policy = await resolveEffectiveSubagentPolicy(request);
+	if (runtime?.execution === "remote") {
+		return runRemoteStructuredSubagent(normalizeRemoteRequest(request, policy), policy, runtime.backend);
+	}
 	const lease = await leaseArtifacts(request.session, request.invocationKind);
 	let changesApplied: boolean | null = null;
 	let mergeSummary = "";

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -283,7 +283,7 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 				if (!params.ids?.length) {
 					return hubErrorResult('`ids` is required for op="cancel".', { op: "cancel", jobs: [] });
 				}
-				return await executeCancel(this.session, manager, this.#ownerId(), params.ids);
+				return await executeCancel(this.session, manager, this.#ownerId(), params.ids, signal);
 			}
 			case "jobs": {
 				const manager = this.session.asyncJobManager;
@@ -343,11 +343,27 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 		const manager = this.session.asyncJobManager;
 		const ownerId = this.#ownerId();
 		const from = params.from?.trim() || undefined;
+		const localSenderMessaging =
+			messaging?.registry.get(messaging.senderId)?.locality === "remote" ? null : messaging;
+		const hasLocalRunningPeer = messaging?.registry
+			.listVisibleTo(messaging.senderId)
+			.some(ref => ref.locality !== "remote" && messaging.registry.isRunning(ref));
+		const hasRemotePeer = messaging?.registry
+			.listVisibleTo(messaging.senderId)
+			.some(ref => ref.locality === "remote");
+		const fromIsRemote = from ? messaging?.registry.get(from)?.locality === "remote" : false;
+		const peerWaitMessaging =
+			messaging?.registry.get(messaging.senderId)?.locality === "remote" ||
+			fromIsRemote ||
+			(!from && !hasLocalRunningPeer && hasRemotePeer)
+				? null
+				: messaging;
 
-		// A message already buffered on the session satisfies the wait first.
-		if (messaging) {
-			const pending = drainPendingInbox(messaging.registry, messaging.senderId, from);
-			if (pending) return messageResult(messaging.senderId, pending);
+		// A local sender always consumes already-buffered session/bus messages
+		// before deciding whether a future remote-only wait is unsupported.
+		if (localSenderMessaging) {
+			const pending = drainPendingInbox(localSenderMessaging.registry, localSenderMessaging.senderId, from);
+			if (pending) return messageResult(localSenderMessaging.senderId, pending);
 		}
 
 		// Resolve which jobs to watch:
@@ -370,17 +386,20 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 
 		if (!manager || runningJobs.length === 0) {
 			// No job legs: pure message wait — or nothing to block on at all.
-			if (!messaging) return nothingToWaitForResult(this.session);
+			if (!peerWaitMessaging) {
+				if (messaging) return executeMessageWait(messaging, { from, timeoutMs: params.timeoutMs }, signal);
+				return nothingToWaitForResult(this.session);
+			}
 			if (!from) {
 				// A bare wait can only be satisfied by a running peer eventually
 				// sending something; with none, return the snapshot immediately
 				// instead of blocking a full message-timeout window.
-				const hasRunningPeer = messaging.registry
-					.listVisibleTo(messaging.senderId)
-					.some(ref => messaging.registry.isRunning(ref));
+				const hasRunningPeer = peerWaitMessaging.registry
+					.listVisibleTo(peerWaitMessaging.senderId)
+					.some(ref => peerWaitMessaging.registry.isRunning(ref));
 				if (!hasRunningPeer) return nothingToWaitForResult(this.session);
 			}
-			return executeMessageWait(messaging, { from, timeoutMs: params.timeoutMs }, signal);
+			return executeMessageWait(peerWaitMessaging, { from, timeoutMs: params.timeoutMs }, signal);
 		}
 
 		// Wait window: explicit timeout wins (0 = no window); otherwise the
@@ -395,13 +414,13 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 
 		// Message leg: park a bus waiter with no timeout of its own — the race
 		// window governs. Cancelled via sentinel so late losers do not reject.
-		const busAbort = messaging ? new AbortController() : undefined;
+		const busAbort = peerWaitMessaging ? new AbortController() : undefined;
 		const busCancelled = new Error("hub wait settled");
 		let removeBusAbortListener: (() => void) | undefined;
 		const busLeg =
-			messaging && busAbort
+			peerWaitMessaging && busAbort
 				? IrcBus.global()
-						.wait(messaging.senderId, { from }, 0, busAbort.signal)
+						.wait(peerWaitMessaging.senderId, { from }, 0, busAbort.signal)
 						.then(
 							message => ({ message, error: null as Error | null }),
 							error => ({
@@ -471,9 +490,9 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 		// A message consumed by the bus waiter must never be dropped — it wins
 		// even a photo-finish race (job results re-deliver themselves; a
 		// dequeued message would otherwise be lost).
-		if (busLeg && messaging) {
+		if (busLeg && peerWaitMessaging) {
 			const settled = await busLeg;
-			if (settled.message) return messageResult(messaging.senderId, settled.message);
+			if (settled.message) return messageResult(peerWaitMessaging.senderId, settled.message);
 		}
 
 		return buildJobResult(this.session, manager, "wait", jobsToWatch, []);

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -7,6 +7,7 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
+import { untilAborted } from "@oh-my-pi/pi-utils";
 import type { AsyncJob, AsyncJobManager } from "../../async";
 import { settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
@@ -35,6 +36,7 @@ const WAIT_DURATION_MS: Record<string, number> = {
 	"1m": 60_000,
 	"5m": 5 * 60_000,
 };
+const REMOTE_AGENT_CANCEL_TIMEOUT_MS = 5_000;
 
 /**
  * A wait snapshot where every watched job is still running and nothing was
@@ -217,9 +219,16 @@ export function buildJobResult(
 
 	const lines: string[] = [];
 
-	if (cancelOutcomes.length > 0) {
-		lines.push(`## Cancelled (${cancelOutcomes.length})\n`);
-		for (const o of cancelOutcomes) lines.push(`- ${o.message}`);
+	const failedCancellations = cancelOutcomes.filter(outcome => outcome.status === "failed");
+	const completedCancellations = cancelOutcomes.filter(outcome => outcome.status !== "failed");
+	if (completedCancellations.length > 0) {
+		lines.push(`## Cancelled (${completedCancellations.length})\n`);
+		for (const outcome of completedCancellations) lines.push(`- ${outcome.message}`);
+		lines.push("");
+	}
+	if (failedCancellations.length > 0) {
+		lines.push(`## Cancellation Failed (${failedCancellations.length})\n`);
+		for (const outcome of failedCancellations) lines.push(`- ${outcome.message}`);
 		lines.push("");
 	}
 
@@ -265,6 +274,7 @@ export function buildJobResult(
 	return {
 		content: [{ type: "text", text: lines.join("\n").trimEnd() }],
 		details,
+		...(cancelOutcomes.some(outcome => outcome.status === "failed") ? { isError: true } : {}),
 		// A wait where everything is still running carries no new information
 		// once a later wait exists — same predicate the TUI uses to displace
 		// stale waiting frames.
@@ -323,16 +333,22 @@ export async function executeCancel(
 	manager: AsyncJobManager,
 	ownerId: string | undefined,
 	ids: string[],
+	signal?: AbortSignal,
 ): Promise<AgentToolResult<CoordinationDetails>> {
 	const ownerFilter = ownerId ? { ownerId } : undefined;
 	const cancelOutcomes: CancelOutcome[] = [];
 	for (const id of ids) {
 		const existing = manager.getJob(id);
+		const registeredRef = session.agentRegistry?.get(id);
+		if (registeredRef?.locality === "remote") {
+			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id, signal));
+			continue;
+		}
 		if (!existing || (ownerId && existing.ownerId !== ownerId)) {
 			// No job by this id (or it belongs to another agent): a budget-aborted
 			// keep-alive subagent lives on as a jobless registration long after its
 			// job row is reaped, so let cancel reach the agent registration too.
-			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id));
+			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id, signal));
 			continue;
 		}
 		if (existing.status !== "running") {
@@ -340,9 +356,9 @@ export async function executeCancel(
 			// The agent registration behind it (job id == agent id for task
 			// spawns) can outlive the row as an idle/parked zombie — try the
 			// registration kill before reporting the row as already done.
-			const regOutcome = await cancelAgentRegistration(session, ownerId, id);
+			const regOutcome = await cancelAgentRegistration(session, ownerId, id, signal);
 			cancelOutcomes.push(
-				regOutcome.status === "cancelled"
+				regOutcome.status === "cancelled" || regOutcome.status === "failed"
 					? regOutcome
 					: {
 							id,
@@ -375,10 +391,11 @@ async function cancelAgentRegistration(
 	session: ToolSession,
 	ownerId: string | undefined,
 	id: string,
+	signal?: AbortSignal,
 ): Promise<CancelOutcome> {
 	const registry = session.agentRegistry;
 	const ref = registry?.get(id);
-	if (ref?.kind !== "sub") {
+	if (!registry || ref?.kind !== "sub") {
 		return { id, status: "not_found", message: `Background job not found: ${id}` };
 	}
 	if (id === ownerId) {
@@ -386,6 +403,25 @@ async function cancelAgentRegistration(
 	}
 	if (ownerId && ref.parentId !== ownerId) {
 		return { id, status: "not_found", message: `Agent ${id} was not spawned by you and cannot be cancelled.` };
+	}
+	if (ref.locality === "remote") {
+		const timeoutSignal = AbortSignal.timeout(REMOTE_AGENT_CANCEL_TIMEOUT_MS);
+		const operationSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+		try {
+			await untilAborted(operationSignal, () => registry.cancelRemote(id, operationSignal));
+			return { id, status: "cancelled", message: `Cancelled remote agent ${id}.` };
+		} catch (error) {
+			const reason = timeoutSignal.aborted
+				? `timed out after ${REMOTE_AGENT_CANCEL_TIMEOUT_MS}ms`
+				: error instanceof Error
+					? error.message
+					: String(error);
+			return {
+				id,
+				status: "failed",
+				message: `Remote agent ${id} cancellation failed: ${reason}.`,
+			};
+		}
 	}
 	const lifecycle = session.agentLifecycle?.();
 	try {

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -66,12 +66,14 @@ export function resolveMessageTimeoutMs(settings: Settings, explicit?: number): 
 	return normalizeIrcTimeoutMs(settings.get("irc.timeoutMs"));
 }
 
-/** Session-buffered inbox drain used before parking a bus waiter. */
+/** Drain one session-buffered message, then the exact IrcBus mailbox, without parking a future waiter. */
 export function drainPendingInbox(registry: AgentRegistry, senderId: string, from?: string): IrcMessage | undefined {
 	const session = registry.get(senderId)?.session;
-	return typeof session?.drainPendingIrcInboxMessages === "function"
-		? session.drainPendingIrcInboxMessages(senderId, { from, limit: 1 })[0]
-		: undefined;
+	const sessionPending =
+		typeof session?.drainPendingIrcInboxMessages === "function"
+			? session.drainPendingIrcInboxMessages(senderId, { from, limit: 1 })[0]
+			: undefined;
+	return sessionPending ?? IrcBus.global().takePending(senderId, from);
 }
 
 /** `wait` result carrying a consumed message. */
@@ -123,7 +125,7 @@ export async function executeList(
 			].filter(Boolean);
 			lines.push(`- ${peer.id} [${peer.displayName} · ${peer.kind} · ${peer.status}] — ${extras.join(", ")}`);
 		}
-		if (peers.some(peer => peer.status === "parked")) {
+		if (refs.some(ref => ref.locality === "local" && ref.id !== senderId && ref.status === "parked")) {
 			lines.push("");
 			lines.push("Parked agents are revived automatically when you message them.");
 		}
@@ -162,6 +164,15 @@ export async function executeSend(
 	const isBroadcast = to === "all";
 	if (isBroadcast && params.await) {
 		return hubErrorResult('`await` is invalid with to:"all" — broadcasts have no single replier.', {
+			op: "send",
+			from: senderId,
+			to,
+		});
+	}
+	const directSender = registry.get(senderId);
+	const directRecipient = isBroadcast ? undefined : registry.get(to);
+	if (params.await && (directSender?.locality === "remote" || directRecipient?.locality === "remote")) {
+		return hubErrorResult("Awaited remote peer sends are unavailable without a controller wait transport.", {
 			op: "send",
 			from: senderId,
 			to,
@@ -215,7 +226,11 @@ export async function executeSend(
 					// Awaited sends mark the sender as blocked on an answer so a
 					// busy recipient that cannot reach a step boundary (async
 					// disabled) auto-replies instead of stranding the sender.
-					{ expectsReply: params.await || undefined, suppressRelay: suppressRelay || undefined },
+					{
+						expectsReply: params.await || undefined,
+						suppressRelay: suppressRelay || undefined,
+						signal,
+					},
 				),
 			),
 		);
@@ -297,7 +312,30 @@ export async function executeMessageWait(
 	signal?: AbortSignal,
 ): Promise<AgentToolResult<CoordinationDetails>> {
 	const { registry, senderId, settings } = deps;
+	if (registry.get(senderId)?.locality === "remote") {
+		return hubErrorResult("Remote peer waits require a controller wait transport.", { op: "wait", from: senderId });
+	}
 	const from = params.from?.trim() || undefined;
+	const pending = drainPendingInbox(registry, senderId, from);
+	if (pending) return messageResult(senderId, pending);
+	const fromRef = from ? registry.get(from) : undefined;
+	if (fromRef?.locality === "remote") {
+		return hubErrorResult(`Remote peer "${from}" cannot be waited through the local message bus.`, {
+			op: "wait",
+			from: senderId,
+		});
+	}
+	if (!from) {
+		const visible = registry.listVisibleTo(senderId);
+		const hasLocalRunningPeer = visible.some(ref => ref.locality !== "remote" && registry.isRunning(ref));
+		const hasRemotePeer = visible.some(ref => ref.locality === "remote");
+		if (!hasLocalRunningPeer && hasRemotePeer) {
+			return hubErrorResult("Remote peers cannot satisfy a local bare message wait.", {
+				op: "wait",
+				from: senderId,
+			});
+		}
+	}
 	const timeoutMs = resolveMessageTimeoutMs(settings, params.timeoutMs);
 	try {
 		const waited = await IrcBus.global().wait(senderId, { from }, timeoutMs, signal, {
@@ -326,6 +364,12 @@ export function executeInbox(
 	senderId: string,
 	peek?: boolean,
 ): AgentToolResult<CoordinationDetails> {
+	if (registry.get(senderId)?.locality === "remote") {
+		return hubErrorResult("Remote peer inbox access requires a controller inbox transport.", {
+			op: "inbox",
+			from: senderId,
+		});
+	}
 	const busMessages = IrcBus.global().inbox(senderId, { peek });
 	const session = registry.get(senderId)?.session;
 	const pendingMessages =
@@ -368,6 +412,7 @@ function outcomeColor(outcome: IrcDeliveryReceipt["outcome"]): ToolUIColor {
 		case "revived":
 			return "warning";
 		case "injected":
+		case "remote":
 			return "accent";
 		case "failed":
 			return "error";

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -52,7 +52,7 @@ export interface JobSnapshot {
 	errorText?: string;
 }
 
-export type CancelStatus = "cancelled" | "not_found" | "already_completed";
+export type CancelStatus = "cancelled" | "not_found" | "already_completed" | "failed";
 
 export interface CancelOutcome {
 	id: string;

--- a/packages/coding-agent/test/cli/auth-gateway-policy-socket.test.ts
+++ b/packages/coding-agent/test/cli/auth-gateway-policy-socket.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import * as path from "node:path";
+import {
+	type AuthGatewayAuthorizationRequest,
+	type AuthGatewayObservation,
+	startAuthGateway,
+} from "@oh-my-pi/pi-ai/auth-gateway";
+import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import {
+	createAuthGatewayPolicyReadinessProbe,
+	createAuthGatewayPolicySocketClient,
+	runAuthGatewayCommand,
+	validateAuthGatewayPolicySocketPath,
+} from "../../src/cli/auth-gateway-cli";
+
+type PolicyRequestHandler = (request: unknown, raw: string, socket: net.Socket) => void;
+
+async function createSocketDir(): Promise<string> {
+	return await fs.mkdtemp(path.join("/tmp", "omp-gateway-policy-"));
+}
+
+async function listenPolicyServer(socketPath: string, handler: PolicyRequestHandler): Promise<net.Server> {
+	await fs.rm(socketPath, { force: true });
+	const server = net.createServer(socket => {
+		let bytes = Buffer.alloc(0);
+		socket.on("data", chunk => {
+			bytes = Buffer.concat([bytes, typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk]);
+			const newline = bytes.indexOf(0x0a);
+			if (newline === -1) return;
+			const raw = bytes.subarray(0, newline).toString("utf8");
+			handler(JSON.parse(raw), raw, socket);
+		});
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(socketPath, () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	return server;
+}
+
+async function closePolicyServer(server: net.Server): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		server.close(error => {
+			if (error) reject(error);
+			else resolve();
+		});
+	});
+}
+
+function writeJson(socket: net.Socket, value: unknown): void {
+	socket.write(`${JSON.stringify(value)}\n`);
+}
+
+function authorizationRequest(secret: string): AuthGatewayAuthorizationRequest {
+	return {
+		requestId: "request-1",
+		format: "openai-chat",
+		requestedModelId: "mock/requested",
+		requestedSessionId: "caller-hint",
+		method: "POST",
+		path: "/v1/chat/completions",
+		authorization: secret,
+		signal: new AbortController().signal,
+	};
+}
+
+const OBSERVATION: AuthGatewayObservation = {
+	type: "authorization",
+	requestId: "request-1",
+	format: "openai-chat",
+	requestedModelId: "mock/requested",
+	outcome: "authorized",
+	authorizationId: "authorization-1",
+	resolvedModelId: "mock/resolved",
+	sessionId: "workspace:session",
+};
+
+describe("auth-gateway policy socket", () => {
+	test("uses ordered one-shot authorization and acknowledged secret-free observation exchanges", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		const rawFrames: string[] = [];
+		const types: string[] = [];
+		const server = await listenPolicyServer(socketPath, (value, raw, socket) => {
+			const envelope = value as Record<string, unknown>;
+			rawFrames.push(raw);
+			types.push(String(envelope.type));
+			if (envelope.type === "authorize") {
+				writeJson(socket, {
+					version: 1,
+					type: "authorize_result",
+					decision: {
+						authorized: true,
+						authorizationId: "authorization-1",
+						requestedModelId: "mock/requested",
+						resolvedModelId: "mock/resolved",
+						sessionId: "workspace:session",
+						allowedOAuthCredentialIds: [7, 3],
+					},
+				});
+				return;
+			}
+			if (envelope.type === "observe") {
+				writeJson(socket, { version: 1, type: "observe_ack", ack: true });
+				return;
+			}
+			writeJson(socket, { version: 1, type: "probe_ack", ack: true });
+		});
+
+		try {
+			const secret = "synthetic-one-time-authorization-value";
+			const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 100 });
+			const decision = await client.authorizeRequest(authorizationRequest(secret));
+			expect(decision).toEqual({
+				authorized: true,
+				authorizationId: "authorization-1",
+				requestedModelId: "mock/requested",
+				resolvedModelId: "mock/resolved",
+				sessionId: "workspace:session",
+				allowedOAuthCredentialIds: [7, 3],
+			});
+			await client.observe(OBSERVATION);
+			expect(await client.probe()).toBe(true);
+
+			expect(types).toEqual(["authorize", "observe", "probe"]);
+			expect(JSON.parse(rawFrames[0] ?? "null")).toEqual({
+				version: 1,
+				type: "authorize",
+				request: {
+					requestId: "request-1",
+					format: "openai-chat",
+					requestedModelId: "mock/requested",
+					requestedSessionId: "caller-hint",
+					method: "POST",
+					path: "/v1/chat/completions",
+					authorization: secret,
+				},
+			});
+			expect(rawFrames.slice(1).join("\n")).not.toContain(secret);
+			expect(rawFrames.join("\n").split(secret)).toHaveLength(2);
+		} finally {
+			await closePolicyServer(server);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects unknown decision fields and fails observation delivery without the exact acknowledgement", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		const server = await listenPolicyServer(socketPath, (value, _raw, socket) => {
+			const envelope = value as Record<string, unknown>;
+			if (envelope.type === "authorize") {
+				writeJson(socket, {
+					version: 1,
+					type: "authorize_result",
+					decision: { authorized: false, reasonCode: "denied", unknown: true },
+				});
+				return;
+			}
+			writeJson(socket, { version: 1, type: "observe_ack", ack: false });
+		});
+		try {
+			const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 100 });
+			await expect(client.authorizeRequest(authorizationRequest("one-time-secret"))).rejects.toThrow(
+				"invalid authorization decision",
+			);
+			await expect(client.observe(OBSERVATION)).rejects.toThrow("invalid observation acknowledgement");
+		} finally {
+			await closePolicyServer(server);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects unknown, oversized, malformed, timed-out, EOF, and unavailable responses", async () => {
+		const cases: Array<{
+			name: string;
+			handler?: PolicyRequestHandler;
+			error: string;
+			maxFrameBytes?: number;
+		}> = [
+			{
+				name: "unknown field",
+				handler: (_value, _raw, socket) => {
+					writeJson(socket, { version: 1, type: "probe_ack", ack: true, extra: true });
+				},
+				error: "invalid readiness acknowledgement",
+			},
+			{
+				name: "oversized",
+				handler: (_value, _raw, socket) => {
+					socket.write("x".repeat(128));
+				},
+				error: "exceeds the frame limit",
+				maxFrameBytes: 64,
+			},
+			{
+				name: "malformed",
+				handler: (_value, _raw, socket) => {
+					socket.write("not-json\n");
+				},
+				error: "malformed JSON",
+			},
+			{
+				name: "timeout",
+				handler: () => {},
+				error: "timed out",
+			},
+			{
+				name: "EOF",
+				handler: (_value, _raw, socket) => {
+					socket.end('{"version":1');
+				},
+				error: "closed before a complete response",
+			},
+		];
+
+		for (const testCase of cases) {
+			const dir = await createSocketDir();
+			const socketPath = path.join(dir, "policy.sock");
+			const server = await listenPolicyServer(socketPath, testCase.handler ?? (() => {}));
+			try {
+				const client = createAuthGatewayPolicySocketClient(socketPath, {
+					timeoutMs: 30,
+					...(testCase.maxFrameBytes === undefined ? {} : { maxFrameBytes: testCase.maxFrameBytes }),
+				});
+				await expect(client.probe()).rejects.toThrow(testCase.error);
+			} finally {
+				await closePolicyServer(server);
+				await fs.rm(dir, { recursive: true, force: true });
+			}
+		}
+
+		const dir = await createSocketDir();
+		try {
+			const client = createAuthGatewayPolicySocketClient(path.join(dir, "missing.sock"), { timeoutMs: 30 });
+			await expect(client.probe()).rejects.toThrow("unavailable");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("aborts an in-flight authorization exchange and closes its connection", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		const received = Promise.withResolvers<void>();
+		const connectionClosed = Promise.withResolvers<void>();
+		const server = await listenPolicyServer(socketPath, (_value, _raw, socket) => {
+			socket.once("close", () => connectionClosed.resolve());
+			received.resolve();
+		});
+		try {
+			const controller = new AbortController();
+			const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 1_000 });
+			const pending = client.authorizeRequest({
+				...authorizationRequest("abort-only-secret"),
+				signal: controller.signal,
+			});
+			await received.promise;
+			controller.abort();
+			await expect(pending).rejects.toThrow("exchange aborted");
+			await connectionClosed.promise;
+		} finally {
+			await closePolicyServer(server);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("tracks readiness across malformed acknowledgements, recovery, and outage", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		let now = 0;
+		const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 250 });
+		const gateway = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: [],
+			storage: {} as AuthStorage,
+			resolveModel: () => undefined,
+			authorizeRequest: client.authorizeRequest,
+			observer: client.observe,
+			readinessProbe: createAuthGatewayPolicyReadinessProbe(client, { cacheMs: 250, now: () => now }),
+			version: "policy-test",
+		});
+		let policyServer: net.Server | undefined;
+		try {
+			let response = await fetch(`${gateway.url}/healthz`);
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ ok: false, version: "policy-test" });
+			now = 251;
+
+			let validAck = false;
+			let probeCount = 0;
+			policyServer = await listenPolicyServer(socketPath, (_value, _raw, socket) => {
+				probeCount++;
+				writeJson(
+					socket,
+					validAck
+						? { version: 1, type: "probe_ack", ack: true }
+						: { version: 1, type: "probe_ack", ack: true, unknown: true },
+				);
+			});
+			response = await fetch(`${gateway.url}/healthz`);
+			expect(response.status).toBe(503);
+			expect(probeCount).toBe(1);
+
+			validAck = true;
+			now = 502;
+			const responses = await Promise.all(Array.from({ length: 8 }, () => fetch(`${gateway.url}/healthz`)));
+			expect(responses.every(item => item.status === 200)).toBe(true);
+			response = responses[0]!;
+			expect(probeCount).toBe(2);
+			expect((await fetch(`${gateway.url}/healthz`)).status).toBe(200);
+			expect(probeCount).toBe(2);
+			expect(await response.json()).toEqual({ ok: true, version: "policy-test" });
+			expect((await fetch(`${gateway.url}/v1/models`)).status).toBe(403);
+
+			await closePolicyServer(policyServer);
+			policyServer = undefined;
+		} finally {
+			if (policyServer) await closePolicyServer(policyServer);
+			await gateway.close();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("validates launch-only socket paths and leaves legacy readiness unchanged", async () => {
+		expect(() => validateAuthGatewayPolicySocketPath("")).toThrow("non-empty absolute path");
+		expect(() => validateAuthGatewayPolicySocketPath("relative.sock")).toThrow("non-empty absolute path");
+		expect(() => validateAuthGatewayPolicySocketPath("/tmp/policy\0.sock")).toThrow("without NUL bytes");
+		await expect(
+			runAuthGatewayCommand({ action: "status", flags: { policySocket: "/tmp/policy.sock" } }),
+		).rejects.toThrow("only valid with `auth-gateway serve`");
+
+		const gateway = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: [],
+			storage: {} as AuthStorage,
+			resolveModel: () => undefined,
+			version: "legacy-test",
+		});
+		try {
+			const response = await fetch(`${gateway.url}/healthz`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ ok: true, version: "legacy-test" });
+		} finally {
+			await gateway.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/registry/remote-agent-registry.test.ts
+++ b/packages/coding-agent/test/registry/remote-agent-registry.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import {
+	AgentRegistry,
+	type RemoteAgentIdentity,
+	type RemoteRegistryBackend,
+} from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { executeCancel } from "@oh-my-pi/pi-coding-agent/tools/hub/jobs";
+
+const IDENTITY: RemoteAgentIdentity = {
+	controllerId: "controller-a",
+	executionId: "execution-a",
+	generation: 7,
+};
+
+function backend(overrides: Partial<RemoteRegistryBackend> = {}): RemoteRegistryBackend {
+	return {
+		status: async identity => ({ identity: { ...identity }, value: "running" }),
+		progress: async identity => ({ identity: { ...identity }, value: { sequence: 1, message: "working" } }),
+		cancel: async identity => ({ identity: { ...identity }, value: "cancelled" }),
+		result: async identity => ({ identity: { ...identity }, value: { outcome: "completed", output: "done" } }),
+		...overrides,
+	};
+}
+
+function registerRemote(registry: AgentRegistry, id = "RemoteChild"): void {
+	registry.registerRemote({
+		id,
+		displayName: "remote child",
+		kind: "sub",
+		parentId: "Main",
+		status: "running",
+		identity: IDENTITY,
+	});
+}
+function cancelHarness(registry: AgentRegistry): { session: ToolSession; manager: AsyncJobManager } {
+	const session: ToolSession = {
+		cwd: "/tmp",
+		hasUI: false,
+		settings: Settings.isolated(),
+		agentRegistry: registry,
+		getAgentId: () => "Main",
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+	};
+	const manager = {
+		getJob: () => undefined,
+		getAllJobs: () => [],
+		getRunningJobs: () => [],
+		cancel: () => false,
+		acknowledgeDeliveries: () => {},
+	} as unknown as AsyncJobManager;
+	return { session, manager };
+}
+
+describe("remote agent registry", () => {
+	it("keeps existing local registrations local and generation-bound", () => {
+		const registry = new AgentRegistry();
+		const first = registry.register({ id: "Local", displayName: "local", kind: "sub", session: null });
+		const second = registry.register({ id: "Local", displayName: "local", kind: "sub", session: null });
+
+		expect(first.locality).toBe("local");
+		expect(second.locality).toBe("local");
+		expect(second.generation).toBe(first.generation + 1);
+	});
+
+	it("rejects local/remote overlap and never admits a remote ref to local revival", async () => {
+		const registry = new AgentRegistry({ remoteBackend: backend() });
+		registerRemote(registry);
+		const lifecycle = new AgentLifecycleManager(registry);
+		const revive = vi.fn(async () => {
+			throw new Error("must not run");
+		});
+
+		lifecycle.adopt("RemoteChild", { idleTtlMs: 0, revive });
+		expect(lifecycle.has("RemoteChild")).toBe(false);
+		expect(registry.attachSession("RemoteChild", {} as never)).toBe(false);
+		await expect(lifecycle.ensureLive("RemoteChild")).rejects.toThrow("cannot be resumed");
+		expect(revive).not.toHaveBeenCalled();
+		expect(() => registry.register({ id: "RemoteChild", displayName: "local", kind: "sub", session: null })).toThrow(
+			/cannot register local agent/i,
+		);
+	});
+
+	it("applies only exact-generation controller status and monotonic progress", async () => {
+		let progressSequence = 2;
+		const registry = new AgentRegistry({
+			remoteBackend: backend({
+				status: async identity => ({ identity: { ...identity }, value: "idle" }),
+				progress: async identity => ({
+					identity: { ...identity },
+					value: { sequence: progressSequence, message: "controller progress" },
+				}),
+			}),
+		});
+		registerRemote(registry);
+
+		const refreshed = await registry.refreshRemote("RemoteChild");
+		expect(refreshed.status).toBe("idle");
+		expect(registry.setStatus("RemoteChild", "running")).toBe(false);
+
+		progressSequence = 1;
+		await expect(registry.refreshRemote("RemoteChild")).rejects.toThrow("stale sequence");
+	});
+
+	it("fails closed for missing backends, stale generations, outages, and malformed results", async () => {
+		const missing = new AgentRegistry();
+		registerRemote(missing);
+		await expect(missing.refreshRemote("RemoteChild")).rejects.toThrow("backend is unavailable");
+
+		const stale = new AgentRegistry({
+			remoteBackend: backend({
+				status: async identity => ({
+					identity: { ...identity, generation: identity.generation + 1 },
+					value: "idle",
+				}),
+			}),
+		});
+		registerRemote(stale);
+		await expect(stale.refreshRemote("RemoteChild")).rejects.toThrow("stale or malformed identity");
+
+		const outage = new AgentRegistry({
+			remoteBackend: backend({ status: async () => Promise.reject(new Error("controller offline")) }),
+		});
+		registerRemote(outage);
+		await expect(outage.refreshRemote("RemoteChild")).rejects.toThrow("controller offline");
+
+		const malformed = new AgentRegistry({
+			remoteBackend: backend({
+				result: async identity => ({ identity: { ...identity }, value: { outcome: "failed" } as never }),
+			}),
+		});
+		registerRemote(malformed);
+		await expect(malformed.resultRemote("RemoteChild")).rejects.toThrow("malformed value");
+	});
+
+	it("installs one global backend closure idempotently and rejects replacement", () => {
+		AgentRegistry.resetGlobalForTests();
+		try {
+			const first = backend();
+			AgentRegistry.installGlobalRemoteBackend(first);
+			expect(() => AgentRegistry.installGlobalRemoteBackend(first)).not.toThrow();
+			expect(() => AgentRegistry.installGlobalRemoteBackend(backend())).toThrow("already installed");
+		} finally {
+			AgentRegistry.resetGlobalForTests();
+		}
+	});
+
+	it("makes controller identity fields runtime-immutable and uniquely indexed", () => {
+		const registry = new AgentRegistry({ remoteBackend: backend() });
+		const ref = registry.registerRemote({
+			id: "RemoteChild",
+			displayName: "remote child",
+			kind: "sub",
+			status: "running",
+			identity: IDENTITY,
+		});
+
+		expect(Reflect.set(ref, "generation", 99)).toBe(false);
+		expect(Reflect.set(ref, "remote", { ...IDENTITY, executionId: "other" })).toBe(false);
+		expect(Reflect.set(ref, "id", "Alias")).toBe(false);
+		expect(Reflect.set(ref, "locality", "local")).toBe(false);
+		expect(Reflect.set(ref, "session", {})).toBe(false);
+		expect(Reflect.set(ref, "sessionFile", "/tmp/local.jsonl")).toBe(false);
+		expect(ref.generation).toBe(IDENTITY.generation);
+		expect(ref.remote).toEqual(IDENTITY);
+		expect(ref.id).toBe("RemoteChild");
+		expect(ref.locality).toBe("remote");
+		expect(ref.session).toBeNull();
+		expect(ref.sessionFile).toBeNull();
+		expect(() =>
+			registry.registerRemote({
+				id: "Alias",
+				displayName: "alias",
+				kind: "sub",
+				status: "running",
+				identity: { ...IDENTITY },
+			}),
+		).toThrow("already registered");
+	});
+
+	it("accepts identical progress replay, rejects conflicting duplicates, and clears identity watermarks on removal", async () => {
+		let sequence = 2;
+		let message = "same";
+		const registry = new AgentRegistry({
+			remoteBackend: backend({
+				progress: async identity => ({ identity: { ...identity }, value: { sequence, message } }),
+			}),
+		});
+		registerRemote(registry);
+		await registry.refreshRemote("RemoteChild");
+		await registry.refreshRemote("RemoteChild");
+
+		message = "conflict";
+		await expect(registry.refreshRemote("RemoteChild")).rejects.toThrow("conflicting duplicate");
+
+		const ref = registry.get("RemoteChild");
+		expect(ref).toBeDefined();
+		registry.unregister("RemoteChild", ref);
+		sequence = 0;
+		message = "new registration";
+		registerRemote(registry, "Replacement");
+		await expect(registry.refreshRemote("Replacement")).resolves.toMatchObject({ id: "Replacement" });
+	});
+
+	it("routes hub cancellation through the remote backend without local abort, dispose, or lifecycle release", async () => {
+		const cancel = vi.fn(async (identity: Readonly<RemoteAgentIdentity>) => ({
+			identity: { ...identity },
+			value: "cancelled" as const,
+		}));
+		const registry = new AgentRegistry({ remoteBackend: backend({ cancel }) });
+		registerRemote(registry);
+		const lifecycle = new AgentLifecycleManager(registry);
+		const release = vi.spyOn(lifecycle, "release");
+		const session: ToolSession = {
+			cwd: "/tmp",
+			hasUI: false,
+			settings: Settings.isolated(),
+			agentRegistry: registry,
+			getAgentId: () => "Main",
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			agentLifecycle: () => lifecycle,
+		};
+		const manager = {
+			getJob: () => undefined,
+			getAllJobs: () => [],
+			getRunningJobs: () => [],
+			cancel: () => false,
+			acknowledgeDeliveries: () => {},
+		} as unknown as AsyncJobManager;
+
+		const result = await executeCancel(session, manager, "Main", ["RemoteChild"]);
+
+		expect(result.details?.cancelled).toEqual([{ id: "RemoteChild", status: "cancelled" }]);
+		expect(cancel).toHaveBeenCalledTimes(1);
+		expect(release).not.toHaveBeenCalled();
+		expect(registry.get("RemoteChild")?.status).toBe("aborted");
+	});
+	it("surfaces remote cancellation rejection and deadline expiry as failed hub results", async () => {
+		const rejectedRegistry = new AgentRegistry({
+			remoteBackend: backend({ cancel: async () => Promise.reject(new Error("controller rejected")) }),
+		});
+		registerRemote(rejectedRegistry);
+		const rejectedHarness = cancelHarness(rejectedRegistry);
+		const rejected = await executeCancel(rejectedHarness.session, rejectedHarness.manager, "Main", ["RemoteChild"]);
+		expect(rejected.isError).toBe(true);
+		expect(rejected.details?.cancelled).toEqual([{ id: "RemoteChild", status: "failed" }]);
+		expect(rejectedRegistry.get("RemoteChild")?.status).toBe("running");
+
+		vi.useFakeTimers();
+		try {
+			const hangingRegistry = new AgentRegistry({
+				remoteBackend: backend({
+					cancel: async () => Promise.withResolvers<never>().promise,
+				}),
+			});
+			registerRemote(hangingRegistry);
+			const hangingHarness = cancelHarness(hangingRegistry);
+			const timedOut = executeCancel(hangingHarness.session, hangingHarness.manager, "Main", ["RemoteChild"]);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			vi.advanceTimersByTime(5_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			const result = await timedOut;
+			expect(result.isError).toBe(true);
+			expect(result.details?.cancelled).toEqual([{ id: "RemoteChild", status: "failed" }]);
+			expect(result.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("timed out") });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -15,8 +15,10 @@ import {
 	buildStructuredSubagentRecoveryHint,
 	resolveEffectiveSubagentPolicy,
 	runStructuredSubagent,
+	type StructuredSubagentBackendContext,
 	StructuredSubagentError,
 	type StructuredSubagentRequest,
+	type StructuredSubagentResult,
 } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
 import type { AgentDefinition, SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
@@ -81,6 +83,33 @@ function result(): SingleResult {
 		durationMs: 1,
 		tokens: 0,
 		requests: 1,
+	};
+}
+
+function remoteResult(context: StructuredSubagentBackendContext): StructuredSubagentResult {
+	const completed = result();
+	completed.id = context.request.identity?.id ?? completed.id;
+	completed.index = context.request.index ?? 0;
+	completed.agent = context.policy.agent.name;
+	completed.agentSource = context.policy.agent.source;
+	completed.task = context.request.assignment;
+	completed.assignment = context.request.assignment;
+	completed.output = '{"agent":true}';
+	if (context.outputSchema.source !== "none") {
+		completed.structuredOutput = {
+			source: context.outputSchema.source,
+			mode: context.outputSchema.mode,
+			status: "valid",
+			data: { agent: true },
+		};
+	}
+	return {
+		result: completed,
+		policy: context.policy,
+		mergeSummary: "",
+		changesApplied: null,
+		artifactsDir: "remote-artifacts",
+		temporaryArtifacts: false,
 	};
 }
 
@@ -271,6 +300,254 @@ describe("structured subagent primitive", () => {
 		expect(settled.policy.modelRole).toBeUndefined();
 		expect(dispatched[0]?.modelRole).toBeUndefined();
 		expect(settled.result.modelRole).toBeUndefined();
+		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
+	});
+
+	it("dispatches remote execution after normalization without touching local artifacts, leases, or executors", async () => {
+		const order: string[] = [];
+		vi.spyOn(discoveryModule, "discoverAgents").mockImplementation(async () => {
+			order.push("discovery");
+			return { agents: [AGENT], projectAgentsDir: null };
+		});
+		const mkdir = vi.spyOn(fs, "mkdir");
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+		const prepareIsolation = vi.spyOn(isolationRunner, "prepareIsolationContext");
+		const loadPlan = vi.spyOn(planHandoff, "loadOverallPlanReference");
+		const childSession = session();
+		let sessionFileCalls = 0;
+		childSession.getSessionFile = () => {
+			sessionFileCalls++;
+			return null;
+		};
+		let received: StructuredSubagentBackendContext | undefined;
+		const schema = {
+			type: "object",
+			properties: { agent: { type: "boolean" } },
+			required: ["agent"],
+			additionalProperties: false,
+		};
+		const backend = {
+			run: async (context: StructuredSubagentBackendContext) => {
+				order.push("remote");
+				received = context;
+				return remoteResult(context);
+			},
+		};
+
+		const settled = await runStructuredSubagent(
+			request({
+				session: childSession,
+				assignment: "  Inspect the target.  ",
+				context: "  Shared context.  ",
+				agent: " worker ",
+				outputSchema: schema,
+				schemaMode: "strict",
+				identity: { label: "  Remote Worker  " },
+			}),
+			{ execution: "remote", backend },
+		);
+
+		expect(order).toEqual(["discovery", "remote"]);
+		expect(received?.request).toMatchObject({
+			assignment: "Inspect the target.",
+			context: "Shared context.",
+			agent: "worker",
+			schemaMode: "strict",
+			identity: { label: "Remote Worker" },
+			index: 0,
+			isolation: { requested: false, merge: "patch", apply: true },
+		});
+		expect(received?.outputSchema).toBe(received?.policy.schema);
+		expect(received?.outputSchema.schema).toBe(schema);
+		expect(settled.result.structuredOutput).toMatchObject({ status: "valid", data: { agent: true } });
+		expect(sessionFileCalls).toBe(0);
+		expect(childSession.agentOutputManager).toBeUndefined();
+		expect(mkdir).not.toHaveBeenCalled();
+		expect(loadPlan).not.toHaveBeenCalled();
+		expect(prepareIsolation).not.toHaveBeenCalled();
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("does not dispatch the remote backend when effective-schema preflight rejects", async () => {
+		mockDiscovery();
+		const remoteRun = vi.fn(async (context: StructuredSubagentBackendContext) => remoteResult(context));
+
+		await expect(
+			runStructuredSubagent(request({ outputSchema: false, schemaMode: "strict" }), {
+				execution: "remote",
+				backend: { run: remoteRun },
+			}),
+		).rejects.toThrow("Invalid strict caller output schema");
+
+		expect(remoteRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("fails closed when remote execution is selected without a backend", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+
+		const settled = await runStructuredSubagent(request(), { execution: "remote" });
+
+		expect(settled.result).toMatchObject({
+			exitCode: 1,
+			error: "Remote structured subagent backend is unavailable.",
+		});
+		expect(settled.temporaryArtifacts).toBe(false);
+		expect(settled.artifactsDir).toBe("");
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("converts a rejected remote execution into an error result without local fallback", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+		const backend = {
+			run: async () => {
+				throw new Error("remote unavailable");
+			},
+		};
+
+		const settled = await runStructuredSubagent(request(), { execution: "remote", backend });
+
+		expect(settled.result).toMatchObject({
+			exitCode: 1,
+			error: "Remote structured subagent execution failed: remote unavailable",
+		});
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("propagates cancellation to the remote backend and settles as aborted", async () => {
+		mockDiscovery();
+		const controller = new AbortController();
+		const started = Promise.withResolvers<void>();
+		const pending = Promise.withResolvers<StructuredSubagentResult>();
+		let receivedSignal: AbortSignal | undefined;
+		const backend = {
+			run: (context: StructuredSubagentBackendContext) => {
+				receivedSignal = context.signal;
+				started.resolve();
+				return pending.promise;
+			},
+		};
+
+		const execution = runStructuredSubagent(request({ signal: controller.signal }), {
+			execution: "remote",
+			backend,
+		});
+		await started.promise;
+		controller.abort(new Error("remote cancellation"));
+		const settled = await execution;
+
+		expect(receivedSignal).toBe(controller.signal);
+		expect(settled.result).toMatchObject({
+			exitCode: 1,
+			aborted: true,
+			abortReason: "remote cancellation",
+			error: "remote cancellation",
+		});
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("fails closed on a malformed remote result without local fallback", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+		const backend = {
+			run: async (context: StructuredSubagentBackendContext) => {
+				const malformed = remoteResult(context);
+				malformed.result.structuredOutput = {
+					source: context.outputSchema.source,
+					mode: context.outputSchema.mode,
+					status: "valid",
+					data: { agent: "not-a-boolean" },
+				};
+				return malformed;
+			},
+		};
+
+		const settled = await runStructuredSubagent(request(), { execution: "remote", backend });
+
+		expect(settled.result.exitCode).toBe(1);
+		expect(settled.result.error).toContain("Remote structured subagent backend returned a malformed result");
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("fails closed when a remote result changes a preallocated agent id", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const backend = {
+			run: async (context: StructuredSubagentBackendContext) => {
+				const mismatched = remoteResult(context);
+				mismatched.result.id = "DifferentAgent";
+				return mismatched;
+			},
+		};
+
+		const settled = await runStructuredSubagent(request({ identity: { id: "ReservedAgent" } }), {
+			execution: "remote",
+			backend,
+		});
+
+		expect(settled.result.exitCode).toBe(1);
+		expect(settled.result.error).toContain("result id does not match the normalized preallocated id");
+		expect(localRun).not.toHaveBeenCalled();
+	});
+
+	it("rejects successful strict invalid and unavailable remote schema results", async () => {
+		mockDiscovery();
+		for (const status of ["invalid", "unavailable"] as const) {
+			const backend = {
+				run: async (context: StructuredSubagentBackendContext) => {
+					const malformed = remoteResult(context);
+					malformed.result.exitCode = 0;
+					malformed.result.stderr = "";
+					malformed.result.structuredOutput = {
+						source: context.outputSchema.source,
+						mode: "strict",
+						status,
+						error: `${status} schema result`,
+					};
+					return malformed;
+				},
+			};
+
+			const settled = await runStructuredSubagent(request({ schemaMode: "strict" }), {
+				execution: "remote",
+				backend,
+			});
+
+			expect(settled.result.exitCode).toBe(1);
+			expect(settled.result.error).toContain(
+				"strict invalid or unavailable structuredOutput must be a failed schema_violation",
+			);
+		}
+	});
+
+	it("keeps explicit local execution on the native executor when a backend is injected", async () => {
+		mockDiscovery();
+		const remoteRun = vi.fn(async (context: StructuredSubagentBackendContext) => remoteResult(context));
+		const localRun = vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(result());
+
+		const settled = await runStructuredSubagent(request({ retainArtifacts: true }), {
+			execution: "local",
+			backend: { run: remoteRun },
+		});
+
+		expect(localRun).toHaveBeenCalledTimes(1);
+		expect(remoteRun).not.toHaveBeenCalled();
+		expect(settled.temporaryArtifacts).toBe(true);
+		expect(path.basename(settled.artifactsDir)).toStartWith("omp-task-");
 		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
 	});
 

--- a/packages/coding-agent/test/tools/remote-peer-transport.test.ts
+++ b/packages/coding-agent/test/tools/remote-peer-transport.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	IrcBus,
+	type IrcMessage,
+	type PeerTransportBackend,
+	type PeerTransportDelivery,
+	type PeerTransportResult,
+} from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { executeMessageWait } from "@oh-my-pi/pi-coding-agent/tools/hub/messaging";
+
+function localSession() {
+	const delivered: IrcMessage[] = [];
+	const session = {
+		isStreaming: true,
+		deliverIrcMessage: async (message: IrcMessage) => {
+			delivered.push(message);
+			return "injected" as const;
+		},
+	} as unknown as AgentSession;
+	return { session, delivered };
+}
+
+function registerRemote(registry: AgentRegistry, id: string, executionId = id): void {
+	registry.registerRemote({
+		id,
+		displayName: id,
+		kind: "sub",
+		parentId: "Main",
+		status: "running",
+		identity: { controllerId: "controller", executionId, generation: 3 },
+	});
+}
+
+function accepted(delivery: PeerTransportDelivery): PeerTransportResult {
+	return {
+		deliveryId: delivery.deliveryId,
+		sequence: delivery.sequence,
+		sender: delivery.sender,
+		recipient: delivery.recipient,
+		outcome: "accepted",
+	};
+}
+
+describe("remote peer transport", () => {
+	it("leaves local-local delivery on the in-process bus", async () => {
+		const registry = new AgentRegistry();
+		const recipient = localSession();
+		registry.register({ id: "Local", displayName: "local", kind: "sub", session: recipient.session });
+		const transport: PeerTransportBackend = {
+			deliver: vi.fn(async () => {
+				throw new Error("transport must not run");
+			}),
+			cancel: vi.fn(async () => {}),
+		};
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), transport);
+
+		const receipt = await bus.send({ from: "Main", to: "Local", body: "local message" });
+
+		expect(receipt).toEqual({ to: "Local", outcome: "injected" });
+		expect(recipient.delivered.map(message => message.body)).toEqual(["local message"]);
+		expect(transport.deliver).not.toHaveBeenCalled();
+	});
+
+	it("routes remote recipients and senders with exact immutable identities and monotonic metadata", async () => {
+		const registry = new AgentRegistry();
+		const local = localSession();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: local.session });
+		registerRemote(registry, "RemoteA", "exec-a");
+		const deliveries: PeerTransportDelivery[] = [];
+		const transport: PeerTransportBackend = {
+			deliver: vi.fn(async delivery => {
+				deliveries.push(delivery);
+				return accepted(delivery);
+			}),
+			cancel: vi.fn(async () => {}),
+		};
+		const lifecycle = new AgentLifecycleManager(registry);
+		const ensureLive = vi.spyOn(lifecycle, "ensureLive");
+		const bus = new IrcBus(registry, lifecycle, transport);
+
+		const outbound = await bus.send({
+			from: "Main",
+			to: "RemoteA",
+			body: "remote message",
+			replyTo: "prior-id",
+			endpoint: "https://attacker.invalid",
+			capability: "admin",
+		} as Omit<IrcMessage, "id" | "ts">);
+		const outboundAgain = await bus.send({ from: "Main", to: "RemoteA", body: "second remote message" });
+		const inbound = await bus.send({ from: "RemoteA", to: "Main", body: "remote sender" });
+
+		expect(outbound.outcome).toBe("remote");
+		expect(outboundAgain.outcome).toBe("remote");
+		expect(inbound.outcome).toBe("remote");
+		expect(deliveries.map(delivery => delivery.sequence)).toEqual([1, 2, 1]);
+		expect(deliveries[0]?.sender).toMatchObject({ locality: "local", agentId: "Main", generation: 1 });
+		expect(deliveries[0]?.recipient).toEqual({
+			locality: "remote",
+			agentId: "RemoteA",
+			controllerId: "controller",
+			executionId: "exec-a",
+			generation: 3,
+		});
+		expect(deliveries[0]?.payload).toEqual({ body: "remote message", replyTo: "prior-id" });
+		expect(Object.keys(deliveries[0]?.payload ?? {}).sort()).toEqual(["body", "replyTo"]);
+		expect(local.delivered).toHaveLength(0);
+		expect(bus.unreadCount("Main")).toBe(0);
+		expect(bus.unreadCount("RemoteA")).toBe(0);
+		expect(ensureLive).not.toHaveBeenCalled();
+	});
+
+	it("keeps transport sequences separate for tuple identities that collide under colon concatenation", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registry.registerRemote({
+			id: "RemoteOne",
+			displayName: "one",
+			kind: "sub",
+			status: "running",
+			identity: { controllerId: "a:b", executionId: "c", generation: 3 },
+		});
+		registry.registerRemote({
+			id: "RemoteTwo",
+			displayName: "two",
+			kind: "sub",
+			status: "running",
+			identity: { controllerId: "a", executionId: "b:c", generation: 3 },
+		});
+		const deliveries: PeerTransportDelivery[] = [];
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), {
+			deliver: async delivery => {
+				deliveries.push(delivery);
+				return accepted(delivery);
+			},
+			cancel: async () => {},
+		});
+
+		await bus.send({ from: "RemoteOne", to: "Main", body: "one" });
+		await bus.send({ from: "RemoteTwo", to: "Main", body: "two" });
+
+		expect(deliveries.map(delivery => delivery.sequence)).toEqual([1, 1]);
+	});
+
+	it("fails closed on stale, malformed, duplicate, conflicting, unknown, and unavailable delivery outcomes", async () => {
+		const outcomes: Array<"stale" | "malformed" | "duplicate" | "conflict" | "outage"> = [
+			"stale",
+			"malformed",
+			"duplicate",
+			"conflict",
+			"outage",
+		];
+		for (const outcome of outcomes) {
+			const registry = new AgentRegistry();
+			registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+			registerRemote(registry, "Remote");
+			const transport: PeerTransportBackend = {
+				deliver: async delivery => {
+					if (outcome === "outage") throw new Error("offline");
+					if (outcome === "malformed") return { deliveryId: delivery.deliveryId } as never;
+					if (outcome === "stale") {
+						return {
+							...accepted(delivery),
+							recipient: { ...delivery.recipient, generation: delivery.recipient.generation + 1 },
+						};
+					}
+					return { ...accepted(delivery), outcome };
+				},
+				cancel: async () => {},
+			};
+			const bus = new IrcBus(registry, new AgentLifecycleManager(registry), transport);
+			const receipt = await bus.send({ from: "Main", to: "Remote", body: "message" });
+			expect(receipt.outcome).toBe("failed");
+			expect(bus.unreadCount("Remote")).toBe(0);
+		}
+
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		const deliver = vi.fn(async (delivery: PeerTransportDelivery) => accepted(delivery));
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), { deliver, cancel: async () => {} });
+		const unknown = await bus.send({ from: "Main", to: "Missing", body: "message" });
+		expect(unknown.outcome).toBe("failed");
+		expect(deliver).not.toHaveBeenCalled();
+
+		registerRemote(registry, "Remote");
+		const unavailable = new IrcBus(registry, new AgentLifecycleManager(registry));
+		expect((await unavailable.send({ from: "Main", to: "Remote", body: "message" })).outcome).toBe("failed");
+	});
+
+	it("installs one global peer transport closure idempotently and rejects replacement", () => {
+		IrcBus.resetGlobalForTests();
+		try {
+			const first: PeerTransportBackend = {
+				deliver: async delivery => accepted(delivery),
+				cancel: async () => {},
+			};
+			IrcBus.installGlobalPeerTransport(first);
+			expect(() => IrcBus.installGlobalPeerTransport(first)).not.toThrow();
+			expect(() =>
+				IrcBus.installGlobalPeerTransport({
+					deliver: async delivery => accepted(delivery),
+					cancel: async () => {},
+				}),
+			).toThrow("already installed");
+		} finally {
+			IrcBus.resetGlobalForTests();
+		}
+	});
+
+	it("rejects filtered and bare remote waits before creating a local bus waiter", async () => {
+		IrcBus.resetGlobalForTests();
+		try {
+			const registry = new AgentRegistry();
+			registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+			registerRemote(registry, "Remote");
+			const wait = vi.spyOn(IrcBus.global(), "wait");
+			const deps = { registry, senderId: "Main", settings: Settings.isolated() };
+
+			const filtered = await executeMessageWait(deps, { from: "Remote", timeoutMs: 0 });
+			const bare = await executeMessageWait(deps, { timeoutMs: 0 });
+
+			expect(filtered.isError).toBe(true);
+			expect(bare.isError).toBe(true);
+			expect(wait).not.toHaveBeenCalled();
+		} finally {
+			IrcBus.resetGlobalForTests();
+		}
+	});
+
+	it("drains buffered IrcBus mail before rejecting a remote-only future wait", async () => {
+		AgentRegistry.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+		try {
+			const registry = AgentRegistry.global();
+			const mainSession = {
+				isStreaming: false,
+				deliverIrcMessage: async () => {
+					throw new Error("buffer directly in IrcBus mailbox");
+				},
+			} as unknown as AgentSession;
+			registry.register({ id: "Main", displayName: "main", kind: "main", session: mainSession });
+			registerRemote(registry, "Remote");
+			const bus = IrcBus.global();
+			const wait = vi.spyOn(bus, "wait");
+			const deps = { registry, senderId: "Main", settings: Settings.isolated() };
+
+			const failedDelivery = await bus.send({ from: "LegacyLocal", to: "Main", body: "already on bus" });
+			expect(failedDelivery.outcome).toBe("failed");
+			expect(bus.unreadCount("Main")).toBe(1);
+
+			const fromBus = await executeMessageWait(deps, { timeoutMs: 0 });
+
+			expect(fromBus.details?.waited?.body).toBe("already on bus");
+			expect(bus.unreadCount("Main")).toBe(0);
+			expect(wait).not.toHaveBeenCalled();
+		} finally {
+			IrcBus.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+		}
+	});
+
+	it("routes abort cancellation to the same remote delivery identity", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registerRemote(registry, "Remote");
+		const pending = Promise.withResolvers<PeerTransportResult>();
+		let captured: PeerTransportDelivery | undefined;
+		const cancel = vi.fn(async (_delivery: Readonly<PeerTransportDelivery>) => {});
+		const transport: PeerTransportBackend = {
+			deliver: async delivery => {
+				captured = delivery;
+				return pending.promise;
+			},
+			cancel,
+		};
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), transport);
+		const controller = new AbortController();
+		const sending = bus.send({ from: "Main", to: "Remote", body: "cancel me" }, { signal: controller.signal });
+		await Promise.resolve();
+		controller.abort(new Error("stop"));
+		await Promise.resolve();
+		expect(cancel).toHaveBeenCalledWith(captured);
+		if (!captured) throw new Error("delivery was not captured");
+		pending.resolve(accepted(captured));
+		expect((await sending).outcome).toBe("remote");
+	});
+});


### PR DESCRIPTION
## Problem

Sandboxed OMP executions need provider access and structured child execution without inheriting unrestricted local credential or subprocess authority. Existing OAuth selection can choose rows before an external policy decision, and structured subagents have no strict remote-only backend.

## Changes

- Add auth-gateway authorization and observation hooks before credential lookup or provider calls.
- Constrain retries and failover to exact authorized OAuth credential row IDs.
- Strip account-routing headers and namespace session/cache identity at the gateway boundary.
- Add a fail-closed Unix policy socket with readiness gating.
- Add a remote structured-subagent backend with no local fallback.
- Add immutable remote registry snapshots and bounded peer-transport hooks.
- Preserve existing behavior when the new hooks are not configured.

## Verification

- 215 relevant tests passed; 0 failed.
- 4 explicit environment-dependent end-to-end tests skipped.
- Final affected-package checks passed.
- Independent security and correctness reviews approved the final bytes.

This PR does not deploy services, configure credentials, or change a default runtime topology.