### PR TITLE
fix(cursor): honor standard proxy env vars on the HTTP/2 run path

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Cloud Code Assist Gemini 3.6/3.7 Flash requests at `minimal` now send `thinkingLevel: LOW` on the aliased `-low` SKU instead of `MINIMAL`, which the API rejects with HTTP 400.
 - Answer Cursor `interaction_query` permission gates (hosted web search, Exa, unnamed field-9 WebFetch) so the Run RPC continues instead of sitting silent until the 300s idle watchdog.
 - Fixed provider tool calls arriving with flattened array argument paths (e.g. Gemini's `questions[0].id`) being stripped and rejected by argument validation; well-formed flattened paths are now rebuilt into the nested arrays the tool schema expects ([#8886](https://github.com/can1357/oh-my-pi/issues/8886)).
+- Fixed the Cursor HTTP/2 run path ignoring the standard `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` environment variables — it only read `PI_PROXY`/`PI_PROXY_CURSOR`, so on networks where reaching `api2.cursor.sh` requires a proxy (e.g. region-restricted egress that blocks US-provider models) runs connected direct and failed with a bare `resource_exhausted` while native Cursor models still worked. The run now resolves the proxy through `getProxyForUrl`, matching the Codex transport and honoring `NO_PROXY` ([#8894](https://github.com/can1357/oh-my-pi/issues/8894)).
 
 ## [17.3.7] - 2026-08-17
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -188,7 +188,7 @@ import {
 } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { connectProxiedSocket, getProxyForProvider, shouldBypassProxy } from "../utils/proxy";
+import { connectProxiedSocket, getProxyForUrl } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { toolWireSchema } from "../utils/schema/wire";
 import {
@@ -663,7 +663,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 					})
 				: undefined;
 
-			const proxyUrl = shouldBypassProxy(new URL(baseUrl)) ? undefined : getProxyForProvider(model.provider);
+			const proxyUrl = getProxyForUrl(model.provider, new URL(baseUrl));
 			if (proxyUrl) {
 				const tlsSocket = await connectProxiedSocket(proxyUrl, baseUrl, {
 					signal: options?.signal,

--- a/packages/ai/test/cursor-proxy-env.test.ts
+++ b/packages/ai/test/cursor-proxy-env.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+describe("Cursor proxy resolution", () => {
+	it("tunnels the run through HTTPS_PROXY when no PI_PROXY is set", async () => {
+		const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures/cursor-proxy-env.ts")], {
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		expect(JSON.parse(stdout)).toEqual({ connectTargets: ["198.51.100.7:8443"] });
+	}, 60_000);
+});

--- a/packages/ai/test/fixtures/cursor-proxy-env.ts
+++ b/packages/ai/test/fixtures/cursor-proxy-env.ts
@@ -1,0 +1,68 @@
+import * as net from "node:net";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// Fake HTTP CONNECT proxy: record the CONNECT target of the first request, then
+// reset. The run fails afterwards regardless — the recorded target is the proof
+// that the Cursor HTTP/2 path routed through the proxy.
+const connectTargets: string[] = [];
+const proxy = net.createServer(socket => {
+	socket.once("data", (chunk: Buffer) => {
+		const firstLine = chunk.toString("utf8").split("\r\n")[0];
+		const match = /^CONNECT\s+(\S+)\s+HTTP\/1\.1$/.exec(firstLine);
+		if (match) connectTargets.push(match[1]);
+		// Refuse the tunnel so the run fails fast instead of hitting the tunnel timeout.
+		socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
+	});
+});
+const proxyListening = Promise.withResolvers<void>();
+proxy.once("error", proxyListening.reject);
+proxy.listen(0, "127.0.0.1", proxyListening.resolve);
+await proxyListening.promise;
+
+const proxyAddress = proxy.address();
+if (!proxyAddress || typeof proxyAddress === "string") throw new Error("proxy did not bind");
+
+// Only the standard HTTPS_PROXY var is set; the provider-specific override and
+// PI_PROXY are unset, so a fix that only reads PI_PROXY would connect direct and
+// never reach this proxy.
+delete Bun.env.PI_PROXY;
+delete Bun.env.PI_PROXY_CURSOR;
+delete Bun.env.HTTP_PROXY;
+delete Bun.env.http_proxy;
+delete Bun.env.ALL_PROXY;
+delete Bun.env.all_proxy;
+delete Bun.env.NO_PROXY;
+delete Bun.env.no_proxy;
+Bun.env.HTTPS_PROXY = `http://127.0.0.1:${proxyAddress.port}`;
+
+// TEST-NET-2 (RFC 5737) target: not local/metadata, so the proxy is not bypassed,
+// and unroutable so nothing actually connects past the proxy.
+const model: Model<"cursor-agent"> = buildModel({
+	id: "cursor-proxy-fixture",
+	name: "Cursor proxy fixture",
+	api: "cursor-agent",
+	provider: "cursor",
+	baseUrl: "https://198.51.100.7:8443",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+});
+const context: Context = {
+	messages: [{ role: "user", content: "trigger proxy connect", timestamp: Date.now() }],
+};
+
+try {
+	const stream = streamCursor(model, context, { apiKey: "test-token" });
+	for await (const _event of stream) {
+		// drain events; the run errors once the proxy resets the tunnel
+	}
+	await stream.result();
+} finally {
+	proxy.close();
+}
+
+process.stdout.write(`${JSON.stringify({ connectTargets })}\n`);


### PR DESCRIPTION
## Repro

The issue author reproduced their `resource_exhausted` (errorId 528384) as a **geo-block**, not the sibling-id wire shape. Their machine always has `HTTP_PROXY=http://127.0.0.1:6152` but `PI_PROXY` unset. OMP's Cursor HTTP/2 run path resolved its proxy through `getProxyForProvider()`, which reads only `PI_PROXY_<PROVIDER>` then `PI_PROXY` — so it ignored `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` and connected **direct** over the CN egress that Cursor geo-blocks for US-provider (Anthropic/OpenAI) models, returning a bare `resource_exhausted`. Native Cursor models (`composer-2.5`, `cursor-grok-4.6`) worked over the same direct CN egress, matching Cursor's China restriction. Setting `PI_PROXY` routed via HK egress and returned `pong`, confirming the credential was healthy.

```bash
# fails direct (HTTP_PROXY set, PI_PROXY unset); succeeds once PI_PROXY is set
PI_PROXY=http://127.0.0.1:6152 omp -p --mode=json --max-time=30 --no-session --no-tools \
  --model cursor/claude-fable-5-low "Reply with exactly: pong"   # -> pong
```

## Cause

`streamCursor` in `packages/ai/src/providers/cursor.ts` resolved the tunnel proxy with `getProxyForProvider(model.provider)` (`packages/ai/src/utils/proxy.ts:120`), whose only sources are `PI_PROXY_<PROVIDER>` and `PI_PROXY`. The equivalent manual-HTTP/2 transport for Codex (`packages/ai/src/providers/openai-codex-responses.ts:4048`) uses `getProxyForUrl()`, which additionally honors the standard `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` vars (and `NO_PROXY` via `shouldBypassProxy`). Bun's native `fetch` transports pick up `HTTP_PROXY` at the runtime level, but this raw `node:http2` path does not, so the Cursor run silently ignored the ambient proxy. The reporter's earlier "unsetting `HTTP(S)_PROXY` does not change the result" test was tautological — that transport never read those vars.

## Fix

- `packages/ai/src/providers/cursor.ts`: resolve the run proxy with `getProxyForUrl(model.provider, new URL(baseUrl))` instead of `getProxyForProvider(...)`. `getProxyForUrl` already applies the `shouldBypassProxy`/`NO_PROXY` check internally, so the explicit bypass guard is folded in and dropped. Import updated accordingly (`getProxyForProvider`/`shouldBypassProxy` -> `getProxyForUrl`).
- `packages/ai/test/fixtures/cursor-proxy-env.ts` + `packages/ai/test/cursor-proxy-env.test.ts`: subprocess test with a fake HTTP CONNECT proxy. It sets only `HTTPS_PROXY` (with `PI_PROXY`/`PI_PROXY_CURSOR` unset) and runs `streamCursor` against a TEST-NET-2 target; it asserts the proxy receives `CONNECT 198.51.100.7:8443`. Pre-fix the proxy receives nothing (direct connect), so the test fails; post-fix it records the CONNECT.
- `packages/ai/CHANGELOG.md`: `[Unreleased] > Fixed` entry.

This fixes the geo/proxy cause behind this account's failure. It does **not** touch the separate sibling-id wire-shape defect (`requestedModel.modelId` = effort slug + empty `parameters[]` vs base id + parameters) that @qiyi71w captured and I confirmed in code; that one needs Cursor's per-model parameter/variant schema (not decoded by OMP's `GetUsableModels` proto) and a maintainer decision on approach, so it should be tracked as its own issue.

## Verification

`bun test packages/ai/test/cursor-proxy-env.test.ts` -> 1 pass, 3 expect() calls, 196ms. `bun test packages/ai/test/cursor-transport-error.test.ts packages/ai/test/cursor-h2-transport-error.test.ts` -> 5 pass (import change did not regress the transport paths). Pre-publish gate (`bun run fix` + `bun check`) passed on push. The live end-to-end (real Cursor account over a proxy) was verified by the reporter; the added test proves the proxy-resolution contract in-repo without account access. Fixes #8894