### PR TITLE
fix(settings): hide excluded search providers from summary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `providers.cacheRetention` setting (`/settings` → Providers → Protocol) to control prompt-cache retention per request: `auto` keeps the provider default (Anthropic: 5m entries with idle keep-alive refreshes), `short` forces 5m, `long` restores 1h TTLs where supported and disables the keep-alive refresh loop, `none` disables prompt caching.
 
+### Fixed
+
+- Fixed the Web Search Provider Order settings summary showing providers excluded from web search ([#8884](https://github.com/can1357/oh-my-pi/issues/8884)).
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1168,15 +1168,15 @@ export class SettingsSelectorComponent implements Component {
 		return entries.map(([provider, limit]) => `${provider}: ${limit}`).join(", ");
 	}
 
-	#createMultiSelect(def: SettingDef & { type: "multiselect" }, done: (value?: string) => void): Container {
-		let options = def.options;
-		if (def.path === "providers.webSearchOrder") {
-			const excluded: unknown = settings.get("providers.webSearchExclude");
-			if (Array.isArray(excluded)) {
-				options = options.filter(option => !excluded.includes(option.value));
-			}
-		}
+	#getMultiSelectOptions(def: SettingDef & { type: "multiselect" }) {
+		if (def.path !== "providers.webSearchOrder") return def.options;
+		const excluded: unknown = settings.get("providers.webSearchExclude");
+		if (!Array.isArray(excluded)) return def.options;
+		return def.options.filter(option => !excluded.includes(option.value));
+	}
 
+	#createMultiSelect(def: SettingDef & { type: "multiselect" }, done: (value?: string) => void): Container {
+		const options = this.#getMultiSelectOptions(def);
 		const current: unknown = settings.get(def.path);
 		const initial = Array.isArray(current)
 			? current.filter((entry): entry is string => typeof entry === "string")
@@ -1196,9 +1196,15 @@ export class SettingsSelectorComponent implements Component {
 	}
 
 	#formatMultiSelectValue(def: SettingDef & { type: "multiselect" }, value: unknown): string {
-		const ids = Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
-		if (ids.length === 0) return def.ordered ? "default" : "none";
-		const labels = ids.map(id => def.options.find(option => option.value === id)?.label ?? id);
+		const options = this.#getMultiSelectOptions(def);
+		const labels = Array.isArray(value)
+			? value.flatMap(entry => {
+					if (typeof entry !== "string") return [];
+					const option = options.find(candidate => candidate.value === entry);
+					return option ? [option.label] : [];
+				})
+			: [];
+		if (labels.length === 0) return def.ordered ? "default" : "none";
 		return def.ordered ? labels.join(" → ") : labels.join(", ");
 	}
 

--- a/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
@@ -96,6 +96,32 @@ describe("multiselect settings (array-of-enum)", () => {
 		expect(menu).toContain(secondChoice!.label);
 	});
 
+	it("hides excluded providers from the web search order row summary", () => {
+		const comp = createSelector();
+		settings.set("providers.webSearchOrder", [firstChoice!.value, secondChoice!.value]);
+		settings.set("providers.webSearchExclude", [firstChoice!.value]);
+		for (const ch of "web search provider order") comp.handleInput(ch);
+
+		const row = Bun.stripANSI(comp.render(120).join("\n"))
+			.split("\n")
+			.find(line => line.includes("Web Search Provider Order"));
+		expect(row).not.toContain(firstChoice!.label);
+		expect(row).toContain(secondChoice!.label);
+	});
+
+	it("shows the default web search order when every configured provider is excluded", () => {
+		const comp = createSelector();
+		settings.set("providers.webSearchOrder", [firstChoice!.value]);
+		settings.set("providers.webSearchExclude", [firstChoice!.value]);
+		for (const ch of "web search provider order") comp.handleInput(ch);
+
+		const row = Bun.stripANSI(comp.render(120).join("\n"))
+			.split("\n")
+			.find(line => line.includes("Web Search Provider Order"));
+		expect(row).not.toContain(firstChoice!.label);
+		expect(row).toContain("default");
+	});
+
 	it("splices the hovered option into the pressed digit's position", () => {
 		const [a, b, c] = SEARCH_PROVIDER_CHOICES;
 		const comp = createSelector();


### PR DESCRIPTION
## What

I reviewed the full diff; this change ensures that the Web Search Provider Order summary matches the providers available in its selector.

- Reuse the same filtered multiselect options when rendering the row summary and the selector.
- Hide excluded and otherwise unavailable providers from the saved-order summary.
- Show `default` when every configured provider is excluded.
- Add regression coverage for partial and complete exclusion.
- Update the coding-agent changelog.

## Why

The Web Search Provider Order selector already filters providers listed in `providers.webSearchExclude`, but the main settings row formatted the raw stored order without applying that filter.

This caused the row summary to display providers that the selector and web search runtime had already excluded.

Fixes #8884

## Testing

- Configured the order as `Perplexity → Gemini` and excluded `Perplexity`.
- Confirmed the main settings row displays only `Gemini`.
- Confirmed the selector does not display `Perplexity` and still displays `Gemini`.
- Confirmed the row displays `default` when every configured provider is excluded.
- `bun check`
- `bun test packages/coding-agent/test/modes/components/settings-multiselect.test.ts` — 6 passed.
- Related settings component tests — 22 passed.
- An expanded selector test run had 50 passes and one unrelated Windows cleanup failure: `EBUSY` while removing a temporary directory; the same test failed at cleanup when rerun alone.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)