### PR TITLE
feat(coding-agent): add speech.duckGain setting for push-to-talk duck volume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `speech.duckGain` (0–1, default 0.25) to configure how far the assistant's speech ducks while push-to-talk is held, replacing the previously hardcoded constant so macOS users no longer need to patch and re-sign the binary ([#8282](https://github.com/can1357/oh-my-pi/issues/8282)).
+
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5117,6 +5117,17 @@ export const SETTINGS_SCHEMA = {
 			options: TTS_LOCAL_VOICE_OPTIONS,
 		},
 	},
+	"speech.duckGain": {
+		type: "number",
+		default: 0.25,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Speech Duck Gain",
+			description:
+				"Volume the assistant's speech ducks to while push-to-talk is held (0 = full mute, 1 = no ducking). Replaces the previously hardcoded 0.25 so macOS users don't need to patch and re-sign the binary (#8282)",
+		},
+	},
 	"providers.tinyModel": {
 		type: "enum",
 		values: TINY_TITLE_MODEL_VALUES,

--- a/packages/coding-agent/src/tts/vocalizer.ts
+++ b/packages/coding-agent/src/tts/vocalizer.ts
@@ -42,7 +42,7 @@ import { settings } from "../config/settings";
 import { DEFAULT_TTS_VOICE } from "./models";
 import { SpeakableStream } from "./speakable";
 import { BlockAccumulator, type SpeechEnhancer } from "./speech-enhancer";
-import { createStreamingPlayer, DUCK_GAIN } from "./streaming-player";
+import { createStreamingPlayer } from "./streaming-player";
 import { type TtsStreamHandle, ttsClient } from "./tts-client";
 
 /** Quiet time on the delta stream before the buffered partial is spoken. */
@@ -224,7 +224,7 @@ export class Vocalizer {
 	/** Lower the volume while the user is speaking (push-to-talk), so speech doesn't drown them out. */
 	duck(): void {
 		this.#ducked = true;
-		for (const player of this.#livePlayers) player.setGain(DUCK_GAIN);
+		for (const player of this.#livePlayers) player.setGain(resolveDuckGain());
 	}
 
 	/** Restore full volume once the user stops speaking. */
@@ -355,7 +355,7 @@ export class Vocalizer {
 		const voice = settings.get("speech.voice") || DEFAULT_TTS_VOICE;
 		const handle = ttsClient.synthesizeStream(modelKey, { voice, signal: abort.signal });
 		const player = this.#createPlayer();
-		player.setGain(this.#ducked ? DUCK_GAIN : 1);
+		player.setGain(this.#ducked ? resolveDuckGain() : 1);
 		this.#liveAborts.add(abort);
 		this.#livePlayers.add(player);
 		this.#chain = this.#chain.then(async () => {
@@ -413,6 +413,20 @@ export class Vocalizer {
 		}
 		player.stop();
 	}
+}
+
+/** Default duck gain, matching the historical hardcoded constant. */
+const DEFAULT_DUCK_GAIN = 0.25;
+
+/**
+ * Resolve the push-to-talk duck gain from the `speech.duckGain` setting.
+ * Clamped to 0..1 so an out-of-range config cannot amplify playback; a
+ * missing or non-finite value falls back to the historical 0.25 (#8282).
+ */
+export function resolveDuckGain(): number {
+	const configured = settings.get("speech.duckGain");
+	if (typeof configured !== "number" || !Number.isFinite(configured)) return DEFAULT_DUCK_GAIN;
+	return Math.min(Math.max(configured, 0), 1);
 }
 
 /** Process-level vocalizer shared by the event controller and the ask tool. */

--- a/packages/coding-agent/test/tts/duck-gain.test.ts
+++ b/packages/coding-agent/test/tts/duck-gain.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveDuckGain } from "@oh-my-pi/pi-coding-agent/tts/vocalizer";
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
+afterEach(() => {
+	resetSettingsForTest();
+});
+
+describe("resolveDuckGain (#8282)", () => {
+	it("defaults to the historical 0.25 when unset", () => {
+		expect(resolveDuckGain()).toBe(0.25);
+	});
+
+	it("returns the configured value", () => {
+		settings.set("speech.duckGain", 0);
+		expect(resolveDuckGain()).toBe(0);
+		settings.set("speech.duckGain", 0.5);
+		expect(resolveDuckGain()).toBe(0.5);
+		settings.set("speech.duckGain", 1);
+		expect(resolveDuckGain()).toBe(1);
+	});
+
+	it("clamps out-of-range values to 0..1", () => {
+		settings.set("speech.duckGain", -0.5);
+		expect(resolveDuckGain()).toBe(0);
+		settings.set("speech.duckGain", 2);
+		expect(resolveDuckGain()).toBe(1);
+	});
+
+	it("falls back to 0.25 on a non-finite value", () => {
+		settings.set("speech.duckGain", Number.NaN);
+		expect(resolveDuckGain()).toBe(0.25);
+	});
+});


### PR DESCRIPTION
Adds a configurable duck gain (`speech.duckGain`, 0–1, default 0.25) so macOS users can mute or adjust assistant speech while holding push-to-talk without patching and re-signing the binary — which breaks macOS TCC folder grants on every update.

Fixes #8282

## What

- New `speech.duckGain` setting (0–1, default 0.25) in `settings-schema.ts`.
- `resolveDuckGain()` in `vocalizer.ts` reads it at runtime, clamps to 0..1, and falls back to the historical 0.25 for missing/non-finite values.
- Both duck call sites — `Vocalizer.duck()` and new-session open (`#openSession`) — use it instead of the hardcoded `DUCK_GAIN` constant.

## Why

The duck gain was hardcoded (`DUCK_GAIN = 0.25`), so users wanting full mute patched the minified bundle and re-signed with `codesign`. Every update changed the binary hash, invalidated macOS TCC folder grants, and re-triggered the permission prompt — including for headless/daemon instances. A first-class setting removes the patch ritual entirely.

## Testing

- New unit tests in `test/tts/duck-gain.test.ts`: default 0.25, configured value, out-of-range clamping (0..1), and non-finite fallback.
- `bun check` + `bun test` pass (199 tests in tts + session suites).

---

I am a full-stack developer intern contributing to this project. Please review and let me know if any changes are needed.

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)