### PR TITLE
Fix local memory guidance before summary exists

### DIFF
--- a/packages/coding-agent/src/prompts/memories/read-path.md
+++ b/packages/coding-agent/src/prompts/memories/read-path.md
@@ -1,8 +1,8 @@
 # Memory Guidance
 Root: memory://root
 Rules:
-1. Read `memory://root/memory_summary.md` first.
-2. If needed, inspect `memory://root/MEMORY.md` and `memory://root/skills/<name>/SKILL.md`.
+1. Read `memory://root` first. It resolves to the current summary when available.
+2. If it is unavailable or more detail is needed, inspect `memory://root/MEMORY.md` and `memory://root/skills/<name>/SKILL.md`.
 3. Memory: heuristics/process context; current repo files, runtime output, user instruction: factual state/final decisions.
 4. Memory changes plan → cite artifact path (e.g. `memory://root/skills/<name>/SKILL.md`) and current-repo evidence.
 5. Memory disagreement with repo state/user instruction → stale; corrected behavior, then update/regenerate memory artifacts.

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -473,7 +473,7 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 
 		const payload = await buildMemoryToolDeveloperInstructions(agentDir, settings);
 		expect(payload).toBeDefined();
-		expect(payload).toContain("memory://root/memory_summary.md");
+		expect(payload).toContain("Read `memory://root` first.");
 		expect(payload).not.toContain(memoryRoot);
 		expect(payload).toContain("...[truncated]...");
 	});

--- a/packages/coding-agent/test/memories/instructions.test.ts
+++ b/packages/coding-agent/test/memories/instructions.test.ts
@@ -25,8 +25,11 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 
 			const instructions = await buildMemoryToolDeveloperInstructions(agentDir, settings);
 			expect(instructions).toBeDefined();
-			expect(instructions).toContain("memory://root/memory_summary.md");
-			expect(instructions).toContain("memory://root/skills/<name>/SKILL.md");
+			expect(instructions).toContain("Read `memory://root` first.");
+			expect(instructions).toContain(
+				"If it is unavailable or more detail is needed, inspect `memory://root/MEMORY.md`",
+			);
+			expect(instructions).not.toContain("memory://root/memory_summary.md");
 			expect(instructions).not.toContain(memoryRoot);
 		});
 	});


### PR DESCRIPTION
## What

I reviewed the full diff; this changes local-memory guidance to use `memory://root` so startup does not fail before `memory_summary.md` exists.

- Replace the direct `memory://root/memory_summary.md` instruction with the stable `memory://root` entry point.
- Retain `memory://root/MEMORY.md` as the detailed fallback.
- Update prompt-rendering regressions to prevent the unstable explicit URI from returning.

## Why

Local-memory consolidation runs in the background during startup. The previous prompt instructed the agent to read the materialized summary file directly,
which can produce `Memory file not found` before consolidation has written it. `memory://root` is the documented URI and resolves to the current summary
when available.

## Testing

- `bun test test/memories/instructions.test.ts test/memories-runtime.test.ts test/internal-urls/memory-protocol.test.ts`
  - 35 passed, 0 failed
- `bun run check`
  - 35 passed, 0 failed
- `bun run check`
  - Biome and TypeScript checks passed

---

- [x] `bun run check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)