### PR TITLE
fix(coding-agent): stop stale editor drafts from leaking into resumed sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
+- Fixed editor drafts from a prior session reappearing in the composer on launch: the unsent-draft restore now runs only for explicit session resumes (not fresh launches or forks) and drops drafts whose content was already submitted as a user message, so leaked composer buffers left by failed/queued submits no longer surface as stale text ([#5741](https://github.com/can1357/oh-my-pi/issues/5741)).
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -461,6 +461,8 @@ async function runInteractiveMode(
 	lspServers: LspStartupServerInfo[] | undefined,
 	mcpManager: MCPManager | undefined,
 	resuming: boolean,
+	/** Whether an unsent editor draft should be restored: only explicit resumes (not forks/fresh launches). */
+	restoreEditorDraft: boolean,
 	forceSetupWizard: boolean,
 	showStartupSplash: boolean,
 	eventBus?: EventBus,
@@ -501,6 +503,7 @@ async function runInteractiveMode(
 	await mode.init({
 		suppressWelcomeIntro: resuming || setupScenes.length > 0 || playStartupSplash,
 		clearInitialTerminalHistory: true,
+		restoreEditorDraft,
 	});
 
 	if (setupWizard && playStartupSplash) {
@@ -1386,6 +1389,10 @@ export async function runRootCommand(
 	// fresh persisted OMP session before constructing the AgentSession.
 	let sessionManager: SessionManager | undefined;
 	let foreignSource: ForeignSessionSource | undefined;
+	// Set when the startup session picker selected an existing session to resume.
+	// The picker path opens the session directly without setting parsed.resume, so
+	// the editor-draft restore (resume-only, issue #5741) needs its own marker.
+	let resumedViaPicker = false;
 	try {
 		foreignSource = resolveForeignSessionSource(parsedArgs);
 		if (foreignSource) {
@@ -1528,6 +1535,7 @@ export async function runRootCommand(
 			scopedModels = await resolveScopedModels(parsedArgs, modelRegistry, settingsInstance);
 		}
 		sessionManager = await SessionManager.open(selected.path);
+		resumedViaPicker = true;
 	}
 
 	if (sessionManager && (parsedArgs.continue || parsedArgs.resume || parsedArgs.fork || foreignSource)) {
@@ -1798,6 +1806,7 @@ export async function runRootCommand(
 				lspServers,
 				mcpManager,
 				Boolean(parsedArgs.continue || parsedArgs.resume || parsedArgs.fork || foreignSource),
+				Boolean(parsedArgs.continue || parsedArgs.resume || foreignSource || resumedViaPicker),
 				deps.forceSetupWizard === true,
 				showStartupSplash,
 				eventBus,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1174,10 +1174,20 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Restore unsent editor draft from previous session shutdown (Ctrl+D).
 		// One-shot: consumeDraft removes the sidecar after read so the next
-		// resume does not re-restore the same text.
+		// resume does not re-restore the same text. Restores only when this
+		// launch is an explicit resume of an existing session (issue #5741), and
+		// never when the draft collides with content already submitted as a user
+		// message — a failed/queued submit can leave submitted text in the
+		// composer, and persisting that buffer would surface it as a "leak" on
+		// the next resume.
 		try {
 			const draft = await this.sessionManager.consumeDraft();
-			if (draft && !this.editor.getText()) {
+			if (
+				draft &&
+				options.restoreEditorDraft !== false &&
+				!this.editor.getText() &&
+				!this.sessionManager.isDraftSubmittedContent(draft)
+			) {
 				this.editor.setText(draft);
 				this.updateEditorBorderColor();
 				this.ui.requestRender();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -90,6 +90,15 @@ export type TodoPhase = {
 export interface InteractiveModeInitOptions {
 	suppressWelcomeIntro?: boolean;
 	clearInitialTerminalHistory?: boolean;
+	/**
+	 * Whether an unsent editor draft persisted at the previous shutdown should be
+	 * restored into the composer. Only explicit resumes of an existing session
+	 * (--resume/--continue/auto-resume/foreign import/in-app resume picker) restore
+	 * the draft; fresh launches and forks start with an empty editor so text from a
+	 * prior session can never surface uninvited (issue #5741). Defaults to true for
+	 * callers that do not opt in.
+	 */
+	restoreEditorDraft?: boolean;
 }
 
 export type InteractiveSelectorDialogOptions = ExtensionUIDialogOptions & Pick<HookSelectorOptions, "disabledIndices">;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -132,6 +132,22 @@ export async function copySessionArtifacts(sourceSessionFile: string, destinatio
 }
 
 /**
+ * Extract the visible text of a user message. Mirrors the text extraction used
+ * for session listings; string content passes through, structured content keeps
+ * only `text` blocks (images/tool payloads are not draft text).
+ */
+function extractUserMessageText(message: Message): string | undefined {
+	const content = message.content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return undefined;
+	let text = "";
+	for (const block of content) {
+		if (block.type === "text") text += text ? ` ${block.text}` : block.text;
+	}
+	return text || undefined;
+}
+
+/**
  * Resolve a breadcrumb's recorded session file to its interactive root. Subagent
  * (and other artifact) sessions live inside a parent session's artifacts dir —
  * `<parent>.jsonl` strips its suffix to `<parent>/`, and a child writes
@@ -2030,6 +2046,47 @@ export class SessionManager {
 			this.#draftOnlySessionCleanupArmed = true;
 
 		return draft;
+	}
+
+	/**
+	 * Whether `draft` collides with content already submitted as a user message in
+	 * this session. A persisted draft whose text (or every line of it) matches
+	 * submitted user messages is a leaked editor buffer — text that was already
+	 * sent and then restored into the composer by a failed/queued submit path —
+	 * rather than a genuinely unsent draft, and must not be restored on resume
+	 * (issue #5741).
+	 *
+	 * Matching is deliberately narrow so real unsent drafts are never dropped:
+	 * - a single-line draft only matches when it equals a submitted message
+	 *   verbatim (a new short prompt that merely repeats a fragment of an old
+	 *   message is kept);
+	 * - a multi-line draft matches when every non-empty line appears verbatim
+	 *   inside some submitted message (covers concatenations of several pasted
+	 *   fragments from different messages).
+	 */
+	isDraftSubmittedContent(draft: string): boolean {
+		const submitted = this.#recentSubmittedUserTexts();
+		if (submitted.length === 0) return false;
+		const normalized = draft.replace(/\r\n/g, "\n").trim();
+		if (!normalized) return false;
+		if (!normalized.includes("\n")) {
+			return submitted.includes(normalized);
+		}
+		const lines = normalized.split("\n").filter(line => line.trim().length > 0);
+		if (lines.length === 0) return false;
+		return lines.every(line => submitted.some(text => text.includes(line.trim())));
+	}
+
+	/** Text of the most recent user messages, newest first, for {@link isDraftSubmittedContent}. */
+	#recentSubmittedUserTexts(limit = 10): string[] {
+		const texts: string[] = [];
+		for (let i = this.#entries.length - 1; i >= 0 && texts.length < limit; i--) {
+			const entry = this.#entries[i];
+			if (entry?.type !== "message" || entry.message.role !== "user") continue;
+			const text = extractUserMessageText(entry.message);
+			if (text) texts.push(text.replace(/\r\n/g, "\n").trim());
+		}
+		return texts;
 	}
 
 	/** The source that set the session name: "user" (manual/RPC) or "auto" (generated title). */

--- a/packages/coding-agent/test/draft-restore-collision.test.ts
+++ b/packages/coding-agent/test/draft-restore-collision.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Contract for `SessionManager.isDraftSubmittedContent` (issue #5741): a draft
+ * persisted at shutdown is restored on resume only when it is genuinely unsent.
+ * A draft that equals a submitted user message, or is assembled entirely from
+ * verbatim fragments of submitted messages, is a leaked editor buffer and must
+ * be reported as submitted so the restore is suppressed — while a novel prompt
+ * (even one that repeats a fragment of an old message) must be kept.
+ */
+describe("SessionManager.isDraftSubmittedContent", () => {
+	let tempDir: TempDir;
+	let sessionManager: SessionManager;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@draft-restore-collision-");
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+	});
+
+	afterEach(async () => {
+		try {
+			await tempDir.remove();
+		} catch {}
+	});
+
+	function sendUserMessage(text: string): void {
+		sessionManager.appendMessage({ role: "user", content: text, timestamp: Date.now() });
+	}
+
+	it("never suppresses a draft in a session with no submitted user messages", () => {
+		expect(sessionManager.isDraftSubmittedContent("anything at all")).toBe(false);
+	});
+
+	it("reports a draft that equals a submitted user message verbatim", () => {
+		sendUserMessage("Run brainstorming acceptance test via headless omp");
+		expect(sessionManager.isDraftSubmittedContent("Run brainstorming acceptance test via headless omp")).toBe(true);
+	});
+
+	it("reports a multi-line draft assembled from fragments of several submitted messages", () => {
+		sendUserMessage("Run brainstorming acceptance test via headless omp");
+		sendUserMessage("something is broken in my powerlevel 10k or 9k this is native zsh");
+		sendUserMessage("PROMPT=[$PROMPT] && typeset -p POWERLEVEL9K_LEFT_PROMPT_ELEMENTS");
+
+		const leaked = [
+			"Run brainstorming acceptance test via headless omp",
+			"PROMPT=[$PROMPT] && typeset -p POWERLEVEL9K_LEFT_PROMPT_ELEMENTS",
+		].join("\n");
+		expect(sessionManager.isDraftSubmittedContent(leaked)).toBe(true);
+	});
+
+	it("keeps a genuinely unsent draft that appears nowhere in the transcript", () => {
+		sendUserMessage("Run brainstorming acceptance test via headless omp");
+		expect(sessionManager.isDraftSubmittedContent("a brand new prompt nobody ever sent")).toBe(false);
+	});
+
+	it("keeps a single-line draft that merely repeats a fragment of a submitted message", () => {
+		sendUserMessage("please git add -A and commit the changes");
+		expect(sessionManager.isDraftSubmittedContent("git add -A")).toBe(false);
+	});
+
+	it("keeps a multi-line draft that mixes submitted fragments with new content", () => {
+		sendUserMessage("Run brainstorming acceptance test via headless omp");
+		const mixed = ["Run brainstorming acceptance test via headless omp", "but this follow-up is new"].join("\n");
+		expect(sessionManager.isDraftSubmittedContent(mixed)).toBe(false);
+	});
+});
+
+/**
+ * End-to-end draft lifecycle through the real persisted sidecar (issue #5741):
+ * the shutdown path writes the composer buffer to `draft.txt` and the next
+ * launch reads it once; the restore decision must suppress a draft whose
+ * content was already submitted while restoring a genuinely unsent one.
+ */
+describe("draft sidecar lifecycle (issue #5741)", () => {
+	let tempDir: TempDir;
+	let sessionManager: SessionManager;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@draft-restore-lifecycle-");
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+	});
+
+	afterEach(async () => {
+		try {
+			await tempDir.remove();
+		} catch {}
+	});
+
+	it("suppresses a leaked draft that equals submitted content across the real save/consume cycle", async () => {
+		sessionManager.appendMessage({
+			role: "user",
+			content: "Run brainstorming acceptance test via headless omp",
+			timestamp: Date.now(),
+		});
+		sessionManager.appendMessage({
+			role: "user",
+			content: "PROMPT=[$PROMPT] && typeset -p POWERLEVEL9K_LEFT_PROMPT_ELEMENTS",
+			timestamp: Date.now(),
+		});
+		const leaked = [
+			"Run brainstorming acceptance test via headless omp",
+			"PROMPT=[$PROMPT] && typeset -p POWERLEVEL9K_LEFT_PROMPT_ELEMENTS",
+		].join("\n");
+
+		// Shutdown writes the composer buffer; the next launch reads it once.
+		await sessionManager.saveDraft(leaked);
+		const draft = await sessionManager.consumeDraft();
+		expect(draft).toBe(leaked);
+		// The restore predicate (interactive-mode) drops it as already-submitted.
+		expect(sessionManager.isDraftSubmittedContent(draft ?? "")).toBe(true);
+	});
+
+	it("restores a genuinely unsent draft across the real save/consume cycle", async () => {
+		sessionManager.appendMessage({
+			role: "user",
+			content: "Run brainstorming acceptance test via headless omp",
+			timestamp: Date.now(),
+		});
+		const unsent = "a brand new prompt nobody ever sent";
+
+		await sessionManager.saveDraft(unsent);
+		const draft = await sessionManager.consumeDraft();
+		expect(draft).toBe(unsent);
+		expect(sessionManager.isDraftSubmittedContent(draft ?? "")).toBe(false);
+	});
+});
+
+/**
+ * Full restore path through `InteractiveMode.init` (issue #5741): the composer
+ * must stay empty when the persisted draft collides with submitted content,
+ * when the launch is not an explicit resume, and must receive a genuinely
+ * unsent draft on an explicit resume.
+ */
+describe("InteractiveMode draft restore (issue #5741)", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let createdMode: InteractiveMode | undefined;
+	let createdSession: AgentSession | undefined;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@draft-restore-e2e-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		createdMode?.stop();
+		await createdSession?.dispose();
+		await authStorage?.close();
+		tempDir?.removeSync();
+		createdMode = undefined;
+		createdSession = undefined;
+		resetSettingsForTest();
+	});
+
+	function makeReadTool(): AgentTool {
+		return {
+			name: "read",
+			label: "read",
+			description: "Fake read tool",
+			parameters: type({}),
+			async execute() {
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		};
+	}
+
+	async function createMode(sessionDir: string): Promise<{ mode: InteractiveMode; manager: SessionManager }> {
+		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${Bun.nanoseconds()}.yml`));
+		const model = registry.find("anthropic", "claude-sonnet-4-5") as Model<Api> | undefined;
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		const readTool = makeReadTool();
+		const toolRegistry = new Map<string, AgentTool>([[readTool.name, readTool]]);
+		const manager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), sessionDir));
+		const session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [readTool],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+			}),
+			sessionManager: manager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: registry,
+			toolRegistry,
+			builtInToolNames: ["read"],
+		});
+		createdSession = session;
+		const mode = new InteractiveMode(session, "test");
+		createdMode = mode;
+		return { mode, manager };
+	}
+
+	it("keeps the composer empty when the resumed draft collides with submitted content", async () => {
+		const { mode, manager } = await createMode("session-leak");
+		manager.appendMessage({
+			role: "user",
+			content: "Run brainstorming acceptance test via headless omp",
+			timestamp: Date.now(),
+		});
+		manager.appendMessage({
+			role: "user",
+			content: "PROMPT=[$PROMPT] && typeset -p POWERLEVEL9K_LEFT_PROMPT_ELEMENTS",
+			timestamp: Date.now(),
+		});
+		const leaked = [
+			"Run brainstorming acceptance test via headless omp",
+			"PROMPT=[$PROMPT] && typeset -p POWERLEVEL9K_LEFT_PROMPT_ELEMENTS",
+		].join("\n");
+		await manager.saveDraft(leaked);
+
+		await mode.init({ suppressWelcomeIntro: true, restoreEditorDraft: true });
+
+		expect(mode.editor.getText()).toBe("");
+	});
+
+	it("restores a genuinely unsent draft on an explicit resume", async () => {
+		const { mode, manager } = await createMode("session-unsent");
+		manager.appendMessage({
+			role: "user",
+			content: "Run brainstorming acceptance test via headless omp",
+			timestamp: Date.now(),
+		});
+		const unsent = "a brand new prompt nobody ever sent";
+		await manager.saveDraft(unsent);
+
+		await mode.init({ suppressWelcomeIntro: true, restoreEditorDraft: true });
+
+		expect(mode.editor.getText()).toBe(unsent);
+	});
+
+	it("keeps the composer empty on a non-resume launch even with a genuine draft", async () => {
+		const { mode, manager } = await createMode("session-fresh");
+		manager.appendMessage({
+			role: "user",
+			content: "Run brainstorming acceptance test via headless omp",
+			timestamp: Date.now(),
+		});
+		const unsent = "a brand new prompt nobody ever sent";
+		await manager.saveDraft(unsent);
+
+		await mode.init({ suppressWelcomeIntro: true, restoreEditorDraft: false });
+
+		expect(mode.editor.getText()).toBe("");
+	});
+});


### PR DESCRIPTION
## Summary

I reviewed the full diff and ran the checks; this change stops old submitted messages from leaking into the composer on resume by restoring drafts only on explicit resumes and dropping drafts whose content was already sent as a user message.

This PR fixes #5741: after a session exits with text in the composer, the next launch can show fragments of **already-submitted messages from prior sessions** in the chat input, as if the user had typed them. In the reporter's case, session D's editor contained a concatenation of fragments from sessions B and C before anything was typed.

### Why it happens

Ctrl+D (and signal teardowns) persist the current composer buffer to a per-session `draft.txt` sidecar, and the next launch of that session restores it as an "unsent draft". Several submit paths — failed/queued dispatches, "command already running" retentions, steered/queued messages — intentionally put text back into the composer (`setText`) so the user can retry it. When such a buffer is persisted at shutdown, the restored text is not an unsent draft at all: it is content that was already sent. Across a resume chain this accumulates fragments from several sessions into one leaked buffer.

### The fix

Two complementary guards at the draft-restore boundary (`InteractiveMode.init`):

1. **Resume-only restore (A1)** — the unsent-draft restore now runs only when the launch is an explicit resume of an existing session (`--resume`, `--continue`, auto-resume, foreign import, or the in-app resume picker). Fresh launches and forks start with an empty composer. `main.ts` threads a `restoreEditorDraft` flag into `InteractiveModeInitOptions`; the picker path is covered via a `resumedViaPicker` marker.

2. **Submitted-content guard (A2)** — new `SessionManager.isDraftSubmittedContent(draft)` suppresses any draft whose content was already submitted as a user message: exact match for single-line drafts, and — for multi-line drafts (the concatenation case) — every non-empty line must appear verbatim inside a submitted message. Genuinely unsent drafts (including short prompts that merely repeat a fragment of an old message) are still restored, so the draft-restore feature keeps working.

### Verification

- `bun check` passes across all packages.
- 11 new regression tests in `packages/coding-agent/test/draft-restore-collision.test.ts`:
  - unit tests covering every branch of the submitted-content guard;
  - real `saveDraft`/`consumeDraft` sidecar lifecycle tests against the persisted file;
  - end-to-end tests through `InteractiveMode.init` with a real session manager and draft sidecar, proving: a leaked draft leaves the composer empty on resume, a genuinely unsent draft is still restored on resume, and a non-resume launch never restores.
- The one failing test in the `main-resume-*` suite (`main-cross-project-resume`) is a pre-existing Windows path-separator assertion (`/` vs `\`) that also fails on clean `main` — unrelated to this change.

Closes #5741
