### PR TITLE
fix(coding-agent): correct task overlap guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -178,6 +178,9 @@
 - Automatically continued Gemini turns that stopped after thinking without final output, using a bounded final-answer reminder instead of exhausting generic retries.
 - Retried Gemini `MALFORMED_FUNCTION_CALL` failures when every emitted tool call was proven unexecuted, while preserving real tool-result and visible-output replay guards.
 - Kept current terminal retry errors in one pinned banner with attempt context while surfacing local continuation failures instead of stale provider errors.
+### Fixed
+
+- Fixed Task tool guidance promising automatic resolution of concurrent same-file edits when shared and isolated execution can expose real conflicts.
 
 ## [17.3.2] - 2026-08-13
 

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -14,7 +14,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - **Agent typing:** Pick each item's `agent` type.{{#if scoutAvailable}} Read-only research MUST use `agent: "scout"` (faster model).{{/if}} Use default worker only when no specialist fits.
 - **No overhead:** Each `task` MUST instruct its agent to skip formatters, linters, and project-wide test suites. Run those once at the end.
 - **One-pass:** Prefer agents that investigate AND edit in one pass;{{#if scoutAvailable}} spin a read-only scout only when affected files are genuinely unknown.{{/if}}
-- **Overlap is safe:** Concurrent edits to the same files auto-resolve{{#if ircEnabled}}; worst case, agents coordinate directly over IRC{{/if}}. NEVER shrink or serialize a batch to avoid file overlap. Two prerequisites:
+- **Overlap:** Parallelize independent ownership. Same-file edits are not guaranteed to merge.{{#if ircEnabled}} Have siblings coordinate through `hub` before editing shared files.{{/if}} Name one integration owner and serialize only the irreducibly shared mutation boundary. Every concurrent batch has two prerequisites:
   1. Every task MUST skip validation (build/lint/tests) — validating mid-flight blocks agents on each other's edits.
   2. Decide cross-task contracts up front (e.g. the interface A implements and B consumes) and state them in the {{#if batchEnabled}}batch `context`{{else}}task{{/if}}, not left for agents to negotiate.
 

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -132,6 +132,16 @@ describe("task.batch schema gating", () => {
 		expect(itemProperties.schemaMode).toBeDefined();
 	});
 
+	it("requires coordination instead of promising same-file auto-resolution", async () => {
+		mockDiscovery();
+		const tool = await TaskTool.create(createSession({ settings: { "task.batch": true } }));
+
+		expect(tool.description).toContain("Same-file edits are not guaranteed to merge");
+		expect(tool.description).toContain("coordinate through `hub` before editing shared files");
+		expect(tool.description).toContain("Name one integration owner");
+		expect(tool.description).not.toContain("Concurrent edits to the same files auto-resolve");
+	});
+
 	it("hides effort by default and exposes it when task.enableEffort is enabled", async () => {
 		mockDiscovery();
 


### PR DESCRIPTION
## What

Replace Task tool's universal same-file auto-resolution promise with the behavior the runtime can support: parallelize independent ownership, coordinate shared-file work through `hub`, name one integration owner, and serialize only the irreducibly shared mutation boundary.

No isolation, merge, or editor runtime behavior changes.

## Why

The current prompt guarantees that concurrent same-file edits auto-resolve, but non-isolated children share one working directory and branch or patch isolation deliberately surfaces genuine conflicts.

Issue #5387 documents the missing write boundary for non-isolated tasks; issues #4135, #4136, #4175, and #4621 cover related conflict paths. None owns the prompt's universal guarantee.

## Testing

- `bun test packages/coding-agent/test/task/task-batch.test.ts -t "requires coordination instead of promising same-file auto-resolution"` — 1 pass, 0 fail.
- `bun test packages/coding-agent/test/task/worktree.test.ts -t "still aborts on genuine cherry-pick conflicts"` — 1 pass, 0 fail.
- `bun test packages/coding-agent/test/task/isolation-runner.test.ts -t "rejects patch-mode conflicts without dirtying the worktree"` — 1 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` — Biome and type checks pass.
- `I reviewed the full diff; this change corrects the Task prompt without changing isolation or merge behavior.`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.
