### PR TITLE
fix(notify): announce every prompt that blocks a turn, and deliver notifications inside Herdr panes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Notifications now reach Herdr panes. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99, has no DCS passthrough envelope, and its bell relay never flags a backgrounded tab, so a pane in the background got no signal at all that the agent had finished or was waiting. Delivery now runs through `herdr notification show`, the way cmux surfaces already do, mapping a waiting question onto Herdr's `request` sound and a settled turn onto `done`.
+- Prompts the agent is waiting on now announce themselves, not just the `ask` tool: tool approvals and the coding-plan reserve question ("switch to the fallback model?"). Such a prompt raised while the pane sits in the background used to be invisible — the turn simply stopped. Dialogs the human opens mid-turn (the large-paste menu, slash-command pickers, user-run extension commands) stay silent, and the `ask.notify` switch governs these too.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- Notifications now reach Herdr panes. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99, has no DCS passthrough envelope, and its bell relay never flags a backgrounded tab, so a pane in the background got no signal at all that the agent had finished or was waiting. Delivery now runs through `herdr notification show`, the way cmux surfaces already do, mapping a waiting question onto Herdr's `request` sound and a settled turn onto `done`.
+- Prompts the agent is waiting on now announce themselves, not just the `ask` tool: tool approvals and the coding-plan reserve question ("switch to the fallback model?"). Such a prompt raised while the pane sits in the background used to be invisible — the turn simply stopped. Dialogs the human opens mid-turn (the large-paste menu, slash-command pickers, user-run extension commands) stay silent, and the `ask.notify` switch governs these too.
 	- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed

--- a/packages/coding-agent/src/eval/preludes.ts
+++ b/packages/coding-agent/src/eval/preludes.ts
@@ -96,8 +96,11 @@ async function approvePreludeInvocation(
 				`Set tools.approval.${definition.name}: allow or use an interactive UI to approve the call.`,
 		);
 	}
+	// The eval call cannot proceed until this is answered, so it announces
+	// itself even when the pane sits in the background — the same contract as
+	// an extension tool approval.
 	const choice = await untilAborted(context.signal, () =>
-		ui.select(formatApprovalPrompt(subject, parameters, resolved.reason), ["Approve", "Deny"]),
+		ui.select(formatApprovalPrompt(subject, parameters, resolved.reason), ["Approve", "Deny"], { announce: true }),
 	);
 	if (choice !== "Approve") throw new Error(`Eval prelude call denied by user: ${definition.name}`);
 }

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -184,6 +184,14 @@ export function getExtensionUISelectOptionLabel(option: ExtensionUISelectItem): 
  */
 export interface ExtensionUIDialogOptions {
 	signal?: AbortSignal;
+	/**
+	 * Opt in to announcing this prompt once it is on screen, so a pane in the
+	 * background shows that the turn is waiting. Silent unless set: a turn being
+	 * in flight does not mean the turn is blocked on this dialog, and a handler
+	 * that opens one without blocking the loop must not claim otherwise. Set it
+	 * when the caller genuinely waits for the answer.
+	 */
+	announce?: boolean;
 	timeout?: number;
 	/** Invoked when the UI times out while waiting for a selection/input */
 	onTimeout?: () => void;

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -329,7 +329,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					: basePrompt;
 			let choice: string | undefined;
 			try {
-				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"]);
+				// The turn cannot proceed until this is answered, so it announces itself
+				// even when the pane sits in the background.
+				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"], { announce: true });
 			} catch (err) {
 				await emitApprovalResolved(false, err instanceof Error ? err.message : "approval aborted");
 				throw err;

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -330,7 +330,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					: basePrompt;
 			let choice: string | undefined;
 			try {
-				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"]);
+				// The turn cannot proceed until this is answered, so it announces itself
+				// even when the pane sits in the background.
+				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"], { announce: true });
 			} catch (err) {
 				await emitApprovalResolved(false, err instanceof Error ? err.message : "approval aborted");
 				throw err;

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,5 +1,5 @@
 import type { Component, OverlayHandle, TUI } from "@oh-my-pi/pi-tui";
-import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
+import { Container, Spacer, TERMINAL, Text } from "@oh-my-pi/pi-tui";
 import type { CollabUiRequestDraft, CollabUiSelectItem } from "@oh-my-pi/pi-wire";
 import { KeybindingsManager } from "../../config/keybindings";
 import type {
@@ -28,7 +28,7 @@ import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
 import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/components/hook-selector";
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
-import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
+import type { AwaitedDialogOptions, InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { normalizeCustomMessagePayload, USER_INTERRUPT_LABEL } from "../../session/messages";
 import { setExtensionTerminalTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
@@ -152,7 +152,7 @@ export class ExtensionUiController {
 			return this.showHookConfirm(
 				"Coding-plan reserve reached",
 				`${confirmation.from} has ${reserve}. Switch to ${confirmation.to}? Choose No to keep using the current plan.`,
-				{ signal },
+				{ signal, announce: true },
 			);
 		});
 
@@ -580,7 +580,7 @@ export class ExtensionUiController {
 	async showCollabAwareSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: InteractiveSelectorDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
 		const request: CollabUiRequestDraft = {
@@ -601,7 +601,7 @@ export class ExtensionUiController {
 	async showCollabAwareEditor(
 		title: string,
 		prefill?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		editorOptions?: { promptStyle?: boolean },
 	): Promise<string | undefined> {
 		const request: CollabUiRequestDraft = { kind: "editor", title, prefill };
@@ -612,7 +612,7 @@ export class ExtensionUiController {
 
 	async showAskDialog(
 		questions: ExtensionAskDialogQuestion[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 	): Promise<ExtensionAskDialogResult | undefined> {
 		const host = this.ctx.collabHost;
 		if (!host) return this.#showLocalAskDialog(questions, dialogOptions);
@@ -635,9 +635,10 @@ export class ExtensionUiController {
 
 	#showLocalAskDialog(
 		questions: ExtensionAskDialogQuestion[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 	): Promise<ExtensionAskDialogResult | undefined> {
-		return this.#presentDialog<ExtensionAskDialogResult>(dialogOptions?.signal, settle => {
+		const announced = dialogOptions?.announce ? (questions[0]?.question ?? "Waiting for input") : undefined;
+		return this.#presentDialog<ExtensionAskDialogResult>(dialogOptions?.signal, announced, settle => {
 			let askDialog: AskDialogComponent | undefined;
 			let promptEditor: HookEditorComponent | undefined;
 			let promptResolve: ((value: string | undefined) => void) | undefined;
@@ -893,15 +894,43 @@ export class ExtensionUiController {
 	}
 
 	/**
+	 * Announce a prompt the agent is waiting on, so one raised while the pane is
+	 * backgrounded is discoverable at all — the turn otherwise just stops.
+	 *
+	 * Callers opt in: a turn being in flight does not mean the turn is blocked on
+	 * this dialog. The large-paste menu, slash-command pickers, user-run extension
+	 * commands and fire-and-forget `message_end` handlers all open dialogs mid-turn
+	 * without blocking it, so only the sites that genuinely wait ask for this —
+	 * tool approvals, the coding-plan reserve question, and collab guest requests
+	 * relayed from a blocked host. `ask.notify` still governs it, the same way it
+	 * governs the `ask` tool.
+	 */
+	#announceAwaitedPrompt(prompt: string): void {
+		if (this.ctx.settings.get("ask.notify") === "off") return;
+		// Headline only. The body of an approval prompt carries the command line,
+		// eval source, or file paths, and a desktop notification is retained in
+		// notification history and shown on a locked screen — not a place for a
+		// token that happened to sit in an argument.
+		const [head = ""] = prompt.split("\n");
+		TERMINAL.sendNotification({
+			title: this.ctx.sessionManager.getSessionName() || "Oh My Pi",
+			body: head.trim().slice(0, 140) || "Waiting for input",
+			type: "ask",
+			urgency: "normal",
+			actions: "focus",
+		});
+	}
+
+	/**
 	 * Show a selector for hooks.
 	 */
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: InteractiveSelectorDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
-		return this.#presentDialog(dialogOptions?.signal, settle => {
+		return this.#presentDialog(dialogOptions?.signal, dialogOptions?.announce ? title : undefined, settle => {
 			const maxVisible = Math.max(4, Math.min(15, this.ctx.ui.terminal.rows - 12));
 			this.ctx.hookSelector = new HookSelectorComponent(
 				title,
@@ -960,7 +989,11 @@ export class ExtensionUiController {
 	/**
 	 * Show a confirmation dialog for hooks.
 	 */
-	async showHookConfirm(title: string, message: string, dialogOptions?: ExtensionUIDialogOptions): Promise<boolean> {
+	async showHookConfirm(
+		title: string,
+		message: string,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
+	): Promise<boolean> {
 		const result = await this.showHookSelector(`${title}\n${message}`, ["Yes", "No"], dialogOptions);
 		return result === "Yes";
 	}
@@ -971,9 +1004,9 @@ export class ExtensionUiController {
 	showHookInput(
 		title: string,
 		placeholder?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 	): Promise<string | undefined> {
-		return this.#presentDialog(dialogOptions?.signal, settle => {
+		return this.#presentDialog(dialogOptions?.signal, dialogOptions?.announce ? title : undefined, settle => {
 			this.ctx.hookInput = new HookInputComponent(
 				title,
 				placeholder,
@@ -1011,10 +1044,10 @@ export class ExtensionUiController {
 	showHookEditor(
 		title: string,
 		prefill?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		editorOptions?: { promptStyle?: boolean },
 	): Promise<string | undefined> {
-		return this.#presentDialog(dialogOptions?.signal, settle => {
+		return this.#presentDialog(dialogOptions?.signal, dialogOptions?.announce ? title : undefined, settle => {
 			this.ctx.hookEditor = new HookEditorComponent(
 				this.ctx.ui,
 				title,
@@ -1225,6 +1258,14 @@ export class ExtensionUiController {
 	 */
 	#presentDialog<T = string>(
 		signal: AbortSignal | undefined,
+		/**
+		 * Prompt to announce once this dialog is actually on screen, or undefined
+		 * for a dialog that announces itself elsewhere. Announcing here rather
+		 * than at the call site matters because a request can sit in
+		 * `#dialogQueue` behind an active dialog, or abort before its turn ever
+		 * arrives: the notification has to follow the presentation, not the ask.
+		 */
+		prompt: string | undefined,
 		present: (settle: (value: T | undefined) => void) => () => void,
 	): Promise<T | undefined> {
 		const { promise, resolve, reject } = Promise.withResolvers<T | undefined>();
@@ -1258,6 +1299,7 @@ export class ExtensionUiController {
 			this.#dialogActive = true;
 			try {
 				hide = present(settle);
+				if (prompt !== undefined) this.#announceAwaitedPrompt(prompt);
 			} catch (error) {
 				settled = true;
 				signal?.removeEventListener("abort", onAbort);

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,5 +1,5 @@
 import type { Component, OverlayHandle, TUI } from "@oh-my-pi/pi-tui";
-import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
+import { Container, Spacer, TERMINAL, Text } from "@oh-my-pi/pi-tui";
 import type { CollabUiRequestDraft, CollabUiSelectItem } from "@oh-my-pi/pi-wire";
 import { KeybindingsManager } from "../../config/keybindings";
 import type {
@@ -29,7 +29,7 @@ import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
 import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/components/hook-selector";
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
-import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
+import type { AwaitedDialogOptions, InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { normalizeCustomMessagePayload, USER_INTERRUPT_LABEL } from "../../session/messages";
 import { setExtensionTerminalTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
@@ -153,7 +153,7 @@ export class ExtensionUiController {
 			return this.showHookConfirm(
 				"Coding-plan reserve reached",
 				`${confirmation.from} has ${reserve}. Switch to ${confirmation.to}? Choose No to keep using the current plan.`,
-				{ signal },
+				{ signal, announce: true },
 			);
 		});
 
@@ -581,7 +581,7 @@ export class ExtensionUiController {
 	async showCollabAwareSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: InteractiveSelectorDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
 		const request: CollabUiRequestDraft = {
@@ -602,7 +602,7 @@ export class ExtensionUiController {
 	async showCollabAwareEditor(
 		title: string,
 		prefill?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		editorOptions?: { promptStyle?: boolean },
 	): Promise<string | undefined> {
 		const request: CollabUiRequestDraft = { kind: "editor", title, prefill };
@@ -613,7 +613,7 @@ export class ExtensionUiController {
 
 	async showAskDialog(
 		questions: ExtensionAskDialogQuestion[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 	): Promise<ExtensionAskDialogResult | undefined> {
 		const host = this.ctx.collabHost;
 		if (!host) return this.#showLocalAskDialog(questions, dialogOptions);
@@ -636,9 +636,10 @@ export class ExtensionUiController {
 
 	#showLocalAskDialog(
 		questions: ExtensionAskDialogQuestion[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 	): Promise<ExtensionAskDialogResult | undefined> {
-		return this.#presentDialog<ExtensionAskDialogResult>(dialogOptions?.signal, settle => {
+		const announced = dialogOptions?.announce ? (questions[0]?.question ?? "Waiting for input") : undefined;
+		return this.#presentDialog<ExtensionAskDialogResult>(dialogOptions?.signal, announced, settle => {
 			let promptEditor: HookEditorComponent | undefined;
 			let promptResolve: ((value: string | undefined) => void) | undefined;
 			let closed = false;
@@ -893,15 +894,43 @@ export class ExtensionUiController {
 	}
 
 	/**
+	 * Announce a prompt the agent is waiting on, so one raised while the pane is
+	 * backgrounded is discoverable at all — the turn otherwise just stops.
+	 *
+	 * Callers opt in: a turn being in flight does not mean the turn is blocked on
+	 * this dialog. The large-paste menu, slash-command pickers, user-run extension
+	 * commands and fire-and-forget `message_end` handlers all open dialogs mid-turn
+	 * without blocking it, so only the sites that genuinely wait ask for this —
+	 * tool approvals, the coding-plan reserve question, and collab guest requests
+	 * relayed from a blocked host. `ask.notify` still governs it, the same way it
+	 * governs the `ask` tool.
+	 */
+	#announceAwaitedPrompt(prompt: string): void {
+		if (this.ctx.settings.get("ask.notify") === "off") return;
+		// Headline only. The body of an approval prompt carries the command line,
+		// eval source, or file paths, and a desktop notification is retained in
+		// notification history and shown on a locked screen — not a place for a
+		// token that happened to sit in an argument.
+		const [head = ""] = prompt.split("\n");
+		TERMINAL.sendNotification({
+			title: this.ctx.sessionManager.getSessionName() || "Oh My Pi",
+			body: head.trim().slice(0, 140) || "Waiting for input",
+			type: "ask",
+			urgency: "normal",
+			actions: "focus",
+		});
+	}
+
+	/**
 	 * Show a selector for hooks.
 	 */
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: InteractiveSelectorDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
-		return this.#presentDialog(dialogOptions?.signal, settle => {
+		return this.#presentDialog(dialogOptions?.signal, dialogOptions?.announce ? title : undefined, settle => {
 			const maxVisible = Math.max(4, Math.min(15, this.ctx.ui.terminal.rows - 12));
 			this.ctx.hookSelector = new HookSelectorComponent(
 				title,
@@ -960,7 +989,11 @@ export class ExtensionUiController {
 	/**
 	 * Show a confirmation dialog for hooks.
 	 */
-	async showHookConfirm(title: string, message: string, dialogOptions?: ExtensionUIDialogOptions): Promise<boolean> {
+	async showHookConfirm(
+		title: string,
+		message: string,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
+	): Promise<boolean> {
 		const result = await this.showHookSelector(`${title}\n${message}`, ["Yes", "No"], dialogOptions);
 		return result === "Yes";
 	}
@@ -971,9 +1004,9 @@ export class ExtensionUiController {
 	showHookInput(
 		title: string,
 		placeholder?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 	): Promise<string | undefined> {
-		return this.#presentDialog(dialogOptions?.signal, settle => {
+		return this.#presentDialog(dialogOptions?.signal, dialogOptions?.announce ? title : undefined, settle => {
 			this.ctx.hookInput = new HookInputComponent(
 				title,
 				placeholder,
@@ -1011,10 +1044,10 @@ export class ExtensionUiController {
 	showHookEditor(
 		title: string,
 		prefill?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		editorOptions?: { promptStyle?: boolean },
 	): Promise<string | undefined> {
-		return this.#presentDialog(dialogOptions?.signal, settle => {
+		return this.#presentDialog(dialogOptions?.signal, dialogOptions?.announce ? title : undefined, settle => {
 			this.ctx.hookEditor = new HookEditorComponent(
 				this.ctx.ui,
 				title,
@@ -1225,6 +1258,14 @@ export class ExtensionUiController {
 	 */
 	#presentDialog<T = string>(
 		signal: AbortSignal | undefined,
+		/**
+		 * Prompt to announce once this dialog is actually on screen, or undefined
+		 * for a dialog that announces itself elsewhere. Announcing here rather
+		 * than at the call site matters because a request can sit in
+		 * `#dialogQueue` behind an active dialog, or abort before its turn ever
+		 * arrives: the notification has to follow the presentation, not the ask.
+		 */
+		prompt: string | undefined,
 		present: (settle: (value: T | undefined) => void) => () => void,
 	): Promise<T | undefined> {
 		const { promise, resolve, reject } = Promise.withResolvers<T | undefined>();
@@ -1258,6 +1299,7 @@ export class ExtensionUiController {
 			this.#dialogActive = true;
 			try {
 				hide = present(settle);
+				if (prompt !== undefined) this.#announceAwaitedPrompt(prompt);
 			} catch (error) {
 				settled = true;
 				signal?.removeEventListener("abort", onAbort);

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -104,6 +104,14 @@ export interface RenderSessionContextOptions {
 	preservedLiveToolCallIds?: ReadonlySet<string>;
 }
 
+/**
+ * Internal companion to the public dialog options: announce this prompt only
+ * when the agent is the party waiting on it. A turn being in flight is not
+ * enough — the large-paste menu and slash-command pickers open mid-turn on the
+ * user's own initiative and must stay silent.
+ */
+export type AwaitedDialogOptions = { announce?: boolean };
+
 export interface InteractiveModeContext {
 	// UI access
 	ui: TUI;
@@ -506,7 +514,7 @@ export interface InteractiveModeContext {
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: InteractiveSelectorDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 	): Promise<string | undefined>;
 	hideHookSelector(): void;
 	showHookInput(title: string, placeholder?: string): Promise<string | undefined>;
@@ -514,7 +522,7 @@ export interface InteractiveModeContext {
 	showHookEditor(
 		title: string,
 		prefill?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		editorOptions?: { promptStyle?: boolean },
 	): Promise<string | undefined>;
 	hideHookEditor(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -110,6 +110,13 @@ export interface AgentHubOpenOptions {
 	armCloseTap?: boolean;
 	initialSection?: "agents" | "activity";
 }
+/**
+ * Internal companion to the public dialog options: announce this prompt only
+ * when the agent is the party waiting on it. A turn being in flight is not
+ * enough — the large-paste menu and slash-command pickers open mid-turn on the
+ * user's own initiative and must stay silent.
+ */
+export type AwaitedDialogOptions = { announce?: boolean };
 
 export interface InteractiveModeContext {
 	// UI access
@@ -534,7 +541,7 @@ export interface InteractiveModeContext {
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: InteractiveSelectorDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 	): Promise<string | undefined>;
 	hideHookSelector(): void;
 	showHookInput(title: string, placeholder?: string): Promise<string | undefined>;
@@ -542,7 +549,7 @@ export interface InteractiveModeContext {
 	showHookEditor(
 		title: string,
 		prefill?: string,
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		editorOptions?: { promptStyle?: boolean },
 	): Promise<string | undefined>;
 	hideHookEditor(): void;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9141,16 +9141,22 @@ export class AgentSession {
 				? `Spend a saved Codex rate-limit reset?\n${lines[0]}`
 				: `Spend ${actions.length} saved Codex rate-limit resets?\n${lines.join("\n")}`;
 		try {
-			const choice = await runner.getUIContext().select(question, [
-				{
-					label: "Yes",
-					description: "Redeem now and remember yes for future eligible Codex resets.",
-				},
-				{
-					label: "No",
-					description: "Do not auto-redeem saved Codex resets.",
-				},
-			]);
+			const choice = await runner.getUIContext().select(
+				question,
+				[
+					{
+						label: "Yes",
+						description: "Redeem now and remember yes for future eligible Codex resets.",
+					},
+					{
+						label: "No",
+						description: "Do not auto-redeem saved Codex resets.",
+					},
+				],
+				// The request is parked on this answer, so a backgrounded pane has to
+				// surface it.
+				{ announce: true },
+			);
 			if (choice === "Yes") {
 				this.settings.set("codexResets.autoRedeem", "yes");
 				return true;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9889,10 +9889,16 @@ export class AgentSession {
 	 * Ask before the first auto-spend (`codexResets.autoRedeem === "unset"`).
 	 * The answer is persisted, so this fires at most once per install. Headless
 	 * hosts get a one-shot notice per episode instead of a prompt.
+	 *
+	 * `announce` is the caller's claim that a request is parked on the answer.
+	 * Only the blocked-retry path can make it: the salvage sweep runs
+	 * fire-and-forget beside a finished usage fetch, so announcing there would
+	 * tell the user a turn is waiting when none is.
 	 */
 	async #confirmCodexAutoRedeem(
 		actions: CodexResetAction[],
 		coordinator: CodexAutoRedeemCoordinator,
+		announce: boolean,
 	): Promise<boolean> {
 		const first = actions[0];
 		if (!first) return false;
@@ -9919,16 +9925,20 @@ export class AgentSession {
 				? `Spend a saved Codex rate-limit reset?\n${lines[0]}`
 				: `Spend ${actions.length} saved Codex rate-limit resets?\n${lines.join("\n")}`;
 		try {
-			const choice = await runner.getUIContext().select(question, [
-				{
-					label: "Yes",
-					description: "Redeem now and remember yes for future eligible Codex resets.",
-				},
-				{
-					label: "No",
-					description: "Do not auto-redeem saved Codex resets.",
-				},
-			]);
+			const choice = await runner.getUIContext().select(
+				question,
+				[
+					{
+						label: "Yes",
+						description: "Redeem now and remember yes for future eligible Codex resets.",
+					},
+					{
+						label: "No",
+						description: "Do not auto-redeem saved Codex resets.",
+					},
+				],
+				{ announce },
+			);
 			if (choice === "Yes") {
 				this.settings.set("codexResets.autoRedeem", "yes");
 				return true;
@@ -10136,7 +10146,8 @@ export class AgentSession {
 			if (plan.actions.length === 0) return false;
 			if (
 				shouldPromptCodexAutoRedeem(cfg.autoRedeem) &&
-				!(await this.#confirmCodexAutoRedeem(plan.actions, coordinator))
+				// A retry is parked on this answer, so a backgrounded pane has to hear it.
+				!(await this.#confirmCodexAutoRedeem(plan.actions, coordinator, true))
 			) {
 				return false;
 			}
@@ -10178,7 +10189,8 @@ export class AgentSession {
 			if (plan.actions.length === 0) return;
 			if (
 				shouldPromptCodexAutoRedeem(cfg.autoRedeem) &&
-				!(await this.#confirmCodexAutoRedeem(plan.actions, coordinator))
+				// Fire-and-forget beside a finished fetch: nothing is waiting, stay silent.
+				!(await this.#confirmCodexAutoRedeem(plan.actions, coordinator, false))
 			) {
 				return;
 			}

--- a/packages/coding-agent/test/codex-auto-reset-integration.test.ts
+++ b/packages/coding-agent/test/codex-auto-reset-integration.test.ts
@@ -140,12 +140,16 @@ describe("codex saved-reset trigger integration", () => {
 		report: UsageReport;
 		liveCredits: ResetCreditAccountStatus[];
 		streamErrorFirst?: boolean;
+		/** Answer the consent prompt through a fake UI instead of running headless. */
+		promptAnswer?: string;
 	}
 
 	interface Harness {
 		session: AgentSession;
 		coordinator: CodexAutoRedeemCoordinator;
 		redeemTargets: ResetCreditTarget[];
+		/** Options passed to every consent `select`, in call order. */
+		promptOptions: Array<Record<string, unknown> | undefined>;
 	}
 
 	function buildSession(opts: HarnessOpts): Harness {
@@ -189,15 +193,29 @@ describe("codex saved-reset trigger integration", () => {
 		const sessionManager = SessionManager.inMemory();
 		managers.push(sessionManager);
 		const coordinator = createCodexAutoRedeemCoordinator();
+		const promptOptions: Array<Record<string, unknown> | undefined> = [];
+		const extensionRunner =
+			opts.promptAnswer === undefined
+				? undefined
+				: ({
+						hasUI: () => true,
+						getUIContext: () => ({
+							select: (_question: string, _choices: unknown, options?: Record<string, unknown>) => {
+								promptOptions.push(options);
+								return Promise.resolve(opts.promptAnswer);
+							},
+						}),
+					} as unknown as ConstructorParameters<typeof AgentSession>[0]["extensionRunner"]);
 		const session = new AgentSession({
 			agent,
 			sessionManager,
 			settings,
 			modelRegistry,
 			codexResetCoordinator: coordinator,
+			extensionRunner,
 		});
 		sessions.push(session);
-		return { session, coordinator, redeemTargets };
+		return { session, coordinator, redeemTargets, promptOptions };
 	}
 
 	it("spends a saved reset on a live 429 even when the report is a pre-block snapshot, then retries", async () => {
@@ -297,5 +315,29 @@ describe("codex saved-reset trigger integration", () => {
 		// and the episode is NOT burned, so a UI session could still redeem it.
 		expect(redeemTargets).toHaveLength(0);
 		expect(coordinator.attemptedKeys.size).toBe(0);
+	});
+
+	it("asks silently from the salvage sweep: no request is parked on the answer", async () => {
+		const { session, coordinator, redeemTargets, promptOptions } = buildSession({
+			settings: { "codexResets.autoRedeem": "unset", "codexResets.salvageHorizonHours": 12 },
+			report: codexReport({
+				primaryUsed: 1.0,
+				weeklyUsed: 0.2,
+				limitReached: false,
+				credits: 1,
+				creditExpiresInMs: 2 * HOUR,
+			}),
+			liveCredits: [liveCreditStatus(1, 2 * HOUR)],
+			promptAnswer: "Yes",
+		});
+
+		await session.fetchUsageReports();
+		await coordinator.sweepPromise;
+
+		// The sweep runs fire-and-forget beside a finished usage fetch, so the
+		// prompt must not claim a turn is waiting on it.
+		expect(promptOptions).toHaveLength(1);
+		expect(promptOptions[0]?.announce).toBe(false);
+		expect(redeemTargets).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
@@ -29,7 +29,11 @@ import type {
 	ExtensionUISelectItem,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { ExtensionUiController } from "@oh-my-pi/pi-coding-agent/modes/controllers/extension-ui-controller";
-import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type {
+	AwaitedDialogOptions,
+	InteractiveModeContext,
+	InteractiveSelectorDialogOptions,
+} from "@oh-my-pi/pi-coding-agent/modes/types";
 import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
 
 // In-memory transport: shared FakeWebSocket + InMemoryRelay harness (see
@@ -43,7 +47,7 @@ interface DialogStub {
 	title: string;
 	options?: ExtensionUISelectItem[];
 	prefill?: string;
-	dialogOptions?: ExtensionUIDialogOptions;
+	dialogOptions?: (ExtensionUIDialogOptions | InteractiveSelectorDialogOptions) & AwaitedDialogOptions;
 	/** Flipped when the guest dismissed the presentation via the abort signal. */
 	aborted: boolean;
 	whenAborted: Promise<void>;
@@ -245,12 +249,12 @@ async function makeHarness(opts?: { readOnly?: boolean }): Promise<GuestUiHarnes
 		showHookSelector: (
 			title: string,
 			options: ExtensionUISelectItem[],
-			dialogOptions?: InteractiveSelectorDialogOptions,
+			dialogOptions?: InteractiveSelectorDialogOptions & AwaitedDialogOptions,
 		): Promise<string | undefined> => presentStub({ kind: "select", title, options, dialogOptions }),
 		showHookEditor: (
 			title: string,
 			prefill?: string,
-			dialogOptions?: ExtensionUIDialogOptions,
+			dialogOptions?: ExtensionUIDialogOptions & AwaitedDialogOptions,
 		): Promise<string | undefined> => presentStub({ kind: "editor", title, prefill, dialogOptions }),
 	} as unknown as InteractiveModeContext;
 
@@ -325,6 +329,10 @@ describe("collab TUI guest ui-request handling (#4049)", () => {
 		expect(dialog.dialogOptions?.checkedIndices).toEqual([0]);
 		expect(dialog.dialogOptions?.markableCount).toBe(2);
 		expect(dialog.dialogOptions?.helpText).toBe("pick one");
+		// The `ui-request` frame carries no announcement intent, so the guest cannot
+		// tell a blocked host apart from a dialog the host's user opened; it stays
+		// silent rather than toasting every mirrored dialog.
+		expect(dialog.dialogOptions?.announce).toBeUndefined();
 
 		dialog.settle("Yes");
 		expect(await h.nextUiResponse()).toEqual({ reqId: 1, value: "Yes" });

--- a/packages/coding-agent/test/eval/prelude-approval.test.ts
+++ b/packages/coding-agent/test/eval/prelude-approval.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { type EvalPreludeDefinition, invokeEvalPrelude } from "@oh-my-pi/pi-coding-agent/eval/preludes";
+import type {
+	ExtensionUIContext,
+	ExtensionUIDialogOptions,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+
+const definition: EvalPreludeDefinition = {
+	name: "fixture",
+	documentation: "fixture",
+	javascript: "",
+	python: "",
+	exports: [],
+	approval: { tier: "exec", policy: "prompt" },
+	async invoke() {
+		return { content: [{ type: "text", text: "ok" }], details: undefined };
+	},
+};
+
+const session: ToolSession = {
+	cwd: process.cwd(),
+	hasUI: true,
+	getSessionFile: () => null,
+	getSessionSpawns: () => null,
+	settings: Settings.isolated(),
+	getEvalPreludes: () => [definition],
+};
+
+describe("eval prelude approval prompt", () => {
+	it("announces the approval, since the eval call blocks on it", async () => {
+		const selects: Array<ExtensionUIDialogOptions | undefined> = [];
+		const ui = {
+			select: async (_title: string, _options: unknown, dialogOptions?: ExtensionUIDialogOptions) => {
+				selects.push(dialogOptions);
+				return "Approve";
+			},
+		} as unknown as ExtensionUIContext;
+		const settings = Settings.isolated();
+		settings.set("tools.approvalMode", "always-ask");
+		const context = { ui, hasUI: true, settings } as unknown as AgentToolContext;
+
+		const result = await invokeEvalPrelude("fixture", {}, { session, toolCallId: "call-1", context });
+
+		expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+		expect(selects).toHaveLength(1);
+		expect(selects[0]?.announce).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2340,10 +2340,13 @@ describe("ExtensionRunner", () => {
 				{ type: "ui_select" },
 				{ type: "tool_approval_resolved", approved: true },
 			]);
-			expect(select).toHaveBeenCalledWith(expect.stringContaining("Allow tool: dangerous_tool"), [
-				"Approve",
-				"Deny",
-			]);
+			// `announce: true` is what makes a backgrounded pane surface the approval:
+			// the turn cannot proceed until it is answered.
+			expect(select).toHaveBeenCalledWith(
+				expect.stringContaining("Allow tool: dangerous_tool"),
+				["Approve", "Deny"],
+				{ announce: true },
+			);
 			delete globalState.__approvalEvents;
 		});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2392,10 +2392,13 @@ describe("ExtensionRunner", () => {
 				{ type: "ui_select" },
 				{ type: "tool_approval_resolved", approved: true },
 			]);
-			expect(select).toHaveBeenCalledWith(expect.stringContaining("Allow tool: dangerous_tool"), [
-				"Approve",
-				"Deny",
-			]);
+			// `announce: true` is what makes a backgrounded pane surface the approval:
+			// the turn cannot proceed until it is answered.
+			expect(select).toHaveBeenCalledWith(
+				expect.stringContaining("Allow tool: dangerous_tool"),
+				["Approve", "Deny"],
+				{ announce: true },
+			);
 			delete globalState.__approvalEvents;
 		});
 

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -74,6 +74,9 @@ function createControllerContext() {
 		editor,
 		editorContainer,
 		ui,
+		// `InteractiveModeContext.session` is required; the controller reads
+		// `isStreaming` to decide whether a blocking prompt needs an alert.
+		session: { isStreaming: false },
 		hookEditor: undefined,
 	} as unknown as TestContext;
 

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
-import { Container, type OverlayOptions, setKeybindings } from "@oh-my-pi/pi-tui";
+import { Container, type OverlayOptions, setKeybindings, TERMINAL } from "@oh-my-pi/pi-tui";
 import { KeybindingsManager } from "../../../src/config/keybindings";
 import type { ExtensionAskDialogQuestion, ExtensionUIContext } from "../../../src/extensibility/extensions";
 import { AskDialogComponent } from "../../../src/modes/components/ask-dialog";
@@ -18,7 +18,7 @@ beforeAll(async () => {
 	setThemeInstance(dark);
 });
 
-function makeHarness() {
+function makeHarness(options: { askNotify?: string; sessionName?: string; streaming?: boolean } = {}) {
 	const editor = new CustomEditor(getEditorTheme());
 	const editorContainer = new Container();
 	editorContainer.addChild(editor);
@@ -44,7 +44,10 @@ function makeHarness() {
 		session: {
 			extensionRunner: undefined,
 			setUsageFallbackConfirmer: vi.fn(),
+			isStreaming: options.streaming ?? false,
 		},
+		settings: { get: (key: string) => (key === "ask.notify" ? (options.askNotify ?? "on") : undefined) },
+		sessionManager: { getSessionName: () => options.sessionName ?? "" },
 		setToolUIContext(context: ExtensionUIContext, hasUI: boolean): void {
 			expect(hasUI).toBe(true);
 			uiContext = context;
@@ -349,5 +352,107 @@ describe("ExtensionUiController custom overlay", () => {
 		expect(component.dispose).toHaveBeenCalledTimes(1);
 		expect(harness.editorContainer.children).toEqual([harness.editor]);
 		expect(harness.editor.getText()).toBe("draft typed while factory is pending");
+	});
+});
+
+describe("prompts that block a turn announce themselves", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	/** Bodies of the announcements made so far, oldest first. */
+	const announcedBodies = (notify: Mock<(...args: never[]) => unknown>): string[] =>
+		notify.mock.calls.map(call => (call[0] as { body: string }).body);
+
+	it("announces a prompt whose caller says the agent is waiting", async () => {
+		const ui = await makeHarness({ sessionName: "my-session", streaming: true }).init();
+		const notify = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+
+		// One dialog owns the surface at a time, so each is dismissed before the
+		// next. `announce` is what tool approvals, the coding-plan reserve question
+		// and relayed collab-guest requests pass.
+		const openers = [
+			(signal: AbortSignal) => ui.select("omp wants to run bash", ["Approve", "Deny"], { signal, announce: true }),
+			(signal: AbortSignal) =>
+				ui.confirm("Coding-plan reserve reached", "Switch to the fallback?", { signal, announce: true }),
+			(signal: AbortSignal) => ui.input?.("Name the branch", undefined, { signal, announce: true }),
+			(signal: AbortSignal) => ui.editor?.("Describe the change", undefined, { signal, announce: true }),
+		];
+		for (const open of openers) {
+			const dismiss = new AbortController();
+			void open(dismiss.signal);
+			dismiss.abort();
+			await Promise.resolve();
+		}
+
+		expect(announcedBodies(notify)).toEqual([
+			"omp wants to run bash",
+			"Coding-plan reserve reached",
+			"Name the branch",
+			"Describe the change",
+		]);
+		expect(notify.mock.calls[0]?.[0]).toMatchObject({ title: "my-session", type: "ask", actions: "focus" });
+	});
+
+	it("announces a queued prompt when it reaches the screen, and never one aborted while queued", async () => {
+		const ui = await makeHarness({ sessionName: "my-session", streaming: true }).init();
+		const notify = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+
+		const active = new AbortController();
+		const abortedWhileQueued = new AbortController();
+		void ui.select("first prompt", ["Approve", "Deny"], { signal: active.signal, announce: true });
+		void ui.select("aborted before its turn", ["Approve", "Deny"], {
+			signal: abortedWhileQueued.signal,
+			announce: true,
+		});
+		void ui.input?.("second prompt", undefined, { announce: true });
+
+		// Only the dialog actually on screen has announced; the two behind it sit
+		// in the queue, invisible, and must stay silent.
+		expect(announcedBodies(notify)).toEqual(["first prompt"]);
+
+		abortedWhileQueued.abort();
+		active.abort();
+		await Promise.resolve();
+
+		// The queue advanced past the aborted request to the one now visible.
+		expect(announcedBodies(notify)).toEqual(["first prompt", "second prompt"]);
+	});
+
+	it("stays silent for every dialog whose caller did not ask, even mid-turn", async () => {
+		const harness = makeHarness({ sessionName: "my-session", streaming: true });
+		const ui = await harness.init();
+		const notify = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q", question: "Which branch?", options: [{ label: "main" }, { label: "next" }] },
+		];
+
+		// A turn being in flight is not the same as the turn waiting on this
+		// dialog: the large-paste menu, slash-command pickers, user-run extension
+		// commands and fire-and-forget `message_end` handlers all reach these
+		// presenters mid-turn without blocking the loop.
+		void harness.controller.showHookSelector("Pasted 400 lines", ["Attach as file", "Insert inline"]);
+		const openers = [
+			() => ui.select("Pick a model", ["a", "b"]),
+			() => ui.confirm("Extension command", "Proceed?"),
+			() => ui.input?.("Name it"),
+			() => ui.editor?.("Write it"),
+			() => ui.askDialog?.(questions),
+		];
+		for (const open of openers) {
+			void open();
+			await Promise.resolve();
+		}
+
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("stays silent when ask.notify is off, even for a waiting prompt", async () => {
+		const silenced = await makeHarness({ streaming: true, askNotify: "off" }).init();
+		const notify = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+
+		void silenced.select("omp wants to run bash", ["Approve", "Deny"], { announce: true });
+
+		expect(notify).not.toHaveBeenCalled();
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed notifications never arriving in a Herdr pane. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and has no passthrough envelope, so a backgrounded pane got no signal at all; delivery now goes through `herdr notification show`, and the in-band write stays as the fallback when the pane id or the `herdr` binary is missing.
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed notifications never arriving in a Herdr pane. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and has no passthrough envelope, so a backgrounded pane got no signal at all; delivery now goes through `herdr notification show`, and the in-band write stays as the fallback when the pane id or the `herdr` binary is missing.
 - Avoid inserting a trailing space when auto-completing directory paths with `@`, and keep autocomplete open when accepting a directory with Tab or Enter.
 
 ## [18.1.9] - 2026-09-04

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -69,6 +69,45 @@ function sendCmuxNotification(message: string | TerminalNotification, env: NodeJ
 	return true;
 }
 
+const HERDR_PANE_ID_PATTERN = /^[0-9A-Za-z:_-]{1,64}$/u;
+
+/**
+ * Route a notification through Herdr when the process runs inside one of its
+ * panes. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and
+ * has no DCS passthrough envelope, and its bell relay does not flag a
+ * backgrounded tab — so without this branch a backgrounded pane gets no signal
+ * at all that the agent finished or is waiting for input.
+ *
+ * `sound` maps the notification kind onto what Herdr offers: a question waiting
+ * on the user rings `request`, a settled turn rings `done`, anything else stays
+ * silent. Returns whether Herdr owns delivery, so every existing terminal
+ * fallback is preserved when the pane id is absent or the binary is missing.
+ */
+function sendHerdrNotification(message: string | TerminalNotification, env: NodeJS.ProcessEnv = Bun.env): boolean {
+	if (env.HERDR_ENV?.trim() !== "1") return false;
+	const paneId = env.HERDR_PANE_ID?.trim();
+	if (!paneId || !HERDR_PANE_ID_PATTERN.test(paneId)) return false;
+
+	const title =
+		typeof message === "string" ? CMUX_NOTIFICATION_TITLE : message.title?.trim() || CMUX_NOTIFICATION_TITLE;
+	const body = typeof message === "string" ? message : (message.body ?? "");
+	const kinds = typeof message === "string" ? [] : [message.type ?? []].flat();
+	const sound = kinds.includes("ask") ? "request" : kinds.includes("completion") ? "done" : "none";
+	try {
+		const child = Bun.spawn({
+			cmd: ["herdr", "notification", "show", title, "--body", body, "--sound", sound],
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		child.unref();
+	} catch {
+		// A missing herdr binary leaves delivery to the existing terminal fallback.
+		return false;
+	}
+	return true;
+}
+
 function hasNeedleBefore(line: string, needle: string, limit: number): boolean {
 	const index = line.indexOf(needle);
 	return index !== -1 && index + needle.length <= limit;
@@ -156,6 +195,11 @@ export class TerminalInfo {
 
 	sendNotification(message: string | TerminalNotification): void {
 		if (isNotificationSuppressed() || isTerminalHeadless()) return;
+		// Innermost surface first. A Herdr pane launched inside a cmux surface
+		// inherits both `HERDR_PANE_ID` and the outer `CMUX_SURFACE_ID`; routing to
+		// cmux there would flag the containing surface and leave the backgrounded
+		// Herdr pane — the one actually waiting — without a sound or a marker.
+		if (sendHerdrNotification(message)) return;
 		if (sendCmuxNotification(message)) return;
 		const formatted = this.formatNotification(message);
 		// Under tmux, terminals whose notify protocol is OSC 9 / OSC 99 would

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -72,6 +72,45 @@ function sendCmuxNotification(message: string | TerminalNotification, env: NodeJ
 	return true;
 }
 
+const HERDR_PANE_ID_PATTERN = /^[0-9A-Za-z:_-]{1,64}$/u;
+
+/**
+ * Route a notification through Herdr when the process runs inside one of its
+ * panes. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and
+ * has no DCS passthrough envelope, and its bell relay does not flag a
+ * backgrounded tab — so without this branch a backgrounded pane gets no signal
+ * at all that the agent finished or is waiting for input.
+ *
+ * `sound` maps the notification kind onto what Herdr offers: a question waiting
+ * on the user rings `request`, a settled turn rings `done`, anything else stays
+ * silent. Returns whether Herdr owns delivery, so every existing terminal
+ * fallback is preserved when the pane id is absent or the binary is missing.
+ */
+function sendHerdrNotification(message: string | TerminalNotification, env: NodeJS.ProcessEnv = Bun.env): boolean {
+	if (env.HERDR_ENV?.trim() !== "1") return false;
+	const paneId = env.HERDR_PANE_ID?.trim();
+	if (!paneId || !HERDR_PANE_ID_PATTERN.test(paneId)) return false;
+
+	const title =
+		typeof message === "string" ? CMUX_NOTIFICATION_TITLE : message.title?.trim() || CMUX_NOTIFICATION_TITLE;
+	const body = typeof message === "string" ? message : (message.body ?? "");
+	const kinds = typeof message === "string" ? [] : [message.type ?? []].flat();
+	const sound = kinds.includes("ask") ? "request" : kinds.includes("completion") ? "done" : "none";
+	try {
+		const child = Bun.spawn({
+			cmd: ["herdr", "notification", "show", title, "--body", body, "--sound", sound],
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		child.unref();
+	} catch {
+		// A missing herdr binary leaves delivery to the existing terminal fallback.
+		return false;
+	}
+	return true;
+}
+
 function hasNeedleBefore(line: string, needle: string, limit: number): boolean {
 	const index = line.indexOf(needle);
 	return index !== -1 && index + needle.length <= limit;
@@ -159,6 +198,11 @@ export class TerminalInfo {
 
 	sendNotification(message: string | TerminalNotification): void {
 		if (isNotificationSuppressed() || isTerminalHeadless()) return;
+		// Innermost surface first. A Herdr pane launched inside a cmux surface
+		// inherits both `HERDR_PANE_ID` and the outer `CMUX_SURFACE_ID`; routing to
+		// cmux there would flag the containing surface and leave the backgrounded
+		// Herdr pane — the one actually waiting — without a sound or a marker.
+		if (sendHerdrNotification(message)) return;
 		if (sendCmuxNotification(message)) return;
 		const formatted = this.formatNotification(message);
 		// Under tmux, terminals whose notify protocol is OSC 9 / OSC 99 would

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -87,7 +87,10 @@ const HERDR_PANE_ID_PATTERN = /^[0-9A-Za-z:_-]{1,64}$/u;
  * fallback is preserved when the pane id is absent or the binary is missing.
  */
 function sendHerdrNotification(message: string | TerminalNotification, env: NodeJS.ProcessEnv = Bun.env): boolean {
-	if (env.HERDR_ENV?.trim() !== "1") return false;
+	// Pane-only detection, like `isInsideHerdr`: an env-sanitizing launcher can
+	// drop HERDR_ENV and keep the pane identity, and that pane can still be
+	// backgrounded. The pane id itself is what the CLI needs, so it stays required.
+	if (!isInsideHerdr(env)) return false;
 	const paneId = env.HERDR_PANE_ID?.trim();
 	if (!paneId || !HERDR_PANE_ID_PATTERN.test(paneId)) return false;
 

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -20,6 +20,7 @@ const originalOsc99Probe = Bun.env.PI_TUI_OSC99_PROBE;
 const originalTmux = Bun.env.TMUX;
 const originalZellij = Bun.env.ZELLIJ;
 const originalHerdrEnv = Bun.env.HERDR_ENV;
+const originalHerdrPaneId = Bun.env.HERDR_PANE_ID;
 const originalPiNotifications = Bun.env.PI_NOTIFICATIONS;
 const originalCmuxSurfaceId = Bun.env.CMUX_SURFACE_ID;
 const originalCmuxWorkspaceId = Bun.env.CMUX_WORKSPACE_ID;
@@ -79,6 +80,7 @@ describe("terminal notifications", () => {
 		delete Bun.env.TMUX;
 		delete Bun.env.ZELLIJ;
 		delete Bun.env.HERDR_ENV;
+		delete Bun.env.HERDR_PANE_ID;
 		delete Bun.env.CMUX_SURFACE_ID;
 		delete Bun.env.CMUX_WORKSPACE_ID;
 		delete Bun.env.CMUX_SOCKET_PATH;
@@ -97,6 +99,7 @@ describe("terminal notifications", () => {
 		restoreEnv("TMUX", originalTmux);
 		restoreEnv("ZELLIJ", originalZellij);
 		restoreEnv("HERDR_ENV", originalHerdrEnv);
+		restoreEnv("HERDR_PANE_ID", originalHerdrPaneId);
 		restoreEnv("PI_NOTIFICATIONS", originalPiNotifications);
 		restoreEnv("CMUX_SURFACE_ID", originalCmuxSurfaceId);
 		restoreEnv("CMUX_WORKSPACE_ID", originalCmuxWorkspaceId);
@@ -221,6 +224,102 @@ describe("terminal notifications", () => {
 		});
 		expect(unref).toHaveBeenCalledTimes(1);
 		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("routes a Herdr pane notification through the CLI instead of a swallowed OSC", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const unref = vi.fn();
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(spawn).toHaveBeenCalledWith({
+			cmd: ["herdr", "notification", "show", "session", "--body", "Waiting for input", "--sound", "request"],
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		expect(unref).toHaveBeenCalledTimes(1);
+		// Herdr swallows bare OSC 9/99 and its bell relay never flags the tab, so
+		// the in-band write must not be the only signal.
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("rings Herdr's completion sound for a settled turn and stays silent otherwise", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Complete", type: "completion" });
+		TERMINAL.sendNotification({ title: "session", body: "Stopped with error", type: "error" });
+
+		const sounds = spawn.mock.calls.map(call => {
+			const { cmd } = call[0] as unknown as { cmd: string[] };
+			return cmd[cmd.indexOf("--sound") + 1];
+		});
+		expect(sounds).toEqual(["done", "none"]);
+	});
+
+	it("keeps the OSC fallback when the Herdr pane id is absent", () => {
+		Bun.env.HERDR_ENV = "1";
+		delete Bun.env.HERDR_PANE_ID;
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification("no pane");
+
+		expect(spawn).not.toHaveBeenCalled();
+		expect(writes).toEqual(["\x1b]99;;no pane\x1b\\"]);
+	});
+
+	it("routes to the Herdr pane, not the cmux surface it was launched inside", () => {
+		// A Herdr pane started inside a cmux surface inherits both sets of vars.
+		// The pane is the innermost surface and the one that can be backgrounded,
+		// so it must win over the container.
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		Bun.env.CMUX_SURFACE_ID = "123e4567-e89b-12d3-a456-426614174000";
+		Bun.env.CMUX_SOCKET_PATH = "/tmp/cmux.sock";
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		const argv = (spawn.mock.calls[0]?.[0] as unknown as { cmd?: string[] } | undefined)?.cmd;
+		expect(argv?.[0]).toBe("herdr");
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("keeps the OSC fallback when the herdr binary is missing", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+		// A pane id says "inside Herdr", but the CLI itself may not be on PATH —
+		// a stripped container, or a pane inherited into a different environment.
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => {
+			throw new Error("spawn herdr ENOENT");
+		});
+
+		TERMINAL.sendNotification("no binary");
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(writes).toEqual(["\x1b]99;;no binary\x1b\\"]);
 	});
 
 	it("keeps the existing OSC fallback for cmux workspace or socket state without a surface", () => {

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -255,6 +255,18 @@ describe("terminal notifications", () => {
 		expect(stdout).not.toHaveBeenCalled();
 	});
 
+	it("routes through the CLI when a launcher dropped HERDR_ENV but kept the pane id", () => {
+		delete Bun.env.HERDR_ENV;
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
 	it("rings Herdr's completion sound for a settled turn and stays silent otherwise", () => {
 		Bun.env.HERDR_ENV = "1";
 		Bun.env.HERDR_PANE_ID = "w6:p1";

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -232,6 +232,102 @@ describe("terminal notifications", () => {
 		expect(stdout).not.toHaveBeenCalled();
 	});
 
+	it("routes a Herdr pane notification through the CLI instead of a swallowed OSC", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const unref = vi.fn();
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(spawn).toHaveBeenCalledWith({
+			cmd: ["herdr", "notification", "show", "session", "--body", "Waiting for input", "--sound", "request"],
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		expect(unref).toHaveBeenCalledTimes(1);
+		// Herdr swallows bare OSC 9/99 and its bell relay never flags the tab, so
+		// the in-band write must not be the only signal.
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("rings Herdr's completion sound for a settled turn and stays silent otherwise", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Complete", type: "completion" });
+		TERMINAL.sendNotification({ title: "session", body: "Stopped with error", type: "error" });
+
+		const sounds = spawn.mock.calls.map(call => {
+			const { cmd } = call[0] as unknown as { cmd: string[] };
+			return cmd[cmd.indexOf("--sound") + 1];
+		});
+		expect(sounds).toEqual(["done", "none"]);
+	});
+
+	it("keeps the OSC fallback when the Herdr pane id is absent", () => {
+		Bun.env.HERDR_ENV = "1";
+		delete Bun.env.HERDR_PANE_ID;
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification("no pane");
+
+		expect(spawn).not.toHaveBeenCalled();
+		expect(writes).toEqual(["\x1b]99;;no pane\x1b\\"]);
+	});
+
+	it("routes to the Herdr pane, not the cmux surface it was launched inside", () => {
+		// A Herdr pane started inside a cmux surface inherits both sets of vars.
+		// The pane is the innermost surface and the one that can be backgrounded,
+		// so it must win over the container.
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		Bun.env.CMUX_SURFACE_ID = "123e4567-e89b-12d3-a456-426614174000";
+		Bun.env.CMUX_SOCKET_PATH = "/tmp/cmux.sock";
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		const argv = (spawn.mock.calls[0]?.[0] as unknown as { cmd?: string[] } | undefined)?.cmd;
+		expect(argv?.[0]).toBe("herdr");
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("keeps the OSC fallback when the herdr binary is missing", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+		// A pane id says "inside Herdr", but the CLI itself may not be on PATH —
+		// a stripped container, or a pane inherited into a different environment.
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => {
+			throw new Error("spawn herdr ENOENT");
+		});
+
+		TERMINAL.sendNotification("no binary");
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(writes).toEqual(["\x1b]99;;no binary\x1b\\"]);
+	});
+
 	it("keeps the existing OSC fallback for cmux workspace or socket state without a surface", () => {
 		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
 		const writes: string[] = [];


### PR DESCRIPTION
This is my own itch: I keep several Herdr panes open, and OMP would sit waiting for my answer in a background tab with no way to tell me. I reviewed the whole diff and I run this build in my daily sessions.

## What

- Every prompt that blocks the turn announces itself, not only the `ask` tool: tool approvals, extension `confirm`/`input`/`select`/`editor` dialogs, eval-prelude approvals, and the coding-plan reserve question. The announcement is opt-in per call (`announce`) and gated on the existing `ask.notify` setting; dialogs the human opens mid-turn (large-paste menu, slash-command pickers) stay silent. It fires when the dialog is actually presented, so a request queued behind another dialog or aborted before its turn does not notify.
- Notifications reach Herdr panes. Herdr swallows bare OSC 9 / OSC 99 and its bell relay never flags a backgrounded tab, so delivery goes through `herdr notification show` (the way cmux surfaces already do), with `ask` -> `request` sound and `completion` -> `done`. A missing pane id or `herdr` binary keeps the existing OSC/BEL fallback byte-for-byte. Detection uses the shared `isInsideHerdr()`, so a launcher that strips `HERDR_ENV` but keeps the pane id still routes.

## Why

A backgrounded Herdr pane got no signal at all when the agent finished or stopped on a question: the notification was either never sent (only `ask` announced) or sent in a form Herdr drops. Both halves are needed for one prompt to reach one background pane.

## Testing

- `bun test packages/tui/test/notifications.test.ts` (28) and `packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts`, `hook-editor`, `extensions-runner`, `collab/guest-ui-request`, `codex-auto-reset-integration` — 176 passed after the rebase; `bun run check` clean in both packages.
- Daily use inside Herdr since August on my own sessions: a tool approval or an `ask` in a background pane now rings and flags the tab; a `/copy` or paste menu opened by me stays silent; completion rings `done`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

