### PR TITLE
fix(coding-agent): keep /mcp test Esc from aborting active turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed Esc after a fast `/mcp test` result aborting the active agent turn instead of consuming the advertised cancellation input ([#9173](https://github.com/can1357/oh-my-pi/issues/9173)).
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -303,6 +303,13 @@ export class InputController {
 			});
 		}
 		this.ctx.editor.onEscape = () => {
+			// `/mcp test` advertises Esc until its post-settlement grace expires.
+			// Consume it before any overlapping main-turn or side-channel action.
+			if (this.ctx.mcpTestEscapeHandler) {
+				this.ctx.mcpTestEscapeHandler();
+				return;
+			}
+
 			// Side-channel panels are the topmost view. Esc dismisses them before
 			// touching loop mode, maintenance, or the underlying main turn.
 			// Active context maintenance owns Esc: auto/manual compaction,

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -303,10 +303,10 @@ export class InputController {
 			});
 		}
 		this.ctx.editor.onEscape = () => {
-			// `/mcp test` advertises Esc until its post-settlement grace expires.
-			// Consume it before any overlapping main-turn or side-channel action.
-			if (this.ctx.mcpTestEscapeHandler) {
-				this.ctx.mcpTestEscapeHandler();
+			// `/mcp test` advertises Esc until each owner's post-settlement grace expires.
+			// Cancel every overlapping test before any main-turn or side-channel action.
+			if (this.ctx.mcpTestEscapeHandlers.size > 0) {
+				for (const handler of this.ctx.mcpTestEscapeHandlers) handler();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1576,7 +1576,6 @@ export class MCPCommandController {
 
 		const abortController = new AbortController();
 		const handleEscape = (): void => abortController.abort();
-		let escapeHandlerInstalled = false;
 
 		let connection: MCPServerConnection | undefined;
 		try {
@@ -1595,8 +1594,7 @@ export class MCPCommandController {
 				return;
 			}
 
-			this.ctx.mcpTestEscapeHandler = handleEscape;
-			escapeHandlerInstalled = true;
+			this.ctx.mcpTestEscapeHandlers.add(handleEscape);
 
 			this.#showMessage(
 				["", theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), ""].join("\n"),
@@ -1662,11 +1660,9 @@ export class MCPCommandController {
 
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
-			if (escapeHandlerInstalled) {
+			if (this.ctx.mcpTestEscapeHandlers.has(handleEscape)) {
 				const timer = setTimeout(() => {
-					if (this.ctx.mcpTestEscapeHandler === handleEscape) {
-						this.ctx.mcpTestEscapeHandler = undefined;
-					}
+					this.ctx.mcpTestEscapeHandlers.delete(handleEscape);
 				}, MCP_TEST_ESCAPE_GRACE_MS);
 				timer.unref();
 			}

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -70,6 +70,7 @@ import { groupBySource, parseRemoveArgs, readScopeFlag, showCommandMessage } fro
 
 const MCP_MANUAL_INPUT_PROVIDER_ID = "mcp";
 const MCP_MANUAL_LOGIN_TIP = "Headless? Paste the redirect URL or code with /login <value>.";
+const MCP_TEST_ESCAPE_GRACE_MS = 5_000;
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string, onTimeout?: () => void): Promise<T> {
 	const { promise: timeoutPromise, reject } = Promise.withResolvers<T>();
 	const timer = setTimeout(() => {
@@ -1573,11 +1574,9 @@ export class MCPCommandController {
 			return;
 		}
 
-		const originalOnEscape = this.ctx.editor.onEscape;
 		const abortController = new AbortController();
-		this.ctx.editor.onEscape = () => {
-			abortController.abort();
-		};
+		const handleEscape = (): void => abortController.abort();
+		let escapeHandlerInstalled = false;
 
 		let connection: MCPServerConnection | undefined;
 		try {
@@ -1595,6 +1594,9 @@ export class MCPCommandController {
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
 			}
+
+			this.ctx.mcpTestEscapeHandler = handleEscape;
+			escapeHandlerInstalled = true;
 
 			this.#showMessage(
 				["", theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), ""].join("\n"),
@@ -1660,7 +1662,14 @@ export class MCPCommandController {
 
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
-			this.ctx.editor.onEscape = originalOnEscape;
+			if (escapeHandlerInstalled) {
+				const timer = setTimeout(() => {
+					if (this.ctx.mcpTestEscapeHandler === handleEscape) {
+						this.ctx.mcpTestEscapeHandler = undefined;
+					}
+				}, MCP_TEST_ESCAPE_GRACE_MS);
+				timer.unref();
+			}
 			if (connection) {
 				// Best-effort: don't block UI on cleanup.
 				void disconnectServer(connection);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1577,11 +1577,17 @@ export class MCPCommandController {
 		const abortController = new AbortController();
 		const handleEscape = (): void => abortController.abort();
 
+		// Claim Esc before the first await: a slow `#resolveServerForAuth()` (e.g.
+		// config on a network filesystem) must not let Esc fall through to the
+		// agent-turn abort while the command is already running.
+		this.ctx.mcpTestEscapeHandlers.add(handleEscape);
+
 		let connection: MCPServerConnection | undefined;
 		try {
 			const found = await this.#resolveServerForAuth(name);
 
 			if (!found) {
+				this.ctx.mcpTestEscapeHandlers.delete(handleEscape);
 				this.ctx.showError(
 					`Server "${name}" not found.\n\nTip: Run ${theme.fg("accent", "/mcp list")} to see available servers.`,
 				);
@@ -1590,11 +1596,10 @@ export class MCPCommandController {
 
 			const { config } = found;
 			if (config.enabled === false) {
+				this.ctx.mcpTestEscapeHandlers.delete(handleEscape);
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
 			}
-
-			this.ctx.mcpTestEscapeHandlers.add(handleEscape);
 
 			this.#showMessage(
 				["", theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), ""].join("\n"),

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1583,6 +1583,10 @@ export class MCPCommandController {
 		this.ctx.mcpTestEscapeHandlers.add(handleEscape);
 
 		let connection: MCPServerConnection | undefined;
+		// The grace window only applies once the "(esc to cancel)" hint is on
+		// screen; a pre-hint failure must release Esc immediately so it is not
+		// swallowed for a prompt the user never saw.
+		let hintShown = false;
 		try {
 			const found = await this.#resolveServerForAuth(name);
 
@@ -1604,6 +1608,7 @@ export class MCPCommandController {
 			this.#showMessage(
 				["", theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), ""].join("\n"),
 			);
+			hintShown = true;
 
 			// Resolve auth config if needed
 			let resolvedConfig: MCPServerConfig;
@@ -1666,10 +1671,14 @@ export class MCPCommandController {
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
 			if (this.ctx.mcpTestEscapeHandlers.has(handleEscape)) {
-				const timer = setTimeout(() => {
+				if (hintShown) {
+					const timer = setTimeout(() => {
+						this.ctx.mcpTestEscapeHandlers.delete(handleEscape);
+					}, MCP_TEST_ESCAPE_GRACE_MS);
+					timer.unref();
+				} else {
 					this.ctx.mcpTestEscapeHandlers.delete(handleEscape);
-				}, MCP_TEST_ESCAPE_GRACE_MS);
-				timer.unref();
+				}
 			}
 			if (connection) {
 				// Best-effort: don't block UI on cleanup.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -624,6 +624,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	optimisticSkillMessagePending = false;
 	lastSigintTime = 0;
 	lastEscapeTime = 0;
+	/** Owns Esc while `/mcp test` is cancellable or its cancellation hint may still be visible. */
+	mcpTestEscapeHandler: (() => void) | undefined;
 	lastLeftTapTime = 0;
 	shutdownRequested = false;
 	#isShuttingDown = false;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -624,8 +624,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	optimisticSkillMessagePending = false;
 	lastSigintTime = 0;
 	lastEscapeTime = 0;
-	/** Owns Esc while `/mcp test` is cancellable or its cancellation hint may still be visible. */
-	mcpTestEscapeHandler: (() => void) | undefined;
+	/** Owns Esc for every `/mcp test` that is active or whose cancellation hint may still be visible. */
+	mcpTestEscapeHandlers = new Set<() => void>();
 	lastLeftTapTime = 0;
 	shutdownRequested = false;
 	#isShuttingDown = false;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -215,6 +215,8 @@ export interface InteractiveModeContext {
 	locallySubmittedUserSignatures: Set<string>;
 	lastSigintTime: number;
 	lastEscapeTime: number;
+	/** Owns Esc while `/mcp test` is cancellable or its cancellation hint may still be visible. */
+	mcpTestEscapeHandler?: () => void;
 	lastLeftTapTime: number;
 	shutdownRequested: boolean;
 	/** True once `shutdown()` has started. Read-only from the context;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -215,8 +215,8 @@ export interface InteractiveModeContext {
 	locallySubmittedUserSignatures: Set<string>;
 	lastSigintTime: number;
 	lastEscapeTime: number;
-	/** Owns Esc while `/mcp test` is cancellable or its cancellation hint may still be visible. */
-	mcpTestEscapeHandler?: () => void;
+	/** Owns Esc for every `/mcp test` that is active or whose cancellation hint may still be visible. */
+	mcpTestEscapeHandlers: Set<() => void>;
 	lastLeftTapTime: number;
 	shutdownRequested: boolean;
 	/** True once `shutdown()` has started. Read-only from the context;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -442,6 +442,20 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
+	it("keeps /mcp test Esc from aborting an overlapping stream", () => {
+		const { ctx, editor, spies } = createContext();
+		mutableSessionState(ctx).isStreaming = true;
+		const mcpTestEscapeHandler = vi.fn();
+		ctx.mcpTestEscapeHandler = mcpTestEscapeHandler;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(mcpTestEscapeHandler).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
 	it("dismisses an active /btw panel before aborting the main stream", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isStreaming: boolean }).isStreaming = true;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -191,6 +191,7 @@ function createContext(): {
 			getKeys: () => [],
 		} as unknown as InteractiveModeContext["keybindings"],
 		compactionQueuedMessages: [],
+		mcpTestEscapeHandlers: new Set(),
 		isBashMode: false,
 		isPythonMode: false,
 		optimisticUserMessageSignature: undefined,
@@ -442,17 +443,27 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
-	it("keeps /mcp test Esc from aborting an overlapping stream", () => {
+	it("keeps every overlapping /mcp test cancellable before aborting the stream", () => {
 		const { ctx, editor, spies } = createContext();
 		mutableSessionState(ctx).isStreaming = true;
-		const mcpTestEscapeHandler = vi.fn();
-		ctx.mcpTestEscapeHandler = mcpTestEscapeHandler;
+		const firstTestEscapeHandler = vi.fn();
+		const latestTestEscapeHandler = vi.fn();
+		ctx.mcpTestEscapeHandlers.add(firstTestEscapeHandler);
+		ctx.mcpTestEscapeHandlers.add(latestTestEscapeHandler);
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
 		editor.onEscape?.();
 
-		expect(mcpTestEscapeHandler).toHaveBeenCalledTimes(1);
+		expect(firstTestEscapeHandler).toHaveBeenCalledTimes(1);
+		expect(latestTestEscapeHandler).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+
+		ctx.mcpTestEscapeHandlers.delete(latestTestEscapeHandler);
+		editor.onEscape?.();
+
+		expect(firstTestEscapeHandler).toHaveBeenCalledTimes(2);
+		expect(latestTestEscapeHandler).toHaveBeenCalledTimes(1);
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -80,14 +80,9 @@ describe("interactive /mcp test", () => {
 		const connectToServer = vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
 		const listTools = vi.spyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
 		const disconnectServer = vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
-		let mcpTestEscapeHandler: (() => void) | undefined;
+		const mcpTestEscapeHandlers = new Set<() => void>();
 		const controller = new MCPCommandController({
-			get mcpTestEscapeHandler() {
-				return mcpTestEscapeHandler;
-			},
-			set mcpTestEscapeHandler(handler: (() => void) | undefined) {
-				mcpTestEscapeHandler = handler;
-			},
+			mcpTestEscapeHandlers,
 			chatContainer: { addChild },
 			present: (content: unknown) => {
 				for (const item of Array.isArray(content) ? content : [content]) addChild(item);
@@ -111,13 +106,13 @@ describe("interactive /mcp test", () => {
 		await controller.handle("/mcp test github");
 		const signal = connectToServer.mock.calls[0]?.[2]?.signal;
 		expect(signal?.aborted).toBe(false);
-		expect(mcpTestEscapeHandler).toEqual(expect.any(Function));
-		mcpTestEscapeHandler?.();
+		expect(mcpTestEscapeHandlers).toHaveLength(1);
+		for (const handler of mcpTestEscapeHandlers) handler();
 		expect(signal?.aborted).toBe(true);
 		vi.advanceTimersByTime(4_999);
-		expect(mcpTestEscapeHandler).toEqual(expect.any(Function));
+		expect(mcpTestEscapeHandlers).toHaveLength(1);
 		vi.advanceTimersByTime(1);
-		expect(mcpTestEscapeHandler).toBeUndefined();
+		expect(mcpTestEscapeHandlers).toHaveLength(0);
 
 		expect(showError).not.toHaveBeenCalled();
 		expect(connectToServer).toHaveBeenCalledWith(

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -124,4 +124,40 @@ describe("interactive /mcp test", () => {
 		expect(disconnectServer).toHaveBeenCalledWith(connection);
 		expect(requestRender).toHaveBeenCalled();
 	});
+
+	it("claims Esc ownership before the awaited server lookup", async () => {
+		const connection = {
+			name: "github",
+			config: { type: "stdio" as const, command: "github-mcp-server", args: ["serve"] },
+			transport: { connected: true, request: vi.fn(), notify: vi.fn(), close: vi.fn(async () => {}) },
+			serverInfo: { name: "GitHub MCP", version: "1.0.0" },
+			capabilities: {},
+		};
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
+		const mcpTestEscapeHandlers = new Set<() => void>();
+		const controller = new MCPCommandController({
+			mcpTestEscapeHandlers,
+			chatContainer: { addChild: vi.fn() },
+			present: vi.fn(),
+			presentCommandOutput: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			editor: {},
+			showError: vi.fn(),
+			showStatus: vi.fn(),
+			session: { refreshMCPTools: vi.fn() },
+			mcpManager: {
+				prepareConfig: vi.fn(async config => config),
+				getConnectionStatus: vi.fn(() => "connected"),
+			},
+		} as never);
+
+		// Do not await: the handler must be registered synchronously, before the
+		// awaited `#resolveServerForAuth()` config read can suspend and let Esc
+		// fall through to aborting the agent turn.
+		const pending = controller.handle("/mcp test github");
+		expect(mcpTestEscapeHandlers).toHaveLength(1);
+		await pending;
+	});
 });

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
+import * as mcpConfigWriter from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
 import { MCPCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-command-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { getConfigRootDir, getProjectDir, removeWithRetries, setAgentDir, setProjectDir } from "@oh-my-pi/pi-utils";
@@ -159,5 +160,35 @@ describe("interactive /mcp test", () => {
 		const pending = controller.handle("/mcp test github");
 		expect(mcpTestEscapeHandlers).toHaveLength(1);
 		await pending;
+	});
+
+	it("releases Esc immediately when lookup fails before the hint is shown", async () => {
+		vi.spyOn(mcpConfigWriter, "readMCPConfigFile").mockRejectedValue(new Error("EACCES: config unreadable"));
+		const connectToServer = vi.spyOn(mcpClient, "connectToServer");
+		const showError = vi.fn();
+		const mcpTestEscapeHandlers = new Set<() => void>();
+		const controller = new MCPCommandController({
+			mcpTestEscapeHandlers,
+			chatContainer: { addChild: vi.fn() },
+			present: vi.fn(),
+			presentCommandOutput: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			editor: {},
+			showError,
+			showStatus: vi.fn(),
+			session: { refreshMCPTools: vi.fn() },
+			mcpManager: {
+				getServerConfig: vi.fn(() => undefined),
+				getSource: vi.fn(() => undefined),
+			},
+		} as never);
+
+		await controller.handle("/mcp test github");
+
+		// The "(esc to cancel)" hint never rendered, so no grace window applies:
+		// Esc must be free again immediately instead of being swallowed for 5s.
+		expect(mcpTestEscapeHandlers).toHaveLength(0);
+		expect(connectToServer).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -11,7 +11,7 @@ const originalProjectDir = getProjectDir();
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
-describe("issue #956: interactive /mcp test", () => {
+describe("interactive /mcp test", () => {
 	let projectDir = "";
 	let agentDir = "";
 
@@ -44,6 +44,7 @@ describe("issue #956: interactive /mcp test", () => {
 	});
 
 	afterEach(async () => {
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 		setProjectDir(originalProjectDir);
 		if (originalAgentDir) {
@@ -56,7 +57,8 @@ describe("issue #956: interactive /mcp test", () => {
 		await removeWithRetries(agentDir);
 	});
 
-	it("tests a connected server discovered from standalone .mcp.json", async () => {
+	it("tests a discovered server and keeps its advertised Esc cancellation grace", async () => {
+		vi.useFakeTimers();
 		const transport = {
 			connected: true,
 			request: vi.fn(),
@@ -78,7 +80,14 @@ describe("issue #956: interactive /mcp test", () => {
 		const connectToServer = vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
 		const listTools = vi.spyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
 		const disconnectServer = vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
+		let mcpTestEscapeHandler: (() => void) | undefined;
 		const controller = new MCPCommandController({
+			get mcpTestEscapeHandler() {
+				return mcpTestEscapeHandler;
+			},
+			set mcpTestEscapeHandler(handler: (() => void) | undefined) {
+				mcpTestEscapeHandler = handler;
+			},
 			chatContainer: { addChild },
 			present: (content: unknown) => {
 				for (const item of Array.isArray(content) ? content : [content]) addChild(item);
@@ -100,6 +109,15 @@ describe("issue #956: interactive /mcp test", () => {
 		} as never);
 
 		await controller.handle("/mcp test github");
+		const signal = connectToServer.mock.calls[0]?.[2]?.signal;
+		expect(signal?.aborted).toBe(false);
+		expect(mcpTestEscapeHandler).toEqual(expect.any(Function));
+		mcpTestEscapeHandler?.();
+		expect(signal?.aborted).toBe(true);
+		vi.advanceTimersByTime(4_999);
+		expect(mcpTestEscapeHandler).toEqual(expect.any(Function));
+		vi.advanceTimersByTime(1);
+		expect(mcpTestEscapeHandler).toBeUndefined();
 
 		expect(showError).not.toHaveBeenCalled();
 		expect(connectToServer).toHaveBeenCalledWith(


### PR DESCRIPTION
## Repro
While an agent turn is streaming, run `/mcp test <name>` against a fast-settling MCP server and press Esc shortly after the result appears while the cancellation hint remains visible. `bun test packages/coding-agent/test/input-controller-escape.test.ts` reproduced the failure: the MCP handler received zero calls and Esc reached the streaming-session abort path.

## Cause
`MCPCommandController.#handleTest()` in `packages/coding-agent/src/modes/controllers/mcp-command-controller.ts` temporarily replaced `editor.onEscape` and restored it as soon as the server test settled. The persistent dispatcher in `InputController.setupKeyHandlers()` then interpreted a reaction to the still-visible hint as an instruction to abort the active agent turn.

## Fix
- Route `/mcp test` Esc ownership through explicit `InteractiveModeContext` state checked before all overlapping session actions.
- Retain that ownership for five seconds after settlement, with identity-checked cleanup so an older test cannot clear a newer handler.
- Cover both dispatcher priority and the post-settlement cancellation grace window; document the user-visible fix in the changelog.

## Verification
`bun test packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/issue-956-repro.test.ts` — 36 passed, 0 failed. `bun check` passed for all packages.

Fixes #9173