### PR TITLE
feat(coding-agent): use Codex Images API

### DIFF
--- a/docs/tools/generate_image.md
+++ b/docs/tools/generate_image.md
@@ -23,6 +23,7 @@ The custom tool is registered only when `generate_image.enabled=true` (default `
 | `changes` | `string[]` | No | Edit instructions for input images. |
 | `aspect_ratio` | `"1:1" \| "3:4" \| "4:3" \| "9:16" \| "16:9" \| "3:2" \| "2:3"` | No | Requested output aspect ratio. |
 | `image_size` | `"1024x1024" \| "1536x1024" \| "1024x1536"` | No | Requested output size where the selected provider supports it. |
+| `background` | `"transparent" \| "opaque" \| "auto"` | No | Background handling for Codex subscription images. Omission uses `auto`. |
 | `input` | `Array<{ path?: string; data?: string; mime_type?: string }>` | No | Input images by local path or inline base64 data. |
 | `provider` | `"auto" \| "openai" \| "openai-codex" \| "antigravity" \| "xai" \| "openrouter" \| "gemini"` | No | Per-request provider preference. A concrete value is tried first; `auto` or omission uses configured/session ordering. |
 
@@ -30,8 +31,8 @@ The custom tool is registered only when `generate_image.enabled=true` (default `
 - Success with image data:
   - `content[0].type = "text"`
   - `content[0].text` summarizes provider/model and saved image paths.
-  - `details = { provider, model, imageCount, imagePaths, images, responseText?, revisedPrompt?, promptFeedback?, usage? }`
-- Provider responses with no image data return `imageCount: 0`, empty `imagePaths` / `images`, and any provider text/feedback available.
+  - `details = { provider, model, imageCount, imagePaths, images, responseText?, revisedPrompt?, promptFeedback?, usage?, background?, outputFormat?, quality?, size? }`
+- Non-Codex provider responses with no image data retain their existing `imageCount: 0` result and any available response text or feedback.
 
 ## Flow
 1. The SDK injects `generate_image` as a custom tool via `getImageGenTools()` only when the feature gate and tool filter allow it.
@@ -41,18 +42,19 @@ The custom tool is registered only when `generate_image.enabled=true` (default `
 5. Provider-specific aspect-ratio support is checked after provider selection.
 6. Provider dispatch:
    - OpenAI: hosted Responses image-generation on an active compatible GPT Responses model.
-   - OpenAI Codex: hosted Responses image-generation on a compatible connected ChatGPT/Codex subscription model, even when the active chat model is from another provider.
+   - OpenAI Codex: standalone GPT Image 2 generations and edits through a connected ChatGPT/Codex subscription, even when the active chat model is from another provider.
    - Antigravity: Google Antigravity SSE endpoint.
    - OpenRouter: image-capable chat completion endpoint.
    - xAI: Grok Imagine generation or edit endpoint.
    - Gemini: Gemini `generateContent` with `responseModalities: ["IMAGE"]`.
-7. Inline images in a successful provider response are saved to temporary files; paths and base64/MIME image metadata are returned. A response with no image data returns a normal zero-image result rather than `isError`.
+7. Inline images in a successful provider response are saved to temporary files; paths and base64/MIME image metadata are returned. A successful Codex response without image data is an error; other provider responses with no image data retain their existing zero-image result.
 
 ## Modes / Variants
 - Text-to-image: provide `subject` and optional style/composition fields, no `input`.
 - Image edit: provide one or more `input` images plus `changes` and a subject that identifies each image role.
 - Text rendering: use `text`; the prompt instructs callers to request sharp, legible, correctly spelled short text.
 - Provider selection: set `provider` to prefer one backend for a request; fallback still follows the remaining configured/session/built-in order after credentialed HTTP failures.
+- Background selection: `background` is supported by the Codex subscription route. Other providers are skipped rather than silently dropping an explicit selection.
 
 ## Side Effects
 - Filesystem: reads local input images and writes generated output images to `omp-image-<snowflake>.<ext>` files under the OS temporary directory.
@@ -65,15 +67,19 @@ The custom tool is registered only when `generate_image.enabled=true` (default `
 - A path input must exist and have a supported content-sniffed image type. Each input object must contain `path` or `data`; `path` wins when both are present.
 - Raw base64 `data` requires `mime_type`; a data URL supplies its own MIME type.
 - Provider timeout is `3 * 60 * 1000` ms.
-- OpenAI hosted output is requested as WebP. Other response files use MIME-derived extensions (`png`, `jpg`, `gif`, or `webp`; unknown MIME types fall back to `.png`).
+- OpenAI hosted Responses output is requested as WebP. Codex subscription images use the standalone GPT Image 2 API and are saved according to their actual decoded MIME type (normally PNG).
 - Common aspect ratios are `1:1`, `3:4`, `4:3`, `9:16`, and `16:9`; only xAI also accepts `3:2` and `2:3`.
 - `image_size` accepts `1024x1024`, `1536x1024`, and `1024x1536`. On xAI these map to `1k`, `2k`, and `2k`; omission defaults to `1k`.
 - xAI edit requests accept at most 3 input images.
+- Codex subscription edits accept at most 5 input images.
 
 ## Errors
 - No usable provider credentials: `No image API credentials found...`; the message lists supported login/API-key routes.
 - Invalid input: file not found, file over 35 MiB, unsupported content-sniffed image type, missing `path`/`data`, empty image data, or raw base64 without `mime_type`.
 - OpenAI path without a compatible GPT model: `Missing active GPT model for OpenAI image generation`.
+- Codex subscription responses without image data: `Codex image request returned no image data.`
+- More than five Codex edit references: `Codex image edits accept at most 5 input images.`
+- Explicit `background` without Codex subscription credentials fails instead of falling back to a provider that would ignore it.
 - Antigravity credentials without `projectId`: `Missing projectId in antigravity credentials`.
 - More than three xAI edit references: `xAI image edits accept up to 3 reference images...`.
 - A `3:2` or `2:3` request fails if no usable xAI route is reached.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -222,6 +222,7 @@
 ### Added
 
 - Added `PERSONALITY.md` support: `~/.omp/agent/PERSONALITY.md` (profile/XDG-aware agent dir) replaces the system prompt's personality block text; `personality: none` still omits the block ([#8528](https://github.com/can1357/oh-my-pi/issues/8528))
+- `generate_image` now uses the standalone GPT Image 2 generations and edits endpoints for Codex subscriptions, with optional `transparent`, `opaque`, or `auto` background handling.
 - Sloppy edits now support inline replacements with `⟪old│new⟫` syntax (`⟪old│⟫` for deletions and `⟪│new⟫` for insertions), alongside automatic recovery for common formatting mistakes without needing a retry.
 - Sloppy edits now recover operations that mix `⟪old│new⟫` inline replacements with a `»` REWRITE instead of failing the payload: a redundant REWRITE is dropped, a diverging one is applied as the final text, and a note explains the interpretation.
 - Expanded archive support in `read` and `write` tools: `read` can now inspect and extract members from `.rar`, `.7z`, `.iso`, `.cab`, `.deb`, `.rpm`, `.cpio`, `.ar`/`.a`, `.lzh`, `.arj`, compressed tar files (`.tar.bz2`, `.tar.xz`, `.tar.zst`), package formats (`.whl`, `.ipa`, `.xpi`, `.vsix`, `.nupkg`, `.cbz`, `.cbr`), `.asar` archives, and single-file compressed streams; `write` can create `.tar.zst` and update `.asar` archives.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `generate_image` now uses the standalone GPT Image 2 generations and edits endpoints for Codex subscriptions, with optional `transparent`, `opaque`, or `auto` background handling.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added
@@ -222,7 +226,6 @@
 ### Added
 
 - Added `PERSONALITY.md` support: `~/.omp/agent/PERSONALITY.md` (profile/XDG-aware agent dir) replaces the system prompt's personality block text; `personality: none` still omits the block ([#8528](https://github.com/can1357/oh-my-pi/issues/8528))
-- `generate_image` now uses the standalone GPT Image 2 generations and edits endpoints for Codex subscriptions, with optional `transparent`, `opaque`, or `auto` background handling.
 - Sloppy edits now support inline replacements with `⟪old│new⟫` syntax (`⟪old│⟫` for deletions and `⟪│new⟫` for insertions), alongside automatic recovery for common formatting mistakes without needing a retry.
 - Sloppy edits now recover operations that mix `⟪old│new⟫` inline replacements with a `»` REWRITE instead of failing the payload: a redundant REWRITE is dropped, a diverging one is applied as the final text, and a note explains the interpretation.
 - Expanded archive support in `read` and `write` tools: `read` can now inspect and extract members from `.rar`, `.7z`, `.iso`, `.cab`, `.deb`, `.rpm`, `.cpio`, `.ar`/`.a`, `.lzh`, `.arj`, compressed tar files (`.tar.bz2`, `.tar.xz`, `.tar.zst`), package formats (`.whl`, `.ipa`, `.xpi`, `.vsix`, `.nupkg`, `.cbz`, `.cbr`), `.asar` archives, and single-file compressed streams; `write` can create `.tar.zst` and update `.asar` archives.

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -42,7 +42,6 @@ const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const CODEX_IMAGE_MODEL = "gpt-image-2";
 const CODEX_IMAGE_MAX_EDIT_IMAGES = 5;
 const CODEX_IMAGE_DEFAULT_MIME_TYPE = "image/png";
-const CODEX_IMAGE_TURN_ID_HEADER = "x-codex-image-turn-id";
 const OPENAI_IMAGE_OUTPUT_FORMAT = "webp";
 const OPENAI_IMAGE_MIME_TYPE = "image/webp";
 
@@ -177,6 +176,8 @@ interface OpenAIResponsesUsage {
 	input_tokens?: number;
 	output_tokens?: number;
 	total_tokens?: number;
+	input_tokens_details?: { image_tokens?: number; text_tokens?: number };
+	output_tokens_details?: { image_tokens?: number; text_tokens?: number };
 }
 
 type ImageUsageMetadata = GeminiUsageMetadata | OpenAIResponsesUsage;
@@ -255,6 +256,7 @@ interface OpenAIHostedImageResult {
 	responseText?: string;
 	revisedPrompt?: string;
 	usage?: OpenAIResponsesUsage;
+	model?: string;
 	background?: CodexImageBackground;
 	outputFormat?: CodexImageOutputFormat;
 	quality?: CodexImageQuality;
@@ -961,16 +963,10 @@ function buildOpenAIImageHeaders(model: Model, apiKey: string, sessionId: string
 	return headers;
 }
 
-function buildCodexImagesHeaders(
-	model: Model,
-	apiKey: string,
-	sessionId: string | undefined,
-	toolCallId: string,
-): Headers {
+function buildCodexImagesHeaders(model: Model, apiKey: string, sessionId: string | undefined): Headers {
 	const headers = buildOpenAIImageHeaders(model, apiKey, sessionId);
 	headers.delete(OPENAI_HEADERS.BETA);
 	headers.set(OPENAI_HEADERS.VERSION, CODEX_CLIENT_VERSION);
-	headers.set(CODEX_IMAGE_TURN_ID_HEADER, toolCallId);
 	return headers;
 }
 
@@ -1051,9 +1047,11 @@ async function generateCodexImage(
 	fetchImpl: FetchImpl,
 	signal: AbortSignal | undefined,
 	sessionId: string | undefined,
-	toolCallId: string,
 ): Promise<OpenAIHostedImageResult> {
 	const edit = inputImages.length > 0;
+	if (edit && inputImages.length > CODEX_IMAGE_MAX_EDIT_IMAGES) {
+		throw new Error(`Codex image edits accept at most ${CODEX_IMAGE_MAX_EDIT_IMAGES} input images.`);
+	}
 
 	const baseRequest: CodexImageGenerationRequest = {
 		prompt: assemblePrompt(params),
@@ -1070,7 +1068,7 @@ async function generateCodexImage(
 		: baseRequest;
 	const response = await fetchImpl(getCodexImagesUrl(model, edit), {
 		method: "POST",
-		headers: buildCodexImagesHeaders(model, apiKey, sessionId, toolCallId),
+		headers: buildCodexImagesHeaders(model, apiKey, sessionId),
 		body: JSON.stringify(requestBody),
 		signal,
 	});
@@ -1105,6 +1103,7 @@ async function generateCodexImage(
 		outputFormat: data.output_format,
 		quality: data.quality,
 		size: data.size,
+		model: CODEX_IMAGE_MODEL,
 		usage: data.usage,
 	};
 }
@@ -1231,7 +1230,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 	approval: "write",
 	description: prompt.render(imageGenDescription),
 	parameters: imageGenSchema,
-	async execute(toolCallId, params, _onUpdate, ctx, signal) {
+	async execute(_toolCallId, params, _onUpdate, ctx, signal) {
 		return untilAborted(signal, async () => {
 			const sessionId = ctx.sessionManager.getSessionId();
 			const providerOrder = imageProviderOrder(ctx.model, params.provider);
@@ -1252,9 +1251,6 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 				if (params.background && provider !== "openai-codex") {
 					unsupportedBackgroundProvider ??= provider;
 					continue;
-				}
-				if (provider === "openai-codex" && (params.input?.length ?? 0) > CODEX_IMAGE_MAX_EDIT_IMAGES) {
-					throw new Error(`Codex image edits accept at most ${CODEX_IMAGE_MAX_EDIT_IMAGES} input images.`);
 				}
 				if (!resolvedImageCache) {
 					resolvedImageCache = [];
@@ -1294,8 +1290,12 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel, sessionId);
 						const parsed = await withAuth(
 							hostedKey,
-							key =>
-								provider === "openai-codex"
+							key => {
+								const useCodexImages = provider === "openai-codex" && getCodexAccountId(key) !== undefined;
+								if (params.background && !useCodexImages) {
+									throw new Error("Background selection requires a Codex subscription OAuth credential.");
+								}
+								return useCodexImages
 									? generateCodexImage(
 											key,
 											hostedModel,
@@ -1304,7 +1304,6 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 											fetchImpl,
 											requestSignal,
 											sessionId,
-											toolCallId,
 										)
 									: generateOpenAIHostedImage(
 											key,
@@ -1314,10 +1313,11 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 											fetchImpl,
 											requestSignal,
 											sessionId,
-										),
+										);
+							},
 							{ signal: requestSignal },
 						);
-						const imageModel = provider === "openai-codex" ? CODEX_IMAGE_MODEL : model;
+						const imageModel = parsed.model ?? model;
 
 						if (parsed.images.length === 0) {
 							const messageText = parsed.responseText ? `\n\n${parsed.responseText}` : "";

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -6,6 +6,7 @@ import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
 import {
 	applyCodexResidencyHeader,
 	CODEX_BASE_URL,
+	CODEX_CLIENT_VERSION,
 	getCodexAccountId,
 	OPENAI_HEADER_VALUES,
 	OPENAI_HEADERS,
@@ -38,6 +39,10 @@ const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image";
 const IMAGE_TIMEOUT = 3 * 60 * 1000; // 3 minutes
 const MAX_IMAGE_SIZE = 35 * 1024 * 1024;
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+const CODEX_IMAGE_MODEL = "gpt-image-2";
+const CODEX_IMAGE_MAX_EDIT_IMAGES = 5;
+const CODEX_IMAGE_DEFAULT_MIME_TYPE = "image/png";
+const CODEX_IMAGE_TURN_ID_HEADER = "x-codex-image-turn-id";
 const OPENAI_IMAGE_OUTPUT_FORMAT = "webp";
 const OPENAI_IMAGE_MIME_TYPE = "image/webp";
 
@@ -88,6 +93,9 @@ export const imageGenSchema = type({
 	"changes?": type("string[]").describe("edits to make"),
 	"aspect_ratio?": aspectRatioSchema,
 	"image_size?": imageSizeSchema,
+	"background?": type
+		.enumerated("transparent", "opaque", "auto")
+		.describe("background handling for Codex subscription image generation"),
 	"input?": inputImageSchema.array().describe("input images"),
 	"provider?": imageProviderSchema,
 });
@@ -247,6 +255,39 @@ interface OpenAIHostedImageResult {
 	responseText?: string;
 	revisedPrompt?: string;
 	usage?: OpenAIResponsesUsage;
+	background?: CodexImageBackground;
+	outputFormat?: CodexImageOutputFormat;
+	quality?: CodexImageQuality;
+	size?: string;
+}
+
+type CodexImageBackground = NonNullable<ImageGenParams["background"]>;
+type CodexImageQuality = "low" | "medium" | "high" | "auto";
+type CodexImageOutputFormat = "png" | "jpeg" | "webp";
+
+interface CodexImageUrl {
+	image_url: string;
+}
+
+interface CodexImageGenerationRequest {
+	prompt: string;
+	background: CodexImageBackground;
+	model: typeof CODEX_IMAGE_MODEL;
+	quality: "auto";
+	size: string;
+}
+
+interface CodexImageEditRequest extends CodexImageGenerationRequest {
+	images: CodexImageUrl[];
+}
+
+interface CodexImageResponse {
+	background?: CodexImageBackground;
+	data?: Array<{ b64_json?: string }>;
+	output_format?: CodexImageOutputFormat;
+	quality?: CodexImageQuality;
+	size?: string;
+	usage?: OpenAIResponsesUsage;
 }
 
 interface OpenRouterImageUrl {
@@ -345,6 +386,10 @@ interface ImageGenToolDetails {
 	promptFeedback?: GeminiPromptFeedback;
 	revisedPrompt?: string;
 	usage?: ImageUsageMetadata;
+	background?: CodexImageBackground;
+	outputFormat?: CodexImageOutputFormat;
+	quality?: CodexImageQuality;
+	size?: string;
 }
 
 interface ImageInput {
@@ -817,9 +862,9 @@ function buildOpenAIHostedImageRequest(
 	};
 }
 
-function createOpenAIInlineImage(data: string): InlineImageData {
+function createOpenAIInlineImage(data: string, fallbackMimeType = OPENAI_IMAGE_MIME_TYPE): InlineImageData {
 	const bytes = Buffer.from(data, "base64");
-	const mimeType = parseImageMetadata(bytes)?.mimeType ?? OPENAI_IMAGE_MIME_TYPE;
+	const mimeType = parseImageMetadata(bytes)?.mimeType ?? fallbackMimeType;
 	return { data, mimeType };
 }
 
@@ -885,6 +930,12 @@ function getOpenAIResponsesUrl(model: Model): string {
 		.replace(URL_PATHS.RESPONSES, URL_PATHS.CODEX_RESPONSES);
 }
 
+function getCodexImagesUrl(model: Model, edit: boolean): string {
+	const url = new URL(getOpenAIResponsesUrl(model));
+	url.pathname = url.pathname.replace(/\/responses$/, edit ? "/images/edits" : "/images/generations");
+	return url.toString();
+}
+
 function buildOpenAIImageHeaders(model: Model, apiKey: string, sessionId: string | undefined): Headers {
 	const headers = new Headers(model.headers ?? {});
 	headers.set("Content-Type", "application/json");
@@ -907,6 +958,19 @@ function buildOpenAIImageHeaders(model: Model, apiKey: string, sessionId: string
 		}
 	}
 
+	return headers;
+}
+
+function buildCodexImagesHeaders(
+	model: Model,
+	apiKey: string,
+	sessionId: string | undefined,
+	toolCallId: string,
+): Headers {
+	const headers = buildOpenAIImageHeaders(model, apiKey, sessionId);
+	headers.delete(OPENAI_HEADERS.BETA);
+	headers.set(OPENAI_HEADERS.VERSION, CODEX_CLIENT_VERSION);
+	headers.set(CODEX_IMAGE_TURN_ID_HEADER, toolCallId);
 	return headers;
 }
 
@@ -977,6 +1041,72 @@ async function generateOpenAIHostedImage(
 
 	const data = (await response.json()) as OpenAIHostedImageResponse;
 	return collectOpenAIHostedImageResult(data);
+}
+
+async function generateCodexImage(
+	apiKey: string,
+	model: Model,
+	params: ImageGenParams,
+	inputImages: InlineImageData[],
+	fetchImpl: FetchImpl,
+	signal: AbortSignal | undefined,
+	sessionId: string | undefined,
+	toolCallId: string,
+): Promise<OpenAIHostedImageResult> {
+	const edit = inputImages.length > 0;
+
+	const baseRequest: CodexImageGenerationRequest = {
+		prompt: assemblePrompt(params),
+		background: params.background ?? "auto",
+		model: CODEX_IMAGE_MODEL,
+		quality: "auto",
+		size: resolveOpenAIImageSize(params.aspect_ratio, params.image_size) ?? "auto",
+	};
+	const requestBody: CodexImageGenerationRequest | CodexImageEditRequest = edit
+		? {
+				...baseRequest,
+				images: inputImages.map(image => ({ image_url: toDataUrl(image) })),
+			}
+		: baseRequest;
+	const response = await fetchImpl(getCodexImagesUrl(model, edit), {
+		method: "POST",
+		headers: buildCodexImagesHeaders(model, apiKey, sessionId, toolCallId),
+		body: JSON.stringify(requestBody),
+		signal,
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new ProviderHttpError(
+			`Codex image request failed (${response.status}): ${getOpenAIResponseErrorMessage(errorText)}`,
+			response.status,
+			{ headers: response.headers },
+		);
+	}
+
+	const data = (await response.json()) as CodexImageResponse;
+	const fallbackMimeType =
+		data.output_format === "webp"
+			? "image/webp"
+			: data.output_format === "jpeg"
+				? "image/jpeg"
+				: CODEX_IMAGE_DEFAULT_MIME_TYPE;
+	const images = (data.data ?? [])
+		.map(image => image.b64_json)
+		.filter((image): image is string => Boolean(image))
+		.map(image => createOpenAIInlineImage(image, fallbackMimeType));
+	if (images.length === 0) {
+		throw new Error("Codex image request returned no image data.");
+	}
+
+	return {
+		images,
+		background: data.background,
+		outputFormat: data.output_format,
+		quality: data.quality,
+		size: data.size,
+		usage: data.usage,
+	};
 }
 
 function combineParts(response: GeminiGenerateContentResponse): GeminiPart[] {
@@ -1101,7 +1231,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 	approval: "write",
 	description: prompt.render(imageGenDescription),
 	parameters: imageGenSchema,
-	async execute(_toolCallId, params, _onUpdate, ctx, signal) {
+	async execute(toolCallId, params, _onUpdate, ctx, signal) {
 		return untilAborted(signal, async () => {
 			const sessionId = ctx.sessionManager.getSessionId();
 			const providerOrder = imageProviderOrder(ctx.model, params.provider);
@@ -1110,6 +1240,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 			const fetchImpl = ctx.fetch ?? fetch;
 			const failures: Array<{ provider: ImageProvider; error: ProviderHttpError }> = [];
 			let unsupportedAspectRatioProvider: ImageProvider | undefined;
+			let unsupportedBackgroundProvider: ImageProvider | undefined;
 			let foundCredentials = false;
 			let resolvedImageCache: InlineImageData[] | undefined;
 
@@ -1117,6 +1248,14 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 				const apiKey = await findImageApiKey(preferredProvider, ctx.modelRegistry, ctx.model, sessionId);
 				if (!apiKey) continue;
 				foundCredentials = true;
+				const provider = apiKey.provider;
+				if (params.background && provider !== "openai-codex") {
+					unsupportedBackgroundProvider ??= provider;
+					continue;
+				}
+				if (provider === "openai-codex" && (params.input?.length ?? 0) > CODEX_IMAGE_MAX_EDIT_IMAGES) {
+					throw new Error(`Codex image edits accept at most ${CODEX_IMAGE_MAX_EDIT_IMAGES} input images.`);
+				}
 				if (!resolvedImageCache) {
 					resolvedImageCache = [];
 					if (params.input?.length) {
@@ -1126,8 +1265,6 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					}
 				}
 				const resolvedImages = resolvedImageCache;
-
-				const provider = apiKey.provider;
 				try {
 					const model =
 						provider === "openai" || provider === "openai-codex"
@@ -1155,21 +1292,32 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 						const hostedModel = apiKey.model;
 						const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel, sessionId);
-
 						const parsed = await withAuth(
 							hostedKey,
 							key =>
-								generateOpenAIHostedImage(
-									key,
-									hostedModel,
-									params,
-									resolvedImages,
-									fetchImpl,
-									requestSignal,
-									sessionId,
-								),
+								provider === "openai-codex"
+									? generateCodexImage(
+											key,
+											hostedModel,
+											params,
+											resolvedImages,
+											fetchImpl,
+											requestSignal,
+											sessionId,
+											toolCallId,
+										)
+									: generateOpenAIHostedImage(
+											key,
+											hostedModel,
+											params,
+											resolvedImages,
+											fetchImpl,
+											requestSignal,
+											sessionId,
+										),
 							{ signal: requestSignal },
 						);
+						const imageModel = provider === "openai-codex" ? CODEX_IMAGE_MODEL : model;
 
 						if (parsed.images.length === 0) {
 							const messageText = parsed.responseText ? `\n\n${parsed.responseText}` : "";
@@ -1177,13 +1325,17 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								content: [{ type: "text", text: `No image data returned.${messageText}` }],
 								details: {
 									provider,
-									model,
+									model: imageModel,
 									imageCount: 0,
 									imagePaths: [],
 									images: [],
 									responseText: parsed.responseText,
 									revisedPrompt: parsed.revisedPrompt,
 									usage: parsed.usage,
+									background: parsed.background,
+									outputFormat: parsed.outputFormat,
+									quality: parsed.quality,
+									size: parsed.size,
 								},
 							};
 						}
@@ -1192,17 +1344,24 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 						return {
 							content: [
-								{ type: "text", text: buildResponseSummary(provider, model, imagePaths, parsed.responseText) },
+								{
+									type: "text",
+									text: buildResponseSummary(provider, imageModel, imagePaths, parsed.responseText),
+								},
 							],
 							details: {
 								provider,
-								model,
+								model: imageModel,
 								imageCount: parsed.images.length,
 								imagePaths,
 								images: parsed.images,
 								responseText: parsed.responseText,
 								revisedPrompt: parsed.revisedPrompt,
 								usage: parsed.usage,
+								background: parsed.background,
+								outputFormat: parsed.outputFormat,
+								quality: parsed.quality,
+								size: parsed.size,
 							},
 						};
 					}
@@ -1660,6 +1819,12 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 			if (!foundCredentials) {
 				throw new Error(
 					"No image API credentials found. Connect a Codex (ChatGPT) subscription, use a GPT Responses/Codex model with OpenAI credentials, log in with google-antigravity or xAI Grok OAuth, or set OPENAI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
+				);
+			}
+
+			if (failures.length === 0 && unsupportedBackgroundProvider) {
+				throw new Error(
+					"Background selection is only supported by Codex subscription image generation. Set provider to openai-codex.",
 				);
 			}
 

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -281,24 +281,35 @@ describe("imageGenTool", () => {
 
 	it("routes Codex subscription generations and edits through the Images API", async () => {
 		setImageProviderOrder(["openai-codex"]);
+		const pngBytes = Buffer.from(
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+			"base64",
+		);
+		const webpBytes = Buffer.from(await new Bun.Image(pngBytes).webp({ quality: 90 }).bytes());
+		const jpegBytes = Buffer.from(await new Bun.Image(pngBytes).jpeg({ quality: 90 }).bytes());
+		const responseImages = [pngBytes, webpBytes, jpegBytes];
+		const declaredFormats = ["jpeg", "png", "webp"] as const;
 		const requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
 		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
 			const url = input.toString();
-			const isEdit = url.endsWith("/images/edits");
-			requests.push({
-				url,
-				headers: new Headers(init?.headers),
-				body: JSON.parse(String(init?.body)) as Record<string, unknown>,
-			});
+			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			const responseIndex = requests.length;
+			requests.push({ url, headers: new Headers(init?.headers), body });
 			return new Response(
 				JSON.stringify({
 					created: 1,
-					background: isEdit ? "transparent" : "auto",
-					data: [{ b64_json: Buffer.from(isEdit ? "edited-png" : "generated-png").toString("base64") }],
-					output_format: "png",
+					background: body.background,
+					data: [{ b64_json: responseImages[responseIndex]?.toString("base64") }],
+					output_format: declaredFormats[responseIndex],
 					quality: "medium",
-					size: isEdit ? "1254x1254" : "1024x1024",
-					usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+					size: url.endsWith("/images/edits") ? "1254x1254" : "1024x1024",
+					usage: {
+						input_tokens: 3,
+						input_tokens_details: { image_tokens: 2, text_tokens: 1 },
+						output_tokens: 4,
+						output_tokens_details: { image_tokens: 4, text_tokens: 0 },
+						total_tokens: 7,
+					},
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
 			);
@@ -316,17 +327,27 @@ describe("imageGenTool", () => {
 			{
 				subject: "make the reference cyan",
 				background: "transparent",
-				input: [{ data: Buffer.from("reference").toString("base64"), mime_type: "image/png" }],
+				input: [{ data: pngBytes.toString("base64"), mime_type: "image/png" }],
 			},
 			undefined,
 			ctx,
 		);
-		generatedImagePaths.push(...(generated.details?.imagePaths ?? []), ...(edited.details?.imagePaths ?? []));
+		const opaque = await imageGenTool.execute(
+			"call-codex-opaque",
+			{ subject: "an opaque icon", background: "opaque" },
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(
+			...(generated.details?.imagePaths ?? []),
+			...(edited.details?.imagePaths ?? []),
+			...(opaque.details?.imagePaths ?? []),
+		);
 
-		expect(requests).toHaveLength(2);
+		expect(requests).toHaveLength(3);
 		expect(requests[0]?.url).toBe("https://chatgpt.com/backend-api/codex/images/generations");
 		expect(requests[0]?.headers.get("chatgpt-account-id")).toBe("acct-codex-1");
-		expect(requests[0]?.headers.get("x-codex-image-turn-id")).toBe("call-codex-generate");
+		expect(requests[0]?.headers.has("x-codex-image-turn-id")).toBe(false);
 		expect(requests[0]?.body).toMatchObject({
 			model: "gpt-image-2",
 			prompt: "a neon skyline.",
@@ -337,24 +358,33 @@ describe("imageGenTool", () => {
 
 		expect(requests[1]?.url).toBe("https://chatgpt.com/backend-api/codex/images/edits");
 		expect(requests[1]?.headers.get("chatgpt-account-id")).toBe("acct-codex-1");
-		expect(requests[1]?.headers.get("x-codex-image-turn-id")).toBe("call-codex-edit");
+		expect(requests[1]?.headers.has("x-codex-image-turn-id")).toBe(false);
 		expect(requests[1]?.body).toMatchObject({
 			model: "gpt-image-2",
 			prompt: "make the reference cyan.",
 			background: "transparent",
 			quality: "auto",
 			size: "auto",
-			images: [{ image_url: `data:image/png;base64,${Buffer.from("reference").toString("base64")}` }],
+			images: [{ image_url: `data:image/png;base64,${pngBytes.toString("base64")}` }],
 		});
+		expect(requests[2]?.body).toMatchObject({ background: "opaque" });
 
+		const expectedUsage = {
+			input_tokens: 3,
+			input_tokens_details: { image_tokens: 2, text_tokens: 1 },
+			output_tokens: 4,
+			output_tokens_details: { image_tokens: 4, text_tokens: 0 },
+			total_tokens: 7,
+		};
 		expect(generated.details).toMatchObject({
 			provider: "openai-codex",
 			model: "gpt-image-2",
 			background: "auto",
 			quality: "medium",
 			size: "1024x1024",
-			outputFormat: "png",
+			outputFormat: "jpeg",
 			imageCount: 1,
+			usage: expectedUsage,
 		});
 		expect(edited.details).toMatchObject({
 			provider: "openai-codex",
@@ -364,14 +394,27 @@ describe("imageGenTool", () => {
 			size: "1254x1254",
 			outputFormat: "png",
 			imageCount: 1,
+			usage: expectedUsage,
 		});
+		expect(opaque.details).toMatchObject({
+			provider: "openai-codex",
+			model: "gpt-image-2",
+			background: "opaque",
+			outputFormat: "webp",
+			imageCount: 1,
+			usage: expectedUsage,
+		});
+
 		const generatedPath = generated.details?.imagePaths[0];
 		const editedPath = edited.details?.imagePaths[0];
-		if (!generatedPath || !editedPath) throw new Error("Expected generated image paths");
+		const opaquePath = opaque.details?.imagePaths[0];
+		if (!generatedPath || !editedPath || !opaquePath) throw new Error("Expected generated image paths");
 		expect(generatedPath.endsWith(".png")).toBe(true);
-		expect(editedPath.endsWith(".png")).toBe(true);
-		expect(await Bun.file(generatedPath).bytes()).toEqual(Buffer.from("generated-png"));
-		expect(await Bun.file(editedPath).bytes()).toEqual(Buffer.from("edited-png"));
+		expect(editedPath.endsWith(".webp")).toBe(true);
+		expect(opaquePath.endsWith(".jpg")).toBe(true);
+		expect(await Bun.file(generatedPath).bytes()).toEqual(pngBytes);
+		expect(await Bun.file(editedPath).bytes()).toEqual(webpBytes);
+		expect(await Bun.file(opaquePath).bytes()).toEqual(jpegBytes);
 	});
 
 	it("rejects Codex subscription edits with more than five input images", async () => {
@@ -542,20 +585,32 @@ describe("imageGenTool", () => {
 	it("sends Codex hosted image requests with opaque proxy bearer keys", async () => {
 		let requestUrl: string | undefined;
 		let requestHeaders: Headers | undefined;
+		const requestBodies: Array<Record<string, unknown>> = [];
 
 		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
 			requestUrl = input.toString();
 			requestHeaders = new Headers(init?.headers);
+			requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
 			return new Response(
-				JSON.stringify({
-					created: 1,
-					background: "auto",
-					data: [{ b64_json: Buffer.from("fake-codex-png").toString("base64") }],
-					output_format: "png",
-					quality: "medium",
-					size: "auto",
-				}),
-				{ status: 200, headers: { "content-type": "application/json" } },
+				[
+					"event: response.output_item.done",
+					`data: ${JSON.stringify({
+						type: "response.output_item.done",
+						item: {
+							type: "image_generation_call",
+							result: Buffer.from("fake-codex-webp").toString("base64"),
+							status: "completed",
+						},
+					})}`,
+					"",
+					"event: response.completed",
+					`data: ${JSON.stringify({
+						type: "response.completed",
+						response: { output: [], status: "completed", error: null },
+					})}`,
+					"",
+				].join("\n"),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
 			);
 		}) as unknown as typeof fetch;
 
@@ -585,18 +640,35 @@ describe("imageGenTool", () => {
 		};
 
 		const result = await imageGenTool.execute("call-codex-opaque", { subject: "a cat" }, undefined, ctx);
-		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+		const manyInputResult = await imageGenTool.execute(
+			"call-codex-opaque-edit",
+			{
+				subject: "combine the references",
+				input: Array.from({ length: 6 }, (_, index) => ({
+					data: Buffer.from(`reference-${index}`).toString("base64"),
+					mime_type: "image/png",
+				})),
+			},
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []), ...(manyInputResult.details?.imagePaths ?? []));
 
-		expect(requestUrl).toBe("https://example-proxy.invalid/backend-api/codex/images/generations");
+		expect(requestUrl).toBe("https://example-proxy.invalid/backend-api/codex/responses");
 		expect(requestHeaders?.get("authorization")).toBe("Bearer opaque-proxy-key");
 		expect(requestHeaders?.has("chatgpt-account-id")).toBe(false);
 		expect(requestHeaders?.has("x-openai-internal-codex-residency")).toBe(false);
-		expect(requestHeaders?.has("OpenAI-Beta")).toBe(false);
+		expect(requestHeaders?.get("OpenAI-Beta")).toBe("responses=experimental");
 		expect(requestHeaders?.get("originator")).toBe("pi");
-		expect(requestHeaders?.get("x-codex-image-turn-id")).toBe("call-codex-opaque");
+		expect(requestHeaders?.has("x-codex-image-turn-id")).toBe(false);
+		const secondInput = requestBodies[1]?.input as Array<{ content?: Array<Record<string, unknown>> }> | undefined;
+		const secondContent = secondInput?.[0]?.content ?? [];
+		expect(secondContent.filter(part => part.type === "input_image")).toHaveLength(6);
 		expect(result.details?.provider).toBe("openai-codex");
-		expect(result.details?.model).toBe("gpt-image-2");
+		expect(result.details?.model).toBe("gpt-5.5-codex");
 		expect(result.details?.imageCount).toBe(1);
+		expect(manyInputResult.details?.model).toBe("gpt-5.5-codex");
+		expect(manyInputResult.details?.imageCount).toBe(1);
 	});
 
 	it("adds Codex account and residency headers from bearer token claims", async () => {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -58,6 +58,47 @@ function createAntigravityXAIContext(model: Model | undefined, fetchMock: typeof
 	};
 }
 
+function createCodexSubscriptionContext(fetchMock: typeof fetch): CustomToolContext {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-codex-1" } }),
+	).toString("base64");
+	const codexToken = `header.${payload}.signature`;
+	const codexModel = {
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		id: "gpt-5.5",
+		name: "GPT-5.5",
+		baseUrl: "https://chatgpt.com/backend-api",
+	} as Model;
+	const activeModel = {
+		api: "anthropic-messages",
+		provider: "anthropic",
+		id: "claude-opus-4",
+		name: "Claude",
+	} as Model;
+
+	return {
+		fetch: fetchMock,
+		sessionManager: {
+			getCwd: () => "/tmp",
+			getSessionId: () => "test-session",
+		} as unknown as ReadonlySessionManager,
+		modelRegistry: {
+			find: (provider: string, id: string) =>
+				provider === "openai-codex" && id === "gpt-5.5" ? codexModel : undefined,
+			getAll: () => [codexModel],
+			getApiKey: async () => codexToken,
+			getApiKeyForProvider: async (provider: string) => (provider === "openai-codex" ? codexToken : undefined),
+			authStorage: { rotateSessionCredential: async () => false },
+			resolver: () => async () => codexToken,
+		} as unknown as ModelRegistry,
+		model: activeModel,
+		isIdle: () => true,
+		hasQueuedMessages: () => false,
+		abort: () => {},
+	};
+}
+
 describe("imageGenTool", () => {
 	it("registers without resolving image provider credentials", async () => {
 		const modelRegistry = {
@@ -238,98 +279,158 @@ describe("imageGenTool", () => {
 		expect(result.details?.imageCount).toBe(1);
 	});
 
-	it("routes image generation through a connected Codex (ChatGPT) subscription when the active model is not OpenAI", async () => {
+	it("routes Codex subscription generations and edits through the Images API", async () => {
 		setImageProviderOrder(["openai-codex"]);
-		let requestUrl: string | undefined;
-		let accountHeader: string | null | undefined;
-		let requestBody: Record<string, unknown> | undefined;
-
-		// A fake Codex JWT (header.payload.signature) so getCodexAccountId can read
-		// chatgpt_account_id from the base64 payload claim.
-		const payload = Buffer.from(
-			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-codex-1" } }),
-		).toString("base64");
-		const codexToken = `header.${payload}.signature`;
-
-		const sse = `data: ${JSON.stringify({
-			type: "response.completed",
-			response: {
-				output: [
-					{
-						type: "image_generation_call",
-						result: Buffer.from("codex-webp").toString("base64"),
-						revised_prompt: "A neon skyline.",
-						status: "completed",
-					},
-				],
-				usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
-			},
-		})}\n\n`;
-
+		const requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
 		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-			requestUrl = input.toString();
-			accountHeader = new Headers(init?.headers).get("chatgpt-account-id");
-			requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
-			return new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
+			const url = input.toString();
+			const isEdit = url.endsWith("/images/edits");
+			requests.push({
+				url,
+				headers: new Headers(init?.headers),
+				body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+			});
+			return new Response(
+				JSON.stringify({
+					created: 1,
+					background: isEdit ? "transparent" : "auto",
+					data: [{ b64_json: Buffer.from(isEdit ? "edited-png" : "generated-png").toString("base64") }],
+					output_format: "png",
+					quality: "medium",
+					size: isEdit ? "1254x1254" : "1024x1024",
+					usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
 		}) as unknown as typeof fetch;
+		const ctx = createCodexSubscriptionContext(fetchMock);
 
-		const codexModel = {
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			id: "gpt-5.5",
-			name: "GPT-5.5",
-			baseUrl: "https://chatgpt.com/backend-api",
-		} as Model;
-		// Active model is Claude — proves the codex subscription path is independent of it.
-		const activeModel = {
-			api: "anthropic-messages",
-			provider: "anthropic",
-			id: "claude-opus-4",
-			name: "Claude",
-		} as Model;
-
-		const ctx: CustomToolContext = {
-			fetch: fetchMock,
-			sessionManager: {
-				getCwd: () => "/tmp",
-				getSessionId: () => "test-session",
-			} as unknown as ReadonlySessionManager,
-			modelRegistry: {
-				find: (provider: string, id: string) =>
-					provider === "openai-codex" && id === "gpt-5.5" ? codexModel : undefined,
-				getAll: () => [codexModel],
-				getApiKey: async () => codexToken,
-				getApiKeyForProvider: async (provider: string) => (provider === "openai-codex" ? codexToken : undefined),
-				authStorage: { rotateSessionCredential: async () => false },
-				resolver: () => async () => codexToken,
-			} as unknown as ModelRegistry,
-			model: activeModel,
-			isIdle: () => true,
-			hasQueuedMessages: () => false,
-			abort: () => {},
-		};
-
-		const result = await imageGenTool.execute(
-			"call-codex",
+		const generated = await imageGenTool.execute(
+			"call-codex-generate",
 			{ subject: "a neon skyline", aspect_ratio: "1:1" },
 			undefined,
 			ctx,
 		);
-		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+		const edited = await imageGenTool.execute(
+			"call-codex-edit",
+			{
+				subject: "make the reference cyan",
+				background: "transparent",
+				input: [{ data: Buffer.from("reference").toString("base64"), mime_type: "image/png" }],
+			},
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(generated.details?.imagePaths ?? []), ...(edited.details?.imagePaths ?? []));
 
-		expect(requestUrl).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(accountHeader).toBe("acct-codex-1");
-		expect(requestBody).toMatchObject({
-			model: "gpt-5.5",
-			tools: [{ type: "image_generation", output_format: "webp", size: "1024x1024", action: "generate" }],
-			stream: true,
+		expect(requests).toHaveLength(2);
+		expect(requests[0]?.url).toBe("https://chatgpt.com/backend-api/codex/images/generations");
+		expect(requests[0]?.headers.get("chatgpt-account-id")).toBe("acct-codex-1");
+		expect(requests[0]?.headers.get("x-codex-image-turn-id")).toBe("call-codex-generate");
+		expect(requests[0]?.body).toMatchObject({
+			model: "gpt-image-2",
+			prompt: "a neon skyline.",
+			background: "auto",
+			quality: "auto",
+			size: "1024x1024",
 		});
-		expect(result.details?.provider).toBe("openai-codex");
-		expect(result.details?.model).toBe("gpt-5.5");
-		expect(result.details?.imageCount).toBe(1);
-		const savedPath = result.details?.imagePaths[0];
-		if (!savedPath) throw new Error("Expected generated image path");
-		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("codex-webp"));
+
+		expect(requests[1]?.url).toBe("https://chatgpt.com/backend-api/codex/images/edits");
+		expect(requests[1]?.headers.get("chatgpt-account-id")).toBe("acct-codex-1");
+		expect(requests[1]?.headers.get("x-codex-image-turn-id")).toBe("call-codex-edit");
+		expect(requests[1]?.body).toMatchObject({
+			model: "gpt-image-2",
+			prompt: "make the reference cyan.",
+			background: "transparent",
+			quality: "auto",
+			size: "auto",
+			images: [{ image_url: `data:image/png;base64,${Buffer.from("reference").toString("base64")}` }],
+		});
+
+		expect(generated.details).toMatchObject({
+			provider: "openai-codex",
+			model: "gpt-image-2",
+			background: "auto",
+			quality: "medium",
+			size: "1024x1024",
+			outputFormat: "png",
+			imageCount: 1,
+		});
+		expect(edited.details).toMatchObject({
+			provider: "openai-codex",
+			model: "gpt-image-2",
+			background: "transparent",
+			quality: "medium",
+			size: "1254x1254",
+			outputFormat: "png",
+			imageCount: 1,
+		});
+		const generatedPath = generated.details?.imagePaths[0];
+		const editedPath = edited.details?.imagePaths[0];
+		if (!generatedPath || !editedPath) throw new Error("Expected generated image paths");
+		expect(generatedPath.endsWith(".png")).toBe(true);
+		expect(editedPath.endsWith(".png")).toBe(true);
+		expect(await Bun.file(generatedPath).bytes()).toEqual(Buffer.from("generated-png"));
+		expect(await Bun.file(editedPath).bytes()).toEqual(Buffer.from("edited-png"));
+	});
+
+	it("rejects Codex subscription edits with more than five input images", async () => {
+		setImageProviderOrder(["openai-codex"]);
+		let requested = false;
+		const ctx = createCodexSubscriptionContext((async () => {
+			requested = true;
+			return new Response(null);
+		}) as unknown as typeof fetch);
+
+		await expect(
+			imageGenTool.execute(
+				"call-codex-too-many-inputs",
+				{
+					subject: "combine the references",
+					input: Array.from({ length: 6 }, (_, index) => ({
+						data: Buffer.from(`reference-${index}`).toString("base64"),
+						mime_type: "image/png",
+					})),
+				},
+				undefined,
+				ctx,
+			),
+		).rejects.toThrow("Codex image edits accept at most 5 input images");
+		expect(requested).toBe(false);
+	});
+
+	it("rejects successful Codex responses without image data", async () => {
+		setImageProviderOrder(["openai-codex"]);
+		const ctx = createCodexSubscriptionContext(
+			(async () =>
+				new Response(JSON.stringify({ created: 1, data: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				})) as unknown as typeof fetch,
+		);
+
+		await expect(imageGenTool.execute("call-codex-empty", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(
+			"Codex image request returned no image data",
+		);
+	});
+
+	it("does not silently drop background selection during provider fallback", async () => {
+		setImageProviderOrder(["antigravity", "xai"]);
+		let requested = false;
+		const ctx = createAntigravityXAIContext(undefined, (async () => {
+			requested = true;
+			return new Response(null);
+		}) as unknown as typeof fetch);
+
+		await expect(
+			imageGenTool.execute(
+				"call-background-unsupported",
+				{ subject: "a cat", background: "transparent" },
+				undefined,
+				ctx,
+			),
+		).rejects.toThrow("Background selection is only supported by Codex subscription image generation");
+		expect(requested).toBe(false);
 	});
 
 	it("falls back when an openai-codex API key lacks a subscription account claim", async () => {
@@ -446,25 +547,15 @@ describe("imageGenTool", () => {
 			requestUrl = input.toString();
 			requestHeaders = new Headers(init?.headers);
 			return new Response(
-				[
-					"event: response.output_item.done",
-					`data: ${JSON.stringify({
-						type: "response.output_item.done",
-						item: {
-							type: "image_generation_call",
-							result: Buffer.from("fake-codex-webp").toString("base64"),
-							status: "completed",
-						},
-					})}`,
-					"",
-					"event: response.completed",
-					`data: ${JSON.stringify({
-						type: "response.completed",
-						response: { output: [], status: "completed", error: null },
-					})}`,
-					"",
-				].join("\n"),
-				{ status: 200, headers: { "content-type": "text/event-stream" } },
+				JSON.stringify({
+					created: 1,
+					background: "auto",
+					data: [{ b64_json: Buffer.from("fake-codex-png").toString("base64") }],
+					output_format: "png",
+					quality: "medium",
+					size: "auto",
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
 			);
 		}) as unknown as typeof fetch;
 
@@ -496,13 +587,15 @@ describe("imageGenTool", () => {
 		const result = await imageGenTool.execute("call-codex-opaque", { subject: "a cat" }, undefined, ctx);
 		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
 
-		expect(requestUrl).toBe("https://example-proxy.invalid/backend-api/codex/responses");
+		expect(requestUrl).toBe("https://example-proxy.invalid/backend-api/codex/images/generations");
 		expect(requestHeaders?.get("authorization")).toBe("Bearer opaque-proxy-key");
 		expect(requestHeaders?.has("chatgpt-account-id")).toBe(false);
 		expect(requestHeaders?.has("x-openai-internal-codex-residency")).toBe(false);
-		expect(requestHeaders?.get("OpenAI-Beta")).toBe("responses=experimental");
+		expect(requestHeaders?.has("OpenAI-Beta")).toBe(false);
 		expect(requestHeaders?.get("originator")).toBe("pi");
+		expect(requestHeaders?.get("x-codex-image-turn-id")).toBe("call-codex-opaque");
 		expect(result.details?.provider).toBe("openai-codex");
+		expect(result.details?.model).toBe("gpt-image-2");
 		expect(result.details?.imageCount).toBe(1);
 	});
 
@@ -521,25 +614,15 @@ describe("imageGenTool", () => {
 		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
 			requestHeaders = new Headers(init?.headers);
 			return new Response(
-				[
-					"event: response.output_item.done",
-					`data: ${JSON.stringify({
-						type: "response.output_item.done",
-						item: {
-							type: "image_generation_call",
-							result: Buffer.from("fake-codex-jwt-webp").toString("base64"),
-							status: "completed",
-						},
-					})}`,
-					"",
-					"event: response.completed",
-					`data: ${JSON.stringify({
-						type: "response.completed",
-						response: { output: [], status: "completed", error: null },
-					})}`,
-					"",
-				].join("\n"),
-				{ status: 200, headers: { "content-type": "text/event-stream" } },
+				JSON.stringify({
+					created: 1,
+					background: "auto",
+					data: [{ b64_json: Buffer.from("fake-codex-jwt-png").toString("base64") }],
+					output_format: "png",
+					quality: "medium",
+					size: "auto",
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
 			);
 		}) as unknown as typeof fetch;
 


### PR DESCRIPTION
## What

- Route Codex subscription image generation through the standalone `codex/images/generations` endpoint used by the latest Codex CLI.
- Route reference-image edits through `codex/images/edits`, with a five-image limit matching Codex.
- Add optional `transparent`, `opaque`, and `auto` background handling for Codex subscription requests.
- Preserve returned background, format, quality, size, and usage metadata, and save images according to their decoded MIME type.
- Keep the existing hosted Responses path unchanged for API-key-backed OpenAI image generation.

## Why

OpenAI made transparent backgrounds available in preview for GPT Image 2 on August 20. This substantially reduces manual background-removal work for people creating sprites and other image assets for games and applications. Along with exposing the background option, this change replaces OMP's Codex subscription hosted-Responses path with the standalone Images endpoints used by current Codex.

코덱스 이미지 생성 API가 8월 20일 투명 배경 생성을 지원하면서, 게임이나 앱용 이미지 스프라이트를 제작할 때 생성 결과의 배경을 별도로 제거해야 했던 번거로움이 크게 줄었다. 이번 변경에서는 선택적 배경 옵션을 추가하고, OMP의 기존 Codex 구독 이미지 생성 경로를 최신 Codex CLI가 사용하는 standalone Images API 경로로 교체했다.

The previous hosted `image_generation` route returned HTTP 400 for transparent backgrounds, while the standalone Codex Images endpoint returned HTTP 200 with a transparent PNG under the same OAuth account.

## Testing

- `bun test test/tools/image-gen.test.ts` — 17 passed, 0 failed
- `bun run check` in `packages/coding-agent`
- `bun run check` at the repository root
- Live Codex OAuth generation through `codex/images/generations`: GPT Image 2 returned a transparent RGBA PNG
- Live Codex OAuth edit through `codex/images/edits`: GPT Image 2 returned `background: transparent`, `outputFormat: png`, and an RGBA PNG

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)