### PR TITLE
fix(collab-web): render the user-added note in ask tool cards

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The ask tool card now renders the note the user attached to their answer; previously it was dropped from HTML exports and the collab guest view.
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/collab-web/src/tool-render/tools/ask.tsx
+++ b/packages/collab-web/src/tool-render/tools/ask.tsx
@@ -22,6 +22,8 @@ interface AskAnswer {
 	id?: string;
 	selectedOptions: string[];
 	customInput?: string;
+	/** Free-form note the user attached to the answer via the rich ask dialog. */
+	note?: string;
 	timedOut?: boolean;
 }
 
@@ -106,6 +108,7 @@ function answerOf(rec: Record<string, unknown>): AskAnswer {
 		id: str(rec.id) ?? undefined,
 		selectedOptions,
 		customInput: str(rec.customInput) ?? undefined,
+		note: str(rec.note) ?? undefined,
 		timedOut: rec.timedOut === true,
 	};
 }
@@ -185,6 +188,11 @@ function QuestionBlock({ q, answer }: { q: AskQuestion; answer: AskAnswer | unde
 			{answer?.customInput !== undefined && (
 				<Row k="✎">
 					<span className="tv-ok-text">{answer.customInput}</span>
+				</Row>
+			)}
+			{answer?.note !== undefined && (
+				<Row k="note:">
+					<span className="tv-muted">{answer.note}</span>
 				</Row>
 			)}
 			{answer && answer.selectedOptions.length === 0 && answer.customInput === undefined && (

--- a/packages/collab-web/test/tool-view.test.tsx
+++ b/packages/collab-web/test/tool-view.test.tsx
@@ -152,3 +152,65 @@ describe("ToolView xd:// dispatches", () => {
 		expect(html).not.toContain("tv-out-title");
 	});
 });
+
+describe("ToolView ask renderer", () => {
+	const questions = [
+		{
+			id: "auth",
+			question: "Which auth method?",
+			options: [{ label: "JWT" }, { label: "OAuth2" }],
+		},
+	];
+
+	it("renders the user-added note from a single-question answer", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="ask"
+				defaultOpen
+				args={{ questions }}
+				result={{
+					content: [{ type: "text", text: "OAuth2 User added note: keep the redirect short-lived" }],
+					details: {
+						question: "Which auth method?",
+						options: ["JWT", "OAuth2"],
+						multi: false,
+						selectedOptions: ["OAuth2"],
+						note: "keep the redirect short-lived",
+					},
+				}}
+			/>,
+		);
+
+		expect(html).toContain('<span>OAuth2</span>');
+		expect(html).toContain("keep the redirect short-lived");
+	});
+
+	it("renders per-question notes from results[] answers", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="ask"
+				defaultOpen
+				args={{
+					questions: [
+						{ id: "db", question: "Storage backend?", options: [{ label: "SQLite" }, { label: "Postgres" }] },
+						{ id: "cache", question: "Cache?", options: [{ label: "Redis" }, { label: "None" }] },
+					],
+				}}
+				result={{
+					content: [{ type: "text", text: "User answers:" }],
+					details: {
+						results: [
+							{ id: "db", question: "Storage backend?", multi: false, selectedOptions: ["Postgres"], note: "managed instance" },
+							{ id: "cache", question: "Cache?", multi: false, selectedOptions: ["Redis"] },
+						],
+					},
+				}}
+			/>,
+		);
+
+		expect(html).toContain('<span>Postgres</span>');
+		expect(html).toContain("managed instance");
+		// The cache question answered without a note must not leak the db note.
+		expect(html.match(/managed instance/g)?.length).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

The ask tool card now renders the note a user attached to their answer. A `note:` prefixed row (muted text) appears after the selection/custom-input rows, for both the single-question `details.note` shape and per-question `details.results[].note`.

## Why

The ask tool persists the user-attached note in its result `details` (documented in `docs/tools/ask.md`), and appends ` User added note: ...` to the result text. The shared tool renderer in `packages/collab-web/src/tool-render/tools/ask.tsx` never read that field: `AskAnswer` carried no `note`, and `QuestionBlock` rendered only the selection, `customInput`, the empty-selection row, and the timeout warning. Because `answersOf()` returns a populated array whenever a selection exists, the `ResultText` fallback that would have printed the raw result text never ran, so the note was dropped entirely — from HTML exports (`/export`, `--export`) and the collab guest view alike. The export pipeline itself serializes `details` correctly, so no changes there; only the renderer drops it.

## Testing

- TDD: added two cases to `packages/collab-web/test/tool-view.test.tsx` (single-question note, per-question `results[].note` with a no-leak assertion); both fail on the pre-fix behavior, pass with the fix.
- `bun test` in `packages/collab-web`: 80 pass / 0 fail.
- `bun run check` in `packages/collab-web` (biome + tsgo): clean.
- End-to-end: synthesized a session JSONL with an `ask` call whose result `details.note` is `keep the redirect flow short-lived`, exported via `exportFromFile()`, opened the HTML in a browser, expanded the ask card, and confirmed the rendered body shows the `note: keep the redirect flow short-lived` row.

Author note: I reviewed the full diff; it only extracts the existing `note` field from ask result details and renders it as one prefixed row, with no behavior change elsewhere.

---

- [x] `bun check` passes (biome + tsgo in `packages/collab-web`, the only touched package)
- [x] Tested locally (focused tests, full package suite, and manual HTML-export browser verification)
- [x] CHANGELOG updated
