### PR TITLE
fix(catalog): route Copilot Grok 4.6 through Responses

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed SuperGrok (`xai-oauth`) Grok 4.6 hiding the thinking-level picker: the Responses effort-capable allowlist now includes `grok-4.6`, so `/model` can select the documented `low`/`medium`/`high`/`xhigh` ladder (`max` is rejected by api.x.ai).
 - Marked CoreWeave runtime discovery as authoritative so stale bundled model ids that the endpoint no longer serves stop appearing as selectable models.
 - ChatGPT Codex discovery that advertises only worker `-wm` SKUs now also registers the plain model route, so a configured `openai-codex/<model>` keeps resolving instead of fuzzy-falling-back to the `-wm` SKU some accounts reject.
+- Fixed GitHub Copilot routing for `grok-4.6` and its 1M-context variant to use the Responses endpoint instead of the unsupported Chat Completions endpoint ([#8807](https://github.com/can1357/oh-my-pi/issues/8807)).
 
 ## [17.3.6] - 2026-08-17
 

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -24448,7 +24448,7 @@
 		"grok-4.6": {
 			"id": "grok-4.6",
 			"name": "Grok 4.6",
-			"api": "openai-completions",
+			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
 			"reasoning": true,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5081,8 +5081,18 @@ export interface GithubCopilotModelManagerConfig {
 
 const COPILOT_ANTHROPIC_MODEL_PATTERN = /^claude-(haiku|sonnet|opus|fable|mythos)-\d/;
 const isCopilotResponsesModelId = (modelId: string): boolean =>
-	modelId === "grok-4.5" || modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
-const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["grok-4.5", "grok-4.5-1m", "mai-code-1-flash-picker"];
+	modelId === "grok-4.5" ||
+	modelId === "grok-4.6" ||
+	modelId.startsWith("gpt-5") ||
+	modelId.startsWith("oswe") ||
+	modelId.startsWith("mai-");
+const COPILOT_CACHE_INVALIDATED_MODEL_IDS = [
+	"grok-4.5",
+	"grok-4.5-1m",
+	"grok-4.6",
+	"grok-4.6-1m",
+	"mai-code-1-flash-picker",
+];
 
 function inferCopilotApi(modelId: string): Api {
 	if (COPILOT_ANTHROPIC_MODEL_PATTERN.test(modelId)) {

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -390,9 +390,23 @@ describe("github copilot model limits mapping", () => {
 		const model = models.find(candidate => candidate.id === "grok-4.5");
 		expect(model?.api).toBe("openai-responses");
 	});
+	it("routes grok-4.6 to the openai-responses endpoint (#8807)", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "grok-4.6",
+					name: "Grok 4.6",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "grok-4.6");
+		expect(model?.api).toBe("openai-responses");
+	});
 	for (const migration of [
 		{ id: "mai-code-1-flash-picker", name: "MAI-Code-1-Flash" },
 		{ id: "grok-4.5", name: "Grok 4.5" },
+		{ id: "grok-4.6", name: "Grok 4.6" },
 	]) {
 		it(`refreshes a cached ${migration.name} completion route after the endpoint migration`, async () => {
 			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `pi-ai-copilot-${migration.id}-cache-`));
@@ -433,7 +447,7 @@ describe("github copilot model limits mapping", () => {
 			}
 		});
 	}
-	it("drops cached Grok 4.5 context variants when the migration refresh fails", async () => {
+	it("drops cached Grok 4.5 and 4.6 context variants when the migration refresh fails", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-grok-variant-cache-"));
 		const cacheDbPath = path.join(tempDir, "models.db");
 		const cacheProviderId = "github-copilot-grok-variant-cache-test";
@@ -449,6 +463,12 @@ describe("github copilot model limits mapping", () => {
 						requestModelId: "grok-4.5",
 						contextWindow: 500_000,
 					},
+					cachedCopilotCompletionModel("grok-4.6", "Grok 4.6"),
+					{
+						...cachedCopilotCompletionModel("grok-4.6-1m", "Grok 4.6 (1M)"),
+						requestModelId: "grok-4.6",
+						contextWindow: 500_000,
+					},
 				],
 			});
 			await oldManager.refresh("online");
@@ -462,13 +482,15 @@ describe("github copilot model limits mapping", () => {
 			const { models } = await manager.refresh("online-if-uncached");
 
 			expect(fetchMock).toHaveBeenCalledTimes(2);
-			// The bundled catalog now ships a responses-route grok-4.5, so the id
-			// resurfaces from the bundle after the failed refresh. The migration
-			// contract is that the stale cached COMPLETIONS route never comes
-			// back — and the cached long-context variant has no bundled entry,
-			// so it stays dropped.
+			// The bundled catalog now ships responses-route grok-4.5 and grok-4.6, so the ids
+			// resurface from the bundle after the failed refresh. The migration
+			// contract is that the stale cached COMPLETIONS routes never come
+			// back — and the cached long-context variants have no bundled entries,
+			// so they stay dropped.
 			expect(models.find(candidate => candidate.id === "grok-4.5")?.api).toBe("openai-responses");
 			expect(models.find(candidate => candidate.id === "grok-4.5-1m")).toBeUndefined();
+			expect(models.find(candidate => candidate.id === "grok-4.6")?.api).toBe("openai-responses");
+			expect(models.find(candidate => candidate.id === "grok-4.6-1m")).toBeUndefined();
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## What

Route GitHub Copilot's `grok-4.6` and `grok-4.6-1m` models through the OpenAI Responses API. Invalidate stale cached Chat
Completions routes and update the bundled catalog entry.

## Why

Fixes #8807. GitHub Copilot serves Grok 4.6 only through `/responses`; requests sent to `/chat/completions` fail with `400
unsupported_api_for_model`.

Reviewed the diff and confirmed that it is limited to correction of the Copilot transport for Grok 4.6.

## Testing

- Ran `bun check`; all TypeScript, Biome, and Rust checks passed.
- Ran `bun test packages/catalog/test/github-copilot-model-limits.test.ts`; all 34 tests passed.
- Launched the branch with `github-copilot/grok-4.6` and sent a prompt through Copilot provider. The model returned the expected response without the previous HTTP 400 error.
- Confirmed the bundled `github-copilot/grok-4.6` catalog entry uses `openai-responses`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)