### PR TITLE
fix(theme): respect Terminal.app color depth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed unreadable colors in macOS Terminal.app by using its supported 256-color mode ([#9162](https://github.com/can1357/oh-my-pi/issues/9162)).
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/modes/theme/color.ts
+++ b/packages/coding-agent/src/modes/theme/color.ts
@@ -1,25 +1,15 @@
+import { detectTerminalId, getTerminalInfo } from "@oh-my-pi/pi-tui";
 import type { ColorMode, ColorValue } from "./schema";
 
 // ============================================================================
 // Color Utilities
 // ============================================================================
 
-export function detectColorMode(): ColorMode {
-	const colorterm = Bun.env.COLORTERM;
-	if (colorterm === "truecolor" || colorterm === "24bit") {
-		return "truecolor";
-	}
-	// Windows Terminal supports truecolor
-	if (Bun.env.WT_SESSION) {
-		return "truecolor";
-	}
-	const term = Bun.env.TERM || "";
-	// Only fall back to 256color for truly limited terminals
-	if (term === "dumb" || term === "" || term === "linux") {
-		return "256color";
-	}
-	// Assume truecolor for everything else - virtually all modern terminals support it
-	return "truecolor";
+/** Resolve theme color depth from the shared terminal capability model. */
+export function detectColorMode(env: NodeJS.ProcessEnv = Bun.env): ColorMode {
+	if (env.WT_SESSION) return "truecolor";
+	const terminal = getTerminalInfo(detectTerminalId(env), process.platform, env);
+	return terminal.trueColor ? "truecolor" : "256color";
 }
 
 export function colorToAnsi(color: string, mode: ColorMode): string {

--- a/packages/coding-agent/test/theme-color-mode.test.ts
+++ b/packages/coding-agent/test/theme-color-mode.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "bun:test";
+import { colorToAnsi, detectColorMode } from "../src/modes/theme/color";
+
+describe("theme color mode", () => {
+	it("emits 256-color SGR for macOS Terminal.app", () => {
+		const mode = detectColorMode({ TERM_PROGRAM: "Apple_Terminal", TERM: "xterm-256color" });
+
+		expect(mode).toBe("256color");
+		expect(colorToAnsi("#f5e0ac", mode)).toBe("\x1b[38;5;223m");
+	});
+});


### PR DESCRIPTION
## Repro
Run omp in macOS Terminal.app, whose environment includes `TERM_PROGRAM=Apple_Terminal` and `TERM=xterm-256color` without `COLORTERM`. The focused probe `TERM_PROGRAM=Apple_Terminal TERM=xterm-256color COLORTERM= bun --eval 'import { detectColorMode, colorToAnsi } from "./packages/coding-agent/src/modes/theme/color.ts"; const mode = detectColorMode(); console.log(JSON.stringify({ mode, sample: colorToAnsi("#f5e0ac", mode) }));'` returned `truecolor` and a `38;2;…` sequence before the fix.

## Cause
`detectColorMode()` in `packages/coding-agent/src/modes/theme/color.ts` optimistically treated every non-dumb terminal as truecolor instead of using the capability model in `packages/tui/src/terminal-capabilities.ts`; Terminal.app therefore received unsupported 24-bit SGR despite being classified as a 256-color terminal elsewhere.

## Fix
- Resolve theme color depth through `detectTerminalId()` and `getTerminalInfo()`.
- Preserve Windows Terminal truecolor detection.
- Add a Terminal.app regression covering the emitted 256-color SGR and document the fix in the changelog.

## Verification
`bun test test/theme-color-mode.test.ts` from `packages/coding-agent` passes (1 test, 2 assertions). Re-running the environment probe returns `256color` and `\u001b[38;5;223m`. The pre-publish `bun check` gate passed.

Fixes #9162