### PR TITLE
test(coding-agent): await overflow maintenance lifecycle

### DIFF
--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -1200,7 +1200,7 @@ describe("AgentSession handoff", () => {
 
 		session.agent.emitExternalEvent({ type: "message_end", message: overflowAssistant });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [overflowAssistant] });
-		await waitFor(() => events.filter(event => event.type === "auto_compaction_end").length === 1);
+		await session.waitForIdle();
 
 		expect(handoffSpy).not.toHaveBeenCalled();
 		const startEvents = events.filter(event => event.type === "auto_compaction_start");
@@ -1522,9 +1522,7 @@ describe("AgentSession handoff", () => {
 
 		session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
-		await waitFor(() =>
-			events.some(event => event.type === "auto_compaction_end" && event.action === "context-full"),
-		);
+		await session.waitForIdle();
 
 		expect(generateHandoffSpy).toHaveBeenCalledTimes(1);
 		const endEvents = events.filter(event => event.type === "auto_compaction_end");


### PR DESCRIPTION
The runtime/session bucket can starve handoff tests past their one-second polling deadlines even when maintenance is healthy. These tests now wait on `AgentSession.waitForIdle()`, which drains the tracked `agent_end` maintenance task, before checking the emitted lifecycle events.

The original overflow test failed 4 of 200 stressed runs before the change and passed 200 of 200 afterward. After rebasing onto current upstream `main`, its newer no-document fallback test reproduced the same timeout while other focused suites ran concurrently. Applying the same lifecycle barrier there passed 20 full-file repetitions: 700 tests and 2,580 assertions.

No production code changes.