### PR TITLE
fix(mcp): run oauth discovery on reauth when handshake needs no auth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed Claude Code marketplace plugins ignoring the `enabledPlugins` switch in `~/.claude/settings.json` and `.claude/settings(.local).json`: a plugin turned off for a project no longer loads there, and a local-scope install enabled for a project loads even when its recorded `projectPath` is a different directory
+- Fixed `/mcp reauth <name>` refusing to run the OAuth flow for HTTP/SSE servers that allow unauthenticated `initialize` but require a bearer token for `tools/call`. A clean handshake no longer counts as proof that OAuth is unnecessary; the probe now falls back to OAuth discovery and only reports "reauthorization is not required" when the server advertises no OAuth endpoint ([#8922](https://github.com/can1357/oh-my-pi/issues/8922)).
 - Fixed task and eval subagents discovering newly added agent definitions while resolving their role aliases from stale startup settings. Subagent preflight now atomically reloads persisted settings before agent discovery while preserving live runtime overrides.
 - Fixed images returned by tools mounted under `xd://` rendering only as file links instead of inline terminal graphics.
 - Resume Cursor idle-stall turns after completed MCP/todo tool results. The watchdog already closes the Connect stream, so unmarked blocks no longer need the `exec-resolved` marker to continue.

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1198,11 +1198,20 @@ export class MCPCommandController {
 			connectionError = error as Error;
 		}
 
-		// Server connected fine without auth — reauth is not needed. A tool-level
-		// challenge overrides this: servers may allow the anonymous handshake yet
-		// protect individual tool calls with `_meta["mcp/www_authenticate"]`.
+		// Server connected fine without auth. A tool-level challenge overrides
+		// this: servers may allow the anonymous handshake yet protect individual
+		// tool calls with `_meta["mcp/www_authenticate"]`. Even without such a
+		// challenge, a clean `initialize` is only weak evidence — per the MCP
+		// spec a server MAY permit unauthenticated `initialize` while requiring a
+		// bearer token for `tools/call`. The user explicitly asked to reauth, so
+		// honor it when the server advertises OAuth discovery metadata; only
+		// refuse when there is genuinely no OAuth endpoint to acquire.
 		if (connectionSucceeded && !authChallenge) {
-			throw new Error("Server connection succeeded without OAuth; reauthorization is not required.");
+			const discovered = "url" in config && config.url ? await discoverOAuthEndpoints(config.url) : null;
+			if (!discovered) {
+				throw new Error("Server connection succeeded without OAuth; reauthorization is not required.");
+			}
+			return discovered;
 		}
 
 		// Tool calls can carry richer RFC 6750/RFC 9728 hints than the original

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -353,6 +353,53 @@ describe("/mcp auth commands", () => {
 		expect(showError).not.toHaveBeenCalled();
 	});
 
+	test("/mcp reauth acquires a credential when the handshake succeeds but tools need OAuth", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		// The anonymous handshake (`initialize`) succeeds; only `tools/call` is
+		// gated behind OAuth. The unauthenticated probe must not treat this as
+		// proof that reauthorization is unnecessary.
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue({} as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue(undefined as never);
+
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request): Promise<Response> => {
+				const url = String(input);
+				if (url === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+					return new Response(
+						JSON.stringify({
+							issuer: "https://mcp.example.com",
+							authorization_endpoint: "https://auth.example.com/authorize",
+							token_endpoint: "https://auth.example.com/token",
+							client_id: "advertised-client",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockResolvedValue({
+			access: "fresh-access",
+			refresh: "fresh-refresh",
+			expires: Date.now() + 3_600_000,
+		});
+
+		const { controller, showError } = createController(authStorage);
+
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL))).toMatchObject({
+			type: "oauth",
+			access: "fresh-access",
+			tokenUrl: "https://auth.example.com/token",
+		});
+	});
+
 	test("reuses embedded DCR client secret during reauth token exchange", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();


### PR DESCRIPTION
## Repro
`/mcp reauth <name>` cannot acquire a credential for an HTTP MCP server that allows unauthenticated `initialize` but requires a bearer token for `tools/call` (e.g. `https://qa.replay.io/api/mcp`). The reauth probe connects with `{ oauth: false }`, `initialize` returns 200, and the command hard-errors with `Failed to reauthorize server: Server connection succeeded without OAuth; reauthorization is not required.` — even though the server advertises complete OAuth discovery documents. Reproduced with `bun test test/mcp-command-reauth.test.ts -t "acquires a credential when the handshake succeeds"`, which surfaced the error before the fix.

## Cause
`MCPCommandController.#resolveOAuthEndpointsFromServer` (`packages/coding-agent/src/modes/controllers/mcp-command-controller.ts`) treated a clean unauthenticated `initialize` with no in-band tool challenge as proof that OAuth was unnecessary and threw immediately. A successful `initialize` is weak evidence: per the MCP spec a server may permit anonymous `initialize` while gating `tools/call` behind OAuth, so this path left no way to obtain a credential the user explicitly asked for.

## Fix
- In `#resolveOAuthEndpointsFromServer`, when the handshake succeeds without a tool challenge, run `discoverOAuthEndpoints(config.url)` and return the discovered endpoints if the server advertises OAuth metadata.
- Only throw `Server connection succeeded without OAuth; reauthorization is not required.` when discovery finds no OAuth endpoint, so servers with genuinely no OAuth still report cleanly.

## Verification
`bun test test/mcp-command-reauth.test.ts` — 13 pass, 0 fail. Added a regression test (`/mcp reauth acquires a credential when the handshake succeeds but tools need OAuth`) that mocks a successful anonymous handshake plus advertised `/.well-known/oauth-authorization-server` metadata and asserts the OAuth credential is stored instead of the command erroring; it fails on the pre-fix code and passes after. Fixes #8922