### PR TITLE
fix(auth): stop concurrent xAI OAuth refresh replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concurrent xAI OAuth refreshes revoking shared grants or repeatedly retrying dead refresh tokens when multiple processes use the same credential database.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -710,6 +710,7 @@ const USAGE_REPORT_CACHE_KEY_VERSION_OVERRIDES: Partial<Record<Provider, number>
 	anthropic: 3,
 };
 const DEFAULT_OAUTH_REFRESH_TIMEOUT_MS = 10_000;
+const OAUTH_REFRESH_FAILURE_BACKOFF_MS = 5 * 60 * 1000;
 /**
  * Refresh OAuth access tokens this many ms before their stated expiry. The
  * skew exists so callers downstream of {@link AuthStorage} (stream providers,
@@ -4853,6 +4854,7 @@ export class AuthStorage {
 					.map(idx => credentials[idx])
 					.filter((selection): selection is { credential: OAuthCredential; index: number } => Boolean(selection))
 					.map(selection => ({ selection, usage: null, usageChecked: false }));
+		const preflightFailures = new Set<OAuthCandidate>();
 
 		// On the warm skip path the candidate list follows the round-robin `order`, not the pin, so
 		// hoist the pinned credential to the front to actually reuse it. When ranking ran, the pin is
@@ -4896,8 +4898,8 @@ export class AuthStorage {
 					candidate.selection.credential = latestCredential;
 					return;
 				}
+				const credentialId = this.#getStoredCredentials(provider)[candidate.selection.index]?.id;
 				try {
-					const credentialId = this.#getStoredCredentials(provider)[candidate.selection.index]?.id;
 					// Hand #refreshOAuthCredential a stale clone (expires:0) so its
 					// not-yet-expired short-circuit doesn't suppress the forced
 					// re-mint; an in-flight peer refresh is still awaited via the
@@ -4924,10 +4926,23 @@ export class AuthStorage {
 						this.#replaceCredentialAt(provider, candidate.selection.index, updated);
 					}
 				} catch (error) {
-					// Recovery for definitive failures (incl. peer rotation) lives in
-					// #tryOAuthCredential; log instead of swallowing silently — a bare
-					// catch here hid stale-refresh-token replays from concurrent
-					// sessions (one-turn 401 "Invalid authentication credentials").
+					// A failed preflight already exercised the provider refresh path.
+					// Do not replay the same refresh token in the final candidate pass.
+					if (credentialId !== undefined) {
+						const latestIndex = this.#getStoredCredentials(provider).findIndex(
+							entry => entry.id === credentialId,
+						);
+						if (latestIndex !== -1) {
+							this.#markCredentialBlocked(
+								provider,
+								providerKey,
+								latestIndex,
+								Date.now() + OAUTH_REFRESH_FAILURE_BACKOFF_MS,
+								blockScope,
+							);
+						}
+					}
+					preflightFailures.add(candidate);
 					logger.debug("OAuth preflight refresh failed", {
 						provider,
 						index: candidate.selection.index,
@@ -4975,6 +4990,7 @@ export class AuthStorage {
 
 		for (const pass of passes) {
 			for (const candidate of candidates) {
+				if (preflightFailures.has(candidate)) continue;
 				const resolved = await this.#tryOAuthCredential(
 					provider,
 					candidate.selection,
@@ -5048,8 +5064,19 @@ export class AuthStorage {
 						credentialId,
 						signal && refreshSignal ? AbortSignal.any([signal, refreshSignal]) : (signal ?? refreshSignal),
 					),
+				isDefinitiveFailure: error => AIError.isDefinitiveOAuthFailure(String(error)),
+				disabledCause: error => `oauth refresh failed: ${String(error)}`,
 			});
-			if (result.credential) return result.credential;
+			if (result.credential) {
+				if (Date.now() < result.credential.expires) return result.credential;
+				throw new AIError.OAuthError(
+					`OAuth refresh did not produce a usable credential for provider: ${provider}`,
+					{
+						kind: "token-refresh",
+						provider,
+					},
+				);
+			}
 			throw new AIError.OAuthError(`OAuth credential no longer exists for provider: ${provider}`, {
 				kind: "token-refresh",
 				provider,
@@ -5081,9 +5108,9 @@ export class AuthStorage {
 						provider,
 					});
 				}
-				refreshPromise = customProvider.refreshToken(credential);
+				refreshPromise = customProvider.refreshToken(credential, signal);
 			} else {
-				refreshPromise = refreshOAuthToken(provider as OAuthProvider, credential);
+				refreshPromise = refreshOAuthToken(provider as OAuthProvider, credential, signal);
 			}
 		}
 		// Bound the refresh so a slow/hanging token endpoint cannot stall credential selection.
@@ -5379,14 +5406,19 @@ export class AuthStorage {
 						index: selection.index,
 					});
 					await this.reload();
-					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
+					return undefined;
 				}
 				if (this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")) {
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
 			} else {
 				// Block temporarily for transient failures (5 minutes)
-				this.#markCredentialBlocked(provider, providerKey, selection.index, Date.now() + 5 * 60 * 1000);
+				this.#markCredentialBlocked(
+					provider,
+					providerKey,
+					selection.index,
+					Date.now() + OAUTH_REFRESH_FAILURE_BACKOFF_MS,
+				);
 			}
 		}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5068,7 +5068,11 @@ export class AuthStorage {
 				disabledCause: error => `oauth refresh failed: ${String(error)}`,
 			});
 			if (result.credential) {
-				if (Date.now() < result.credential.expires) return result.credential;
+				// Match #refreshOAuthCredential's freshness contract: a reloaded
+				// credential within the refresh skew still counts as needing refresh,
+				// so returning it here would make the final candidate pass refresh the
+				// same row again and replay the token we just failed on.
+				if (Date.now() + OAUTH_REFRESH_SKEW_MS < result.credential.expires) return result.credential;
 				throw new AIError.OAuthError(
 					`OAuth refresh did not produce a usable credential for provider: ${provider}`,
 					{

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -60,12 +60,12 @@ export function unregisterOAuthProviders(sourceId: string): void {
 }
 
 /**
- * Refresh token for any OAuth provider.
- * Saves the new credentials and returns the new access token.
+ * Refresh a built-in OAuth grant, cancelling provider work when refresh ownership ends.
  */
 export async function refreshOAuthToken(
 	provider: OAuthProvider,
 	credentials: OAuthCredentials,
+	signal?: AbortSignal,
 ): Promise<OAuthCredentials> {
 	if (!credentials) {
 		throw new AIError.OAuthError(`No OAuth credentials found for ${provider}`, {
@@ -82,7 +82,7 @@ export async function refreshOAuthToken(
 	}
 	// Providers without a real refresher (static bearer tokens / API keys that
 	// don't expire) return the credentials unchanged.
-	return def.refreshToken ? def.refreshToken(credentials) : credentials;
+	return def.refreshToken ? def.refreshToken(credentials, signal) : credentials;
 }
 function getPerplexityJwtExpiryMs(token: string): number | undefined {
 	const parts = token.split(".");

--- a/packages/ai/src/registry/oauth/types.ts
+++ b/packages/ai/src/registry/oauth/types.ts
@@ -89,7 +89,8 @@ export interface OAuthProviderInterface {
 	readonly name: string;
 	readonly sourceId?: string;
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials | string>;
-	refreshToken?(credentials: OAuthCredentials): Promise<OAuthCredentials>;
+	/** Refresh a stored grant; the signal bounds provider network work to refresh ownership. */
+	refreshToken?(credentials: OAuthCredentials, signal?: AbortSignal): Promise<OAuthCredentials>;
 	getApiKey?(credentials: OAuthCredentials): string;
 	/** Store resulting OAuth credentials under a different provider id. */
 	readonly storeCredentialsAs?: string;

--- a/packages/ai/src/registry/oauth/xai-oauth.ts
+++ b/packages/ai/src/registry/oauth/xai-oauth.ts
@@ -106,6 +106,7 @@ export function validateXAIBillingEndpoint(url: string, field: string = "billing
 async function xaiOAuthDiscovery(
 	timeoutMs: number = DISCOVERY_TIMEOUT_MS,
 	fetchOverride?: FetchImpl,
+	signal?: AbortSignal,
 ): Promise<XAIOAuthDiscovery> {
 	const fetchImpl = fetchOverride ?? fetch;
 	let response: Response;
@@ -113,7 +114,7 @@ async function xaiOAuthDiscovery(
 		response = await fetchImpl(XAI_OAUTH_DISCOVERY_URL, {
 			method: "GET",
 			headers: { Accept: "application/json" },
-			signal: AbortSignal.timeout(timeoutMs),
+			signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs),
 		});
 	} catch (error) {
 		throw new AIError.OAuthError(
@@ -482,7 +483,7 @@ async function pollXAIDeviceToken(
 /** Log in to xAI Grok with the RFC 8628 device authorization grant. */
 export async function loginXAIOAuth(ctrl: OAuthController): Promise<OAuthCredentials> {
 	const fetchImpl = ctrl.fetch ?? fetch;
-	const discovery = await xaiOAuthDiscovery(DISCOVERY_TIMEOUT_MS, fetchImpl);
+	const discovery = await xaiOAuthDiscovery(DISCOVERY_TIMEOUT_MS, fetchImpl, ctrl.signal);
 	const device = await requestXAIDeviceAuthorization(fetchImpl, ctrl.signal);
 	ctrl.onAuth?.({
 		url: device.verificationUriComplete,
@@ -503,15 +504,19 @@ export async function loginXAIOAuth(ctrl: OAuthController): Promise<OAuthCredent
  * Refresh an xAI OAuth access token using a stored refresh_token.
  *
  * Re-runs OIDC discovery and re-validates the token endpoint before sending
- * the stored refresh token.
+ * the stored refresh token. Caller cancellation aborts every network request.
  */
-export async function refreshXAIOAuthToken(refreshToken: string, fetchOverride?: FetchImpl): Promise<OAuthCredentials> {
+export async function refreshXAIOAuthToken(
+	refreshToken: string,
+	fetchOverride?: FetchImpl,
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
 	const fetchImpl = fetchOverride ?? fetch;
 	if (typeof refreshToken !== "string" || !refreshToken.trim()) {
 		throw new AIError.OAuthError("missing refresh_token", { kind: "validation", provider: "xai" });
 	}
 
-	const discovery = await xaiOAuthDiscovery(DISCOVERY_TIMEOUT_MS, fetchImpl);
+	const discovery = await xaiOAuthDiscovery(DISCOVERY_TIMEOUT_MS, fetchImpl, signal);
 	const tokenEndpoint = validateXAIEndpoint(discovery.token_endpoint, "token_endpoint");
 
 	const body = new URLSearchParams({
@@ -528,7 +533,9 @@ export async function refreshXAIOAuthToken(refreshToken: string, fetchOverride?:
 		},
 		body,
 		redirect: "error",
-		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+		signal: signal
+			? AbortSignal.any([signal, AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS)])
+			: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 	});
 
 	if (!response.ok) {
@@ -555,5 +562,5 @@ export async function refreshXAIOAuthToken(refreshToken: string, fetchOverride?:
 		);
 	}
 	const credentials = parseXAITokenResponse(payload, "xAI token refresh response", refreshToken);
-	return withXAIOAuthIdentity(credentials, fetchImpl);
+	return withXAIOAuthIdentity(credentials, fetchImpl, signal);
 }

--- a/packages/ai/src/registry/types.ts
+++ b/packages/ai/src/registry/types.ts
@@ -74,7 +74,8 @@ export interface ProviderDefinition {
 	readonly prepareModelDiscovery?: ProviderModelDiscoveryPreparer;
 	// --- interactive login (OAuthProviderInterface-compatible) ---
 	readonly login?: (callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials | string>;
-	readonly refreshToken?: (credentials: OAuthCredentials) => Promise<OAuthCredentials>;
+	/** Refresh a stored grant; the signal bounds provider network work to refresh ownership. */
+	readonly refreshToken?: (credentials: OAuthCredentials, signal?: AbortSignal) => Promise<OAuthCredentials>;
 	readonly getApiKey?: (credentials: OAuthCredentials) => string;
 	/** Store OAuth credentials under a different provider id (e.g. `openai-codex-device` ⇒ `openai-codex`). */
 	readonly storeCredentialsAs?: string;

--- a/packages/ai/src/registry/xai-oauth.ts
+++ b/packages/ai/src/registry/xai-oauth.ts
@@ -9,9 +9,9 @@ export const xaiOauthProvider = {
 		const { loginXAIOAuth } = await import("./oauth/xai-oauth");
 		return loginXAIOAuth(cb);
 	},
-	refreshToken: async (credentials: OAuthCredentials) => {
+	refreshToken: async (credentials: OAuthCredentials, signal?: AbortSignal) => {
 		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
 		const { refreshXAIOAuthToken } = await import("./oauth/xai-oauth");
-		return refreshXAIOAuthToken(credentials.refresh);
+		return refreshXAIOAuthToken(credentials.refresh, undefined, signal);
 	},
 } as const satisfies ProviderDefinition;

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -849,4 +849,43 @@ describe("AuthStorage OAuth refresh race", () => {
 		expect(result).toMatchObject({ refreshed: false, removed: false });
 		expect(result.credential).toMatchObject({ type: "oauth", access: "peer-rotated-access" });
 	});
+
+	test("stops after a definitive refresh failure loses its disable CAS", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		await authStorage.set("unit-oauth-definitive-cas-loss", [
+			{
+				type: "oauth",
+				access: "access-old",
+				refresh: "refresh-old",
+				expires: Date.now() - 60_000,
+			},
+		]);
+		const controller = new AbortController();
+		let refreshCalls = 0;
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-definitive-cas-loss",
+			name: "Unit OAuth Definitive CAS Loss",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: Date.now() + 60 * 60_000 };
+			},
+			async refreshToken() {
+				refreshCalls += 1;
+				if (refreshCalls > 1) controller.abort(new Error("unexpected retry"));
+				throw new Error('HTTP 400 invalid_grant {"error":"invalid_grant"}');
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+		vi.spyOn(store, "tryDisableAuthCredentialIfMatches").mockReturnValue(false);
+
+		await expect(
+			authStorage.getApiKey("unit-oauth-definitive-cas-loss", "session-cas-loss", {
+				signal: controller.signal,
+			}),
+		).resolves.toBeUndefined();
+		expect(refreshCalls).toBe(1);
+	});
 });

--- a/packages/ai/test/registry/oauth/xai-oauth.test.ts
+++ b/packages/ai/test/registry/oauth/xai-oauth.test.ts
@@ -11,6 +11,7 @@ import {
 	validateXAIBillingEndpoint,
 	validateXAIEndpoint,
 } from "../../../src/registry/oauth/xai-oauth";
+import type { FetchImpl } from "../../../src/types";
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -285,6 +286,32 @@ describe("refreshXAIOAuthToken", () => {
 		});
 		expect(requests.map(request => request.url)).toEqual([DISCOVERY_URL, TOKEN_ENDPOINT, USERINFO_URL]);
 		expect(requests.find(request => request.url === TOKEN_ENDPOINT)?.init?.redirect).toBe("error");
+	});
+
+	it("binds refresh HTTP requests to the caller abort signal", async () => {
+		const accessToken = jwtWithPayload({ sub: "jwt-sub" });
+		const controller = new AbortController();
+		const requests: RecordedRequest[] = [];
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+			requests.push({ url, init });
+			if (url === DISCOVERY_URL) return jsonResponse({ token_endpoint: TOKEN_ENDPOINT });
+			if (url === TOKEN_ENDPOINT) {
+				return jsonResponse({
+					access_token: accessToken,
+					expires_in: 3600,
+				});
+			}
+			if (url === USERINFO_URL) return jsonResponse({ sub: "profile-sub" });
+			throw new Error(`Unexpected xAI OAuth request: ${url}`);
+		};
+
+		await refreshXAIOAuthToken("old-refresh-token", fetchMock, controller.signal);
+		const refreshSignal = requests.find(request => request.url === TOKEN_ENDPOINT)?.init?.signal;
+		expect(refreshSignal?.aborted).toBe(false);
+
+		controller.abort(new Error("refresh ownership ended"));
+		expect(refreshSignal?.aborted).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Repro
With two `AuthStorage` instances sharing one SQLite credential row, an `invalid_grant` whose disable CAS misses re-enters refresh with the same dead token; separately, aborting xAI refresh ownership leaves its HTTP request live. Reproduced with `bun test packages/ai/test/auth-storage-oauth-refresh-race.test.ts packages/ai/test/registry/oauth/xai-oauth.test.ts --test-name-pattern 'stops after a definitive refresh|binds refresh HTTP requests'`: both regressions failed before the fix.

## Cause
`AuthStorage.#refreshOAuthCredentialUnshared` in `packages/ai/src/auth-storage.ts` did not classify definitive provider failures inside `refreshStoredOAuthCredential`, and `#resolveOAuthSelection` retried a failed preflight in the final candidate pass; its outer CAS-miss branch recursively selected the same row again. `refreshXAIOAuthToken` in `packages/ai/src/registry/oauth/xai-oauth.ts` used only provider-local timeout signals, so a storage timeout could release the durable lease while the xAI discovery or token request continued.

## Fix
- Handle definitive refresh failures while the SQLite lease owner is still fenced, reject expired CAS-loss results, and skip candidates whose preflight already failed.
- Reload and stop after an outer disable CAS miss instead of recursively refreshing the same credential.
- Propagate refresh ownership cancellation through provider refresh interfaces and bind xAI discovery, token, and identity requests to it.
- Add CAS-loss retry and xAI abort-signal regressions plus an Unreleased changelog entry.

## Verification
`bun test packages/ai/test/auth-storage-oauth-refresh-race.test.ts packages/ai/test/auth-storage-usage-cache.test.ts packages/ai/test/auth-storage-force-refresh-rotate.test.ts packages/ai/test/auth-storage-refresh-skew.test.ts packages/ai/test/auth-storage-broker-no-sentinel.test.ts packages/ai/test/auth-storage-check-credentials.test.ts packages/ai/test/registry/oauth/xai-oauth.test.ts` passed: 101 tests, 467 assertions, 0 failures. `bun check` passed for all packages. Fixes #9092