### PR TITLE
fix(cli): include active profile in session resume hint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
+### Fixed
+
+- Fixed the session resume hint dropping the active `--profile`, so the `omp --resume <id>` command printed on exit (and the fatal-recovery hint) failed with `Session "<id>" not found` for sessions started under a named profile. The hint now carries `--profile <name>` when a profile is active ([#9018](https://github.com/can1357/oh-my-pi/issues/9018)).
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -41,7 +41,6 @@ import type { TerminalAppearanceRequestToken } from "@oh-my-pi/pi-tui/terminal";
 import { isInsideTerminalMultiplexer } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import {
 	$env,
-	APP_NAME,
 	adjustHsv,
 	formatNumber,
 	getProjectDir,
@@ -138,6 +137,7 @@ import { formatStartupChangelogSummary, type StartupChangelogSelection } from ".
 import { copyToClipboard } from "../utils/clipboard";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
+import { resumeCommand } from "../utils/resume-command";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
 import { messageHasDisplayableThinking } from "../utils/thinking-display";
 import {
@@ -4311,7 +4311,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const sessionId = this.sessionManager.getSessionId();
 		const sessionFile = this.sessionManager.getSessionFile();
 		if (sessionId && sessionFile && this.sessionManager.isSessionOnDisk()) {
-			process.stderr.write(`\n${chalk.dim(`Resume this session with ${APP_NAME} --resume ${sessionId}`)}\n`);
+			process.stderr.write(`\n${chalk.dim(`Resume this session with ${resumeCommand(sessionId)}`)}\n`);
 		}
 
 		await postmortem.quit(0);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -83,7 +83,6 @@ import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { MacOSPowerAssertion } from "@oh-my-pi/pi-natives";
 import {
 	$env,
-	APP_NAME,
 	escapeXmlText,
 	formatDuration,
 	getAgentDbPath,
@@ -210,6 +209,7 @@ import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
 import { normalizeModelContextImages } from "../utils/image-loading";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
+import { resumeCommand } from "../utils/resume-command";
 import { generateSessionTitle } from "../utils/title-generator";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
 import type { VibeModeState } from "../vibe/state";
@@ -1452,7 +1452,7 @@ export class AgentSession {
 			if (!sessionId || !this.sessionManager.getSessionFile()) return undefined;
 			return {
 				label: this.#agentId ?? (this.#agentKind === "main" ? "Main" : "Agent"),
-				command: `${APP_NAME} --resume ${sessionId}`,
+				command: resumeCommand(sessionId),
 			};
 		});
 

--- a/packages/coding-agent/src/utils/resume-command.ts
+++ b/packages/coding-agent/src/utils/resume-command.ts
@@ -1,0 +1,18 @@
+import { APP_NAME, getActiveProfile } from "@oh-my-pi/pi-utils";
+
+/**
+ * Build the shell command that resumes a session by id.
+ *
+ * Sessions launched under a named profile are stored in that profile's agent
+ * directory (`~/.omp/profiles/<name>/agent`), so a bare `omp --resume <id>`
+ * run without the profile looks in the default directory and fails with
+ * `Session "<id>" not found`. When a profile is active, prefix `--profile
+ * <name>` so the emitted hint is a command the user can paste verbatim
+ * (issue #9018). Profile names are validated against a strict charset
+ * (`normalizeProfileName`), so no shell quoting is required.
+ */
+export function resumeCommand(sessionId: string): string {
+	const profile = getActiveProfile();
+	const profileFlag = profile ? `--profile ${profile} ` : "";
+	return `${APP_NAME} ${profileFlag}--resume ${sessionId}`;
+}

--- a/packages/coding-agent/test/utils/resume-command.test.ts
+++ b/packages/coding-agent/test/utils/resume-command.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { resumeCommand } from "@oh-my-pi/pi-coding-agent/utils/resume-command";
+import { APP_NAME, getActiveProfile, setProfile } from "@oh-my-pi/pi-utils/dirs";
+
+describe("resumeCommand", () => {
+	const originalProfile = getActiveProfile();
+
+	afterEach(() => {
+		setProfile(originalProfile);
+	});
+
+	it("omits the profile flag in the default profile", () => {
+		setProfile(undefined);
+		expect(resumeCommand("abc123")).toBe(`${APP_NAME} --resume abc123`);
+	});
+
+	it("carries the active profile so the emitted hint is runnable verbatim", () => {
+		// Profile sessions live in ~/.omp/profiles/<name>/agent, so a resume hint
+		// without --profile fails with "Session not found" (issue #9018).
+		setProfile("personal");
+		expect(resumeCommand("abc123")).toBe(`${APP_NAME} --profile personal --resume abc123`);
+	});
+});


### PR DESCRIPTION
## Repro
Start a session under a named profile, write a message, quit, then run the `omp --resume <id>` command printed on exit. It fails with `Session "<id>" not found` because the session lives in the profile-scoped agent dir while the hint resolves against the default profile.

Deterministic repro (`bun /tmp/repro-9018.ts`):
```
session stored under profile 'personal': ~/.omp/profiles/personal/agent/sessions
default profile sessions dir           : <default>/sessions
old exit hint printed                  : omp --resume 018f-demo-uuid
resolves session dirs match?           : false
```

## Cause
Profile sessions persist under `~/.omp/profiles/<name>/agent/sessions` (`getSessionsDir` follows the active profile via `packages/utils/src/dirs.ts`). Two hint builders hard-coded `${APP_NAME} --resume ${sessionId}` with no profile: `InteractiveMode.shutdown()` in `modes/interactive-mode.ts` and the fatal-recovery hint registered in `session/agent-session.ts`. A bare `--resume` therefore looks in the default profile's sessions dir and cannot find the session.

## Fix
- Add `utils/resume-command.ts` exporting `resumeCommand(sessionId)`, which prefixes `--profile <name>` when `getActiveProfile()` returns a named profile (profile names are charset-validated, so no shell quoting is needed).
- Route the exit hint (`modes/interactive-mode.ts`) and the fatal-recovery hint (`session/agent-session.ts`) through the helper; drop the now-unused `APP_NAME` imports.
- Add `test/utils/resume-command.test.ts` covering the default (no flag) and named-profile (`--profile personal`) cases.
- Changelog entry under `[Unreleased] → Fixed`.

## Verification
`bun test test/utils/resume-command.test.ts test/profile-cli.test.ts` → 11 pass. Manual check: `resumeCommand("018f-demo-uuid")` under `setProfile("personal")` returns `omp --profile personal --resume 018f-demo-uuid`.

Fixes #9018