### PR TITLE
fix(tests): isolate TUI scrollback tests from terminal multiplexers

### DIFF
--- a/packages/coding-agent/test/helpers/terminal-multiplexer.ts
+++ b/packages/coding-agent/test/helpers/terminal-multiplexer.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach } from "bun:test";
+
+/**
+ * Neutralize every terminal-multiplexer signal for the calling test file.
+ *
+ * `isInsideTerminalMultiplexer()` treats `TMUX`, `STY`, `ZELLIJ`,
+ * `HERDR_ENV=1`, the `CMUX_*` markers and a `tmux`/`screen` `TERM` as
+ * authoritative, and `isMultiplexerSession()` then routes rendering down the
+ * path that cannot rebuild scrollback. Tests that assert the destructive
+ * full-paint behavior otherwise fail for anyone running the suite inside tmux,
+ * screen, Zellij or CMUX. Restores whatever was set afterwards.
+ */
+export function withoutTerminalMultiplexer(): void {
+	const KEYS = [
+		"TMUX",
+		"STY",
+		"ZELLIJ",
+		"HERDR_ENV",
+		"CMUX_WORKSPACE_ID",
+		"CMUX_SURFACE_ID",
+		"CMUX_REMOTE_TRANSPORT",
+		"TERM",
+	] as const;
+	const previous = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of KEYS) {
+			previous.set(key, Bun.env[key]);
+			delete Bun.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const [key, value] of previous) {
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+		previous.clear();
+	});
+}

--- a/packages/coding-agent/test/streaming-preview-height.test.ts
+++ b/packages/coding-agent/test/streaming-preview-height.test.ts
@@ -11,6 +11,7 @@ import { previewWindowRows } from "@oh-my-pi/pi-coding-agent/tools/render-utils"
 import { TUI, visibleWidth } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 
 // The streaming edit preview is a fixed-height tail window ("cursor"): the last
 // EDIT_STREAMING_PREVIEW_LINES rows of the recomputed diff are pinned to the
@@ -21,6 +22,8 @@ import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 // whole change segments grew and shrank tick to tick (the stutter), and the
 // earlier high-water fix padded the deficit with blank rows (the "large
 // rectangle that is half empty" regression). The tail window has neither.
+withoutTerminalMultiplexer();
+
 describe("streaming edit preview height (stable, full tail window)", () => {
 	const oldBlock = ["function foo() {", "  const x = 1;", "  return x;", "}"].join("\n");
 	const tail = ["", "function bar() {", "  return 2;", "}", "", "function baz() {", "  return 3;", "}", ""].join("\n");

--- a/packages/coding-agent/test/tool-execution-write-repaint.test.ts
+++ b/packages/coding-agent/test/tool-execution-write-repaint.test.ts
@@ -4,6 +4,7 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { type Component, TUI } from "@oh-my-pi/pi-tui";
 import { StressRenderScheduler } from "../../tui/test/render-stress-scheduler";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 
 function writeArgs(lineCount: number) {
 	return {
@@ -30,6 +31,8 @@ function plainBuffer(term: VirtualTerminal): string[] {
 		.map(row => Bun.stripANSI(row).trimEnd())
 		.filter(Boolean);
 }
+
+withoutTerminalMultiplexer();
 
 describe("ToolExecutionComponent write repaint seam", () => {
 	const components: ToolExecutionComponent[] = [];

--- a/packages/tui/test/component-render.test.ts
+++ b/packages/tui/test/component-render.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import {
 	type Component,
 	Container,
@@ -10,20 +10,12 @@ import {
 	type NativeScrollbackReplay,
 	TUI,
 } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { StressRenderScheduler } from "./render-stress-scheduler";
 import { defaultEditorTheme } from "./test-themes";
 import { VirtualTerminal } from "./virtual-terminal";
 
-const ORIGINAL_HERDR_ENV = Bun.env.HERDR_ENV;
-
-beforeEach(() => {
-	delete Bun.env.HERDR_ENV;
-});
-
-afterEach(() => {
-	if (ORIGINAL_HERDR_ENV === undefined) delete Bun.env.HERDR_ENV;
-	else Bun.env.HERDR_ENV = ORIGINAL_HERDR_ENV;
-});
+withoutTerminalMultiplexer();
 
 // Behavioral tests for TUI.requestComponentRender: a component whose own
 // content changed (spinner frame, blink) asks for a component-scoped frame.

--- a/packages/tui/test/helpers/terminal-multiplexer.ts
+++ b/packages/tui/test/helpers/terminal-multiplexer.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach } from "bun:test";
+
+/**
+ * Neutralize every terminal-multiplexer signal for the calling test file.
+ *
+ * `isInsideTerminalMultiplexer()` treats `TMUX`, `STY`, `ZELLIJ`,
+ * `HERDR_ENV=1`, the `CMUX_*` markers and a `tmux`/`screen` `TERM` as
+ * authoritative, and `isMultiplexerSession()` then routes rendering down the
+ * path that cannot rebuild scrollback. Tests that assert the destructive
+ * full-paint behavior otherwise fail for anyone running the suite inside tmux,
+ * screen, Zellij or CMUX. Restores whatever was set afterwards.
+ */
+export function withoutTerminalMultiplexer(): void {
+	const KEYS = [
+		"TMUX",
+		"STY",
+		"ZELLIJ",
+		"HERDR_ENV",
+		"CMUX_WORKSPACE_ID",
+		"CMUX_SURFACE_ID",
+		"CMUX_REMOTE_TRANSPORT",
+		"TERM",
+	] as const;
+	const previous = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of KEYS) {
+			previous.set(key, Bun.env[key]);
+			delete Bun.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const [key, value] of previous) {
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+		previous.clear();
+	});
+}

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { type Component, CURSOR_MARKER, type Focusable, type OverlayFocusOwner, TUI } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class LineComponent implements Component {
@@ -166,6 +167,8 @@ async function settleResize(term: VirtualTerminal): Promise<void> {
 	await Bun.sleep(160);
 	await flushRender(term);
 }
+
+withoutTerminalMultiplexer();
 
 describe("TUI overlays", () => {
 	let savedTerminalEnv: Record<string, string | undefined> = {};


### PR DESCRIPTION
I reviewed the full diff; these tests used to fail because the suite is being run inside tmux/screen/Zellij.

## Problem

`isMultiplexerSession()` treats `TMUX`, `STY`, `ZELLIJ`, `HERDR_ENV=1`, the
three `CMUX_*` markers and a `tmux`/`screen` `TERM` as authoritative, and routes
rendering down the path that cannot rebuild scrollback. Nine tests across four
files assert the destructive full-paint behavior, so they fail for anyone
running the suite inside a multiplexer:

| File | Failures |
| --- | --- |
| `packages/tui/test/overlay-scroll.test.ts` | 6 |
| `packages/tui/test/component-render.test.ts` | 1 |
| `packages/coding-agent/test/streaming-preview-height.test.ts` | 1 |
| `packages/coding-agent/test/tool-execution-write-repaint.test.ts` | 1 |

`component-render.test.ts` already guards against this — it clears `HERDR_ENV`
in `beforeEach` and restores it after — but that covers one of the nine signals.
The other three files have no guard at all.

## Change

A shared `withoutTerminalMultiplexer()` helper clears the whole family and
restores whatever was set. It replaces the partial `HERDR_ENV` block in
`component-render.test.ts` and is called from the other three files.

`overlay-scroll.test.ts` has its own local `withEnv(name, value, run)` that
*sets* these variables inside test bodies to exercise multiplexer behavior on
purpose. That still runs after `beforeEach`, so those cases keep working.

`packages/tui` and `packages/coding-agent` do not share test helpers, so the
function is defined once per package — same as `withOfficialAnthropicEndpoint`
in #8795.

## Verification

Four affected files, each variable injected on its own:

| env | before | after |
| --- | --- | --- |
| (clean) | 0 | 0 |
| `TMUX` | 9 | 0 |
| `STY` | 9 | 0 |
| `ZELLIJ` | 9 | 0 |
| `HERDR_ENV=1` | 9 | 0 |
| `CMUX_WORKSPACE_ID` | 9 | 0 |
| `CMUX_SURFACE_ID` | 9 | 0 |
| `CMUX_REMOTE_TRANSPORT` | 9 | 0 |
| `TERM=tmux-256color` | 9 | 0 |
| `TERM=screen-256color` | 9 | 0 |

Reverting only the `delete` inside the helper brings the failures back (1 in
`packages/tui`, 2 in `packages/coding-agent` for the files run together), so the
helper is what fixes them. Checked in two independent checkouts.

`bun run check:ts` and `biome check` are clean.

One note while verifying: the full `test:ts` run is not perfectly stable on this
machine — a clean-environment run reported one failure once and zero on a
re-run, with no failing test name captured. That flake is unrelated to these
files and out of scope here; the table above is from targeted runs of the four
files, which reproduce identically every time.
