### PR TITLE
fix(catalog): opencode-go muse-spark-1.2-contributor → openai-responses

### DIFF
--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -77448,6 +77448,36 @@
 				]
 			}
 		},
+		"muse-spark-1.2-contributor": {
+			"id": "muse-spark-1.2-contributor",
+			"name": "Muse Spark 1.2 Contributor",
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5713,6 +5713,10 @@ const OPENCODE_ZEN_API_RESOLUTION = createOpenCodeApiResolution("https://opencod
 // 2026-08-08; Flash only — deepseek-v4-pro serves fine on chat completions).
 const OPENCODE_GO_API_RESOLUTION = createOpenCodeApiResolution("https://opencode.ai/zen/go", {
 	"deepseek-v4-flash": "openai-responses",
+	// muse-spark-1.2-contributor is served only at /zen/go/v1/responses — the
+	// /zen/go/v1/chat/completions route does not exist for it (endpoint table:
+	// https://opencode.ai/docs/go/#endpoints, issue #8963).
+	"muse-spark-1.2-contributor": "openai-responses",
 	"minimax-m2.7": "openai-completions",
 	"minimax-m3": "openai-completions",
 	"minimax-m3-free": "openai-completions",

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -54,6 +54,17 @@ describe("OpenCode provider discovery", () => {
 		});
 	});
 
+	test("routes opencode-go muse-spark-1.2-contributor to the responses API", () => {
+		const descriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "opencode-go");
+		// The OpenCode Go gateway serves muse-spark-1.2-contributor only at
+		// /zen/go/v1/responses (https://opencode.ai/docs/go/#endpoints); the
+		// /zen/go/v1/chat/completions route it previously resolved to fails.
+		expect(descriptor?.resolveApi?.("muse-spark-1.2-contributor", { tool_call: true })).toEqual({
+			api: "openai-responses",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+	});
+
 	test("replaces stale bundled Zen models with each credential's live endpoint list", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-zen-"));
 		try {


### PR DESCRIPTION
Fixes #8963

## Problem

The OpenCode Go gateway serves `muse-spark-1.2-contributor` only via the Responses API at `https://opencode.ai/zen/go/v1/responses` (see the endpoints table at https://opencode.ai/docs/go/#endpoints), but the bundled catalog resolved it to `api: "openai-completions"`, so requests went to `/v1/chat/completions` and failed.

## Change

- `packages/catalog/src/provider-models/openai-compat.ts`: added a per-id override in `OPENCODE_GO_API_RESOLUTION` mapping `muse-spark-1.2-contributor` to `openai-responses` (resolver source; `models.json` is generated, never hand-edited).
- `packages/catalog/src/models.json`: regenerated via `bun run gen:models`. The generated file also contained unrelated live-catalog data drift for other providers (pricing/name churn from models.dev); only the opencode-go change from the regen is included here to keep this PR scoped. The opencode-go `muse-spark-1.2-contributor` entry now carries `api: "openai-responses"` / `baseUrl: "https://opencode.ai/zen/go/v1"`.
- `packages/catalog/test/opencode-provider.test.ts`: added a regression test asserting that resolving `muse-spark-1.2-contributor` for the `opencode-go` descriptor yields `{ api: "openai-responses", baseUrl: "https://opencode.ai/zen/go/v1" }`, matching the existing `deepseek-v4-flash` test style.

## Verification

- `bun test packages/catalog/test/opencode-provider.test.ts` → 4 pass, 0 fail (includes the new test).
- `bun run gen:models` succeeded; `models.json` was updated for the opencode-go entry and is included in this commit.
