### PR TITLE
fix(coding-agent): preserve shell operators after internal URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `providers.cacheRetention` setting (`/settings` → Providers → Protocol) to control prompt-cache retention per request: `auto` keeps the provider default (Anthropic: 5m entries with idle keep-alive refreshes), `short` forces 5m, `long` restores 1h TTLs where supported and disables the keep-alive refresh loop, `none` disables prompt caching.
 
+### Fixed
+
+- Fixed unquoted internal URLs in `bash` commands consuming adjacent shell operators into the resolved filesystem path.
+
 ## [17.3.7] - 2026-08-17
 
 ### Changed

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -9,10 +9,12 @@ import { normalizeLocalScheme } from "./path-utils";
 import { ToolError } from "./tool-errors";
 
 /** Regex to find skill:// tokens in command text. */
-const SKILL_URL_PATTERN = /'skill:\/\/[^'\s")`\\]+'|"skill:\/\/[^"\s')`\\]+"|skill:\/\/[^\s'")`\\]+/g;
+const SKILL_URL_PATTERN = /'skill:\/\/[^'\s")`\\]+'|"skill:\/\/[^"\s')`\\]+"|skill:\/\/[^\s'")`\\;&|<>($]+/g;
 
+// Unquoted URLs stop before shell syntax so expansion cannot quote an adjacent
+// operator or substitution into the resolved path.
 const INTERNAL_URL_PATTERN_INCLUDING_NORMALIZED_LOCAL =
-	/'(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^'\s")`\\]+'|"(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^"\s')`\\]+"|(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^\s'")`\\]+|'local:\/[^'\s")`\\]+'|"local:\/[^"\s')`\\]+"|(?<![./\\\\\w-])local:\/[^\s'")`\\]+/g;
+	/'(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^'\s")`\\]+'|"(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^"\s')`\\]+"|(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^\s'")`\\;&|<>($]+|'local:\/[^'\s")`\\]+'|"local:\/[^"\s')`\\]+"|(?<![./\\\\\w-])local:\/[^\s'")`\\;&|<>($]+/g;
 
 const SUPPORTED_INTERNAL_SCHEMES = ["skill", "agent", "artifact", "plan", "memory", "rule", "local"] as const;
 

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -300,6 +300,16 @@ describe("expandInternalUrls", () => {
 		);
 	});
 
+	it("keeps query parameters in an unquoted internal URL", async () => {
+		const router = createInternalRouter({
+			"agent://reviewer?q=needle": { sourcePath: "/tmp/session/reviewer.md" },
+		});
+
+		await expect(
+			expandInternalUrls("cat agent://reviewer?q=needle", { skills: [], internalRouter: router }),
+		).resolves.toBe(`cat ${shellEscape("/tmp/session/reviewer.md")}`);
+	});
+
 	it("expands local:// URLs to filesystem paths without requiring preexisting files", async () => {
 		const localOptions = {
 			getArtifactsDir: () => "/tmp/session-artifacts",
@@ -310,6 +320,19 @@ describe("expandInternalUrls", () => {
 
 		await expect(expandInternalUrls(command, { skills: [], localOptions })).resolves.toBe(
 			`mv /tmp/source.json ${shellEscape(expectedPath)}`,
+		);
+	});
+
+	it("preserves an adjacent command separator after an unquoted local URL", async () => {
+		const localOptions = {
+			getArtifactsDir: () => "/tmp/session-artifacts",
+			getSessionId: () => "session-1",
+		};
+		const command = 'bb review-packet gates --body-file local://body.txt; echo "exit=$?"';
+		const expectedPath = resolveLocalUrlToPath("local://body.txt", localOptions);
+
+		await expect(expandInternalUrls(command, { skills: [], localOptions })).resolves.toBe(
+			`bb review-packet gates --body-file ${shellEscape(expectedPath)}; echo "exit=$?"`,
 		);
 	});
 


### PR DESCRIPTION
## What

Fix internal URI expansion in `bash` commands so unquoted URIs stop before adjacent shell operators and substitutions instead of consuming them
into the resolved filesystem path.

For example:

```bash
command local://body.txt; echo "done"
```

now preserves `; echo "done"` as shell syntax rather than resolving `local://body.txt;` as the URI.

The same boundary handling applies to both internal URL and skill URL expansion. URI query parameters such as `agent://reviewer?q=needle`
remain intact.

## Why

Unquoted `local://` URIs followed immediately by shell operators such as `;`, `&&`, or `|` were matched together with the operator. URI expansion then shell-escaped the operator as part of the resolved path, mangling argv and preventing the intended shell operation from executing.

This could also swallow trailing cleanup commands or cause otherwise valid commands to print usage errors.

## Testing

Added regression coverage for:

- An unquoted `local://` URI immediately followed by a command separator.
- Preserving query parameters in unquoted internal URLs.

Verification performed:

```text
Focused regressions: 2 passed, 0 failed
Complete bash URI test file: 42 passed, 0 failed
bun run check: passed
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)