### PR TITLE
fix(coding-agent): clarify eval agent kernel isolation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -268,6 +268,9 @@
 - Automatically continued Gemini turns that stopped after thinking without final output, using a bounded final-answer reminder instead of exhausting generic retries.
 - Retried Gemini `MALFORMED_FUNCTION_CALL` failures when every emitted tool call was proven unexecuted, while preserving real tool-result and visible-output replay guards.
 - Kept current terminal retry errors in one pinned banner with attempt context while surfacing local continuation failures instead of stale provider errors.
+### Fixed
+
+- Fixed the Eval tool description implying that `agent()` children share parent kernel state; only `task` subagents inherit Eval state.
 
 ## [17.3.2] - 2026-08-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fixed retry fallback chains stopping prematurely when encountering nested fallback configurations, and fixed session role priority during fallback chain selection.
 - Fixed cancelled prompts disappearing upon abort during turn setup, properly restoring user text and attachments to the input editor.
 - Fixed built-in shell utilities (`grep`, `rg`, `diff`, `find`, `timeout`, `top`, `date`, `head`, `tail`, `stat`, `truncate`, `kill`) across numerous POSIX/GNU/BSD compatibility edge cases and early-pipeline SIGPIPE handling.
+- Fixed Eval guidance that implied `agent()` children share parent kernel state and advertised them when spawning was disabled.
 - Fixed Cursor sessions missing standard string-replacement edit tooling after server tool injection.
 - Fixed `hub wait` duplicating frozen rows into native scrollback during viewport overflow.
 - Fixed dark-theme contrast issues on markdown code-fence headers.
@@ -268,9 +269,6 @@
 - Automatically continued Gemini turns that stopped after thinking without final output, using a bounded final-answer reminder instead of exhausting generic retries.
 - Retried Gemini `MALFORMED_FUNCTION_CALL` failures when every emitted tool call was proven unexecuted, while preserving real tool-result and visible-output replay guards.
 - Kept current terminal retry errors in one pinned banner with attempt context while surfacing local continuation failures instead of stale provider errors.
-### Fixed
-
-- Fixed the Eval tool description implying that `agent()` children share parent kernel state; only `task` subagents inherit Eval state.
 
 ## [17.3.2] - 2026-08-13
 

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -1,4 +1,5 @@
-Run one step of code in a persistent kernel. State persists across calls and `task` subagents; Eval `agent()` children use independent kernels.
+Run one step of code in a persistent kernel. State persists across calls and `task` subagents.
+{{#if spawns}}Eval `agent()` children use independent kernels.{{/if}}
 
 Work incrementally: imports → define → test → use, each its own cell. Re-run setup ONLY after `reset`, kernel crash.
 Parallelize *within* a cell with `parallel(thunks)`, not by batching.

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -1,4 +1,4 @@
-Run one step of code in a persistent kernel. State persists across calls and subagents.
+Run one step of code in a persistent kernel. State persists across calls and `task` subagents; Eval `agent()` children use independent kernels.
 
 Work incrementally: imports → define → test → use, each its own cell. Re-run setup ONLY after `reset`, kernel crash.
 Parallelize *within* a cell with `parallel(thunks)`, not by batching.

--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -368,7 +368,7 @@ describe("runEvalAgent", () => {
 		]);
 	});
 
-	it("inherits non-plan LSP and IRC policy for bridge subagents", async () => {
+	it("keeps bridge kernels independent while inheriting non-plan LSP and IRC policy", async () => {
 		mockAgents();
 		const runSpy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => singleResult(options));
 		// makeSession() defaults to enableLsp: true and task.enableLsp: true.
@@ -381,6 +381,7 @@ describe("runEvalAgent", () => {
 		expect(options.enableLsp).toBe(true);
 		expect(options.enableIrc).toBe(true);
 		expect(options.keepAlive).toBe(false);
+		expect(options.parentEvalSessionId).toBeUndefined();
 	});
 
 	it("registers temp artifact dirs for in-memory handle results so agent URLs resolve", async () => {

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -49,17 +49,12 @@ describe("eval tool description", () => {
 		expect(text).toContain("agent(prompt");
 	});
 
-	it("distinguishes shared task state from isolated agent() kernels", () => {
-		const text = getEvalToolDescription({ py: true, js: true, spawns: true });
-		expect(text).toContain("State persists across calls and `task` subagents");
-		expect(text).toContain("Eval `agent()` children use independent kernels");
-	});
-
 	it("omits agent() when the session forbids spawning", () => {
 		// Subagents with spawns: undefined (resolved to "") cannot launch tasks.
 		// The prelude doc must not promise a helper that always throws.
 		const text = getEvalToolDescription({ py: true, js: true, spawns: false });
 		expect(text).not.toContain("agent(prompt");
+		expect(text).not.toContain("agent()");
 	});
 
 	it("EvalTool description reflects spawn policy from the session", () => {

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -54,7 +54,6 @@ describe("eval tool description", () => {
 		// The prelude doc must not promise a helper that always throws.
 		const text = getEvalToolDescription({ py: true, js: true, spawns: false });
 		expect(text).not.toContain("agent(prompt");
-		expect(text).not.toContain("agent()");
 	});
 
 	it("EvalTool description reflects spawn policy from the session", () => {

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -49,6 +49,12 @@ describe("eval tool description", () => {
 		expect(text).toContain("agent(prompt");
 	});
 
+	it("distinguishes shared task state from isolated agent() kernels", () => {
+		const text = getEvalToolDescription({ py: true, js: true, spawns: true });
+		expect(text).toContain("State persists across calls and `task` subagents");
+		expect(text).toContain("Eval `agent()` children use independent kernels");
+	});
+
 	it("omits agent() when the session forbids spawning", () => {
 		// Subagents with spawns: undefined (resolved to "") cannot launch tasks.
 		// The prelude doc must not promise a helper that always throws.


### PR DESCRIPTION
## What

Clarify the Eval kernel-state contract.
State persists across calls and ordinary `task` subagents.
Children launched through Eval `agent()` use independent kernels.

The focused tests also pin the existing bridge policy.
They assert that `runEvalAgent` does not pass a Parent Eval session ID.

## Why

The current prompt says state persists across all subagents, but Eval `agent()` intentionally uses `shareEvalSession: false`.
Sharing that executor would reintroduce the deadlock avoided by the existing bridge design.

Issues #3196 and #5279 and PR #3205 describe related Eval isolation behavior.
None corrects this later prompt regression.

## Testing

- `bun test packages/coding-agent/test/tools/eval-description.test.ts packages/coding-agent/test/eval/agent-bridge-policy.test.ts` — 48 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` — Biome and type checks pass.
- GitHub Actions run `32440357822` — all required jobs pass.

I checked the relevant issues, comments, pull requests, and discussions; this pull request is not a duplicate.

---

- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] Focused tests pass
- [x] CHANGELOG updated

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output.
Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones.
My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.