### PR TITLE
fix(tui): keep a running tool block out of native scrollback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tool blocks no longer commit their spinner head and preview rows to native scrollback while they run, so a completed call cannot re-anchor the committed prefix and duplicate its box in a multiplexer pane ([#8881](https://github.com/can1357/oh-my-pi/issues/8881)).
+
 ### Added
 
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -876,17 +876,16 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	/**
-	 * Keeps in-flight TV-wall frames out of immutable native scrollback: the
-	 * `vibe_wait` wall, displaceable snapshots (`hub` waiting polls, `todo`
-	 * lists), and live `task` calls. Their frames replace each other rather
-	 * than append — task progress rows rewrite in place on every snapshot —
-	 * so an unpinned commit records a per-tick frozen snapshot (and for
-	 * displaceable blocks force-seals them, stacking the next poll below).
-	 * The finalized frame commits exactly once when the pin lifts.
+	 * Keeps in-flight frames out of immutable native scrollback. An unfinalized
+	 * block still rewrites rows it already rendered — a preview replaced by the
+	 * result, a TV-wall frame replacing its predecessor — so committing them
+	 * guarantees a later committed-prefix re-anchor, and on a multiplexer that
+	 * cannot erase scrollback the engine recommits the block below its stale
+	 * copy (issue #8881). Height is not a concern: an unfinalized block renders
+	 * a bounded preview, and the finalized frame commits once the pin lifts.
 	 */
 	isNativeScrollbackLiveRegionPinned(): boolean {
-		if (this.isTranscriptBlockFinalized()) return false;
-		return this.#toolName === "vibe_wait" || this.#toolName === "task" || this.#displaceableByToolName !== undefined;
+		return !this.isTranscriptBlockFinalized();
 	}
 
 	/**

--- a/packages/coding-agent/test/transcript-history-exactly-once.test.ts
+++ b/packages/coding-agent/test/transcript-history-exactly-once.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import {
+	stopSharedSpinnerTicker,
+	ToolExecutionComponent,
+} from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { type Component, TUI } from "@oh-my-pi/pi-tui";
 import { StressRenderScheduler } from "../../tui/test/render-stress-scheduler";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
@@ -99,5 +104,85 @@ describe("transcript committed history", () => {
 	it("keeps version-untracked committed history exactly once on the tape", async () => {
 		const counts = await streamPastCommit(false);
 		expect([...counts.entries()].filter(([, count]) => count > 1)).toEqual([]);
+	});
+});
+
+/**
+ * Streams a real foreground tool call past the commit boundary and then lands
+ * its result. Regression guard for #8881: an unfinalized block rewrites rows it
+ * already rendered, so committing them guarantees a later committed-prefix
+ * re-anchor, and on a multiplexer that cannot erase scrollback the engine
+ * recommits the block below its stale copy — the pane shows one box interleaved
+ * with rows of a later frame. Driving `ToolExecutionComponent` itself keeps the
+ * component's pin under test instead of a mock's imitation of it.
+ */
+describe("foreground tool block history", () => {
+	it("commits a completed call exactly once, and no mid-run row", async () => {
+		await initTheme();
+		stopSharedSpinnerTicker();
+		const term = new VirtualTerminal(40, 6);
+		Object.defineProperty(term, "isNativeViewportAtBottom", { configurable: true, value: () => undefined });
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const chat = new TranscriptContainer();
+		for (let i = 0; i < 4; i++) chat.addChild(new HistoryBlock([`hist-${i}-alpha`, `hist-${i}-beta`], false));
+		const tool = new ToolExecutionComponent(
+			"bash",
+			{ command: "echo hi" },
+			{},
+			undefined,
+			{ requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
+			process.cwd(),
+		);
+		chat.addChild(tool);
+		tui.addChild(chat);
+		const output = (rows: number) => ({
+			content: [
+				{
+					type: "text",
+					text: Array.from({ length: rows }, (_, i) => `out ${String(i).padStart(3, "0")}`).join("\n"),
+				},
+			],
+		});
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			// Partial results grow the block past the 6-row viewport, so its rows
+			// reach the commit boundary while the call is still live.
+			for (let rows = 1; rows <= 30; rows++) {
+				tool.updateResult(output(rows), true);
+				tui.requestRender();
+				await scheduler.drain(term);
+			}
+			expect(tool.isNativeScrollbackLiveRegionPinned()).toBe(true);
+			tool.updateResult(output(30), false);
+			tui.requestRender();
+			await scheduler.drain(term);
+			expect(tool.isNativeScrollbackLiveRegionPinned()).toBe(false);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+
+		const counts = new Map<string, number>();
+		for (const row of term.getScrollBuffer()) {
+			const text = Bun.stripANSI(row).trimEnd();
+			if (text.length === 0) continue;
+			counts.set(text, (counts.get(text) ?? 0) + 1);
+		}
+		// Every row the block put on the tape — header, section divider, borders
+		// and body alike — must belong to the final frame and appear once. The
+		// header rows carry the reported corruption: a stale running header and
+		// the timing-bearing final one are different strings, so a duplicate
+		// count alone would permit both. The block's rows must reach the tape at
+		// all, or these assertions hold vacuously; a bash result renders a
+		// bounded preview, so rows the preview dropped are legitimately absent.
+		const frameRow = /^[╭│├╰]/u;
+		const taped = [...counts.keys()].filter(row => frameRow.test(row));
+		const final = new Set(tool.render(40).map(row => Bun.stripANSI(row).trimEnd()));
+		expect([...counts.entries()].filter(([, count]) => count > 1)).toEqual([]);
+		expect(taped.filter(row => !final.has(row))).toEqual([]);
+		expect(taped.length).toBeGreaterThan(0);
 	});
 });


### PR DESCRIPTION
Closes #8881.

I hit this in my own long session: a `🐍` tool box in the pane showed four of its own code rows, then rows belonging to two *later* calls, with the box border still drawn around them and the top border split across two rows. Five boxes in one session's scrollback were affected.

## Mechanism

A tool block rewrites rows it has already rendered — the head gains its timing when the result lands, the spinner stops, a bounded preview is replaced by the result. `isNativeScrollbackLiveRegionPinned()` only pinned TV-wall blocks (`vibe_wait`, live `task`, displaceable `hub`/`todo` polls), so an ordinary foreground call taller than the viewport committed those still-mutating rows to immutable native scrollback.

Completing the call then re-anchored the committed-prefix audit: completion is exactly when those frozen rows enter the hard-scanned newly-final zone, where any content change re-anchors by design. On a multiplexer that cannot erase scrollback the engine recommits below the stale copy — "duplication, never loss" as documented in `findCommittedPrefixResync`. Correct engine behaviour; the defect is that the component let those rows commit at all.

## Fix

Pin the live region while the block is unfinalized — the same law #8970 established for anchored regions. It costs nothing in height: an unfinalized block renders a bounded preview (`EVAL_DEFAULT_PREVIEW_LINES = 10`), and the finalized frame still commits exactly once when the pin lifts.

## Evidence

`test/transcript-history-exactly-once.test.ts` gains a case that drives a real `ToolExecutionComponent` through partial results past the commit boundary on a 6-row terminal, then lands the final result:

| | before | after |
|---|---|---|
| stale mid-run rows on the tape | 6 | **0** |
| duplicated rows | 1 | **0** |

Every box row that reaches the tape now belongs to the final frame. The test drives the production component rather than a mock, so the pin cannot regress behind an imitation of it; restoring the old three-name policy fails the case.

Suites: `bun run check` clean; `packages/tui` 1529 pass; `test/modes` 863, `test/tools` 2304, `test/session` 496, `test/session-manager` 228, plus the blocks most exposed to commit behaviour (`job-poll-displacement`, `compaction-transcript-reuse`, `tool-execution-preview-coalesce`, `tool-execution-custom-repaint`, `eval-commit-stability`) — 0 failures. One unrelated failure in `test/acp-lazy-startup.test.ts` reproduces on a clean `upstream/main`.


## Relation to the `wontfix` on #8881

roboomp reproduced the engine mechanism there and kept `wontfix`: the audit re-anchor cannot distinguish a transient reflow oscillation from a genuine shift, and clamping the emitted chunk to the scrollback high-water mark loses content (it fails `render-regressions.test.ts:1575` and `streaming-scrollback-defer.test.ts:1226`). I agree with that assessment.

This PR does not touch that policy. It removes the precondition on the component side: rows that are still going to be rewritten never reach the tape, so the `duplication, never loss` repair is never asked to arbitrate over them. The engine's repair path and its tests are unchanged.
