### PR TITLE
fix(models): restore auth headers for discovery cache

### DIFF
--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -42,11 +42,11 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	/** Cached model ids whose presence forces refresh when the static or migration-policy fingerprint changes. */
 	dropCachedModelIdsOnStaticMismatch?: readonly string[];
 	/**
-	 * Trusted, provider-wide request headers (compile-time constants, never
-	 * credentials) that the cache may restore by value for any model whose live
-	 * headers matched them at write time. Lets header-bearing dynamic models
-	 * without a bundled static entry survive offline reads instead of being
-	 * dropped as unrestorable (e.g. GitHub Copilot's User-Agent + API version).
+	 * Trusted, provider-wide request headers that can be safely re-derived at
+	 * cache-read time. The cache never persists their values. Models whose live
+	 * headers matched this record at write time can survive offline reads without
+	 * a bundled static source, including configured discovery providers whose
+	 * bearer header comes from the current local config.
 	 */
 	restorableHeaderFallback?: Record<string, string>;
 	/** Optional dynamic endpoint fetcher. */

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Configured discovery providers with `authHeader` keep cached models available across restarts ([#9112](https://github.com/can1357/oh-my-pi/issues/9112)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -789,6 +789,13 @@ export class ModelRegistry {
 		return { models: cachedModels, authoritativeFreshProviders };
 	}
 
+	#configuredDiscoveryHeaderFallback(providerId: string): Record<string, string> | undefined {
+		const override = this.#providerOverrides.get(providerId);
+		if (override?.authHeader !== true || !override.apiKey) return undefined;
+		const headers = mergeAuthHeaderSources([override.headers], override.authHeader, override.apiKey);
+		return headers && Object.keys(headers).length > 0 ? headers : undefined;
+	}
+
 	#loadCachedDiscoverableModels(): Model<Api>[] {
 		const cachedModels: Model<Api>[] = [];
 		for (const providerConfig of this.#discoverableProviders) {
@@ -809,13 +816,21 @@ export class ModelRegistry {
 				continue;
 			}
 			const configStale = this.#isDiscoveryCacheOlderThanModelsConfig(cache.updatedAt);
-			// Cached rows never persist headers (#5780); models that had live
-			// headers cannot be rebuilt here, so exclude them and mark the
-			// discovery stale to force a refetch instead of returning models
-			// missing required transport headers.
+			// Cached rows never persist headers (#5780). A pinned models.yml
+			// authHeader is re-derived from the current config; this also repairs
+			// rows written before the discovery manager knew that fallback, when
+			// every header-bearing model was marked unrestorable.
+			const restorableHeaderFallback = this.#configuredDiscoveryHeaderFallback(providerConfig.provider);
 			const omittedHeaderIds = new Set(cache.headerOmittedModelIds);
+			const hasUnrestoredHeaders = omittedHeaderIds.size > 0 && !restorableHeaderFallback;
 			const usableCacheModels =
-				omittedHeaderIds.size > 0 ? cache.models.filter(model => !omittedHeaderIds.has(model.id)) : cache.models;
+				omittedHeaderIds.size === 0
+					? cache.models
+					: restorableHeaderFallback
+						? cache.models.map(model =>
+								omittedHeaderIds.has(model.id) ? { ...model, headers: { ...restorableHeaderFallback } } : model,
+							)
+						: cache.models.filter(model => !omittedHeaderIds.has(model.id));
 			const models = this.#applyProviderModelOverrides(
 				providerConfig.provider,
 				this.#normalizeDiscoverableModels(
@@ -836,7 +851,7 @@ export class ModelRegistry {
 					!cache.fresh ||
 					!cache.authoritative ||
 					configStale ||
-					omittedHeaderIds.size > 0,
+					hasUnrestoredHeaders,
 				fetchedAt: cache.updatedAt,
 				models: models.map(model => model.id),
 			});
@@ -1197,6 +1212,7 @@ export class ModelRegistry {
 			cacheProviderId,
 			cacheTtlMs: 24 * 60 * 60 * 1000,
 			fetchDynamicModels,
+			restorableHeaderFallback: this.#configuredDiscoveryHeaderFallback(providerId),
 		});
 		const result = await manager.refresh(effectiveStrategy);
 		const status = discoveryError

--- a/packages/coding-agent/test/model-registry-cache-headers.test.ts
+++ b/packages/coding-agent/test/model-registry-cache-headers.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -49,5 +50,56 @@ describe("startup model cache header restoration (#5780)", () => {
 			if (!live) continue;
 			expect(live.headers).toEqual(model.headers);
 		}
+	});
+
+	test("cached configured-discovery models regain derived auth headers on registry startup", async () => {
+		const modelsPath = path.join(tempDir, "models.json");
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					probe: {
+						baseUrl: "https://example.invalid/v1/",
+						api: "openai-completions",
+						apiKey: "test-key",
+						authHeader: true,
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		const primedRegistry = new ModelRegistry(authStorage, modelsPath, {
+			fetch: async (input, init) => {
+				expect(String(input)).toBe("https://example.invalid/v1/models");
+				expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer test-key");
+				return Response.json({ data: [{ id: "probe-model" }] });
+			},
+		});
+		await primedRegistry.refreshProvider("probe", "online");
+		expect(primedRegistry.find("probe", "probe-model")?.headers?.Authorization).toBe("Bearer test-key");
+		const cacheDbPath = path.join(tempDir, "models.db");
+		const cacheDb = new Database(cacheDbPath);
+		const cacheRow = cacheDb
+			.query<{ unrestorable_header_model_ids: string }, []>(
+				"SELECT unrestorable_header_model_ids FROM model_cache WHERE provider_id LIKE 'probe:%'",
+			)
+			.get();
+		expect(cacheRow?.unrestorable_header_model_ids).toBe("[]");
+		cacheDb.close();
+
+		const restartedRegistry = new ModelRegistry(authStorage, modelsPath, {
+			fetch: () => Promise.reject(new Error("offline")),
+		});
+		const cached = restartedRegistry.find("probe", "probe-model");
+		expect(cached).toBeDefined();
+		expect(cached?.headers?.Authorization).toBe("Bearer test-key");
+
+		const oldCacheDb = new Database(cacheDbPath);
+		oldCacheDb.run("UPDATE model_cache SET unrestorable_header_model_ids = ?", [JSON.stringify(["probe-model"])]);
+		oldCacheDb.close();
+		const upgradedRegistry = new ModelRegistry(authStorage, modelsPath, {
+			fetch: () => Promise.reject(new Error("offline")),
+		});
+		expect(upgradedRegistry.find("probe", "probe-model")?.headers?.Authorization).toBe("Bearer test-key");
 	});
 });


### PR DESCRIPTION
## Repro
A configured `openai-models-list` provider with `apiKey` and `authHeader: true` discovers and caches a model, but a new registry reading that cache returns no model before refresh. Reproduced with `bun test packages/coding-agent/test/model-registry-cache-headers.test.ts`; before the fix, `find("probe", "probe-model")` returned `undefined` after restart.

## Cause
`ModelRegistry.#discoverProviderModels` in `packages/coding-agent/src/config/model-registry.ts` created its `ModelManager` without a `restorableHeaderFallback`, so `writeModelCache` marked every header-bearing discovery row unrestorable. `ModelRegistry.#loadCachedDiscoverableModels` then dropped every header-omitted row even though the pinned `models.yml` API key and `authHeader` could safely re-derive the bearer header.

## Fix
- Derive a trusted configured-discovery header fallback from the current pinned API key, `authHeader`, and provider headers.
- Restore omitted headers from that fallback at startup, including rows written by 17.4.0 with unrestorable markers.
- Pass the same fallback to the catalog model manager so new cache rows are marked restorable, and cover both current and legacy cache rows.
- Document the user-visible restart fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/model-registry-cache-headers.test.ts packages/coding-agent/test/model-discovery.test.ts` passed: 69 tests, 379 expectations. `bun check` passed across all workspaces.

Fixes #9112