### PR TITLE
fix(task): bound isolation baseline capture to avoid host OOM

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed isolated `task` subagents crashing the whole host (bun `SIGTRAP` / `Out of memory`) when spawned in a working tree carrying multiple GB of uncommitted content. `captureBaseline` buffered every untracked file's binary diff into one in-memory string before any backend clone, so a multi-GB tree exhausted the heap and trapped the process — taking the TUI and all in-process subagents down. Baseline capture now sizes untracked content up front and refuses an over-budget snapshot with an actionable error (commit/gitignore the bulk, or set `task.isolation.mode: none`) instead of buffering gigabytes, and the isolation preflight no longer mislabels these failures as "requires a git repository" ([#8939](https://github.com/can1357/oh-my-pi/issues/8939)).
 - Fixed Claude Code marketplace plugins ignoring the `enabledPlugins` switch in `~/.claude/settings.json` and `.claude/settings(.local).json`: a plugin turned off for a project no longer loads there, and a local-scope install enabled for a project loads even when its recorded `projectPath` is a different directory
 - Fixed task and eval subagents discovering newly added agent definitions while resolving their role aliases from stale startup settings. Subagent preflight now atomically reloads persisted settings before agent discovery while preserving live runtime overrides.
 - Fixed images returned by tools mounted under `xd://` rendering only as file links instead of inline terminal graphics.

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -573,7 +573,7 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 				const message = error instanceof Error ? error.message : String(error);
 				throw new StructuredSubagentError(
 					"isolation",
-					`Isolated subagent execution requires a git repository. ${message}`,
+					`Isolated subagent execution could not be prepared: ${message}`,
 					{ cause: error },
 				);
 			}

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@oh-my-pi/pi-natives";
-import { getWorktreeDir, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import { formatBytes, getWorktreeDir, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import * as git from "../utils/git";
 import * as jj from "../utils/jj";
 import { writeIsolationOwner } from "./isolation-ownership";
@@ -93,6 +93,56 @@ async function discoverNestedRepos(repoRoot: string): Promise<string[]> {
 	return result;
 }
 
+/**
+ * Ceiling on the working-tree content a single repo baseline may buffer in
+ * memory. Baseline capture embeds every uncommitted byte — staged/unstaged
+ * binary diffs plus a `--no-index` binary diff of each untracked file — into
+ * in-memory strings (see {@link captureUntrackedPatch}). A binary diff is
+ * ~1.3x the raw bytes, so a multi-GB working tree produces a single string
+ * that blows past the engine's string limit and the process's memory, taking
+ * the whole host down (issue #8939). `git ls-files --others
+ * --exclude-standard` already omits gitignored bulk, so this only trips on
+ * pathological non-ignored content; when it does we refuse the isolated spawn
+ * with an actionable error instead of trapping the host.
+ */
+export const ISOLATION_BASELINE_MAX_CONTENT_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * Thrown when a repo's uncommitted content exceeds
+ * {@link ISOLATION_BASELINE_MAX_CONTENT_BYTES}. Surfaced verbatim so the
+ * caller can report the real cause (oversized working tree) rather than
+ * masking it as a missing git repository.
+ */
+export class IsolationBaselineTooLargeError extends Error {
+	constructor(
+		readonly repoRoot: string,
+		readonly contentBytes: number,
+	) {
+		super(
+			`Working tree at ${repoRoot} carries ${formatBytes(contentBytes)} of uncommitted content, ` +
+				`over the ${formatBytes(ISOLATION_BASELINE_MAX_CONTENT_BYTES)} isolation-snapshot budget. ` +
+				`Isolated task snapshots buffer this content in memory, so proceeding would exhaust the host. ` +
+				`Commit or gitignore the bulk (untracked files that aren't ignored are the usual culprit), ` +
+				`or set \`task.isolation.mode: none\` to run tasks without isolation.`,
+		);
+		this.name = "IsolationBaselineTooLargeError";
+	}
+}
+
+/** Sum the on-disk size of untracked files, skipping entries that vanished. */
+async function sumUntrackedBytes(repoRoot: string, untracked: readonly string[]): Promise<number> {
+	if (untracked.length === 0) return 0;
+	const { results } = await mapWithConcurrencyLimit([...untracked], 16, async entry => {
+		try {
+			const stat = await fs.stat(path.join(repoRoot, entry));
+			return stat.isFile() ? stat.size : 0;
+		} catch {
+			return 0;
+		}
+	});
+	return results.reduce((total: number, size) => total + (size ?? 0), 0);
+}
+
 async function captureUntrackedPatch(repoRoot: string, untracked: readonly string[]): Promise<string> {
 	if (untracked.length === 0) return "";
 	const nullPath = getGitNoIndexNullPath();
@@ -113,6 +163,16 @@ async function captureRepoBaseline(repoRoot: string): Promise<RepoBaseline> {
 	const staged = await git.diff(repoRoot, { binary: true, cached: true });
 	const unstaged = await git.diff(repoRoot, { binary: true });
 	const untracked = await git.ls.untracked(repoRoot);
+	// Gate before capturing the untracked patch: that step embeds every
+	// untracked byte into one in-memory string, so an oversized tree must be
+	// refused here rather than after buffering gigabytes (#8939). Untracked
+	// bytes come from stat (no reads); staged/unstaged are already captured
+	// binary diffs, so their string length is their in-memory footprint.
+	const untrackedBytes = await sumUntrackedBytes(repoRoot, untracked);
+	const contentBytes = untrackedBytes + staged.length + unstaged.length;
+	if (contentBytes > ISOLATION_BASELINE_MAX_CONTENT_BYTES) {
+		throw new IsolationBaselineTooLargeError(repoRoot, contentBytes);
+	}
 	const untrackedPatch = await captureUntrackedPatch(repoRoot, untracked);
 	return { repoRoot, headCommit, staged, unstaged, untracked, untrackedPatch };
 }

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -431,7 +431,7 @@ describe("structured subagent primitive", () => {
 			runStructuredSubagent(
 				request({ session: session({ isolationMode: "worktree" }), isolation: { requested: true } }),
 			),
-		).rejects.toThrow("Isolated subagent execution requires a git repository");
+		).rejects.toThrow("Isolated subagent execution could not be prepared: not a repository");
 		expect(artifactsDirsFromRegistry()).toEqual([]);
 	});
 

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -11,6 +11,8 @@ import {
 	ensureIsolation,
 	getGitNoIndexNullPath,
 	getRepoRoot,
+	ISOLATION_BASELINE_MAX_CONTENT_BYTES,
+	IsolationBaselineTooLargeError,
 	mergeTaskBranches,
 	parseIsolationMode,
 } from "@oh-my-pi/pi-coding-agent/task/worktree";
@@ -71,6 +73,38 @@ describe("worktree isolation helpers", () => {
 		expect(parseIsolationMode("block-clone")).toBe(natives.IsoBackendKind.WindowsBlockClone);
 		expect(parseIsolationMode("rcopy")).toBe(natives.IsoBackendKind.Rcopy);
 		expect(parseIsolationMode("worktree")).toBe(natives.IsoBackendKind.Rcopy);
+	});
+
+	// Regression for #8939: baseline capture buffered every untracked byte into
+	// one in-memory string, so a multi-GB working tree OOM'd and trapped the
+	// whole host at isolated-task spawn. captureRepoBaseline now stats untracked
+	// size up front and refuses over-budget trees with a typed, actionable error
+	// before any content is buffered. Sparse files give a large logical size at
+	// ~zero disk cost, so the guard trips deterministically without writing GBs.
+	it("refuses to snapshot a working tree whose untracked content exceeds the isolation budget", async () => {
+		const repo = await createGitRepo();
+		await runGit(repo, ["config", "user.email", "test@example.com"]);
+		await runGit(repo, ["config", "user.name", "Test User"]);
+		await fs.writeFile(path.join(repo, "README.md"), "hi\n");
+		await runGit(repo, ["add", "README.md"]);
+		await runGit(repo, ["commit", "-q", "-m", "init"]);
+
+		const half = Math.ceil(ISOLATION_BASELINE_MAX_CONTENT_BYTES / 2) + 1;
+		for (const name of ["big-a.bin", "big-b.bin"]) {
+			const file = path.join(repo, name);
+			await fs.writeFile(file, "");
+			await fs.truncate(file, half); // sparse: logical size only
+		}
+
+		const error = await captureBaseline(repo).then(
+			() => null,
+			(err: unknown) => err,
+		);
+		expect(error).toBeInstanceOf(IsolationBaselineTooLargeError);
+		expect((error as IsolationBaselineTooLargeError).contentBytes).toBeGreaterThan(
+			ISOLATION_BASELINE_MAX_CONTENT_BYTES,
+		);
+		expect((error as Error).message).toContain("task.isolation.mode: none");
 	});
 
 	// Real git worktree/stash/merge I/O is the contract under test and cannot be


### PR DESCRIPTION
## Repro
With `task.isolation.mode: auto` (or any copy backend), spawning an isolated `task` subagent in a repo whose working tree carries multiple GB of uncommitted content OOM/`SIGTRAP`-crashes the whole host — TUI and every in-process subagent go with it — or surfaces the misleading `Isolated subagent execution requires a git repository. Out of memory`. Reproduced cross-platform (on Linux): a git repo with 240 untracked files totalling ~240MB, fed to `captureBaseline(repoRoot)`, produces a single `RepoBaseline.untrackedPatch` string of 324,409,999 chars (~1.3x content) and ~729MB RSS delta; the size scales linearly, so at the reporter's 7.9GB tree the single string blows past the engine's string limit / process memory.

## Cause
`captureUntrackedPatch` in `packages/coding-agent/src/task/worktree.ts` runs `git diff --binary --no-index /dev/null <file>` for every untracked file and `join("\n")`s all outputs into one string held in `RepoBaseline.untrackedPatch` for the whole task lifetime. This runs inside `captureBaseline` (`prepareIsolationContext`) *before* any backend clone, so it fires for `auto`/`apfs` alike; when the allocation failure lands in a native frame bun traps (`SIGTRAP`), otherwise it surfaces as a caught `Out of memory`. That caught error was then wrapped by `structured-subagent.ts` as `Isolated subagent execution requires a git repository. …`, mislabeling an OOM as a missing repo.

## Fix
- `captureRepoBaseline` now fetches the untracked list first, sums untracked content via `fs.stat` (`sumUntrackedBytes`, no reads) plus the staged/unstaged diff lengths, and throws a typed `IsolationBaselineTooLargeError` when the total exceeds `ISOLATION_BASELINE_MAX_CONTENT_BYTES` (1 GiB) — *before* buffering any content. `git ls-files --others --exclude-standard` already omits gitignored bulk, so this only trips on pathological non-ignored content; the error is actionable (commit/gitignore the bulk, or set `task.isolation.mode: none`).
- `structured-subagent.ts` isolation preflight no longer prefixes every prepare failure with "requires a git repository"; it surfaces the real underlying message (`getRepoRoot` already emits specific no-repo/jj messages).
- Added a `worktree.test.ts` regression that uses sparse files to trip the budget deterministically without writing GBs, plus updated the `structured-subagent.test.ts` wording assertion; CHANGELOG entry added.

## Verification
`bun test packages/coding-agent/test/task/worktree.test.ts` → 41 pass; `bun test packages/coding-agent/test/task/structured-subagent.test.ts` → 26 pass; `bun --cwd=packages/coding-agent run check:types` clean. Manually reproduced the pre-fix buffering (324MB string / 729MB RSS for 240MB of untracked content) and confirmed the new guard refuses an over-budget tree with the typed error instead of buffering. Fixes #8939