### PR TITLE
fix(natives): resolve platform leaf from scope dir when core runs from bun cache

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `enclosingBlockBoundaries` and `blockRangeAt` now reuse a parsed tree-sitter tree when the same source and language were parsed before, and skip subtrees whose line span holds no visible line. Together these cut the block-context work the `read` tool performs on every non-raw read: for an 81KB TypeScript source with a mid-file window, 13.4ms to 4.45ms on a first parse and to 0.149ms once the tree is cached; for a 1.06MB source, 188.1ms to 55.8ms and to 0.440ms. The tree cache is bounded (12 entries, 4MiB of retained source) and verifies content byte-for-byte on every hit, so a hash collision can only cost a re-parse. The subtree skip is proven equivalent by differential comparison against the exhaustive walk across 4827 repository files and 38,616 window comparisons.
 
+### Fixed
+
+- Fixed the native addon failing to load for out-of-tree consumers (custom tools importing `@oh-my-pi/pi-tui`, the `omp stats` worker) when the core `@oh-my-pi/pi-natives` package runs from bun's global install cache. The loader resolved the platform leaf package (`@oh-my-pi/pi-natives-<tag>`) via `require.resolve`, which can't see the leaf when it is laid out as a version-pinned sibling with no enclosing `node_modules`; the loader now falls back to scanning the core package's scope directory for the sibling that holds the addon ([#8901](https://github.com/can1357/oh-my-pi/issues/8901)).
+
 ## [17.3.5] - 2026-08-16
 
 ### Fixed

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -56,6 +56,15 @@ export interface ResolveLoaderCandidatesInput {
 
 export function resolveLoaderCandidates(input: ResolveLoaderCandidatesInput): string[];
 
+export interface FindScopedLeafPackageDirInput {
+	platformTag: string;
+	packageVersion: string;
+	addonFilenames: string[];
+	corePackageDir: string;
+}
+
+export function findScopedLeafPackageDir(input: FindScopedLeafPackageDirInput): string | null;
+
 export interface InitLoaderContextOverrides {
 	nativeDir?: string;
 	platform?: NodeJS.Platform | string;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -56,18 +56,67 @@ function getNativesDir() {
 	return path.join(os.homedir(), ".omp", "natives");
 }
 
-function resolveLeafPackageDir(platformTag) {
+function resolveLeafPackageDir(platformTag, addonFilenames) {
 	try {
 		const require_ = createRequire(import.meta.url);
 		return path.dirname(require_.resolve(`@oh-my-pi/pi-natives-${platformTag}/package.json`));
 	} catch {
-		return null;
+		// `require.resolve` can't reach bun's global-cache leaves: there the leaf
+		// is a versioned sibling of the core package with no enclosing
+		// `node_modules`, so the node resolution walk misses it. Scan the scope
+		// directory for the sibling that actually holds the addon. See #8901.
+		return findScopedLeafPackageDir({
+			platformTag,
+			packageVersion: packageJson.version,
+			addonFilenames,
+			corePackageDir: path.join(import.meta.dir, ".."),
+		});
 	}
 }
 
 // =========================================================================
 // Pure helpers — re-exported for unit tests in `packages/natives/test/`.
 // =========================================================================
+
+/**
+ * Locate the platform leaf package (`@oh-my-pi/pi-natives-<tag>`) directory that
+ * holds the prebuilt addon by scanning the core package's scope directory for a
+ * matching sibling.
+ *
+ * Fallback for when `require.resolve` can't find the leaf: when the core package
+ * runs from bun's global install cache, the leaf is laid out as a version-pinned
+ * sibling (`<cache>/@oh-my-pi/pi-natives-<tag>@<ver>@@@N/`) with no enclosing
+ * `node_modules`, so node's resolution walk misses it. Out-of-tree consumers —
+ * custom tools importing `@oh-my-pi/pi-tui`, the `omp stats` worker — hit exactly
+ * this. See https://github.com/can1357/oh-my-pi/issues/8901.
+ *
+ * @param {{ platformTag: string; packageVersion: string; addonFilenames: string[]; corePackageDir: string }} input
+ * @returns {string | null} Absolute leaf directory holding an addon, or null when none does.
+ */
+export function findScopedLeafPackageDir({ platformTag, packageVersion, addonFilenames, corePackageDir }) {
+	const scopeDir = path.dirname(corePackageDir);
+	let entries;
+	try {
+		entries = fs.readdirSync(scopeDir);
+	} catch {
+		return null;
+	}
+	const leafBaseName = `pi-natives-${platformTag}`;
+	// Match the plain package dir (`node_modules` install) and bun's
+	// version-pinned cache dirs (`pi-natives-<tag>@<ver>@@@N`), but never a
+	// longer tag (`pi-natives-<tag>-something`).
+	const isLeaf = name => name === leafBaseName || name.startsWith(`${leafBaseName}@`);
+	// Prefer a sibling whose version matches this package so a stale cached
+	// release never shadows the addon built for the running loader.
+	const matches = entries
+		.filter(isLeaf)
+		.sort((a, b) => Number(b.includes(`@${packageVersion}`)) - Number(a.includes(`@${packageVersion}`)));
+	for (const name of matches) {
+		const dir = path.join(scopeDir, name);
+		if (addonFilenames.some(filename => fs.existsSync(path.join(dir, filename)))) return dir;
+	}
+	return null;
+}
 
 /**
  * @param {{
@@ -774,21 +823,20 @@ export function initLoaderContext(overrides = {}) {
 		!isCompiledBinary &&
 		!normalizedNativeDir.includes("\\node_modules\\") &&
 		!normalizedNativeDir.includes("/node_modules/");
+	const selectedVariant = resolveCpuVariant(getVariantOverride());
+	const addonFilenames = getAddonFilenames({ tag: platformTag, arch: process.arch, variant: selectedVariant });
+	const addonLabel = selectedVariant ? `${platformTag} (${selectedVariant})` : platformTag;
 	const leafPackageDir =
 		isCompiledBinary || isWorkspaceLoad
 			? null
 			: overrides.leafPackageDir === undefined
-				? resolveLeafPackageDir(platformTag)
+				? resolveLeafPackageDir(platformTag, addonFilenames)
 				: overrides.leafPackageDir;
 	const stageFromNodeModules = shouldStageNodeModulesAddon({
 		platform,
 		isCompiledBinary,
 		nativeDir: normalizedNativeDir,
 	});
-
-	const selectedVariant = resolveCpuVariant(getVariantOverride());
-	const addonFilenames = getAddonFilenames({ tag: platformTag, arch: process.arch, variant: selectedVariant });
-	const addonLabel = selectedVariant ? `${platformTag} (${selectedVariant})` : platformTag;
 
 	const candidates = resolveLoaderCandidates({
 		addonFilenames,

--- a/packages/natives/test/issue-8901-repro.test.ts
+++ b/packages/natives/test/issue-8901-repro.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/8901.
+ *
+ * When the core `@oh-my-pi/pi-natives` package runs from bun's global install
+ * cache — the case for out-of-tree consumers such as a custom tool importing
+ * `@oh-my-pi/pi-tui`, or the `omp stats` worker — the platform leaf package is
+ * laid out as a *version-pinned sibling* of the core package:
+ *
+ *   <cache>/@oh-my-pi/pi-natives@<ver>@@@N/            (core, no .node)
+ *   <cache>/@oh-my-pi/pi-natives-<tag>@<ver>@@@N/      (leaf, holds the .node)
+ *
+ * Neither is under an enclosing `node_modules`, so node's resolution walk
+ * (`createRequire(...).resolve("@oh-my-pi/pi-natives-<tag>/package.json")`)
+ * cannot find the leaf and `resolveLeafPackageDir` returned `null`. The leaf
+ * candidate then dropped out of the loader search list and the addon failed to
+ * load even though it was installed and complete.
+ *
+ * `findScopedLeafPackageDir` is the fallback: it scans the core package's scope
+ * directory for the sibling leaf that actually holds the addon.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { findScopedLeafPackageDir } from "../native/loader-state.js";
+
+const PLATFORM_TAG = "linux-x64";
+const VERSION = "17.3.7";
+const ADDON = `pi_natives.${PLATFORM_TAG}.node`;
+
+const tmpDirs: string[] = [];
+
+/**
+ * Build a bun-cache-style scope directory: a core package plus zero or more
+ * leaf siblings, none under an enclosing `node_modules`. Returns the core
+ * package directory (what the loader passes as `corePackageDir`).
+ */
+function buildScope(leaves: Array<{ dirName: string; addonFiles: string[] }>): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "issue-8901-"));
+	tmpDirs.push(root);
+	const scope = path.join(root, "@oh-my-pi");
+	const coreDir = path.join(scope, `pi-natives@${VERSION}@@@1`);
+	fs.mkdirSync(path.join(coreDir, "native"), { recursive: true });
+	fs.writeFileSync(
+		path.join(coreDir, "package.json"),
+		JSON.stringify({ name: "@oh-my-pi/pi-natives", version: VERSION }),
+	);
+	for (const leaf of leaves) {
+		const leafDir = path.join(scope, leaf.dirName);
+		fs.mkdirSync(leafDir, { recursive: true });
+		for (const file of leaf.addonFiles) fs.writeFileSync(path.join(leafDir, file), "DUMMY");
+	}
+	return coreDir;
+}
+
+afterEach(() => {
+	for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("issue 8901: leaf resolution from the bun install cache", () => {
+	it("finds the version-pinned sibling leaf that holds the addon", () => {
+		const corePackageDir = buildScope([
+			{ dirName: `pi-natives-${PLATFORM_TAG}@${VERSION}@@@1`, addonFiles: [ADDON] },
+		]);
+		const found = findScopedLeafPackageDir({
+			platformTag: PLATFORM_TAG,
+			packageVersion: VERSION,
+			addonFilenames: [ADDON],
+			corePackageDir,
+		});
+		expect(found).toBe(path.join(path.dirname(corePackageDir), `pi-natives-${PLATFORM_TAG}@${VERSION}@@@1`));
+	});
+
+	it("also resolves the plain (node_modules) sibling directory name", () => {
+		const corePackageDir = buildScope([{ dirName: `pi-natives-${PLATFORM_TAG}`, addonFiles: [ADDON] }]);
+		const found = findScopedLeafPackageDir({
+			platformTag: PLATFORM_TAG,
+			packageVersion: VERSION,
+			addonFilenames: [ADDON],
+			corePackageDir,
+		});
+		expect(found).toBe(path.join(path.dirname(corePackageDir), `pi-natives-${PLATFORM_TAG}`));
+	});
+
+	it("prefers the version-matching sibling over a stale cached release", () => {
+		const stale = `pi-natives-${PLATFORM_TAG}@17.3.5@@@1`;
+		const current = `pi-natives-${PLATFORM_TAG}@${VERSION}@@@1`;
+		const corePackageDir = buildScope([
+			{ dirName: stale, addonFiles: [ADDON] },
+			{ dirName: current, addonFiles: [ADDON] },
+		]);
+		const found = findScopedLeafPackageDir({
+			platformTag: PLATFORM_TAG,
+			packageVersion: VERSION,
+			addonFilenames: [ADDON],
+			corePackageDir,
+		});
+		expect(found).toBe(path.join(path.dirname(corePackageDir), current));
+	});
+
+	it("matches an addon under a variant filename (x64 leaves ship baseline/modern)", () => {
+		const baseline = `pi_natives.${PLATFORM_TAG}-baseline.node`;
+		const corePackageDir = buildScope([
+			{ dirName: `pi-natives-${PLATFORM_TAG}@${VERSION}@@@1`, addonFiles: [baseline] },
+		]);
+		const found = findScopedLeafPackageDir({
+			platformTag: PLATFORM_TAG,
+			packageVersion: VERSION,
+			addonFilenames: [`pi_natives.${PLATFORM_TAG}-modern.node`, baseline, ADDON],
+			corePackageDir,
+		});
+		expect(found).toBe(path.join(path.dirname(corePackageDir), `pi-natives-${PLATFORM_TAG}@${VERSION}@@@1`));
+	});
+
+	it("ignores a sibling for a different platform tag", () => {
+		const corePackageDir = buildScope([
+			{ dirName: `pi-natives-darwin-arm64@${VERSION}@@@1`, addonFiles: ["pi_natives.darwin-arm64.node"] },
+		]);
+		const found = findScopedLeafPackageDir({
+			platformTag: PLATFORM_TAG,
+			packageVersion: VERSION,
+			addonFilenames: [ADDON],
+			corePackageDir,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("returns null when the matching sibling exists but holds no addon", () => {
+		const corePackageDir = buildScope([
+			{ dirName: `pi-natives-${PLATFORM_TAG}@${VERSION}@@@1`, addonFiles: ["README.md"] },
+		]);
+		const found = findScopedLeafPackageDir({
+			platformTag: PLATFORM_TAG,
+			packageVersion: VERSION,
+			addonFilenames: [ADDON],
+			corePackageDir,
+		});
+		expect(found).toBeNull();
+	});
+});


### PR DESCRIPTION
## Repro
A custom tool that imports `@oh-my-pi/pi-tui` (the shipped `examples/custom-tools` pattern) fails to load with `Failed to load pi_natives native addon` even though `@oh-my-pi/pi-natives-<tag>` is installed and holds the `.node`. The reporter observed the `Tried:` list containing only `nativeDir` and `execDir` — the platform-leaf candidate was absent. Reproduced the underlying resolution gap by mimicking bun's global install-cache layout (core package + a version-pinned leaf sibling holding the `.node`, neither under an enclosing `node_modules`) and calling `createRequire(coreLoaderUrl).resolve("@oh-my-pi/pi-natives-<tag>/package.json")`:

```
leaf .node present on disk: true
RESOLVE FAILED: MODULE_NOT_FOUND
```

## Cause
`resolveLeafPackageDir` in `packages/natives/native/loader-state.js` resolved the platform leaf via `createRequire(import.meta.url).resolve("@oh-my-pi/pi-natives-<tag>/package.json")`. When bun runs the core `@oh-my-pi/pi-natives` from its global install cache — the case for out-of-tree consumers such as custom tools importing `@oh-my-pi/pi-tui` or the `omp stats` worker — the leaf is laid out as a version-pinned sibling (`<cache>/@oh-my-pi/pi-natives-<tag>@<ver>@@@N/`) with no enclosing `node_modules`. Node's resolution walk can't see it, so `resolveLeafPackageDir` returned `null`, `leafPackageDir` dropped out of the candidate list built by `resolveLoaderCandidates`, and only `nativeDir` + `execDir` remained.

## Fix
- Added `findScopedLeafPackageDir` (pure helper, exported for tests) to `loader-state.js`: when `require.resolve` misses, scan the core package's scope directory for a sibling matching `pi-natives-<tag>` / `pi-natives-<tag>@<ver>@@@N`, preferring a version match, and return the first one that actually holds an addon file.
- `resolveLeafPackageDir` now falls back to `findScopedLeafPackageDir` in its `catch`, passing the already-computed `addonFilenames`.
- Reordered `initLoaderContext` so `selectedVariant`/`addonFilenames`/`addonLabel` are computed before leaf resolution (the fallback needs `addonFilenames`).
- Declared the new export in `loader-state.d.ts`.
- Changelog entry under `packages/natives` `[Unreleased] > Fixed`.

## Verification
`bun test packages/natives/test/issue-8901-repro.test.ts` — 6/6 pass (finds the versioned sibling, the plain node_modules dir, prefers the version match, matches variant filenames, ignores a different-tag sibling, returns null when no addon present). Full `bun test packages/natives/test/` passes except a pre-existing `pdfToMarkdown is not a function` failure in `native.test.ts`, confirmed present on a clean checkout of this branch's base (the native `pdfToMarkdown` binding is unavailable in this build) and unrelated to this diff. `bun check` (natives typecheck) green. Fixes #8901