### PR TITLE
feat(task): per-agent lean subagent prompt mode

### DIFF
--- a/docs/task-agent-discovery.md
+++ b/docs/task-agent-discovery.md
@@ -27,7 +27,7 @@ It covers runtime behavior as implemented today, including precedence, invalid-d
 Task agents normalize into `AgentDefinition` (`src/task/types.ts`):
 
 - required `name`, `description`, and `systemPrompt`
-- optional `tools`, `spawns`, prioritized `model` list, `thinkingLevel`, `output`, `blocking`, `autoloadSkills`, `readSummarize`, `prewalk`, `advisor`
+- optional `tools`, `spawns`, prioritized `model` list, `thinkingLevel`, `output`, `blocking`, `autoloadSkills`, `readSummarize`, `prewalk`, `advisor`, `inheritBasePrompt`
 - `source`: `"bundled" | "user" | "project"` (extension agents are tagged with their extension root's project/user level)
 - optional `filePath`
 
@@ -108,6 +108,16 @@ modelRoles:
 
 The `vibe_spawn` `cli` remains `fast` or `good`; update `modelRoles` to change the worker model.
 
+### Prompt inheritance
+
+Subagents normally retain the generic interactive base prompt, then add their agent-specific role and task context before the final project/current-context segment. An agent can set:
+
+```yaml
+inheritBasePrompt: false
+```
+
+This removes only the first generic base-prompt segment. The agent prompt, task `context`, project context, current-context segments, selected tool schemas, and output schema remain. Use it for focused local agents with a complete role prompt; do not use it to compensate for an underspecified agent or task assignment.
+
 ## Bundled agents
 
 Bundled agents are embedded at build time (`src/task/agents.ts`) using text imports.
@@ -116,6 +126,8 @@ Bundled agents are embedded at build time (`src/task/agents.ts`) using text impo
 
 - `scout`, `designer`, `reviewer`, `security-reviewer`, and `librarian` from prompt files
 - `task` and `sonic` from the shared `task.md` body plus injected frontmatter; no bundled agent sets `prewalk` — the generic `task` agent's hand-off is armed by the `task.prewalk` setting (default off), or per agent via `/agents` / `task.agentPrewalk` / user agent frontmatter
+
+The focused worker agents `scout`, `task`, and `sonic` set `inheritBasePrompt: false`; their complete agent contracts, project context, task context, tool schemas, and output schemas remain.
 
 Loading path:
 

--- a/packages/coding-agent/src/cli/agents-cli.ts
+++ b/packages/coding-agent/src/cli/agents-cli.ts
@@ -64,6 +64,7 @@ function toFrontmatter(agent: AgentDefinition): Record<string, unknown> {
 	if (agent.thinkingLevel) frontmatter.thinkingLevel = agent.thinkingLevel;
 	if (agent.output !== undefined) frontmatter.output = agent.output;
 	if (agent.blocking) frontmatter.blocking = true;
+	if (agent.inheritBasePrompt === false) frontmatter.inheritBasePrompt = false;
 
 	return frontmatter;
 }

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -247,6 +247,7 @@ export interface ParsedAgentFields {
 	prewalk?: boolean | string;
 	/** `true` = advise with the default advisor-role model; string = advise with that model pattern. */
 	advisor?: boolean | string;
+	inheritBasePrompt?: boolean;
 }
 
 /**
@@ -313,6 +314,7 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 		const trimmed = frontmatter.advisor.trim();
 		if (trimmed) advisor = trimmed;
 	}
+	const inheritBasePrompt = parseBoolean(frontmatter.inheritBasePrompt);
 	const autoloadSkills = parseArrayOrCSV(frontmatter.autoloadSkills)
 		?.map(s => s.trim())
 		.filter(Boolean);
@@ -329,6 +331,7 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 		readSummarize,
 		prewalk,
 		advisor,
+		inheritBasePrompt,
 	};
 }
 

--- a/packages/coding-agent/src/prompts/agents/frontmatter.md
+++ b/packages/coding-agent/src/prompts/agents/frontmatter.md
@@ -8,6 +8,7 @@ description: {{jsonStringify description}}
 {{/if}}{{#if blocking}}blocking: true
 {{/if}}{{#if prewalk}}prewalk: {{jsonStringify prewalk}}
 {{/if}}{{#if advisor}}advisor: {{jsonStringify advisor}}
+{{/if}}{{#if omitBasePrompt}}inheritBasePrompt: false
 {{/if}}{{#if autoloadSkills}}autoloadSkills: {{jsonStringify autoloadSkills}}
 {{/if}}---
 {{body}}

--- a/packages/coding-agent/src/prompts/agents/scout.md
+++ b/packages/coding-agent/src/prompts/agents/scout.md
@@ -5,6 +5,7 @@ tools: read, grep, glob, web_search
 model: "@smol"
 thinking-level: medium
 read-summarize: false
+inheritBasePrompt: false
 output:
   properties:
     summary:

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -28,6 +28,7 @@ interface AgentFrontmatter {
 	blocking?: boolean;
 	prewalk?: boolean | string;
 	advisor?: boolean | string;
+	inheritBasePrompt?: boolean;
 }
 
 interface EmbeddedAgentDef {
@@ -39,7 +40,11 @@ interface EmbeddedAgentDef {
 function buildAgentContent(def: EmbeddedAgentDef): string {
 	const body = prompt.render(def.template);
 	if (!def.frontmatter) return body;
-	return prompt.render(agentFrontmatterTemplate, { ...def.frontmatter, body });
+	return prompt.render(agentFrontmatterTemplate, {
+		...def.frontmatter,
+		omitBasePrompt: def.frontmatter.inheritBasePrompt === false,
+		body,
+	});
 }
 
 const EMBEDDED_AGENT_DEFS: EmbeddedAgentDef[] = [
@@ -56,6 +61,7 @@ const EMBEDDED_AGENT_DEFS: EmbeddedAgentDef[] = [
 			spawns: "*",
 			model: "@task",
 			thinkingLevel: AUTO_THINKING,
+			inheritBasePrompt: false,
 			// No `prewalk` frontmatter: the generic task hand-off (strong model
 			// plans, then hands off to the smol role) is armed by the
 			// `task.prewalk` setting (default off) or per agent via /agents
@@ -70,6 +76,7 @@ const EMBEDDED_AGENT_DEFS: EmbeddedAgentDef[] = [
 			description: "Low-reasoning agent for strictly mechanical updates or data collection only",
 			model: "@smol",
 			thinkingLevel: Effort.Medium,
+			inheritBasePrompt: false,
 		},
 		template: taskMd,
 	},

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3099,9 +3099,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
 						ircSelfId: ircEnabled ? id : "",
 					});
-					return defaultPrompt.length === 0
+					// `inheritBasePrompt: false` drops the interactive harness prompt (entry 0)
+					// and keeps only project context plus the subagent contract.
+					const inheritedPrompt = agent.inheritBasePrompt === false ? defaultPrompt.slice(1) : defaultPrompt;
+					return inheritedPrompt.length === 0
 						? [subagentPrompt]
-						: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
+						: [...inheritedPrompt.slice(0, -1), subagentPrompt, inheritedPrompt[inheritedPrompt.length - 1]];
 				},
 				sessionManager: sessionManagerForRun,
 				hasUI: false,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -366,6 +366,12 @@ export interface AgentDefinition {
 	thinkingLevel?: ConfiguredThinkingLevel;
 	output?: unknown;
 	blocking?: boolean;
+	/**
+	 * Whether to retain the generic interactive base prompt.
+	 * Set false for focused agents whose own prompt and tool schemas provide the required contract.
+	 * Project context and later prompt segments are still retained.
+	 */
+	inheritBasePrompt?: boolean;
 	autoloadSkills?: string[];
 	/** When `false`, the agent's `read` tool returns verbatim file content instead of structural summaries. */
 	readSummarize?: boolean;

--- a/packages/coding-agent/test/discovery/agent-fields.test.ts
+++ b/packages/coding-agent/test/discovery/agent-fields.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { parseAgentFields } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { getBundledAgent } from "@oh-my-pi/pi-coding-agent/task/agents";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 
 describe("parseAgentFields", () => {
@@ -36,6 +37,29 @@ describe("parseAgentFields", () => {
 		expect(fields).toBeDefined();
 		expect(fields?.blocking).toBeUndefined();
 	});
+
+	test("parses inheritBasePrompt from boolean frontmatter", () => {
+		const fields = parseAgentFields({
+			name: "explore",
+			description: "desc",
+			inheritBasePrompt: false,
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.inheritBasePrompt).toBe(false);
+	});
+
+	test("ignores invalid inheritBasePrompt values", () => {
+		const fields = parseAgentFields({
+			name: "explore",
+			description: "desc",
+			inheritBasePrompt: "minimal",
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.inheritBasePrompt).toBeUndefined();
+	});
+
 	test("parses legacy thinking key", () => {
 		const fields = parseAgentFields({
 			name: "reviewer",
@@ -197,5 +221,11 @@ describe("parseAgentFields", () => {
 		);
 		expect(parseAgentFields({ name: "worker", description: "desc", advisor: "  " })?.advisor).toBeUndefined();
 		expect(parseAgentFields({ name: "worker", description: "desc" })?.advisor).toBeUndefined();
+	});
+});
+
+describe("bundled prompt inheritance", () => {
+	test.each(["scout", "task", "sonic"])("%s omits the interactive base prompt", name => {
+		expect(getBundledAgent(name)?.inheritBasePrompt).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -243,6 +243,39 @@ describe("runSubprocess yield reminders", () => {
 		expect(userPrompt).not.toMatch(/CONTEXT\n=+/);
 	});
 
+	it("can omit the interactive base prompt while retaining project and current context", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-lean-system",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			agent: { ...baseOptions.agent, inheritBasePrompt: false },
+			id: "subagent-lean-system",
+		});
+
+		const systemPromptBuilder = createAgentSessionSpy.mock.calls[0]?.[0]?.systemPrompt;
+		expect(systemPromptBuilder).toBeFunction();
+		if (typeof systemPromptBuilder !== "function") throw new Error("Expected system prompt builder");
+
+		const systemPrompt = systemPromptBuilder(["interactive", "project", "now"]);
+		expect(systemPrompt).toHaveLength(3);
+		expect(systemPrompt).not.toContain("interactive");
+		expect(systemPrompt?.[0]).toBe("project");
+		expect(systemPrompt?.[1]).toContain(baseAgent.systemPrompt);
+		expect(systemPrompt?.[2]).toBe("now");
+	});
+
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];
 		const promptOptions: Array<PromptOptions | undefined> = [];


### PR DESCRIPTION
## Problem

Every delegated subagent inherits the full interactive base prompt. On a local/self-hosted backend with a 32k window that is most of the budget before any work starts: measured on this workstation, a `scout`-shaped subagent spends **12,601 prompt tokens** with `--no-tools --no-skills --no-rules --no-extensions`, and two concurrent scouts alone reserve ~38k against a shared backend context budget, producing mid-stream `Context size has been exceeded` failures.

`NULL_PROMPT=true` already removes the base prompt, but it is process-global (`buildSystemPrompt` reads `$env.NULL_PROMPT`), so it cannot be scoped to delegated work — setting it on an interactive parent also strips that session's safety and repository instructions.

## Change

Adds an opt-out per agent instead of per process:

- `inheritBasePrompt?: boolean` on `AgentDefinition` / agent frontmatter, parsed in `parseAgentFields()` (booleans only; invalid values ignored).
- `runSubprocess()` drops entry 0 (the interactive harness prompt) when `inheritBasePrompt === false`, and keeps the project context, the rendered subagent role prompt, and the trailing `now` section. Tool schemas, task context, and output schemas are untouched.
- Frontmatter template round-trips the flag, so `omp agents unpack` emits `inheritBasePrompt: false` and re-parses identically.
- Bundled focused workers `scout`, `task`, and `sonic` set it. `designer`, `reviewer`, `security-reviewer`, and `librarian` keep the base prompt.

Measured: `1,668` vs `12,601` prompt tokens for the equivalent lean scout invocation (87% reduction), which fits two concurrent scouts inside a 32k backend budget.

## Tests

- `packages/coding-agent/test/discovery/agent-fields.test.ts` - parses/ignores `inheritBasePrompt`; asserts the three bundled workers set it.
- `packages/coding-agent/test/task/executor-subagent-reminders.test.ts` - asserts the built system prompt omits the interactive entry while retaining project context, role prompt, and `now`.

`bun test` on both files: 51 pass. `biome check` and `check:types` clean on the touched files.