### PR TITLE
feat(coding-agent): report async bash progress to active turns

### DIFF
--- a/docs/tools/bash.md
+++ b/docs/tools/bash.md
@@ -27,6 +27,7 @@
 | `cwd` | `string` | No | Working directory, resolved against `session.cwd` via `resolveToCwd`. Must exist and be a directory. |
 | `pty` | `boolean` | No | Request PTY mode. Default `false`. PTY is used only when `pty: true`, `PI_NO_PTY !== "1"`, and the tool context has a UI. |
 | `async` | `boolean` | No | Background execution request. Present only when `async.enabled` is true for the session. Returns immediately with a job id instead of waiting; it does not change the effective deadline, including a disabled deadline from `timeout: 0`. |
+| `progress` | `boolean` | No | With `async: true`, opt in to model-visible progress while the owning session is actively streaming. Complete non-empty output lines are coalesced to at most one update per second. |
 
 ## Outputs
 The tool returns a single `text` content block plus optional `details`.
@@ -47,6 +48,7 @@ The tool returns a single `text` content block plus optional `details`.
 - Background progress / completion:
   - delivered through `onUpdate` / async job manager, not the initial return.
   - running updates contain tail text and `details.async.state: "running"` only after the job is considered backgrounded.
+  - with `progress: true`, complete output lines are also delivered to the model as bounded `async-progress` asides; partial lines are held until completed, including the final unterminated line.
   - completion/failure updates carry final text and `details.async.state: "completed" | "failed"`. A non-zero exit or timeout is recorded as a failed background job.
 - Failure:
   - cancellation, missing exit status, validation failures, intercepted commands, and client-terminal-bridge timeouts throw `ToolError` / `ToolAbortError`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in `progress: true` updates for asynchronous Bash jobs, reporting complete output lines to the model while the owning session is active ([#2762](https://github.com/can1357/oh-my-pi/issues/2762)).
+
 ## [17.3.6] - 2026-08-17
 
 ### Added

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -5,6 +5,7 @@ const DELIVERY_RETRY_MAX_MS = 30_000;
 const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
+const AGENT_PROGRESS_INTERVAL_MS = 1_000;
 /** Abort reason used only when the owning session shuts down the entire manager. */
 export const ASYNC_JOB_MANAGER_SHUTDOWN_REASON = Symbol("AsyncJobManager shutdown");
 
@@ -27,6 +28,13 @@ interface PollEscalationState {
 	level: number;
 	/** Timestamp (ms) when the most recent poll wait returned. */
 	lastPollEndAt: number;
+}
+
+interface AgentProgressState {
+	lastEmitAt: number;
+	pendingText?: string;
+	seq: number;
+	timer?: NodeJS.Timeout;
 }
 
 export interface AsyncJob {
@@ -64,6 +72,13 @@ export interface AsyncJob {
 
 /** Delivery callback for a settled job's result text. */
 export type AsyncJobDeliverySink = (jobId: string, text: string, job?: AsyncJob) => void | Promise<void>;
+
+/** Best-effort owner-routed delivery for progress from a still-running job. */
+export interface AsyncJobProgressSink {
+	deliver(jobId: string, text: string, job: AsyncJob, seq: number): void | Promise<void>;
+	/** Ambient progress is useful only while the owning session is actively streaming. */
+	state(): "idle" | "streaming";
+}
 
 export interface AsyncJobManagerOptions {
 	/**
@@ -148,6 +163,8 @@ export class AsyncJobManager {
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #pollEscalation = new Map<string | undefined, PollEscalationState>();
 	readonly #deliverySinks = new Map<string, AsyncJobDeliverySink>();
+	readonly #progressSinks = new Map<string, AsyncJobProgressSink>();
+	readonly #progressState = new Map<string, AgentProgressState>();
 	readonly #onJobComplete: AsyncJobManagerOptions["onJobComplete"];
 	readonly #maxRunningJobs: number;
 	readonly #retentionMs: number;
@@ -189,6 +206,8 @@ export class AsyncJobManager {
 			jobId: string;
 			signal: AbortSignal;
 			reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+			/** Report intentional progress to the owning model, separately from TUI updates. */
+			reportAgentProgress: (text: string) => void;
 			/** Clear the queued flag once the job actually starts executing. */
 			markRunning: () => void;
 		}) => Promise<string>,
@@ -245,6 +264,7 @@ export class AsyncJobManager {
 					jobId: id,
 					signal: abortController.signal,
 					reportProgress,
+					reportAgentProgress: text => this.#recordAgentProgress(job, text),
 					markRunning: () => {
 						job.queued = false;
 					},
@@ -335,6 +355,7 @@ export class AsyncJobManager {
 		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
 		for (const jobId of uniqueJobIds) {
 			this.#watchedJobs.add(jobId);
+			this.#clearAgentProgress(jobId);
 		}
 		this.#notifyDeliveryQueueChanged();
 		return uniqueJobIds.length;
@@ -383,6 +404,7 @@ export class AsyncJobManager {
 
 		for (const jobId of uniqueJobIds) {
 			this.#suppressedDeliveries.add(jobId);
+			this.#clearAgentProgress(jobId);
 		}
 
 		const before = this.#deliveries.length;
@@ -476,6 +498,87 @@ export class AsyncJobManager {
 		return () => {
 			if (this.#deliverySinks.get(ownerId) === sink) this.#deliverySinks.delete(ownerId);
 		};
+	}
+
+	/**
+	 * Route progress for jobs owned by `ownerId`. The newest registration wins,
+	 * matching completion delivery ownership.
+	 */
+	registerProgressSink(ownerId: string, sink: AsyncJobProgressSink): () => void {
+		this.#progressSinks.set(ownerId, sink);
+		return () => {
+			if (this.#progressSinks.get(ownerId) === sink) this.#progressSinks.delete(ownerId);
+		};
+	}
+
+	#recordAgentProgress(job: AsyncJob, text: string): void {
+		if (this.#disposed || job.status !== "running" || this.isDeliverySuppressed(job.id)) return;
+		let state = this.#progressState.get(job.id);
+		if (!state) {
+			state = { lastEmitAt: 0, seq: 0 };
+			this.#progressState.set(job.id, state);
+		}
+		state.pendingText = text;
+		const waitMs = state.lastEmitAt + AGENT_PROGRESS_INTERVAL_MS - Date.now();
+		if (waitMs <= 0) {
+			this.#flushAgentProgress(job.id);
+			return;
+		}
+		if (state.timer) return;
+		state.timer = setTimeout(() => this.#flushAgentProgress(job.id), waitMs);
+		state.timer.unref();
+	}
+
+	#flushAgentProgress(jobId: string): void {
+		const state = this.#progressState.get(jobId);
+		if (!state) return;
+		if (state.timer) {
+			clearTimeout(state.timer);
+			state.timer = undefined;
+		}
+		const job = this.#jobs.get(jobId);
+		if (job?.status !== "running" || this.isDeliverySuppressed(jobId)) {
+			this.#clearAgentProgress(jobId);
+			return;
+		}
+		const text = state.pendingText;
+		if (text === undefined) return;
+		const sink = job.ownerId === undefined ? undefined : this.#progressSinks.get(job.ownerId);
+		if (sink?.state() !== "streaming") return;
+
+		state.pendingText = undefined;
+		state.lastEmitAt = Date.now();
+		state.seq += 1;
+		try {
+			const delivery = sink.deliver(jobId, text, job, state.seq);
+			if (delivery) {
+				delivery.catch(error => {
+					logger.warn("Async job progress delivery failed", {
+						jobId,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+			}
+		} catch (error) {
+			logger.warn("Async job progress delivery failed", {
+				jobId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	#clearAgentProgress(jobId: string): void {
+		const state = this.#progressState.get(jobId);
+		if (!state) return;
+		if (state.timer) clearTimeout(state.timer);
+		this.#progressState.delete(jobId);
+	}
+
+	#clearAllAgentProgress(): void {
+		for (const state of this.#progressState.values()) {
+			if (state.timer) clearTimeout(state.timer);
+		}
+		this.#progressState.clear();
 	}
 
 	/**
@@ -612,6 +715,8 @@ export class AsyncJobManager {
 		this.#watchedJobs.clear();
 		this.#pollEscalation.clear();
 		this.#deliverySinks.clear();
+		this.#progressSinks.clear();
+		this.#clearAllAgentProgress();
 		return jobsSettled && drained;
 	}
 
@@ -645,10 +750,12 @@ export class AsyncJobManager {
 		this.#evictionTimers.delete(jobId);
 		this.#suppressedDeliveries.delete(jobId);
 		this.#watchedJobs.delete(jobId);
+		this.#clearAgentProgress(jobId);
 		return this.#jobs.delete(jobId);
 	}
 
 	#scheduleEviction(jobId: string): void {
+		this.#clearAgentProgress(jobId);
 		if (this.#disposed) return;
 		if (this.#retentionMs <= 0) {
 			this.#evictJob(jobId);

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -31,6 +31,7 @@ import { theme } from "../theme/theme";
 import {
 	assistantHasVisibleContent,
 	assistantUsageIsBilled,
+	buildAsyncProgressBlock,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -471,6 +472,10 @@ export class ChatTranscriptBuilder {
 		if (message.customType === "async-result") {
 			const component = buildAsyncResultBlock(message);
 			this.container.addChild(component);
+			return;
+		}
+		if (message.customType === "async-progress") {
+			this.container.addChild(buildAsyncProgressBlock(message));
 			return;
 		}
 		if (message.customType === LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE) {

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -6,7 +6,7 @@
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
-import { formatBytes, formatDuration } from "@oh-my-pi/pi-utils";
+import { formatBytes, formatDuration, sanitizeText } from "@oh-my-pi/pi-utils";
 import {
 	type CustomMessage,
 	type FileMentionMessage,
@@ -14,7 +14,7 @@ import {
 	shouldRenderAbortReason,
 } from "../../session/messages";
 import { createIrcMessageCard } from "../../tools/hub";
-import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
+import { replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { ToolActivityContainer } from "../components/tool-activity";
 import { TranscriptBlock } from "../components/transcript-container";
@@ -65,6 +65,35 @@ export function buildAsyncResultBlock(message: CustomOrHookMessage): ToolActivit
 		block.addChild(new Text(line, 1, 0));
 	}
 	return new ToolActivityContainer(block);
+}
+
+/** Render bounded progress from a background job that is still running. */
+export function buildAsyncProgressBlock(message: CustomOrHookMessage): TranscriptBlock {
+	const details = (
+		message as CustomMessage<{
+			jobs?: Array<{ jobId?: string; type?: "bash" | "task"; elapsedMs?: number; text?: string }>;
+		}>
+	).details;
+	const block = new TranscriptBlock();
+	for (const job of details?.jobs ?? []) {
+		const jobId = job.jobId ?? "unknown";
+		const elapsed = typeof job.elapsedMs === "number" ? formatDuration(job.elapsedMs) : undefined;
+		const header = [
+			theme.fg("dim", `${theme.status.running} Background job progress`),
+			theme.fg("dim", job.type ? `[${job.type}]` : "[job]"),
+			theme.fg("accent", jobId),
+			elapsed ? theme.fg("dim", `(${elapsed})`) : undefined,
+		]
+			.filter(Boolean)
+			.join(" ");
+		block.addChild(new Text(header, 1, 0));
+		for (const line of (job.text ?? "").split("\n")) {
+			if (line.trim().length === 0) continue;
+			const rendered = truncateToWidth(replaceTabs(shortenPath(sanitizeText(line))), TRUNCATE_LENGTHS.LINE);
+			block.addChild(new Text(theme.fg("dim", `  ${rendered}`), 1, 0));
+		}
+	}
+	return block;
 }
 
 /**

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -56,6 +56,7 @@ import { createAssistantMessageComponent } from "./interactive-context-helpers";
 import {
 	assistantHasVisibleContent,
 	assistantUsageIsBilled,
+	buildAsyncProgressBlock,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -173,6 +174,10 @@ export class UiHelpers {
 					if (message.customType === "async-result") {
 						const component = buildAsyncResultBlock(message);
 						this.ctx.chatContainer.addChild(component);
+						break;
+					}
+					if (message.customType === "async-progress") {
+						this.ctx.chatContainer.addChild(buildAsyncProgressBlock(message));
 						break;
 					}
 					if (message.customType === LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE) {

--- a/packages/coding-agent/src/prompts/tools/async-progress.md
+++ b/packages/coding-agent/src/prompts/tools/async-progress.md
@@ -1,0 +1,7 @@
+{{#if multiple}}The following background jobs are STILL RUNNING.{{else}}The following background job is STILL RUNNING.{{/if}} This is a progress update only; no action is required.
+
+{{#each jobs}}
+### {{jobId}} ({{elapsed}})
+
+{{text}}
+{{/each}}

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -9,7 +9,7 @@ Use ONLY for one binary or a short pipeline that computes a fact (`wc -l`, `sort
 - Order-dependent commands use `&&` in one call; independent calls may run concurrently.
 - Internal URIs (`skill://`, `agent://`, …) auto-resolve to paths.
 {{#if hasShellBuiltins}}- aux utils available: mkdir, wc, sort, comm, diff, uniq, base64, cmp, md5sum, sha{1,224,256,384,512}sum, b2sum, basename, dirname, readlink, realpath, touch, stat, date, mktemp, seq, yes, printenv, truncate, tac, nproc, uname, whoami, hostname, which, ps, pgrep, pkill, pidwait, top, cut, tee, tr, paste, sed, xargs, jq, rm, mv, ln, ts, sponge, ifne, isutf8, combine{{#unless isWindows}}, errno{{/unless}}{{/if}}
-{{#if asyncEnabled}}- `async: true` defers a finite command's result; it does not extend `timeout`.{{/if}}
+{{#if asyncEnabled}}- `async: true` defers a finite command's result; it does not extend `timeout`. Set `progress: true` to receive complete non-empty output lines while actively working.{{/if}}
 </instruction>
 
 <critical>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -239,8 +239,11 @@ import type {
 import {
 	ASYNC_INLINE_RESULT_MAX_CHARS,
 	ASYNC_PREVIEW_MAX_CHARS,
+	ASYNC_PROGRESS_MESSAGE_TYPE,
 	ASYNC_RESULT_MESSAGE_TYPE,
+	type AsyncProgressEntry,
 	type AsyncResultEntry,
+	buildAsyncProgressBatchMessage,
 	buildAsyncResultBatchMessage,
 } from "./async-job-delivery";
 import { BashRunner, type BashRunnerHost } from "./bash-runner";
@@ -554,6 +557,8 @@ export class AgentSession {
 	readonly #asyncJobManager: AsyncJobManager | undefined;
 	/** Clears this session's owner delivery sink registration; set when a manager + agent id exist. */
 	#unregisterAsyncDeliverySink: (() => void) | undefined;
+	#unregisterAsyncProgressSink: (() => void) | undefined;
+	#unregisterAsyncProgressQueue: (() => void) | undefined;
 	/**
 	 * Async-delivery generation, bumped on every session transition that evicts
 	 * this owner's jobs (see {@link AgentSession.#cancelOwnAsyncJobs}). Stamped
@@ -1378,6 +1383,21 @@ export class AgentSession {
 				isStale: entry => entry.epoch !== this.#asyncDeliveryEpoch || manager.isDeliverySuppressed(entry.jobId),
 				build: buildAsyncResultBatchMessage,
 			});
+			this.#unregisterAsyncProgressSink = manager.registerProgressSink(this.#agentId, {
+				state: () => (this.isStreaming ? "streaming" : "idle"),
+				deliver: (jobId, text, job, seq) => this.#deliverAsyncJobProgress(jobId, text, job, seq),
+			});
+			this.#unregisterAsyncProgressQueue = this.yieldQueue.register<AsyncProgressEntry>(
+				ASYNC_PROGRESS_MESSAGE_TYPE,
+				{
+					skipIdleFlush: true,
+					isStale: entry =>
+						entry.epoch !== this.#asyncDeliveryEpoch ||
+						manager.isDeliverySuppressed(entry.jobId) ||
+						manager.getJob(entry.jobId)?.status !== "running",
+					build: buildAsyncProgressBatchMessage,
+				},
+			);
 		}
 		this.agent.setAssistantMessageEventInterceptor((message, assistantMessageEvent) => {
 			const event: AgentEvent = {
@@ -1853,6 +1873,7 @@ export class AgentSession {
 		// prior session's background result cannot inject into the next transcript.
 		this.#asyncDeliveryEpoch += 1;
 		this.yieldQueue.clear("async-result");
+		this.yieldQueue.clear(ASYNC_PROGRESS_MESSAGE_TYPE);
 	}
 
 	/**
@@ -1929,6 +1950,18 @@ export class AgentSession {
 		if (manager.isDeliverySuppressed(jobId)) return;
 		const durationMs = job ? Math.max(0, Date.now() - job.startTime) : undefined;
 		this.yieldQueue.enqueue<AsyncResultEntry>("async-result", { jobId, result: formatted, job, durationMs, epoch });
+	}
+
+	#deliverAsyncJobProgress(jobId: string, text: string, job: AsyncJob, seq: number): void {
+		if (this.#isDisposed || !this.isStreaming) return;
+		this.yieldQueue.enqueue<AsyncProgressEntry>(ASYNC_PROGRESS_MESSAGE_TYPE, {
+			jobId,
+			text,
+			job,
+			seq,
+			elapsedMs: Math.max(0, Date.now() - job.startTime),
+			epoch: this.#asyncDeliveryEpoch,
+		});
 	}
 
 	async #formatAsyncResultForFollowUp(result: string): Promise<string> {
@@ -3936,6 +3969,10 @@ export class AgentSession {
 		// dead-letter rather than enqueue a follow-up into a disposing session.
 		this.#unregisterAsyncDeliverySink?.();
 		this.#unregisterAsyncDeliverySink = undefined;
+		this.#unregisterAsyncProgressSink?.();
+		this.#unregisterAsyncProgressSink = undefined;
+		this.#unregisterAsyncProgressQueue?.();
+		this.#unregisterAsyncProgressQueue = undefined;
 		const manager = this.#ownedAsyncJobManager;
 		// The shutdown reason is reserved for the top-level session that OWNS the
 		// manager — the genuine process/handled-shutdown path — so the task

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -8,8 +8,9 @@
  * This replaces the old single hardwired `onJobComplete` closure that routed
  * every completion — regardless of owner — into the first top-level session.
  */
-import { prompt } from "@oh-my-pi/pi-utils";
+import { formatDuration, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import type { AsyncJob } from "../async";
+import asyncProgressTemplate from "../prompts/tools/async-progress.md" with { type: "text" };
 import asyncResultTemplate from "../prompts/tools/async-result.md" with { type: "text" };
 import type { CustomMessage } from "./messages";
 
@@ -19,6 +20,7 @@ import type { CustomMessage } from "./messages";
  * yield: a result injected after the yield supersedes that yield's payload.
  */
 export const ASYNC_RESULT_MESSAGE_TYPE = "async-result";
+export const ASYNC_PROGRESS_MESSAGE_TYPE = "async-progress";
 
 /** Result payloads longer than this spill to an artifact with an inline preview. */
 export const ASYNC_INLINE_RESULT_MAX_CHARS = 12_000;
@@ -37,6 +39,74 @@ export interface AsyncResultEntry {
 	 * the manager's per-id suppression marker.
 	 */
 	epoch: number;
+}
+
+export interface AsyncProgressEntry {
+	jobId: string;
+	text: string;
+	job: AsyncJob | undefined;
+	seq: number;
+	elapsedMs: number;
+	epoch: number;
+}
+
+type AsyncProgressJobDetails = {
+	jobId: string;
+	type?: "bash" | "task";
+	label?: string;
+	elapsedMs: number;
+	text: string;
+};
+
+export type AsyncProgressDetails = {
+	jobs: AsyncProgressJobDetails[];
+};
+
+const ASYNC_PROGRESS_MAX_LINES_PER_JOB = 3;
+const ASYNC_PROGRESS_MAX_CHARS = 4_000;
+
+function capProgressText(text: string, maxChars: number): string {
+	const lines = sanitizeText(text)
+		.split("\n")
+		.filter(line => line.trim().length > 0)
+		.slice(-ASYNC_PROGRESS_MAX_LINES_PER_JOB);
+	const joined = lines.join("\n");
+	if (joined.length <= maxChars) return joined;
+	return joined.slice(-maxChars);
+}
+
+/** Build one bounded aside, keeping only the newest update for each job. */
+export function buildAsyncProgressBatchMessage(
+	entries: AsyncProgressEntry[],
+): CustomMessage<AsyncProgressDetails> | null {
+	if (entries.length === 0) return null;
+	const newestByJob = new Map<string, AsyncProgressEntry>();
+	for (const entry of entries) {
+		const previous = newestByJob.get(entry.jobId);
+		if (!previous || entry.seq >= previous.seq) newestByJob.set(entry.jobId, entry);
+	}
+
+	const survivors = Array.from(newestByJob.values());
+	const perJobChars = Math.max(1, Math.floor(ASYNC_PROGRESS_MAX_CHARS / survivors.length));
+	const jobs = survivors.map(entry => ({
+		jobId: entry.jobId,
+		type: entry.job?.type,
+		label: entry.job?.label,
+		elapsedMs: entry.elapsedMs,
+		text: capProgressText(entry.text, perJobChars),
+	}));
+	return {
+		role: "custom",
+		customType: ASYNC_PROGRESS_MESSAGE_TYPE,
+		content: prompt.render(asyncProgressTemplate, {
+			multiple: jobs.length > 1,
+			jobs: jobs.map(job => ({ ...job, elapsed: formatDuration(job.elapsedMs) })),
+		}),
+		display: true,
+		attribution: "agent",
+		details: { jobs },
+		timestamp: Date.now(),
+	};
 }
 
 type AsyncResultJobDetails = {

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -284,6 +284,16 @@ function customOneLiner(msg: CustomMessage | HookMessage): string {
 				.join(", ");
 			return `[async-result] ${oneLine(labels)}`;
 		}
+		case "async-progress": {
+			const jobs = Array.isArray(details.jobs) ? details.jobs : [];
+			const parts = jobs.map(job => {
+				const entry = (job ?? {}) as Record<string, unknown>;
+				const id = typeof entry.jobId === "string" ? entry.jobId : "job";
+				const text = typeof entry.text === "string" ? entry.text : "";
+				return text ? `${id}: ${oneLine(text)}` : id;
+			});
+			return `[async-progress] ${parts.join("; ")}`;
+		}
 		default:
 			return `[${msg.customType}] ${oneLine(contentToText(msg.content))}`;
 	}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -300,6 +300,52 @@ async function saveBashOriginalArtifact(session: ToolSession, originalText: stri
 	}
 }
 
+/** Incrementally reports complete, non-empty output lines. */
+class BashProgressLines {
+	static readonly MAX_LINE_CHARS = 4_000;
+	readonly #report: (line: string) => void;
+	#partial = "";
+
+	constructor(report: (line: string) => void) {
+		this.#report = report;
+	}
+
+	append(chunk: string): void {
+		let start = 0;
+		let newline = chunk.indexOf("\n");
+		while (newline !== -1) {
+			this.#appendPartial(chunk.slice(start, newline));
+			this.#reportLine(this.#partial);
+			this.#partial = "";
+			start = newline + 1;
+			newline = chunk.indexOf("\n", start);
+		}
+		if (start < chunk.length) this.#appendPartial(chunk.slice(start));
+	}
+
+	finish(): void {
+		if (this.#partial === "") return;
+		const line = this.#partial;
+		this.#partial = "";
+		this.#reportLine(line);
+	}
+
+	#appendPartial(segment: string): void {
+		if (segment.length >= BashProgressLines.MAX_LINE_CHARS) {
+			this.#partial = segment.slice(-BashProgressLines.MAX_LINE_CHARS);
+			return;
+		}
+		const keep = BashProgressLines.MAX_LINE_CHARS - segment.length;
+		this.#partial = `${this.#partial.slice(-keep)}${segment}`;
+	}
+
+	#reportLine(rawLine: string): void {
+		const line = rawLine.replace(/\r$/, "");
+		if (line.trim().length === 0) return;
+		this.#report(line);
+	}
+}
+
 const BASH_TIMEOUT_DESCRIPTION = `timeout in seconds; 0 disables the command deadline; nonzero values are clamped to ${TOOL_TIMEOUTS.bash.min}-${TOOL_TIMEOUTS.bash.max}`;
 
 const bashSchemaBase = type({
@@ -317,6 +363,7 @@ const bashSchemaWithAsync = type({
 	"cwd?": "string",
 	"pty?": "boolean",
 	"async?": type("boolean").describe("run in background"),
+	"progress?": type("boolean").describe("report complete output lines while the background job runs"),
 });
 
 type BashToolSchema = typeof bashSchemaBase | typeof bashSchemaWithAsync;
@@ -329,6 +376,7 @@ export interface BashToolInput {
 
 	async?: boolean;
 	pty?: boolean;
+	progress?: boolean;
 }
 
 export interface BashToolDetails {
@@ -803,6 +851,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		resolvedEnv?: Record<string, string>;
 		onUpdate?: AgentToolUpdateCallback<BashToolDetails>;
 		forwardUpdates: boolean;
+		progressMode: "disabled" | "lines";
 	}): ManagedBashJobHandle {
 		const manager = this.session.asyncJobManager;
 		if (!manager) {
@@ -817,26 +866,34 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		const jobId = manager.register(
 			"bash",
 			label,
-			async ({ jobId, signal: runSignal, reportProgress }) => {
+			async ({ jobId, signal: runSignal, reportProgress, reportAgentProgress }) => {
 				const { path: artifactPath, id: artifactId } = (await this.session.allocateOutputArtifact?.("bash")) ?? {};
 				const tailBuffer = new TailBuffer(DEFAULT_MAX_BYTES);
+				const progressLines =
+					options.progressMode === "lines" ? new BashProgressLines(reportAgentProgress) : undefined;
 				const wallTimeStart = performance.now();
 				try {
-					const result = await executeBash(options.command, {
-						cwd: options.commandCwd,
-						sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
-						timeout: options.timeoutMs ?? 0,
-						signal: runSignal,
-						env: options.resolvedEnv,
-						artifactPath,
-						artifactId,
-						onChunk: chunk => {
-							tailBuffer.append(chunk);
-							latestText = tailBuffer.text();
-							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
-						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
-					});
+					let result: BashResult;
+					try {
+						result = await executeBash(options.command, {
+							cwd: options.commandCwd,
+							sessionKey: `${this.session.getSessionId?.() ?? ""}:async:${jobId}`,
+							timeout: options.timeoutMs ?? 0,
+							signal: runSignal,
+							env: options.resolvedEnv,
+							artifactPath,
+							artifactId,
+							onChunk: chunk => {
+								tailBuffer.append(chunk);
+								latestText = tailBuffer.text();
+								void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
+								progressLines?.append(chunk);
+							},
+							onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						});
+					} finally {
+						progressLines?.finish();
+					}
 					const wallTimeMs = performance.now() - wallTimeStart;
 					const finalResult = await this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -952,6 +1009,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 
 			async: asyncRequested = false,
 			pty = false,
+			progress = false,
 		}: BashToolInput,
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<BashToolDetails>,
@@ -974,6 +1032,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		}
 		if (asyncRequested && !this.#asyncEnabled) {
 			throw new ToolError("Async bash execution is disabled. Enable async.enabled to use async mode.");
+		}
+		if (progress && !asyncRequested) {
+			throw new ToolError("progress requires `async: true`; foreground commands return their output directly.");
 		}
 
 		// Check both the original command and the cwd-normalized command so
@@ -1068,6 +1129,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				resolvedEnv,
 				onUpdate,
 				forwardUpdates: false,
+				progressMode: progress ? "lines" : "disabled",
 			});
 			return this.#buildBackgroundStartResult(job.jobId, "", timeoutSec, {
 				requestedTimeoutSec,
@@ -1106,6 +1168,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				resolvedEnv,
 				onUpdate,
 				forwardUpdates: !startBackgrounded,
+				progressMode: "disabled",
 			});
 			if (startBackgrounded) {
 				return this.#buildBackgroundStartResult(job.jobId, "", timeoutSec, {

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -14,7 +14,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { DaemonCompletionNotification } from "@oh-my-pi/pi-coding-agent/launch/protocol";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import type { AsyncResultEntry } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
+import type { AsyncProgressEntry, AsyncResultEntry } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -343,6 +343,120 @@ describe("AgentSession owner-routed async delivery", () => {
 		// reaches quiescence.
 		await session.settleAsyncWork();
 		expect(session.hasPendingAsyncWork()).toBe(false);
+	});
+
+	it("holds progress while idle and injects it at the next active turn", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({});
+		AsyncJobManager.setInstance(manager);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+			ownedAsyncJobManager: manager,
+		});
+
+		const gate = Promise.withResolvers<string>();
+		manager.register("bash", "progress job", () => gate.promise, { id: "progress-job", ownerId: "Main" });
+		const job = manager.getJob("progress-job");
+		if (!job) throw new Error("Expected registered progress job");
+		session.yieldQueue.enqueue<AsyncProgressEntry>("async-progress", {
+			jobId: job.id,
+			text: "LAZY PROGRESS MARKER",
+			job,
+			seq: 1,
+			elapsedMs: 10,
+			epoch: 0,
+		});
+
+		await Promise.resolve();
+		expect(mock.calls).toHaveLength(0);
+
+		await session.sendUserMessage("inspect progress");
+		expect(
+			mock.calls.some(call =>
+				call.context.messages.some(message =>
+					typeof message.content === "string"
+						? message.content.includes("LAZY PROGRESS MARKER")
+						: message.content.some(
+								content => content.type === "text" && content.text.includes("LAZY PROGRESS MARKER"),
+							),
+				),
+			),
+		).toBe(true);
+
+		manager.watchJobs([job.id]);
+		gate.resolve("done");
+		await manager.waitForAll();
+	});
+
+	it("drops late progress from a prior session after its job id is reused", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({});
+		AsyncJobManager.setInstance(manager);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+			ownedAsyncJobManager: manager,
+		});
+		expect(await session.newSession()).toBe(true);
+
+		const gate = Promise.withResolvers<string>();
+		manager.register("bash", "reused progress job", () => gate.promise, { id: "reused-job", ownerId: "Main" });
+		const job = manager.getJob("reused-job");
+		if (!job) throw new Error("Expected registered reused job");
+		session.yieldQueue.enqueue<AsyncProgressEntry>("async-progress", {
+			jobId: job.id,
+			text: "STALE PROGRESS MARKER",
+			job,
+			seq: 1,
+			elapsedMs: 10,
+			epoch: 0,
+		});
+
+		await session.sendUserMessage("fresh turn");
+		expect(
+			mock.calls.every(call =>
+				call.context.messages.every(message =>
+					typeof message.content === "string"
+						? !message.content.includes("STALE PROGRESS MARKER")
+						: message.content.every(
+								content => content.type !== "text" || !content.text.includes("STALE PROGRESS MARKER"),
+							),
+				),
+			),
+		).toBe(true);
+
+		manager.watchJobs([job.id]);
+		gate.resolve("done");
+		await manager.waitForAll();
 	});
 
 	it("keeps the event loop live until a delayed idle flush runs", async () => {

--- a/packages/coding-agent/test/async-job-progress.test.ts
+++ b/packages/coding-agent/test/async-job-progress.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { type AsyncJob, AsyncJobManager, type AsyncJobProgressSink } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+
+function heldJob(manager: AsyncJobManager, ownerId = "Main") {
+	const gate = Promise.withResolvers<void>();
+	const started = Promise.withResolvers<(text: string) => void>();
+	const jobId = manager.register(
+		"bash",
+		"held",
+		async ({ reportAgentProgress }) => {
+			started.resolve(reportAgentProgress);
+			await gate.promise;
+			return "done";
+		},
+		{ ownerId },
+	);
+	return { jobId, report: started.promise, release: gate.resolve };
+}
+
+function recordingSink(active = true): {
+	sink: AsyncJobProgressSink;
+	seen: Array<{ jobId: string; text: string; seq: number }>;
+	setActive(value: boolean): void;
+} {
+	const seen: Array<{ jobId: string; text: string; seq: number }> = [];
+	let state: "idle" | "streaming" = active ? "streaming" : "idle";
+	return {
+		sink: {
+			state: () => state,
+			deliver: (jobId, text, _job: AsyncJob, seq) => {
+				seen.push({ jobId, text, seq });
+			},
+		},
+		seen,
+		setActive(value) {
+			state = value ? "streaming" : "idle";
+		},
+	};
+}
+
+describe("AsyncJobManager model progress", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("coalesces to the newest update on a fixed trailing edge", async () => {
+		vi.useFakeTimers();
+		const manager = new AsyncJobManager({});
+		const recorder = recordingSink();
+		manager.registerProgressSink("Main", recorder.sink);
+		const job = heldJob(manager);
+		const report = await job.report;
+
+		report("first");
+		report("second");
+		report("newest");
+		expect(recorder.seen.map(item => item.text)).toEqual(["first"]);
+
+		vi.advanceTimersByTime(1_000);
+		expect(recorder.seen).toEqual([
+			{ jobId: job.jobId, text: "first", seq: 1 },
+			{ jobId: job.jobId, text: "newest", seq: 2 },
+		]);
+
+		report("stale after completion");
+		job.release();
+		await manager.waitForAll();
+		vi.advanceTimersByTime(1_000);
+		expect(recorder.seen).toHaveLength(2);
+	});
+
+	test("respects wait/ack suppression and routes only to the owning active session", async () => {
+		const manager = new AsyncJobManager({});
+		const mine = recordingSink(false);
+		const other = recordingSink();
+		manager.registerProgressSink("Main", mine.sink);
+		manager.registerProgressSink("Other", other.sink);
+		const job = heldJob(manager);
+		const report = await job.report;
+
+		report("idle");
+		expect(mine.seen).toEqual([]);
+		mine.setActive(true);
+		report("active");
+		expect(mine.seen.map(item => item.text)).toEqual(["active"]);
+		expect(other.seen).toEqual([]);
+
+		manager.watchJobs([job.jobId]);
+		report("watched");
+		expect(mine.seen).toHaveLength(1);
+		manager.unwatchJobs([job.jobId]);
+		manager.acknowledgeDeliveries([job.jobId]);
+		report("acknowledged");
+		expect(mine.seen).toHaveLength(1);
+
+		job.release();
+		await manager.waitForAll();
+	});
+
+	test("sink failures are best-effort and do not block completion", async () => {
+		const completions: string[] = [];
+		const manager = new AsyncJobManager({});
+		manager.registerProgressSink("Main", {
+			state: () => "streaming",
+			deliver: async () => {
+				throw new Error("sink failed");
+			},
+		});
+		manager.registerDeliverySink("Main", (_jobId, text) => {
+			completions.push(text);
+		});
+
+		const jobId = manager.register(
+			"bash",
+			"failure",
+			async ({ reportAgentProgress }) => {
+				reportAgentProgress("tick");
+				return "complete";
+			},
+			{ ownerId: "Main" },
+		);
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+
+		expect(manager.getJob(jobId)?.status).toBe("completed");
+		expect(completions).toEqual(["complete"]);
+	});
+});

--- a/packages/coding-agent/test/async-progress-message.test.ts
+++ b/packages/coding-agent/test/async-progress-message.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import * as os from "node:os";
+import type { AsyncJob } from "@oh-my-pi/pi-coding-agent/async";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { buildAsyncProgressBlock } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
+import {
+	ASYNC_PROGRESS_MESSAGE_TYPE,
+	type AsyncProgressEntry,
+	buildAsyncProgressBatchMessage,
+} from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
+
+function job(id: string): AsyncJob {
+	return {
+		id,
+		type: "bash",
+		status: "running",
+		startTime: 0,
+		label: id,
+		abortController: new AbortController(),
+		promise: Promise.resolve(),
+	};
+}
+
+function entry(jobId: string, text: string, seq = 1): AsyncProgressEntry {
+	return { jobId, text, seq, job: job(jobId), elapsedMs: 5_000, epoch: 0 };
+}
+
+function content(message: { content: unknown } | null): string {
+	if (!message || typeof message.content !== "string") throw new Error("Expected text content");
+	return message.content;
+}
+
+beforeAll(async () => {
+	const theme = await getThemeByName("dark");
+	if (!theme) throw new Error("Failed to load dark theme for tests");
+	setThemeInstance(theme);
+});
+
+describe("async progress messages", () => {
+	test("keeps the latest sequence and applies shared line/character caps", () => {
+		const message = buildAsyncProgressBatchMessage([
+			entry("bg_1", "stale", 1),
+			entry("bg_1", `discarded\nline2\nline3\n${"x".repeat(5_000)}`, 2),
+			entry("bg_2", "important", 1),
+		]);
+		const jobs = message?.details?.jobs ?? [];
+
+		expect(message?.customType).toBe(ASYNC_PROGRESS_MESSAGE_TYPE);
+		expect(jobs).toHaveLength(2);
+		expect(jobs.reduce((total, item) => total + item.text.length, 0)).toBeLessThanOrEqual(4_000);
+		expect(jobs[0]?.text.split("\n").length).toBeLessThanOrEqual(3);
+		expect(content(message)).not.toContain("stale");
+		expect(content(message)).toContain("important");
+		expect(content(message)).toContain("STILL RUNNING");
+		expect(content(message)).toContain("no action is required");
+
+		const lineCapped = buildAsyncProgressBatchMessage([entry("bg_3", "one\ntwo\nthree\nfour")]);
+		expect(lineCapped?.details?.jobs[0]?.text).toBe("two\nthree\nfour");
+	});
+
+	test("renders the custom message as sanitized progress rather than a completion", () => {
+		const message = buildAsyncProgressBatchMessage([
+			entry("bg_7", `\u001b[31m${os.homedir()}/private/output\rone\tvalue\u001b[0m`),
+		]);
+		if (!message) throw new Error("Expected progress message");
+		const rendered = Bun.stripANSI(buildAsyncProgressBlock(message).render(80).join("\n"));
+
+		expect(rendered).toContain("Background job progress [bash] bg_7");
+		expect(rendered).toContain("~/private/outputone");
+		expect(rendered).toMatch(/one +value/);
+		expect(rendered).not.toContain("\t");
+		expect(rendered).not.toContain("\r");
+		expect(rendered).not.toContain(os.homedir());
+		expect(rendered).not.toContain("completed");
+	});
+});

--- a/packages/coding-agent/test/bash-progress-param.test.ts
+++ b/packages/coding-agent/test/bash-progress-param.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
+
+const SETTINGS: Record<string, unknown> = {
+	"async.enabled": true,
+	"bash.autoBackground.enabled": false,
+	"bash.autoBackground.thresholdMs": 60_000,
+	"bashInterceptor.enabled": false,
+	"astGrep.enabled": false,
+	"astEdit.enabled": false,
+	"grep.enabled": false,
+	"glob.enabled": false,
+};
+
+function makeSession(manager: AsyncJobManager): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		skills: [],
+		asyncJobManager: manager,
+		getAgentId: () => "Main",
+		getSessionId: () => "progress-test",
+		getSessionFile: () => null,
+		settings: {
+			get: (key: string) => SETTINGS[key],
+			getBashInterceptorRules: () => [],
+		},
+		getClientBridge: () => undefined,
+	} as unknown as ToolSession;
+}
+
+function collectProgress(manager: AsyncJobManager): string[] {
+	const seen: string[] = [];
+	manager.registerDeliverySink("Main", () => {});
+	manager.registerProgressSink("Main", {
+		state: () => "streaming",
+		deliver: (_jobId, text) => {
+			seen.push(text);
+		},
+	});
+	return seen;
+}
+
+describe("bash progress parameter", () => {
+	test("defaults off", async () => {
+		const manager = new AsyncJobManager({});
+		const seen = collectProgress(manager);
+		const tool = new BashTool(makeSession(manager));
+
+		await tool.execute("default-off", { command: "printf 'one\\ntwo\\n'", async: true });
+		await manager.waitForAll();
+
+		expect(seen).toEqual([]);
+	});
+
+	test("reports complete non-empty lines and flushes the final partial line", async () => {
+		const manager = new AsyncJobManager({});
+		const seen = collectProgress(manager);
+		const tool = new BashTool(makeSession(manager));
+
+		await tool.execute("complete-lines", {
+			command: "printf par; sleep 0.1; printf 'tial\\n\\n'",
+			async: true,
+			progress: true,
+		});
+		await manager.waitForAll();
+		await tool.execute("final-partial", {
+			command: "printf final",
+			async: true,
+			progress: true,
+		});
+		await manager.waitForAll();
+
+		expect(seen).toEqual(["partial", "final"]);
+	}, 10_000);
+
+	test("bounds an unterminated output line before reporting it", async () => {
+		const manager = new AsyncJobManager({});
+		const seen = collectProgress(manager);
+		const tool = new BashTool(makeSession(manager));
+
+		await tool.execute("bounded-line", {
+			command: "printf '%05000d' 0",
+			async: true,
+			progress: true,
+		});
+		await manager.waitForAll();
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]).toHaveLength(4_000);
+		expect(seen[0]).toBe("0".repeat(4_000));
+	});
+
+	test("rejects progress for a foreground command", async () => {
+		const manager = new AsyncJobManager({});
+		const tool = new BashTool(makeSession(manager));
+
+		await expect(tool.execute("foreground", { command: "echo no", progress: true })).rejects.toThrow(
+			/requires `async: true`/,
+		);
+	});
+});


### PR DESCRIPTION
First slice of #2762, scoped to the behavior discussed in the issue.

## What changed

- `bash({ async: true, progress: true })` treats each complete non-empty output line as a progress event. The option is off by default and rejected for foreground commands.
- The async job manager keeps only the latest update and emits at most once per second to the owning session.
- Progress is a lazy aside: it can join an active model turn, but never wakes an idle session. Polling/acknowledgement, job completion, session replacement, and disposal all make queued progress stale.
- Model and TUI payloads are bounded and sanitized. Live and rebuilt transcript paths use the same renderer.

This intentionally leaves command-owning monitors, idle wakeups, regex filters, runtime tuning, and task-job progress out of this PR. A monitor follow-up should coordinate with #5785 instead of introducing a second process-monitor API.

Claude Code's Monitor was used as an interaction benchmark: complete output lines are useful event boundaries, while filtering and polling belong in the monitored command. This PR does not copy its wake-on-every-event behavior.

## Verification

- 46 focused async job, session delivery, yield queue, and Bash tests
- `bun check`
