### PR TITLE
feat(tui): add reserved right-sidebar extension widgets

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -566,7 +566,42 @@ Current no-op methods in this controller:
 - `setFooter`
 - `setHeader`
 
-`setEditorComponent` is wired to the live editor (`ctx.setEditorComponent(factory)`). `setWidget` renders real widget components above or below the editor via `setHookWidget(...)` (`placement: "aboveEditor" | "belowEditor"`; string-array content capped at 10 lines).
+`setEditorComponent` is wired to the live editor (`ctx.setEditorComponent(factory)`). `setWidget` renders real widget components above or below the editor via `setHookWidget(...)` (`placement: "aboveEditor" | "belowEditor"`; string-array content capped at 10 lines), or in the reserved column described below.
+
+### Reserved right sidebar
+
+Use `placement: "rightSidebar"` to reserve terminal columns for observational UI. The complete copyable [`right-sidebar.ts`](../packages/coding-agent/examples/extensions/right-sidebar.ts) example mounts a component factory with this call:
+
+```ts
+ctx.ui.setWidget(
+  "right-sidebar-example",
+  (tui) => {
+    sidebar = new SidebarExample(tui);
+    render(ctx);
+    return sidebar;
+  },
+  {
+    placement: "rightSidebar",
+    width: 44,
+    minWidth: 28,
+    minMainWidth: 64,
+  },
+);
+```
+
+The geometry fields have these semantics:
+
+- `width` is the preferred reserved-column width.
+- `minWidth` is the smallest visible reserved-column width.
+- `minMainWidth` is the smallest width retained for the transcript, editor, and other main content.
+- `width` and `minWidth` both include the one-column separator, so the component receives `sidebar width - 1` in `render(width)`.
+- The sidebar is hidden when the terminal is narrower than `minMainWidth + minWidth`; otherwise it shrinks as needed from `width` to `minWidth`. With the values above, 120 columns produce 76 main columns plus a 44-column sidebar (43 content columns), 91 columns hide it, and 92 columns produce 64 main columns plus a 28-column sidebar (27 content columns).
+
+Right-sidebar widgets are display-only: they cannot receive focus or input, so typing and commands continue to target the editor. String-array widgets keep at most 10 content lines and then show a truncation notice; prefer a component factory for more than 10 lines. The extension owns the widget lifecycle—remove it explicitly with `ctx.ui.setWidget("right-sidebar-example", undefined)`, including during `session_shutdown`.
+
+Print, headless, and subagent paths do not render the sidebar (`ctx.hasUI` is `false` and UI methods are inert). RPC mode can forward string-array widgets to a host, but component factories do not emit RPC frames.
+
+This reserved column is not a modal `ctx.ui.custom()` overlay: modal overlays composite over the viewport and can temporarily cover the sidebar, while the sidebar participates in the base layout and reflows main content. It is also distinct from PR [#4603](https://github.com/can1357/oh-my-pi/pull/4603)'s `rightEditor` tradeoff, which placed widgets opportunistically in unused whitespace rather than reserving a column.
 
 ### RPC mode (`rpc-mode.ts`)
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -612,6 +612,24 @@ Example:
 }
 ```
 
+`setWidget` forwards string-array sidebar content and geometry:
+
+```json
+{
+  "type": "extension_ui_request",
+  "id": "123",
+  "method": "setWidget",
+  "widgetKey": "quota",
+  "widgetLines": ["5 hour 42%"],
+  "widgetPlacement": "rightSidebar",
+  "widgetWidth": 44,
+  "widgetMinWidth": 28,
+  "widgetMinMainWidth": 64
+}
+```
+
+RPC hosts may ignore unsupported widget placements. Component-factory widgets are process-local UI and emit no RPC frame; only string-array widgets are forwarded.
+
 ### Inbound response
 
 `RpcExtensionUIResponse` (`type: "extension_ui_response"`):

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed prompt guidance and descriptions for Task tools and SSH usage.
 - ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+- Added `rightSidebar` extension widget placement with preferred, minimum, and main-content width geometry plus RPC forwarding ([#8126](https://github.com/can1357/oh-my-pi/issues/8126)). This is separate from PR [#4603](https://github.com/can1357/oh-my-pi/pull/4603)'s `rightEditor` whitespace-widget tradeoff: reserved sidebars reflow the main content.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -43,6 +43,7 @@ cp permission-gate.ts ~/.omp/agent/extensions/
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors      |
 | `thinking-note.ts` | Adds display-only supplemental UI below assistant thinking blocks              |
 | `snake.ts`       | Snake game with custom UI, keyboard handling, and session persistence          |
+| `right-sidebar.ts` | Responsive reserved column with a `/right-sidebar` visibility toggle                    |
 
 ### Git Integration
 

--- a/packages/coding-agent/examples/extensions/right-sidebar.ts
+++ b/packages/coding-agent/examples/extensions/right-sidebar.ts
@@ -31,7 +31,7 @@ export default function rightSidebarExample(pi: ExtensionAPI): void {
 	function mount(ctx: ExtensionContext): void {
 		ctx.ui.setWidget(
 			"right-sidebar-example",
-			(tui) => {
+			tui => {
 				sidebar = new SidebarExample(tui);
 				render(ctx);
 				return sidebar;

--- a/packages/coding-agent/examples/extensions/right-sidebar.ts
+++ b/packages/coding-agent/examples/extensions/right-sidebar.ts
@@ -1,0 +1,66 @@
+import type { ExtensionAPI, ExtensionContext } from "@oh-my-pi/pi-coding-agent";
+import type { Component, TUI } from "@oh-my-pi/pi-tui";
+import { truncateToWidth } from "@oh-my-pi/pi-tui";
+
+class SidebarExample implements Component {
+	#lines: readonly string[] = [];
+	constructor(private readonly tui: TUI) {}
+	setLines(lines: readonly string[]): void {
+		this.#lines = lines;
+		this.tui.requestComponentRender(this);
+	}
+	render(width: number): readonly string[] {
+		return this.#lines.map(line => truncateToWidth(line, width));
+	}
+}
+
+export default function rightSidebarExample(pi: ExtensionAPI): void {
+	let sidebar: SidebarExample | undefined;
+	let visible = true;
+
+	function render(ctx: ExtensionContext): void {
+		const usage = ctx.getContextUsage();
+		sidebar?.setLines([
+			"RIGHT SIDEBAR",
+			`model  ${ctx.model?.provider ?? "none"}/${ctx.model?.id ?? "none"}`,
+			`context ${usage ? `${usage.percent.toFixed(1)}%` : "unavailable"}`,
+			`state   ${ctx.isIdle() ? "ready" : "running"}`,
+		]);
+	}
+
+	function mount(ctx: ExtensionContext): void {
+		ctx.ui.setWidget(
+			"right-sidebar-example",
+			(tui) => {
+				sidebar = new SidebarExample(tui);
+				render(ctx);
+				return sidebar;
+			},
+			{
+				placement: "rightSidebar",
+				width: 44,
+				minWidth: 28,
+				minMainWidth: 64,
+			},
+		);
+	}
+
+	pi.registerCommand("right-sidebar", {
+		description: "Toggle the reserved right-sidebar example",
+		handler: async (_args, ctx) => {
+			visible = !visible;
+			if (visible) mount(ctx);
+			else ctx.ui.setWidget("right-sidebar-example", undefined);
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		mount(ctx);
+	});
+	pi.on("agent_start", async (_event, ctx) => render(ctx));
+	pi.on("agent_end", async (_event, ctx) => render(ctx));
+	pi.on("session_shutdown", async (_event, ctx) => {
+		ctx.ui.setWidget("right-sidebar-example", undefined);
+		sidebar = undefined;
+	});
+}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -219,10 +219,16 @@ export interface ExtensionUIDialogOptions {
 /** Raw terminal input listener for extensions. */
 export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
 
-export type WidgetPlacement = "aboveEditor" | "belowEditor";
+export type WidgetPlacement = "aboveEditor" | "belowEditor" | "rightSidebar";
 
 export interface ExtensionWidgetOptions {
 	placement?: WidgetPlacement;
+	/** Preferred reserved-column width, including the separator. `rightSidebar` only. */
+	width?: number;
+	/** Smallest visible reserved-column width, including the separator. `rightSidebar` only. */
+	minWidth?: number;
+	/** Smallest width retained for transcript/editor content. `rightSidebar` only. */
+	minMainWidth?: number;
 }
 
 export type ExtensionUiComponent = Component & { dispose?(): void };
@@ -287,7 +293,13 @@ export interface ExtensionUIContext {
 	/** Set the working/loading message shown during streaming. Call with no argument to restore default. */
 	setWorkingMessage(message?: string): void;
 
-	/** Set a widget to display above or below the editor. Accepts string array or component factory. */
+	/**
+	 * Set a widget using a string array or component factory.
+	 *
+	 * String arrays are capped at 10 lines; component factories are uncapped.
+	 * `rightSidebar` widgets are non-focusable and respond to terminal-width changes.
+	 * Sidebar geometry fields are ignored for above/below placements.
+	 */
 	setWidget(key: string, content: ExtensionWidgetContent, options?: ExtensionWidgetOptions): void;
 
 	/** Set a custom footer component, or undefined to restore the built-in footer. */

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -55,11 +55,14 @@ type GuestUiResult = { kind: "answered"; value: string } | { kind: "cancelled" }
 
 class ExtensionWidgetBoundary implements Component {
 	#failed = false;
+	readonly children: Component[];
 
 	constructor(
 		private readonly inner: ExtensionUiComponent,
 		private readonly onError: (error: unknown) => void,
-	) {}
+	) {
+		this.children = [inner];
+	}
 
 	render(width: number): readonly string[] {
 		if (this.#failed) return [];
@@ -360,16 +363,19 @@ export class ExtensionUiController {
 
 	setHookWidget(key: string, content: ExtensionWidgetContent, options?: ExtensionWidgetOptions): void {
 		const placement = options?.placement ?? "aboveEditor";
+		const restoreFocus = placement === "rightSidebar" && content !== undefined;
+		const previousFocus = restoreFocus ? this.ctx.ui.getFocused() : null;
 		this.#removeHookWidget(this.#hookWidgetsAbove, key);
 		this.#removeHookWidget(this.#hookWidgetsBelow, key);
-		this.#removeRightSidebarWidget(key);
 
 		if (content === undefined) {
+			this.#removeRightSidebarWidget(key);
 			this.#rebuildHookWidgets();
 			return;
 		}
 
 		if (placement === "rightSidebar") {
+			const existing = this.#hookWidgetsRight.get(key);
 			const inner = this.#createHookWidget(content);
 			let boundary: ExtensionWidgetBoundary;
 			boundary = new ExtensionWidgetBoundary(inner, () => {
@@ -380,12 +386,16 @@ export class ExtensionUiController {
 				this.#rebuildHookWidgets();
 				this.ctx.showError(`Extension widget "${key}" render failed`);
 			});
+			existing?.component.dispose();
+			// Map#set on an existing key replaces its value without moving it.
 			this.#hookWidgetsRight.set(key, { component: boundary, options: options ?? {} });
 		} else {
+			this.#removeRightSidebarWidget(key);
 			const target = placement === "belowEditor" ? this.#hookWidgetsBelow : this.#hookWidgetsAbove;
 			target.set(key, this.#createHookWidget(content));
 		}
 		this.#rebuildHookWidgets();
+		if (restoreFocus) this.ctx.ui.setFocus(previousFocus);
 	}
 
 	#removeHookWidget(widgets: Map<string, ExtensionUiComponent>, key: string): void {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,4 +1,4 @@
-import type { Component, OverlayHandle, TUI } from "@oh-my-pi/pi-tui";
+import type { Component, OverlayHandle, RightSidebarOptions, TUI } from "@oh-my-pi/pi-tui";
 import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
 import type { CollabUiRequestDraft, CollabUiSelectItem } from "@oh-my-pi/pi-wire";
 import { KeybindingsManager } from "../../config/keybindings";
@@ -53,6 +53,39 @@ interface CollabAskDialogWinner {
  *  "unavailable" collide with the transport sentinel. */
 type GuestUiResult = { kind: "answered"; value: string } | { kind: "cancelled" } | { kind: "unavailable" };
 
+class ExtensionWidgetBoundary implements Component {
+	#failed = false;
+
+	constructor(
+		private readonly inner: ExtensionUiComponent,
+		private readonly onError: (error: unknown) => void,
+	) {}
+
+	render(width: number): readonly string[] {
+		if (this.#failed) return [];
+		try {
+			return this.inner.render(width);
+		} catch (error) {
+			this.#failed = true;
+			queueMicrotask(() => this.onError(error));
+			return [];
+		}
+	}
+
+	invalidate(): void {
+		this.inner.invalidate?.();
+	}
+
+	dispose(): void {
+		this.inner.dispose?.();
+	}
+}
+
+interface RightSidebarWidgetEntry {
+	component: ExtensionWidgetBoundary;
+	options: ExtensionWidgetOptions;
+}
+
 function toWireSelectOptions(options: ExtensionUISelectItem[]): CollabUiSelectItem[] {
 	return options.map(option =>
 		typeof option === "string"
@@ -68,6 +101,8 @@ export class ExtensionUiController {
 	#composerShapeDisposers: Array<() => void> = [];
 	#hookWidgetsAbove = new Map<string, ExtensionUiComponent>();
 	#hookWidgetsBelow = new Map<string, ExtensionUiComponent>();
+	#hookWidgetsRight = new Map<string, RightSidebarWidgetEntry>();
+	#hookWidgetsRightContainer = new Container();
 	// Single-file dialog surface (`editorContainer` + focus) is shared by the
 	// selector / input / editor modals, so only one may be presented at a time;
 	// the rest queue. See `#presentDialog`.
@@ -327,14 +362,29 @@ export class ExtensionUiController {
 		const placement = options?.placement ?? "aboveEditor";
 		this.#removeHookWidget(this.#hookWidgetsAbove, key);
 		this.#removeHookWidget(this.#hookWidgetsBelow, key);
+		this.#removeRightSidebarWidget(key);
 
 		if (content === undefined) {
 			this.#rebuildHookWidgets();
 			return;
 		}
 
-		const target = placement === "belowEditor" ? this.#hookWidgetsBelow : this.#hookWidgetsAbove;
-		target.set(key, this.#createHookWidget(content));
+		if (placement === "rightSidebar") {
+			const inner = this.#createHookWidget(content);
+			let boundary: ExtensionWidgetBoundary;
+			boundary = new ExtensionWidgetBoundary(inner, () => {
+				const entry = this.#hookWidgetsRight.get(key);
+				if (entry?.component !== boundary) return;
+				this.#hookWidgetsRight.delete(key);
+				boundary.dispose();
+				this.#rebuildHookWidgets();
+				this.ctx.showError(`Extension widget "${key}" render failed`);
+			});
+			this.#hookWidgetsRight.set(key, { component: boundary, options: options ?? {} });
+		} else {
+			const target = placement === "belowEditor" ? this.#hookWidgetsBelow : this.#hookWidgetsAbove;
+			target.set(key, this.#createHookWidget(content));
+		}
 		this.#rebuildHookWidgets();
 	}
 
@@ -342,6 +392,12 @@ export class ExtensionUiController {
 		const existing = widgets.get(key);
 		existing?.dispose?.();
 		widgets.delete(key);
+	}
+
+	#removeRightSidebarWidget(key: string): void {
+		const existing = this.#hookWidgetsRight.get(key);
+		existing?.component.dispose();
+		this.#hookWidgetsRight.delete(key);
 	}
 
 	#createHookWidget(content: ExtensionWidgetContent): ExtensionUiComponent {
@@ -364,7 +420,30 @@ export class ExtensionUiController {
 	#rebuildHookWidgets(): void {
 		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerAbove, this.#hookWidgetsAbove, true, true);
 		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerBelow, this.#hookWidgetsBelow, false, false);
+		this.#rebuildRightSidebarWidgets();
 		this.ctx.ui.requestRender();
+	}
+
+	#rebuildRightSidebarWidgets(): void {
+		this.#hookWidgetsRightContainer.clear();
+		for (const entry of this.#hookWidgetsRight.values()) {
+			this.#hookWidgetsRightContainer.addChild(entry.component);
+		}
+
+		if (this.#hookWidgetsRight.size === 0) {
+			this.ctx.ui.setRightSidebar(undefined);
+			return;
+		}
+
+		const geometry = [...this.#hookWidgetsRight.values()].reduce<RightSidebarOptions>(
+			(acc, entry) => ({
+				width: Math.max(acc.width, entry.options.width ?? 44),
+				minWidth: Math.max(acc.minWidth, entry.options.minWidth ?? 28),
+				minMainWidth: Math.max(acc.minMainWidth, entry.options.minMainWidth ?? 64),
+			}),
+			{ width: 2, minWidth: 2, minMainWidth: 1 },
+		);
+		this.ctx.ui.setRightSidebar(this.#hookWidgetsRightContainer, geometry);
 	}
 
 	#renderHookWidgetContainer(
@@ -1159,8 +1238,13 @@ export class ExtensionUiController {
 		for (const widget of this.#hookWidgetsBelow.values()) {
 			widget.dispose?.();
 		}
+		for (const entry of this.#hookWidgetsRight.values()) {
+			entry.component.dispose();
+		}
 		this.#hookWidgetsAbove.clear();
 		this.#hookWidgetsBelow.clear();
+		this.#hookWidgetsRight.clear();
+		this.#hookWidgetsRightContainer.clear();
 		this.#rebuildHookWidgets();
 	}
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -374,28 +374,31 @@ export class ExtensionUiController {
 			return;
 		}
 
-		if (placement === "rightSidebar") {
-			const existing = this.#hookWidgetsRight.get(key);
-			const inner = this.#createHookWidget(content);
-			let boundary: ExtensionWidgetBoundary;
-			boundary = new ExtensionWidgetBoundary(inner, () => {
-				const entry = this.#hookWidgetsRight.get(key);
-				if (entry?.component !== boundary) return;
-				this.#hookWidgetsRight.delete(key);
-				boundary.dispose();
-				this.#rebuildHookWidgets();
-				this.ctx.showError(`Extension widget "${key}" render failed`);
-			});
-			existing?.component.dispose();
-			// Map#set on an existing key replaces its value without moving it.
-			this.#hookWidgetsRight.set(key, { component: boundary, options: options ?? {} });
-		} else {
-			this.#removeRightSidebarWidget(key);
-			const target = placement === "belowEditor" ? this.#hookWidgetsBelow : this.#hookWidgetsAbove;
-			target.set(key, this.#createHookWidget(content));
+		try {
+			if (placement === "rightSidebar") {
+				const existing = this.#hookWidgetsRight.get(key);
+				const inner = this.#createHookWidget(content);
+				let boundary: ExtensionWidgetBoundary;
+				boundary = new ExtensionWidgetBoundary(inner, () => {
+					const entry = this.#hookWidgetsRight.get(key);
+					if (entry?.component !== boundary) return;
+					this.#hookWidgetsRight.delete(key);
+					boundary.dispose();
+					this.#rebuildHookWidgets();
+					this.ctx.showError(`Extension widget "${key}" render failed`);
+				});
+				existing?.component.dispose();
+				// Map#set on an existing key replaces its value without moving it.
+				this.#hookWidgetsRight.set(key, { component: boundary, options: options ?? {} });
+			} else {
+				this.#removeRightSidebarWidget(key);
+				const target = placement === "belowEditor" ? this.#hookWidgetsBelow : this.#hookWidgetsAbove;
+				target.set(key, this.#createHookWidget(content));
+			}
+			this.#rebuildHookWidgets();
+		} finally {
+			if (restoreFocus) this.ctx.ui.setFocus(previousFocus);
 		}
-		this.#rebuildHookWidgets();
-		if (restoreFocus) this.ctx.ui.setFocus(previousFocus);
 	}
 
 	#removeHookWidget(widgets: Map<string, ExtensionUiComponent>, key: string): void {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -20,8 +20,8 @@ import {
 	type ExtensionUIContext,
 	type ExtensionUIDialogOptions,
 	type ExtensionUISelectItem,
-	type ExtensionWidgetOptions,
 	type ExtensionWidgetContent,
+	type ExtensionWidgetOptions,
 	getExtensionUISelectOptionLabel,
 } from "../../extensibility/extensions";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -21,6 +21,7 @@ import {
 	type ExtensionUIDialogOptions,
 	type ExtensionUISelectItem,
 	type ExtensionWidgetOptions,
+	type ExtensionWidgetContent,
 	getExtensionUISelectOptionLabel,
 } from "../../extensibility/extensions";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
@@ -656,21 +657,24 @@ export function requestRpcDialog<T>(
 	return promise;
 }
 
-/** Emit a legacy RPC widget frame without interactive-only sidebar placement. */
+/** Emit a passive RPC widget frame; component factories remain headless no-ops. */
 export function emitRpcWidgetRequest(
 	output: (frame: RpcExtensionUIRequest | object) => void,
 	key: string,
-	lines: string[] | undefined,
+	content: ExtensionWidgetContent,
 	options?: ExtensionWidgetOptions,
 ): void {
-	const widgetPlacement = options?.placement === "rightSidebar" ? undefined : options?.placement;
+	if (content !== undefined && !Array.isArray(content)) return;
 	const request: RpcExtensionUIRequest = {
 		type: "extension_ui_request",
 		id: Snowflake.next() as string,
 		method: "setWidget",
 		widgetKey: key,
-		widgetLines: lines,
-		...(widgetPlacement === undefined ? {} : { widgetPlacement }),
+		widgetLines: content,
+		...(options?.placement === undefined ? {} : { widgetPlacement: options.placement }),
+		...(options?.width === undefined ? {} : { widgetWidth: options.width }),
+		...(options?.minWidth === undefined ? {} : { widgetMinWidth: options.minWidth }),
+		...(options?.minMainWidth === undefined ? {} : { widgetMinMainWidth: options.minMainWidth }),
 	};
 	output(request);
 }
@@ -840,12 +844,8 @@ export async function runRpcMode(
 			// Not supported in RPC mode
 		}
 
-		setWidget(key: string, content: unknown, options?: ExtensionWidgetOptions): void {
-			// Only support string arrays in RPC mode - factory functions are ignored
-			if (content === undefined || Array.isArray(content)) {
-				emitRpcWidgetRequest(this.output, key, content as string[] | undefined, options);
-			}
-			// Component factories are not supported in RPC mode - would need TUI access
+		setWidget(key: string, content: ExtensionWidgetContent, options?: ExtensionWidgetOptions): void {
+			emitRpcWidgetRequest(this.output, key, content, options);
 		}
 
 		setFooter(_factory: unknown): void {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -655,6 +655,25 @@ export function requestRpcDialog<T>(
 	output({ type: "extension_ui_request", id, ...request } as RpcExtensionUIRequest);
 	return promise;
 }
+
+/** Emit a legacy RPC widget frame without interactive-only sidebar placement. */
+export function emitRpcWidgetRequest(
+	output: (frame: RpcExtensionUIRequest | object) => void,
+	key: string,
+	lines: string[] | undefined,
+	options?: ExtensionWidgetOptions,
+): void {
+	const widgetPlacement = options?.placement === "rightSidebar" ? undefined : options?.placement;
+	const request: RpcExtensionUIRequest = {
+		type: "extension_ui_request",
+		id: Snowflake.next() as string,
+		method: "setWidget",
+		widgetKey: key,
+		widgetLines: lines,
+		...(widgetPlacement === undefined ? {} : { widgetPlacement }),
+	};
+	output(request);
+}
 /**
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
@@ -824,14 +843,7 @@ export async function runRpcMode(
 		setWidget(key: string, content: unknown, options?: ExtensionWidgetOptions): void {
 			// Only support string arrays in RPC mode - factory functions are ignored
 			if (content === undefined || Array.isArray(content)) {
-				this.output({
-					type: "extension_ui_request",
-					id: Snowflake.next() as string,
-					method: "setWidget",
-					widgetKey: key,
-					widgetLines: content as string[] | undefined,
-					widgetPlacement: options?.placement,
-				} as RpcExtensionUIRequest);
+				emitRpcWidgetRequest(this.output, key, content as string[] | undefined, options);
 			}
 			// Component factories are not supported in RPC mode - would need TUI access
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -409,7 +409,10 @@ export type RpcExtensionUIRequest =
 			method: "setWidget";
 			widgetKey: string;
 			widgetLines: string[] | undefined;
-			widgetPlacement?: "aboveEditor" | "belowEditor";
+			widgetPlacement?: "aboveEditor" | "belowEditor" | "rightSidebar";
+			widgetWidth?: number;
+			widgetMinWidth?: number;
+			widgetMinMainWidth?: number;
 	  }
 	| { type: "extension_ui_request"; id: string; method: "setTitle"; title: string }
 	| { type: "extension_ui_request"; id: string; method: "set_editor_text"; text: string }

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, describe, expect, it, mock } from "bun:test";
-import { type Component, Container } from "@oh-my-pi/pi-tui";
+import { type Component, Container, TUI } from "@oh-my-pi/pi-tui";
 import type { ExtensionWidgetOptions, WidgetPlacement } from "../src/extensibility/extensions";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 
 beforeAll(async () => {
 	const dark = await getThemeByName("dark");
@@ -24,17 +25,19 @@ class Probe implements Component {
 	}
 }
 
-function createController() {
+function createController(uiOverrides: Record<string, unknown> = {}) {
 	const mounted: Array<{ component: Component | undefined; options: unknown }> = [];
 	const setRightSidebar = mock((component: Component | undefined, options?: unknown) => {
 		mounted.push({ component, options });
 	});
 	const requestRender = mock(() => {});
+	const setFocus = mock((_component: Component | null) => {});
+	const getFocused = mock((): Component | null => null);
 	const showError = mock((_message: string) => {});
 	const hookWidgetContainerAbove = new Container();
 	const hookWidgetContainerBelow = new Container();
 	const ctx = {
-		ui: { requestRender, setRightSidebar },
+		ui: { requestRender, setRightSidebar, setFocus, getFocused, ...uiOverrides },
 		hookWidgetContainerAbove,
 		hookWidgetContainerBelow,
 		showError,
@@ -78,6 +81,74 @@ describe("ExtensionUiController rightSidebar widgets", () => {
 		expect(aIndex).toBeGreaterThanOrEqual(0);
 		expect(bIndex).toBeGreaterThanOrEqual(0);
 		expect(aIndex).toBeLessThan(bIndex);
+	});
+
+	it("keeps same-placement updates in order and disposes the replaced widget exactly once", () => {
+		const { controller, mounted } = createController();
+		const oldA = new Probe(["old A"]);
+		const newA = new Probe(["new A"]);
+		const b = new Probe(["B"]);
+		controller.setHookWidget("a", () => oldA, rightSidebarDefaults);
+		controller.setHookWidget("b", () => b, rightSidebarDefaults);
+
+		controller.setHookWidget("a", () => newA, rightSidebarDefaults);
+
+		const lines = mounted.at(-1)?.component?.render(43) ?? [];
+		expect(lines.findIndex(line => line.includes("new A"))).toBeLessThan(
+			lines.findIndex(line => line.includes("B")),
+		);
+		expect(oldA.disposeCalls).toBe(1);
+		expect(newA.disposeCalls).toBe(0);
+		expect(b.disposeCalls).toBe(0);
+	});
+
+	it("rejects focus requested by a sidebar factory and keeps input on the editor", async () => {
+		const terminal = new VirtualTerminal(120, 8);
+		const tui = new TUI(terminal);
+		const editorInputs: string[] = [];
+		const sidebarInputs: string[] = [];
+		const editor: Component = {
+			render: () => ["EDITOR"],
+			handleInput: data => editorInputs.push(data),
+		};
+		const sidebarChild: Component = {
+			render: () => ["SIDEBAR"],
+			handleInput: data => sidebarInputs.push(data),
+		};
+		const sidebarRoot = new Container();
+		sidebarRoot.addChild(sidebarChild);
+		const { controller } = createController({
+			requestRender: () => tui.requestRender(),
+			setRightSidebar: (component: Component | undefined, options?: unknown) =>
+				tui.setRightSidebar(component, options as never),
+			setFocus: (component: Component | null) => tui.setFocus(component),
+			getFocused: () => tui.getFocused(),
+		});
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		controller.setHookWidget(
+			"focus-thief",
+			ui => {
+				ui.setFocus(sidebarChild);
+				return sidebarRoot;
+			},
+			rightSidebarDefaults,
+		);
+		tui.start();
+		try {
+			await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDEBAR")));
+			expect(tui.getFocused()).toBe(editor);
+
+			tui.setFocus(sidebarChild);
+			terminal.sendInput("x");
+
+			expect(tui.getFocused()).toBe(editor);
+			expect(editorInputs).toEqual(["x"]);
+			expect(sidebarInputs).toEqual([]);
+		} finally {
+			tui.stop();
+		}
 	});
 
 	it("removes and disposes only the matching key, then unmounts the final key", () => {

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -151,6 +151,52 @@ describe("ExtensionUiController rightSidebar widgets", () => {
 		}
 	});
 
+	it("restores editor focus when a focus-stealing sidebar factory throws", async () => {
+		const terminal = new VirtualTerminal(120, 8);
+		const tui = new TUI(terminal);
+		const editorInputs: string[] = [];
+		const editor: Component = {
+			render: () => ["EDITOR"],
+			handleInput: data => editorInputs.push(data),
+		};
+		const orphan: Component = {
+			render: () => ["ORPHAN"],
+			handleInput: () => {
+				throw new Error("orphan received input");
+			},
+		};
+		const { controller } = createController({
+			requestRender: () => tui.requestRender(),
+			setRightSidebar: (component: Component | undefined, options?: unknown) =>
+				tui.setRightSidebar(component, options as never),
+			setFocus: (component: Component | null) => tui.setFocus(component),
+			getFocused: () => tui.getFocused(),
+		});
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		tui.start();
+		try {
+			await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("EDITOR")));
+
+			expect(() =>
+				controller.setHookWidget(
+					"throwing-focus-thief",
+					ui => {
+						ui.setFocus(orphan);
+						throw new Error("factory failed");
+					},
+					rightSidebarDefaults,
+				),
+			).toThrow("factory failed");
+			expect(tui.getFocused()).toBe(editor);
+
+			terminal.sendInput("x");
+			expect(editorInputs).toEqual(["x"]);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("removes and disposes only the matching key, then unmounts the final key", () => {
 		const { controller, mounted } = createController();
 		const first = new Probe(["A"]);

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -1,9 +1,9 @@
 import { beforeAll, describe, expect, it, mock } from "bun:test";
 import { type Component, Container, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import type { ExtensionWidgetOptions, WidgetPlacement } from "../src/extensibility/extensions";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
-import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 
 beforeAll(async () => {
 	const dark = await getThemeByName("dark");
@@ -94,9 +94,7 @@ describe("ExtensionUiController rightSidebar widgets", () => {
 		controller.setHookWidget("a", () => newA, rightSidebarDefaults);
 
 		const lines = mounted.at(-1)?.component?.render(43) ?? [];
-		expect(lines.findIndex(line => line.includes("new A"))).toBeLessThan(
-			lines.findIndex(line => line.includes("B")),
-		);
+		expect(lines.findIndex(line => line.includes("new A"))).toBeLessThan(lines.findIndex(line => line.includes("B")));
 		expect(oldA.disposeCalls).toBe(1);
 		expect(newA.disposeCalls).toBe(0);
 		expect(b.disposeCalls).toBe(0);

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, mock } from "bun:test";
-import { Container, type Component } from "@oh-my-pi/pi-tui";
+import { type Component, Container } from "@oh-my-pi/pi-tui";
 import type { ExtensionWidgetOptions, WidgetPlacement } from "../src/extensibility/extensions";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
@@ -91,7 +91,12 @@ describe("ExtensionUiController rightSidebar widgets", () => {
 
 		expect(first.disposeCalls).toBe(1);
 		expect(second.disposeCalls).toBe(0);
-		expect(mounted.at(-1)?.component?.render(43).some(line => line.includes("B"))).toBe(true);
+		expect(
+			mounted
+				.at(-1)
+				?.component?.render(43)
+				.some(line => line.includes("B")),
+		).toBe(true);
 
 		controller.setHookWidget("b", undefined, rightSidebarDefaults);
 		controller.setHookWidget("b", undefined, rightSidebarDefaults);
@@ -163,13 +168,8 @@ describe("ExtensionUiController rightSidebar widgets", () => {
 	});
 
 	it("fully cleans up every placement and unmounts the aggregate", () => {
-		const {
-			controller,
-			hookWidgetContainerAbove,
-			hookWidgetContainerBelow,
-			mounted,
-			setRightSidebar,
-		} = createController();
+		const { controller, hookWidgetContainerAbove, hookWidgetContainerBelow, mounted, setRightSidebar } =
+			createController();
 		const above = new Probe(["above"]);
 		const below = new Probe(["below"]);
 		const rightA = new Probe(["right A"]);

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it, mock } from "bun:test";
+import { beforeAll, describe, expect, it, mock } from "bun:test";
 import { Container, type Component } from "@oh-my-pi/pi-tui";
 import type { ExtensionWidgetOptions, WidgetPlacement } from "../src/extensibility/extensions";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	const dark = await getThemeByName("dark");
+	if (!dark) throw new Error("Failed to load dark theme");
+	setThemeInstance(dark);
+});
 
 class Probe implements Component {
 	disposeCalls = 0;

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -61,15 +61,23 @@ describe("ExtensionUiController rightSidebar widgets", () => {
 		const { controller, mounted } = createController();
 		controller.setHookWidget("a", ["A"], {
 			placement: "rightSidebar",
-			width: 40,
+			width: 46,
 			minWidth: 24,
 			minMainWidth: 60,
 		});
-		controller.setHookWidget("b", ["B"], rightSidebarDefaults);
+		controller.setHookWidget("b", ["B"], {
+			placement: "rightSidebar",
+			minWidth: 30,
+			minMainWidth: 70,
+		});
 
-		expect(mounted.at(-1)?.options).toEqual({ width: 44, minWidth: 28, minMainWidth: 64 });
-		const lines = mounted.at(-1)?.component?.render(43) ?? [];
-		expect(lines.findIndex(line => line.includes("A"))).toBeLessThan(lines.findIndex(line => line.includes("B")));
+		expect(mounted.at(-1)?.options).toEqual({ width: 46, minWidth: 30, minMainWidth: 70 });
+		const lines = mounted.at(-1)?.component?.render(45) ?? [];
+		const aIndex = lines.findIndex(line => line.includes("A"));
+		const bIndex = lines.findIndex(line => line.includes("B"));
+		expect(aIndex).toBeGreaterThanOrEqual(0);
+		expect(bIndex).toBeGreaterThanOrEqual(0);
+		expect(aIndex).toBeLessThan(bIndex);
 	});
 
 	it("removes and disposes only the matching key, then unmounts the final key", () => {

--- a/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
+++ b/packages/coding-agent/test/extension-ui-right-sidebar.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Container, type Component } from "@oh-my-pi/pi-tui";
+import type { ExtensionWidgetOptions, WidgetPlacement } from "../src/extensibility/extensions";
+import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
+
+class Probe implements Component {
+	disposeCalls = 0;
+
+	constructor(private readonly lines: readonly string[]) {}
+
+	render(): readonly string[] {
+		return this.lines;
+	}
+
+	dispose(): void {
+		this.disposeCalls++;
+	}
+}
+
+function createController() {
+	const mounted: Array<{ component: Component | undefined; options: unknown }> = [];
+	const setRightSidebar = mock((component: Component | undefined, options?: unknown) => {
+		mounted.push({ component, options });
+	});
+	const requestRender = mock(() => {});
+	const showError = mock((_message: string) => {});
+	const hookWidgetContainerAbove = new Container();
+	const hookWidgetContainerBelow = new Container();
+	const ctx = {
+		ui: { requestRender, setRightSidebar },
+		hookWidgetContainerAbove,
+		hookWidgetContainerBelow,
+		showError,
+	} as never;
+
+	return {
+		controller: new ExtensionUiController(ctx),
+		hookWidgetContainerAbove,
+		hookWidgetContainerBelow,
+		mounted,
+		requestRender,
+		setRightSidebar,
+		showError,
+	};
+}
+
+const rightSidebarPlacement: WidgetPlacement = "rightSidebar";
+const rightSidebarDefaults = {
+	placement: rightSidebarPlacement,
+} satisfies ExtensionWidgetOptions;
+
+describe("ExtensionUiController rightSidebar widgets", () => {
+	it("aggregates keyed widgets in stable order and resolves the strictest geometry", () => {
+		const { controller, mounted } = createController();
+		controller.setHookWidget("a", ["A"], {
+			placement: "rightSidebar",
+			width: 40,
+			minWidth: 24,
+			minMainWidth: 60,
+		});
+		controller.setHookWidget("b", ["B"], rightSidebarDefaults);
+
+		expect(mounted.at(-1)?.options).toEqual({ width: 44, minWidth: 28, minMainWidth: 64 });
+		const lines = mounted.at(-1)?.component?.render(43) ?? [];
+		expect(lines.findIndex(line => line.includes("A"))).toBeLessThan(lines.findIndex(line => line.includes("B")));
+	});
+
+	it("removes and disposes only the matching key, then unmounts the final key", () => {
+		const { controller, mounted } = createController();
+		const first = new Probe(["A"]);
+		const second = new Probe(["B"]);
+		controller.setHookWidget("a", () => first, rightSidebarDefaults);
+		controller.setHookWidget("b", () => second, rightSidebarDefaults);
+
+		controller.setHookWidget("a", undefined, rightSidebarDefaults);
+
+		expect(first.disposeCalls).toBe(1);
+		expect(second.disposeCalls).toBe(0);
+		expect(mounted.at(-1)?.component?.render(43).some(line => line.includes("B"))).toBe(true);
+
+		controller.setHookWidget("b", undefined, rightSidebarDefaults);
+		controller.setHookWidget("b", undefined, rightSidebarDefaults);
+
+		expect(second.disposeCalls).toBe(1);
+		expect(mounted.at(-1)?.component).toBeUndefined();
+	});
+
+	it("keeps component factories uncapped while retaining the string-array cap", () => {
+		const { controller, mounted } = createController();
+		const lines = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`);
+
+		controller.setHookWidget("factory", () => new Probe(lines), rightSidebarDefaults);
+		expect(mounted.at(-1)?.component?.render(80)).toHaveLength(12);
+
+		controller.setHookWidget("factory", lines, rightSidebarDefaults);
+		const rendered = mounted.at(-1)?.component?.render(80) ?? [];
+		expect(rendered).toHaveLength(11);
+		expect(rendered.at(-1)).toContain("widget truncated");
+	});
+
+	it("contains a throwing widget, removes it asynchronously, disposes once, and reports a sanitized error", async () => {
+		const { controller, mounted, showError } = createController();
+		const dispose = mock(() => {});
+		controller.setHookWidget(
+			"broken",
+			() => ({
+				render: () => {
+					throw new Error("sensitive render detail");
+				},
+				dispose,
+			}),
+			rightSidebarDefaults,
+		);
+
+		expect(() => mounted.at(-1)?.component?.render(43)).not.toThrow();
+		expect(dispose).not.toHaveBeenCalled();
+		await Promise.resolve();
+
+		expect(mounted.at(-1)?.component).toBeUndefined();
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(showError).toHaveBeenCalledTimes(1);
+		expect(showError).toHaveBeenCalledWith('Extension widget "broken" render failed');
+	});
+
+	it("does not let a stale render failure remove a replacement with the same key", async () => {
+		const { controller, mounted, showError } = createController();
+		const failedDispose = mock(() => {});
+		const replacement = new Probe(["replacement"]);
+		controller.setHookWidget(
+			"shared",
+			() => ({
+				render: () => {
+					throw new Error("stale failure");
+				},
+				dispose: failedDispose,
+			}),
+			rightSidebarDefaults,
+		);
+		mounted.at(-1)?.component?.render(43);
+
+		controller.setHookWidget("shared", () => replacement, rightSidebarDefaults);
+		await Promise.resolve();
+
+		expect(failedDispose).toHaveBeenCalledTimes(1);
+		expect(replacement.disposeCalls).toBe(0);
+		expect(mounted.at(-1)?.component?.render(43)).toContain("replacement");
+		expect(showError).not.toHaveBeenCalled();
+	});
+
+	it("fully cleans up every placement and unmounts the aggregate", () => {
+		const {
+			controller,
+			hookWidgetContainerAbove,
+			hookWidgetContainerBelow,
+			mounted,
+			setRightSidebar,
+		} = createController();
+		const above = new Probe(["above"]);
+		const below = new Probe(["below"]);
+		const rightA = new Probe(["right A"]);
+		const rightB = new Probe(["right B"]);
+		controller.setHookWidget("above", () => above);
+		controller.setHookWidget("below", () => below, { placement: "belowEditor" });
+		controller.setHookWidget("right-a", () => rightA, rightSidebarDefaults);
+		controller.setHookWidget("right-b", () => rightB, rightSidebarDefaults);
+
+		controller.clearHookWidgets();
+		controller.clearHookWidgets();
+
+		expect(above.disposeCalls).toBe(1);
+		expect(below.disposeCalls).toBe(1);
+		expect(rightA.disposeCalls).toBe(1);
+		expect(rightB.disposeCalls).toBe(1);
+		expect(hookWidgetContainerAbove.children).toHaveLength(1);
+		expect(hookWidgetContainerBelow.children).toHaveLength(0);
+		expect(mounted.at(-1)?.component).toBeUndefined();
+		expect(setRightSidebar).toHaveBeenLastCalledWith(undefined);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
@@ -38,6 +38,7 @@ function makeHarness() {
 			requestRender,
 			setFocus,
 			showOverlay,
+			setRightSidebar: vi.fn(),
 			terminal: { rows: 40 },
 		},
 		editorContainer,

--- a/packages/coding-agent/test/rpc-extension-ui.test.ts
+++ b/packages/coding-agent/test/rpc-extension-ui.test.ts
@@ -91,7 +91,7 @@ describe("RPC extension UI", () => {
 
 	it("ignores component widget factories in RPC mode", () => {
 		const output = vi.fn<(frame: object) => void>();
-		const componentFactory = (() => ({ render: () => [] })) as never;
+		const componentFactory = () => ({ render: () => [] });
 
 		expect(() =>
 			emitRpcWidgetRequest(output, "quota", componentFactory, { placement: "rightSidebar" }),

--- a/packages/coding-agent/test/rpc-extension-ui.test.ts
+++ b/packages/coding-agent/test/rpc-extension-ui.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
-import { type PendingExtensionRequest, requestRpcDialog } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import {
+	emitRpcWidgetRequest,
+	type PendingExtensionRequest,
+	requestRpcDialog,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
 
 describe("RPC extension UI", () => {
 	it("cancels the remote dialog when its signal aborts", async () => {
@@ -36,5 +40,29 @@ describe("RPC extension UI", () => {
 			targetId: request.id,
 		});
 		expect(pendingRequests.size).toBe(0);
+	});
+
+	it("omits unsupported right-sidebar placement from passive widget frames", () => {
+		const output = vi.fn<(frame: object) => void>();
+
+		emitRpcWidgetRequest(output, "right", ["sidebar"], { placement: "rightSidebar" });
+		emitRpcWidgetRequest(output, "below", ["status"], { placement: "belowEditor" });
+
+		expect(output).toHaveBeenNthCalledWith(1, {
+			type: "extension_ui_request",
+			id: expect.any(String),
+			method: "setWidget",
+			widgetKey: "right",
+			widgetLines: ["sidebar"],
+		});
+		expect(JSON.stringify(output.mock.calls[0]?.[0])).not.toContain("rightSidebar");
+		expect(output).toHaveBeenNthCalledWith(2, {
+			type: "extension_ui_request",
+			id: expect.any(String),
+			method: "setWidget",
+			widgetKey: "below",
+			widgetLines: ["status"],
+			widgetPlacement: "belowEditor",
+		});
 	});
 });

--- a/packages/coding-agent/test/rpc-extension-ui.test.ts
+++ b/packages/coding-agent/test/rpc-extension-ui.test.ts
@@ -42,20 +42,43 @@ describe("RPC extension UI", () => {
 		expect(pendingRequests.size).toBe(0);
 	});
 
-	it("omits unsupported right-sidebar placement from passive widget frames", () => {
+	it("forwards right-sidebar placement and geometry for passive widget frames", () => {
 		const output = vi.fn<(frame: object) => void>();
 
-		emitRpcWidgetRequest(output, "right", ["sidebar"], { placement: "rightSidebar" });
+		emitRpcWidgetRequest(output, "quota", ["5 hour 42%"], {
+			placement: "rightSidebar",
+			width: 44,
+			minWidth: 28,
+			minMainWidth: 64,
+		});
+
+		expect(output).toHaveBeenCalledWith({
+			type: "extension_ui_request",
+			id: expect.any(String),
+			method: "setWidget",
+			widgetKey: "quota",
+			widgetLines: ["5 hour 42%"],
+			widgetPlacement: "rightSidebar",
+			widgetWidth: 44,
+			widgetMinWidth: 28,
+			widgetMinMainWidth: 64,
+		});
+	});
+
+	it("keeps supported legacy widget placements unchanged", () => {
+		const output = vi.fn<(frame: object) => void>();
+
+		emitRpcWidgetRequest(output, "above", ["context"], { placement: "aboveEditor" });
 		emitRpcWidgetRequest(output, "below", ["status"], { placement: "belowEditor" });
 
 		expect(output).toHaveBeenNthCalledWith(1, {
 			type: "extension_ui_request",
 			id: expect.any(String),
 			method: "setWidget",
-			widgetKey: "right",
-			widgetLines: ["sidebar"],
+			widgetKey: "above",
+			widgetLines: ["context"],
+			widgetPlacement: "aboveEditor",
 		});
-		expect(JSON.stringify(output.mock.calls[0]?.[0])).not.toContain("rightSidebar");
 		expect(output).toHaveBeenNthCalledWith(2, {
 			type: "extension_ui_request",
 			id: expect.any(String),
@@ -64,5 +87,15 @@ describe("RPC extension UI", () => {
 			widgetLines: ["status"],
 			widgetPlacement: "belowEditor",
 		});
+	});
+
+	it("ignores component widget factories in RPC mode", () => {
+		const output = vi.fn<(frame: object) => void>();
+		const componentFactory = (() => ({ render: () => [] })) as never;
+
+		expect(() =>
+			emitRpcWidgetRequest(output, "quota", componentFactory, { placement: "rightSidebar" }),
+		).not.toThrow();
+		expect(output).not.toHaveBeenCalled();
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added optional `getNativeScrollbackLiveRegionPinnedStart()` hook to allow nested transcripts to pin a later dashboard without shifting the earliest live seam.
+- Added a viewport-local reserved right-sidebar compositor with responsive reflow ([#8126](https://github.com/can1357/oh-my-pi/issues/8126)). Unlike PR [#4603](https://github.com/can1357/oh-my-pi/pull/4603)'s `rightEditor` tradeoff, it reserves columns and reflows main content instead of placing widgets in available whitespace.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -37,6 +37,8 @@ export * from "./latex-block";
 export * from "./latex-to-unicode";
 // SGR mouse report parsing
 export * from "./mouse";
+// Reserved sidebar layout
+export * from "./reserved-sidebar";
 // Mermaid diagram support
 // Input buffering for batch splitting
 export * from "./stdin-buffer";

--- a/packages/tui/src/reserved-sidebar.ts
+++ b/packages/tui/src/reserved-sidebar.ts
@@ -14,6 +14,9 @@ export interface ResolvedRightSidebarLayout {
 	visible: boolean;
 }
 
+/** Close main-row SGR and OSC 8 state before entering reserved columns. */
+export const RIGHT_SIDEBAR_BOUNDARY_RESET = "\x1b[0m\x1b]8;;\x07";
+
 function finiteInteger(value: number, fallback: number): number {
 	return Number.isFinite(value) ? Math.trunc(value) : fallback;
 }
@@ -61,7 +64,7 @@ export function composeRightSidebar(
 		const main = truncateToWidth(window[row] ?? "", layout.mainWidth);
 		const mainPadding = " ".repeat(Math.max(0, layout.mainWidth - visibleWidth(main)));
 		const sidebar = truncateToWidth(sidebarLines[row] ?? "", layout.sidebarContentWidth);
-		output[row] = `${main}${mainPadding}${separator}${sidebar}`;
+		output[row] = `${main}${RIGHT_SIDEBAR_BOUNDARY_RESET}${mainPadding}${separator}${sidebar}`;
 	}
 	return output;
 }

--- a/packages/tui/src/reserved-sidebar.ts
+++ b/packages/tui/src/reserved-sidebar.ts
@@ -1,0 +1,67 @@
+import { truncateToWidth, visibleWidth } from "./utils";
+
+export interface RightSidebarOptions {
+	width: number;
+	minWidth: number;
+	minMainWidth: number;
+}
+
+export interface ResolvedRightSidebarLayout {
+	terminalWidth: number;
+	mainWidth: number;
+	sidebarWidth: number;
+	sidebarContentWidth: number;
+	visible: boolean;
+}
+
+function finiteInteger(value: number, fallback: number): number {
+	return Number.isFinite(value) ? Math.trunc(value) : fallback;
+}
+
+export function resolveRightSidebarLayout(
+	terminalWidth: number,
+	options: RightSidebarOptions,
+): ResolvedRightSidebarLayout {
+	const width = Math.max(1, finiteInteger(terminalWidth, 1));
+	const preferred = Math.max(2, finiteInteger(options.width, 2));
+	const minimum = Math.max(2, Math.min(preferred, finiteInteger(options.minWidth, preferred)));
+	const minimumMain = Math.max(1, finiteInteger(options.minMainWidth, 1));
+
+	if (width < minimumMain + minimum) {
+		return {
+			terminalWidth: width,
+			mainWidth: width,
+			sidebarWidth: 0,
+			sidebarContentWidth: 0,
+			visible: false,
+		};
+	}
+
+	const sidebarWidth = Math.min(preferred, width - minimumMain);
+	return {
+		terminalWidth: width,
+		mainWidth: width - sidebarWidth,
+		sidebarWidth,
+		sidebarContentWidth: sidebarWidth - 1,
+		visible: true,
+	};
+}
+
+export function composeRightSidebar(
+	window: readonly string[],
+	sidebarLines: readonly string[],
+	layout: ResolvedRightSidebarLayout,
+	separator = "│",
+): readonly string[] {
+	if (!layout.visible) return window;
+	if (visibleWidth(separator) !== 1) throw new Error("Right sidebar separator must occupy one column");
+
+	const output = new Array<string>(window.length);
+	for (let row = 0; row < window.length; row++) {
+		const main = truncateToWidth(window[row] ?? "", layout.mainWidth);
+		const mainPadding = " ".repeat(Math.max(0, layout.mainWidth - visibleWidth(main)));
+		const sidebar = truncateToWidth(sidebarLines[row] ?? "", layout.sidebarContentWidth);
+		output[row] = `${main}${mainPadding}${separator}${sidebar}`;
+	}
+	return output;
+}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3464,7 +3464,7 @@ export class TUI extends Container {
 		const height = this.terminal.rows;
 		const sidebarLayout = this.#resolveRightSidebar(terminalWidth);
 		const mainWidth = sidebarLayout.mainWidth;
-		const contentWidthChanged = mainWidth !== this.#composeWidth;
+		const contentWidthChanged = this.#composeWidth >= 0 && mainWidth !== this.#composeWidth;
 
 		// Consume the component-scoped accumulation: it describes the render
 		// requests made up to this frame, whichever path the frame takes.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3446,8 +3446,8 @@ export class TUI extends Container {
 		width: number,
 		height: number,
 		cursorPos: { row: number; col: number } | null,
-	): { lines: string[]; cursorPos: { row: number; col: number } | null } {
-		if (!isConPTYHosted()) return { lines, cursorPos };
+	): { lines: string[]; cursorPos: { row: number; col: number } | null; sourceStart: number } {
+		if (!isConPTYHosted()) return { lines, cursorPos, sourceStart: 0 };
 
 		let totalBytes = 0;
 		let exceedsThreshold = false;
@@ -3458,7 +3458,7 @@ export class TUI extends Container {
 				break;
 			}
 		}
-		if (!exceedsThreshold) return { lines, cursorPos };
+		if (!exceedsThreshold) return { lines, cursorPos, sourceStart: 0 };
 
 		let retainedBytes = 0;
 		let retainedStart = lines.length;
@@ -3469,7 +3469,7 @@ export class TUI extends Container {
 			retainedStart -= 1;
 			retainedBytes += Buffer.byteLength(lines[retainedStart] ?? "", "utf8") + 8;
 		}
-		if (retainedStart <= 0) return { lines, cursorPos };
+		if (retainedStart <= 0) return { lines, cursorPos, sourceStart: 0 };
 
 		const marker = truncateToWidth(
 			`[${retainedStart} older lines hidden to keep Windows console resume responsive]`,
@@ -3483,11 +3483,12 @@ export class TUI extends Container {
 		}
 
 		if (cursorPos === null || cursorPos.row < retainedStart) {
-			return { lines: truncated, cursorPos: null };
+			return { lines: truncated, cursorPos: null, sourceStart: retainedStart };
 		}
 		return {
 			lines: truncated,
 			cursorPos: { row: cursorPos.row - retainedStart + 1, col: cursorPos.col },
+			sourceStart: retainedStart,
 		};
 	}
 
@@ -4930,6 +4931,7 @@ export class TUI extends Container {
 		// theme change / session replace) just to be returned unchanged.
 		// `paintLines` stays null unless truncation actually rewrote the replay.
 		let paintLines: string[] | null = null;
+		let paintMainLines: string[] | null = null;
 		let paintLineCount = chunkTo + height;
 		if (options.boundConptyPaint && isConPTYHosted()) {
 			const merged = new Array<string>(chunkTo + height);
@@ -4942,6 +4944,15 @@ export class TUI extends Container {
 				paintLines = paint.lines;
 				paintLineCount = paint.lines.length;
 				paintCursorPos = paint.cursorPos;
+				paintMainLines = new Array<string>(paint.lines.length);
+				paintMainLines[0] = paint.lines[0] ?? "";
+				for (let i = 1; i < paint.lines.length; i++) {
+					const sourceRow = paint.sourceStart + i - 1;
+					paintMainLines[i] =
+						sourceRow < chunkTo
+							? (frame[sourceRow] ?? "")
+							: (options.mainWindow[sourceRow - chunkTo] ?? "");
+				}
 			}
 		}
 		let buffer = this.#paintBeginSequence + this.#leaveResizeAltSequence() + options.leadingSequence + purgeSequence;
@@ -5035,10 +5046,12 @@ export class TUI extends Container {
 		} else {
 			// ConPTY-truncated replay: leading rows were dropped, so frame-space
 			// positions are unknown — placements still clip to the write row but
-			// skip epoch bookkeeping.
+			// skip epoch bookkeeping. `paintMainLines` maps the exact retained
+			// source slice so sidebar composition cannot hide image/OSC metadata.
 			for (let i = 0; i < paintLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				const line = visibleTexts && i >= visibleStart ? visibleTexts[i - visibleStart] : (paintLines[i] ?? "");
+				const mainLine = paintMainLines?.[i] ?? line;
 				const writeRow = Math.min(i, height - 1);
 				buffer += options.clearScrollback
 					? this.#lineRewriteSequence(
@@ -5047,9 +5060,11 @@ export class TUI extends Container {
 							writeRow,
 							-1,
 							chunkTo,
-							this.#osc66SpacerGlyphWidth(paintLines, i),
+							this.#osc66SpacerGlyphWidth(paintMainLines ?? paintLines, i),
+							mainLine,
+							options.sidebarLayout,
 						)
-					: this.#terminalLine(line, writeRow, -1, chunkTo);
+					: this.#terminalLine(line, writeRow, -1, chunkTo, mainLine, options.sidebarLayout);
 			}
 		}
 		buffer += fillSequence;
@@ -5512,7 +5527,8 @@ export class TUI extends Container {
 								options.sidebarLayout,
 							);
 							if (suffix.length > 0) {
-								buffer += suffix + LINE_TERMINATOR + ERASE_TO_END_OF_LINE;
+								buffer += suffix + LINE_TERMINATOR;
+								if (visibleWidth(line) < width) buffer += ERASE_TO_END_OF_LINE;
 								continue;
 							}
 						}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3966,7 +3966,7 @@ export class TUI extends Container {
 		// remainder removes committed rows — drop the commit seam by it and let
 		// the next chunk re-commit them. A short frame gains blank rows instead
 		// of pulling.
-		if (fullPaint || widthChanged) {
+		if (fullPaint || widthEpochOccurred) {
 			this.#muxPushedRows = 0;
 		} else if (
 			geometryChanged &&
@@ -4057,7 +4057,7 @@ export class TUI extends Container {
 			windowTop = Math.max(0, frameLength - height);
 			chunkTo = windowTop;
 			this.#committedRows = windowTop;
-			if (widthChanged) {
+			if (widthEpochOccurred) {
 				// A rewrap invalidated the recorded bytes: re-base the audit prefix
 				// at the new width so the accepted wrap drift does not read as a
 				// violation on the next ordinary frame.
@@ -4091,7 +4091,7 @@ export class TUI extends Container {
 				hasVisibleOverlay || geometryChanged
 					? this.#committedRows
 					: Math.min(windowTop, Math.max(this.#committedRows, commitCeiling));
-			if (widthChanged) {
+			if (widthEpochOccurred) {
 				committedPrefixResliced = true;
 				this.#committedPrefix = rawFrame.slice(0, this.#committedRows);
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -198,6 +198,13 @@ interface RightSidebarRegistration {
 	options: RightSidebarOptions;
 }
 
+interface ActiveViewportLayout {
+	terminalWidth: number;
+	mainWidth: number;
+	height: number;
+	sidebar: ResolvedRightSidebarLayout;
+}
+
 const DEFAULT_RIGHT_SIDEBAR_OPTIONS: RightSidebarOptions = {
 	width: 44,
 	minWidth: 28,
@@ -1554,6 +1561,24 @@ export class TUI extends Container {
 				};
 	}
 
+	#activeViewportLayout(): ActiveViewportLayout {
+		const terminalWidth = this.terminal.columns;
+		const sidebar = this.#resolveRightSidebar(terminalWidth);
+		return {
+			terminalWidth,
+			mainWidth: sidebar.mainWidth,
+			height: this.terminal.rows,
+			sidebar,
+		};
+	}
+
+	#composeRightSidebarIntoWindow(window: string[], layout: ResolvedRightSidebarLayout): string[] {
+		const registration = this.#rightSidebar;
+		if (!layout.visible || !registration) return window;
+		const sidebarLines = registration.component.render(layout.sidebarContentWidth);
+		return [...composeRightSidebar(window, sidebarLines, layout)];
+	}
+
 	override captureNativeScrollbackWidthEpoch(): unknown {
 		const liveSource = this.#frameSegments.findIndex(segment => segment.liveLocalStart !== undefined);
 		const indices = Array.from({ length: this.#frameSegments.length }, (_value, index) => index)
@@ -2174,6 +2199,7 @@ export class TUI extends Container {
 
 	override invalidate(): void {
 		super.invalidate();
+		this.#rightSidebar?.component.invalidate?.();
 		for (const overlay of this.overlayStack) overlay.component.invalidate?.();
 	}
 
@@ -2622,10 +2648,12 @@ export class TUI extends Container {
 			return;
 		}
 
-		const terminalWidth = this.terminal.columns;
-		const height = this.terminal.rows;
-		const sidebarLayout = this.#resolveRightSidebar(terminalWidth);
-		const mainWidth = sidebarLayout.mainWidth;
+		const {
+			terminalWidth,
+			height,
+			mainWidth,
+			sidebar: sidebarLayout,
+		} = this.#activeViewportLayout();
 		if (!this.#hasEverRendered || this.#resizeEventPending) {
 			this.requestComponentRender(component);
 			return;
@@ -3490,10 +3518,13 @@ export class TUI extends Container {
 	 */
 	#doRender(): void {
 		if (this.#stopped) return;
-		const terminalWidth = this.terminal.columns;
-		const height = this.terminal.rows;
-		const sidebarLayout = this.#resolveRightSidebar(terminalWidth);
-		const mainWidth = sidebarLayout.mainWidth;
+		const layout = this.#activeViewportLayout();
+		const {
+			terminalWidth,
+			height,
+			mainWidth,
+			sidebar: sidebarLayout,
+		} = layout;
 		const contentWidthChanged = this.#composeWidth >= 0 && mainWidth !== this.#composeWidth;
 
 		// Consume the component-scoped accumulation: it describes the render
@@ -3596,7 +3627,7 @@ export class TUI extends Container {
 		// (overlay resizes are not on the drag-cost hot path).
 		if (this.#resizeViewportActive && this.#hasEverRendered && this.#getTopmostVisibleOverlay() === undefined) {
 			this.#componentRenderTargets.clear();
-			this.#renderResizeViewport(terminalWidth, height);
+			this.#renderResizeViewport(layout);
 			return;
 		}
 
@@ -4032,10 +4063,7 @@ export class TUI extends Container {
 		const frame = this.#prepareFrame(rawFrame, mainWidth);
 		let window: string[] = new Array(height);
 		for (let r = 0; r < height; r++) window[r] = frame[windowTop + r] ?? "";
-		if (sidebarLayout.visible && this.#rightSidebar) {
-			const sidebarLines = this.#rightSidebar.component.render(sidebarLayout.sidebarContentWidth);
-			window = [...composeRightSidebar(window, sidebarLines, sidebarLayout)];
-		}
+		window = this.#composeRightSidebarIntoWindow(window, sidebarLayout);
 		if (hasVisibleOverlay) {
 			window = this.#compositeOverlaysIntoWindow(window, terminalWidth, height);
 			const overlayMarkers = this.#extractCursorMarkers(window);
@@ -5005,8 +5033,9 @@ export class TUI extends Container {
 	 * `#commit` nor `#emitFullPaint`, so the settle full paint reconciles against
 	 * the pre-drag screen state.
 	 */
-	#renderResizeViewport(width: number, height: number): void {
-		if (width <= 0 || height <= 0) return;
+	#renderResizeViewport(layout: ActiveViewportLayout): void {
+		const { terminalWidth, mainWidth, height } = layout;
+		if (terminalWidth <= 0 || mainWidth <= 0 || height <= 0) return;
 		// Tail renders call block.render(), which observes inline images on the
 		// budget. This is a STABLE (partial) pass: the tail walk is bottom-up and
 		// sees only the visible subset, so display-order-by-call-order is wrong
@@ -5017,8 +5046,8 @@ export class TUI extends Container {
 		// off a partial walk. The settle paint's own beginPass()/endPass() is the
 		// authoritative accounting, and its beginPass() wipes these frames.
 		this.#imageBudget.beginPass(true);
-		const { framed, viewportTop, contentRows } = this.#composeResizeViewport(width, height);
-		this.#emitResizeViewport(framed, viewportTop, height, contentRows, width);
+		const { framed, viewportTop, contentRows } = this.#composeResizeViewport(layout);
+		this.#emitResizeViewport(framed, viewportTop, height, contentRows, terminalWidth);
 		this.#resizeViewportPaintCount += 1;
 	}
 
@@ -5042,16 +5071,18 @@ export class TUI extends Container {
 	 * (issue #8318).
 	 */
 	#composeResizeViewport(
-		width: number,
-		height: number,
+		layout: ActiveViewportLayout,
 	): { framed: readonly string[]; viewportTop: number; contentRows: number } {
+		const { mainWidth, height } = layout;
 		const maxRows = height + TUI.#OSC66_MAX_SPACER_ROWS;
 		const tail: string[] = []; // bottom-first: viewport rows plus context above
 		const children = this.children;
 		for (let i = children.length - 1; i >= 0 && tail.length < maxRows; i--) {
 			const child = children[i]!;
 			const provider = asViewportTailProvider(child);
-			const rows = provider ? provider.renderViewportTail(width, maxRows - tail.length) : child.render(width);
+			const rows = provider
+				? provider.renderViewportTail(mainWidth, maxRows - tail.length)
+				: child.render(mainWidth);
 			for (let r = rows.length - 1; r >= 0 && tail.length < maxRows; r--) {
 				tail.push(rows[r]!);
 			}
@@ -5069,7 +5100,14 @@ export class TUI extends Container {
 		const framed: string[] = new Array(extra + height);
 		for (let k = 0; k < extra; k++) framed[k] = tail[tail.length - 1 - k]!;
 		for (let screenRow = 0; screenRow < height; screenRow++) framed[extra + screenRow] = window[screenRow]!;
-		return { framed: this.#prepareLinesArray(framed, width), viewportTop: extra, contentRows };
+		const prepared = this.#prepareLinesArray(framed, mainWidth);
+		if (layout.sidebar.visible) {
+			const composedWindow = this.#composeRightSidebarIntoWindow(prepared.slice(extra), layout.sidebar);
+			for (let screenRow = 0; screenRow < height; screenRow++) {
+				prepared[extra + screenRow] = composedWindow[screenRow]!;
+			}
+		}
+		return { framed: prepared, viewportTop: extra, contentRows };
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -22,6 +22,12 @@ import { DEFAULT_MAX_INLINE_IMAGES, ImageBudget } from "./components/image";
 import { planDeccaraFills } from "./deccara";
 import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
+import {
+	composeRightSidebar,
+	resolveRightSidebarLayout,
+	type ResolvedRightSidebarLayout,
+	type RightSidebarOptions,
+} from "./reserved-sidebar";
 import { isConPTYHosted, setAltScreenActive, type Terminal } from "./terminal";
 import {
 	encodeKittyDeleteImage,
@@ -186,6 +192,17 @@ export interface Component {
 	 */
 	dispose?(): void;
 }
+
+interface RightSidebarRegistration {
+	component: Component;
+	options: RightSidebarOptions;
+}
+
+const DEFAULT_RIGHT_SIDEBAR_OPTIONS: RightSidebarOptions = {
+	width: 44,
+	minWidth: 28,
+	minMainWidth: 64,
+};
 
 /** Lets an overlay root delegate keyboard focus to components it owns. */
 export interface OverlayFocusOwner {
@@ -1493,6 +1510,8 @@ export class TUI extends Container {
 	#preparedMeta: PreparedLine[] = [];
 	#preparedValidRows = 0;
 
+	#rightSidebar: RightSidebarRegistration | undefined;
+
 	// Overlay stack for modal components rendered on top of base content
 	overlayStack: {
 		component: Component;
@@ -1507,6 +1526,32 @@ export class TUI extends Container {
 		this.#renderScheduler = options?.renderScheduler ?? DEFAULT_RENDER_SCHEDULER;
 		this.#showHardwareCursor = showHardwareCursor === undefined ? this.#showHardwareCursor : showHardwareCursor;
 		this.#watchdog = new LoopWatchdog();
+	}
+
+	setRightSidebar(
+		component: Component | undefined,
+		options: RightSidebarOptions = DEFAULT_RIGHT_SIDEBAR_OPTIONS,
+	): void {
+		if (component === undefined) {
+			if (this.#rightSidebar === undefined) return;
+			this.#rightSidebar = undefined;
+		} else {
+			this.#rightSidebar = { component, options };
+		}
+		this.requestRender(true, { clearScrollback: !isMultiplexerSession() });
+	}
+
+	#resolveRightSidebar(terminalWidth: number): ResolvedRightSidebarLayout {
+		const registration = this.#rightSidebar;
+		return registration
+			? resolveRightSidebarLayout(terminalWidth, registration.options)
+			: {
+					terminalWidth,
+					mainWidth: terminalWidth,
+					sidebarWidth: 0,
+					sidebarContentWidth: 0,
+					visible: false,
+				};
 	}
 
 	override captureNativeScrollbackWidthEpoch(): unknown {
@@ -3415,8 +3460,11 @@ export class TUI extends Container {
 	 */
 	#doRender(): void {
 		if (this.#stopped) return;
-		const width = this.terminal.columns;
+		const terminalWidth = this.terminal.columns;
 		const height = this.terminal.rows;
+		const sidebarLayout = this.#resolveRightSidebar(terminalWidth);
+		const mainWidth = sidebarLayout.mainWidth;
+		const contentWidthChanged = mainWidth !== this.#composeWidth;
 
 		// Consume the component-scoped accumulation: it describes the render
 		// requests made up to this frame, whichever path the frame takes.
@@ -3444,7 +3492,7 @@ export class TUI extends Container {
 			this.#altActive = true;
 			this.#altMouseTrackingActive = wantMouseTracking;
 			this.#altPreviousLines = [];
-			this.#altEnterWidth = width;
+			this.#altEnterWidth = terminalWidth;
 			this.#altEnterHeight = height;
 			this.#altWidthEpochBoundary = this.captureNativeScrollbackWidthEpoch();
 		} else if (!wantAlt && this.#altActive) {
@@ -3473,9 +3521,9 @@ export class TUI extends Container {
 			// toggles — the Warp-class quirk. Latch the in-place resize path so
 			// this exit and the revert SIGWINCH repaint without an ED3 scrollback
 			// rewrap instead of flashing a destructive full paint (#6511).
-			if (width !== this.#altEnterWidth || height !== this.#altEnterHeight) {
+			if (terminalWidth !== this.#altEnterWidth || height !== this.#altEnterHeight) {
 				this.#resizeEventPending = true;
-				if (width === this.#altEnterWidth) this.#altToggleResizesInPlace = true;
+				if (terminalWidth === this.#altEnterWidth) this.#altToggleResizesInPlace = true;
 			}
 		} else if (wantMouseTracking !== this.#altMouseTrackingActive) {
 			this.terminal.write(wantMouseTracking ? MOUSE_TRACKING_ON : MOUSE_TRACKING_OFF);
@@ -3483,7 +3531,7 @@ export class TUI extends Container {
 		}
 		if (this.#altActive) {
 			this.#componentRenderTargets.clear();
-			this.#renderAltFrame(width, height);
+			this.#renderAltFrame(terminalWidth, height);
 			return;
 		}
 
@@ -3518,7 +3566,7 @@ export class TUI extends Container {
 		// (overlay resizes are not on the drag-cost hot path).
 		if (this.#resizeViewportActive && this.#hasEverRendered && this.#getTopmostVisibleOverlay() === undefined) {
 			this.#componentRenderTargets.clear();
-			this.#renderResizeViewport(width, height);
+			this.#renderResizeViewport(terminalWidth, height);
 			return;
 		}
 
@@ -3531,7 +3579,8 @@ export class TUI extends Container {
 			!this.#resizeRepaintsInPlace() &&
 			(this.#clearScrollbackOnNextRender ||
 				this.#resizeEventPending ||
-				(this.#previousWidth > 0 && this.#previousWidth !== width) ||
+				contentWidthChanged ||
+				(this.#previousWidth > 0 && this.#previousWidth !== terminalWidth) ||
 				(this.#previousHeight > 0 && this.#previousHeight !== height));
 		if (replayFullHistory) {
 			for (const child of this.children) prepareNativeScrollbackReplay(child);
@@ -3543,19 +3592,19 @@ export class TUI extends Container {
 		// a quiescent budget, and a partial tree walk would under-count display
 		// order — and re-renders only the requested root subtrees, reusing the
 		// previous segment of every other root child.
-		const partialRoots = componentScopedOnly ? this.#resolvePartialComposeRoots(width, height) : null;
+		const partialRoots = componentScopedOnly ? this.#resolvePartialComposeRoots(terminalWidth, height) : null;
 		this.#componentRenderTargets.clear();
 		let rawFrame: readonly string[];
 		if (partialRoots !== null) {
 			this.#partialComposeRoots = partialRoots;
 			try {
-				rawFrame = this.render(width);
+				rawFrame = this.render(mainWidth);
 			} finally {
 				this.#partialComposeRoots = null;
 			}
 		} else {
 			this.#imageBudget.beginPass();
-			rawFrame = this.render(width);
+			rawFrame = this.render(mainWidth);
 			this.#imageBudget.endPass();
 		}
 		// Ghostty initial-image deferral must run before any render state is
@@ -3594,8 +3643,9 @@ export class TUI extends Container {
 		const resizeHadPendingRender = this.#multiplexerResizeHasPendingRender;
 		this.#multiplexerResizeHasPendingRender = false;
 		if (resizeEventOccurred) this.#forgetHardwareCursorState();
-		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
-		const widthEpochOccurred = widthChanged || (resizeEventOccurred && this.#multiplexerWidthEpochPending);
+		const terminalWidthChanged = this.#previousWidth > 0 && this.#previousWidth !== terminalWidth;
+		const widthEpochOccurred =
+			contentWidthChanged || terminalWidthChanged || (resizeEventOccurred && this.#multiplexerWidthEpochPending);
 		const capturedWidthEpochBoundary = this.#multiplexerWidthEpochBoundary;
 		const widthEpochBoundary = this.#widthEpochOverlayBoundary ?? capturedWidthEpochBoundary;
 		const widthEpochSourceBoundary = widthEpochOccurred
@@ -3617,7 +3667,7 @@ export class TUI extends Container {
 		const heightChanged =
 			(this.#previousHeight > 0 && this.#previousHeight !== height) ||
 			(resizeEventOccurred && this.#previousHeight > 0);
-		const geometryChanged = widthChanged || heightChanged;
+		const geometryChanged = contentWidthChanged || terminalWidthChanged || heightChanged;
 		const widthEpochReset = widthEpochOccurred && this.#resizeRepaintsInPlace();
 		// A later width reset cannot use the opaque native ledger against
 		// attachment rows from the current-width placement epoch. Capture that
@@ -3947,16 +3997,20 @@ export class TUI extends Container {
 				break;
 			}
 		}
-		const frame = this.#prepareFrame(rawFrame, width);
+		const frame = this.#prepareFrame(rawFrame, mainWidth);
 		let window: string[] = new Array(height);
 		for (let r = 0; r < height; r++) window[r] = frame[windowTop + r] ?? "";
+		if (sidebarLayout.visible && this.#rightSidebar) {
+			const sidebarLines = this.#rightSidebar.component.render(sidebarLayout.sidebarContentWidth);
+			window = [...composeRightSidebar(window, sidebarLines, sidebarLayout)];
+		}
 		if (hasVisibleOverlay) {
-			window = this.#compositeOverlaysIntoWindow(window, width, height);
+			window = this.#compositeOverlaysIntoWindow(window, terminalWidth, height);
 			const overlayMarkers = this.#extractCursorMarkers(window);
 			if (overlayMarkers.length > 0) {
 				cursorPos = { row: windowTop + overlayMarkers[0]!.row, col: overlayMarkers[0]!.col };
 			}
-			window = this.#prepareLinesArray(window, width);
+			window = this.#prepareLinesArray(window, terminalWidth);
 		}
 		const cursorTrackingLineCount = hasVisibleOverlay ? Math.max(frame.length, windowTop + height) : frame.length;
 
@@ -4006,7 +4060,7 @@ export class TUI extends Container {
 
 		// 6. Emit.
 		if (intent.kind === "fullPaint") {
-			this.#emitFullPaint(frame, window, width, height, cursorPos, purgeSequence, imageTransmitBuffer, {
+			this.#emitFullPaint(frame, window, terminalWidth, height, cursorPos, purgeSequence, imageTransmitBuffer, {
 				clearScrollback: intent.clearScrollback,
 				chunkTo,
 				windowTop,
@@ -4074,7 +4128,7 @@ export class TUI extends Container {
 				commitTo = commitFrom;
 			}
 			this.#imageBudget.observeCommitWatermark(commitTo);
-			this.#emitWidthEpochBaseline(frame, window, width, height, cursorPos, purgeSequence, imageTransmitBuffer, {
+			this.#emitWidthEpochBaseline(frame, window, terminalWidth, height, cursorPos, purgeSequence, imageTransmitBuffer, {
 				repaintFromScreenRow: 0,
 				commitFrom,
 				commitTo,
@@ -4155,7 +4209,7 @@ export class TUI extends Container {
 		if (imageTransmitBuffer.length > 0) {
 			this.terminal.write(imageTransmitBuffer);
 		}
-		this.#emitUpdate(frame, window, width, height, cursorPos, purgeSequence, {
+		this.#emitUpdate(frame, window, terminalWidth, height, cursorPos, purgeSequence, {
 			chunkTo,
 			windowTop,
 			prevWindowTop,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -24,6 +24,7 @@ import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
 import {
 	composeRightSidebar,
+	RIGHT_SIDEBAR_BOUNDARY_RESET,
 	type ResolvedRightSidebarLayout,
 	type RightSidebarOptions,
 	resolveRightSidebarLayout,
@@ -1370,6 +1371,9 @@ export class TUI extends Container {
 	#windowTopRow = 0;
 	// Exactly what is painted on the screen rows (post-composite, prepared).
 	#previousWindow: string[] = [];
+	// Main-only rows corresponding to #previousWindow. Sidebar composition is
+	// viewport-local and must never participate in scroll-append/history checks.
+	#previousMainWindow: string[] = [];
 	#nativeScrollbackLiveRegionStart: number | undefined;
 	#nativeScrollbackLiveRegionPinned = false;
 	// Start row of the topmost live region that pinned itself. The topmost seam
@@ -1539,13 +1543,23 @@ export class TUI extends Container {
 		component: Component | undefined,
 		options: RightSidebarOptions = DEFAULT_RIGHT_SIDEBAR_OPTIONS,
 	): void {
+		const previousLayout = this.#resolveRightSidebar(this.terminal.columns);
 		if (component === undefined) {
 			if (this.#rightSidebar === undefined) return;
 			this.#rightSidebar = undefined;
 		} else {
 			this.#rightSidebar = { component, options };
 		}
-		this.requestRender(true, { clearScrollback: this.#hasEverRendered && !isMultiplexerSession() });
+		const nextLayout = this.#resolveRightSidebar(this.terminal.columns);
+		const geometryChanged =
+			previousLayout.visible !== nextLayout.visible ||
+			previousLayout.mainWidth !== nextLayout.mainWidth ||
+			previousLayout.sidebarWidth !== nextLayout.sidebarWidth;
+		if (geometryChanged) {
+			this.requestRender(true, { clearScrollback: this.#hasEverRendered && !isMultiplexerSession() });
+		} else {
+			this.requestRender();
+		}
 	}
 
 	#resolveRightSidebar(terminalWidth: number): ResolvedRightSidebarLayout {
@@ -2074,6 +2088,13 @@ export class TUI extends Container {
 	}
 
 	setFocus(component: Component | null): void {
+		if (
+			component !== null &&
+			this.#rightSidebar !== undefined &&
+			subtreeContains(this.#rightSidebar.component, component)
+		) {
+			return;
+		}
 		const topVisibleOverlay = this.#getTopmostVisibleOverlay();
 		if (topVisibleOverlay && !isOverlayFocusTarget(topVisibleOverlay.component, component)) {
 			const currentFocus = this.#focusedComponent;
@@ -2747,9 +2768,12 @@ export class TUI extends Container {
 		let firstChanged = -1;
 		let lastChanged = -1;
 		const previousWindow = this.#previousWindow;
+		const previousMainWindow = this.#previousMainWindow;
 		for (let i = 0; i < nextWindowLines.length; i++) {
 			const line = nextWindowLines[i]!;
-			if (previousWindow[screenStart + i] === line) continue;
+			const unchanged = previousWindow[screenStart + i] === line;
+			previousMainWindow[screenStart + i] = mainWindowLines[i] ?? "";
+			if (unchanged) continue;
 			previousWindow[screenStart + i] = line;
 			if (firstChanged === -1) firstChanged = i;
 			lastChanged = i;
@@ -2791,6 +2815,8 @@ export class TUI extends Container {
 				segment.start + i,
 				this.#committedRows,
 				this.#osc66SpacerGlyphWidth(this.#preparedFrame, segment.start + i),
+				mainWindowLines[i] ?? "",
+				sidebarLayout,
 			);
 		}
 		const cursorControl = this.#cursorControlSequence(
@@ -2802,7 +2828,7 @@ export class TUI extends Container {
 		buffer += this.#paintEndSequence;
 		this.terminal.write(buffer);
 		this.#windowTopRow = windowTop;
-		this.#commit(this.#composedFrame, previousWindow, terminalWidth, height, cursorControl);
+		this.#commit(this.#composedFrame, previousWindow, previousMainWindow, terminalWidth, height, cursorControl);
 	}
 
 	#postFullPaintSettleDelay(): number {
@@ -3496,8 +3522,38 @@ export class TUI extends Container {
 		});
 	}
 
-	#terminalLine(line: string, screenRow = -1, frameRow = -1, committedTo = -1): string {
-		if (TERMINAL.isImageLine(line)) return this.#imageLineSequence(line, screenRow, frameRow, committedTo);
+	#rightSidebarSuffixSequence(
+		line: string,
+		mainLine: string,
+		layout: ResolvedRightSidebarLayout | undefined,
+	): string {
+		if (!layout?.visible) return "";
+		const main = truncateToWidth(mainLine, layout.mainWidth);
+		if (!line.startsWith(main)) return "";
+		const paddingWidth = Math.max(0, layout.mainWidth - visibleWidth(main));
+		const suffixOffset = main.length + RIGHT_SIDEBAR_BOUNDARY_RESET.length + paddingWidth;
+		if (suffixOffset > line.length) return "";
+		const suffix = line.slice(suffixOffset);
+		const moveToBoundary = layout.mainWidth > 0 ? `\x1b[${layout.mainWidth}C` : "";
+		return `${RIGHT_SIDEBAR_BOUNDARY_RESET}\r${moveToBoundary}${suffix}`;
+	}
+
+	#terminalLine(
+		line: string,
+		screenRow = -1,
+		frameRow = -1,
+		committedTo = -1,
+		mainLine = line,
+		sidebarLayout?: ResolvedRightSidebarLayout,
+	): string {
+		if (TERMINAL.isImageLine(mainLine)) {
+			if (mainLine === line) return this.#imageLineSequence(mainLine, screenRow, frameRow, committedTo);
+			const suffix = this.#rightSidebarSuffixSequence(line, mainLine, sidebarLayout);
+			if (suffix.length > 0) {
+				const placement = this.#imageLineSequence(mainLine, screenRow, frameRow, committedTo);
+				return placement + suffix + LINE_TERMINATOR;
+			}
+		}
 		const coalesced = coalesceAdjacentSgr(line);
 		return coalesced + (line.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET);
 	}
@@ -4051,9 +4107,9 @@ export class TUI extends Container {
 			}
 		}
 		const frame = this.#prepareFrame(rawFrame, mainWidth);
-		let window: string[] = new Array(height);
-		for (let r = 0; r < height; r++) window[r] = frame[windowTop + r] ?? "";
-		window = this.#composeRightSidebarIntoWindow(window, sidebarLayout);
+		const mainWindow: string[] = new Array(height);
+		for (let r = 0; r < height; r++) mainWindow[r] = frame[windowTop + r] ?? "";
+		let window = this.#composeRightSidebarIntoWindow(mainWindow, sidebarLayout);
 		if (hasVisibleOverlay) {
 			window = this.#compositeOverlaysIntoWindow(window, terminalWidth, height);
 			const overlayMarkers = this.#extractCursorMarkers(window);
@@ -4111,6 +4167,8 @@ export class TUI extends Container {
 		// 6. Emit.
 		if (intent.kind === "fullPaint") {
 			this.#emitFullPaint(frame, window, terminalWidth, height, cursorPos, purgeSequence, imageTransmitBuffer, {
+				mainWindow,
+				sidebarLayout,
 				clearScrollback: intent.clearScrollback,
 				chunkTo,
 				windowTop,
@@ -4181,6 +4239,8 @@ export class TUI extends Container {
 			this.#emitWidthEpochBaseline(
 				frame,
 				window,
+				mainWindow,
+				sidebarLayout,
 				terminalWidth,
 				height,
 				cursorPos,
@@ -4269,6 +4329,8 @@ export class TUI extends Container {
 			this.terminal.write(imageTransmitBuffer);
 		}
 		this.#emitUpdate(frame, window, terminalWidth, height, cursorPos, purgeSequence, {
+			mainWindow,
+			sidebarLayout,
 			chunkTo,
 			windowTop,
 			prevWindowTop,
@@ -4570,6 +4632,8 @@ export class TUI extends Container {
 		frameRow = -1,
 		committedTo = -1,
 		spacerGlyphWidth = -1,
+		mainLine = line,
+		sidebarLayout?: ResolvedRightSidebarLayout,
 	): string {
 		// Reserved lower half of a scaled OSC 66 heading. The glyph re-emitted on
 		// the row above owns columns `[0, spacerGlyphWidth)` here, so preserve
@@ -4579,10 +4643,13 @@ export class TUI extends Container {
 		// keeps the erase on the default background (BCE).
 		if (spacerGlyphWidth >= 0) {
 			if (spacerGlyphWidth >= width) return "";
-			return `${SEGMENT_RESET}\x1b[${spacerGlyphWidth}C${ERASE_TO_END_OF_LINE}`;
+			let sequence = `${SEGMENT_RESET}\x1b[${spacerGlyphWidth}C${ERASE_TO_END_OF_LINE}`;
+			const suffix = this.#rightSidebarSuffixSequence(line, mainLine, sidebarLayout);
+			if (suffix.length > 0) sequence += suffix + LINE_TERMINATOR;
+			return sequence;
 		}
-		if (TERMINAL.isImageLine(line)) {
-			return ERASE_LINE + this.#imageLineSequence(line, screenRow, frameRow, committedTo);
+		if (TERMINAL.isImageLine(mainLine)) {
+			return ERASE_LINE + this.#terminalLine(line, screenRow, frameRow, committedTo, mainLine, sidebarLayout);
 		}
 		const terminalLine = this.#terminalLine(line);
 		const asciiWidth = this.#ansiAsciiLineWidth(line, width);
@@ -4607,12 +4674,14 @@ export class TUI extends Container {
 	#commit(
 		lines: readonly string[],
 		window: string[],
+		mainWindow: string[],
 		width: number,
 		height: number,
 		hardwareCursor: HardwareCursorUpdate,
 	): void {
 		this.#previousFrameLength = lines.length;
 		this.#previousWindow = window;
+		this.#previousMainWindow = mainWindow;
 		this.#forceViewportRepaintOnNextRender = false;
 		this.#previousWidth = width;
 		this.#previousHeight = height;
@@ -4677,6 +4746,8 @@ export class TUI extends Container {
 	#emitWidthEpochBaseline(
 		frame: readonly string[],
 		window: string[],
+		mainWindow: string[],
+		sidebarLayout: ResolvedRightSidebarLayout,
 		width: number,
 		height: number,
 		cursorPos: { row: number; col: number } | null,
@@ -4730,6 +4801,9 @@ export class TUI extends Container {
 						screenRow,
 						options.windowTop + screenRow,
 						options.commitTo,
+						this.#osc66SpacerGlyphWidth(frame, options.windowTop + screenRow),
+						mainWindow[screenRow] ?? "",
+						sidebarLayout,
 					);
 				}
 			} else {
@@ -4754,6 +4828,9 @@ export class TUI extends Container {
 						Math.min(options.commitTo - options.commitFrom + screenRow, height - 1),
 						options.windowTop + screenRow,
 						options.commitTo,
+						this.#osc66SpacerGlyphWidth(frame, options.windowTop + screenRow),
+						mainWindow[screenRow] ?? "",
+						sidebarLayout,
 					);
 					wroteLine = true;
 				}
@@ -4767,6 +4844,9 @@ export class TUI extends Container {
 					screenRow,
 					options.windowTop + screenRow,
 					options.commitTo,
+					this.#osc66SpacerGlyphWidth(frame, options.windowTop + screenRow),
+					mainWindow[screenRow] ?? "",
+					sidebarLayout,
 				);
 			}
 		}
@@ -4784,7 +4864,7 @@ export class TUI extends Container {
 		buffer += this.#paintEndSequence;
 		this.terminal.write(buffer);
 
-		this.#commit(frame, window, width, height, {
+		this.#commit(frame, window, mainWindow, width, height, {
 			toRow: target?.row ?? contentBottomRow,
 			state: target,
 			visible: target?.visible ?? false,
@@ -4806,6 +4886,8 @@ export class TUI extends Container {
 		purgeSequence: string,
 		imageTransmitBuffer: string,
 		options: {
+			mainWindow: string[];
+			sidebarLayout: ResolvedRightSidebarLayout;
 			clearScrollback: boolean;
 			chunkTo: number;
 			windowTop: number;
@@ -4938,8 +5020,17 @@ export class TUI extends Container {
 							frameRow,
 							chunkTo,
 							this.#osc66SpacerGlyphWidth(frame, frameRow),
+							options.mainWindow[screenRow] ?? "",
+							options.sidebarLayout,
 						)
-					: this.#terminalLine(line, writeRow, frameRow, chunkTo);
+					: this.#terminalLine(
+							line,
+							writeRow,
+							frameRow,
+							chunkTo,
+							options.mainWindow[screenRow] ?? "",
+							options.sidebarLayout,
+						);
 			}
 		} else {
 			// ConPTY-truncated replay: leading rows were dropped, so frame-space
@@ -4992,7 +5083,7 @@ export class TUI extends Container {
 
 		this.#committedRows = chunkTo;
 		this.#windowTopRow = windowTop;
-		this.#commit(frame, window, width, height, committedCursor);
+		this.#commit(frame, window, options.mainWindow, width, height, committedCursor);
 	}
 
 	/**
@@ -5045,8 +5136,16 @@ export class TUI extends Container {
 		// off a partial walk. The settle paint's own beginPass()/endPass() is the
 		// authoritative accounting, and its beginPass() wipes these frames.
 		this.#imageBudget.beginPass(true);
-		const { framed, viewportTop, contentRows } = this.#composeResizeViewport(layout);
-		this.#emitResizeViewport(framed, viewportTop, height, contentRows, terminalWidth);
+		const { framed, mainFramed, viewportTop, contentRows } = this.#composeResizeViewport(layout);
+		this.#emitResizeViewport(
+			framed,
+			mainFramed,
+			layout.sidebar,
+			viewportTop,
+			height,
+			contentRows,
+			terminalWidth,
+		);
 		this.#resizeViewportPaintCount += 1;
 	}
 
@@ -5071,6 +5170,7 @@ export class TUI extends Container {
 	 */
 	#composeResizeViewport(layout: ActiveViewportLayout): {
 		framed: readonly string[];
+		mainFramed: readonly string[];
 		viewportTop: number;
 		contentRows: number;
 	} {
@@ -5101,14 +5201,16 @@ export class TUI extends Container {
 		const framed: string[] = new Array(extra + height);
 		for (let k = 0; k < extra; k++) framed[k] = tail[tail.length - 1 - k]!;
 		for (let screenRow = 0; screenRow < height; screenRow++) framed[extra + screenRow] = window[screenRow]!;
-		const prepared = this.#prepareLinesArray(framed, mainWidth);
+		const mainFramed = this.#prepareLinesArray(framed, mainWidth);
+		let paintedFramed = mainFramed;
 		if (layout.sidebar.visible) {
-			const composedWindow = this.#composeRightSidebarIntoWindow(prepared.slice(extra), layout.sidebar);
+			paintedFramed = mainFramed.slice();
+			const composedWindow = this.#composeRightSidebarIntoWindow(mainFramed.slice(extra), layout.sidebar);
 			for (let screenRow = 0; screenRow < height; screenRow++) {
-				prepared[extra + screenRow] = composedWindow[screenRow]!;
+				paintedFramed[extra + screenRow] = composedWindow[screenRow]!;
 			}
 		}
-		return { framed: prepared, viewportTop: extra, contentRows };
+		return { framed: paintedFramed, mainFramed, viewportTop: extra, contentRows };
 	}
 
 	/**
@@ -5180,6 +5282,8 @@ export class TUI extends Container {
 	 */
 	#emitResizeViewport(
 		framed: readonly string[],
+		mainFramed: readonly string[],
+		sidebarLayout: ResolvedRightSidebarLayout,
 		viewportTop: number,
 		height: number,
 		contentRows: number,
@@ -5200,7 +5304,9 @@ export class TUI extends Container {
 				r,
 				-1,
 				this.#committedRows,
-				this.#osc66SpacerGlyphWidth(framed, idx),
+				this.#osc66SpacerGlyphWidth(mainFramed, idx),
+				mainFramed[idx] ?? "",
+				sidebarLayout,
 			);
 		}
 		// Park the hardware cursor at the real content bottom, not the padded
@@ -5299,6 +5405,8 @@ export class TUI extends Container {
 		cursorPos: { row: number; col: number } | null,
 		purgeSequence: string,
 		options: {
+			mainWindow: string[];
+			sidebarLayout: ResolvedRightSidebarLayout;
 			chunkTo: number;
 			windowTop: number;
 			prevWindowTop: number;
@@ -5321,6 +5429,7 @@ export class TUI extends Container {
 		const chunkLength = chunkTo - chunkFrom;
 		const scroll = windowTop - prevWindowTop;
 		const previousWindow = this.#previousWindow;
+		const previousMainWindow = this.#previousMainWindow;
 		const contentRows = Math.max(1, Math.min(height, frame.length - windowTop));
 		const contentBottomRow = windowTop + contentRows - 1;
 		// Terminals clamp the hardware cursor to the viewport on resize; clamp
@@ -5337,16 +5446,44 @@ export class TUI extends Container {
 			scroll < height &&
 			chunkFrom === prevWindowTop
 		) {
-			let prefixIntact = previousWindow.length === height;
+			let prefixIntact = previousMainWindow.length === height;
 			for (let i = 0; prefixIntact && i < chunkLength; i++) {
-				if (previousWindow[i] !== frame[chunkFrom + i]) prefixIntact = false;
+				if (previousMainWindow[i] !== frame[chunkFrom + i]) prefixIntact = false;
 			}
 			if (prefixIntact) {
 				let buffer = this.#paintBeginSequence + purgeSequence;
-				const moveToBottom = height - 1 - currentScreenRow;
-				if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
+				if (options.sidebarLayout.visible) {
+					if (currentScreenRow > 0) buffer += `\x1b[${currentScreenRow}A`;
+					buffer += "\r";
+					for (let i = 0; i < scroll; i++) {
+						if (i > 0) buffer += "\r\n";
+						buffer += this.#lineRewriteSequence(
+							frame[chunkFrom + i] ?? "",
+							width,
+							i,
+							chunkFrom + i,
+							chunkTo,
+							this.#osc66SpacerGlyphWidth(frame, chunkFrom + i),
+						);
+					}
+					const moveToBottom = height - scroll;
+					if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
+				} else {
+					const moveToBottom = height - 1 - currentScreenRow;
+					if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
+				}
 				for (let r = height - scroll; r < height; r++) {
-					buffer += `\r\n${this.#lineRewriteSequence(window[r] ?? "", width, height - 1, windowTop + r, chunkTo, this.#osc66SpacerGlyphWidth(frame, windowTop + r))}`;
+					buffer += "\r\n";
+					buffer += this.#lineRewriteSequence(
+						window[r] ?? "",
+						width,
+						height - 1,
+						windowTop + r,
+						chunkTo,
+						this.#osc66SpacerGlyphWidth(frame, windowTop + r),
+						options.mainWindow[r] ?? "",
+						options.sidebarLayout,
+					);
 				}
 				// Rewrite any remaining changed rows after the shift.
 				let firstChanged = -1;
@@ -5363,13 +5500,31 @@ export class TUI extends Container {
 					buffer += "\r";
 					for (let r = firstChanged; r <= lastChanged; r++) {
 						if (r > firstChanged) buffer += "\r\n";
+						const line = window[r] ?? "";
+						if (line === (previousWindow[r + scroll] ?? "")) continue;
+						if (
+							options.sidebarLayout.visible &&
+							(options.mainWindow[r] ?? "") === (previousMainWindow[r + scroll] ?? "")
+						) {
+							const suffix = this.#rightSidebarSuffixSequence(
+								line,
+								options.mainWindow[r] ?? "",
+								options.sidebarLayout,
+							);
+							if (suffix.length > 0) {
+								buffer += suffix + LINE_TERMINATOR + ERASE_TO_END_OF_LINE;
+								continue;
+							}
+						}
 						buffer += this.#lineRewriteSequence(
-							window[r] ?? "",
+							line,
 							width,
 							r,
 							windowTop + r,
 							chunkTo,
 							this.#osc66SpacerGlyphWidth(frame, windowTop + r),
+							options.mainWindow[r] ?? "",
+							options.sidebarLayout,
 						);
 					}
 					cursorFromRow = windowTop + lastChanged;
@@ -5380,7 +5535,7 @@ export class TUI extends Container {
 				this.terminal.write(buffer);
 				this.#committedRows = chunkTo;
 				this.#windowTopRow = windowTop;
-				this.#commit(frame, window, width, height, cursorControl);
+				this.#commit(frame, window, options.mainWindow, width, height, cursorControl);
 				return;
 			}
 		}
@@ -5411,6 +5566,7 @@ export class TUI extends Container {
 				this.#writeCursorPosition(cursorPos, cursorTrackingLineCount);
 				this.#previousWidth = width;
 				this.#previousHeight = height;
+				this.#previousMainWindow = options.mainWindow;
 				return;
 			}
 			let buffer = this.#paintBeginSequence + purgeSequence;
@@ -5446,6 +5602,8 @@ export class TUI extends Container {
 					windowTop + r,
 					this.#committedRows,
 					this.#osc66SpacerGlyphWidth(frame, windowTop + r),
+					options.mainWindow[r] ?? "",
+					options.sidebarLayout,
 				);
 			}
 			buffer += fillSequence;
@@ -5462,7 +5620,7 @@ export class TUI extends Container {
 			buffer += this.#paintEndSequence;
 			this.terminal.write(buffer);
 			this.#windowTopRow = windowTop;
-			this.#commit(frame, window, width, height, cursorControl);
+			this.#commit(frame, window, options.mainWindow, width, height, cursorControl);
 			return;
 		}
 
@@ -5496,6 +5654,8 @@ export class TUI extends Container {
 				windowTop + screenRow,
 				chunkTo,
 				this.#osc66SpacerGlyphWidth(frame, windowTop + screenRow),
+				options.mainWindow[screenRow] ?? "",
+				options.sidebarLayout,
 			);
 			wroteLine = true;
 		}
@@ -5507,7 +5667,7 @@ export class TUI extends Container {
 		this.terminal.write(buffer);
 		this.#committedRows = chunkTo;
 		this.#windowTopRow = windowTop;
-		this.#commit(frame, window, width, height, cursorControl);
+		this.#commit(frame, window, options.mainWindow, width, height, cursorControl);
 	}
 
 	/** Optional intent log under PI_DEBUG_REDRAW. */

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -24,9 +24,9 @@ import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
 import {
 	composeRightSidebar,
-	resolveRightSidebarLayout,
 	type ResolvedRightSidebarLayout,
 	type RightSidebarOptions,
+	resolveRightSidebarLayout,
 } from "./reserved-sidebar";
 import { isConPTYHosted, setAltScreenActive, type Terminal } from "./terminal";
 import {
@@ -2648,12 +2648,7 @@ export class TUI extends Container {
 			return;
 		}
 
-		const {
-			terminalWidth,
-			height,
-			mainWidth,
-			sidebar: sidebarLayout,
-		} = this.#activeViewportLayout();
+		const { terminalWidth, height, mainWidth, sidebar: sidebarLayout } = this.#activeViewportLayout();
 		if (!this.#hasEverRendered || this.#resizeEventPending) {
 			this.requestComponentRender(component);
 			return;
@@ -3519,12 +3514,7 @@ export class TUI extends Container {
 	#doRender(): void {
 		if (this.#stopped) return;
 		const layout = this.#activeViewportLayout();
-		const {
-			terminalWidth,
-			height,
-			mainWidth,
-			sidebar: sidebarLayout,
-		} = layout;
+		const { terminalWidth, height, mainWidth, sidebar: sidebarLayout } = layout;
 		const contentWidthChanged = this.#composeWidth >= 0 && mainWidth !== this.#composeWidth;
 
 		// Consume the component-scoped accumulation: it describes the render
@@ -4188,16 +4178,25 @@ export class TUI extends Container {
 				commitTo = commitFrom;
 			}
 			this.#imageBudget.observeCommitWatermark(commitTo);
-			this.#emitWidthEpochBaseline(frame, window, terminalWidth, height, cursorPos, purgeSequence, imageTransmitBuffer, {
-				repaintFromScreenRow: 0,
-				commitFrom,
-				commitTo,
-				appendOnly: logicalAppend,
-				prepaintWindowTop: logicalAppend && !logicalPrefixAppend && !hasVisibleOverlay ? commitFrom : undefined,
-				windowTop,
-				cursorTrackingLineCount,
-				leadingSequence: deferredAltExit,
-			});
+			this.#emitWidthEpochBaseline(
+				frame,
+				window,
+				terminalWidth,
+				height,
+				cursorPos,
+				purgeSequence,
+				imageTransmitBuffer,
+				{
+					repaintFromScreenRow: 0,
+					commitFrom,
+					commitTo,
+					appendOnly: logicalAppend,
+					prepaintWindowTop: logicalAppend && !logicalPrefixAppend && !hasVisibleOverlay ? commitFrom : undefined,
+					windowTop,
+					cursorTrackingLineCount,
+					leadingSequence: deferredAltExit,
+				},
+			);
 			this.#pendingAltExit = "";
 			if (!hasVisibleOverlay) {
 				this.#widthEpochOverlayReplayPending = false;
@@ -5070,9 +5069,11 @@ export class TUI extends Container {
 	 * above the fold, so its reserved rows are preserved instead of erased
 	 * (issue #8318).
 	 */
-	#composeResizeViewport(
-		layout: ActiveViewportLayout,
-	): { framed: readonly string[]; viewportTop: number; contentRows: number } {
+	#composeResizeViewport(layout: ActiveViewportLayout): {
+		framed: readonly string[];
+		viewportTop: number;
+		contentRows: number;
+	} {
 		const { mainWidth, height } = layout;
 		const maxRows = height + TUI.#OSC66_MAX_SPACER_ROWS;
 		const tail: string[] = []; // bottom-first: viewport rows plus context above

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1538,7 +1538,7 @@ export class TUI extends Container {
 		} else {
 			this.#rightSidebar = { component, options };
 		}
-		this.requestRender(true, { clearScrollback: !isMultiplexerSession() });
+		this.requestRender(true, { clearScrollback: this.#hasEverRendered && !isMultiplexerSession() });
 	}
 
 	#resolveRightSidebar(terminalWidth: number): ResolvedRightSidebarLayout {
@@ -2622,13 +2622,19 @@ export class TUI extends Container {
 			return;
 		}
 
-		const width = this.terminal.columns;
+		const terminalWidth = this.terminal.columns;
 		const height = this.terminal.rows;
+		const sidebarLayout = this.#resolveRightSidebar(terminalWidth);
+		const mainWidth = sidebarLayout.mainWidth;
 		if (!this.#hasEverRendered || this.#resizeEventPending) {
 			this.requestComponentRender(component);
 			return;
 		}
-		if (width !== this.#previousWidth || height !== this.#previousHeight || width !== this.#composeWidth) {
+		if (
+			terminalWidth !== this.#previousWidth ||
+			height !== this.#previousHeight ||
+			mainWidth !== this.#composeWidth
+		) {
 			this.requestComponentRender(component);
 			return;
 		}
@@ -2685,25 +2691,43 @@ export class TUI extends Container {
 			return;
 		}
 
-		const nextLines = root.render(width);
+		const nextLines = root.render(mainWidth);
 		if (nextLines.length !== segment.rowCount) {
 			this.requestComponentRender(component);
 			return;
 		}
 
-		let firstChanged = -1;
-		let lastChanged = -1;
-		const previousWindow = this.#previousWindow;
+		const mainWindowLines = new Array<string>(nextLines.length);
 		for (let i = 0; i < nextLines.length; i++) {
 			const frameRow = segment.start + i;
 			const raw = nextLines[i]!;
 			const composed = this.#stripCursorMarkers(raw);
-			const prepared = this.#prepareLine(composed, width);
+			const prepared = this.#prepareLine(composed, mainWidth);
 			this.#composedFrame[frameRow] = composed;
 			this.#preparedMeta[frameRow] = prepared;
 			this.#preparedFrame[frameRow] = prepared.line;
-			if (previousWindow[screenStart + i] === prepared.line) continue;
-			previousWindow[screenStart + i] = prepared.line;
+			mainWindowLines[i] = prepared.line;
+		}
+		const sidebarRegistration = this.#rightSidebar;
+		const sidebarLines =
+			sidebarLayout.visible && sidebarRegistration
+				? sidebarRegistration.component.render(sidebarLayout.sidebarContentWidth)
+				: undefined;
+		const nextWindowLines = sidebarLines
+			? composeRightSidebar(
+					mainWindowLines,
+					sidebarLines.slice(screenStart, screenStart + mainWindowLines.length),
+					sidebarLayout,
+				)
+			: mainWindowLines;
+
+		let firstChanged = -1;
+		let lastChanged = -1;
+		const previousWindow = this.#previousWindow;
+		for (let i = 0; i < nextWindowLines.length; i++) {
+			const line = nextWindowLines[i]!;
+			if (previousWindow[screenStart + i] === line) continue;
+			previousWindow[screenStart + i] = line;
 			if (firstChanged === -1) firstChanged = i;
 			lastChanged = i;
 		}
@@ -2723,7 +2747,7 @@ export class TUI extends Container {
 
 		if (firstChanged === -1) {
 			this.#writeCursorPosition(cursorPos, this.#composedFrame.length);
-			this.#previousWidth = width;
+			this.#previousWidth = terminalWidth;
 			this.#previousHeight = height;
 			return;
 		}
@@ -2738,8 +2762,8 @@ export class TUI extends Container {
 		for (let i = firstChanged; i <= lastChanged; i++) {
 			if (i > firstChanged) buffer += "\r\n";
 			buffer += this.#lineRewriteSequence(
-				this.#preparedFrame[segment.start + i] ?? "",
-				width,
+				previousWindow[screenStart + i] ?? "",
+				terminalWidth,
 				screenStart + i,
 				segment.start + i,
 				this.#committedRows,
@@ -2755,7 +2779,7 @@ export class TUI extends Container {
 		buffer += this.#paintEndSequence;
 		this.terminal.write(buffer);
 		this.#windowTopRow = windowTop;
-		this.#commit(this.#composedFrame, previousWindow, width, height, cursorControl);
+		this.#commit(this.#composedFrame, previousWindow, terminalWidth, height, cursorControl);
 	}
 
 	#postFullPaintSettleDelay(): number {
@@ -2803,10 +2827,16 @@ export class TUI extends Container {
 	 * the partial compose would reuse, or when a requested component is not
 	 * reachable from the current root child list.
 	 */
-	#resolvePartialComposeRoots(width: number, height: number): Set<Component> | null {
+	#resolvePartialComposeRoots(terminalWidth: number, mainWidth: number, height: number): Set<Component> | null {
 		if (this.#componentRenderTargets.size === 0) return null;
 		if (!this.#hasEverRendered || this.#resizeEventPending) return null;
-		if (width !== this.#previousWidth || height !== this.#previousHeight || width !== this.#composeWidth) return null;
+		if (
+			terminalWidth !== this.#previousWidth ||
+			height !== this.#previousHeight ||
+			mainWidth !== this.#composeWidth
+		) {
+			return null;
+		}
 		if (this.#clearScrollbackOnNextRender || this.#forceViewportRepaintOnNextRender) return null;
 		if (this.overlayStack.length > 0) return null;
 		// The image budget audits display order across the whole frame; a
@@ -3592,7 +3622,9 @@ export class TUI extends Container {
 		// a quiescent budget, and a partial tree walk would under-count display
 		// order — and re-renders only the requested root subtrees, reusing the
 		// previous segment of every other root child.
-		const partialRoots = componentScopedOnly ? this.#resolvePartialComposeRoots(terminalWidth, height) : null;
+		const partialRoots = componentScopedOnly
+			? this.#resolvePartialComposeRoots(terminalWidth, mainWidth, height)
+			: null;
 		this.#componentRenderTargets.clear();
 		let rawFrame: readonly string[];
 		if (partialRoots !== null) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3523,6 +3523,11 @@ export class TUI extends Container {
 		});
 	}
 
+	#rightSidebarBoundarySequence(layout: ResolvedRightSidebarLayout): string {
+		const moveToBoundary = layout.mainWidth > 0 ? `\x1b[${layout.mainWidth}C` : "";
+		return `${RIGHT_SIDEBAR_BOUNDARY_RESET}\r${moveToBoundary}`;
+	}
+
 	#rightSidebarSuffixSequence(
 		line: string,
 		mainLine: string,
@@ -3535,8 +3540,7 @@ export class TUI extends Container {
 		const suffixOffset = main.length + RIGHT_SIDEBAR_BOUNDARY_RESET.length + paddingWidth;
 		if (suffixOffset > line.length) return "";
 		const suffix = line.slice(suffixOffset);
-		const moveToBoundary = layout.mainWidth > 0 ? `\x1b[${layout.mainWidth}C` : "";
-		return `${RIGHT_SIDEBAR_BOUNDARY_RESET}\r${moveToBoundary}${suffix}`;
+		return this.#rightSidebarBoundarySequence(layout) + suffix;
 	}
 
 	#terminalLine(
@@ -4607,6 +4611,15 @@ export class TUI extends Container {
 	}
 
 	/**
+	 * Exact final-cell confidence shared by whole-row and sidebar-only rewrites.
+	 * `undefined` means the ASCII scanner cannot prove physical width.
+	 */
+	#lineFillsWidth(line: string, width: number): boolean | undefined {
+		const exactWidth = this.#ansiAsciiLineWidth(line, width);
+		return exactWidth === undefined ? undefined : exactWidth >= width;
+	}
+
+	/**
 	 * Columns to preserve when `lines[index]` is a blank row that a scaled OSC 66
 	 * heading flows into, or `-1` when it is not such a row. A scale-`s` heading
 	 * occupies `s` rows and `visibleWidth` columns, so the `s - 1` blank rows
@@ -4653,11 +4666,11 @@ export class TUI extends Container {
 			return ERASE_LINE + this.#terminalLine(line, screenRow, frameRow, committedTo, mainLine, sidebarLayout);
 		}
 		const terminalLine = this.#terminalLine(line);
-		const asciiWidth = this.#ansiAsciiLineWidth(line, width);
-		if (asciiWidth !== undefined) {
+		const fillsWidth = this.#lineFillsWidth(line, width);
+		if (fillsWidth !== undefined) {
 			// Exact width model: skip the erase only when the row truly fills
 			// the line (an EL there would eat the last cell via pending-wrap).
-			return asciiWidth >= width ? terminalLine : terminalLine + ERASE_TO_END_OF_LINE;
+			return fillsWidth ? terminalLine : terminalLine + ERASE_TO_END_OF_LINE;
 		}
 		// Non-ASCII rows: the native measure can over-count combining-heavy
 		// scripts, so a row it calls "full" may render short and leave stale
@@ -5527,8 +5540,13 @@ export class TUI extends Container {
 								options.sidebarLayout,
 							);
 							if (suffix.length > 0) {
+								const fillsWidth = this.#lineFillsWidth(line, width);
+								if (fillsWidth === undefined) {
+									buffer +=
+										this.#rightSidebarBoundarySequence(options.sidebarLayout) + ERASE_TO_END_OF_LINE;
+								}
 								buffer += suffix + LINE_TERMINATOR;
-								if (visibleWidth(line) < width) buffer += ERASE_TO_END_OF_LINE;
+								if (fillsWidth === false) buffer += ERASE_TO_END_OF_LINE;
 								continue;
 							}
 						}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -24,8 +24,8 @@ import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
 import {
 	composeRightSidebar,
-	RIGHT_SIDEBAR_BOUNDARY_RESET,
 	type ResolvedRightSidebarLayout,
+	RIGHT_SIDEBAR_BOUNDARY_RESET,
 	type RightSidebarOptions,
 	resolveRightSidebarLayout,
 } from "./reserved-sidebar";
@@ -3528,11 +3528,7 @@ export class TUI extends Container {
 		return `${RIGHT_SIDEBAR_BOUNDARY_RESET}\r${moveToBoundary}`;
 	}
 
-	#rightSidebarSuffixSequence(
-		line: string,
-		mainLine: string,
-		layout: ResolvedRightSidebarLayout | undefined,
-	): string {
+	#rightSidebarSuffixSequence(line: string, mainLine: string, layout: ResolvedRightSidebarLayout | undefined): string {
 		if (!layout?.visible) return "";
 		const main = truncateToWidth(mainLine, layout.mainWidth);
 		if (!line.startsWith(main)) return "";
@@ -4962,9 +4958,7 @@ export class TUI extends Container {
 				for (let i = 1; i < paint.lines.length; i++) {
 					const sourceRow = paint.sourceStart + i - 1;
 					paintMainLines[i] =
-						sourceRow < chunkTo
-							? (frame[sourceRow] ?? "")
-							: (options.mainWindow[sourceRow - chunkTo] ?? "");
+						sourceRow < chunkTo ? (frame[sourceRow] ?? "") : (options.mainWindow[sourceRow - chunkTo] ?? "");
 				}
 			}
 		}
@@ -5165,15 +5159,7 @@ export class TUI extends Container {
 		// authoritative accounting, and its beginPass() wipes these frames.
 		this.#imageBudget.beginPass(true);
 		const { framed, mainFramed, viewportTop, contentRows } = this.#composeResizeViewport(layout);
-		this.#emitResizeViewport(
-			framed,
-			mainFramed,
-			layout.sidebar,
-			viewportTop,
-			height,
-			contentRows,
-			terminalWidth,
-		);
+		this.#emitResizeViewport(framed, mainFramed, layout.sidebar, viewportTop, height, contentRows, terminalWidth);
 		this.#resizeViewportPaintCount += 1;
 	}
 
@@ -5542,8 +5528,7 @@ export class TUI extends Container {
 							if (suffix.length > 0) {
 								const fillsWidth = this.#lineFillsWidth(line, width);
 								if (fillsWidth === undefined) {
-									buffer +=
-										this.#rightSidebarBoundarySequence(options.sidebarLayout) + ERASE_TO_END_OF_LINE;
+									buffer += this.#rightSidebarBoundarySequence(options.sidebarLayout) + ERASE_TO_END_OF_LINE;
 								}
 								buffer += suffix + LINE_TERMINATOR;
 								if (fillsWidth === false) buffer += ERASE_TO_END_OF_LINE;

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -481,5 +481,4 @@ describe("TUI direct-placement clipping", () => {
 			tui.stop();
 		}
 	});
-
 });

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -280,6 +280,7 @@ describe("TUI direct-placement clipping", () => {
 		const lines: string[] = [];
 		return {
 			tui,
+			term,
 			writes,
 			pump,
 			imageId,
@@ -391,6 +392,38 @@ describe("TUI direct-placement clipping", () => {
 			// them: both must replace placement 2 exactly — repeated overlay
 			// toggles must not mint a fresh placement per frame (#8057 review).
 			expect(new Set(after.map(p => p.placementId))).toEqual(new Set([2]));
+		} finally {
+			h.tui.stop();
+		}
+	});
+
+	it("clips straddling placements and advances epochs with a visible sidebar", () => {
+		const h = makeHarness("sidebar-straddle");
+		h.tui.setRightSidebar(
+			{ render: () => Array.from({ length: 12 }, (_, index) => `SIDE-${index}`) },
+			{ width: 12, minWidth: 8, minMainWidth: 20 },
+		);
+		try {
+			h.tui.start();
+			h.pump();
+			h.streamLines(10);
+			h.writes.length = 0;
+
+			const overlay = h.tui.showOverlay(new Text("OVERLAY", 0, 0), { anchor: "top-left", width: "100%" });
+			h.pump();
+			overlay.hide();
+			h.pump();
+
+			const placements = capturePlacements(h.output(), h.imageId);
+			expect(placements.length).toBeGreaterThan(0);
+			for (const placement of placements) {
+				expect(placement.placementId).toBe(2);
+				expect(placement.rows).toBeLessThan(6);
+				expect(placement.srcY).toBe(Math.floor((60 * (6 - placement.rows)) / 6));
+				expect(placement.cuu).toBe(placement.rows - 1);
+			}
+			const { baseY } = h.term.getBufferPosition();
+			expect(h.term.getScrollBuffer().slice(0, baseY).some(line => line.includes("SIDE-"))).toBe(false);
 		} finally {
 			h.tui.stop();
 		}

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import { type Component, Container, type NativeScrollbackLiveRegion, type RenderScheduler, TUI } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	Container,
+	type NativeScrollbackLiveRegion,
+	type RenderScheduler,
+	TUI,
+} from "@oh-my-pi/pi-tui";
 import { Image, ImageBudget } from "@oh-my-pi/pi-tui/components/image";
 import { Text } from "@oh-my-pi/pi-tui/components/text";
 import { getKittyGraphics, setKittyGraphics } from "@oh-my-pi/pi-tui/kitty-graphics";
@@ -425,7 +431,12 @@ describe("TUI direct-placement clipping", () => {
 				expect(placement.cuu).toBe(placement.rows - 1);
 			}
 			const { baseY } = h.term.getBufferPosition();
-			expect(h.term.getScrollBuffer().slice(0, baseY).some(line => line.includes("SIDE-"))).toBe(false);
+			expect(
+				h.term
+					.getScrollBuffer()
+					.slice(0, baseY)
+					.some(line => line.includes("SIDE-")),
+			).toBe(false);
 		} finally {
 			h.tui.stop();
 		}

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import { Container, type NativeScrollbackLiveRegion, type RenderScheduler, TUI } from "@oh-my-pi/pi-tui";
+import { type Component, Container, type NativeScrollbackLiveRegion, type RenderScheduler, TUI } from "@oh-my-pi/pi-tui";
 import { Image, ImageBudget } from "@oh-my-pi/pi-tui/components/image";
 import { Text } from "@oh-my-pi/pi-tui/components/text";
 import { getKittyGraphics, setKittyGraphics } from "@oh-my-pi/pi-tui/kitty-graphics";
@@ -27,6 +27,7 @@ const BASE64_ONE_PIXEL_PNG =
 // be re-used (Kitty replace semantics strip the old placement everywhere,
 // scrollback included — the permanently cropped images on WezTerm).
 
+const PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, "platform");
 const originalProtocol = TERMINAL.imageProtocol;
 const originalTerminalId = terminal.id;
 const originalGraphics = { ...getKittyGraphics() };
@@ -42,6 +43,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	setCellDimensions(originalCellDims);
+	if (PLATFORM_DESCRIPTOR) Object.defineProperty(process, "platform", PLATFORM_DESCRIPTOR);
 	terminal.imageProtocol = originalProtocol;
 	terminal.id = originalTerminalId;
 	setKittyGraphics(originalGraphics);
@@ -510,6 +512,58 @@ describe("TUI direct-placement clipping", () => {
 			expect(columns.length).toBeGreaterThan(0);
 			expect(columns.at(-1)).toBeLessThanOrEqual(76);
 			expect(terminal.getViewport().some(line => line.includes("SIDEBAR"))).toBe(true);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("keeps main-only Kitty clipping metadata through ConPTY truncation with a sidebar", async () => {
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		const terminal = new VirtualTerminal(120, 12, 12_000);
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		const tui = new TUI(terminal);
+		const filler: Component = {
+			render: width =>
+				Array.from({ length: 7000 }, (_, index) =>
+					`${index.toString().padStart(5, "0")}-${"x".repeat(width)}`.slice(0, width),
+				),
+		};
+		const imageKey = "conpty-sidebar-clip";
+		const image = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 4, maxHeightCells: 6, budget: tui.imageBudget, imageKey },
+			{ widthPx: 40, heightPx: 60 },
+		);
+		const imageId = tui.imageBudget.acquireId(imageKey);
+		tui.addChild(filler);
+		tui.addChild(image);
+		tui.addChild({
+			render: () => Array.from({ length: 10 }, (_, index) => `tail-${index}`),
+		});
+		tui.setRightSidebar(
+			{ render: () => Array.from({ length: 12 }, (_, index) => `SIDE-${index}`) },
+			{ width: 44, minWidth: 28, minMainWidth: 64 },
+		);
+		try {
+			tui.start({ clearScrollback: true });
+			await terminal.waitForRender();
+
+			const output = writes.join("");
+			expect(output).toContain("older lines hidden");
+			const placements = capturePlacements(output, imageId);
+			expect(placements.length).toBeGreaterThan(0);
+			const placement = placements.at(-1)!;
+			expect(placement.placementId).toBe(1);
+			expect(placement.rows).toBe(2);
+			expect(placement.srcY).toBe(40);
+			expect(placement.cuu).toBe(1);
 		} finally {
 			tui.stop();
 		}

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -449,4 +449,37 @@ describe("TUI direct-placement clipping", () => {
 			h.tui.stop();
 		}
 	});
+	it("clips main inline images before the reserved sidebar column", async () => {
+		const terminal = new VirtualTerminal(120, 12);
+		const writes: string[] = [];
+		const realWrite = terminal.write.bind(terminal);
+		vi.spyOn(terminal, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		const tui = new TUI(terminal);
+		const imageKey = "sidebar-boundary";
+		const image = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 100, maxHeightCells: 2, budget: tui.imageBudget, imageKey },
+			{ widthPx: 800, heightPx: 20 },
+		);
+		const imageId = tui.imageBudget.acquireId(imageKey);
+		tui.addChild(image);
+		tui.setRightSidebar({ render: () => ["SIDEBAR"] }, { width: 44, minWidth: 28, minMainWidth: 64 });
+		try {
+			tui.start();
+			await terminal.waitForRender(() => writes.join("").includes(`i=${imageId}`));
+			const placementPattern = new RegExp(`i=${imageId},p=\\d+,c=(\\d+),r=\\d+`, "g");
+			const columns = [...writes.join("").matchAll(placementPattern)].map(match => Number(match[1]));
+			expect(columns.length).toBeGreaterThan(0);
+			expect(columns.at(-1)).toBeLessThanOrEqual(76);
+			expect(terminal.getViewport().some(line => line.includes("SIDEBAR"))).toBe(true);
+		} finally {
+			tui.stop();
+		}
+	});
+
 });

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -528,10 +528,7 @@ describe("TUI direct-placement clipping", () => {
 		});
 		const tui = new TUI(terminal);
 		const filler: Component = {
-			render: width =>
-				Array.from({ length: 7000 }, (_, index) =>
-					`${index.toString().padStart(5, "0")}-${"x".repeat(width)}`.slice(0, width),
-				),
+			render: () => ["prefix", `\x1b_Ga=T,f=100;${"A".repeat(530_000)}\x1b\\`],
 		};
 		const imageKey = "conpty-sidebar-clip";
 		const image = new Image(
@@ -542,11 +539,15 @@ describe("TUI direct-placement clipping", () => {
 			{ widthPx: 40, heightPx: 60 },
 		);
 		const imageId = tui.imageBudget.acquireId(imageKey);
+		const placementOnly: Component = {
+			render: width => {
+				const lines = image.render(width);
+				return [lines.at(-1) ?? ""];
+			},
+		};
 		tui.addChild(filler);
-		tui.addChild(image);
-		tui.addChild({
-			render: () => Array.from({ length: 10 }, (_, index) => `tail-${index}`),
-		});
+		tui.addChild(placementOnly);
+		tui.addChild({ render: () => Array.from({ length: 11 }, (_, index) => `tail-${index}`) });
 		tui.setRightSidebar(
 			{ render: () => Array.from({ length: 12 }, (_, index) => `SIDE-${index}`) },
 			{ width: 44, minWidth: 28, minMainWidth: 64 },
@@ -561,9 +562,9 @@ describe("TUI direct-placement clipping", () => {
 			expect(placements.length).toBeGreaterThan(0);
 			const placement = placements.at(-1)!;
 			expect(placement.placementId).toBe(1);
-			expect(placement.rows).toBe(2);
-			expect(placement.srcY).toBe(40);
-			expect(placement.cuu).toBe(1);
+			expect(placement.rows).toBeLessThan(6);
+			expect(placement.srcY).toBe(Math.floor((60 * (6 - placement.rows)) / 6));
+			expect(placement.cuu).toBe(placement.rows - 1);
 		} finally {
 			tui.stop();
 		}

--- a/packages/tui/test/issue-8318-repro.test.ts
+++ b/packages/tui/test/issue-8318-repro.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type Component, type NativeScrollbackLiveRegion, TUI } from "@oh-my-pi/pi-tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
@@ -11,6 +11,11 @@ import { VirtualTerminal } from "./virtual-terminal";
 const OSC66 = "\x1b]66;";
 const ST = "\x1b\\";
 const ERASE_LINE = "\x1b[2K";
+const PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, "platform");
+
+afterEach(() => {
+	if (PLATFORM_DESCRIPTOR) Object.defineProperty(process, "platform", PLATFORM_DESCRIPTOR);
+});
 
 class RawLines implements Component {
 	#lines: string[];
@@ -334,6 +339,34 @@ describe("issue #8318: scaled OSC 66 headings survive repaint and resize", () =>
 			const spacer = rows[headingIndex + 1]!;
 			expectClearsRightOfGlyph(spacer, 14);
 			expect(spacer).toContain("SIDE-1");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("keeps main-only OSC 66 spacer metadata through ConPTY truncation with a sidebar", async () => {
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		const term = new VirtualTerminal(80, 6, 12_000);
+		const tui = new TUI(term);
+		tui.addChild(
+			new RawLines(
+				Array.from({ length: 9000 }, (_, index) => `${index.toString().padStart(5, "0")}-${"x".repeat(80)}`),
+			),
+		);
+		tui.addChild(new RawLines([`${OSC66}s=2;Heading${ST}`, "", "Body"]));
+		tui.setRightSidebar(
+			{ render: () => Array.from({ length: 6 }, (_, index) => `SIDE-${index}`) },
+			{ width: 20, minWidth: 12, minMainWidth: 40 },
+		);
+		const writes = captureWrites(term);
+		try {
+			tui.start({ clearScrollback: true });
+			await term.waitForRender();
+
+			expect(writes.join("")).toContain("older lines hidden");
+			const { spacers } = headingAndSpacers(writes, 1);
+			expectClearsRightOfGlyph(spacers[0]!, 14);
+			expect(spacers[0]).toContain("SIDE-4");
 		} finally {
 			tui.stop();
 		}

--- a/packages/tui/test/issue-8318-repro.test.ts
+++ b/packages/tui/test/issue-8318-repro.test.ts
@@ -281,4 +281,61 @@ describe("issue #8318: scaled OSC 66 headings survive repaint and resize", () =>
 			tui.stop();
 		}
 	});
+
+	it("preserves scaled-heading spacer glyphs and sidebar suffixes on ordinary paints", async () => {
+		const term = new VirtualTerminal(80, 6);
+		const tui = new TUI(term);
+		const content = new RawLines(["old heading", "old spacer", "Body"]);
+		tui.addChild(content);
+		tui.setRightSidebar(
+			{ render: () => ["SIDE-0", "SIDE-1", "SIDE-2"] },
+			{ width: 20, minWidth: 12, minMainWidth: 40 },
+		);
+		const writes = captureWrites(term);
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+
+			content.setLines([`${OSC66}s=2;Heading${ST}`, "", "Body"]);
+			tui.requestRender();
+			await settle(term);
+
+			const { spacers } = headingAndSpacers(writes, 1);
+			expectClearsRightOfGlyph(spacers[0]!, 14);
+			expect(spacers[0]).toContain("SIDE-1");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("classifies scaled-heading spacer rows from main-only resize frames", async () => {
+		const term = new VirtualTerminal(80, 6);
+		const tui = new TUI(term);
+		tui.addChild(new RawLines([`${OSC66}s=2;Heading${ST}`, "", "Body"]));
+		tui.setRightSidebar(
+			{ render: () => ["SIDE-0", "SIDE-1", "SIDE-2"] },
+			{ width: 20, minWidth: 12, minMainWidth: 40 },
+		);
+		const writes = captureWrites(term);
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+
+			term.resize(79, 6);
+			const viewportPaint = writes.find(
+				write => write.includes("\x1b[H") && !write.includes("\x1b[2J") && !write.includes("\x1b[3J"),
+			);
+			expect(viewportPaint).toBeDefined();
+			const rows = viewportPaint!.split("\r\n");
+			const headingIndex = rows.findIndex(row => row.includes(OSC66));
+			expect(headingIndex).toBeGreaterThanOrEqual(0);
+			const spacer = rows[headingIndex + 1]!;
+			expectClearsRightOfGlyph(spacer, 14);
+			expect(spacer).toContain("SIDE-1");
+		} finally {
+			tui.stop();
+		}
+	});
 });

--- a/packages/tui/test/reserved-sidebar-layout.test.ts
+++ b/packages/tui/test/reserved-sidebar-layout.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import {
+	composeRightSidebar,
+	resolveRightSidebarLayout,
+	type RightSidebarOptions,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
+
+const OPTIONS: RightSidebarOptions = {
+	width: 44,
+	minWidth: 28,
+	minMainWidth: 64,
+};
+
+describe("resolveRightSidebarLayout", () => {
+	it("uses the preferred width when the terminal has room", () => {
+		expect(resolveRightSidebarLayout(120, OPTIONS)).toEqual({
+			terminalWidth: 120,
+			mainWidth: 76,
+			sidebarWidth: 44,
+			sidebarContentWidth: 43,
+			visible: true,
+		});
+	});
+
+	it("shrinks the sidebar before the main content", () => {
+		expect(resolveRightSidebarLayout(100, OPTIONS)).toEqual({
+			terminalWidth: 100,
+			mainWidth: 64,
+			sidebarWidth: 36,
+			sidebarContentWidth: 35,
+			visible: true,
+		});
+	});
+
+	it("is visible exactly at the minimum combined width", () => {
+		expect(resolveRightSidebarLayout(92, OPTIONS)).toEqual({
+			terminalWidth: 92,
+			mainWidth: 64,
+			sidebarWidth: 28,
+			sidebarContentWidth: 27,
+			visible: true,
+		});
+	});
+
+	it("gives the full terminal to main content below the threshold", () => {
+		expect(resolveRightSidebarLayout(91, OPTIONS)).toEqual({
+			terminalWidth: 91,
+			mainWidth: 91,
+			sidebarWidth: 0,
+			sidebarContentWidth: 0,
+			visible: false,
+		});
+	});
+
+	it("normalizes fractional and inverted dimensions", () => {
+		expect(
+			resolveRightSidebarLayout(80, {
+				width: 10.9,
+				minWidth: 30.2,
+				minMainWidth: 1.8,
+			}),
+		).toEqual({
+			terminalWidth: 80,
+			mainWidth: 70,
+			sidebarWidth: 10,
+			sidebarContentWidth: 9,
+			visible: true,
+		});
+	});
+});
+
+describe("composeRightSidebar", () => {
+	it("places the separator at mainWidth and preserves ANSI width", () => {
+		const layout = resolveRightSidebarLayout(120, OPTIONS);
+		const result = composeRightSidebar(
+			["main", "\x1b[31mcolored\x1b[0m"],
+			["side", "quota 42%"],
+			layout,
+		);
+
+		expect(result).toHaveLength(2);
+		expect(visibleWidth(result[0]!)).toBeLessThanOrEqual(120);
+		expect(result[0]!.indexOf("│")).toBeGreaterThan(0);
+		expect(result[0]).toContain("side");
+		expect(result[1]).toContain("\x1b[31mcolored\x1b[0m");
+		expect(result[1]).toContain("quota 42%");
+	});
+
+	it("returns the original window reference when hidden", () => {
+		const window = ["main"] as const;
+		const layout = resolveRightSidebarLayout(91, OPTIONS);
+		expect(composeRightSidebar(window, ["side"], layout)).toBe(window);
+	});
+});

--- a/packages/tui/test/reserved-sidebar-layout.test.ts
+++ b/packages/tui/test/reserved-sidebar-layout.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
 	composeRightSidebar,
-	resolveRightSidebarLayout,
 	type RightSidebarOptions,
+	resolveRightSidebarLayout,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 
@@ -73,11 +73,7 @@ describe("resolveRightSidebarLayout", () => {
 describe("composeRightSidebar", () => {
 	it("places the separator at mainWidth and preserves ANSI width", () => {
 		const layout = resolveRightSidebarLayout(120, OPTIONS);
-		const result = composeRightSidebar(
-			["main", "\x1b[31mcolored\x1b[0m"],
-			["side", "quota 42%"],
-			layout,
-		);
+		const result = composeRightSidebar(["main", "\x1b[31mcolored\x1b[0m"], ["side", "quota 42%"], layout);
 
 		expect(result).toHaveLength(2);
 		expect(visibleWidth(result[0]!)).toBeLessThanOrEqual(120);

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -33,6 +33,23 @@ async function createMounted(rows = 8) {
 }
 
 describe("TUI reserved right sidebar", () => {
+	it("preserves default initial-paint scrollback semantics", async () => {
+		const terminal = new VirtualTerminal(120, 8, 100);
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+		const tui = new TUI(terminal);
+		const main = new WidthAndTextProbe("MAIN");
+		tui.addChild(main);
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => main.lastWidth === 120);
+		expect(writes.join("")).not.toContain("\x1b[3J");
+	});
+
 	it("renders main and sidebar at their allocated widths", async () => {
 		const { terminal, main, side } = await createMounted();
 		expect(main.lastWidth).toBe(76);

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -5,7 +5,10 @@ import { VirtualTerminal } from "./virtual-terminal";
 
 class WidthAndTextProbe implements Component {
 	readonly widths: number[] = [];
-	constructor(private readonly prefix: string, private readonly rows = 1) {}
+	constructor(
+		private readonly prefix: string,
+		private readonly rows = 1,
+	) {}
 	render(width: number): readonly string[] {
 		this.widths.push(width);
 		return Array.from({ length: this.rows }, (_, index) => `${this.prefix}-${index}`);

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -282,6 +282,39 @@ describe("TUI reserved right sidebar", () => {
 		expect(terminal.getViewport()).toEqual(baseline);
 	});
 
+	it("clears stale suffix cells when combining-heavy width is uncertain", async () => {
+		const terminal = new VirtualTerminal(120, 5, 100);
+		const tui = new TUI(terminal);
+		const main = new MutableLinesProbe(Array.from({ length: 8 }, (_, index) => `MAIN-${index}`));
+		tui.addChild(main);
+		tui.setRightSidebar(
+			{
+				render: width => [
+					"a\u064e".repeat(Math.ceil(width / 2)),
+					"L".repeat(width),
+					...Array.from({ length: 3 }, (_, index) => `short-${index}`),
+				],
+			},
+			{ width: 44, minWidth: 28, minMainWidth: 64 },
+		);
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MAIN-7")));
+
+		main.lines.push("MAIN-8");
+		tui.requestRender();
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MAIN-8")));
+
+		const baseline = terminal.getViewport();
+		const firstSuffix = baseline[0]?.slice(76) ?? "";
+		expect(firstSuffix).toContain("a");
+		expect(firstSuffix).not.toContain("L");
+
+		tui.requestRender();
+		await terminal.waitForRender();
+		expect(terminal.getViewport()).toEqual(baseline);
+	});
+
 	it("isolates main SGR and OSC 8 state before padding, separator, and sidebar", async () => {
 		const terminal = new VirtualTerminal(120, 4, 100);
 		const writes: string[] = [];

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class WidthAndTextProbe implements Component {
+	readonly widths: number[] = [];
+	constructor(private readonly prefix: string, private readonly rows = 1) {}
+	render(width: number): readonly string[] {
+		this.widths.push(width);
+		return Array.from({ length: this.rows }, (_, index) => `${this.prefix}-${index}`);
+	}
+	get lastWidth(): number | undefined {
+		return this.widths.at(-1);
+	}
+}
+
+const active: Array<{ tui: TUI; terminal: VirtualTerminal }> = [];
+afterEach(() => {
+	for (const entry of active.splice(0)) entry.tui.stop();
+});
+
+async function createMounted(rows = 8) {
+	const terminal = new VirtualTerminal(120, rows, 100);
+	const tui = new TUI(terminal);
+	const main = new WidthAndTextProbe("MAIN", rows + 8);
+	const side = new WidthAndTextProbe("SIDE", rows);
+	tui.addChild(main);
+	tui.setRightSidebar(side, { width: 44, minWidth: 28, minMainWidth: 64 });
+	tui.start();
+	active.push({ tui, terminal });
+	await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDE-")));
+	return { terminal, tui, main, side };
+}
+
+describe("TUI reserved right sidebar", () => {
+	it("renders main and sidebar at their allocated widths", async () => {
+		const { terminal, main, side } = await createMounted();
+		expect(main.lastWidth).toBe(76);
+		expect(side.lastWidth).toBe(43);
+		expect(terminal.getViewport().some(line => line.includes("MAIN-") && line.includes("SIDE-"))).toBe(true);
+	});
+
+	it("keeps sidebar text out of native scrollback", async () => {
+		const { terminal } = await createMounted(5);
+		const { baseY } = terminal.getBufferPosition();
+		const history = terminal.getScrollBuffer().slice(0, baseY);
+		expect(baseY).toBeGreaterThan(0);
+		expect(history.some(line => line.includes("SIDE-"))).toBe(false);
+	});
+
+	it("restores full-width main rendering after unmount", async () => {
+		const { terminal, tui, main } = await createMounted();
+		tui.setRightSidebar(undefined);
+		await terminal.waitForRender(() => main.lastWidth === 120);
+		expect(main.lastWidth).toBe(120);
+		expect(terminal.getViewport().some(line => line.includes("SIDE-"))).toBe(false);
+	});
+});

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -242,7 +242,12 @@ describe("TUI reserved right sidebar", () => {
 		expect(tui.fullRedraws).toBe(redraws);
 		expect(rewrittenMainRows.size).toBeLessThan(5);
 		const { baseY } = terminal.getBufferPosition();
-		expect(terminal.getScrollBuffer().slice(0, baseY).some(line => line.includes("SIDEBAR"))).toBe(false);
+		expect(
+			terminal
+				.getScrollBuffer()
+				.slice(0, baseY)
+				.some(line => line.includes("SIDEBAR")),
+		).toBe(false);
 	});
 
 	it("does not erase a full-width sidebar suffix during scroll-append diffs", async () => {
@@ -258,8 +263,7 @@ describe("TUI reserved right sidebar", () => {
 		tui.addChild(main);
 		tui.setRightSidebar(
 			{
-				render: width =>
-					Array.from({ length: 5 }, (_, index) => `${"s".repeat(width - 1)}${index}`),
+				render: width => Array.from({ length: 5 }, (_, index) => `${"s".repeat(width - 1)}${index}`),
 			},
 			{ width: 44, minWidth: 28, minMainWidth: 64 },
 		);

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -245,6 +245,43 @@ describe("TUI reserved right sidebar", () => {
 		expect(terminal.getScrollBuffer().slice(0, baseY).some(line => line.includes("SIDEBAR"))).toBe(false);
 	});
 
+	it("does not erase a full-width sidebar suffix during scroll-append diffs", async () => {
+		const terminal = new VirtualTerminal(120, 5, 100);
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+		const tui = new TUI(terminal);
+		const main = new MutableLinesProbe(Array.from({ length: 8 }, (_, index) => `MAIN-${index}`));
+		tui.addChild(main);
+		tui.setRightSidebar(
+			{
+				render: width =>
+					Array.from({ length: 5 }, (_, index) => `${"s".repeat(width - 1)}${index}`),
+			},
+			{ width: 44, minWidth: 28, minMainWidth: 64 },
+		);
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MAIN-7")));
+		writes.length = 0;
+
+		main.lines.push("MAIN-8");
+		tui.requestRender();
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MAIN-8")));
+
+		expect(writes.join("")).not.toContain(`0\x1b[0m\x1b]8;;\x07\x1b[K`);
+		const baseline = terminal.getViewport();
+		expect(baseline[0]?.endsWith("0")).toBe(true);
+		writes.length = 0;
+
+		tui.requestRender();
+		await terminal.waitForRender();
+		expect(terminal.getViewport()).toEqual(baseline);
+	});
+
 	it("isolates main SGR and OSC 8 state before padding, separator, and sidebar", async () => {
 		const terminal = new VirtualTerminal(120, 4, 100);
 		const writes: string[] = [];

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -29,6 +29,14 @@ class MutableWidthAndTextProbe implements Component {
 	}
 }
 
+class MutableLinesProbe implements Component {
+	constructor(readonly lines: string[]) {}
+
+	render(): readonly string[] {
+		return this.lines;
+	}
+}
+
 class RenderCountingTUI extends TUI {
 	renders = 0;
 
@@ -94,6 +102,58 @@ describe("TUI reserved right sidebar", () => {
 		expect(terminal.getScrollBuffer().some(line => line.includes("EXISTING-HISTORY"))).toBe(true);
 	});
 
+	it("uses an ordinary render for same-geometry sidebar updates without clearing history", async () => {
+		const terminal = new VirtualTerminal(120, 4, 100);
+		terminal.write("EXISTING-HISTORY\r\nA\r\nB\r\nC\r\nD");
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+		const tui = new TUI(terminal);
+		tui.addChild(new WidthAndTextProbe("MAIN", 4));
+		tui.setRightSidebar(new WidthAndTextProbe("OLD-SIDE", 4), {
+			width: 44,
+			minWidth: 28,
+			minMainWidth: 64,
+		});
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("OLD-SIDE")));
+		writes.length = 0;
+
+		tui.setRightSidebar(new WidthAndTextProbe("NEW-SIDE", 4), {
+			width: 44,
+			minWidth: 28,
+			minMainWidth: 64,
+		});
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("NEW-SIDE")));
+
+		expect(writes.join("")).not.toContain("\x1b[3J");
+		expect(terminal.getScrollBuffer().some(line => line.includes("EXISTING-HISTORY"))).toBe(true);
+	});
+
+	it("still reflows with a destructive replay when sidebar geometry changes", async () => {
+		const { terminal, tui, main } = await createMounted(4);
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+
+		tui.setRightSidebar(new WidthAndTextProbe("NARROW-SIDE", 4), {
+			width: 36,
+			minWidth: 28,
+			minMainWidth: 64,
+		});
+		await terminal.waitForRender(() => main.lastWidth === 84);
+
+		expect(writes.join("")).toContain("\x1b[3J");
+		expect(main.lastWidth).toBe(84);
+	});
+
 	it("keeps component-scoped composition on the allocated main width", async () => {
 		const terminal = new VirtualTerminal(120, 8, 100);
 		const scheduler = new StressRenderScheduler();
@@ -153,6 +213,59 @@ describe("TUI reserved right sidebar", () => {
 		const history = terminal.getScrollBuffer().slice(0, baseY);
 		expect(baseY).toBeGreaterThan(0);
 		expect(history.some(line => line.includes("SIDE-"))).toBe(false);
+	});
+
+	it("keeps the scroll-append fast path with a visible sidebar", async () => {
+		const terminal = new VirtualTerminal(120, 5, 100);
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+		const tui = new TUI(terminal);
+		const main = new MutableLinesProbe(Array.from({ length: 8 }, (_, index) => `MAIN-${index}`));
+		tui.addChild(main);
+		tui.setRightSidebar({ render: () => ["SIDEBAR"] }, { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MAIN-7")));
+		const redraws = tui.fullRedraws;
+		writes.length = 0;
+
+		main.lines.push("MAIN-8");
+		tui.requestRender();
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MAIN-8")));
+
+		const output = writes.join("");
+		const rewrittenMainRows = new Set([...output.matchAll(/MAIN-\d+/g)].map(match => match[0]));
+		expect(tui.fullRedraws).toBe(redraws);
+		expect(rewrittenMainRows.size).toBeLessThan(5);
+		const { baseY } = terminal.getBufferPosition();
+		expect(terminal.getScrollBuffer().slice(0, baseY).some(line => line.includes("SIDEBAR"))).toBe(false);
+	});
+
+	it("isolates main SGR and OSC 8 state before padding, separator, and sidebar", async () => {
+		const terminal = new VirtualTerminal(120, 4, 100);
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+		const tui = new TUI(terminal);
+		tui.addChild({
+			render: () => ["\x1b[31;41m\x1b]8;;https://example.test\x07MAIN"],
+		});
+		tui.setRightSidebar({ render: () => ["SIDEBAR"] }, { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => terminal.getViewport()[0]?.includes("SIDEBAR") ?? false);
+
+		expect(writes.join("")).toContain("MAIN\x1b[0m\x1b]8;;\x07");
+		expect(terminal.getViewportRowForegroundColumns(0)).toEqual([0, 1, 2, 3]);
+		expect(terminal.getViewportRowBackgroundColumns(0)).toEqual([0, 1, 2, 3]);
+		expect(terminal.getViewportRowHyperlinkColumns(0)).toEqual([0, 1, 2, 3]);
 	});
 
 	it("restores full-width main rendering after unmount", async () => {

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -265,7 +265,7 @@ describe("TUI reserved right sidebar", () => {
 		expect(writes.join("")).toContain("MAIN\x1b[0m\x1b]8;;\x07");
 		expect(terminal.getViewportRowForegroundColumns(0)).toEqual([0, 1, 2, 3]);
 		expect(terminal.getViewportRowBackgroundColumns(0)).toEqual([0, 1, 2, 3]);
-		expect(terminal.getViewportRowHyperlinkColumns(0)).toEqual([0, 1, 2, 3]);
+		expect(terminal.getViewportRowHyperlinkColumns(0).some(column => column >= 76)).toBe(false);
 	});
 
 	it("restores full-width main rendering after unmount", async () => {

--- a/packages/tui/test/reserved-sidebar-render.test.ts
+++ b/packages/tui/test/reserved-sidebar-render.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { StressRenderScheduler } from "./render-stress-scheduler";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class WidthAndTextProbe implements Component {
@@ -11,6 +12,26 @@ class WidthAndTextProbe implements Component {
 	}
 	get lastWidth(): number | undefined {
 		return this.widths.at(-1);
+	}
+}
+
+class MutableWidthAndTextProbe implements Component {
+	readonly widths: number[] = [];
+
+	constructor(public text: string) {}
+
+	render(width: number): readonly string[] {
+		this.widths.push(width);
+		return [this.text];
+	}
+}
+
+class RenderCountingTUI extends TUI {
+	renders = 0;
+
+	override render(width: number): readonly string[] {
+		this.renders++;
+		return super.render(width);
 	}
 }
 
@@ -48,6 +69,72 @@ describe("TUI reserved right sidebar", () => {
 		active.push({ tui, terminal });
 		await terminal.waitForRender(() => main.lastWidth === 120);
 		expect(writes.join("")).not.toContain("\x1b[3J");
+	});
+
+	it("preserves existing history when the sidebar mounts before start", async () => {
+		const terminal = new VirtualTerminal(120, 4, 100);
+		terminal.write("EXISTING-HISTORY\r\nA\r\nB\r\nC\r\nD");
+		expect(terminal.getScrollBuffer().some(line => line.includes("EXISTING-HISTORY"))).toBe(true);
+		const writes: string[] = [];
+		const write = terminal.write.bind(terminal);
+		terminal.write = data => {
+			writes.push(data);
+			write(data);
+		};
+		const tui = new TUI(terminal);
+		tui.addChild(new WidthAndTextProbe("MAIN"));
+		tui.setRightSidebar(new WidthAndTextProbe("SIDE", 4), { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		active.push({ tui, terminal });
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDE-")));
+		expect(writes.join("")).not.toContain("\x1b[3J");
+		expect(terminal.getScrollBuffer().some(line => line.includes("EXISTING-HISTORY"))).toBe(true);
+	});
+
+	it("keeps component-scoped composition on the allocated main width", async () => {
+		const terminal = new VirtualTerminal(120, 8, 100);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(terminal, undefined, { renderScheduler: scheduler });
+		const transcript = new WidthAndTextProbe("TRANSCRIPT");
+		const spinner = new MutableWidthAndTextProbe("SPIN-0");
+		tui.addChild(transcript);
+		tui.addChild(spinner);
+		tui.setRightSidebar(new WidthAndTextProbe("SIDE", 8), { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		active.push({ tui, terminal });
+		await scheduler.drain(terminal);
+		const transcriptRenders = transcript.widths.length;
+
+		spinner.text = "SPIN-1";
+		tui.requestComponentRender(spinner);
+		await scheduler.drain(terminal);
+
+		expect(transcript.widths.length).toBe(transcriptRenders);
+		expect(terminal.getViewport().some(line => line.includes("SPIN-1") && line.includes("SIDE-1"))).toBe(true);
+	});
+
+	it("keeps direct writes enabled on the allocated main width", async () => {
+		const terminal = new VirtualTerminal(120, 8, 100);
+		const scheduler = new StressRenderScheduler();
+		const tui = new RenderCountingTUI(terminal, undefined, { renderScheduler: scheduler });
+		const transcript = new WidthAndTextProbe("TRANSCRIPT");
+		const spinner = new MutableWidthAndTextProbe("SPIN-0");
+		tui.addChild(transcript);
+		tui.addChild(spinner);
+		tui.setRightSidebar(new WidthAndTextProbe("SIDE", 8), { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		active.push({ tui, terminal });
+		await scheduler.drain(terminal);
+		const transcriptRenders = transcript.widths.length;
+		const tuiRenders = tui.renders;
+
+		spinner.text = "SPIN-1";
+		tui.requestDirectWrite(spinner);
+		await scheduler.drain(terminal);
+
+		expect(transcript.widths.length).toBe(transcriptRenders);
+		expect(tui.renders).toBe(tuiRenders);
+		expect(terminal.getViewport().some(line => line.includes("SPIN-1") && line.includes("SIDE-1"))).toBe(true);
 	});
 
 	it("renders main and sidebar at their allocated widths", async () => {

--- a/packages/tui/test/reserved-sidebar-resize.test.ts
+++ b/packages/tui/test/reserved-sidebar-resize.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { type Component, TUI, type ViewportTailProvider } from "@oh-my-pi/pi-tui";
+import { createProcessTerminalRenderHarness, WidthProbe } from "./process-terminal-render-harness";
+import { VirtualTerminal } from "./virtual-terminal";
+
+const disposers: Array<() => void> = [];
+afterEach(() => {
+	for (const dispose of disposers.splice(0)) dispose();
+});
+
+class StaticSidebar implements Component {
+	readonly widths: number[] = [];
+	readonly inputs: string[] = [];
+	invalidations = 0;
+	line = "SIDEBAR";
+
+	render(width: number): readonly string[] {
+		this.widths.push(width);
+		return [this.line];
+	}
+
+	handleInput(data: string): void {
+		this.inputs.push(data);
+	}
+
+	invalidate(): void {
+		this.invalidations++;
+	}
+}
+
+const DIRECT_RESIZE_ENV: Record<string, string | undefined> = {
+	TMUX: undefined,
+	STY: undefined,
+	ZELLIJ: undefined,
+	HERDR_ENV: undefined,
+	CMUX_WORKSPACE_ID: undefined,
+	CMUX_SURFACE_ID: undefined,
+	CMUX_REMOTE_TRANSPORT: undefined,
+	TERM_PROGRAM: undefined,
+	PI_TUI_RESIZE_IN_PLACE: "0",
+};
+
+async function withEnvPatch<T>(patch: Record<string, string | undefined>, run: () => T | Promise<T>): Promise<T> {
+	const saved: Record<string, string | undefined> = {};
+	for (const key in patch) {
+		saved[key] = Bun.env[key];
+		const value = patch[key];
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+	try {
+		return await run();
+	} finally {
+		for (const key in saved) {
+			const value = saved[key];
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+	}
+}
+
+class ContextTail implements Component, ViewportTailProvider {
+	readonly maxRows: number[] = [];
+	readonly rows = Array.from({ length: 30 }, (_, index) => `MAIN-${index}`);
+
+	render(width: number): readonly string[] {
+		return this.rows.map(line => line.slice(0, width));
+	}
+
+	renderViewportTail(width: number, maxRows: number): readonly string[] {
+		this.maxRows.push(maxRows);
+		return this.rows.slice(-maxRows).map(line => line.slice(0, width));
+	}
+}
+
+class IndexedSidebar implements Component {
+	render(): readonly string[] {
+		return Array.from({ length: 30 }, (_, index) => `SIDE-${index}`);
+	}
+}
+
+describe("reserved sidebar resize behavior", () => {
+	it("hides below 92 columns and restores without remounting", async () => {
+		const harness = createProcessTerminalRenderHarness(120, 20);
+		disposers.push(() => harness.dispose());
+		const side = new StaticSidebar();
+		harness.tui.setRightSidebar(side, { width: 44, minWidth: 28, minMainWidth: 64 });
+		await harness.settle();
+		expect(harness.probe.last).toBe(76);
+		expect(side.widths.at(-1)).toBe(43);
+
+		await harness.osResize(91, 20);
+		expect(harness.probe.last).toBe(91);
+		expect(side.widths.at(-1)).toBe(43);
+
+		await harness.osResize(92, 20);
+		expect(harness.probe.last).toBe(64);
+		expect(side.widths.at(-1)).toBe(27);
+	});
+
+	it("renders overlays above both main and sidebar and restores the sidebar", async () => {
+		const terminal = new VirtualTerminal(120, 8);
+		const tui = new TUI(terminal);
+		const main = new WidthProbe();
+		const side = new StaticSidebar();
+		tui.addChild(main);
+		tui.setRightSidebar(side, { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		disposers.push(() => tui.stop());
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDEBAR")));
+
+		const overlay = tui.showOverlay({ render: () => ["MODAL"] }, { anchor: "top-right", width: 44 });
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("MODAL")));
+		const coveredRow = terminal.getViewport().find(line => line.includes("MODAL"));
+		expect(coveredRow).not.toContain("SIDEBAR");
+
+		overlay.hide();
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDEBAR")));
+		expect(terminal.getViewport().some(line => line.includes("SIDEBAR"))).toBe(true);
+	});
+
+	it("keeps input focus on main content and invalidates the sidebar", async () => {
+		const terminal = new VirtualTerminal(120, 8);
+		const tui = new TUI(terminal);
+		const mainInputs: string[] = [];
+		const main: Component = {
+			render: () => ["MAIN"],
+			handleInput: data => mainInputs.push(data),
+		};
+		const side = new StaticSidebar();
+		tui.addChild(main);
+		tui.setFocus(main);
+		tui.setRightSidebar(side, { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		disposers.push(() => tui.stop());
+		await terminal.waitForRender();
+		terminal.sendInput("x");
+		expect(mainInputs).toEqual(["x"]);
+		expect(side.inputs).toEqual([]);
+		tui.invalidate();
+		expect(side.invalidations).toBe(1);
+	});
+
+	it("falls back to a full paint for sidebar-scoped render requests", async () => {
+		const terminal = new VirtualTerminal(120, 8);
+		const tui = new TUI(terminal);
+		const side = new StaticSidebar();
+		tui.addChild({ render: () => ["MAIN"] });
+		tui.setRightSidebar(side, { width: 44, minWidth: 28, minMainWidth: 64 });
+		tui.start();
+		disposers.push(() => tui.stop());
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDEBAR")));
+		side.line = "UPDATED";
+		tui.requestComponentRender(side);
+		await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("UPDATED")));
+		expect(terminal.getViewport().some(line => line.includes("UPDATED"))).toBe(true);
+	});
+
+	it("composes the resize sidebar onto visible rows without consuming context rows", async () => {
+		await withEnvPatch(DIRECT_RESIZE_ENV, async () => {
+			const terminal = new VirtualTerminal(120, 8, 100);
+			const tui = new TUI(terminal);
+			const main = new ContextTail();
+			tui.addChild(main);
+			tui.setRightSidebar(new IndexedSidebar(), { width: 44, minWidth: 28, minMainWidth: 64 });
+			tui.start();
+			disposers.push(() => tui.stop());
+			await terminal.waitForRender(() => terminal.getViewport().some(line => line.includes("SIDE-7")));
+
+			terminal.resize(119, 8);
+			await terminal.flush();
+
+			expect(tui.resizeViewportActive).toBe(true);
+			expect(main.maxRows.at(-1)).toBeGreaterThan(8);
+			const viewport = terminal.getViewport();
+			expect(viewport[0]).toContain("SIDE-0");
+			expect(viewport[7]).toContain("SIDE-7");
+		});
+	});
+});

--- a/packages/tui/test/reserved-sidebar-resize.test.ts
+++ b/packages/tui/test/reserved-sidebar-resize.test.ts
@@ -36,6 +36,7 @@ const DIRECT_RESIZE_ENV: Record<string, string | undefined> = {
 	CMUX_WORKSPACE_ID: undefined,
 	CMUX_SURFACE_ID: undefined,
 	CMUX_REMOTE_TRANSPORT: undefined,
+	TERM: undefined,
 	TERM_PROGRAM: undefined,
 	PI_TUI_RESIZE_IN_PLACE: "0",
 };

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -410,6 +410,17 @@ export class VirtualTerminal implements Terminal {
 		return columns;
 	}
 
+	/** Columns in a viewport row that carry an OSC 8 hyperlink. */
+	getViewportRowHyperlinkColumns(row: number): number[] {
+		const cells = this.#presentedRowCells(row);
+		if (!cells) return [];
+		const columns: number[] = [];
+		for (let col = 0; col < cells.length; col++) {
+			if ((cells[col]?.hyperlink_id ?? 0) !== 0) columns.push(col);
+		}
+		return columns;
+	}
+
 	/** Whether the cell at a viewport position carries the italic attribute. */
 	getCellItalic(row: number, col: number): boolean {
 		const cells = this.#presentedRowCells(row);

--- a/python/omp-rpc/src/omp_rpc/protocol.py
+++ b/python/omp-rpc/src/omp_rpc/protocol.py
@@ -20,7 +20,9 @@ SteeringMode: TypeAlias = Literal["all", "one-at-a-time"]
 InterruptMode: TypeAlias = Literal["immediate", "wait"]
 StopReason: TypeAlias = Literal["stop", "length", "toolUse", "error", "aborted"]
 NotifyType: TypeAlias = Literal["info", "warning", "error"]
-WidgetPlacement: TypeAlias = Literal["aboveEditor", "belowEditor"]
+WidgetPlacement: TypeAlias = Literal[
+    "aboveEditor", "belowEditor", "rightSidebar"
+]
 TodoStatus: TypeAlias = Literal[
     "pending", "in_progress", "completed", "abandoned", "blocked"
 ]
@@ -77,7 +79,7 @@ _STOP_REASON_VALUES: Final[frozenset[str]] = frozenset(
 )
 _NOTIFY_TYPE_VALUES: Final[frozenset[str]] = frozenset({"info", "warning", "error"})
 _WIDGET_PLACEMENT_VALUES: Final[frozenset[str]] = frozenset(
-    {"aboveEditor", "belowEditor"}
+    {"aboveEditor", "belowEditor", "rightSidebar"}
 )
 _TODO_STATUS_VALUES: Final[frozenset[str]] = frozenset(
     {"pending", "in_progress", "completed", "abandoned", "blocked"}
@@ -934,6 +936,9 @@ class ExtensionUiRequest:
     widget_key: str | None = None
     widget_lines: tuple[str, ...] | None = None
     widget_placement: WidgetPlacement | None = None
+    widget_width: int | None = None
+    widget_min_width: int | None = None
+    widget_min_main_width: int | None = None
     text: str | None = None
     url: str | None = None
     launch_url: str | None = None
@@ -1568,6 +1573,9 @@ def parse_extension_ui_request(payload: JsonObject) -> ExtensionUiRequest:
                 field="extension_ui_request.widgetPlacement",
             ),
         ),
+        widget_width=_optional_int(payload, "widgetWidth"),
+        widget_min_width=_optional_int(payload, "widgetMinWidth"),
+        widget_min_main_width=_optional_int(payload, "widgetMinMainWidth"),
         text=_optional_str(payload, "text"),
         url=_optional_str(payload, "url"),
         launch_url=_optional_str(payload, "launchUrl"),

--- a/python/omp-rpc/tests/test_protocol.py
+++ b/python/omp-rpc/tests/test_protocol.py
@@ -14,6 +14,7 @@ from omp_rpc import (
     parse_notification,
     parse_session_state,
 )
+from omp_rpc.protocol import parse_extension_ui_request
 
 
 class ProtocolParsingTests(unittest.TestCase):
@@ -228,6 +229,39 @@ class ProtocolParsingTests(unittest.TestCase):
         self.assertTrue(notification.is_interactive())
         self.assertTrue(notification.requires_response())
         self.assertFalse(notification.is_passive())
+
+    def test_parse_right_sidebar_widget_geometry(self) -> None:
+        request = parse_extension_ui_request(
+            {
+                "type": "extension_ui_request",
+                "id": "1",
+                "method": "setWidget",
+                "widgetKey": "quota",
+                "widgetLines": ["5 hour 42%"],
+                "widgetPlacement": "rightSidebar",
+                "widgetWidth": 44,
+                "widgetMinWidth": 28,
+                "widgetMinMainWidth": 64,
+            }
+        )
+
+        self.assertEqual(request.widget_placement, "rightSidebar")
+        self.assertEqual(request.widget_width, 44)
+        self.assertEqual(request.widget_min_width, 28)
+        self.assertEqual(request.widget_min_main_width, 64)
+
+    def test_reject_boolean_sidebar_width(self) -> None:
+        with self.assertRaisesRegex(ValueError, "widgetWidth must be an integer"):
+            parse_extension_ui_request(
+                {
+                    "type": "extension_ui_request",
+                    "id": "1",
+                    "method": "setWidget",
+                    "widgetKey": "quota",
+                    "widgetPlacement": "rightSidebar",
+                    "widgetWidth": True,
+                }
+            )
 
     def test_parse_open_url_request(self) -> None:
         notification = parse_notification(


### PR DESCRIPTION
## What

- add a TUI-level reserved right sidebar that reflows main content while keeping sidebar rows viewport-local and out of native scrollback
- expose `ctx.ui.setWidget(..., { placement: "rightSidebar", width, minWidth, minMainWidth })` with keyed aggregation, non-focusable components, error containment, and stable replacement order
- preserve ordinary, resize, partial/direct-write, Kitty image, OSC 66, ConPTY truncation, and scroll-append renderer paths
- forward the placement and geometry through TypeScript RPC and the typed Python client
- add a copyable extension example, extension/RPC docs, and changelog entries

## Why

Addresses #8126. Extensions can currently render above/below the editor or use modal overlays, but cannot reserve a persistent side column.

This is deliberately separate from #4603: `rightEditor` opportunistically composites blocks into conversation whitespace, while `rightSidebar` reserves 28–44 columns and reflows transcript/editor content.

## Testing

- focused TUI matrix: `134 pass`, `0 fail`, `698 assertions` across 10 files
- focused extension/controller/RPC matrix: `108 pass`, `0 fail`, `317 assertions` across 4 files
- Python RPC protocol: `20 passed`, `2 subtests passed`
- `packages/tui`: `bun run check` passes
- `packages/coding-agent`: `bun run check` passes
- full TypeScript harness completed green in an isolated HOME/config run; the root `bun run test` then stopped at the unchanged Rust stage because `cargo nextest`/Cargo are not installed on this workstation
- supervised real CLI PTY smoke verified 120/91/92-column geometry, editor focus, toggle, Settings overlay cover/restore, 107 native scrollback rows with no sidebar text, and clean exit
- focused coverage: `reserved-sidebar.ts` 100% functions/lines; `tui.ts` 80.32% lines

---

- [ ] `bun check` passes (package TypeScript checks pass; Rust tooling unavailable locally)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)