### PR TITLE
credential store: prefer newest credentials over oldest

### DIFF
--- a/packages/ai/src/auth/sqlite-credential-store.ts
+++ b/packages/ai/src/auth/sqlite-credential-store.ts
@@ -388,10 +388,10 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#localAuthRevision = this.#readLocalAuthRevision();
 
 		this.#listActiveStmt = this.#db.prepare(
-			"SELECT id, provider, credential_type, data, disabled_cause, identity_key FROM auth_credentials WHERE disabled_cause IS NULL ORDER BY id ASC",
+			"SELECT id, provider, credential_type, data, disabled_cause, identity_key FROM auth_credentials WHERE disabled_cause IS NULL ORDER BY id DESC",
 		);
 		this.#listActiveByProviderStmt = this.#db.prepare(
-			"SELECT id, provider, credential_type, data, disabled_cause, identity_key FROM auth_credentials WHERE provider = ? AND disabled_cause IS NULL ORDER BY id ASC",
+			"SELECT id, provider, credential_type, data, disabled_cause, identity_key FROM auth_credentials WHERE provider = ? AND disabled_cause IS NULL ORDER BY id DESC",
 		);
 		this.#listDisabledStmt = this.#db.prepare(
 			"SELECT id, provider, credential_type, data, disabled_cause, identity_key, updated_at FROM auth_credentials WHERE disabled_cause IS NOT NULL ORDER BY id ASC",


### PR DESCRIPTION
## Problem

When a user has multiple stored credentials for the same provider (e.g. re-logging after a token expires), the **oldest** credential was always selected first via `ORDER BY id ASC`. With expired/revoked tokens still in the pool, each cold provider request burns unnecessary 401 round-trips before reaching the valid newest credential.

## Root cause

Two prepared statements in `SqliteAuthCredentialStore` query active credentials ordered by `ORDER BY id ASC`:

- `#listActiveStmt` — used by `listAuthCredentials()`, `getApiKey()`, `getOAuth()`, `listProviders()`
- `#listActiveByProviderStmt` — used by `listAuthCredentials(provider)`, `replaceAuthCredentialsForProvider()`, `upsertAuthCredentialForProvider()`

Both feed into `AuthStorage`'s in-memory cache, which the credential-selection and round-robin code inherits. The fallback (when all credentials are blocked) also defaults to the first (oldest) entry.

## Fix

Changed both queries to `ORDER BY id DESC`. Newest credential (most recently added via `login`) is now preferred. This applies universally across all providers and credential types.

Disabled-credential audit queries and the identity-key migration query remain at `ASC` — they're display-only and unaffected.