### PR TITLE
fix(catalog,ai): align Antigravity Hub User-Agent and drop synthetic onboarding headers

### DIFF
--- a/packages/ai/src/registry/oauth/google-antigravity.ts
+++ b/packages/ai/src/registry/oauth/google-antigravity.ts
@@ -27,8 +27,6 @@ const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const CLOUD_CODE_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const DAILY_CLOUD_CODE_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
-const NODE_API_CLIENT_USER_AGENT = "google-api-nodejs-client/10.3.0";
-const GOOG_API_CLIENT_HEADER = "gl-node/22.21.1";
 const TIER_FREE = "free-tier";
 const PROJECT_ONBOARD_MAX_ATTEMPTS = 5;
 const PROJECT_ONBOARD_INTERVAL_MS = 2000;
@@ -207,14 +205,9 @@ async function discoverProject(
 			tier_id: fallbackTierId,
 			metadata: getAntigravityOnboardMetadata(),
 		};
-		const onboardHeaders: Record<string, string> = {
-			...headers,
-			"User-Agent": `${headers["User-Agent"]} ${NODE_API_CLIENT_USER_AGENT}`,
-			"X-Goog-Api-Client": GOOG_API_CLIENT_HEADER,
-		};
 		const provisionedProject = await onboardProjectWithRetries(
 			DAILY_CLOUD_CODE_ENDPOINT,
-			onboardHeaders,
+			headers,
 			onboardBody,
 			signal,
 			onProgress,

--- a/packages/catalog/src/wire/gemini-headers.ts
+++ b/packages/catalog/src/wire/gemini-headers.ts
@@ -23,8 +23,10 @@ export const getGeminiCliHeaders = (modelId?: string) => ({
  * (and its @google/genai → google-auth-library dependency chain) into the startup
  * parse graph.
  *
- * Format captured from the real 2.8.0 `antigravity/hub` client:
- * `antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)`.
+ * Format decompiled from real 2.8.1 `antigravity/hub` client (`setHeaders` @ `0x101a531c0`):
+ * `antigravity/hub/2.8.1 (os_type=darwin; arch=arm64; aidev_client; cl=963137146; auth_method=oauth)`.
+ * Token ordering from decompiled binary: `os_type` -> `arch` -> `aidev_client` -> `cl` -> `auth_method=oauth`.
+ *
  * The backend gates newer models (e.g. gemini-3.7-flash) on the client version,
  * so the version tracks the latest Antigravity release via the update manifest
  * (see {@link ensureAntigravityVersion}) with `DEFAULT_ANTIGRAVITY_VERSION` as
@@ -32,7 +34,7 @@ export const getGeminiCliHeaders = (modelId?: string) => ({
  * client the version and manifest are captured from, independent of the host
  * platform. Overrides: PI_AI_ANTIGRAVITY_VERSION / _CL / _OS / _ARCH.
  */
-export const DEFAULT_ANTIGRAVITY_VERSION = "2.8.0";
+export const DEFAULT_ANTIGRAVITY_VERSION = "2.8.1";
 
 const ANTIGRAVITY_VERSION_MANIFEST_URL =
 	"https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-arm64-mac.yml";
@@ -98,7 +100,8 @@ export function getAntigravityUserAgent(): string {
 	const cl = process.env.PI_AI_ANTIGRAVITY_CL || "963137146";
 	const os = process.env.PI_AI_ANTIGRAVITY_OS || "darwin";
 	const arch = process.env.PI_AI_ANTIGRAVITY_ARCH || "arm64";
-	return `antigravity/hub/${version} (aidev_client; os_type=${os}; arch=${arch}; cl=${cl})`;
+	const clPart = cl ? `; cl=${cl}` : "";
+	return `antigravity/hub/${version} (os_type=${os}; arch=${arch}; aidev_client${clPart}; auth_method=oauth)`;
 }
 
 /**

--- a/packages/catalog/test/antigravity-headers.test.ts
+++ b/packages/catalog/test/antigravity-headers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DEFAULT_ANTIGRAVITY_VERSION,
+	getAntigravityUserAgent,
+	getAntigravityVersion,
+	parseAntigravityManifestVersion,
+} from "../src/wire/gemini-headers";
+
+describe("antigravity User-Agent wire parity", () => {
+	it("generates exact decompiled Hub format: os_type -> arch -> aidev_client -> cl -> auth_method=oauth", () => {
+		const ua = getAntigravityUserAgent();
+		expect(ua).toBe(
+			`antigravity/hub/${DEFAULT_ANTIGRAVITY_VERSION} (os_type=darwin; arch=arm64; aidev_client; cl=963137146; auth_method=oauth)`,
+		);
+	});
+
+	it("honors env overrides for version, cl, os, and arch", () => {
+		const origEnv = { ...process.env };
+		try {
+			process.env.PI_AI_ANTIGRAVITY_VERSION = "2.9.0";
+			process.env.PI_AI_ANTIGRAVITY_OS = "windows";
+			process.env.PI_AI_ANTIGRAVITY_ARCH = "amd64";
+			process.env.PI_AI_ANTIGRAVITY_CL = "999888777";
+
+			expect(getAntigravityVersion()).toBe("2.9.0");
+			expect(getAntigravityUserAgent()).toBe(
+				"antigravity/hub/2.9.0 (os_type=windows; arch=amd64; aidev_client; cl=999888777; auth_method=oauth)",
+			);
+		} finally {
+			process.env = origEnv;
+		}
+	});
+
+	it("parses version correctly from update manifest YAML", () => {
+		expect(parseAntigravityManifestVersion("version: 2.8.1\nfiles: []")).toBe("2.8.1");
+		expect(parseAntigravityManifestVersion("version: '2.8.1'\n")).toBe("2.8.1");
+		expect(parseAntigravityManifestVersion('version: "2.8.1"\n')).toBe("2.8.1");
+		expect(parseAntigravityManifestVersion("invalid yaml")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

1. **User-Agent format parity**: Align `getAntigravityUserAgent()` token sequence with decompiled Antigravity Hub 2.8.1 (`language_server` binary `codeassistclient.(*CodeAssistClient).setHeaders` @ `0x101a531c0`):
   - Decompiled sequence: `os_type` → `arch` → `aidev_client` → `cl` → `auth_method=oauth`.
   - Result: `antigravity/hub/2.8.1 (os_type=darwin; arch=arm64; aidev_client; cl=963137146; auth_method=oauth)`.
2. **Update default fallback version**: Update `DEFAULT_ANTIGRAVITY_VERSION` fallback from `2.8.0` to `2.8.1` (matching latest Hub DMG release).
3. **Drop synthetic onboarding headers**: Remove synthetic `NODE_API_CLIENT_USER_AGENT` (`google-api-nodejs-client/10.3.0`) and `GOOG_API_CLIENT_HEADER` (`gl-node/22.21.1`) from `onboardUser` requests (confirmed absent in decompiled Hub binary).
4. **Unit tests**: Added unit tests in `packages/catalog/test/antigravity-headers.test.ts`.

## Evidence & Verification

- **Decompiled Binary**: Antigravity Hub 2.8.1 arm64 (`language_server` 144.5MB Go1.26.5).
- **Live Wire Test with Active OAuth Token** (`daily-cloudcode-pa.googleapis.com`):
  - `fetchAvailableModels`: 28/28 models returned (200 OK).
  - `generateContent` (`gemini-3.7-flash-low`): 200 OK streaming completion.
- **Local Tests**:
  - `bun --cwd packages/catalog test test/antigravity-headers.test.ts` (3 passed, 0 failed)
  - `biome check` (0 errors)