### PR TITLE
fix(tui): bound the resume transcript replay restart loop to stop 100% CPU livelock on --resume

### DIFF
--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Usage } from "@oh-my-pi/pi-ai";
 import { getStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { type Component, Spacer, Text, TruncatedText } from "@oh-my-pi/pi-tui";
+import { logger } from "@oh-my-pi/pi-utils";
 import type { AdvisorMessageDetails } from "../../advisor";
 import { COLLAB_PROMPT_MESSAGE_TYPE, type CollabPromptDetails } from "../../collab/protocol";
 import { settings } from "../../config/settings";
@@ -72,6 +73,18 @@ interface RenderInitialMessagesOptions {
 
 const TRANSCRIPT_RENDER_CHUNK_MESSAGES = 32;
 const TRANSCRIPT_RENDER_CHUNK_MS = 8;
+/**
+ * Upper bound on full-transcript replay restarts inside
+ * {@link UiHelpers.renderInitialMessages}. Each restart discards the staged
+ * tree and replays every message from scratch, so on a large resumed session
+ * (issue #7811: ~6k entries) a single pass takes longer than the interval
+ * between entries persisted by background sources — the restart condition
+ * becomes permanently true and an unbounded loop livelocks at 100% CPU (and,
+ * on the synchronous mid-stream path, blocks the event loop so not even
+ * SIGTERM can run). Entries that land after the final accepted pass are
+ * durable in the session file and reach the display on the next rebuild.
+ */
+const TRANSCRIPT_REPLAY_MAX_ATTEMPTS = 5;
 
 function waitForImmediate(): Promise<void> {
 	const { promise, resolve } = Promise.withResolvers<void>();
@@ -769,6 +782,7 @@ export class UiHelpers {
 			populateHistory: false,
 		};
 		let committed = false;
+		let replayAttempts = 0;
 		this.ctx.initialChatRendered = false;
 		try {
 			while (true) {
@@ -782,6 +796,23 @@ export class UiHelpers {
 				if (this.ctx.viewSession.sessionManager.getEntries().length === replayEntryCount) {
 					break;
 				}
+				replayAttempts++;
+				if (replayAttempts >= TRANSCRIPT_REPLAY_MAX_ATTEMPTS) {
+					// A source keeps persisting entries faster than a full replay pass
+					// completes. Accept the transcript just replayed instead of
+					// restarting forever (see TRANSCRIPT_REPLAY_MAX_ATTEMPTS).
+					logger.warn("renderInitialMessages: transcript replay did not converge; accepting current replay", {
+						attempts: replayAttempts,
+						replayEntryCount,
+						currentEntryCount: this.ctx.viewSession.sessionManager.getEntries().length,
+					});
+					break;
+				}
+				// Yield between passes so a restarted replay — including the fully
+				// synchronous mid-stream branch above — can never wedge the event
+				// loop: signal handlers, timers, and terminal input keep running
+				// while the replay is retried.
+				await waitForImmediate();
 
 				// An extension persisted a display message while the transcript replay
 				// yielded. The display callback stayed gated by initialChatRendered;

--- a/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
+++ b/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
@@ -734,3 +734,64 @@ describe("UiHelpers.renderSessionContext — mid-stream tool call rebuild", () =
 		expect(rendered).toContain("GROWN_TAIL_SENTINEL");
 	});
 });
+
+describe("UiHelpers.renderInitialMessages — replay convergence (issue #7811)", () => {
+	/** getEntries mock whose returned array grows on every call, simulating a
+	 * source that persists a new session entry during every replay pass. */
+	function growingEntriesCtx(): ReturnType<typeof makeCtx> & { getEntriesCalls: () => number } {
+		const made = makeCtx();
+		let calls = 0;
+		const getEntries = vi.fn(() => {
+			calls++;
+			return Array.from({ length: calls }, () => ({ type: "message" }));
+		});
+		(made.ctx.viewSession.sessionManager as unknown as { getEntries: unknown }).getEntries = getEntries;
+		(made.ctx.sessionManager as unknown as { getEntries: unknown }).getEntries = getEntries;
+		return { ...made, getEntriesCalls: () => calls };
+	}
+
+	it("terminates when entries are persisted during every replay pass", async () => {
+		// Regression: the replay restart loop was unbounded. A source persisting
+		// one entry per pass made the entry-count check permanently false, so a
+		// large resumed session replayed from scratch forever at 100% CPU
+		// (issue #7811). The loop must give up after a bounded number of
+		// restarts and accept the transcript it just replayed.
+		await Settings.init({ inMemory: true });
+		const { ctx, transcriptSpy } = growingEntriesCtx();
+
+		let settled = false;
+		const replay = new UiHelpers(ctx).renderInitialMessages().then(() => {
+			settled = true;
+		});
+		const timeout = new Promise<void>(resolve => setTimeout(resolve, 5_000));
+		await Promise.race([replay, timeout]);
+
+		expect(settled).toBeTrue();
+		// Bounded restarts: one initial context build plus at most the restart cap.
+		expect(transcriptSpy.mock.calls.length).toBeLessThanOrEqual(6);
+		expect(ctx.initialChatRendered).toBeTrue();
+	});
+
+	it("still replays once more when a single entry lands mid-replay", async () => {
+		// The intended reconciliation must survive the cap: one entry persisted
+		// during the first pass triggers exactly one restart against the fresh
+		// context, then the stable entry count exits the loop.
+		await Settings.init({ inMemory: true });
+		const { ctx, transcriptSpy } = makeCtx();
+		const lengths = [0, 1, 1, 1, 1, 1, 1, 1];
+		let call = 0;
+		const getEntries = vi.fn(() => {
+			const length = lengths[Math.min(call, lengths.length - 1)]!;
+			call++;
+			return Array.from({ length }, () => ({ type: "message" }));
+		});
+		(ctx.viewSession.sessionManager as unknown as { getEntries: unknown }).getEntries = getEntries;
+		(ctx.sessionManager as unknown as { getEntries: unknown }).getEntries = getEntries;
+
+		await new UiHelpers(ctx).renderInitialMessages();
+
+		// Initial context build + exactly one reconciliation restart.
+		expect(transcriptSpy).toHaveBeenCalledTimes(2);
+		expect(ctx.initialChatRendered).toBeTrue();
+	});
+});


### PR DESCRIPTION
Fixes #7811

## Root cause

`UiHelpers.renderInitialMessages` (`packages/coding-agent/src/modes/utils/ui-helpers.ts`) reconciles the replayed transcript against the live session inside a `while (true)` loop: if the session's entry count changed while the replay pass ran, it disposes everything and restarts the entire O(n) replay from scratch.

Two problems combine into the livelock reported in #7811:

1. **The restart loop is unbounded.** Any source that keeps persisting entries during a replay pass (background jobs, late diagnostics, async tool results landing on a resumed session) makes the entry-count-stable check permanently false, so a large session replays from scratch forever.
2. **The restart path never yields.** The dispose → rebuild restart runs back-to-back with no `await` between passes, so on a big transcript the event loop is wedged solid — which is exactly why the process pins a core at 100% and never services SIGTERM (signal handlers run as event-loop callbacks). On the reporter's 17 MB / 6117-entry session each pass is expensive enough that even occasional mid-replay writes keep it spinning indefinitely.

## Fix

- Cap reconciliation restarts at `TRANSCRIPT_REPLAY_MAX_ATTEMPTS = 5`. At the cap, log a `logger.warn` with the attempt/entry-count diagnostics and **accept the replay just completed** instead of restarting. This is safe: entries that landed mid-replay are durable in the session and will be shown by the next transcript rebuild — the initial paint just stops chasing a moving target.
- `await waitForImmediate()` between replay passes, so even while reconciling the event loop gets control back and SIGTERM/SIGINT are serviced normally.

Normal behavior is unchanged: a stable session exits the loop on the first pass, and a single entry landing mid-replay still triggers exactly one catch-up restart (covered by a test).

## Tests

Added to `test/modes/utils/render-initial-messages.test.ts` (`replay convergence (issue #7811)` describe):

- **terminates when entries are persisted during every replay pass** — a `getEntries` mock that grows on every call reproduces the livelock precondition; asserts the replay settles (raced against a 5 s timeout), builds the transcript context at most 1 + cap times, and still marks `initialChatRendered`.
- **still replays once more when a single entry lands mid-replay** — asserts the intended reconciliation survives the cap: exactly one restart (transcript built exactly twice), then convergence.

## Notes

- I couldn't reproduce the interactive TUI hang in my environment, so verification is via the unit tests above + CI. @-reporter: it would be great if you could re-test `--resume` on the original 17 MB / 6117-entry session with this branch.
- Opened as **draft** for maintainer review.