### PR TITLE
feat: strengthen Hindsight mental model seeds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Hindsight now creates the built-in User Preferences, Project Decisions, Project Workflow, and Project Pitfalls models only when each is absent, leaving existing models unchanged. Their source queries now require a claim, its evidence, when it was last observed, and a confidence, and reject unsupported, volatile, or superseded state; each refresh keeps delta + refresh-after-consolidation while excluding other mental models, pinning `all_strict` tag matching, keeping a refresh trace, and bounding its own recall budget.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3165,7 +3165,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Hindsight",
 			label: "Hindsight Mental Model Auto-Seed",
 			description:
-				"At session start, create any built-in mental models (project-conventions, project-decisions, user-preferences) that do not yet exist on the bank.",
+				"At session start, create any built-in mental models (project-workflow, project-pitfalls, project-decisions, user-preferences) that do not yet exist on the bank.",
 			condition: "hindsightActive",
 		},
 	},

--- a/packages/coding-agent/src/hindsight/mental-models.ts
+++ b/packages/coding-agent/src/hindsight/mental-models.ts
@@ -3,7 +3,10 @@
  *
  * Mental models are persisted, named summaries on the Hindsight server. They
  * are populated by a background reflect at create time and refreshed
- * automatically when consolidation runs (`refresh_after_consolidation: true`).
+ * automatically when consolidation runs (`refresh_after_consolidation: true`),
+ * under the per-seed trigger policy in `seeds.json`: a delta refresh whose
+ * scope excludes other mental models, pins its tag-match mode, keeps a refresh
+ * trace, and bounds its own recall budget (see `MentalModelSeedTrigger`).
  *
  * This module:
  *   1. **Seeds** a small, curated set of mental models on first session boot
@@ -28,7 +31,7 @@
  * Seed tags are baked from `seeds.json` plus, for `projectTagged: true`
  * entries, the active scope's `retainTags` (i.e. `project:<cwd>`). In
  * `per-project-tagged`, those project seeds also get project-suffixed ids so
- * each tag can own its conventions/decisions models in the shared bank.
+ * each tag can own its workflow/pitfalls/decisions models in the shared bank.
  * Untagged seeds (e.g. `user-preferences`) read every memory in the bank — the
  * reflect call applies no tag filter when `tags` is empty.
  *
@@ -44,12 +47,37 @@ import type { BankScope } from "./bank";
 import type {
 	HindsightApi,
 	MentalModelListResponse,
-	MentalModelMode,
 	MentalModelSummary,
 	MentalModelTrigger,
+	TagsMatch,
 } from "./client";
 import type { HindsightScoping } from "./config";
 import seedsData from "./seeds.json" with { type: "json" };
+
+/**
+ * Trigger policy a seed may carry. Extends the wire trigger with the refresh
+ * scope and recall-budget knobs Hindsight reads off the stored trigger:
+ * `exclude_mental_models` keeps a refresh from reading other curated models,
+ * `tags_match` pins the tag filter instead of inheriting the server default,
+ * `keep_trace` records why an unattended refresh produced what it did, and the
+ * three recall knobs bound the per-refresh retrieval instead of inheriting
+ * mutable bank/global defaults. The object is forwarded verbatim to
+ * `createMentalModel`, so every field here reaches the server.
+ */
+export interface MentalModelSeedTrigger extends MentalModelTrigger {
+	/** Skip the reflect loop's `search_mental_models` tool (no summary-of-summaries feedback). */
+	exclude_mental_models?: boolean;
+	/** Tag-match mode for the refresh scope. Pinned rather than inherited. */
+	tags_match?: TagsMatch;
+	/** Persist the refresh trace — the only post-hoc diagnostic for unattended refreshes. */
+	keep_trace?: boolean;
+	/** Whether the refresh's internal recall returns raw chunk text. */
+	include_chunks?: boolean;
+	/** Token budget for facts returned by the refresh's internal recall. */
+	recall_max_tokens?: number;
+	/** Token budget for raw chunks returned by the refresh's internal recall. */
+	recall_chunks_max_tokens?: number;
+}
 
 interface RawSeed {
 	id: string;
@@ -57,7 +85,7 @@ interface RawSeed {
 	source_query: string;
 	scopes: HindsightScoping[];
 	projectTagged: boolean;
-	trigger?: { mode?: MentalModelMode; refresh_after_consolidation?: boolean };
+	trigger?: MentalModelSeedTrigger;
 	max_tokens?: number;
 	extra_tags?: string[];
 }
@@ -76,7 +104,7 @@ export interface MentalModelSeed {
 	maxTokens?: number;
 	/** Legacy unqualified seed ids accepted as already-present when tags match. */
 	legacyIds?: string[];
-	trigger?: MentalModelTrigger;
+	trigger?: MentalModelSeedTrigger;
 }
 
 /**

--- a/packages/coding-agent/src/hindsight/seeds.json
+++ b/packages/coding-agent/src/hindsight/seeds.json
@@ -7,7 +7,7 @@
 			"source_query": "What durable preferences does the user hold for coding style, tooling, workflow, communication, and review? Include a preference only when separate sessions support it or the user stated it as a standing rule. For each entry give the preference as a directive claim, the evidence behind it (what the user said or repeatedly did), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported guesses, one-off requests, task-specific instructions, and volatile in-flight state. When two preferences conflict, keep the most recent and drop the superseded one. Keep only entries expected to still hold in six months.",
 			"scopes": ["global", "per-project", "per-project-tagged"],
 			"projectTagged": false,
-			"max_tokens": 600,
+			"max_tokens": 900,
 			"trigger": {
 				"mode": "delta",
 				"refresh_after_consolidation": true,
@@ -25,7 +25,7 @@
 			"source_query": "What established build, test, release, review, and development workflows does this project follow? Include a workflow only when a repository source (script, config, CI definition, documented command) or repeated practice supports it. For each entry give the workflow as an actionable claim, the evidence behind it (command, file, or repeated observation), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported guesses, one-off commands, and volatile state such as in-flight tasks, branches, or incidents. Drop any workflow superseded by a newer command or tool. Keep only entries expected to still hold in six months.",
 			"scopes": ["per-project", "per-project-tagged"],
 			"projectTagged": true,
-			"max_tokens": 800,
+			"max_tokens": 1200,
 			"trigger": {
 				"mode": "delta",
 				"refresh_after_consolidation": true,
@@ -43,7 +43,7 @@
 			"source_query": "What recurring failures, hazards, or sharp edges affect this project, and what durable mitigation is established for each? Include a pitfall only when it was observed more than once or carries an evidenced mitigation. For each entry give the failure mode and its mitigation as a claim, the evidence behind it (error, incident, or landed fix), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported or speculative risks and volatile state such as a single transient outage or an open investigation. Drop any pitfall a landed fix has superseded. Keep only entries expected to still hold in six months.",
 			"scopes": ["per-project", "per-project-tagged"],
 			"projectTagged": true,
-			"max_tokens": 800,
+			"max_tokens": 1200,
 			"trigger": {
 				"mode": "delta",
 				"refresh_after_consolidation": true,
@@ -61,7 +61,7 @@
 			"source_query": "What durable architectural or product decisions govern this project, and what rationale or trade-off was recorded for each? Include a decision only when it was actually adopted, not merely proposed. For each entry give the decision as a claim, the evidence behind it (where it was decided or where it is enforced), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported guesses and volatile state such as proposals, open questions, and in-flight plans. When decisions conflict, keep the one that superseded the others and say what it replaced. Keep only entries expected to still hold in six months.",
 			"scopes": ["per-project", "per-project-tagged"],
 			"projectTagged": true,
-			"max_tokens": 800,
+			"max_tokens": 1200,
 			"trigger": {
 				"mode": "delta",
 				"refresh_after_consolidation": true,

--- a/packages/coding-agent/src/hindsight/seeds.json
+++ b/packages/coding-agent/src/hindsight/seeds.json
@@ -1,32 +1,77 @@
 {
-	"$schema_doc": "Built-in mental model seeds. Each entry is created once per bank if absent. Existing models are NEVER modified by the bootstrap path — operators who want to change a curated model must delete and re-seed (or call refreshMentalModel for a content-only refresh). Tags must intersect the tags actually attached to retains, otherwise refresh returns empty (Hindsight all_strict matching). Source queries live here and not in TS so changes are reviewable as data, not code. `max_tokens` bounds server-side reflect generation per model; a separate client-side render budget bounds the total injected block.",
+	"$schema_doc": "Built-in mental model seeds. Each entry is created once per bank if absent. Existing models are NEVER modified by the bootstrap path — operators who want to change a curated model must delete and re-seed (or call refreshMentalModel for a content-only refresh). Tags must intersect the tags actually attached to retains, otherwise refresh returns empty (Hindsight all_strict matching). Source queries live here and not in TS so changes are reviewable as data, not code. `max_tokens` bounds server-side reflect generation per model; a separate client-side render budget bounds the total injected block. Every seed carries the same trigger policy: `delta` + `refresh_after_consolidation` keeps the normal incremental refresh; `exclude_mental_models` keeps a refresh from reading other curated models (no summary-of-summaries feedback); `tags_match: all_strict` pins the tag filter instead of inheriting the server default (a no-op filter for untagged seeds, strict isolation for project-tagged ones); `keep_trace` is the only way to diagnose a consolidation-driven refresh after the fact; and `include_chunks` / `recall_max_tokens` / `recall_chunks_max_tokens` pin the per-refresh recall budget instead of inheriting mutable bank/global defaults. Chunk text stays on because these queries demand evidence per entry and the bank retains verbatim, but both token budgets are pinned so the evidence channel stays bounded.",
 	"seeds": [
 		{
 			"id": "user-preferences",
 			"name": "User Preferences",
-			"source_query": "What does the user prefer in coding style, tooling, communication, and review? Capture only durable preferences expressed across sessions, not one-off requests.",
+			"source_query": "What durable preferences does the user hold for coding style, tooling, workflow, communication, and review? Include a preference only when separate sessions support it or the user stated it as a standing rule. For each entry give the preference as a directive claim, the evidence behind it (what the user said or repeatedly did), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported guesses, one-off requests, task-specific instructions, and volatile in-flight state. When two preferences conflict, keep the most recent and drop the superseded one. Keep only entries expected to still hold in six months.",
 			"scopes": ["global", "per-project", "per-project-tagged"],
 			"projectTagged": false,
 			"max_tokens": 600,
-			"trigger": { "mode": "delta", "refresh_after_consolidation": true }
+			"trigger": {
+				"mode": "delta",
+				"refresh_after_consolidation": true,
+				"exclude_mental_models": true,
+				"tags_match": "all_strict",
+				"keep_trace": true,
+				"include_chunks": true,
+				"recall_max_tokens": 8000,
+				"recall_chunks_max_tokens": 3000
+			}
 		},
 		{
-			"id": "project-conventions",
-			"name": "Project Conventions",
-			"source_query": "What are this project's conventions for code style, build, testing, release, and pull-request review? Only include conventions that are explicit in the project (settings, scripts, contributor docs, repeatedly enforced in review).",
+			"id": "project-workflow",
+			"name": "Project Workflow",
+			"source_query": "What established build, test, release, review, and development workflows does this project follow? Include a workflow only when a repository source (script, config, CI definition, documented command) or repeated practice supports it. For each entry give the workflow as an actionable claim, the evidence behind it (command, file, or repeated observation), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported guesses, one-off commands, and volatile state such as in-flight tasks, branches, or incidents. Drop any workflow superseded by a newer command or tool. Keep only entries expected to still hold in six months.",
 			"scopes": ["per-project", "per-project-tagged"],
 			"projectTagged": true,
 			"max_tokens": 800,
-			"trigger": { "mode": "delta", "refresh_after_consolidation": true }
+			"trigger": {
+				"mode": "delta",
+				"refresh_after_consolidation": true,
+				"exclude_mental_models": true,
+				"tags_match": "all_strict",
+				"keep_trace": true,
+				"include_chunks": true,
+				"recall_max_tokens": 8000,
+				"recall_chunks_max_tokens": 3000
+			}
+		},
+		{
+			"id": "project-pitfalls",
+			"name": "Project Pitfalls",
+			"source_query": "What recurring failures, hazards, or sharp edges affect this project, and what durable mitigation is established for each? Include a pitfall only when it was observed more than once or carries an evidenced mitigation. For each entry give the failure mode and its mitigation as a claim, the evidence behind it (error, incident, or landed fix), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported or speculative risks and volatile state such as a single transient outage or an open investigation. Drop any pitfall a landed fix has superseded. Keep only entries expected to still hold in six months.",
+			"scopes": ["per-project", "per-project-tagged"],
+			"projectTagged": true,
+			"max_tokens": 800,
+			"trigger": {
+				"mode": "delta",
+				"refresh_after_consolidation": true,
+				"exclude_mental_models": true,
+				"tags_match": "all_strict",
+				"keep_trace": true,
+				"include_chunks": true,
+				"recall_max_tokens": 8000,
+				"recall_chunks_max_tokens": 3000
+			}
 		},
 		{
 			"id": "project-decisions",
 			"name": "Project Decisions",
-			"source_query": "What durable architectural or product decisions have been made for this project, and what rationale or trade-offs were recorded? Include only decisions that are stable across sessions; exclude transient plans, unresolved ideas, and active task state.",
+			"source_query": "What durable architectural or product decisions govern this project, and what rationale or trade-off was recorded for each? Include a decision only when it was actually adopted, not merely proposed. For each entry give the decision as a claim, the evidence behind it (where it was decided or where it is enforced), when it was last observed, and a confidence of high, medium, or low. Exclude unsupported guesses and volatile state such as proposals, open questions, and in-flight plans. When decisions conflict, keep the one that superseded the others and say what it replaced. Keep only entries expected to still hold in six months.",
 			"scopes": ["per-project", "per-project-tagged"],
 			"projectTagged": true,
 			"max_tokens": 800,
-			"trigger": { "mode": "delta", "refresh_after_consolidation": true }
+			"trigger": {
+				"mode": "delta",
+				"refresh_after_consolidation": true,
+				"exclude_mental_models": true,
+				"tags_match": "all_strict",
+				"keep_trace": true,
+				"include_chunks": true,
+				"recall_max_tokens": 8000,
+				"recall_chunks_max_tokens": 3000
+			}
 		}
 	]
 }

--- a/packages/coding-agent/test/hindsight-mental-models.test.ts
+++ b/packages/coding-agent/test/hindsight-mental-models.test.ts
@@ -6,6 +6,7 @@ import {
 	type MentalModelSummary,
 } from "@oh-my-pi/pi-coding-agent/hindsight/client";
 import {
+	builtinSeedsForTest,
 	diffMentalModelContent,
 	ensureMentalModels,
 	loadMentalModelsBlock,
@@ -19,6 +20,87 @@ afterEach(() => {
 });
 
 /* -------------------------------------------------------------------------- */
+/* seeds.json — the built-in taxonomy, encoded as data                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The trigger policy every built-in seed must carry. `delta` +
+ * `refresh_after_consolidation` is the normal Hindsight refresh path; the rest
+ * pins refresh scope and recall budget so a curated model can never read other
+ * mental models, inherit a mutable server-side recall default, or refresh
+ * unattended without leaving a trace.
+ */
+const SEED_TRIGGER = {
+	mode: "delta",
+	refresh_after_consolidation: true,
+	exclude_mental_models: true,
+	tags_match: "all_strict",
+	keep_trace: true,
+	include_chunks: true,
+	recall_max_tokens: 8000,
+	recall_chunks_max_tokens: 3000,
+};
+
+describe("builtin seeds", () => {
+	it("encodes exactly the four-model taxonomy — no architecture or environment seed", () => {
+		expect(builtinSeedsForTest.map(seed => seed.id)).toEqual([
+			"user-preferences",
+			"project-workflow",
+			"project-pitfalls",
+			"project-decisions",
+		]);
+		expect(builtinSeedsForTest.map(seed => seed.name)).toEqual([
+			"User Preferences",
+			"Project Workflow",
+			"Project Pitfalls",
+			"Project Decisions",
+		]);
+	});
+
+	it("keeps user preferences global and untagged while project models stay project-tagged", () => {
+		const preferences = builtinSeedsForTest.find(seed => seed.id === "user-preferences");
+		expect(preferences?.scopes).toEqual(["global", "per-project", "per-project-tagged"]);
+		expect(preferences?.projectTagged).toBe(false);
+		expect(preferences?.max_tokens).toBe(600);
+		for (const id of ["project-workflow", "project-pitfalls", "project-decisions"]) {
+			const seed = builtinSeedsForTest.find(candidate => candidate.id === id);
+			expect(seed?.scopes).toEqual(["per-project", "per-project-tagged"]);
+			expect(seed?.projectTagged).toBe(true);
+			expect(seed?.max_tokens).toBe(800);
+		}
+	});
+
+	it("gives every seed the same bounded, non-inheriting trigger policy", () => {
+		for (const seed of builtinSeedsForTest) {
+			expect(seed.trigger).toEqual(SEED_TRIGGER);
+		}
+	});
+
+	it("requires claim, evidence, recency, and confidence from every source query", () => {
+		for (const seed of builtinSeedsForTest) {
+			const query = seed.source_query.toLowerCase();
+			expect(query).toContain("claim");
+			expect(query).toContain("evidence");
+			expect(query).toContain("last observed");
+			expect(query).toContain("confidence of high, medium, or low");
+		}
+	});
+
+	it("makes every source query exclude unsupported, volatile, and superseded state", () => {
+		for (const seed of builtinSeedsForTest) {
+			const query = seed.source_query.toLowerCase();
+			expect(query).toContain("exclude");
+			expect(query).toContain("unsupported");
+			expect(query).toMatch(/volatile|one-off|one-time|speculative/);
+			expect(query).toMatch(/supersede/);
+			// Six-month usefulness is the whole point of a curated model: a
+			// query that admits short-lived state churns on every refresh.
+			expect(query).toContain("six months");
+		}
+	});
+});
+
+/* -------------------------------------------------------------------------- */
 /* resolveSeedsForScope                                                        */
 /* -------------------------------------------------------------------------- */
 
@@ -27,20 +109,14 @@ afterEach(() => {
 // matching). Tag derivation MUST stay disciplined per scoping mode.
 
 describe("resolveSeedsForScope", () => {
-	it("global scoping emits only seeds whose scopes include 'global', and never project-tagged ones", () => {
+	it("global scoping emits only untagged user preferences", () => {
 		const scope: BankScope = { bankId: "omp" };
 		const seeds = resolveSeedsForScope(scope, "global");
-		expect(seeds.length).toBeGreaterThan(0);
-		// project-conventions is per-project only — must not appear.
-		expect(seeds.some(s => s.id === "project-conventions")).toBe(false);
-		// user-preferences applies to every scope.
-		const userPrefs = seeds.find(s => s.id === "user-preferences");
-		expect(userPrefs).toBeDefined();
-		// In global mode there is no project axis, so untagged seeds carry no tags.
-		expect(userPrefs?.tags).toEqual([]);
+		expect(seeds.map(seed => seed.id)).toEqual(["user-preferences"]);
+		expect(seeds[0].tags).toEqual([]);
 	});
 
-	it("per-project-tagged scoping bakes the scope's retainTags into projectTagged seeds and leaves untagged seeds bare", () => {
+	it("per-project-tagged scoping emits the exact project taxonomy with project-qualified ids", () => {
 		const scope: BankScope = {
 			bankId: "omp",
 			retainTags: ["project:omp"],
@@ -48,24 +124,39 @@ describe("resolveSeedsForScope", () => {
 			recallTagsMatch: "any",
 		};
 		const seeds = resolveSeedsForScope(scope, "per-project-tagged");
-		const projectConv = seeds.find(s => s.id === "project-conventions-omp");
-		const userPrefs = seeds.find(s => s.id === "user-preferences");
-		expect(projectConv?.legacyIds).toEqual(["project-conventions"]);
-		expect(projectConv?.tags).toEqual(["project:omp"]);
-		// user-preferences is intentionally untagged so the refresh reads the
-		// whole bank, not just the project subset.
-		expect(userPrefs?.tags).toEqual([]);
+		expect(seeds.map(seed => seed.id).toSorted()).toEqual([
+			"project-decisions-omp",
+			"project-pitfalls-omp",
+			"project-workflow-omp",
+			"user-preferences",
+		]);
+
+		const userPreferences = seeds.find(seed => seed.id === "user-preferences");
+		expect(userPreferences?.tags).toEqual([]);
+		for (const [id, legacyId] of [
+			["project-decisions-omp", "project-decisions"],
+			["project-workflow-omp", "project-workflow"],
+			["project-pitfalls-omp", "project-pitfalls"],
+		] as const) {
+			const projectSeed = seeds.find(seed => seed.id === id);
+			expect(projectSeed?.tags).toEqual(["project:omp"]);
+			expect(projectSeed?.legacyIds).toEqual([legacyId]);
+		}
 	});
 
-	it("per-project scoping yields project-conventions but the scope carries no tags so the seed is untagged", () => {
+	it("per-project scoping emits the exact unsuffixed taxonomy with the built-in trigger policy", () => {
 		const scope: BankScope = { bankId: "omp-myproj" };
 		const seeds = resolveSeedsForScope(scope, "per-project");
-		const projectConv = seeds.find(s => s.id === "project-conventions");
-		expect(projectConv).toBeDefined();
-		// per-project mode isolates via bank id, not tags. retainTags is undefined,
-		// so projectTagged seeds resolve to no tags. This is correct: the bank is
-		// already a per-project silo.
-		expect(projectConv?.tags).toEqual([]);
+		expect(seeds.map(seed => seed.id).toSorted()).toEqual([
+			"project-decisions",
+			"project-pitfalls",
+			"project-workflow",
+			"user-preferences",
+		]);
+		for (const seed of seeds) {
+			expect(seed.tags).toEqual([]);
+			expect(seed.trigger).toEqual(SEED_TRIGGER);
+		}
 	});
 });
 
@@ -74,7 +165,14 @@ describe("resolveSeedsForScope", () => {
 /* -------------------------------------------------------------------------- */
 
 interface FakeApiCalls {
-	created: Array<{ id: string | undefined; name: string; sourceQuery: string; tags?: string[] }>;
+	created: Array<{
+		id: string | undefined;
+		name: string;
+		sourceQuery: string;
+		tags?: string[];
+		maxTokens?: number;
+		trigger?: unknown;
+	}>;
 }
 
 function makeFakeApi(existing: MentalModelSummary[]): { api: HindsightApi; calls: FakeApiCalls } {
@@ -85,9 +183,16 @@ function makeFakeApi(existing: MentalModelSummary[]): { api: HindsightApi; calls
 			_bankId: string,
 			name: string,
 			sourceQuery: string,
-			options: { id?: string; tags?: string[] },
+			options: { id?: string; tags?: string[]; maxTokens?: number; trigger?: unknown },
 		) => {
-			calls.created.push({ id: options.id, name, sourceQuery, tags: options.tags });
+			calls.created.push({
+				id: options.id,
+				name,
+				sourceQuery,
+				tags: options.tags,
+				maxTokens: options.maxTokens,
+				trigger: options.trigger,
+			});
 			return { operation_id: `op-${calls.created.length}` };
 		},
 	} as unknown as HindsightApi;
@@ -102,20 +207,20 @@ describe("ensureMentalModels", () => {
 			"omp",
 			[
 				{ id: "user-preferences", name: "User Preferences", sourceQuery: "q1", tags: [] },
-				{ id: "project-conventions", name: "Project Conventions", sourceQuery: "q2", tags: ["project:omp"] },
+				{ id: "project-workflow", name: "Project Workflow", sourceQuery: "q2", tags: ["project:omp"] },
 			],
 			false,
 		);
 		expect(calls.created).toHaveLength(1);
-		expect(calls.created[0].id).toBe("project-conventions");
+		expect(calls.created[0].id).toBe("project-workflow");
 		expect(calls.created[0].tags).toEqual(["project:omp"]);
 	});
 
 	it("matches legacy bare project seeds only when their tags match the active project", async () => {
 		const legacyProjectA: MentalModelSummary = {
-			id: "project-conventions",
+			id: "project-workflow",
 			bank_id: "omp",
-			name: "Project Conventions",
+			name: "Project Workflow",
 			tags: ["project:a"],
 		};
 
@@ -125,11 +230,11 @@ describe("ensureMentalModels", () => {
 			"omp",
 			[
 				{
-					id: "project-conventions-a",
-					name: "Project Conventions",
+					id: "project-workflow-a",
+					name: "Project Workflow",
 					sourceQuery: "q",
 					tags: ["project:a"],
-					legacyIds: ["project-conventions"],
+					legacyIds: ["project-workflow"],
 				},
 			],
 			false,
@@ -142,17 +247,17 @@ describe("ensureMentalModels", () => {
 			"omp",
 			[
 				{
-					id: "project-conventions-b",
-					name: "Project Conventions",
+					id: "project-workflow-b",
+					name: "Project Workflow",
 					sourceQuery: "q",
 					tags: ["project:b"],
-					legacyIds: ["project-conventions"],
+					legacyIds: ["project-workflow"],
 				},
 			],
 			false,
 		);
 		expect(differentProject.calls.created).toHaveLength(1);
-		expect(differentProject.calls.created[0].id).toBe("project-conventions-b");
+		expect(differentProject.calls.created[0].id).toBe("project-workflow-b");
 	});
 
 	it("does not modify existing models even if their fields drift from the seed list", async () => {
@@ -192,6 +297,35 @@ describe("ensureMentalModels", () => {
 			ensureMentalModels(api, "omp", [{ id: "x", name: "X", sourceQuery: "q", tags: [] }], false),
 		).resolves.toBeUndefined();
 		expect(calls.created).toHaveLength(0);
+	});
+
+	it("forwards each resolved seed's tags, token cap, and trigger policy to createMentalModel", async () => {
+		const { api, calls } = makeFakeApi([]);
+		const seeds = resolveSeedsForScope(
+			{ bankId: "omp", retainTags: ["project:omp"], recallTags: ["project:omp"], recallTagsMatch: "any" },
+			"per-project-tagged",
+		);
+		await ensureMentalModels(api, "omp", seeds, false);
+
+		expect(calls.created.map(call => call.id)).toEqual([
+			"user-preferences",
+			"project-workflow-omp",
+			"project-pitfalls-omp",
+			"project-decisions-omp",
+		]);
+		for (const call of calls.created) {
+			expect(call.trigger).toEqual(SEED_TRIGGER);
+		}
+
+		const preferences = calls.created.find(call => call.id === "user-preferences");
+		// Untagged on purpose: an empty tag list must reach the wire as absent,
+		// otherwise the refresh filters against a tag we never retain with.
+		expect(preferences?.tags).toBeUndefined();
+		expect(preferences?.maxTokens).toBe(600);
+
+		const workflow = calls.created.find(call => call.id === "project-workflow-omp");
+		expect(workflow?.tags).toEqual(["project:omp"]);
+		expect(workflow?.maxTokens).toBe(800);
 	});
 });
 

--- a/packages/coding-agent/test/hindsight-mental-models.test.ts
+++ b/packages/coding-agent/test/hindsight-mental-models.test.ts
@@ -61,12 +61,12 @@ describe("builtin seeds", () => {
 		const preferences = builtinSeedsForTest.find(seed => seed.id === "user-preferences");
 		expect(preferences?.scopes).toEqual(["global", "per-project", "per-project-tagged"]);
 		expect(preferences?.projectTagged).toBe(false);
-		expect(preferences?.max_tokens).toBe(600);
+		expect(preferences?.max_tokens).toBe(900);
 		for (const id of ["project-workflow", "project-pitfalls", "project-decisions"]) {
 			const seed = builtinSeedsForTest.find(candidate => candidate.id === id);
 			expect(seed?.scopes).toEqual(["per-project", "per-project-tagged"]);
 			expect(seed?.projectTagged).toBe(true);
-			expect(seed?.max_tokens).toBe(800);
+			expect(seed?.max_tokens).toBe(1200);
 		}
 	});
 
@@ -321,11 +321,11 @@ describe("ensureMentalModels", () => {
 		// Untagged on purpose: an empty tag list must reach the wire as absent,
 		// otherwise the refresh filters against a tag we never retain with.
 		expect(preferences?.tags).toBeUndefined();
-		expect(preferences?.maxTokens).toBe(600);
+		expect(preferences?.maxTokens).toBe(900);
 
 		const workflow = calls.created.find(call => call.id === "project-workflow-omp");
 		expect(workflow?.tags).toEqual(["project:omp"]);
-		expect(workflow?.maxTokens).toBe(800);
+		expect(workflow?.maxTokens).toBe(1200);
 	});
 });
 


### PR DESCRIPTION
Replace broad built-in Hindsight mental models with evidence-gated User Preferences, Project Decisions, Project Workflow, and Project Pitfalls seeds. Each seed preserves delta refresh, excludes other mental models from recall, enables full trace/chunk evidence, and uses bounded recall and output budgets. Legacy broad IDs are cleaned up only after all replacement models exist. The managed render budget is raised separately in the deployment repository.\n\nValidation: `bun test test/hindsight-mental-models.test.ts` (25 pass). `bun run check` could not run in the isolated worktree because project dependencies, including Biome, are not installed.