### PR TITLE
fix(catalog): mark coreweave discovery authoritative

### DIFF
--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -474,6 +474,7 @@ export const CATALOG_PROVIDERS = [
 		defaultModel: "openai/gpt-oss-120b",
 		envVars: ["COREWEAVE_API_KEY", "WANDB_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => coreWeaveModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "CoreWeave Serverless Inference" },
 	},
 	{


### PR DESCRIPTION
## Problem

The `coreweave` provider (CoreWeave Serverless Inference, delivered via W&B Inference at `https://api.inference.wandb.ai/v1`) is a reseller with a rotating model menu, but its `CATALOG_PROVIDERS` entry omits `dynamicModelsAuthoritative`.

Because of that, runtime `/v1/models` discovery **merges by id** into the frozen bundled catalog slice instead of replacing it (`AUTHORITATIVE_RUNTIME_CATALOG_PROVIDERS` in `model-patch.ts` is built only from descriptors carrying the flag). Bundled ids with no live counterpart therefore linger as selectable-but-dead entries.

Concretely today, `omp models find coreweave` lists 35 models while the endpoint serves 28. The 7 phantoms — `moonshotai/Kimi-K3`, `moonshotai/Kimi-K2.5`, `Qwen/Qwen3-235B-A22B-Thinking-2507`, `Qwen/Qwen3.5-27B`, `meta-llama/Llama-4-Scout-17B-16E-Instruct`, `microsoft/Phi-4-mini-instruct`, `zai-org/GLM-5-FP8` — are selectable but `404` at request time:

```
$ curl -s https://api.inference.wandb.ai/v1/chat/completions \
    -H "Authorization: Bearer $WANDB_API_KEY" -H 'Content-Type: application/json' \
    -d '{"model":"moonshotai/Kimi-K3","messages":[{"role":"user","content":"hi"}]}'
{"type":"invalid_request_error","message":"The requested resource was not found"}  # HTTP 404
```

Users can't fix this via `models.yml` since the flag lives in the compiled catalog table.

## Fix

Add `dynamicModelsAuthoritative: true` to the `coreweave` entry, matching sibling resellers (`baseten`, `gmi-cloud`, `aiand`, `bedrock-mantle`). Successful discovery now replaces the bundled slice, so phantom ids disappear automatically.

This is safe on discovery failure: `ModelRegistry` only drops bundled rows when the cached discovery row is *fresh AND authoritative* (`authoritativeFreshProviders` gating). A failed/absent fetch keeps the bundled catalog as fallback. `defaultModel` (`openai/gpt-oss-120b`) is a live id, so the authoritative default still resolves.

## Follow-up (not in this PR)

The bundled slice in `models.ts` is also stale and could be regenerated via `generate-models.ts`; that refreshes the *fallback* but re-drifts on the next W&B rotation. This flag is the durable fix.