### PR TITLE
fix(tui): bound the live /btw answer to the viewport

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a long `/btw` answer piling its own rows into native scrollback while the primary turn streams. The panel lives in the anchored live region, which only stays out of history while it fits the viewport; an unbounded side answer scrolled off, was recorded, and was recorded again on every rebuild. The live answer is now bounded to 40% of the viewport (floor 6 rows) with its newest end visible, the same way queued command output is bounded, and `c copy` still yields the whole answer. Measured on one pane with a 60-line answer under a 200-line streaming reply: 39 duplicated lines before, 0 after.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/coding-agent/src/modes/components/btw-panel.ts
+++ b/packages/coding-agent/src/modes/components/btw-panel.ts
@@ -11,6 +11,35 @@ interface BtwPanelComponentOptions {
 	canBranch?: () => boolean;
 }
 
+/** Never shrink the live side answer below this, even on a short terminal. */
+const BTW_ANSWER_MIN_ROWS = 6;
+/** Ceiling for the live side answer as a share of the viewport. */
+const BTW_ANSWER_VIEWPORT_FRACTION = 0.4;
+
+/**
+ * Bounds the rendered answer so the anchored panel keeps fitting the window.
+ * Delegates to the real renderer at the real width, so the visible rows cannot
+ * drift from the answer the user copies or branches.
+ */
+class BoundedAnswer implements Component {
+	constructor(
+		private readonly answer: Component,
+		private readonly maxRows: () => number,
+	) {}
+
+	render(width: number): readonly string[] {
+		const rows = this.answer.render(width);
+		const limit = Math.max(1, this.maxRows());
+		if (rows.length <= limit) return rows;
+		const hidden = rows.length - (limit - 1);
+		// Keep the tail: a streaming answer is read at its newest end.
+		return [
+			theme.fg("dim", `… ${hidden} earlier ${hidden === 1 ? "row" : "rows"} — c copy for the full answer`),
+			...rows.slice(rows.length - (limit - 1)),
+		];
+	}
+}
+
 class BtwFooter implements Component {
 	#getLine: () => string;
 	#line: string | undefined;
@@ -156,6 +185,23 @@ export class BtwPanelComponent extends Container {
 				this.#state === "running" ? `${theme.status.pending} Waiting for response…` : "No text returned.";
 			return new Text(theme.fg("dim", waiting), 1, 0);
 		}
-		return new Markdown(text, 1, 0, getMarkdownTheme());
+		return new BoundedAnswer(new Markdown(text, 1, 0, getMarkdownTheme()), () => this.#maxAnswerRows());
+	}
+
+	/**
+	 * The panel lives in the anchored live region above the editor, which the
+	 * engine can only keep out of native scrollback while it fits the window.
+	 * A long side answer that outgrows it scrolls off, commits as history, and
+	 * then re-commits from its new position on the next rebuild — the answer
+	 * piles up in chunks while it is still streaming. Bound the live view the
+	 * same way queued command output is bounded; the full text stays one `c`
+	 * away and `b` still promotes all of it into the chat.
+	 */
+	#maxAnswerRows(): number {
+		// Hosts that render the panel outside a real terminal (tests, headless
+		// probes) expose no viewport; fall back to the floor rather than assuming.
+		const viewport = this.#tui.terminal?.rows;
+		if (typeof viewport !== "number" || !Number.isFinite(viewport) || viewport <= 0) return BTW_ANSWER_MIN_ROWS;
+		return Math.max(BTW_ANSWER_MIN_ROWS, Math.trunc(viewport * BTW_ANSWER_VIEWPORT_FRACTION));
 	}
 }

--- a/packages/coding-agent/test/modes/components/btw-panel-bounded.test.ts
+++ b/packages/coding-agent/test/modes/components/btw-panel-bounded.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { BtwPanelComponent } from "@oh-my-pi/pi-coding-agent/modes/components/btw-panel";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+// Contract under test: the `/btw` panel lives in the anchored live region above
+// the editor. That region only stays out of native scrollback while it fits the
+// viewport — rows that scroll off are recorded, and a rebuilt-in-place panel
+// then records them again on the next frame. Measured on a real pane before this
+// bound existed: a 60-line side answer streaming under a growing transcript left
+// 39 of its lines in history 2-3 times each; with the bound, zero.
+function tuiStub(rows: number): TUI {
+	return {
+		requestComponentRender: vi.fn(),
+		terminal: { rows },
+	} as unknown as TUI;
+}
+
+function visibleRows(component: BtwPanelComponent, width = 80): string[] {
+	return component.render(width).map(row => stripVTControlCharacters(row));
+}
+
+describe("BtwPanelComponent answer bound", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	it("keeps a long answer within a viewport share and points at the full copy", () => {
+		const panel = new BtwPanelComponent({ question: "why", tui: tuiStub(40) });
+		const answer = Array.from({ length: 80 }, (_, i) => `line-${i + 1}`).join("\n");
+		panel.setAnswer(answer);
+		panel.markComplete();
+
+		const rendered = visibleRows(panel);
+		// 40 rows viewport -> 16 answer rows, plus the panel's own chrome.
+		expect(rendered.length).toBeLessThan(30);
+		expect(rendered.some(row => row.includes("earlier rows") && row.includes("c copy"))).toBe(true);
+		// The newest end of a streaming answer is what the reader wants visible.
+		expect(rendered.some(row => row.includes("line-80"))).toBe(true);
+		expect(rendered.some(row => row.includes("line-1\b") || row === " line-1")).toBe(false);
+		// Nothing is lost: the copy affordance still yields the whole answer.
+		expect(panel.getCopyText()).toBe(answer);
+	});
+
+	it("never shrinks the answer below the floor on a short terminal", () => {
+		const panel = new BtwPanelComponent({ question: "why", tui: tuiStub(4) });
+		panel.setAnswer(Array.from({ length: 40 }, (_, i) => `row-${i + 1}`).join("\n"));
+		panel.markComplete();
+
+		const answerRows = visibleRows(panel).filter(row => row.includes("row-"));
+		expect(answerRows.length).toBeGreaterThanOrEqual(5);
+	});
+
+	it("renders a short answer untouched", () => {
+		const panel = new BtwPanelComponent({ question: "why", tui: tuiStub(40) });
+		panel.setAnswer("one\ntwo\nthree");
+		panel.markComplete();
+
+		const rendered = visibleRows(panel);
+		expect(rendered.some(row => row.includes("earlier rows"))).toBe(false);
+		for (const word of ["one", "two", "three"]) {
+			expect(rendered.some(row => row.includes(word))).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## What

A long `/btw` answer piles its own rows into native scrollback while the primary
turn is streaming — the side question and its rows reappear in history in chunks.

The `/btw` panel lives in the anchored live region above the editor
(`AnchoredLiveContainer` in `interactive-mode.ts`). That region only stays out of
history while it **fits the viewport**: rows that scroll off the window are
recorded by the terminal, and because the panel rebuilds in place on every
streamed delta, the next frame records them again.

This bounds the live answer the same way queued command output is already bounded
by `DeferredCommandPreview`: 40% of the viewport, floor 6 rows, newest end
visible, with one dim row saying how many rows are hidden and that `c` copies the
whole answer. `getCopyText()` and `b` (branch to chat) still carry the full text,
so nothing is lost.

## Why not fix the engine

I tried first. Tracking the topmost *pinned* seam separately and clamping the
commit ceiling to it (the frame's pinned flag currently comes from the topmost
seam, which during a turn is the unpinned transcript) removed exactly **one copy
of eight** in a harness probe. Rows that already left the window physically live
in the terminal's history; bookkeeping cannot unwrite them, and the ED3
erase-and-replay path is the wrong tool while a reader may be scrolled up. So the
component has to stay inside the region that is safe.

## Measurements

Harness probe, isolating the invariant (anchored pinned region under a growing
`seam = Infinity` transcript, 8-row window, one row of the region rewritten per
frame):

| anchored region | copies of the rewritten row in history | duplicated rows |
|---|---|---|
| taller than viewport | 8 | 9 |
| fits viewport | **1** | **0** |

Live pane, same recipe both runs (60-line `/btw` answer submitted 9 s into a
200-line streaming reply, exact-line duplicate count in the pane's real
scrollback via `herdr pane read --source recent-unwrapped`):

| build | duplicated answer lines | total answer-line occurrences |
|---|---|---|
| `17.3.5` as installed | **39** | 154 |
| this branch | **0** | 8 |

The engine's own `PI_DEBUG_REDRAW` log for the failing runs shows the recorded
rows being re-committed (and, in two captures, `committed` regressing 2-3 rows
right after a `fullPaint(clearScrollback=true)`).

## Tests

`packages/coding-agent/test/modes/components/btw-panel-bounded.test.ts`:
a long answer stays inside the viewport share and advertises the hidden-row count
with `c copy`; the floor holds on a 4-row terminal; a short answer renders
untouched; `getCopyText()` returns the full answer.

`bun run check` clean; 1349 tests pass across `test/modes`, `test/session`,
`test/session-manager`. The five existing `btw-controller`/`BtwPanelComponent`
tests that stub `TUI` without a terminal keep passing — the viewport read is
defensive and falls back to the floor.

## Note

I first reported this as #8793 with a wrong mechanism (I had counted occurrences
in the raw PTY stream, which includes full repaints) and closed it. This PR is the
verified version: the counts above come from the pane's actual scrollback.
