### PR TITLE
fix(extensions): expose project trust to improve extension compatibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
+- Added `isProjectTrusted()` to `ExtensionContext`, a compatibility shim for extensions written against upstream `@earendil-works/pi-coding-agent`'s per-directory trust gate (e.g. Plannotator). It always returns `true`, truthfully reflecting that OMP already loads project-local inputs (`.omp/extensions`, `.omp/config.yml`) unconditionally.
 
 ## [17.3.8] - 2026-08-19
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1154,6 +1154,7 @@ export class ExtensionRunner {
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,
 			modelRegistry: this.modelRegistry,
+			isProjectTrusted: () => true,
 			get model() {
 				return getModel();
 			},

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -511,6 +511,19 @@ export interface ExtensionContext {
 		options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback<TDetails> },
 	): Promise<AgentToolResult<TDetails>>;
 
+	/**
+	 * Whether project-local inputs for the current working directory (extensions, settings,
+	 * skills, resources) are trusted. Upstream `@earendil-works/pi-coding-agent` (>=0.79) asks the
+	 * user once per directory before loading project-local inputs and exposes the saved decision
+	 * here; extensions written against that API (e.g. Plannotator) feature-detect this method to
+	 * decide whether project-local config is safe to load, and warn when it is absent.
+	 *
+	 * OMP has no equivalent per-directory trust gate: `.omp/extensions`, `.omp/config.yml`, and
+	 * other project-local inputs are already discovered and loaded unconditionally (see
+	 * `docs/extension-loading.md`). This method exists for compatibility with that upstream surface
+	 * and always returns `true`, truthfully reflecting that OMP already trusts project-local inputs
+	 * by default -- it does not narrow or widen OMP's own security model.
+	 */
 	isProjectTrusted(): boolean;
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -510,6 +510,8 @@ export interface ExtensionContext {
 		params: Record<string, unknown>,
 		options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback<TDetails> },
 	): Promise<AgentToolResult<TDetails>>;
+
+	isProjectTrusted(): boolean;
 }
 
 /**


### PR DESCRIPTION
## What

Adds `isProjectTrusted(): boolean` to `ExtensionContext`, wired into `ExtensionRunner`'s context construction as `() => true`.

## Why

Upstream `@earendil-works/pi-coding-agent` (>=0.79) added a per-directory trust prompt: it asks the user once before loading project-local inputs
(extensions, settings, skills, resources) and exposes the saved decision via `isProjectTrusted()` on the extension context. Extensions written against that upstream API — notably **Plannotator** — feature-detect this method to decide whether project-local config is safe to load, and warn when it's absent.

OMP has no equivalent per-directory trust gate: `.omp/extensions`, `.omp/config.yml`, and other project-local inputs are already discovered and loaded unconditionally (see `extension-loading.md`). Rather than build a matching trust-prompt subsystem, this adds the method as a compatibility shim that always returns `true` - truthfully reflecting that OMP already trusts project-local inputs by default. It neither narrows nor widens OMP's own security model; it just satisfies the feature-detection so Plannotator (and similar extensions) stop warning and load correctly on OMP.

## Testing

- Confirmed the new field type-checks against `ExtensionRunner`'s context construction and doesn't conflict with existing `ExtensionContext`
consumers.
- Purely additive - no existing OMP code path is gated on this value, so no behavior change for current extensions.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)