### PR TITLE
feat(tui): add persistent fullscreen chat mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -217,6 +217,7 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
+- Added `tui.fullscreen`, a persistent alternate-screen chat layout with an independently scrollable transcript, draggable scrollbar, and fixed editor/status dock. It can be switched live from `/settings`.
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -80,6 +80,8 @@ export interface Args {
 	skills?: string[];
 	noRules?: boolean;
 	noTitle?: boolean;
+	/** One-run terminal layout override. */
+	tuiMode?: "regular" | "fullscreen";
 	autoApprove?: boolean;
 	approvalMode?: "always-ask" | "write" | "yolo";
 	messages: string[];
@@ -215,6 +217,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 				const consumed = consumeBuiltInStringValue(arg, args, i + 1);
 				i = consumed.index;
 				STRING_SETTERS[arg](result, consumed.value, parseDeps);
+			} else if (arg === "--tui-mode") {
+				throw new CliUsageError("--tui-mode requires regular or fullscreen");
 			}
 		} else if (OPTIONAL_VALUE_FLAGS.has(arg)) {
 			const config = OPTIONAL_FLAGS[arg];

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -152,6 +152,16 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--max-time": (result, value) => {
 		result.maxTime = parseMaxTimeSeconds(value);
 	},
+	"--tui-mode": (result, value) => {
+		if (value === "regular" || value === "fullscreen") {
+			result.tuiMode = value;
+			return;
+		}
+		if (value.startsWith("-")) {
+			throw new CliUsageError("--tui-mode requires regular or fullscreen");
+		}
+		throw new CliUsageError(`Invalid TUI mode ${JSON.stringify(value)}. Valid values: regular, fullscreen`);
+	},
 	"--service-tier": (result, value) => {
 		if (!isServiceTierOpenAISettingValue(value)) {
 			throw new CliUsageError(

--- a/packages/coding-agent/src/cli/help-extra.ts
+++ b/packages/coding-agent/src/cli/help-extra.ts
@@ -62,6 +62,8 @@ export function getExtraHelpText(): string {
   PI_NO_PTY                  - Disable PTY-based interactive bash execution
   For complete environment variable reference, see:
   ${chalk.dim("docs/environment-variables.md")}
+${chalk.bold("Display:")}
+  --tui-mode <regular|fullscreen>  Start this run in the regular terminal view or the fullscreen TUI
 ${chalk.bold("Available Tools (default-enabled unless noted):")}
   read          - Read file contents
   bash          - Execute bash commands

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -43,6 +43,10 @@ export const launchHelp = {
 			description: "Output mode: text (default), json, rpc, or rpc-ui",
 			options: ["text", "json", "rpc", "acp", "rpc-ui"],
 		}),
+		"tui-mode": Flags.string({
+			description: "Terminal layout for this run: regular (default) or fullscreen",
+			options: ["regular", "fullscreen"],
+		}),
 		config: Flags.string({
 			description: "Load an extra config.yml-style overlay for this run (repeatable)",
 			multiple: true,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -970,6 +970,17 @@ export const SETTINGS_SCHEMA = {
 			description: "Remove the 1-character horizontal padding from the left and right of the terminal output",
 		},
 	},
+	"tui.fullscreen": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Fullscreen TUI",
+			description:
+				"Use an alternate-screen chat view with an independently scrollable transcript, scrollbar, and fixed editor/status dock",
+		},
+	},
 	"tui.scrollbackRebuild": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1312,6 +1312,10 @@ export async function runRootCommand(
 		// setup-time checks (e.g. #wrapToolForAcpPermission) also see the yolo intent.
 		settingsInstance.override("tools.approvalMode", "yolo");
 	}
+	if (parsedArgs.tuiMode) {
+		// --tui-mode affects only this process; /settings remains the persistent preference.
+		settingsInstance.override("tui.fullscreen", parsedArgs.tuiMode === "fullscreen");
+	}
 	if (parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		applyRpcDefaultSettingOverrides(settingsInstance);
 	} else if (parsedArgs.mode === "acp") {

--- a/packages/coding-agent/src/modes/components/fullscreen-chat-view.ts
+++ b/packages/coding-agent/src/modes/components/fullscreen-chat-view.ts
@@ -119,9 +119,10 @@ export class FullscreenChatView implements Component, OverlayFocusOwner {
 		}
 
 		if (event.release) {
-			const consumed = this.#draggingScrollbar;
 			this.#draggingScrollbar = false;
-			return consumed;
+			// Mouse tracking is enabled for the whole fullscreen surface, so even a
+			// release that did not end a scrollbar drag must stay out of the editor.
+			return true;
 		}
 
 		const scrollbarColumn = this.#width - 1;

--- a/packages/coding-agent/src/modes/components/fullscreen-chat-view.ts
+++ b/packages/coding-agent/src/modes/components/fullscreen-chat-view.ts
@@ -1,0 +1,149 @@
+import {
+	type Component,
+	type Container,
+	Ellipsis,
+	matchesKey,
+	type OverlayFocusOwner,
+	parseSgrMouse,
+	ScrollView,
+	type SgrMouseEvent,
+} from "@oh-my-pi/pi-tui";
+
+/**
+ * Persistent alternate-screen chat surface.
+ *
+ * The regular OMP root remains the source of truth for every existing
+ * transcript, status, hook, and editor component. This view only gives those
+ * components a viewport: history scrolls independently while the live dock
+ * stays fixed at the bottom of the terminal.
+ */
+export class FullscreenChatView implements Component, OverlayFocusOwner {
+	#scrollView = new ScrollView([], { height: 1, scrollbar: "auto", ellipsis: Ellipsis.Omit });
+	#followTail = true;
+	#viewportHeight = 1;
+	#width = 1;
+	#draggingScrollbar = false;
+
+	constructor(
+		private readonly transcriptComponents: readonly Component[],
+		private readonly dockComponents: readonly Component[],
+		private readonly editorContainer: Container,
+		private readonly terminalRows: () => number,
+	) {}
+
+	/** Lets the normal editor slot keep keyboard focus while this overlay owns the screen. */
+	ownsOverlayFocusTarget(component: Component): boolean {
+		return this.editorContainer.children.includes(component);
+	}
+
+	/** True when a viewport navigation key or mouse gesture changed the scroll position. */
+	handleViewportInput(data: string): boolean {
+		const mouse = parseSgrMouse(data);
+		if (mouse) return this.#handleMouse(mouse);
+
+		if (!this.#handleViewportKey(data)) return false;
+		this.#followTail = this.#scrollView.getScrollOffset() === this.#scrollView.getMaxScrollOffset();
+		return true;
+	}
+
+	invalidate(): void {
+		for (const component of this.transcriptComponents) component.invalidate?.();
+		for (const component of this.dockComponents) component.invalidate?.();
+	}
+
+	render(width: number): readonly string[] {
+		this.#width = Math.max(1, width);
+		const terminalRows = Math.max(1, this.terminalRows());
+		const dockLines = this.#renderDock(this.#width, terminalRows);
+		this.#viewportHeight = Math.max(1, terminalRows - dockLines.length);
+		const fullWidthTranscript = this.#renderComponents(this.transcriptComponents, this.#width);
+		// The scrollbar consumes the last terminal column. Re-render the
+		// transcript at its remaining width so each component wraps its own
+		// content instead of ScrollView cutting a rendered line short.
+		const transcriptWidth =
+			fullWidthTranscript.length > this.#viewportHeight ? Math.max(1, this.#width - 1) : this.#width;
+		const transcriptLines =
+			transcriptWidth === this.#width
+				? fullWidthTranscript
+				: this.#renderComponents(this.transcriptComponents, transcriptWidth);
+
+		this.#scrollView.setHeight(this.#viewportHeight);
+		this.#scrollView.setLines(transcriptLines);
+		if (this.#followTail) this.#scrollView.scrollToBottom();
+
+		const transcriptViewport = this.#scrollView.render(this.#width);
+		return [...transcriptViewport, ...dockLines];
+	}
+
+	#renderComponents(components: readonly Component[], width: number): string[] {
+		const lines: string[] = [];
+		for (const component of components) lines.push(...component.render(width));
+		return lines;
+	}
+
+	#renderDock(width: number, terminalRows: number): string[] {
+		const lines = this.#renderComponents(this.dockComponents, width);
+		// Keep one transcript row usable even when a transient panel and a tall
+		// editor would otherwise consume the whole terminal. The tail contains
+		// the editor and footer, which must remain available to type.
+		return lines.length < terminalRows ? lines : lines.slice(lines.length - terminalRows + 1);
+	}
+
+	#handleViewportKey(data: string): boolean {
+		// Keep normal arrows available to the multiline editor. These fullscreen
+		// navigation keys mirror upstream Pi's alternate-screen defaults.
+		if (matchesKey(data, "pageUp")) {
+			this.#scrollView.page(-1);
+			return true;
+		}
+		if (matchesKey(data, "pageDown")) {
+			this.#scrollView.page(1);
+			return true;
+		}
+		if (matchesKey(data, "home")) {
+			this.#scrollView.scrollToTop();
+			return true;
+		}
+		if (matchesKey(data, "end")) {
+			this.#scrollView.scrollToBottom();
+			return true;
+		}
+		return false;
+	}
+
+	#handleMouse(event: SgrMouseEvent): boolean {
+		if (event.wheel !== null) {
+			this.#scrollView.scroll(event.wheel);
+			this.#followTail = this.#scrollView.getScrollOffset() === this.#scrollView.getMaxScrollOffset();
+			return true;
+		}
+
+		if (event.release) {
+			const consumed = this.#draggingScrollbar;
+			this.#draggingScrollbar = false;
+			return consumed;
+		}
+
+		const scrollbarColumn = this.#width - 1;
+		if (event.leftClick && event.col === scrollbarColumn && event.row < this.#viewportHeight) {
+			this.#draggingScrollbar = true;
+			this.#scrollToPointer(event.row);
+			return true;
+		}
+		if (event.motion && this.#draggingScrollbar) {
+			this.#scrollToPointer(event.row);
+			return true;
+		}
+		// Mouse tracking is active while fullscreen owns the TTY. Consume idle
+		// motion and clicks so their escape sequences never enter the editor.
+		return true;
+	}
+
+	#scrollToPointer(row: number): void {
+		const max = this.#scrollView.getMaxScrollOffset();
+		const denominator = Math.max(1, this.#viewportHeight - 1);
+		const ratio = Math.max(0, Math.min(1, row / denominator));
+		this.#scrollView.setScrollOffset(Math.round(max * ratio));
+		this.#followTail = this.#scrollView.getScrollOffset() === max;
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -574,6 +574,10 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 				break;
 
+			case "tui.fullscreen":
+				this.ctx.setFullscreenTui(value as boolean);
+				break;
+
 			case "tui.scrollbackRebuild":
 				this.ctx.ui.setScrollbackRebuild(value as boolean);
 				break;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4183,10 +4183,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.#extensionUiController.clearHookWidgets();
-		this.#fullscreenChatInputUnsubscribe?.();
-		this.#fullscreenChatInputUnsubscribe = undefined;
-		this.#fullscreenChatOverlay = undefined;
-		this.#fullscreenChatView = undefined;
+		// TUI keeps overlay entries across stop/start cycles. Tear the base view
+		// down through its normal path so a later UI restart cannot re-enter the
+		// alternate screen with an orphaned fullscreen surface.
+		this.setFullscreenTui(false);
 		for (const unsubscribe of this.#eventBusUnsubscribers) {
 			unsubscribe();
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -161,6 +161,7 @@ import { CustomEditor } from "./components/custom-editor";
 import { DynamicBorder } from "./components/dynamic-border";
 import { ErrorBannerComponent } from "./components/error-banner";
 import type { EvalExecutionComponent } from "./components/eval-execution";
+import { FullscreenChatView } from "./components/fullscreen-chat-view";
 import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent, HookSelectorSlider } from "./components/hook-selector";
@@ -668,6 +669,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	#planReviewAnnotationState = new Map<string, PlanReviewAnnotationState>();
 	/** Annotation state held until the associated queued refinement actually starts. */
 	#planReviewAnnotationStateBySubmission = new WeakMap<SubmittedUserInput, string>();
+	#fullscreenChatView: FullscreenChatView | undefined;
+	#fullscreenChatOverlay: OverlayHandle | undefined;
+	#fullscreenChatInputUnsubscribe: (() => void) | undefined;
 	readonly lspServers: LspStartupServerInfo[] | undefined = undefined;
 	mcpManager?: MCPManager;
 	readonly #toolUiContextSetter: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
@@ -1113,6 +1117,12 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Start the UI. Cold `omp` launch opts into clearing on the first paint so
 		// the initial welcome frame does not append over the previous run's scrollback.
+		// Start listeners run before TUI's first paint. Enter the alternate screen
+		// there so resuming a long session never replays its transcript into the
+		// normal Windows console buffer before fullscreen takes over.
+		this.ui.addStartListener(() => {
+			if (this.settings.get("tui.fullscreen")) this.setFullscreenTui(true);
+		});
 		this.ui.start({ clearScrollback: options.clearInitialTerminalHistory === true });
 		pushTerminalTitle();
 		setTerminalTitleStateEnabled(this.settings.get("tui.titleState"));
@@ -4173,6 +4183,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.#extensionUiController.clearHookWidgets();
+		this.#fullscreenChatInputUnsubscribe?.();
+		this.#fullscreenChatInputUnsubscribe = undefined;
+		this.#fullscreenChatOverlay = undefined;
+		this.#fullscreenChatView = undefined;
 		for (const unsubscribe of this.#eventBusUnsubscribers) {
 			unsubscribe();
 		}
@@ -4292,7 +4306,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			: new CustomEditor(getEditorTheme());
 		if (!factory) this.ui.enableScopedInputRender(nextEditor);
 
-		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
+		nextEditor.setUseTerminalCursor(this.#fullscreenChatOverlay ? false : this.ui.getShowHardwareCursor());
 		nextEditor.setImeSafeCursorLayout(this.settings.get("tui.imeSafeCursor"));
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
 		nextEditor.onAutocompleteCancel = () => {
@@ -4323,6 +4337,51 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		this.updateEditorBorderColor();
 		this.ui.requestRender();
+	}
+
+	/** Enable or disable the persistent alternate-screen chat layout. */
+	setFullscreenTui(enabled: boolean): void {
+		if (enabled) {
+			if (this.#fullscreenChatOverlay) return;
+			const dockStart = this.ui.children.indexOf(this.pendingMessagesContainer);
+			if (dockStart === -1) return;
+			this.#fullscreenChatView = new FullscreenChatView(
+				this.ui.children.slice(0, dockStart),
+				this.ui.children.slice(dockStart),
+				this.editorContainer,
+				() => this.ui.terminal.rows,
+			);
+			this.#fullscreenChatInputUnsubscribe = this.ui.addInputListener(data => {
+				const focused = this.ui.getFocused();
+				if (!focused || !this.editorContainer.children.includes(focused)) return undefined;
+				if (!this.#fullscreenChatView?.handleViewportInput(data)) return undefined;
+				this.ui.requestRender();
+				return { consume: true };
+			});
+			this.editor.setUseTerminalCursor(false);
+			this.#fullscreenChatOverlay = this.ui.showOverlay(this.#fullscreenChatView, {
+				width: "100%",
+				maxHeight: "100%",
+				anchor: "top-left",
+				margin: 0,
+				fullscreen: true,
+				mouseTracking: true,
+				base: true,
+			});
+			this.ui.setFocus(this.editorContainer.children[0] ?? this.editor);
+			this.ui.requestRender(true);
+			return;
+		}
+
+		if (!this.#fullscreenChatOverlay) return;
+		this.#fullscreenChatInputUnsubscribe?.();
+		this.#fullscreenChatInputUnsubscribe = undefined;
+		this.#fullscreenChatOverlay.hide();
+		this.#fullscreenChatOverlay = undefined;
+		this.#fullscreenChatView = undefined;
+		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
+		this.ui.setFocus(this.editorContainer.children[0] ?? this.editor);
+		this.ui.requestRender(true);
 	}
 
 	// UI helpers

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -242,6 +242,8 @@ export interface InteractiveModeContext {
 	setEditorComponent(
 		factory: ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => CustomEditor) | undefined,
 	): void;
+	/** Toggle the persistent alternate-screen chat layout. */
+	setFullscreenTui(enabled: boolean): void;
 
 	// UI helpers
 	/**

--- a/packages/coding-agent/test/cli-tui-mode-flag.test.ts
+++ b/packages/coding-agent/test/cli-tui-mode-flag.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { CliUsageError } from "@oh-my-pi/pi-coding-agent/cli/usage-error";
+
+describe("--tui-mode", () => {
+	it.each(["regular", "fullscreen"] as const)("parses %s", mode => {
+		expect(parseArgs(["--tui-mode", mode]).tuiMode).toBe(mode);
+		expect(parseArgs([`--tui-mode=${mode}`]).tuiMode).toBe(mode);
+	});
+
+	it("rejects a missing or invalid mode", () => {
+		expect(() => parseArgs(["--tui-mode"])).toThrow("--tui-mode requires regular or fullscreen");
+		expect(() => parseArgs(["--tui-mode", "windowed"])).toThrow(CliUsageError);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-fullscreen-stop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-fullscreen-stop.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TUI } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+describe("InteractiveMode fullscreen teardown", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+	let terminal: VirtualTerminal;
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@omp-fullscreen-stop-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		terminal = new VirtualTerminal(80, 24);
+		mode.ui = new TUI(terminal);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		await mode.init({ suppressWelcomeIntro: true });
+		await terminal.waitForRender();
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("does not restore a fullscreen surface after the mode stops", async () => {
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation(data => {
+			writes.push(data);
+			write(data);
+		});
+
+		mode.setFullscreenTui(true);
+		await terminal.waitForRender();
+		expect(writes.join("")).toContain("\x1b[?1049h");
+
+		mode.stop();
+		writes.length = 0;
+		mode.ui.start();
+		await terminal.waitForRender();
+
+		expect(writes.join("")).not.toContain("\x1b[?1049h");
+		mode.ui.stop();
+	});
+});

--- a/packages/coding-agent/test/modes/components/fullscreen-chat-view.test.ts
+++ b/packages/coding-agent/test/modes/components/fullscreen-chat-view.test.ts
@@ -63,4 +63,18 @@ describe("FullscreenChatView", () => {
 		const rendered = view.render(12);
 		expect(rendered.slice(0, 4).some(line => line.includes("…"))).toBe(false);
 	});
+
+	it("consumes mouse releases that do not end a scrollbar drag", () => {
+		const transcript = new LinesComponent(["message"]);
+		const editor = new LinesComponent(["editor"]);
+		const editorContainer = new Container();
+		editorContainer.addChild(editor);
+		const view = new FullscreenChatView([transcript], [editorContainer], editorContainer, () => 6);
+
+		view.render(12);
+		// A press away from the scrollbar is ignored by navigation but remains
+		// consumed. Its matching release must not leak an SGR sequence to the editor.
+		expect(view.handleViewportInput("\x1b[<0;1;1M")).toBe(true);
+		expect(view.handleViewportInput("\x1b[<0;1;1m")).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/modes/components/fullscreen-chat-view.test.ts
+++ b/packages/coding-agent/test/modes/components/fullscreen-chat-view.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { FullscreenChatView } from "@oh-my-pi/pi-coding-agent/modes/components/fullscreen-chat-view";
+import { type Component, Container } from "@oh-my-pi/pi-tui";
+
+class LinesComponent implements Component {
+	constructor(private readonly lines: readonly string[]) {}
+
+	render(): readonly string[] {
+		return this.lines;
+	}
+}
+
+class WrappingComponent implements Component {
+	constructor(private readonly text: string) {}
+
+	render(width: number): readonly string[] {
+		const lineWidth = Math.max(1, width);
+		const lines: string[] = [];
+		for (let index = 0; index < this.text.length; index += lineWidth) {
+			lines.push(this.text.slice(index, index + lineWidth));
+		}
+		return lines;
+	}
+}
+
+describe("FullscreenChatView", () => {
+	it("keeps the editor dock visible while history scrolls independently", () => {
+		const transcript = new LinesComponent(Array.from({ length: 10 }, (_, index) => `message-${index + 1}`));
+		const status = new LinesComponent(["status"]);
+		const editor = new LinesComponent(["editor"]);
+		const editorContainer = new Container();
+		editorContainer.addChild(editor);
+		const view = new FullscreenChatView([transcript], [status, editorContainer], editorContainer, () => 6);
+
+		const initial = view.render(12);
+		expect(initial[0]).toContain("message-7");
+		expect(initial.slice(-2)).toEqual(["status", "editor"]);
+		expect(view.ownsOverlayFocusTarget(editor)).toBe(true);
+		expect(view.ownsOverlayFocusTarget(transcript)).toBe(false);
+		expect(view.handleViewportInput("\x1b[A")).toBe(false);
+
+		expect(view.handleViewportInput("\x1b[5~")).toBe(true);
+		const pageUp = view.render(12);
+		expect(pageUp[0]).toContain("message-4");
+		expect(pageUp.slice(-2)).toEqual(["status", "editor"]);
+
+		// Click the top of the scrollbar. The visible transcript jumps back to
+		// the beginning while the fixed dock remains in place.
+		expect(view.handleViewportInput("\x1b[<0;12;1M")).toBe(true);
+		const top = view.render(12);
+		expect(top[0]).toContain("message-1");
+		expect(top.slice(-2)).toEqual(["status", "editor"]);
+	});
+
+	it("reflows transcript lines before reserving space for the scrollbar", () => {
+		const transcript = new WrappingComponent("abcdefghijklmnopqrstuvwxyz0123456789".repeat(2));
+		const status = new LinesComponent(["status"]);
+		const editor = new LinesComponent(["editor"]);
+		const editorContainer = new Container();
+		editorContainer.addChild(editor);
+		const view = new FullscreenChatView([transcript], [status, editorContainer], editorContainer, () => 6);
+
+		const rendered = view.render(12);
+		expect(rendered.slice(0, 4).some(line => line.includes("…"))).toBe(false);
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -37,6 +37,9 @@
 
 - Fixed an issue where repeated pane-width adjustments or terminal resizing could corrupt native scrollback and soft-wrap behavior.
 - Fixed an issue where scaled OSC 66 Markdown headings (such as "Large Headings" on Kitty) would render as invisible placeholders or get partially cleared after a redraw or terminal resize.
+### Added
+
+- Added base fullscreen overlays, which keep an alternate-screen application surface below ordinary dialogs and menus without stealing their focus.
 
 ## [17.2.13] - 2026-08-11
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -514,6 +514,12 @@ export interface OverlayOptions {
 	 */
 	fullscreen?: boolean;
 	/**
+	 * Keep this overlay below ordinary dialogs and menus. Used by persistent
+	 * application surfaces that own the alternate screen without behaving like a
+	 * modal; normal overlays continue to receive focus and input above it.
+	 */
+	base?: boolean;
+	/**
 	 * Enable terminal mouse reporting while fullscreen. Defaults on; disable it
 	 * when native terminal text selection takes precedence over pointer events.
 	 */
@@ -1989,9 +1995,10 @@ export class TUI extends Container {
 	showOverlay(component: Component, options?: OverlayOptions): OverlayHandle {
 		component.setIgnoreTight?.(true);
 		const entry = { component, options, preFocus: this.#focusedComponent, hidden: false };
-		this.overlayStack.push(entry);
+		if (options?.base) this.overlayStack.unshift(entry);
+		else this.overlayStack.push(entry);
 		// Only focus if overlay is actually visible
-		if (this.#isOverlayVisible(entry)) {
+		if (this.#isOverlayVisible(entry) && this.#getTopmostVisibleOverlay() === entry) {
 			this.setFocus(component);
 		}
 		this.terminal.hideCursor();
@@ -2006,8 +2013,7 @@ export class TUI extends Container {
 					this.overlayStack.splice(index, 1);
 					// Restore focus if this overlay or one of its owned targets had focus
 					if (isOverlayFocusTarget(component, this.#focusedComponent)) {
-						const topVisible = this.#getTopmostVisibleOverlay();
-						this.setFocus(topVisible?.component ?? entry.preFocus);
+						this.#restoreOverlayFocus(entry);
 					}
 					if (this.overlayStack.length === 0) {
 						this.terminal.hideCursor();
@@ -2023,8 +2029,7 @@ export class TUI extends Container {
 				if (hidden) {
 					// If this overlay or one of its owned targets had focus, move focus to next visible or preFocus
 					if (isOverlayFocusTarget(component, this.#focusedComponent)) {
-						const topVisible = this.#getTopmostVisibleOverlay();
-						this.setFocus(topVisible?.component ?? entry.preFocus);
+						this.#restoreOverlayFocus(entry);
 					}
 				} else {
 					// Restore focus to this overlay when showing (if it's actually visible)
@@ -2043,8 +2048,7 @@ export class TUI extends Container {
 		const overlay = this.overlayStack.pop();
 		if (!overlay) return;
 		// Find topmost visible overlay, or fall back to preFocus
-		const topVisible = this.#getTopmostVisibleOverlay();
-		this.setFocus(topVisible?.component ?? overlay.preFocus);
+		this.#restoreOverlayFocus(overlay);
 		if (this.overlayStack.length === 0) {
 			this.terminal.hideCursor();
 			this.#recordHardwareCursorHidden();
@@ -2054,7 +2058,7 @@ export class TUI extends Container {
 
 	/** Check if there are any visible overlays */
 	hasOverlay(): boolean {
-		return this.overlayStack.some(o => this.#isOverlayVisible(o));
+		return this.overlayStack.some(o => this.#isOverlayVisible(o) && o.options?.base !== true);
 	}
 
 	/** Check if an overlay entry is currently visible */
@@ -2074,6 +2078,16 @@ export class TUI extends Container {
 			}
 		}
 		return undefined;
+	}
+
+	/** Restore focus after a modal leaves without stealing an owned base surface's editor. */
+	#restoreOverlayFocus(entry: (typeof this.overlayStack)[number]): void {
+		const topVisible = this.#getTopmostVisibleOverlay();
+		if (topVisible?.options?.base && isOverlayFocusTarget(topVisible.component, entry.preFocus)) {
+			this.setFocus(entry.preFocus);
+			return;
+		}
+		this.setFocus(topVisible?.component ?? entry.preFocus);
 	}
 
 	override invalidate(): void {
@@ -2963,13 +2977,7 @@ export class TUI extends Container {
 		const focusedOverlay = this.overlayStack.find(o => o.component === this.#focusedComponent);
 		if (focusedOverlay && !this.#isOverlayVisible(focusedOverlay)) {
 			// Focused overlay is no longer visible, redirect to topmost visible overlay
-			const topVisible = this.#getTopmostVisibleOverlay();
-			if (topVisible) {
-				this.setFocus(topVisible.component);
-			} else {
-				// No visible overlays, restore to preFocus
-				this.setFocus(focusedOverlay.preFocus);
-			}
+			this.#restoreOverlayFocus(focusedOverlay);
 		}
 
 		// Pass input to focused component (including Ctrl+C).
@@ -3376,9 +3384,11 @@ export class TUI extends Container {
 		// requests it, borrow the terminal's alternate buffer and paint only the
 		// modal there; the normal screen and all accounting stay untouched.
 		let deferredAltExit = this.#pendingAltExit;
-		const topOverlay = this.#getTopmostVisibleOverlay();
-		const wantAlt = topOverlay?.options?.fullscreen === true;
-		const wantMouseTracking = wantAlt && topOverlay.options?.mouseTracking !== false;
+		const fullscreenOverlay = [...this.overlayStack]
+			.reverse()
+			.find(entry => this.#isOverlayVisible(entry) && entry.options?.fullscreen === true);
+		const wantAlt = fullscreenOverlay !== undefined;
+		const wantMouseTracking = wantAlt && fullscreenOverlay.options?.mouseTracking !== false;
 		if (wantAlt && !this.#altActive) {
 			// Enhanced keyboard modes can be buffer-local: re-push the active
 			// modified-key reporting sequence on the freshly entered alternate

--- a/packages/tui/test/overlay-focus.test.ts
+++ b/packages/tui/test/overlay-focus.test.ts
@@ -96,6 +96,42 @@ class OwningOverlay extends FocusRecorder implements OverlayFocusOwner {
 }
 
 describe("TUI overlay focus", () => {
+	it("keeps a fullscreen base surface behind ordinary overlays", () => {
+		const terminal = new MinimalTerminal();
+		const tui = new TUI(terminal);
+		const editor = new FocusRecorder("editor");
+		const fullscreenSurface = new OwningOverlay("fullscreen-surface");
+		const dialog = new FocusRecorder("dialog");
+
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			fullscreenSurface.focusTarget = editor;
+			const surfaceHandle = tui.showOverlay(fullscreenSurface, { fullscreen: true, base: true });
+			tui.setFocus(editor);
+
+			expect(tui.getFocused()).toBe(editor);
+			expect(tui.hasOverlay()).toBe(false);
+			terminal.sendInput("draft");
+			expect(editor.inputs).toEqual(["draft"]);
+
+			const dialogHandle = tui.showOverlay(dialog);
+			expect(tui.getFocused()).toBe(dialog);
+			expect(tui.hasOverlay()).toBe(true);
+			terminal.sendInput("confirm");
+			expect(dialog.inputs).toEqual(["confirm"]);
+
+			dialogHandle.hide();
+			expect(tui.getFocused()).toBe(editor);
+			expect(tui.hasOverlay()).toBe(false);
+			surfaceHandle.hide();
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("keeps keyboard focus on the visible overlay when a hidden surface requests focus", () => {
 		const terminal = new MinimalTerminal();
 		const tui = new TUI(terminal);

--- a/packages/tui/test/start-listener.test.ts
+++ b/packages/tui/test/start-listener.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
-import { TUI } from "@oh-my-pi/pi-tui";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
 import { VirtualTerminal } from "./virtual-terminal";
+
+class RenderProbe implements Component {
+	constructor(private readonly events: string[]) {}
+
+	render(): string[] {
+		this.events.push("render");
+		return [];
+	}
+}
 
 describe("TUI start listeners", () => {
 	it("fires registered hooks on initial start and restart", () => {
@@ -17,6 +26,24 @@ describe("TUI start listeners", () => {
 			tui.stop();
 			tui.start();
 			expect(starts).toBe(2);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("runs start hooks before the initial render", async () => {
+		const events: string[] = [];
+		const tui = new TUI(new VirtualTerminal(80, 24));
+		tui.addChild(new RenderProbe(events));
+		tui.addStartListener(() => {
+			events.push("start");
+		});
+
+		try {
+			tui.start();
+			await Bun.sleep(50);
+			expect(events[0]).toBe("start");
+			expect(events).toContain("render");
 		} finally {
 			tui.stop();
 		}

--- a/packages/tui/test/start-listener.test.ts
+++ b/packages/tui/test/start-listener.test.ts
@@ -33,7 +33,8 @@ describe("TUI start listeners", () => {
 
 	it("runs start hooks before the initial render", async () => {
 		const events: string[] = [];
-		const tui = new TUI(new VirtualTerminal(80, 24));
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
 		tui.addChild(new RenderProbe(events));
 		tui.addStartListener(() => {
 			events.push("start");
@@ -41,7 +42,7 @@ describe("TUI start listeners", () => {
 
 		try {
 			tui.start();
-			await Bun.sleep(50);
+			await terminal.waitForRender(() => events.includes("render"));
 			expect(events[0]).toBe("start");
 			expect(events).toContain("render");
 		} finally {


### PR DESCRIPTION
## Summary
- adds a persistent alternate-screen conversation view with an independently scrollable transcript, scrollbar, and fixed editor/status dock
- adds the `tui.fullscreen` setting and `--tui-mode=fullscreen` one-run override
- enters the alternate screen before the first TUI paint so resuming a long conversation does not replay it into the Windows console scrollback
- keeps modal focus restoration and terminal mouse interaction working above the fullscreen base view

## Verification
- focused TUI tests: 12 passed
- TypeScript checks passed in `packages/coding-agent` and `packages/tui`
- Biome check passed for changed sources
- attempted the full TypeScript CI suite locally; its Windows run also hits existing Unix-only commands, POSIX-path expectations, and file-lock cleanup failures outside this change. GitHub CI is the authoritative cross-platform result.