### PR TITLE
feat(coding-agent): support extension usage providers

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -128,6 +128,48 @@ Core methods:
 
 `getServiceTiers()` returns a detached snapshot of the session's live per-family tier map. `setServiceTier(family, tier)` changes one family for subsequent requests; pass `undefined` to clear that session override. OpenAI accepts `auto`, `default`, `flex`, `scale`, or `priority`; Anthropic accepts `priority`; Google accepts `flex` or `priority`. Changes made while a response is streaming do not alter that in-flight request.
 
+### Provider registration
+
+`pi.registerProvider(name, config)` can include an optional `usage` field containing a
+`UsageProvider` imported from `@oh-my-pi/pi-ai`. Its `fetchUsage` implementation receives the
+normalized credential and returns a normalized `UsageReport`; the result is then handled
+by the host's AuthStorage cache, history, and usage displays just like built-in provider
+usage.
+
+```ts
+pi.registerProvider("my-provider", {
+  baseUrl: "https://api.example.com/v1",
+  api: "openai-completions",
+  usage: {
+    id: "my-provider",
+    async fetchUsage(params, { fetch }) {
+      const response = await fetch("https://api.example.com/usage", {
+        headers: { Authorization: `Bearer ${params.credential.apiKey}` },
+      });
+      if (!response.ok) return null;
+      const payload = (await response.json()) as { used: number; limit: number };
+      return {
+        provider: "my-provider",
+        fetchedAt: Date.now(),
+        limits: [
+          {
+            id: "requests",
+            label: "Requests",
+            scope: { provider: "my-provider" },
+            amount: { used: payload.used, limit: payload.limit, unit: "requests" },
+          },
+        ],
+      };
+    },
+  },
+});
+```
+
+An extension usage provider overrides a built-in provider with the same name for as
+long as that extension registration is active. `pi.unregisterProvider(name)` (and
+extension source cleanup) removes only that runtime override, restoring the built-in
+or configured usage resolver.
+
 In interactive mode, `input` handlers run before the built-in first-message auto-title check. Extensions that call `await pi.setSessionName(...)` from `input` can set the persisted session name and prevent the default auto-generated title from running for that session.
 
 Also exposed:

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1313,6 +1313,8 @@ export class AuthStorage {
 	 */
 	#persistedBlockStoreDamaged = false;
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
+	/** Runtime extension providers take precedence over this configured/default resolver. */
+	#runtimeUsageProviderOverrides: Map<Provider, UsageProvider> = new Map();
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
 	#usageCacheEpoch = 0;
@@ -1490,6 +1492,27 @@ export class AuthStorage {
 	 */
 	removeRuntimeApiKey(provider: string): void {
 		this.#runtimeOverrides.delete(provider);
+	}
+
+	/**
+	 * Install a runtime usage provider override (not persisted to disk).
+	 *
+	 * Runtime overrides are checked before the configured resolver, including its
+	 * built-in fallback. Removing the override restores that resolver unchanged.
+	 */
+	setRuntimeUsageProvider(provider: Provider, usageProvider: UsageProvider): void {
+		this.#runtimeUsageProviderOverrides.set(provider, usageProvider);
+		this.#invalidateUsageReportCacheForProvider(provider);
+	}
+
+	/** Remove a runtime usage provider override and restore configured/default resolution. */
+	removeRuntimeUsageProvider(provider: Provider): void {
+		if (!this.#runtimeUsageProviderOverrides.delete(provider)) return;
+		this.#invalidateUsageReportCacheForProvider(provider);
+	}
+
+	#resolveUsageProvider(provider: Provider): UsageProvider | undefined {
+		return this.#runtimeUsageProviderOverrides.get(provider) ?? this.#usageProviderResolver?.(provider);
 	}
 
 	/**
@@ -3216,10 +3239,7 @@ export class AuthStorage {
 	}
 
 	async #fetchUsageUncached(request: UsageRequestDescriptor, timeoutMs?: number): Promise<UsageReport | null> {
-		const resolver = this.#usageProviderResolver;
-		if (!resolver) return null;
-
-		const providerImpl = resolver(request.provider);
+		const providerImpl = this.#resolveUsageProvider(request.provider);
 		if (!providerImpl) return null;
 
 		const timeoutSignal =
@@ -3363,7 +3383,7 @@ export class AuthStorage {
 			// value through transient failures. Session-cookie providers can opt out
 			// so an expired login does not display stale quota indefinitely.
 			const retainLastGood =
-				!forceRefresh && this.#usageProviderResolver?.(request.provider)?.retainLastGoodOnFailure !== false;
+				!forceRefresh && this.#resolveUsageProvider(request.provider)?.retainLastGoodOnFailure !== false;
 			const lastGood = retainLastGood
 				? (this.#usageCache.getStale<UsageReport | null>(cacheKey)?.value ?? null)
 				: null;
@@ -3479,7 +3499,7 @@ export class AuthStorage {
 		options?: { sessionId?: string; baseUrl?: string },
 	): boolean {
 		if (this.#fetchUsageReportsOverride) return false;
-		const parseHeaders = this.#usageProviderResolver?.(provider)?.parseRateLimitHeaders;
+		const parseHeaders = this.#resolveUsageProvider(provider)?.parseRateLimitHeaders;
 		if (!parseHeaders) return false;
 
 		const credential = this.#resolveActiveOAuthCredential(provider, options?.sessionId);
@@ -3559,18 +3579,16 @@ export class AuthStorage {
 	async #collectUsageRequests(options?: {
 		baseUrlResolver?: (provider: Provider) => string | undefined;
 	}): Promise<UsageRequestDescriptor[]> {
-		const resolver = this.#usageProviderResolver;
-		if (!resolver) return [];
-
 		const requests: UsageRequestDescriptor[] = [];
 		const providers = new Set<string>([
 			...this.#data.keys(),
+			...this.#runtimeUsageProviderOverrides.keys(),
 			...DEFAULT_USAGE_PROVIDERS.map(provider => provider.id),
 		]);
 
 		for (const providerId of providers) {
 			const provider = providerId as Provider;
-			const providerImpl = resolver(provider);
+			const providerImpl = this.#resolveUsageProvider(provider);
 			if (!providerImpl) continue;
 			const baseUrl = options?.baseUrlResolver?.(provider);
 			let entries = this.#getStoredCredentials(providerId);
@@ -3608,7 +3626,7 @@ export class AuthStorage {
 			if (entries.length === 0) {
 				const runtimeKey = this.#runtimeOverrides.get(providerId);
 				const envKey = getEnvApiKey(providerId);
-				const apiKey = runtimeKey ?? envKey;
+				const apiKey = runtimeKey ?? this.#configOverrides.get(providerId) ?? envKey;
 				if (!apiKey) continue;
 				const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
 				if (providerImpl.supports && !providerImpl.supports(request)) continue;
@@ -3864,7 +3882,7 @@ export class AuthStorage {
 	 * providers without a usage API) — the latter never warrants a usage row.
 	 */
 	usageProviderFor(provider: Provider): UsageProvider | undefined {
-		return this.#usageProviderResolver?.(provider);
+		return this.#resolveUsageProvider(provider);
 	}
 
 	/**
@@ -4115,7 +4133,7 @@ export class AuthStorage {
 			if (shouldReconcileStoreHookReports && reports) this.#reconcileCodexUsageBlocksFromReports(reports);
 			return reports;
 		}
-		if (!this.#usageProviderResolver) return null;
+		if (!this.#usageProviderResolver && this.#runtimeUsageProviderOverrides.size === 0) return null;
 
 		const requests = await this.#collectUsageRequests(options);
 		if (requests.length === 0) return [];
@@ -4206,7 +4224,7 @@ export class AuthStorage {
 	async checkCredentials(options?: CheckCredentialsOptions): Promise<CredentialHealthResult[]> {
 		options?.signal?.throwIfAborted();
 		const stored = this.#store.listAuthCredentials();
-		const resolver = this.#usageProviderResolver;
+
 		const timeoutMs = options?.timeoutMs ?? this.#usageRequestTimeoutMs;
 		const completionProbe = options?.completionProbe;
 		const completionTimeoutMs = options?.completionTimeoutMs ?? timeoutMs;
@@ -4307,7 +4325,7 @@ export class AuthStorage {
 				continue;
 			}
 
-			const providerImpl = resolver?.(row.provider as Provider);
+			const providerImpl = this.#resolveUsageProvider(row.provider as Provider);
 			if (!providerImpl) {
 				base.reason = `no usage probe configured for provider ${row.provider}`;
 			} else if (providerImpl.supports && !providerImpl.supports(initialRequest)) {
@@ -5888,6 +5906,26 @@ export class AuthStorage {
 			);
 			const existing = this.#usageCache.getStale<UsageReport | null>(cacheKey);
 			this.#usageCache.set(cacheKey, { value: existing?.value ?? null, expiresAt: expired });
+		}
+	}
+
+	/**
+	 * Expire cached reports for a provider after its runtime usage implementation changes.
+	 * This keeps a newly installed extension provider from serving a built-in snapshot.
+	 */
+	#invalidateUsageReportCacheForProvider(provider: Provider): void {
+		this.#usageCacheEpoch += 1;
+		const expired = Date.now() - 1;
+		const prefix = `report:${this.#usageCacheProviderKey(provider)}:`;
+		if (this.#usageCache.deletePrefix(prefix)) return;
+		for (const entry of this.#getStoredCredentials(provider)) {
+			this.#usageCache.set(
+				this.#buildUsageReportCacheKey({
+					provider,
+					credential: this.#buildUsageCredential(entry.credential),
+				}),
+				{ value: null, expiresAt: expired },
+			);
 		}
 	}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1314,7 +1314,8 @@ export class AuthStorage {
 	#persistedBlockStoreDamaged = false;
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	/** Runtime extension providers take precedence over this configured/default resolver. */
-	#runtimeUsageProviderOverrides: Map<Provider, UsageProvider> = new Map();
+	#runtimeUsageProviderOverrides: Map<Provider, { provider: UsageProvider; apiKey?: string }> = new Map();
+	#usageReportCacheKeysByProvider: Map<Provider, Set<string>> = new Map();
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
 	#usageCacheEpoch = 0;
@@ -1500,19 +1501,18 @@ export class AuthStorage {
 	 * Runtime overrides are checked before the configured resolver, including its
 	 * built-in fallback. Removing the override restores that resolver unchanged.
 	 */
-	setRuntimeUsageProvider(provider: Provider, usageProvider: UsageProvider): void {
-		this.#runtimeUsageProviderOverrides.set(provider, usageProvider);
+	setRuntimeUsageProvider(provider: Provider, usageProvider: UsageProvider, apiKey?: string): void {
+		this.#runtimeUsageProviderOverrides.set(provider, { provider: usageProvider, apiKey });
 		this.#invalidateUsageReportCacheForProvider(provider);
 	}
-
 	/** Remove a runtime usage provider override and restore configured/default resolution. */
 	removeRuntimeUsageProvider(provider: Provider): void {
-		if (!this.#runtimeUsageProviderOverrides.delete(provider)) return;
+		if (!this.#runtimeUsageProviderOverrides.has(provider)) return;
 		this.#invalidateUsageReportCacheForProvider(provider);
+		this.#runtimeUsageProviderOverrides.delete(provider);
 	}
-
 	#resolveUsageProvider(provider: Provider): UsageProvider | undefined {
-		return this.#runtimeUsageProviderOverrides.get(provider) ?? this.#usageProviderResolver?.(provider);
+		return this.#runtimeUsageProviderOverrides.get(provider)?.provider ?? this.#usageProviderResolver?.(provider);
 	}
 
 	/**
@@ -3095,14 +3095,16 @@ export class AuthStorage {
 			this.#usageCache.set(this.#usageForceRefreshCacheKey(provider), { value: null, expiresAt: 0 });
 		}
 	}
-
 	#buildUsageReportCacheKey(request: UsageRequestDescriptor): string {
 		const baseUrl = this.#normalizeUsageBaseUrl(request.baseUrl) || "default";
 		const identity = this.#buildUsageCacheIdentity(request.credential);
 		const providerKey = this.#usageCacheProviderKey(request.provider);
-		return `report:${providerKey}:${baseUrl}:${identity}`;
+		const cacheKey = `report:${providerKey}:${baseUrl}:${identity}`;
+		const cacheKeys = this.#usageReportCacheKeysByProvider.get(request.provider) ?? new Set<string>();
+		cacheKeys.add(cacheKey);
+		this.#usageReportCacheKeysByProvider.set(request.provider, cacheKeys);
+		return cacheKey;
 	}
-
 	#buildUsageReportsCacheKey(requests: ReadonlyArray<UsageRequestDescriptor>): string {
 		const snapshot = requests
 			.map(request => {
@@ -3344,7 +3346,6 @@ export class AuthStorage {
 			return null;
 		}
 	}
-
 	async #fetchUsageCached(
 		request: UsageRequestDescriptor,
 		options: { timeoutMs?: number; forceRefresh?: boolean } = {},
@@ -3352,6 +3353,7 @@ export class AuthStorage {
 		const timeoutMs = options.timeoutMs;
 		const forceRefresh = options.forceRefresh ?? false;
 		const cacheKey = this.#buildUsageReportCacheKey(request);
+
 		const now = Date.now();
 		const cached = forceRefresh ? undefined : this.#usageCache.get<UsageReport | null>(cacheKey);
 		// Fresh cache hit: return whatever's there (success or null fallback).
@@ -3398,7 +3400,6 @@ export class AuthStorage {
 		this.#usageRequestInFlight.set(inFlightKey, promise);
 		return promise;
 	}
-
 	/**
 	 * Append a freshly fetched report to durable usage history (when the store
 	 * supports it). The usage cache is latest-snapshot-only — these rows are
@@ -3625,8 +3626,12 @@ export class AuthStorage {
 
 			if (entries.length === 0) {
 				const runtimeKey = this.#runtimeOverrides.get(providerId);
-				const envKey = getEnvApiKey(providerId);
-				const apiKey = runtimeKey ?? this.#configOverrides.get(providerId) ?? envKey;
+				const extensionUsageKeyConfig = this.#runtimeUsageProviderOverrides.get(provider)?.apiKey,
+					extensionUsageKey = extensionUsageKeyConfig
+						? await this.#configValueResolver(extensionUsageKeyConfig)
+						: undefined,
+					envKey = getEnvApiKey(providerId);
+				const apiKey = runtimeKey ?? extensionUsageKey ?? envKey;
 				if (!apiKey) continue;
 				const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
 				if (providerImpl.supports && !providerImpl.supports(request)) continue;
@@ -5918,17 +5923,19 @@ export class AuthStorage {
 		const expired = Date.now() - 1;
 		const prefix = `report:${this.#usageCacheProviderKey(provider)}:`;
 		if (this.#usageCache.deletePrefix(prefix)) return;
+		const cacheKeys = new Set(this.#usageReportCacheKeysByProvider.get(provider));
 		for (const entry of this.#getStoredCredentials(provider)) {
-			this.#usageCache.set(
+			cacheKeys.add(
 				this.#buildUsageReportCacheKey({
 					provider,
 					credential: this.#buildUsageCredential(entry.credential),
 				}),
-				{ value: null, expiresAt: expired },
 			);
 		}
+		for (const cacheKey of cacheKeys) {
+			this.#usageCache.set(cacheKey, { value: null, expiresAt: expired });
+		}
 	}
-
 	/**
 	 * Drop report snapshots for a user-requested refresh so a failed probe
 	 * cannot replay the pre-invalidation last-good value. The persisted marker

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
+- Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1995,7 +1995,7 @@ export class ModelRegistry {
 		// provider lifetime. #clearRuntimeProviderState removes this override when
 		// the owning extension is unregistered or replaced.
 		if (config.usage) {
-			this.authStorage.setRuntimeUsageProvider(providerName, config.usage);
+			this.authStorage.setRuntimeUsageProvider(providerName, config.usage, config.apiKey);
 		}
 		if (config.apiKey) {
 			this.#installProviderApiKey(providerName, config.apiKey);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { ApiKeyResolver, FetchImpl } from "@oh-my-pi/pi-ai";
+import type { ApiKeyResolver, FetchImpl, UsageProvider } from "@oh-my-pi/pi-ai";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { registerOAuthProvider, unregisterOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
@@ -1865,6 +1865,7 @@ export class ModelRegistry {
 		this.#runtimeModelModifiers.delete(providerName);
 		this.#lastModelModifierWarnings.delete(providerName);
 		this.authStorage.removeConfigApiKey(providerName);
+		this.authStorage.removeRuntimeUsageProvider(providerName);
 	}
 
 	/**
@@ -1989,6 +1990,13 @@ export class ModelRegistry {
 		}
 
 		this.#ensureFullSnapshot();
+
+		// Extension usage providers override built-ins/configured resolvers for the
+		// provider lifetime. #clearRuntimeProviderState removes this override when
+		// the owning extension is unregistered or replaced.
+		if (config.usage) {
+			this.authStorage.setRuntimeUsageProvider(providerName, config.usage);
+		}
 		if (config.apiKey) {
 			this.#installProviderApiKey(providerName, config.apiKey);
 			// Persist runtime API keys so they survive #reloadStaticModels() cycles
@@ -2180,6 +2188,8 @@ export interface ProviderConfigInput {
 	authHeader?: boolean;
 	/** Streaming transport override — see {@link Model.transport}. */
 	transport?: Model<Api>["transport"];
+	/** Optional normalized usage fetcher; takes precedence over built-in usage providers. */
+	usage?: UsageProvider;
 	oauth?: {
 		name: string;
 		login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials | string>;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -36,6 +36,7 @@ import type {
 	Static,
 	TextContent,
 	TSchema,
+	UsageProvider,
 } from "@oh-my-pi/pi-ai";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
 import type {
@@ -1501,6 +1502,8 @@ export interface ProviderConfig {
 	authHeader?: boolean;
 	/** Models to register. If provided, replaces all existing models for this provider. */
 	models?: ProviderModelConfig[];
+	/** Optional normalized usage fetcher used by AuthStorage for this provider. */
+	usage?: UsageProvider;
 	/** OAuth provider for /login support. */
 	oauth?: {
 		/** Display name in login UI. */

--- a/packages/coding-agent/test/extension-provider-registration-rollback.test.ts
+++ b/packages/coding-agent/test/extension-provider-registration-rollback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { UsageProvider, UsageReport } from "@oh-my-pi/pi-ai";
 import { unregisterOAuthProvider } from "@oh-my-pi/pi-ai/oauth";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
@@ -230,6 +231,68 @@ describe("extension provider registration rollback", () => {
 			);
 		} finally {
 			unregisterOAuthProvider("cliproxyapi");
+			authStorage.close();
+			tempDir.removeSync();
+		}
+	});
+
+	test("uses extension usage providers and restores built-in resolution on unregister", async () => {
+		const tempDir = TempDir.createSync("@extension-usage-provider-");
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const provider = "extension-usage-provider";
+		const report: UsageReport = {
+			provider,
+			fetchedAt: 123,
+			limits: [
+				{
+					id: "requests",
+					label: "Requests",
+					scope: { provider },
+					amount: { used: 25, limit: 100, unit: "requests" },
+					status: "ok",
+				},
+			],
+		};
+		const extensionUsage: UsageProvider = {
+			id: provider,
+			fetchUsage: async params => {
+				expect(params.provider).toBe(provider);
+				expect(params.credential).toEqual({ type: "api_key", apiKey: "extension-usage-key" });
+				return report;
+			},
+		};
+
+		try {
+			const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.json"));
+			const runtime = new ExtensionRuntime();
+			const events = new EventBus();
+			await loadExtensionFromFactory(
+				pi => {
+					pi.registerProvider(provider, { apiKey: "extension-usage-key", usage: extensionUsage });
+				},
+				process.cwd(),
+				events,
+				runtime,
+				"extension-usage-provider",
+			);
+			for (const registration of runtime.pendingProviderRegistrations) {
+				modelRegistry.registerProvider(registration.name, registration.config, registration.sourceId);
+			}
+
+			await expect(authStorage.fetchUsageReports()).resolves.toEqual([report]);
+			expect(authStorage.usageProviderFor(provider)).toBe(extensionUsage);
+
+			modelRegistry.unregisterProvider(provider);
+			expect(authStorage.usageProviderFor(provider)).toBeUndefined();
+
+			const builtinUsage = authStorage.usageProviderFor("synthetic");
+			if (!builtinUsage) throw new Error("Expected the synthetic built-in usage provider");
+			const syntheticOverride: UsageProvider = { ...extensionUsage, id: "synthetic" };
+			modelRegistry.registerProvider("synthetic", { usage: syntheticOverride }, "extension-usage-provider");
+			expect(authStorage.usageProviderFor("synthetic")).toBe(syntheticOverride);
+			modelRegistry.unregisterProvider("synthetic");
+			expect(authStorage.usageProviderFor("synthetic")).toBe(builtinUsage);
+		} finally {
 			authStorage.close();
 			tempDir.removeSync();
 		}

--- a/packages/coding-agent/test/extension-provider-registration-rollback.test.ts
+++ b/packages/coding-agent/test/extension-provider-registration-rollback.test.ts
@@ -238,7 +238,15 @@ describe("extension provider registration rollback", () => {
 
 	test("uses extension usage providers and restores built-in resolution on unregister", async () => {
 		const tempDir = TempDir.createSync("@extension-usage-provider-");
-		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		let usageFetchCalls = 0;
+		const usageFetch: typeof fetch = Object.assign(
+			async (..._args: Parameters<typeof fetch>) => {
+				usageFetchCalls += 1;
+				return new Response(null, { status: 500 });
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"), { usageFetch });
 		const provider = "extension-usage-provider";
 		const report: UsageReport = {
 			provider,
@@ -277,9 +285,15 @@ describe("extension provider registration rollback", () => {
 			);
 			for (const registration of runtime.pendingProviderRegistrations) {
 				modelRegistry.registerProvider(registration.name, registration.config, registration.sourceId);
+				modelRegistry.registerProvider("synthetic", { apiKey: "must-not-be-probed" });
 			}
 
-			await expect(authStorage.fetchUsageReports()).resolves.toEqual([report]);
+			await expect(
+				authStorage.fetchUsageReports().then(reports => {
+					expect(usageFetchCalls).toBe(0);
+					return reports;
+				}),
+			).resolves.toEqual([report]);
 			expect(authStorage.usageProviderFor(provider)).toBe(extensionUsage);
 
 			modelRegistry.unregisterProvider(provider);


### PR DESCRIPTION
## What

Extensions can attach normalized usage fetchers to provider registrations. Their reports now use the existing AuthStorage cache, history, and usage display pipeline; unregistering restores the configured or built-in usage provider.

## Why

Custom extension providers need to expose quota and usage data through the same reporting surfaces as bundled providers.

## Testing

- Passed Biome and type checks for packages/ai auth storage.
- Passed Biome checks for changed coding-agent sources and regression test.
- Focused runtime tests could not start because the pi_natives addon is unavailable. Building it is blocked because the Bazel coder-vm config is unavailable.
- The coding-agent type check stops at the existing ExtensionCommandContext.isProjectTrusted error in src/session/agent-session.ts.

---

- [x] bun check passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)