### PR TITLE
fix(nix): give dlopen'd ONNX addons a libstdc++ path

### DIFF
--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -13,6 +13,13 @@ fallback is used when that role is unset.
 
 - **Stack**: `@huggingface/transformers` (transformers.js) v4 running under Bun. In Bun the library
   loads the **native `onnxruntime-node` backend** (not the WASM build).
+- **Non-FHS distros (NixOS, and any host without `libstdc++.so.6` on the loader path)**: the
+  on-demand `onnxruntime-node` / `sherpa-onnx-node` / `sharp` addons are prebuilt binaries that
+  `dlopen` `libstdc++.so.6` and `libgcc_s.so.1`, and they carry their own `DT_RUNPATH`, so nothing in
+  the omp executable's own RPATH can resolve them. Set `OMP_NATIVE_LIBRARY_PATH` to the
+  colon-separated directories holding those libraries; omp appends it to `LD_LIBRARY_PATH` for the
+  inference worker subprocesses only (never for shell/eval/daemon children). The Nix package
+  (`nix/package.nix`) sets this by default.
 - **Device policy**: local tiny models default to CPU-only inference and retry once on CPU if an
   explicit accelerated provider cannot initialize.
   - Pick a provider persistently with the `providers.tinyModelDevice` setting (`default` keeps CPU),

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,6 +8,7 @@
   lib,
   libopus,
   libpulseaudio,
+  makeBinaryWrapper,
   ninja,
   pipewire,
   pkg-config,
@@ -52,6 +53,9 @@ let
     _: patch: source + "/${patch}"
   ) rootPackageJson.patchedDependencies;
   patchOverrides = bun2nix.patchedDependenciesToOverrides { inherit patchedDependencies; };
+  runtimeNativeLibraries = lib.optionals stdenv.hostPlatform.isLinux (
+    [ stdenv.cc.cc.lib ] ++ lib.optional (stdenv.cc.cc ? libgcc) stdenv.cc.cc.libgcc
+  );
   bunRuntimeTemplate = stdenvNoCC.mkDerivation {
     pname = "omp-bun-runtime-template";
     inherit (bun) version;
@@ -91,7 +95,10 @@ stdenv.mkDerivation {
     rustPlatform.cargoSetupHook
     rustToolchain
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+    makeBinaryWrapper
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
   # pcre2 is vendored via PCRE2_SYS_STATIC, but opus must link the nixpkgs
@@ -195,6 +202,20 @@ stdenv.mkDerivation {
     remove-references-to -t ${bun} "$out/bin/omp"
   '';
 
+  # Prebuilt addons that omp bun-installs into its cache at first use
+  # (onnxruntime-node, sherpa-onnx-node, sharp, fastembed) are process.dlopen'd and
+  # need libstdc++.so.6 / libgcc_s.so.1, which nix glibc's default loader path lacks;
+  # their own DT_RUNPATH means this executable's RPATH is never consulted for their
+  # dependencies, so only LD_LIBRARY_PATH resolves them. The agent injects this value
+  # into the inference worker subprocesses' LD_LIBRARY_PATH alone (see
+  # packages/coding-agent/src/subprocess/worker-client.ts) instead of exporting
+  # LD_LIBRARY_PATH process-wide, where it would also reorder the loader search path
+  # of every user command the bash tool, daemon PTY sessions and eval kernels spawn.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram "$out/bin/omp" \
+      --set-default OMP_NATIVE_LIBRARY_PATH "${lib.makeLibraryPath runtimeNativeLibraries}"
+  '';
+
   disallowedReferences = [ bun ];
 
   doInstallCheck = true;
@@ -203,6 +224,12 @@ stdenv.mkDerivation {
     HOME="$TMPDIR" "$out/bin/omp" --smoke-test | grep -q "smoke-test: ok"
     BUN_BE_BUN=1 "$out/bin/omp" -e \
       'if (Bun.version !== "${bun.version}" || typeof Bun.Image !== "function") process.exit(1)'
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      # The addons are dlopen'd, so prove the advertised directories actually
+      # resolve the libraries rather than merely carrying a plausible string.
+      env -u LD_LIBRARY_PATH BUN_BE_BUN=1 "$out/bin/omp" -e \
+        'const {dlopen}=require("bun:ffi");const dirs=(process.env.OMP_NATIVE_LIBRARY_PATH||"").split(":").filter(Boolean);const need={"libstdc++.so.6":{__cxa_demangle:{args:["ptr","ptr","ptr","ptr"],returns:"ptr"}},"libgcc_s.so.1":{_Unwind_Backtrace:{args:["ptr","ptr"],returns:"i32"}}};for(const lib of Object.keys(need)){let ok=false;for(const d of dirs){try{dlopen(d+"/"+lib,need[lib]);ok=true;break}catch(e){}}if(!ok){console.error("unresolved: "+lib);process.exit(1)}}'
+    ''}
     runHook postInstallCheck
   '';
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Nix-packaged builds no longer fail to load the on-demand `onnxruntime-node`/`sherpa-onnx` addons with `libstdc++.so.6: cannot open shared object file` (STT, TTS, tiny-model and mnemopi workers) — the package advertises its C++ runtime library dirs and the agent injects them into the inference worker subprocesses only.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -3,6 +3,7 @@ import {
 	createUnavailableWorker,
 	createWorkerHandle,
 	createWorkerSubprocess,
+	inferenceWorkerEnv,
 	logWorkerMessage,
 	resolveWorkerSpawnCmd,
 	SMOKE_TEST_TIMEOUT_MS,
@@ -10,7 +11,6 @@ import {
 	smokeTestWorker,
 	spawnWorkerOrUnavailable,
 	type WorkerHandle,
-	workerEnvFromParent,
 } from "../subprocess/worker-client";
 import type { MnemopiEmbedModelId, MnemopiEmbedWorkerInbound, MnemopiEmbedWorkerOutbound } from "./embed-protocol";
 
@@ -37,14 +37,14 @@ export const MNEMOPI_EMBED_WORKER_ARG = "__omp_worker_mnemopi_embed";
 /**
  * Spawn the mnemopi embeddings worker as a subprocess. Exported for tests and
  * the smoke probe; production callers go through {@link spawnMnemopiEmbedWorker}.
- * The child inherits the parent env verbatim — fastembed honours `HF_HUB_*`,
+ * The child inherits the parent env — fastembed honours `HF_HUB_*`,
  * `HTTPS_PROXY`, etc., and our `loadFastembed()` reads the same `OMP_*`
  * runtime-install knobs the parent uses.
  */
 export function createMnemopiEmbedSubprocess(): SpawnedSubprocess<MnemopiEmbedWorkerOutbound> {
 	return createWorkerSubprocess<MnemopiEmbedWorkerOutbound>({
 		spawnCommand: resolveWorkerSpawnCmd(MNEMOPI_EMBED_WORKER_ARG),
-		env: workerEnvFromParent(),
+		env: inferenceWorkerEnv(),
 		exitLabel: "mnemopi embed subprocess",
 	});
 }

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -146,6 +146,38 @@ export function workerEnvFromParent(overlay?: Record<string, string>): Record<st
 }
 
 /**
+ * `LD_LIBRARY_PATH` overlay that lets a dlopen'd native addon find its C++
+ * runtime. The ONNX addons installed on demand under `~/.omp/agent/cache/**`
+ * are `process.dlopen`'d and need `libstdc++.so.6` / `libgcc_s.so.1`; because
+ * each addon carries its own `DT_RUNPATH`, an RPATH on our executable cannot
+ * satisfy them, so the path has to come from the environment. On distros where
+ * those libraries are outside the loader's default search path (NixOS) the
+ * packaged build exports `OMP_NATIVE_LIBRARY_PATH` (see `nix/package.nix`).
+ * Appended last so an inherited `LD_LIBRARY_PATH` keeps precedence.
+ * Pure for testability; see {@link inferenceWorkerEnv} for the spawn-time glue.
+ */
+export function nativeLibraryPathOverlay(
+	env: Record<string, string | undefined>,
+	platform: NodeJS.Platform,
+): Record<string, string> {
+	if (platform !== "linux") return {};
+	const native = env.OMP_NATIVE_LIBRARY_PATH;
+	if (typeof native !== "string" || native.length === 0) return {};
+	const inherited = env.LD_LIBRARY_PATH;
+	return { LD_LIBRARY_PATH: inherited ? `${inherited}:${native}` : native };
+}
+
+/**
+ * Env for an ONNX inference worker: the parent env plus the native library
+ * path. Only these workers get it — the daemon broker spawns user PTY sessions
+ * and eval kernels through {@link workerEnvFromParent}, and rewriting the
+ * loader search path of arbitrary user commands risks a `GLIBCXX` mismatch.
+ */
+export function inferenceWorkerEnv(overlay?: Record<string, string>): Record<string, string> {
+	return workerEnvFromParent({ ...nativeLibraryPathOverlay($env, process.platform), ...overlay });
+}
+
+/**
  * Spawn an inference worker subprocess and wire its IPC fan-out. Stdio is
  * captured (stderr redirected to a temp file, stdout ignored) so native
  * runtimes can't corrupt the chat scrollback while the crash reason still

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -4,6 +4,7 @@ import {
 	createUnavailableWorker,
 	createWorkerHandle,
 	createWorkerSubprocess,
+	inferenceWorkerEnv,
 	logWorkerMessage,
 	type RefCountedWorkerHandle,
 	resolveWorkerSpawnCmd,
@@ -11,7 +12,6 @@ import {
 	type SpawnedSubprocess,
 	smokeTestWorker,
 	spawnWorkerOrUnavailable,
-	workerEnvFromParent,
 } from "../subprocess/worker-client";
 import { safeSend } from "../utils/ipc";
 import { tinyModelDeviceSettingToEnv } from "./device";
@@ -116,7 +116,7 @@ export function tinyWorkerEnvOverlay(
  * subprocess).
  */
 export function tinyWorkerEnv(): Record<string, string> {
-	return workerEnvFromParent(
+	return inferenceWorkerEnv(
 		tinyWorkerEnvOverlay(
 			$env,
 			readTinyModelSetting("providers.tinyModelDevice"),

--- a/packages/coding-agent/test/tiny-worker-env.test.ts
+++ b/packages/coding-agent/test/tiny-worker-env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { nativeLibraryPathOverlay } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
 import { tinyWorkerEnvOverlay } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
 
 describe("tinyWorkerEnvOverlay", () => {
@@ -17,5 +18,33 @@ describe("tinyWorkerEnvOverlay", () => {
 	it("omits a var when its setting is the default sentinel or unset", () => {
 		expect(tinyWorkerEnvOverlay({}, "default", "default")).toEqual({});
 		expect(tinyWorkerEnvOverlay({}, undefined, undefined)).toEqual({});
+	});
+});
+
+describe("nativeLibraryPathOverlay", () => {
+	it("appends the advertised dirs after an inherited LD_LIBRARY_PATH", () => {
+		expect(
+			nativeLibraryPathOverlay(
+				{ LD_LIBRARY_PATH: "/inherited", OMP_NATIVE_LIBRARY_PATH: "/store/gcc/lib" },
+				"linux",
+			),
+		).toEqual({ LD_LIBRARY_PATH: "/inherited:/store/gcc/lib" });
+	});
+
+	it("uses the advertised dirs alone when nothing is inherited", () => {
+		expect(
+			nativeLibraryPathOverlay({ OMP_NATIVE_LIBRARY_PATH: "/store/gcc/lib:/store/libgcc/lib" }, "linux"),
+		).toEqual({ LD_LIBRARY_PATH: "/store/gcc/lib:/store/libgcc/lib" });
+	});
+
+	it("stays out of the env on non-Linux platforms", () => {
+		const env = { OMP_NATIVE_LIBRARY_PATH: "/store/gcc/lib" };
+		expect(nativeLibraryPathOverlay(env, "darwin")).toEqual({});
+		expect(nativeLibraryPathOverlay(env, "win32")).toEqual({});
+	});
+
+	it("stays out of the env on Linux when no dirs are advertised", () => {
+		expect(nativeLibraryPathOverlay({ LD_LIBRARY_PATH: "/inherited" }, "linux")).toEqual({});
+		expect(nativeLibraryPathOverlay({ OMP_NATIVE_LIBRARY_PATH: "" }, "linux")).toEqual({});
 	});
 });


### PR DESCRIPTION
## Problem

On NixOS, every local-inference feature of the Nix-packaged `omp` dies on first use:

```
Warning: Error: libstdc++.so.6: cannot open shared object file: No such file or directory
    at dlopen (unknown)
    at <anonymous> (~/.omp/agent/cache/stt-runtime/transformers-4.2.0/node_modules/onnxruntime-node/dist/binding.js:10)
    ...
    at <anonymous> (/$bunfs/root/packages/coding-agent/src/cli.js:620528:76)
```

The prebuilt addons omp `bun install`s on demand into `~/.omp/agent/cache/**` — `onnxruntime-node`, `sherpa-onnx-node`, `sharp`, `fastembed` — are `process.dlopen`'d and need `libstdc++.so.6` / `libgcc_s.so.1`. Nix glibc's `ld.so` default search path contains only glibc; those two live in separate store paths (`gcc-*-lib`, `gcc-*-libgcc`). Result: STT, TTS, tiny-model titles and mnemopi embeddings are all unavailable.

## Why it can't be fixed with ELF surgery

`onnxruntime_binding.node` carries its own **`DT_RUNPATH`** (`$ORIGIN/`). Measured with a C++ fixture (executable dlopens a module needing `libstdc++`):

| exe tag | module tag | dlopen |
|---|---|---|
| `DT_RUNPATH` | none | fail |
| `DT_RPATH` | none | ok |
| `DT_RPATH` | `DT_RUNPATH` | **fail** ← the real addon |
| none | any | ok via `LD_LIBRARY_PATH` |

glibc consults the loading chain's `DT_RPATH` only for objects without their own `DT_RUNPATH`, so patchelf'ing the `omp` binary cannot help. An environment path is the only lever.

## Why not just export `LD_LIBRARY_PATH` from a wrapper

`LD_LIBRARY_PATH` overrides a binary's own RUNPATH and is inherited by every child. omp's bash tool, daemon PTY sessions (`launch/broker.ts`) and eval kernels spawn arbitrary user commands, so a nixpkgs-unstable `libstdc++` forced ahead of their own would be a real `GLIBCXX_3.4.x not found` hazard on any machine whose other closures are newer.

## Change

- `nix/package.nix`: wrap `omp` with `makeBinaryWrapper` and `--set-default OMP_NATIVE_LIBRARY_PATH "${lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.cc.cc.libgcc ]}"` (Linux only; Darwin finds libc++ in `/usr/lib`). `--set-default` so a user value still wins.
- `src/subprocess/worker-client.ts`: new `nativeLibraryPathOverlay(env, platform)` (pure) and `inferenceWorkerEnv(overlay?)`, which appends that value to the child's `LD_LIBRARY_PATH` — inherited entries keep precedence.
- `tiny/title-client.ts` (`tinyWorkerEnv`, shared by the tiny-model, STT and TTS workers) and `mnemopi/embed-client.ts` use it. `workerEnvFromParent` is deliberately untouched, so the broker, LSP mux, daemon PTYs and eval kernels never get an injected loader path.
- `installCheckPhase` gains a Linux probe that actually `dlopen`s `libstdc++.so.6` and `libgcc_s.so.1` from the advertised directories with the ambient `LD_LIBRARY_PATH` stripped — a wrong path fails the build instead of shipping.
- `docs/local-models.md` documents `OMP_NATIVE_LIBRARY_PATH` as the escape hatch for non-FHS hosts installing omp outside this flake.

## Verification

- `nix build .#omp` → install checks green, including the new dlopen probe.
- Built wrapper exports both store lib dirs; a user-supplied `OMP_NATIVE_LIBRARY_PATH` overrides it; `omp --smoke-test` → `smoke-test: ok` (that path spawns real worker subprocesses through the wrapper).
- End-to-end on the real STT whisper worker with the cached `whisper-small` model:
  - `OMP_NATIVE_LIBRARY_PATH` unset → reproduces the stack above verbatim (`worker-runtime.ts:455`).
  - set → transcription returns normally.
- `bun test test/tiny-worker-env.test.ts` → 7 pass / 0 fail; `biome check .` clean; `tsgo --noEmit` clean.
