### PR TITLE
feat(runtime): expose compiled source identity

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `omp --build-info` for compiled binaries, reporting the exact source commit embedded by clean local and release builds.
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -2,7 +2,7 @@
 
 import { createRequire } from "node:module";
 import * as path from "node:path";
-import { compileCodingAgent } from "./compile-binary";
+import { compileCodingAgent, resolveCleanSourceCommit } from "./compile-binary";
 
 const packageDir = path.join(import.meta.dir, "..");
 const repoRoot = path.join(packageDir, "..", "..");
@@ -71,6 +71,8 @@ async function runCommand(
 }
 
 async function main(): Promise<void> {
+	const sourceCommit = resolveCleanSourceCommit(repoRoot);
+
 	const crossBuild = resolveCrossBuild(Bun.env.CROSS_TARGET);
 	const shouldAdhocSign = process.platform === "darwin" && !crossBuild && Bun.env.BUN_NO_CODESIGN_MACHO_BINARY !== "1";
 	const outName = crossBuild ? `omp-${crossBuild.id}` : "omp";
@@ -97,6 +99,7 @@ async function main(): Promise<void> {
 				target: crossBuild?.target,
 				executablePath: Bun.env.BUN_COMPILE_EXECUTABLE_PATH || undefined,
 				skipBuiltinCodesign: shouldAdhocSign,
+				sourceCommit,
 			});
 
 			if (shouldAdhocSign) {

--- a/packages/coding-agent/scripts/compile-binary.ts
+++ b/packages/coding-agent/scripts/compile-binary.ts
@@ -1,8 +1,60 @@
+import * as path from "node:path";
+import { parseEmbeddedSourceCommit } from "@oh-my-pi/pi-utils/dirs";
+
 import { buildDocsIndexPayload } from "./generate-docs-index";
 import { createLegacyPiVirtualModulePlugin } from "./legacy-pi-virtual-module";
 
 /** Native runtime dependencies always resolved from the on-demand install instead of embedded into compiled binaries. */
 export const COMPILED_EXTERNAL_DEPENDENCIES: readonly string[] = Object.freeze(["fastembed", "onnxruntime-node"]);
+
+const RUNTIME_BUILD_SOURCE_MODULE = path.join("packages", "utils", "src", "runtime-build-source.ts");
+
+function createRuntimeBuildSourcePlugin(repoRoot: string, sourceCommit: string | undefined): Bun.BunPlugin {
+	const modulePath = path.resolve(repoRoot, RUNTIME_BUILD_SOURCE_MODULE);
+	const sourceLiteral = sourceCommit === undefined ? "undefined" : JSON.stringify(sourceCommit);
+	return {
+		name: "runtime-build-source",
+		setup(build) {
+			build.onLoad({ filter: /runtime-build-source\.ts$/ }, args => {
+				if (path.resolve(args.path) !== modulePath) return undefined;
+				return {
+					contents: `export const RUNTIME_BUILD_SOURCE_COMMIT: string | undefined = ${sourceLiteral};\n`,
+					loader: "ts",
+				};
+			});
+		},
+	};
+}
+
+/**
+ * Read the exact Git object identity that a production binary binds into its
+ * bytes. Call this before generators touch checked-in placeholders.
+ */
+export function resolveCleanSourceCommit(sourceRoot: string): string {
+	const head = Bun.spawnSync(["git", "-C", sourceRoot, "rev-parse", "HEAD"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (head.exitCode !== 0) {
+		throw new Error(`Unable to read Git HEAD for binary build: ${head.stderr.toString().trim()}`);
+	}
+	const sourceCommit = parseEmbeddedSourceCommit(head.stdout.toString().trim());
+	if (!sourceCommit) {
+		throw new Error("Git HEAD for binary build must be a lowercase 40-hex commit");
+	}
+
+	const status = Bun.spawnSync(["git", "-C", sourceRoot, "status", "--porcelain=v1", "--untracked-files=all"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (status.exitCode !== 0) {
+		throw new Error(`Unable to inspect binary build worktree: ${status.stderr.toString().trim()}`);
+	}
+	if (status.stdout.toString().length > 0) {
+		throw new Error("Refusing to build a binary from a dirty worktree");
+	}
+	return sourceCommit;
+}
 
 /** Inputs shared by local and release coding-agent binary builds. */
 export interface CodingAgentCompileOptions {
@@ -14,6 +66,9 @@ export interface CodingAgentCompileOptions {
 	readonly outfile: string;
 	/** Concrete Transformers.js version baked into the tiny-model worker. */
 	readonly transformersVersion: string;
+	/** Optional immutable Git identity embedded into the standalone artifact. */
+	readonly sourceCommit?: string;
+
 	/** Optional cross-compilation runtime target. */
 	readonly target?: Bun.Build.CompileTarget;
 	/** Optional unmodified Bun executable used as the standalone runtime template. */
@@ -29,6 +84,12 @@ export interface CodingAgentCompileOptions {
  * graph supplied by an in-memory build plugin rather than generated files.
  */
 export async function compileCodingAgent(options: CodingAgentCompileOptions): Promise<void> {
+	const sourceCommit =
+		options.sourceCommit === undefined ? undefined : parseEmbeddedSourceCommit(options.sourceCommit);
+	if (options.sourceCommit !== undefined && !sourceCommit) {
+		throw new Error("Coding-agent binary source commit must be lowercase 40-hex");
+	}
+
 	const previousCodesignSetting = Bun.env.BUN_NO_CODESIGN_MACHO_BINARY;
 	if (options.skipBuiltinCodesign) {
 		Bun.env.BUN_NO_CODESIGN_MACHO_BINARY = "1";
@@ -47,7 +108,10 @@ export async function compileCodingAgent(options: CodingAgentCompileOptions): Pr
 				identifiers: options.minifyIdentifiers ?? false,
 				keepNames: true,
 			},
-			plugins: [await createLegacyPiVirtualModulePlugin()],
+			plugins: [
+				createRuntimeBuildSourcePlugin(options.repoRoot, sourceCommit),
+				await createLegacyPiVirtualModulePlugin(),
+			],
 			compile: {
 				...(options.executablePath
 					? { executablePath: options.executablePath }

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -19,6 +19,7 @@ import type { CliConfig, CommandMetadata } from "@oh-my-pi/pi-utils/cli";
 import {
 	APP_NAME,
 	getActiveProfile,
+	getRuntimeBuildInfo,
 	MIN_BUN_VERSION,
 	resolveProfileEnv,
 	setProfile,
@@ -392,6 +393,17 @@ export async function runCli(argv: string[]): Promise<void> {
 	// poison `workerHostEntry()` for the whole test process, forcing eval/stats/
 	// browser workers onto the same-realm inline fallback.
 	if (isProcessEntry) declareWorkerHostEntry();
+
+	if (resolvedArgv.length === 1 && resolvedArgv[0] === "--build-info") {
+		const buildInfo = getRuntimeBuildInfo();
+		if (!buildInfo) {
+			process.stderr.write("error: runtime build info is unavailable because no valid source commit was embedded\n");
+			process.exitCode = 1;
+			return;
+		}
+		process.stdout.write(`${JSON.stringify(buildInfo)}\n`);
+		return;
+	}
 
 	if (resolvedArgv[0] === "--smoke-test") {
 		await runSmokeTest();

--- a/packages/coding-agent/test/cli-build-info.test.ts
+++ b/packages/coding-agent/test/cli-build-info.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { runCli } from "../src/cli";
+
+const SOURCE_COMMIT = "a".repeat(40);
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
+}
+
+describe("--build-info", () => {
+	const originalSourceCommit = process.env.PI_SOURCE_COMMIT;
+	const originalCompiled = process.env.PI_COMPILED;
+	const originalExitCode = process.exitCode;
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		restoreEnv("PI_SOURCE_COMMIT", originalSourceCommit);
+		restoreEnv("PI_COMPILED", originalCompiled);
+		process.exitCode = originalExitCode ?? 0;
+	});
+
+	it("rejects a source run even when its environment names a valid commit", async () => {
+		process.env.PI_SOURCE_COMMIT = SOURCE_COMMIT;
+		process.env.PI_COMPILED = "true";
+		process.exitCode = 0;
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		await runCli(["--build-info"]);
+
+		expect(process.exitCode).toBe(1);
+		expect(stdout).not.toHaveBeenCalled();
+		expect(stderr).toHaveBeenCalledWith(
+			"error: runtime build info is unavailable because no valid source commit was embedded\n",
+		);
+	});
+});

--- a/packages/coding-agent/test/compile-binary.test.ts
+++ b/packages/coding-agent/test/compile-binary.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { compileCodingAgent, resolveCleanSourceCommit } from "../scripts/compile-binary";
+
+function runGit(sourceRoot: string, args: string[]): string {
+	const result = Bun.spawnSync(["git", "-C", sourceRoot, ...args], { stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+	}
+	return result.stdout.toString().trim();
+}
+
+async function createCommittedSourceRoot(): Promise<string> {
+	const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-compile-binary-"));
+	runGit(sourceRoot, ["init", "--quiet"]);
+	runGit(sourceRoot, ["config", "user.email", "omp-test@example.test"]);
+	runGit(sourceRoot, ["config", "user.name", "OMP Test"]);
+	await fs.writeFile(path.join(sourceRoot, "README.md"), "fixture\n");
+	runGit(sourceRoot, ["add", "README.md"]);
+	runGit(sourceRoot, ["commit", "--quiet", "-m", "fixture"]);
+	return sourceRoot;
+}
+
+describe("compiled binary source commit", () => {
+	let sourceRoot = "";
+
+	afterEach(async () => {
+		if (sourceRoot) await fs.rm(sourceRoot, { recursive: true, force: true });
+		sourceRoot = "";
+	});
+
+	it("derives the clean committed lowercase HEAD", async () => {
+		sourceRoot = await createCommittedSourceRoot();
+
+		const sourceCommit = resolveCleanSourceCommit(sourceRoot);
+		expect(sourceCommit).toMatch(/^[0-9a-f]{40}$/);
+		expect(sourceCommit).toBe(runGit(sourceRoot, ["rev-parse", "HEAD"]));
+	});
+
+	it("rejects dirty tracked and untracked source roots", async () => {
+		sourceRoot = await createCommittedSourceRoot();
+		await fs.writeFile(path.join(sourceRoot, "README.md"), "changed\n");
+		expect(() => resolveCleanSourceCommit(sourceRoot)).toThrow("Refusing to build a binary from a dirty worktree");
+
+		runGit(sourceRoot, ["checkout", "--", "README.md"]);
+		await fs.writeFile(path.join(sourceRoot, "untracked.txt"), "untracked\n");
+		expect(() => resolveCleanSourceCommit(sourceRoot)).toThrow("Refusing to build a binary from a dirty worktree");
+	});
+
+	it("rejects an invalid embedded source commit before bundling", async () => {
+		await expect(
+			compileCodingAgent({
+				repoRoot: "/unused",
+				entrypoint: "/unused/cli.ts",
+				outfile: "/unused/omp",
+				transformersVersion: "0.0.0",
+				sourceCommit: "A".repeat(40),
+			}),
+		).rejects.toThrow("Coding-agent binary source commit must be lowercase 40-hex");
+	});
+});

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { engines, version } from "../package.json" with { type: "json" };
+import { RUNTIME_BUILD_SOURCE_COMMIT } from "./runtime-build-source";
 
 /** App name (e.g. "omp") */
 export const APP_NAME: string = "omp";
@@ -33,6 +34,41 @@ export const USER_AGENT = `omp/${VERSION}`;
 
 /** Minimum Bun version */
 export const MIN_BUN_VERSION: string = engines.bun.replace(/[^0-9.]/g, "");
+
+/** Stable schema emitted by `omp --build-info` from a compiled artifact. */
+export const RUNTIME_BUILD_INFO_SCHEMA = "sheltie.runtime-build-info/v1";
+
+export interface RuntimeBuildInfo {
+	readonly schema: typeof RUNTIME_BUILD_INFO_SCHEMA;
+	readonly name: "omp";
+	readonly version: string;
+	readonly sourceCommit: string;
+}
+
+const SOURCE_COMMIT_RE = /^[0-9a-f]{40}$/;
+
+/** Accept only the immutable Git object identity embedded by the binary builder. */
+export function parseEmbeddedSourceCommit(sourceCommit: string | undefined): string | undefined {
+	return sourceCommit !== undefined && SOURCE_COMMIT_RE.test(sourceCommit) ? sourceCommit : undefined;
+}
+
+/**
+ * Resolve build metadata only from the source identity module replaced by the
+ * standalone binary builder. Source runs keep its immutable `undefined`
+ * fallback, so ambient process state cannot claim artifact provenance.
+ */
+export function getRuntimeBuildInfo(
+	sourceCommit: string | undefined = RUNTIME_BUILD_SOURCE_COMMIT,
+): RuntimeBuildInfo | undefined {
+	const embeddedSourceCommit = parseEmbeddedSourceCommit(sourceCommit);
+	if (!embeddedSourceCommit) return undefined;
+	return {
+		schema: RUNTIME_BUILD_INFO_SCHEMA,
+		name: "omp",
+		version: VERSION,
+		sourceCommit: embeddedSourceCommit,
+	};
+}
 
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const PROFILE_ENV_KEYS = ["OMP_PROFILE", "PI_PROFILE"] as const;

--- a/packages/utils/src/runtime-build-source.ts
+++ b/packages/utils/src/runtime-build-source.ts
@@ -1,0 +1,5 @@
+/**
+ * Source-mode fallback for artifact identity. The standalone binary builder
+ * replaces this exact module with an immutable commit literal during bundling.
+ */
+export const RUNTIME_BUILD_SOURCE_COMMIT: string | undefined = undefined;

--- a/packages/utils/test/runtime-build-info.test.ts
+++ b/packages/utils/test/runtime-build-info.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import {
+	getRuntimeBuildInfo,
+	parseEmbeddedSourceCommit,
+	RUNTIME_BUILD_INFO_SCHEMA,
+	VERSION,
+} from "@oh-my-pi/pi-utils/dirs";
+
+const SOURCE_COMMIT = "a".repeat(40);
+
+describe("runtime build info", () => {
+	it("parses a compiled source commit into the exact JSONL record", () => {
+		const buildInfo = getRuntimeBuildInfo(SOURCE_COMMIT);
+
+		expect(buildInfo).toEqual({
+			schema: RUNTIME_BUILD_INFO_SCHEMA,
+			name: "omp",
+			version: VERSION,
+			sourceCommit: SOURCE_COMMIT,
+		});
+		expect(`${JSON.stringify(buildInfo)}\n`).toBe(
+			`{"schema":"sheltie.runtime-build-info/v1","name":"omp","version":"${VERSION}","sourceCommit":"${SOURCE_COMMIT}"}\n`,
+		);
+	});
+
+	it("rejects missing and invalid source commits", () => {
+		expect(parseEmbeddedSourceCommit(undefined)).toBeUndefined();
+		expect(parseEmbeddedSourceCommit("A".repeat(40))).toBeUndefined();
+		expect(parseEmbeddedSourceCommit("a".repeat(39))).toBeUndefined();
+		expect(parseEmbeddedSourceCommit(`${SOURCE_COMMIT}\n`)).toBeUndefined();
+		expect(getRuntimeBuildInfo(undefined)).toBeUndefined();
+		expect(getRuntimeBuildInfo("A".repeat(40))).toBeUndefined();
+	});
+
+	it("does not let a source run claim ambient process or global state", () => {
+		const globals = globalThis as Record<string, unknown>;
+		const previousSourceCommit = process.env.PI_SOURCE_COMMIT;
+		const previousGlobalSourceCommit = globals.PI_SOURCE_COMMIT;
+		try {
+			process.env.PI_SOURCE_COMMIT = SOURCE_COMMIT;
+			globals.PI_SOURCE_COMMIT = SOURCE_COMMIT;
+			expect(getRuntimeBuildInfo()).toBeUndefined();
+		} finally {
+			if (previousSourceCommit === undefined) {
+				delete process.env.PI_SOURCE_COMMIT;
+			} else {
+				process.env.PI_SOURCE_COMMIT = previousSourceCommit;
+			}
+			if (previousGlobalSourceCommit === undefined) {
+				delete globals.PI_SOURCE_COMMIT;
+			} else {
+				globals.PI_SOURCE_COMMIT = previousGlobalSourceCommit;
+			}
+		}
+	});
+});

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -3,7 +3,11 @@
 import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import * as path from "node:path";
-import { COMPILED_EXTERNAL_DEPENDENCIES, compileCodingAgent } from "../packages/coding-agent/scripts/compile-binary";
+import {
+	COMPILED_EXTERNAL_DEPENDENCIES,
+	compileCodingAgent,
+	resolveCleanSourceCommit,
+} from "../packages/coding-agent/scripts/compile-binary";
 
 interface BinaryTarget {
 	id: string;
@@ -129,7 +133,7 @@ async function embedNative(target: BinaryTarget): Promise<void> {
 	});
 }
 
-async function buildBinary(target: BinaryTarget): Promise<void> {
+async function buildBinary(target: BinaryTarget, sourceCommit: string): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
@@ -147,6 +151,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 		target: target.target,
 		minifyIdentifiers: true,
 		skipBuiltinCodesign: shouldAdhocSignDarwinBinary(target),
+		sourceCommit,
 	});
 	// Bun 1.3.12 emits a truncated Mach-O signature on darwin builds.
 	if (shouldAdhocSignDarwinBinary(target)) {
@@ -190,6 +195,8 @@ async function main(): Promise<void> {
 	if (selectedTargets.length === 0) {
 		throw new Error("No release targets selected.");
 	}
+	// Resolve before code generation makes its checked-in placeholders dirty.
+	const sourceCommit = isDryRun ? "" : resolveCleanSourceCommit(repoRoot);
 
 	await fs.mkdir(binariesDir, { recursive: true });
 	// Generate inside the try so resetArtifacts() always restores the empty
@@ -197,7 +204,7 @@ async function main(): Promise<void> {
 	try {
 		await generateBundle();
 		for (const target of selectedTargets) {
-			await buildBinary(target);
+			await buildBinary(target, sourceCommit);
 		}
 	} finally {
 		await resetArtifacts();


### PR DESCRIPTION
## What

Add `omp --build-info` to compiled binaries as one strict JSONL record containing the artifact's schema, name, version, and exact source commit.

Local and release binary builders now derive a lowercase 40-hex commit from a clean Git worktree before generators run. The bundler replaces one exact source-identity module with that immutable commit literal; source runs keep an `undefined` fallback, so environment variables, globals, and source paths cannot forge artifact provenance. Existing `omp --version` output is unchanged.

This is independent of the session-compaction event in #8703.

## Why

> これはまだ通常のSheltie配布経路へbindされていない。Herdrが起動するompをfork buildへ明示的に向ける必要がある。

Sheltie needs a machine-readable way to verify that the executable it launches was compiled from the expected OMP source revision. Runtime Git lookup cannot prove the identity of deployed bytes, so the revision must be bound during compilation and reported by the artifact itself.

## Testing

- `bun test packages/utils/test/runtime-build-info.test.ts packages/coding-agent/test/cli-build-info.test.ts packages/coding-agent/test/compile-binary.test.ts` — 7 passed, 17 assertions
- `bun check` — TypeScript, Biome, and Rust checks passed
- `bun --cwd=packages/coding-agent run build` — passed
- `packages/coding-agent/dist/omp --build-info` — emitted `{"schema":"sheltie.runtime-build-info/v1","name":"omp","version":"17.3.7","sourceCommit":"1b61b3fa555d799ad03e9348e73e36112714b0d3"}`
- `packages/coding-agent/dist/omp --version` — emitted `omp/17.3.7`
- Source-run spoof probe with both `PI_SOURCE_COMMIT` and `PI_COMPILED` set — rejected with exit code 1 and no JSONL output

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing CLI/build contract)