### PR TITLE
feat(coding-agent): add active tool timer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in working-row timer that shows elapsed time for the active tool call above the prompt editor.
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -999,6 +999,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"display.showWorkingTimer": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Show Tool Timer",
+			description: "Show elapsed time for the active tool call on the working row above the prompt editor.",
+		},
+	},
+
 	"display.smoothStreaming": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -555,6 +555,9 @@ export class Settings {
 		if (path === "statusLine.sessionAccent") {
 			statusLineSessionAccentSignal.fire();
 		}
+		if (path === "display.showWorkingTimer") {
+			displayShowWorkingTimerSignal.fire();
+		}
 		if (path === "modelRoles") {
 			modelRolesSignal.fire();
 		}
@@ -2364,6 +2367,15 @@ const modelRolesSignal = new SettingSignal("modelRoles");
 
 /** Subscribe to model role changes. Returns an unsubscribe function. */
 export const onModelRolesChanged: (cb: () => void) => () => void = modelRolesSignal.on.bind(modelRolesSignal);
+
+/** Fires when `display.showWorkingTimer` changes at runtime. */
+const displayShowWorkingTimerSignal = new SettingSignal("display.showWorkingTimer");
+
+/**
+ * Subscribe to working-timer setting changes.
+ * Returns an unsubscribe function. Callers should re-read settings in the callback.
+ */
+export const onDisplayShowWorkingTimerChanged = (cb: () => void) => displayShowWorkingTimerSignal.on(cb);
 
 /** Fires when `statusLine.sessionAccent` changes at runtime. */
 const statusLineSessionAccentSignal = new SettingSignal("statusLine.sessionAccent");

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -90,6 +90,7 @@ export class EventController {
 	#lastVisibleBlockCount = 0;
 	#renderedCustomMessages = new Set<string>();
 	#lastIntent: string | undefined = undefined;
+	#activeToolExecutions = new Map<string, { startedAt: number; message: string }>();
 	#backgroundTaskCallIds = new Set<string>();
 	/** Tool calls whose approval prompt drove the title into `attention`; cleared
 	 *  at their tool_execution_end so the title returns to `working`. */
@@ -484,6 +485,7 @@ export class EventController {
 	}
 
 	#updateWorkingMessageFromIntent(intent: unknown): void {
+		if (this.#activeToolExecutions.size > 0) return;
 		if (this.ctx.session.isAborting) return;
 		// Streamed JSON can deliver non-string `i` (object, number, boolean) before
 		// schema validation; `?.` only guards null/undefined, so guard the type too.
@@ -492,6 +494,33 @@ export class EventController {
 		if (!trimmed || trimmed === this.#lastIntent) return;
 		this.#lastIntent = trimmed;
 		this.ctx.setWorkingMessage(`${trimmed}${interruptHint()}`);
+	}
+
+	#startToolExecutionStatus(event: Extract<AgentSessionEvent, { type: "tool_execution_start" }>): void {
+		if (this.ctx.session.isAborting || this.#activeToolExecutions.has(event.toolCallId)) return;
+		const intent = typeof event.intent === "string" ? event.intent.trim() : "";
+		this.#activeToolExecutions.set(event.toolCallId, {
+			startedAt: Date.now(),
+			message: intent || `Running ${event.toolName}`,
+		});
+		this.#syncActiveToolExecutionStatus();
+	}
+
+	#finishToolExecutionStatus(toolCallId: string): void {
+		if (!this.#activeToolExecutions.delete(toolCallId)) return;
+		this.#syncActiveToolExecutionStatus();
+	}
+
+	#syncActiveToolExecutionStatus(): void {
+		const active = this.#activeToolExecutions.values().next().value;
+		if (!active) {
+			this.#lastIntent = undefined;
+			this.ctx.setWorkingMessage(undefined, { timerStartedAt: null });
+			return;
+		}
+		if (this.ctx.session.isAborting) return;
+		this.#lastIntent = active.message;
+		this.ctx.setWorkingMessage(`${active.message}${interruptHint()}`, { timerStartedAt: active.startedAt });
 	}
 
 	subscribeToAgent(): void {
@@ -754,6 +783,7 @@ export class EventController {
 		this.#pinnedErrorComponent = undefined;
 		this.#pinnedErrorMessage = undefined;
 		this.#restorePinnedErrorInline = true;
+		this.#activeToolExecutions.clear();
 		this.ctx.clearPinnedError();
 		if (this.ctx.retryLoader) {
 			this.ctx.retryLoader.stop();
@@ -1351,7 +1381,7 @@ export class EventController {
 	async #handleToolExecutionStart(event: Extract<AgentSessionEvent, { type: "tool_execution_start" }>): Promise<void> {
 		if (this.#retractedToolCallIds.has(event.toolCallId)) return;
 		this.#ensureWorkingLoaderWhileStreaming();
-		this.#updateWorkingMessageFromIntent(event.intent);
+		this.#startToolExecutionStatus(event);
 		if (event.toolName === "ask" || this.#toolWillPromptForApproval(event.toolName, event.args)) {
 			this.#approvalAttentionToolCallIds.add(event.toolCallId);
 			setTerminalTitleState("attention");
@@ -1506,10 +1536,9 @@ export class EventController {
 	}
 
 	async #handleToolExecutionEnd(event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>): Promise<void> {
-		// `createAbortedToolResult` emits start/end after an error/aborted
-		// assistant message. The matching card was deliberately retracted at
-		// message_end; consume the completion instead of recreating/updating UI.
-		if (this.#retractedToolCallIds.delete(event.toolCallId)) return;
+		const retracted = this.#retractedToolCallIds.delete(event.toolCallId);
+		this.#finishToolExecutionStatus(event.toolCallId);
+		if (retracted) return;
 		// A synthetic aborted/error completion (agent-loop's placeholder for a
 		// never-run call on a terminal error/abort) settles the card in place so a
 		// terminal failure stays visible. Remember it so `#handleAutoRetryStart`
@@ -1729,6 +1758,7 @@ export class EventController {
 	}
 
 	async #finishAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
+		this.#activeToolExecutions.clear();
 		this.#setTerminalProgress(false);
 		this.ctx.statusLine.markActivityEnd();
 		this.#streamingReveal.stop();
@@ -1810,6 +1840,7 @@ export class EventController {
 		if (!this.ctx.viewSession.isStreaming) return;
 		if (this.ctx.autoCompactionLoader || this.ctx.retryLoader) return;
 		this.ctx.ensureLoadingAnimation();
+		if (this.#activeToolExecutions.size > 0) this.#syncActiveToolExecutionStatus();
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -62,6 +62,7 @@ import { formatModelString, type ResolvedModelRoleValue } from "../config/model-
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import {
 	isSettingsInitialized,
+	onDisplayShowWorkingTimerChanged,
 	onModelRolesChanged,
 	onStatusLineSessionAccentChanged,
 	Settings,
@@ -279,6 +280,81 @@ function renderWorkingMessage(message: string, accent?: WorkingMessageAccent): s
 		],
 		theme,
 	);
+}
+
+function workingMessageWithTimer(message: string, elapsedMs: number): string {
+	const timer = `${theme.sep.dot}${formatDuration(elapsedMs)}`;
+	const hint = interruptHint();
+	if (!message.endsWith(hint)) return `${message}${timer}`;
+	return `${message.slice(0, -hint.length)}${timer}${hint}`;
+}
+
+class WorkingLoader extends Loader {
+	#baseMessage: string;
+	#startedAt: number | undefined;
+	readonly #timerEnabled: () => boolean;
+	#elapsedTimer?: NodeJS.Timeout;
+
+	constructor(
+		ui: TUI,
+		spinnerColorFn: (text: string) => string,
+		messageColorFn: LoaderMessageColorFn,
+		message: string,
+		timerEnabled: () => boolean,
+		spinnerFrames?: string[],
+	) {
+		super(ui, spinnerColorFn, messageColorFn, message, spinnerFrames);
+		this.#baseMessage = message;
+		this.#timerEnabled = timerEnabled;
+	}
+
+	override setMessage(message: string): void {
+		this.setWorkingState(message);
+	}
+
+	setWorkingState(message: string, timerStartedAt?: number | null): void {
+		this.#baseMessage = message;
+		if (timerStartedAt !== undefined) {
+			this.#startedAt = timerStartedAt ?? undefined;
+		}
+		this.#syncTimer();
+		this.#syncMessage();
+	}
+
+	refreshTimerSetting(): void {
+		this.#syncTimer();
+		this.#syncMessage();
+	}
+
+	override stop(): void {
+		if (this.#elapsedTimer) {
+			clearInterval(this.#elapsedTimer);
+			this.#elapsedTimer = undefined;
+		}
+		super.stop();
+	}
+
+	#syncTimer(): void {
+		if (!this.#timerEnabled() || this.#startedAt === undefined) {
+			if (this.#elapsedTimer) {
+				clearInterval(this.#elapsedTimer);
+				this.#elapsedTimer = undefined;
+			}
+			return;
+		}
+		if (this.#elapsedTimer) return;
+		this.#elapsedTimer = setInterval(() => this.#syncMessage(), 1_000);
+		this.#elapsedTimer.unref?.();
+	}
+
+	#syncMessage(): void {
+		const startedAt = this.#startedAt;
+		const message =
+			this.#timerEnabled() && startedAt !== undefined
+				? workingMessageWithTimer(this.#baseMessage, Date.now() - startedAt)
+				: this.#baseMessage;
+		super.setMessage(message);
+	}
 }
 
 const EDITOR_MAX_HEIGHT_MIN = 6;
@@ -1199,6 +1275,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			onStatusLineSessionAccentChanged(() => {
 				this.#syncStatusLineSettings();
 				this.#handleSessionAccentInputsChanged();
+			}),
+			onDisplayShowWorkingTimerChanged(() => {
+				if (this.loadingAnimation instanceof WorkingLoader) {
+					this.loadingAnimation.refreshTimerSetting();
+				}
 			}),
 		);
 		// Resync the welcome banner to the live model: init-time reconciliations
@@ -4541,7 +4622,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			// message is static, so leave `animated` unset and let the loader use
 			// the spinner-only ~12.5fps cadence instead of repainting a frozen line.
 			if (shimmerEnabled()) messageColorFn.animated = true;
-			this.loadingAnimation = new Loader(
+			this.loadingAnimation = new WorkingLoader(
 				this.ui,
 				spinner => {
 					const accent = this.#getWorkingMessageAccent();
@@ -4549,6 +4630,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				},
 				messageColorFn,
 				this.#defaultWorkingMessage,
+				() => settings.get("display.showWorkingTimer"),
 				getSymbolTheme().spinnerFrames,
 			);
 			this.statusContainer.addChild(this.loadingAnimation);
@@ -4570,21 +4652,24 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	setWorkingMessage(message?: string): void {
+	setWorkingMessage(message?: string, options?: { timerStartedAt?: number | null }): void {
+		const workingMessage = message ?? this.#defaultWorkingMessage;
 		if (message === undefined) {
 			this.#pendingWorkingMessage = undefined;
-			if (this.loadingAnimation) {
-				this.loadingAnimation.setMessage(this.#defaultWorkingMessage);
+		}
+
+		if (this.loadingAnimation) {
+			if (this.loadingAnimation instanceof WorkingLoader) {
+				this.loadingAnimation.setWorkingState(workingMessage, options?.timerStartedAt);
+			} else {
+				this.loadingAnimation.setMessage(workingMessage);
 			}
 			return;
 		}
 
-		if (this.loadingAnimation) {
-			this.loadingAnimation.setMessage(message);
-			return;
+		if (message !== undefined) {
+			this.#pendingWorkingMessage = message;
 		}
-
-		this.#pendingWorkingMessage = message;
 	}
 
 	applyPendingWorkingMessage(): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -279,7 +279,7 @@ export interface InteractiveModeContext {
 	flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void>;
 	flushPendingBashComponents(): void;
 	flushPendingModelSwitch(): Promise<void>;
-	setWorkingMessage(message?: string): void;
+	setWorkingMessage(message?: string, options?: { timerStartedAt?: number | null }): void;
 	applyPendingWorkingMessage(): void;
 	ensureLoadingAnimation(): void;
 	startPendingSubmission(input: {

--- a/packages/coding-agent/test/interactive-mode-working-accent.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-accent.test.ts
@@ -86,7 +86,7 @@ afterAll(() => {
 	resetSettingsForTest();
 });
 
-describe("InteractiveMode working-message session accent cache", () => {
+describe("InteractiveMode working row", () => {
 	it("reports a live seam only while status content is mounted", async () => {
 		const { mode } = await createHarness("Live status");
 		const statusContainer = mode.statusContainer as Container & NativeScrollbackLiveRegion;
@@ -98,6 +98,44 @@ describe("InteractiveMode working-message session accent cache", () => {
 		startStableLoader(mode);
 		expect(statusContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
 		expect(statusContainer.isNativeScrollbackLiveRegionPinned?.()).toBe(true);
+	});
+
+	it("shows elapsed time only while a tool call is active", async () => {
+		const { mode } = await createHarness("Timed work");
+		settings.set("display.showWorkingTimer", true);
+		vi.useFakeTimers();
+		let now = 10_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		try {
+			mode.ensureLoadingAnimation();
+			expect(Bun.stripANSI(renderLoader(mode))).not.toContain("0s");
+
+			mode.setWorkingMessage("Indexing files", { timerStartedAt: now });
+			expect(Bun.stripANSI(renderLoader(mode))).toContain(`Indexing files${theme.sep.dot}0s`);
+
+			now += 11_000;
+			vi.advanceTimersByTime(11_000);
+			expect(Bun.stripANSI(renderLoader(mode))).toContain(`Indexing files${theme.sep.dot}11s`);
+
+			mode.setWorkingMessage("Still indexing");
+			expect(Bun.stripANSI(renderLoader(mode))).toContain(`Still indexing${theme.sep.dot}11s`);
+
+			mode.setWorkingMessage(undefined, { timerStartedAt: null });
+			mode.loadingAnimation?.stop();
+			const settled = Bun.stripANSI(renderLoader(mode));
+			expect(settled).toContain("Working");
+			expect(settled).not.toContain("11s");
+
+			now += 5_000;
+			vi.advanceTimersByTime(5_000);
+			expect(Bun.stripANSI(renderLoader(mode))).toBe(settled);
+		} finally {
+			mode.loadingAnimation?.stop();
+			settings.set("display.showWorkingTimer", false);
+			vi.useRealTimers();
+			vi.restoreAllMocks();
+		}
 	});
 
 	it("reuses one computed accent across loader spinner and message colorizers", async () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
@@ -52,7 +52,17 @@ function toolStartWithIntent(toolCallId: string, intent: string): AgentSessionEv
 	} as unknown as AgentSessionEvent;
 }
 
-describe("EventController aborted-turn working messages", () => {
+function toolEnd(toolCallId: string): AgentSessionEvent {
+	return {
+		type: "tool_execution_end",
+		toolCallId,
+		toolName: "grep",
+		result: { content: [], details: undefined },
+		isError: false,
+	} as unknown as AgentSessionEvent;
+}
+
+describe("EventController working messages", () => {
 	beforeAll(async () => {
 		await initTheme(false);
 	});
@@ -130,5 +140,30 @@ describe("EventController aborted-turn working messages", () => {
 
 		expect(setWorkingMessage).toHaveBeenCalledTimes(1);
 		expect(setWorkingMessage.mock.calls[0]?.[0]).toContain("Editing module");
+	});
+
+	it("keeps the oldest concurrent tool timer until that tool finishes", async () => {
+		const { ctx, pendingTools, setWorkingMessage } = createContext();
+		const controller = new EventController(ctx);
+		await controller.handleEvent(AGENT_START);
+		setWorkingMessage.mockClear();
+		let now = 1_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		pendingTools.set("call-1", { updateResult: vi.fn() });
+		await controller.handleEvent(toolStartWithIntent("call-1", "Searching files"));
+		now = 2_000;
+		pendingTools.set("call-2", { updateResult: vi.fn() });
+		await controller.handleEvent(toolStartWithIntent("call-2", "Reading index"));
+
+		expect(setWorkingMessage.mock.lastCall?.[0]).toContain("Searching files");
+		expect(setWorkingMessage.mock.lastCall?.[1]).toEqual({ timerStartedAt: 1_000 });
+
+		await controller.handleEvent(toolEnd("call-1"));
+		expect(setWorkingMessage.mock.lastCall?.[0]).toContain("Reading index");
+		expect(setWorkingMessage.mock.lastCall?.[1]).toEqual({ timerStartedAt: 2_000 });
+
+		await controller.handleEvent(toolEnd("call-2"));
+		expect(setWorkingMessage.mock.lastCall).toEqual([undefined, { timerStartedAt: null }]);
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -8,6 +8,7 @@ import { __providerInFlightForTesting, streamSimple } from "@oh-my-pi/pi-ai/stre
 import type { Context } from "@oh-my-pi/pi-ai/types";
 import {
 	onAppendOnlyModeChanged,
+	onDisplayShowWorkingTimerChanged,
 	onStatusLineSessionAccentChanged,
 	resetSettingsForTest,
 	type SettingPath,
@@ -459,6 +460,35 @@ describe("Settings", () => {
 			expect(Settings.isolated({ inlineToolDescriptors: true }).get("inlineToolDescriptors")).toBe("on");
 			expect(Settings.isolated({ inlineToolDescriptors: false }).get("inlineToolDescriptors")).toBe("off");
 			expect(Settings.isolated().get("inlineToolDescriptors")).toBe("auto");
+		});
+	});
+
+	describe("display.showWorkingTimer hooks", () => {
+		it("notifies subscribers only when the effective value changes", () => {
+			const isolated = Settings.isolated();
+			const values: boolean[] = [];
+			const unsubscribe = onDisplayShowWorkingTimerChanged(() => {
+				values.push(isolated.get("display.showWorkingTimer"));
+			});
+
+			try {
+				isolated.set("display.showWorkingTimer", false);
+				expect(values).toEqual([]);
+
+				isolated.set("display.showWorkingTimer", true);
+				expect(values).toEqual([true]);
+
+				isolated.override("display.showWorkingTimer", true);
+				expect(values).toEqual([true]);
+
+				isolated.clearOverride("display.showWorkingTimer");
+				expect(values).toEqual([true]);
+			} finally {
+				unsubscribe();
+			}
+
+			isolated.set("display.showWorkingTimer", false);
+			expect(values).toEqual([true]);
 		});
 	});
 


### PR DESCRIPTION
## What

Add a timer to the bottom row, eg
```text
⠋ Waiting for long running command · 4m ⟦esc⟧
 ```
but it's not a timer for the turn, but since the last tool invocation. Change is hidden behind a flag so no default behavior change, but I think it makes sense to make it default and remove the setting.

## Why

Useful to monitor how long the agent is stuck on a command, in case it got failed to set reasonable timeout. 

## Testing

Added tests, but mainly manually is made up session.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
