### PR TITLE
docs(context-files): document disabling a single context file

### DIFF
--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -195,7 +195,7 @@ disabledProviders:
 | Discovery provider ids | `native`, `claude`, `codex`, `gemini`, `opencode`, `github`, `agents`, `agents-md` | The entire config source is removed — not just its context files, but also any MCP servers, slash commands, skills, hooks, tools, prompts, and settings it would have contributed. |
 | Model provider ids     | `anthropic`, `openai`, `google`, `groq`, `ollama`, `openrouter`                    | The model backend is removed from selection even when its credentials are present. See [Providers](./providers.md).                                                                |
 
-Ids are exact and the two namespaces do not collide by accident: `google` disables the Google model backend, while `gemini` disables the Gemini CLI discovery files. Disabling a discovery provider is heavier than it looks — disabling `claude`, for instance, also drops Claude-discovered MCP servers, commands, skills, hooks, tools, and settings, not only `CLAUDE.md`.
+Ids are exact and the two namespaces do not collide by accident: `google` disables the Google model backend, while `gemini` disables the Gemini CLI discovery files. Disabling a discovery provider is heavier than it looks — disabling `claude`, for instance, also drops Claude-discovered MCP servers, commands, skills, hooks, tools, and settings, not only `CLAUDE.md`. To drop the context file alone and keep everything else the provider contributes, use [`disabledExtensions`](#disabling-a-single-context-file) instead.
 
 Only `enabledModels` and `disabledProviders` support **path-scoped** entries, so you can vary provider availability per subtree:
 
@@ -211,6 +211,37 @@ A scoped entry applies when the cwd equals the configured path or sits beneath i
 
 Remember that higher-precedence settings layers **replace** array settings rather than appending to them. If your global config disables `claude` but a project config sets `disabledProviders: [github]`, then inside that project Claude discovery is re-enabled and only GitHub is disabled. See [Settings](./settings.md) for the full layer precedence, merge rules, and path-scoped array details.
 
+## Disabling a single context file
+
+`disabledProviders` removes a whole config source. To drop one context file and keep the rest of what its provider contributes, list its extension id in `disabledExtensions`:
+
+```yaml
+# ~/.omp/agent/config.yml, .omp/config.yml, or a --config overlay
+disabledExtensions:
+  - context-file:user:CLAUDE.md
+```
+
+Context-file ids have the form `context-file:<level>:<basename>`, where `<level>` is `user` or `project` and `<basename>` is the file name with no directory part:
+
+| Id                                  | Disables                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------ |
+| `context-file:user:CLAUDE.md`       | The user-level `CLAUDE.md`, while Claude's MCP servers, commands, skills, hooks, tools, and settings keep loading. |
+| `context-file:project:AGENTS.md`    | **Every** project-level `AGENTS.md`, at each directory depth the walk reaches — the id carries no depth. |
+| `context-file:user:AGENTS.md`       | Every user-level file named `AGENTS.md`, whichever provider supplied it.       |
+
+The match is on level and file name only, so one entry covers every provider that contributes a file of that name at that level, and a project entry cannot be narrowed to a single depth. When you need per-directory control, use a project `.omp/config.yml` in the subtree that should differ, or the path-scoped `disabledProviders` form above.
+
+Disabling is not the same as shadowing, and the difference is visible: a disabled file is dropped before deduplication, so it does not claim its scope. **The file it used to shadow is loaded in its place.** In a project holding both `.claude/CLAUDE.md` and `AGENTS.md`, `CLAUDE.md` normally wins the depth-0 scope; disable `context-file:project:CLAUDE.md` and `AGENTS.md` becomes the project context rather than the scope falling empty. To leave the scope with no file at all, disable each candidate name.
+
+Two everyday uses:
+
+- **Non-interactive runs.** A user-level context file written for your own interactive sessions is usually wrong for `-p` runs driven by another program, which arrive with their own instructions. Disabling it in a `--config` overlay keeps your interactive setup untouched.
+- **Delegated work.** When one agent drives another, the caller's own operating instructions travel into the callee's prompt as user-level context and can contradict the task it was actually given.
+
+`disabledExtensions` is not path-scoped: only `enabledModels` and `disabledProviders` accept the `path:` form. Like every array setting it is replaced, not merged, by a higher-precedence layer.
+
+Browse the ids interactively with `/extensions`, which lists every discovered context file with its level, source, and current state, and toggles the same setting.
+
 ## Troubleshooting
 
 ### A file is not loaded
@@ -221,6 +252,7 @@ Remember that higher-precedence settings layers **replace** array settings rathe
 - `~/.codex/AGENTS.md` and `~/.config/opencode/AGENTS.md` are user-level only and have no project equivalent.
 - Empty files contribute nothing for the native and standalone providers.
 - A disabled discovery provider contributes nothing — check `disabledProviders` across your global, project, and `--config` layers.
+- A single file can also be turned off on its own — check `disabledExtensions` for a matching `context-file:<level>:<basename>` entry, and remember that a project entry applies at every depth. `/extensions` shows the file as `disabled` when this is the cause.
 
 ### The wrong file wins
 

--- a/docs/extension-loading.md
+++ b/docs/extension-loading.md
@@ -133,6 +133,24 @@ disabledExtensions:
   - extension-module:foo
 ```
 
+### Disable specific items of other capabilities
+
+`disabledExtensions` is not limited to extension modules. Every capability that
+defines `toExtensionId` contributes ids to the same list, and loading filters
+them out before the item reaches the session.
+
+Context files use `context-file:<level>:<basename>`, where `<level>` is `user`
+or `project`:
+
+```yaml
+disabledExtensions:
+  - context-file:user:CLAUDE.md
+```
+
+The id carries no directory and no depth, so a `project` entry disables files of
+that name at every depth the discovery walk reaches. See
+[Context files](./context-files.md#disabling-a-single-context-file).
+
 ---
 
 ## Path and entry resolution


### PR DESCRIPTION
`disabledExtensions` already filters context files by `context-file:<level>:<basename>`, but neither docs/context-files.md nor docs/extension-loading.md said so. context-files.md documented only `disabledProviders` and warned that it is heavier than it looks, without pointing at the narrower switch that solves exactly that case.

Adds a "Disabling a single context file" section with the id format, a worked table, the interaction with shadowing, and the `/extensions` entry point; cross-links it from the `disabledProviders` warning and the troubleshooting list; extends the id-format section in extension-loading.md beyond `extension-module:`.

## What

Documents that `disabledExtensions` can turn off a single context file, using the
`context-file:<level>:<basename>` id.

`docs/context-files.md` gets a "Disabling a single context file" section: the id format,
a worked table for the three common cases, how disabling interacts with shadowing, and a
pointer to `/extensions`. It is cross-linked from the `disabledProviders` warning and from
the "A file is not loaded" troubleshooting list. `docs/extension-loading.md` gains a section
noting that `disabledExtensions` is not limited to `extension-module:` ids.

No code changes.

## Why

I was looking for a way to prevent the automatic reading of instruction files. The user arguments had no effect, so I went deeper into the investigation, determined to add the feature myself.
Fortunately the capability already exists, but nothing documents it. `docs/context-files.md` covers
only `disabledProviders` and warns that it is heavier than it looks — "disabling `claude`,
for instance, also drops Claude-discovered MCP servers, commands, skills, hooks, tools, and
settings, not only `CLAUDE.md`" — without mentioning the narrower switch that solves exactly
that case. `docs/extension-loading.md` documents the id format for `extension-module:` only.

Searching the settings for a way to skip a user-level `CLAUDE.md` finds nothing: `--no-rules`,
`--no-skills`, and even replacing the prompt with `--system-prompt` all leave the file in
context, and none of the 459 documented settings keys mentions it. The answer is only
discoverable by reading `capability/context-file.ts` and `capability/index.ts`.

While documenting it I found one behavior worth stating explicitly: a disabled item is
skipped before deduplication, so it does not claim its scope and the file it used to shadow
is loaded in its place. That is easy to trip over when you expect the scope to go empty.

## Testing

omp 17.4.0, local llama.cpp-backed model, each case run as
`omp -p "<question>" --no-session --mode json --no-tools --config <overlay>`, asking the model
to quote instruction text without tool access.

1. **User level.** Baseline quoted a distinctive line from `~/.claude/CLAUDE.md` verbatim.
   With `disabledExtensions: ["context-file:user:CLAUDE.md"]` the same question answered `NONE`.
2. **Project level, all depths.** Repo with `AGENTS.md` at the root and `sub/AGENTS.md`, run
   from `sub/`: baseline returned both markers. With `context-file:project:AGENTS.md` it
   returned `NONE` — one id covers every depth, as the section now states.
3. **Shadowing promotion.** Repo with both `.claude/CLAUDE.md` and `AGENTS.md`: baseline
   returned only the `CLAUDE.md` marker. With `context-file:project:CLAUDE.md` disabled it
   returned the `AGENTS.md` marker, confirming the promotion behavior described above.

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)