### PR TITLE
fix(catalog): route copilot grok-4.6 through responses api

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed SuperGrok (`xai-oauth`) Grok 4.6 hiding the thinking-level picker: the Responses effort-capable allowlist now includes `grok-4.6`, so `/model` can select the documented `low`/`medium`/`high`/`xhigh` ladder (`max` is rejected by api.x.ai).
 - Marked CoreWeave runtime discovery as authoritative so stale bundled model ids that the endpoint no longer serves stop appearing as selectable models.
 - ChatGPT Codex discovery that advertises only worker `-wm` SKUs now also registers the plain model route, so a configured `openai-codex/<model>` keeps resolving instead of fuzzy-falling-back to the `-wm` SKU some accounts reject.
+- Fixed GitHub Copilot `grok-4.6` / `grok-4.6-1m` failing with HTTP 400 `unsupported_api_for_model` by routing them through the OpenAI Responses API (`/responses`) instead of `/chat/completions`, matching `grok-4.5`. Stale cached completion routes are invalidated on refresh ([#8807](https://github.com/can1357/oh-my-pi/issues/8807)).
 
 ## [17.3.6] - 2026-08-17
 

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -24448,7 +24448,7 @@
 		"grok-4.6": {
 			"id": "grok-4.6",
 			"name": "Grok 4.6",
-			"api": "openai-completions",
+			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
 			"reasoning": true,
@@ -24468,18 +24468,14 @@
 				"User-Agent": "opencode/1.3.15",
 				"X-GitHub-Api-Version": "2026-06-01"
 			},
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
 					"minimal",
 					"low",
 					"medium",
-					"high"
+					"high",
+					"xhigh"
 				]
 			}
 		},

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5081,8 +5081,18 @@ export interface GithubCopilotModelManagerConfig {
 
 const COPILOT_ANTHROPIC_MODEL_PATTERN = /^claude-(haiku|sonnet|opus|fable|mythos)-\d/;
 const isCopilotResponsesModelId = (modelId: string): boolean =>
-	modelId === "grok-4.5" || modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
-const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["grok-4.5", "grok-4.5-1m", "mai-code-1-flash-picker"];
+	modelId === "grok-4.5" ||
+	modelId === "grok-4.6" ||
+	modelId.startsWith("gpt-5") ||
+	modelId.startsWith("oswe") ||
+	modelId.startsWith("mai-");
+const COPILOT_CACHE_INVALIDATED_MODEL_IDS = [
+	"grok-4.5",
+	"grok-4.5-1m",
+	"grok-4.6",
+	"grok-4.6-1m",
+	"mai-code-1-flash-picker",
+];
 
 function inferCopilotApi(modelId: string): Api {
 	if (COPILOT_ANTHROPIC_MODEL_PATTERN.test(modelId)) {

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -390,9 +390,23 @@ describe("github copilot model limits mapping", () => {
 		const model = models.find(candidate => candidate.id === "grok-4.5");
 		expect(model?.api).toBe("openai-responses");
 	});
+	it("routes grok-4.6 to the openai-responses endpoint (#8807)", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "grok-4.6",
+					name: "Grok 4.6",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "grok-4.6");
+		expect(model?.api).toBe("openai-responses");
+	});
 	for (const migration of [
 		{ id: "mai-code-1-flash-picker", name: "MAI-Code-1-Flash" },
 		{ id: "grok-4.5", name: "Grok 4.5" },
+		{ id: "grok-4.6", name: "Grok 4.6" },
 	]) {
 		it(`refreshes a cached ${migration.name} completion route after the endpoint migration`, async () => {
 			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `pi-ai-copilot-${migration.id}-cache-`));


### PR DESCRIPTION
## Repro
Selecting `github-copilot/grok-4.6` (or `grok-4.6-1m`) and sending any prompt fails with HTTP 400 `model "grok-4.6" is not accessible via the /chat/completions endpoint (type=unsupported_api_for_model)`. The bundled catalog confirms the misroute: `getBundledModel("github-copilot", "grok-4.6").api` is `openai-completions` while `grok-4.5` is `openai-responses`. GitHub Copilot's `GET /models` reports `supported_endpoints: ["/responses"]` for grok-4.6.

## Cause
`isCopilotResponsesModelId` in `packages/catalog/src/provider-models/openai-compat.ts` hardcoded `modelId === "grok-4.5"` and never matched `grok-4.6`. That predicate drives both the static generator (`COPILOT_API_RESOLUTION_RULES`) and dynamic discovery (`inferCopilotApi`), so grok-4.6 (and its synthesized `-1m` sibling, which inherits the base api) stayed on `openai-completions`, and `models.json` shipped `api: "openai-completions"` for `github-copilot/grok-4.6`. Identical regression to #7096, fixed for grok-4.5 in #7097.

## Fix
- `isCopilotResponsesModelId` now also matches `grok-4.6`, so the generator and discovery classify it (and `grok-4.6-1m`) as `openai-responses`.
- Added `grok-4.6` / `grok-4.6-1m` to `COPILOT_CACHE_INVALIDATED_MODEL_IDS` so users with a stale cached completion route get it dropped on the next refresh.
- Regenerated `github-copilot/grok-4.6` in `models.json` to `api: openai-responses` (the responses policy drops the `compat` block and adds the `xhigh` effort) — output verified identical to a full `bun run gen:models`, edited surgically to avoid unrelated upstream catalog drift.
- Added regression coverage in `github-copilot-model-limits.test.ts`: a discovery-routing assertion for grok-4.6 (#8807) and grok-4.6 in the cache-migration loop.

## Verification
`bun test test/github-copilot-model-limits.test.ts` → 34 pass; `bun test test/xai-responses-thinking-policy.test.ts test/xai-api-key-responses.test.ts test/identity-family.test.ts` → 42 pass. Fixes #8807