### PR TITLE
fix(coding-agent): condition think prelude guidance for subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagents aborting when external thinking exposes `think` as the required prelude before their remaining tools become callable ([#8909](https://github.com/can1357/oh-my-pi/pull/8909) by [@olegpulatov](https://github.com/olegpulatov)).
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -96,7 +96,7 @@ Write JSON args as `content` to `xd://<tool>` via `{{toolRefs.write}}`. Invalid 
 
 {{#has tools "think"}}
 § Scratchpad
-`{{toolRefs.think}}`: private scratchpad; not shown to user.
+`{{toolRefs.think}}`: private scratchpad; not shown to user. MUST use for planning; other tools become callable when it completes.
 {{/has}}
 
 § Tool Policy

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -206,7 +206,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.setModel(fable);
 			expect(session.getToolByName("think")).toBeDefined();
 			expect(session.getActiveToolNames()).toContain("think");
-			expect(session.systemPrompt.join("\n")).toContain("private scratchpad; not shown to user");
+			expect(session.systemPrompt.join("\n")).toContain("other tools become callable when it completes");
 
 			await session.setModel(responses);
 			expect(session.getActiveToolNames()).toContain("think");
@@ -217,7 +217,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 
 			await session.setModel(unsupported);
 			expect(session.getActiveToolNames()).not.toContain("think");
-			expect(session.systemPrompt.join("\n")).not.toContain("private scratchpad; not shown to user");
+			expect(session.systemPrompt.join("\n")).not.toContain("other tools become callable when it completes");
 		} finally {
 			await session.dispose();
 		}


### PR DESCRIPTION
## What

add custom guidance for subagents on think tool
I choose here system prompt as they are shared, can be only subagent
because sometimes main agent skipped thinking

not covered here but spotted:
there is no upper bound on thinking besides max output context

## Why

sol-med task subagent refused to work:
Args
└─ 📁 result
└─ 📄 error:

"Blocked: the assigned environment exposed only the private think tool in this worker session; filesystem
read/edit, shell execution, coordination, and result-submission tools were unavailable. I could not inspect the required e2e
mechanism, create scripts/capture-shots.mjs, run it, or verify generated PNGs without fabricating results."

filed as https://github.com/can1357/oh-my-pi/issues/8892

## Testing

giving it instructions made it proceed

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
