### PR TITLE
fix(coding-agent): clarify Todo items schema

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Todo tool schemas now identify `items` as valid for single-phase `init` and `append`.
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -83,7 +83,7 @@ const todoSchema = type({
 	// No `atLeastLength(1)` here: `items` is only meaningful for `init`/`append`,
 	// and both enforce non-empty with op-specific errors. A stray `items: []` on
 	// an op that ignores it (e.g. `view`) must not be a hard schema rejection.
-	"items?": type("string").describe("task content").array().describe("tasks to append"),
+	"items?": type("string").describe("task content").array().describe("tasks for single-phase init or append"),
 	"reason?": type("string").describe("blocker note (block op)"),
 }).describe("apply a single todo operation");
 

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
+import { toolWireSchema } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
@@ -423,6 +424,18 @@ describe("TodoTool operations", () => {
 		if (summary?.type !== "text") throw new Error("Expected text summary");
 		expect(summary.text).toContain("Todo list is empty.");
 		expect(result.isError).toBeUndefined();
+	});
+});
+
+describe("TodoTool provider schema", () => {
+	it("advertises items for single-phase init and append", () => {
+		expect(toolWireSchema(new TodoTool(createSession()))).toMatchObject({
+			properties: {
+				items: {
+					description: "tasks for single-phase init or append",
+				},
+			},
+		});
 	});
 });
 


### PR DESCRIPTION
## What

Clarify the Todo tool's provider-facing `items` schema description.
It now identifies `items` as valid for single-phase `init` and `append`.
Runtime behavior is unchanged.

## Why

Single-phase init was added for common Gemini Todo calls and is documented in the model prompt and full tool docs.
The schema-local description still says only “tasks to append”.
Providers and `xd://` docs expose that hint directly to models, where it contradicts the accepted `init` shape.

## Testing

- `bun test packages/coding-agent/test/tools/todo.test.ts` — 73 pass, 0 fail.
- `bun run --cwd packages/coding-agent check`
- `bun check`
- Provider wire inspection returned `tasks for single-phase init or append`.
- `{op:"init",items:["First","Second"]}` produced `Tasks` with `First` active and `Second` pending.

Just a little fix for coherence.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.