### PR TITLE
fix(ai): preserve Codex custom-tool append chains

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed Codex Responses append chains falling back to full-context replay when replay-sanitized assistant items differ only by output-only IDs or lifecycle status.
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3740,6 +3740,17 @@ const ITEM_LIFECYCLE_EXCLUDE_MAP = {
 };
 
 /**
+ * Replay sanitization strips output item IDs from message/function/custom
+ * assistant items. A live transcript rebuilt from the corresponding agent
+ * message may still retain that ID; it is output-only identity, while call_id
+ * remains the semantic tool/result pairing key.
+ */
+const REPLAY_SANITIZED_ITEM_EXCLUDE_MAP = {
+	status: true,
+	id: true,
+};
+
+/**
  * Strict-prefix delta for stateful `previous_response_id` chaining (used by the
  * platform Responses provider and the Codex provider on both transports):
  * returns the input items the current request appends beyond the previous
@@ -3766,7 +3777,12 @@ export function buildResponsesDeltaInput<TItem extends ResponseInputItem | Input
 	for (const series of [previous.input, previousResponseItems]) {
 		if (!series) continue;
 		for (const item of series) {
-			if (deepEqualsWithout(item, current.input[index], ITEM_LIFECYCLE_EXCLUDE_MAP)) {
+			const type = item.type;
+			const omitKeys =
+				type === "message" || type === "function_call" || type === "custom_tool_call"
+					? REPLAY_SANITIZED_ITEM_EXCLUDE_MAP
+					: ITEM_LIFECYCLE_EXCLUDE_MAP;
+			if (deepEqualsWithout(item, current.input[index], omitKeys)) {
 				index++;
 			} else {
 				return null;

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -3639,6 +3639,112 @@ describe("openai-codex streaming", () => {
 		]);
 	});
 
+	it("chains websocket custom-tool output when live replay retains the provider item id", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-custom-append-");
+		setAgentDir(tempDir.path());
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const customInput = "print('ok')";
+
+		class CustomToolAppendWebSocket extends MockWebSocket {
+			constructor(url: string, options?: WsOptions) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			override send(data: string): void {
+				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
+				if (sentRequests.length === 1) {
+					this.sendJson({
+						type: "response.output_item.added",
+						output_index: 0,
+						item: {
+							type: "custom_tool_call",
+							id: "ctc_eval_1",
+							call_id: "call_eval_1",
+							name: "eval",
+							input: "",
+						},
+					});
+					this.sendJson({
+						type: "response.output_item.done",
+						output_index: 0,
+						item: {
+							type: "custom_tool_call",
+							id: "ctc_eval_1",
+							call_id: "call_eval_1",
+							name: "eval",
+							input: customInput,
+							status: "completed",
+						},
+					});
+					this.sendJson({
+						type: "response.completed",
+						response: { id: "resp_custom", status: "completed", usage: DEFAULT_USAGE },
+					});
+					return;
+				}
+				this.emitCodexResponse({
+					messageId: "msg_custom_done",
+					responseId: "resp_custom_done",
+					text: "Done",
+					terminalType: "response.completed",
+				});
+			}
+		}
+
+		global.WebSocket = CustomToolAppendWebSocket as unknown as typeof WebSocket;
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const firstUser = { role: "user" as const, content: "Run the code", timestamp: Date.now() };
+		const options = {
+			apiKey: createCodexTestToken(),
+			fetch: vi.fn(async () => {
+				throw new Error("SSE fallback should not be called");
+			}) as FetchImpl,
+			providerSessionState,
+			sessionId: "ws-custom-tool-append",
+		};
+
+		const firstResponse = await streamOpenAICodexResponses(
+			model,
+			{ systemPrompt: ["You are a helpful assistant."], messages: [firstUser] },
+			options,
+		).result();
+		const toolCall = firstResponse.content.find(
+			(block): block is Extract<(typeof firstResponse.content)[number], { type: "toolCall" }> =>
+				block.type === "toolCall",
+		);
+		if (!toolCall) throw new Error("expected a custom tool call");
+		expect(toolCall.customWireName).toBe("eval");
+		const toolResult = {
+			role: "toolResult" as const,
+			toolCallId: toolCall.id,
+			toolName: toolCall.name,
+			content: [{ type: "text" as const, text: "ok" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		await streamOpenAICodexResponses(
+			model,
+			{
+				systemPrompt: ["You are a helpful assistant."],
+				messages: [firstUser, firstResponse, toolResult],
+			},
+			options,
+		).result();
+
+		expect(sentRequests).toHaveLength(2);
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_custom");
+		expect(sentRequests[1]?.input).toEqual([
+			expect.objectContaining({
+				type: "custom_tool_call_output",
+				call_id: "call_eval_1",
+				output: "ok",
+			}),
+		]);
+	});
+
 	it("does not enable websocket append state for a non-replayable response", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());

--- a/packages/ai/test/openai-responses-delta-input.test.ts
+++ b/packages/ai/test/openai-responses-delta-input.test.ts
@@ -52,6 +52,34 @@ describe("buildResponsesDeltaInput streaming-symbol scrub", () => {
 		expect(delta?.[0]).toBe(appended);
 	});
 
+	it("chains a replay-sanitized custom tool call when live history retains its output id", () => {
+		const user: ResponseInputItem = {
+			type: "message",
+			role: "user",
+			content: [{ type: "input_text", text: "edit the file" }],
+		};
+		const previousCustomCall = {
+			type: "custom_tool_call",
+			call_id: "call_eval_1",
+			name: "eval",
+			input: "print('ok')",
+		} as ResponseInputItem;
+		const liveCustomCall = {
+			...previousCustomCall,
+			id: "ctc_eval_1",
+			status: "completed",
+		} as ResponseInputItem;
+		const output = {
+			type: "custom_tool_call_output",
+			call_id: "call_eval_1",
+			output: "ok",
+		} as ResponseInputItem;
+
+		expect(
+			buildResponsesDeltaInput({ input: [user] }, [previousCustomCall], { input: [user, liveCustomCall, output] }),
+		).toEqual([output]);
+	});
+
 	it("still breaks the chain on a real content change, not just symbol noise", () => {
 		const previous = { input: [baselineItems()[0]] };
 		const previousResponseItems = [baselineItems()[1]];


### PR DESCRIPTION
## What

- Treat `id` and `status` as output-only when comparing replay-sanitized assistant `message`, `function_call`, and `custom_tool_call` items for Responses append-chain identity.
- Keep every semantic field strict, including `call_id`, tool name, arguments/input, message content, and reasoning/image/computer identities.
- Add direct delta-builder and Codex WebSocket regressions, plus an `[Unreleased]` changelog entry.

## Why

Assistant history differed only by output-only id/status fields, causing unnecessary full-context resets.

The replay sanitizer already removes IDs from these assistant item kinds because the Responses input schema rejects output-item IDs, while a live reconstructed transcript can retain them. Comparing the raw and sanitized shapes byte-for-byte therefore broke an otherwise valid `previous_response_id` chain.

## Testing

Base reproduction on upstream `main` (`76a294cb19`):

```text
bun test packages/ai/test/openai-responses-delta-input.test.ts -t "chains a replay-sanitized custom tool call when live history retains its output id"
0 pass, 1 fail: expected the appended custom_tool_call_output; received null
```

Fixed branch:

```text
bun test packages/ai/test/openai-responses-delta-input.test.ts
5 pass, 0 fail

bun test packages/ai/test/openai-codex-stream.test.ts
83 pass, 0 fail

bun test packages/ai/test/openai-responses-stateful.test.ts
15 pass, 0 fail

bun --cwd=packages/ai run check:types
passed

bunx biome check packages/ai/src/providers/openai-shared.ts packages/ai/test/openai-codex-stream.test.ts packages/ai/test/openai-responses-delta-input.test.ts
passed
```

The WebSocket scenario emits a custom `eval` call carrying output-only `id`/`status`, rebuilds the live assistant history, appends its tool result, and confirms the second request retains `previous_response_id` with only `custom_tool_call_output` as delta input.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)