### PR TITLE
fix(discovery): isolate Claude project plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
+### Fixed
+
+- Fixed Claude Code marketplace plugins installed with `scope: "project"` loading outside their recorded `projectPath`, so foreign projects no longer inherit their MCP servers, hooks, tools, commands, skills, or agents ([#9043](https://github.com/can1357/oh-my-pi/issues/9043)).
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -766,7 +766,7 @@ export function buildExtensionModuleItems(
  * Entry for an installed Claude Code plugin.
  */
 export interface ClaudePluginEntry {
-	/** Claude registry scope; local entries are restricted to their project path. */
+	/** Claude registry scope; project and local entries are restricted to their project path. */
 	scope?: "user" | "project" | "local";
 	installPath: string;
 	version: string;
@@ -774,7 +774,7 @@ export interface ClaudePluginEntry {
 	lastUpdated: string;
 	gitCommitSha?: string;
 	enabled?: boolean;
-	/** Project root recorded by Claude for a local installation. */
+	/** Project root recorded by Claude for a project-bound installation. */
 	projectPath?: string;
 }
 
@@ -1000,11 +1000,11 @@ export async function listClaudePluginRoots(
 					if (entry.enabled === false) continue;
 					// Claude Code's own on/off switch: `enabledPlugins` in settings.json /
 					// settings.local.json. `false` hides the plugin here even though it is
-					// installed; `true` opts a local-scope install into this project even
+					// installed; `true` opts a project-bound install into this project even
 					// when its recorded projectPath is a different directory.
 					const override = enabledOverrides.enabled.get(pluginId);
 					if (override === false) continue;
-					if (entry.scope === "local" && override !== true) {
+					if ((entry.scope === "local" || entry.scope === "project") && override !== true) {
 						if (!entry.projectPath || !activeClaudeProjectPath) continue;
 						let entryProjectPath = canonicalClaudeProjectPaths.get(entry.projectPath);
 						if (entryProjectPath === undefined) {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -186,7 +186,7 @@ describe("listClaudePluginRoots", () => {
 		]);
 	});
 
-	test("isolates local plugins to their canonical project", async () => {
+	test("isolates local and project plugins to their canonical project", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		const projectA = path.join(tempDir, "project-a");
 		const projectB = path.join(tempDir, "project-b");
@@ -200,7 +200,7 @@ describe("listClaudePluginRoots", () => {
 		]);
 		await fs.symlink(projectB, projectBAlias, "dir");
 
-		const entry = (scope: "user" | "local", installPath: string, projectPath?: string) => ({
+		const entry = (scope: "user" | "project" | "local", installPath: string, projectPath?: string) => ({
 			scope,
 			installPath,
 			projectPath,
@@ -212,16 +212,25 @@ describe("listClaudePluginRoots", () => {
 			version: 2,
 			plugins: {
 				"user-plugin@market": [entry("user", "/plugins/user")],
-				"active-plugin@market": [entry("local", "/plugins/active", projectB)],
-				"foreign-plugin@market": [entry("local", "/plugins/foreign", projectA)],
+				"active-local-plugin@market": [entry("local", "/plugins/active-local", projectB)],
+				"foreign-local-plugin@market": [entry("local", "/plugins/foreign-local", projectA)],
+				"active-project-plugin@market": [entry("project", "/plugins/active-project", projectB)],
+				"foreign-project-plugin@market": [entry("project", "/plugins/foreign-project", projectA)],
 			},
 		};
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
 		const result = await listClaudePluginRoots(tempDir, path.join(projectBAlias, "packages", "app"));
 
-		expect(result.roots.map(root => root.id)).toEqual(["user-plugin@market", "active-plugin@market"]);
-		expect(result.roots.find(root => root.id === "active-plugin@market")?.scope).toBe("project");
+		expect(result.roots.map(root => root.id)).toEqual([
+			"user-plugin@market",
+			"active-local-plugin@market",
+			"active-project-plugin@market",
+		]);
+		expect(result.roots.filter(root => root.id !== "user-plugin@market").map(root => root.scope)).toEqual([
+			"project",
+			"project",
+		]);
 	});
 
 	test("hides a plugin the user switched off with enabledPlugins in project settings", async () => {
@@ -321,32 +330,6 @@ describe("listClaudePluginRoots", () => {
 		expect(after.roots[0]?.scope).toBe("project");
 	});
 
-	test("parses plugin with project scope", async () => {
-		const pluginsDir = path.join(tempDir, ".claude", "plugins");
-		await fs.mkdir(pluginsDir, { recursive: true });
-
-		const registry = {
-			version: 2,
-			plugins: {
-				"project-plugin@market": [
-					{
-						scope: "project",
-						installPath: "/path/to/project-plugin",
-						version: "2.0.0",
-						installedAt: "2025-01-01T00:00:00Z",
-						lastUpdated: "2025-01-01T00:00:00Z",
-					},
-				],
-			},
-		};
-
-		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
-
-		const result = await listClaudePluginRoots(tempDir);
-		expect(result.roots).toHaveLength(1);
-		expect(result.roots[0].scope).toBe("project");
-	});
-
 	test("handles multiple entries per plugin ID", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		await fs.mkdir(pluginsDir, { recursive: true });
@@ -364,6 +347,7 @@ describe("listClaudePluginRoots", () => {
 					},
 					{
 						scope: "project",
+						projectPath: tempDir,
 						installPath: "/path/to/v1",
 						version: "1.0.0",
 						installedAt: "2025-01-01T00:00:00Z",
@@ -375,7 +359,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listClaudePluginRoots(tempDir, tempDir);
 		// Should return both entries, not just the first one
 		expect(result.roots).toHaveLength(2);
 		expect(result.roots[0].version).toBe("2.0.0");
@@ -1521,6 +1505,7 @@ describe("discoverAgents plugin precedence", () => {
 					},
 					{
 						scope: "project",
+						projectPath: tempDir,
 						installPath: projectPluginPath,
 						version: "1.0.1",
 						installedAt: "2025-01-02T00:00:00Z",


### PR DESCRIPTION
## Repro
A Claude registry containing matching and foreign `scope: "project"` entries leaked the foreign root from `listClaudePluginRoots()`. Reproduced with `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts --test-name-pattern 'isolates local and project plugins'`; before the fix it failed because `foreign-project-plugin@market` was returned.

## Cause
`listClaudePluginRoots()` in `packages/coding-agent/src/discovery/helpers.ts` canonicalized and compared `projectPath` only when `entry.scope === "local"`. Claude `project` entries bypassed that branch and were appended as active roots regardless of the current project.

## Fix
- Apply the existing canonical, symlink-safe `projectPath` boundary to both Claude `local` and `project` entries.
- Cover matching and foreign entries for both scopes in one discovery regression test.
- Update project-scoped fixtures to carry their owning `projectPath` and document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` passes: 39 tests, 94 assertions. `bun run check:types` passes in `packages/coding-agent`. The pre-publish `bun check` gate passed. A broader `bun test packages/coding-agent/test/discovery` attempt reached 229 passing tests but could not complete because the ungenerated `packages/coding-agent/src/export/html/tool-views.generated.js` artifact was absent.

Fixes #9043