### PR TITLE
fix(catalog): cap Vercel Muse Spark contributor output tokens

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Vercel AI Gateway Muse Spark 1.2 Contributor requests failing with HTTP 400 by capping the advertised output allowance to the model's 131K output limit.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -266696,7 +266696,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3296,6 +3296,12 @@ export function vercelAiGatewayModelManagerOptions(
 				): ModelSpec<"anthropic-messages"> => {
 					const pricing = entry.pricing as Record<string, unknown> | undefined;
 					const tags = Array.isArray(entry.tags) ? (entry.tags as string[]) : [];
+					const reportedMaxTokens = typeof entry.max_tokens === "number" ? entry.max_tokens : defaults.maxTokens;
+					const modelId = typeof entry.id === "string" ? entry.id : defaults.id;
+					const maxTokens =
+						modelId === "meta/muse-spark-1.2-contributor" && typeof reportedMaxTokens === "number"
+							? Math.min(reportedMaxTokens, 131_072)
+							: reportedMaxTokens;
 
 					return {
 						...defaults,
@@ -3310,7 +3316,7 @@ export function vercelAiGatewayModelManagerOptions(
 						},
 						contextWindow:
 							typeof entry.context_window === "number" ? entry.context_window : defaults.contextWindow,
-						maxTokens: typeof entry.max_tokens === "number" ? entry.max_tokens : defaults.maxTokens,
+						maxTokens,
 					};
 				},
 				fetch: config?.fetch,

--- a/packages/catalog/test/vercel-ai-gateway-provider.test.ts
+++ b/packages/catalog/test/vercel-ai-gateway-provider.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { vercelAiGatewayModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+
+describe("Vercel AI Gateway provider", () => {
+	test("caps meta/muse-spark-1.2-contributor output allowance to 131072 while preserving context window", async () => {
+		// Vercel currently reports both context_window and max_tokens as 1M for the
+		// contributor model, which makes Anthropic messages requests fail with 400
+		// when prompt + max_tokens exceeds the shared context window. The mapper
+		// must cap the output allowance while leaving the context window intact.
+		const contributorId = "meta/muse-spark-1.2-contributor";
+		const controlId = "anthropic/claude-sonnet-4-5-20250929";
+		const fetchMock = (async () =>
+			Response.json({
+				object: "list",
+				data: [
+					{
+						id: contributorId,
+						object: "model",
+						owned_by: "meta",
+						tags: ["tool-use", "reasoning", "vision"],
+						context_window: 1_048_576,
+						max_tokens: 1_048_576,
+						pricing: { input: 0.0000001, output: 0.0000002 },
+					},
+					{
+						id: controlId,
+						object: "model",
+						owned_by: "anthropic",
+						tags: ["tool-use", "reasoning"],
+						context_window: 200_000,
+						max_tokens: 8192,
+						pricing: { input: 0.000003, output: 0.000015 },
+					},
+				],
+			})) as unknown as typeof fetch;
+
+		const options = vercelAiGatewayModelManagerOptions({ fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+		expect(models).not.toBeNull();
+		const byId = new Map((models ?? []).map(model => [model.id, model]));
+
+		const contributor = byId.get(contributorId);
+		expect(contributor).toBeDefined();
+		expect(contributor?.contextWindow).toBe(1_048_576);
+		expect(contributor?.maxTokens).toBe(131_072);
+
+		const control = byId.get(controlId);
+		expect(control).toBeDefined();
+		expect(control?.contextWindow).toBe(200_000);
+		expect(control?.maxTokens).toBe(8192);
+	});
+});


### PR DESCRIPTION
## Problem

Vercel AI Gateway reports both `context_window` and `max_tokens` as 1,048,576 for `meta/muse-spark-1.2-contributor`. OMP copies that output allowance into Anthropic Messages requests. Any non-empty prompt then pushes prompt plus requested output beyond the shared context window and Vercel returns HTTP 400.

## Fix

Cap this model's Vercel discovery value to 131,072 tokens, matching OMP's first-party Meta definition. Keep the 1,048,576-token context window unchanged. Apply the correction in the Vercel mapper so live discovery and generated catalogs use the same value.

## Verification

- Added a mocked Vercel discovery regression test with a non-Muse control model.
- Ran the catalog checks and tests.
- Regenerated the bundled catalog.
- Before the upstream patch, a local `models.yml` override to 131,072 returned `OMP_MUSE_OK` through Vercel, confirming the corrected value works end to end.
