### PR TITLE
fix(lsp): hard wall-clock bound on per-server diagnostics pipeline (edit tool hang)

### DIFF
--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import path from "node:path";
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
 import { formatPathRelativeToCwd } from "../tools/path-utils";
 import { throwIfAborted } from "../tools/tool-errors";
 import { getOrCreateClient, sendRequest, supportsDocumentDiagnostics, waitForProjectLoaded } from "./client";
@@ -48,6 +48,19 @@ export const INLINE_DIAGNOSTICS_WAIT_TIMEOUT_MS = 500;
  * delivers late instead of giving up before it ever publishes.
  */
 export const DEFERRED_DIAGNOSTICS_WAIT_TIMEOUT_MS = 12_000;
+/**
+ * Extra wall-clock headroom granted to each per-server diagnostics pipeline on
+ * top of its diagnostics wait budget. The pipeline includes client creation
+ * (spawn + initialize), project load, and custom linter runs — steps that have
+ * no own deadline when the caller passes a user-abort-only signal (the edit
+ * tool does exactly that: `sendRequest` skips its default timeout whenever a
+ * signal is present). A wedged server or hung linter subprocess then blocks
+ * the edit forever, and because the edit tool is `exclusive`, every later edit
+ * queues behind it (issue #4910). This grace period turns that infinite hang
+ * into a bounded skip: the slow server is dropped from this round's results
+ * and the edit returns.
+ */
+export const DIAGNOSTICS_PIPELINE_GRACE_MS = 10_000;
 export const MAX_GLOB_DIAGNOSTIC_TARGETS = 20;
 export const WORKSPACE_SYMBOL_LIMIT = 200;
 export const PROJECT_INDEXED_ACTIONS: ReadonlySet<string> = new Set([
@@ -296,6 +309,12 @@ interface GetDiagnosticsForFileOptions {
 	expectedDocumentVersions?: ServerVersionMap;
 	/** Per-server wait budget (ms). Defaults to {@link SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS}. */
 	timeoutMs?: number;
+	/**
+	 * Hard wall-clock bound (ms) for each server's whole pipeline (client init,
+	 * project load, linting, diagnostics wait). Defaults to the wait budget plus
+	 * {@link DIAGNOSTICS_PIPELINE_GRACE_MS}. Exposed as a test seam.
+	 */
+	pipelineBudgetMs?: number;
 }
 
 /**
@@ -358,40 +377,53 @@ export async function getDiagnosticsForFile(
 	if (servers.length === 0) {
 		return undefined;
 	}
+	const waitBudgetMs = timeoutMs ?? SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS;
+	const pipelineBudgetMs = options.pipelineBudgetMs ?? waitBudgetMs + DIAGNOSTICS_PIPELINE_GRACE_MS;
 
 	const uri = fileToUri(absolutePath);
 	const relPath = formatPathRelativeToCwd(absolutePath, cwd);
 	const allDiagnostics: Diagnostic[] = [];
 	const serverNames: string[] = [];
 
-	// Wait for diagnostics from all servers in parallel
+	// Wait for diagnostics from all servers in parallel. Each server's whole
+	// pipeline is wrapped in a hard wall-clock bound: the caller's signal is
+	// typically user-abort-only (never fires on its own), and both `sendRequest`
+	// during client init (no default timeout when a signal is present) and
+	// custom `LinterClient.lint` (no signal at all) can otherwise block forever
+	// on a wedged server (issue #4910). A server that overruns its budget is
+	// rejected by `untilAborted`, lands as a rejected `allSettled` entry, and is
+	// simply skipped for this round — the edit still returns.
 	const results = await Promise.allSettled(
-		servers.map(async ([serverName, serverConfig]) => {
-			throwIfAborted(signal);
-			// Use custom linter client if configured
-			if (serverConfig.createClient) {
-				const linterClient = getLinterClient(serverName, serverConfig, cwd);
-				const diagnostics = await linterClient.lint(absolutePath);
-				return { serverName, serverConfig, diagnostics };
-			}
+		servers.map(([serverName, serverConfig]) => {
+			const budgetSignal = AbortSignal.timeout(pipelineBudgetMs);
+			const boundSignal = signal ? AbortSignal.any([signal, budgetSignal]) : budgetSignal;
+			return untilAborted(boundSignal, async () => {
+				throwIfAborted(boundSignal);
+				// Use custom linter client if configured
+				if (serverConfig.createClient) {
+					const linterClient = getLinterClient(serverName, serverConfig, cwd);
+					const diagnostics = await linterClient.lint(absolutePath);
+					return { serverName, serverConfig, diagnostics };
+				}
 
-			// Default: use LSP
-			const client = await getOrCreateClient(serverConfig, cwd, undefined, signal);
-			throwIfAborted(signal);
-			if (isProjectAwareLspServer(serverConfig)) {
-				await waitForProjectLoaded(client, signal);
-				throwIfAborted(signal);
-			}
-			// Content already synced + didSave sent, wait for fresh diagnostics
-			const minVersion = minVersions?.get(serverName);
-			const expectedDocumentVersion = expectedDocumentVersions?.get(serverName);
-			const diagnostics = await waitForDiagnostics(client, uri, {
-				timeoutMs: timeoutMs ?? SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS,
-				signal,
-				minVersion,
-				expectedDocumentVersion,
+				// Default: use LSP
+				const client = await getOrCreateClient(serverConfig, cwd, undefined, boundSignal);
+				throwIfAborted(boundSignal);
+				if (isProjectAwareLspServer(serverConfig)) {
+					await waitForProjectLoaded(client, boundSignal);
+					throwIfAborted(boundSignal);
+				}
+				// Content already synced + didSave sent, wait for fresh diagnostics
+				const minVersion = minVersions?.get(serverName);
+				const expectedDocumentVersion = expectedDocumentVersions?.get(serverName);
+				const diagnostics = await waitForDiagnostics(client, uri, {
+					timeoutMs: waitBudgetMs,
+					signal: boundSignal,
+					minVersion,
+					expectedDocumentVersion,
+				});
+				return { serverName, serverConfig, diagnostics };
 			});
-			return { serverName, serverConfig, diagnostics };
 		}),
 	);
 

--- a/packages/coding-agent/test/lsp/issue-4910-diagnostics-bounded.test.ts
+++ b/packages/coding-agent/test/lsp/issue-4910-diagnostics-bounded.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { getDiagnosticsForFile } from "@oh-my-pi/pi-coding-agent/lsp/diagnostics";
+import type { Diagnostic, LinterClient, ServerConfig } from "@oh-my-pi/pi-coding-agent/lsp/types";
+
+/**
+ * Regression test for issue #4910: `edit` silently hangs forever on some
+ * files, and because the edit tool runs `exclusive`, every later edit queues
+ * behind the wedged one.
+ *
+ * Root cause: the batched writethrough flush reaches `getDiagnosticsForFile`
+ * on its blocking (non-deferred) branch with a user-abort-only signal. Two
+ * steps inside the per-server pipeline had no own deadline:
+ *
+ * 1. `getOrCreateClient` → `sendRequest(client, "initialize", …, signal)`
+ *    skips its default timeout whenever a signal is present, assuming the
+ *    caller's signal is a deadline. The edit tool's signal only fires on user
+ *    abort, so a wedged language server blocked the request forever.
+ * 2. Custom `LinterClient.lint` takes no signal or timeout at all, so a hung
+ *    linter subprocess blocked forever.
+ *
+ * The fix wraps each server's whole pipeline in `untilAborted` with a
+ * wall-clock budget (`pipelineBudgetMs`, defaulting to the diagnostics wait
+ * budget plus `DIAGNOSTICS_PIPELINE_GRACE_MS`). An overrunning server is
+ * rejected, skipped by the existing `Promise.allSettled` collection, and the
+ * edit returns.
+ *
+ * These tests use the custom-linter branch (no real LSP process needed) with
+ * the `pipelineBudgetMs` test seam shrunk so the bound is observable in
+ * milliseconds.
+ */
+
+/** A linter whose `lint` never settles — models a hung linter subprocess. */
+function hungLinterConfig(): ServerConfig {
+	const client: LinterClient = {
+		format: async (_filePath, content) => content,
+		lint: () => new Promise<Diagnostic[]>(() => {}),
+	};
+	return {
+		command: "hung-linter-4910",
+		fileTypes: [".py"],
+		rootMarkers: [],
+		createClient: () => client,
+	};
+}
+
+/** A healthy linter that returns immediately with no findings. */
+function healthyLinterConfig(): ServerConfig {
+	const client: LinterClient = {
+		format: async (_filePath, content) => content,
+		lint: async () => [],
+	};
+	return {
+		command: "healthy-linter-4910",
+		fileTypes: [".py"],
+		rootMarkers: [],
+		createClient: () => client,
+	};
+}
+
+describe("issue #4910: diagnostics pipeline is wall-clock bounded", () => {
+	test("a linter that never settles cannot hang getDiagnosticsForFile", async () => {
+		const started = Date.now();
+		// Unique server name: getLinterClient caches by `serverName:cwd`.
+		const result = await getDiagnosticsForFile(
+			"/tmp/issue-4910/falcon_emu.py",
+			"/tmp/issue-4910",
+			[["hung-linter-4910", hungLinterConfig()]],
+			{ pipelineBudgetMs: 50 },
+		);
+		const elapsed = Date.now() - started;
+
+		// The hung server is skipped, so no server produced results.
+		expect(result).toBeUndefined();
+		// Bounded promptly by the budget, not by any multi-second default.
+		// Generous ceiling to stay robust on slow CI machines.
+		expect(elapsed).toBeLessThan(5_000);
+	});
+
+	test("a healthy linter still reports normally under the same budget", async () => {
+		const result = await getDiagnosticsForFile(
+			"/tmp/issue-4910/falcon_emu.py",
+			"/tmp/issue-4910",
+			[["healthy-linter-4910", healthyLinterConfig()]],
+			{ pipelineBudgetMs: 5_000 },
+		);
+
+		expect(result).toBeDefined();
+		expect(result?.server).toBe("healthy-linter-4910");
+		expect(result?.summary).toBe("OK");
+		expect(result?.errored).toBe(false);
+	});
+});


### PR DESCRIPTION
Refs #4910

## Symptom

`edit` silently hangs forever on some files, and because the edit tool runs with `concurrency: "exclusive"`, every later edit queues behind the wedged one — matching the report's "edits never return" behavior. The patcher itself is fast (roboomp reproduced 40ms with LSP disabled), which points at the LSP writethrough path, not the edit engine.

## Root cause

The batched writethrough flush (`flushLspWritethroughBatch`) does not pass `getDeferred`, so `fetchDiagnosticsWithDeferral` takes the **blocking, non-deferred branch** into `getDiagnosticsForFile` with a **user-abort-only signal**. Inside the per-server pipeline, two steps then have no deadline at all:

1. **Client init**: `getOrCreateClient` → `sendRequest(client, "initialize", …, signal)`. `sendRequest` computes `timeoutMs ?? (signal ? undefined : DEFAULT_REQUEST_TIMEOUT_MS)` — i.e. it **skips its default timeout whenever a signal is present**, assuming the caller's signal carries a deadline. The edit tool's signal only fires on user abort, so a wedged language server blocks `initialize` forever.
2. **Custom linters**: `LinterClient.lint(filePath)` takes no signal or timeout, so a hung linter subprocess blocks forever.

All other stages of the writethrough are already bounded (5s sync stage, 5s version capture, 500ms inline wait, 15s `projectLoaded` auto-resolve, 2s watched-files notify) — these two were the only unbounded holes, and either one wedges the exclusive edit lane indefinitely.

## Fix

In `getDiagnosticsForFile`, wrap each server's **whole pipeline** (client init → project load → lint/diagnostics wait) in `untilAborted` from `@oh-my-pi/pi-utils` with a hard wall-clock budget:

- New exported constant `DIAGNOSTICS_PIPELINE_GRACE_MS = 10_000` — headroom for init/project-load on top of the diagnostics wait budget.
- Per-server `budgetSignal = AbortSignal.timeout(waitBudget + grace)`, combined with the caller's signal via `AbortSignal.any`.
- An overrunning server rejects (`untilAborted` rejects even if the inner promise never settles), lands as a rejected `Promise.allSettled` entry, and is simply **skipped for this round** — the edit returns. Healthy servers are unaffected: their pipelines complete far inside the budget and results flow exactly as before.
- `pipelineBudgetMs` added to `GetDiagnosticsForFileOptions` as a test seam (same pattern as `workspaceReadyTimings`).

Note: `getOrCreateClient` already treats abort-during-init as transient (no 3-minute negative cache when `signal?.aborted`), so a server that was merely slow this round gets a fresh chance next round.

## Regression test

`packages/coding-agent/test/lsp/issue-4910-diagnostics-bounded.test.ts` drives the custom-linter branch (no real LSP process spawned):

- a linter whose `lint()` **never settles** + `pipelineBudgetMs: 50` → `getDiagnosticsForFile` still resolves promptly (returns `undefined`, hung server skipped);
- a healthy linter control under the same seam → normal `"OK"` result.

## Framing

The original issue is `needs-info` and was not reproduced by maintainers; this PR is a defensive fix for the only unbounded-wait holes on the exact code path the reporter's symptom implicates, so a wedged server/linter can no longer freeze the exclusive edit lane. Opened as **draft** for human review.