### PR TITLE
test(tui): make resize settle timing deterministic

### DIFF
--- a/packages/tui/test/issue-2088-repro.test.ts
+++ b/packages/tui/test/issue-2088-repro.test.ts
@@ -732,25 +732,27 @@ describe("issue #2088: tmux pane-resize race produces viewport flash", () => {
 			const term = new VirtualTerminal(40, 6, 1000);
 			const lines = Array.from({ length: 12 }, (_value, index) => `line-${index}`);
 			const component = new MutableLinesComponent(lines);
-			const tui = new TUI(term);
+			const scheduler = new ManualRenderScheduler();
+			const tui = new TUI(term, undefined, { renderScheduler: scheduler });
 			tui.addChild(component);
 
 			try {
 				tui.start();
-				await settle(term);
+				await scheduler.advanceBy(0, term);
+				const baselineRedraws = tui.fullRedraws;
 				const writes = captureWrites(term);
 
 				term.resize(80, 6);
-				await Bun.sleep(10);
+				await scheduler.advanceBy(10, term);
 				lines[11] = "line-11 updated during resize";
 				component.setLines(lines);
 				tui.requestRender();
 
-				await Bun.sleep(20);
+				await scheduler.advanceBy(20, term);
 				expect(writes).toHaveLength(0);
 
-				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
-				await settle(term);
+				await scheduler.advanceBy(20, term);
+				expect(tui.fullRedraws - baselineRedraws).toBe(1);
 				expect(visible(term).at(-1)).toBe("line-11 updated during resize");
 			} finally {
 				tui.stop();


### PR DESCRIPTION
## Problem

The issue #2088 regression test sleeps inside a 50 ms settle window. On a loaded runner, the sleep can resume after the deadline and observe the correct settled paint as if it were an early write.

## Change

Use the existing manual render scheduler to drive the same contract at exact times:

- no terminal writes at 30 ms
- one full redraw at the 50 ms deadline
- content queued during settlement is visible

Production TUI code is unchanged.

## Verification

Pinning the original test and 16 CPU workers to one core reproduced `expected length 0, received length 1`. The scheduler-driven version passed 200 stressed runs on the fork. After rebasing onto current upstream `main`, the full issue #2088 file passed: 55 tests and 679 assertions.