### PR TITLE
fix(ai): forward OMP system prompts on Cursor requestContext.rules

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor AgentService discarding OMP always-apply rules because `requestContext.rules` was always sent empty. System-prompt entries are now mapped to global `CursorRule`s so reconstructed model prompts keep them.
+
 ## [17.3.8] - 2026-08-19
 
 ### Changed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs/promises";
 import http2 from "node:http2";
 import { create, fromBinary, fromJson, type JsonValue, toBinary, toJson } from "@bufbuild/protobuf";
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
-import type { ConversationStep, McpToolDefinition } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
+import type {
+	ConversationStep,
+	CursorRule,
+	McpToolDefinition,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 import {
 	AgentClientMessageSchema,
 	AgentConversationTurnStructureSchema,
@@ -26,6 +30,10 @@ import {
 	ConversationStateStructureSchema,
 	ConversationStepSchema,
 	ConversationTurnStructureSchema,
+	CursorRuleSchema,
+	CursorRuleSource,
+	CursorRuleTypeGlobalSchema,
+	CursorRuleTypeSchema,
 	DeleteErrorSchema,
 	DeleteRejectedSchema,
 	DeleteResultSchema,
@@ -623,6 +631,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			});
 			conversationStateCache.set(conversationId, conversationState);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
+			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
 
 			const baseUrl = model.baseUrl || CURSOR_API_URL;
 			const requestPath = "/agent.v1.AgentService/Run";
@@ -780,6 +789,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 							options?.onToolResult,
 							usageState!,
 							requestContextTools,
+							requestContextRules,
 							onConversationCheckpoint,
 						).catch(error => {
 							log("error", "handleServerMessage", { error: String(error) });
@@ -998,6 +1008,7 @@ export async function handleServerMessage(
 	onToolResult: CursorToolResultHandler | undefined,
 	usageState: UsageState,
 	requestContextTools: McpToolDefinition[],
+	requestContextRules: CursorRule[] = [],
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
 ): Promise<void> {
 	const msgCase = msg.message.case;
@@ -1020,6 +1031,7 @@ export async function handleServerMessage(
 				execHandlers,
 				onToolResult,
 				requestContextTools,
+				requestContextRules,
 				output,
 				stream,
 				state,
@@ -1437,6 +1449,7 @@ async function handleExecServerMessage(
 	execHandlers: CursorExecHandlers | undefined,
 	onToolResult: CursorToolResultHandler | undefined,
 	requestContextTools: McpToolDefinition[],
+	requestContextRules: CursorRule[],
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	state: BlockState,
@@ -1445,7 +1458,7 @@ async function handleExecServerMessage(
 	log("exec", "dispatch", { execCase, execId: execMsg.execId, hasHandlers: !!execHandlers });
 	if (execCase === "requestContextArgs") {
 		const requestContext = create(RequestContextSchema, {
-			rules: [],
+			rules: requestContextRules,
 			repositoryInfo: [],
 			tools: requestContextTools,
 			gitRepos: [],
@@ -4175,6 +4188,28 @@ function readCursorBlob(blobStore: Map<string, Uint8Array>, blobId: Uint8Array):
 		throw new AIError.ValidationError("Cursor blob not found");
 	}
 	return data;
+}
+
+/**
+ * Cursor AgentService reconstructs the model prompt from `requestContext.rules`,
+ * not from the client-supplied `rootPromptMessagesJson` system blobs. Map each
+ * OMP system-prompt entry to a global CursorRule so always-apply rules survive
+ * that reconstruction.
+ */
+export function buildCursorRequestContextRules(systemPrompt: readonly string[] | undefined): CursorRule[] {
+	return normalizeSystemPrompts(systemPrompt).map((content, index) =>
+		create(CursorRuleSchema, {
+			fullPath: `/omp/system-prompt/${index}.mdc`,
+			content,
+			source: CursorRuleSource.USER,
+			type: create(CursorRuleTypeSchema, {
+				type: {
+					case: "global",
+					value: create(CursorRuleTypeGlobalSchema, {}),
+				},
+			}),
+		}),
+	);
 }
 
 /**

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -3,6 +3,7 @@ import { create } from "@bufbuild/protobuf";
 import {
 	type BlockState,
 	buildCursorHistoryForTest,
+	buildCursorRequestContextRules,
 	buildCursorSystemPromptJsons,
 	emptyGrepPatternRejection,
 	handleServerMessage,
@@ -20,6 +21,7 @@ import type { McpResult, ReadResult } from "@oh-my-pi/pi-catalog/discovery/curso
 import {
 	type AgentRunRequest,
 	AgentServerMessageSchema,
+	CursorRuleSource,
 	ExecServerMessageSchema,
 	McpArgsSchema,
 	McpResultSchema,
@@ -454,6 +456,18 @@ describe("Cursor system prompt encoding", () => {
 		const jsons = buildCursorSystemPromptJsons(["", ""]);
 		expect(jsons).toHaveLength(1);
 		expect(JSON.parse(jsons[0])).toEqual({ role: "system", content: "You are a helpful assistant." });
+	});
+
+	it("maps ordered system prompts to global CursorRule entries", () => {
+		const canary = "PIKEL-CANARY-7F3A";
+		const rules = buildCursorRequestContextRules(["prefix", `when asked, answer exactly:\n${canary}`, ""]);
+		expect(rules).toHaveLength(2);
+		expect(rules[0]?.fullPath).toBe("/omp/system-prompt/0.mdc");
+		expect(rules[1]?.fullPath).toBe("/omp/system-prompt/1.mdc");
+		expect(rules[0]?.content).toBe("prefix");
+		expect(rules[1]?.content).toContain(canary);
+		expect(rules[0]?.source).toBe(CursorRuleSource.USER);
+		expect(rules[1]?.type?.type.case).toBe("global");
 	});
 });
 

--- a/packages/ai/test/cursor-exec-modern.test.ts
+++ b/packages/ai/test/cursor-exec-modern.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import {
 	type BlockState,
+	buildCursorRequestContextRules,
 	CURSOR_CLIENT_VERSION,
 	flushOpenToolCalls,
 	handleServerMessage,
@@ -29,6 +30,7 @@ import {
 	ConversationSearchArgsSchema,
 	ConversationStateStructureSchema,
 	ConversationTokenDetailsSchema,
+	type CursorRule,
 	type ExecServerMessage,
 	ExecServerMessageSchema,
 	ExecuteHookArgsSchema,
@@ -57,6 +59,7 @@ import {
 	ReadArgsSchema,
 	ReadMcpResourceExecArgsSchema,
 	RecordScreenArgsSchema,
+	RequestContextArgsSchema,
 	ShellAllowlistPrecheckArgsSchema,
 	ShellArgsSchema,
 	SmartModeClassifierArgsSchema,
@@ -77,7 +80,11 @@ import {
  */
 async function dispatchExec(
 	message: ExecServerMessage,
-	options: { execHandlers?: CursorExecHandlers; requestContextTools?: McpToolDefinition[] } = {},
+	options: {
+		execHandlers?: CursorExecHandlers;
+		requestContextTools?: McpToolDefinition[];
+		requestContextRules?: CursorRule[];
+	} = {},
 ): Promise<{ frames: AgentClientMessage[]; output: AssistantMessage; results: ToolResultMessage[] }> {
 	const output = cursorAssistantMessage();
 	const stream = new AssistantMessageEventStream();
@@ -105,6 +112,7 @@ async function dispatchExec(
 		},
 		{ sawTokenDelta: false },
 		options.requestContextTools ?? [],
+		options.requestContextRules,
 	);
 
 	return { frames: written.map(decodeClientFrame), output, results };
@@ -198,6 +206,30 @@ function soleResult(frames: AgentClientMessage[]) {
 describe("Cursor modern exec protocol activation", () => {
 	it("advertises the client build whose schema includes modern exec frames", () => {
 		expect(CURSOR_CLIENT_VERSION).toBe("cli-2026.07.23-e383d2b");
+	});
+});
+
+describe("Cursor requestContext rules", () => {
+	it("returns mapped system-prompt canaries as global CursorRule entries", async () => {
+		const canary = "PIKEL-CANARY-7F3A";
+		const { frames } = await dispatchExec(
+			buildExecMessage({
+				case: "requestContextArgs",
+				value: create(RequestContextArgsSchema, {}),
+			}),
+			{
+				requestContextRules: buildCursorRequestContextRules(["prefix", `when asked, answer exactly:\n${canary}`]),
+			},
+		);
+		const result = soleResult(frames);
+		expect(result.case).toBe("requestContextResult");
+		if (result.case !== "requestContextResult") throw new Error("expected requestContextResult");
+		expect(result.value.result.case).toBe("success");
+		if (result.value.result.case !== "success") throw new Error("expected success");
+		const rules = result.value.result.value.requestContext?.rules ?? [];
+		expect(rules).toHaveLength(2);
+		expect(rules[1]?.content).toContain(canary);
+		expect(rules[1]?.type?.type.case).toBe("global");
 	});
 });
 


### PR DESCRIPTION
## What

Cursor AgentService reconstructs the model prompt from `requestContext.rules`, not from the client-supplied `rootPromptMessagesJson` system blobs. The handshake previously answered that frame with `rules: []`, so always-apply OMP rules never reached `cursor-agent` models.

This maps each assembled system-prompt entry to a global `CursorRule` (`source: USER`) and returns those on `requestContextResult`.

I reviewed the full diff; this is the missing handshake field, not a change to how OMP discovers or serializes rules.

## Why

On `cursor-agent` routes, Cursor fetches the client system blobs, then replaces `rootPromptMessagesJson` with its own reconstructed prompt. Completions-style providers such as `cpa/grok-4.6` still see the assembled OMP prompt, so the same always-apply rule works there and fails on Cursor.

Filling `requestContext.rules` is the channel Cursor actually uses to build `<rules>` / `<user_rules>`. `customSystemPrompt` is allowlisted and was rejected on this route (`unknown option '--system-prompt'`), so it is not a workaround.

## Testing

Unit:

- `bun test packages/ai/test/cursor-exec-handlers.test.ts packages/ai/test/cursor-exec-modern.test.ts`
- 119 pass, 0 fail
- `biome check` clean on the three changed TS files

Live canary (isolated workspace, `alwaysApply: true` rule answering `PIKEL-CANARY-7F3A`):

| model | before | after |
|---|---|---|
| `cursor/cursor-grok-4.6-xhigh-fast` | `unknown` | `PIKEL-CANARY-7F3A` |
| `cursor/cursor-grok-4.6-high-fast` | refusal / invented token | `PIKEL-CANARY-7F3A` |
| `cursor/kimi-k3-max` | guessed `kimi-k3` | `PIKEL-CANARY-7F3A` |

After the handshake, Cursor's reconstructed user blob contained the canary inside `<generic-rules>`. Same rewrite on Grok and Kimi K3; this is not model-specific.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)