### PR TITLE
feat(coding-agent): add sealed remote runtime mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an explicit opt-in `--remote-runtime-config` Unix-socket transport for structured subagents, remote registry lifecycle, peer messaging, and Hub operations. This exposes a versioned runtime/source-reference integration seam only; it does not make Oh My Pi a Juiz production authority, ship controller credentials or endpoints, or enable remote execution by default.
+
 ## [17.3.6] - 2026-08-17
 
 ### Added

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -32,6 +32,8 @@ export interface Args {
 	provider?: string;
 	model?: string;
 	config?: string[];
+	/** Absolute path to one immutable sealed-runtime authority descriptor. */
+	remoteRuntimeConfig?: string;
 	smol?: string;
 	slow?: string;
 	plan?: string;

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -117,6 +117,9 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--config": (result, value) => {
 		result.config = [...(result.config ?? []), value];
 	},
+	"--remote-runtime-config": (result, value) => {
+		result.remoteRuntimeConfig = value;
+	},
 	"--add-dir": (result, value) => {
 		result.addDir = [...(result.addDir ?? []), value];
 	},

--- a/packages/coding-agent/src/commands/acp.ts
+++ b/packages/coding-agent/src/commands/acp.ts
@@ -10,6 +10,7 @@ import { type Args as ParsedArgs, parseArgs, reportCliUsageError } from "../cli/
 import { acpHelp as commandHelp } from "../cli/command-help";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
+import { runWithRemoteRuntimeConfig } from "../remote-runtime/bootstrap";
 
 export default class Acp extends Command {
 	static description = commandHelp.description;
@@ -29,6 +30,10 @@ export default class Acp extends Command {
 		}
 		if (!terminalAuth) {
 			parsed.mode = "acp";
+		}
+		if (parsed.remoteRuntimeConfig) {
+			await runWithRemoteRuntimeConfig(parsed.remoteRuntimeConfig, () => runRootCommand(parsed, args));
+			return;
 		}
 		await runRootCommand(parsed, args);
 	}

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -47,6 +47,9 @@ export const launchHelp = {
 			description: "Load an extra config.yml-style overlay for this run (repeatable)",
 			multiple: true,
 		}),
+		"remote-runtime-config": Flags.string({
+			description: "Use a sealed remote runtime authority descriptor (absolute JSON file path)",
+		}),
 		"add-dir": Flags.string({
 			description: "Add a workspace directory beyond the working directory (repeatable)",
 			multiple: true,

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -6,6 +6,7 @@ import { Command } from "@oh-my-pi/pi-utils/cli";
 import { type Args as ParsedArgs, parseArgs, reportCliUsageError } from "../cli/args";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
+import { runWithRemoteRuntimeConfig } from "../remote-runtime/bootstrap";
 import { launchHelp } from "./launch-help";
 
 export default class Index extends Command {
@@ -28,6 +29,10 @@ export default class Index extends Command {
 				return;
 			}
 			throw error;
+		}
+		if (parsed.remoteRuntimeConfig) {
+			await runWithRemoteRuntimeConfig(parsed.remoteRuntimeConfig, () => runRootCommand(parsed, args));
+			return;
 		}
 		await runRootCommand(parsed, args);
 	}

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -17,7 +17,8 @@
 
 import { logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
-import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import { type AgentRef, AgentRegistry, MAIN_AGENT_ID, type RemoteAgentIdentity } from "../registry/agent-registry";
+import { currentRemoteRuntime } from "../remote-runtime/scope";
 import type { CustomMessage } from "../session/messages";
 
 export interface IrcMessage {
@@ -34,8 +35,47 @@ export interface IrcMessage {
 
 export interface IrcDeliveryReceipt {
 	to: string;
-	outcome: "injected" | "woken" | "revived" | "failed";
+	outcome: "injected" | "woken" | "revived" | "remote" | "failed";
 	error?: string;
+}
+
+export type PeerExecutionIdentity =
+	| { locality: "local"; agentId: string; generation: number }
+	| ({
+			locality: "remote";
+			agentId: string;
+	  } & RemoteAgentIdentity);
+
+export interface PeerTransportPayload {
+	body: string;
+	replyTo?: string;
+}
+
+export interface PeerTransportDelivery {
+	deliveryId: string;
+	sequence: number;
+	kind: "message";
+	sender: PeerExecutionIdentity;
+	recipient: PeerExecutionIdentity;
+	payload: PeerTransportPayload;
+}
+
+export interface PeerTransportResult {
+	deliveryId: string;
+	sequence: number;
+	sender: PeerExecutionIdentity;
+	recipient: PeerExecutionIdentity;
+	outcome: "accepted" | "rejected" | "duplicate" | "conflict";
+	error?: string;
+}
+
+/**
+ * Trusted transport adapter. Endpoint and capability material is captured by
+ * the implementation and is deliberately absent from every delivery payload.
+ */
+export interface PeerTransportBackend {
+	deliver(delivery: Readonly<PeerTransportDelivery>, signal?: AbortSignal): Promise<PeerTransportResult>;
+	cancel(delivery: Readonly<PeerTransportDelivery>): Promise<void>;
 }
 
 interface IrcWaiter {
@@ -66,12 +106,19 @@ export class IrcBus {
 	readonly #lifecycle: () => AgentLifecycleManager;
 	readonly #mailboxes = new Map<string, IrcMessage[]>();
 	readonly #waiters = new Map<string, IrcWaiter[]>();
+	readonly #transportSequences = new WeakMap<AgentRef, number>();
+	readonly #peerTransport: PeerTransportBackend | undefined;
 
-	constructor(registry: AgentRegistry = AgentRegistry.global(), lifecycle?: AgentLifecycleManager) {
+	constructor(
+		registry: AgentRegistry = AgentRegistry.global(),
+		lifecycle?: AgentLifecycleManager,
+		peerTransport?: PeerTransportBackend,
+	) {
 		this.#registry = registry;
 		// Lazy: the lifecycle global self-constructs against the global registry,
 		// so only touch it when a parked recipient actually needs reviving.
 		this.#lifecycle = () => lifecycle ?? AgentLifecycleManager.global();
+		this.#peerTransport = peerTransport;
 	}
 
 	/**
@@ -100,7 +147,7 @@ export class IrcBus {
 	 */
 	async send(
 		msg: Omit<IrcMessage, "id" | "ts">,
-		opts?: { expectsReply?: boolean; suppressRelay?: boolean },
+		opts?: { expectsReply?: boolean; suppressRelay?: boolean; signal?: AbortSignal },
 	): Promise<IrcDeliveryReceipt> {
 		const message: IrcMessage = { ...msg, id: Snowflake.next(), ts: Date.now() };
 		const ref = this.#registry.get(message.to);
@@ -125,6 +172,24 @@ export class IrcBus {
 				outcome: "failed",
 				error: `Agent "${message.to}" is a read-only advisor transcript and cannot be messaged.`,
 			};
+		}
+		const senderRef = this.#registry.get(message.from);
+		if (ref.locality === "remote" || senderRef?.locality === "remote") {
+			if (!senderRef) {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: `Unknown sender agent "${message.from}" for remote delivery.`,
+				};
+			}
+			if (senderRef.status === "aborted") {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: `Sender agent "${message.from}" was hard-aborted.`,
+				};
+			}
+			return this.#sendRemote(message, senderRef, ref, opts?.signal);
 		}
 
 		// A `parked` recipient always needs the lifecycle to revive it — this is
@@ -276,7 +341,9 @@ export class IrcBus {
 		if (liveness) {
 			const { registry, senderId } = liveness;
 			const hasRunningSender = (from?: string): boolean =>
-				registry.listVisibleTo(senderId).some(ref => registry.isRunning(ref) && (!from || ref.id === from));
+				registry
+					.listVisibleTo(senderId)
+					.some(ref => ref.locality !== "remote" && registry.isRunning(ref) && (!from || ref.id === from));
 			const check = filter.from ? () => hasRunningSender(filter.from) : () => hasRunningSender();
 			unsubscribeLiveness = registry.onChange(() => {
 				if (!check()) {
@@ -290,6 +357,10 @@ export class IrcBus {
 
 		return promise;
 	}
+	/** Consume the oldest already-buffered message without parking a future waiter. */
+	takePending(agentId: string, from?: string): IrcMessage | undefined {
+		return this.#takeFromMailbox(agentId, from);
+	}
 
 	/** Drain (or peek) pending messages for `agentId`. */
 	inbox(agentId: string, opts?: { peek?: boolean }): IrcMessage[] {
@@ -302,6 +373,127 @@ export class IrcBus {
 
 	unreadCount(agentId: string): number {
 		return this.#mailboxes.get(agentId)?.length ?? 0;
+	}
+
+	#executionIdentity(ref: AgentRef): PeerExecutionIdentity | undefined {
+		if (ref.locality === "remote") {
+			return Object.freeze({
+				locality: "remote",
+				agentId: ref.id,
+				controllerId: ref.remote.controllerId,
+				executionId: ref.remote.executionId,
+				generation: ref.remote.generation,
+			});
+		}
+		if (!Number.isSafeInteger(ref.generation) || (ref.generation ?? 0) <= 0) return undefined;
+		return Object.freeze({ locality: "local", agentId: ref.id, generation: ref.generation as number });
+	}
+
+	#sameExecution(left: PeerExecutionIdentity, right: PeerExecutionIdentity): boolean {
+		if (left.locality !== right.locality || left.agentId !== right.agentId || left.generation !== right.generation)
+			return false;
+		return (
+			left.locality === "local" ||
+			(right.locality === "remote" &&
+				left.controllerId === right.controllerId &&
+				left.executionId === right.executionId)
+		);
+	}
+
+	async #sendRemote(
+		message: IrcMessage,
+		senderRef: AgentRef,
+		recipientRef: AgentRef,
+		signal?: AbortSignal,
+	): Promise<IrcDeliveryReceipt> {
+		const transport = currentRemoteRuntime()?.peerTransport ?? this.#peerTransport;
+		if (!transport) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: `Remote peer transport is unavailable for "${message.to}".`,
+			};
+		}
+		if (Buffer.byteLength(message.body) > 131_072 || Buffer.byteLength(message.replyTo ?? "") > 256) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: "Remote peer message exceeds the transport bounds.",
+			};
+		}
+		const sender = this.#executionIdentity(senderRef);
+		const recipient = this.#executionIdentity(recipientRef);
+		if (!sender || !recipient) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: "Remote peer delivery requires generation-bound local execution identities.",
+			};
+		}
+		if (signal?.aborted) {
+			return { to: message.to, outcome: "failed", error: "Remote peer delivery was cancelled." };
+		}
+		const sequence = (this.#transportSequences.get(senderRef) ?? 0) + 1;
+		this.#transportSequences.set(senderRef, sequence);
+		const payload = Object.freeze({
+			body: message.body,
+			...(message.replyTo ? { replyTo: message.replyTo } : {}),
+		});
+		const delivery = Object.freeze({
+			deliveryId: message.id,
+			sequence,
+			kind: "message" as const,
+			sender,
+			recipient,
+			payload,
+		});
+		let removeAbort: (() => void) | undefined;
+		if (signal) {
+			const cancel = (): void => {
+				void transport.cancel(delivery).catch(() => {
+					logger.debug("IrcBus: remote delivery cancellation failed", {
+						deliveryId: delivery.deliveryId,
+					});
+				});
+			};
+			signal.addEventListener("abort", cancel, { once: true });
+			removeAbort = () => signal.removeEventListener("abort", cancel);
+		}
+		try {
+			const result = await transport.deliver(delivery, signal);
+			if (
+				!result ||
+				typeof result !== "object" ||
+				result.deliveryId !== delivery.deliveryId ||
+				result.sequence !== delivery.sequence ||
+				!this.#sameExecution(result.sender, delivery.sender) ||
+				!this.#sameExecution(result.recipient, delivery.recipient) ||
+				!["accepted", "rejected", "duplicate", "conflict"].includes(result.outcome) ||
+				(result.error !== undefined && (typeof result.error !== "string" || result.error.length > 4096))
+			) {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: "Remote peer transport returned a malformed or stale delivery result.",
+				};
+			}
+			if (result.outcome !== "accepted") {
+				return {
+					to: message.to,
+					outcome: "failed",
+					error: `Remote peer delivery was ${result.outcome}.`,
+				};
+			}
+			return { to: message.to, outcome: "remote" };
+		} catch {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: "Remote peer delivery failed.",
+			};
+		} finally {
+			removeAbort?.();
+		}
 	}
 
 	#enqueue(message: IrcMessage): void {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -67,6 +67,7 @@ import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
 import { createWarpEventBridgeExtension } from "./modes/warp-events";
 import { AgentLifecycleManager } from "./registry/agent-lifecycle";
+import { currentRemoteRuntime } from "./remote-runtime/scope";
 import {
 	type CreateAgentSessionOptions,
 	type CreateAgentSessionResult,
@@ -1208,6 +1209,9 @@ export async function runRootCommand(
 	rawArgs: string[],
 	deps: RunRootCommandDependencies = DEFAULT_RUN_ROOT_DEPENDENCIES,
 ): Promise<void> {
+	if (parsed.remoteRuntimeConfig && !currentRemoteRuntime()) {
+		throw new Error("Remote runtime configuration must be installed before the root command starts.");
+	}
 	logger.startTiming();
 	startStartupWatchdog();
 

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -155,8 +155,12 @@ export class AgentLifecycleManager {
 	adopt(id: string, opts: AdoptOptions, expected?: AgentRefExpectation): void {
 		if (id === MAIN_AGENT_ID) return;
 		const ref = this.#registry.get(id);
-		if (!ref || (expected !== undefined && ref !== expected && ref.session !== expected)) {
-			logger.warn("AgentLifecycleManager.adopt: unknown or replaced agent id", { id });
+		if (
+			!ref ||
+			ref.locality === "remote" ||
+			(expected !== undefined && ref !== expected && ref.session !== expected)
+		) {
+			logger.warn("AgentLifecycleManager.adopt: unknown, remote, or replaced agent id", { id });
 			return;
 		}
 		const existing = this.#adopted.get(id);
@@ -186,7 +190,7 @@ export class AgentLifecycleManager {
 	 */
 	async reclaimDeadCorpse(id: string, expected: AgentRef): Promise<boolean> {
 		const ref = this.#registry.get(id);
-		if (ref !== expected || ref.status !== "parked" || ref.session) return false;
+		if (ref !== expected || ref.locality === "remote" || ref.status !== "parked" || ref.session) return false;
 		if (this.#adopted.has(id) || this.#parks.has(id) || this.#revivals.has(id)) return false;
 
 		const persistedFactory = ref.sessionFile ? this.#persistedReviverFactory : undefined;
@@ -247,7 +251,7 @@ export class AgentLifecycleManager {
 		const adopted = this.#adopted.get(id);
 		if (!adopted) return;
 		const ref = this.#registry.get(id);
-		if (!ref || adopted.ref !== ref) return;
+		if (!ref || ref.locality === "remote" || adopted.ref !== ref) return;
 		const session = ref.session;
 		if (!session) return;
 
@@ -315,6 +319,10 @@ export class AgentLifecycleManager {
 	 * cancelled (session still live) or awaited to completion before revive.
 	 */
 	async ensureLive(id: string): Promise<AgentSession> {
+		const initialRef = this.#registry.get(id);
+		if (initialRef?.locality === "remote") {
+			throw new Error(`Remote agent "${id}" cannot be resumed by the local lifecycle manager.`);
+		}
 		const park = this.#parks.get(id);
 		if (park) {
 			const parked = this.#registry.get(id);
@@ -363,6 +371,9 @@ export class AgentLifecycleManager {
 	 * when the agent is not revivable or no reviver can be produced.
 	 */
 	async #resolveAndRevive(id: string, ref: AgentRef): Promise<AgentSession> {
+		if (ref.locality === "remote") {
+			throw new Error(`Remote agent "${id}" cannot be revived by the local lifecycle manager.`);
+		}
 		let adoption = this.#adopted.get(id);
 		let revive = adoption?.ref === ref ? adoption.revive : undefined;
 		let coldAdopted = false;
@@ -417,6 +428,7 @@ export class AgentLifecycleManager {
 	async release(id: string, expected?: AgentRefExpectation, options?: { tombstone?: boolean }): Promise<boolean> {
 		const adopted = this.#adopted.get(id);
 		const current = this.#registry.get(id);
+		if (current?.locality === "remote") return false;
 		const currentMatches =
 			current && (expected === undefined || current === expected || current.session === expected);
 		const adoptedMatches =

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -10,6 +10,7 @@
  */
 
 import { logger } from "@oh-my-pi/pi-utils";
+import { currentRemoteRuntime } from "../remote-runtime/scope";
 import type { AgentSession } from "../session/agent-session";
 import { oneLineLabel } from "../task/types";
 
@@ -69,7 +70,15 @@ export interface AgentHistorySummary {
 	branchName?: string;
 }
 
-export interface AgentRef {
+export interface LocalAgentRef {
+	/**
+	 * Omitted local fields preserve source compatibility with historical
+	 * persisted/manual AgentRef fixtures. Registry-created refs always populate
+	 * both fields; only remote refs require the discriminant.
+	 */
+	locality?: "local";
+	/** Registry-owned generation, incremented whenever a local id is registered again. */
+	generation?: number;
 	id: string;
 	displayName: string;
 	kind: AgentKind;
@@ -85,8 +94,86 @@ export interface AgentRef {
 	/** Persisted identity and telemetry restored after the live observer is gone. */
 	history?: AgentHistorySummary;
 }
+export interface RegisteredLocalAgentRef extends LocalAgentRef {
+	locality: "local";
+	generation: number;
+}
+
+/** Immutable controller-owned execution identity. It contains no endpoint or capability material. */
+export interface RemoteAgentIdentity {
+	controllerId: string;
+	executionId: string;
+	generation: number;
+}
+
+export interface RemoteAgentRef {
+	readonly locality: "remote";
+	/** Controller-owned generation, mirrored for identity checks and roster consumers. */
+	readonly generation: number;
+	readonly id: string;
+	displayName: string;
+	kind: AgentKind;
+	parentId?: string;
+	status: AgentStatus;
+	readonly session: null;
+	readonly sessionFile: null;
+	createdAt: number;
+	lastActivity: number;
+	activity?: string;
+	history?: AgentHistorySummary;
+	/** Frozen at registration; backend responses must echo this identity exactly. */
+	readonly remote: Readonly<RemoteAgentIdentity>;
+}
+
+export type AgentRef = LocalAgentRef | RemoteAgentRef;
 
 export type AgentRefExpectation = AgentRef | AgentSession;
+
+export interface RemoteAgentProgress {
+	sequence: number;
+	message?: string;
+}
+
+export interface RemoteAgentResult {
+	outcome: "completed" | "failed" | "cancelled";
+	output?: unknown;
+	error?: string;
+}
+
+export interface RemoteRegistryResponse<T> {
+	identity: RemoteAgentIdentity;
+	value: T;
+}
+
+/**
+ * Trusted controller adapter. Endpoint and authority state belong in this
+ * closure; none of it is accepted from refs, settings, prompts, or payloads.
+ */
+export interface RemoteRegistryBackend {
+	status(identity: Readonly<RemoteAgentIdentity>, signal?: AbortSignal): Promise<RemoteRegistryResponse<AgentStatus>>;
+	progress(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<RemoteAgentProgress>>;
+	cancel(identity: Readonly<RemoteAgentIdentity>, signal?: AbortSignal): Promise<RemoteRegistryResponse<"cancelled">>;
+	result(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<RemoteAgentResult>>;
+}
+
+export interface RemoteRegisterInput {
+	id: string;
+	displayName: string;
+	kind: AgentKind;
+	parentId?: string;
+	status: AgentStatus;
+	identity: RemoteAgentIdentity;
+	createdAt?: number;
+	lastActivity?: number;
+	activity?: string;
+	history?: AgentHistorySummary;
+}
 
 export type RegistryEvent =
 	| { type: "registered"; ref: AgentRef }
@@ -131,6 +218,129 @@ export class AgentRegistry {
 
 	readonly #refs = new Map<string, AgentRef>();
 	readonly #listeners = new Set<RegistryListener>();
+	readonly #localGenerations = new Map<string, number>();
+	readonly #remoteProgress = new Map<string, RemoteAgentProgress>();
+	readonly #remoteResults = new Map<string, RemoteAgentResult>();
+	readonly #remoteResultRequests = new Map<string, Promise<RemoteAgentResult>>();
+	readonly #remoteIdentityOwners = new Map<string, string>();
+	readonly #remoteBackendOwners = new WeakMap<RemoteAgentRef, RemoteRegistryBackend>();
+	readonly #remoteBackend: RemoteRegistryBackend | undefined;
+
+	constructor(options?: { remoteBackend?: RemoteRegistryBackend }) {
+		this.#remoteBackend = options?.remoteBackend;
+	}
+
+	static #validIdentity(identity: unknown): identity is RemoteAgentIdentity {
+		if (!identity || typeof identity !== "object") return false;
+		const candidate = identity as Partial<RemoteAgentIdentity>;
+		return (
+			typeof candidate.controllerId === "string" &&
+			candidate.controllerId.length > 0 &&
+			candidate.controllerId.length <= 256 &&
+			candidate.controllerId === candidate.controllerId.trim() &&
+			typeof candidate.executionId === "string" &&
+			candidate.executionId.length > 0 &&
+			candidate.executionId.length <= 256 &&
+			candidate.executionId === candidate.executionId.trim() &&
+			Number.isSafeInteger(candidate.generation) &&
+			(candidate.generation ?? 0) > 0
+		);
+	}
+	static #sameIdentity(left: Readonly<RemoteAgentIdentity>, right: RemoteAgentIdentity): boolean {
+		return (
+			left.controllerId === right.controllerId &&
+			left.executionId === right.executionId &&
+			left.generation === right.generation
+		);
+	}
+	static #identityKey(identity: Readonly<RemoteAgentIdentity>): string {
+		return `${identity.controllerId.length}:${identity.controllerId}${identity.executionId.length}:${identity.executionId}:${identity.generation}`;
+	}
+
+	#resolveRemoteAuthority(authority?: RemoteRegistryBackend): RemoteRegistryBackend {
+		const owner = authority ?? this.#remoteBackend;
+		if (!owner) {
+			throw new Error("Remote agent registration requires an explicit or constructor backend owner.");
+		}
+		const scopedRuntime = currentRemoteRuntime();
+		if (scopedRuntime && owner !== scopedRuntime.registryBackend) {
+			throw new Error("Sealed remote agent registration requires the installed controller backend.");
+		}
+		return owner;
+	}
+
+	#awaitRemoteResult(request: Promise<RemoteAgentResult>, signal?: AbortSignal): Promise<RemoteAgentResult> {
+		if (!signal) return request;
+		signal.throwIfAborted();
+		return new Promise<RemoteAgentResult>((resolve, reject) => {
+			let settled = false;
+			const finish = (callback: () => void): void => {
+				if (settled) return;
+				settled = true;
+				signal.removeEventListener("abort", onAbort);
+				callback();
+			};
+			const onAbort = (): void => {
+				finish(() => {
+					reject(
+						signal.reason instanceof Error ? signal.reason : new Error("Remote agent result wait was cancelled."),
+					);
+				});
+			};
+			signal.addEventListener("abort", onAbort, { once: true });
+			request.then(
+				value => finish(() => resolve(value)),
+				error => finish(() => reject(error)),
+			);
+			if (signal.aborted) onAbort();
+		});
+	}
+
+	#remoteRef(id: string): RemoteAgentRef {
+		const ref = this.#refs.get(id);
+		if (!ref) throw new Error(`Unknown remote agent "${id}".`);
+		if (ref.locality !== "remote") throw new Error(`Agent "${id}" is local, not remote.`);
+		return ref;
+	}
+
+	async #remoteCall<T>(
+		id: string,
+		operation: keyof RemoteRegistryBackend,
+		signal?: AbortSignal,
+	): Promise<{ ref: RemoteAgentRef; value: T }> {
+		const ref = this.#remoteRef(id);
+		const backend = this.#remoteBackendOwners.get(ref);
+		if (!backend) throw new Error(`Remote agent "${id}" has no backend owner.`);
+		const ambient = currentRemoteRuntime()?.registryBackend;
+		if (ambient && backend !== ambient) {
+			throw new Error(`Remote agent "${id}" belongs to a different sealed runtime.`);
+		}
+		let response: RemoteRegistryResponse<T>;
+		try {
+			const call = backend[operation] as (
+				identity: Readonly<RemoteAgentIdentity>,
+				callSignal?: AbortSignal,
+			) => Promise<RemoteRegistryResponse<T>>;
+			response = await call.call(backend, ref.remote, signal);
+		} catch (error) {
+			throw new Error(
+				`Remote agent ${operation} failed for "${id}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+		signal?.throwIfAborted();
+		if (
+			!response ||
+			typeof response !== "object" ||
+			!AgentRegistry.#validIdentity(response.identity) ||
+			!AgentRegistry.#sameIdentity(ref.remote, response.identity)
+		) {
+			throw new Error(`Remote agent ${operation} returned a stale or malformed identity for "${id}".`);
+		}
+		if (this.#refs.get(id) !== ref) {
+			throw new Error(`Remote agent "${id}" changed generation during ${operation}.`);
+		}
+		return { ref, value: response.value };
+	}
 
 	#matchesExpected(ref: AgentRef, expected?: AgentRefExpectation): boolean {
 		return expected === undefined || ref === expected || ref.session === expected;
@@ -141,9 +351,17 @@ export class AgentRegistry {
 		return false;
 	}
 
-	register(input: RegisterInput): AgentRef {
+	register(input: RegisterInput): RegisteredLocalAgentRef {
+		const existing = this.#refs.get(input.id);
+		if (existing?.locality === "remote") {
+			throw new Error(`Cannot register local agent "${input.id}" over a remote execution.`);
+		}
 		const now = Date.now();
-		const ref: AgentRef = {
+		const generation = (this.#localGenerations.get(input.id) ?? 0) + 1;
+		this.#localGenerations.set(input.id, generation);
+		const ref: RegisteredLocalAgentRef = {
+			locality: "local",
+			generation,
 			id: input.id,
 			displayName: input.displayName,
 			kind: input.kind,
@@ -161,16 +379,183 @@ export class AgentRegistry {
 		return ref;
 	}
 
+	/** Register a controller-owned execution without creating any local session or revival state. */
+	registerRemote(input: RemoteRegisterInput, authority?: RemoteRegistryBackend): RemoteAgentRef {
+		const owner = this.#resolveRemoteAuthority(authority);
+		if (!AgentRegistry.#validIdentity(input.identity)) {
+			throw new Error(`Remote agent "${input.id}" has an invalid controller identity.`);
+		}
+		if (input.id.length === 0 || input.id !== input.id.trim()) {
+			throw new Error("Remote agent id must be a non-empty normalized string.");
+		}
+		if (this.#refs.has(input.id)) {
+			throw new Error(`Agent "${input.id}" is already registered; local and remote executions cannot overlap.`);
+		}
+		const identityKey = AgentRegistry.#identityKey(input.identity);
+		const identityOwner = this.#remoteIdentityOwners.get(identityKey);
+		if (identityOwner) {
+			throw new Error(`Remote execution identity is already registered as agent "${identityOwner}".`);
+		}
+		const now = Date.now();
+		const remote = Object.freeze({ ...input.identity });
+		const ref: RemoteAgentRef = {
+			locality: "remote",
+			generation: remote.generation,
+			id: input.id,
+			displayName: input.displayName,
+			kind: input.kind,
+			parentId: input.parentId,
+			status: input.status,
+			session: null,
+			sessionFile: null,
+			createdAt: input.createdAt ?? now,
+			lastActivity: input.lastActivity ?? now,
+			activity: input.activity ? oneLineLabel(input.activity) : undefined,
+			history: input.history,
+			remote,
+		};
+		Object.defineProperties(ref, {
+			id: { value: input.id, enumerable: true, writable: false, configurable: false },
+			locality: { value: "remote", enumerable: true, writable: false, configurable: false },
+			generation: { value: remote.generation, enumerable: true, writable: false, configurable: false },
+			remote: { value: remote, enumerable: true, writable: false, configurable: false },
+			session: { value: null, enumerable: true, writable: false, configurable: false },
+			sessionFile: { value: null, enumerable: true, writable: false, configurable: false },
+		});
+		this.#remoteIdentityOwners.set(identityKey, ref.id);
+		this.#refs.set(ref.id, ref);
+		this.#remoteBackendOwners.set(ref, owner);
+		this.#emit({ type: "registered", ref });
+		return ref;
+	}
+
+	/** Apply the terminal state for the exact running registration accepted from this authority. */
+	settleRemote(
+		input: RemoteRegisterInput,
+		expected: RemoteAgentRef,
+		authority?: RemoteRegistryBackend,
+	): RemoteAgentRef {
+		const owner = this.#resolveRemoteAuthority(authority);
+		const ref = this.#remoteRef(input.id);
+		if (this.#remoteBackendOwners.get(ref) !== owner) {
+			throw new Error(`Remote agent "${input.id}" belongs to a different sealed runtime.`);
+		}
+		if (
+			ref !== expected ||
+			input.status === "running" ||
+			!AgentRegistry.#sameIdentity(ref.remote, input.identity) ||
+			ref.displayName !== input.displayName ||
+			ref.kind !== input.kind ||
+			ref.parentId !== input.parentId ||
+			ref.createdAt !== input.createdAt
+		) {
+			throw new Error(`Remote agent "${input.id}" returned a conflicting terminal registration.`);
+		}
+		this.#applyRemoteStatus(ref, input.status);
+		return ref;
+	}
+
+	/** Refresh controller-owned status and progress, rejecting stale generations and malformed state. */
+	async refreshRemote(id: string, signal?: AbortSignal): Promise<RemoteAgentRef> {
+		const statusResponse = await this.#remoteCall<AgentStatus>(id, "status", signal);
+		const status = statusResponse.value;
+		if (!["running", "idle", "parked", "aborted"].includes(status)) {
+			throw new Error(`Remote agent status returned a malformed value for "${id}".`);
+		}
+		const progressResponse = await this.#remoteCall<RemoteAgentProgress>(id, "progress", signal);
+		const progress = progressResponse.value;
+		if (
+			!progress ||
+			typeof progress !== "object" ||
+			!Number.isSafeInteger(progress.sequence) ||
+			progress.sequence < 0 ||
+			(progress.message !== undefined && typeof progress.message !== "string")
+		) {
+			throw new Error(`Remote agent progress returned a malformed value for "${id}".`);
+		}
+		const identityKey = AgentRegistry.#identityKey(progressResponse.ref.remote);
+		const priorProgress = this.#remoteProgress.get(identityKey);
+		if (priorProgress && progress.sequence < priorProgress.sequence) {
+			throw new Error(`Remote agent progress returned a stale sequence for "${id}".`);
+		}
+		if (priorProgress && progress.sequence === priorProgress.sequence && progress.message !== priorProgress.message) {
+			throw new Error(`Remote agent progress returned a conflicting duplicate sequence for "${id}".`);
+		}
+		const ref = progressResponse.ref;
+		if (statusResponse.ref !== ref) throw new Error(`Remote agent "${id}" changed generation during refresh.`);
+		this.#remoteProgress.set(identityKey, { sequence: progress.sequence, message: progress.message });
+		this.#applyRemoteStatus(ref, status);
+		if (progress.message !== undefined && status === "running") ref.activity = oneLineLabel(progress.message);
+		ref.lastActivity = Date.now();
+		this.#emit({ type: "metadata_changed", ref });
+		return ref;
+	}
+
+	/** Route cancellation to the controller. Missing/rejecting backends never fall back to local session control. */
+	async cancelRemote(id: string, signal?: AbortSignal): Promise<void> {
+		const { ref, value } = await this.#remoteCall<"cancelled">(id, "cancel", signal);
+		if (value !== "cancelled") throw new Error(`Remote agent cancel returned a malformed result for "${id}".`);
+		this.#applyRemoteStatus(ref, "aborted");
+	}
+
+	/** Read the controller's terminal result without executing or reviving anything locally. */
+	async resultRemote(id: string, signal?: AbortSignal): Promise<RemoteAgentResult> {
+		signal?.throwIfAborted();
+		const ref = this.#remoteRef(id);
+		const identityKey = AgentRegistry.#identityKey(ref.remote);
+		const cached = this.#remoteResults.get(identityKey);
+		if (cached) return cached;
+		const pending = this.#remoteResultRequests.get(identityKey);
+		if (pending) return this.#awaitRemoteResult(pending, signal);
+		const request = (async (): Promise<RemoteAgentResult> => {
+			const response = await this.#remoteCall<RemoteAgentResult>(id, "result");
+			const value = response.value;
+			if (
+				!value ||
+				typeof value !== "object" ||
+				!["completed", "failed", "cancelled"].includes(value.outcome) ||
+				(value.error !== undefined && typeof value.error !== "string") ||
+				(value.outcome === "completed" && value.error !== undefined) ||
+				(value.outcome === "failed" && !value.error)
+			) {
+				throw new Error(`Remote agent result returned a malformed value for "${id}".`);
+			}
+			if (response.ref !== ref) throw new Error(`Remote agent "${id}" changed generation during result.`);
+			const terminal = Object.freeze({ ...value });
+			this.#remoteResults.set(identityKey, terminal);
+			return terminal;
+		})();
+		this.#remoteResultRequests.set(identityKey, request);
+		const cleanup = (): void => {
+			if (this.#remoteResultRequests.get(identityKey) === request) this.#remoteResultRequests.delete(identityKey);
+		};
+		void request.then(cleanup, cleanup);
+		return await this.#awaitRemoteResult(request, signal);
+	}
+
+	#applyRemoteStatus(ref: RemoteAgentRef, status: AgentStatus): void {
+		if (ref.status === "aborted" && status !== "aborted") {
+			throw new Error(`Remote agent "${ref.id}" is aborted and cannot be revived.`);
+		}
+		if (ref.status === status) return;
+		ref.status = status;
+		if (status !== "running") ref.activity = undefined;
+		ref.lastActivity = Date.now();
+		this.#emit({ type: "status_changed", ref });
+	}
+
 	/**
 	 * Register a new id only when it is absent, or reuse the exact detached
 	 * `parked` ref a revival was authorized to revive. A missing, replaced, or
 	 * terminal expected ref is a failed CAS: delayed revivers must never claim an
 	 * id after its prior generation disappeared or was hard-killed.
 	 */
-	registerIfAvailable(input: RegisterInput, expected: AgentRef | null): AgentRef | undefined {
+	registerIfAvailable(input: RegisterInput, expected: AgentRef | null): LocalAgentRef | undefined {
 		const current = this.#refs.get(input.id);
 		if (expected === null) return current ? undefined : this.register(input);
-		return current === expected && current.status === "parked" && !current.session ? current : undefined;
+		return current === expected && current.locality !== "remote" && current.status === "parked" && !current.session
+			? current
+			: undefined;
 	}
 
 	/** Attach transcript-derived identity and telemetry without changing lifecycle state. */
@@ -188,6 +573,7 @@ export class AgentRegistry {
 	setStatus(id: string, status: AgentStatus, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
 		if (!ref) return this.#rejectStatusUpdate(id, status, "missing-ref");
+		if (ref.locality === "remote") return this.#rejectStatusUpdate(id, status, "remote-status-is-controller-owned");
 		if (!this.#matchesExpected(ref, expected)) {
 			return this.#rejectStatusUpdate(id, status, "session-ownership-changed");
 		}
@@ -222,7 +608,7 @@ export class AgentRegistry {
 	 */
 	setActivity(id: string, activity: string): void {
 		const ref = this.#refs.get(id);
-		if (!ref) return;
+		if (!ref || ref.locality === "remote") return;
 		if (ref.status !== "running") return;
 		const gist = oneLineLabel(activity);
 		ref.lastActivity = Date.now();
@@ -237,10 +623,10 @@ export class AgentRegistry {
 		expected?: AgentRefExpectation,
 	): boolean {
 		const ref = this.#refs.get(id);
-		// Never attach a late-created session to a hard-killed tombstone. This
-		// closes the race between a parked reviver claiming the ref and finishing
-		// createAgentSession after an explicit kill.
-		if (!ref || ref.status === "aborted" || !this.#matchesExpected(ref, expected)) return false;
+		// Remote executions never accept local sessions, including from delayed
+		// revivers racing a controller registration.
+		if (!ref || ref.locality === "remote" || ref.status === "aborted" || !this.#matchesExpected(ref, expected))
+			return false;
 		ref.session = session;
 		if (sessionFile !== undefined) ref.sessionFile = sessionFile;
 		ref.lastActivity = Date.now();
@@ -249,7 +635,7 @@ export class AgentRegistry {
 
 	detachSession(id: string, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
-		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		if (!ref || ref.locality === "remote" || !this.#matchesExpected(ref, expected)) return false;
 		ref.session = null;
 		return true;
 	}
@@ -257,6 +643,13 @@ export class AgentRegistry {
 	unregister(id: string, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
 		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		if (ref.locality === "remote") {
+			const identityKey = AgentRegistry.#identityKey(ref.remote);
+			this.#remoteProgress.delete(identityKey);
+			this.#remoteResults.delete(identityKey);
+			if (this.#remoteIdentityOwners.get(identityKey) === ref.id) this.#remoteIdentityOwners.delete(identityKey);
+			this.#remoteResultRequests.delete(identityKey);
+		}
 		this.#refs.delete(id);
 		this.#emit({ type: "removed", ref });
 		return true;
@@ -281,10 +674,10 @@ export class AgentRegistry {
 		);
 	}
 
-	/** Whether a ref's claimed running state is corroborated by its attached live session. */
+	/** Whether a running claim is corroborated by its owning runtime. */
 	isRunning(ref: AgentRef): boolean {
 		if (ref.status !== "running") return false;
-		return ref.session?.isStreaming === true;
+		return ref.locality === "remote" || ref.session?.isStreaming === true;
 	}
 
 	/** Mirror a session's authoritative run-state notifications into its owned registry ref. */

--- a/packages/coding-agent/src/remote-runtime/backends.ts
+++ b/packages/coding-agent/src/remote-runtime/backends.ts
@@ -1,0 +1,864 @@
+import { randomUUID } from "node:crypto";
+import type {
+	PeerExecutionIdentity,
+	PeerTransportBackend,
+	PeerTransportDelivery,
+	PeerTransportResult,
+} from "../irc/bus";
+import {
+	AgentRegistry,
+	type AgentStatus,
+	MAIN_AGENT_ID,
+	type RemoteAgentIdentity,
+	type RemoteAgentProgress,
+	type RemoteAgentRef,
+	type RemoteAgentResult,
+	type RemoteRegisterInput,
+	type RemoteRegistryBackend,
+	type RemoteRegistryResponse,
+} from "../registry/agent-registry";
+import type {
+	StructuredSubagentBackend,
+	StructuredSubagentBackendContext,
+	StructuredSubagentResult,
+} from "../task/structured-subagent";
+import { oneLineLabel, type SingleResult, type StructuredSubagentOutput } from "../task/types";
+import { type RemoteRuntimeClient, RemoteRuntimeProtocolError } from "./client";
+import type { RemoteRuntimeConfig } from "./config";
+
+const REGISTRY_RESPONSE_KEYS: Record<string, true> = { identity: true, value: true };
+const IDENTITY_KEYS: Record<string, true> = { controllerId: true, executionId: true, generation: true };
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const REGISTRY_PROGRESS_KEYS: Record<string, true> = { sequence: true, message: true };
+const REGISTRY_RESULT_KEYS: Record<string, true> = { outcome: true, output: true, error: true };
+const PEER_RESULT_KEYS: Record<string, true> = {
+	deliveryId: true,
+	sequence: true,
+	sender: true,
+	recipient: true,
+	outcome: true,
+	error: true,
+};
+const PEER_IDENTITY_KEYS: Record<string, true> = {
+	locality: true,
+	agentId: true,
+	generation: true,
+	controllerId: true,
+	executionId: true,
+};
+const STRUCTURED_RESPONSE_KEYS: Record<string, true> = { execution: true, registration: true };
+const STRUCTURED_EXECUTION_KEYS: Record<string, true> = {
+	result: true,
+	mergeSummary: true,
+	changesApplied: true,
+	temporaryArtifacts: true,
+};
+const REMOTE_REGISTRATION_KEYS: Record<string, true> = {
+	id: true,
+	displayName: true,
+	kind: true,
+	parentId: true,
+	status: true,
+	identity: true,
+	createdAt: true,
+	lastActivity: true,
+};
+const STRUCTURED_OBSERVATION_KEYS: Record<string, true> = { type: true, registration: true };
+const CHILD_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+const REMOTE_LAUNCH_TIMEOUT_GRACE_MS = 30_000;
+const REMOTE_LAUNCH_TIMEOUT_MAX_MS = 2_147_000_000;
+
+function remoteLaunchTimeout(maxRuntimeMs: number): number | null {
+	if (!Number.isSafeInteger(maxRuntimeMs) || maxRuntimeMs < 0) {
+		throw new RemoteRuntimeProtocolError("INVALID_TIMEOUT", "Remote structured runtime limit is malformed.");
+	}
+	if (maxRuntimeMs === 0) return null;
+	return Math.min(maxRuntimeMs + REMOTE_LAUNCH_TIMEOUT_GRACE_MS, REMOTE_LAUNCH_TIMEOUT_MAX_MS);
+}
+
+interface ActiveRemoteLaunch {
+	readonly registry: AgentRegistry;
+	running?: { readonly input: RemoteRegisterInput; readonly ref: RemoteAgentRef };
+	terminal?: RemoteRegisterInput;
+	observationError?: RemoteRuntimeProtocolError;
+}
+const SINGLE_RESULT_KEYS: Record<string, true> = {
+	index: true,
+	id: true,
+	agent: true,
+	agentSource: true,
+	task: true,
+	assignment: true,
+	description: true,
+	lastIntent: true,
+	exitCode: true,
+	output: true,
+	stderr: true,
+	truncated: true,
+	structuredOutput: true,
+	durationMs: true,
+	tokens: true,
+	requests: true,
+	contextTokens: true,
+	contextWindow: true,
+	modelOverride: true,
+	modelRole: true,
+	resolvedModel: true,
+	resolvedModelIsFallback: true,
+	error: true,
+	aborted: true,
+	abortReason: true,
+	usage: true,
+	extractedToolData: true,
+	retryFailure: true,
+	outputMeta: true,
+};
+const USAGE_KEYS: Record<string, true> = {
+	input: true,
+	output: true,
+	cacheRead: true,
+	cacheWrite: true,
+	totalTokens: true,
+	contextTokens: true,
+	orchestration: true,
+	premiumRequests: true,
+	reasoningTokens: true,
+	cttl: true,
+	server: true,
+	cost: true,
+};
+const USAGE_COST_KEYS: Record<string, true> = {
+	input: true,
+	output: true,
+	cacheRead: true,
+	cacheWrite: true,
+	total: true,
+};
+const USAGE_ORCHESTRATION_KEYS: Record<string, true> = { input: true, cacheRead: true, output: true };
+const USAGE_CTTL_KEYS: Record<string, true> = { ephemeral5m: true, ephemeral1h: true };
+const USAGE_SERVER_KEYS: Record<string, true> = { webSearch: true, webFetch: true };
+const RETRY_FAILURE_KEYS: Record<string, true> = { attempt: true, errorMessage: true };
+const OUTPUT_META_KEYS: Record<string, true> = { lineCount: true, charCount: true };
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function requireFiniteNonNegativeFields(
+	value: Record<string, unknown>,
+	required: readonly string[],
+	optional: readonly string[],
+	label: string,
+): void {
+	requireKeys(value, required, label);
+	for (const key of required) {
+		if (!isFiniteNonNegativeNumber(value[key])) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", `${label} is malformed.`);
+		}
+	}
+	for (const key of optional) {
+		if (value[key] !== undefined && !isFiniteNonNegativeNumber(value[key])) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", `${label} is malformed.`);
+		}
+	}
+}
+
+function parseUsage(value: unknown): NonNullable<SingleResult["usage"]> {
+	const usage = protocolObject(value, "Remote structured child usage");
+	rejectUnknownKeys(usage, USAGE_KEYS, "Remote structured child usage");
+	requireFiniteNonNegativeFields(
+		usage,
+		["input", "output", "cacheRead", "cacheWrite", "totalTokens"],
+		["contextTokens", "premiumRequests", "reasoningTokens"],
+		"Remote structured child usage",
+	);
+
+	const cost = protocolObject(usage.cost, "Remote structured child usage cost");
+	rejectUnknownKeys(cost, USAGE_COST_KEYS, "Remote structured child usage cost");
+	requireFiniteNonNegativeFields(
+		cost,
+		["input", "output", "cacheRead", "cacheWrite", "total"],
+		[],
+		"Remote structured child usage cost",
+	);
+
+	if (usage.orchestration !== undefined) {
+		const orchestration = protocolObject(usage.orchestration, "Remote structured child orchestration usage");
+		rejectUnknownKeys(orchestration, USAGE_ORCHESTRATION_KEYS, "Remote structured child orchestration usage");
+		requireFiniteNonNegativeFields(
+			orchestration,
+			[],
+			["input", "cacheRead", "output"],
+			"Remote structured child orchestration usage",
+		);
+	}
+	if (usage.cttl !== undefined) {
+		const cttl = protocolObject(usage.cttl, "Remote structured child cache TTL usage");
+		rejectUnknownKeys(cttl, USAGE_CTTL_KEYS, "Remote structured child cache TTL usage");
+		requireFiniteNonNegativeFields(
+			cttl,
+			[],
+			["ephemeral5m", "ephemeral1h"],
+			"Remote structured child cache TTL usage",
+		);
+	}
+	if (usage.server !== undefined) {
+		const server = protocolObject(usage.server, "Remote structured child server usage");
+		rejectUnknownKeys(server, USAGE_SERVER_KEYS, "Remote structured child server usage");
+		requireFiniteNonNegativeFields(server, [], ["webSearch", "webFetch"], "Remote structured child server usage");
+	}
+	return usage as unknown as NonNullable<SingleResult["usage"]>;
+}
+
+function parseExtractedToolData(value: unknown): NonNullable<SingleResult["extractedToolData"]> {
+	const extracted = protocolObject(value, "Remote structured child extracted tool data");
+	for (const entries of Object.values(extracted)) {
+		if (!Array.isArray(entries)) {
+			throw new RemoteRuntimeProtocolError(
+				"MALFORMED_RESULT",
+				"Remote structured child extracted tool data is malformed.",
+			);
+		}
+	}
+	return extracted as NonNullable<SingleResult["extractedToolData"]>;
+}
+
+function parseRetryFailure(value: unknown): NonNullable<SingleResult["retryFailure"]> {
+	const retryFailure = protocolObject(value, "Remote structured child retry failure");
+	rejectUnknownKeys(retryFailure, RETRY_FAILURE_KEYS, "Remote structured child retry failure");
+	requireKeys(retryFailure, ["attempt", "errorMessage"], "Remote structured child retry failure");
+	if (
+		!Number.isSafeInteger(retryFailure.attempt) ||
+		(retryFailure.attempt as number) < 1 ||
+		typeof retryFailure.errorMessage !== "string"
+	) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote structured child retry failure is malformed.");
+	}
+	return retryFailure as NonNullable<SingleResult["retryFailure"]>;
+}
+
+function parseOutputMeta(value: unknown): NonNullable<SingleResult["outputMeta"]> {
+	const outputMeta = protocolObject(value, "Remote structured child output metadata");
+	rejectUnknownKeys(outputMeta, OUTPUT_META_KEYS, "Remote structured child output metadata");
+	requireKeys(outputMeta, ["lineCount", "charCount"], "Remote structured child output metadata");
+	if (
+		!Number.isSafeInteger(outputMeta.lineCount) ||
+		(outputMeta.lineCount as number) < 0 ||
+		!Number.isSafeInteger(outputMeta.charCount) ||
+		(outputMeta.charCount as number) < 0
+	) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote structured child output metadata is malformed.");
+	}
+	return outputMeta as NonNullable<SingleResult["outputMeta"]>;
+}
+
+function parseSingleResult(value: Record<string, unknown>): SingleResult {
+	requireKeys(
+		value,
+		[
+			"index",
+			"id",
+			"agent",
+			"agentSource",
+			"task",
+			"exitCode",
+			"output",
+			"stderr",
+			"truncated",
+			"durationMs",
+			"tokens",
+			"requests",
+		],
+		"Remote structured child result",
+	);
+	if (
+		!Number.isInteger(value.index) ||
+		typeof value.id !== "string" ||
+		typeof value.agent !== "string" ||
+		!["bundled", "user", "project"].includes(value.agentSource as string) ||
+		typeof value.task !== "string" ||
+		!Number.isInteger(value.exitCode) ||
+		typeof value.output !== "string" ||
+		typeof value.stderr !== "string" ||
+		typeof value.truncated !== "boolean" ||
+		typeof value.durationMs !== "number" ||
+		!Number.isFinite(value.durationMs) ||
+		value.durationMs < 0 ||
+		typeof value.tokens !== "number" ||
+		!Number.isFinite(value.tokens) ||
+		value.tokens < 0 ||
+		!Number.isInteger(value.requests) ||
+		(value.requests as number) < 0 ||
+		(value.assignment !== undefined && typeof value.assignment !== "string") ||
+		(value.description !== undefined && typeof value.description !== "string") ||
+		(value.lastIntent !== undefined && typeof value.lastIntent !== "string") ||
+		(value.contextTokens !== undefined && !isFiniteNonNegativeNumber(value.contextTokens)) ||
+		(value.contextWindow !== undefined && !isFiniteNonNegativeNumber(value.contextWindow)) ||
+		(value.modelOverride !== undefined &&
+			typeof value.modelOverride !== "string" &&
+			(!Array.isArray(value.modelOverride) || !value.modelOverride.every(model => typeof model === "string"))) ||
+		(value.modelRole !== undefined && typeof value.modelRole !== "string") ||
+		(value.resolvedModel !== undefined && typeof value.resolvedModel !== "string") ||
+		(value.resolvedModelIsFallback !== undefined && typeof value.resolvedModelIsFallback !== "boolean") ||
+		(value.error !== undefined && typeof value.error !== "string") ||
+		(value.aborted !== undefined && typeof value.aborted !== "boolean") ||
+		(value.abortReason !== undefined && typeof value.abortReason !== "string")
+	) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote structured child result is malformed.");
+	}
+	let structuredOutput: StructuredSubagentOutput | undefined;
+	if (value.structuredOutput !== undefined) {
+		const candidate = protocolObject(value.structuredOutput, "Remote structured output");
+		rejectUnknownKeys(
+			candidate,
+			{ source: true, mode: true, status: true, data: true, error: true },
+			"Remote structured output",
+		);
+		requireKeys(candidate, ["source", "mode", "status"], "Remote structured output");
+		if (
+			!["caller", "agent", "session", "none"].includes(candidate.source as string) ||
+			!["permissive", "strict"].includes(candidate.mode as string) ||
+			!["valid", "invalid", "unavailable"].includes(candidate.status as string) ||
+			(candidate.error !== undefined && typeof candidate.error !== "string")
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote structured output is malformed.");
+		}
+		structuredOutput = {
+			source: candidate.source as StructuredSubagentOutput["source"],
+			mode: candidate.mode as StructuredSubagentOutput["mode"],
+			status: candidate.status as StructuredSubagentOutput["status"],
+			...(Object.hasOwn(candidate, "data") ? { data: candidate.data } : {}),
+			...(typeof candidate.error === "string" ? { error: candidate.error } : {}),
+		};
+	}
+	const usage = value.usage === undefined ? undefined : parseUsage(value.usage);
+	const extractedToolData =
+		value.extractedToolData === undefined ? undefined : parseExtractedToolData(value.extractedToolData);
+	const retryFailure = value.retryFailure === undefined ? undefined : parseRetryFailure(value.retryFailure);
+	const outputMeta = value.outputMeta === undefined ? undefined : parseOutputMeta(value.outputMeta);
+	return {
+		index: value.index as number,
+		id: value.id,
+		agent: value.agent,
+		agentSource: value.agentSource as SingleResult["agentSource"],
+		task: value.task,
+		...(typeof value.assignment === "string" ? { assignment: value.assignment } : {}),
+		...(typeof value.description === "string" ? { description: value.description } : {}),
+		...(typeof value.lastIntent === "string" ? { lastIntent: value.lastIntent } : {}),
+		exitCode: value.exitCode as number,
+		output: value.output,
+		stderr: value.stderr,
+		truncated: value.truncated,
+		durationMs: value.durationMs,
+		tokens: value.tokens,
+		requests: value.requests as number,
+		...(typeof value.contextTokens === "number" ? { contextTokens: value.contextTokens } : {}),
+		...(typeof value.contextWindow === "number" ? { contextWindow: value.contextWindow } : {}),
+		...(typeof value.modelOverride === "string" || Array.isArray(value.modelOverride)
+			? { modelOverride: value.modelOverride as string | string[] }
+			: {}),
+		...(typeof value.modelRole === "string" ? { modelRole: value.modelRole } : {}),
+		...(typeof value.resolvedModel === "string" ? { resolvedModel: value.resolvedModel } : {}),
+		...(typeof value.resolvedModelIsFallback === "boolean"
+			? { resolvedModelIsFallback: value.resolvedModelIsFallback }
+			: {}),
+		...(structuredOutput ? { structuredOutput } : {}),
+		...(typeof value.error === "string" ? { error: value.error } : {}),
+		...(typeof value.aborted === "boolean" ? { aborted: value.aborted } : {}),
+		...(typeof value.abortReason === "string" ? { abortReason: value.abortReason } : {}),
+		...(usage ? { usage } : {}),
+		...(extractedToolData ? { extractedToolData } : {}),
+		...(retryFailure ? { retryFailure } : {}),
+		...(outputMeta ? { outputMeta } : {}),
+	};
+}
+
+function protocolObject(value: unknown, label: string): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", `${label} is malformed.`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function rejectUnknownKeys(value: Record<string, unknown>, allowed: Record<string, true>, label: string): void {
+	for (const key of Object.keys(value)) {
+		if (!Object.hasOwn(allowed, key)) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", `${label} contains unknown fields.`);
+		}
+	}
+}
+
+function requireKeys(value: Record<string, unknown>, required: readonly string[], label: string): void {
+	for (const key of required) {
+		if (!Object.hasOwn(value, key)) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", `${label} is incomplete.`);
+		}
+	}
+}
+
+function parseIdentity(value: unknown): RemoteAgentIdentity {
+	const identity = protocolObject(value, "Remote execution identity");
+	rejectUnknownKeys(identity, IDENTITY_KEYS, "Remote execution identity");
+	requireKeys(identity, ["controllerId", "executionId", "generation"], "Remote execution identity");
+	if (
+		typeof identity.controllerId !== "string" ||
+		identity.controllerId.length === 0 ||
+		identity.controllerId.length > 64 ||
+		typeof identity.executionId !== "string" ||
+		!ULID_RE.test(identity.executionId) ||
+		!Number.isSafeInteger(identity.generation) ||
+		(identity.generation as number) <= 0
+	) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote execution identity is malformed.");
+	}
+	return {
+		controllerId: identity.controllerId,
+		executionId: identity.executionId,
+		generation: identity.generation as number,
+	};
+}
+
+function samePeerIdentity(left: PeerExecutionIdentity, right: PeerExecutionIdentity): boolean {
+	if (left.locality !== right.locality || left.agentId !== right.agentId || left.generation !== right.generation) {
+		return false;
+	}
+	return (
+		left.locality === "local" ||
+		(right.locality === "remote" &&
+			left.controllerId === right.controllerId &&
+			left.executionId === right.executionId)
+	);
+}
+
+function parsePeerIdentity(value: unknown): PeerExecutionIdentity {
+	const identity = protocolObject(value, "Peer execution identity");
+	rejectUnknownKeys(identity, PEER_IDENTITY_KEYS, "Peer execution identity");
+	requireKeys(identity, ["locality", "agentId", "generation"], "Peer execution identity");
+	if (
+		(identity.locality !== "local" && identity.locality !== "remote") ||
+		typeof identity.agentId !== "string" ||
+		identity.agentId.length === 0 ||
+		identity.agentId.length > 256 ||
+		!Number.isSafeInteger(identity.generation) ||
+		(identity.generation as number) <= 0
+	) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Peer execution identity is malformed.");
+	}
+	if (identity.locality === "local") {
+		if (identity.controllerId !== undefined || identity.executionId !== undefined) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Local peer identity contains remote fields.");
+		}
+		return { locality: "local", agentId: identity.agentId, generation: identity.generation as number };
+	}
+	if (
+		typeof identity.controllerId !== "string" ||
+		identity.controllerId.length === 0 ||
+		identity.controllerId.length > 64 ||
+		typeof identity.executionId !== "string" ||
+		!ULID_RE.test(identity.executionId)
+	) {
+		throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote peer identity is malformed.");
+	}
+	return {
+		locality: "remote",
+		agentId: identity.agentId,
+		generation: identity.generation as number,
+		controllerId: identity.controllerId,
+		executionId: identity.executionId,
+	};
+}
+
+/** Socket implementation of the controller-owned registry calls. */
+export class SocketRemoteRegistryBackend implements RemoteRegistryBackend {
+	readonly #client: RemoteRuntimeClient;
+
+	constructor(client: RemoteRuntimeClient) {
+		this.#client = client;
+	}
+
+	async status(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<AgentStatus>> {
+		const response = await this.#registryRequest("registry.status", identity, signal);
+		if (!["running", "idle", "parked", "aborted"].includes(response.value as string)) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote registry status result is malformed.");
+		}
+		return { identity: response.identity, value: response.value as AgentStatus };
+	}
+
+	async progress(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<RemoteAgentProgress>> {
+		const response = await this.#registryRequest("registry.progress", identity, signal);
+		const progress = protocolObject(response.value, "Remote registry progress result");
+		rejectUnknownKeys(progress, REGISTRY_PROGRESS_KEYS, "Remote registry progress result");
+		requireKeys(progress, ["sequence"], "Remote registry progress result");
+		if (
+			!Number.isSafeInteger(progress.sequence) ||
+			(progress.sequence as number) < 0 ||
+			(progress.message !== undefined && (typeof progress.message !== "string" || progress.message.length > 4_096))
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote registry progress result is malformed.");
+		}
+		return {
+			identity: response.identity,
+			value: {
+				sequence: progress.sequence as number,
+				...(typeof progress.message === "string" ? { message: progress.message } : {}),
+			},
+		};
+	}
+
+	async cancel(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<"cancelled">> {
+		const response = await this.#registryRequest("registry.cancel", identity, signal);
+		if (response.value !== "cancelled") {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote registry cancellation result is malformed.");
+		}
+		return { identity: response.identity, value: "cancelled" };
+	}
+
+	async result(
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<RemoteAgentResult>> {
+		const response = await this.#registryRequest("registry.result", identity, signal);
+		const result = protocolObject(response.value, "Remote registry terminal result");
+		rejectUnknownKeys(result, REGISTRY_RESULT_KEYS, "Remote registry terminal result");
+		requireKeys(result, ["outcome"], "Remote registry terminal result");
+		if (
+			(result.outcome !== "completed" && result.outcome !== "failed" && result.outcome !== "cancelled") ||
+			(result.outcome === "completed" && result.error !== undefined) ||
+			(result.outcome === "failed" &&
+				(typeof result.error !== "string" || result.error.length === 0 || result.error.length > 4_096)) ||
+			(result.outcome === "cancelled" && result.error !== undefined)
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote registry terminal result is malformed.");
+		}
+		return {
+			identity: response.identity,
+			value: {
+				outcome: result.outcome as RemoteAgentResult["outcome"],
+				...(Object.hasOwn(result, "output") ? { output: result.output } : {}),
+				...(result.outcome === "failed" ? { error: "Remote execution failed." } : {}),
+			},
+		};
+	}
+
+	async #registryRequest(
+		operation: string,
+		identity: Readonly<RemoteAgentIdentity>,
+		signal?: AbortSignal,
+	): Promise<RemoteRegistryResponse<unknown>> {
+		const result = await this.#client.request(operation, { identity }, { signal });
+		const response = protocolObject(result, "Remote registry result");
+		rejectUnknownKeys(response, REGISTRY_RESPONSE_KEYS, "Remote registry result");
+		requireKeys(response, ["identity", "value"], "Remote registry result");
+		const responseIdentity = parseIdentity(response.identity);
+		if (
+			responseIdentity.controllerId !== identity.controllerId ||
+			responseIdentity.executionId !== identity.executionId ||
+			responseIdentity.generation !== identity.generation
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote registry result identity is stale.");
+		}
+		return { identity: responseIdentity, value: response.value };
+	}
+}
+
+/** Socket implementation of ordered peer delivery and cancellation. */
+export class SocketPeerTransportBackend implements PeerTransportBackend {
+	readonly #client: RemoteRuntimeClient;
+	readonly #executionId: string;
+
+	constructor(client: RemoteRuntimeClient, config: RemoteRuntimeConfig) {
+		this.#client = client;
+		this.#executionId = config.executionId;
+	}
+
+	async deliver(delivery: Readonly<PeerTransportDelivery>, signal?: AbortSignal): Promise<PeerTransportResult> {
+		const result = await this.#client.request(
+			"peer.deliver",
+			{ delivery },
+			{
+				signal,
+				idempotencyKey: `${this.#executionId}:peer:${delivery.deliveryId}`,
+			},
+		);
+		const response = protocolObject(result, "Remote peer result");
+		rejectUnknownKeys(response, PEER_RESULT_KEYS, "Remote peer result");
+		requireKeys(response, ["deliveryId", "sequence", "sender", "recipient", "outcome"], "Remote peer result");
+		const parsed: PeerTransportResult = {
+			deliveryId: typeof response.deliveryId === "string" ? response.deliveryId : "",
+			sequence: typeof response.sequence === "number" ? response.sequence : -1,
+			sender: parsePeerIdentity(response.sender),
+			recipient: parsePeerIdentity(response.recipient),
+			outcome: response.outcome as PeerTransportResult["outcome"],
+			...(typeof response.error === "string" ? { error: response.error } : {}),
+		};
+		if (
+			parsed.deliveryId !== delivery.deliveryId ||
+			parsed.sequence !== delivery.sequence ||
+			!samePeerIdentity(parsed.sender, delivery.sender) ||
+			!samePeerIdentity(parsed.recipient, delivery.recipient) ||
+			!["accepted", "rejected", "duplicate", "conflict"].includes(parsed.outcome) ||
+			(parsed.error !== undefined && parsed.error.length > 4_096)
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote peer result is malformed or stale.");
+		}
+		return parsed;
+	}
+
+	async cancel(delivery: Readonly<PeerTransportDelivery>): Promise<void> {
+		const result = await this.#client.request(
+			"peer.cancel",
+			{ deliveryId: delivery.deliveryId, sequence: delivery.sequence },
+			{ idempotencyKey: `${this.#executionId}:peer:${delivery.deliveryId}:cancel` },
+		);
+		const response = protocolObject(result, "Remote peer cancellation result");
+		rejectUnknownKeys(response, { cancelled: true }, "Remote peer cancellation result");
+		requireKeys(response, ["cancelled"], "Remote peer cancellation result");
+		if (response.cancelled !== true) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote peer cancellation result is malformed.");
+		}
+	}
+}
+
+/**
+ * Socket backend for structured children; it sends no ToolSession or filesystem paths.
+ * Each launch requires one running registry observation before its terminal response.
+ */
+export class SocketStructuredSubagentBackend implements StructuredSubagentBackend {
+	readonly #client: RemoteRuntimeClient;
+	readonly #config: RemoteRuntimeConfig;
+	readonly #registryBackend: RemoteRegistryBackend;
+	readonly #active = new WeakMap<StructuredSubagentBackendContext, ActiveRemoteLaunch>();
+
+	constructor(client: RemoteRuntimeClient, config: RemoteRuntimeConfig, registryBackend?: RemoteRegistryBackend) {
+		this.#client = client;
+		this.#config = config;
+		this.#registryBackend = registryBackend ?? new SocketRemoteRegistryBackend(client);
+	}
+
+	async run(context: StructuredSubagentBackendContext): Promise<StructuredSubagentResult> {
+		const { request, policy } = context;
+		const index = request.index ?? 0;
+		const observationStream = `subagent.${randomUUID()}`;
+		const idempotencyKey = request.parentToolCallId
+			? `${this.#config.executionId}:${request.parentToolCallId}:${index}`
+			: `${this.#config.executionId}:${randomUUID()}`;
+		const state: ActiveRemoteLaunch = {
+			registry: context.request.session.agentRegistry ?? AgentRegistry.global(),
+		};
+		if (this.#active.has(context)) {
+			throw new RemoteRuntimeProtocolError("DUPLICATE_LAUNCH", "Remote structured launch context was reused.");
+		}
+		this.#active.set(context, state);
+		const removeObservation = this.#client.onObservation(observationStream, envelope => {
+			try {
+				const observation = protocolObject(envelope.observation, "Remote structured observation");
+				rejectUnknownKeys(observation, STRUCTURED_OBSERVATION_KEYS, "Remote structured observation");
+				requireKeys(observation, ["type", "registration"], "Remote structured observation");
+				if (observation.type !== "registry.register" || state.running) {
+					throw new RemoteRuntimeProtocolError(
+						"MALFORMED_RESULT",
+						"Remote structured registration observation is malformed or duplicated.",
+					);
+				}
+				const input = this.#parseRegistration(observation.registration, context, "running");
+				const ref = state.registry.registerRemote(input, this.#registryBackend);
+				state.running = { input, ref };
+			} catch {
+				state.observationError = new RemoteRuntimeProtocolError(
+					"REGISTRATION_REJECTED",
+					"Remote structured running registration was rejected.",
+				);
+			}
+		});
+		try {
+			const maxRuntimeMs = request.maxRuntimeMs ?? request.session.settings.get("task.maxRuntimeMs");
+			const restrictToolNames = policy.planMode || request.session.restrictToolNames === true;
+			const result = await this.#client.request(
+				"subagent.run",
+				{
+					invocationKind: request.invocationKind,
+					assignment: request.assignment,
+					context: request.context ?? null,
+					agent: {
+						name: policy.agent.name,
+						source: policy.agent.source,
+						modelOverride: policy.modelOverride ?? null,
+						modelRole: policy.modelRole ?? null,
+					},
+					planMode: policy.planMode,
+					restrictToolNames,
+					enableMCP: !restrictToolNames && (request.session.enableMCP ?? true),
+					outputSchema: {
+						...(context.outputSchema.schema === undefined ? {} : { schema: context.outputSchema.schema }),
+						outputSchemaOverridesAgent: context.outputSchema.outputSchemaOverridesAgent,
+						source: context.outputSchema.source,
+						mode: context.outputSchema.mode,
+						reference: this.#config.schemaRef,
+					},
+					identity: {
+						id: request.identity?.id ?? null,
+						label: request.identity?.label ?? null,
+					},
+					index,
+					parentToolCallId: request.parentToolCallId ?? null,
+					effort: request.effort ?? null,
+					observationStream,
+					isolated: policy.isIsolated,
+					mergeMode: policy.mergeMode,
+					applyChanges: policy.applyChanges,
+					enableLsp: policy.enableLsp,
+					enableIrc: policy.enableIrc,
+					maxRuntimeMs,
+				},
+				{
+					signal: context.signal,
+					idempotencyKey,
+					timeoutMs: remoteLaunchTimeout(maxRuntimeMs),
+				},
+			);
+			if (state.observationError) throw state.observationError;
+			return this.#parseResult(result, context, state);
+		} catch (error) {
+			this.discard(context);
+			throw error;
+		} finally {
+			removeObservation();
+		}
+	}
+
+	accept(context: StructuredSubagentBackendContext): void {
+		const state = this.#active.get(context);
+		if (!state?.running || !state.terminal) {
+			throw new RemoteRuntimeProtocolError(
+				"MISSING_REGISTRATION",
+				"Remote structured launch did not publish a running child registration.",
+			);
+		}
+		if (!this.#sameRegistration(state.running.input, state.terminal)) {
+			throw new RemoteRuntimeProtocolError(
+				"CONFLICTING_REGISTRATION",
+				"Remote structured terminal registration conflicts with the running child.",
+			);
+		}
+		state.registry.settleRemote(state.terminal, state.running.ref, this.#registryBackend);
+		this.#active.delete(context);
+	}
+
+	discard(context: StructuredSubagentBackendContext): void {
+		const state = this.#active.get(context);
+		if (!state) return;
+		if (state.running) state.registry.unregister(state.running.ref.id, state.running.ref);
+		this.#active.delete(context);
+	}
+
+	#parseResult(
+		value: unknown,
+		context: StructuredSubagentBackendContext,
+		state: ActiveRemoteLaunch,
+	): StructuredSubagentResult {
+		const response = protocolObject(value, "Remote structured subagent response");
+		rejectUnknownKeys(response, STRUCTURED_RESPONSE_KEYS, "Remote structured subagent response");
+		requireKeys(response, ["execution", "registration"], "Remote structured subagent response");
+		const execution = protocolObject(response.execution, "Remote structured execution");
+		rejectUnknownKeys(execution, STRUCTURED_EXECUTION_KEYS, "Remote structured execution");
+		requireKeys(
+			execution,
+			["result", "mergeSummary", "changesApplied", "temporaryArtifacts"],
+			"Remote structured execution",
+		);
+		if (
+			execution.mergeSummary !== "" ||
+			execution.changesApplied !== null ||
+			execution.temporaryArtifacts !== false
+		) {
+			throw new RemoteRuntimeProtocolError(
+				"MALFORMED_RESULT",
+				"Remote structured execution cannot expose controller filesystem state.",
+			);
+		}
+		const childResult = protocolObject(execution.result, "Remote structured child result");
+		rejectUnknownKeys(childResult, SINGLE_RESULT_KEYS, "Remote structured child result");
+		const parsedChildResult = parseSingleResult(childResult);
+		const registration = this.#parseRegistration(response.registration, context, "terminal");
+		if (parsedChildResult.id !== registration.id) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote child registration is malformed.");
+		}
+		state.terminal = registration;
+		return {
+			result: parsedChildResult,
+			policy: context.policy,
+			mergeSummary: "",
+			changesApplied: null,
+			artifactsDir: "",
+			temporaryArtifacts: false,
+		};
+	}
+
+	#parseRegistration(
+		value: unknown,
+		context: StructuredSubagentBackendContext,
+		expectedStatus: "running" | "terminal",
+	): RemoteRegisterInput {
+		const registration = protocolObject(value, "Remote child registration");
+		rejectUnknownKeys(registration, REMOTE_REGISTRATION_KEYS, "Remote child registration");
+		requireKeys(
+			registration,
+			["id", "displayName", "kind", "parentId", "status", "identity", "createdAt", "lastActivity"],
+			"Remote child registration",
+		);
+		const identity = parseIdentity(registration.identity);
+		const expectedParentId = context.request.session.getAgentId?.() ?? MAIN_AGENT_ID;
+		const displayName =
+			typeof registration.displayName === "string" ? oneLineLabel(registration.displayName, 128) : "";
+		if (
+			typeof registration.id !== "string" ||
+			!CHILD_ID_RE.test(registration.id) ||
+			(context.request.identity?.id !== undefined && registration.id !== context.request.identity.id) ||
+			displayName.length === 0 ||
+			registration.kind !== "sub" ||
+			registration.parentId !== expectedParentId ||
+			(expectedStatus === "running"
+				? registration.status !== "running"
+				: !["idle", "parked", "aborted"].includes(registration.status as string)) ||
+			!Number.isSafeInteger(registration.createdAt) ||
+			(registration.createdAt as number) < 0 ||
+			!Number.isSafeInteger(registration.lastActivity) ||
+			(registration.lastActivity as number) < (registration.createdAt as number) ||
+			identity.controllerId !== this.#config.controllerId
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_RESULT", "Remote child registration is malformed.");
+		}
+		return {
+			id: registration.id,
+			displayName,
+			kind: "sub",
+			parentId: registration.parentId as string,
+			status: registration.status as AgentStatus,
+			identity,
+			createdAt: registration.createdAt as number,
+			lastActivity: registration.lastActivity as number,
+		};
+	}
+
+	#sameRegistration(running: RemoteRegisterInput, terminal: RemoteRegisterInput): boolean {
+		return (
+			running.id === terminal.id &&
+			running.displayName === terminal.displayName &&
+			running.kind === terminal.kind &&
+			running.parentId === terminal.parentId &&
+			running.createdAt === terminal.createdAt &&
+			running.identity.controllerId === terminal.identity.controllerId &&
+			running.identity.executionId === terminal.identity.executionId &&
+			running.identity.generation === terminal.identity.generation
+		);
+	}
+}

--- a/packages/coding-agent/src/remote-runtime/bootstrap.ts
+++ b/packages/coding-agent/src/remote-runtime/bootstrap.ts
@@ -1,0 +1,41 @@
+import { SocketPeerTransportBackend, SocketRemoteRegistryBackend, SocketStructuredSubagentBackend } from "./backends";
+import { RemoteRuntimeClient } from "./client";
+import { loadRemoteRuntimeConfig, type RemoteRuntimeConfig } from "./config";
+import { type RemoteRuntimeBindings, runWithSealedRemoteRuntime } from "./scope";
+
+export interface RemoteRuntimeInstallation {
+	readonly bindings: RemoteRuntimeBindings;
+	readonly client: RemoteRuntimeClient;
+}
+
+/** Construct one immutable backend set without installing process-global state. */
+export function createRemoteRuntimeInstallation(
+	config: RemoteRuntimeConfig,
+	client: RemoteRuntimeClient = new RemoteRuntimeClient(config),
+): RemoteRuntimeInstallation {
+	const registryBackend = new SocketRemoteRegistryBackend(client);
+	const bindings: RemoteRuntimeBindings = Object.freeze({
+		subagentBackend: new SocketStructuredSubagentBackend(client, config, registryBackend),
+		registryBackend,
+		peerTransport: new SocketPeerTransportBackend(client, config),
+	});
+	return Object.freeze({ bindings, client });
+}
+
+/**
+ * Load and authenticate the launch-owned descriptor before command/session
+ * construction, bind all remote seams for callback, then close only this
+ * installation's client after the asynchronous scope has been removed.
+ */
+export async function runWithRemoteRuntimeConfig<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
+	const config = await loadRemoteRuntimeConfig(configPath);
+	const installation = createRemoteRuntimeInstallation(config);
+	try {
+		return await runWithSealedRemoteRuntime(installation.bindings, async () => {
+			await installation.client.start();
+			return callback();
+		});
+	} finally {
+		installation.client.close();
+	}
+}

--- a/packages/coding-agent/src/remote-runtime/client.ts
+++ b/packages/coding-agent/src/remote-runtime/client.ts
@@ -1,0 +1,820 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import * as path from "node:path";
+import { REMOTE_RUNTIME_PROTOCOL_VERSION, type RemoteRuntimeConfig } from "./config";
+
+export const REMOTE_RUNTIME_MAX_FRAME_BYTES = 1_048_576;
+export const REMOTE_RUNTIME_REQUIRED_CAPABILITIES = Object.freeze([
+	"structured-subagent",
+	"running-child-registration",
+	"registry",
+	"peer-transport",
+	"observations",
+]);
+const MAX_ERROR_CODE_LENGTH = 64;
+const MAX_OPERATION_LENGTH = 96;
+const MAX_TRACKED_SETTLED_REQUESTS = 1_024;
+const MAX_TRACKED_ABANDONED_REQUESTS = 1_024;
+const MAX_TRACKED_CANCEL_REQUESTS = 1_024;
+const MAX_OBSERVATION_STREAMS = 1_024;
+const MAX_REQUEST_TIMEOUT_MS = 2_147_000_000;
+const BOOTSTRAP_RESULT_KEYS: Record<string, true> = {
+	version: true,
+	capabilities: true,
+	maxFrameBytes: true,
+};
+const REQUEST_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const IDEMPOTENCY_KEY_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+const STREAM_RE = /^[A-Za-z0-9._:-]{1,128}$/;
+const ERROR_CODE_RE = /^[A-Z][A-Z0-9_]{0,63}$/;
+const OPERATION_RE = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)+$/;
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+const REQUEST_ENVELOPE_KEYS: Record<string, true> = {
+	protocol: true,
+	kind: true,
+	requestId: true,
+	idempotencyKey: true,
+	context: true,
+	operation: true,
+	payload: true,
+};
+const RESULT_ENVELOPE_KEYS: Record<string, true> = {
+	protocol: true,
+	kind: true,
+	requestId: true,
+	result: true,
+};
+const ERROR_ENVELOPE_KEYS: Record<string, true> = {
+	protocol: true,
+	kind: true,
+	requestId: true,
+	error: true,
+};
+const REMOTE_ERROR_KEYS: Record<string, true> = { code: true, message: true, retryable: true };
+const CANCEL_ENVELOPE_KEYS: Record<string, true> = {
+	protocol: true,
+	kind: true,
+	requestId: true,
+	idempotencyKey: true,
+	context: true,
+	targetRequestId: true,
+	reason: true,
+};
+const CANCEL_ACK_KEYS: Record<string, true> = { cancelled: true };
+const OBSERVATION_ENVELOPE_KEYS: Record<string, true> = {
+	protocol: true,
+	kind: true,
+	stream: true,
+	cursor: true,
+	observation: true,
+};
+
+export interface RemoteRuntimeRequestContext {
+	readonly controllerId: string;
+	readonly executionId: string;
+	readonly revision: string;
+	readonly grantId: string;
+	readonly policyDigest: string;
+	readonly parentExecutionId: string | null;
+	readonly rootExecutionId: string;
+	readonly depth: number;
+	readonly assignmentId: string;
+	readonly budgetRef: string;
+	readonly schemaRef: string;
+}
+
+export interface RemoteRuntimeRequestEnvelope {
+	readonly protocol: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly kind: "request";
+	readonly requestId: string;
+	readonly idempotencyKey: string;
+	readonly context: RemoteRuntimeRequestContext;
+	readonly operation: string;
+	readonly payload: unknown;
+}
+
+export interface RemoteRuntimeCancelEnvelope {
+	readonly protocol: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly kind: "cancel";
+	readonly requestId: string;
+	readonly idempotencyKey: string;
+	readonly context: RemoteRuntimeRequestContext;
+	readonly targetRequestId: string;
+	readonly reason: "aborted" | "timeout";
+}
+
+export interface RemoteRuntimeResultEnvelope {
+	readonly protocol: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly kind: "result";
+	readonly requestId: string;
+	readonly result: unknown;
+}
+
+export interface RemoteRuntimeError {
+	readonly code: string;
+	readonly message: string;
+	readonly retryable: boolean;
+}
+
+export interface RemoteRuntimeErrorEnvelope {
+	readonly protocol: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly kind: "error";
+	readonly requestId: string;
+	readonly error: RemoteRuntimeError;
+}
+
+export interface RemoteRuntimeObservationEnvelope {
+	readonly protocol: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly kind: "observation";
+	readonly stream: string;
+	readonly cursor: number;
+	readonly observation: unknown;
+}
+
+export interface RemoteRuntimeRequestOptions {
+	readonly signal?: AbortSignal;
+	readonly idempotencyKey?: string;
+	readonly timeoutMs?: number | null;
+}
+
+interface PendingRequest {
+	readonly operation: string;
+	readonly resolve: (value: unknown) => void;
+	readonly reject: (error: Error) => void;
+	readonly timeout?: NodeJS.Timeout;
+	readonly signal?: AbortSignal;
+	readonly onAbort?: () => void;
+	written: boolean;
+}
+
+type ObservationListener = (envelope: RemoteRuntimeObservationEnvelope) => void;
+
+interface SocketIdentity {
+	readonly dev: number;
+	readonly ino: number;
+	readonly uid: number;
+	readonly mode: number;
+}
+
+/** Stable, deliberately detail-free error safe for user-visible propagation and logs. */
+export class RemoteRuntimeProtocolError extends Error {
+	readonly code: string;
+	readonly operation?: string;
+
+	constructor(code: string, message: string, operation?: string) {
+		super(message);
+		this.name = "RemoteRuntimeProtocolError";
+		this.code = code;
+		this.operation = operation;
+	}
+}
+
+function assertExactKeys(value: Record<string, unknown>, expected: Record<string, true>, label: string): void {
+	for (const key of Object.keys(value)) {
+		if (!Object.hasOwn(expected, key))
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", `${label} has unknown fields.`);
+	}
+	for (const key of Object.keys(expected)) {
+		if (!Object.hasOwn(value, key))
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", `${label} is incomplete.`);
+	}
+}
+
+function boundedOperation(operation: string): void {
+	if (operation.length > MAX_OPERATION_LENGTH || !OPERATION_RE.test(operation)) {
+		throw new RemoteRuntimeProtocolError("INVALID_OPERATION", "Remote runtime operation is malformed.");
+	}
+}
+
+/** One persistent, multiplexed NDJSON connection to the sealed control plane. */
+export class RemoteRuntimeClient {
+	readonly #config: RemoteRuntimeConfig;
+	readonly #context: RemoteRuntimeRequestContext;
+	readonly #pending = new Map<string, PendingRequest>();
+	readonly #settledRequestIds = new Set<string>();
+	readonly #abandonedRequestIds = new Set<string>();
+	readonly #cancelRequestIds = new Set<string>();
+	readonly #observationCursors = new Map<string, number>();
+	readonly #observationListeners = new Map<string, Set<ObservationListener>>();
+	#socket: net.Socket | undefined;
+	#connectPromise: Promise<void> | undefined;
+	#connectResolve: (() => void) | undefined;
+	#connectReject: ((error: Error) => void) | undefined;
+	#socketVerified = false;
+	#buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+	#closed = false;
+
+	constructor(config: RemoteRuntimeConfig) {
+		this.#config = config;
+		this.#context = Object.freeze({
+			controllerId: config.controllerId,
+			executionId: config.executionId,
+			revision: config.revision,
+			grantId: config.grantId,
+			policyDigest: config.policyDigest,
+			parentExecutionId: config.parentExecutionId,
+			rootExecutionId: config.rootExecutionId,
+			depth: config.depth,
+			assignmentId: config.assignmentId,
+			budgetRef: config.budgetRef,
+			schemaRef: config.schemaRef,
+		});
+	}
+
+	/** Establish the socket and require an explicit version/capability acknowledgement before callers can run. */
+	async start(signal?: AbortSignal): Promise<void> {
+		const result = await this.request(
+			"runtime.bootstrap",
+			{
+				version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+				capabilities: REMOTE_RUNTIME_REQUIRED_CAPABILITIES,
+				maxFrameBytes: REMOTE_RUNTIME_MAX_FRAME_BYTES,
+			},
+			{ signal, idempotencyKey: `${this.#config.executionId}:bootstrap` },
+		);
+		try {
+			if (typeof result !== "object" || result === null || Array.isArray(result)) {
+				throw new RemoteRuntimeProtocolError("VERSION_MISMATCH", "Remote runtime bootstrap was rejected.");
+			}
+			const response = result as Record<string, unknown>;
+			assertExactKeys(response, BOOTSTRAP_RESULT_KEYS, "Remote runtime bootstrap result");
+			if (response.version !== REMOTE_RUNTIME_PROTOCOL_VERSION) {
+				throw new RemoteRuntimeProtocolError("VERSION_MISMATCH", "Remote runtime protocol version mismatch.");
+			}
+			if (
+				!Array.isArray(response.capabilities) ||
+				response.capabilities.length !== REMOTE_RUNTIME_REQUIRED_CAPABILITIES.length ||
+				new Set(response.capabilities).size !== REMOTE_RUNTIME_REQUIRED_CAPABILITIES.length ||
+				response.capabilities.some(
+					capability =>
+						typeof capability !== "string" || !REMOTE_RUNTIME_REQUIRED_CAPABILITIES.includes(capability),
+				)
+			) {
+				throw new RemoteRuntimeProtocolError(
+					"CAPABILITY_MISMATCH",
+					"Remote runtime capability acknowledgement mismatch.",
+				);
+			}
+			if (response.maxFrameBytes !== REMOTE_RUNTIME_MAX_FRAME_BYTES) {
+				throw new RemoteRuntimeProtocolError(
+					"FRAME_LIMIT_MISMATCH",
+					"Remote runtime frame limit acknowledgement mismatch.",
+				);
+			}
+		} catch (error) {
+			const failure =
+				error instanceof RemoteRuntimeProtocolError
+					? error
+					: new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime bootstrap was rejected.");
+			this.#terminalFailure(failure);
+			throw failure;
+		}
+	}
+
+	onObservation(stream: string, listener: ObservationListener): () => void {
+		if (!STREAM_RE.test(stream)) {
+			throw new RemoteRuntimeProtocolError("INVALID_STREAM", "Remote runtime observation stream is malformed.");
+		}
+		let listeners = this.#observationListeners.get(stream);
+		if (!listeners) {
+			if (this.#observationListeners.size >= MAX_OBSERVATION_STREAMS) {
+				throw new RemoteRuntimeProtocolError("TOO_MANY_STREAMS", "Remote runtime observation limit exceeded.");
+			}
+			listeners = new Set();
+			this.#observationListeners.set(stream, listeners);
+		}
+		listeners.add(listener);
+		return () => {
+			listeners?.delete(listener);
+			if (listeners?.size === 0) {
+				this.#observationListeners.delete(stream);
+				this.#observationCursors.delete(stream);
+			}
+		};
+	}
+
+	async request(operation: string, payload: unknown, options: RemoteRuntimeRequestOptions = {}): Promise<unknown> {
+		boundedOperation(operation);
+		if (this.#closed) throw new RemoteRuntimeProtocolError("CLOSED", "Remote runtime is unavailable.", operation);
+		if (options.signal?.aborted) {
+			throw new RemoteRuntimeProtocolError("ABORTED", "Remote runtime request was cancelled.", operation);
+		}
+		const requestId = randomUUID();
+		const idempotencyKey = options.idempotencyKey ?? `${this.#config.executionId}:${requestId}`;
+		if (!IDEMPOTENCY_KEY_RE.test(idempotencyKey)) {
+			throw new RemoteRuntimeProtocolError(
+				"INVALID_IDEMPOTENCY_KEY",
+				"Remote runtime idempotency key is malformed.",
+			);
+		}
+		const timeoutMs = options.timeoutMs === undefined ? this.#config.requestTimeoutMs : options.timeoutMs;
+		if (
+			(timeoutMs === null && operation !== "subagent.run") ||
+			(timeoutMs !== null &&
+				(!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_REQUEST_TIMEOUT_MS))
+		) {
+			throw new RemoteRuntimeProtocolError("INVALID_TIMEOUT", "Remote runtime request timeout is malformed.");
+		}
+		const envelope: RemoteRuntimeRequestEnvelope = {
+			protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+			kind: "request",
+			requestId,
+			idempotencyKey,
+			context: this.#context,
+			operation,
+			payload,
+		};
+		const frame = this.#encodeFrame(envelope, operation);
+		const deferred = Promise.withResolvers<unknown>();
+		const timeout =
+			timeoutMs === null
+				? undefined
+				: setTimeout(() => {
+						this.#cancelPending(requestId, "timeout");
+					}, timeoutMs);
+		const onAbort = options.signal
+			? () => {
+					this.#cancelPending(requestId, "aborted");
+				}
+			: undefined;
+		const pending: PendingRequest = {
+			operation,
+			resolve: deferred.resolve,
+			reject: deferred.reject,
+			timeout,
+			signal: options.signal,
+			onAbort,
+			written: false,
+		};
+		this.#pending.set(requestId, pending);
+		options.signal?.addEventListener("abort", onAbort as () => void, { once: true });
+		try {
+			await Promise.race([this.#ensureConnected(), deferred.promise]);
+			if (!this.#pending.has(requestId)) return await deferred.promise;
+			const socket = this.#socket;
+			if (!socket || socket.destroyed)
+				throw new RemoteRuntimeProtocolError("UNAVAILABLE", "Remote runtime is unavailable.");
+			pending.written = true;
+			socket.write(frame);
+		} catch (error) {
+			if (this.#pending.delete(requestId)) {
+				this.#cleanupPending(pending);
+				pending.reject(
+					error instanceof RemoteRuntimeProtocolError
+						? error
+						: new RemoteRuntimeProtocolError("UNAVAILABLE", "Remote runtime is unavailable.", operation),
+				);
+			}
+		}
+		return deferred.promise;
+	}
+
+	/** Close the exact connection owned by this runtime and reject all still-pending operations. */
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		const socket = this.#socket;
+		this.#socket = undefined;
+		socket?.destroy();
+		this.#failAll(new RemoteRuntimeProtocolError("CLOSED", "Remote runtime was closed."));
+		this.#observationListeners.clear();
+	}
+
+	#encodeFrame(envelope: RemoteRuntimeRequestEnvelope | RemoteRuntimeCancelEnvelope, operation?: string): Buffer {
+		let json: string;
+		try {
+			json = JSON.stringify(envelope);
+		} catch {
+			throw new RemoteRuntimeProtocolError(
+				"UNSERIALIZABLE",
+				"Remote runtime payload is not serializable.",
+				operation,
+			);
+		}
+		const frame = Buffer.from(`${json}\n`);
+		if (frame.byteLength > REMOTE_RUNTIME_MAX_FRAME_BYTES) {
+			throw new RemoteRuntimeProtocolError(
+				"FRAME_TOO_LARGE",
+				"Remote runtime payload exceeds the frame limit.",
+				operation,
+			);
+		}
+		return frame;
+	}
+
+	async #verifySocketPath(expected?: SocketIdentity): Promise<SocketIdentity> {
+		try {
+			const stat = await fs.lstat(this.#config.socketPath);
+			const effectiveUid = typeof process.geteuid === "function" ? process.geteuid() : undefined;
+			if (
+				effectiveUid === undefined ||
+				stat.isSymbolicLink() ||
+				!stat.isSocket() ||
+				stat.uid !== effectiveUid ||
+				(stat.mode & 0o077) !== 0
+			) {
+				throw new Error("untrusted");
+			}
+			const identity: SocketIdentity = {
+				dev: stat.dev,
+				ino: stat.ino,
+				uid: stat.uid,
+				mode: stat.mode,
+			};
+			if (
+				expected &&
+				(identity.dev !== expected.dev ||
+					identity.ino !== expected.ino ||
+					identity.uid !== expected.uid ||
+					identity.mode !== expected.mode)
+			) {
+				throw new Error("changed");
+			}
+			let directory = await fs.realpath(path.dirname(this.#config.socketPath));
+			while (true) {
+				const directoryStat = await fs.lstat(directory);
+				if (
+					directoryStat.isSymbolicLink() ||
+					!directoryStat.isDirectory() ||
+					(directoryStat.uid !== effectiveUid && directoryStat.uid !== 0) ||
+					((directoryStat.mode & 0o022) !== 0 && (directoryStat.mode & 0o1000) === 0)
+				) {
+					throw new Error("writable");
+				}
+				const parent = path.dirname(directory);
+				if (parent === directory) break;
+				directory = parent;
+			}
+			return identity;
+		} catch {
+			throw new RemoteRuntimeProtocolError(
+				"UNTRUSTED_SOCKET",
+				"Remote runtime socket failed local authority verification.",
+			);
+		}
+	}
+
+	async #openVerifiedSocket(): Promise<void> {
+		try {
+			const identity = await this.#verifySocketPath();
+			if (this.#closed) throw new RemoteRuntimeProtocolError("CLOSED", "Remote runtime is unavailable.");
+			const socket = net.createConnection({ path: this.#config.socketPath });
+			this.#socketVerified = false;
+			this.#socket = socket;
+			socket.once("connect", () => {
+				void this.#verifySocketPath(identity).then(
+					() => {
+						if (this.#closed || this.#socket !== socket || socket.destroyed) return;
+						this.#socketVerified = true;
+						this.#connectResolve?.();
+						this.#connectResolve = undefined;
+						this.#connectReject = undefined;
+					},
+					error => {
+						this.#terminalFailure(
+							error instanceof RemoteRuntimeProtocolError
+								? error
+								: new RemoteRuntimeProtocolError(
+										"UNTRUSTED_SOCKET",
+										"Remote runtime socket failed local authority verification.",
+									),
+						);
+					},
+				);
+			});
+			socket.on("data", data => {
+				if (!this.#socketVerified) {
+					this.#terminalFailure(
+						new RemoteRuntimeProtocolError(
+							"UNTRUSTED_SOCKET",
+							"Remote runtime sent data before local authority verification completed.",
+						),
+					);
+					return;
+				}
+				this.#onData(typeof data === "string" ? Buffer.from(data) : data);
+			});
+			socket.on("end", () => {
+				if (!this.#closed && this.#buffer.length > 0) {
+					this.#terminalFailure(
+						new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime ended with an incomplete frame."),
+					);
+				}
+			});
+			socket.on("error", () => {
+				this.#terminalFailure(new RemoteRuntimeProtocolError("UNAVAILABLE", "Remote runtime is unavailable."));
+			});
+			socket.on("close", () => {
+				if (!this.#closed)
+					this.#terminalFailure(new RemoteRuntimeProtocolError("UNAVAILABLE", "Remote runtime disconnected."));
+			});
+		} catch (error) {
+			this.#terminalFailure(
+				error instanceof RemoteRuntimeProtocolError
+					? error
+					: new RemoteRuntimeProtocolError("UNAVAILABLE", "Remote runtime is unavailable."),
+			);
+		}
+	}
+
+	#ensureConnected(): Promise<void> {
+		if (this.#closed)
+			return Promise.reject(new RemoteRuntimeProtocolError("CLOSED", "Remote runtime is unavailable."));
+		if (this.#socketVerified && this.#socket && !this.#socket.destroyed && this.#socket.readyState === "open") {
+			return Promise.resolve();
+		}
+		if (this.#connectPromise) return this.#connectPromise;
+		const deferred = Promise.withResolvers<void>();
+		this.#connectPromise = deferred.promise;
+		this.#connectResolve = deferred.resolve;
+		this.#connectReject = deferred.reject;
+		void this.#openVerifiedSocket();
+		return deferred.promise;
+	}
+
+	#onData(data: Buffer): void {
+		if (this.#closed) return;
+		this.#buffer = this.#buffer.length === 0 ? data : Buffer.concat([this.#buffer, data]);
+		while (true) {
+			const newline = this.#buffer.indexOf(0x0a);
+			if (newline === -1) {
+				if (this.#buffer.byteLength > REMOTE_RUNTIME_MAX_FRAME_BYTES) {
+					this.#terminalFailure(
+						new RemoteRuntimeProtocolError("FRAME_TOO_LARGE", "Remote runtime frame exceeds the limit."),
+					);
+				}
+				return;
+			}
+			if (newline + 1 > REMOTE_RUNTIME_MAX_FRAME_BYTES) {
+				this.#terminalFailure(
+					new RemoteRuntimeProtocolError("FRAME_TOO_LARGE", "Remote runtime frame exceeds the limit."),
+				);
+				return;
+			}
+			const line = this.#buffer.subarray(0, newline);
+			this.#buffer = this.#buffer.subarray(newline + 1);
+			if (line.byteLength === 0 || line.at(-1) === 0x0d) {
+				this.#terminalFailure(
+					new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime frame is malformed."),
+				);
+				return;
+			}
+			try {
+				this.#handleLine(UTF8_DECODER.decode(line));
+			} catch (error) {
+				this.#terminalFailure(
+					error instanceof RemoteRuntimeProtocolError
+						? error
+						: new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime frame is malformed."),
+				);
+				return;
+			}
+		}
+	}
+
+	#handleLine(line: string): void {
+		let decoded: unknown;
+		try {
+			decoded = JSON.parse(line);
+		} catch {
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime frame is malformed.");
+		}
+		if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime frame is malformed.");
+		}
+		const envelope = decoded as Record<string, unknown>;
+		if (envelope.protocol !== REMOTE_RUNTIME_PROTOCOL_VERSION) {
+			throw new RemoteRuntimeProtocolError("VERSION_MISMATCH", "Remote runtime protocol version mismatch.");
+		}
+		if (envelope.kind === "result") {
+			assertExactKeys(envelope, RESULT_ENVELOPE_KEYS, "Remote runtime result envelope");
+			this.#settleResult(envelope.requestId, envelope.result);
+			return;
+		}
+		if (envelope.kind === "error") {
+			assertExactKeys(envelope, ERROR_ENVELOPE_KEYS, "Remote runtime error envelope");
+			this.#settleError(envelope.requestId, envelope.error);
+			return;
+		}
+		if (envelope.kind === "observation") {
+			assertExactKeys(envelope, OBSERVATION_ENVELOPE_KEYS, "Remote runtime observation envelope");
+			this.#deliverObservation(envelope);
+			return;
+		}
+		throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime frame kind is unsupported.");
+	}
+
+	#settleResult(requestIdValue: unknown, result: unknown): void {
+		const requestId = this.#validatedResponseRequestId(requestIdValue);
+		if (this.#cancelRequestIds.delete(requestId)) {
+			if (typeof result !== "object" || result === null || Array.isArray(result)) {
+				throw new RemoteRuntimeProtocolError(
+					"MALFORMED_FRAME",
+					"Remote runtime cancel acknowledgement is malformed.",
+				);
+			}
+			const acknowledgement = result as Record<string, unknown>;
+			assertExactKeys(acknowledgement, CANCEL_ACK_KEYS, "Remote runtime cancel acknowledgement");
+			if (acknowledgement.cancelled !== true) {
+				throw new RemoteRuntimeProtocolError(
+					"MALFORMED_FRAME",
+					"Remote runtime cancel acknowledgement is malformed.",
+				);
+			}
+			return;
+		}
+		const pending = this.#pending.get(requestId);
+		if (!pending) {
+			if (this.#abandonedRequestIds.delete(requestId)) return;
+			if (this.#settledRequestIds.has(requestId)) {
+				throw new RemoteRuntimeProtocolError(
+					"DUPLICATE_TERMINAL",
+					"Remote runtime sent duplicate terminal frames.",
+				);
+			}
+			throw new RemoteRuntimeProtocolError("UNKNOWN_REQUEST", "Remote runtime responded to an unknown request.");
+		}
+		this.#pending.delete(requestId);
+		this.#rememberSettled(requestId);
+		this.#cleanupPending(pending);
+		pending.resolve(result);
+	}
+
+	#settleError(requestIdValue: unknown, errorValue: unknown): void {
+		const requestId = this.#validatedResponseRequestId(requestIdValue);
+		const cancelAcknowledgement = this.#cancelRequestIds.has(requestId);
+		if (typeof errorValue !== "object" || errorValue === null || Array.isArray(errorValue)) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime error envelope is malformed.");
+		}
+		const remoteError = errorValue as Record<string, unknown>;
+		assertExactKeys(remoteError, REMOTE_ERROR_KEYS, "Remote runtime error");
+		if (
+			typeof remoteError.code !== "string" ||
+			remoteError.code.length > MAX_ERROR_CODE_LENGTH ||
+			!ERROR_CODE_RE.test(remoteError.code) ||
+			typeof remoteError.message !== "string" ||
+			Buffer.byteLength(remoteError.message) > 4_096 ||
+			typeof remoteError.retryable !== "boolean"
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime error envelope is malformed.");
+		}
+		if (cancelAcknowledgement) {
+			this.#cancelRequestIds.delete(requestId);
+			return;
+		}
+		const pending = this.#pending.get(requestId);
+		if (!pending) {
+			if (this.#abandonedRequestIds.delete(requestId)) return;
+			if (this.#settledRequestIds.has(requestId)) {
+				throw new RemoteRuntimeProtocolError(
+					"DUPLICATE_TERMINAL",
+					"Remote runtime sent duplicate terminal frames.",
+				);
+			}
+			throw new RemoteRuntimeProtocolError("UNKNOWN_REQUEST", "Remote runtime responded to an unknown request.");
+		}
+		this.#pending.delete(requestId);
+		this.#rememberSettled(requestId);
+		this.#cleanupPending(pending);
+		pending.reject(
+			new RemoteRuntimeProtocolError(
+				remoteError.code,
+				`Remote runtime ${pending.operation} failed (${remoteError.code}).`,
+				pending.operation,
+			),
+		);
+	}
+
+	#deliverObservation(envelope: Record<string, unknown>): void {
+		if (
+			typeof envelope.stream !== "string" ||
+			!STREAM_RE.test(envelope.stream) ||
+			!Number.isSafeInteger(envelope.cursor) ||
+			(envelope.cursor as number) <= 0
+		) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime observation envelope is malformed.");
+		}
+		const listeners = this.#observationListeners.get(envelope.stream);
+		if (!listeners || listeners.size === 0) return;
+		const prior = this.#observationCursors.get(envelope.stream) ?? 0;
+		if (envelope.cursor !== prior + 1) {
+			throw new RemoteRuntimeProtocolError(
+				"OBSERVATION_ORDER",
+				"Remote runtime observation cursor is not contiguous.",
+			);
+		}
+		this.#observationCursors.set(envelope.stream, envelope.cursor as number);
+		const observation: RemoteRuntimeObservationEnvelope = {
+			protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+			kind: "observation",
+			stream: envelope.stream,
+			cursor: envelope.cursor as number,
+			observation: envelope.observation,
+		};
+		for (const listener of listeners) {
+			try {
+				listener(observation);
+			} catch {
+				// A launch-local consumer failure must not terminate unrelated multiplexed requests.
+			}
+		}
+	}
+
+	#validatedResponseRequestId(value: unknown): string {
+		if (typeof value !== "string" || !REQUEST_ID_RE.test(value)) {
+			throw new RemoteRuntimeProtocolError("MALFORMED_FRAME", "Remote runtime response requestId is malformed.");
+		}
+		return value;
+	}
+
+	#cancelPending(requestId: string, reason: "aborted" | "timeout"): void {
+		const pending = this.#pending.get(requestId);
+		if (!pending) return;
+		this.#pending.delete(requestId);
+		this.#cleanupPending(pending);
+		this.#rememberSettled(requestId);
+		this.#rememberAbandoned(requestId);
+		if (pending.written && this.#socket && !this.#socket.destroyed) {
+			const cancelRequestId = randomUUID();
+			this.#rememberCancel(cancelRequestId);
+			const cancel: RemoteRuntimeCancelEnvelope = {
+				protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+				kind: "cancel",
+				requestId: cancelRequestId,
+				idempotencyKey: `${this.#config.executionId}:${cancelRequestId}`,
+				context: this.#context,
+				targetRequestId: requestId,
+				reason,
+			};
+			try {
+				this.#socket.write(this.#encodeFrame(cancel));
+			} catch {
+				// The original request still fails closed; cancellation is best effort after disconnect.
+			}
+		}
+		pending.reject(
+			new RemoteRuntimeProtocolError(
+				reason === "timeout" ? "TIMEOUT" : "ABORTED",
+				reason === "timeout" ? "Remote runtime request timed out." : "Remote runtime request was cancelled.",
+				pending.operation,
+			),
+		);
+	}
+
+	#cleanupPending(pending: PendingRequest): void {
+		clearTimeout(pending.timeout);
+		if (pending.signal && pending.onAbort) pending.signal.removeEventListener("abort", pending.onAbort);
+	}
+
+	#rememberSettled(requestId: string): void {
+		this.#settledRequestIds.add(requestId);
+		if (this.#settledRequestIds.size <= MAX_TRACKED_SETTLED_REQUESTS) return;
+		const oldest = this.#settledRequestIds.values().next().value;
+		if (typeof oldest === "string") this.#settledRequestIds.delete(oldest);
+	}
+
+	#rememberAbandoned(requestId: string): void {
+		this.#abandonedRequestIds.delete(requestId);
+		this.#abandonedRequestIds.add(requestId);
+		if (this.#abandonedRequestIds.size <= MAX_TRACKED_ABANDONED_REQUESTS) return;
+		const oldest = this.#abandonedRequestIds.values().next().value;
+		if (typeof oldest === "string") this.#abandonedRequestIds.delete(oldest);
+	}
+
+	#rememberCancel(requestId: string): void {
+		this.#cancelRequestIds.add(requestId);
+		if (this.#cancelRequestIds.size <= MAX_TRACKED_CANCEL_REQUESTS) return;
+		const oldest = this.#cancelRequestIds.values().next().value;
+		if (typeof oldest === "string") this.#cancelRequestIds.delete(oldest);
+	}
+
+	#terminalFailure(error: RemoteRuntimeProtocolError): void {
+		this.#connectReject?.(error);
+		this.#connectResolve = undefined;
+		this.#connectReject = undefined;
+		this.#socketVerified = false;
+		this.#closed = true;
+		this.#socket?.destroy();
+		this.#socket = undefined;
+		this.#failAll(error);
+	}
+
+	#failAll(error: RemoteRuntimeProtocolError): void {
+		for (const [requestId, pending] of this.#pending) {
+			this.#pending.delete(requestId);
+			this.#rememberSettled(requestId);
+			this.#cleanupPending(pending);
+			pending.reject(error);
+		}
+	}
+}
+
+// These constants are exported only for exact-frame contract tests and controller implementations.
+export const REMOTE_RUNTIME_FRAME_KEYS = Object.freeze({
+	request: REQUEST_ENVELOPE_KEYS,
+	cancel: CANCEL_ENVELOPE_KEYS,
+	result: RESULT_ENVELOPE_KEYS,
+	error: ERROR_ENVELOPE_KEYS,
+	observation: OBSERVATION_ENVELOPE_KEYS,
+});

--- a/packages/coding-agent/src/remote-runtime/config.ts
+++ b/packages/coding-agent/src/remote-runtime/config.ts
@@ -1,0 +1,215 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const REMOTE_RUNTIME_PROTOCOL_VERSION = "omp.remote-runtime.v1" as const;
+
+const CONFIG_KEYS = [
+	"version",
+	"socketPath",
+	"controllerId",
+	"executionId",
+	"rootExecutionId",
+	"parentExecutionId",
+	"assignmentId",
+	"depth",
+	"revision",
+	"grantId",
+	"policyDigest",
+	"budgetRef",
+	"schemaRef",
+	"requestTimeoutMs",
+] as const;
+const CONFIG_KEY_LOOKUP: Record<(typeof CONFIG_KEYS)[number], true> = {
+	version: true,
+	socketPath: true,
+	controllerId: true,
+	executionId: true,
+	rootExecutionId: true,
+	parentExecutionId: true,
+	assignmentId: true,
+	depth: true,
+	revision: true,
+	grantId: true,
+	policyDigest: true,
+	budgetRef: true,
+	schemaRef: true,
+	requestTimeoutMs: true,
+};
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const REVISION_RE = /^[0-9a-f]{40}$/i;
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/i;
+const CONTROLLER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const LOGICAL_REF_RE = /^[a-z][a-z0-9+.-]{0,31}:[A-Za-z0-9._~-]{1,191}$/;
+const MAX_CONFIG_BYTES = 16_384;
+const MAX_SOCKET_PATH_BYTES = 100;
+
+export class RemoteRuntimeConfigError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RemoteRuntimeConfigError";
+	}
+}
+
+/** Immutable, launch-owned authority descriptor. It intentionally has no credential field. */
+export interface RemoteRuntimeConfig {
+	readonly version: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly socketPath: string;
+	readonly controllerId: string;
+	readonly executionId: string;
+	readonly rootExecutionId: string;
+	readonly parentExecutionId: string | null;
+	readonly assignmentId: string;
+	readonly depth: number;
+	readonly revision: string;
+	readonly grantId: string;
+	readonly policyDigest: string;
+	readonly budgetRef: string;
+	readonly schemaRef: string;
+	readonly requestTimeoutMs: number;
+}
+
+function requireString(value: unknown, field: string): string {
+	if (typeof value !== "string" || value.length === 0 || value !== value.trim() || value.includes("\0")) {
+		throw new RemoteRuntimeConfigError(`Remote runtime config field ${field} must be a non-empty normalized string.`);
+	}
+	return value;
+}
+
+function requireUlid(value: unknown, field: string): string {
+	const candidate = requireString(value, field);
+	if (!ULID_RE.test(candidate))
+		throw new RemoteRuntimeConfigError(`Remote runtime config field ${field} must be an uppercase ULID.`);
+	return candidate;
+}
+
+function requireLogicalRef(value: unknown, field: string): string {
+	const candidate = requireString(value, field);
+	if (!LOGICAL_REF_RE.test(candidate)) {
+		throw new RemoteRuntimeConfigError(`Remote runtime config field ${field} must be a bounded logical reference.`);
+	}
+	return candidate;
+}
+
+/** Validate untrusted JSON without accepting aliases, defaults, or partial authority. */
+export function parseRemoteRuntimeConfig(value: unknown): RemoteRuntimeConfig {
+	if (process.platform === "win32")
+		throw new RemoteRuntimeConfigError("Sealed remote runtime mode requires Unix domain sockets.");
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new RemoteRuntimeConfigError("Remote runtime config must be a JSON object.");
+	}
+	const candidate = value as Record<string, unknown>;
+	for (const key of Object.keys(candidate)) {
+		if (!Object.hasOwn(CONFIG_KEY_LOOKUP, key))
+			throw new RemoteRuntimeConfigError("Remote runtime config contains unknown fields.");
+	}
+	for (const key of CONFIG_KEYS) {
+		if (!Object.hasOwn(candidate, key))
+			throw new RemoteRuntimeConfigError(`Remote runtime config is missing required field ${key}.`);
+	}
+	if (candidate.version !== REMOTE_RUNTIME_PROTOCOL_VERSION) {
+		throw new RemoteRuntimeConfigError(`Remote runtime config version must be ${REMOTE_RUNTIME_PROTOCOL_VERSION}.`);
+	}
+	const socketPath = requireString(candidate.socketPath, "socketPath");
+	if (!path.isAbsolute(socketPath) || /^[A-Za-z]:[\\/]/.test(socketPath)) {
+		throw new RemoteRuntimeConfigError("Remote runtime socketPath must be an absolute Unix path.");
+	}
+	if (Buffer.byteLength(socketPath) > MAX_SOCKET_PATH_BYTES) {
+		throw new RemoteRuntimeConfigError("Remote runtime socketPath exceeds the Unix socket path limit.");
+	}
+	const controllerId = requireString(candidate.controllerId, "controllerId");
+	if (!CONTROLLER_ID_RE.test(controllerId))
+		throw new RemoteRuntimeConfigError("Remote runtime controllerId is malformed.");
+	if (!Number.isSafeInteger(candidate.depth) || (candidate.depth as number) < 0 || (candidate.depth as number) > 64) {
+		throw new RemoteRuntimeConfigError("Remote runtime config field depth must be an integer between 0 and 64.");
+	}
+	const revision = requireString(candidate.revision, "revision");
+	if (!REVISION_RE.test(revision)) {
+		throw new RemoteRuntimeConfigError("Remote runtime revision must be an immutable 40-character commit hash.");
+	}
+	const policyDigest = requireString(candidate.policyDigest, "policyDigest");
+	if (!DIGEST_RE.test(policyDigest))
+		throw new RemoteRuntimeConfigError("Remote runtime policyDigest must be a SHA-256 digest.");
+	if (
+		!Number.isSafeInteger(candidate.requestTimeoutMs) ||
+		(candidate.requestTimeoutMs as number) < 100 ||
+		(candidate.requestTimeoutMs as number) > 120_000
+	) {
+		throw new RemoteRuntimeConfigError("Remote runtime requestTimeoutMs must be an integer between 100 and 120000.");
+	}
+	const parentExecutionId =
+		candidate.parentExecutionId === null ? null : requireUlid(candidate.parentExecutionId, "parentExecutionId");
+	const config: RemoteRuntimeConfig = {
+		version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		socketPath,
+		controllerId,
+		executionId: requireUlid(candidate.executionId, "executionId"),
+		rootExecutionId: requireUlid(candidate.rootExecutionId, "rootExecutionId"),
+		parentExecutionId,
+		assignmentId: requireUlid(candidate.assignmentId, "assignmentId"),
+		depth: candidate.depth as number,
+		revision: revision.toLowerCase(),
+		grantId: requireUlid(candidate.grantId, "grantId"),
+		policyDigest: policyDigest.toLowerCase(),
+		budgetRef: requireLogicalRef(candidate.budgetRef, "budgetRef"),
+		schemaRef: requireLogicalRef(candidate.schemaRef, "schemaRef"),
+		requestTimeoutMs: candidate.requestTimeoutMs as number,
+	};
+	if (config.depth === 0 && config.parentExecutionId !== null) {
+		throw new RemoteRuntimeConfigError("A root remote runtime config cannot declare parentExecutionId.");
+	}
+	if (config.depth > 0 && config.parentExecutionId === null) {
+		throw new RemoteRuntimeConfigError("A nested remote runtime config requires parentExecutionId.");
+	}
+	return Object.freeze(config);
+}
+
+/** Read one bounded descriptor through a stable file handle, then freeze its validated value. */
+export async function loadRemoteRuntimeConfig(configPath: string): Promise<RemoteRuntimeConfig> {
+	if (configPath.includes("\0") || !path.isAbsolute(configPath) || /^[A-Za-z]:[\\/]/.test(configPath)) {
+		throw new RemoteRuntimeConfigError("--remote-runtime-config requires an absolute Unix path.");
+	}
+	let handle: fs.FileHandle;
+	try {
+		handle = await fs.open(configPath, "r");
+	} catch {
+		throw new RemoteRuntimeConfigError("Remote runtime config could not be opened.");
+	}
+	try {
+		const before = await handle.stat();
+		const effectiveUid = process.geteuid?.();
+		if (
+			!before.isFile() ||
+			before.size <= 0 ||
+			before.size > MAX_CONFIG_BYTES ||
+			effectiveUid === undefined ||
+			before.uid !== effectiveUid ||
+			(before.mode & 0o077) !== 0
+		) {
+			throw new RemoteRuntimeConfigError(
+				"Remote runtime config must be a current-user-owned, private, non-empty bounded regular file.",
+			);
+		}
+		const text = await handle.readFile({ encoding: "utf8" });
+		const after = await handle.stat();
+		if (
+			before.dev !== after.dev ||
+			before.ino !== after.ino ||
+			before.size !== after.size ||
+			before.mtimeMs !== after.mtimeMs
+		) {
+			throw new RemoteRuntimeConfigError("Remote runtime config changed while it was being read.");
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(text);
+		} catch {
+			throw new RemoteRuntimeConfigError("Remote runtime config must contain valid JSON.");
+		}
+		return parseRemoteRuntimeConfig(parsed);
+	} catch (error) {
+		if (error instanceof RemoteRuntimeConfigError) throw error;
+		throw new RemoteRuntimeConfigError("Remote runtime config could not be read.");
+	} finally {
+		await handle.close().catch(() => {});
+	}
+}

--- a/packages/coding-agent/src/remote-runtime/scope.ts
+++ b/packages/coding-agent/src/remote-runtime/scope.ts
@@ -1,0 +1,52 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { PeerTransportBackend } from "../irc/bus";
+import type { RemoteRegistryBackend } from "../registry/agent-registry";
+import type { StructuredSubagentBackend } from "../task/structured-subagent";
+
+/** Backends installed for exactly one sealed runtime invocation. */
+export interface RemoteRuntimeBindings {
+	readonly subagentBackend: StructuredSubagentBackend;
+	readonly registryBackend: RemoteRegistryBackend;
+	readonly peerTransport: PeerTransportBackend;
+}
+
+const remoteRuntimeStorage = new AsyncLocalStorage<RemoteRuntimeBindings>();
+let sealedRuntimeActive = false;
+
+/** Whether a config-sealed process must reject missing async-local authority. */
+export function remoteRuntimeSealActive(): boolean {
+	return sealedRuntimeActive;
+}
+
+/** Install the one process-sealing scope created from a launch descriptor. */
+export async function runWithSealedRemoteRuntime<T>(
+	bindings: RemoteRuntimeBindings,
+	callback: () => Promise<T>,
+): Promise<T> {
+	if (sealedRuntimeActive) {
+		throw new Error("A config-sealed remote runtime is already active in this process.");
+	}
+	sealedRuntimeActive = true;
+	try {
+		return await runWithRemoteRuntime(bindings, callback);
+	} finally {
+		sealedRuntimeActive = false;
+	}
+}
+
+/** Return the sealed runtime bound to the current asynchronous command scope. */
+export function currentRemoteRuntime(): RemoteRuntimeBindings | undefined {
+	return remoteRuntimeStorage.getStore();
+}
+
+/**
+ * Install one immutable backend set for the lifetime of callback. Async-local
+ * scope keeps concurrent SDK/CLI sessions isolated and removes the exact
+ * installed set automatically when callback settles.
+ */
+export function runWithRemoteRuntime<T>(bindings: RemoteRuntimeBindings, callback: () => T): T {
+	if (remoteRuntimeStorage.getStore()) {
+		throw new Error("A sealed remote runtime is already installed for this command scope.");
+	}
+	return remoteRuntimeStorage.run(Object.freeze(bindings), callback);
+}

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -16,6 +16,7 @@ import { loadOverallPlanReference } from "../plan-mode/plan-handoff";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
 import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.md" with { type: "text" };
 import { MAIN_AGENT_ID } from "../registry/agent-registry";
+import { currentRemoteRuntime, remoteRuntimeSealActive } from "../remote-runtime/scope";
 import type { TaskEffort } from "../thinking";
 import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
@@ -143,6 +144,34 @@ export interface StructuredSubagentResult {
 	changesApplied: boolean | null;
 	artifactsDir: string;
 	temporaryArtifacts: boolean;
+}
+
+/** Explicit execution mode selected by trusted runtime plumbing. */
+export type StructuredSubagentExecutionMode = "local" | "remote";
+
+/** Fully resolved input handed to a remotely executing backend. */
+export interface StructuredSubagentBackendContext {
+	readonly request: StructuredSubagentRequest;
+	readonly policy: EffectiveSubagentPolicy;
+	readonly outputSchema: StructuredSubagentSchemaResolution;
+	readonly signal?: AbortSignal;
+}
+
+/**
+ * Trusted runtime seam for executing a normalized structured subagent remotely.
+ * Lifecycle hooks let a transport publish a running child before completion,
+ * then commit or roll it back only after the shared result validator decides.
+ */
+export interface StructuredSubagentBackend {
+	run(context: StructuredSubagentBackendContext): Promise<StructuredSubagentResult>;
+	accept?(context: StructuredSubagentBackendContext, result: StructuredSubagentResult): Promise<void> | void;
+	discard?(context: StructuredSubagentBackendContext): Promise<void> | void;
+}
+
+/** Launch-owned execution selection; this is deliberately separate from agent-authored request data. */
+export interface StructuredSubagentRuntimeOptions {
+	execution?: StructuredSubagentExecutionMode;
+	backend?: StructuredSubagentBackend;
 }
 
 /** Machine-readable failure category so adapters can retain their native errors. */
@@ -540,12 +569,225 @@ function attachStructuredOutputMetadata(result: SingleResult, schema: Structured
 	result.structuredOutput = output;
 }
 
+function normalizeRemoteRequest(
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+): StructuredSubagentRequest {
+	const identity = request.identity
+		? {
+				id: trimToUndefined(request.identity.id),
+				label: trimToUndefined(request.identity.label),
+			}
+		: undefined;
+	return {
+		...request,
+		assignment: request.assignment.trim(),
+		context: request.context?.trim() || undefined,
+		agent: policy.agentName,
+		schemaMode: policy.schema.mode,
+		identity,
+		index: request.index ?? 0,
+		isolation: {
+			requested: policy.isIsolated,
+			merge: policy.mergeMode,
+			apply: policy.applyChanges,
+		},
+		enableLsp: policy.enableLsp,
+		enableIrc: policy.enableIrc,
+	};
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function validateRemoteResult(
+	value: unknown,
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+): string | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return "result envelope must be an object";
+	const envelope = value as Partial<StructuredSubagentResult>;
+	if (typeof envelope.result !== "object" || envelope.result === null || Array.isArray(envelope.result))
+		return "result must be an object";
+	if (typeof envelope.policy !== "object" || envelope.policy === null || Array.isArray(envelope.policy))
+		return "policy must be an object";
+	if (typeof envelope.mergeSummary !== "string") return "mergeSummary must be a string";
+	if (envelope.changesApplied !== null && typeof envelope.changesApplied !== "boolean")
+		return "changesApplied must be boolean or null";
+	if (typeof envelope.artifactsDir !== "string") return "artifactsDir must be a string";
+	if (typeof envelope.temporaryArtifacts !== "boolean") return "temporaryArtifacts must be boolean";
+
+	const result = envelope.result;
+	if (!Number.isInteger(result.index) || result.index !== (request.index ?? 0))
+		return "result index does not match the normalized request";
+	if (typeof result.id !== "string" || result.id.trim().length === 0) return "result id must be a non-empty string";
+	if (request.identity?.id !== undefined && result.id !== request.identity.id)
+		return "result id does not match the normalized preallocated id";
+	if (result.agent !== policy.agent.name) return "result agent does not match the resolved agent";
+	if (result.agentSource !== policy.agent.source) return "result agentSource does not match the resolved agent";
+	if (typeof result.task !== "string") return "result task must be a string";
+	if (result.assignment !== undefined && result.assignment !== request.assignment)
+		return "result assignment does not match the normalized request";
+	if (!Number.isInteger(result.exitCode)) return "result exitCode must be an integer";
+	if (typeof result.output !== "string") return "result output must be a string";
+	if (typeof result.stderr !== "string") return "result stderr must be a string";
+	if (typeof result.truncated !== "boolean") return "result truncated must be boolean";
+	if (!isFiniteNonNegativeNumber(result.durationMs)) return "result durationMs must be a non-negative number";
+	if (!isFiniteNonNegativeNumber(result.tokens)) return "result tokens must be a non-negative number";
+	if (!Number.isInteger(result.requests) || (result.requests as number) < 0)
+		return "result requests must be a non-negative integer";
+	if (result.error !== undefined && typeof result.error !== "string") return "result error must be a string";
+	if (result.aborted !== undefined && typeof result.aborted !== "boolean") return "result aborted must be boolean";
+	if (result.abortReason !== undefined && typeof result.abortReason !== "string")
+		return "result abortReason must be a string";
+
+	if (policy.schema.source === "none") {
+		if (result.structuredOutput !== undefined) return "schema-free result must not contain structuredOutput";
+		return undefined;
+	}
+	if (typeof result.structuredOutput !== "object" || result.structuredOutput === null)
+		return "schema-bearing result must contain structuredOutput";
+	const structuredOutput = result.structuredOutput;
+	if (structuredOutput.source !== policy.schema.source)
+		return "structuredOutput source does not match effective schema";
+	if (structuredOutput.mode !== policy.schema.mode) return "structuredOutput mode does not match effective schema";
+	if (
+		structuredOutput.status !== "valid" &&
+		structuredOutput.status !== "invalid" &&
+		structuredOutput.status !== "unavailable"
+	) {
+		return "structuredOutput status is invalid";
+	}
+	if (structuredOutput.error !== undefined && typeof structuredOutput.error !== "string")
+		return "structuredOutput error must be a string";
+	if (
+		policy.schema.mode === "strict" &&
+		structuredOutput.status !== "valid" &&
+		(result.exitCode === 0 || !result.stderr.includes("schema_violation"))
+	) {
+		return "strict invalid or unavailable structuredOutput must be a failed schema_violation";
+	}
+	if (structuredOutput.status === "valid") {
+		if (!Object.hasOwn(structuredOutput, "data")) return "valid structuredOutput must contain data";
+		const { validator, error } = buildOutputValidator(policy.schema.schema);
+		if (error) return "valid structuredOutput cannot satisfy an unusable effective schema";
+		const validation = validator?.validate(structuredOutput.data);
+		if (validation && !validation.success) return "structuredOutput data does not satisfy the effective schema";
+	}
+	return undefined;
+}
+
+function remoteAbortReason(signal: AbortSignal | undefined): string {
+	const reason = signal?.reason;
+	if (reason instanceof Error && reason.message.trim()) return reason.message.trim();
+	if (typeof reason === "string" && reason.trim()) return reason.trim();
+	return "Cancelled by caller";
+}
+
+function buildRemoteFailure(
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+	message: string,
+	startedAt: number,
+	aborted = false,
+): StructuredSubagentResult {
+	const id = trimToUndefined(request.identity?.id) ?? sanitizeAgentId(request.identity?.label) ?? "remote";
+	const result = buildFailureResult(request, policy, id, startedAt)(message);
+	if (aborted) {
+		result.aborted = true;
+		result.abortReason = message;
+	}
+	attachStructuredOutputMetadata(result, policy.schema);
+	return {
+		result,
+		policy,
+		mergeSummary: "",
+		changesApplied: null,
+		artifactsDir: "",
+		temporaryArtifacts: false,
+	};
+}
+
+const REMOTE_ABORTED = Symbol("remote structured subagent aborted");
+
+async function runRemoteStructuredSubagent(
+	request: StructuredSubagentRequest,
+	policy: EffectiveSubagentPolicy,
+	backend: StructuredSubagentBackend | undefined,
+): Promise<StructuredSubagentResult> {
+	const startedAt = Date.now();
+	if (!backend) {
+		return buildRemoteFailure(request, policy, "Remote structured subagent backend is unavailable.", startedAt);
+	}
+	const signal = request.signal;
+	if (signal?.aborted) {
+		return buildRemoteFailure(request, policy, remoteAbortReason(signal), startedAt, true);
+	}
+	const context: StructuredSubagentBackendContext = {
+		request,
+		policy,
+		outputSchema: policy.schema,
+		signal,
+	};
+	const cancellation = Promise.withResolvers<typeof REMOTE_ABORTED>();
+	const onAbort = () => cancellation.resolve(REMOTE_ABORTED);
+	signal?.addEventListener("abort", onAbort, { once: true });
+	try {
+		const backendRun = backend.run(context);
+		const candidate = signal ? await Promise.race([backendRun, cancellation.promise]) : await backendRun;
+		if (candidate === REMOTE_ABORTED || signal?.aborted) {
+			await backend.discard?.(context);
+			return buildRemoteFailure(request, policy, remoteAbortReason(signal), startedAt, true);
+		}
+		const malformed = validateRemoteResult(candidate, request, policy);
+		if (malformed) {
+			await backend.discard?.(context);
+			return buildRemoteFailure(
+				request,
+				policy,
+				`Remote structured subagent backend returned a malformed result: ${malformed}.`,
+				startedAt,
+			);
+		}
+		await backend.accept?.(context, candidate);
+		return { ...candidate, policy };
+	} catch (error) {
+		await backend.discard?.(context);
+		if (signal?.aborted) {
+			return buildRemoteFailure(request, policy, remoteAbortReason(signal), startedAt, true);
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		return buildRemoteFailure(request, policy, `Remote structured subagent execution failed: ${message}`, startedAt);
+	} finally {
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
 /**
- * Execute a validated subagent. Preflight errors occur before any artifact
- * lease or child dispatch; callers keep responsibility for their result text.
+ * Execute a validated subagent. Preflight errors occur before any dispatch.
+ * Explicit remote execution follows policy resolution and precedes every local
+ * artifact lease, isolation preparation, and subprocess path.
  */
-export async function runStructuredSubagent(request: StructuredSubagentRequest): Promise<StructuredSubagentResult> {
+export async function runStructuredSubagent(
+	request: StructuredSubagentRequest,
+	runtime?: StructuredSubagentRuntimeOptions,
+): Promise<StructuredSubagentResult> {
 	const policy = await resolveEffectiveSubagentPolicy(request);
+	const scopedRuntime = currentRemoteRuntime();
+	if (scopedRuntime) {
+		return runRemoteStructuredSubagent(
+			normalizeRemoteRequest(request, policy),
+			policy,
+			scopedRuntime.subagentBackend,
+		);
+	}
+	if (remoteRuntimeSealActive()) {
+		throw new Error("Config-sealed remote runtime authority is missing from the current asynchronous scope.");
+	}
+	if (runtime?.execution === "remote") {
+		return runRemoteStructuredSubagent(normalizeRemoteRequest(request, policy), policy, runtime.backend);
+	}
 	const lease = await leaseArtifacts(request.session, request.invocationKind);
 	let changesApplied: boolean | null = null;
 	let mergeSummary = "";

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -283,7 +283,7 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 				if (!params.ids?.length) {
 					return hubErrorResult('`ids` is required for op="cancel".', { op: "cancel", jobs: [] });
 				}
-				return await executeCancel(this.session, manager, this.#ownerId(), params.ids);
+				return await executeCancel(this.session, manager, this.#ownerId(), params.ids, signal);
 			}
 			case "jobs": {
 				const manager = this.session.asyncJobManager;
@@ -343,11 +343,27 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 		const manager = this.session.asyncJobManager;
 		const ownerId = this.#ownerId();
 		const from = params.from?.trim() || undefined;
+		const localSenderMessaging =
+			messaging?.registry.get(messaging.senderId)?.locality === "remote" ? null : messaging;
+		const hasLocalRunningPeer = messaging?.registry
+			.listVisibleTo(messaging.senderId)
+			.some(ref => ref.locality !== "remote" && messaging.registry.isRunning(ref));
+		const hasRemotePeer = messaging?.registry
+			.listVisibleTo(messaging.senderId)
+			.some(ref => ref.locality === "remote");
+		const fromIsRemote = from ? messaging?.registry.get(from)?.locality === "remote" : false;
+		const peerWaitMessaging =
+			messaging?.registry.get(messaging.senderId)?.locality === "remote" ||
+			fromIsRemote ||
+			(!from && !hasLocalRunningPeer && hasRemotePeer)
+				? null
+				: messaging;
 
-		// A message already buffered on the session satisfies the wait first.
-		if (messaging) {
-			const pending = drainPendingInbox(messaging.registry, messaging.senderId, from);
-			if (pending) return messageResult(messaging.senderId, pending);
+		// A local sender always consumes already-buffered session/bus messages
+		// before deciding whether a future remote-only wait is unsupported.
+		if (localSenderMessaging) {
+			const pending = drainPendingInbox(localSenderMessaging.registry, localSenderMessaging.senderId, from);
+			if (pending) return messageResult(localSenderMessaging.senderId, pending);
 		}
 
 		// Resolve which jobs to watch:
@@ -370,17 +386,20 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 
 		if (!manager || runningJobs.length === 0) {
 			// No job legs: pure message wait — or nothing to block on at all.
-			if (!messaging) return nothingToWaitForResult(this.session);
+			if (!peerWaitMessaging) {
+				if (messaging) return executeMessageWait(messaging, { from, timeoutMs: params.timeoutMs }, signal);
+				return nothingToWaitForResult(this.session);
+			}
 			if (!from) {
 				// A bare wait can only be satisfied by a running peer eventually
 				// sending something; with none, return the snapshot immediately
 				// instead of blocking a full message-timeout window.
-				const hasRunningPeer = messaging.registry
-					.listVisibleTo(messaging.senderId)
-					.some(ref => messaging.registry.isRunning(ref));
+				const hasRunningPeer = peerWaitMessaging.registry
+					.listVisibleTo(peerWaitMessaging.senderId)
+					.some(ref => peerWaitMessaging.registry.isRunning(ref));
 				if (!hasRunningPeer) return nothingToWaitForResult(this.session);
 			}
-			return executeMessageWait(messaging, { from, timeoutMs: params.timeoutMs }, signal);
+			return executeMessageWait(peerWaitMessaging, { from, timeoutMs: params.timeoutMs }, signal);
 		}
 
 		// Wait window: explicit timeout wins (0 = no window); otherwise the
@@ -395,13 +414,13 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 
 		// Message leg: park a bus waiter with no timeout of its own — the race
 		// window governs. Cancelled via sentinel so late losers do not reject.
-		const busAbort = messaging ? new AbortController() : undefined;
+		const busAbort = peerWaitMessaging ? new AbortController() : undefined;
 		const busCancelled = new Error("hub wait settled");
 		let removeBusAbortListener: (() => void) | undefined;
 		const busLeg =
-			messaging && busAbort
+			peerWaitMessaging && busAbort
 				? IrcBus.global()
-						.wait(messaging.senderId, { from }, 0, busAbort.signal)
+						.wait(peerWaitMessaging.senderId, { from }, 0, busAbort.signal)
 						.then(
 							message => ({ message, error: null as Error | null }),
 							error => ({
@@ -471,9 +490,9 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 		// A message consumed by the bus waiter must never be dropped — it wins
 		// even a photo-finish race (job results re-deliver themselves; a
 		// dequeued message would otherwise be lost).
-		if (busLeg && messaging) {
+		if (busLeg && peerWaitMessaging) {
 			const settled = await busLeg;
-			if (settled.message) return messageResult(messaging.senderId, settled.message);
+			if (settled.message) return messageResult(peerWaitMessaging.senderId, settled.message);
 		}
 
 		return buildJobResult(this.session, manager, "wait", jobsToWatch, []);

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -7,6 +7,7 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
+import { untilAborted } from "@oh-my-pi/pi-utils";
 import type { AsyncJob, AsyncJobManager } from "../../async";
 import { settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
@@ -35,6 +36,7 @@ const WAIT_DURATION_MS: Record<string, number> = {
 	"1m": 60_000,
 	"5m": 5 * 60_000,
 };
+const REMOTE_AGENT_CANCEL_TIMEOUT_MS = 5_000;
 
 /**
  * A wait snapshot where every watched job is still running and nothing was
@@ -217,9 +219,16 @@ export function buildJobResult(
 
 	const lines: string[] = [];
 
-	if (cancelOutcomes.length > 0) {
-		lines.push(`## Cancelled (${cancelOutcomes.length})\n`);
-		for (const o of cancelOutcomes) lines.push(`- ${o.message}`);
+	const failedCancellations = cancelOutcomes.filter(outcome => outcome.status === "failed");
+	const completedCancellations = cancelOutcomes.filter(outcome => outcome.status !== "failed");
+	if (completedCancellations.length > 0) {
+		lines.push(`## Cancelled (${completedCancellations.length})\n`);
+		for (const outcome of completedCancellations) lines.push(`- ${outcome.message}`);
+		lines.push("");
+	}
+	if (failedCancellations.length > 0) {
+		lines.push(`## Cancellation Failed (${failedCancellations.length})\n`);
+		for (const outcome of failedCancellations) lines.push(`- ${outcome.message}`);
 		lines.push("");
 	}
 
@@ -265,6 +274,7 @@ export function buildJobResult(
 	return {
 		content: [{ type: "text", text: lines.join("\n").trimEnd() }],
 		details,
+		...(cancelOutcomes.some(outcome => outcome.status === "failed") ? { isError: true } : {}),
 		// A wait where everything is still running carries no new information
 		// once a later wait exists — same predicate the TUI uses to displace
 		// stale waiting frames.
@@ -323,16 +333,57 @@ export async function executeCancel(
 	manager: AsyncJobManager,
 	ownerId: string | undefined,
 	ids: string[],
+	signal?: AbortSignal,
 ): Promise<AgentToolResult<CoordinationDetails>> {
 	const ownerFilter = ownerId ? { ownerId } : undefined;
 	const cancelOutcomes: CancelOutcome[] = [];
 	for (const id of ids) {
 		const existing = manager.getJob(id);
+		const registeredRef = session.agentRegistry?.get(id);
+		const ownedRunningJob = existing?.status === "running" && (!ownerId || existing.ownerId === ownerId);
+		if (ownedRunningJob) {
+			const remoteCancellation =
+				registeredRef?.locality === "remote" ? cancelAgentRegistration(session, ownerId, id, signal) : undefined;
+			const localCancelled = manager.cancel(id, ownerFilter);
+			if (remoteCancellation) {
+				const remoteOutcome = await remoteCancellation;
+				if (!localCancelled) {
+					cancelOutcomes.push({
+						id,
+						status: "failed",
+						message: `Background job ${id} remained running while remote cancellation was attempted.`,
+					});
+				} else if (remoteOutcome.status !== "cancelled") {
+					cancelOutcomes.push({
+						...remoteOutcome,
+						status: "failed",
+						message: `${remoteOutcome.message} The owning local background job was cancelled.`,
+					});
+				} else {
+					cancelOutcomes.push({
+						id,
+						status: "cancelled",
+						message: `Cancelled remote agent ${id} and its owning local background job.`,
+					});
+				}
+			} else {
+				cancelOutcomes.push(
+					localCancelled
+						? { id, status: "cancelled", message: `Cancelled background job ${id}.` }
+						: { id, status: "failed", message: `Background job ${id} remained running.` },
+				);
+			}
+			continue;
+		}
+		if (registeredRef?.locality === "remote") {
+			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id, signal));
+			continue;
+		}
 		if (!existing || (ownerId && existing.ownerId !== ownerId)) {
 			// No job by this id (or it belongs to another agent): a budget-aborted
 			// keep-alive subagent lives on as a jobless registration long after its
 			// job row is reaped, so let cancel reach the agent registration too.
-			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id));
+			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id, signal));
 			continue;
 		}
 		if (existing.status !== "running") {
@@ -340,9 +391,9 @@ export async function executeCancel(
 			// The agent registration behind it (job id == agent id for task
 			// spawns) can outlive the row as an idle/parked zombie — try the
 			// registration kill before reporting the row as already done.
-			const regOutcome = await cancelAgentRegistration(session, ownerId, id);
+			const regOutcome = await cancelAgentRegistration(session, ownerId, id, signal);
 			cancelOutcomes.push(
-				regOutcome.status === "cancelled"
+				regOutcome.status === "cancelled" || regOutcome.status === "failed"
 					? regOutcome
 					: {
 							id,
@@ -375,10 +426,11 @@ async function cancelAgentRegistration(
 	session: ToolSession,
 	ownerId: string | undefined,
 	id: string,
+	signal?: AbortSignal,
 ): Promise<CancelOutcome> {
 	const registry = session.agentRegistry;
 	const ref = registry?.get(id);
-	if (ref?.kind !== "sub") {
+	if (!registry || ref?.kind !== "sub") {
 		return { id, status: "not_found", message: `Background job not found: ${id}` };
 	}
 	if (id === ownerId) {
@@ -386,6 +438,25 @@ async function cancelAgentRegistration(
 	}
 	if (ownerId && ref.parentId !== ownerId) {
 		return { id, status: "not_found", message: `Agent ${id} was not spawned by you and cannot be cancelled.` };
+	}
+	if (ref.locality === "remote") {
+		const timeoutSignal = AbortSignal.timeout(REMOTE_AGENT_CANCEL_TIMEOUT_MS);
+		const operationSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+		try {
+			await untilAborted(operationSignal, () => registry.cancelRemote(id, operationSignal));
+			return { id, status: "cancelled", message: `Cancelled remote agent ${id}.` };
+		} catch (error) {
+			const reason = timeoutSignal.aborted
+				? `timed out after ${REMOTE_AGENT_CANCEL_TIMEOUT_MS}ms`
+				: error instanceof Error
+					? error.message
+					: String(error);
+			return {
+				id,
+				status: "failed",
+				message: `Remote agent ${id} cancellation failed: ${reason}.`,
+			};
+		}
 	}
 	const lifecycle = session.agentLifecycle?.();
 	try {

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -66,12 +66,14 @@ export function resolveMessageTimeoutMs(settings: Settings, explicit?: number): 
 	return normalizeIrcTimeoutMs(settings.get("irc.timeoutMs"));
 }
 
-/** Session-buffered inbox drain used before parking a bus waiter. */
+/** Drain one session-buffered message, then the exact IrcBus mailbox, without parking a future waiter. */
 export function drainPendingInbox(registry: AgentRegistry, senderId: string, from?: string): IrcMessage | undefined {
 	const session = registry.get(senderId)?.session;
-	return typeof session?.drainPendingIrcInboxMessages === "function"
-		? session.drainPendingIrcInboxMessages(senderId, { from, limit: 1 })[0]
-		: undefined;
+	const sessionPending =
+		typeof session?.drainPendingIrcInboxMessages === "function"
+			? session.drainPendingIrcInboxMessages(senderId, { from, limit: 1 })[0]
+			: undefined;
+	return sessionPending ?? IrcBus.global().takePending(senderId, from);
 }
 
 /** `wait` result carrying a consumed message. */
@@ -123,7 +125,11 @@ export async function executeList(
 			].filter(Boolean);
 			lines.push(`- ${peer.id} [${peer.displayName} · ${peer.kind} · ${peer.status}] — ${extras.join(", ")}`);
 		}
-		if (peers.some(peer => peer.status === "parked")) {
+		if (
+			refs.some(
+				ref => ref.locality === "local" && ref.kind !== "advisor" && ref.id !== senderId && ref.status === "parked",
+			)
+		) {
 			lines.push("");
 			lines.push("Parked agents are revived automatically when you message them.");
 		}
@@ -162,6 +168,15 @@ export async function executeSend(
 	const isBroadcast = to === "all";
 	if (isBroadcast && params.await) {
 		return hubErrorResult('`await` is invalid with to:"all" — broadcasts have no single replier.', {
+			op: "send",
+			from: senderId,
+			to,
+		});
+	}
+	const directSender = registry.get(senderId);
+	const directRecipient = isBroadcast ? undefined : registry.get(to);
+	if (params.await && (directSender?.locality === "remote" || directRecipient?.locality === "remote")) {
+		return hubErrorResult("Awaited remote peer sends are unavailable without a controller wait transport.", {
 			op: "send",
 			from: senderId,
 			to,
@@ -215,7 +230,11 @@ export async function executeSend(
 					// Awaited sends mark the sender as blocked on an answer so a
 					// busy recipient that cannot reach a step boundary (async
 					// disabled) auto-replies instead of stranding the sender.
-					{ expectsReply: params.await || undefined, suppressRelay: suppressRelay || undefined },
+					{
+						expectsReply: params.await || undefined,
+						suppressRelay: suppressRelay || undefined,
+						signal,
+					},
 				),
 			),
 		);
@@ -297,7 +316,30 @@ export async function executeMessageWait(
 	signal?: AbortSignal,
 ): Promise<AgentToolResult<CoordinationDetails>> {
 	const { registry, senderId, settings } = deps;
+	if (registry.get(senderId)?.locality === "remote") {
+		return hubErrorResult("Remote peer waits require a controller wait transport.", { op: "wait", from: senderId });
+	}
 	const from = params.from?.trim() || undefined;
+	const pending = drainPendingInbox(registry, senderId, from);
+	if (pending) return messageResult(senderId, pending);
+	const fromRef = from ? registry.get(from) : undefined;
+	if (fromRef?.locality === "remote") {
+		return hubErrorResult(`Remote peer "${from}" cannot be waited through the local message bus.`, {
+			op: "wait",
+			from: senderId,
+		});
+	}
+	if (!from) {
+		const visible = registry.listVisibleTo(senderId);
+		const hasLocalRunningPeer = visible.some(ref => ref.locality !== "remote" && registry.isRunning(ref));
+		const hasRemotePeer = visible.some(ref => ref.locality === "remote");
+		if (!hasLocalRunningPeer && hasRemotePeer) {
+			return hubErrorResult("Remote peers cannot satisfy a local bare message wait.", {
+				op: "wait",
+				from: senderId,
+			});
+		}
+	}
 	const timeoutMs = resolveMessageTimeoutMs(settings, params.timeoutMs);
 	try {
 		const waited = await IrcBus.global().wait(senderId, { from }, timeoutMs, signal, {
@@ -326,6 +368,12 @@ export function executeInbox(
 	senderId: string,
 	peek?: boolean,
 ): AgentToolResult<CoordinationDetails> {
+	if (registry.get(senderId)?.locality === "remote") {
+		return hubErrorResult("Remote peer inbox access requires a controller inbox transport.", {
+			op: "inbox",
+			from: senderId,
+		});
+	}
 	const busMessages = IrcBus.global().inbox(senderId, { peek });
 	const session = registry.get(senderId)?.session;
 	const pendingMessages =
@@ -368,6 +416,7 @@ function outcomeColor(outcome: IrcDeliveryReceipt["outcome"]): ToolUIColor {
 		case "revived":
 			return "warning";
 		case "injected":
+		case "remote":
 			return "accent";
 		case "failed":
 			return "error";

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -52,7 +52,7 @@ export interface JobSnapshot {
 	errorText?: string;
 }
 
-export type CancelStatus = "cancelled" | "not_found" | "already_completed";
+export type CancelStatus = "cancelled" | "not_found" | "already_completed" | "failed";
 
 export interface CancelOutcome {
 	id: string;

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -25,6 +25,7 @@ import { MCPManager } from "../mcp/manager";
 import vibeTurnResultTemplate from "../prompts/tools/vibe-turn-result.md" with { type: "text" };
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import { type AgentRef, AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import { currentRemoteRuntime } from "../remote-runtime/scope";
 import { SessionManager, SessionPersistenceIndeterminateError } from "../session/session-manager";
 import { getBundledAgent } from "../task/agents";
 import { type ExecutorOptions, runSubagentFollowUpTurn, runSubprocess } from "../task/executor";
@@ -1481,6 +1482,9 @@ export class VibeSessionRegistry {
 		message: string,
 		options: { first: boolean },
 	): string {
+		if (currentRemoteRuntime()) {
+			throw new ToolError("Vibe mode cannot execute native workers inside a sealed remote runtime.");
+		}
 		const turnIndex = record.turnCount + 1;
 		const turn: VibeTurn = {
 			jobId: "",

--- a/packages/coding-agent/test/registry/remote-agent-registry.test.ts
+++ b/packages/coding-agent/test/registry/remote-agent-registry.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import {
+	AgentRegistry,
+	type RemoteAgentIdentity,
+	type RemoteRegistryBackend,
+} from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { executeCancel } from "@oh-my-pi/pi-coding-agent/tools/hub/jobs";
+
+const IDENTITY: RemoteAgentIdentity = {
+	controllerId: "controller-a",
+	executionId: "execution-a",
+	generation: 7,
+};
+
+function backend(overrides: Partial<RemoteRegistryBackend> = {}): RemoteRegistryBackend {
+	return {
+		status: async identity => ({ identity: { ...identity }, value: "running" }),
+		progress: async identity => ({ identity: { ...identity }, value: { sequence: 1, message: "working" } }),
+		cancel: async identity => ({ identity: { ...identity }, value: "cancelled" }),
+		result: async identity => ({ identity: { ...identity }, value: { outcome: "completed", output: "done" } }),
+		...overrides,
+	};
+}
+
+function registerRemote(registry: AgentRegistry, id = "RemoteChild"): void {
+	registry.registerRemote({
+		id,
+		displayName: "remote child",
+		kind: "sub",
+		parentId: "Main",
+		status: "running",
+		identity: IDENTITY,
+	});
+}
+function cancelHarness(registry: AgentRegistry): { session: ToolSession; manager: AsyncJobManager } {
+	const session: ToolSession = {
+		cwd: "/tmp",
+		hasUI: false,
+		settings: Settings.isolated(),
+		agentRegistry: registry,
+		getAgentId: () => "Main",
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+	};
+	const manager = {
+		getJob: () => undefined,
+		getAllJobs: () => [],
+		getRunningJobs: () => [],
+		cancel: () => false,
+		acknowledgeDeliveries: () => {},
+	} as unknown as AsyncJobManager;
+	return { session, manager };
+}
+
+describe("remote agent registry", () => {
+	it("keeps existing local registrations local and generation-bound", () => {
+		const registry = new AgentRegistry();
+		const first = registry.register({ id: "Local", displayName: "local", kind: "sub", session: null });
+		const second = registry.register({ id: "Local", displayName: "local", kind: "sub", session: null });
+
+		expect(first.locality).toBe("local");
+		expect(second.locality).toBe("local");
+		expect(second.generation).toBe(first.generation + 1);
+	});
+
+	it("rejects local/remote overlap and never admits a remote ref to local revival", async () => {
+		const registry = new AgentRegistry({ remoteBackend: backend() });
+		registerRemote(registry);
+		const lifecycle = new AgentLifecycleManager(registry);
+		const revive = vi.fn(async () => {
+			throw new Error("must not run");
+		});
+
+		lifecycle.adopt("RemoteChild", { idleTtlMs: 0, revive });
+		expect(lifecycle.has("RemoteChild")).toBe(false);
+		expect(registry.attachSession("RemoteChild", {} as never)).toBe(false);
+		await expect(lifecycle.ensureLive("RemoteChild")).rejects.toThrow("cannot be resumed");
+		expect(revive).not.toHaveBeenCalled();
+		expect(() => registry.register({ id: "RemoteChild", displayName: "local", kind: "sub", session: null })).toThrow(
+			/cannot register local agent/i,
+		);
+	});
+
+	it("applies only exact-generation controller status and monotonic progress", async () => {
+		let progressSequence = 2;
+		const registry = new AgentRegistry({
+			remoteBackend: backend({
+				status: async identity => ({ identity: { ...identity }, value: "idle" }),
+				progress: async identity => ({
+					identity: { ...identity },
+					value: { sequence: progressSequence, message: "controller progress" },
+				}),
+			}),
+		});
+		registerRemote(registry);
+
+		const refreshed = await registry.refreshRemote("RemoteChild");
+		expect(refreshed.status).toBe("idle");
+		expect(registry.setStatus("RemoteChild", "running")).toBe(false);
+
+		progressSequence = 1;
+		await expect(registry.refreshRemote("RemoteChild")).rejects.toThrow("stale sequence");
+	});
+
+	it("fails closed for ownerless registration, stale generations, outages, and malformed results", async () => {
+		const missing = new AgentRegistry();
+		expect(() => registerRemote(missing)).toThrow("explicit or constructor backend owner");
+
+		const stale = new AgentRegistry({
+			remoteBackend: backend({
+				status: async identity => ({
+					identity: { ...identity, generation: identity.generation + 1 },
+					value: "idle",
+				}),
+			}),
+		});
+		registerRemote(stale);
+		await expect(stale.refreshRemote("RemoteChild")).rejects.toThrow("stale or malformed identity");
+
+		const outage = new AgentRegistry({
+			remoteBackend: backend({ status: async () => Promise.reject(new Error("controller offline")) }),
+		});
+		registerRemote(outage);
+		await expect(outage.refreshRemote("RemoteChild")).rejects.toThrow("controller offline");
+
+		const malformed = new AgentRegistry({
+			remoteBackend: backend({
+				result: async identity => ({ identity: { ...identity }, value: { outcome: "failed" } as never }),
+			}),
+		});
+		registerRemote(malformed);
+		await expect(malformed.resultRemote("RemoteChild")).rejects.toThrow("malformed value");
+	});
+
+	it("makes controller identity fields runtime-immutable and uniquely indexed", () => {
+		const registry = new AgentRegistry({ remoteBackend: backend() });
+		const ref = registry.registerRemote({
+			id: "RemoteChild",
+			displayName: "remote child",
+			kind: "sub",
+			status: "running",
+			identity: IDENTITY,
+		});
+
+		expect(Reflect.set(ref, "generation", 99)).toBe(false);
+		expect(Reflect.set(ref, "remote", { ...IDENTITY, executionId: "other" })).toBe(false);
+		expect(Reflect.set(ref, "id", "Alias")).toBe(false);
+		expect(Reflect.set(ref, "locality", "local")).toBe(false);
+		expect(Reflect.set(ref, "session", {})).toBe(false);
+		expect(Reflect.set(ref, "sessionFile", "/tmp/local.jsonl")).toBe(false);
+		expect(ref.generation).toBe(IDENTITY.generation);
+		expect(ref.remote).toEqual(IDENTITY);
+		expect(ref.id).toBe("RemoteChild");
+		expect(ref.locality).toBe("remote");
+		expect(ref.session).toBeNull();
+		expect(ref.sessionFile).toBeNull();
+		expect(() =>
+			registry.registerRemote({
+				id: "Alias",
+				displayName: "alias",
+				kind: "sub",
+				status: "running",
+				identity: { ...IDENTITY },
+			}),
+		).toThrow("already registered");
+	});
+
+	it("accepts identical progress replay, rejects conflicting duplicates, and clears identity watermarks on removal", async () => {
+		let sequence = 2;
+		let message = "same";
+		const registry = new AgentRegistry({
+			remoteBackend: backend({
+				progress: async identity => ({ identity: { ...identity }, value: { sequence, message } }),
+			}),
+		});
+		registerRemote(registry);
+		await registry.refreshRemote("RemoteChild");
+		await registry.refreshRemote("RemoteChild");
+
+		message = "conflict";
+		await expect(registry.refreshRemote("RemoteChild")).rejects.toThrow("conflicting duplicate");
+
+		const ref = registry.get("RemoteChild");
+		expect(ref).toBeDefined();
+		registry.unregister("RemoteChild", ref);
+		sequence = 0;
+		message = "new registration";
+		registerRemote(registry, "Replacement");
+		await expect(registry.refreshRemote("Replacement")).resolves.toMatchObject({ id: "Replacement" });
+	});
+
+	it("reads and freezes exactly one controller terminal result per generation", async () => {
+		const result = vi.fn(async (identity: Readonly<RemoteAgentIdentity>) => ({
+			identity: { ...identity },
+			value: { outcome: "completed" as const, output: "done" },
+		}));
+		const registry = new AgentRegistry({ remoteBackend: backend({ result }) });
+		registerRemote(registry);
+
+		const [first, replay] = await Promise.all([
+			registry.resultRemote("RemoteChild"),
+			registry.resultRemote("RemoteChild"),
+		]);
+
+		expect(result).toHaveBeenCalledTimes(1);
+		expect(replay).toBe(first);
+		expect(Object.isFrozen(first)).toBe(true);
+	});
+
+	it("isolates each result joiner's cancellation while retaining one controller request", async () => {
+		const terminal = Promise.withResolvers<{ outcome: "completed"; output: string }>();
+		const result = vi.fn(async (identity: Readonly<RemoteAgentIdentity>) => ({
+			identity: { ...identity },
+			value: await terminal.promise,
+		}));
+		const registry = new AgentRegistry({ remoteBackend: backend({ result }) });
+		registerRemote(registry);
+		const controller = new AbortController();
+
+		const cancelled = registry.resultRemote("RemoteChild", controller.signal);
+		const live = registry.resultRemote("RemoteChild");
+		const cancelledOutcome = cancelled.then(
+			() => undefined,
+			error => error,
+		);
+		controller.abort(new Error("caller stopped waiting"));
+		const later = registry.resultRemote("RemoteChild");
+		const failure = await cancelledOutcome;
+		terminal.resolve({ outcome: "completed", output: "done" });
+		const joined = await Promise.all([live, later]);
+
+		expect(failure).toBeInstanceOf(Error);
+		if (!(failure instanceof Error)) throw new Error("Expected cancellation failure.");
+		expect(failure.message).toBe("caller stopped waiting");
+		expect(joined).toMatchObject([
+			{ outcome: "completed", output: "done" },
+			{ outcome: "completed", output: "done" },
+		]);
+		expect(result).toHaveBeenCalledTimes(1);
+	}, 5_000);
+	it("routes hub cancellation through the remote backend without local abort, dispose, or lifecycle release", async () => {
+		const cancel = vi.fn(async (identity: Readonly<RemoteAgentIdentity>) => ({
+			identity: { ...identity },
+			value: "cancelled" as const,
+		}));
+		const registry = new AgentRegistry({ remoteBackend: backend({ cancel }) });
+		registerRemote(registry);
+		const lifecycle = new AgentLifecycleManager(registry);
+		const release = vi.spyOn(lifecycle, "release");
+		const session: ToolSession = {
+			cwd: "/tmp",
+			hasUI: false,
+			settings: Settings.isolated(),
+			agentRegistry: registry,
+			getAgentId: () => "Main",
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			agentLifecycle: () => lifecycle,
+		};
+		const manager = {
+			getJob: () => undefined,
+			getAllJobs: () => [],
+			getRunningJobs: () => [],
+			cancel: () => false,
+			acknowledgeDeliveries: () => {},
+		} as unknown as AsyncJobManager;
+
+		const result = await executeCancel(session, manager, "Main", ["RemoteChild"]);
+
+		expect(result.details?.cancelled).toEqual([{ id: "RemoteChild", status: "cancelled" }]);
+		expect(cancel).toHaveBeenCalledTimes(1);
+		expect(release).not.toHaveBeenCalled();
+		expect(registry.get("RemoteChild")?.status).toBe("aborted");
+	});
+	it("surfaces remote cancellation rejection and deadline expiry as failed hub results", async () => {
+		const rejectedRegistry = new AgentRegistry({
+			remoteBackend: backend({ cancel: async () => Promise.reject(new Error("controller rejected")) }),
+		});
+		registerRemote(rejectedRegistry);
+		const rejectedHarness = cancelHarness(rejectedRegistry);
+		const rejected = await executeCancel(rejectedHarness.session, rejectedHarness.manager, "Main", ["RemoteChild"]);
+		expect(rejected.isError).toBe(true);
+		expect(rejected.details?.cancelled).toEqual([{ id: "RemoteChild", status: "failed" }]);
+		expect(rejectedRegistry.get("RemoteChild")?.status).toBe("running");
+
+		vi.useFakeTimers();
+		try {
+			const hangingRegistry = new AgentRegistry({
+				remoteBackend: backend({
+					cancel: async () => Promise.withResolvers<never>().promise,
+				}),
+			});
+			registerRemote(hangingRegistry);
+			const hangingHarness = cancelHarness(hangingRegistry);
+			const timedOut = executeCancel(hangingHarness.session, hangingHarness.manager, "Main", ["RemoteChild"]);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			vi.advanceTimersByTime(5_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			const result = await timedOut;
+			expect(result.isError).toBe(true);
+			expect(result.details?.cancelled).toEqual([{ id: "RemoteChild", status: "failed" }]);
+			expect(result.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("timed out") });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/coding-agent/test/remote-runtime/backends.test.ts
+++ b/packages/coding-agent/test/remote-runtime/backends.test.ts
@@ -1,0 +1,633 @@
+import { describe, expect, it, vi } from "bun:test";
+import { IrcBus, type PeerTransportDelivery } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry, type RemoteRegistryBackend } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import {
+	SocketPeerTransportBackend,
+	SocketRemoteRegistryBackend,
+	SocketStructuredSubagentBackend,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/backends";
+import type { RemoteRuntimeClient } from "@oh-my-pi/pi-coding-agent/remote-runtime/client";
+import {
+	parseRemoteRuntimeConfig,
+	REMOTE_RUNTIME_PROTOCOL_VERSION,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/config";
+import type { StructuredSubagentBackendContext } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
+
+function config(executionId = "01ARZ3NDEKTSV4RRFFQ69G5FAV") {
+	return parseRemoteRuntimeConfig({
+		version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		socketPath: "/var/run/omp-runtime.sock",
+		controllerId: "controller-a",
+		executionId,
+		rootExecutionId: executionId,
+		parentExecutionId: null,
+		assignmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+		depth: 0,
+		revision: "a".repeat(40),
+		grantId: "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+		policyDigest: `sha256:${"b".repeat(64)}`,
+		budgetRef: "budget:root-1",
+		schemaRef: "schema:root-1",
+		requestTimeoutMs: 1_000,
+	});
+}
+
+function context(
+	registry: AgentRegistry,
+	index = 0,
+	maxRuntimeMs = 5_000,
+	schema: unknown = {},
+	effort?: "lo" | "med" | "hi",
+): StructuredSubagentBackendContext {
+	return {
+		request: {
+			session: {
+				cwd: "/Users/private/workspace",
+				agentRegistry: registry,
+			} as never,
+			invocationKind: "task",
+			assignment: "Review the logical source reference.",
+			context: "bounded context",
+			identity: { id: "RemoteChild", label: "remote child" },
+			index,
+			parentToolCallId: "tool-call-1",
+			maxRuntimeMs,
+			effort,
+		},
+		policy: {
+			agent: { name: "reviewer", source: "bundled" },
+			modelOverride: "slow",
+			modelRole: "slow",
+			planMode: false,
+			schema: { schema, source: "caller", mode: "strict", outputSchemaOverridesAgent: true },
+			isIsolated: false,
+			mergeMode: "patch",
+			applyChanges: false,
+			enableLsp: false,
+			enableIrc: true,
+		} as never,
+		outputSchema: { source: "caller", mode: "strict", schema, outputSchemaOverridesAgent: true },
+	};
+}
+
+function response(extra: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		execution: {
+			result: {
+				index: 0,
+				id: "RemoteChild",
+				agent: "reviewer",
+				agentSource: "bundled",
+				task: "Review the logical source reference.",
+				assignment: "Review the logical source reference.",
+				exitCode: 0,
+				output: "done",
+				stderr: "",
+				truncated: false,
+				durationMs: 1,
+				tokens: 1,
+				requests: 1,
+			},
+			mergeSummary: "",
+			changesApplied: null,
+			temporaryArtifacts: false,
+		},
+		registration: {
+			id: "RemoteChild",
+			displayName: "remote child",
+			kind: "sub",
+			parentId: "Main",
+			status: "idle",
+			identity: {
+				controllerId: "controller-a",
+				executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAY",
+				generation: 1,
+			},
+			createdAt: 1,
+			lastActivity: 2,
+		},
+		...extra,
+	};
+}
+
+function runningRegistration(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	const registration = response().registration as Record<string, unknown>;
+	return { ...registration, status: "running", ...overrides };
+}
+
+function requireObservationStream(value: unknown): string {
+	if (!value || typeof value !== "object" || !("observationStream" in value)) {
+		throw new Error("missing observation stream");
+	}
+	const stream = value.observationStream;
+	if (typeof stream !== "string") throw new Error("malformed observation stream");
+	return stream;
+}
+
+describe("remote runtime structured backend", () => {
+	it("publishes a running child, sends logical launch data only, and commits the terminal registration", async () => {
+		const registry = new AgentRegistry();
+		let payload: unknown;
+		let observation: ((envelope: { stream: string; observation: unknown }) => void) | undefined;
+		let sawRunning = false;
+		const request = vi.fn(async (_operation: string, candidate: unknown) => {
+			payload = candidate;
+			const stream = requireObservationStream(candidate);
+			observation?.({ stream, observation: { type: "registry.register", registration: runningRegistration() } });
+			sawRunning = registry.get("RemoteChild")?.status === "running";
+			return response();
+		});
+		const client = {
+			request,
+			onObservation: (_stream: string, listener: typeof observation) => {
+				observation = listener;
+				return () => {
+					observation = undefined;
+				};
+			},
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketStructuredSubagentBackend(client, config());
+		const launch = context(registry);
+
+		const settled = await backend.run(launch);
+		expect(sawRunning).toBe(true);
+		expect(registry.get("RemoteChild")?.status).toBe("running");
+		backend.accept(launch);
+
+		expect(request).toHaveBeenCalledWith(
+			"subagent.run",
+			expect.objectContaining({
+				observationStream: expect.stringMatching(/^subagent\./),
+				planMode: false,
+				restrictToolNames: false,
+				enableMCP: true,
+			}),
+			{
+				signal: undefined,
+				idempotencyKey: "01ARZ3NDEKTSV4RRFFQ69G5FAV:tool-call-1:0",
+				timeoutMs: 35_000,
+			},
+		);
+		const encoded = JSON.stringify(payload);
+		expect(encoded).toContain('"reference":"schema:root-1"');
+		expect(encoded).toContain('"schema":{}');
+		expect(encoded).not.toContain("/Users/private/workspace");
+		expect(encoded).not.toContain("socketPath");
+		expect(encoded).not.toContain("grantId");
+		expect(settled.artifactsDir).toBe("");
+		expect(registry.get("RemoteChild")).toMatchObject({
+			locality: "remote",
+			status: "idle",
+			session: null,
+			sessionFile: null,
+		});
+	});
+
+	it("scopes deterministic idempotency to the execution and forwards each invocation schema and effort", async () => {
+		const timeouts: Array<number | null | undefined> = [];
+		const keys: Array<string | undefined> = [];
+		const payloads: unknown[] = [];
+		const client = {
+			onObservation: () => () => {},
+			request: async (
+				_operation: string,
+				payload: unknown,
+				options: { idempotencyKey?: string; timeoutMs?: number | null },
+			) => {
+				payloads.push(payload);
+				keys.push(options.idempotencyKey);
+				timeouts.push(options.timeoutMs);
+				return response();
+			},
+		} as unknown as RemoteRuntimeClient;
+		const firstExecution = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+		const secondExecution = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
+		const firstBackend = new SocketStructuredSubagentBackend(client, config(firstExecution));
+		const secondBackend = new SocketStructuredSubagentBackend(client, config(secondExecution));
+		const firstSchema = { type: "object", required: ["first"] };
+		const secondSchema = { type: "object", required: ["second"] };
+		const first = context(new AgentRegistry(), 0, 5_000, firstSchema, "lo");
+		const second = context(new AgentRegistry(), 0, 0, secondSchema, "hi");
+
+		await firstBackend.run(first);
+		await secondBackend.run(second);
+		firstBackend.discard(first);
+		secondBackend.discard(second);
+
+		expect(keys).toEqual([`${firstExecution}:tool-call-1:0`, `${secondExecution}:tool-call-1:0`]);
+		expect(timeouts).toEqual([35_000, null]);
+		expect(payloads).toEqual([
+			expect.objectContaining({
+				effort: "lo",
+				outputSchema: {
+					schema: firstSchema,
+					outputSchemaOverridesAgent: true,
+					source: "caller",
+					mode: "strict",
+					reference: "schema:root-1",
+				},
+			}),
+			expect.objectContaining({
+				effort: "hi",
+				outputSchema: {
+					schema: secondSchema,
+					outputSchemaOverridesAgent: true,
+					source: "caller",
+					mode: "strict",
+					reference: "schema:root-1",
+				},
+			}),
+		]);
+	});
+
+	it("preserves explicit null and absent effective schema bodies", async () => {
+		const payloads: Array<Record<string, unknown>> = [];
+		const client = {
+			onObservation: () => () => {},
+			request: async (_operation: string, payload: Record<string, unknown>) => {
+				payloads.push(payload);
+				return response();
+			},
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketStructuredSubagentBackend(client, config());
+		const explicitNull = context(new AgentRegistry(), 0, 5_000, null);
+		const absentBase = context(new AgentRegistry());
+		const absent = {
+			...absentBase,
+			policy: {
+				...absentBase.policy,
+				schema: { schema: undefined, source: "none", mode: "permissive", outputSchemaOverridesAgent: false },
+			},
+			outputSchema: {
+				schema: undefined,
+				source: "none",
+				mode: "permissive",
+				outputSchemaOverridesAgent: false,
+			},
+		} satisfies StructuredSubagentBackendContext;
+
+		await backend.run(explicitNull);
+		await backend.run(absent);
+		backend.discard(explicitNull);
+		backend.discard(absent);
+		expect(payloads[0]?.outputSchema).toEqual({
+			schema: null,
+			outputSchemaOverridesAgent: true,
+			source: "caller",
+			mode: "strict",
+			reference: "schema:root-1",
+		});
+		expect(payloads[1]?.outputSchema).toEqual({
+			outputSchemaOverridesAgent: false,
+			source: "none",
+			mode: "permissive",
+			reference: "schema:root-1",
+		});
+	});
+
+	it("validates and forwards admitted child result metadata", async () => {
+		const remoteResponse = response();
+		const execution = remoteResponse.execution as Record<string, unknown>;
+		const childResult = execution.result as Record<string, unknown>;
+		const usage = {
+			input: 10,
+			output: 4,
+			cacheRead: 3,
+			cacheWrite: 2,
+			totalTokens: 19,
+			contextTokens: 17,
+			orchestration: { input: 1, cacheRead: 2, output: 3 },
+			premiumRequests: 1,
+			reasoningTokens: 2,
+			cttl: { ephemeral5m: 1, ephemeral1h: 1 },
+			server: { webSearch: 1, webFetch: 2 },
+			cost: { input: 0.1, output: 0.2, cacheRead: 0.03, cacheWrite: 0.04, total: 0.37 },
+		};
+		const extractedToolData = { task: [{ id: "Nested", state: "completed" }] };
+		Object.assign(childResult, {
+			description: "remote child",
+			lastIntent: "Return the verdict",
+			contextTokens: 17,
+			contextWindow: 200_000,
+			modelOverride: ["slow", "fast"],
+			modelRole: "slow",
+			resolvedModel: "anthropic/claude-sonnet-4-6:high",
+			resolvedModelIsFallback: true,
+			usage,
+			extractedToolData,
+			retryFailure: { attempt: 2, errorMessage: "rate limited" },
+			outputMeta: { lineCount: 1, charCount: 4 },
+		});
+		const client = {
+			onObservation: () => () => {},
+			request: async () => remoteResponse,
+		} as unknown as RemoteRuntimeClient;
+		const launch = context(new AgentRegistry());
+		const backend = new SocketStructuredSubagentBackend(client, config());
+
+		const settled = await backend.run(launch);
+		backend.discard(launch);
+
+		expect(settled.result).toMatchObject({
+			description: "remote child",
+			lastIntent: "Return the verdict",
+			contextTokens: 17,
+			contextWindow: 200_000,
+			modelOverride: ["slow", "fast"],
+			modelRole: "slow",
+			resolvedModel: "anthropic/claude-sonnet-4-6:high",
+			resolvedModelIsFallback: true,
+			usage,
+			extractedToolData,
+			retryFailure: { attempt: 2, errorMessage: "rate limited" },
+			outputMeta: { lineCount: 1, charCount: 4 },
+		});
+	});
+
+	it("rejects malformed admitted child result metadata instead of dropping it", async () => {
+		const malformedMetadata = [
+			{
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					credential: "must-not-be-admitted",
+				},
+			},
+			{ extractedToolData: { task: { state: "completed" } } },
+			{ resolvedModel: 42 },
+		];
+		for (const metadata of malformedMetadata) {
+			const remoteResponse = response();
+			const execution = remoteResponse.execution as Record<string, unknown>;
+			Object.assign(execution.result as Record<string, unknown>, metadata);
+			const client = {
+				onObservation: () => () => {},
+				request: async () => remoteResponse,
+			} as unknown as RemoteRuntimeClient;
+			const backend = new SocketStructuredSubagentBackend(client, config());
+
+			await expect(backend.run(context(new AgentRegistry()))).rejects.toMatchObject({
+				code: "MALFORMED_RESULT",
+			});
+		}
+	});
+
+	it("keeps an in-flight child visible, messageable, and controller-cancellable", async () => {
+		const identity = {
+			controllerId: "controller-a",
+			executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAY",
+			generation: 1,
+		};
+		const cancel = vi.fn(async () => ({ identity, value: "cancelled" as const }));
+		const authority: RemoteRegistryBackend = {
+			status: async () => ({ identity, value: "running" }),
+			progress: async () => ({ identity, value: { sequence: 1 } }),
+			cancel,
+			result: async () => ({ identity, value: { outcome: "cancelled" } }),
+		};
+		const registry = new AgentRegistry({ remoteBackend: authority });
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: {} as never });
+		const observed = Promise.withResolvers<void>();
+		const terminal = Promise.withResolvers<Record<string, unknown>>();
+		let observation: ((envelope: { stream: string; observation: unknown }) => void) | undefined;
+		const client = {
+			onObservation: (_stream: string, listener: typeof observation) => {
+				observation = listener;
+				return () => {
+					observation = undefined;
+				};
+			},
+			request: async (_operation: string, candidate: unknown) => {
+				observation?.({
+					stream: requireObservationStream(candidate),
+					observation: { type: "registry.register", registration: runningRegistration() },
+				});
+				observed.resolve();
+				return terminal.promise;
+			},
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketStructuredSubagentBackend(client, config(), authority);
+		const launch = context(registry);
+		const execution = backend.run(launch);
+		await observed.promise;
+
+		expect(registry.list().map(ref => ref.id)).toContain("RemoteChild");
+		const deliver = vi.fn(async delivery => ({ ...delivery, outcome: "accepted" as const }));
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), {
+			deliver,
+			cancel: async () => {},
+		});
+		await expect(bus.send({ from: "Main", to: "RemoteChild", body: "status?" })).resolves.toMatchObject({
+			outcome: "remote",
+		});
+		expect(deliver).toHaveBeenCalledTimes(1);
+		await registry.cancelRemote("RemoteChild");
+		expect(cancel).toHaveBeenCalledTimes(1);
+
+		terminal.resolve(
+			response({
+				registration: { ...runningRegistration(), status: "aborted" },
+			}),
+		);
+		await execution;
+		backend.accept(launch);
+		expect(registry.get("RemoteChild")?.status).toBe("aborted");
+	});
+
+	it("rejects unknown nested result fields and rolls back an observed running child", async () => {
+		const registry = new AgentRegistry();
+		let observation: ((envelope: { stream: string; observation: unknown }) => void) | undefined;
+		const client = {
+			onObservation: (_stream: string, listener: typeof observation) => {
+				observation = listener;
+				return () => {
+					observation = undefined;
+				};
+			},
+			request: async (_operation: string, candidate: unknown) => {
+				observation?.({
+					stream: requireObservationStream(candidate),
+					observation: { type: "registry.register", registration: runningRegistration() },
+				});
+				return response({ controllerCredential: "must-not-be-admitted" });
+			},
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketStructuredSubagentBackend(client, config());
+
+		await expect(backend.run(context(registry))).rejects.toMatchObject({ code: "MALFORMED_RESULT" });
+		expect(registry.get("RemoteChild")).toBeUndefined();
+	});
+
+	it("requires the controller to publish a running registration before terminal acceptance", async () => {
+		const registry = new AgentRegistry();
+		const client = {
+			onObservation: () => () => {},
+			request: async () => response(),
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketStructuredSubagentBackend(client, config());
+		const launch = context(registry);
+		await backend.run(launch);
+
+		expect(() => backend.accept(launch)).toThrow("did not publish a running child registration");
+		backend.discard(launch);
+		expect(registry.get("RemoteChild")).toBeUndefined();
+	});
+
+	it("normalizes bounded display names and rejects roster-breaking child ids", async () => {
+		const displayName = `${"x".repeat(180)}\nprivate`;
+		const acceptedRegistry = new AgentRegistry();
+		let acceptedObservation: ((envelope: { stream: string; observation: unknown }) => void) | undefined;
+		const acceptedClient = {
+			onObservation: (_stream: string, listener: typeof acceptedObservation) => {
+				acceptedObservation = listener;
+				return () => {
+					acceptedObservation = undefined;
+				};
+			},
+			request: async (_operation: string, candidate: unknown) => {
+				acceptedObservation?.({
+					stream: requireObservationStream(candidate),
+					observation: {
+						type: "registry.register",
+						registration: runningRegistration({ displayName }),
+					},
+				});
+				return response({
+					registration: { ...runningRegistration({ displayName }), status: "idle" },
+				});
+			},
+		} as unknown as RemoteRuntimeClient;
+		const acceptedBackend = new SocketStructuredSubagentBackend(acceptedClient, config());
+		const acceptedLaunch = context(acceptedRegistry);
+		await acceptedBackend.run(acceptedLaunch);
+		acceptedBackend.accept(acceptedLaunch);
+		const storedName = acceptedRegistry.get("RemoteChild")?.displayName ?? "";
+		expect(storedName).not.toContain("\n");
+		expect([...storedName].length).toBeLessThanOrEqual(128);
+
+		const rejectedRegistry = new AgentRegistry();
+		let rejectedObservation: ((envelope: { stream: string; observation: unknown }) => void) | undefined;
+		const rejectedClient = {
+			onObservation: (_stream: string, listener: typeof rejectedObservation) => {
+				rejectedObservation = listener;
+				return () => {
+					rejectedObservation = undefined;
+				};
+			},
+			request: async (_operation: string, candidate: unknown) => {
+				rejectedObservation?.({
+					stream: requireObservationStream(candidate),
+					observation: {
+						type: "registry.register",
+						registration: runningRegistration({ id: "Remote\nInjected" }),
+					},
+				});
+				return response();
+			},
+		} as unknown as RemoteRuntimeClient;
+		const rejectedBackend = new SocketStructuredSubagentBackend(rejectedClient, config());
+		await expect(rejectedBackend.run(context(rejectedRegistry))).rejects.toMatchObject({
+			code: "REGISTRATION_REJECTED",
+		});
+		expect(rejectedRegistry.get("RemoteChild")).toBeUndefined();
+	});
+	it("forwards the plan-mode authority restriction instead of requesting an unrestricted child", async () => {
+		let payload: Record<string, unknown> | undefined;
+		const client = {
+			onObservation: () => () => {},
+			request: async (_operation: string, candidate: Record<string, unknown>) => {
+				payload = candidate;
+				return response();
+			},
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketStructuredSubagentBackend(client, config());
+		const launch = context(new AgentRegistry());
+		(launch.policy as { planMode: boolean }).planMode = true;
+
+		await backend.run(launch);
+		backend.discard(launch);
+
+		expect(payload).toMatchObject({
+			planMode: true,
+			restrictToolNames: true,
+			enableMCP: false,
+		});
+	});
+
+	it("strictly parses registry terminal results and redacts controller failure text", async () => {
+		const identity = {
+			controllerId: "controller-a",
+			executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAY",
+			generation: 1,
+		};
+		const client = {
+			request: async () => ({
+				identity,
+				value: {
+					outcome: "failed",
+					error: "token secret failed at /Users/private/controller.sock",
+				},
+			}),
+		} as unknown as RemoteRuntimeClient;
+		const backend = new SocketRemoteRegistryBackend(client);
+
+		const terminal = await backend.result(identity);
+
+		expect(terminal.value).toEqual({ outcome: "failed", error: "Remote execution failed." });
+		expect(JSON.stringify(terminal)).not.toContain("secret");
+		expect(JSON.stringify(terminal)).not.toContain("/Users/private");
+	});
+});
+
+describe("remote runtime peer backend", () => {
+	it("scopes delivery and cancellation idempotency to the sealed execution", async () => {
+		const keys: string[] = [];
+		const client = {
+			request: async (
+				operation: string,
+				payload: { delivery?: PeerTransportDelivery },
+				options: { idempotencyKey: string },
+			) => {
+				keys.push(options.idempotencyKey);
+				if (operation === "peer.cancel") return { cancelled: true };
+				if (!payload.delivery) throw new Error("missing delivery");
+				return {
+					deliveryId: payload.delivery.deliveryId,
+					sequence: payload.delivery.sequence,
+					sender: payload.delivery.sender,
+					recipient: payload.delivery.recipient,
+					outcome: "accepted",
+				};
+			},
+		} as unknown as RemoteRuntimeClient;
+		const executionId = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+		const backend = new SocketPeerTransportBackend(client, config(executionId));
+		const delivery: PeerTransportDelivery = {
+			deliveryId: "shared-process-local-id",
+			sequence: 1,
+			kind: "message",
+			sender: {
+				locality: "remote",
+				agentId: "RemoteChild",
+				controllerId: "controller-a",
+				executionId,
+				generation: 1,
+			},
+			recipient: { locality: "local", agentId: "Main", generation: 1 },
+			payload: { body: "bounded message" },
+		};
+
+		await expect(backend.deliver(delivery)).resolves.toMatchObject({ outcome: "accepted" });
+		await backend.cancel(delivery);
+
+		expect(keys).toEqual([
+			`${executionId}:peer:${delivery.deliveryId}`,
+			`${executionId}:peer:${delivery.deliveryId}:cancel`,
+		]);
+	});
+});

--- a/packages/coding-agent/test/remote-runtime/bootstrap.test.ts
+++ b/packages/coding-agent/test/remote-runtime/bootstrap.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import type { PeerTransportBackend } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import {
+	AgentRegistry,
+	type RemoteRegisterInput,
+	type RemoteRegistryBackend,
+} from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { runWithRemoteRuntimeConfig } from "@oh-my-pi/pi-coding-agent/remote-runtime/bootstrap";
+import {
+	REMOTE_RUNTIME_MAX_FRAME_BYTES,
+	REMOTE_RUNTIME_REQUIRED_CAPABILITIES,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/client";
+import { REMOTE_RUNTIME_PROTOCOL_VERSION } from "@oh-my-pi/pi-coding-agent/remote-runtime/config";
+import {
+	currentRemoteRuntime,
+	type RemoteRuntimeBindings,
+	remoteRuntimeSealActive,
+	runWithRemoteRuntime,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/scope";
+import type { StructuredSubagentBackend } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function bindings(label: string): RemoteRuntimeBindings {
+	const subagentBackend: StructuredSubagentBackend = {
+		run: async () => {
+			throw new Error(label);
+		},
+	};
+	const registryBackend: RemoteRegistryBackend = {
+		status: async identity => ({ identity: { ...identity }, value: "running" }),
+		progress: async identity => ({ identity: { ...identity }, value: { sequence: 1, message: label } }),
+		cancel: async identity => ({ identity: { ...identity }, value: "cancelled" }),
+		result: async identity => ({ identity: { ...identity }, value: { outcome: "completed", output: label } }),
+	};
+	const peerTransport: PeerTransportBackend = {
+		deliver: async delivery => ({ ...delivery, outcome: "accepted" }),
+		cancel: async () => {},
+	};
+	return { subagentBackend, registryBackend, peerTransport };
+}
+
+function descriptor(socketPath: string): Record<string, unknown> {
+	return {
+		version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		socketPath,
+		controllerId: "controller-a",
+		executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		rootExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		parentExecutionId: null,
+		assignmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+		depth: 0,
+		revision: "a".repeat(40),
+		grantId: "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+		policyDigest: `sha256:${"b".repeat(64)}`,
+		budgetRef: "budget:root-1",
+		schemaRef: "schema:root-1",
+		requestTimeoutMs: 1_000,
+	};
+}
+
+describe("sealed remote runtime bootstrap", () => {
+	it("installs before the production callback and removes exactly that scope on teardown", async () => {
+		using tempDir = TempDir.createSync("@omp-remote-bootstrap-");
+		const socketPath = tempDir.join("runtime.sock");
+		const configPath = tempDir.join("runtime.json");
+		await Bun.write(configPath, JSON.stringify(descriptor(socketPath)));
+		await fs.chmod(configPath, 0o600);
+		const socketClosed = Promise.withResolvers<void>();
+		const server = net.createServer(socket => {
+			let residual = "";
+			socket.on("data", data => {
+				residual += data.toString("utf8");
+				const newline = residual.indexOf("\n");
+				if (newline === -1) return;
+				const request = JSON.parse(residual.slice(0, newline)) as { requestId: string };
+				socket.write(
+					`${JSON.stringify({
+						protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+						kind: "result",
+						requestId: request.requestId,
+						result: {
+							version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+							capabilities: REMOTE_RUNTIME_REQUIRED_CAPABILITIES,
+							maxFrameBytes: REMOTE_RUNTIME_MAX_FRAME_BYTES,
+						},
+					})}\n`,
+				);
+			});
+			socket.on("close", socketClosed.resolve);
+		});
+		const listening = Promise.withResolvers<void>();
+		server.once("listening", listening.resolve);
+		server.once("error", listening.reject);
+		server.listen(socketPath);
+		await listening.promise;
+		await fs.chmod(socketPath, 0o600);
+		try {
+			expect(currentRemoteRuntime()).toBeUndefined();
+			expect(remoteRuntimeSealActive()).toBe(false);
+			await runWithRemoteRuntimeConfig(configPath, async () => {
+				const installed = currentRemoteRuntime();
+				expect(remoteRuntimeSealActive()).toBe(true);
+				expect(installed).toBeDefined();
+				expect(installed?.subagentBackend.constructor.name).toBe("SocketStructuredSubagentBackend");
+				expect(installed?.registryBackend.constructor.name).toBe("SocketRemoteRegistryBackend");
+				expect(installed?.peerTransport.constructor.name).toBe("SocketPeerTransportBackend");
+			});
+			expect(currentRemoteRuntime()).toBeUndefined();
+			expect(remoteRuntimeSealActive()).toBe(false);
+			await socketClosed.promise;
+		} finally {
+			const closed = Promise.withResolvers<void>();
+			server.close(error => (error ? closed.reject(error) : closed.resolve()));
+			await closed.promise;
+		}
+	});
+
+	it("keeps concurrent command scopes isolated and rejects nested replacement", async () => {
+		const first = bindings("first");
+		const second = bindings("second");
+		const firstGate = Promise.withResolvers<void>();
+		const secondGate = Promise.withResolvers<void>();
+		const firstRun = runWithRemoteRuntime(first, async () => {
+			expect(currentRemoteRuntime()).toBe(first);
+			firstGate.resolve();
+			await secondGate.promise;
+			expect(currentRemoteRuntime()).toBe(first);
+			expect(() => runWithRemoteRuntime(second, () => undefined)).toThrow("already installed");
+		});
+		const secondRun = runWithRemoteRuntime(second, async () => {
+			await firstGate.promise;
+			expect(currentRemoteRuntime()).toBe(second);
+			secondGate.resolve();
+		});
+		await Promise.all([firstRun, secondRun]);
+		expect(currentRemoteRuntime()).toBeUndefined();
+	});
+
+	it("binds remote refs to explicit owners and rejects a different ambient backend", async () => {
+		const owner = bindings("owner");
+		const different = bindings("different");
+		const registry = new AgentRegistry({ remoteBackend: owner.registryBackend });
+		const input: RemoteRegisterInput = {
+			id: "RemoteChild",
+			displayName: "remote child",
+			kind: "sub",
+			parentId: "Main",
+			status: "running",
+			identity: { controllerId: "controller-a", executionId: "execution-a", generation: 1 },
+			createdAt: 1,
+		};
+		const ref = registry.registerRemote(input);
+
+		await expect(registry.refreshRemote("RemoteChild")).resolves.toMatchObject({ activity: "owner" });
+		await runWithRemoteRuntime(different, async () => {
+			await expect(registry.refreshRemote("RemoteChild")).rejects.toThrow("different sealed runtime");
+			expect(() => registry.settleRemote({ ...input, status: "idle" }, ref, different.registryBackend)).toThrow(
+				"different sealed runtime",
+			);
+			expect(() =>
+				new AgentRegistry().registerRemote({
+					...input,
+					id: "OwnerlessChild",
+					identity: { ...input.identity, executionId: "execution-b" },
+				}),
+			).toThrow("explicit or constructor backend owner");
+		});
+		expect(ref.status).toBe("running");
+	});
+});

--- a/packages/coding-agent/test/remote-runtime/client.test.ts
+++ b/packages/coding-agent/test/remote-runtime/client.test.ts
@@ -1,0 +1,695 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import {
+	REMOTE_RUNTIME_MAX_FRAME_BYTES,
+	REMOTE_RUNTIME_REQUIRED_CAPABILITIES,
+	RemoteRuntimeClient,
+	RemoteRuntimeProtocolError,
+	type RemoteRuntimeRequestEnvelope,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/client";
+import {
+	parseRemoteRuntimeConfig,
+	REMOTE_RUNTIME_PROTOCOL_VERSION,
+	type RemoteRuntimeConfig,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/config";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+interface ServerHarness {
+	readonly socketPath: string;
+	readonly server: net.Server;
+	readonly sockets: Set<net.Socket>;
+}
+
+function runtimeConfig(socketPath: string, timeoutMs = 1_000): RemoteRuntimeConfig {
+	return parseRemoteRuntimeConfig({
+		version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		socketPath,
+		controllerId: "controller-a",
+		executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		rootExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		parentExecutionId: null,
+		assignmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+		depth: 0,
+		revision: "a".repeat(40),
+		grantId: "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+		policyDigest: `sha256:${"b".repeat(64)}`,
+		budgetRef: "budget:root-1",
+		schemaRef: "schema:root-1",
+		requestTimeoutMs: timeoutMs,
+	});
+}
+async function startServer(
+	socketPath: string,
+	onFrame: (socket: net.Socket, frame: Record<string, unknown>) => void,
+	onConnect?: (socket: net.Socket) => void,
+): Promise<ServerHarness> {
+	const sockets = new Set<net.Socket>();
+	const server = net.createServer(socket => {
+		onConnect?.(socket);
+		sockets.add(socket);
+		let residual: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+		socket.on("data", chunk => {
+			const data = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+			residual = residual.length === 0 ? Buffer.from(data) : Buffer.concat([residual, data]);
+			while (true) {
+				const newline = residual.indexOf(0x0a);
+				if (newline === -1) return;
+				const line = residual.subarray(0, newline).toString("utf8");
+				residual = Buffer.from(residual.subarray(newline + 1));
+				onFrame(socket, JSON.parse(line) as Record<string, unknown>);
+			}
+		});
+		socket.on("close", () => sockets.delete(socket));
+	});
+	const listening = Promise.withResolvers<void>();
+	server.once("listening", listening.resolve);
+	server.once("error", listening.reject);
+	server.listen(socketPath);
+	await listening.promise;
+	await fs.chmod(socketPath, 0o600);
+	return { socketPath, server, sockets };
+}
+
+async function stopServer(harness: ServerHarness): Promise<void> {
+	for (const socket of harness.sockets) socket.destroy();
+	const closed = Promise.withResolvers<void>();
+	harness.server.close(error => (error ? closed.reject(error) : closed.resolve()));
+	await closed.promise;
+}
+
+function resultFrame(requestId: string, result: unknown): string {
+	return `${JSON.stringify({
+		protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		kind: "result",
+		requestId,
+		result,
+	})}\n`;
+}
+
+function bootstrapAcknowledgement(capabilities: readonly string[] = REMOTE_RUNTIME_REQUIRED_CAPABILITIES): {
+	readonly version: typeof REMOTE_RUNTIME_PROTOCOL_VERSION;
+	readonly capabilities: readonly string[];
+	readonly maxFrameBytes: number;
+} {
+	return {
+		version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		capabilities,
+		maxFrameBytes: REMOTE_RUNTIME_MAX_FRAME_BYTES,
+	};
+}
+
+function bootstrapAware(
+	handle: (socket: net.Socket, frame: RemoteRuntimeRequestEnvelope) => void,
+): (socket: net.Socket, frame: Record<string, unknown>) => void {
+	return (socket, frame) => {
+		if (frame.kind !== "request" || typeof frame.requestId !== "string") return;
+		const request = frame as unknown as RemoteRuntimeRequestEnvelope;
+		if (request.operation === "runtime.bootstrap") {
+			socket.write(resultFrame(request.requestId, bootstrapAcknowledgement()));
+			return;
+		}
+		handle(socket, request);
+	};
+}
+
+describe("sealed remote runtime socket protocol", () => {
+	it("requires an exact bootstrap capability set, protocol version, and frame limit", async () => {
+		const cases: ReadonlyArray<{
+			readonly acknowledgement: unknown;
+			readonly code: string;
+		}> = [
+			{
+				acknowledgement: bootstrapAcknowledgement(REMOTE_RUNTIME_REQUIRED_CAPABILITIES.slice(0, -1)),
+				code: "CAPABILITY_MISMATCH",
+			},
+			{
+				acknowledgement: bootstrapAcknowledgement([
+					...REMOTE_RUNTIME_REQUIRED_CAPABILITIES,
+					"unrequested-capability",
+				]),
+				code: "CAPABILITY_MISMATCH",
+			},
+			{
+				acknowledgement: { ...bootstrapAcknowledgement(), version: "omp.remote-runtime.v2" },
+				code: "VERSION_MISMATCH",
+			},
+			{
+				acknowledgement: { ...bootstrapAcknowledgement(), maxFrameBytes: REMOTE_RUNTIME_MAX_FRAME_BYTES - 1 },
+				code: "FRAME_LIMIT_MISMATCH",
+			},
+		];
+
+		for (const testCase of cases) {
+			using tempDir = TempDir.createSync("@rr-");
+			const socketPath = tempDir.join("runtime.sock");
+			const harness = await startServer(socketPath, (socket, frame) => {
+				if (frame.kind === "request" && typeof frame.requestId === "string") {
+					socket.write(resultFrame(frame.requestId, testCase.acknowledgement));
+				}
+			});
+			const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+			try {
+				await expect(client.start()).rejects.toMatchObject({ code: testCase.code });
+			} finally {
+				client.close();
+				await stopServer(harness);
+			}
+		}
+	});
+
+	it("sends an exact authority-bound request frame with no endpoint or credential material", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const observed = Promise.withResolvers<RemoteRuntimeRequestEnvelope>();
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				observed.resolve(request);
+				socket.write(resultFrame(request.requestId, { accepted: true }));
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		try {
+			await client.start();
+			await expect(client.request("registry.status", { identity: "logical" })).resolves.toEqual({ accepted: true });
+			const request = await observed.promise;
+			expect(Object.keys(request).sort()).toEqual(
+				["context", "idempotencyKey", "kind", "operation", "payload", "protocol", "requestId"].sort(),
+			);
+			expect(request.context).toEqual({
+				controllerId: "controller-a",
+				executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+				revision: "a".repeat(40),
+				grantId: "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+				policyDigest: `sha256:${"b".repeat(64)}`,
+				parentExecutionId: null,
+				rootExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+				depth: 0,
+				assignmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+				budgetRef: "budget:root-1",
+				schemaRef: "schema:root-1",
+			});
+			expect(JSON.stringify(request)).not.toContain(socketPath);
+			expect(JSON.stringify(request)).not.toMatch(/token|credential/i);
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("rejects symlinked, permissive, foreign-owned, and substitutable socket fixtures", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const realSocket = tempDir.join("runtime.sock");
+		const harness = await startServer(
+			realSocket,
+			bootstrapAware(() => {}),
+		);
+		try {
+			const symlinkSocket = tempDir.join("runtime-link.sock");
+			await fs.symlink(realSocket, symlinkSocket);
+			await expect(new RemoteRuntimeClient(runtimeConfig(symlinkSocket)).start()).rejects.toMatchObject({
+				code: "UNTRUSTED_SOCKET",
+			});
+
+			await fs.chmod(realSocket, 0o660);
+			await expect(new RemoteRuntimeClient(runtimeConfig(realSocket)).start()).rejects.toMatchObject({
+				code: "UNTRUSTED_SOCKET",
+			});
+			await fs.chmod(realSocket, 0o600);
+
+			if (typeof process.geteuid !== "function") throw new Error("test requires geteuid");
+			const effectiveUid = process.geteuid();
+			const uid = vi.spyOn(process, "geteuid").mockReturnValue(effectiveUid + 1);
+			try {
+				await expect(new RemoteRuntimeClient(runtimeConfig(realSocket)).start()).rejects.toMatchObject({
+					code: "UNTRUSTED_SOCKET",
+				});
+			} finally {
+				uid.mockRestore();
+			}
+		} finally {
+			await stopServer(harness);
+		}
+
+		const openDirectory = tempDir.join("open");
+		await fs.mkdir(openDirectory, { mode: 0o700 });
+		const openSocket = `${openDirectory}/runtime.sock`;
+		const openHarness = await startServer(
+			openSocket,
+			bootstrapAware(() => {}),
+		);
+		try {
+			await fs.chmod(openDirectory, 0o777);
+			await expect(new RemoteRuntimeClient(runtimeConfig(openSocket)).start()).rejects.toMatchObject({
+				code: "UNTRUSTED_SOCKET",
+			});
+		} finally {
+			await fs.chmod(openDirectory, 0o700);
+			await stopServer(openHarness);
+		}
+	});
+
+	it("rejects inbound frames before post-connect socket authority verification", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const connected = Promise.withResolvers<void>();
+		const verificationGate = Promise.withResolvers<void>();
+		const preVerificationDispatch = Promise.withResolvers<void>();
+		const observed: number[] = [];
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware(() => {}),
+			socket => {
+				socket.write(
+					`${JSON.stringify({
+						protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+						kind: "observation",
+						stream: "attacker",
+						cursor: 1,
+						observation: { injected: true },
+					})}\n`,
+				);
+				connected.resolve();
+			},
+		);
+		const originalRealpath = fs.realpath;
+		let verificationPass = 0;
+		const gatedRealpath = async (pathValue: Parameters<typeof fs.realpath>[0]): Promise<string> => {
+			const resolved = await originalRealpath(pathValue);
+			verificationPass += 1;
+			if (verificationPass === 2) await verificationGate.promise;
+			return resolved;
+		};
+		const realpath = vi.spyOn(fs, "realpath").mockImplementation(gatedRealpath as typeof fs.realpath);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		client.onObservation("attacker", envelope => {
+			observed.push(envelope.cursor);
+			preVerificationDispatch.resolve();
+		});
+		const started = client.start();
+		try {
+			await connected.promise;
+			const outcome = await Promise.race([
+				started.then(
+					() => ({ kind: "started" as const }),
+					error => ({ kind: "rejected" as const, error }),
+				),
+				preVerificationDispatch.promise.then(() => ({ kind: "dispatched" as const })),
+			]);
+			expect(outcome).toMatchObject({
+				kind: "rejected",
+				error: { code: "UNTRUSTED_SOCKET" },
+			});
+			expect(observed).toEqual([]);
+		} finally {
+			verificationGate.resolve();
+			await started.catch(() => undefined);
+			client.close();
+			realpath.mockRestore();
+			await stopServer(harness);
+		}
+	});
+
+	it("reassembles fragmented frames and demultiplexes coalesced concurrent results", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const requests: RemoteRuntimeRequestEnvelope[] = [];
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				requests.push(request);
+				if (requests.length !== 2) return;
+				const second = resultFrame(requests[1].requestId, { order: 2 });
+				const first = resultFrame(requests[0].requestId, { order: 1 });
+				const combined = Buffer.from(`${second}${first}`);
+				socket.write(combined.subarray(0, 13));
+				socket.write(combined.subarray(13, 41));
+				socket.write(combined.subarray(41));
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		try {
+			await client.start();
+			const [first, second] = await Promise.all([
+				client.request("registry.status", { n: 1 }),
+				client.request("registry.progress", { n: 2 }),
+			]);
+			expect(first).toEqual({ order: 1 });
+			expect(second).toEqual({ order: 2 });
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("allows an explicitly unlimited subagent run to outlive the generic RPC timeout", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				setTimeout(() => socket.write(resultFrame(request.requestId, { completed: true })), 150);
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath, 100));
+		try {
+			await client.start();
+			await expect(client.request("subagent.run", {}, { timeoutMs: null })).resolves.toEqual({ completed: true });
+			await expect(client.request("registry.status", {}, { timeoutMs: null })).rejects.toMatchObject({
+				code: "INVALID_TIMEOUT",
+			});
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("emits exact cancellation frames for AbortSignal and request deadlines", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const cancels: Record<string, unknown>[] = [];
+		const sawTwoCancels = Promise.withResolvers<void>();
+		const sawAbortRequest = Promise.withResolvers<void>();
+		const sawTimeoutRequest = Promise.withResolvers<void>();
+		let requestCount = 0;
+		const harness = await startServer(socketPath, (socket, frame) => {
+			if (
+				frame.kind === "request" &&
+				frame.operation === "runtime.bootstrap" &&
+				typeof frame.requestId === "string"
+			) {
+				socket.write(resultFrame(frame.requestId, bootstrapAcknowledgement()));
+				return;
+			}
+			if (frame.kind === "request") {
+				requestCount += 1;
+				if (requestCount === 1) sawAbortRequest.resolve();
+				if (requestCount === 2) sawTimeoutRequest.resolve();
+				if (requestCount === 3 && typeof frame.requestId === "string") {
+					socket.write(resultFrame(frame.requestId, { alive: true }));
+				}
+			}
+			if (frame.kind === "cancel") {
+				cancels.push(frame);
+				if (cancels.length === 2) sawTwoCancels.resolve();
+				if (typeof frame.requestId === "string") {
+					socket.write(resultFrame(frame.requestId, { cancelled: true }));
+				}
+			}
+		});
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		try {
+			await client.start();
+			const controller = new AbortController();
+			const aborted = client.request("registry.status", {}, { signal: controller.signal });
+			await sawAbortRequest.promise;
+			controller.abort();
+			await expect(aborted).rejects.toMatchObject({ code: "ABORTED" });
+			vi.useFakeTimers();
+			const timedOut = client.request("registry.progress", {}, { timeoutMs: 10 });
+			await sawTimeoutRequest.promise;
+			vi.advanceTimersByTime(10);
+			await expect(timedOut).rejects.toMatchObject({ code: "TIMEOUT" });
+			await sawTwoCancels.promise;
+			expect(cancels.map(frame => frame.reason).sort()).toEqual(["aborted", "timeout"]);
+			for (const cancel of cancels) {
+				expect(Object.keys(cancel).sort()).toEqual(
+					["context", "idempotencyKey", "kind", "protocol", "reason", "requestId", "targetRequestId"].sort(),
+				);
+			}
+			vi.useRealTimers();
+			await expect(client.request("registry.result", {})).resolves.toEqual({ alive: true });
+		} finally {
+			vi.useRealTimers();
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("rejects outgoing and residual incoming frames beyond the byte ceiling", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				if (request.operation === "registry.status") {
+					socket.write(Buffer.alloc(REMOTE_RUNTIME_MAX_FRAME_BYTES + 1, 0x61));
+				}
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		try {
+			await client.start();
+			await expect(
+				client.request("peer.deliver", { body: "x".repeat(REMOTE_RUNTIME_MAX_FRAME_BYTES) }),
+			).rejects.toMatchObject({
+				code: "FRAME_TOO_LARGE",
+			});
+			await expect(client.request("registry.status", {})).rejects.toMatchObject({ code: "FRAME_TOO_LARGE" });
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("rejects a non-empty residual buffer when the controller ends without a newline", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				socket.end(
+					JSON.stringify({
+						protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+						kind: "result",
+						requestId: request.requestId,
+						result: { incomplete: true },
+					}),
+				);
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		try {
+			await client.start();
+			await expect(client.request("registry.status", {})).rejects.toMatchObject({ code: "MALFORMED_FRAME" });
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("rejects unknown envelope fields and protocol version mismatches terminally", async () => {
+		for (const mode of ["unknown", "version"] as const) {
+			using tempDir = TempDir.createSync("@rr-");
+			const socketPath = tempDir.join("runtime.sock");
+			const harness = await startServer(socketPath, (socket, frame) => {
+				if (frame.kind !== "request" || typeof frame.requestId !== "string") return;
+				socket.write(
+					`${JSON.stringify({
+						protocol: mode === "version" ? "omp.remote-runtime.v2" : REMOTE_RUNTIME_PROTOCOL_VERSION,
+						kind: "result",
+						requestId: frame.requestId,
+						result: bootstrapAcknowledgement(),
+						...(mode === "unknown" ? { extra: true } : {}),
+					})}\n`,
+				);
+			});
+			const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+			try {
+				await expect(client.start()).rejects.toBeInstanceOf(RemoteRuntimeProtocolError);
+				await expect(client.request("registry.status", {})).rejects.toMatchObject({ code: expect.any(String) });
+			} finally {
+				client.close();
+				await stopServer(harness);
+			}
+		}
+	});
+
+	it("enforces contiguous observation cursors across coalesced frames", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const harness = await startServer(socketPath, (socket, frame) => {
+			if (frame.kind !== "request" || typeof frame.requestId !== "string") return;
+			const bootstrap = resultFrame(frame.requestId, bootstrapAcknowledgement());
+			const observations = [1, 2]
+				.map(cursor =>
+					JSON.stringify({
+						protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+						kind: "observation",
+						stream: "peer:main",
+						cursor,
+						observation: { body: `message-${cursor}` },
+					}),
+				)
+				.join("\n");
+			socket.write(`${bootstrap}${observations}\n`);
+		});
+		const sawTwoObservations = Promise.withResolvers<void>();
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		const observed: number[] = [];
+		client.onObservation("peer:main", envelope => {
+			observed.push(envelope.cursor);
+			if (observed.length === 2) sawTwoObservations.resolve();
+		});
+		try {
+			await client.start();
+			await sawTwoObservations.promise;
+			expect(observed).toEqual([1, 2]);
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("isolates observation listener failures and ignores unowned streams while requests continue", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				if (request.operation === "registry.status") {
+					socket.write(
+						`${JSON.stringify({
+							protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+							kind: "observation",
+							stream: "subagent.owned",
+							cursor: 1,
+							observation: { registration: "conflict" },
+						})}\n${JSON.stringify({
+							protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+							kind: "observation",
+							stream: "subagent.unowned",
+							cursor: 999,
+							observation: {},
+						})}\n`,
+					);
+				}
+				socket.write(resultFrame(request.requestId, { operation: request.operation }));
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		client.onObservation("subagent.owned", () => {
+			throw new Error("launch-local registration collision");
+		});
+		try {
+			await client.start();
+			await expect(
+				Promise.all([client.request("registry.status", {}), client.request("registry.progress", {})]),
+			).resolves.toEqual([{ operation: "registry.status" }, { operation: "registry.progress" }]);
+			await expect(client.request("registry.result", {})).resolves.toEqual({
+				operation: "registry.result",
+			});
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("retains a bounded exact set of abandoned request ids and fails closed after eviction", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("runtime.sock");
+		const abandonedCount = 1_025;
+		const controllers = Array.from({ length: abandonedCount }, () => new AbortController());
+		const requestIds = new Array<string>(abandonedCount);
+		let peerSocket: net.Socket | undefined;
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				peerSocket = socket;
+				if (request.operation === "registry.abandon") {
+					const payload = request.payload;
+					if (
+						typeof payload !== "object" ||
+						payload === null ||
+						!("index" in payload) ||
+						typeof payload.index !== "number" ||
+						!Number.isInteger(payload.index) ||
+						payload.index < 0 ||
+						payload.index >= controllers.length
+					) {
+						throw new Error("remote runtime test received an invalid abandonment index");
+					}
+					requestIds[payload.index] = request.requestId;
+					controllers[payload.index].abort();
+					return;
+				}
+				if (request.operation === "registry.probe") {
+					socket.write(resultFrame(request.requestId, { alive: true }));
+					return;
+				}
+				if (request.operation === "registry.evicted") {
+					socket.write(
+						`${resultFrame(requestIds[0], { late: "evicted" })}${resultFrame(request.requestId, {
+							unsafe: true,
+						})}`,
+					);
+				}
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath, 10_000));
+		try {
+			await client.start();
+			const outcomes = await Promise.all(
+				controllers.map((controller, index) =>
+					client.request("registry.abandon", { index }, { signal: controller.signal }).then(
+						() => "resolved",
+						error => (error as RemoteRuntimeProtocolError).code,
+					),
+				),
+			);
+			expect(outcomes.every(code => code === "ABORTED")).toBe(true);
+			expect(requestIds.every(requestId => typeof requestId === "string")).toBe(true);
+			const connectedSocket = peerSocket;
+			if (!connectedSocket) throw new Error("remote runtime test socket did not connect");
+
+			connectedSocket.write(resultFrame(requestIds[abandonedCount - 1], { late: "retained" }));
+			await expect(client.request("registry.probe", {})).resolves.toEqual({ alive: true });
+			await expect(client.request("registry.evicted", {})).rejects.toMatchObject({ code: "UNKNOWN_REQUEST" });
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+
+	it("never exposes controller error text, credentials, or private paths", async () => {
+		using tempDir = TempDir.createSync("@rr-");
+		const socketPath = tempDir.join("r.sock");
+		const harness = await startServer(
+			socketPath,
+			bootstrapAware((socket, request) => {
+				socket.write(
+					`${JSON.stringify({
+						protocol: REMOTE_RUNTIME_PROTOCOL_VERSION,
+						kind: "error",
+						requestId: request.requestId,
+						error: {
+							code: "DENIED",
+							message: "token super-secret failed at /Users/private/controller.sock",
+							retryable: false,
+						},
+					})}\n`,
+				);
+			}),
+		);
+		const client = new RemoteRuntimeClient(runtimeConfig(socketPath));
+		try {
+			await client.start();
+			let failure: unknown;
+			try {
+				await client.request("registry.status", {});
+			} catch (error) {
+				failure = error;
+			}
+			expect(failure).toBeInstanceOf(RemoteRuntimeProtocolError);
+			const message = String(failure);
+			expect(message).toContain("DENIED");
+			expect(message).not.toContain("super-secret");
+			expect(message).not.toContain("/Users/private");
+			expect(message).not.toContain(socketPath);
+		} finally {
+			client.close();
+			await stopServer(harness);
+		}
+	});
+});

--- a/packages/coding-agent/test/remote-runtime/config.test.ts
+++ b/packages/coding-agent/test/remote-runtime/config.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import {
+	loadRemoteRuntimeConfig,
+	parseRemoteRuntimeConfig,
+	REMOTE_RUNTIME_PROTOCOL_VERSION,
+} from "@oh-my-pi/pi-coding-agent/remote-runtime/config";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function validConfig(): Record<string, unknown> {
+	return {
+		version: REMOTE_RUNTIME_PROTOCOL_VERSION,
+		socketPath: "/var/run/omp-runtime.sock",
+		controllerId: "controller-a",
+		executionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		rootExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		parentExecutionId: null,
+		assignmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+		depth: 0,
+		revision: "a".repeat(40),
+		grantId: "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+		policyDigest: `sha256:${"b".repeat(64)}`,
+		budgetRef: "budget:root-1",
+		schemaRef: "schema:root-1",
+		requestTimeoutMs: 5_000,
+	};
+}
+
+describe("sealed remote runtime config", () => {
+	it("parses the single explicit CLI descriptor without environment inference", () => {
+		const parsed = parseArgs(["--remote-runtime-config", "/tmp/runtime.json", "work"]);
+		expect(parsed.remoteRuntimeConfig).toBe("/tmp/runtime.json");
+		expect(parsed.messages).toEqual(["work"]);
+		expect(parseArgs([]).remoteRuntimeConfig).toBeUndefined();
+	});
+
+	it("freezes a complete bounded authority descriptor", () => {
+		const config = parseRemoteRuntimeConfig(validConfig());
+		expect(Object.isFrozen(config)).toBe(true);
+		expect(config.revision).toBe("a".repeat(40));
+		expect(config.policyDigest).toBe(`sha256:${"b".repeat(64)}`);
+	});
+
+	it("rejects partial and unknown credential-bearing config", () => {
+		const partial = validConfig();
+		delete partial.grantId;
+		expect(() => parseRemoteRuntimeConfig(partial)).toThrow("missing required field grantId");
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), token: "do-not-admit" })).toThrow("unknown fields");
+		let failure: unknown;
+		try {
+			parseRemoteRuntimeConfig({ ...validConfig(), "/Users/private/token": "secret" });
+		} catch (error) {
+			failure = error;
+		}
+		expect(String(failure)).toContain("unknown fields");
+		expect(String(failure)).not.toContain("/Users/private");
+		expect(String(failure)).not.toContain("secret");
+	});
+
+	it("rejects relative, NUL, Windows-style, and overlong socket paths", () => {
+		for (const socketPath of ["runtime.sock", "/tmp/runtime\0.sock", "C:\\runtime.sock", `/${"x".repeat(101)}`]) {
+			expect(() => parseRemoteRuntimeConfig({ ...validConfig(), socketPath })).toThrow();
+		}
+	});
+
+	it("rejects relative and NUL descriptor paths before filesystem access", async () => {
+		await expect(loadRemoteRuntimeConfig("runtime.json")).rejects.toThrow("absolute Unix path");
+		await expect(loadRemoteRuntimeConfig("/tmp/runtime\u0000.json")).rejects.toThrow("absolute Unix path");
+	});
+
+	it.skipIf(process.platform === "win32")("requires a current-user-owned private descriptor", async () => {
+		using tempDir = TempDir.createSync("@omp-remote-config-");
+		const configPath = path.join(tempDir.path(), "runtime.json");
+		await fs.writeFile(configPath, JSON.stringify(validConfig()), { mode: 0o600 });
+		expect((await loadRemoteRuntimeConfig(configPath)).executionId).toBe("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+		for (const mode of [0o640, 0o644]) {
+			await fs.chmod(configPath, mode);
+			await expect(loadRemoteRuntimeConfig(configPath)).rejects.toThrow("current-user-owned, private");
+		}
+	});
+
+	it("rejects mutable revisions, malformed digests and ULIDs, and inconsistent lineage", () => {
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), revision: "main" })).toThrow("immutable");
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), policyDigest: "sha256:not-a-digest" })).toThrow(
+			"SHA-256",
+		);
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), executionId: "execution-a" })).toThrow("ULID");
+		expect(() =>
+			parseRemoteRuntimeConfig({
+				...validConfig(),
+				depth: 1,
+				parentExecutionId: null,
+			}),
+		).toThrow("requires parentExecutionId");
+	});
+
+	it("rejects unbounded timeouts and non-logical schema or budget references", () => {
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), requestTimeoutMs: 0 })).toThrow("between 100");
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), budgetRef: "/private/budget.json" })).toThrow(
+			"logical reference",
+		);
+		expect(() => parseRemoteRuntimeConfig({ ...validConfig(), schemaRef: "../schema.json" })).toThrow(
+			"logical reference",
+		);
+	});
+});

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -8,6 +8,7 @@ import {
 	resetRegisteredArtifactDirsForTests,
 } from "@oh-my-pi/pi-coding-agent/internal-urls/registry-helpers";
 import * as planHandoff from "@oh-my-pi/pi-coding-agent/plan-mode/plan-handoff";
+import { runWithRemoteRuntime } from "@oh-my-pi/pi-coding-agent/remote-runtime/scope";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
 import * as isolationRunner from "@oh-my-pi/pi-coding-agent/task/isolation-runner";
@@ -15,8 +16,10 @@ import {
 	buildStructuredSubagentRecoveryHint,
 	resolveEffectiveSubagentPolicy,
 	runStructuredSubagent,
+	type StructuredSubagentBackendContext,
 	StructuredSubagentError,
 	type StructuredSubagentRequest,
+	type StructuredSubagentResult,
 } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
 import type { AgentDefinition, SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
@@ -81,6 +84,33 @@ function result(): SingleResult {
 		durationMs: 1,
 		tokens: 0,
 		requests: 1,
+	};
+}
+
+function remoteResult(context: StructuredSubagentBackendContext): StructuredSubagentResult {
+	const completed = result();
+	completed.id = context.request.identity?.id ?? completed.id;
+	completed.index = context.request.index ?? 0;
+	completed.agent = context.policy.agent.name;
+	completed.agentSource = context.policy.agent.source;
+	completed.task = context.request.assignment;
+	completed.assignment = context.request.assignment;
+	completed.output = '{"agent":true}';
+	if (context.outputSchema.source !== "none") {
+		completed.structuredOutput = {
+			source: context.outputSchema.source,
+			mode: context.outputSchema.mode,
+			status: "valid",
+			data: { agent: true },
+		};
+	}
+	return {
+		result: completed,
+		policy: context.policy,
+		mergeSummary: "",
+		changesApplied: null,
+		artifactsDir: "remote-artifacts",
+		temporaryArtifacts: false,
 	};
 }
 
@@ -272,6 +302,289 @@ describe("structured subagent primitive", () => {
 		expect(dispatched[0]?.modelRole).toBeUndefined();
 		expect(settled.result.modelRole).toBeUndefined();
 		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
+	});
+
+	it("dispatches remote execution after normalization without touching local artifacts, leases, or executors", async () => {
+		const order: string[] = [];
+		vi.spyOn(discoveryModule, "discoverAgents").mockImplementation(async () => {
+			order.push("discovery");
+			return { agents: [AGENT], projectAgentsDir: null };
+		});
+		const mkdir = vi.spyOn(fs, "mkdir");
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+		const prepareIsolation = vi.spyOn(isolationRunner, "prepareIsolationContext");
+		const loadPlan = vi.spyOn(planHandoff, "loadOverallPlanReference");
+		const childSession = session();
+		let sessionFileCalls = 0;
+		childSession.getSessionFile = () => {
+			sessionFileCalls++;
+			return null;
+		};
+		let received: StructuredSubagentBackendContext | undefined;
+		const schema = {
+			type: "object",
+			properties: { agent: { type: "boolean" } },
+			required: ["agent"],
+			additionalProperties: false,
+		};
+		const accept = vi.fn();
+		const discard = vi.fn();
+		const backend = {
+			run: async (context: StructuredSubagentBackendContext) => {
+				order.push("remote");
+				received = context;
+				return remoteResult(context);
+			},
+			accept,
+			discard,
+		};
+
+		const settled = await runStructuredSubagent(
+			request({
+				session: childSession,
+				assignment: "  Inspect the target.  ",
+				context: "  Shared context.  ",
+				agent: " worker ",
+				outputSchema: schema,
+				schemaMode: "strict",
+				identity: { label: "  Remote Worker  " },
+			}),
+			{ execution: "remote", backend },
+		);
+
+		expect(order).toEqual(["discovery", "remote"]);
+		expect(received?.request).toMatchObject({
+			assignment: "Inspect the target.",
+			context: "Shared context.",
+			agent: "worker",
+			schemaMode: "strict",
+			identity: { label: "Remote Worker" },
+			index: 0,
+			isolation: { requested: false, merge: "patch", apply: true },
+		});
+		expect(received?.outputSchema).toBe(received?.policy.schema);
+		expect(received?.outputSchema.schema).toBe(schema);
+		expect(settled.result.structuredOutput).toMatchObject({ status: "valid", data: { agent: true } });
+		expect(accept).toHaveBeenCalledTimes(1);
+		expect(discard).not.toHaveBeenCalled();
+		expect(sessionFileCalls).toBe(0);
+		expect(childSession.agentOutputManager).toBeUndefined();
+		expect(mkdir).not.toHaveBeenCalled();
+		expect(loadPlan).not.toHaveBeenCalled();
+		expect(prepareIsolation).not.toHaveBeenCalled();
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("does not dispatch the remote backend when effective-schema preflight rejects", async () => {
+		mockDiscovery();
+		const remoteRun = vi.fn(async (context: StructuredSubagentBackendContext) => remoteResult(context));
+
+		await expect(
+			runStructuredSubagent(request({ outputSchema: false, schemaMode: "strict" }), {
+				execution: "remote",
+				backend: { run: remoteRun },
+			}),
+		).rejects.toThrow("Invalid strict caller output schema");
+
+		expect(remoteRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("fails closed when remote execution is selected without a backend", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+
+		const settled = await runStructuredSubagent(request(), { execution: "remote" });
+
+		expect(settled.result).toMatchObject({
+			exitCode: 1,
+			error: "Remote structured subagent backend is unavailable.",
+		});
+		expect(settled.temporaryArtifacts).toBe(false);
+		expect(settled.artifactsDir).toBe("");
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("converts a rejected remote execution into an error result without local fallback", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+		const backend = {
+			run: async () => {
+				throw new Error("remote unavailable");
+			},
+		};
+
+		const settled = await runStructuredSubagent(request(), { execution: "remote", backend });
+
+		expect(settled.result).toMatchObject({
+			exitCode: 1,
+			error: "Remote structured subagent execution failed: remote unavailable",
+		});
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("propagates cancellation to the remote backend and settles as aborted", async () => {
+		mockDiscovery();
+		const controller = new AbortController();
+		const started = Promise.withResolvers<void>();
+		const pending = Promise.withResolvers<StructuredSubagentResult>();
+		let receivedSignal: AbortSignal | undefined;
+		const discard = vi.fn();
+		const backend = {
+			run: (context: StructuredSubagentBackendContext) => {
+				receivedSignal = context.signal;
+				started.resolve();
+				return pending.promise;
+			},
+			discard,
+		};
+
+		const execution = runStructuredSubagent(request({ signal: controller.signal }), {
+			execution: "remote",
+			backend,
+		});
+		await started.promise;
+		controller.abort(new Error("remote cancellation"));
+		const settled = await execution;
+
+		expect(receivedSignal).toBe(controller.signal);
+		expect(settled.result).toMatchObject({
+			exitCode: 1,
+			aborted: true,
+			abortReason: "remote cancellation",
+			error: "remote cancellation",
+		});
+		expect(discard).toHaveBeenCalledTimes(1);
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("fails closed on a malformed remote result without local fallback", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const isolatedRun = vi.spyOn(isolationRunner, "runIsolatedSubprocess");
+		const discard = vi.fn();
+		const backend = {
+			run: async (context: StructuredSubagentBackendContext) => {
+				const malformed = remoteResult(context);
+				malformed.result.structuredOutput = {
+					source: context.outputSchema.source,
+					mode: context.outputSchema.mode,
+					status: "valid",
+					data: { agent: "not-a-boolean" },
+				};
+				return malformed;
+			},
+			discard,
+		};
+
+		const settled = await runStructuredSubagent(request(), { execution: "remote", backend });
+
+		expect(settled.result.exitCode).toBe(1);
+		expect(settled.result.error).toContain("Remote structured subagent backend returned a malformed result");
+		expect(discard).toHaveBeenCalledTimes(1);
+		expect(localRun).not.toHaveBeenCalled();
+		expect(isolatedRun).not.toHaveBeenCalled();
+		expect(artifactsDirsFromRegistry()).toEqual([]);
+	});
+
+	it("fails closed when a remote result changes a preallocated agent id", async () => {
+		mockDiscovery();
+		const localRun = vi.spyOn(executorModule, "runSubprocess");
+		const backend = {
+			run: async (context: StructuredSubagentBackendContext) => {
+				const mismatched = remoteResult(context);
+				mismatched.result.id = "DifferentAgent";
+				return mismatched;
+			},
+		};
+
+		const settled = await runStructuredSubagent(request({ identity: { id: "ReservedAgent" } }), {
+			execution: "remote",
+			backend,
+		});
+
+		expect(settled.result.exitCode).toBe(1);
+		expect(settled.result.error).toContain("result id does not match the normalized preallocated id");
+		expect(localRun).not.toHaveBeenCalled();
+	});
+
+	it("rejects successful strict invalid and unavailable remote schema results", async () => {
+		mockDiscovery();
+		for (const status of ["invalid", "unavailable"] as const) {
+			const backend = {
+				run: async (context: StructuredSubagentBackendContext) => {
+					const malformed = remoteResult(context);
+					malformed.result.exitCode = 0;
+					malformed.result.stderr = "";
+					malformed.result.structuredOutput = {
+						source: context.outputSchema.source,
+						mode: "strict",
+						status,
+						error: `${status} schema result`,
+					};
+					return malformed;
+				},
+			};
+
+			const settled = await runStructuredSubagent(request({ schemaMode: "strict" }), {
+				execution: "remote",
+				backend,
+			});
+
+			expect(settled.result.exitCode).toBe(1);
+			expect(settled.result.error).toContain(
+				"strict invalid or unavailable structuredOutput must be a failed schema_violation",
+			);
+		}
+	});
+
+	it("keeps explicit local execution on the native executor when a backend is injected", async () => {
+		mockDiscovery();
+		const remoteRun = vi.fn(async (context: StructuredSubagentBackendContext) => remoteResult(context));
+		const localRun = vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(result());
+
+		const settled = await runStructuredSubagent(request({ retainArtifacts: true }), {
+			execution: "local",
+			backend: { run: remoteRun },
+		});
+
+		expect(localRun).toHaveBeenCalledTimes(1);
+		expect(remoteRun).not.toHaveBeenCalled();
+		expect(settled.temporaryArtifacts).toBe(true);
+		expect(path.basename(settled.artifactsDir)).toStartWith("omp-task-");
+		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
+	});
+
+	it("forces every structured launch through the scoped sealed backend without local fallback", async () => {
+		mockDiscovery();
+		const remoteRun = vi.fn(async (context: StructuredSubagentBackendContext) => remoteResult(context));
+		const localRun = vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(result());
+
+		const settled = await runWithRemoteRuntime(
+			{
+				subagentBackend: { run: remoteRun },
+				registryBackend: {} as never,
+				peerTransport: {} as never,
+			},
+			() =>
+				runStructuredSubagent(request(), {
+					execution: "local",
+					backend: { run: async () => Promise.reject(new Error("must not run")) },
+				}),
+		);
+
+		expect(settled.result.exitCode).toBe(0);
+		expect(remoteRun).toHaveBeenCalledTimes(1);
+		expect(localRun).not.toHaveBeenCalled();
 	});
 
 	it("leases temporary artifacts for a retained invocation and registers them for agent URLs", async () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -665,6 +665,8 @@ describe("IRC", () => {
 			const peerIds = details?.peers?.map(peer => peer.id) ?? [];
 			expect(peerIds).toContain("0-Worker");
 			expect(peerIds).not.toContain("0-Main/advisor");
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+			expect(text).not.toContain("Parked agents are revived automatically");
 		});
 
 		it("op=send returns receipts immediately without waiting for a reply", async () => {

--- a/packages/coding-agent/test/tools/remote-peer-transport.test.ts
+++ b/packages/coding-agent/test/tools/remote-peer-transport.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	IrcBus,
+	type IrcMessage,
+	type PeerTransportBackend,
+	type PeerTransportDelivery,
+	type PeerTransportResult,
+} from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry, type RemoteRegistryBackend } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { executeMessageWait } from "@oh-my-pi/pi-coding-agent/tools/hub/messaging";
+
+const REMOTE_OWNER: RemoteRegistryBackend = {
+	status: async identity => ({ identity: { ...identity }, value: "running" }),
+	progress: async identity => ({ identity: { ...identity }, value: { sequence: 0 } }),
+	cancel: async identity => ({ identity: { ...identity }, value: "cancelled" }),
+	result: async identity => ({ identity: { ...identity }, value: { outcome: "completed" } }),
+};
+
+function localSession() {
+	const delivered: IrcMessage[] = [];
+	const session = {
+		isStreaming: true,
+		deliverIrcMessage: async (message: IrcMessage) => {
+			delivered.push(message);
+			return "injected" as const;
+		},
+	} as unknown as AgentSession;
+	return { session, delivered };
+}
+
+function registerRemote(registry: AgentRegistry, id: string, executionId = id): void {
+	registry.registerRemote(
+		{
+			id,
+			displayName: id,
+			kind: "sub",
+			parentId: "Main",
+			status: "running",
+			identity: { controllerId: "controller", executionId, generation: 3 },
+		},
+		REMOTE_OWNER,
+	);
+}
+
+function accepted(delivery: PeerTransportDelivery): PeerTransportResult {
+	return {
+		deliveryId: delivery.deliveryId,
+		sequence: delivery.sequence,
+		sender: delivery.sender,
+		recipient: delivery.recipient,
+		outcome: "accepted",
+	};
+}
+
+describe("remote peer transport", () => {
+	it("leaves local-local delivery on the in-process bus", async () => {
+		const registry = new AgentRegistry();
+		const recipient = localSession();
+		registry.register({ id: "Local", displayName: "local", kind: "sub", session: recipient.session });
+		const transport: PeerTransportBackend = {
+			deliver: vi.fn(async () => {
+				throw new Error("transport must not run");
+			}),
+			cancel: vi.fn(async () => {}),
+		};
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), transport);
+
+		const receipt = await bus.send({ from: "Main", to: "Local", body: "local message" });
+
+		expect(receipt).toEqual({ to: "Local", outcome: "injected" });
+		expect(recipient.delivered.map(message => message.body)).toEqual(["local message"]);
+		expect(transport.deliver).not.toHaveBeenCalled();
+	});
+
+	it("routes remote recipients and senders with exact immutable identities and monotonic metadata", async () => {
+		const registry = new AgentRegistry();
+		const local = localSession();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: local.session });
+		registerRemote(registry, "RemoteA", "exec-a");
+		const deliveries: PeerTransportDelivery[] = [];
+		const transport: PeerTransportBackend = {
+			deliver: vi.fn(async delivery => {
+				deliveries.push(delivery);
+				return accepted(delivery);
+			}),
+			cancel: vi.fn(async () => {}),
+		};
+		const lifecycle = new AgentLifecycleManager(registry);
+		const ensureLive = vi.spyOn(lifecycle, "ensureLive");
+		const bus = new IrcBus(registry, lifecycle, transport);
+
+		const outbound = await bus.send({
+			from: "Main",
+			to: "RemoteA",
+			body: "remote message",
+			replyTo: "prior-id",
+			endpoint: "https://attacker.invalid",
+			capability: "admin",
+		} as Omit<IrcMessage, "id" | "ts">);
+		const outboundAgain = await bus.send({ from: "Main", to: "RemoteA", body: "second remote message" });
+		const inbound = await bus.send({ from: "RemoteA", to: "Main", body: "remote sender" });
+
+		expect(outbound.outcome).toBe("remote");
+		expect(outboundAgain.outcome).toBe("remote");
+		expect(inbound.outcome).toBe("remote");
+		expect(deliveries.map(delivery => delivery.sequence)).toEqual([1, 2, 1]);
+		expect(deliveries[0]?.sender).toMatchObject({ locality: "local", agentId: "Main", generation: 1 });
+		expect(deliveries[0]?.recipient).toEqual({
+			locality: "remote",
+			agentId: "RemoteA",
+			controllerId: "controller",
+			executionId: "exec-a",
+			generation: 3,
+		});
+		expect(deliveries[0]?.payload).toEqual({ body: "remote message", replyTo: "prior-id" });
+		expect(Object.keys(deliveries[0]?.payload ?? {}).sort()).toEqual(["body", "replyTo"]);
+		expect(local.delivered).toHaveLength(0);
+		expect(bus.unreadCount("Main")).toBe(0);
+		expect(bus.unreadCount("RemoteA")).toBe(0);
+		expect(ensureLive).not.toHaveBeenCalled();
+	});
+
+	it("keeps transport sequences separate for tuple identities that collide under colon concatenation", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registry.registerRemote(
+			{
+				id: "RemoteOne",
+				displayName: "one",
+				kind: "sub",
+				status: "running",
+				identity: { controllerId: "a:b", executionId: "c", generation: 3 },
+			},
+			REMOTE_OWNER,
+		);
+		registry.registerRemote(
+			{
+				id: "RemoteTwo",
+				displayName: "two",
+				kind: "sub",
+				status: "running",
+				identity: { controllerId: "a", executionId: "b:c", generation: 3 },
+			},
+			REMOTE_OWNER,
+		);
+		const deliveries: PeerTransportDelivery[] = [];
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), {
+			deliver: async delivery => {
+				deliveries.push(delivery);
+				return accepted(delivery);
+			},
+			cancel: async () => {},
+		});
+
+		await bus.send({ from: "RemoteOne", to: "Main", body: "one" });
+		await bus.send({ from: "RemoteTwo", to: "Main", body: "two" });
+
+		expect(deliveries.map(delivery => delivery.sequence)).toEqual([1, 1]);
+	});
+
+	it("does not reset a still-live sender after more than 4096 other live identities send", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registerRemote(registry, "LongLived");
+		const deliveries: PeerTransportDelivery[] = [];
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), {
+			deliver: async delivery => {
+				deliveries.push(delivery);
+				return accepted(delivery);
+			},
+			cancel: async () => {},
+		});
+
+		await bus.send({ from: "LongLived", to: "Main", body: "first" });
+		for (let index = 0; index < 4096; index++) {
+			const id = `Remote${index}`;
+			registerRemote(registry, id);
+			await bus.send({ from: id, to: "Main", body: "fill" });
+		}
+		await bus.send({ from: "LongLived", to: "Main", body: "second" });
+
+		expect(deliveries[0]?.sequence).toBe(1);
+		expect(deliveries.at(-1)?.sequence).toBe(2);
+	});
+
+	it("starts an independent sequence when a sender id is re-registered with a new generation", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registerRemote(registry, "Remote", "execution");
+		const deliveries: PeerTransportDelivery[] = [];
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), {
+			deliver: async delivery => {
+				deliveries.push(delivery);
+				return accepted(delivery);
+			},
+			cancel: async () => {},
+		});
+
+		await bus.send({ from: "Remote", to: "Main", body: "first" });
+		await bus.send({ from: "Remote", to: "Main", body: "second" });
+		const firstGeneration = registry.get("Remote");
+		if (!firstGeneration) throw new Error("remote sender was not registered");
+		expect(registry.unregister("Remote", firstGeneration)).toBe(true);
+		registry.registerRemote(
+			{
+				id: "Remote",
+				displayName: "Remote",
+				kind: "sub",
+				parentId: "Main",
+				status: "running",
+				identity: { controllerId: "controller", executionId: "execution", generation: 4 },
+			},
+			REMOTE_OWNER,
+		);
+		await bus.send({ from: "Remote", to: "Main", body: "new generation" });
+
+		expect(deliveries.map(delivery => delivery.sequence)).toEqual([1, 2, 1]);
+		expect(deliveries.at(-1)?.sender.generation).toBe(4);
+	});
+
+	it("fails closed on stale, malformed, duplicate, conflicting, unknown, and unavailable delivery outcomes", async () => {
+		const outcomes: Array<"stale" | "malformed" | "duplicate" | "conflict" | "outage"> = [
+			"stale",
+			"malformed",
+			"duplicate",
+			"conflict",
+			"outage",
+		];
+		for (const outcome of outcomes) {
+			const registry = new AgentRegistry();
+			registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+			registerRemote(registry, "Remote");
+			const transport: PeerTransportBackend = {
+				deliver: async delivery => {
+					if (outcome === "outage") throw new Error("offline");
+					if (outcome === "malformed") return { deliveryId: delivery.deliveryId } as never;
+					if (outcome === "stale") {
+						return {
+							...accepted(delivery),
+							recipient: { ...delivery.recipient, generation: delivery.recipient.generation + 1 },
+						};
+					}
+					return { ...accepted(delivery), outcome };
+				},
+				cancel: async () => {},
+			};
+			const bus = new IrcBus(registry, new AgentLifecycleManager(registry), transport);
+			const receipt = await bus.send({ from: "Main", to: "Remote", body: "message" });
+			expect(receipt.outcome).toBe("failed");
+			expect(bus.unreadCount("Remote")).toBe(0);
+		}
+
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		const deliver = vi.fn(async (delivery: PeerTransportDelivery) => accepted(delivery));
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), { deliver, cancel: async () => {} });
+		const unknown = await bus.send({ from: "Main", to: "Missing", body: "message" });
+		expect(unknown.outcome).toBe("failed");
+		expect(deliver).not.toHaveBeenCalled();
+
+		registerRemote(registry, "Remote");
+		const unavailable = new IrcBus(registry, new AgentLifecycleManager(registry));
+		expect((await unavailable.send({ from: "Main", to: "Remote", body: "message" })).outcome).toBe("failed");
+	});
+
+	it("does not allocate sequence or cancel for a pre-aborted delivery that was never sent", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registerRemote(registry, "Remote");
+		const deliveries: PeerTransportDelivery[] = [];
+		const deliver = vi.fn(async (delivery: PeerTransportDelivery) => {
+			deliveries.push(delivery);
+			return accepted(delivery);
+		});
+		const cancel = vi.fn(async () => {});
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), { deliver, cancel });
+		const controller = new AbortController();
+		controller.abort(new Error("stopped before send"));
+
+		const aborted = await bus.send({ from: "Main", to: "Remote", body: "aborted" }, { signal: controller.signal });
+		const delivered = await bus.send({ from: "Main", to: "Remote", body: "delivered" });
+
+		expect(aborted.outcome).toBe("failed");
+		expect(delivered.outcome).toBe("remote");
+		expect(deliveries.map(delivery => delivery.sequence)).toEqual([1]);
+		expect(cancel).not.toHaveBeenCalled();
+	});
+
+	it("rejects filtered and bare remote waits before creating a local bus waiter", async () => {
+		IrcBus.resetGlobalForTests();
+		try {
+			const registry = new AgentRegistry();
+			registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+			registerRemote(registry, "Remote");
+			const wait = vi.spyOn(IrcBus.global(), "wait");
+			const deps = { registry, senderId: "Main", settings: Settings.isolated() };
+
+			const filtered = await executeMessageWait(deps, { from: "Remote", timeoutMs: 0 });
+			const bare = await executeMessageWait(deps, { timeoutMs: 0 });
+
+			expect(filtered.isError).toBe(true);
+			expect(bare.isError).toBe(true);
+			expect(wait).not.toHaveBeenCalled();
+		} finally {
+			IrcBus.resetGlobalForTests();
+		}
+	});
+
+	it("drains buffered IrcBus mail before rejecting a remote-only future wait", async () => {
+		AgentRegistry.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+		try {
+			const registry = AgentRegistry.global();
+			const mainSession = {
+				isStreaming: false,
+				deliverIrcMessage: async () => {
+					throw new Error("buffer directly in IrcBus mailbox");
+				},
+			} as unknown as AgentSession;
+			registry.register({ id: "Main", displayName: "main", kind: "main", session: mainSession });
+			registerRemote(registry, "Remote");
+			const bus = IrcBus.global();
+			const wait = vi.spyOn(bus, "wait");
+			const deps = { registry, senderId: "Main", settings: Settings.isolated() };
+
+			const failedDelivery = await bus.send({ from: "LegacyLocal", to: "Main", body: "already on bus" });
+			expect(failedDelivery.outcome).toBe("failed");
+			expect(bus.unreadCount("Main")).toBe(1);
+
+			const fromBus = await executeMessageWait(deps, { timeoutMs: 0 });
+
+			expect(fromBus.details?.waited?.body).toBe("already on bus");
+			expect(bus.unreadCount("Main")).toBe(0);
+			expect(wait).not.toHaveBeenCalled();
+		} finally {
+			IrcBus.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+		}
+	});
+
+	it("routes abort cancellation to the same remote delivery identity", async () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "Main", displayName: "main", kind: "main", session: localSession().session });
+		registerRemote(registry, "Remote");
+		const pending = Promise.withResolvers<PeerTransportResult>();
+		let captured: PeerTransportDelivery | undefined;
+		const cancel = vi.fn(async (_delivery: Readonly<PeerTransportDelivery>) => {});
+		const transport: PeerTransportBackend = {
+			deliver: async delivery => {
+				captured = delivery;
+				return pending.promise;
+			},
+			cancel,
+		};
+		const bus = new IrcBus(registry, new AgentLifecycleManager(registry), transport);
+		const controller = new AbortController();
+		const sending = bus.send({ from: "Main", to: "Remote", body: "cancel me" }, { signal: controller.signal });
+		await Promise.resolve();
+		controller.abort(new Error("stop"));
+		await Promise.resolve();
+		expect(cancel).toHaveBeenCalledWith(captured);
+		if (!captured) throw new Error("delivery was not captured");
+		pending.resolve(accepted(captured));
+		expect((await sending).outcome).toBe("remote");
+	});
+});


### PR DESCRIPTION
## Problem
Sandboxed runtimes need subagents to run outside the coordinator process and its local authority. Sandboxed controller endpoints need an explicit remote-only backend that never falls back to local execution and preserves lifecycle, registry, peer, cancellation, and terminal semantics.

## Changes
- Add an opt-in `--remote-runtime-config` Unix-socket transport for structured subagents, remote registry lifecycle, peer messaging, and Hub operations.
- Authenticate a launch-owned private descriptor and socket path; use strict versioned request/result/observation schemas, bounded frames, exact idempotency keys, cancellation, and generic terminal failures.
- Route structured subagent dispatch through one sealed AsyncLocalStorage scope with a process-wide no-fallback latch; create the socket inside that scope so observation callbacks retain the exact controller authority.
- Preserve policy effort, plan-mode restrictions, model role/override, schema provenance, MCP/LSP/IRC flags, execution-scoped identities, and result metadata across the wire.
- Reject controller-supplied filesystem/workspace mutations and preserve local behavior when the flag is absent.

## Verification
Exact head: `c9cc7809f4d89722bb0b0a5a72a20fad4ea514e2`

- 122 focused remote-runtime/structured-subagent/peer/IRC tests passed; 0 failed.
- Coding-agent TypeScript check passed.
- `git diff --check` passed.
- Gitleaks scanned the exact commit: no leaks.
- Independent exact-head correctness review: correct, no blocking findings.
- Independent exact-head security review: approved, no blocking findings; RR-SEAL-001 confirmed fixed.
- Upstream CI: all observed code checks pass or remain in progress. The separate OMP Nix workflow failed before checkout because GitHub returned 429/503 downloading `cachix/install-nix-action`; rerun requires upstream admin rights.

This is a versioned remote-only client seam. It does not ship a controller/server, credentials, private endpoints, production Juiz authority, or enable remote execution by default.