### PR TITLE
fix(plugins): expose marketplace plugin settings

### DIFF
--- a/docs/plugin-manager-installer-plumbing.md
+++ b/docs/plugin-manager-installer-plumbing.md
@@ -143,6 +143,8 @@ If uninstall command fails, runtime state is not changed.
 
 `omp plugin list` combines this result with `MarketplaceManager.listInstalledPlugins()`.
 
+`PluginManager.getPlugin()` resolves one runtime package directly, including a marketplace symlink intentionally omitted from `list()`. Config commands use this path so marketplace settings remain addressable without duplicating marketplace entries in list and status output.
+
 ## Link flow (`PluginManager.link`)
 
 `link` supports local plugin development by symlinking a local package into `~/.omp/plugins/node_modules/<pkg.name>`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Marketplace-installed plugins with manifest settings can now be configured through `omp plugin config` and Settings → Plugins ([#9106](https://github.com/can1357/oh-my-pi/issues/9106)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -14,7 +14,9 @@ import {
 	getMarketplacesRegistryPath,
 	getPluginsCacheDir,
 	MarketplaceManager,
+	parsePluginId,
 } from "../extensibility/plugins/marketplace/index.js";
+import type { InstalledPlugin } from "../extensibility/plugins/types";
 import { theme } from "../modes/theme/theme";
 
 // =============================================================================
@@ -865,8 +867,33 @@ async function handleConfig(
 	}
 }
 
+/**
+ * Enumerate every installed plugin to validate — npm/link plugins from
+ * {@link PluginManager.list} plus marketplace runtime packages, which `list()`
+ * intentionally omits. Marketplace summaries are resolved through their trusted
+ * install path; deduped by resolved package name so a project install shadows a
+ * same-named user install (project summaries are enumerated first).
+ */
+async function collectPluginsForValidation(manager: PluginManager): Promise<InstalledPlugin[]> {
+	const byName = new Map<string, InstalledPlugin>();
+	for (const plugin of await manager.list()) {
+		byName.set(plugin.name, plugin);
+	}
+	const mktMgr = await makeMarketplaceManager();
+	for (const summary of await mktMgr.listInstalledPlugins()) {
+		const entry = summary.entries[0];
+		if (!entry) continue;
+		const fallbackName = parsePluginId(summary.id)?.name ?? summary.id;
+		const resolved = await manager.getPlugin(fallbackName, { path: entry.installPath });
+		if (resolved && !byName.has(resolved.name)) {
+			byName.set(resolved.name, resolved);
+		}
+	}
+	return [...byName.values()];
+}
+
 async function handleConfigValidate(manager: PluginManager, flags: { json?: boolean }): Promise<void> {
-	const plugins = await manager.list();
+	const plugins = await collectPluginsForValidation(manager);
 	const results: Array<{ plugin: string; key: string; error: string }> = [];
 
 	for (const plugin of plugins) {

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -763,8 +763,7 @@ async function handleConfig(
 		process.exit(1);
 	}
 
-	const plugins = await manager.list();
-	const plugin = plugins.find(p => p.name === pluginName);
+	const plugin = await manager.getPlugin(pluginName);
 
 	if (!plugin) {
 		console.error(chalk.red(`Plugin "${pluginName}" not found`));

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -103,6 +103,9 @@ interface PluginPackageSnapshot {
 
 interface RuntimePackageJson {
 	name?: unknown;
+	version: string;
+	omp?: PluginManifest;
+	pi?: PluginManifest;
 }
 // =============================================================================
 // Plugin Manager
@@ -222,6 +225,39 @@ export class PluginManager {
 			installedNames.add(name);
 		}
 		return installedNames;
+	}
+	async #resolvePlugin(
+		fallbackName: string,
+		pluginPath: string,
+		config: PluginRuntimeConfig,
+		projectOverrides: ProjectPluginOverrides,
+	): Promise<InstalledPlugin | undefined> {
+		let pluginPkg: RuntimePackageJson;
+		try {
+			pluginPkg = await Bun.file(path.join(pluginPath, "package.json")).json();
+		} catch (err) {
+			if (isEnoent(err)) return undefined;
+			throw err;
+		}
+
+		const name = typeof pluginPkg.name === "string" && pluginPkg.name.length > 0 ? pluginPkg.name : fallbackName;
+		const manifest: PluginManifest = pluginPkg.omp || pluginPkg.pi || { version: pluginPkg.version };
+		manifest.version = pluginPkg.version;
+		const runtimeState = config.plugins[name] || {
+			version: pluginPkg.version,
+			enabledFeatures: null,
+			enabled: true,
+		};
+		const isDisabledInProject = projectOverrides.disabled?.includes(name) ?? false;
+
+		return {
+			name,
+			version: pluginPkg.version,
+			path: pluginPath,
+			manifest,
+			enabledFeatures: projectOverrides.features?.[name] ?? runtimeState.enabledFeatures,
+			enabled: runtimeState.enabled && !isDisabledInProject,
+		};
 	}
 	async #collectMarketplaceRuntimePackageRealpaths(): Promise<Map<string, Set<string>>> {
 		const registry = await readInstalledPluginsRegistry(getInstalledPluginsRegistryPath());
@@ -642,6 +678,29 @@ export class PluginManager {
 	}
 
 	/**
+	 * Resolve one installed plugin, including a marketplace runtime package that
+	 * is intentionally omitted from {@link list}.
+	 *
+	 * `options.path` is the trusted install path from the marketplace registry.
+	 */
+	async getPlugin(name: string, options: { path?: string } = {}): Promise<InstalledPlugin | undefined> {
+		const [deps, config, projectOverrides] = await Promise.all([
+			this.#readDeps(getPluginsPackageJson()),
+			this.#ensureConfigLoaded(),
+			this.#loadProjectOverrides(),
+		]);
+		if (!options.path && !this.#collectInstalledNames(deps, config).has(name)) {
+			return undefined;
+		}
+		return this.#resolvePlugin(
+			name,
+			options.path ?? path.join(getPluginsNodeModules(), name),
+			config,
+			projectOverrides,
+		);
+	}
+
+	/**
 	 * List all installed plugins.
 	 */
 	async list(): Promise<InstalledPlugin[]> {
@@ -664,34 +723,10 @@ export class PluginManager {
 		for (const name of installedNames) {
 			const pluginPath = path.join(getPluginsNodeModules(), name);
 			if (await this.#isMarketplaceRuntimeLink(name, deps, marketplaceRuntimeRealpaths, pluginPath)) continue;
-			const pluginPkgPath = path.join(pluginPath, "package.json");
-			let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
-			try {
-				pluginPkg = await Bun.file(pluginPkgPath).json();
-			} catch (err) {
-				if (isEnoent(err)) continue;
-				throw err;
+			const plugin = await this.#resolvePlugin(name, pluginPath, config, projectOverrides);
+			if (plugin) {
+				plugins.push(plugin);
 			}
-			const manifest: PluginManifest = pluginPkg.omp || pluginPkg.pi || { version: pluginPkg.version };
-			manifest.version = pluginPkg.version;
-
-			const runtimeState = config.plugins[name] || {
-				version: pluginPkg.version,
-				enabledFeatures: null,
-				enabled: true,
-			};
-
-			const isDisabledInProject = projectOverrides.disabled?.includes(name) ?? false;
-			const projectFeatures = projectOverrides.features?.[name];
-
-			plugins.push({
-				name,
-				version: pluginPkg.version,
-				path: pluginPath,
-				manifest,
-				enabledFeatures: projectFeatures ?? runtimeState.enabledFeatures,
-				enabled: runtimeState.enabled && !isDisabledInProject,
-			});
 		}
 
 		return plugins;

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -11,6 +11,7 @@ import {
 	isEnoent,
 	logger,
 } from "@oh-my-pi/pi-utils";
+import { resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { loadExtensions } from "../extensions/loader";
 import { refreshBunGitCache } from "./bun-git-cache";
 import { type GitSource, parseGitUrl } from "./git-url";
@@ -681,7 +682,10 @@ export class PluginManager {
 	 * Resolve one installed plugin, including a marketplace runtime package that
 	 * is intentionally omitted from {@link list}.
 	 *
-	 * `options.path` is the trusted install path from the marketplace registry.
+	 * Resolution order: an explicit trusted `options.path` (marketplace registry
+	 * entry) wins; otherwise the user plugin root; otherwise the active project's
+	 * marketplace registry, so `--scope project` installs resolve when the CLI
+	 * runs inside that project.
 	 */
 	async getPlugin(name: string, options: { path?: string } = {}): Promise<InstalledPlugin | undefined> {
 		const [deps, config, projectOverrides] = await Promise.all([
@@ -689,15 +693,44 @@ export class PluginManager {
 			this.#ensureConfigLoaded(),
 			this.#loadProjectOverrides(),
 		]);
-		if (!options.path && !this.#collectInstalledNames(deps, config).has(name)) {
-			return undefined;
+		if (options.path) {
+			return this.#resolvePlugin(name, options.path, config, projectOverrides);
 		}
-		return this.#resolvePlugin(
-			name,
-			options.path ?? path.join(getPluginsNodeModules(), name),
-			config,
-			projectOverrides,
-		);
+		if (this.#collectInstalledNames(deps, config).has(name)) {
+			return this.#resolvePlugin(name, path.join(getPluginsNodeModules(), name), config, projectOverrides);
+		}
+		const projectPath = await this.#resolveProjectMarketplaceInstallPath(name);
+		if (projectPath) {
+			return this.#resolvePlugin(name, projectPath, config, projectOverrides);
+		}
+		return undefined;
+	}
+
+	/**
+	 * Locate a project-scoped marketplace plugin's cached install path by package
+	 * name. Project marketplace installs register their runtime symlink and
+	 * lockfile under the project root — invisible to the user-root lookup above —
+	 * so match each active-project registry entry against its resolved package
+	 * name (`package.json` `name`, falling back to the plugin-id segment).
+	 */
+	async #resolveProjectMarketplaceInstallPath(name: string): Promise<string | undefined> {
+		const registryPath = await resolveActiveProjectRegistryPath(this.#cwd);
+		if (!registryPath) return undefined;
+		const registry = await readInstalledPluginsRegistry(registryPath);
+		for (const pluginId in registry.plugins) {
+			const fallbackName = parsePluginId(pluginId)?.name ?? pluginId;
+			for (const entry of registry.plugins[pluginId]) {
+				let packageName = fallbackName;
+				try {
+					const pkg: RuntimePackageJson = await Bun.file(path.join(entry.installPath, "package.json")).json();
+					if (typeof pkg.name === "string" && pkg.name.length > 0) packageName = pkg.name;
+				} catch (err) {
+					if (!isEnoent(err)) throw err;
+				}
+				if (packageName === name) return entry.installPath;
+			}
+		}
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -124,8 +124,7 @@ export class PluginManager {
 	// Runtime Config Management
 	// ==========================================================================
 
-	async #loadRuntimeConfig(): Promise<PluginRuntimeConfig> {
-		const lockPath = getPluginsLockfile();
+	async #readRuntimeConfigAt(lockPath: string): Promise<PluginRuntimeConfig> {
 		try {
 			return normalizePluginRuntimeConfig(await Bun.file(lockPath).json());
 		} catch (err) {
@@ -133,6 +132,10 @@ export class PluginManager {
 			logger.warn("Failed to load plugin runtime config", { path: lockPath, error: String(err) });
 			return normalizePluginRuntimeConfig({});
 		}
+	}
+
+	async #loadRuntimeConfig(): Promise<PluginRuntimeConfig> {
+		return this.#readRuntimeConfigAt(getPluginsLockfile());
 	}
 
 	async #ensureConfigLoaded(): Promise<PluginRuntimeConfig> {
@@ -682,55 +685,52 @@ export class PluginManager {
 	 * Resolve one installed plugin, including a marketplace runtime package that
 	 * is intentionally omitted from {@link list}.
 	 *
-	 * Resolution order: an explicit trusted `options.path` (marketplace registry
-	 * entry) wins; otherwise the user plugin root; otherwise the active project's
-	 * marketplace registry, so `--scope project` installs resolve when the CLI
-	 * runs inside that project.
+	 * Resolution order mirrors {@link getEnabledPlugins}: an explicit trusted
+	 * `options.path` (marketplace registry entry) wins; otherwise the active
+	 * project plugin root shadows the user root — so inside a project where the
+	 * same package name exists in both scopes, config reads and writes act on the
+	 * project copy's manifest rather than the inactive user copy.
 	 */
 	async getPlugin(name: string, options: { path?: string } = {}): Promise<InstalledPlugin | undefined> {
-		const [deps, config, projectOverrides] = await Promise.all([
-			this.#readDeps(getPluginsPackageJson()),
-			this.#ensureConfigLoaded(),
-			this.#loadProjectOverrides(),
-		]);
+		const [config, projectOverrides] = await Promise.all([this.#ensureConfigLoaded(), this.#loadProjectOverrides()]);
 		if (options.path) {
 			return this.#resolvePlugin(name, options.path, config, projectOverrides);
 		}
+		const projectPlugin = await this.#resolvePluginAtActiveProjectRoot(name, projectOverrides);
+		if (projectPlugin) {
+			return projectPlugin;
+		}
+		const deps = await this.#readDeps(getPluginsPackageJson());
 		if (this.#collectInstalledNames(deps, config).has(name)) {
 			return this.#resolvePlugin(name, path.join(getPluginsNodeModules(), name), config, projectOverrides);
-		}
-		const projectPath = await this.#resolveProjectMarketplaceInstallPath(name);
-		if (projectPath) {
-			return this.#resolvePlugin(name, projectPath, config, projectOverrides);
 		}
 		return undefined;
 	}
 
 	/**
-	 * Locate a project-scoped marketplace plugin's cached install path by package
-	 * name. Project marketplace installs register their runtime symlink and
-	 * lockfile under the project root — invisible to the user-root lookup above —
-	 * so match each active-project registry entry against its resolved package
-	 * name (`package.json` `name`, falling back to the plugin-id segment).
+	 * Resolve a plugin from the active project plugin root
+	 * (`<anchor>/.omp/plugins`). Project npm/link/marketplace installs all record
+	 * their runtime state and `node_modules` symlink there — invisible to the
+	 * user-root lookup — so this reads the project's own `package.json`
+	 * dependencies plus `omp-plugins.lock.json`, and resolves the package from
+	 * the project `node_modules`. Returns undefined when there is no active
+	 * project, when it coincides with the user root, or when the package is not
+	 * installed there.
 	 */
-	async #resolveProjectMarketplaceInstallPath(name: string): Promise<string | undefined> {
+	async #resolvePluginAtActiveProjectRoot(
+		name: string,
+		projectOverrides: ProjectPluginOverrides,
+	): Promise<InstalledPlugin | undefined> {
 		const registryPath = await resolveActiveProjectRegistryPath(this.#cwd);
 		if (!registryPath) return undefined;
-		const registry = await readInstalledPluginsRegistry(registryPath);
-		for (const pluginId in registry.plugins) {
-			const fallbackName = parsePluginId(pluginId)?.name ?? pluginId;
-			for (const entry of registry.plugins[pluginId]) {
-				let packageName = fallbackName;
-				try {
-					const pkg: RuntimePackageJson = await Bun.file(path.join(entry.installPath, "package.json")).json();
-					if (typeof pkg.name === "string" && pkg.name.length > 0) packageName = pkg.name;
-				} catch (err) {
-					if (!isEnoent(err)) throw err;
-				}
-				if (packageName === name) return entry.installPath;
-			}
-		}
-		return undefined;
+		const projectRoot = path.dirname(registryPath);
+		if (path.resolve(projectRoot) === path.resolve(getPluginsDir())) return undefined;
+		const [projectDeps, projectConfig] = await Promise.all([
+			this.#readDeps(path.join(projectRoot, "package.json")),
+			this.#readRuntimeConfigAt(path.join(projectRoot, "omp-plugins.lock.json")),
+		]);
+		if (!this.#collectInstalledNames(projectDeps, projectConfig).has(name)) return undefined;
+		return this.#resolvePlugin(name, path.join(projectRoot, "node_modules", name), projectConfig, projectOverrides);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -3,10 +3,7 @@
  *
  * Provides a hierarchical settings interface:
  * - Plugin list (npm plugins + marketplace plugins)
- *   - npm plugin detail (enable/disable, features, config)
- *   - Marketplace plugin detail (enable/disable + read-only metadata)
- *     - Feature toggles
- *     - Config value editor
+ *   - Plugin details (enablement, manifest settings, and marketplace metadata)
  */
 import {
 	type Component,
@@ -23,13 +20,14 @@ import {
 import { logger } from "@oh-my-pi/pi-utils";
 import { clearPluginRootsAndCaches, resolveOrDefaultProjectRegistryPath } from "../../discovery/helpers";
 import { PluginManager } from "../../extensibility/plugins/manager";
-import type { InstalledPluginSummary } from "../../extensibility/plugins/marketplace";
 import {
 	getInstalledPluginsRegistryPath,
 	getMarketplacesCacheDir,
 	getMarketplacesRegistryPath,
 	getPluginsCacheDir,
+	type InstalledPluginSummary,
 	MarketplaceManager,
+	parsePluginId,
 } from "../../extensibility/plugins/marketplace";
 import type { InstalledPlugin, PluginSettingSchema } from "../../extensibility/plugins/types";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../../modes/theme/theme";
@@ -81,6 +79,72 @@ export interface PluginListCallbacks {
  */
 function marketplaceEnabled(summary: InstalledPluginSummary): boolean {
 	return summary.entries[0]?.enabled !== false;
+}
+
+async function buildPluginConfigItems(
+	plugin: InstalledPlugin,
+	manager: PluginManager,
+	onConfigChange: (key: string, value: unknown) => void,
+): Promise<SettingItem[]> {
+	const schemaSettings = plugin.manifest.settings;
+	if (!schemaSettings) return [];
+
+	const settings = await manager.getPluginSettings(plugin.name);
+	const items: SettingItem[] = [];
+	for (const key in schemaSettings) {
+		const schema = schemaSettings[key];
+		const currentValue = settings[key] ?? schema.default;
+		const displayValue = schema.secret && currentValue ? "••••••••" : String(currentValue ?? "(not set)");
+
+		if (schema.type === "boolean") {
+			items.push({
+				id: `config:${key}`,
+				label: `  ${key}`,
+				description: schema.description || `Configure ${key}`,
+				currentValue: currentValue ? "true" : "false",
+				values: ["true", "false"],
+			});
+		} else if (schema.type === "enum") {
+			items.push({
+				id: `config:${key}`,
+				label: `  ${key}`,
+				description: schema.description || `Configure ${key}`,
+				currentValue: String(currentValue ?? schema.default ?? ""),
+				submenu: (cv, done) =>
+					new ConfigEnumSubmenu(
+						key,
+						schema.description || `Select value for ${key}`,
+						schema.values,
+						cv,
+						value => {
+							onConfigChange(key, value);
+							done(value);
+						},
+						() => done(),
+					),
+			});
+		} else {
+			items.push({
+				id: `config:${key}`,
+				label: `  ${key}`,
+				description: schema.description || `Configure ${key}`,
+				currentValue: displayValue,
+				submenu: (cv, done) =>
+					new ConfigInputSubmenu(
+						key,
+						schema,
+						cv === "(not set)" ? "" : cv,
+						value => {
+							const parsed = schema.type === "number" ? Number(value) : value;
+							onConfigChange(key, parsed);
+							done(String(value));
+						},
+						() => done(),
+					),
+			});
+		}
+	}
+	return items;
 }
 
 /**
@@ -273,64 +337,7 @@ export class PluginDetailComponent extends OverlayPanel {
 			}
 		}
 
-		// Config settings
-		if (manifest.settings && Object.keys(manifest.settings).length > 0) {
-			const settings = await this.manager.getPluginSettings(plugin.name);
-
-			for (const [key, schema] of Object.entries(manifest.settings)) {
-				const currentValue = settings[key] ?? schema.default;
-				const displayValue = schema.secret && currentValue ? "••••••••" : String(currentValue ?? "(not set)");
-
-				if (schema.type === "boolean") {
-					items.push({
-						id: `config:${key}`,
-						label: `  ${key}`,
-						description: schema.description || `Configure ${key}`,
-						currentValue: currentValue ? "true" : "false",
-						values: ["true", "false"],
-					});
-				} else if (schema.type === "enum") {
-					items.push({
-						id: `config:${key}`,
-						label: `  ${key}`,
-						description: schema.description || `Configure ${key}`,
-						currentValue: String(currentValue ?? schema.default ?? ""),
-						submenu: (cv, done) =>
-							new ConfigEnumSubmenu(
-								key,
-								schema.description || `Select value for ${key}`,
-								schema.values,
-								cv,
-								value => {
-									this.callbacks.onConfigChange(key, value);
-									done(value);
-								},
-								() => done(),
-							),
-					});
-				} else {
-					// string or number - show as submenu with input
-					items.push({
-						id: `config:${key}`,
-						label: `  ${key}`,
-						description: schema.description || `Configure ${key}`,
-						currentValue: displayValue,
-						submenu: (cv, done) =>
-							new ConfigInputSubmenu(
-								key,
-								schema,
-								cv === "(not set)" ? "" : cv,
-								value => {
-									const parsed = schema.type === "number" ? Number(value) : value;
-									this.callbacks.onConfigChange(key, parsed);
-									done(String(value));
-								},
-								() => done(),
-							),
-					});
-				}
-			}
-		}
+		items.push(...(await buildPluginConfigItems(plugin, this.manager, this.callbacks.onConfigChange)));
 
 		this.#settingsList = new SettingsList(
 			items,
@@ -379,28 +386,57 @@ export class PluginDetailComponent extends OverlayPanel {
 
 export interface MarketplacePluginDetailCallbacks {
 	onEnabledChange: (enabled: boolean) => void;
+	onConfigChange: (pluginName: string, key: string, value: unknown) => void;
+	/** Schedules a TUI frame after asynchronous manifest settings load. */
+	requestRender?: () => void;
 	onBack: () => void;
 }
 
 /**
- * Detail view for a marketplace plugin. Marketplace plugins do not declare
- * features or settings, so the panel exposes a single enable/disable toggle
- * plus the read-only metadata from the installed-plugins registry.
+ * Detail view for a marketplace plugin, including settings declared by its
+ * runtime package and metadata from the installed-plugins registry.
  */
 export class MarketplacePluginDetailComponent extends OverlayPanel {
-	#settingsList: SettingsList;
+	#settingsList!: SettingsList;
 
 	constructor(
 		private plugin: InstalledPluginSummary,
+		private readonly manager: PluginManager,
 		private readonly callbacks: MarketplacePluginDetailCallbacks,
 	) {
 		super(plugin.id);
+		this.#render(undefined, []);
+		void this.#loadConfig();
+	}
 
+	async #loadConfig(): Promise<void> {
+		const entry = this.plugin.entries[0];
+		if (!entry) return;
+
+		const fallbackName = parsePluginId(this.plugin.id)?.name ?? this.plugin.id;
+		try {
+			const runtimePlugin = await this.manager.getPlugin(fallbackName, { path: entry.installPath });
+			if (!runtimePlugin) return;
+			const configItems = await buildPluginConfigItems(runtimePlugin, this.manager, (key, value) =>
+				this.callbacks.onConfigChange(runtimePlugin.name, key, value),
+			);
+			this.#render(runtimePlugin, configItems);
+			this.callbacks.requestRender?.();
+		} catch (err) {
+			logger.error("Settings → Plugins: failed to load marketplace plugin settings", {
+				pluginId: this.plugin.id,
+				path: entry.installPath,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	#render(runtimePlugin: InstalledPlugin | undefined, configItems: SettingItem[]): void {
+		this.clear();
+
+		const plugin = this.plugin;
 		const entry = plugin.entries[0];
-		const enabled = marketplaceEnabled(plugin);
-
 		this.title = plugin.id;
-
 		const subtitleParts = [`[${plugin.scope}]`];
 		if (plugin.shadowedBy) subtitleParts.push(`${theme.status.shadowed} shadowed by ${plugin.shadowedBy}`);
 		this.addChild(new Text(theme.fg("muted", subtitleParts.join(" ")), 0, 0));
@@ -411,14 +447,14 @@ export class MarketplacePluginDetailComponent extends OverlayPanel {
 				id: "__enabled__",
 				label: "Enabled",
 				description: "Enable or disable this marketplace plugin",
-				currentValue: enabled ? "true" : "false",
+				currentValue: marketplaceEnabled(plugin) ? "true" : "false",
 				values: ["true", "false"],
 			},
+			...configItems,
 		];
-
 		this.#settingsList = new SettingsList(
 			items,
-			items.length,
+			Math.min(items.length, 10),
 			getSettingsListTheme(),
 			(id, newValue) => {
 				if (id === "__enabled__") {
@@ -428,6 +464,11 @@ export class MarketplacePluginDetailComponent extends OverlayPanel {
 						...this.plugin,
 						entries: this.plugin.entries.map(e => ({ ...e, enabled: next })),
 					};
+				} else if (id.startsWith("config:")) {
+					const key = id.slice(7);
+					if (runtimePlugin?.manifest.settings?.[key]?.type === "boolean") {
+						this.callbacks.onConfigChange(runtimePlugin.name, key, newValue === "true");
+					}
 				}
 			},
 			this.callbacks.onBack,
@@ -435,9 +476,6 @@ export class MarketplacePluginDetailComponent extends OverlayPanel {
 
 		this.addChild(this.#settingsList);
 		this.addChild(new Spacer(1));
-
-		// Read-only metadata. SettingsList rejects items without `values`/`submenu`,
-		// so we render the metadata as plain text rows beneath the toggle.
 		this.addChild(new Text(theme.fg("dim", `version       ${entry?.version ?? "(unknown)"}`), 0, 0));
 		this.addChild(new Text(theme.fg("dim", `scope         ${plugin.scope}`), 0, 0));
 		this.addChild(
@@ -454,7 +492,7 @@ export class MarketplacePluginDetailComponent extends OverlayPanel {
 		}
 
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "Enter to toggle · Esc to go back"), 0, 0));
+		this.addChild(new Text(theme.fg("dim", "Enter to edit · Esc to go back"), 0, 0));
 	}
 
 	handleInput(data: string): void {
@@ -571,6 +609,8 @@ class ConfigInputSubmenu extends OverlayPanel {
 export interface PluginSettingsCallbacks {
 	onClose: () => void;
 	onPluginChanged: () => void | Promise<void>;
+	/** Schedules a TUI frame after asynchronous plugin data loads. */
+	requestRender?: () => void;
 }
 
 /** Component with handleInput method */
@@ -693,7 +733,7 @@ export class PluginSettingsComponent extends Container {
 		this.#currentMarketplacePlugin = plugin;
 		this.clear();
 
-		this.#viewComponent = new MarketplacePluginDetailComponent(plugin, {
+		this.#viewComponent = new MarketplacePluginDetailComponent(plugin, this.#manager, {
 			onEnabledChange: async enabled => {
 				try {
 					const mgr = await this.#buildMarketplaceManager();
@@ -708,7 +748,12 @@ export class PluginSettingsComponent extends Container {
 					});
 				}
 			},
+			onConfigChange: async (pluginName, key, value) => {
+				await this.#manager.setPluginSetting(pluginName, key, value);
+				await this.callbacks.onPluginChanged();
+			},
 			onBack: () => this.#showPluginList(),
+			requestRender: this.callbacks.requestRender,
 		});
 
 		this.addChild(this.#viewComponent);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1406,6 +1406,7 @@ export class SettingsSelectorComponent implements Component {
 		this.#pluginComponent = new PluginSettingsComponent(this.context.cwd, {
 			onClose: () => this.callbacks.onCancel(),
 			onPluginChanged: () => this.callbacks.onPluginsChanged?.(),
+			requestRender: this.context.requestRender,
 		});
 	}
 

--- a/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
+++ b/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
@@ -249,54 +249,100 @@ describe("PluginSettingsComponent", () => {
 	});
 });
 
+async function renderMarketplaceDetail(component: MarketplacePluginDetailComponent, needle: string): Promise<string> {
+	for (let i = 0; i < 5; i++) {
+		await Promise.resolve();
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		if (text.includes(needle)) return text;
+	}
+	return stripVTControlCharacters(component.render(120).join("\n"));
+}
+
 describe("MarketplacePluginDetailComponent", () => {
-	it("exposes the enable toggle and metadata", () => {
+	it("exposes the enable toggle and metadata", async () => {
 		const plugin = marketplace("plugin@mkt", {
 			entry: { gitCommitSha: "abc1234", enabled: false },
 		});
+		const manager = new PluginManager(process.cwd());
+		spyOn(manager, "getPlugin").mockResolvedValue(undefined);
 
-		const component = new MarketplacePluginDetailComponent(plugin, {
+		const component = new MarketplacePluginDetailComponent(plugin, manager, {
 			onEnabledChange: () => {},
+			onConfigChange: () => {},
 			onBack: () => {},
 		});
 
-		const text = stripVTControlCharacters(component.render(120).join("\n"));
-		expect(text).toContain("plugin@mkt");
+		const text = await renderMarketplaceDetail(component, "plugin@mkt");
 		expect(text).toContain("Enabled");
-		// Read-only metadata must surface, including scope and the git commit SHA.
 		expect(text).toContain("0.4.2");
 		expect(text).toContain("abc1234");
 		expect(text).toContain("user");
 		expect(text).toContain("/cache/marketplace/plugin@mkt");
 	});
 
-	it("invokes onEnabledChange when the enabled toggle is activated", () => {
+	it("invokes onEnabledChange when the enabled toggle is activated", async () => {
 		const calls: boolean[] = [];
-		const component = new MarketplacePluginDetailComponent(marketplace("toggle@mkt"), {
+		const manager = new PluginManager(process.cwd());
+		spyOn(manager, "getPlugin").mockResolvedValue(undefined);
+		const component = new MarketplacePluginDetailComponent(marketplace("toggle@mkt"), manager, {
 			onEnabledChange: enabled => calls.push(enabled),
+			onConfigChange: () => {},
 			onBack: () => {},
 		});
+		await renderMarketplaceDetail(component, "Enabled");
 
-		// Activate the Enabled toggle (it is the first item). Space cycles its value.
 		component.handleInput(" ");
 
 		expect(calls).toEqual([false]);
 	});
 
-	it("shortens home-relative install paths to ~ before rendering", () => {
+	it("renders and updates settings from the marketplace runtime package", async () => {
+		const manager = new PluginManager(process.cwd());
+		const runtimePlugin = npm("omp-commit", {
+			manifest: {
+				version: "1.0.0",
+				settings: {
+					mainBranchProtection: {
+						type: "boolean",
+						default: true,
+					},
+				},
+			},
+		});
+		spyOn(manager, "getPlugin").mockResolvedValue(runtimePlugin);
+		spyOn(manager, "getPluginSettings").mockResolvedValue({});
+		const changes: Array<[string, string, unknown]> = [];
+		let renderRequests = 0;
+		const component = new MarketplacePluginDetailComponent(marketplace("omp-commit@market"), manager, {
+			onEnabledChange: () => {},
+			onConfigChange: (pluginName, key, value) => changes.push([pluginName, key, value]),
+			requestRender: () => renderRequests++,
+			onBack: () => {},
+		});
+		const text = await renderMarketplaceDetail(component, "mainBranchProtection");
+		expect(text).toContain("true");
+		expect(renderRequests).toBe(1);
+
+		component.handleInput("\x1b[B");
+		component.handleInput(" ");
+
+		expect(changes).toEqual([["omp-commit", "mainBranchProtection", false]]);
+	});
+
+	it("shortens home-relative install paths to ~ before rendering", async () => {
 		const home = os.homedir();
 		const installPath = `${home}/.omp/cache/plugins/sample@mkt`;
 		const plugin = marketplace("sample@mkt", { entry: { installPath } });
+		const manager = new PluginManager(process.cwd());
+		spyOn(manager, "getPlugin").mockResolvedValue(undefined);
 
-		const component = new MarketplacePluginDetailComponent(plugin, {
+		const component = new MarketplacePluginDetailComponent(plugin, manager, {
 			onEnabledChange: () => {},
+			onConfigChange: () => {},
 			onBack: () => {},
 		});
 
-		const text = stripVTControlCharacters(component.render(120).join("\n"));
-		// `shortenPath` keeps the rest of the path intact but replaces $HOME with `~`,
-		// so the user's home directory never leaks into the rendered TUI surface.
-		expect(text).toContain("~/.omp/cache/plugins/sample@mkt");
+		const text = await renderMarketplaceDetail(component, "~/.omp/cache/plugins/sample@mkt");
 		expect(text).not.toContain(home);
 	});
 });

--- a/packages/coding-agent/test/plugin-config-validate.test.ts
+++ b/packages/coding-agent/test/plugin-config-validate.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for `omp plugin config validate` (#9106).
+ *
+ * `handleConfigValidate` used to enumerate only `PluginManager.list()`, which
+ * intentionally omits marketplace runtime packages — so an invalid constrained
+ * value stored for a marketplace plugin (e.g. after a schema-changing upgrade or
+ * a bad TUI write) was skipped and validation falsely reported success. The fix
+ * adds a marketplace-aware enumeration path.
+ *
+ * `flags.json` is set so the renderer takes the JSON branch and avoids the theme.
+ */
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { runPluginCommand } from "@oh-my-pi/pi-coding-agent/cli/plugin-cli";
+import { PluginManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/manager";
+import type { InstalledPluginSummary } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import { MarketplaceManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import type { InstalledPlugin } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/types";
+
+describe("runPluginCommand({ action: 'config', args: ['validate'] })", () => {
+	const output: string[] = [];
+
+	beforeEach(() => {
+		output.length = 0;
+		spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			output.push(args.map(String).join(" "));
+		});
+		spyOn(console, "error").mockImplementation(() => undefined);
+	});
+	afterEach(() => {
+		mock.restore();
+	});
+
+	test("reports an invalid stored value on a marketplace plugin that list() omits", async () => {
+		const summary: InstalledPluginSummary = {
+			id: "omp-commit@market",
+			scope: "user",
+			entries: [
+				{
+					scope: "user",
+					installPath: "/cache/omp-commit",
+					version: "2.0.0",
+					installedAt: "2026-08-20T00:00:00.000Z",
+					lastUpdated: "2026-08-20T00:00:00.000Z",
+				},
+			],
+		};
+		const resolved: InstalledPlugin = {
+			name: "omp-commit",
+			version: "2.0.0",
+			path: "/cache/omp-commit",
+			manifest: {
+				version: "2.0.0",
+				settings: { splitMode: { type: "enum", values: ["auto", "manual"], default: "auto" } },
+			},
+			enabledFeatures: null,
+			enabled: true,
+		};
+
+		// list() omits marketplace runtime packages by design.
+		spyOn(PluginManager.prototype, "list").mockResolvedValue([]);
+		spyOn(MarketplaceManager.prototype, "listInstalledPlugins").mockResolvedValue([summary]);
+		const getPlugin = spyOn(PluginManager.prototype, "getPlugin").mockResolvedValue(resolved);
+		spyOn(PluginManager.prototype, "getPluginSettings").mockResolvedValue({ splitMode: "bogus" });
+
+		await runPluginCommand({ action: "config", args: ["validate"], flags: { json: true } });
+
+		// Resolved through the trusted marketplace install path.
+		expect(getPlugin).toHaveBeenCalledWith("omp-commit", { path: "/cache/omp-commit" });
+
+		const report = JSON.parse(output.join("\n")) as {
+			valid: boolean;
+			errors: Array<{ plugin: string; key: string }>;
+		};
+		expect(report.valid).toBe(false);
+		expect(report.errors).toContainEqual(expect.objectContaining({ plugin: "omp-commit", key: "splitMode" }));
+	});
+});

--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -55,4 +55,61 @@ describe("plugin config", () => {
 
 		await expect(new PluginManager(tmpRoot).getPluginSettings(pluginName)).resolves.toEqual({});
 	});
+
+	test("resolves marketplace settings without restoring duplicate list entries", async () => {
+		const pluginName = "omp-commit";
+		const installPath = path.join(pluginsDir, "cache", pluginName);
+		const pluginPath = path.join(pluginsDir, "node_modules", pluginName);
+		await Bun.write(
+			path.join(installPath, "package.json"),
+			JSON.stringify({
+				name: pluginName,
+				version: "1.0.0",
+				omp: {
+					version: "1.0.0",
+					settings: {
+						mainBranchProtection: {
+							type: "boolean",
+							default: true,
+						},
+					},
+				},
+			}),
+		);
+		await fs.mkdir(path.dirname(pluginPath), { recursive: true });
+		await fs.symlink(installPath, pluginPath, "dir");
+		await Bun.write(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"omp-commit@market": [
+						{
+							scope: "user",
+							installPath,
+							version: "1.0.0",
+							installedAt: "2026-08-20T00:00:00.000Z",
+							lastUpdated: "2026-08-20T00:00:00.000Z",
+						},
+					],
+				},
+			}),
+		);
+		await Bun.write(
+			lockfile,
+			JSON.stringify({
+				plugins: {
+					[pluginName]: { version: "1.0.0", enabledFeatures: null, enabled: true },
+				},
+				settings: {},
+			}),
+		);
+
+		const manager = new PluginManager(tmpRoot);
+		expect(await manager.list()).toEqual([]);
+		expect((await manager.getPlugin(pluginName))?.manifest.settings?.mainBranchProtection?.default).toBe(true);
+
+		await manager.setPluginSetting(pluginName, "mainBranchProtection", false);
+		expect(await manager.getPluginSettings(pluginName)).toEqual({ mainBranchProtection: false });
+	});
 });

--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -112,4 +112,46 @@ describe("plugin config", () => {
 		await manager.setPluginSetting(pluginName, "mainBranchProtection", false);
 		expect(await manager.getPluginSettings(pluginName)).toEqual({ mainBranchProtection: false });
 	});
+
+	test("resolves project-scoped marketplace plugin via the active project registry", async () => {
+		const pluginName = "omp-commit";
+		const installPath = path.join(tmpRoot, "cache", "omp-commit-project");
+		await Bun.write(
+			path.join(installPath, "package.json"),
+			JSON.stringify({
+				name: pluginName,
+				version: "2.0.0",
+				omp: {
+					version: "2.0.0",
+					settings: {
+						splitMode: { type: "enum", values: ["auto", "manual"], default: "auto" },
+					},
+				},
+			}),
+		);
+		// Project anchor (.omp/) plus a project-scoped marketplace registry entry —
+		// none of it registered in the user plugin root.
+		await fs.mkdir(path.join(tmpRoot, ".omp", "plugins"), { recursive: true });
+		await Bun.write(
+			path.join(tmpRoot, ".omp", "plugins", "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"omp-commit@market": [
+						{
+							scope: "project",
+							installPath,
+							version: "2.0.0",
+							installedAt: "2026-08-20T00:00:00.000Z",
+							lastUpdated: "2026-08-20T00:00:00.000Z",
+						},
+					],
+				},
+			}),
+		);
+
+		const manager = new PluginManager(tmpRoot);
+		expect(await manager.list()).toEqual([]);
+		expect((await manager.getPlugin(pluginName))?.manifest.settings?.splitMode?.default).toBe("auto");
+	});
 });

--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -113,45 +113,62 @@ describe("plugin config", () => {
 		expect(await manager.getPluginSettings(pluginName)).toEqual({ mainBranchProtection: false });
 	});
 
-	test("resolves project-scoped marketplace plugin via the active project registry", async () => {
-		const pluginName = "omp-commit";
-		const installPath = path.join(tmpRoot, "cache", "omp-commit-project");
+	async function writeManifest(dir: string, manifest: Record<string, unknown>): Promise<void> {
 		await Bun.write(
-			path.join(installPath, "package.json"),
-			JSON.stringify({
-				name: pluginName,
+			path.join(dir, "package.json"),
+			JSON.stringify({ name: "omp-commit", version: "2.0.0", ...manifest }),
+		);
+	}
+
+	async function installProjectMarketplacePlugin(schemaDefault: string): Promise<string> {
+		const installPath = path.join(tmpRoot, "cache", `omp-commit-project-${schemaDefault}`);
+		await writeManifest(installPath, {
+			omp: {
 				version: "2.0.0",
-				omp: {
-					version: "2.0.0",
-					settings: {
-						splitMode: { type: "enum", values: ["auto", "manual"], default: "auto" },
-					},
-				},
-			}),
-		);
-		// Project anchor (.omp/) plus a project-scoped marketplace registry entry —
-		// none of it registered in the user plugin root.
-		await fs.mkdir(path.join(tmpRoot, ".omp", "plugins"), { recursive: true });
+				settings: { splitMode: { type: "enum", values: ["auto", "manual"], default: schemaDefault } },
+			},
+		});
+		const projectRoot = path.join(tmpRoot, ".omp", "plugins");
+		await fs.mkdir(path.join(projectRoot, "node_modules"), { recursive: true });
+		await fs.symlink(installPath, path.join(projectRoot, "node_modules", "omp-commit"), "dir");
 		await Bun.write(
-			path.join(tmpRoot, ".omp", "plugins", "installed_plugins.json"),
+			path.join(projectRoot, "omp-plugins.lock.json"),
 			JSON.stringify({
-				version: 2,
-				plugins: {
-					"omp-commit@market": [
-						{
-							scope: "project",
-							installPath,
-							version: "2.0.0",
-							installedAt: "2026-08-20T00:00:00.000Z",
-							lastUpdated: "2026-08-20T00:00:00.000Z",
-						},
-					],
-				},
+				plugins: { "omp-commit": { version: "2.0.0", enabledFeatures: null, enabled: true } },
+				settings: {},
 			}),
 		);
+		return installPath;
+	}
+
+	test("resolves a project-scoped marketplace plugin absent from the user root", async () => {
+		await installProjectMarketplacePlugin("auto");
 
 		const manager = new PluginManager(tmpRoot);
 		expect(await manager.list()).toEqual([]);
-		expect((await manager.getPlugin(pluginName))?.manifest.settings?.splitMode?.default).toBe("auto");
+		expect((await manager.getPlugin("omp-commit"))?.manifest.settings?.splitMode?.default).toBe("auto");
+	});
+
+	test("prefers the active project plugin over a same-named user install", async () => {
+		// User install: same package name, different schema default.
+		const userPkg = path.join(pluginsDir, "node_modules", "omp-commit");
+		await writeManifest(userPkg, {
+			omp: {
+				version: "1.0.0",
+				settings: { splitMode: { type: "enum", values: ["auto", "manual"], default: "manual" } },
+			},
+		});
+		await Bun.write(
+			lockfile,
+			JSON.stringify({
+				plugins: { "omp-commit": { version: "1.0.0", enabledFeatures: null, enabled: true } },
+				settings: {},
+			}),
+		);
+		// Project install shadows it with default "auto".
+		await installProjectMarketplacePlugin("auto");
+
+		const manager = new PluginManager(tmpRoot);
+		expect((await manager.getPlugin("omp-commit"))?.manifest.settings?.splitMode?.default).toBe("auto");
 	});
 });


### PR DESCRIPTION
## Repro
With a registry-backed marketplace package symlink declaring `package.json#omp.settings`, `XDG_DATA_HOME=<fixture> bun packages/coding-agent/src/cli.ts plugin config list omp-commit` exited 1 with a plugin-not-found error; Settings → Plugins showed only enablement and registry metadata.

## Cause
`handleConfig()` in `packages/coding-agent/src/cli/plugin-cli.ts` resolved targets through `PluginManager.list()`, whose intentional marketplace-symlink filter prevents duplicate list/status entries. `MarketplacePluginDetailComponent` in `packages/coding-agent/src/modes/components/plugin-settings.ts` consumed only `InstalledPluginSummary`, so it never resolved the runtime package manifest or settings store.

## Fix
- Add `PluginManager.getPlugin()` to resolve one registered package, or a trusted marketplace install path, without changing `list()` deduplication.
- Resolve config command targets through that direct path.
- Reuse the existing manifest setting editors for marketplace details and request a TUI redraw after asynchronous settings load.
- Cover direct marketplace resolution, preserved list deduplication, settings rendering, mutation, and redraw behavior.

## Verification
- `bun test test/plugin-config.test.ts test/modes/components/plugin-list-marketplace.test.ts` — 15 passed, 0 failed.
- `bun check` in `packages/coding-agent` — Biome and `tsgo --noEmit` passed.
- Re-ran `plugin config list/set/get/delete` against the marketplace fixture; all resolved `omp-commit`, and set/get/delete persisted the expected boolean/default values.
- Launched the actual TUI against the fixture; Settings → Plugins rendered `mainBranchProtection` automatically and Space changed it from `true` to `false`.

Fixes #9106