### PR TITLE
feat(auth-gateway): add fail-closed policy socket

### DIFF
--- a/docs/auth-broker-gateway.md
+++ b/docs/auth-broker-gateway.md
@@ -129,13 +129,14 @@ Capability-dependent responses include `Vary: OMP-Auth-Broker-Capabilities` so i
 ### CLI
 
 ```
-omp auth-gateway serve   [--bind=host:port] [--no-auth]
+omp auth-gateway serve   [--bind=host:port] [--no-auth] [--policy-socket=/absolute/path.sock]
 omp auth-gateway token   [--regenerate] [--json]
 omp auth-gateway status  [--json]
 omp auth-gateway check   [--strict] [--json]
 ```
 
 - `serve` requires `OMP_AUTH_BROKER_URL` (or `auth.broker.url` in `config.yml`) — the gateway is itself a broker client. It calls `AuthBrokerClient.fetchSnapshot()`, wraps it in `RemoteAuthCredentialStore`, and constructs an `AuthStorage` that resolves access tokens through the broker. Default bind is `127.0.0.1:4000`. The gateway token is stored at `<config-dir>/auth-gateway.token` (`0600`); `--no-auth` disables the bearer check entirely (loopback-only use).
+- `--policy-socket` opts `serve` into fail-closed, per-request authorization and content-free observation over a bounded NDJSON Unix-socket session. Each authorization carries the exact received request-body byte length and SHA-256 so the trusted policy service can bind the one-time authorization to the payload before credential access. The path must be absolute; the socket must be owned by the gateway's effective user, every ancestor directory must be owned by that user or root, no group/world-writable ancestor is accepted without the sticky bit, and the socket must not be a symlink. Policy mode requires the socket for readiness, restricts credential selection to the authorized OAuth row IDs, forwards no caller-controlled provider headers or identity handles, and returns `403` from `/v1/usage`, `/v1/credentials/check`, and `/v1/models` because those aggregate endpoints cannot be attributed to one authorized request.
 - `token` / `status` manage and inspect the gateway bearer token and upstream broker readiness.
 - `check` probes broker-backed credentials through the gateway store. Without `--strict` it uses provider usage probes; `--strict` also exercises each credential against its chat-completion endpoint and can consume a small amount of quota.
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added fail-closed auth-gateway policy hooks for pre-credential authorization, OAuth row allowlists, caller-identity stripping, and content-free request observations.
+- Added opt-in fail-closed auth-gateway policy hooks for payload-digest-bound pre-credential authorization, OAuth row allowlists, caller-identity stripping, content-free request observations, and dependency-aware readiness.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added fail-closed auth-gateway policy hooks for pre-credential authorization, OAuth row allowlists, caller-identity stripping, and content-free request observations.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/ai/src/auth-gateway/http.ts
+++ b/packages/ai/src/auth-gateway/http.ts
@@ -4,7 +4,7 @@
  * Centralized so we share the same JSON shape, auth check,
  * and peer-resolution logic.
  */
-import { timingSafeEqual as nodeTimingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual as nodeTimingSafeEqual } from "node:crypto";
 import type { Api, AssistantMessage, Model } from "../types";
 
 const JSON_HEADERS = {
@@ -21,8 +21,14 @@ export function json(status: number, body: unknown, headers?: Record<string, str
 
 const JSON_DECODER = new TextDecoder();
 
-/** Read and parse a JSON request without permitting an unbounded policy preflight allocation. */
-export async function readBoundedJson(request: Request, maxBytes: number): Promise<unknown> {
+export interface BoundedJson {
+	value: unknown;
+	byteLength: number;
+	sha256: string;
+}
+
+/** Read, digest, and parse JSON without permitting an unbounded policy preflight allocation. */
+export async function readBoundedJson(request: Request, maxBytes: number): Promise<BoundedJson> {
 	const declaredLength = Number(request.headers.get("content-length"));
 	if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
 		throw new Error("Request JSON body exceeds gateway policy limit");
@@ -59,7 +65,11 @@ export async function readBoundedJson(request: Request, maxBytes: number): Promi
 			offset += chunk.byteLength;
 		}
 	}
-	return JSON.parse(JSON_DECODER.decode(bytes)) as unknown;
+	return {
+		value: JSON.parse(JSON_DECODER.decode(bytes)) as unknown,
+		byteLength: totalBytes,
+		sha256: createHash("sha256").update(bytes).digest("hex"),
+	};
 }
 
 /**
@@ -164,26 +174,6 @@ const PASSTHROUGH_HEADER_NAMES: Record<string, true> = {
 	"x-conversation-id": true,
 };
 
-/** Policy mode forwards only protocol feature/version headers with no identity semantics. */
-const POLICY_PASSTHROUGH_HEADER_NAMES: Record<string, true> = {
-	"anthropic-beta": true,
-	"anthropic-version": true,
-	"openai-beta": true,
-};
-
-/** Retain only explicitly safe protocol feature/version headers in policy mode. */
-export function stripPolicyIdentityHeaders(
-	headers: Readonly<Record<string, string>> | undefined,
-): Record<string, string> {
-	const out: Record<string, string> = {};
-	for (const [name, value] of Object.entries(headers ?? {})) {
-		const lower = name.toLowerCase();
-		if (!value || !POLICY_PASSTHROUGH_HEADER_NAMES[lower]) continue;
-		out[lower] = value;
-	}
-	return out;
-}
-
 /**
  * Extract allow-listed passthrough headers from an inbound request. Keys are
  * lowercased; empty values are dropped. Called once per request in
@@ -194,14 +184,11 @@ export function captureRequestHeaders(
 	options?: { stripPolicyIdentity?: boolean },
 ): Record<string, string> {
 	const out: Record<string, string> = {};
+	if (options?.stripPolicyIdentity) return out;
 	headers.forEach((value, key) => {
 		if (!value) return;
 		const lower = key.toLowerCase();
-		if (options?.stripPolicyIdentity) {
-			if (POLICY_PASSTHROUGH_HEADER_NAMES[lower]) out[lower] = value;
-			return;
-		}
-		if (PASSTHROUGH_HEADER_NAMES[lower] || lower.startsWith("x-stainless-")) out[lower] = value;
+		if (Object.hasOwn(PASSTHROUGH_HEADER_NAMES, lower) || lower.startsWith("x-stainless-")) out[lower] = value;
 	});
 	return out;
 }

--- a/packages/ai/src/auth-gateway/http.ts
+++ b/packages/ai/src/auth-gateway/http.ts
@@ -19,6 +19,49 @@ export function json(status: number, body: unknown, headers?: Record<string, str
 	});
 }
 
+const JSON_DECODER = new TextDecoder();
+
+/** Read and parse a JSON request without permitting an unbounded policy preflight allocation. */
+export async function readBoundedJson(request: Request, maxBytes: number): Promise<unknown> {
+	const declaredLength = Number(request.headers.get("content-length"));
+	if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+		throw new Error("Request JSON body exceeds gateway policy limit");
+	}
+	if (!request.body) throw new Error("Request JSON body is empty");
+
+	const reader = request.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let totalBytes = 0;
+	try {
+		for (;;) {
+			const chunk = await reader.read();
+			if (chunk.done) break;
+			totalBytes += chunk.value.byteLength;
+			if (totalBytes > maxBytes) {
+				try {
+					await reader.cancel();
+				} catch {
+					// The bounded rejection below is authoritative.
+				}
+				throw new Error("Request JSON body exceeds gateway policy limit");
+			}
+			chunks.push(chunk.value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const bytes = chunks.length === 1 ? chunks[0]! : new Uint8Array(totalBytes);
+	if (chunks.length !== 1) {
+		let offset = 0;
+		for (const chunk of chunks) {
+			bytes.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+	}
+	return JSON.parse(JSON_DECODER.decode(bytes)) as unknown;
+}
+
 /**
  * Diagnostic response headers for translated inference requests, mirroring the
  * names existing gateway-aware clients already parse: `x-request-id` /
@@ -121,19 +164,44 @@ const PASSTHROUGH_HEADER_NAMES: Record<string, true> = {
 	"x-conversation-id": true,
 };
 
+/** Policy mode forwards only protocol feature/version headers with no identity semantics. */
+const POLICY_PASSTHROUGH_HEADER_NAMES: Record<string, true> = {
+	"anthropic-beta": true,
+	"anthropic-version": true,
+	"openai-beta": true,
+};
+
+/** Retain only explicitly safe protocol feature/version headers in policy mode. */
+export function stripPolicyIdentityHeaders(
+	headers: Readonly<Record<string, string>> | undefined,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [name, value] of Object.entries(headers ?? {})) {
+		const lower = name.toLowerCase();
+		if (!value || !POLICY_PASSTHROUGH_HEADER_NAMES[lower]) continue;
+		out[lower] = value;
+	}
+	return out;
+}
+
 /**
  * Extract allow-listed passthrough headers from an inbound request. Keys are
  * lowercased; empty values are dropped. Called once per request in
  * `handleFormatEndpoint`; parsers then read `options.headers`.
  */
-export function captureRequestHeaders(headers: Headers): Record<string, string> {
+export function captureRequestHeaders(
+	headers: Headers,
+	options?: { stripPolicyIdentity?: boolean },
+): Record<string, string> {
 	const out: Record<string, string> = {};
 	headers.forEach((value, key) => {
 		if (!value) return;
 		const lower = key.toLowerCase();
-		if (PASSTHROUGH_HEADER_NAMES[lower] || lower.startsWith("x-stainless-")) {
-			out[lower] = value;
+		if (options?.stripPolicyIdentity) {
+			if (POLICY_PASSTHROUGH_HEADER_NAMES[lower]) out[lower] = value;
+			return;
 		}
+		if (PASSTHROUGH_HEADER_NAMES[lower] || lower.startsWith("x-stainless-")) out[lower] = value;
 	});
 	return out;
 }

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -30,8 +30,9 @@ import * as openaiChat from "../providers/openai-chat-server";
 import * as openaiResponses from "../providers/openai-responses-server";
 import * as piNative from "../providers/pi-native-server";
 import { completeSimple, streamSimple } from "../stream";
-import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "../types";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "../types";
 import { deterministicUuid } from "../utils/deterministic-id";
+import { AssistantMessageEventStream } from "../utils/event-stream";
 import { parseBind } from "../utils/parse-bind";
 import {
 	captureRequestHeaders,
@@ -39,16 +40,22 @@ import {
 	gatewayResponseHeaders,
 	isAuthorized,
 	json,
+	readBoundedJson,
 	resolvePeer,
+	stripPolicyIdentityHeaders,
 	withCors,
 } from "./http";
 import type {
+	AuthGatewayAuthorizationDecision,
+	AuthGatewayAuthorizationGrant,
+	AuthGatewayObservation,
+	AuthGatewayPolicyObservationBase,
 	AuthGatewayServerHandle,
 	AuthGatewayServerOptions,
 	AuthGatewayFormatModule as FormatModule,
 	AuthGatewayParsedRequest as ParsedFormatRequest,
 } from "./types";
-import { DEFAULT_AUTH_GATEWAY_BIND } from "./types";
+import { AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER, DEFAULT_AUTH_GATEWAY_BIND } from "./types";
 
 // ParsedFormatRequest / ParsedFormatOptions / FormatModule come from ./types.
 
@@ -75,6 +82,271 @@ const FORMAT_ROUTES: Record<string, { module: FormatModule; label: string }> = {
 	"/v1/messages": { module: anthropicMessages, label: "anthropic-messages" },
 	"/v1/responses": { module: openaiResponses, label: "openai-responses" },
 };
+
+const MAX_POLICY_MODEL_SELECTOR_LENGTH = 512;
+const MAX_POLICY_SESSION_ID_LENGTH = 1024;
+const MAX_POLICY_AUTHORIZATION_ID_LENGTH = 512;
+const MAX_POLICY_CREDENTIAL_IDS = 256;
+const MAX_POLICY_AUTHORIZATION_INPUT_LENGTH = 4096;
+const MAX_POLICY_REQUEST_BODY_BYTES = 64 * 1024 * 1024;
+
+const AUTHORIZATION_DENIAL_FIELDS: Record<string, true> = {
+	authorized: true,
+	reasonCode: true,
+};
+const AUTHORIZATION_GRANT_FIELDS: Record<string, true> = {
+	authorized: true,
+	authorizationId: true,
+	requestedModelId: true,
+	resolvedModelId: true,
+	sessionId: true,
+	allowedOAuthCredentialIds: true,
+};
+
+class AuthGatewayObserverDeliveryError extends Error {
+	constructor() {
+		super("Gateway observer is unavailable");
+		this.name = "AuthGatewayObserverDeliveryError";
+	}
+}
+
+interface GatewayPolicy {
+	requestId: string;
+	format: string;
+	authorizationId: string;
+	requestedModelId: string;
+	resolvedModelId: string;
+	sessionId: string;
+	allowedOAuthCredentialIds: ReadonlySet<number>;
+}
+
+type GatewayAuthorizationResult = { ok: true; policy?: GatewayPolicy } | { ok: false; response: Response };
+type GatewayFormatError = (status: number, type: string, message: string) => Response;
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBoundedPolicyText(value: unknown, maxLength: number): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value.length <= maxLength &&
+		value.trim() === value &&
+		!/\p{Cc}/u.test(value)
+	);
+}
+
+function hasOnlyDecisionFields(value: Record<string, unknown>, allowed: Record<string, true>): boolean {
+	return Object.keys(value).every(key => allowed[key]);
+}
+
+function validateAuthorizationGrant(
+	decision: unknown,
+	requestedModelId: string,
+): AuthGatewayAuthorizationGrant | undefined {
+	if (!isUnknownRecord(decision) || decision.authorized !== true) return undefined;
+	if (!hasOnlyDecisionFields(decision, AUTHORIZATION_GRANT_FIELDS)) return undefined;
+	if (
+		!isBoundedPolicyText(decision.authorizationId, MAX_POLICY_AUTHORIZATION_ID_LENGTH) ||
+		!isBoundedPolicyText(decision.requestedModelId, MAX_POLICY_MODEL_SELECTOR_LENGTH) ||
+		decision.requestedModelId !== requestedModelId ||
+		!isBoundedPolicyText(decision.resolvedModelId, MAX_POLICY_MODEL_SELECTOR_LENGTH) ||
+		!isBoundedPolicyText(decision.sessionId, MAX_POLICY_SESSION_ID_LENGTH)
+	) {
+		return undefined;
+	}
+	const namespaceSeparator = decision.sessionId.indexOf(":");
+	if (namespaceSeparator <= 0 || namespaceSeparator === decision.sessionId.length - 1) return undefined;
+	if (
+		!Array.isArray(decision.allowedOAuthCredentialIds) ||
+		decision.allowedOAuthCredentialIds.length === 0 ||
+		decision.allowedOAuthCredentialIds.length > MAX_POLICY_CREDENTIAL_IDS
+	) {
+		return undefined;
+	}
+	const seen = new Set<number>();
+	for (const credentialId of decision.allowedOAuthCredentialIds) {
+		if (!Number.isSafeInteger(credentialId) || credentialId <= 0 || seen.has(credentialId)) return undefined;
+		seen.add(credentialId);
+	}
+	return decision as unknown as AuthGatewayAuthorizationGrant;
+}
+
+function validateAuthorizationDenial(decision: unknown): { reasonCode?: string } | undefined {
+	if (!isUnknownRecord(decision) || decision.authorized !== false) return undefined;
+	if (!hasOnlyDecisionFields(decision, AUTHORIZATION_DENIAL_FIELDS)) return undefined;
+	if (decision.reasonCode === undefined) return {};
+	if (
+		typeof decision.reasonCode !== "string" ||
+		decision.reasonCode.length === 0 ||
+		decision.reasonCode.length > 128 ||
+		!/^[a-z0-9][a-z0-9._-]*$/i.test(decision.reasonCode)
+	) {
+		return undefined;
+	}
+	return { reasonCode: decision.reasonCode };
+}
+
+async function emitGatewayObservation(
+	bootOpts: AuthGatewayBootOptions,
+	observation: AuthGatewayObservation,
+): Promise<void> {
+	if (!bootOpts.observer) return;
+	try {
+		await bootOpts.observer(observation);
+	} catch {
+		throw new AuthGatewayObserverDeliveryError();
+	}
+}
+
+function policyObservationBase(policy: GatewayPolicy): AuthGatewayPolicyObservationBase {
+	return {
+		requestId: policy.requestId,
+		format: policy.format,
+		authorizationId: policy.authorizationId,
+		requestedModelId: policy.requestedModelId,
+		resolvedModelId: policy.resolvedModelId,
+		sessionId: policy.sessionId,
+	};
+}
+
+function observerFailureResponse(formatError: GatewayFormatError): Response {
+	return formatError(503, "authorization_error", "Gateway policy observer is unavailable");
+}
+
+async function authorizeGatewayRequest(
+	bootOpts: AuthGatewayBootOptions,
+	req: Request,
+	input: {
+		requestId: string;
+		format: string;
+		requestedModelId: string;
+		requestedSessionId?: string;
+	},
+	formatError: GatewayFormatError,
+): Promise<GatewayAuthorizationResult> {
+	const authorizer = bootOpts.authorizeRequest;
+	if (!authorizer) return { ok: true };
+	if (
+		!isBoundedPolicyText(input.requestedModelId, MAX_POLICY_MODEL_SELECTOR_LENGTH) ||
+		(input.requestedSessionId !== undefined &&
+			!isBoundedPolicyText(input.requestedSessionId, MAX_POLICY_SESSION_ID_LENGTH))
+	) {
+		return {
+			ok: false,
+			response: formatError(400, "invalid_request_error", "Policy request identifiers exceed gateway limits"),
+		};
+	}
+	const authorization = req.headers.get(AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER);
+	if (!isBoundedPolicyText(authorization, MAX_POLICY_AUTHORIZATION_INPUT_LENGTH)) {
+		return {
+			ok: false,
+			response: formatError(401, "authorization_error", "Missing or invalid gateway policy authorization"),
+		};
+	}
+
+	let decision: AuthGatewayAuthorizationDecision;
+	try {
+		decision = await authorizer({
+			requestId: input.requestId,
+			format: input.format,
+			requestedModelId: input.requestedModelId,
+			requestedSessionId: input.requestedSessionId,
+			method: req.method,
+			path: new URL(req.url).pathname,
+			authorization,
+			signal: req.signal,
+		});
+	} catch {
+		try {
+			await emitGatewayObservation(bootOpts, {
+				type: "authorization",
+				requestId: input.requestId,
+				format: input.format,
+				requestedModelId: input.requestedModelId,
+				outcome: "error",
+			});
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return { ok: false, response: observerFailureResponse(formatError) };
+			}
+			throw error;
+		}
+		return {
+			ok: false,
+			response: formatError(503, "authorization_error", "Gateway authorization policy is unavailable"),
+		};
+	}
+
+	const denial = validateAuthorizationDenial(decision);
+	if (denial) {
+		try {
+			await emitGatewayObservation(bootOpts, {
+				type: "authorization",
+				requestId: input.requestId,
+				format: input.format,
+				requestedModelId: input.requestedModelId,
+				outcome: "denied",
+				reasonCode: denial.reasonCode,
+			});
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return { ok: false, response: observerFailureResponse(formatError) };
+			}
+			throw error;
+		}
+		return {
+			ok: false,
+			response: formatError(403, "authorization_error", "Request denied by gateway policy"),
+		};
+	}
+
+	const grant = validateAuthorizationGrant(decision, input.requestedModelId);
+	if (!grant) {
+		try {
+			await emitGatewayObservation(bootOpts, {
+				type: "authorization",
+				requestId: input.requestId,
+				format: input.format,
+				requestedModelId: input.requestedModelId,
+				outcome: "error",
+			});
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return { ok: false, response: observerFailureResponse(formatError) };
+			}
+			throw error;
+		}
+		return {
+			ok: false,
+			response: formatError(500, "authorization_error", "Gateway authorization policy returned an invalid decision"),
+		};
+	}
+
+	const policy: GatewayPolicy = {
+		requestId: input.requestId,
+		format: input.format,
+		authorizationId: grant.authorizationId,
+		requestedModelId: grant.requestedModelId,
+		resolvedModelId: grant.resolvedModelId,
+		sessionId: grant.sessionId,
+		allowedOAuthCredentialIds: new Set(grant.allowedOAuthCredentialIds),
+	};
+	try {
+		await emitGatewayObservation(bootOpts, {
+			type: "authorization",
+			...policyObservationBase(policy),
+			outcome: "authorized",
+		});
+	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return { ok: false, response: observerFailureResponse(formatError) };
+		}
+		throw error;
+	}
+	return { ok: true, policy };
+}
 
 // (passthrough fast-path removed — it bypassed pi-ai provider logic, in
 // particular the Anthropic Claude-Code OAuth system-prompt prefix injection.
@@ -229,31 +501,85 @@ function buildStreamOptions(parsed: ParsedFormatRequest, api: Api, signal: Abort
  * failure with a fresh credential. Returning `undefined` aborts the retry
  * and surfaces the original error to the caller.
  */
+interface GatewayResolvedCredential {
+	apiKey: string;
+	credentialId?: number;
+}
+
 async function refreshGatewayApiKeyAfterAuthError(
-	storage: AuthStorage,
+	bootOpts: AuthGatewayBootOptions,
 	model: Model<Api>,
 	sessionId: string,
-	provider: string,
-	oldKey: string,
+	oldCredential: GatewayResolvedCredential,
 	error: unknown,
 	signal: AbortSignal,
 	format: string,
 	peer: string,
-): Promise<string | undefined> {
+	policy?: GatewayPolicy,
+): Promise<GatewayResolvedCredential | undefined> {
 	const message = error instanceof Error ? error.message : String(error);
 	const status = extractHttpStatusFromError(error);
-	if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
+	const usageLimit = AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message);
+	if (policy) {
+		if (oldCredential.credentialId === undefined) return undefined;
+		const switched = await bootOpts.storage.rotateSessionCredential(model.provider, sessionId, {
+			error,
+			modelId: model.id,
+			credentialId: oldCredential.credentialId,
+			signal,
+			allowedOAuthCredentialIds: policy.allowedOAuthCredentialIds,
+			redactOAuthErrors: true,
+		});
+		if (!switched) {
+			await emitGatewayObservation(bootOpts, {
+				type: "error",
+				...policyObservationBase(policy),
+				stage: "credential_selection",
+				code: "credential_rotation_unavailable",
+			});
+			return undefined;
+		}
+		const access = await bootOpts.storage.getOAuthApiKeyFromCredentialIds(
+			model.provider,
+			sessionId,
+			policy.allowedOAuthCredentialIds,
+			{ modelId: model.id, signal },
+		);
+		if (
+			!access ||
+			access.credentialId === oldCredential.credentialId ||
+			!policy.allowedOAuthCredentialIds.has(access.credentialId)
+		) {
+			await emitGatewayObservation(bootOpts, {
+				type: "error",
+				...policyObservationBase(policy),
+				stage: "credential_selection",
+				code: "credential_rotation_unavailable",
+			});
+			return undefined;
+		}
+		await emitGatewayObservation(bootOpts, {
+			type: "credential_rotation",
+			...policyObservationBase(policy),
+			previousCredentialId: oldCredential.credentialId,
+			credentialId: access.credentialId,
+			reason: usageLimit ? "usage_limit" : "authentication_failure",
+		});
+		return access;
+	}
+
+	if (usageLimit) {
 		const retryAfterMs = extractRetryHint(undefined, message);
-		const { switched, retryAtMs } = await storage.markUsageLimitReached(provider, sessionId, {
+		const { switched, retryAtMs } = await bootOpts.storage.markUsageLimitReached(model.provider, sessionId, {
 			retryAfterMs,
 			baseUrl: model.baseUrl,
 			modelId: model.id,
-			apiKey: oldKey,
+			apiKey: oldCredential.apiKey,
 			signal,
 		});
 		logger.debug("auth-gateway retrying provider request after usage-limit block", {
 			format,
-			provider,
+			provider: model.provider,
 			peer,
 			switched,
 			retryAfterMs,
@@ -261,16 +587,18 @@ async function refreshGatewayApiKeyAfterAuthError(
 			error: message,
 		});
 		if (!switched) return undefined;
-		return storage.getApiKey(provider, sessionId, { modelId: model.id, signal });
+		const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, { modelId: model.id, signal });
+		return apiKey ? { apiKey } : undefined;
 	}
-	await storage.invalidateCredentialMatching(provider, oldKey, { sessionId, signal });
+	await bootOpts.storage.invalidateCredentialMatching(model.provider, oldCredential.apiKey, { sessionId, signal });
 	logger.debug("auth-gateway retrying provider request after credential invalidation", {
 		format,
-		provider,
+		provider: model.provider,
 		peer,
 		error: message,
 	});
-	return storage.getApiKey(provider, sessionId, { modelId: model.id, signal });
+	const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, { modelId: model.id, signal });
+	return apiKey ? { apiKey } : undefined;
 }
 
 /**
@@ -287,43 +615,70 @@ async function refreshGatewayApiKeyAfterAuthError(
  * credential that actually failed.
  */
 function buildGatewayApiKeyResolver(
-	storage: AuthStorage,
+	bootOpts: AuthGatewayBootOptions,
 	model: Model<Api>,
 	sessionId: string,
-	initialKey: string,
+	initialCredential: GatewayResolvedCredential,
 	requestSignal: AbortSignal,
 	format: string,
 	peer: string,
+	policy?: GatewayPolicy,
 ): ApiKeyResolver {
-	let lastKey = initialKey;
+	let currentCredential = initialCredential;
 	return async ({ lastChance, error, signal }) => {
 		const sig = signal ?? requestSignal;
 		if (error === undefined) {
-			lastKey = initialKey;
-			return initialKey;
+			currentCredential = initialCredential;
+			return initialCredential.apiKey;
 		}
 		if (!lastChance) {
-			const refreshed = await storage.getApiKey(model.provider, sessionId, {
+			if (policy) {
+				const credentialId = currentCredential.credentialId;
+				if (credentialId === undefined || !policy.allowedOAuthCredentialIds.has(credentialId)) return undefined;
+				const resolved = await bootOpts.storage.getOAuthApiKeyByCredentialId(model.provider, credentialId, {
+					modelId: model.id,
+					signal: sig,
+					forceRefresh: true,
+				});
+				if (!resolved || !policy.allowedOAuthCredentialIds.has(resolved.credentialId)) {
+					await emitGatewayObservation(bootOpts, {
+						type: "error",
+						...policyObservationBase(policy),
+						stage: "credential_selection",
+						code: "credential_rotation_unavailable",
+					});
+					return undefined;
+				}
+				currentCredential = resolved;
+				await emitGatewayObservation(bootOpts, {
+					type: "credential_selection",
+					...policyObservationBase(policy),
+					credentialId: resolved.credentialId,
+					phase: "force_refresh",
+				});
+				return resolved.apiKey;
+			}
+			const refreshed = await bootOpts.storage.getApiKey(model.provider, sessionId, {
 				modelId: model.id,
 				signal: sig,
 				forceRefresh: true,
 			});
-			lastKey = refreshed ?? lastKey;
+			if (refreshed) currentCredential = { apiKey: refreshed };
 			return refreshed;
 		}
 		const next = await refreshGatewayApiKeyAfterAuthError(
-			storage,
+			bootOpts,
 			model,
 			sessionId,
-			model.provider,
-			lastKey,
+			currentCredential,
 			error,
 			sig,
 			format,
 			peer,
+			policy,
 		);
-		lastKey = next ?? lastKey;
-		return next;
+		if (next) currentCredential = next;
+		return next?.apiKey;
 	};
 }
 
@@ -341,6 +696,108 @@ function mirrorRequestAbort(req: Request): AbortController {
 	return controller;
 }
 
+async function observePolicyFailure(
+	bootOpts: AuthGatewayBootOptions,
+	policy: GatewayPolicy,
+	stage: "model_resolution" | "credential_selection" | "upstream",
+	code:
+		| "model_unavailable"
+		| "credential_unavailable"
+		| "credential_rotation_unavailable"
+		| "request_aborted"
+		| "upstream_error",
+	outcome: "error" | "aborted" = "error",
+): Promise<void> {
+	await emitGatewayObservation(bootOpts, {
+		type: "error",
+		...policyObservationBase(policy),
+		stage,
+		code,
+	});
+	await emitGatewayObservation(bootOpts, {
+		type: "terminal",
+		...policyObservationBase(policy),
+		outcome,
+	});
+}
+
+function genericPolicyErrorMessage(message: AssistantMessage, reason: "error" | "aborted"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: message.api,
+		provider: message.provider,
+		model: message.model,
+		timestamp: message.timestamp,
+		usage: message.usage,
+		stopReason: reason,
+		errorMessage: reason === "aborted" ? "Request was aborted" : "Upstream request failed",
+		errorStatus: message.errorStatus,
+		errorId: message.errorId,
+	};
+}
+
+function withPolicyEventObservations(
+	events: AssistantMessageEventStream,
+	bootOpts: AuthGatewayBootOptions,
+	policy: GatewayPolicy,
+): AssistantMessageEventStream {
+	const observed = new AssistantMessageEventStream();
+	const pump = async (): Promise<void> => {
+		let terminal = false;
+		try {
+			for await (const event of events) {
+				if (event.type === "done") {
+					await emitGatewayObservation(bootOpts, {
+						type: "terminal",
+						...policyObservationBase(policy),
+						outcome: "success",
+					});
+					terminal = true;
+					observed.push(event);
+					return;
+				}
+				if (event.type === "error") {
+					const outcome = event.reason === "aborted" ? "aborted" : "error";
+					await observePolicyFailure(
+						bootOpts,
+						policy,
+						"upstream",
+						outcome === "aborted" ? "request_aborted" : "upstream_error",
+						outcome,
+					);
+					terminal = true;
+					observed.push({
+						type: "error",
+						reason: event.reason,
+						error: genericPolicyErrorMessage(event.error, event.reason),
+					});
+					return;
+				}
+				observed.push(event);
+			}
+			if (!terminal) {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				observed.fail(new Error("Gateway upstream stream failed"));
+			}
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				observed.fail(error);
+				return;
+			}
+			try {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+			} catch (observationError) {
+				observed.fail(observationError);
+				return;
+			}
+			observed.fail(new Error("Gateway upstream stream failed"));
+		}
+	};
+	void pump();
+	return observed;
+}
+
 // (handlePassthrough removed — see note above.)
 
 async function handleFormatEndpoint(
@@ -356,10 +813,11 @@ async function handleFormatEndpoint(
 
 	let body: unknown;
 	try {
-		body = await req.json();
+		body = bootOpts.authorizeRequest ? await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES) : await req.json();
 	} catch (error) {
 		if (controller.signal.aborted) return clientClosedResponse(route);
-		return route.module.formatError(400, "invalid_request_error", `Invalid JSON body: ${String(error)}`);
+		const message = bootOpts.authorizeRequest ? "Invalid JSON request body" : `Invalid JSON body: ${String(error)}`;
+		return route.module.formatError(400, "invalid_request_error", message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
 
@@ -374,11 +832,6 @@ async function handleFormatEndpoint(
 		return route.module.formatError(400, "invalid_request_error", "Missing top-level `model` field");
 	}
 
-	const model = bootOpts.resolveModel(modelId);
-	if (!model) {
-		return route.module.formatError(404, "invalid_request_error", `Unknown model: ${modelId}`);
-	}
-
 	// Parse the wire-format request BEFORE resolving the credential so we
 	// have a stable per-conversation `sessionId` to thread into AuthStorage.
 	// Sticky-credential tracking and `markUsageLimitReached` both key off
@@ -390,44 +843,121 @@ async function handleFormatEndpoint(
 		parsed = route.module.parseRequest(body, req.headers);
 	} catch (error) {
 		if (controller.signal.aborted) return clientClosedResponse(route);
-		const message = error instanceof Error ? error.message : String(error);
+		const message = bootOpts.authorizeRequest
+			? "Invalid provider-format request body"
+			: error instanceof Error
+				? error.message
+				: String(error);
 		return route.module.formatError(400, "invalid_request_error", message);
 	}
-	// Merge gateway-captured passthrough headers under the parser's own
-	// captures. Parsers that set `options.headers` themselves win (they may
-	// have stripped or normalized values); the gateway's allow-list fills in
-	// anything they didn't touch.
-	{
-		const captured = captureRequestHeaders(req.headers);
-		parsed.options.headers = { ...captured, ...(parsed.options.headers ?? {}) };
+	const authorization = await authorizeGatewayRequest(
+		bootOpts,
+		req,
+		{
+			requestId,
+			format: route.label,
+			requestedModelId: parsed.modelId,
+			requestedSessionId: parsed.options.promptCacheKey,
+		},
+		route.module.formatError,
+	);
+	if (!authorization.ok) return authorization.response;
+	const policy = authorization.policy;
+
+	const resolvedModelId = policy?.resolvedModelId ?? parsed.modelId;
+	const model = bootOpts.resolveModel(resolvedModelId);
+	if (!model) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "model_resolution", "model_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw error;
+			}
+			return route.module.formatError(404, "invalid_request_error", "Authorized model is unavailable");
+		}
+		return route.module.formatError(404, "invalid_request_error", `Unknown model: ${parsed.modelId}`);
+	}
+
+	// In policy mode parser-captured account, organization, project, client,
+	// and credential headers are discarded before provider options are built.
+	const captured = captureRequestHeaders(req.headers, { stripPolicyIdentity: policy !== undefined });
+	const parsedHeaders = policy ? stripPolicyIdentityHeaders(parsed.options.headers) : (parsed.options.headers ?? {});
+	parsed.options.headers = { ...captured, ...parsedHeaders };
+
+	const sessionId =
+		policy?.sessionId ?? parsed.options.promptCacheKey ?? deriveSessionId(parsed.modelId, parsed.context);
+	if (policy) {
+		parsed.options.promptCacheKey = sessionId;
+		delete parsed.options.user;
+		delete parsed.options.metadata;
+		delete parsed.options.previousResponseId;
+		delete parsed.options.extra;
+	} else {
+		parsed.options.promptCacheKey ??= sessionId;
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
 
-	// Sticky credential id: honour the client's `prompt_cache_key` when
-	// supplied (so external session ids align), otherwise derive from
-	// modelId + system + tools + first message. Mirrored into
-	// streamOpts.sessionId / promptCacheKey by `buildStreamOptions`.
-	const sessionId = parsed.options.promptCacheKey ?? deriveSessionId(parsed.modelId, parsed.context);
-	parsed.options.promptCacheKey ??= sessionId;
-
-	// pi-ai's stream() does NOT consult AuthStorage — the caller (us) is
-	// expected to resolve the credential and pass it as `options.apiKey`.
-	// For OAuth providers this returns the access token (refreshed via the
-	// broker override on AuthStorage when needed).
-	let apiKey: string | undefined;
+	let credential: GatewayResolvedCredential | undefined;
 	try {
-		apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
-			modelId: model.id,
-			signal: controller.signal,
-		});
+		if (policy) {
+			const access = await bootOpts.storage.getOAuthApiKeyFromCredentialIds(
+				model.provider,
+				sessionId,
+				policy.allowedOAuthCredentialIds,
+				{ modelId: model.id, signal: controller.signal },
+			);
+			if (access && policy.allowedOAuthCredentialIds.has(access.credentialId)) {
+				credential = access;
+				await emitGatewayObservation(bootOpts, {
+					type: "credential_selection",
+					...policyObservationBase(policy),
+					credentialId: access.credentialId,
+					phase: "initial",
+				});
+			}
+		} else {
+			const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
+				modelId: model.id,
+				signal: controller.signal,
+			});
+			if (apiKey) credential = { apiKey };
+		}
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(route.module.formatError);
+		}
 		if (controller.signal.aborted) return clientClosedResponse(route);
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw observationError;
+			}
+			return route.module.formatError(503, "authentication_error", "Authorized OAuth credential selection failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway getApiKey threw", { provider: model.provider, peer, error: classified.message });
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
-	if (!apiKey) {
+	if (!credential) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw error;
+			}
+			return route.module.formatError(401, "authentication_error", "No authorized OAuth credential is available");
+		}
 		return route.module.formatError(
 			401,
 			"authentication_error",
@@ -437,13 +967,14 @@ async function handleFormatEndpoint(
 
 	const streamOpts = buildStreamOptions(parsed, model.api, controller.signal);
 	streamOpts.apiKey = buildGatewayApiKeyResolver(
-		bootOpts.storage,
+		bootOpts,
 		model,
 		sessionId,
-		apiKey,
+		credential,
 		controller.signal,
 		route.label,
 		peer,
+		policy,
 	);
 
 	logger.info("auth-gateway request", {
@@ -458,12 +989,29 @@ async function handleFormatEndpoint(
 
 	if (!parsed.stream) {
 		try {
-			if (controller.signal.aborted) return clientClosedResponse(route);
+			if (controller.signal.aborted) {
+				if (policy) await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+				return clientClosedResponse(route);
+			}
 			const message = await completeSimple(model, parsed.context, streamOpts);
 			if (message.stopReason === "aborted" || message.stopReason === "error") {
 				const errorMessage =
 					message.errorMessage ??
 					(message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed");
+				if (policy) {
+					await observePolicyFailure(
+						bootOpts,
+						policy,
+						"upstream",
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "aborted" : "error",
+					);
+					return route.module.formatError(
+						message.stopReason === "aborted" ? 499 : 502,
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed",
+					);
+				}
 				logger.warn("auth-gateway non-streaming failed", {
 					format: route.label,
 					reason: message.stopReason,
@@ -476,13 +1024,46 @@ async function handleFormatEndpoint(
 				const classified = classifyGatewayError(errorMessage);
 				return route.module.formatError(classified.status, classified.type, errorMessage);
 			}
+			if (policy) {
+				await emitGatewayObservation(bootOpts, {
+					type: "terminal",
+					...policyObservationBase(policy),
+					outcome: "success",
+				});
+			}
 			return json(
 				200,
 				route.module.encodeResponse(message, parsed.modelId),
 				gatewayResponseHeaders(model, { requestId, message, startedAt }),
 			);
 		} catch (error) {
-			if (controller.signal.aborted) return clientClosedResponse(route);
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return observerFailureResponse(route.module.formatError);
+			}
+			if (controller.signal.aborted) {
+				if (policy) {
+					try {
+						await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+					} catch (observationError) {
+						if (observationError instanceof AuthGatewayObserverDeliveryError) {
+							return observerFailureResponse(route.module.formatError);
+						}
+						throw observationError;
+					}
+				}
+				return clientClosedResponse(route);
+			}
+			if (policy) {
+				try {
+					await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				} catch (observationError) {
+					if (observationError instanceof AuthGatewayObserverDeliveryError) {
+						return observerFailureResponse(route.module.formatError);
+					}
+					throw observationError;
+				}
+				return route.module.formatError(502, "upstream_error", "Upstream request failed");
+			}
 			const classified = classifyGatewayError(error);
 			logger.warn("auth-gateway non-streaming aborted", {
 				format: route.label,
@@ -498,12 +1079,27 @@ async function handleFormatEndpoint(
 		if (controller.signal.aborted) return clientClosedResponse(route);
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(route.module.formatError);
+		}
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(route.module.formatError);
+				}
+				throw observationError;
+			}
+			return route.module.formatError(502, "upstream_error", "Upstream request failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway streamSimple threw", { format: route.label, error: classified.message, peer });
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
 
+	if (policy) events = withPolicyEventObservations(events, bootOpts, policy);
 	const sseStream = route.module.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
 		onCancel: reason => {
@@ -550,10 +1146,11 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	let body: unknown;
 	try {
-		body = await req.json();
+		body = bootOpts.authorizeRequest ? await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES) : await req.json();
 	} catch (error) {
 		if (controller.signal.aborted) return aborted();
-		return piNative.formatError(400, "invalid_request_error", `Invalid JSON body: ${String(error)}`);
+		const message = bootOpts.authorizeRequest ? "Invalid JSON request body" : `Invalid JSON body: ${String(error)}`;
+		return piNative.formatError(400, "invalid_request_error", message);
 	}
 	if (controller.signal.aborted) return aborted();
 
@@ -562,36 +1159,121 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		parsed = piNative.parseRequest(body, req.headers);
 	} catch (error) {
 		if (controller.signal.aborted) return aborted();
-		const message = error instanceof Error ? error.message : String(error);
+		const message = bootOpts.authorizeRequest
+			? "Invalid pi-native request body"
+			: error instanceof Error
+				? error.message
+				: String(error);
 		return piNative.formatError(400, "invalid_request_error", message);
 	}
 
-	const model = bootOpts.resolveModel(parsed.modelId);
+	const authorization = await authorizeGatewayRequest(
+		bootOpts,
+		req,
+		{
+			requestId,
+			format: "pi-native",
+			requestedModelId: parsed.modelId,
+			requestedSessionId: parsed.options.sessionId ?? parsed.options.promptCacheKey,
+		},
+		piNative.formatError,
+	);
+	if (!authorization.ok) return authorization.response;
+	const policy = authorization.policy;
+
+	const resolvedModelId = policy?.resolvedModelId ?? parsed.modelId;
+	const model = bootOpts.resolveModel(resolvedModelId);
 	if (!model) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "model_resolution", "model_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw error;
+			}
+			return piNative.formatError(404, "invalid_request_error", "Authorized model is unavailable");
+		}
 		return piNative.formatError(404, "invalid_request_error", `Unknown model: ${parsed.modelId}`);
 	}
-	// Pi-native already parsed `streamOpts.sessionId` (when set by the
-	// client); fall back to the derived key so credential-stickiness lines
-	// up with cache-prefix stickiness — same identity used for both means
-	// the next turn of this conversation reuses the same credential until
-	// it hits a usage cap, then markUsageLimitReached can hand off.
-	const sessionId = parsed.options.sessionId ?? deriveSessionId(parsed.modelId, parsed.context);
-	parsed.options.sessionId ??= sessionId;
 
-	let apiKey: string | undefined;
+	const sessionId =
+		policy?.sessionId ??
+		parsed.options.sessionId ??
+		parsed.options.promptCacheKey ??
+		deriveSessionId(parsed.modelId, parsed.context);
+	if (policy) {
+		parsed.options.sessionId = sessionId;
+		parsed.options.promptCacheKey = sessionId;
+		parsed.options.headers = stripPolicyIdentityHeaders(parsed.options.headers);
+		delete parsed.options.metadata;
+		delete parsed.options.initiatorOverride;
+		delete parsed.options.cachedContent;
+		delete parsed.options.openrouterVariant;
+		delete parsed.options.statefulResponses;
+	} else {
+		parsed.options.sessionId ??= sessionId;
+	}
+
+	let credential: GatewayResolvedCredential | undefined;
 	try {
-		apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
-			modelId: model.id,
-			signal: controller.signal,
-		});
+		if (policy) {
+			const access = await bootOpts.storage.getOAuthApiKeyFromCredentialIds(
+				model.provider,
+				sessionId,
+				policy.allowedOAuthCredentialIds,
+				{ modelId: model.id, signal: controller.signal },
+			);
+			if (access && policy.allowedOAuthCredentialIds.has(access.credentialId)) {
+				credential = access;
+				await emitGatewayObservation(bootOpts, {
+					type: "credential_selection",
+					...policyObservationBase(policy),
+					credentialId: access.credentialId,
+					phase: "initial",
+				});
+			}
+		} else {
+			const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
+				modelId: model.id,
+				signal: controller.signal,
+			});
+			if (apiKey) credential = { apiKey };
+		}
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(piNative.formatError);
+		}
 		if (controller.signal.aborted) return aborted();
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw observationError;
+			}
+			return piNative.formatError(503, "authentication_error", "Authorized OAuth credential selection failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway getApiKey threw", { provider: model.provider, peer, error: classified.message });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return aborted();
-	if (!apiKey) {
+	if (!credential) {
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+			} catch (error) {
+				if (error instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw error;
+			}
+			return piNative.formatError(401, "authentication_error", "No authorized OAuth credential is available");
+		}
 		return piNative.formatError(
 			401,
 			"authentication_error",
@@ -603,15 +1285,16 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	// trust the client's options (already allow-listed by `parseRequest`) and
 	// only inject server-controlled fields. The codex sampling strip mirrors
 	// `buildStreamOptions` — Codex rejects every one with a 400 (#3117).
-	const streamOpts: SimpleStreamOptions = { ...parsed.options, apiKey, signal: controller.signal };
+	const streamOpts: SimpleStreamOptions = { ...parsed.options, signal: controller.signal };
 	streamOpts.apiKey = buildGatewayApiKeyResolver(
-		bootOpts.storage,
+		bootOpts,
 		model,
 		sessionId,
-		apiKey,
+		credential,
 		controller.signal,
 		"pi-native",
 		peer,
+		policy,
 	);
 	if (model.api === "openai-codex-responses") {
 		delete streamOpts.temperature;
@@ -624,10 +1307,17 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		delete streamOpts.repetitionPenalty;
 	}
 	// Merge gateway-captured passthrough headers under the client's own
-	// headers — the client's values win when they collide.
-	const captured = captureRequestHeaders(req.headers);
-	streamOpts.headers = { ...captured, ...(streamOpts.headers ?? {}) };
-	streamOpts.sessionId ??= sessionId;
+	// headers. Policy mode strips caller-controlled identity and auth values
+	// from both sources, and the authorized session always wins.
+	const captured = captureRequestHeaders(req.headers, { stripPolicyIdentity: policy !== undefined });
+	const optionHeaders = policy ? stripPolicyIdentityHeaders(streamOpts.headers) : (streamOpts.headers ?? {});
+	streamOpts.headers = { ...captured, ...optionHeaders };
+	if (policy) {
+		streamOpts.sessionId = sessionId;
+		streamOpts.promptCacheKey = sessionId;
+	} else {
+		streamOpts.sessionId ??= sessionId;
+	}
 
 	logger.info("auth-gateway request", {
 		requestId,
@@ -641,12 +1331,29 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	if (!parsed.stream) {
 		try {
-			if (controller.signal.aborted) return aborted();
+			if (controller.signal.aborted) {
+				if (policy) await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+				return aborted();
+			}
 			const message = await completeSimple(model, parsed.context, streamOpts);
 			if (message.stopReason === "aborted" || message.stopReason === "error") {
 				const errorMessage =
 					message.errorMessage ??
 					(message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed");
+				if (policy) {
+					await observePolicyFailure(
+						bootOpts,
+						policy,
+						"upstream",
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "aborted" : "error",
+					);
+					return piNative.formatError(
+						message.stopReason === "aborted" ? 499 : 502,
+						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
+						message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed",
+					);
+				}
 				logger.warn("auth-gateway non-streaming failed", {
 					format: "pi-native",
 					reason: message.stopReason,
@@ -659,9 +1366,42 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 				const classified = classifyGatewayError(errorMessage);
 				return piNative.formatError(classified.status, classified.type, errorMessage);
 			}
+			if (policy) {
+				await emitGatewayObservation(bootOpts, {
+					type: "terminal",
+					...policyObservationBase(policy),
+					outcome: "success",
+				});
+			}
 			return json(200, { message }, gatewayResponseHeaders(model, { requestId, message, startedAt }));
 		} catch (error) {
-			if (controller.signal.aborted) return aborted();
+			if (error instanceof AuthGatewayObserverDeliveryError) {
+				return observerFailureResponse(piNative.formatError);
+			}
+			if (controller.signal.aborted) {
+				if (policy) {
+					try {
+						await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
+					} catch (observationError) {
+						if (observationError instanceof AuthGatewayObserverDeliveryError) {
+							return observerFailureResponse(piNative.formatError);
+						}
+						throw observationError;
+					}
+				}
+				return aborted();
+			}
+			if (policy) {
+				try {
+					await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				} catch (observationError) {
+					if (observationError instanceof AuthGatewayObserverDeliveryError) {
+						return observerFailureResponse(piNative.formatError);
+					}
+					throw observationError;
+				}
+				return piNative.formatError(502, "upstream_error", "Upstream request failed");
+			}
 			const classified = classifyGatewayError(error);
 			logger.warn("auth-gateway non-streaming aborted", { format: "pi-native", error: classified.message, peer });
 			return piNative.formatError(classified.status, classified.type, classified.message);
@@ -673,12 +1413,27 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		if (controller.signal.aborted) return aborted();
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
+		if (error instanceof AuthGatewayObserverDeliveryError) {
+			return observerFailureResponse(piNative.formatError);
+		}
+		if (policy) {
+			try {
+				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+			} catch (observationError) {
+				if (observationError instanceof AuthGatewayObserverDeliveryError) {
+					return observerFailureResponse(piNative.formatError);
+				}
+				throw observationError;
+			}
+			return piNative.formatError(502, "upstream_error", "Upstream request failed");
+		}
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway streamSimple threw", { format: "pi-native", error: classified.message, peer });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return aborted();
 
+	if (policy) events = withPolicyEventObservations(events, bootOpts, policy);
 	const sseStream = piNative.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
 		onCancel: reason => {
@@ -778,6 +1533,9 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 				// Same shape as the broker's `/v1/usage`, so widget/llm-git speak to either with the
 				// same client struct.
 				if (req.method === "GET" && pathname === "/v1/usage") {
+					if (opts.authorizeRequest) {
+						return withCors(json(403, { error: "route unavailable in gateway policy mode" }), req);
+					}
 					return withCors(await handleUsage(opts.storage, req.signal), req);
 				}
 
@@ -785,6 +1543,9 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 				// pool is producing 401s. Aggregated `/v1/usage` silently drops failed
 				// credentials, so we need a separate endpoint that captures errors.
 				if (req.method === "GET" && pathname === "/v1/credentials/check") {
+					if (opts.authorizeRequest) {
+						return withCors(json(403, { error: "route unavailable in gateway policy mode" }), req);
+					}
 					return withCors(await handleCredentialsCheck(opts.storage, req.signal), req);
 				}
 

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -42,7 +42,6 @@ import {
 	json,
 	readBoundedJson,
 	resolvePeer,
-	stripPolicyIdentityHeaders,
 	withCors,
 } from "./http";
 import type {
@@ -138,7 +137,7 @@ function isBoundedPolicyText(value: unknown, maxLength: number): value is string
 }
 
 function hasOnlyDecisionFields(value: Record<string, unknown>, allowed: Record<string, true>): boolean {
-	return Object.keys(value).every(key => allowed[key]);
+	return Object.keys(value).every(key => Object.hasOwn(allowed, key));
 }
 
 function validateAuthorizationGrant(
@@ -215,6 +214,74 @@ function observerFailureResponse(formatError: GatewayFormatError): Response {
 	return formatError(503, "authorization_error", "Gateway policy observer is unavailable");
 }
 
+class GatewayPolicyRequest {
+	#terminal = false;
+	#observerError: AuthGatewayObserverDeliveryError | undefined;
+	readonly #bootOpts: AuthGatewayBootOptions;
+
+	constructor(
+		readonly policy: GatewayPolicy,
+		bootOpts: AuthGatewayBootOptions,
+	) {
+		this.#bootOpts = bootOpts;
+	}
+
+	get observerError(): AuthGatewayObserverDeliveryError | undefined {
+		return this.#observerError;
+	}
+
+	async observe(observation: AuthGatewayObservation): Promise<void> {
+		if (this.#observerError) throw this.#observerError;
+		try {
+			await emitGatewayObservation(this.#bootOpts, observation);
+		} catch (error) {
+			if (error instanceof AuthGatewayObserverDeliveryError) this.#observerError = error;
+			throw error;
+		}
+	}
+
+	async fail(
+		stage: "model_resolution" | "credential_selection" | "upstream",
+		code: "model_unavailable" | "credential_unavailable" | "credential_rotation_unavailable" | "upstream_error",
+	): Promise<void> {
+		if (this.#terminal) return;
+		await this.observe({
+			type: "error",
+			...policyObservationBase(this.policy),
+			stage,
+			code,
+		});
+		await this.#settle("error", false);
+	}
+
+	async settleAbortedBestEffort(): Promise<void> {
+		await this.#settle("aborted", true);
+	}
+
+	async settleSuccessBestEffort(): Promise<void> {
+		await this.#settle("success", true);
+	}
+
+	async #settle(outcome: "success" | "error" | "aborted", bestEffort: boolean): Promise<void> {
+		if (this.#terminal) return;
+		this.#terminal = true;
+		try {
+			await this.observe({
+				type: "terminal",
+				...policyObservationBase(this.policy),
+				outcome,
+			});
+		} catch (error) {
+			if (!bestEffort || !(error instanceof AuthGatewayObserverDeliveryError)) throw error;
+			logger.warn("auth-gateway policy terminal observation failed after request completion", {
+				requestId: this.policy.requestId,
+				format: this.policy.format,
+				outcome,
+			});
+		}
+	}
+}
+
 async function authorizeGatewayRequest(
 	bootOpts: AuthGatewayBootOptions,
 	req: Request,
@@ -223,6 +290,8 @@ async function authorizeGatewayRequest(
 		format: string;
 		requestedModelId: string;
 		requestedSessionId?: string;
+		payloadByteLength: number;
+		payloadSha256: string;
 	},
 	formatError: GatewayFormatError,
 ): Promise<GatewayAuthorizationResult> {
@@ -253,26 +322,14 @@ async function authorizeGatewayRequest(
 			format: input.format,
 			requestedModelId: input.requestedModelId,
 			requestedSessionId: input.requestedSessionId,
+			payloadByteLength: input.payloadByteLength,
+			payloadSha256: input.payloadSha256,
 			method: req.method,
 			path: new URL(req.url).pathname,
 			authorization,
 			signal: req.signal,
 		});
 	} catch {
-		try {
-			await emitGatewayObservation(bootOpts, {
-				type: "authorization",
-				requestId: input.requestId,
-				format: input.format,
-				requestedModelId: input.requestedModelId,
-				outcome: "error",
-			});
-		} catch (error) {
-			if (error instanceof AuthGatewayObserverDeliveryError) {
-				return { ok: false, response: observerFailureResponse(formatError) };
-			}
-			throw error;
-		}
 		return {
 			ok: false,
 			response: formatError(503, "authorization_error", "Gateway authorization policy is unavailable"),
@@ -515,13 +572,17 @@ async function refreshGatewayApiKeyAfterAuthError(
 	signal: AbortSignal,
 	format: string,
 	peer: string,
-	policy?: GatewayPolicy,
+	policyRequest?: GatewayPolicyRequest,
 ): Promise<GatewayResolvedCredential | undefined> {
 	const message = error instanceof Error ? error.message : String(error);
 	const status = extractHttpStatusFromError(error);
 	const usageLimit = AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message);
-	if (policy) {
+	const policy = policyRequest?.policy;
+	if (policyRequest && policy) {
 		if (oldCredential.credentialId === undefined) return undefined;
+		// AuthStorage must apply the provider error before it can identify the
+		// actual next eligible row. Any later observer rejection is latched on
+		// this request, so the retry cannot turn that mutation into a success.
 		const switched = await bootOpts.storage.rotateSessionCredential(model.provider, sessionId, {
 			error,
 			modelId: model.id,
@@ -531,7 +592,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 			redactOAuthErrors: true,
 		});
 		if (!switched) {
-			await emitGatewayObservation(bootOpts, {
+			await policyRequest.observe({
 				type: "error",
 				...policyObservationBase(policy),
 				stage: "credential_selection",
@@ -550,7 +611,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 			access.credentialId === oldCredential.credentialId ||
 			!policy.allowedOAuthCredentialIds.has(access.credentialId)
 		) {
-			await emitGatewayObservation(bootOpts, {
+			await policyRequest.observe({
 				type: "error",
 				...policyObservationBase(policy),
 				stage: "credential_selection",
@@ -558,7 +619,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 			});
 			return undefined;
 		}
-		await emitGatewayObservation(bootOpts, {
+		await policyRequest.observe({
 			type: "credential_rotation",
 			...policyObservationBase(policy),
 			previousCredentialId: oldCredential.credentialId,
@@ -622,17 +683,19 @@ function buildGatewayApiKeyResolver(
 	requestSignal: AbortSignal,
 	format: string,
 	peer: string,
-	policy?: GatewayPolicy,
+	policyRequest?: GatewayPolicyRequest,
 ): ApiKeyResolver {
+	const policy = policyRequest?.policy;
 	let currentCredential = initialCredential;
 	return async ({ lastChance, error, signal }) => {
+		if (policyRequest?.observerError) throw policyRequest.observerError;
 		const sig = signal ?? requestSignal;
 		if (error === undefined) {
 			currentCredential = initialCredential;
 			return initialCredential.apiKey;
 		}
 		if (!lastChance) {
-			if (policy) {
+			if (policyRequest && policy) {
 				const credentialId = currentCredential.credentialId;
 				if (credentialId === undefined || !policy.allowedOAuthCredentialIds.has(credentialId)) return undefined;
 				const resolved = await bootOpts.storage.getOAuthApiKeyByCredentialId(model.provider, credentialId, {
@@ -641,7 +704,7 @@ function buildGatewayApiKeyResolver(
 					forceRefresh: true,
 				});
 				if (!resolved || !policy.allowedOAuthCredentialIds.has(resolved.credentialId)) {
-					await emitGatewayObservation(bootOpts, {
+					await policyRequest.observe({
 						type: "error",
 						...policyObservationBase(policy),
 						stage: "credential_selection",
@@ -649,13 +712,13 @@ function buildGatewayApiKeyResolver(
 					});
 					return undefined;
 				}
-				currentCredential = resolved;
-				await emitGatewayObservation(bootOpts, {
+				await policyRequest.observe({
 					type: "credential_selection",
 					...policyObservationBase(policy),
 					credentialId: resolved.credentialId,
 					phase: "force_refresh",
 				});
+				currentCredential = resolved;
 				return resolved.apiKey;
 			}
 			const refreshed = await bootOpts.storage.getApiKey(model.provider, sessionId, {
@@ -675,7 +738,7 @@ function buildGatewayApiKeyResolver(
 			sig,
 			format,
 			peer,
-			policy,
+			policyRequest,
 		);
 		if (next) currentCredential = next;
 		return next?.apiKey;
@@ -696,31 +759,6 @@ function mirrorRequestAbort(req: Request): AbortController {
 	return controller;
 }
 
-async function observePolicyFailure(
-	bootOpts: AuthGatewayBootOptions,
-	policy: GatewayPolicy,
-	stage: "model_resolution" | "credential_selection" | "upstream",
-	code:
-		| "model_unavailable"
-		| "credential_unavailable"
-		| "credential_rotation_unavailable"
-		| "request_aborted"
-		| "upstream_error",
-	outcome: "error" | "aborted" = "error",
-): Promise<void> {
-	await emitGatewayObservation(bootOpts, {
-		type: "error",
-		...policyObservationBase(policy),
-		stage,
-		code,
-	});
-	await emitGatewayObservation(bootOpts, {
-		type: "terminal",
-		...policyObservationBase(policy),
-		outcome,
-	});
-}
-
 function genericPolicyErrorMessage(message: AssistantMessage, reason: "error" | "aborted"): AssistantMessage {
 	return {
 		role: "assistant",
@@ -739,34 +777,29 @@ function genericPolicyErrorMessage(message: AssistantMessage, reason: "error" | 
 
 function withPolicyEventObservations(
 	events: AssistantMessageEventStream,
-	bootOpts: AuthGatewayBootOptions,
-	policy: GatewayPolicy,
+	policyRequest: GatewayPolicyRequest,
+	abortUpstream: (reason: Error) => void,
 ): AssistantMessageEventStream {
 	const observed = new AssistantMessageEventStream();
 	const pump = async (): Promise<void> => {
-		let terminal = false;
 		try {
 			for await (const event of events) {
+				if (policyRequest.observerError) {
+					abortUpstream(policyRequest.observerError);
+					observed.fail(policyRequest.observerError);
+					return;
+				}
 				if (event.type === "done") {
-					await emitGatewayObservation(bootOpts, {
-						type: "terminal",
-						...policyObservationBase(policy),
-						outcome: "success",
-					});
-					terminal = true;
+					await policyRequest.settleSuccessBestEffort();
 					observed.push(event);
 					return;
 				}
 				if (event.type === "error") {
-					const outcome = event.reason === "aborted" ? "aborted" : "error";
-					await observePolicyFailure(
-						bootOpts,
-						policy,
-						"upstream",
-						outcome === "aborted" ? "request_aborted" : "upstream_error",
-						outcome,
-					);
-					terminal = true;
+					if (event.reason === "aborted") {
+						await policyRequest.settleAbortedBestEffort();
+					} else {
+						await policyRequest.fail("upstream", "upstream_error");
+					}
 					observed.push({
 						type: "error",
 						reason: event.reason,
@@ -776,22 +809,24 @@ function withPolicyEventObservations(
 				}
 				observed.push(event);
 			}
-			if (!terminal) {
-				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
-				observed.fail(new Error("Gateway upstream stream failed"));
-			}
+			abortUpstream(new Error("Gateway upstream stream ended before a terminal event"));
+			await policyRequest.fail("upstream", "upstream_error");
+			observed.fail(new Error("Gateway upstream stream failed"));
 		} catch (error) {
-			if (error instanceof AuthGatewayObserverDeliveryError) {
-				observed.fail(error);
+			if (policyRequest.observerError) {
+				abortUpstream(policyRequest.observerError);
+				observed.fail(policyRequest.observerError);
 				return;
 			}
 			try {
-				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				await policyRequest.fail("upstream", "upstream_error");
 			} catch (observationError) {
 				observed.fail(observationError);
 				return;
 			}
-			observed.fail(new Error("Gateway upstream stream failed"));
+			observed.fail(
+				error instanceof AuthGatewayObserverDeliveryError ? error : new Error("Gateway upstream stream failed"),
+			);
 		}
 	};
 	void pump();
@@ -810,10 +845,28 @@ async function handleFormatEndpoint(
 	const requestId = crypto.randomUUID();
 	const controller = mirrorRequestAbort(req);
 	if (controller.signal.aborted) return clientClosedResponse(route);
+	if (
+		bootOpts.authorizeRequest &&
+		!isBoundedPolicyText(
+			req.headers.get(AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER),
+			MAX_POLICY_AUTHORIZATION_INPUT_LENGTH,
+		)
+	) {
+		return route.module.formatError(401, "authorization_error", "Missing or invalid gateway policy authorization");
+	}
 
 	let body: unknown;
+	let payloadByteLength = 0;
+	let payloadSha256 = "";
 	try {
-		body = bootOpts.authorizeRequest ? await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES) : await req.json();
+		if (bootOpts.authorizeRequest) {
+			const bounded = await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES);
+			body = bounded.value;
+			payloadByteLength = bounded.byteLength;
+			payloadSha256 = bounded.sha256;
+		} else {
+			body = await req.json();
+		}
 	} catch (error) {
 		if (controller.signal.aborted) return clientClosedResponse(route);
 		const message = bootOpts.authorizeRequest ? "Invalid JSON request body" : `Invalid JSON body: ${String(error)}`;
@@ -824,12 +877,17 @@ async function handleFormatEndpoint(
 	// All three supported wire formats put the model id on a top-level `model`
 	// field. Read it without running the full strict schema so the route can
 	// produce a coherent error envelope when the model id is missing.
-	const modelId =
-		typeof body === "object" && body !== null && typeof (body as { model?: unknown }).model === "string"
-			? (body as { model: string }).model
-			: undefined;
+	let modelId: string | undefined;
+	if (typeof body === "object" && body !== null && "model" in body && typeof body.model === "string") {
+		modelId = body.model;
+	}
 	if (!modelId) {
 		return route.module.formatError(400, "invalid_request_error", "Missing top-level `model` field");
+	}
+
+	const nativeModel = bootOpts.authorizeRequest ? undefined : bootOpts.resolveModel(modelId);
+	if (!bootOpts.authorizeRequest && !nativeModel) {
+		return route.module.formatError(404, "invalid_request_error", `Unknown model: ${modelId}`);
 	}
 
 	// Parse the wire-format request BEFORE resolving the credential so we
@@ -858,18 +916,26 @@ async function handleFormatEndpoint(
 			format: route.label,
 			requestedModelId: parsed.modelId,
 			requestedSessionId: parsed.options.promptCacheKey,
+			payloadByteLength,
+			payloadSha256,
 		},
 		route.module.formatError,
 	);
 	if (!authorization.ok) return authorization.response;
 	const policy = authorization.policy;
+	const policyRequest = policy ? new GatewayPolicyRequest(policy, bootOpts) : undefined;
+	const abortedAfterGrant = async (): Promise<Response> => {
+		await policyRequest?.settleAbortedBestEffort();
+		return clientClosedResponse(route);
+	};
+	if (controller.signal.aborted) return abortedAfterGrant();
 
 	const resolvedModelId = policy?.resolvedModelId ?? parsed.modelId;
-	const model = bootOpts.resolveModel(resolvedModelId);
+	const model = policy ? bootOpts.resolveModel(resolvedModelId) : nativeModel;
 	if (!model) {
-		if (policy) {
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "model_resolution", "model_unavailable");
+				await policyRequest.fail("model_resolution", "model_unavailable");
 			} catch (error) {
 				if (error instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(route.module.formatError);
@@ -884,7 +950,7 @@ async function handleFormatEndpoint(
 	// In policy mode parser-captured account, organization, project, client,
 	// and credential headers are discarded before provider options are built.
 	const captured = captureRequestHeaders(req.headers, { stripPolicyIdentity: policy !== undefined });
-	const parsedHeaders = policy ? stripPolicyIdentityHeaders(parsed.options.headers) : (parsed.options.headers ?? {});
+	const parsedHeaders = policy ? {} : (parsed.options.headers ?? {});
 	parsed.options.headers = { ...captured, ...parsedHeaders };
 
 	const sessionId =
@@ -894,11 +960,10 @@ async function handleFormatEndpoint(
 		delete parsed.options.user;
 		delete parsed.options.metadata;
 		delete parsed.options.previousResponseId;
-		delete parsed.options.extra;
 	} else {
 		parsed.options.promptCacheKey ??= sessionId;
 	}
-	if (controller.signal.aborted) return clientClosedResponse(route);
+	if (controller.signal.aborted) return abortedAfterGrant();
 
 	let credential: GatewayResolvedCredential | undefined;
 	try {
@@ -909,14 +974,15 @@ async function handleFormatEndpoint(
 				policy.allowedOAuthCredentialIds,
 				{ modelId: model.id, signal: controller.signal },
 			);
+			if (controller.signal.aborted) return abortedAfterGrant();
 			if (access && policy.allowedOAuthCredentialIds.has(access.credentialId)) {
-				credential = access;
-				await emitGatewayObservation(bootOpts, {
+				await policyRequest?.observe({
 					type: "credential_selection",
 					...policyObservationBase(policy),
 					credentialId: access.credentialId,
 					phase: "initial",
 				});
+				credential = access;
 			}
 		} else {
 			const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
@@ -926,13 +992,13 @@ async function handleFormatEndpoint(
 			if (apiKey) credential = { apiKey };
 		}
 	} catch (error) {
-		if (error instanceof AuthGatewayObserverDeliveryError) {
+		if (error instanceof AuthGatewayObserverDeliveryError || policyRequest?.observerError) {
 			return observerFailureResponse(route.module.formatError);
 		}
-		if (controller.signal.aborted) return clientClosedResponse(route);
-		if (policy) {
+		if (controller.signal.aborted) return abortedAfterGrant();
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+				await policyRequest.fail("credential_selection", "credential_unavailable");
 			} catch (observationError) {
 				if (observationError instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(route.module.formatError);
@@ -945,11 +1011,11 @@ async function handleFormatEndpoint(
 		logger.warn("auth-gateway getApiKey threw", { provider: model.provider, peer, error: classified.message });
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
-	if (controller.signal.aborted) return clientClosedResponse(route);
+	if (controller.signal.aborted) return abortedAfterGrant();
 	if (!credential) {
-		if (policy) {
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+				await policyRequest.fail("credential_selection", "credential_unavailable");
 			} catch (error) {
 				if (error instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(route.module.formatError);
@@ -974,7 +1040,7 @@ async function handleFormatEndpoint(
 		controller.signal,
 		route.label,
 		peer,
-		policy,
+		policyRequest,
 	);
 
 	logger.info("auth-gateway request", {
@@ -989,28 +1055,20 @@ async function handleFormatEndpoint(
 
 	if (!parsed.stream) {
 		try {
-			if (controller.signal.aborted) {
-				if (policy) await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
-				return clientClosedResponse(route);
-			}
+			if (controller.signal.aborted) return abortedAfterGrant();
 			const message = await completeSimple(model, parsed.context, streamOpts);
+			if (policyRequest?.observerError) return observerFailureResponse(route.module.formatError);
 			if (message.stopReason === "aborted" || message.stopReason === "error") {
 				const errorMessage =
 					message.errorMessage ??
 					(message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed");
-				if (policy) {
-					await observePolicyFailure(
-						bootOpts,
-						policy,
-						"upstream",
-						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
-						message.stopReason === "aborted" ? "aborted" : "error",
-					);
-					return route.module.formatError(
-						message.stopReason === "aborted" ? 499 : 502,
-						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
-						message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed",
-					);
+				if (policyRequest) {
+					if (message.stopReason === "aborted") {
+						await policyRequest.settleAbortedBestEffort();
+						return route.module.formatError(499, "request_aborted", "Request was aborted");
+					}
+					await policyRequest.fail("upstream", "upstream_error");
+					return route.module.formatError(502, "upstream_error", "Upstream request failed");
 				}
 				logger.warn("auth-gateway non-streaming failed", {
 					format: route.label,
@@ -1024,38 +1082,21 @@ async function handleFormatEndpoint(
 				const classified = classifyGatewayError(errorMessage);
 				return route.module.formatError(classified.status, classified.type, errorMessage);
 			}
-			if (policy) {
-				await emitGatewayObservation(bootOpts, {
-					type: "terminal",
-					...policyObservationBase(policy),
-					outcome: "success",
-				});
-			}
+			if (policyRequest?.observerError) return observerFailureResponse(route.module.formatError);
+			await policyRequest?.settleSuccessBestEffort();
 			return json(
 				200,
 				route.module.encodeResponse(message, parsed.modelId),
 				gatewayResponseHeaders(model, { requestId, message, startedAt }),
 			);
 		} catch (error) {
-			if (error instanceof AuthGatewayObserverDeliveryError) {
+			if (error instanceof AuthGatewayObserverDeliveryError || policyRequest?.observerError) {
 				return observerFailureResponse(route.module.formatError);
 			}
-			if (controller.signal.aborted) {
-				if (policy) {
-					try {
-						await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
-					} catch (observationError) {
-						if (observationError instanceof AuthGatewayObserverDeliveryError) {
-							return observerFailureResponse(route.module.formatError);
-						}
-						throw observationError;
-					}
-				}
-				return clientClosedResponse(route);
-			}
-			if (policy) {
+			if (controller.signal.aborted) return abortedAfterGrant();
+			if (policyRequest) {
 				try {
-					await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+					await policyRequest.fail("upstream", "upstream_error");
 				} catch (observationError) {
 					if (observationError instanceof AuthGatewayObserverDeliveryError) {
 						return observerFailureResponse(route.module.formatError);
@@ -1076,15 +1117,15 @@ async function handleFormatEndpoint(
 
 	let events: AssistantMessageEventStream;
 	try {
-		if (controller.signal.aborted) return clientClosedResponse(route);
+		if (controller.signal.aborted) return abortedAfterGrant();
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
-		if (error instanceof AuthGatewayObserverDeliveryError) {
+		if (error instanceof AuthGatewayObserverDeliveryError || policyRequest?.observerError) {
 			return observerFailureResponse(route.module.formatError);
 		}
-		if (policy) {
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				await policyRequest.fail("upstream", "upstream_error");
 			} catch (observationError) {
 				if (observationError instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(route.module.formatError);
@@ -1097,15 +1138,20 @@ async function handleFormatEndpoint(
 		logger.warn("auth-gateway streamSimple threw", { format: route.label, error: classified.message, peer });
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
-	if (controller.signal.aborted) return clientClosedResponse(route);
+	if (controller.signal.aborted) return abortedAfterGrant();
 
-	if (policy) events = withPolicyEventObservations(events, bootOpts, policy);
+	if (policyRequest) {
+		events = withPolicyEventObservations(events, policyRequest, reason => {
+			if (!controller.signal.aborted) controller.abort(reason);
+		});
+	}
 	const sseStream = route.module.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
 		onCancel: reason => {
 			if (!controller.signal.aborted) {
 				controller.abort(reason instanceof Error ? reason : new Error("client closed request"));
 			}
+			void policyRequest?.settleAbortedBestEffort();
 		},
 	});
 	return new Response(sseStream, {
@@ -1143,16 +1189,59 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	const controller = mirrorRequestAbort(req);
 	const aborted = (): Response => piNative.formatError(499, "request_aborted", "client closed request");
 	if (controller.signal.aborted) return aborted();
+	if (
+		bootOpts.authorizeRequest &&
+		!isBoundedPolicyText(
+			req.headers.get(AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER),
+			MAX_POLICY_AUTHORIZATION_INPUT_LENGTH,
+		)
+	) {
+		return piNative.formatError(401, "authorization_error", "Missing or invalid gateway policy authorization");
+	}
 
 	let body: unknown;
+	let payloadByteLength = 0;
+	let payloadSha256 = "";
 	try {
-		body = bootOpts.authorizeRequest ? await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES) : await req.json();
+		if (bootOpts.authorizeRequest) {
+			const bounded = await readBoundedJson(req, MAX_POLICY_REQUEST_BODY_BYTES);
+			body = bounded.value;
+			payloadByteLength = bounded.byteLength;
+			payloadSha256 = bounded.sha256;
+		} else {
+			body = await req.json();
+		}
 	} catch (error) {
 		if (controller.signal.aborted) return aborted();
 		const message = bootOpts.authorizeRequest ? "Invalid JSON request body" : `Invalid JSON body: ${String(error)}`;
 		return piNative.formatError(400, "invalid_request_error", message);
 	}
 	if (controller.signal.aborted) return aborted();
+
+	let nativeModel: Model<Api> | undefined;
+	if (!bootOpts.authorizeRequest && typeof body === "object" && body !== null) {
+		let requestedModelId: string | undefined;
+		if ("modelId" in body && typeof body.modelId === "string" && body.modelId.length > 0) {
+			requestedModelId = body.modelId;
+		} else if ("model" in body && typeof body.model === "string" && body.model.length > 0) {
+			requestedModelId = body.model;
+		} else if (
+			"model" in body &&
+			typeof body.model === "object" &&
+			body.model !== null &&
+			"id" in body.model &&
+			typeof body.model.id === "string" &&
+			body.model.id.length > 0
+		) {
+			requestedModelId = body.model.id;
+		}
+		if (requestedModelId) {
+			nativeModel = bootOpts.resolveModel(requestedModelId);
+			if (!nativeModel) {
+				return piNative.formatError(404, "invalid_request_error", `Unknown model: ${requestedModelId}`);
+			}
+		}
+	}
 
 	let parsed: piNative.PiNativeParsedRequest;
 	try {
@@ -1175,18 +1264,26 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 			format: "pi-native",
 			requestedModelId: parsed.modelId,
 			requestedSessionId: parsed.options.sessionId ?? parsed.options.promptCacheKey,
+			payloadByteLength,
+			payloadSha256,
 		},
 		piNative.formatError,
 	);
 	if (!authorization.ok) return authorization.response;
 	const policy = authorization.policy;
+	const policyRequest = policy ? new GatewayPolicyRequest(policy, bootOpts) : undefined;
+	const abortedAfterGrant = async (): Promise<Response> => {
+		await policyRequest?.settleAbortedBestEffort();
+		return aborted();
+	};
+	if (controller.signal.aborted) return abortedAfterGrant();
 
 	const resolvedModelId = policy?.resolvedModelId ?? parsed.modelId;
-	const model = bootOpts.resolveModel(resolvedModelId);
+	const model = policy ? bootOpts.resolveModel(resolvedModelId) : nativeModel;
 	if (!model) {
-		if (policy) {
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "model_resolution", "model_unavailable");
+				await policyRequest.fail("model_resolution", "model_unavailable");
 			} catch (error) {
 				if (error instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(piNative.formatError);
@@ -1198,15 +1295,11 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		return piNative.formatError(404, "invalid_request_error", `Unknown model: ${parsed.modelId}`);
 	}
 
-	const sessionId =
-		policy?.sessionId ??
-		parsed.options.sessionId ??
-		parsed.options.promptCacheKey ??
-		deriveSessionId(parsed.modelId, parsed.context);
+	const sessionId = policy?.sessionId ?? parsed.options.sessionId ?? deriveSessionId(parsed.modelId, parsed.context);
 	if (policy) {
 		parsed.options.sessionId = sessionId;
 		parsed.options.promptCacheKey = sessionId;
-		parsed.options.headers = stripPolicyIdentityHeaders(parsed.options.headers);
+		parsed.options.headers = {};
 		delete parsed.options.metadata;
 		delete parsed.options.initiatorOverride;
 		delete parsed.options.cachedContent;
@@ -1215,6 +1308,7 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	} else {
 		parsed.options.sessionId ??= sessionId;
 	}
+	if (controller.signal.aborted) return abortedAfterGrant();
 
 	let credential: GatewayResolvedCredential | undefined;
 	try {
@@ -1225,14 +1319,15 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 				policy.allowedOAuthCredentialIds,
 				{ modelId: model.id, signal: controller.signal },
 			);
+			if (controller.signal.aborted) return abortedAfterGrant();
 			if (access && policy.allowedOAuthCredentialIds.has(access.credentialId)) {
-				credential = access;
-				await emitGatewayObservation(bootOpts, {
+				await policyRequest?.observe({
 					type: "credential_selection",
 					...policyObservationBase(policy),
 					credentialId: access.credentialId,
 					phase: "initial",
 				});
+				credential = access;
 			}
 		} else {
 			const apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
@@ -1242,13 +1337,13 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 			if (apiKey) credential = { apiKey };
 		}
 	} catch (error) {
-		if (error instanceof AuthGatewayObserverDeliveryError) {
+		if (error instanceof AuthGatewayObserverDeliveryError || policyRequest?.observerError) {
 			return observerFailureResponse(piNative.formatError);
 		}
-		if (controller.signal.aborted) return aborted();
-		if (policy) {
+		if (controller.signal.aborted) return abortedAfterGrant();
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+				await policyRequest.fail("credential_selection", "credential_unavailable");
 			} catch (observationError) {
 				if (observationError instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(piNative.formatError);
@@ -1261,11 +1356,11 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		logger.warn("auth-gateway getApiKey threw", { provider: model.provider, peer, error: classified.message });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
-	if (controller.signal.aborted) return aborted();
+	if (controller.signal.aborted) return abortedAfterGrant();
 	if (!credential) {
-		if (policy) {
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "credential_selection", "credential_unavailable");
+				await policyRequest.fail("credential_selection", "credential_unavailable");
 			} catch (error) {
 				if (error instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(piNative.formatError);
@@ -1294,7 +1389,7 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		controller.signal,
 		"pi-native",
 		peer,
-		policy,
+		policyRequest,
 	);
 	if (model.api === "openai-codex-responses") {
 		delete streamOpts.temperature;
@@ -1310,7 +1405,7 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	// headers. Policy mode strips caller-controlled identity and auth values
 	// from both sources, and the authorized session always wins.
 	const captured = captureRequestHeaders(req.headers, { stripPolicyIdentity: policy !== undefined });
-	const optionHeaders = policy ? stripPolicyIdentityHeaders(streamOpts.headers) : (streamOpts.headers ?? {});
+	const optionHeaders = policy ? {} : (streamOpts.headers ?? {});
 	streamOpts.headers = { ...captured, ...optionHeaders };
 	if (policy) {
 		streamOpts.sessionId = sessionId;
@@ -1331,28 +1426,20 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	if (!parsed.stream) {
 		try {
-			if (controller.signal.aborted) {
-				if (policy) await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
-				return aborted();
-			}
+			if (controller.signal.aborted) return abortedAfterGrant();
 			const message = await completeSimple(model, parsed.context, streamOpts);
+			if (policyRequest?.observerError) return observerFailureResponse(piNative.formatError);
 			if (message.stopReason === "aborted" || message.stopReason === "error") {
 				const errorMessage =
 					message.errorMessage ??
 					(message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed");
-				if (policy) {
-					await observePolicyFailure(
-						bootOpts,
-						policy,
-						"upstream",
-						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
-						message.stopReason === "aborted" ? "aborted" : "error",
-					);
-					return piNative.formatError(
-						message.stopReason === "aborted" ? 499 : 502,
-						message.stopReason === "aborted" ? "request_aborted" : "upstream_error",
-						message.stopReason === "aborted" ? "Request was aborted" : "Upstream request failed",
-					);
+				if (policyRequest) {
+					if (message.stopReason === "aborted") {
+						await policyRequest.settleAbortedBestEffort();
+						return piNative.formatError(499, "request_aborted", "Request was aborted");
+					}
+					await policyRequest.fail("upstream", "upstream_error");
+					return piNative.formatError(502, "upstream_error", "Upstream request failed");
 				}
 				logger.warn("auth-gateway non-streaming failed", {
 					format: "pi-native",
@@ -1366,34 +1453,17 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 				const classified = classifyGatewayError(errorMessage);
 				return piNative.formatError(classified.status, classified.type, errorMessage);
 			}
-			if (policy) {
-				await emitGatewayObservation(bootOpts, {
-					type: "terminal",
-					...policyObservationBase(policy),
-					outcome: "success",
-				});
-			}
+			if (policyRequest?.observerError) return observerFailureResponse(piNative.formatError);
+			await policyRequest?.settleSuccessBestEffort();
 			return json(200, { message }, gatewayResponseHeaders(model, { requestId, message, startedAt }));
 		} catch (error) {
-			if (error instanceof AuthGatewayObserverDeliveryError) {
+			if (error instanceof AuthGatewayObserverDeliveryError || policyRequest?.observerError) {
 				return observerFailureResponse(piNative.formatError);
 			}
-			if (controller.signal.aborted) {
-				if (policy) {
-					try {
-						await observePolicyFailure(bootOpts, policy, "upstream", "request_aborted", "aborted");
-					} catch (observationError) {
-						if (observationError instanceof AuthGatewayObserverDeliveryError) {
-							return observerFailureResponse(piNative.formatError);
-						}
-						throw observationError;
-					}
-				}
-				return aborted();
-			}
-			if (policy) {
+			if (controller.signal.aborted) return abortedAfterGrant();
+			if (policyRequest) {
 				try {
-					await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+					await policyRequest.fail("upstream", "upstream_error");
 				} catch (observationError) {
 					if (observationError instanceof AuthGatewayObserverDeliveryError) {
 						return observerFailureResponse(piNative.formatError);
@@ -1410,15 +1480,15 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 
 	let events: AssistantMessageEventStream;
 	try {
-		if (controller.signal.aborted) return aborted();
+		if (controller.signal.aborted) return abortedAfterGrant();
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
-		if (error instanceof AuthGatewayObserverDeliveryError) {
+		if (error instanceof AuthGatewayObserverDeliveryError || policyRequest?.observerError) {
 			return observerFailureResponse(piNative.formatError);
 		}
-		if (policy) {
+		if (policyRequest) {
 			try {
-				await observePolicyFailure(bootOpts, policy, "upstream", "upstream_error");
+				await policyRequest.fail("upstream", "upstream_error");
 			} catch (observationError) {
 				if (observationError instanceof AuthGatewayObserverDeliveryError) {
 					return observerFailureResponse(piNative.formatError);
@@ -1431,15 +1501,20 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		logger.warn("auth-gateway streamSimple threw", { format: "pi-native", error: classified.message, peer });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
-	if (controller.signal.aborted) return aborted();
+	if (controller.signal.aborted) return abortedAfterGrant();
 
-	if (policy) events = withPolicyEventObservations(events, bootOpts, policy);
+	if (policyRequest) {
+		events = withPolicyEventObservations(events, policyRequest, reason => {
+			if (!controller.signal.aborted) controller.abort(reason);
+		});
+	}
 	const sseStream = piNative.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
 		onCancel: reason => {
 			if (!controller.signal.aborted) {
 				controller.abort(reason instanceof Error ? reason : new Error("client closed request"));
 			}
+			void policyRequest?.settleAbortedBestEffort();
 		},
 	});
 	return new Response(sseStream, {
@@ -1503,6 +1578,9 @@ function handleModelsList(opts: AuthGatewayBootOptions): Response {
 }
 
 export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServerHandle {
+	if (opts.authorizeRequest && (!opts.observer || !opts.readinessProbe)) {
+		throw new Error("Auth gateway policy mode requires both observer and readinessProbe");
+	}
 	const bind = parseBind(opts.bind ?? DEFAULT_AUTH_GATEWAY_BIND);
 	const tokens = new Set<string>(opts.bearerTokens);
 	const version = opts.version;
@@ -1522,6 +1600,15 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 			}
 			try {
 				if (req.method === "GET" && pathname === "/healthz") {
+					if (opts.readinessProbe) {
+						try {
+							if (!(await opts.readinessProbe(req.signal))) {
+								return withCors(json(503, { ok: false, version }), req);
+							}
+						} catch {
+							return withCors(json(503, { ok: false, version }), req);
+						}
+					}
 					return withCors(json(200, { ok: true, version }), req);
 				}
 				if (!isAuthorized(req, tokens)) {
@@ -1563,6 +1650,9 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 
 				// Model catalog.
 				if (req.method === "GET" && pathname === "/v1/models") {
+					if (opts.authorizeRequest) {
+						return withCors(json(403, { error: "route unavailable in gateway policy mode" }), req);
+					}
 					return withCors(handleModelsList(opts), req);
 				}
 

--- a/packages/ai/src/auth-gateway/types.ts
+++ b/packages/ai/src/auth-gateway/types.ts
@@ -23,6 +23,9 @@ import type {
 /** Default bind. Loopback-only — front with reverse proxy for remote access. */
 export const DEFAULT_AUTH_GATEWAY_BIND = "127.0.0.1:4000";
 
+/** Sensitive one-time policy input. Never forwarded upstream, observed, or logged. */
+export const AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER = "x-omp-auth-gateway-authorization";
+
 export type AuthGatewayToolChoice = "auto" | "none" | "required" | { name: string } | { type: "computer" };
 
 export interface AuthGatewayParsedRequestOptions {
@@ -136,11 +139,127 @@ export interface AuthGatewayFormatModule {
 	formatError(status: number, type: string, message: string): Response;
 }
 
+/** Bounded, content-free request metadata handed to a gateway policy hook. */
+export interface AuthGatewayAuthorizationRequest {
+	/** Gateway-generated identity for this HTTP request. */
+	requestId: string;
+	/** Wire route being authorized (for example `openai-chat` or `pi-native`). */
+	format: string;
+	/** Exact model selector parsed from the caller's request. */
+	requestedModelId: string;
+	/** Optional caller-supplied conversation hint. A grant must replace this with its own namespaced session id. */
+	requestedSessionId?: string;
+	method: string;
+	path: string;
+	/**
+	 * Sensitive bounded one-time gateway authorization input from
+	 * {@link AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER}. Never forwarded,
+	 * observed, or logged.
+	 */
+	authorization: string;
+	signal: AbortSignal;
+}
+
+/** A fail-closed policy denial. `reasonCode` is observer metadata and is never reflected to the client. */
+export interface AuthGatewayAuthorizationDenial {
+	authorized: false;
+	reasonCode?: string;
+}
+
+/**
+ * A policy grant binding one request to an exact model, session, and ordered
+ * OAuth credential allowlist. Every field is validated by the gateway before
+ * model resolution or credential access.
+ */
+export interface AuthGatewayAuthorizationGrant {
+	authorized: true;
+	authorizationId: string;
+	requestedModelId: string;
+	resolvedModelId: string;
+	/** Namespaced durable identity, for example `workspace:conversation`. */
+	sessionId: string;
+	/** Durable OAuth credential row ids, in policy preference order. */
+	allowedOAuthCredentialIds: readonly number[];
+}
+
+export type AuthGatewayAuthorizationDecision = AuthGatewayAuthorizationDenial | AuthGatewayAuthorizationGrant;
+
+export type AuthGatewayRequestAuthorizer = (
+	request: AuthGatewayAuthorizationRequest,
+) => AuthGatewayAuthorizationDecision | Promise<AuthGatewayAuthorizationDecision>;
+
+export type AuthGatewayAuthorizationObservation = {
+	type: "authorization";
+	requestId: string;
+	format: string;
+	requestedModelId: string;
+	outcome: "authorized" | "denied" | "error";
+	authorizationId?: string;
+	resolvedModelId?: string;
+	sessionId?: string;
+	reasonCode?: string;
+};
+
+export interface AuthGatewayPolicyObservationBase {
+	requestId: string;
+	format: string;
+	authorizationId: string;
+	requestedModelId: string;
+	resolvedModelId: string;
+	sessionId: string;
+}
+
+export type AuthGatewayCredentialSelectionObservation = AuthGatewayPolicyObservationBase & {
+	type: "credential_selection";
+	credentialId: number;
+	phase: "initial" | "force_refresh";
+};
+
+export type AuthGatewayCredentialRotationObservation = AuthGatewayPolicyObservationBase & {
+	type: "credential_rotation";
+	previousCredentialId: number;
+	credentialId: number;
+	reason: "usage_limit" | "authentication_failure";
+};
+
+export type AuthGatewayErrorObservation = AuthGatewayPolicyObservationBase & {
+	type: "error";
+	stage: "model_resolution" | "credential_selection" | "upstream";
+	code:
+		| "model_unavailable"
+		| "credential_unavailable"
+		| "credential_rotation_unavailable"
+		| "request_aborted"
+		| "upstream_error";
+};
+
+export type AuthGatewayTerminalObservation = AuthGatewayPolicyObservationBase & {
+	type: "terminal";
+	outcome: "success" | "error" | "aborted";
+};
+
+/**
+ * Content-free gateway observation. Events contain durable identities and
+ * outcomes only: never bearer bytes, request prompts, or provider responses.
+ */
+export type AuthGatewayObservation =
+	| AuthGatewayAuthorizationObservation
+	| AuthGatewayCredentialSelectionObservation
+	| AuthGatewayCredentialRotationObservation
+	| AuthGatewayErrorObservation
+	| AuthGatewayTerminalObservation;
+
+export type AuthGatewayObserver = (event: AuthGatewayObservation) => void | Promise<void>;
+
 export interface AuthGatewayServerOptions {
 	/** Listen address. Default `127.0.0.1:4000`. */
 	bind?: string;
 	/** Accept any of these bearer tokens. Empty allows unauthenticated calls. */
-	bearerTokens: string[];
+	bearerTokens: readonly string[];
+	/** Enables fail-closed policy mode for inference routes when supplied. */
+	authorizeRequest?: AuthGatewayRequestAuthorizer;
+	/** Optional trusted sink for content-free policy observations. Rejection fails the request closed. */
+	observer?: AuthGatewayObserver;
 	/** Version surfaced on `/healthz`. */
 	version?: string;
 }

--- a/packages/ai/src/auth-gateway/types.ts
+++ b/packages/ai/src/auth-gateway/types.ts
@@ -151,6 +151,9 @@ export interface AuthGatewayAuthorizationRequest {
 	requestedSessionId?: string;
 	method: string;
 	path: string;
+	/** Exact received request-body length and SHA-256, bound by the one-time authorization. */
+	payloadByteLength: number;
+	payloadSha256: string;
 	/**
 	 * Sensitive bounded one-time gateway authorization input from
 	 * {@link AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER}. Never forwarded,
@@ -225,12 +228,7 @@ export type AuthGatewayCredentialRotationObservation = AuthGatewayPolicyObservat
 export type AuthGatewayErrorObservation = AuthGatewayPolicyObservationBase & {
 	type: "error";
 	stage: "model_resolution" | "credential_selection" | "upstream";
-	code:
-		| "model_unavailable"
-		| "credential_unavailable"
-		| "credential_rotation_unavailable"
-		| "request_aborted"
-		| "upstream_error";
+	code: "model_unavailable" | "credential_unavailable" | "credential_rotation_unavailable" | "upstream_error";
 };
 
 export type AuthGatewayTerminalObservation = AuthGatewayPolicyObservationBase & {
@@ -256,10 +254,20 @@ export interface AuthGatewayServerOptions {
 	bind?: string;
 	/** Accept any of these bearer tokens. Empty allows unauthenticated calls. */
 	bearerTokens: readonly string[];
-	/** Enables fail-closed policy mode for inference routes when supplied. */
+	/**
+	 * Enables fail-closed policy mode for inference routes. Construction also
+	 * requires both `observer` and `readinessProbe`.
+	 */
 	authorizeRequest?: AuthGatewayRequestAuthorizer;
-	/** Optional trusted sink for content-free policy observations. Rejection fails the request closed. */
+	/**
+	 * Optional trusted sink for content-free policy observations. Rejection
+	 * before provider completion fails the request closed. A failed terminal
+	 * success observation is reported internally but cannot replace a provider
+	 * response that already completed successfully.
+	 */
 	observer?: AuthGatewayObserver;
+	/** Optional bounded dependency probe for `/healthz`; false or rejection returns 503. */
+	readinessProbe?: (signal: AbortSignal) => boolean | Promise<boolean>;
 	/** Version surfaced on `/healthz`. */
 	version?: string;
 }

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -820,6 +820,12 @@ type AuthApiKeyOptions = {
 	 * that a peer/broker rotated out from under us is replaced before retrying.
 	 */
 	forceRefresh?: boolean;
+	/** Restrict OAuth ranking, refresh, and fallback to these durable row ids. */
+	allowedOAuthCredentialIds?: ReadonlySet<number>;
+	/** Resolve persisted OAuth even when a local API-key override exists. Strict policy paths only. */
+	ignoreApiKeyOverrides?: boolean;
+	/** Redact token-endpoint text from logs and durable disable causes. Strict policy paths only. */
+	redactOAuthErrors?: boolean;
 };
 type OAuthResolutionResult = { apiKey: string; credential: OAuthCredential; credentialId?: number };
 
@@ -842,6 +848,12 @@ export interface OAuthAccess {
 	/** Organization/workspace the credential is scoped to (Anthropic/ChatGPT multi-subscription). */
 	orgId?: string;
 	orgName?: string;
+}
+
+/** Provider-shaped OAuth authentication plus its durable credential row identity. */
+export interface OAuthApiKeySelection {
+	apiKey: string;
+	credentialId: number;
 }
 
 /**
@@ -3193,7 +3205,11 @@ export class AuthStorage {
 		});
 	}
 
-	async #fetchUsageUncached(request: UsageRequestDescriptor, timeoutMs?: number): Promise<UsageReport | null> {
+	async #fetchUsageUncached(
+		request: UsageRequestDescriptor,
+		timeoutMs?: number,
+		redactOAuthErrors = false,
+	): Promise<UsageReport | null> {
 		const resolver = this.#usageProviderResolver;
 		if (!resolver) return null;
 
@@ -3255,7 +3271,7 @@ export class AuthStorage {
 					// that token and never mutate credential state from this path.
 					this.#usageLogger?.debug("Usage credential refresh failed, using original credential", {
 						provider: request.provider,
-						error: errorMsg,
+						error: redactOAuthErrors ? "oauth_usage_refresh_failed" : errorMsg,
 					});
 				}
 			}
@@ -3266,7 +3282,7 @@ export class AuthStorage {
 		try {
 			const report = await providerImpl.fetchUsage(params, {
 				fetch: this.#usageFetch,
-				logger: this.#usageLogger,
+				logger: redactOAuthErrors ? undefined : this.#usageLogger,
 			});
 			// Attribute the report to the credential's organization. The orgId and
 			// orgName fallbacks apply independently: Claude's usage endpoint stamps
@@ -3297,7 +3313,7 @@ export class AuthStorage {
 			}
 			logger.debug("AuthStorage usage fetch failed", {
 				provider: request.provider,
-				error: String(error),
+				error: redactOAuthErrors ? "usage_fetch_failed" : String(error),
 			});
 			return null;
 		}
@@ -3305,7 +3321,7 @@ export class AuthStorage {
 
 	async #fetchUsageCached(
 		request: UsageRequestDescriptor,
-		options: { timeoutMs?: number; forceRefresh?: boolean } = {},
+		options: { timeoutMs?: number; forceRefresh?: boolean; redactOAuthErrors?: boolean } = {},
 	): Promise<UsageReport | null> {
 		const timeoutMs = options.timeoutMs;
 		const forceRefresh = options.forceRefresh ?? false;
@@ -3318,11 +3334,11 @@ export class AuthStorage {
 		}
 
 		const usageCacheEpoch = this.#usageCacheEpoch;
-		const inFlightKey = `${cacheKey}\0${usageCacheEpoch}`;
+		const inFlightKey = `${cacheKey}\0${usageCacheEpoch}\0${options.redactOAuthErrors ? "redacted" : "diagnostic"}`;
 		const inFlight = this.#usageRequestInFlight.get(inFlightKey);
 		if (inFlight) return inFlight;
 		const promise = (async () => {
-			const report = await this.#fetchUsageUncached(request, timeoutMs);
+			const report = await this.#fetchUsageUncached(request, timeoutMs, options.redactOAuthErrors);
 			if (usageCacheEpoch !== this.#usageCacheEpoch) return report;
 			const ttlJitter = USAGE_REPORT_TTL_MS * (Math.random() * 0.5 - 0.25);
 			if (report !== null) {
@@ -3802,7 +3818,7 @@ export class AuthStorage {
 	async #getUsageReport(
 		provider: Provider,
 		credential: AuthCredential,
-		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal },
+		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal; redactOAuthErrors?: boolean },
 	): Promise<UsageReport | null> {
 		// Store-level hook (e.g. `RemoteAuthCredentialStore`) is authoritative
 		// when present for OAuth: the broker already aggregates usage from a
@@ -3831,6 +3847,7 @@ export class AuthStorage {
 		}
 		return this.#fetchUsageCached(this.#buildUsageRequest(provider, usageCredential, options?.baseUrl), {
 			timeoutMs: options?.timeoutMs ?? this.#usageRequestTimeoutMs,
+			redactOAuthErrors: options?.redactOAuthErrors,
 		});
 	}
 
@@ -4398,16 +4415,19 @@ export class AuthStorage {
 		targetIndex: number,
 		blockedUntil: number,
 		routing: CredentialBlockRouting,
+		allowedCredentialIds?: ReadonlySet<number>,
 	): UsageLimitMarkResult {
 		if (targetIndex >= 0) {
 			this.#markCredentialBlocked(provider, routing.providerKey, targetIndex, blockedUntil, routing.blockScope);
 		}
 
-		const remainingCredentials = this.#getCredentialsForProvider(provider)
-			.map((credential, index) => ({ credential, index }))
+		const remainingCredentials = this.#getStoredCredentials(provider)
+			.map((entry, index) => ({ ...entry, index }))
 			.filter(
-				(entry): entry is { credential: AuthCredential; index: number } =>
-					entry.credential.type === credentialType && entry.index !== targetIndex,
+				entry =>
+					entry.credential.type === credentialType &&
+					entry.index !== targetIndex &&
+					(!allowedCredentialIds || allowedCredentialIds.has(entry.id)),
 			);
 
 		let retryAtMs: number | undefined;
@@ -4443,6 +4463,8 @@ export class AuthStorage {
 			apiKey?: string;
 			credentialId?: number;
 			signal?: AbortSignal;
+			allowedOAuthCredentialIds?: ReadonlySet<number>;
+			redactOAuthErrors?: boolean;
 		},
 	): Promise<UsageLimitMarkResult> {
 		let sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
@@ -4465,6 +4487,9 @@ export class AuthStorage {
 		if (!sessionCredential) return { switched: false };
 		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
 		if (!target || target.credential.type !== sessionCredential.type) return { switched: false };
+		if (options?.allowedOAuthCredentialIds && !options.allowedOAuthCredentialIds.has(target.id)) {
+			return { switched: false };
+		}
 		const credentialType = sessionCredential.type;
 		const targetCredentialId = target.id;
 
@@ -4494,7 +4519,14 @@ export class AuthStorage {
 		const targetIndex = this.#getStoredCredentials(provider).findIndex(
 			entry => entry.id === targetCredentialId && entry.credential.type === credentialType,
 		);
-		return this.#blockCredentialForRotation(provider, credentialType, targetIndex, blockedUntil, routing);
+		return this.#blockCredentialForRotation(
+			provider,
+			credentialType,
+			targetIndex,
+			blockedUntil,
+			routing,
+			options?.allowedOAuthCredentialIds,
+		);
 	}
 
 	#resolveWindowResetAt(window: UsageLimit["window"]): number | undefined {
@@ -4743,9 +4775,27 @@ export class AuthStorage {
 		sessionId?: string,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthResolutionResult | undefined> {
-		const credentials = this.#getCredentialsForProvider(provider)
-			.map((credential, index) => ({ credential, index }))
-			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
+		const stored = this.#getStoredCredentials(provider);
+		const allowedCredentialIds = options?.allowedOAuthCredentialIds;
+		let credentials: OAuthSelection[];
+		if (allowedCredentialIds) {
+			const selectionsById = new Map<number, OAuthSelection>();
+			for (let index = 0; index < stored.length; index++) {
+				const entry = stored[index];
+				if (entry?.credential.type === "oauth") {
+					selectionsById.set(entry.id, { credential: entry.credential, index });
+				}
+			}
+			credentials = [];
+			for (const credentialId of allowedCredentialIds) {
+				const selection = selectionsById.get(credentialId);
+				if (selection) credentials.push(selection);
+			}
+		} else {
+			credentials = stored
+				.map((entry, index) => ({ credential: entry.credential, index }))
+				.filter((entry): entry is OAuthSelection => entry.credential.type === "oauth");
+		}
 
 		if (credentials.length === 0) return undefined;
 
@@ -5106,9 +5156,13 @@ export class AuthStorage {
 		provider: string,
 		selection: { credential: OAuthCredential; index: number },
 		options: AuthApiKeyOptions | undefined,
+		requiredCredentialId?: number,
 	): Promise<boolean> {
 		const stored = this.#getStoredCredentials(provider);
-		const selected = stored[selection.index];
+		const selected =
+			requiredCredentialId === undefined
+				? stored[selection.index]
+				: stored.find(entry => entry.id === requiredCredentialId);
 		if (selected?.credential.type !== "oauth") return false;
 
 		const prepare = this.#store.prepareForRequest?.bind(this.#store);
@@ -5136,6 +5190,8 @@ export class AuthStorage {
 			rankingContext?: CredentialRankingContext;
 			blockScope?: string;
 			blockScopes?: readonly string[];
+			/** Durable row identity required by strict policy-scoped resolution. */
+			requiredCredentialId?: number;
 			/** When false, a definitive failure of THIS credential returns undefined instead of falling back to the ranked/round-robin selector (target-only resolution). */
 			allowFallback?: boolean;
 		},
@@ -5152,7 +5208,11 @@ export class AuthStorage {
 			blockScope,
 			blockScopes,
 			allowFallback = true,
+			requiredCredentialId,
 		} = usageOptions;
+		if (requiredCredentialId !== undefined) {
+			if (!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)) return undefined;
+		}
 		if (
 			!allowBlocked &&
 			this.#isCredentialBlocked(provider, providerKey, selection.index, blockScopes ?? blockScope)
@@ -5160,14 +5220,14 @@ export class AuthStorage {
 			return undefined;
 		}
 
-		if (!(await this.#prepareOAuthCredentialForRequest(provider, selection, options))) {
+		if (!(await this.#prepareOAuthCredentialForRequest(provider, selection, options, requiredCredentialId))) {
 			return undefined;
 		}
 		// Capture the row id once, immediately after #prepareOAuthCredentialForRequest
 		// resynced selection.index from the store. A concurrent disable during the
 		// usage/refresh awaits below can shift positional indices, so every later
 		// refresh / persist / CAS-disable addresses the row by this stable id.
-		const credentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
+		const credentialId = requiredCredentialId ?? this.#getStoredCredentials(provider)[selection.index]?.id;
 
 		const planRequirement = providedPlanRequirement ?? resolveOpenAICodexPlanRequirement(provider, options?.modelId);
 		const hasPlanRequirement = planRequirement !== "none";
@@ -5185,6 +5245,12 @@ export class AuthStorage {
 					timeoutMs: this.#usageRequestTimeoutMs,
 				});
 				usageChecked = true;
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 			}
 			if (applyPlanFilter && getOpenAICodexPlanEligibility(usage, planRequirement) !== true) {
 				return undefined;
@@ -5207,14 +5273,24 @@ export class AuthStorage {
 
 		try {
 			let result: { newCredentials: OAuthCredentials; apiKey: string } | null;
+			const refreshTarget =
+				options?.forceRefresh && requiredCredentialId !== undefined
+					? { ...selection.credential, expires: 0 }
+					: selection.credential;
 			const customProvider = getOAuthProvider(provider);
 			if (customProvider) {
 				const refreshedCredentials = await this.#refreshOAuthCredential(
 					provider,
-					selection.credential,
+					refreshTarget,
 					credentialId,
 					options?.signal,
 				);
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 				const apiKey = customProvider.getApiKey
 					? customProvider.getApiKey(refreshedCredentials)
 					: refreshedCredentials.access;
@@ -5227,14 +5303,26 @@ export class AuthStorage {
 				// auth failure and soft-disable a still-valid credential.
 				const refreshedCredentials = await this.#refreshOAuthCredential(
 					provider,
-					selection.credential,
+					refreshTarget,
 					credentialId,
 					options?.signal,
 				);
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 				const oauthCreds: Record<string, OAuthCredentials> = {
 					[provider]: refreshedCredentials,
 				};
 				result = await getOAuthApiKey(provider as OAuthProvider, oauthCreds);
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 			}
 			if (!result) return undefined;
 			const updated: OAuthCredential = {
@@ -5254,6 +5342,7 @@ export class AuthStorage {
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);
 				if (idx !== -1) selection.index = idx;
+				if (requiredCredentialId !== undefined && idx === -1) return undefined;
 			} else {
 				this.#replaceCredentialAt(provider, selection.index, updated);
 			}
@@ -5265,6 +5354,12 @@ export class AuthStorage {
 						timeoutMs: this.#usageRequestTimeoutMs,
 					});
 					usageChecked = true;
+					if (
+						requiredCredentialId !== undefined &&
+						!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+					) {
+						return undefined;
+					}
 				}
 				if (applyPlanFilter && getOpenAICodexPlanEligibility(usage, planRequirement) !== true) {
 					return undefined;
@@ -5284,6 +5379,12 @@ export class AuthStorage {
 					}
 				}
 			}
+			if (
+				requiredCredentialId !== undefined &&
+				!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+			) {
+				return undefined;
+			}
 			this.#recordOAuthBearerCredentialId(provider, result.apiKey, credentialId);
 			this.#recordSessionCredential(provider, sessionId, "oauth", selection.index);
 			return { apiKey: result.apiKey, credential: updated, credentialId };
@@ -5292,11 +5393,16 @@ export class AuthStorage {
 			// Only remove credentials for definitive auth failures
 			// Keep credentials for transient errors (network, 5xx) and block temporarily
 			const isDefinitiveFailure = AIError.isDefinitiveOAuthFailure(errorMsg);
+			const diagnosticError = options?.redactOAuthErrors
+				? isDefinitiveFailure
+					? "oauth_authorization_failed"
+					: "oauth_refresh_failed"
+				: errorMsg;
 
 			logger.warn("OAuth token refresh failed", {
 				provider,
 				index: selection.index,
-				error: errorMsg,
+				error: diagnosticError,
 				isDefinitiveFailure,
 			});
 
@@ -5319,6 +5425,7 @@ export class AuthStorage {
 						});
 						await this.reload();
 						if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
+						if (requiredCredentialId !== undefined) return undefined;
 					}
 				}
 				// Permanently disable invalid credentials with an explicit cause for inspection/debugging.
@@ -5331,13 +5438,13 @@ export class AuthStorage {
 								provider,
 								credentialId,
 								selection.credential,
-								`oauth refresh failed: ${errorMsg}`,
+								options?.redactOAuthErrors ? "oauth authorization failed" : `oauth refresh failed: ${errorMsg}`,
 							)
 						: this.#tryDisableCredentialAtIfMatches(
 								provider,
 								selection.index,
 								selection.credential,
-								`oauth refresh failed: ${errorMsg}`,
+								options?.redactOAuthErrors ? "oauth authorization failed" : `oauth refresh failed: ${errorMsg}`,
 							);
 				if (!disabled) {
 					logger.debug("OAuth refresh disable lost CAS; reloading after peer rotation", {
@@ -5346,12 +5453,19 @@ export class AuthStorage {
 					});
 					await this.reload();
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
+					if (requiredCredentialId !== undefined) return undefined;
 				}
 				if (this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")) {
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
 			} else {
 				// Block temporarily for transient failures (5 minutes)
+				if (
+					requiredCredentialId !== undefined &&
+					!this.#syncOAuthSelectionFromStore(provider, selection, requiredCredentialId)
+				) {
+					return undefined;
+				}
 				this.#markCredentialBlocked(provider, providerKey, selection.index, Date.now() + 5 * 60 * 1000);
 			}
 		}
@@ -5530,13 +5644,96 @@ export class AuthStorage {
 			.filter((entry): entry is StoredOAuthSelection => entry.credential.type === "oauth");
 	}
 
+	async #resolveStoredOAuthApiKey(
+		provider: string,
+		selection: StoredOAuthSelection,
+		sessionId: string | undefined,
+		options: AuthApiKeyOptions | undefined,
+		allowBlocked: boolean,
+	): Promise<OAuthApiKeySelection | undefined> {
+		const resolved = await this.#tryOAuthCredential(
+			provider,
+			{ credential: selection.credential, index: selection.index },
+			this.#getProviderTypeKey(provider, "oauth"),
+			sessionId,
+			options,
+			{
+				checkUsage: false,
+				planRequirement: "none",
+				enforcePlanRequirement: false,
+				allowBlocked,
+				allowFallback: false,
+				requiredCredentialId: selection.credentialId,
+			},
+		);
+		if (!resolved?.credentialId) return undefined;
+		return { apiKey: resolved.apiKey, credentialId: resolved.credentialId };
+	}
+
+	/**
+	 * Resolve provider-shaped OAuth authentication in exact allowlist order.
+	 * Unblocked rows are tried first; if every authorized row is blocked, the
+	 * same insertion order is retried without consulting any outside row or
+	 * static-key source.
+	 */
+	async getOAuthApiKeyFromCredentialIds(
+		provider: string,
+		sessionId: string,
+		allowedCredentialIds: ReadonlySet<number>,
+		options?: AuthApiKeyOptions,
+	): Promise<OAuthApiKeySelection | undefined> {
+		const orderedIds: number[] = [];
+		for (const credentialId of allowedCredentialIds) {
+			if (!Number.isSafeInteger(credentialId) || credentialId <= 0) return undefined;
+			orderedIds.push(credentialId);
+		}
+		if (orderedIds.length === 0) return undefined;
+		for (const allowBlocked of [false, true]) {
+			for (const credentialId of orderedIds) {
+				const selection = this.#getStoredOAuthSelections(provider).find(
+					candidate => candidate.credentialId === credentialId,
+				);
+				if (!selection) continue;
+				const resolved = await this.#resolveStoredOAuthApiKey(
+					provider,
+					selection,
+					sessionId,
+					{ ...options, ignoreApiKeyOverrides: true, redactOAuthErrors: true },
+					allowBlocked,
+				);
+				if (resolved) return resolved;
+			}
+		}
+		return undefined;
+	}
+
+	/** Force/resolve one exact OAuth row as provider-shaped authentication, without fallback. */
+	async getOAuthApiKeyByCredentialId(
+		provider: string,
+		credentialId: number,
+		options?: AuthApiKeyOptions,
+	): Promise<OAuthApiKeySelection | undefined> {
+		if (!Number.isSafeInteger(credentialId) || credentialId <= 0) return undefined;
+		const selection = this.#getStoredOAuthSelections(provider).find(
+			candidate => candidate.credentialId === credentialId,
+		);
+		if (!selection) return undefined;
+		return this.#resolveStoredOAuthApiKey(
+			provider,
+			selection,
+			undefined,
+			{ ...options, ignoreApiKeyOverrides: true, redactOAuthErrors: true },
+			true,
+		);
+	}
+
 	/** Refresh one stored OAuth selection and shape it as an {@link OAuthAccessResolution}. */
 	async #resolveStoredOAuthAccess(
 		provider: string,
 		selection: StoredOAuthSelection,
 		providerKey: string,
 		options: AuthApiKeyOptions | undefined,
-	): Promise<OAuthAccessResolution> {
+	): Promise<OAuthAccessResolution & { credentialId: number }> {
 		try {
 			const resolved = await this.#tryOAuthCredential(
 				provider,
@@ -5700,15 +5897,19 @@ export class AuthStorage {
 	 * requested row, preserving exact-account affinity for operations whose
 	 * provenance and policy boundary are tied to one workspace.
 	 *
-	 * Returns `undefined` when the row does not exist for `provider` or an
-	 * explicit runtime/config API-key override suppresses OAuth.
+	 * Returns `undefined` when the row does not exist for `provider`. Runtime
+	 * and config overrides suppress OAuth unless `options.ignoreApiKeyOverrides`
+	 * is set by a strict OAuth-only caller.
 	 */
 	async getOAuthAccessByCredentialId(
 		provider: string,
 		credentialId: number,
 		options?: AuthApiKeyOptions,
-	): Promise<OAuthAccessResolution | undefined> {
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+	): Promise<(OAuthAccessResolution & { credentialId: number }) | undefined> {
+		if (
+			!options?.ignoreApiKeyOverrides &&
+			(this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider))
+		) {
 			return undefined;
 		}
 		const selection = this.#getStoredOAuthSelections(provider).find(
@@ -6216,7 +6417,15 @@ export class AuthStorage {
 	async rotateSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { error?: unknown; modelId?: string; apiKey?: string; credentialId?: number; signal?: AbortSignal },
+		options?: {
+			error?: unknown;
+			modelId?: string;
+			apiKey?: string;
+			credentialId?: number;
+			signal?: AbortSignal;
+			allowedOAuthCredentialIds?: ReadonlySet<number>;
+			redactOAuthErrors?: boolean;
+		},
 	): Promise<boolean> {
 		const error = options?.error;
 		const status = AIError.status(error);
@@ -6233,6 +6442,8 @@ export class AuthStorage {
 					apiKey: options?.apiKey,
 					credentialId: options?.credentialId,
 					signal: options?.signal,
+					allowedOAuthCredentialIds: options?.allowedOAuthCredentialIds,
+					redactOAuthErrors: options?.redactOAuthErrors,
 				})
 			).switched;
 		}
@@ -6242,6 +6453,10 @@ export class AuthStorage {
 			apiKey: options?.apiKey,
 		});
 		if (!sessionCredential) return false;
+		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
+		if (options?.allowedOAuthCredentialIds && (!target || !options.allowedOAuthCredentialIds.has(target.id))) {
+			return false;
+		}
 
 		if (AIError.isAccountPolicyError(error)) {
 			const routing = this.#credentialBlockRouting(provider, sessionCredential.type, options?.modelId);
@@ -6251,19 +6466,21 @@ export class AuthStorage {
 				sessionCredential.index,
 				Date.now() + AuthStorage.#defaultBackoffMs,
 				routing,
+				options?.allowedOAuthCredentialIds,
 			).switched;
 		}
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);
 		// Snapshot sibling availability before mutating so a soft-deleting
 		// suspect hook can't reindex the answer out from under us.
-		const hasSibling = this.#getCredentialsForProvider(provider).some(
-			(credential, index) =>
-				credential.type === sessionCredential.type &&
+		const hasSibling = this.#getStoredCredentials(provider).some(
+			(entry, index) =>
+				entry.credential.type === sessionCredential.type &&
 				index !== sessionCredential.index &&
+				(!options?.allowedOAuthCredentialIds || options.allowedOAuthCredentialIds.has(entry.id)) &&
 				!this.#isCredentialBlocked(provider, providerKey, index),
 		);
-		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
+
 		const sticky = this.#getSessionCredential(provider, sessionId);
 		if (
 			!sessionCredential.explicit ||

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5651,6 +5651,10 @@ export class AuthStorage {
 		options: AuthApiKeyOptions | undefined,
 		allowBlocked: boolean,
 	): Promise<OAuthApiKeySelection | undefined> {
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const blockScope = strategy?.blockScope?.(rankingContext);
+		const blockScopes = strategy?.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
 		const resolved = await this.#tryOAuthCredential(
 			provider,
 			{ credential: selection.credential, index: selection.index },
@@ -5664,6 +5668,8 @@ export class AuthStorage {
 				allowBlocked,
 				allowFallback: false,
 				requiredCredentialId: selection.credentialId,
+				blockScope,
+				blockScopes,
 			},
 		);
 		if (!resolved?.credentialId) return undefined;
@@ -6496,7 +6502,9 @@ export class AuthStorage {
 		);
 
 		if (target && AIError.isInvalidatedOAuthTokenError(error)) {
-			const disabledCause = message ?? "upstream reported invalidated OAuth token";
+			const disabledCause = options?.redactOAuthErrors
+				? "upstream reported invalidated OAuth token"
+				: (message ?? "upstream reported invalidated OAuth token");
 			const deleted = this.#store.deleteAuthCredentialRemote
 				? await this.#store.deleteAuthCredentialRemote(target.id, disabledCause)
 				: this.disableCredentialById(target.id, disabledCause);

--- a/packages/ai/test/auth-gateway-policy.test.ts
+++ b/packages/ai/test/auth-gateway-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -89,6 +90,18 @@ function policyGrant(
 	};
 }
 
+function openAIChatBody(model: string, extra?: Record<string, unknown>): string {
+	return JSON.stringify({
+		model,
+		messages: [{ role: "user", content: "raw-policy-prompt" }],
+		stream: false,
+		prompt_cache_key: "caller-body-session",
+		metadata: { account_id: "caller-metadata-account" },
+		user: "caller-user",
+		...extra,
+	});
+}
+
 async function postOpenAIChat(url: string, model: string, extra?: Record<string, unknown>): Promise<Response> {
 	return fetch(`${url}/v1/chat/completions`, {
 		method: "POST",
@@ -105,19 +118,31 @@ async function postOpenAIChat(url: string, model: string, extra?: Record<string,
 			Session_Id: "caller-header-session",
 			"OpenAI-Beta": "responses=v1",
 		},
-		body: JSON.stringify({
-			model,
-			messages: [{ role: "user", content: "raw-policy-prompt" }],
-			stream: false,
-			prompt_cache_key: "caller-body-session",
-			metadata: { account_id: "caller-metadata-account" },
-			user: "caller-user",
-			...extra,
-		}),
+		body: openAIChatBody(model, extra),
 	});
 }
 
 describe("auth-gateway policy hooks", () => {
+	it("preserves native unknown-model precedence over strict body validation", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-native-unknown-model", ["oauth-a"]);
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			resolveModel: () => undefined,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "unknown-model", { messages: "invalid" });
+			expect(response.status).toBe(404);
+			expect(await response.text()).toContain("Unknown model: unknown-model");
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
 	it("authorizes a provider-format request before model and credential access, then strips caller identity", async () => {
 		registerMockApi();
 		const fixture = await createPolicyStorage("gw-policy-order", ["oauth-a", "oauth-b"]);
@@ -153,25 +178,38 @@ describe("auth-gateway policy hooks", () => {
 			observer: event => {
 				observations.push(event);
 			},
+			readinessProbe: () => true,
 			resolveModel: selector => {
 				order.push("model");
 				return selector === "resolved-model" ? mock : undefined;
 			},
 		});
 		try {
-			const response = await postOpenAIChat(handle.url, "caller-model");
+			const response = await postOpenAIChat(handle.url, "caller-model", {
+				stream: true,
+				stream_options: { include_usage: true },
+			});
 			expect(response.status).toBe(200);
+			const body = await response.text();
+			expect(body).toContain('"choices":[]');
+			expect(body).toContain('"usage":');
 			expect(order).toEqual(["authorize", "model", "credential", "upstream"]);
 			expect(authorizationRequest?.requestedModelId).toBe("caller-model");
 			expect(authorizationRequest?.authorization).toBe("policy-input");
 			expect(authorizationRequest?.requestedSessionId).toBe("caller-body-session");
+			const expectedBody = openAIChatBody("caller-model", {
+				stream: true,
+				stream_options: { include_usage: true },
+			});
+			expect(authorizationRequest?.payloadByteLength).toBe(Buffer.byteLength(expectedBody));
+			expect(authorizationRequest?.payloadSha256).toBe(createHash("sha256").update(expectedBody).digest("hex"));
 			expect(mock.calls).toHaveLength(1);
 			const options = mock.calls[0]!.options;
 			expect(options?.apiKey).toBe("oauth-b");
 			expect(options?.sessionId).toBe("workspace:authorized-session");
 			expect(options?.promptCacheKey).toBe("workspace:authorized-session");
 			expect(options?.metadata).toBeUndefined();
-			expect(options?.headers).toEqual({ "openai-beta": "responses=v1" });
+			expect(options?.headers).toEqual({});
 			expect(observations.map(event => event.type)).toEqual(["authorization", "credential_selection", "terminal"]);
 			const serializedObservations = JSON.stringify(observations);
 			expect(serializedObservations).not.toContain("oauth-a");
@@ -212,6 +250,8 @@ describe("auth-gateway policy hooks", () => {
 					fixture.credentialIds[1]!,
 					fixture.credentialIds[0]!,
 				]),
+			observer: () => {},
+			readinessProbe: () => true,
 			resolveModel: () => mock,
 		});
 		try {
@@ -233,6 +273,11 @@ describe("auth-gateway policy hooks", () => {
 		let modelResolutions = 0;
 		let authorizerCalls = 0;
 		const observations: AuthGatewayObservation[] = [];
+		const dangerousFieldByModel: Record<string, string> = {
+			"proto-model": "__proto__",
+			"constructor-model": "constructor",
+			"tostring-model": "toString",
+		};
 		const handle = startAuthGateway({
 			bind: "127.0.0.1:0",
 			bearerTokens: ["gateway-token"],
@@ -241,6 +286,25 @@ describe("auth-gateway policy hooks", () => {
 				authorizerCalls++;
 				if (request.requestedModelId === "denied-model") {
 					return { authorized: false, reasonCode: "account_not_allowed" };
+				}
+				if (request.requestedModelId === "throw-model") {
+					throw new Error("private authorizer failure");
+				}
+				const dangerousField = dangerousFieldByModel[request.requestedModelId];
+				if (dangerousField) {
+					const dangerousDecision: Record<string, unknown> = {
+						authorized: true,
+						authorizationId: "authorization:dangerous",
+						requestedModelId: request.requestedModelId,
+						resolvedModelId: "resolved-model",
+						sessionId: "workspace:dangerous",
+						allowedOAuthCredentialIds: [fixture.credentialIds[0]!],
+					};
+					Object.defineProperty(dangerousDecision, dangerousField, {
+						value: true,
+						enumerable: true,
+					});
+					return dangerousDecision as unknown as AuthGatewayAuthorizationDecision;
 				}
 				return {
 					authorized: true,
@@ -254,6 +318,7 @@ describe("auth-gateway policy hooks", () => {
 			observer: event => {
 				observations.push(event);
 			},
+			readinessProbe: () => true,
 			resolveModel: () => {
 				modelResolutions++;
 				return undefined;
@@ -263,22 +328,31 @@ describe("auth-gateway policy hooks", () => {
 			const missingPolicyInput = await fetch(`${handle.url}/v1/chat/completions`, {
 				method: "POST",
 				headers: { Authorization: "Bearer gateway-token", "Content-Type": "application/json" },
-				body: JSON.stringify({
-					model: "missing-policy-input",
-					messages: [{ role: "user", content: "must not authorize" }],
-					stream: false,
-				}),
+				body: "{",
 			});
 			const denied = await postOpenAIChat(handle.url, "denied-model");
 			const malformed = await postOpenAIChat(handle.url, "malformed-model");
+			const unavailable = await postOpenAIChat(handle.url, "throw-model");
+			const dangerous = await Promise.all(
+				Object.keys(dangerousFieldByModel).map(model => postOpenAIChat(handle.url, model)),
+			);
 			expect(missingPolicyInput.status).toBe(401);
-			expect(authorizerCalls).toBe(2);
+			expect(authorizerCalls).toBe(6);
 			expect(denied.status).toBe(403);
 			expect(malformed.status).toBe(500);
+			expect(dangerous.map(response => response.status)).toEqual([500, 500, 500]);
+			expect(unavailable.status).toBe(503);
+			const unavailableBody = await unavailable.text();
+			expect(unavailableBody).toContain("Gateway authorization policy is unavailable");
+			expect(unavailableBody).not.toContain("observer");
+			expect(unavailableBody).not.toContain("private authorizer failure");
 			expect(modelResolutions).toBe(0);
 			expect(accessSpy).toHaveBeenCalledTimes(0);
 			expect(observations.map(event => (event.type === "authorization" ? event.outcome : event.type))).toEqual([
 				"denied",
+				"error",
+				"error",
+				"error",
 				"error",
 			]);
 			expect(await denied.text()).not.toContain("account_not_allowed");
@@ -345,6 +419,7 @@ describe("auth-gateway policy hooks", () => {
 			observer: event => {
 				observations.push(event);
 			},
+			readinessProbe: () => true,
 			resolveModel: () => mock,
 		});
 		try {
@@ -402,6 +477,7 @@ describe("auth-gateway policy hooks", () => {
 			observer: event => {
 				observations.push(event);
 			},
+			readinessProbe: () => true,
 			resolveModel: () => mock,
 		});
 		try {
@@ -419,7 +495,53 @@ describe("auth-gateway policy hooks", () => {
 		}
 	});
 
-	it("withholds the streaming terminal frame when the terminal observer fails", async () => {
+	it("surfaces a latched retry observation failure instead of a generic upstream error", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage(
+			"gw-policy-retry-observer",
+			["retry-stale", "retry-sibling"],
+			"mock",
+			access => `${access}-reminted`,
+		);
+		let attempts = 0;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "retry-observer-model",
+			handler: () => {
+				attempts++;
+				if (attempts === 1) throw new ProviderHttpError("private invalid credential", 401);
+				return { content: ["must not escape"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "retry-observer-model", "workspace:retry-observer", fixture.credentialIds),
+			observer: event => {
+				if (event.type === "credential_selection" && event.phase === "force_refresh") {
+					throw new Error("private retry observer failure");
+				}
+			},
+			readinessProbe: () => true,
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "retry-observer-alias");
+			const body = await response.text();
+			expect(response.status).toBe(503);
+			expect(body).toContain("Gateway policy observer is unavailable");
+			expect(body).not.toContain("upstream");
+			expect(body).not.toContain("private");
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("preserves successful provider responses when terminal observation delivery fails", async () => {
 		registerMockApi();
 		const fixture = await createPolicyStorage("gw-policy-stream-observer", ["oauth-a"]);
 		const mock = createMockModel({
@@ -436,6 +558,7 @@ describe("auth-gateway policy hooks", () => {
 			observer: event => {
 				if (event.type === "terminal") throw new Error("terminal-observer-private-failure");
 			},
+			readinessProbe: () => true,
 			resolveModel: () => mock,
 		});
 		try {
@@ -450,8 +573,14 @@ describe("auth-gateway policy hooks", () => {
 				received += decoder.decode(chunk.value, { stream: true });
 			}
 			received += decoder.decode();
-			expect(received).not.toContain("[DONE]");
+			expect(received).toContain("[DONE]");
 			expect(received).not.toContain("terminal-observer-private-failure");
+
+			const completeResponse = await postOpenAIChat(handle.url, "stream-observer-alias");
+			expect(completeResponse.status).toBe(200);
+			const completeBody = await completeResponse.text();
+			expect(completeBody).toContain("visible output");
+			expect(completeBody).not.toContain("terminal-observer-private-failure");
 		} finally {
 			await handle.close();
 			await closePolicyStorage(fixture);
@@ -467,7 +596,7 @@ describe("auth-gateway policy hooks", () => {
 		const mock = createMockModel({
 			provider: "mock",
 			id: "pi-resolved",
-			responses: [{ content: ["policy"] }, { content: ["legacy"] }],
+			responses: [{ content: ["policy"] }, { content: ["legacy"] }, { content: ["legacy-prompt-only"] }],
 		});
 		const policyHandle = startAuthGateway({
 			bind: "127.0.0.1:0",
@@ -480,6 +609,8 @@ describe("auth-gateway policy hooks", () => {
 					"workspace:pi-authorized",
 					request.requestedModelId === "pi-missing" ? [999_999] : [allowedId],
 				),
+			observer: () => {},
+			readinessProbe: () => true,
 			resolveModel: () => mock,
 		});
 		try {
@@ -528,7 +659,7 @@ describe("auth-gateway policy hooks", () => {
 			expect(policyOptions?.initiatorOverride).toBeUndefined();
 			expect(policyOptions?.openrouterVariant).toBeUndefined();
 			expect(policyOptions?.statefulResponses).toBeUndefined();
-			expect(policyOptions?.headers).toEqual({ "openai-beta": "responses=v1" });
+			expect(policyOptions?.headers).toEqual({});
 
 			const missingResponse = await fetch(`${policyHandle.url}/v1/pi/stream`, {
 				method: "POST",
@@ -569,11 +700,41 @@ describe("auth-gateway policy hooks", () => {
 			expect(legacyResponse.status).toBe(200);
 			expect(mock.calls[1]!.options?.apiKey).toBe("legacy-runtime-key");
 			expect(mock.calls[1]!.options?.sessionId).toBe("caller-legacy-session");
+
+			const promptOnlyResponse = await fetch(`${legacyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: { Authorization: "Bearer gateway-token", "Content-Type": "application/json" },
+				body: JSON.stringify({
+					modelId: "pi-legacy",
+					context: { messages: [{ role: "user", content: "legacy prompt only", timestamp: 4 }] },
+					stream: false,
+					options: { promptCacheKey: "caller-prompt-only" },
+				}),
+			});
+			expect(promptOnlyResponse.status).toBe(200);
+			expect(mock.calls[2]!.options?.promptCacheKey).toBe("caller-prompt-only");
+			expect(mock.calls[2]!.options?.sessionId).not.toBe("caller-prompt-only");
 		} finally {
 			await legacyHandle.close();
 			await closePolicyStorage(fixture);
 			clearCustomApis();
 		}
+	});
+
+	it("requires the complete observer and readiness policy composite at construction", () => {
+		const base = {
+			bind: "127.0.0.1:0",
+			bearerTokens: [],
+			storage: {} as AuthStorage,
+			authorizeRequest: () => ({ authorized: false as const }),
+			resolveModel: () => undefined,
+		};
+		expect(() => startAuthGateway({ ...base, readinessProbe: () => true })).toThrow(
+			"requires both observer and readinessProbe",
+		);
+		expect(() => startAuthGateway({ ...base, observer: () => {} })).toThrow(
+			"requires both observer and readinessProbe",
+		);
 	});
 
 	it("fails closed before model or credential access when the observer rejects authorization", async () => {
@@ -590,6 +751,7 @@ describe("auth-gateway policy hooks", () => {
 			observer: () => {
 				throw new Error("observer-private-failure");
 			},
+			readinessProbe: () => true,
 			resolveModel: () => {
 				modelResolutions++;
 				return undefined;

--- a/packages/ai/test/auth-gateway-policy.test.ts
+++ b/packages/ai/test/auth-gateway-policy.test.ts
@@ -1,0 +1,625 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import {
+	AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER,
+	type AuthGatewayAuthorizationDecision,
+	type AuthGatewayAuthorizationRequest,
+	type AuthGatewayObservation,
+	startAuthGateway,
+} from "@oh-my-pi/pi-ai/auth-gateway";
+import { AuthStorage, type AuthStorageOptions, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { logger } from "@oh-my-pi/pi-utils";
+
+interface PolicyStorageFixture {
+	dir: string;
+	storage: AuthStorage;
+	credentialIds: number[];
+	oauthSource?: string;
+}
+
+function oauthCredential(access: string) {
+	return {
+		type: "oauth" as const,
+		access,
+		refresh: `${access}-refresh`,
+		expires: Date.now() + 60 * 60_000,
+	};
+}
+async function createPolicyStorage(
+	name: string,
+	accesses: readonly string[],
+	provider = "mock",
+	refreshAccess?: (access: string) => string,
+	options?: AuthStorageOptions,
+): Promise<PolicyStorageFixture> {
+	const oauthSource = provider === "mock" ? `auth-gateway-policy-${name}` : undefined;
+	if (oauthSource) {
+		registerOAuthProvider({
+			id: provider,
+			name: "Auth Gateway Policy Test",
+			sourceId: oauthSource,
+			async login() {
+				return { access: "login", refresh: "login-refresh", expires: Date.now() + 60 * 60_000 };
+			},
+			async refreshToken(credentials) {
+				return {
+					...credentials,
+					access: refreshAccess?.(credentials.access) ?? credentials.access,
+					expires: Date.now() + 60 * 60_000,
+				};
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+	}
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), `${name}-`));
+	const store = await SqliteAuthCredentialStore.open(path.join(dir, "auth.db"));
+	const storage = new AuthStorage(store, options);
+	await storage.set(provider, accesses.map(oauthCredential));
+	const credentialIds = store.listAuthCredentials(provider).map(row => row.id);
+	return { dir, storage, credentialIds, oauthSource };
+}
+
+async function closePolicyStorage(fixture: PolicyStorageFixture): Promise<void> {
+	if (fixture.oauthSource) unregisterOAuthProviders(fixture.oauthSource);
+	fixture.storage.close();
+	await fs.rm(fixture.dir, { recursive: true, force: true });
+}
+
+function policyGrant(
+	request: AuthGatewayAuthorizationRequest,
+	resolvedModelId: string,
+	sessionId: string,
+	allowedOAuthCredentialIds: readonly number[],
+) {
+	return {
+		authorized: true as const,
+		authorizationId: `authorization:${request.requestId}`,
+		requestedModelId: request.requestedModelId,
+		resolvedModelId,
+		sessionId,
+		allowedOAuthCredentialIds,
+	};
+}
+
+async function postOpenAIChat(url: string, model: string, extra?: Record<string, unknown>): Promise<Response> {
+	return fetch(`${url}/v1/chat/completions`, {
+		method: "POST",
+		headers: {
+			Authorization: "Bearer gateway-token",
+			[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+			"X-Client-Id": "caller-client",
+			"X-Workspace-Id": "caller-workspace",
+			"X-Stainless-Lang": "typescript",
+			"Content-Type": "application/json",
+			"OpenAI-Organization": "caller-org",
+			"OpenAI-Project": "caller-project",
+			"ChatGPT-Account-Id": "caller-account",
+			Session_Id: "caller-header-session",
+			"OpenAI-Beta": "responses=v1",
+		},
+		body: JSON.stringify({
+			model,
+			messages: [{ role: "user", content: "raw-policy-prompt" }],
+			stream: false,
+			prompt_cache_key: "caller-body-session",
+			metadata: { account_id: "caller-metadata-account" },
+			user: "caller-user",
+			...extra,
+		}),
+	});
+}
+
+describe("auth-gateway policy hooks", () => {
+	it("authorizes a provider-format request before model and credential access, then strips caller identity", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-order", ["oauth-a", "oauth-b"]);
+		fixture.storage.setRuntimeApiKey("mock", "runtime-key-must-not-win");
+		const allowedId = fixture.credentialIds[1]!;
+		const order: string[] = [];
+		const observations: AuthGatewayObservation[] = [];
+		let authorizationRequest: AuthGatewayAuthorizationRequest | undefined;
+		const originalAccess = fixture.storage.getOAuthApiKeyFromCredentialIds.bind(fixture.storage);
+		const accessSpy = spyOn(fixture.storage, "getOAuthApiKeyFromCredentialIds").mockImplementation(
+			async (provider, sessionId, allowedCredentialIds, options) => {
+				order.push("credential");
+				return originalAccess(provider, sessionId, allowedCredentialIds, options);
+			},
+		);
+		const mock = createMockModel({
+			provider: "mock",
+			id: "resolved-model",
+			handler: () => {
+				order.push("upstream");
+				return { content: ["ok"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request => {
+				order.push("authorize");
+				authorizationRequest = request;
+				return policyGrant(request, "resolved-model", "workspace:authorized-session", [allowedId]);
+			},
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: selector => {
+				order.push("model");
+				return selector === "resolved-model" ? mock : undefined;
+			},
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "caller-model");
+			expect(response.status).toBe(200);
+			expect(order).toEqual(["authorize", "model", "credential", "upstream"]);
+			expect(authorizationRequest?.requestedModelId).toBe("caller-model");
+			expect(authorizationRequest?.authorization).toBe("policy-input");
+			expect(authorizationRequest?.requestedSessionId).toBe("caller-body-session");
+			expect(mock.calls).toHaveLength(1);
+			const options = mock.calls[0]!.options;
+			expect(options?.apiKey).toBe("oauth-b");
+			expect(options?.sessionId).toBe("workspace:authorized-session");
+			expect(options?.promptCacheKey).toBe("workspace:authorized-session");
+			expect(options?.metadata).toBeUndefined();
+			expect(options?.headers).toEqual({ "openai-beta": "responses=v1" });
+			expect(observations.map(event => event.type)).toEqual(["authorization", "credential_selection", "terminal"]);
+			const serializedObservations = JSON.stringify(observations);
+			expect(serializedObservations).not.toContain("oauth-a");
+			expect(serializedObservations).not.toContain("oauth-b");
+			expect(serializedObservations).not.toContain("raw-policy-prompt");
+		} finally {
+			accessSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("preserves provider-shaped OAuth authentication and policy grant insertion order", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage(
+			"gw-policy-structured-oauth",
+			["structured-a", "structured-b"],
+			"github-copilot",
+		);
+		fixture.storage.setRuntimeApiKey("github-copilot", "outside-static-key");
+		let selectedToken: string | undefined;
+		const mock = createMockModel({
+			provider: "github-copilot",
+			id: "structured-model",
+			handler: (_context, options) => {
+				const structured = JSON.parse(String(options?.apiKey)) as { token?: unknown };
+				selectedToken = typeof structured.token === "string" ? structured.token : undefined;
+				return { content: ["ok"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "structured-model", "workspace:structured", [
+					fixture.credentialIds[1]!,
+					fixture.credentialIds[0]!,
+				]),
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "structured-alias");
+			expect(response.status).toBe(200);
+			expect(selectedToken).toBe("structured-b");
+			expect(mock.calls[0]!.options?.apiKey).not.toBe("outside-static-key");
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("rejects denied and malformed policy decisions without model or credential access", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-denial", ["oauth-a"]);
+		const accessSpy = spyOn(fixture.storage, "getOAuthApiKeyFromCredentialIds");
+		let modelResolutions = 0;
+		let authorizerCalls = 0;
+		const observations: AuthGatewayObservation[] = [];
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request => {
+				authorizerCalls++;
+				if (request.requestedModelId === "denied-model") {
+					return { authorized: false, reasonCode: "account_not_allowed" };
+				}
+				return {
+					authorized: true,
+					authorizationId: "authorization:malformed",
+					requestedModelId: request.requestedModelId,
+					resolvedModelId: "resolved-model",
+					sessionId: "workspace:malformed",
+					allowedOAuthCredentialIds: [],
+				} as AuthGatewayAuthorizationDecision;
+			},
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: () => {
+				modelResolutions++;
+				return undefined;
+			},
+		});
+		try {
+			const missingPolicyInput = await fetch(`${handle.url}/v1/chat/completions`, {
+				method: "POST",
+				headers: { Authorization: "Bearer gateway-token", "Content-Type": "application/json" },
+				body: JSON.stringify({
+					model: "missing-policy-input",
+					messages: [{ role: "user", content: "must not authorize" }],
+					stream: false,
+				}),
+			});
+			const denied = await postOpenAIChat(handle.url, "denied-model");
+			const malformed = await postOpenAIChat(handle.url, "malformed-model");
+			expect(missingPolicyInput.status).toBe(401);
+			expect(authorizerCalls).toBe(2);
+			expect(denied.status).toBe(403);
+			expect(malformed.status).toBe(500);
+			expect(modelResolutions).toBe(0);
+			expect(accessSpy).toHaveBeenCalledTimes(0);
+			expect(observations.map(event => (event.type === "authorization" ? event.outcome : event.type))).toEqual([
+				"denied",
+				"error",
+			]);
+			expect(await denied.text()).not.toContain("account_not_allowed");
+		} finally {
+			accessSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("keeps usage-limit rotation inside the authorized OAuth row set", async () => {
+		registerMockApi();
+		const privateUsageError = "private token-endpoint response";
+		const fixture = await createPolicyStorage(
+			"gw-policy-rotation",
+			["oauth-a", "oauth-b", "oauth-outside"],
+			"mock",
+			undefined,
+			{
+				usageProviderResolver: provider =>
+					provider === "mock"
+						? {
+								id: "mock",
+								async fetchUsage(_params, context) {
+									context.logger?.warn("private usage provider diagnostic", {
+										error: privateUsageError,
+									});
+									throw new Error(privateUsageError);
+								},
+							}
+						: undefined,
+				rankingStrategyResolver: provider =>
+					provider === "mock"
+						? {
+								findWindowLimits() {
+									return {};
+								},
+								windowDefaults: { primaryMs: 60_000, secondaryMs: 60_000 },
+							}
+						: undefined,
+			},
+		);
+		const debugSpy = spyOn(logger, "debug");
+		const allowedIds = fixture.credentialIds.slice(0, 2);
+		const observations: AuthGatewayObservation[] = [];
+		let attempts = 0;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "rotation-model",
+			handler: () => {
+				attempts++;
+				if (attempts === 1) {
+					throw new ProviderHttpError("quota reached", 429, { code: "insufficient_quota" });
+				}
+				return { content: ["ok"] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request => policyGrant(request, "rotation-model", "workspace:rotation", allowedIds),
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "rotation-alias");
+			expect(response.status).toBe(200);
+			const attemptedKeys = mock.calls.map(call => call.options?.apiKey);
+			expect(attemptedKeys).toHaveLength(2);
+			expect(new Set(attemptedKeys).size).toBe(2);
+			for (const key of attemptedKeys) {
+				if (typeof key !== "string") throw new Error("expected OAuth API key");
+				expect(["oauth-a", "oauth-b"]).toContain(key);
+			}
+			expect(attemptedKeys).not.toContain("oauth-outside");
+			const rotation = observations.find(event => event.type === "credential_rotation");
+			expect(rotation?.type).toBe("credential_rotation");
+			if (rotation?.type !== "credential_rotation") throw new Error("expected credential rotation observation");
+			expect(allowedIds).toContain(rotation.previousCredentialId);
+			expect(allowedIds).toContain(rotation.credentialId);
+			expect(JSON.stringify(observations)).not.toContain("oauth-outside");
+			const diagnostics = JSON.stringify(debugSpy.mock.calls);
+			expect(diagnostics).toContain("usage_fetch_failed");
+			expect(diagnostics).not.toContain(privateUsageError);
+		} finally {
+			debugSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+	it("force-refreshes the same authorized OAuth row before rotating after an authentication failure", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage(
+			"gw-policy-force-refresh",
+			["fresh-but-stale", "authorized-sibling"],
+			"mock",
+			access => `${access}-reminted`,
+		);
+		const observations: AuthGatewayObservation[] = [];
+		let attempts = 0;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "force-refresh-model",
+			handler: (_context, options) => {
+				attempts++;
+				if (attempts === 1) throw new ProviderHttpError("invalid credential", 401);
+				return { content: [String(options?.apiKey)] };
+			},
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "force-refresh-model", "workspace:force-refresh", fixture.credentialIds),
+			observer: event => {
+				observations.push(event);
+			},
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "force-refresh-alias");
+			expect(response.status).toBe(200);
+			expect(mock.calls.map(call => call.options?.apiKey)).toEqual(["fresh-but-stale", "fresh-but-stale-reminted"]);
+			expect(
+				observations.some(event => event.type === "credential_selection" && event.phase === "force_refresh"),
+			).toBe(true);
+			expect(observations.some(event => event.type === "credential_rotation")).toBe(false);
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("withholds the streaming terminal frame when the terminal observer fails", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-stream-observer", ["oauth-a"]);
+		const mock = createMockModel({
+			provider: "mock",
+			id: "stream-observer-model",
+			handler: () => ({ content: ["visible output"] }),
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "stream-observer-model", "workspace:stream-observer", [fixture.credentialIds[0]!]),
+			observer: event => {
+				if (event.type === "terminal") throw new Error("terminal-observer-private-failure");
+			},
+			resolveModel: () => mock,
+		});
+		try {
+			const response = await postOpenAIChat(handle.url, "stream-observer-alias", { stream: true });
+			expect(response.status).toBe(200);
+			const reader = response.body!.getReader();
+			const decoder = new TextDecoder();
+			let received = "";
+			for (;;) {
+				const chunk = await reader.read();
+				if (chunk.done) break;
+				received += decoder.decode(chunk.value, { stream: true });
+			}
+			received += decoder.decode();
+			expect(received).not.toContain("[DONE]");
+			expect(received).not.toContain("terminal-observer-private-failure");
+		} finally {
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("strips pi-native overrides, refuses out-of-set policy selection, and preserves legacy resolution", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-pi", ["oauth-policy"]);
+		fixture.storage.setRuntimeApiKey("mock", "legacy-runtime-key");
+		const allowedId = fixture.credentialIds[0]!;
+		const mock = createMockModel({
+			provider: "mock",
+			id: "pi-resolved",
+			responses: [{ content: ["policy"] }, { content: ["legacy"] }],
+		});
+		const policyHandle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(
+					request,
+					"pi-resolved",
+					"workspace:pi-authorized",
+					request.requestedModelId === "pi-missing" ? [999_999] : [allowedId],
+				),
+			resolveModel: () => mock,
+		});
+		try {
+			const policyResponse = await fetch(`${policyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer gateway-token",
+					"Content-Type": "application/json",
+					[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+				},
+				body: JSON.stringify({
+					modelId: "pi-policy",
+					context: { messages: [{ role: "user", content: "pi raw prompt", timestamp: 1 }] },
+					stream: false,
+					options: {
+						sessionId: "caller-session",
+						promptCacheKey: "caller-cache-key",
+						metadata: { project: "caller-project" },
+						initiatorOverride: "caller-provider-identity",
+						openrouterVariant: "caller-provider-route",
+						statefulResponses: true,
+						headers: {
+							Authorization: "caller-upstream-token",
+							"chatgpt-account-id": "caller-account",
+							"openai-project": "caller-project",
+							session_id: "caller-header-session",
+							"openai-beta": "responses=v1",
+							"x-client-id": "caller-client",
+							"x-user-id": "caller-user",
+							"x-tenant-id": "caller-tenant",
+							"x-workspace-id": "caller-workspace",
+							"x-device-id": "caller-device",
+							apikey: "caller-api-key",
+							"x-auth": "caller-auth",
+							"x-client-secret": "caller-secret",
+						},
+					},
+				}),
+			});
+			expect(policyResponse.status).toBe(200);
+			const policyOptions = mock.calls[0]!.options;
+			expect(policyOptions?.apiKey).toBe("oauth-policy");
+			expect(policyOptions?.sessionId).toBe("workspace:pi-authorized");
+			expect(policyOptions?.promptCacheKey).toBe("workspace:pi-authorized");
+			expect(policyOptions?.metadata).toBeUndefined();
+			expect(policyOptions?.initiatorOverride).toBeUndefined();
+			expect(policyOptions?.openrouterVariant).toBeUndefined();
+			expect(policyOptions?.statefulResponses).toBeUndefined();
+			expect(policyOptions?.headers).toEqual({ "openai-beta": "responses=v1" });
+
+			const missingResponse = await fetch(`${policyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer gateway-token",
+					"Content-Type": "application/json",
+					[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+				},
+				body: JSON.stringify({
+					modelId: "pi-missing",
+					context: { messages: [{ role: "user", content: "must not run", timestamp: 2 }] },
+					stream: false,
+				}),
+			});
+			expect(missingResponse.status).toBe(401);
+			expect(mock.calls).toHaveLength(1);
+		} finally {
+			await policyHandle.close();
+		}
+
+		const legacyHandle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			resolveModel: () => mock,
+		});
+		try {
+			const legacyResponse = await fetch(`${legacyHandle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: { Authorization: "Bearer gateway-token", "Content-Type": "application/json" },
+				body: JSON.stringify({
+					modelId: "pi-legacy",
+					context: { messages: [{ role: "user", content: "legacy", timestamp: 3 }] },
+					stream: false,
+					options: { sessionId: "caller-legacy-session" },
+				}),
+			});
+			expect(legacyResponse.status).toBe(200);
+			expect(mock.calls[1]!.options?.apiKey).toBe("legacy-runtime-key");
+			expect(mock.calls[1]!.options?.sessionId).toBe("caller-legacy-session");
+		} finally {
+			await legacyHandle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+
+	it("fails closed before model or credential access when the observer rejects authorization", async () => {
+		registerMockApi();
+		const fixture = await createPolicyStorage("gw-policy-observer", ["oauth-a"]);
+		const accessSpy = spyOn(fixture.storage, "getOAuthApiKeyFromCredentialIds");
+		let modelResolutions = 0;
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["gateway-token"],
+			storage: fixture.storage,
+			authorizeRequest: request =>
+				policyGrant(request, "pi-resolved", "workspace:observer", [fixture.credentialIds[0]!]),
+			observer: () => {
+				throw new Error("observer-private-failure");
+			},
+			resolveModel: () => {
+				modelResolutions++;
+				return undefined;
+			},
+		});
+		try {
+			const response = await fetch(`${handle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer gateway-token",
+					"Content-Type": "application/json",
+					[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "policy-input",
+				},
+				body: JSON.stringify({
+					modelId: "pi-observer",
+					context: { messages: [{ role: "user", content: "must stay private", timestamp: 1 }] },
+					stream: false,
+				}),
+			});
+			const responseText = await response.text();
+			expect(response.status).toBe(503);
+			expect(responseText).not.toContain("observer-private-failure");
+			expect(responseText).not.toContain("must stay private");
+			expect(modelResolutions).toBe(0);
+			expect(accessSpy).toHaveBeenCalledTimes(0);
+		} finally {
+			accessSpy.mockRestore();
+			await handle.close();
+			await closePolicyStorage(fixture);
+			clearCustomApis();
+		}
+	});
+});

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -282,6 +282,33 @@ describe("AuthStorage codex oauth ranking", () => {
 		}
 	});
 
+	test("strict OAuth row selection skips model-scoped blocks before trying blocked rows", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock) throw new Error("test setup failed");
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("blocked", "blocked@example.com") },
+			{ type: "oauth", ...createCredential("healthy", "healthy@example.com") },
+		]);
+		const rows = store.listAuthCredentials("openai-codex");
+		const blocked = rows[0];
+		const healthy = rows[1];
+		if (!blocked || !healthy) throw new Error("expected two stored credentials");
+		store.upsertCredentialBlock({
+			credentialId: blocked.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "chat",
+			blockedUntilMs: Date.now() + HOUR_MS,
+		});
+
+		const selected = await authStorage.getOAuthApiKeyFromCredentialIds(
+			"openai-codex",
+			"policy:scoped-block",
+			new Set([blocked.id, healthy.id]),
+			{ modelId: "gpt-5.3-codex" },
+		);
+
+		expect(selected).toEqual({ apiKey: "api-healthy", credentialId: healthy.id });
+	});
+
 	test("prefers near-reset weekly account over lower-used far-reset account", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in fail-closed Unix policy-socket integration to `auth-gateway serve`, with payload byte-length and SHA-256 binding plus a request-scoped framed session for authorization, content-free observations, and dependency-aware readiness.
+
 ## [17.3.6] - 2026-08-17
 
 ### Added

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -14,6 +14,7 @@
  */
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as path from "node:path";
 import {
 	type Api,
@@ -30,7 +31,13 @@ import {
 	RemoteAuthCredentialStore,
 	type SnapshotResponse,
 } from "@oh-my-pi/pi-ai/auth-broker";
-import { DEFAULT_AUTH_GATEWAY_BIND, startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
+import {
+	type AuthGatewayAuthorizationDecision,
+	type AuthGatewayAuthorizationRequest,
+	type AuthGatewayObservation,
+	DEFAULT_AUTH_GATEWAY_BIND,
+	startAuthGateway,
+} from "@oh-my-pi/pi-ai/auth-gateway";
 import { type GeneratedProvider, getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { getConfigRootDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -44,6 +51,7 @@ export interface AuthGatewayCommandArgs {
 	flags: {
 		json?: boolean;
 		bind?: string;
+		policySocket?: string;
 		regenerate?: boolean;
 		/**
 		 * Disable bearer-token auth on inbound requests. Useful when the gateway
@@ -63,6 +71,479 @@ export interface AuthGatewayCommandArgs {
 }
 
 const ACTIONS: readonly AuthGatewayAction[] = ["serve", "token", "status", "check"];
+
+const AUTH_GATEWAY_POLICY_PROTOCOL_VERSION = 1;
+const DEFAULT_POLICY_SOCKET_TIMEOUT_MS = 2_000;
+const DEFAULT_POLICY_SOCKET_MAX_FRAME_BYTES = 64 * 1024;
+const MAX_POLICY_SOCKET_TIMEOUT_MS = 30_000;
+const MAX_POLICY_SOCKET_FRAME_BYTES = 1024 * 1024;
+
+interface AuthGatewayPolicySocketClientOptions {
+	timeoutMs?: number;
+	maxFrameBytes?: number;
+}
+
+/**
+ * Opt-in policy transport. Authorization opens one framed socket session per
+ * gateway request; ordered content-free observations reuse it until denial,
+ * error, or terminal settlement closes the session.
+ */
+export interface AuthGatewayPolicySocketClient {
+	authorizeRequest(request: AuthGatewayAuthorizationRequest): Promise<AuthGatewayAuthorizationDecision>;
+	observe(observation: AuthGatewayObservation): Promise<void>;
+	probe(signal?: AbortSignal): Promise<boolean>;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+	value: unknown,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): value is Record<string, unknown> {
+	if (!isJsonObject(value)) return false;
+	const allowed = new Set([...required, ...optional]);
+	const keys = Object.keys(value);
+	if (keys.length < required.length || keys.length > allowed.size) return false;
+	for (const key of required) {
+		if (!Object.hasOwn(value, key)) return false;
+	}
+	for (const key of keys) {
+		if (!allowed.has(key)) return false;
+	}
+	return true;
+}
+
+function parsePolicyDecision(value: unknown): AuthGatewayAuthorizationDecision {
+	if (hasExactKeys(value, ["authorized"], ["reasonCode"]) && value.authorized === false) {
+		return value as unknown as AuthGatewayAuthorizationDecision;
+	}
+	if (
+		hasExactKeys(value, [
+			"authorized",
+			"authorizationId",
+			"requestedModelId",
+			"resolvedModelId",
+			"sessionId",
+			"allowedOAuthCredentialIds",
+		]) &&
+		value.authorized === true
+	) {
+		return value as unknown as AuthGatewayAuthorizationDecision;
+	}
+	throw new Error("Gateway policy socket returned an invalid authorization decision");
+}
+
+function validatePositiveBoundedInteger(value: number, maximum: number, name: string): void {
+	if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+		throw new Error(`${name} must be a positive integer no greater than ${maximum}`);
+	}
+}
+
+export function validateAuthGatewayPolicySocketPath(socketPath: string): void {
+	if (socketPath.length === 0 || socketPath.includes("\0") || !path.isAbsolute(socketPath)) {
+		throw new Error("--policy-socket must be a non-empty absolute path without NUL bytes");
+	}
+	if (process.platform === "win32") {
+		throw new Error("--policy-socket is only supported on Unix platforms");
+	}
+}
+
+async function validatePolicySocketTrustAnchor(socketPath: string): Promise<string> {
+	const effectiveUid = process.geteuid?.();
+	if (effectiveUid === undefined) {
+		throw new Error("Gateway policy socket ownership cannot be verified on this platform");
+	}
+	const socketStat = await fs.lstat(socketPath);
+	if (socketStat.isSymbolicLink() || !socketStat.isSocket()) {
+		throw new Error("Gateway policy socket path must name a Unix socket, not a symlink");
+	}
+	if (socketStat.uid !== effectiveUid) {
+		throw new Error("Gateway policy socket must be owned by the current effective user");
+	}
+
+	const socketName = path.basename(socketPath);
+	const canonicalParent = await fs.realpath(path.dirname(socketPath));
+	const canonicalSocketStat = await fs.lstat(path.join(canonicalParent, socketName));
+	if (canonicalSocketStat.dev !== socketStat.dev || canonicalSocketStat.ino !== socketStat.ino) {
+		throw new Error("Gateway policy socket changed during trust validation");
+	}
+	let ancestor = canonicalParent;
+	for (;;) {
+		const stat = await fs.lstat(ancestor);
+		if (stat.isSymbolicLink() || !stat.isDirectory()) {
+			throw new Error("Gateway policy socket ancestor chain is not directory-only");
+		}
+		if (stat.uid !== effectiveUid && stat.uid !== 0) {
+			throw new Error("Gateway policy socket ancestors must be owned by the current effective user or root");
+		}
+		const isGroupOrWorldWritable = (stat.mode & 0o022) !== 0;
+		const hasStickyBit = (stat.mode & 0o1000) !== 0;
+		if (isGroupOrWorldWritable && !hasStickyBit) {
+			throw new Error("Gateway policy socket ancestor chain contains an unsafe writable directory");
+		}
+		const parent = path.dirname(ancestor);
+		if (parent === ancestor) break;
+		ancestor = parent;
+	}
+
+	// Node/Bun does not expose Unix peer credentials for net.Socket. This
+	// validates the filesystem trust anchor immediately before each connect;
+	// it intentionally does not claim kernel-authenticated peer identity.
+	return path.join(canonicalParent, socketName);
+}
+
+interface PendingPolicySocketExchange {
+	deferred: PromiseWithResolvers<unknown>;
+	encoded: Buffer;
+	chunks: Buffer[];
+	payloadBytes: number;
+	maxFrameBytes: number;
+	sent: boolean;
+	timer: NodeJS.Timeout;
+	signal?: AbortSignal;
+	onAbort: () => void;
+}
+
+class PolicySocketConnection {
+	readonly #socket = new net.Socket();
+	#pending: PendingPolicySocketExchange | undefined;
+	#closedError: Error | undefined;
+	#connectStarted = false;
+	readonly #socketPath: string;
+	readonly #timeoutMs: number;
+
+	constructor(socketPath: string, timeoutMs: number) {
+		this.#socketPath = socketPath;
+		this.#timeoutMs = timeoutMs;
+		this.#socket.setNoDelay(true);
+		this.#socket.on("connect", () => this.#sendPending());
+		this.#socket.on("data", chunk => this.#handleData(chunk));
+		this.#socket.on("error", () => this.#fail(new Error("Gateway policy socket is unavailable")));
+		this.#socket.on("end", () => this.#fail(new Error("Gateway policy socket closed before a complete response")));
+		this.#socket.on("close", () => this.#fail(new Error("Gateway policy socket closed before a complete response")));
+	}
+
+	async exchange(request: Record<string, unknown>, maxFrameBytes: number, signal?: AbortSignal): Promise<unknown> {
+		if (signal?.aborted) return Promise.reject(new Error("Gateway policy socket exchange aborted"));
+		if (this.#closedError) return Promise.reject(this.#closedError);
+		if (this.#pending) return Promise.reject(new Error("Gateway policy socket exchange is already in progress"));
+		if (!this.#connectStarted) {
+			let canonicalSocketPath: string;
+			try {
+				canonicalSocketPath = await validatePolicySocketTrustAnchor(this.#socketPath);
+			} catch (error) {
+				const failure = error instanceof Error ? error : new Error("Gateway policy socket trust validation failed");
+				this.#fail(failure);
+				throw failure;
+			}
+			if (signal?.aborted) throw new Error("Gateway policy socket exchange aborted");
+			this.#connectStarted = true;
+			this.#socket.connect({ path: canonicalSocketPath });
+		}
+
+		const encoded = Buffer.from(`${JSON.stringify(request)}\n`, "utf8");
+		if (encoded.byteLength - 1 > maxFrameBytes) {
+			return Promise.reject(new Error("Gateway policy socket request exceeds the frame limit"));
+		}
+
+		const deferred = Promise.withResolvers<unknown>();
+		const onAbort = (): void => this.#fail(new Error("Gateway policy socket exchange aborted"));
+		const pending: PendingPolicySocketExchange = {
+			deferred,
+			encoded,
+			chunks: [],
+			payloadBytes: 0,
+			maxFrameBytes,
+			sent: false,
+			timer: setTimeout(() => this.#fail(new Error("Gateway policy socket exchange timed out")), this.#timeoutMs),
+			signal,
+			onAbort,
+		};
+		this.#pending = pending;
+		signal?.addEventListener("abort", pending.onAbort, { once: true });
+		if (signal?.aborted) {
+			pending.onAbort();
+		} else {
+			this.#sendPending();
+		}
+		return deferred.promise;
+	}
+
+	close(): void {
+		this.#fail(new Error("Gateway policy socket connection closed"));
+	}
+
+	#sendPending(): void {
+		const pending = this.#pending;
+		if (!pending || pending.sent || this.#socket.connecting || this.#socket.destroyed) return;
+		pending.sent = true;
+		try {
+			this.#socket.write(pending.encoded);
+		} catch {
+			this.#fail(new Error("Gateway policy socket write failed"));
+		}
+	}
+
+	#handleData(chunk: Buffer | string): void {
+		const pending = this.#pending;
+		if (!pending) {
+			this.#fail(new Error("Gateway policy socket returned unsolicited frame data"));
+			return;
+		}
+		const chunkBytes = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+		const newline = chunkBytes.indexOf(0x0a);
+		if (newline === -1) {
+			pending.payloadBytes += chunkBytes.byteLength;
+			if (pending.payloadBytes > pending.maxFrameBytes) {
+				this.#fail(new Error("Gateway policy socket response exceeds the frame limit"));
+				return;
+			}
+			pending.chunks.push(chunkBytes);
+			return;
+		}
+		if (pending.payloadBytes + newline > pending.maxFrameBytes) {
+			this.#fail(new Error("Gateway policy socket response exceeds the frame limit"));
+			return;
+		}
+		if (newline !== chunkBytes.byteLength - 1) {
+			this.#fail(new Error("Gateway policy socket returned trailing frame data"));
+			return;
+		}
+		pending.chunks.push(chunkBytes.subarray(0, newline));
+		try {
+			const bytes = Buffer.concat(pending.chunks, pending.payloadBytes + newline);
+			const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+			this.#succeed(JSON.parse(text));
+		} catch {
+			this.#fail(new Error("Gateway policy socket returned malformed JSON"));
+		}
+	}
+
+	#succeed(value: unknown): void {
+		const pending = this.#pending;
+		if (!pending) return;
+		this.#pending = undefined;
+		this.#cleanupPending(pending);
+		pending.deferred.resolve(value);
+	}
+
+	#fail(error: Error): void {
+		this.#closedError ??= error;
+		const pending = this.#pending;
+		this.#pending = undefined;
+		if (pending) {
+			this.#cleanupPending(pending);
+			pending.deferred.reject(error);
+		}
+		if (!this.#socket.destroyed) this.#socket.destroy();
+	}
+
+	#cleanupPending(pending: PendingPolicySocketExchange): void {
+		clearTimeout(pending.timer);
+		pending.signal?.removeEventListener("abort", pending.onAbort);
+	}
+}
+
+interface ActivePolicySocketSession {
+	connection: PolicySocketConnection;
+	tail: Promise<void>;
+}
+
+export function createAuthGatewayPolicySocketClient(
+	socketPath: string,
+	options: AuthGatewayPolicySocketClientOptions = {},
+): AuthGatewayPolicySocketClient {
+	validateAuthGatewayPolicySocketPath(socketPath);
+	const timeoutMs = options.timeoutMs ?? DEFAULT_POLICY_SOCKET_TIMEOUT_MS;
+	const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_POLICY_SOCKET_MAX_FRAME_BYTES;
+	validatePositiveBoundedInteger(timeoutMs, MAX_POLICY_SOCKET_TIMEOUT_MS, "Policy socket timeout");
+	validatePositiveBoundedInteger(maxFrameBytes, MAX_POLICY_SOCKET_FRAME_BYTES, "Policy socket frame limit");
+	const sessions = new Map<string, ActivePolicySocketSession>();
+
+	const closeSession = (requestId: string, session: ActivePolicySocketSession): void => {
+		if (sessions.get(requestId) === session) sessions.delete(requestId);
+		session.connection.close();
+	};
+
+	return {
+		authorizeRequest: async request => {
+			const connection = new PolicySocketConnection(socketPath, timeoutMs);
+			try {
+				const response = await connection.exchange(
+					{
+						version: AUTH_GATEWAY_POLICY_PROTOCOL_VERSION,
+						type: "authorize",
+						request: {
+							requestId: request.requestId,
+							format: request.format,
+							requestedModelId: request.requestedModelId,
+							...(request.requestedSessionId === undefined
+								? {}
+								: { requestedSessionId: request.requestedSessionId }),
+							method: request.method,
+							path: request.path,
+							payloadByteLength: request.payloadByteLength,
+							payloadSha256: request.payloadSha256,
+							authorization: request.authorization,
+						},
+					},
+					maxFrameBytes,
+					request.signal,
+				);
+				if (
+					!hasExactKeys(response, ["version", "type", "decision"]) ||
+					response.version !== AUTH_GATEWAY_POLICY_PROTOCOL_VERSION ||
+					response.type !== "authorize_result"
+				) {
+					throw new Error("Gateway policy socket returned an invalid authorization response");
+				}
+				const decision = parsePolicyDecision(response.decision);
+				if (sessions.has(request.requestId)) {
+					throw new Error("Gateway policy socket request id is already active");
+				}
+				sessions.set(request.requestId, { connection, tail: Promise.resolve() });
+				return decision;
+			} catch (error) {
+				connection.close();
+				throw error;
+			}
+		},
+		observe: observation => {
+			const session = sessions.get(observation.requestId);
+			if (!session) {
+				return Promise.reject(new Error("Gateway policy socket has no active authorization session"));
+			}
+			const final =
+				observation.type === "terminal" ||
+				(observation.type === "authorization" && observation.outcome !== "authorized");
+			const exchange = session.tail.then(async () => {
+				const response = await session.connection.exchange(
+					{
+						version: AUTH_GATEWAY_POLICY_PROTOCOL_VERSION,
+						type: "observe",
+						observation,
+					},
+					maxFrameBytes,
+				);
+				if (
+					!hasExactKeys(response, ["version", "type", "ack"]) ||
+					response.version !== AUTH_GATEWAY_POLICY_PROTOCOL_VERSION ||
+					response.type !== "observe_ack" ||
+					response.ack !== true
+				) {
+					throw new Error("Gateway policy socket returned an invalid observation acknowledgement");
+				}
+			});
+			const result = exchange.then(
+				() => {
+					if (final) closeSession(observation.requestId, session);
+				},
+				error => {
+					closeSession(observation.requestId, session);
+					throw error;
+				},
+			);
+			session.tail = result.catch(() => {});
+			return result;
+		},
+		probe: async signal => {
+			const connection = new PolicySocketConnection(socketPath, timeoutMs);
+			try {
+				const response = await connection.exchange(
+					{
+						version: AUTH_GATEWAY_POLICY_PROTOCOL_VERSION,
+						type: "probe",
+					},
+					maxFrameBytes,
+					signal,
+				);
+				if (
+					!hasExactKeys(response, ["version", "type", "ack"]) ||
+					response.version !== AUTH_GATEWAY_POLICY_PROTOCOL_VERSION ||
+					response.type !== "probe_ack" ||
+					response.ack !== true
+				) {
+					throw new Error("Gateway policy socket returned an invalid readiness acknowledgement");
+				}
+				return true;
+			} finally {
+				connection.close();
+			}
+		},
+	};
+}
+
+export interface AuthGatewayPolicyReadinessProbeOptions {
+	cacheMs?: number;
+	now?: () => number;
+}
+
+interface InFlightPolicyReadinessProbe {
+	promise: Promise<boolean>;
+}
+
+export function createAuthGatewayPolicyReadinessProbe(
+	client: AuthGatewayPolicySocketClient,
+	options: AuthGatewayPolicyReadinessProbeOptions = {},
+): (signal?: AbortSignal) => Promise<boolean> {
+	const cacheMs = options.cacheMs ?? 250;
+	const now = options.now ?? Date.now;
+	validatePositiveBoundedInteger(cacheMs, 10_000, "Policy readiness cache");
+	let cached = false;
+	let cacheExpiresAt = 0;
+	let inFlight: InFlightPolicyReadinessProbe | undefined;
+
+	const startProbe = (): InFlightPolicyReadinessProbe => {
+		// The shared probe has its own lifetime: HTTP caller cancellation stops
+		// only that caller's wait and cannot bypass or poison the readiness cache.
+		const probeSignal = new AbortController().signal;
+		const probe = client.probe(probeSignal).then(
+			result => {
+				cached = result;
+				cacheExpiresAt = now() + cacheMs;
+				return result;
+			},
+			() => {
+				cached = false;
+				cacheExpiresAt = now() + cacheMs;
+				return false;
+			},
+		);
+		const state: InFlightPolicyReadinessProbe = { promise: probe };
+		state.promise = probe.finally(() => {
+			if (inFlight === state) inFlight = undefined;
+		});
+		inFlight = state;
+		return state;
+	};
+
+	const waitForProbe = (state: InFlightPolicyReadinessProbe, signal?: AbortSignal): Promise<boolean> => {
+		const deferred = Promise.withResolvers<boolean>();
+		let settled = false;
+		const finish = (result: boolean): void => {
+			if (settled) return;
+			settled = true;
+			signal?.removeEventListener("abort", onAbort);
+			deferred.resolve(result);
+		};
+		const onAbort = (): void => finish(false);
+		if (signal?.aborted) {
+			finish(false);
+		} else {
+			signal?.addEventListener("abort", onAbort, { once: true });
+			void state.promise.then(finish);
+		}
+		return deferred.promise;
+	};
+
+	return signal => {
+		if (now() < cacheExpiresAt) return Promise.resolve(cached);
+		return waitForProbe(inFlight ?? startProbe(), signal);
+	};
+}
 
 function getTokenFilePath(): string {
 	return path.join(getConfigRootDir(), "auth-gateway.token");
@@ -169,6 +650,8 @@ export function indexModelsByRequestId(
 }
 
 async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
+	const policyClient = flags.policySocket ? createAuthGatewayPolicySocketClient(flags.policySocket) : undefined;
+	const policyReadinessProbe = policyClient ? createAuthGatewayPolicyReadinessProbe(policyClient) : undefined;
 	const brokerConfig = await resolveAuthBrokerConfig();
 	if (!brokerConfig) {
 		throw new Error(
@@ -222,6 +705,13 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 		version: VERSION,
 		resolveModel: (id: string) => modelById.get(id),
 		listModels: () => modelById.values(),
+		...(policyClient && policyReadinessProbe
+			? {
+					authorizeRequest: policyClient.authorizeRequest,
+					observer: policyClient.observe,
+					readinessProbe: policyReadinessProbe,
+				}
+			: {}),
 	});
 	process.stdout.write(`auth-gateway listening on ${handle.url}\n`);
 	if (gatewayToken) {
@@ -387,6 +877,12 @@ async function runStatus(flags: AuthGatewayCommandArgs["flags"]): Promise<void> 
 }
 
 export async function runAuthGatewayCommand(cmd: AuthGatewayCommandArgs): Promise<void> {
+	if (cmd.flags.policySocket !== undefined) {
+		validateAuthGatewayPolicySocketPath(cmd.flags.policySocket);
+		if (cmd.action !== "serve") {
+			throw new Error("--policy-socket is only valid with `auth-gateway serve`");
+		}
+	}
 	switch (cmd.action) {
 		case "serve":
 			await runServe(cmd.flags);

--- a/packages/coding-agent/src/commands/auth-gateway.ts
+++ b/packages/coding-agent/src/commands/auth-gateway.ts
@@ -25,6 +25,9 @@ export default class AuthGateway extends Command {
 	static flags = {
 		json: Flags.boolean({ description: "Output JSON (token/status/check)" }),
 		bind: Flags.string({ description: "Bind address for `serve` (host:port)", char: "b" }),
+		"policy-socket": Flags.string({
+			description: "Opt into fail-closed gateway policy authorization over an absolute Unix socket path",
+		}),
 		regenerate: Flags.boolean({ description: "Regenerate the gateway bearer token (token)" }),
 		"no-auth": Flags.boolean({
 			description:
@@ -59,6 +62,7 @@ export default class AuthGateway extends Command {
 			flags: {
 				json: flags.json,
 				bind: flags.bind,
+				policySocket: flags["policy-socket"],
 				regenerate: flags.regenerate,
 				noAuth: flags["no-auth"],
 				strict: flags.strict,

--- a/packages/coding-agent/test/cli/auth-gateway-policy-socket.test.ts
+++ b/packages/coding-agent/test/cli/auth-gateway-policy-socket.test.ts
@@ -1,0 +1,575 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import * as path from "node:path";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import {
+	AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER,
+	type AuthGatewayAuthorizationRequest,
+	type AuthGatewayObservation,
+	startAuthGateway,
+} from "@oh-my-pi/pi-ai/auth-gateway";
+import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import {
+	type AuthGatewayPolicySocketClient,
+	createAuthGatewayPolicyReadinessProbe,
+	createAuthGatewayPolicySocketClient,
+	runAuthGatewayCommand,
+	validateAuthGatewayPolicySocketPath,
+} from "../../src/cli/auth-gateway-cli";
+
+type PolicyRequestHandler = (request: unknown, raw: string, socket: net.Socket) => void;
+
+async function createSocketDir(): Promise<string> {
+	return await fs.mkdtemp(path.join("/tmp", "omp-gateway-policy-"));
+}
+
+async function listenPolicyServer(socketPath: string, handler: PolicyRequestHandler): Promise<net.Server> {
+	await fs.rm(socketPath, { force: true });
+	const server = net.createServer(socket => {
+		let bytes = Buffer.alloc(0);
+		socket.on("data", chunk => {
+			bytes = Buffer.concat([bytes, typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk]);
+			for (;;) {
+				const newline = bytes.indexOf(0x0a);
+				if (newline === -1) return;
+				const raw = bytes.subarray(0, newline).toString("utf8");
+				bytes = bytes.subarray(newline + 1);
+				handler(JSON.parse(raw), raw, socket);
+			}
+		});
+	});
+	const listening = Promise.withResolvers<void>();
+	server.once("error", listening.reject);
+	server.listen(socketPath, () => {
+		server.off("error", listening.reject);
+		listening.resolve();
+	});
+	await listening.promise;
+	return server;
+}
+
+async function closePolicyServer(server: net.Server): Promise<void> {
+	const closed = Promise.withResolvers<void>();
+	server.close(error => {
+		if (error) closed.reject(error);
+		else closed.resolve();
+	});
+	await closed.promise;
+}
+
+function writeJson(socket: net.Socket, value: unknown): void {
+	socket.write(`${JSON.stringify(value)}\n`);
+}
+
+function authorizationRequest(secret: string): AuthGatewayAuthorizationRequest {
+	return {
+		requestId: "request-1",
+		format: "openai-chat",
+		requestedModelId: "mock/requested",
+		requestedSessionId: "caller-hint",
+		method: "POST",
+		path: "/v1/chat/completions",
+		payloadByteLength: 321,
+		payloadSha256: "a".repeat(64),
+		authorization: secret,
+		signal: new AbortController().signal,
+	};
+}
+
+const OBSERVATION: AuthGatewayObservation = {
+	type: "authorization",
+	requestId: "request-1",
+	format: "openai-chat",
+	requestedModelId: "mock/requested",
+	outcome: "authorized",
+	authorizationId: "authorization-1",
+	resolvedModelId: "mock/resolved",
+	sessionId: "workspace:session",
+};
+
+const TERMINAL_OBSERVATION: AuthGatewayObservation = {
+	type: "terminal",
+	requestId: "request-1",
+	format: "openai-chat",
+	authorizationId: "authorization-1",
+	requestedModelId: "mock/requested",
+	resolvedModelId: "mock/resolved",
+	sessionId: "workspace:session",
+	outcome: "success",
+};
+
+describe("auth-gateway policy socket", () => {
+	test("reuses one request-scoped connection for authorization and acknowledged secret-free observations", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		const rawFrames: string[] = [];
+		const types: string[] = [];
+		const connections = new Set<net.Socket>();
+		const server = await listenPolicyServer(socketPath, (value, raw, socket) => {
+			connections.add(socket);
+			const envelope = value as Record<string, unknown>;
+			rawFrames.push(raw);
+			types.push(String(envelope.type));
+			if (envelope.type === "authorize") {
+				writeJson(socket, {
+					version: 1,
+					type: "authorize_result",
+					decision: {
+						authorized: true,
+						authorizationId: "authorization-1",
+						requestedModelId: "mock/requested",
+						resolvedModelId: "mock/resolved",
+						sessionId: "workspace:session",
+						allowedOAuthCredentialIds: [7, 3],
+					},
+				});
+				return;
+			}
+			if (envelope.type === "observe") {
+				writeJson(socket, { version: 1, type: "observe_ack", ack: true });
+				return;
+			}
+			writeJson(socket, { version: 1, type: "probe_ack", ack: true });
+		});
+
+		try {
+			const secret = "synthetic-one-time-authorization-value";
+			const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 100 });
+			const decision = await client.authorizeRequest(authorizationRequest(secret));
+			expect(decision).toEqual({
+				authorized: true,
+				authorizationId: "authorization-1",
+				requestedModelId: "mock/requested",
+				resolvedModelId: "mock/resolved",
+				sessionId: "workspace:session",
+				allowedOAuthCredentialIds: [7, 3],
+			});
+			await client.observe(OBSERVATION);
+			await client.observe(TERMINAL_OBSERVATION);
+			expect(await client.probe()).toBe(true);
+
+			expect(types).toEqual(["authorize", "observe", "observe", "probe"]);
+			expect(connections.size).toBe(2);
+			expect(JSON.parse(rawFrames[0] ?? "null")).toEqual({
+				version: 1,
+				type: "authorize",
+				request: {
+					requestId: "request-1",
+					format: "openai-chat",
+					requestedModelId: "mock/requested",
+					requestedSessionId: "caller-hint",
+					method: "POST",
+					path: "/v1/chat/completions",
+					payloadByteLength: 321,
+					payloadSha256: "a".repeat(64),
+					authorization: secret,
+				},
+			});
+			expect(rawFrames.slice(1).join("\n")).not.toContain(secret);
+			expect(rawFrames.join("\n").split(secret)).toHaveLength(2);
+		} finally {
+			await closePolicyServer(server);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects unknown decision fields and fails observation delivery without the exact acknowledgement", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		let authorizationCount = 0;
+		const server = await listenPolicyServer(socketPath, (value, _raw, socket) => {
+			const envelope = value as Record<string, unknown>;
+			if (envelope.type === "authorize") {
+				authorizationCount++;
+				writeJson(socket, {
+					version: 1,
+					type: "authorize_result",
+					decision:
+						authorizationCount === 1
+							? { authorized: false, reasonCode: "denied", unknown: true }
+							: {
+									authorized: true,
+									authorizationId: "authorization-1",
+									requestedModelId: "mock/requested",
+									resolvedModelId: "mock/resolved",
+									sessionId: "workspace:session",
+									allowedOAuthCredentialIds: [7],
+								},
+				});
+				return;
+			}
+			writeJson(socket, { version: 1, type: "observe_ack", ack: false });
+		});
+		try {
+			const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 100 });
+			await expect(client.authorizeRequest(authorizationRequest("one-time-secret"))).rejects.toThrow(
+				"invalid authorization decision",
+			);
+			await client.authorizeRequest(authorizationRequest("valid-second-authorization"));
+			await expect(client.observe(OBSERVATION)).rejects.toThrow("invalid observation acknowledgement");
+		} finally {
+			await closePolicyServer(server);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects unknown, oversized, malformed, timed-out, EOF, and unavailable responses", async () => {
+		const cases: Array<{
+			name: string;
+			handler?: PolicyRequestHandler;
+			error: string;
+			maxFrameBytes?: number;
+		}> = [
+			{
+				name: "unknown field",
+				handler: (_value, _raw, socket) => {
+					writeJson(socket, { version: 1, type: "probe_ack", ack: true, extra: true });
+				},
+				error: "invalid readiness acknowledgement",
+			},
+			{
+				name: "oversized",
+				handler: (_value, _raw, socket) => {
+					socket.write("x".repeat(128));
+				},
+				error: "exceeds the frame limit",
+				maxFrameBytes: 64,
+			},
+			{
+				name: "malformed",
+				handler: (_value, _raw, socket) => {
+					socket.write("not-json\n");
+				},
+				error: "malformed JSON",
+			},
+			{
+				name: "timeout",
+				handler: () => {},
+				error: "timed out",
+			},
+			{
+				name: "EOF",
+				handler: (_value, _raw, socket) => {
+					socket.end('{"version":1');
+				},
+				error: "closed before a complete response",
+			},
+		];
+
+		for (const testCase of cases) {
+			const dir = await createSocketDir();
+			const socketPath = path.join(dir, "policy.sock");
+			const server = await listenPolicyServer(socketPath, testCase.handler ?? (() => {}));
+			try {
+				const client = createAuthGatewayPolicySocketClient(socketPath, {
+					timeoutMs: 30,
+					...(testCase.maxFrameBytes === undefined ? {} : { maxFrameBytes: testCase.maxFrameBytes }),
+				});
+				await expect(client.probe()).rejects.toThrow(testCase.error);
+			} finally {
+				await closePolicyServer(server);
+				await fs.rm(dir, { recursive: true, force: true });
+			}
+		}
+
+		const dir = await createSocketDir();
+		try {
+			const client = createAuthGatewayPolicySocketClient(path.join(dir, "missing.sock"), { timeoutMs: 30 });
+			await expect(client.probe()).rejects.toThrow("ENOENT");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("enforces the filesystem trust anchor without claiming unavailable peer credentials", async () => {
+		const dir = await createSocketDir();
+		const regularPath = path.join(dir, "regular");
+		const realSocketPath = path.join(dir, "real.sock");
+		const symlinkPath = path.join(dir, "linked.sock");
+		await fs.writeFile(regularPath, "not a socket");
+		const realServer = await listenPolicyServer(realSocketPath, (_value, _raw, socket) => {
+			writeJson(socket, { version: 1, type: "probe_ack", ack: true });
+		});
+		await fs.symlink(realSocketPath, symlinkPath);
+		try {
+			const effectiveUid = process.geteuid?.();
+			if (effectiveUid === undefined) throw new Error("expected effective user ID on Unix");
+			expect((await fs.lstat(realSocketPath)).uid).toBe(effectiveUid);
+			expect(await createAuthGatewayPolicySocketClient(realSocketPath).probe()).toBe(true);
+			await expect(createAuthGatewayPolicySocketClient(regularPath).probe()).rejects.toThrow(
+				"must name a Unix socket",
+			);
+			await expect(createAuthGatewayPolicySocketClient(symlinkPath).probe()).rejects.toThrow("not a symlink");
+		} finally {
+			await closePolicyServer(realServer);
+		}
+
+		const unsafeDir = path.join(dir, "unsafe");
+		await fs.mkdir(unsafeDir);
+		await fs.chmod(unsafeDir, 0o777);
+		const unsafeSocketPath = path.join(unsafeDir, "policy.sock");
+		const unsafeServer = await listenPolicyServer(unsafeSocketPath, (_value, _raw, socket) => {
+			writeJson(socket, { version: 1, type: "probe_ack", ack: true });
+		});
+		try {
+			await expect(createAuthGatewayPolicySocketClient(unsafeSocketPath).probe()).rejects.toThrow(
+				"unsafe writable directory",
+			);
+		} finally {
+			await closePolicyServer(unsafeServer);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("aborts an in-flight authorization exchange and closes its connection", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		const received = Promise.withResolvers<void>();
+		const connectionClosed = Promise.withResolvers<void>();
+		const server = await listenPolicyServer(socketPath, (_value, _raw, socket) => {
+			socket.once("close", () => connectionClosed.resolve());
+			received.resolve();
+		});
+		try {
+			const controller = new AbortController();
+			const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 1_000 });
+			const pending = client.authorizeRequest({
+				...authorizationRequest("abort-only-secret"),
+				signal: controller.signal,
+			});
+			await received.promise;
+			controller.abort();
+			await expect(pending).rejects.toThrow("exchange aborted");
+			await connectionClosed.promise;
+		} finally {
+			await closePolicyServer(server);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("settles and closes every post-grant cancellation window exactly once", async () => {
+		for (const phase of ["preflight", "credential", "upstream"] as const) {
+			registerMockApi();
+			const dir = await createSocketDir();
+			const socketPath = path.join(dir, "policy.sock");
+			const phaseEntered = Promise.withResolvers<void>();
+			const phaseRelease = Promise.withResolvers<void>();
+			const terminalArrived = Promise.withResolvers<AuthGatewayObservation>();
+			const sessionClosed = Promise.withResolvers<void>();
+			const observations: AuthGatewayObservation[] = [];
+			const policyServer = await listenPolicyServer(socketPath, (value, _raw, socket) => {
+				const envelope = value as Record<string, unknown>;
+				if (envelope.type === "authorize") {
+					socket.once("close", () => sessionClosed.resolve());
+					writeJson(socket, {
+						version: 1,
+						type: "authorize_result",
+						decision: {
+							authorized: true,
+							authorizationId: `authorization-${phase}`,
+							requestedModelId: "cancel-model",
+							resolvedModelId: "cancel-model",
+							sessionId: `workspace:${phase}`,
+							allowedOAuthCredentialIds: [7],
+						},
+					});
+					return;
+				}
+				if (envelope.type !== "observe") return;
+				const observationValue = envelope.observation;
+				if (
+					!observationValue ||
+					typeof observationValue !== "object" ||
+					!("type" in observationValue) ||
+					typeof observationValue.type !== "string"
+				) {
+					throw new Error("expected policy observation frame");
+				}
+				const observation = observationValue as AuthGatewayObservation;
+				observations.push(observation);
+				if (phase === "preflight" && observation.type === "authorization") {
+					phaseEntered.resolve();
+					void phaseRelease.promise.then(() => writeJson(socket, { version: 1, type: "observe_ack", ack: true }));
+					return;
+				}
+				writeJson(socket, { version: 1, type: "observe_ack", ack: true });
+				if (observation.type === "terminal") terminalArrived.resolve(observation);
+			});
+			const storage = {
+				getOAuthApiKeyFromCredentialIds: async () => {
+					if (phase === "credential") {
+						phaseEntered.resolve();
+						await phaseRelease.promise;
+					}
+					return { apiKey: "authorized-key", credentialId: 7 };
+				},
+			} as unknown as AuthStorage;
+			const mock = createMockModel({
+				provider: "mock",
+				id: "cancel-model",
+				handler: async () => {
+					if (phase === "upstream") {
+						phaseEntered.resolve();
+						await phaseRelease.promise;
+					}
+					return { content: ["cancelled output"] };
+				},
+			});
+			const policyClient = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 1_000 });
+			const gateway = startAuthGateway({
+				bind: "127.0.0.1:0",
+				bearerTokens: [],
+				storage,
+				authorizeRequest: policyClient.authorizeRequest,
+				observer: policyClient.observe,
+				readinessProbe: createAuthGatewayPolicyReadinessProbe(policyClient),
+				resolveModel: () => mock,
+			});
+			try {
+				const controller = new AbortController();
+				const request = fetch(`${gateway.url}/v1/chat/completions`, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						[AUTH_GATEWAY_POLICY_AUTHORIZATION_HEADER]: "one-time-cancel-authorization",
+					},
+					body: JSON.stringify({
+						model: "cancel-model",
+						messages: [{ role: "user", content: "cancel me" }],
+						stream: false,
+					}),
+					signal: controller.signal,
+				}).catch(() => undefined);
+				await phaseEntered.promise;
+				controller.abort();
+				phaseRelease.resolve();
+				await request;
+				const terminal = await terminalArrived.promise;
+				await sessionClosed.promise;
+				expect(terminal.type).toBe("terminal");
+				if (terminal.type !== "terminal") throw new Error("expected terminal observation");
+				// Client cancellation and server completion race after the request
+				// reaches the gateway; either terminal outcome is valid, but the
+				// policy session must still settle exactly once.
+				expect(["aborted", "success"]).toContain(terminal.outcome);
+				expect(observations.filter(observation => observation.type === "terminal")).toHaveLength(1);
+			} finally {
+				await gateway.close();
+				await closePolicyServer(policyServer);
+				await fs.rm(dir, { recursive: true, force: true });
+				clearCustomApis();
+			}
+		}
+	});
+
+	test("lets callers stop waiting while one shared readiness probe finishes and populates the cache", async () => {
+		const probeStarted = Promise.withResolvers<AbortSignal>();
+		const probeResult = Promise.withResolvers<boolean>();
+		let probeCalls = 0;
+		const client = {
+			probe: (signal?: AbortSignal): Promise<boolean> => {
+				if (!signal) return Promise.reject(new Error("expected readiness signal"));
+				probeCalls++;
+				probeStarted.resolve(signal);
+				return probeResult.promise;
+			},
+		} as AuthGatewayPolicySocketClient;
+		const readiness = createAuthGatewayPolicyReadinessProbe(client);
+		const controller = new AbortController();
+		const cancelledWait = readiness(controller.signal);
+		const sharedSignal = await probeStarted.promise;
+		controller.abort();
+		expect(await cancelledWait).toBe(false);
+		expect(sharedSignal.aborted).toBe(false);
+
+		const nextWait = readiness();
+		expect(probeCalls).toBe(1);
+		probeResult.resolve(true);
+		expect(await nextWait).toBe(true);
+		expect(await readiness()).toBe(true);
+		expect(probeCalls).toBe(1);
+	});
+
+	test("tracks readiness across malformed acknowledgements, recovery, and outage", async () => {
+		const dir = await createSocketDir();
+		const socketPath = path.join(dir, "policy.sock");
+		let now = 0;
+		const client = createAuthGatewayPolicySocketClient(socketPath, { timeoutMs: 250 });
+		const gateway = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: [],
+			storage: {} as AuthStorage,
+			resolveModel: () => undefined,
+			authorizeRequest: client.authorizeRequest,
+			observer: client.observe,
+			readinessProbe: createAuthGatewayPolicyReadinessProbe(client, { cacheMs: 250, now: () => now }),
+			version: "policy-test",
+		});
+		let policyServer: net.Server | undefined;
+		try {
+			let response = await fetch(`${gateway.url}/healthz`);
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ ok: false, version: "policy-test" });
+			now = 251;
+
+			let validAck = false;
+			let probeCount = 0;
+			policyServer = await listenPolicyServer(socketPath, (_value, _raw, socket) => {
+				probeCount++;
+				writeJson(
+					socket,
+					validAck
+						? { version: 1, type: "probe_ack", ack: true }
+						: { version: 1, type: "probe_ack", ack: true, unknown: true },
+				);
+			});
+			response = await fetch(`${gateway.url}/healthz`);
+			expect(response.status).toBe(503);
+			expect(probeCount).toBe(1);
+
+			validAck = true;
+			now = 502;
+			const responses = await Promise.all(Array.from({ length: 8 }, () => fetch(`${gateway.url}/healthz`)));
+			expect(responses.every(item => item.status === 200)).toBe(true);
+			response = responses[0]!;
+			expect(probeCount).toBe(2);
+			expect((await fetch(`${gateway.url}/healthz`)).status).toBe(200);
+			expect(probeCount).toBe(2);
+			expect(await response.json()).toEqual({ ok: true, version: "policy-test" });
+			expect((await fetch(`${gateway.url}/v1/models`)).status).toBe(403);
+
+			await closePolicyServer(policyServer);
+			policyServer = undefined;
+		} finally {
+			if (policyServer) await closePolicyServer(policyServer);
+			await gateway.close();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("validates launch-only socket paths and leaves legacy readiness unchanged", async () => {
+		expect(() => validateAuthGatewayPolicySocketPath("")).toThrow("non-empty absolute path");
+		expect(() => validateAuthGatewayPolicySocketPath("relative.sock")).toThrow("non-empty absolute path");
+		expect(() => validateAuthGatewayPolicySocketPath("/tmp/policy\0.sock")).toThrow("without NUL bytes");
+		await expect(
+			runAuthGatewayCommand({ action: "status", flags: { policySocket: "/tmp/policy.sock" } }),
+		).rejects.toThrow("only valid with `auth-gateway serve`");
+
+		const gateway = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: [],
+			storage: {} as AuthStorage,
+			resolveModel: () => undefined,
+			version: "legacy-test",
+		});
+		try {
+			const response = await fetch(`${gateway.url}/healthz`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ ok: true, version: "legacy-test" });
+		} finally {
+			await gateway.close();
+		}
+	});
+});


### PR DESCRIPTION
## Problem
Sandboxed runtimes need to use the existing multi-account OAuth store without receiving credentials or choosing arbitrary stored accounts. The current auth gateway resolves credentials before any external controller authorization and has no fail-closed observation seam.

## Changes
- Add opt-in pre-credential authorization and content-free observation hooks.
- Bind authorization to the exact request method, path, model/role/session selector, received payload byte length, and SHA-256.
- Restrict lookup, refresh, quota rotation, and retries to one exact ordered OAuth row allowlist.
- Strip caller-controlled provider headers and identity/session handles; replace cache/session identity with the grant namespace.
- Add a bounded, request-scoped NDJSON Unix policy client with strict framing, explicit readiness, socket ownership/mode/path validation, cancellation, and terminal cleanup.
- Preserve native CLI auth-gateway behavior when policy mode is absent.
- Document the private auth-broker/policy contract without adding credentials, endpoints, or host bindings.

## Verification
Exact head: `285c505f858d97f9e45af153638fb0916e403a9c`

- 20 focused auth-gateway/policy tests passed.
- Coding-agent and AI TypeScript checks passed.
- `git diff --check` passed.
- Gitleaks scanned the exact outgoing commits: no leaks.
- Independent exact-head correctness review: correct, no findings.
- Independent exact-head security review: no blocking findings; six low/informational advisories recorded.
- Upstream CI: every code check passed; release-only jobs skipped as expected.

This is an opt-in client seam. It does not implement or deploy the trusted controller/server, open a listener, provide credentials, bind a host endpoint, or enable remote behavior by default.