### PR TITLE
fix: provider-qualified model selectors fail closed instead of shadowing to OpenRouter

### DIFF
--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -22,7 +22,7 @@ import { modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
 import { buildModelProviderPriorityRank } from "@oh-my-pi/pi-catalog/identity";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
-import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
+import { getBundledModel, modelsAreEqual, type GeneratedProvider } from "@oh-my-pi/pi-catalog/models";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
 import { resolveBareVariantAlias, resolveVariantAlias } from "@oh-my-pi/pi-catalog/variant-collapse";
 import { fuzzyMatch } from "@oh-my-pi/pi-tui";
@@ -596,6 +596,38 @@ function includeSyntheticAllowedModels(available: Model<Api>[], allowedModels: I
 }
 
 /**
+ * Provider-lock a raw-id cross match.
+ *
+ * A slash-prefixed selector like `anthropic/claude-opus-5` is ambiguous: it is
+ * both the `anthropic` provider's canonical selector and — verbatim — an
+ * OpenRouter aggregator model id. When the named provider genuinely carries
+ * that model id in the bundled catalog but the model is missing from the
+ * candidate set (provider disabled, no credentials, or filtered out), letting
+ * the raw-id fallback re-bind the request onto a different provider's
+ * same-named model is a silent, expensive surprise — typically the aggregator's
+ * copy (OpenRouter bills published per-token Claude prices). Such a reference
+ * is provider-locked: it must fail rather than shadow.
+ *
+ * The lock only applies when the named provider carries the exact id in the
+ * bundled catalog. An aggregator raw id the named provider does NOT carry
+ * (e.g. `openai/gpt-4o:extended` — `openai` bundles `gpt-4o`, not the
+ * `:extended` variant) is legitimately an aggregator id and keeps resolving
+ * through the raw-id fallback, so bare aggregator selectors keep working.
+ */
+function isProviderLockedCrossMatch(pattern: string, matchedModel: Model<Api>): boolean {
+	const slashIdx = pattern.indexOf("/");
+	if (slashIdx <= 0) {
+		return false;
+	}
+	const provider = pattern.slice(0, slashIdx);
+	const modelId = pattern.slice(slashIdx + 1);
+	if (matchedModel.provider.toLowerCase() === provider.toLowerCase()) {
+		return false;
+	}
+	return getBundledModel(provider as GeneratedProvider, modelId) !== undefined;
+}
+
+/**
  * Find an exact explicit provider/model match.
  */
 function findExactModelReferenceMatch(modelReference: string, availableModels: Model<Api>[]): Model<Api> | undefined {
@@ -644,11 +676,17 @@ function matchModel(
 	// Exact ID match (case-insensitive) — this must happen before provider-scoped
 	// fuzzy matching so raw IDs that contain slashes (for example OpenRouter model
 	// IDs like "openai/gpt-4o:extended") still resolve as IDs instead of being
-	// misread as a provider-qualified selector.
+	// misread as a provider-qualified selector. A provider-qualified pattern
+	// whose named provider carries the id stays locked to that provider when its
+	// only exact-id matches live on a different provider (isProviderLockedCrossMatch).
 	const lowerPattern = modelPattern.toLowerCase();
 	const exactMatches = availableModels.filter(m => m.id.toLowerCase() === lowerPattern);
 	if (exactMatches.length > 0) {
-		return pickPreferredModel(exactMatches, context);
+		const unlockedMatches = exactMatches.filter(m => !isProviderLockedCrossMatch(modelPattern, m));
+		if (unlockedMatches.length > 0) {
+			return pickPreferredModel(unlockedMatches, context);
+		}
+		return undefined;
 	}
 
 	const bedrockInferenceProfile = resolveBedrockInferenceProfileModelId(modelPattern, availableModels);
@@ -1710,11 +1748,16 @@ function findExactCliModel(
 	// Flat-id (or full-selector-string) matches prefer authenticated providers,
 	// then fall back to catalog order. This covers aggregator-style flat ids
 	// that merely look provider-qualified (e.g. "openai/gpt-oss-120b" hosted on
-	// OpenRouter), where the provider/id decomposition above found nothing.
+	// OpenRouter), where the provider/id decomposition above found nothing. A
+	// provider-qualified selector whose named provider carries the id must not
+	// re-bind onto another provider's same-named flat id
+	// (isProviderLockedCrossMatch); it stays provider-locked and fails instead.
 	const lower = selector.toLowerCase();
 	const isFlatMatch = (model: Model<Api>) =>
 		model.id.toLowerCase() === lower || formatModelString(model).toLowerCase() === lower;
-	const preferred = availableModels.find(isFlatMatch);
+	const preferred = availableModels.find(
+		m => isFlatMatch(m) && !isProviderLockedCrossMatch(selector, m),
+	);
 	if (preferred) return preferred;
 	// The unauthenticated catalog fallback is a weak match: a bare id like
 	// `default` collides with the bundled `cursor/default` model, which must not
@@ -1723,7 +1766,9 @@ function findExactCliModel(
 	// role gets a chance first; the deferred fuzzy fallback below still recovers
 	// the catalog id when no role matches.
 	if (options?.catalogFallback === false) return undefined;
-	return availableModels === allModels ? undefined : allModels.find(isFlatMatch);
+	return availableModels === allModels
+		? undefined
+		: allModels.find(m => isFlatMatch(m) && !isProviderLockedCrossMatch(selector, m));
 }
 
 export interface ResolveCliModelResult {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -22,7 +22,7 @@ import { modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
 import { buildModelProviderPriorityRank } from "@oh-my-pi/pi-catalog/identity";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
-import { getBundledModel, modelsAreEqual, type GeneratedProvider } from "@oh-my-pi/pi-catalog/models";
+import { type GeneratedProvider, getBundledModel, modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
 import { resolveBareVariantAlias, resolveVariantAlias } from "@oh-my-pi/pi-catalog/variant-collapse";
 import { fuzzyMatch } from "@oh-my-pi/pi-tui";
@@ -1755,9 +1755,7 @@ function findExactCliModel(
 	const lower = selector.toLowerCase();
 	const isFlatMatch = (model: Model<Api>) =>
 		model.id.toLowerCase() === lower || formatModelString(model).toLowerCase() === lower;
-	const preferred = availableModels.find(
-		m => isFlatMatch(m) && !isProviderLockedCrossMatch(selector, m),
-	);
+	const preferred = availableModels.find(m => isFlatMatch(m) && !isProviderLockedCrossMatch(selector, m));
 	if (preferred) return preferred;
 	// The unauthenticated catalog fallback is a weak match: a bare id like
 	// `default` collides with the bundled `cursor/default` model, which must not

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -677,6 +677,69 @@ describe("parseModelPattern", () => {
 		});
 	});
 
+	describe("provider-qualified selectors vs aggregator raw-id shadowing", () => {
+		const anthropicOpus5 = createOpusModel("anthropic", "claude-opus-5", "Claude Opus 5");
+		const openRouterOpus5 = buildModel({
+			id: "anthropic/claude-opus-5",
+			name: "Claude Opus 5 (OpenRouter)",
+			api: "anthropic-messages",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			thinking: {
+				mode: "budget",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+			input: ["text", "image"],
+			cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+			contextWindow: 200000,
+			maxTokens: 32000,
+		});
+
+		test("anthropic/claude-opus-5 does not shadow onto the OpenRouter flat id when anthropic is unavailable", () => {
+			// Anthropic carries claude-opus-5 in the bundled catalog but is absent from
+			// the candidate set (disabled provider, missing creds at boot): the selector
+			// is provider-qualified and must fail rather than re-bind to OpenRouter.
+			const result = parseModelPattern("anthropic/claude-opus-5", [openRouterOpus5]);
+			expect(result.model).toBeUndefined();
+		});
+
+		test("anthropic/claude-opus-5 resolves to the anthropic provider when it is available", () => {
+			const result = parseModelPattern("anthropic/claude-opus-5", [anthropicOpus5, openRouterOpus5]);
+			expect(result.model?.provider).toBe("anthropic");
+			expect(result.model?.id).toBe("claude-opus-5");
+		});
+
+		test("explicit openrouter/anthropic/claude-opus-5 still selects the OpenRouter model", () => {
+			const result = parseModelPattern("openrouter/anthropic/claude-opus-5", [openRouterOpus5]);
+			expect(result.model?.provider).toBe("openrouter");
+			expect(result.model?.id).toBe("anthropic/claude-opus-5");
+		});
+
+		test("resolveModelFromString keeps the provider lock when anthropic is absent", () => {
+			const result = resolveModelFromString("anthropic/claude-opus-5", [openRouterOpus5]);
+			expect(result).toBeUndefined();
+		});
+
+		test("resolveCliModel keeps the provider lock when anthropic is absent", () => {
+			const result = resolveCliModel({
+				cliModel: "anthropic/claude-opus-5",
+				modelRegistry: {
+					getAll: () => [openRouterOpus5],
+					getAvailable: () => [],
+				},
+			});
+			expect(result.model).toBeUndefined();
+			expect(result.error).toBeTruthy();
+		});
+
+		test("openai/gpt-4o:extended still resolves to the OpenRouter raw id (openai carries no such id)", () => {
+			const result = parseModelPattern("openai/gpt-4o:extended", allModels);
+			expect(result.model?.provider).toBe("openrouter");
+			expect(result.model?.id).toBe("openai/gpt-4o:extended");
+		});
+	});
+
 	describe("edge cases", () => {
 		test("empty pattern matches via partial matching", () => {
 			// Empty string is included in all model IDs, so partial matching finds a match


### PR DESCRIPTION
A selector like `anthropic/claude-opus-5` is both the anthropic provider's canonical selector and, verbatim, an OpenRouter model id. When the named provider is out of the candidate set (disabled, no creds at boot), the exact provider-scoped reference misses and the raw-id flat match re-binds the request onto OpenRouter's same-named model. Requests that should fail closed instead bill the aggregator at per-token Claude prices.

Raw-id fallback is only legitimate when the named provider does not carry the id (`openai/gpt-4o:extended`). Lock the reference when it does by checking the bundled catalog, then fail rather than shadow. `openrouter/anthropic/claude-opus-5` still selects OpenRouter explicitly.

Verified: `test/model-resolver.test.ts` green, tsgo clean.