### PR TITLE
docs(coding-agent): document prewalk

### DIFF
--- a/docs/prewalk.md
+++ b/docs/prewalk.md
@@ -1,0 +1,60 @@
+# Prewalk
+
+Prewalk is a one-shot handoff from the active model to a faster or cheaper model after planning reaches implementation. It lets the starting model inspect the repository, create a todo list, and begin the change before the target model continues the session.
+
+Prewalk is off by default. Its default target is the model assigned to the `@smol` role.
+
+## Enable prewalk
+
+Enable prewalk persistently in the global config:
+
+```bash
+omp config set prewalk.enabled true
+```
+
+The equivalent YAML in `~/.omp/agent/config.yml` or a project `.omp/config.yml` is:
+
+```yaml
+prewalk:
+  enabled: true
+```
+
+Session flags override the configured value:
+
+| Flag | Effect |
+| --- | --- |
+| `--prewalk` | Arm prewalk for the new session. |
+| `--no-prewalk` | Leave prewalk disabled for the session, even when `prewalk.enabled` is `true`. |
+| `--prewalk-into <model-or-role>` | Arm prewalk and use the supplied model pattern or role instead of `@smol`. |
+
+For example:
+
+```bash
+omp --prewalk
+omp --prewalk-into @smol
+omp --prewalk-into openai/gpt-5-mini
+```
+
+At startup, OMP resolves the target with the normal model-role and model-matching rules. If the target cannot be resolved or has no configured credentials, OMP prints a warning and starts with prewalk unarmed.
+
+## Handoff trigger
+
+An armed prewalk injects a planning nudge. When the `todo` tool is active, the handoff stays gated until the agent has successfully created or updated the todo list. OMP then switches models after the first completed `edit` or `write` call.
+
+Calls to other tools do not trigger the handoff. A read-only `xd://` device request routed through `write`, such as LSP navigation, also does not count; only device operations classified as workspace writes or execution count.
+
+The switch is one-shot: after the handoff, prewalk disarms itself. The target model and thinking level are not changed when they already match the active session, because that handoff would be a no-op.
+
+## Arm from an active session
+
+Run the slash command to arm prewalk without restarting OMP or enabling it in config:
+
+```text
+/prewalk
+```
+
+`/prewalk` always targets the `@smol` role. If prewalk is already armed, the command leaves the existing target in place. After a handoff is consumed, switch to another model and run `/prewalk` again to arm another one-shot handoff. To choose a different target at startup, use `--prewalk-into`.
+
+## Subagent prewalk
+
+Task subagents have separate prewalk controls: agent frontmatter, `task.prewalk`, and per-agent `task.agentPrewalk` overrides. See [Task agent discovery](./task-agent-discovery.md) for their precedence and target selection.

--- a/docs/prewalk.md
+++ b/docs/prewalk.md
@@ -39,7 +39,7 @@ At startup, OMP resolves the target with the normal model-role and model-matchin
 
 ## Handoff trigger
 
-An armed prewalk injects a planning nudge. When the `todo` tool is active, the handoff stays gated until the agent has successfully created or updated the todo list. OMP then switches models after the first completed `edit` or `write` call.
+An armed prewalk injects a planning nudge. When the `todo` tool is active, any successful `todo` call—including the read-only `view` operation—opens the handoff gate. OMP then switches models after the first completed `edit` or `write` call.
 
 Calls to other tools do not trigger the handoff. A read-only `xd://` device request routed through `write`, such as LSP navigation, also does not count; only device operations classified as workspace writes or execution count.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed prompt guidance and descriptions for Task tools and SSH usage.
 - ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+- Documented how to enable, trigger, target, and manually re-arm prewalk ([#9179](https://github.com/can1357/oh-my-pi/issues/9179)).
 
 ## [17.4.0] - 2026-08-20
 


### PR DESCRIPTION
## Repro

On current `main`, `omp read omp://prewalk` exits 1 with `Documentation file not found: prewalk`, and the `omp://` root listing contains no prewalk reference because the source corpus has no `docs/prewalk.md`.

## Cause

`packages/coding-agent/src/internal-urls/docs-index.ts` builds the shipped `omp://` index from the root `docs/` Markdown corpus. Prewalk’s runtime, CLI flags, setting, and slash command exist, but that corpus had no dedicated page for them.

## Fix

- Add `docs/prewalk.md` covering `prewalk.enabled`, all session flags, the default `@smol` target, the todo-gated `edit`/`write` trigger, one-shot behavior, and `/prewalk` re-arming.
- Link the separate task-subagent controls and record the documentation fix in the coding-agent changelog.

## Verification

`bun packages/coding-agent/src/cli.ts read omp://prewalk.md` exits 0 and renders the new reference. `bun packages/coding-agent/src/cli.ts read omp://` exits 0 and lists `[prewalk.md](omp://prewalk.md)`. The publish gate completed `bun run fix` and `bun check`.

Fixes #9179