### PR TITLE
feat(coding-agent): Space selects single-choice ask options without submitting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Ask dialog: Space now selects a single-choice option without submitting, so you can add a note (`n`) before confirming with Enter.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -616,13 +616,13 @@ export class AskDialogComponent implements Component {
 		const question = this.#questions[this.#currentQuestionIndex()];
 		// Enter advances in multi-question dialogs and submits single-question ones.
 		const enterAction = this.#questions.length > 1 ? "next" : "submit";
-		const action = question?.multi ? `Space toggle · Enter ${enterAction}` : "Enter select · n note";
+		const action = question?.multi ? `Space toggle · Enter ${enterAction}` : "Space select · Enter submit · n note";
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		if (this.#questionCanPage && indicator) {
 			return `${action} · ↑/↓${tabs} · ${cancel} · ${pageKeysLabel()} ${indicator}`;
 		}
 		const scroll = indicator ? ` ${indicator} scroll ·` : "";
-		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}`;
+		return `${action} · ↑/↓${tabs} ·${scroll} ${cancel}`;
 	}
 
 	#questionRows(question: ExtensionAskDialogQuestion): QuestionRow[] {
@@ -686,7 +686,7 @@ export class AskDialogComponent implements Component {
 		}
 		const isEnter = matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n";
 		const isSpace = matchesKey(keyData, "space") || keyData === " ";
-		if (!isEnter && !(question.multi && isSpace)) return;
+		if (!isEnter && !isSpace) return;
 		if (rowItem.kind === "other") {
 			void this.#promptForCustomInput(question, state, rowItem);
 			return;
@@ -708,6 +708,16 @@ export class AskDialogComponent implements Component {
 			} else {
 				state.selectedOptions.add(option.label);
 			}
+			this.#requestRender();
+			return;
+		}
+		if (isSpace) {
+			// Space marks the focused option as the choice without forwarding,
+			// so the user can review it or add a note (`n`) before submitting
+			// with Enter. Enter alone still selects and advances in one step.
+			state.selectedOptions = new Set([option.label]);
+			state.customInput = undefined;
+			clearNoteUnlessRow(state, rowItem.key);
 			this.#requestRender();
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -616,7 +616,9 @@ export class AskDialogComponent implements Component {
 		const question = this.#questions[this.#currentQuestionIndex()];
 		// Enter advances in multi-question dialogs and submits single-question ones.
 		const enterAction = this.#questions.length > 1 ? "next" : "submit";
-		const action = question?.multi ? `Space toggle · Enter ${enterAction}` : "Space select · Enter submit · n note";
+		const action = question?.multi
+			? `Space toggle · Enter ${enterAction}`
+			: `Space select · Enter ${enterAction} · n note`;
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		if (this.#questionCanPage && indicator) {
 			return `${action} · ↑/↓${tabs} · ${cancel} · ${pageKeysLabel()} ${indicator}`;
@@ -687,13 +689,13 @@ export class AskDialogComponent implements Component {
 		const isEnter = matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n";
 		const isSpace = matchesKey(keyData, "space") || keyData === " ";
 		if (!isEnter && !isSpace) return;
-		if (rowItem.kind === "other") {
-			void this.#promptForCustomInput(question, state, rowItem);
-			return;
-		}
-		const option = question.options[rowItem.optionIndex ?? -1];
-		if (!option) return;
 		if (question.multi) {
+			if (rowItem.kind === "other") {
+				void this.#promptForCustomInput(question, state, rowItem, false);
+				return;
+			}
+			const option = question.options[rowItem.optionIndex ?? -1];
+			if (!option) return;
 			if (isEnter) {
 				// Enter confirms the current selection without toggling the
 				// focused option; Space toggles. Advances to the next question
@@ -712,6 +714,14 @@ export class AskDialogComponent implements Component {
 			return;
 		}
 		if (isSpace) {
+			if (rowItem.kind === "other") {
+				// Space opens the custom-answer prompt without forwarding so the
+				// dialog stays open until Enter commits it.
+				void this.#promptForCustomInput(question, state, rowItem, false);
+				return;
+			}
+			const option = question.options[rowItem.optionIndex ?? -1];
+			if (!option) return;
 			// Space marks the focused option as the choice without forwarding,
 			// so the user can review it or add a note (`n`) before submitting
 			// with Enter. Enter alone still selects and advances in one step.
@@ -721,6 +731,18 @@ export class AskDialogComponent implements Component {
 			this.#requestRender();
 			return;
 		}
+		// Single-select Enter: commit an existing Space-marked answer (option or
+		// custom) regardless of the cursor row; otherwise act on the focused row.
+		if (state.selectedOptions.size > 0 || state.customInput !== undefined) {
+			this.#advanceAfterQuestion();
+			return;
+		}
+		if (rowItem.kind === "other") {
+			void this.#promptForCustomInput(question, state, rowItem, true);
+			return;
+		}
+		const option = question.options[rowItem.optionIndex ?? -1];
+		if (!option) return;
 		state.selectedOptions = new Set([option.label]);
 		state.customInput = undefined;
 		clearNoteUnlessRow(state, rowItem.key);
@@ -764,6 +786,7 @@ export class AskDialogComponent implements Component {
 		question: ExtensionAskDialogQuestion,
 		state: QuestionState,
 		rowItem: QuestionRow,
+		forwardOnAnswer: boolean,
 	): Promise<void> {
 		this.#promptActive = true;
 		try {
@@ -782,7 +805,7 @@ export class AskDialogComponent implements Component {
 			if (!question.multi) {
 				state.selectedOptions.clear();
 				clearNoteUnlessRow(state, rowItem.key);
-				this.#advanceAfterQuestion();
+				if (forwardOnAnswer) this.#advanceAfterQuestion();
 			}
 		} finally {
 			this.#promptActive = false;

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -132,6 +132,77 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option B"]);
 	});
 
+	it("single-question, single-select: Space(A) then Down then Enter submits A, not B", () => {
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose one?",
+				options: [{ label: "Option A" }, { label: "Option B" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+
+		component.handleInput(SPACE); // mark A
+		component.handleInput(DOWN); // cursor to B
+		component.handleInput(ENTER); // commit the mark, not B
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option A"]);
+	});
+
+	it("single-question, single-select: Space on Other stays open; Enter commits the custom answer", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("my custom answer"));
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose one?",
+				options: [{ label: "Option A" }, { label: "Option B" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt,
+		});
+
+		component.handleInput(DOWN); // Option B
+		component.handleInput(DOWN); // Other
+		component.handleInput(SPACE);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+		expect(onSubmit).not.toHaveBeenCalled(); // dialog stays open
+
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0]).toEqual(
+			expect.objectContaining({
+				selectedOptions: [],
+				customInput: "my custom answer",
+			}),
+		);
+	});
+
+	it("multi-question, single-select: footer hints Enter next, not submit", () => {
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Q1?", options: [{ label: "A1" }, { label: "B1" }] },
+			{ id: "q2", question: "Q2?", options: [{ label: "A2" }, { label: "B2" }] },
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit: vi.fn(),
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+
+		expect(render(component)).toContain("Space select · Enter next · n note");
+	});
+
 	it("single-question, single-select: Space then n attaches a note to the marked choice", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Why A"));
 		const onSubmit = vi.fn();

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -101,6 +101,113 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option A"]);
 	});
 
+	it("single-question, single-select: Space marks the choice without forwarding; Enter submits it", () => {
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose one?",
+				options: [{ label: "Option A" }, { label: "Option B" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+		expect(render(component)).toContain("Space select · Enter submit · n note");
+
+		// Space marks Option A as the choice; nothing is forwarded or submitted.
+		component.handleInput(SPACE);
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		// Moving the cursor and marking another option moves the choice.
+		component.handleInput(DOWN);
+		component.handleInput(SPACE);
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		// Enter submits the marked choice.
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option B"]);
+	});
+
+	it("single-question, single-select: Space then n attaches a note to the marked choice", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Why A"));
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose one?",
+				options: [{ label: "Option A" }, { label: "Option B" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt,
+		});
+
+		// Space selects without forwarding, then `n` adds a note to the choice.
+		component.handleInput(SPACE);
+		expect(onSubmit).not.toHaveBeenCalled();
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+		expect(onPrompt.mock.calls[0][0]).toBe("Note for Option A: Choose one?");
+
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0]).toEqual(
+			expect.objectContaining({
+				selectedOptions: ["Option A"],
+				note: "Why A",
+			}),
+		);
+	});
+
+	it("multi-question, single-select: Space marks without advancing; Enter advances to the next question", () => {
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Q1?",
+				options: [{ label: "A1" }, { label: "B1" }],
+			},
+			{
+				id: "q2",
+				question: "Q2?",
+				options: [{ label: "A2" }, { label: "B2" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+
+		// Space marks A1 without advancing to Q2.
+		component.handleInput(SPACE);
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(render(component)).toContain("Q1?");
+
+		// Re-marking another option moves the choice; Enter then advances.
+		component.handleInput(DOWN);
+		component.handleInput(SPACE);
+		component.handleInput(ENTER);
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(render(component)).toContain("Q2?");
+
+		// Mark on Q2 and submit from the Submit tab.
+		component.handleInput(SPACE);
+		component.handleInput(TAB);
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results.map((result: { selectedOptions: string[] }) => result.selectedOptions)).toEqual([["B1"], ["A2"]]);
+	});
+
 	it("single-question, single-select: DOWN then Enter selects second option and submits", () => {
 		const onSubmit = vi.fn();
 		const onCancel = vi.fn();


### PR DESCRIPTION
## Summary

Single-choice ask questions previously forwarded (submitted/advanced) on the
first confirm key: Enter. There was no way to select an option and keep the
dialog open to review it or add a note — the workaround was Enter, navigate
back, then `n`, which is cumbersome.

This change makes Space mark the focused single-choice option **without
forwarding**, so the flow becomes: `↑/↓` to the option → `Space` to select →
`n` to add a note → `Enter` to submit. Enter alone still selects and advances
in one step, so users who never press Space see no behavior change.

## Design notes

- I considered the alternative of making `n` select *and* add a note in one
  key, but it conflates two actions and would surprise users pressing `n` on
  an unselected row. Space-as-select keeps the existing `n` semantics intact
  while enabling the select-then-note flow.
- Footer hint changed from `Enter select · n note` to
  `Space select · Enter submit · n note`. The word "move" was dropped from the
  `↑/↓ move` hint to satisfy the width requirement: the 36-char action plus
  `↑/↓ move` plus the `↓ scroll` indicator overflows the 56-column footer at
  narrow (60-col) terminals, and the existing scroll-width test guards that.

## Verification

I reviewed the full diff of this commit. The ask-dialog test suite exercises
the exact changed path and passes (44/44, `tsgo --noEmit` and biome clean):

- Space marks the choice without submitting; Enter submits the marked option.
- Space then `n` attaches the note to the marked choice.
- Multi-question dialog: Space marks without advancing; Enter advances.


## Tooling

This change was made with Oh My Pi (OMP); this PR's content was drafted with
deepseek v4.

## Human review!

I reviewed the diff and the resulting behavior!!