### PR TITLE
fix(mcp): prefer RFC 9728 resource scopes over auth-server catalogue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP OAuth: authorization requests now use the RFC 9728 protected-resource `scopes_supported` instead of the authorization server's broad catalogue, so pre-registered clients provisioned for a subset of scopes are no longer rejected ([#9099](https://github.com/can1357/oh-my-pi/issues/9099)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -449,7 +449,7 @@ export async function discoverOAuthEndpoints(
 								: typeof metadata.public_client_id === "string"
 									? metadata.public_client_id
 									: undefined,
-				scopes: readMetadataScopes(metadata) ?? protectedScopes,
+				scopes: protectedScopes ?? readMetadataScopes(metadata),
 				resource,
 			};
 		}
@@ -473,7 +473,7 @@ export async function discoverOAuthEndpoints(
 									: typeof oauthData.public_client_id === "string"
 										? oauthData.public_client_id
 										: undefined,
-					scopes: readMetadataScopes(oauthData) ?? protectedScopes,
+					scopes: protectedScopes ?? readMetadataScopes(oauthData),
 					resource,
 				};
 			}

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -326,6 +326,52 @@ describe("resource_metadata chain", () => {
 		});
 	});
 
+	it("prefers RFC 9728 resource scopes over the auth server's broad scopes_supported", async () => {
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+
+			if (url === "https://ws.cloud.databricks.com/.well-known/oauth-protected-resource/api/2.0/mcp/genie") {
+				return new Response(
+					JSON.stringify({
+						resource: "https://ws.cloud.databricks.com/api/2.0/mcp/genie",
+						scopes_supported: ["genie", "offline_access"],
+						authorization_servers: ["https://ws.cloud.databricks.com/oidc"],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === "https://ws.cloud.databricks.com/oidc/.well-known/oauth-authorization-server") {
+				return new Response(
+					JSON.stringify({
+						issuer: "https://ws.cloud.databricks.com/oidc",
+						authorization_endpoint: "https://ws.cloud.databricks.com/oidc/v1/authorize",
+						token_endpoint: "https://ws.cloud.databricks.com/oidc/v1/token",
+						// Tenant-wide catalogue the pre-registered client is not provisioned for.
+						scopes_supported: ["email", "openid", "profile", "workspace"],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints(
+			"https://ws.cloud.databricks.com/api/2.0/mcp/genie",
+			undefined,
+			"https://ws.cloud.databricks.com/.well-known/oauth-protected-resource/api/2.0/mcp/genie",
+			{ fetch: fetchImpl },
+		);
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://ws.cloud.databricks.com/oidc/v1/authorize",
+			tokenUrl: "https://ws.cloud.databricks.com/oidc/v1/token",
+			scopes: "genie offline_access",
+			resource: "https://ws.cloud.databricks.com/api/2.0/mcp/genie",
+		});
+	});
+
 	it("threads challenge-derived scopes into endpoints discovered via resource metadata", async () => {
 		const fetchImpl = mockFetch((input: FetchInput) => {
 			const url = String(input);


### PR DESCRIPTION
## Repro
When an MCP server's RFC 9728 protected-resource metadata advertises a narrow `scopes_supported` and its authorization server also publishes a broad `scopes_supported`, OMP built the authorize request from the auth server's list. For a pre-registered client provisioned for a subset of the issuer's catalogue (e.g. Databricks managed MCP: resource requires `genie offline_access`, tenant issuer lists 54 scopes), the authorize request is rejected (`Scopes 'email openid profile' are not assigned to the client`). Reproduced with a mock fetch driving `discoverOAuthEndpoints` through the protected-resource → authorization_servers chain: before the fix `scopes` came back as the broad auth-server catalogue instead of `genie offline_access`.

## Cause
`findEndpoints` inside `discoverOAuthEndpoints` (`packages/coding-agent/src/mcp/oauth-discovery.ts`) returned `scopes: readMetadataScopes(metadata) ?? protectedScopes` on both return paths. `protectedScopes` carries the RFC 9728 resource scopes (threaded correctly, including through the recursive `authorization_servers` hop), but `metadata` on that hop is the authorization-server document. Since the issuer document publishes a non-empty `scopes_supported`, the `??` short-circuited before `protectedScopes` could apply, so resource-scoped metadata was discarded whenever the issuer advertised any scopes.

## Fix
- Flip precedence in both `findEndpoints` return paths to `protectedScopes ?? readMetadataScopes(...)`. RFC 9728 §3 makes the protected-resource document authoritative for what the resource requires; RFC 8414 `scopes_supported` is only the issuer catalogue. `protectedScopes` is only ever populated from protected-resource metadata or an RFC 6750 `scope=` challenge, so servers publishing no resource metadata are unaffected.
- Added a regression test in `test/oauth-discovery.test.ts` asserting the narrow resource scopes win when the auth server also publishes a broad `scopes_supported`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/oauth-discovery.test.ts` → 23 pass, 0 fail. Manually confirmed pre-fix the discovery returns the broad catalogue and post-fix returns `genie offline_access` for the Databricks-shaped chain. Existing scope-carrying tests (resource metadata, challenge scopes) remain green.

Fixes #9099