### PR TITLE
fix(tests): stop ANTHROPIC_BASE_URL from failing the Anthropic suites

### DIFF
--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -32,7 +32,7 @@ import type {
 } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
-import { withEnv } from "./helpers";
+import { withEnv, withOfficialAnthropicEndpoint } from "./helpers";
 
 const ANTHROPIC_MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
 	id: "claude-sonnet-4-5",
@@ -151,6 +151,8 @@ function expectClaudeMetadataUserId(userId: string | undefined, expectedSessionI
 		}
 	}
 }
+
+withOfficialAnthropicEndpoint();
 
 describe("Anthropic request fingerprint alignment", () => {
 	it("maps Stainless arch values from explicit inputs", () => {

--- a/packages/ai/test/anthropic-cache-refresh.test.ts
+++ b/packages/ai/test/anthropic-cache-refresh.test.ts
@@ -3,6 +3,7 @@ import { streamSimple } from "@oh-my-pi/pi-ai";
 import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { Context, FetchImpl, Model, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { withOfficialAnthropicEndpoint } from "./helpers";
 
 const CACHE_REFRESH_DELAY_MS = 5 * 60_000 - 15_000;
 const CACHE_TOKENS = 1_200;
@@ -208,6 +209,8 @@ afterEach(() => {
 	vi.useRealTimers();
 	vi.restoreAllMocks();
 });
+
+withOfficialAnthropicEndpoint();
 
 describe("Anthropic prompt-cache refresh", () => {
 	it("replays max_tokens=0 once per interval and stops after three refreshes", async () => {

--- a/packages/ai/test/anthropic-fast-mode.test.ts
+++ b/packages/ai/test/anthropic-fast-mode.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { Context, Model, ProviderSessionState, ServiceTier } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { withOfficialAnthropicEndpoint } from "./helpers";
 
 function makeAnthropicModel(id: string): Model<"anthropic-messages"> {
 	return buildModel({
@@ -51,6 +52,8 @@ function capturePayload(model: Model<"anthropic-messages">, opts: CaptureOptions
 	});
 	return promise;
 }
+
+withOfficialAnthropicEndpoint();
 
 describe("Anthropic priority service tier → speed='fast'", () => {
 	it("sets speed='fast' for Claude Opus 4.7 when serviceTier='priority'", async () => {

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -13,7 +13,7 @@ import type {
 import type { AssistantMessageEvent, Context, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { structuredCloneJSON } from "@oh-my-pi/pi-utils";
-import { withEnv } from "./helpers";
+import { withEnv, withOfficialAnthropicEndpoint } from "./helpers";
 
 const model: Model<"anthropic-messages"> = buildModel({
 	id: "claude-sonnet-4-5",
@@ -350,6 +350,8 @@ function countEvents(events: AssistantMessageEvent[], type: AssistantMessageEven
 afterEach(() => {
 	vi.restoreAllMocks();
 });
+
+withOfficialAnthropicEndpoint();
 
 describe("anthropic stream envelope handling", () => {
 	it("ignores duplicate message_start envelopes without resetting streamed text", async () => {

--- a/packages/ai/test/helpers/index.ts
+++ b/packages/ai/test/helpers/index.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai/types";
@@ -113,4 +114,30 @@ async function readAuthGatewayE2EStatus(): Promise<AuthGatewayE2EStatus> {
 		return { ok: false, reason: `healthz unreachable: ${msg}` };
 	}
 	return { ok: true, token };
+}
+
+/**
+ * Neutralize `ANTHROPIC_BASE_URL` for the calling test file.
+ *
+ * The variable reroutes the effective Anthropic endpoint, and every
+ * "official endpoint" behavior — eager tool-input streaming, long cache
+ * retention, the Cowork TLS profile, the Claude Code session header — switches
+ * off once it points elsewhere. A contributor running a gateway, or running the
+ * suite from inside another agent, otherwise sees these tests fail on a clean
+ * checkout. Tests that exercise gateway routing set the variable explicitly
+ * with `withEnv` inside the test body, which still wins over this reset.
+ */
+export function withOfficialAnthropicEndpoint(): void {
+	let previous: string | undefined;
+	beforeEach(() => {
+		previous = Bun.env.ANTHROPIC_BASE_URL;
+		delete Bun.env.ANTHROPIC_BASE_URL;
+	});
+	afterEach(() => {
+		if (previous === undefined) {
+			delete Bun.env.ANTHROPIC_BASE_URL;
+		} else {
+			Bun.env.ANTHROPIC_BASE_URL = previous;
+		}
+	});
 }

--- a/packages/ai/test/leaked-thinking-stream.test.ts
+++ b/packages/ai/test/leaked-thinking-stream.test.ts
@@ -15,6 +15,7 @@ import { getStreamingPartialJson, setStreamingPartialJson } from "@oh-my-pi/pi-a
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { wrapLeakedThinkingStream } from "@oh-my-pi/pi-ai/utils/leaked-thinking-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { withOfficialAnthropicEndpoint } from "./helpers";
 
 /** Minimal assistant message; `content`/`stopReason` overridden per event. */
 function msg(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
@@ -91,6 +92,8 @@ async function nextToolSnapshot(iterator: AsyncIterator<AssistantMessageEvent>):
 		};
 	}
 }
+
+withOfficialAnthropicEndpoint();
 
 describe("wrapLeakedThinkingStream", () => {
 	async function runLeakedText(chunks: readonly string[]): Promise<{

--- a/packages/coding-agent/test/fast-mode-scope.test.ts
+++ b/packages/coding-agent/test/fast-mode-scope.test.ts
@@ -10,6 +10,9 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { withOfficialAnthropicEndpoint } from "./helpers/anthropic-endpoint";
+
+withOfficialAnthropicEndpoint();
 
 describe("/fast targets the current model's service-tier family", () => {
 	let tempDir: TempDir;

--- a/packages/coding-agent/test/helpers/anthropic-endpoint.ts
+++ b/packages/coding-agent/test/helpers/anthropic-endpoint.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach } from "bun:test";
+
+/**
+ * Neutralize `ANTHROPIC_BASE_URL` for the calling test file.
+ *
+ * The variable reroutes the effective Anthropic endpoint, and every
+ * "official endpoint" behavior — eager tool-input streaming, long cache
+ * retention, the Cowork TLS profile, the Claude Code session header — switches
+ * off once it points elsewhere. A contributor running a gateway, or running the
+ * suite from inside another agent, otherwise sees these tests fail on a clean
+ * checkout. Tests that exercise gateway routing set the variable explicitly
+ * with `withEnv` inside the test body, which still wins over this reset.
+ */
+export function withOfficialAnthropicEndpoint(): void {
+	let previous: string | undefined;
+	beforeEach(() => {
+		previous = Bun.env.ANTHROPIC_BASE_URL;
+		delete Bun.env.ANTHROPIC_BASE_URL;
+	});
+	afterEach(() => {
+		if (previous === undefined) {
+			delete Bun.env.ANTHROPIC_BASE_URL;
+		} else {
+			Bun.env.ANTHROPIC_BASE_URL = previous;
+		}
+	});
+}


### PR DESCRIPTION
I reviewed the full diff; this change stops the Anthropic tests from being affected by the local `ANTHROPIC_BASE_URL`.

## Problem

On a clean checkout, `bun run test:ts` fails 14 tests across 6 files when the
developer's shell has `ANTHROPIC_BASE_URL` set:

| File | Failures |
| --- | --- |
| `packages/ai/test/anthropic-alignment.test.ts` | 6 |
| `packages/ai/test/anthropic-cache-refresh.test.ts` | 4 |
| `packages/ai/test/anthropic-fast-mode.test.ts` | 1 |
| `packages/ai/test/anthropic-stream-envelope.test.ts` | 1 |
| `packages/ai/test/leaked-thinking-stream.test.ts` | 1 |
| `packages/coding-agent/test/fast-mode-scope.test.ts` | 1 |

`resolveAnthropicBaseUrl` reads `$env.ANTHROPIC_BASE_URL` ahead of the model's
own `baseUrl`, so the effective endpoint stops being official. Everything gated
on that — `eager_input_streaming`, long cache retention, the Cowork TLS profile,
the Claude Code session header, priority service tier — switches off, and the
assertions fail.

This is easy to hit for this project's own audience: anyone routing through a
gateway, and anyone running the suite from inside another agent (which is how I
found it).

## Change

Adds `withOfficialAnthropicEndpoint()` — a `beforeEach`/`afterEach` pair that
removes the variable and restores whatever was there. Six files call it. This
matches the save-delete-restore pattern already used in
`anthropic-stream-timeout.test.ts` and `aws-credentials.test.ts`, and keeps the
narrow per-test seam AGENTS.md asks for instead of a file-wide `Bun.env` write.

The tests that deliberately exercise gateway routing set the variable with
`withEnv` inside the test body, which runs after `beforeEach` and still wins.

`packages/ai` and `packages/coding-agent` do not share test helpers, so the
function is defined once per package.

## Verification

With `ANTHROPIC_BASE_URL` set in my shell:

- before: 14 failures across the 6 files above; after: 0.
- the two gateway-routing tests in `anthropic-alignment.test.ts` still pass.
- reverting only the `delete` inside the helper brings back exactly the same
  14 failures, 6/4/1/1/1/1 per file — so the helper is what fixes them.
- the variable is still set in my shell after the run, so the restore works.

With the variable unset (CI's situation), the same files stay green — no
behavior change for a clean environment.

Full suite went from 4 failing chunks to 2. The remaining two are unrelated and
out of scope for this PR: `status-line-path.test.ts` depends on a `Projects`
directory in `$HOME`, and `bash-executor.test.ts` reads the developer's real
`~/.zshrc`. Both fail with `ANTHROPIC_BASE_URL` unset too.

`bun run check:ts` and `biome check` are clean.
