### PR TITLE
fix(ai): strip MCP x-mcp-header annotation from Google/CCA schema

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Google Cloud Code Assist / Antigravity rejecting MCP tool schemas with `400 Invalid JSON payload received. Unknown name "x-mcp-header"`: the MCP 2026-07-28 `x-mcp-header` transport annotation (which mirrors a parameter into an `Mcp-Param-*` HTTP header) is now stripped from the Google/CCA wire schema by `normalizeSchemaForGoogle` / `normalizeSchemaForCCA`, while remaining available to the MCP transport/execution layer ([#9016](https://github.com/can1357/oh-my-pi/issues/9016)).
+
 ## [17.3.8] - 2026-08-19
 
 ### Changed

--- a/packages/ai/src/utils/schema/fields.ts
+++ b/packages/ai/src/utils/schema/fields.ts
@@ -40,6 +40,11 @@ export const UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
 	dependencies: true,
 	dependentSchemas: true,
 	dependentRequired: true,
+	// MCP 2026-07-28 transport annotation (mirrors a param into an `Mcp-Param-*`
+	// HTTP header on the Streamable HTTP transport); not a JSON Schema keyword.
+	// Google Cloud Code Assist 400s on the unknown field name, so strip it from
+	// the wire schema. MCP transport/execution reads it from the raw tool schema.
+	"x-mcp-header": true,
 };
 
 /**

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -349,6 +349,39 @@ describe("normalizeSchemaForGoogle", () => {
 		});
 	});
 
+	it("strips the MCP x-mcp-header transport annotation on the Google wire (issue #9016)", () => {
+		// `x-mcp-header` (MCP 2026-07-28) mirrors a param into an `Mcp-Param-*`
+		// HTTP header on the Streamable HTTP transport; it is not a JSON Schema
+		// keyword and Google Cloud Code Assist 400s on the unknown field name.
+		const input = {
+			type: "object",
+			properties: {
+				owner: { type: "string", "x-mcp-header": "owner" },
+				repo: { type: "string", "x-mcp-header": "repo" },
+			},
+			required: ["owner", "repo"],
+		};
+		const stripped = {
+			type: "object",
+			properties: { owner: { type: "string" }, repo: { type: "string" } },
+			required: ["owner", "repo"],
+		};
+
+		expect(normalizeSchemaForGoogle(input)).toEqual({ ...stripped, propertyOrdering: ["owner", "repo"] });
+		expect(normalizeSchemaForCCA(input)).toEqual(stripped);
+
+		// A property literally named `x-mcp-header` is a schema-map entry, not the
+		// annotation, and must survive on every wire.
+		expect(normalizeSchemaForGoogle({ type: "object", properties: { "x-mcp-header": { type: "string" } } })).toEqual({
+			type: "object",
+			properties: { "x-mcp-header": { type: "string" } },
+		});
+
+		// MCP transport/execution reads the annotation from the raw schema, so the
+		// MCP normalizer must leave it intact.
+		expect(normalizeSchemaForMCP(input)).toEqual(input);
+	});
+
 	it("strips draft-2019 conditional keywords the OpenAPI-style wire cannot model", () => {
 		// `dependentSchemas`/`dependencies`/`dependentRequired` have no Google
 		// OpenAPI Schema representation and are not caught by residual checks, so


### PR DESCRIPTION
## Repro
With the `smol` role on a Google Antigravity Gemini model and GitHub MCP tools exposed, the bundled `scout` agent fails before inference with `Cloud Code Assist API error (400): Invalid JSON payload received. Unknown name "x-mcp-header"`. GitHub MCP tool schemas carry the MCP 2026-07-28 `x-mcp-header` annotation on their properties (e.g. `owner`, `repo`). Isolated at the schema-conversion boundary:

```
bun -e 'import { normalizeSchemaForGoogle, normalizeSchemaForCCA } from "./packages/ai/src/utils/schema"; const s = { type: "object", properties: { owner: { type: "string", "x-mcp-header": "owner" }, repo: { type: "string", "x-mcp-header": "repo" } }, required: ["owner","repo"] }; console.log(JSON.stringify(normalizeSchemaForGoogle(s))); console.log(JSON.stringify(normalizeSchemaForCCA(s)));'
# before: both preserve "x-mcp-header" in the wire schema
```

## Cause
`x-mcp-header` (MCP 2026-07-28) is a transport-only extension property that mirrors a parameter into an `Mcp-Param-*` HTTP header on the Streamable HTTP transport; it is not a JSON Schema keyword. `normalizeSchemaForGoogle` / `normalizeSchemaForCCA` in `packages/ai/src/utils/schema/normalize.ts` strip only the keys in `UNSUPPORTED_SCHEMA_FIELDS` (`packages/ai/src/utils/schema/fields.ts`, via `isGoogleUnsupportedSchemaField`), which did not include `x-mcp-header`. The annotation therefore survived into `tools[].function_declarations[].parameters`, and Google Cloud Code Assist 400s on the unknown field name.

## Fix
- `packages/ai/src/utils/schema/fields.ts`: add `"x-mcp-header": true` to `UNSUPPORTED_SCHEMA_FIELDS` (shared by `normalizeSchemaForGoogle` and `normalizeSchemaForCCA`), so it is stripped from the Google/CCA wire schema. The MCP normalizer (`isMcpUnsupportedSchemaField`) is untouched, so transport/execution still reads the annotation from the raw tool schema.
- `packages/ai/test/schema-normalization.test.ts`: regression test asserting Google/CCA strip the annotation while preserving structural fields, a property literally named `x-mcp-header` survives (schema-map entry, not the annotation), and the MCP normalizer preserves it.
- `packages/ai/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification
`bun test packages/ai/test/schema-normalization.test.ts` → 72 pass / 0 fail. Post-fix repro shows `x-mcp-header` removed from both wire schemas with `type`/`required`/`propertyOrdering` intact. `bun check` passes. Fixes #9016