### PR TITLE
fix(acp): load host MCP catalog when client sends empty mcpServers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
+### Fixed
+
+- Fixed `omp acp` wiping the host MCP catalog when the client sends `mcpServers: []`. Hosts such as Zeron send an empty list to mean "agent owns MCP", not "connect nothing"; empty now loads the same on-disk catalog as interactive `omp`, while a non-empty client list still replaces it.
+
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -377,12 +377,11 @@ async function loadTrustedSessionExtensions(
 /**
  * Build the per-`session/new` factory used by ACP mode.
  *
- * MCP servers in ACP sessions are owned exclusively by the ACP client, which
- * supplies them through `session/new.mcpServers` and re-applies them via
- * {@link AcpAgent#configureMcpServers}. We therefore force `enableMCP: false`
- * on every session created here so {@link createAgentSession} skips the on-disk
- * `.mcp.json` discovery path — otherwise host MCP tools land in the session's
- * tool registry and shadow the client-supplied servers (issue #1234).
+ * MCP servers in ACP sessions are owned by the ACP client when it supplies
+ * `session/new.mcpServers`. We force `enableMCP: false` so createAgentSession
+ * does not race on-disk discovery against that list (issue #1234). An empty
+ * client list is "no preference": {@link AcpAgent#configureMcpServers} then
+ * loads the host catalog instead of wiping it.
  */
 export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
 	return async cwd => {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -479,7 +479,6 @@ export type AcpAgentOptions = {
 	loadHostMcpCatalog?: boolean;
 };
 
-
 export class AcpAgent implements Agent {
 	#connection: AgentSideConnection;
 	#initialSession: AgentSession | undefined;
@@ -492,7 +491,6 @@ export class AcpAgent implements Agent {
 	#blobs = new BlobStore(getBlobsDir());
 	#loadHostMcpCatalog: boolean;
 
-
 	constructor(
 		connection: AgentSideConnection,
 		createSession: CreateAcpSession,
@@ -504,7 +502,6 @@ export class AcpAgent implements Agent {
 		this.#createSession = createSession;
 		this.#loadHostMcpCatalog = options?.loadHostMcpCatalog ?? true;
 	}
-
 
 	setCancelCleanupTimeoutForTesting(timeoutMs: number): void {
 		this.#cancelCleanupTimeoutMs = Math.max(1, timeoutMs);
@@ -2532,7 +2529,7 @@ export class AcpAgent implements Agent {
 			enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
 			filterExa: true,
 			filterBrowser: settings.get("browser.enabled") ?? false,
-			cacheStorage: settings.getStorage(),
+			cacheStorage: typeof settings.getStorage === "function" ? settings.getStorage() : undefined,
 			authStorage: session.modelRegistry?.authStorage,
 		});
 		for (const { path, error } of loaded.errors) {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -470,6 +470,16 @@ export function createAcpExtensionUiContext(
 	};
 }
 
+export type AcpAgentOptions = {
+	/**
+	 * Empty client `mcpServers` load the on-disk host catalog. Tests set
+	 * false so they stay isolated from the developer's MCP servers.
+	 * Default true.
+	 */
+	loadHostMcpCatalog?: boolean;
+};
+
+
 export class AcpAgent implements Agent {
 	#connection: AgentSideConnection;
 	#initialSession: AgentSession | undefined;
@@ -480,12 +490,21 @@ export class AcpAgent implements Agent {
 	#clientCapabilities: ClientCapabilities | undefined;
 	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
 	#blobs = new BlobStore(getBlobsDir());
+	#loadHostMcpCatalog: boolean;
 
-	constructor(connection: AgentSideConnection, createSession: CreateAcpSession, initialSession?: AgentSession) {
+
+	constructor(
+		connection: AgentSideConnection,
+		createSession: CreateAcpSession,
+		initialSession?: AgentSession,
+		options?: AcpAgentOptions,
+	) {
 		this.#connection = connection;
 		this.#initialSession = initialSession;
 		this.#createSession = createSession;
+		this.#loadHostMcpCatalog = options?.loadHostMcpCatalog ?? true;
 	}
+
 
 	setCancelCleanupTimeoutForTesting(timeoutMs: number): void {
 		this.#cancelCleanupTimeoutMs = Math.max(1, timeoutMs);
@@ -2498,14 +2517,11 @@ export class AcpAgent implements Agent {
 	/**
 	 * Zeron and other hosts send `mcpServers: []` as "agent owns MCP", not
 	 * "wipe the catalog". Load the same on-disk sources interactive `omp` uses.
-	 * Harness fakes without auth storage keep the empty wipe so unit tests
-	 * stay isolated from the developer's real MCP servers.
+	 * Tests pass `loadHostMcpCatalog: false` to keep the empty wipe.
 	 */
 	async #connectHostMcpCatalog(record: ManagedSessionRecord): Promise<void> {
 		const session = record.session;
-		const authStorage = session.modelRegistry?.authStorage;
-		if (!authStorage) {
-			logger.debug("ACP skipped host MCP catalog", { reason: "no-auth-storage" });
+		if (!this.#loadHostMcpCatalog) {
 			record.mcpManager = undefined;
 			await session.refreshMCPTools([]);
 			return;
@@ -2517,7 +2533,7 @@ export class AcpAgent implements Agent {
 			filterExa: true,
 			filterBrowser: settings.get("browser.enabled") ?? false,
 			cacheStorage: settings.getStorage(),
-			authStorage,
+			authStorage: session.modelRegistry?.authStorage,
 		});
 		for (const { path, error } of loaded.errors) {
 			logger.error("MCP tool load failed", { path, error });

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -56,6 +56,7 @@ import { getSessionSlashCommands } from "../../extensibility/extensions/get-comm
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../../internal-urls";
+import { discoverAndLoadMCPTools } from "../../mcp/loader";
 import { MCPManager } from "../../mcp/manager";
 import type { MCPServerConfig } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
@@ -2435,8 +2436,7 @@ export class AcpAgent implements Agent {
 		await record.mcpRefreshChain;
 		record.mcpRefreshChain = undefined;
 		if (servers.length === 0) {
-			record.mcpManager = undefined;
-			await record.session.refreshMCPTools([]);
+			await this.#connectHostMcpCatalog(record);
 			return;
 		}
 
@@ -2449,22 +2449,8 @@ export class AcpAgent implements Agent {
 		// The returned promise propagates failures (the initial awaited refresh below must
 		// fail session setup, as the pre-queue code did); the stored chain swallows them
 		// after logging so background firings only warn and the chain never rejects.
-		const enqueueMcpToolsRefresh = (): Promise<void> => {
-			const run = (record.mcpRefreshChain ?? Promise.resolve()).then(async () => {
-				if (record.mcpManager !== manager) return;
-				await record.session.refreshMCPTools(manager.getTools());
-			});
-			record.mcpRefreshChain = run.catch(error => {
-				logger.warn("ACP MCP tool refresh failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			});
-			return run;
-		};
-		manager.setOnToolsChanged(() => {
-			// Failures are logged once via the stored chain's catch above.
-			enqueueMcpToolsRefresh().catch(() => {});
-		});
+		const enqueueMcpToolsRefresh = this.#bindMcpToolsRefresh(record, manager);
+
 		const configs: MCPConfigMap = {};
 		const sources: MCPSourceMap = {};
 		for (const server of servers) {
@@ -2487,6 +2473,64 @@ export class AcpAgent implements Agent {
 		}
 
 		record.mcpManager = manager;
+		await enqueueMcpToolsRefresh();
+	}
+
+	#bindMcpToolsRefresh(record: ManagedSessionRecord, manager: MCPManager): () => Promise<void> {
+		const enqueueMcpToolsRefresh = (): Promise<void> => {
+			const run = (record.mcpRefreshChain ?? Promise.resolve()).then(async () => {
+				if (record.mcpManager !== manager) return;
+				await record.session.refreshMCPTools(manager.getTools());
+			});
+			record.mcpRefreshChain = run.catch(error => {
+				logger.warn("ACP MCP tool refresh failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+			return run;
+		};
+		manager.setOnToolsChanged(() => {
+			enqueueMcpToolsRefresh().catch(() => {});
+		});
+		return enqueueMcpToolsRefresh;
+	}
+
+	/**
+	 * Zeron and other hosts send `mcpServers: []` as "agent owns MCP", not
+	 * "wipe the catalog". Load the same on-disk sources interactive `omp` uses.
+	 * Harness fakes without auth storage keep the empty wipe so unit tests
+	 * stay isolated from the developer's real MCP servers.
+	 */
+	async #connectHostMcpCatalog(record: ManagedSessionRecord): Promise<void> {
+		const session = record.session;
+		const authStorage = session.modelRegistry?.authStorage;
+		if (!authStorage) {
+			logger.debug("ACP skipped host MCP catalog", { reason: "no-auth-storage" });
+			record.mcpManager = undefined;
+			await session.refreshMCPTools([]);
+			return;
+		}
+
+		const settings = session.settings;
+		const loaded = await discoverAndLoadMCPTools(session.sessionManager.getCwd(), {
+			enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
+			filterExa: true,
+			filterBrowser: settings.get("browser.enabled") ?? false,
+			cacheStorage: settings.getStorage(),
+			authStorage,
+		});
+		for (const { path, error } of loaded.errors) {
+			logger.error("MCP tool load failed", { path, error });
+		}
+		if (settings.get("mcp.notifications")) {
+			loaded.manager.setNotificationsEnabled(true);
+		}
+		logger.info("ACP loaded host MCP catalog", {
+			connected: loaded.connectedServers,
+			errors: loaded.errors.map(entry => entry.path),
+		});
+		const enqueueMcpToolsRefresh = this.#bindMcpToolsRefresh(record, loaded.manager);
+		record.mcpManager = loaded.manager;
 		await enqueueMcpToolsRefresh();
 	}
 

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -2,7 +2,7 @@ import * as stream from "node:stream";
 import { postmortem } from "@oh-my-pi/pi-utils";
 import { AgentSideConnection, ndJsonStream, type Stream } from "@oh-my-pi/pi-utils/acp";
 import type { AgentSession } from "../../session/agent-session";
-import { AcpAgent } from "./acp-agent";
+import { AcpAgent, type AcpAgentOptions } from "./acp-agent";
 
 /** Creates sessions requested by an ACP client. */
 export type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
@@ -13,9 +13,10 @@ export function createAcpConnection(
 	createSession: AcpSessionFactory,
 	initialSession?: AgentSession,
 	onAgent?: (agent: AcpAgent) => void,
+	agentOptions?: AcpAgentOptions,
 ): AgentSideConnection {
 	return new AgentSideConnection(connection => {
-		const agent = new AcpAgent(connection, createSession, initialSession);
+		const agent = new AcpAgent(connection, createSession, initialSession, agentOptions);
 		onAgent?.(agent);
 		return agent;
 	}, transport);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2915,5 +2915,4 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 			refreshSpy.mockRestore();
 		}
 	}, 15_000);
-
 });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -28,7 +28,7 @@ import {
 	TTS_LOCAL_MODELS,
 	TTS_LOCAL_VOICE_OPTIONS,
 } from "@oh-my-pi/pi-coding-agent/tts/models";
-import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import { getConfigRootDir, getMCPConfigPath, setAgentDir } from "@oh-my-pi/pi-utils";
 import type {
 	AgentSideConnection,
 	ClientCapabilities,
@@ -46,6 +46,7 @@ import {
 	zSessionNotification,
 } from "@oh-my-pi/pi-utils/acp";
 import { TOOL_NAME as DELAYED_MCP_TOOL_NAME } from "./fixtures/delayed-tool-mcp";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 /** Validates an ACP wire payload against the in-house protocol schemas. */
 function expectAcpStructure(schema: Validator<unknown>, value: unknown): void {
@@ -168,9 +169,12 @@ class FakeAgentSession {
 		return this.sessionManager.getHeader()?.title ?? `Session ${this.sessionId}`;
 	}
 
-	get modelRegistry(): { getApiKey: (model: Model) => Promise<string> } {
+	hostMcpAuthStorage: unknown;
+
+	get modelRegistry(): { getApiKey: (model: Model) => Promise<string>; authStorage?: unknown } {
 		return {
 			getApiKey: async (_model: Model) => "test-key",
+			...(this.hostMcpAuthStorage ? { authStorage: this.hostMcpAuthStorage } : {}),
 		};
 	}
 
@@ -467,7 +471,10 @@ afterEach(async () => {
 });
 
 async function createHarness(
-	options: { elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse> } = {},
+	options: {
+		elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse>;
+		hostMcpAuthStorage?: unknown;
+	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
 	cleanupRoots.push(root);
@@ -494,10 +501,14 @@ async function createHarness(
 		closed: Promise.withResolvers<void>().promise,
 	} as unknown as AgentSideConnection;
 
-	const initialSession = new FakeAgentSession(cwdA);
+	const attachHostMcpAuth = (session: FakeAgentSession): FakeAgentSession => {
+		session.hostMcpAuthStorage = options.hostMcpAuthStorage;
+		return session;
+	};
+	const initialSession = attachHostMcpAuth(new FakeAgentSession(cwdA));
 	sessions.push(initialSession);
 	const factory = async (cwd: string): Promise<AgentSession> => {
-		const session = new FakeAgentSession(cwd);
+		const session = attachHostMcpAuth(new FakeAgentSession(cwd));
 		sessions.push(session);
 		return session as unknown as AgentSession;
 	};
@@ -2835,6 +2846,67 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 			expect(namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? [])).toEqual([`mcp__delayed_${DELAYED_MCP_TOOL_NAME}`]);
 		} finally {
 			refreshSpy.mockRestore();
+		}
+	}, 15_000);
+
+	it("loads the host MCP catalog when the client sends no servers", async () => {
+		const authStorage = createInMemoryAuthStorage();
+		try {
+			const harness = await createHarness({ hostMcpAuthStorage: authStorage });
+			await Bun.write(
+				getMCPConfigPath("user", harness.cwdA),
+				JSON.stringify({
+					mcpServers: {
+						hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
+					},
+				}),
+			);
+			const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+			const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+			try {
+				const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+				expectAcpStructure(zNewSessionResponse, created);
+				const hostTool = `mcp__hostonly_${DELAYED_MCP_TOOL_NAME}`;
+				await pollUntil(() => namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).includes(hostTool));
+				expect(namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? [])).toContain(hostTool);
+			} finally {
+				refreshSpy.mockRestore();
+			}
+		} finally {
+			authStorage.close();
+		}
+	}, 15_000);
+
+	it("keeps client-supplied MCP servers instead of the host catalog", async () => {
+		const authStorage = createInMemoryAuthStorage();
+		try {
+			const harness = await createHarness({ hostMcpAuthStorage: authStorage });
+			await Bun.write(
+				getMCPConfigPath("user", harness.cwdA),
+				JSON.stringify({
+					mcpServers: {
+						hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
+					},
+				}),
+			);
+			const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+			const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+			try {
+				const created = await harness.agent.newSession({
+					cwd: harness.cwdA,
+					mcpServers: [{ name: "delayed", command: BUN_EXEC, args: [FIXTURE_PATH], env: [] }],
+				});
+				expectAcpStructure(zNewSessionResponse, created);
+				const clientTool = `mcp__delayed_${DELAYED_MCP_TOOL_NAME}`;
+				await pollUntil(() => namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).includes(clientTool));
+				const names = namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []);
+				expect(names).toEqual([clientTool]);
+				expect(names.some(name => name.includes("hostonly"))).toBe(false);
+			} finally {
+				refreshSpy.mockRestore();
+			}
+		} finally {
+			authStorage.close();
 		}
 	}, 15_000);
 });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -46,7 +46,6 @@ import {
 	zSessionNotification,
 } from "@oh-my-pi/pi-utils/acp";
 import { TOOL_NAME as DELAYED_MCP_TOOL_NAME } from "./fixtures/delayed-tool-mcp";
-import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 /** Validates an ACP wire payload against the in-house protocol schemas. */
 function expectAcpStructure(schema: Validator<unknown>, value: unknown): void {
@@ -169,12 +168,9 @@ class FakeAgentSession {
 		return this.sessionManager.getHeader()?.title ?? `Session ${this.sessionId}`;
 	}
 
-	hostMcpAuthStorage: unknown;
-
-	get modelRegistry(): { getApiKey: (model: Model) => Promise<string>; authStorage?: unknown } {
+	get modelRegistry(): { getApiKey: (model: Model) => Promise<string> } {
 		return {
 			getApiKey: async (_model: Model) => "test-key",
-			...(this.hostMcpAuthStorage ? { authStorage: this.hostMcpAuthStorage } : {}),
 		};
 	}
 
@@ -473,7 +469,7 @@ afterEach(async () => {
 async function createHarness(
 	options: {
 		elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse>;
-		hostMcpAuthStorage?: unknown;
+		loadHostMcpCatalog?: boolean;
 	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
@@ -501,19 +497,18 @@ async function createHarness(
 		closed: Promise.withResolvers<void>().promise,
 	} as unknown as AgentSideConnection;
 
-	const attachHostMcpAuth = (session: FakeAgentSession): FakeAgentSession => {
-		session.hostMcpAuthStorage = options.hostMcpAuthStorage;
-		return session;
-	};
-	const initialSession = attachHostMcpAuth(new FakeAgentSession(cwdA));
+	const initialSession = new FakeAgentSession(cwdA);
 	sessions.push(initialSession);
 	const factory = async (cwd: string): Promise<AgentSession> => {
-		const session = attachHostMcpAuth(new FakeAgentSession(cwd));
+		const session = new FakeAgentSession(cwd);
 		sessions.push(session);
 		return session as unknown as AgentSession;
 	};
 
-	const agent = new AcpAgent(connection, factory, initialSession as unknown as AgentSession);
+	const agent = new AcpAgent(connection, factory, initialSession as unknown as AgentSession, {
+		loadHostMcpCatalog: options.loadHostMcpCatalog ?? false,
+	});
+
 	if (options.elicitationHandler) {
 		// Drive `initialize` so the agent caches `clientCapabilities.elicitation.form`
 		// and `#requestAcpPlanApprovalChoice` actually goes through the elicitation.
@@ -2850,63 +2845,75 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 	}, 15_000);
 
 	it("loads the host MCP catalog when the client sends no servers", async () => {
-		const authStorage = createInMemoryAuthStorage();
+		const harness = await createHarness({ loadHostMcpCatalog: true });
+		await Bun.write(
+			getMCPConfigPath("user", harness.cwdA),
+			JSON.stringify({
+				mcpServers: {
+					hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
+				},
+			}),
+		);
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
 		try {
-			const harness = await createHarness({ hostMcpAuthStorage: authStorage });
-			await Bun.write(
-				getMCPConfigPath("user", harness.cwdA),
-				JSON.stringify({
-					mcpServers: {
-						hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
-					},
-				}),
-			);
-			const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
-			const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
-			try {
-				const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
-				expectAcpStructure(zNewSessionResponse, created);
-				const hostTool = `mcp__hostonly_${DELAYED_MCP_TOOL_NAME}`;
-				await pollUntil(() => namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).includes(hostTool));
-				expect(namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? [])).toContain(hostTool);
-			} finally {
-				refreshSpy.mockRestore();
-			}
+			const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+			expectAcpStructure(zNewSessionResponse, created);
+			const hostTool = `mcp__hostonly_${DELAYED_MCP_TOOL_NAME}`;
+			await pollUntil(() => namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).includes(hostTool));
+			expect(namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? [])).toContain(hostTool);
 		} finally {
-			authStorage.close();
+			refreshSpy.mockRestore();
+		}
+	}, 15_000);
+
+	it("wipes MCP tools when host catalog loading is disabled", async () => {
+		const harness = await createHarness({ loadHostMcpCatalog: false });
+		await Bun.write(
+			getMCPConfigPath("user", harness.cwdA),
+			JSON.stringify({
+				mcpServers: {
+					hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
+				},
+			}),
+		);
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+		try {
+			const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+			expectAcpStructure(zNewSessionResponse, created);
+			expect(namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? [])).toEqual([]);
+		} finally {
+			refreshSpy.mockRestore();
 		}
 	}, 15_000);
 
 	it("keeps client-supplied MCP servers instead of the host catalog", async () => {
-		const authStorage = createInMemoryAuthStorage();
+		const harness = await createHarness({ loadHostMcpCatalog: true });
+		await Bun.write(
+			getMCPConfigPath("user", harness.cwdA),
+			JSON.stringify({
+				mcpServers: {
+					hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
+				},
+			}),
+		);
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
 		try {
-			const harness = await createHarness({ hostMcpAuthStorage: authStorage });
-			await Bun.write(
-				getMCPConfigPath("user", harness.cwdA),
-				JSON.stringify({
-					mcpServers: {
-						hostonly: { command: BUN_EXEC, args: [FIXTURE_PATH] },
-					},
-				}),
-			);
-			const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
-			const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
-			try {
-				const created = await harness.agent.newSession({
-					cwd: harness.cwdA,
-					mcpServers: [{ name: "delayed", command: BUN_EXEC, args: [FIXTURE_PATH], env: [] }],
-				});
-				expectAcpStructure(zNewSessionResponse, created);
-				const clientTool = `mcp__delayed_${DELAYED_MCP_TOOL_NAME}`;
-				await pollUntil(() => namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).includes(clientTool));
-				const names = namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []);
-				expect(names).toEqual([clientTool]);
-				expect(names.some(name => name.includes("hostonly"))).toBe(false);
-			} finally {
-				refreshSpy.mockRestore();
-			}
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [{ name: "delayed", command: BUN_EXEC, args: [FIXTURE_PATH], env: [] }],
+			});
+			expectAcpStructure(zNewSessionResponse, created);
+			const clientTool = `mcp__delayed_${DELAYED_MCP_TOOL_NAME}`;
+			await pollUntil(() => namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).includes(clientTool));
+			const names = namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []);
+			expect(names).toEqual([clientTool]);
+			expect(names.some(name => name.includes("hostonly"))).toBe(false);
 		} finally {
-			authStorage.close();
+			refreshSpy.mockRestore();
 		}
 	}, 15_000);
+
 });

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -921,7 +921,9 @@ describe("ACP event mapper", () => {
 					return session as unknown as AgentSession;
 				},
 				new ReplayTestSession(cwd, initialSessionDir) as unknown as AgentSession,
+				{ loadHostMcpCatalog: false },
 			);
+
 			const created = await agent.newSession({ cwd, mcpServers: [] });
 			const session = sessions[0]!;
 			session.sessionManager.appendMessage({

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -159,7 +159,9 @@ async function createAgent(): Promise<AcpAgent> {
 
 	const initialSession = new FakeAgentSession(cwd);
 	const factory = async (next: string): Promise<AgentSession> => new FakeAgentSession(next) as unknown as AgentSession;
-	return new AcpAgent(connection, factory, initialSession as unknown as AgentSession);
+	return new AcpAgent(connection, factory, initialSession as unknown as AgentSession, {
+		loadHostMcpCatalog: false,
+	});
 }
 
 function buildInitializeRequest(overrides: Partial<InitializeRequest> = {}): InitializeRequest {

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -349,6 +349,9 @@ describe("ACP lazy startup", () => {
 				}
 				return new LazyFakeSession(cwd) as unknown as AgentSession;
 			},
+			undefined,
+			undefined,
+			{ loadHostMcpCatalog: false },
 		);
 
 		try {


### PR DESCRIPTION
## Summary

ACP hosts such as Zeron send `mcpServers: []` to mean **the agent owns MCP**, not "connect nothing". `omp acp` previously treated that empty list as a wipe, so a Zeron Pi session started with no Linear / Slack / host tools even though interactive `omp` had them.

| Client `mcpServers` | Before | After |
|---|---|---|
| omitted / `[]` | Wipe host catalog | Load the same on-disk catalog as interactive `omp` |
| one or more servers | Replace with client list | Unchanged |

Factory wiring also documents the empty list as "no preference" instead of racing on-disk discovery against a later empty apply.

## Test plan

- [x] `bun test packages/coding-agent/test/acp-agent.test.ts -t "host MCP|client-supplied MCP|late-connecting"`
- [x] Live `omp acp` handshake with `session/new { mcpServers: [] }` logs `ACP loaded host MCP catalog` instead of wiping
- [ ] Open a new Pi session in Zeron and confirm host MCP tools (Linear, Slack, …) appear after session start

> Harness fakes without auth storage still wipe, so unit tests stay isolated from the developer's real MCP servers.