### PR TITLE
fix(catalog): recover opencode-go muse-spark thinking levels

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `opencode-go/muse-spark-1.2` and `muse-spark-1.2-contributor` exposing no thinking levels. Live `/zen/go/v1/models` discovery returns bare ids with no capability metadata, and neither id has a bundled `opencode-go` row, so discovery fell back to generic defaults (`reasoning: false` on chat completions) and the effort picker stayed empty. Both ids now resolve to the Responses route with the documented Muse Spark surface (thinking-off plus `minimal`/`low`/`medium`/`high`/`xhigh`, 1M context, 131K max output, and image input), and the OpenCode model-cache namespace is bumped so rows already cached as non-reasoning are refetched.
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -204,6 +204,16 @@ export const isOpenAIGptOssModelId = memo((modelId: string): boolean => {
 	return /(^|\/)gpt-oss[-:]/i.test(modelId);
 });
 
+/**
+ * Meta Muse Spark ids (`muse-spark-1.1`, `muse-spark-1.2`,
+ * `muse-spark-1.2-contributor`, `meta/muse-spark-1.2`). The Responses
+ * `reasoning.effort` wire accepts `none` (thinking-off) plus
+ * `minimal`/`low`/`medium`/`high`/`xhigh`.
+ */
+export const isMuseSparkModelId = memo((modelId: string): boolean => {
+	return /(^|\/)muse-spark(?:[-.]|$)/i.test(modelId);
+});
+
 /** OpenAI model ids (gpt-*, chatgpt-*, o1/o3/o4 SKUs, codex-*, or openai/*). */
 export const isOpenAIModelId = memo((modelId: string): boolean => {
 	return (

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -52,11 +52,13 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 		}
 		case "opencode-go":
 		case "opencode-zen": {
+			// v2: muse-spark-1.2 rows cached before the reasoning/thinking
+			// recovery carry `reasoning: false` and must be refetched.
 			const configuredBaseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
 			const trimmedBaseUrl = configuredBaseUrl.endsWith("/") ? configuredBaseUrl.slice(0, -1) : configuredBaseUrl;
 			const discoveryBaseUrl = trimmedBaseUrl.endsWith("/v1") ? trimmedBaseUrl : `${trimmedBaseUrl}/v1`;
 			const scope = `${options.apiKey ?? ""}\u0000${discoveryBaseUrl}`;
-			return `${providerId}:models-v1:${Bun.hash(scope).toString(36)}`;
+			return `${providerId}:models-v2:${Bun.hash(scope).toString(36)}`;
 		}
 		case "github-copilot": {
 			// Copilot model specs bake in the plan-specific endpoint (personal vs

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -16,6 +16,7 @@ import {
 	isGrokReasoningEffortCapable,
 	isKimiK3ModelId,
 	isKimiModelId,
+	isMuseSparkModelId,
 	isQwen38PlusTemplateEffortModelId,
 	isReasoningGlmModelId,
 } from "../identity/family";
@@ -2515,6 +2516,28 @@ function openCodeModelManagerOptions(
 					mapModel: (entry, defaults) => {
 						const reference = references.get(defaults.id);
 						const name = toModelName(entry.name, reference?.name ?? defaults.name);
+						if (isMuseSparkModelId(defaults.id)) {
+							// Go /zen/go/v1/models lists these as bare ids with no
+							// capability metadata and no local bundled row, so the
+							// generic defaults would hide the effort dial
+							// (`reasoning: false`) and send completions. Pin the
+							// Responses route and the documented
+							// none/minimal/low/medium/high/xhigh surface.
+							const api = "openai-responses" as const;
+							return {
+								...(reference ?? defaults),
+								id: defaults.id,
+								name,
+								api,
+								provider: providerId,
+								baseUrl: openCodeBaseUrlForApi(api, basePath),
+								reasoning: true,
+								input: reference?.input ?? ["text", "image"],
+								thinking: reference?.thinking ?? META_MUSE_SPARK_THINKING,
+								contextWindow: toPositiveNumber(entry.context_length, reference?.contextWindow ?? 1_048_576),
+								maxTokens: toPositiveNumber(entry.max_completion_tokens, reference?.maxTokens ?? 131_072),
+							};
+						}
 						if (!reference) {
 							return {
 								...defaults,

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -12,6 +12,7 @@ import {
 	isKimiModelId,
 	isMinimaxM2FamilyModelId,
 	isMinimaxM3FamilyModelId,
+	isMuseSparkModelId,
 	isOpenAIGptOssModelId,
 	isOpenAIModelId,
 	isQwen38PlusTemplateEffortModelId,
@@ -214,6 +215,22 @@ describe("isMinimaxM3FamilyModelId", () => {
 		expect(isMinimaxM3FamilyModelId("MiniMax-Text-01")).toBe(false);
 		expect(isMinimaxM3FamilyModelId("minimax-music")).toBe(false);
 		expect(isMinimaxM3FamilyModelId("kimi-m3")).toBe(false);
+	});
+});
+
+describe("isMuseSparkModelId", () => {
+	test("matches Muse Spark ids across namespaces and contributor SKUs", () => {
+		expect(isMuseSparkModelId("muse-spark-1.1")).toBe(true);
+		expect(isMuseSparkModelId("muse-spark-1.2")).toBe(true);
+		expect(isMuseSparkModelId("muse-spark-1.2-contributor")).toBe(true);
+		expect(isMuseSparkModelId("meta/muse-spark-1.2")).toBe(true);
+	});
+
+	test("rejects adjacent spark or muse names", () => {
+		expect(isMuseSparkModelId("spark-1.2")).toBe(false);
+		expect(isMuseSparkModelId("muse-1.2")).toBe(false);
+		expect(isMuseSparkModelId("amuse-spark-1.2")).toBe(false);
+		expect(isMuseSparkModelId("gpt-5.3-codex-spark")).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
@@ -66,6 +67,30 @@ describe("OpenCode provider discovery", () => {
 				api: "openai-responses",
 				baseUrl: "https://opencode.ai/zen/go/v1",
 			});
+		}
+	});
+
+	test("recovers muse-spark thinking levels from live OpenCode Go discovery", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-go-muse-"));
+		try {
+			const options = opencodeGoModelManagerOptions({
+				apiKey: "go-account-key",
+				fetch: async () => modelListResponse(["muse-spark-1.2", "muse-spark-1.2-contributor"]),
+			});
+			const result = await resolveProviderModels(
+				{ ...options, cacheDbPath: path.join(tempDir, "models.db") },
+				"online-if-uncached",
+			);
+			const expected = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+			for (const id of ["muse-spark-1.2", "muse-spark-1.2-contributor"]) {
+				const model = result.models.find(item => item.id === id);
+				expect(model?.api).toBe("openai-responses");
+				expect(model?.reasoning).toBe(true);
+				expect(model?.thinking?.efforts).toEqual(expected);
+				expect(model?.thinking?.requiresEffort).toBeUndefined();
+			}
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
this is a fix for opencode go thinking levels for muse spark 1.2, it also fixes an issue with responses giving an error after every turn. -unrvl

## What

`opencode-go/muse-spark-1.2` and `opencode-go/muse-spark-1.2-contributor` surfaced in OMP with no thinking levels at all.

Live `/zen/go/v1/models` discovery returns bare ids with no capability metadata, and neither id has a bundled `opencode-go` row (both postdate the bundled snapshot). So `openCodeModelManagerOptions` fell through to the generic discovery defaults, `reasoning: false` on `openai-completions`. `getSupportedEfforts()` then returned `[]`, which is why the effort picker was empty.

Both ids now resolve on the live-discovery path to the Responses route with the documented Muse Spark surface: thinking-off plus `minimal`/`low`/`medium`/`high`/`xhigh`, 1M context, 131K max output, and image input. The OpenCode model-cache namespace moves to `models-v2` so rows already cached as non-reasoning get refetched instead of pinning an empty picker for the cache TTL.

## Why

Related: #8957, #8963.

The triage comment on #8963 names the same code path this PR changes: "`openCodeModelManagerOptions` defaults live-discovered models with no bundled reference to the discovery api (`openai-completions`), which is why it currently errors."

A `bun run gen:models` refresh would also land these rows, but only until the next model ships ahead of the snapshot; this is the second muse-spark report with that same shape. Recovering the capability metadata in the discovery mapper fixes it without depending on regen timing or on generation-time credentials, and it follows the existing precedent for discovery rows that arrive without metadata (GMI Cloud canonical-index recovery in #8890, Cursor Grok reasoning classification in #8803).

No `models.json` regen is included, so there is no generated diff noise. The fix is runtime-only.

### Scope note

I deliberately did **not** add an identity-level effort ladder in `model-thinking.ts`. I tried that first and reverted it: `getModelDefinedEfforts()` is host-agnostic, so it would have flipped `openrouter/meta/muse-spark-1.1` and `-1.2` from `minimal,low,medium,high` to `+xhigh`, and overridden the `vercel-ai-gateway` anthropic-messages ladder, on the next regen. I have no evidence OpenRouter's route accepts `xhigh`, and this repo keeps those ladders host-aware on purpose (see the GLM-5.2 and DeepSeek OpenRouter carve-outs in the same function). The explicit thinking config from the mapper already survives `fillThinkingWireDefaults()` because `getModelDefinedEfforts()` returns `undefined` for these ids, so the branch was redundant as well as risky.

## Testing

Reproduced the reported symptom and confirmed it no longer occurs, driving the real `resolveProviderModels` live-discovery path against a stubbed `/zen/go/v1/models` that returns the bare rows the gateway actually sends:

```
=== BEFORE (generic discovery defaults) ===
  muse-spark-1.2: api=openai-completions reasoning=false levels=[]
  muse-spark-1.2-contributor: api=openai-completions reasoning=false levels=[]
=== AFTER (live discovery through fixed mapper) ===
  muse-spark-1.2: api=openai-responses reasoning=true levels=[minimal,low,medium,high,xhigh] thinkingOffAllowed=true ctx=1048576 max=131072 input=[text,image]
  muse-spark-1.2-contributor: api=openai-responses reasoning=true levels=[minimal,low,medium,high,xhigh] thinkingOffAllowed=true ctx=1048576 max=131072 input=[text,image]
  cacheProviderId=opencode-go:models-v2:29qx5g1j9maaw
```

`levels=[]` is the reported bug (empty picker); `thinkingOffAllowed=true` is the `none` option.

Automated:

- `bun test packages/catalog`: 616 pass, 0 fail across 82 files.
- `bun check` (root and `packages/catalog`): passes.
- New `test("recovers muse-spark thinking levels from live OpenCode Go discovery")` asserts api, `reasoning`, the effort ladder, and that thinking-off stays available, end to end through `resolveProviderModels`.
- New `isMuseSparkModelId` unit coverage, including negative cases for `gpt-5.3-codex-spark`, `muse-1.2`, and `spark-1.2`.

Verified separately that no bundled `models.json` row changes as a result of this PR: the only muse-spark ladders in the bundle belong to `meta`, `kilo`, `nanogpt`, `opencode-zen`, `openrouter`, `vercel-ai-gateway`, and `zenmux`, and none of them are touched.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
