### PR TITLE
fix(advisor): defer in-progress non-blocker advice instead of dropping it

### DIFF
--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -181,6 +181,12 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	 *  by retagging the same text at a lower or equal severity. */
 	#deliveredNoteSeverities = new Map<string, number>();
 	#inProgressUpdate = false;
+	/** Notes withheld while the primary was mid-turn, in arrival order. Flushed
+	 *  deterministically on the first `beginUpdate(false)` so delivery does not
+	 *  depend on the advisor model choosing to re-raise (it may not, since the
+	 *  tool previously returned "Recorded." for a note that was never routed).
+	 *  Cleared on `resetDeliveredNotes` alongside the delivered-rank map. */
+	#deferredNotes: { note: string; severity?: AdviseDetails["severity"] }[] = [];
 
 	constructor(private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void) {}
 
@@ -190,13 +196,24 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	 * not interrupt the primary before it can finish its planned steps.
 	 */
 	beginUpdate(inProgress: boolean): void {
+		const wasInProgress = this.#inProgressUpdate;
 		this.#inProgressUpdate = inProgress;
+		// Turn just completed: flush everything withheld mid-turn, oldest first.
+		// Each flush re-enters the normal dedupe path (escalation rank > delivered
+		// rank), so a note the advisor already got through at a higher severity
+		// stays suppressed while a genuinely-new deferred note is delivered once.
+		if (wasInProgress && !inProgress && this.#deferredNotes.length > 0) {
+			const pending = this.#deferredNotes;
+			this.#deferredNotes = [];
+			for (const { note, severity } of pending) this.#deliver(note, severity);
+		}
 	}
 
 	/** Clear delivered-note memory when the advisor starts a fresh conversation. */
 	resetDeliveredNotes(): void {
 		this.#deliveredNoteSeverities.clear();
 		this.#inProgressUpdate = false;
+		this.#deferredNotes = [];
 	}
 
 	async execute(
@@ -207,28 +224,43 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<AdviseDetails>> {
 		if (this.#inProgressUpdate && args.severity !== "blocker") {
+			// Withheld, not delivered: queue for the deterministic flush on the next
+			// completed update. Skip if an identical note is already pending so a
+			// long mid-turn can't pile up 20 copies of the same advice. Tell the
+			// advisor the truth — the previous "Recorded." made it believe the note
+			// reached the primary, so it never re-raised and the advice was lost.
+			const key = advisorNoteDedupeKey(args.note);
+			const alreadyPending = this.#deferredNotes.some(p => advisorNoteDedupeKey(p.note) === key);
+			if (!alreadyPending) this.#deferredNotes.push({ note: args.note, severity: args.severity });
 			return {
-				content: [{ type: "text", text: "Recorded." }],
+				content: [
+					{
+						type: "text",
+						text: "Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes. Do not re-raise the same point.",
+					},
+				],
 				details: { note: args.note, severity: args.severity },
 				useless: true,
 			};
 		}
-		const key = advisorNoteDedupeKey(args.note);
-		const rank = advisorSeverityRank(args.severity);
-		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
-		if (rank <= previousRank) {
-			return {
-				content: [{ type: "text", text: "Duplicate advice ignored." }],
-				details: { note: args.note, severity: args.severity },
-				useless: true,
-			};
-		}
-		this.#deliveredNoteSeverities.set(key, rank);
-		this.onAdvice(args.note, args.severity);
+		const delivered = this.#deliver(args.note, args.severity);
 		return {
-			content: [{ type: "text", text: "Recorded." }],
+			content: [{ type: "text", text: delivered ? "Recorded." : "Duplicate advice ignored." }],
 			details: { note: args.note, severity: args.severity },
 			useless: true,
 		};
+	}
+
+	/** Run one note through the escalation-rank dedupe and, if it passes, route it
+	 *  to the primary. Returns true when the note was actually delivered. Shared by
+	 *  the live path (`execute`) and the deferred flush (`beginUpdate(false)`). */
+	#deliver(note: string, severity?: AdviseDetails["severity"]): boolean {
+		const key = advisorNoteDedupeKey(note);
+		const rank = advisorSeverityRank(severity);
+		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
+		if (rank <= previousRank) return false;
+		this.#deliveredNoteSeverities.set(key, rank);
+		this.onAdvice(note, severity);
+		return true;
 	}
 }

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -440,23 +440,48 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenNthCalledWith(3, note, "blocker");
 		});
 
-		it("withholds non-blockers for in-progress updates without consuming dedupe state", async () => {
+		it("defers non-blockers during in-progress updates and flushes them on the next completed update", async () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);
 			const note = "The result still needs a focused regression test.";
 
 			tool.beginUpdate(true);
-			await tool.execute("tc-1", { note, severity: "concern" });
+			const deferred = await tool.execute("tc-1", { note, severity: "concern" });
 			await tool.execute("tc-2", { note: "Minor naming cleanup.", severity: "nit" });
 			await tool.execute("tc-3", { note: "A destructive command is running.", severity: "blocker" });
 
+			// Deferred notes are NOT delivered mid-turn; blocker still goes through.
 			expect(onAdvice).toHaveBeenCalledTimes(1);
 			expect(onAdvice).toHaveBeenCalledWith("A destructive command is running.", "blocker");
+			// The tool tells the advisor the note is deferred, not silently "Recorded.".
+			expect(JSON.stringify(deferred.content)).toContain("Deferred");
+
+			// Completing the turn deterministically flushes both withheld notes,
+			// oldest first — no reliance on the advisor model re-raising them.
+			tool.beginUpdate(false);
+			expect(onAdvice).toHaveBeenCalledTimes(3);
+			expect(onAdvice).toHaveBeenNthCalledWith(2, note, "concern");
+			expect(onAdvice).toHaveBeenNthCalledWith(3, "Minor naming cleanup.", "nit");
+
+			// A later explicit re-raise of the same note is deduped (already delivered).
+			await tool.execute("tc-4", { note, severity: "concern" });
+			expect(onAdvice).toHaveBeenCalledTimes(3);
+		});
+
+		it("does not pile up duplicate deferred notes during a long mid-turn", async () => {
+			const onAdvice = vi.fn();
+			const tool = new AdviseTool(onAdvice);
+			const note = "Same point raised repeatedly.";
+
+			tool.beginUpdate(true);
+			await tool.execute("tc-1", { note, severity: "concern" });
+			await tool.execute("tc-2", { note, severity: "concern" });
+			await tool.execute("tc-3", { note, severity: "concern" });
 
 			tool.beginUpdate(false);
-			await tool.execute("tc-4", { note, severity: "concern" });
-			expect(onAdvice).toHaveBeenCalledTimes(2);
-			expect(onAdvice).toHaveBeenLastCalledWith(note, "concern");
+			// Identical note queued once, flushed once.
+			expect(onAdvice).toHaveBeenCalledTimes(1);
+			expect(onAdvice).toHaveBeenCalledWith(note, "concern");
 		});
 
 		it("validates parameters using ArkType", () => {


### PR DESCRIPTION
## Problem

When the primary agent is mid-turn (streaming / running tools), `AdviseTool` deliberately withholds non-`blocker` advice so it doesn't derail partial work. But the withhold path is a silent drop:

```
advisor calls advise("X is wrong", concern)   [primary mid-turn]
  → tool returns "Recorded."        ← misleading receipt
  → onAdvice() is NEVER called      ← note discarded
  → advisor believes it flagged X, moves on, never re-raises
  → X is lost permanently
```

Observed in a real session: 10 `advise` calls, 0 landed in the main transcript — 6 were swallowed by this in-progress gate.

## Fix

Replace the drop-and-hope path with a deterministic deferred queue:

- Withheld notes are pushed onto a `#deferredNotes` queue, deduped by normalized note key so a long mid-turn can't pile up repeats.
- The tool now honestly returns `"Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes."` instead of the misleading `"Recorded."`.
- `beginUpdate(false)` — fired when the turn completes — flushes the queue oldest-first through a shared `#deliver`, which re-enters the normal escalation-rank dedupe (so a note already delivered at a higher severity stays suppressed, and a genuinely-new deferred note is delivered exactly once).

Delivery no longer depends on the advisor model choosing to re-raise (it may not, since the old `"Recorded."` told it the note already landed).

## Testing

- Two new/updated tests in `advisor.test.ts`:
  - deferred notes flush oldest-first on `beginUpdate(false)`, blocker still bypasses mid-turn, and the receipt text says "Deferred";
  - identical notes withheld repeatedly during a long mid-turn are queued once and flushed once; a later explicit re-raise stays deduped.
- Mutation-verified: the rewritten withhold test fails on the old drop-and-re-raise contract and passes on the new deferred-flush behavior.
- `bun test test/advisor/` green (163/163 in `advisor.test.ts`); typecheck clean.

## Scope

Advisor-only change; no effect on the primary agent's turn flow. `blocker` severity behavior is unchanged (still bypasses the gate and interrupts immediately).