### PR TITLE
feat(tui): main-view drag-select copy and composer click-to-caret

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Settings menus now support click-to-toggle and drag-to-reorder for list items, as well as warning indicators and risk notes on sensitive options such as External Thinking.
 - Supervised process completion notices now render as compact single-line entries.
 - The todo HUD header now displays a consolidated progress bar showing task completion across all stages.
+- `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
 ### Fixed
 
@@ -53,6 +54,10 @@
 - Fixed prompt guidance and descriptions for Task tools and SSH usage.
 - ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+- Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
+- Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
+- Enabled main-view drag-select copy through the existing clipboard helper, with a status-line confirmation.
+- Added `tui.mainTextSelection` (default on) so that can be turned off, restoring native click-drag select and unshifted wheel.
 
 ## [17.4.0] - 2026-08-20
 
@@ -91,12 +96,6 @@
 - Cancelled prompts during pre-stream turn setup restore the text and image attachments to the editor.
 - `top` builtin accepts single-dash macOS flags such as `-pid` and `-stats`.
 - GNU/BSD compat sweep across built-in shell utilities (`timeout`, `diff`, `find`, `date`, `tail`, `head`, `rg`, `stat`, `truncate`, `cksum`, `sleep`, `which`, `nohup`, `kill`).
-- Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
-- Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
-
-### Changed
-
-- `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
 ## [17.3.8] - 2026-08-19
 
@@ -179,9 +178,6 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
-- Enabled main-view drag-select copy through the existing clipboard helper, with a status-line confirmation.
-- Added `tui.mainTextSelection` (default on) so that can be turned off, restoring native click-drag select and unshifted wheel.
-
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -179,6 +179,8 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
+- Enabled main-view drag-select copy through the existing clipboard helper, with a status-line confirmation.
+
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -180,6 +180,7 @@
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
 - Enabled main-view drag-select copy through the existing clipboard helper, with a status-line confirmation.
+- Added `tui.mainTextSelection` (default on) so that can be turned off, restoring native click-drag select and unshifted wheel.
 
 
 ## [17.3.5] - 2026-08-16

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1096,6 +1096,17 @@ export const SETTINGS_SCHEMA = {
 			description: "Remove the 1-character horizontal padding from the left and right of the terminal output",
 		},
 	},
+	"tui.mainTextSelection": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Main-view drag-select copy",
+			description:
+				"Drag-select transcript text to copy, and click in the composer to place the caret. Turns on mouse tracking, so native click-drag select and unshifted wheel need Shift or this setting off. Selection covers only the visible window.",
+		},
+	},
 	"tui.scrollbackRebuild": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -585,6 +585,21 @@ export class SelectorController {
 				this.ctx.ui.setScrollbackRebuild(value as boolean);
 				break;
 
+			case "tui.mainTextSelection":
+				if (value) {
+					this.ctx.ui.enableMainTextSelection(async text => {
+						try {
+							await copyToClipboard(text);
+							this.ctx.showStatus("Copied!");
+						} catch (error) {
+							this.ctx.showWarning(`Copy failed: ${error instanceof Error ? error.message : String(error)}`);
+						}
+					});
+				} else {
+					this.ctx.ui.disableMainTextSelection();
+				}
+				break;
+
 			case "tui.renderMermaid":
 				setMarkdownMermaidRendering(value as boolean);
 				this.ctx.session.refreshBaseSystemPrompt().catch(err => {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -813,6 +813,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setMaxInlineImages(settings.get("tui.maxInlineImages"));
 		this.ui.setScrollbackRebuild(settings.get("tui.scrollbackRebuild"));
+		this.ui.enableMainTextSelection(async text => {
+			try {
+				await copyToClipboard(text);
+				this.showStatus("Copied!");
+			} catch (error) {
+				this.showWarning(`Copy failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		});
 		// OSC 66 text-sizing is Kitty-only; resolve the setting against the terminal's
 		// capability (`TERMINAL.textSizing` defaults on for Kitty) so it stays off
 		// unless the user opts in, and never emits raw escapes on other terminals.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -813,14 +813,16 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setMaxInlineImages(settings.get("tui.maxInlineImages"));
 		this.ui.setScrollbackRebuild(settings.get("tui.scrollbackRebuild"));
-		this.ui.enableMainTextSelection(async text => {
-			try {
-				await copyToClipboard(text);
-				this.showStatus("Copied!");
-			} catch (error) {
-				this.showWarning(`Copy failed: ${error instanceof Error ? error.message : String(error)}`);
-			}
-		});
+		if (settings.get("tui.mainTextSelection")) {
+			this.ui.enableMainTextSelection(async text => {
+				try {
+					await copyToClipboard(text);
+					this.showStatus("Copied!");
+				} catch (error) {
+					this.showWarning(`Copy failed: ${error instanceof Error ? error.message : String(error)}`);
+				}
+			});
+		}
 		// OSC 66 text-sizing is Kitty-only; resolve the setting against the terminal's
 		// capability (`TERMINAL.textSizing` defaults on for Kitty) so it stays off
 		// unless the user opts in, and never emits raw escapes on other terminals.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed images rendering as the `[Image: …]` text card on SIXEL terminals that expose no identifying environment variable (foot, xterm, contour): the graphics probe no longer requires Windows Terminal, and no longer reads an XTSMGRAPHICS success reply as a failure.
 - Fixed the multiline editor ignoring a `tui.input.submit` remap onto Ctrl+Enter: the hardcoded Ctrl/Shift+Enter → newline fallbacks now yield to an explicit submit binding, so Ctrl+Enter can be used to submit ([#8906](https://github.com/can1357/oh-my-pi/issues/8906)).
 - Main-view drag-select now copies the highlighted text to the clipboard, and a click in the composer places the caret on that word.
+- Wheel reports scroll the in-app transcript (composer stays pinned). Native history is left alone so drag-select and wheel can both stay on.
 
 
 ## [17.3.5] - 2026-08-16

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added optional `getNativeScrollbackLiveRegionPinnedStart()` hook to allow nested transcripts to pin a later dashboard without shifting the earliest live seam.
 
+### Fixed
+
+- Main-view drag-select now copies the highlighted text to the clipboard, and a click in the composer places the caret on that word.
+- Wheel reports scroll the in-app transcript (composer stays pinned). Native history is left alone so drag-select and wheel can both stay on.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added
@@ -19,9 +24,6 @@
 
 - Fixed images rendering as the `[Image: …]` text card on SIXEL terminals that expose no identifying environment variable (foot, xterm, contour): the graphics probe no longer requires Windows Terminal, and no longer reads an XTSMGRAPHICS success reply as a failure.
 - Fixed the multiline editor ignoring a `tui.input.submit` remap onto Ctrl+Enter: the hardcoded Ctrl/Shift+Enter → newline fallbacks now yield to an explicit submit binding, so Ctrl+Enter can be used to submit ([#8906](https://github.com/can1357/oh-my-pi/issues/8906)).
-- Main-view drag-select now copies the highlighted text to the clipboard, and a click in the composer places the caret on that word.
-- Wheel reports scroll the in-app transcript (composer stays pinned). Native history is left alone so drag-select and wheel can both stay on.
-
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - Fixed images rendering as the `[Image: …]` text card on SIXEL terminals that expose no identifying environment variable (foot, xterm, contour): the graphics probe no longer requires Windows Terminal, and no longer reads an XTSMGRAPHICS success reply as a failure.
 - Fixed the multiline editor ignoring a `tui.input.submit` remap onto Ctrl+Enter: the hardcoded Ctrl/Shift+Enter → newline fallbacks now yield to an explicit submit binding, so Ctrl+Enter can be used to submit ([#8906](https://github.com/can1357/oh-my-pi/issues/8906)).
+- Main-view drag-select now copies the highlighted text to the clipboard, and a click in the composer places the caret on that word.
+
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -442,6 +442,7 @@ export class Editor implements Component, Focusable {
 
 	// Store last layout width for cursor navigation
 	#lastLayoutWidth: number = 80;
+	#lastRenderWidth: number = 80;
 	// Line measurement + word-wrap cache shared by #layoutText,
 	// #buildVisualLineMap, and key handlers within a frame. Line text is a
 	// sound key (strings are immutable); cleared on layout-width or
@@ -928,6 +929,7 @@ export class Editor implements Component, Focusable {
 		const contentAreaWidth = this.#getContentWidth(width, paddingX);
 		const layoutWidth = this.#getLayoutWidth(width, paddingX);
 		this.#lastLayoutWidth = layoutWidth;
+		this.#lastRenderWidth = width;
 
 		const box = this.#theme.symbols.boxRound;
 		const borderWidth = this.#getHorizontalChromeWidth(paddingX);
@@ -1775,6 +1777,32 @@ export class Editor implements Component, Focusable {
 
 	getCursor(): { line: number; col: number } {
 		return { line: this.#state.cursorLine, col: this.#state.cursorCol };
+	}
+
+	/**
+	 * Place the caret from a mouse click in this editor's local frame.
+	 * `row`/`col` are 0-based cells in the editor's last render. Returns false
+	 * when the click is on chrome (top border, autocomplete) rather than text.
+	 */
+	placeCursorFromMouse(row: number, col: number): boolean {
+		if (row < 0 || col < 0) return false;
+		const contentRow = this.#borderVisible ? row - 1 : row;
+		if (contentRow < 0) return false;
+		const visualIndex = contentRow + this.#scrollOffset;
+		const visualLines = this.#buildVisualLineMap(this.#lastLayoutWidth);
+		const vl = visualLines[visualIndex];
+		if (!vl) return false;
+		const paddingX = this.#getEditorPaddingX();
+		const leftChrome = this.#borderVisible
+			? this.#getHorizontalChromeWidth(paddingX)
+			: this.#getPromptGutterWidth(this.#lastRenderWidth, paddingX);
+		const textCol = Math.max(0, col - leftChrome);
+		const line = this.#state.lines[vl.logicalLine] || "";
+		const segment = line.slice(vl.startCol, vl.startCol + vl.length);
+		this.#resetKillSequence();
+		this.#state.cursorLine = vl.logicalLine;
+		this.#setCursorCol(vl.startCol + offsetAtVisualCol(segment, textCol));
+		return true;
 	}
 
 	moveToLineStart(): void {

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -22,6 +22,9 @@ export interface EditorComponent extends Component {
 	/** Handle raw terminal input (key presses, paste sequences, etc.) */
 	handleInput(data: string): void;
 
+	/** Place the caret from a local-frame mouse click. Returns false for chrome. */
+	placeCursorFromMouse?(row: number, col: number): boolean;
+
 	// =========================================================================
 	// Callbacks (required)
 	// =========================================================================

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -37,6 +37,8 @@ export * from "./latex-block";
 export * from "./latex-to-unicode";
 // SGR mouse report parsing
 export * from "./mouse";
+// Visible-window drag selection
+export * from "./text-selection";
 // Mermaid diagram support
 // Input buffering for batch splitting
 export * from "./stdin-buffer";

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -37,8 +37,6 @@ export * from "./latex-block";
 export * from "./latex-to-unicode";
 // SGR mouse report parsing
 export * from "./mouse";
-// Visible-window drag selection
-export * from "./text-selection";
 // Mermaid diagram support
 // Input buffering for batch splitting
 export * from "./stdin-buffer";
@@ -47,6 +45,8 @@ export type * from "./symbols";
 export * from "./terminal";
 // Terminal image support
 export * from "./terminal-capabilities";
+// Visible-window drag selection
+export * from "./text-selection";
 // TTY ID
 export * from "./ttyid";
 export * from "./tui";

--- a/packages/tui/src/text-selection.ts
+++ b/packages/tui/src/text-selection.ts
@@ -31,7 +31,6 @@ export function selectionIsEmpty(sel: TextSelection): boolean {
 	return sel.anchor.row === sel.head.row && sel.anchor.col === sel.head.col;
 }
 
-
 /** Reconstruct selected text from composed viewport lines. Strips ANSI. */
 export function reconstructSelectionText(lines: readonly string[], sel: TextSelection): string {
 	if (selectionIsEmpty(sel)) return "";

--- a/packages/tui/src/text-selection.ts
+++ b/packages/tui/src/text-selection.ts
@@ -1,0 +1,114 @@
+/**
+ * Visible-window text selection for the main-view TUI.
+ *
+ * Coordinates are 0-based screen cells (SGR mouse). Reconstruction and
+ * highlight operate on already-composed viewport lines — the grok-build
+ * visible-line algorithm, not the off-screen block engine.
+ */
+
+import { parseSgrMouse, type SgrMouseEvent } from "./mouse";
+import { sliceByColumn, visibleWidth } from "./utils";
+
+export interface Cell {
+	row: number;
+	col: number;
+}
+
+export interface TextSelection {
+	anchor: Cell;
+	head: Cell;
+}
+
+export function orderedRange(sel: TextSelection): { start: Cell; end: Cell } {
+	const { anchor, head } = sel;
+	if (anchor.row < head.row || (anchor.row === head.row && anchor.col <= head.col)) {
+		return { start: anchor, end: head };
+	}
+	return { start: head, end: anchor };
+}
+
+export function selectionIsEmpty(sel: TextSelection): boolean {
+	return sel.anchor.row === sel.head.row && sel.anchor.col === sel.head.col;
+}
+
+
+/** Reconstruct selected text from composed viewport lines. Strips ANSI. */
+export function reconstructSelectionText(lines: readonly string[], sel: TextSelection): string {
+	if (selectionIsEmpty(sel)) return "";
+	const { start, end } = orderedRange(sel);
+	const first = Math.max(0, start.row);
+	const last = Math.min(lines.length - 1, end.row);
+	if (last < first) return "";
+	const out: string[] = [];
+	for (let r = first; r <= last; r++) {
+		const line = lines[r] ?? "";
+		const width = visibleWidth(line);
+		const from = r === start.row ? Math.min(width, Math.max(0, start.col)) : 0;
+		const to = r === end.row ? Math.min(width, Math.max(0, end.col)) : width;
+		const slice = to > from ? sliceByColumn(line, from, to - from, true) : "";
+		out.push(Bun.stripANSI(slice).replace(/\s+$/u, ""));
+	}
+	return out.join("\n");
+}
+
+/** Invert the selected cells in place. Does not mutate line identity for empty ranges. */
+export function applySelectionHighlight(lines: string[], sel: TextSelection): void {
+	if (selectionIsEmpty(sel)) return;
+	const { start, end } = orderedRange(sel);
+	for (let r = Math.max(0, start.row); r <= end.row && r < lines.length; r++) {
+		const line = lines[r] ?? "";
+		const width = visibleWidth(line);
+		const from = r === start.row ? Math.min(width, Math.max(0, start.col)) : 0;
+		const to = r === end.row ? Math.min(width, Math.max(0, end.col)) : width;
+		if (to <= from) continue;
+		const before = from > 0 ? sliceByColumn(line, 0, from, true) : "";
+		const mid = sliceByColumn(line, from, to - from, true);
+		const after = to < width ? sliceByColumn(line, to, width - to, true) : "";
+		lines[r] = `${before}\x1b[7m${mid}\x1b[27m${after}`;
+	}
+}
+
+/**
+ * Update selection from an SGR event. Returns:
+ * - `"start"` / `"move"` when the drag changed
+ * - `"copy"` when a non-empty selection was released
+ * - `"ignore"` when the event is not a left-button selection gesture
+ * - `"consumed"` when the event is a mouse report that must not reach the editor
+ */
+export function applySelectionMouse(
+	sel: TextSelection | null,
+	event: SgrMouseEvent,
+): { selection: TextSelection | null; action: "start" | "move" | "copy" | "ignore" | "consumed" } {
+	const cell: Cell = { row: event.row, col: event.col };
+	if (event.wheel !== null) {
+		return { selection: sel, action: "consumed" };
+	}
+	const button = event.button & 3;
+	if (event.release) {
+		if (!sel) return { selection: null, action: "consumed" };
+		if (selectionIsEmpty(sel)) return { selection: null, action: "consumed" };
+		return { selection: sel, action: "copy" };
+	}
+	if (event.leftClick) {
+		return { selection: { anchor: cell, head: cell }, action: "start" };
+	}
+	if (event.motion && button === 0 && sel) {
+		if (sel.head.row === cell.row && sel.head.col === cell.col) {
+			return { selection: sel, action: "consumed" };
+		}
+		return { selection: { anchor: sel.anchor, head: cell }, action: "move" };
+	}
+	if (button !== 0) return { selection: sel, action: "ignore" };
+	return { selection: sel, action: "consumed" };
+}
+
+/** Parse an SGR report and apply it to the current selection. */
+export function applySelectionInput(
+	sel: TextSelection | null,
+	data: string,
+): { selection: TextSelection | null; action: "start" | "move" | "copy" | "ignore" | "consumed" } | null {
+	if (!data.startsWith("\x1b[<")) return null;
+	const event = parseSgrMouse(data);
+	if (!event) return null;
+	return applySelectionMouse(sel, event);
+}

--- a/packages/tui/src/text-selection.ts
+++ b/packages/tui/src/text-selection.ts
@@ -72,16 +72,17 @@ export function applySelectionHighlight(lines: string[], sel: TextSelection): vo
  * Update selection from an SGR event. Returns:
  * - `"start"` / `"move"` when the drag changed
  * - `"copy"` when a non-empty selection was released
+ * - `"scroll"` when the report is a wheel notch (not a selection gesture)
  * - `"ignore"` when the event is not a left-button selection gesture
  * - `"consumed"` when the event is a mouse report that must not reach the editor
  */
 export function applySelectionMouse(
 	sel: TextSelection | null,
 	event: SgrMouseEvent,
-): { selection: TextSelection | null; action: "start" | "move" | "copy" | "ignore" | "consumed" } {
+): { selection: TextSelection | null; action: "start" | "move" | "copy" | "scroll" | "ignore" | "consumed" } {
 	const cell: Cell = { row: event.row, col: event.col };
 	if (event.wheel !== null) {
-		return { selection: sel, action: "consumed" };
+		return { selection: sel, action: "scroll" };
 	}
 	const button = event.button & 3;
 	if (event.release) {
@@ -106,7 +107,7 @@ export function applySelectionMouse(
 export function applySelectionInput(
 	sel: TextSelection | null,
 	data: string,
-): { selection: TextSelection | null; action: "start" | "move" | "copy" | "ignore" | "consumed" } | null {
+): { selection: TextSelection | null; action: "start" | "move" | "copy" | "scroll" | "ignore" | "consumed" } | null {
 	if (!data.startsWith("\x1b[<")) return null;
 	const event = parseSgrMouse(data);
 	if (!event) return null;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -22,14 +22,8 @@ import { DEFAULT_MAX_INLINE_IMAGES, ImageBudget } from "./components/image";
 import { planDeccaraFills } from "./deccara";
 import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
-import { isConPTYHosted, setAltScreenActive, type Terminal } from "./terminal";
-import {
-	applySelectionHighlight,
-	applySelectionMouse,
-	reconstructSelectionText,
-	type TextSelection,
-} from "./text-selection";
 import { parseSgrMouse } from "./mouse";
+import { isConPTYHosted, setAltScreenActive, type Terminal } from "./terminal";
 import {
 	encodeKittyDeleteImage,
 	encodeKittyDeletePlacement,
@@ -44,6 +38,12 @@ import {
 	synchronizedOutputUserOverride,
 	TERMINAL,
 } from "./terminal-capabilities";
+import {
+	applySelectionHighlight,
+	applySelectionMouse,
+	reconstructSelectionText,
+	type TextSelection,
+} from "./text-selection";
 import {
 	Ellipsis,
 	extractSegments,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1459,6 +1459,8 @@ export class TUI extends Container {
 	#textSelection: TextSelection | null = null;
 	#selectionSourceWindow: string[] | null = null;
 	#onSelectionCopy: ((text: string) => void | Promise<void>) | undefined;
+	/** Lines the live window is peeked above the tail. 0 follows the composer. */
+	#viewOffset = 0;
 	#tuiStarted = false;
 	#altPreviousLines: string[] = [];
 	#altEnterWidth = 0;
@@ -2289,12 +2291,29 @@ export class TUI extends Container {
 		if (this.#tuiStarted && !this.#altActive) this.terminal.write(MAIN_MOUSE_TRACKING_ON);
 	}
 
+	/** Turn off main-view drag-select and restore native terminal mouse handling. */
+	disableMainTextSelection(): void {
+		this.#onSelectionCopy = undefined;
+		this.#mainMouseTracking = false;
+		this.#textSelection = null;
+		this.#selectionSourceWindow = null;
+		this.#viewOffset = 0;
+		if (this.#tuiStarted && !this.#altActive) this.terminal.write(MAIN_MOUSE_TRACKING_OFF);
+		this.requestRender();
+	}
+
 	#handleMainSelectionInput(data: string): boolean {
 		const event = parseSgrMouse(data);
 		if (!event) return false;
 		if (event.leftClick && this.#tryPlaceEditorCursor(event.row, event.col)) return true;
 		const result = applySelectionMouse(this.#textSelection, event);
 		if (result.action === "ignore") return false;
+		if (result.action === "scroll") {
+			this.#textSelection = null;
+			this.#selectionSourceWindow = null;
+			this.#scrollMainView(event.wheel ?? -1);
+			return true;
+		}
 		if (result.action === "copy") {
 			const text = result.selection
 				? reconstructSelectionText(this.#selectionSourceWindow ?? [], result.selection)
@@ -2310,12 +2329,28 @@ export class TUI extends Container {
 		return true;
 	}
 
+	#scrollMainView(delta: -1 | 1): void {
+		const maxOffset = this.#windowTopRow;
+		const next = delta < 0 ? Math.min(maxOffset, this.#viewOffset + 3) : Math.max(0, this.#viewOffset - 3);
+		if (next === this.#viewOffset) return;
+		this.#viewOffset = next;
+		this.requestRender();
+	}
+
 	#tryPlaceEditorCursor(screenRow: number, screenCol: number): boolean {
 		const focused = this.#focusedComponent;
 		if (!focused || typeof focused.placeCursorFromMouse !== "function") return false;
 		const loc = this.#locateInFrame(focused);
 		if (!loc) return false;
-		const localRow = screenRow + this.#windowTopRow - loc.start;
+		const height = this.terminal.rows;
+		const editorRows = Math.min(height, loc.rows);
+		const scrollRows = height - editorRows;
+		const viewTop = Math.max(0, this.#windowTopRow - this.#viewOffset);
+		const frameRow =
+			this.#viewOffset > 0 && editorRows > 0 && screenRow >= scrollRows
+				? this.#windowTopRow + screenRow
+				: viewTop + screenRow;
+		const localRow = frameRow - loc.start;
 		if (localRow < 0 || localRow >= loc.rows) return false;
 		if (!focused.placeCursorFromMouse(localRow, screenCol)) return false;
 		this.requestRender();
@@ -4029,7 +4064,7 @@ export class TUI extends Container {
 			// accepted wrap drift does not read as a violation on the next
 			// ordinary frame.
 			chunkTo =
-				hasVisibleOverlay || geometryChanged
+				hasVisibleOverlay || geometryChanged || this.#viewOffset > 0
 					? this.#committedRows
 					: Math.min(windowTop, Math.max(this.#committedRows, commitCeiling));
 			if (widthChanged) {
@@ -4049,8 +4084,15 @@ export class TUI extends Container {
 			}
 		}
 		const frame = this.#prepareFrame(rawFrame, width);
+		this.#viewOffset = Math.min(this.#viewOffset, windowTop);
+		const viewTop = Math.max(0, windowTop - this.#viewOffset);
+		const peekEditor = this.#viewOffset > 0 ? this.#focusedComponent : null;
+		const peekEditorLoc = peekEditor ? this.#locateInFrame(peekEditor) : undefined;
+		const editorRows = peekEditorLoc ? Math.min(height, peekEditorLoc.rows) : 0;
+		const peekScrollRows = height - editorRows;
 		let window: string[] = new Array(height);
-		for (let r = 0; r < height; r++) window[r] = frame[windowTop + r] ?? "";
+		for (let r = 0; r < peekScrollRows; r++) window[r] = frame[viewTop + r] ?? "";
+		for (let r = 0; r < editorRows; r++) window[peekScrollRows + r] = frame[windowTop + peekScrollRows + r] ?? "";
 		if (this.#textSelection && !hasVisibleOverlay) {
 			this.#selectionSourceWindow = window.slice();
 			applySelectionHighlight(window, this.#textSelection);
@@ -4174,7 +4216,7 @@ export class TUI extends Container {
 				scrollRows = Math.min(logicalSuffixRows, appendWindowMovement);
 				commitTo = commitFrom + scrollRows;
 			}
-			if (hasVisibleOverlay) {
+			if (hasVisibleOverlay || this.#viewOffset > 0) {
 				scrollRows = 0;
 				commitTo = commitFrom;
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -24,6 +24,13 @@ import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
 import { isConPTYHosted, setAltScreenActive, type Terminal } from "./terminal";
 import {
+	applySelectionHighlight,
+	applySelectionMouse,
+	reconstructSelectionText,
+	type TextSelection,
+} from "./text-selection";
+import { parseSgrMouse } from "./mouse";
+import {
 	encodeKittyDeleteImage,
 	encodeKittyDeletePlacement,
 	encodeKittyPlacementLine,
@@ -86,13 +93,12 @@ const CURSOR_BEGIN = `${HIDE_CURSOR}${SYNC_OUTPUT_BEGIN}`;
 const CURSOR_BEGIN_NO_SYNC = HIDE_CURSOR;
 const CURSOR_END = SYNC_OUTPUT_END;
 const CURSOR_END_NO_SYNC = "";
-// Mouse reporting is scoped to fullscreen overlays that opt into pointer
-// interaction. 1000h = button click tracking, 1003h = any-motion tracking for
-// hover targets, and 1006h = SGR extended coordinates past column/row 223.
-// Selection-first overlays leave these modes disabled so the terminal retains
-// native text selection.
+// Overlay mouse reporting: 1000h click + 1003h any-motion (hover) + 1006h SGR.
 const MOUSE_TRACKING_ON = "\x1b[?1000h\x1b[?1003h\x1b[?1006h";
 const MOUSE_TRACKING_OFF = "\x1b[?1006l\x1b[?1003l\x1b[?1000l";
+// Main-view drag-select: 1002h button-motion only (no hover flood).
+const MAIN_MOUSE_TRACKING_ON = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+const MAIN_MOUSE_TRACKING_OFF = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
 const ALT_SCREEN_ENTER = "\x1b[?1049h";
 const ALT_SCREEN_EXIT = "\x1b[?1049l";
 
@@ -867,6 +873,22 @@ export class Container
 		this.#memoLines = lines;
 		return lines;
 	}
+
+	/** Last-compose frame offset of `target` under this container, if present. */
+	locateDescendant(target: Component): { start: number; rows: number } | undefined {
+		let start = 0;
+		for (let i = 0; i < this.children.length; i++) {
+			const child = this.children[i]!;
+			const rows = this.#memoChildLines[i]?.length ?? 0;
+			if (child === target) return { start, rows };
+			if (child instanceof Container) {
+				const inner = child.locateDescendant(target);
+				if (inner) return { start: start + inner.start, rows: inner.rows };
+			}
+			start += rows;
+		}
+		return undefined;
+	}
 }
 
 /**
@@ -1433,6 +1455,11 @@ export class TUI extends Container {
 	// normal screen. #altPreviousLines is the last alt frame, for repaint-skip.
 	#altActive = false;
 	#altMouseTrackingActive = false;
+	#mainMouseTracking = false;
+	#textSelection: TextSelection | null = null;
+	#selectionSourceWindow: string[] | null = null;
+	#onSelectionCopy: ((text: string) => void | Promise<void>) | undefined;
+	#tuiStarted = false;
 	#altPreviousLines: string[] = [];
 	#altEnterWidth = 0;
 	#altEnterHeight = 0;
@@ -2134,6 +2161,7 @@ export class TUI extends Container {
 
 	start(options?: TUIStartOptions): void {
 		this.#stopped = false;
+		this.#tuiStarted = true;
 		this.#watchdog.start();
 		this.#ghosttyInitialImageDelayDone = false;
 		this.#ghosttyImageReadyAtMs = this.#renderScheduler.now() + TUI.#GHOSTTY_INITIAL_IMAGE_DELAY_MS;
@@ -2229,6 +2257,7 @@ export class TUI extends Container {
 		this.#recordHardwareCursorHidden();
 		this.#querySixelSupport();
 		this.#queryCellSize();
+		if (this.#mainMouseTracking) this.terminal.write(MAIN_MOUSE_TRACKING_ON);
 		this.requestRender(true, { clearScrollback: options?.clearScrollback === true });
 	}
 
@@ -2248,6 +2277,60 @@ export class TUI extends Container {
 
 	removeInputListener(listener: InputListener): void {
 		this.#inputListeners.delete(listener);
+	}
+
+	/**
+	 * Enable main-view drag-select. SGR button-motion tracking stays on the
+	 * normal screen; fullscreen overlays take over and this is restored on exit.
+	 */
+	enableMainTextSelection(onCopy: (text: string) => void | Promise<void>): void {
+		this.#onSelectionCopy = onCopy;
+		this.#mainMouseTracking = true;
+		if (this.#tuiStarted && !this.#altActive) this.terminal.write(MAIN_MOUSE_TRACKING_ON);
+	}
+
+	#handleMainSelectionInput(data: string): boolean {
+		const event = parseSgrMouse(data);
+		if (!event) return false;
+		if (event.leftClick && this.#tryPlaceEditorCursor(event.row, event.col)) return true;
+		const result = applySelectionMouse(this.#textSelection, event);
+		if (result.action === "ignore") return false;
+		if (result.action === "copy") {
+			const text = result.selection
+				? reconstructSelectionText(this.#selectionSourceWindow ?? [], result.selection)
+				: "";
+			this.#textSelection = null;
+			this.#selectionSourceWindow = null;
+			if (text.length > 0) void this.#onSelectionCopy?.(text);
+			this.requestRender();
+			return true;
+		}
+		this.#textSelection = result.selection;
+		if (result.action === "start" || result.action === "move") this.requestRender();
+		return true;
+	}
+
+	#tryPlaceEditorCursor(screenRow: number, screenCol: number): boolean {
+		const focused = this.#focusedComponent;
+		if (!focused || typeof focused.placeCursorFromMouse !== "function") return false;
+		const loc = this.#locateInFrame(focused);
+		if (!loc) return false;
+		const localRow = screenRow + this.#windowTopRow - loc.start;
+		if (localRow < 0 || localRow >= loc.rows) return false;
+		if (!focused.placeCursorFromMouse(localRow, screenCol)) return false;
+		this.requestRender();
+		return true;
+	}
+
+	#locateInFrame(target: Component): { start: number; rows: number } | undefined {
+		for (const seg of this.#frameSegments) {
+			if (seg.component === target) return { start: seg.start, rows: seg.rowCount };
+			if (seg.component instanceof Container) {
+				const inner = seg.component.locateDescendant(target);
+				if (inner) return { start: seg.start + inner.start, rows: inner.rows };
+			}
+		}
+		return undefined;
 	}
 
 	#querySixelSupport(): void {
@@ -2386,6 +2469,10 @@ export class TUI extends Container {
 		if (this.#resizeAltActive) {
 			this.terminal.write(this.#leaveResizeAltSequence());
 		}
+		this.#tuiStarted = false;
+		if (this.#mainMouseTracking) this.terminal.write(MAIN_MOUSE_TRACKING_OFF);
+		this.#textSelection = null;
+		this.#selectionSourceWindow = null;
 		if (this.#altActive || this.#pendingAltExit) {
 			const mouseExit = this.#altMouseTrackingActive ? MOUSE_TRACKING_OFF : "";
 			const exitSequence = this.#pendingAltExit || `${mouseExit}${this.#keyboardEnhancementExit()}\x1b[?1049l`;
@@ -2981,6 +3068,15 @@ export class TUI extends Container {
 		if (matchesKey(data, "ctrl+c") || matchesKey(data, "escape")) {
 			this.#inputRenderGraceUntilMs = this.#renderScheduler.now() + TUI.#INPUT_RENDER_GRACE_MS;
 		}
+		if (
+			this.#mainMouseTracking &&
+			!this.#altActive &&
+			this.#getTopmostVisibleOverlay() === undefined &&
+			data.startsWith("\x1b[<") &&
+			this.#handleMainSelectionInput(data)
+		) {
+			return;
+		}
 		if (this.#inputListeners.size > 0) {
 			let current = data;
 			for (const listener of this.#inputListeners) {
@@ -3435,7 +3531,11 @@ export class TUI extends Container {
 			// modified-key reporting sequence on the freshly entered alternate
 			// screen, or Esc/modified keys revert to legacy encoding inside
 			// fullscreen overlays (Ghostty/kitty/iTerm2).
-			const mouseEnter = wantMouseTracking ? MOUSE_TRACKING_ON : "";
+			const mouseEnter = wantMouseTracking
+				? MOUSE_TRACKING_ON
+				: this.#mainMouseTracking
+					? MAIN_MOUSE_TRACKING_OFF
+					: "";
 			this.terminal.write(`\x1b[?1049h${this.#keyboardEnhancementEnter()}${mouseEnter}`);
 			setAltScreenActive(true);
 			this.terminal.hideCursor();
@@ -3450,7 +3550,8 @@ export class TUI extends Container {
 		} else if (!wantAlt && this.#altActive) {
 			const mouseExit = this.#altMouseTrackingActive ? MOUSE_TRACKING_OFF : "";
 			const enhancementExit = this.#keyboardEnhancementExit();
-			const exitSequence = `${mouseExit}${enhancementExit}\x1b[?1049l`;
+			const mouseRestore = this.#mainMouseTracking ? MAIN_MOUSE_TRACKING_ON : "";
+			const exitSequence = `${mouseExit}${enhancementExit}\x1b[?1049l${mouseRestore}`;
 			// Session replacement can finish while a fullscreen selector is still
 			// covering the old normal buffer. Keep the overlay visible until the
 			// replacement is ready, then fuse the buffer restore into that full paint;
@@ -3950,6 +4051,10 @@ export class TUI extends Container {
 		const frame = this.#prepareFrame(rawFrame, width);
 		let window: string[] = new Array(height);
 		for (let r = 0; r < height; r++) window[r] = frame[windowTop + r] ?? "";
+		if (this.#textSelection && !hasVisibleOverlay) {
+			this.#selectionSourceWindow = window.slice();
+			applySelectionHighlight(window, this.#textSelection);
+		}
 		if (hasVisibleOverlay) {
 			window = this.#compositeOverlaysIntoWindow(window, width, height);
 			const overlayMarkers = this.#extractCursorMarkers(window);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -26,6 +26,15 @@ describe("Editor component", () => {
 		expect(editor.getNativeScrollbackWidthEpochRevision()).toBe(changed);
 	});
 
+	it("places the caret on a clicked word", () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setText("hello world");
+		editor.render(40);
+		expect(editor.placeCursorFromMouse(0, 4)).toBe(false);
+		expect(editor.placeCursorFromMouse(1, 3 + 6)).toBe(true);
+		expect(editor.getCursor()).toEqual({ line: 0, col: 6 });
+	});
+
 	it("advances its width-epoch revision when max height exposes more draft rows", () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setText("draft-0\ndraft-1\ndraft-2\ndraft-3");

--- a/packages/tui/test/text-selection.test.ts
+++ b/packages/tui/test/text-selection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import {
+	applySelectionHighlight,
+	applySelectionInput,
+	orderedRange,
+	reconstructSelectionText,
+	type TextSelection,
+} from "../src/text-selection";
+
+describe("text-selection", () => {
+	it("orders a backward drag", () => {
+		const sel: TextSelection = { anchor: { row: 2, col: 4 }, head: { row: 1, col: 1 } };
+		expect(orderedRange(sel)).toEqual({ start: { row: 1, col: 1 }, end: { row: 2, col: 4 } });
+	});
+
+	it("reconstructs a single-line slice and strips ANSI", () => {
+		const lines = ["\x1b[1mal\x1b[0mpha beta"];
+		const text = reconstructSelectionText(lines, {
+			anchor: { row: 0, col: 0 },
+			head: { row: 0, col: 5 },
+		});
+		expect(text).toBe("alpha");
+	});
+
+	it("reconstructs a multi-line range", () => {
+		const lines = ["alpha", "beta", "gamma"];
+		const text = reconstructSelectionText(lines, {
+			anchor: { row: 0, col: 2 },
+			head: { row: 2, col: 3 },
+		});
+		expect(text).toBe("pha\nbeta\ngam");
+	});
+
+	it("trims trailing spaces from copied lines", () => {
+		const lines = ["hello   ", "world   "];
+		const text = reconstructSelectionText(lines, {
+			anchor: { row: 0, col: 0 },
+			head: { row: 1, col: 8 },
+		});
+		expect(text).toBe("hello\nworld");
+	});
+
+	it("inverts the selected span", () => {
+		const lines = ["alpha beta"];
+		applySelectionHighlight(lines, { anchor: { row: 0, col: 0 }, head: { row: 0, col: 5 } });
+		expect(lines[0]).toContain("\x1b[7m");
+		expect(Bun.stripANSI(lines[0]!)).toBe("alpha beta");
+	});
+
+	it("starts a selection on left press and copies on generic release", () => {
+		let sel = applySelectionInput(null, "\x1b[<0;1;1M");
+		expect(sel?.action).toBe("start");
+		sel = applySelectionInput(sel!.selection, "\x1b[<32;6;1M");
+		expect(sel?.action).toBe("move");
+		sel = applySelectionInput(sel!.selection, "\x1b[<3;6;1m");
+		expect(sel?.action).toBe("copy");
+		expect(reconstructSelectionText(["alpha beta"], sel!.selection!)).toBe("alpha");
+	});
+
+	it("consumes wheel without starting a selection", () => {
+		const result = applySelectionInput(null, "\x1b[<64;1;1M");
+		expect(result?.action).toBe("consumed");
+		expect(result?.selection).toBeNull();
+	});
+
+	it("ignores a click-release with no drag", () => {
+		let sel = applySelectionInput(null, "\x1b[<0;1;1M");
+		sel = applySelectionInput(sel!.selection, "\x1b[<3;1;1m");
+		expect(sel?.action).toBe("consumed");
+		expect(sel?.selection).toBeNull();
+	});
+});

--- a/packages/tui/test/text-selection.test.ts
+++ b/packages/tui/test/text-selection.test.ts
@@ -57,9 +57,9 @@ describe("text-selection", () => {
 		expect(reconstructSelectionText(["alpha beta"], sel!.selection!)).toBe("alpha");
 	});
 
-	it("consumes wheel without starting a selection", () => {
+	it("reports wheel as scroll without starting a selection", () => {
 		const result = applySelectionInput(null, "\x1b[<64;1;1M");
-		expect(result?.action).toBe("consumed");
+		expect(result?.action).toBe("scroll");
 		expect(result?.selection).toBeNull();
 	});
 


### PR DESCRIPTION
I tested this in my Superconductor Oh My Pi session: dragging over transcript text copies it, and clicking a word in the input box puts the caret there so I can edit.

## What changed

The main view never captured the mouse, so there was no drag-to-copy, and after enabling mouse tracking for copy the composer could not receive clicks.

- Drag-select on the main transcript highlights the span and, on release, copies via the existing clipboard helper (OSC 52 plus native) and shows `Copied!`.
- A left click in the composer places the caret on that word. Clicks on editor chrome are ignored so transcript drag-select still works.
- Fullscreen overlays keep their own mouse tracking and restore the main-view modes on exit.

## Verification

- `bun test packages/tui/test/text-selection.test.ts` — 8 pass
- `bun test packages/tui/test/editor.test.ts -t "places the caret"` — pass
- Manual: restart omp, drag a transcript span, paste elsewhere; click a word in the draft and type

I reviewed the diff before opening this PR.