### PR TITLE
fix(coding-agent): restore inherit stdio for external editor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- External editor (Ctrl+G, plan review/annotation, `/todo edit`) now spawns with `stdio: "inherit"` again, so emacsclient-based `$EDITOR` renders in the visible pane instead of an invisible terminal ([#9077](https://github.com/can1357/oh-my-pi/issues/9077)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
@@ -2035,25 +2034,6 @@ export class InputController {
 		this.ctx.showStatus(`Thinking blocks: ${this.ctx.hideThinkingBlock ? "hidden" : "visible"}`);
 	}
 
-	#getEditorTerminalPath(): string | null {
-		if (process.platform === "win32") {
-			return null;
-		}
-		return "/dev/tty";
-	}
-
-	async #openEditorTerminalHandle(): Promise<fs.FileHandle | null> {
-		const terminalPath = this.#getEditorTerminalPath();
-		if (!terminalPath) {
-			return null;
-		}
-		try {
-			return await fs.open(terminalPath, "r+");
-		} catch {
-			return null;
-		}
-	}
-
 	async openExternalEditor(): Promise<void> {
 		const editorCmd = getEditorCommand();
 		if (!editorCmd) {
@@ -2063,16 +2043,9 @@ export class InputController {
 
 		const currentText = this.ctx.editor.getExpandedText?.() ?? this.ctx.editor.getText();
 
-		let ttyHandle: fs.FileHandle | null = null;
 		try {
-			ttyHandle = await this.#openEditorTerminalHandle();
 			this.ctx.ui.stop();
-
-			const stdio: [number | "inherit", number | "inherit", number | "inherit"] = ttyHandle
-				? [ttyHandle.fd, ttyHandle.fd, ttyHandle.fd]
-				: ["inherit", "inherit", "inherit"];
-
-			const result = await openInEditor(editorCmd, currentText, { extension: ".omp.md", stdio });
+			const result = await openInEditor(editorCmd, currentText, { extension: ".omp.md" });
 			if (result !== null) {
 				this.ctx.editor.setText(result);
 			}
@@ -2081,10 +2054,6 @@ export class InputController {
 				`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		} finally {
-			if (ttyHandle) {
-				await ttyHandle.close();
-			}
-
 			this.ctx.ui.start();
 			this.ctx.ui.requestRender();
 		}

--- a/packages/coding-agent/src/modes/controllers/todo-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/todo-command-controller.ts
@@ -410,16 +410,9 @@ export class TodoCommandController {
 		const initialMarkdown =
 			current.length > 0 ? phasesToMarkdown(current) : "# Todos\n- [ ] (replace this with your tasks)\n";
 
-		const fileHandle = await this.#openTtyHandle();
 		this.ctx.ui.stop();
 		try {
-			const stdio: [number | "inherit", number | "inherit", number | "inherit"] = fileHandle
-				? [fileHandle.fd, fileHandle.fd, fileHandle.fd]
-				: ["inherit", "inherit", "inherit"];
-			const result = await openInEditor(editorCmd, initialMarkdown, {
-				extension: ".todo.md",
-				stdio,
-			});
+			const result = await openInEditor(editorCmd, initialMarkdown, { extension: ".todo.md" });
 			if (result === null) {
 				this.ctx.showWarning("Editor exited without saving; todos unchanged.");
 				return;
@@ -437,22 +430,8 @@ export class TodoCommandController {
 				`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		} finally {
-			if (fileHandle) {
-				await fileHandle.close().catch(() => {});
-			}
 			this.ctx.ui.start();
 			this.ctx.ui.requestRender();
-		}
-	}
-
-	async #openTtyHandle(): Promise<fs.FileHandle | null> {
-		const stdinPath = (process.stdin as unknown as { path?: string }).path;
-		const candidate = typeof stdinPath === "string" ? stdinPath : undefined;
-		if (!candidate) return null;
-		try {
-			return await fs.open(candidate, "r+");
-		} catch {
-			return null;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3199,25 +3199,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#hidePlanReview();
 	}
 
-	#getEditorTerminalPath(): string | null {
-		if (process.platform === "win32") {
-			return null;
-		}
-		return "/dev/tty";
-	}
-
-	async #openEditorTerminalHandle(): Promise<fs.FileHandle | null> {
-		const terminalPath = this.#getEditorTerminalPath();
-		if (!terminalPath) {
-			return null;
-		}
-		try {
-			return await fs.open(terminalPath, "r+");
-		} catch {
-			return null;
-		}
-	}
-
 	#getPlanApprovalContextUsage(): ContextUsage | undefined {
 		const executionModel = this.#planModePreviousModelState?.model ?? this.session.model;
 		const contextWindow = executionModel?.contextWindow;
@@ -3271,18 +3252,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		let ttyHandle: fs.FileHandle | null = null;
 		try {
-			ttyHandle = await this.#openEditorTerminalHandle();
 			this.ui.stop();
-
-			const stdio: [number | "inherit", number | "inherit", number | "inherit"] = ttyHandle
-				? [ttyHandle.fd, ttyHandle.fd, ttyHandle.fd]
-				: ["inherit", "inherit", "inherit"];
-
 			const result = await openInEditor(editorCmd, currentText, {
 				extension: path.extname(resolvedPath) || ".md",
-				stdio,
 				trimTrailingNewline: false,
 			});
 			if (result !== null) {
@@ -3293,9 +3266,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		} catch (error) {
 			this.showWarning(`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`);
 		} finally {
-			if (ttyHandle) {
-				await ttyHandle.close();
-			}
 			this.ui.start();
 			this.ui.requestRender(true);
 		}
@@ -3308,25 +3278,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		let ttyHandle: fs.FileHandle | null = null;
 		try {
-			ttyHandle = await this.#openEditorTerminalHandle();
 			this.ui.stop();
-
-			const stdio: [number | "inherit", number | "inherit", number | "inherit"] = ttyHandle
-				? [ttyHandle.fd, ttyHandle.fd, ttyHandle.fd]
-				: ["inherit", "inherit", "inherit"];
-
-			const result = await openInEditor(editorCmd, draft, { extension: ".md", stdio });
+			const result = await openInEditor(editorCmd, draft, { extension: ".md" });
 			if (result !== null) {
 				commit(result);
 			}
 		} catch (error) {
 			this.showWarning(`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`);
 		} finally {
-			if (ttyHandle) {
-				await ttyHandle.close();
-			}
 			this.ui.start();
 			this.ui.requestRender(true);
 		}

--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -27,8 +27,6 @@ export function getEditorCommand(): string | undefined {
 export interface OpenInEditorOptions {
 	/** File extension for the temp file (default: ".md"). */
 	extension?: string;
-	/** Custom stdio configuration (default: all "inherit"). */
-	stdio?: [number | "inherit", number | "inherit", number | "inherit"];
 	/** Keep the file's trailing newline instead of trimming it from the returned text. */
 	trimTrailingNewline?: boolean;
 }
@@ -72,11 +70,12 @@ export async function openInEditor(
 		await Bun.write(tmpFile, content);
 
 		const spawnCommand = resolveEditorSpawnCommand(editorCmd, tmpFile);
-		const [stdin, stdout, stderr] = options?.stdio ?? ["inherit", "inherit", "inherit"];
+		// Inherit the real pane pty so terminal editors (including emacsclient,
+		// which resolves the device via ttyname) render into the visible pane.
 		const child = Bun.spawn(spawnCommand.cmd, {
-			stdin,
-			stdout,
-			stderr,
+			stdin: "inherit",
+			stdout: "inherit",
+			stderr: "inherit",
 			windowsVerbatimArguments: spawnCommand.windowsVerbatimArguments,
 		});
 		const exitCode = await child.exited;


### PR DESCRIPTION
## Repro
With an emacsclient-based `$EDITOR` (`emacsclient --nw <file>`) and a running Emacs daemon, pressing Ctrl+G (or using plan review/annotation, `/todo edit`) opens the buffer in the daemon on an invisible terminal frame (`terminal-name` = `/dev/tty`); nothing renders in the pane and, when the editor session ends, omp dies on TUI restart with `setRawMode failed with errno: 25`. `nvim` masks the bug because it renders directly through the fd. Reproduce by setting `$EDITOR` to an `emacsclient --nw` wrapper with a daemon running, then pressing Ctrl+G.

## Cause
Commit `2098542f6f` changed the external-editor spawn from `stdio: "inherit"` to a `/dev/tty`-opened fd passed as stdin/stdout/stderr (via `#getEditorTerminalPath`/`#openEditorTerminalHandle` in `packages/coding-agent/src/modes/controllers/input-controller.ts` and `packages/coding-agent/src/modes/interactive-mode.ts`, plus a `process.stdin.path` variant in `todo-command-controller.ts` and the `stdio` option on `openInEditor` in `packages/coding-agent/src/utils/external-editor.ts`). A terminal emacsclient reports its terminal via `ttyname(stdin)`; when stdin is an fd opened through the generic `/dev/tty` device, `ttyname()` returns the literal `"/dev/tty"`, so the daemon opens its own controlling terminal and renders nowhere visible. The workaround targeted a Bun stdin-after-pause leak (`oven-sh/bun@b3cfaab07`, Oct 2025) that is already fixed in the pinned `bun@1.3.14`; upstream `pi` never adopted `/dev/tty` and ships `inherit`.

## Fix
- `utils/external-editor.ts` — drop the `stdio` option from `OpenInEditorOptions` and always spawn the editor with `stdin/stdout/stderr: "inherit"`, so the child inherits the real pane pty (`ttyname` resolves to `/dev/ttysXXX`).
- `modes/controllers/input-controller.ts` — remove `#getEditorTerminalPath`/`#openEditorTerminalHandle` and the tty-handle plumbing from `openExternalEditor`; drop the now-unused `node:fs/promises` import.
- `modes/interactive-mode.ts` — remove the same helpers and simplify `#openPlanInExternalEditor` / `#openPlanAnnotationInExternalEditor` to plain `inherit`.
- `modes/controllers/todo-command-controller.ts` — remove `#openTtyHandle` and let `/todo edit` use the default `inherit`.
- `CHANGELOG.md` — add the fix under `[Unreleased]`.

## Verification
`bun test test/external-editor.test.ts` → 8 pass (the quoted-editor-path test spawns a real editor through the now-`inherit` path and round-trips edited content). `bun run check:types` (tsgo) clean; `biome check` clean on the changed files. The emacsclient invisible-frame failure is Emacs-daemon-specific and not in-process reproducible, so no synthetic test was added; the existing suite already exercises the changed spawn path. Fixes #9077