### PR TITLE
fix(session): generate titles from /skill invocation args

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session-title generation ignoring user `/skill:<name>` invocations, so titles now see the skill name and args instead of only later assistant text.
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -173,6 +173,11 @@ export class InputController {
 		},
 	) {}
 
+	/** Session-level title starts (user `/skill:` via promptCustomMessage) reuse this UI. */
+	notifyTitleGenerationStart(): void {
+		this.#showTinyTitleDownloadProgress(this.ctx.settings.get("providers.tinyModel"));
+	}
+
 	#enhancedPaste?: EnhancedPasteController;
 	#focusedLeftTapListenerInstalled = false;
 	#focusedPasteListenerInstalled = false;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -895,6 +895,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#selectorController = new SelectorController(this);
 		this.#focusController = new SessionFocusController(this);
 		this.#inputController = new InputController(this);
+		this.session.setTitleGenerationStart?.(() => {
+			this.#inputController.notifyTitleGenerationStart();
+		});
 		this.#observerRegistry = new SessionObserverRegistry();
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -534,6 +534,7 @@ export class AgentSession {
 	 *  generation path. Refresh via {@link AgentSession.setTitleSystemPrompt} when
 	 *  the session cwd changes. */
 	#titleSystemPrompt: string | undefined;
+	#titleGenerationStart: (() => void) | undefined;
 	#titleGenerationAbortController = new AbortController();
 	#toolChoiceQueue = new ToolChoiceQueue();
 
@@ -6551,7 +6552,7 @@ export class AgentSession {
 		if (isLocalExtensionCommand || this.sessionName || $env.PI_NO_TITLE || isLowSignalTitleInput(firstMessage)) {
 			return;
 		}
-		onStart?.();
+		(onStart ?? this.#titleGenerationStart)?.();
 		this.generateTitle(firstMessage)
 			.then(async title => {
 				// Re-check after generation so concurrent attempts cannot replace
@@ -6610,6 +6611,12 @@ export class AgentSession {
 	 *  against the destination project's override. */
 	setTitleSystemPrompt(prompt: string | undefined): void {
 		this.#titleSystemPrompt = prompt;
+	}
+
+	/** Install the interactive title-download UI hook. Used when `/skill:` starts
+	 *  titling from {@link promptCustomMessage} without the input-controller callback. */
+	setTitleGenerationStart(handler: (() => void) | undefined): void {
+		this.#titleGenerationStart = handler;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -308,6 +308,7 @@ import {
 	sanitizeAssistantForReparentedHistory,
 	USER_INTERRUPT_LABEL,
 } from "./messages";
+import { skillPromptTitleInput } from "./skill-title-input";
 import { ModelControls, type ModelControlsHost } from "./model-controls";
 import { isPrewalkPlanNudge, PrewalkCoordinator, type PrewalkCoordinatorHost } from "./prewalk";
 import {
@@ -5466,11 +5467,20 @@ export class AgentSession {
 		let keywordNotices: CustomMessage[] = [];
 		if (message.customType === SKILL_PROMPT_MESSAGE_TYPE && message.attribution === "user") {
 			const details = message.details;
+			let skillName: string | undefined;
 			let skillArgs = "";
-			if (details && typeof details === "object" && "args" in details && typeof details.args === "string") {
-				skillArgs = details.args;
+			if (details && typeof details === "object") {
+				if ("name" in details && typeof details.name === "string") skillName = details.name;
+				if ("args" in details && typeof details.args === "string") skillArgs = details.args;
 			}
 			keywordNotices = this.#createMagicKeywordNotices(skillArgs);
+			this.maybeStartTitleGeneration(
+				skillPromptTitleInput({
+					name: skillName,
+					args: skillArgs,
+					queueChipText: options?.queueChipText,
+				}),
+			);
 		}
 
 		if (options?.queueOnly) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -535,6 +535,7 @@ export class AgentSession {
 	 *  the session cwd changes. */
 	#titleSystemPrompt: string | undefined;
 	#titleGenerationStart: (() => void) | undefined;
+	#titleGenerationInFlight = false;
 	#titleGenerationAbortController = new AbortController();
 	#toolChoiceQueue = new ToolChoiceQueue();
 
@@ -6549,10 +6550,22 @@ export class AgentSession {
 			this.#extensionRunner?.getCommand(
 				extensionCommandSpace === -1 ? firstMessage.slice(1) : firstMessage.slice(1, extensionCommandSpace),
 			) !== undefined;
-		if (isLocalExtensionCommand || this.sessionName || $env.PI_NO_TITLE || isLowSignalTitleInput(firstMessage)) {
+		if (
+			isLocalExtensionCommand ||
+			this.sessionName ||
+			this.#titleGenerationInFlight ||
+			$env.PI_NO_TITLE ||
+			isLowSignalTitleInput(firstMessage)
+		) {
 			return;
 		}
-		(onStart ?? this.#titleGenerationStart)?.();
+		this.#titleGenerationInFlight = true;
+		try {
+			(onStart ?? this.#titleGenerationStart)?.();
+		} catch (error) {
+			this.#titleGenerationInFlight = false;
+			throw error;
+		}
 		this.generateTitle(firstMessage)
 			.then(async title => {
 				// Re-check after generation so concurrent attempts cannot replace
@@ -6567,6 +6580,9 @@ export class AgentSession {
 					reason: "uncaught-auto-title-error",
 					error: err instanceof Error ? err.message : String(err),
 				});
+			})
+			.finally(() => {
+				this.#titleGenerationInFlight = false;
 			});
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -308,7 +308,6 @@ import {
 	sanitizeAssistantForReparentedHistory,
 	USER_INTERRUPT_LABEL,
 } from "./messages";
-import { skillPromptTitleInput } from "./skill-title-input";
 import { ModelControls, type ModelControlsHost } from "./model-controls";
 import { isPrewalkPlanNudge, PrewalkCoordinator, type PrewalkCoordinatorHost } from "./prewalk";
 import {
@@ -339,6 +338,7 @@ import { SessionProviderBoundary, type SessionProviderBoundaryHost } from "./ses
 import { SessionStatsTracker, type SessionStatsTrackerHost } from "./session-stats";
 import { SessionTools, type SessionToolsHost } from "./session-tools";
 import type { ShakeMode, ShakeResult } from "./shake-types";
+import { skillPromptTitleInput } from "./skill-title-input";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { planTurnPersistence, sameMessageContent, sessionMessagePersistenceKey } from "./turn-persistence";
 import { TurnRecovery, type TurnRecoveryHost } from "./turn-recovery";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -535,7 +535,7 @@ export class AgentSession {
 	 *  the session cwd changes. */
 	#titleSystemPrompt: string | undefined;
 	#titleGenerationStart: (() => void) | undefined;
-	#titleGenerationInFlight = false;
+	#titleGenerationInFlightFor: string | undefined;
 	#titleGenerationAbortController = new AbortController();
 	#toolChoiceQueue = new ToolChoiceQueue();
 
@@ -6550,26 +6550,31 @@ export class AgentSession {
 			this.#extensionRunner?.getCommand(
 				extensionCommandSpace === -1 ? firstMessage.slice(1) : firstMessage.slice(1, extensionCommandSpace),
 			) !== undefined;
+		const sessionId = this.sessionManager.getSessionId();
 		if (
 			isLocalExtensionCommand ||
 			this.sessionName ||
-			this.#titleGenerationInFlight ||
+			this.#titleGenerationInFlightFor === sessionId ||
 			$env.PI_NO_TITLE ||
 			isLowSignalTitleInput(firstMessage)
 		) {
 			return;
 		}
-		this.#titleGenerationInFlight = true;
+		this.#titleGenerationInFlightFor = sessionId;
 		try {
 			(onStart ?? this.#titleGenerationStart)?.();
 		} catch (error) {
-			this.#titleGenerationInFlight = false;
+			if (this.#titleGenerationInFlightFor === sessionId) {
+				this.#titleGenerationInFlightFor = undefined;
+			}
 			throw error;
 		}
 		this.generateTitle(firstMessage)
 			.then(async title => {
-				// Re-check after generation so concurrent attempts cannot replace
-				// the first title that completed.
+				// Re-check after generation so a later completion cannot replace
+				// the first title, and a request from a replaced session cannot
+				// name the current one.
+				if (this.sessionManager.getSessionId() !== sessionId) return;
 				if (title && !this.sessionName) {
 					await this.sessionManager.setSessionName(title, "auto");
 				}
@@ -6582,7 +6587,9 @@ export class AgentSession {
 				});
 			})
 			.finally(() => {
-				this.#titleGenerationInFlight = false;
+				if (this.#titleGenerationInFlightFor === sessionId) {
+					this.#titleGenerationInFlightFor = undefined;
+				}
 			});
 	}
 

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -38,6 +38,7 @@ export {
 
 import type { OutputMeta } from "../tools/output-meta";
 import { formatOutputNotice } from "../tools/output-meta";
+import { titleTextFromSkillPrompt } from "./skill-title-input";
 
 export const SKILL_PROMPT_MESSAGE_TYPE = "skill-prompt";
 export const LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE = "lsp-late-diagnostic";
@@ -163,6 +164,11 @@ function thinkingFromContent(content: unknown): string {
 }
 
 function titleConversationTurnFromMessage(message: AgentMessage): TitleConversationTurn | undefined {
+	if (message.role === "custom") {
+		const text = titleTextFromSkillPrompt(message);
+		if (!text) return undefined;
+		return { role: "user", text };
+	}
 	if (message.role !== "user" && message.role !== "assistant") return undefined;
 	const text = textFromContent(message.content);
 	const thinking = message.role === "assistant" ? thinkingFromContent(message.content) : undefined;

--- a/packages/coding-agent/src/session/skill-title-input.ts
+++ b/packages/coding-agent/src/session/skill-title-input.ts
@@ -1,9 +1,5 @@
 /** Compact title-model input for a user-invoked `/skill:<name>` prompt. */
-export function skillPromptTitleInput(input: {
-	name?: string;
-	args?: string;
-	queueChipText?: string;
-}): string {
+export function skillPromptTitleInput(input: { name?: string; args?: string; queueChipText?: string }): string {
 	const chip = input.queueChipText?.trim();
 	if (chip) return chip;
 	const name = input.name?.trim();

--- a/packages/coding-agent/src/session/skill-title-input.ts
+++ b/packages/coding-agent/src/session/skill-title-input.ts
@@ -1,0 +1,36 @@
+/** Compact title-model input for a user-invoked `/skill:<name>` prompt. */
+export function skillPromptTitleInput(input: {
+	name?: string;
+	args?: string;
+	queueChipText?: string;
+}): string {
+	const chip = input.queueChipText?.trim();
+	if (chip) return chip;
+	const name = input.name?.trim();
+	const args = input.args?.trim();
+	if (name && args) return `/skill:${name} ${args}`;
+	if (name) return `/skill:${name}`;
+	return args ?? "";
+}
+
+/** Title text for a persisted skill-prompt custom message. Never the expanded SKILL.md body. */
+export function titleTextFromSkillPrompt(message: {
+	role: string;
+	customType?: string;
+	attribution?: string;
+	details?: unknown;
+}): string | undefined {
+	if (message.role !== "custom" || message.customType !== "skill-prompt" || message.attribution !== "user") {
+		return undefined;
+	}
+	let name: string | undefined;
+	let args: string | undefined;
+	let queueChipText: string | undefined;
+	if (message.details && typeof message.details === "object") {
+		const details = message.details as Record<string, unknown>;
+		if (typeof details.name === "string") name = details.name;
+		if (typeof details.args === "string") args = details.args;
+		if (typeof details.__queueChipText === "string") queueChipText = details.__queueChipText;
+	}
+	return skillPromptTitleInput({ name, args, queueChipText }) || undefined;
+}

--- a/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
+++ b/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
@@ -106,4 +106,65 @@ describe("AgentSession title generation disposal", () => {
 		response.resolve(createAssistantMessage("<title>manual llm</title>"));
 		await response.promise;
 	});
+
+	it("lets a replacement session title itself and ignores the previous request", async () => {
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"providers.tinyModel": "online",
+		});
+		settings.overrideModelRoles({ smol: `${model.provider}/${model.id}` });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		const firstStarted = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const firstResponse = Promise.withResolvers<ai.AssistantMessage>();
+		const secondResponse = Promise.withResolvers<ai.AssistantMessage>();
+		let titleCalls = 0;
+		const completeSimple = vi.spyOn(ai, "completeSimple").mockImplementation(() => {
+			titleCalls += 1;
+			if (titleCalls === 1) {
+				firstStarted.resolve();
+				return firstResponse.promise;
+			}
+			secondStarted.resolve();
+			return secondResponse.promise;
+		});
+		const generateTitle = vi.spyOn(session, "generateTitle");
+		const setSessionName = vi.spyOn(session.sessionManager, "setSessionName");
+		const firstSessionId = session.sessionManager.getSessionId();
+
+		session.maybeStartTitleGeneration("/skill:implement issues/07-manual-llm.md");
+		await firstStarted.promise;
+		expect(await session.newSession()).toBe(true);
+		expect(session.sessionManager.getSessionId()).not.toBe(firstSessionId);
+
+		session.maybeStartTitleGeneration("name the replacement session");
+		await secondStarted.promise;
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+
+		firstResponse.resolve(createAssistantMessage("<title>old skill</title>"));
+		expect(await generateTitle.mock.results[0]?.value).toBe("old skill");
+		await Promise.resolve();
+		expect(setSessionName).not.toHaveBeenCalled();
+		expect(session.sessionName).toBeUndefined();
+
+		secondResponse.resolve(createAssistantMessage("<title>replacement session</title>"));
+		expect(await generateTitle.mock.results[1]?.value).toBe("replacement session");
+		await setSessionName.mock.results[0]?.value;
+		expect(session.sessionName).toBe("replacement session");
+	});
 });

--- a/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
+++ b/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
@@ -68,4 +68,42 @@ describe("AgentSession title generation disposal", () => {
 		expect(requestSignal?.aborted).toBe(true);
 		expect(await generation).toBeNull();
 	});
+
+	it("does not start a second auto-title request while the first is still in flight", async () => {
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"providers.tinyModel": "online",
+		});
+		settings.overrideModelRoles({ smol: `${model.provider}/${model.id}` });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		const started = Promise.withResolvers<void>();
+		const response = Promise.withResolvers<ai.AssistantMessage>();
+		const completeSimple = vi.spyOn(ai, "completeSimple").mockImplementation(() => {
+			started.resolve();
+			return response.promise;
+		});
+
+		session.maybeStartTitleGeneration("/skill:implement issues/07-manual-llm.md");
+		await started.promise;
+		session.maybeStartTitleGeneration("/skill:implement issues/08-app-settings.md");
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+
+		response.resolve(createAssistantMessage("<title>manual llm</title>"));
+		await response.promise;
+	});
 });

--- a/packages/coding-agent/test/session/messages.test.ts
+++ b/packages/coding-agent/test/session/messages.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import {
 	type CustomMessage,
+	buildReplanTitleContext,
 	convertToLlm,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	replaceLlmImagesWithText,
@@ -279,5 +280,60 @@ describe("replaceLlmImagesWithText", () => {
 		]);
 
 		expect(replaceLlmImagesWithText(converted, "[image omitted]")).toBe(converted);
+	});
+});
+
+describe("buildReplanTitleContext", () => {
+	it("titles a user skill invocation from skill args, not the expanded skill body", () => {
+		const skill: CustomMessage<SkillPromptDetails> = {
+			role: "custom",
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content:
+				"[IMPORTANT: User invoked the \"implement\" skill]\n\nImplement the work described by the user.\n\nUse this skill.",
+			display: true,
+			details: {
+				name: "implement",
+				path: "/tmp/implement/SKILL.md",
+				args: "issues/07-manual-llm.md 创建临时工作树实现",
+				lineCount: 20,
+			},
+			attribution: "user",
+			timestamp: 1,
+		};
+		const context = buildReplanTitleContext([skill, settledAssistant("先读 implement 技能、ticket 07")]);
+
+		expect(context).toContain("07-manual-llm.md");
+		expect(context).toContain("ticket 07");
+		expect(context).not.toContain("Use this skill.");
+		expect(context).not.toContain("IMPORTANT");
+	});
+
+	it("does not feed an autoloaded skill prompt into title context", () => {
+		const skill = customMessage(SKILL_PROMPT_MESSAGE_TYPE, "agent");
+		skill.details = { ...skill.details, args: "issues/07-manual-llm.md" };
+
+		expect(buildReplanTitleContext([skill])).toBe("");
+	});
+
+	it("prefers the operator /skill chip over persisted name and args", () => {
+		const skill: CustomMessage<SkillPromptDetails> = {
+			role: "custom",
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Use this skill.",
+			display: true,
+			details: {
+				name: "implement",
+				path: "/tmp/implement/SKILL.md",
+				args: "issues/07-manual-llm.md",
+				lineCount: 1,
+				__queueChipText: "/skill:implement issues/08-app-settings.md",
+			},
+			attribution: "user",
+			timestamp: 1,
+		};
+		const context = buildReplanTitleContext([skill]);
+
+		expect(context).toContain("08-app-settings.md");
+		expect(context).not.toContain("07-manual-llm.md");
 	});
 });

--- a/packages/coding-agent/test/session/messages.test.ts
+++ b/packages/coding-agent/test/session/messages.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import {
-	type CustomMessage,
 	buildReplanTitleContext,
+	type CustomMessage,
 	convertToLlm,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	replaceLlmImagesWithText,
@@ -289,7 +289,7 @@ describe("buildReplanTitleContext", () => {
 			role: "custom",
 			customType: SKILL_PROMPT_MESSAGE_TYPE,
 			content:
-				"[IMPORTANT: User invoked the \"implement\" skill]\n\nImplement the work described by the user.\n\nUse this skill.",
+				'[IMPORTANT: User invoked the "implement" skill]\n\nImplement the work described by the user.\n\nUse this skill.',
 			display: true,
 			details: {
 				name: "implement",
@@ -310,7 +310,7 @@ describe("buildReplanTitleContext", () => {
 
 	it("does not feed an autoloaded skill prompt into title context", () => {
 		const skill = customMessage(SKILL_PROMPT_MESSAGE_TYPE, "agent");
-		skill.details = { ...skill.details, args: "issues/07-manual-llm.md" };
+		skill.details = { name: "atomic-commit", path: "/tmp/SKILL.md", lineCount: 1, args: "issues/07-manual-llm.md" };
 
 		expect(buildReplanTitleContext([skill])).toBe("");
 	});

--- a/packages/coding-agent/test/session/skill-title-input.test.ts
+++ b/packages/coding-agent/test/session/skill-title-input.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { formatTitleConversationContext } from "../../src/tiny/message-preproc";
 import { skillPromptTitleInput, titleTextFromSkillPrompt } from "../../src/session/skill-title-input";
+import { formatTitleConversationContext } from "../../src/tiny/message-preproc";
 
 describe("skillPromptTitleInput", () => {
 	it("uses the operator /skill chip when present", () => {

--- a/packages/coding-agent/test/session/skill-title-input.test.ts
+++ b/packages/coding-agent/test/session/skill-title-input.test.ts
@@ -3,14 +3,14 @@ import { skillPromptTitleInput, titleTextFromSkillPrompt } from "../../src/sessi
 import { formatTitleConversationContext } from "../../src/tiny/message-preproc";
 
 describe("skillPromptTitleInput", () => {
-	it("uses the operator /skill chip when present", () => {
-		expect(
-			skillPromptTitleInput({
-				name: "implement",
-				args: "issues/07-manual-llm.md",
-				queueChipText: "/skill:implement issues/08-app-settings.md",
-			}),
-		).toBe("/skill:implement issues/08-app-settings.md");
+	it("prefers the operator chip over reconstructed skill args", () => {
+		const text = skillPromptTitleInput({
+			name: "implement",
+			args: "issues/07-manual-llm.md",
+			queueChipText: "/skill:implement issues/08-app-settings.md",
+		});
+		expect(text.includes("08-app-settings.md")).toBe(true);
+		expect(text.includes("07-manual-llm.md")).toBe(false);
 	});
 
 	it("reconstructs /skill:name args when the chip was stripped", () => {

--- a/packages/coding-agent/test/session/skill-title-input.test.ts
+++ b/packages/coding-agent/test/session/skill-title-input.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { formatTitleConversationContext } from "../../src/tiny/message-preproc";
+import { skillPromptTitleInput, titleTextFromSkillPrompt } from "../../src/session/skill-title-input";
+
+describe("skillPromptTitleInput", () => {
+	it("uses the operator /skill chip when present", () => {
+		expect(
+			skillPromptTitleInput({
+				name: "implement",
+				args: "issues/07-manual-llm.md",
+				queueChipText: "/skill:implement issues/08-app-settings.md",
+			}),
+		).toBe("/skill:implement issues/08-app-settings.md");
+	});
+
+	it("reconstructs /skill:name args when the chip was stripped", () => {
+		expect(skillPromptTitleInput({ name: "implement", args: "issues/07-manual-llm.md 创建临时工作树实现" })).toBe(
+			"/skill:implement issues/07-manual-llm.md 创建临时工作树实现",
+		);
+	});
+});
+
+describe("titleTextFromSkillPrompt", () => {
+	it("reads args from a user skill-prompt and ignores expanded body fields", () => {
+		const text = titleTextFromSkillPrompt({
+			role: "custom",
+			customType: "skill-prompt",
+			attribution: "user",
+			details: {
+				name: "implement",
+				path: "/tmp/implement/SKILL.md",
+				args: "issues/07-manual-llm.md",
+				lineCount: 20,
+			},
+		});
+		expect(text).toBe("/skill:implement issues/07-manual-llm.md");
+	});
+
+	it("ignores autoloaded skill prompts", () => {
+		expect(
+			titleTextFromSkillPrompt({
+				role: "custom",
+				customType: "skill-prompt",
+				attribution: "agent",
+				details: { name: "implement", args: "issues/07-manual-llm.md" },
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("replan title envelope", () => {
+	it("puts skill args in the user turn and keeps assistant text", () => {
+		const text = titleTextFromSkillPrompt({
+			role: "custom",
+			customType: "skill-prompt",
+			attribution: "user",
+			details: {
+				name: "implement",
+				args: "issues/07-manual-llm.md 创建临时工作树实现",
+			},
+		});
+		const context = formatTitleConversationContext([
+			{ role: "user", text },
+			{ role: "assistant", text: "先读 implement 技能、ticket 07" },
+		]);
+
+		expect(context).toContain("07-manual-llm.md");
+		expect(context).toContain("ticket 07");
+		expect(context).not.toContain("SKILL.md");
+	});
+});


### PR DESCRIPTION
## What

User-invoked `/skill:<name> <args>` commands now participate in session-title generation.

The title model receives the operator chip (`queueChipText`) when present, otherwise a reconstructed `/skill:<name> <args>` line. The expanded SKILL.md body is not used. Autoloaded (agent-attributed) skill prompts remain excluded from title context.

## Why

`/skill:` submissions are stored as `skill-prompt` custom messages, not `role: "user"`. The interactive skill path also returns before first-input title generation. Replan titles therefore saw only later assistant commentary, so the generated title could ignore the skill arguments entirely.

## Testing

- Unit tests for chip vs reconstructed `/skill:name args`, autoload exclusion, and `buildReplanTitleContext` (args in, skill body out).
- Local reproduction via a user-attributed `promptCustomMessage` skill-prompt: the session title is derived from the invocation args, not from later assistant text.
- CHANGELOG: Unreleased / Fixed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)