### PR TITLE
fix(ai): hoist assistant messages interleaved between tool calls and outputs

### DIFF
--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -22,7 +22,11 @@ import {
 	createOpenAICodexCompatibilityMetadata,
 	getCodexAttestationHeader,
 } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
-import { parseAzureDeploymentNameMap, parseTextSignature } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import {
+	hoistInterleavedAssistantMessages,
+	parseAzureDeploymentNameMap,
+	parseTextSignature,
+} from "@oh-my-pi/pi-ai/providers/openai-shared";
 import { transformMessages } from "@oh-my-pi/pi-ai/providers/transform-messages";
 import type {
 	Api,
@@ -740,7 +744,9 @@ export function buildOpenAiNativeHistory(
 		msgIndex++;
 	}
 
-	return stripOpenAIResponsesOutputOnlyStatusesForReplay(input);
+	// Same canonical-ordering guard as buildResponsesInput: some gateways
+	// reject a message interleaved between a call batch and its outputs.
+	return stripOpenAIResponsesOutputOnlyStatusesForReplay(hoistInterleavedAssistantMessages(input));
 }
 
 // ============================================================================

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1496,6 +1496,55 @@ export function repairOrphanResponsesToolCalls(input: ResponseInput): ResponseIn
 }
 
 /**
+ * Hoist assistant message items that sit between a tool-call batch and its
+ * outputs to before the first call of that batch.
+ *
+ * The Responses API keys tool outputs by `call_id`, so item order carries no
+ * semantics there, but some upstream gateways (observed: opencode-go / Console
+ * Go) reject a message interleaved between `function_call` items and their
+ * `function_call_output`s with `400 No tool output found for tool call …`,
+ * nondeterministically blaming one call of the batch. The shape arises when a
+ * model streams a trailing text/thinking block after its tool calls: the
+ * block-encode path preserves stream order, so the demoted thinking text lands
+ * as a message item between the calls and the tool results appended after
+ * them.
+ *
+ * Content is unchanged — the message is moved to the canonical
+ * message(s) → calls → outputs position of the same assistant turn.
+ */
+export function hoistInterleavedAssistantMessages<TItem extends { type?: unknown; role?: unknown }>(
+	input: TItem[],
+): TItem[] {
+	let firstPendingCallIndex = -1;
+	let pendingCalls = 0;
+	let changed = false;
+	const result: TItem[] = [];
+	for (const item of input) {
+		const type = item?.type;
+		if (responsesToolCallKind(type) !== undefined) {
+			if (pendingCalls === 0) firstPendingCallIndex = result.length;
+			pendingCalls += 1;
+			result.push(item);
+			continue;
+		}
+		if (responsesToolOutputKind(type) !== undefined) {
+			pendingCalls = Math.max(0, pendingCalls - 1);
+			result.push(item);
+			continue;
+		}
+		const role = item?.role;
+		if (pendingCalls > 0 && role === "assistant") {
+			result.splice(firstPendingCallIndex, 0, item);
+			firstPendingCallIndex += 1;
+			changed = true;
+			continue;
+		}
+		result.push(item);
+	}
+	return changed ? result : input;
+}
+
+/**
  * Some Responses backends (notably GitHub Copilot) reject the OpenAI image
  * `detail: "original"` value with a 400. When the model does not advertise
  * support for it, degrade `"original"` to `"auto"` so the request still goes
@@ -1898,7 +1947,12 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 
 	const withRepairedOutputs = options.repairOrphanOutputs ? repairOrphanResponsesToolOutputs(messages) : messages;
 	const withRepairedCalls = repairOrphanResponsesToolCalls(withRepairedOutputs);
-	return stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay(withRepairedCalls);
+	// Gateways that validate item order reject a message interleaved between a
+	// call batch and its outputs (see hoistInterleavedAssistantMessages); run
+	// the normalization after the orphan repairs so the canonical
+	// message(s) → calls → outputs shape is what reaches the wire.
+	const withOrderedMessages = hoistInterleavedAssistantMessages(withRepairedCalls);
+	return stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay(withOrderedMessages);
 }
 
 type ResponsesReplayAssistantMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };

--- a/packages/ai/test/openai-responses-interleaved-message.test.ts
+++ b/packages/ai/test/openai-responses-interleaved-message.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "bun:test";
+import type { ResponseInput } from "@oh-my-pi/pi-ai/providers/openai-responses-wire";
+import { buildResponsesInput, hoistInterleavedAssistantMessages } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { Context, ModelSpec, TextContent } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const model = buildModel({
+	id: "test-opencode-go",
+	name: "Test opencode-go",
+	api: "openai-responses",
+	provider: "opencode-go",
+	baseUrl: "https://opencode.ai/zen/go/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 16000,
+} satisfies ModelSpec<"openai-responses">);
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function message(text: string): ResponseInput[number] {
+	return {
+		type: "message",
+		id: `msg_${Bun.hash(text).toString(36)}`,
+		role: "assistant",
+		content: [{ type: "output_text", text, annotations: [] }],
+		status: "completed",
+	} as ResponseInput[number];
+}
+
+function call(id: string, name = "bash"): ResponseInput[number] {
+	return {
+		type: "function_call",
+		call_id: id,
+		name,
+		arguments: "{}",
+	} as ResponseInput[number];
+}
+
+function output(id: string): ResponseInput[number] {
+	return {
+		type: "function_call_output",
+		call_id: id,
+		output: "ok",
+	} as ResponseInput[number];
+}
+
+function user(text: string): ResponseInput[number] {
+	return { role: "user", content: text } as ResponseInput[number];
+}
+
+/** True when an assistant message appears between a tool call and its output. */
+function hasInterleavedMessage(items: readonly unknown[]): boolean {
+	let pendingCalls = 0;
+	for (const item of items) {
+		if (!item || typeof item !== "object") continue;
+		const type = (item as { type?: unknown }).type;
+		if (type === "function_call" || type === "custom_tool_call" || type === "computer_call") {
+			pendingCalls += 1;
+			continue;
+		}
+		if (type === "function_call_output" || type === "custom_tool_call_output" || type === "computer_call_output") {
+			pendingCalls = Math.max(0, pendingCalls - 1);
+			continue;
+		}
+		if (pendingCalls > 0 && (item as { role?: unknown }).role === "assistant") return true;
+	}
+	return false;
+}
+
+describe("hoistInterleavedAssistantMessages", () => {
+	it("moves a message between a call batch and its outputs to before the first call", () => {
+		// Shape captured from a live opencode-go / Console Go 400: the model
+		// streamed a trailing thinking block after six tool calls, and the
+		// block-encode path preserved stream order, leaving the demoted text
+		// message between the calls and the appended outputs.
+		const input: ResponseInput = [
+			message("<think>\n**Planning focused runtime verification**\n</think>"),
+			call("call_a"),
+			call("call_b"),
+			call("call_c"),
+			call("call_d"),
+			call("call_e"),
+			call("call_f"),
+			message("<think>\n</thinking\n</think>"),
+			output("call_a"),
+			output("call_b"),
+			output("call_c"),
+			output("call_d"),
+			output("call_e"),
+			output("call_f"),
+		];
+
+		const hoisted = hoistInterleavedAssistantMessages(input);
+
+		expect(hasInterleavedMessage(hoisted)).toBe(false);
+		// The interleaved message survives, moved to the canonical position.
+		const messageIndex = hoisted.findIndex(item => (item as { content?: unknown }) && item === input[7]);
+		expect(messageIndex).toBeGreaterThanOrEqual(0);
+		const firstCallIndex = hoisted.findIndex(item => (item as { type?: string }).type === "function_call");
+		expect(messageIndex).toBeLessThan(firstCallIndex);
+		// All calls precede all outputs, content otherwise untouched.
+		expect(hoisted).toHaveLength(input.length);
+	});
+
+	it("returns the input unchanged when no message sits between calls and outputs", () => {
+		const input: ResponseInput = [
+			message("text before calls"),
+			call("call_a"),
+			call("call_b"),
+			output("call_a"),
+			output("call_b"),
+			user("next turn"),
+		];
+
+		expect(hoistInterleavedAssistantMessages(input)).toBe(input);
+	});
+
+	it("hoists messages between custom_tool_call batches and their outputs", () => {
+		const input: ResponseInput = [
+			{ type: "custom_tool_call", call_id: "call_c", name: "apply_patch", input: "patch" } as ResponseInput[number],
+			message("trailing think after the call"),
+			{ type: "custom_tool_call_output", call_id: "call_c", output: "ok" } as ResponseInput[number],
+		];
+
+		const hoisted = hoistInterleavedAssistantMessages(input);
+
+		expect(hasInterleavedMessage(hoisted)).toBe(false);
+		const firstCallIndex = hoisted.findIndex(item => (item as { type?: string }).type === "custom_tool_call");
+		expect((hoisted[firstCallIndex - 1] as { role?: unknown }).role).toBe("assistant");
+	});
+
+	it("does not hoist user messages", () => {
+		const input: ResponseInput = [call("call_a"), user("user text while a result is pending"), output("call_a")];
+
+		// A user message between a call and its output is not a shape this pass
+		// repairs (it does not arise from the block-encode path); leave it alone.
+		expect(hoistInterleavedAssistantMessages(input)).toBe(input);
+	});
+
+	it("handles multiple batches, repairing only the interleaved one", () => {
+		const input: ResponseInput = [
+			message("turn one text"),
+			call("call_1"),
+			output("call_1"),
+			message("turn two text"),
+			call("call_2"),
+			message("trailing think"),
+			output("call_2"),
+		];
+
+		const hoisted = hoistInterleavedAssistantMessages(input);
+
+		expect(hasInterleavedMessage(hoisted)).toBe(false);
+		expect(hoisted).toHaveLength(input.length);
+	});
+});
+
+describe("buildResponsesInput interleaved assistant turn", () => {
+	it("never emits a message between a call batch and its outputs", () => {
+		// Reproduces the failing live turn: one assistant message whose content
+		// blocks are [demoted think text, six tool calls, malformed trailing
+		// think text] — the block-encode path used to emit the trailing text as
+		// a message item after the calls, interleaving it between the calls and
+		// the six tool results appended afterwards.
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "<think>\n**Planning focused runtime verification**\n</think>" },
+						{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "uv run pytest -q" } },
+						{ type: "toolCall", id: "call_2", name: "bash", arguments: { command: "npm test" } },
+						{ type: "toolCall", id: "call_3", name: "bash", arguments: { command: "docker compose config" } },
+						{ type: "toolCall", id: "call_4", name: "grep", arguments: { pattern: "Vite" } },
+						{ type: "toolCall", id: "call_5", name: "read", arguments: { path: "README.md" } },
+						{ type: "toolCall", id: "call_6", name: "todo", arguments: { op: "view" } },
+						{ type: "text", text: "<think>\n</thinking\n</think>" },
+					],
+					api: "openai-responses",
+					provider: "opencode-go",
+					model: "test-opencode-go",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				...Array.from({ length: 6 }, (_, index) => ({
+					role: "toolResult" as const,
+					toolCallId: `call_${index + 1}`,
+					toolName: "bash",
+					content: [{ type: "text" as const, text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				})),
+			],
+		};
+
+		const items = buildResponsesInput({
+			model,
+			context,
+			strictResponsesPairing: true,
+			supportsImageDetailOriginal: false,
+		});
+
+		expect(hasInterleavedMessage(items)).toBe(false);
+		// The trailing think text survives, positioned before the calls.
+		const texts = items
+			.filter(item => (item as { type?: string }).type === "message")
+			.map(item => ((item as { content?: unknown }).content as TextContent[])[0]?.text ?? "");
+		expect(texts.some(text => text.includes("</thinking"))).toBe(true);
+		// Six calls, six outputs, all paired.
+		const callIds = items.filter(item => (item as { type?: string }).type === "function_call").length;
+		const outputIds = items.filter(item => (item as { type?: string }).type === "function_call_output").length;
+		expect(callIds).toBe(6);
+		expect(outputIds).toBe(6);
+	});
+});


### PR DESCRIPTION
Fixes #8789.

## Problem

Agent turns against the `opencode-go` provider (Console Go gateway) fail with:

```
400 Error from provider (Console Go): Upstream request failed: [invalid_request_error] No tool output found for tool call call_…
```

The named call's output **is present** in the request (all calls pair 1:1 with outputs — verified against the captured payload). The gateway rejects a specific input shape: when a model streams a trailing text/thinking block **after** its tool calls, the block-encode path preserves stream order and emits the demoted text as an assistant `message` item **between** the `function_call` items and the `function_call_output` items appended after them:

```jsonc
{ "type": "message", "role": "assistant", "content": [/* planning think */] },
{ "type": "function_call", "call_id": "call_a" },
/* …5 more calls… */
{ "type": "message", "role": "assistant", "content": [/* "<think>\n</thinking\n</think>" */] },  // ← interleaved
{ "type": "function_call_output", "call_id": "call_a" }
```

OpenAI's Responses API keys outputs by `call_id` and tolerates any item order; the Console Go validator does not — it rejects nondeterministically, naming a random call of the batch on every retry (5 identical retries named 5 different calls). The poisoned turn stays in history and breaks every subsequent request to that session, including idle recaps.

## Fix

`hoistInterleavedAssistantMessages`: hoist any assistant `message` item that sits between a tool-call batch and its outputs to before the first call of that batch, restoring the canonical `message(s) → calls → outputs` shape. Content is unchanged — only the position of an already-model-owned message item moves.

- `packages/ai/src/providers/openai-shared.ts` — new pass, wired into `buildResponsesInput` after the orphan repairs.
- `packages/agent/src/compaction/openai.ts` — mirrored in `buildOpenAiNativeHistory` (same shape can reach the wire through compaction inputs).
- `packages/ai/test/openai-responses-interleaved-message.test.ts` — unit tests for the pass (exact captured shape, canonical-input unchanged, custom tool calls, multi-batch) plus an integration test driving `buildResponsesInput` with the failing turn; the integration test fails without the wiring and passes with it.

## Verification

- `bun test` on the affected suites: 45 pass (interleaved-message, orphan-repair, computer-contract, parallel-tool-result-images, empty-tool-result, harmony-marker-escaping).
- `tsgo -p packages/ai/tsconfig.json --noEmit` and `-p packages/agent/tsconfig.json --noEmit`: clean.
- `biome check` on all changed files: clean.