### PR TITLE
fix(coding-agent): fall back to text when image clipboard read throws

### DIFF
--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -318,7 +318,17 @@ export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
 		return null;
 	}
 
-	return (await nativeReadImageFromClipboard()) ?? null;
+	try {
+		return (await nativeReadImageFromClipboard()) ?? null;
+	} catch (error) {
+		// Some selection owners make the native image read throw instead of
+		// reporting "no image" — e.g. an xclip-written text-only selection
+		// (arboard: "Unknown error ... incorrect type received from clipboard").
+		// Treat a failed image read as "no image" so the caller's smart-paste
+		// text fallback still delivers the clipboard content.
+		logger.warn("clipboard: failed to read clipboard image", { error: String(error) });
+		return null;
+	}
 }
 
 /**

--- a/packages/coding-agent/test/utils/clipboard.test.ts
+++ b/packages/coding-agent/test/utils/clipboard.test.ts
@@ -197,6 +197,21 @@ describe("readImageFromClipboard dispatch", () => {
 		expect(nativeSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("treats a throwing native image read as no image on linux with a display", async () => {
+		// Regression: an xclip-written text-only selection makes arboard's
+		// image read throw ("Unknown error ... incorrect type received from
+		// clipboard") instead of reporting no image. readImageFromClipboard
+		// must not propagate that — the smart-paste text fallback depends on
+		// a null return.
+		setPlatform("linux");
+		process.env.DISPLAY = ":0";
+		vi.spyOn(native, "readImageFromClipboard").mockRejectedValue(
+			new Error("Unknown error while interacting with the clipboard: incorrect type received from clipboard"),
+		);
+
+		expect(await readImageFromClipboard()).toBeNull();
+	});
+
 	it.each(["image/png", "image/jpeg", "image/gif", "image/webp"] as const)(
 		"reads %s bytes through wl-paste before the native bridge on Wayland-only Linux",
 		async mimeType => {


### PR DESCRIPTION
**Bug:** Smart paste (`Ctrl+V` → `app.clipboard.pasteImage`) reads the clipboard image first, then falls back to text. On X11, when the selection owner is `xclip` with a text-only payload — e.g. text written by a voxtype-style `xclip -selection clipboard` — arboard 3.6.1's `get_image()` **throws** `Unknown error while interacting with the clipboard: incorrect type received from clipboard` instead of returning `ContentNotAvailable`. The throw escapes `readImageFromClipboard` and aborts `handleImagePaste` with "Failed to read clipboard", dropping dictated text entirely.

Verified empirically in Xvfb: `xclip -selection clipboard` + text → arboard `get_image()` throws the above; `get_text()` succeeds. Other owners (browsers, kitty, most GUI apps) return `ContentNotAvailable` → `null` → text fallback works, which is why only xclip-written clipboards fail.

**Fix:** `readImageFromClipboard` catches a throwing native image read and returns `null`, preserving the "no image" contract the smart-paste text fallback relies on. Logs the failure.

**Tests:** Added regression test (linux + DISPLAY, native read rejects → resolves null); full clipboard util suite passes (22 tests).
