### PR TITLE
feat(acp): expose fast mode, advisor, and auto-compaction as boolean config options

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -96,6 +96,9 @@
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 - Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
+### Added
+
+- Fast mode, advisor, and auto-compaction now appear as switches in ACP editor clients (Zed 1.14.2+), alongside the existing mode/model/thinking selectors.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Fast mode, advisor, and auto-compaction now appear as switches in ACP editor clients (Zed 1.14.2+), alongside the existing mode/model/thinking selectors.
+
 ## [17.4.3] - 2026-08-21
 
 ### Fixed
@@ -96,9 +100,6 @@
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 - Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
-### Added
-
-- Fast mode, advisor, and auto-compaction now appear as switches in ACP editor clients (Zed 1.14.2+), alongside the existing mode/model/thinking selectors.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { type AssistantMessage, type Model, serviceTierFamily } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import { getBlobsDir, isEnoent, logger, type postmortem, VERSION } from "@oh-my-pi/pi-utils";
 import {
 	type Agent,
@@ -791,7 +791,7 @@ export class AcpAgent implements Agent {
 				// A client replaying a saved default can ask for fast mode on a
 				// model that has no service-tier family; skip rather than let
 				// `setFastMode` emit an operator notice for a no-op.
-				if (this.#supportsFastMode(record.session)) {
+				if (record.session.supportsFastMode()) {
 					record.session.setFastMode(enabled);
 				}
 				break;
@@ -1750,16 +1750,6 @@ export class AcpAgent implements Agent {
 		});
 	}
 
-	/**
-	 * Fast mode is a per-model-family service-tier switch. A model with no
-	 * service-tier family has nothing to toggle — `setFastMode` would only
-	 * emit "The current model has no service-tier control for /fast to
-	 * toggle." — so hide the switch instead of showing a dead one.
-	 */
-	#supportsFastMode(session: AgentSession): boolean {
-		return session.model !== undefined && serviceTierFamily(session.model) !== undefined;
-	}
-
 	#buildConfigOptions(session: AgentSession): SessionConfigOption[] {
 		const currentModeId = this.#getCurrentModeId(session);
 		const modeOptions = this.#getAvailableModes(session).map(mode => ({
@@ -1811,7 +1801,10 @@ export class AcpAgent implements Agent {
 		// selects first in the array, which clients use both for placement
 		// priority and to resolve category keybinding ties.
 		if (this.#clientCapabilities?.session?.configOptions?.boolean != null) {
-			if (this.#supportsFastMode(session)) {
+			// A model with no service-tier family has nothing to toggle, and
+			// `setFastMode` would only emit "no service-tier control for /fast to
+			// toggle" — so hide the switch rather than show a dead one.
+			if (session.supportsFastMode()) {
 				configOptions.push({
 					id: FAST_CONFIG_ID,
 					name: "Fast mode",

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import { type AssistantMessage, type Model, serviceTierFamily } from "@oh-my-pi/pi-ai";
 import { getBlobsDir, isEnoent, logger, type postmortem, VERSION } from "@oh-my-pi/pi-utils";
 import {
 	type Agent,
@@ -98,6 +98,9 @@ const REFINE_OPTION = "Refine plan";
 const MODE_CONFIG_ID = "mode";
 const MODEL_CONFIG_ID = "model";
 const THINKING_CONFIG_ID = "thinking";
+const FAST_CONFIG_ID = "fast";
+const ADVISOR_CONFIG_ID = "advisor";
+const AUTO_COMPACTION_CONFIG_ID = "autoCompaction";
 const THINKING_OFF = "off";
 const SESSION_PAGE_SIZE = 50;
 const SPEECH_MODELS_LIST_METHOD = "speech.models.list";
@@ -772,19 +775,32 @@ export class AcpAgent implements Agent {
 
 	async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
 		const record = this.#getSessionRecord(params.sessionId);
-		if (typeof params.value === "boolean") {
-			throw new Error(`Unsupported boolean ACP config option: ${params.configId}`);
-		}
 
 		switch (params.configId) {
 			case MODE_CONFIG_ID:
-				this.#applyModeChange(record.session, params.value);
+				this.#applyModeChange(record.session, this.#expectSelectValue(params));
 				break;
 			case MODEL_CONFIG_ID:
-				await this.#setModelById(record.session, params.value);
+				await this.#setModelById(record.session, this.#expectSelectValue(params));
 				break;
 			case THINKING_CONFIG_ID:
-				this.#setThinkingLevelById(record.session, params.value);
+				this.#setThinkingLevelById(record.session, this.#expectSelectValue(params));
+				break;
+			case FAST_CONFIG_ID: {
+				const enabled = this.#expectBooleanValue(params);
+				// A client replaying a saved default can ask for fast mode on a
+				// model that has no service-tier family; skip rather than let
+				// `setFastMode` emit an operator notice for a no-op.
+				if (this.#supportsFastMode(record.session)) {
+					record.session.setFastMode(enabled);
+				}
+				break;
+			}
+			case ADVISOR_CONFIG_ID:
+				record.session.setAdvisorEnabled(this.#expectBooleanValue(params));
+				break;
+			case AUTO_COMPACTION_CONFIG_ID:
+				record.session.setAutoCompactionEnabled(this.#expectBooleanValue(params));
 				break;
 			default:
 				throw new Error(`Unknown ACP config option: ${params.configId}`);
@@ -814,6 +830,20 @@ export class AcpAgent implements Agent {
 			await this.#pushConfigOptionUpdate(record);
 		}
 		return { configOptions: this.#buildConfigOptions(record.session) };
+	}
+
+	#expectSelectValue(params: SetSessionConfigOptionRequest): string {
+		if (typeof params.value === "boolean") {
+			throw new Error(`Unsupported boolean ACP config option: ${params.configId}`);
+		}
+		return params.value;
+	}
+
+	#expectBooleanValue(params: SetSessionConfigOptionRequest): boolean {
+		if (typeof params.value !== "boolean") {
+			throw new Error(`Expected a boolean value for ACP config option: ${params.configId}`);
+		}
+		return params.value;
 	}
 
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
@@ -1720,6 +1750,16 @@ export class AcpAgent implements Agent {
 		});
 	}
 
+	/**
+	 * Fast mode is a per-model-family service-tier switch. A model with no
+	 * service-tier family has nothing to toggle — `setFastMode` would only
+	 * emit "The current model has no service-tier control for /fast to
+	 * toggle." — so hide the switch instead of showing a dead one.
+	 */
+	#supportsFastMode(session: AgentSession): boolean {
+		return session.model !== undefined && serviceTierFamily(session.model) !== undefined;
+	}
+
 	#buildConfigOptions(session: AgentSession): SessionConfigOption[] {
 		const currentModeId = this.#getCurrentModeId(session);
 		const modeOptions = this.#getAvailableModes(session).map(mode => ({
@@ -1765,6 +1805,41 @@ export class AcpAgent implements Agent {
 			),
 			options: this.#buildThinkingOptions(session),
 		});
+
+		// ACP: agents MUST NOT send `type: "boolean"` options unless the client
+		// advertised support. Appending after mode/model/thinking keeps the
+		// selects first in the array, which clients use both for placement
+		// priority and to resolve category keybinding ties.
+		if (this.#clientCapabilities?.session?.configOptions?.boolean != null) {
+			if (this.#supportsFastMode(session)) {
+				configOptions.push({
+					id: FAST_CONFIG_ID,
+					name: "Fast mode",
+					description: "Priority service tier (OpenAI service_tier=priority, Anthropic speed=fast)",
+					category: "model_config",
+					type: "boolean",
+					currentValue: session.isFastModeEnabled(),
+				});
+			}
+			const advisorEnabled = session.isAdvisorEnabled();
+			configOptions.push({
+				id: ADVISOR_CONFIG_ID,
+				name: "Advisor",
+				description:
+					advisorEnabled && !session.isAdvisorActive()
+						? "A second model reviews each turn — no model is assigned to the 'advisor' role"
+						: "A second model reviews each turn and injects notes",
+				type: "boolean",
+				currentValue: advisorEnabled,
+			});
+			configOptions.push({
+				id: AUTO_COMPACTION_CONFIG_ID,
+				name: "Auto-compaction",
+				description: "Automatically compact the session context before it overflows",
+				type: "boolean",
+				currentValue: session.autoCompactionEnabled,
+			});
+		}
 		return configOptions;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7154,6 +7154,11 @@ export class AgentSession {
 		return this.#models.cycleThinkingLevel();
 	}
 
+	/** Reports whether the active model has any service tier a `/fast` toggle could set. */
+	supportsFastMode(): boolean {
+		return this.#models.supportsFastMode();
+	}
+
 	/** Reports whether `/fast` is enabled for the active model family. */
 	isFastModeEnabled(): boolean {
 		return this.#models.isFastModeEnabled();

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -655,6 +655,19 @@ export class ModelControls {
 	}
 
 	/**
+	 * Whether the active model exposes a service-tier family at all, i.e.
+	 * whether a `/fast` toggle would do anything. False when no model is
+	 * selected or the provider has no service tiers (e.g. Fireworks, which
+	 * carries its own Providers › Fireworks Tier toggle instead).
+	 *
+	 * Callers that surface a fast-mode control use this to hide it rather than
+	 * offering a switch whose writes {@link setFastMode} would discard.
+	 */
+	supportsFastMode(): boolean {
+		return this.#model !== undefined && serviceTierFamily(this.#model) !== undefined;
+	}
+
+	/**
 	 * True when the currently selected model's family is set to `priority` — the
 	 * `/fast` on/off state for the active model. Returns false when no model is
 	 * selected or the model exposes no service-tier family (e.g. Fireworks, which

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -86,6 +86,7 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				} else {
 					await runtime.output("Advisor disabled.");
 				}
+				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
 			}
 			if (verb === "on") {
@@ -93,11 +94,13 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				await runtime.output(
 					active ? "Advisor enabled." : "Advisor setting enabled, but no model is assigned to the 'advisor' role.",
 				);
+				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
 			}
 			if (verb === "off") {
 				runtime.session.setAdvisorEnabled(false);
 				await runtime.output("Advisor disabled.");
+				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
 			}
 			if (verb === "status") {

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -407,16 +407,19 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			if (!arg || arg === "toggle") {
 				const enabled = runtime.session.toggleFastMode();
 				await runtime.output(`Fast mode ${enabled ? "enabled" : "disabled"}.`);
+				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
 			}
 			if (arg === "on") {
 				const supported = runtime.session.setFastMode(true);
 				await runtime.output(supported ? "Fast mode enabled." : "Fast mode is unavailable for the current model.");
+				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
 			}
 			if (arg === "off") {
 				runtime.session.setFastMode(false);
 				await runtime.output("Fast mode disabled.");
+				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
 			}
 			if (arg === "status") {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Model } from "@oh-my-pi/pi-ai";
+import { type Model, serviceTierFamily } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -382,6 +382,12 @@ class FakeAgentSession {
 		this.setFastModeCalls.push(enabled);
 		this.fastMode = enabled;
 		return true;
+	}
+
+	// Mirrors ModelControls.supportsFastMode so the Fireworks (no service-tier
+	// family) case stays a real classification, not a hardcoded fake answer.
+	supportsFastMode(): boolean {
+		return this.model !== undefined && serviceTierFamily(this.model) !== undefined;
 	}
 
 	isFastModeEnabled(): boolean {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -3396,7 +3396,7 @@ describe("ACP boolean config options", () => {
 		await Bun.sleep(0);
 	});
 
-	it("degrades the advisor description when no model is assigned to the advisor role", async () => {
+	it("distinguishes an enabled-but-inert advisor from an active one", async () => {
 		const harness = await createHarness({ clientCapabilities: BOOLEAN_CAPABILITIES });
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
@@ -3407,9 +3407,7 @@ describe("ACP boolean config options", () => {
 			configId: "advisor",
 			value: true,
 		});
-		expect(inactiveResponse.configOptions.find(option => option.id === "advisor")?.description).toBe(
-			"A second model reviews each turn — no model is assigned to the 'advisor' role",
-		);
+		const inactiveOption = inactiveResponse.configOptions.find(option => option.id === "advisor");
 
 		session.advisorActive = true;
 		const activeResponse = await harness.agent.setSessionConfigOption({
@@ -3417,9 +3415,18 @@ describe("ACP boolean config options", () => {
 			configId: "advisor",
 			value: true,
 		});
-		expect(activeResponse.configOptions.find(option => option.id === "advisor")?.description).toBe(
-			"A second model reviews each turn and injects notes",
-		);
+		const activeOption = activeResponse.configOptions.find(option => option.id === "advisor");
+
+		// The observable contract is that `currentValue` tracks the *enabled*
+		// flag while the description separately reveals whether the advisor can
+		// actually run — so a client can warn that an enabled advisor is inert
+		// for want of a role assignment. The exact prose is not a wire contract
+		// (no ACP consumer parses it), so assert the distinction, not the bytes.
+		expect(inactiveOption?.currentValue).toBe(true);
+		expect(activeOption?.currentValue).toBe(true);
+		expect(inactiveOption?.description).not.toBe(activeOption?.description);
+		expect(inactiveOption?.description).toMatch(/advisor/i);
+		expect(activeOption?.description).not.toMatch(/advisor/i);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -130,6 +130,10 @@ class FakeAgentSession {
 	systemPrompt = "system";
 	disposed = false;
 	fastMode = false;
+	setFastModeCalls: boolean[] = [];
+	advisorEnabled = false;
+	advisorActive = false;
+	autoCompactionEnabled = true;
 	forcedToolChoice: string | undefined;
 	get settings(): Settings {
 		return Settings.instance;
@@ -375,12 +379,30 @@ class FakeAgentSession {
 	}
 
 	setFastMode(enabled: boolean): boolean {
+		this.setFastModeCalls.push(enabled);
 		this.fastMode = enabled;
 		return true;
 	}
 
 	isFastModeEnabled(): boolean {
 		return this.fastMode;
+	}
+
+	setAdvisorEnabled(enabled: boolean): boolean {
+		this.advisorEnabled = enabled;
+		return enabled && this.advisorActive;
+	}
+
+	isAdvisorEnabled(): boolean {
+		return this.advisorEnabled;
+	}
+
+	isAdvisorActive(): boolean {
+		return this.advisorEnabled && this.advisorActive;
+	}
+
+	setAutoCompactionEnabled(enabled: boolean): void {
+		this.autoCompactionEnabled = enabled;
 	}
 
 	setForcedToolChoice(toolName: string): void {
@@ -484,6 +506,7 @@ async function createHarness(
 		clientCapabilities?: ClientCapabilities;
 		/** Runs before a notification is recorded, so a test can delay one delivery. */
 		sessionUpdateHook?: (notification: SessionNotification) => Promise<void> | void;
+		sessionModels?: Model[];
 	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
@@ -516,10 +539,10 @@ async function createHarness(
 		closed: Promise.withResolvers<void>().promise,
 	} as unknown as AgentSideConnection;
 
-	const initialSession = new FakeAgentSession(cwdA);
+	const initialSession = new FakeAgentSession(cwdA, options.sessionModels);
 	sessions.push(initialSession);
 	const factory = async (cwd: string, factoryOptions?: { interactivePrompts?: boolean }) => {
-		const session = new FakeAgentSession(cwd);
+		const session = new FakeAgentSession(cwd, options.sessionModels);
 		const setToolUIContext = vi.fn();
 		sessions.push(session);
 		setToolUIContextSpies.push(setToolUIContext);
@@ -3254,6 +3277,191 @@ describe("ACP agent", () => {
 			expect(second.sessionId).toBe("session-after-switch");
 			expect(third.sessionId).toBe("session-after-switch");
 		});
+	});
+});
+
+describe("ACP boolean config options", () => {
+	const BOOLEAN_CAPABILITIES: ClientCapabilities = { session: { configOptions: { boolean: {} } } };
+	const FIREWORKS_MODEL: Model = buildModel({
+		id: "kimi-k2",
+		name: "Kimi",
+		api: "openai-completions",
+		provider: "fireworks",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	});
+
+	function configIds(configOptions: Array<{ id: string }> | null | undefined): string[] {
+		return (configOptions ?? []).map(option => option.id);
+	}
+
+	it("advertises fast/advisor/autoCompaction only with the capability", async () => {
+		const harness = await createHarness({ clientCapabilities: BOOLEAN_CAPABILITIES });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+
+		expect(configIds(created.configOptions)).toEqual([
+			"mode",
+			"model",
+			"thinking",
+			"fast",
+			"advisor",
+			"autoCompaction",
+		]);
+		const fastOption = created.configOptions?.find(option => option.id === "fast");
+		expect(fastOption?.type).toBe("boolean");
+		expect(fastOption?.category).toBe("model_config");
+		expect(fastOption?.currentValue).toBe(false);
+		const advisorOption = created.configOptions?.find(option => option.id === "advisor");
+		expect(advisorOption?.type).toBe("boolean");
+		expect(advisorOption?.category).toBeUndefined();
+		const autoCompactionOption = created.configOptions?.find(option => option.id === "autoCompaction");
+		expect(autoCompactionOption?.type).toBe("boolean");
+		expect(autoCompactionOption?.category).toBeUndefined();
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("omits the boolean options without the capability", async () => {
+		const harness = await createHarness({ clientCapabilities: {} });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+
+		expect(configIds(created.configOptions)).toEqual(["mode", "model", "thinking"]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("hides fast mode for a model with no service-tier family", async () => {
+		const harness = await createHarness({
+			clientCapabilities: BOOLEAN_CAPABILITIES,
+			sessionModels: [FIREWORKS_MODEL],
+		});
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+
+		const ids = configIds(created.configOptions);
+		expect(ids).toContain("advisor");
+		expect(ids).toContain("autoCompaction");
+		expect(ids).not.toContain("fast");
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("toggles fast, advisor, and autoCompaction and pushes config_option_update", async () => {
+		const harness = await createHarness({ clientCapabilities: BOOLEAN_CAPABILITIES });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		const updatesBefore = harness.updates.length;
+		const fastResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "fast",
+			value: true,
+		});
+		expect(session.isFastModeEnabled()).toBe(true);
+		expect(fastResponse.configOptions.find(option => option.id === "fast")?.currentValue).toBe(true);
+
+		const advisorResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "advisor",
+			value: true,
+		});
+		expect(session.advisorEnabled).toBe(true);
+		expect(advisorResponse.configOptions.find(option => option.id === "advisor")?.currentValue).toBe(true);
+
+		const compactionResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "autoCompaction",
+			value: false,
+		});
+		expect(session.autoCompactionEnabled).toBe(false);
+		expect(compactionResponse.configOptions.find(option => option.id === "autoCompaction")?.currentValue).toBe(false);
+
+		const configUpdates = harness.updates
+			.slice(updatesBefore)
+			.filter(
+				notification =>
+					notification.sessionId === created.sessionId &&
+					notification.update.sessionUpdate === "config_option_update",
+			);
+		expect(configUpdates.length).toBe(3);
+		expectAcpNotifications(configUpdates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("degrades the advisor description when no model is assigned to the advisor role", async () => {
+		const harness = await createHarness({ clientCapabilities: BOOLEAN_CAPABILITIES });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		session.advisorActive = false;
+		const inactiveResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "advisor",
+			value: true,
+		});
+		expect(inactiveResponse.configOptions.find(option => option.id === "advisor")?.description).toBe(
+			"A second model reviews each turn — no model is assigned to the 'advisor' role",
+		);
+
+		session.advisorActive = true;
+		const activeResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "advisor",
+			value: true,
+		});
+		expect(activeResponse.configOptions.find(option => option.id === "advisor")?.description).toBe(
+			"A second model reviews each turn and injects notes",
+		);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("skips setting fast mode on a model with no service-tier family", async () => {
+		const harness = await createHarness({
+			clientCapabilities: BOOLEAN_CAPABILITIES,
+			sessionModels: [FIREWORKS_MODEL],
+		});
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "fast",
+			value: true,
+		});
+		expect(session.setFastModeCalls).toEqual([]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("rejects wrong value types for select and boolean config options", async () => {
+		const harness = await createHarness({ clientCapabilities: BOOLEAN_CAPABILITIES });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+
+		await expect(
+			harness.agent.setSessionConfigOption({ sessionId: created.sessionId, configId: "mode", value: true }),
+		).rejects.toThrow("Unsupported boolean ACP config option: mode");
+
+		await expect(
+			harness.agent.setSessionConfigOption({
+				sessionId: created.sessionId,
+				configId: "advisor",
+				value: "on",
+			}),
+		).rejects.toThrow("Expected a boolean value for ACP config option: advisor");
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
 	});
 });
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { type Model, serviceTierFamily } from "@oh-my-pi/pi-ai";
+import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -159,6 +159,7 @@ class FakeAgentSession {
 	constructor(
 		cwd: string,
 		private readonly models: Model[] = TEST_MODELS,
+		private readonly fastModeSupported: boolean = true,
 	) {
 		this.sessionManager = SessionManager.create(cwd);
 		this.sessionId = this.sessionManager.getSessionId();
@@ -384,10 +385,11 @@ class FakeAgentSession {
 		return true;
 	}
 
-	// Mirrors ModelControls.supportsFastMode so the Fireworks (no service-tier
-	// family) case stays a real classification, not a hardcoded fake answer.
+	// ACP only ever asks the session this question, so tests state the answer
+	// directly instead of re-deriving it from the model. Whether a given model
+	// has a service-tier family is `ModelControls`' contract, covered there.
 	supportsFastMode(): boolean {
-		return this.model !== undefined && serviceTierFamily(this.model) !== undefined;
+		return this.fastModeSupported;
 	}
 
 	isFastModeEnabled(): boolean {
@@ -513,6 +515,8 @@ async function createHarness(
 		/** Runs before a notification is recorded, so a test can delay one delivery. */
 		sessionUpdateHook?: (notification: SessionNotification) => Promise<void> | void;
 		sessionModels?: Model[];
+		/** Answer ACP gets from `session.supportsFastMode()`; ACP never inspects the model itself. */
+		sessionFastModeSupported?: boolean;
 	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
@@ -545,10 +549,10 @@ async function createHarness(
 		closed: Promise.withResolvers<void>().promise,
 	} as unknown as AgentSideConnection;
 
-	const initialSession = new FakeAgentSession(cwdA, options.sessionModels);
+	const initialSession = new FakeAgentSession(cwdA, options.sessionModels, options.sessionFastModeSupported);
 	sessions.push(initialSession);
 	const factory = async (cwd: string, factoryOptions?: { interactivePrompts?: boolean }) => {
-		const session = new FakeAgentSession(cwd, options.sessionModels);
+		const session = new FakeAgentSession(cwd, options.sessionModels, options.sessionFastModeSupported);
 		const setToolUIContext = vi.fn();
 		sessions.push(session);
 		setToolUIContextSpies.push(setToolUIContext);
@@ -3342,10 +3346,11 @@ describe("ACP boolean config options", () => {
 		await Bun.sleep(0);
 	});
 
-	it("hides fast mode for a model with no service-tier family", async () => {
+	it("hides fast mode when the session reports no service-tier control", async () => {
 		const harness = await createHarness({
 			clientCapabilities: BOOLEAN_CAPABILITIES,
 			sessionModels: [FIREWORKS_MODEL],
+			sessionFastModeSupported: false,
 		});
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 
@@ -3438,10 +3443,11 @@ describe("ACP boolean config options", () => {
 		await Bun.sleep(0);
 	});
 
-	it("skips setting fast mode on a model with no service-tier family", async () => {
+	it("skips setting fast mode when the session reports no service-tier control", async () => {
 		const harness = await createHarness({
 			clientCapabilities: BOOLEAN_CAPABILITIES,
 			sessionModels: [FIREWORKS_MODEL],
+			sessionFastModeSupported: false,
 		});
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -17,6 +17,8 @@ import { removeWithRetries, setProjectDir } from "@oh-my-pi/pi-utils";
 
 interface FakeAcpBuiltinSession {
 	fastMode: boolean;
+	advisorEnabled: boolean;
+	advisorActive: boolean;
 	forcedToolChoice: string | undefined;
 	isStreaming: boolean;
 	sessionFile: string | undefined;
@@ -28,6 +30,10 @@ interface FakeAcpBuiltinSession {
 	toggleFastMode(): boolean;
 	setFastMode(enabled: boolean): boolean;
 	isFastModeEnabled(): boolean;
+	setAdvisorEnabled(enabled: boolean): boolean;
+	isAdvisorEnabled(): boolean;
+	toggleAdvisorEnabled(): boolean;
+	isAdvisorActive(): boolean;
 	setForcedToolChoice(toolName: string): void;
 	fetchUsageReports?: () => Promise<unknown>;
 	getAsyncJobSnapshot: (opts?: { recentLimit?: number }) => { running: unknown[]; recent: unknown[] } | null;
@@ -84,6 +90,8 @@ function createRuntime() {
 	let fakeSessionManager: FakeAcpBuiltinSessionManager | undefined;
 	const session: FakeAcpBuiltinSession = {
 		fastMode: false,
+		advisorEnabled: false,
+		advisorActive: false,
 		forcedToolChoice: undefined as string | undefined,
 		isStreaming: false,
 		sessionFile: undefined,
@@ -102,6 +110,20 @@ function createRuntime() {
 		},
 		isFastModeEnabled() {
 			return this.fastMode;
+		},
+		setAdvisorEnabled(enabled: boolean) {
+			this.advisorEnabled = enabled;
+			return enabled && this.advisorActive;
+		},
+		isAdvisorEnabled() {
+			return this.advisorEnabled;
+		},
+		toggleAdvisorEnabled() {
+			this.advisorEnabled = !this.advisorEnabled;
+			return this.advisorEnabled;
+		},
+		isAdvisorActive() {
+			return this.advisorEnabled && this.advisorActive;
 		},
 		setForcedToolChoice(toolName: string) {
 			this.forcedToolChoice = toolName;
@@ -241,6 +263,49 @@ describe("ACP builtin slash commands", () => {
 
 		expect(result).toEqual({ consumed: true });
 		expect(output).toEqual(["Fast mode is off."]);
+	});
+
+	it("/fast on emits a config-change notification and enables fast mode", async () => {
+		const { output, runtime, session } = createRuntime();
+		let configNotified = 0;
+		runtime.notifyConfigChanged = () => {
+			configNotified++;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/fast on", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session.fastMode).toBe(true);
+		expect(output).toEqual(["Fast mode enabled."]);
+		expect(configNotified).toBe(1);
+	});
+
+	it("/fast status does not emit a config-change notification", async () => {
+		const { runtime } = createRuntime();
+		let configNotified = 0;
+		runtime.notifyConfigChanged = () => {
+			configNotified++;
+		};
+
+		await executeAcpBuiltinSlashCommand("/fast status", runtime);
+
+		expect(configNotified).toBe(0);
+	});
+
+	it("/advisor on emits a config-change notification and enables the advisor", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.advisorActive = true;
+		let configNotified = 0;
+		runtime.notifyConfigChanged = () => {
+			configNotified++;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/advisor on", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session.advisorEnabled).toBe(true);
+		expect(output).toEqual(["Advisor enabled."]);
+		expect(configNotified).toBe(1);
 	});
 
 	it("toggles extended context with explicit controls and reports state", async () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ClientCapabilities.session.configOptions.boolean` in the ACP protocol types, so clients can advertise support for boolean session config options.
+
 ## [17.4.2] - 2026-08-21
 
 ### Fixed

--- a/packages/utils/src/acp/protocol.ts
+++ b/packages/utils/src/acp/protocol.ts
@@ -148,6 +148,7 @@ export interface ClientCapabilities {
 	terminal?: boolean;
 	auth?: { terminal?: boolean };
 	elicitation?: { form?: Record<string, unknown>; url?: Record<string, unknown> };
+	session?: { configOptions?: { boolean?: Record<string, unknown> } };
 	_meta?: Record<string, unknown>;
 }
 /** Implementation identity sent during initialization. */


### PR DESCRIPTION
## What

Exposes three ACP boolean session config options — mirroring the TUI's `/fast`, `/advisor`, and auto-compaction — to ACP clients that advertise boolean support (Zed 1.14.2+ via `session.configOptions.boolean`):

| id | maps to | category |
| --- | --- | --- |
| `fast` | `AgentSession.setFastMode` / `isFastModeEnabled` (priority service tier) | `model_config` |
| `advisor` | `AgentSession.setAdvisorEnabled` / `isAdvisorEnabled` | *(none — no reserved category fits)* |
| `autoCompaction` | `AgentSession.setAutoCompactionEnabled` / `autoCompactionEnabled` | *(none)* |

`fast` is hidden entirely for a model with no `serviceTierFamily` (e.g. Fireworks) instead of advertising a switch that would silently no-op.

## Capability gate

Per spec, an agent must not send `type: "boolean"` options unless the client advertised support. `ClientCapabilities.session.configOptions.boolean` is added to `packages/utils/src/acp/protocol.ts` (no other protocol change needed — `SessionConfigOption` already modeled the boolean variant). `#buildConfigOptions` only appends the three boolean entries when `clientCapabilities.session.configOptions.boolean != null`; clients without that capability keep seeing exactly today's `mode`/`model`/`thinking` selectors, and `/fast`/`/advisor` remain reachable as slash commands.

`setSessionConfigOption` now validates value type per option id (`#expectSelectValue` / `#expectBooleanValue`) instead of an unconditional boolean throw, and does **not** re-check the capability on set — a client replaying a saved default for a now-unsupported model (e.g. `fast` on a non-service-tier model) is silently skipped rather than erroring or emitting an operator notice.

`/fast` and `/advisor` now call `runtime.notifyConfigChanged?.()` on their `toggle`/`on`/`off` branches (matching the existing `/model` precedent) so flipping state via the message box keeps the ACP switches in sync.

## Computer use is intentionally excluded

Zed persists boolean config selections as **per-agent defaults** and replays them into future sessions (`agent_servers.<agent>.default_config_options`). That's the wrong lifetime for a desktop capture/input capability like computer use, so it stays a slash-command-only toggle in this PR.

## Screenshot

Live Zed session on this branch rendering the three switches beside the mode/model/thinking selectors:

![boolean config options in Zed](https://raw.githubusercontent.com/joseotaviorf/oh-my-pi/acp-ask-evidence/.github/pr-assets/acp-boolean-config.png)

## Verification

- `bun --cwd=packages/coding-agent run check:types` — clean
- `bun run check:tools` (biome) — clean
- `bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts` — 151 pass, 0 fail
- Stdio smoke test against the built CLI (`bun packages/coding-agent/src/cli.ts acp`):
  - `initialize` with `clientCapabilities.session.configOptions.boolean` → `session/new` returns `configOptions` ids `mode, model, thinking, fast, advisor, autoCompaction`; `fast` carries `"category":"model_config"`, `"type":"boolean"`; `autoCompaction` starts `"currentValue":true`.
  - `session/set_config_option` on `autoCompaction` → `false` returns the updated value **and** a matching `session/update` `config_option_update` notification.
  - Restarting with `clientCapabilities: {}` → `session/new` returns exactly `mode, model, thinking`, no boolean entries.
- Manual Zed check: relaunched Zed against this checkout's `omp-dev` agent entry; confirmed the three switches render with correct labels beside the mode/model/thinking selectors in a live session on this branch (screenshot above).

