### PR TITLE
fix(utils): make readJsonl tolerant of malformed frames instead of aborting

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `readJsonl` no longer aborts a stream when a frame contains raw control characters (e.g. unescaped tabs or `\x01` inside a string, which `Bun.JSONL.parseChunk` rejects). The offending record is repaired via `repairJson` and re-parsed; if it still does not parse, it is skipped and streaming resumes at the next line. A partial record at end-of-stream is dropped instead of throwing `"JSONL stream ended unexpectedly"`. This fixes provider turns aborting with `Failed to parse JSONL` on ollama-cloud thinking-model streams.
+
 ### Added
 
 - New unified archive API `@oh-my-pi/pi-utils/ar`, providing an `openArchive`/`ArchiveReader` interface across formats (including ZIP/ZIP64, tar with gz/bz2/xz/zst compression, ASAR, RAR 4/5, 7z, ISO 9660, CAB, cpio, RPM, Unix ar, Debian packages, LZH, ARJ, and single-stream compressed files) with lazy ranged reads for local files or HTTP range requests via `httpByteSource`, size limits, symlink-safe extraction, and deterministic archive creation for zip, tar, tar.gz, tar.zst, and asar.

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -1,7 +1,7 @@
 const trailingEvents = new WeakSet<ServerSentEvent>();
 
 import { abortableSource } from "./abortable";
-import { parseStreamingJson } from "./json-parse";
+import { parseStreamingJson, repairJson } from "./json-parse";
 
 const LF = 0x0a;
 type JsonlChunkResult = {
@@ -10,6 +10,15 @@ type JsonlChunkResult = {
 	read: number;
 	done: boolean;
 };
+
+/**
+ * Locate the end of the malformed JSONL record that starts at `from` — the
+ * next line feed, or `length` when the record runs to the end of the buffer.
+ */
+function nextLineEnd(buffer: Uint8Array, from: number): number {
+	const nl = buffer.indexOf(LF, from);
+	return nl === -1 ? buffer.length : nl;
+}
 
 function parseJsonlChunkCompat(input: Uint8Array, beg?: number, end?: number): JsonlChunkResult;
 function parseJsonlChunkCompat(input: string): JsonlChunkResult;
@@ -62,9 +71,13 @@ export async function* readJsonl<T>(stream: ReadableStream<Uint8Array>, signal?:
 				if (values.length > 0) {
 					yield* values as T[];
 				}
-				if (error) throw error;
-				if (!done) {
-					throw new Error("JSONL stream ended unexpectedly");
+				if (error) {
+					yield* buffer.recoverMalformed<T>(tail, 0, tail.length);
+				} else if (!done) {
+					// A partial record at EOF: attempt the same repair pass; if the
+					// frame still does not parse, drop it rather than abort the
+					// stream over a truncated final frame.
+					yield* buffer.recoverMalformed<T>(tail, 0, tail.length);
 				}
 			}
 		}
@@ -179,7 +192,10 @@ class ConcatSink {
 			if (values.length > 0) {
 				yield* values as T[];
 			}
-			if (error) throw error;
+			if (error) {
+				yield* this.recoverMalformed<T>(chunk, read, end);
+				return;
+			}
 			if (done) return;
 			this.reset(chunk.subarray(read, end));
 			return;
@@ -196,7 +212,11 @@ class ConcatSink {
 		if (values.length > 0) {
 			yield* values as T[];
 		}
-		if (error) throw error;
+		if (error) {
+			this.#length = 0;
+			yield* this.recoverMalformed<T>(space.subarray(0, total), read, total);
+			return;
+		}
 		if (done) {
 			this.#length = 0;
 			return;
@@ -206,6 +226,51 @@ class ConcatSink {
 			space.copyWithin(0, read, total);
 		}
 		this.#length = rem;
+	}
+
+	/**
+	 * Salvage a JSONL chunk whose parse reported a malformed record. The line
+	 * containing the first parse error is repaired (raw control characters
+	 * inside strings escaped) and re-parsed; if it still does not parse it is
+	 * skipped, and scanning resumes at the following line — a malformed frame
+	 * no longer aborts the whole provider stream.
+	 */
+	*recoverMalformed<T>(buffer: Uint8Array, beg: number, end: number) {
+		let from = beg;
+		while (from < end) {
+			const lineEnd = nextLineEnd(buffer, from);
+			const segment = buffer.subarray(from, lineEnd);
+			if (segment.length > 0) {
+				let parsed: unknown | undefined;
+				try {
+					parsed = JSON.parse(repairJson(new TextDecoder().decode(segment)));
+				} catch {
+					parsed = undefined;
+				}
+				if (parsed !== undefined) {
+					if (Array.isArray(parsed)) {
+						if (parsed.length > 0) yield* parsed as T[];
+					} else {
+						yield parsed as T;
+					}
+					this.#length = 0;
+					if (lineEnd < end) {
+						this.reset(buffer.subarray(lineEnd + 1, end));
+					}
+					return;
+				}
+				if (lineEnd === end) {
+					// No line terminator after the unparseable record: it is an
+					// incomplete frame, not a malformed one — hold it so the next
+					// chunk can complete it.
+					this.#length = 0;
+					this.reset(buffer.subarray(from, end));
+					return;
+				}
+			}
+			from = lineEnd + 1;
+		}
+		this.#length = 0;
 	}
 }
 

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -2,6 +2,7 @@ const trailingEvents = new WeakSet<ServerSentEvent>();
 
 import { abortableSource } from "./abortable";
 import { parseStreamingJson, repairJson } from "./json-parse";
+import * as logger from "./logger";
 
 const LF = 0x0a;
 type JsonlChunkResult = {
@@ -67,17 +68,17 @@ export async function* readJsonl<T>(stream: ReadableStream<Uint8Array>, signal?:
 			const tail = buffer.flush();
 			if (tail) {
 				buffer.clear();
-				const { values, error, done } = parseJsonlChunkCompat(tail, 0, tail.length);
+				const { values, error, read, done } = parseJsonlChunkCompat(tail, 0, tail.length);
 				if (values.length > 0) {
 					yield* values as T[];
 				}
 				if (error) {
-					yield* buffer.recoverMalformed<T>(tail, 0, tail.length);
+					yield* buffer.recoverMalformed<T>(tail, read, tail.length);
 				} else if (!done) {
 					// A partial record at EOF: attempt the same repair pass; if the
 					// frame still does not parse, drop it rather than abort the
 					// stream over a truncated final frame.
-					yield* buffer.recoverMalformed<T>(tail, 0, tail.length);
+					yield* buffer.recoverMalformed<T>(tail, read, tail.length);
 				}
 			}
 		}
@@ -235,7 +236,7 @@ class ConcatSink {
 	 * skipped, and scanning resumes at the following line — a malformed frame
 	 * no longer aborts the whole provider stream.
 	 */
-	*recoverMalformed<T>(buffer: Uint8Array, beg: number, end: number) {
+	*recoverMalformed<T>(buffer: Uint8Array, beg: number, end: number): Generator<T, void, unknown> {
 		let from = beg;
 		while (from < end) {
 			const lineEnd = nextLineEnd(buffer, from);
@@ -248,14 +249,43 @@ class ConcatSink {
 					parsed = undefined;
 				}
 				if (parsed !== undefined) {
-					if (Array.isArray(parsed)) {
-						if (parsed.length > 0) yield* parsed as T[];
-					} else {
-						yield parsed as T;
-					}
+					logger.debug("Repaired JSONL record containing raw control characters", {
+						stream: "readJsonl",
+						offset: from,
+					});
+					// Emit the repaired record as a single frame (a top-level
+					// array is one JSONL value, not one frame per element).
+					yield parsed as T;
 					this.#length = 0;
 					if (lineEnd < end) {
-						this.reset(buffer.subarray(lineEnd + 1, end));
+						// Drain any complete records that follow the repaired
+						// frame before returning, so an idle stream (RPC/MCP)
+						// does not stall them until the next chunk arrives.
+						const suffix = buffer.subarray(lineEnd + 1, end);
+						this.reset(suffix);
+						if (suffix.length > 0) {
+							// Parse the copy (byteOffset 0) — Bun.JSONL.parseChunk
+							// mis-parses nonzero-byteOffset views.
+							const copied = this.flush();
+							if (copied) {
+								const {
+									values: next,
+									error: nextError,
+									read: nextRead,
+									done: nextDone,
+								} = parseJsonlChunkCompat(copied, 0, copied.length);
+								if (next.length > 0) {
+									yield* next as T[];
+								}
+								if (nextError) {
+									yield* this.recoverMalformed<T>(copied, nextRead, copied.length);
+								} else if (nextDone) {
+									this.#length = 0;
+								} else {
+									this.reset(copied.subarray(nextRead));
+								}
+							}
+						}
 					}
 					return;
 				}
@@ -267,6 +297,10 @@ class ConcatSink {
 					this.reset(buffer.subarray(from, end));
 					return;
 				}
+				logger.debug("Skipped unparseable JSONL record", {
+					stream: "readJsonl",
+					offset: from,
+				});
 			}
 			from = lineEnd + 1;
 		}

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -144,6 +144,67 @@ describe("readJsonl", () => {
 		const output = await collectAsync(readJsonl(readable));
 		expect(output).toEqual([{ z: 9 }]);
 	});
+
+	it("repairs a record with raw control chars instead of aborting", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\n{"e":"a\u0001b"}\n{"c":3}\n'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }, { e: "a\u0001b" }, { c: 3 }]);
+	});
+
+	it("skips a malformed line and keeps parsing the rest", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\n{bad json}\n{"c":3}\n'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }, { c: 3 }]);
+	});
+
+	it("recovers when the malformed line is split across chunk boundaries", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\n{"e":"x\u0001'));
+				controller.enqueue(encoder.encode('y"}\n{"c":3}\n'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }, { e: "x\u0001y" }, { c: 3 }]);
+	});
+
+	it("drops a truncated final frame instead of throwing at EOF", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\n{"b":'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }]);
+	});
+
+	it("drops a malformed final frame without trailing newline", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\n{bad'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }]);
+	});
 });
 
 describe("createSanitizerStream", () => {

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -205,6 +205,44 @@ describe("readJsonl", () => {
 		const output = await collectAsync(readJsonl(readable));
 		expect(output).toEqual([{ a: 1 }]);
 	});
+
+	it("does not re-emit records before a malformed tail at EOF", async () => {
+		// Regression: the EOF recovery path restarted at offset 0, re-parsing
+		// and re-yielding the last complete record before the malformed frame.
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('bad\n{"a":1}\n{"b":2}\n{trunc'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }, { b: 2 }]);
+	});
+
+	it("emits a repaired top-level array as a single frame", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\n["x\u0001y",2]\n{"c":3}\n'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ a: 1 }, ["x\u0001y", 2], { c: 3 }]);
+	});
+
+	it("drains complete records that follow a repaired frame in the same chunk", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"e":"a\u0001b"}\n{"b":2}\n{"c":3}\n'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(readJsonl(readable));
+		expect(output).toEqual([{ e: "a\u0001b" }, { b: 2 }, { c: 3 }]);
+	});
 });
 
 describe("createSanitizerStream", () => {


### PR DESCRIPTION
## Summary

`readJsonl` (used by the ollama/ollama-cloud provider stream, MCP stdio transport, and RPC client) treats any `Bun.JSONL.parseChunk` error as fatal and aborts the whole stream. A JSONL line containing raw control characters (unescaped tab, `\x01`, ESC inside a string) makes `parseChunk` return `{ error: {}, read: 0 }` — it does not throw — and `readJsonl` turns that into a provider error, killing the agent turn with **"Failed to parse JSONL"**.

ollama-cloud thinking-model streams (e.g. `deepseek-v4-flash:0731`) emit such frames mid-turn, so the default thinking model pairing is unreliable (can1357/oh-my-pi#8195).

## Change

- On a parse error, the offending line is re-parsed through the existing `repairJson` (escapes raw control chars inside strings) — so valid content is preserved, not discarded — and yielded normally.
- If the repaired line still does not parse, it is skipped and scanning resumes at the next record. **A malformed frame no longer aborts the stream.**
- An unparseable tail *without* a line terminator is held as a partial frame (not dropped), so a later chunk can complete it.
- At EOF, a partial or malformed final frame ends the stream cleanly instead of throwing `"JSONL stream ended unexpectedly"`.
- Malformed lines that are irrecoverable mid-stream are skipped (the `parseJsonlLenient` behaviour); repaired lines keep their content.

## Tests

Added to `packages/utils/test/stream.test.ts`:
- repairs a record with raw control chars instead of aborting (the #8195 repro)
- skips a malformed line and keeps parsing the rest
- recovers when the malformed line is split across chunk boundaries
- drops a truncated final frame instead of throwing at EOF
- drops a malformed final frame without trailing newline

All 38 `stream.test.ts` tests pass; `tsgo --noEmit` and biome clean on the touched files.

Closes can1357/oh-my-pi#8195