### PR TITLE
fix(tui): prevent mixed-scope usage windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Status-line usage no longer combines quota windows scoped to different models or tiers ([#9138](https://github.com/can1357/oh-my-pi/issues/9138)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1266,7 +1266,12 @@ export class StatusLineComponent implements Component {
 		const identity = activeProvider
 			? session.modelRegistry?.authStorage?.getOAuthAccountIdentity(activeProvider, session.sessionId)
 			: undefined;
-		return this.#formatUsageContextKey(activeProvider, identity);
+		// Model id is part of the invalidation key (but not the account-scoped
+		// fireworks key): normalized usage now selects a model-scoped window group,
+		// so switching models must drop the previous model's cached scope instead
+		// of showing it for the rest of the TTL.
+		const activeModelId = session.state.model?.id ?? session.model?.id ?? "";
+		return `${this.#formatUsageContextKey(activeProvider, identity)}\0${activeModelId}`;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -42,7 +42,22 @@ import type {
 const JJ_REFRESH_TTL_MS = 5000;
 const WATCHER_FAILURE_POLL_TTL_MS = 5000;
 
-function normalizeCodexIdentityValue(value: unknown): string | undefined {
+/** A displayable limit after provider, account, model, and window filtering. */
+interface UsageWindowCandidate {
+	id?: string;
+	windowClass: "5h" | "7d" | "monthly";
+	fraction: number;
+	resetsAt?: number;
+}
+
+/** Limits sharing one model/tier scope, ranked as an indivisible display unit. */
+interface UsageScopeGroup {
+	priority: number;
+	tier?: string;
+	candidates: UsageWindowCandidate[];
+}
+
+function normalizeUsageScopeValue(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
 }
 
@@ -54,21 +69,21 @@ function normalizeCodexIdentityValue(value: unknown): string | undefined {
  */
 function codexReportMatchesExactIdentity(report: UsageReport, identity: OAuthAccountIdentity | undefined): boolean {
 	if (!identity) return false;
-	const accountId = normalizeCodexIdentityValue(identity.accountId);
-	const email = normalizeCodexIdentityValue(identity.email);
-	const projectId = normalizeCodexIdentityValue(identity.projectId);
-	const orgId = normalizeCodexIdentityValue(identity.orgId);
+	const accountId = normalizeUsageScopeValue(identity.accountId);
+	const email = normalizeUsageScopeValue(identity.email);
+	const projectId = normalizeUsageScopeValue(identity.projectId);
+	const orgId = normalizeUsageScopeValue(identity.orgId);
 	if (!accountId && !email && !projectId && !orgId) return false;
 
 	const metadata = report.metadata ?? {};
 	const reportAccountId =
-		normalizeCodexIdentityValue(metadata.accountId) ?? normalizeCodexIdentityValue(metadata.account_id);
+		normalizeUsageScopeValue(metadata.accountId) ?? normalizeUsageScopeValue(metadata.account_id);
 	const reportProjectId =
-		normalizeCodexIdentityValue(metadata.projectId) ?? normalizeCodexIdentityValue(metadata.project_id);
+		normalizeUsageScopeValue(metadata.projectId) ?? normalizeUsageScopeValue(metadata.project_id);
 	if (accountId && reportAccountId !== accountId) return false;
-	if (email && normalizeCodexIdentityValue(metadata.email) !== email) return false;
+	if (email && normalizeUsageScopeValue(metadata.email) !== email) return false;
 	if (projectId && reportProjectId !== projectId) return false;
-	if (orgId && normalizeCodexIdentityValue(metadata.orgId) !== orgId) return false;
+	if (orgId && normalizeUsageScopeValue(metadata.orgId) !== orgId) return false;
 	return true;
 }
 
@@ -1310,11 +1325,16 @@ export class StatusLineComponent implements Component {
 		}
 		this.#latestAppliedUsageRefreshSequence = sequence;
 		const activeProvider = session.state.model?.provider ?? session.model?.provider;
+		const activeModelId = session.state.model?.id ?? session.model?.id;
 		const activeIdentity =
 			activeProvider && session.modelRegistry?.authStorage
 				? session.modelRegistry.authStorage.getOAuthAccountIdentity(activeProvider, session.sessionId)
 				: undefined;
-		const normalized = this.#normalizeUsageReports(reports, activeProvider, activeIdentity);
+		const normalized = this.#normalizeUsageReports(reports, {
+			provider: activeProvider,
+			modelId: activeModelId,
+			identity: activeIdentity,
+		});
 		const resetSnapshot =
 			activeProvider === "openai-codex" ? this.#normalizeCodexResetSnapshot(reports, activeIdentity) : null;
 		const usageChanged = this.#cachedUsage !== normalized;
@@ -1425,8 +1445,7 @@ export class StatusLineComponent implements Component {
 
 	#normalizeUsageReports(
 		reports: unknown,
-		activeProvider?: string,
-		activeIdentity?: OAuthAccountIdentity,
+		context: { provider?: string; modelId?: string; identity?: OAuthAccountIdentity },
 	): {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
@@ -1434,14 +1453,97 @@ export class StatusLineComponent implements Component {
 		monthly?: { percent: number; resetHours?: number };
 	} | null {
 		if (!Array.isArray(reports)) return null;
+		const now = Date.now();
+		const activeModelId = normalizeUsageScopeValue(context.modelId);
+		const scopeGroups = new Map<string, UsageScopeGroup>();
+		for (const report of reports) {
+			if (!report || typeof report !== "object") continue;
+			const provider = "provider" in report ? report.provider : undefined;
+			if (context.provider && provider !== context.provider) continue;
+			const limits = "limits" in report ? report.limits : undefined;
+			if (!Array.isArray(limits)) continue;
+			// fetchUsageReports supplies normalized rows; the guards above protect
+			// the unknown session boundary before the account matcher reads metadata.
+			const usageReport = report as UsageReport;
+			for (const limit of limits) {
+				if (
+					!limit ||
+					typeof limit !== "object" ||
+					!("scope" in limit) ||
+					!limit.scope ||
+					typeof limit.scope !== "object" ||
+					!("amount" in limit) ||
+					!limit.amount ||
+					typeof limit.amount !== "object"
+				) {
+					continue;
+				}
+				const scope = limit.scope;
+				const amount = limit.amount;
+				// The matcher only reads scope identity fields, whose object boundary
+				// is validated above; other required UsageLimit fields are irrelevant.
+				const usageLimit = limit as UsageLimit;
+				if (context.identity && !limitMatchesActiveAccount(usageReport, usageLimit, context.identity)) continue;
+
+				const fraction = "usedFraction" in amount ? amount.usedFraction : undefined;
+				if (typeof fraction !== "number") continue;
+				const window =
+					"window" in limit && limit.window && typeof limit.window === "object" ? limit.window : undefined;
+				const windowId = "windowId" in scope ? scope.windowId : undefined;
+				const durationValue = window && "durationMs" in window ? window.durationMs : undefined;
+				const durationMs = typeof durationValue === "number" ? durationValue : undefined;
+				const subscriptionWindow =
+					windowId === "5h" || windowId === "7d"
+						? windowId
+						: durationMs !== undefined && Math.abs(durationMs - 5 * 3_600_000) <= 60_000
+							? "5h"
+							: durationMs !== undefined && Math.abs(durationMs - 7 * 86_400_000) <= 60_000
+								? "7d"
+								: undefined;
+				const windowClass =
+					subscriptionWindow ??
+					((context.provider === "cursor" || context.provider === "opencode-go") &&
+					(windowId === "monthly" || windowId === "30d")
+						? "monthly"
+						: undefined);
+				if (!windowClass) continue;
+
+				const modelId = normalizeUsageScopeValue("modelId" in scope ? scope.modelId : undefined);
+				if (modelId && modelId !== activeModelId) continue;
+				const rawTier = "tier" in scope ? scope.tier : undefined;
+				const tier = typeof rawTier === "string" && rawTier.trim() ? rawTier.trim() : undefined;
+				const normalizedTier = normalizeUsageScopeValue(tier);
+				const scopeKey = `${modelId ?? ""}\0${normalizedTier ?? ""}`;
+				// Exact-model groups outrank provider-wide groups; within either
+				// specificity, untiered limits preserve the historical preference.
+				const priority = modelId ? (normalizedTier ? 1 : 0) : normalizedTier ? 3 : 2;
+				const id = "id" in limit && typeof limit.id === "string" ? limit.id : undefined;
+				const resetValue = window && "resetsAt" in window ? window.resetsAt : undefined;
+				const displayCandidate: UsageWindowCandidate = {
+					id,
+					windowClass,
+					fraction,
+					resetsAt: typeof resetValue === "number" ? resetValue : undefined,
+				};
+				const group = scopeGroups.get(scopeKey);
+				if (group) {
+					group.candidates.push(displayCandidate);
+				} else {
+					scopeGroups.set(scopeKey, { priority, tier, candidates: [displayCandidate] });
+				}
+			}
+		}
+
+		let selectedGroup: UsageScopeGroup | undefined;
+		for (const group of scopeGroups.values()) {
+			if (!selectedGroup || group.priority < selectedGroup.priority) selectedGroup = group;
+		}
+		if (!selectedGroup) return null;
+
 		let fiveHour: { percent: number; resetMinutes?: number } | undefined;
 		let sevenDay: { percent: number; resetHours?: number } | undefined;
 		let monthly: { percent: number; resetHours?: number } | undefined;
-		let fiveHourTier: string | undefined;
-		let sevenDayTier: string | undefined;
-		let monthlyTier: string | undefined;
 		let monthlyPriority = Number.POSITIVE_INFINITY;
-		const now = Date.now();
 		const cursorMonthlyPriority = (limitId: unknown): number => {
 			// When /auth/usage and /api/usage-summary are merged, prefer the personal
 			// dashboard rails over legacy per-model request fractions.
@@ -1450,92 +1552,41 @@ export class StatusLineComponent implements Component {
 			if (typeof limitId === "string" && limitId.startsWith("cursor:usd:individual-")) return 2;
 			return 3;
 		};
-		for (const report of reports) {
-			if (!report || typeof report !== "object") continue;
-			const provider = (report as { provider?: unknown }).provider;
-			if (activeProvider && provider !== activeProvider) continue;
-			const limits = (report as { limits?: unknown }).limits;
-			if (!Array.isArray(limits)) continue;
-			const usageReport = report as UsageReport;
-			for (const limit of limits) {
-				if (!limit || typeof limit !== "object") continue;
-				if (activeIdentity && !limitMatchesActiveAccount(usageReport, limit as UsageLimit, activeIdentity)) {
-					continue;
-				}
-				const l = limit as {
-					id?: string;
-					scope?: { windowId?: string; tier?: string };
-					window?: { resetsAt?: number; durationMs?: number };
-					amount?: { usedFraction?: number };
+		for (const candidate of selectedGroup.candidates) {
+			if (candidate.windowClass === "5h" && !fiveHour) {
+				fiveHour = {
+					percent: candidate.fraction * 100,
+					resetMinutes:
+						typeof candidate.resetsAt === "number"
+							? Math.max(0, Math.round((candidate.resetsAt - now) / 60_000))
+							: undefined,
 				};
-				const fraction = l.amount?.usedFraction;
-				if (typeof fraction !== "number") continue;
-				const windowId = l.scope?.windowId;
-				const tier = l.scope?.tier;
-				const resetsAt = l.window?.resetsAt;
-				// Canonical window ids win. Fall back to the reported span (same
-				// tolerance as the 5h priority-boost check) so providers that emit
-				// non-canonical ids, and cache rows written before a provider was
-				// canonicalized, still map onto the two subscription windows.
-				const durationMs = l.window?.durationMs;
-				const windowClass =
-					windowId === "5h" || windowId === "7d"
-						? windowId
-						: durationMs !== undefined && Math.abs(durationMs - 5 * 3_600_000) <= 60_000
-							? "5h"
-							: durationMs !== undefined && Math.abs(durationMs - 7 * 86_400_000) <= 60_000
-								? "7d"
-								: undefined;
-				// Accept tiered limits, but prefer untiered (backward compat with Anthropic).
-				// An untiered limit always replaces a tiered one; among same-tieredness, first wins.
-				if (windowClass === "5h" && (!fiveHour || (fiveHourTier !== undefined && !tier))) {
-					fiveHour = {
-						percent: fraction * 100,
-						resetMinutes:
-							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 60_000)) : undefined,
-					};
-					fiveHourTier = tier || undefined;
-				}
-				if (windowClass === "7d" && (!sevenDay || (sevenDayTier !== undefined && !tier))) {
-					sevenDay = {
-						percent: fraction * 100,
+			}
+			if (candidate.windowClass === "7d" && !sevenDay) {
+				sevenDay = {
+					percent: candidate.fraction * 100,
+					resetHours:
+						typeof candidate.resetsAt === "number"
+							? Math.max(0, Math.round((candidate.resetsAt - now) / 3_600_000))
+							: undefined,
+				};
+			}
+			if (candidate.windowClass === "monthly") {
+				const priority = cursorMonthlyPriority(candidate.id);
+				if (priority < monthlyPriority) {
+					monthly = {
+						percent: candidate.fraction * 100,
 						resetHours:
-							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 3_600_000)) : undefined,
+							typeof candidate.resetsAt === "number"
+								? Math.max(0, Math.round((candidate.resetsAt - now) / 3_600_000))
+								: undefined,
 					};
-					sevenDayTier = tier || undefined;
-				}
-				// Monthly rendering is gated to providers with a single monthly
-				// bucket (Cursor's priority selector picks its personal rail;
-				// OpenCode Go emits exactly one). Copilot also emits monthly
-				// windows, but its multi-bucket shape needs a dedicated selector
-				// before we surface `mo N%` for it.
-				if (
-					(activeProvider === "cursor" || activeProvider === "opencode-go") &&
-					(windowId === "monthly" || windowId === "30d")
-				) {
-					const priority = cursorMonthlyPriority(l.id);
-					const shouldReplace =
-						!monthly ||
-						priority < monthlyPriority ||
-						(priority === monthlyPriority && monthlyTier !== undefined && !tier);
-					if (shouldReplace) {
-						monthly = {
-							percent: fraction * 100,
-							resetHours:
-								typeof resetsAt === "number"
-									? Math.max(0, Math.round((resetsAt - now) / 3_600_000))
-									: undefined,
-						};
-						monthlyTier = tier || undefined;
-						monthlyPriority = priority;
-					}
+					monthlyPriority = priority;
 				}
 			}
 		}
 		if (!fiveHour && !sevenDay && !monthly) return null;
-		// Single compact label; prefer the five-hour tier if displayed windows ever disagree.
-		const effectiveTier = fiveHourTier ?? sevenDayTier ?? monthlyTier;
-		return { tier: effectiveTier, fiveHour, sevenDay, monthly };
+		return { tier: selectedGroup.tier, fiveHour, sevenDay, monthly };
 	}
 
 	/**

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -284,6 +284,77 @@ describe("usage status-line segment", () => {
 		expect(refreshed).toContain("24%");
 	});
 
+	it("invalidates cached usage when the active model changes within a provider", async () => {
+		const model = { id: "gpt-5.6-sol", contextWindow: 1000, provider: "openai-codex" };
+		const reports = [
+			{
+				provider: "openai-codex",
+				metadata: { accountId: "active-account" },
+				limits: [
+					{ scope: { windowId: "7d" }, amount: { usedFraction: 0.08 } },
+					{
+						scope: { windowId: "5h", tier: "spark", modelId: "GPT-5.3-Codex-Spark" },
+						amount: { usedFraction: 0.42 },
+					},
+					{
+						scope: { windowId: "7d", tier: "spark", modelId: "GPT-5.3-Codex-Spark" },
+						amount: { usedFraction: 0.11 },
+					},
+				],
+			},
+		];
+		const session = {
+			state: { messages: [], model },
+			model,
+			sessionManager: {
+				getUsageStatistics: () => ({
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					orchestrationInput: 0,
+					orchestrationOutput: 0,
+					orchestrationCacheRead: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
+			},
+			fetchUsageReports: async () => reports,
+			modelRegistry: {
+				authStorage: {
+					getOAuthAccountIdentity: (requestedProvider: string) =>
+						requestedProvider === "openai-codex" ? { accountId: "active-account" } : undefined,
+				},
+			},
+			getAsyncJobSnapshot: () => ({ running: [] }),
+			getContextUsage: () => undefined,
+		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+		const component = new StatusLineComponent(session);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["usage"],
+			sessionAccent: false,
+		});
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const solContent = stripVTControlCharacters(component.getTopBorder(200).content);
+		expect(solContent).not.toContain("spark");
+		expect(solContent).not.toContain("5h");
+		expect(solContent).toContain("8%");
+
+		model.id = "gpt-5.3-codex-spark";
+		const immediate = stripVTControlCharacters(component.getTopBorder(200).content);
+		expect(immediate).not.toContain("8%");
+		await flushUsageRefresh();
+		const sparkContent = stripVTControlCharacters(component.getTopBorder(200).content);
+		expect(sparkContent).toContain("spark");
+		expect(sparkContent).toContain("5h");
+		expect(sparkContent).toContain("42%");
+	});
+
 	it("keeps active-provider rate-limit header reports with account metadata", async () => {
 		const component = makeComponent(
 			[

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -18,11 +18,15 @@ afterAll(() => {
 
 function makeComponent(
 	reports: unknown,
-	options: { provider?: string; activeIdentity?: { accountId?: string; email?: string; projectId?: string } } = {},
+	options: {
+		provider?: string;
+		modelId?: string;
+		activeIdentity?: { accountId?: string; email?: string; projectId?: string };
+	} = {},
 ): StatusLineComponent {
 	const component = new StatusLineComponent({
-		state: { messages: [], model: { contextWindow: 1000, provider: options.provider } },
-		model: { contextWindow: 1000, provider: options.provider },
+		state: { messages: [], model: { id: options.modelId, contextWindow: 1000, provider: options.provider } },
+		model: { id: options.modelId, contextWindow: 1000, provider: options.provider },
 		sessionManager: {
 			getUsageStatistics: () => ({
 				input: 0,
@@ -110,7 +114,49 @@ describe("usage status-line segment", () => {
 		expect(content).toContain("8%");
 	});
 
-	it("prefers untiered windows and labels the displayed tiered window", async () => {
+	it("selects one coherent scope for the active model", async () => {
+		const reports = [
+			{
+				provider: "openai-codex",
+				limits: [
+					{
+						scope: { windowId: "5h", tier: "spark", modelId: "GPT-5.3-Codex-Spark" },
+						amount: { usedFraction: 0 },
+					},
+					{ scope: { windowId: "7d" }, amount: { usedFraction: 0.08 } },
+					{
+						scope: { windowId: "7d", tier: "spark", modelId: "GPT-5.3-Codex-Spark" },
+						amount: { usedFraction: 0 },
+					},
+				],
+			},
+		];
+		const component = makeComponent(reports, { provider: "openai-codex", modelId: "gpt-5.6-sol" });
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).not.toContain("spark");
+		expect(content).not.toContain("5h");
+		expect(content).toContain("7d");
+		expect(content).toContain("8%");
+
+		const sparkComponent = makeComponent(reports, {
+			provider: "openai-codex",
+			modelId: "gpt-5.3-codex-spark",
+		});
+		sparkComponent.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const sparkContent = stripVTControlCharacters(sparkComponent.getTopBorder(200).content);
+
+		expect(sparkContent).toContain("spark");
+		expect(sparkContent).toContain("5h");
+		expect(sparkContent).toContain("7d");
+		expect(sparkContent).not.toContain("8%");
+	});
+
+	it("keeps windows within the preferred untiered scope", async () => {
 		const component = makeComponent([
 			{
 				limits: [
@@ -125,12 +171,12 @@ describe("usage status-line segment", () => {
 		await flushUsageRefresh();
 		const content = stripVTControlCharacters(component.getTopBorder(200).content);
 
-		expect(content).toContain("prolite");
+		expect(content).not.toContain("prolite");
 		expect(content).not.toContain("stale");
 		expect(content).toContain("5h");
 		expect(content).toContain("24%");
-		expect(content).toContain("7d");
-		expect(content).toContain("8%");
+		expect(content).not.toContain("7d");
+		expect(content).not.toContain("8%");
 	});
 
 	it("scopes fetched usage reports to the active provider and account", async () => {


### PR DESCRIPTION
## Repro
With `openai-codex/gpt-5.6-sol` active, feed the status-line usage segment an untiered `7d` limit plus Spark-scoped `5h` and `7d` limits, then run `bun test packages/coding-agent/test/status-line-usage.test.ts`; before the fix the focused case renders `spark · 5h 0% · 7d 8%`.

## Cause
`StatusLineComponent.#normalizeUsageReports()` in `packages/coding-agent/src/modes/components/status-line/component.ts` selected each window independently, preferred untiered candidates per window, and ignored `scope.modelId`, so the final tier label and windows could come from different model/tier scopes.

## Fix
- Pass the active model id into usage normalization and discard limits scoped to another model.
- Group eligible limits by model and tier, then select one group before selecting its windows.
- Cover non-Spark, Spark, and untiered-versus-tiered scope selection in the status-line test.
- Document the user-visible correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/status-line-usage.test.ts` passes with 21 tests and 93 assertions; `bun check` passes across all packages.

Fixes #9138