### PR TITLE
fix(ai): strip deprecated/readOnly/writeOnly/$comment annotation keywords from CCA/Google tool schemas

### DIFF
--- a/packages/ai/src/utils/schema/fields.ts
+++ b/packages/ai/src/utils/schema/fields.ts
@@ -40,6 +40,15 @@ export const UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
 	dependencies: true,
 	dependentSchemas: true,
 	dependentRequired: true,
+	// JSON Schema annotation keywords: pure metadata the Google/CCA wire
+	// schemas have no field for. protojson rejects unknown fields outright
+	// ("Cannot find field"), so MCP servers annotating parameters with
+	// `deprecated` / `readOnly` / `writeOnly` (e.g. Stitch's screen tools)
+	// used to 400 the entire request.
+	deprecated: true,
+	readOnly: true,
+	writeOnly: true,
+	$comment: true,
 };
 
 /**
@@ -182,10 +191,6 @@ export const CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS: Record<string, true> = {
 	description: true,
 	default: true,
 	examples: true,
-	deprecated: true,
-	readOnly: true,
-	writeOnly: true,
-	$comment: true,
 };
 
 /**
@@ -207,4 +212,10 @@ export const CCA_UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
 	$dynamicRef: true,
 	$dynamicAnchor: true,
 	propertyNames: true,
+	// Annotation keywords have no CCA Schema proto field; protojson rejects
+	// them with INVALID_ARGUMENT ("Cannot find field").
+	deprecated: true,
+	readOnly: true,
+	writeOnly: true,
+	$comment: true,
 };

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -928,6 +928,31 @@ describe("normalizeSchemaForCCA", () => {
 		});
 	});
 
+	it("strips annotation keywords (deprecated, readOnly, writeOnly, $comment) that Cloud Code Assist rejects", () => {
+		// MCP servers (e.g. Stitch's screen tools) annotate parameters with
+		// `deprecated: true`; CCA's protojson has no such Schema field and
+		// rejects the whole request with 400 "Cannot find field".
+		const sanitized = normalizeSchemaForCCA({
+			type: "object",
+			properties: {
+				projectId: { type: "string", deprecated: true, readOnly: true },
+				screenId: { type: "string", writeOnly: true, $comment: "internal id" },
+				name: { type: "string" },
+			},
+			required: ["name"],
+		});
+
+		expect(sanitized).toEqual({
+			type: "object",
+			properties: {
+				projectId: { type: "string" },
+				screenId: { type: "string" },
+				name: { type: "string" },
+			},
+			required: ["name"],
+		});
+	});
+
 	it("lifts stripped validation keywords into description", () => {
 		const normalized = normalizeSchemaForCCA({
 			type: "string",


### PR DESCRIPTION
## Problem

Cloud Code Assist's protojson rejects any JSON-Schema key that has no corresponding field in its `Schema` proto, failing the **entire** request with `400 INVALID_ARGUMENT` ("Cannot find field"). MCP servers legitimately annotate parameters with `deprecated: true` (Stitch's `get_screen` / `fetch_screen_code` tools do this on `projectId` and `screenId`). `normalizeSchemaForCCA` preserved the key, so one annotated parameter 400'd every Antigravity / Gemini CLI session that had such a server attached:

```
Cloud Code Assist API error (400): Invalid JSON payload received. Unknown name "deprecated" at 'request.tools[0].function_declarations[41].parameters.properties[2].value': Cannot find field.
```

## Change

`packages/ai/src/utils/schema/fields.ts` — a 4-line-classification fix:

- Add `deprecated`, `readOnly`, `writeOnly`, `$comment` to `UNSUPPORTED_SCHEMA_FIELDS` (the set stripped by both `normalizeSchemaForGoogle` and `normalizeSchemaForCCA`).
- Add the same keys to `CCA_UNSUPPORTED_SCHEMA_FIELDS` so the CCA compatibility audit flags them consistently.
- Remove them from `CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS` so mixed-type combiner collapse cannot reintroduce them.

These are pure annotation keywords with no meaning on the wire for Google/CCA, so dropping them is lossless for the model.

`packages/ai/test/schema-normalization.test.ts` — regression test reproducing the exact failing shape (a `deprecated` + `readOnly` parameter inside a tool schema).

## Verification

- Reproduced the 400 against the real Cloud Code Assist endpoint with the Stitch MCP server attached; captured request payload shows `Unknown name "deprecated" at 'request.tools[0].function_declarations[41].parameters.properties[2].value'`.
- Ran the fixed `normalizeSchemaForCCA` over that exact captured payload: `deprecated` is stripped, parameter descriptions and structure preserved.
- `bun test` on the four schema suites (`schema-normalization`, `schema-compatibility`, `google-tool-schema`, `google-gemini-cli-alignment`): **141 pass, 0 fail**, including the new regression test.
- Built the binary and exercised the same session end-to-end: the Antigravity request completes normally after the fix.

## Personal note

I hit this exact 400 error running omp with the Antigravity model while Stitch MCP was attached, and after this change my same session completes normally.
