### PR TITLE
feat(image): add Black Forest Labs (FLUX) image provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Black Forest Labs (`bfl`) as a login provider.
+
 ### Fixed
 
 - Fixed local OpenAI-compatible servers with strict `chat_template_kwargs` whitelists (e.g. NInfer) failing every Qwen 3.8+ turn with `400 chat_template_kwargs.reasoning_effort is not supported` after the effort routing fix: the reasoning-effort fallback now recognizes a rejection of the kwargs spelling itself, retries with the kwarg stripped while keeping the effort on the standard top-level `reasoning_effort` field (hoisting it there for the kwargs-only vLLM dialect), and remembers the shape for the rest of the session. Value-level rejections and drops now also update the `chat_template_kwargs.reasoning_effort` twin instead of leaving a stale effort for kwargs-reading renderers, and unknown-parameter 400s naming `reasoning_effort` are recognized as effort rejections.

--- a/packages/ai/src/registry/black-forest-labs.ts
+++ b/packages/ai/src/registry/black-forest-labs.ts
@@ -1,0 +1,13 @@
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const bflProvider = {
+	id: "bfl",
+	name: "Black Forest Labs (FLUX)",
+	envKeys: "BFL_API_KEY",
+	login: async (cb: OAuthLoginCallbacks) => {
+		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
+		const { loginBfl } = await import("./oauth/black-forest-labs");
+		return loginBfl(cb);
+	},
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/black-forest-labs.ts
+++ b/packages/ai/src/registry/oauth/black-forest-labs.ts
@@ -1,0 +1,58 @@
+import * as AIError from "../../error";
+import { ProviderHttpError } from "../../error/classes";
+import { createApiKeyLogin } from "../api-key-login";
+import type { OAuthController } from "./types";
+
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+// BFL reads only the x-key header; Authorization: Bearer is ignored.
+async function validateBflApiKey(apiKey: string, options: OAuthController): Promise<void> {
+	const timeoutSignal = AbortSignal.timeout(VALIDATION_TIMEOUT_MS);
+	const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+	const fetchImpl = options.fetch ?? fetch;
+
+	let response: Response;
+	try {
+		response = await fetchImpl("https://api.bfl.ai/v1/credits", {
+			method: "GET",
+			headers: { "x-key": apiKey },
+			signal,
+		});
+	} catch {
+		if (options.signal?.aborted) throw new AIError.LoginCancelledError();
+		return; // fail open: connectivity must not block storing a pasted key
+	}
+
+	if (response.status !== 401 && response.status !== 403 && response.status !== 422) {
+		return; // 200 = valid; 5xx/429 fail open
+	}
+
+	let detail = "";
+	try {
+		const body = (await response.json()) as { detail?: unknown };
+		if (typeof body.detail === "string") detail = body.detail;
+	} catch {
+		// keep the HTTP status as the failure category
+	}
+
+	const message = detail
+		? `Black Forest Labs API key validation failed (${response.status}): ${detail}`
+		: `Black Forest Labs API key validation failed (${response.status})`;
+	throw new ProviderHttpError(message, response.status, { headers: response.headers });
+}
+
+const pasteBflKey = createApiKeyLogin({
+	providerLabel: "Black Forest Labs",
+	authUrl: "https://dashboard.bfl.ai/keys",
+	instructions: "Create or copy an API key in the BFL dashboard, then paste it here.",
+	promptMessage: "Paste your BFL API key",
+	placeholder: "API key from dashboard.bfl.ai/keys",
+	validation: null,
+});
+
+export async function loginBfl(options: OAuthController): Promise<string> {
+	const key = await pasteBflKey(options);
+	options.onProgress?.("Validating API key...");
+	await validateBflApiKey(key, options);
+	return key;
+}

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -8,6 +8,7 @@ import { anthropicProvider } from "./anthropic";
 import { azureProvider } from "./azure";
 import { basetenProvider } from "./baseten";
 import { bedrockMantleProvider } from "./bedrock-mantle";
+import { bflProvider } from "./black-forest-labs";
 import { cerebrasProvider } from "./cerebras";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
 import { coreWeaveProvider } from "./coreweave";
@@ -145,6 +146,7 @@ const ALL = [
 	tavilyProvider,
 	kagiProvider,
 	exaProvider,
+	bflProvider,
 	parallelProvider,
 	ollamaProvider,
 	ollamaCloudProvider,

--- a/packages/ai/test/black-forest-labs-login.test.ts
+++ b/packages/ai/test/black-forest-labs-login.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "bun:test";
+import { LoginCancelledError } from "@oh-my-pi/pi-ai/error";
+import { loginBfl } from "@oh-my-pi/pi-ai/registry/oauth/black-forest-labs";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+describe("bfl login", () => {
+	it("validates the trimmed pasted key via x-key against the credits endpoint and rejects on 403", async () => {
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			expect(url).toBe("https://api.bfl.ai/v1/credits");
+			expect(init?.method).toBe("GET");
+			// BFL authenticates via x-key only - never Authorization: Bearer.
+			expect(init?.headers).toEqual({ "x-key": "bfl-test-key" });
+			return new Response(JSON.stringify({ detail: "Not authenticated" }), {
+				status: 403,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await expect(
+			loginBfl({
+				onPrompt: async () => "  bfl-test-key  ",
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Black Forest Labs API key validation failed (403): Not authenticated");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails open when the validation request cannot reach the network", async () => {
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			throw new Error("network unreachable");
+		});
+
+		const apiKey = await loginBfl({
+			onPrompt: async () => "bfl-offline-key",
+			fetch: fetchMock,
+		});
+
+		expect(apiKey).toBe("bfl-offline-key");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a malformed key with the 422 detail from the API", async () => {
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			return new Response(JSON.stringify({ detail: "Invalid API key format" }), {
+				status: 422,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await expect(
+			loginBfl({
+				onPrompt: async () => "not-a-key",
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Black Forest Labs API key validation failed (422): Invalid API key format");
+	});
+
+	it("surfaces cancellation instead of failing open when the user aborts mid-validation", async () => {
+		const controller = new AbortController();
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			controller.abort();
+			throw new Error("request aborted");
+		});
+
+		await expect(
+			loginBfl({
+				onPrompt: async () => "bfl-aborted-key",
+				fetch: fetchMock,
+				signal: controller.signal,
+			}),
+		).rejects.toThrow(LoginCancelledError);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
+- Added Black Forest Labs (FLUX) to the `generate_image` tool: text-to-image via `flux-2-pro`, edits via `flux-kontext-pro`, authenticated with `/login bfl` or `BFL_API_KEY`.
 
 ### Changed
 

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -34,6 +34,10 @@ const DEFAULT_MODEL = "gemini-3-pro-image-preview";
 const DEFAULT_OPENROUTER_MODEL = "google/gemini-3-pro-image-preview";
 const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3-pro-image";
 const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image";
+const DEFAULT_BFL_IMAGE_MODEL = "flux-2-pro";
+const DEFAULT_BFL_EDIT_MODEL = "flux-kontext-pro";
+const BFL_BASE_URL = "https://api.bfl.ai/v1";
+const BFL_POLL_INTERVAL_MS = 1500;
 const IMAGE_TIMEOUT = 3 * 60 * 1000; // 3 minutes
 const MAX_IMAGE_SIZE = 35 * 1024 * 1024;
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -319,6 +323,35 @@ type XAIImageRequestBody =
 	| (XAIImageRequestBase & { readonly image: XAIImageReference; readonly images?: never })
 	| (XAIImageRequestBase & { readonly images: readonly XAIImageReference[]; readonly image?: never });
 
+// BFL task API: POST /v1/<model> -> {id, polling_url}; poll until "Ready".
+interface BFLGenerationRequest {
+	prompt: string;
+	/** Kontext models only; others ignore it. */
+	aspect_ratio?: string;
+	width?: number;
+	height?: number;
+	/** Base64 source image (Kontext edits). */
+	input_image?: string;
+}
+
+// flux-2-pro/flux-pro-1.1 take width/height and ignore aspect_ratio (Kontext only).
+function resolveBFLDimensions(aspectRatio: string): { width: number; height: number } {
+	const [w = 1, h = 1] = aspectRatio.split(":").map(Number);
+	const scale = Math.sqrt((1024 * 1024) / (w * h));
+	const snap = (term: number) => Math.min(1440, Math.max(256, Math.floor((term * scale) / 32) * 32));
+	return { width: snap(w), height: snap(h) };
+}
+
+interface BFLSubmitResponse {
+	id?: string;
+	polling_url?: string;
+}
+
+interface BFLResultResponse {
+	status?: string;
+	result?: { sample?: string };
+}
+
 interface AntigravityResponseChunk {
 	response?: {
 		candidates?: Array<{
@@ -451,11 +484,11 @@ export function setImageProviderOrder(providers: readonly string[]): void {
 	configuredImageProviderOrder = providers.filter(isImageProviderId);
 }
 function assertImageAspectRatioSupported(provider: ImageProvider, aspectRatio: ImageGenParams["aspect_ratio"]): void {
-	if (!aspectRatio || provider === "xai" || COMMON_IMAGE_ASPECT_RATIO_SET.has(aspectRatio)) {
+	if (!aspectRatio || provider === "xai" || provider === "bfl" || COMMON_IMAGE_ASPECT_RATIO_SET.has(aspectRatio)) {
 		return;
 	}
 	throw new Error(
-		`Aspect ratio ${aspectRatio} is only supported by xAI image generation. Set providers.image to xai or use one of ${COMMON_IMAGE_ASPECT_RATIOS.join(", ")}.`,
+		`Aspect ratio ${aspectRatio} is only supported by xAI and BFL image generation. Set providers.image to xai or bfl, or use one of ${COMMON_IMAGE_ASPECT_RATIOS.join(", ")}.`,
 	);
 }
 
@@ -518,6 +551,18 @@ async function findOpenRouterImageCredentials(
 	}
 	const apiKey = getEnvApiKey("openrouter");
 	if (apiKey) return { provider: "openrouter", apiKey };
+	return null;
+}
+
+async function findBFLImageCredentials(modelRegistry?: ModelRegistry, sessionId?: string): Promise<ImageApiKey | null> {
+	if (modelRegistry) {
+		// AuthStorage.getApiKey already falls back to env keys, so this covers BFL_API_KEY too.
+		const apiKey = await modelRegistry.getApiKeyForProvider("bfl", sessionId);
+		if (apiKey) return { provider: "bfl", apiKey: modelRegistry.resolver("bfl", { sessionId }) };
+		return null;
+	}
+	const apiKey = getEnvApiKey("bfl") ?? $env.BFL_API_KEY;
+	if (apiKey) return { provider: "bfl", apiKey };
 	return null;
 }
 
@@ -649,6 +694,8 @@ async function findImageApiKey(
 			return modelRegistry ? findAntigravityCredentials(modelRegistry, sessionId) : null;
 		case "xai":
 			return findXAIImageCredentials(modelRegistry);
+		case "bfl":
+			return findBFLImageCredentials(modelRegistry, sessionId);
 		case "openrouter":
 			return findOpenRouterImageCredentials(modelRegistry, sessionId);
 		case "gemini":
@@ -1135,11 +1182,16 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 									? DEFAULT_OPENROUTER_MODEL
 									: provider === "xai"
 										? DEFAULT_XAI_IMAGE_MODEL
-										: DEFAULT_MODEL;
+										: provider === "bfl"
+											? resolvedImages.length > 0
+												? DEFAULT_BFL_EDIT_MODEL
+												: DEFAULT_BFL_IMAGE_MODEL
+											: DEFAULT_MODEL;
 					const resolvedModel = provider === "openrouter" ? resolveOpenRouterModel(model) : model;
 					if (
 						params.aspect_ratio &&
 						provider !== "xai" &&
+						provider !== "bfl" &&
 						!COMMON_IMAGE_ASPECT_RATIO_SET.has(params.aspect_ratio)
 					) {
 						unsupportedAspectRatioProvider ??= provider;
@@ -1545,6 +1597,118 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						};
 					}
 
+					if (provider === "bfl") {
+						const prompt = assemblePrompt(params);
+						// ProviderHttpError (not plain Error) so the provider loop falls through.
+						if (resolvedImages.length > 1) {
+							throw new ProviderHttpError(
+								`BFL Kontext edits accept a single reference image; got ${resolvedImages.length}.`,
+								422,
+							);
+						}
+						const bflBody: BFLGenerationRequest =
+							resolvedImages.length > 0
+								? {
+										prompt,
+										...(params.aspect_ratio ? { aspect_ratio: params.aspect_ratio } : {}),
+										input_image: resolvedImages[0].data,
+									}
+								: { prompt, ...resolveBFLDimensions(params.aspect_ratio ?? "1:1") };
+
+						const sampleUrl = await withAuth(
+							apiKey.apiKey,
+							async key => {
+								// x-key only; Authorization: Bearer is ignored.
+								const submitResp = await fetchImpl(`${BFL_BASE_URL}/${resolvedModel}`, {
+									method: "POST",
+									headers: { "x-key": key, "Content-Type": "application/json" },
+									body: JSON.stringify(bflBody),
+									signal: requestSignal,
+								});
+								const submitText = await submitResp.text();
+								if (!submitResp.ok) {
+									throw new ProviderHttpError(
+										`BFL image request failed (${submitResp.status}): ${submitText}`,
+										submitResp.status,
+										{ headers: submitResp.headers },
+									);
+								}
+								let submitted: BFLSubmitResponse;
+								try {
+									submitted = JSON.parse(submitText) as BFLSubmitResponse;
+								} catch {
+									throw new ProviderHttpError(`BFL returned malformed JSON: ${submitText.slice(0, 200)}`, 502);
+								}
+								const pollingUrl = submitted.polling_url ?? `${BFL_BASE_URL}/get_result?id=${submitted.id}`;
+
+								// requestSignal (3-min IMAGE_TIMEOUT) bounds the poll loop.
+								for (;;) {
+									const pollResp = await fetchImpl(pollingUrl, {
+										method: "GET",
+										headers: { "x-key": key },
+										signal: requestSignal,
+									});
+									const pollText = await pollResp.text();
+									if (!pollResp.ok) {
+										throw new ProviderHttpError(
+											`BFL image poll failed (${pollResp.status}): ${pollText}`,
+											pollResp.status,
+											{ headers: pollResp.headers },
+										);
+									}
+									let poll: BFLResultResponse;
+									try {
+										poll = JSON.parse(pollText) as BFLResultResponse;
+									} catch {
+										throw new ProviderHttpError(
+											`BFL returned malformed JSON: ${pollText.slice(0, 200)}`,
+											502,
+										);
+									}
+									if (poll.status === "Ready") {
+										const sample = poll.result?.sample;
+										if (!sample) {
+											throw new ProviderHttpError(`BFL result missing sample URL: ${pollText}`, 502);
+										}
+										return sample;
+									}
+									if (poll.status !== "Pending" && poll.status !== "Queued" && poll.status !== "Processing") {
+										throw new ProviderHttpError(
+											`BFL image generation failed (${poll.status ?? "unknown status"}): ${pollText}`,
+											422,
+										);
+									}
+									await Bun.sleep(BFL_POLL_INTERVAL_MS);
+								}
+							},
+							{ signal: requestSignal },
+						);
+
+						// result.sample is a signed URL (~10 min); download immediately. Download
+						// failures throw plain Error, so wrap them for provider fallthrough.
+						let bflImage: InlineImageData;
+						try {
+							bflImage = await loadImageFromUrl(sampleUrl, fetchImpl, requestSignal);
+						} catch (error) {
+							if (error instanceof ProviderHttpError) throw error;
+							throw new ProviderHttpError(error instanceof Error ? error.message : String(error), 502);
+						}
+						const bflImagePaths = await saveImagesToTemp([bflImage]);
+
+						return {
+							content: [
+								{ type: "text", text: buildResponseSummary(provider, resolvedModel, bflImagePaths, undefined) },
+							],
+							details: {
+								provider,
+								model: resolvedModel,
+								imageCount: 1,
+								imagePaths: bflImagePaths,
+								images: [bflImage],
+							},
+						};
+					}
+
 					const parts = [] as Array<{ text?: string; inlineData?: InlineImageData }>;
 					for (const image of resolvedImages) {
 						parts.push({ inlineData: image });
@@ -1656,7 +1820,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 			if (!foundCredentials) {
 				throw new Error(
-					"No image API credentials found. Connect a Codex (ChatGPT) subscription, use a GPT Responses/Codex model with OpenAI credentials, log in with google-antigravity or xAI Grok OAuth, or set OPENAI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
+					"No image API credentials found. Connect a Codex (ChatGPT) subscription, use a GPT Responses/Codex model with OpenAI credentials, log in with google-antigravity, xAI Grok OAuth, or Black Forest Labs, or set OPENAI_API_KEY, XAI_API_KEY, BFL_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
 				);
 			}
 

--- a/packages/coding-agent/src/tools/image-providers.ts
+++ b/packages/coding-agent/src/tools/image-providers.ts
@@ -7,7 +7,7 @@
  */
 
 /** Image generation backends, in settings/tool vocabulary. */
-export type ImageProvider = "antigravity" | "gemini" | "openai" | "openai-codex" | "openrouter" | "xai";
+export type ImageProvider = "antigravity" | "bfl" | "gemini" | "openai" | "openai-codex" | "openrouter" | "xai";
 
 /** Auto-resolution fallback order when no configured entry or session provider matches. */
 export const AUTO_IMAGE_PROVIDER_ORDER: readonly ImageProvider[] = [
@@ -15,6 +15,7 @@ export const AUTO_IMAGE_PROVIDER_ORDER: readonly ImageProvider[] = [
 	"openai-codex",
 	"antigravity",
 	"xai",
+	"bfl",
 	"openrouter",
 	"gemini",
 ];
@@ -40,6 +41,11 @@ export const IMAGE_PROVIDER_CHOICES = [
 		value: "xai",
 		label: "xAI Grok Imagine",
 		description: "Requires xAI Grok OAuth or XAI_API_KEY",
+	},
+	{
+		value: "bfl",
+		label: "Black Forest Labs",
+		description: "FLUX via /login bfl or BFL_API_KEY",
 	},
 	{ value: "gemini", label: "Gemini", description: "Requires GEMINI_API_KEY" },
 	{ value: "openrouter", label: "OpenRouter", description: "Requires OPENROUTER_API_KEY" },

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -806,4 +806,389 @@ describe("imageGenTool", () => {
 		expect(requestUrls).toEqual(["https://api.x.ai/v1/images/generations"]);
 		expect(result.details?.provider).toBe("xai");
 	});
+
+	function createBFLContext(fetchMock: typeof fetch, extraProviders: Record<string, string> = {}): CustomToolContext {
+		const providerKeys: Record<string, string> = { bfl: "test-bfl-key", ...extraProviders };
+		return {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => undefined,
+				getApiKeyForProvider: async (provider: string) => providerKeys[provider],
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: (provider: string) => provider in providerKeys,
+					rotateSessionCredential: async () => false,
+				},
+				resolver: (provider: string) => async () => providerKeys[provider] ?? "test-bfl-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+	}
+
+	it("generates a BFL image via submit, poll, and signed sample download", async () => {
+		setImageProviderOrder(["bfl"]);
+		const requestUrls: string[] = [];
+		let submitBody: Record<string, unknown> | undefined;
+		let pollCount = 0;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url === "https://api.bfl.ai/v1/flux-2-pro") {
+				submitBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return new Response(
+					JSON.stringify({ id: "task-1", polling_url: "https://api.eu.bfl.ai/v1/get_result?id=task-1" }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://api.eu.bfl.ai/v1/get_result?id=task-1") {
+				pollCount += 1;
+				if (pollCount === 1) {
+					return new Response(JSON.stringify({ status: "Pending" }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response(
+					JSON.stringify({ status: "Ready", result: { sample: "https://delivery.bfl.ai/sample.png" } }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://delivery.bfl.ai/sample.png") {
+				return new Response(Buffer.from("fake-bfl-image"), {
+					status: 200,
+					headers: { "content-type": "image/png" },
+				});
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock);
+		const result = await imageGenTool.execute("call-bfl", { subject: "a fox", aspect_ratio: "4:3" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://api.bfl.ai/v1/flux-2-pro",
+			"https://api.eu.bfl.ai/v1/get_result?id=task-1",
+			"https://api.eu.bfl.ai/v1/get_result?id=task-1",
+			"https://delivery.bfl.ai/sample.png",
+		]);
+		// flux-2-pro ignores aspect_ratio: the ratio must arrive as explicit dimensions.
+		expect(submitBody).toEqual({ prompt: "a fox.", width: 1152, height: 864 });
+		expect(result.details?.provider).toBe("bfl");
+		expect(result.details?.model).toBe("flux-2-pro");
+		expect(result.details?.imageCount).toBe(1);
+		expect(result.details?.images?.[0]?.data).toBe(Buffer.from("fake-bfl-image").toBase64());
+		const savedPath = result.details?.imagePaths[0];
+		if (!savedPath) throw new Error("Expected generated image path");
+		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-bfl-image"));
+	}, 15_000);
+
+	it("authenticates BFL submit and poll requests with the x-key header, never Authorization", async () => {
+		setImageProviderOrder(["bfl"]);
+		const captured: { xKey: string | null; authorization: string | null } = { xKey: null, authorization: null };
+		const pollCaptured: { xKey: string | null; authorization: string | null } = { xKey: null, authorization: null };
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			if (url === "https://api.bfl.ai/v1/flux-2-pro") {
+				const headers = new Headers(init?.headers);
+				captured.xKey = headers.get("x-key");
+				captured.authorization = headers.get("authorization");
+				return new Response(
+					JSON.stringify({ id: "task-2", polling_url: "https://api.eu.bfl.ai/v1/get_result?id=task-2" }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://api.eu.bfl.ai/v1/get_result?id=task-2") {
+				const headers = new Headers(init?.headers);
+				pollCaptured.xKey = headers.get("x-key");
+				pollCaptured.authorization = headers.get("authorization");
+				return new Response(
+					JSON.stringify({ status: "Ready", result: { sample: "https://delivery.bfl.ai/sample2.png" } }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response(Buffer.from("bfl-wire-image"), {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock);
+		const result = await imageGenTool.execute("call-bfl-wire", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(captured.xKey).toBe("test-bfl-key");
+		expect(captured.authorization).toBeNull();
+		// The regional polling URL is authenticated the same way as the submit.
+		expect(pollCaptured.xKey).toBe("test-bfl-key");
+		expect(pollCaptured.authorization).toBeNull();
+		expect(result.details?.provider).toBe("bfl");
+	});
+
+	it("maps xAI-only ratios to explicit BFL dimensions instead of skipping the provider", async () => {
+		setImageProviderOrder(["bfl"]);
+		let submitBody: Record<string, unknown> | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			if (url === "https://api.bfl.ai/v1/flux-2-pro") {
+				submitBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return new Response(
+					JSON.stringify({ id: "task-5", polling_url: "https://api.eu.bfl.ai/v1/get_result?id=task-5" }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://api.eu.bfl.ai/v1/get_result?id=task-5") {
+				return new Response(
+					JSON.stringify({ status: "Ready", result: { sample: "https://delivery.bfl.ai/sample5.png" } }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response(Buffer.from("bfl-ratio-image"), {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock);
+		const result = await imageGenTool.execute(
+			"call-bfl-ratio",
+			{ subject: "a cat", aspect_ratio: "3:2" },
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(submitBody).toEqual({ prompt: "a cat.", width: 1248, height: 832 });
+		expect(result.details?.provider).toBe("bfl");
+	});
+
+	it("falls through to the next credentialed provider on a BFL HTTP failure", async () => {
+		setImageProviderOrder(["bfl", "xai"]);
+		const requestUrls: string[] = [];
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.startsWith("https://api.bfl.ai/")) {
+				return new Response(JSON.stringify({ detail: "Not authenticated" }), {
+					status: 403,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("bfl-fallback-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock, { "xai-oauth": "test-xai-token" });
+		const result = await imageGenTool.execute("call-bfl-fallback", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual(["https://api.bfl.ai/v1/flux-2-pro", "https://api.x.ai/v1/images/generations"]);
+		expect(result.details?.provider).toBe("xai");
+	});
+
+	it("routes BFL edits to flux-kontext-pro with the source image in the body", async () => {
+		setImageProviderOrder(["bfl"]);
+		let submitUrl: string | undefined;
+		let submitBody: Record<string, unknown> | undefined;
+		const sourceImage = Buffer.from("bfl-source-image").toString("base64");
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			if (url.startsWith("https://api.bfl.ai/v1/flux-")) {
+				submitUrl = url;
+				submitBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return new Response(
+					JSON.stringify({ id: "task-3", polling_url: "https://api.eu.bfl.ai/v1/get_result?id=task-3" }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://api.eu.bfl.ai/v1/get_result?id=task-3") {
+				return new Response(
+					JSON.stringify({ status: "Ready", result: { sample: "https://delivery.bfl.ai/sample3.png" } }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response(Buffer.from("bfl-edited-image"), {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock);
+		const result = await imageGenTool.execute(
+			"call-bfl-edit",
+			{
+				subject: "a cat",
+				changes: ["make it wear a hat"],
+				aspect_ratio: "4:3",
+				input: [{ data: sourceImage, mime_type: "image/png" }],
+			},
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(submitUrl).toBe("https://api.bfl.ai/v1/flux-kontext-pro");
+		// Kontext honors aspect_ratio directly; no width/height mapping on the edit path.
+		expect(submitBody).toEqual({
+			prompt: "a cat.\n\nChanges:\n- make it wear a hat",
+			aspect_ratio: "4:3",
+			input_image: sourceImage,
+		});
+		expect(result.details?.provider).toBe("bfl");
+		expect(result.details?.model).toBe("flux-kontext-pro");
+	});
+
+	it("falls through to the next credentialed provider when a BFL poll ends terminal-non-ready", async () => {
+		setImageProviderOrder(["bfl", "xai"]);
+		const requestUrls: string[] = [];
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url === "https://api.bfl.ai/v1/flux-2-pro") {
+				return new Response(
+					JSON.stringify({ id: "task-4", polling_url: "https://api.eu.bfl.ai/v1/get_result?id=task-4" }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://api.eu.bfl.ai/v1/get_result?id=task-4") {
+				return new Response(JSON.stringify({ status: "Content Moderated" }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("bfl-moderated-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock, { "xai-oauth": "test-xai-token" });
+		const result = await imageGenTool.execute("call-bfl-moderated", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://api.bfl.ai/v1/flux-2-pro",
+			"https://api.eu.bfl.ai/v1/get_result?id=task-4",
+			"https://api.x.ai/v1/images/generations",
+		]);
+		expect(result.details?.provider).toBe("xai");
+	});
+
+	it("falls through past BFL when an edit supplies more than one reference image", async () => {
+		setImageProviderOrder(["bfl", "xai"]);
+		const requestUrls: string[] = [];
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.startsWith("https://api.bfl.ai/")) {
+				throw new Error(`BFL must not be called for multi-image edits: ${url}`);
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("bfl-multi-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const sourceImage = Buffer.from("bfl-source-image").toString("base64");
+
+		const ctx = createBFLContext(fetchMock, { "xai-oauth": "test-xai-token" });
+		const result = await imageGenTool.execute(
+			"call-bfl-multi-input",
+			{
+				subject: "a cat",
+				changes: ["make it wear a hat"],
+				input: [
+					{ data: sourceImage, mime_type: "image/png" },
+					{ data: sourceImage, mime_type: "image/png" },
+				],
+			},
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual(["https://api.x.ai/v1/images/edits"]);
+		expect(result.details?.provider).toBe("xai");
+	});
+
+	it("falls through to the next credentialed provider when BFL returns malformed JSON", async () => {
+		setImageProviderOrder(["bfl", "xai"]);
+		const requestUrls: string[] = [];
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.startsWith("https://api.bfl.ai/")) {
+				return new Response("<html>gateway error</html>", {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				});
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("bfl-malformed-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock, { "xai-oauth": "test-xai-token" });
+		const result = await imageGenTool.execute("call-bfl-malformed", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual(["https://api.bfl.ai/v1/flux-2-pro", "https://api.x.ai/v1/images/generations"]);
+		expect(result.details?.provider).toBe("xai");
+	});
+
+	it("falls through to the next credentialed provider when the BFL sample download fails", async () => {
+		setImageProviderOrder(["bfl", "xai"]);
+		const requestUrls: string[] = [];
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url === "https://api.bfl.ai/v1/flux-2-pro") {
+				return new Response(
+					JSON.stringify({ id: "task-6", polling_url: "https://api.eu.bfl.ai/v1/get_result?id=task-6" }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://api.eu.bfl.ai/v1/get_result?id=task-6") {
+				return new Response(
+					JSON.stringify({ status: "Ready", result: { sample: "https://delivery.bfl.ai/sample6.png" } }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://delivery.bfl.ai/sample6.png") {
+				return new Response("expired signature", { status: 403 });
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("bfl-download-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx = createBFLContext(fetchMock, { "xai-oauth": "test-xai-token" });
+		const result = await imageGenTool.execute("call-bfl-download-fail", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://api.bfl.ai/v1/flux-2-pro",
+			"https://api.eu.bfl.ai/v1/get_result?id=task-6",
+			"https://delivery.bfl.ai/sample6.png",
+			"https://api.x.ai/v1/images/generations",
+		]);
+		expect(result.details?.provider).toBe("xai");
+	});
 });


### PR DESCRIPTION
## What

Adds black forest labs flux models as an image provider
https://bfl.ai/models

## Why

unlock using FLUX models

## Testing

<img width="543" height="541" alt="Screenshot 2026-08-18 at 9 10 46 AM" src="https://github.com/user-attachments/assets/fb1d460d-1966-4e6d-b808-5fa08d4a3c5a" />

test gen in omp with api 

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
