### PR TITLE
fix: honor explicit retry-after on the active model before consulting the fallback chain

### DIFF
--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1977,12 +1977,21 @@ export class TurnRecovery {
 			// the same model/credential instead of drilling to a cold
 			// cross-provider fallback (cache bust + billed request) mid-window.
 			// The chain still engages after the budget exhausts.
+			//
+			// Capacity errors are the exception. A 429 quota window clears on its
+			// own and the same model is worth waiting for; a 503 "no capacity" or
+			// "hosted inference unavailable" is the route being down, and its
+			// retry-after is a guess at when that ends. Parking on it spends the
+			// whole budget on a model that cannot serve — a live outage burned ten
+			// attempts on `runinfra/deepseek-v4-pro` this way, with retry-after
+			// windows up to 38895ms, and never reached the OpenRouter leg.
+			const capacityUnavailable = rateLimitReason === "MODEL_CAPACITY_EXHAUSTED";
 			if (
 				allowModelFallback &&
 				retrySettings.modelFallback &&
 				!thinkingLoop &&
 				!(retryBudgetExhausted && classifierRefusal) &&
-				!(parsedRetryAfterMs !== undefined && !retryBudgetExhausted)
+				!(parsedRetryAfterMs !== undefined && !retryBudgetExhausted && !capacityUnavailable)
 			) {
 				if (!classifierRefusal) {
 					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1972,11 +1972,17 @@ export class TurnRecovery {
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {
 			// A refusal chain stops at the retry budget: the exhausted-attempt
 			// last resort is for provider failures, not classifier decisions.
+			// When the provider explicitly asked for a wait (retry-after header
+			// surfaced as `retry-after-ms=` in the error message), honor it on
+			// the same model/credential instead of drilling to a cold
+			// cross-provider fallback (cache bust + billed request) mid-window.
+			// The chain still engages after the budget exhausts.
 			if (
 				allowModelFallback &&
 				retrySettings.modelFallback &&
 				!thinkingLoop &&
-				!(retryBudgetExhausted && classifierRefusal)
+				!(retryBudgetExhausted && classifierRefusal) &&
+				!(parsedRetryAfterMs !== undefined && !retryBudgetExhausted)
 			) {
 				if (!classifierRefusal) {
 					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -353,7 +353,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -1655,7 +1657,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -1707,7 +1711,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -1827,7 +1833,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// No exact key for this model and no role assignment: only the
 		// `anthropic/*` wildcard can match, proving provider-level coverage.
@@ -2173,7 +2181,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// `google-vertex/*` is not a fixed target: it must adopt the failing
 		// model's id (google/gemini-2.5-flash -> google-vertex/gemini-2.5-flash).
@@ -2226,7 +2236,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// `openrouter/google/*` splits into provider `openrouter` + id prefix
 		// `google`: the failing bare id is re-prefixed into the aggregator's
@@ -2280,7 +2292,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// Key `openrouter/google/*` covers only openrouter's google-namespaced
 		// ids; the plain `google-vertex/*` target drops the aggregator's vendor
@@ -2335,7 +2349,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -3594,7 +3610,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(requested);
 				if (requestedModel.provider === "openrouter" && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: [`ok:${requested}`] });
 				}
@@ -3650,7 +3666,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				if (requestedModel.provider === primaryModel.provider && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: `rate limit exceeded retry-after-ms=${FALLBACK_TEST_RETRY_AFTER_MS}` });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: [`ok:${requestedModel.provider}/${requestedModel.id}`] });
 				}
@@ -3691,7 +3707,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels, { retryAfterMs: 200 });
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "Too many requests",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -3731,7 +3749,7 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.provider).toBe(fallbackModel.provider);
 		expect(session.model?.id).toBe(fallbackModel.id);
 
-		now += 240;
+		now += 31000;
 		await session.prompt("Third prompt should lazily revert to primary");
 		await session.waitForIdle();
 		expect(requestedModels).toEqual([
@@ -3921,7 +3939,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${model.provider}/${model.id}`);
 				if (model.id === primaryModel.id && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "Too many requests" });
 				} else if (model.id === fallbackModel.id && fallbackTurns === 0) {
 					fallbackTurns += 1;
 					mock.push({ content: [bigText] });
@@ -4040,7 +4058,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${model.provider}/${model.id}`);
 				if (model.id === primaryModel.id && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: ["ok"] });
 				}
@@ -4124,7 +4142,7 @@ describe("AgentSession retry fallback", () => {
 					mock.push({
 						content: [{ type: "thinking", thinking: "lorem ipsum ".repeat(5000) }],
 						stopReason: "error",
-						errorMessage: "rate limit exceeded retry-after-ms=200",
+						errorMessage: "overloaded_error: provider returned error 503",
 					});
 				} else {
 					mock.push({ content: ["ok"] });
@@ -4201,7 +4219,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(requested);
 				if (requested === "openrouter/z-ai/glm-4.7@cerebras" && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "Too many requests" });
 				} else {
 					mock.push({ content: [`ok:${requested}`] });
 				}
@@ -4235,7 +4253,7 @@ describe("AgentSession retry fallback", () => {
 			`${fallbackModel.provider}/${fallbackModel.id}`,
 		]);
 
-		now += 240;
+		now += 31000;
 		await session.prompt("Second prompt should restore routed primary");
 		await session.waitForIdle();
 		expect(requestedModels).toEqual([
@@ -4257,7 +4275,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels, { retryAfterMs: 200 });
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "Too many requests",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -4290,7 +4310,7 @@ describe("AgentSession retry fallback", () => {
 		expect(session.thinkingLevel).toBeUndefined();
 
 		session.setThinkingLevel(Effort.Low);
-		now += 240;
+		now += 31000;
 		await session.prompt("Second prompt should restore model but preserve user thinking change");
 		await session.waitForIdle();
 		expect(requestedModels).toEqual([
@@ -4311,7 +4331,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -4356,7 +4378,9 @@ describe("AgentSession retry fallback", () => {
 		}
 		const requestedModels: string[] = [];
 		const usageChecks: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.usageAwareFallback": true,
@@ -4802,7 +4826,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
@@ -4841,7 +4867,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
@@ -4992,6 +5020,173 @@ describe("AgentSession retry fallback", () => {
 
 		// Proactive: the primary was never requested, so no retry saga ran.
 		expect(requestedModels).toEqual([`${fallbackModel.provider}/${fallbackModel.id}`]);
+		expect(session.servingModel).toEqual({
+			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			isFallback: true,
+		});
+	});
+
+	it("parks the fallback consult on an explicit retry-after while budget remains", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const fallbackSucceededEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_succeeded" }>> = [];
+		const mock = createMockModel({
+			responses: [{ throw: "rate limit exceeded retry-after-ms=200" }, { content: ["Recovered on primary retry"] }],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+			if (event.type === "retry_fallback_succeeded") {
+				fallbackSucceededEvents.push(event);
+			}
+		});
+
+		await session.prompt("Retry on the primary despite a configured chain");
+		await session.waitForIdle();
+
+		// The explicit retry-after parks the chain consult mid-budget: the same
+		// primary is retried after honoring the wait, never a cold fallback.
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+		]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({
+			attempt: 1,
+			maxAttempts: 1,
+			delayMs: 200,
+			errorMessage: "rate limit exceeded retry-after-ms=200",
+		});
+		expect(waitSpy).toHaveBeenCalledWith(200, { signal: expect.any(AbortSignal) });
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		expect(fallbackAppliedEvents).toHaveLength(0);
+		expect(fallbackSucceededEvents).toHaveLength(0);
+		expect(session.model?.provider).toBe(primaryModel.provider);
+		expect(session.model?.id).toBe(primaryModel.id);
+		const lastAssistant = getLastAssistantMessage(session);
+		expect(lastAssistant.stopReason).toBe("stop");
+		expect(lastAssistant.content).toContainEqual({ type: "text", text: "Recovered on primary retry" });
+	});
+
+	it("engages the fallback chain once the retry budget exhausts despite an explicit retry-after", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel();
+		let primaryAttempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.id === primaryModel.id && primaryAttempts < 2) {
+					primaryAttempts += 1;
+					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+				} else {
+					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Exhaust the retry budget, then fail over");
+		await session.waitForIdle();
+
+		// The first park retries the primary after honoring the retry-after; the
+		// exhausted attempt finally consults the chain and lands on the fallback,
+		// which gets a fresh retry budget.
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(retryStartEvents).toHaveLength(2);
+		expect(retryStartEvents[0]).toMatchObject({ maxAttempts: 1, delayMs: 200 });
+		expect(retryStartEvents[1]).toMatchObject({ maxAttempts: 1, delayMs: 0 });
+		expect(fallbackAppliedEvents).toHaveLength(1);
+		expect(fallbackAppliedEvents[0]).toMatchObject({
+			type: "retry_fallback_applied",
+			from: `${primaryModel.provider}/${primaryModel.id}`,
+			to: `${fallbackModel.provider}/${fallbackModel.id}`,
+			role: "default",
+		});
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true });
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
 		expect(session.servingModel).toEqual({
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
 			isFallback: true,

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -5026,6 +5026,81 @@ describe("AgentSession retry fallback", () => {
 		});
 	});
 
+	it("consults the chain on a capacity 503 even when it carries an explicit retry-after", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel({
+			responses: [
+				{ throw: "503 Hosted inference is temporarily unavailable. retry-after-ms=38895" },
+				{ content: ["Recovered on the fallback"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 5,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Fail over instead of waiting out an outage");
+		await session.waitForIdle();
+
+		// The route is down, so its retry-after is a guess. The chain engages on
+		// the first attempt rather than spending the budget on a dead model.
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackAppliedEvents).toHaveLength(1);
+		expect(fallbackAppliedEvents[0]).toMatchObject({
+			from: `${primaryModel.provider}/${primaryModel.id}`,
+			to: `${fallbackModel.provider}/${fallbackModel.id}`,
+			role: "default",
+		});
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ delayMs: 0 });
+		expect(waitSpy).not.toHaveBeenCalledWith(38895, expect.anything());
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
+	});
+
 	it("parks the fallback consult on an explicit retry-after while budget remains", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");

--- a/packages/coding-agent/test/issue-3464-ollama-cloud-task-backoff.test.ts
+++ b/packages/coding-agent/test/issue-3464-ollama-cloud-task-backoff.test.ts
@@ -72,7 +72,7 @@ describe("issue #3464: ollama-cloud task backoff", () => {
 				requestedModels.push(`${model.provider}/${model.id}`);
 				if (model.provider === primary.provider && model.id === primary.id && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
 				}


### PR DESCRIPTION
## Summary

A provider error that carries an explicit retry-after (`retry-after-ms=`, `retry-after`, `x-ratelimit-reset`, parsed in `TurnRecovery`) now parks the fallback consult while the retry budget is unspent. The same model and credential are retried after the wait, instead of a cold cross-provider fallback mid-window (cache bust, billed request, unproven credential).

The fallback chain still engages once the retry budget exhausts.

Capacity errors are exempt. A 429 quota window clears on its own and the same model is worth waiting for. A 503 no-capacity or hosted-inference-unavailable is the route being down, and its retry-after is a guess at when that ends, so parking on it spends the whole budget on a model that cannot serve. `parseRateLimitReason` already separates the two: `MODEL_CAPACITY_EXHAUSTED` skips the park and consults the chain immediately.

## Behavior change

Before: any retryable provider error with a configured chain attempted the fallback immediately.

| | budget unspent | budget exhausted |
|---|---|---|
| 429 with retry-after, before | fallback mid-window | fallback |
| 429 with retry-after, after | retry primary after wait | fallback |
| 503 capacity, after | fallback immediately | fallback |

## Tests

Eight-file bun suite under `packages/coding-agent/test/`: agent-session-retry-fallback, agent-session-retry-recovery, agent-session-manual-retry, agent-session-retry-cap, retry-fallback, issue-2750-subagent-runtime-fallback, turn-recovery-replay-unsafe, issue-3464-ollama-cloud-task-backoff.

169 pass, 0 fail before the ollama-cloud adaptation lands ahead of the CI rerun; the ollama-cloud task-backoff chain test now feeds a capacity 503 (never parked) so its default-chain assertion still hops. `biome check .` and `tsgo --noEmit` both exit 0, run as separate legs.

Three new tests: park-while-budget-remains, engage-after-exhaustion, and the capacity-503 exemption. Chain-resolution tests feed retry-after-free errors so the guard never fires where the chain should engage.

## Readiness and #9000

Rebased on `main` at `858f7dd91f`. Two conflicts resolved against upstream: the `!thinkingLoop` clause added to the same condition is kept alongside the retry-after clause, and the thinking-loop test added to the same file is kept alongside this branch's tests.

Merges cleanly with #9000 (chain-hop to a fallback model's own chain), no conflicts in either file, 131 pass across five suites with both applied. The two are complements rather than alternatives: #9000 makes the second chain reachable, and this PR is what decides whether a failing model gets to the chain at all. Merged alone, #9000 still can't reach the OpenRouter leg during a RunInfra outage, because this guard would park before the consult — the capacity exemption above is what opens that path. Either merge order works.

## Repro

Configure a fallback chain, then drive the primary with `rate limit exceeded retry-after-ms=200` while the budget still has attempts. Before: the chain is consulted mid-budget and the session switches models. After: the primary is retried after the 200ms wait; the chain engages only once the budget is gone.

For the exemption, throw `503 Hosted inference is temporarily unavailable. retry-after-ms=38895` instead. The chain engages on the first attempt with `delayMs: 0`.

https://claude.ai/code/session_0142iDTa611rxnapRL4Kmgp8
