### PR TITLE
fix(dap): support preattached GDB remote adapters

### DIFF
--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -170,7 +170,7 @@ Side-channel artifacts outside the model tool result:
     - `fileTypes`: lowercase file extensions used for launch auto-selection.
     - `rootMarkers`: files/directories used to rank adapters for a project.
     - `launchDefaults`: default DAP launch arguments merged before the selected program/cwd/args.
-    - `attachDefaults`: default DAP attach arguments. Set `skipAttachRequest: true` for a preconnected adapter; explicit `debug attach` then needs no PID or port.
+    - `attachDefaults`: default DAP attach arguments. An explicit adapter may attach without a PID or port; its adapter validates these arguments.
     - `connectMode`: `"stdio"` (default), `"socket"` (Delve-style platform-dependent socket/callback), or `"tcp"` (spawn a local DAP server with `${port}` substituted into `args`).
     - `acceptsDirectoryProgram`: set `true` for adapters such as `dlv` that can launch a package/project directory.
 
@@ -198,7 +198,7 @@ Example `.omp/dap.json`:
 }
 ```
 
-Preconnected GDB example for an OpenOCD remote target:
+GDB example for an OpenOCD remote target:
 
 ```json
 {
@@ -209,20 +209,16 @@ Preconnected GDB example for an OpenOCD remote target:
         "-q",
         "-ex",
         "file zig-out/firmware/gc9a01-test.elf",
-        "-ex",
-        "target extended-remote :3334",
         "-i",
         "dap"
       ],
       "attachDefaults": {
-        "skipAttachRequest": true
+        "target": ":3334"
       }
     }
   }
 }
 ```
-
-Use this only when GDB establishes the GDB Remote Serial Protocol connection through its startup arguments. Calling `attach` after that connection is incompatible with GDB's DAP mode.
 - **Transport**
   - `stdio`: direct adapter `stdin`/`stdout` framing.
   - `socket`: Unix domain socket on Linux; adapter callback to a local TCP listener on macOS/other.

--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -170,7 +170,7 @@ Side-channel artifacts outside the model tool result:
     - `fileTypes`: lowercase file extensions used for launch auto-selection.
     - `rootMarkers`: files/directories used to rank adapters for a project.
     - `launchDefaults`: default DAP launch arguments merged before the selected program/cwd/args.
-    - `attachDefaults`: default DAP attach arguments merged before pid/port/host/cwd.
+    - `attachDefaults`: default DAP attach arguments. Set `skipAttachRequest: true` for a preconnected adapter; explicit `debug attach` then needs no PID or port.
     - `connectMode`: `"stdio"` (default), `"socket"` (Delve-style platform-dependent socket/callback), or `"tcp"` (spawn a local DAP server with `${port}` substituted into `args`).
     - `acceptsDirectoryProgram`: set `true` for adapters such as `dlv` that can launch a package/project directory.
 
@@ -197,6 +197,32 @@ Example `.omp/dap.json`:
   }
 }
 ```
+
+Preconnected GDB example for an OpenOCD remote target:
+
+```json
+{
+  "adapters": {
+    "pico-openocd": {
+      "command": "gdb",
+      "args": [
+        "-q",
+        "-ex",
+        "file zig-out/firmware/gc9a01-test.elf",
+        "-ex",
+        "target extended-remote :3334",
+        "-i",
+        "dap"
+      ],
+      "attachDefaults": {
+        "skipAttachRequest": true
+      }
+    }
+  }
+}
+```
+
+Use this only when GDB establishes the GDB Remote Serial Protocol connection through its startup arguments. Calling `attach` after that connection is incompatible with GDB's DAP mode.
 - **Transport**
   - `stdio`: direct adapter `stdin`/`stdout` framing.
   - `socket`: Unix domain socket on Linux; adapter callback to a local TCP listener on macOS/other.

--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -43,7 +43,7 @@
 | `frame_id` | `number` | No | Frame selector for `evaluate`, `scopes`, `data_breakpoint_info`. `scopes` and `evaluate` default to the current stopped frame when omitted. |
 | `scope_id` | `number` | No | Variables reference from a scope. Accepted by `variables`; also used as a fallback variables reference for `data_breakpoint_info`. |
 | `variable_ref` | `number` | No | Variables reference for `variables`; preferred over `scope_id` when both are present. |
-| `pid` | `number` | No | Local process id for `attach`. `attach` requires `pid` or `port`. |
+| `pid` | `number` | No | Local process id for `attach`. Required with `port` only when no explicit adapter is selected. |
 | `port` | `number` | No | Remote attach port. If no adapter is forced, attach prefers `debugpy` when `port` is present. |
 | `host` | `string` | No | Remote attach host for `attach`. |
 | `levels` | `number` | No | Max stack frames for `stack_trace`. |
@@ -66,7 +66,7 @@
 
 ### Action-specific requirements
 - `launch`: `program`
-- `attach`: `pid` or `port`
+- `attach`: `pid` or `port`, unless an explicit adapter supplies its attach arguments
 - `set_breakpoint` / `remove_breakpoint`: `function`, or `file` + `line`
 - `set_instruction_breakpoint` / `remove_instruction_breakpoint`: `instruction_reference`
 - `data_breakpoint_info`: `name`
@@ -123,7 +123,7 @@ Side-channel artifacts outside the model tool result:
 
 1. Tool registration is conditional: `DebugTool.createIf()` in `packages/coding-agent/src/tools/debug.ts` returns `null` unless `session.settings.get("debug.enabled")` is true (default `true`). `packages/coding-agent/src/tools/index.ts` wires the factory and rechecks the same setting in tool filtering.
 2. `DebugTool.execute()` clamps `params.timeout` through `clampTimeout("debug", params.timeout)`, applying the optional positive `tools.maxTimeout` cap before the tool's 5-second floor and 300-second ceiling, and composes the caller `AbortSignal` with `AbortSignal.timeout(...)`.
-3. `launch` resolves cwd/program paths, classifies the target as file/directory/missing, rejects directories unless the chosen adapter sets `acceptsDirectoryProgram`, and delegates to `dapSessionManager.launch()`. `attach` requires `pid` or `port`, resolves cwd, selects an adapter, and delegates to `.attach()`.
+3. `launch` resolves cwd/program paths, classifies the target as file/directory/missing, rejects directories unless the chosen adapter sets `acceptsDirectoryProgram`, and delegates to `dapSessionManager.launch()`. `attach` resolves cwd and selects an adapter; it requires `pid` or `port` only without an explicit adapter.
 4. `DapSessionManager.launch()` / `.attach()` enforce one root session, spawn the adapter through `DapClient.spawn()`, register listeners, send `initialize`, cache capabilities, subscribe for tree-wide stop events, send `launch`/`attach`, then complete the `initialized` → `configurationDone` handshake.
 5. `DapClient.spawn()` starts adapters detached with `NON_INTERACTIVE_ENV`. `stdio` uses the adapter pipes; `socket` uses a Unix socket on Linux or an adapter callback to a local TCP listener elsewhere; `tcp` substitutes `${port}` in adapter args, starts its local server, then connects. Child sessions reuse a root `tcp` server through `DapClient.connect()`.
 6. `#registerSession()` in `packages/coding-agent/src/dap/session.ts` installs reverse-request handlers:
@@ -320,7 +320,7 @@ GDB example for an OpenOCD remote target:
 ## Errors
 - Parameter validation in `packages/coding-agent/src/tools/debug.ts` throws `ToolError` with explicit messages such as:
   - `program is required for launch`
-  - `attach requires pid or port`
+  - `attach requires pid or port` when no explicit adapter is selected
   - `set_breakpoint requires file+line or function`
   - `variables requires variable_ref or scope_id`
   - `instruction_count is required for disassemble`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Explicit DAP adapters can attach without a PID or port when their `attachDefaults` provide the adapter-specific target arguments.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -1490,6 +1490,9 @@ export class DapSessionManager {
 			if (session.parentSessionId) {
 				await this.#applyRootBreakpointsToSession(session, signal, timeoutMs);
 			}
+			if (session.status === "launching" || session.status === "configuring") {
+				session.status = "running";
+			}
 			return;
 		}
 		// Wait for the initialized event if we haven't seen it yet.

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -393,6 +393,10 @@ export class DapSessionManager {
 				timeoutMs,
 			);
 			session.needsConfigurationDone = session.capabilities.supportsConfigurationDoneRequest === true;
+			if (options.adapter.attachDefaults.skipAttachRequest === true) {
+				await this.#completeConfigurationHandshake(session, signal, timeoutMs);
+				return buildSummary(session);
+			}
 			const attachArguments: DapAttachArguments = {
 				...options.adapter.attachDefaults,
 				cwd: options.cwd,

--- a/packages/coding-agent/src/dap/types.ts
+++ b/packages/coding-agent/src/dap/types.ts
@@ -475,6 +475,11 @@ export interface DapClientState {
 	capabilities?: DapCapabilities;
 }
 
+export interface DapAttachDefaults extends Record<string, unknown> {
+	/** When true, the adapter is already attached and needs no DAP attach request. */
+	skipAttachRequest?: boolean;
+}
+
 export interface DapAdapterConfig {
 	command: string;
 	args?: string[];
@@ -482,7 +487,7 @@ export interface DapAdapterConfig {
 	fileTypes?: string[];
 	rootMarkers?: string[];
 	launchDefaults?: Record<string, unknown>;
-	attachDefaults?: Record<string, unknown>;
+	attachDefaults?: DapAttachDefaults;
 	/** "stdio" (default): communicate via stdin/stdout pipes.
 	 *  "socket": adapter-specific socket launch (currently Delve).
 	 *  "tcp": spawn a DAP server with `${port}` substituted in `args`, then connect to it. */
@@ -502,7 +507,7 @@ export interface DapResolvedAdapter {
 	fileTypes: string[];
 	rootMarkers: string[];
 	launchDefaults: Record<string, unknown>;
-	attachDefaults: Record<string, unknown>;
+	attachDefaults: DapAttachDefaults;
 	connectMode: "stdio" | "socket" | "tcp";
 	acceptsDirectoryProgram: boolean;
 }

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -775,11 +775,7 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 						`No debugger adapter available. Installed adapters: ${getConfiguredAdapters(commandCwd)}`,
 					);
 				}
-				if (
-					params.pid === undefined &&
-					params.port === undefined &&
-					(!params.adapter || adapter.attachDefaults.skipAttachRequest !== true)
-				) {
+				if (params.pid === undefined && params.port === undefined && !params.adapter) {
 					throw new ToolError("attach requires pid or port");
 				}
 				const snapshot = await dapSessionManager.attach(

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -764,9 +764,6 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 				return result.text(formatSessionSnapshot(snapshot).join("\n")).done();
 			}
 			case "attach": {
-				if (params.pid === undefined && params.port === undefined) {
-					throw new ToolError("attach requires pid or port");
-				}
 				const commandCwd = params.cwd ? resolveToCwd(params.cwd, this.session.cwd) : this.session.cwd;
 				const adapter = selectAttachAdapter(commandCwd, params.adapter, params.port);
 				if (!adapter) {
@@ -777,6 +774,13 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 					throw new ToolError(
 						`No debugger adapter available. Installed adapters: ${getConfiguredAdapters(commandCwd)}`,
 					);
+				}
+				if (
+					params.pid === undefined &&
+					params.port === undefined &&
+					(!params.adapter || adapter.attachDefaults.skipAttachRequest !== true)
+				) {
+					throw new ToolError("attach requires pid or port");
 				}
 				const snapshot = await dapSessionManager.attach(
 					{ adapter, cwd: commandCwd, pid: params.pid, port: params.port, host: params.host },

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -229,7 +229,7 @@ describe("DAP launch failure handling", () => {
 		const fake = new FakeDapClient(adapter, process.cwd(), {});
 		spyOn(DapClient, "spawn").mockResolvedValue(fake as unknown as DapClient);
 
-		const summary = await manager.attach({ adapter, cwd: process.cwd(), pid: 123 });
+		const summary = await manager.attach({ adapter, cwd: process.cwd() });
 
 		expect(fake.requests.map(request => request.command)).toEqual(["configurationDone"]);
 		expect(summary.status).toBe("running");

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -823,11 +823,11 @@ describe("DebugTool launch validation", () => {
 		}
 	});
 
-	it("allows explicit preattached adapters to attach without pid or port", async () => {
+	it("allows explicit adapters with target attach defaults to attach without pid or port", async () => {
 		const adapter: DapResolvedAdapter = {
 			...TEST_ADAPTER,
 			name: "pico-openocd",
-			attachDefaults: { request: "attach", skipAttachRequest: true },
+			attachDefaults: { target: ":3334" },
 		};
 		const selectAttachSpy = spyOn(dapModule, "selectAttachAdapter").mockReturnValue(adapter);
 		const sessionAttachSpy = spyOn(dapModule.dapSessionManager, "attach").mockImplementation(async opts => {
@@ -850,7 +850,7 @@ describe("DebugTool launch validation", () => {
 			expect(sessionAttachSpy).toHaveBeenCalledTimes(1);
 			const [opts] = sessionAttachSpy.mock.calls[0]!;
 			expect(opts.adapter).toBe(adapter);
-			expect(opts.adapter.attachDefaults.skipAttachRequest).toBe(true);
+			expect(opts.adapter.attachDefaults.target).toBe(":3334");
 			expect(opts.pid).toBeUndefined();
 			expect(opts.port).toBeUndefined();
 		} finally {

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -220,6 +220,22 @@ describe("DAP launch failure handling", () => {
 		expect(message).toContain("configurationDone: Expected process to be stopped.");
 	});
 
+	it("completes configuration without sending attach for preattached adapters", async () => {
+		const adapter: DapResolvedAdapter = {
+			...TEST_ADAPTER,
+			attachDefaults: { request: "attach", skipAttachRequest: true },
+		};
+		const manager = new DapSessionManager();
+		const fake = new FakeDapClient(adapter, process.cwd(), {});
+		spyOn(DapClient, "spawn").mockResolvedValue(fake as unknown as DapClient);
+
+		const summary = await manager.attach({ adapter, cwd: process.cwd(), pid: 123 });
+
+		expect(fake.requests.map(request => request.command)).toEqual(["configurationDone"]);
+		expect(summary.status).toBe("running");
+		expect(summary.needsConfigurationDone).toBe(false);
+	});
+
 	it("does not emit an unhandled rejection when launch fails before initial stop watchers settle", async () => {
 		const manager = new DapSessionManager();
 		const fake = new FakeDapClient(TEST_ADAPTER, process.cwd(), {

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -74,6 +74,7 @@ class FakeDapClient {
 			attachError?: string;
 			attachErrorDelayMs?: number;
 			configurationDoneError?: string;
+			supportsConfigurationDone?: boolean;
 			rejectStopWaiters?: boolean;
 			stopAfterLaunch?: boolean;
 		},
@@ -95,7 +96,7 @@ class FakeDapClient {
 
 	async initialize(): Promise<DapCapabilities> {
 		queueMicrotask(() => this.#emit("initialized", {}));
-		return { supportsConfigurationDoneRequest: true };
+		return { supportsConfigurationDoneRequest: this.options.supportsConfigurationDone ?? true };
 	}
 
 	async sendRequest(command: string, args?: unknown): Promise<unknown> {
@@ -226,12 +227,12 @@ describe("DAP launch failure handling", () => {
 			attachDefaults: { request: "attach", skipAttachRequest: true },
 		};
 		const manager = new DapSessionManager();
-		const fake = new FakeDapClient(adapter, process.cwd(), {});
+		const fake = new FakeDapClient(adapter, process.cwd(), { supportsConfigurationDone: false });
 		spyOn(DapClient, "spawn").mockResolvedValue(fake as unknown as DapClient);
 
 		const summary = await manager.attach({ adapter, cwd: process.cwd() });
 
-		expect(fake.requests.map(request => request.command)).toEqual(["configurationDone"]);
+		expect(fake.requests.map(request => request.command)).toEqual([]);
 		expect(summary.status).toBe("running");
 		expect(summary.needsConfigurationDone).toBe(false);
 	});

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -823,6 +823,42 @@ describe("DebugTool launch validation", () => {
 		}
 	});
 
+	it("allows explicit preattached adapters to attach without pid or port", async () => {
+		const adapter: DapResolvedAdapter = {
+			...TEST_ADAPTER,
+			name: "pico-openocd",
+			attachDefaults: { request: "attach", skipAttachRequest: true },
+		};
+		const selectAttachSpy = spyOn(dapModule, "selectAttachAdapter").mockReturnValue(adapter);
+		const sessionAttachSpy = spyOn(dapModule.dapSessionManager, "attach").mockImplementation(async opts => {
+			throw Object.assign(new Error("captured attach"), { capturedOptions: opts });
+		});
+		try {
+			const session: ToolSession = {
+				cwd: process.cwd(),
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				settings: Settings.isolated({ "debug.enabled": true }),
+			};
+			const tool = new DebugTool(session);
+
+			await expect(tool.execute("call", { action: "attach", adapter: "pico-openocd" })).rejects.toThrow(
+				/captured attach/,
+			);
+			expect(selectAttachSpy).toHaveBeenCalledWith(process.cwd(), "pico-openocd", undefined);
+			expect(sessionAttachSpy).toHaveBeenCalledTimes(1);
+			const [opts] = sessionAttachSpy.mock.calls[0]!;
+			expect(opts.adapter).toBe(adapter);
+			expect(opts.adapter.attachDefaults.skipAttachRequest).toBe(true);
+			expect(opts.pid).toBeUndefined();
+			expect(opts.port).toBeUndefined();
+		} finally {
+			sessionAttachSpy.mockRestore();
+			selectAttachSpy.mockRestore();
+		}
+	});
+
 	it("throws targeted 'python not found in PATH' when adapter:'debugpy' is unresolvable for attach", async () => {
 		const attachSpy = spyOn(dapModule, "selectAttachAdapter").mockReturnValue(null);
 		try {

--- a/scripts/omp-local
+++ b/scripts/omp-local
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-script=$(readlink -f -- "${BASH_SOURCE[0]}")
-root=$(cd -- "$(dirname -- "$script")/.." && pwd)
-exec nix develop "$root" -c bun --cwd="$root/packages/coding-agent" src/cli.ts "$@"

--- a/scripts/omp-local
+++ b/scripts/omp-local
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script=$(readlink -f -- "${BASH_SOURCE[0]}")
+root=$(cd -- "$(dirname -- "$script")/.." && pwd)
+exec nix develop "$root" -c bun --cwd="$root/packages/coding-agent" src/cli.ts "$@"


### PR DESCRIPTION
## What

Allow an explicit DAP adapter to attach without a PID or port when `attachDefaults` supplies the adapter-specific target arguments.

Adds regression coverage, documents the explicit-adapter exception, and adds the coding-agent changelog entry.

## Why

Some DAP adapters define their remote target in adapter configuration rather than through OMP's generic PID/port fields. OMP now forwards those configured attach arguments and lets the adapter validate them.

## Testing

```text
bun test packages/coding-agent/test/debug/dap-launch-failures.test.ts
31 pass, 0 fail

bun run check:ts
pass
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
