### PR TITLE
fix: heal Qwen XML tool-call markup

### DIFF
--- a/packages/ai/src/dialect/qwen-xml.ts
+++ b/packages/ai/src/dialect/qwen-xml.ts
@@ -1,0 +1,82 @@
+import type { InbandScanEvent, InbandScanner } from "./types";
+
+const SECTION_OPEN = "<tool_calls>";
+const SECTION_CLOSE = "</tool_calls>";
+const TOOL_ELEMENT = /^<([A-Za-z_][\w.-]*)(\s[^<>]*?)?\s*\/>$/s;
+const ATTRIBUTE = /([A-Za-z_][\w.-]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+
+export class QwenXmlInbandScanner implements InbandScanner {
+	#buffer = "";
+	#insideSection = false;
+
+	feed(chunk: string): InbandScanEvent[] {
+		this.#buffer += chunk;
+		return this.#drain(false);
+	}
+
+	flush(): InbandScanEvent[] {
+		return this.#drain(true);
+	}
+
+	#drain(flush: boolean): InbandScanEvent[] {
+		const events: InbandScanEvent[] = [];
+		while (this.#buffer.length > 0) {
+			if (!this.#insideSection) {
+				const open = this.#buffer.indexOf(SECTION_OPEN);
+				if (open >= 0) {
+					if (open > 0) events.push({ type: "text", text: this.#buffer.slice(0, open) });
+					this.#buffer = this.#buffer.slice(open + SECTION_OPEN.length);
+					this.#insideSection = true;
+					continue;
+				}
+				if (flush) {
+					events.push({ type: "text", text: this.#buffer });
+					this.#buffer = "";
+					break;
+				}
+				const held = longestSuffixPrefix(this.#buffer, SECTION_OPEN);
+				const visibleLength = this.#buffer.length - held;
+				if (visibleLength > 0) {
+					events.push({ type: "text", text: this.#buffer.slice(0, visibleLength) });
+					this.#buffer = this.#buffer.slice(visibleLength);
+				}
+				break;
+			}
+
+			const close = this.#buffer.indexOf(SECTION_CLOSE);
+			if (close < 0) {
+				if (flush) this.#buffer = "";
+				break;
+			}
+			const section = this.#buffer.slice(0, close);
+			for (const element of section.match(/<[^<>]+\/>/gs) ?? []) {
+				const call = parseToolElement(element);
+				if (!call) continue;
+				const id = `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+				events.push({ type: "toolStart", id, name: call.name });
+				events.push({ type: "toolEnd", id, name: call.name, arguments: call.arguments, rawBlock: element });
+			}
+			this.#buffer = this.#buffer.slice(close + SECTION_CLOSE.length);
+			this.#insideSection = false;
+		}
+		return events;
+	}
+}
+
+function parseToolElement(element: string): { name: string; arguments: Record<string, unknown> } | undefined {
+	const match = TOOL_ELEMENT.exec(element);
+	if (!match) return undefined;
+	const args: Record<string, unknown> = {};
+	for (const attribute of match[2]?.matchAll(ATTRIBUTE) ?? []) {
+		args[attribute[1]!] = attribute[3] ?? attribute[4] ?? "";
+	}
+	return { name: match[1]!, arguments: args };
+}
+
+function longestSuffixPrefix(text: string, target: string): number {
+	const max = Math.min(text.length, target.length - 1);
+	for (let length = max; length > 0; length--) {
+		if (text.endsWith(target.slice(0, length))) return length;
+	}
+	return 0;
+}

--- a/packages/ai/src/utils/stream-markup-healing.ts
+++ b/packages/ai/src/utils/stream-markup-healing.ts
@@ -10,6 +10,7 @@
 import { isDeepseekModelIdOrName } from "@oh-my-pi/pi-catalog/identity";
 
 import { createInbandScanner } from "../dialect/factory";
+import { QwenXmlInbandScanner } from "../dialect/qwen-xml";
 import { ThinkingInbandScanner } from "../dialect/thinking";
 import type { InbandScanEvent, InbandScanner } from "../dialect/types";
 
@@ -23,7 +24,7 @@ export interface HealedToolCall {
 	readonly arguments: string;
 }
 
-export type StreamMarkupHealingPattern = "kimi" | "dsml" | "thinking";
+export type StreamMarkupHealingPattern = "kimi" | "dsml" | "qwen" | "thinking";
 
 export interface StreamMarkupHealingOptions {
 	readonly pattern: StreamMarkupHealingPattern;
@@ -64,7 +65,9 @@ export class StreamMarkupHealing {
 				? createInbandScanner("kimi")
 				: options.pattern === "dsml"
 					? createInbandScanner("xml", { xmlTagset: "dsml" })
-					: undefined;
+					: options.pattern === "qwen"
+						? new QwenXmlInbandScanner()
+						: undefined;
 	}
 
 	get pattern(): StreamMarkupHealingPattern {
@@ -157,6 +160,10 @@ export class StreamMarkupHealing {
 		if (this.#sectionTerminated || !this.#toolScanner) return;
 		if (this.#pattern === "kimi") {
 			this.#sectionTerminated = text.includes(KIMI_SECTION_END);
+			return;
+		}
+		if (this.#pattern === "qwen") {
+			this.#sectionTerminated = text.includes("</tool_calls>");
 			return;
 		}
 		this.#sectionTerminated =

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -450,6 +450,44 @@ describe("StreamMarkupHealing DSML envelope pattern", () => {
 	});
 });
 
+describe("StreamMarkupHealing Qwen XML pattern", () => {
+	const leaked = '<tool_calls>\n<read path="/etc/hostname" />\n</tool_calls>';
+
+	it("parses a self-closing tool element into a structured call", () => {
+		const healing = new StreamMarkupHealing({ pattern: "qwen" });
+		expect(healing.feed(leaked)).toBe("");
+
+		const calls = healing.drainCompleted();
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("read");
+		expect(JSON.parse(calls[0]!.arguments)).toEqual({ path: "/etc/hostname" });
+	});
+
+	it("reconstructs markup split across arbitrary chunk boundaries", () => {
+		const healing = new StreamMarkupHealing({ pattern: "qwen" });
+		let visible = "";
+		for (const char of leaked) visible += healing.feed(char);
+		visible += healing.flushPending();
+
+		expect(visible).toBe("");
+		expect(healing.drainCompleted()).toHaveLength(1);
+	});
+
+	it("preserves text around a complete tool-call section", () => {
+		const healing = new StreamMarkupHealing({ pattern: "qwen" });
+		const events = healing.feedEvents(`Before\n${leaked}\nAfter`);
+
+		expect(events.map(event => event.type)).toEqual(["text", "toolCall", "text"]);
+	});
+
+	it("drops an incomplete tool-call section", () => {
+		const healing = new StreamMarkupHealing({ pattern: "qwen" });
+		expect(healing.feed('<tool_calls><read path="/etc/host')).toBe("");
+		expect(healing.flushPending()).toBe("");
+		expect(healing.drainCompleted()).toHaveLength(0);
+	});
+});
+
 describe("StreamMarkupHealing thinking pattern", () => {
 	it("parses plain think tags as thinking events across chunk boundaries", () => {
 		const healing = new StreamMarkupHealing({ pattern: "thinking" });

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -161,7 +161,7 @@ export type OpenAIReasoningDisableMode =
 	| "qwen-enable-thinking-false"
 	| "qwen-template-false";
 
-export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "thinking";
+export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "qwen" | "thinking";
 
 /**
  * Compatibility settings for openai-completions API.

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -49,6 +49,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 		"supportsStrictMode?": "boolean",
 		"toolStrictMode?": '"all_strict" | "none"',
 		"streamIdleTimeoutMs?": "number >= 0",
+		"streamMarkupHealingPattern?": '"kimi" | "dsml" | "qwen" | "thinking"',
 		"supportsLongPromptCacheRetention?": "boolean",
 		"supportsReasoningParams?": "boolean",
 		"alwaysSendMaxTokens?": "boolean",


### PR DESCRIPTION
## Problem

Qwen 3.6 behind an OpenAI-compatible local endpoint can leak tool calls as visible XML:

```xml
<tool_calls>
<read path="/etc/hostname" />
</tool_calls>
```

OMP currently prints this markup instead of executing the tool.

## Change

- add a streaming-safe Qwen XML scanner
- expose `streamMarkupHealingPattern: qwen` in model config
- preserve surrounding visible text
- drop incomplete sections instead of making them runnable
- handle arbitrary stream chunk boundaries

## Verification

- `bun test packages/ai/test/stream-markup-healing.test.ts` — 59 passed
- `bun run check:ts` — passed

Closes #8944