### PR TITLE
fix(coding-agent): scope model config to SDK agent directory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed SDK sessions with a custom agent directory inheriting process-global model overrides instead of loading that directory's own `models.yml`.
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -256,6 +256,8 @@ export class ModelRegistry {
 			ignoreLocalModelConfig?: boolean;
 			/** Settings source for availability and context-window policies. */
 			settings?: Settings;
+			/** Model discovery cache database. Defaults beside an explicit models config. */
+			cacheDbPath?: string;
 			fetch?: FetchImpl;
 		},
 	) {
@@ -267,7 +269,8 @@ export class ModelRegistry {
 				? () => Promise.reject(new Error("network disabled in model-registry runtime test"))
 				: wrapFetchForExtraCa(fetch));
 		this.#modelsConfigFile = ModelsConfigFile.relocate(modelsPath ?? path.join(getAgentDir(), "models.yml"));
-		this.#cacheDbPath = modelsPath ? path.join(path.dirname(modelsPath), "models.db") : undefined;
+		this.#cacheDbPath =
+			options?.cacheDbPath ?? (modelsPath ? path.join(path.dirname(modelsPath), "models.db") : undefined);
 		// Set up fallback resolver for custom provider API keys
 		this.authStorage.setFallbackResolver(provider => {
 			const keyConfig = this.#customProviderApiKeys.get(provider);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import {
 	Agent,
 	type AgentEvent,
@@ -28,7 +29,17 @@ import {
 } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { FALLBACK_DIALECT, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { $env, $flag, getAgentDir, getProjectDir, logger, postmortem, prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import {
+	$env,
+	$flag,
+	getAgentDir,
+	getModelDbPath,
+	getProjectDir,
+	logger,
+	postmortem,
+	prompt,
+	Snowflake,
+} from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import {
 	discoverAdvisorConfigs,
@@ -1259,9 +1270,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		options.modelRegistry ??
 		new ModelRegistry(
 			options.authStorage ?? (await logger.time("discoverModels", discoverAuthStorage, agentDir)),
-			undefined,
+			path.join(agentDir, "models.yml"),
 			{
 				settings,
+				cacheDbPath: getModelDbPath(agentDir),
 			},
 		);
 	// Track whether we internally created the authStorage so we can close it

--- a/packages/coding-agent/test/model-registry-cache-headers.test.ts
+++ b/packages/coding-agent/test/model-registry-cache-headers.test.ts
@@ -52,6 +52,41 @@ describe("startup model cache header restoration (#5780)", () => {
 		}
 	});
 
+	test("uses an explicit cache path independently of the models config directory", async () => {
+		const modelsPath = path.join(tempDir, "config", "models.json");
+		const cacheDbPath = path.join(tempDir, "data", "models.db");
+		await fs.promises.mkdir(path.dirname(cacheDbPath), { recursive: true });
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					probe: {
+						baseUrl: "https://example.invalid/v1/",
+						api: "openai-completions",
+						authHeader: true,
+						apiKey: "test-key",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+
+		const primedRegistry = new ModelRegistry(authStorage, modelsPath, {
+			cacheDbPath,
+			fetch: async () => Response.json({ data: [{ id: "probe-model" }] }),
+		});
+		await primedRegistry.refreshProvider("probe", "online");
+
+		expect(await Bun.file(cacheDbPath).exists()).toBe(true);
+		expect(await Bun.file(path.join(path.dirname(modelsPath), "models.db")).exists()).toBe(false);
+
+		const restartedRegistry = new ModelRegistry(authStorage, modelsPath, {
+			cacheDbPath,
+			fetch: () => Promise.reject(new Error("offline")),
+		});
+		expect(restartedRegistry.find("probe", "probe-model")).toBeDefined();
+	});
+
 	test("cached configured-discovery models regain derived auth headers on registry startup", async () => {
 		const modelsPath = path.join(tempDir, "models.json");
 		fs.writeFileSync(

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1063,6 +1063,50 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("loads model overrides from the supplied agent directory", async () => {
+		await Bun.write(
+			path.join(tempDir, "models.yml"),
+			[
+				"providers:",
+				"  openai-codex:",
+				"    modelOverrides:",
+				"      gpt-5.6-sol:",
+				"        contextWindow: 123456",
+			].join("\n"),
+		);
+		const authStorage = createInMemoryAuthStorage();
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey("openai-codex", "codex-oauth-token");
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			settings: Settings.isolated({ extendedContext: true }),
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+			modelPattern: "openai-codex/gpt-5.6-sol",
+		});
+
+		try {
+			expect(session.model?.provider).toBe("openai-codex");
+			expect(session.model?.id).toBe("gpt-5.6-sol");
+			expect(session.model?.contextWindow).toBe(123_456);
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	test("restores role model max selector from extension provider after startup resume", async () => {
 		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!defaultModel) {


### PR DESCRIPTION
`createAgentSession({ agentDir })` scopes settings and authentication to that directory, but its default model registry still reads `models.yml` from the process-global agent directory. An embedded SDK session can therefore inherit model overrides from its host.

Construct the default registry from `<agentDir>/models.yml`. A regression test stores an override only in the supplied directory and verifies that the session resolves it.

## Reproduction

With a distinctive model override in `PI_CODING_AGENT_DIR`, the affected context-cap test receives the global value (258,000) instead of its expected caller-scoped value (272,000). Pointing `PI_CODING_AGENT_DIR` to an empty directory passes, isolating the leaked input.

## Verification

After rebasing onto current upstream `main`, `sdk-model-selection.test.ts` passed all 31 tests and 100 assertions under an isolated `PI_CODING_AGENT_DIR`.