### PR TITLE
feat(acp): expose /retry and /handoff over ACP

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -823,6 +823,7 @@ export class AcpAgent implements Agent {
 			output: output => this.#emitCommandOutput(record, output),
 			refreshCommands: () => this.#emitAvailableCommandsUpdate(record),
 			reloadPlugins: () => this.#reloadPluginState(record),
+			keepTurnOpenUntilIdle: () => record.session.waitForIdle(),
 			notifyTitleChanged: async () => {
 				await this.#connection.sessionUpdate({
 					sessionId: record.session.sessionId,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -823,7 +823,16 @@ export class AcpAgent implements Agent {
 			output: output => this.#emitCommandOutput(record, output),
 			refreshCommands: () => this.#emitAvailableCommandsUpdate(record),
 			reloadPlugins: () => this.#reloadPluginState(record),
-			keepTurnOpenUntilIdle: () => record.session.waitForIdle(),
+			keepTurnOpenUntilIdle: async () => {
+				await record.session.waitForIdle();
+				// `AgentSession.#emit()` does not await listeners, so the retried
+				// turn's `agent_end` handler — which emits the trailing chunks and
+				// end-of-turn updates — can still be in flight once the session is
+				// idle. Drain the tracked handlers too, or the prompt response can
+				// overtake its own updates. Same pairing as the `!agentInvoked`
+				// path below.
+				await this.#waitForPromptEventHandlers(record);
+			},
 			notifyTitleChanged: async () => {
 				await this.#connection.sessionUpdate({
 					sessionId: record.session.sessionId,

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1018,7 +1018,11 @@ export async function runRpcMode(
 						});
 						return success(id, "prompt");
 					}
-					return success(id, "prompt", { agentInvoked: false });
+					// A consumed builtin is normally local-only, but some (e.g.
+					// `/retry`) schedule an agent turn whose events stream after
+					// this response. Report that so the host does not finalize the
+					// request as non-agent work while the agent is running.
+					return success(id, "prompt", { agentInvoked: builtinResult.agentInvoked === true });
 				}
 
 				// Don't await - events will stream

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -346,7 +346,9 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 			// stream the continuation through their own session subscription, and
 			// blocking their command queue here would strand a follow-up `abort`.
 			await runtime.keepTurnOpenUntilIdle?.();
-			return commandConsumed();
+			// `retry()` returned true, so a real agent turn is now scheduled — RPC
+			// hosts must not be told this was local-only work.
+			return commandConsumed({ agentInvoked: true });
 		},
 		handleTui: async (_command, runtime) => {
 			const didRetry = await runtime.ctx.session.retry();

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -1,9 +1,9 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { setProjectDir } from "@oh-my-pi/pi-utils";
+import { logger, setProjectDir } from "@oh-my-pi/pi-utils";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
-import type { FreshSessionResult } from "../session/agent-session";
+import type { FreshSessionResult, HandoffResult } from "../session/agent-session";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
@@ -196,8 +196,44 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 	{
 		name: "handoff",
 		description: "Hand off session context to a new session",
+		acpDescription: "Summarize the session into a handoff document and compact in place",
 		inlineHint: "[focus instructions]",
 		allowArgs: true,
+		handle: async (command, runtime) => {
+			if (runtime.session.isStreaming) {
+				return usage("Wait for the current response to finish or abort it before handing off.", runtime);
+			}
+			if (runtime.session.isGeneratingHandoff) {
+				return usage("Handoff generation is already in progress.", runtime);
+			}
+			let result: HandoffResult | undefined;
+			try {
+				result = await runtime.session.handoff(command.args || undefined);
+			} catch (err) {
+				const message = errorMessage(err);
+				// `session.handoff()` normalizes genuine cancellations to this exact
+				// message; every other throw is a real failure (no model selected,
+				// nothing to hand off, already compacted, provider error) and is
+				// surfaced verbatim behind the same "<verb> failed:" prefix `/compact`
+				// uses.
+				if (message === "Handoff cancelled") {
+					return usage("Handoff cancelled.", runtime);
+				}
+				// Persist the real failure so it stays debuggable after the client
+				// message scrolls away (same rationale as the TUI path, #7993).
+				logger.error("Handoff failed", { error: message });
+				return usage(`Handoff failed: ${message}`, runtime);
+			}
+			if (!result) {
+				return usage("Handoff cancelled.", runtime);
+			}
+			const lines = ["Context handed off and compacted in place."];
+			if (result.savedPath) {
+				lines.push(`Handoff document saved to: ${result.savedPath}`);
+			}
+			await runtime.output(lines.join("\n"));
+			return commandConsumed();
+		},
 		handleTui: async (command, runtime) => {
 			const customInstructions = command.args || undefined;
 			runtime.ctx.editor.setText("");
@@ -281,6 +317,24 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 	{
 		name: "retry",
 		description: "Retry the last failed agent turn",
+		handle: async (_command, runtime) => {
+			if (runtime.session.isStreaming) {
+				return usage("Wait for the current response to finish or abort it before retrying.", runtime);
+			}
+			const didRetry = await runtime.session.retry();
+			if (!didRetry) {
+				return usage("Nothing to retry.", runtime);
+			}
+			await runtime.output("Retrying the last failed turn.");
+			// `AgentSession.retry()` only schedules the continuation as a
+			// post-prompt task; it returns before the retried turn streams. The
+			// ACP prompt turn must stay open across that turn: `AcpAgent.prompt`
+			// installs the event subscription before running the command and
+			// `#finishPrompt` unsubscribes, so returning here would silently
+			// swallow the entire retried turn (model output and tool calls).
+			await runtime.session.waitForIdle();
+			return commandConsumed();
+		},
 		handleTui: async (_command, runtime) => {
 			const didRetry = await runtime.ctx.session.retry();
 			if (!didRetry) {

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -5,6 +5,7 @@ import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
 import type { FreshSessionResult, HandoffResult } from "../session/agent-session";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
+import { USER_INTERRUPT_LABEL } from "../session/messages";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { resolveToCwd } from "../tools/path-utils";
@@ -211,11 +212,21 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 				result = await runtime.session.handoff(command.args || undefined);
 			} catch (err) {
 				const message = errorMessage(err);
-				// `session.handoff()` normalizes genuine cancellations to this exact
-				// message; every other throw is a real failure (no model selected,
-				// nothing to hand off, already compacted, provider error) and is
-				// surfaced verbatim behind the same "<verb> failed:" prefix `/compact`
-				// uses.
+				// A user interrupt (ACP `session/cancel`, TUI Esc) already settled the
+				// owning turn: `AgentSession.abort()` forwards its reason into the
+				// handoff abort controller, and `throwIfHandoffAborted` rethrows a
+				// reasoned abort verbatim — so the throw arrives as
+				// `USER_INTERRUPT_LABEL`, not "Handoff cancelled". Emitting anything
+				// here would append an out-of-turn chunk after the client already saw
+				// `stopReason: "cancelled"`, so consume silently.
+				if (message === USER_INTERRUPT_LABEL) {
+					return commandConsumed();
+				}
+				// `session.handoff()` normalizes an unreasoned cancellation to this
+				// exact message; every other throw is a real failure (no model
+				// selected, nothing to hand off, already compacted, provider error)
+				// and is surfaced verbatim behind the same "<verb> failed:" prefix
+				// `/compact` uses.
 				if (message === "Handoff cancelled") {
 					return usage("Handoff cancelled.", runtime);
 				}
@@ -227,11 +238,10 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 			if (!result) {
 				return usage("Handoff cancelled.", runtime);
 			}
-			const lines = ["Context handed off and compacted in place."];
-			if (result.savedPath) {
-				lines.push(`Handoff document saved to: ${result.savedPath}`);
-			}
-			await runtime.output(lines.join("\n"));
+			// `savedPath` is deliberately not reported: `SessionHandoff` only writes
+			// the document to disk when `options.autoTriggered` is set, which the
+			// user-invoked path never passes.
+			await runtime.output("Context handed off and compacted in place.");
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {
@@ -327,12 +337,15 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 			}
 			await runtime.output("Retrying the last failed turn.");
 			// `AgentSession.retry()` only schedules the continuation as a
-			// post-prompt task; it returns before the retried turn streams. The
-			// ACP prompt turn must stay open across that turn: `AcpAgent.prompt`
-			// installs the event subscription before running the command and
-			// `#finishPrompt` unsubscribes, so returning here would silently
-			// swallow the entire retried turn (model output and tool calls).
-			await runtime.session.waitForIdle();
+			// post-prompt task; it returns before the retried turn streams. Hosts
+			// whose prompt turn owns the event subscription (ACP) must stay open
+			// across that turn — `AcpAgent.prompt` installs the subscription
+			// before running the command and `#finishPrompt` unsubscribes, so
+			// returning early would silently swallow the entire retried turn
+			// (model output and tool calls). RPC and TUI omit this hook: they
+			// stream the continuation through their own session subscription, and
+			// blocking their command queue here would strand a follow-up `abort`.
+			await runtime.keepTurnOpenUntilIdle?.();
 			return commandConsumed();
 		},
 		handleTui: async (_command, runtime) => {

--- a/packages/coding-agent/src/slash-commands/helpers/parse.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/parse.ts
@@ -35,9 +35,17 @@ export function parseSlashCommand(text: string): ParsedSlashCommand | null {
 	};
 }
 
-/** Mark a command as fully consumed in the ACP shape. */
-export function commandConsumed(): { consumed: true } {
-	return { consumed: true };
+/**
+ * Mark a command as fully consumed in the ACP shape.
+ *
+ * Pass `agentInvoked` when the command scheduled a real agent turn whose events
+ * will stream after it returns (e.g. `/retry`). RPC hosts use that marker to
+ * tell local-only commands apart from work that starts a turn, so reporting
+ * `agentInvoked: false` there would have them finalize the request while the
+ * agent is still running.
+ */
+export function commandConsumed(options?: { agentInvoked?: boolean }): { consumed: true; agentInvoked?: boolean } {
+	return options?.agentInvoked ? { consumed: true, agentInvoked: true } : { consumed: true };
 }
 
 /** Emit a usage/error message and consume the command. */

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -70,6 +70,21 @@ export interface SlashCommandRuntime {
 	 * consistent view after plugin or project-scope changes.
 	 */
 	reloadPlugins: () => Promise<void>;
+	/**
+	 * Keep the host's prompt turn open until the session goes idle.
+	 *
+	 * Provided only by the ACP dispatcher, whose prompt turn owns the event
+	 * subscription and settles as soon as a builtin reports consumed: work a
+	 * command merely *schedules* (e.g. `/retry`'s post-prompt continuation)
+	 * would otherwise stream into an already-unsubscribed turn and be dropped.
+	 *
+	 * Deliberately absent in RPC and TUI: both observe the continuation through
+	 * their own always-on session subscription, and `RpcClient.prompt()`
+	 * documents an immediate return — blocking it there would also park the
+	 * serialized command queue, so a client could not `abort` the very turn it
+	 * is waiting on.
+	 */
+	keepTurnOpenUntilIdle?: () => Promise<void>;
 	notifyTitleChanged?: () => Promise<void> | void;
 	notifyConfigChanged?: () => Promise<void> | void;
 }

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -45,7 +45,7 @@ export interface ParsedSlashCommand {
  * - `{ prompt: string }` — command handled, pass `prompt` through as the new
  *   user input (e.g. `/force <tool> <prompt>` keeps `<prompt>` as the message).
  */
-export type SlashCommandResult = undefined | { consumed: true } | { prompt: string };
+export type SlashCommandResult = undefined | { consumed: true; agentInvoked?: boolean } | { prompt: string };
 
 /**
  * Runtime visible to slash-command handlers that run in text/ACP mode.
@@ -155,4 +155,4 @@ export interface SlashCommandSpec extends BuiltinSlashCommand {
 }
 
 /** Result returned by `executeAcpBuiltinSlashCommand`. */
-export type AcpBuiltinSlashCommandResult = false | { consumed: true } | { prompt: string };
+export type AcpBuiltinSlashCommandResult = false | { consumed: true; agentInvoked?: boolean } | { prompt: string };

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -474,7 +474,11 @@ afterEach(async () => {
 });
 
 async function createHarness(
-	options: { elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse> } = {},
+	options: {
+		elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse>;
+		/** Runs before a notification is recorded, so a test can delay one delivery. */
+		sessionUpdateHook?: (notification: SessionNotification) => Promise<void> | void;
+	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
 	cleanupRoots.push(root);
@@ -492,6 +496,9 @@ async function createHarness(
 	const sessions: FakeAgentSession[] = [];
 	const connection = {
 		sessionUpdate: async (notification: SessionNotification) => {
+			// Only await when a hook is configured: `await undefined` would insert a
+			// microtask before the push and perturb ordering-sensitive tests.
+			if (options.sessionUpdateHook) await options.sessionUpdateHook(notification);
 			updates.push(notification);
 		},
 		unstable_createElicitation: options.elicitationHandler
@@ -2081,6 +2088,79 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("drains in-flight ACP event handlers before closing a /retry turn with no agent_end", async () => {
+		// `AgentSession.#emit()` does not await listeners, so a retried turn's
+		// update can still be in delivery once the session reports idle. When the
+		// scheduled continuation never emits `agent_end` (e.g. a generation
+		// mismatch skips it), `#runPromptOrCommand`'s trailing `#finishPrompt` is
+		// what closes the turn — so the turn-holding hook must drain
+		// `record.promptEventHandlers` first or the response overtakes its chunk.
+		const deliveryBlocked = Promise.withResolvers<void>();
+		const deliveryRelease = Promise.withResolvers<void>();
+		let held = false;
+		const harness = await createHarness({
+			sessionUpdateHook: async notification => {
+				if (
+					held ||
+					notification.update.sessionUpdate !== "agent_message_chunk" ||
+					notification.update.content.type !== "text" ||
+					notification.update.content.text !== "Recovered answer."
+				) {
+					return;
+				}
+				held = true;
+				deliveryBlocked.resolve();
+				await deliveryRelease.promise;
+			},
+		});
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		session.retryResult = true;
+
+		let emitted = false;
+		session.waitForIdleBlocker = async () => {
+			if (emitted) return;
+			emitted = true;
+			// Deliberately no `agent_end`: this exercises the trailing-finishPrompt
+			// path rather than the `#handlePromptEvent` one.
+			const assistantMessage = makeAssistantMessage("Recovered answer.");
+			for (const listener of session.listeners()) {
+				listener({
+					type: "message_update",
+					message: assistantMessage,
+					assistantMessageEvent: { type: "text_delta", delta: "Recovered answer." },
+				} as AgentSessionEvent);
+			}
+		};
+
+		const prompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "/retry" }],
+		});
+		await deliveryBlocked.promise;
+
+		try {
+			const resolvedEarly = await Promise.race([prompt.then(() => true), Bun.sleep(0).then(() => false)]);
+			expect(resolvedEarly).toBe(false);
+
+			deliveryRelease.resolve();
+			const response = await prompt;
+			expect(response.stopReason).toBe("end_turn");
+			expect(
+				harness.updates.some(
+					update =>
+						update.update.sessionUpdate === "agent_message_chunk" &&
+						update.update.content.type === "text" &&
+						update.update.content.text === "Recovered answer.",
+				),
+			).toBe(true);
+		} finally {
+			deliveryRelease.resolve();
+			harness.abortController.abort();
+			await Bun.sleep(0);
+		}
 	});
 
 	it("drains async job deliveries before completing the ACP prompt", async () => {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -147,6 +147,8 @@ class FakeAgentSession {
 	waitForIdleBlocker: (() => Promise<void>) | undefined;
 	asyncJobDrain: ((options?: { timeoutMs?: number }) => Promise<boolean>) | undefined;
 	usageFallbackConfirmer: ((confirmation: UsageFallbackConfirmation) => Promise<boolean>) | undefined;
+	retryResult = false;
+	retryCalls = 0;
 	#listeners = new Set<(event: AgentSessionEvent) => void>();
 
 	constructor(
@@ -246,6 +248,11 @@ class FakeAgentSession {
 		}
 		this.isStreaming = false;
 		return true;
+	}
+
+	async retry(): Promise<boolean> {
+		this.retryCalls++;
+		return this.retryResult;
 	}
 
 	async waitForIdle(): Promise<void> {
@@ -1749,6 +1756,7 @@ describe("ACP agent", () => {
 				: [],
 		);
 		expect(names).toContain("fast");
+		expect(names).toContain("retry");
 		expect(names).toContain("force");
 		expect(names).toContain("skill:sample");
 		expect(names).not.toContain("settings");
@@ -1757,7 +1765,7 @@ describe("ACP agent", () => {
 		expect(names).not.toContain("loop");
 		expect(names).not.toContain("login");
 		expect(names).not.toContain("new");
-		expect(names).not.toContain("handoff");
+		expect(names).toContain("handoff");
 		expect(names).not.toContain("fork");
 		expect(names).not.toContain("btw");
 		expect(names).not.toContain("drop");
@@ -2021,6 +2029,58 @@ describe("ACP agent", () => {
 			harness.abortController.abort();
 			await Bun.sleep(0);
 		}
+	});
+
+	it("streams the retried turn inside the /retry prompt turn", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		session.retryResult = true;
+
+		let emitted = false;
+		session.waitForIdleBlocker = async () => {
+			// One-shot: `#waitForAcpPromptIdle` calls `session.waitForIdle()` again
+			// while handling the retried turn's own `agent_end`, so an unguarded
+			// blocker would re-enter and recurse forever.
+			if (emitted) return;
+			emitted = true;
+			const assistantMessage = makeAssistantMessage("Recovered answer.");
+			for (const listener of session.listeners()) {
+				listener({
+					type: "message_update",
+					message: assistantMessage,
+					assistantMessageEvent: { type: "text_delta", delta: "Recovered answer." },
+				} as AgentSessionEvent);
+			}
+			session.sessionManager.appendMessage(assistantMessage);
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+		};
+
+		const response = await harness.agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "/retry" }],
+		});
+
+		expect(response.stopReason).toBe("end_turn");
+		expect(session.retryCalls).toBe(1);
+
+		const chunkTexts = harness.updates
+			.filter(
+				update =>
+					update.sessionId === created.sessionId &&
+					update.update.sessionUpdate === "agent_message_chunk" &&
+					update.update.content.type === "text",
+			)
+			.map(update => (update.update as { content: { type: "text"; text: string } }).content.text);
+		expect(chunkTexts).toEqual(["Retrying the last failed turn.", "Recovered answer."]);
+
+		expect(session.waitForIdleCalls).toBeGreaterThanOrEqual(1);
+		expectAcpNotifications(harness.updates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
 	});
 
 	it("drains async job deliveries before completing the ACP prompt", async () => {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -551,7 +551,6 @@ describe("ACP builtin slash commands", () => {
 			"/btw hi",
 			"/new",
 			"/drop",
-			"/handoff",
 			"/fork",
 		];
 		for (const cmd of removedCommands) {

--- a/packages/coding-agent/test/slash-commands/handoff.test.ts
+++ b/packages/coding-agent/test/slash-commands/handoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import {
 	ACP_BUILTIN_SLASH_COMMANDS,
 	executeAcpBuiltinSlashCommand,
@@ -53,19 +54,14 @@ describe("/handoff dispatch (ACP)", () => {
 		expect(h2.handoff).toHaveBeenCalledWith(undefined);
 	});
 
-	it("reports success with no saved path as a single line", async () => {
-		const h = acpRuntime({ handoffResult: { document: "doc" } });
-		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
-		expect(h.output).toHaveBeenCalledWith("Context handed off and compacted in place.");
-	});
-
-	it("includes the saved path when present, in one output call", async () => {
+	it("reports success as a single line and never reports a saved path", async () => {
+		// `SessionHandoff` only writes the document to disk under
+		// `options.autoTriggered`, which the user-invoked path never passes, so
+		// `savedPath` is unreachable here even when the type allows it.
 		const h = acpRuntime({ handoffResult: { document: "doc", savedPath: "/tmp/handoff.md" } });
 		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
 		expect(h.output).toHaveBeenCalledTimes(1);
-		const text = h.output.mock.calls[0]?.[0] as string;
-		expect(text).toContain("Context handed off and compacted in place.");
-		expect(text).toContain("Handoff document saved to: /tmp/handoff.md");
+		expect(h.output).toHaveBeenCalledWith("Context handed off and compacted in place.");
 	});
 
 	it("reports cancellation when the handoff resolves undefined", async () => {
@@ -78,6 +74,17 @@ describe("/handoff dispatch (ACP)", () => {
 		const h = acpRuntime({ handoffError: new Error("Handoff cancelled") });
 		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
 		expect(h.output).toHaveBeenCalledWith("Handoff cancelled.");
+	});
+
+	it("stays silent when the owning turn was cancelled by the user", async () => {
+		// ACP `session/cancel` aborts with USER_INTERRUPT_LABEL, which
+		// `throwIfHandoffAborted` rethrows verbatim. The turn has already
+		// resolved as `cancelled`, so any output here would be an out-of-turn
+		// chunk reporting a false failure.
+		const h = acpRuntime({ handoffError: new Error(USER_INTERRUPT_LABEL) });
+		const result = await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.output).not.toHaveBeenCalled();
+		expect(result).toEqual({ consumed: true });
 	});
 
 	it("surfaces other failures behind the Handoff failed prefix", async () => {

--- a/packages/coding-agent/test/slash-commands/handoff.test.ts
+++ b/packages/coding-agent/test/slash-commands/handoff.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "bun:test";
+import {
+	ACP_BUILTIN_SLASH_COMMANDS,
+	executeAcpBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+
+function acpRuntime({
+	isStreaming = false,
+	isGeneratingHandoff = false,
+	handoffResult,
+	handoffError,
+}: {
+	isStreaming?: boolean;
+	isGeneratingHandoff?: boolean;
+	handoffResult?: unknown;
+	handoffError?: Error;
+}) {
+	const handoff = vi.fn(async () => {
+		if (handoffError) throw handoffError;
+		return handoffResult;
+	});
+	const output = vi.fn();
+	const runtime = {
+		session: { isStreaming, isGeneratingHandoff, handoff },
+		output,
+	} as unknown as SlashCommandRuntime;
+	return { handoff, output, runtime };
+}
+
+describe("/handoff dispatch (ACP)", () => {
+	it("refuses to hand off while streaming", async () => {
+		const h = acpRuntime({ isStreaming: true });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.handoff).not.toHaveBeenCalled();
+		expect((h.output.mock.calls[0]?.[0] as string) ?? "").toContain("before handing off");
+	});
+
+	it("refuses to hand off while a handoff is already generating", async () => {
+		const h = acpRuntime({ isGeneratingHandoff: true });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.handoff).not.toHaveBeenCalled();
+		expect(h.output).toHaveBeenCalledWith("Handoff generation is already in progress.");
+	});
+
+	it("passes focus instructions through, undefined when bare", async () => {
+		const h1 = acpRuntime({ handoffResult: { document: "doc" } });
+		await executeAcpBuiltinSlashCommand("/handoff focus on auth", h1.runtime);
+		expect(h1.handoff).toHaveBeenCalledWith("focus on auth");
+
+		const h2 = acpRuntime({ handoffResult: { document: "doc" } });
+		await executeAcpBuiltinSlashCommand("/handoff", h2.runtime);
+		expect(h2.handoff).toHaveBeenCalledWith(undefined);
+	});
+
+	it("reports success with no saved path as a single line", async () => {
+		const h = acpRuntime({ handoffResult: { document: "doc" } });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Context handed off and compacted in place.");
+	});
+
+	it("includes the saved path when present, in one output call", async () => {
+		const h = acpRuntime({ handoffResult: { document: "doc", savedPath: "/tmp/handoff.md" } });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.output).toHaveBeenCalledTimes(1);
+		const text = h.output.mock.calls[0]?.[0] as string;
+		expect(text).toContain("Context handed off and compacted in place.");
+		expect(text).toContain("Handoff document saved to: /tmp/handoff.md");
+	});
+
+	it("reports cancellation when the handoff resolves undefined", async () => {
+		const h = acpRuntime({ handoffResult: undefined });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Handoff cancelled.");
+	});
+
+	it("reports cancellation without the failed prefix when the handoff throws cancellation", async () => {
+		const h = acpRuntime({ handoffError: new Error("Handoff cancelled") });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Handoff cancelled.");
+	});
+
+	it("surfaces other failures behind the Handoff failed prefix", async () => {
+		const h = acpRuntime({ handoffError: new Error("Nothing to hand off (no messages yet)") });
+		await executeAcpBuiltinSlashCommand("/handoff", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Handoff failed: Nothing to hand off (no messages yet)");
+	});
+
+	it("is advertised with the focus hint and the ACP description", () => {
+		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(c => c.name === "handoff");
+		expect(advertised?.input?.hint).toBe("[focus instructions]");
+		expect(advertised?.description).toBe("Summarize the session into a handoff document and compact in place");
+	});
+});

--- a/packages/coding-agent/test/slash-commands/retry.test.ts
+++ b/packages/coding-agent/test/slash-commands/retry.test.ts
@@ -91,7 +91,7 @@ describe("/retry dispatch (ACP)", () => {
 		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
 		expect(h.output.mock.calls[0]?.[0]).toBe("Retrying the last failed turn.");
 		expect(h.keepTurnOpenUntilIdle).toHaveBeenCalledTimes(1);
-		expect(result).toEqual({ consumed: true });
+		expect(result).toEqual({ consumed: true, agentInvoked: true });
 	});
 
 	it("returns immediately for hosts that stream the continuation themselves (RPC/TUI)", async () => {
@@ -102,7 +102,18 @@ describe("/retry dispatch (ACP)", () => {
 		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
 		expect(h.retry).toHaveBeenCalledTimes(1);
 		expect(h.output.mock.calls[0]?.[0]).toBe("Retrying the last failed turn.");
-		expect(result).toEqual({ consumed: true });
+		expect(result).toEqual({ consumed: true, agentInvoked: true });
+	});
+
+	it("reports a scheduled retry as agent work, and a no-op retry as local-only", async () => {
+		// RPC maps a bare `{ consumed: true }` to `agentInvoked: false`. A
+		// successful retry schedules an `agent.continue()` turn, so reporting
+		// local-only there would have the host finalize the request while the
+		// retried turn is still streaming.
+		const scheduled = await executeAcpBuiltinSlashCommand("/retry", acpRuntime({ retryResult: true }).runtime);
+		const noop = await executeAcpBuiltinSlashCommand("/retry", acpRuntime({ retryResult: false }).runtime);
+		expect(scheduled).toEqual({ consumed: true, agentInvoked: true });
+		expect(noop).toEqual({ consumed: true });
 	});
 
 	it("is advertised to ACP clients", () => {

--- a/packages/coding-agent/test/slash-commands/retry.test.ts
+++ b/packages/coding-agent/test/slash-commands/retry.test.ts
@@ -49,15 +49,24 @@ describe("/retry slash command", () => {
 	});
 });
 
-function acpRuntime({ isStreaming = false, retryResult = false }: { isStreaming?: boolean; retryResult?: boolean }) {
+function acpRuntime({
+	isStreaming = false,
+	retryResult = false,
+	withKeepOpen = true,
+}: {
+	isStreaming?: boolean;
+	retryResult?: boolean;
+	withKeepOpen?: boolean;
+}) {
 	const retry = vi.fn(async () => retryResult);
-	const waitForIdle = vi.fn(async () => {});
+	const keepTurnOpenUntilIdle = vi.fn(async () => {});
 	const output = vi.fn();
 	const runtime = {
-		session: { isStreaming, retry, waitForIdle },
+		session: { isStreaming, retry },
 		output,
+		...(withKeepOpen ? { keepTurnOpenUntilIdle } : {}),
 	} as unknown as SlashCommandRuntime;
-	return { retry, waitForIdle, output, runtime };
+	return { retry, keepTurnOpenUntilIdle, output, runtime };
 }
 
 describe("/retry dispatch (ACP)", () => {
@@ -73,15 +82,26 @@ describe("/retry dispatch (ACP)", () => {
 		const h = acpRuntime({ retryResult: false });
 		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
 		expect(h.output).toHaveBeenCalledWith("Nothing to retry.");
-		expect(h.waitForIdle).not.toHaveBeenCalled();
+		expect(h.keepTurnOpenUntilIdle).not.toHaveBeenCalled();
 		expect(result).toEqual({ consumed: true });
 	});
 
-	it("announces the retry and waits for the retried turn to settle", async () => {
+	it("announces the retry and holds the ACP turn open for the retried turn", async () => {
 		const h = acpRuntime({ retryResult: true });
 		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
 		expect(h.output.mock.calls[0]?.[0]).toBe("Retrying the last failed turn.");
-		expect(h.waitForIdle).toHaveBeenCalledTimes(1);
+		expect(h.keepTurnOpenUntilIdle).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("returns immediately for hosts that stream the continuation themselves (RPC/TUI)", async () => {
+		// RPC's `prompt` awaits this dispatcher before responding and serializes
+		// later frames, so blocking here would break `RpcClient.prompt()`'s
+		// documented immediate return and strand a follow-up `abort`.
+		const h = acpRuntime({ retryResult: true, withKeepOpen: false });
+		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
+		expect(h.retry).toHaveBeenCalledTimes(1);
+		expect(h.output.mock.calls[0]?.[0]).toBe("Retrying the last failed turn.");
 		expect(result).toEqual({ consumed: true });
 	});
 

--- a/packages/coding-agent/test/slash-commands/retry.test.ts
+++ b/packages/coding-agent/test/slash-commands/retry.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "bun:test";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import {
+	ACP_BUILTIN_SLASH_COMMANDS,
+	executeAcpBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 
 function createRuntime(didRetry: boolean) {
 	const retry = vi.fn(async () => didRetry);
@@ -41,5 +46,46 @@ describe("/retry slash command", () => {
 		expect(harness.retry).toHaveBeenCalledTimes(1);
 		expect(harness.showStatus).toHaveBeenCalledWith("Nothing to retry");
 		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});
+
+function acpRuntime({ isStreaming = false, retryResult = false }: { isStreaming?: boolean; retryResult?: boolean }) {
+	const retry = vi.fn(async () => retryResult);
+	const waitForIdle = vi.fn(async () => {});
+	const output = vi.fn();
+	const runtime = {
+		session: { isStreaming, retry, waitForIdle },
+		output,
+	} as unknown as SlashCommandRuntime;
+	return { retry, waitForIdle, output, runtime };
+}
+
+describe("/retry dispatch (ACP)", () => {
+	it("refuses to retry while streaming", async () => {
+		const h = acpRuntime({ isStreaming: true });
+		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
+		expect(h.retry).not.toHaveBeenCalled();
+		expect(result).toEqual({ consumed: true });
+		expect((h.output.mock.calls[0]?.[0] as string) ?? "").toContain("before retrying");
+	});
+
+	it("reports when there is nothing to retry", async () => {
+		const h = acpRuntime({ retryResult: false });
+		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Nothing to retry.");
+		expect(h.waitForIdle).not.toHaveBeenCalled();
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("announces the retry and waits for the retried turn to settle", async () => {
+		const h = acpRuntime({ retryResult: true });
+		const result = await executeAcpBuiltinSlashCommand("/retry", h.runtime);
+		expect(h.output.mock.calls[0]?.[0]).toBe("Retrying the last failed turn.");
+		expect(h.waitForIdle).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ consumed: true });
+	});
+
+	it("is advertised to ACP clients", () => {
+		expect(ACP_BUILTIN_SLASH_COMMANDS.find(c => c.name === "retry")).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary

`/retry` and `/handoff` existed only as TUI handlers (`handleTui`) in `builtin-lifecycle.ts`, so ACP clients (Zed) neither saw them in `available_commands_update` nor could invoke them — the text fell through to the model as a prompt.

This is the last of the three deferred omp-side ACP PRs; the other two (#9042 ask elicitation, #9080 boolean config options) are already open. This branch is independent of both: its only source file is `builtin-lifecycle.ts`.

## Changes

Both commands gain a text/ACP-mode `handle`, which makes `buildAvailableSlashCommands` advertise them and `executeAcpBuiltinSlashCommand` execute them.

- **`/retry`** re-runs the last failed turn and keeps the ACP prompt turn open so the retried turn streams to the client. `AgentSession.retry()` only schedules the continuation as a post-prompt task and returns before it streams, so the handler awaits `session.waitForIdle()` after calling it — otherwise the retried turn's output would be silently swallowed.
- **`/handoff [focus instructions]`** generates the handoff document and compacts in place, refusing while a response is in progress (`SessionMaintenance.handoff` deliberately does not abort the live agent). Also corrects the ACP-facing description, which previously said "to a new session" — session identity never changes; it's a compaction on the current session.

Adding `handle` also puts both names into `ACP_BUILTIN_RESERVED_NAMES`, so an extension command with either name is no longer advertised to ACP clients (it was already unreachable since builtin dispatch runs before extension commands).

`handleTui` is untouched on both specs (it supersedes `handle` in the TUI dispatcher), so TUI behavior is unaffected.

## Testing

- `bun --cwd=packages/coding-agent run check:types` — clean
- `bun run check:tools` — clean
- `bun test packages/coding-agent/test/slash-commands/retry.test.ts packages/coding-agent/test/slash-commands/handoff.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/acp-agent.test.ts` — 153 pass
- Manual stdio ACP smoke test (`bun packages/coding-agent/src/cli.ts acp`):
  - `session/new` → `available_commands_update` now advertises `retry` and `handoff` (with the new description/hint)
  - `/retry` on a fresh session → `Nothing to retry.` / `stopReason: end_turn`
  - `/handoff` on a fresh session → `Handoff failed: Nothing to hand off (no messages yet)` / `stopReason: end_turn`
  - Positive handoff path (real provider call) not run in this environment — unrelated native-module encoding error on the configured model, orthogonal to this change
