### PR TITLE
fix(catalog): route opencode-go muse-spark to responses api

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed SuperGrok (`xai-oauth`) Grok 4.6 hiding the thinking-level picker: the Responses effort-capable allowlist now includes `grok-4.6`, so `/model` can select the documented `low`/`medium`/`high`/`xhigh` ladder (`max` is rejected by api.x.ai).
 - Marked CoreWeave runtime discovery as authoritative so stale bundled model ids that the endpoint no longer serves stop appearing as selectable models.
 - ChatGPT Codex discovery that advertises only worker `-wm` SKUs now also registers the plain model route, so a configured `openai-codex/<model>` keeps resolving instead of fuzzy-falling-back to the `-wm` SKU some accounts reject.
+- Fixed `opencode-go/muse-spark-1.2` (and `muse-spark-1.2-contributor`) failing every tool-call turn with `OpenAI completions stream closed before a finish_reason was received`. The Go gateway serves these ids only at `/zen/go/v1/responses`, but the `/zen/go/v1/models` discovery omits the `provider.npm` hint, so the resolver fell through to `openai-completions`; both ids are now pinned to `openai-responses` like `deepseek-v4-flash` ([#8957](https://github.com/can1357/oh-my-pi/issues/8957)).
 
 ## [17.3.6] - 2026-08-17
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5715,8 +5715,17 @@ const OPENCODE_ZEN_API_RESOLUTION = createOpenCodeApiResolution("https://opencod
 // /zen/go/v1/chat/completions route does not work for this model while
 // /zen/go/v1/responses does (user-verified against the live gateway,
 // 2026-08-08; Flash only — deepseek-v4-pro serves fine on chat completions).
+//
+// muse-spark-1.2 / muse-spark-1.2-contributor are the same inverse case: the
+// Go gateway's /zen/go/v1/models discovery drops the `provider.npm` hint, so
+// without an override they fall through to openai-completions even though the
+// gateway only serves them at /zen/go/v1/responses (@ai-sdk/openai per
+// https://opencode.ai/docs/go/#endpoints). The completions parser then closes
+// the stream with no finish_reason on every tool-call turn (#8957).
 const OPENCODE_GO_API_RESOLUTION = createOpenCodeApiResolution("https://opencode.ai/zen/go", {
 	"deepseek-v4-flash": "openai-responses",
+	"muse-spark-1.2": "openai-responses",
+	"muse-spark-1.2-contributor": "openai-responses",
 	"minimax-m2.7": "openai-completions",
 	"minimax-m3": "openai-completions",
 	"minimax-m3-free": "openai-completions",

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -54,6 +54,21 @@ describe("OpenCode provider discovery", () => {
 		});
 	});
 
+	test("routes opencode-go muse-spark-1.2 to the responses API (#8957)", () => {
+		const descriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "opencode-go");
+		// The Go /zen/go/v1/models discovery drops the provider.npm hint for the
+		// muse-spark ids, so without an override they fall through to
+		// openai-completions even though the gateway only serves them at
+		// /zen/go/v1/responses. Sending completions requests closes the stream
+		// with no finish_reason on every tool-call turn.
+		for (const id of ["muse-spark-1.2", "muse-spark-1.2-contributor"]) {
+			expect(descriptor?.resolveApi?.(id, { tool_call: true })).toEqual({
+				api: "openai-responses",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+			});
+		}
+	});
+
 	test("replaces stale bundled Zen models with each credential's live endpoint list", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-zen-"));
 		try {


### PR DESCRIPTION
## Repro
`opencode-go/muse-spark-1.2` throws `OpenAI completions stream closed before a finish_reason was received` on every tool-call turn (reported by @Ayush12358; also hit by @AIast0r and @veermetri05). Invoking the `opencode-go` descriptor resolver reproduces the misroute:

```
muse-spark-1.2             -> { api: "openai-completions", baseUrl: "https://opencode.ai/zen/go/v1" }   # wrong
muse-spark-1.2 (npm=openai) -> { api: "openai-responses",   baseUrl: "https://opencode.ai/zen/go/v1" }   # correct
```

## Cause
The OpenCode Go gateway serves Muse Spark 1.2 (and `muse-spark-1.2-contributor`) only at `https://opencode.ai/zen/go/v1/responses` (OpenAI Responses transport, `@ai-sdk/openai` per the [Go endpoints table](https://opencode.ai/docs/go/#endpoints)). `OPENCODE_GO_API_RESOLUTION` in `packages/catalog/src/provider-models/openai-compat.ts` only maps a model to `openai-responses` when the discovered `/zen/go/v1/models` metadata carries `provider.npm === "@ai-sdk/openai"`. That hint is absent for the muse-spark ids, so they fall through to the default `openai-completions`; omp POSTs to `/v1/chat/completions`, and the completions stream parser (`packages/ai/src/providers/openai-completions.ts`) throws when the stream closes with no `finish_reason`.

## Fix
- Pin `muse-spark-1.2` and `muse-spark-1.2-contributor` to `openai-responses` in `OPENCODE_GO_API_RESOLUTION`, mirroring the existing `deepseek-v4-flash` override.
- Add a resolver regression in `packages/catalog/test/opencode-provider.test.ts` asserting both ids resolve to `{ api: "openai-responses", baseUrl: "https://opencode.ai/zen/go/v1" }`.
- Changelog entry under `packages/catalog` `[Unreleased] > Fixed`.

No `models.json` regen: opencode-go uses authoritative runtime discovery and has no bundled muse-spark entry, so the resolution rules govern this at runtime.

## Verification
`bun test test/opencode-provider.test.ts test/issue-1617-repro.test.ts test/meta-provider.test.ts` (packages/catalog) — 12 pass, 0 fail. The new resolver test fails before the override and passes after.

Fixes #8957