### PR TITLE
fix(pi-natives): bound PTY output backlog to stop unbounded native allocation during event-loop wedge (#7328)

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use napi::{
-	JsString,
+	JsString, Status,
 	bindgen_prelude::*,
 	threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
@@ -109,6 +109,21 @@ const POST_CANCEL_DRAIN_TIMEOUT: Duration = Duration::from_millis(300);
 const POST_EXIT_DRAIN_TIMEOUT: Duration = Duration::from_millis(300);
 #[cfg(not(windows))]
 const FINAL_READER_DRAIN_TIMEOUT: Duration = Duration::from_millis(50);
+/// Maximum pending `on_chunk` invocations queued on the N-API
+/// threadsafe-function before further chunks are dropped (#7328). With a max
+/// read size of 64 KiB per chunk this caps the native output backlog at
+/// ~64 MiB, mirroring `MAX_STDOUT_BACKLOG_BYTES` in the TUI backlog guard.
+const MAX_PENDING_CHUNK_EVENTS: usize = 1024;
+/// Capacity of the reader-thread to consumer channel. When full, the reader
+/// thread blocks, which propagates backpressure to the kernel PTY buffer
+/// instead of growing native memory without bound (#7328).
+const READER_CHANNEL_CAPACITY: usize = 256;
+
+/// `on_chunk` callback with a bounded N-API queue. The default
+/// `ThreadsafeFunction` queue is unbounded (`MaxQueueSize = 0`), which allows
+/// unbounded native memory growth when the JS event loop stalls (#7328).
+type ChunkCallback =
+	ThreadsafeFunction<String, Unknown<'static>, String, Status, true, false, MAX_PENDING_CHUNK_EVENTS>;
 
 struct PtySessionCore {
 	control_tx: flume::Sender<ControlMessage>,
@@ -141,7 +156,7 @@ impl PtySession {
 		env: &'env Env,
 		options: PtyStartOptions<'env>,
 		#[napi(ts_arg_type = "((error: Error | null, chunk: string) => void) | undefined | null")]
-		on_chunk: Option<ThreadsafeFunction<String>>,
+		on_chunk: Option<ChunkCallback>,
 		#[napi(ts_arg_type = "((error: Error | null, pid: number) => void) | undefined | null")]
 		on_start: Option<ThreadsafeFunction<u32>>,
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
@@ -163,7 +178,7 @@ impl PtySession {
 		env: &'env Env,
 		options: PtyArgvStartOptions<'env>,
 		#[napi(ts_arg_type = "((error: Error | null, chunk: string) => void) | undefined | null")]
-		on_chunk: Option<ThreadsafeFunction<String>>,
+		on_chunk: Option<ChunkCallback>,
 		#[napi(ts_arg_type = "((error: Error | null, pid: number) => void) | undefined | null")]
 		on_start: Option<ThreadsafeFunction<u32>>,
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
@@ -206,7 +221,7 @@ impl PtySession {
 		run_config: PtyRunConfig,
 		timeout_ms: Option<u32>,
 		signal: Option<Unknown<'env>>,
-		on_chunk: Option<ThreadsafeFunction<String>>,
+		on_chunk: Option<ChunkCallback>,
 		on_start: Option<ThreadsafeFunction<u32>>,
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let ct = task::CancelToken::new(timeout_ms, signal);
@@ -269,7 +284,7 @@ fn terminate_pty_processes(
 }
 fn run_pty_sync(
 	config: PtyRunConfig,
-	on_chunk: Option<ThreadsafeFunction<String>>,
+	on_chunk: Option<ChunkCallback>,
 	on_start: Option<ThreadsafeFunction<u32>>,
 	control_rx: flume::Receiver<ControlMessage>,
 	ct: task::CancelToken,
@@ -376,7 +391,7 @@ fn run_pty_sync(
 		.try_clone_reader()
 		.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))?;
 
-	let (reader_tx, reader_rx) = flume::unbounded::<ReaderEvent>();
+	let (reader_tx, reader_rx) = flume::bounded::<ReaderEvent>(READER_CHANNEL_CAPACITY);
 	let reader_thread = std::thread::spawn(move || {
 		const REPLACEMENT: &str = "\u{FFFD}";
 		const BUF: usize = 65536;
@@ -441,6 +456,7 @@ fn run_pty_sync(
 	let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
 	#[cfg(not(unix))]
 	let process_group_id: Option<i32> = None;
+	let mut chunk_emitter = ChunkEmitter::new(on_chunk.as_ref());
 	let mut timed_out = false;
 	let mut cancelled = false;
 	let mut reader_done = false;
@@ -480,7 +496,7 @@ fn run_pty_sync(
 
 		for _ in 0..READER_EVENTS_PER_TICK {
 			match reader_rx.try_recv() {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
+				Ok(ReaderEvent::Chunk(chunk)) => chunk_emitter.emit(&chunk),
 				Ok(ReaderEvent::Done) => {
 					reader_done = true;
 					break;
@@ -515,7 +531,7 @@ fn run_pty_sync(
 					.min(Duration::from_millis(16))
 			});
 			match reader_rx.recv_timeout(wait_duration) {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
+				Ok(ReaderEvent::Chunk(chunk)) => chunk_emitter.emit(&chunk),
 				Ok(ReaderEvent::Done) => reader_done = true,
 				Err(flume::RecvTimeoutError::Timeout) => {},
 				Err(flume::RecvTimeoutError::Disconnected) => {
@@ -583,7 +599,7 @@ fn run_pty_sync(
 			let remaining = finalize_deadline.saturating_duration_since(Instant::now());
 			let wait_duration = remaining.min(Duration::from_millis(5));
 			match reader_rx.recv_timeout(wait_duration) {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
+				Ok(ReaderEvent::Chunk(chunk)) => chunk_emitter.emit(&chunk),
 				Ok(ReaderEvent::Done) => {
 					reader_done = true;
 					break;
@@ -627,8 +643,57 @@ fn run_pty_sync(
 	Ok(PtyRunResult { exit_code, cancelled, timed_out })
 }
 
-fn emit_chunk(text: &str, callback: Option<&ThreadsafeFunction<String>>) {
-	if let Some(callback) = callback {
-		callback.call(Ok(text.to_string()), ThreadsafeFunctionCallMode::NonBlocking);
+/// Emits output chunks to the JS `on_chunk` callback with drop-on-full
+/// semantics.
+///
+/// The threadsafe-function queue is bounded (`MAX_PENDING_CHUNK_EVENTS`); when
+/// the JS event loop stalls and the queue fills up, further chunks are dropped
+/// and counted instead of accumulating in native memory without bound (#7328).
+/// Once the queue accepts events again, a loss marker is prepended so
+/// consumers know output was truncated.
+struct ChunkEmitter<'cb> {
+	callback:      Option<&'cb ChunkCallback>,
+	dropped_bytes: u64,
+}
+
+impl<'cb> ChunkEmitter<'cb> {
+	const fn new(callback: Option<&'cb ChunkCallback>) -> Self {
+		Self { callback, dropped_bytes: 0 }
+	}
+
+	fn emit(&mut self, text: &str) {
+		let Some(callback) = self.callback else {
+			return;
+		};
+		let payload = if self.dropped_bytes == 0 {
+			text.to_string()
+		} else {
+			format!("{}{}", loss_marker(self.dropped_bytes), text)
+		};
+		let payload_len = u64::try_from(payload.len()).unwrap_or(u64::MAX);
+		if callback.call(Ok(payload), ThreadsafeFunctionCallMode::NonBlocking) == Status::QueueFull {
+			self.dropped_bytes = self.dropped_bytes.saturating_add(payload_len);
+		} else {
+			self.dropped_bytes = 0;
+		}
+	}
+}
+
+/// Human-readable notice inserted into the output stream after chunks were
+/// dropped because the JS consumer stalled (#7328).
+fn loss_marker(dropped_bytes: u64) -> String {
+	format!("\n[pty output truncated: {dropped_bytes} bytes dropped while the consumer was stalled]\n")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::loss_marker;
+
+	#[test]
+	fn loss_marker_reports_dropped_byte_count() {
+		let marker = loss_marker(1024);
+		assert!(marker.contains("1024 bytes dropped"));
+		assert!(marker.starts_with('\n'));
+		assert!(marker.ends_with('\n'));
 	}
 }


### PR DESCRIPTION
Fixes the unbounded-allocation half of #7328 (orphaned PTY session grew to **35.8 GiB RSS at ~9 MB/s** with all JS-side I/O frozen).

## Root cause

Credit to @bannert1337 for the diagnosis pointing at the unbounded native reader path — with one refinement on the mechanism:

- The unbounded flume `ReaderEvent` channel is **not** the accumulator: it is drained by the consumer loop in `run_pty_sync`, which runs on a `tokio::task::spawn_blocking` thread and keeps draining even when the JS event loop wedges.
- The actual unbounded accumulator is the **N-API threadsafe-function queue** behind `on_chunk`. napi-rs v3's `ThreadsafeFunction` defaults to `MaxQueueSize = 0` (unbounded), and `emit_chunk` called it with `NonBlocking` mode while **ignoring the returned `Status`**. When the JS event loop stalls, every 64 KiB PTY chunk is copied into that queue forever — nothing on the native side ever stops it.

So the TUI-side `OutputBacklogGuard` from #6856 (`MAX_STDOUT_BACKLOG_BYTES` = 64 MiB) bounds the JS write side, but the native read side had no equivalent guard. This PR adds it.

## Changes (`crates/pi-natives/src/pty.rs`)

1. **Bounded TSFN queue** — `on_chunk` is now a `ChunkCallback` type alias: a `ThreadsafeFunction` with the const generic `MaxQueueSize` set to `MAX_PENDING_CHUNK_EVENTS = 1024` instead of the unbounded default. At the 64 KiB max read size that caps the native backlog at **~64 MiB**, deliberately mirroring `MAX_STDOUT_BACKLOG_BYTES`.
2. **Drop-with-loss-marker policy** — new `ChunkEmitter` replaces `emit_chunk` and checks the `Status` returned by `call()`. On `Status::QueueFull` the chunk is dropped and its bytes counted; once the queue accepts events again, a loud `[pty output truncated: N bytes dropped while the consumer was stalled]` marker is prepended so consumers know output was lost. **Drops can only occur when the JS consumer is already stalled** — healthy operation is byte-for-byte unchanged.
3. **Bounded reader channel** (defense-in-depth) — `flume::bounded(READER_CHANNEL_CAPACITY = 256)` instead of unbounded. If the consumer tick ever falls behind, the reader thread's blocking `send` propagates backpressure into the kernel PTY buffer instead of heap growth. Teardown is unaffected: `send` errors out immediately once the receiver is dropped.
4. Unit test for the loss-marker format.

## Scope / staging

- This fixes the **memory-growth symptom**: a wedged event loop now costs at most ~64 MiB of native backlog instead of unbounded gigabytes, and the process stays SIGTERM-able from the memory side.
- The **event-loop wedge itself** (one core spinning; the issue remains `needs_info` pending a CPU profile) is *not* addressed here — deliberately kept out of scope so this stays a small, reviewable native change.
- The Windows openpty/master-drop helper channels remain unbounded — they carry a single message each and are not on the output path.

## Testing

- `loss_marker` unit test included.
- The behavioral change (QueueFull handling) requires a wedged JS event loop to trigger, which isn't reproducible in a unit test harness; the logic is deliberately confined to the small `ChunkEmitter` struct for reviewability.
- Rust workspace validation via CI (`Validate Rust workspace` / `Build native addons`).

Closes #7328 (allocation unboundedness; spin-source investigation can stay open/tracked separately at maintainer's discretion).