### PR TITLE
fix(tui): show subagent role and generate real HUD labels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Subagents HUD role display and restored generated task labels by keeping spawn handles separate from UI descriptions.
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed
@@ -21,11 +25,6 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
-### Fixed
-
-- Fixed the anchored Subagents HUD omitting the spawned agent role and repeating the spawn id as `Name: Name` when the generated label echoed the handle.
-- Stopped the task tool from using the spawn handle as the HUD description, which blocked tiny-model label generation and produced `Name: Name`.
-
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 
 - Fixed the anchored Subagents HUD omitting the spawned agent role and repeating the spawn id as `Name: Name` when the generated label echoed the handle.
+- Stopped the task tool from using the spawn handle as the HUD description, which blocked tiny-model label generation and produced `Name: Name`.
 
 
 ## [17.3.5] - 2026-08-16

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,10 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
+### Fixed
+
+- Fixed the anchored Subagents HUD omitting the spawned agent role and repeating the spawn id as `Name: Name` when the generated label echoed the handle.
+
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -117,6 +117,7 @@ import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } fr
 import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
+import { labelEchoesHandle } from "../task/label";
 import { agentTypeBadge, formatTaskId } from "../task/render";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import { tinyTitleClient } from "../tiny/title-client";
@@ -450,13 +451,6 @@ const MODEL_CYCLE_TRACK_CLEAR_MS = 4000;
 const SUBAGENT_HUD_VISIBLE_LIMIT = 8;
 const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
 
-/** True when `label` is the spawn handle, including collision suffixes (`Name-2`). */
-function hudLabelEchoesId(id: string, label: string): boolean {
-	if (label.localeCompare(id, undefined, { sensitivity: "accent" }) === 0) return true;
-	const suffix = id.startsWith(`${label}-`) ? id.slice(label.length + 1) : "";
-	return /^\d+$/.test(suffix);
-}
-
 /**
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
  * a bounded set of running-agent rows in the same `Id ⟨role⟩: description` shape
@@ -487,7 +481,7 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 				const badge = agentTypeBadge(role, theme);
 				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
 				const description = session.description?.trim() || session.progress?.description?.trim();
-				const distinctDescription = description && !hudLabelEchoesId(session.id, description) ? description : undefined;
+				const distinctDescription = description && !labelEchoesHandle(session.id, description) ? description : undefined;
 				if (distinctDescription) {
 					const budget = Math.max(
 						TRUNCATE_LENGTHS.SHORT,
@@ -498,7 +492,7 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 					// No spawn description: fall back to a muted task preview, same as
 					// the inline task rows when a row has no label.
 					const taskPreview = session.progress?.task?.trim();
-					if (taskPreview && !hudLabelEchoesId(session.id, taskPreview)) {
+					if (taskPreview && !labelEchoesHandle(session.id, taskPreview)) {
 						line += ` ${theme.fg("muted", truncateToWidth(replaceTabs(taskPreview), TRUNCATE_LENGTHS.SHORT))}`;
 					}
 				}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -450,6 +450,13 @@ const MODEL_CYCLE_TRACK_CLEAR_MS = 4000;
 const SUBAGENT_HUD_VISIBLE_LIMIT = 8;
 const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
 
+/** True when `label` is the spawn handle, including collision suffixes (`Name-2`). */
+function hudLabelEchoesId(id: string, label: string): boolean {
+	if (label.localeCompare(id, undefined, { sensitivity: "accent" }) === 0) return true;
+	const suffix = id.startsWith(`${label}-`) ? id.slice(label.length + 1) : "";
+	return /^\d+$/.test(suffix);
+}
+
 /**
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
  * a bounded set of running-agent rows in the same `Id ⟨role⟩: description` shape
@@ -480,10 +487,7 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 				const badge = agentTypeBadge(role, theme);
 				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
 				const description = session.description?.trim() || session.progress?.description?.trim();
-				const distinctDescription =
-					description && description.localeCompare(session.id, undefined, { sensitivity: "accent" }) !== 0
-						? description
-						: undefined;
+				const distinctDescription = description && !hudLabelEchoesId(session.id, description) ? description : undefined;
 				if (distinctDescription) {
 					const budget = Math.max(
 						TRUNCATE_LENGTHS.SHORT,
@@ -494,7 +498,7 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 					// No spawn description: fall back to a muted task preview, same as
 					// the inline task rows when a row has no label.
 					const taskPreview = session.progress?.task?.trim();
-					if (taskPreview && taskPreview.localeCompare(session.id, undefined, { sensitivity: "accent" }) !== 0) {
+					if (taskPreview && !hudLabelEchoesId(session.id, taskPreview)) {
 						line += ` ${theme.fg("muted", truncateToWidth(replaceTabs(taskPreview), TRUNCATE_LENGTHS.SHORT))}`;
 					}
 				}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -481,7 +481,8 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 				const badge = agentTypeBadge(role, theme);
 				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
 				const description = session.description?.trim() || session.progress?.description?.trim();
-				const distinctDescription = description && !labelEchoesHandle(session.id, description) ? description : undefined;
+				const distinctDescription =
+					description && !labelEchoesHandle(session.id, description) ? description : undefined;
 				if (distinctDescription) {
 					const budget = Math.max(
 						TRUNCATE_LENGTHS.SHORT,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -117,7 +117,7 @@ import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } fr
 import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
-import { formatTaskId } from "../task/render";
+import { agentTypeBadge, formatTaskId } from "../task/render";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import { tinyTitleClient } from "../tiny/title-client";
 import type { LspStartupServerInfo } from "../tools";
@@ -452,8 +452,8 @@ const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
 
 /**
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
- * a bounded set of running-agent rows in the same `Id: description` shape the
- * inline task rows use (muted task preview when no description was given).
+ * a bounded set of running-agent rows in the same `Id ⟨role⟩: description` shape
+ * the inline task rows use (muted task preview when no description was given).
  * Layout mirrors the Todos HUD exactly: unindented header, then
  * `renderTreeList` rows (dim connectors) shifted right by one space.
  * Only detached background spawns are listed: a sync task call blocks the
@@ -476,16 +476,25 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 			expanded: true,
 			renderItem: session => {
 				const displayId = formatTaskId(session.id);
-				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}`;
+				const role = session.agent ?? session.progress?.agent;
+				const badge = agentTypeBadge(role, theme);
+				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
 				const description = session.description?.trim() || session.progress?.description?.trim();
-				if (description) {
-					const budget = Math.max(TRUNCATE_LENGTHS.SHORT, columns - visibleWidth(displayId) - 10);
-					line += `${theme.fg("accent", ":")} ${theme.fg("accent", truncateToWidth(replaceTabs(description), budget))}`;
+				const distinctDescription =
+					description && description.localeCompare(session.id, undefined, { sensitivity: "accent" }) !== 0
+						? description
+						: undefined;
+				if (distinctDescription) {
+					const budget = Math.max(
+						TRUNCATE_LENGTHS.SHORT,
+						columns - visibleWidth(displayId) - visibleWidth(Bun.stripANSI(badge)) - 10,
+					);
+					line += `${theme.fg("accent", ":")} ${theme.fg("accent", truncateToWidth(replaceTabs(distinctDescription), budget))}`;
 				} else {
 					// No spawn description: fall back to a muted task preview, same as
 					// the inline task rows when a row has no label.
 					const taskPreview = session.progress?.task?.trim();
-					if (taskPreview) {
+					if (taskPreview && taskPreview.localeCompare(session.id, undefined, { sensitivity: "accent" }) !== 0) {
 						line += ` ${theme.fg("muted", truncateToWidth(replaceTabs(taskPreview), TRUNCATE_LENGTHS.SHORT))}`;
 					}
 				}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1424,6 +1424,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 				...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 				...(params.effort !== undefined ? { effort: params.effort } : {}),
+				// `name` is the spawn handle: keep it for id allocation when this
+				// path did not pre-reserve one. Do not treat it as a HUD description.
 				identity: { id: preAllocatedId, label: params.name },
 				index: spawnIndex,
 				parentToolCallId: toolCallId,

--- a/packages/coding-agent/src/task/label.ts
+++ b/packages/coding-agent/src/task/label.ts
@@ -13,8 +13,11 @@ const TASK_LABEL_SYSTEM_PROMPT = prompt.render(taskLabelSystemPrompt);
 export function labelEchoesHandle(handle: string | undefined, label: string): boolean {
 	if (!handle) return false;
 	if (label.localeCompare(handle, undefined, { sensitivity: "accent" }) === 0) return true;
-	const suffix = handle.startsWith(`${label}-`) ? handle.slice(label.length + 1) : "";
-	return /^\d+$/.test(suffix);
+	const separator = handle.lastIndexOf("-");
+	if (separator <= 0) return false;
+	const prefix = handle.slice(0, separator);
+	const suffix = handle.slice(separator + 1);
+	return /^\d+$/.test(suffix) && prefix.localeCompare(label, undefined, { sensitivity: "accent" }) === 0;
 }
 
 /** Compresses a delegated assignment into a one-sentence UI label via the tiny title model — fired by the executor spawn path because the task wire schema no longer carries a `description`; null on empty input or failure. */

--- a/packages/coding-agent/src/task/label.ts
+++ b/packages/coding-agent/src/task/label.ts
@@ -9,6 +9,14 @@ import { generateSessionTitle } from "../utils/title-generator";
 
 const TASK_LABEL_SYSTEM_PROMPT = prompt.render(taskLabelSystemPrompt);
 
+/** True when a generated label is just the spawn handle, including `Name-2`. */
+export function labelEchoesHandle(handle: string | undefined, label: string): boolean {
+	if (!handle) return false;
+	if (label.localeCompare(handle, undefined, { sensitivity: "accent" }) === 0) return true;
+	const suffix = handle.startsWith(`${label}-`) ? handle.slice(label.length + 1) : "";
+	return /^\d+$/.test(suffix);
+}
+
 /** Compresses a delegated assignment into a one-sentence UI label via the tiny title model — fired by the executor spawn path because the task wire schema no longer carries a `description`; null on empty input or failure. */
 export async function generateTaskLabel(
 	assignment: string,
@@ -20,7 +28,7 @@ export async function generateTaskLabel(
 	const text = assignment.trim();
 	if (!text) return null;
 	try {
-		return await generateSessionTitle(
+		const label = await generateSessionTitle(
 			text,
 			registry,
 			settings,
@@ -30,6 +38,8 @@ export async function generateTaskLabel(
 			TASK_LABEL_SYSTEM_PROMPT,
 			signal,
 		);
+		if (!label || labelEchoesHandle(sessionId, label)) return null;
+		return label;
 	} catch (err) {
 		logger.debug("task-label: generation failed", {
 			sessionId,

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -710,7 +710,7 @@ function formatAgentHeaderLabel(args: Partial<TaskParams> | undefined): string |
 }
 
 /** Dim `⟨agent⟩` badge for a non-default agent type; empty for the generic worker. */
-function agentTypeBadge(agent: string | undefined, theme: Theme): string {
+export function agentTypeBadge(agent: string | undefined, theme: Theme): string {
 	const trimmed = agent?.trim();
 	if (!trimmed || trimmed === "task") return "";
 	return ` ${theme.fg("dim", `${theme.format.bracketLeft}${trimmed}${theme.format.bracketRight}`)}`;

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -393,7 +393,10 @@ function buildExecutorOptions(
 		assignment: request.assignment.trim(),
 		context: request.context?.trim() || undefined,
 		planReference: undefined,
-		description: trimToUndefined(request.identity?.label),
+		// Task `name` is the spawn handle (id allocation). Eval `label` is a
+		// real UI description. Copy it only for eval so generateTaskLabel can run.
+		description:
+			request.invocationKind === "eval" ? trimToUndefined(request.identity?.label) : undefined,
 		index: request.index ?? 0,
 		parentToolCallId: request.parentToolCallId,
 		detached: request.detached,
@@ -476,7 +479,8 @@ function buildFailureResult(
 			agentSource: policy.agent.source,
 			task: renderSubagentPrompt(request.assignment),
 			assignment: request.assignment.trim(),
-			description: trimToUndefined(request.identity?.label),
+			description:
+				request.invocationKind === "eval" ? trimToUndefined(request.identity?.label) : undefined,
 			exitCode: 1,
 			output: "",
 			stderr: message,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -395,8 +395,7 @@ function buildExecutorOptions(
 		planReference: undefined,
 		// Task `name` is the spawn handle (id allocation). Eval `label` is a
 		// real UI description. Copy it only for eval so generateTaskLabel can run.
-		description:
-			request.invocationKind === "eval" ? trimToUndefined(request.identity?.label) : undefined,
+		description: request.invocationKind === "eval" ? trimToUndefined(request.identity?.label) : undefined,
 		index: request.index ?? 0,
 		parentToolCallId: request.parentToolCallId,
 		detached: request.detached,
@@ -479,8 +478,7 @@ function buildFailureResult(
 			agentSource: policy.agent.source,
 			task: renderSubagentPrompt(request.assignment),
 			assignment: request.assignment.trim(),
-			description:
-				request.invocationKind === "eval" ? trimToUndefined(request.identity?.label) : undefined,
+			description: request.invocationKind === "eval" ? trimToUndefined(request.identity?.label) : undefined,
 			exitCode: 1,
 			output: "",
 			stderr: message,

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -130,6 +130,17 @@ describe("subagent HUD lines", () => {
 		expect(echoed).toMatch(/HindsightMcpFunnel.*scout/);
 		expect(echoed).not.toContain("HindsightMcpFunnel: HindsightMcpFunnel");
 
+		const collision = render([
+			makeSession({
+				id: "HindsightMcpFunnel-3",
+				agent: "scout",
+				description: "HindsightMcpFunnel",
+			}),
+		]);
+		expect(collision).toContain("HindsightMcpFunnel-3");
+		expect(collision).toMatch(/HindsightMcpFunnel-3.*scout/);
+		expect(collision).not.toContain("HindsightMcpFunnel-3: HindsightMcpFunnel");
+
 		const defaultWorker = render([makeSession({ id: "AuthLoader", agent: "task", description: "Refactor auth" })]);
 		expect(defaultWorker).toContain("AuthLoader: Refactor auth");
 		expect(defaultWorker).not.toMatch(/AuthLoader.*task/);

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -107,6 +107,34 @@ describe("subagent HUD lines", () => {
 		expect(out).toContain("SchemaMigrator: Migrating the users table");
 	});
 
+	it("shows a non-default role badge and hides descriptions that only echo the id", () => {
+		const withRole = render([
+			makeSession({
+				id: "HindsightMcpFunnel",
+				agent: "scout",
+				description: "Audit MCP funnel wiring",
+			}),
+		]);
+		expect(withRole).toContain("HindsightMcpFunnel");
+		expect(withRole).toMatch(/HindsightMcpFunnel.*scout/);
+		expect(withRole).toContain("Audit MCP funnel wiring");
+
+		const echoed = render([
+			makeSession({
+				id: "HindsightMcpFunnel",
+				agent: "scout",
+				description: "HindsightMcpFunnel",
+			}),
+		]);
+		expect(echoed).toContain("HindsightMcpFunnel");
+		expect(echoed).toMatch(/HindsightMcpFunnel.*scout/);
+		expect(echoed).not.toContain("HindsightMcpFunnel: HindsightMcpFunnel");
+
+		const defaultWorker = render([makeSession({ id: "AuthLoader", agent: "task", description: "Refactor auth" })]);
+		expect(defaultWorker).toContain("AuthLoader: Refactor auth");
+		expect(defaultWorker).not.toMatch(/AuthLoader.*task/);
+	});
+
 	it("only shows active subagents and clears once everything finished", () => {
 		const finishedStates = ["completed", "failed", "aborted"] as const;
 		const sessions: ObservableSession[] = [

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -110,40 +110,40 @@ describe("subagent HUD lines", () => {
 	it("shows a non-default role badge and hides descriptions that only echo the id", () => {
 		const withRole = render([
 			makeSession({
-				id: "HindsightMcpFunnel",
+				id: "AuthLoader",
 				agent: "scout",
-				description: "Audit MCP funnel wiring",
+				description: "Refactor the auth flow",
 			}),
 		]);
-		expect(withRole).toContain("HindsightMcpFunnel");
-		expect(withRole).toMatch(/HindsightMcpFunnel.*scout/);
-		expect(withRole).toContain("Audit MCP funnel wiring");
+		expect(withRole).toContain("AuthLoader");
+		expect(withRole).toMatch(/AuthLoader.*scout/);
+		expect(withRole).toContain("Refactor the auth flow");
 
 		const echoed = render([
 			makeSession({
-				id: "HindsightMcpFunnel",
+				id: "AuthLoader",
 				agent: "scout",
-				description: "HindsightMcpFunnel",
+				description: "AuthLoader",
 			}),
 		]);
-		expect(echoed).toContain("HindsightMcpFunnel");
-		expect(echoed).toMatch(/HindsightMcpFunnel.*scout/);
-		expect(echoed).not.toContain("HindsightMcpFunnel: HindsightMcpFunnel");
+		expect(echoed).toContain("AuthLoader");
+		expect(echoed).toMatch(/AuthLoader.*scout/);
+		expect(echoed).not.toContain("AuthLoader: AuthLoader");
 
 		const collision = render([
 			makeSession({
-				id: "HindsightMcpFunnel-3",
+				id: "AuthLoader-3",
 				agent: "scout",
-				description: "HindsightMcpFunnel",
+				description: "AuthLoader",
 			}),
 		]);
-		expect(collision).toContain("HindsightMcpFunnel-3");
-		expect(collision).toMatch(/HindsightMcpFunnel-3.*scout/);
-		expect(collision).not.toContain("HindsightMcpFunnel-3: HindsightMcpFunnel");
+		expect(collision).toContain("AuthLoader-3");
+		expect(collision).toMatch(/AuthLoader-3.*scout/);
+		expect(collision).not.toContain("AuthLoader-3: AuthLoader");
 
-		const defaultWorker = render([makeSession({ id: "AuthLoader", agent: "task", description: "Refactor auth" })]);
-		expect(defaultWorker).toContain("AuthLoader: Refactor auth");
-		expect(defaultWorker).not.toMatch(/AuthLoader.*task/);
+		const defaultWorker = render([makeSession({ id: "SchemaMigrator", agent: "task", description: "Migrate users" })]);
+		expect(defaultWorker).toContain("SchemaMigrator: Migrate users");
+		expect(defaultWorker).not.toMatch(/SchemaMigrator.*task/);
 	});
 
 	it("only shows active subagents and clears once everything finished", () => {

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -141,7 +141,9 @@ describe("subagent HUD lines", () => {
 		expect(collision).toMatch(/AuthLoader-3.*scout/);
 		expect(collision).not.toContain("AuthLoader-3: AuthLoader");
 
-		const defaultWorker = render([makeSession({ id: "SchemaMigrator", agent: "task", description: "Migrate users" })]);
+		const defaultWorker = render([
+			makeSession({ id: "SchemaMigrator", agent: "task", description: "Migrate users" }),
+		]);
 		expect(defaultWorker).toContain("SchemaMigrator: Migrate users");
 		expect(defaultWorker).not.toMatch(/SchemaMigrator.*task/);
 	});

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -141,6 +141,16 @@ describe("subagent HUD lines", () => {
 		expect(collision).toMatch(/AuthLoader-3.*scout/);
 		expect(collision).not.toContain("AuthLoader-3: AuthLoader");
 
+		const mixedCase = render([
+			makeSession({
+				id: "AuthLoader-3",
+				agent: "scout",
+				description: "authloader",
+			}),
+		]);
+		expect(mixedCase).toContain("AuthLoader-3");
+		expect(mixedCase).not.toContain("AuthLoader-3: authloader");
+
 		const defaultWorker = render([
 			makeSession({ id: "SchemaMigrator", agent: "task", description: "Migrate users" }),
 		]);

--- a/packages/coding-agent/test/task-label.test.ts
+++ b/packages/coding-agent/test/task-label.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { generateTaskLabel } from "@oh-my-pi/pi-coding-agent/task/label";
+import { generateTaskLabel, labelEchoesHandle } from "@oh-my-pi/pi-coding-agent/task/label";
 
 function getModelOrThrow(id: string): Model<Api> {
 	const model = getBundledModel("anthropic", id);
@@ -92,5 +92,12 @@ describe("task label generation", () => {
 			"AuthLoader",
 		);
 		expect(labeled).toBe("Sleep then reply done");
+	});
+
+	it("treats a case-insensitive Name-N collision as an echoed handle", () => {
+		expect(labelEchoesHandle("AuthLoader-3", "authloader")).toBe(true);
+		expect(labelEchoesHandle("AuthLoader-3", "AuthLoader")).toBe(true);
+		expect(labelEchoesHandle("AuthLoader", "authloader")).toBe(true);
+		expect(labelEchoesHandle("AuthLoader-3", "Migrate users")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/task-label.test.ts
+++ b/packages/coding-agent/test/task-label.test.ts
@@ -65,4 +65,34 @@ describe("task label generation", () => {
 		expect(requestSignal).toBe(controller.signal);
 		expect(await label).toBeNull();
 	});
+
+	it("rejects a generated label that only echoes the spawn handle", async () => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "<title>AuthLoader</title>" }],
+		} as never);
+
+		const echoed = await generateTaskLabel(
+			"Sleep forty seconds then reply done",
+			createRegistry(model),
+			createSettings(model),
+			"AuthLoader",
+		);
+		expect(echoed).toBeNull();
+
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "<title>Sleep then reply done</title>" }],
+		} as never);
+		const labeled = await generateTaskLabel(
+			"Sleep forty seconds then reply done",
+			createRegistry(model),
+			createSettings(model),
+			"AuthLoader",
+		);
+		expect(labeled).toBe("Sleep then reply done");
+	});
+
+
 });

--- a/packages/coding-agent/test/task-label.test.ts
+++ b/packages/coding-agent/test/task-label.test.ts
@@ -93,6 +93,4 @@ describe("task label generation", () => {
 		);
 		expect(labeled).toBe("Sleep then reply done");
 	});
-
-
 });

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -213,7 +213,6 @@ describe("structured subagent primitive", () => {
 		await fs.rm(evalLabeled.artifactsDir, { recursive: true, force: true });
 	});
 
-
 	it("derives modelRole from the raw selector source in request, override, definition order", async () => {
 		const customAgent = { ...AGENT, model: ["@definition"] };
 		mockDiscovery(customAgent);

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -186,6 +186,34 @@ describe("structured subagent primitive", () => {
 		expect(settled.result.modelRole).toBe("reviewer");
 		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
 	});
+	it("does not treat a spawn handle as the HUD description", async () => {
+		mockDiscovery();
+		const dispatched: executorModule.ExecutorOptions[] = [];
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			dispatched.push(options);
+			return result();
+		});
+
+		const handleOnly = await runStructuredSubagent(
+			request({ identity: { id: "AuthLoader", label: "AuthLoader" }, retainArtifacts: true }),
+		);
+		expect(dispatched[0]?.description).toBeUndefined();
+		expect(dispatched[0]?.id).toBe("AuthLoader");
+		await fs.rm(handleOnly.artifactsDir, { recursive: true, force: true });
+
+		dispatched.length = 0;
+		const evalLabeled = await runStructuredSubagent(
+			request({
+				invocationKind: "eval",
+				identity: { label: "Refactor the auth flow" },
+				retainArtifacts: true,
+			}),
+		);
+		expect(dispatched[0]?.description).toBe("Refactor the auth flow");
+		await fs.rm(evalLabeled.artifactsDir, { recursive: true, force: true });
+	});
+
+
 	it("derives modelRole from the raw selector source in request, override, definition order", async () => {
 		const customAgent = { ...AGENT, model: ["@definition"] };
 		mockDiscovery(customAgent);


### PR DESCRIPTION
## What

Two stacked HUD fixes:

1. The anchored Subagents HUD now shows the spawned agent role (`⟨scout⟩`) the same way inline Task rows already do, and it no longer prints `Name: Name` when a description just echoes the handle.
2. The task tool no longer treats the spawn handle (`name`) as the HUD description. That copy blocked `generateTaskLabel`, so the tiny-model summary never ran. Eval `label` is still a real UI description; task `name` stays an id-allocation handle.

## Why

`task` already stores `session.agent`, but `renderSubagentHudLines` only rendered `id: description`. The first symptom was a scout named `HindsightMcpFunnel` whose row looked like `HindsightMcpFunnel: HindsightMcpFunnel`, with no role.

That HUD filter was only a bandage. The cause was earlier: `#runSpawn` passed `identity: { id, label: params.name }`, and `buildExecutorOptions` copied `identity.label` into `progress.description`. `generateTaskLabel` then skipped because a description was already set.

## Testing

- `bun test packages/coding-agent/test/subagent-hud-render.test.ts packages/coding-agent/test/task-label.test.ts packages/coding-agent/test/task/structured-subagent.test.ts` — 38 pass
- Restarted a clean omp on this worktree after the source mtimes, then spawned a default worker and a scout. Live HUD:
  - `AuthLoader: Execute sleep command and reply done`
  - `SchemaMigrator ⟨scout⟩: Wait 45 seconds then output done`
- Default worker still has no badge; scout badge is live.
- `labelEchoesHandle("AuthLoader-3", "authloader")` is now true (case-insensitive `Name-N` suffix).
- Biome format on the touched files (CI lint failed on wrapping / extra blank lines).

---

- [ ] `bun check` passes (not run; focused HUD/label tests + biome on the touched files)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)