### PR TITLE
fix(extensibility): break legacy-pi shim resolution self-loop bricking startup (#8900)

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -32,6 +32,7 @@ import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../
 import { EventBus } from "../../utils/event-bus";
 import * as TypeBox from "../legacy-typebox";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/legacy-pi-compat";
+import { installLegacyPiShimLoopGuard } from "../plugins/legacy-pi-shim-loop-guard";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 
 import { resolvePath, withHostGuard } from "../utils";
@@ -51,6 +52,10 @@ import type {
 	ToolInfo,
 } from "./types";
 
+// Guard first: Bun runs onResolve hooks in registration order, and the loop
+// guard must see shim-originated resolutions before the compat resolver's
+// override map does (issue #8900).
+installLegacyPiShimLoopGuard();
 installLegacyPiSpecifierShim();
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-shim-loop-guard.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-shim-loop-guard.ts
@@ -1,0 +1,207 @@
+/**
+ * Shim resolution self-loop guard (issue #8900).
+ *
+ * The compat shims value-import their own canonical package root by bare
+ * specifier: `legacy-pi-tui-shim.ts` does `export * from "@oh-my-pi/pi-tui"`,
+ * the pi-ai shim re-exports `@oh-my-pi/pi-ai`, and the coding-agent shim
+ * imports `@oh-my-pi/pi-tui` / `@oh-my-pi/pi-ai`. The process-global
+ * `onResolve` installed by `installLegacyPiSpecifierShim()` also fires for
+ * imports originating *from* those shim files, and its package-root override
+ * map sends the bare specifier straight back onto the shim. ESM tolerates a
+ * true self-cycle, but when consecutive hops disagree on module identity —
+ * macOS symlink realpath divergence (`/var` → `/private/var`), bun
+ * global-cache install paths, `?mtime=` cache-bust suffixes — Bun keys every
+ * hop as a brand-new module and resolution recurses without bound: an opaque
+ * `RangeError: Maximum call stack size exceeded` before the TUI exists,
+ * triggered by a single custom tool that value-imports
+ * `@oh-my-pi/pi-coding-agent`.
+ *
+ * The guard is a separate `Bun.plugin` registered *before*
+ * `installLegacyPiSpecifierShim()` — Bun runs `onResolve` hooks in
+ * registration order and the first non-undefined result wins. Imports issued
+ * by an on-disk compat shim resolve the real canonical package here and never
+ * reach the override map; every other resolution falls through untouched.
+ * Shim → canonical always terminates; extension → shim behavior is unchanged.
+ *
+ * Compiled-binary mode serves the shims as virtual modules in the
+ * `omp-legacy-pi-bundled` namespace, so the guard is inert there by
+ * construction and skips installation entirely.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isCompiledBinary } from "@oh-my-pi/pi-utils";
+import { registerPluginCacheInvalidator } from "../../discovery/helpers";
+import { __computeBundledSelfPackageRoot } from "./legacy-pi-compat";
+
+// Mirrors the scope/package alternation of `LEGACY_PI_SPECIFIER_FILTER` in
+// legacy-pi-compat.ts. The two filters must stay in sync: the guard only needs
+// to fire for specifiers the compat resolver would also claim.
+const PI_SCOPE_ALIASES = ["oh-my-pi", "mariozechner", "earendil-works"] as const;
+const PI_PACKAGE_NAMES = ["pi-agent-core", "pi-ai", "pi-coding-agent", "pi-natives", "pi-tui", "pi-utils"] as const;
+const LEGACY_PI_SPECIFIER_FILTER = new RegExp(
+	`^@(?:${PI_SCOPE_ALIASES.join("|")})/(?:${PI_PACKAGE_NAMES.join("|")})(?:/.*)?$`,
+);
+const LEGACY_PI_SCOPE_PREFIX = new RegExp(`^@(?:${PI_SCOPE_ALIASES.join("|")})/`);
+
+// Compiled-mode virtual specifiers (`omp-legacy-pi-bundled:<key>`) are served
+// by dedicated handlers in legacy-pi-compat.ts and must never be treated as
+// filesystem paths here.
+const BUNDLED_VIRTUAL_SCHEME = "omp-legacy-pi-bundled:";
+
+function isBundledVirtualSpecifier(value: string): boolean {
+	return value.startsWith(BUNDLED_VIRTUAL_SCHEME);
+}
+
+/** Canonicalize a legacy `@(scope)/pi-*` specifier onto `@oh-my-pi/`. */
+export function __canonicalizeLegacyPiSpecifier(specifier: string): string {
+	return specifier.replace(LEGACY_PI_SCOPE_PREFIX, "@oh-my-pi/");
+}
+
+const syncRealpathCache = new Map<string, string>();
+
+function clearShimLoopGuardCaches(): void {
+	syncRealpathCache.clear();
+}
+
+registerPluginCacheInvalidator(clearShimLoopGuardCaches);
+
+function realpathSyncOrSelf(candidatePath: string, realpathSyncImpl?: (p: string) => string): string {
+	if (realpathSyncImpl) {
+		// Injected impls (tests) skip the module-level cache so stubs cannot
+		// poison production resolutions.
+		try {
+			return realpathSyncImpl(candidatePath);
+		} catch {
+			return candidatePath;
+		}
+	}
+	const cached = syncRealpathCache.get(candidatePath);
+	if (cached !== undefined) {
+		return cached;
+	}
+	let real = candidatePath;
+	try {
+		real = fs.realpathSync(candidatePath);
+	} catch {
+		// Missing path: fall back to identity so comparison still uses the
+		// raw normalized path.
+	}
+	syncRealpathCache.set(candidatePath, real);
+	return real;
+}
+
+/**
+ * Normalize a resolver path for identity comparison: drop `?mtime=` style
+ * cache-bust suffixes, `path.normalize`, then resolve symlinks.
+ */
+function comparableResolverPath(candidatePath: string, realpathSyncImpl?: (p: string) => string): string {
+	const queryIdx = candidatePath.indexOf("?");
+	const withoutQuery = queryIdx === -1 ? candidatePath : candidatePath.slice(0, queryIdx);
+	return realpathSyncOrSelf(path.normalize(withoutQuery), realpathSyncImpl);
+}
+
+/**
+ * True when handing `resolved` to `importer` would give a module its own file
+ * back under a (possibly different) path — the direct self-edge of the issue
+ * #8900 recursion. Comparison is `path.normalize` + realpath insensitive and
+ * ignores query-string cache-bust suffixes.
+ *
+ * Exported for tests; production callers go through the installed guard.
+ */
+export function __isLegacyPiSelfLoopResolution(
+	resolved: string,
+	importer: string | undefined,
+	realpathSyncImpl?: (p: string) => string,
+): boolean {
+	if (!importer || isBundledVirtualSpecifier(resolved) || isBundledVirtualSpecifier(importer)) {
+		return false;
+	}
+	return comparableResolverPath(resolved, realpathSyncImpl) === comparableResolverPath(importer, realpathSyncImpl);
+}
+
+const SHIM_FILE_NAMES = ["legacy-pi-ai-shim.ts", "legacy-pi-coding-agent-shim.ts", "legacy-pi-tui-shim.ts"] as const;
+
+/**
+ * The on-disk compat shim paths, computed the same way legacy-pi-compat.ts
+ * computes them: from the npm prebuilt package root when `PI_BUNDLED` is set
+ * (`bundle-dist.ts` defines it; `import.meta.dir` then points at
+ * `<package>/dist`), otherwise from the monorepo source tree relative to this
+ * file.
+ */
+function defaultShimPaths(): string[] {
+	const bundledRoot = process.env.PI_BUNDLED ? __computeBundledSelfPackageRoot(import.meta.dir) : undefined;
+	const shimDir = bundledRoot ? path.join(bundledRoot, "src", "extensibility") : path.resolve(import.meta.dir, "..");
+	return SHIM_FILE_NAMES.map(file => path.join(shimDir, file));
+}
+
+/**
+ * True when `importer` is one of the on-disk compat shim modules. Imports
+ * issued by the shims themselves must resolve the real canonical packages —
+ * mapping them back onto a shim is either an immediate self-cycle (the
+ * pi-tui / pi-ai shims re-export their own package root) or one resolution
+ * hop away from one.
+ *
+ * Exported for tests; production callers go through the installed guard.
+ */
+export function __isLegacyPiShimImporter(
+	importer: string | undefined,
+	shimPaths: readonly string[] = defaultShimPaths(),
+	realpathSyncImpl?: (p: string) => string,
+): boolean {
+	if (!importer || isBundledVirtualSpecifier(importer)) {
+		return false;
+	}
+	const comparableImporter = comparableResolverPath(importer, realpathSyncImpl);
+	return shimPaths.some(shimPath => comparableResolverPath(shimPath, realpathSyncImpl) === comparableImporter);
+}
+
+let isLegacyPiShimLoopGuardInstalled = false;
+
+/**
+ * Install the guard plugin. Must be called before
+ * `installLegacyPiSpecifierShim()` so this `onResolve` runs first. Idempotent.
+ */
+export function installLegacyPiShimLoopGuard(): void {
+	if (isLegacyPiShimLoopGuardInstalled || isCompiledBinary()) {
+		// Compiled-binary mode serves shims as virtual modules in a separate
+		// namespace; there is no file-namespace shim importer to guard.
+		isLegacyPiShimLoopGuardInstalled = true;
+		return;
+	}
+	isLegacyPiShimLoopGuardInstalled = true;
+
+	Bun.plugin({
+		name: "omp:legacy-pi-shim-loop-guard",
+		setup(build) {
+			build.onResolve({ filter: LEGACY_PI_SPECIFIER_FILTER, namespace: "file" }, args => {
+				if (!__isLegacyPiShimImporter(args.importer)) {
+					// Not shim-originated: fall through to the compat resolver.
+					return undefined;
+				}
+				const canonical = __canonicalizeLegacyPiSpecifier(args.path);
+				// Prefer host-relative resolution (dev mode and source-link
+				// installs), then the importer's own tree (plugin-installed
+				// peer deps). Both failing means the canonical package is
+				// genuinely unresolvable; fall through so the compat
+				// resolver's own fallbacks (and error surface) apply.
+				try {
+					const resolved = Bun.resolveSync(canonical, import.meta.dir);
+					if (!__isLegacyPiSelfLoopResolution(resolved, args.importer)) {
+						return { path: resolved };
+					}
+				} catch {
+					// Continue to importer-relative resolution below.
+				}
+				try {
+					const resolved = Bun.resolveSync(canonical, path.dirname(args.importer));
+					if (!__isLegacyPiSelfLoopResolution(resolved, args.importer)) {
+						return { path: resolved };
+					}
+				} catch {
+					// Fall through to the compat resolver.
+				}
+				return undefined;
+			});
+		},
+	});
+}

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -10,6 +10,7 @@ import { getPluginsDir, getPluginsLockfile, isEnoent } from "@oh-my-pi/pi-utils"
 import { getConfigDirPaths } from "../../config";
 import { registerPluginCacheInvalidator, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
+import { installLegacyPiShimLoopGuard } from "./legacy-pi-shim-loop-guard";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type { InstalledPlugin, PluginManifest, PluginRuntimeConfig, ProjectPluginOverrides } from "./types";
 
@@ -18,6 +19,10 @@ export interface ScopedInstalledPlugin extends InstalledPlugin {
 	scope: "user" | "project";
 }
 
+// Guard first: Bun runs onResolve hooks in registration order, and the loop
+// guard must see shim-originated resolutions before the compat resolver's
+// override map does (issue #8900).
+installLegacyPiShimLoopGuard();
 installLegacyPiSpecifierShim();
 
 const enabledPluginsCache = new Map<string, Promise<ScopedInstalledPlugin[]>>();

--- a/packages/coding-agent/test/extensibility/legacy-pi-shim-self-loop.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-shim-self-loop.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	__isLegacyPiSelfLoopResolution,
+	__isLegacyPiShimImporter,
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+
+// Regression for issue #8900: a custom tool that value-imports
+// `@oh-my-pi/pi-coding-agent` bricked the agent with an opaque
+// `RangeError: Maximum call stack size exceeded` before the TUI existed.
+//
+// Mechanism: the process-global `onResolve` installed by
+// `installLegacyPiSpecifierShim()` also fires for imports originating *from*
+// the compat shims, and the package-root override map sent the shims' own
+// bare re-exports (`legacy-pi-tui-shim.ts` does
+// `export * from "@oh-my-pi/pi-tui"`) straight back onto the shim. ESM
+// tolerates a true self-cycle, but when consecutive hops disagree on module
+// identity — macOS `/var` → `/private/var` symlink realpaths, bun
+// global-cache install paths, `?mtime=` cache-bust suffixes — Bun keys every
+// hop as a new module and resolution recurses without bound.
+//
+// The fix routes shim-originated (or otherwise self-targeting) resolutions to
+// the real canonical package. These tests pin the guard predicates, including
+// the path-identity-divergence cases that made the loop environment-specific.
+describe("legacy pi shim resolution self-loop guard (issue #8900)", () => {
+	const SHIM = "/host/src/extensibility/legacy-pi-tui-shim.ts";
+
+	describe("__isLegacyPiSelfLoopResolution", () => {
+		it("detects the direct self-edge (resolved === importer)", () => {
+			expect(__isLegacyPiSelfLoopResolution(SHIM, SHIM)).toBe(true);
+		});
+
+		it("detects the self-edge across symlink realpath divergence (macOS /var vs /private/var)", () => {
+			const realpaths = new Map([["/var/host/legacy-pi-tui-shim.ts", "/private/var/host/legacy-pi-tui-shim.ts"]]);
+			const realpathStub = (p: string): string => {
+				const mapped = realpaths.get(p);
+				if (mapped) return mapped;
+				return p;
+			};
+			expect(
+				__isLegacyPiSelfLoopResolution(
+					"/var/host/legacy-pi-tui-shim.ts",
+					"/private/var/host/legacy-pi-tui-shim.ts",
+					realpathStub,
+				),
+			).toBe(true);
+		});
+
+		it("detects the self-edge when the importer carries a ?mtime= cache-bust suffix", () => {
+			expect(__isLegacyPiSelfLoopResolution(SHIM, `${SHIM}?mtime=42`, p => p)).toBe(true);
+		});
+
+		it("detects the self-edge through unnormalized path segments", () => {
+			const unnormalized = "/host/src/extensibility/../extensibility/legacy-pi-tui-shim.ts";
+			expect(__isLegacyPiSelfLoopResolution(unnormalized, SHIM, p => p)).toBe(true);
+		});
+
+		it("passes distinct modules through", () => {
+			expect(__isLegacyPiSelfLoopResolution(SHIM, "/project/tools/probe.ts", p => p)).toBe(false);
+		});
+
+		it("never flags virtual omp-legacy-pi-bundled: specifiers", () => {
+			expect(__isLegacyPiSelfLoopResolution("omp-legacy-pi-bundled:@oh-my-pi/pi-tui", SHIM, p => p)).toBe(false);
+			expect(__isLegacyPiSelfLoopResolution(SHIM, "omp-legacy-pi-bundled:@oh-my-pi/pi-tui", p => p)).toBe(false);
+		});
+
+		it("passes missing importers through", () => {
+			expect(__isLegacyPiSelfLoopResolution(SHIM, undefined, p => p)).toBe(false);
+			expect(__isLegacyPiSelfLoopResolution(SHIM, "", p => p)).toBe(false);
+		});
+	});
+
+	describe("__isLegacyPiShimImporter", () => {
+		const SHIM_PATHS = [
+			"/host/src/extensibility/legacy-pi-ai-shim.ts",
+			"/host/src/extensibility/legacy-pi-coding-agent-shim.ts",
+			"/host/src/extensibility/legacy-pi-tui-shim.ts",
+		] as const;
+
+		it("flags imports issued by a shim file", () => {
+			expect(__isLegacyPiShimImporter(SHIM, SHIM_PATHS, p => p)).toBe(true);
+		});
+
+		it("flags shim importers reached through a symlinked path", () => {
+			const realpathStub = (p: string): string =>
+				p === "/var/link/legacy-pi-tui-shim.ts" ? "/host/src/extensibility/legacy-pi-tui-shim.ts" : p;
+			expect(__isLegacyPiShimImporter("/var/link/legacy-pi-tui-shim.ts", SHIM_PATHS, realpathStub)).toBe(true);
+		});
+
+		it("passes non-shim importers through", () => {
+			expect(__isLegacyPiShimImporter("/project/tools/probe.ts", SHIM_PATHS, p => p)).toBe(false);
+			expect(__isLegacyPiShimImporter(undefined, SHIM_PATHS, p => p)).toBe(false);
+		});
+
+		it("never flags virtual-namespace importers (compiled-binary mode)", () => {
+			expect(__isLegacyPiShimImporter("omp-legacy-pi-bundled:@oh-my-pi/pi-tui", SHIM_PATHS, p => p)).toBe(false);
+		});
+
+		it("recognizes the real on-disk shim files through the default shim set", () => {
+			// In dev / source-link mode the default shim set is the three
+			// sibling source files. The tui shim is the one whose
+			// `export * from "@oh-my-pi/pi-tui"` re-entered the resolver.
+			const realTuiShim = path.resolve(import.meta.dir, "..", "..", "src", "extensibility", "legacy-pi-tui-shim.ts");
+			expect(fs.existsSync(realTuiShim)).toBe(true);
+			expect(__isLegacyPiShimImporter(realTuiShim)).toBe(true);
+			expect(__isLegacyPiShimImporter(fs.realpathSync(realTuiShim))).toBe(true);
+		});
+
+		it("recognizes a symlinked copy of a real shim file (the environment-specific loop trigger)", () => {
+			const realTuiShim = path.resolve(import.meta.dir, "..", "..", "src", "extensibility", "legacy-pi-tui-shim.ts");
+			const linkDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-8900-"));
+			const linkPath = path.join(linkDir, "legacy-pi-tui-shim.ts");
+			try {
+				fs.symlinkSync(realTuiShim, linkPath);
+			} catch {
+				// Symlink creation can be unavailable (e.g. restricted CI
+				// runners); the realpath-divergence behavior is still pinned
+				// by the stub-based cases above.
+				fs.rmSync(linkDir, { recursive: true, force: true });
+				return;
+			}
+			try {
+				expect(__isLegacyPiShimImporter(linkPath)).toBe(true);
+			} finally {
+				fs.rmSync(linkDir, { recursive: true, force: true });
+			}
+		});
+	});
+});

--- a/packages/coding-agent/test/extensibility/legacy-pi-shim-self-loop.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-shim-self-loop.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import {
 	__isLegacyPiSelfLoopResolution,
 	__isLegacyPiShimImporter,
-} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-shim-loop-guard";
 
 // Regression for issue #8900: a custom tool that value-imports
 // `@oh-my-pi/pi-coding-agent` bricked the agent with an opaque


### PR DESCRIPTION
## Summary

Fixes #8900 — a single custom tool that value-imports `@oh-my-pi/pi-coding-agent` hard-bricks the agent with an opaque `RangeError: Maximum call stack size exceeded` before the TUI exists (no `--safe-mode` escape that keeps the tool installed, config edits by hand required).

## Root cause

`installLegacyPiSpecifierShim()` installs a process-global Bun `onResolve` for `@(oh-my-pi|mariozechner|earendil-works)/(pi-agent-core|pi-ai|pi-coding-agent|pi-natives|pi-tui|pi-utils)`. Its package-root override map sends `pi-ai` / `pi-coding-agent` / `pi-tui` roots to the sibling compat shim files — **but the shims themselves re-import their own canonical packages by bare specifier** (`legacy-pi-tui-shim.ts` does `export * from "@oh-my-pi/pi-tui"`), and the resolver maps that straight back onto the shim.

ESM tolerates a true self-cycle, so on most machines this latent loop is invisible. It detonates when consecutive resolution hops disagree on module *identity* — macOS `/var` → `/private/var` symlink realpath divergence, bun global-cache install paths, `?mtime=` cache-bust suffixes — because Bun then keys each hop as a brand-new module and resolution recurses without bound. That's why @roboomp couldn't repro on linux x64 while tracing exactly this self-loop as the latent hazard (https://github.com/can1357/oh-my-pi/issues/8900#issuecomment-5340051490). This PR targets that traced loop, with the identity-divergence cases pinned as the repro in tests.

## Fix

A small standalone guard module, `legacy-pi-shim-loop-guard.ts`, registered **before** `installLegacyPiSpecifierShim()` at both call sites (`plugins/loader.ts`, `extensions/loader.ts`). Bun runs `onResolve` hooks in registration order and the first non-`undefined` result wins, so:

- **Imports issued *by* an on-disk compat shim** resolve the real canonical package (`Bun.resolveSync`, host-relative then importer-relative) and never reach the override map → the shim→shim self-edge is severed; shim → canonical always terminates.
- **Every other resolution returns `undefined`** and falls through to the existing compat resolver untouched — extension → shim remapping behavior is unchanged.
- Path identity comparison is `path.normalize` + `realpathSync` insensitive and strips `?query` suffixes (cached, invalidated via `registerPluginCacheInvalidator`), so the guard holds precisely in the environments where the loop detonated.
- **Compiled-binary mode is untouched by construction**: shims are virtual `omp-legacy-pi-bundled:` modules there; the guard skips installation under `isCompiledBinary()` and its predicates explicitly ignore virtual-namespace specifiers.

Keeping the guard in its own module (instead of patching the 2,900-line `legacy-pi-compat.ts` resolver internals) keeps the diff reviewable and the loop-breaking logic independently testable; the two existing call sites gain one line each.

## Tests

`packages/coding-agent/test/extensibility/legacy-pi-shim-self-loop.test.ts` pins the guard predicates:

- direct self-edge (`resolved === importer`)
- self-edge across symlink realpath divergence (`/var` vs `/private/var`, the macOS trigger)
- self-edge under `?mtime=` cache-bust suffixes and unnormalized path segments
- shim-importer detection via explicit paths, symlinked paths, and the **real on-disk shim files** through the default shim set (including an actual `symlinkSync` copy — the environment-specific loop trigger; degrades gracefully on runners without symlink perms)
- negative cases: distinct modules, non-shim importers, missing importers, and virtual `omp-legacy-pi-bundled:` specifiers (compiled-mode inertness)

## Not in this PR (proposed follow-up)

Fix B from the issue discussion — making the terminal failure path *name the offending tool file* instead of dying with a bare RangeError — is orthogonal hardening of the loader's error surface and is left as a follow-up so this PR stays a minimal, verifiable loop-break.

## Notes for review

- No behavior change for any resolution not originating from a shim file.
- `LEGACY_PI_SPECIFIER_FILTER` is mirrored from `legacy-pi-compat.ts` (kept in sync by comment); the guard only claims specifiers the compat resolver would also claim.
- Draft for maintainer review per issue's `needs-info` status — happy to adjust scope or fold the guard into the compat module if preferred.