### PR TITLE
marketplace 插件自动安装依赖

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -304,6 +304,7 @@ export class MarketplaceManager {
 		try {
 			version = await this.#resolvePluginVersion(pluginEntry, sourcePath);
 			cachePath = await cachePlugin(sourcePath, this.#opts.pluginsCacheDir, marketplace, name, version);
+			await this.#installPluginDependencies(cachePath);
 			await this.#writeEmbeddedLspConfig(pluginEntry, cachePath);
 			await this.#writeEmbeddedDapConfig(pluginEntry, cachePath);
 		} finally {
@@ -790,6 +791,43 @@ export class MarketplaceManager {
 
 	async #writeRuntimeConfig(scope: "user" | "project", config: PluginRuntimeConfig): Promise<void> {
 		await Bun.write(this.#runtimeLockPath(scope), JSON.stringify(config, null, 2));
+	}
+
+	async #installPluginDependencies(cachePath: string): Promise<void> {
+		try {
+			const pkgFile = Bun.file(path.join(cachePath, "package.json"));
+			if (!(await pkgFile.exists())) return;
+			const pkg = (await pkgFile.json()) as Record<string, unknown>;
+			const deps = pkg["dependencies"];
+			const hasDeps =
+				deps !== null && typeof deps === "object" && Object.keys(deps as Record<string, unknown>).length > 0;
+			if (!hasDeps) return;
+			const proc = Bun.spawn(["bun", "install", "--ignore-scripts"], {
+				cwd: cachePath,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			if (exitCode !== 0) {
+				logger.warn("Failed to install marketplace plugin dependencies", {
+					cachePath,
+					exitCode,
+					stdout,
+					stderr,
+				});
+			} else {
+				logger.debug("Installed marketplace plugin dependencies", { cachePath });
+			}
+		} catch (err) {
+			logger.warn("Failed to install marketplace plugin dependencies", {
+				cachePath,
+				error: String(err),
+			});
+		}
 	}
 
 	async #resolvePluginPackageName(installPath: string, fallbackName: string): Promise<string> {


### PR DESCRIPTION
## 概述

marketplace 方式安装的插件仅 `cachePlugin` + `symlink`，未执行 `bun install`，导致声明了 `dependencies` 的插件（如 `fff@omp-extensions` 依赖 `@ff-labs/fff-bun` / `fff-node` / `@sinclair/typebox`）在全新安装后因 `node_modules` 缺失而无法加载：

```
FFF init failed: Cannot find module '@ff-labs/fff-bun'
```

## 变更

- `MarketplaceManager` 在 `cachePlugin()` 后新增 `#installPluginDependencies(cachePath)`：检测 `package.json#dependencies` 非空则在 `cachePath` 执行 `bun install --ignore-scripts`，失败仅 `logger.warn` 不阻断安装（离线场景由插件侧自愈兜底）。
- 配合 `omp-extensions#66`（`fff` SDK 自愈：在 `import('@ff-labs/fff-bun')` 失败时自动 `bun install` 并重试）实现双层保障：新版 OMP 直接装好依赖，旧版 OMP 也能在首次加载时自愈。

## 验证

- 全新安装场景：删除 `~/.omp/plugins/cache/plugins/omp-extensions___fff___0.1.1/node_modules` 后启动 OMP，SDK 自动重建依赖，`fffind`/`ffgrep` 可用。
- `omp plugin discover` 正确显示 `fff@0.1.1`，`omp plugin upgrade` 写入新缓存并自动安装。

