### PR TITLE
fix(retry): reach a fallback model's own chain instead of burning the budget on it

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1490,6 +1490,8 @@ export class AgentSession {
 				this.#maintenance.resolveCompactionModelCandidates(model, availableModels),
 			resolveRetryFallbackRole: (selector, model, roleHint) =>
 				this.#recovery.resolveRetryFallbackRole(selector, model, roleHint),
+			retryFallbackChainKeys: (selector, model, options) =>
+				this.#recovery.retryFallbackChainKeys(selector, model, options),
 			findRetryFallbackCandidates: (role, selector, model) =>
 				this.#recovery.findRetryFallbackCandidates(role, selector, model),
 			isRetryFallbackSelectorSuppressed: selector => this.#recovery.isRetryFallbackSelectorSuppressed(selector),

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -267,6 +267,11 @@ export interface SessionAdvisorsHost {
 		currentModel?: Model | null,
 		roleHint?: string,
 	): string | undefined;
+	retryFallbackChainKeys(
+		currentSelector: string,
+		currentModel?: Model | null,
+		options?: { pinnedRole?: string; roleHint?: string },
+	): string[];
 	findRetryFallbackCandidates(
 		role: string,
 		currentSelector: string,
@@ -1240,43 +1245,54 @@ export class SessionAdvisors {
 
 		const retrySettings = this.#host.settings.getGroup("retry");
 		if (!retrySettings.enabled || !retrySettings.modelFallback) return false;
-		const role =
-			advisor.retryFallback?.role ?? this.#host.resolveRetryFallbackRole(currentSelector, currentModel, "advisor");
-		if (!role || this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length === 0)
+		// Same two-key walk the main loop uses: the chain that owns this advisor's
+		// active fallback, then the chain the current model owns. Without the
+		// second key an advisor that lands on the last entry of one chain never
+		// reaches that entry's own chain and re-hits the dead model instead.
+		const chainKeys = this.#host.retryFallbackChainKeys(currentSelector, currentModel, {
+			pinnedRole: advisor.retryFallback?.role,
+			roleHint: "advisor",
+		});
+		if (
+			!chainKeys.some(role => this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length > 0)
+		) {
 			return false;
+		}
 
 		this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
-		for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
-			if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
-			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
-			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
-			if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, { signal });
-			if (!apiKey) continue;
-			signal.throwIfAborted();
+		for (const role of chainKeys) {
+			for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
+				if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
+				const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
+				const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
+				if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
+				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, { signal });
+				if (!apiKey) continue;
+				signal.throwIfAborted();
 
-			const originalThinkingLevel = advisor.thinkingLevel;
-			const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
-			const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
-			if (advisor.retryFallback) {
-				advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
-			} else {
-				advisor.retryFallback = {
+				const originalThinkingLevel = advisor.thinkingLevel;
+				const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
+				const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
+				if (advisor.retryFallback) {
+					advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
+				} else {
+					advisor.retryFallback = {
+						role,
+						originalSelector: currentSelector,
+						originalThinkingLevel,
+						lastAppliedThinkingLevel: nextThinkingLevel,
+					};
+				}
+				advisor.retryFallbackPendingSuccess = true;
+				this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
+				await this.#host.emitSessionEvent({
+					type: "retry_fallback_applied",
+					from: currentSelector,
+					to: selector.raw,
 					role,
-					originalSelector: currentSelector,
-					originalThinkingLevel,
-					lastAppliedThinkingLevel: nextThinkingLevel,
-				};
+				});
+				return true;
 			}
-			advisor.retryFallbackPendingSuccess = true;
-			this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
-			await this.#host.emitSessionEvent({
-				type: "retry_fallback_applied",
-				from: currentSelector,
-				to: selector.raw,
-				role,
-			});
-			return true;
 		}
 		return false;
 	}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1327,12 +1327,13 @@ export class TurnRecovery {
 	 * alternate models instead of looping in place, and every hop still spends a
 	 * retry attempt, so the budget terminates either way.
 	 */
-	#retryFallbackChainKeys(
+	retryFallbackChainKeys(
 		currentSelector: string,
 		currentModel: Model | null | undefined = this.#host.model(),
+		options?: { pinnedRole?: string; roleHint?: string },
 	): string[] {
-		const pinned = this.#activeRetryFallback?.role;
-		const current = this.resolveRetryFallbackRole(currentSelector, currentModel);
+		const pinned = options?.pinnedRole ?? this.#activeRetryFallback?.role;
+		const current = this.resolveRetryFallbackRole(currentSelector, currentModel, options?.roleHint);
 		if (!pinned) return current ? [current] : [];
 		return current && current !== pinned ? [pinned, current] : [pinned];
 	}
@@ -1414,7 +1415,7 @@ export class TurnRecovery {
 
 		let fallback: { role: string; selector: RetryFallbackSelector; apiKey: string } | undefined;
 		const ceiling = this.#host.thinkingLevelCeiling();
-		const chainKeys = this.#retryFallbackChainKeys(currentSelector, currentModel);
+		const chainKeys = this.retryFallbackChainKeys(currentSelector, currentModel);
 		for (const role of chainKeys) {
 			for (const candidate of this.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
 				if (this.isRetryFallbackSelectorSuppressed(candidate)) continue;
@@ -1608,7 +1609,7 @@ export class TurnRecovery {
 		const latestAssistant = this.#host.agent.state.messages.findLast(
 			(message): message is AssistantMessage => message.role === "assistant" && message !== failedMessage,
 		);
-		for (const role of this.#retryFallbackChainKeys(currentSelector)) {
+		for (const role of this.retryFallbackChainKeys(currentSelector)) {
 			for (const selector of this.findRetryFallbackCandidates(role, currentSelector)) {
 				if (this.isRetryFallbackSelectorSuppressed(selector)) continue;
 				const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
@@ -1713,7 +1714,7 @@ export class TurnRecovery {
 		if (AIError.isContextOverflow(message, model.contextWindow ?? 0)) return false;
 		if (this.#hasReplayUnsafeOutput(message)) return false;
 		const currentSelector = formatRetryFallbackSelector(model, this.#host.thinkingLevel());
-		return this.#retryFallbackChainKeys(currentSelector).some(
+		return this.retryFallbackChainKeys(currentSelector).some(
 			role => this.findRetryFallbackCandidates(role, currentSelector).length > 0,
 		);
 	}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1310,6 +1310,33 @@ export class TurnRecovery {
 		);
 	}
 
+	/**
+	 * Chain keys to consult for the active model, most specific walk first: the
+	 * chain that owns the current fallback walk, then the chain the CURRENT model
+	 * owns when that is a different key.
+	 *
+	 * The second key is what makes a chain reachable from the end of another one.
+	 * `#activeRetryFallback.role` is pinned at the first hop and never
+	 * re-resolved, so a session that lands on the last entry of one chain has no
+	 * candidate left and retries the same model until the budget is gone — even
+	 * when that entry is itself a chain key with its own fallbacks configured
+	 * (`anthropic/claude-opus-5 -> … -> runinfra/deepseek-v4-pro`, whose own
+	 * `runinfra/deepseek-v4-pro -> openrouter/deepseek/…` chain was unreachable).
+	 *
+	 * Two keys is the whole walk per attempt. Chains that point at each other
+	 * alternate models instead of looping in place, and every hop still spends a
+	 * retry attempt, so the budget terminates either way.
+	 */
+	#retryFallbackChainKeys(
+		currentSelector: string,
+		currentModel: Model | null | undefined = this.#host.model(),
+	): string[] {
+		const pinned = this.#activeRetryFallback?.role;
+		const current = this.resolveRetryFallbackRole(currentSelector, currentModel);
+		if (!pinned) return current ? [current] : [];
+		return current && current !== pinned ? [pinned, current] : [pinned];
+	}
+
 	/** Finds fallback candidates that follow the active selector. */
 	findRetryFallbackCandidates(
 		role: string,
@@ -1385,62 +1412,64 @@ export class TurnRecovery {
 		}
 		if (!this.#host.settings.get("retry.modelFallback")) return false;
 
-		const role = this.#activeRetryFallback?.role ?? this.resolveRetryFallbackRole(currentSelector, currentModel);
-		if (!role) return false;
-		let fallback: { selector: RetryFallbackSelector; apiKey: string } | undefined;
+		let fallback: { role: string; selector: RetryFallbackSelector; apiKey: string } | undefined;
 		const ceiling = this.#host.thinkingLevelCeiling();
-		for (const candidate of this.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
-			if (this.isRetryFallbackSelectorSuppressed(candidate)) continue;
-			const resolved = resolveModelOverride([candidate.raw], this.#host.modelRegistry, this.#host.settings);
-			const candidateModel = resolved.model ?? this.#host.modelRegistry.find(candidate.provider, candidate.id);
-			if (!candidateModel || !this.#host.modelRegistry.hasConfiguredAuth(candidateModel)) continue;
-			if (ceiling !== undefined && !modelSupportsEffortCeiling(candidateModel, ceiling)) continue;
-			// A usage fallback must also fit: skip a candidate whose window cannot
-			// hold the live context so we never switch onto an oversized request
-			// (issue #8065).
-			if (!this.#host.contextFitsModel(candidateModel)) continue;
-			try {
-				const candidateHealth = await this.#host.modelRegistry.authStorage.getModelUsageHealth(
-					candidateModel.provider,
-					{
-						modelId: candidateModel.id,
-						sessionId: this.#host.sessionId(),
-						baseUrl: candidateModel.baseUrl,
-						reserveFraction: this.#host.settings.get("retry.usageReservePct") / 100,
-						signal,
-					},
-				);
-				if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
-				if (candidateHealth.state === "depleted" || candidateHealth.state === "reserve") continue;
-				if (candidateHealth.state === "healthy") {
-					const selected = candidateHealth.accounts.find(account => account.selected);
-					if (
-						selected &&
-						selected.state !== "healthy" &&
-						candidateHealth.accounts.some(account => account.state === "healthy")
-					) {
-						this.#host.modelRegistry.authStorage.releaseSessionCredentialForReselection(
-							candidateModel.provider,
-							this.#host.sessionId(),
-						);
+		const chainKeys = this.#retryFallbackChainKeys(currentSelector, currentModel);
+		for (const role of chainKeys) {
+			for (const candidate of this.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
+				if (this.isRetryFallbackSelectorSuppressed(candidate)) continue;
+				const resolved = resolveModelOverride([candidate.raw], this.#host.modelRegistry, this.#host.settings);
+				const candidateModel = resolved.model ?? this.#host.modelRegistry.find(candidate.provider, candidate.id);
+				if (!candidateModel || !this.#host.modelRegistry.hasConfiguredAuth(candidateModel)) continue;
+				if (ceiling !== undefined && !modelSupportsEffortCeiling(candidateModel, ceiling)) continue;
+				// A usage fallback must also fit: skip a candidate whose window cannot
+				// hold the live context so we never switch onto an oversized request
+				// (issue #8065).
+				if (!this.#host.contextFitsModel(candidateModel)) continue;
+				try {
+					const candidateHealth = await this.#host.modelRegistry.authStorage.getModelUsageHealth(
+						candidateModel.provider,
+						{
+							modelId: candidateModel.id,
+							sessionId: this.#host.sessionId(),
+							baseUrl: candidateModel.baseUrl,
+							reserveFraction: this.#host.settings.get("retry.usageReservePct") / 100,
+							signal,
+						},
+					);
+					if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
+					if (candidateHealth.state === "depleted" || candidateHealth.state === "reserve") continue;
+					if (candidateHealth.state === "healthy") {
+						const selected = candidateHealth.accounts.find(account => account.selected);
+						if (
+							selected &&
+							selected.state !== "healthy" &&
+							candidateHealth.accounts.some(account => account.state === "healthy")
+						) {
+							this.#host.modelRegistry.authStorage.releaseSessionCredentialForReselection(
+								candidateModel.provider,
+								this.#host.sessionId(),
+							);
+						}
 					}
+				} catch {
+					if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
+					// Unknown usage fails open for an otherwise valid fallback.
 				}
-			} catch {
 				if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
-				// Unknown usage fails open for an otherwise valid fallback.
-			}
-			if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
-			let apiKey: string | undefined;
-			try {
-				apiKey = await this.#host.modelRegistry.getApiKey(candidateModel, this.#host.sessionId(), { signal });
-			} catch {
+				let apiKey: string | undefined;
+				try {
+					apiKey = await this.#host.modelRegistry.getApiKey(candidateModel, this.#host.sessionId(), { signal });
+				} catch {
+					if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
+					continue;
+				}
 				if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
-				continue;
+				if (!apiKey) continue;
+				fallback = { role, selector: candidate, apiKey };
+				break;
 			}
-			if (signal.aborted || !modelsAreEqual(this.#host.model(), currentModel)) return false;
-			if (!apiKey) continue;
-			fallback = { selector: candidate, apiKey };
-			break;
+			if (fallback) break;
 		}
 		if (!fallback) return false;
 
@@ -1468,7 +1497,7 @@ export class TurnRecovery {
 			return false;
 		}
 		this.#usageReserveApprovedSelector = undefined;
-		return this.applyRetryFallbackCandidate(role, fallback.selector, currentSelector, {
+		return this.applyRetryFallbackCandidate(fallback.role, fallback.selector, currentSelector, {
 			pinFallback: true,
 			apiKey: fallback.apiKey,
 			signal,
@@ -1575,46 +1604,45 @@ export class TurnRecovery {
 		failedMessage: AssistantMessage,
 		options?: { pinFallback?: boolean },
 	): Promise<boolean> {
-		const role = this.#activeRetryFallback?.role ?? this.resolveRetryFallbackRole(currentSelector);
-		if (!role) return false;
-
 		const ceiling = this.#host.thinkingLevelCeiling();
 		const latestAssistant = this.#host.agent.state.messages.findLast(
 			(message): message is AssistantMessage => message.role === "assistant" && message !== failedMessage,
 		);
-		for (const selector of this.findRetryFallbackCandidates(role, currentSelector)) {
-			if (this.isRetryFallbackSelectorSuppressed(selector)) continue;
-			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
-			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
-			if (!candidate) continue;
-			// Anthropic signatures and redacted blocks are model-bound, while the
-			// latest assistant response must remain byte-identical. A same-provider
-			// model switch can satisfy neither constraint, so keep retrying the
-			// source model or consider a later cross-provider candidate whose
-			// message transform can safely demote the foreign thinking.
-			if (
-				candidate.api === "anthropic-messages" &&
-				latestAssistant?.api === "anthropic-messages" &&
-				latestAssistant.provider === candidate.provider &&
-				latestAssistant.model !== candidate.id &&
-				latestAssistant.content.some(
-					block =>
-						(block.type === "thinking" && Boolean(block.thinkingSignature?.trim())) ||
-						block.type === "redactedThinking",
-				)
-			) {
-				continue;
+		for (const role of this.#retryFallbackChainKeys(currentSelector)) {
+			for (const selector of this.findRetryFallbackCandidates(role, currentSelector)) {
+				if (this.isRetryFallbackSelectorSuppressed(selector)) continue;
+				const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
+				const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
+				if (!candidate) continue;
+				// Anthropic signatures and redacted blocks are model-bound, while the
+				// latest assistant response must remain byte-identical. A same-provider
+				// model switch can satisfy neither constraint, so keep retrying the
+				// source model or consider a later cross-provider candidate whose
+				// message transform can safely demote the foreign thinking.
+				if (
+					candidate.api === "anthropic-messages" &&
+					latestAssistant?.api === "anthropic-messages" &&
+					latestAssistant.provider === candidate.provider &&
+					latestAssistant.model !== candidate.id &&
+					latestAssistant.content.some(
+						block =>
+							(block.type === "thinking" && Boolean(block.thinkingSignature?.trim())) ||
+							block.type === "redactedThinking",
+					)
+				) {
+					continue;
+				}
+				// A candidate whose effort floor exceeds the per-spawn ceiling would be
+				// clamped UP past the cap by its model floor — skip it entirely.
+				if (ceiling !== undefined && !modelSupportsEffortCeiling(candidate, ceiling)) continue;
+				// Skip a candidate whose window cannot hold the retry context. The
+				// failed assistant is removed before continue(), so exclude it here to
+				// judge the request that will actually be sent (issue #8065).
+				if (!this.#host.contextFitsModel(candidate, failedMessage)) continue;
+				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
+				if (!apiKey) continue;
+				return this.applyRetryFallbackCandidate(role, selector, currentSelector, options);
 			}
-			// A candidate whose effort floor exceeds the per-spawn ceiling would be
-			// clamped UP past the cap by its model floor — skip it entirely.
-			if (ceiling !== undefined && !modelSupportsEffortCeiling(candidate, ceiling)) continue;
-			// Skip a candidate whose window cannot hold the retry context. The
-			// failed assistant is removed before continue(), so exclude it here to
-			// judge the request that will actually be sent (issue #8065).
-			if (!this.#host.contextFitsModel(candidate, failedMessage)) continue;
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
-			if (!apiKey) continue;
-			return this.applyRetryFallbackCandidate(role, selector, currentSelector, options);
 		}
 
 		return false;
@@ -1685,9 +1713,9 @@ export class TurnRecovery {
 		if (AIError.isContextOverflow(message, model.contextWindow ?? 0)) return false;
 		if (this.#hasReplayUnsafeOutput(message)) return false;
 		const currentSelector = formatRetryFallbackSelector(model, this.#host.thinkingLevel());
-		const role = this.#activeRetryFallback?.role ?? this.resolveRetryFallbackRole(currentSelector);
-		if (!role) return false;
-		return this.findRetryFallbackCandidates(role, currentSelector).length > 0;
+		return this.#retryFallbackChainKeys(currentSelector).some(
+			role => this.findRetryFallbackCandidates(role, currentSelector).length > 0,
+		);
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1662,6 +1662,100 @@ describe("AgentSession retry fallback", () => {
 		});
 	});
 
+	it("hops an advisor to the chain owned by the fallback it landed on", async () => {
+		const mainModel = getBundledModel("openai", "gpt-4o-mini");
+		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const advisorFallback = getBundledModel("google", "gemini-2.5-flash");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!mainModel || !advisorPrimary || !advisorFallback || !secondFallback) {
+			throw new Error("Expected bundled advisor fallback models to exist");
+		}
+
+		const mainMock = createMockModel({ responses: [{ content: ["Primary complete"] }] });
+		const advisorMock = createMockModel();
+		const requestedAdvisorModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const fallbackSucceeded = Promise.withResolvers<void>();
+		const advisorPrimarySelector = `${advisorPrimary.provider}/${advisorPrimary.id}`;
+		const advisorRoleSelector = `${advisorPrimarySelector}:high`;
+		const advisorFallbackSelector = `${advisorFallback.provider}/${advisorFallback.id}`;
+		const secondFallbackSelector = `${secondFallback.provider}/${secondFallback.id}`;
+
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: mainModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: mainMock.stream,
+		});
+		// The advisor role chain ends at the first fallback, which owns a chain of
+		// its own. Reaching the second requires re-resolving from the live model.
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": {
+				advisor: [advisorFallbackSelector],
+				[advisorFallbackSelector]: [secondFallbackSelector],
+			},
+			"advisor.syncBacklog": "1",
+		});
+		settings.setModelRole("advisor", advisorRoleSelector);
+		vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: false });
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorConfigs: [{ name: "chain-hop-test", model: advisorRoleSelector }],
+			advisorStreamFn: (model, context, options) => {
+				const selector = `${model.provider}/${model.id}`;
+				requestedAdvisorModels.push(selector);
+				if (selector === advisorPrimarySelector || selector === advisorFallbackSelector) {
+					advisorMock.push({ throw: "overloaded_error: provider returned error 503" });
+				} else if (selector === secondFallbackSelector) {
+					advisorMock.push({ content: ["Advisor recovered on the second chain"] });
+				} else {
+					throw new Error(`Unexpected advisor model requested: ${selector}`);
+				}
+				return advisorMock.stream(model, context, options);
+			},
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") fallbackAppliedEvents.push(event);
+			if (event.type === "retry_fallback_succeeded") fallbackSucceeded.resolve();
+		});
+
+		session.setAdvisorEnabled(true);
+		await session.prompt("Complete one primary turn");
+		await session.waitForIdle();
+		await fallbackSucceeded.promise;
+
+		expect(requestedAdvisorModels).toEqual([advisorPrimarySelector, advisorFallbackSelector, secondFallbackSelector]);
+		expect(session.getAdvisorAgent()?.state.model).toMatchObject({
+			provider: secondFallback.provider,
+			id: secondFallback.id,
+		});
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: advisorRoleSelector,
+				to: advisorFallbackSelector,
+				role: "advisor",
+			},
+			{
+				type: "retry_fallback_applied",
+				from: `${advisorFallbackSelector}:high`,
+				to: secondFallbackSelector,
+				role: advisorFallbackSelector,
+			},
+		]);
+	});
+
 	it("ignores late advisor fallback credentials after a session transition", async () => {
 		const mainModel = getBundledModel("openai", "gpt-4o-mini");
 		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -305,6 +305,93 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("hops to the chain owned by a fallback that is the last entry of the chain it came from", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !firstFallback || !secondFallback) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === primaryModel.provider && model.id === primaryModel.id) {
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
+				} else if (model.provider === firstFallback.provider && model.id === firstFallback.id) {
+					mock.push({ throw: "503 Hosted inference is temporarily unavailable" });
+				} else if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+					mock.push({ content: ["Recovered on the second chain"] });
+				} else {
+					throw new Error(`Unexpected model requested during chain-hop test: ${model.provider}/${model.id}`);
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		// Two chains, joined only by their shared entry: the role chain ends at
+		// the first fallback, which is itself a chain key. Reaching the second
+		// fallback requires re-resolving the chain for the active model.
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": {
+				default: [`${firstFallback.provider}/${firstFallback.id}`],
+				[`${firstFallback.provider}/${firstFallback.id}`]: [`${secondFallback.provider}/${secondFallback.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Recover across two chains");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${secondFallback.provider}/${secondFallback.id}`,
+		]);
+		expect(session.model?.provider).toBe(secondFallback.provider);
+		expect(session.model?.id).toBe(secondFallback.id);
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${firstFallback.provider}/${firstFallback.id}`,
+				role: "default",
+			},
+			{
+				type: "retry_fallback_applied",
+				from: `${firstFallback.provider}/${firstFallback.id}`,
+				to: `${secondFallback.provider}/${secondFallback.id}`,
+				role: `${firstFallback.provider}/${firstFallback.id}`,
+			},
+		]);
+	});
+
 	it("keeps non-Gemini empty-body errors on the model-fallback path", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");


### PR DESCRIPTION
## Summary

A fallback chain's last entry can be a chain key with its own fallbacks configured. Those fallbacks are unreachable today, and the retry budget burns on the dead model instead.

`#activeRetryFallback.role` is set on the first hop and never re-resolved, so every later hop walks that same chain. Reach the last entry and there are no candidates left, so the loop retries the current model until the budget is gone.

Config from the session that hit this:

```yaml
retry:
  fallbackChains:
    anthropic/claude-opus-5:
      - anthropic-2/claude-opus-5
      - openai-codex/gpt-5.6-terra
      - runinfra/deepseek-v4-pro
    runinfra/deepseek-v4-pro:
      - openrouter/deepseek/deepseek-v4-pro-0813
```

A 429 on Opus walked the first chain down to `runinfra/deepseek-v4-pro`, which was mid-outage. Ten retries of 503s and stream timeouts later the turn died with `Retry budget exhausted`. The OpenRouter leg never got a request.

## Fix

`#retryFallbackChainKeys()` returns the chain that owns the active walk, then the chain the current model owns when that resolves to a different key. Three call sites consult both: the usage-aware fallback, the retry fallback, and the hard-error eligibility check.

Two keys is the whole walk per attempt, so this doesn't open a search. Chains that point at each other alternate models rather than looping in place, and each hop still spends a retry attempt, so the budget terminates either way.

## Tests

167 pass, 0 fail across the seven retry suites. `biome check .` and `tsgo --noEmit` both exit 0, run as separate legs.

One new test in `agent-session-retry-fallback.test.ts` covers the two-chain case. Without the fix it records 9 extra requests to the dead fallback instead of 1 hop, which is the exhaustion shape above.

https://claude.ai/code/session_0142iDTa611rxnapRL4Kmgp8
