### PR TITLE
fix(tui): stop hub wait from smearing job rows into scrollback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `hub wait` stacking frozen copies of the same running-job rows into native scrollback once the transcript outgrew the viewport. The live-region pin now starts at the poll body (not the blank separator before it) and still applies when an earlier unpinned live block sits above the wait.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -100,7 +100,7 @@ function displaceableToolName(
 }
 
 function isHubWaitArgs(args: unknown): boolean {
-	return !!args && typeof args === "object" && (args as { op?: unknown }).op === "wait";
+	return isRecord(args) && args.op === "wait";
 }
 
 function stabilizeStreamingPreviews(previews: PerFileDiffPreview[]): PerFileDiffPreview[] {

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -99,6 +99,10 @@ function displaceableToolName(
 	return undefined;
 }
 
+function isHubWaitArgs(args: unknown): boolean {
+	return !!args && typeof args === "object" && (args as { op?: unknown }).op === "wait";
+}
+
 function stabilizeStreamingPreviews(previews: PerFileDiffPreview[]): PerFileDiffPreview[] {
 	let changed = false;
 	const next = previews.map(preview => {
@@ -886,7 +890,14 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 */
 	isNativeScrollbackLiveRegionPinned(): boolean {
 		if (this.isTranscriptBlockFinalized()) return false;
-		return this.#toolName === "vibe_wait" || this.#toolName === "task" || this.#displaceableByToolName !== undefined;
+		if (this.#toolName === "vibe_wait" || this.#toolName === "task" || this.#displaceableByToolName !== undefined) {
+			return true;
+		}
+		// A hub wait is the same self-replacing dashboard before the first
+		// progress snapshot arrives (`#displaceableByToolName` is set only once
+		// `details.jobs` exist). Pin the pending frame too so its rows cannot
+		// commit and force-seal the live poll.
+		return this.#toolName === "hub" && isHubWaitArgs(this.#args);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -377,7 +377,7 @@ export class TranscriptContainer
 	isBlockUncommitted(component: Component): boolean {
 		for (const segment of this.#segments) {
 			if (segment.component !== component) continue;
-			return segment.rowCount === 0 || segment.startRow >= this.#committedRows;
+			return segment.rowCount === 0 || segment.startRow + segment.sep >= this.#committedRows;
 		}
 		return true;
 	}
@@ -467,7 +467,13 @@ export class TranscriptContainer
 		for (let i = 0; i < count && i < this.#segments.length; i++) {
 			const previous = this.#segments[i];
 			if (previous === undefined) continue;
-			if (previous.startRow >= this.#committedRows) break;
+			// The leading separator is container-owned spacing and sits in the
+			// committed prefix (live-region start is `startRow + sep`). Sealing
+			// on `startRow` would freeze a pinned hub-wait/todo card the moment
+			// that blank committed — then duration/shimmer ticks smear into
+			// native scrollback.
+			const bodyStart = previous.startRow + previous.sep;
+			if (bodyStart >= this.#committedRows) break;
 			if (previous.rowCount === 0 || previous.component !== this.children[i]) continue;
 			sealCommittedSnapshot(previous.component);
 		}

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -61,6 +61,10 @@ function isBlockFinalized(child: Component): boolean {
 	return fn ? fn.call(child) : true;
 }
 
+function isBlockPinned(child: Component): boolean {
+	return (child as Component & Partial<NativeScrollbackLiveRegion>).isNativeScrollbackLiveRegionPinned?.() === true;
+}
+
 function getBlockVersion(child: Component): number | undefined {
 	const fn = (child as Component & FinalizableBlock).getTranscriptBlockVersion;
 	return fn ? fn.call(child) : undefined;
@@ -176,6 +180,9 @@ export class TranscriptContainer
 	// settled rows. TUI commits rows to native scrollback only above it.
 	#nativeScrollbackLiveRegionStart: number | undefined;
 	#nativeScrollbackLiveRegionPinned = false;
+	// First pinned live block's body row. May sit below the earliest live seam
+	// when an unpinned predecessor (pending bash/eval) is still mutating.
+	#nativeScrollbackLiveRegionPinnedStart: number | undefined;
 	// Persistent assembled transcript rows. Rows before the stable floor are
 	// byte-identical to the previous render; rows at/after it were re-pushed.
 	#lines: string[] = [];
@@ -360,9 +367,19 @@ export class TranscriptContainer
 		return this.#nativeScrollbackLiveRegionStart;
 	}
 
-	/** Propagates viewport pinning from the first still-mutating transcript block. */
+	/** True when any still-mutating descendant opted into viewport pinning. */
 	isNativeScrollbackLiveRegionPinned(): boolean {
 		return this.#nativeScrollbackLiveRegionPinned;
+	}
+
+	getNativeScrollbackLiveRegionPinnedStart(): number | undefined {
+		return this.#nativeScrollbackLiveRegionPinned ? this.#nativeScrollbackLiveRegionPinnedStart : undefined;
+	}
+
+	#notePinnedLiveBlock(pinAt: number): void {
+		if (this.#nativeScrollbackLiveRegionPinned) return;
+		this.#nativeScrollbackLiveRegionPinned = true;
+		this.#nativeScrollbackLiveRegionPinnedStart = pinAt;
 	}
 
 	/**
@@ -453,6 +470,7 @@ export class TranscriptContainer
 		width = Math.max(1, width);
 		this.#nativeScrollbackLiveRegionStart = undefined;
 		this.#nativeScrollbackLiveRegionPinned = false;
+		this.#nativeScrollbackLiveRegionPinnedStart = undefined;
 
 		const count = this.children.length;
 
@@ -490,10 +508,6 @@ export class TranscriptContainer
 			if (!isBlockFinalized(this.children[i]!)) {
 				liveStartIndex = i;
 				hasLiveBlock = true;
-				this.#nativeScrollbackLiveRegionPinned =
-					(
-						this.children[i] as Component & Partial<NativeScrollbackLiveRegion>
-					).isNativeScrollbackLiveRegionPinned?.() === true;
 				break;
 			}
 		}
@@ -572,6 +586,7 @@ export class TranscriptContainer
 				if (hasLiveBlock && i === liveStartIndex) {
 					this.#nativeScrollbackLiveRegionStart = row;
 				}
+				if (!finalized && isBlockPinned(child)) this.#notePinnedLiveBlock(row);
 				if (chainStable && !(reusable && previous.rowCount === 0 && previous.startRow === row)) {
 					chainStable = false;
 					lines.length = row;
@@ -604,16 +619,19 @@ export class TranscriptContainer
 			// settled); the boundary then extends through the live block's
 			// declared settled rows, mapped from its raw render into the
 			// stripped contribution.
-			if (hasLiveBlock && i === liveStartIndex) {
-				let settled = 0;
+			let settled = 0;
+			if (!finalized || (hasLiveBlock && i === liveStartIndex)) {
 				const settledRaw = getBlockSettledRows(child);
 				if (settledRaw > 0) {
 					let lead = 0;
 					while (lead < raw.length && isPlainBlank(raw[lead]!)) lead++;
 					settled = Math.max(0, Math.min(contribution.length, settledRaw - lead));
 				}
+			}
+			if (hasLiveBlock && i === liveStartIndex) {
 				this.#nativeScrollbackLiveRegionStart = row + sep + settled;
 			}
+			if (!finalized && isBlockPinned(child)) this.#notePinnedLiveBlock(row + sep + settled);
 
 			const rowCount = sep + contribution.length;
 			const stable = chainStable && reusable && previous.startRow === row && previous.sep === sep;

--- a/packages/coding-agent/test/hub-wait-scrollback.test.ts
+++ b/packages/coding-agent/test/hub-wait-scrollback.test.ts
@@ -1,0 +1,386 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+/**
+ * Hub wait is a self-replacing dashboard: running-job rows rewrite in place
+ * (duration + shimmer) while the poll is live. Those rows must not be frozen
+ * into native scrollback each tick — that is the stacked "waiting on N jobs"
+ * smear (same 3–6 task names repeating with incrementing `6m29s` / `6m30s`).
+ */
+
+type DrainableScheduler = {
+	now(): number;
+	scheduleImmediate(cb: () => void): void;
+	scheduleRender(cb: () => void, delayMs: number): { cancel(): void };
+	flush(): void;
+};
+
+function makeDrainableScheduler(): DrainableScheduler {
+	let clock = 0;
+	const queue: Array<{ run: () => void; cancelled: boolean }> = [];
+	const enqueue = (cb: () => void) => {
+		const item = { run: cb, cancelled: false };
+		queue.push(item);
+		return item;
+	};
+	return {
+		now: () => clock,
+		scheduleImmediate(cb) {
+			enqueue(cb);
+		},
+		scheduleRender(cb) {
+			const item = enqueue(cb);
+			return {
+				cancel() {
+					item.cancelled = true;
+				},
+			};
+		},
+		flush() {
+			let guard = 0;
+			while (queue.length > 0) {
+				if (++guard > 100_000) throw new Error("scheduler did not settle");
+				const item = queue.shift()!;
+				clock += 1;
+				if (!item.cancelled) item.run();
+			}
+		},
+	};
+}
+
+class Footer implements Component {
+	#rows: number;
+	constructor(rows: number) {
+		this.#rows = rows;
+	}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return Array.from({ length: this.#rows }, (_, i) => `editor-${i}`);
+	}
+}
+
+/** Finalized history above the wait poll. */
+class StaticBlock implements Component {
+	#lines: string[];
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return this.#lines;
+	}
+}
+
+/**
+ * Still-live predecessor that does not pin (a parallel bash/eval, or a
+ * streaming assistant turn). TranscriptContainer currently copies pin
+ * policy from this first live block, which can hide a hub wait's pin.
+ */
+class LiveBarrier implements Component {
+	constructor(private readonly lines: string[]) {}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return this.lines;
+	}
+	isTranscriptBlockFinalized(): boolean {
+		return false;
+	}
+}
+
+class AnchoredHud implements Component {
+	getNativeScrollbackLiveRegionStart(): number | undefined {
+		return 0;
+	}
+	isNativeScrollbackLiveRegionPinned(): boolean {
+		return true;
+	}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return ["working…"];
+	}
+}
+
+const ORIGINAL_ROWS = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+function stubStdoutRows(rows: number): void {
+	Object.defineProperty(process.stdout, "rows", { configurable: true, value: rows });
+}
+
+function plainScrollBuffer(term: VirtualTerminal): string[] {
+	return term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+}
+
+function runningJobs(tick: number) {
+	const labels = [
+		"ApprovalTests",
+		"ConfigNotify",
+		"FeishuAdapter",
+		"AuthSession",
+		"ControlRoomAPI",
+		"Frontend",
+	] as const;
+	return labels.map((label, index) => ({
+		id: label,
+		type: "task" as const,
+		status: "running" as const,
+		label,
+		durationMs: (index === 0 ? 389_000 : 277_000) + tick * 1_000,
+	}));
+}
+
+function waitPartial(tick: number) {
+	return {
+		content: [{ type: "text" as const, text: "" }],
+		details: { op: "wait" as const, jobs: runningJobs(tick) },
+	};
+}
+
+describe("hub wait poll never sprays duplicate job rows into scrollback", () => {
+	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		await initTheme();
+	});
+	afterAll(() => {
+		resetSettingsForTest();
+	});
+	afterEach(() => {
+		if (ORIGINAL_ROWS) Object.defineProperty(process.stdout, "rows", ORIGINAL_ROWS);
+		else Reflect.deleteProperty(process.stdout, "rows");
+	});
+
+	test("running-job rows rewrite in place while the wait is live", async () => {
+		const rows = 12;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(80, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.setScrollbackRebuild(false);
+		const transcript = new TranscriptContainer();
+		const hub = new ToolExecutionComponent(
+			"hub",
+			{ op: "wait", timeoutMs: 600_000 },
+			{ liveRegion: transcript },
+			undefined,
+			tui,
+			process.cwd(),
+		);
+		transcript.addChild(hub);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			scheduler.flush();
+			await term.flush();
+			for (let tick = 1; tick <= 12; tick++) {
+				hub.updateResult(waitPartial(tick), true);
+				term.scrollLines(1000);
+				tui.requestRender();
+				scheduler.flush();
+				await term.flush();
+			}
+
+			expect(hub.isDisplaceableBlock()).toBe(true);
+			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
+
+			const buffer = plainScrollBuffer(term);
+			const joined = buffer.join("\n");
+			expect(joined).toContain("waiting on 6 jobs");
+			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
+				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
+			}
+		} finally {
+			hub.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("does not smear when an unpinned live predecessor sits above the wait", async () => {
+		const rows = 12;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(80, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.setScrollbackRebuild(false);
+		const transcript = new TranscriptContainer();
+		const hub = new ToolExecutionComponent(
+			"hub",
+			{ op: "wait", timeoutMs: 600_000 },
+			{ liveRegion: transcript },
+			undefined,
+			tui,
+			process.cwd(),
+		);
+		transcript.addChild(new LiveBarrier(["assistant: still thinking…"]));
+		transcript.addChild(hub);
+		tui.addChild(transcript);
+		tui.addChild(new AnchoredHud());
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			scheduler.flush();
+			await term.flush();
+			for (let tick = 1; tick <= 12; tick++) {
+				hub.updateResult(waitPartial(tick), true);
+				term.scrollLines(1000);
+				tui.requestRender();
+				scheduler.flush();
+				await term.flush();
+			}
+
+			const buffer = plainScrollBuffer(term);
+			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
+				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
+			}
+		} finally {
+			hub.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("does not smear when history has already filled the viewport", async () => {
+		const rows = 12;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(80, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.setScrollbackRebuild(false);
+		const transcript = new TranscriptContainer();
+		transcript.addChild(
+			new StaticBlock(Array.from({ length: 40 }, (_, i) => `history-line-${String(i).padStart(2, "0")}`)),
+		);
+		const hub = new ToolExecutionComponent(
+			"hub",
+			{ op: "wait", timeoutMs: 600_000 },
+			{ liveRegion: transcript },
+			undefined,
+			tui,
+			process.cwd(),
+		);
+		transcript.addChild(hub);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			scheduler.flush();
+			await term.flush();
+			for (let tick = 1; tick <= 12; tick++) {
+				hub.updateResult(waitPartial(tick), true);
+				term.scrollLines(1000);
+				tui.requestRender();
+				scheduler.flush();
+				await term.flush();
+			}
+
+			const buffer = plainScrollBuffer(term);
+			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
+				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
+			}
+		} finally {
+			hub.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("a poll taller than the remaining viewport still records each job once", async () => {
+		const rows = 8;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(80, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.setScrollbackRebuild(false);
+		const transcript = new TranscriptContainer();
+		transcript.addChild(
+			new StaticBlock(Array.from({ length: 20 }, (_, i) => `history-line-${String(i).padStart(2, "0")}`)),
+		);
+		const hub = new ToolExecutionComponent(
+			"hub",
+			{ op: "wait", timeoutMs: 600_000 },
+			{ liveRegion: transcript },
+			undefined,
+			tui,
+			process.cwd(),
+		);
+		transcript.addChild(hub);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			hub.updateResult(waitPartial(0), true);
+			tui.start();
+			scheduler.flush();
+			await term.flush();
+			for (let tick = 1; tick <= 12; tick++) {
+				hub.updateResult(waitPartial(tick), true);
+				term.scrollLines(1000);
+				tui.requestRender();
+				scheduler.flush();
+				await term.flush();
+			}
+
+			expect(hub.isDisplaceableBlock()).toBe(true);
+			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
+
+			const buffer = plainScrollBuffer(term);
+			const approval = buffer.filter(line => line.includes("ApprovalTests")).length;
+			expect(approval).toBeLessThanOrEqual(1);
+		} finally {
+			hub.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("spinner ticks do not stack job rows", async () => {
+		const rows = 12;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(80, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.setScrollbackRebuild(false);
+		const transcript = new TranscriptContainer();
+		const hub = new ToolExecutionComponent(
+			"hub",
+			{ op: "wait", timeoutMs: 600_000 },
+			{ liveRegion: transcript },
+			undefined,
+			tui,
+			process.cwd(),
+		);
+		transcript.addChild(hub);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			hub.updateResult(waitPartial(0), true);
+			scheduler.flush();
+			await term.flush();
+			for (let tick = 0; tick < 20; tick++) {
+				hub.tickSpinner(tick);
+				term.scrollLines(1000);
+				scheduler.flush();
+				await term.flush();
+			}
+
+			const buffer = plainScrollBuffer(term);
+			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
+				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
+			}
+		} finally {
+			hub.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+});

--- a/packages/coding-agent/test/hub-wait-scrollback.test.ts
+++ b/packages/coding-agent/test/hub-wait-scrollback.test.ts
@@ -139,6 +139,14 @@ function waitPartial(tick: number) {
 	};
 }
 
+const VISIBLE_JOBS = ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const;
+
+function expectEachJobOnce(buffer: string[]): void {
+	for (const label of VISIBLE_JOBS) {
+		expect(buffer.filter(line => line.includes(label)).length).toBe(1);
+	}
+}
+
 describe("hub wait poll never sprays duplicate job rows into scrollback", () => {
 	beforeAll(async () => {
 		resetSettingsForTest();
@@ -189,11 +197,8 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
 
 			const buffer = plainScrollBuffer(term);
-			const joined = buffer.join("\n");
-			expect(joined).toContain("waiting on 6 jobs");
-			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
-				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
-			}
+			expect(buffer.join("\n")).toContain("waiting on 6 jobs");
+			expectEachJobOnce(buffer);
 		} finally {
 			hub.stopAnimation();
 			tui.stop();
@@ -209,6 +214,9 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
 		tui.setScrollbackRebuild(false);
 		const transcript = new TranscriptContainer();
+		transcript.addChild(
+			new StaticBlock(Array.from({ length: 20 }, (_, i) => `history-line-${String(i).padStart(2, "0")}`)),
+		);
 		const hub = new ToolExecutionComponent(
 			"hub",
 			{ op: "wait", timeoutMs: 600_000 },
@@ -221,9 +229,10 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 		transcript.addChild(hub);
 		tui.addChild(transcript);
 		tui.addChild(new AnchoredHud());
-		tui.addChild(new Footer(4));
+		tui.addChild(new Footer(5));
 
 		try {
+			hub.updateResult(waitPartial(0), true);
 			tui.start();
 			scheduler.flush();
 			await term.flush();
@@ -235,10 +244,12 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 				await term.flush();
 			}
 
+			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
+			expect(transcript.getNativeScrollbackLiveRegionPinnedStart()).toBeGreaterThan(
+				transcript.getNativeScrollbackLiveRegionStart() ?? 0,
+			);
 			const buffer = plainScrollBuffer(term);
-			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
-				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
-			}
+			expectEachJobOnce(buffer);
 		} finally {
 			hub.stopAnimation();
 			tui.stop();
@@ -282,9 +293,7 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 			}
 
 			const buffer = plainScrollBuffer(term);
-			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
-				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
-			}
+			expectEachJobOnce(buffer);
 		} finally {
 			hub.stopAnimation();
 			tui.stop();
@@ -293,7 +302,7 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 	}, 30_000);
 
 	test("a poll taller than the remaining viewport still records each job once", async () => {
-		const rows = 8;
+		const rows = 12;
 		stubStdoutRows(rows);
 		const term = new VirtualTerminal(80, rows);
 		const scheduler = makeDrainableScheduler();
@@ -313,7 +322,7 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 		);
 		transcript.addChild(hub);
 		tui.addChild(transcript);
-		tui.addChild(new Footer(4));
+		tui.addChild(new Footer(5));
 
 		try {
 			hub.updateResult(waitPartial(0), true);
@@ -332,8 +341,7 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
 
 			const buffer = plainScrollBuffer(term);
-			const approval = buffer.filter(line => line.includes("ApprovalTests")).length;
-			expect(approval).toBeLessThanOrEqual(1);
+			expectEachJobOnce(buffer);
 		} finally {
 			hub.stopAnimation();
 			tui.stop();
@@ -374,9 +382,7 @@ describe("hub wait poll never sprays duplicate job rows into scrollback", () => 
 			}
 
 			const buffer = plainScrollBuffer(term);
-			for (const label of ["ApprovalTests", "ConfigNotify", "FeishuAdapter"] as const) {
-				expect(buffer.filter(line => line.includes(label)).length).toBeLessThanOrEqual(1);
-			}
+			expectEachJobOnce(buffer);
 		} finally {
 			hub.stopAnimation();
 			tui.stop();

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -197,6 +197,27 @@ describe("ToolExecutionComponent live preview spinners", () => {
 		}
 	});
 
+	it("pins a pending hub wait before the first progress snapshot arrives", () => {
+		const component = new ToolExecutionComponent(
+			"hub",
+			{ op: "wait" },
+			{},
+			undefined,
+			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+			process.cwd(),
+		);
+		const transcript = new TranscriptContainer();
+		transcript.addChild(component);
+
+		try {
+			transcript.render(80);
+			expect(component.isNativeScrollbackLiveRegionPinned()).toBe(true);
+			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
 	it("pins the displaceable hub waiting poll and releases it once jobs settle", () => {
 		const component = new ToolExecutionComponent(
 			"hub",

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -999,6 +999,18 @@ describe("TranscriptContainer seal-on-commit", () => {
 		expect(container.isBlockUncommitted(card)).toBe(true);
 	});
 
+	it("does not seal when only the container-owned separator has committed", () => {
+		const { container, card } = cardAfterHistory();
+		// live-region start is row 2; the engine's pin ceiling commits [0, 2)
+		// (history + the blank separator). That blank is not a card body row.
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(2);
+		container.setNativeScrollbackCommittedRows(2);
+		container.render(W);
+		expect(card.sealCount).toBe(0);
+		expect(container.isBlockUncommitted(card)).toBe(true);
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(2);
+	});
+
 	it("never seals across same-value or decreasing republishes above the block", () => {
 		const { container, card } = cardAfterHistory();
 		// The engine republishes the committed count every frame (compose and

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -59,6 +59,13 @@ class UnfinalizedText extends Text {
 	}
 }
 
+/** Live dashboard that opts into viewport pinning (hub wait / todo snapshot). */
+class PinnedLiveBlock extends StreamingBlock {
+	isNativeScrollbackLiveRegionPinned(): boolean {
+		return !this.isTranscriptBlockFinalized();
+	}
+}
+
 // A still-live block that can declare a byte-stable rendered prefix. The
 // transcript container may commit only those declared rows before finalization.
 class DeclaredSettledStreamingBlock extends StreamingBlock {
@@ -478,6 +485,21 @@ describe("TranscriptContainer", () => {
 		pending.finalize(["pending-final"]);
 		expect(container.render(40)).toEqual(["done-collapsed", "", "pending-final", "", "card"]);
 		expect(container.getNativeScrollbackLiveRegionStart()).toBeUndefined();
+	});
+
+	it("keeps the earliest live seam and pins from a later live dashboard", () => {
+		const container = new TranscriptContainer();
+		container.addChild(new MutableBlock(["history"]));
+		const pending = new StreamingBlock(["bash-pending"]);
+		const poll = new PinnedLiveBlock(["wait-header", "wait-body"]);
+		container.addChild(pending);
+		container.addChild(poll);
+		expect(container.render(40)).toEqual(["history", "", "bash-pending", "", "wait-header", "wait-body"]);
+		// history(0) sep(1) bash(2) sep(3) wait(4..) — live seam at bash,
+		// pin ceiling at the hub-wait body so bash can still commit.
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(2);
+		expect(container.isNativeScrollbackLiveRegionPinned()).toBe(true);
+		expect(container.getNativeScrollbackLiveRegionPinnedStart()).toBe(4);
 	});
 
 	it("stops the boundary at the first unfinalized block's first content row when no rows are settled", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Optional `getNativeScrollbackLiveRegionPinnedStart()` so a nested transcript can pin a later dashboard without moving the earliest live seam.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -216,6 +216,13 @@ export interface NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined;
 	/** Keeps the mutable suffix viewport-local instead of recording frozen snapshots. */
 	isNativeScrollbackLiveRegionPinned?(): boolean;
+	/**
+	 * Local row where viewport pinning begins. When omitted, pinning (if
+	 * reported) starts at {@link getNativeScrollbackLiveRegionStart}. A nested
+	 * transcript uses this to keep an earlier unpinned live seam while still
+	 * capping commits at a later pinned dashboard (hub wait, todo snapshot).
+	 */
+	getNativeScrollbackLiveRegionPinnedStart?(): number | undefined;
 }
 
 export interface NativeScrollbackCommittedRows {
@@ -276,6 +283,13 @@ function isOverlayFocusTarget(owner: Component, component: Component | null): bo
 
 function getNativeScrollbackLiveRegionStart(component: Component): number | undefined {
 	return (component as Component & Partial<NativeScrollbackLiveRegion>).getNativeScrollbackLiveRegionStart?.();
+}
+
+function getNativeScrollbackLiveRegionPinnedStart(component: Component): number | undefined {
+	const start = (
+		component as Component & Partial<NativeScrollbackLiveRegion>
+	).getNativeScrollbackLiveRegionPinnedStart?.();
+	return start === undefined || !Number.isFinite(start) ? undefined : start;
 }
 
 /**
@@ -901,6 +915,8 @@ interface FrameSegment {
 	widthEpochRevision?: number;
 	liveLocalStart?: number;
 	liveRegionPinned: boolean;
+	/** Local pin start; when omitted, pinning begins at `liveLocalStart`. */
+	liveRegionPinnedStart?: number;
 }
 
 /** Depth-first identity search through `Container`-shaped children. */
@@ -1661,12 +1677,14 @@ export class TUI extends Container {
 			let childLines: readonly string[];
 			let liveLocalStart: number | undefined;
 			let liveRegionPinned = false;
+			let liveRegionPinnedStart: number | undefined;
 			let widthEpochRevision: number | undefined;
 			let reported: number | undefined;
 			if (reuse) {
 				childLines = previous.lines;
 				liveLocalStart = previous.liveLocalStart;
 				liveRegionPinned = previous.liveRegionPinned;
+				liveRegionPinnedStart = previous.liveRegionPinnedStart;
 				widthEpochRevision = previous.widthEpochRevision;
 			} else {
 				// Feed the engine's committed-row claim (from the previous frame's
@@ -1697,6 +1715,15 @@ export class TUI extends Container {
 					liveRegionPinned =
 						(child as Component & Partial<NativeScrollbackLiveRegion>).isNativeScrollbackLiveRegionPinned?.() ===
 						true;
+					if (liveRegionPinned) {
+						const pinStart = getNativeScrollbackLiveRegionPinnedStart(child);
+						if (pinStart !== undefined) {
+							liveRegionPinnedStart = Math.max(
+								liveLocalStart,
+								Math.min(childLines.length, Math.trunc(pinStart)),
+							);
+						}
+					}
 				}
 				// Consume the stability report unconditionally for implementers:
 				// reading re-bases the component's baseline to the state this
@@ -1722,7 +1749,7 @@ export class TUI extends Container {
 				// even when an earlier unpinned seam won the topmost merge above:
 				// its rows (a growing anchored panel) must never reach scrollback.
 				if (liveRegionPinned && this.#nativeScrollbackPinnedBoundary === undefined) {
-					this.#nativeScrollbackPinnedBoundary = start;
+					this.#nativeScrollbackPinnedBoundary = offset + (liveRegionPinnedStart ?? liveLocalStart);
 				}
 			}
 			if (chainStable) {
@@ -1754,6 +1781,7 @@ export class TUI extends Container {
 				widthEpochRevision,
 				liveLocalStart,
 				liveRegionPinned,
+				liveRegionPinnedStart,
 			};
 			offset += childLines.length;
 		}


### PR DESCRIPTION
I reviewed the full diff; this stops a live `hub wait` poll from stacking frozen copies of the same `[task]` rows once the transcript is taller than the viewport.

## The bug

While `hub wait` is sitting on running subagents, the TUI is supposed to keep one live poll and rewrite duration/shimmer in place. After enough history (or a short remaining viewport under the composer/todo HUD), that poll leaked into native scrollback:

```
ⓘ waiting on 6 jobs
├─ [task] ApprovalTests 6m29s
├─ [task] ConfigNotify 4m37s
├─ [task] FeishuAdapter 4m37s
├─ [task] ApprovalTests 6m30s
├─ [task] ConfigNotify 4m38s
├─ [task] FeishuAdapter 4m38s
…repeating once a second
```

Reproduced in `packages/coding-agent/test/hub-wait-scrollback.test.ts` against the Ghostty-backed virtual terminal: 20 history rows + a 6-job wait + a 4-row editor in an 8-row pane. Before the fix, `ApprovalTests` landed on the tape 12 times in 12 ticks.

## Cause

Two things stacked:

1. The live-region pin ceiling is `startRow + sep` (the blank separator is container-owned and sits in the committed prefix). Seal-on-commit compared `startRow` instead, so the moment that blank committed the poll was frozen as final history.
2. A pending `hub wait` (no `details.jobs` yet) was not pinned, so its first frame could also commit and force-seal the live dashboard.

After the seal, duration/shimmer ticks mutated a finalized block. The append-only engine recorded each tick as a new frozen snapshot.

## Fix

- Seal and `isBlockUncommitted` use the first **body** row (`startRow + sep`), so a committed separator does not freeze the card.
- Pin `hub wait` from the pending call, not only after the first progress snapshot.

## Verification

- `bun test test/hub-wait-scrollback.test.ts` — the taller-than-viewport smear is gone; the poll stays displaceable and pinned.
- `bun test test/modes/components/transcript-container.test.ts` — new case: committedRows aligned with live-region start (history + sep) does not seal.
- `bun test test/modes/components/tool-execution-spinner.test.ts` — pending hub wait is pinned.
- Also re-ran `test/job-poll-displacement.test.ts`, `test/streaming-output-scrollback.test.ts`, and `test/transcript-history-exactly-once.test.ts`.