### PR TITLE
fix(nix): preload libstdc++ so runtime-downloaded addons load on NixOS

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -195,6 +195,22 @@ stdenv.mkDerivation {
     remove-references-to -t ${bun} "$out/bin/omp"
   '';
 
+  # The compiled binary lazily downloads prebuilt npm addons on first use
+  # (onnxruntime-node for the tiny-title worker, @img/sharp-* for image
+  # processing). They NEED libstdc++.so.6 but are never present at build
+  # time, and NixOS provides no default search path for it, so the dlopen
+  # fails and no session title is generated. Force libstdc++ to load at
+  # process start via DT_NEEDED: afterwards every dlopen'd addon resolves
+  # libstdc++.so.6 / libgcc_s.so.1 by soname from the already-loaded set,
+  # regardless of the addon's own DT_RUNPATH. An LD_LIBRARY_PATH wrapper
+  # would also work but leaks into every spawned child process (including
+  # toolchains the user builds with), so it is deliberately avoided.
+  # stdenv.cc.cc.lib is already in buildInputs, so the autoPatchelfHook
+  # pass that follows resolves the new dependency and sets the RPATH.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf --add-needed libstdc++.so.6 "$out/bin/omp"
+  '';
+
   disallowedReferences = [ bun ];
 
   doInstallCheck = true;
@@ -203,6 +219,11 @@ stdenv.mkDerivation {
     HOME="$TMPDIR" "$out/bin/omp" --smoke-test | grep -q "smoke-test: ok"
     BUN_BE_BUN=1 "$out/bin/omp" -e \
       'if (Bun.version !== "${bun.version}" || typeof Bun.Image !== "function") process.exit(1)'
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      # The libstdc++ preload (see postFixup) must survive: without it the
+      # runtime-downloaded tiny-title/sharp addons fail to dlopen on NixOS.
+      patchelf --print-needed "$out/bin/omp" | grep -q '^libstdc++\.so\.6$'
+    ''}
     runHook postInstallCheck
   '';
 


### PR DESCRIPTION
## Problem

On NixOS, session titles are never generated (and image processing fails): the tiny-title worker crashes when loading its runtime.

Since the switch to a `bun build --compile` single binary, `@huggingface/transformers`, `onnxruntime-node` and `@img/sharp-*` are no longer part of the build output. They are downloaded lazily on first use into `~/.omp/agent/cache/tiny-title-runtime/` as pristine npm prebuilts. Those `.node`/`.so` files `NEED libstdc++.so.6`, but:

- they don't exist at build time, so `autoPatchelfHook` cannot fix them;
- NixOS has no default search path that provides `libstdc++.so.6`;
- their own `DT_RUNPATH` is `$ORIGIN`-only.

Result: `dlopen` fails with `libstdc++.so.6: cannot open shared object file`, the tiny-title worker dies, and sessions stay untitled.

## Fix

Add `DT_NEEDED libstdc++.so.6` to the compiled binary. libstdc++ is then loaded at process start (`libgcc_s.so.1` alongside, through libstdc++'s own RUNPATH), and every subsequently `dlopen`'d addon resolves both by soname from the already-loaded set — bypassing all path-search subtleties, including the rule that an addon carrying `DT_RUNPATH` suppresses the loader-chain `DT_RPATH` walk.

Deliberately **not** an `LD_LIBRARY_PATH` wrapper: this is a development tool, and the variable would leak into every spawned child process, hijacking the libstdc++ of toolchains the user builds with.

Linux-only; on Darwin the addons link the system libc++, which always exists. `stdenv.cc.cc.lib` is already in `buildInputs`, so the `autoPatchelfHook` pass after `postFixup` re-resolves the new dependency and manages the final RPATH itself (verified in the build log) — no manual rpath is needed.

## Verification

- `installCheckPhase` now asserts the `DT_NEEDED` entry survives future refactors.
- dlopen matrix against the real runtime cache, in a clean environment (`env -i`):

  | binary | `onnxruntime-node` | `@img/sharp-linux-x64` |
  |---|---|---|
  | unpatched | ✗ libstdc++.so.6 not found | ✗ |
  | + `DT_RUNPATH` on main binary | ✗ | ✗ |
  | + `DT_RPATH` on main binary | ✗ (binding carries `DT_RUNPATH`) | ✓ (binding carries `DT_RPATH`) |
  | **+ `DT_NEEDED libstdc++.so.6` (this PR)** | **✓** | **✓** |

- End-to-end on NixOS: ran the built `bin/omp`, asked a question, and the local tiny model generated the session title — visible in the TUI title bar and persisted as `"title":"Paris"` in the session file.
