### PR TITLE
fix(ai): execute Cursor native StrReplace editToolCall

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor native StrReplace (`editToolCall`) being dropped: the interaction stream now opens a single `edit` block, materialization `readArgs` return raw file bytes instead of hashline-formatted text, and the following `writeArgs` pair onto that block instead of synthesizing a full-file write.
+
 ## [17.3.8] - 2026-08-19
+
 
 ### Changed
 

--- a/packages/ai/src/providers/cursor-pi-args.ts
+++ b/packages/ai/src/providers/cursor-pi-args.ts
@@ -43,8 +43,9 @@ export function piReadPath(readPath: string, offset?: number, limit?: number): s
 	const start = offset !== undefined ? Math.max(1, Math.floor(offset)) : undefined;
 	const count = limit !== undefined ? Math.floor(limit) : undefined;
 	if (start === undefined && count === undefined) return readPath;
-	if (start === undefined) return `${readPath}:raw:1+${count}`;
-	return count === undefined ? `${readPath}:raw:${start}-` : `${readPath}:raw:${start}+${count}`;
+	const base = readPath.split(":").some(chunk => chunk.toLowerCase() === "raw") ? readPath : `${readPath}:raw`;
+	if (start === undefined) return `${base}:1+${count}`;
+	return count === undefined ? `${base}:${start}-` : `${base}:${start}+${count}`;
 }
 
 const READ_RANGE_CHUNK_RE = /^L?(\d+)(?:(\.\.|[-+])L?(\d+)?)?$/i;
@@ -75,6 +76,41 @@ export function piReadPathHasRange(readPath: string): boolean {
 	if (last?.toLowerCase() !== "raw") return false;
 	const preceding = chunks.at(-2);
 	return preceding !== undefined && isReadRangeList(preceding);
+}
+
+/**
+ * Force a Cursor exec read onto `read`'s verbatim `:raw` selector.
+ *
+ * Native `editToolCall` (StrReplace) materializes via `readArgs` then
+ * `writeArgs`. The server treats the read result as file bytes and writes
+ * them back. A hashline-formatted native read (`[path#TAG]` + `LINE:`
+ * prefixes) poisons that cycle: the write would persist the markup.
+ * `:raw` is the existing selector that drops both. A path that already
+ * carries `raw` is left alone; a range-only selector gets `raw` inserted
+ * so the range still applies without the gutter.
+ */
+export function cursorRawReadPath(readPath: string): string {
+	const chunks = readPath.split(":");
+	if (chunks.some(chunk => chunk.toLowerCase() === "raw")) return readPath;
+	if (piReadPathHasRange(readPath)) {
+		const last = chunks.pop()!;
+		return `${chunks.join(":")}:raw:${last}`;
+	}
+	return `${readPath}:raw`;
+}
+
+/**
+ * Path the edit-owned materialization read should execute.
+ *
+ * Range is composed first (`piReadPath` already uses `:raw` for a range),
+ * then a whole-file path is forced onto `:raw`. The caller must drop
+ * `offset`/`limit` after this so the bridge's `piReadPath` cannot append a
+ * second `:raw` onto the already-composed selector.
+ */
+export function cursorEditOwnedReadPath(readPath: string, offset?: number, limit?: number): string | null {
+	const ranged = piReadPath(readPath, offset, limit);
+	if (ranged === null) return null;
+	return cursorRawReadPath(ranged);
 }
 
 /**

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -210,6 +210,7 @@ import {
 	buildPiWriteError,
 	buildPiWriteRejected,
 	buildPiWriteResult,
+	cursorEditOwnedReadPath,
 	omitUndefinedArgs,
 	piEscapeRegexLiteral,
 	piGrepSkip,
@@ -941,7 +942,7 @@ export type ToolCallState = ToolCall & {
 	[kStreamingBlockIndex]: number;
 	[kStreamingPartialJson]?: string;
 	[kStreamingLastParseLen]?: number;
-	[kStreamingBlockKind]: "mcp" | "todo" | "cursor-exec" | "connect-scm" | "web-fetch";
+	[kStreamingBlockKind]: "mcp" | "todo" | "cursor-exec" | "cursor-edit" | "connect-scm" | "web-fetch";
 	[kStreamingEnvelopeId]?: string;
 	[kCursorExecResolved]?: true;
 };
@@ -963,6 +964,17 @@ export interface BlockState {
 	openToolCalls: Map<string, ToolCallState>;
 	/** MCP call IDs synthesized from exec frames before their redundant streamed block arrives. */
 	resolvedMcpToolCallIds: Set<string>;
+	/**
+	 * Native `editToolCall` (StrReplace) ids whose materialization `readArgs` /
+	 * `writeArgs` must stay raw and must not synthesize extra transcript blocks.
+	 *
+	 * Optional so existing test harnesses stay valid. Both the interaction
+	 * envelope `call_id` and the inner `toolCallId` are recorded — exec frames
+	 * pair on the inner id.
+	 */
+	editOwnedToolCallIds?: Set<string>;
+	/** Edit blocks whose write already persisted a `toolResult`. */
+	pairedEditToolCallIds?: Set<string>;
 	firstTokenTime: number | undefined;
 	setTextBlock: (b: (TextContent & { [kStreamingBlockIndex]: number }) | null) => void;
 	setThinkingBlock: (b: (ThinkingContent & { [kStreamingBlockIndex]: number }) | null) => void;
@@ -1483,16 +1495,30 @@ async function handleExecServerMessage(
 		case "readArgs": {
 			const args = execMsg.message.value;
 			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
-			// The same composed selector the bridge executes: showing a bare path
-			// for a ranged read makes the returned slice look like the whole
-			// file in every rebuilt transcript.
-			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "read", {
-				path: piReadDisplayPath(args.path, args.offset, args.limit),
-			});
+			const editOwned = isEditOwnedToolCallId(state, output, args.toolCallId);
+			// Native StrReplace materializes by reading then writing the same
+			// toolCallId. The server treats the read result as file bytes, so a
+			// hashline-formatted native read would be written back as markup.
+			// Force `:raw` and skip the extra transcript block — the edit card
+			// already owns this id.
+			const composed = editOwned ? cursorEditOwnedReadPath(args.path, args.offset, args.limit) : args.path;
+			const handlerArgs = editOwned
+				? composed === null
+					? args
+					: { ...args, path: composed, offset: undefined, limit: undefined }
+				: args;
+			if (!editOwned) {
+				// The same composed selector the bridge executes: showing a bare path
+				// for a ranged read makes the returned slice look like the whole
+				// file in every rebuilt transcript.
+				synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "read", {
+					path: piReadDisplayPath(args.path, args.offset, args.limit),
+				});
+			}
 			const { execResult } = await resolveExecHandler(
-				args,
+				handlerArgs,
 				execHandlers?.read?.bind(execHandlers),
-				onToolResult,
+				editOwned ? undefined : onToolResult,
 				toolResult =>
 					buildReadResultFromToolResult(
 						args.path,
@@ -1501,7 +1527,7 @@ async function handleExecServerMessage(
 					),
 				reason => buildReadRejectedResult(args.path, reason),
 				error => buildReadErrorResult(args.path, error),
-				{ toolCallId: args.toolCallId, toolName: "read" },
+				editOwned ? null : { toolCallId: args.toolCallId, toolName: "read" },
 			);
 			sendExecClientMessage(h2Request, execMsg, "readResult", execResult);
 			return;
@@ -1564,15 +1590,25 @@ async function handleExecServerMessage(
 		case "writeArgs": {
 			const args = execMsg.message.value;
 			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			const editOwned = isEditOwnedToolCallId(state, output, args.toolCallId);
 			// Match the bridge: prefer `fileText`, fall back to decoded `fileBytes`.
 			const content = args.fileText ?? new TextDecoder().decode(args.fileBytes ?? new Uint8Array());
-			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "write", {
-				path: args.path,
-				content,
-			});
+			if (!editOwned) {
+				synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "write", {
+					path: args.path,
+					content,
+				});
+			}
+			const write = execHandlers?.write?.bind(execHandlers);
+			const writeHandler = write
+				? async (writeArgs: typeof args) => {
+						const result = await write(writeArgs);
+						return editOwned ? remapExecHandlerToolName(result, "edit") : result;
+					}
+				: undefined;
 			const { execResult } = await resolveExecHandler(
 				args,
-				execHandlers?.write?.bind(execHandlers),
+				writeHandler,
 				onToolResult,
 				toolResult =>
 					buildWriteResultFromToolResult(
@@ -1586,8 +1622,9 @@ async function handleExecServerMessage(
 					),
 				reason => buildWriteRejectedResult(args.path, reason),
 				error => buildWriteErrorResult(args.path, error),
-				{ toolCallId: args.toolCallId, toolName: "write" },
+				{ toolCallId: args.toolCallId, toolName: editOwned ? "edit" : "write" },
 			);
+			if (editOwned) markEditToolCallPaired(state, args.toolCallId);
 			sendExecClientMessage(h2Request, execMsg, "writeResult", execResult);
 			return;
 		}
@@ -3249,6 +3286,174 @@ function selectMcpCall(toolCall: CursorMcpToolCallCarrier | undefined): CursorMc
 	return toolCall?.mcpToolCall;
 }
 
+interface CursorEditToolCall {
+	args?: {
+		path?: string;
+		streamContent?: string;
+	};
+	result?: {
+		result?: {
+			case?: string;
+			value?: {
+				error?: string;
+				reason?: string;
+				message?: string;
+				path?: string;
+				modelVisibleError?: string;
+			};
+		};
+	};
+}
+
+interface CursorEditToolCallCarrier {
+	tool?: { case?: string; value?: unknown };
+	toolCallId?: string;
+	editToolCall?: CursorEditToolCall;
+}
+
+/**
+ * Same oneof-first selector as MCP: a wire-decoded `ToolCall` exposes
+ * `editToolCall` only as `{ case: "editToolCall", value }`.
+ */
+function selectEditCall(toolCall: CursorEditToolCallCarrier | undefined): CursorEditToolCall | undefined {
+	const oneof = toolCall?.tool;
+	if (oneof?.case === "editToolCall") return oneof.value as CursorEditToolCall;
+	return toolCall?.editToolCall;
+}
+
+function selectEditStreamDelta(update: {
+	toolCallDelta?: {
+		delta?: { case?: string; value?: { streamContentDelta?: string } };
+		editToolCallDelta?: { streamContentDelta?: string };
+	};
+}): string | undefined {
+	const oneof = update.toolCallDelta?.delta;
+	if (oneof?.case === "editToolCallDelta") return oneof.value?.streamContentDelta;
+	return update.toolCallDelta?.editToolCallDelta?.streamContentDelta;
+}
+
+function rememberEditOwnedToolCall(
+	state: BlockState,
+	toolCall: CursorEditToolCallCarrier | undefined,
+	envelopeId?: string,
+): void {
+	if (!state.editOwnedToolCallIds) state.editOwnedToolCallIds = new Set();
+	const ids = state.editOwnedToolCallIds;
+	if (envelopeId) ids.add(envelopeId);
+	if (toolCall?.toolCallId) ids.add(toolCall.toolCallId);
+}
+
+function isEditOwnedToolCallId(state: BlockState, output: AssistantMessage, toolCallId: string): boolean {
+	if (state.editOwnedToolCallIds?.has(toolCallId)) return true;
+	return output.content.some(block => block.type === "toolCall" && block.id === toolCallId && block.name === "edit");
+}
+
+function stringToolArg(args: Record<string, unknown> | undefined, key: string): string | undefined {
+	const value = args?.[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function markEditToolCallPaired(state: BlockState, toolCallId: string): void {
+	if (!state.pairedEditToolCallIds) state.pairedEditToolCallIds = new Set();
+	state.pairedEditToolCallIds.add(toolCallId);
+}
+
+/**
+ * `EditToolCall.result` is an `EditResult` message whose own oneof is also
+ * named `result`. The discriminator is `result.result.case`, same nesting as
+ * `describeConnectScmResult` / the todo extractors.
+ */
+function describeEditResult(toolCall: CursorEditToolCallCarrier | undefined): { text: string; isError: boolean } {
+	const oneof = selectEditCall(toolCall)?.result?.result;
+	const variant = oneof?.case;
+	const value = oneof?.value;
+	if (variant === "success") {
+		return { text: value?.message || value?.path || "Edited", isError: false };
+	}
+	if (variant === "error") {
+		return { text: value?.modelVisibleError || value?.error || "Edit failed", isError: true };
+	}
+	if (variant === "rejected") {
+		return { text: value?.reason || "Edit rejected", isError: true };
+	}
+	if (variant === "fileNotFound") {
+		return { text: value?.path ? `File not found: ${value.path}` : "File not found", isError: true };
+	}
+	if (variant === "readPermissionDenied") {
+		return { text: value?.path ? `Read permission denied: ${value.path}` : "Read permission denied", isError: true };
+	}
+	if (variant === "writePermissionDenied") {
+		return {
+			text: value?.error || (value?.path ? `Write permission denied: ${value.path}` : "Write permission denied"),
+			isError: true,
+		};
+	}
+	return { text: "Edit reported no result", isError: true };
+}
+
+function remapExecHandlerToolName<TResult>(
+	result: CursorExecHandlerResult<TResult>,
+	toolName: string,
+): CursorExecHandlerResult<TResult> {
+	if (isToolResultMessage(result)) return { ...result, toolName };
+	if (result && typeof result === "object" && "toolResult" in result) {
+		const record = result as { result?: TResult; toolResult?: ToolResultMessage };
+		if (record.toolResult && record.result !== undefined) {
+			return { result: record.result, toolResult: { ...record.toolResult, toolName } };
+		}
+		if (record.toolResult) return { ...record.toolResult, toolName };
+	}
+	return result;
+}
+
+/**
+ * Open (or refresh) the single `edit` transcript block for a native StrReplace
+ * `editToolCall`. Materialization reads/writes reuse this id and must not
+ * synthesize their own blocks.
+ */
+function openOrUpdateEditBlock(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	state: BlockState,
+	toolCall: CursorEditToolCallCarrier | undefined,
+	envelopeId?: string,
+): ToolCallState | undefined {
+	const edit = selectEditCall(toolCall);
+	if (!edit && toolCall?.tool?.case !== "editToolCall") return undefined;
+	rememberEditOwnedToolCall(state, toolCall, envelopeId);
+	const id = toolCall?.toolCallId || envelopeId;
+	if (!id) return undefined;
+
+	const nextArgs = omitUndefinedArgs({
+		path: edit?.args?.path,
+		stream_content: edit?.args?.streamContent,
+	});
+	const existing = output.content.find(
+		(block): block is ToolCallState => block.type === "toolCall" && block.id === id,
+	);
+	if (existing) {
+		existing.arguments = { ...existing.arguments, ...nextArgs };
+		return existing;
+	}
+
+	endCurrentTextBlock(output, stream, state);
+	endCurrentThinkingBlock(output, stream, state);
+	const block: ToolCallState = {
+		type: "toolCall",
+		id,
+		name: "edit",
+		arguments: nextArgs,
+		[kStreamingBlockIndex]: output.content.length,
+		[kStreamingBlockKind]: "cursor-edit",
+		[kStreamingEnvelopeId]: envelopeId || undefined,
+		[kCursorExecResolved]: true,
+	};
+	output.content.push(block);
+	retainStreamedCall(state, block, envelopeId);
+	stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+	return block;
+}
+
 /**
  * The streamed `ToolCall` variants whose block the exec channel owns.
  *
@@ -3333,15 +3538,17 @@ export function flushOpenToolCalls(
 			clearStreamingPartialJson(block);
 		}
 		const kind = block[kStreamingBlockKind];
-		if (kind === "connect-scm" || kind === "todo") {
-			state.onToolResult?.({
-				role: "toolResult",
-				toolCallId: block.id,
-				toolName: block.name,
-				content: [{ type: "text", text: "The connection to Cursor closed before this call completed." }],
-				isError: true,
-				timestamp: Date.now(),
-			});
+		if (kind === "connect-scm" || kind === "todo" || kind === "cursor-edit") {
+			if (!(kind === "cursor-edit" && state.pairedEditToolCallIds?.has(block.id))) {
+				state.onToolResult?.({
+					role: "toolResult",
+					toolCallId: block.id,
+					toolName: block.name,
+					content: [{ type: "text", text: "The connection to Cursor closed before this call completed." }],
+					isError: true,
+					timestamp: Date.now(),
+				});
+			}
 		}
 		stream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: output });
 	}
@@ -3984,13 +4191,31 @@ export function processInteractionUpdate(
 				output.content.push(block);
 				retainStreamedCall(state, block, update.message.value.callId);
 				stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+				return;
 			}
+
+			openOrUpdateEditBlock(output, stream, state, toolCall, update.message.value.callId);
 		}
 	} else if (updateCase === "toolCallDelta" || updateCase === "partialToolCall") {
+		const value = update.message.value;
+		if (updateCase === "partialToolCall" && value.toolCall) {
+			openOrUpdateEditBlock(output, stream, state, value.toolCall, value.callId);
+		}
+		const editDelta = selectEditStreamDelta(value);
+		if (editDelta) {
+			const target = resolveStreamedCall(state, value.callId);
+			if (target?.[kStreamingBlockKind] === "cursor-edit") {
+				const current = stringToolArg(target.arguments, "stream_content") ?? "";
+				target.arguments = { ...target.arguments, stream_content: current + editDelta };
+				const idx = output.content.indexOf(target);
+				stream.push({ type: "toolcall_delta", contentIndex: idx, delta: editDelta, partial: output });
+				return;
+			}
+		}
 		// Same correlation rule as the completion path below: an argument delta
 		// belonging to a different call must not be appended to this block's
 		// buffer, which would corrupt the JSON both of them parse.
-		const target = resolveStreamedCall(state, update.message.value.callId);
+		const target = resolveStreamedCall(state, value.callId);
 		if (target?.[kStreamingBlockKind] === "mcp") {
 			// Cursor's `args_text_delta` is "aggregated args text so far" per agent.proto: each
 			// delta is a cumulative snapshot of the JSON-text args. Strip the prefix we already
@@ -4115,6 +4340,26 @@ export function processInteractionUpdate(
 					log("error", "onTodoSnapshot", { error: hostError });
 				}
 				state.onToolResult?.(persisted ?? buildTodoToolResult(settled.id, snapshot, hostError ?? error));
+			} else if (settled[kStreamingBlockKind] === "cursor-edit") {
+				const edit = selectEditCall(toolCall);
+				if (edit?.args) {
+					settled.arguments = omitUndefinedArgs({
+						...settled.arguments,
+						path: edit.args.path ?? stringToolArg(settled.arguments, "path"),
+						stream_content: edit.args.streamContent ?? stringToolArg(settled.arguments, "stream_content"),
+					});
+				}
+				if (!state.pairedEditToolCallIds?.has(settled.id)) {
+					const { text, isError } = describeEditResult(toolCall);
+					state.onToolResult?.({
+						role: "toolResult",
+						toolCallId: settled.id,
+						toolName: "edit",
+						content: [{ type: "text", text }],
+						isError,
+						timestamp: Date.now(),
+					});
+				}
 			}
 			const idx = output.content.indexOf(settled);
 			clearStreamingPartialJson(settled);

--- a/packages/ai/src/providers/cursor/exec-modern.ts
+++ b/packages/ai/src/providers/cursor/exec-modern.ts
@@ -74,6 +74,8 @@ import type { ToolResultMessage } from "../../types";
  * and their translation are consumed together.
  */
 export {
+	cursorEditOwnedReadPath,
+	cursorRawReadPath,
 	omitUndefinedArgs,
 	piEscapeRegexLiteral,
 	piGrepSkip,

--- a/packages/ai/test/cursor-edit-tool-call.test.ts
+++ b/packages/ai/test/cursor-edit-tool-call.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it } from "bun:test";
+import { create } from "@bufbuild/protobuf";
+import {
+	type BlockState,
+	flushOpenToolCalls,
+	handleServerMessage,
+	processInteractionUpdate,
+	type ToolCallState,
+} from "@oh-my-pi/pi-ai/providers/cursor";
+import type {
+	AssistantMessage,
+	CursorExecHandlers,
+	CursorToolResultHandler,
+	ToolResultMessage,
+} from "@oh-my-pi/pi-ai/types";
+import { kCursorExecResolved, kStreamingBlockKind } from "@oh-my-pi/pi-ai/utils/block-symbols";
+
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import {
+	AgentServerMessageSchema,
+	EditErrorSchema,
+	EditResultSchema,
+	EditToolCallSchema,
+	ExecServerMessageSchema,
+	ReadArgsSchema,
+	ToolCallSchema,
+	WriteArgsSchema,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
+
+const EDIT_ID = "tool_7aef3020-f275-4579-887c-34106e146f7";
+const ENVELOPE_ID = "call-edit-1";
+const TARGET = "/tmp/omp-cursor-edit-probe/note.txt";
+
+function cursorAssistantMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "cursor-composer-2.5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function newBlockState(onToolResult?: CursorToolResultHandler): BlockState {
+	let textBlock: BlockState["currentTextBlock"] = null;
+	let thinkingBlock: BlockState["currentThinkingBlock"] = null;
+	let toolCall: ToolCallState | null = null;
+	return {
+		get currentTextBlock() {
+			return textBlock;
+		},
+		get currentThinkingBlock() {
+			return thinkingBlock;
+		},
+		get currentToolCall() {
+			return toolCall;
+		},
+		openToolCalls: new Map(),
+		resolvedMcpToolCallIds: new Set(),
+		firstTokenTime: undefined,
+		setTextBlock: b => {
+			textBlock = b;
+		},
+		setThinkingBlock: b => {
+			thinkingBlock = b;
+		},
+		setToolCall: t => {
+			toolCall = t;
+		},
+		setFirstTokenTime: () => {},
+		onToolResult,
+	};
+}
+
+function editToolCall(path: string, streamContent?: string) {
+	return {
+		toolCallId: EDIT_ID,
+		tool: {
+			case: "editToolCall" as const,
+			value: { args: { path, streamContent } },
+		},
+	};
+}
+
+function startEdit(output: AssistantMessage, stream: AssistantMessageEventStream, state: BlockState): void {
+	processInteractionUpdate(
+		{
+			message: {
+				case: "toolCallStarted",
+				value: { callId: ENVELOPE_ID, toolCall: editToolCall(TARGET, "orange") },
+			},
+		},
+		output,
+		stream,
+		state,
+		{ sawTokenDelta: false },
+	);
+}
+
+function mockH2() {
+	const written: unknown[] = [];
+	return {
+		written,
+		h2Request: {
+			write: (chunk: unknown) => {
+				written.push(chunk);
+				return true;
+			},
+		} as unknown as Parameters<typeof handleServerMessage>[5],
+	};
+}
+
+function execRead(value: { path?: string; toolCallId?: string }) {
+	return create(AgentServerMessageSchema, {
+		message: {
+			case: "execServerMessage",
+			value: create(ExecServerMessageSchema, {
+				id: 1,
+				execId: "exec-readArgs",
+				message: { case: "readArgs", value: create(ReadArgsSchema, value) },
+			}),
+		},
+	});
+}
+
+function execWrite(value: { path?: string; fileText?: string; toolCallId?: string }) {
+	return create(AgentServerMessageSchema, {
+		message: {
+			case: "execServerMessage",
+			value: create(ExecServerMessageSchema, {
+				id: 1,
+				execId: "exec-writeArgs",
+				message: { case: "writeArgs", value: create(WriteArgsSchema, value) },
+			}),
+		},
+	});
+}
+
+describe("cursor native editToolCall (StrReplace)", () => {
+	it("opens one edit block and does not synthesize read/write cards for its materialization", async () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const toolResults: ToolResultMessage[] = [];
+		const state = newBlockState(result => {
+			toolResults.push(result);
+			return result;
+		});
+		const readPaths: string[] = [];
+		const { h2Request } = mockH2();
+		const execHandlers: CursorExecHandlers = {
+			async read(args) {
+				readPaths.push(args.path);
+				return {
+					role: "toolResult",
+					toolCallId: args.toolCallId,
+					toolName: "read",
+					content: [{ type: "text", text: "Hello from OMP probe.\nThe fruit is apple.\nGoodbye.\n" }],
+					isError: false,
+					timestamp: 1,
+				} satisfies ToolResultMessage;
+			},
+			async write(args) {
+				return {
+					role: "toolResult",
+					toolCallId: args.toolCallId,
+					toolName: "write",
+					content: [{ type: "text", text: "wrote" }],
+					isError: false,
+					timestamp: 2,
+				} satisfies ToolResultMessage;
+			},
+		};
+
+		startEdit(output, stream, state);
+
+		await handleServerMessage(
+			execRead({ path: TARGET, toolCallId: EDIT_ID }),
+			output,
+			stream,
+			state,
+			new Map(),
+			h2Request,
+			execHandlers,
+			result => {
+				toolResults.push(result);
+				return result;
+			},
+			{ sawTokenDelta: false },
+			[],
+		);
+		await handleServerMessage(
+			execWrite({
+				path: TARGET,
+				toolCallId: EDIT_ID,
+				fileText: "Hello from OMP probe.\nThe fruit is orange.\nGoodbye.\n",
+			}),
+			output,
+			stream,
+			state,
+			new Map(),
+			h2Request,
+			execHandlers,
+			result => {
+				toolResults.push(result);
+				return result;
+			},
+			{ sawTokenDelta: false },
+			[],
+		);
+
+		processInteractionUpdate(
+			{
+				message: {
+					case: "toolCallCompleted",
+					value: { callId: ENVELOPE_ID, toolCall: editToolCall(TARGET, "orange") },
+				},
+			},
+			output,
+			stream,
+			state,
+			{ sawTokenDelta: false },
+		);
+
+		const calls = output.content.filter((block): block is ToolCallState => block.type === "toolCall");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("edit");
+		expect(calls[0]?.id).toBe(EDIT_ID);
+		expect(calls[0]?.[kStreamingBlockKind]).toBe("cursor-edit");
+		expect(calls[0]?.[kCursorExecResolved]).toBe(true);
+		expect(calls[0]?.arguments).toEqual({ path: TARGET, stream_content: "orange" });
+		expect(readPaths).toEqual([`${TARGET}:raw`]);
+		expect(toolResults.map(result => result.toolName)).toEqual(["edit"]);
+		expect(toolResults[0]?.toolCallId).toBe(EDIT_ID);
+		expect(toolResults[0]?.isError).toBe(false);
+	});
+
+	it("still synthesizes a read block when the exec id is not an editToolCall", async () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const { h2Request } = mockH2();
+		const readPaths: string[] = [];
+		const execHandlers: CursorExecHandlers = {
+			async read(args) {
+				readPaths.push(args.path);
+				return {
+					role: "toolResult",
+					toolCallId: args.toolCallId,
+					toolName: "read",
+					content: [{ type: "text", text: "plain" }],
+					isError: false,
+					timestamp: 1,
+				} satisfies ToolResultMessage;
+			},
+		};
+
+		await handleServerMessage(
+			execRead({ path: TARGET, toolCallId: "call-read-plain" }),
+			output,
+			stream,
+			newBlockState(),
+			new Map(),
+			h2Request,
+			execHandlers,
+			undefined,
+			{ sawTokenDelta: false },
+			[],
+		);
+
+		const calls = output.content.filter(block => block.type === "toolCall");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("read");
+		expect(readPaths).toEqual([TARGET]);
+	});
+
+	it("appends streamContentDelta onto the open edit block", () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const state = newBlockState();
+		startEdit(output, stream, state);
+
+		processInteractionUpdate(
+			{
+				message: {
+					case: "toolCallDelta",
+					value: {
+						callId: ENVELOPE_ID,
+						toolCallDelta: {
+							delta: { case: "editToolCallDelta", value: { streamContentDelta: " peel" } },
+						},
+					},
+				},
+			},
+			output,
+			stream,
+			state,
+			{ sawTokenDelta: false },
+		);
+
+		const block = output.content[0];
+		expect(block?.type).toBe("toolCall");
+		if (block?.type !== "toolCall") throw new Error("expected edit block");
+		expect(block.arguments.stream_content).toBe("orange peel");
+	});
+
+	it("pairs a wire EditResult error as a failed edit, not Edit completed", () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const toolResults: ToolResultMessage[] = [];
+		const state = newBlockState(result => {
+			toolResults.push(result);
+			return result;
+		});
+		startEdit(output, stream, state);
+
+		const completed = create(ToolCallSchema, {
+			toolCallId: EDIT_ID,
+			tool: {
+				case: "editToolCall",
+				value: create(EditToolCallSchema, {
+					args: { path: TARGET, streamContent: "orange" },
+					result: create(EditResultSchema, {
+						result: {
+							case: "error",
+							value: create(EditErrorSchema, { path: TARGET, error: "permission denied" }),
+						},
+					}),
+				}),
+			},
+		});
+		processInteractionUpdate(
+			{ message: { case: "toolCallCompleted", value: { callId: ENVELOPE_ID, toolCall: completed } } },
+			output,
+			stream,
+			state,
+			{ sawTokenDelta: false },
+		);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.toolName).toBe("edit");
+		expect(toolResults[0]?.isError).toBe(true);
+		expect(
+			toolResults[0]?.content.some(part => part.type === "text" && part.text.includes("permission denied")),
+		).toBe(true);
+	});
+
+	it("pairs an interrupted cursor-edit when the transport dies before writeArgs", () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const toolResults: ToolResultMessage[] = [];
+		const state = newBlockState(result => {
+			toolResults.push(result);
+			return result;
+		});
+		startEdit(output, stream, state);
+		expect(toolResults).toHaveLength(0);
+
+		flushOpenToolCalls(output, stream, state);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.toolCallId).toBe(EDIT_ID);
+		expect(toolResults[0]?.toolName).toBe("edit");
+		expect(toolResults[0]?.isError).toBe(true);
+	});
+
+	it("treats a completion with no EditResult as a failed edit", () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const toolResults: ToolResultMessage[] = [];
+		const state = newBlockState(result => {
+			toolResults.push(result);
+			return result;
+		});
+		startEdit(output, stream, state);
+
+		processInteractionUpdate(
+			{
+				message: {
+					case: "toolCallCompleted",
+					value: { callId: ENVELOPE_ID, toolCall: editToolCall(TARGET, "orange") },
+				},
+			},
+			output,
+			stream,
+			state,
+			{ sawTokenDelta: false },
+		);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.isError).toBe(true);
+		expect(toolResults[0]?.content.some(part => part.type === "text" && part.text.includes("no result"))).toBe(true);
+	});
+
+	it("does not invent a closed-connection error after writeArgs already paired", async () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const toolResults: ToolResultMessage[] = [];
+		const state = newBlockState(result => {
+			toolResults.push(result);
+			return result;
+		});
+		const { h2Request } = mockH2();
+		const execHandlers: CursorExecHandlers = {
+			async write(args) {
+				return {
+					role: "toolResult",
+					toolCallId: args.toolCallId,
+					toolName: "write",
+					content: [{ type: "text", text: "wrote" }],
+					isError: false,
+					timestamp: 2,
+				} satisfies ToolResultMessage;
+			},
+		};
+		startEdit(output, stream, state);
+		await handleServerMessage(
+			execWrite({ path: TARGET, toolCallId: EDIT_ID, fileText: "orange\n" }),
+			output,
+			stream,
+			state,
+			new Map(),
+			h2Request,
+			execHandlers,
+			result => {
+				toolResults.push(result);
+				return result;
+			},
+			{ sawTokenDelta: false },
+			[],
+		);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.isError).toBe(false);
+
+		flushOpenToolCalls(output, stream, state);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.isError).toBe(false);
+	});
+
+	it("composes a ranged edit-owned read as one :raw selector", async () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const { h2Request } = mockH2();
+		const readPaths: string[] = [];
+		const execHandlers: CursorExecHandlers = {
+			async read(args) {
+				readPaths.push(args.path);
+				expect(args.offset).toBeUndefined();
+				expect(args.limit).toBeUndefined();
+				return {
+					role: "toolResult",
+					toolCallId: args.toolCallId,
+					toolName: "read",
+					content: [{ type: "text", text: "line" }],
+					isError: false,
+					timestamp: 1,
+				} satisfies ToolResultMessage;
+			},
+		};
+		const state = newBlockState();
+		startEdit(output, stream, state);
+		await handleServerMessage(
+			create(AgentServerMessageSchema, {
+				message: {
+					case: "execServerMessage",
+					value: create(ExecServerMessageSchema, {
+						id: 1,
+						execId: "exec-read-range",
+						message: {
+							case: "readArgs",
+							value: create(ReadArgsSchema, { path: TARGET, toolCallId: EDIT_ID, offset: 2, limit: 1 }),
+						},
+					}),
+				},
+			}),
+			output,
+			stream,
+			state,
+			new Map(),
+			h2Request,
+			execHandlers,
+			undefined,
+			{ sawTokenDelta: false },
+			[],
+		);
+
+		expect(readPaths).toEqual([`${TARGET}:raw:2+1`]);
+	});
+});

--- a/packages/ai/test/cursor-mcp-tool-catalog.test.ts
+++ b/packages/ai/test/cursor-mcp-tool-catalog.test.ts
@@ -56,4 +56,15 @@ describe("cursor buildMcpToolDefinitions", () => {
 		expect(lspDef?.providerIdentifier).toBe("pi-agent");
 		expect(lspDef?.toolName).toBe("lsp");
 	});
+
+	it("advertises hashline edit, which Cursor has no native equivalent for", () => {
+		// Native StrReplace is `editToolCall`, not hashline. Filtering `edit`
+		// would leave the model with no way to apply a tagged section rewrite.
+		const defs = buildMcpToolDefinitions([tool("read"), tool("bash"), tool("edit")]);
+		const editDef = defs.find(def => def.name === "edit");
+		expect(editDef).toBeDefined();
+		expect(editDef?.providerIdentifier).toBe("pi-agent");
+		expect(editDef?.toolName).toBe("edit");
+		expect(defs.map(def => def.name)).not.toContain("read");
+	});
 });

--- a/packages/ai/test/cursor-pi-args.test.ts
+++ b/packages/ai/test/cursor-pi-args.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
-import { omitUndefinedArgs, piGrepSkip } from "../src/providers/cursor-pi-args";
+import {
+	cursorEditOwnedReadPath,
+	cursorRawReadPath,
+	omitUndefinedArgs,
+	piGrepSkip,
+	piReadPath,
+} from "../src/providers/cursor-pi-args";
+
 import type { Tool } from "../src/types";
 import { validateToolArguments } from "../src/utils/validation";
 
@@ -82,5 +89,25 @@ describe("omitUndefinedArgs", () => {
 				arguments: omitUndefinedArgs(rawGrep),
 			}),
 		).toEqual({ pattern: "needle", path: "." });
+	});
+});
+
+describe("cursorRawReadPath", () => {
+	it("appends :raw to a whole-file path so hashline markup is not returned", () => {
+		expect(cursorRawReadPath("/tmp/note.txt")).toBe("/tmp/note.txt:raw");
+	});
+
+	it("inserts raw before an existing line range instead of dropping the range", () => {
+		expect(cursorRawReadPath("/tmp/note.txt:10-20")).toBe("/tmp/note.txt:raw:10-20");
+	});
+
+	it("leaves a path that already carries raw alone", () => {
+		expect(cursorRawReadPath("/tmp/note.txt:raw")).toBe("/tmp/note.txt:raw");
+		expect(cursorRawReadPath("/tmp/note.txt:raw:2+3")).toBe("/tmp/note.txt:raw:2+3");
+	});
+
+	it("does not stack a second :raw when a range is composed onto a raw path", () => {
+		expect(piReadPath("/tmp/note.txt:raw", 2, 1)).toBe("/tmp/note.txt:raw:2+1");
+		expect(cursorEditOwnedReadPath("/tmp/note.txt", 2, 1)).toBe("/tmp/note.txt:raw:2+1");
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Fixed Cursor sessions hiding hashline `edit`, which left the model with only native StrReplace (dropped) or bash/python string replacement after the server injected Cursor CLI tool instructions.
+- Fixed Cursor MCP calls named `StrReplace`/`Edit` (or `edit` with `old_string`/`new_string`) 404ing after the server injected CLI tool instructions: those names now run the replace-mode bridge `edit` instead of falling through to bash/python.
+
 
 ## [17.3.8] - 2026-08-19
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor sessions hiding hashline `edit`, which left the model with only native StrReplace (dropped) or bash/python string replacement after the server injected Cursor CLI tool instructions.
+
 ## [17.3.8] - 2026-08-19
+
 
 ### Added
 
@@ -61,7 +66,6 @@
 - Fixed terminals that deliver Shift+Enter as a bare LF (or the legacy CSI `13;2~` form) getting a plain switch instead of summarize-and-switch in the `/tree` selector ([#8821](https://github.com/can1357/oh-my-pi/issues/8821)).
 - Fixed OMP panicking at startup when the host environment contains a non-UTF-8 variable value; such entries are now skipped when copying the host environment into the shell ([#8925](https://github.com/can1357/oh-my-pi/issues/8925)).
 - Fixed `/mcp reauth` refusing to run the OAuth flow for HTTP MCP servers that allow unauthenticated `initialize` but require auth for `tools/call`; endpoint discovery now runs against the server URL before giving up ([#8922](https://github.com/can1357/oh-my-pi/issues/8922)).
-
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/cursor-bridge-tools.ts
+++ b/packages/coding-agent/src/cursor-bridge-tools.ts
@@ -63,10 +63,10 @@ export function createBridgeEditTool(session: ToolSession, extensionRunner: Exte
  * (issue #5680). The granted map is never mutated: an unsubstituted result is a
  * copy, so a caller without an `edit` grant cannot accidentally gain one.
  *
- * The advisor roster passes its granted map here; the primary session keeps its
- * instance out of the registry entirely (Cursor does not advertise `edit`) and
- * serves it through the bridge's `getEditReplaceTool` accessor instead — not
- * the `getTool` fallback, which doubles as the agent loop's resolver for
+ * The advisor roster passes its granted map here. The primary session
+ * advertises hashline `edit` as MCP and still serves the replace-mode
+ * instance through the bridge's `getEditReplaceTool` accessor — not the
+ * `getTool` fallback, which doubles as the agent loop's resolver for
  * unadvertised calls and must stay device-only.
  */
 export function bridgeToolMap(

--- a/packages/coding-agent/src/cursor-bridge-tools.ts
+++ b/packages/coding-agent/src/cursor-bridge-tools.ts
@@ -79,3 +79,85 @@ export function bridgeToolMap(
 	if (bridgeEdit) bridged.set("edit", bridgeEdit);
 	return bridged;
 }
+
+/**
+ * Server-injected Cursor CLI edit names that are not in the OMP registry.
+ *
+ * Native Ultra edits arrive as `editToolCall`. If that frame is absent, the
+ * model still follows the injected instructions and calls these as MCP — which
+ * used to 404 and fall through to bash/python string replace.
+ */
+const CURSOR_STRREPLACE_MCP_NAMES = new Set([
+	"StrReplace",
+	"str_replace",
+	"strReplace",
+	"SearchReplace",
+	"search_replace",
+	"Edit",
+]);
+
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+	const value = args[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+export function isCursorStrReplaceMcpName(name: string): boolean {
+	return CURSOR_STRREPLACE_MCP_NAMES.has(name);
+}
+
+/**
+ * Project a Cursor CLI / Pi-style replacement payload onto `replace` kwargs.
+ *
+ * Unknown shapes are returned unchanged so the replace schema still rejects
+ * them instead of inventing an empty edit.
+ */
+export function normalizeCursorReplaceArgs(args: Record<string, unknown>): Record<string, unknown> {
+	const path = stringArg(args, "path");
+	const old_string =
+		stringArg(args, "old_string") ??
+		stringArg(args, "old_str") ??
+		stringArg(args, "old_text") ??
+		stringArg(args, "oldString") ??
+		stringArg(args, "oldText");
+	const new_string =
+		stringArg(args, "new_string") ??
+		stringArg(args, "new_str") ??
+		stringArg(args, "new_text") ??
+		stringArg(args, "newString") ??
+		stringArg(args, "newText");
+	const replaceAll = args.replace_all ?? args.replaceAll;
+	if (path === undefined || old_string === undefined || new_string === undefined) return args;
+	return {
+		path,
+		old_string,
+		new_string,
+		...(typeof replaceAll === "boolean" ? { replace_all: replaceAll } : {}),
+	};
+}
+
+/**
+ * Whether this MCP invocation should run the replace-mode bridge `edit`.
+ *
+ * Server-injected names always do. An `edit` call that already carries a
+ * hashline `input` stays on the advertised instance. An `edit` call that
+ * carries `old_string`/`new_string` (or a Pi/CLI synonym) is the mixed
+ * fallback: our tool name plus the server's schema.
+ */
+export function cursorMcpPrefersReplaceEdit(name: string, args: Record<string, unknown>): boolean {
+	if (isCursorStrReplaceMcpName(name)) return true;
+	if (name !== "edit") return false;
+	if (typeof args.input === "string" || typeof args._input === "string") return false;
+	const old_string =
+		stringArg(args, "old_string") ??
+		stringArg(args, "old_str") ??
+		stringArg(args, "old_text") ??
+		stringArg(args, "oldString") ??
+		stringArg(args, "oldText");
+	const new_string =
+		stringArg(args, "new_string") ??
+		stringArg(args, "new_str") ??
+		stringArg(args, "new_text") ??
+		stringArg(args, "newString") ??
+		stringArg(args, "newText");
+	return old_string !== undefined && new_string !== undefined;
+}

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -28,6 +28,7 @@ import {
 	piTimeout,
 } from "@oh-my-pi/pi-ai/providers/cursor/exec-modern";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
+import { cursorMcpPrefersReplaceEdit, normalizeCursorReplaceArgs } from "./cursor-bridge-tools";
 import type { MCPResourceReadResult } from "./mcp/types";
 import type { ApprovalMode } from "./tools/approval";
 import { resolveApproval } from "./tools/approval";
@@ -924,6 +925,16 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 	async mcp(call: CursorMcpCall) {
 		const toolName = call.toolName || call.name;
 		const toolCallId = decodeToolCallId(call.toolCallId);
+		const args = Object.keys(call.args ?? {}).length > 0 ? call.args : decodeMcpArgs(call.rawArgs ?? {});
+		if (cursorMcpPrefersReplaceEdit(toolName, args)) {
+			const replaceTool = this.options.getEditReplaceTool?.();
+			if (!replaceTool) {
+				const availableTools = Array.from(this.options.tools.keys()).filter(name => name.startsWith("mcp__"));
+				const message = formatMcpToolErrorMessage(toolName, availableTools);
+				return createToolResultMessage(toolCallId, toolName, buildToolErrorResult(message), true);
+			}
+			return await executeTool(this.options, "edit", toolCallId, normalizeCursorReplaceArgs(args), replaceTool);
+		}
 		const tool = this.options.getExecutableTool?.(toolName) ?? this.options.tools.get(toolName);
 		if (!tool) {
 			const availableTools = Array.from(this.options.tools.keys()).filter(name => name.startsWith("mcp__"));
@@ -932,7 +943,6 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			return createToolResultMessage(toolCallId, toolName, result, true);
 		}
 
-		const args = Object.keys(call.args ?? {}).length > 0 ? call.args : decodeMcpArgs(call.rawArgs ?? {});
 		const toolResultMessage = await executeTool(this.options, toolName, toolCallId, args);
 		return toolResultMessage;
 	}
@@ -947,16 +957,19 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 	 */
 	async mcpApprovalPreflight(call: CursorMcpCall) {
 		const toolName = call.toolName || call.name;
-		const tool = this.options.getExecutableTool?.(toolName) ?? this.options.tools.get(toolName);
+		const args = Object.keys(call.args ?? {}).length > 0 ? call.args : decodeMcpArgs(call.rawArgs ?? {});
+		const preferReplace = cursorMcpPrefersReplaceEdit(toolName, args);
+		const tool = preferReplace
+			? this.options.getEditReplaceTool?.()
+			: (this.options.getExecutableTool?.(toolName) ?? this.options.tools.get(toolName));
 		if (!tool) return false;
 		const context = this.options.getToolContext?.();
 		const settings = context?.settings;
 		const approvalMode: ApprovalMode =
 			context?.autoApprove === true ? "yolo" : (settings?.get("tools.approvalMode") ?? "yolo");
-		const args = Object.keys(call.args ?? {}).length > 0 ? call.args : decodeMcpArgs(call.rawArgs ?? {});
 		const approval = resolveApproval(
 			tool,
-			args,
+			preferReplace ? normalizeCursorReplaceArgs(args) : args,
 			approvalMode,
 			(settings?.get("tools.approval") ?? {}) as Record<string, unknown>,
 		);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2673,23 +2673,18 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		for (const tool of toolRegistry.values()) {
 			toolRegistry.set(tool.name, new ExtensionToolWrapper(tool, extensionRunner));
 		}
-		// Cursor's own client owns file edits, so `edit` is not advertised to the
-		// model (commit 8ba0498eb: full-file `write` is used instead). The exec
-		// bridge is a different consumer: the server sends native `pi_edit`
-		// frames regardless of the advertised catalog, and answering them needs
-		// a real tool.
+		// Hashline `edit` stays in the registry so Cursor can call it as MCP.
+		// Native StrReplace arrives as `editToolCall` and materializes through
+		// exec `readArgs`/`writeArgs`; `pi_edit` still needs a `replace`-mode
+		// instance because `PiEditExecArgs` carries `old_string`/`new_string`,
+		// which is exactly `replace`'s schema and nothing else's. The registry
+		// instance follows the session's configured mode, so the bridge builds
+		// its own and serves it through `getEditReplaceTool` — not `getTool`,
+		// which doubles as the agent loop's fallback for unadvertised calls.
 		//
-		// It must be a `replace`-mode instance. `PiEditExecArgs` carries
-		// `old_string`/`new_string` replacements, which is exactly `replace`'s schema and
-		// nothing else's — under the default `hashline` mode the frame's args do
-		// not match the tool's parameters at all. The registry instance follows
-		// the session's configured mode, so the bridge builds its own.
-		//
-		// The grant is captured HERE, before the Cursor branch below deletes
-		// `edit` from the registry, and independently of the session's provider:
+		// The grant is captured here, independently of the session's provider:
 		// a session that starts on another provider can switch to Cursor later,
-		// and the roster is built once, at session creation. Reading the registry
-		// at frame time would see the switched-to state, not the grant.
+		// and the roster is built once, at session creation.
 		const editWasGranted = toolRegistry.has("edit");
 		// Built on first use rather than eagerly: a session that never reaches
 		// Cursor never constructs it.
@@ -2710,10 +2705,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// resource-download frames that mutate files without running a registry
 		// tool, so it needs the grant as the session actually made it.
 		const cursorCanMutateFiles = editWasGranted || toolRegistry.has("write");
-		if (model?.provider === "cursor") {
-			toolRegistry.delete("edit");
-			builtInRegistryToolNames.delete("edit");
-		}
 
 		let writeRegistration: Promise<boolean> | undefined;
 		const ensureWriteRegistered = (): Promise<boolean> => {

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -24,7 +24,10 @@ import {
 	bridgeToolMap,
 	createBridgeEditTool,
 	createBridgeGrepFactory,
+	cursorMcpPrefersReplaceEdit,
+	normalizeCursorReplaceArgs,
 } from "@oh-my-pi/pi-coding-agent/cursor-bridge-tools";
+
 import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -581,6 +584,134 @@ describe("bridge tool resolution beyond the model-facing registry", () => {
 
 		expect(result.isError).toBe(true);
 		expect(await Bun.file(target).exists()).toBe(false);
+	});
+});
+
+describe("Cursor MCP StrReplace fallback", () => {
+	let cwd: string;
+
+	beforeEach(async () => {
+		cwd = await fs.mkdtemp(path.join(os.tmpdir(), "cursor-mcp-strreplace-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(cwd);
+	});
+
+	it("projects CLI and Pi replacement fields onto replace kwargs", () => {
+		expect(
+			normalizeCursorReplaceArgs({ path: "/tmp/n.txt", old_text: "a", new_text: "b", replaceAll: true }),
+		).toEqual({ path: "/tmp/n.txt", old_string: "a", new_string: "b", replace_all: true });
+		expect(normalizeCursorReplaceArgs({ path: "/tmp/n.txt", input: "[n]" })).toEqual({
+			path: "/tmp/n.txt",
+			input: "[n]",
+		});
+	});
+
+	it("routes injected CLI names and replace-shaped edit onto the bridge", () => {
+		expect(cursorMcpPrefersReplaceEdit("StrReplace", { path: "a", old_string: "x", new_string: "y" })).toBe(true);
+		expect(cursorMcpPrefersReplaceEdit("Edit", { path: "a", old_text: "x", new_text: "y" })).toBe(true);
+		expect(cursorMcpPrefersReplaceEdit("edit", { path: "a", old_string: "x", new_string: "y" })).toBe(true);
+		expect(cursorMcpPrefersReplaceEdit("edit", { input: "[a#0000]\nPUT 1.=1:\n+x\n" })).toBe(false);
+		expect(cursorMcpPrefersReplaceEdit("write", { path: "a", old_string: "x", new_string: "y" })).toBe(false);
+	});
+
+	it("edits a file when the server-injected StrReplace name arrives as MCP", async () => {
+		const target = path.join(cwd, "note.txt");
+		await Bun.write(target, "alpha\nbeta\n");
+		const session = createTestSession(cwd);
+		const handlers = new CursorExecHandlers({
+			cwd,
+			tools: new Map<string, Tool>([["edit", new EditTool(session)]]),
+			getEditReplaceTool: () => createBridgeEditTool(session, passthroughRunner()),
+		});
+
+		const result = await handlers.mcp({
+			name: "StrReplace",
+			providerIdentifier: "cursor",
+			toolName: "StrReplace",
+			toolCallId: "sr1",
+			args: { path: target, old_string: "beta", new_string: "gamma" },
+			rawArgs: {},
+		});
+
+		expect(await Bun.file(target).text()).toBe("alpha\ngamma\n");
+		expect(result.content.map(part => (part.type === "text" ? part.text : "")).join("")).not.toMatch(
+			/not found|not available/i,
+		);
+	});
+
+	it("runs replace-mode when advertised hashline edit is called with old_string", async () => {
+		const target = path.join(cwd, "note.txt");
+		await Bun.write(target, "alpha\nbeta\n");
+		const session = createTestSession(cwd);
+		const hashline = new EditTool(session);
+		expect(hashline.mode).not.toBe("replace");
+		const handlers = new CursorExecHandlers({
+			cwd,
+			tools: new Map<string, Tool>([["edit", hashline]]),
+			getEditReplaceTool: () => createBridgeEditTool(session, passthroughRunner()),
+		});
+
+		const result = await handlers.mcp({
+			name: "edit",
+			providerIdentifier: "pi-agent",
+			toolName: "edit",
+			toolCallId: "e-mix",
+			args: { path: target, old_text: "beta", new_text: "gamma" },
+			rawArgs: {},
+		});
+
+		expect(await Bun.file(target).text()).toBe("alpha\ngamma\n");
+		expect(result.content.map(part => (part.type === "text" ? part.text : "")).join("")).not.toMatch(
+			/not found|not available/i,
+		);
+	});
+
+	it("does not run replace-mode for a hashline edit payload", async () => {
+		const session = createTestSession(cwd);
+		let replaceBuilt = 0;
+		const handlers = new CursorExecHandlers({
+			cwd,
+			tools: new Map<string, Tool>([["edit", new EditTool(session)]]),
+			getEditReplaceTool: () => {
+				replaceBuilt++;
+				return createBridgeEditTool(session, passthroughRunner());
+			},
+		});
+
+		await handlers.mcp({
+			name: "edit",
+			providerIdentifier: "pi-agent",
+			toolName: "edit",
+			toolCallId: "e-hl",
+			args: { input: "[missing.txt]\nPUT 1.=1:\n+x\n" },
+			rawArgs: {},
+		});
+
+		expect(replaceBuilt).toBe(0);
+	});
+
+	it("still 404s StrReplace when edit was not granted", async () => {
+		const target = path.join(cwd, "note.txt");
+		await Bun.write(target, "alpha\nbeta\n");
+		const handlers = new CursorExecHandlers({
+			cwd,
+			tools: new Map<string, Tool>(),
+			getEditReplaceTool: () => undefined,
+		});
+
+		const result = await handlers.mcp({
+			name: "StrReplace",
+			providerIdentifier: "cursor",
+			toolName: "StrReplace",
+			toolCallId: "sr-deny",
+			args: { path: target, old_string: "beta", new_string: "gamma" },
+			rawArgs: {},
+		});
+
+		expect(result.isError).toBe(true);
+		expect(await Bun.file(target).text()).toBe("alpha\nbeta\n");
 	});
 });
 

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -327,13 +327,13 @@ describe("bridge tool resolution beyond the model-facing registry", () => {
 	});
 
 	it("edits a real file from a pi_edit frame when `edit` is withheld from the model", async () => {
-		// For Cursor the session drops `edit` from the tool registry so the model
-		// is steered to full-file `write`. The native `pi_edit` frame arrives
-		// regardless of the advertised catalog, so the bridge must still reach a
-		// real edit tool through `getEditReplaceTool` — otherwise every modern
-		// edit answers "Tool \"edit\" not available" and the file is untouched.
-		// (Not the `getTool` fallback: that resolver also serves the agent loop's
-		// unadvertised calls, so it stays device-only.)
+		// A restricted roster omits `edit`. Native `pi_edit` still arrives, so
+		// the bridge must reach a real replace-mode tool through
+		// `getEditReplaceTool` — otherwise every modern edit answers
+		// `Tool "edit" not available` and the file is untouched.
+		// (Not the `getTool` fallback: that resolver also serves the agent
+		// loop's unadvertised calls, so it stays device-only.)
+
 		const target = path.join(cwd, "sample.txt");
 		await Bun.write(target, "alpha\nbeta\n");
 		// Build it exactly as the session does. Both bridge callsites go through
@@ -395,13 +395,11 @@ describe("bridge tool resolution beyond the model-facing registry", () => {
 	});
 
 	it("runs the replace-mode instance even when the registry still holds another mode", async () => {
-		// The state a session reaches by starting on a non-Cursor provider and
-		// switching to Cursor: `edit` was never deleted from the registry (that
-		// only happens for a session created on Cursor) and the roster is not
-		// rebuilt on switch, so the configured-mode instance is still there.
-		// `executeTool` prefers the map over the `getTool` fallback, so without
-		// an explicit replace-mode accessor every native edit after the switch
-		// fails validation against the wrong schema.
+		// Hashline `edit` stays advertised as MCP. `executeTool` prefers the map
+		// over the `getTool` fallback, so without an explicit replace-mode
+		// accessor every native `pi_edit` fails validation against the hashline
+		// schema.
+
 		const target = path.join(cwd, "sample.txt");
 		await Bun.write(target, "alpha\nbeta\n");
 		const session = createTestSession(cwd);

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -1986,13 +1986,14 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
-	// A session created on another provider keeps its configured-mode `edit` in
-	// the registry (only a Cursor-created session moves it out) and the tool
-	// roster is built once, at creation — switching to Cursor later does not
-	// rebuild it. These two cover both directions of that wiring: the granted
-	// session must still reach a replace-mode instance for `pi_edit` (whose
-	// `old_string`/`new_string` args do not validate against the default `hashline`
-	// schema), and the restricted one must still be refused.
+	// Hashline `edit` stays in the registry on Cursor so the model can still
+	// call it as MCP. Native StrReplace arrives as `editToolCall` and is
+	// materialized via exec read/write; `pi_edit` still uses the replace-mode
+	// instance from `getEditReplaceTool`. The roster is built once at creation.
+	// These two cover both directions of that wiring: the granted session must
+	// still reach a replace-mode instance for `pi_edit` (whose `old_string` /
+	// `new_string` args do not validate against the default `hashline` schema),
+	// and the restricted one must still be refused.
 	//
 	// The handlers are internal to the session; `streamFn` is where they are
 	// handed to the provider, which is the externally observable seam.
@@ -2047,6 +2048,24 @@ describe("createAgentSession defaultInactive tool activation", () => {
 
 				expect(result.isError).toBeFalsy();
 				expect(fs.readFileSync(target, "utf8")).toBe("alpha\ngamma\n");
+			} finally {
+				await session.dispose();
+			}
+		});
+	});
+
+	it("keeps hashline edit advertised when the session starts on Cursor", async () => {
+		const tempDir = makeTempDir();
+		const cursorModel = getBundledModel("cursor", "composer-1.5");
+		if (!cursorModel) throw new Error("expected bundled Cursor model");
+
+		await withProviderAuth(["cursor"], async () => {
+			const { session } = await createAgentSession({
+				...baseOptions(tempDir),
+				model: cursorModel,
+			});
+			try {
+				expect(session.getActiveToolNames()).toContain("edit");
 			} finally {
 				await session.dispose();
 			}


### PR DESCRIPTION
## Problem

Cursor Ultra injects official CLI tools server-side. Targeted edits arrive as native `editToolCall` (StrReplace): `streamContent` is the replacement fragment, then exec `readArgs` + `writeArgs` reuse that `toolCallId`. The server treats the read result as file bytes and writes them back.

OMP dropped `editToolCall` / `editToolCallDelta`, hid hashline `edit` on Cursor-started sessions, and answered unknown MCP names with `toolNotFound`. The remaining mutation path was `write` + bash/python string replace. Hashline-formatted native reads would have poisoned the cycle even if the write had landed.

## Change

- Keep hashline `edit` advertised as MCP (removed the Cursor-only `toolRegistry.delete("edit")`).
- Open one resolved `edit` block for native `editToolCall`; append `streamContentDelta` onto it.
- Force `:raw` on edit-owned `readArgs` (range composed once via `cursorEditOwnedReadPath`; `offset`/`limit` dropped so the bridge cannot stack a second `:raw`).
- Pair edit-owned `writeArgs` onto that block (`toolName: "edit"`), not a new write card.
- `pi_edit` still runs the replace-mode instance through `getEditReplaceTool`.
- Missing `EditResult` is a failed pairing; `flushOpenToolCalls` pairs interrupted `cursor-edit` blocks unless `writeArgs` already persisted a result.
- Follow-up: MCP calls named `StrReplace` / `Edit` / `str_replace` / `SearchReplace`, or `edit` carrying `old_string`/`new_string` (or Pi/CLI synonyms), run that same replace-mode bridge instead of 404ing. Hashline `input` stays on the advertised instance. Ungranted sessions still 404. Approval preflight uses the same alias.

## Tests

- `packages/ai/test/cursor-edit-tool-call.test.ts` (new) plus existing Cursor provider / SDK activation tests.
- `packages/coding-agent/test/cursor-exec.test.ts`: `Cursor MCP StrReplace fallback` (6 cases).
- `bun test` on the six Cursor provider files: 172 pass.
- `bun check` passed in the worktree.
- OMP-native autoreview (DeepSeek V4 Pro): two fix cycles, then a clean pass-3 verdict on the first commit.
- Live `cursor/composer-2.5` print turn on this branch (`DEBUG_CURSOR=2`): native `editToolCall` + edit-owned `readArgs` returned raw bytes, `writeArgs` wrote a clean `apple`→`orange` file. No bash/python, no MCP `StrReplace` 404. Pre-patch capture of the same prompt wrote hashline back (`[note.txt#0AAB]`).

## Unverified

- Other Cursor models / Max-mode variants beyond Composer 2.5.
- Unmodelled proto fields 37–58 and skills (#6532) are still out of scope.

## Risk

Server-side CLI injection cannot be suppressed from OMP. This branch executes the native `editToolCall` cycle instead of dropping it, and MCP `StrReplace`/`Edit` is a replace-mode fallback if that frame is absent. Hashline `edit` remains advertised as a second fallback. Unknown exec variants still answer `unknown_exec_variant` / `exec_variant_unsupported` rather than implementing proto 37–58.
