### PR TITLE
fix(ui): collapse settled rows in live subagent previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Focused live task and eval subagent previews on unfinished agents, collapsing settled rows into a status summary ([#8949](https://github.com/can1357/oh-my-pi/issues/8949)).
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -1456,6 +1456,27 @@ function formatHiddenProgressLine(hidden: readonly AgentProgress[], theme: Theme
 	const hint = formatExpandHint(theme, false, true);
 	return `${theme.fg("dim", formatMoreItems(hidden.length, "agent"))}${breakdown}${hint ? ` ${hint}` : ""}`;
 }
+/**
+ * Keep compact live progress focused on unfinished agents. Settled rows remain
+ * available in expanded mode and in the final result, while the live preview
+ * summarizes them above the active edge.
+ */
+function selectCollapsedProgress(ordered: readonly AgentProgress[]): {
+	visible: readonly AgentProgress[];
+	hidden: readonly AgentProgress[];
+} {
+	const live = ordered.filter(progress => progress.status === "pending" || progress.status === "running");
+	if (live.length === 0) return { visible: ordered, hidden: [] };
+
+	const visible = live.slice(Math.max(0, live.length - COLLAPSED_AGENT_LIMIT));
+	if (visible.length === ordered.length) return { visible, hidden: [] };
+
+	const visibleSet = new Set(visible);
+	return {
+		visible,
+		hidden: ordered.filter(progress => !visibleSet.has(progress)),
+	};
+}
 
 /**
  * Pick the agent rows that stay visible when a finalized batch is collapsed:
@@ -1578,15 +1599,16 @@ export function renderResult(
 			Boolean(details.progress && details.progress.length > 0) && details.results.length === 0;
 		if (shouldRenderProgress && details.progress) {
 			const ordered = orderProgressForDisplay(details.progress);
-			// Collapsed view keeps the live edge: finished rows sort to the top of
-			// the display order, so folding from the top keeps running/pending
-			// agents (and their current-tool lines) visible while one summary line
-			// stands in for everything above it.
-			const visible = expanded ? ordered : ordered.slice(Math.max(0, ordered.length - COLLAPSED_AGENT_LIMIT));
-			if (visible.length < ordered.length) {
-				lines.push(formatHiddenProgressLine(ordered.slice(0, ordered.length - visible.length), theme));
+			// Collapsed live view keeps unfinished rows visible and folds settled
+			// rows into one status summary above them. Expanded mode retains the
+			// complete progress history.
+			const progressDisplay = expanded
+				? { visible: ordered, hidden: [] as AgentProgress[] }
+				: selectCollapsedProgress(ordered);
+			if (progressDisplay.hidden.length > 0) {
+				lines.push(formatHiddenProgressLine(progressDisplay.hidden, theme));
 			}
-			for (const progress of visible) {
+			for (const progress of progressDisplay.visible) {
 				lines.push(
 					...renderAgentProgress(progress, "", "  ", expanded, theme, spinnerFrame, frozen, undefined, 0, nowMs),
 				);
@@ -1613,7 +1635,13 @@ export function renderResult(
 						details.progress.filter(progress => !details.results.some(res => res.id === progress.id)),
 					)
 				: [];
-			for (const progress of supplementalProgress) {
+			const progressDisplay = expanded
+				? { visible: supplementalProgress, hidden: [] as AgentProgress[] }
+				: selectCollapsedProgress(supplementalProgress);
+			if (progressDisplay.hidden.length > 0) {
+				lines.push(formatHiddenProgressLine(progressDisplay.hidden, theme));
+			}
+			for (const progress of progressDisplay.visible) {
 				lines.push(
 					...renderAgentProgress(progress, "", "  ", expanded, theme, spinnerFrame, frozen, undefined, 0, nowMs),
 				);
@@ -1788,10 +1816,14 @@ function renderNestedTaskTree(
 		const inflight = details.progress;
 		if (inflight && inflight.length > 0) {
 			const ordered = orderProgressForDisplay(inflight);
-			const visible = expanded ? ordered : ordered.slice(Math.max(0, ordered.length - COLLAPSED_AGENT_LIMIT));
-			const hiddenCount = ordered.length - visible.length;
-			visible.forEach((prog, index) => {
-				const { prefix, continuePrefix } = nestedMarkers(hiddenCount === 0 && index === visible.length - 1, theme);
+			const progressDisplay = expanded
+				? { visible: ordered, hidden: [] as AgentProgress[] }
+				: selectCollapsedProgress(ordered);
+			progressDisplay.visible.forEach((prog, index) => {
+				const { prefix, continuePrefix } = nestedMarkers(
+					progressDisplay.hidden.length === 0 && index === progressDisplay.visible.length - 1,
+					theme,
+				);
 				lines.push(
 					...renderAgentProgress(
 						prog,
@@ -1807,9 +1839,9 @@ function renderNestedTaskTree(
 					),
 				);
 			});
-			if (hiddenCount > 0) {
+			if (progressDisplay.hidden.length > 0) {
 				const { prefix } = nestedMarkers(true, theme);
-				lines.push(`${prefix} ${theme.fg("dim", formatMoreItems(hiddenCount, "agent"))}`);
+				lines.push(`${prefix} ${formatHiddenProgressLine(progressDisplay.hidden, theme)}`);
 			}
 		}
 		seen.delete(details);

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -33,6 +33,8 @@ import { formatStyledTruncationWarning, stripOutputNotice } from "./output-meta"
 import {
 	formatBadge,
 	formatDuration,
+	formatExpandHint,
+	formatMoreItems,
 	formatStatusIcon,
 	formatTitle,
 	previewWindowRows,
@@ -141,6 +143,51 @@ function agentEventStatus(value: unknown): AgentEventStatus {
 			return "running";
 	}
 }
+const EVAL_COLLAPSED_AGENT_LIMIT = 4;
+
+function selectCollapsedAgentEvents(events: readonly EvalStatusEvent[]): {
+	visible: readonly EvalStatusEvent[];
+	hidden: readonly EvalStatusEvent[];
+} {
+	const live = events.filter(event => {
+		const status = agentEventStatus(event.status);
+		return status === "pending" || status === "running";
+	});
+	if (live.length === 0) return { visible: events, hidden: [] };
+
+	const visible = live.slice(Math.max(0, live.length - EVAL_COLLAPSED_AGENT_LIMIT));
+	if (visible.length === events.length) return { visible, hidden: [] };
+
+	const visibleSet = new Set(visible);
+	return {
+		visible,
+		hidden: events.filter(event => !visibleSet.has(event)),
+	};
+}
+
+function formatHiddenAgentEvents(hidden: readonly EvalStatusEvent[], theme: Theme): string {
+	const counts: Record<AgentEventStatus, number> = {
+		pending: 0,
+		running: 0,
+		completed: 0,
+		failed: 0,
+		aborted: 0,
+	};
+	for (const event of hidden) counts[agentEventStatus(event.status)]++;
+
+	const parts: string[] = [];
+	if (counts.completed > 0) parts.push(theme.fg("dim", `${counts.completed} done`));
+	if (counts.running > 0) parts.push(theme.fg("dim", `${counts.running} running`));
+	if (counts.pending > 0) parts.push(theme.fg("dim", `${counts.pending} pending`));
+	if (counts.failed > 0) parts.push(theme.fg("error", `${counts.failed} failed`));
+	if (counts.aborted > 0) parts.push(theme.fg("error", `${counts.aborted} aborted`));
+	const breakdown =
+		parts.length > 0
+			? `${theme.fg("dim", " (")}${parts.join(theme.fg("dim", theme.sep.dot))}${theme.fg("dim", ")")}`
+			: "";
+	const hint = formatExpandHint(theme, false, true);
+	return `${theme.fg("dim", formatMoreItems(hidden.length, "agent"))}${breakdown}${hint ? ` ${hint}` : ""}`;
+}
 
 /** Append the toolCount · context · cost · model stat run, mirroring the task tool. */
 function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
@@ -174,11 +221,20 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
  * subagent: a status line (icon · id · stats) plus, while running, the current
  * tool/intent. Drawn below the cell box so progress streams live.
  */
-function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spinnerFrame?: number): string[] {
+function renderAgentProgressEvents(
+	events: EvalStatusEvent[],
+	theme: Theme,
+	spinnerFrame?: number,
+	expanded = false,
+): string[] {
+	const display = expanded ? { visible: events, hidden: [] as EvalStatusEvent[] } : selectCollapsedAgentEvents(events);
 	const lines: string[] = [];
-	for (let i = 0; i < events.length; i++) {
-		const event = events[i];
-		const isLast = i === events.length - 1;
+	if (display.hidden.length > 0) {
+		lines.push(formatHiddenAgentEvents(display.hidden, theme));
+	}
+	for (let i = 0; i < display.visible.length; i++) {
+		const event = display.visible[i];
+		const isLast = i === display.visible.length - 1;
 		const prefix = theme.fg("dim", isLast ? theme.tree.last : theme.tree.branch);
 		const cont = isLast ? "   " : `${theme.fg("dim", theme.tree.vertical)}  `;
 
@@ -652,7 +708,7 @@ export const evalToolRenderer = {
 						);
 						lines.push(...cellLines);
 						if (agentEvents.length > 0) {
-							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, options.spinnerFrame));
+							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, options.spinnerFrame, expanded));
 						}
 						if (i < cellResults.length - 1) {
 							lines.push("");

--- a/packages/coding-agent/test/task/task-progress-render.test.ts
+++ b/packages/coding-agent/test/task/task-progress-render.test.ts
@@ -303,9 +303,9 @@ describe("task progress rendering", () => {
 		expect(rendered).toContain("Combine the winning patches.");
 	});
 
-	it("pins unfinished tasks below finished ones, finished sorted by runtime asc", async () => {
+	it("orders finished progress before unfinished rows when expanded", async () => {
 		const theme = (await getThemeByName("dark"))!;
-		const options: RenderResultOptions = { expanded: false, isPartial: true, spinnerFrame: 0 };
+		const options: RenderResultOptions = { expanded: true, isPartial: true, spinnerFrame: 0 };
 		const details: TaskToolDetails = {
 			projectAgentsDir: null,
 			results: [],
@@ -402,6 +402,51 @@ describe("task progress rendering", () => {
 			expect(expanded).toContain(id);
 		}
 		expect(expanded).not.toContain("more agents");
+	});
+
+	it("folds settled rows even when the live edge fits the collapsed cap", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const details: TaskToolDetails = {
+			projectAgentsDir: null,
+			results: [],
+			totalDurationMs: 0,
+			progress: [
+				runningProgress({ index: 0, id: "DoneOne", status: "completed", durationMs: 1000 }),
+				runningProgress({ index: 1, id: "FailedOne", status: "failed", durationMs: 2000 }),
+				runningProgress({ index: 2, id: "StillLive", status: "running" }),
+			],
+		};
+
+		const collapsed = Bun.stripANSI(
+			taskToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "" }], details },
+					{ expanded: false, isPartial: true, spinnerFrame: 0 },
+					theme,
+				)
+				.render(120)
+				.join("\n"),
+		);
+		expect(collapsed).toContain("StillLive");
+		expect(collapsed).not.toContain("DoneOne");
+		expect(collapsed).not.toContain("FailedOne");
+		expect(collapsed).toContain("… 2 more agents");
+		expect(collapsed).toContain("1 done");
+		expect(collapsed).toContain("1 failed");
+
+		const expanded = Bun.stripANSI(
+			taskToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "" }], details },
+					{ expanded: true, isPartial: true, spinnerFrame: 0 },
+					theme,
+				)
+				.render(120)
+				.join("\n"),
+		);
+		for (const id of ["DoneOne", "FailedOne", "StillLive"]) {
+			expect(expanded).toContain(id);
+		}
 	});
 
 	it("keeps problem rows visible when the collapsed result list folds", async () => {

--- a/packages/coding-agent/test/tools/eval-agent-progress.test.ts
+++ b/packages/coding-agent/test/tools/eval-agent-progress.test.ts
@@ -25,7 +25,11 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		resetSettingsForTest();
 	});
 
-	function render(statusEvents: EvalStatusEvent[], status: "running" | "complete" = "running"): string[] {
+	function render(
+		statusEvents: EvalStatusEvent[],
+		status: "running" | "complete" = "running",
+		expanded = false,
+	): string[] {
 		const details: EvalToolDetails = {
 			language: "python",
 			languages: ["python"],
@@ -43,7 +47,7 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		};
 		const component = evalToolRenderer.renderResult(
 			{ content: [{ type: "text", text: "" }], details },
-			{ expanded: false, isPartial: status === "running", spinnerFrame: 0 },
+			{ expanded, isPartial: status === "running", spinnerFrame: 0 },
 			theme,
 		);
 		return Bun.stripANSI(component.render(120).join("\n")).split("\n");
@@ -114,7 +118,7 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		expect(below).toContain("$0.06");
 	});
 
-	it("renders one line per subagent for a parallel fan-out", () => {
+	it("focuses the live preview on unfinished eval subagents", () => {
 		const events: EvalStatusEvent[] = [
 			{ op: "agent", id: "0-Alpha", agent: "task", status: "running", lastIntent: "scanning" },
 			{ op: "agent", id: "1-Beta", agent: "task", status: "completed", toolCount: 3, durationMs: 900 },
@@ -124,8 +128,23 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		const lines = render(events);
 		const below = lines.slice(boxBottomIndex(lines) + 1).join("\n");
 		expect(below).toContain("0-Alpha");
-		expect(below).toContain("1-Beta");
+		expect(below).not.toContain("1-Beta");
 		expect(below).toContain("2-Gamma");
+		expect(below).toContain("1 done");
+	});
+
+	it("shows settled eval subagents when expanded", () => {
+		const events: EvalStatusEvent[] = [
+			{ op: "agent", id: "0-Alpha", agent: "task", status: "running", lastIntent: "scanning" },
+			{ op: "agent", id: "1-Beta", agent: "task", status: "completed", toolCount: 3, durationMs: 900 },
+			{ op: "agent", id: "2-Gamma", agent: "task", status: "running", currentTool: "search" },
+		];
+
+		const lines = render(events, "running", true);
+		const below = lines.slice(boxBottomIndex(lines) + 1).join("\n");
+		for (const id of ["0-Alpha", "1-Beta", "2-Gamma"]) {
+			expect(below).toContain(id);
+		}
 	});
 
 	it("still folds non-agent status events into the box Status section", () => {


### PR DESCRIPTION
## Summary

- Keep compact task-tool progress focused on pending/running subagents while a batch is live.
- Apply the same policy to mixed and nested task progress and to eval `agent()` progress.
- Replace hidden settled rows with a per-status summary; expanded views and settled progress retain the full history.
- Add regression coverage and changelog entry.

Fixes #8949

## Verification

- `bun test packages/coding-agent/test/task/task-progress-render.test.ts packages/coding-agent/test/tools/eval-agent-progress.test.ts` — 20 passed.
- `bun run check` from `packages/coding-agent` — Biome and `tsgo` passed.
- Full `bun test` — 12 failures outside the changed files (tool repaint/streaming preview, cursor hard-link guard, browser launch, Python bridge, and eval completion environment/runtime cases); 12,464 tests passed and 406 skipped.
