### PR TITLE
fix(ci): fetch crates before the offline cargo-deny check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,13 @@ jobs:
          - name: Verify Rust license compliance (cargo-deny 0.20.2)
            run: |
               cargo install --locked --version 0.20.2 cargo-deny
+              # `--offline` needs every workspace crate already in the registry
+              # cache. PR runs use a fresh GitHub-hosted runner (see runs-on
+              # above), where the only prior cargo work is the cargo-deny
+              # install, so nothing populates the index for our own graph and
+              # resolution fails. Non-PR events land on omp-kata, whose Cargo
+              # cache is warm, which is why main stayed green. Fetch first.
+              cargo fetch --locked
               cargo deny --locked --offline check licenses sources
          - name: Type check workspace
            run: bun run ci:check:full


### PR DESCRIPTION
Noticed that CI is failing because of the license check. Thought I'd send a small pull to fix it.

## What's wrong

`cargo deny --locked --offline check licenses sources` resolves the whole workspace graph through `cargo metadata`, which needs every crate already present in the local registry cache. Nothing populates that cache for our own graph — the preceding `cargo install --locked --version 0.20.2 cargo-deny` only caches cargo-deny's own dependencies.

That stays invisible on non-PR events, which run on `omp-kata` with a PVC-backed Cargo cache, so the index is warm and resolution succeeds. Pull requests hit the other half of the job's `runs-on`:

```yaml
runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-22.04' || 'omp-kata' }}
```

On a fresh `ubuntu-22.04` runner the cache is empty, so the step fails on the first workspace dependency it cannot resolve:

```
[ERROR] failed to fetch crates: error: no matching package named `ast-grep-core` found
[ERROR] `cargo metadata` exited with an error: error: no matching package named `ast-grep-core` found
help: if this error is too confusing you may wish to retry without `--offline`
```

`ast-grep-core 0.39.9` is on crates.io and is not yanked, so this was never a bad dependency — only a cold cache.

## The change

One added command:

```yaml
  cargo install --locked --version 0.20.2 cargo-deny
+ cargo fetch --locked
  cargo deny --locked --offline check licenses sources
```

Additive on purpose: the existing command and its flags are untouched, so warm-cache behavior on `omp-kata` is unchanged, and the `--offline` guarantee still holds for the check itself.

## Verification

I reproduced the failure and confirmed the fix with an isolated `CARGO_HOME`, which simulates the fresh PR runner:

| Step | Result |
| --- | --- |
| Cold cache → `cargo metadata --locked --offline` | exit 101, `no matching package named ... found` + the same `offline mode ... surprising resolution failures` hint |
| `cargo fetch --locked` into that cache | exit 0 |
| Same cache → `cargo metadata --locked --offline` | exit 0, no errors |

Locally the first unresolvable crate is `anyhow` rather than `ast-grep-core` — resolution order differs from CI, but the failing command and its error are the same, and `cargo metadata` is exactly what the CI log reports failing.

No changelog entry, matching the recent `fix(ci):` commits.

## Alternative

Dropping `--offline` would also fix it, and the line above already reaches the network to install cargo-deny, so the flag is not buying isolation for the step as a whole. I went with `cargo fetch` because it cannot change anything for the warm self-hosted runner — happy to switch if you'd rather have the simpler command.
