### PR TITLE
fix(discovery): honor Claude Code enabledPlugins for marketplace plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude Code marketplace plugins ignoring the `enabledPlugins` switch in `~/.claude/settings.json` and `.claude/settings(.local).json`: a plugin turned off for a project no longer loads there, and a local-scope install enabled for a project loads even when its recorded `projectPath` is a different directory
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -898,6 +898,40 @@ async function canonicalClaudeProjectPath(projectPath: string): Promise<string |
 	}
 }
 
+/**
+ * Claude Code `enabledPlugins` overrides, merged across the same settings
+ * layers Claude Code itself consults: `<claude-config>/settings.json`, then
+ * `<dir>/.claude/settings.json` and `<dir>/.claude/settings.local.json` for
+ * each project directory (later layers win, `.local` wins within a layer).
+ *
+ * Returns `pluginId -> boolean` for the ids the user toggled explicitly, and
+ * the list of settings files that contributed (for cache keying).
+ */
+async function readClaudeEnabledPlugins(
+	claudeConfigDir: string,
+	projectDirs: string[],
+): Promise<{ enabled: Map<string, boolean>; sources: string[] }> {
+	const enabled = new Map<string, boolean>();
+	const sources: string[] = [];
+	const candidates = [path.join(claudeConfigDir, "settings.json")];
+	for (const dir of projectDirs) {
+		candidates.push(path.join(dir, ".claude", "settings.json"), path.join(dir, ".claude", "settings.local.json"));
+	}
+	for (const file of candidates) {
+		const content = await readFile(file);
+		if (!content) continue;
+		const data = tryParseJson<{ enabledPlugins?: unknown }>(content);
+		if (!data || typeof data !== "object") continue;
+		const map = data.enabledPlugins;
+		if (!map || typeof map !== "object" || Array.isArray(map)) continue;
+		sources.push(file);
+		for (const [pluginId, value] of Object.entries(map as Record<string, unknown>)) {
+			if (typeof value === "boolean") enabled.set(pluginId, value);
+		}
+	}
+	return { enabled, sources };
+}
+
 const pluginRootsCache = new Map<string, { roots: ClaudePluginRoot[]; warnings: string[] }>();
 
 const pluginCacheInvalidators = new Set<() => void>();
@@ -922,7 +956,10 @@ export async function listClaudePluginRoots(
 	const resolvedProjectPath = cwd ? await resolveActiveProjectRegistryPath(cwd) : null;
 	const projectRoot = resolvedProjectPath ? path.dirname(path.dirname(path.dirname(resolvedProjectPath))) : cwd;
 	const activeClaudeProjectPath = projectRoot ? await canonicalClaudeProjectPath(projectRoot) : null;
-	const cacheKey = `${claudeConfigDir}:${ompRegistryPath}:${resolvedProjectPath ?? ""}:${activeClaudeProjectPath ?? ""}`;
+	const canonicalCwd = cwd ? await canonicalClaudeProjectPath(cwd) : null;
+	const settingsDirs = [...new Set([activeClaudeProjectPath, canonicalCwd].filter((d): d is string => !!d))];
+	const enabledOverrides = await readClaudeEnabledPlugins(claudeConfigDir, settingsDirs);
+	const cacheKey = `${claudeConfigDir}:${ompRegistryPath}:${resolvedProjectPath ?? ""}:${activeClaudeProjectPath ?? ""}:${canonicalCwd ?? ""}:${enabledOverrides.sources.join("|")}`;
 	const cached = pluginRootsCache.get(cacheKey);
 	if (cached) return cached;
 
@@ -961,7 +998,13 @@ export async function listClaudePluginRoots(
 						continue;
 					}
 					if (entry.enabled === false) continue;
-					if (entry.scope === "local") {
+					// Claude Code's own on/off switch: `enabledPlugins` in settings.json /
+					// settings.local.json. `false` hides the plugin here even though it is
+					// installed; `true` opts a local-scope install into this project even
+					// when its recorded projectPath is a different directory.
+					const override = enabledOverrides.enabled.get(pluginId);
+					if (override === false) continue;
+					if (entry.scope === "local" && override !== true) {
 						if (!entry.projectPath || !activeClaudeProjectPath) continue;
 						let entryProjectPath = canonicalClaudeProjectPaths.get(entry.projectPath);
 						if (entryProjectPath === undefined) {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -224,6 +224,103 @@ describe("listClaudePluginRoots", () => {
 		expect(result.roots.find(root => root.id === "active-plugin@market")?.scope).toBe("project");
 	});
 
+	test("hides a plugin the user switched off with enabledPlugins in project settings", async () => {
+		// Contract: a plugin Claude Code would not load in this project (enabledPlugins:false in
+		// .claude/settings.local.json) must not contribute skills/MCP/commands here either.
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const project = path.join(tempDir, "project");
+		await Promise.all([
+			fs.mkdir(pluginsDir, { recursive: true }),
+			fs.mkdir(path.join(project, ".claude"), { recursive: true }),
+			fs.mkdir(path.join(project, ".git"), { recursive: true }),
+		]);
+		const entry = (installPath: string) => ({
+			scope: "user",
+			installPath,
+			version: "1.0.0",
+			installedAt: "2025-01-01T00:00:00Z",
+			lastUpdated: "2025-01-01T00:00:00Z",
+		});
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"kept@market": [entry("/plugins/kept")],
+					"muted@market": [entry("/plugins/muted")],
+					"muted-then-restored@market": [entry("/plugins/restored")],
+				},
+			}),
+		);
+		// settings.json turns two off; settings.local.json turns one of them back on (local wins).
+		await fs.writeFile(
+			path.join(project, ".claude", "settings.json"),
+			JSON.stringify({ enabledPlugins: { "muted@market": false, "muted-then-restored@market": false } }),
+		);
+		await fs.writeFile(
+			path.join(project, ".claude", "settings.local.json"),
+			JSON.stringify({ enabledPlugins: { "muted-then-restored@market": true } }),
+		);
+
+		const inProject = await listClaudePluginRoots(tempDir, project);
+		expect(inProject.roots.map(root => root.id).sort()).toEqual(["kept@market", "muted-then-restored@market"]);
+
+		// The switch is per project: elsewhere the same user-scope install still loads.
+		const elsewhere = path.join(tempDir, "elsewhere");
+		await fs.mkdir(path.join(elsewhere, ".git"), { recursive: true });
+		const outside = await listClaudePluginRoots(tempDir, elsewhere);
+		expect(outside.roots.map(root => root.id).sort()).toEqual([
+			"kept@market",
+			"muted-then-restored@market",
+			"muted@market",
+		]);
+	});
+
+	test("enabledPlugins:true opts a local-scope install into a project with a different projectPath", async () => {
+		// Contract: Claude Code loads a plugin wherever enabledPlugins says true, regardless of
+		// which directory the local-scope install was recorded under. Without this, a plugin
+		// installed from a parent directory never loads from the child project it is enabled in.
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const parent = path.join(tempDir, "clients");
+		const child = path.join(parent, "acme");
+		await Promise.all([
+			fs.mkdir(pluginsDir, { recursive: true }),
+			fs.mkdir(path.join(child, ".claude"), { recursive: true }),
+			fs.mkdir(path.join(child, ".git"), { recursive: true }),
+		]);
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"acme@market": [
+						{
+							scope: "local",
+							installPath: "/plugins/acme",
+							projectPath: parent,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+
+		const before = await listClaudePluginRoots(tempDir, child);
+		expect(before.roots).toEqual([]);
+
+		clearClaudePluginRootsCache();
+		clearFsCache();
+		await fs.writeFile(
+			path.join(child, ".claude", "settings.local.json"),
+			JSON.stringify({ enabledPlugins: { "acme@market": true } }),
+		);
+		const after = await listClaudePluginRoots(tempDir, child);
+		expect(after.roots.map(root => root.id)).toEqual(["acme@market"]);
+		expect(after.roots[0]?.scope).toBe("project");
+	});
+
 	test("parses plugin with project scope", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		await fs.mkdir(pluginsDir, { recursive: true });


### PR DESCRIPTION
## What

The `claude-plugins` discovery provider now honors Claude Code's `enabledPlugins` map (`~/.claude/settings.json`, `<project>/.claude/settings.json`, `<project>/.claude/settings.local.json`; later layers win, `.local` wins within a layer). Project layers are read for the active plugin project root (nearest `.omp/`, else git root) and for the cwd.

- `enabledPlugins["name@marketplace"] = false` → the plugin's skills/commands/MCP/hooks are not loaded in that project, even though it is in `installed_plugins.json`.
- `enabledPlugins["name@marketplace"] = true` → a `scope: "local"` install loads in that project even when its recorded `projectPath` is a different directory.
- Ids not mentioned keep the existing behavior. Contributing settings files are part of the plugin-roots cache key.

## Why

Claude Code decides *whether* an installed plugin is active per project via `enabledPlugins`; omp only read the install registry. So a plugin a user had explicitly turned off for a repo still loaded in omp, and — the case that bit me — a client plugin installed with `--scope local` from a parent directory (`~/clients`) and enabled in a child project (`~/clients/acme/.claude/settings.local.json`) never loaded from that project or any repo under it, because the exact `projectPath` match failed. The only workaround was hand-maintaining a parallel `.omp/plugins/installed_plugins.json` per project.

From my side: I hit this on my own multi-client setup (per-client plugins enabled in `~/Freelance/<client>/.claude/settings.local.json`, sessions launched from repos under those dirs); with this change omp loads the same plugins Claude Code does there and I could delete the duplicate `.omp/plugins/installed_plugins.json` files. Authored with an AI agent under my direction; the end-to-end check below ran against my real config.

## Testing

- `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` — 40 pass. The two new tests fail on `main` (checked by stashing the source change) and pass with it: (1) per-project `false` hides a user-scope plugin, `settings.local.json` overrides `settings.json`, and the same plugin still loads from another project; (2) `true` opts a local-scope install recorded under a parent dir into the child project.
- `bun test test/discovery test/marketplace` — 492 pass, 0 fail. `bun run check:ts` — clean.
- End to end, real filesystem: a plugin registered `scope: local, projectPath: ~/Freelance` and enabled in `~/Freelance/Sazabi/.claude/settings.local.json`, run from `~/Freelance/Sazabi/monorepo` with `omp -p --skills 'blacksmith*,terraform-refactor*' "list your skills"`: released 17.3.5 → `NONE`; this branch (`bun --cwd=packages/coding-agent src/cli.ts`) → `blacksmith, terraform-refactor`.

---

- [x] `bun check` passes (`check:ts`; no Rust touched)
- [x] Tested locally
- [x] CHANGELOG updated
