### PR TITLE
fix(coding-agent): clarify task spawn-policy defaults

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `/settings` rows can now carry a risk note: a warning glyph on the row plus a warning-colored line above the description. `External Thinking` (`externalThinking`, `--external-thinking`) is the first user — providers have flagged the request shape it produces as abuse, up to account-level enforcement, so both the settings entry and `--help` now say so.
 
+### Fixed
+
+- Fixed Task descriptions mislabeling restrictive spawn-policy defaults as general-purpose workers.
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -23,7 +23,9 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `context`: Shared project state, constraints, and contracts. Applies to the entire batch; do not duplicate this background into individual tasks.
 - `tasks[]`: Array of subagents to spawn.
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
-  - `agent`: The agent type running this item (e.g. {{#if scoutAvailable}}`scout`, {{/if}}`reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
+  - `agent`: The agent type to spawn (e.g. {{#if scoutAvailable}}`scout`, {{/if}}`reviewer`).
+    Omitting `agent` selects the spawn-policy default (`{{defaultAgent}}`). Use it only when that agent fits the task.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
+    NEVER pass the spawn-policy default explicitly. Only omit it after checking the available agents below.
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
@@ -38,7 +40,9 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 {{/if}}
 {{else}}
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
-- `agent`: The agent type to spawn (e.g. {{#if scoutAvailable}}`scout`, {{/if}}`reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
+- `agent`: The agent type to spawn (e.g. {{#if scoutAvailable}}`scout`, {{/if}}`reviewer`).
+  Omitting `agent` selects the spawn-policy default (`{{defaultAgent}}`). Use it only when that agent fits the task.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
+  NEVER pass the spawn-policy default explicitly. Only omit it after checking the available agents below.
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -33,12 +33,21 @@ const taskAgent: AgentDefinition = {
 	source: "bundled",
 };
 
+const scoutAgent: AgentDefinition = {
+	name: "scout",
+	description: "Read-only research agent",
+	systemPrompt: "You are a scout agent.",
+	tools: ["read"],
+	source: "bundled",
+};
+
 function createSession(
 	options: {
 		manager?: AsyncJobManager;
 		settings?: Record<string, unknown>;
 		agentId?: string;
 		planMode?: boolean;
+		spawns?: string;
 	} = {},
 ): ToolSession {
 	return {
@@ -46,7 +55,7 @@ function createSession(
 		hasUI: false,
 		settings: Settings.isolated(options.settings ?? {}),
 		getSessionFile: () => null,
-		getSessionSpawns: () => "*",
+		getSessionSpawns: () => options.spawns ?? "*",
 		getAgentId: () => options.agentId ?? null,
 		getPlanModeState: options.planMode ? () => ({ enabled: true }) : undefined,
 		asyncJobManager: options.manager,
@@ -130,6 +139,15 @@ describe("task.batch schema gating", () => {
 		expect(itemProperties.outputSchema).toBeDefined();
 		expect(typeof itemProperties.outputSchema).toBe("object");
 		expect(itemProperties.schemaMode).toBeDefined();
+	});
+
+	it("describes a restricted specialist as the spawn-policy default", async () => {
+		mockDiscovery(scoutAgent);
+		const tool = await TaskTool.create(createSession({ spawns: "scout" }));
+
+		expect(tool.description).toContain("spawn-policy default (`scout`)");
+		expect(tool.description).not.toContain("general-purpose worker");
+		expect(tool.description).toContain("### scout (READ-ONLY)");
 	});
 
 	it("hides effort by default and exposes it when task.enableEffort is enabled", async () => {


### PR DESCRIPTION
## What

Make the Task tool describe omitted `agent` values as the spawn-policy default instead of calling every default a general-purpose worker.

The focused test covers a restrictive `spawns: scout` policy and confirms that Scout remains identified as read-only.

## Why

The runtime resolves an omitted `agent` to the first allowed agent under restrictive policies, so a reviewer can default to read-only Scout rather than the generic `task` agent.

The prompt currently calls that selected default a general-purpose worker, which can encourage unsuitable omitted-agent calls.

## Scope

The change only corrects model-facing wording and adds focused coverage.

Spawn-policy resolution, schema defaults, and runtime enforcement remain unchanged.

## Testing

- `bun test packages/coding-agent/test/task/task-batch.test.ts` — 19 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` — Biome and type checks pass.
- `I reviewed the full diff; this change only corrects the Task default description and leaves spawn-policy resolution unchanged.`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.
