### PR TITLE
fix(coding-agent): stop pinning worker subprocess cwd to the install dir

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
+- Fixed worker subprocesses (memory embeddings, tiny-model titles, TTS/STT, JS eval, browser relay, LSP mux, daemon broker) running with their cwd pinned to the CLI install directory. They share the agent's foreground process group, and terminal cwd heuristics such as kitty's `new_tab_with_cwd` pick the newest process in that group, so new terminal tabs opened in `~/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist` while any worker was alive. Workers now spawn with the absolute host entry and inherit the agent's cwd.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -108,17 +108,20 @@ export const SMOKE_TEST_TIMEOUT_MS = 30_000;
 /**
  * Resolve the command used to relaunch the agent CLI into worker mode. In a
  * compiled binary the entry point is the binary itself; otherwise re-enter the
- * declared worker-host entry with a cwd-relative script path (Bun's subprocess
- * IPC is more reliable that way under `bun test`), falling back to this
- * package's own `src/cli.ts` when no host entry is declared (bun test, SDK
- * embedding).
+ * declared worker-host entry by absolute path. Workers deliberately spawn
+ * without a pinned cwd there: they share the parent's foreground process
+ * group, and terminal cwd heuristics (kitty's new_tab_with_cwd) read the
+ * newest process in that group, so anchoring them to the install dir leaks
+ * into newly opened terminal tabs. With no declared host entry (bun test, SDK
+ * embedding) fall back to a cwd-relative `src/cli.ts`, which Bun subprocess
+ * IPC handles more reliably under `bun test`.
  */
 export function resolveWorkerSpawnCmd(workerArg: string): WorkerSpawnCommand {
 	const executable = stripWindowsExtendedLengthPathPrefix(process.execPath);
 	if (isCompiledBinary()) return { cmd: [executable, workerArg] };
 	const hostEntry = workerHostEntry();
 	if (hostEntry) {
-		return { cmd: [executable, path.basename(hostEntry), workerArg], cwd: path.dirname(hostEntry) };
+		return { cmd: [executable, hostEntry, workerArg] };
 	}
 	const packageRoot = path.resolve(import.meta.dir, "..", "..");
 	return { cmd: [executable, "src/cli.ts", workerArg], cwd: packageRoot };


### PR DESCRIPTION
When running omp directly in a shell inside kitty, creating a new tab with new_tab_with_cwd (default Ctrl+Shift+T binding) opens the new tab in the omp installation directory (~/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist) instead of the project directory.

omp's background worker subprocesses are spawned with their cwd pinned to the install dir while remaining in omp's foreground process group, and kitty's cwd heuristic picks the newest process in that group — the worker — as the source of the "current directory".