### PR TITLE
feat(hindsight): plumb retain strategy, additive recall tags, and project observation scopes

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -448,6 +448,7 @@ one of the listed lowercase values; invalid values are ignored.
 | `HINDSIGHT_BANK_ID`                | `hindsight.bankId`              | Non-empty string; unset by default, so the selected scoping mode derives the bank |
 | `HINDSIGHT_BANK_MISSION`           | `hindsight.bankMission`         | Non-empty string; default empty string                                            |
 | `HINDSIGHT_RETAIN_MODE`            | `hindsight.retainMode`          | `full-session` or `last-turn`; default `full-session`                             |
+| `HINDSIGHT_RETAIN_STRATEGY`        | `hindsight.retainStrategy`      | Non-empty strategy; unset omits the request field and uses bank default           |
 | `HINDSIGHT_RECALL_BUDGET`          | `hindsight.recallBudget`        | `low`, `mid`, or `high`; default `mid`                                            |
 | `HINDSIGHT_AUTO_RECALL`            | `hindsight.autoRecall`          | Boolean; default `true`                                                           |
 | `HINDSIGHT_AUTO_RETAIN`            | `hindsight.autoRetain`          | Boolean; default `true`                                                           |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `hindsight.retainStrategy` (env `HINDSIGHT_RETAIN_STRATEGY`) — optional per-item Hindsight extraction strategy on auto-retain. Unset omits the field so the bank default applies; it is not written as a `strategy:*` tag.
+- `hindsight.recallTags` and `hindsight.recallTagsMatch` — extra recall tags and match mode. In `per-project-tagged`, configured tags are appended after the automatic `project:<repo>` tag and deduplicated. Default match remains `any`.
+
+### Changed
+
+- `per-project-tagged` auto-retain now sends `observation_scopes: [[project:<repo>]]` so observation consolidation follows the routing project instead of the server default (which could fragment on extra tags).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3127,6 +3127,18 @@ export const SETTINGS_SCHEMA = {
 	"hindsight.retainEveryNTurns": { type: "number", default: 3 },
 	"hindsight.retainOverlapTurns": { type: "number", default: 2 },
 	"hindsight.retainContext": { type: "string", default: "omp" },
+	"hindsight.retainStrategy": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			group: "Hindsight",
+			label: "Hindsight Retain Strategy",
+			description:
+				"Per-item Hindsight extraction strategy sent on auto-retain. When unset, the field is omitted and the bank's retain_default_strategy applies.",
+			condition: "hindsightActive",
+		},
+	},
 
 	"hindsight.recallBudget": {
 		type: "enum",
@@ -3137,6 +3149,12 @@ export const SETTINGS_SCHEMA = {
 	"hindsight.recallContextTurns": { type: "number", default: 1 },
 	"hindsight.recallMaxQueryChars": { type: "number", default: 800 },
 	"hindsight.recallTypes": { type: "array", default: HINDSIGHT_RECALL_TYPES_DEFAULT },
+	"hindsight.recallTags": { type: "array", default: [] as string[] },
+	"hindsight.recallTagsMatch": {
+		type: "enum",
+		values: ["any", "all", "any_strict", "all_strict"] as const,
+		default: "any",
+	},
 
 	"hindsight.debug": { type: "boolean", default: false },
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -2508,6 +2508,9 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 	"hindsight.bankId": () => hindsightScopeSignal.fire(),
 	"hindsight.bankIdPrefix": () => hindsightScopeSignal.fire(),
 	"hindsight.scoping": () => hindsightScopeSignal.fire(),
+	"hindsight.recallTags": () => hindsightScopeSignal.fire(),
+	"hindsight.recallTagsMatch": () => hindsightScopeSignal.fire(),
+	"hindsight.retainStrategy": () => hindsightScopeSignal.fire(),
 	extendedContext: () => extendedContextSignal.fire(),
 	"worktree.base": value => {
 		const dir = typeof value === "string" && value.trim() ? value : undefined;

--- a/packages/coding-agent/src/hindsight/backend.ts
+++ b/packages/coding-agent/src/hindsight/backend.ts
@@ -58,6 +58,7 @@ export const hindsightBackend: MemoryBackend = {
 					retainTags: parent.retainTags,
 					recallTags: parent.recallTags,
 					recallTagsMatch: parent.recallTagsMatch,
+					observationScopes: parent.observationScopes,
 					config: parent.config,
 					session,
 					banksSet: parent.banksSet,
@@ -233,6 +234,7 @@ async function installPrimaryState(
 		retainTags: scope.retainTags,
 		recallTags: scope.recallTags,
 		recallTagsMatch: scope.recallTagsMatch,
+		observationScopes: scope.observationScopes,
 		config,
 		session,
 		banksSet,
@@ -289,7 +291,7 @@ async function rebuildPrimaryStateOnScopeChange(session: AgentSession): Promise<
 	}
 
 	const next = computeBankScope(config, session.sessionManager.getCwd());
-	if (bankScopesEqual(next, current)) return;
+	if (bankScopesEqual(next, current) && current.config.retainStrategy === config.retainStrategy) return;
 
 	// Preserve the banksSet so we don't re-PUT banks we've already confirmed.
 	await installPrimaryState(session, settings, current.banksSet);
@@ -313,13 +315,14 @@ function stringArraysEqual(a: string[] | undefined, b: string[] | undefined): bo
  */
 function bankScopesEqual(
 	scope: BankScope,
-	state: Pick<HindsightSessionState, "bankId" | "retainTags" | "recallTags" | "recallTagsMatch">,
+	state: Pick<HindsightSessionState, "bankId" | "retainTags" | "recallTags" | "recallTagsMatch" | "observationScopes">,
 ): boolean {
 	return (
 		scope.bankId === state.bankId &&
 		stringArraysEqual(scope.retainTags, state.retainTags) &&
 		stringArraysEqual(scope.recallTags, state.recallTags) &&
-		scope.recallTagsMatch === state.recallTagsMatch
+		scope.recallTagsMatch === state.recallTagsMatch &&
+		JSON.stringify(scope.observationScopes) === JSON.stringify(state.observationScopes)
 	);
 }
 

--- a/packages/coding-agent/src/hindsight/bank.ts
+++ b/packages/coding-agent/src/hindsight/bank.ts
@@ -45,6 +45,8 @@ export interface BankScope {
 	recallTags?: string[];
 	/** Match mode for `recallTags`. Defaults to `any` so untagged ("global") memories surface too. */
 	recallTagsMatch?: RecallTagsMatch;
+	/** Observation consolidation scopes. Tagged mode uses only the derived project tag. */
+	observationScopes?: string[][];
 }
 
 /** Compose the prefixed base bank id (no project segment). */
@@ -79,6 +81,17 @@ function projectLabel(directory: string): string {
 	return path.basename(primary ?? directory).toLowerCase() || UNKNOWN_PROJECT;
 }
 
+function uniquePreserveOrder(tags: string[]): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const tag of tags) {
+		if (!tag || seen.has(tag)) continue;
+		seen.add(tag);
+		out.push(tag);
+	}
+	return out;
+}
+
 /**
  * Resolve the active bank target plus optional tag scoping.
  *
@@ -97,10 +110,11 @@ export function computeBankScope(config: HindsightConfig, directory: string): Ba
 			return {
 				bankId: base,
 				retainTags: [tag],
-				recallTags: [tag],
-				// `any` keeps untagged "global" memories visible alongside the
-				// project-tagged ones; flip to `*_strict` to harden isolation.
-				recallTagsMatch: "any",
+				recallTags: uniquePreserveOrder([tag, ...config.recallTags]),
+				// `any` keeps untagged / `project:global` memories visible
+				// alongside the cwd project tag unless the operator hardens it.
+				recallTagsMatch: config.recallTagsMatch,
+				observationScopes: [[tag]],
 			};
 		}
 	}

--- a/packages/coding-agent/src/hindsight/client.ts
+++ b/packages/coding-agent/src/hindsight/client.ts
@@ -107,6 +107,8 @@ export interface RetainOptions extends HindsightRequestOptions {
 	async?: boolean;
 	tags?: string[];
 	updateMode?: UpdateMode;
+	observationScopes?: MemoryItemInput["observationScopes"];
+	strategy?: string;
 }
 
 export interface RetainBatchOptions extends HindsightRequestOptions {
@@ -268,6 +270,8 @@ export class HindsightApi {
 			documentId: options?.documentId,
 			tags: options?.tags,
 			updateMode: options?.updateMode,
+			observationScopes: options?.observationScopes,
+			strategy: options?.strategy,
 		});
 
 		return this.#request<RetainResponse>(

--- a/packages/coding-agent/src/hindsight/config.ts
+++ b/packages/coding-agent/src/hindsight/config.ts
@@ -32,6 +32,8 @@ export interface HindsightConfig {
 	retainEveryNTurns: number;
 	retainOverlapTurns: number;
 	retainContext: string;
+	/** Per-item Hindsight extraction strategy. Null/empty omits the field. */
+	retainStrategy: string | null;
 
 	recallBudget: "low" | "mid" | "high";
 	recallMaxTokens: number;
@@ -39,6 +41,9 @@ export interface HindsightConfig {
 	recallContextTurns: number;
 	recallMaxQueryChars: number;
 	recallPromptPreamble: string;
+	/** Extra recall tags merged after the automatic project tag in tagged mode. */
+	recallTags: string[];
+	recallTagsMatch: "any" | "all" | "any_strict" | "all_strict";
 
 	debug: boolean;
 
@@ -60,6 +65,7 @@ export interface HindsightConfig {
 const VALID_RETAIN_MODES: HindsightConfig["retainMode"][] = ["full-session", "last-turn"];
 const VALID_BUDGETS: HindsightConfig["recallBudget"][] = ["low", "mid", "high"];
 const VALID_SCOPINGS: HindsightScoping[] = ["global", "per-project", "per-project-tagged"];
+const VALID_TAGS_MATCH: HindsightConfig["recallTagsMatch"][] = ["any", "all", "any_strict", "all_strict"];
 
 const DEFAULT_PREAMBLE =
 	"Relevant memories from past conversations (prioritize recent when conflicting). " +
@@ -102,6 +108,26 @@ function pickScoping(value: unknown): HindsightScoping | undefined {
 		: undefined;
 }
 
+function pickTagsMatch(value: unknown): HindsightConfig["recallTagsMatch"] | undefined {
+	return typeof value === "string" && (VALID_TAGS_MATCH as string[]).includes(value)
+		? (value as HindsightConfig["recallTagsMatch"])
+		: undefined;
+}
+
+function coerceStringList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const item of value) {
+		if (typeof item !== "string") continue;
+		const tag = item.trim();
+		if (!tag || seen.has(tag)) continue;
+		seen.add(tag);
+		out.push(tag);
+	}
+	return out;
+}
+
 /**
  * Load the resolved Hindsight config.
  *
@@ -128,6 +154,7 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 	const reflectTimeoutMsEnv = envInt(env.HINDSIGHT_REFLECT_TIMEOUT_MS);
 	const recallTimeoutMsEnv = envInt(env.HINDSIGHT_RECALL_TIMEOUT_MS);
 	const retainTimeoutMsEnv = envInt(env.HINDSIGHT_RETAIN_TIMEOUT_MS);
+	const retainStrategyEnv = envString(env.HINDSIGHT_RETAIN_STRATEGY);
 
 	// Read from settings (each falls back to its schema default).
 	const settingsRetainMode = pickRetainMode(settings.get("hindsight.retainMode"));
@@ -143,6 +170,17 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 			value: settings.get("hindsight.scoping"),
 		});
 	}
+	const settingsTagsMatch = pickTagsMatch(settings.get("hindsight.recallTagsMatch"));
+	if (settings.get("hindsight.recallTagsMatch") && !settingsTagsMatch) {
+		logger.warn("Hindsight: invalid recallTagsMatch setting, falling back to any", {
+			value: settings.get("hindsight.recallTagsMatch"),
+		});
+	}
+	const settingsRetainStrategy = envString(
+		typeof settings.get("hindsight.retainStrategy") === "string"
+			? settings.get("hindsight.retainStrategy")
+			: undefined,
+	);
 
 	const config: HindsightConfig = {
 		hindsightApiUrl: apiUrlEnv ?? settings.get("hindsight.apiUrl") ?? null,
@@ -161,6 +199,7 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 		retainEveryNTurns: retainEveryNTurnsEnv ?? settings.get("hindsight.retainEveryNTurns"),
 		retainOverlapTurns: settings.get("hindsight.retainOverlapTurns"),
 		retainContext: settings.get("hindsight.retainContext") ?? "omp",
+		retainStrategy: retainStrategyEnv ?? settingsRetainStrategy ?? null,
 
 		recallBudget: recallBudgetEnv ?? settingsRecallBudget ?? "mid",
 		recallMaxTokens: recallMaxTokensEnv ?? settings.get("hindsight.recallMaxTokens"),
@@ -168,6 +207,8 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 		recallContextTurns: recallContextTurnsEnv ?? settings.get("hindsight.recallContextTurns"),
 		recallMaxQueryChars: recallMaxQueryCharsEnv ?? settings.get("hindsight.recallMaxQueryChars"),
 		recallPromptPreamble: DEFAULT_PREAMBLE,
+		recallTags: coerceStringList(settings.get("hindsight.recallTags")),
+		recallTagsMatch: settingsTagsMatch ?? "any",
 
 		debug: debugEnv ?? settings.get("hindsight.debug"),
 

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -44,6 +44,8 @@ export interface HindsightSessionStateOptions {
 	/** Tag filter applied to every recall/reflect — non-empty in per-project-tagged mode. */
 	recallTags?: string[];
 	recallTagsMatch?: "any" | "all" | "any_strict" | "all_strict";
+	/** Observation consolidation scopes copied from the resolved bank scope. */
+	observationScopes?: string[][];
 	config: HindsightConfig;
 	session: AgentSession;
 	banksSet: Set<string>;
@@ -150,12 +152,18 @@ export class HindsightRetainQueue {
 
 		try {
 			await ensureBankExists(state.client, state.bankId, state.config, state.banksSet);
+			const retainStrategy = state.config.retainStrategy || undefined;
 			const batch: MemoryItemInput[] = items.map(item => ({
 				content: item.content,
 				context: item.context ?? state.config.retainContext,
-				metadata: { session_id: sessionId },
+				metadata: {
+					session_id: sessionId,
+					...(retainStrategy ? { retain_strategy: retainStrategy } : {}),
+				},
 				tags: state.retainTags,
 				timestamp: item.timestamp,
+				strategy: retainStrategy,
+				observationScopes: state.observationScopes,
 			}));
 			await state.client.retainBatch(state.bankId, batch, { async: true });
 			if (state.config.debug) {
@@ -209,6 +217,8 @@ export class HindsightSessionState {
 	/** Tag filter applied to every recall/reflect — non-empty in per-project-tagged mode. */
 	recallTags?: string[];
 	recallTagsMatch?: "any" | "all" | "any_strict" | "all_strict";
+	/** Observation consolidation scopes copied from the resolved bank scope. */
+	observationScopes?: string[][];
 	config: HindsightConfig;
 	session: AgentSession;
 	banksSet: Set<string>;
@@ -254,6 +264,7 @@ export class HindsightSessionState {
 		this.retainTags = options.retainTags;
 		this.recallTags = options.recallTags;
 		this.recallTagsMatch = options.recallTagsMatch;
+		this.observationScopes = options.observationScopes;
 		this.config = options.config;
 		this.session = options.session;
 		this.banksSet = options.banksSet;
@@ -346,13 +357,19 @@ export class HindsightSessionState {
 		}
 
 		await ensureBankExists(this.client, this.bankId, this.config, this.banksSet);
+		const retainStrategy = this.config.retainStrategy || undefined;
 		await this.client.retain(this.bankId, transcript, {
 			documentId,
 			context: this.config.retainContext,
-			metadata: { session_id: this.sessionId },
+			metadata: {
+				session_id: this.sessionId,
+				...(retainStrategy ? { retain_strategy: retainStrategy } : {}),
+			},
 			tags: this.retainTags,
 			timestamp: retainedAt,
 			async: true,
+			strategy: retainStrategy,
+			observationScopes: this.observationScopes,
 		});
 		if (nextCachedTranscript !== undefined) {
 			this.#cachedTranscript = nextCachedTranscript;

--- a/packages/coding-agent/test/hindsight-bank.test.ts
+++ b/packages/coding-agent/test/hindsight-bank.test.ts
@@ -68,6 +68,9 @@ const baseConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig =
 	mentalModelAutoSeed: false,
 	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
 	mentalModelMaxRenderChars: 16_000,
+	retainStrategy: null,
+	recallTags: [],
+	recallTagsMatch: "any",
 	...overrides,
 });
 
@@ -138,6 +141,7 @@ describe("computeBankScope", () => {
 				retainTags: ["project:proj"],
 				recallTags: ["project:proj"],
 				recallTagsMatch: "any",
+				observationScopes: [["project:proj"]],
 			});
 		});
 
@@ -157,6 +161,51 @@ describe("computeBankScope", () => {
 			const scope = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), "/work/General");
 			expect(scope.retainTags).toEqual(["project:general"]);
 			expect(scope.recallTags).toEqual(["project:general"]);
+		});
+
+		it("adds configured recallTags after the automatic project tag", () => {
+			const scope = computeBankScope(
+				baseConfig({ scoping: "per-project-tagged", recallTags: ["project:global"] }),
+				"/path/speech-core",
+			);
+			expect(scope.retainTags).toEqual(["project:speech-core"]);
+			expect(scope.recallTags).toEqual(["project:speech-core", "project:global"]);
+			expect(scope.recallTagsMatch).toBe("any");
+			expect(scope.observationScopes).toEqual([["project:speech-core"]]);
+		});
+
+		it("does not let configured recallTags replace the automatic project tag", () => {
+			const scope = computeBankScope(
+				baseConfig({ scoping: "per-project-tagged", recallTags: ["project:global", "project:speech-core"] }),
+				"/path/speech-core",
+			);
+			expect(scope.recallTags).toEqual(["project:speech-core", "project:global"]);
+		});
+
+		it("deduplicates configured recall tags against the automatic project tag", () => {
+			const scope = computeBankScope(
+				baseConfig({
+					scoping: "per-project-tagged",
+					recallTags: ["project:speech-core", "project:global", "project:global"],
+				}),
+				"/path/speech-core",
+			);
+			expect(scope.recallTags).toEqual(["project:speech-core", "project:global"]);
+		});
+
+		it("forwards recallTagsMatch", () => {
+			const scope = computeBankScope(
+				baseConfig({ scoping: "per-project-tagged", recallTagsMatch: "any_strict" }),
+				"/work/proj",
+			);
+			expect(scope.recallTagsMatch).toBe("any_strict");
+		});
+
+		it("scopes observations to the derived project tag only", () => {
+			const scope = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), "/path/speech-core");
+			expect(scope.observationScopes).toEqual([["project:speech-core"]]);
+			expect(JSON.stringify(scope.observationScopes)).not.toContain("role:");
+			expect(JSON.stringify(scope.observationScopes)).not.toContain("source:");
 		});
 	});
 

--- a/packages/coding-agent/test/hindsight-config.test.ts
+++ b/packages/coding-agent/test/hindsight-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadHindsightConfig } from "@oh-my-pi/pi-coding-agent/hindsight/config";
+
+function load(
+	overrides: Record<string, unknown> = {},
+	env: NodeJS.ProcessEnv = {},
+) {
+	return loadHindsightConfig(Settings.isolated(overrides as never), env);
+}
+
+describe("loadHindsightConfig retain/recall seam", () => {
+	it("omits retainStrategy when unset", () => {
+		expect(load().retainStrategy).toBeNull();
+	});
+
+	it("loads retainStrategy from settings", () => {
+		expect(load({ "hindsight.retainStrategy": "coding" }).retainStrategy).toBe("coding");
+	});
+
+	it("prefers HINDSIGHT_RETAIN_STRATEGY over settings", () => {
+		expect(
+			load({ "hindsight.retainStrategy": "coding" }, { HINDSIGHT_RETAIN_STRATEGY: "life-ops" }).retainStrategy,
+		).toBe("life-ops");
+	});
+
+	it("loads additive recallTags and recallTagsMatch", () => {
+		const config = load({
+			"hindsight.recallTags": ["project:global", "project:global"],
+			"hindsight.recallTagsMatch": "any_strict",
+		});
+		expect(config.recallTags).toEqual(["project:global"]);
+		expect(config.recallTagsMatch).toBe("any_strict");
+	});
+
+	it("falls back to any when recallTagsMatch is invalid", () => {
+		expect(load({ "hindsight.recallTagsMatch": "tag_groups" }).recallTagsMatch).toBe("any");
+	});
+});

--- a/packages/coding-agent/test/hindsight-retain-seam.test.ts
+++ b/packages/coding-agent/test/hindsight-retain-seam.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { HindsightApi } from "@oh-my-pi/pi-coding-agent/hindsight/client";
+import type { HindsightConfig } from "@oh-my-pi/pi-coding-agent/hindsight/config";
+import type { HindsightMessage } from "@oh-my-pi/pi-coding-agent/hindsight/content";
+import { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+function captureBodies(): unknown[] {
+	const bodies: unknown[] = [];
+	const fetchMock: typeof globalThis.fetch = Object.assign(
+		async (_input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+			bodies.push(JSON.parse(String(init?.body ?? "{}")));
+			return new Response("{}", { status: 200 });
+		},
+		{ preconnect: globalThis.fetch.preconnect },
+	);
+	vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+	return bodies;
+}
+
+const makeConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig => ({
+	hindsightApiUrl: "http://localhost:8888",
+	hindsightApiToken: null,
+	bankId: "personal",
+	bankIdPrefix: "",
+	scoping: "per-project-tagged",
+	bankMission: "",
+	retainMission: null,
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	recallBudget: "mid",
+	recallMaxTokens: 1024,
+	recallTypes: ["world", "experience"],
+	recallContextTurns: 1,
+	recallMaxQueryChars: 800,
+	recallPromptPreamble: "preamble",
+	debug: false,
+	requestTimeoutMs: 30_000,
+	reflectTimeoutMs: 30_000,
+	recallTimeoutMs: 30_000,
+	retainTimeoutMs: 30_000,
+	mentalModelsEnabled: false,
+	mentalModelAutoSeed: false,
+	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
+	mentalModelMaxRenderChars: 16_000,
+	retainStrategy: null,
+	recallTags: [],
+	recallTagsMatch: "any",
+	...overrides,
+});
+
+describe("Hindsight retain/recall request bodies", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("omits item.strategy when retainStrategy is unset", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		await client.retain("personal", "session", { tags: ["project:speech-core"] });
+		const item = (bodies[0] as { items: Array<Record<string, unknown>> }).items[0];
+		expect(item).toEqual({ content: "session", tags: ["project:speech-core"] });
+		expect(item).not.toHaveProperty("strategy");
+		expect(JSON.stringify(item)).not.toContain("strategy:coding");
+	});
+
+	it("serializes retainStrategy as item.strategy and not a strategy tag", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		await client.retain("personal", "session", {
+			tags: ["project:speech-core"],
+			strategy: "coding",
+			observationScopes: [["project:speech-core"]],
+		});
+		const item = (bodies[0] as { items: Array<Record<string, unknown>> }).items[0];
+		expect(item.strategy).toBe("coding");
+		expect(item.observation_scopes).toEqual([["project:speech-core"]]);
+		expect(item.tags).toEqual(["project:speech-core"]);
+		expect(item.tags).not.toContain("strategy:coding");
+	});
+
+	it("forwards recall tags_match", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		await client.recall("personal", "what did we decide", {
+			tags: ["project:speech-core", "project:global"],
+			tagsMatch: "any",
+		});
+		expect(bodies[0]).toMatchObject({
+			query: "what did we decide",
+			tags: ["project:speech-core", "project:global"],
+			tags_match: "any",
+		});
+	});
+
+	it("session auto-retain emits strategy and project-only observation scopes", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		const messages: HindsightMessage[] = [{ role: "user", content: "pin the speech-core decoder" }];
+		const state = new HindsightSessionState({
+			sessionId: "sess-1",
+			client,
+			bankId: "personal",
+			retainTags: ["project:speech-core"],
+			recallTags: ["project:speech-core", "project:global"],
+			recallTagsMatch: "any",
+			observationScopes: [["project:speech-core"]],
+			config: makeConfig({ retainStrategy: "coding" }),
+			session: { sessionId: "sess-1" } as object as AgentSession,
+			banksSet: new Set(["personal"]),
+		});
+
+		await state.retainSession(messages);
+
+		const body = bodies[0] as { items: Array<Record<string, unknown>> };
+		const item = body.items[0];
+		expect(item.strategy).toBe("coding");
+		expect(item.tags).toEqual(["project:speech-core"]);
+		expect(item.tags).not.toContain("strategy:coding");
+		expect(item.observation_scopes).toEqual([["project:speech-core"]]);
+		expect(JSON.stringify(item.observation_scopes)).not.toContain("role:");
+		expect(JSON.stringify(item.observation_scopes)).not.toContain("source:");
+		expect(item.metadata).toEqual({ session_id: "sess-1", retain_strategy: "coding" });
+	});
+
+	it("session auto-retain omits strategy when unset", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		const state = new HindsightSessionState({
+			sessionId: "sess-2",
+			client,
+			bankId: "personal",
+			retainTags: ["project:speech-core"],
+			observationScopes: [["project:speech-core"]],
+			config: makeConfig(),
+			session: { sessionId: "sess-2" } as object as AgentSession,
+			banksSet: new Set(["personal"]),
+		});
+
+		await state.retainSession([{ role: "user", content: "remember this" }]);
+		const item = (bodies[0] as { items: Array<Record<string, unknown>> }).items[0];
+		expect(item).not.toHaveProperty("strategy");
+		expect((item.metadata as Record<string, string>)).toEqual({ session_id: "sess-2" });
+	});
+});

--- a/packages/coding-agent/test/hindsight-retention-cache.test.ts
+++ b/packages/coding-agent/test/hindsight-retention-cache.test.ts
@@ -40,6 +40,9 @@ const makeConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig =
 	mentalModelAutoSeed: false,
 	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
 	mentalModelMaxRenderChars: 16_000,
+	retainStrategy: null,
+	recallTags: [],
+	recallTagsMatch: "any",
 	...overrides,
 });
 

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -73,6 +73,9 @@ function makeConfig(overrides: Partial<HindsightConfig> = {}): HindsightConfig {
 		mentalModelAutoSeed: false,
 		mentalModelRefreshIntervalMs: 5 * 60 * 1000,
 		mentalModelMaxRenderChars: 16_000,
+		retainStrategy: null,
+		recallTags: [],
+		recallTagsMatch: "any",
 		...overrides,
 	};
 }


### PR DESCRIPTION
I reviewed the full diff; this only wires fields the Hindsight client already serializes, and I checked the captured request bodies in the new tests.

## Why

The Hindsight HTTP item builder already supports `strategy` and `observation_scopes`. Runtime/config plumbing never passed them through auto-retain.

Without that seam, operators cannot choose a bank extraction strategy or merge `project:global` into `per-project-tagged` recall. Observation consolidation also had no explicit project scope.

## What changed

- `hindsight.retainStrategy` (optional, env `HINDSIGHT_RETAIN_STRATEGY`): sent as the per-item `strategy` field. Unset omits the field so the bank `retain_default_strategy` applies. It does **not** become a `strategy:*` tag.
- `hindsight.recallTags`: additive in `per-project-tagged` — `[project:<cwd>, ...configured]`, deduped. Configured tags cannot replace the automatic project tag.
- `hindsight.recallTagsMatch`: `any | all | any_strict | all_strict`, default `any`.
- Tagged auto-retain now sends `observation_scopes: [[project:<repo>]]` only. Role/source/other tags stay on the item tags, not in observation scopes.

## Backwards compatibility

If the new settings are unset, retain bodies omit `strategy`, recall tags remain just the derived project tag, and `tags_match` stays `any`. Existing untagged memories remain visible under `any`.

## Tests

`bun test` in `packages/coding-agent` for:

- `test/hindsight-config.test.ts`
- `test/hindsight-retain-seam.test.ts`
- `test/hindsight-bank.test.ts`
- `test/hindsight-client.test.ts`
- `test/hindsight-retention-cache.test.ts`
- `test/hindsight-backend.test.ts`
- `test/hindsight-content.test.ts`
- `test/hindsight-mental-models.test.ts`

Result: **115 pass / 0 fail**.

The retain-seam tests assert emitted bodies, including:

```json
{ "strategy": "coding", "tags": ["project:speech-core"], "observation_scopes": [["project:speech-core"]] }
```

and recall:

```json
{ "tags": ["project:speech-core", "project:global"], "tags_match": "any" }
```

I also walked a dry retain through the client path: unset strategy leaves `strategy` off the item; `retainStrategy: coding` sets `item.strategy` only.

No personal bank config, missions, or local ontology is in this PR.