### PR TITLE
fix(todo): parse escaped-bracket checklist items in /todo edit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
+- Fixed `/todo edit` failing with "Could not parse Markdown" when checklist items had backslash-escaped brackets (`- \[x\]`), which editors and markdown renderers commonly emit ([#9188](https://github.com/can1357/oh-my-pi/issues/9188)).
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.
 - Fixed external editor spawning (Ctrl+G, plan review, `/todo edit`) failing to attach to visible terminals for editors like `emacsclient`.

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -683,7 +683,10 @@ export function markdownToPhases(md: string): { phases: TodoPhase[]; errors: str
 			continue;
 		}
 
-		const taskMatch = /^[-*+]\s*\[(.?)\]\s+(.+?)\s*$/.exec(trimmed);
+		// Tolerate backslash-escaped brackets (`- \[x\]`): some editors and
+		// markdown serializers escape `[` (and `]`) when round-tripping, yet the
+		// line still renders as a normal `[x]` checkbox. Accept either form.
+		const taskMatch = /^[-*+]\s*\\?\[(.?)\\?\]\s+(.+?)\s*$/.exec(trimmed);
 		if (taskMatch) {
 			if (!currentPhase) {
 				currentPhase = { name: "Todos", tasks: [] };

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -310,6 +310,21 @@ describe("TodoTool operations", () => {
 		expect(parsedA?.blocker).toBe("x");
 	});
 
+	it("parses checklist items with backslash-escaped brackets from /todo edit", () => {
+		// Editors/serializers (e.g. content pasted from a markdown renderer) escape
+		// `[` and `]`; the line still renders as a checkbox, so it must parse rather
+		// than error out and drop the user's edits (issue #9188).
+		const md = ["# Todos", "* \\[x] first", "- \\[ \\] second", "+ \\[/\\] third"].join("\n");
+		const { phases, errors } = markdownToPhases(md);
+		expect(errors).toEqual([]);
+		const tasks = phases[0]?.tasks ?? [];
+		expect(tasks).toEqual([
+			{ content: "first", status: "completed" },
+			{ content: "second", status: "pending" },
+			{ content: "third", status: "in_progress" },
+		]);
+	});
+
 	it("normalizes a multi-line blocker reason so the markdown round-trip survives", async () => {
 		const tool = new TodoTool(createSession());
 		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a"] }] });


### PR DESCRIPTION
## Repro
Running `/todo edit` and saving a checklist whose brackets are backslash-escaped — e.g. `* \[x] 审阅议题与现有仓库` — fails with `Error: Could not parse Markdown: Line N: unrecognized syntax "* \[x] ..."`, and the edits are discarded. Verified by calling `markdownToPhases` on markdown containing `* \[x] ...` lines: every task line lands in the `errors` array and no tasks are parsed.

## Cause
`markdownToPhases` in `packages/coding-agent/src/tools/todo.ts` matched checklist items with `/^[-*+]\s*\[(.?)\]\s+(.+?)\s*$/`, which requires bare `[`/`]`. Editors and markdown serializers commonly escape brackets (`\[x\]` / `\[x]`), which still render as `[x]` checkboxes; those lines miss the regex and fall through to the `unrecognized syntax` error path, so `/todo edit` rejects the whole document.

## Fix
- Allow an optional backslash before each bracket in the task-line regex (`/^[-*+]\s*\\?\[(.?)\\?\]\s+(.+?)\s*$/`), so bare, half-escaped, and fully-escaped forms all parse identically.
- Added a regression test in `packages/coding-agent/test/tools/todo.test.ts` covering `* \[x]`, `- \[ \]`, and `+ \[/\]`.
- Changelog entry under `[Unreleased] › Fixed`.

## Verification
`bun test test/tools/todo.test.ts` → 73 pass, 0 fail. Manually confirmed the reporter's exact input now parses to three tasks with no errors. Fixes #9188