### PR TITLE
fix(cursor): split reasoning-sibling slugs into base id + reasoning param

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed Google Cloud Code Assist and Antigravity rejecting MCP tool schemas with unsupported annotations (`x-mcp-header`, `deprecated`, `readOnly`, `writeOnly`, `$comment`).
 - Fixed Cursor provider issues with native file edit streaming (`editToolCall`) and ensuring always-apply system rules are properly preserved.
 - Fixed Cursor HTTP/2 requests ignoring standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`).
+- Fixed Cursor reasoning-sibling models (e.g. `gpt-5.4-mini-low`, `gpt-5.6-sol-xhigh`) failing with `resource_exhausted` (errorId 528384): the per-effort GPT slug is now split into its base model id plus a `{ id: "reasoning", value: <effort> }` request parameter, matching the official `cursor-agent` wire shape, instead of sending the sibling slug as the wire model id with no parameters ([#9164](https://github.com/can1357/oh-my-pi/issues/9164)).
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1,7 +1,12 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import http2 from "node:http2";
-import type { ConversationStep, CursorRule, McpToolDefinition } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import type {
+	ConversationStep,
+	CursorRule,
+	McpToolDefinition,
+	RequestedModel_ModelParameterbytes,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
 import {
 	AgentClientMessageSchema,
 	AgentConversationTurnStructureSchema,
@@ -106,6 +111,7 @@ import {
 	RequestContextResultSchema,
 	RequestContextSchema,
 	RequestContextSuccessSchema,
+	RequestedModel_ModelParameterbytesSchema,
 	RequestedModelSchema,
 	ResumeActionSchema,
 	SelectedContextSchema,
@@ -151,7 +157,8 @@ import {
 	toBinary,
 	toJson,
 } from "@oh-my-pi/pi-catalog/discovery/protobuf";
-import { isKimiK3ModelId } from "@oh-my-pi/pi-catalog/identity";
+import { THINKING_EFFORTS } from "@oh-my-pi/pi-catalog/effort";
+import { isKimiK3ModelId, parseOpenAIModel } from "@oh-my-pi/pi-catalog/identity";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import {
 	$env,
@@ -5011,6 +5018,44 @@ function extractImages(content: (TextContent | ImageContent)[]) {
 		);
 }
 
+/**
+ * Resolve the Cursor Run wire model id and its parameter list.
+ *
+ * Cursor's `GetUsableModels` lists reasoning models as per-effort sibling
+ * slugs (`gpt-5.4-mini-low`, `gpt-5.6-sol-high`), and OMP copies those ids 1:1.
+ * The Run endpoint rejects a sibling slug as the wire `model_id` with
+ * `resource_exhausted` (errorId 528384); the official `cursor-agent` splits the
+ * slug into its base model id plus a `reasoning` effort parameter. Mirror that
+ * for OpenAI-family ids: strip a trailing effort tier and emit
+ * `{ id: "reasoning", value: <effort> }`.
+ *
+ * Non-OpenAI ids pass through unchanged — Cursor-native ids (`composer-*`,
+ * `cursor-grok-*`, `default`) carry no effort suffix, and Claude/other siblings
+ * need additional parameters (`thinking`, `context`) whose per-model values are
+ * not exposed by the decoded `GetUsableModels` schema, so guessing them would
+ * re-trigger 528384.
+ */
+function resolveCursorWireModel(model: Model<"cursor-agent">): {
+	modelId: string;
+	parameters: RequestedModel_ModelParameterbytes[];
+} {
+	const wireModelId = model.requestModelId ?? model.id;
+	// Split a trailing effort tier (`-low`, `-high`, `-xhigh`, …) off the id and
+	// translate it only when the remaining base parses as an OpenAI model.
+	const idx = wireModelId.lastIndexOf("-");
+	const effort = idx > 0 ? wireModelId.slice(idx + 1) : "";
+	if (effort && (THINKING_EFFORTS as readonly string[]).includes(effort)) {
+		const base = wireModelId.slice(0, idx);
+		if (parseOpenAIModel(base) !== null) {
+			return {
+				modelId: base,
+				parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: effort })],
+			};
+		}
+	}
+	return { modelId: wireModelId, parameters: [] };
+}
+
 export async function buildGrpcRequest(
 	model: Model<"cursor-agent">,
 	context: Context,
@@ -5117,7 +5162,7 @@ export async function buildGrpcRequest(
 		turns,
 	});
 
-	const wireModelId = model.requestModelId ?? model.id;
+	const { modelId: wireModelId, parameters: wireParameters } = resolveCursorWireModel(model);
 	const cursorMaxMode = model.cursorMaxMode === true;
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: wireModelId,
@@ -5128,6 +5173,7 @@ export async function buildGrpcRequest(
 	const requestedModel = create(RequestedModelSchema, {
 		modelId: wireModelId,
 		maxMode: cursorMaxMode,
+		parameters: wireParameters,
 	});
 
 	let runRequest = create(AgentRunRequestSchema, {

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { AgentRunRequest } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+
+function cursorModel(id: string): Model<"cursor-agent"> {
+	return buildModel({
+		id,
+		name: id,
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+	});
+}
+
+function capture(model: Model<"cursor-agent">): Promise<AgentRunRequest> {
+	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
+	streamCursor(model, { messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context, {
+		apiKey: "test-token",
+		onPayload: payload => {
+			if (payload && typeof payload === "object" && "$typeName" in payload) {
+				resolve(payload as AgentRunRequest);
+			} else {
+				reject(new Error("Cursor payload was not an AgentRunRequest"));
+			}
+			throw new Error("stop after capturing Cursor payload");
+		},
+	});
+	return promise;
+}
+
+describe("Cursor requestedModel wire shape", () => {
+	it("splits a GPT reasoning-sibling slug into base id + reasoning parameter", async () => {
+		const payload = await capture(cursorModel("gpt-5.4-mini-low"));
+		expect(payload.requestedModel?.modelId).toBe("gpt-5.4-mini");
+		expect(payload.requestedModel?.parameters).toEqual([expect.objectContaining({ id: "reasoning", value: "low" })]);
+		// modelDetails is still read server-side, so it must carry the base id too.
+		expect(payload.modelDetails?.modelId).toBe("gpt-5.4-mini");
+	});
+
+	it("handles multi-segment GPT bases and the xhigh tier", async () => {
+		const payload = await capture(cursorModel("gpt-5.6-sol-xhigh"));
+		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol");
+		expect(payload.requestedModel?.parameters).toEqual([
+			expect.objectContaining({ id: "reasoning", value: "xhigh" }),
+		]);
+	});
+
+	it("leaves Cursor-native ids untouched with no parameters", async () => {
+		const payload = await capture(cursorModel("cursor-composer-2.5"));
+		expect(payload.requestedModel?.modelId).toBe("cursor-composer-2.5");
+		expect(payload.requestedModel?.parameters).toEqual([]);
+	});
+
+	it("does not translate non-OpenAI siblings (Claude effort schema is undecoded)", async () => {
+		const payload = await capture(cursorModel("claude-fable-5-low"));
+		expect(payload.requestedModel?.modelId).toBe("claude-fable-5-low");
+		expect(payload.requestedModel?.parameters).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Repro
Selecting a Cursor reasoning-sibling model (e.g. `cursor/gpt-5.4-mini-low`, `cursor/gpt-5.6-sol-xhigh`) fails with a bare Connect `resource_exhausted` (errorId 528384, 0 tokens). Captured `buildGrpcRequest`'s `AgentRunRequest` offline via the `onPayload` hook (no live Cursor call): `requestedModel.modelId = gpt-5.4-mini-low`, `parameters = []`, `modelDetails.modelId = gpt-5.4-mini-low` — matching the reporter's capture. `bun test packages/ai/test/cursor-requested-model.test.ts`.

## Cause
`normalizeCursorModel` (`packages/catalog/src/discovery/cursor.ts`) copies `GetUsableModels` per-effort sibling slugs 1:1 into catalog ids, and `buildGrpcRequest` (`packages/ai/src/providers/cursor.ts`) set `wireModelId = model.requestModelId ?? model.id`, sending the slug verbatim as the Run wire `model_id` with an empty `parameters[]`. The official `cursor-agent` instead sends the base model id plus a `reasoning` effort parameter; the server rejects the slug shape with 528384.

## Fix
- Added `resolveCursorWireModel` in `packages/ai/src/providers/cursor.ts`: strips a trailing effort tier (`THINKING_EFFORTS`) off the wire id and, when the remaining base parses as an OpenAI model (`parseOpenAIModel`), returns the base id + `[{ id: "reasoning", value: <effort> }]`.
- `buildGrpcRequest` now sets both `modelDetails.modelId` and `requestedModel.modelId` to the resolved base and attaches the parameters to `requestedModel`.
- Cursor-native ids (`composer-*`, `cursor-grok-*`, `default`) and non-OpenAI siblings pass through unchanged.
- Added `packages/ai/test/cursor-requested-model.test.ts` (GPT split, multi-segment base + `xhigh`, native passthrough, Claude passthrough).

Scope: Claude effort siblings (`claude-fable-5-*`) also need `thinking`/`context` parameters, whose per-model values are not exposed by the decoded `GetUsableModels` schema (`ThinkingDetails` is an empty message today). As the reporter warned, hardcoding one capture re-triggers 528384, so Claude is intentionally left as a pass-through pending the parameter/variant schema being decoded from a raw `GetUsableModels` response.

## Verification
`bun test packages/ai/test/cursor-requested-model.test.ts` (4 pass) and `bun test packages/ai/test/cursor-exec-handlers.test.ts` (42 pass, no regression); `bun run check:types` in `packages/ai` clean; `biome check` clean. Live 528384 clearance could not be verified here (no Cursor Ultra credential); the test asserts the wire bytes now match the official `cursor-agent` GPT capture from the issue. Fixes #9164