### PR TITLE
fix(catalog): recover gmi-cloud model params from canonical index

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed SuperGrok (`xai-oauth`) Grok 4.6 hiding the thinking-level picker: the Responses effort-capable allowlist now includes `grok-4.6`, so `/model` can select the documented `low`/`medium`/`high`/`xhigh` ladder (`max` is rejected by api.x.ai).
 - Marked CoreWeave runtime discovery as authoritative so stale bundled model ids that the endpoint no longer serves stop appearing as selectable models.
 - ChatGPT Codex discovery that advertises only worker `-wm` SKUs now also registers the plain model route, so a configured `openai-codex/<model>` keeps resolving instead of fuzzy-falling-back to the `-wm` SKU some accounts reject.
+- Fixed GMI Cloud (`gmi-cloud`) models resolved via `/v1/models` discovery surfacing with `null` context windows, zero pricing, and no reasoning/thinking metadata for every model except the bundled `deepseek-ai/DeepSeek-V4-Flash` seed. GMI's endpoint returns only bare `{id}` rows, so the mapper now recovers intrinsic capability metadata (context window, output limit, reasoning, thinking ladder) for resold open-weight models from the cross-provider canonical reference index — matching the SiliconFlow behavior — while never borrowing another provider's pricing ([#8890](https://github.com/can1357/oh-my-pi/issues/8890)).
 
 ## [17.3.6] - 2026-08-17
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1074,10 +1074,61 @@ export interface GmiCloudModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+/**
+ * Map a discovered GMI Cloud model to a full spec.
+ *
+ * GMI's `/v1/models` returns only bare `{id}` rows, so discovery defaults carry
+ * no limits, reasoning, or thinking metadata. When a gmi-cloud bundled
+ * reference exists (the seeded default) it supplies GMI's published tariff and
+ * limits directly. Every other id is an open-weight model GMI resells under its
+ * canonical id (`deepseek-ai/…`, `moonshotai/…`, `zai-org/…`, `Qwen/…`), so its
+ * intrinsic capabilities — context window, output limit, reasoning, thinking
+ * ladder — are recovered from any bundled upstream entry via the canonical
+ * reference index. Pricing is deliberately never borrowed across providers:
+ * GMI's per-model tariff is unknown for these ids, so cost stays zeroed rather
+ * than inheriting another provider's rate.
+ */
+function mapGmiCloudModel(
+	entry: OpenAICompatibleModelRecord,
+	defaults: ModelSpec<"openai-completions">,
+	reference: ModelSpec<"openai-completions"> | undefined,
+): ModelSpec<"openai-completions"> {
+	if (reference) {
+		return mapWithBundledReference(entry, defaults, reference);
+	}
+	const canonical = resolveModelReference(defaults.id, getBundledModelReferenceIndex()) as
+		| ModelSpec<"openai-completions">
+		| undefined;
+	if (!canonical) {
+		return { ...defaults, name: toModelName(entry.name, defaults.name) };
+	}
+	const contextWindow = canonical.contextWindow ?? defaults.contextWindow;
+	const maxTokens =
+		canonical.maxTokens != null && contextWindow != null
+			? Math.min(canonical.maxTokens, contextWindow)
+			: (canonical.maxTokens ?? defaults.maxTokens);
+	return {
+		...defaults,
+		name: toModelName(entry.name, canonical.name ?? defaults.name),
+		reasoning: canonical.reasoning,
+		input: canonical.input,
+		...(canonical.thinking && { thinking: canonical.thinking }),
+		contextWindow,
+		maxTokens,
+	};
+}
+
 export function gmiCloudModelManagerOptions(
 	config?: GmiCloudModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions("gmi-cloud", GMI_CLOUD_BASE_URL, config);
+	return createOpenAICompatibleModelManagerOptions({
+		api: "openai-completions",
+		providerId: "gmi-cloud",
+		defaultBaseUrl: GMI_CLOUD_BASE_URL,
+		config,
+		requireApiKey: true,
+		mapModel: mapGmiCloudModel,
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/catalog/test/gmi-cloud-provider.test.ts
+++ b/packages/catalog/test/gmi-cloud-provider.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { getBundledModelReferenceIndex } from "@oh-my-pi/pi-catalog/identity/bundled";
+import { resolveModelReference } from "@oh-my-pi/pi-catalog/identity/reference";
 import { CATALOG_PROVIDERS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
-import { GMI_CLOUD_STATIC_MODELS } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import {
+	GMI_CLOUD_STATIC_MODELS,
+	gmiCloudModelManagerOptions,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 
 describe("GMI Cloud provider", () => {
 	test("static seed covers the descriptor's default model", () => {
@@ -14,5 +19,53 @@ describe("GMI Cloud provider", () => {
 			dynamicModelsAuthoritative: true,
 		});
 		expect(GMI_CLOUD_STATIC_MODELS.map(model => model.id)).toContain("deepseek-ai/DeepSeek-V4-Flash");
+	});
+
+	// GMI's `/v1/models` returns only bare `{id}` rows, so discovery defaults
+	// carry no limits/reasoning/thinking. The mapper must recover intrinsic
+	// capability metadata for resold open-weight models from the cross-provider
+	// canonical index while never inheriting another provider's pricing.
+	test("dynamic discovery recovers canonical params without borrowing pricing", async () => {
+		// Self-select a bundled reasoning model with a thinking ladder that GMI
+		// does not seed — the very shape that regressed to null params — instead
+		// of hardcoding a churning model id.
+		const index = getBundledModelReferenceIndex();
+		const resold = [...index.exact.values()].find(model => {
+			if (model.provider === "gmi-cloud" || !model.id.includes("/")) return false;
+			if (GMI_CLOUD_STATIC_MODELS.some(seed => seed.id === model.id)) return false;
+			const ref = resolveModelReference(model.id, index);
+			return ref?.reasoning === true && ref.thinking?.mode === "effort" && (ref.contextWindow ?? 0) > 0;
+		});
+		if (!resold) {
+			throw new Error("no bundled resold reasoning model available to exercise canonical recovery");
+		}
+
+		const discoveredIds = [resold.id, "gmi-only/nonexistent-model"];
+		const fetch = (async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: discoveredIds.map(id => ({ id, object: "model", created: 0, owned_by: "public" })),
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			)) as unknown as typeof globalThis.fetch;
+
+		const options = gmiCloudModelManagerOptions({ apiKey: "test-key", fetch });
+		const models = (await options.fetchDynamicModels?.()) ?? [];
+		const byId = new Map(models.map(model => [model.id, model]));
+
+		// Resold model recovers intrinsic capabilities from the canonical index...
+		const recovered = byId.get(resold.id);
+		const canonical = resolveModelReference(resold.id, index);
+		expect(recovered?.contextWindow).toBe(canonical?.contextWindow ?? null);
+		expect(recovered?.reasoning).toBe(true);
+		expect(recovered?.thinking?.mode).toBe("effort");
+		// ...but pricing is never borrowed across providers.
+		expect(recovered?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+
+		// An id absent from every bundle stays bare rather than fabricating params.
+		const unknown = byId.get("gmi-only/nonexistent-model");
+		expect(unknown?.contextWindow).toBeNull();
+		expect(unknown?.reasoning).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
With a `GMI_API_KEY` configured, every GMI Cloud model except the bundled `deepseek-ai/DeepSeek-V4-Flash` seed resolves with a `null` context window (shown as `??` in the model picker), blank pricing in `/models`, and no reasoning/thinking controls. GMI's `GET /v1/models` ([docs](https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference)) returns only bare rows — `{id, object, created, owned_by}` — with no capability metadata. Driving `gmiCloudModelManagerOptions({apiKey, fetch}).fetchDynamicModels()` against a stubbed bare response reproduces it: `deepseek-ai/DeepSeek-V4-Flash` keeps `ctx=1048576 cost=0.14/0.28 thinking=high/max`, while `moonshotai/Kimi-K2.6`, `zai-org/GLM-5.1`, and `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` all come back `ctx=null cost=0/0 reasoning=false` with no thinking config.

## Cause
`gmiCloudModelManagerOptions` (`packages/catalog/src/provider-models/openai-compat.ts`) built its manager through `createSimpleOpenAICompletionsOptions` → `mapWithBundledReference`, which only recovers params for ids present in the **gmi-cloud** bundle. That bundle contains exactly one model (`GMI_CLOUD_STATIC_MODELS`), so every other discovered id fell through to the bare discovery defaults (`contextWindow: null`, `cost: {0,0,0,0}`, `reasoning: false`). SiliconFlow — which resells the same open-weight models behind an equally bare `/models` endpoint — already solves this via cross-provider canonical resolution (`resolveModelReference` over `getBundledModelReferenceIndex`), but the gmi-cloud mapper never consulted it.

## Fix
- Add `mapGmiCloudModel`: when a gmi-cloud bundled reference exists (the seeded default) keep the existing `mapWithBundledReference` path (GMI's published tariff + limits); otherwise recover context window, max tokens, reasoning, thinking ladder, and input modalities from the cross-provider canonical reference index for resold open-weight ids. Pricing is deliberately never borrowed across providers — GMI's per-model tariff is unknown for these ids, so cost stays zeroed rather than inheriting another provider's rate (mirrors SiliconFlow's documented decision).
- Rebuild `gmiCloudModelManagerOptions` on `createOpenAICompatibleModelManagerOptions` with the new mapper instead of the generic simple builder.
- Add a regression test that self-selects a bundled resold reasoning model from the canonical index (avoiding brittle hardcoded ids) and asserts recovery of context/reasoning/thinking, zeroed pricing, and bare fallback for an id absent from every bundle.

## Verification
`bun test` in `packages/catalog` — 604 pass, 0 fail (incl. the new `dynamic discovery recovers canonical params without borrowing pricing` case). `bun run check` (biome + tsgo) clean. Manually confirmed via the stubbed-discovery repro that Kimi-K2.6/GLM-5.1/Qwen3-Coder now resolve non-null context windows and effort thinking ladders while their cost stays `{0,0,0,0}`, and an unknown id still resolves to bare defaults. Fixes #8890