### PR TITLE
fix(catalog): add deepseek-v4-pro-0813 discovery limits

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `deepseek-v4-pro-0813` surfacing from Alibaba Token Plan discovery with `contextWindow`/`maxTokens` of `null`. The dated DeepSeek V4 Pro snapshot was missing from `ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS`, so unlike its `deepseek-v4-flash-0731` sibling it fell through to unknown limits ([#8847](https://github.com/can1357/oh-my-pi/issues/8847)).
+
 ## [17.3.6] - 2026-08-17
 
 ### Changed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2980,6 +2980,10 @@ export const ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS: Readonly<Record<string,
 		contextWindow: 1_000_000,
 		maxTokens: 384_000,
 	},
+	"deepseek-v4-pro-0813": {
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+	},
 	"deepseek-v3.2": {
 		contextWindow: 131_072,
 		maxTokens: 65_536,

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -75,6 +75,7 @@ describe("QwenCloud Token Plan provider", () => {
 						},
 						{ id: "deepseek-v4-flash", owned_by: "qwencloud" },
 						{ id: "deepseek-v4-flash-0731", owned_by: "qwencloud" },
+						{ id: "deepseek-v4-pro-0813", owned_by: "qwencloud" },
 						{ id: "kimi-k2.7-code", owned_by: "qwencloud" },
 						{ id: "MiniMax-M2.5", owned_by: "qwencloud" },
 						{ id: "qwen3.6-plus", owned_by: "qwencloud" },
@@ -106,6 +107,7 @@ describe("QwenCloud Token Plan provider", () => {
 			"deepseek-v3.2",
 			"deepseek-v4-flash",
 			"deepseek-v4-flash-0731",
+			"deepseek-v4-pro-0813",
 			"future-chat-model",
 			"glm-5",
 			"glm-5.1",
@@ -122,6 +124,7 @@ describe("QwenCloud Token Plan provider", () => {
 			["qwen3.8-max", 1_000_000, 131_072],
 			["deepseek-v4-flash", 1_000_000, 384_000],
 			["deepseek-v4-flash-0731", 1_000_000, 384_000],
+			["deepseek-v4-pro-0813", 1_000_000, 384_000],
 			["deepseek-v3.2", 131_072, 65_536],
 			["glm-5.1", 202_752, 128_000],
 			["glm-5", 202_752, 16_384],
@@ -133,7 +136,7 @@ describe("QwenCloud Token Plan provider", () => {
 		for (const [id, contextWindow, maxTokens] of expectedLimits) {
 			expect(models?.find(model => model.id === id)).toMatchObject({ contextWindow, maxTokens });
 		}
-		for (const id of ["deepseek-v4-flash", "deepseek-v4-flash-0731"]) {
+		for (const id of ["deepseek-v4-flash", "deepseek-v4-flash-0731", "deepseek-v4-pro-0813"]) {
 			expect(models?.find(model => model.id === id)).toMatchObject({
 				reasoning: true,
 				thinking: {


### PR DESCRIPTION
Refs #8847

## What

`deepseek-v4-pro-0813` surfaces from Alibaba Token Plan discovery with `contextWindow: null` / `maxTokens: null`.

Alibaba's Token Plan advertises both dated DeepSeek V4 snapshots, but only `deepseek-v4-flash-0731` has an entry in `ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS`. `deepseek-v4-pro-0813` isn't in `ALIBABA_TOKEN_PLAN_STATIC_MODELS` either — only the undated `deepseek-v4-pro` is — so it falls through to unknown limits. That's the #7486 symptom, still live for this one id.

Reasoning already works for it: the `normalizedId.startsWith("deepseek-v4")` branch in `mapModel` gives it `reasoning: true` plus the high/max effort ladder. **Only the limits were missing**, so this is a one-entry fix at 1M context / 384K output, matching both `deepseek-v4-pro` and `deepseek-v4-flash-0731`.

```diff
  "deepseek-v4-flash-0731": {
  	contextWindow: 1_000_000,
  	maxTokens: 384_000,
  },
+ "deepseek-v4-pro-0813": {
+ 	contextWindow: 1_000_000,
+ 	maxTokens: 384_000,
+ },
```

## Testing

Extended the existing `discovers subscribed chat models from the native models endpoint` test rather than adding a parallel one — it already advertises `deepseek-v4-flash-0731` and asserts the limits table, so the dated Pro snapshot belongs in the same contract.

Confirmed the test genuinely defends the change:

- **Without** the source fix: `1 fail` — `deepseek-v4-pro-0813` comes back with `contextWindow`/`maxTokens` null
- **With** the fix: `6 pass, 0 fail, 31 expect() calls`

Also run:

- `bun --cwd=packages/catalog run check` (biome + tsgo) — clean
- `bun test packages/catalog/test/` — **589 pass, 0 fail**

## Context

This came out of #8847, which I filed against a badly stale local checkout and which is therefore mostly wrong about this provider — I've left a correction on the issue. Everything else it claimed as missing is already handled on `main`:

- the 4 "missing" flagship models (`qwen3.8-max`, `qwen3.8-max-preview`, `qwen3.7-plus`, `glm-5.2`) are in `ALIBABA_TOKEN_PLAN_STATIC_MODELS`
- `kimi-k2.7-code`, `glm-5`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.5`, `deepseek-v3.2`, `deepseek-v4-flash` all already carry correct discovery limits
- image/audio/video ids are excluded by `ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES`
- region-locked credentials are handled via `parseAlibabaTokenPlanCredential` (#6682)

`deepseek-v4-pro-0813` was the only real remaining gap.

---

- [x] `bun check` passes (catalog package)
- [x] Tested locally
- [x] CHANGELOG updated
