### PR TITLE
fix(task): stop wall-clock timer rewriting committed subagent outcomes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
+- Fixed an aggressive `task.maxRuntimeMs` mislabeling committed subagent outcomes: a budget-killed run is no longer reported as a runtime-limit timeout, and a subagent that yielded a complete result before the deadline is no longer reported as aborted when teardown crosses the deadline ([#9191](https://github.com/can1357/oh-my-pi/issues/9191)).
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.
 - Fixed external editor spawning (Ctrl+G, plan review, `/todo edit`) failing to attach to visible terminals for editors like `emacsclient`.

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1100,12 +1100,6 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	};
 
 	const requestAbort = (reason: AbortReason) => {
-		if (reason === "timeout") {
-			runtimeLimitExceeded = true;
-		}
-		if (reason === "budget") {
-			budgetLimitExceeded = true;
-		}
 		if (abortSent) {
 			// Shutdown is a superseding external abort: a process teardown that
 			// races a self-inflicted budget hard-abort must still follow the
@@ -1127,6 +1121,19 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			return;
 		}
 		if (resolved) return;
+		// Limit flags must stay below the abortSent/resolved guards, next to the
+		// abortReason they mirror. The wall-clock timer can fire during teardown —
+		// after a budget hard-abort or a committed yield has already settled the
+		// run — and resolveAbortReasonText/finalizeRunResult read these flags
+		// (not abortReason), so a post-commitment timeout must not set them or it
+		// rewrites the real outcome (budget kill mislabeled, completed yield tagged
+		// aborted).
+		if (reason === "timeout") {
+			runtimeLimitExceeded = true;
+		}
+		if (reason === "budget") {
+			budgetLimitExceeded = true;
+		}
 		abortSent = true;
 		abortReason = reason;
 		abortController.abort();

--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -734,4 +734,121 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		// consumer's assignment is a straight copy, so undefined is acceptable.
 		expect(result.contextWindow).toBeUndefined();
 	});
+
+	it("attributes a budget hard-abort to the budget, not a timer that fires during teardown", async () => {
+		// softRequestBudget=1 -> stop at 1.5 requests, hard abort at 1.5 + grace.
+		// The child burns 8 requests immediately, so the budget kills the run at
+		// t~0. maxRuntimeMs=400 then fires while the budget abort's teardown is
+		// still in flight (abort() holds the run open past the deadline). The
+		// wall-clock timer must not rewrite the already-committed budget outcome.
+		const settings = Settings.isolated({ "task.softRequestBudget": 1, "task.maxRuntimeMs": 400 });
+		const { promise: hang, resolve: releaseHang } = Promise.withResolvers<void>();
+		let listenerRef: ((event: AgentSessionEvent) => void) | undefined;
+		let abortCount = 0;
+		const session: Partial<AgentSession> = {
+			setIrcWakeTurnObserver: () => {},
+			subscribeRunState: () => () => {},
+			state: { messages: [] } as never,
+			agent: { state: { systemPrompt: ["test"] } } as never,
+			extensionRunner: undefined as never,
+			sessionManager: { appendSessionInit: () => {} } as never,
+			getActiveToolNames: () => ["read", "yield"],
+			getEnabledToolNames: () => ["read", "yield"],
+			setActiveToolsByName: async () => {},
+			subscribe: (listener: (event: AgentSessionEvent) => void) => {
+				listenerRef = listener;
+				return () => {};
+			},
+			hasPendingAsyncWork: () => false,
+			prompt: async () => {
+				for (let i = 0; i < 8; i++) {
+					listenerRef?.({
+						type: "message_end",
+						message: { role: "assistant", content: [{ type: "text", text: `step ${i}` }] },
+					} as unknown as AgentSessionEvent);
+				}
+				await hang;
+				return true;
+			},
+			waitForIdle: async () => {
+				await hang;
+			},
+			getLastAssistantMessage: () => undefined,
+			abort: async () => {
+				abortCount += 1;
+				// Genuine delay: the defect is the real interleaving between the
+				// executor's setTimeout(maxRuntimeMs) and its async teardown, so the
+				// teardown must outlast the deadline against the real clock. Fake
+				// timers would dictate that ordering instead of observing it.
+				await Bun.sleep(1500);
+				releaseHang();
+			},
+			dispose: async () => {},
+		};
+		mockCreateAgentSession(session as AgentSession);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-budget-then-timer", settings });
+
+		expect(abortCount).toBeGreaterThanOrEqual(1);
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toContain("Soft request budget exceeded");
+		expect(result.abortReason).not.toContain("runtime limit exceeded");
+	});
+
+	it("does not flip a committed pre-deadline yield to an aborted timeout", async () => {
+		// The child yields a full report at t~0, well inside the 400ms budget.
+		// Post-yield teardown then runs past the deadline; a timer that fires
+		// after the outcome is committed must be a no-op — the run succeeded.
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 400 });
+		let listenerRef: ((event: AgentSessionEvent) => void) | undefined;
+		let abortCount = 0;
+		const session: Partial<AgentSession> = {
+			setIrcWakeTurnObserver: () => {},
+			subscribeRunState: () => () => {},
+			state: { messages: [] } as never,
+			agent: { state: { systemPrompt: ["test"] } } as never,
+			extensionRunner: undefined as never,
+			sessionManager: { appendSessionInit: () => {} } as never,
+			getActiveToolNames: () => ["read", "yield"],
+			getEnabledToolNames: () => ["read", "yield"],
+			setActiveToolsByName: async () => {},
+			subscribe: (listener: (event: AgentSessionEvent) => void) => {
+				listenerRef = listener;
+				return () => {};
+			},
+			hasPendingAsyncWork: () => false,
+			prompt: async () => {
+				listenerRef?.({
+					type: "tool_execution_end",
+					toolCallId: "tool-yield",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { finding: "complete report" } },
+					},
+					isError: false,
+				} as AgentSessionEvent);
+				return true;
+			},
+			waitForIdle: async () => {},
+			getLastAssistantMessage: () => undefined,
+			abort: async () => {
+				abortCount += 1;
+				// Genuine delay: post-yield teardown must outlast the real
+				// setTimeout(maxRuntimeMs) so the timer fires after the yield has
+				// committed. See the budget test above for why fake timers do not fit.
+				await Bun.sleep(1500);
+			},
+			dispose: async () => {},
+		};
+		mockCreateAgentSession(session as AgentSession);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-yield-then-timer", settings });
+
+		expect(abortCount).toBeGreaterThanOrEqual(1);
+		expect(result.extractedToolData?.yield).toBeDefined();
+		expect(result.aborted).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.abortReason).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Repro
With an aggressively-set `task.maxRuntimeMs`, a wall-clock timer that fires *after* a subagent run's outcome is already committed rewrites that outcome. Two failures, one root cause: (1) a subagent killed by the soft request budget is reported as `Subagent runtime limit exceeded (task.maxRuntimeMs=N)` — wrong cause; (2) a subagent that committed a complete, successful `yield` before the deadline is reported as `aborted: true`, `exitCode: 1`. Both need only that session teardown outlive the remaining wall-clock slack. Reproduced against the default branch with the reporter's stub harness (`bun test test/task/executor-wall-clock.test.ts`).

## Cause
In `createSubagentRunMonitor.requestAbort` (`packages/coding-agent/src/task/executor.ts`), `runtimeLimitExceeded` and `budgetLimitExceeded` were assigned *above* the `abortSent`/`resolved` guards. `resolveAbortReasonText` and `finalizeRunResult` read those raw flags (with `runtimeLimitExceeded` at top priority) rather than the guard-protected `abortReason`. So a `requestAbort("timeout")` from the timer during teardown — when `abortSent` was already set by a budget hard-abort, or when a yield had committed and only the teardown `sessionAbortController.abort()` had run — still set `runtimeLimitExceeded`, poisoning the reported cause and flipping the exit/abort status. The timer's own `if (!resolved)` guard does not close the window: `resolved` flips only in `monitor.finish()`, which runs after teardown completes.

## Fix
- Move the `runtimeLimitExceeded`/`budgetLimitExceeded` writes below the `abortSent`/`resolved` guards in `requestAbort`, giving the flags the same protection `abortReason` already had. A post-commitment `requestAbort("timeout")` becomes a no-op; a genuine in-flight timeout still sets the flag, aborts, and reports a timeout.
- Add two regression tests to `test/task/executor-wall-clock.test.ts`: a budget hard-abort attributed to the budget (not a teardown timer), and a committed pre-deadline yield that stays `aborted: false` / `exitCode: 0`. Both exercise the real `setTimeout(maxRuntimeMs)`/teardown interleaving, matching the file's existing real-timer contract.
- Changelog entry under `[Unreleased]` → Fixed.

## Verification
`bun test test/task/` → 361 pass / 0 fail (was 359 pass / 2 fail with the new tests on the unpatched code). The existing regression test "a late successful yield does not flip a timed-out run to success" still passes, since there the timeout fires first. Fixes #9191