### PR TITLE
fix(rpc): preserve select option descriptions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed RPC UI select requests dropping option descriptions, allowing hosts to render described choices ([#9175](https://github.com/can1357/oh-my-pi/issues/9175)).
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -44,6 +44,7 @@ import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
+	RpcExtensionUISelectOptionDetail,
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
 	RpcHostToolDefinition,
@@ -541,6 +542,42 @@ function isSubagentSubscriptionLevel(value: unknown): value is RpcSubagentSubscr
 	return value === "off" || value === "progress" || value === "events";
 }
 
+/** Sends an RPC select request while retaining aligned option descriptions. */
+export function requestRpcSelect(
+	pendingRequests: Map<string, PendingExtensionRequest>,
+	output: RpcOutput,
+	title: string,
+	options: ExtensionUISelectItem[],
+	dialogOptions?: ExtensionUIDialogOptions,
+): Promise<string | undefined> {
+	const labels = new Array<string>(options.length);
+	let optionDetails: RpcExtensionUISelectOptionDetail[] | undefined;
+	for (let index = 0; index < options.length; index++) {
+		const option = options[index]!;
+		labels[index] = getExtensionUISelectOptionLabel(option);
+		if (typeof option === "string") continue;
+		const description = option.description?.trim();
+		if (!description) continue;
+		optionDetails ??= Array.from({ length: options.length }, () => ({}));
+		optionDetails[index] = { description };
+	}
+
+	return requestRpcDialog(
+		pendingRequests,
+		output,
+		dialogOptions,
+		undefined,
+		{
+			method: "select",
+			title,
+			options: labels,
+			...(optionDetails ? { optionDetails } : {}),
+			timeout: dialogOptions?.timeout,
+		},
+		response => parseValueDialogResponse(response, dialogOptions),
+	);
+}
+
 export function requestRpcEditor(
 	pendingRequests: Map<string, PendingExtensionRequest>,
 	output: RpcOutput,
@@ -742,19 +779,7 @@ export async function runRpcMode(
 			options: ExtensionUISelectItem[],
 			dialogOptions?: ExtensionUIDialogOptions,
 		): Promise<string | undefined> {
-			return requestRpcDialog(
-				this.pendingRequests,
-				this.output,
-				dialogOptions,
-				undefined,
-				{
-					method: "select",
-					title,
-					options: options.map(getExtensionUISelectOptionLabel),
-					timeout: dialogOptions?.timeout,
-				},
-				response => parseValueDialogResponse(response, dialogOptions),
-			);
+			return requestRpcSelect(this.pendingRequests, this.output, title, options, dialogOptions);
 		}
 
 		confirm(title: string, message: string, dialogOptions?: ExtensionUIDialogOptions): Promise<boolean> {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -367,10 +367,22 @@ export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
 // ============================================================================
 // Extension UI Events (stdout)
 // ============================================================================
+/** Positional presentation metadata for an RPC select option. */
+export interface RpcExtensionUISelectOptionDetail {
+	description?: string;
+}
 
 /** Emitted when an extension needs user input */
 export type RpcExtensionUIRequest =
-	| { type: "extension_ui_request"; id: string; method: "select"; title: string; options: string[]; timeout?: number }
+	| {
+			type: "extension_ui_request";
+			id: string;
+			method: "select";
+			title: string;
+			options: string[];
+			optionDetails?: RpcExtensionUISelectOptionDetail[];
+			timeout?: number;
+	  }
 	| { type: "extension_ui_request"; id: string; method: "confirm"; title: string; message: string; timeout?: number }
 	| {
 			type: "extension_ui_request";

--- a/packages/coding-agent/test/rpc-extension-ui.test.ts
+++ b/packages/coding-agent/test/rpc-extension-ui.test.ts
@@ -1,7 +1,69 @@
 import { describe, expect, it, vi } from "bun:test";
-import { type PendingExtensionRequest, requestRpcDialog } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import {
+	type PendingExtensionRequest,
+	requestRpcDialog,
+	requestRpcSelect,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+
+function requireRequest(frame: object | undefined): { id: string } {
+	if (!frame || !("id" in frame)) {
+		throw new Error("Expected the RPC dialog request to carry an id");
+	}
+	const id = frame.id;
+	if (typeof id !== "string") throw new Error("Expected the RPC dialog request id to be a string");
+	return { id };
+}
+
+function resolveSelection(pendingRequests: Map<string, PendingExtensionRequest>, id: string, value: string): void {
+	const request = pendingRequests.get(id);
+	if (!request) throw new Error(`Expected pending RPC dialog request ${id}`);
+	request.resolve({ type: "extension_ui_response", id, value });
+}
 
 describe("RPC extension UI", () => {
+	it("keeps the label-only wire shape for bare options", async () => {
+		const pendingRequests = new Map<string, PendingExtensionRequest>();
+		const output = vi.fn<(frame: object) => void>();
+		const result = requestRpcSelect(pendingRequests, output, "Action", ["Keep", "Deploy"]);
+		const request = requireRequest(output.mock.calls[0]?.[0]);
+
+		expect(output).toHaveBeenCalledWith({
+			type: "extension_ui_request",
+			id: request.id,
+			method: "select",
+			title: "Action",
+			options: ["Keep", "Deploy"],
+			timeout: undefined,
+		});
+
+		resolveSelection(pendingRequests, request.id, "Keep");
+		expect(await result).toBe("Keep");
+	});
+
+	it("emits aligned descriptions and resolves with the selected label", async () => {
+		const pendingRequests = new Map<string, PendingExtensionRequest>();
+		const output = vi.fn<(frame: object) => void>();
+		const result = requestRpcSelect(pendingRequests, output, "Action", [
+			"Keep",
+			{ label: "Deploy", description: " Push to production " },
+			{ label: "Preview", description: "   " },
+		]);
+		const request = requireRequest(output.mock.calls[0]?.[0]);
+
+		expect(output).toHaveBeenCalledWith({
+			type: "extension_ui_request",
+			id: request.id,
+			method: "select",
+			title: "Action",
+			options: ["Keep", "Deploy", "Preview"],
+			optionDetails: [{}, { description: "Push to production" }, {}],
+			timeout: undefined,
+		});
+
+		resolveSelection(pendingRequests, request.id, "Deploy");
+		expect(await result).toBe("Deploy");
+	});
+
 	it("cancels the remote dialog when its signal aborts", async () => {
 		const pendingRequests = new Map<string, PendingExtensionRequest>();
 		const output = vi.fn<(frame: object) => void>();

--- a/python/omp-rpc/src/omp_rpc/protocol.py
+++ b/python/omp-rpc/src/omp_rpc/protocol.py
@@ -167,6 +167,16 @@ def _optional_json_object(value: object, *, field: str) -> JsonObject | None:
     return _clone_json_object(value, field=field)
 
 
+def _optional_json_objects(
+    values: object, *, field: str
+) -> tuple[JsonObject, ...] | None:
+    if values is None:
+        return None
+    if not isinstance(values, list):
+        raise ValueError(f"{field} must be a list")
+    return tuple(_clone_json_object(item, field=f"{field}[]") for item in values)
+
+
 def _clone_json_objects(values: object, *, field: str) -> tuple[JsonObject, ...]:
     if values is None:
         return ()
@@ -923,6 +933,7 @@ class ExtensionUiRequest:
     title: str | None = None
     options: tuple[str, ...] | None = None
     message: str | None = None
+    option_details: tuple[JsonObject, ...] | None = field(default=None, kw_only=True)
     placeholder: str | None = None
     prefill: str | None = None
     timeout: int | None = None
@@ -1539,6 +1550,9 @@ def parse_extension_ui_request(payload: JsonObject) -> ExtensionUiRequest:
         title=_optional_str(payload, "title"),
         options=_tuple_of_strings(
             payload.get("options"), field="extension_ui_request.options"
+        ),
+        option_details=_optional_json_objects(
+            payload.get("optionDetails"), field="extension_ui_request.optionDetails"
         ),
         message=_optional_str(payload, "message"),
         placeholder=_optional_str(payload, "placeholder"),

--- a/python/omp-rpc/tests/test_protocol.py
+++ b/python/omp-rpc/tests/test_protocol.py
@@ -229,6 +229,33 @@ class ProtocolParsingTests(unittest.TestCase):
         self.assertTrue(notification.requires_response())
         self.assertFalse(notification.is_passive())
 
+    def test_parse_select_option_details(self) -> None:
+        notification = parse_notification(
+            {
+                "type": "extension_ui_request",
+                "id": "ui-2",
+                "method": "select",
+                "title": "Deploy",
+                "options": ["Keep", "Deploy"],
+                "optionDetails": [{}, {"description": "Push to production"}],
+            }
+        )
+
+        self.assertIsInstance(notification, ExtensionUiRequest)
+        self.assertEqual(notification.options, ("Keep", "Deploy"))
+        self.assertEqual(
+            notification.option_details,
+            ({}, {"description": "Push to production"}),
+        )
+
+    def test_extension_ui_request_preserves_positional_constructor(self) -> None:
+        request = ExtensionUiRequest(
+            "ui-legacy", "confirm", "Confirm", None, "Continue?"
+        )
+
+        self.assertEqual(request.message, "Continue?")
+        self.assertIsNone(request.option_details)
+
     def test_parse_open_url_request(self) -> None:
         notification = parse_notification(
             {


### PR DESCRIPTION
## Repro
A described select option is reduced to its label before the RPC host sees it. Running `bun -e 'import { getExtensionUISelectOptionLabel } from "./packages/coding-agent/src/extensibility/extensions/types.ts"; const items = ["Keep", { label: "Deploy", description: "Push to production" }]; console.log(JSON.stringify({ type: "extension_ui_request", method: "select", title: "Action", options: items.map(getExtensionUISelectOptionLabel) }));'` on current `main` emits `options:["Keep","Deploy"]` with no description metadata.

## Cause
`RpcExtensionUIContext.select()` in `packages/coding-agent/src/modes/rpc/rpc-mode.ts` mapped every `ExtensionUISelectItem` through `getExtensionUISelectOptionLabel()` and `RpcExtensionUIRequest` in `rpc-types.ts` exposed no field for the discarded presentation metadata.

## Fix
- Add optional aligned `optionDetails` metadata to select request frames while retaining `options: string[]`.
- Omit metadata for label-only or whitespace-only options and preserve empty positional entries for mixed lists.
- Route select requests through a focused helper and cover both emitted frames and selected-label responses.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/rpc-extension-ui.test.ts` passes 3 tests; `bun check` passes. A direct `requestRpcSelect()` smoke run emits aligned `optionDetails` and resolves the host response to `selected=Deploy`.

Fixes #9175