### PR TITLE
fix(search): use parallel fan-out when only free providers available

### DIFF
--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -24,6 +24,7 @@ import {
 	formatSearchProviderFailures,
 	getSearchProvider,
 	getSearchProviderLabel,
+	isSearchProviderExcluded,
 	resolveProviderCandidates,
 	type SearchProvider,
 	type SearchProviderCandidate,
@@ -37,6 +38,16 @@ import {
 	type SearchProviderId,
 	type SearchResponse,
 } from "./types";
+
+/**
+ * Credential-free providers that can be queried in parallel via the Public
+ * Web aggregate. When the auto-chain resolves to only these providers the
+ * sequential fallback is replaced by a parallel fan-out so that a bot
+ * challenge or network stall on one engine does not block the others.
+ *
+ * Must stay in sync with `PUBLIC_ENGINE_IDS` in `./providers/public.ts`.
+ */
+const CREDENTIAL_FREE_IDS = new Set<SearchProviderId>(["startpage", "google", "duckduckgo", "ecosia", "mojeek"]);
 
 /** Web search tool parameters schema */
 export const webSearchSchema = type({
@@ -178,6 +189,63 @@ async function executeSearch(
 		}
 	} catch {
 		// Preserve the default for one-shot callers that do not initialize Settings.
+	}
+
+	// When the auto-chain resolves to only credential-free providers, use the
+	// Public Web parallel fan-out instead of trying each one sequentially.
+	// This avoids the worst case where every free provider times out in series
+	// (5 × 60 s = 5 min) when a single parallel pass (5 s soft / 30 s hard)
+	// would return or fail much faster.
+	const resolvedFreeCount = candidates.filter(
+		c => CREDENTIAL_FREE_IDS.has(c.id) && !isSearchProviderExcluded(c.id),
+	).length;
+	const isExplicit = explicitProvider !== undefined && explicitProvider !== "auto";
+	if (!isExplicit && resolvedFreeCount > 0 && resolvedFreeCount === candidates.length) {
+		const { searchPublicWeb } = await import("./providers/public");
+		try {
+			const response = await searchPublicWeb({
+				query: params.query,
+				parsedQuery,
+				limit: params.limit,
+				recency: params.recency,
+				systemPrompt: webSearchSystemPrompt,
+				maxOutputTokens: params.max_tokens,
+				numSearchResults: params.num_search_results,
+				temperature: params.temperature,
+				signal,
+				timeoutMs,
+				authStorage,
+				modelRegistry,
+				sessionId,
+				antigravityEndpointMode,
+				geminiModel,
+			});
+
+			let finalResponse = response;
+			const constraintNotes: string[] = [];
+			if (parsedQuery.hasConstraints && response.sources.length > 0) {
+				const filtered = applyQueryConstraints(response.sources, parsedQuery);
+				if (filtered.sources.length !== response.sources.length) {
+					finalResponse = { ...response, sources: filtered.sources };
+				}
+				for (const label of filtered.dropped) {
+					constraintNotes.push(`no results matched \`${label}\`; the constraint was relaxed`);
+				}
+			}
+
+			if (!hasRenderableSearchContent(finalResponse)) {
+				throw new SearchProviderError("public", "Public Web returned no renderable search content.", 204);
+			}
+
+			return {
+				content: [{ type: "text" as const, text: formatForLLM(finalResponse, constraintNotes) }],
+				details: { response: finalResponse },
+			};
+		} catch (error) {
+			throwIfAborted(signal);
+			// Fall through to the sequential loop so the error message still
+			// names the individual engines that failed.
+		}
 	}
 
 	const failures: Array<{ provider: Pick<SearchProvider, "id" | "label">; error: unknown }> = [];


### PR DESCRIPTION
## Problem

When no credentialed search provider is configured, the auto-chain falls back to credential-free providers (startpage → duckduckgo → ecosia → google → mojeek) **sequentially**, each with a 60s timeout. When all are bot-challenged or unreachable (common from datacenter IPs), the user waits up to **5 minutes** before seeing:

```
All web search providers failed: startpage: The operation timed out.; duckduckgo: The operation timed out.; ecosia: The operation timed out.; google: The operation timed out.; mojeek: The operation timed out.
```

## Fix

The `public` provider already implements parallel fan-out over these same engines with a **5s soft / 30s hard deadline** and cross-engine consensus ranking. This PR detects the "only credential-free providers available" scenario in `executeSearch` and automatically routes through `searchPublicWeb` instead of the sequential loop.

**Before:** 5 engines × 60s timeout = up to 5 min hang
**After:** parallel fan-out with 30s hard deadline, returns as soon as any engine succeeds

The sequential loop is kept as a fallback when the parallel path throws, so the error message still names individual engine failures.

## Changes

- `packages/coding-agent/src/web/search/index.ts`:
  - Added `CREDENTIAL_FREE_IDS` set (kept in sync with `PUBLIC_ENGINE_IDS` in `public.ts`)
  - Added `isSearchProviderExcluded` to imports from `./provider`
  - Before the sequential fallback loop: detect when all candidates are credential-free providers
  - If so, dynamically import `searchPublicWeb` and run parallel fan-out
  - On success: apply constraint filtering and return
  - On failure: fall through to sequential loop for proper error aggregation

I reviewed the full diff; this change makes free-provider-only searches fail fast instead of hanging for minutes.