### PR TITLE
feat(coding-agent): add extension API for status-line segments

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -706,7 +706,7 @@ pi.registerStatusLineSegment("developer_cost", (context, _next, theme) => ({
 }));
 ```
 
-The context exposes `width`, token/cost/rate usage, context tokens and percent, the Git branch, and accumulated active milliseconds. Segment content may contain themed ANSI styling; OMP owns placement, width overflow, separators, and background rendering. Call `ctx.ui.refreshStatusLine()` after changing extension-owned renderer state so the interactive top border repaints while idle.
+The context exposes `width`, token/cost/rate usage, context tokens and percent, the Git branch, and accumulated active milliseconds. Segment content may contain themed ANSI styling; OMP owns placement, separators, and background rendering. On overflow OMP drops trailing right segments and shrinks the built-in `path` segment; a custom left segment (other than `path`) is not truncated, so keep its content bounded to avoid overflowing the bar. Call `ctx.ui.refreshStatusLine()` after changing extension-owned renderer state so the interactive top border repaints while idle.
 
 ## Tool call/result renderer
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -114,7 +114,7 @@ Core methods:
 
 - `on(event, handler)`
 - `registerTool`, `registerCommand`, `registerShortcut`, `registerFlag`
-- `registerMessageRenderer`, `registerAssistantThinkingRenderer`
+- `registerMessageRenderer`, `registerAssistantThinkingRenderer`, `registerStatusLineSegment`
 - `registerComposerShape`
 - `setLabel`, `getFlag`
 - `sendMessage`, `sendUserMessage`, `appendEntry`, `exec`
@@ -677,6 +677,36 @@ pi.registerAssistantThinkingRenderer((context, theme) => {
 ```
 
 Used by interactive rendering to add display-only supplemental UI below each visible assistant thinking block. The renderer receives the already-visible thinking text, content/thinking indexes, theme, and a `requestRender()` callback for async renderers. All registered renderers that return a component are appended in registration order. Renderers must not mutate messages; the original thinking block remains the provider/session source of truth.
+
+## Status-line segment renderer
+
+Register a segment id, then list it in `statusLine.leftSegments` or `statusLine.rightSegments` with `statusLine.preset: custom`. The renderer synchronously receives a stable metrics/context snapshot, a `next()` function, and the current theme. For a built-in id, `next()` renders the built-in segment; for a new id, it returns an invisible segment. Return `next()` unchanged to preserve the current behavior, or return a replacement result to hide or replace it.
+
+`next()` also executes wrappers registered by extensions loaded earlier. Later-loaded extensions are the outermost wrapper, so each wrapper must call `next()` when it wants to compose instead of replace. A wrapper exception or invalid result is ignored and the next renderer still runs.
+
+```yaml
+statusLine:
+  preset: custom
+  rightSegments: [model, mode, developer_cost]
+```
+
+```ts
+pi.registerStatusLineSegment("mode", (_context, next, theme) => {
+  const original = next();
+  if (!original.visible) return original;
+  return {
+    ...original,
+    content: [original.content, theme.fg("accent", "review")].join(" · "),
+  };
+});
+
+pi.registerStatusLineSegment("developer_cost", (context, _next, theme) => ({
+  content: theme.fg("muted", "dev $" + context.usage.cost.toFixed(2)),
+  visible: true,
+}));
+```
+
+The context exposes `width`, token/cost/rate usage, context tokens and percent, the Git branch, and accumulated active milliseconds. Segment content may contain themed ANSI styling; OMP owns placement, width overflow, separators, and background rendering. Call `ctx.ui.refreshStatusLine()` after changing extension-owned renderer state so the interactive top border repaints while idle.
 
 ## Tool call/result renderer
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,8 @@
 - Cancelled prompts during pre-stream turn setup restore the text and image attachments to the editor.
 - `top` builtin accepts single-dash macOS flags such as `-pid` and `-stats`.
 - GNU/BSD compat sweep across built-in shell utilities (`timeout`, `diff`, `find`, `date`, `tail`, `head`, `rg`, `stat`, `truncate`, `cksum`, `sleep`, `which`, `nohup`, `kill`).
+- `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
+- Added `ExtensionAPI.registerStatusLineSegment(id, renderer)`, allowing extensions to add configured status-line segments or synchronously wrap built-in segments through `next()`, plus `ctx.ui.refreshStatusLine()` for repainting extension-owned state while idle. OMP retains layout, overflow, separators, and safe fallback when an extension renderer fails.
 
 ## [17.3.8] - 2026-08-19
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -239,6 +239,9 @@ export type StatusLineSegmentId =
 	| "usage"
 	| "collab";
 
+/** A built-in status-line id or an id registered by an extension. */
+export type StatusLineSegmentRef = StatusLineSegmentId | (string & {});
+
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {
 	value: V;
@@ -5943,8 +5946,8 @@ export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
 	showHookStatus: boolean;
-	leftSegments: StatusLineSegmentId[];
-	rightSegments: StatusLineSegmentId[];
+	leftSegments: StatusLineSegmentRef[];
+	rightSegments: StatusLineSegmentRef[];
 	segmentOptions: Record<string, unknown>;
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -47,6 +47,7 @@ import type {
 	MessageRenderer,
 	ProviderConfig,
 	RegisteredCommand,
+	StatusLineSegmentRenderer,
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
@@ -232,6 +233,10 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		this.extension.messageRenderers.set(customType, renderer as MessageRenderer);
 	}
 
+	registerStatusLineSegment(id: string, renderer: StatusLineSegmentRenderer): void {
+		this.extension.statusLineSegments.set(id, renderer);
+	}
+
 	registerAssistantThinkingRenderer(renderer: AssistantThinkingRenderer): void {
 		this.extension.assistantThinkingRenderers.push(renderer);
 	}
@@ -348,6 +353,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		fileDeleteFallbackHandlers: [],
 		messageRenderers: new Map(),
 		composerShapes: new Map(),
+		statusLineSegments: new Map(),
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -64,6 +64,8 @@ import type {
 	SessionCompactingResult,
 	SessionStopEvent,
 	SessionStopEventResult,
+	StatusLineSegmentContext,
+	StatusLineSegmentResult,
 	ToolCallEvent,
 	ToolCallEventResult,
 	ToolRegistrationListener,
@@ -405,6 +407,7 @@ const noOpUIContext: ExtensionUIContext = {
 	notify: () => {},
 	onTerminalInput: () => () => {},
 	setStatus: () => {},
+	refreshStatusLine: () => {},
 	setWorkingMessage: () => {},
 	setWidget: () => {},
 	setFooter: () => {},
@@ -430,7 +433,22 @@ const noOpUIContext: ExtensionUIContext = {
 interface ToolRegistrationScope {
 	pending: Set<Promise<void>>;
 	signal?: AbortSignal;
+
 	closed: boolean;
+}
+
+function isStatusLineSegmentResult(value: unknown): value is StatusLineSegmentResult {
+	try {
+		if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+		const result = value as { content?: unknown; visible?: unknown };
+		return typeof result.content === "string" && typeof result.visible === "boolean";
+	} catch {
+		return false;
+	}
+}
+
+function invisibleStatusLineSegment(): StatusLineSegmentResult {
+	return { content: "", visible: false };
 }
 
 export class ExtensionRunner {
@@ -1091,6 +1109,85 @@ export class ExtensionRunner {
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * Render a status-line segment through every extension wrapper registered for
+	 * `id`, around the supplied built-in or invisible base renderer.
+	 *
+	 * Extensions are composed in load order so the newest extension is the
+	 * outermost wrapper. Each wrapper receives a memoized `next()` callback;
+	 * malformed or throwing wrappers are skipped in favor of the result beneath
+	 * them.
+	 */
+	renderStatusLineSegment(
+		id: string,
+		ctx: StatusLineSegmentContext,
+		segmentTheme: Theme,
+		renderBase: () => StatusLineSegmentResult,
+	): StatusLineSegmentResult {
+		const safeBase = (): StatusLineSegmentResult => {
+			try {
+				const result = renderBase();
+				if (isStatusLineSegmentResult(result)) return result;
+				logger.warn("Extension status-line segment base renderer returned an invalid result", { id });
+			} catch (error) {
+				logger.warn("Extension status-line segment base renderer threw", {
+					id,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+			return invisibleStatusLineSegment();
+		};
+
+		let render: () => StatusLineSegmentResult = safeBase;
+		for (const extension of this.extensions) {
+			const renderer = extension.statusLineSegments.get(id);
+			if (!renderer) continue;
+
+			const nextRenderer = render;
+			render = (): StatusLineSegmentResult => {
+				let nextCalled = false;
+				let nextResult: StatusLineSegmentResult | undefined;
+				const next = (): StatusLineSegmentResult => {
+					if (!nextCalled) {
+						nextCalled = true;
+						nextResult = nextRenderer();
+					}
+					return nextResult ?? invisibleStatusLineSegment();
+				};
+
+				try {
+					const result = renderer(ctx, next, segmentTheme);
+					if (isStatusLineSegmentResult(result)) return result;
+					logger.warn("Extension status-line segment renderer returned an invalid result", {
+						id,
+						extensionPath: extension.path,
+					});
+				} catch (error) {
+					logger.warn("Extension status-line segment renderer threw; falling through", {
+						id,
+						extensionPath: extension.path,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+				return next();
+			};
+		}
+
+		try {
+			return render();
+		} catch (error) {
+			logger.warn("Extension status-line segment rendering failed", {
+				id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return invisibleStatusLineSegment();
+		}
+	}
+
+	hasStatusLineSegment(id: string): boolean {
+		return this.extensions.some(extension => extension.statusLineSegments.has(id));
 	}
 
 	getAssistantThinkingRenderers(): AssistantThinkingRenderer[] {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -451,6 +451,33 @@ function invisibleStatusLineSegment(): StatusLineSegmentResult {
 	return { content: "", visible: false };
 }
 
+/** Matches only CSI SGR sequences (`\x1b[<params>m`), the styling extensions are documented to emit. */
+const ANSI_SGR_RE = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Neutralizes newlines, tabs, and other C0/C1 control characters in
+ * extension-supplied segment content, without touching CSI SGR styling
+ * escapes. Built-in segments already funnel their text through
+ * `sanitizeStatusText`, which strips ANSI entirely; extension content must
+ * keep its ANSI styling, so control characters are mapped to spaces in place
+ * instead of relying on that stricter sanitizer. This protects the
+ * single-line status bar layout (`component.ts`) from a segment whose
+ * content contains a literal newline or tab.
+ */
+function sanitizeExtensionSegmentContent(content: string): string {
+	if (!content) return content;
+	let sanitized = "";
+	let lastIndex = 0;
+	for (const match of content.matchAll(ANSI_SGR_RE)) {
+		const index = match.index ?? 0;
+		sanitized += content.slice(lastIndex, index).replace(/[\u0000-\u001f\u007f-\u009f]/g, " ");
+		sanitized += match[0];
+		lastIndex = index + match[0].length;
+	}
+	sanitized += content.slice(lastIndex).replace(/[\u0000-\u001f\u007f-\u009f]/g, " ");
+	return sanitized;
+}
+
 export class ExtensionRunner {
 	#uiContext: ExtensionUIContext;
 	#mode: ExtensionMode = "print";
@@ -1176,7 +1203,8 @@ export class ExtensionRunner {
 		}
 
 		try {
-			return render();
+			const result = render();
+			return { ...result, content: sanitizeExtensionSegmentContent(result.content) };
 		} catch (error) {
 			logger.warn("Extension status-line segment rendering failed", {
 				id,

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -283,6 +283,9 @@ export interface ExtensionUIContext {
 	/** Set status text in the footer/status bar. Pass undefined to clear. */
 	setStatus(key: string, text: string | undefined): void;
 
+	/** Re-render status-line segments after extension-owned state changes. */
+	refreshStatusLine(): void;
+
 	/** Set the working/loading message shown during streaming. Call with no argument to restore default. */
 	setWorkingMessage(message?: string): void;
 
@@ -1147,6 +1150,45 @@ export type AssistantThinkingRenderer = (
 	context: AssistantThinkingRenderContext,
 	theme: Theme,
 ) => Component | undefined;
+// ============================================================================
+// Status Line Segments
+// ============================================================================
+
+export interface StatusLineSegmentUsage {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	cost: number;
+	tokensPerSecond: number | null;
+}
+
+/** Data made available to an extension-registered status-line segment renderer. */
+export interface StatusLineSegmentContext {
+	/** Terminal columns budgeted for the whole status line; segments do not need to truncate to this themselves. */
+	width: number;
+	usage: StatusLineSegmentUsage;
+	/** Context usage percent, or null when unknown (e.g. right after compaction). */
+	contextPercent: number | null;
+	contextTokens: number;
+	contextWindow: number;
+	git: { branch: string | null } | null;
+	/** Active (non-idle) processing time accumulated this session, in ms. */
+	activeMs: number;
+}
+
+export interface StatusLineSegmentResult {
+	content: string;
+	visible: boolean;
+}
+
+/** Synchronous middleware for an extension-registered status-line segment. */
+export type StatusLineSegmentRenderer = (
+	ctx: StatusLineSegmentContext,
+	next: () => StatusLineSegmentResult,
+	theme: Theme,
+) => StatusLineSegmentResult;
 
 // ============================================================================
 // Command Registration
@@ -1381,6 +1423,17 @@ export interface ExtensionAPI {
 	 * replaced; when extensions reuse an id, the later extension wins.
 	 */
 	registerComposerShape(definition: ComposerShapeDefinition): void;
+
+	/**
+	 * Register a named status-line segment usable from `statusLine.leftSegments` /
+	 * `statusLine.rightSegments` config, alongside the built-in segment ids.
+	 *
+	 * For a built-in id, `next()` renders its built-in segment. For a new id,
+	 * `next()` returns an invisible segment. When multiple extensions register
+	 * the same id, their middleware is composed in load order, with the most
+	 * recently loaded extension outermost.
+	 */
+	registerStatusLineSegment(id: string, renderer: StatusLineSegmentRenderer): void;
 
 	// =========================================================================
 	// Actions
@@ -1713,6 +1766,7 @@ export interface Extension {
 	fileDeleteFallbackHandlers: FileDeleteFallbackHandler[];
 	messageRenderers: Map<string, MessageRenderer>;
 	composerShapes: Map<string, ComposerShapeDefinition>;
+	statusLineSegments: Map<string, StatusLineSegmentRenderer>;
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -435,6 +435,7 @@ export function createAcpExtensionUiContext(
 		},
 		onTerminalInput: () => () => {},
 		setStatus: () => {},
+		refreshStatusLine: () => {},
 		setWorkingMessage: () => {},
 		setWidget: () => {},
 		setFooter: () => {},

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -38,7 +38,7 @@ import type {
 	ContextLineMode,
 	SettingTab,
 	StatusLinePreset,
-	StatusLineSegmentId,
+	StatusLineSegmentRef,
 	StatusLineSeparatorStyle,
 } from "../../config/settings-schema";
 import { SETTING_TABS, TAB_METADATA } from "../../config/settings-schema";
@@ -566,8 +566,8 @@ export interface SettingsRuntimeContext {
 export interface StatusLinePreviewSettings {
 	preset?: StatusLinePreset;
 	contextLine?: ContextLineMode;
-	leftSegments?: StatusLineSegmentId[];
-	rightSegments?: StatusLineSegmentId[];
+	leftSegments?: StatusLineSegmentRef[];
+	rightSegments?: StatusLineSegmentRef[];
 	separator?: StatusLineSeparatorStyle;
 	sessionAccent?: boolean;
 	transparent?: boolean;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -34,8 +34,8 @@ import { getSeparator } from "./separators";
 import type {
 	CollabStatus,
 	EffectiveStatusLineSettings,
-	StatusLineSegmentId,
 	StatusLineSegmentOptions,
+	StatusLineSegmentRef,
 	StatusLineSettings,
 } from "./types";
 
@@ -276,22 +276,22 @@ const EMPTY_MESSAGES: readonly AgentMessage[] = [];
 const STATUS_USAGE_START_DELAY_MS = 0;
 const STATUS_USAGE_REFRESH_TIMEOUT_MS = 2_000;
 
-function isContextSegment(segment: StatusLineSegmentId): boolean {
+function isContextSegment(segment: StatusLineSegmentRef): boolean {
 	return segment === "context_pct" || segment === "context_total";
 }
 
-function hasContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasContextSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("context_pct") || segments.includes("context_total");
 }
 
-function hasNonContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasNonContextSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	for (const segment of segments) {
 		if (!isContextSegment(segment)) return true;
 	}
 	return false;
 }
 
-function removeContextSegments(parts: string[], segments: StatusLineSegmentId[]): void {
+function removeContextSegments(parts: string[], segments: StatusLineSegmentRef[]): void {
 	let writeIndex = 0;
 	for (let readIndex = 0; readIndex < segments.length; readIndex++) {
 		const segment = segments[readIndex];
@@ -307,18 +307,18 @@ function removeContextSegments(parts: string[], segments: StatusLineSegmentId[])
 function formatEmbeddedContextPercent(percent: number): string {
 	return `${percent > 0 && percent < 1 ? percent.toFixed(1) : Math.round(percent)}%`;
 }
-function hasGitSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasGitSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("git");
 }
 
-function hasPrSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasPrSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("pr");
 }
-function hasPathSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasPathSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("path");
 }
 
-function hasGitBackedSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasGitBackedSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return hasGitSegment(segments) || hasPrSegment(segments);
 }
 
@@ -1807,7 +1807,7 @@ export class StatusLineComponent implements Component {
 
 		// Collect visible segment contents
 		const leftParts: string[] = [];
-		const leftSegIds: StatusLineSegmentId[] = [];
+		const leftSegIds: StatusLineSegmentRef[] = [];
 		const leftSegmentIds = layout === "plain-right" ? [] : effectiveSettings.leftSegments;
 		for (const segId of leftSegmentIds) {
 			if (subagentBadge && segId === "subagents") continue;
@@ -1819,7 +1819,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		const rightParts: string[] = [];
-		const rightSegIds: StatusLineSegmentId[] = [];
+		const rightSegIds: StatusLineSegmentRef[] = [];
 		const rightSegmentIds = layout === "plain-left" ? [] : effectiveSettings.rightSegments;
 		for (const segId of rightSegmentIds) {
 			if (subagentBadge && segId === "subagents") continue;

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -3,13 +3,20 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
+import type { StatusLineSegmentContext as ExtensionStatusLineSegmentContext } from "../../../extensibility/extensions/types";
 import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { sanitizeStatusText } from "../../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
-import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
+import type {
+	RenderedSegment,
+	SegmentContext,
+	StatusLineSegment,
+	StatusLineSegmentId,
+	StatusLineSegmentRef,
+} from "./types";
 
 export type { SegmentContext } from "./types";
 
@@ -755,12 +762,34 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	collab: collabSegment,
 };
 
-export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {
-	const segment = SEGMENTS[id];
-	if (!segment) {
-		return { content: "", visible: false };
-	}
-	return segment.render(ctx);
+function toExtensionStatusLineSegmentContext(ctx: SegmentContext): ExtensionStatusLineSegmentContext {
+	return {
+		width: ctx.width,
+		usage: {
+			inputTokens: ctx.usageStats.input,
+			outputTokens: ctx.usageStats.output,
+			cacheReadTokens: ctx.usageStats.cacheRead,
+			cacheWriteTokens: ctx.usageStats.cacheWrite,
+			totalTokens: ctx.usageStats.totalTokens,
+			cost: ctx.usageStats.cost,
+			tokensPerSecond: ctx.usageStats.tokensPerSecond,
+		},
+		contextPercent: ctx.contextPercent,
+		contextTokens: ctx.contextTokens,
+		contextWindow: ctx.contextWindow,
+		git: { branch: ctx.git.branch },
+		activeMs: ctx.activeMs,
+	};
+}
+
+export function renderSegment(id: StatusLineSegmentRef, ctx: SegmentContext): RenderedSegment {
+	const renderBase = (): RenderedSegment => {
+		const segment = SEGMENTS[id as StatusLineSegmentId];
+		return segment?.render(ctx) ?? { content: "", visible: false };
+	};
+	const extensionRunner = ctx.session.extensionRunner;
+	if (!extensionRunner?.hasStatusLineSegment(id)) return renderBase();
+	return extensionRunner.renderStatusLineSegment(id, toExtensionStatusLineSegmentContext(ctx), theme, renderBase);
 }
 
 export const ALL_SEGMENT_IDS: StatusLineSegmentId[] = Object.keys(SEGMENTS) as StatusLineSegmentId[];

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -3,13 +3,14 @@ import type {
 	ContextLineMode,
 	StatusLinePreset,
 	StatusLineSegmentId,
+	StatusLineSegmentRef,
 	StatusLineSeparatorStyle,
 } from "../../../config/settings-schema";
 import type { AgentSession } from "../../../session/agent-session";
 import type { ActiveRepoContext } from "../../../utils/active-repo-context";
 import type { LoopLimitRuntime } from "../../loop-limit";
 
-export type { ContextLineMode, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle };
+export type { ContextLineMode, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentRef, StatusLineSeparatorStyle };
 
 /** Collab session indicator + (guest-only) host-state override for segments. */
 export interface CollabStatus {
@@ -28,8 +29,8 @@ export interface StatusLineSegmentOptions {
 
 export interface StatusLineSettings {
 	preset?: StatusLinePreset;
-	leftSegments?: StatusLineSegmentId[];
-	rightSegments?: StatusLineSegmentId[];
+	leftSegments?: StatusLineSegmentRef[];
+	rightSegments?: StatusLineSegmentRef[];
 	separator?: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
 	showHookStatus?: boolean;

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -108,6 +108,7 @@ export class ExtensionUiController {
 			notify: (message, type) => this.showHookNotify(message, type),
 			onTerminalInput: handler => this.addExtensionTerminalInputListener(handler),
 			setStatus: (key, text) => this.setHookStatus(key, text),
+			refreshStatusLine: () => this.refreshStatusLine(),
 			setWorkingMessage: message => this.ctx.setWorkingMessage(message),
 			setWidget: (key, content, options) => this.setHookWidget(key, content, options),
 			setTitle: title => setExtensionTerminalTitle(title),
@@ -574,6 +575,12 @@ export class ExtensionUiController {
 	 */
 	setHookStatus(key: string, text: string | undefined): void {
 		this.ctx.statusLine.setHookStatus(key, text);
+		this.ctx.ui.requestRender();
+	}
+
+	/** Rebuild the editor top border after an extension changes segment state. */
+	refreshStatusLine(): void {
+		this.ctx.statusLine.invalidate();
 		this.ctx.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -817,6 +817,10 @@ export async function runRpcMode(
 			} as RpcExtensionUIRequest);
 		}
 
+		refreshStatusLine(): void {
+			// Status-line segments are interactive-TUI only.
+		}
+
 		setWorkingMessage(_message?: string): void {
 			// Not supported in RPC mode
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -369,6 +369,7 @@ const noOpUIContext: ExtensionUIContext = {
 	notify: () => {},
 	onTerminalInput: () => () => {},
 	setStatus: () => {},
+	refreshStatusLine: () => {},
 	setWorkingMessage: () => {},
 	setWidget: () => {},
 	setTitle: () => {},

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -531,6 +531,54 @@ describe("ExtensionRunner", () => {
 			expect(definition.style.id).toBe("extension-dock");
 		});
 	});
+
+	describe("status-line segments", () => {
+		it("registers and renders a named extension segment", async () => {
+			fs.writeFileSync(
+				path.join(extensionsDir, "status-line.ts"),
+				`export default function(pi) {
+					pi.registerStatusLineSegment("developer_cost", (_context, next) => {
+						const base = next();
+						return { content: base.content + " developer-cost", visible: true };
+					});
+				}`,
+			);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			const rendered = runner.renderStatusLineSegment(
+				"developer_cost",
+				{
+					width: 80,
+					usage: {
+						inputTokens: 0,
+						outputTokens: 0,
+						cacheReadTokens: 0,
+						cacheWriteTokens: 0,
+						totalTokens: 0,
+						cost: 0,
+						tokensPerSecond: null,
+					},
+					contextPercent: null,
+					contextTokens: 0,
+					contextWindow: 0,
+					git: null,
+					activeMs: 0,
+				},
+				undefined as never,
+				() => ({ content: "built-in", visible: false }),
+			);
+
+			expect(rendered).toEqual({ content: "built-in developer-cost", visible: true });
+		});
+	});
 	describe("flags", () => {
 		it("collects flags from extensions", async () => {
 			const extCode = `
@@ -2261,6 +2309,7 @@ describe("ExtensionRunner", () => {
 					notify: () => {},
 					onTerminalInput: () => () => {},
 					setStatus: () => {},
+					refreshStatusLine: () => {},
 					setWorkingMessage: () => {},
 					setWidget: () => {},
 					setFooter: () => {},
@@ -3857,6 +3906,7 @@ describe("ExtensionRunner", () => {
 				fileDeleteFallbackHandlers: [],
 				messageRenderers: new Map(),
 				composerShapes: new Map(),
+				statusLineSegments: new Map(),
 				commands: new Map(),
 				flags: new Map(),
 				shortcuts: new Map(),

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -510,6 +510,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 				fileDeleteFallbackHandlers: [],
 				messageRenderers: new Map(),
 				composerShapes: new Map(),
+				statusLineSegments: new Map(),
 				commands: new Map(),
 				flags: new Map(),
 				shortcuts: new Map(),

--- a/packages/coding-agent/test/status-line-extension-segments.test.ts
+++ b/packages/coding-agent/test/status-line-extension-segments.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type {
+	StatusLineSegmentContext,
+	StatusLineSegmentResult,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+const context: StatusLineSegmentContext = {
+	width: 80,
+	usage: {
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		totalTokens: 0,
+		cost: 0,
+		tokensPerSecond: null,
+	},
+	contextPercent: null,
+	contextTokens: 0,
+	contextWindow: 0,
+	git: null,
+	activeMs: 0,
+};
+
+function renderWithExtensions(
+	text: string,
+	renderers: Array<(next: () => StatusLineSegmentResult) => StatusLineSegmentResult>,
+): StatusLineSegmentResult {
+	const runner = {
+		extensions: renderers.map((renderer, index) => ({
+			path: `extension-${index}`,
+			statusLineSegments: new Map([
+				["mode", (_context: StatusLineSegmentContext, next: () => StatusLineSegmentResult) => renderer(next)],
+			]),
+		})),
+	} as unknown as ExtensionRunner;
+	return ExtensionRunner.prototype.renderStatusLineSegment.call(
+		runner,
+		"mode",
+		context,
+		undefined as unknown as Theme,
+		() => ({ content: text, visible: true }),
+	);
+}
+
+describe("ExtensionRunner status-line segment middleware", () => {
+	it("wraps the built-in result with later-loaded extensions outermost", () => {
+		const result = renderWithExtensions("built-in", [
+			next => {
+				const result = next();
+				return { ...result, content: `first(${result.content})` };
+			},
+			next => {
+				const result = next();
+				return { ...result, content: `second(${result.content})` };
+			},
+		]);
+
+		expect(result).toEqual({ content: "second(first(built-in))", visible: true });
+	});
+
+	it("falls through a throwing wrapper without rendering the base twice", () => {
+		let baseCalls = 0;
+		const runner = {
+			extensions: [
+				{
+					path: "broken-extension",
+					statusLineSegments: new Map([
+						[
+							"mode",
+							() => {
+								throw new Error("broken renderer");
+							},
+						],
+					]),
+				},
+			],
+		} as unknown as ExtensionRunner;
+
+		const result = ExtensionRunner.prototype.renderStatusLineSegment.call(
+			runner,
+			"mode",
+			context,
+			undefined as unknown as Theme,
+			() => {
+				baseCalls++;
+				return { content: "built-in", visible: true };
+			},
+		);
+
+		expect(result).toEqual({ content: "built-in", visible: true });
+		expect(baseCalls).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/status-line-extension-segments.test.ts
+++ b/packages/coding-agent/test/status-line-extension-segments.test.ts
@@ -93,4 +93,16 @@ describe("ExtensionRunner status-line segment middleware", () => {
 		expect(result).toEqual({ content: "built-in", visible: true });
 		expect(baseCalls).toBe(1);
 	});
+
+	it("neutralizes control characters in extension content while preserving ANSI SGR styling", () => {
+		const result = renderWithExtensions("built-in", [
+			_next => ({
+				content: "line1\nline2\tindented\x1b[31mred\x1b[39m",
+				visible: true,
+			}),
+		]);
+
+		expect(result.content).toBe("line1 line2 indented\x1b[31mred\x1b[39m");
+		expect(result.visible).toBe(true);
+	});
 });


### PR DESCRIPTION
## What

Adds `ExtensionAPI.registerStatusLineSegment(id, renderer)` so extensions can register new status-line segments or synchronously wrap built-in ones via `next()`. Adds `ctx.ui.refreshStatusLine()` so extensions can repaint the status line while idle after mutating their own renderer state.

## Why

Extensions had no way to surface custom state (build status, task progress, etc.) in the status line, or to augment built-in segments. OMP retains layout, overflow, and separator handling, and falls back safely if an extension renderer throws or returns an invalid result.

## Testing

- `bun run check:ts` passes for all packages, including `@oh-my-pi/pi-coding-agent`.
- `bun run check:rs` fails in this sandbox on an unrelated, pre-existing crate (`audiopus_sys`/opus via a bazel remote-cache lookup that fails here: `/cache/disk/disk (No such file or directory)`). This diff touches zero `.rs`/`Cargo.toml` files, so it cannot be the cause.
- `bun test packages/coding-agent/test/status-line-extension-segments.test.ts packages/coding-agent/test/extensions-runner.test.ts` could not be executed to a pass/fail verdict in this sandbox: both fail at import time because the `pi_natives` native addon binary isn't built/present here (`bun --cwd=packages/natives run build` also fails here, on an unrelated bazel config value `coder-vm` not defined). Confirmed pre-existing/environmental by reverting the new tests and re-running the untouched file — same failure. These tests need to be run in an environment with the native addon available before merge.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)