### PR TITLE
fix(sdk): refresh discoverable providers for deferred role aliases

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,6 +46,7 @@
 - The exit banner only advertises `omp --resume <id>` when the session was actually written to disk, so the printed command no longer fails for sessions that ended before persistence ([#8860](https://github.com/can1357/oh-my-pi/issues/8860)).
 - Fixed terminals that deliver Shift+Enter as a bare LF (or the legacy CSI `13;2~` form) getting a plain switch instead of summarize-and-switch in the `/tree` selector ([#8821](https://github.com/can1357/oh-my-pi/issues/8821)).
 - Fixed OMP panicking at startup when the host environment contains a non-UTF-8 variable value; such entries are now skipped when copying the host environment into the shell ([#8925](https://github.com/can1357/oh-my-pi/issues/8925)).
+- Fixed `--model @<role>` failing with `Model "@<role>" not found` when the role maps to a model on a discovery-backed provider (oMLX, Ollama, llama-swap). Deferred resolution treated a role's expanded `configuredPatterns` as a resolved runtime match, skipping the discoverable-provider refresh so the model was never fetched; only a concretely resolved model now short-circuits that refresh ([#8863](https://github.com/can1357/oh-my-pi/issues/8863)).
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2137,9 +2137,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						settings,
 						preferences: matchPreferences,
 					});
-					return Boolean(
-						resolved.model || (resolved.configuredPatterns && resolved.configuredPatterns.length > 0),
-					);
+					// Only a concretely resolved model counts as a runtime match. A role
+					// alias that expanded to `configuredPatterns` but resolved no model
+					// (its discoverable provider hasn't been fetched yet) must NOT
+					// short-circuit the fallback refresh below — otherwise `@role`
+					// selectors pointing at discovery-backed models never trigger the
+					// fetch and fail with `Model "@role" not found`.
+					return Boolean(resolved.model);
 				}),
 			);
 			if (!runtimeResolved && modelRegistry.getDiscoverableProviders().length > 0) {

--- a/packages/coding-agent/test/sdk-deferred-role-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-deferred-role-discovery.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+// Regression for #8863: a deferred `--model @<role>` whose role maps to a model
+// on a discovery-backed provider (ollama/oMLX/llama-swap) must trigger the
+// online-if-uncached discovery refresh. Before the fix the deferred guard in
+// sdk.ts treated the role's expanded `configuredPatterns` as a resolved runtime
+// match, so `runtimeResolved` was `true`, the fallback refresh was skipped, and
+// resolution failed with `Model "@<role>" not found`.
+describe("createAgentSession deferred role alias on discoverable provider (#8863)", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+	const savedOllamaEnv: Record<string, string | undefined> = {};
+
+	beforeEach(async () => {
+		for (const key of ["OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_CONTEXT_LENGTH"] as const) {
+			savedOllamaEnv[key] = Bun.env[key];
+			delete Bun.env[key];
+		}
+		tempDir = path.join(os.tmpdir(), `pi-test-sdk-deferred-role-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		for (const key of ["OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_CONTEXT_LENGTH"] as const) {
+			const original = savedOllamaEnv[key];
+			if (original === undefined) delete Bun.env[key];
+			else Bun.env[key] = original;
+		}
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) removeSyncWithRetries(tempDir);
+	});
+
+	const mockOllamaDiscovery = (modelNames: string[], endpoint = "http://127.0.0.1:11434"): FetchImpl => {
+		return async input => {
+			const url = String(input);
+			if (url === `${endpoint}/api/tags`) {
+				return new Response(JSON.stringify({ models: modelNames.map(name => ({ name })) }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === `${endpoint}/api/show`) {
+				return new Response(JSON.stringify({ capabilities: ["completion"] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+	};
+
+	it("refreshes discoverable providers so @smol resolves to the discovered model", async () => {
+		fs.writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					ollama: {
+						baseUrl: "http://127.0.0.1:11434/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "ollama" },
+					},
+				},
+			}),
+		);
+		// Fresh registry with no discovery cache: the ollama model is only
+		// reachable through a refresh, which the deferred path must perform.
+		const modelRegistry = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: mockOllamaDiscovery(["phi3"]),
+		});
+		const settings = Settings.isolated({
+			modelRoles: { smol: "ollama/phi3" },
+			"compaction.enabled": false,
+		});
+
+		let session: AgentSession | undefined;
+		try {
+			const result = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				sessionManager: SessionManager.inMemory(tempDir),
+				authStorage,
+				modelRegistry,
+				settings,
+				modelPattern: "@smol",
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				taskDepth: 1,
+				agentId: "SubAgent",
+			});
+			session = result.session;
+
+			expect(result.session.model?.provider).toBe("ollama");
+			expect(result.session.model?.id).toBe("phi3");
+		} finally {
+			session?.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With a discovery-backed provider configured in `models.yml` (`discovery:` — oMLX, Ollama, llama-swap) and a role mapping to one of its models (e.g. `modelRoles.smol = ollama/phi3`), starting with `--model @smol` before discovery has populated fails: resolution reports `Model "@smol" not found`. Reproduced via `bun test test/sdk-deferred-role-discovery.test.ts` — `createAgentSession({ modelPattern: "@smol" })` against a fresh (uncached) registry left `session.model` undefined.

## Cause
In `packages/coding-agent/src/sdk.ts`, the deferred-pattern guard computed `runtimeResolved` as `Boolean(resolved.model || configuredPatterns.length > 0)`. When a role alias is evaluated before its discoverable provider has been fetched, `resolveCliModel` (`config/model-resolver.ts:1911-1921`) returns `model: undefined` but a non-empty `configuredPatterns` (the role's expansion) plus a not-found error. The non-empty `configuredPatterns` made `runtimeResolved` true, so the `!runtimeResolved && getDiscoverableProviders().length > 0` fallback `modelRegistry.refresh("online-if-uncached")` was skipped. The discoverable model was never fetched and `expandedModelPatterns` then failed to resolve.

## Fix
- `sdk.ts`: `runtimeResolved` now keys off `Boolean(resolved.model)` only — a role that expanded to `configuredPatterns` but resolved no concrete model no longer short-circuits the discovery refresh.
- Added `test/sdk-deferred-role-discovery.test.ts`: integration regression driving `createAgentSession({ modelPattern: "@smol" })` against an uncached ollama discovery provider; asserts `session.model` resolves to `ollama/phi3`. Fails (model undefined) on the pre-fix condition.
- CHANGELOG entry under `[Unreleased]` → Fixed.

## Verification
`bun test test/sdk-deferred-role-discovery.test.ts test/model-resolver.test.ts` → 159 pass, 0 fail. Confirmed the new test fails on the old `configuredPatterns`-based condition and passes after the fix.

Fixes #8863