### PR TITLE
feat(coding-agent): model hub fallback-to-primary promotion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- The `/model` Roles panel's `[`/`]` fallback reordering now supports promoting a fallback into the primary slot: pressing `[` on a role's front fallback entry swaps it with the role's current primary (demoting the primary into the vacated chain slot) instead of no-op'ing at the chain boundary. Scoped to role-keyed chains with an explicit primary — model/provider-keyed chains and roles still on auto-selection have no primary slot to promote into.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -31,7 +31,18 @@ import type { ModelRegistry } from "../../config/model-registry";
 import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValue } from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
-import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
+import {
+	formatRetryFallbackSelector,
+	isRetryFallbackWildcardKey,
+	parseRetryFallbackChainEntry,
+	parseRetryFallbackSelector,
+} from "../../session/retry-fallback-chains";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	concreteThinkingLevel,
+	getConfiguredThinkingLevelMetadata,
+} from "../../thinking";
 import { theme } from "../theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import {
@@ -79,14 +90,19 @@ export interface ScopedModelItem {
 export type ModelRoleSelectionScope = "global" | "project";
 
 export interface ModelHubCallbacks {
-	/** Persist a role assignment. */
+	/**
+	 * Persist a role assignment. An explicit `false` (sync or resolved) tells a
+	 * caller that derives further state from the assignment (e.g. promoting a
+	 * fallback) that it did not apply, so it must not persist that derived
+	 * state; any other return, including `void`, is treated as success.
+	 */
 	onAssign: (
 		model: Model,
 		role: string,
 		thinkingLevel: ConfiguredThinkingLevel | undefined,
 		selector: string,
 		scope?: ModelRoleSelectionScope,
-	) => void;
+	) => void | boolean | Promise<void | boolean>;
 	/** Clear a configured role back to auto-selection. */
 	onUnassign: (role: string, scope?: ModelRoleSelectionScope) => void;
 	/** Persist a `retry.fallbackChains` entry — keyed by a role, `provider/model-id`, or `provider/*`; an empty chain clears the key. */
@@ -211,6 +227,15 @@ export class ModelHubComponent implements Component {
 	#roleScrollStart = 0;
 	/** Roles rows actually drawn this frame; bounds mouse hit-testing to the visible window. */
 	#rolesVisibleCount = 0;
+	/**
+	 * Roles whose front-fallback promotion is awaiting an async `onAssign`
+	 * result. While a role is in this set, every mutation of its primary or
+	 * chain is rejected: without this, a `[`/`]`/`x`/Enter pressed during the
+	 * gap could persist a chain edit that the promotion's own eventual write
+	 * (still holding a stale pre-await snapshot) then silently overwrites, or
+	 * vice versa — either way discarding one of the two edits.
+	 */
+	#pendingPromotions = new Set<string>();
 
 	#assigning: AssignTarget | null = null;
 	#strip: StripState | null = null;
@@ -784,8 +809,14 @@ export class ModelHubComponent implements Component {
 		return resolved.explicitThinkingLevel ? (resolved.thinkingLevel ?? ThinkingLevel.Inherit) : ThinkingLevel.Inherit;
 	}
 
-	/** Persist `role → item`, preserving a still-supported thinking level, then open the thinking strip. */
+	/**
+	 * Persist `role → item`, preserving a still-supported thinking level,
+	 * then open the thinking strip. Rejects while `role`'s promotion is
+	 * pending — it would otherwise race the promotion's own `onAssign` call
+	 * for the same role.
+	 */
 	#assignRole(item: ModelBrowserItem, role: string, returnToRoles: boolean, scope?: ModelRoleSelectionScope): void {
+		if (this.#pendingPromotions.has(role)) return;
 		if (this.#settings.get("modelRoleStorage") === "project" && scope === undefined) {
 			this.#openScopeStrip(item, role, returnToRoles);
 			return;
@@ -806,15 +837,18 @@ export class ModelHubComponent implements Component {
 	}
 
 	#unassignRole(role: string): void {
+		if (this.#pendingPromotions.has(role)) return;
 		const assignment = this.#roles[role];
 		if (!assignment || assignment.autoSelected) return;
-		if (this.#settings.get("modelRoleStorage") === "project") {
-			const source = this.#settings.getModelRoleSource(role);
-			this.#callbacks.onUnassign(role, source === "default" ? undefined : source);
-		} else {
-			this.#callbacks.onUnassign(role);
-		}
+		this.#callbacks.onUnassign(role, this.#roleStorageScope(role));
 		this.#refreshAfterMutation();
+	}
+
+	/** The scope a persisted write to `role` should carry: its current storage source under project storage, else `undefined`. */
+	#roleStorageScope(role: string): ModelRoleSelectionScope | undefined {
+		if (this.#settings.get("modelRoleStorage") !== "project") return undefined;
+		const source = this.#settings.getModelRoleSource(role);
+		return source === "default" ? undefined : source;
 	}
 
 	#thinkingOptionsFor(model: Model): ConfiguredThinkingLevel[] {
@@ -931,7 +965,7 @@ export class ModelHubComponent implements Component {
 				}
 				return;
 			case "unassign":
-				if (chip.role) {
+				if (chip.role && !this.#pendingPromotions.has(chip.role)) {
 					if (this.#settings.get("modelRoleStorage") === "project") {
 						this.#callbacks.onUnassign(chip.role, chip.scope);
 					} else {
@@ -960,7 +994,7 @@ export class ModelHubComponent implements Component {
 				}
 				return;
 			case "thinking":
-				if (strip.role && chip.thinkingLevel !== undefined) {
+				if (strip.role && chip.thinkingLevel !== undefined && !this.#pendingPromotions.has(strip.role)) {
 					this.#callbacks.onAssign(
 						strip.item.model,
 						strip.role,
@@ -1029,6 +1063,7 @@ export class ModelHubComponent implements Component {
 
 	/** Write the picked model into the target chain slot, dedupe, and land back on its Roles row. */
 	#commitFallback(item: ModelBrowserItem, target: { role: string; index: number | null }): void {
+		if (this.#pendingPromotions.has(target.role)) return;
 		const chain = [...(this.#fallbackChains()[target.role] ?? [])];
 		const selector = item.selector;
 		if (target.index !== null && target.index < chain.length) {
@@ -1049,8 +1084,16 @@ export class ModelHubComponent implements Component {
 		if (rowIndex >= 0) this.#roleIndex = rowIndex;
 	}
 
-	/** Persist `role`'s chain through the host callback and rebuild dependent state. */
+	/**
+	 * Persist `role`'s chain through the host callback and rebuild dependent
+	 * state. Rejects while `role`'s promotion is pending — the central
+	 * choke point for every chain-mutating path (append/replace/remove/
+	 * reorder/clear), so a promotion can never race a concurrent edit; the
+	 * promotion's own eventual write bypasses this by removing itself from
+	 * `#pendingPromotions` first.
+	 */
 	#setFallbackChain(role: string, chain: string[]): void {
+		if (this.#pendingPromotions.has(role)) return;
 		this.#callbacks.onFallbackChainChange?.(role, chain);
 		this.#refreshAfterMutation();
 	}
@@ -1065,6 +1108,7 @@ export class ModelHubComponent implements Component {
 
 	/** Remove one chain entry; the cursor stays on the nearest surviving row. */
 	#removeFallback(row: { role: string; chainIndex: number }): void {
+		if (this.#pendingPromotions.has(row.role)) return;
 		const chain = [...(this.#fallbackChains()[row.role] ?? [])];
 		if (row.chainIndex >= chain.length) return;
 		chain.splice(row.chainIndex, 1);
@@ -1072,14 +1116,90 @@ export class ModelHubComponent implements Component {
 		this.#roleIndex = Math.min(this.#roleIndex, Math.max(0, this.#rolesRows.length - 1));
 	}
 
-	/** Move a chain entry one slot earlier/later; the cursor follows the moved entry. */
+	/**
+	 * Move a chain entry one slot earlier/later; the cursor follows the moved
+	 * entry. Moving the front entry earlier promotes it to `row.role`'s
+	 * primary model instead, demoting the current primary into its slot.
+	 */
 	#moveFallback(row: { role: string; chainIndex: number }, delta: -1 | 1): void {
+		if (this.#pendingPromotions.has(row.role)) return;
 		const chain = [...(this.#fallbackChains()[row.role] ?? [])];
+		if (row.chainIndex >= chain.length) return;
 		const target = row.chainIndex + delta;
-		if (row.chainIndex >= chain.length || target < 0 || target >= chain.length) return;
+		if (target < 0) {
+			void this.#promoteFallback(row.role, chain);
+			return;
+		}
+		if (target >= chain.length) return;
 		[chain[row.chainIndex], chain[target]] = [chain[target], chain[row.chainIndex]];
 		this.#setFallbackChain(row.role, chain);
 		this.#roleIndex += delta;
+	}
+
+	/**
+	 * Swap `role`'s primary model with the front of its fallback chain,
+	 * preserving each side's thinking level. The front entry is resolved
+	 * with `parseRetryFallbackChainEntry` against the primary as `current`,
+	 * so a `provider/*`/`provider/prefix/*` wildcard entry promotes to the
+	 * same concrete model runtime fallback recovery would pick — not just a
+	 * literal `provider/id` selector. A front entry's own `:level` suffix
+	 * wins; an unsuffixed entry inherits the current primary's level instead
+	 * of resetting to `Inherit`, matching the runtime fallback's
+	 * `selector.thinkingLevel ?? currentThinkingLevel` carry-over
+	 * (`turn-recovery.ts`). No-op for model/provider-keyed chains (they have
+	 * no primary to swap into), for roles without an explicit primary
+	 * (nothing to demote), for a front entry whose resolved model is no
+	 * longer available, for a role already promoting, and — since
+	 * `onAssign` may validate/switch asynchronously (e.g. a failed provider
+	 * switch) — for an assignment that reports it did not apply: the chain
+	 * is left untouched so a rejected promotion cannot demote the primary
+	 * out from under it. `role` is added to `#pendingPromotions` for the
+	 * async gap so every other role/chain mutation (see `#setFallbackChain`,
+	 * `#assignRole`, `#unassignRole`) rejects input instead of racing this
+	 * call's captured `primary`/`chain` snapshot with the eventual
+	 * demote-write.
+	 */
+	async #promoteFallback(role: string, chain: readonly string[]): Promise<void> {
+		if (this.#pendingPromotions.has(role)) return;
+		if (!this.#visibleRoleIds().includes(role)) return;
+		const primary = this.#roles[role];
+		if (!primary || primary.autoSelected) return;
+		const currentSelector = parseRetryFallbackSelector(
+			`${primary.model.provider}/${primary.model.id}`,
+			this.#registry,
+		);
+		if (!currentSelector) return;
+		const parsed = parseRetryFallbackChainEntry(this.#registry, chain[0], currentSelector);
+		if (!parsed) return;
+		const promoted = this.#availableItems.find(
+			item => item.model.provider === parsed.provider && item.model.id === parsed.id,
+		);
+		if (!promoted) return;
+		let level: ConfiguredThinkingLevel = parsed.thinkingLevel ?? primary.thinkingLevel;
+		if (!this.#thinkingOptionsFor(promoted.model).includes(level)) level = ThinkingLevel.Inherit;
+		const scope = this.#roleStorageScope(role);
+		this.#pendingPromotions.add(role);
+		this.#tui.requestRender();
+		let applied: void | boolean;
+		try {
+			applied = await this.#callbacks.onAssign(promoted.model, role, level, promoted.selector, scope);
+		} finally {
+			this.#pendingPromotions.delete(role);
+		}
+		if (applied === false) {
+			this.#tui.requestRender();
+			return;
+		}
+		const demotedSelector = formatRetryFallbackSelector(primary.model, concreteThinkingLevel(primary.thinkingLevel));
+		// A wildcard front entry (`provider/*`, `provider/prefix/*`) is a
+		// standing provider-level rule, not a one-off pick — it resolves fresh
+		// against whatever the primary becomes, so promoting through it keeps
+		// it in the chain (now behind the newly demoted primary) instead of
+		// consuming it. Only a concrete front entry, whose selector IS the
+		// promoted model, gets replaced by the demoted primary.
+		const restOfChain = isRetryFallbackWildcardKey(chain[0]) ? chain : chain.slice(1);
+		this.#setFallbackChain(role, [demotedSelector, ...restOfChain]);
+		this.#roleIndex = Math.max(0, this.#roleIndex - 1);
 	}
 
 	#cancelAssign(): void {
@@ -1383,7 +1503,8 @@ export class ModelHubComponent implements Component {
 			return;
 		}
 		// Reordering: [ / shift+↑ moves the row earlier, ] / shift+↓ later —
-		// cycle order on a role row, chain order on a fallback row.
+		// cycle order on a role row, chain order on a fallback row (moving the
+		// front entry earlier promotes it to primary, demoting the primary).
 		if (matchesKey(data, "shift+up")) {
 			if (role) this.#moveCycleMembership(role, -1);
 			else if (row?.kind === "fallback") this.#moveFallback(row, -1);
@@ -1833,9 +1954,10 @@ export class ModelHubComponent implements Component {
 			// Quick-cycle membership badge (`⟳2` = second stop of the ctrl+p cycle).
 			const cycleIndex = cycleOrder.indexOf(role);
 			const cycleStyled = cycleIndex >= 0 ? theme.fg("accent", `${theme.icon.loop}${cycleIndex + 1}`) : "";
+			const pendingStyled = this.#pendingPromotions.has(role) ? theme.fg("warning", "promoting…") : "";
 
 			let line = ` ${cursor} ${dot} ${tagStyled}  ${value}`;
-			const right = [levelStyled, cycleStyled].filter(part => part.length > 0).join("  ");
+			const right = [levelStyled, cycleStyled, pendingStyled].filter(part => part.length > 0).join("  ");
 			const rightWidth = visibleWidth(right);
 			const lineWidth = visibleWidth(line);
 			if (rightWidth > 0 && lineWidth + rightWidth + 2 <= width) {
@@ -1941,8 +2063,17 @@ export class ModelHubComponent implements Component {
 				return "↑/↓ providers · → roles · Esc close";
 			}
 			const row = this.#rolesRows[this.#roleIndex];
+			if ((row?.kind === "role" || row?.kind === "fallback") && this.#pendingPromotions.has(row.role)) {
+				return "Promotion pending — applying the new primary model…";
+			}
 			if (row?.kind === "fallback") {
-				return "↑/↓ rows · Enter replace · f add another · x remove · [/] reorder · ← providers";
+				const canPromote =
+					row.chainIndex === 0 &&
+					this.#visibleRoleIds().includes(row.role) &&
+					!!this.#roles[row.role] &&
+					!this.#roles[row.role]?.autoSelected;
+				const reorder = canPromote ? "[ promote to primary · ] reorder" : "[/] reorder";
+				return `↑/↓ rows · Enter replace · f add another · x remove · ${reorder} · ← providers`;
 			}
 			if (row?.kind === "chainKey") {
 				return "↑/↓ rows · Enter/f add fallback · x clear chain · ← providers";

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -893,7 +893,7 @@ export class SelectorController {
 									thinkingLevel: isAuto ? ThinkingLevel.Inherit : concreteThinking,
 									persist: targetScope === "global",
 								});
-								if (!switched) return;
+								if (!switched) return false;
 								if (targetScope === "project") {
 									this.ctx.settings.setProjectModelRole(
 										"default",
@@ -924,6 +924,7 @@ export class SelectorController {
 						}
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
+						return false;
 					} finally {
 						releaseDefaultMutation?.();
 						hub?.refreshAfterExternalMutation();

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -348,27 +348,24 @@ export function resolveRetryFallbackChainKey(
  * id-prefixed `provider/prefix/*` entry re-prefixes the failing model's
  * bare id instead (openrouter/google/* : google-antigravity/x →
  * openrouter/google/x). Ids the target provider lacks are skipped by the
- * candidate loop's registry lookup.
+ * candidate loop's registry lookup. Exported so callers outside retry
+ * resolution (e.g. the `/model` hub's fallback-promotion UI) resolve a
+ * wildcard chain entry against a chosen `current` the same way runtime
+ * fallback recovery does, instead of duplicating this logic.
  */
-function parseRetryFallbackChainEntry(
-	context: RetryFallbackResolutionContext,
+export function parseRetryFallbackChainEntry(
+	modelLookup: RetryFallbackModelLookup,
 	entry: string,
 	current: RetryFallbackSelector | undefined,
 ): RetryFallbackSelector | undefined {
-	if (!isRetryFallbackWildcardKey(entry)) return parseRetryFallbackSelector(entry, context.modelLookup);
+	if (!isRetryFallbackWildcardKey(entry)) return parseRetryFallbackSelector(entry, modelLookup);
 	if (!current) return undefined;
-	const { provider, idPrefix } = parseRetryFallbackWildcard(entry, candidate =>
-		context.modelLookup.hasProvider(candidate),
-	);
+	const { provider, idPrefix } = parseRetryFallbackWildcard(entry, candidate => modelLookup.hasProvider(candidate));
 	const bareId = current.id.slice(current.id.lastIndexOf("/") + 1);
 	let id: string;
 	if (idPrefix !== undefined) {
 		id = `${idPrefix}/${bareId}`;
-	} else if (
-		bareId !== current.id &&
-		!context.modelLookup.find(provider, current.id) &&
-		context.modelLookup.find(provider, bareId)
-	) {
+	} else if (bareId !== current.id && !modelLookup.find(provider, current.id) && modelLookup.find(provider, bareId)) {
 		// Aggregator → direct: the failing id carries a vendor prefix the
 		// target provider does not use (openrouter/google/x → google-vertex/x).
 		id = bareId;
@@ -417,7 +414,7 @@ function getRetryFallbackEffectiveChain(
 		}
 	}
 	for (const selector of context.chains[chainKey] ?? []) {
-		const parsed = parseRetryFallbackChainEntry(context, selector, parsedCurrent);
+		const parsed = parseRetryFallbackChainEntry(context.modelLookup, selector, parsedCurrent);
 		if (!parsed || seen.has(parsed.raw)) continue;
 		seen.add(parsed.raw);
 		chain.push(parsed);

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -769,6 +769,248 @@ describe("ModelHub", () => {
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-b"]);
 		});
 
+		test("[ on the front fallback of a role promotes it to primary, demoting the current primary into its slot", async () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({ models: [a, b], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's only chain entry (model-b)
+			hub.handleInput("[");
+			await Promise.resolve(); // let the awaited onAssign settle before the chain rewrite runs
+
+			expect(onAssign).toHaveBeenCalledWith(b, "default", ThinkingLevel.Inherit, "test/model-b", undefined);
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a"]);
+		});
+
+		test("[ on the front fallback is a no-op when the role has no explicit primary to demote", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				"retry.fallbackChains": { default: ["test/model-a", "test/model-b"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({ models: [a, b], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // first chain entry (model-a), default has no explicit primary
+			hub.handleInput("[");
+
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+		});
+
+		test("[ on a model-keyed chain's front entry is a no-op (no primary slot to promote into)", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				"retry.fallbackChains": { "test/model-a": ["test/model-b"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({ models: [a, b], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(UP); // wraps to the trailing "+ New fallback…" row
+			hub.handleInput(UP); // steps onto the chain's front entry (model-b)
+			hub.handleInput("[");
+
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+		});
+
+		test("[ on a front fallback with its own :level suffix applies that level to the promoted primary and preserves the old primary's level in its demoted slot", async () => {
+			const primaryModel = getBundledModel("openai", "gpt-5.5");
+			const fallbackModel = getBundledModel("openai", "gpt-5.6");
+			if (!primaryModel || !fallbackModel) {
+				throw new Error("Expected bundled OpenAI models for promote thinking-level test");
+			}
+			const settings = Settings.isolated({
+				modelRoles: { default: `${primaryModel.provider}/${primaryModel.id}:high` },
+				"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}:low`] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({
+				models: [primaryModel, fallbackModel],
+				scoped: true,
+				settings,
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's only chain entry (gpt-5.6:low)
+			hub.handleInput("[");
+			await Promise.resolve(); // let the awaited onAssign settle before the chain rewrite runs
+
+			expect(onAssign).toHaveBeenCalledWith(
+				fallbackModel,
+				"default",
+				ThinkingLevel.Low,
+				`${fallbackModel.provider}/${fallbackModel.id}`,
+				undefined,
+			);
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [
+				`${primaryModel.provider}/${primaryModel.id}:high`,
+			]);
+		});
+
+		test("[ on an unsuffixed front fallback inherits the current primary's thinking level instead of resetting to inherit", async () => {
+			const primaryModel = getBundledModel("openai", "gpt-5.5");
+			const fallbackModel = getBundledModel("openai", "gpt-5.6");
+			if (!primaryModel || !fallbackModel) {
+				throw new Error("Expected bundled OpenAI models for promote thinking-level test");
+			}
+			const settings = Settings.isolated({
+				modelRoles: { default: `${primaryModel.provider}/${primaryModel.id}:high` },
+				"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({
+				models: [primaryModel, fallbackModel],
+				scoped: true,
+				settings,
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's only chain entry (gpt-5.6, no suffix)
+			hub.handleInput("[");
+			await Promise.resolve(); // let the awaited onAssign settle before the chain rewrite runs
+
+			// The fallback carries no explicit level, so promoting it inherits the
+			// outgoing primary's :high instead of collapsing to Inherit.
+			expect(onAssign).toHaveBeenCalledWith(
+				fallbackModel,
+				"default",
+				ThinkingLevel.High,
+				`${fallbackModel.provider}/${fallbackModel.id}`,
+				undefined,
+			);
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", [
+				`${primaryModel.provider}/${primaryModel.id}:high`,
+			]);
+		});
+
+		test("[ on a provider-wildcard front entry (provider/*) promotes to its resolved concrete model and keeps the wildcard rule in the chain", async () => {
+			const a = makeModel("a", "model");
+			const b = makeModel("b", "model");
+			const settings = Settings.isolated({
+				modelRoles: { default: "a/model" },
+				"retry.fallbackChains": { default: ["b/*"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({ models: [a, b], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's only chain entry (b/*)
+			hub.handleInput("["); // promote — the wildcard resolves against the primary's id
+			await Promise.resolve(); // let the awaited onAssign settle before the chain rewrite runs
+
+			expect(onAssign).toHaveBeenCalledWith(b, "default", ThinkingLevel.Inherit, "b/model", undefined);
+			// A wildcard is a standing provider-level rule, not a one-off pick:
+			// promoting through it demotes the old primary ahead of the rule
+			// instead of deleting the rule from the chain.
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["a/model", "b/*"]);
+		});
+
+		test("[ on the front fallback does not rewrite the chain while the assignment is still pending, and applies it once resolved", async () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const { promise: assignSettled, resolve: settleAssign } = Promise.withResolvers<boolean>();
+			const onAssign = vi.fn(() => assignSettled);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's only chain entry (model-b)
+			hub.handleInput("[");
+
+			// The assignment (e.g. an in-flight provider switch) hasn't settled yet —
+			// the chain must not be rewritten out from under the still-pending swap.
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(onAssign).toHaveBeenCalledWith(b, "default", ThinkingLevel.Inherit, "test/model-b", undefined);
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+
+			settleAssign(true);
+			await assignSettled;
+			await Promise.resolve();
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a"]);
+		});
+
+		test("[ on the front fallback leaves the chain untouched when the assignment reports failure", async () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			// Mirrors a rejected provider switch (selector-controller.ts's
+			// `onAssign` returns `false` when `session.setModel` reports
+			// `switched: false`): the chain must not demote the primary that
+			// never actually moved.
+			const onAssign = vi.fn(async () => false);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's only chain entry (model-b)
+			hub.handleInput("[");
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(onAssign).toHaveBeenCalledWith(b, "default", ThinkingLevel.Inherit, "test/model-b", undefined);
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+		});
+
+		test("[ on the front fallback of a two-entry chain freezes further reordering until the promotion resolves", async () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const c = makeModel("test", "model-c");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b", "test/model-c"] },
+			});
+			const { promise: assignSettled, resolve: settleAssign } = Promise.withResolvers<boolean>();
+			const onAssign = vi.fn(() => assignSettled);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b, c],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default's front chain entry (model-b)
+			hub.handleInput("["); // promote model-b — the assignment is still pending
+			await Promise.resolve();
+			expect(normalize(hub.render(220))).toContain("promoting…");
+
+			// A `]` on the same still-front row during the pending gap must be
+			// rejected outright, not applied against a stale pre-promotion chain
+			// snapshot and then clobbered (or clobber) the promotion's own write.
+			hub.handleInput("]");
+			await Promise.resolve();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+
+			settleAssign(true);
+			await assignSettled;
+			await Promise.resolve();
+
+			// Only the promotion's own write landed: model-a demoted into the
+			// chain, model-c undisturbed — the rejected `]` never touched settings.
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a", "test/model-c"]);
+			expect(normalize(hub.render(220))).not.toContain("promoting…");
+		});
+
 		test("windows the roles list so model-keyed chains past the panel height stay reachable", () => {
 			const settings = Settings.isolated({
 				// Model-keyed chains sort alphabetically; the unique tail key lands last.


### PR DESCRIPTION
## What

Completes primary/fallback promotion in the `/model` Roles panel. Pressing `[` on a role's **front** fallback entry now promotes it to primary, demoting the current primary into the vacated chain slot — the mirror of the existing `]`/`[` chain-reorder keybinds, at the chain boundary where reordering previously just stopped.

End-to-end behavior this PR ships:

- **Promote/demote swap**: `[` on chain slot 0 swaps the front fallback into the role's primary and writes the old primary back into slot 0 of the chain (instead of no-op'ing at the boundary, as it did before).
- **Concrete and wildcard chain entries both promote correctly**: a plain `provider/id[:level]` entry resolves directly; a `provider/*` / `provider/prefix/*` wildcard entry resolves against the current primary through the same resolver runtime fallback recovery uses (`parseRetryFallbackChainEntry`, now exported from `retry-fallback-chains.ts` and reused rather than duplicated). A promoted wildcard rule stays in the chain afterward — it's a standing provider-level policy, not a one-off pick consumed by promotion.
- **Thinking levels survive the swap in both directions**: an explicit `:level` suffix on the fallback entry wins; an unsuffixed entry inherits the outgoing primary's level instead of collapsing to `Inherit` (matching `turn-recovery.ts`'s runtime `selector.thinkingLevel ?? currentThinkingLevel` carry-over); the demoted primary keeps its own level in its new chain slot.
- **Correct behavior under the real async contract**: `onAssign` is async in production and can report failure (`switched: false` on a rejected provider switch, or a thrown error). Promotion now awaits it and only rewrites the chain on success, so a rejected switch can't still demote/lose a model that never actually moved. (`ModelHubCallbacks.onAssign`'s type is widened to let a caller signal this; `selector-controller.ts`'s two failure paths now report it.)
- **Safe under concurrent input**: while a role's promotion is resolving, every mutation of that role's primary or chain — `[`/`]`/`x`/backspace/Enter/`f` on its rows, and the role strip's assign/unassign/thinking chip actions — is rejected rather than racing the promotion's own captured pre-swap state, so a `]` (or any other edit) pressed mid-promotion can't silently discard one write or the other. The affected role shows a "promoting…" row badge and a matching footer hint while this is in flight.

## Also in this PR

- Restored `packages/coding-agent/CHANGELOG.md`. It had been corrupted in the working tree with raw `read`-tool output (numbered lines, a `[FILENAME#TAG]` header) in place of Markdown, collapsing ~15k lines of release history to ~300. Restored verbatim from the current released history, with this feature's one entry placed under `## [Unreleased]` (a rebase artifact briefly misplaced it inside the now-released, immutable `17.4.0` section — caught and fixed before push; diffed byte-for-byte against `origin/main`'s `17.4.0` section to confirm no other drift).

## Files touched

- `src/modes/components/model-hub.ts` — the promote/demote implementation, thinking-level carry-over, async gating, input-freezing state (`#pendingPromotions`), and the row/footer UI hints.
- `src/modes/controllers/selector-controller.ts` — `onAssign`'s two failure paths (`switched: false`, thrown error) now report failure to the hub.
- `src/session/retry-fallback-chains.ts` — `parseRetryFallbackChainEntry` exported with a narrowed (`modelLookup`-only) signature so the hub can reuse it instead of duplicating wildcard-entry resolution.
- `test/model-hub.test.ts` — 10 new tests: the base promote/demote swap, thinking-level suffix preservation (explicit and inherited), a pending/failed async assignment leaving the chain untouched, a concurrent `]` rejected mid-promotion, and a wildcard entry promoting to its resolved concrete model while staying in the chain.
- `CHANGELOG.md` — restored + one `Unreleased` entry.

## Testing

- `bun check` (biome + `tsgo --noEmit`) passes.
- **`bun test test/model-hub.test.ts` was never run against this change.** The coding-agent suite needs the `pi_natives` native addon, which is unbuildable in the sandbox this PR was authored in (missing `coder-vm` Bazel config there), and I deliberately didn't install the CI-documented `@oh-my-pi/pi-natives-linux-x64` fallback package since that would have dirtied `package.json`/`bun.lock`. That means **none** of the 10 new tests have executed — including the microtask-flush (`await Promise.resolve()`) timing assumptions the async-race tests depend on, which is exactly the class of thing that only fails at runtime. Please run the suite before merging.

---

- [x] `bun check` passes
- [ ] Tested locally (not run in the authoring sandbox — see Testing above)
- [x] CHANGELOG updated
