### PR TITLE
fix(advisor): activate enabled advisor after model discovery settles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
+### Fixed
+
+- Fixed an advisor enabled in config staying inactive (`no_model`, gray `++`) after a fresh session start until `/advisor on` was run, when its configured model came from a discovery-backed provider (e.g. GitHub Copilot). `SessionAdvisors` resolved the advisor role once at construction against a catalog that background discovery had not finished populating; the advisor now retries once the initial model refresh settles and activates without a manual toggle ([#9010](https://github.com/can1357/oh-my-pi/issues/9010)).
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1635,6 +1635,14 @@ export class AgentSession {
 		// Re-evaluate append-only context mode when the setting changes at runtime.
 		this.#unsubscribeAppendOnly = onAppendOnlyModeChanged(_value => this.#syncAppendOnlyContext(this.model));
 		this.#unsubscribeModelRoles = onModelRolesChanged(() => this.#advisors.onModelRolesChanged());
+
+		// An advisor enabled in config resolves its role against the model catalog
+		// as it stands at construction. Discovery-backed providers (e.g. GitHub
+		// Copilot) may not be populated yet — background discovery is started
+		// fire-and-forget before the session is built — so a valid configured model
+		// can land as `no_model`. Retry once the initial refresh settles so the
+		// advisor activates without a manual /advisor toggle. See #9010.
+		void this.#retryInactiveAdvisorAfterModelDiscovery();
 	}
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
@@ -9346,6 +9354,19 @@ export class AgentSession {
 	 */
 	setAdvisorEnabled(enabled: boolean): boolean {
 		return this.#advisors.setAdvisorEnabled(enabled);
+	}
+
+	/**
+	 * Reactivate an advisor that resolved to `no_model` at construction because a
+	 * discovery-backed provider had not populated the model registry yet. Awaits
+	 * the initial background refresh, then rebuilds the advisor and emits
+	 * `model_changed` so the status line reflects the now-active advisor. See #9010.
+	 */
+	async #retryInactiveAdvisorAfterModelDiscovery(): Promise<void> {
+		if (this.#isDisposed || !this.#advisors.hasInactiveNoModelAdvisor()) return;
+		await this.#modelRegistry.awaitBackgroundRefresh();
+		if (this.#isDisposed) return;
+		if (this.#advisors.retryAfterModelDiscovery()) this.#emit({ type: "model_changed" });
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -355,6 +355,38 @@ export class SessionAdvisors {
 		this.#buildAdvisorRuntime(true);
 	}
 
+	/**
+	 * True when the enabled advisor roster still has an entry left at `no_model`.
+	 *
+	 * At construction the advisor role is resolved against whatever the model
+	 * catalog holds at that instant. Discovery-backed providers (e.g. GitHub
+	 * Copilot) may not have populated the registry yet, so a valid configured
+	 * model can transiently fail to resolve and record `no_model`. See #9010.
+	 */
+	hasInactiveNoModelAdvisor(): boolean {
+		if (!this.#advisorEnabled) return false;
+		for (const entry of this.#advisorStatuses.values()) {
+			if (entry.status === "no_model") return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Reactivate an enabled advisor stuck at `no_model` after the initial
+	 * background model discovery settles, so a valid configured model that was
+	 * merely late to the catalog starts without a manual `/advisor` toggle. The
+	 * rebuild is quiet (no warnings) because a warning was already emitted at
+	 * construction. Returns true when the rebuild brought an advisor online so the
+	 * caller can refresh the status line. See #9010.
+	 */
+	retryAfterModelDiscovery(): boolean {
+		if (this.#host.isDisposed() || !this.hasInactiveNoModelAdvisor()) return false;
+		const before = this.#advisors.length;
+		if (before > 0 && !this.#advisorRuntimeMatchesCurrentConfig()) this.#stopAdvisorRuntime();
+		this.#buildAdvisorRuntime(true, false);
+		return this.#advisors.length > before;
+	}
+
 	/** Starts configured advisor runtimes when they are eligible. */
 	buildRuntime(seedToCurrent = false): boolean {
 		return this.#buildAdvisorRuntime(seedToCurrent);
@@ -652,7 +684,7 @@ export class SessionAdvisors {
 		return true;
 	}
 
-	#buildAdvisorRuntime(seedToCurrent = false): boolean {
+	#buildAdvisorRuntime(seedToCurrent = false, emitWarnings = true): boolean {
 		if (this.#host.isDisposed()) return false;
 		if (this.#advisors.length > 0) return true;
 		if (!this.#advisorEnabled) return false;
@@ -662,7 +694,7 @@ export class SessionAdvisors {
 		// entry (`paused`/`no_model`/`running`) in roster order; the build loop
 		// below confirms `running` for successfully built advisors.
 		this.#advisorStatuses.clear();
-		const descriptors = this.#resolveAdvisorRuntimeDescriptors(true);
+		const descriptors = this.#resolveAdvisorRuntimeDescriptors(emitWarnings);
 
 		// Advisor service tier (`tier.advisor`): "none" (default) runs the advisor
 		// on standard processing; "inherit" tracks the session's live per-family

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -314,6 +314,56 @@ describe("AgentSession advisor toggle", () => {
 		);
 	});
 
+	it("activates an enabled advisor once background model discovery settles", async () => {
+		// Advisor role points at a valid model that is missing from the catalog at
+		// construction (discovery-backed provider still loading), so the advisor
+		// starts `no_model`. Regression for the startup ordering race in #9010.
+		const advisorSelector = `${replacementModel.provider}/${replacementModel.id}`;
+		const settings = Settings.isolated({ "compaction.enabled": false, "advisor.enabled": true });
+		settings.setModelRole("advisor", advisorSelector);
+
+		const fullCatalog = modelRegistry.getAvailable();
+		const withoutAdvisorModel = fullCatalog.filter(
+			m => !(m.provider === replacementModel.provider && m.id === replacementModel.id),
+		);
+		let discovered = false;
+		vi.spyOn(modelRegistry, "getAvailable").mockImplementation(() =>
+			discovered ? fullCatalog : withoutAdvisorModel,
+		);
+		const { promise: refreshSettled, resolve: settleRefresh } = Promise.withResolvers<void>();
+		vi.spyOn(modelRegistry, "awaitBackgroundRefresh").mockImplementation(() => refreshSettled);
+
+		const raceSession = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+		});
+
+		// The retry emits `model_changed` once it rebuilds; await that signal
+		// rather than a wall-clock delay so the test tracks the real event.
+		const { promise: advisorRebuilt, resolve: signalRebuilt } = Promise.withResolvers<void>();
+		const unsubscribe = raceSession.subscribe(event => {
+			if (event.type === "model_changed") signalRebuilt();
+		});
+		try {
+			expect(raceSession.isAdvisorEnabled()).toBe(true);
+			expect(raceSession.isAdvisorActive()).toBe(false);
+
+			// Discovery completes and the background refresh settles: the advisor
+			// rebuilds against the now-complete catalog and goes live.
+			discovered = true;
+			settleRefresh();
+			await advisorRebuilt;
+			expect(raceSession.isAdvisorActive()).toBe(true);
+		} finally {
+			unsubscribe();
+			vi.restoreAllMocks();
+			await raceSession.dispose();
+		}
+	});
+
 	it("keeps sessions isolated when sharing a Settings instance", async () => {
 		const sharedSettings = Settings.isolated({ "compaction.enabled": false });
 		sharedSettings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");


### PR DESCRIPTION
## Repro
Configure `advisor.enabled: true` with `modelRoles.advisor` pointing at a discovery-backed provider model (e.g. `github-copilot/claude-opus-4.8-1m:high`) and start a fresh session. The `++` indicator stays gray and `/advisor status` reports `[no model]`; `/advisor on` then activates it and turns `++` green. Traced through `sdk.createAgentSession()` -> `modelRegistry.refreshInBackground()` (fire-and-forget) -> `new AgentSession()` -> `new SessionAdvisors({enabled:true})`, where the advisor role resolves against a catalog that background discovery has not yet populated.

## Cause
`SessionAdvisors` resolves the advisor role once, synchronously, in its constructor: `#buildAdvisorRuntime` -> `#resolveAdvisorRuntimeDescriptors` -> `resolveAdvisorRoleSelection(settings, modelRegistry.getAvailable())` (`packages/coding-agent/src/session/session-advisors.ts`). Because `createAgentSession` starts model discovery as a fire-and-forget background refresh *before* constructing the session, discovery-backed providers are absent from `getAvailable()` at that instant, so a valid configured model resolves to nothing and the advisor is recorded `no_model`. Nothing rebuilds it when discovery completes: `AgentSession` only subscribes to `onModelRolesChanged` (a settings signal), and `ModelRegistry` exposes no refresh-settled event. `/advisor on` re-runs the identical resolution via `setAdvisorEnabled` -> `#buildAdvisorRuntime`, which now succeeds because discovery has settled.

## Fix
- `SessionAdvisors.hasInactiveNoModelAdvisor()`: reports whether the enabled roster still has a `no_model` entry.
- `SessionAdvisors.retryAfterModelDiscovery()`: quietly rebuilds such an advisor (no duplicate warning; a warning was already emitted at construction) and reports whether one came online.
- `#buildAdvisorRuntime` gains an `emitWarnings` parameter so the retry rebuild stays silent.
- `AgentSession` constructor fires `#retryInactiveAdvisorAfterModelDiscovery()`: awaits `ModelRegistry.awaitBackgroundRefresh()` (the existing settle seam), then rebuilds the inactive advisor and emits `model_changed` so the status line refreshes the `++` badge.

## Verification
`bun test test/advisor-toggle.test.ts` (packages/coding-agent) — 31 pass, including the new regression `activates an enabled advisor once background model discovery settles`, which starts an enabled advisor against a catalog missing its model, settles the mocked background refresh, and asserts the advisor auto-activates. `bun check` passes (biome + tsgo). Fixes #9010