### PR TITLE
feat(acp): expose the ask tool through elicitation forms

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added
@@ -19,9 +23,6 @@
 - `qwenTemplateReasoningEffort` in `models.yml` `compat` to disable the Qwen 3.8+ reasoning-effort template parameter for strict local servers.
 - Click-to-toggle and drag-to-reorder for list-valued editors in `/settings`.
 - `icon.subscription` and `icon.advisor` symbol-theme tokens (Nerd Font, Unicode, ASCII).
-- ACP clients that advertise form elicitation can now expose `ask` as a single interactive form, including single-choice, multi-select, recommended, and free-text answers.
-
-- Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,9 @@
 - `qwenTemplateReasoningEffort` in `models.yml` `compat` to disable the Qwen 3.8+ reasoning-effort template parameter for strict local servers.
 - Click-to-toggle and drag-to-reorder for list-valued editors in `/settings`.
 - `icon.subscription` and `icon.advisor` symbol-theme tokens (Nerd Font, Unicode, ASCII).
+- ACP clients that advertise form elicitation can now expose `ask` as a single interactive form, including single-choice, multi-select, recommended, and free-text answers.
+
+- Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 
 ### Changed
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -343,7 +343,12 @@ export async function submitInteractiveInput(
 	}
 }
 
-type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
+interface AcpSessionHandle {
+	session: AgentSession;
+	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+}
+
+type AcpSessionFactory = (cwd: string, options?: { interactivePrompts?: boolean }) => Promise<AcpSessionHandle>;
 
 export interface AcpSessionFactoryOptions {
 	baseOptions: CreateAgentSessionOptions;
@@ -387,7 +392,7 @@ async function loadTrustedSessionExtensions(
  * tool registry and shadow the client-supplied servers (issue #1234).
  */
 export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
-	return async cwd => {
+	return async (cwd, factoryOptions) => {
 		const nextSettings = await args.settings.cloneForCwd(cwd);
 		const nextSessionManager = SessionManager.create(cwd, args.sessionDir);
 		const agentId = `acp:${nextSessionManager.getSessionId()}`;
@@ -408,7 +413,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 				`Trusted extension failed to load: ${trustedExtensions.errors.map(item => item.error).join("; ")}`,
 			);
 		}
-		const { session: nextSession } = await args.createSession({
+		const { session: nextSession, setToolUIContext } = await args.createSession({
 			...args.baseOptions,
 			cwd,
 			sessionManager: nextSessionManager,
@@ -416,8 +421,9 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			authStorage: args.authStorage,
 			modelRegistry: args.modelRegistry,
 			agentId,
-			// Preserve reserve-policy confirmation until ACP capabilities are known
-			// without enabling AskTool or other UI-only session behavior.
+			// ACP defers the `ask` capability and reserve-policy confirmation until
+			// client capabilities are known, without enabling other UI-only behavior.
+			interactivePrompts: factoryOptions?.interactivePrompts,
 			deferUsageReserveConfirmation: true,
 			enableMCP: false,
 			titleSystemPrompt,
@@ -448,7 +454,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 				throw error;
 			}
 		}
-		return nextSession;
+		return { session: nextSession, setToolUIContext };
 	};
 }
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -72,6 +72,7 @@ import { buildAvailableSlashCommands, toAcpAvailableCommands } from "../../slash
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "../../stt/models";
 import { refreshAgentDiscovery } from "../../task";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
+import { OTHER_OPTION } from "../../tools/ask";
 import { normalizeLocalScheme } from "../../tools/path-utils";
 import { ToolError } from "../../tools/tool-errors";
 import {
@@ -163,6 +164,7 @@ function isPromptTurnInFlight(turn: PromptTurnState | undefined): turn is Prompt
 
 type ManagedSessionRecord = {
 	session: AgentSession;
+	setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined;
 	mcpManager: MCPManager | undefined;
 	// Ordered queue of MCP tool refreshes for this record. Rebuilt per
 	// `#configureMcpServers` call; drained on reconfigure so a stale in-flight
@@ -215,7 +217,13 @@ type MCPSourceMap = {
 	[name: string]: MCPSource;
 };
 
-type CreateAcpSession = (cwd: string) => Promise<AgentSession>;
+type CreateAcpSession = (
+	cwd: string,
+	options?: { interactivePrompts?: boolean },
+) => Promise<{
+	session: AgentSession;
+	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+}>;
 
 type AcpSpeechOption = {
 	value: string;
@@ -271,11 +279,7 @@ function buildAcpSpeechModelsCatalog(): Record<string, unknown> {
 }
 
 /**
- * Bridge a single ExtensionUIContext call to the ACP `unstable_createElicitation`
- * surface. Skills/extensions ask for one value at a time (a chosen option, a
- * confirmation, a piece of text), so every elicitation here uses a one-property
- * `value` schema; the caller narrows the resulting `ElicitationContentValue`
- * back to its concrete primitive type.
+ * Bridge an ExtensionUIContext form to ACP `unstable_createElicitation`.
  *
  * `dialogOptions.signal` short-circuits the elicitation if it is already
  * aborted and races the in-flight request against the abort event. The SDK
@@ -285,8 +289,8 @@ function buildAcpSpeechModelsCatalog(): Record<string, unknown> {
  * resolving the local promise unblocks the caller (matches the RPC mode
  * pattern in `requestRpcEditor`). The abort listener is removed once the
  * elicitation settles so that callers which reuse the same signal across many
- * elicitations (e.g. `ask` multi-select loops) don't accumulate listeners and
- * trip Node's `MaxListeners` warning.
+ * elicitations don't accumulate listeners and trip Node's `MaxListeners`
+ * warning.
  *
  * `dialogOptions.timeout` mirrors `RpcExtensionUIContext.#createDialogPromise`:
  * when the timer fires before the client responds, `onTimeout` is invoked and
@@ -294,14 +298,15 @@ function buildAcpSpeechModelsCatalog(): Record<string, unknown> {
  * arrive after abort/timeout — both rejections and successful `accept`s —
  * are dropped silently (no `logger.warn`) to keep operator logs clean.
  */
-async function elicitFromAcpClient(
+async function elicitFormFromAcpClient(
 	connection: AgentSideConnection,
 	sessionId: string,
-	method: "select" | "confirm" | "input" | "editor",
+	method: string,
 	message: string,
-	property: ElicitationPropertySchema,
+	properties: Record<string, ElicitationPropertySchema>,
+	required: string[] | undefined,
 	dialogOptions: ExtensionUIDialogOptions | undefined,
-): Promise<ElicitationContentValue | undefined> {
+): Promise<Record<string, ElicitationContentValue> | undefined> {
 	const signal = dialogOptions?.signal;
 	if (signal?.aborted) {
 		return undefined;
@@ -312,7 +317,7 @@ async function elicitFromAcpClient(
 	const finish = (value: CreateElicitationResponse | undefined) => {
 		if (settled) return;
 		settled = true;
-		if (timeoutId !== undefined) clearTimeout(timeoutId);
+		clearTimeout(timeoutId);
 		signal?.removeEventListener("abort", onAbort);
 		resolve(value);
 	};
@@ -343,8 +348,8 @@ async function elicitFromAcpClient(
 			message,
 			requestedSchema: {
 				type: "object",
-				properties: { value: property },
-				required: ["value"],
+				properties,
+				required,
 			},
 		})
 		.then(finish, error => {
@@ -357,7 +362,27 @@ async function elicitFromAcpClient(
 	if (!isAcceptedElicitation(response) || !response.content) {
 		return undefined;
 	}
-	return response.content.value;
+	return response.content;
+}
+
+async function elicitFromAcpClient(
+	connection: AgentSideConnection,
+	sessionId: string,
+	method: "select" | "confirm" | "input" | "editor",
+	message: string,
+	property: ElicitationPropertySchema,
+	dialogOptions: ExtensionUIDialogOptions | undefined,
+): Promise<ElicitationContentValue | undefined> {
+	const content = await elicitFormFromAcpClient(
+		connection,
+		sessionId,
+		method,
+		message,
+		{ value: property },
+		["value"],
+		dialogOptions,
+	);
+	return content?.value;
 }
 
 /** Narrows a `CreateElicitationResponse` to the accepted-with-content branch; the SDK's `action: string` catch-all arm otherwise defeats literal narrowing on `action !== "accept"`. */
@@ -429,6 +454,109 @@ export function createAcpExtensionUiContext(
 				dialogOptions,
 			);
 			return typeof value === "string" ? value : undefined;
+		},
+		askDialog: async (questions, dialogOptions) => {
+			if (!supportsForm) return undefined;
+			const properties: Record<string, ElicitationPropertySchema> = {};
+			for (const [index, question] of questions.entries()) {
+				const key = `q${index}`;
+				const entries = question.options.map(option => ({
+					const: option.label,
+					title: option.label,
+					...(option.description?.trim() ? { description: option.description.trim() } : {}),
+				}));
+				const description = question.header?.trim();
+				if (entries.length > 0) {
+					if (question.multi === true) {
+						properties[key] = {
+							type: "array",
+							title: question.question,
+							...(description ? { description } : {}),
+							items: { anyOf: entries },
+						};
+					} else {
+						const recommended = question.recommended;
+						properties[key] = {
+							type: "string",
+							title: question.question,
+							...(description ? { description } : {}),
+							oneOf: entries,
+							...(recommended !== undefined && recommended >= 0 && recommended < question.options.length
+								? { default: question.options[recommended].label }
+								: {}),
+						};
+					}
+				}
+				properties[`${key}__other`] = { type: "string", title: OTHER_OPTION };
+			}
+
+			let timedOut = false;
+			const content = await elicitFormFromAcpClient(
+				connection,
+				getSessionId(),
+				"askDialog",
+				questions.length === 1 ? questions[0].question : `Answer ${questions.length} questions`,
+				properties,
+				undefined,
+				{
+					...dialogOptions,
+					onTimeout: () => {
+						timedOut = true;
+						dialogOptions?.onTimeout?.();
+					},
+				},
+			);
+			if (timedOut) {
+				return {
+					kind: "submit",
+					results: questions.map(question => {
+						const labels = question.options.map(option => option.label);
+						const fallbackIndex = Math.min(
+							Math.max(question.recommended ?? 0, 0),
+							Math.max(labels.length - 1, 0),
+						);
+						const fallback = labels[fallbackIndex];
+						return {
+							id: question.id,
+							question: question.question,
+							options: labels,
+							multi: question.multi ?? false,
+							selectedOptions: fallback === undefined ? [] : [fallback],
+							customInput: undefined,
+							timedOut: true,
+						};
+					}),
+				};
+			}
+			if (!content) return undefined;
+
+			return {
+				kind: "submit",
+				results: questions.map((question, index) => {
+					const key = `q${index}`;
+					const otherKey = `${key}__other`;
+					const labels = question.options.map(option => option.label);
+					const otherValue = content[otherKey];
+					const customInput = typeof otherValue === "string" && otherValue.trim() ? otherValue.trim() : undefined;
+					const value = content[key];
+					const selectedOptions =
+						question.multi === true
+							? Array.isArray(value)
+								? value.filter(candidate => typeof candidate === "string" && labels.includes(candidate))
+								: []
+							: customInput === undefined && typeof value === "string" && labels.includes(value)
+								? [value]
+								: [];
+					return {
+						id: question.id,
+						question: question.question,
+						options: labels,
+						multi: question.multi ?? false,
+						selectedOptions,
+						customInput,
+					};
+				}),
+			};
 		},
 		notify: (message, type) => {
 			logger.debug("ACP extension notification", { message, type });
@@ -1054,14 +1182,16 @@ export class AcpAgent implements Agent {
 	}
 
 	async #createNewSessionRecord(cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
-		const session = await this.#createSession(path.resolve(cwd));
+		const { session, setToolUIContext } = await this.#createSession(path.resolve(cwd), {
+			interactivePrompts: this.#clientCapabilities?.elicitation?.form != null,
+		});
 		try {
 			await session.sessionManager.ensureOnDisk();
 		} catch (error) {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers);
+		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext);
 	}
 
 	async #loadManagedSession(sessionId: string, cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
@@ -1096,7 +1226,9 @@ export class AcpAgent implements Agent {
 
 	async #forkManagedSession(params: ForkSessionRequest): Promise<ManagedSessionRecord> {
 		const sourcePath = await this.#resolveForkSourceSessionPath(params.sessionId);
-		const session = await this.#createSession(path.resolve(params.cwd));
+		const { session, setToolUIContext } = await this.#createSession(path.resolve(params.cwd), {
+			interactivePrompts: this.#clientCapabilities?.elicitation?.form != null,
+		});
 		try {
 			const success = await session.switchSession(sourcePath);
 			if (!success) {
@@ -1110,7 +1242,7 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, params.mcpServers ?? []);
+		return await this.#registerPreparedSession(session, params.mcpServers ?? [], setToolUIContext);
 	}
 
 	async #openStoredSession(
@@ -1119,7 +1251,9 @@ export class AcpAgent implements Agent {
 		mcpServers: McpServer[],
 		sessionId: string,
 	): Promise<ManagedSessionRecord> {
-		const session = await this.#createSession(path.resolve(cwd));
+		const { session, setToolUIContext } = await this.#createSession(path.resolve(cwd), {
+			interactivePrompts: this.#clientCapabilities?.elicitation?.form != null,
+		});
 		try {
 			const success = await session.switchSession(sessionPath);
 			if (!success) {
@@ -1129,11 +1263,15 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers);
+		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext);
 	}
 
-	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
-		const record = this.#createManagedSessionRecord(session);
+	async #registerPreparedSession(
+		session: AgentSession,
+		mcpServers: McpServer[],
+		setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
+	): Promise<ManagedSessionRecord> {
+		const record = this.#createManagedSessionRecord(session, setToolUIContext);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
@@ -1148,9 +1286,13 @@ export class AcpAgent implements Agent {
 		}
 	}
 
-	#createManagedSessionRecord(session: AgentSession): ManagedSessionRecord {
+	#createManagedSessionRecord(
+		session: AgentSession,
+		setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined = undefined,
+	): ManagedSessionRecord {
 		return {
 			session,
+			setToolUIContext,
 			mcpManager: undefined,
 			mcpRefreshChain: undefined,
 			promptTurn: undefined,
@@ -2323,6 +2465,7 @@ export class AcpAgent implements Agent {
 			this.#clientCapabilities,
 		);
 		if (this.#clientCapabilities?.elicitation?.form != null) {
+			record.setToolUIContext?.(uiContext, true);
 			record.session.setUsageFallbackConfirmer((confirmation, signal) => {
 				const reserve =
 					confirmation.remainingPercent === undefined

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,11 +1,18 @@
 import * as stream from "node:stream";
 import { postmortem } from "@oh-my-pi/pi-utils";
 import { AgentSideConnection, ndJsonStream, type Stream } from "@oh-my-pi/pi-utils/acp";
+import type { ExtensionUIContext } from "../../extensibility/extensions/types";
 import type { AgentSession } from "../../session/agent-session";
 import { AcpAgent } from "./acp-agent";
 
+/** Session and deferred tool UI hook created for an ACP client workspace. */
+export interface AcpSessionHandle {
+	session: AgentSession;
+	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+}
+
 /** Creates sessions requested by an ACP client. */
-export type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
+export type AcpSessionFactory = (cwd: string, options?: { interactivePrompts?: boolean }) => Promise<AcpSessionHandle>;
 
 /** Creates an ACP connection and exposes its agent when process-level teardown must own it. */
 export function createAcpConnection(

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -562,6 +562,12 @@ export interface CreateAgentSessionOptions {
 	/** Whether UI is available (enables interactive tools like ask). Default: false */
 	hasUI?: boolean;
 	/**
+	 * A human can answer synchronous prompts even without a terminal UI (e.g. an
+	 * ACP client rendering elicitation forms). Enables `ask` without enabling
+	 * TUI-only session behavior such as eager LSP warmup. Default: `hasUI`.
+	 */
+	interactivePrompts?: boolean;
+	/**
 	 * Defer `confirm` reserve-policy fallback until AgentSession prompt-time UI is configured.
 	 * ACP uses this while capabilities are negotiated without enabling UI-only tools.
 	 */
@@ -1675,6 +1681,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			setActiveToolNames,
 			toolRegistry,
 			hasUI: options.hasUI ?? false,
+			canPromptUser: options.interactivePrompts ?? options.hasUI ?? false,
 			getApiKey: options.getApiKey,
 			get additionalDirectories() {
 				return sessionManager.getAdditionalDirectories();

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -45,7 +45,7 @@ import { ToolAbortError } from "./tool-errors";
 // Types
 // =============================================================================
 
-const OTHER_OPTION = "Other (type your own)";
+export const OTHER_OPTION = "Other (type your own)";
 const CHAT_ABOUT_THIS_OPTION = "Chat about this";
 const NEXT_OPTION = "Next →";
 const RESERVED_OPTION_LABELS: Record<string, true> = {
@@ -830,11 +830,12 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 	}
 
 	static createIf(session: ToolSession): AskTool | null {
-		return session.hasUI ? new AskTool(session) : null;
+		return (session.canPromptUser ?? session.hasUI) ? new AskTool(session) : null;
 	}
 
 	/** Send terminal notification when ask tool is waiting for input */
 	#sendAskNotification(): void {
+		if (!this.session.hasUI) return;
 		const method = this.session.settings.get("ask.notify");
 		if (method === "off") return;
 		TERMINAL.sendNotification({

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -159,6 +159,8 @@ export interface ToolSession {
 	additionalDirectories?: string[];
 	/** Whether UI is available */
 	hasUI: boolean;
+	/** Whether `ask` can reach a human. Defaults to `hasUI`. */
+	canPromptUser?: boolean;
 	/** Whether this session has begun disposal. */
 	isDisposed?: () => boolean;
 	/**

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import {
 	ACP_BOOTSTRAP_RACE_GUARD_MS,
@@ -426,11 +427,15 @@ function holdPromptStreaming(session: FakeAgentSession): () => void {
 	return () => finishPrompt();
 }
 
+type SetToolUIContextSpy = (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+
 interface AgentHarness {
 	agent: AcpAgent;
 	updates: SessionNotification[];
 	abortController: AbortController;
 	sessions: FakeAgentSession[];
+	setToolUIContextSpies: SetToolUIContextSpy[];
+	sessionFactoryOptions: Array<{ interactivePrompts?: boolean } | undefined>;
 	cwdA: string;
 	cwdB: string;
 	findSession(sessionId: string): FakeAgentSession | undefined;
@@ -467,7 +472,10 @@ afterEach(async () => {
 });
 
 async function createHarness(
-	options: { elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse> } = {},
+	options: {
+		elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse>;
+		clientCapabilities?: ClientCapabilities;
+	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
 	cleanupRoots.push(root);
@@ -483,6 +491,8 @@ async function createHarness(
 	const updates: SessionNotification[] = [];
 	const abortController = new AbortController();
 	const sessions: FakeAgentSession[] = [];
+	const setToolUIContextSpies: SetToolUIContextSpy[] = [];
+	const sessionFactoryOptions: Array<{ interactivePrompts?: boolean } | undefined> = [];
 	const connection = {
 		sessionUpdate: async (notification: SessionNotification) => {
 			updates.push(notification);
@@ -496,19 +506,22 @@ async function createHarness(
 
 	const initialSession = new FakeAgentSession(cwdA);
 	sessions.push(initialSession);
-	const factory = async (cwd: string): Promise<AgentSession> => {
+	const factory = async (cwd: string, factoryOptions?: { interactivePrompts?: boolean }) => {
 		const session = new FakeAgentSession(cwd);
+		const setToolUIContext = vi.fn();
 		sessions.push(session);
-		return session as unknown as AgentSession;
+		setToolUIContextSpies.push(setToolUIContext);
+		sessionFactoryOptions.push(factoryOptions);
+		return { session: session as unknown as AgentSession, setToolUIContext };
 	};
 
 	const agent = new AcpAgent(connection, factory, initialSession as unknown as AgentSession);
-	if (options.elicitationHandler) {
-		// Drive `initialize` so the agent caches `clientCapabilities.elicitation.form`
-		// and `#requestAcpPlanApprovalChoice` actually goes through the elicitation.
+	const clientCapabilities =
+		options.clientCapabilities ?? (options.elicitationHandler ? { elicitation: { form: {} } } : undefined);
+	if (clientCapabilities) {
 		await agent.initialize({
 			protocolVersion: 1,
-			clientCapabilities: { elicitation: { form: {} } },
+			clientCapabilities,
 		} as Parameters<typeof agent.initialize>[0]);
 	}
 
@@ -517,6 +530,8 @@ async function createHarness(
 		updates,
 		abortController,
 		sessions,
+		setToolUIContextSpies,
+		sessionFactoryOptions,
 		cwdA,
 		cwdB,
 		findSession: (sessionId: string) => sessions.find(session => session.sessionId === sessionId),
@@ -2436,6 +2451,40 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("installs the tool UI context when form elicitation is available", async () => {
+		const harness = await createHarness({ clientCapabilities: { elicitation: { form: {} } } });
+		const session = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		await harness.agent.prompt({
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "ping" }],
+		} as PromptRequest);
+
+		expect(harness.sessionFactoryOptions).toEqual([{ interactivePrompts: true }]);
+		expect(harness.setToolUIContextSpies).toHaveLength(1);
+		expect(harness.setToolUIContextSpies[0]).toHaveBeenCalledTimes(1);
+		expect(harness.setToolUIContextSpies[0]).toHaveBeenCalledWith(
+			expect.objectContaining({ askDialog: expect.any(Function) }),
+			true,
+		);
+
+		await harness.agent.dispose();
+	});
+
+	it("does not install the tool UI context without form elicitation", async () => {
+		const harness = await createHarness({ clientCapabilities: {} });
+		const session = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		await harness.agent.prompt({
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "ping" }],
+		} as PromptRequest);
+
+		expect(harness.sessionFactoryOptions).toEqual([{ interactivePrompts: false }]);
+		expect(harness.setToolUIContextSpies).toHaveLength(1);
+		expect(harness.setToolUIContextSpies[0]).not.toHaveBeenCalled();
+
+		await harness.agent.dispose();
+	});
+
 	describe("ACP elicitation bridge", () => {
 		const FORM_CAPABILITIES: ClientCapabilities = { elicitation: { form: {} } };
 
@@ -2459,6 +2508,258 @@ describe("ACP agent", () => {
 		): request is Extract<CreateElicitationRequest, { mode: "form" }> {
 			return request.mode === "form";
 		}
+		it("translates a recommended single-choice ask into one form", async () => {
+			const { connection, calls } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0: "Approach B" },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-single", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{
+					id: "approach",
+					question: "Which approach?",
+					header: "Choose one",
+					options: [
+						{ label: "Approach A", description: "Faster" },
+						{ label: "Approach B", description: "Safer" },
+					],
+					recommended: 0,
+				},
+			]);
+
+			expect(calls).toHaveLength(1);
+			const request = calls[0]!;
+			if (!isFormElicitation(request)) throw new Error("expected form-mode elicitation");
+			expect(request.message).toBe("Which approach?");
+			expect(request.requestedSchema.required).toBeUndefined();
+			expect(request.requestedSchema.properties.q0).toEqual({
+				type: "string",
+				title: "Which approach?",
+				description: "Choose one",
+				oneOf: [
+					{ const: "Approach A", title: "Approach A", description: "Faster" },
+					{ const: "Approach B", title: "Approach B", description: "Safer" },
+				],
+				default: "Approach A",
+			});
+			expect(request.requestedSchema.properties.q0__other).toEqual({
+				type: "string",
+				title: "Other (type your own)",
+			});
+			expect(result).toEqual({
+				kind: "submit",
+				results: [
+					{
+						id: "approach",
+						question: "Which approach?",
+						options: ["Approach A", "Approach B"],
+						multi: false,
+						selectedOptions: ["Approach B"],
+						customInput: undefined,
+					},
+				],
+			});
+		});
+
+		it("translates a multi-select ask into an array anyOf schema", async () => {
+			const { connection, calls } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0: ["A", "C"] },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-multi", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{
+					id: "features",
+					question: "Which features?",
+					options: [{ label: "A" }, { label: "B" }, { label: "C" }],
+					multi: true,
+				},
+			]);
+
+			expect(calls).toHaveLength(1);
+			const request = calls[0]!;
+			if (!isFormElicitation(request)) throw new Error("expected form-mode elicitation");
+			expect(request.requestedSchema.properties.q0).toEqual({
+				type: "array",
+				title: "Which features?",
+				items: {
+					anyOf: [
+						{ const: "A", title: "A" },
+						{ const: "B", title: "B" },
+						{ const: "C", title: "C" },
+					],
+				},
+			});
+			expect(result?.kind === "submit" ? result.results[0]?.selectedOptions : undefined).toEqual(["A", "C"]);
+		});
+
+		it("accepts a trimmed free-text-only ask response", async () => {
+			const { connection } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0__other: "  widget " },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-other", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{ id: "widget", question: "Which widget?", options: [{ label: "Standard" }] },
+			]);
+
+			expect(result?.kind === "submit" ? result.results[0] : undefined).toMatchObject({
+				selectedOptions: [],
+				customInput: "widget",
+			});
+		});
+		it("treats a single-choice custom answer as exclusive", async () => {
+			const { connection } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0: "Standard", q0__other: "custom" },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-exclusive-other", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{ id: "widget", question: "Which widget?", options: [{ label: "Standard" }] },
+			]);
+
+			expect(result?.kind === "submit" ? result.results[0] : undefined).toMatchObject({
+				selectedOptions: [],
+				customInput: "custom",
+			});
+		});
+
+		it("uses only free-text fields for questions without options", async () => {
+			const { connection, calls } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0__other: "single answer", q1__other: "multi answer" },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-no-options", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{ id: "single", question: "Single?", options: [] },
+				{ id: "multi", question: "Multi?", options: [], multi: true },
+			]);
+
+			expect(calls).toHaveLength(1);
+			const request = calls[0]!;
+			if (!isFormElicitation(request)) throw new Error("expected form-mode elicitation");
+			expect(Object.keys(request.requestedSchema.properties)).toEqual(["q0__other", "q1__other"]);
+			expect(result?.kind === "submit" ? result.results : undefined).toMatchObject([
+				{ id: "single", selectedOptions: [], customInput: "single answer" },
+				{ id: "multi", selectedOptions: [], customInput: "multi answer" },
+			]);
+		});
+
+		it("drops ask values the client was never offered", async () => {
+			const { connection } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0: "Nonexistent" },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-invalid", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([{ id: "choice", question: "Choose", options: [{ label: "Existing" }] }]);
+
+			expect(result?.kind === "submit" ? result.results[0]?.selectedOptions : undefined).toEqual([]);
+		});
+
+		it("packs multiple ask questions into one ordered form", async () => {
+			const { connection, calls } = createElicitConnection(async () => ({
+				action: "accept",
+				content: { q0: "PostgreSQL", q1: ["auth", "search"] },
+			}));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-many", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{
+					id: "storage",
+					question: "Storage?",
+					options: [{ label: "SQLite" }, { label: "PostgreSQL" }],
+				},
+				{
+					id: "features",
+					question: "Features?",
+					options: [{ label: "auth" }, { label: "billing" }, { label: "search" }],
+					multi: true,
+				},
+			]);
+
+			expect(calls).toHaveLength(1);
+			const request = calls[0]!;
+			if (!isFormElicitation(request)) throw new Error("expected form-mode elicitation");
+			expect(request.message).toBe("Answer 2 questions");
+			expect(Object.keys(request.requestedSchema.properties)).toEqual(["q0", "q0__other", "q1", "q1__other"]);
+			expect(result?.kind === "submit" ? result.results.map(item => item.id) : undefined).toEqual([
+				"storage",
+				"features",
+			]);
+			expect(result?.kind === "submit" ? result.results.map(item => item.selectedOptions) : undefined).toEqual([
+				["PostgreSQL"],
+				["auth", "search"],
+			]);
+		});
+
+		it("returns undefined when an ask form is cancelled", async () => {
+			const { connection } = createElicitConnection(async () => ({ action: "cancel" }));
+			const ctx = createAcpExtensionUiContext(connection, () => "session-ask-cancel", FORM_CAPABILITIES);
+
+			const result = await ctx.askDialog!([
+				{ id: "choice", question: "Choose", options: [{ label: "A" }, { label: "B" }] },
+			]);
+
+			expect(result).toBeUndefined();
+		});
+		it("returns ordered fallback answers when an ask form times out", async () => {
+			vi.useFakeTimers();
+			try {
+				const { promise: never } = Promise.withResolvers<CreateElicitationResponse>();
+				const { connection } = createElicitConnection(() => never);
+				const ctx = createAcpExtensionUiContext(connection, () => "session-ask-timeout", FORM_CAPABILITIES);
+				const onTimeout = vi.fn();
+
+				const pending = ctx.askDialog!(
+					[
+						{
+							id: "choice",
+							question: "Choose",
+							options: [{ label: "A" }, { label: "B" }],
+							recommended: 1,
+						},
+						{ id: "free-text", question: "Explain", options: [] },
+					],
+					{ timeout: 10, onTimeout },
+				);
+				await Promise.resolve();
+				vi.advanceTimersByTime(10);
+				await Promise.resolve();
+
+				expect(await pending).toEqual({
+					kind: "submit",
+					results: [
+						{
+							id: "choice",
+							question: "Choose",
+							options: ["A", "B"],
+							multi: false,
+							selectedOptions: ["B"],
+							customInput: undefined,
+							timedOut: true,
+						},
+						{
+							id: "free-text",
+							question: "Explain",
+							options: [],
+							multi: false,
+							selectedOptions: [],
+							customInput: undefined,
+							timedOut: true,
+						},
+					],
+				});
+				expect(onTimeout).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 
 		it("translates select to a single-property string-enum elicitation", async () => {
 			const { connection, calls } = createElicitConnection(async () => ({
@@ -2601,6 +2902,9 @@ describe("ACP agent", () => {
 			expect(await ctx.confirm("X", "Y")).toBe(false);
 			expect(await ctx.input("X")).toBeUndefined();
 			expect(await ctx.editor("X")).toBeUndefined();
+			expect(
+				await ctx.askDialog!([{ id: "choice", question: "Choose", options: [{ label: "A" }] }]),
+			).toBeUndefined();
 			expect(calls).toHaveLength(0);
 		});
 

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -918,7 +918,10 @@ describe("ACP event mapper", () => {
 				async (sessionCwd: string) => {
 					const session = new ReplayTestSession(sessionCwd, sessionDir);
 					sessions.push(session);
-					return session as unknown as AgentSession;
+					return {
+						session: session as unknown as AgentSession,
+						setToolUIContext: () => {},
+					};
 				},
 				new ReplayTestSession(cwd, initialSessionDir) as unknown as AgentSession,
 			);

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -158,7 +158,10 @@ async function createAgent(): Promise<AcpAgent> {
 	} as unknown as AgentSideConnection;
 
 	const initialSession = new FakeAgentSession(cwd);
-	const factory = async (next: string): Promise<AgentSession> => new FakeAgentSession(next) as unknown as AgentSession;
+	const factory = async (next: string) => ({
+		session: new FakeAgentSession(next) as unknown as AgentSession,
+		setToolUIContext: () => {},
+	});
 	return new AcpAgent(connection, factory, initialSession as unknown as AgentSession);
 }
 

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -333,7 +333,10 @@ describe("ACP lazy startup", () => {
 		const client = new TestClient();
 		let createCalls = 0;
 		const creationStarted = Promise.withResolvers<void>();
-		const blockedCreation = Promise.withResolvers<AgentSession>();
+		const blockedCreation = Promise.withResolvers<{
+			session: AgentSession;
+			setToolUIContext: () => void;
+		}>();
 
 		const agentConnection = new ClientSideConnection(
 			() => client,
@@ -347,7 +350,10 @@ describe("ACP lazy startup", () => {
 				if (createCalls === 1) {
 					return await blockedCreation.promise;
 				}
-				return new LazyFakeSession(cwd) as unknown as AgentSession;
+				return {
+					session: new LazyFakeSession(cwd) as unknown as AgentSession,
+					setToolUIContext: () => {},
+				};
 			},
 		);
 
@@ -365,7 +371,10 @@ describe("ACP lazy startup", () => {
 			await creationStarted.promise;
 			expect(createCalls).toBe(1);
 
-			blockedCreation.resolve(new LazyFakeSession("/tmp/acp-lazy-startup") as unknown as AgentSession);
+			blockedCreation.resolve({
+				session: new LazyFakeSession("/tmp/acp-lazy-startup") as unknown as AgentSession,
+				setToolUIContext: () => {},
+			});
 			const sessionResponse = await newSessionPromise;
 			expect(sessionResponse.sessionId).toEqual(expect.any(String));
 		} finally {
@@ -439,7 +448,7 @@ describe("ACP lazy startup", () => {
 					},
 					settings,
 					runAcpMode: async createAcpSession => {
-						session = await createAcpSession(cwd);
+						session = (await createAcpSession(cwd)).session;
 						throw new Error("stop test ACP mode");
 					},
 				},

--- a/packages/coding-agent/test/acp-mcp-isolation.test.ts
+++ b/packages/coding-agent/test/acp-mcp-isolation.test.ts
@@ -66,7 +66,7 @@ describe("createAcpSessionFactory MCP isolation (issue #1234)", () => {
 			});
 
 			const result = await factory(tempDir.path());
-			expect(result).toBe(fakeSession);
+			expect(result.session).toBe(fakeSession);
 			expect(captured).toHaveLength(1);
 			expect(captured[0].enableMCP).toBe(false);
 		} finally {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { type } from "@oh-my-pi/omptype";
 import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
@@ -12,6 +12,7 @@ import { getThemeByName, initTheme, type Theme } from "@oh-my-pi/pi-coding-agent
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { AskTool, askToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/ask";
 import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+import { TERMINAL } from "@oh-my-pi/pi-tui";
 
 function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
@@ -21,6 +22,7 @@ function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
 		getSessionSpawns: () => "*",
 		settings: Settings.isolated(),
 		...overrides,
+		canPromptUser: overrides.canPromptUser ?? overrides.hasUI ?? true,
 	};
 }
 
@@ -1584,6 +1586,50 @@ describe("AskTool rich ask dialog", () => {
 			note: "My Custom Note",
 			timedOut: undefined,
 		});
+	});
+
+	it("does not emit terminal notifications for non-terminal prompt surfaces", async () => {
+		const sendNotification = spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const askDialog = vi.fn().mockResolvedValue({
+			kind: "submit",
+			results: [
+				{
+					id: "storage",
+					question: "Storage?",
+					options: ["SQLite", "PostgreSQL"],
+					multi: false,
+					selectedOptions: ["PostgreSQL"],
+				},
+			],
+		});
+		const tool = new AskTool(
+			createSession({
+				hasUI: false,
+				canPromptUser: true,
+				settings: Settings.isolated({ "ask.notify": "on" }),
+			}),
+		);
+
+		try {
+			await tool.execute(
+				"call-acp-dialog",
+				{
+					questions: [
+						{
+							id: "storage",
+							question: "Storage?",
+							options: [{ label: "SQLite" }, { label: "PostgreSQL" }],
+						},
+					],
+				},
+				undefined,
+				undefined,
+				createContext({ askDialog }),
+			);
+			expect(sendNotification).not.toHaveBeenCalled();
+		} finally {
+			sendNotification.mockRestore();
+		}
 	});
 
 	it("aborts and throws ToolAbortError when askDialog returns undefined", async () => {


### PR DESCRIPTION
## Summary

- add an `interactivePrompts` session capability so ACP clients can expose `ask` without enabling terminal-only session behavior
- carry the deferred tool UI hook through ACP session creation and install it when the client advertises form elicitation
- translate `ask` questions into one ACP form, including single-select and multi-select options, recommendations, descriptions, free-text answers, cancellation, and timeout handling
- keep ACP lazy startup behavior unchanged and cover capability negotiation, form schemas, result filtering, ordering, cancellation, and UI-context wiring with tests

## Before

The ACP agent had no `ask` tool and could not request an interactive choice.

![Before: ACP session without the ask tool](https://raw.githubusercontent.com/joseotaviorf/oh-my-pi/acp-ask-evidence/.github/pr-assets/acp-ask-before.png)

## After

The same prompt renders an inline elicitation form in Zed and returns the selected value to the agent.

![After: ACP ask tool rendered as an elicitation form](https://raw.githubusercontent.com/joseotaviorf/oh-my-pi/acp-ask-evidence/.github/pr-assets/acp-ask-after.png)

## Verification

- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:tools`
- `bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts packages/coding-agent/test/tools/ask.test.ts`
- exercised form-capable and form-incapable ACP clients over stdio
- verified single-select, multi-question/multi-select, answer propagation, and cancellation in Zed
