### PR TITLE
refactor(web-search): split Codex OAuth from OpenAI Responses search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Custom and API-key Codex web-search configurations must migrate to provider `openai` and configure `providers.webSearchOpenAIProvider` plus `providers.webSearchOpenAIModel`. Codex web search now uses official ChatGPT OAuth transport only.
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5264,6 +5264,28 @@ export const SETTINGS_SCHEMA = {
 			description: "Model ID for Gemini Google Search grounding. Defaults to gemini-2.5-flash.",
 		},
 	},
+	"providers.webSearchOpenAIProvider": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "OpenAI web_search provider",
+			description:
+				"Provider ID from models.yml; use with OpenAI web_search model to select a provider whose model uses api: openai-responses",
+		},
+	},
+	"providers.webSearchOpenAIModel": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "OpenAI web_search model",
+			description:
+				"Model ID from models.yml; use with OpenAI web_search provider to select a model whose API is openai-responses",
+		},
+	},
 	"providers.antigravityEndpoint": {
 		type: "enum",
 		values: ["auto", "production", "sandbox"] as const,

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -1,7 +1,7 @@
 /**
  * Unified Web Search Tool
  *
- * Single tool supporting Anthropic, Perplexity, Exa, Brave, Jina, Kimi, Gemini, Codex, Tavily, Kagi, Z.AI, SearXNG, and Synthetic
+ * Single tool supporting Anthropic, Perplexity, Exa, Brave, Jina, Kimi, Gemini, Codex, OpenAI API, Tavily, Kagi, Z.AI, SearXNG, and Synthetic
  * providers with provider-specific parameters exposed conditionally.
  */
 
@@ -170,6 +170,16 @@ async function executeSearch(
 		geminiModel = undefined;
 	}
 
+	let openaiProvider: string | undefined;
+	let openaiModel: string | undefined;
+	try {
+		openaiProvider = settings.get("providers.webSearchOpenAIProvider");
+		openaiModel = settings.get("providers.webSearchOpenAIModel");
+	} catch {
+		openaiProvider = undefined;
+		openaiModel = undefined;
+	}
+
 	let timeoutMs = DEFAULT_WEB_SEARCH_TIMEOUT_SECONDS * 1_000;
 	try {
 		const configuredSeconds = settings.get("providers.webSearchTimeoutSeconds");
@@ -218,6 +228,8 @@ async function executeSearch(
 				sessionId,
 				antigravityEndpointMode,
 				geminiModel,
+				openaiProvider,
+				openaiModel,
 			});
 
 			// Lenient constraint pass over whatever the provider returned: enforce

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -44,6 +44,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.codex,
 		load: async () => new (await import("./providers/codex")).CodexProvider(),
 	},
+	openai: {
+		id: "openai",
+		label: SEARCH_PROVIDER_LABELS.openai,
+		load: async () => new (await import("./providers/openai")).OpenAIProvider(),
+	},
 	xai: {
 		id: "xai",
 		label: SEARCH_PROVIDER_LABELS.xai,

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -74,6 +74,8 @@ export interface SearchParams {
 	sessionId?: string;
 	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	geminiModel?: string;
+	openaiProvider?: string;
+	openaiModel?: string;
 }
 
 /** Base class for web search providers. */

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -1,17 +1,9 @@
 /**
  * OpenAI Codex Web Search Provider
  *
- * Uses the configured Codex Responses transport for proxy/API-key setups and
- * the official ChatGPT backend for OAuth logins.
+ * Uses only the official ChatGPT Codex Responses endpoint with openai-codex OAuth.
  */
-import {
-	type AuthStorage,
-	type FetchImpl,
-	type Model,
-	type OAuthAccess,
-	withAuth,
-	withOAuthAccess,
-} from "@oh-my-pi/pi-ai";
+import { type AuthStorage, type FetchImpl, type Model, withOAuthAccess } from "@oh-my-pi/pi-ai";
 import { resolveCodexResponsesUrl } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import {
@@ -22,14 +14,19 @@ import {
 	OPENAI_HEADER_VALUES,
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
-import { $env, readSseJson, USER_AGENT } from "@oh-my-pi/pi-utils";
-import type { ModelRegistry } from "../../../config/model-registry";
-import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { $env, USER_AGENT } from "@oh-my-pi/pi-utils";
+import type { SearchResponse } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { formatQuery, GOOGLE_QUERY_SYNTAX, parseSearchQuery } from "../query";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
-import { classifyProviderHttpError, withHardTimeout } from "./utils";
+import {
+	callHostedResponsesSearch,
+	HostedResponsesNoWebSearchError,
+	type HostedResponsesResult,
+} from "./hosted-responses";
+
+const CODEX_RESPONSES_URL = resolveCodexResponsesUrl(CODEX_BASE_URL);
 
 const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
@@ -45,9 +42,6 @@ const DEFAULT_MODEL_PREFERENCES = [
 	"gpt-5.1-codex",
 	"gpt-5-codex-mini",
 ];
-const DEFAULT_INSTRUCTIONS =
-	"You are a helpful assistant with web search capabilities. Search the web to answer the user's question accurately and cite your sources.";
-
 type CodexSearchModel = Model<"openai-codex-responses">;
 
 interface CodexModelCandidate {
@@ -55,20 +49,7 @@ interface CodexModelCandidate {
 	catalogModel?: CodexSearchModel;
 }
 
-interface CodexSearchTransport {
-	baseUrl: string;
-	url: string;
-	headers: Record<string, string>;
-	customEndpoint: boolean;
-}
-
-interface CodexSearchResult {
-	answer: string;
-	sources: SearchSource[];
-	model: string;
-	requestId: string;
-	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
-}
+type CodexSearchResult = HostedResponsesResult;
 
 function getBundledCodexModels(): CodexSearchModel[] {
 	const models: CodexSearchModel[] = [];
@@ -109,28 +90,8 @@ function getDefaultModelCandidates(): CodexModelCandidate[] {
 	return fallbackModel ? [{ modelId: fallbackModel.id, catalogModel: fallbackModel }] : [{ modelId: FALLBACK_MODEL }];
 }
 
-/**
- * Raised when Codex produced an answer without invoking the hosted `web_search`
- * tool. GPT-5.6 Responses-Lite models receive `tool_choice: "auto"` (the forced
- * hosted choice is invalid under the lite shape — see #5771 / #5772), so the
- * model may skip searching and return a plain completion. A search command must
- * not present that as a successful, search-backed result (#6988); this advances
- * the candidate chain to a model that will search, or surfaces a clear failure
- * when the model was explicitly configured.
- */
-class CodexNoWebSearchError extends SearchProviderError {
-	constructor() {
-		super(
-			"codex",
-			"Codex returned a completion without running web search (no web_search_call event); refusing to treat a non-search answer as a search result",
-			502,
-		);
-		this.name = "CodexNoWebSearchError";
-	}
-}
-
 function shouldRetryWithNextDefaultModel(error: unknown): boolean {
-	if (error instanceof CodexNoWebSearchError) return true;
+	if (error instanceof HostedResponsesNoWebSearchError) return true;
 	if (!(error instanceof SearchProviderError)) return false;
 	if (error.provider !== "codex" || error.status !== 400) return false;
 	return /model is not supported|requested model is not supported|not supported when using codex with a chatgpt account/i.test(
@@ -149,294 +110,11 @@ export interface CodexSearchParams {
 	search_context_size?: "low" | "medium" | "high";
 }
 
-/** Codex API response structure */
-interface CodexWebSearchSource {
-	url?: string;
-	source_website_url?: string;
-	title?: string;
-	caption?: string;
-}
-
-interface CodexResponseItem {
-	type: string;
-	id?: string;
-	role?: string;
-	name?: string;
-	call_id?: string;
-	status?: string;
-	arguments?: string;
-	content?: CodexContentPart[];
-	summary?: Array<{ type: string; text: string }>;
-	action?: { sources?: CodexWebSearchSource[] };
-	sources?: CodexWebSearchSource[];
-	results?: CodexWebSearchSource[];
-}
-
-interface CodexContentPart {
-	type: string;
-	text?: string;
-	annotations?: CodexAnnotation[];
-}
-
-interface CodexAnnotation {
-	type: string;
-	url?: string;
-	title?: string;
-	start_index?: number;
-	end_index?: number;
-}
-
-interface CodexUsage {
-	input_tokens?: number;
-	output_tokens?: number;
-	total_tokens?: number;
-	input_tokens_details?: { cached_tokens?: number };
-}
-
-interface CodexResponse {
-	id?: string;
-	model?: string;
-	status?: string;
-	usage?: CodexUsage;
-}
-
-/**
- * Known Codex "image placeholder" answers — short prose the assistant emits in
- * place of a real answer when it produced a screenshot instead of text. These
- * carry no information, so callers treat them as non-answers and advance the
- * chain to a provider that returns text. Extend by adding the normalized
- * literal below; no regex tuning required.
- */
-const IMAGE_PLACEHOLDER_ANSWERS: ReadonlySet<string> = new Set([
-	"see attached image",
-	"attached image",
-	"see the attached image",
-	"see image",
-	"see image above",
-	"image above",
-	"see image below",
-	"image below",
-]);
-
-function isImagePlaceholderAnswer(text: string): boolean {
-	// Strip surrounding brackets/quotes and trailing punctuation, lowercase,
-	// then match against the known-placeholder set.
-	const normalized = text
-		.trim()
-		.replace(/^[[("'`*_]+/, "")
-		.replace(/[\])"'`*_.!?]+$/, "")
-		.trim()
-		.toLowerCase();
-	return IMAGE_PLACEHOLDER_ANSWERS.has(normalized);
-}
-
-function cleanSourceUrl(rawUrl: string): string {
-	try {
-		const url = new URL(rawUrl);
-		if (url.searchParams.get("utm_source") === "openai") {
-			url.searchParams.delete("utm_source");
-		}
-		return url.toString();
-	} catch {
-		return rawUrl.replace(/[?&]utm_source=openai$/u, "");
-	}
-}
-
-function addSource(sources: SearchSource[], source: SearchSource): void {
-	const normalizedSource = { ...source, url: cleanSourceUrl(source.url) };
-	const existing = sources.find(candidate => candidate.url === normalizedSource.url);
-	if (!existing) {
-		sources.push(normalizedSource);
-		return;
-	}
-	if (existing.title === existing.url && normalizedSource.title !== normalizedSource.url) {
-		existing.title = normalizedSource.title;
-	}
-	if (!existing.snippet && normalizedSource.snippet) {
-		existing.snippet = normalizedSource.snippet;
-	}
-}
-
-function extractCitationSnippet(text: string, start: number | undefined, end: number | undefined): string | undefined {
-	if (start === undefined || end === undefined || !text) return undefined;
-	const before = Math.max(0, start - 100);
-	const after = Math.min(text.length, end + 100);
-	const snippet = text
-		.slice(before, after)
-		.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
-		.trim();
-	if (!snippet) return undefined;
-	return snippet.length > 300 ? `${snippet.slice(0, 297)}...` : snippet;
-}
-
-function countCharacter(text: string, target: string): number {
-	let count = 0;
-	for (const char of text) {
-		if (char === target) {
-			count += 1;
-		}
-	}
-	return count;
-}
-
-/**
- * Strips prose punctuation and unmatched closing delimiters from extracted URLs.
- * Codex often returns links in markdown or sentence text without structured annotations.
- */
-function normalizeExtractedUrl(candidate: string): string | null {
-	let url = candidate.trim();
-
-	while (url.length > 0) {
-		const lastCharacter = url.at(-1);
-		if (!lastCharacter) break;
-		if (/[.,!?;:'"]/u.test(lastCharacter)) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		if (lastCharacter === ")" && countCharacter(url, ")") > countCharacter(url, "(")) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		if (lastCharacter === "]" && countCharacter(url, "]") > countCharacter(url, "[")) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		if (lastCharacter === "}" && countCharacter(url, "}") > countCharacter(url, "{")) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		break;
-	}
-
-	if (!/^https?:\/\//.test(url)) {
-		return null;
-	}
-
-	try {
-		return new URL(url).toString();
-	} catch {
-		return null;
-	}
-}
-
-function findMarkdownLinkUrlEnd(text: string, openParenIndex: number): number | null {
-	let depth = 0;
-
-	for (let index = openParenIndex; index < text.length; index += 1) {
-		const character = text[index];
-		if (!character || character === "\n") {
-			return null;
-		}
-		if (character === "(") {
-			depth += 1;
-			continue;
-		}
-		if (character !== ")") {
-			continue;
-		}
-		depth -= 1;
-		if (depth === 0) {
-			return index;
-		}
-		if (depth < 0) {
-			return null;
-		}
-	}
-
-	return null;
-}
-
-/**
- * Extracts citation sources from markdown links and bare URLs in the answer text.
- * Used as a fallback when the Codex response omits `url_citation` annotations.
- */
-function extractTextSources(text: string): SearchSource[] {
-	const sources: SearchSource[] = [];
-
-	for (let index = 0; index < text.length; index += 1) {
-		if (text[index] !== "[") {
-			continue;
-		}
-		const titleEnd = text.indexOf("]", index + 1);
-		if (titleEnd === -1 || text[titleEnd + 1] !== "(") {
-			continue;
-		}
-		const urlEnd = findMarkdownLinkUrlEnd(text, titleEnd + 1);
-		if (urlEnd === null) {
-			continue;
-		}
-		const title = text.slice(index + 1, titleEnd).trim();
-		const url = normalizeExtractedUrl(text.slice(titleEnd + 2, urlEnd));
-		if (url) {
-			addSource(sources, { title: title || url, url });
-		}
-		index = urlEnd;
-	}
-
-	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
-		const url = normalizeExtractedUrl(match[0] ?? "");
-		if (!url) continue;
-		addSource(sources, { title: url, url });
-	}
-
-	return sources;
-}
-
-/**
- * Resolve a Codex bearer + accountId through {@link AuthStorage} — the single
- * refresh authority. Returns `null` when no OAuth credential is configured,
- * when the credential cannot be refreshed (broker error, revoked token, etc.),
- * or when the access token carries no `chatgpt_account_id` claim.
- */
-async function findCodexAuth(
-	authStorage: AuthStorage,
-	sessionId: string | undefined,
-	signal: AbortSignal | undefined,
-): Promise<{ access: OAuthAccess; accountId: string } | null> {
-	const access = await authStorage.getOAuthAccess("openai-codex", sessionId, { signal });
-	if (!access) return null;
-	const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
-	if (!accountId) return null;
-	return { access, accountId };
-}
-
-function resolveCodexSearchTransport(modelRegistry: ModelRegistry | undefined, modelId: string): CodexSearchTransport {
-	const registryModel = modelRegistry?.find("openai-codex", modelId);
-	const bundledModel = getBundledCodexModels().find(model => model.id === modelId);
-	const providerBaseUrl = modelRegistry?.getProviderBaseUrl("openai-codex");
-	let baseUrl = providerBaseUrl ?? registryModel?.baseUrl ?? CODEX_BASE_URL;
-	if (registryModel?.baseUrl && registryModel.baseUrl !== (bundledModel?.baseUrl ?? CODEX_BASE_URL)) {
-		baseUrl = registryModel.baseUrl;
-	}
-
-	const url = resolveCodexResponsesUrl(baseUrl);
-	return {
-		baseUrl,
-		url,
-		headers: {
-			...(modelRegistry?.getProviderHeaders("openai-codex") ?? {}),
-			...(registryModel?.headers ?? {}),
-		},
-		customEndpoint: url !== resolveCodexResponsesUrl(CODEX_BASE_URL),
-	};
-}
-
-/**
- * Builds HTTP headers for Codex API requests.
- */
-function buildCodexHeaders(
-	accessToken: string,
-	accountId: string | undefined,
-	configuredHeaders: Record<string, string>,
-): Headers {
-	const headers = new Headers(configuredHeaders);
-	headers.delete("x-api-key");
+/** Build HTTP headers for the official ChatGPT Codex Responses endpoint. */
+function buildCodexHeaders(accessToken: string, accountId: string): Headers {
+	const headers = new Headers();
 	headers.set("Authorization", `Bearer ${accessToken}`);
-	if (accountId) {
-		headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
-	} else {
-		headers.delete(OPENAI_HEADERS.ACCOUNT_ID);
-	}
+	headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
 	applyCodexResidencyHeader(headers, accessToken);
 	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
 	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
@@ -447,253 +125,40 @@ function buildCodexHeaders(
 	return headers;
 }
 
-/**
- * Extracts a backend error `{code, message}` from a Codex SSE event, tolerating
- * the envelope shapes the ChatGPT Codex backend emits: top-level `{code,message}`,
- * a nested `error` object, and a `response.error` object (as in `response.failed`).
- * Without this the nested shapes collapse to `Codex error (): Unknown error`,
- * discarding the backend diagnostic — e.g. a regional/model-snapshot rejection (#7200).
- */
-function extractCodexSseError(rawEvent: Record<string, unknown>): { code: string; message: string } {
-	const candidates: unknown[] = [
-		rawEvent,
-		rawEvent.error,
-		(rawEvent.response as { error?: unknown } | undefined)?.error,
-	];
-	let code = "";
-	let message = "";
-	for (const candidate of candidates) {
-		if (!candidate || typeof candidate !== "object") continue;
-		const record = candidate as Record<string, unknown>;
-		if (!code && typeof record.code === "string" && record.code) code = record.code;
-		if (!message && typeof record.message === "string" && record.message) message = record.message;
-	}
-	return { code, message };
-}
-
-function classifyCodexSseErrorStatus(code: string, message: string): number {
-	const detail = `${code} ${message}`.toLowerCase();
-	if (/rate[- ]?limit|too many requests|quota|\b429\b/u.test(detail)) return 429;
-	if (/unauthori[sz]ed|\b401\b/u.test(detail)) return 401;
-	if (/forbidden|\b403\b/u.test(detail)) return 403;
-	if (/timeout|timed out/u.test(detail)) return 504;
-	return 500;
-}
-
-/**
- * Calls the Codex Responses API with web search tool enabled.
- * The caller provides the exact model id to send; retry / fallback policy
- * lives one layer up in `searchCodex()` so we can distinguish explicit user
- * overrides from the default ChatGPT-account model-selection path.
- */
+/** Call the official Codex Responses endpoint with shared Hosted Search logic. */
 async function callCodexSearch(
-	auth: { accessToken: string; accountId?: string },
+	auth: { accessToken: string; accountId: string },
 	query: string,
 	options: {
 		signal?: AbortSignal;
 		timeoutMs?: number;
-		systemPrompt?: string;
+		systemPrompt: string;
 		searchContextSize?: "low" | "medium" | "high";
 		model: CodexModelCandidate;
 		fetch?: FetchImpl;
-		transport: CodexSearchTransport;
 	},
 ): Promise<CodexSearchResult> {
-	const headers = buildCodexHeaders(auth.accessToken, auth.accountId, options.transport.headers);
-
-	const requestedModel = options.model.modelId;
-
-	const body: Record<string, unknown> = {
-		model: requestedModel,
-		stream: true,
-		store: false,
-		include: ["web_search_call.action.sources"],
-		parallel_tool_calls: true,
-		input: [
-			{
-				type: "message",
-				role: "user",
-				content: [{ type: "input_text", text: query }],
-			},
-		],
-		tools: [
-			{
-				type: "web_search",
-				search_context_size: options.searchContextSize ?? "high",
-			},
-		],
-		tool_choice: { type: "web_search" },
-		instructions: options.systemPrompt ?? DEFAULT_INSTRUCTIONS,
-	};
-
-	const fetchImpl = options.fetch ?? fetch;
-	const response = await fetchImpl(options.transport.url, {
-		method: "POST",
-		headers,
-		body: JSON.stringify(body),
-		signal: withHardTimeout(options.signal, options.timeoutMs),
+	return callHostedResponsesSearch({
+		provider: "codex",
+		displayName: "Codex",
+		url: CODEX_RESPONSES_URL,
+		model: options.model.modelId,
+		query,
+		instructions: options.systemPrompt,
+		searchContextSize: options.searchContextSize,
+		headers: buildCodexHeaders(auth.accessToken, auth.accountId),
+		signal: options.signal,
+		timeoutMs: options.timeoutMs,
+		fetch: options.fetch,
 	});
-
-	if (!response.ok) {
-		const errorText = await response.text();
-		const classified = classifyProviderHttpError("codex", response.status, errorText);
-		if (classified) throw classified;
-		throw new SearchProviderError("codex", `Codex API error (${response.status}): ${errorText}`, response.status);
-	}
-
-	if (!response.body) {
-		throw new SearchProviderError("codex", "Codex API returned no response body", 500);
-	}
-
-	// Parse SSE stream
-	const answerParts: string[] = [];
-	const streamedAnswerParts: string[] = [];
-	const sources: SearchSource[] = [];
-	let model = requestedModel;
-	let requestId = "";
-	let usage: { inputTokens: number; outputTokens: number; totalTokens: number } | undefined;
-	// A search command must reject a completion that did not invoke the hosted
-	// tool rather than returning an answer from the model's own knowledge (#6988).
-	let webSearchInvoked = false;
-
-	for await (const rawEvent of readSseJson<Record<string, unknown>>(response.body, options.signal)) {
-		const eventType = typeof rawEvent.type === "string" ? rawEvent.type : "";
-		if (!eventType) continue;
-
-		if (eventType.startsWith("response.web_search_call")) {
-			webSearchInvoked = true;
-		}
-
-		if (eventType === "response.created") {
-			const resp = (rawEvent as { response?: CodexResponse }).response;
-			if (resp?.id) requestId = resp.id;
-			if (resp?.model) model = resp.model;
-		} else if (eventType === "response.output_text.delta") {
-			const delta = typeof rawEvent.delta === "string" ? rawEvent.delta : "";
-			if (delta) {
-				streamedAnswerParts.push(delta);
-			}
-		} else if (eventType === "response.output_item.done") {
-			const item = rawEvent.item as CodexResponseItem | undefined;
-			if (!item) continue;
-			if (item.type === "web_search_call") {
-				webSearchInvoked = true;
-				const sourceGroups = [item.action?.sources, item.sources, item.results];
-				for (const group of sourceGroups) {
-					for (const source of group ?? []) {
-						const url = source.url ?? source.source_website_url;
-						if (!url) continue;
-						addSource(sources, {
-							title: source.title ?? source.caption ?? url,
-							url,
-						});
-					}
-				}
-			}
-
-			// Handle text message content and extract sources from annotations
-			if (item.type === "message" && item.content) {
-				for (const part of item.content) {
-					if (part.type === "output_text" && part.text) {
-						answerParts.push(part.text);
-
-						// Extract sources from url_citation annotations
-						if (part.annotations) {
-							for (const annotation of part.annotations) {
-								if (annotation.type === "url_citation" && annotation.url) {
-									addSource(sources, {
-										title: annotation.title ?? annotation.url,
-										url: annotation.url,
-										snippet: extractCitationSnippet(part.text, annotation.start_index, annotation.end_index),
-									});
-								}
-							}
-						}
-					}
-				}
-			}
-
-			// Handle reasoning summary as part of answer
-			if (item.type === "reasoning" && item.summary) {
-				for (const part of item.summary) {
-					if (part.type === "summary_text" && part.text) {
-						answerParts.push(part.text);
-					}
-				}
-			}
-		} else if (eventType === "response.completed" || eventType === "response.done") {
-			const resp = (rawEvent as { response?: CodexResponse }).response;
-			if (resp) {
-				if (resp.model) model = resp.model;
-				if (resp.id) requestId = resp.id;
-				if (resp.usage) {
-					const cachedTokens = resp.usage.input_tokens_details?.cached_tokens ?? 0;
-					usage = {
-						inputTokens: (resp.usage.input_tokens ?? 0) - cachedTokens,
-						outputTokens: resp.usage.output_tokens ?? 0,
-						totalTokens: resp.usage.total_tokens ?? 0,
-					};
-				}
-			}
-		} else if (eventType === "error") {
-			const { code, message } = extractCodexSseError(rawEvent);
-			throw new SearchProviderError(
-				"codex",
-				`Codex error (${code}): ${message || "Unknown error"}`,
-				classifyCodexSseErrorStatus(code, message),
-			);
-		} else if (eventType === "response.failed") {
-			const { code, message } = extractCodexSseError(rawEvent);
-			const detail = code
-				? `Codex request failed (${code}): ${message || "Request failed"}`
-				: `Codex request failed: ${message || "Request failed"}`;
-			throw new SearchProviderError("codex", detail, classifyCodexSseErrorStatus(code, message));
-		}
-	}
-
-	if (!webSearchInvoked) {
-		throw new CodexNoWebSearchError();
-	}
-
-	const finalAnswer = answerParts.join("\n\n").trim();
-	const streamedAnswer = streamedAnswerParts.join("").trim();
-	// Throw to advance the chain whenever Codex emitted nothing but image
-	// placeholder prose — including the case where the streamed delta itself
-	// is the placeholder (the model occasionally streams the same text it
-	// publishes as the final output_text).
-	const finalIsPlaceholder = finalAnswer.length > 0 && isImagePlaceholderAnswer(finalAnswer);
-	const streamedIsPlaceholder = streamedAnswer.length > 0 && isImagePlaceholderAnswer(streamedAnswer);
-	const hasFinalText = finalAnswer.length > 0 && !finalIsPlaceholder;
-	const hasStreamedText = streamedAnswer.length > 0 && !streamedIsPlaceholder;
-	if (!hasFinalText && !hasStreamedText && sources.length === 0) {
-		throw new SearchProviderError("codex", "Codex returned image-only response", 502);
-	}
-	const answer = hasFinalText ? finalAnswer : hasStreamedText ? streamedAnswer : "";
-
-	// Fallback: when Codex omits url_citation annotations, scrape markdown links
-	// and bare URLs from the synthesized answer so callers still receive sources.
-	if (sources.length === 0 && answer.length > 0) {
-		for (const source of extractTextSources(answer)) {
-			addSource(sources, source);
-		}
-	}
-
-	return {
-		answer,
-		sources,
-		model,
-		requestId,
-		usage,
-	};
 }
 
 async function runCodexSearchCandidates(options: {
-	auth: { accessToken: string; accountId?: string };
+	auth: { accessToken: string; accountId: string };
 	params: SearchParams;
 	query: string;
 	modelCandidates: CodexModelCandidate[];
 	modelWasConfigured: boolean;
-	transport: CodexSearchTransport;
 }): Promise<CodexSearchResult> {
 	let lastError: unknown;
 	for (let index = 0; index < options.modelCandidates.length; index += 1) {
@@ -708,7 +173,6 @@ async function runCodexSearchCandidates(options: {
 				searchContextSize: "high",
 				model: candidate,
 				fetch: options.params.fetch,
-				transport: options.transport,
 			});
 		} catch (error) {
 			lastError = error;
@@ -740,121 +204,60 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 	if (!firstCandidate) {
 		throw new SearchProviderError("codex", "No Codex web search model is configured.");
 	}
-	const transport = resolveCodexSearchTransport(params.modelRegistry, firstCandidate.modelId);
 	// The ChatGPT-backend Codex endpoint speaks the undocumented codex-rs
-	// request shape (responses-lite moves tools into an `additional_tools`
-	// developer item), so the documented `web_search.filters.allowed_domains`
-	// parameter cannot be assumed to survive it. Instead, re-emit directive
-	// queries with the full Google-style operator syntax — the backing index
-	// parses the classic operator set — and leave directive-free queries
-	// byte-identical.
+	// request shape, so re-emit directive queries with the classic Google-style
+	// operators and leave directive-free queries byte-identical.
 	const parsed = params.parsedQuery ?? parseSearchQuery(params.query);
 	const query = parsed.hasDirectives ? formatQuery(parsed, GOOGLE_QUERY_SYNTAX) : params.query;
 
-	let result: CodexSearchResult;
-	if (transport.customEndpoint) {
-		// ModelRegistry resolves command-backed provider keys before consulting
-		// its AuthStorage, so a lower-priority OAuth origin is irrelevant when
-		// that command source is configured.
-		const credentialSource = params.modelRegistry?.authStorage ?? params.authStorage;
-		const credentialOrigin = credentialSource.getCredentialOrigin("openai-codex");
-		const hasCommandBackedKey = params.modelRegistry?.hasCommandBackedApiKey("openai-codex") === true;
-		if (!hasCommandBackedKey && (credentialOrigin?.kind === "oauth" || credentialOrigin?.kind === "env")) {
-			throw new SearchProviderError(
-				"codex",
-				`Refusing to send official Codex OAuth credentials to custom endpoint ${transport.baseUrl}. Configure an API key for provider "openai-codex".`,
-			);
-		}
-
-		const resolverOptions = {
+	const result = await withOAuthAccess(
+		params.authStorage,
+		"openai-codex",
+		access => {
+			const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
+			if (!accountId) throw new Error("Codex OAuth credential is missing a ChatGPT account id");
+			return runCodexSearchCandidates({
+				auth: { accessToken: access.accessToken, accountId },
+				params,
+				query,
+				modelCandidates,
+				modelWasConfigured: configuredModel !== undefined,
+			});
+		},
+		{
 			sessionId: params.sessionId,
-			baseUrl: transport.baseUrl,
-			modelId: firstCandidate.modelId,
-		};
-		const keyOrResolver = params.modelRegistry
-			? params.modelRegistry.resolver("openai-codex", resolverOptions)
-			: params.authStorage.resolver("openai-codex", resolverOptions);
-		result = await withAuth(
-			keyOrResolver,
-			accessToken =>
-				runCodexSearchCandidates({
-					auth: { accessToken },
-					params,
-					query,
-					modelCandidates,
-					modelWasConfigured: configuredModel !== undefined,
-					transport,
-				}),
-			{
-				signal: params.signal,
-				missingKeyMessage: 'Codex credentials not found. Configure an API key for provider "openai-codex".',
-			},
-		);
-	} else {
-		const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
-		if (!seed) {
-			throw new Error(
+			signal: params.signal,
+			missingAccessMessage:
 				"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
-			);
-		}
-
-		result = await withOAuthAccess(
-			params.authStorage,
-			"openai-codex",
-			access => {
-				// A refreshed/rotated credential can carry a different bearer and
-				// ChatGPT account id than the seed used to select the first attempt.
-				const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
-				if (!accountId) {
-					throw new Error("Codex OAuth credential is missing a ChatGPT account id");
-				}
-				return runCodexSearchCandidates({
-					auth: { accessToken: access.accessToken, accountId },
-					params,
-					query,
-					modelCandidates,
-					modelWasConfigured: configuredModel !== undefined,
-					transport,
-				});
-			},
-			{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
-		);
-	}
+		},
+	);
 
 	let sources = result.sources;
-
 	const numResults = params.numSearchResults ?? params.limit;
-	if (numResults && sources.length > numResults) {
-		sources = sources.slice(0, numResults);
-	}
+	if (numResults && sources.length > numResults) sources = sources.slice(0, numResults);
 
 	return {
 		provider: "codex",
 		answer: result.answer || undefined,
 		sources,
-		usage: result.usage
-			? {
-					inputTokens: result.usage.inputTokens,
-					outputTokens: result.usage.outputTokens,
-					totalTokens: result.usage.totalTokens,
-				}
-			: undefined,
+		citations: result.citations.length > 0 ? result.citations : undefined,
+		usage: result.usage,
 		model: result.model,
 		requestId: result.requestId,
 	};
 }
 
 /**
- * Checks whether Codex web search has an API key or OAuth credential.
+ * Checks whether Codex web search has an openai-codex OAuth credential.
  */
 export async function hasCodexSearch(authStorage: AuthStorage): Promise<boolean> {
-	return authStorage.hasAuth("openai-codex");
+	return authStorage.hasOAuth("openai-codex");
 }
 
 /** Search provider for OpenAI Codex web search. */
 export class CodexProvider extends SearchProvider {
 	readonly id = "codex";
-	readonly label = "OpenAI";
+	readonly label = "OpenAI Codex";
 
 	isAvailable(authStorage: AuthStorage): Promise<boolean> | boolean {
 		return hasCodexSearch(authStorage);

--- a/packages/coding-agent/src/web/search/providers/hosted-responses.ts
+++ b/packages/coding-agent/src/web/search/providers/hosted-responses.ts
@@ -1,0 +1,459 @@
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import { readSseJson } from "@oh-my-pi/pi-utils";
+import type { SearchCitation, SearchProviderId, SearchSource, SearchUsage } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+export interface HostedResponsesRequestOptions {
+	model: string;
+	query: string;
+	instructions: string;
+	searchContextSize?: "low" | "medium" | "high";
+}
+
+export interface HostedResponsesCallOptions extends HostedResponsesRequestOptions {
+	provider: SearchProviderId;
+	displayName: string;
+	url: string;
+	headers: Headers;
+	signal?: AbortSignal;
+	timeoutMs?: number;
+	fetch?: FetchImpl;
+}
+
+export interface HostedResponsesResult {
+	answer: string;
+	sources: SearchSource[];
+	citations: SearchCitation[];
+	model: string;
+	requestId: string;
+	usage?: SearchUsage;
+}
+
+interface HostedWebSearchSource {
+	url?: string;
+	source_website_url?: string;
+	title?: string;
+	caption?: string;
+}
+
+interface HostedCitationAnnotation {
+	type?: string;
+	url?: string;
+	title?: string;
+	start_index?: number;
+	end_index?: number;
+}
+
+interface HostedContentPart {
+	type?: string;
+	text?: string;
+	annotations?: HostedCitationAnnotation[];
+}
+
+interface HostedResponseItem {
+	type?: string;
+	content?: HostedContentPart[];
+	annotations?: HostedCitationAnnotation[];
+	action?: { sources?: HostedWebSearchSource[] };
+	sources?: HostedWebSearchSource[];
+	results?: HostedWebSearchSource[];
+	summary?: Array<{ type?: string; text?: string }>;
+}
+
+interface HostedUsage {
+	input_tokens?: number;
+	output_tokens?: number;
+	total_tokens?: number;
+	input_tokens_details?: { cached_tokens?: number };
+}
+
+interface HostedResponse {
+	id?: string;
+	model?: string;
+	usage?: HostedUsage;
+}
+
+/** Resolve a standard OpenAI Responses endpoint from a complete provider URL. */
+export function resolveHostedResponsesUrl(baseUrl: string): string {
+	const normalized = baseUrl.trim().replace(/\/+$/, "");
+	if (!normalized) throw new Error("OpenAI Responses base URL is empty");
+	return normalized.endsWith("/responses") ? normalized : `${normalized}/responses`;
+}
+
+/** Build the common streamed Hosted Responses web-search request body. */
+export function buildHostedResponsesRequestBody(options: HostedResponsesRequestOptions): Record<string, unknown> {
+	return {
+		model: options.model,
+		stream: true,
+		store: false,
+		include: ["web_search_call.action.sources"],
+		parallel_tool_calls: true,
+		input: [
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: options.query }],
+			},
+		],
+		tools: [
+			{
+				type: "web_search",
+				search_context_size: options.searchContextSize ?? "high",
+			},
+		],
+		tool_choice: { type: "web_search" },
+		instructions: options.instructions,
+	};
+}
+
+const IMAGE_PLACEHOLDER_ANSWERS: Record<string, true> = {
+	"see attached image": true,
+	"attached image": true,
+	"see the attached image": true,
+	"see image": true,
+	"see image above": true,
+	"image above": true,
+	"see image below": true,
+	"image below": true,
+};
+
+function isImagePlaceholderAnswer(text: string): boolean {
+	const normalized = text
+		.trim()
+		.replace(/^[[("'`*_]+/, "")
+		.replace(/[\])"'`*_.!?]+$/, "")
+		.trim()
+		.toLowerCase();
+	return IMAGE_PLACEHOLDER_ANSWERS[normalized] === true;
+}
+
+/** Raised when a Responses model answers without actually invoking web_search. */
+export class HostedResponsesNoWebSearchError extends SearchProviderError {
+	constructor(provider: SearchProviderId, displayName: string) {
+		super(
+			provider,
+			`${displayName} returned a completion without running web search (no web_search_call event); refusing to treat a non-search answer as a search result`,
+			502,
+		);
+		this.name = "HostedResponsesNoWebSearchError";
+	}
+}
+
+function cleanSourceUrl(rawUrl: string): string {
+	try {
+		const url = new URL(rawUrl);
+		if (url.searchParams.get("utm_source") === "openai") url.searchParams.delete("utm_source");
+		return url.toString();
+	} catch {
+		return rawUrl.replace(/[?&]utm_source=openai$/u, "");
+	}
+}
+
+function addSource(sources: SearchSource[], source: SearchSource): void {
+	const normalizedSource = { ...source, url: cleanSourceUrl(source.url) };
+	const existing = sources.find(candidate => candidate.url === normalizedSource.url);
+	if (!existing) {
+		sources.push(normalizedSource);
+		return;
+	}
+	if (existing.title === existing.url && normalizedSource.title !== normalizedSource.url) {
+		existing.title = normalizedSource.title;
+	}
+	if (!existing.snippet && normalizedSource.snippet) existing.snippet = normalizedSource.snippet;
+}
+
+function addCitation(citations: SearchCitation[], citation: SearchCitation): void {
+	const normalized = { ...citation, url: cleanSourceUrl(citation.url) };
+	const existing = citations.find(candidate => candidate.url === normalized.url);
+	if (!existing) {
+		citations.push(normalized);
+		return;
+	}
+	if (existing.title === existing.url && normalized.title !== normalized.url) existing.title = normalized.title;
+	if (!existing.citedText && normalized.citedText) existing.citedText = normalized.citedText;
+}
+
+function extractCitationSnippet(text: string, start: number | undefined, end: number | undefined): string | undefined {
+	if (start === undefined || end === undefined || !text) return undefined;
+	const before = Math.max(0, start - 100);
+	const after = Math.min(text.length, end + 100);
+	const snippet = text
+		.slice(before, after)
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.trim();
+	if (!snippet) return undefined;
+	return snippet.length > 300 ? `${snippet.slice(0, 297)}...` : snippet;
+}
+
+function countCharacter(text: string, target: string): number {
+	let count = 0;
+	for (const character of text) if (character === target) count += 1;
+	return count;
+}
+
+function normalizeExtractedUrl(candidate: string): string | null {
+	let url = candidate.trim();
+	while (url.length > 0) {
+		const lastCharacter = url.at(-1);
+		if (!lastCharacter) break;
+		if (/[.,!?;:'"]/u.test(lastCharacter)) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === ")" && countCharacter(url, ")") > countCharacter(url, "(")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === "]" && countCharacter(url, "]") > countCharacter(url, "[")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === "}" && countCharacter(url, "}") > countCharacter(url, "{")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		break;
+	}
+	if (!/^https?:\/\//.test(url)) return null;
+	try {
+		return new URL(url).toString();
+	} catch {
+		return null;
+	}
+}
+
+function findMarkdownLinkUrlEnd(text: string, openParenIndex: number): number | null {
+	let depth = 0;
+	for (let index = openParenIndex; index < text.length; index += 1) {
+		const character = text[index];
+		if (!character || character === "\n") return null;
+		if (character === "(") {
+			depth += 1;
+			continue;
+		}
+		if (character !== ")") continue;
+		depth -= 1;
+		if (depth === 0) return index;
+		if (depth < 0) return null;
+	}
+	return null;
+}
+
+function extractTextSources(text: string): SearchSource[] {
+	const sources: SearchSource[] = [];
+	for (let index = 0; index < text.length; index += 1) {
+		if (text[index] !== "[") continue;
+		const titleEnd = text.indexOf("]", index + 1);
+		if (titleEnd === -1 || text[titleEnd + 1] !== "(") continue;
+		const urlEnd = findMarkdownLinkUrlEnd(text, titleEnd + 1);
+		if (urlEnd === null) continue;
+		const title = text.slice(index + 1, titleEnd).trim();
+		const url = normalizeExtractedUrl(text.slice(titleEnd + 2, urlEnd));
+		if (url) addSource(sources, { title: title || url, url });
+		index = urlEnd;
+	}
+	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
+		const url = normalizeExtractedUrl(match[0] ?? "");
+		if (url) addSource(sources, { title: url, url });
+	}
+	return sources;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function asResponse(value: unknown): HostedResponse | undefined {
+	return asRecord(value) as HostedResponse | undefined;
+}
+
+function asResponseItem(value: unknown): HostedResponseItem | undefined {
+	return asRecord(value) as HostedResponseItem | undefined;
+}
+
+function extractSseError(rawEvent: Record<string, unknown>): { code: string; message: string } {
+	const response = asRecord(rawEvent.response);
+	const candidates: unknown[] = [rawEvent, rawEvent.error, response?.error];
+	let code = "";
+	let message = "";
+	for (const candidate of candidates) {
+		const record = asRecord(candidate);
+		if (!record) continue;
+		if (!code && typeof record.code === "string" && record.code) code = record.code;
+		if (!message && typeof record.message === "string" && record.message) message = record.message;
+	}
+	return { code, message };
+}
+
+function classifySseErrorStatus(code: string, message: string): number {
+	const detail = `${code} ${message}`.toLowerCase();
+	if (/rate[- ]?limit|too many requests|quota|\b429\b/u.test(detail)) return 429;
+	if (/unauthori[sz]ed|\b401\b/u.test(detail)) return 401;
+	if (/forbidden|\b403\b/u.test(detail)) return 403;
+	if (/timeout|timed out/u.test(detail)) return 504;
+	return 500;
+}
+
+function collectAnnotation(
+	annotation: HostedCitationAnnotation,
+	text: string,
+	sources: SearchSource[],
+	citations: SearchCitation[],
+): void {
+	if (annotation.type !== "url_citation" || !annotation.url) return;
+	const title = annotation.title ?? annotation.url;
+	const snippet = extractCitationSnippet(text, annotation.start_index, annotation.end_index);
+	addSource(sources, { title, url: annotation.url, ...(snippet ? { snippet } : {}) });
+	addCitation(citations, { title, url: annotation.url, ...(snippet ? { citedText: snippet } : {}) });
+}
+
+function collectWebSearchSources(item: HostedResponseItem, sources: SearchSource[]): void {
+	if (item.type !== "web_search_call") return;
+	for (const group of [item.action?.sources, item.sources, item.results]) {
+		if (!Array.isArray(group)) continue;
+		for (const source of group) {
+			if (!source || typeof source !== "object") continue;
+			const url = source.url ?? source.source_website_url;
+			if (!url) continue;
+			addSource(sources, { title: source.title ?? source.caption ?? url, url });
+		}
+	}
+}
+
+function collectMessage(
+	item: HostedResponseItem,
+	answerParts: string[],
+	sources: SearchSource[],
+	citations: SearchCitation[],
+): void {
+	if (item.type === "message" && Array.isArray(item.content)) {
+		for (const part of item.content) {
+			if (part.type !== "output_text" || !part.text) continue;
+			answerParts.push(part.text);
+			for (const annotation of part.annotations ?? []) collectAnnotation(annotation, part.text, sources, citations);
+		}
+	}
+	for (const annotation of item.annotations ?? []) collectAnnotation(annotation, "", sources, citations);
+	if (item.type === "reasoning" && Array.isArray(item.summary)) {
+		for (const part of item.summary) {
+			if (part.type === "summary_text" && part.text) answerParts.push(part.text);
+		}
+	}
+}
+
+/** Parse a streamed Hosted Responses body shared by Codex and OpenAI providers. */
+export async function parseHostedResponsesSse(
+	body: ReadableStream<Uint8Array>,
+	options: Pick<HostedResponsesCallOptions, "provider" | "displayName" | "model" | "signal">,
+): Promise<HostedResponsesResult> {
+	const answerParts: string[] = [];
+	const streamedAnswerParts: string[] = [];
+	const sources: SearchSource[] = [];
+	const citations: SearchCitation[] = [];
+	let model = options.model;
+	let requestId = "";
+	let usage: SearchUsage | undefined;
+	let webSearchInvoked = false;
+
+	for await (const rawEvent of readSseJson<Record<string, unknown>>(body, options.signal)) {
+		const eventType = typeof rawEvent.type === "string" ? rawEvent.type : "";
+		if (!eventType) continue;
+		if (eventType.startsWith("response.web_search_call")) webSearchInvoked = true;
+
+		if (eventType === "response.created") {
+			const response = asResponse(rawEvent.response);
+			if (response?.id) requestId = response.id;
+			if (response?.model) model = response.model;
+			continue;
+		}
+		if (eventType === "response.output_text.delta") {
+			const delta = typeof rawEvent.delta === "string" ? rawEvent.delta : "";
+			if (delta) streamedAnswerParts.push(delta);
+			continue;
+		}
+		if (eventType === "response.output_item.done") {
+			const item = asResponseItem(rawEvent.item);
+			if (!item) continue;
+			if (item.type === "web_search_call") webSearchInvoked = true;
+			collectWebSearchSources(item, sources);
+			collectMessage(item, answerParts, sources, citations);
+			continue;
+		}
+		if (eventType === "response.completed" || eventType === "response.done") {
+			const response = asResponse(rawEvent.response);
+			if (!response) continue;
+			if (response.model) model = response.model;
+			if (response.id) requestId = response.id;
+			if (response.usage) {
+				const cachedTokens = response.usage.input_tokens_details?.cached_tokens ?? 0;
+				const inputTokens = response.usage.input_tokens;
+				const outputTokens = response.usage.output_tokens;
+				const totalTokens = response.usage.total_tokens;
+				const parsedUsage: SearchUsage = {
+					...(typeof inputTokens === "number" ? { inputTokens: inputTokens - cachedTokens } : {}),
+					...(typeof outputTokens === "number" ? { outputTokens } : {}),
+					...(typeof totalTokens === "number" ? { totalTokens } : {}),
+				};
+				usage = Object.keys(parsedUsage).length > 0 ? parsedUsage : undefined;
+			}
+			continue;
+		}
+		if (eventType === "error") {
+			const { code, message } = extractSseError(rawEvent);
+			throw new SearchProviderError(
+				options.provider,
+				`${options.displayName} error (${code}): ${message || "Unknown error"}`,
+				classifySseErrorStatus(code, message),
+			);
+		}
+		if (eventType === "response.failed") {
+			const { code, message } = extractSseError(rawEvent);
+			const detail = code
+				? `${options.displayName} request failed (${code}): ${message || "Request failed"}`
+				: `${options.displayName} request failed: ${message || "Request failed"}`;
+			throw new SearchProviderError(options.provider, detail, classifySseErrorStatus(code, message));
+		}
+	}
+
+	if (!webSearchInvoked) throw new HostedResponsesNoWebSearchError(options.provider, options.displayName);
+
+	const finalAnswer = answerParts.join("\n\n").trim();
+	const streamedAnswer = streamedAnswerParts.join("").trim();
+	const finalIsPlaceholder = finalAnswer.length > 0 && isImagePlaceholderAnswer(finalAnswer);
+	const streamedIsPlaceholder = streamedAnswer.length > 0 && isImagePlaceholderAnswer(streamedAnswer);
+	const hasFinalText = finalAnswer.length > 0 && !finalIsPlaceholder;
+	const hasStreamedText = streamedAnswer.length > 0 && !streamedIsPlaceholder;
+	if (!hasFinalText && !hasStreamedText && sources.length === 0) {
+		throw new SearchProviderError(options.provider, `${options.displayName} returned image-only response`, 502);
+	}
+	const answer = hasFinalText ? finalAnswer : hasStreamedText ? streamedAnswer : "";
+	if (sources.length === 0 && answer.length > 0) {
+		for (const source of extractTextSources(answer)) addSource(sources, source);
+	}
+	return { answer, sources, citations, model, requestId, usage };
+}
+
+/** POST and parse one streamed Hosted Responses search. */
+export async function callHostedResponsesSearch(options: HostedResponsesCallOptions): Promise<HostedResponsesResult> {
+	const response = await (options.fetch ?? fetch)(options.url, {
+		method: "POST",
+		headers: options.headers,
+		body: JSON.stringify(buildHostedResponsesRequestBody(options)),
+		signal: withHardTimeout(options.signal, options.timeoutMs),
+	});
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError(options.provider, response.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError(
+			options.provider,
+			`${options.displayName} API error (${response.status}): ${errorText}`,
+			response.status,
+		);
+	}
+	if (!response.body) {
+		throw new SearchProviderError(options.provider, `${options.displayName} API returned no response body`, 500);
+	}
+	return parseHostedResponsesSse(response.body, options);
+}

--- a/packages/coding-agent/src/web/search/providers/openai.ts
+++ b/packages/coding-agent/src/web/search/providers/openai.ts
@@ -1,0 +1,131 @@
+import { type AuthStorage, withAuth } from "@oh-my-pi/pi-ai";
+import { settings } from "../../../config/settings";
+import type { SearchResponse } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { callHostedResponsesSearch, resolveHostedResponsesUrl } from "./hosted-responses";
+
+function configuredOpenAIProvider(): string | undefined {
+	try {
+		const provider = settings.get("providers.webSearchOpenAIProvider");
+		if (typeof provider !== "string") return undefined;
+		const normalized = provider.trim();
+		return normalized.length > 0 ? normalized : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Check auto-chain availability for the configured OpenAI-compatible target. */
+export function hasOpenAISearch(authStorage: AuthStorage): boolean {
+	const provider = configuredOpenAIProvider();
+	if (!provider) return false;
+	if (typeof authStorage.hasResolvableAuth === "function") return authStorage.hasResolvableAuth(provider);
+	return authStorage.hasAuth(provider);
+}
+
+function requireOpenAISelection(params: SearchParams): { provider: string; modelId: string } {
+	const provider = params.openaiProvider?.trim();
+	const modelId = params.openaiModel?.trim();
+	if (!provider || !modelId) {
+		throw new SearchProviderError(
+			"openai",
+			"OpenAI API web search requires both providers.webSearchOpenAIProvider and providers.webSearchOpenAIModel",
+		);
+	}
+	return { provider, modelId };
+}
+
+/** Execute Hosted web search through a selected `openai-responses` model. */
+export async function searchOpenAI(params: SearchParams): Promise<SearchResponse> {
+	const selection = requireOpenAISelection(params);
+	const registry = params.modelRegistry;
+	if (!registry) {
+		throw new SearchProviderError("openai", "OpenAI API web search requires a model registry");
+	}
+
+	const model = registry.find(selection.provider, selection.modelId);
+	if (!model) {
+		throw new SearchProviderError(
+			"openai",
+			`OpenAI API web search model not found: ${selection.provider}/${selection.modelId}`,
+		);
+	}
+	if (model.api !== "openai-responses") {
+		throw new SearchProviderError(
+			"openai",
+			`OpenAI API web search requires api: openai-responses for ${selection.provider}/${selection.modelId}`,
+		);
+	}
+	if (!model.baseUrl.trim()) {
+		throw new SearchProviderError("openai", `OpenAI API web search model has no base URL: ${selection.modelId}`);
+	}
+
+	const headers = new Headers({
+		...(registry.getProviderHeaders(selection.provider) ?? {}),
+		...(model.headers ?? {}),
+	});
+	headers.delete("chatgpt-account-id");
+	headers.set("Accept", "text/event-stream");
+	headers.set("Content-Type", "application/json");
+
+	const apiKey = params.authStorage.resolver(selection.provider, {
+		sessionId: params.sessionId,
+		baseUrl: model.baseUrl,
+		modelId: model.id,
+	});
+	const result = await withAuth(
+		apiKey,
+		key => {
+			const requestHeaders = new Headers(headers);
+			requestHeaders.set("Authorization", `Bearer ${key}`);
+			return callHostedResponsesSearch({
+				provider: "openai",
+				displayName: "OpenAI API",
+				url: resolveHostedResponsesUrl(model.baseUrl),
+				model: model.requestModelId ?? model.id,
+				query: params.query,
+				instructions: params.systemPrompt,
+				headers: requestHeaders,
+				signal: params.signal,
+				timeoutMs: params.timeoutMs,
+				fetch: params.fetch,
+			});
+		},
+		{
+			signal: params.signal,
+			missingKeyMessage: `API key not found for OpenAI web search provider "${selection.provider}"`,
+		},
+	);
+	const resultCap = params.numSearchResults ?? params.limit;
+	const sources = resultCap ? result.sources.slice(0, resultCap) : result.sources;
+	const citations = resultCap ? result.citations.slice(0, resultCap) : result.citations;
+	return {
+		provider: "openai",
+		answer: result.answer || undefined,
+		sources,
+		citations: citations.length > 0 ? citations : undefined,
+		usage: result.usage,
+		model: result.model,
+		requestId: result.requestId,
+	};
+}
+
+/** Search provider for standard OpenAI-compatible Hosted Responses APIs. */
+export class OpenAIProvider extends SearchProvider {
+	readonly id = "openai";
+	readonly label = "OpenAI API";
+
+	isAvailable(authStorage: AuthStorage): boolean {
+		return hasOpenAISearch(authStorage);
+	}
+
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+		return true;
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchOpenAI(params);
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -27,8 +27,13 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	},
 	{
 		value: "codex",
-		label: "OpenAI",
-		description: "OpenAI's native web_search (uses ChatGPT OAuth via /login openai-codex)",
+		label: "OpenAI Codex",
+		description: "OpenAI Codex web_search via ChatGPT OAuth (uses /login openai-codex)",
+	},
+	{
+		value: "openai",
+		label: "OpenAI API",
+		description: "Hosted web_search via a configured OpenAI Responses Provider (uses that provider's API key)",
 	},
 	{
 		value: "xai",

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
-import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import type { SearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/base";
 import { hasCodexSearch, searchCodex } from "@oh-my-pi/pi-coding-agent/web/search/providers/codex";
 
@@ -215,47 +214,10 @@ describe("searchCodex model selection", () => {
 		hasOAuth() {
 			return true;
 		},
-	} as unknown as AuthStorage;
-	const proxyAuthStorage = {
 		hasAuth(provider: string) {
 			return provider === "openai-codex";
 		},
-		getCredentialOrigin() {
-			return { kind: "config" as const };
-		},
-		resolver() {
-			return async () => "test-proxy-key";
-		},
 	} as unknown as AuthStorage;
-	const oauthOnlyAuthStorage = {
-		...proxyAuthStorage,
-		getCredentialOrigin() {
-			return { kind: "oauth" as const };
-		},
-	} as unknown as AuthStorage;
-	const proxyModelRegistry = {
-		find(_provider: string, modelId: string) {
-			return {
-				provider: "openai-codex",
-				id: modelId,
-				api: "openai-codex-responses",
-				baseUrl: "https://proxy.example/backend-api",
-				headers: { "X-Proxy-Tenant": "tenant-1" },
-			};
-		},
-		getProviderBaseUrl() {
-			return "https://proxy.example/backend-api";
-		},
-		getProviderHeaders() {
-			return { "X-Proxy-Tenant": "tenant-1" };
-		},
-		hasCommandBackedApiKey() {
-			return false;
-		},
-		resolver() {
-			return async () => "test-proxy-key";
-		},
-	} as unknown as ModelRegistry;
 	let capturedRequest: CapturedRequest | null = null;
 
 	function makeSearchParams(query: string, fetch?: FetchImpl): SearchParams {
@@ -295,13 +257,17 @@ describe("searchCodex model selection", () => {
 		}
 	});
 
-	it("uses GPT-5.6 Luna as the first bundled default", async () => {
+	it("uses the official Codex Responses URL with openai-codex OAuth", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
 		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.6-luna")));
 
+		expect(await hasCodexSearch(fakeAuthStorage)).toBe(true);
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(new Headers(capturedRequest?.headers).get("x-openai-internal-codex-residency")).toBe("us");
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("authorization")).toBe(`Bearer ${residencyToken}`);
+		expect(headers.get("chatgpt-account-id")).toBe("acct-test");
+		expect(headers.get("x-openai-internal-codex-residency")).toBe("us");
 		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
 		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
@@ -349,84 +315,6 @@ describe("searchCodex model selection", () => {
 		await searchCodex(makeSearchParams(query, mockCodexFetch("gpt-5.6-luna")));
 
 		expect(sentUserText()).toBe(query);
-	});
-
-	it("uses configured Codex endpoint, API key, and headers without OAuth", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
-		const result = await searchCodex({
-			...makeSearchParams("proxy codex model", mockCodexFetch("gpt-5.4")),
-			authStorage: proxyAuthStorage,
-			modelRegistry: proxyModelRegistry,
-		});
-
-		expect(await hasCodexSearch(proxyAuthStorage)).toBe(true);
-		expect(capturedRequest?.url).toBe("https://proxy.example/backend-api/codex/responses");
-		const headers = new Headers(capturedRequest?.headers);
-		expect(headers.get("authorization")).toBe("Bearer test-proxy-key");
-		expect(headers.get("x-proxy-tenant")).toBe("tenant-1");
-		expect(headers.has("chatgpt-account-id")).toBe(false);
-		expect(headers.has("x-openai-internal-codex-residency")).toBe(false);
-		expect(result.answer).toBe("Codex answer");
-	});
-
-	it("refuses to send official OAuth credentials to a configured Codex endpoint", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
-		const fetchMock = vi.fn();
-
-		await expect(
-			searchCodex({
-				...makeSearchParams("unsafe proxy", fetchMock),
-				authStorage: oauthOnlyAuthStorage,
-				modelRegistry: proxyModelRegistry,
-			}),
-		).rejects.toThrow("Refusing to send official Codex OAuth credentials");
-		expect(fetchMock).not.toHaveBeenCalled();
-	});
-
-	it("validates the credential origin from the registry storage that supplies the key", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
-		const fetchMock = vi.fn();
-		const oauthBackedRegistry = {
-			...proxyModelRegistry,
-			authStorage: oauthOnlyAuthStorage,
-			resolver() {
-				return async () => "official-oauth-token";
-			},
-		} as unknown as ModelRegistry;
-
-		await expect(
-			searchCodex({
-				...makeSearchParams("registry oauth leak", fetchMock),
-				authStorage: proxyAuthStorage,
-				modelRegistry: oauthBackedRegistry,
-			}),
-		).rejects.toThrow("Refusing to send official Codex OAuth credentials");
-		expect(fetchMock).not.toHaveBeenCalled();
-	});
-
-	it("prefers a command-backed proxy key over stored OAuth on a custom endpoint", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
-		const commandBackedRegistry = {
-			...proxyModelRegistry,
-			authStorage: oauthOnlyAuthStorage,
-			hasCommandBackedApiKey(provider: string) {
-				return provider === "openai-codex";
-			},
-			resolver() {
-				return async () => "command-proxy-key";
-			},
-		} as unknown as ModelRegistry;
-
-		const result = await searchCodex({
-			...makeSearchParams("command proxy key", mockCodexFetch("gpt-5.4")),
-			authStorage: oauthOnlyAuthStorage,
-			modelRegistry: commandBackedRegistry,
-		});
-
-		const headers = new Headers(capturedRequest?.headers);
-		expect(headers.get("authorization")).toBe("Bearer command-proxy-key");
-		expect(headers.has("chatgpt-account-id")).toBe(false);
-		expect(result.answer).toBe("Codex answer");
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {

--- a/packages/coding-agent/test/tools/web-search-openai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-openai.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthStorage, FetchImpl, Model } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import type { SearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/base";
+import { searchOpenAI } from "@oh-my-pi/pi-coding-agent/web/search/providers/openai";
+
+type CapturedRequest = {
+	url: string;
+	headers: RequestInit["headers"];
+	body: Record<string, unknown> | null;
+};
+
+const model = {
+	provider: "pindo",
+	id: "pindo-search-model",
+	requestModelId: "pindo-wire-model",
+	api: "openai-responses",
+	baseUrl: "https://proxy.example/v1",
+	headers: {
+		"X-Model-Header": "model-value",
+		Authorization: "Bearer model-header-must-not-win",
+		"chatgpt-account-id": "acct-must-not-leak",
+	},
+} as unknown as Model<"openai-responses">;
+
+function makeSseResponse(): string {
+	const answer = "Pindo found the hosted result.";
+	const citationStart = answer.indexOf("hosted result");
+	return [
+		`data: ${JSON.stringify({ type: "response.web_search_call.completed", item_id: "ws_pindo" })}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "web_search_call",
+				action: { sources: [{ url: "https://example.com/pindo?utm_source=openai", title: "Pindo source" }] },
+			},
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				content: [
+					{
+						type: "output_text",
+						text: answer,
+						annotations: [
+							{
+								type: "url_citation",
+								url: "https://example.com/pindo?utm_source=openai",
+								title: "Pindo source",
+								start_index: citationStart,
+								end_index: citationStart + "hosted result".length,
+							},
+						],
+					},
+				],
+			},
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.completed",
+			response: {
+				id: "resp_pindo",
+				model: "pindo-wire-model",
+				usage: { input_tokens: 11, output_tokens: 8, total_tokens: 19 },
+			},
+		})}`,
+		"",
+	].join("\n");
+}
+
+describe("searchOpenAI Hosted Responses transport", () => {
+	let capturedRequest: CapturedRequest | null = null;
+
+	const authStorage = {
+		resolver(provider: string, options?: { sessionId?: string; baseUrl?: string; modelId?: string }) {
+			expect(provider).toBe("pindo");
+			expect(options).toEqual({
+				sessionId: "pindo-search-session",
+				baseUrl: "https://proxy.example/v1",
+				modelId: "pindo-search-model",
+			});
+			return async () => "pindo-api-key";
+		},
+	} as unknown as AuthStorage;
+	const modelRegistry = {
+		find(provider: string, modelId: string) {
+			expect(provider).toBe("pindo");
+			expect(modelId).toBe("pindo-search-model");
+			return model;
+		},
+		getProviderHeaders(provider: string) {
+			expect(provider).toBe("pindo");
+			return {
+				Authorization: "Bearer provider-header-must-not-win",
+				Accept: "application/json",
+				"Content-Type": "text/plain",
+				"X-Provider-Header": "provider-value",
+			};
+		},
+		resolver() {
+			return async () => "registry-api-key";
+		},
+	} as unknown as ModelRegistry;
+
+	function makeSearchParams(fetch: FetchImpl): SearchParams {
+		return {
+			query: "latest Pindo web search",
+			systemPrompt: "Answer with sources.",
+			authStorage,
+			modelRegistry,
+			sessionId: "pindo-search-session",
+			openaiProvider: "pindo",
+			openaiModel: "pindo-search-model",
+			fetch,
+		};
+	}
+
+	it("uses standard /responses, provider API key, Hosted tool, and shared SSE parsing", async () => {
+		const fetchMock: FetchImpl = (url, init) => {
+			capturedRequest = {
+				url: typeof url === "string" ? url : url.toString(),
+				headers: init?.headers,
+				body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
+			};
+			return Promise.resolve(
+				new Response(makeSseResponse(), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			);
+		};
+
+		const result = await searchOpenAI(makeSearchParams(fetchMock));
+
+		expect(capturedRequest?.url).toBe("https://proxy.example/v1/responses");
+		expect(capturedRequest?.url).not.toContain("/codex/responses");
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("authorization")).toBe("Bearer pindo-api-key");
+		expect(headers.get("accept")).toBe("text/event-stream");
+		expect(headers.get("content-type")).toBe("application/json");
+		expect(headers.get("x-provider-header")).toBe("provider-value");
+		expect(headers.get("x-model-header")).toBe("model-value");
+		expect(headers.has("chatgpt-account-id")).toBe(false);
+		expect(capturedRequest?.body).toEqual(
+			expect.objectContaining({
+				model: "pindo-wire-model",
+				stream: true,
+				tools: [{ type: "web_search", search_context_size: "high" }],
+				tool_choice: { type: "web_search" },
+			}),
+		);
+		expect(result).toMatchObject({
+			provider: "openai",
+			answer: "Pindo found the hosted result.",
+			model: "pindo-wire-model",
+			requestId: "resp_pindo",
+			usage: { inputTokens: 11, outputTokens: 8, totalTokens: 19 },
+		});
+		expect(result.sources).toEqual([
+			{ title: "Pindo source", url: "https://example.com/pindo", snippet: "Pindo found the hosted result." },
+		]);
+		expect(result.citations).toEqual([
+			{ title: "Pindo source", url: "https://example.com/pindo", citedText: "Pindo found the hosted result." },
+		]);
+	});
+
+	it("rejects a selected model that is not an openai-responses model", async () => {
+		const invalidRegistry = {
+			...modelRegistry,
+			find() {
+				return { ...model, api: "openai-completions" };
+			},
+		} as unknown as ModelRegistry;
+		await expect(
+			searchOpenAI({
+				...makeSearchParams(() => Promise.reject(new Error("fetch must not run"))),
+				modelRegistry: invalidRegistry,
+			}),
+		).rejects.toThrow("requires api: openai-responses");
+	});
+});

--- a/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
+++ b/packages/coding-agent/test/web/search/cli-provider-settings.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { AuthStorage, Model } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runSearchQuery } from "@oh-my-pi/pi-coding-agent/web/search";
 import {
 	SEARCH_PROVIDER_ORDER,
 	setExcludedSearchProviders,
@@ -159,5 +162,99 @@ describe("runSearchCommand provider settings", () => {
 		const plain = stripVTControlCharacters(stdout);
 		expect(plain).toContain("Provider: Jina");
 		expect(plain).not.toContain("Provider: Tavily (API)");
+	});
+
+	it("uses configured OpenAI settings end to end with SearchParams auth and registry transport settings", async () => {
+		settings.set("providers.webSearchOpenAIProvider", "pindo");
+		settings.set("providers.webSearchOpenAIModel", "pindo-search");
+
+		const model = {
+			provider: "pindo",
+			id: "pindo-model-id",
+			requestModelId: "pindo-wire-model",
+			api: "openai-responses",
+			baseUrl: "https://proxy.example/v1",
+			headers: {
+				"X-Model-Header": "model-value",
+				Authorization: "Bearer model-header-must-not-win",
+				"chatgpt-account-id": "acct-must-not-leak",
+			},
+		} as unknown as Model<"openai-responses">;
+		const registryAuthStorage = {
+			resolver() {
+				return async () => "registry-auth-key";
+			},
+		} as unknown as AuthStorage;
+		const resolverCalls: Array<{
+			provider: string;
+			options?: { sessionId?: string; baseUrl?: string; modelId?: string };
+		}> = [];
+		const authStorage = {
+			resolver(provider: string, options?: { sessionId?: string; baseUrl?: string; modelId?: string }) {
+				resolverCalls.push({ provider, options });
+				return async () => "search-auth-key";
+			},
+		} as unknown as AuthStorage;
+		const modelRegistry = {
+			authStorage: registryAuthStorage,
+			find(provider: string, modelId: string) {
+				expect(provider).toBe("pindo");
+				expect(modelId).toBe("pindo-search");
+				return model;
+			},
+			getProviderHeaders(provider: string) {
+				expect(provider).toBe("pindo");
+				return {
+					Authorization: "Bearer provider-header-must-not-win",
+					"X-Provider-Header": "provider-value",
+				};
+			},
+			resolver() {
+				return registryAuthStorage.resolver("pindo");
+			},
+		} as unknown as ModelRegistry;
+
+		let capturedUrl: string | undefined;
+		let capturedHeaders: Headers | undefined;
+		let capturedBody: Record<string, unknown> | undefined;
+		const configuredFetch: typeof fetch = Object.assign(
+			async (input: string | Request | URL, init?: RequestInit): Promise<Response> => {
+				capturedUrl = responseUrl(input);
+				capturedHeaders = new Headers(init?.headers);
+				capturedBody = init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : undefined;
+				const sse = [
+					`data: ${JSON.stringify({ type: "response.web_search_call.completed" })}`,
+					"",
+					`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "configured OpenAI result" })}`,
+					"",
+				].join("\n");
+				return new Response(sse, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(configuredFetch);
+
+		const result = await runSearchQuery(
+			{ query: "configured OpenAI search", provider: "openai" },
+			{ authStorage, modelRegistry, sessionId: "configured-search-session" },
+		);
+
+		expect(result.details.response.provider).toBe("openai");
+		expect(capturedUrl).toBe("https://proxy.example/v1/responses");
+		expect(capturedBody?.model).toBe("pindo-wire-model");
+		expect(capturedHeaders?.get("x-provider-header")).toBe("provider-value");
+		expect(capturedHeaders?.get("x-model-header")).toBe("model-value");
+		expect(capturedHeaders?.get("authorization")).toBe("Bearer search-auth-key");
+		expect(capturedHeaders?.has("chatgpt-account-id")).toBe(false);
+		expect(resolverCalls).toEqual([
+			{
+				provider: "pindo",
+				options: {
+					sessionId: "configured-search-session",
+					baseUrl: "https://proxy.example/v1",
+					modelId: "pindo-model-id",
+				},
+			},
+		]);
 	});
 });

--- a/packages/coding-agent/test/web/search/provider-chain.test.ts
+++ b/packages/coding-agent/test/web/search/provider-chain.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import {
+	getSearchProviderLabel,
 	resolveProviderCandidates,
 	resolveProviderChain,
 	setExcludedSearchProviders,
@@ -54,6 +55,14 @@ describe("resolveProviderCandidates", () => {
 			"exa",
 			...SEARCH_PROVIDER_ORDER.filter(id => id !== "perplexity" && id !== "gemini" && id !== "exa"),
 		]);
+	});
+
+	it("allows OpenAI API Hosted web_search to be configured and distinguishes it from Codex", () => {
+		expect(getSearchProviderLabel("openai")).toBe("OpenAI API");
+		expect(getSearchProviderLabel("codex")).toBe("OpenAI Codex");
+
+		setSearchProviderOrder(["openai"]);
+		expect(resolveProviderCandidates()[0]).toEqual({ id: "openai", explicit: true });
 	});
 
 	it("marks configured-order entries explicit so hand-listed providers keep explicit-selection semantics", () => {


### PR DESCRIPTION
## Summary

- keep Codex web search on the official ChatGPT subscription transport (`https://chatgpt.com/backend-api/codex/responses`) with `openai-codex` OAuth only
- add an `openai` web-search provider that uses a configured provider/model, its API key, and the standard `<baseUrl>/responses` Hosted Search tool
- share the Hosted Responses request/SSE parser between Codex and OpenAI without forwarding ChatGPT account headers to custom providers
- honor catalog `requestModelId` values when sending the selected model upstream

This removes the false assumption that arbitrary OpenAI-compatible relays implement a private `<baseUrl>/codex/responses` route. Relays such as Pindo can instead use their normal Responses endpoint.

## Configuration

```json
{
  "providers": {
    "webSearchOpenAIProvider": "pindo",
    "webSearchOpenAIModel": "<openai-responses model id>"
  }
}
```

Select `openai` explicitly or include it in the web-search provider order.

## Verification

- `bun test packages/coding-agent/test/tools/web-search-codex.test.ts packages/coding-agent/test/tools/web-search-openai.test.ts packages/coding-agent/test/web/search` — 148 passed
- `bun --cwd=packages/coding-agent run check` — passed
- `bun check` — passed
