### PR TITLE
feat(coding-agent): display live prompt processing progress (llama.cpp)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `prompt_progress` agent events so clients can display provider-reported prompt processing progress before generation begins.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1403,6 +1403,7 @@ export class Agent {
 			onPayload: this.#onPayload,
 			onResponse: this.#onResponse,
 			onSseEvent: this.#onSseEvent,
+			onPromptProgress: progress => this.#emit({ type: "prompt_progress", progress }),
 			getApiKey: this.getApiKey,
 			getToolContext: this.#getToolContext,
 			syncContextBeforeModelCall: async (context, signal) => {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -8,6 +8,7 @@ import type {
 	ImageContent,
 	Message,
 	Model,
+	PromptProgress,
 	ServiceTier,
 	SimpleStreamOptions,
 	Static,
@@ -874,6 +875,7 @@ export type AgentEvent =
 	// Turn lifecycle - a turn is one assistant response + any tool calls/results
 	| { type: "turn_start" }
 	| { type: "turn_end"; message: AgentMessage; toolResults: ToolResultMessage[] }
+	| { type: "prompt_progress"; progress: PromptProgress }
 	// Message lifecycle - emitted for user, assistant, and toolResult messages
 	| { type: "message_start"; message: AgentMessage }
 	// Only emitted for assistant messages during streaming

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -8,6 +8,26 @@ import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream"
 import { createAssistantMessage } from "./helpers";
 
 describe("Agent", () => {
+	it("forwards provider prompt progress to subscribers", async () => {
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"] },
+			streamFn: (model, context, options) => {
+				options?.onPromptProgress?.({ total: 100, cached: 40, processed: 56 }, model);
+				return mock.stream(model, context, options);
+			},
+		});
+		const events: AgentEvent[] = [];
+		agent.subscribe(event => events.push(event));
+
+		await agent.prompt("ping");
+
+		expect(events).toContainEqual({
+			type: "prompt_progress",
+			progress: { total: 100, cached: 40, processed: 56 },
+		});
+	});
+
 	it("should support steering message queueing", async () => {
 		const agent = new Agent();
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added normalized prompt-processing progress events for llama.cpp Responses streams, including capability-gated `return_progress` requests, propagation across pi-native gateways, and safe handling of missing or malformed progress frames.
+- Added normalized prompt-processing progress events for llama.cpp Responses streams, including capability-gated `return_progress` requests, client-negotiated propagation across pi-native gateways, and safe handling of missing or malformed progress frames.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added normalized prompt-processing progress events for llama.cpp Responses streams, including capability-gated `return_progress` requests and safe handling of missing or malformed progress frames.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added normalized prompt-processing progress events for llama.cpp Responses streams, including capability-gated `return_progress` requests and safe handling of missing or malformed progress frames.
+- Added normalized prompt-processing progress events for llama.cpp Responses streams, including capability-gated `return_progress` requests, propagation across pi-native gateways, and safe handling of missing or malformed progress frames.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -669,23 +669,23 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		}
 	}
 
-	const promptProgress = createPiNativePromptProgressRelay();
-	streamOpts.onPromptProgress = progress => promptProgress.emit(progress);
+	const promptProgress = parsed.capabilities.promptProgress ? createPiNativePromptProgressRelay() : undefined;
+	if (promptProgress) streamOpts.onPromptProgress = progress => promptProgress.emit(progress);
 	let events: AssistantMessageEventStream;
 	try {
 		if (controller.signal.aborted) {
-			promptProgress.close();
+			promptProgress?.close();
 			return aborted();
 		}
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
-		promptProgress.close();
+		promptProgress?.close();
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway streamSimple threw", { format: "pi-native", error: classified.message, peer });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) {
-		promptProgress.close();
+		promptProgress?.close();
 		return aborted();
 	}
 

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -28,6 +28,7 @@ import { isUsageLimitOutcome } from "../error/rate-limit";
 import * as anthropicMessages from "../providers/anthropic-messages-server";
 import * as openaiChat from "../providers/openai-chat-server";
 import * as openaiResponses from "../providers/openai-responses-server";
+import { createPiNativePromptProgressRelay } from "../providers/pi-native-protocol";
 import * as piNative from "../providers/pi-native-server";
 import { completeSimple, streamSimple } from "../stream";
 import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "../types";
@@ -668,19 +669,29 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		}
 	}
 
+	const promptProgress = createPiNativePromptProgressRelay();
+	streamOpts.onPromptProgress = progress => promptProgress.emit(progress);
 	let events: AssistantMessageEventStream;
 	try {
-		if (controller.signal.aborted) return aborted();
+		if (controller.signal.aborted) {
+			promptProgress.close();
+			return aborted();
+		}
 		events = streamSimple(model, parsed.context, streamOpts);
 	} catch (error) {
+		promptProgress.close();
 		const classified = classifyGatewayError(error);
 		logger.warn("auth-gateway streamSimple threw", { format: "pi-native", error: classified.message, peer });
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
-	if (controller.signal.aborted) return aborted();
+	if (controller.signal.aborted) {
+		promptProgress.close();
+		return aborted();
+	}
 
 	const sseStream = piNative.encodeStream(events, parsed.modelId, parsed.options, {
 		signal: controller.signal,
+		promptProgress,
 		onCancel: reason => {
 			if (!controller.signal.aborted) {
 				controller.abort(reason instanceof Error ? reason : new Error("client closed request"));

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -35,6 +35,7 @@ import {
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { OpenAIHttpError, postOpenAIStream } from "../utils/openai-http";
+import { notifyPromptProgress } from "../utils/prompt-progress";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
 import {
@@ -779,13 +780,7 @@ const streamOpenAIResponsesOnce = (
 					for await (const event of timedOpenaiStream) {
 						if (supportsPromptProgress) {
 							const progress = parseLlamaCppPromptProgress(event);
-							if (progress) {
-								try {
-									options?.onPromptProgress?.(progress, model);
-								} catch {
-									// Progress observers are diagnostic/UI-only and cannot break generation.
-								}
-							}
+							if (progress) notifyPromptProgress(options?.onPromptProgress, progress, model);
 						}
 						if (isOpenAIResponsesReplayUnsafeEvent(event)) {
 							sawReplayUnsafeOutput = true;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -10,6 +10,7 @@ import type {
 	Context,
 	Model,
 	OpenAICompat,
+	PromptProgress,
 	ProviderSessionState,
 	RawSseEvent,
 	ServiceTier,
@@ -367,6 +368,35 @@ function markOpenAIResponsesChainZeroDataRetention(chain: OpenAIResponsesChainSt
 
 type OpenRouterAnthropicCacheControl = { type: "ephemeral"; ttl?: "1h" };
 
+/** Parse llama.cpp's top-level extension on Responses `response.in_progress` events. */
+function parseLlamaCppPromptProgress(event: unknown): PromptProgress | undefined {
+	if (!event || typeof event !== "object") return undefined;
+	const record = event as Record<string, unknown>;
+	if (record.type !== "response.in_progress") return undefined;
+	const raw = record.prompt_progress;
+	if (!raw || typeof raw !== "object") return undefined;
+	const progress = raw as Record<string, unknown>;
+	const total = progress.total;
+	const processed = progress.processed;
+	const cached = progress.cache;
+	if (
+		typeof total !== "number" ||
+		!Number.isFinite(total) ||
+		total <= 0 ||
+		typeof processed !== "number" ||
+		!Number.isFinite(processed) ||
+		processed < 0 ||
+		processed > total ||
+		typeof cached !== "number" ||
+		!Number.isFinite(cached) ||
+		cached < 0 ||
+		cached > processed
+	) {
+		return undefined;
+	}
+	return { total, processed, cached };
+}
+
 type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	top_p?: number;
 	top_k?: number;
@@ -375,6 +405,7 @@ type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	repetition_penalty?: number;
 	session_id?: string;
 	stream_options?: { include_obfuscation?: boolean };
+	return_progress?: boolean;
 	provider?: OpenAICompat["openRouterRouting"];
 	reasoning?: { effort?: string } | { enabled: false };
 	cache_control?: OpenRouterAnthropicCacheControl;
@@ -731,6 +762,7 @@ const streamOpenAIResponsesOnce = (
 					attemptStream.queue.length = 0;
 				};
 				nativeOutputItems.length = 0;
+				const supportsPromptProgress = model.compat.supportsPromptProgress;
 				const timedOpenaiStream = iterateWithIdleTimeout(openaiStream, {
 					idleTimeoutMs,
 					firstItemTimeoutMs: firstEventTimeoutMs,
@@ -739,10 +771,22 @@ const streamOpenAIResponsesOnce = (
 					onFirstItemTimeout: () => abortTracker.abortLocally(firstEventTimeoutAbortError),
 					onIdle: () => requestAbortController.abort(),
 					abortSignal: options?.signal,
-					isProgressItem: isOpenAIResponsesProgressEvent,
+					isProgressItem: event =>
+						isOpenAIResponsesProgressEvent(event) ||
+						(supportsPromptProgress && parseLlamaCppPromptProgress(event) !== undefined),
 				});
 				const observedOpenaiStream = (async function* (): AsyncGenerator<ResponseStreamEvent> {
 					for await (const event of timedOpenaiStream) {
+						if (supportsPromptProgress) {
+							const progress = parseLlamaCppPromptProgress(event);
+							if (progress) {
+								try {
+									options?.onPromptProgress?.(progress, model);
+								} catch {
+									// Progress observers are diagnostic/UI-only and cannot break generation.
+								}
+							}
+						}
 						if (isOpenAIResponsesReplayUnsafeEvent(event)) {
 							sawReplayUnsafeOutput = true;
 							if (!forwardAttemptLive) {
@@ -1211,6 +1255,7 @@ export function buildParams(
 		session_id: model.compat.isOpenRouterHost ? getOpenRouterResponsesSessionId(options) : undefined,
 		store: false,
 		stream_options: model.compat.supportsObfuscationOptOut ? { include_obfuscation: false } : undefined,
+		return_progress: model.compat.supportsPromptProgress ? true : undefined,
 	};
 	if (options?.include?.length) params.include = Array.from(new Set(options.include));
 	maybeAddOpenRouterAnthropicCacheControl(params, model, cacheRetention);

--- a/packages/ai/src/providers/pi-native-client.ts
+++ b/packages/ai/src/providers/pi-native-client.ts
@@ -2,12 +2,11 @@
  * Client half of the pi-native auth-gateway protocol.
  *
  * Dispatches a {@link streamSimple}-shaped request to an `omp auth-gateway`
- * via `POST /v1/pi/stream`, reads the SSE event stream back, and pushes the
- * parsed events into a local {@link AssistantMessageEventStream} — the same
- * stream type every other provider client produces. Callers downstream of
- * `streamSimple` cannot tell whether the events came from a real provider
- * SDK or from a gateway hop; they consume `AssistantMessageEvent`s either
- * way.
+ * via `POST /v1/pi/stream`, reads canonical assistant events plus pi-native
+ * prompt-progress frames from SSE, and pushes only the assistant events into
+ * a local {@link AssistantMessageEventStream}. Prompt progress is delivered
+ * through the caller's observer, so callers downstream of `streamSimple`
+ * retain the same assistant-event contract as every other provider client.
  *
  * Activated when a {@link Model} has `transport: "pi-native"` set; the
  * dispatch hook lives in `streamSimple()` (see `../stream.ts`). Used by
@@ -30,6 +29,7 @@ import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import { notifyProviderResponse } from "../utils/provider-response";
+import { isPiNativePromptProgressFrame } from "./pi-native-protocol";
 
 /**
  * Fields that must not cross the wire — either non-serializable (functions,
@@ -45,6 +45,7 @@ const NON_WIRE_KEYS = new Set<keyof SimpleStreamOptions>([
 	"onPayload",
 	"onResponse",
 	"onSseEvent",
+	"onPromptProgress",
 	"execHandlers",
 	"cursorExecHandlers",
 	"cursorOnToolResult",
@@ -53,9 +54,15 @@ const NON_WIRE_KEYS = new Set<keyof SimpleStreamOptions>([
 const PI_NATIVE_STREAM_IDLE_TIMEOUT_ERROR = "pi-native stream stalled while waiting for the next event";
 const PI_NATIVE_STREAM_FIRST_EVENT_TIMEOUT_ERROR = "pi-native stream timed out while waiting for the first event";
 
+function getPiNativeFrameType(event: unknown): unknown {
+	if (typeof event !== "object" || event === null || !("type" in event)) return undefined;
+	return event.type;
+}
+
 function isPiNativeProgressEvent(event: unknown): boolean {
-	if (typeof event !== "object" || event === null || !("type" in event)) return true;
-	return event.type !== "start";
+	const type = getPiNativeFrameType(event);
+	if (type === "prompt_progress") return isPiNativePromptProgressFrame(event);
+	return type !== "start";
 }
 
 function buildWireOptions(options: SimpleStreamOptions | undefined): Record<string, unknown> {
@@ -129,11 +136,12 @@ function buildHeaders(model: Model<Api>, apiKey: string | undefined): Record<str
  * Stream a turn through an `omp auth-gateway` over the pi-native protocol.
  *
  * The returned {@link AssistantMessageEventStream} receives each parsed
- * `AssistantMessageEvent` verbatim from the gateway; the terminal `done` /
- * `error` event resolves `.result()` automatically via the base class's
- * completion check. Non-streaming consumers just call `.result()` and pay
- * for SSE framing they don't use — that overhead is dominated by provider
- * latency, so we always stream rather than maintaining a parallel
+ * `AssistantMessageEvent` verbatim from the gateway; prompt-progress frames
+ * invoke `options.onPromptProgress` and are otherwise consumed here. The
+ * terminal `done` / `error` event resolves `.result()` automatically via the
+ * base class's completion check. Non-streaming consumers just call `.result()`
+ * and pay for SSE framing they don't use — that overhead is dominated by
+ * provider latency, so we always stream rather than maintaining a parallel
  * non-streaming path.
  */
 export function streamPiNative<TApi extends Api>(
@@ -202,10 +210,7 @@ export function streamPiNative<TApi extends Api>(
 
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
 			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
-			const source = readSseJson<AssistantMessageEvent>(
-				response.body as ReadableStream<Uint8Array>,
-				abortTracker.requestSignal,
-			);
+			const source = readSseJson<unknown>(response.body as ReadableStream<Uint8Array>, abortTracker.requestSignal);
 			const watchedSource = iterateWithIdleTimeout(source, {
 				idleTimeoutMs,
 				firstItemTimeoutMs: firstEventTimeoutMs,
@@ -218,7 +223,18 @@ export function streamPiNative<TApi extends Api>(
 				isProgressItem: isPiNativeProgressEvent,
 			});
 			let sawTerminal = false;
-			for await (const event of watchedSource) {
+			for await (const frame of watchedSource) {
+				if (getPiNativeFrameType(frame) === "prompt_progress") {
+					if (isPiNativePromptProgressFrame(frame)) {
+						try {
+							options?.onPromptProgress?.(frame.progress, model);
+						} catch {
+							// Progress observers are diagnostic/UI-only and cannot break generation.
+						}
+					}
+					continue;
+				}
+				const event = frame as AssistantMessageEvent;
 				if (event.type === "done" || event.type === "error") sawTerminal = true;
 				stream.push(event);
 				// `stream.push` resolves `.result()` on `done`/`error`; subsequent

--- a/packages/ai/src/providers/pi-native-client.ts
+++ b/packages/ai/src/providers/pi-native-client.ts
@@ -29,7 +29,7 @@ import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import { notifyProviderResponse } from "../utils/provider-response";
-import { isPiNativePromptProgressFrame } from "./pi-native-protocol";
+import { isPiNativePromptProgressFrame, PI_NATIVE_CLIENT_CAPABILITIES } from "./pi-native-protocol";
 
 /**
  * Fields that must not cross the wire — either non-serializable (functions,
@@ -185,6 +185,7 @@ export function streamPiNative<TApi extends Api>(
 				modelId: `${model.provider}/${model.id}`,
 				context,
 				options: buildWireOptions(options),
+				capabilities: PI_NATIVE_CLIENT_CAPABILITIES,
 				stream: true,
 			});
 

--- a/packages/ai/src/providers/pi-native-client.ts
+++ b/packages/ai/src/providers/pi-native-client.ts
@@ -28,6 +28,7 @@ import type {
 import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import { notifyPromptProgress } from "../utils/prompt-progress";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { isPiNativePromptProgressFrame, PI_NATIVE_CLIENT_CAPABILITIES } from "./pi-native-protocol";
 
@@ -227,11 +228,7 @@ export function streamPiNative<TApi extends Api>(
 			for await (const frame of watchedSource) {
 				if (getPiNativeFrameType(frame) === "prompt_progress") {
 					if (isPiNativePromptProgressFrame(frame)) {
-						try {
-							options?.onPromptProgress?.(frame.progress, model);
-						} catch {
-							// Progress observers are diagnostic/UI-only and cannot break generation.
-						}
+						notifyPromptProgress(options?.onPromptProgress, frame.progress, model);
 					}
 					continue;
 				}

--- a/packages/ai/src/providers/pi-native-protocol.ts
+++ b/packages/ai/src/providers/pi-native-protocol.ts
@@ -1,5 +1,15 @@
 import type { AssistantMessageEvent, PromptProgress } from "../types";
 
+/** Optional pi-native wire extensions understood by the requesting client. */
+export interface PiNativeClientCapabilities {
+	promptProgress?: true;
+}
+
+/** Extensions supported by this pi-native client build. */
+export const PI_NATIVE_CLIENT_CAPABILITIES = {
+	promptProgress: true,
+} as const satisfies PiNativeClientCapabilities;
+
 /** Prompt-processing progress carried beside canonical assistant events. */
 export interface PiNativePromptProgressFrame {
 	type: "prompt_progress";

--- a/packages/ai/src/providers/pi-native-protocol.ts
+++ b/packages/ai/src/providers/pi-native-protocol.ts
@@ -1,0 +1,89 @@
+import type { AssistantMessageEvent, PromptProgress } from "../types";
+
+/** Prompt-processing progress carried beside canonical assistant events. */
+export interface PiNativePromptProgressFrame {
+	type: "prompt_progress";
+	progress: PromptProgress;
+}
+
+/** Frames emitted by the pi-native gateway SSE endpoint. */
+export type PiNativeStreamFrame = AssistantMessageEvent | PiNativePromptProgressFrame;
+
+/** One-shot prompt-progress bridge owned by a pi-native gateway request. */
+export interface PiNativePromptProgressRelay {
+	emit(progress: PromptProgress): void;
+	subscribe(listener: (progress: PromptProgress) => void): () => void;
+	close(): void;
+}
+
+/**
+ * Bridge a provider callback to the SSE encoder without racing stream setup.
+ * Progress emitted before the encoder subscribes is buffered briefly; closing
+ * the request drops the buffer and makes later provider callbacks no-ops.
+ */
+export function createPiNativePromptProgressRelay(): PiNativePromptProgressRelay {
+	let closed = false;
+	let listener: ((progress: PromptProgress) => void) | undefined;
+	let pending: PromptProgress | undefined;
+
+	return {
+		emit(progress) {
+			if (closed) return;
+			if (!listener) {
+				// Progress is a cumulative snapshot, so only the newest value matters
+				// during the brief gap before the SSE encoder subscribes.
+				pending = progress;
+				return;
+			}
+			try {
+				listener(progress);
+			} catch {
+				// Progress is diagnostic/UI-only and cannot break generation.
+			}
+		},
+		subscribe(next) {
+			if (closed) return () => {};
+			listener = next;
+			if (pending) {
+				try {
+					next(pending);
+				} catch {
+					// Match live delivery: observer failures are isolated.
+				}
+			}
+			pending = undefined;
+			return () => {
+				if (listener === next) listener = undefined;
+			};
+		},
+		close() {
+			closed = true;
+			listener = undefined;
+			pending = undefined;
+		},
+	};
+}
+
+/** Validate a prompt-progress frame received across the gateway boundary. */
+export function isPiNativePromptProgressFrame(value: unknown): value is PiNativePromptProgressFrame {
+	if (!value || typeof value !== "object") return false;
+	const frame = value as Record<string, unknown>;
+	if (frame.type !== "prompt_progress" || !frame.progress || typeof frame.progress !== "object") return false;
+	const progress = frame.progress as Record<string, unknown>;
+	const total = progress.total;
+	const processed = progress.processed;
+	const cached = progress.cached;
+	return (
+		typeof total === "number" &&
+		Number.isFinite(total) &&
+		total > 0 &&
+		typeof processed === "number" &&
+		Number.isFinite(processed) &&
+		processed >= 0 &&
+		processed <= total &&
+		typeof cached === "number" &&
+		Number.isFinite(cached) &&
+		cached >= 0 &&
+		cached <= processed
+	);
+}

--- a/packages/ai/src/providers/pi-native-server.ts
+++ b/packages/ai/src/providers/pi-native-server.ts
@@ -10,18 +10,18 @@
  * translations impose on first-class pi-ai fields (service tier, cache
  * markers, thinking budgets, tool-choice variants, …).
  *
- * The streaming wire is {@link AssistantMessageEvent} serialized verbatim and
- * SSE-framed. Same type pi-ai already produces internally; the client feeds
- * each parsed event straight into `AssistantMessageEventStream.push()` with
- * no translation. Including `partial: AssistantMessage` on every delta is
- * O(N²) in turn length on the wire — acceptable for the loopback / sidecar
- * topology this transport is designed for; provider latency dominates the
- * actual cost.
+ * The streaming wire carries {@link AssistantMessageEvent}s serialized
+ * verbatim plus pi-native-only prompt-progress frames. The client consumes
+ * progress through its observer and feeds every assistant event straight into
+ * `AssistantMessageEventStream.push()` with no translation. Including
+ * `partial: AssistantMessage` on every delta is O(N²) in turn length on the
+ * wire — acceptable for the loopback / sidecar topology this transport is
+ * designed for; provider latency dominates the actual cost.
  *
  * Endpoint contract:
  *   POST /v1/pi/stream
  *   body:    { modelId, context, options?, stream? }   // `stream` defaults to true
- *   200 SSE: stream of `AssistantMessageEvent` (terminated by `data: [DONE]`)
+ *   200 SSE: assistant events plus prompt-progress frames (terminated by `data: [DONE]`)
  *   200 JSON (stream=false): { message: AssistantMessage }
  *   4xx/5xx: { error: { type, message } }
  */
@@ -29,6 +29,7 @@
 import type { AuthGatewayStreamControl } from "../auth-gateway/types";
 import * as AIError from "../error";
 import type { AssistantMessageEventStream, Context, SimpleStreamOptions } from "../types";
+import type { PiNativePromptProgressFrame, PiNativePromptProgressRelay } from "./pi-native-protocol";
 
 export interface PiNativeParsedRequest {
 	modelId: string;
@@ -157,8 +158,14 @@ export function parseRequest(body: unknown, _headers?: Headers): PiNativeParsedR
 const SSE_ENCODER = new TextEncoder();
 const SSE_DONE = SSE_ENCODER.encode("data: [DONE]\n\n");
 
+export interface PiNativeStreamControl extends AuthGatewayStreamControl {
+	/** Provider progress relay installed before `streamSimple` starts. */
+	promptProgress?: PiNativePromptProgressRelay;
+}
+
 /**
- * Ship every {@link AssistantMessageEvent} verbatim, SSE-framed.
+ * Ship every {@link AssistantMessageEvent} verbatim and interleave provider
+ * prompt-progress frames from the request relay.
  *
  * No per-event re-shaping: the pi-native client is pi-ai itself, so the
  * canonical event type IS the wire type. Including the rolling
@@ -173,7 +180,7 @@ export function encodeStream(
 	events: AssistantMessageEventStream,
 	_requestedModelId?: string,
 	_options?: SimpleStreamOptions,
-	control?: AuthGatewayStreamControl,
+	control?: PiNativeStreamControl,
 ): ReadableStream<Uint8Array> {
 	let cancelled = control?.signal?.aborted === true;
 	const markCancelled = () => {
@@ -182,11 +189,17 @@ export function encodeStream(
 	control?.signal?.addEventListener("abort", markCancelled, { once: true });
 	return new ReadableStream<Uint8Array>({
 		async start(controller) {
+			let unsubscribePromptProgress: (() => void) | undefined;
 			try {
 				if (cancelled) {
 					controller.close();
 					return;
 				}
+				unsubscribePromptProgress = control?.promptProgress?.subscribe(progress => {
+					if (cancelled) return;
+					const frame: PiNativePromptProgressFrame = { type: "prompt_progress", progress };
+					controller.enqueue(SSE_ENCODER.encode(`data: ${JSON.stringify(frame)}\n\n`));
+				});
 				for await (const event of events) {
 					if (cancelled) return;
 					controller.enqueue(SSE_ENCODER.encode(`data: ${JSON.stringify(event)}\n\n`));
@@ -212,11 +225,14 @@ export function encodeStream(
 					controller.close();
 				}
 			} finally {
+				unsubscribePromptProgress?.();
+				control?.promptProgress?.close();
 				control?.signal?.removeEventListener("abort", markCancelled);
 			}
 		},
 		cancel(reason) {
 			cancelled = true;
+			control?.promptProgress?.close();
 			control?.signal?.removeEventListener("abort", markCancelled);
 			control?.onCancel?.(reason);
 		},

--- a/packages/ai/src/providers/pi-native-server.ts
+++ b/packages/ai/src/providers/pi-native-server.ts
@@ -20,7 +20,7 @@
  *
  * Endpoint contract:
  *   POST /v1/pi/stream
- *   body:    { modelId, context, options?, stream? }   // `stream` defaults to true
+ *   body:    { modelId, context, options?, capabilities?, stream? }   // `stream` defaults to true
  *   200 SSE: assistant events plus prompt-progress frames (terminated by `data: [DONE]`)
  *   200 JSON (stream=false): { message: AssistantMessage }
  *   4xx/5xx: { error: { type, message } }
@@ -29,12 +29,17 @@
 import type { AuthGatewayStreamControl } from "../auth-gateway/types";
 import * as AIError from "../error";
 import type { AssistantMessageEventStream, Context, SimpleStreamOptions } from "../types";
-import type { PiNativePromptProgressFrame, PiNativePromptProgressRelay } from "./pi-native-protocol";
+import type {
+	PiNativeClientCapabilities,
+	PiNativePromptProgressFrame,
+	PiNativePromptProgressRelay,
+} from "./pi-native-protocol";
 
 export interface PiNativeParsedRequest {
 	modelId: string;
 	context: Context;
 	options: SimpleStreamOptions;
+	capabilities: PiNativeClientCapabilities;
 	stream: boolean;
 }
 /**
@@ -140,6 +145,13 @@ export function parseRequest(body: unknown, _headers?: Headers): PiNativeParsedR
 		}
 	}
 
+	const capabilities: PiNativeClientCapabilities = {};
+	const rawCapabilities = obj.capabilities;
+	if (typeof rawCapabilities === "object" && rawCapabilities !== null && !Array.isArray(rawCapabilities)) {
+		const capabilityBag = rawCapabilities as Record<string, unknown>;
+		if (capabilityBag.promptProgress === true) capabilities.promptProgress = true;
+	}
+
 	// `stream` defaults to true — pi-native clients overwhelmingly stream, and
 	// matching `streamProxy`'s implicit-stream behavior avoids a one-flag papercut.
 	const stream = typeof obj.stream === "boolean" ? obj.stream : true;
@@ -148,6 +160,7 @@ export function parseRequest(body: unknown, _headers?: Headers): PiNativeParsedR
 		modelId,
 		context: context as Context,
 		options,
+		capabilities,
 		stream,
 	};
 }

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1904,6 +1904,7 @@ function mapOptionsForApi<TApi extends Api>(
 		onPayload: options?.onPayload,
 		onResponse: options?.onResponse,
 		onSseEvent: options?.onSseEvent,
+		onPromptProgress: options?.onPromptProgress,
 		execHandlers: options?.execHandlers,
 		fetch: options?.fetch,
 		fallbacks: options?.fallbacks,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -529,6 +529,12 @@ export interface StreamOptions {
 	 */
 	onSseEvent?: (event: RawSseEvent, model?: Model<Api>) => void;
 	/**
+	 * Optional observer for provider-reported prompt processing progress.
+	 * Emitted only when the active provider advertises support.
+	 * Observer failures must not alter the provider stream.
+	 */
+	onPromptProgress?: (progress: PromptProgress, model?: Model<Api>) => void;
+	/**
 	 * Optional override for the first-event watchdog in milliseconds. Built-in
 	 * providers apply this budget twice when they can: once to the underlying
 	 * SDK/request while waiting for the HTTP stream object to exist, then again
@@ -588,6 +594,16 @@ export interface StreamOptions {
 
 	/** Cursor exec/MCP tool handlers (cursor-agent only). */
 	execHandlers?: CursorExecHandlers;
+}
+
+/** Normalized prompt processing counters reported by a streaming provider. */
+export interface PromptProgress {
+	/** Total prompt tokens reported for the current request. */
+	total: number;
+	/** Prompt tokens already processed, including tokens restored from cache. */
+	processed: number;
+	/** Prompt tokens restored from the provider's cache. */
+	cached: number;
 }
 
 // Unified options with reasoning passed to streamSimple() and completeSimple()

--- a/packages/ai/src/utils/prompt-progress.ts
+++ b/packages/ai/src/utils/prompt-progress.ts
@@ -1,0 +1,17 @@
+import { isPromise } from "node:util/types";
+import type { Api, Model, PromptProgress, StreamOptions } from "../types";
+
+/** Deliver diagnostic prompt progress without allowing observer failures to affect generation. */
+export function notifyPromptProgress(
+	observer: StreamOptions["onPromptProgress"] | undefined,
+	progress: PromptProgress,
+	model?: Model<Api>,
+): void {
+	if (!observer) return;
+	try {
+		const result = observer(progress, model) as unknown;
+		if (isPromise(result)) void result.catch(() => {});
+	} catch {
+		// Prompt-progress observers are diagnostic/UI-only.
+	}
+}

--- a/packages/ai/test/auth-gateway-pi-native.test.ts
+++ b/packages/ai/test/auth-gateway-pi-native.test.ts
@@ -6,6 +6,7 @@ import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
 import { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
 import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { createPiNativePromptProgressRelay } from "@oh-my-pi/pi-ai/providers/pi-native-protocol";
 import { encodeStream, formatError, parseRequest } from "@oh-my-pi/pi-ai/providers/pi-native-server";
 import type {
 	AssistantMessage,
@@ -273,7 +274,75 @@ describe("pi-native gateway cache controls", () => {
 		}
 	});
 });
+
+describe("pi-native gateway prompt progress", () => {
+	it("bridges provider prompt progress into the pi-native SSE stream", async () => {
+		registerMockApi();
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gw-pi-native-progress-"));
+		const storage = await AuthStorage.create(path.join(dir, "auth.db"));
+		storage.setRuntimeApiKey("openrouter", "test-key");
+		const mock = createMockModel({ provider: "openrouter", id: "pi-native-progress" });
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["test-token"],
+			storage,
+			resolveModel: () => mock,
+			version: "test",
+		});
+
+		try {
+			mock.push((_context, options) => {
+				options?.onPromptProgress?.({ total: 100, processed: 56, cached: 40 }, mock);
+				return { content: ["ok"] };
+			});
+			const response = await fetch(`${handle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: { Authorization: "Bearer test-token", "Content-Type": "application/json" },
+				body: JSON.stringify({ modelId: "pi-native-progress", context: baseContext }),
+			});
+
+			expect(response.status).toBe(200);
+			const frames = (await collectSse(response.body!)).map(parseSseLine);
+			expect(frames).toContainEqual({
+				type: "prompt_progress",
+				progress: { total: 100, processed: 56, cached: 40 },
+			});
+			expect(frames).toContainEqual(expect.objectContaining({ type: "done" }));
+		} finally {
+			await handle.close();
+			storage.close();
+			await fs.rm(dir, { recursive: true, force: true });
+			clearCustomApis();
+		}
+	});
+});
+
 describe("pi-native encodeStream", () => {
+	it("emits the latest progress snapshot buffered before the encoder attaches", async () => {
+		const final = baseAssistant();
+		const promptProgress = createPiNativePromptProgressRelay();
+		promptProgress.emit({ total: 100, processed: 20, cached: 0 });
+		promptProgress.emit({ total: 100, processed: 40, cached: 0 });
+
+		const chunks = await collectSse(
+			encodeStream(
+				makeEventStream([{ type: "done", reason: "stop", message: final }], final),
+				undefined,
+				undefined,
+				{
+					promptProgress,
+				},
+			),
+		);
+		const parsed = chunks.map(parseSseLine);
+
+		expect(parsed).toEqual([
+			{ type: "prompt_progress", progress: { total: 100, processed: 40, cached: 0 } },
+			{ type: "done", reason: "stop", message: JSON.parse(JSON.stringify(final)) },
+			"[DONE]",
+		]);
+	});
+
 	it("ships every AssistantMessageEvent verbatim, terminated by [DONE]", async () => {
 		// Pi-native is omp-talks-to-omp: the client feeds parsed events directly
 		// into `AssistantMessageEventStream.push()`, so the wire IS the canonical

--- a/packages/ai/test/auth-gateway-pi-native.test.ts
+++ b/packages/ai/test/auth-gateway-pi-native.test.ts
@@ -276,7 +276,7 @@ describe("pi-native gateway cache controls", () => {
 });
 
 describe("pi-native gateway prompt progress", () => {
-	it("bridges provider prompt progress into the pi-native SSE stream", async () => {
+	it("emits prompt progress only when the client advertises support", async () => {
 		registerMockApi();
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gw-pi-native-progress-"));
 		const storage = await AuthStorage.create(path.join(dir, "auth.db"));
@@ -292,13 +292,32 @@ describe("pi-native gateway prompt progress", () => {
 
 		try {
 			mock.push((_context, options) => {
+				options?.onPromptProgress?.({ total: 100, processed: 25, cached: 0 }, mock);
+				return { content: ["legacy"] };
+			});
+			const legacyResponse = await fetch(`${handle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: { Authorization: "Bearer test-token", "Content-Type": "application/json" },
+				body: JSON.stringify({ modelId: "pi-native-progress", context: baseContext }),
+			});
+
+			expect(legacyResponse.status).toBe(200);
+			const legacyFrames = (await collectSse(legacyResponse.body!)).map(parseSseLine);
+			expect(legacyFrames).not.toContainEqual(expect.objectContaining({ type: "prompt_progress" }));
+			expect(legacyFrames).toContainEqual(expect.objectContaining({ type: "done" }));
+
+			mock.push((_context, options) => {
 				options?.onPromptProgress?.({ total: 100, processed: 56, cached: 40 }, mock);
 				return { content: ["ok"] };
 			});
 			const response = await fetch(`${handle.url}/v1/pi/stream`, {
 				method: "POST",
 				headers: { Authorization: "Bearer test-token", "Content-Type": "application/json" },
-				body: JSON.stringify({ modelId: "pi-native-progress", context: baseContext }),
+				body: JSON.stringify({
+					modelId: "pi-native-progress",
+					context: baseContext,
+					capabilities: { promptProgress: true },
+				}),
 			});
 
 			expect(response.status).toBe(200);

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -9,6 +9,18 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { waitForDelayOrAbort } from "./helpers";
 
 const openAIResponsesModel = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+const llamaCppResponsesModel: Model<"openai-responses"> = buildModel({
+	id: "llama-local",
+	name: "llama-local",
+	api: "openai-responses",
+	provider: "llama.cpp",
+	baseUrl: "http://127.0.0.1:8080/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 8192,
+});
 const openAICompletionsModel = {
 	...(getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">),
 	api: "openai-completions",
@@ -113,7 +125,10 @@ function createSseResponse(events: unknown[]): Response {
 	});
 }
 
-function createNoProgressOpenAIResponsesStream(signal: AbortSignal | undefined): Response {
+function createNoProgressOpenAIResponsesStream(
+	signal: AbortSignal | undefined,
+	includePromptProgress = false,
+): Response {
 	const encoder = new TextEncoder();
 	let interval: NodeJS.Timeout | undefined;
 	let abortListener: (() => void) | undefined;
@@ -139,6 +154,7 @@ function createNoProgressOpenAIResponsesStream(signal: AbortSignal | undefined):
 					encode({
 						type: "response.in_progress",
 						response: { id: "resp_stalled", status: "in_progress" },
+						...(includePromptProgress ? { prompt_progress: { total: 100, cache: 40, processed: 56 } } : {}),
 					}),
 				);
 			}, 2);
@@ -179,8 +195,8 @@ function createDelayedFetch(
 	return mockFetch as typeof fetch;
 }
 
-function createOpenAIResponsesSuccessResponse(): Response {
-	return createSseResponse([
+function openAIResponsesSuccessEvents(): unknown[] {
+	return [
 		{ type: "response.created", response: { id: "resp_delayed" } },
 		{
 			type: "response.output_item.added",
@@ -211,7 +227,56 @@ function createOpenAIResponsesSuccessResponse(): Response {
 				},
 			},
 		},
-	]);
+	];
+}
+
+function createOpenAIResponsesSuccessResponse(): Response {
+	return createSseResponse(openAIResponsesSuccessEvents());
+}
+
+function createPromptProgressOpenAIResponsesStream(signal: AbortSignal | undefined): Response {
+	const encoder = new TextEncoder();
+	let interval: NodeJS.Timeout | undefined;
+	let abortListener: (() => void) | undefined;
+	const encode = (event: unknown): Uint8Array => encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encode(openAIResponsesSuccessEvents()[0]!));
+			let processed = 0;
+			interval = setInterval(() => {
+				processed += 1;
+				controller.enqueue(
+					encode({
+						type: "response.in_progress",
+						response: { id: "resp_delayed", status: "in_progress" },
+						prompt_progress: { total: 20, cache: 0, processed },
+					}),
+				);
+				if (processed < 20) return;
+				if (interval) clearInterval(interval);
+				for (const event of openAIResponsesSuccessEvents().slice(1)) {
+					controller.enqueue(encode(event));
+				}
+				controller.close();
+			}, 10);
+			abortListener = () => {
+				if (interval) clearInterval(interval);
+				if (abortListener) signal?.removeEventListener("abort", abortListener);
+				const reason = signal?.reason;
+				controller.error(reason instanceof Error ? reason : new Error("request aborted"));
+			};
+			if (signal?.aborted) queueMicrotask(() => abortListener?.());
+			else signal?.addEventListener("abort", abortListener, { once: true });
+		},
+		cancel() {
+			if (interval) clearInterval(interval);
+			if (abortListener) signal?.removeEventListener("abort", abortListener);
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
 }
 
 function createOpenAICompletionsSuccessResponse(modelId: string): Response {
@@ -452,27 +517,53 @@ describe("OpenAI-family first-event timeouts", () => {
 		}
 	});
 
-	it("times out OpenAI responses streams that only emit no-progress status events", async () => {
+	it("does not let llama.cpp prompt progress frames reset other providers' idle watchdog", async () => {
 		const fetchMock: FetchImpl = (input: string | URL | Request, init?: RequestInit) =>
-			Promise.resolve(createNoProgressOpenAIResponsesStream(getRequestSignal(input, init)));
+			Promise.resolve(createNoProgressOpenAIResponsesStream(getRequestSignal(input, init), true));
+		const controller = new AbortController();
+		const abortTimer = setTimeout(() => controller.abort(new Error("fallback abort")), 200);
+		abortTimer.unref();
 
-		const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+		try {
+			const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+				apiKey: "test-key",
+				signal: controller.signal,
+				streamFirstEventTimeoutMs: 1_000,
+				streamIdleTimeoutMs: 20,
+				fetch: fetchMock,
+			}).result();
+
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toBe("OpenAI responses stream stalled while waiting for the next event");
+			expect(JSON.parse(JSON.stringify(result.content))).toEqual([
+				{
+					type: "toolCall",
+					id: "call_stalled|fc_stalled",
+					name: "todo",
+					arguments: {},
+				},
+			]);
+		} finally {
+			clearTimeout(abortTimer);
+		}
+	});
+
+	it("keeps capability-gated llama.cpp streams alive during prompt processing", async () => {
+		const progress: number[] = [];
+		const fetchMock: FetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+			Promise.resolve(createPromptProgressOpenAIResponsesStream(getRequestSignal(input, init)));
+
+		const result = await streamOpenAIResponses(llamaCppResponsesModel, baseContext(), {
 			apiKey: "test-key",
 			streamFirstEventTimeoutMs: 1_000,
-			streamIdleTimeoutMs: 20,
+			streamIdleTimeoutMs: 50,
 			fetch: fetchMock,
+			onPromptProgress: update => progress.push(update.processed),
 		}).result();
 
-		expect(result.stopReason).toBe("error");
-		expect(result.errorMessage).toBe("OpenAI responses stream stalled while waiting for the next event");
-		expect(JSON.parse(JSON.stringify(result.content))).toEqual([
-			{
-				type: "toolCall",
-				id: "call_stalled|fc_stalled",
-				name: "todo",
-				arguments: {},
-			},
-		]);
+		expect(result.stopReason).toBe("stop");
+		expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
+		expect(progress).toEqual(Array.from({ length: 20 }, (_, index) => index + 1));
 	});
 
 	it("forwards streamSimple per-call timeout options to OpenAI-family providers", async () => {

--- a/packages/ai/test/openai-responses-prompt-progress.test.ts
+++ b/packages/ai/test/openai-responses-prompt-progress.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "bun:test";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+import type { Context, FetchImpl, Model, PromptProgress } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+const context: Context = {
+	systemPrompt: ["Test"],
+	messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
+};
+
+function makeModel(provider: string): Model<"openai-responses"> {
+	return buildModel({
+		api: "openai-responses",
+		provider,
+		id: "local-model",
+		name: "Local model",
+		baseUrl: "http://127.0.0.1:8080/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 1024,
+	} satisfies ModelSpec<"openai-responses">);
+}
+
+function responseEvents(progressEvents: unknown[]): unknown[] {
+	return [
+		{ type: "response.created", response: { id: "resp_1", status: "in_progress" } },
+		...progressEvents,
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		},
+		{ type: "response.output_text.delta", output_index: 0, item_id: "msg_1", delta: "pong" },
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "pong", annotations: [] }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_1",
+				status: "completed",
+				usage: { input_tokens: 8, output_tokens: 1, total_tokens: 9 },
+			},
+		},
+	];
+}
+
+function mockFetch(events: unknown[]): { fetch: FetchImpl; requests: Array<Record<string, unknown>> } {
+	const requests: Array<Record<string, unknown>> = [];
+	const fetch: FetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+		if (typeof init?.body === "string") requests.push(JSON.parse(init.body) as Record<string, unknown>);
+		const body = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join("");
+		return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+	});
+	return { fetch, requests };
+}
+
+async function run(
+	model: Model<"openai-responses">,
+	events: unknown[],
+): Promise<{ requests: Array<Record<string, unknown>>; progress: PromptProgress[] }> {
+	const transport = mockFetch(events);
+	const progress: PromptProgress[] = [];
+	await streamSimple(model, context, {
+		apiKey: "test",
+		fetch: transport.fetch,
+		onPromptProgress: update => progress.push(update),
+	}).result();
+	return { requests: transport.requests, progress };
+}
+
+describe("llama.cpp Responses prompt progress", () => {
+	it("requests and emits normalized progress for the llama.cpp provider", async () => {
+		const result = await run(
+			makeModel("llama.cpp"),
+			responseEvents([
+				{
+					type: "response.in_progress",
+					response: { id: "resp_1", status: "in_progress" },
+					prompt_progress: { total: 100, cache: 40, processed: 56, time_ms: 12.5 },
+				},
+			]),
+		);
+
+		expect(result.requests).toHaveLength(1);
+		expect(result.requests[0]?.return_progress).toBe(true);
+		expect(result.progress).toEqual([{ total: 100, cached: 40, processed: 56 }]);
+	});
+
+	it("does not request or expose the llama.cpp extension for other providers", async () => {
+		const result = await run(
+			makeModel("openai"),
+			responseEvents([
+				{
+					type: "response.in_progress",
+					response: { id: "resp_1", status: "in_progress" },
+					prompt_progress: { total: 100, cache: 40, processed: 56, time_ms: 12.5 },
+				},
+			]),
+		);
+
+		expect(result.requests[0]).not.toHaveProperty("return_progress");
+		expect(result.progress).toEqual([]);
+	});
+
+	it("ignores missing or malformed progress while the response continues normally", async () => {
+		const result = await run(
+			makeModel("llama.cpp"),
+			responseEvents([
+				{ type: "response.in_progress", response: { id: "resp_1", status: "in_progress" } },
+				{
+					type: "response.in_progress",
+					response: { id: "resp_1", status: "in_progress" },
+					prompt_progress: { total: 100, cache: 60, processed: 50 },
+				},
+			]),
+		);
+
+		expect(result.progress).toEqual([]);
+	});
+});

--- a/packages/ai/test/openai-responses-prompt-progress.test.ts
+++ b/packages/ai/test/openai-responses-prompt-progress.test.ts
@@ -129,4 +129,27 @@ describe("llama.cpp Responses prompt progress", () => {
 
 		expect(result.progress).toEqual([]);
 	});
+
+	it("isolates rejected async progress observers from generation", async () => {
+		const transport = mockFetch(
+			responseEvents([
+				{
+					type: "response.in_progress",
+					response: { id: "resp_1", status: "in_progress" },
+					prompt_progress: { total: 100, cache: 40, processed: 56 },
+				},
+			]),
+		);
+
+		const result = await streamSimple(makeModel("llama.cpp"), context, {
+			apiKey: "test",
+			fetch: transport.fetch,
+			onPromptProgress: async () => {
+				throw new Error("observer failed");
+			},
+		}).result();
+		await Bun.sleep(0);
+
+		expect(result.content).toContainEqual(expect.objectContaining({ type: "text", text: "pong" }));
+	});
 });

--- a/packages/ai/test/pi-native-client.test.ts
+++ b/packages/ai/test/pi-native-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, type Mock, mock, spyOn } from "bun:test";
 import { streamPiNative } from "@oh-my-pi/pi-ai/providers/pi-native-client";
+import type { PiNativeStreamFrame } from "@oh-my-pi/pi-ai/providers/pi-native-protocol";
 import type {
 	AssistantMessage,
 	AssistantMessageEvent,
@@ -11,7 +12,7 @@ import type {
 } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
-function sseBytes(events: AssistantMessageEvent[]): Uint8Array {
+function sseBytes(events: PiNativeStreamFrame[]): Uint8Array {
 	const encoder = new TextEncoder();
 	const parts: Uint8Array[] = [];
 	for (const event of events) {
@@ -27,7 +28,7 @@ function sseBytes(events: AssistantMessageEvent[]): Uint8Array {
 	}
 	return out;
 }
-function sseEventBytes(event: AssistantMessageEvent): Uint8Array {
+function sseEventBytes(event: PiNativeStreamFrame): Uint8Array {
 	return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
 }
 
@@ -86,7 +87,7 @@ function delayedBody(chunks: Array<{ atMs: number; bytes: Uint8Array }>): Readab
 	});
 }
 
-function fakeResponse(events: AssistantMessageEvent[], init: ResponseInit = {}): Response {
+function fakeResponse(events: PiNativeStreamFrame[], init: ResponseInit = {}): Response {
 	return new Response(fakeBody(sseBytes(events)), {
 		status: 200,
 		headers: { "Content-Type": "text/event-stream" },
@@ -209,6 +210,7 @@ describe("streamPiNative request shape", () => {
 				responseMetadata = response;
 			},
 			onSseEvent: () => undefined,
+			onPromptProgress: () => undefined,
 			providerSessionState: new Map(),
 			maxTokens: 1024,
 		});
@@ -221,6 +223,7 @@ describe("streamPiNative request shape", () => {
 		expect("onPayload" in body.options).toBe(false);
 		expect("onResponse" in body.options).toBe(false);
 		expect("onSseEvent" in body.options).toBe(false);
+		expect("onPromptProgress" in body.options).toBe(false);
 		expect("providerSessionState" in body.options).toBe(false);
 		// And the legitimate options survive
 		expect(body.options.maxTokens).toBe(1024);
@@ -300,6 +303,92 @@ describe("streamPiNative event flow", () => {
 		const result = await stream.result();
 
 		expect(seen).toEqual(events);
+		expect(result).toEqual(final);
+	});
+
+	it("forwards prompt progress to the local observer without emitting an assistant event", async () => {
+		const final = baseAssistant({ content: [{ type: "text", text: "done" }] });
+		const start = { type: "start", partial: baseAssistant() } satisfies AssistantMessageEvent;
+		const done = { type: "done", reason: "stop", message: final } satisfies AssistantMessageEvent;
+		const progress = { total: 100, processed: 56, cached: 40 };
+		const fetchImpl: FetchImpl = (async () =>
+			fakeResponse([start, { type: "prompt_progress", progress }, done])) as FetchImpl;
+		const observed: (typeof progress)[] = [];
+
+		const stream = streamPiNative(fakeModel(), baseContext, {
+			apiKey: "k",
+			fetch: fetchImpl,
+			onPromptProgress: update => observed.push(update),
+		});
+		const seen = await collectEvents(stream);
+
+		expect(observed).toEqual([progress]);
+		expect(seen).toEqual([start, done]);
+		expect(await stream.result()).toEqual(final);
+	});
+
+	it("keeps the first-event watchdog alive with pi-native prompt-progress frames", async () => {
+		const final = baseAssistant({ content: [{ type: "text", text: "done" }] });
+		const chunks = [
+			{ atMs: 0, bytes: sseEventBytes({ type: "start", partial: baseAssistant() }) },
+			{
+				atMs: 15,
+				bytes: sseEventBytes({
+					type: "prompt_progress",
+					progress: { total: 100, processed: 20, cached: 0 },
+				}),
+			},
+			{
+				atMs: 35,
+				bytes: sseEventBytes({
+					type: "prompt_progress",
+					progress: { total: 100, processed: 40, cached: 0 },
+				}),
+			},
+			{
+				atMs: 55,
+				bytes: sseEventBytes({
+					type: "prompt_progress",
+					progress: { total: 100, processed: 60, cached: 0 },
+				}),
+			},
+			{ atMs: 75, bytes: sseEventBytes({ type: "done", reason: "stop", message: final }) },
+		];
+		const fetchImpl: FetchImpl = (async () =>
+			new Response(delayedBody(chunks), {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			})) as FetchImpl;
+		const observed: number[] = [];
+
+		const result = await streamPiNative(fakeModel(), baseContext, {
+			apiKey: "k",
+			fetch: fetchImpl,
+			streamFirstEventTimeoutMs: 25,
+			streamIdleTimeoutMs: 25,
+			onPromptProgress: progress => observed.push(progress.processed),
+		}).result();
+
+		expect(result).toEqual(final);
+		expect(observed).toEqual([20, 40, 60]);
+	});
+
+	it("isolates pi-native prompt-progress observer failures from generation", async () => {
+		const final = baseAssistant({ content: [{ type: "text", text: "done" }] });
+		const fetchImpl: FetchImpl = (async () =>
+			fakeResponse([
+				{ type: "prompt_progress", progress: { total: 100, processed: 56, cached: 40 } },
+				{ type: "done", reason: "stop", message: final },
+			])) as FetchImpl;
+
+		const result = await streamPiNative(fakeModel(), baseContext, {
+			apiKey: "k",
+			fetch: fetchImpl,
+			onPromptProgress: () => {
+				throw new Error("observer failed");
+			},
+		}).result();
+
 		expect(result).toEqual(final);
 	});
 

--- a/packages/ai/test/pi-native-client.test.ts
+++ b/packages/ai/test/pi-native-client.test.ts
@@ -149,7 +149,7 @@ afterEach(() => {
 });
 
 describe("streamPiNative request shape", () => {
-	it("POSTs `{modelId, context, options, stream:true}` to `<baseUrl>/v1/pi/stream`", async () => {
+	it("POSTs the prompt-progress capability with the canonical request", async () => {
 		const final = baseAssistant();
 		const captured: { url?: string; init?: RequestInit } = {};
 		const fetchImpl: FetchImpl = (async (input, init) => {
@@ -177,6 +177,7 @@ describe("streamPiNative request shape", () => {
 		// registry keys on `${provider}/${id}` first (see auth-gateway-cli runServe).
 		expect(body.modelId).toBe("anthropic/claude-sonnet-4-5");
 		expect(body.context).toEqual(baseContext);
+		expect(body.capabilities).toEqual({ promptProgress: true });
 		expect(body.stream).toBe(true);
 		expect(body.options.temperature).toBe(0.7);
 	});

--- a/packages/ai/test/pi-native-client.test.ts
+++ b/packages/ai/test/pi-native-client.test.ts
@@ -393,6 +393,26 @@ describe("streamPiNative event flow", () => {
 		expect(result).toEqual(final);
 	});
 
+	it("isolates rejected async pi-native prompt-progress observers from generation", async () => {
+		const final = baseAssistant({ content: [{ type: "text", text: "done" }] });
+		const fetchImpl: FetchImpl = (async () =>
+			fakeResponse([
+				{ type: "prompt_progress", progress: { total: 100, processed: 56, cached: 40 } },
+				{ type: "done", reason: "stop", message: final },
+			])) as FetchImpl;
+
+		const result = await streamPiNative(fakeModel(), baseContext, {
+			apiKey: "k",
+			fetch: fetchImpl,
+			onPromptProgress: async () => {
+				throw new Error("observer failed");
+			},
+		}).result();
+		await Bun.sleep(0);
+
+		expect(result).toEqual(final);
+	});
+
 	it("classifies non-2xx responses into Errors with status + type tags", async () => {
 		const fetchImpl: FetchImpl = (async () =>
 			new Response(JSON.stringify({ error: { type: "authentication_error", message: "no credential" } }), {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+- Added Responses compatibility metadata for llama.cpp prompt processing progress, including custom providers discovered through the llama.cpp protocol.
+
 ### Fixed
 
 - Raised the GPT-5.6 Sol/Terra/Luna context window on the Codex transport (openai-codex) from 372K to 1M tokens: OpenAI enabled the 1M window for subscription Codex on 2026-08-16, but the Codex model registry still reports the stale 272,000, so discovery now floors these SKUs at 1,000,000 instead of trusting the reported value ([openai/codex#38917](https://github.com/openai/codex/issues/38917)).

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -713,6 +713,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		// other reasoners (grok-build, grok-code-fast-1, …) 400 if it is sent.
 		supportsReasoningEffort: !isXaiHost || isGrokReasoningEffortCapable(id),
 		supportsLongPromptCacheRetention: isOpenAIUrl,
+		supportsPromptProgress: spec.provider === "llama.cpp",
 		supportsPromptCacheBreakpoints,
 		promptCacheBreakpointTtl: supportsPromptCacheBreakpoints ? "30m" : undefined,
 		// Azure OpenAI and GitHub Copilot Responses paths require tool results
@@ -815,6 +816,7 @@ type ResponsesOnlyCompat = Omit<ResolvedOpenAIResponsesCompat, keyof ResolvedOpe
 function pickResponsesOnly(compat: ResolvedOpenAIResponsesCompat): ResponsesOnlyCompat {
 	return {
 		supportsLongPromptCacheRetention: compat.supportsLongPromptCacheRetention,
+		supportsPromptProgress: compat.supportsPromptProgress,
 		strictResponsesPairing: compat.strictResponsesPairing,
 		supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
 		supportsObfuscationOptOut: compat.supportsObfuscationOptOut,

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -350,6 +350,12 @@ export interface OpenAICompat {
 	streamIdleTimeoutMs?: number;
 	/** Whether the host honors `prompt_cache_retention: "24h"` on the Responses API. Default: auto-detected (api.openai.com). */
 	supportsLongPromptCacheRetention?: boolean;
+	/**
+	 * Whether the Responses endpoint accepts llama.cpp's `return_progress`
+	 * request field and emits `prompt_progress` on `response.in_progress` events.
+	 * Default: enabled only for the llama.cpp provider.
+	 */
+	supportsPromptProgress?: boolean;
 	/** Whether tool schemas must be sent either all strict or all non-strict. Undefined keeps the existing per-tool mixed behavior. */
 	toolStrictMode?: "all_strict" | "none";
 	/** Whether request shaping may send reasoning params at all. Default: auto-detected (disabled for GitHub Copilot chat-completions). */
@@ -686,6 +692,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "isOpenRouterHost"
 			| "supportsStrictMode"
 			| "supportsLongPromptCacheRetention"
+			| "supportsPromptProgress"
 			| "alwaysSendMaxTokens"
 			| "wireModelIdMode"
 			| "vercelGatewayRouting"
@@ -717,6 +724,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 /** Fully-resolved Responses-API compat view (same contract as `ResolvedOpenAICompat`). */
 export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompat {
 	supportsLongPromptCacheRetention: boolean;
+	supportsPromptProgress: boolean;
 	strictResponsesPairing: boolean;
 	supportsImageDetailOriginal: boolean;
 	supportsObfuscationOptOut: boolean;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added live llama.cpp prompt processing percentages to the interactive `Working` indicator, with automatic fallback when the server does not report progress.
 - Added `ExtensionAPI.registerFileWriteFallback(handler)` and `ExtensionAPI.registerFileDeleteFallback(handler)`, letting an extension supply a fallback writer or deleter that is consulted when a native `write`, `edit`, or `apply_patch` byte-write or unlink is denied with a permission error (`EPERM`/`EACCES`/`EROFS`) — for hosts that embed the agent inside a sandbox that denies direct filesystem access but exposes a privileged channel. The brokered path is symlink-resolved so a handler's allowlist sees the real destination, a destination that cannot be resolved is not brokered at all, and `req.sessionId` names the session that issued the mutation so a handler sharing the process-wide registry can enforce policy per session. See [`docs/extensions.md`](../../docs/extensions.md).
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Added live llama.cpp prompt processing percentages to the interactive `Working` indicator, with automatic fallback when the server does not report progress.
+- Added live llama.cpp prompt processing percentages to the interactive `Working` indicator, with automatic fallback when the server does not support progress fields.
 - Added `ExtensionAPI.registerFileWriteFallback(handler)` and `ExtensionAPI.registerFileDeleteFallback(handler)`, letting an extension supply a fallback writer or deleter that is consulted when a native `write`, `edit`, or `apply_patch` byte-write or unlink is denied with a permission error (`EPERM`/`EACCES`/`EROFS`) — for hosts that embed the agent inside a sandbox that denies direct filesystem access but exposes a privileged channel. The brokered path is symlink-resolved so a handler's allowlist sees the real destination, a destination that cannot be resolved is not brokered at all, and `req.sessionId` names the session that issued the mutation so a handler sharing the process-wide registry can enforce policy per session. See [`docs/extensions.md`](../../docs/extensions.md).
 ### Fixed
 

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -66,6 +66,7 @@ const WIRE_AGENT_EVENT_TYPES: Record<WireAgentEvent["type"], true> = {
 	agent_end: true,
 	turn_start: true,
 	turn_end: true,
+	prompt_progress: true,
 	message_start: true,
 	message_update: true,
 	message_end: true,

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -37,6 +37,13 @@ import type { ProviderDiscovery } from "./models-config-schema";
 export const DISCOVERY_DEFAULT_CONTEXT_WINDOW = OPENAI_COMPAT_DISCOVERY_DEFAULT_CONTEXT_WINDOW;
 export const DISCOVERY_DEFAULT_MAX_TOKENS = OPENAI_COMPAT_DISCOVERY_DEFAULT_MAX_TOKENS;
 
+const LLAMA_CPP_DISCOVERY_COMPAT = { supportsPromptProgress: true } satisfies OpenAICompat;
+
+/** Compatibility defaults implied by a configured discovery protocol. */
+export function getDiscoveryCompatDefaults(discovery: ProviderDiscovery | undefined): OpenAICompat | undefined {
+	return discovery?.type === "llama.cpp" ? LLAMA_CPP_DISCOVERY_COMPAT : undefined;
+}
+
 /**
  * Run `fn` with a hard deadline while also signalling cooperative transports
  * to abort. The independent rejection keeps discovery bounded when a runtime
@@ -657,6 +664,7 @@ export async function discoverLlamaCppModels(
 						supportsStore: false,
 						supportsDeveloperRole: false,
 						supportsReasoningEffort: false,
+						...LLAMA_CPP_DISCOVERY_COMPAT,
 					},
 				} as ModelSpec<Api>),
 			),

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -62,6 +62,7 @@ import {
 	discoverLlamaCppModelRuntimeMetadata,
 	discoverModelsByProviderType,
 	ensureLlamaCppV1BaseUrl,
+	getDiscoveryCompatDefaults,
 	getImplicitOllamaBaseUrl,
 	getOllamaContextLengthOverride,
 	normalizeLiteLLMDiscoveryBaseUrl,
@@ -124,6 +125,15 @@ interface CustomModelsResult {
 	configuredProviders?: Set<string>;
 	error?: ConfigError;
 	found: boolean;
+}
+
+function resolveProviderCompat(
+	compat: ModelSpec<Api>["compat"] | undefined,
+	discovery: DiscoveryProviderConfig["discovery"] | undefined,
+	disableStrictTools: boolean | undefined,
+): ModelSpec<Api>["compat"] | undefined {
+	const resolvedCompat = mergeCompat(getDiscoveryCompatDefaults(discovery), compat);
+	return disableStrictTools ? mergeCompat(resolvedCompat, { disableStrictTools: true }) : resolvedCompat;
 }
 
 /**
@@ -940,6 +950,11 @@ export class ModelRegistry {
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
+			const providerCompat = resolveProviderCompat(
+				providerConfig.compat,
+				providerConfig.discovery,
+				providerConfig.disableStrictTools,
+			);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
 			if (
 				providerConfig.baseUrl ||
@@ -951,7 +966,6 @@ export class ModelRegistry {
 				providerConfig.remoteCompaction ||
 				providerConfig.transport
 			) {
-				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
 					baseUrl:
 						providerConfig.discovery?.type === "litellm"
@@ -960,7 +974,7 @@ export class ModelRegistry {
 					headers: resolvedProviderHeaders,
 					apiKey: providerConfig.apiKey,
 					authHeader: providerConfig.authHeader,
-					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
+					compat: providerCompat,
 					remoteCompaction: providerConfig.remoteCompaction,
 					transport: providerConfig.transport,
 				});
@@ -972,7 +986,6 @@ export class ModelRegistry {
 			}
 
 			if (providerConfig.discovery && (providerConfig.api || providerConfig.discovery.type === "proxy")) {
-				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				discoverableProviders.push({
 					provider: providerName,
 					// Proxy discovery derives per-model api from /v1/models's
@@ -981,7 +994,7 @@ export class ModelRegistry {
 					api: (providerConfig.api ?? "openai-completions") as Api,
 					baseUrl: providerConfig.baseUrl,
 					headers: resolvedProviderHeaders,
-					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
+					compat: providerCompat,
 					remoteCompaction: providerConfig.remoteCompaction,
 					discovery: providerConfig.discovery,
 					optional: false,
@@ -1582,13 +1595,15 @@ export class ModelRegistry {
 			const modelDefs = providerConfig.models ?? [];
 			if (modelDefs.length === 0) continue; // Override-only, no custom models
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
+			const providerCompat = resolveProviderCompat(
+				providerConfig.compat,
+				providerConfig.discovery,
+				providerConfig.disableStrictTools,
+			);
 			if (providerConfig.apiKey) {
 				this.#installProviderApiKey(providerName, providerConfig.apiKey);
 			}
 			for (const modelDef of modelDefs) {
-				const providerCompat = providerConfig.disableStrictTools
-					? mergeCompat(providerConfig.compat, { disableStrictTools: true })
-					: providerConfig.compat;
 				const model = buildCustomModelOverlay(
 					providerName,
 					providerConfig.baseUrl!,

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -50,6 +50,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 		"toolStrictMode?": '"all_strict" | "none"',
 		"streamIdleTimeoutMs?": "number >= 0",
 		"supportsLongPromptCacheRetention?": "boolean",
+		"supportsPromptProgress?": "boolean",
 		"supportsReasoningParams?": "boolean",
 		"alwaysSendMaxTokens?": "boolean",
 		"strictResponsesPairing?": "boolean",

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1196,6 +1196,7 @@ export class EventController {
 	}
 
 	async #handlePromptProgress(event: Extract<AgentSessionEvent, { type: "prompt_progress" }>): Promise<void> {
+		if (this.ctx.session.isAborting) return;
 		const percent = Math.floor((event.progress.processed / event.progress.total) * 100);
 		if (percent === this.#promptProgressPercent) return;
 		this.#promptProgressPercent = percent;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -180,6 +180,7 @@ export class EventController {
 	#prevHideThinking = false;
 	#handlers: AgentSessionEventHandlers;
 	#terminalProgressActive = false;
+	#promptProgressPercent: number | undefined = undefined;
 	// Coalescing window for `message_update` events at the subscription boundary.
 	// `message_update` carries the CUMULATIVE assistant message (every update
 	// re-lists all content blocks), so when a burst of deltas arrives faster than
@@ -235,6 +236,7 @@ export class EventController {
 			agent_end: e => this.#handleAgentEnd(e),
 			turn_start: async () => {},
 			turn_end: async e => this.#handleTurnEnd(e),
+			prompt_progress: e => this.#handlePromptProgress(e),
 			message_start: e => this.#handleMessageStart(e),
 			message_update: e => this.#handleMessageUpdate(e),
 			message_end: e => this.#handleMessageEnd(e),
@@ -734,6 +736,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.#promptProgressPercent = undefined;
 		this.#clearApprovalPreviewGates();
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
@@ -1019,6 +1022,10 @@ export class EventController {
 	}
 
 	async #handleMessageUpdate(event: Extract<AgentSessionEvent, { type: "message_update" }>): Promise<void> {
+		if (this.#promptProgressPercent !== undefined) {
+			this.#promptProgressPercent = undefined;
+			this.ctx.setWorkingMessage();
+		}
 		this.#ensureWorkingLoaderWhileStreaming();
 		if (!this.#vocalizedMessageUpdates.delete(event)) {
 			this.#vocalizeDelta(event);
@@ -1186,6 +1193,14 @@ export class EventController {
 
 			this.ctx.ui.requestRender();
 		}
+	}
+
+	async #handlePromptProgress(event: Extract<AgentSessionEvent, { type: "prompt_progress" }>): Promise<void> {
+		const percent = Math.floor((event.progress.processed / event.progress.total) * 100);
+		if (percent === this.#promptProgressPercent) return;
+		this.#promptProgressPercent = percent;
+		this.ctx.setWorkingMessage(`Working (${percent}%)${interruptHint()}`);
+		this.ctx.ui.requestRender();
 	}
 
 	async #handleMessageEnd(event: Extract<AgentSessionEvent, { type: "message_end" }>): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -108,6 +108,7 @@ const agentEventTypes = new Set<AgentEvent["type"]>([
 	"agent_end",
 	"turn_start",
 	"turn_end",
+	"prompt_progress",
 	"message_start",
 	"message_update",
 	"message_end",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2084,8 +2084,26 @@ export class AgentSession {
 	 * turn-ending error render entirely.
 	 */
 	#subscriberEmitGate: Promise<void> = Promise.resolve();
+	/**
+	 * Source-order generation for prompt processing. Subscriber delivery can lag
+	 * behind agent-core while an extension handler is awaited, so the generation
+	 * lets a delayed prompt-progress event detect that output or a newer turn has
+	 * already overtaken it.
+	 */
+	#promptProgressGeneration = 0;
+	#assistantOutputGeneration: number | undefined;
 
 	async #emitSessionEvent(event: AgentSessionEvent, options: { detachExtensions?: boolean } = {}): Promise<void> {
+		// Record prompt/output ordering before the first await. `message_update`
+		// bypasses the subscriber gate for responsive streaming, while prompt
+		// progress waits behind extension handlers; this source-order state prevents
+		// delayed progress from restoring the loader after output has arrived.
+		if (event.type === "agent_start" || event.type === "turn_start") {
+			this.#promptProgressGeneration++;
+		} else if (event.type === "message_update") {
+			this.#assistantOutputGeneration = this.#promptProgressGeneration;
+		}
+		const promptProgressGeneration = this.#promptProgressGeneration;
 		if (event.type === "message_update") {
 			this.#emit(event);
 			void this.#queueExtensionEvent(event);
@@ -2120,6 +2138,13 @@ export class AgentSession {
 			// care about the final settle.
 			if (event.type === "agent_end" && this.#promptInFlightCount > 0) {
 				this.#pendingAgentEndEmit = event;
+				return;
+			}
+			if (
+				event.type === "prompt_progress" &&
+				(promptProgressGeneration !== this.#promptProgressGeneration ||
+					promptProgressGeneration === this.#assistantOutputGeneration)
+			) {
 				return;
 			}
 			this.#emit(event);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -135,6 +135,7 @@ const agentEventTypes = new Set<AgentEvent["type"]>([
 	"agent_end",
 	"turn_start",
 	"turn_end",
+	"prompt_progress",
 	"message_start",
 	"message_update",
 	"message_end",

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -846,6 +846,72 @@ describe("AgentSession message pipeline", () => {
 		await Bun.sleep(0);
 	});
 
+	it("drops prompt progress overtaken by output without suppressing the next turn", async () => {
+		const turnStartBlocked = Promise.withResolvers<void>();
+		const extensionEmit = vi.fn(async (event: { type: string }) => {
+			if (event.type === "turn_start") await turnStartBlocked.promise;
+		});
+		const session = new AgentSession({
+			agent: createAgent(),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: {} as never,
+			extensionRunner: {
+				hasHandlers: () => true,
+				emit: extensionEmit,
+			} as never,
+		});
+		sessions.push(session);
+
+		const events: AgentSessionEvent[] = [];
+		const firstTurnEnd = Promise.withResolvers<void>();
+		const nextTurnProgress = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			events.push(event);
+			if (event.type === "turn_end") firstTurnEnd.resolve();
+			if (event.type === "prompt_progress") nextTurnProgress.resolve();
+		});
+
+		const assistantMessage = createAssistantMessage("output");
+		session.agent.emitExternalEvent({ type: "turn_start" });
+		session.agent.emitExternalEvent({
+			type: "prompt_progress",
+			progress: { total: 100, processed: 50, cached: 0 },
+		});
+		session.agent.emitExternalEvent({
+			type: "message_update",
+			message: assistantMessage,
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "output",
+				partial: assistantMessage,
+			},
+		});
+		session.agent.emitExternalEvent({ type: "turn_end", message: assistantMessage, toolResults: [] });
+
+		try {
+			await Bun.sleep(0);
+			expect(events.some(event => event.type === "message_update")).toBe(true);
+			expect(events.some(event => event.type === "prompt_progress")).toBe(false);
+		} finally {
+			turnStartBlocked.resolve();
+		}
+		await firstTurnEnd.promise;
+		expect(events.some(event => event.type === "prompt_progress")).toBe(false);
+
+		session.agent.emitExternalEvent({ type: "turn_start" });
+		session.agent.emitExternalEvent({
+			type: "prompt_progress",
+			progress: { total: 100, processed: 25, cached: 0 },
+		});
+		await nextTurnProgress.promise;
+		expect(events.at(-1)).toEqual({
+			type: "prompt_progress",
+			progress: { total: 100, processed: 25, cached: 0 },
+		});
+	});
+
 	it("keeps first-turn memory in the stable prompt on the next turn", async () => {
 		const api = "test-injected-memory-append-only-cache";
 		const contexts: Context[] = [];

--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
@@ -431,15 +431,15 @@ describe("collab TUI guest ui-request handling (#4049)", () => {
 	});
 });
 
-// ── Proto handshake (#4049: ui-request frames require COLLAB_PROTO >= 3) ───
+// ── Proto handshake ─────────────────────────────────────────────────────────
 //
-// The ui-request/ui-response grammar shipped without a proto bump, so v2
-// guests joined fine and silently dropped host asks. These tests pin the
-// enforcement: a real CollabHost must reject stale-proto hellos with an
+// Incompatible frame and event additions require stale guests to be rejected
+// before live traffic reaches code that cannot dispatch it. These tests pin
+// the enforcement: a real CollabHost must reject stale-proto hellos with an
 // observable error frame (never a welcome), current-proto guests must still
-// complete a full ui-request round trip, and a rejected CollabGuestLink
-// join must fail fast with the host's reason instead of hanging until the
-// welcome timeout.
+// complete a full ui-request round trip, and a rejected CollabGuestLink join
+// must fail fast with the host's reason instead of hanging until the welcome
+// timeout.
 
 /** Minimal InteractiveModeContext double: only the members CollabHost touches. */
 function makeHostContext(): InteractiveModeContext {
@@ -518,17 +518,17 @@ async function joinRawGuest(
 	return { socket, nextFrame };
 }
 
-describe("collab proto handshake (#4049)", () => {
-	it("host rejects a stale-proto hello with a protocol-mismatch error and never welcomes or admits the guest", async () => {
+describe("collab proto handshake", () => {
+	it("host rejects a v3 guest before forwarding unsupported prompt-progress events", async () => {
 		const host = new CollabHost(makeHostContext());
 		await host.start("ws://localhost:8787");
-		const guest = await joinRawGuest(host.link, COLLAB_PROTO - 1);
+		const guest = await joinRawGuest(host.link, 3);
 		try {
 			const reply = await guest.nextFrame();
 			if (reply.t !== "error") throw new Error(`expected error, got ${reply.t}`);
 			expect(reply.message).toContain("protocol mismatch");
 			expect(reply.message).toContain(`host speaks v${COLLAB_PROTO}`);
-			expect(reply.message).toContain(`guest sent v${COLLAB_PROTO - 1}`);
+			expect(reply.message).toContain("guest sent v3");
 			// The rejected guest was never admitted: no participant entry, and a
 			// host ask finds no writable peer to route to.
 			expect(host.participants.filter(p => p.role !== "host")).toEqual([]);
@@ -539,14 +539,14 @@ describe("collab proto handshake (#4049)", () => {
 		}
 	});
 
-	it("welcomes a current-proto guest at v3 and round-trips a ui-request", async () => {
+	it("welcomes a current-proto guest at v4 and round-trips a ui-request", async () => {
 		const host = new CollabHost(makeHostContext());
 		await host.start("ws://localhost:8787");
 		const guest = await joinRawGuest(host.link, COLLAB_PROTO);
 		try {
 			const welcome = await guest.nextFrame();
 			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
-			expect(welcome.proto).toBe(3);
+			expect(welcome.proto).toBe(4);
 
 			const pending = host.requestGuestUi({ kind: "select", title: "Continue?", options: ["Yes"] });
 			if (!pending) throw new Error("expected writable guest UI request");

--- a/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
+++ b/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
@@ -55,6 +55,11 @@ process.stdout.write(
 			: { type: "ready" },
 	)}\n`,
 );
+if (Bun.env.MOCK_RPC_PROMPT_PROGRESS === "1") {
+	process.stdout.write(
+		`${JSON.stringify({ type: "prompt_progress", progress: { total: 100, processed: 56, cached: 40 } })}\n`,
+	);
+}
 
 function writeFrame(frame: Record<string, unknown>): void {
 	const logical = Buffer.from(JSON.stringify(frame), "utf8");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1056,9 +1056,29 @@ describe("ModelRegistry", () => {
 
 			const model = registry.find("custom-local", "gpt-5.4");
 			expect(model?.contextWindow).toBe(1_000_000);
+			expect(getOpenAICompat(model)?.supportsPromptProgress).toBe(true);
 			// llama.cpp discovery probes the bare root (`/models`, `/props`); chat
 			// traffic must go to the OpenAI-compatible `/v1` prefix.
 			expect(model?.baseUrl).toBe("http://127.0.0.1:8080/v1");
+		});
+
+		test("llama.cpp discovery capability honors an explicit provider opt-out", async () => {
+			writeRawModelsJson({
+				"custom-local": {
+					baseUrl: "http://127.0.0.1:8080",
+					apiKey: "TEST_KEY",
+					api: "openai-responses",
+					discovery: { type: "llama.cpp" },
+					compat: { supportsPromptProgress: false },
+					models: [{ id: "local-model" }],
+				},
+			});
+			const fetchMock = mockOpenAiCompatibleModels("http://127.0.0.1:8080/models", ["local-model"]);
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+			await registry.refreshProvider("custom-local", "online");
+
+			expect(getOpenAICompat(registry.find("custom-local", "local-model"))?.supportsPromptProgress).toBe(false);
 		});
 
 		test("discoverable custom compat survives refresh", async () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
@@ -9,6 +9,7 @@ import { vocalizer } from "@oh-my-pi/pi-coding-agent/tts/vocalizer";
 function createContext() {
 	const setWorkingMessage = vi.fn();
 	const ensureLoadingAnimation = vi.fn();
+	const requestRender = vi.fn();
 	const pendingTools = new Map<string, unknown>();
 	const session = {
 		getToolByName: () => undefined,
@@ -30,11 +31,11 @@ function createContext() {
 		setWorkingMessage,
 		clearPinnedError: vi.fn(),
 		ensureLoadingAnimation,
-		ui: { requestRender: vi.fn() },
+		ui: { requestRender },
 		session,
 		viewSession: session,
 	} as unknown as InteractiveModeContext;
-	return { ctx, pendingTools, setWorkingMessage, session };
+	return { ctx, pendingTools, requestRender, setWorkingMessage, session };
 }
 
 const AGENT_START = { type: "agent_start" } as unknown as AgentSessionEvent;
@@ -112,6 +113,23 @@ describe("EventController working messages", () => {
 
 		expect(setWorkingMessage).toHaveBeenCalledTimes(1);
 		expect(setWorkingMessage.mock.calls[0]?.[0]).toContain("Searching files");
+	});
+
+	it("suppresses late prompt-progress updates while aborting", async () => {
+		const { ctx, requestRender, setWorkingMessage, session } = createContext();
+		const controller = new EventController(ctx);
+		await controller.handleEvent(AGENT_START);
+		setWorkingMessage.mockClear();
+		requestRender.mockClear();
+		session.isAborting = true;
+
+		await controller.handleEvent({
+			type: "prompt_progress",
+			progress: { total: 100, cached: 40, processed: 56 },
+		});
+
+		expect(setWorkingMessage).not.toHaveBeenCalled();
+		expect(requestRender).not.toHaveBeenCalled();
 	});
 
 	it("resumes intent updates once aborting clears", async () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
@@ -52,7 +52,7 @@ function toolStartWithIntent(toolCallId: string, intent: string): AgentSessionEv
 	} as unknown as AgentSessionEvent;
 }
 
-describe("EventController aborted-turn working messages", () => {
+describe("EventController working messages", () => {
 	beforeAll(async () => {
 		await initTheme(false);
 	});
@@ -130,5 +130,47 @@ describe("EventController aborted-turn working messages", () => {
 
 		expect(setWorkingMessage).toHaveBeenCalledTimes(1);
 		expect(setWorkingMessage.mock.calls[0]?.[0]).toContain("Editing module");
+	});
+
+	it("shows prompt progress and restores the default label when output starts", async () => {
+		const { ctx, setWorkingMessage } = createContext();
+		const controller = new EventController(ctx);
+		await controller.handleEvent(AGENT_START);
+		setWorkingMessage.mockClear();
+
+		await controller.handleEvent({
+			type: "prompt_progress",
+			progress: { total: 100, cached: 40, processed: 56 },
+		});
+		expect(setWorkingMessage).toHaveBeenLastCalledWith(expect.stringContaining("Working (56%)"));
+		await controller.handleEvent({
+			type: "prompt_progress",
+			progress: { total: 200, cached: 80, processed: 113 },
+		});
+		expect(setWorkingMessage).toHaveBeenCalledTimes(1);
+
+		await controller.handleEvent({
+			type: "message_update",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "p" }],
+				api: "openai-responses",
+				provider: "test-provider",
+				model: "test-model",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "p", partial: undefined },
+		} as unknown as AgentSessionEvent);
+
+		expect(setWorkingMessage).toHaveBeenLastCalledWith();
 	});
 });

--- a/packages/coding-agent/test/rpc-client.restart.test.ts
+++ b/packages/coding-agent/test/rpc-client.restart.test.ts
@@ -15,6 +15,34 @@ function isProcessAlive(pid: number): boolean {
 }
 
 describe("RpcClient lifecycle (issue #4079 B)", () => {
+	test("forwards prompt progress through agent and session event listeners", async () => {
+		using client = new RpcClient({
+			cliPath: MOCK_AGENT,
+			env: { MOCK_RPC_PROMPT_PROGRESS: "1" },
+		});
+		const agentEvent = Promise.withResolvers<unknown>();
+		const sessionEvent = Promise.withResolvers<unknown>();
+		client.onEvent(event => {
+			if (event.type === "prompt_progress") agentEvent.resolve(event);
+		});
+		client.onSessionEvent(event => {
+			if (event.type === "prompt_progress") sessionEvent.resolve(event);
+		});
+
+		await client.start();
+		const events = await Promise.race([
+			Promise.all([agentEvent.promise, sessionEvent.promise]),
+			Bun.sleep(1_000).then(() => {
+				throw new Error("Timed out waiting for prompt_progress RPC event");
+			}),
+		]);
+
+		expect(events).toEqual([
+			{ type: "prompt_progress", progress: { total: 100, processed: 56, cached: 40 } },
+			{ type: "prompt_progress", progress: { total: 100, processed: 56, cached: 40 } },
+		]);
+	}, 20_000);
+
 	test("auto-negotiates protocol v2 and reassembles an oversized response", async () => {
 		using client = new RpcClient({
 			cliPath: MOCK_AGENT,

--- a/packages/wire/CHANGELOG.md
+++ b/packages/wire/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added normalized prompt-processing progress events for collaboration clients.
+
 ## [16.3.0] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/wire/CHANGELOG.md
+++ b/packages/wire/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Upgraded the collaboration protocol to version 4. Guests using version 3 are rejected during the handshake because they cannot handle prompt-progress events.
+
 ### Added
 
 - Added normalized prompt-processing progress events for collaboration clients.

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -401,8 +401,11 @@ export type WireFrame = GuestFrame | HostFrame;
  *   answered by the `ui-response` guest frame. Guests that predate the
  *   grammar would silently drop `ui-request` (asks hang forever on the
  *   host), so they must be rejected at hello.
+ * - `4`: hosts may send `prompt_progress` agent events. Version 3 guests do
+ *   not recognize that event and fail while dispatching it, so they must be
+ *   rejected at hello.
  */
-export const COLLAB_PROTO = 3;
+export const COLLAB_PROTO = 4;
 
 /** Parameter key used for intent tracing (e.g. prompt explanation/reasoning) */
 export const INTENT_FIELD = "i";

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -178,11 +178,19 @@ export interface CollabPromptDetails {
 // Events (handled subset)
 // ═══════════════════════════════════════════════════════════════════════════
 
+/** Normalized prompt processing counters reported by a streaming provider. */
+export interface PromptProgress {
+	total: number;
+	processed: number;
+	cached: number;
+}
+
 export type AgentEvent =
 	| { type: "agent_start" }
 	| { type: "agent_end" }
 	| { type: "turn_start" }
 	| { type: "turn_end" }
+	| { type: "prompt_progress"; progress: PromptProgress }
 	| { type: "message_start"; message: WireMessage }
 	/** Carries the FULL accumulating partial message — no delta tracking needed. */
 	| { type: "message_update"; message: WireMessage }

--- a/packages/wire/test/constants.test.ts
+++ b/packages/wire/test/constants.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("collab wire constants", () => {
 	it("exports the protocol constants consumed by host, guest, and relay links", () => {
-		expect(COLLAB_PROTO).toBe(3);
+		expect(COLLAB_PROTO).toBe(4);
 		expect(COLLAB_PROMPT_MESSAGE_TYPE).toBe("collab-prompt");
 		expect(ENVELOPE_HEADER_LENGTH).toBe(4);
 		expect(ROOM_ID_BYTES).toBe(16);


### PR DESCRIPTION
## What

This PR adds capability-gated support for llama.cpp's `prompt-progress` field and displays real-time percentages such as `Working (67%)`.

Missing or malformed fields (and all non-llama.cpp providers) fall back to existing behaviour.

<img width="547" height="156" alt="image" src="https://github.com/user-attachments/assets/e5a1fffe-de07-4993-8f1f-9f74a3e6e7fa" />


## Why

Prompt processing on local models can take a significant amount of time before generating output. OMP currently only displays `Working`, giving no indication of progress.

## Testing

Added test coverage. `bun check` passes, and the local binary passes `omp.exe --smoke-test`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
