### PR TITLE
fix(catalog): disable forced tool choice for OpenCode Responses

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed OpenCode Console Go and Zen Responses (`opencode-go` / `opencode-zen`) rejecting forced `tool_choice` (including External Thinking's named `think`) with HTTP 400 `param=tool_choice`. `buildOpenAIResponsesCompat` now sets `supportsForcedToolChoice` false for those providers so the request mapper downgrades forced/named choices to `auto`.
 - Fixed `opencode-go/muse-spark-1.2` and `muse-spark-1.2-contributor` still failing every tool-call turn with `OpenAI completions stream closed before a finish_reason was received` on 17.3.8. The earlier pin only covered the models.dev resolver, but models.dev omits these ids under `opencode-go` entirely, so live `/zen/go/v1/models` discovery had no bundled reference and defaulted them to chat completions. The per-id API pins now also apply inside the discovery mapper, and pinned ids invalidate cached routes written before the pin ([#8957](https://github.com/can1357/oh-my-pi/issues/8957)).
 - Future gateway-first OpenCode models (ids the gateway serves before models.dev lists them, like muse-spark-1.2 was) no longer default to chat completions blindly: discovery now borrows the `openai-responses` route from the sibling gateway's catalog or the billing-variant base id (`-free`/`-contributor`). Only the responses signal is borrowed — anthropic transports genuinely diverge across the gateways (e.g. `minimax-m2.5`) and are never inferred.
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -759,7 +759,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		disableReasoningOnForcedToolChoice: isKimiModel,
 		disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
 		supportsToolChoice: true,
-		supportsForcedToolChoice: true,
+		supportsForcedToolChoice: spec.provider !== "opencode-go" && spec.provider !== "opencode-zen",
 		supportsNamedToolChoice: STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS[spec.provider] !== true,
 		reasoningContentField: "reasoning_content",
 		requiresReasoningContentForToolCalls:

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -435,6 +435,33 @@ describe("openai-completions wire-quirk compat detection", () => {
 			).supportsForcedToolChoice,
 		).toBe(true);
 	});
+	it("downgrades forced tool choice for OpenCode gateways on Responses API", () => {
+		expect(
+			buildOpenAIResponsesCompat({
+				id: "muse-spark-1.2-contributor",
+				provider: "opencode-go",
+				name: "Muse Spark",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+			}).supportsForcedToolChoice,
+		).toBe(false);
+		expect(
+			buildOpenAIResponsesCompat({
+				id: "muse-spark-1.2",
+				provider: "opencode-zen",
+				name: "Muse Spark",
+				baseUrl: "https://opencode.ai/zen/v1",
+			}).supportsForcedToolChoice,
+		).toBe(false);
+		expect(
+			buildOpenAIResponsesCompat({
+				id: "gpt-5",
+				provider: "openai",
+				name: "GPT-5",
+				baseUrl: "https://api.openai.com/v1",
+			}).supportsForcedToolChoice,
+		).toBe(true);
+	});
+
 
 	it("requires a synthetic assistant bridge after tool results only for Mistral hosts", () => {
 		// Mistral/Devstral reject a user message directly after a tool result; the chat


### PR DESCRIPTION
## Repro

On OpenCode Console Go (`https://opencode.ai/zen/go/v1/responses`) and Zen (`https://opencode.ai/zen/v1/responses`), a turn that sends a forced `tool_choice` — including the named `think` choice used for external thinking — is rejected with HTTP 400 `param=tool_choice`. Reproduced with `opencode-go/muse-spark-1.2-contributor` (and the Zen sibling). Those gateways accept only `tool_choice: "auto"`.

This is separate from the Responses API pin ([#8980](https://github.com/can1357/oh-my-pi/pull/8980)) and from thinking-level mapping ([#8999](https://github.com/can1357/oh-my-pi/issues/8999)). After those, muse-spark still 400s on `tool_choice`.

## Cause

`buildOpenAIResponsesCompat` hard-coded `supportsForcedToolChoice: true` for every host. Chat Completions already downgrades forced choice for OpenCode DeepSeek reasoning (`isOpenCodeHost && isDeepseekReasoning`); the Responses builder never did.

`OPENCODE_GO_API_ID_OVERRIDES` only selects the transport (`openai-responses` vs completions). It cannot carry this compat flag. When `supportsForcedToolChoice` is false, `mapOpenAIResponsesToolChoiceForTools` already rewrites a forced or named choice to `"auto"`.

## Fix

In `buildOpenAIResponsesCompat`, set `supportsForcedToolChoice` to false for `opencode-go` and `opencode-zen`. Other Responses hosts remain true.

## Testing

`packages/catalog/test/build.test.ts`:

- `opencode-go` and `opencode-zen` Responses specs report `supportsForcedToolChoice === false`
- a first-party OpenAI Responses spec stays `true`

Existing Completions-only OpenCode DeepSeek coverage is unchanged.
