### PR TITLE
fix(tui): honor tui.input.submit remap onto ctrl+enter

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed images rendering as the `[Image: …]` text card on SIXEL terminals that expose no identifying environment variable (foot, xterm, contour): the graphics probe no longer requires Windows Terminal, and no longer reads an XTSMGRAPHICS success reply as a failure.
+- Fixed the multiline editor ignoring a `tui.input.submit` remap onto Ctrl+Enter: the hardcoded Ctrl/Shift+Enter → newline fallbacks now yield to an explicit submit binding, so Ctrl+Enter can be used to submit ([#8906](https://github.com/can1357/oh-my-pi/issues/8906)).
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1458,14 +1458,19 @@ export class Editor implements Component, Focusable {
 				this.#addNewLine();
 			}
 		}
-		// New line
+		// New line. A key the user explicitly bound to `tui.input.submit` wins
+		// over these hardcoded newline fallbacks, so Ctrl/Shift+Enter can be
+		// remapped to submit (#8906). The bare-LF case is exempt: its canonical
+		// form is "enter" (indistinguishable from plain Enter), so gating it
+		// would hijack the default Enter=submit binding.
 		else if (
-			(data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
-			matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
-			data === "\x1b\r" || // Option+Enter in some terminals (legacy)
-			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
-			kb.matchesCanonical(canonical, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
-			(data.length > 1 && data.includes("\x1b") && data.includes("\r")) ||
+			(!kb.matchesCanonical(canonical, "tui.input.submit") &&
+				((data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
+					matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
+					data === "\x1b\r" || // Option+Enter in some terminals (legacy)
+					data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
+					kb.matchesCanonical(canonical, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
+					(data.length > 1 && data.includes("\x1b") && data.includes("\r")))) ||
 			(data === "\n" && data.length === 1) // Shift+Enter from iTerm2 mapping
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -164,6 +164,38 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("Submit/newline keybindings", () => {
+		it("submits on Ctrl+Enter when tui.input.submit is remapped to it (#8906)", () => {
+			setKeybindings(
+				new KeybindingsManager(TUI_KEYBINDINGS, {
+					"tui.input.submit": "ctrl+enter",
+					"tui.input.newLine": "enter",
+				}),
+			);
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("hello");
+			let submitted: string | undefined;
+			editor.onSubmit = text => {
+				submitted = text;
+			};
+			editor.handleInput("\x1b[13;5u"); // kitty CSI-u Ctrl+Enter
+			expect(submitted).toBe("hello");
+			expect(editor.getText()).toBe("");
+		});
+
+		it("still inserts a newline on Ctrl+Enter under the default bindings", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("hello");
+			let submitted: string | undefined;
+			editor.onSubmit = text => {
+				submitted = text;
+			};
+			editor.handleInput("\x1b[13;5u"); // kitty CSI-u Ctrl+Enter
+			expect(submitted).toBeUndefined();
+			expect(editor.getText()).toBe("hello\n");
+		});
+	});
+
 	describe("Prompt history navigation", () => {
 		it("does nothing on Up arrow when history is empty", () => {
 			const editor = new Editor(defaultEditorTheme);


### PR DESCRIPTION
## Repro
With `tui.input.submit` remapped to `ctrl+enter` in the keybindings config (and `ctrl+enter` removed from `app.message.followUp`), pressing Ctrl+Enter in the composer inserts a newline instead of submitting. Reproduced by constructing the base `Editor` with a `KeybindingsManager` that binds `tui.input.submit=ctrl+enter` / `tui.input.newLine=enter`, feeding the kitty CSI-u Ctrl+Enter sequence `\x1b[13;5u`, and observing `onSubmit` never fires while the draft becomes `"hello\n"`.

## Cause
`packages/tui/src/components/editor.ts` (`#handleInputChunk`) evaluates a hardcoded Ctrl/Shift+Enter → newline branch (`matchesKey(data, "ctrl+enter")` and the modifier-tagged-LF checks) *before* the config-driven `tui.input.submit` branch. In the default config Ctrl+Enter is intercepted upstream as the `app.message.followUp` chord (`input-controller.ts` custom key handler), so the newline branch is only reached once the user removes Ctrl+Enter from follow-up — and then it swallows the key before the submit lookup runs, ignoring the remap.

## Fix
- Gate the hardcoded newline fallbacks (Ctrl+Enter, legacy Option/Shift+Enter escape sequences, `tui.input.newLine` config, mixed ESC+CR) behind `!kb.matchesCanonical(canonical, "tui.input.submit")`, so a key the user explicitly bound to submit falls through to the submit branch.
- Keep the bare-LF case (`data === "\n"`, iTerm2 Shift+Enter) exempt from the gate: its canonical form is `"enter"`, indistinguishable from plain Enter, so gating it would hijack the default Enter=submit binding.
- Add regression tests in `packages/tui/test/editor.test.ts`: Ctrl+Enter submits when remapped, and still inserts a newline under the default bindings.

## Verification
`cd packages/tui && bun test test/editor.test.ts` → 166 pass / 0 fail (includes the 2 new tests); `bun test test/keybindings.test.ts` → 6 pass. Manually verified the fix preserves default Ctrl+Enter→newline, plain Enter→submit, kitty Shift+Enter→newline, and bare-LF→newline. Fixes #8906