### PR TITLE
fix(coding-agent): account eval subagent output in turn budget

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed eval-spawned subagent output being omitted from per-turn output-token budgets, including failed and isolated runs ([#9187](https://github.com/can1357/oh-my-pi/issues/9187)).
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -124,6 +124,8 @@ export interface IsolatedRunOptions {
 	 * build a result shape consistent with their non-isolated path.
 	 */
 	buildFailureResult: (err: unknown) => SingleResult;
+	/** Observe the real child result before post-run isolation work. */
+	onSubprocessResult?: (result: SingleResult) => void;
 }
 
 async function writeIsolationPatch(
@@ -172,6 +174,7 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 				opts.baseOptions.onCleanupDeferred?.(completion);
 			},
 		});
+		opts.onSubprocessResult?.(result);
 		if (deferredCleanup) return result;
 		if (opts.mergeMode === "branch" && result.exitCode === 0) {
 			try {

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -555,6 +555,10 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 	let requiresRecoveryArtifacts = false;
 	let completedSuccessfully = false;
 	let deferredCleanup: Promise<void> | undefined;
+	const onSubprocessResult =
+		request.invocationKind === "eval"
+			? (result: SingleResult) => request.session.recordEvalSubagentUsage?.(result.usage?.output ?? 0)
+			: undefined;
 	try {
 		const id = await reserveStructuredSubagentId(request.session, {
 			...request.identity,
@@ -578,19 +582,24 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 				);
 			}
 		}
-		const result = !isolationContext
-			? await runSubprocess(baseOptions)
-			: await runIsolatedSubprocess({
-					baseOptions,
-					context: isolationContext,
-					preferredBackend: parseIsolationMode(request.session.settings.get("task.isolation.mode")),
-					agentId: id,
-					mergeMode: policy.mergeMode,
-					artifactsDir: lease.artifactsDir,
-					description: trimToUndefined(request.identity?.label),
-					buildCommitMessage: makeIsolationCommitMessage(request.session),
-					buildFailureResult: buildFailureResult(request, policy, id, Date.now()),
-				});
+		let result: SingleResult;
+		if (!isolationContext) {
+			result = await runSubprocess(baseOptions);
+			onSubprocessResult?.(result);
+		} else {
+			result = await runIsolatedSubprocess({
+				baseOptions,
+				context: isolationContext,
+				preferredBackend: parseIsolationMode(request.session.settings.get("task.isolation.mode")),
+				agentId: id,
+				mergeMode: policy.mergeMode,
+				artifactsDir: lease.artifactsDir,
+				description: trimToUndefined(request.identity?.label),
+				buildCommitMessage: makeIsolationCommitMessage(request.session),
+				buildFailureResult: buildFailureResult(request, policy, id, Date.now()),
+				onSubprocessResult,
+			});
+		}
 		attachStructuredOutputMetadata(result, policy.schema);
 		requiresRecoveryArtifacts =
 			policy.isIsolated &&

--- a/packages/coding-agent/test/eval/agent-bridge.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge.test.ts
@@ -3,8 +3,11 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { runEvalAgent } from "@oh-my-pi/pi-coding-agent/eval/agent-bridge";
 import type { LocalProtocolOptions } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as taskDiscovery from "@oh-my-pi/pi-coding-agent/task/discovery";
 import * as taskExecutor from "@oh-my-pi/pi-coding-agent/task/executor";
+import * as isolationRunner from "@oh-my-pi/pi-coding-agent/task/isolation-runner";
+import { runStructuredSubagent } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
 import type { AgentDefinition, SingleResult, StructuredSubagentOutput } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
@@ -24,6 +27,28 @@ function createResult(overrides: Partial<SingleResult> = {}): SingleResult {
 		requests: 0,
 		...overrides,
 	};
+}
+
+function createUsage(output: number) {
+	return {
+		input: 9_000,
+		output,
+		cacheRead: 8_000,
+		cacheWrite: 7_000,
+		totalTokens: 24_000 + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createBudgetSession(sessionManager: SessionManager): ToolSession {
+	return {
+		cwd: "/tmp",
+		settings: Settings.isolated(),
+		getSessionSpawns: () => "*",
+		getSessionFile: () => null,
+		getTurnBudget: () => sessionManager.getTurnBudget(),
+		recordEvalSubagentUsage: (output: number) => sessionManager.recordEvalSubagentOutput(output),
+	} as unknown as ToolSession;
 }
 
 describe("runEvalAgent", () => {
@@ -92,5 +117,118 @@ describe("runEvalAgent", () => {
 
 		expect(result.data).toEqual({ status: "ok" });
 		expect(result.details).toMatchObject({ structured: true, schemaSource: "agent", schemaMode: "strict" });
+	});
+
+	it("updates the real turn budget by output tokens only", async () => {
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Handle task",
+			source: "bundled",
+		};
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.beginTurnBudget(100_000, true);
+		vi.spyOn(taskDiscovery, "discoverAgents").mockResolvedValue({ agents: [agent], projectAgentsDir: null });
+		vi.spyOn(taskExecutor, "runSubprocess").mockResolvedValue(createResult({ usage: createUsage(1_234) }));
+
+		await runEvalAgent({ prompt: "do work", agent: "task" }, { session: createBudgetSession(sessionManager) });
+
+		expect(sessionManager.getTurnBudget()).toEqual({
+			total: 100_000,
+			spent: 1_234,
+			hard: true,
+		});
+	});
+
+	it("charges output exactly once when an eval-spawned subagent returns an error", async () => {
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Handle task",
+			source: "bundled",
+		};
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.beginTurnBudget(100_000, false);
+		vi.spyOn(taskDiscovery, "discoverAgents").mockResolvedValue({ agents: [agent], projectAgentsDir: null });
+		vi.spyOn(taskExecutor, "runSubprocess").mockResolvedValue(
+			createResult({
+				exitCode: 1,
+				error: "agent failed",
+				stderr: "agent failed",
+				usage: createUsage(2_345),
+			}),
+		);
+
+		await expect(
+			runEvalAgent({ prompt: "do work", agent: "task" }, { session: createBudgetSession(sessionManager) }),
+		).rejects.toThrow("agent failed");
+
+		expect(sessionManager.getTurnBudget().spent).toBe(2_345);
+	});
+
+	it("charges isolated output before a later cleanup failure", async () => {
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Handle task",
+			source: "bundled",
+		};
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.beginTurnBudget(100_000, true);
+		const session = createBudgetSession(sessionManager);
+		session.settings.set("task.isolation.mode", "auto");
+		vi.spyOn(taskDiscovery, "discoverAgents").mockResolvedValue({ agents: [agent], projectAgentsDir: null });
+		vi.spyOn(isolationRunner, "prepareIsolationContext").mockResolvedValue({
+			repoRoot: "/tmp",
+			baseline: {
+				root: {
+					repoRoot: "/tmp",
+					headCommit: "base",
+					staged: "",
+					unstaged: "",
+					untracked: [],
+					untrackedPatch: "",
+				},
+				nested: [],
+			},
+		});
+		vi.spyOn(isolationRunner, "runIsolatedSubprocess").mockImplementation(async options => {
+			options.onSubprocessResult?.(createResult({ usage: createUsage(4_567) }));
+			throw new Error("cleanup failed");
+		});
+
+		await expect(runEvalAgent({ prompt: "do work", agent: "task", isolated: true }, { session })).rejects.toThrow(
+			"cleanup failed",
+		);
+
+		expect(sessionManager.getTurnBudget().spent).toBe(4_567);
+	});
+
+	it("does not route ordinary task subagents through the eval budget accumulator", async () => {
+		const agent: AgentDefinition = {
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Handle task",
+			source: "bundled",
+		};
+		const recordEvalSubagentUsage = vi.fn();
+		const session = {
+			cwd: "/tmp",
+			settings: Settings.isolated(),
+			getSessionSpawns: () => "*",
+			getSessionFile: () => null,
+			recordEvalSubagentUsage,
+		} as unknown as ToolSession;
+		vi.spyOn(taskDiscovery, "discoverAgents").mockResolvedValue({ agents: [agent], projectAgentsDir: null });
+		vi.spyOn(taskExecutor, "runSubprocess").mockResolvedValue(createResult({ usage: createUsage(3_456) }));
+
+		await runStructuredSubagent({
+			session,
+			invocationKind: "task",
+			assignment: "do work",
+			agent: "task",
+		});
+
+		expect(recordEvalSubagentUsage).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
 import {
 	applyEligibleNestedPatches,
@@ -204,6 +205,78 @@ describe("runIsolatedSubprocess", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("observes real child usage before fallible isolation cleanup", async () => {
+		const childResult = result({
+			exitCode: 1,
+			error: "agent failed",
+			usage: {
+				input: 9_000,
+				output: 1_234,
+				cacheRead: 8_000,
+				cacheWrite: 7_000,
+				totalTokens: 25_234,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		});
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.beginTurnBudget(100_000, true);
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: "/repo/isolated",
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(childResult);
+		vi.spyOn(worktreeModule, "cleanupIsolation").mockRejectedValue(new Error("cleanup failed"));
+		const onSubprocessResult = vi.fn((child: SingleResult) => {
+			sessionManager.recordEvalSubagentOutput(child.usage?.output ?? 0);
+		});
+
+		await expect(
+			runIsolatedSubprocess({
+				baseOptions: {
+					cwd: "/repo",
+					agent: {
+						name: "task",
+						description: "Task agent",
+						systemPrompt: "test",
+						source: "bundled",
+					},
+					task: "Do work",
+					index: 0,
+					id: "UsageAccounting",
+				},
+				context: {
+					repoRoot: "/repo",
+					baseline: {
+						root: {
+							repoRoot: "/repo",
+							headCommit: "base",
+							staged: "",
+							unstaged: "",
+							untracked: [],
+							untrackedPatch: "",
+						},
+						nested: [],
+					},
+				},
+				preferredBackend: undefined,
+				agentId: "UsageAccounting",
+				mergeMode: "patch",
+				artifactsDir: "/artifacts",
+				buildFailureResult: error => result({ exitCode: 1, error: String(error) }),
+				onSubprocessResult,
+			}),
+		).rejects.toThrow("cleanup failed");
+
+		expect(onSubprocessResult).toHaveBeenCalledTimes(1);
+		expect(sessionManager.getTurnBudget()).toEqual({
+			total: 100_000,
+			spent: 1_234,
+			hard: true,
+		});
 	});
 });
 


### PR DESCRIPTION
## Repro
A mocked eval child returned a `SingleResult` with `usage.output = 1234`; `bun test packages/coding-agent/test/eval/agent-bridge.test.ts` failed because `recordEvalSubagentUsage` received 0 calls instead of 1.

## Cause
`runStructuredSubagent` in `packages/coding-agent/src/task/structured-subagent.ts` returned eval child results without forwarding `usage.output` to the session budget callback. Isolated execution also kept the real child result inside `runIsolatedSubprocess` until after fallible worktree cleanup.

## Fix
- Record eval-only child usage immediately after `runSubprocess` returns.
- Expose the real isolated child result before post-run capture and cleanup, then route it through the same eval-only accounting callback.
- Cover real `SessionManager` state, child failures, isolated cleanup failures, and ordinary task-path isolation.
- Document the corrected budget behavior in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/eval/agent-bridge.test.ts packages/coding-agent/test/task/isolation-runner.test.ts` passed: 21 tests, 67 assertions. `bun run check:types` passed in `packages/coding-agent`. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #9187