### PR TITLE
fix(ai): never resend unsigned Bedrock reasoning content on replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Bedrock Converse resending unsigned reasoning content on the request path for non-Claude reasoning models (Amazon Nova and any model addressed via an opaque application-inference-profile ARN): `convertMessages` assumed a model that *streams* `reasoningContent` also *accepts* it echoed back unsigned, which holds for Claude (only after it later gains a signature) but not Nova — Nova rejects the echo with `Bedrock HTTP 400: "User messages cannot contain reasoning content. Please remove the reasoning content and try again."` on every turn after the first, wedging the agent loop. Thinking blocks without a captured signature are now always demoted to plain text on replay, matching how Anthropic, Google, and OpenAI-compatible providers already handle reasoning they can't safely resend.
+- Fixed Bedrock Converse resending unsigned reasoning content on the request path, which made Amazon Nova reject every turn after the first with `User messages cannot contain reasoning content` and wedge the agent loop. Thinking blocks without a captured signature are now demoted to plain text on replay, matching the other providers.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bedrock Converse resending unsigned reasoning content on the request path for non-Claude reasoning models (Amazon Nova and any model addressed via an opaque application-inference-profile ARN): `convertMessages` assumed a model that *streams* `reasoningContent` also *accepts* it echoed back unsigned, which holds for Claude (only after it later gains a signature) but not Nova — Nova rejects the echo with `Bedrock HTTP 400: "User messages cannot contain reasoning content. Please remove the reasoning content and try again."` on every turn after the first, wedging the agent loop. Thinking blocks without a captured signature are now always demoted to plain text on replay, matching how Anthropic, Google, and OpenAI-compatible providers already handle reasoning they can't safely resend.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -779,17 +779,6 @@ function takeCachePoint(policy: BedrockPromptCachePolicy): CachePoint | undefine
 	return { cachePoint: { type: "default", ...(policy.ttl ? { ttl: policy.ttl } : {}) } };
 }
 
-/**
- * Check if the model supports thinking signatures in reasoningContent.
- * Only Anthropic Claude models support the signature field.
- * Other models (Nova, Titan, Mistral, Llama, etc.) reject it with:
- * "This model doesn't support the reasoningContent.reasoningText.signature field"
- */
-function supportsThinkingSignature(model: Model<"bedrock-converse-stream">): boolean {
-	const id = model.id.toLowerCase();
-	return id.includes("anthropic.claude") || id.includes("anthropic/claude");
-}
-
 function buildSystemPrompt(
 	systemPrompt: readonly string[] | string | undefined,
 	promptCachePolicy: BedrockPromptCachePolicy,
@@ -869,21 +858,25 @@ function convertMessages(
 						case "thinking":
 							// Skip empty thinking blocks
 							if (c.thinking.trim().length === 0) continue;
-							// A captured signature is authoritative even when the model id is an opaque ARN.
-							// Without one, known non-Claude families use unsigned reasoning; known Claude ids demote to text.
+							// A captured signature is authoritative even when the model id is an opaque ARN:
+							// only a model that itself streamed a signature (Claude) can have one, so replay
+							// it as signed reasoningContent regardless of how the id is spelled.
 							if (c.thinkingSignature) {
 								contentBlocks.push({
 									reasoningContent: {
 										reasoningText: { text: c.thinking.toWellFormed(), signature: c.thinkingSignature },
 									},
 								});
-							} else if (!supportsThinkingSignature(model)) {
-								// Model doesn't support signatures at all — send as unsigned reasoning
-								contentBlocks.push({
-									reasoningContent: { reasoningText: { text: c.thinking.toWellFormed() } },
-								});
 							} else {
-								// Model requires signature but we don't have one — demote to text
+								// No signature was captured. Do NOT fall back to unsigned reasoningContent here:
+								// a model streaming reasoningContent does not imply it accepts reasoningContent
+								// echoed back in a request. Amazon Nova streams unsigned reasoning just fine but
+								// rejects it on replay with HTTP 400 "User messages cannot contain reasoning
+								// content. Please remove the reasoning content and try again.", which wedges the
+								// agent loop on every turn after the first. Demote to plain text instead — the
+								// content survives, just no longer typed as a reasoning block. This matches how
+								// every other provider (Anthropic, Google, OpenAI-completions) handles thinking
+								// blocks it can't safely replay.
 								contentBlocks.push({ text: renderDemotedThinking(model.id, c.thinking) });
 							}
 							break;

--- a/packages/ai/test/bedrock-nova-unsigned-reasoning.test.ts
+++ b/packages/ai/test/bedrock-nova-unsigned-reasoning.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// Amazon Nova streams reasoningContent natively (with no signature — Nova never
+// sends one), but rejects that same unsigned reasoningContent when it is echoed
+// back in a later request:
+//
+//   Bedrock HTTP 400: "User messages cannot contain reasoning content.
+//   Please remove the reasoning content and try again."
+//
+// This wedges the agent loop on every turn after the first. The bug was that
+// convertMessages() assumed any model that *produces* reasoning also *accepts*
+// it echoed back — true for Claude (which signs it), unproven and false for
+// Nova. Unsigned thinking blocks must now demote to plain text instead of
+// being resent as reasoningContent.
+const novaModel: Model<"bedrock-converse-stream"> = buildModel({
+	id: "us.amazon.nova-pro-v1:0",
+	name: "Nova Pro",
+	api: "bedrock-converse-stream",
+	provider: "amazon-bedrock",
+	baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0.8, output: 3.2, cacheRead: 0.2, cacheWrite: 1 },
+	contextWindow: 300000,
+	maxTokens: 5000,
+});
+
+// An opaque application-inference-profile ARN addressing Nova hits the same
+// path: it also fails supportsThinkingSignature-style Claude-id detection, so
+// it must not be treated as Claude-signature-capable either.
+const novaProfileArn = "arn:aws:bedrock:us-east-1:1234567890:application-inference-profile/company-nova-pro";
+
+function contextWithUnsignedThinking(modelId: string): Context {
+	return {
+		messages: [
+			{ role: "user", content: "Plan the change", timestamp: 0 },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "Inspect the implementation", thinkingSignature: "" },
+					{ type: "text", text: "I found the relevant code." },
+				],
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+				model: modelId,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 1,
+			},
+			{ role: "user", content: "Continue", timestamp: 2 },
+		],
+	};
+}
+
+async function captureReplayPayload(model: Model<"bedrock-converse-stream">, context: Context): Promise<unknown> {
+	const controller = new AbortController();
+	controller.abort();
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+
+	void streamBedrock(model, context, {
+		bearerToken: "test-token",
+		signal: controller.signal,
+		maxTokens: 16,
+		onPayload: payload => resolve(payload),
+	});
+
+	return promise;
+}
+
+describe("Bedrock Nova unsigned reasoning replay", () => {
+	test("demotes an unsigned thinking block to text instead of resending reasoningContent", async () => {
+		const payload = await captureReplayPayload(novaModel, contextWithUnsignedThinking(novaModel.id));
+		const messages = (payload as { messages: Array<{ role: string; content: Array<Record<string, unknown>> }> })
+			.messages;
+
+		expect(messages[0].role).toBe("user");
+		expect(messages[0].content[0]).toMatchObject({ text: "Plan the change" });
+		expect(messages[2].role).toBe("user");
+		expect(messages[2].content[0]).toMatchObject({ text: "Continue" });
+
+		const assistantMessage = messages[1];
+		expect(assistantMessage.role).toBe("assistant");
+		// The captured (unsigned) thinking block must be demoted to plain text...
+		expect(assistantMessage.content[0]).toMatchObject({
+			text: "<thinking>\nInspect the implementation\n</thinking>",
+		});
+		expect(assistantMessage.content[1]).toMatchObject({ text: "I found the relevant code." });
+		// ...and must never resend reasoningContent without a signature — that's exactly
+		// what Nova's HTTP 400 rejects.
+		for (const block of assistantMessage.content) {
+			expect(block).not.toHaveProperty("reasoningContent");
+		}
+	});
+
+	test("also demotes unsigned thinking for a Nova-backed application-inference-profile ARN", async () => {
+		const profileModel: Model<"bedrock-converse-stream"> = buildModel({
+			id: novaProfileArn,
+			name: "Nova Pro (inference profile)",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+			baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0.8, output: 3.2, cacheRead: 0.2, cacheWrite: 1 },
+			contextWindow: 300000,
+			maxTokens: 5000,
+		});
+
+		const payload = await captureReplayPayload(profileModel, contextWithUnsignedThinking(novaProfileArn));
+
+		const assistantMessage = (payload as { messages: Array<{ role: string; content: unknown[] }> }).messages[1];
+		for (const block of assistantMessage.content) {
+			expect(block).not.toHaveProperty("reasoningContent");
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Amazon Nova streams `reasoningContent` natively (unsigned — Nova never sends a signature). `convertMessages()` in `packages/ai/src/providers/amazon-bedrock.ts` echoes that captured thinking block straight back into the *next* request as unsigned `reasoningContent` whenever `supportsThinkingSignature(model)` is false. Nova rejects its own reasoning played back to it:

    Bedrock HTTP 400: "User messages cannot contain reasoning content.
    Please remove the reasoning content and try again."

This fires on every turn after the first, wedging the whole agent loop with empty replies. The same path is hit by any model addressed through an opaque Bedrock application-inference-profile ARN, since `supportsThinkingSignature()` can only recognize Claude via an `anthropic.claude` substring in the id.

## Root cause

`convertMessages()` assumed a model that *produces* reasoning will also *accept* it echoed back in a request:

```js
if (c.thinkingSignature) {
  // signed reasoningContent
} else if (!supportsThinkingSignature(model)) {
  // UNSIGNED reasoningContent  <-- Nova hits this and gets rejected
} else {
  // demote to text
}
```

That assumption holds for Claude (once it later supplies a signature) but was never actually validated for Nova, or any other non-Claude Bedrock reasoning model. `supportsThinkingSignature()` itself only ever confirms Claude membership; it says nothing about whether a model accepts reasoning echoed back, signed or not.

This is adjacent to, but distinct from, #6610 (fixed in #6613): #6610 was about a *signed* Claude thinking block losing its signature when addressed by an ARN. This bug is about *unsigned* reasoning from a non-Claude model being sent back to a provider that never accepts it, regardless of ARN vs. plain id.

## Fix

Only replay `reasoningContent` when a signature was actually captured — a signature can only ever come from a model's own stream, so its presence is authoritative independent of how the id is spelled (mirrors the ARN-signature fix from #6613). Every thinking block without a signature now demotes to plain text via the existing `renderDemotedThinking()` helper, matching how every other provider in this codebase (Anthropic, Google, OpenAI-completions) already handles reasoning it can't safely resend. The now-dead `supportsThinkingSignature()` id-sniffing helper is removed along with its last caller.

This is minimal and backwards-compatible: Claude ARN/plain-id replay is unaffected (still gated purely on `c.thinkingSignature`, unchanged from #6613); Nova and any other non-Claude Bedrock reasoning model now degrade gracefully (reasoning content survives as plain text) instead of hard-failing every turn after the first.

## Testing

Added `packages/ai/test/bedrock-nova-unsigned-reasoning.test.ts`: asserts an unsigned Nova thinking block is demoted to text (never emits `reasoningContent`) for both a plain Nova model id and a Nova-backed application-inference-profile ARN. Full `pi-ai` suite passes (`bun test --parallel`, 3993 pass), `bedrock*` suite passes (40 pass), `bun run check:types` clean.

Found running Amazon Nova Pro through a Bedrock application-inference-profile ARN in an agent loop.