### PR TITLE
fix(coding-agent): allow auth oauth without apiKey in models.yml

### DIFF
--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -66,7 +66,7 @@ export function validateProviderConfiguration(
 		const requiresAuth =
 			mode === "runtime-register"
 				? !config.apiKey && !config.oauthConfigured
-				: !config.apiKey && (config.auth ?? "apiKey") !== "none";
+				: !config.apiKey && (config.auth ?? "apiKey") !== "none" && (config.auth ?? "apiKey") !== "oauth";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"


### PR DESCRIPTION
Custom providers configured with auth: oauth in models.yml no longer require apiKey to pass config validation. This enables custom model definitions for OAuth providers like xai-oauth and google-gemini-cli without overriding their stored/broker OAuth credentials at runtime.