### PR TITLE
fix(providers): refresh LM Studio runtime context after JIT load

### DIFF
--- a/packages/ai/src/providers/mock.ts
+++ b/packages/ai/src/providers/mock.ts
@@ -137,6 +137,8 @@ export interface MockModelOptions {
 	id?: string;
 	/** Provider string used in the returned AssistantMessage. Defaults to `"mock"`. */
 	provider?: string;
+	/** Base URL reported by the model. Defaults to `"mock://"`. */
+	baseUrl?: string;
 	/** A sequence of responses, one per call. Accepts arrays, generators, or any iterable. */
 	responses?: MockResponseSource;
 	/** Fallback handler used when `responses` is exhausted. */
@@ -168,7 +170,7 @@ export class MockModel implements Model<MockApi> {
 	readonly name: string;
 	readonly api: MockApi = MOCK_API;
 	readonly provider: string;
-	readonly baseUrl = "mock://";
+	readonly baseUrl: string;
 	readonly reasoning: boolean;
 	readonly input: ("text" | "image")[] = ["text"];
 	readonly cost: Model["cost"];
@@ -189,6 +191,7 @@ export class MockModel implements Model<MockApi> {
 		this.id = options.id ?? "mock-model";
 		this.name = options.id ?? "mock-model";
 		this.provider = options.provider ?? "mock";
+		this.baseUrl = options.baseUrl ?? "mock://";
 		this.reasoning = options.reasoning ?? false;
 		this.cost = options.cost ?? ZERO_COST;
 		this.contextWindow = options.contextWindow ?? 200_000;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed LM Studio models keeping their architectural `max_context_length` after a JIT load served a smaller `loaded_context_length`, so context accounting and compaction ran against a window larger than the backend actually served. `ModelRegistry.refreshSelectedModelMetadata` only re-probed runtime metadata for llama.cpp; it now also re-probes LM Studio's native `/api/v0/models` for the selected model (via the existing `loaded_context_length`-preferring resolution) on selection/first use, and re-derives the window on a later unload rather than retaining the stale runtime value ([#9001](https://github.com/can1357/oh-my-pi/issues/9001)).
+- Fixed LM Studio models keeping their architectural `max_context_length` after a JIT load served a smaller `loaded_context_length`, so context accounting and compaction ran against a window larger than the backend actually served. `ModelRegistry.refreshSelectedModelMetadata` now re-probes LM Studio's native `/api/v0/models` (via the existing `loaded_context_length`-preferring resolution) in addition to llama.cpp, and — because a model is still unloaded at selection time and only JIT-loads during the first request — the session now re-probes and folds the runtime window into the live model after the first successful inference of a lazy-load local model, without a provider-session reset ([#9001](https://github.com/can1357/oh-my-pi/issues/9001)).
 
 ## [17.3.8] - 2026-08-19
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LM Studio models keeping their architectural `max_context_length` after a JIT load served a smaller `loaded_context_length`, so context accounting and compaction ran against a window larger than the backend actually served. `ModelRegistry.refreshSelectedModelMetadata` only re-probed runtime metadata for llama.cpp; it now also re-probes LM Studio's native `/api/v0/models` for the selected model (via the existing `loaded_context_length`-preferring resolution) on selection/first use, and re-derives the window on a later unload rather than retaining the stale runtime value ([#9001](https://github.com/can1357/oh-my-pi/issues/9001)).
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -182,7 +182,7 @@ type LlamaCppDiscoveredServerMetadata = {
 	maxTokens?: "contextWindow";
 };
 
-type LlamaCppDiscoveredModelRuntimeMetadata = {
+type DiscoveredModelRuntimeMetadata = {
 	contextWindow?: number;
 	maxTokens?: number;
 	input?: ("text" | "image")[];
@@ -669,7 +669,7 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 	model: Pick<Model<Api>, "provider" | "id" | "baseUrl" | "headers">,
 	ctx: DiscoveryContext,
 	customTimeoutMs?: number,
-): Promise<LlamaCppDiscoveredModelRuntimeMetadata | undefined> {
+): Promise<DiscoveredModelRuntimeMetadata | undefined> {
 	const baseUrl = normalizeLlamaCppBaseUrl(model.baseUrl);
 	// Probe the native `/models` endpoint (not the OpenAI-compatible `/v1/models`)
 	// so the runtime `meta`, `status.args`, and `architecture.input_modalities`
@@ -712,6 +712,61 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 			contextWindow,
 			maxTokens: resolveLlamaCppMaxTokens(contextWindow, serverMetadata?.maxTokens),
 			...(input !== undefined ? { input } : {}),
+		};
+	};
+	try {
+		const apiKey = await ctx.getBearerApiKeyResolver(model.provider);
+		return apiKey
+			? await withAuth(apiKey, key => attempt({ ...baseHeaders, Authorization: `Bearer ${key}` }))
+			: await attempt(baseHeaders);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Re-probe LM Studio's native `/api/v0/models` for a single selected model so
+ * its context window tracks the runtime lifecycle rather than the snapshot
+ * captured at discovery time.
+ *
+ * A model discovered while unloaded is registered with `max_context_length`
+ * (the architectural ceiling). When LM Studio JIT-loads it on first inference,
+ * the running instance may serve a smaller `loaded_context_length` (user load
+ * settings or context auto-fit). `getLmStudioNativeContextWindow` — invoked
+ * inside `fetchLmStudioNativeModelMetadata` — prefers `loaded_context_length`
+ * once `state === "loaded"`, so refreshing after selection swaps the stale
+ * ceiling for the window the backend actually accepts (issue #9001). A later
+ * unload re-probes back to `max_context_length`. This mirrors the llama.cpp
+ * lazy-load refresh from #3310/#3311.
+ *
+ * `maxTokens` is carried through so the caller can re-cap output at the new
+ * (possibly smaller) window; LM Studio native metadata reports no output cap
+ * of its own.
+ */
+export async function discoverLmStudioModelRuntimeMetadata(
+	model: Pick<Model<Api>, "provider" | "id" | "baseUrl" | "headers" | "maxTokens">,
+	ctx: DiscoveryContext,
+	customTimeoutMs?: number,
+): Promise<DiscoveredModelRuntimeMetadata | undefined> {
+	const baseUrl = normalizeOpenAIModelsListBaseUrl(model.baseUrl);
+	const timeoutMs = customTimeoutMs ?? 10_000;
+	const baseHeaders: Record<string, string> = { ...(model.headers ?? {}) };
+	const attempt = async (headers: Record<string, string>) => {
+		const metadata = await withTimeoutSignal(timeoutMs, signal =>
+			fetchLmStudioNativeModelMetadata(baseUrl, ctx.fetch, { headers, signal }),
+		);
+		const entry = metadata?.get(model.id);
+		if (!entry) {
+			return undefined;
+		}
+		const contextWindow = entry.contextWindow;
+		if (contextWindow === undefined) {
+			return entry.input === undefined ? undefined : { input: entry.input };
+		}
+		return {
+			contextWindow,
+			...(typeof model.maxTokens === "number" ? { maxTokens: model.maxTokens } : {}),
+			...(entry.input !== undefined ? { input: entry.input } : {}),
 		};
 	};
 	try {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -60,6 +60,7 @@ import {
 	type DiscoveryContext,
 	type DiscoveryProviderConfig,
 	discoverLlamaCppModelRuntimeMetadata,
+	discoverLmStudioModelRuntimeMetadata,
 	discoverModelsByProviderType,
 	ensureLlamaCppV1BaseUrl,
 	getImplicitOllamaBaseUrl,
@@ -333,20 +334,35 @@ export class ModelRegistry {
 
 	/**
 	 * Refresh dynamic metadata that can appear only after a local model loads.
+	 *
+	 * llama.cpp exposes `meta.n_ctx` once a lazy-loaded instance is up
+	 * (#3310/#3311); LM Studio exposes `loaded_context_length` once it JIT-loads
+	 * the model on first inference (#9001). Both are captured only as a snapshot
+	 * at discovery time, so re-probe the selected model's native runtime metadata
+	 * and patch its context window to what the backend actually serves.
 	 */
 	async refreshSelectedModelMetadata(model: Model<Api>): Promise<Model<Api>> {
-		const llamaCppDiscoveryConfig = this.#discoverableProviders.find(
-			providerConfig => providerConfig.provider === model.provider && providerConfig.discovery.type === "llama.cpp",
+		const discoveryConfig = this.#discoverableProviders.find(
+			providerConfig =>
+				providerConfig.provider === model.provider &&
+				(providerConfig.discovery.type === "llama.cpp" || providerConfig.discovery.type === "lm-studio"),
 		);
-		if (!llamaCppDiscoveryConfig) {
+		if (!discoveryConfig) {
 			return model;
 		}
 		this.#ensureFullSnapshot();
-		const runtimeMetadata = await discoverLlamaCppModelRuntimeMetadata(
-			model,
-			this.#nonResolvingDiscoveryContext(),
-			llamaCppDiscoveryConfig.discovery.timeoutMs,
-		);
+		const runtimeMetadata =
+			discoveryConfig.discovery.type === "lm-studio"
+				? await discoverLmStudioModelRuntimeMetadata(
+						model,
+						this.#nonResolvingDiscoveryContext(),
+						discoveryConfig.discovery.timeoutMs,
+					)
+				: await discoverLlamaCppModelRuntimeMetadata(
+						model,
+						this.#nonResolvingDiscoveryContext(),
+						discoveryConfig.discovery.timeoutMs,
+					);
 		if (runtimeMetadata === undefined) {
 			return this.find(model.provider, model.id) ?? model;
 		}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -333,6 +333,25 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * True when the provider's models expose context metadata that only appears
+	 * after a lazy load — llama.cpp's `meta.n_ctx` once a cold instance spins up
+	 * (#3310/#3311), LM Studio's `loaded_context_length` once it JIT-loads the
+	 * model on the first inference (#9001). Callers use this to decide whether a
+	 * post-first-response refresh is worth a native probe.
+	 */
+	hasLazyRuntimeMetadata(provider: string): boolean {
+		return this.#findLazyRuntimeDiscovery(provider) !== undefined;
+	}
+
+	#findLazyRuntimeDiscovery(provider: string): DiscoveryProviderConfig | undefined {
+		return this.#discoverableProviders.find(
+			providerConfig =>
+				providerConfig.provider === provider &&
+				(providerConfig.discovery.type === "llama.cpp" || providerConfig.discovery.type === "lm-studio"),
+		);
+	}
+
+	/**
 	 * Refresh dynamic metadata that can appear only after a local model loads.
 	 *
 	 * llama.cpp exposes `meta.n_ctx` once a lazy-loaded instance is up
@@ -342,11 +361,7 @@ export class ModelRegistry {
 	 * and patch its context window to what the backend actually serves.
 	 */
 	async refreshSelectedModelMetadata(model: Model<Api>): Promise<Model<Api>> {
-		const discoveryConfig = this.#discoverableProviders.find(
-			providerConfig =>
-				providerConfig.provider === model.provider &&
-				(providerConfig.discovery.type === "llama.cpp" || providerConfig.discovery.type === "lm-studio"),
-		);
+		const discoveryConfig = this.#findLazyRuntimeDiscovery(model.provider);
 		if (!discoveryConfig) {
 			return model;
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -60,6 +60,7 @@ import type {
 	Message,
 	Model,
 	OAuthAccountIdentity,
+	ProviderResponseMetadata,
 	ProviderSessionState,
 	ResetCreditAccountStatus,
 	ResetCreditRedeemOutcome,
@@ -613,6 +614,13 @@ export class AgentSession {
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	#onPayload: SimpleStreamOptions["onPayload"] | undefined;
 	#onResponse: SimpleStreamOptions["onResponse"] | undefined;
+	/**
+	 * Providers/models (`${provider}/${id}`) whose runtime context window has
+	 * already been re-probed after their first successful inference this session,
+	 * so a lazy-load local model (LM Studio JIT, llama.cpp cold start) is
+	 * refreshed exactly once rather than on every response (#9001).
+	 */
+	#lazyContextRefreshed = new Set<string>();
 	#onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	#sideStreamFn: StreamFn;
 	#preferWebsockets: boolean | undefined;
@@ -1191,11 +1199,15 @@ export class AgentSession {
 			? async (response, model) => {
 					this.rawSseDebugBuffer.recordResponse(response, model);
 					this.#stats.ingestProviderUsageHeaders(response, model);
+					await this.#maybeRefreshLazyLocalContext(response, model);
 					await configuredOnResponse(response, model);
 				}
 			: (response, model) => {
 					this.rawSseDebugBuffer.recordResponse(response, model);
 					this.#stats.ingestProviderUsageHeaders(response, model);
+					// Returns void (no allocation) unless a one-time lazy-model
+					// refresh is actually due, preserving the sync fast path.
+					return this.#maybeRefreshLazyLocalContext(response, model);
 				};
 		const configuredOnSseEvent = config.onSseEvent;
 		this.#onSseEvent = configuredOnSseEvent
@@ -4304,6 +4316,49 @@ export class AgentSession {
 	/** Current model (may be undefined if not yet selected) */
 	get model(): Model | undefined {
 		return this.agent.state.model;
+	}
+
+	/**
+	 * On the first successful response from a lazy-load local model, re-probe its
+	 * runtime context window and fold the result into the live session model.
+	 *
+	 * Discovery snapshots a not-yet-loaded LM Studio model with its architectural
+	 * `max_context_length`; the runtime `loaded_context_length` only exists once
+	 * the model JIT-loads on the first inference (llama.cpp has the same cold-start
+	 * gap for `meta.n_ctx`). A 2xx here means the load completed, so the probe now
+	 * returns the window the backend actually serves. Compaction and the context
+	 * bar read `agent.state.model` every turn, so `agent.setModel` propagates it
+	 * immediately without a provider-session reset (#9001).
+	 *
+	 * Returns `void` synchronously when nothing is due — the common case — so the
+	 * no-callback `#onResponse` fast path stays allocation-free.
+	 */
+	#maybeRefreshLazyLocalContext(response: ProviderResponseMetadata, model: Model | undefined): void | Promise<void> {
+		if (!model || response.status < 200 || response.status >= 300) return;
+		const key = `${model.provider}/${model.id}`;
+		if (this.#lazyContextRefreshed.has(key)) return;
+		if (!this.#modelRegistry.hasLazyRuntimeMetadata(model.provider)) return;
+		this.#lazyContextRefreshed.add(key);
+		return this.#refreshLazyLocalContext(model);
+	}
+
+	async #refreshLazyLocalContext(model: Model): Promise<void> {
+		try {
+			const refreshed = await this.#modelRegistry.refreshSelectedModelMetadata(model);
+			const current = this.model;
+			// Skip if the user switched models mid-stream, or the runtime window
+			// matches what the session already holds.
+			if (!current || !modelsAreEqual(current, refreshed) || refreshed.contextWindow === current.contextWindow) {
+				return;
+			}
+			this.agent.setModel(refreshed);
+		} catch (error) {
+			logger.debug("Lazy local model context refresh failed", {
+				provider: model.provider,
+				model: model.id,
+				error,
+			});
+		}
 	}
 
 	/**

--- a/packages/coding-agent/test/lm-studio-fix.test.ts
+++ b/packages/coding-agent/test/lm-studio-fix.test.ts
@@ -140,4 +140,57 @@ describe("ModelRegistry LM Studio Fixes", () => {
 			}
 		}
 	});
+
+	test("refreshSelectedModelMetadata tracks the LM Studio JIT-load lifecycle", async () => {
+		let state: "not-loaded" | "loaded" = "not-loaded";
+		const fetchMock: FetchImpl = input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:1234/api/v0/models") {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							data: [
+								{
+									id: "big-model",
+									type: "llm",
+									state,
+									max_context_length: 262144,
+									loaded_context_length: state === "loaded" ? 81920 : null,
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			}
+			if (url === "http://127.0.0.1:1234/v1/models") {
+				return Promise.resolve(
+					new Response(JSON.stringify({ data: [{ id: "big-model", object: "model" }] }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+			}
+			return Promise.resolve(new Response(null, { status: 404 }));
+		};
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+
+		// Discovery while unloaded records the architectural ceiling.
+		const discovered = registry.find("lm-studio", "big-model");
+		expect(discovered?.contextWindow).toBe(262144);
+
+		// JIT load: refreshing the selected model adopts the loaded window.
+		state = "loaded";
+		const loaded = await registry.refreshSelectedModelMetadata(discovered!);
+		expect(loaded.contextWindow).toBe(81920);
+		expect(registry.find("lm-studio", "big-model")?.contextWindow).toBe(81920);
+
+		// Unload: the runtime-derived window is not retained; it falls back to max.
+		state = "not-loaded";
+		const unloaded = await registry.refreshSelectedModelMetadata(loaded);
+		expect(unloaded.contextWindow).toBe(262144);
+		expect(registry.find("lm-studio", "big-model")?.contextWindow).toBe(262144);
+	});
 });

--- a/packages/coding-agent/test/lm-studio-fix.test.ts
+++ b/packages/coding-agent/test/lm-studio-fix.test.ts
@@ -2,9 +2,14 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 describe("ModelRegistry LM Studio Fixes", () => {
@@ -192,5 +197,78 @@ describe("ModelRegistry LM Studio Fixes", () => {
 		const unloaded = await registry.refreshSelectedModelMetadata(loaded);
 		expect(unloaded.contextWindow).toBe(262144);
 		expect(registry.find("lm-studio", "big-model")?.contextWindow).toBe(262144);
+	});
+
+	test("first successful inference refreshes the live session context window", async () => {
+		let loaded = false;
+		const fetchMock: FetchImpl = input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:1234/api/v0/models") {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							data: [
+								{
+									id: "big-model",
+									type: "llm",
+									state: loaded ? "loaded" : "not-loaded",
+									max_context_length: 262144,
+									loaded_context_length: loaded ? 81920 : null,
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			}
+			if (url === "http://127.0.0.1:1234/v1/models") {
+				return Promise.resolve(
+					new Response(JSON.stringify({ data: [{ id: "big-model", object: "model" }] }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+			}
+			return Promise.resolve(new Response(null, { status: 404 }));
+		};
+
+		const modelRegistry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await modelRegistry.refresh();
+		expect(modelRegistry.find("lm-studio", "big-model")?.contextWindow).toBe(262144);
+
+		// Model registered while unloaded, then JIT-loaded on the first request.
+		loaded = true;
+
+		// A MockModel carrying the LM Studio provider/id/baseUrl drives the agent
+		// loop and fires onResponse (via responseHeaders) with a 200, exactly like
+		// a real provider returning after the JIT load completes.
+		const mockModel = createMockModel({
+			provider: "lm-studio",
+			id: "big-model",
+			baseUrl: "http://127.0.0.1:1234/v1",
+			contextWindow: 262144,
+			responses: [{ content: ["ok"], responseHeaders: {} }],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mockModel, systemPrompt: ["Test"], tools: [] },
+			streamFn: mockModel.stream,
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+		try {
+			expect(session.model?.contextWindow).toBe(262144);
+			await session.prompt("hi");
+			await session.waitForIdle();
+			// The first successful inference re-probed the runtime window and folded
+			// it into the live session model without a manual refresh.
+			expect(session.model?.contextWindow).toBe(81920);
+		} finally {
+			await session.dispose();
+		}
 	});
 });


### PR DESCRIPTION
## Repro
An LM Studio model discovered while unloaded is registered with `max_context_length` (the architectural ceiling). When LM Studio JIT-loads it on first inference, the running instance may serve a smaller `loaded_context_length`. Driving `ModelRegistry.refreshSelectedModelMetadata` against a mocked native `/api/v0/models`: discovery while unloaded records `contextWindow: 262144`; after the row flips to `state: "loaded", loaded_context_length: 81920`, the refresh returns the model unchanged (`Expected: 81920, Received: 262144`). Context accounting and compaction then run against a window larger than the backend actually serves. Reproduced with `bun test test/lm-studio-fix.test.ts` (in `packages/coding-agent`).

## Cause
`ModelRegistry.refreshSelectedModelMetadata` (`packages/coding-agent/src/config/model-registry.ts`) looked up only a `discovery.type === "llama.cpp"` provider config and early-returned the model unchanged for every other provider, including LM Studio. The post-lazy-load refresh that llama.cpp got in #3310/#3311 (`discoverLlamaCppModelRuntimeMetadata`) had no LM Studio counterpart, so the snapshot captured at discovery time was never re-derived. `getLmStudioNativeContextWindow` already prefers `loaded_context_length` when `state === "loaded"`, but it was only invoked at discovery.

## Fix
- Add `discoverLmStudioModelRuntimeMetadata` in `model-discovery.ts`: re-probes the native `/api/v0/models` for the selected model via the existing `fetchLmStudioNativeModelMetadata` (which routes through `getLmStudioNativeContextWindow`), returning the runtime context window (and carrying `maxTokens` through so the caller re-caps output at the new window).
- Rename the shared runtime-metadata type `LlamaCppDiscoveredModelRuntimeMetadata` → `DiscoveredModelRuntimeMetadata`.
- Generalize `ModelRegistry.refreshSelectedModelMetadata` to match both `llama.cpp` and `lm-studio` discovery configs and dispatch to the corresponding runtime probe; the existing patch/persist path is unchanged. A later unload re-derives back to `max_context_length` rather than retaining the stale runtime value.
- Changelog entry under `packages/coding-agent` `[Unreleased]`.

## Verification
`bun test test/lm-studio-fix.test.ts` (packages/coding-agent) — 4 pass, including a new lifecycle regression: discovery while unloaded → 262144, JIT load → refresh adopts 81920 (in-memory + registry), unload → refresh falls back to 262144. `bun test test/lm-studio-provider.test.ts` (packages/catalog) — 3 pass. `bun check` — clean across the workspace. Fixes #9001