### PR TITLE
fix(ai): guard DeepSeek models from image_url payload errors in openai-completions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed DeepSeek models rejecting requests with HTTP 400 `unknown variant \`image_url\`, expected \`text\`` when screenshots or image-producing tool results are present in conversation history or when `model.input` claims vision capability; `convertMessages` in `openai-completions` now strips `image_url` content parts and injects non-vision image placeholders for all DeepSeek endpoints.
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -111,7 +111,7 @@ import {
 } from "./openai-shared";
 import { transformMessages } from "./transform-messages";
 import {
-	isDashscopeCompatibleModeTextOnlyQwen,
+	isOpenAICompletionsVisionSupported,
 	joinTextWithImagePlaceholder,
 	NON_VISION_IMAGE_PLACEHOLDER,
 } from "./vision-guard";
@@ -1935,7 +1935,7 @@ export function convertMessages(
 					content: text,
 				});
 			} else {
-				const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
+				const supportsImages = isOpenAICompletionsVisionSupported(model);
 				const content: ChatCompletionContentPart[] = [];
 				let omittedImages = false;
 				for (const item of msg.content) {
@@ -2225,7 +2225,7 @@ export function convertMessages(
 					.filter(c => c.type === "text")
 					.map(c => (c as TextContent).text)
 					.join("\n");
-				const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
+				const supportsImages = isOpenAICompletionsVisionSupported(model);
 				const hasImages = toolMsg.content.some(c => c.type === "image");
 				const omittedImages = hasImages && !supportsImages;
 

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -1,5 +1,5 @@
-import { isDashscopeCompatibleModeUrl } from "@oh-my-pi/pi-catalog/hosts";
-import { isQwenModelId } from "@oh-my-pi/pi-catalog/identity";
+import { isDashscopeCompatibleModeUrl, modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
+import { isDeepseekModelIdOrName, isQwenModelId } from "@oh-my-pi/pi-catalog/identity";
 
 import type { ImageContent, Model, TextContent } from "../types";
 
@@ -63,4 +63,35 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 	const major = maxMatch[1] ? Number.parseInt(maxMatch[1], 10) : 0;
 	const minor = maxMatch[2] ? Number.parseInt(maxMatch[2], 10) : 0;
 	return major < 3 || (major === 3 && minor < 8);
+}
+
+/**
+ * Detect known text-only DeepSeek models served via OpenAI-compatible Chat
+ * Completions endpoints whose server-side deserializers reject `image_url`
+ * content parts with HTTP 400 (`unknown variant \`image_url\`, expected \`text\``).
+ *
+ * Used as a defensive override in `convertMessages` so misconfigured model
+ * definitions or user overrides (e.g. `models.yml` claiming `input: [text, image]`)
+ * do not crash the session with an unrecoverable 400.
+ */
+export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean {
+	return (
+		modelMatchesHost(model, "deepseekFamily") ||
+		isDeepseekModelIdOrName(model.id) ||
+		isDeepseekModelIdOrName(model.name ?? "") ||
+		model.provider === "deepseek"
+	);
+}
+
+/**
+ * Evaluates whether an OpenAI-compatible Chat Completions model genuinely
+ * supports multimodal image inputs on the wire. Defensive guards override
+ * misconfigured provider descriptors or user model entries (e.g. text-only
+ * DashScope Qwen SKUs, DeepSeek models) whose endpoints reject `image_url`.
+ */
+export function isOpenAICompletionsVisionSupported(model: Model<"openai-completions">): boolean {
+	if (!model.input.includes("image")) return false;
+	if (isDashscopeCompatibleModeTextOnlyQwen(model)) return false;
+	if (isTextOnlyDeepSeek(model)) return false;
+	return true;
 }

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -439,4 +439,86 @@ describe("openai-completions convertMessages", () => {
 			expect(imageParts.length).toBe(1);
 		}
 	});
+	it("strips image_url content for DeepSeek models on OpenAI-compatible endpoints", () => {
+		// DeepSeek API rejects `image_url` content parts with 400
+		// "unknown variant `image_url`, expected `text`". Even if a model entry
+		// or custom models.yml misconfigures `input: ["text", "image"]`,
+		// convertMessages must never forward `image_url` parts.
+		const deepseekModelIds = [
+			{ id: "deepseek-v4-pro", provider: "deepseek", baseUrl: "https://api.deepseek.com/v1" },
+			{ id: "deepseek-v4-flash", provider: "deepseek", baseUrl: "https://api.deepseek.com/v1" },
+			{ id: "deepseek-chat", provider: "deepseek", baseUrl: "https://api.deepseek.com" },
+			{ id: "deepseek-reasoner", provider: "deepseek", baseUrl: "https://api.deepseek.com" },
+			{ id: "deepseek-ai/DeepSeek-V4-Pro", provider: "custom-proxy", baseUrl: "https://llm-proxy.example.com/v1" },
+		];
+
+		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+
+		for (const spec of deepseekModelIds) {
+			const model: Model<"openai-completions"> = {
+				...baseModel,
+				id: spec.id,
+				name: spec.id,
+				provider: spec.provider as Model<"openai-completions">["provider"],
+				baseUrl: spec.baseUrl,
+				api: "openai-completions",
+				input: ["text", "image"],
+			};
+
+			const now = Date.now();
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tool-1", name: "browser", arguments: { action: "screenshot" } }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: emptyUsage,
+				stopReason: "toolUse",
+				timestamp: now,
+			};
+
+			const context: Context = {
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "Take a screenshot" },
+							{ type: "image", data: "ZmFrZQ==", mimeType: "image/webp" },
+						],
+						timestamp: now - 2,
+					},
+					assistantMessage,
+					buildToolResult("tool-1", now + 1),
+				],
+			};
+
+			const messages = convertMessages(model, context, compat);
+
+			for (const m of messages) {
+				if (Array.isArray(m.content)) {
+					for (const part of m.content as Array<{ type?: string }>) {
+						expect(part?.type).not.toBe("image_url");
+					}
+				}
+			}
+
+			const userMessage = messages.find(m => m.role === "user");
+			expect(userMessage).toBeDefined();
+			const userContent = userMessage?.content;
+			const userText =
+				typeof userContent === "string"
+					? userContent
+					: (userContent as Array<{ type?: string; text?: string }>)
+							.filter(p => p?.type === "text")
+							.map(p => p?.text ?? "")
+							.join("\n");
+			expect(userText).toContain("Take a screenshot");
+			expect(userText).toContain(NON_VISION_IMAGE_PLACEHOLDER);
+
+			const toolMessage = messages.find(m => m.role === "tool");
+			expect(toolMessage).toBeDefined();
+			expect(typeof toolMessage?.content).toBe("string");
+			expect(toolMessage?.content as string).toContain(NON_VISION_IMAGE_PLACEHOLDER);
+		}
+	});
 });


### PR DESCRIPTION
## Problem

When using DeepSeek models (e.g. `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-chat`, `deepseek-reasoner`) via the `openai-completions` provider, sending a user message or tool result containing an image (e.g. browser screenshots) causes DeepSeek's API endpoint (`https://api.deepseek.com/v1/chat/completions`) to reject the request with HTTP 400:

```
Failed to deserialize the JSON body into the target type: messages[4]: unknown variant `image_url`, expected `text` at line 1 column 395009
```

This occurs because DeepSeek's server-side deserializer strictly accepts only `text` content parts (or string content) and does not support the `image_url` variant. Even if a model definition or user override in `models.yml` includes `"image"` in `model.input`, `openai-completions` forwarded `image_url` parts, crashing the session into an unrecoverable 400 retry loop.

## Fix

1. Added `isTextOnlyDeepSeek` in `packages/ai/src/providers/vision-guard.ts` matching DeepSeek provider, `deepseekFamily` hosts, and DeepSeek model IDs/names.
2. Consolidated vision support checking via `isOpenAICompletionsVisionSupported` in `packages/ai/src/providers/vision-guard.ts`, combining `model.input.includes("image")`, DashScope text-only Qwen guards (`isDashscopeCompatibleModeTextOnlyQwen`), and DeepSeek text-only guards (`isTextOnlyDeepSeek`).
3. Updated `convertMessages` in `packages/ai/src/providers/openai-completions.ts` to use `isOpenAICompletionsVisionSupported(model)`, ensuring images are cleanly replaced with `NON_VISION_IMAGE_PLACEHOLDER` (`[image omitted: model does not support vision]`) for both user turns and tool-result summaries.
4. Added test suite coverage in `packages/ai/test/openai-completions-tool-result-images.test.ts` verifying image stripping and placeholder injection for DeepSeek models.
5. Updated `packages/ai/CHANGELOG.md`.