### PR TITLE
fix(mcp): cap minted tool names at 64 chars

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP tool names longer than 64 characters (e.g. `chrome-devtools-mcp`'s `performance_analyze_insight`) are now capped at 64 with a deterministic hash suffix, so strict validators like Meta/OpenAI Responses no longer reject every turn with HTTP 400 `name must be at most 64 characters` ([#9130](https://github.com/can1357/oh-my-pi/issues/9130)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -358,6 +358,29 @@ function sanitizeMCPToolNamePart(value: string, fallback: string): string {
 	return sanitized.length > 0 ? sanitized : fallback;
 }
 
+/**
+ * Longest tool name strict validators accept. OpenAI Responses/Completions and
+ * Meta Responses enforce `^[a-zA-Z0-9_-]{1,64}$`; names over 64 chars are
+ * rejected with HTTP 400 `name must be at most 64 characters` (#9130).
+ */
+const MAX_MCP_TOOL_NAME_LENGTH = 64;
+/** Length of the deterministic hash suffix appended when a minted name overflows. */
+const MCP_TOOL_NAME_HASH_LENGTH = 8;
+
+/**
+ * Cap a minted MCP tool name at {@link MAX_MCP_TOOL_NAME_LENGTH}. An overlong
+ * name keeps a readable prefix and gains a deterministic base-36 hash suffix of
+ * the full name, so distinct long names stay unique and the same name is stable
+ * across turns — the model must call the exact registry key, and the hash is
+ * seed-fixed so it never shifts between processes.
+ */
+function capMCPToolNameLength(name: string): string {
+	if (name.length <= MAX_MCP_TOOL_NAME_LENGTH) return name;
+	const hash = Bun.hash(name).toString(36).slice(0, MCP_TOOL_NAME_HASH_LENGTH);
+	const keep = MAX_MCP_TOOL_NAME_LENGTH - hash.length - 1;
+	return `${name.slice(0, keep)}_${hash}`;
+}
+
 export function createMCPToolName(serverName: string, toolName: string): string {
 	const sanitizedServerName = sanitizeMCPToolNamePart(serverName, "server");
 	const sanitizedToolName = sanitizeMCPToolNamePart(toolName, "tool");
@@ -370,7 +393,7 @@ export function createMCPToolName(serverName: string, toolName: string): string 
 		normalizedToolName = sanitizedToolName.slice(prefixWithUnderscore.length);
 	}
 
-	return `mcp__${sanitizedServerName}_${normalizedToolName}`;
+	return capMCPToolNameLength(`mcp__${sanitizedServerName}_${normalizedToolName}`);
 }
 
 export interface MCPToolOriginSource {

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import type { MCPReconnect } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import {
+	createMCPToolName,
 	DeferredMCPTool,
 	deduplicateMCPToolsByName,
 	isRetriableConnectionError,
@@ -67,6 +68,36 @@ describe("deduplicateMCPToolsByName", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createMCPToolName
+// ---------------------------------------------------------------------------
+
+describe("createMCPToolName", () => {
+	it("caps overlong names at 64 chars so strict validators accept them (#9130)", () => {
+		// chrome-devtools-mcp's performance_analyze_insight minted to 68 chars,
+		// which Meta/OpenAI Responses reject with HTTP 400 "name must be at most
+		// 64 characters".
+		const name = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");
+		expect(name.length).toBeLessThanOrEqual(64);
+		expect(name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+		// A readable prefix survives the cap.
+		expect(name.startsWith("mcp__chrome_devtools_mcp_")).toBe(true);
+	});
+
+	it("leaves names within the limit untouched", () => {
+		expect(createMCPToolName("puppeteer", "puppeteer_screenshot")).toBe("mcp__puppeteer_screenshot");
+	});
+
+	it("is deterministic and keeps distinct overlong names distinct", () => {
+		const a = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");
+		const b = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");
+		const c = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_something_else_entirely");
+		expect(a).toBe(b);
+		expect(a).not.toBe(c);
+		expect(c.length).toBeLessThanOrEqual(64);
 	});
 });
 


### PR DESCRIPTION
## Repro
Using `meta/muse-spark-1.2-contributor` (`api.meta.ai/v1/responses`, `openai-responses`) with `chrome-devtools-mcp` enabled, every turn failed with HTTP 400 ``name`` must be at most 64 characters, got 68. Invoking the actual mint function reproduces the offending name:

```
$ bun repro.ts   # imports createMCPToolName from packages/coding-agent/src/mcp/tool-bridge.ts
"mcp__chrome_devtools_mcp_chrome_devtools_performance_analyze_insight"
length: 68
exceeds OpenAI-family 64-char limit: true
```

This matches `body.tools[].name` in the reporter's HTTP-400 log byte-for-byte.

## Cause
`createMCPToolName` (`packages/coding-agent/src/mcp/tool-bridge.ts`) — the single mint point for both `MCPTool` and `DeferredMCPTool` — builds `mcp__<server>_<tool>` with no length cap. `chrome-devtools-mcp` sanitizes to `chrome_devtools_mcp`, and the tool `chrome_devtools_performance_analyze_insight` does not share that prefix, so nothing is stripped and the result is 68 chars. Strict validators enforce the OpenAI-family constraint `^[a-zA-Z0-9_-]{1,64}$` (Meta Responses here; OpenAI Responses/Completions reject the same), so the request never reaches the model.

## Fix
- Add `capMCPToolNameLength` in `tool-bridge.ts`: names over 64 chars keep a readable prefix and gain a deterministic base-36 `Bun.hash` suffix of the full name, so distinct long names stay unique and the same name is stable across turns (the model must call the exact registry key; the hash seed is fixed, so it never shifts between processes). Names within the limit are returned unchanged.
- Apply it to the single `createMCPToolName` return, covering every provider and both tool wrappers at the mint point.
- Add a regression test in `test/mcp-reconnect.test.ts` (cap to <=64, valid charset, prefix survival, determinism, distinct-name uniqueness).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/mcp-reconnect.test.ts` → 38 pass / 0 fail. Manual re-run of the repro after the fix yields a 64-char name matching `^[a-zA-Z0-9_-]{1,64}$`; exactly-64 and short names are unchanged. Fixes #9130