### PR TITLE
fix(auth): start idle subscription seats before overage

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4514,17 +4514,20 @@ export class AuthStorage {
 	}
 
 	/**
-	 * Computes the required drain rate: `headroomFraction / remainingHours` —
-	 * how fast the window's remaining quota must be consumed to fully use it
-	 * before it resets and expires. Higher = more headroom at risk of expiring
-	 * unused = ranked first, so selection chases quota that is about to be
-	 * wasted ("use it or lose it"). Without a reset clock, the full window
-	 * duration is assumed to remain so clocked and clockless scores stay comparable.
+	 * Computes the required drain rate: `headroomFraction / remainingHours`.
+	 * Higher scores rank first so quota that resets sooner is not stranded.
+	 *
+	 * A measured window with headroom but no reset clock has not started yet.
+	 * Rank it first so a fresh subscription seat is used before running siblings
+	 * spill into paid overage. A missing limit is different: its 0.5 headroom is
+	 * only an unknown-usage placeholder, so it keeps the conservative full-window
+	 * score instead of jumping the queue.
 	 */
 	#computeWindowRequiredDrain(limit: UsageLimit | undefined, nowMs: number, fallbackDurationMs: number): number {
 		const headroom = 1 - this.#normalizeUsageFraction(limit);
 		if (headroom <= 0) return 0;
 		const resetAt = this.#resolveWindowResetAt(limit?.window);
+		if (resetAt === undefined && limit !== undefined) return Number.POSITIVE_INFINITY;
 		const durationMs = limit?.window?.durationMs ?? fallbackDurationMs;
 		let remainingMs = resetAt === undefined ? durationMs : resetAt - nowMs;
 		if (Number.isFinite(durationMs) && durationMs > 0) {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2128,6 +2128,7 @@ export class AuthStorage {
 					secondary,
 					nowMs,
 					strategy.windowDefaults.secondaryMs,
+					args.provider === "anthropic",
 				),
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
@@ -4517,17 +4518,27 @@ export class AuthStorage {
 	 * Computes the required drain rate: `headroomFraction / remainingHours`.
 	 * Higher scores rank first so quota that resets sooner is not stranded.
 	 *
-	 * A measured window with headroom but no reset clock has not started yet.
-	 * Rank it first so a fresh subscription seat is used before running siblings
-	 * spill into paid overage. A missing limit is different: its 0.5 headroom is
-	 * only an unknown-usage placeholder, so it keeps the conservative full-window
-	 * score instead of jumping the queue.
+	 * `prioritizeClocklessZero` opts in the one window shape where "no clock"
+	 * means "not started": Anthropic publishes `resetsAt` on a weekly window
+	 * only once that window is running, so 0% used with no clock is an untouched
+	 * subscription seat. Rank it first so it is started before running siblings
+	 * spill into paid overage. Every other clockless window keeps the
+	 * conservative full-window score — a partially consumed duration-only window
+	 * (Kimi's 5h/7d shape) and a missing limit's 0.5 unknown-usage placeholder
+	 * carry no evidence that the quota is idle, so neither may jump the queue.
 	 */
-	#computeWindowRequiredDrain(limit: UsageLimit | undefined, nowMs: number, fallbackDurationMs: number): number {
+	#computeWindowRequiredDrain(
+		limit: UsageLimit | undefined,
+		nowMs: number,
+		fallbackDurationMs: number,
+		prioritizeClocklessZero = false,
+	): number {
 		const headroom = 1 - this.#normalizeUsageFraction(limit);
 		if (headroom <= 0) return 0;
 		const resetAt = this.#resolveWindowResetAt(limit?.window);
-		if (resetAt === undefined && limit !== undefined) return Number.POSITIVE_INFINITY;
+		if (prioritizeClocklessZero && resetAt === undefined && limit?.amount.usedFraction === 0) {
+			return Number.POSITIVE_INFINITY;
+		}
 		const durationMs = limit?.window?.durationMs ?? fallbackDurationMs;
 		let remainingMs = resetAt === undefined ? durationMs : resetAt - nowMs;
 		if (Number.isFinite(durationMs) && durationMs > 0) {
@@ -4714,6 +4725,7 @@ export class AuthStorage {
 					secondary,
 					nowMs,
 					strategy.windowDefaults.secondaryMs,
+					args.provider === "anthropic",
 				),
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4520,12 +4520,15 @@ export class AuthStorage {
 	 *
 	 * `prioritizeClocklessZero` opts in the one window shape where "no clock"
 	 * means "not started": Anthropic publishes `resetsAt` on a weekly window
-	 * only once that window is running, so 0% used with no clock is an untouched
-	 * subscription seat. Rank it first so it is started before running siblings
-	 * spill into paid overage. Every other clockless window keeps the
-	 * conservative full-window score — a partially consumed duration-only window
-	 * (Kimi's 5h/7d shape) and a missing limit's 0.5 unknown-usage placeholder
-	 * carry no evidence that the quota is idle, so neither may jump the queue.
+	 * only once that window is running, so an account-wide row at 0% used with
+	 * no clock is an untouched subscription seat. Rank it first so it is started
+	 * before running siblings spill into paid overage.
+	 *
+	 * Every weaker shape keeps the conservative full-window score, because none
+	 * of them prove the seat is idle: a partially consumed duration-only window
+	 * (Kimi's 5h/7d shape), a missing limit's 0.5 unknown-usage placeholder, and
+	 * a tier-scoped row (`anthropic:7d:fable`) that says nothing about the
+	 * account-wide weekly quota it is nested inside.
 	 */
 	#computeWindowRequiredDrain(
 		limit: UsageLimit | undefined,
@@ -4536,7 +4539,12 @@ export class AuthStorage {
 		const headroom = 1 - this.#normalizeUsageFraction(limit);
 		if (headroom <= 0) return 0;
 		const resetAt = this.#resolveWindowResetAt(limit?.window);
-		if (prioritizeClocklessZero && resetAt === undefined && limit?.amount.usedFraction === 0) {
+		if (
+			prioritizeClocklessZero &&
+			resetAt === undefined &&
+			limit?.amount.usedFraction === 0 &&
+			limit.scope.shared === true
+		) {
 			return Number.POSITIVE_INFINITY;
 		}
 		const durationMs = limit?.window?.durationMs ?? fallbackDurationMs;

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2865,7 +2865,12 @@ describe("AuthStorage claude oauth ranking", () => {
 		expectExclusivePreference(counts, "api-acct-near", "api-acct-far");
 	});
 
-	test("assumes the full duration remains when ranking clockless windows", async () => {
+	// Anthropic publishes `resetsAt` only once a weekly window is running, so a
+	// seat nobody has touched this period reports 0% used and no clock. It must
+	// be started before a running sibling is drained further: idle weekly quota
+	// strands at the period roll-over, while draining a running seat past its
+	// cap spills into paid extra usage.
+	test("starts an unstarted weekly window before draining a clocked sibling", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 
 		await authStorage.set("anthropic", [
@@ -2891,7 +2896,7 @@ describe("AuthStorage claude oauth ranking", () => {
 		);
 
 		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-clockless");
-		expect(apiKey).toBe("api-acct-clocked");
+		expect(apiKey).toBe("api-acct-clockless");
 	});
 
 	test("does not rank a missing weekly window as the account's 5h window", async () => {

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2934,6 +2934,43 @@ describe("AuthStorage claude oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-clocked");
 	});
 
+	// A tier row is nested inside the account-wide weekly quota, so 0% on
+	// `anthropic:7d:fable` says nothing about how much of the shared week is
+	// left. When a report ships that row but no shared `anthropic:7d`,
+	// `findClaudeSecondaryLimit` hands the tier row back as `secondary` — it
+	// must not buy the seat infinite priority on that evidence.
+	test("does not boost a clockless tier-scoped weekly row standing in for the shared window", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-tier-only", "tier@example.com") },
+			{ type: "oauth", ...createCredential("acct-shared", "shared@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-tier-only",
+			createClaudeUsageReport({
+				accountId: "acct-tier-only",
+				primary: { usedFraction: 0, resetInMs: FIVE_HOUR_MS },
+				// No shared 7d row at all, just an untouched clockless Fable row.
+				fableSecondary: { usedFraction: 0 },
+			}),
+		);
+		usageByAccount.set(
+			"acct-shared",
+			createClaudeUsageReport({
+				accountId: "acct-shared",
+				primary: { usedFraction: 0, resetInMs: FIVE_HOUR_MS },
+				secondary: { usedFraction: 0.5, resetInMs: 12 * HOUR_MS },
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-tier-only", {
+			modelId: "claude-fable-5",
+		});
+		expect(apiKey).toBe("api-acct-shared");
+	});
+
 	test("does not rank a missing weekly window as the account's 5h window", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2899,6 +2899,41 @@ describe("AuthStorage claude oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-clockless");
 	});
 
+	// The bump above keys off "untouched", not "unclocked": a weekly window that
+	// already reports usage with no reset stamp (the duration-only shape Kimi's
+	// parser also emits) carries no evidence the quota is idle, so it still has
+	// to win on drain pressure like any other measured window.
+	test("keeps a partially used clockless weekly window behind an urgent clocked sibling", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-part-clockless", "part@example.com") },
+			{ type: "oauth", ...createCredential("acct-clocked", "clocked@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-part-clockless",
+			createClaudeUsageReport({
+				accountId: "acct-part-clockless",
+				primary: { usedFraction: 0, resetInMs: FIVE_HOUR_MS },
+				// 0.5 headroom assumed to span a full week: ~0.003/h.
+				secondary: { usedFraction: 0.5 },
+			}),
+		);
+		usageByAccount.set(
+			"acct-clocked",
+			createClaudeUsageReport({
+				accountId: "acct-clocked",
+				primary: { usedFraction: 0, resetInMs: FIVE_HOUR_MS },
+				// Same headroom, 12h to burn it: ~0.042/h, so this seat is first.
+				secondary: { usedFraction: 0.5, resetInMs: 12 * HOUR_MS },
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-part-clockless");
+		expect(apiKey).toBe("api-acct-clocked");
+	});
+
 	test("does not rank a missing weekly window as the account's 5h window", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 


### PR DESCRIPTION
## Problem

Anthropic reports no `resetsAt` for an untouched weekly window. The ranking fallback treated that as a full week remaining, which gave a fresh account the lowest possible required-drain score. Running accounts stayed first until hot or blocked, leaving paid seats idle while active seats spilled into extra usage.

## Fix

Treat a measured clockless window as highest urgency. Missing limits retain the conservative full-window fallback because their 0.5 headroom is only an unknown-usage placeholder.

## Verification

- Updated the existing Claude OAuth ranking contract.
- `bun test packages/ai/test/auth-storage-codex-selection.test.ts`: 62 pass, 0 fail.
- `bun --cwd=packages/ai run check`: clean.
- Full AI suite: 3912 pass. Two transient failures pass in isolation. The remaining llama.cpp context-overflow test receives local HTTP 404 and is unrelated.