### PR TITLE
feat(ai): show Cursor spending-dashboard usage on /usage

### DIFF
--- a/docs/provider-quirks.md
+++ b/docs/provider-quirks.md
@@ -473,6 +473,7 @@ Cursor's integration in `packages/ai` operates over an HTTP/2 Connect RPC transp
 - **Usage & Quota Tracking (`packages/ai/src/usage/cursor.ts`)**:
   - Standard quota fetched from `https://api2.cursor.sh/auth/usage` (`parseCursorUsage`).
   - For OAuth credentials with WorkOS user sessions (`WorkosCursorSessionToken=${userId}::${accessToken}`), fetches personal usage from `https://cursor.com/api/usage-summary` (`parseCursorIndividualUsage`) and user profile email from `https://cursor.com/api/auth/me`.
+  - The same session also POSTs `https://cursor.com/api/dashboard/get-current-period-usage` and `https://cursor.com/api/dashboard/get-plan-info` so `/usage` can show the spending-tab Included Usage rail, plan name/price, and Cursor Models bucket note.
 
 ### Catalog model handling
 - **Descriptor Config (`packages/catalog/src/provider-models/descriptors.ts`)**:

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Cursor `/usage` now reads the spending dashboard: included-dollar usage, Ultra/Pro plan name and price, and Cursor Models bucket notes from `/api/usage-summary`, `/api/dashboard/get-current-period-usage`, and `/api/dashboard/get-plan-info`.
+
 ## [17.3.8] - 2026-08-19
 
 ### Changed

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -25,7 +25,7 @@ function normalizeCursorBaseUrl(baseUrl?: string): string {
 	return baseUrl.replace(/\/+$/, "");
 }
 
-type CursorUsageSource = "auth-usage" | "usage-summary" | "auth-me";
+type CursorUsageSource = "auth-usage" | "usage-summary" | "auth-me" | "current-period-usage" | "plan-info";
 
 async function fetchCursorJson(
 	ctx: UsageFetchContext,
@@ -71,6 +71,63 @@ function deriveResetsAt(payload: Record<string, unknown>): number | undefined {
 		}
 	}
 	return undefined;
+}
+
+function titleCaseCursorPlan(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const parts = value
+		.trim()
+		.split(/[-_\s]+/g)
+		.filter(Boolean)
+		.map(part => part[0]!.toUpperCase() + part.slice(1).toLowerCase());
+	return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function formatCursorPlanType(name?: string, price?: string): string | undefined {
+	const label = name?.trim();
+	const cost = price?.trim();
+	if (label && cost) return `${label} (${cost})`;
+	return label || cost || undefined;
+}
+
+export interface CursorPlanInfo {
+	planName?: string;
+	price?: string;
+}
+
+export function parseCursorPlanInfo(payload: unknown): CursorPlanInfo | null {
+	if (!isRecord(payload) || !isRecord(payload.planInfo)) return null;
+	const planName =
+		typeof payload.planInfo.planName === "string" && payload.planInfo.planName.trim()
+			? payload.planInfo.planName.trim()
+			: undefined;
+	const price =
+		typeof payload.planInfo.price === "string" && payload.planInfo.price.trim()
+			? payload.planInfo.price.trim()
+			: undefined;
+	if (!planName && !price) return null;
+	return { ...(planName ? { planName } : {}), ...(price ? { price } : {}) };
+}
+
+function cursorAutoBucketNote(models: unknown): string | undefined {
+	if (!Array.isArray(models)) return undefined;
+	const names = models
+		.filter((model): model is string => typeof model === "string" && model.trim() !== "")
+		.map(model => model.trim());
+	if (names.length === 0) return undefined;
+	return `Includes ${names.join(", ")}`;
+}
+
+function pushCursorIncludedUsage(limits: UsageLimit[], amount: UsageAmount, window: UsageWindow): void {
+	if (amount.limit === undefined || amount.limit <= 0) return;
+	limits.push({
+		id: "cursor:usd:individual-included",
+		label: "Included Usage",
+		scope: { provider: "cursor", windowId: window.id },
+		window,
+		amount,
+		...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
+	});
 }
 
 /**
@@ -166,6 +223,10 @@ function parseCursorPlanDashboardAmounts(bucket: Record<string, unknown>): {
 
 function pushCursorPlanRails(limits: UsageLimit[], bucket: Record<string, unknown>, window: UsageWindow): void {
 	const rails = parseCursorPlanDashboardAmounts(bucket);
+	if (rails.auto || rails.api) {
+		const included = parseCursorCentsBucket(bucket);
+		if (included) pushCursorIncludedUsage(limits, included, window);
+	}
 	if (rails.auto) {
 		limits.push({
 			id: "cursor:usd:individual-auto",
@@ -196,6 +257,47 @@ function pushCursorPlanRails(limits: UsageLimit[], bucket: Record<string, unknow
 			...(rails.fallback.usedFraction !== undefined ? { status: usageStatus(rails.fallback.usedFraction) } : {}),
 		});
 	}
+}
+
+export function parseCursorCurrentPeriodUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
+	if (!isRecord(payload) || !isRecord(payload.planUsage)) return null;
+	const resetsAt = deriveResetsAt(payload);
+	const window: UsageWindow = {
+		id: "monthly",
+		label: "Monthly",
+		...(resetsAt !== undefined ? { resetsAt } : {}),
+	};
+	const enabled = payload.planUsage.enabled !== false && payload.enabled !== false;
+	const bucket = {
+		enabled,
+		used: payload.planUsage.totalSpend ?? payload.planUsage.used,
+		limit: payload.planUsage.limit,
+		remaining: payload.planUsage.remaining,
+		autoPercentUsed: payload.planUsage.autoPercentUsed,
+		apiPercentUsed: payload.planUsage.apiPercentUsed,
+		totalPercentUsed: payload.planUsage.totalPercentUsed,
+	};
+	const limits: UsageLimit[] = [];
+	pushCursorPlanRails(limits, bucket, window);
+	if (limits.length === 0) {
+		const included = parseCursorCentsBucket({
+			enabled,
+			used: payload.planUsage.totalSpend ?? payload.planUsage.used,
+			limit: payload.planUsage.limit,
+			remaining: payload.planUsage.remaining,
+		});
+		if (included) pushCursorIncludedUsage(limits, included, window);
+	}
+	if (limits.length === 0) return null;
+	const auto = limits.find(limit => limit.id === "cursor:usd:individual-auto");
+	const bucketNote = cursorAutoBucketNote(payload.autoBucketModels);
+	if (auto && bucketNote) auto.notes = [bucketNote];
+	return {
+		provider: "cursor",
+		fetchedAt,
+		limits,
+		raw: payload,
+	};
 }
 
 /**
@@ -262,11 +364,13 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 
 	if (limits.length === 0) return null;
 
+	const planType = formatCursorPlanType(titleCaseCursorPlan(payload.membershipType));
 	return {
 		provider: "cursor",
 		fetchedAt,
 		limits,
 		raw: payload,
+		...(planType ? { metadata: { planType } } : {}),
 	};
 }
 
@@ -384,12 +488,20 @@ export const cursorUsageProvider: UsageProvider = {
 
 		let summaryReportPromise = Promise.resolve<UsageReport | null>(null);
 		let profileEmailPromise = Promise.resolve<string | undefined>(undefined);
+		let periodReportPromise = Promise.resolve<UsageReport | null>(null);
+		let planInfoPromise = Promise.resolve<CursorPlanInfo | null>(null);
 		if (credential.type === "oauth" && baseUrl === DEFAULT_CURSOR_BASE_URL) {
 			const userId = extractCursorAccessTokenUserId(token);
 			if (userId) {
 				const sessionHeaders: Record<string, string> = {
 					Accept: "application/json",
 					Cookie: `WorkosCursorSessionToken=${encodeURIComponent(`${userId}::${token}`)}`,
+				};
+				const dashboardHeaders: Record<string, string> = {
+					...sessionHeaders,
+					"Content-Type": "application/json",
+					Origin: "https://cursor.com",
+					Referer: "https://cursor.com/dashboard?tab=spending",
 				};
 				summaryReportPromise = fetchCursorJson(
 					ctx,
@@ -419,35 +531,87 @@ export const cursorUsageProvider: UsageProvider = {
 					}
 					return payload.email.trim();
 				});
+				periodReportPromise = fetchCursorJson(
+					ctx,
+					"https://cursor.com/api/dashboard/get-current-period-usage",
+					{
+						method: "POST",
+						headers: dashboardHeaders,
+						body: "{}",
+						signal: params.signal,
+					},
+					"current-period-usage",
+				).then(payload => parseCursorCurrentPeriodUsage(payload, fetchedAt));
+				planInfoPromise = fetchCursorJson(
+					ctx,
+					"https://cursor.com/api/dashboard/get-plan-info",
+					{
+						method: "POST",
+						headers: dashboardHeaders,
+						body: "{}",
+						signal: params.signal,
+					},
+					"plan-info",
+				).then(payload => parseCursorPlanInfo(payload));
 			}
 		}
 
-		const [legacyReport, summaryReport, profileEmail] = await Promise.all([
+		const [legacyReport, summaryReport, profileEmail, periodReport, planInfo] = await Promise.all([
 			legacyReportPromise,
 			summaryReportPromise,
 			profileEmailPromise,
+			periodReportPromise,
+			planInfoPromise,
 		]);
+		const dashboardReport = summaryReport ?? periodReport;
 		let report: UsageReport | null;
-		if (legacyReport && summaryReport) {
+		if (legacyReport && dashboardReport) {
 			report = {
 				provider: "cursor",
 				fetchedAt,
-				limits: [...legacyReport.limits, ...summaryReport.limits],
+				limits: [...legacyReport.limits, ...dashboardReport.limits],
 				raw: {
 					authUsage: legacyReport.raw,
-					usageSummary: summaryReport.raw,
+					...(summaryReport?.raw !== undefined ? { usageSummary: summaryReport.raw } : {}),
+					...(periodReport?.raw !== undefined ? { currentPeriodUsage: periodReport.raw } : {}),
 				},
+				...(dashboardReport.metadata ? { metadata: dashboardReport.metadata } : {}),
+				...(dashboardReport.notes ? { notes: dashboardReport.notes } : {}),
 			};
 		} else {
-			report = legacyReport ?? summaryReport;
+			report = legacyReport ?? dashboardReport;
 		}
 		if (!report) return null;
 
+		if (summaryReport && periodReport) {
+			const auto = report.limits.find(limit => limit.id === "cursor:usd:individual-auto");
+			const periodAuto = periodReport.limits.find(limit => limit.id === "cursor:usd:individual-auto");
+			if (auto && periodAuto?.notes?.length) {
+				auto.notes = [...new Set([...(auto.notes ?? []), ...periodAuto.notes])];
+			}
+			if (
+				!report.limits.some(
+					limit =>
+						limit.id === "cursor:usd:individual-included" ||
+						limit.id === "cursor:usd:individual-plan" ||
+						limit.id === "cursor:usd:individual-overall",
+				)
+			) {
+				const included = periodReport.limits.find(limit => limit.id === "cursor:usd:individual-included");
+				if (included) report.limits.unshift(included);
+			}
+		}
+
 		const email = profileEmail ?? credential.email?.trim();
+		const planType =
+			formatCursorPlanType(planInfo?.planName, planInfo?.price) ??
+			(typeof report.metadata?.planType === "string" ? report.metadata.planType : undefined);
 		const metadata = {
+			...report.metadata,
 			...(email ? { email } : {}),
 			...(credential.accountId ? { accountId: credential.accountId } : {}),
 			...(credential.projectId ? { projectId: credential.projectId } : {}),
+			...(planType ? { planType } : {}),
 		};
 		if (Object.keys(metadata).length > 0) report.metadata = metadata;
 		return report;

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { type AuthCredentialStore, AuthStorage } from "../src/auth-storage";
 import type { UsageFetchContext, UsageFetchParams } from "../src/usage";
-import { cursorUsageProvider, parseCursorIndividualUsage, parseCursorUsage } from "../src/usage/cursor";
+import {
+	cursorUsageProvider,
+	parseCursorCurrentPeriodUsage,
+	parseCursorIndividualUsage,
+	parseCursorPlanInfo,
+	parseCursorUsage,
+} from "../src/usage/cursor";
 
 function createCursorAccessToken(sub: string): string {
 	const payload = btoa(JSON.stringify({ sub })).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
@@ -220,13 +226,23 @@ describe("cursor usage provider", () => {
 
 			const report = parseCursorIndividualUsage(payload, 123);
 			expect(report?.limits.map(limit => ({ id: limit.id, label: limit.label }))).toEqual([
+				{ id: "cursor:usd:individual-included", label: "Included Usage" },
 				{ id: "cursor:usd:individual-auto", label: "Cursor Models" },
 				{ id: "cursor:usd:individual-api", label: "Other Models" },
 				{ id: "cursor:usd:individual-ondemand", label: "On-Demand Usage" },
 			]);
-			const auto = report?.limits[0]?.amount;
-			const api = report?.limits[1]?.amount;
-			const onDemand = report?.limits[2]?.amount;
+			const included = report?.limits[0]?.amount;
+			const auto = report?.limits[1]?.amount;
+			const api = report?.limits[2]?.amount;
+			const onDemand = report?.limits[3]?.amount;
+			expect(included).toEqual({
+				used: 15.04,
+				limit: 70,
+				remaining: 54.96,
+				usedFraction: 1504 / 7000,
+				remainingFraction: 5496 / 7000,
+				unit: "usd",
+			});
 			expect(auto?.unit).toBe("percent");
 			expect(auto?.used).toBeCloseTo(1.85);
 			expect(auto?.usedFraction).toBeCloseTo(0.0185);
@@ -275,6 +291,7 @@ describe("cursor usage provider", () => {
 				},
 			});
 			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:usd:individual-included",
 				"cursor:usd:individual-auto",
 				"cursor:usd:individual-api",
 			]);
@@ -323,6 +340,22 @@ describe("cursor usage provider", () => {
 			).toBeNull();
 		});
 
+		it("surfaces membershipType as plan metadata", () => {
+			const report = parseCursorIndividualUsage({
+				membershipType: "pro_plus",
+				individualUsage: {
+					plan: {
+						enabled: true,
+						used: 1504,
+						limit: 7000,
+						remaining: 5496,
+						autoPercentUsed: 1.85,
+						apiPercentUsed: 0,
+					},
+				},
+			});
+			expect(report?.metadata).toEqual({ planType: "Pro Plus" });
+		});
 		it("emits uncapped used-only dollar usage when the limit is null", () => {
 			const report = parseCursorIndividualUsage({
 				individualUsage: { overall: { enabled: true, used: "2500", limit: null } },
@@ -389,6 +422,75 @@ describe("cursor usage provider", () => {
 				},
 				status: "ok",
 			});
+		});
+	});
+
+	describe("parseCursorCurrentPeriodUsage", () => {
+		it("maps spending-tab planUsage to included and percent rails", () => {
+			const report = parseCursorCurrentPeriodUsage(
+				{
+					billingCycleEnd: "1789759085000",
+					planUsage: {
+						totalSpend: 82,
+						limit: 40000,
+						remaining: 39918,
+						autoPercentUsed: 0.006,
+						apiPercentUsed: 0.14,
+					},
+					autoBucketModels: ["default", "composer-2"],
+				},
+				123,
+			);
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:usd:individual-included",
+				"cursor:usd:individual-auto",
+				"cursor:usd:individual-api",
+			]);
+			expect(report?.limits[0]?.amount).toMatchObject({ used: 0.82, limit: 400, unit: "usd" });
+			expect(report?.limits[1]?.notes).toEqual(["Includes default, composer-2"]);
+			expect(report?.limits[0]?.window?.resetsAt).toBe(1_789_759_085_000);
+		});
+
+		it("rejects a nested disabled plan even when stale percent fields remain", () => {
+			expect(
+				parseCursorCurrentPeriodUsage({
+					planUsage: {
+						enabled: false,
+						totalSpend: 82,
+						limit: 40000,
+						autoPercentUsed: 0.006,
+						apiPercentUsed: 0.14,
+					},
+				}),
+			).toBeNull();
+		});
+
+		it("rejects a top-level disabled plan even when stale percent fields remain", () => {
+			expect(
+				parseCursorCurrentPeriodUsage({
+					enabled: false,
+					planUsage: {
+						totalSpend: 82,
+						limit: 40000,
+						autoPercentUsed: 0.006,
+						apiPercentUsed: 0.14,
+					},
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("parseCursorPlanInfo", () => {
+		it("reads Ultra plan name and price", () => {
+			expect(
+				parseCursorPlanInfo({
+					planInfo: { planName: "Ultra", price: "$200/mo", includedAmountCents: 40000 },
+				}),
+			).toEqual({ planName: "Ultra", price: "$200/mo" });
+		});
+
+		it("rejects payloads without planInfo", () => {
+			expect(parseCursorPlanInfo({ membershipType: "ultra" })).toBeNull();
 		});
 	});
 
@@ -566,7 +668,12 @@ describe("cursor usage provider", () => {
 					expect(headers.get("Authorization")).toBe(`Bearer ${accessToken}`);
 					return Response.json(authUsagePayload);
 				}
-				expect(["https://cursor.com/api/usage-summary", "https://cursor.com/api/auth/me"]).toContain(url);
+				expect([
+					"https://cursor.com/api/usage-summary",
+					"https://cursor.com/api/auth/me",
+					"https://cursor.com/api/dashboard/get-current-period-usage",
+					"https://cursor.com/api/dashboard/get-plan-info",
+				]).toContain(url);
 				expect(headers.get("Accept")).toBe("application/json");
 				expect(headers.get("Cookie")).toBe(
 					`WorkosCursorSessionToken=${encodeURIComponent(`user_123::${accessToken}`)}`,
@@ -596,6 +703,8 @@ describe("cursor usage provider", () => {
 				"https://api2.cursor.sh/auth/usage",
 				"https://cursor.com/api/usage-summary",
 				"https://cursor.com/api/auth/me",
+				"https://cursor.com/api/dashboard/get-current-period-usage",
+				"https://cursor.com/api/dashboard/get-plan-info",
 			]);
 			expect(report?.metadata).toEqual({
 				email: "person@example.com",
@@ -694,6 +803,109 @@ describe("cursor usage provider", () => {
 			});
 		});
 
+		it("overlays spending-tab plan name and Cursor Models note", async () => {
+			const accessToken = createCursorAccessToken("auth0|user_ultra");
+			const mockFetch = (async (input: string | URL): Promise<Response> => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url === "https://api2.cursor.sh/auth/usage") {
+					return Response.json({});
+				}
+				if (url === "https://cursor.com/api/usage-summary") {
+					return Response.json({
+						membershipType: "ultra",
+						individualUsage: {
+							plan: {
+								enabled: true,
+								used: 82,
+								limit: 40000,
+								remaining: 39918,
+								autoPercentUsed: 0.006,
+								apiPercentUsed: 0.14,
+							},
+						},
+					});
+				}
+				if (url === "https://cursor.com/api/auth/me") {
+					return Response.json({ email: "ultra@example.com", sub: "user_ultra" });
+				}
+				if (url === "https://cursor.com/api/dashboard/get-current-period-usage") {
+					return Response.json({
+						planUsage: {
+							totalSpend: 82,
+							limit: 40000,
+							remaining: 39918,
+							autoPercentUsed: 0.006,
+							apiPercentUsed: 0.14,
+						},
+						autoBucketModels: ["default", "composer-2"],
+					});
+				}
+				if (url === "https://cursor.com/api/dashboard/get-plan-info") {
+					return Response.json({
+						planInfo: { planName: "Ultra", price: "$200/mo" },
+					});
+				}
+				return new Response("not found", { status: 404 });
+			}) as unknown as typeof fetch;
+
+			const report = await cursorUsageProvider.fetchUsage(
+				{
+					provider: "cursor",
+					credential: { type: "oauth", accessToken },
+				},
+				{ fetch: mockFetch },
+			);
+
+			expect(report?.metadata).toEqual({
+				email: "ultra@example.com",
+				planType: "Ultra ($200/mo)",
+			});
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:usd:individual-included",
+				"cursor:usd:individual-auto",
+				"cursor:usd:individual-api",
+			]);
+			expect(report?.limits.find(limit => limit.id === "cursor:usd:individual-auto")?.notes).toEqual([
+				"Includes default, composer-2",
+			]);
+		});
+
+		it("uses spending-tab period usage when the summary request fails", async () => {
+			const accessToken = createCursorAccessToken("auth0|user_period");
+			const mockFetch = (async (input: string | URL): Promise<Response> => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url === "https://cursor.com/api/usage-summary") {
+					return new Response("Unavailable", { status: 503 });
+				}
+				if (url === "https://cursor.com/api/dashboard/get-current-period-usage") {
+					return Response.json({
+						planUsage: {
+							totalSpend: 82,
+							limit: 40000,
+							remaining: 39918,
+							autoPercentUsed: 0.006,
+							apiPercentUsed: 0.14,
+						},
+					});
+				}
+				return Response.json({});
+			}) as unknown as typeof fetch;
+
+			const report = await cursorUsageProvider.fetchUsage(
+				{
+					provider: "cursor",
+					credential: { type: "oauth", accessToken },
+				},
+				{ fetch: mockFetch },
+			);
+
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:usd:individual-included",
+				"cursor:usd:individual-auto",
+				"cursor:usd:individual-api",
+			]);
+		});
+
 		it("returns legacy usage when the personal summary request fails", async () => {
 			const accessToken = createCursorAccessToken("auth0|user_789");
 			const authUsagePayload = {
@@ -728,6 +940,8 @@ describe("cursor usage provider", () => {
 				"https://api2.cursor.sh/auth/usage",
 				"https://cursor.com/api/usage-summary",
 				"https://cursor.com/api/auth/me",
+				"https://cursor.com/api/dashboard/get-current-period-usage",
+				"https://cursor.com/api/dashboard/get-plan-info",
 			]);
 			expect(report?.limits.map(limit => limit.id)).toEqual(["cursor:requests:gpt-4"]);
 			expect(report?.raw).toEqual(authUsagePayload);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `/usage` and the status-line monthly Cursor meter now follow the spending dashboard: plan name/price on the provider header, an Included Usage rail, and `mo N%` preferring that included pool over legacy per-model request fractions.
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1377,7 +1377,13 @@ export class StatusLineComponent implements Component {
 			// When /auth/usage and /api/usage-summary are merged, prefer the personal
 			// dashboard rails over legacy per-model request fractions.
 			if (limitId === "cursor:usd:individual-auto") return 0;
-			if (limitId === "cursor:usd:individual-plan" || limitId === "cursor:usd:individual-overall") return 1;
+			if (
+				limitId === "cursor:usd:individual-plan" ||
+				limitId === "cursor:usd:individual-overall" ||
+				limitId === "cursor:usd:individual-included"
+			) {
+				return 1;
+			}
 			if (typeof limitId === "string" && limitId.startsWith("cursor:usd:individual-")) return 2;
 			return 3;
 		};

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1878,7 +1878,19 @@ export function renderUsageReports(
 			}
 		}
 
-		lines.push(uiTheme.bold(uiTheme.fg("accent", providerName)));
+		const planTypes = [
+			...new Set(
+				providerReports.flatMap(report => {
+					const planType = report.metadata?.planType;
+					return typeof planType === "string" && planType.trim() ? [planType.trim()] : [];
+				}),
+			),
+		];
+		const providerHeading =
+			planTypes.length === 1
+				? `${uiTheme.bold(uiTheme.fg("accent", providerName))} ${uiTheme.fg("dim", `· ${planTypes[0]}`)}`
+				: uiTheme.bold(uiTheme.fg("accent", providerName));
+		lines.push(providerHeading);
 		const activeAccountLabel = formatActiveAccountLabel(activeAccount);
 		if (activeAccountLabel) {
 			lines.push(`  ${uiTheme.fg("accent", "in use by this session:")} ${activeAccountLabel}`);

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1886,10 +1886,13 @@ export function renderUsageReports(
 				}),
 			),
 		];
-		const providerHeading =
+		const planLabel =
 			planTypes.length === 1
-				? `${uiTheme.bold(uiTheme.fg("accent", providerName))} ${uiTheme.fg("dim", `· ${planTypes[0]}`)}`
-				: uiTheme.bold(uiTheme.fg("accent", providerName));
+				? replaceTabs(truncateToWidth(sanitizeText(planTypes[0]!.replace(/[\r\n]+/g, " ")), availableWidth))
+				: undefined;
+		const providerHeading = planLabel
+			? `${uiTheme.bold(uiTheme.fg("accent", providerName))} ${uiTheme.fg("dim", `· ${planLabel}`)}`
+			: uiTheme.bold(uiTheme.fg("accent", providerName));
 		lines.push(providerHeading);
 		const activeAccountLabel = formatActiveAccountLabel(activeAccount);
 		if (activeAccountLabel) {

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -77,7 +77,18 @@ function renderUsageReports(
 	for (const [provider, providerReports] of [...grouped.entries()].sort(([left], [right]) =>
 		left.localeCompare(right),
 	)) {
-		lines.push("", formatProviderName(provider));
+		const planTypes = [
+			...new Set(
+				providerReports.flatMap(report => {
+					const planType = report.metadata?.planType;
+					return typeof planType === "string" && planType.trim() ? [planType.trim()] : [];
+				}),
+			),
+		];
+		lines.push(
+			"",
+			planTypes.length === 1 ? `${formatProviderName(provider)} · ${planTypes[0]}` : formatProviderName(provider),
+		);
 		const reportingModels = usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`));
 		if (reportingModels.length > 0) {
 			lines.push("  Models with usage data");

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -87,7 +87,9 @@ function renderUsageReports(
 		];
 		lines.push(
 			"",
-			planTypes.length === 1 ? `${formatProviderName(provider)} · ${planTypes[0]}` : formatProviderName(provider),
+			planTypes.length === 1
+				? `${formatProviderName(provider)} · ${sanitizeText(planTypes[0]!.replace(/[\r\n]+/g, " ").replace(/\t/g, "  "))}`
+				: formatProviderName(provider),
 		);
 		const reportingModels = usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`));
 		if (reportingModels.length > 0) {

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -3,6 +3,7 @@ import type { UsageReport } from "@oh-my-pi/pi-ai";
 import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { buildUsageReportText } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/usage-report";
 
 interface RenderableBlock {
 	render(width: number): string[];
@@ -157,6 +158,43 @@ describe("CommandController /usage", () => {
 		expect(output).toContain("Included Usage");
 	});
 
+	it("sanitizes Cursor plan names before rendering the provider header", async () => {
+		const present = vi.fn();
+		const ctx = {
+			session: createUsageSessionDouble(),
+			ui: { terminal: { columns: 100 } },
+			present,
+			presentCommandOutput: present,
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		await controller.handleUsageCommand([
+			{
+				provider: "cursor",
+				fetchedAt: Date.now(),
+				limits: [
+					{
+						id: "cursor:usd:individual-included",
+						label: "Included Usage",
+						scope: { provider: "cursor", windowId: "monthly" },
+						window: { id: "monthly", label: "Monthly" },
+						amount: { unit: "usd", used: 0.82, limit: 400, remaining: 399.18, usedFraction: 0.00205 },
+						status: "ok",
+					},
+				],
+				metadata: { planType: "\u001b[31mUltra\t($200/mo)\u001b[0m" },
+			},
+		]);
+
+		const output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
+		expect(output).toContain("Ultra");
+		expect(output).toContain("($200/mo)");
+		expect(output).not.toContain("\u001b[31m");
+		expect(output).not.toContain("\t");
+	});
+
 	it("renders saved reset expiry lines for future and expired credits", async () => {
 		const present = vi.fn();
 		const ctx = {
@@ -196,5 +234,35 @@ describe("CommandController /usage", () => {
 		expect(output).toContain(`expires in`);
 		expect(output).toContain(`(${futureIso.slice(0, 10)})`);
 		expect(output).toContain(`expired (${expiredIso.slice(0, 10)})`);
+	});
+});
+
+describe("buildUsageReportText plan header", () => {
+	it("sanitizes Cursor plan names on the plaintext provider header", async () => {
+		const text = await buildUsageReportText({
+			session: {
+				model: undefined,
+				fetchUsageReports: async () => [
+					{
+						provider: "cursor",
+						fetchedAt: Date.now(),
+						limits: [
+							{
+								id: "cursor:usd:individual-included",
+								label: "Included Usage",
+								scope: { provider: "cursor", windowId: "monthly" },
+								amount: { unit: "usd", used: 0.82, limit: 400 },
+							},
+						],
+						metadata: { planType: "\u001b[31mUltra\t($200/mo)\u001b[0m" },
+					},
+				],
+				getUsageReportingModelSelectors: () => [],
+			},
+		} as never);
+
+		expect(text).toContain("Cursor · Ultra  ($200/mo)");
+		expect(text).not.toContain("\u001b[31m");
+		expect(text).not.toContain("\t");
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -120,6 +120,43 @@ describe("CommandController /usage", () => {
 		expect(output).toContain("resets in 1d");
 	});
 
+	it("renders Cursor spending-tab plan name on the provider header", async () => {
+		const present = vi.fn();
+		const ctx = {
+			session: createUsageSessionDouble(),
+			ui: { terminal: { columns: 100 } },
+			present,
+			presentCommandOutput: present,
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+		const now = Date.now();
+
+		await controller.handleUsageCommand([
+			{
+				provider: "cursor",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "cursor:usd:individual-included",
+						label: "Included Usage",
+						scope: { provider: "cursor", windowId: "monthly" },
+						window: { id: "monthly", label: "Monthly" },
+						amount: { unit: "usd", used: 0.82, limit: 400, remaining: 399.18, usedFraction: 0.00205 },
+						status: "ok",
+					},
+				],
+				metadata: { email: "cursor@example.test", planType: "Ultra ($200/mo)" },
+			},
+		]);
+
+		const output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
+		expect(output).toContain("Cursor");
+		expect(output).toContain("Ultra ($200/mo)");
+		expect(output).toContain("Included Usage");
+	});
+
 	it("renders saved reset expiry lines for future and expired credits", async () => {
 		const present = vi.fn();
 		const ctx = {

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -400,6 +400,37 @@ describe("usage status-line segment", () => {
 		expect(content).not.toContain("90%");
 	});
 
+	it("prefers Cursor included usage over legacy monthly request limits", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "cursor",
+					limits: [
+						{
+							id: "cursor:requests:gpt-4",
+							scope: { windowId: "monthly" },
+							amount: { usedFraction: 0.9 },
+						},
+						{
+							id: "cursor:usd:individual-included",
+							scope: { windowId: "monthly" },
+							amount: { usedFraction: 0.00205 },
+						},
+					],
+				},
+			],
+			{ provider: "cursor" },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("mo");
+		expect(content).toContain("0%");
+		expect(content).not.toContain("90%");
+	});
+
 	it("renders all three OpenCode Go windows including monthly", async () => {
 		const now = Date.now();
 		const component = makeComponent(


### PR DESCRIPTION
## What

`/usage` (and the status-line monthly Cursor meter) now match the Cursor spending dashboard for OAuth WorkOS sessions.

- Included Usage rail from `plan.used` / `plan.limit` (USD)
- Cursor Models / Other Models percent rails (unchanged)
- Provider header shows Ultra/Pro plan name and price from `get-plan-info`
- Cursor Models note from `autoBucketModels` (e.g. `Includes default, composer-2`)
- Status-line `mo N%` prefers the included-dollar pool over legacy per-model request fractions

Grokbot is intentionally omitted. It is a separate weekly Grok Bot product quota that OMP never spends, and the spending-dashboard endpoints we use do not expose it.

## Why

Cursor already appeared in `/usage`, but it showed only the model-percent rails. The spending tab’s included-dollar pool and plan line were missing, so the report did not match what the dashboard shows.

## Testing

- `bun test packages/ai/test/cursor-usage.test.ts packages/coding-agent/test/status-line-usage.test.ts packages/coding-agent/test/modes/controllers/usage-command.test.ts` — 62 pass
- `bun check` — passed
- Live fetch against a stored Cursor OAuth session confirmed `usage-summary` + `get-current-period-usage` + `get-plan-info` and the Ultra / $0.82 / $400 shape

OMP-native autoreview: clean after one accepted P2 (disabled `planUsage` flag now gates both period-usage parse paths).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)