### PR TITLE
feat(extensions): report agentKind on tool_call events

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `agentKind` (`"main"` | `"sub"`) and `taskDepth` to the extension `tool_call` event, so a handler can tell a top-level call from a delegated one. Both fields are optional, and a handler running on a host that does not report them sees `undefined` — letting it fail open rather than break. This makes depth-scoped policy expressible: an extension can block `write`/`edit`/`bash` for `agentKind === "main"` while leaving the subagents that perform the work untouched, which previously was impossible because both paths emitted the same undifferentiated event.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -900,6 +900,14 @@ export interface ToolApprovalResolvedEvent {
 interface ToolCallEventBase {
 	type: "tool_call";
 	toolCallId: string;
+	/** Orchestration depth of the session issuing the call: 0 for the top-level
+	 *  agent, >0 for a subagent. Undefined when the host does not report it.
+	 *  Enables depth-scoped policy that must not affect delegated work. */
+	taskDepth?: number;
+	/** Whether the call originates from the top-level agent (`"main"`) or a
+	 *  spawned subagent (`"sub"`). Undefined when the host does not report it.
+	 *  Prefer this over {@link taskDepth} for main-vs-delegated policy. */
+	agentKind?: "main" | "sub";
 }
 
 export interface BashToolCallEvent extends ToolCallEventBase {

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -211,6 +211,8 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 						type: "tool_call",
 						toolName: this.tool.name,
 						toolCallId,
+						taskDepth: context?.taskDepth,
+						agentKind: context?.agentKind,
 						input: normalizeToolEventInput(
 							this.tool.name,
 							resolveToolEventInput(this.tool, toolEventArgs(params, context)),

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2589,6 +2589,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			settings,
 			localProtocolOptions,
 			autoApprove: options.autoApprove ?? false,
+			// Orchestration depth of the session owning this tool call: 0 for the
+			// top-level agent, >0 for a subagent. Surfaced so extensions can apply
+			// depth-scoped policy (e.g. "the orchestrator delegates file writes")
+			// without blocking the subagents that must perform the work.
+			taskDepth,
+			agentKind,
 		});
 		const toolContextStore = new ToolContextStore(getSessionContext);
 		const setSessionActiveToolNames = (names: Iterable<string>): void => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3486,6 +3486,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			obfuscator,
 			agentId: resolvedAgentId,
 			agentKind,
+			taskDepth,
 			providerSessionId: options.providerSessionId,
 			providerPromptCacheKeySource,
 			parentEvalSessionId: options.parentEvalSessionId,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -235,6 +235,8 @@ export interface AgentSessionConfig {
 	agentId?: string;
 	/** Whether this is a top-level or subagent session. */
 	agentKind?: "main" | "sub";
+	/** Orchestration depth of this session: 0 for top-level, >0 for a subagent. */
+	taskDepth?: number;
 	/** Provider-facing session ID override. */
 	providerSessionId?: string;
 	/** Whether the provider prompt-cache key was explicit or fork-inherited. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -576,6 +576,8 @@ export class AgentSession {
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
+	/** Orchestration depth: 0 for the top-level session, >0 for a subagent. */
+	#taskDepth = 0;
 	#scoutAllowedBySpawnPolicy = true;
 	#providerSessionId: string | undefined;
 	#freshProviderSessionId: string | undefined;
@@ -1372,6 +1374,7 @@ export class AgentSession {
 		this.#loopGuards = new LoopGuards(streamGuardsHost);
 		this.#agentId = config.agentId;
 		this.#agentKind = config.agentKind ?? "main";
+		this.#taskDepth = config.taskDepth ?? 0;
 		this.#scoutAllowedBySpawnPolicy = config.scoutAllowedBySpawnPolicy ?? true;
 		this.#providerSessionId = config.providerSessionId;
 		this.#inheritedProviderPromptCacheKey =
@@ -3412,6 +3415,7 @@ export class AgentSession {
 				toolName: ctx.tool.name,
 				toolCallId: ctx.toolCall.id,
 				agentKind: this.#agentKind,
+				taskDepth: this.#taskDepth,
 				input: normalizeToolEventInput(ctx.tool.name, resolveToolEventInput(ctx.tool, eventArgs)),
 			},
 			signal,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3411,6 +3411,7 @@ export class AgentSession {
 				type: "tool_call",
 				toolName: ctx.tool.name,
 				toolCallId: ctx.toolCall.id,
+				agentKind: this.#agentKind,
 				input: normalizeToolEventInput(ctx.tool.name, resolveToolEventInput(ctx.tool, eventArgs)),
 			},
 			signal,

--- a/packages/coding-agent/src/tools/context.ts
+++ b/packages/coding-agent/src/tools/context.ts
@@ -7,6 +7,12 @@ declare module "@oh-my-pi/pi-agent-core" {
 		ui?: ExtensionUIContext;
 		hasUI?: boolean;
 		toolNames?: string[];
+		/** Orchestration depth of the session issuing this call: 0 for the
+		 *  top-level agent, >0 for a subagent. Lets policy distinguish the
+		 *  orchestrator from the workers it delegates to. */
+		taskDepth?: number;
+		/** Whether this call comes from the top-level agent or a spawned subagent. */
+		agentKind?: "main" | "sub";
 		toolCall?: ToolCallContext;
 		/** Set on `xd://` device dispatches: the write tool's outer approval gate
 		 *  already resolved this call at the mounted tool's tier, so the inner

--- a/packages/coding-agent/test/extension-tool-call-session-identity.test.ts
+++ b/packages/coding-agent/test/extension-tool-call-session-identity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests that ExtensionToolWrapper reports the calling session's identity on
+ * `tool_call`. Extensions need this to scope policy to the top-level agent
+ * without also constraining the subagents it delegates to — blocking a tool
+ * on an undifferentiated event blocks both.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+
+describe("ExtensionToolWrapper tool_call session identity", () => {
+	let tempDir: TempDir;
+	let extensionsDir: string;
+	let sessionManager: SessionManager;
+	let sharedTempDir: TempDir;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage;
+	let observedPath: string;
+
+	beforeAll(async () => {
+		sharedTempDir = TempDir.createSync("@pi-tool-call-identity-shared-");
+		authStorage = await AuthStorage.create(path.join(sharedTempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		sharedTempDir.removeSync();
+	});
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-tool-call-identity-");
+		extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		sessionManager = SessionManager.inMemory();
+		observedPath = path.join(tempDir.path(), "observed.json");
+	});
+
+	afterEach(() => {
+		tempDir.removeSync();
+	});
+
+	/**
+	 * Loads an extension that appends each `tool_call` event's identity fields to
+	 * a JSON-lines file, so the assertion reads what the wrapper actually emitted.
+	 */
+	const runnerRecordingIdentity = async (): Promise<ExtensionRunner> => {
+		fs.writeFileSync(
+			path.join(extensionsDir, "record-identity.ts"),
+			`import * as fs from "node:fs";
+			export default function (pi) {
+				pi.on("tool_call", event => {
+					fs.appendFileSync(
+						${JSON.stringify(observedPath)},
+						JSON.stringify({ agentKind: event.agentKind, taskDepth: event.taskDepth }) + "\\n",
+					);
+				});
+			}`,
+		);
+		const discovered = fs
+			.readdirSync(extensionsDir, { withFileTypes: true })
+			.filter(entry => entry.isFile() && entry.name.endsWith(".ts"))
+			.map(entry => path.join(extensionsDir, entry.name))
+			.sort();
+		const result = await loadExtensions(discovered, tempDir.path());
+		return new ExtensionRunner(result.extensions, result.runtime, tempDir.path(), sessionManager, modelRegistry);
+	};
+
+	const observed = (): Array<{ agentKind?: string; taskDepth?: number }> =>
+		fs
+			.readFileSync(observedPath, "utf8")
+			.split("\n")
+			.filter(line => line.length > 0)
+			.map(line => JSON.parse(line));
+
+	const identityTool: AgentTool = {
+		name: "write",
+		label: "Write",
+		description: "Test tool",
+		parameters: {} as never,
+		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+	} as AgentTool;
+
+	it("reports agentKind main and taskDepth 0 for a top-level call", async () => {
+		const wrapped = new ExtensionToolWrapper(identityTool, await runnerRecordingIdentity());
+
+		await wrapped.execute("call-main", {} as never, undefined, undefined, {
+			agentKind: "main",
+			taskDepth: 0,
+		} as AgentToolContext);
+
+		expect(observed()).toEqual([{ agentKind: "main", taskDepth: 0 }]);
+	});
+
+	it("reports agentKind sub and the child depth for a delegated call", async () => {
+		const wrapped = new ExtensionToolWrapper(identityTool, await runnerRecordingIdentity());
+
+		await wrapped.execute("call-sub", {} as never, undefined, undefined, {
+			agentKind: "sub",
+			taskDepth: 1,
+		} as AgentToolContext);
+
+		expect(observed()).toEqual([{ agentKind: "sub", taskDepth: 1 }]);
+	});
+
+	it("omits both fields when the host does not report them", async () => {
+		const wrapped = new ExtensionToolWrapper(identityTool, await runnerRecordingIdentity());
+
+		// A handler must be able to tell "top-level" from "not reported" so it can
+		// fail open on hosts that predate these fields.
+		await wrapped.execute("call-unknown", {} as never, undefined, undefined, {} as AgentToolContext);
+
+		expect(observed()).toEqual([{}]);
+	});
+});

--- a/packages/coding-agent/test/extension-tool-call-session-identity.test.ts
+++ b/packages/coding-agent/test/extension-tool-call-session-identity.test.ts
@@ -1,124 +1,139 @@
 /**
- * Tests that ExtensionToolWrapper reports the calling session's identity on
- * `tool_call`. Extensions need this to scope policy to the top-level agent
- * without also constraining the subagents it delegates to — blocking a tool
- * on an undifferentiated event blocks both.
+ * Tests that a `tool_call` event reports the calling session's identity through
+ * the real session dispatch path. Extensions need this to scope policy to the
+ * top-level agent without also constraining the subagents it delegates to —
+ * blocking a tool on an undifferentiated event blocks both.
+ *
+ * These drive `AgentSession` via `createAgentSession` rather than invoking the
+ * tool wrapper directly: for a model-dispatched call `#beforeToolCall` marks the
+ * event as already emitted and the wrapper suppresses its own, so the session
+ * path is the only one that runs in practice.
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import type { AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { afterEach, describe, expect, it } from "bun:test";
+import { type Api, clearCustomApis, type Model, type ModelSpec, registerCustomApi } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
-import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
-import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
-import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
 
-describe("ExtensionToolWrapper tool_call session identity", () => {
-	let tempDir: TempDir;
-	let extensionsDir: string;
-	let sessionManager: SessionManager;
-	let sharedTempDir: TempDir;
-	let modelRegistry: ModelRegistry;
-	let authStorage: AuthStorage;
-	let observedPath: string;
+interface ObservedIdentity {
+	agentKind?: "main" | "sub";
+	taskDepth?: number;
+}
 
-	beforeAll(async () => {
-		sharedTempDir = TempDir.createSync("@pi-tool-call-identity-shared-");
-		authStorage = await AuthStorage.create(path.join(sharedTempDir.path(), "testauth.db"));
-		modelRegistry = new ModelRegistry(authStorage);
-	});
-
-	afterAll(() => {
-		authStorage.close();
-		sharedTempDir.removeSync();
-	});
-
-	beforeEach(() => {
-		tempDir = TempDir.createSync("@pi-tool-call-identity-");
-		extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
-		fs.mkdirSync(extensionsDir, { recursive: true });
-		sessionManager = SessionManager.inMemory();
-		observedPath = path.join(tempDir.path(), "observed.json");
-	});
-
+describe("tool_call session identity", () => {
 	afterEach(() => {
-		tempDir.removeSync();
+		clearCustomApis();
 	});
+
+	/** Model that dispatches one `read` call, then finishes. */
+	function registerToolCallingApi(api: string): void {
+		let requests = 0;
+		registerCustomApi(api, () => {
+			requests++;
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				if (requests === 1) {
+					const message = createAssistantMessage("");
+					const toolCall = {
+						type: "toolCall",
+						id: "call-identity-1",
+						name: "read",
+						arguments: { path: "identity.txt" },
+					} as const;
+					message.content = [toolCall];
+					message.stopReason = "toolUse";
+					stream.push({ type: "toolcall_start", contentIndex: 0, partial: message });
+					stream.push({ type: "toolcall_end", contentIndex: 0, toolCall: toolCall as never, partial: message });
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage("done");
+					stream.push({ type: "done", reason: "stop", message });
+				}
+			});
+			return stream;
+		});
+	}
+
+	function buildStubModel(api: string, id: string): Model<Api> {
+		return buildModel({
+			id,
+			name: id,
+			api,
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+	}
 
 	/**
-	 * Loads an extension that appends each `tool_call` event's identity fields to
-	 * a JSON-lines file, so the assertion reads what the wrapper actually emitted.
+	 * Runs one model-dispatched tool call in a session at `taskDepth`, returning
+	 * the identity fields the `tool_call` handler observed. `undefined` omits the
+	 * option entirely, exercising the default top-level case.
 	 */
-	const runnerRecordingIdentity = async (): Promise<ExtensionRunner> => {
-		fs.writeFileSync(
-			path.join(extensionsDir, "record-identity.ts"),
-			`import * as fs from "node:fs";
-			export default function (pi) {
-				pi.on("tool_call", event => {
-					fs.appendFileSync(
-						${JSON.stringify(observedPath)},
-						JSON.stringify({ agentKind: event.agentKind, taskDepth: event.taskDepth }) + "\\n",
-					);
-				});
-			}`,
-		);
-		const discovered = fs
-			.readdirSync(extensionsDir, { withFileTypes: true })
-			.filter(entry => entry.isFile() && entry.name.endsWith(".ts"))
-			.map(entry => path.join(extensionsDir, entry.name))
-			.sort();
-		const result = await loadExtensions(discovered, tempDir.path());
-		return new ExtensionRunner(result.extensions, result.runtime, tempDir.path(), sessionManager, modelRegistry);
-	};
+	async function observeIdentity(taskDepth: number | undefined): Promise<ObservedIdentity[]> {
+		using tempDir = TempDir.createSync("@pi-tool-call-identity-");
+		const api = `test-identity-${taskDepth ?? "default"}`;
+		registerToolCallingApi(api);
+		const observed: ObservedIdentity[] = [];
+		const recordIdentity: ExtensionFactory = pi => {
+			pi.on("tool_call", async event => {
+				observed.push({ agentKind: event.agentKind, taskDepth: event.taskDepth });
+				return undefined;
+			});
+		};
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model: buildStubModel(api, `identity-model-${taskDepth ?? "default"}`),
+			disableExtensionDiscovery: true,
+			extensions: [recordIdentity],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			toolNames: ["read"],
+			...(taskDepth === undefined ? {} : { taskDepth }),
+		});
+		try {
+			await session.sendUserMessage("read it");
+			return observed;
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	}
 
-	const observed = (): Array<{ agentKind?: string; taskDepth?: number }> =>
-		fs
-			.readFileSync(observedPath, "utf8")
-			.split("\n")
-			.filter(line => line.length > 0)
-			.map(line => JSON.parse(line));
-
-	const identityTool: AgentTool = {
-		name: "write",
-		label: "Write",
-		description: "Test tool",
-		parameters: {} as never,
-		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
-	} as AgentTool;
-
-	it("reports agentKind main and taskDepth 0 for a top-level call", async () => {
-		const wrapped = new ExtensionToolWrapper(identityTool, await runnerRecordingIdentity());
-
-		await wrapped.execute("call-main", {} as never, undefined, undefined, {
-			agentKind: "main",
-			taskDepth: 0,
-		} as AgentToolContext);
-
-		expect(observed()).toEqual([{ agentKind: "main", taskDepth: 0 }]);
+	it("reports main and depth 0 for a top-level session", async () => {
+		expect(await observeIdentity(undefined)).toEqual([{ agentKind: "main", taskDepth: 0 }]);
 	});
 
-	it("reports agentKind sub and the child depth for a delegated call", async () => {
-		const wrapped = new ExtensionToolWrapper(identityTool, await runnerRecordingIdentity());
-
-		await wrapped.execute("call-sub", {} as never, undefined, undefined, {
-			agentKind: "sub",
-			taskDepth: 1,
-		} as AgentToolContext);
-
-		expect(observed()).toEqual([{ agentKind: "sub", taskDepth: 1 }]);
+	it("reports sub and the child depth for a delegated session", async () => {
+		expect(await observeIdentity(1)).toEqual([{ agentKind: "sub", taskDepth: 1 }]);
 	});
 
-	it("omits both fields when the host does not report them", async () => {
-		const wrapped = new ExtensionToolWrapper(identityTool, await runnerRecordingIdentity());
-
-		// A handler must be able to tell "top-level" from "not reported" so it can
-		// fail open on hosts that predate these fields.
-		await wrapped.execute("call-unknown", {} as never, undefined, undefined, {} as AgentToolContext);
-
-		expect(observed()).toEqual([{}]);
+	it("distinguishes a nested subagent from a first-level one", async () => {
+		// `agentKind` collapses every subagent to "sub"; depth is what separates a
+		// nested agent from a first-level one, so it must survive the real path.
+		expect(await observeIdentity(2)).toEqual([{ agentKind: "sub", taskDepth: 2 }]);
 	});
 });


### PR DESCRIPTION
## Problem

`tool_call` gives an extension no way to tell whether a call came from the
top-level agent or a spawned subagent. Both paths emit the same event shape, so
policy meant only for the orchestrator cannot be expressed: blocking a tool in a
`tool_call` handler also blocks the subagents that have to do the work.

The concrete case is the delegation pattern — "the orchestrator plans and
delegates; subagents mutate files" — which keeps the top-level context free of
build output and diffs, and keeps the agent that wrote a change from also being
the one that reviews it. Today that is unimplementable in a handler.

## Change

Surface the distinction the session already tracks. `AgentSession` holds
`#agentKind: "main" | "sub"`, and `sdk.ts` derives `taskDepth`; both are now
carried on the `tool_call` event via the tool context.

A handler can then scope policy:

```ts
pi.on("tool_call", event => {
  if (event.agentKind !== "main") return;           // delegated work untouched
  if (!MUTATING_TOOLS[event.toolName]) return;
  return { block: true, reason: "delegate this with the task tool" };
});
```

Both fields are optional, so a handler on a host that does not report them sees
`undefined` and can fail open rather than break. `agentKind` is the preferred
discriminator; `taskDepth` additionally separates nested subagents, which
`agentKind` collapses.

Populated at both emit sites: `AgentSession#beforeToolCall` (the path used at
runtime) and `ExtensionToolWrapper` (kept consistent).

## Testing

New `test/extension-tool-call-session-identity.test.ts` covers `main`/0,
`sub`/1, and the unreported case. Verified to fail without the source change —
the two identity assertions observe `{}` instead of the expected values.

`bun test` over `extensions-runner`, `hook-tool-wrapper-input`,
`sdk-tool-activation`, and the new file: 134 pass, 0 fail. `biome check` and
`tsc --noEmit` clean on all six touched files.

Also exercised end to end against a local build: with a `tool_call` handler
blocking `write`/`edit`/`bash` for `agentKind === "main"`, a top-level write and
a top-level bash redirect were both refused, a `sonic` subagent wrote its file
normally, and `xd://` device dispatch (which rides the `write` tool) still
worked. Each verified on disk rather than from the agent's own report.

## Notes

Scoped to one package, additive, no behavior change for existing handlers: the
fields are new and optional, and nothing reads them unless a handler opts in.
