### PR TITLE
fix(catalog): restore config-derived auth headers for cached discovery providers

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -810,12 +810,27 @@ export class ModelRegistry {
 			}
 			const configStale = this.#isDiscoveryCacheOlderThanModelsConfig(cache.updatedAt);
 			// Cached rows never persist headers (#5780); models that had live
-			// headers cannot be rebuilt here, so exclude them and mark the
-			// discovery stale to force a refetch instead of returning models
-			// missing required transport headers.
+			// headers are re-derived from provider config here rather than dropped,
+			// so they are available at startup without a network round-trip.
+			// When no authHeader/apiKey config exists (keyless providers such as
+			// ollama / lm-studio / llama.cpp) restoredHeaders is undefined and the
+			// old behaviour — filter out header-omitted models and mark stale — is
+			// preserved exactly.
+			const providerOverride = this.#providerOverrides.get(providerConfig.provider);
+			const restoredHeaders = mergeAuthHeaderSources(
+				[providerConfig.headers],
+				providerOverride?.authHeader,
+				providerOverride?.apiKey,
+			);
 			const omittedHeaderIds = new Set(cache.headerOmittedModelIds);
 			const usableCacheModels =
-				omittedHeaderIds.size > 0 ? cache.models.filter(model => !omittedHeaderIds.has(model.id)) : cache.models;
+				omittedHeaderIds.size === 0
+					? cache.models
+					: restoredHeaders
+						? cache.models.map(model =>
+								omittedHeaderIds.has(model.id) ? { ...model, headers: { ...restoredHeaders } } : model,
+							)
+						: cache.models.filter(model => !omittedHeaderIds.has(model.id));
 			const models = this.#applyProviderModelOverrides(
 				providerConfig.provider,
 				this.#normalizeDiscoverableModels(
@@ -836,7 +851,7 @@ export class ModelRegistry {
 					!cache.fresh ||
 					!cache.authoritative ||
 					configStale ||
-					omittedHeaderIds.size > 0,
+					(omittedHeaderIds.size > 0 && !restoredHeaders),
 				fetchedAt: cache.updatedAt,
 				models: models.map(model => model.id),
 			});
@@ -1197,6 +1212,11 @@ export class ModelRegistry {
 			cacheProviderId,
 			cacheTtlMs: 24 * 60 * 60 * 1000,
 			fetchDynamicModels,
+			restorableHeaderFallback: mergeAuthHeaderSources(
+				[providerConfig.headers],
+				this.#providerOverrides.get(providerId)?.authHeader,
+				this.#providerOverrides.get(providerId)?.apiKey,
+			),
 		});
 		const result = await manager.refresh(effectiveStrategy);
 		const status = discoveryError

--- a/packages/coding-agent/test/issue-9112-authheader-discovery-cache.test.ts
+++ b/packages/coding-agent/test/issue-9112-authheader-discovery-cache.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry as ModelRegistryImpl } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("issue #9112 authHeader + discovery: provider survives cache startup", () => {
+	let tempDir: string;
+	let modelsPath: string;
+	let authStorage: AuthStorage;
+	let authStorage2: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-issue-9112-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.yml");
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorage2 = await AuthStorage.create(path.join(tempDir, "auth2.db"));
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		authStorage2.close();
+		if (tempDir && fs.existsSync(tempDir)) {
+			removeSyncWithRetries(tempDir);
+		}
+	});
+
+	test("restores authHeader discovery models from cache without a network call", async () => {
+		// Write a models.yml with authHeader: true + discovery:
+		fs.writeFileSync(
+			modelsPath,
+			[
+				"providers:",
+				"  probe:",
+				"    baseUrl: http://probe.invalid/v1",
+				"    api: openai-completions",
+				"    apiKey: static-test-key",
+				"    authHeader: true",
+				"    discovery:",
+				"      type: openai-models-list",
+			].join("\n"),
+		);
+
+		// --- First registry: online refresh writes the cache ---
+		const fetchMock: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = async (
+			input,
+			_init,
+		) => {
+			const url = String(input);
+			if (url !== "http://probe.invalid/v1/models") {
+				throw new Error(`Unexpected URL in first registry: ${url}`);
+			}
+			return new Response(JSON.stringify({ data: [{ id: "alpha" }, { id: "beta" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const registry1 = new ModelRegistryImpl(authStorage, modelsPath, { fetch: fetchMock });
+		await registry1.refreshProvider("probe");
+
+		const firstModels = registry1.getAll().filter(m => m.provider === "probe");
+		expect(firstModels.map(m => m.id).sort()).toEqual(["alpha", "beta"]);
+		// Headers must carry the auth key on the live registry
+		for (const m of firstModels) {
+			expect((m.headers as Record<string, string>)?.Authorization).toBe("Bearer static-test-key");
+		}
+
+		// --- Second registry: cold start — must load from cache, network must NOT be called ---
+		const neverFetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = async (
+			input,
+			_init,
+		) => {
+			throw new Error(`Network must not be called in second registry; got: ${String(input)}`);
+		};
+
+		const registry2 = new ModelRegistryImpl(authStorage2, modelsPath, { fetch: neverFetch });
+		// Do NOT call refreshProvider — we want what the constructor loaded from cache.
+
+		// This is the new-behavior assertion: must fail before the fix with empty list.
+		const cachedModels = registry2.getAll().filter(m => m.provider === "probe");
+		expect(cachedModels.map(m => m.id).sort()).toEqual(["alpha", "beta"]);
+		for (const m of cachedModels) {
+			expect((m.headers as Record<string, string>)?.Authorization).toBe("Bearer static-test-key");
+		}
+	});
+});


### PR DESCRIPTION
Fixes #9112

`models.yml` providers using `authHeader: true` with `discovery:` had every discovered model marked unrestorable, so they contributed nothing to the startup catalog and a `modelRoles` entry pointing at them failed to restore until the background refresh finished.

`#loadCachedDiscoverableModels` now rebuilds the config-derived headers with `mergeAuthHeaderSources` rather than dropping the affected models, and the configured-discovery manager passes the same record as `restorableHeaderFallback`. Models are still only dropped when no `authHeader`/`apiKey` config exists to rebuild from, so keyless discovery providers are unchanged.

No credential is persisted: `restorableHeaderFallback` is a parameter only and the `model_cache` column list is untouched. `issue-5780-repro.test.ts` still guards this.