### PR TITLE
fix(session): refuse text-only stop while todos remain open

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Compaction summaries now keep an Incomplete Todos section so pending/in_progress items survive the cut.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Compaction summaries now keep an Incomplete Todos section so pending/in_progress items survive the cut.
+- Compaction summaries now keep an Incomplete Todos section so pending/in_progress items survive the cut. The section is a clean output heading; preserve-don't-mark-done lives in the instruction prose.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/agent/src/compaction/prompts/compaction-summary.md
+++ b/packages/agent/src/compaction/prompts/compaction-summary.md
@@ -2,6 +2,8 @@ You MUST summarize the conversation above into a structured handoff summary for 
 
 IMPORTANT: If the conversation ends with an unanswered question or a request awaiting user response (e.g., "Please run command and paste output"), you MUST preserve that exact question/request.
 
+Preserve pending/in_progress items from additional-context and the conversation in Incomplete Todos; do not mark them done.
+
 You MUST use this format (sections can be omitted if not applicable):
 
 ## Goal
@@ -28,7 +30,7 @@ You MUST use this format (sections can be omitted if not applicable):
 1. [Ordered list of next actions]
 
 ## Incomplete Todos
-- [ ] [Preserve pending/in_progress items from additional-context and the conversation; do not mark them done]
+[pending/in_progress items only]
 
 ## Critical Context
 - [Important data, pending questions, references]

--- a/packages/agent/src/compaction/prompts/compaction-summary.md
+++ b/packages/agent/src/compaction/prompts/compaction-summary.md
@@ -27,6 +27,9 @@ You MUST use this format (sections can be omitted if not applicable):
 ## Next Steps
 1. [Ordered list of next actions]
 
+## Incomplete Todos
+- [ ] [Preserve pending/in_progress items from additional-context and the conversation; do not mark them done]
+
 ## Critical Context
 - [Important data, pending questions, references]
 

--- a/packages/agent/src/compaction/prompts/compaction-update-summary.md
+++ b/packages/agent/src/compaction/prompts/compaction-update-summary.md
@@ -37,6 +37,9 @@ Format (omit inapplicable sections):
 ## Next Steps
 1. [Update based on current state]
 
+## Incomplete Todos
+- [ ] [Preserve pending/in_progress items from additional-context and the conversation; do not mark them done]
+
 ## Critical Context
 - [Preserve important context; add new if needed]
 

--- a/packages/agent/src/compaction/prompts/compaction-update-summary.md
+++ b/packages/agent/src/compaction/prompts/compaction-update-summary.md
@@ -11,6 +11,7 @@ MUST:
 - keep sections concise.
 - preserve relevant tool outputs/command results.
 - include mentioned repository state changes (branch, uncommitted changes).
+- preserve pending/in_progress items from additional-context and the conversation in Incomplete Todos; do not mark them done.
 
 Format (omit inapplicable sections):
 
@@ -38,7 +39,7 @@ Format (omit inapplicable sections):
 1. [Update based on current state]
 
 ## Incomplete Todos
-- [ ] [Preserve pending/in_progress items from additional-context and the conversation; do not mark them done]
+[pending/in_progress items only]
 
 ## Critical Context
 - [Preserve important context; add new if needed]

--- a/packages/agent/test/compaction-summary-cap.test.ts
+++ b/packages/agent/test/compaction-summary-cap.test.ts
@@ -96,4 +96,18 @@ describe("compaction summary output budget", () => {
 		await generateSummary(messages, getModel(), 10_000, "test-key");
 		expect(spy.mock.calls[0]?.[2]?.maxTokens).toBe(8_000);
 	});
+
+	test("includes extraContext in the summarizer prompt", async () => {
+		const spy = vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("summary"));
+		await generateSummary(messages, getModel(), 10_000, "test-key", undefined, undefined, undefined, {
+			extraContext: [
+				"Incomplete todos that MUST survive compaction (pending/in_progress only; a text-only stop is not completion):",
+				"[Work] [pending] do the thing",
+			],
+		});
+		const promptText = JSON.stringify(spy.mock.calls[0]?.[1]);
+		expect(promptText).toContain("<additional-context>");
+		expect(promptText).toContain("[Work] [pending] do the thing");
+		expect(promptText).toContain("## Incomplete Todos");
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after snapcompact auto-continue and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)).
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (capped leftover list on a non-user snapshot plus a standing summary section that rewrites when the live list changes), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)). A skipped post-budget continue no longer leaves a forced `todo` tool_choice queued for the next user turn; Google models can use the `"required"` hatch; leftover pending/in_progress items reconstruct from the compaction `## Incomplete Todos` section after the last todo result is summarized away; and a fake-complete slogan with a trailing question still reminds.
+- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (capped leftover list on a non-user snapshot plus a standing summary section that rewrites when the live list changes), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)). A skipped post-budget continue no longer leaves a forced `todo` tool_choice queued for the next user turn; Google models pin the named `todo` tool instead of a generic `"required"` hatch; leftover pending/in_progress items reconstruct from the compaction `## Incomplete Todos` section (including a heading with a trailing colon or extra text) after the last todo result is summarized away; and a completion claim with a trailing question still reminds.
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after snapcompact auto-continue and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)).
+- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (incomplete list is now part of the summarizer input), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)).
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (incomplete list is now part of the summarizer input), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)).
+- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (capped leftover list on a non-user snapshot plus a standing summary section that rewrites when the live list changes), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)).
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (capped leftover list on a non-user snapshot plus a standing summary section that rewrites when the live list changes), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)).
+- Fixed a text-only `stop` being treated as a terminal turn while todos were still `pending` or `in_progress`, including after the reminder budget, snapcompact/LLM compaction (capped leftover list on a non-user snapshot plus a standing summary section that rewrites when the live list changes), and thinking-loop recovery ([#8874](https://github.com/can1357/oh-my-pi/issues/8874)). A skipped post-budget continue no longer leaves a forced `todo` tool_choice queued for the next user turn; Google models can use the `"required"` hatch; leftover pending/in_progress items reconstruct from the compaction `## Incomplete Todos` section after the last todo result is summarized away; and a fake-complete slogan with a trailing question still reminds.
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/coding-agent/src/prompts/system/auto-continue.md
+++ b/packages/coding-agent/src/prompts/system/auto-continue.md
@@ -1,1 +1,1 @@
-Resume the user's latest intent. Re-read kept recent messages above the summary to confirm the latest request. If it supersedes earlier plans in the summary, follow it. If no work remains, say so briefly; do not invent work.
+Resume the user's latest intent. Re-read kept recent messages above the summary to confirm the latest request. If it supersedes earlier plans in the summary, follow it.{{#unless hasOpenTodos}} If no work remains, say so briefly; do not invent work.{{/unless}}

--- a/packages/coding-agent/src/prompts/system/post-compaction-incomplete-todos.md
+++ b/packages/coding-agent/src/prompts/system/post-compaction-incomplete-todos.md
@@ -6,4 +6,6 @@ These incomplete todos remain after compaction. Continue them; do not treat the 
   - [{{status}}] {{content}}
 {{/each}}
 {{/each}}
+{{#if overflow}}+ {{overflow}} more
+{{/if}}
 </system-reminder>

--- a/packages/coding-agent/src/prompts/system/post-compaction-incomplete-todos.md
+++ b/packages/coding-agent/src/prompts/system/post-compaction-incomplete-todos.md
@@ -1,0 +1,9 @@
+<system-reminder>
+These incomplete todos remain after compaction. Continue them; do not treat the summary or a text-only stop as completion.
+{{#each phases}}
+- {{name}}
+{{#each tasks}}
+  - [{{status}}] {{content}}
+{{/each}}
+{{/each}}
+</system-reminder>

--- a/packages/coding-agent/src/prompts/system/thinking-loop-redirect.md
+++ b/packages/coding-agent/src/prompts/system/thinking-loop-redirect.md
@@ -4,7 +4,7 @@ Loop guard interrupted prior turn: near-identical reasoning or response repeated
 Repeating the same plan, summary, or intention loops again. Break pattern now:
 - STOP narrating intended actions. Issue one concrete normal-format tool call: smallest real next step.
 - Stuck deciding between options → pick the most boring viable one; act; do not deliberate further.
-- Task genuinely complete → emit final answer, not more reasoning.
-
+{{#unless hasOpenTodos}}- Task genuinely complete → emit final answer, not more reasoning.
+{{/unless}}
 Do something different from looped content. Act, don't re-plan.
 </system-interrupt>

--- a/packages/coding-agent/src/prompts/tools/todo.md
+++ b/packages/coding-agent/src/prompts/tools/todo.md
@@ -25,6 +25,7 @@ Each completion: earliest still-open task (phase order) auto-promotes to `in_pro
 ## Rules
 
 - Mark tasks done immediately after finishing; complete phases in order.
+- If items are pending and none are in_progress, mark one in_progress before continuing.
 - NEVER make a todo call the turn's only tool call. Batch with real work: `init` with first reads/edits; each `done`/`start` with next action. Solo todo turns waste a round trip.
 - Waiting on something you can't act on—a user decision, another agent, external service: `block` task (optional `reason`); remains tracked but avoids stop reminder. `unblock` when actionable. If blocker agent-actionable, `append` an unblocking task instead.
 - Keep introduced `task`/`phase` strings stable.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1105,6 +1105,7 @@ export class AgentSession {
 			runAutoCompaction: (reason, willRetry, deferred, allowDefer, options) =>
 				this.#maintenance.runAutoCompaction(reason, willRetry, deferred, allowDefer, options),
 			withBashBranchTransition: operation => this.#bash.withBranchTransition(operation),
+			hasOpenActionableTodos: () => this.#todo.hasOpenActionableTodos(),
 		};
 		this.#recovery = new TurnRecovery(recoveryHost, { initialRetryFallback: config.initialRetryFallback });
 		this.#detachUsageBeforeQueueDequeue = this.agent.addBeforeQueuedMessageDequeueHook(async signal => {
@@ -3287,14 +3288,17 @@ export class AgentSession {
 			// at invocation (past the abort check below), so an aborted continuation queues
 			// nothing; scoped to this request via prependMessages, never the shared queue.
 			const eagerNudges = this.#todo.buildPostCompactionEagerNudges();
+			const continueText = prompt.render(autoContinuePrompt, {
+				hasOpenTodos: this.#todo.hasOpenActionableTodos(),
+			});
 			await this.#promptWithMessage(
 				{
 					role: "developer",
-					content: [{ type: "text", text: autoContinuePrompt }],
+					content: [{ type: "text", text: continueText }],
 					attribution: "agent",
 					timestamp: Date.now(),
 				},
-				autoContinuePrompt,
+				continueText,
 				{
 					skipPostPromptRecoveryWait: true,
 					prependMessages: eagerNudges.length > 0 ? eagerNudges : undefined,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1040,15 +1040,20 @@ export class AgentSession {
 			planModeEnabled: () => this.#planModeState?.enabled === true,
 			consumeLastServedToolChoiceLabel: () => this.#toolChoiceQueue.consumeLastServedLabel(),
 			forceTodoToolChoice: () => {
-				// Post-budget escape hatch. Named tool_choice only; a string/"required"
-				// result is not a named todo force. checkCompletion still appends the
-				// text reminder and continues when this returns false.
+				// Post-budget escape hatch. Named tool_choice, or Google's string
+				// "required" (buildNamedToolChoice cannot name a Gemini tool).
+				// checkCompletion still appends the text reminder and continues when
+				// this returns false.
 				if (!this.getActiveToolNames().includes("todo")) return false;
 				const forced = buildNamedToolChoice("todo", this.model);
-				if (!forced || typeof forced === "string") return false;
+				if (!forced) return false;
+				if (typeof forced === "string" && forced !== "required") return false;
 				this.#toolChoiceQueue.removeByLabel("todo-escape");
 				this.#toolChoiceQueue.pushOnce(forced, { label: "todo-escape" });
 				return true;
+			},
+			clearForcedTodoToolChoice: () => {
+				this.#toolChoiceQueue.removeByLabel("todo-escape");
 			},
 		};
 		this.#todo = new TodoTracker(todoHost);
@@ -5376,6 +5381,7 @@ export class AgentSession {
 			// A user turn owns the next decision; drop a queued forced choice from
 			// a reminder continuation this prompt just preempted.
 			this.#toolChoiceQueue.removeByLabel("plan-mode-decision");
+			this.#toolChoiceQueue.removeByLabel("todo-escape");
 		}
 
 		// If streaming, queue via steer() or followUp() based on option

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1040,6 +1040,9 @@ export class AgentSession {
 			planModeEnabled: () => this.#planModeState?.enabled === true,
 			consumeLastServedToolChoiceLabel: () => this.#toolChoiceQueue.consumeLastServedLabel(),
 			forceTodoToolChoice: () => {
+				// Post-budget escape hatch. Named tool_choice only; a string/"required"
+				// result is not a named todo force. checkCompletion still appends the
+				// text reminder and continues when this returns false.
 				if (!this.getActiveToolNames().includes("todo")) return false;
 				const forced = buildNamedToolChoice("todo", this.model);
 				if (!forced || typeof forced === "string") return false;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1039,6 +1039,14 @@ export class AgentSession {
 			toolRegistry: () => this.#tools.registry,
 			planModeEnabled: () => this.#planModeState?.enabled === true,
 			consumeLastServedToolChoiceLabel: () => this.#toolChoiceQueue.consumeLastServedLabel(),
+			forceTodoToolChoice: () => {
+				if (!this.getActiveToolNames().includes("todo")) return false;
+				const forced = buildNamedToolChoice("todo", this.model);
+				if (!forced || typeof forced === "string") return false;
+				this.#toolChoiceQueue.removeByLabel("todo-escape");
+				this.#toolChoiceQueue.pushOnce(forced, { label: "todo-escape" });
+				return true;
+			},
 		};
 		this.#todo = new TodoTracker(todoHost);
 		this.#ownedAsyncJobManager = config.ownedAsyncJobManager;
@@ -1549,6 +1557,8 @@ export class AgentSession {
 				this.#planReferenceSent = false;
 			},
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
+			incompleteTodosCompactionContext: () => this.#todo.buildIncompleteTodosCompactionContext(),
+			appendIncompleteTodosToCompactionSummary: summary => this.#todo.appendIncompleteTodosToSummary(summary),
 			resetAdvisorRuntimes: (reason?: string) => this.#advisors.resetAllRuntimes(reason),
 			rebaseAfterCompaction: () => this.#stats.rebaseAfterCompaction(),
 			recordAnchoredHistoryRewrite: tokensRemoved => this.#stats.recordAnchoredHistoryRewrite(tokensRemoved),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1040,14 +1040,14 @@ export class AgentSession {
 			planModeEnabled: () => this.#planModeState?.enabled === true,
 			consumeLastServedToolChoiceLabel: () => this.#toolChoiceQueue.consumeLastServedLabel(),
 			forceTodoToolChoice: () => {
-				// Post-budget escape hatch. Named tool_choice, or Google's string
-				// "required" (buildNamedToolChoice cannot name a Gemini tool).
-				// checkCompletion still appends the text reminder and continues when
-				// this returns false.
+				// Post-budget escape hatch. Only a named tool_choice pins `todo`.
+				// Google can name it (`{ type: "tool", name }`); a string
+				// `"required"` would let the model call any tool and then
+				// text-only stop again, so do not queue it. checkCompletion still
+				// appends the hatch text and continues when this returns false.
 				if (!this.getActiveToolNames().includes("todo")) return false;
 				const forced = buildNamedToolChoice("todo", this.model);
-				if (!forced) return false;
-				if (typeof forced === "string" && forced !== "required") return false;
+				if (!forced || typeof forced === "string") return false;
 				this.#toolChoiceQueue.removeByLabel("todo-escape");
 				this.#toolChoiceQueue.pushOnce(forced, { label: "todo-escape" });
 				return true;

--- a/packages/coding-agent/src/session/incomplete-todos.ts
+++ b/packages/coding-agent/src/session/incomplete-todos.ts
@@ -1,0 +1,126 @@
+import type { TodoPhase } from "../tools/todo";
+
+/** Cap leftover-todo dumps so a huge list cannot overflow every compact. */
+export const INCOMPLETE_TODOS_SNAPSHOT_CAP = 40;
+const INCOMPLETE_TODOS_HEADING = "## Incomplete Todos";
+
+export interface IncompleteTodoRow {
+	phase: string;
+	status: "pending" | "in_progress";
+	title: string;
+}
+
+export interface CappedIncompleteTodos {
+	rows: IncompleteTodoRow[];
+	overflow: number;
+}
+
+/** Flatten pending/in_progress items as phase + status + title rows. */
+export function collectIncompleteTodoRows(phases: readonly TodoPhase[]): IncompleteTodoRow[] {
+	const rows: IncompleteTodoRow[] = [];
+	for (const phase of phases) {
+		for (const task of phase.tasks) {
+			if (task.status !== "pending" && task.status !== "in_progress") continue;
+			rows.push({ phase: phase.name, status: task.status, title: task.content });
+		}
+	}
+	return rows;
+}
+
+/** Keep the first `cap` rows and report how many were omitted. */
+export function capIncompleteTodoRows(
+	rows: readonly IncompleteTodoRow[],
+	cap = INCOMPLETE_TODOS_SNAPSHOT_CAP,
+): CappedIncompleteTodos {
+	if (rows.length <= cap) return { rows: [...rows], overflow: 0 };
+	return { rows: rows.slice(0, cap), overflow: rows.length - cap };
+}
+
+/** Snapshot lines: `[phase] [status] title`, plus `+ N more` when capped. */
+export function formatIncompleteTodoSnapshotLines(
+	rows: readonly IncompleteTodoRow[],
+	cap = INCOMPLETE_TODOS_SNAPSHOT_CAP,
+): string[] {
+	const capped = capIncompleteTodoRows(rows, cap);
+	const lines = capped.rows.map(row => `[${row.phase}] [${row.status}] ${row.title}`);
+	if (capped.overflow > 0) lines.push(`+ ${capped.overflow} more`);
+	return lines;
+}
+
+/** Group capped rows back into phase lists for markdown / prompt rendering. */
+export function groupIncompleteTodoRowsByPhase(rows: readonly IncompleteTodoRow[]): Array<{
+	name: string;
+	tasks: Array<{ content: string; status: "pending" | "in_progress" }>;
+}> {
+	const phases: Array<{
+		name: string;
+		tasks: Array<{ content: string; status: "pending" | "in_progress" }>;
+	}> = [];
+	for (const row of rows) {
+		const last = phases.at(-1);
+		if (last?.name === row.phase) {
+			last.tasks.push({ content: row.title, status: row.status });
+			continue;
+		}
+		phases.push({ name: row.phase, tasks: [{ content: row.title, status: row.status }] });
+	}
+	return phases;
+}
+
+/** Standing summary section, or undefined when nothing remains. */
+export function formatIncompleteTodosSection(
+	rows: readonly IncompleteTodoRow[],
+	cap = INCOMPLETE_TODOS_SNAPSHOT_CAP,
+): string | undefined {
+	const capped = capIncompleteTodoRows(rows, cap);
+	if (capped.rows.length === 0) return undefined;
+	const phases = groupIncompleteTodoRowsByPhase(capped.rows);
+	const lines = [
+		INCOMPLETE_TODOS_HEADING,
+		"These pending/in_progress items remain after compaction; continue them. A text-only stop is not completion.",
+		...phases.flatMap(phase => [
+			`- ${phase.name}`,
+			...phase.tasks.map(task => `  - [${task.status}] ${task.content}`),
+		]),
+	];
+	if (capped.overflow > 0) lines.push(`- + ${capped.overflow} more`);
+	return lines.join("\n");
+}
+
+/**
+ * Replace a stale `## Incomplete Todos` section with `block`, or strip it when
+ * `block` is undefined. The next ATX heading (`## `) ends the section.
+ */
+export function upsertIncompleteTodosSection(summary: string, block: string | undefined): string {
+	const split = splitIncompleteTodosSection(summary);
+	if (!split) {
+		if (!block) return summary;
+		const trimmed = summary.trimEnd();
+		return trimmed.length === 0 ? `${block}\n` : `${trimmed}\n\n${block}\n`;
+	}
+	if (!block) {
+		if (split.before.length === 0) return split.after.length === 0 ? "" : `${split.after}\n`;
+		if (split.after.length === 0) return `${split.before}\n`;
+		return `${split.before}\n\n${split.after}\n`;
+	}
+	if (split.before.length === 0) {
+		return split.after.length === 0 ? `${block}\n` : `${block}\n\n${split.after}\n`;
+	}
+	if (split.after.length === 0) return `${split.before}\n\n${block}\n`;
+	return `${split.before}\n\n${block}\n\n${split.after}\n`;
+}
+
+function splitIncompleteTodosSection(summary: string): { before: string; after: string } | undefined {
+	const headingRe = /^## Incomplete Todos[ \t]*$/m;
+	const match = headingRe.exec(summary);
+	if (!match) return undefined;
+	const start = match.index;
+	const afterHeading = start + match[0].length;
+	const rest = summary.slice(afterHeading);
+	const nextHeading = /^## /m.exec(rest);
+	const end = nextHeading ? afterHeading + nextHeading.index : summary.length;
+	return {
+		before: summary.slice(0, start).trimEnd(),
+		after: summary.slice(end).replace(/^\n+/, "").trimEnd(),
+	};
+}

--- a/packages/coding-agent/src/session/incomplete-todos.ts
+++ b/packages/coding-agent/src/session/incomplete-todos.ts
@@ -110,7 +110,7 @@ export function upsertIncompleteTodosSection(summary: string, block: string | un
 	return `${split.before}\n\n${block}\n\n${split.after}\n`;
 }
 
-function splitIncompleteTodosSection(summary: string): { before: string; after: string } | undefined {
+function splitIncompleteTodosSection(summary: string): { before: string; body: string; after: string } | undefined {
 	const headingRe = /^## Incomplete Todos[ \t]*$/m;
 	const match = headingRe.exec(summary);
 	if (!match) return undefined;
@@ -121,6 +121,37 @@ function splitIncompleteTodosSection(summary: string): { before: string; after: 
 	const end = nextHeading ? afterHeading + nextHeading.index : summary.length;
 	return {
 		before: summary.slice(0, start).trimEnd(),
+		body: summary.slice(start, end).trim(),
 		after: summary.slice(end).replace(/^\n+/, "").trimEnd(),
 	};
+}
+
+const INCOMPLETE_TODO_TASK_RE = /^\s+- \[(pending|in_progress)\] (.+)$/;
+const INCOMPLETE_TODO_PHASE_RE = /^- (.+)$/;
+const INCOMPLETE_TODO_OVERFLOW_RE = /^- \+ \d+ more$/;
+
+/**
+ * Reconstruct leftover pending/in_progress phases from a compaction summary's
+ * standing `## Incomplete Todos` section. Used after the latest todo toolResult
+ * has been summarized away.
+ */
+export function parseIncompleteTodosFromSummary(summary: string): TodoPhase[] {
+	const split = splitIncompleteTodosSection(summary);
+	if (!split) return [];
+	const phases: TodoPhase[] = [];
+	for (const line of split.body.split(/\r?\n/)) {
+		if (line === INCOMPLETE_TODOS_HEADING || INCOMPLETE_TODO_OVERFLOW_RE.test(line)) continue;
+		const task = INCOMPLETE_TODO_TASK_RE.exec(line);
+		if (task) {
+			const last = phases.at(-1);
+			if (!last) continue;
+			last.tasks.push({ content: task[2], status: task[1] as "pending" | "in_progress" });
+			continue;
+		}
+		const phase = INCOMPLETE_TODO_PHASE_RE.exec(line);
+		if (phase && !INCOMPLETE_TODO_OVERFLOW_RE.test(line)) {
+			phases.push({ name: phase[1], tasks: [] });
+		}
+	}
+	return phases.filter(phase => phase.tasks.length > 0);
 }

--- a/packages/coding-agent/src/session/incomplete-todos.ts
+++ b/packages/coding-agent/src/session/incomplete-todos.ts
@@ -3,6 +3,8 @@ import type { TodoPhase } from "../tools/todo";
 /** Cap leftover-todo dumps so a huge list cannot overflow every compact. */
 export const INCOMPLETE_TODOS_SNAPSHOT_CAP = 40;
 const INCOMPLETE_TODOS_HEADING = "## Incomplete Todos";
+/** Exact h2, or the same heading with a trailing colon / extra text. */
+const INCOMPLETE_TODOS_HEADING_RE = /^## Incomplete Todos(?:[ \t]*:.*|[ \t]+.+)?[ \t]*$/m;
 
 export interface IncompleteTodoRow {
 	phase: string;
@@ -111,8 +113,7 @@ export function upsertIncompleteTodosSection(summary: string, block: string | un
 }
 
 function splitIncompleteTodosSection(summary: string): { before: string; body: string; after: string } | undefined {
-	const headingRe = /^## Incomplete Todos[ \t]*$/m;
-	const match = headingRe.exec(summary);
+	const match = INCOMPLETE_TODOS_HEADING_RE.exec(summary);
 	if (!match) return undefined;
 	const start = match.index;
 	const afterHeading = start + match[0].length;
@@ -140,7 +141,7 @@ export function parseIncompleteTodosFromSummary(summary: string): TodoPhase[] {
 	if (!split) return [];
 	const phases: TodoPhase[] = [];
 	for (const line of split.body.split(/\r?\n/)) {
-		if (line === INCOMPLETE_TODOS_HEADING || INCOMPLETE_TODO_OVERFLOW_RE.test(line)) continue;
+		if (INCOMPLETE_TODOS_HEADING_RE.test(line) || INCOMPLETE_TODO_OVERFLOW_RE.test(line)) continue;
 		const task = INCOMPLETE_TODO_TASK_RE.exec(line);
 		if (task) {
 			const last = phases.at(-1);

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -235,6 +235,10 @@ export interface SessionMaintenanceHost {
 	resetCodexProviderAfterCompaction(compaction: CodexCompactionContext): void;
 	resetPlanReference(): void;
 	syncTodoPhasesFromBranch(): void;
+	/** Live pending/in_progress todo lines for the compaction summarizer input. */
+	incompleteTodosCompactionContext(): string[];
+	/** Keep incomplete todos in the standing compaction summary text. */
+	appendIncompleteTodosToCompactionSummary(summary: string): string;
 	resetAdvisorRuntimes(reason?: string): void;
 	rebaseAfterCompaction(): void;
 	recordAnchoredHistoryRewrite(tokensRemoved: number): void;
@@ -636,7 +640,7 @@ export class SessionMaintenance {
 				compactionCandidates = this.#getCompactionModelCandidates(availableModels);
 			}
 			const pathEntries = this.#host.sessionManager.getBranch();
-			const preparation = prepareCompaction(pathEntries, effectiveSettings, this.#model);
+			let preparation = prepareCompaction(pathEntries, effectiveSettings, this.#model);
 			if (!preparation) {
 				// Check why we can't compact
 				const lastEntry = pathEntries[pathEntries.length - 1];
@@ -670,6 +674,8 @@ export class SessionMaintenance {
 			}
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
+			this.#host.syncTodoPhasesFromBranch();
+			preparation = this.#withIncompleteTodoSnapshot(preparation);
 
 			// Strategy honored on manual /compact too. Custom instructions (public
 			// user focus OR internal plan-mode guidance) imply a directed LLM
@@ -843,7 +849,7 @@ export class SessionMaintenance {
 						compactionAbortController.signal,
 						{
 							promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
-							extraContext: compactionPrep.hookContext,
+							extraContext: this.#compactionExtraContext(compactionPrep.hookContext),
 							remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
 							convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),
 							codexCompaction,
@@ -871,6 +877,7 @@ export class SessionMaintenance {
 				throw new CompactionCancelledError();
 			}
 
+			summary = this.#host.appendIncompleteTodosToCompactionSummary(summary);
 			this.#host.sessionManager.appendCompaction(
 				summary,
 				shortSummary,
@@ -1547,6 +1554,26 @@ export class SessionMaintenance {
 		);
 	}
 
+	#compactionExtraContext(hookContext: string[] | undefined): string[] | undefined {
+		const todoContext = this.#host.incompleteTodosCompactionContext();
+		if (todoContext.length === 0) return hookContext;
+		return [...todoContext, ...(hookContext ?? [])];
+	}
+
+	#withIncompleteTodoSnapshot(preparation: CompactionPreparation): CompactionPreparation {
+		const todoContext = this.#host.incompleteTodosCompactionContext();
+		if (todoContext.length === 0) return preparation;
+		const snapshot: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: `<incomplete-todos>\n${todoContext.join("\n")}\n</incomplete-todos>` }],
+			timestamp: Date.now(),
+		};
+		return {
+			...preparation,
+			messagesToSummarize: [snapshot, ...preparation.messagesToSummarize],
+		};
+	}
+
 	async #compactWithFallbackModel(
 		preparation: CompactionPreparation,
 		customInstructions: string | undefined,
@@ -2111,6 +2138,7 @@ export class SessionMaintenance {
 		const rebuilt = snapcompact.getPreservedArchive(result.preserveData);
 		if (!rebuilt || rebuilt.frames.length >= archive.frames.length) return undefined;
 
+		result.summary = this.#host.appendIncompleteTodosToCompactionSummary(result.summary);
 		const rebuiltEntryId = this.#host.sessionManager.appendCompaction(
 			result.summary,
 			result.shortSummary,
@@ -2518,6 +2546,8 @@ export class SessionMaintenance {
 			}
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
+			this.#host.syncTodoPhasesFromBranch();
+			preparation = this.#withIncompleteTodoSnapshot(preparation);
 
 			let summary: string;
 			let shortSummary: string | undefined;
@@ -2667,7 +2697,7 @@ export class SessionMaintenance {
 								autoCompactionSignal,
 								{
 									promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
-									extraContext: compactionPrep.hookContext,
+									extraContext: this.#compactionExtraContext(compactionPrep.hookContext),
 									remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
 									metadata: this.#host.agent.metadataForProvider(candidate.provider),
 									initiatorOverride: "agent",
@@ -2813,6 +2843,7 @@ export class SessionMaintenance {
 				return COMPACTION_CHECK_NONE;
 			}
 
+			summary = this.#host.appendIncompleteTodosToCompactionSummary(summary);
 			this.#host.sessionManager.appendCompaction(
 				summary,
 				shortSummary,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2141,6 +2141,8 @@ export class SessionMaintenance {
 		const rebuilt = snapcompact.getPreservedArchive(result.preserveData);
 		if (!rebuilt || rebuilt.frames.length >= archive.frames.length) return undefined;
 
+		// Regular compact paths sync before writing leftovers; rescue must too.
+		this.#host.syncTodoPhasesFromBranch();
 		result.summary = this.#host.appendIncompleteTodosToCompactionSummary(result.summary);
 		const rebuiltEntryId = this.#host.sessionManager.appendCompaction(
 			result.summary,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1564,8 +1564,11 @@ export class SessionMaintenance {
 		const todoContext = this.#host.incompleteTodosCompactionContext();
 		if (todoContext.length === 0) return preparation;
 		const snapshot: AgentMessage = {
-			role: "user",
-			content: [{ type: "text", text: `<incomplete-todos>\n${todoContext.join("\n")}\n</incomplete-todos>` }],
+			role: "custom",
+			customType: "incomplete-todos-snapshot",
+			content: `<incomplete-todos>\n${todoContext.join("\n")}\n</incomplete-todos>`,
+			display: false,
+			attribution: "agent",
 			timestamp: Date.now(),
 		};
 		return {

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -60,6 +60,8 @@ export interface TodoTrackerHost {
 	toolRegistry(): Map<string, AgentTool>;
 	planModeEnabled(): boolean;
 	consumeLastServedToolChoiceLabel(): string | undefined;
+	/** Force the next model turn to call the todo tool (post-budget escape hatch). */
+	forceTodoToolChoice(): boolean;
 }
 
 /** Owns canonical todo state, eager preludes, and completion reminders. */
@@ -189,6 +191,46 @@ export class TodoTracker {
 		return this.#incompleteActionableByPhase().some(phase => phase.tasks.length > 0);
 	}
 
+	/**
+	 * Structured incomplete-todo lines for the compaction summarizer input
+	 * (`SummaryOptions.extraContext`), so the contract survives the cut.
+	 */
+	buildIncompleteTodosCompactionContext(): string[] {
+		const incompleteByPhase = this.#incompleteActionableByPhase();
+		if (incompleteByPhase.length === 0) return [];
+		const lines = [
+			"Incomplete todos that MUST survive compaction (pending/in_progress only; a text-only stop is not completion):",
+		];
+		for (const phase of incompleteByPhase) {
+			for (const task of phase.tasks) {
+				lines.push(`[${phase.name}] [${task.status}] ${task.content}`);
+			}
+		}
+		return lines;
+	}
+
+	/**
+	 * Appends the incomplete todo list to a compaction summary so it remains
+	 * durable text after snapcompact/LLM summarization (mirrors file-ops upsert).
+	 */
+	appendIncompleteTodosToSummary(summary: string): string {
+		const incompleteByPhase = this.#incompleteActionableByPhase();
+		if (incompleteByPhase.length === 0) return summary;
+		const block = [
+			"## Incomplete Todos",
+			"These pending/in_progress items remain after compaction; continue them. A text-only stop is not completion.",
+			...incompleteByPhase.flatMap(phase => [
+				`- ${phase.name}`,
+				...phase.tasks.map(task => `  - [${task.status}] ${task.content}`),
+			]),
+		].join("\n");
+		const trimmed = summary.trimEnd();
+		if (trimmed.includes("## Incomplete Todos")) {
+			return `${trimmed}\n`;
+		}
+		return `${trimmed}\n\n${block}\n`;
+	}
+
 	/** Builds reminder-only eager preludes after compaction. */
 	buildPostCompactionEagerNudges(): AgentMessage[] {
 		const nudges: AgentMessage[] = [];
@@ -219,11 +261,6 @@ export class TodoTracker {
 			this.#reminderCount = 0;
 			return false;
 		}
-		const remindersMax = this.#host.settings.get("todo.remindersMax");
-		if (this.#reminderCount >= remindersMax) {
-			logger.debug("Todo completion: max reminders reached", { count: this.#reminderCount });
-			return false;
-		}
 		const incompleteByPhase = this.#incompleteActionableByPhase();
 		const incomplete = incompleteByPhase.flatMap(phase => phase.tasks);
 		if (incomplete.length === 0) {
@@ -242,24 +279,34 @@ export class TodoTracker {
 			});
 			return false;
 		}
-		this.#reminderCount++;
+		const remindersMax = this.#host.settings.get("todo.remindersMax");
+		const pastBudget = this.#reminderCount >= remindersMax;
+		if (!pastBudget) {
+			this.#reminderCount++;
+		}
+		const attempt = pastBudget ? remindersMax : this.#reminderCount;
+		const isEscapeHatch = pastBudget || this.#reminderCount >= remindersMax;
 		const todoList = incompleteByPhase
 			.map(phase => `- ${phase.name}\n${phase.tasks.map(task => `  - [${task.status}] ${task.content}`).join("\n")}`)
 			.join("\n");
+		const actionLine = isEscapeHatch
+			? "Do not close with prose. Mark each remaining item complete, blocked, or abandoned with the todo tool (done / block / drop), then continue real work. A text-only stop is not completion."
+			: "Please continue working on these tasks or mark them complete/blocked/abandoned with the todo tool if finished. A text-only stop is not completion.";
 		const reminder =
 			`<system-reminder>\n` +
 			`You stopped with ${incomplete.length} incomplete todo item(s):\n${todoList}\n\n` +
-			`Please continue working on these tasks or mark them complete with the todo tool if finished. A text-only stop is not completion.\n` +
-			`(Reminder ${this.#reminderCount}/${remindersMax})\n` +
+			`${actionLine}\n` +
+			`(Reminder ${attempt}/${remindersMax}${pastBudget ? "; budget spent — todo tool required" : ""})\n` +
 			`</system-reminder>`;
-		logger.debug("Todo completion: sending reminder", {
+		logger.debug(pastBudget ? "Todo completion: post-budget escape hatch" : "Todo completion: sending reminder", {
 			incomplete: incomplete.length,
-			attempt: this.#reminderCount,
+			attempt,
+			pastBudget,
 		});
 		await this.#host.emitSessionEvent({
 			type: "todo_reminder",
 			todos: incomplete,
-			attempt: this.#reminderCount,
+			attempt,
 			maxAttempts: remindersMax,
 		});
 		const reminderMessage: Message = {
@@ -271,6 +318,9 @@ export class TodoTracker {
 		this.#mutationsSinceLastTouch = 0;
 		this.#host.agent.appendMessage(reminderMessage);
 		this.#host.sessionManager.appendMessage(reminderMessage);
+		if (isEscapeHatch) {
+			this.#host.forceTodoToolChoice();
+		}
 		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
 		return true;
 	}

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -5,6 +5,9 @@ import type { Settings } from "../config/settings";
 import eagerTaskPrompt from "../prompts/system/eager-task.md" with { type: "text" };
 import eagerTodoPrompt from "../prompts/system/eager-todo.md" with { type: "text" };
 import midRunTodoNudgePrompt from "../prompts/system/mid-run-todo-nudge.md" with { type: "text" };
+import postCompactionIncompleteTodosPrompt from "../prompts/system/post-compaction-incomplete-todos.md" with {
+	type: "text",
+};
 import { getLatestTodoPhasesFromEntries, isTodoPhase, type TodoItem, type TodoPhase } from "../tools/todo";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { AgentSessionEvent } from "./agent-session-events";
@@ -64,7 +67,6 @@ export class TodoTracker {
 	readonly #host: TodoTrackerHost;
 	#phases: TodoPhase[] = [];
 	#reminderCount = 0;
-	#reminderAwaitingProgress = false;
 	#mutationsSinceLastTouch = 0;
 	#midRunNudgeCount = 0;
 
@@ -95,7 +97,6 @@ export class TodoTracker {
 	/** Resets per-prompt reminder and mutation budgets. */
 	resetCycle(): void {
 		this.#reminderCount = 0;
-		this.#reminderAwaitingProgress = false;
 		this.#mutationsSinceLastTouch = 0;
 		this.#midRunNudgeCount = 0;
 	}
@@ -107,7 +108,6 @@ export class TodoTracker {
 		} else if (!isError && MUTATING_TOOLS[toolName]) {
 			this.#mutationsSinceLastTouch++;
 		}
-		this.#reminderAwaitingProgress = false;
 	}
 
 	/** Detects whether a successful todo result came from an init operation. */
@@ -184,11 +184,28 @@ export class TodoTracker {
 		};
 	}
 
+	/** True when any todo is still pending or in_progress (blocked/abandoned/completed do not count). */
+	hasOpenActionableTodos(): boolean {
+		return this.#incompleteActionableByPhase().some(phase => phase.tasks.length > 0);
+	}
+
 	/** Builds reminder-only eager preludes after compaction. */
 	buildPostCompactionEagerNudges(): AgentMessage[] {
 		const nudges: AgentMessage[] = [];
-		const todo = this.createEagerTodoPrelude(undefined);
-		if (todo) nudges.push(todo.message);
+		const incompleteByPhase = this.#incompleteActionableByPhase();
+		if (incompleteByPhase.length > 0) {
+			nudges.push({
+				role: "custom",
+				customType: "post-compaction-incomplete-todos",
+				content: prompt.render(postCompactionIncompleteTodosPrompt, { phases: incompleteByPhase }),
+				display: false,
+				attribution: "agent",
+				timestamp: Date.now(),
+			});
+		} else {
+			const todo = this.createEagerTodoPrelude(undefined);
+			if (todo) nudges.push(todo.message);
+		}
 		const task = this.createEagerTaskPrelude(undefined);
 		if (task) nudges.push(task);
 		return nudges;
@@ -198,15 +215,8 @@ export class TodoTracker {
 	async checkCompletion(message: AssistantMessage): Promise<boolean> {
 		if (this.#host.consumeLastServedToolChoiceLabel() === "user-force") return false;
 		if (this.#host.planModeEnabled()) return false;
-		if (this.#reminderAwaitingProgress) {
-			logger.debug("Todo completion: prior reminder still awaiting agent action; staying silent", {
-				attempt: this.#reminderCount,
-			});
-			return false;
-		}
 		if (!this.#host.settings.get("todo.reminders") || !this.#host.settings.get("todo.enabled")) {
 			this.#reminderCount = 0;
-			this.#reminderAwaitingProgress = false;
 			return false;
 		}
 		const remindersMax = this.#host.settings.get("todo.remindersMax");
@@ -214,27 +224,10 @@ export class TodoTracker {
 			logger.debug("Todo completion: max reminders reached", { count: this.#reminderCount });
 			return false;
 		}
-		const phases = this.phases;
-		if (phases.length === 0) {
-			this.#reminderCount = 0;
-			this.#reminderAwaitingProgress = false;
-			return false;
-		}
-		const incompleteByPhase = phases
-			.map(phase => ({
-				name: phase.name,
-				tasks: phase.tasks
-					.filter(
-						(task): task is TodoItem & { status: "pending" | "in_progress" } =>
-							task.status === "pending" || task.status === "in_progress",
-					)
-					.map(task => ({ content: task.content, status: task.status })),
-			}))
-			.filter(phase => phase.tasks.length > 0);
+		const incompleteByPhase = this.#incompleteActionableByPhase();
 		const incomplete = incompleteByPhase.flatMap(phase => phase.tasks);
 		if (incomplete.length === 0) {
 			this.#reminderCount = 0;
-			this.#reminderAwaitingProgress = false;
 			return false;
 		}
 		if (isAwaitingUserAnswer(message)) {
@@ -251,12 +244,12 @@ export class TodoTracker {
 		}
 		this.#reminderCount++;
 		const todoList = incompleteByPhase
-			.map(phase => `- ${phase.name}\n${phase.tasks.map(task => `  - ${task.content}`).join("\n")}`)
+			.map(phase => `- ${phase.name}\n${phase.tasks.map(task => `  - [${task.status}] ${task.content}`).join("\n")}`)
 			.join("\n");
 		const reminder =
 			`<system-reminder>\n` +
 			`You stopped with ${incomplete.length} incomplete todo item(s):\n${todoList}\n\n` +
-			`Please continue working on these tasks or mark them complete if finished.\n` +
+			`Please continue working on these tasks or mark them complete with the todo tool if finished. A text-only stop is not completion.\n` +
 			`(Reminder ${this.#reminderCount}/${remindersMax})\n` +
 			`</system-reminder>`;
 		logger.debug("Todo completion: sending reminder", {
@@ -276,7 +269,6 @@ export class TodoTracker {
 			timestamp: Date.now(),
 		};
 		this.#mutationsSinceLastTouch = 0;
-		this.#reminderAwaitingProgress = true;
 		this.#host.agent.appendMessage(reminderMessage);
 		this.#host.sessionManager.appendMessage(reminderMessage);
 		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
@@ -324,6 +316,23 @@ export class TodoTracker {
 			toolRefs: { task: wireName("task"), todo: wireName("todo") },
 			taskBatch: this.#host.settings.get("task.batch"),
 		};
+	}
+
+	#incompleteActionableByPhase(): Array<{
+		name: string;
+		tasks: Array<{ content: string; status: "pending" | "in_progress" }>;
+	}> {
+		return this.#phases
+			.map(phase => ({
+				name: phase.name,
+				tasks: phase.tasks
+					.filter(
+						(task): task is TodoItem & { status: "pending" | "in_progress" } =>
+							task.status === "pending" || task.status === "in_progress",
+					)
+					.map(task => ({ content: task.content, status: task.status })),
+			}))
+			.filter(phase => phase.tasks.length > 0);
 	}
 
 	#clonePhases(phases: TodoPhase[]): TodoPhase[] {

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -61,7 +61,9 @@ export interface TodoTrackerHost {
 	model(): Model | undefined;
 	agentKind(): "main" | "sub";
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
-	scheduleAgentContinue(options: { generation?: number }): void;
+	scheduleAgentContinue(options: { generation?: number; onSkip?: () => void }): void;
+	/** Drop a queued post-budget todo force so a skipped continue cannot hijack the next turn. */
+	clearForcedTodoToolChoice(): void;
 	promptGeneration(): number;
 	hasPendingAsyncWake(): boolean;
 	getActiveToolNames(): string[];
@@ -317,7 +319,12 @@ export class TodoTracker {
 			this.#host.forceTodoToolChoice();
 		}
 		// Continue even if forceTodoToolChoice no-ops (todo missing / no named choice).
-		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
+		this.#host.scheduleAgentContinue({
+			generation: this.#host.promptGeneration(),
+			// User-prompt preempt / abort / compaction skips the continue but must not
+			// leave a forced todo queued for the next unrelated turn.
+			onSkip: () => this.#host.clearForcedTodoToolChoice(),
+		});
 		return true;
 	}
 
@@ -427,9 +434,27 @@ function isResponseCueLine(line: string): boolean {
 	return USER_RESPONSE_CUE_RE.test(candidate);
 }
 
+const FAKE_COMPLETE_SLOGAN_RE =
+	/\b(?:task(?:s)?\s+complete|all\s+done|all\s+\d+\s+items?\b[\s\S]{0,40}\b(?:done|wired|complete|finished))\b/i;
+
+function textBeforeTrailingQuestion(text: string): string {
+	return text.replace(/(?:^|[\n.!]\s*)[^.!?\n？]*[?？]\s*$/u, "").trim();
+}
+
+function isFakeCompleteSlogan(text: string): boolean {
+	return FAKE_COMPLETE_SLOGAN_RE.test(text);
+}
+
 function isAwaitingUserAnswer(message: AssistantMessage): boolean {
 	const text = assistantText(message);
 	if (!text) return false;
 	const lastLine = text.split(/\r?\n/).at(-1)?.trim();
-	return lastLine !== undefined && (isQuestionPromptLine(lastLine) || isResponseCueLine(lastLine));
+	if (lastLine === undefined || !(isQuestionPromptLine(lastLine) || isResponseCueLine(lastLine))) {
+		return false;
+	}
+	// A genuine last-line question still yields. A fake-complete slogan that
+	// tacks on "anything else?" must not skip the leftover-todo reminder.
+	const prefix = textBeforeTrailingQuestion(text);
+	if (prefix && isFakeCompleteSlogan(prefix)) return false;
+	return true;
 }

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -264,7 +264,9 @@ export class TodoTracker {
 			this.#reminderCount = 0;
 			return false;
 		}
-		if (isAwaitingUserAnswer(message)) {
+		// Skip only when the turn is awaiting a user answer and does not also
+		// claim completion. A slogan plus "anything else?" still reminds.
+		if (isAwaitingUserAnswer(message) && !claimsCompletion(textBeforeTrailingQuestion(assistantText(message)))) {
 			logger.debug("Todo completion: assistant is waiting for user input; skipping reminder", {
 				incomplete: incomplete.length,
 			});
@@ -434,27 +436,20 @@ function isResponseCueLine(line: string): boolean {
 	return USER_RESPONSE_CUE_RE.test(candidate);
 }
 
-const FAKE_COMPLETE_SLOGAN_RE =
-	/\b(?:task(?:s)?\s+complete|all\s+done|all\s+\d+\s+items?\b[\s\S]{0,40}\b(?:done|wired|complete|finished))\b/i;
+const COMPLETION_CLAIM_RE =
+	/\b(?:(?:i(?:'ve| have)|we(?:'ve| have))\s+(?:now\s+)?(?:finished|completed|done)\s+(?:everything|all)\b|(?:i(?:'m| am)|we(?:'re| are))\s+(?:all\s+)?(?:done|finished)\b|(?:the\s+)?task(?:s)?\s+(?:is\s+|are\s+|now\s+)?complete\b|(?:the\s+)?(?:work|job)\s+is\s+(?:done|finished|complete(?:d)?)\b|(?:finished|completed)\s+everything\b|everything\s+(?:is\s+)?(?:done|finished|complete(?:d)?)\b|all\s+done\b|all\s+(?:the\s+)?(?:tasks?|items?|todos?|work)\s+(?:are\s+|is\s+|now\s+)?(?:done|finished|complete(?:d)?|wired)\b|all\s+\d+\s+items?\b[\s\S]{0,40}\b(?:done|wired|complete|finished)\b|that(?:'s| is)\s+(?:all|everything)\b)/i;
 
 function textBeforeTrailingQuestion(text: string): string {
 	return text.replace(/(?:^|[\n.!]\s*)[^.!?\n？]*[?？]\s*$/u, "").trim();
 }
 
-function isFakeCompleteSlogan(text: string): boolean {
-	return FAKE_COMPLETE_SLOGAN_RE.test(text);
+function claimsCompletion(text: string): boolean {
+	return text.length > 0 && COMPLETION_CLAIM_RE.test(text);
 }
 
 function isAwaitingUserAnswer(message: AssistantMessage): boolean {
 	const text = assistantText(message);
 	if (!text) return false;
 	const lastLine = text.split(/\r?\n/).at(-1)?.trim();
-	if (lastLine === undefined || !(isQuestionPromptLine(lastLine) || isResponseCueLine(lastLine))) {
-		return false;
-	}
-	// A genuine last-line question still yields. A fake-complete slogan that
-	// tacks on "anything else?" must not skip the leftover-todo reminder.
-	const prefix = textBeforeTrailingQuestion(text);
-	if (prefix && isFakeCompleteSlogan(prefix)) return false;
-	return true;
+	return lastLine !== undefined && (isQuestionPromptLine(lastLine) || isResponseCueLine(lastLine));
 }

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -8,9 +8,17 @@ import midRunTodoNudgePrompt from "../prompts/system/mid-run-todo-nudge.md" with
 import postCompactionIncompleteTodosPrompt from "../prompts/system/post-compaction-incomplete-todos.md" with {
 	type: "text",
 };
-import { getLatestTodoPhasesFromEntries, isTodoPhase, type TodoItem, type TodoPhase } from "../tools/todo";
+import { getLatestTodoPhasesFromEntries, isTodoPhase, type TodoPhase } from "../tools/todo";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { AgentSessionEvent } from "./agent-session-events";
+import {
+	capIncompleteTodoRows,
+	collectIncompleteTodoRows,
+	formatIncompleteTodoSnapshotLines,
+	formatIncompleteTodosSection,
+	groupIncompleteTodoRowsByPhase,
+	upsertIncompleteTodosSection,
+} from "./incomplete-todos";
 import type { SessionManager } from "./session-manager";
 
 const MID_RUN_NUDGE_MUTATION_THRESHOLD = 12;
@@ -196,50 +204,37 @@ export class TodoTracker {
 	 * (`SummaryOptions.extraContext`), so the contract survives the cut.
 	 */
 	buildIncompleteTodosCompactionContext(): string[] {
-		const incompleteByPhase = this.#incompleteActionableByPhase();
-		if (incompleteByPhase.length === 0) return [];
-		const lines = [
+		const rows = collectIncompleteTodoRows(this.#phases);
+		if (rows.length === 0) return [];
+		return [
 			"Incomplete todos that MUST survive compaction (pending/in_progress only; a text-only stop is not completion):",
+			...formatIncompleteTodoSnapshotLines(rows),
 		];
-		for (const phase of incompleteByPhase) {
-			for (const task of phase.tasks) {
-				lines.push(`[${phase.name}] [${task.status}] ${task.content}`);
-			}
-		}
-		return lines;
 	}
 
 	/**
-	 * Appends the incomplete todo list to a compaction summary so it remains
-	 * durable text after snapcompact/LLM summarization (mirrors file-ops upsert).
+	 * Upserts the incomplete todo list into a compaction summary so it remains
+	 * durable text after snapcompact/LLM summarization. A later compact rewrites
+	 * the section from the live list, or strips it when nothing remains.
 	 */
 	appendIncompleteTodosToSummary(summary: string): string {
-		const incompleteByPhase = this.#incompleteActionableByPhase();
-		if (incompleteByPhase.length === 0) return summary;
-		const block = [
-			"## Incomplete Todos",
-			"These pending/in_progress items remain after compaction; continue them. A text-only stop is not completion.",
-			...incompleteByPhase.flatMap(phase => [
-				`- ${phase.name}`,
-				...phase.tasks.map(task => `  - [${task.status}] ${task.content}`),
-			]),
-		].join("\n");
-		const trimmed = summary.trimEnd();
-		if (trimmed.includes("## Incomplete Todos")) {
-			return `${trimmed}\n`;
-		}
-		return `${trimmed}\n\n${block}\n`;
+		const rows = collectIncompleteTodoRows(this.#phases);
+		return upsertIncompleteTodosSection(summary, formatIncompleteTodosSection(rows));
 	}
 
 	/** Builds reminder-only eager preludes after compaction. */
 	buildPostCompactionEagerNudges(): AgentMessage[] {
 		const nudges: AgentMessage[] = [];
-		const incompleteByPhase = this.#incompleteActionableByPhase();
-		if (incompleteByPhase.length > 0) {
+		const rows = collectIncompleteTodoRows(this.#phases);
+		if (rows.length > 0) {
+			const capped = capIncompleteTodoRows(rows);
 			nudges.push({
 				role: "custom",
 				customType: "post-compaction-incomplete-todos",
-				content: prompt.render(postCompactionIncompleteTodosPrompt, { phases: incompleteByPhase }),
+				content: prompt.render(postCompactionIncompleteTodosPrompt, {
+					phases: groupIncompleteTodoRowsByPhase(capped.rows),
+					overflow: capped.overflow,
+				}),
 				display: false,
 				attribution: "agent",
 				timestamp: Date.now(),
@@ -321,6 +316,7 @@ export class TodoTracker {
 		if (isEscapeHatch) {
 			this.#host.forceTodoToolChoice();
 		}
+		// Continue even if forceTodoToolChoice no-ops (todo missing / no named choice).
 		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
 		return true;
 	}
@@ -372,17 +368,7 @@ export class TodoTracker {
 		name: string;
 		tasks: Array<{ content: string; status: "pending" | "in_progress" }>;
 	}> {
-		return this.#phases
-			.map(phase => ({
-				name: phase.name,
-				tasks: phase.tasks
-					.filter(
-						(task): task is TodoItem & { status: "pending" | "in_progress" } =>
-							task.status === "pending" || task.status === "in_progress",
-					)
-					.map(task => ({ content: task.content, status: task.status })),
-			}))
-			.filter(phase => phase.tasks.length > 0);
+		return groupIncompleteTodoRowsByPhase(collectIncompleteTodoRows(this.#phases));
 	}
 
 	#clonePhases(phases: TodoPhase[]): TodoPhase[] {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -167,6 +167,8 @@ export interface TurnRecoveryHost {
 		},
 	): Promise<RecoveryCompactionResult>;
 	withBashBranchTransition<T>(operation: () => T): T;
+	/** Whether any todo is still pending or in_progress. */
+	hasOpenActionableTodos(): boolean;
 }
 
 /** Construction-time retry state restored from model selection. */
@@ -2219,17 +2221,20 @@ export class TurnRecovery {
 	#maybeInjectThinkingLoopRedirect(id: number): void {
 		if (!AIError.is(id, AIError.Flag.ThinkingLoop)) return;
 		if (this.#host.settings.get("model.loopGuard.enabled") !== true) return;
+		const content = prompt.render(thinkingLoopRedirectTemplate, {
+			hasOpenTodos: this.#host.hasOpenActionableTodos(),
+		});
 		this.#host.agent.appendMessage({
 			role: "custom",
 			customType: THINKING_LOOP_REDIRECT_TYPE,
-			content: thinkingLoopRedirectTemplate,
+			content,
 			display: false,
 			attribution: "agent",
 			timestamp: Date.now(),
 		});
 		this.#host.sessionManager.appendCustomMessageEntry(
 			THINKING_LOOP_REDIRECT_TYPE,
-			thinkingLoopRedirectTemplate,
+			content,
 			false,
 			undefined,
 			"agent",

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -9,6 +9,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import todoDescription from "../prompts/tools/todo.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
+import { parseIncompleteTodosFromSummary } from "../session/incomplete-todos";
 import type { SessionEntry } from "../session/session-entries";
 import { framedBlock, renderStatusLine, renderTreeList } from "../tui";
 import { normalizePathLikeInput, resolveToCwd } from "./path-utils";
@@ -175,6 +176,7 @@ export function nextActionableTask(phases: readonly TodoPhase[]): TodoItem | und
 export const USER_TODO_EDIT_CUSTOM_TYPE = "user_todo_edit";
 
 export function getLatestTodoPhasesFromEntries(entries: SessionEntry[]): TodoPhase[] {
+	let skipCompactionSections = false;
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
 		if (entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE) {
@@ -182,6 +184,16 @@ export function getLatestTodoPhasesFromEntries(entries: SessionEntry[]): TodoPha
 			if (data && Array.isArray(data.phases)) {
 				return clonePhases(data.phases as TodoPhase[]);
 			}
+			continue;
+		}
+		if (entry.type === "compaction") {
+			if (skipCompactionSections) continue;
+			const reconstructed = parseIncompleteTodosFromSummary(entry.summary);
+			if (reconstructed.length > 0) return clonePhases(reconstructed);
+			// Latest compact had no leftover section (stripped or pre-feature).
+			// Keep walking for an older toolResult / user_todo_edit, but ignore
+			// stale leftover sections from earlier compacts.
+			skipCompactionSections = true;
 			continue;
 		}
 		if (entry.type !== "message") continue;

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -768,6 +768,14 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 				: "."
 		}`,
 	);
+	if (
+		!readOnly &&
+		errors.length === 0 &&
+		remainingTasks.some(task => task.status === "pending") &&
+		!remainingTasks.some(task => task.status === "in_progress")
+	) {
+		lines.push("No task is in_progress. Mark one in_progress with the todo tool before continuing.");
+	}
 	for (const phase of phases) {
 		lines.push(`  ${phase.name}:`);
 		for (const task of phase.tasks) {

--- a/packages/coding-agent/src/utils/tool-choice.ts
+++ b/packages/coding-agent/src/utils/tool-choice.ts
@@ -2,8 +2,8 @@ import type { Api, Model, ToolChoice } from "@oh-my-pi/pi-ai";
 
 /**
  * Build a provider-aware tool choice that targets one specific tool when supported.
- * Providers that only expose required/any forcing may still honor named choices by
- * narrowing their request tool list before transport.
+ * Google maps `{ type: "tool", name }` to `allowedFunctionNames`; a string
+ * `"required"` is not a named pin and is not returned here.
  */
 export function buildNamedToolChoice(toolName: string, model?: Model<Api>): ToolChoice | undefined {
 	if (!model) return undefined;
@@ -26,7 +26,7 @@ export function buildNamedToolChoice(toolName: string, model?: Model<Api>): Tool
 	}
 
 	if (model.api === "google-generative-ai" || model.api === "google-gemini-cli" || model.api === "google-vertex") {
-		return "required";
+		return { type: "tool", name: toolName };
 	}
 
 	return undefined;

--- a/packages/coding-agent/test/agent-session-eager-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-compaction.test.ts
@@ -368,7 +368,7 @@ describe("AgentSession eager prelude re-injection after compaction", () => {
 		expect(continuation.toolChoice).toBeUndefined();
 	});
 
-	it("does not re-inject the eager todo reminder when todos survived compaction", async () => {
+	it("re-injects the surviving incomplete todo list instead of the create-a-list prelude", async () => {
 		const { session, sessionManager, waitForCall } = await createHarness({
 			"task.eager": "default",
 			"todo.enabled": true,
@@ -389,6 +389,29 @@ describe("AgentSession eager prelude re-injection after compaction", () => {
 		expect(session.getTodoPhases().length).toBeGreaterThan(0);
 		expect(continuation.messageTexts.some(text => text.includes("Consider calling"))).toBe(false);
 		expect(continuation.messageTexts.some(text => text.includes("You MUST call"))).toBe(false);
+		const incompleteNudge = continuation.messageTexts.find(text =>
+			text.includes("These incomplete todos remain after compaction"),
+		);
+		expect(incompleteNudge).toBeDefined();
+		expect(incompleteNudge).toContain("- Work");
+		expect(incompleteNudge).toContain("- [pending] do the thing");
+		expect(continuation.messageTexts.some(text => text.includes("If no work remains, say so"))).toBe(false);
+	});
+
+	it("keeps the no-work-remains auto-continue line when no todos are open", async () => {
+		const { session, waitForCall } = await createHarness({
+			"task.eager": "default",
+			"todo.enabled": true,
+			"todo.eager": "default",
+		});
+		stubCompaction();
+
+		const continuation = await runToContinuation(session, waitForCall);
+
+		expect(continuation.messageTexts.some(text => text.includes("If no work remains, say so"))).toBe(true);
+		expect(
+			continuation.messageTexts.some(text => text.includes("These incomplete todos remain after compaction")),
+		).toBe(false);
 	});
 
 	it("resets Codex provider history after successful auto-compaction", async () => {

--- a/packages/coding-agent/test/agent-session-eager-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-compaction.test.ts
@@ -89,14 +89,17 @@ function createAssistantResponse(text: string) {
 /** Short-circuit the LLM summary so compaction completes without a network call. */
 function stubCompaction(
 	firstKeptEntryId?: string,
-	captured?: { extraContext?: string[]; snapshotText?: string },
+	captured?: { extraContext?: string[]; snapshotText?: string; snapshotRole?: string },
 ): void {
 	vi.spyOn(compactionModule, "compact").mockImplementation(
 		async (preparation, _model, _apiKey, _custom, _signal, options) => {
 			if (captured) {
 				captured.extraContext = options?.extraContext;
 				const first = preparation.messagesToSummarize[0];
-				if (first) captured.snapshotText = getMessageText(first);
+				if (first) {
+					captured.snapshotText = getMessageText(first);
+					captured.snapshotRole = first.role;
+				}
 			}
 			return {
 				summary: "compacted",
@@ -392,7 +395,7 @@ describe("AgentSession eager prelude re-injection after compaction", () => {
 		const todoEntryId = sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, {
 			phases: [{ name: "Work", tasks: [{ content: "do the thing", status: "pending" }] }],
 		});
-		const captured: { extraContext?: string[]; snapshotText?: string } = {};
+		const captured: { extraContext?: string[]; snapshotText?: string; snapshotRole?: string } = {};
 		stubCompaction(todoEntryId, captured);
 
 		const continuationPromise = waitForCall(call => call.callIndex > 0);
@@ -410,6 +413,8 @@ describe("AgentSession eager prelude re-injection after compaction", () => {
 		expect(incompleteNudge).toContain("- [pending] do the thing");
 		expect(continuation.messageTexts.some(text => text.includes("If no work remains, say so"))).toBe(false);
 		expect(captured.extraContext?.some(line => line.includes("[Work] [pending] do the thing"))).toBe(true);
+		expect(captured.snapshotRole).toBe("custom");
+		expect(captured.snapshotRole).not.toBe("user");
 		expect(captured.snapshotText).toContain("<incomplete-todos>");
 		expect(captured.snapshotText).toContain("[Work] [pending] do the thing");
 		expect(

--- a/packages/coding-agent/test/agent-session-eager-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-compaction.test.ts
@@ -87,14 +87,26 @@ function createAssistantResponse(text: string) {
 }
 
 /** Short-circuit the LLM summary so compaction completes without a network call. */
-function stubCompaction(firstKeptEntryId?: string): void {
-	vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
-		summary: "compacted",
-		shortSummary: undefined,
-		firstKeptEntryId: firstKeptEntryId ?? preparation.firstKeptEntryId,
-		tokensBefore: preparation.tokensBefore,
-		details: {},
-	}));
+function stubCompaction(
+	firstKeptEntryId?: string,
+	captured?: { extraContext?: string[]; snapshotText?: string },
+): void {
+	vi.spyOn(compactionModule, "compact").mockImplementation(
+		async (preparation, _model, _apiKey, _custom, _signal, options) => {
+			if (captured) {
+				captured.extraContext = options?.extraContext;
+				const first = preparation.messagesToSummarize[0];
+				if (first) captured.snapshotText = getMessageText(first);
+			}
+			return {
+				summary: "compacted",
+				shortSummary: undefined,
+				firstKeptEntryId: firstKeptEntryId ?? preparation.firstKeptEntryId,
+				tokensBefore: preparation.tokensBefore,
+				details: {},
+			};
+		},
+	);
 }
 
 /** Emit a high-usage assistant turn to drive threshold (context-full) auto-compaction. */
@@ -380,7 +392,8 @@ describe("AgentSession eager prelude re-injection after compaction", () => {
 		const todoEntryId = sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, {
 			phases: [{ name: "Work", tasks: [{ content: "do the thing", status: "pending" }] }],
 		});
-		stubCompaction(todoEntryId);
+		const captured: { extraContext?: string[]; snapshotText?: string } = {};
+		stubCompaction(todoEntryId, captured);
 
 		const continuationPromise = waitForCall(call => call.callIndex > 0);
 		emitHighUsageTurn(session);
@@ -396,6 +409,14 @@ describe("AgentSession eager prelude re-injection after compaction", () => {
 		expect(incompleteNudge).toContain("- Work");
 		expect(incompleteNudge).toContain("- [pending] do the thing");
 		expect(continuation.messageTexts.some(text => text.includes("If no work remains, say so"))).toBe(false);
+		expect(captured.extraContext?.some(line => line.includes("[Work] [pending] do the thing"))).toBe(true);
+		expect(captured.snapshotText).toContain("<incomplete-todos>");
+		expect(captured.snapshotText).toContain("[Work] [pending] do the thing");
+		expect(
+			continuation.messageTexts.some(
+				text => text.includes("## Incomplete Todos") && text.includes("[pending] do the thing"),
+			),
+		).toBe(true);
 	});
 
 	it("keeps the no-work-remains auto-continue line when no todos are open", async () => {

--- a/packages/coding-agent/test/agent-session-thinking-loop-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-thinking-loop-retry.test.ts
@@ -302,12 +302,70 @@ describe("AgentSession thinking-loop retry", () => {
 		expect(redirects[0].attribution).toBe("agent");
 		expect(typeof redirects[0].content).toBe("string");
 		expect(redirects[0].content).toContain("thinking_loop_detected");
+		expect(redirects[0].content).toContain("Task genuinely complete → emit final answer");
 
 		const assistants = session.agent.state.messages.filter(
 			(message): message is AssistantMessage => message.role === "assistant",
 		);
 		expect(assistants).toHaveLength(1);
 		expect(assistants[0].content).toEqual([{ type: "text", text: "Recovered after retry." }]);
+	});
+
+	it("drops the emit-final-answer option from the thinking-loop redirect while todos are open", async () => {
+		const model = createMockModel({ provider: "openrouter", id: "google/gemini-3.5-flash" }).model;
+		const calls: string[] = [];
+		const contexts: Context[] = [];
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			convertToLlm,
+			streamFn: (requestedModel, context, _options?: SimpleStreamOptions) => {
+				calls.push(`${requestedModel.provider}/${requestedModel.id}`);
+				contexts.push(context);
+				return calls.length === 1 ? errorIdOnlyThinkingLoopStream(requestedModel) : successStream(requestedModel);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.enabled": true,
+			"retry.baseDelayMs": 0,
+			"retry.maxDelayMs": 5_000,
+			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
+			"todo.enabled": true,
+			"model.loopGuard.enabled": true,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.setTodoPhases([
+			{
+				name: "Work",
+				tasks: [{ content: "finish the remaining items", status: "pending" }],
+			},
+		]);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Trigger redirect injection after thinking loop with open todos");
+		await session.waitForIdle();
+
+		const redirects = session.agent.state.messages.filter(
+			(message): message is CustomMessage =>
+				message.role === "custom" && message.customType === "thinking-loop-redirect",
+		);
+		expect(redirects).toHaveLength(1);
+		expect(redirects[0].content).toContain("thinking_loop_detected");
+		expect(redirects[0].content).toContain("Issue one concrete normal-format tool call");
+		expect(redirects[0].content).not.toContain("emit final answer");
 	});
 
 	it("injects a redirect notice on each consecutive thinking-loop retry", async () => {

--- a/packages/coding-agent/test/agent-session-thinking-loop-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-thinking-loop-retry.test.ts
@@ -338,6 +338,7 @@ describe("AgentSession thinking-loop retry", () => {
 			"retry.maxRetries": 1,
 			"retry.modelFallback": false,
 			"todo.enabled": true,
+			"todo.reminders": false,
 			"model.loopGuard.enabled": true,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);

--- a/packages/coding-agent/test/agent-session-todo-escape.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-escape.test.ts
@@ -126,7 +126,7 @@ describe("AgentSession todo-escape tool_choice", () => {
 		expect(session.toolChoiceQueue.inspect()).not.toContain("todo-escape");
 	});
 
-	it("allows Google required through the todo escape hatch", async () => {
+	it("pins the named todo tool on Google instead of a generic required choice", async () => {
 		const base = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!base) throw new Error("Expected bundled anthropic model");
 		const google = { ...base, api: "google-generative-ai", provider: "google", id: "gemini-2.5-flash" } as Model;
@@ -136,6 +136,6 @@ describe("AgentSession todo-escape tool_choice", () => {
 		emitTextOnlyStop();
 		await session.waitForIdle();
 		expect(session.toolChoiceQueue.inspect()).toContain("todo-escape");
-		expect(session.toolChoiceQueue.nextToolChoice()).toBe("required");
+		expect(session.toolChoiceQueue.nextToolChoice()).toEqual({ type: "tool", name: "todo" });
 	});
 });

--- a/packages/coding-agent/test/agent-session-todo-escape.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-escape.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+const sharedAuthStorage = createInMemoryAuthStorage();
+sharedAuthStorage.setRuntimeApiKey("anthropic", "test-key");
+const sharedModelRegistry = new ModelRegistry(sharedAuthStorage);
+
+afterAll(() => {
+	sharedAuthStorage.close();
+});
+
+function textOnlyAssistant(text = "Task complete. All 1 items now wired."): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: 100,
+			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 120,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession todo-escape tool_choice", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+
+	function emitTextOnlyStop(text?: string): void {
+		const msg = textOnlyAssistant(text);
+		session.agent.emitExternalEvent({ type: "message_end", message: msg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [msg] });
+	}
+
+	let servedToolChoice: unknown;
+
+	async function createSession(model: Model): Promise<void> {
+		tempDir = TempDir.createSync("@pi-todo-escape-session-");
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		const todoTool: AgentTool = {
+			name: "todo",
+			label: "Todo",
+			description: "Todo",
+			parameters: type({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		};
+		servedToolChoice = undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [todoTool],
+				messages: [],
+			},
+			convertToLlm,
+			getToolChoice: () => session?.nextToolChoiceDirective(),
+			streamFn: (_model, _context, options) => {
+				servedToolChoice = options?.toolChoice;
+				const response = textOnlyAssistant("Which trade-off should I optimize for?");
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					stream.push({ type: "done", reason: "stop", message: response });
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"todo.enabled": true,
+				"todo.reminders": true,
+				"todo.remindersMax": 1,
+				"todo.eager": "default",
+			}),
+			modelRegistry: sharedModelRegistry,
+			toolRegistry: new Map([[todoTool.name, todoTool]]),
+		});
+		session.setTodoPhases([{ name: "Work", tasks: [{ content: "do the thing", status: "pending" }] }]);
+	}
+
+	afterEach(async () => {
+		await session.dispose();
+		try {
+			await tempDir.remove();
+		} catch {}
+		vi.restoreAllMocks();
+	});
+
+	it("queues todo-escape and drops it when a user prompt preempts the continue", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled anthropic model");
+		await createSession(model);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop();
+		await session.waitForIdle();
+		expect(session.toolChoiceQueue.inspect()).toContain("todo-escape");
+
+		await session.prompt("new user instruction");
+		await session.waitForIdle();
+		// The leftover hatch must not be served on the user turn. The turn yields
+		// with a real question so it does not immediately re-queue a new hatch.
+		expect(servedToolChoice).toBeUndefined();
+		expect(session.toolChoiceQueue.inspect()).not.toContain("todo-escape");
+	});
+
+	it("allows Google required through the todo escape hatch", async () => {
+		const base = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!base) throw new Error("Expected bundled anthropic model");
+		const google = { ...base, api: "google-generative-ai", provider: "google", id: "gemini-2.5-flash" } as Model;
+		await createSession(google);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop();
+		await session.waitForIdle();
+		expect(session.toolChoiceQueue.inspect()).toContain("todo-escape");
+		expect(session.toolChoiceQueue.nextToolChoice()).toBe("required");
+	});
+});

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -201,6 +201,30 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(agentEndTerminalStates.at(-1)).toBe(true);
 	});
 
+	it("still reminds when a fake-complete slogan ends with a trailing question", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("Task complete. All done. Is there anything else?");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([1]);
+		expect(todoReminderTranscriptEntry()).toBeDefined();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(agentEndTerminalStates.at(-1)).toBe(false);
+	});
+
+	it("still treats a last-line-only question as a real stop", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("I need a decision on the remaining work.\n\nWhich trade-off should I optimize for?");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([]);
+		expect(todoReminderTranscriptEntry()).toBeUndefined();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(agentEndTerminalStates.at(-1)).toBe(true);
+	});
+
 	it("still reminds when the assistant answers its own prompt-shaped question", async () => {
 		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -10,15 +10,13 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 /**
- * Regression coverage for issue #2590: `#checkTodoCompletion` used to schedule
- * `agent.continue()` after appending its `<system-reminder>`, so any text-only
- * acknowledgement from the agent ("paused at your instruction") triggered another
- * `agent_end`, which incremented the counter and fired the next reminder — no
- * user input required. Within a single user pause that loop runs 1/3 → 2/3 → 3/3.
+ * Stop-time todo reminders (#2590 / #8874).
  *
- * The contract these tests defend: a reminder MUST NOT escalate inside a
- * self-continuation chain unless the agent has produced a tool-level result
- * (e.g. called `todo` or `edit`) between the prior reminder and the next stop.
+ * A text-only `stop` with pending/in_progress todos is not terminal unless the
+ * assistant is waiting for the user (question / response cue) or the remaining
+ * items are blocked/abandoned/completed. A text-only "all done" after reminder
+ * 1/3 is not progress and must not suppress 2/3–3/3. The reminder budget still
+ * caps at `todo.remindersMax` so a fake-complete cannot loop forever.
  */
 const sharedAuthStorage = createInMemoryAuthStorage();
 sharedAuthStorage.setRuntimeApiKey("anthropic", "test-key");
@@ -33,6 +31,7 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 	let session: AgentSession;
 	let sessionManager: SessionManager;
 	let reminderAttempts: number[];
+	let agentEndTerminalStates: Array<boolean | undefined>;
 
 	function textOnlyAssistantMessage(text = "paused at your instruction"): AssistantMessage {
 		return {
@@ -137,8 +136,14 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		});
 
 		reminderAttempts = [];
+		agentEndTerminalStates = [];
 		session.subscribe((event: AgentSessionEvent) => {
 			if (event.type === "todo_reminder") reminderAttempts.push(event.attempt);
+			if (event.type === "agent_end") {
+				agentEndTerminalStates.push(
+					(event as Extract<AgentSessionEvent, { type: "agent_end" }> & { isTerminal?: boolean }).isTerminal,
+				);
+			}
 		});
 
 		session.setTodoPhases([
@@ -165,6 +170,7 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		emitTextOnlyStop();
 		await session.waitForIdle();
 		expect(reminderAttempts).toEqual([1]);
+		expect(agentEndTerminalStates).toEqual([false]);
 
 		const reminderEntry = todoReminderTranscriptEntry();
 		expect(reminderEntry?.type).toBe("message");
@@ -227,41 +233,58 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("fires exactly one reminder per user pause when the agent only acknowledges", async () => {
-		// Each call to continue() mirrors what the bug-reported model did: emit another
-		// text-only stop ("paused at your instruction"), no tool calls in between.
+	it("does not treat a text-only all-done as terminal or as reminder progress", async () => {
 		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
-			emitTextOnlyStop();
+			emitTextOnlyStop("Task complete. All 2 items now wired.");
 		});
 
-		emitTextOnlyStop();
+		emitTextOnlyStop("Task complete. All 2 items now wired.");
 		await session.waitForIdle();
 
-		// With the bug: reminderAttempts === [1, 2, 3] within a single user pause.
-		// With the fix: the second `agent_end` is suppressed because no tool action ran
-		// between the first reminder and the agent's text-only ack.
-		expect(reminderAttempts).toEqual([1]);
+		// 1/3, then the same text-only slogan, then 2/3 and 3/3. After the budget
+		// the next text-only stop is allowed to settle.
+		expect(reminderAttempts).toEqual([1, 2, 3]);
+		expect(agentEndTerminalStates[0]).toBe(false);
+		expect(agentEndTerminalStates.at(-1)).toBe(true);
 	});
 
-	it("re-escalates after the agent makes tool-level progress between stops", async () => {
+	it("still re-escalates after the agent makes tool-level progress between stops", async () => {
 		let continueCount = 0;
 		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
 			continueCount += 1;
 			if (continueCount === 1) {
-				// In response to reminder 1/3 the agent actually did work (called `todo`),
-				// then stopped again with todos still incomplete.
 				emitToolResult("todo", { phases: session.getTodoPhases() });
 				emitTextOnlyStop();
 				return;
 			}
-			// Subsequent continuations are bare acks — they must not escalate further.
 			emitTextOnlyStop();
 		});
 
 		emitTextOnlyStop();
 		await session.waitForIdle();
 
-		// 1/3 fires, agent does work, 2/3 fires, agent acks → suppressed, no 3/3.
-		expect(reminderAttempts).toEqual([1, 2]);
+		expect(reminderAttempts).toEqual([1, 2, 3]);
+	});
+
+	it("allows a text-only stop when remaining todos are only blocked or closed", async () => {
+		session.setTodoPhases([
+			{
+				name: "Waiting",
+				tasks: [
+					{ content: "Need review", status: "blocked", blocker: "waiting on user" },
+					{ content: "Shipped", status: "completed" },
+					{ content: "Dropped", status: "abandoned" },
+				],
+			},
+		]);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("Task complete.");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([]);
+		expect(todoReminderTranscriptEntry()).toBeUndefined();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(agentEndTerminalStates.at(-1)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -15,8 +15,9 @@ import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
  * A text-only `stop` with pending/in_progress todos is not terminal unless the
  * assistant is waiting for the user (question / response cue) or the remaining
  * items are blocked/abandoned/completed. A text-only "all done" after reminder
- * 1/3 is not progress and must not suppress 2/3–3/3. The reminder budget still
- * caps at `todo.remindersMax` so a fake-complete cannot loop forever.
+ * 1/3 is not progress and must not suppress 2/3–3/3. After `todo.remindersMax`,
+ * a text-only slogan is still not a terminal stop: the last reminder is an
+ * escape hatch that requires a todo-tool action (done / block / drop).
  */
 const sharedAuthStorage = createInMemoryAuthStorage();
 sharedAuthStorage.setRuntimeApiKey("anthropic", "test-key");
@@ -234,18 +235,44 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 	});
 
 	it("does not treat a text-only all-done as terminal or as reminder progress", async () => {
+		let extraStops = 0;
 		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
-			emitTextOnlyStop("Task complete. All 2 items now wired.");
+			extraStops += 1;
+			// Cap extra stops so the post-budget escape hatch can be observed without
+			// looping forever (production keeps scheduling continue until a todo-tool
+			// action lands).
+			if (extraStops <= 4) {
+				emitTextOnlyStop("Task complete. All 2 items now wired.");
+			}
 		});
 
 		emitTextOnlyStop("Task complete. All 2 items now wired.");
 		await session.waitForIdle();
 
 		// 1/3, then the same text-only slogan, then 2/3 and 3/3. After the budget
-		// the next text-only stop is allowed to settle.
-		expect(reminderAttempts).toEqual([1, 2, 3]);
+		// a text-only stop is still not terminal while pending/in_progress remain.
+		expect(reminderAttempts.slice(0, 3)).toEqual([1, 2, 3]);
+		expect(reminderAttempts.every(attempt => attempt >= 1 && attempt <= 3)).toBe(true);
 		expect(agentEndTerminalStates[0]).toBe(false);
-		expect(agentEndTerminalStates.at(-1)).toBe(true);
+		expect(agentEndTerminalStates.at(-1)).toBe(false);
+		expect(agentEndTerminalStates.every(state => state === false)).toBe(true);
+
+		const reminderTexts = sessionManager.getBranch().flatMap(entry => {
+			if (entry.type !== "message" || entry.message.role !== "developer") return [];
+			const { content } = entry.message;
+			if (!Array.isArray(content)) return [];
+			return content
+				.filter(
+					(item): item is TextContent =>
+						item.type === "text" && item.text.includes("You stopped with 2 incomplete todo item(s):"),
+				)
+				.map(item => item.text);
+		});
+		const lastReminder = reminderTexts.at(-1);
+		expect(lastReminder).toContain("todo tool");
+		expect(lastReminder).toContain("done / block / drop");
+		expect(lastReminder).toContain("Do not close with prose");
+		expect(lastReminder).not.toContain("If no work remains");
 	});
 
 	it("still re-escalates after the agent makes tool-level progress between stops", async () => {
@@ -257,13 +284,14 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 				emitTextOnlyStop();
 				return;
 			}
-			emitTextOnlyStop();
+			if (continueCount <= 4) emitTextOnlyStop();
 		});
 
 		emitTextOnlyStop();
 		await session.waitForIdle();
 
-		expect(reminderAttempts).toEqual([1, 2, 3]);
+		expect(reminderAttempts.slice(0, 3)).toEqual([1, 2, 3]);
+		expect(agentEndTerminalStates.at(-1)).toBe(false);
 	});
 
 	it("allows a text-only stop when remaining todos are only blocked or closed", async () => {

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -186,6 +186,7 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(reminderAttempts).toEqual([]);
 		expect(todoReminderTranscriptEntry()).toBeUndefined();
 		expect(continueSpy).not.toHaveBeenCalled();
+		expect(agentEndTerminalStates.at(-1)).toBe(true);
 	});
 
 	it("does not remind or continue when the assistant yields with a non-English (Chinese) question", async () => {
@@ -197,6 +198,7 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(reminderAttempts).toEqual([]);
 		expect(todoReminderTranscriptEntry()).toBeUndefined();
 		expect(continueSpy).not.toHaveBeenCalled();
+		expect(agentEndTerminalStates.at(-1)).toBe(true);
 	});
 
 	it("still reminds when the assistant answers its own prompt-shaped question", async () => {
@@ -292,6 +294,20 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 
 		expect(reminderAttempts.slice(0, 3)).toEqual([1, 2, 3]);
 		expect(agentEndTerminalStates.at(-1)).toBe(false);
+	});
+
+	it("refuses a text-only terminal stop while an in_progress todo remains", async () => {
+		session.setTodoPhases([
+			{
+				name: "Pending review",
+				tasks: [{ content: "Slice 81", status: "in_progress" }],
+			},
+		]);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+		emitTextOnlyStop();
+		await session.waitForIdle();
+		expect(reminderAttempts).toEqual([1]);
+		expect(agentEndTerminalStates).toEqual([false]);
 	});
 
 	it("allows a text-only stop when remaining todos are only blocked or closed", async () => {

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -213,6 +213,18 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(agentEndTerminalStates.at(-1)).toBe(false);
 	});
 
+	it("still reminds when finished-everything claims completion before a trailing question", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("I've finished everything. Let me know if you'd like anything else?");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([1]);
+		expect(todoReminderTranscriptEntry()).toBeDefined();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(agentEndTerminalStates.at(-1)).toBe(false);
+	});
+
 	it("still treats a last-line-only question as a real stop", async () => {
 		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 

--- a/packages/coding-agent/test/incomplete-todos-snapshot.test.ts
+++ b/packages/coding-agent/test/incomplete-todos-snapshot.test.ts
@@ -5,9 +5,11 @@ import {
 	formatIncompleteTodoSnapshotLines,
 	formatIncompleteTodosSection,
 	INCOMPLETE_TODOS_SNAPSHOT_CAP,
+	parseIncompleteTodosFromSummary,
 	upsertIncompleteTodosSection,
 } from "@oh-my-pi/pi-coding-agent/session/incomplete-todos";
-import type { TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { getLatestTodoPhasesFromEntries, type TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
 
 function phase(
 	name: string,
@@ -80,5 +82,119 @@ describe("incomplete todo snapshot helpers", () => {
 		expect(stripped).toContain("## Next Steps");
 		expect(stripped).not.toContain("## Incomplete Todos");
 		expect(stripped).not.toContain("new leftover");
+	});
+
+	it("reconstructs leftover phases from the standing Incomplete Todos section", () => {
+		const summary = [
+			"## Goal",
+			"Ship the parser",
+			"",
+			formatIncompleteTodosSection([
+				{ phase: "Work", status: "in_progress", title: "do the thing" },
+				{ phase: "Work", status: "pending", title: "wire it" },
+				{ phase: "Later", status: "pending", title: "docs" },
+			]),
+			"",
+			"## Next Steps",
+			"1. Keep going",
+			"",
+		].join("\n");
+
+		expect(parseIncompleteTodosFromSummary(summary)).toEqual([
+			{
+				name: "Work",
+				tasks: [
+					{ content: "do the thing", status: "in_progress" },
+					{ content: "wire it", status: "pending" },
+				],
+			},
+			{ name: "Later", tasks: [{ content: "docs", status: "pending" }] },
+		]);
+	});
+});
+
+describe("getLatestTodoPhasesFromEntries reconstructs leftover todos after compact", () => {
+	const TIMESTAMP = "2026-08-18T00:00:00.000Z";
+
+	function compaction(id: string, parentId: string | null, summary: string): SessionEntry {
+		return {
+			type: "compaction",
+			id,
+			parentId,
+			timestamp: TIMESTAMP,
+			summary,
+			firstKeptEntryId: "kept",
+			tokensBefore: 1000,
+		};
+	}
+
+	it("reads leftover pending/in_progress from the latest compaction summary", () => {
+		const summary = [
+			"Earlier work was summarized.",
+			"",
+			formatIncompleteTodosSection([
+				{ phase: "Work", status: "pending", title: "do the thing" },
+				{ phase: "Work", status: "in_progress", title: "wire it" },
+			]),
+		].join("\n");
+
+		const entries = [
+			{
+				type: "message",
+				id: "user",
+				parentId: null,
+				timestamp: TIMESTAMP,
+				message: { role: "user", content: [{ type: "text", text: "go" }], timestamp: 1 },
+			},
+			compaction("c1", "user", summary),
+		] as SessionEntry[];
+
+		expect(getLatestTodoPhasesFromEntries(entries)).toEqual([
+			{
+				name: "Work",
+				tasks: [
+					{ content: "do the thing", status: "pending" },
+					{ content: "wire it", status: "in_progress" },
+				],
+			},
+		]);
+	});
+
+	it("prefers a newer todo toolResult over an older compaction leftover section", () => {
+		const leftover = formatIncompleteTodosSection([{ phase: "Work", status: "pending", title: "stale leftover" }]);
+		const entries = [
+			compaction("c1", null, leftover ?? ""),
+			{
+				type: "message",
+				id: "todo",
+				parentId: "c1",
+				timestamp: TIMESTAMP,
+				message: {
+					role: "toolResult",
+					toolName: "todo",
+					toolCallId: "call-1",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					details: {
+						phases: [{ name: "Work", tasks: [{ content: "fresh item", status: "in_progress" }] }],
+					},
+					timestamp: 2,
+				},
+			},
+		] as SessionEntry[];
+
+		expect(getLatestTodoPhasesFromEntries(entries)).toEqual([
+			{ name: "Work", tasks: [{ content: "fresh item", status: "in_progress" }] },
+		]);
+	});
+
+	it("does not revive leftovers from an older compaction once the latest compact stripped the section", () => {
+		const stale = formatIncompleteTodosSection([{ phase: "Work", status: "pending", title: "old leftover" }]);
+		const entries = [
+			compaction("c1", null, stale ?? ""),
+			compaction("c2", "c1", "## Goal\nAll caught up.\n"),
+		] as SessionEntry[];
+
+		expect(getLatestTodoPhasesFromEntries(entries)).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/incomplete-todos-snapshot.test.ts
+++ b/packages/coding-agent/test/incomplete-todos-snapshot.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import {
+	capIncompleteTodoRows,
+	collectIncompleteTodoRows,
+	formatIncompleteTodoSnapshotLines,
+	formatIncompleteTodosSection,
+	INCOMPLETE_TODOS_SNAPSHOT_CAP,
+	upsertIncompleteTodosSection,
+} from "@oh-my-pi/pi-coding-agent/session/incomplete-todos";
+import type { TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
+
+function phase(
+	name: string,
+	...tasks: Array<{ content: string; status: TodoPhase["tasks"][number]["status"] }>
+): TodoPhase {
+	return { name, tasks };
+}
+
+describe("incomplete todo snapshot helpers", () => {
+	it("collects pending and in_progress rows with phase, status, and title", () => {
+		const rows = collectIncompleteTodoRows([
+			phase(
+				"Work",
+				{ content: "do the thing", status: "pending" },
+				{ content: "wire it", status: "in_progress" },
+				{ content: "shipped", status: "completed" },
+				{ content: "blocked wait", status: "blocked" },
+				{ content: "dropped", status: "abandoned" },
+			),
+			phase("Later", { content: "docs", status: "pending" }),
+		]);
+		expect(rows).toEqual([
+			{ phase: "Work", status: "pending", title: "do the thing" },
+			{ phase: "Work", status: "in_progress", title: "wire it" },
+			{ phase: "Later", status: "pending", title: "docs" },
+		]);
+	});
+
+	it("caps snapshot lines and appends + N more", () => {
+		const rows = Array.from({ length: INCOMPLETE_TODOS_SNAPSHOT_CAP + 7 }, (_, index) => ({
+			phase: "Work",
+			status: index === 0 ? ("in_progress" as const) : ("pending" as const),
+			title: `item ${index + 1}`,
+		}));
+		const lines = formatIncompleteTodoSnapshotLines(rows);
+		expect(lines).toHaveLength(INCOMPLETE_TODOS_SNAPSHOT_CAP + 1);
+		expect(lines[0]).toBe("[Work] [in_progress] item 1");
+		expect(lines[1]).toBe("[Work] [pending] item 2");
+		expect(lines.at(-1)).toBe("+ 7 more");
+		expect(capIncompleteTodoRows(rows).overflow).toBe(7);
+	});
+
+	it("replaces a stale Incomplete Todos section and strips it when empty", () => {
+		const stale = [
+			"## Goal",
+			"Ship the parser",
+			"",
+			"## Incomplete Todos",
+			"These pending/in_progress items remain after compaction; continue them. A text-only stop is not completion.",
+			"- Work",
+			"  - [pending] old leftover",
+			"",
+			"## Next Steps",
+			"1. Keep going",
+			"",
+		].join("\n");
+
+		const replaced = upsertIncompleteTodosSection(
+			stale,
+			formatIncompleteTodosSection([{ phase: "Work", status: "in_progress", title: "new leftover" }]),
+		);
+		expect(replaced).toContain("## Goal");
+		expect(replaced).toContain("## Next Steps");
+		expect(replaced).toContain("[in_progress] new leftover");
+		expect(replaced).not.toContain("old leftover");
+		expect(replaced.indexOf("## Incomplete Todos")).toBeLessThan(replaced.indexOf("## Next Steps"));
+
+		const stripped = upsertIncompleteTodosSection(replaced, undefined);
+		expect(stripped).toContain("## Goal");
+		expect(stripped).toContain("## Next Steps");
+		expect(stripped).not.toContain("## Incomplete Todos");
+		expect(stripped).not.toContain("new leftover");
+	});
+});

--- a/packages/coding-agent/test/incomplete-todos-snapshot.test.ts
+++ b/packages/coding-agent/test/incomplete-todos-snapshot.test.ts
@@ -52,6 +52,38 @@ describe("incomplete todo snapshot helpers", () => {
 		expect(capIncompleteTodoRows(rows).overflow).toBe(7);
 	});
 
+	it("replaces an Incomplete Todos heading that has a trailing colon or extra text", () => {
+		const stale = [
+			"## Goal",
+			"Ship the parser",
+			"",
+			"## Incomplete Todos: leftover work",
+			"These pending/in_progress items remain after compaction; continue them. A text-only stop is not completion.",
+			"- Work",
+			"  - [pending] old leftover",
+			"",
+			"## Next Steps",
+			"1. Keep going",
+			"",
+		].join("\n");
+
+		const replaced = upsertIncompleteTodosSection(
+			stale,
+			formatIncompleteTodosSection([{ phase: "Work", status: "in_progress", title: "new leftover" }]),
+		);
+		expect(replaced).toContain("## Goal");
+		expect(replaced).toContain("## Next Steps");
+		expect(replaced).toContain("[in_progress] new leftover");
+		expect(replaced).not.toContain("old leftover");
+		expect(replaced).not.toContain("## Incomplete Todos:");
+		expect([...replaced.matchAll(/## Incomplete Todos/g)]).toHaveLength(1);
+
+		const reconstructed = parseIncompleteTodosFromSummary(
+			["## Goal", "", "## Incomplete Todos leftover", "- Work", "  - [pending] still open", ""].join("\n"),
+		);
+		expect(reconstructed).toEqual([{ name: "Work", tasks: [{ content: "still open", status: "pending" }] }]);
+	});
+
 	it("replaces a stale Incomplete Todos section and strips it when empty", () => {
 		const stale = [
 			"## Goal",

--- a/packages/coding-agent/test/todo-tracker-escape.test.ts
+++ b/packages/coding-agent/test/todo-tracker-escape.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TodoTracker, type TodoTrackerHost } from "@oh-my-pi/pi-coding-agent/session/todo-tracker";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function textOnlyAssistant(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 15,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+describe("TodoTracker escape-hatch continue skip", () => {
+	it("passes onSkip so a skipped continue can drop the forced todo", async () => {
+		const tempDir = TempDir.createSync("@pi-todo-escape-");
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled anthropic model");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		const scheduled: Array<{ generation?: number; onSkip?: () => void }> = [];
+		let cleared = 0;
+		const host: TodoTrackerHost = {
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"todo.enabled": true,
+				"todo.reminders": true,
+				"todo.remindersMax": 1,
+			}),
+			model: () => model,
+			agentKind: () => "main",
+			emitSessionEvent: async () => {},
+			scheduleAgentContinue: options => {
+				scheduled.push(options);
+			},
+			clearForcedTodoToolChoice: () => {
+				cleared += 1;
+			},
+			promptGeneration: () => 3,
+			hasPendingAsyncWake: () => false,
+			getActiveToolNames: () => ["todo"],
+			toolRegistry: () => new Map(),
+			planModeEnabled: () => false,
+			consumeLastServedToolChoiceLabel: () => undefined,
+			forceTodoToolChoice: () => true,
+		};
+
+		const tracker = new TodoTracker(host);
+		tracker.setPhases([{ name: "Work", tasks: [{ content: "do the thing", status: "pending" }] }]);
+
+		const reminded = await tracker.checkCompletion(textOnlyAssistant("Task complete. All 1 items now wired."));
+		expect(reminded).toBe(true);
+		expect(scheduled).toHaveLength(1);
+		expect(scheduled[0]?.generation).toBe(3);
+		expect(scheduled[0]?.onSkip).toBeTypeOf("function");
+
+		scheduled[0]?.onSkip?.();
+		expect(cleared).toBe(1);
+
+		await tempDir.remove();
+	});
+});

--- a/packages/coding-agent/test/tool-choice.test.ts
+++ b/packages/coding-agent/test/tool-choice.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { buildNamedToolChoice } from "@oh-my-pi/pi-coding-agent/utils/tool-choice";
+
+describe("buildNamedToolChoice", () => {
+	it("returns a named Anthropic tool choice", () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled anthropic model");
+		expect(buildNamedToolChoice("todo", model)).toEqual({ type: "tool", name: "todo" });
+	});
+
+	it("returns required for Google/Gemini so the todo escape hatch can engage", () => {
+		const base = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!base) throw new Error("Expected bundled anthropic model");
+		const google = { ...base, api: "google-generative-ai", provider: "google", id: "gemini-2.5-flash" } as Model;
+		expect(buildNamedToolChoice("todo", google)).toBe("required");
+	});
+});

--- a/packages/coding-agent/test/tool-choice.test.ts
+++ b/packages/coding-agent/test/tool-choice.test.ts
@@ -10,10 +10,10 @@ describe("buildNamedToolChoice", () => {
 		expect(buildNamedToolChoice("todo", model)).toEqual({ type: "tool", name: "todo" });
 	});
 
-	it("returns required for Google/Gemini so the todo escape hatch can engage", () => {
+	it("names todo for Google/Gemini instead of a generic required choice", () => {
 		const base = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!base) throw new Error("Expected bundled anthropic model");
 		const google = { ...base, api: "google-generative-ai", provider: "google", id: "gemini-2.5-flash" } as Model;
-		expect(buildNamedToolChoice("todo", google)).toBe("required");
+		expect(buildNamedToolChoice("todo", google)).toEqual({ type: "tool", name: "todo" });
 	});
 });

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -81,6 +81,7 @@ function createHost(
 		runAutoCompaction: async () =>
 			({ deferredHandoff: false, continuationScheduled: false }) as RecoveryCompactionResult,
 		withBashBranchTransition: <T>(operation: () => T): T => operation(),
+		hasOpenActionableTodos: () => false,
 	};
 }
 


### PR DESCRIPTION
**Status:** superseded in its core by #10047 (merged) and #10053 — the text-only-stop/todo-reminder surface lives there now. The only unique piece left in this branch is the leftover-todo **compaction persistence** handling; it would need a fresh port onto current `main` (this branch is several hundred commits behind). Keeping open for that port; not send-ready as-is.

Fixes #8874.

A text-only "done" with open pending/in_progress todos was treated as a legal terminal turn after reminder 1/3 (and again after the reminder budget), and snapcompact/LLM compaction only re-listed leftover work after the cut.

This keeps stop-time reminders firing through the budget, then treats the last reminder as an escape hatch: a text-only slogan is still not terminal while items remain pending or in_progress, and the model is told to mark them complete/blocked/abandoned with the todo tool. Incomplete todos (phase + status + title) are now part of the compaction summarizer extraContext, a non-user conversation snapshot (so snapcompact can see the list without treating it as user text), and a standing summary section that is rewritten from the live pending/in_progress list after later compacts (or stripped when none remain). Those leftover dumps are capped so a huge list cannot overflow every compact. Questions, blocked/abandoned/completed-only lists still allow a real stop.

Follow-up on that path:

- A skipped post-budget continue no longer leaves a forced `todo` tool_choice (`todo-escape`) queued for the next user turn. User-prompt preempt clears it the same way `plan-mode-decision` is cleared.
- Google/Gemini `buildNamedToolChoice` names `todo` (`{ type: "tool", name }`, mapped to `allowedFunctionNames`). A string `"required"` is not queued, because it lets the model call any tool and then text-only stop again. If a named choice cannot be built, the hatch text still continues and still requires a `todo` tool call (done / block / drop).
- Snapcompact/dead-end rescue syncs todo phases from the branch before writing the leftover section, matching regular compact.
- After compact, leftover pending/in_progress reconstruct from the standing `## Incomplete Todos` section when the latest todo toolResult has been summarized away. Headings with a trailing colon or extra text are replaced instead of duplicated. A later compact that strips the section still does not revive leftovers from an older block.
- When actionable todos are open, the reminder is skipped only if the turn is awaiting a user answer and the body does not claim completion. "I've finished everything. Let me know if you'd like anything else?" still reminds and stays non-terminal. A genuine last-line-only question (English or Chinese) still yields.
- There is no terminal give-up cap after `remindersMax`. A text-only slogan with pending/in_progress stays non-terminal; unbounded-continue concerns stay as stronger hatch text, not a clean `agent_end`.

## Verification

I exercised the reported path in the coding-agent tests (no live session logs):

- text-only `stop` with two pending items → reminder 1/3, `agent_end.isTerminal === false`, continue scheduled
- text-only `stop` with an `in_progress` item → same non-terminal reminder path
- repeating "Task complete. All 2 items now wired." with no tools → reminders 2/3 and 3/3 fire; after the budget the next text-only stop is still non-terminal and the last reminder requires a todo-tool action
- user-facing question (English and Chinese) → no reminder, no continue, `agent_end.isTerminal === true`
- last-line-only question still yields; fake-complete + trailing question still reminds
- "I've finished everything. Let me know if you'd like anything else?" still reminds and is non-terminal
- blocked / abandoned / completed-only list → no reminder, terminal stop allowed
- snapcompact/LLM auto-compaction with a surviving pending item → leftover list in summarizer extraContext and a non-user compacted conversation snapshot (`[Work] [pending] do the thing`); standing `## Incomplete Todos` section is rewritten (not left stale) and stripped when empty; leftover rows capped at 40 with `+ N more`; post-compaction nudge still re-lists; "If no work remains, say so" omitted
- leftover pending/in_progress reconstruct from that compaction section when no later todo toolResult remains; `## Incomplete Todos:` / extra heading text is replaced once
- post-budget `todo-escape` is dropped when a user prompt preempts the continue; Google hatch queues a named `todo` tool_choice
- thinking-loop redirect with open todos → "emit final answer" dropped; "Issue one concrete ... tool call" kept

`bun test` on the session/todo/compaction files plus the escape-hatch, reconstruct, and question-stop tests: 26 focused + 36 nearby suites green. `bun run check` in `packages/coding-agent`: biome + types clean.

## Test plan

- [x] text-only stop with pending todos is non-terminal and reminds
- [x] text-only stop with in_progress todos is non-terminal and reminds
- [x] text-only "all done" does not count as reminder progress
- [x] after remindersMax, text-only stop is still not terminal while pending/in_progress remain
- [x] last reminder requires a todo-tool action (done / block / drop), not a verbal close
- [x] blocked/closed-only todos still allow a terminal stop
- [x] question path still allows a terminal stop (`isTerminal === true`)
- [x] fake-complete + trailing question still reminds
- [x] "I've finished everything. Let me know if you'd like anything else?" still reminds and stays non-terminal
- [x] last-line-only question remains a real stop
- [x] skipped continue / user prompt drops leftover `todo-escape`
- [x] Google hatch queues a named `todo` tool_choice, not `"required"`
- [x] leftover todos reconstruct from the compaction `## Incomplete Todos` section
- [x] `## Incomplete Todos:` / extra heading text is replaced instead of duplicated
- [x] later compact that strips the section does not revive stale leftovers
- [x] compaction summarizer input includes leftover todos
- [x] conversation snapshot is non-user (custom, display false)
- [x] standing Incomplete Todos section is rewritten when the live list changes and stripped when empty
- [x] leftover dumps are capped with `+ N more`
- [x] post-compaction auto-continue re-lists leftover todos
- [x] thinking-loop redirect omits final-answer while todos are open

