### PR TITLE
fix(catalog): expose low/high/max efforts for opencode-go deepseek-v4-flash

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `opencode-go/deepseek-v4-flash` exposing the generic `minimal`/`low`/`medium`/`high`/`xhigh` thinking ladder instead of DeepSeek V4's real `low`/`high`/`max` tiers. The model is pinned to the Responses transport (the Go gateway serves it only at `/responses`), which the DeepSeek effort branch did not admit, so it fell through to the default ladder; the branch now covers the `openai-responses` transport like every other host ([#9134](https://github.com/can1357/oh-my-pi/issues/9134)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -391,9 +391,15 @@ function getModelDefinedEfforts<TApi extends Api>(
 		return QWEN38_TEMPLATE_REASONING_EFFORTS;
 	}
 	if (
-		(isOpenAICompatReasoningApi(spec.api) || (spec.api === "ollama-chat" && spec.provider === "ollama-cloud")) &&
+		(isOpenAICompatReasoningApi(spec.api) ||
+			spec.api === "openai-responses" ||
+			(spec.api === "ollama-chat" && spec.provider === "ollama-cloud")) &&
 		isDeepseekReasoningModel(spec)
 	) {
+		// The DeepSeek V4 effort ladder is a model property, not a transport one:
+		// `opencode-go/deepseek-v4-flash` is pinned to `openai-responses` (the Go
+		// gateway serves it only at /responses), yet carries the same wire-exact
+		// low/high/max scale — so the Responses transport is admitted here too.
 		// DeepSeek V4 (Flash and Pro) accepts the wire-exact low/high/max ladder
 		// on every first-party/aggregator host — the direct API, aggregators, and
 		// Ollama Cloud alike (medium/xhigh fold into high, max is a real wire

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -199042,11 +199042,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			},
 			"tokenizer": "deepseek-v3",

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -314,6 +314,30 @@ describe("model thinking derivation", () => {
 		expect(getSupportedEfforts(v32)).toEqual([Effort.High, Effort.Max]);
 	});
 
+	it("applies the DeepSeek effort contract to opencode-go openai-responses flash (issue #9134)", () => {
+		// opencode-go/deepseek-v4-flash is pinned to the Responses transport
+		// (the Go gateway serves it only at /responses), but the effort ladder
+		// is a model property: it must expose low/high/max like the pro sibling
+		// on chat completions, not the generic minimal..xhigh fallback.
+		const flash = createModel({
+			id: "deepseek-v4-flash",
+			api: "openai-responses",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+		const pro = createModel({
+			id: "deepseek-v4-pro",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+
+		expect(getSupportedEfforts(flash)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(flash.thinking?.effortMap).toBeUndefined();
+		expect(() => requireSupportedEffort(flash, Effort.Medium)).toThrow(/Supported efforts: low, high, max/);
+		expect(getSupportedEfforts(pro)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+	});
+
 	it("grants the low/high/max ladder to OpenRouter deepseek-v4-pro-0813 but not the undated route (issue #8517)", () => {
 		// OpenRouter's /models advertises reasoning.supported_efforts
 		// [low, high, max] for the dated SKU; the discovered ladder is baked


### PR DESCRIPTION
## Repro
`opencode-go/deepseek-v4-flash` ships the wrong reasoning-effort ladder in the bundled catalog: `[minimal, low, medium, high, xhigh]` instead of DeepSeek V4's real `[low, high, max]`, making the invalid `medium`/`minimal`/`xhigh` tiers selectable in the thinking picker. Running `buildModel` (the same derivation the generator uses) on the flash spec reproduces it:

```
opencode-go/deepseek-v4-flash (openai-responses): ["minimal","low","medium","high","xhigh"]
deepseek/deepseek-v4-flash  (openai-completions): ["low","high","max"]
```

## Cause
The DeepSeek V4 effort branch in `getModelDefinedEfforts` (`packages/catalog/src/model-thinking.ts`) is gated on `isOpenAICompatReasoningApi(spec.api)`, which admits only `openai-completions`/`openrouter`. `opencode-go/deepseek-v4-flash` has its API pinned to `openai-responses` via `OPENCODE_GO_API_ID_OVERRIDES` (`provider-models/openai-compat.ts` — the Go gateway serves this model only at `/zen/go/v1/responses`), so it misses the branch and falls through to the default `minimal..xhigh` ladder. It is the only DeepSeek V4 entry on `openai-responses`, so every other host was already correct.

## Fix
- `model-thinking.ts`: admit the `openai-responses` transport in the DeepSeek V4 effort-ladder gate — the ladder is a model property, not a transport one.
- `models.json`: rebake the single `opencode-go/deepseek-v4-flash` entry's `thinking` to `{ mode: "effort", efforts: [low, high, max] }` via the corrected derivation (no other entry changed).
- Added a regression test in `test/model-thinking.test.ts` asserting the Responses-transport flash exposes `low/high/max` and rejects `medium`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test` in `packages/catalog` — 628 pass / 0 fail (85 files), including the new `issue #9134` case. Manually confirmed against local source that `buildModel` now derives `[low, high, max]` for `opencode-go/deepseek-v4-flash` on the `openai-responses` transport, matching the `deepseek-v4-pro` sibling and the direct API.

Fixes #9134