### PR TITLE
fix(coding-agent): stop binding callable tool schemas in applyToolProxy

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -55,7 +55,7 @@
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
 ### Fixed
 
-- Fixed a crash (`Error: Failed to measure JavaScript string`) that killed read-only subagents (`scout`, restricted-tool custom agents) at their first prompt when an extension registered tools with ArkType parameters. Tool proxying no longer strips callable schemas, and token accounting tolerates unserializable schemas.
+- Fixed read-only subagents (`scout`, restricted-tool custom agents) crashing before their first prompt when extensions register callable tool schemas.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,9 @@
 - Fixed prompt guidance and descriptions for Task tools and SSH usage.
 - ACP editor clients that support elicitation forms (Zed) can now use `ask`, so the agent can pose single-choice, multi-select, and free-text questions inline instead of guessing.
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
+### Fixed
+
+- Fixed every read-only subagent (e.g. `scout`, restricted-tool custom agents) crashing at first prompt with `Error: Failed to measure JavaScript string` when an extension registers tools whose `parameters` is a bind-capable callable schema (an ArkType `Type` from the extension's own bundled arktype). `applyToolProxy` bound the schema, stripping its `toJsonSchema`/`assert` surface, so `toolWireSchema` returned the bare bound function, `JSON.stringify` yielded `undefined`, and the poisoned fragment list crashed the native tokenizer inside pre-prompt context accounting. Callable schemas now pass through the tool proxy unbound, and `estimateToolSchemaTokens` skips non-string fragments so token accounting can never take down a session on an exotic schema.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -55,7 +55,7 @@
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
 ### Fixed
 
-- Fixed every read-only subagent (e.g. `scout`, restricted-tool custom agents) crashing at first prompt with `Error: Failed to measure JavaScript string` when an extension registers tools whose `parameters` is a bind-capable callable schema (an ArkType `Type` from the extension's own bundled arktype). `applyToolProxy` bound the schema, stripping its `toJsonSchema`/`assert` surface, so `toolWireSchema` returned the bare bound function, `JSON.stringify` yielded `undefined`, and the poisoned fragment list crashed the native tokenizer inside pre-prompt context accounting. Callable schemas now pass through the tool proxy unbound, and `estimateToolSchemaTokens` skips non-string fragments so token accounting can never take down a session on an exotic schema.
+- Fixed a crash (`Error: Failed to measure JavaScript string`) that killed read-only subagents (`scout`, restricted-tool custom agents) at their first prompt when an extension registered tools with ArkType parameters. Tool proxying no longer strips callable schemas, and token accounting tolerates unserializable schemas.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/src/extensibility/tool-proxy.ts
+++ b/packages/coding-agent/src/extensibility/tool-proxy.ts
@@ -1,6 +1,8 @@
 /**
  * Defines lazy proxy properties on a wrapper so it forwards to the underlying tool.
  */
+import { isArkSchema } from "@oh-my-pi/pi-ai/utils/schema";
+
 export function applyToolProxy<TTool extends object>(tool: TTool, wrapper: object): void {
 	const visited = new Set<PropertyKey>();
 	let current: object | null = tool;
@@ -14,10 +16,15 @@ export function applyToolProxy<TTool extends object>(tool: TTool, wrapper: objec
 			Object.defineProperty(wrapper, key, {
 				get() {
 					const value = (tool as Record<PropertyKey, unknown>)[key];
-					// Bind real methods so `this` is preserved through the wrapper, but leave
-					// callable values that aren't plain functions untouched — notably an ArkType
-					// `Type` (the `parameters` schema) is callable yet lacks `Function.prototype.bind`.
-					return typeof value === "function" && typeof value.bind === "function" ? value.bind(tool) : value;
+					if (typeof value !== "function") return value;
+					// Callable schema values (ArkType `Type`, e.g. the `parameters` schema)
+					// must pass through untouched: `bind()` returns a bare bound function
+					// that drops the schema surface (`toJsonSchema`/`assert`/own keys), so a
+					// bound schema later stringifies to `undefined` and poisons wire-schema
+					// and token accounting. Only genuine methods are bound so `this` is
+					// preserved through the wrapper.
+					if (isArkSchema(value) || typeof value.bind !== "function") return value;
+					return value.bind(tool);
 				},
 				enumerable: true,
 				configurable: true,

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -127,14 +127,20 @@ export function estimateToolSchemaTokens(
 ): number {
 	const fragments: string[] = [];
 	for (const tool of tools) {
-		fragments.push(tool.name, tool.description);
+		// Extension-supplied tools may carry a non-string name/description or a
+		// parameters value whose wire schema stringifies to `undefined` (e.g. a
+		// callable schema that escaped normalization). A non-string fragment is
+		// fatal inside the native tokenizer, so only real strings are counted.
+		if (typeof tool.name === "string") fragments.push(tool.name);
+		if (typeof tool.description === "string") fragments.push(tool.description);
 		try {
 			const wireTool: AiTool = {
 				name: tool.name,
 				description: tool.description,
 				parameters: tool.parameters as AiTool["parameters"],
 			};
-			fragments.push(JSON.stringify(toolWireSchema(wireTool) ?? {}));
+			const wireJson = JSON.stringify(toolWireSchema(wireTool) ?? {});
+			if (typeof wireJson === "string") fragments.push(wireJson);
 		} catch {
 			// Schema may contain functions or cycles; ignore.
 		}

--- a/packages/coding-agent/test/extensibility/tool-proxy.test.ts
+++ b/packages/coding-agent/test/extensibility/tool-proxy.test.ts
@@ -24,6 +24,23 @@ describe("applyToolProxy", () => {
 		expect(wrapper.parameters).toBeInstanceOf(Function);
 	});
 
+	it("preserves bind-capable schema callables from external arktype copies", () => {
+		// Regression: an extension bundling its own arktype registers tools whose
+		// `parameters` is a callable Type that DOES have Function.prototype.bind
+		// (unlike omptype). Binding it returned a bare bound function with no
+		// schema surface, so toolWireSchema stringified to undefined and the
+		// native tokenizer crashed every read-only subagent at first prompt.
+		const schema = Object.assign((value: unknown) => value, {
+			toJsonSchema: () => ({ type: "object" }),
+			assert: (value: unknown) => value,
+		});
+		const tool = { name: "ext", description: "ext tool", parameters: schema };
+		const wrapper: Record<string, unknown> = {};
+		applyToolProxy(tool, wrapper);
+		expect(wrapper.parameters).toBe(schema);
+		expect(isArkSchema(wrapper.parameters)).toBe(true);
+	});
+
 	it("binds prototype methods to the underlying tool", async () => {
 		const wrapper: Record<string, unknown> = {};
 		applyToolProxy(new DemoTool(), wrapper);

--- a/packages/coding-agent/test/modes/context-usage.test.ts
+++ b/packages/coding-agent/test/modes/context-usage.test.ts
@@ -16,8 +16,19 @@ import {
 	estimateToolSchemaTokens,
 	renderContextUsage,
 } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
+import { applyToolProxy } from "../../src/extensibility/tool-proxy";
 
 const tokenizer = new Tokenizer();
+
+/** An arktype-shaped callable schema from an external arktype copy: a plain
+ * function carrying `toJsonSchema`/`assert` that — unlike omptype schemas —
+ * HAS `Function.prototype.bind`. */
+function bindCapableSchema() {
+	return Object.assign((value: unknown) => value, {
+		toJsonSchema: () => ({ type: "object", properties: { a: { type: "string" } } }),
+		assert: (value: unknown) => value,
+	});
+}
 
 describe("estimateToolSchemaTokens", () => {
 	it("counts arktype tool schemas by their wire JSON Schema, not arktype internals", () => {
@@ -34,6 +45,58 @@ describe("estimateToolSchemaTokens", () => {
 			tokenizer,
 		);
 		expect(arktypeEstimate).toBe(wireEstimate);
+	});
+
+	it("counts a proxied bind-capable callable schema by its wire JSON Schema", () => {
+		// Regression (PR #9185): applyToolProxy bound every callable property,
+		// and an external-arktype Type HAS Function.prototype.bind (unlike
+		// omptype), so the bound `parameters` lost its schema surface,
+		// toolWireSchema returned the bare function, and the undefined
+		// JSON.stringify poisoned token accounting — crashing every read-only
+		// subagent at first prompt. The proxied schema must keep counting as
+		// its wire JSON Schema, identical to the pre-converted equivalent.
+		const schema = bindCapableSchema();
+		const wrapper: Record<string, unknown> = {};
+		applyToolProxy({ name: "ext", description: "ext tool", parameters: schema }, wrapper);
+		const proxied = wrapper as { name: string; description: string; parameters: unknown };
+		const estimate = estimateToolSchemaTokens([proxied as never], tokenizer);
+		expect(estimate).toBe(
+			estimateToolSchemaTokens(
+				[{ name: "ext", description: "ext tool", parameters: arkToWireSchema(schema as never) } as never],
+				tokenizer,
+			),
+		);
+		expect(estimate).toBeGreaterThan(0);
+	});
+
+	it("runs the full non-message breakdown on a proxied extension tool", () => {
+		// The crash frame was computeNonMessageBreakdown → estimateToolSchemaTokens
+		// inside pre-prompt compaction; exercise that whole path, memo included.
+		const schema = bindCapableSchema();
+		const wrapper: Record<string, unknown> = {};
+		applyToolProxy({ name: "ext", description: "ext tool", parameters: schema }, wrapper);
+		const session = { systemPrompt: ["base"], agent: { state: { tools: [wrapper] } } };
+		const breakdown = computeNonMessageBreakdown(session as never, tokenizer);
+		expect(breakdown.toolsTokens).toBeGreaterThan(0);
+	});
+
+	it("skips a parameters value that stringifies to undefined instead of crashing", () => {
+		// A plain function is neither an arktype schema nor JSON-serializable:
+		// the independent unserializable-schema fallback must skip it and still
+		// count the tool's own strings.
+		const estimate = estimateToolSchemaTokens(
+			[{ name: "odd", description: "odd tool", parameters: function bareSchema() {} } as never],
+			tokenizer,
+		);
+		expect(estimate).toBeGreaterThan(0);
+	});
+
+	it("skips non-string name/description fragments", () => {
+		const estimate = estimateToolSchemaTokens(
+			[{ name: "odd", description: undefined, parameters: { type: "object" } } as never],
+			tokenizer,
+		);
+		expect(estimate).toBeGreaterThan(0);
 	});
 });
 

--- a/packages/coding-agent/test/modes/context-usage.test.ts
+++ b/packages/coding-agent/test/modes/context-usage.test.ts
@@ -56,17 +56,16 @@ describe("estimateToolSchemaTokens", () => {
 		// subagent at first prompt. The proxied schema must keep counting as
 		// its wire JSON Schema, identical to the pre-converted equivalent.
 		const schema = bindCapableSchema();
+		const unwrapped = { name: "ext", description: "ext tool", parameters: schema };
 		const wrapper: Record<string, unknown> = {};
-		applyToolProxy({ name: "ext", description: "ext tool", parameters: schema }, wrapper);
+		applyToolProxy(unwrapped, wrapper);
 		const proxied = wrapper as { name: string; description: string; parameters: unknown };
-		const estimate = estimateToolSchemaTokens([proxied as never], tokenizer);
-		expect(estimate).toBe(
-			estimateToolSchemaTokens(
-				[{ name: "ext", description: "ext tool", parameters: arkToWireSchema(schema as never) } as never],
-				tokenizer,
-			),
+		// The proxied tool must keep counting exactly like the unwrapped tool:
+		// old code fed `undefined` into the tokenizer here and crashed.
+		expect(estimateToolSchemaTokens([proxied as never], tokenizer)).toBe(
+			estimateToolSchemaTokens([unwrapped as never], tokenizer),
 		);
-		expect(estimate).toBeGreaterThan(0);
+		expect(estimateToolSchemaTokens([proxied as never], tokenizer)).toBeGreaterThan(0);
 	});
 
 	it("runs the full non-message breakdown on a proxied extension tool", () => {
@@ -80,15 +79,15 @@ describe("estimateToolSchemaTokens", () => {
 		expect(breakdown.toolsTokens).toBeGreaterThan(0);
 	});
 
-	it("skips a parameters value that stringifies to undefined instead of crashing", () => {
+	it("skips a parameters value that stringifies to undefined, counting exactly name + description", () => {
 		// A plain function is neither an arktype schema nor JSON-serializable:
-		// the independent unserializable-schema fallback must skip it and still
-		// count the tool's own strings.
+		// the independent unserializable-schema fallback must skip it while the
+		// tool's own strings still contribute their exact token share.
 		const estimate = estimateToolSchemaTokens(
 			[{ name: "odd", description: "odd tool", parameters: function bareSchema() {} } as never],
 			tokenizer,
 		);
-		expect(estimate).toBeGreaterThan(0);
+		expect(estimate).toBe(estimateToolSchemaTokens([{ name: "odd", description: "odd tool" } as never], tokenizer));
 	});
 
 	it("skips non-string name/description fragments", () => {


### PR DESCRIPTION
## What

`applyToolProxy` binds every function-valued property of a wrapped tool so methods keep `this`. Its guard assumed a callable ArkType `Type` "lacks `Function.prototype.bind`" — true for omptype, **false for a real arktype `Type`** (e.g. from an extension's own bundled `arktype` copy). Such a `parameters` schema got `.bind(tool)`-ed into a bare bound function with no schema surface (`toJsonSchema`/`assert`/own keys). Downstream, `isArkSchema` no longer recognized it, `toolWireSchema` returned the function itself, `JSON.stringify(fn)` produced `undefined`, and the poisoned fragment array was fatal inside the native tokenizer:

```
Error: Failed to measure JavaScript string
    at countTokens (unknown)
    at estimateToolSchemaTokens (modes/utils/context-usage.ts)
    at computeNonMessageBreakdown ...
    at getContextBreakdown (session/session-stats.ts)
    at runPrePromptCompactionIfNeeded (session/session-maintenance.ts)
```

This killed **every read-only subagent (`scout`, restricted-tool custom agents) at its first prompt, 100% reproducible** when such an extension is installed. Only read-only seats die because without the `write` tool, extension/MCP tools stay first-class in `state.tools` instead of being compressed to `xd://` devices — so the poisoned schema enters pre-prompt token accounting.

Changes:
- `tool-proxy.ts`: callable schemas (`isArkSchema`) pass through unbound; only genuine methods are bound.
- `context-usage.ts` (`estimateToolSchemaTokens`): only push real strings — non-string name/description or a wire schema that stringifies to `undefined` can never poison `countTokens`, so token accounting cannot take down a session on an exotic schema again.
- Regression test with a bind-capable, external-arktype-shaped callable schema (fails on the old code, passes with the fix). The existing "preserves schema callables" test only covered omptype, whose `Type` has no `bind` — which is why the old guard looked safe.

## Why

Bundled read-only agents were unusable on any setup with an extension registering arktype-parameter tools (reproduced with pi-lens 4.0.0: `lens_diagnostics`, `module_report`, `read_symbol`, …). The crash happens before the first provider request, so the subagent dies with an opaque native error and zero output.

## Testing

- Reproduced the crash on v17.4.0 from source (`bun cli.ts -p` spawning a `scout`), confirmed the exact undefined fragments via instrumentation, then confirmed scout and a restricted-tool custom agent complete end-to-end with the fix — both from source and from a compiled binary.
- `bun test packages/coding-agent/test/extensibility/tool-proxy.test.ts packages/coding-agent/test/modes/context-usage.test.ts` — 13 pass, 0 fail; the new regression test fails without the `tool-proxy.ts` change.
- `bun run check:ts` (workspace biome + tsgo) passes; no Rust changes.

---

- [x] `bun check` passes (`check:ts`; no Rust touched)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)