### PR TITLE
Advisor blocker advisories wake a new turn instead of parking in the immune window

### DIFF
--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -110,8 +110,10 @@ export function isAdvisorInterruptImmuneTurnActive(opts: {
  *   auto-resume anything, so it is delivered live. Parking it during an active
  *   run instead strands it (it never reaches the running agent) and the withheld
  *   notes dump as one burst at the next user prompt — the bug this guards.
- * - During the post-interrupt immune-turn window, further `concern`/`blocker`
- *   notes are downgraded to asides; preservation still wins.
+ * - During the post-interrupt immune-turn window, further `concern` notes are
+ *   downgraded to asides; preservation still wins. A `blocker` is exempt: it
+ *   means the agent handed off broken or unexercised work, so it still steers a
+ *   triggered turn even right after a prior interrupt (#5628).
  */
 export function resolveAdvisorDeliveryChannel(opts: {
 	severity: AdvisorSeverity | undefined;
@@ -127,7 +129,7 @@ export function resolveAdvisorDeliveryChannel(opts: {
 	if (opts.autoResumeSuppressed && (opts.aborting || !opts.streaming)) return "preserve";
 	if (opts.terminalAnswerNoQueuedWork && opts.severity !== "blocker" && !opts.streaming && !opts.aborting)
 		return "preserve";
-	if (opts.interruptImmuneTurnActive) return "aside";
+	if (opts.interruptImmuneTurnActive && opts.severity !== "blocker") return "aside";
 	return "steer";
 }
 

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -5509,7 +5509,7 @@ describe("advisor", () => {
 			).toBe("steer");
 		});
 
-		it("routes interrupting notes to the aside queue during immune turns without overriding preservation", () => {
+		it("downgrades concern to aside during immune turns, but still steers a blocker (#5628)", () => {
 			expect(
 				resolveAdvisorDeliveryChannel({
 					severity: "concern",
@@ -5519,6 +5519,15 @@ describe("advisor", () => {
 					interruptImmuneTurnActive: true,
 				}),
 			).toBe("aside");
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: false,
+					streaming: false,
+					aborting: false,
+					interruptImmuneTurnActive: true,
+				}),
+			).toBe("steer");
 			expect(
 				resolveAdvisorDeliveryChannel({
 					severity: "blocker",


### PR DESCRIPTION
An advisor blocker note at the end of a turn did not start a new turn.

The post-interrupt immune window downgraded every interrupting note to a queued aside. A blocker means the agent handed off broken or unexercised work, so parking it until the next user prompt left the handoff unacknowledged.

Before: the blocker queued as an aside and sat until the next user input.
After: a blocker bypasses the immune window and steers a triggered turn. Concerns keep the cooldown. This matches the existing blocker exception for terminal answers (#5628).

Verified: 294 advisor tests green, tsgo clean.