### PR TITLE
fix(snapcompact): elide inline base64 data URLs before truncation

### DIFF
--- a/packages/snapcompact/CHANGELOG.md
+++ b/packages/snapcompact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed character-based truncation splitting inline base64 data URLs: the elision marker landed inside the payload of archived tool results/args (and `planArchive()` edge slices could split URLs in any message text), leaving a recognizable-but-undecodable image reference that persisted in the archive and was rejected as invalid image input by OpenAI-dialect providers on every later request. Inline data URLs are now replaced atomically with a deterministic `[data URL omitted: <mime>, <n> base64 chars]` placeholder before any cap runs; re-compaction and `historyBlocks` reconstruction heal archives corrupted before the guard existed.
+
 ## [17.3.8] - 2026-08-19
 
 ### Fixed

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -848,7 +848,9 @@ function elideDataUrls(text: string, context: DataUrlContext = "source"): string
 				CANONICAL_BASE64.test(payload) ||
 				payload.length >= DAMAGED_PAYLOAD_MIN_CHARS;
 			if (!isAtom) return match;
-			const b64Chars = marker ? payload.length - marker[0].length : payload.length;
+			const b64Chars = marker
+				? payload.length - marker[0].length + Number(/\d+/.exec(marker[0])?.[0] ?? 0)
+				: payload.length;
 			const placeholder = `[data URL omitted: ${mime}, ${b64Chars} base64 chars]`;
 			// Swallow the Markdown wrapper only when both delimiters matched;
 			// otherwise re-emit whichever half was captured untouched.
@@ -1699,7 +1701,7 @@ export function archiveSourceText(archive: Archive): string | undefined {
 		[archive.textHead, archive.textTail]
 			.filter((part): part is string => typeof part === "string" && part.length > 0)
 			.join(NEWLINE_GLYPH);
-	return text.length > 0 ? toPlainText(text) : undefined;
+	return text.length > 0 ? elideDataUrls(toPlainText(text), "archive") : undefined;
 }
 
 /** Build the text used to choose and preflight a font-aware snapcompact shape. */

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -783,22 +783,22 @@ const ELIDED_MARKER = String.raw`\[(?:…|\.{3})\d+ch elided(?:…|\.{3})\]`;
  *  Quoted-string values (RFC 822) are out of scope. */
 const MEDIA_TYPE_TOKEN = String.raw`[\w!#$%&'*+.^|~-]+`;
 
-/** An inline base64 data URL, optionally wrapped in a Markdown image/link
- *  atom. The payload may be empty or carry one embedded elision marker so
- *  fragments left by pre-guard slices — including a cut landing exactly on
- *  `;base64,` — still match. RFC 2397 allows `*( ";" parameter )` between
- *  type/subtype and the terminal `;base64`; unquoted tokens are matched,
+/** An inline base64 data URL. The payload may be empty or carry one embedded
+ *  elision marker so fragments left by pre-guard slices — including a cut
+ *  landing exactly on `;base64,` — still match. RFC 2397 allows `*( ";" parameter )`
+ *  between type/subtype and the terminal `;base64`; unquoted tokens are matched,
  *  quoted-string values are out of scope. `data:` and `base64` match
- *  case-insensitively (`gi`). */
+ *  case-insensitively (`gi`). Matching starts at `data:`; Markdown wrappers are
+ *  recovered by {@link adjacentMarkdownOpenerStart} after each hit. */
 const DATA_URL_ATOM = new RegExp(
-	String.raw`(!?\[[^\]\n]*\]\(\s*)?` +
-		String.raw`data:([A-Za-z][\w.+-]*\/[\w.+-]+(?:;${MEDIA_TYPE_TOKEN}=${MEDIA_TYPE_TOKEN})*);base64,` +
+	String.raw`data:([A-Za-z][\w.+-]*\/[\w.+-]+(?:;${MEDIA_TYPE_TOKEN}=${MEDIA_TYPE_TOKEN})*);base64,` +
 		String.raw`([A-Za-z0-9+/=]*(?:\s*${ELIDED_MARKER}\s*[A-Za-z0-9+/=]*)?)` +
 		String.raw`(\s*\))?`,
 	"gi",
 );
 
 const ELIDED_MARKER_RE = new RegExp(String.raw`\s*${ELIDED_MARKER}\s*`);
+const MARKDOWN_WHITESPACE_CHAR = /\s/;
 
 /** Canonical base64: 4-char groups with valid terminal padding. */
 const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/;
@@ -814,6 +814,26 @@ const DAMAGED_PAYLOAD_MIN_CHARS = 40;
  *  any offset — even 0–39 chars past `;base64,` — so every recognized prefix
  *  is suspect and is always elided. */
 type DataUrlContext = "source" | "archive";
+
+/** Start of `!?[label](\s*` immediately before `dataIndex`, or `undefined`.
+ *  The opener must lie in `[cursor, dataIndex)`. Nested `[` in the label is
+ *  kept (the old `[^\]\n]*` class allowed it) by taking the earliest `[` after
+ *  a prior `]`, newline, or `cursor`; the scan never walks already-emitted
+ *  text, so repeated `](data:...)` stays linear. */
+function adjacentMarkdownOpenerStart(text: string, dataIndex: number, cursor: number): number | undefined {
+	let i = dataIndex;
+	while (i > cursor && MARKDOWN_WHITESPACE_CHAR.test(text.charAt(i - 1))) i--;
+	// `](` and any following whitespace must sit in [cursor, dataIndex).
+	if (i - 2 < cursor || text.charAt(i - 1) !== "(" || text.charAt(i - 2) !== "]") return undefined;
+	let opener = -1;
+	for (let j = i - 3; j >= cursor; j--) {
+		const c = text.charAt(j);
+		if (c === "]" || c === "\n") break;
+		if (c === "[") opener = j;
+	}
+	if (opener < 0) return undefined;
+	return opener > cursor && text.charAt(opener - 1) === "!" ? opener - 1 : opener;
+}
 
 /** Replace every inline base64 data URL atomically with a deterministic
  *  placeholder. A character cap that slices inside a base64 payload leaves a
@@ -832,32 +852,53 @@ type DataUrlContext = "source" | "archive";
  *  function of the captured text. */
 function elideDataUrls(text: string, context: DataUrlContext = "source"): string {
 	if (!/;base64,/i.test(text)) return text;
-	return text.replace(
-		DATA_URL_ATOM,
-		(
-			match: string,
-			opener: string | undefined,
-			mime: string,
-			payload: string,
-			closer: string | undefined,
-		): string => {
-			const marker = ELIDED_MARKER_RE.exec(payload);
-			const isAtom =
-				context === "archive" ||
-				marker !== null ||
-				CANONICAL_BASE64.test(payload) ||
-				payload.length >= DAMAGED_PAYLOAD_MIN_CHARS;
-			if (!isAtom) return match;
+	DATA_URL_ATOM.lastIndex = 0;
+	let match = DATA_URL_ATOM.exec(text);
+	if (match === null) return text;
+	const out: string[] = [];
+	let cursor = 0;
+	while (match !== null) {
+		const urlStart = match.index;
+		const urlEnd = urlStart + match[0].length;
+		const mime = match[1] ?? "";
+		const payload = match[2] ?? "";
+		const closer = match[3];
+		const marker = ELIDED_MARKER_RE.exec(payload);
+		const isAtom =
+			context === "archive" ||
+			marker !== null ||
+			CANONICAL_BASE64.test(payload) ||
+			payload.length >= DAMAGED_PAYLOAD_MIN_CHARS;
+		if (!isAtom) {
+			// Advance through short prose too, so a later wrapper cannot swallow
+			// a data URL already copied out of its Markdown label.
+			out.push(text.slice(cursor, urlEnd));
+			cursor = urlEnd;
+		} else {
 			const b64Chars = marker
 				? payload.length - marker[0].length + Number(/\d+/.exec(marker[0])?.[0] ?? 0)
 				: payload.length;
 			const placeholder = `[data URL omitted: ${mime}, ${b64Chars} base64 chars]`;
+			const foundOpener = adjacentMarkdownOpenerStart(text, urlStart, cursor);
+			const openerStart = foundOpener !== undefined && foundOpener >= cursor ? foundOpener : undefined;
+			const emitStart = openerStart ?? urlStart;
+			out.push(text.slice(cursor, emitStart));
 			// Swallow the Markdown wrapper only when both delimiters matched;
-			// otherwise re-emit whichever half was captured untouched.
-			if (opener !== undefined && closer !== undefined) return placeholder;
-			return `${opener ?? ""}${placeholder}${closer ?? ""}`;
-		},
-	);
+			// otherwise re-emit whichever half was captured untouched. An opener
+			// that starts before the already-emitted cursor would overlap a prior
+			// replacement, so that URL is treated as bare.
+			if (openerStart !== undefined && closer !== undefined) {
+				out.push(placeholder);
+			} else {
+				const opener = openerStart !== undefined ? text.slice(openerStart, urlStart) : "";
+				out.push(opener, placeholder, closer ?? "");
+			}
+			cursor = urlEnd;
+		}
+		match = DATA_URL_ATOM.exec(text);
+	}
+	out.push(text.slice(cursor));
+	return out.join("");
 }
 
 const DIM_MARKERS = /[\u000e\u000f]/g;

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -775,6 +775,89 @@ function truncateForSummary(text: string, maxChars: number, headRatio: number): 
 	return `${text.slice(0, headChars)} […${elided}ch elided…] ${tail}`;
 }
 
+/** One elision marker as emitted by {@link truncateForSummary} (Unicode
+ *  ellipses) or as persisted after `normalize()` (ASCII dots). */
+const ELIDED_MARKER = String.raw`\[(?:…|\.{3})\d+ch elided(?:…|\.{3})\]`;
+
+/** Unquoted RFC 2045 token used as a media-type parameter name or value.
+ *  Quoted-string values (RFC 822) are out of scope. */
+const MEDIA_TYPE_TOKEN = String.raw`[\w!#$%&'*+.^|~-]+`;
+
+/** An inline base64 data URL, optionally wrapped in a Markdown image/link
+ *  atom. The payload may be empty or carry one embedded elision marker so
+ *  fragments left by pre-guard slices — including a cut landing exactly on
+ *  `;base64,` — still match. RFC 2397 allows `*( ";" parameter )` between
+ *  type/subtype and the terminal `;base64`; unquoted tokens are matched,
+ *  quoted-string values are out of scope. `data:` and `base64` match
+ *  case-insensitively (`gi`). */
+const DATA_URL_ATOM = new RegExp(
+	String.raw`(!?\[[^\]\n]*\]\(\s*)?` +
+		String.raw`data:([A-Za-z][\w.+-]*\/[\w.+-]+(?:;${MEDIA_TYPE_TOKEN}=${MEDIA_TYPE_TOKEN})*);base64,` +
+		String.raw`([A-Za-z0-9+/=]*(?:\s*${ELIDED_MARKER}\s*[A-Za-z0-9+/=]*)?)` +
+		String.raw`(\s*\))?`,
+	"gi",
+);
+
+const ELIDED_MARKER_RE = new RegExp(String.raw`\s*${ELIDED_MARKER}\s*`);
+
+/** Canonical base64: 4-char groups with valid terminal padding. */
+const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/;
+
+/** A non-canonical payload at least this long is a damaged fragment of a real
+ *  data URL (e.g. an archive head cut mid-payload by a structure-blind slice),
+ *  not a prose mention like `data:image/png;base64,abc`. */
+const DAMAGED_PAYLOAD_MIN_CHARS = 40;
+
+/** Context for {@link elideDataUrls}. `source` text is intact (never sliced),
+ *  so a short non-canonical payload is a prose mention and stays untouched.
+ *  `archive` text may have been cut by pre-guard structure-blind slices at
+ *  any offset — even 0–39 chars past `;base64,` — so every recognized prefix
+ *  is suspect and is always elided. */
+type DataUrlContext = "source" | "archive";
+
+/** Replace every inline base64 data URL atomically with a deterministic
+ *  placeholder. A character cap that slices inside a base64 payload leaves a
+ *  recognizable image reference that can never decode; OpenAI-dialect
+ *  providers reject such requests as invalid image input, and because the
+ *  corrupted text persists in the archive the session re-fails on every later
+ *  request. The payload is worthless to a model as text, so the whole atom —
+ *  Markdown wrapper included — collapses to its metadata. Payloads already
+ *  carrying an elision marker, and non-canonical fragments left by pre-guard
+ *  slices, are healed the same way.
+ *
+ *  The placeholder's `<mime>` is the media type as written: type/subtype plus
+ *  any unquoted RFC 2397 `;parameter=value` segments, original case preserved.
+ *  Parameters are kept rather than stripped to a bare type/subtype so charset
+ *  (and similar) remain visible after elision and the label stays a pure
+ *  function of the captured text. */
+function elideDataUrls(text: string, context: DataUrlContext = "source"): string {
+	if (!/;base64,/i.test(text)) return text;
+	return text.replace(
+		DATA_URL_ATOM,
+		(
+			match: string,
+			opener: string | undefined,
+			mime: string,
+			payload: string,
+			closer: string | undefined,
+		): string => {
+			const marker = ELIDED_MARKER_RE.exec(payload);
+			const isAtom =
+				context === "archive" ||
+				marker !== null ||
+				CANONICAL_BASE64.test(payload) ||
+				payload.length >= DAMAGED_PAYLOAD_MIN_CHARS;
+			if (!isAtom) return match;
+			const b64Chars = marker ? payload.length - marker[0].length : payload.length;
+			const placeholder = `[data URL omitted: ${mime}, ${b64Chars} base64 chars]`;
+			// Swallow the Markdown wrapper only when both delimiters matched;
+			// otherwise re-emit whichever half was captured untouched.
+			if (opener !== undefined && closer !== undefined) return placeholder;
+			return `${opener ?? ""}${placeholder}${closer ?? ""}`;
+		},
+	);
+}
+
 const DIM_MARKERS = /[\u000e\u000f]/g;
 
 /** Plain-text history kept verbatim at each chronological edge, in HQ-frame-
@@ -836,7 +919,7 @@ export function serializeConversation(messages: Message[], options?: SerializeOp
 	// Wrap a raw tool-result body in an `<out>` block, dimming only the body so
 	// the frame coloring keeps scope markers and calls loud.
 	const renderResultBlock = (rawText: string): string => {
-		const body = truncateForSummary(stripDimMarkers(rawText), toolResultMaxChars, headRatio);
+		const body = truncateForSummary(elideDataUrls(stripDimMarkers(rawText)), toolResultMaxChars, headRatio);
 		return `<out>\n${dimToolResults ? `${DIM_ON}${body}${DIM_OFF}` : body}\n</out>`;
 	};
 
@@ -894,7 +977,7 @@ export function serializeConversation(messages: Message[], options?: SerializeOp
 							.filter(([key]) => key !== INTENT_FIELD)
 							.map(
 								([key, value]) =>
-									`${key}=${truncateForSummary(JSON.stringify(value) ?? "undefined", toolArgMaxChars, headRatio)}`,
+									`${key}=${truncateForSummary(elideDataUrls(JSON.stringify(value) ?? "undefined"), toolArgMaxChars, headRatio)}`,
 							)
 							.join(", "),
 						toolCallMaxChars,
@@ -1704,7 +1787,7 @@ export function historyBlocks(archive: Archive, options: HistoryBlockOptions = {
 			: hasOmittedImages
 				? `\n${omittedFrameNotice(budgeted.omittedFrames, budgeted.omittedBytes)}\n`
 				: "";
-		blocks.push({ type: "text", text: toPlainText(archive.textHead) + suffix });
+		blocks.push({ type: "text", text: elideDataUrls(toPlainText(archive.textHead), "archive") + suffix });
 	} else if (hasOmittedImages && !hasImages) {
 		blocks.push({ type: "text", text: omittedFrameNotice(budgeted.omittedFrames, budgeted.omittedBytes) });
 	}
@@ -1721,7 +1804,7 @@ export function historyBlocks(archive: Archive, options: HistoryBlockOptions = {
 			: archive.truncatedChars > 0 || hasOmittedImages
 				? "\n-------------- middle history omitted above\n"
 				: "";
-		const tail = prefix + toPlainText(archive.textTail);
+		const tail = prefix + elideDataUrls(toPlainText(archive.textTail), "archive");
 		const lastBlock = blocks[blocks.length - 1];
 		if (lastBlock?.type === "text") {
 			lastBlock.text += tail;
@@ -1917,11 +2000,14 @@ export async function compact<TMessage = Message>(
 			.join(NEWLINE_GLYPH);
 	// Legacy archives may carry `¶think:` sections from before includeThinking
 	// existed; scrub them when this compaction excludes thinking so the
-	// re-rendered archive stops replaying reasoning (issue #6093).
+	// re-rendered archive stops replaying reasoning (issue #6093). They may
+	// also carry data URLs a pre-guard slice cut at any offset; heal those in
+	// archive context before the text is folded into the new source.
+	const previousTextHealed = elideDataUrls(previousTextRaw, "archive");
 	const previousText =
-		options?.includeThinking === false && previousTextRaw.length > 0
-			? stripThinkingSections(previousTextRaw)
-			: previousTextRaw;
+		options?.includeThinking === false && previousTextHealed.length > 0
+			? stripThinkingSections(previousTextHealed)
+			: previousTextHealed;
 	const hasPreviousText = previousText.length > 0;
 	const includedPreviousSummary = !hasPreviousText && !!previousSummary;
 	const shapeProbeText = renderabilityProbeText(serialized, previousPreserveData, previousSummary);
@@ -1949,6 +2035,12 @@ export async function compact<TMessage = Message>(
 	if (hasPreviousText) {
 		archiveText = archiveText.length > 0 ? `${previousText}${NEWLINE_GLYPH}${archiveText}` : previousText;
 	}
+	// Data URLs must never reach planArchive: its edge slices are structure-
+	// blind, and a split payload replays as broken image input on every later
+	// request. previousText is already strictly healed above; this source-mode
+	// pass covers intact URLs in fresh user/assistant text, which the
+	// serializer never truncates.
+	archiveText = elideDataUrls(archiveText);
 
 	const layout = planArchive(archiveText, high, low, maxFrames);
 	truncatedChars += layout.truncatedChars;

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -1486,4 +1486,16 @@ describe("data URL elision", () => {
 			}
 		}
 	});
+
+	it("prevents archive migration text from replaying invalid image input to summarizers/providers", () => {
+		const poisoned = "data:image/png;base64,QUFB [...900ch elided...] QUFB";
+		const text = snapcompact.archiveSourceText({
+			frames: [],
+			totalChars: poisoned.length,
+			truncatedChars: 0,
+			textHead: poisoned,
+		});
+		expect(text).toContain("[data URL omitted: image/png, 908 base64 chars]");
+		expect(text).not.toMatch(recognizableDataUrl);
+	});
 });

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -1313,3 +1313,177 @@ describe("new shape variants", () => {
 		expect(snapcompact.isShape({ ...base, font: "9x9" })).toBe(false);
 	});
 });
+
+describe("data URL elision", () => {
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><desc>${"A".repeat(6000)}</desc></svg>`;
+	const b64 = Buffer.from(svg, "utf8").toString("base64");
+	const dataUrl = `data:image/svg+xml;base64,${b64}`;
+	const placeholder = `[data URL omitted: image/svg+xml, ${b64.length} base64 chars]`;
+	// No base64 run long enough to read as an image payload may survive.
+	const leakedPayload = /;base64,[A-Za-z0-9+/=]{40}/;
+	const markerInPayload = /;base64,[A-Za-z0-9+/=]*\s*\[(?:…|\.{3})\d+ch elided/;
+	const recognizableDataUrl = /data:[A-Za-z][\w.+-]*\/[\w.+-]+(?:;[\w!#$%&'*+.^|~-]+=[\w!#$%&'*+.^|~-]+)*;base64,/i;
+
+	it("prevents archived Markdown tool-result images from reaching providers as sliced undecodable data URLs", () => {
+		const out = snapcompact.serializeConversation([
+			createToolResultMessage(`Reader output:\n\n![inline SVG](${dataUrl})\ntrailing text`),
+		]);
+		expect(out).toContain(placeholder);
+		expect(out).not.toMatch(leakedPayload);
+		expect(out).toContain("trailing text");
+	});
+
+	it("prevents archived bare tool-result data URLs from reaching providers as sliced undecodable payloads", () => {
+		const out = snapcompact.serializeConversation([createToolResultMessage(`see ${dataUrl} end`)]);
+		expect(out).toContain(placeholder);
+		expect(out).not.toMatch(leakedPayload);
+	});
+
+	it("prevents character-cap head/tail cuts from leaving a recognizable data URL in archived tool results", () => {
+		// Sweep the atom across the 1,200-char head and 800-char tail boundaries.
+		// Each pad is a distinct cut landing: 0 start, 600 inside head, 1150/1199
+		// straddle the head cut, 4000 discarded middle, 6500 straddle tail, 7400 tail.
+		for (const pad of [0, 600, 1150, 1199, 4000, 6500, 7400]) {
+			const text = `${"p".repeat(pad)} ![img](${dataUrl}) ${"s".repeat(7600 - pad)}`;
+			const out = snapcompact.normalize(snapcompact.serializeConversation([createToolResultMessage(text)]));
+			expect(out).not.toMatch(leakedPayload);
+			expect(out).not.toMatch(markerInPayload);
+		}
+	});
+
+	it("prevents archived tool-call arguments from reaching providers as sliced undecodable data URLs", () => {
+		const out = snapcompact.serializeConversation([
+			createAssistantMessage([
+				{
+					type: "toolCall",
+					id: "c1",
+					name: "write",
+					arguments: { path: "a.html", content: `<img src="${dataUrl}">` },
+				},
+			]),
+		]);
+		expect(out).not.toMatch(leakedPayload);
+		expect(out).toContain("data URL omitted: image/svg+xml");
+	});
+
+	it("prevents a canonical 1x1 GIF data URL from surviving in archived tool results as image input", () => {
+		const payload = "R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+		const out = snapcompact.serializeConversation([
+			createToolResultMessage(`const BLANK = "data:image/gif;base64,${payload}";`),
+		]);
+		expect(out).toContain(`[data URL omitted: image/gif, ${payload.length} base64 chars]`);
+		expect(out).not.toMatch(/data:image\/gif;base64,/i);
+	});
+
+	it("prevents prose mentions like data:image/png;base64,abc from being rewritten into placeholders", () => {
+		const prose = "e.g. 'data:image/png;base64,abc' is the expected shape";
+		const out = snapcompact.serializeConversation([createToolResultMessage(prose)]);
+		expect(out).toContain(prose);
+		expect(out).not.toContain("data URL omitted");
+	});
+
+	it("prevents a ;charset=utf-8 data URL from surviving in archived tool results as image input", () => {
+		const url = `data:image/svg+xml;charset=utf-8;base64,${b64}`;
+		const out = snapcompact.serializeConversation([createToolResultMessage(`see ${url} end`)]);
+		expect(out).toContain(`[data URL omitted: image/svg+xml;charset=utf-8, ${b64.length} base64 chars]`);
+		expect(out).not.toMatch(recognizableDataUrl);
+	});
+
+	it("prevents uppercase DATA:/BASE64 data URLs from surviving in archived tool results as image input", () => {
+		const url = `DATA:IMAGE/PNG;BASE64,${b64}`;
+		const out = snapcompact.serializeConversation([createToolResultMessage(`see ${url} end`)]);
+		expect(out).toContain(`[data URL omitted: IMAGE/PNG, ${b64.length} base64 chars]`);
+		expect(out).not.toMatch(recognizableDataUrl);
+	});
+
+	it("prevents user-message data URLs from surviving as sliced undecodable image refs in the compacted archive", async () => {
+		const result = await snapcompact.compact(
+			makePreparation({
+				messagesToSummarize: [
+					createUserMessage(`${"context ".repeat(400)}![img](${dataUrl})${" more".repeat(400)}`),
+				],
+			}),
+			{ frameSize: TEST_FRAME_SIZE, maxFrames: 3 },
+		);
+		const archive = snapcompact.getPreservedArchive(result.preserveData);
+		const all = `${archive?.text ?? ""}\n${archive?.textHead ?? ""}\n${archive?.textTail ?? ""}`;
+		expect(all).not.toMatch(leakedPayload);
+		expect(all).not.toMatch(markerInPayload);
+	});
+
+	it("prevents re-compaction of a pre-guard archive from replaying undecodable data-URL fragments", async () => {
+		const legacyHead =
+			`earlier work ![a](${dataUrl}) then ` +
+			`data:image/png;base64,${"QUFB".repeat(50)} [...900ch elided...] ${"QUFB".repeat(10)} and ` +
+			`data:image/webp;base64, [...123ch elided...] QUFB plus a bare cut data:image/jpeg;base64,`;
+		const result = await snapcompact.compact(
+			makePreparation({
+				messagesToSummarize: [createUserMessage("Next turn after legacy archive.")],
+				previousPreserveData: {
+					snapcompact: {
+						frames: [],
+						totalChars: legacyHead.length,
+						truncatedChars: 0,
+						textHead: legacyHead,
+						textTail: "recent tail",
+					},
+				},
+			}),
+			{ frameSize: TEST_FRAME_SIZE, maxFrames: 3 },
+		);
+		const archive = snapcompact.getPreservedArchive(result.preserveData);
+		const all = `${archive?.text ?? ""}\n${archive?.textHead ?? ""}\n${archive?.textTail ?? ""}`;
+		expect(all).not.toMatch(/data:[A-Za-z][\w.+-]*\/[\w.+-]+;base64,/);
+		expect(all).not.toMatch(markerInPayload);
+		expect(all).toContain("data URL omitted: image/svg+xml");
+		expect(all).toContain("data URL omitted: image/webp");
+	});
+
+	it("prevents historyBlocks from replaying poisoned archive prefixes as invalid image input", () => {
+		const rows: Array<{ head: string; placeholder: string; retain?: string }> = [
+			{
+				// cut +0: empty payload after `;base64,` (exercises regex `*` zero-width match)
+				head: "history ![x](data:image/svg+xml;base64,",
+				placeholder: "data URL omitted: image/svg+xml",
+			},
+			{
+				// cut +1: `Q` (strict archive path below source floor)
+				head: "history ![x](data:image/svg+xml;base64,Q",
+				placeholder: "data URL omitted: image/svg+xml",
+			},
+			{
+				// cut +39: `${"QUFB".repeat(9)}QUL` (just below 40-char floor)
+				head: `history ![x](data:image/svg+xml;base64,${"QUFB".repeat(9)}QUL`,
+				placeholder: "data URL omitted: image/svg+xml",
+			},
+			{
+				// marker directly after comma: pre-guard slice landed on `;base64,`
+				head: "data:image/webp;base64, [...900ch elided...] QUFB rest",
+				placeholder: "data URL omitted: image/webp",
+				retain: " rest",
+			},
+			{
+				// parameterized archive fragment: explicit source+archive RFC 2397 requirement
+				head: "data:image/svg+xml;charset=utf-8;base64,Q",
+				placeholder: "data URL omitted: image/svg+xml;charset=utf-8",
+			},
+		];
+		for (const row of rows) {
+			const blocks = snapcompact.historyBlocks({
+				frames: [],
+				totalChars: row.head.length,
+				truncatedChars: 5,
+				textHead: row.head,
+				textTail: "tail",
+			});
+			const text = blocks.map(b => (b.type === "text" ? b.text : "")).join("\n");
+			expect(text).not.toMatch(recognizableDataUrl);
+			expect(text).toContain(row.placeholder);
+			if (row.retain !== undefined) {
+				expect(text).toContain(row.retain);
+				expect(text).not.toContain(";base64,");
+				expect(text).not.toContain("ch elided");
+			}
+		}
+	});
+});

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -1498,4 +1498,16 @@ describe("data URL elision", () => {
 		expect(text).toContain("[data URL omitted: image/png, 908 base64 chars]");
 		expect(text).not.toMatch(recognizableDataUrl);
 	});
+
+	it("prevents unmatched Markdown brackets from stalling tool-result compaction", () => {
+		// Unmatched `[` plus `;base64,` used to stall tool-result compaction in
+		// the data-URL matcher before the 2,000-character cap could apply.
+		const text = `${"[".repeat(80_000)};base64,`;
+		const out = snapcompact.serializeConversation([createToolResultMessage(text)]);
+		const marker = "[…78008ch elided…]";
+		expect(out).toContain(marker);
+		expect(out).toContain(
+			`${snapcompact.DIM_ON}${"[".repeat(1200)} ${marker} ${"[".repeat(792)};base64,${snapcompact.DIM_OFF}`,
+		);
+	}, 2_000);
 });


### PR DESCRIPTION
## What

Snapcompact now replaces inline base64 data URLs with `[data URL omitted: <mime>, <n> base64 chars]` before applying tool-result limits or slicing archive text. This includes URLs inside Markdown images and links.

The same cleanup runs when `compact()` carries older archive text forward and when `historyBlocks()` rebuilds persisted history. The matcher accepts RFC 2397 parameters such as `;charset=utf-8` and treats `data:` and `base64` case-insensitively. Short prose examples such as `data:image/png;base64,abc` remain unchanged in fresh text.

## Why

Character-based truncation could put an elision marker in the middle of a base64 payload:

```text
before: data:image/svg+xml;base64,<payload head><long payload middle><payload tail>
after:  data:image/svg+xml;base64,<payload head>[...<n>ch elided...]<payload tail>
```

The result still looked like image input but was not valid base64. Snapcompact stored and replayed it, so OpenAI-dialect providers rejected later requests with HTTP 400. Retrying used the same corrupted archive.

## Testing

- `cd packages/snapcompact && bun test`: 92 pass, 0 fail.
- `bun run check` in `packages/snapcompact`: biome and tsgo pass.
- Ran the standalone reproduction against this branch. The archive no longer retains the Markdown data URL.
- Regression cases cover tool results, tool-call arguments, user text, re-compaction, `historyBlocks()`, cuts immediately after `;base64,` and 1 or 39 characters later, a marker directly after the comma, RFC 2397 parameters, uppercase syntax, canonical short URLs, and prose nonmatches.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)