### PR TITLE
fix(collab): retain host UI requests until a writer joins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row
+- Fixed collab host UI requests raised before a writable guest joins being lost; up to 64 pending asks now replay to later writers ([#9031](https://github.com/can1357/oh-my-pi/pull/9031) by [@alphastorm](https://github.com/alphastorm)).
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The prompt border now colors Insert mode too (green), instead of falling through to the session accent. Normal and Visual were already colored, so Insert was the one mode the border could not distinguish — on themes whose accent matches the session accent it was indistinguishable from Normal. Borders outside Vim mode are unchanged.
 ### Fixed
 
+- Fixed collab host UI requests raised before a writable guest joins being lost; up to 64 pending asks now replay only to writable guests, and already-aborted asks no longer consume request IDs ([#9031](https://github.com/can1357/oh-my-pi/pull/9031) by [@alphastorm](https://github.com/alphastorm)).
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -111,6 +111,7 @@ const TRANSCRIPT_ENTRY_TOO_LARGE_ERROR = `transcript entry exceeds transcript fe
  * ship in a chunk of their own.
  */
 const SNAPSHOT_CHUNK_BYTES = 512 * 1024;
+const MAX_PENDING_UI_REQUESTS = 64;
 /**
  * Outcome of {@link CollabHost.requestGuestUi}. `answered` carries the guest's
  * response (an `undefined` value is a genuine guest cancel); `unavailable`
@@ -172,7 +173,7 @@ export class CollabHost {
 	}
 
 	requestGuestUi(request: CollabUiRequestDraft, signal?: AbortSignal): Promise<CollabGuestUiResult> | null {
-		if (!this.#socket || !this.#hasWritablePeers()) return null;
+		if (!this.#socket || signal?.aborted || this.#pendingUi.size >= MAX_PENDING_UI_REQUESTS) return null;
 		const reqId = ++this.#uiReqSeq;
 		const fullRequest: CollabUiRequest = { ...request, reqId };
 		const { promise, resolve } = Promise.withResolvers<CollabGuestUiResult>();
@@ -186,18 +187,10 @@ export class CollabHost {
 			resolve(result);
 		};
 		const onAbort = (): void => settle({ kind: "unavailable" });
-		if (signal?.aborted) return Promise.resolve({ kind: "unavailable" });
 		signal?.addEventListener("abort", onAbort, { once: true });
 		this.#pendingUi.set(reqId, { request: fullRequest, settle });
 		this.#sendWritablePeers({ t: "ui-request", request: fullRequest });
 		return promise;
-	}
-
-	#hasWritablePeers(): boolean {
-		for (const peer of this.#peers.values()) {
-			if (peer.canWrite) return true;
-		}
-		return false;
 	}
 
 	#sendWritablePeers(frame: CollabFrame): void {

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -112,6 +112,7 @@ const TRANSCRIPT_ENTRY_TOO_LARGE_ERROR = `transcript entry exceeds transcript fe
  * ship in a chunk of their own.
  */
 const SNAPSHOT_CHUNK_BYTES = 512 * 1024;
+const MAX_PENDING_UI_REQUESTS = 64;
 /**
  * Outcome of {@link CollabHost.requestGuestUi}. `answered` carries the guest's
  * response (an `undefined` value is a genuine guest cancel); `unavailable`
@@ -173,7 +174,7 @@ export class CollabHost {
 	}
 
 	requestGuestUi(request: CollabUiRequestDraft, signal?: AbortSignal): Promise<CollabGuestUiResult> | null {
-		if (!this.#socket || !this.#hasWritablePeers()) return null;
+		if (!this.#socket || signal?.aborted || this.#pendingUi.size >= MAX_PENDING_UI_REQUESTS) return null;
 		const reqId = ++this.#uiReqSeq;
 		const fullRequest: CollabUiRequest = { ...request, reqId };
 		const { promise, resolve } = Promise.withResolvers<CollabGuestUiResult>();
@@ -187,18 +188,10 @@ export class CollabHost {
 			resolve(result);
 		};
 		const onAbort = (): void => settle({ kind: "unavailable" });
-		if (signal?.aborted) return Promise.resolve({ kind: "unavailable" });
 		signal?.addEventListener("abort", onAbort, { once: true });
 		this.#pendingUi.set(reqId, { request: fullRequest, settle });
 		this.#sendWritablePeers({ t: "ui-request", request: fullRequest });
 		return promise;
-	}
-
-	#hasWritablePeers(): boolean {
-		for (const peer of this.#peers.values()) {
-			if (peer.canWrite) return true;
-		}
-		return false;
 	}
 
 	#sendWritablePeers(frame: CollabFrame): void {

--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
@@ -529,10 +529,14 @@ describe("collab proto handshake (#4049)", () => {
 			expect(reply.message).toContain("protocol mismatch");
 			expect(reply.message).toContain(`host speaks v${COLLAB_PROTO}`);
 			expect(reply.message).toContain(`guest sent v${COLLAB_PROTO - 1}`);
-			// The rejected guest was never admitted: no participant entry, and a
-			// host ask finds no writable peer to route to.
+			// The rejected guest was never admitted. A host ask is retained for a
+			// later writer instead of being exposed to the stale peer.
 			expect(host.participants.filter(p => p.role !== "host")).toEqual([]);
-			expect(host.requestGuestUi({ kind: "select", title: "anyone?", options: ["Yes"] })).toBeNull();
+			const abort = new AbortController();
+			const pending = host.requestGuestUi({ kind: "select", title: "anyone?", options: ["Yes"] }, abort.signal);
+			if (!pending) throw new Error("expected retained UI request");
+			abort.abort();
+			expect(await pending).toEqual({ kind: "unavailable" });
 		} finally {
 			guest.socket.close();
 			await host.stop("test done");

--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
@@ -529,10 +529,14 @@ describe("collab proto handshake (#4049)", () => {
 			expect(reply.message).toContain("protocol mismatch");
 			expect(reply.message).toContain(`host speaks v${COLLAB_PROTO}`);
 			expect(reply.message).toContain(`guest sent v${COLLAB_PROTO - 1}`);
-			// The rejected guest was never admitted: no participant entry, and a
-			// host ask finds no writable peer to route to.
+			// The rejected guest was never admitted. A host ask is retained for a
+			// later writer instead of being exposed to the stale peer.
 			expect(host.participants.filter(p => p.role !== "host")).toEqual([]);
-			expect(host.requestGuestUi({ kind: "select", title: "anyone?", options: ["Yes"] })).toBeNull();
+			const abort = new AbortController();
+			const pending = host.requestGuestUi({ kind: "select", title: "anyone?", options: ["Yes"] }, abort.signal);
+			if (!pending) throw new Error("expected retained UI request");
+			abort.abort();
+			expect(await pending).toEqual({ kind: "unavailable" });
 		} finally {
 			guest.socket.close();
 			await host.stop("test done");
@@ -674,6 +678,37 @@ describe("collab host dialog vs teardown (#4049 follow-up)", () => {
 			},
 		};
 	}
+
+	it("lets a later writer dismiss a host dialog that was opened with no peers", async () => {
+		const ctx = makeHostContext();
+		const host = new CollabHost(ctx);
+		await host.start("ws://localhost:8787");
+		ctx.collabHost = host;
+		const controller = new StubDialogController(ctx);
+		let guest: { socket: CollabSocket; nextFrame(): Promise<CollabFrame> } | undefined;
+		try {
+			const result = controller.showCollabAwareSelector("Deploy later?", ["Yes", "No"]);
+			const dialog = controller.localDialogs[0];
+			if (!dialog) throw new Error("expected the local dialog before a writer joined");
+
+			guest = await joinRawGuest(host.link, COLLAB_PROTO);
+			const welcome = await guest.nextFrame();
+			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+			// Force a directed frame after hello so a missing replay fails without
+			// relying on a timeout: the pending ui-request must precede this error.
+			guest.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+			const request = await guest.nextFrame();
+			if (request.t !== "ui-request") throw new Error(`expected ui-request, got ${request.t}`);
+			expect(request.request.title).toBe("Deploy later?");
+
+			guest.socket.send({ t: "ui-response", reqId: request.request.reqId, value: undefined });
+			expect(await result).toBeUndefined();
+			expect(dialog.signal?.aborted).toBe(true);
+		} finally {
+			guest?.socket.close();
+			await host.stop("test done");
+		}
+	});
 
 	it("keeps the local dialog running through collab teardown and returns its eventual answer", async () => {
 		const race = await openRace();

--- a/packages/coding-agent/test/collab/read-only.test.ts
+++ b/packages/coding-agent/test/collab/read-only.test.ts
@@ -169,6 +169,101 @@ afterAll(async () => {
 });
 
 describe("collab read-only links", () => {
+	it("retains host UI before any writer joins and replays it only to a later writer", async () => {
+		const abort = new AbortController();
+		const pending = host.requestGuestUi(
+			{ kind: "select", title: "Retained before join?", options: ["Yes"] },
+			abort.signal,
+		);
+		if (!pending) throw new Error("expected retained UI request");
+		try {
+			const viewer = await joinAsGuest(host.viewLink, "retained-viewer");
+			guestCleanups.push(() => viewer.socket.close());
+			const viewerWelcome = await viewer.nextFrame();
+			if (viewerWelcome.t !== "welcome") throw new Error(`expected welcome, got ${viewerWelcome.t}`);
+			expect(viewerWelcome.readOnly).toBe(true);
+
+			const writer = await joinAsGuest(host.link, "retained-writer");
+			guestCleanups.push(() => writer.socket.close());
+			const writerWelcome = await writer.nextFrame();
+			if (writerWelcome.t !== "welcome") throw new Error(`expected welcome, got ${writerWelcome.t}`);
+			const request = await writer.nextFrame();
+			if (request.t !== "ui-request") throw new Error(`expected ui-request, got ${request.t}`);
+			expect(request.request).toMatchObject({ title: "Retained before join?", options: ["Yes"] });
+
+			writer.socket.send({ t: "ui-response", reqId: request.request.reqId, value: "Yes" });
+			expect(await pending).toEqual({ kind: "answered", value: "Yes" });
+			expect(await writer.nextFrame()).toEqual({ t: "ui-request-end", reqId: request.request.reqId });
+		} finally {
+			abort.abort();
+		}
+	});
+
+	it("rejects a pre-aborted request without consuming a request ID", async () => {
+		const firstAbort = new AbortController();
+		const secondAbort = new AbortController();
+		const first = host.requestGuestUi({ kind: "editor", title: "First" }, firstAbort.signal);
+		if (!first) throw new Error("expected first retained request");
+		const preAborted = new AbortController();
+		preAborted.abort();
+		expect(host.requestGuestUi({ kind: "editor", title: "Rejected" }, preAborted.signal)).toBeNull();
+		const second = host.requestGuestUi({ kind: "editor", title: "Second" }, secondAbort.signal);
+		if (!second) throw new Error("expected second retained request");
+		try {
+			const writer = await joinAsGuest(host.link, "pre-abort-writer");
+			guestCleanups.push(() => writer.socket.close());
+			const welcome = await writer.nextFrame();
+			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+			const firstFrame = await writer.nextFrame();
+			const secondFrame = await writer.nextFrame();
+			if (firstFrame.t !== "ui-request" || secondFrame.t !== "ui-request") {
+				throw new Error("expected retained ui-request frames");
+			}
+			expect(secondFrame.request.reqId).toBe(firstFrame.request.reqId + 1);
+		} finally {
+			firstAbort.abort();
+			secondAbort.abort();
+			await Promise.all([first, second]);
+		}
+	});
+
+	it("caps retained host UI at 64 without consuming an ID for the rejected request", async () => {
+		const aborts = Array.from({ length: 64 }, () => new AbortController());
+		const pending = aborts.map((abort, index) => {
+			const request = host.requestGuestUi({ kind: "editor", title: `Pending ${index}` }, abort.signal);
+			if (!request) throw new Error(`request ${index} was rejected before the cap`);
+			return request;
+		});
+		const replacementAbort = new AbortController();
+		let replacement: Promise<unknown> | null = null;
+		try {
+			expect(host.requestGuestUi({ kind: "editor", title: "Overflow" })).toBeNull();
+			aborts[0]?.abort();
+			expect(await pending[0]).toEqual({ kind: "unavailable" });
+			replacement = host.requestGuestUi({ kind: "editor", title: "Replacement" }, replacementAbort.signal);
+			if (!replacement) throw new Error("expected replacement after releasing one request");
+
+			const writer = await joinAsGuest(host.link, "cap-writer");
+			guestCleanups.push(() => writer.socket.close());
+			const welcome = await writer.nextFrame();
+			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+			const requestIds: number[] = [];
+			for (let index = 0; index < 64; index += 1) {
+				const frame = await writer.nextFrame();
+				if (frame.t !== "ui-request") throw new Error(`expected ui-request, got ${frame.t}`);
+				requestIds.push(frame.request.reqId);
+			}
+			for (let index = 1; index < requestIds.length; index += 1) {
+				expect(requestIds[index]).toBe((requestIds[index - 1] ?? 0) + 1);
+			}
+		} finally {
+			for (const abort of aborts) abort.abort();
+			replacementAbort.abort();
+			await Promise.all(pending);
+			if (replacement) await replacement;
+		}
+	});
+
 	it("welcomes view-link guests read-only and refuses their mutating frames", async () => {
 		const { prompts, aborts } = harness;
 		expect(host.viewLink).not.toBe(host.link);

--- a/packages/coding-agent/test/collab/read-only.test.ts
+++ b/packages/coding-agent/test/collab/read-only.test.ts
@@ -169,6 +169,127 @@ afterAll(async () => {
 });
 
 describe("collab read-only links", () => {
+	it("retains host UI through a writer disconnect and replays it only to writable guests", async () => {
+		const abort = new AbortController();
+		const pending = host.requestGuestUi(
+			{ kind: "select", title: "Retained before join?", options: ["Yes"] },
+			abort.signal,
+		);
+		if (!pending) throw new Error("expected retained UI request");
+		try {
+			const viewer = await joinAsGuest(host.viewLink, "retained-viewer");
+			guestCleanups.push(() => viewer.socket.close());
+			const viewerWelcome = await viewer.nextFrame();
+			if (viewerWelcome.t !== "welcome") throw new Error(`expected welcome, got ${viewerWelcome.t}`);
+			expect(viewerWelcome.readOnly).toBe(true);
+			// This reply is ordered after every frame emitted during hello. If the
+			// retained ask leaked to the viewer, it would arrive before the error.
+			viewer.socket.send({ t: "prompt", text: "read-only barrier" });
+			const viewerReply = await viewer.nextFrame();
+			if (viewerReply.t !== "error") throw new Error(`expected error, got ${viewerReply.t}`);
+
+			const writer = await joinAsGuest(host.link, "retained-writer-first");
+			guestCleanups.push(() => writer.socket.close());
+			const writerWelcome = await writer.nextFrame();
+			if (writerWelcome.t !== "welcome") throw new Error(`expected welcome, got ${writerWelcome.t}`);
+			writer.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+			const request = await writer.nextFrame();
+			if (request.t !== "ui-request") throw new Error(`expected ui-request, got ${request.t}`);
+			expect(request.request).toMatchObject({ title: "Retained before join?", options: ["Yes"] });
+			const writerBarrier = await writer.nextFrame();
+			if (writerBarrier.t !== "error") throw new Error(`expected error, got ${writerBarrier.t}`);
+			writer.socket.close();
+
+			const replacement = await joinAsGuest(host.link, "retained-writer-replacement");
+			guestCleanups.push(() => replacement.socket.close());
+			const replacementWelcome = await replacement.nextFrame();
+			if (replacementWelcome.t !== "welcome") {
+				throw new Error(`expected welcome, got ${replacementWelcome.t}`);
+			}
+			replacement.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+			expect(await replacement.nextFrame()).toEqual(request);
+			const replacementBarrier = await replacement.nextFrame();
+			if (replacementBarrier.t !== "error") {
+				throw new Error(`expected error, got ${replacementBarrier.t}`);
+			}
+
+			replacement.socket.send({ t: "ui-response", reqId: request.request.reqId, value: "Yes" });
+			expect(await pending).toEqual({ kind: "answered", value: "Yes" });
+			expect(await replacement.nextFrame()).toEqual({ t: "ui-request-end", reqId: request.request.reqId });
+		} finally {
+			abort.abort();
+		}
+	});
+
+	it("rejects a pre-aborted request without consuming a request ID", async () => {
+		const firstAbort = new AbortController();
+		const secondAbort = new AbortController();
+		const first = host.requestGuestUi({ kind: "editor", title: "First" }, firstAbort.signal);
+		if (!first) throw new Error("expected first retained request");
+		const preAborted = new AbortController();
+		preAborted.abort();
+		expect(host.requestGuestUi({ kind: "editor", title: "Rejected" }, preAborted.signal)).toBeNull();
+		const second = host.requestGuestUi({ kind: "editor", title: "Second" }, secondAbort.signal);
+		if (!second) throw new Error("expected second retained request");
+		try {
+			const writer = await joinAsGuest(host.link, "pre-abort-writer");
+			guestCleanups.push(() => writer.socket.close());
+			const welcome = await writer.nextFrame();
+			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+			writer.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+			const firstFrame = await writer.nextFrame();
+			const secondFrame = await writer.nextFrame();
+			if (firstFrame.t !== "ui-request" || secondFrame.t !== "ui-request") {
+				throw new Error("expected retained ui-request frames");
+			}
+			expect(secondFrame.request.reqId).toBe(firstFrame.request.reqId + 1);
+		} finally {
+			firstAbort.abort();
+			secondAbort.abort();
+			await Promise.all([first, second]);
+		}
+	});
+
+	it("caps retained host UI at 64 and reuses an aborted slot without consuming an ID", async () => {
+		const aborts = Array.from({ length: 64 }, () => new AbortController());
+		const pending = aborts.map((abort, index) => {
+			const request = host.requestGuestUi({ kind: "editor", title: `Pending ${index}` }, abort.signal);
+			if (!request) throw new Error(`request ${index} was rejected before the cap`);
+			return request;
+		});
+		const replacementAbort = new AbortController();
+		let replacement: Promise<unknown> | null = null;
+		try {
+			expect(host.requestGuestUi({ kind: "editor", title: "Overflow" })).toBeNull();
+			aborts[0]?.abort();
+			expect(await pending[0]).toEqual({ kind: "unavailable" });
+			replacement = host.requestGuestUi({ kind: "editor", title: "Replacement" }, replacementAbort.signal);
+			if (!replacement) throw new Error("expected replacement after releasing one request");
+
+			const writer = await joinAsGuest(host.link, "cap-writer");
+			guestCleanups.push(() => writer.socket.close());
+			const welcome = await writer.nextFrame();
+			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+			writer.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+			const requestIds: number[] = [];
+			for (let index = 0; index < 64; index += 1) {
+				const frame = await writer.nextFrame();
+				if (frame.t !== "ui-request") throw new Error(`expected ui-request, got ${frame.t}`);
+				requestIds.push(frame.request.reqId);
+			}
+			const firstRequestId = requestIds[0];
+			if (firstRequestId === undefined) throw new Error("expected retained request IDs");
+			expect(requestIds).toEqual(Array.from({ length: 64 }, (_, index) => firstRequestId + index));
+			const barrier = await writer.nextFrame();
+			if (barrier.t !== "error") throw new Error(`expected error, got ${barrier.t}`);
+		} finally {
+			for (const abort of aborts) abort.abort();
+			replacementAbort.abort();
+			await Promise.all(pending);
+			if (replacement) await replacement;
+		}
+	});
+
 	it("welcomes view-link guests read-only and refuses their mutating frames", async () => {
 		const { prompts, aborts } = harness;
 		expect(host.viewLink).not.toBe(host.link);
@@ -267,28 +388,6 @@ describe("collab read-only links", () => {
 		expect(await pending).toEqual({ kind: "answered", value: "Yes" });
 		const end = await guest.nextFrame();
 		expect(end).toEqual({ t: "ui-request-end", reqId: request.request.reqId });
-	});
-
-	it("replays pending host UI requests to writable guests that join later", async () => {
-		const firstGuest = await joinAsGuest(host.link, "writer-ui-first");
-		guestCleanups.push(() => firstGuest.socket.close());
-		const firstWelcome = await firstGuest.nextFrame();
-		if (firstWelcome.t !== "welcome") throw new Error(`expected welcome, got ${firstWelcome.t}`);
-
-		const pending = host.requestGuestUi({ kind: "editor", title: "Pending?", prefill: "draft" });
-		if (!pending) throw new Error("expected writable guest UI request");
-		const firstRequest = await firstGuest.nextFrame();
-		if (firstRequest.t !== "ui-request") throw new Error(`expected ui-request, got ${firstRequest.t}`);
-
-		const secondGuest = await joinAsGuest(host.link, "writer-ui-second");
-		guestCleanups.push(() => secondGuest.socket.close());
-		const secondWelcome = await secondGuest.nextFrame();
-		if (secondWelcome.t !== "welcome") throw new Error(`expected welcome, got ${secondWelcome.t}`);
-		const replayed = await secondGuest.nextFrame();
-		expect(replayed).toEqual(firstRequest);
-
-		secondGuest.socket.send({ t: "ui-response", reqId: firstRequest.request.reqId, value: "late" });
-		expect(await pending).toEqual({ kind: "answered", value: "late" });
 	});
 
 	it("treats a forged write token as read-only", async () => {


### PR DESCRIPTION
## Problem

`CollabHost` already replayed an outstanding UI request when another writable guest joined. The missing case was an ask raised before any writer existed: `requestGuestUi()` returned `null`, so no pending entry existed to replay. Hosts asking with zero peers—or only view-only peers—lost the remote ask.

## Change

- Retain host UI requests while the collab socket is live, even with no current writer.
- Replay pending asks only to writable guests.
- Reject already-aborted asks before allocating a request ID.
- Bound retained asks at 64; abort, answer, and teardown still settle and remove them.

### Maintainer decision

This intentionally changes the default behavior of `#raceCollabDialog`: a host dialog opened with zero peers now has a retained remote side. A writer joining later can answer or cancel it, which can dismiss the still-open local dialog. Possession of the write token remains the authority boundary; view-only guests receive no UI request.

Please confirm that this should be the default rather than an opt-in setting. Context: https://github.com/can1357/oh-my-pi/discussions/6460

## Verification

Rebased onto upstream `6abe169e117ea3955a5973fd9782b661d16738f2`. Final tests fail against the pre-fix `host.ts` (`18 pass, 5 fail`) and pass with the change:

```sh
bun test packages/coding-agent/test/collab/read-only.test.ts \
  packages/coding-agent/test/collab/guest-ui-request.test.ts
# 23 pass, 0 fail, 78 expect() calls

bun --cwd=packages/coding-agent run check:types
# clean
```

The regressions cover zero-writer/later-writer behavior, view-only isolation, writer disconnect and replay, later-writer cancellation of an open host dialog, abort/pre-abort cleanup, and the 64-entry cap. Focused `oxlint` and `oxfmt --check` runs on the changed files also pass.

