### PR TITLE
feat(coding-agent): add context token status segment

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -682,6 +682,7 @@ tui:
 | `tui.hyperlinks`            | enum    | `auto`           | `off`, `auto`, `always`.                                                  |
 
 For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`.
+Use `context_pct` for percentage/window, `context_tokens` for used tokens/window, or `context_total` for the window alone.
 
 ### Interaction
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `context_tokens` custom status-line segment that displays current context usage as used tokens over the model window.
+
 ### Changed
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -174,6 +174,7 @@ export type StatusLineSegmentId =
 	| "token_rate"
 	| "cost"
 	| "context_pct"
+	| "context_tokens"
 	| "context_total"
 	| "time_spent"
 	| "time"

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -269,7 +269,7 @@ const STATUS_USAGE_START_DELAY_MS = 0;
 const STATUS_USAGE_REFRESH_TIMEOUT_MS = 2_000;
 
 function hasContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
-	return segments.includes("context_pct") || segments.includes("context_total");
+	return segments.includes("context_pct") || segments.includes("context_tokens") || segments.includes("context_total");
 }
 function hasGitSegment(segments: readonly StatusLineSegmentId[]): boolean {
 	return segments.includes("git");

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -468,6 +468,20 @@ const contextPctSegment: StatusLineSegment = {
 	},
 };
 
+const contextTokensSegment: StatusLineSegment = {
+	id: "context_tokens",
+	render(ctx) {
+		const window = ctx.contextWindow;
+		const autoIcon = ctx.autoCompactEnabled && theme.icon.auto ? ` ${theme.icon.auto}` : "";
+		const text = `${formatNumber(ctx.contextTokens)}/${window > 0 ? formatNumber(window) : "?"}${autoIcon}`;
+		const color = getContextUsageThemeColor(getContextUsageLevel(ctx.contextPercent ?? 0, window));
+		return {
+			content: withIcon(theme.icon.context, theme.fg(color, text)),
+			visible: true,
+		};
+	},
+};
+
 const contextTotalSegment: StatusLineSegment = {
 	id: "context_total",
 	render(ctx) {
@@ -700,6 +714,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	token_rate: tokenRateSegment,
 	cost: costSegment,
 	context_pct: contextPctSegment,
+	context_tokens: contextTokensSegment,
 	context_total: contextTotalSegment,
 	time_spent: timeSpentSegment,
 	time: timeSegment,

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -236,6 +236,24 @@ describe("StatusLineComponent context breakdown", () => {
 		expect(plain).toContain("1.8%/272K");
 	});
 
+	it("renders anchored used tokens against the context window", () => {
+		const { session } = makeSession({
+			messages: [userMessage("hi"), assistantMessage("done")],
+			usage: { tokens: 5000, contextWindow: 272_000, percent: 1.8 },
+		});
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["context_tokens"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		const plain = comp.getTopBorder(80).content.replaceAll(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("5K/272K");
+		expect(plain).not.toContain("%");
+	});
+
 	it("renders speculative percent instead of ? after compaction", () => {
 		const { session } = makeSession({
 			messages: [userMessage("compaction summary")],


### PR DESCRIPTION
## What

Adds a `context_tokens` custom status-line segment that renders current context usage as used tokens over the model window (for example, `5K/272K`). It reuses the existing context warning colors and auto-compaction indicator, and remains opt-in through custom status-line segment lists.

## Why

`context_pct` only exposes percentage-based occupancy, while `context_total` only exposes the model window. Neither shows the current context token count already available to the status-line renderer.

## Testing

Behavior exercised locally: rendered a custom `StatusLineComponent` top border with `context_tokens` and provider-anchored usage of 5,000 / 272,000 tokens; the rendered output contained `5K/272K` and no percentage.

- `bun test packages/coding-agent/test/status-line-context-cache.test.ts` — 14 passed
- `bun --cwd=packages/coding-agent run check`
- `nix develop -c bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)