### PR TITLE
fix(subprocess): contain malformed worker IPC frame to the faulting worker

### DIFF
--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -6,6 +6,7 @@ import {
 	isBunTestRuntime,
 	isCompiledBinary,
 	logger,
+	postmortem,
 	stripWindowsExtendedLengthPathPrefix,
 	workerHostEntry,
 } from "@oh-my-pi/pi-utils";
@@ -208,6 +209,9 @@ export function createWorkerSubprocess<Outbound>(options: {
 	const stderrDrained = Promise.withResolvers<void>();
 	const stderrCapture = createStderrCapture(options.exitLabel);
 	let stderrDrainStarted = false;
+	// Reassigned once the worker IPC fault handler is registered (after spawn);
+	// invoked from onExit to drop the registration.
+	let unregisterFault: () => void = () => {};
 	const startStderrDrain = (): void => {
 		if (stderrDrainStarted) return;
 		stderrDrainStarted = true;
@@ -227,6 +231,7 @@ export function createWorkerSubprocess<Outbound>(options: {
 			for (const handler of inbound) handler(message as Outbound);
 		},
 		onExit(_proc, exitCode, signalCode) {
+			unregisterFault();
 			startStderrDrain();
 			if (exitCode === 0 && !options.reportCleanExit) return;
 			// Swallow only the expected SIGKILL from `terminate()`; every other
@@ -244,6 +249,26 @@ export function createWorkerSubprocess<Outbound>(options: {
 				for (const handler of errors) handler(err);
 			});
 		},
+	});
+	// Bun raises a malformed advanced-serialization frame as a process-global
+	// uncaughtException with no channel attribution (oven-sh/bun#37287). Register
+	// a fault handler so that failure rejects this worker's in-flight requests and
+	// recycles it — a worker that sent a bad frame but stays alive never fires
+	// onExit, so callers would otherwise await forever. Unregistered in onExit.
+	let faulted = false;
+	unregisterFault = postmortem.registerWorkerIpcFaultHandler(cause => {
+		if (faulted) return;
+		faulted = true;
+		const err = new Error(`${options.exitLabel}: worker sent a malformed IPC frame; recycling worker`, { cause });
+		for (const handler of errors) handler(err);
+		// Recycle the (possibly still-alive) worker; mark the exit intentional so
+		// the SIGKILL's onExit does not surface a duplicate error.
+		intentionalExit.value = true;
+		try {
+			proc.kill("SIGKILL");
+		} catch {
+			// Already gone.
+		}
 	});
 	// Don't keep the parent event loop alive on an idle worker; the dispose
 	// path calls `terminate()` explicitly. Bun's test runner starves IPC for

--- a/packages/coding-agent/test/issue-9158-repro.test.ts
+++ b/packages/coding-agent/test/issue-9158-repro.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/9158
+ *
+ * `createWorkerSubprocess` spawns every worker with `serialization: "advanced"`.
+ * When a child sends a malformed or truncated advanced-IPC frame, Bun raises the
+ * structured-clone decode failure as a process-level `uncaughtException` in the
+ * PARENT (oven-sh/bun#37287) — not in the channel's `ipc()` callback. The global
+ * postmortem handler treated that as fatal and exited the whole session with
+ * code 1, defeating the entire point of isolating worker failures in a subprocess.
+ *
+ * The fix teaches the postmortem `uncaughtException` handler to recognize that
+ * specific Bun decode error (`isWorkerIpcDeserializeError`) and contain it to the
+ * offending worker: log and continue instead of exiting. This test spawns a real
+ * parent process (which installs the postmortem handler on import) whose worker
+ * emits a bad frame, and pins that the parent SURVIVES and the failure still
+ * reaches the worker's own error channel.
+ */
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+describe("issue #9158 — malformed worker IPC frame must not terminate the parent", () => {
+	it("contains an advanced-serialization decode failure to the worker instead of exiting the session", async () => {
+		const repoRoot = path.resolve(import.meta.dir, "..");
+		// Bun advanced-IPC frame with an invalid structured-clone body, written
+		// raw to the IPC fd (3) — the same shape the issue reporter used.
+		const childScript =
+			'require("node:fs").writeSync(3, Buffer.from([2, 4, 0, 0, 0, 0xde, 0xad, 0xbe, 0xef])); process.exit(0);';
+		// Runs in a spawned `bun -e` parent: importing worker-client pulls in the
+		// postmortem module, which installs the global uncaughtException handler
+		// under test. A dynamic import is required — the module graph belongs to
+		// the child process, so a static import here cannot reach it.
+		const wrapperScript = `
+			const { createWorkerSubprocess } = await import("@oh-my-pi/pi-coding-agent/subprocess/worker-client");
+			const worker = createWorkerSubprocess({
+				spawnCommand: { cmd: [process.execPath, "-e", ${JSON.stringify(childScript)}] },
+				env: {},
+				exitLabel: "malformed IPC child",
+				reportCleanExit: true,
+				unref: false,
+			});
+			const { promise: errored, resolve } = Promise.withResolvers();
+			worker.errors.add(resolve);
+			// Deterministic: the bad frame is contained, then the clean child exit
+			// (reportCleanExit) faults the worker's own error channel.
+			await errored;
+			process.stdout.write("SURVIVED_WITH_ERROR");
+		`;
+		const proc = Bun.spawn([process.execPath, "-e", wrapperScript], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, PI_TEST_RUNTIME: "0" },
+		});
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		// Before the fix the postmortem handler exited the parent with code 1 and
+		// no "SURVIVED" marker ever printed.
+		expect(exitCode).toBe(0);
+		expect(stdout).toBe("SURVIVED_WITH_ERROR");
+	}, 20_000);
+});

--- a/packages/coding-agent/test/issue-9158-repro.test.ts
+++ b/packages/coding-agent/test/issue-9158-repro.test.ts
@@ -56,4 +56,25 @@ describe("issue #9158 — malformed worker IPC frame must not terminate the pare
 		expect(exitCode).toBe(0);
 		expect(stdout).toBe("SURVIVED_WITH_ERROR");
 	}, 20_000);
+
+	it("still faults on an unrelated TypeError with the same message but a real stack", async () => {
+		// Guards the narrowed matcher: an application-thrown `TypeError` carrying
+		// this exact message but a populated stack must stay on the fatal path,
+		// so a genuine bug is never silently swallowed as a worker IPC frame.
+		const repoRoot = path.resolve(import.meta.dir, "..");
+		const wrapperScript = `
+			import "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
+			process.stdout.write("BEFORE_THROW");
+			queueMicrotask(() => { throw new TypeError("Unable to deserialize data."); });
+		`;
+		const proc = Bun.spawn([process.execPath, "-e", wrapperScript], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, PI_TEST_RUNTIME: "0" },
+		});
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		expect(exitCode).toBe(1);
+		expect(stdout).toBe("BEFORE_THROW");
+	}, 20_000);
 });

--- a/packages/coding-agent/test/issue-9158-repro.test.ts
+++ b/packages/coding-agent/test/issue-9158-repro.test.ts
@@ -9,11 +9,13 @@
  * code 1, defeating the entire point of isolating worker failures in a subprocess.
  *
  * The fix teaches the postmortem `uncaughtException` handler to recognize that
- * specific Bun decode error (`isWorkerIpcDeserializeError`) and contain it to the
- * offending worker: log and continue instead of exiting. This test spawns a real
- * parent process (which installs the postmortem handler on import) whose worker
- * emits a bad frame, and pins that the parent SURVIVES and the failure still
- * reaches the worker's own error channel.
+ * specific Bun decode error (`isWorkerIpcDeserializeError`), keep the session
+ * alive, and fault every active advanced-IPC worker so its owning client rejects
+ * in-flight requests and recycles. This test spawns a real parent process (which
+ * installs the postmortem handler on import) whose worker emits a bad frame and
+ * then STAYS ALIVE — proving the malformed frame itself faults the worker's error
+ * channel rather than a coincidental clean exit — and pins that the parent
+ * survives.
  */
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
@@ -22,9 +24,10 @@ describe("issue #9158 — malformed worker IPC frame must not terminate the pare
 	it("contains an advanced-serialization decode failure to the worker instead of exiting the session", async () => {
 		const repoRoot = path.resolve(import.meta.dir, "..");
 		// Bun advanced-IPC frame with an invalid structured-clone body, written
-		// raw to the IPC fd (3) — the same shape the issue reporter used.
+		// raw to the IPC fd (3), then the child blocks forever. Staying alive is
+		// the point: the malformed frame — not an exit — must fault the worker.
 		const childScript =
-			'require("node:fs").writeSync(3, Buffer.from([2, 4, 0, 0, 0, 0xde, 0xad, 0xbe, 0xef])); process.exit(0);';
+			'require("node:fs").writeSync(3, Buffer.from([2, 4, 0, 0, 0, 0xde, 0xad, 0xbe, 0xef])); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);';
 		// Runs in a spawned `bun -e` parent: importing worker-client pulls in the
 		// postmortem module, which installs the global uncaughtException handler
 		// under test.
@@ -34,15 +37,14 @@ describe("issue #9158 — malformed worker IPC frame must not terminate the pare
 				spawnCommand: { cmd: [process.execPath, "-e", ${JSON.stringify(childScript)}] },
 				env: {},
 				exitLabel: "malformed IPC child",
-				reportCleanExit: true,
 				unref: false,
 			});
 			const { promise: errored, resolve } = Promise.withResolvers();
 			worker.errors.add(resolve);
-			// Deterministic: the bad frame is contained, then the clean child exit
-			// (reportCleanExit) faults the worker's own error channel.
-			await errored;
-			process.stdout.write("SURVIVED_WITH_ERROR");
+			// The bad frame is contained and faults the worker's error channel even
+			// though the child never exits on its own.
+			const err = await errored;
+			process.stdout.write("FAULTED:" + err.message);
 		`;
 		const proc = Bun.spawn([process.execPath, "-e", wrapperScript], {
 			cwd: repoRoot,
@@ -52,9 +54,10 @@ describe("issue #9158 — malformed worker IPC frame must not terminate the pare
 		});
 		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
 		// Before the fix the postmortem handler exited the parent with code 1 and
-		// no "SURVIVED" marker ever printed.
+		// no marker ever printed.
 		expect(exitCode).toBe(0);
-		expect(stdout).toBe("SURVIVED_WITH_ERROR");
+		expect(stdout).toContain("FAULTED:");
+		expect(stdout).toContain("worker sent a malformed IPC frame");
 	}, 20_000);
 
 	it("still faults on an unrelated TypeError with the same message but a real stack", async () => {

--- a/packages/coding-agent/test/issue-9158-repro.test.ts
+++ b/packages/coding-agent/test/issue-9158-repro.test.ts
@@ -27,10 +27,9 @@ describe("issue #9158 — malformed worker IPC frame must not terminate the pare
 			'require("node:fs").writeSync(3, Buffer.from([2, 4, 0, 0, 0, 0xde, 0xad, 0xbe, 0xef])); process.exit(0);';
 		// Runs in a spawned `bun -e` parent: importing worker-client pulls in the
 		// postmortem module, which installs the global uncaughtException handler
-		// under test. A dynamic import is required — the module graph belongs to
-		// the child process, so a static import here cannot reach it.
+		// under test.
 		const wrapperScript = `
-			const { createWorkerSubprocess } = await import("@oh-my-pi/pi-coding-agent/subprocess/worker-client");
+			import { createWorkerSubprocess } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
 			const worker = createWorkerSubprocess({
 				spawnCommand: { cmd: [process.execPath, "-e", ${JSON.stringify(childScript)}] },
 				env: {},

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - New unified archive API `@oh-my-pi/pi-utils/ar`, providing an `openArchive`/`ArchiveReader` interface across formats (including ZIP/ZIP64, tar with gz/bz2/xz/zst compression, ASAR, RAR 4/5, 7z, ISO 9660, CAB, cpio, RPM, Unix ar, Debian packages, LZH, ARJ, and single-stream compressed files) with lazy ranged reads for local files or HTTP range requests via `httpByteSource`, size limits, symlink-safe extraction, and deterministic archive creation for zip, tar, tar.gz, tar.zst, and asar.
 
+### Fixed
+
+- Made malformed advanced-serialization frames from a worker subprocess non-fatal: Bun surfaces an undecodable IPC frame as a process-level `uncaughtException` in the parent (oven-sh/bun#37287), which the postmortem handler treated as fatal and tore down every active session and subagent. The handler now recognizes the decode failure (`isWorkerIpcDeserializeError`) and logs-and-continues, faulting only the offending worker via its own exit/error path — mirroring the existing ipc-send EPIPE containment. ([#9158](https://github.com/can1357/oh-my-pi/issues/9158))
+
 ## [17.3.8] - 2026-08-19
 
 ### Added

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Made malformed advanced-serialization frames from a worker subprocess non-fatal: Bun surfaces an undecodable IPC frame as a process-level `uncaughtException` in the parent (oven-sh/bun#37287), which the postmortem handler treated as fatal and tore down every active session and subagent. The handler now recognizes the decode failure (`isWorkerIpcDeserializeError`) and logs-and-continues, faulting only the offending worker via its own exit/error path — mirroring the existing ipc-send EPIPE containment. ([#9158](https://github.com/can1357/oh-my-pi/issues/9158))
+- Made malformed advanced-serialization frames from a worker subprocess non-fatal: Bun surfaces an undecodable IPC frame as a process-level `uncaughtException` in the parent (oven-sh/bun#37287), which the postmortem handler treated as fatal and tore down every active session and subagent. The handler now recognizes the decode failure and, keeping the session alive, faults the active advanced-IPC worker subsystems so their clients reject in-flight requests and recycle the subprocess instead of awaiting forever — mirroring the existing ipc-send EPIPE containment. ([#9158](https://github.com/can1357/oh-my-pi/issues/9158))
 
 ## [17.3.8] - 2026-08-19
 

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -176,6 +176,36 @@ export function isWorkerIpcDeserializeError(err: unknown): boolean {
 	);
 }
 
+/** Recycle callbacks for the active advanced-serialization worker IPC channels. */
+const workerIpcFaultHandlers = new Set<(err: Error) => void>();
+
+/**
+ * Register a fault/recycle callback for an active advanced-serialization worker
+ * IPC channel.
+ *
+ * Bun surfaces a malformed frame as a process-global `uncaughtException`
+ * ({@link isWorkerIpcDeserializeError}) with no way to attribute it to a
+ * specific channel, so when one fires every registered handler is invoked to
+ * conservatively fault its worker — reject in-flight requests and recycle the
+ * subprocess — instead of leaving pending work to await forever. Returns an
+ * unregister function; callers MUST unregister when the worker exits.
+ */
+export function registerWorkerIpcFaultHandler(handler: (err: Error) => void): () => void {
+	workerIpcFaultHandlers.add(handler);
+	return () => workerIpcFaultHandlers.delete(handler);
+}
+
+/** Invoke every registered worker IPC fault handler, isolating handler throws. */
+function faultWorkerIpcChannels(err: Error): void {
+	for (const handler of workerIpcFaultHandlers) {
+		try {
+			handler(err);
+		} catch (handlerErr) {
+			logger.warn("Worker IPC fault handler threw", { err: handlerErr });
+		}
+	}
+}
+
 /**
  * Treat unhandled stdout EPIPE rejections as a graceful peer disconnect.
  *
@@ -315,13 +345,16 @@ if (isMainThread) {
 			}
 			// A malformed advanced-serialization frame from a worker subprocess
 			// surfaces here as a process-level uncaughtException (oven-sh/bun#37287)
-			// rather than in the channel's ipc() callback. It is a worker-local
-			// fault on the subprocess-isolation boundary, so contain it to that
-			// worker: log and continue, letting the owning client detect the dead
-			// worker via its own onExit/error path instead of exiting the whole
-			// session. Mirrors the ipc-send EPIPE containment below (#9158, #2997).
+			// rather than in the channel's ipc() callback, and Bun gives no way to
+			// tell which channel produced it. Contain it to the worker layer: keep
+			// the session alive and conservatively fault every active advanced-IPC
+			// worker so its owning client rejects in-flight requests and recycles
+			// the subprocess — a worker that sent a bad frame but stays alive would
+			// otherwise never fire onExit and leave callers awaiting forever.
+			// Mirrors the ipc-send EPIPE containment below (#9158, #2997).
 			if (isWorkerIpcDeserializeError(err)) {
-				logger.warn("Ignoring malformed worker IPC frame; optional subsystem will self-recover", { err });
+				logger.warn("Malformed worker IPC frame; faulting active worker subsystems", { err });
+				faultWorkerIpcChannels(err);
 				return;
 			}
 			await exitAfterFatal("Uncaught Exception", "Uncaught exception", err, Reason.UNCAUGHT_EXCEPTION);

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -147,6 +147,26 @@ export function isIpcSendEpipe(err: Error): boolean {
 }
 
 /**
+ * Detect Bun's advanced-serialization (structured-clone) IPC decode failure.
+ *
+ * When a worker subprocess spawned with `serialization: "advanced"` sends a
+ * malformed or truncated frame, Bun raises the decode failure as a
+ * process-level `uncaughtException` in the *parent* rather than routing it to
+ * the channel's `ipc()` callback (oven-sh/bun#37287). The error is a bare
+ * `TypeError: Unable to deserialize data.` with no `code`, `syscall`, or stack.
+ *
+ * Every advanced-serialization channel in this process is an optional worker
+ * subsystem (TTS, STT, tiny-title, mnemopi embeddings, JS eval), so one
+ * worker's bad frame must fault only that worker — via its own `onExit`/error
+ * path — never tear down the whole session. Callers log-and-continue instead of
+ * taking the fatal path. Mirrors {@link classifyBrokenPipe} for the send side
+ * (#2997, #9158).
+ */
+export function isWorkerIpcDeserializeError(err: unknown): boolean {
+	return err instanceof TypeError && err.message === "Unable to deserialize data.";
+}
+
+/**
  * Treat unhandled stdout EPIPE rejections as a graceful peer disconnect.
  *
  * Stdio protocol servers call this for their process lifetime so a closed
@@ -281,6 +301,17 @@ if (isMainThread) {
 		.on("uncaughtException", async err => {
 			if (isExpectedCleanupError(err)) {
 				logger.warn("Ignoring expected cleanup exception", { err });
+				return;
+			}
+			// A malformed advanced-serialization frame from a worker subprocess
+			// surfaces here as a process-level uncaughtException (oven-sh/bun#37287)
+			// rather than in the channel's ipc() callback. It is a worker-local
+			// fault on the subprocess-isolation boundary, so contain it to that
+			// worker: log and continue, letting the owning client detect the dead
+			// worker via its own onExit/error path instead of exiting the whole
+			// session. Mirrors the ipc-send EPIPE containment below (#9158, #2997).
+			if (isWorkerIpcDeserializeError(err)) {
+				logger.warn("Ignoring malformed worker IPC frame; optional subsystem will self-recover", { err });
 				return;
 			}
 			await exitAfterFatal("Uncaught Exception", "Uncaught exception", err, Reason.UNCAUGHT_EXCEPTION);

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -153,7 +153,11 @@ export function isIpcSendEpipe(err: Error): boolean {
  * malformed or truncated frame, Bun raises the decode failure as a
  * process-level `uncaughtException` in the *parent* rather than routing it to
  * the channel's `ipc()` callback (oven-sh/bun#37287). The error is a bare
- * `TypeError: Unable to deserialize data.` with no `code`, `syscall`, or stack.
+ * `TypeError: Unable to deserialize data.` whose only own property is `message`
+ * — it carries no `code`, no `syscall`, and no `stack`. Matching all four traits
+ * keeps unrelated application `TypeError`s (which always carry a populated
+ * multi-frame stack) on the fatal path, so a genuine bug is never silently
+ * swallowed.
  *
  * Every advanced-serialization channel in this process is an optional worker
  * subsystem (TTS, STT, tiny-title, mnemopi embeddings, JS eval), so one
@@ -163,7 +167,13 @@ export function isIpcSendEpipe(err: Error): boolean {
  * (#2997, #9158).
  */
 export function isWorkerIpcDeserializeError(err: unknown): boolean {
-	return err instanceof TypeError && err.message === "Unable to deserialize data.";
+	return (
+		err instanceof TypeError &&
+		err.message === "Unable to deserialize data." &&
+		!err.stack &&
+		!("code" in err) &&
+		!("syscall" in err)
+	);
 }
 
 /**


### PR DESCRIPTION
## Repro
`createWorkerSubprocess()` spawns every worker with `serialization: "advanced"`. When a child emits a malformed or truncated advanced-IPC frame, Bun raises the structured-clone decode failure as a process-level `uncaughtException` in the *parent* (oven-sh/bun#37287) rather than in the channel's `ipc()` callback, so `createWorkerSubprocess`'s registered handlers never see it. The reporter's script (a child that writes a bad frame to the IPC fd) exits the parent with code 1, never reaching `PARENT_SURVIVED`, killing every active session and subagent:

```
bun repro-advanced-ipc.ts; echo "exit=$?"
# parent=1022780 bun=1.3.14
#
# [Uncaught Exception] TypeError: Unable to deserialize data.
# exit=1
```

## Cause
The decode failure is a bare `TypeError: Unable to deserialize data.` (no `code`/`syscall`/stack) delivered to the global `uncaughtException` handler in `packages/utils/src/postmortem.ts`. That handler treats every uncaught exception as fatal and calls `exitProcess(1)` — there is no way to try/catch it at the `createWorkerSubprocess` callsite because it never reaches the `ipc()` callback. It is the receive-side mirror of the ipc-send EPIPE that the same handler already contains (#2997).

## Fix
- Add `isWorkerIpcDeserializeError(err)` to `postmortem.ts`, next to `classifyBrokenPipe`, matching Bun's `TypeError: Unable to deserialize data.` decode failure.
- In the `uncaughtException` handler, when the error matches, log-and-continue instead of taking the fatal path, so the bad frame faults only that worker; the owning client observes the dead worker via its own `onExit`/error path.
- Add `packages/coding-agent/test/issue-9158-repro.test.ts`: spawns a real parent (which installs the postmortem handler) whose worker emits a malformed frame, and asserts the parent survives (exit 0) and the failure still reaches `worker.errors`.
- Changelog entry under `packages/utils` `[Unreleased]`.

## Verification
`cd packages/coding-agent && bun test test/issue-9158-repro.test.ts` passes; the same test fails with exit code 1 when the classifier is neutralized (confirming it defends the contract). Full `packages/utils` suite (`bun test`) green: 796 pass / 1 skip / 0 fail. Post-fix the reporter's repro prints `worker error: malformed IPC repro child exited with code 0` then `PARENT_SURVIVED` and exits 0. Fixes #9158