### PR TITLE
fix(coding-agent): /mcp test Esc no longer interrupts the running session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed prompt guidance and descriptions for Task tools and SSH usage.
 - ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+- Pressing Esc during `/mcp test` now cancels only the test; a session still streaming keeps running even once the test has already completed.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -329,6 +329,9 @@ export class InputController {
 			if (this.ctx.hasActiveCleanse() && this.ctx.handleCleanseEscape()) {
 				return;
 			}
+			if (this.ctx.hasActiveMcpTest() && this.ctx.handleMcpTestEscape()) {
+				return;
+			}
 
 			if (!this.ctx.focusedAgentId) {
 				const viewSession = this.ctx.viewSession;

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1577,10 +1577,25 @@ export class MCPCommandController {
 
 		let connection: MCPServerConnection | undefined;
 		let testStarted = false;
+		// Own Esc before the config-file resolution: the lookup reads user/project and
+		// fallback configs from disk, which can be slow on network-backed filesystems.
+		// Esc during that window must cancel the test rather than fall through to
+		// aborting the streaming session. Validation exits below release ownership
+		// immediately (no grace window) because no cancellable test ever started.
+		this.ctx.beginMcpTest(abortController, name);
 		try {
 			const found = await this.#resolveServerForAuth(name);
 
+			if (abortController.signal.aborted) {
+				// Esc during resolution: the test never started. Settle (not clear) so
+				// the grace window still consumes a reflexive second Esc.
+				this.ctx.settleMcpTest(abortController);
+				this.ctx.showStatus(`Cancelled MCP test for "${name}"`);
+				return;
+			}
+
 			if (!found) {
+				this.ctx.clearMcpTest(abortController);
 				this.ctx.showError(
 					`Server "${name}" not found.\n\nTip: Run ${theme.fg("accent", "/mcp list")} to see available servers.`,
 				);
@@ -1589,14 +1604,11 @@ export class MCPCommandController {
 
 			const { config } = found;
 			if (config.enabled === false) {
+				this.ctx.clearMcpTest(abortController);
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
 			}
 
-			// Own Esc only once the cancellable test actually starts; validation
-			// exits above must not arm the post-settle grace state (a missing or
-			// disabled server would otherwise swallow Esc for five seconds).
-			this.ctx.beginMcpTest(abortController, name);
 			testStarted = true;
 
 			this.#showMessage(
@@ -1641,8 +1653,20 @@ export class MCPCommandController {
 			this.#showMessage(lines.join("\n"));
 		} catch (error) {
 			if (abortController.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+				// Settle here when the abort raced a resolution failure (testStarted is
+				// still false, so `finally` will not); a connect-phase abort settles via
+				// the testStarted path below.
+				if (!testStarted) {
+					this.ctx.settleMcpTest(abortController);
+				}
 				this.ctx.showStatus(`Cancelled MCP test for "${name}"`);
 				return;
+			}
+
+			if (!testStarted) {
+				// Resolution itself failed (e.g. unreadable config): no test ever
+				// started, so Esc ownership is released without the grace window.
+				this.ctx.clearMcpTest(abortController);
 			}
 
 			const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1580,11 +1580,18 @@ export class MCPCommandController {
 		// Own Esc before the config-file resolution: the lookup reads user/project and
 		// fallback configs from disk, which can be slow on network-backed filesystems.
 		// Esc during that window must cancel the test rather than fall through to
-		// aborting the streaming session. Validation exits below release ownership
-		// immediately (no grace window) because no cancellable test ever started.
+		// aborting the streaming session — so the lookup itself is raced against the
+		// signal, unblocking the command (and giving cancellation feedback) the moment
+		// Esc fires instead of waiting out the filesystem read. Validation exits below
+		// release ownership immediately (no grace window) because no cancellable test
+		// ever started.
 		this.ctx.beginMcpTest(abortController, name);
 		try {
-			const found = await this.#resolveServerForAuth(name);
+			const found = await raceAbortSignal(
+				this.#resolveServerForAuth(name),
+				abortController.signal,
+				() => new DOMException("Aborted", "AbortError"),
+			);
 
 			if (abortController.signal.aborted) {
 				// Esc during resolution: the test never started. Settle (not clear) so

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1573,11 +1573,8 @@ export class MCPCommandController {
 			return;
 		}
 
-		const originalOnEscape = this.ctx.editor.onEscape;
 		const abortController = new AbortController();
-		this.ctx.editor.onEscape = () => {
-			abortController.abort();
-		};
+		this.ctx.beginMcpTest(abortController, name);
 
 		let connection: MCPServerConnection | undefined;
 		try {
@@ -1660,7 +1657,7 @@ export class MCPCommandController {
 
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
-			this.ctx.editor.onEscape = originalOnEscape;
+			this.ctx.settleMcpTest(abortController);
 			if (connection) {
 				// Best-effort: don't block UI on cleanup.
 				void disconnectServer(connection);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1574,9 +1574,9 @@ export class MCPCommandController {
 		}
 
 		const abortController = new AbortController();
-		this.ctx.beginMcpTest(abortController, name);
 
 		let connection: MCPServerConnection | undefined;
+		let testStarted = false;
 		try {
 			const found = await this.#resolveServerForAuth(name);
 
@@ -1592,6 +1592,12 @@ export class MCPCommandController {
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
 			}
+
+			// Own Esc only once the cancellable test actually starts; validation
+			// exits above must not arm the post-settle grace state (a missing or
+			// disabled server would otherwise swallow Esc for five seconds).
+			this.ctx.beginMcpTest(abortController, name);
+			testStarted = true;
 
 			this.#showMessage(
 				["", theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), ""].join("\n"),
@@ -1657,7 +1663,9 @@ export class MCPCommandController {
 
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
-			this.ctx.settleMcpTest(abortController);
+			if (testStarted) {
+				this.ctx.settleMcpTest(abortController);
+			}
 			if (connection) {
 				// Best-effort: don't block UI on cleanup.
 				void disconnectServer(connection);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -194,6 +194,7 @@ import {
 	type LoopLimitRuntime,
 	parseLoopLimitArgs,
 } from "./loop-limit";
+import { McpTestEscapeState } from "./mcp-test-escape";
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { countRunningSubagentBadgeAgents, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
 import {
@@ -687,6 +688,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	readonly #tanCommandController: TanCommandController;
 	readonly #omfgController: OmfgController;
 	readonly #cleanseController: CleanseCommandController;
+	readonly #mcpTestEscape: McpTestEscapeState = new McpTestEscapeState();
 	readonly #commandController: CommandController;
 	readonly #todoCommandController: TodoCommandController;
 	readonly #liveCommandController: LiveCommandController;
@@ -5289,6 +5291,29 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	handleCleanseEscape(): boolean {
 		return this.#cleanseController.handleEscape();
+	}
+
+	beginMcpTest(abortController: AbortController, name: string): void {
+		this.#mcpTestEscape.begin(abortController, name);
+	}
+
+	settleMcpTest(abortController: AbortController): void {
+		this.#mcpTestEscape.settle(abortController);
+	}
+
+	hasActiveMcpTest(): boolean {
+		return this.#mcpTestEscape.hasActive();
+	}
+
+	handleMcpTestEscape(): boolean {
+		const decision = this.#mcpTestEscape.handleEscape();
+		if (decision === "fallthrough") return false;
+		if (decision === "consume") {
+			const name = this.#mcpTestEscape.name ?? "unknown";
+			const cancelled = this.#mcpTestEscape.cancelled ?? false;
+			this.showStatus(`MCP test for "${name}" ${cancelled ? "was cancelled" : "already completed"}`);
+		}
+		return true;
 	}
 
 	cycleThinkingLevel(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -5301,6 +5301,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#mcpTestEscape.settle(abortController);
 	}
 
+	clearMcpTest(abortController: AbortController): void {
+		this.#mcpTestEscape.clear(abortController);
+	}
+
 	hasActiveMcpTest(): boolean {
 		return this.#mcpTestEscape.hasActive();
 	}

--- a/packages/coding-agent/src/modes/mcp-test-escape.ts
+++ b/packages/coding-agent/src/modes/mcp-test-escape.ts
@@ -42,6 +42,15 @@ export class McpTestEscapeState {
 		}, MCP_TEST_ESC_GRACE_MS);
 	}
 
+	/** Release Esc ownership immediately, without the grace window. Used when a test is registered
+	 *  before validation but never actually starts (missing/disabled server): Esc must fall through
+	 *  to normal semantics right away. Identity-guarded like {@link settle}. */
+	clear(abortController: AbortController): void {
+		if (this.#active?.abortController === abortController) {
+			this.#active = undefined;
+		}
+	}
+
 	hasActive(): boolean {
 		return this.#active !== undefined;
 	}

--- a/packages/coding-agent/src/modes/mcp-test-escape.ts
+++ b/packages/coding-agent/src/modes/mcp-test-escape.ts
@@ -17,8 +17,14 @@ export type McpTestEscDecision = "abort" | "consume" | "fallthrough";
 export class McpTestEscapeState {
 	#active: { abortController: AbortController; name: string; settledAt?: number; cancelled?: boolean } | undefined;
 
-	/** Register an in-flight test. Replaces any previous active state (concurrent tests are not supported). */
+	/** Register an in-flight test. Supersedes any previous active state (concurrent tests are not
+	 *  supported): a still-pending predecessor is aborted so its connection attempt and subprocess
+	 *  are not orphaned when Esc ownership moves to the new test. */
 	begin(abortController: AbortController, name: string): void {
+		const previous = this.#active;
+		if (previous && previous.settledAt === undefined) {
+			previous.abortController.abort();
+		}
 		this.#active = { abortController, name };
 	}
 

--- a/packages/coding-agent/src/modes/mcp-test-escape.ts
+++ b/packages/coding-agent/src/modes/mcp-test-escape.ts
@@ -1,0 +1,68 @@
+/**
+ * Esc-routing state for `/mcp test`.
+ *
+ * While a test is pending, Esc aborts it. After it settles (fast for most
+ * servers — context7 answers in ~1s), Esc stays owned by the test for a short
+ * grace window so a user reacting to the "(esc to cancel)" hint never falls
+ * through to the session interrupt path. Past the window, Esc is released back
+ * to normal semantics.
+ */
+
+/** How long after a /mcp test settles, Esc stays owned by the test result instead of falling
+ *  through to the session interrupt path (covers the user reaction window to "(esc to cancel)"). */
+export const MCP_TEST_ESC_GRACE_MS = 5000;
+
+export type McpTestEscDecision = "abort" | "consume" | "fallthrough";
+
+export class McpTestEscapeState {
+	#active: { abortController: AbortController; name: string; settledAt?: number; cancelled?: boolean } | undefined;
+
+	/** Register an in-flight test. Replaces any previous active state (concurrent tests are not supported). */
+	begin(abortController: AbortController, name: string): void {
+		this.#active = { abortController, name };
+	}
+
+	/** Mark the test for `abortController` settled. Identity-guarded: a superseded (replaced) test
+	 *  must not settle the newer one. Records `cancelled` when the signal was already aborted, and
+	 *  schedules release of the active state after MCP_TEST_ESC_GRACE_MS via setTimeout. */
+	settle(abortController: AbortController): void {
+		if (!this.#active || this.#active.abortController !== abortController) return;
+		this.#active.settledAt = Date.now();
+		this.#active.cancelled = abortController.signal.aborted;
+		const settled = this.#active;
+		setTimeout(() => {
+			// Release only if this settle is still the active one (superseded by a newer begin).
+			if (this.#active === settled) this.#active = undefined;
+		}, MCP_TEST_ESC_GRACE_MS);
+	}
+
+	hasActive(): boolean {
+		return this.#active !== undefined;
+	}
+
+	/** Esc routing decision. Pending → abort the test, return "abort". Settled within grace →
+	 *  "consume" (never the session). Settled past grace (or no active test) → release state, "fallthrough". */
+	handleEscape(now: number = Date.now()): McpTestEscDecision {
+		const active = this.#active;
+		if (!active) return "fallthrough";
+		if (active.settledAt === undefined) {
+			active.abortController.abort();
+			return "abort";
+		}
+		if (now - active.settledAt < MCP_TEST_ESC_GRACE_MS) {
+			return "consume";
+		}
+		this.#active = undefined;
+		return "fallthrough";
+	}
+
+	/** Name of the active test (for consume feedback). */
+	get name(): string | undefined {
+		return this.#active?.name;
+	}
+
+	/** Whether the settled test was aborted by Esc (for consume feedback). */
+	get cancelled(): boolean | undefined {
+		return this.#active?.cancelled;
+	}
+}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -457,6 +457,7 @@ export interface InteractiveModeContext {
 	handleCleanseEscape(): boolean;
 	beginMcpTest(abortController: AbortController, name: string): void;
 	settleMcpTest(abortController: AbortController): void;
+	clearMcpTest(abortController: AbortController): void;
 	hasActiveMcpTest(): boolean;
 	handleMcpTestEscape(): boolean;
 	cycleThinkingLevel(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -455,6 +455,10 @@ export interface InteractiveModeContext {
 	handleCleanseCommand(args: string): Promise<void>;
 	hasActiveCleanse(): boolean;
 	handleCleanseEscape(): boolean;
+	beginMcpTest(abortController: AbortController, name: string): void;
+	settleMcpTest(abortController: AbortController): void;
+	hasActiveMcpTest(): boolean;
+	handleMcpTestEscape(): boolean;
 	cycleThinkingLevel(): void;
 	cycleRoleModel(direction?: "forward" | "backward"): Promise<void>;
 	toggleToolOutputExpansion(): void;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -218,6 +218,8 @@ function createContext(): {
 		hasActiveOmfg,
 		handleCleanseEscape,
 		hasActiveCleanse,
+		handleMcpTestEscape: vi.fn(() => true),
+		hasActiveMcpTest: vi.fn(() => false),
 		showTreeSelector: vi.fn(),
 		showUserMessageSelector: vi.fn(),
 		showSessionSelector: vi.fn(),
@@ -453,6 +455,34 @@ describe("InputController escape behavior", () => {
 
 		expect(spies.handleBtwEscape).toHaveBeenCalledTimes(1);
 		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("consumes Esc for an active /mcp test before aborting the main stream", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		ctx.hasActiveMcpTest = vi.fn(() => true);
+		ctx.handleMcpTestEscape = vi.fn(() => true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(ctx.handleMcpTestEscape).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("falls through to the stream abort when the /mcp test escape is not handled", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		ctx.hasActiveMcpTest = vi.fn(() => true);
+		ctx.handleMcpTestEscape = vi.fn(() => false);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(ctx.handleMcpTestEscape).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledTimes(1);
 	});
 
 	it("dismisses an active /btw panel before canceling a pending optimistic submission", () => {

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -92,6 +92,7 @@ describe("issue #956: interactive /mcp test", () => {
 			editor: {},
 			beginMcpTest: vi.fn(),
 			settleMcpTest: vi.fn(),
+			clearMcpTest: vi.fn(),
 			showError,
 			showStatus,
 			session: { refreshMCPTools },

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -90,6 +90,8 @@ describe("issue #956: interactive /mcp test", () => {
 			},
 			ui: { requestRender },
 			editor: {},
+			beginMcpTest: vi.fn(),
+			settleMcpTest: vi.fn(),
 			showError,
 			showStatus,
 			session: { refreshMCPTools },

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -8,6 +8,7 @@ import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
 import * as oauthFlow from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
 import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { MCPCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-command-controller";
+import { McpTestEscapeState } from "@oh-my-pi/pi-coding-agent/modes/mcp-test-escape";
 import { OAuthManualInputManager } from "@oh-my-pi/pi-coding-agent/modes/oauth-manual-input";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import {
@@ -47,17 +48,16 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 	const showStatus = vi.fn();
 	const present = vi.fn();
 	const editor: { onEscape?: () => void } = {};
-	const beginMcpTest = vi.fn((_abortController: AbortController, _name: string) => {
-		// Mirror McpTestEscapeState.begin: superseding a still-pending test
-		// aborts its predecessor so the first connection attempt is not
-		// orphaned when Esc ownership moves to the new test. mock.calls
-		// already contains the current call, so the predecessor is at -2.
-		const prior = beginMcpTest.mock.calls.at(-2)?.[0] as AbortController | undefined;
-		if (prior && prior !== _abortController && !prior.signal.aborted) {
-			prior.abort();
-		}
+	// The controller tests exercise the real Esc state machine, not a reimplementation:
+	// the spies only record calls while delegating to McpTestEscapeState, so a regression
+	// in InteractiveMode's delegation or the state's supersede logic fails these tests.
+	const mcpTestEscape = new McpTestEscapeState();
+	const beginMcpTest = vi.fn((abortController: AbortController, name: string) => {
+		mcpTestEscape.begin(abortController, name);
 	});
-	const settleMcpTest = vi.fn();
+	const settleMcpTest = vi.fn((abortController: AbortController) => {
+		mcpTestEscape.settle(abortController);
+	});
 	const prepareConfig = vi.fn(async (config: MCPServerConfig) => config);
 	const mcpManager = {
 		prepareConfig,

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -47,6 +47,8 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 	const showStatus = vi.fn();
 	const present = vi.fn();
 	const editor: { onEscape?: () => void } = {};
+	const beginMcpTest = vi.fn();
+	const settleMcpTest = vi.fn();
 	const prepareConfig = vi.fn(async (config: MCPServerConfig) => config);
 	const mcpManager = {
 		prepareConfig,
@@ -76,10 +78,24 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 			modelRegistry: { authStorage },
 		},
 		mcpManager,
+		beginMcpTest,
+		settleMcpTest,
 	} as never;
 	const controller = new MCPCommandController(ctx);
 
-	return { controller, ctx, showError, showStatus, present, editor, oauthManualInput, prepareConfig, mcpManager };
+	return {
+		controller,
+		ctx,
+		showError,
+		showStatus,
+		present,
+		editor,
+		oauthManualInput,
+		prepareConfig,
+		mcpManager,
+		beginMcpTest,
+		settleMcpTest,
+	};
 }
 
 describe("/mcp auth commands", () => {
@@ -490,6 +506,59 @@ describe("/mcp auth commands", () => {
 		// onEscape must be restored to its previous value so subsequent user
 		// input does not keep aborting the (now-finished) flow.
 		expect(editor.onEscape).not.toBe(installedEscape);
+	});
+
+	test("/mcp test registers Esc cancellation through ctx state, not editor.onEscape", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		let connectSignal: AbortSignal | undefined;
+		vi.spyOn(mcpClient, "connectToServer").mockImplementation((_name, _config, options) => {
+			connectSignal = options?.signal;
+			// Pending until the test's abort controller fires (mirrors a slow
+			// server whose connection is still in flight when Esc is pressed).
+			// An already-aborted signal must reject immediately — the abort
+			// event has already fired and cannot re-trigger a later listener.
+			return new Promise((_, reject) => {
+				const signal = options?.signal;
+				if (signal?.aborted) {
+					reject(new DOMException("Aborted", "AbortError"));
+					return;
+				}
+				signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+					once: true,
+				});
+			});
+		});
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
+
+		const { controller, editor, showStatus, beginMcpTest, settleMcpTest } = createController(authStorage);
+
+		const testPromise = controller.handle("/mcp test envserver");
+
+		// #handleTest registers its abort controller synchronously, before the
+		// first await — the poll is just a safety net.
+		const deadline = Date.now() + 1_000;
+		while (beginMcpTest.mock.calls.length === 0 && Date.now() < deadline) {
+			await Bun.sleep(10);
+		}
+		expect(beginMcpTest).toHaveBeenCalledTimes(1);
+		// Esc ownership moved to ctx state: the editor slot must stay untouched.
+		expect(editor.onEscape).toBeUndefined();
+
+		const [registeredController, registeredName] = beginMcpTest.mock.calls[0] as [AbortController, string];
+		expect(registeredName).toBe("envserver");
+		registeredController.abort();
+
+		await Promise.race([
+			testPromise,
+			Bun.sleep(2_000).then(() => {
+				throw new Error("/mcp test did not resolve within 2s of Esc");
+			}),
+		]);
+
+		expect(connectSignal?.aborted).toBe(true);
+		expect(showStatus).toHaveBeenCalledWith('Cancelled MCP test for "envserver"');
+		expect(settleMcpTest).toHaveBeenCalledWith(registeredController);
 	});
 
 	test("reauth supersedes an unfinished MCP OAuth flow", async () => {

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -58,6 +58,9 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 	const settleMcpTest = vi.fn((abortController: AbortController) => {
 		mcpTestEscape.settle(abortController);
 	});
+	const clearMcpTest = vi.fn((abortController: AbortController) => {
+		mcpTestEscape.clear(abortController);
+	});
 	const prepareConfig = vi.fn(async (config: MCPServerConfig) => config);
 	const mcpManager = {
 		prepareConfig,
@@ -91,6 +94,7 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 		mcpManager,
 		beginMcpTest,
 		settleMcpTest,
+		clearMcpTest,
 	} as never;
 	const controller = new MCPCommandController(ctx);
 
@@ -106,6 +110,8 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 		mcpManager,
 		beginMcpTest,
 		settleMcpTest,
+		clearMcpTest,
+		mcpTestEscape,
 	};
 }
 
@@ -545,8 +551,8 @@ describe("/mcp auth commands", () => {
 
 		const testPromise = controller.handle("/mcp test envserver");
 
-		// #handleTest registers Esc ownership after server validation (a couple
-		// of awaits in); the poll waits for that registration.
+		// #handleTest registers Esc ownership synchronously on entry (before the
+		// config-file resolution); the poll waits for that registration.
 		const deadline = Date.now() + 1_000;
 		while (beginMcpTest.mock.calls.length === 0 && Date.now() < deadline) {
 			await Bun.sleep(10);
@@ -557,6 +563,13 @@ describe("/mcp auth commands", () => {
 
 		const [registeredController, registeredName] = beginMcpTest.mock.calls[0] as [AbortController, string];
 		expect(registeredName).toBe("envserver");
+
+		// Press Esc while the connection is in flight (not during resolution, which
+		// is a different cancellation path covered by its own test below).
+		while (connectSignal === undefined && Date.now() < deadline) {
+			await Bun.sleep(10);
+		}
+		expect(connectSignal).toBeDefined();
 		registeredController.abort();
 
 		await Promise.race([
@@ -571,18 +584,83 @@ describe("/mcp auth commands", () => {
 		expect(settleMcpTest).toHaveBeenCalledWith(registeredController);
 	});
 
-	test("/mcp test does not arm Esc state for a missing server", async () => {
+	test("/mcp test releases Esc ownership without grace for a missing server", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
-		const { controller, showError, beginMcpTest, settleMcpTest } = createController(authStorage);
+		const { controller, showError, beginMcpTest, settleMcpTest, clearMcpTest, mcpTestEscape } =
+			createController(authStorage);
 
 		await controller.handle("/mcp test nonexistent");
 
-		// Validation exits must not own Esc: no begin, no settle — a streaming
-		// session keeps interruptible and no five-second grace state is armed.
+		// Esc ownership is registered before the config-file resolution, so the
+		// missing-server exit must release it immediately (no begin-without-clear
+		// leak, no settle grace window): a streaming session stays interruptible
+		// and the state is gone before the handle returns.
 		expect(showError).toHaveBeenCalledWith(expect.stringContaining('Server "nonexistent" not found'));
-		expect(beginMcpTest).not.toHaveBeenCalled();
+		expect(beginMcpTest).toHaveBeenCalledTimes(1);
+		const [registeredController] = beginMcpTest.mock.calls[0] as [AbortController, string];
+		expect(clearMcpTest).toHaveBeenCalledWith(registeredController);
 		expect(settleMcpTest).not.toHaveBeenCalled();
+		expect(mcpTestEscape.hasActive()).toBe(false);
+	});
+
+	test("/mcp test releases Esc ownership without grace for a disabled server", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		// "disabled-server" is not in the temp user config, so resolution reaches
+		// the runtime-discovered fallback (getServerConfig) with a disabled entry.
+		const { controller, showError, clearMcpTest, mcpTestEscape } = createController(authStorage, {
+			getServerConfig: () => ({ enabled: false, type: "http", url: "http://localhost:1" }),
+			getSource: () => "user",
+		});
+
+		await controller.handle("/mcp test disabled-server");
+
+		expect(showError).toHaveBeenCalledWith(expect.stringContaining('Server "disabled-server" is disabled'));
+		expect(clearMcpTest).toHaveBeenCalledTimes(1);
+		expect(mcpTestEscape.hasActive()).toBe(false);
+	});
+
+	test("Esc during /mcp test config resolution cancels the test, not the session", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		// Holds #resolveServerForAuth open past #findConfiguredServer — mirrors a
+		// slow (network-backed) config lookup while the user presses Esc.
+		const resolution = Promise.withResolvers<{ type: "http"; url: string } | undefined>();
+		const { controller, showError, showStatus, beginMcpTest, settleMcpTest, mcpTestEscape } = createController(
+			authStorage,
+			{
+				getServerConfig: () => resolution.promise,
+				getSource: () => "user",
+			},
+		);
+
+		const testPromise = controller.handle("/mcp test envserver");
+
+		// Esc ownership is armed before resolution starts.
+		const deadline = Date.now() + 1_000;
+		while (beginMcpTest.mock.calls.length === 0 && Date.now() < deadline) {
+			await Bun.sleep(10);
+		}
+		expect(beginMcpTest).toHaveBeenCalledTimes(1);
+		const [registeredController] = beginMcpTest.mock.calls[0] as [AbortController, string];
+		registeredController.abort();
+
+		// Resolution completes after the Esc: the test is reported cancelled —
+		// not "not found" — and settles with the grace window (cancelled), so a
+		// reflexive second Esc is consumed instead of aborting the session.
+		resolution.resolve({ type: "http", url: "http://localhost:1" });
+		await Promise.race([
+			testPromise,
+			Bun.sleep(2_000).then(() => {
+				throw new Error("/mcp test did not resolve after Esc during resolution");
+			}),
+		]);
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(showStatus).toHaveBeenCalledWith('Cancelled MCP test for "envserver"');
+		expect(settleMcpTest).toHaveBeenCalledWith(registeredController);
+		expect(mcpTestEscape.handleEscape()).toBe("consume");
 	});
 
 	test("a second /mcp test supersedes a pending one by aborting its connection", async () => {
@@ -606,11 +684,15 @@ describe("/mcp auth commands", () => {
 
 		const first = controller.handle("/mcp test envserver");
 		const deadline = Date.now() + 1_000;
-		while (beginMcpTest.mock.calls.length < 1 && Date.now() < deadline) {
+		// The second test supersedes the first while its connection attempt is in
+		// flight (begin runs before the config resolution, so a bare begin-count
+		// poll would abort the first during resolution instead).
+		while (signals.length < 1 && Date.now() < deadline) {
 			await Bun.sleep(10);
 		}
+		expect(signals[0]).toBeDefined();
 		const second = controller.handle("/mcp test envserver");
-		while (beginMcpTest.mock.calls.length < 2 && Date.now() < deadline) {
+		while ((beginMcpTest.mock.calls.length < 2 || signals.length < 2) && Date.now() < deadline) {
 			await Bun.sleep(10);
 		}
 		expect(beginMcpTest).toHaveBeenCalledTimes(2);

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -57,6 +57,8 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 		getTools: vi.fn(() => []),
 		waitForConnection: vi.fn(async () => {}),
 		getConnectionStatus: vi.fn(() => "connected"),
+		getServerConfig: vi.fn(() => undefined),
+		getSource: vi.fn(() => undefined),
 		...mcpManagerOverrides,
 	};
 	const oauthManualInput = new OAuthManualInputManager();
@@ -518,16 +520,15 @@ describe("/mcp auth commands", () => {
 			// server whose connection is still in flight when Esc is pressed).
 			// An already-aborted signal must reject immediately — the abort
 			// event has already fired and cannot re-trigger a later listener.
-			return new Promise((_, reject) => {
-				const signal = options?.signal;
-				if (signal?.aborted) {
-					reject(new DOMException("Aborted", "AbortError"));
-					return;
-				}
-				signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
-					once: true,
-				});
-			});
+			const pending = Promise.withResolvers<never>();
+			const reject = (): void => pending.reject(new DOMException("Aborted", "AbortError"));
+			const signal = options?.signal;
+			if (signal?.aborted) {
+				reject();
+			} else {
+				signal?.addEventListener("abort", reject, { once: true });
+			}
+			return pending.promise;
 		});
 		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
 
@@ -535,8 +536,8 @@ describe("/mcp auth commands", () => {
 
 		const testPromise = controller.handle("/mcp test envserver");
 
-		// #handleTest registers its abort controller synchronously, before the
-		// first await — the poll is just a safety net.
+		// #handleTest registers Esc ownership after server validation (a couple
+		// of awaits in); the poll waits for that registration.
 		const deadline = Date.now() + 1_000;
 		while (beginMcpTest.mock.calls.length === 0 && Date.now() < deadline) {
 			await Bun.sleep(10);
@@ -559,6 +560,20 @@ describe("/mcp auth commands", () => {
 		expect(connectSignal?.aborted).toBe(true);
 		expect(showStatus).toHaveBeenCalledWith('Cancelled MCP test for "envserver"');
 		expect(settleMcpTest).toHaveBeenCalledWith(registeredController);
+	});
+
+	test("/mcp test does not arm Esc state for a missing server", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		const { controller, showError, beginMcpTest, settleMcpTest } = createController(authStorage);
+
+		await controller.handle("/mcp test nonexistent");
+
+		// Validation exits must not own Esc: no begin, no settle — a streaming
+		// session keeps interruptible and no five-second grace state is armed.
+		expect(showError).toHaveBeenCalledWith(expect.stringContaining('Server "nonexistent" not found'));
+		expect(beginMcpTest).not.toHaveBeenCalled();
+		expect(settleMcpTest).not.toHaveBeenCalled();
 	});
 
 	test("reauth supersedes an unfinished MCP OAuth flow", async () => {

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -5,8 +5,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
+import * as configWriter from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
 import * as oauthFlow from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
-import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import type { MCPConfigFile, MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { MCPCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-command-controller";
 import { McpTestEscapeState } from "@oh-my-pi/pi-coding-agent/modes/mcp-test-escape";
 import { OAuthManualInputManager } from "@oh-my-pi/pi-coding-agent/modes/oauth-manual-input";
@@ -624,42 +625,45 @@ describe("/mcp auth commands", () => {
 	test("Esc during /mcp test config resolution cancels the test, not the session", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
-		// Holds #resolveServerForAuth open past #findConfiguredServer — mirrors a
-		// slow (network-backed) config lookup while the user presses Esc.
-		const resolution = Promise.withResolvers<{ type: "http"; url: string } | undefined>();
-		const { controller, showError, showStatus, beginMcpTest, settleMcpTest, mcpTestEscape } = createController(
-			authStorage,
-			{
-				getServerConfig: () => resolution.promise,
-				getSource: () => "user",
-			},
-		);
+		// Block the operation #resolveServerForAuth actually awaits — the
+		// config-file read. envserver is found through real config reads before
+		// the (synchronous) manager lookup is ever consulted, so the seam has to
+		// sit on readMCPConfigFile to reproduce a slow (network-backed) lookup.
+		const resolution = Promise.withResolvers<MCPConfigFile>();
+		const readSpy = vi.spyOn(configWriter, "readMCPConfigFile").mockReturnValue(resolution.promise);
+		const { controller, showError, showStatus, beginMcpTest, settleMcpTest, mcpTestEscape } =
+			createController(authStorage);
 
 		const testPromise = controller.handle("/mcp test envserver");
 
-		// Esc ownership is armed before resolution starts.
+		// Esc ownership is armed before the blocked resolution starts.
 		const deadline = Date.now() + 1_000;
 		while (beginMcpTest.mock.calls.length === 0 && Date.now() < deadline) {
 			await Bun.sleep(10);
 		}
 		expect(beginMcpTest).toHaveBeenCalledTimes(1);
+		expect(readSpy).toHaveBeenCalled();
 		const [registeredController] = beginMcpTest.mock.calls[0] as [AbortController, string];
 		registeredController.abort();
 
-		// Resolution completes after the Esc: the test is reported cancelled —
-		// not "not found" — and settles with the grace window (cancelled), so a
-		// reflexive second Esc is consumed instead of aborting the session.
-		resolution.resolve({ type: "http", url: "http://localhost:1" });
+		// The command unblocks on Esc even though the config read never
+		// resolves here: the lookup is raced against the signal, so the
+		// cancellation is reported the moment Esc fires instead of after the
+		// filesystem operation completes.
 		await Promise.race([
 			testPromise,
 			Bun.sleep(2_000).then(() => {
-				throw new Error("/mcp test did not resolve after Esc during resolution");
+				throw new Error("/mcp test did not resolve after Esc during blocked resolution");
 			}),
 		]);
 
 		expect(showError).not.toHaveBeenCalled();
 		expect(showStatus).toHaveBeenCalledWith('Cancelled MCP test for "envserver"');
 		expect(settleMcpTest).toHaveBeenCalledWith(registeredController);
+		// Settled with the grace window (cancelled): a reflexive second Esc is
+		// consumed, not the session. This also proves begin ran before the
+		// blocked resolution — settle's identity guard would otherwise have no
+		// state to record and Esc would fall through.
 		expect(mcpTestEscape.handleEscape()).toBe("consume");
 	});
 

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -47,7 +47,16 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 	const showStatus = vi.fn();
 	const present = vi.fn();
 	const editor: { onEscape?: () => void } = {};
-	const beginMcpTest = vi.fn();
+	const beginMcpTest = vi.fn((_abortController: AbortController, _name: string) => {
+		// Mirror McpTestEscapeState.begin: superseding a still-pending test
+		// aborts its predecessor so the first connection attempt is not
+		// orphaned when Esc ownership moves to the new test. mock.calls
+		// already contains the current call, so the predecessor is at -2.
+		const prior = beginMcpTest.mock.calls.at(-2)?.[0] as AbortController | undefined;
+		if (prior && prior !== _abortController && !prior.signal.aborted) {
+			prior.abort();
+		}
+	});
 	const settleMcpTest = vi.fn();
 	const prepareConfig = vi.fn(async (config: MCPServerConfig) => config);
 	const mcpManager = {
@@ -574,6 +583,64 @@ describe("/mcp auth commands", () => {
 		expect(showError).toHaveBeenCalledWith(expect.stringContaining('Server "nonexistent" not found'));
 		expect(beginMcpTest).not.toHaveBeenCalled();
 		expect(settleMcpTest).not.toHaveBeenCalled();
+	});
+
+	test("a second /mcp test supersedes a pending one by aborting its connection", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		const signals: AbortSignal[] = [];
+		vi.spyOn(mcpClient, "connectToServer").mockImplementation((_name, _config, options) => {
+			signals.push(options?.signal as AbortSignal);
+			const pending = Promise.withResolvers<never>();
+			const reject = (): void => pending.reject(new DOMException("Aborted", "AbortError"));
+			const signal = options?.signal;
+			if (signal?.aborted) {
+				reject();
+			} else {
+				signal?.addEventListener("abort", reject, { once: true });
+			}
+			return pending.promise;
+		});
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
+		const { controller, showStatus, beginMcpTest } = createController(authStorage);
+
+		const first = controller.handle("/mcp test envserver");
+		const deadline = Date.now() + 1_000;
+		while (beginMcpTest.mock.calls.length < 1 && Date.now() < deadline) {
+			await Bun.sleep(10);
+		}
+		const second = controller.handle("/mcp test envserver");
+		while (beginMcpTest.mock.calls.length < 2 && Date.now() < deadline) {
+			await Bun.sleep(10);
+		}
+		expect(beginMcpTest).toHaveBeenCalledTimes(2);
+
+		// The superseded test's connection attempt is aborted when the new test
+		// takes over Esc ownership; the new test's signal stays untouched.
+		expect(signals[0]?.aborted).toBe(true);
+		expect(signals[1]?.aborted).toBe(false);
+
+		// The first command resolves as cancelled; the second is still pending.
+		await Promise.race([
+			first,
+			Bun.sleep(2_000).then(() => {
+				throw new Error("superseded /mcp test did not resolve within 2s");
+			}),
+		]);
+		expect(showStatus).toHaveBeenCalledWith('Cancelled MCP test for "envserver"');
+		expect(signals[1]?.aborted).toBe(false);
+
+		// Esc now owns only the second test: cancelling it resolves the command.
+		const [secondController] = beginMcpTest.mock.calls[1] as [AbortController, string];
+		secondController.abort();
+		await Promise.race([
+			second,
+			Bun.sleep(2_000).then(() => {
+				throw new Error("active /mcp test did not resolve within 2s of Esc");
+			}),
+		]);
+		expect(signals[1]?.aborted).toBe(true);
+		expect(showStatus).toHaveBeenCalledTimes(2);
 	});
 
 	test("reauth supersedes an unfinished MCP OAuth flow", async () => {

--- a/packages/coding-agent/test/mcp-test-escape.test.ts
+++ b/packages/coding-agent/test/mcp-test-escape.test.ts
@@ -60,6 +60,21 @@ describe("McpTestEscapeState", () => {
 		expect(state.cancelled).toBe(false);
 	});
 
+	test("begin supersedes a pending test by aborting its predecessor", () => {
+		const state = new McpTestEscapeState();
+		const first = new AbortController();
+		const second = new AbortController();
+		state.begin(first, "old");
+		state.begin(second, "new");
+
+		// The orphaned predecessor's connection attempt must not survive the
+		// Esc-ownership handover.
+		expect(first.signal.aborted).toBe(true);
+		expect(second.signal.aborted).toBe(false);
+		expect(state.handleEscape()).toBe("abort");
+		expect(second.signal.aborted).toBe(true);
+	});
+
 	test("a superseded test cannot settle or cancel the newer one", () => {
 		const state = new McpTestEscapeState();
 		const first = new AbortController();
@@ -71,6 +86,7 @@ describe("McpTestEscapeState", () => {
 		expect(state.hasActive()).toBe(true);
 		expect(state.handleEscape()).toBe("abort");
 		expect(second.signal.aborted).toBe(true);
-		expect(first.signal.aborted).toBe(false);
+		// The superseded test was aborted by begin, not by this Esc.
+		expect(first.signal.aborted).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/mcp-test-escape.test.ts
+++ b/packages/coding-agent/test/mcp-test-escape.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { MCP_TEST_ESC_GRACE_MS, McpTestEscapeState } from "@oh-my-pi/pi-coding-agent/modes/mcp-test-escape";
+
+describe("McpTestEscapeState", () => {
+	test('pending test: Esc aborts it and returns "abort"', () => {
+		const state = new McpTestEscapeState();
+		const controller = new AbortController();
+		state.begin(controller, "fast");
+
+		expect(state.hasActive()).toBe(true);
+		expect(state.handleEscape()).toBe("abort");
+		expect(controller.signal.aborted).toBe(true);
+	});
+
+	test("settled test: Esc is consumed within the grace window, falls through after it", () => {
+		const state = new McpTestEscapeState();
+		const controller = new AbortController();
+		state.begin(controller, "fast");
+		state.settle(controller);
+
+		expect(state.handleEscape(Date.now() + 1000)).toBe("consume");
+		expect(state.handleEscape(Date.now() + MCP_TEST_ESC_GRACE_MS - 1)).toBe("consume");
+		// Past the grace window: Esc is released back to normal semantics.
+		expect(state.handleEscape(Date.now() + MCP_TEST_ESC_GRACE_MS + 1)).toBe("fallthrough");
+		expect(state.hasActive()).toBe(false);
+	});
+
+	test("no active test: Esc falls through without touching anything", () => {
+		const state = new McpTestEscapeState();
+		expect(state.handleEscape()).toBe("fallthrough");
+		expect(state.hasActive()).toBe(false);
+	});
+
+	test("settle records cancellation when the signal was already aborted", () => {
+		const state = new McpTestEscapeState();
+		const controller = new AbortController();
+		state.begin(controller, "slow");
+		controller.abort();
+		state.settle(controller);
+
+		expect(state.cancelled).toBe(true);
+		expect(state.name).toBe("slow");
+		expect(state.handleEscape(Date.now() + 1000)).toBe("consume");
+	});
+
+	test("settle records completion when the signal was not aborted", () => {
+		const state = new McpTestEscapeState();
+		const controller = new AbortController();
+		state.begin(controller, "fast");
+		state.settle(controller);
+
+		expect(state.cancelled).toBe(false);
+	});
+
+	test("a superseded test cannot settle or cancel the newer one", () => {
+		const state = new McpTestEscapeState();
+		const first = new AbortController();
+		const second = new AbortController();
+		state.begin(first, "old");
+		state.begin(second, "new");
+		state.settle(first); // stale settle must be ignored
+
+		expect(state.hasActive()).toBe(true);
+		expect(state.handleEscape()).toBe("abort");
+		expect(second.signal.aborted).toBe(true);
+		expect(first.signal.aborted).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/mcp-test-escape.test.ts
+++ b/packages/coding-agent/test/mcp-test-escape.test.ts
@@ -39,6 +39,29 @@ describe("McpTestEscapeState", () => {
 		expect(state.hasActive()).toBe(false);
 	});
 
+	test("clear releases Esc ownership immediately, without the grace window", () => {
+		const state = new McpTestEscapeState();
+		const controller = new AbortController();
+		state.begin(controller, "missing");
+		state.clear(controller);
+
+		expect(state.hasActive()).toBe(false);
+		expect(state.handleEscape()).toBe("fallthrough");
+	});
+
+	test("clear is identity-guarded: a stale controller cannot release the active test", () => {
+		const state = new McpTestEscapeState();
+		const stale = new AbortController();
+		const active = new AbortController();
+		state.begin(stale, "old");
+		state.begin(active, "new");
+		state.clear(stale); // superseded controller must be ignored
+
+		expect(state.hasActive()).toBe(true);
+		expect(state.handleEscape()).toBe("abort");
+		expect(active.signal.aborted).toBe(true);
+	});
+
 	test("settle records cancellation when the signal was already aborted", () => {
 		const state = new McpTestEscapeState();
 		const controller = new AbortController();

--- a/packages/coding-agent/test/mcp-test-escape.test.ts
+++ b/packages/coding-agent/test/mcp-test-escape.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import { MCP_TEST_ESC_GRACE_MS, McpTestEscapeState } from "@oh-my-pi/pi-coding-agent/modes/mcp-test-escape";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("McpTestEscapeState", () => {
 	test('pending test: Esc aborts it and returns "abort"', () => {
@@ -13,15 +17,19 @@ describe("McpTestEscapeState", () => {
 	});
 
 	test("settled test: Esc is consumed within the grace window, falls through after it", () => {
+		// Freeze the clock so the grace boundary is measured from one stable
+		// settlement timestamp instead of two wall-clock reads.
+		const now = 1_000_000;
+		vi.spyOn(Date, "now").mockReturnValue(now);
 		const state = new McpTestEscapeState();
 		const controller = new AbortController();
 		state.begin(controller, "fast");
 		state.settle(controller);
 
-		expect(state.handleEscape(Date.now() + 1000)).toBe("consume");
-		expect(state.handleEscape(Date.now() + MCP_TEST_ESC_GRACE_MS - 1)).toBe("consume");
+		expect(state.handleEscape(now + 1000)).toBe("consume");
+		expect(state.handleEscape(now + MCP_TEST_ESC_GRACE_MS - 1)).toBe("consume");
 		// Past the grace window: Esc is released back to normal semantics.
-		expect(state.handleEscape(Date.now() + MCP_TEST_ESC_GRACE_MS + 1)).toBe("fallthrough");
+		expect(state.handleEscape(now + MCP_TEST_ESC_GRACE_MS + 1)).toBe("fallthrough");
 		expect(state.hasActive()).toBe(false);
 	});
 


### PR DESCRIPTION
## Problem

While an agent turn is streaming, running `/mcp test <name>` and then pressing Esc to cancel the test can stop the running session instead: the Esc falls through to the session interrupt path and aborts the streaming turn.

## Root cause

`/mcp test` (MCPCommandController.#handleTest) used to own Esc by swapping the single `editor.onEscape` slot with an abort handler, restored in `finally`. For fast-settling servers (e.g. context7 settles in ~1s) the handler is already restored by the time the user reacts to the still-visible "(esc to cancel)" hint, so Esc hits the input-controller dispatcher and — with a turn streaming — calls `session.abort()`. Verified live: pressing Esc after a settled test produced `agent_end ... stopReason:"aborted"` and stopped the prompt; Esc during a genuinely pending test cancelled only the test.

## Fix

Move `/mcp test` Esc ownership out of the handler-swap into `InteractiveMode` state consulted first by the input-controller dispatcher, matching the existing btw/omfg/cleanse pattern (`ctx.hasActiveX() && ctx.handleXEscape()`):

- New `McpTestEscapeState` (`modes/mcp-test-escape.ts`): pending → Esc aborts the test; settled → Esc stays owned for a 5s grace window (consumed with a status message) so a reaction to "(esc to cancel)" can never kill the session; past the window → Esc is released to normal semantics.
- `#handleTest` registers `beginMcpTest(abortController, name)` instead of swapping `editor.onEscape`; `settleMcpTest` runs in `finally`.
- Dispatcher check inserted after the cleanse check in `input-controller.ts` (overlays keep topmost Esc precedence).

## Verification

- `bun run check:types` (tsgo) and biome clean on all changed files.
- New unit tests (`test/mcp-test-escape.test.ts`) cover the Esc-routing contract: pending abort, grace-window consume, post-grace fallthrough, cancellation flag, superseded-test identity guard. `test/mcp-command-reauth.test.ts` gains a controller test asserting `/mcp test` registers cancellation through ctx state and never touches `editor.onEscape`; 20/20 tests pass.
- Live repro with a built binary (real streaming turn, `deepseek-v4-flash` via opencode-go):
  - A: `/mcp test fast` mid-stream → Esc after settle → status consumed, turn **kept streaming** (previously: session aborted).
  - B: `/mcp test slow` mid-stream → Esc while pending → test cancelled (server process killed before its response), turn kept streaming.
  - C: plain Esc while streaming (no test) → session still aborts (interrupt intact).
  - D: idle `/mcp test` → Esc after settle consumed, no error, TUI responsive.
