### PR TITLE
fix(tools): correct SSH guidance tool names

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
+### Fixed
+
+- Fixed SSH guidance recommending retired `search` and standalone `ssh` routes.
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/internal-urls/ssh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/ssh-protocol.ts
@@ -289,7 +289,7 @@ export class SshProtocolHandler implements ProtocolHandler {
 		}
 		if (kind === "other") {
 			throw new Error(
-				`ssh://: ${remotePath} is not a regular file (FIFO, socket, or device); ssh:// reads UTF-8 text files only — use the ssh tool for special files`,
+				`ssh://: ${remotePath} is not a regular file (FIFO, socket, or device); ssh:// reads UTF-8 text files only — use \`bash\` with a remote SSH command for special files`,
 			);
 		}
 		const fileResult = await readRemoteFile(target, remotePath, {
@@ -304,7 +304,7 @@ export class SshProtocolHandler implements ProtocolHandler {
 		const content = decodeUtf8Text(fileResult.bytes);
 		if (content === null) {
 			throw new Error(
-				`ssh://: ${remotePath} is a binary or non-UTF-8 file; ssh:// supports UTF-8 text only — use the ssh tool or an sshfs mount`,
+				`ssh://: ${remotePath} is a binary or non-UTF-8 file; ssh:// supports UTF-8 text only — use \`bash\` with a remote SSH command or an \`sshfs\` mount`,
 			);
 		}
 		// No `sourcePath`: keeps search on the virtual-resource path so the

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -19,8 +19,8 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 - Documents → extracted text. Notebooks → editable cells. Images → {{#if INSPECT_IMAGE_ENABLED}}metadata; call `inspect_image`{{else}}decoded inline{{/if}}. `:raw` bypasses converters.
 - URLs → reader-mode clean text/markdown; `:raw` → untouched HTML. Bare `host:port` needs trailing slash.
 - Internal URIs — all schemes take selectors. `artifact://<id>` recovers spilled output; page with `:N-M`/`:raw:N-M`.
-- `ssh://host/<path>` reads remote file/dir (UTF-8, ≤1 MiB); bare `ssh://` lists hosts; also `write`/`search`-able.
-  Literal `:`, `?`, `#` → percent-encode (`%3A`/`%3F`/`%23`). Requires POSIX shell (else `ssh` tool).
+- `ssh://host/<path>` reads remote file/dir (UTF-8, ≤1 MiB); bare `ssh://` lists hosts; writable with `write` and searchable with `grep`.
+  Literal `:`, `?`, `#` → percent-encode (`%3A`/`%3F`/`%23`). Requires a verified POSIX shell on the remote host. For Windows or other unsupported hosts, use `bash` with a remote SSH command or mount with `sshfs`.
 
 <critical>
 Summary footer names elided ranges? Re-issue ONLY those ranges. NEVER guess `..`/`…` content.

--- a/packages/coding-agent/src/ssh/file-transfer.ts
+++ b/packages/coding-agent/src/ssh/file-transfer.ts
@@ -30,12 +30,12 @@ async function ensurePosixRemote(target: SSHConnectionTarget): Promise<"sh" | "b
 	const info = await ensureHostInfo(target);
 	if (info.os === "windows") {
 		throw new Error(
-			`ssh://: ${target.name} is a Windows host; ssh:// supports POSIX remotes only (head/cat/mv) — use the ssh tool for Windows hosts`,
+			`ssh://: ${target.name} is a Windows host; ssh:// supports POSIX remotes only (head/cat/mv) — use \`bash\` with a remote SSH command for Windows hosts`,
 		);
 	}
 	if (!info.transferShell) {
 		throw new Error(
-			`ssh://: ${target.name} has no verified POSIX shell for ssh:// read/write — none of sh/bash/zsh round-tripped a capability probe (use the ssh tool for this host)`,
+			`ssh://: ${target.name} has no verified POSIX shell for ssh:// read/write — none of sh/bash/zsh round-tripped a capability probe (use \`bash\` with a remote SSH command for this host)`,
 		);
 	}
 	return info.transferShell;

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -809,7 +809,7 @@ async function resolveInternalSearchInputs(opts: {
 		// misleading. Local/skill/vault dir resources set `sourcePath` and skip this.
 		if (resource.isDirectory && !resource.sourcePath) {
 			throw new ToolError(
-				`search cannot recurse the directory listing at ${rawPath}; search a specific file under it (e.g. ${rawPath.replace(/\/+$/, "")}/<file>) or read ${rawPath} to list its entries`,
+				`grep cannot recurse the directory listing at ${rawPath}; grep a specific file under it (e.g. ${rawPath.replace(/\/+$/, "")}/<file>) or read ${rawPath} to list its entries`,
 			);
 		}
 		if (resource.sourcePath) {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -1478,7 +1478,7 @@ export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<To
 		}
 		if (isSshUrl(rawPath)) {
 			throw new ToolError(
-				`Cannot ${internalUrlAction} a remote ssh:// path (no local file): ${rawPath}. Use \`read ${rawPath}\` to view it, or the \`search\` tool to grep remote files.`,
+				`Cannot ${internalUrlAction} a remote ssh:// path (no local file): ${rawPath}. Use \`read ${rawPath}\` to view it, or use \`grep\` on a specific remote file.`,
 			);
 		}
 		if (hasGlobPathChars(rawPath)) {

--- a/packages/coding-agent/test/internal-urls/ssh-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/ssh-protocol.test.ts
@@ -104,7 +104,9 @@ describe("SshProtocolHandler", () => {
 			bytes: new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01]),
 			truncated: false,
 		});
-		await expect(handler.resolve(parseInternalUrl("ssh://icaro/bin/true"))).rejects.toThrow(/binary or non-UTF-8/);
+		await expect(handler.resolve(parseInternalUrl("ssh://icaro/bin/true"))).rejects.toThrow(
+			/binary or non-UTF-8.*use `bash` with a remote SSH command or an `sshfs` mount/,
+		);
 	});
 
 	it("rejects a file whose first invalid byte falls past the old 8 KiB sniff window", async () => {
@@ -181,7 +183,9 @@ describe("SshProtocolHandler", () => {
 		const readSpy = vi
 			.spyOn(fileTransfer, "readRemoteFile")
 			.mockResolvedValue({ bytes: new Uint8Array(), truncated: false });
-		await expect(handler.resolve(parseInternalUrl("ssh://icaro/dev/zero"))).rejects.toThrow(/not a regular file/);
+		await expect(handler.resolve(parseInternalUrl("ssh://icaro/dev/zero"))).rejects.toThrow(
+			/not a regular file.*use `bash` with a remote SSH command/,
+		);
 		expect(readSpy).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/ssh/file-transfer-posix-guard.test.ts
+++ b/packages/coding-agent/test/ssh/file-transfer-posix-guard.test.ts
@@ -19,8 +19,12 @@ describe("ssh file-transfer POSIX guard", () => {
 			compatEnabled: false,
 		});
 		const target: SSHConnectionTarget = { name: "winbox", host: "winbox" };
-		await expect(readRemoteFile(target, "C:/x.txt", { maxBytes: 1024 })).rejects.toThrow(/Windows host/);
-		await expect(writeRemoteFile(target, "C:/x.txt", new Uint8Array([1]), {})).rejects.toThrow(/Windows host/);
+		await expect(readRemoteFile(target, "C:/x.txt", { maxBytes: 1024 })).rejects.toThrow(
+			/Windows host.*use `bash` with a remote SSH command/,
+		);
+		await expect(writeRemoteFile(target, "C:/x.txt", new Uint8Array([1]), {})).rejects.toThrow(
+			/Windows host.*use `bash` with a remote SSH command/,
+		);
 		// Prove the guard ran through the stubbed transport rather than failing early
 		// for an unrelated reason (e.g. a future import refactor bypassing the mocks).
 		expect(ensureConnectionSpy).toHaveBeenCalled();
@@ -40,9 +44,11 @@ describe("ssh file-transfer POSIX guard", () => {
 			compatEnabled: false,
 		});
 		const target: SSHConnectionTarget = { name: "noshell", host: "noshell" };
-		await expect(readRemoteFile(target, "/etc/hosts", { maxBytes: 1024 })).rejects.toThrow(/no verified POSIX shell/);
+		await expect(readRemoteFile(target, "/etc/hosts", { maxBytes: 1024 })).rejects.toThrow(
+			/no verified POSIX shell.*use `bash` with a remote SSH command/,
+		);
 		await expect(writeRemoteFile(target, "/tmp/x", new Uint8Array([1]), {})).rejects.toThrow(
-			/no verified POSIX shell/,
+			/no verified POSIX shell.*use `bash` with a remote SSH command/,
 		);
 	});
 

--- a/packages/coding-agent/test/tools/grep-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/grep-internal-urls.test.ts
@@ -622,7 +622,7 @@ describe("GrepTool internal URL resolution", () => {
 		const listSpy = vi.spyOn(sshFileTransfer, "listRemoteDir").mockResolvedValue([]);
 		const tool = new GrepTool(createSession());
 		await expect(tool.execute("ssh-dir-search", { pattern: "x", path: "ssh://h/etc" })).rejects.toThrow(
-			/directory listing|cannot recurse/,
+			/grep cannot recurse the directory listing/,
 		);
 		expect(listSpy).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/tools/read-guidance.test.ts
+++ b/packages/coding-agent/test/tools/read-guidance.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+
+function createSession(): ToolSession {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	};
+}
+
+describe("Read SSH guidance", () => {
+	it("advertises grep and current SSH fallbacks instead of retired tool names", () => {
+		const description = new ReadTool(createSession()).description;
+
+		expect(description).toContain("searchable with `grep`");
+		expect(description).toContain("use `bash` with a remote SSH command");
+		expect(description).toContain("`sshfs`");
+		expect(description).not.toContain("`search`");
+		expect(description).not.toContain("`ssh` tool");
+	});
+});

--- a/packages/coding-agent/test/tools/ssh-url-ungated-tools.test.ts
+++ b/packages/coding-agent/test/tools/ssh-url-ungated-tools.test.ts
@@ -43,7 +43,7 @@ describe("ssh:// is rejected before any connection in read/write-tier tools", ()
 		for (const internalUrlAction of ["search", "rewrite"]) {
 			await expect(
 				resolveToolSearchScope({ rawPaths: ["ssh://h/x"], cwd: os.tmpdir(), internalUrlAction }),
-			).rejects.toThrow(/ssh:\/\//);
+			).rejects.toThrow(/use `grep` on a specific remote file/);
 		}
 		expect(spy).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## What

Replace stale model-facing SSH route names with the current provider-visible tools and document truthful fallbacks.

- Use `grep` for specific remote files instead of retired `search`.
- Use `bash` with a remote SSH command or `sshfs` where `ssh://` cannot operate.
- Preserve SSH URL read, write, and `grep` behavior without restoring retired tools.

## Why

Read guidance and SSH runtime errors recommend `search` and a standalone `ssh` tool that are absent from the provider-visible registry.
Models can therefore produce unavailable tool calls or miss the supported `grep ssh://file` route.

## Testing

- Focused SSH/Grep regression tests pass: 68 tests, 0 failures.
- `bun --cwd=packages/coding-agent run check` passes Biome.
- The package type check reports pre-existing `SettingsListTheme.warning` errors in `src/modes/theme/tui-adapters.ts:257,272`.
- `packages/coding-agent/CHANGELOG.md` contains the Unreleased fix entry.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

I checked the relevant issues, comments, pull requests, and discussions; this pull request is not a duplicate.

### Disclosure

Investigated thoroughly with openrouter/openai/gpt-5.6-luna (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.