### PR TITLE
fix(ai): route Cursor Grok effort onto the sibling wire id

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 
 - Fixed Cursor Grok 4.5/4.6 (and Fast) effort selections being billed and served as the collapsed default Low sibling: `cursor-agent` now resolves `thinking.effortRouting` onto the outbound wire id (`cursor-grok-4.6-xhigh-fast` for xHigh Fast), matching Devin/Gemini CLI.
+- Fixed Cursor turns on non-reasoning models (e.g. Composer 2.5) throwing when a leftover SDK or global `reasoning` option was set; effort-to-wire-id routing now runs only when the model advertises reasoning.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Fixed Cursor Grok 4.5/4.6 (and Fast) effort selections being billed and served as the collapsed default Low sibling: `cursor-agent` now resolves `thinking.effortRouting` onto the outbound wire id (`cursor-grok-4.6-xhigh-fast` for xHigh Fast), matching Devin/Gemini CLI.
-- Fixed Cursor turns on non-reasoning models (e.g. Composer 2.5) throwing when a leftover SDK or global `reasoning` option was set; effort-to-wire-id routing now runs only when the model advertises reasoning.
+- Fixed Cursor turns throwing when a leftover SDK or global `reasoning` option was set on models without effort-tier siblings (Composer 2.5, discovered `cursor-grok-*` ids); effort-to-wire-id routing now runs only when `thinking.effortRouting` is present.
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Fixed Google Cloud Code Assist and Antigravity rejecting MCP tool schemas with unsupported annotations (`x-mcp-header`, `deprecated`, `readOnly`, `writeOnly`, `$comment`).
 - Fixed Cursor provider issues with native file edit streaming (`editToolCall`) and ensuring always-apply system rules are properly preserved.
 - Fixed Cursor HTTP/2 requests ignoring standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`).
+### Fixed
+
+- Fixed Cursor Grok 4.5/4.6 (and Fast) effort selections being billed and served as the collapsed default Low sibling: `cursor-agent` now resolves `thinking.effortRouting` onto the outbound wire id (`cursor-grok-4.6-xhigh-fast` for xHigh Fast), matching Devin/Gemini CLI.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed Cursor Grok 4.5/4.6 (and Fast) effort selections being billed and served as the collapsed default Low sibling: `cursor-agent` now resolves `thinking.effortRouting` onto the outbound wire id (`cursor-grok-4.6-xhigh-fast` for xHigh Fast), matching Devin/Gemini CLI.
+- Fixed Cursor turns on non-reasoning models (e.g. Composer 2.5) throwing when a leftover SDK or global `reasoning` option was set; effort-to-wire-id routing now runs only when the model advertises reasoning.
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.
@@ -17,10 +19,6 @@
 - Fixed Google Cloud Code Assist and Antigravity rejecting MCP tool schemas with unsupported annotations (`x-mcp-header`, `deprecated`, `readOnly`, `writeOnly`, `$comment`).
 - Fixed Cursor provider issues with native file edit streaming (`editToolCall`) and ensuring always-apply system rules are properly preserved.
 - Fixed Cursor HTTP/2 requests ignoring standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`).
-### Fixed
-
-- Fixed Cursor Grok 4.5/4.6 (and Fast) effort selections being billed and served as the collapsed default Low sibling: `cursor-agent` now resolves `thinking.effortRouting` onto the outbound wire id (`cursor-grok-4.6-xhigh-fast` for xHigh Fast), matching Devin/Gemini CLI.
-- Fixed Cursor turns on non-reasoning models (e.g. Composer 2.5) throwing when a leftover SDK or global `reasoning` option was set; effort-to-wire-id routing now runs only when the model advertises reasoning.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -330,6 +330,13 @@ export interface CursorOptions extends StreamOptions {
 	conversationId?: string;
 	execHandlers?: CursorExecHandlers;
 	onToolResult?: CursorToolResultHandler;
+	/**
+	 * Upstream wire model id override for collapsed effort-tier variants.
+	 * Serialized as `requestModelId ?? model.requestModelId ?? model.id`.
+	 * Cursor Grok Fast/standard lanes encode effort in the sibling id
+	 * (`cursor-grok-4.6-xhigh-fast`), not a separate thinking field.
+	 */
+	requestModelId?: string;
 }
 
 const CONNECT_END_STREAM_FLAG = 0b00000010;
@@ -5117,7 +5124,7 @@ export async function buildGrpcRequest(
 		turns,
 	});
 
-	const wireModelId = model.requestModelId ?? model.id;
+	const wireModelId = options?.requestModelId ?? model.requestModelId ?? model.id;
 	const cursorMaxMode = model.cursorMaxMode === true;
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: wireModelId,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -2307,10 +2307,16 @@ function mapOptionsForApi<TApi extends Api>(
 			});
 
 		case "cursor-agent": {
+			const cursorModel = model as Model<"cursor-agent">;
+			const effort =
+				options?.reasoning && !options.disableReasoning && !options.forceReasoningOff
+					? requireSupportedEffort(cursorModel, options.reasoning)
+					: undefined;
 			const execHandlers = options?.cursorExecHandlers ?? options?.execHandlers;
 			const onToolResult = options?.cursorOnToolResult ?? execHandlers?.onToolResult;
 			return castApi<"cursor-agent">({
 				...base,
+				requestModelId: resolveWireModelId(cursorModel, effort),
 				execHandlers,
 				onToolResult,
 			});

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -2308,10 +2308,15 @@ function mapOptionsForApi<TApi extends Api>(
 
 		case "cursor-agent": {
 			const cursorModel = model as Model<"cursor-agent">;
-			// Skip effort resolution when the model has no thinking surface; a leftover
-			// global/SDK `reasoning` option must not throw on Composer-class ids.
+			// Cursor effort lives in the sibling wire id (`thinking.effortRouting`).
+			// Discovery can mark unbundled `cursor-grok-*` rows reasoning:true and
+			// buildModel may bake a default effort ladder with no routing — a leftover
+			// global/SDK `reasoning` option must not trip requireSupportedEffort.
 			const effort =
-				options?.reasoning && cursorModel.reasoning && !options.disableReasoning && !options.forceReasoningOff
+				options?.reasoning &&
+				cursorModel.thinking?.effortRouting &&
+				!options.disableReasoning &&
+				!options.forceReasoningOff
 					? requireSupportedEffort(cursorModel, options.reasoning)
 					: undefined;
 			const execHandlers = options?.cursorExecHandlers ?? options?.execHandlers;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -2308,8 +2308,10 @@ function mapOptionsForApi<TApi extends Api>(
 
 		case "cursor-agent": {
 			const cursorModel = model as Model<"cursor-agent">;
+			// Skip effort resolution when the model has no thinking surface; a leftover
+			// global/SDK `reasoning` option must not throw on Composer-class ids.
 			const effort =
-				options?.reasoning && !options.disableReasoning && !options.forceReasoningOff
+				options?.reasoning && cursorModel.reasoning && !options.disableReasoning && !options.forceReasoningOff
 					? requireSupportedEffort(cursorModel, options.reasoning)
 					: undefined;
 			const execHandlers = options?.cursorExecHandlers ?? options?.execHandlers;

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -589,6 +589,33 @@ describe("Cursor request action encoding", () => {
 		expect(payload.requestedModel?.modelId).toBe("cursor-composer-2.5");
 	});
 
+	it("ignores a generic reasoning option on reasoning Cursor models without an effort surface", async () => {
+		// Discovery marks unbundled `cursor-grok-*` ids reasoning:true from the id
+		// heuristic. buildModel then bakes a default Grok effort ladder with no
+		// effortRouting, so requireSupportedEffort would reject leftover xhigh
+		// ("Supported efforts: minimal, low, medium, high") and never build the
+		// Run RPC. The request must still go out on the catalog id.
+		const discoveredGrok = buildModel({
+			id: "cursor-grok-9.9",
+			name: "Grok 9.9",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1,
+			maxTokens: 1,
+		});
+		const payload = await captureCursorPayloadFromStreamSimple(
+			{ messages: [{ role: "user", content: "continue", timestamp: 0 }] },
+			discoveredGrok,
+			{ reasoning: Effort.XHigh },
+		);
+		expect(payload.modelDetails?.modelId).toBe("cursor-grok-9.9");
+		expect(payload.requestedModel?.modelId).toBe("cursor-grok-9.9");
+	});
+
 	it("sends max-mode metadata with prior history when switching providers mid-conversation", async () => {
 		const payload = await captureCursorPayload(
 			{

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -575,6 +575,20 @@ describe("Cursor request action encoding", () => {
 		expect(xhighPayload.modelDetails?.displayModelId).toBe("cursor-grok-4.6-fast");
 	});
 
+	it("ignores a generic reasoning option on non-reasoning Cursor models", async () => {
+		// Composer 2.5 has no effort siblings. A leftover SDK/global `reasoning`
+		// option used to throw "does not support thinking" inside mapOptionsForApi
+		// and never built the Run RPC. The request must still go out on the
+		// catalog id.
+		const payload = await captureCursorPayloadFromStreamSimple(
+			{ messages: [{ role: "user", content: "continue", timestamp: 0 }] },
+			cursorModel,
+			{ reasoning: Effort.XHigh },
+		);
+		expect(payload.modelDetails?.modelId).toBe("cursor-composer-2.5");
+		expect(payload.requestedModel?.modelId).toBe("cursor-composer-2.5");
+	});
+
 	it("sends max-mode metadata with prior history when switching providers mid-conversation", async () => {
 		const payload = await captureCursorPayload(
 			{

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Effort } from "@oh-my-pi/pi-ai";
 import {
 	type BlockState,
 	buildCursorHistoryForTest,
@@ -12,6 +13,7 @@ import {
 	type ToolCallState,
 } from "@oh-my-pi/pi-ai/providers/cursor";
 import { streamCursor as lazyStreamCursor, setCursorProviderModule } from "@oh-my-pi/pi-ai/providers/register-builtins";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { AssistantMessage, Context, CursorExecHandlers, Model, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
@@ -91,6 +93,20 @@ function cursorAssistant(
 	};
 }
 
+function captureCursorRunRequest(
+	resolve: (payload: AgentRunRequest) => void,
+	reject: (error: Error) => void,
+): (payload: unknown) => never {
+	return payload => {
+		if (isAgentRunRequest(payload)) {
+			resolve(payload);
+		} else {
+			reject(new Error("Cursor payload was not an AgentRunRequest"));
+		}
+		throw new Error("stop after capturing Cursor payload");
+	};
+}
+
 function captureCursorPayload(
 	context: Context,
 	model: Model<"cursor-agent"> = cursorModel,
@@ -100,15 +116,24 @@ function captureCursorPayload(
 	streamCursor(model, context, {
 		apiKey: "test-token",
 		requestModelId: options?.requestModelId,
-		onPayload: payload => {
-			if (isAgentRunRequest(payload)) {
-				resolve(payload);
-			} else {
-				reject(new Error("Cursor payload was not an AgentRunRequest"));
-			}
-			throw new Error("stop after capturing Cursor payload");
-		},
+		onPayload: captureCursorRunRequest(resolve, reject),
 	});
+	return promise;
+}
+
+function captureCursorPayloadFromStreamSimple(
+	context: Context,
+	model: Model<"cursor-agent">,
+	options?: { reasoning?: Effort },
+): Promise<AgentRunRequest> {
+	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
+	void streamSimple(model, context, {
+		apiKey: "test-token",
+		reasoning: options?.reasoning,
+		onPayload: captureCursorRunRequest(resolve, reject),
+	})
+		.result()
+		.catch(reject);
 	return promise;
 }
 
@@ -521,13 +546,13 @@ describe("Cursor request action encoding", () => {
 			requestModelId: "cursor-grok-4.6-low-fast",
 			thinking: {
 				mode: "effort",
-				efforts: ["low", "medium", "high", "xhigh"],
+				efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
 				requiresEffort: true,
 				effortRouting: {
-					low: "cursor-grok-4.6-low-fast",
-					medium: "cursor-grok-4.6-medium-fast",
-					high: "cursor-grok-4.6-high-fast",
-					xhigh: "cursor-grok-4.6-xhigh-fast",
+					[Effort.Low]: "cursor-grok-4.6-low-fast",
+					[Effort.Medium]: "cursor-grok-4.6-medium-fast",
+					[Effort.High]: "cursor-grok-4.6-high-fast",
+					[Effort.XHigh]: "cursor-grok-4.6-xhigh-fast",
 				},
 			},
 		});
@@ -540,10 +565,10 @@ describe("Cursor request action encoding", () => {
 		expect(defaultPayload.requestedModel?.modelId).toBe("cursor-grok-4.6-low-fast");
 		expect(defaultPayload.modelDetails?.displayModelId).toBe("cursor-grok-4.6-fast");
 
-		const xhighPayload = await captureCursorPayload(
+		const xhighPayload = await captureCursorPayloadFromStreamSimple(
 			{ messages: [{ role: "user", content: "continue", timestamp: 0 }] },
 			grokFast,
-			{ requestModelId: "cursor-grok-4.6-xhigh-fast" },
+			{ reasoning: Effort.XHigh },
 		);
 		expect(xhighPayload.modelDetails?.modelId).toBe("cursor-grok-4.6-xhigh-fast");
 		expect(xhighPayload.requestedModel?.modelId).toBe("cursor-grok-4.6-xhigh-fast");

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { Effort } from "@oh-my-pi/pi-ai";
 import {
 	type BlockState,
 	buildCursorHistoryForTest,
@@ -36,6 +35,7 @@ import {
 	ReadSuccessSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
 import { create } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { logger } from "@oh-my-pi/pi-utils";
 
 afterEach(() => {

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -91,10 +91,15 @@ function cursorAssistant(
 	};
 }
 
-function captureCursorPayload(context: Context, model: Model<"cursor-agent"> = cursorModel): Promise<AgentRunRequest> {
+function captureCursorPayload(
+	context: Context,
+	model: Model<"cursor-agent"> = cursorModel,
+	options?: { requestModelId?: string },
+): Promise<AgentRunRequest> {
 	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
 	streamCursor(model, context, {
 		apiKey: "test-token",
+		requestModelId: options?.requestModelId,
 		onPayload: payload => {
 			if (isAgentRunRequest(payload)) {
 				resolve(payload);
@@ -499,6 +504,50 @@ describe("Cursor request action encoding", () => {
 		expect(payload.modelDetails?.maxMode).toBe(true);
 		expect(payload.requestedModel?.modelId).toBe("cursor-composer-2.5-max");
 		expect(payload.requestedModel?.maxMode).toBe(true);
+	});
+
+	it("sends the resolved Grok Fast sibling id, not the collapsed Low default", async () => {
+		const grokFast = buildModel({
+			id: "cursor-grok-4.6-fast",
+			name: "Grok 4.6 Fast",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1,
+			maxTokens: 1,
+			requestModelId: "cursor-grok-4.6-low-fast",
+			thinking: {
+				mode: "effort",
+				efforts: ["low", "medium", "high", "xhigh"],
+				requiresEffort: true,
+				effortRouting: {
+					low: "cursor-grok-4.6-low-fast",
+					medium: "cursor-grok-4.6-medium-fast",
+					high: "cursor-grok-4.6-high-fast",
+					xhigh: "cursor-grok-4.6-xhigh-fast",
+				},
+			},
+		});
+
+		const defaultPayload = await captureCursorPayload(
+			{ messages: [{ role: "user", content: "continue", timestamp: 0 }] },
+			grokFast,
+		);
+		expect(defaultPayload.modelDetails?.modelId).toBe("cursor-grok-4.6-low-fast");
+		expect(defaultPayload.requestedModel?.modelId).toBe("cursor-grok-4.6-low-fast");
+		expect(defaultPayload.modelDetails?.displayModelId).toBe("cursor-grok-4.6-fast");
+
+		const xhighPayload = await captureCursorPayload(
+			{ messages: [{ role: "user", content: "continue", timestamp: 0 }] },
+			grokFast,
+			{ requestModelId: "cursor-grok-4.6-xhigh-fast" },
+		);
+		expect(xhighPayload.modelDetails?.modelId).toBe("cursor-grok-4.6-xhigh-fast");
+		expect(xhighPayload.requestedModel?.modelId).toBe("cursor-grok-4.6-xhigh-fast");
+		expect(xhighPayload.modelDetails?.displayModelId).toBe("cursor-grok-4.6-fast");
 	});
 
 	it("sends max-mode metadata with prior history when switching providers mid-conversation", async () => {


### PR DESCRIPTION
Collapsed Cursor Grok 4.5/4.6 (and Fast) always sent the catalog default Low sibling (`cursor-grok-4.6-low-fast`) even when the picker was set to xHigh. Cursor has no separate effort field — the wire id *is* the effort — so those turns were billed and served as Low Fast. The dashboard mislabel is the actual routing.

`cursor-agent` now calls `resolveWireModelId` like Devin and Gemini CLI, and the Cursor client uses `options.requestModelId` on the Run RPC. A payload test covers Low default vs xHigh Fast (`cursor-grok-4.6-xhigh-fast`).

I reviewed the full diff; this is the same bug I saw on the Cursor usage chart (xHigh Fast showing up as Low Fast). I confirmed the collapsed catalog still defaults `requestModelId` to Low, and that `mapOptionsForApi` never remapped it before this change. I ran `bun test packages/ai/test/cursor-exec-handlers.test.ts --test-name-pattern "Grok Fast|max-mode metadata on model"` (2 pass). I have not yet run a live Cursor OAuth turn after this build — new Fast xHigh requests should land on `cursor-grok-4.6-xhigh-fast` after restart.

Past dashboard usage stays on Low Fast because that is what was requested.