### PR TITLE
feat(mcp): support gateway URL elicitation (#8808)

### DIFF
--- a/docs/mcp-protocol-transports.md
+++ b/docs/mcp-protocol-transports.md
@@ -104,6 +104,14 @@ Client emits JSON-RPC notifications via `transport.notify(...)`.
 
 Server-initiated notifications are surfaced through transport `onNotification`; `MCPManager` consumes known MCP list/update notifications and can forward all notifications through its own callback.
 
+### URL elicitation requests and completion
+
+`connectToServer()` advertises `capabilities.elicitation.url` unconditionally during `initialize`. A server-to-client `elicitation/create` request is parsed as URL mode only (`mode: "url"`, non-empty `elicitationId`, string `url`/`message`, HTTPS URL without embedded credentials). The transport-level callback receives exactly `(request)`; the client/connection-level callback preserves `(serverName, request)`. If no handler is installed, the client returns `{ action: "decline" }`. Form-mode requests are not handled by the URL path and receive the normal unsupported-method response.
+
+Tool calls can return the MCP URL-elicitation-required error (`-32042`) with a validated `elicitations` array in `MCPRequestError.data`. The manager deduplicates in-flight consent prompts by server name and elicitation id. After an accepted prompt, completion is optional: when the manager has a completion waiter it waits for `notifications/elicitation/complete`, including notifications that arrived before the waiter; the wait has a bounded configurable deadline and observes caller cancellation. The tool bridge performs at most one follow-up call, so repeated elicitation requirements, decline, cancel, timeout, or abort are surfaced without an unbounded retry loop.
+
+Server-request responses are JSON-RPC envelopes. Arbitrary thrown values contribute only a safe code/message; structured `data` is serialized back only for `MCPRequestError`, whose data is explicitly protocol-owned. URL values and elicitation payloads are not logged or persisted.
+
 ## Stdio transport internals
 
 ## Lifecycle and state transitions

--- a/docs/mcp-protocol-transports.md
+++ b/docs/mcp-protocol-transports.md
@@ -110,7 +110,7 @@ Server-initiated notifications are surfaced through transport `onNotification`; 
 
 Tool calls can return the MCP URL-elicitation-required error (`-32042`) with a validated `elicitations` array in `MCPRequestError.data`. The manager deduplicates in-flight consent prompts by server name and elicitation id. After an accepted prompt, completion is optional: when the manager has a completion waiter it waits for `notifications/elicitation/complete`, including notifications that arrived before the waiter; the wait has a bounded configurable deadline and observes caller cancellation. The tool bridge performs at most one follow-up call, so repeated elicitation requirements, decline, cancel, timeout, or abort are surfaced without an unbounded retry loop.
 
-Server-request responses are JSON-RPC envelopes. Arbitrary thrown values contribute only a safe code/message; structured `data` is serialized back only for `MCPRequestError`, whose data is explicitly protocol-owned. URL values and elicitation payloads are not logged or persisted.
+Server-request responses are JSON-RPC envelopes. Arbitrary thrown values contribute only a safe code/message; structured `data` is serialized back only for `MCPRequestError`, whose data is explicitly protocol-owned. URL values are redacted from transport logs. Elicitation payloads may be held transiently in bounded in-memory completion and listener buffers; they are not written to durable persistence.
 
 ## Stdio transport internals
 

--- a/docs/mcp-runtime-lifecycle.md
+++ b/docs/mcp-runtime-lifecycle.md
@@ -147,6 +147,14 @@ Server and tool name components are lowercased and sanitized to letters/undersco
 
 Both return structured tool output and convert remaining transport/tool errors into `MCP error: ...` tool content (abort remains abort).
 
+### URL elicitation
+
+The client advertises MCP URL-mode elicitation (`capabilities.elicitation.url`) on every initialize handshake. This capability declaration is unconditional: when no consent handler is installed (including headless/SDK sessions), an incoming `elicitation/create` request is answered with `decline` rather than being left unsupported. Interactive sessions install a URL handler on the manager; the handler receives `(serverName, request)` and is the only path that can accept or cancel the user-visible consent prompt.
+
+When a tool call returns the MCP URL-elicitation-required error (`-32042`), the tool bridge prompts once per unique `serverName + elicitationId`, accepts only an explicit `accept`, waits for the optional `notifications/elicitation/complete` notification when a completion waiter is available, and retries the tool once. Completion may arrive before the waiter is registered; that early completion is consumed by the subsequent wait. The wait has a bounded configurable deadline, and caller cancellation or deadline expiry aborts the retry instead of leaving the tool call pending. A second elicitation-required error is surfaced rather than recursively prompting.
+
+URL elicitation is intentionally interactive-only in this runtime. Headless/SDK sessions advertise the protocol capability for interoperability but have no consent UI and therefore decline requests. URLs and authorization payloads are not written to logs or persistence; only server identity, method, and lifecycle status are safe operational context.
+
 ## Refresh/reload paths (startup vs live reload)
 
 ### Initial startup path

--- a/docs/mcp-runtime-lifecycle.md
+++ b/docs/mcp-runtime-lifecycle.md
@@ -153,7 +153,7 @@ The client advertises MCP URL-mode elicitation (`capabilities.elicitation.url`) 
 
 When a tool call returns the MCP URL-elicitation-required error (`-32042`), the tool bridge prompts once per unique `serverName + elicitationId`, accepts only an explicit `accept`, waits for the optional `notifications/elicitation/complete` notification when a completion waiter is available, and retries the tool once. Completion may arrive before the waiter is registered; that early completion is consumed by the subsequent wait. The wait has a bounded configurable deadline, and caller cancellation or deadline expiry aborts the retry instead of leaving the tool call pending. A second elicitation-required error is surfaced rather than recursively prompting.
 
-URL elicitation is intentionally interactive-only in this runtime. Headless/SDK sessions advertise the protocol capability for interoperability but have no consent UI and therefore decline requests. URLs and authorization payloads are not written to logs or persistence; only server identity, method, and lifecycle status are safe operational context.
+URL elicitation is intentionally interactive-only in this runtime. Headless/SDK sessions advertise the protocol capability for interoperability but have no consent UI and therefore decline requests. URL values are redacted from transport logs; elicitation payloads may be held transiently in bounded in-memory completion and listener buffers, but are not written to durable persistence.
 
 ## Refresh/reload paths (startup vs live reload)
 

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -36,6 +36,8 @@ import type {
 	MCPToolDefinition,
 	MCPToolsListResult,
 	MCPTransport,
+	MCPUrlElicitation,
+	MCPUrlElicitationResponse,
 } from "./types";
 
 import { MCP_PROTOCOL_VERSION } from "./types";
@@ -67,6 +69,30 @@ async function defaultRequestHandler(method: string, _params: unknown): Promise<
 	}
 }
 
+function parseUrlElicitation(params: unknown): MCPUrlElicitation {
+	if (typeof params !== "object" || params === null) {
+		throw Object.assign(new Error("Invalid URL elicitation request"), { code: -32602 });
+	}
+	const value = params as Record<string, unknown>;
+	if (value.mode !== "url" || typeof value.elicitationId !== "string" || value.elicitationId.length === 0) {
+		throw Object.assign(new Error("Invalid URL elicitation request"), { code: -32602 });
+	}
+	if (typeof value.url !== "string" || typeof value.message !== "string") {
+		throw Object.assign(new Error("Invalid URL elicitation request"), { code: -32602 });
+	}
+	try {
+		if (new URL(value.url).protocol !== "https:") throw new Error("URL must use HTTPS");
+	} catch {
+		throw Object.assign(new Error("Invalid URL elicitation URL"), { code: -32602 });
+	}
+	return {
+		mode: "url",
+		elicitationId: value.elicitationId,
+		url: value.url,
+		message: value.message,
+	};
+}
+
 /**
  * Create a transport for the given server config.
  */
@@ -94,12 +120,15 @@ async function initializeConnection(
 		signal?: AbortSignal;
 		/** Called after notifications/initialized succeeds. */
 		onInitialized?: () => void | Promise<void>;
+		/** Whether URL-mode elicitation is supported by an installed handler. */
+		urlElicitation?: boolean;
 	},
 ): Promise<MCPInitializeResult> {
 	const params: MCPInitializeParams = {
 		protocolVersion: MCP_PROTOCOL_VERSION,
 		capabilities: {
 			roots: { listChanged: false },
+			...(options?.urlElicitation ? { elicitation: { url: {} } } : {}),
 		},
 		clientInfo: CLIENT_INFO,
 	};
@@ -141,6 +170,7 @@ export async function connectToServer(
 		signal?: AbortSignal;
 		onNotification?: (method: string, params: unknown) => void;
 		onRequest?: (method: string, params: unknown) => Promise<unknown>;
+		urlElicitationHandler?: (serverName: string, request: MCPUrlElicitation) => Promise<MCPUrlElicitationResponse>;
 	},
 ): Promise<MCPServerConnection> {
 	const timeoutMs = resolveMCPTimeoutMs(config.timeout);
@@ -154,12 +184,23 @@ export async function connectToServer(
 
 		// Always handle standard MCP server-to-client requests (ping, roots/list).
 		// The initialize request declares roots capability, so we must respond to
-		// roots/list — even for short-lived test connections.
-		transport.onRequest = options?.onRequest ?? defaultRequestHandler;
+		// roots/list — even for short-lived test connections. URL elicitation is
+		// advertised and dispatched only when a handler was explicitly supplied.
+		if (options?.urlElicitationHandler) {
+			transport.urlElicitationHandler = async request =>
+				options.urlElicitationHandler!(name, parseUrlElicitation(request));
+		}
+		transport.onRequest = async (method, params) => {
+			if (method === "elicitation/create" && transport.urlElicitationHandler) {
+				return transport.urlElicitationHandler(parseUrlElicitation(params));
+			}
+			return (options?.onRequest ?? defaultRequestHandler)(method, params);
+		};
 
 		try {
 			const initResult = await initializeConnection(transport, {
 				signal: options?.signal,
+				urlElicitation: options?.urlElicitationHandler !== undefined,
 				async onInitialized() {
 					// Open the optional GET SSE stream only after the initialized
 					// notification makes the session ready for further traffic.
@@ -175,6 +216,9 @@ export async function connectToServer(
 				transport,
 				serverInfo: initResult.serverInfo,
 				capabilities: initResult.capabilities,
+				urlElicitationHandler: options?.urlElicitationHandler
+					? (request => options.urlElicitationHandler!(name, request))
+					: undefined,
 				instructions: initResult.instructions,
 			};
 		} catch (error) {

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -81,7 +81,10 @@ function parseUrlElicitation(params: unknown): MCPUrlElicitation {
 		throw Object.assign(new Error("Invalid URL elicitation request"), { code: -32602 });
 	}
 	try {
-		if (new URL(value.url).protocol !== "https:") throw new Error("URL must use HTTPS");
+		const parsed = new URL(value.url);
+		if (parsed.protocol !== "https:" || parsed.username !== "" || parsed.password !== "") {
+			throw new Error("URL must use HTTPS without embedded credentials");
+		}
 	} catch {
 		throw Object.assign(new Error("Invalid URL elicitation URL"), { code: -32602 });
 	}
@@ -91,6 +94,11 @@ function parseUrlElicitation(params: unknown): MCPUrlElicitation {
 		url: value.url,
 		message: value.message,
 	};
+}
+
+function isUrlElicitationRequest(params: unknown): boolean {
+	if (typeof params !== "object" || params === null || !("mode" in params)) return false;
+	return params.mode === "url";
 }
 
 /**
@@ -177,35 +185,35 @@ export async function connectToServer(
 	let transport: MCPTransport | undefined;
 
 	const connect = async (): Promise<MCPServerConnection> => {
-		transport = await createTransport(config);
+		const t = await createTransport(config);
+		transport = t;
 		if (options?.onNotification) {
-			transport.onNotification = options.onNotification;
+			t.onNotification = options.onNotification;
 		}
 
 		// Always handle standard MCP server-to-client requests (ping, roots/list).
 		// The initialize request declares roots capability, so we must respond to
 		// roots/list — even for short-lived test connections. URL elicitation is
-		// advertised and dispatched only when a handler was explicitly supplied.
-		if (options?.urlElicitationHandler) {
-			transport.urlElicitationHandler = async request =>
-				options.urlElicitationHandler!(name, parseUrlElicitation(request));
-		}
-		transport.onRequest = async (method, params) => {
-			if (method === "elicitation/create" && transport.urlElicitationHandler) {
-				return transport.urlElicitationHandler(parseUrlElicitation(params));
+		// advertised unconditionally; clients without a consent handler decline it.
+		const handleUrlElicitation = options?.urlElicitationHandler ?? (async () => ({ action: "decline" as const }));
+		t.urlElicitationHandler = async request => handleUrlElicitation(name, parseUrlElicitation(request));
+		t.onRequest = async (method, params) => {
+			if (method === "elicitation/create" && isUrlElicitationRequest(params)) {
+				const request = parseUrlElicitation(params);
+				return t.urlElicitationHandler ? t.urlElicitationHandler(request) : { action: "decline" as const };
 			}
 			return (options?.onRequest ?? defaultRequestHandler)(method, params);
 		};
 
 		try {
-			const initResult = await initializeConnection(transport, {
+			const initResult = await initializeConnection(t, {
 				signal: options?.signal,
-				urlElicitation: options?.urlElicitationHandler !== undefined,
+				urlElicitation: true,
 				async onInitialized() {
 					// Open the optional GET SSE stream only after the initialized
 					// notification makes the session ready for further traffic.
-					if ("startSSEListener" in transport! && typeof transport!.startSSEListener === "function") {
-						await (transport as { startSSEListener(): Promise<void> }).startSSEListener();
+					if ("startSSEListener" in t && typeof t.startSSEListener === "function") {
+						await t.startSSEListener();
 					}
 				},
 			});
@@ -213,16 +221,14 @@ export async function connectToServer(
 			return {
 				name,
 				config,
-				transport,
+				transport: t,
 				serverInfo: initResult.serverInfo,
 				capabilities: initResult.capabilities,
-				urlElicitationHandler: options?.urlElicitationHandler
-					? (request => options.urlElicitationHandler!(name, request))
-					: undefined,
+				urlElicitationHandler: options?.urlElicitationHandler,
 				instructions: initResult.instructions,
 			};
 		} catch (error) {
-			await transport.close();
+			await t.close();
 			throw error;
 		}
 	};

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -40,7 +40,7 @@ import type {
 	MCPUrlElicitationResponse,
 } from "./types";
 
-import { MCP_PROTOCOL_VERSION } from "./types";
+import { MCP_PROTOCOL_VERSION, MCPRequestError } from "./types";
 
 /** Client info sent during initialization */
 const CLIENT_INFO = {
@@ -196,7 +196,7 @@ export async function connectToServer(
 		// roots/list — even for short-lived test connections. URL elicitation is
 		// advertised unconditionally; clients without a consent handler decline it.
 		const handleUrlElicitation = options?.urlElicitationHandler ?? (async () => ({ action: "decline" as const }));
-		t.urlElicitationHandler = async request => handleUrlElicitation(name, parseUrlElicitation(request));
+		t.urlElicitationHandler = async request => handleUrlElicitation(name, request);
 		t.onRequest = async (method, params) => {
 			if (method === "elicitation/create" && isUrlElicitationRequest(params)) {
 				const request = parseUrlElicitation(params);
@@ -279,7 +279,12 @@ export async function listTools(
 			params.cursor = cursor;
 		}
 
-		const result = await connection.transport.request<MCPToolsListResult>("tools/list", params, options);
+		const result = await requestWithUrlElicitationRetry<MCPToolsListResult>(
+			connection,
+			"tools/list",
+			params,
+			options,
+		);
 		allTools.push(...result.tools);
 		cursor = result.nextCursor;
 	} while (cursor);
@@ -318,6 +323,84 @@ export async function disconnectServer(connection: MCPServerConnection): Promise
 	await connection.transport.close();
 }
 
+const URL_ELICITATION_REQUIRED_CODE = -32042;
+const DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS = 300_000;
+const URL_ELICITATION_TIMEOUT_ENV = "OMP_MCP_URL_ELICITATION_TIMEOUT_MS";
+
+function resolveUrlElicitationWaitTimeoutMs(): number {
+	const configured = Number.parseInt(process.env[URL_ELICITATION_TIMEOUT_ENV] ?? "", 10);
+	return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS;
+}
+
+function getUrlElicitations(error: unknown): MCPUrlElicitation[] | undefined {
+	if (!(error instanceof MCPRequestError) || error.code !== URL_ELICITATION_REQUIRED_CODE) return undefined;
+	if (typeof error.data !== "object" || error.data === null || !("elicitations" in error.data)) return undefined;
+	const values = (error.data as { elicitations?: unknown }).elicitations;
+	if (!Array.isArray(values) || values.length === 0) return undefined;
+	const requests: MCPUrlElicitation[] = [];
+	for (const value of values) {
+		try {
+			requests.push(parseUrlElicitation(value));
+		} catch {
+			return undefined;
+		}
+	}
+	return requests;
+}
+
+async function requestWithUrlElicitationRetry<T>(
+	connection: MCPServerConnection,
+	method: string,
+	params: Record<string, unknown>,
+	options?: MCPRequestOptions,
+): Promise<T> {
+	try {
+		return await connection.transport.request<T>(method, params, options);
+	} catch (error) {
+		const elicitations = getUrlElicitations(error);
+		const handler = connection.urlElicitationHandler;
+		if (!elicitations || !handler) throw error;
+
+		for (const elicitation of elicitations) {
+			const completionController = connection.waitForUrlElicitationCompletion ? new AbortController() : undefined;
+			const completionSignal = completionController
+				? options?.signal
+					? AbortSignal.any([options.signal, completionController.signal])
+					: completionController.signal
+				: options?.signal;
+			const completionPromise = connection.waitForUrlElicitationCompletion?.(
+				elicitation.elicitationId,
+				completionSignal,
+			);
+			try {
+				const response = await handler(connection.name, elicitation);
+				if (response.action !== "accept") {
+					throw new Error(
+						`MCP server "${connection.name}" URL authorization was ${response.action} for ${method}.`,
+					);
+				}
+				if (completionPromise) {
+					try {
+						await withTimeout(
+							completionPromise,
+							resolveUrlElicitationWaitTimeoutMs(),
+							"MCP URL elicitation completion wait expired",
+							options?.signal,
+						);
+					} catch (waitError) {
+						if (options?.signal?.aborted) throw waitError;
+					}
+				}
+			} finally {
+				completionController?.abort();
+				await completionPromise?.catch(() => {});
+			}
+		}
+
+		return connection.transport.request<T>(method, params, options);
+	}
+}
+
 /**
  * Check if a server supports tools.
  */
@@ -349,7 +432,12 @@ export async function listResources(
 			params.cursor = cursor;
 		}
 
-		const result = await connection.transport.request<MCPResourcesListResult>("resources/list", params, options);
+		const result = await requestWithUrlElicitationRetry<MCPResourcesListResult>(
+			connection,
+			"resources/list",
+			params,
+			options,
+		);
 		allResources.push(...result.resources);
 		cursor = result.nextCursor;
 	} while (cursor);
@@ -397,7 +485,8 @@ export async function listResourceTemplates(
 				params.cursor = cursor;
 			}
 
-			const result = await connection.transport.request<MCPResourceTemplatesListResult>(
+			const result = await requestWithUrlElicitationRetry<MCPResourceTemplatesListResult>(
+				connection,
 				"resources/templates/list",
 				params,
 				options,
@@ -429,7 +518,8 @@ export async function readResource(
 	options?: MCPRequestOptions,
 ): Promise<MCPResourceReadResult> {
 	const params: MCPResourceReadParams = { uri };
-	return connection.transport.request<MCPResourceReadResult>(
+	return requestWithUrlElicitationRetry<MCPResourceReadResult>(
+		connection,
 		"resources/read",
 		params as unknown as Record<string, unknown>,
 		options,
@@ -448,7 +538,8 @@ export async function subscribeToResources(
 	const results = await Promise.allSettled(
 		uris.map(uri => {
 			const params: MCPResourceSubscribeParams = { uri };
-			return connection.transport.request(
+			return requestWithUrlElicitationRetry(
+				connection,
 				"resources/subscribe",
 				params as unknown as Record<string, unknown>,
 				options,
@@ -474,7 +565,8 @@ export async function unsubscribeFromResources(
 	const results = await Promise.allSettled(
 		uris.map(uri => {
 			const params: MCPResourceSubscribeParams = { uri };
-			return connection.transport.request(
+			return requestWithUrlElicitationRetry(
+				connection,
 				"resources/unsubscribe",
 				params as unknown as Record<string, unknown>,
 				options,
@@ -526,7 +618,12 @@ export async function listPrompts(
 			params.cursor = cursor;
 		}
 
-		const result = await connection.transport.request<MCPPromptsListResult>("prompts/list", params, options);
+		const result = await requestWithUrlElicitationRetry<MCPPromptsListResult>(
+			connection,
+			"prompts/list",
+			params,
+			options,
+		);
 		allPrompts.push(...result.prompts);
 		cursor = result.nextCursor;
 	} while (cursor);
@@ -549,7 +646,8 @@ export async function getPrompt(
 		params.arguments = args;
 	}
 
-	return connection.transport.request<MCPGetPromptResult>(
+	return requestWithUrlElicitationRetry<MCPGetPromptResult>(
+		connection,
 		"prompts/get",
 		params as unknown as Record<string, unknown>,
 		options,

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -50,7 +50,9 @@ import type {
 	MCPServerConnection,
 	MCPToolDefinition,
 	MCPTransport,
+	MCPUrlElicitation,
 	MCPUrlElicitationHandler,
+	MCPUrlElicitationResponse,
 } from "./types";
 import { MCPNotificationMethods } from "./types";
 
@@ -210,7 +212,10 @@ export class MCPManager {
 
 	#connections = new Map<string, MCPServerConnection>();
 	#urlElicitationHandler?: MCPUrlElicitationHandler;
+	#urlElicitationPrompts = new Map<string, Promise<MCPUrlElicitationResponse>>();
 	#urlCompletionWaiters = new Map<string, Map<string, Set<UrlCompletionWaiter>>>();
+	#completedUrlElicitations = new Map<string, Map<string, number>>();
+
 	#tools: CustomTool<TSchema, MCPToolDetails>[] = [];
 	#pendingConnections = new Map<string, Promise<MCPServerConnection>>();
 	#pendingToolLoads = new Map<string, Promise<ToolLoadResult>>();
@@ -400,9 +405,11 @@ export class MCPManager {
 	setUrlElicitationHandler(handler: MCPUrlElicitationHandler | undefined): void {
 		this.#urlElicitationHandler = handler;
 		for (const connection of this.#connections.values()) {
-			connection.urlElicitationHandler = handler;
+			connection.urlElicitationHandler = handler
+				? (serverName, request) => this.#requestUrlElicitation(serverName, request)
+				: undefined;
 			connection.transport.urlElicitationHandler = handler
-				? request => handler(connection.name, request)
+				? request => this.#requestUrlElicitation(connection.name, request)
 				: undefined;
 		}
 	}
@@ -510,7 +517,7 @@ export class MCPManager {
 						this.#handleServerNotification(name, method, params);
 					},
 					onRequest: (method, params) => this.#handleServerRequest(method, params),
-					urlElicitationHandler: this.#urlElicitationHandler,
+					urlElicitationHandler: (serverName, request) => this.#requestUrlElicitation(serverName, request),
 				});
 			})().then(
 				async connection => {
@@ -527,7 +534,9 @@ export class MCPManager {
 						throw new Error(`Server "${name}" was disconnected during initial connection`);
 					}
 
-					connection.urlElicitationHandler = this.#urlElicitationHandler;
+					connection.urlElicitationHandler = this.#urlElicitationHandler
+						? (serverName, request) => this.#requestUrlElicitation(serverName, request)
+						: undefined;
 					connection.waitForUrlElicitationCompletion = (elicitationId, signal) =>
 						this.#waitForUrlElicitationCompletion(name, elicitationId, signal);
 					this.#pendingConnections.delete(name);
@@ -706,12 +715,28 @@ export class MCPManager {
 		sortMCPToolsByName(this.#tools);
 	}
 
+	#requestUrlElicitation(serverName: string, request: MCPUrlElicitation): Promise<MCPUrlElicitationResponse> {
+		const handler = this.#urlElicitationHandler;
+		if (!handler) return Promise.resolve({ action: "decline" });
+		const key = `${serverName}\0${request.elicitationId}`;
+		const existing = this.#urlElicitationPrompts.get(key);
+		if (existing) return existing;
+		const prompt = handler(serverName, request).finally(() => this.#urlElicitationPrompts.delete(key));
+		this.#urlElicitationPrompts.set(key, prompt);
+		return prompt;
+	}
+
 	async #waitForUrlElicitationCompletion(
 		serverName: string,
 		elicitationId: string,
 		signal?: AbortSignal,
 	): Promise<void> {
 		if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : new Error("Aborted");
+		const completed = this.#completedUrlElicitations.get(serverName)?.get(elicitationId);
+		if (completed !== undefined) {
+			this.#completedUrlElicitations.get(serverName)?.delete(elicitationId);
+			return;
+		}
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		let byId = this.#urlCompletionWaiters.get(serverName);
 		if (!byId) {
@@ -764,15 +789,27 @@ export class MCPManager {
 		const connectionKnown = this.#connections.has(serverName);
 		let refreshPromise: Promise<void> | undefined;
 		switch (method) {
-			case "notifications/elicitation/complete": {
+			case MCPNotificationMethods.ELICITATION_COMPLETE: {
 				const elicitationId =
-					params && typeof params === "object" && "elicitationId" in params && typeof params.elicitationId === "string"
+					params &&
+					typeof params === "object" &&
+					"elicitationId" in params &&
+					typeof params.elicitationId === "string"
 						? params.elicitationId
 						: undefined;
-				const waiters = elicitationId ? this.#urlCompletionWaiters.get(serverName)?.get(elicitationId) : undefined;
-				if (waiters) {
-					for (const waiter of waiters) waiter.resolve();
-					this.#urlCompletionWaiters.get(serverName)?.delete(elicitationId!);
+				if (elicitationId) {
+					const waiters = this.#urlCompletionWaiters.get(serverName)?.get(elicitationId);
+					if (waiters) {
+						for (const waiter of waiters) waiter.resolve();
+						this.#urlCompletionWaiters.get(serverName)?.delete(elicitationId);
+					} else {
+						let completed = this.#completedUrlElicitations.get(serverName);
+						if (!completed) {
+							completed = new Map();
+							this.#completedUrlElicitations.set(serverName, completed);
+						}
+						completed.set(elicitationId, Date.now());
+					}
 				}
 				break;
 			}
@@ -1190,9 +1227,11 @@ export class MCPManager {
 				this.#handleServerNotification(name, method, params);
 			},
 			onRequest: (method, params) => this.#handleServerRequest(method, params),
-			urlElicitationHandler: this.#urlElicitationHandler,
+			urlElicitationHandler: (serverName, request) => this.#requestUrlElicitation(serverName, request),
 		});
-		connection.urlElicitationHandler = this.#urlElicitationHandler;
+		connection.urlElicitationHandler = this.#urlElicitationHandler
+			? (serverName, request) => this.#requestUrlElicitation(serverName, request)
+			: undefined;
 		connection.waitForUrlElicitationCompletion = (elicitationId, signal) =>
 			this.#waitForUrlElicitationCompletion(name, elicitationId, signal);
 

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -116,6 +116,8 @@ const RECONNECT_BURST_LIMIT = 5;
  * cleared; subsequent frames deliver directly to attached listeners.
  */
 const NOTIFICATION_BUFFER_CAP = 100;
+const COMPLETED_URL_ELICITATION_TTL_MS = 300_000;
+const COMPLETED_URL_ELICITATION_CAP = NOTIFICATION_BUFFER_CAP;
 
 function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 	const tracked: TrackedPromise<T> = { promise, status: "pending" };
@@ -732,10 +734,12 @@ export class MCPManager {
 		signal?: AbortSignal,
 	): Promise<void> {
 		if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : new Error("Aborted");
-		const completed = this.#completedUrlElicitations.get(serverName)?.get(elicitationId);
+		const completedById = this.#completedUrlElicitations.get(serverName);
+		const completed = completedById?.get(elicitationId);
 		if (completed !== undefined) {
-			this.#completedUrlElicitations.get(serverName)?.delete(elicitationId);
-			return;
+			completedById!.delete(elicitationId);
+			if (Date.now() - completed <= COMPLETED_URL_ELICITATION_TTL_MS) return;
+			if (completedById!.size === 0) this.#completedUrlElicitations.delete(serverName);
 		}
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		let byId = this.#urlCompletionWaiters.get(serverName);
@@ -808,7 +812,16 @@ export class MCPManager {
 							completed = new Map();
 							this.#completedUrlElicitations.set(serverName, completed);
 						}
-						completed.set(elicitationId, Date.now());
+						const now = Date.now();
+						for (const [id, timestamp] of completed) {
+							if (now - timestamp > COMPLETED_URL_ELICITATION_TTL_MS) completed.delete(id);
+						}
+						completed.set(elicitationId, now);
+						while (completed.size > COMPLETED_URL_ELICITATION_CAP) {
+							const oldest = completed.keys().next().value;
+							if (oldest === undefined) break;
+							completed.delete(oldest);
+						}
 					}
 				}
 				break;
@@ -978,6 +991,16 @@ export class MCPManager {
 		);
 	}
 
+	#clearUrlElicitationState(serverName: string): void {
+		this.#completedUrlElicitations.delete(serverName);
+		const byId = this.#urlCompletionWaiters.get(serverName);
+		if (!byId) return;
+		this.#urlCompletionWaiters.delete(serverName);
+		for (const waiters of byId.values()) {
+			for (const waiter of waiters) waiter.reject(new Error(`MCP server "${serverName}" disconnected`));
+		}
+	}
+
 	/**
 	 * Drop a connection from the active map and detach its lifecycle hooks.
 	 *
@@ -988,6 +1011,7 @@ export class MCPManager {
 	 */
 	#detachConnection(name: string, connection: MCPServerConnection): void {
 		connection.transport.onClose = undefined;
+		this.#clearUrlElicitationState(name);
 		if (this.#connections.get(name) === connection) {
 			this.#connections.delete(name);
 		}
@@ -1017,6 +1041,7 @@ export class MCPManager {
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
 		this.#reconnectHistory.delete(name);
+		this.#clearUrlElicitationState(name);
 
 		const connection = this.#connections.get(name);
 
@@ -1048,6 +1073,8 @@ export class MCPManager {
 		this.#epoch++;
 		const promises = Array.from(this.#connections, ([name, connection]) => this.#discardConnection(name, connection));
 		await Promise.allSettled(promises);
+		this.#completedUrlElicitations.clear();
+		this.#urlCompletionWaiters.clear();
 
 		this.#pendingConnections.clear();
 		this.#pendingToolLoads.clear();

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -50,6 +50,7 @@ import type {
 	MCPServerConnection,
 	MCPToolDefinition,
 	MCPTransport,
+	MCPUrlElicitationHandler,
 } from "./types";
 import { MCPNotificationMethods } from "./types";
 
@@ -70,6 +71,11 @@ type TrackedPromise<T> = {
 	status: "pending" | "fulfilled" | "rejected";
 	value?: T;
 	reason?: unknown;
+};
+
+type UrlCompletionWaiter = {
+	resolve: () => void;
+	reject: (error: unknown) => void;
 };
 
 const STARTUP_TIMEOUT_MS = 250;
@@ -203,6 +209,8 @@ export class MCPManager {
 	}
 
 	#connections = new Map<string, MCPServerConnection>();
+	#urlElicitationHandler?: MCPUrlElicitationHandler;
+	#urlCompletionWaiters = new Map<string, Map<string, Set<UrlCompletionWaiter>>>();
 	#tools: CustomTool<TSchema, MCPToolDetails>[] = [];
 	#pendingConnections = new Map<string, Promise<MCPServerConnection>>();
 	#pendingToolLoads = new Map<string, Promise<ToolLoadResult>>();
@@ -388,6 +396,17 @@ export class MCPManager {
 		this.#authStorage = authStorage;
 	}
 
+	/** Set the callback used to request user consent for URL-mode elicitations. */
+	setUrlElicitationHandler(handler: MCPUrlElicitationHandler | undefined): void {
+		this.#urlElicitationHandler = handler;
+		for (const connection of this.#connections.values()) {
+			connection.urlElicitationHandler = handler;
+			connection.transport.urlElicitationHandler = handler
+				? request => handler(connection.name, request)
+				: undefined;
+		}
+	}
+
 	/** Set the callback used to complete OAuth after a tool-level auth challenge. */
 	setAuthHandler(handler: MCPAuthHandler | undefined): void {
 		this.#authHandler = handler;
@@ -490,9 +509,8 @@ export class MCPManager {
 					onNotification: (method, params) => {
 						this.#handleServerNotification(name, method, params);
 					},
-					onRequest: (method, params) => {
-						return this.#handleServerRequest(method, params);
-					},
+					onRequest: (method, params) => this.#handleServerRequest(method, params),
+					urlElicitationHandler: this.#urlElicitationHandler,
 				});
 			})().then(
 				async connection => {
@@ -509,6 +527,9 @@ export class MCPManager {
 						throw new Error(`Server "${name}" was disconnected during initial connection`);
 					}
 
+					connection.urlElicitationHandler = this.#urlElicitationHandler;
+					connection.waitForUrlElicitationCompletion = (elicitationId, signal) =>
+						this.#waitForUrlElicitationCompletion(name, elicitationId, signal);
 					this.#pendingConnections.delete(name);
 					this.#connections.set(name, connection);
 					this.#serverConfigs.set(name, config);
@@ -685,6 +706,37 @@ export class MCPManager {
 		sortMCPToolsByName(this.#tools);
 	}
 
+	async #waitForUrlElicitationCompletion(
+		serverName: string,
+		elicitationId: string,
+		signal?: AbortSignal,
+	): Promise<void> {
+		if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : new Error("Aborted");
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		let byId = this.#urlCompletionWaiters.get(serverName);
+		if (!byId) {
+			byId = new Map();
+			this.#urlCompletionWaiters.set(serverName, byId);
+		}
+		let waiters = byId.get(elicitationId);
+		if (!waiters) {
+			waiters = new Set();
+			byId.set(elicitationId, waiters);
+		}
+		const waiter: UrlCompletionWaiter = { resolve, reject };
+		waiters.add(waiter);
+		const onAbort = () => reject(signal?.reason instanceof Error ? signal.reason : new Error("Aborted"));
+		signal?.addEventListener("abort", onAbort, { once: true });
+		try {
+			await promise;
+		} finally {
+			signal?.removeEventListener("abort", onAbort);
+			waiters.delete(waiter);
+			if (waiters.size === 0) byId.delete(elicitationId);
+			if (byId.size === 0) this.#urlCompletionWaiters.delete(serverName);
+		}
+	}
+
 	#triggerNotificationRefresh(serverName: string, kind: "tools" | "resources" | "prompts"): Promise<void> {
 		const refresh = (() => {
 			switch (kind) {
@@ -712,6 +764,18 @@ export class MCPManager {
 		const connectionKnown = this.#connections.has(serverName);
 		let refreshPromise: Promise<void> | undefined;
 		switch (method) {
+			case "notifications/elicitation/complete": {
+				const elicitationId =
+					params && typeof params === "object" && "elicitationId" in params && typeof params.elicitationId === "string"
+						? params.elicitationId
+						: undefined;
+				const waiters = elicitationId ? this.#urlCompletionWaiters.get(serverName)?.get(elicitationId) : undefined;
+				if (waiters) {
+					for (const waiter of waiters) waiter.resolve();
+					this.#urlCompletionWaiters.get(serverName)?.delete(elicitationId!);
+				}
+				break;
+			}
 			case MCPNotificationMethods.TOOLS_LIST_CHANGED:
 				if (connectionKnown) refreshPromise = this.#triggerNotificationRefresh(serverName, "tools");
 				break;
@@ -1125,10 +1189,12 @@ export class MCPManager {
 			onNotification: (method, params) => {
 				this.#handleServerNotification(name, method, params);
 			},
-			onRequest: (method, params) => {
-				return this.#handleServerRequest(method, params);
-			},
+			onRequest: (method, params) => this.#handleServerRequest(method, params),
+			urlElicitationHandler: this.#urlElicitationHandler,
 		});
+		connection.urlElicitationHandler = this.#urlElicitationHandler;
+		connection.waitForUrlElicitationCompletion = (elicitationId, signal) =>
+			this.#waitForUrlElicitationCompletion(name, elicitationId, signal);
 
 		connection.config = config;
 		if (source) connection._source = source;

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -22,6 +22,7 @@ import { normalizeLocalScheme } from "../tools/path-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { callTool } from "./client";
 import { renderMCPCall, renderMCPResult } from "./render";
+import { resolveMCPTimeoutMs } from "./timeout";
 import type {
 	MCPAuthChallenge,
 	MCPContent,
@@ -274,9 +275,15 @@ function getMcpAuthChallenge(result: MCPToolCallResult): MCPAuthChallenge | unde
 	const wwwAuthenticate = values.filter((value): value is string => typeof value === "string" && value.trim() !== "");
 	return wwwAuthenticate.length > 0 ? { wwwAuthenticate } : undefined;
 }
-
 const URL_ELICITATION_REQUIRED_CODE = -32042;
-const URL_ELICITATION_WAIT_TIMEOUT_MS = 120_000;
+const DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS = 30_000;
+
+function resolveUrlElicitationWaitTimeoutMs(connection: MCPServerConnection): number {
+	const configured = resolveMCPTimeoutMs(connection.config.timeout);
+	return configured > 0
+		? Math.min(configured, DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS)
+		: DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS;
+}
 
 function getUrlElicitations(error: unknown): MCPUrlElicitation[] | undefined {
 	if (!(error instanceof MCPRequestError) || error.code !== URL_ELICITATION_REQUIRED_CODE) return undefined;
@@ -292,7 +299,8 @@ function getUrlElicitations(error: unknown): MCPUrlElicitation[] | undefined {
 		}
 		if (typeof item.url !== "string" || typeof item.message !== "string") return undefined;
 		try {
-			if (new URL(item.url).protocol !== "https:") return undefined;
+			const parsed = new URL(item.url);
+			if (parsed.protocol !== "https:" || parsed.username !== "" || parsed.password !== "") return undefined;
 		} catch {
 			return undefined;
 		}
@@ -350,19 +358,36 @@ async function callToolWithUrlElicitationRetry(
 		rethrowIfAborted(error, signal);
 		const elicitations = getUrlElicitations(error);
 		const handler = connection.urlElicitationHandler;
-		const waitForCompletion = connection.waitForUrlElicitationCompletion;
-		if (!elicitations || !handler || !waitForCompletion) throw error;
+		if (!elicitations || !handler) throw error;
 
+		const deadline = Date.now() + resolveUrlElicitationWaitTimeoutMs(connection);
+		const waitForCompletion = connection.waitForUrlElicitationCompletion;
 		for (const elicitation of elicitations) {
-			const response = await handler(connection.name, elicitation);
-			if (response.action !== "accept") {
-				return { connection, error: new Error("URL elicitation declined") };
+			// Register before prompting: a fast server may complete while the
+			// consent UI is still open. The manager also buffers early events.
+			const completionController = waitForCompletion ? new AbortController() : undefined;
+			const completionSignal = completionController
+				? signal
+					? AbortSignal.any([signal, completionController.signal])
+					: completionController.signal
+				: signal;
+			const completionPromise = waitForCompletion
+				? waitForCompletion(elicitation.elicitationId, completionSignal)
+				: undefined;
+			try {
+				const response = await handler(connection.name, elicitation);
+				if (response.action !== "accept") {
+					return { connection, error: new Error("URL elicitation declined") };
+				}
+				if (completionPromise) {
+					const remaining = deadline - Date.now();
+					if (remaining <= 0) throw new Error("Timed out waiting for MCP URL elicitation completion");
+					await withTimeout(completionPromise, remaining, "Timed out waiting for MCP URL elicitation completion");
+				}
+			} finally {
+				completionController?.abort();
+				await completionPromise?.catch(() => {});
 			}
-			await withTimeout(
-				waitForCompletion(elicitation.elicitationId, signal),
-				URL_ELICITATION_WAIT_TIMEOUT_MS,
-				"Timed out waiting for MCP URL elicitation completion",
-			);
 		}
 
 		// Deliberately call the non-recursive auth wrapper: a second -32042 is
@@ -565,7 +590,13 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const providerName = this.connection._source?.providerName;
 
 		try {
-			const attempt = await callToolWithUrlElicitationRetry(this.connection, this.tool.name, args, this.reconnect, signal);
+			const attempt = await callToolWithUrlElicitationRetry(
+				this.connection,
+				this.tool.name,
+				args,
+				this.reconnect,
+				signal,
+			);
 			if (attempt.error !== undefined) {
 				return buildErrorResult(attempt.error, this.connection.name, this.tool.name, provider, providerName);
 			}
@@ -688,7 +719,13 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 			const connection = await untilAborted(signal, () => this.getConnection());
 			throwIfAborted(signal);
 			try {
-				const attempt = await callToolWithUrlElicitationRetry(connection, this.tool.name, args, this.reconnect, signal);
+				const attempt = await callToolWithUrlElicitationRetry(
+					connection,
+					this.tool.name,
+					args,
+					this.reconnect,
+					signal,
+				);
 				if (attempt.error !== undefined) {
 					return buildErrorResult(
 						attempt.error,

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -6,7 +6,7 @@
 import type { AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { TSchema } from "@oh-my-pi/pi-ai";
 import { normalizeSchemaForMCP } from "@oh-my-pi/pi-ai/utils/schema";
-import { logger, untilAborted } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted, withTimeout } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import type { SourceMeta } from "../capability/types";
 import type {
@@ -29,7 +29,9 @@ import type {
 	MCPToolCallParams,
 	MCPToolCallResult,
 	MCPToolDefinition,
+	MCPUrlElicitation,
 } from "./types";
+import { MCPRequestError } from "./types";
 
 /** Reconnect callback: tears down a stale connection, optionally authorizing first. */
 export type MCPReconnect = (options?: { authChallenge?: MCPAuthChallenge }) => Promise<MCPServerConnection | null>;
@@ -273,6 +275,37 @@ function getMcpAuthChallenge(result: MCPToolCallResult): MCPAuthChallenge | unde
 	return wwwAuthenticate.length > 0 ? { wwwAuthenticate } : undefined;
 }
 
+const URL_ELICITATION_REQUIRED_CODE = -32042;
+const URL_ELICITATION_WAIT_TIMEOUT_MS = 120_000;
+
+function getUrlElicitations(error: unknown): MCPUrlElicitation[] | undefined {
+	if (!(error instanceof MCPRequestError) || error.code !== URL_ELICITATION_REQUIRED_CODE) return undefined;
+	if (typeof error.data !== "object" || error.data === null || !("elicitations" in error.data)) return undefined;
+	const values = (error.data as { elicitations?: unknown }).elicitations;
+	if (!Array.isArray(values) || values.length === 0) return undefined;
+	const requests: MCPUrlElicitation[] = [];
+	for (const value of values) {
+		if (typeof value !== "object" || value === null) return undefined;
+		const item = value as Record<string, unknown>;
+		if (item.mode !== "url" || typeof item.elicitationId !== "string" || item.elicitationId.length === 0) {
+			return undefined;
+		}
+		if (typeof item.url !== "string" || typeof item.message !== "string") return undefined;
+		try {
+			if (new URL(item.url).protocol !== "https:") return undefined;
+		} catch {
+			return undefined;
+		}
+		requests.push({
+			mode: "url",
+			elicitationId: item.elicitationId,
+			url: item.url,
+			message: item.message,
+		});
+	}
+	return requests;
+}
+
 async function callToolWithAuthRetry(
 	connection: MCPServerConnection,
 	toolName: string,
@@ -301,6 +334,40 @@ async function callToolWithAuthRetry(
 	} catch (error) {
 		rethrowIfAborted(error, signal);
 		return { connection: newConnection, error };
+	}
+}
+
+async function callToolWithUrlElicitationRetry(
+	connection: MCPServerConnection,
+	toolName: string,
+	args: MCPToolArgs,
+	reconnect: MCPReconnect | undefined,
+	signal?: AbortSignal,
+): Promise<MCPToolCallAttempt> {
+	try {
+		return await callToolWithAuthRetry(connection, toolName, args, reconnect, signal);
+	} catch (error) {
+		rethrowIfAborted(error, signal);
+		const elicitations = getUrlElicitations(error);
+		const handler = connection.urlElicitationHandler;
+		const waitForCompletion = connection.waitForUrlElicitationCompletion;
+		if (!elicitations || !handler || !waitForCompletion) throw error;
+
+		for (const elicitation of elicitations) {
+			const response = await handler(connection.name, elicitation);
+			if (response.action !== "accept") {
+				return { connection, error: new Error("URL elicitation declined") };
+			}
+			await withTimeout(
+				waitForCompletion(elicitation.elicitationId, signal),
+				URL_ELICITATION_WAIT_TIMEOUT_MS,
+				"Timed out waiting for MCP URL elicitation completion",
+			);
+		}
+
+		// Deliberately call the non-recursive auth wrapper: a second -32042 is
+		// surfaced to the caller instead of opening an unbounded consent loop.
+		return await callToolWithAuthRetry(connection, toolName, args, reconnect, signal);
 	}
 }
 
@@ -498,7 +565,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const providerName = this.connection._source?.providerName;
 
 		try {
-			const attempt = await callToolWithAuthRetry(this.connection, this.tool.name, args, this.reconnect, signal);
+			const attempt = await callToolWithUrlElicitationRetry(this.connection, this.tool.name, args, this.reconnect, signal);
 			if (attempt.error !== undefined) {
 				return buildErrorResult(attempt.error, this.connection.name, this.tool.name, provider, providerName);
 			}
@@ -621,7 +688,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 			const connection = await untilAborted(signal, () => this.getConnection());
 			throwIfAborted(signal);
 			try {
-				const attempt = await callToolWithAuthRetry(connection, this.tool.name, args, this.reconnect, signal);
+				const attempt = await callToolWithUrlElicitationRetry(connection, this.tool.name, args, this.reconnect, signal);
 				if (attempt.error !== undefined) {
 					return buildErrorResult(
 						attempt.error,

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -22,7 +22,6 @@ import { normalizeLocalScheme } from "../tools/path-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { callTool } from "./client";
 import { renderMCPCall, renderMCPResult } from "./render";
-import { resolveMCPTimeoutMs } from "./timeout";
 import type {
 	MCPAuthChallenge,
 	MCPContent,
@@ -276,13 +275,12 @@ function getMcpAuthChallenge(result: MCPToolCallResult): MCPAuthChallenge | unde
 	return wwwAuthenticate.length > 0 ? { wwwAuthenticate } : undefined;
 }
 const URL_ELICITATION_REQUIRED_CODE = -32042;
-const DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS = 30_000;
+const URL_ELICITATION_TIMEOUT_ENV = "OMP_MCP_URL_ELICITATION_TIMEOUT_MS";
+const DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS = 300_000;
 
-function resolveUrlElicitationWaitTimeoutMs(connection: MCPServerConnection): number {
-	const configured = resolveMCPTimeoutMs(connection.config.timeout);
-	return configured > 0
-		? Math.min(configured, DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS)
-		: DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS;
+function resolveUrlElicitationWaitTimeoutMs(): number {
+	const configured = Number.parseInt(process.env[URL_ELICITATION_TIMEOUT_ENV] ?? "", 10);
+	return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_URL_ELICITATION_WAIT_TIMEOUT_MS;
 }
 
 function getUrlElicitations(error: unknown): MCPUrlElicitation[] | undefined {
@@ -359,8 +357,7 @@ async function callToolWithUrlElicitationRetry(
 		const elicitations = getUrlElicitations(error);
 		const handler = connection.urlElicitationHandler;
 		if (!elicitations || !handler) throw error;
-
-		const deadline = Date.now() + resolveUrlElicitationWaitTimeoutMs(connection);
+		const deadline = Date.now() + resolveUrlElicitationWaitTimeoutMs();
 		const waitForCompletion = connection.waitForUrlElicitationCompletion;
 		for (const elicitation of elicitations) {
 			// Register before prompting: a fast server may complete while the
@@ -377,12 +374,28 @@ async function callToolWithUrlElicitationRetry(
 			try {
 				const response = await handler(connection.name, elicitation);
 				if (response.action !== "accept") {
-					return { connection, error: new Error("URL elicitation declined") };
+					return {
+						connection,
+						error: new Error(
+							`MCP server "${connection.name}" URL authorization was ${response.action} for tool "${toolName}".`,
+						),
+					};
 				}
 				if (completionPromise) {
 					const remaining = deadline - Date.now();
-					if (remaining <= 0) throw new Error("Timed out waiting for MCP URL elicitation completion");
-					await withTimeout(completionPromise, remaining, "Timed out waiting for MCP URL elicitation completion");
+					if (remaining > 0) {
+						try {
+							await withTimeout(
+								completionPromise,
+								remaining,
+								"Timed out waiting for MCP URL elicitation completion",
+								signal,
+							);
+						} catch (waitError) {
+							rethrowIfAborted(waitError, signal);
+							// Completion is optional; retry once after the deadline.
+						}
+					}
 				}
 			} finally {
 				completionController?.abort();

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -17,7 +17,7 @@ import type {
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCPRequestError, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 import { type MCPFetchInit, mcpFetch, withoutHeader } from "./header-policy";
@@ -419,7 +419,7 @@ export class HttpTransport implements MCPTransport {
 			const result = (await response.json()) as JsonRpcResponse;
 
 			if (result.error) {
-				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
+				throw new MCPRequestError(result.error);
 			}
 
 			return result.result as T;
@@ -471,7 +471,7 @@ export class HttpTransport implements MCPTransport {
 									captured = true;
 									operation.clear();
 									if (message.error) {
-										reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
+										reject(new MCPRequestError(message.error));
 									} else {
 										resolve(message.result as T);
 									}

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -9,7 +9,7 @@ import type {
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCPRequestError, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, resolveMCPTimeoutMs } from "../timeout";
 import { type MCPFetchInit, mcpFetch } from "./header-policy";
@@ -179,7 +179,7 @@ export class LegacySseTransport implements MCPTransport {
 				if (pending.abortHandler) pending.operation.signal?.removeEventListener("abort", pending.abortHandler);
 				const response = message as JsonRpcResponse;
 				if (response.error) {
-					pending.reject(new Error(`MCP error ${response.error.code}: ${response.error.message}`));
+					pending.reject(new MCPRequestError(response.error));
 				} else {
 					pending.resolve(response.result);
 				}

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -19,7 +19,7 @@ import type {
 	MCPStdioServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
-import { toJsonRpcError } from "../../mcp/types";
+import { MCPRequestError, toJsonRpcError } from "../../mcp/types";
 import { RequestIdAllocator } from "../request-id";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
@@ -680,7 +680,7 @@ export class StdioTransport implements MCPTransport {
 			if (pending) {
 				this.#pendingRequests.delete(response.id);
 				if (response.error) {
-					pending.reject(new Error(`MCP error ${response.error.code}: ${response.error.message}`));
+					pending.reject(new MCPRequestError(response.error));
 				} else {
 					pending.resolve(response.result);
 				}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -291,7 +291,6 @@ export type MCPUrlElicitationHandler = (
 /** Transport-level URL elicitation handler without a server-name closure. */
 export type MCPUrlElicitationRequestHandler = (request: MCPUrlElicitation) => Promise<MCPUrlElicitationResponse>;
 
-
 /** tools/call response */
 export interface MCPToolCallResult {
 	content: MCPContent[];
@@ -513,19 +512,24 @@ export const MCPNotificationMethods = {
 	RESOURCES_LIST_CHANGED: "notifications/resources/list_changed",
 	RESOURCES_UPDATED: "notifications/resources/updated",
 	PROMPTS_LIST_CHANGED: "notifications/prompts/list_changed",
+	ELICITATION_COMPLETE: "notifications/elicitation/complete",
 } as const;
 
-/** Extract a JsonRpcError from a thrown value. Preserves `.code`, `.message`, and `.data`. */
+/** Extract a JSON-RPC error safe to send back to an MCP server. */
 export function toJsonRpcError(error: unknown): JsonRpcError {
+	if (error instanceof MCPRequestError) {
+		return error.data === undefined
+			? { code: error.code, message: error.message }
+			: { code: error.code, message: error.message, data: error.data };
+	}
 	if (error instanceof Error) {
 		const code = "code" in error && typeof error.code === "number" ? error.code : -32603;
-		const data = "data" in error ? error.data : undefined;
-		return data === undefined ? { code, message: error.message } : { code, message: error.message, data };
+		return { code, message: error.message };
 	}
 	if (typeof error === "object" && error !== null) {
 		const obj = error as Record<string, unknown>;
 		if (typeof obj.code === "number" && typeof obj.message === "string") {
-			return { code: obj.code, message: obj.message, data: obj.data };
+			return { code: obj.code, message: obj.message };
 		}
 	}
 	return { code: -32603, message: "Internal error" };

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -36,6 +36,18 @@ export interface JsonRpcError {
 	message: string;
 	data?: unknown;
 }
+/** A structured JSON-RPC error returned by an MCP request. */
+export class MCPRequestError extends Error {
+	readonly code: number;
+	readonly data?: unknown;
+
+	constructor(error: JsonRpcError) {
+		super(`MCP error ${error.code}: ${error.message}`);
+		this.name = "MCPRequestError";
+		this.code = error.code;
+		this.data = error.data;
+	}
+}
 
 export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
 
@@ -174,6 +186,8 @@ export interface MCPImplementation {
 export interface MCPClientCapabilities {
 	roots?: { listChanged?: boolean };
 	sampling?: Record<string, never>;
+	/** URL-mode elicitation support. */
+	elicitation?: { url?: Record<string, never>; form?: Record<string, never> };
 	experimental?: Record<string, unknown>;
 }
 
@@ -254,6 +268,29 @@ export interface MCPAuthChallenge {
 	/** Values from `_meta["mcp/www_authenticate"]`. */
 	readonly wwwAuthenticate: readonly string[];
 }
+/** A URL-mode MCP elicitation request. */
+export interface MCPUrlElicitation {
+	readonly mode: "url";
+	readonly elicitationId: string;
+	readonly url: string;
+	readonly message: string;
+}
+
+export type MCPUrlElicitationAction = "accept" | "decline" | "cancel";
+
+export interface MCPUrlElicitationResponse {
+	readonly action: MCPUrlElicitationAction;
+}
+
+/** UI callback for a server-owned URL interaction. */
+export type MCPUrlElicitationHandler = (
+	serverName: string,
+	request: MCPUrlElicitation,
+) => Promise<MCPUrlElicitationResponse>;
+
+/** Transport-level URL elicitation handler without a server-name closure. */
+export type MCPUrlElicitationRequestHandler = (request: MCPUrlElicitation) => Promise<MCPUrlElicitationResponse>;
+
 
 /** tools/call response */
 export interface MCPToolCallResult {
@@ -299,6 +336,8 @@ export interface MCPTransport {
 	onNotification?: (method: string, params: unknown) => void;
 	/** Handler for server-to-client requests (e.g. roots/list). Returns result or throws a JsonRpcError. */
 	onRequest?: (method: string, params: unknown) => Promise<unknown>;
+	/** Handler for user-approved URL-mode elicitation requests. */
+	urlElicitationHandler?: MCPUrlElicitationRequestHandler;
 }
 
 /** Transport factory function */
@@ -320,6 +359,10 @@ export interface MCPServerConnection {
 	serverInfo: MCPImplementation;
 	/** Server capabilities */
 	capabilities: MCPServerCapabilities;
+	/** Handler for user-approved URL-mode elicitation requests. */
+	urlElicitationHandler?: MCPUrlElicitationHandler;
+	/** Wait for the server to report completion of a URL elicitation. */
+	waitForUrlElicitationCompletion?: (elicitationId: string, signal?: AbortSignal) => Promise<void>;
 	/** Cached tools (populated on demand) */
 	tools?: MCPToolDefinition[];
 	/** Source metadata (for display) */
@@ -472,16 +515,17 @@ export const MCPNotificationMethods = {
 	PROMPTS_LIST_CHANGED: "notifications/prompts/list_changed",
 } as const;
 
-/** Extract a JsonRpcError from a thrown value. Preserves `.code` and `.message` from Error instances or plain objects. */
+/** Extract a JsonRpcError from a thrown value. Preserves `.code`, `.message`, and `.data`. */
 export function toJsonRpcError(error: unknown): JsonRpcError {
 	if (error instanceof Error) {
 		const code = "code" in error && typeof error.code === "number" ? error.code : -32603;
-		return { code, message: error.message };
+		const data = "data" in error ? error.data : undefined;
+		return data === undefined ? { code, message: error.message } : { code, message: error.message, data };
 	}
 	if (typeof error === "object" && error !== null) {
 		const obj = error as Record<string, unknown>;
 		if (typeof obj.code === "number" && typeof obj.message === "string") {
-			return { code: obj.code, message: obj.message };
+			return { code: obj.code, message: obj.message, data: obj.data };
 		}
 	}
 	return { code: -32603, message: "Internal error" };

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -57,7 +57,7 @@ import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibili
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../../internal-urls";
 import { MCPManager } from "../../mcp/manager";
-import type { MCPServerConfig } from "../../mcp/types";
+import type { MCPServerConfig, MCPUrlElicitation, MCPUrlElicitationResponse } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
 import { normalizePlanTitle, type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
@@ -2425,6 +2425,43 @@ export class AcpAgent implements Agent {
 		record.extensionsConfigured = true;
 	}
 
+	async #handleMcpUrlElicitation(
+		record: ManagedSessionRecord,
+		serverName: string,
+		request: MCPUrlElicitation,
+	): Promise<MCPUrlElicitationResponse> {
+		if (this.#clientCapabilities?.elicitation?.url == null) {
+			return { action: "decline" };
+		}
+
+		let host = "unknown host";
+		try {
+			const parsed = new URL(request.url);
+			host = parsed.host || parsed.protocol.replace(/:$/, "") || host;
+		} catch {
+			// Keep malformed URLs out of the consent text; the ACP client still receives the URL field.
+		}
+
+		try {
+			const response = await this.#connection.unstable_createElicitation({
+				mode: "url",
+				sessionId: record.session.sessionId,
+				message: `MCP server "${serverName}" requests authorization at ${host}.\n${request.message}`,
+				url: request.url,
+				elicitationId: request.elicitationId,
+			});
+			if (response.action === "accept") return { action: "accept" };
+			if (response.action === "cancel") return { action: "cancel" };
+			return { action: "decline" };
+		} catch {
+			logger.warn("ACP URL elicitation failed", {
+				serverName,
+				elicitationId: request.elicitationId,
+			});
+			return { action: "decline" };
+		}
+	}
+
 	async #configureMcpServers(record: ManagedSessionRecord, servers: McpServer[]): Promise<void> {
 		if (record.mcpManager) {
 			await record.mcpManager.disconnectAll();
@@ -2441,6 +2478,9 @@ export class AcpAgent implements Agent {
 		}
 
 		const manager = new MCPManager(record.session.sessionManager.getCwd());
+		manager.setUrlElicitationHandler((serverName, request) =>
+			this.#handleMcpUrlElicitation(record, serverName, request),
+		);
 		// MCP servers connect and reconnect independently, so `onToolsChanged` can fire
 		// several times back to back. Each firing is chained onto `record.mcpRefreshChain`
 		// so refreshes apply in order, and each one re-reads `manager.getTools()` at the

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -54,6 +54,8 @@ import type {
 	MCPConfigFile,
 	MCPServerConfig,
 	MCPServerConnection,
+	MCPUrlElicitation,
+	MCPUrlElicitationResponse,
 } from "../../mcp/types";
 import { shortenPath } from "../../tools/render-utils";
 import { urlHyperlinkAlways } from "../../tui";
@@ -1814,6 +1816,32 @@ export class MCPCommandController {
 		} catch (error) {
 			this.ctx.showError(`Failed to clear auth: ${error instanceof Error ? error.message : String(error)}`);
 		}
+	}
+
+	/** Present URL-mode MCP consent in the interactive selector. */
+	async handleMCPUrlElicitation(serverName: string, request: MCPUrlElicitation): Promise<MCPUrlElicitationResponse> {
+		let host = "unknown host";
+		try {
+			const parsed = new URL(request.url);
+			host = parsed.host || parsed.protocol.replace(/:$/, "") || host;
+		} catch {
+			// Keep malformed URLs out of the consent text; the opener still receives the original request on accept.
+		}
+		const choice = await this.ctx.showHookSelector(
+			`Open URL requested by MCP server "${serverName}"?\nHost: ${host}\n${request.message}`,
+			[
+				{ label: "Accept", description: `Open ${host} in your browser` },
+				{ label: "Decline", description: `Do not open ${host}` },
+				"Cancel",
+			],
+		);
+		if (choice === "Accept") {
+			this.ctx.openInBrowser(request.url);
+			this.ctx.showStatus(`Opened URL requested by MCP server "${serverName}" (${host}).`);
+			return { action: "accept" };
+		}
+		if (choice === "Decline") return { action: "decline" };
+		return { action: "cancel" };
 	}
 
 	/** Reauthorize a server after a tool-level OAuth challenge. */

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4402,14 +4402,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		serverName: string,
 		request: MCPUrlElicitation,
 	): Promise<{ action: "accept" | "decline" | "cancel" }> {
-		const consent = await this.showHookConfirm(
-			`Open URL requested by MCP server "${serverName}"?`,
-			`${request.message}\n${request.url}`,
+		let host = "unknown host";
+		try {
+			const parsed = new URL(request.url);
+			host = parsed.host || parsed.protocol.replace(/:$/, "") || host;
+		} catch {
+			// Keep malformed URLs out of the consent text; the MCP request is still declined or cancelled safely.
+		}
+		const choice = await this.showHookSelector(
+			`Open URL requested by MCP server "${serverName}"?\nHost: ${host}\n${request.message}`,
+			[
+				{ label: "Accept", description: `Open ${host} in your browser` },
+				{ label: "Decline", description: `Do not open ${host}` },
+				"Cancel",
+			],
 		);
-		if (!consent) return { action: "decline" };
-		this.openInBrowser(request.url);
-		this.showStatus(`Opened URL requested by MCP server "${serverName}".`);
-		return { action: "accept" };
+		if (choice === "Accept") {
+			this.openInBrowser(request.url);
+			this.showStatus(`Opened URL requested by MCP server "${serverName}" (${host}).`);
+			return { action: "accept" };
+		}
+		if (choice === "Decline") return { action: "decline" };
+		return { action: "cancel" };
 	}
 
 	showStatus(message: string, options?: { dim?: boolean }): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -84,7 +84,7 @@ import { loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
 import { copyLocalArtifacts, resolveLocalUrlToPath } from "../internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
-import type { MCPManager, MCPUrlElicitation } from "../mcp";
+import type { MCPManager } from "../mcp";
 import {
 	formatMCPConnectionStatusMessage,
 	isMcpConnectionStatusEvent,
@@ -771,7 +771,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			new MCPCommandController(this).handleMCPAuthChallenge(serverName, challenge),
 		);
 		this.mcpManager?.setUrlElicitationHandler((serverName, request) =>
-			this.#handleMcpUrlElicitation(serverName, request),
+			new MCPCommandController(this).handleMCPUrlElicitation(serverName, request),
 		);
 		this.#eventBus = eventBus;
 		if (eventBus) {
@@ -4396,34 +4396,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.transcriptMessageComponents = new WeakMap<AgentMessage, Component>();
 		this.chatContainer.dispose();
 		this.chatContainer.clear();
-	}
-
-	async #handleMcpUrlElicitation(
-		serverName: string,
-		request: MCPUrlElicitation,
-	): Promise<{ action: "accept" | "decline" | "cancel" }> {
-		let host = "unknown host";
-		try {
-			const parsed = new URL(request.url);
-			host = parsed.host || parsed.protocol.replace(/:$/, "") || host;
-		} catch {
-			// Keep malformed URLs out of the consent text; the MCP request is still declined or cancelled safely.
-		}
-		const choice = await this.showHookSelector(
-			`Open URL requested by MCP server "${serverName}"?\nHost: ${host}\n${request.message}`,
-			[
-				{ label: "Accept", description: `Open ${host} in your browser` },
-				{ label: "Decline", description: `Do not open ${host}` },
-				"Cancel",
-			],
-		);
-		if (choice === "Accept") {
-			this.openInBrowser(request.url);
-			this.showStatus(`Opened URL requested by MCP server "${serverName}" (${host}).`);
-			return { action: "accept" };
-		}
-		if (choice === "Decline") return { action: "decline" };
-		return { action: "cancel" };
 	}
 
 	showStatus(message: string, options?: { dim?: boolean }): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -84,7 +84,7 @@ import { loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
 import { copyLocalArtifacts, resolveLocalUrlToPath } from "../internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
-import type { MCPManager } from "../mcp";
+import type { MCPManager, MCPUrlElicitation } from "../mcp";
 import {
 	formatMCPConnectionStatusMessage,
 	isMcpConnectionStatusEvent,
@@ -769,6 +769,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.mcpManager = mcpManager;
 		this.mcpManager?.setAuthHandler((serverName, challenge) =>
 			new MCPCommandController(this).handleMCPAuthChallenge(serverName, challenge),
+		);
+		this.mcpManager?.setUrlElicitationHandler((serverName, request) =>
+			this.#handleMcpUrlElicitation(serverName, request),
 		);
 		this.#eventBus = eventBus;
 		if (eventBus) {
@@ -4393,6 +4396,20 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.transcriptMessageComponents = new WeakMap<AgentMessage, Component>();
 		this.chatContainer.dispose();
 		this.chatContainer.clear();
+	}
+
+	async #handleMcpUrlElicitation(
+		serverName: string,
+		request: MCPUrlElicitation,
+	): Promise<{ action: "accept" | "decline" | "cancel" }> {
+		const consent = await this.showHookConfirm(
+			`Open URL requested by MCP server "${serverName}"?`,
+			`${request.message}\n${request.url}`,
+		);
+		if (!consent) return { action: "decline" };
+		this.openInBrowser(request.url);
+		this.showStatus(`Opened URL requested by MCP server "${serverName}".`);
+		return { action: "accept" };
 	}
 
 	showStatus(message: string, options?: { dim?: boolean }): void {

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -102,6 +102,46 @@ describe("MCP Streamable HTTP initialization", () => {
 	});
 });
 
+describe("MCP URL elicitation capability", () => {
+	it("advertises URL elicitation when a handler is installed", async () => {
+		let initializeCapabilities: unknown;
+		server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				if (req.method === "DELETE") return new Response(null, { status: 204 });
+				const body = (await req.json()) as { id?: string | number; method: string; params?: { capabilities?: unknown } };
+				if (body.method === "initialize") {
+					initializeCapabilities = body.params?.capabilities;
+					return Response.json({
+						jsonrpc: "2.0",
+						id: body.id,
+						result: {
+							protocolVersion: "2025-11-25",
+							capabilities: {},
+							serverInfo: { name: "url-elicitation", version: "1.0.0" },
+						},
+					});
+				}
+				return new Response(null, { status: 202 });
+			},
+		});
+
+		const connection = await connectToServer(
+			"url-elicitation",
+			{
+				type: "http",
+				url: `http://127.0.0.1:${server.port}/mcp`,
+				timeout: GUARD_TIMEOUT_MS,
+			},
+			{ urlElicitationHandler: async () => ({ action: "decline" }) },
+		);
+
+		expect(initializeCapabilities).toMatchObject({ elicitation: { url: {} } });
+		await connection.transport.close();
+	});
+});
+
 describe("MCP Streamable HTTP transport timeouts", () => {
 	it("keeps the request timeout active until a JSON response body is fully read", async () => {
 		server = Bun.serve({
@@ -152,6 +192,40 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 		await expect(withPendingGuard(transport.request<ToolList>("tools/list"), "request")).resolves.toEqual({
 			tools: [{ name: "fast", inputSchema: { type: "object" } }],
 		});
+	});
+});
+
+it("preserves structured JSON-RPC error data", async () => {
+	server = Bun.serve({
+		port: 0,
+		fetch() {
+			return Response.json({
+				jsonrpc: "2.0",
+				id: 1,
+				error: {
+					code: -32042,
+					message: "URL elicitation required",
+					data: {
+						elicitations: [
+							{
+								mode: "url",
+								elicitationId: "test-id",
+								url: "https://gateway.example/authorize",
+								message: "Authorize the gateway",
+							},
+						],
+					},
+				},
+			});
+		},
+	});
+	const transport = await connectedTransport();
+
+	await expect(transport.request("tools/call")).rejects.toMatchObject({
+		code: -32042,
+		data: {
+			elicitations: [{ elicitationId: "test-id", url: "https://gateway.example/authorize" }],
+		},
 	});
 });
 

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -50,6 +50,86 @@ async function withPendingGuard<T>(promise: Promise<T>, label: string): Promise<
 	]);
 }
 
+async function captureElicitationResponse(
+	mode: "url" | "form" | "credentials",
+	handler?: (
+		serverName: string,
+		request: { mode: "url"; elicitationId: string; url: string; message: string },
+	) => Promise<{ action: "accept" | "decline" | "cancel" }>,
+): Promise<Record<string, unknown>> {
+	let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+	let resolveResponse!: (body: Record<string, unknown>) => void;
+	const responsePromise = new Promise<Record<string, unknown>>(resolve => {
+		resolveResponse = resolve;
+	});
+	server = Bun.serve({
+		port: 0,
+		async fetch(req) {
+			if (req.method === "GET") {
+				const request = {
+					jsonrpc: "2.0",
+					id: 99,
+					method: "elicitation/create",
+					params:
+						mode === "url"
+							? {
+									mode: "url",
+									elicitationId: "request-1",
+									url: "https://gateway.example/authorize",
+									message: "Authorize the gateway",
+								}
+							: mode === "credentials"
+								? {
+										mode: "url",
+										elicitationId: "request-1",
+										url: "https://user:secret@gateway.example/authorize",
+										message: "Authorize the gateway",
+									}
+								: { mode: "form", elicitationId: "request-1", message: "Not supported here" },
+				};
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamController = controller;
+							controller.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify(request)}\n\n`));
+						},
+					}),
+					{ headers: { "Content-Type": "text/event-stream" } },
+				);
+			}
+			if (req.method === "DELETE") return new Response(null, { status: 204 });
+			const body = (await req.json()) as Record<string, unknown>;
+			if (body.method === "initialize") {
+				return Response.json({
+					jsonrpc: "2.0",
+					id: body.id,
+					result: {
+						protocolVersion: "2025-11-25",
+						capabilities: {},
+						serverInfo: { name: "elicitation-test", version: "1.0.0" },
+					},
+				});
+			}
+			if (body.id !== undefined) resolveResponse(body);
+			return new Response(null, { status: 202 });
+		},
+	});
+
+	const connection = await connectToServer(
+		"elicitation-test",
+		{
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+			timeout: GUARD_TIMEOUT_MS,
+		},
+		handler ? { urlElicitationHandler: handler } : undefined,
+	);
+	const response = await responsePromise;
+	await connection.transport.close();
+	streamController?.close();
+	return response;
+}
+
 describe("MCP Streamable HTTP initialization", () => {
 	it("sends initialized before opening the optional GET SSE stream", async () => {
 		const requests: string[] = [];
@@ -103,14 +183,18 @@ describe("MCP Streamable HTTP initialization", () => {
 });
 
 describe("MCP URL elicitation capability", () => {
-	it("advertises URL elicitation when a handler is installed", async () => {
+	it("advertises URL elicitation without a handler", async () => {
 		let initializeCapabilities: unknown;
 		server = Bun.serve({
 			port: 0,
 			async fetch(req) {
 				if (req.method === "GET") return new Response(null, { status: 405 });
 				if (req.method === "DELETE") return new Response(null, { status: 204 });
-				const body = (await req.json()) as { id?: string | number; method: string; params?: { capabilities?: unknown } };
+				const body = (await req.json()) as {
+					id?: string | number;
+					method: string;
+					params?: { capabilities?: unknown };
+				};
 				if (body.method === "initialize") {
 					initializeCapabilities = body.params?.capabilities;
 					return Response.json({
@@ -127,18 +211,54 @@ describe("MCP URL elicitation capability", () => {
 			},
 		});
 
-		const connection = await connectToServer(
-			"url-elicitation",
-			{
-				type: "http",
-				url: `http://127.0.0.1:${server.port}/mcp`,
-				timeout: GUARD_TIMEOUT_MS,
-			},
-			{ urlElicitationHandler: async () => ({ action: "decline" }) },
-		);
+		const connection = await connectToServer("url-elicitation", {
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+			timeout: GUARD_TIMEOUT_MS,
+		});
 
 		expect(initializeCapabilities).toMatchObject({ elicitation: { url: {} } });
 		await connection.transport.close();
+	});
+
+	it("declines URL requests without a handler", async () => {
+		const response = await captureElicitationResponse("url");
+
+		expect(response).toMatchObject({ id: 99, result: { action: "decline" } });
+		expect(response).not.toHaveProperty("error");
+	});
+
+	it("rejects URL credentials before invoking a handler", async () => {
+		const response = await captureElicitationResponse("credentials");
+
+		expect(response).toMatchObject({ id: 99, error: { code: -32602 } });
+		expect(response).not.toHaveProperty("result");
+	});
+
+	it("passes server name and request to the connection-level handler", async () => {
+		let received: { serverName: string; request: unknown } | undefined;
+		const response = await captureElicitationResponse("url", async (serverName, request) => {
+			received = { serverName, request };
+			return { action: "decline" };
+		});
+
+		expect(received).toEqual({
+			serverName: "elicitation-test",
+			request: {
+				mode: "url",
+				elicitationId: "request-1",
+				url: "https://gateway.example/authorize",
+				message: "Authorize the gateway",
+			},
+		});
+		expect(response).toMatchObject({ id: 99, result: { action: "decline" } });
+	});
+
+	it("rejects form requests instead of routing them through URL elicitation", async () => {
+		const response = await captureElicitationResponse("form");
+
+		expect(response).toMatchObject({ id: 99, error: { code: -32601 } });
+		expect(response).not.toHaveProperty("result");
 	});
 });
 

--- a/packages/coding-agent/test/mcp-json-rpc.test.ts
+++ b/packages/coding-agent/test/mcp-json-rpc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { parseSSE, redactUrlForLog } from "@oh-my-pi/pi-coding-agent/mcp/json-rpc";
+import { MCPRequestError, toJsonRpcError } from "@oh-my-pi/pi-coding-agent/mcp/types";
 
 describe("redactUrlForLog", () => {
 	it("redacts credential-bearing query params but keeps the rest", () => {
@@ -22,5 +23,24 @@ describe("parseSSE", () => {
 
 	it("returns null when nothing parses", () => {
 		expect(parseSSE("data: ping\nnot json either")).toBeNull();
+	});
+});
+
+describe("toJsonRpcError", () => {
+	it("does not serialize arbitrary thrown object data", () => {
+		const error = toJsonRpcError({ code: -32042, message: "elicitation required", data: { secret: "do-not-send" } });
+
+		expect(error).toEqual({ code: -32042, message: "elicitation required" });
+		expect(error).not.toHaveProperty("data");
+	});
+
+	it("preserves data only for MCPRequestError", () => {
+		const data = { elicitations: [{ mode: "url", elicitationId: "id-1" }] };
+
+		expect(toJsonRpcError(new MCPRequestError({ code: -32042, message: "elicitation required", data }))).toEqual({
+			code: -32042,
+			message: "MCP error -32042: elicitation required",
+			data,
+		});
 	});
 });

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
 import { DeferredMCPTool, MCPTool, type MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp";
-import type { MCPServerConnection } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { MCPRequestError, type MCPServerConnection, type MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import { createMockConnection, createMockTransport } from "./mcp-test-utils";
@@ -14,6 +14,13 @@ type CapturedRequest = {
 };
 
 const unusedContext = {} as CustomToolContext;
+
+const URL_ELICITATION = {
+	mode: "url" as const,
+	elicitationId: "elicitation-1",
+	url: "https://gateway.example/authorize",
+	message: "Authorize the gateway",
+};
 
 function createSearchToolDefinition(): MCPToolDefinition {
 	return {
@@ -202,5 +209,89 @@ describe("MCP tool arguments", () => {
 				params: { name: "read_image_with_model", arguments: { image_path: expectedPath } },
 			},
 		]);
+	});
+
+	it("prompts once and retries after a URL elicitation-required error", async () => {
+		let calls = 0;
+		let prompts = 0;
+		const transport: MCPTransport = {
+			connected: true,
+			async request<T>(): Promise<T> {
+				calls += 1;
+				if (calls === 1) {
+					throw new MCPRequestError({
+						code: -32042,
+						message: "URL elicitation required",
+						data: { elicitations: [URL_ELICITATION] },
+					});
+				}
+				return { content: [{ type: "text", text: "ok" }] } as T;
+			},
+			async notify(): Promise<void> {},
+			async close(): Promise<void> {},
+		};
+		const connection = createMockConnection({ tools: {} }, transport);
+		connection.urlElicitationHandler = async (_server, request) => {
+			prompts += 1;
+			expect(request).toEqual(URL_ELICITATION);
+			return { action: "accept" };
+		};
+		const tool = new MCPTool(connection, createSearchToolDefinition());
+
+		const result = await tool.execute(
+			"call-1",
+			{ symbol: "Foo", language: "TypeScript" },
+			undefined,
+			unusedContext,
+			undefined,
+		);
+
+		expect(calls).toBe(2);
+		expect(prompts).toBe(1);
+		expect(result).toMatchObject({ isError: false, content: [{ type: "text", text: "ok" }] });
+	});
+
+	it("registers an optional completion waiter before prompting", async () => {
+		let calls = 0;
+		let waiterRegistered = false;
+		const completion = Promise.withResolvers<void>();
+		const transport: MCPTransport = {
+			connected: true,
+			async request<T>(): Promise<T> {
+				calls += 1;
+				if (calls === 1) {
+					throw new MCPRequestError({
+						code: -32042,
+						message: "URL elicitation required",
+						data: { elicitations: [URL_ELICITATION] },
+					});
+				}
+				return { content: [{ type: "text", text: "ok" }] } as T;
+			},
+			async notify(): Promise<void> {},
+			async close(): Promise<void> {},
+		};
+		const connection = createMockConnection({ tools: {} }, transport);
+		connection.waitForUrlElicitationCompletion = async () => {
+			waiterRegistered = true;
+			await completion.promise;
+		};
+		connection.urlElicitationHandler = async () => {
+			expect(waiterRegistered).toBe(true);
+			completion.resolve();
+			return { action: "accept" };
+		};
+		const tool = new MCPTool(connection, createSearchToolDefinition());
+
+		const result = await tool.execute(
+			"call-1",
+			{ symbol: "Foo", language: "TypeScript" },
+			undefined,
+			unusedContext,
+			undefined,
+		);
+
+		expect(calls).toBe(2);
+		expect(result).toMatchObject({ isError: false, content: [{ type: "text", text: "ok" }] });
 	});
 });

--- a/packages/coding-agent/test/mcp-url-elicitation.test.ts
+++ b/packages/coding-agent/test/mcp-url-elicitation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import type { MCPServerConfig, MCPServerConnection, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+
+const CONFIG: MCPServerConfig = { type: "stdio", command: "fake-mcp-server" };
+const REQUEST = {
+	mode: "url" as const,
+	elicitationId: "elicitation-1",
+	url: "https://gateway.example/authorize",
+	message: "Authorize the gateway",
+};
+
+function fakeConnection(name: string): MCPServerConnection {
+	const transport: MCPTransport = {
+		connected: true,
+		async request<T>(method: string): Promise<T> {
+			if (method === "tools/list") return { tools: [] } as T;
+			return {} as T;
+		},
+		async notify(): Promise<void> {},
+		async close(): Promise<void> {
+			transport.connected = false;
+		},
+	};
+	return {
+		name,
+		config: CONFIG,
+		transport,
+		serverInfo: { name: "fake", version: "1.0.0" },
+		capabilities: { tools: {} },
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("MCP URL elicitation lifecycle", () => {
+	it("deduplicates prompts by server and elicitation id", async () => {
+		const manager = new MCPManager(process.cwd());
+		const connection = fakeConnection("server");
+		const prompt = Promise.withResolvers<{ action: "accept" }>();
+		const prompts: Array<{ server: string; id: string }> = [];
+		vi.spyOn(mcpClient, "connectToServer").mockImplementation(async (_name, _config, options) => {
+			connection.transport.onNotification = options?.onNotification;
+			return connection;
+		});
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
+		manager.setUrlElicitationHandler(async (server, request) => {
+			prompts.push({ server, id: request.elicitationId });
+			return prompt.promise;
+		});
+
+		await manager.connectServers({ server: CONFIG }, {});
+		const handler = connection.urlElicitationHandler;
+		if (!handler) throw new Error("Expected URL elicitation handler");
+		const first = handler("server", REQUEST);
+		const second = handler("server", REQUEST);
+
+		expect(first).toBe(second);
+		expect(prompts).toEqual([{ server: "server", id: "elicitation-1" }]);
+		prompt.resolve({ action: "accept" });
+		await expect(first).resolves.toEqual({ action: "accept" });
+	});
+
+	it("consumes completion notifications that arrive before the waiter", async () => {
+		const manager = new MCPManager(process.cwd());
+		const connection = fakeConnection("server");
+		vi.spyOn(mcpClient, "connectToServer").mockImplementation(async (_name, _config, options) => {
+			connection.transport.onNotification = options?.onNotification;
+			return connection;
+		});
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
+
+		await manager.connectServers({ server: CONFIG }, {});
+		connection.transport.onNotification?.("notifications/elicitation/complete", { elicitationId: "early" });
+
+		await expect(connection.waitForUrlElicitationCompletion?.("early")).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Related issue
References #8808.

## Problem
When an MCP gateway exposes a tool whose downstream provider needs OAuth 3LO, the gateway can return the MCP URL elicitation error (`-32042`) from a tool call. OMP previously flattened that response into a generic error, so the model only received a link instead of an interactive authorization flow.

## Change
- Preserve structured JSON-RPC error data across HTTP, SSE, and stdio transports.
- Advertise MCP URL elicitation capability when a handler is installed.
- Validate elicitation requests and require HTTPS URLs.
- Prompt for consent in interactive mode, open the URL, wait for `notifications/elicitation/complete`, then retry once.
- Wire handler updates to existing connections and bound retries/timeouts.

## Verification
- `git diff --check` passes.
- Added focused HTTP transport regression coverage for structured errors and capability negotiation.
- Bun tests and type checks were not runnable in this environment because Bun and dependencies are unavailable.