### PR TITLE
fix(ai): retry peer-rotated oauth credential during preflight

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
+- Fixed OAuth preflight refresh stranding a peer-rotated credential: when a concurrent process rotated a rotating-refresh-token grant (e.g. Anthropic) during preflight, the resolve pass skipped the freshly reloaded row and failed the request with no credentials for single-account setups ([#9194](https://github.com/can1357/oh-my-pi/issues/9194)).
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.
 - Fixed Antigravity OAuth login handling for project discovery and free-tier onboarding against Cloud Code Assist endpoints.
 - Fixed provider-detected OAuth access token expiration terminating active turns instead of automatically refreshing credentials and replaying the request.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4965,13 +4965,25 @@ export class AuthStorage {
 						// so if this branch only blocked the row (like the transient case), the
 						// definitive failure would never reach `#tryOAuthCredential`'s own
 						// disable logic and the row would be retried forever instead of torn down.
-						await this.#disableDefinitiveOAuthFailure(
+						const outcome = await this.#disableDefinitiveOAuthFailure(
 							provider,
 							credentialId,
 							candidate.selection.credential,
 							candidate.selection.index,
 							errorMsg,
 						);
+						if (outcome !== "disabled") {
+							// A peer rotated this row (or won the disable CAS) between our
+							// snapshot and the refresh, so the helper reloaded storage and left
+							// the row intact — it now holds a valid, freshly rotated credential.
+							// Re-sync the candidate onto it and leave it eligible so the final
+							// pass retries with the live token instead of stranding it (mirrors
+							// #tryOAuthCredential's peer-rotated re-resolve).
+							if (credentialId !== undefined) {
+								this.#syncOAuthSelectionFromStore(provider, candidate.selection, credentialId);
+							}
+							return;
+						}
 					} else if (credentialId !== undefined) {
 						const latestIndex = this.#getStoredCredentials(provider).findIndex(
 							entry => entry.id === credentialId,

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4972,16 +4972,20 @@ export class AuthStorage {
 							candidate.selection.index,
 							errorMsg,
 						);
-						if (outcome !== "disabled") {
+						if (
+							outcome !== "disabled" &&
+							credentialId !== undefined &&
+							this.#syncOAuthSelectionFromStore(provider, candidate.selection, credentialId)
+						) {
 							// A peer rotated this row (or won the disable CAS) between our
-							// snapshot and the refresh, so the helper reloaded storage and left
-							// the row intact — it now holds a valid, freshly rotated credential.
+							// snapshot and the refresh; the helper reloaded storage and the row
+							// still exists, so it now holds a valid, freshly rotated credential.
 							// Re-sync the candidate onto it and leave it eligible so the final
 							// pass retries with the live token instead of stranding it (mirrors
-							// #tryOAuthCredential's peer-rotated re-resolve).
-							if (credentialId !== undefined) {
-								this.#syncOAuthSelectionFromStore(provider, candidate.selection, credentialId);
-							}
+							// #tryOAuthCredential's peer-rotated re-resolve). If the peer instead
+							// deleted/disabled the row, the re-sync fails and we fall through to
+							// preflightFailures — leaving a stale index could rebind the candidate
+							// to a sibling account with the wrong prefetched usage/plan.
 							return;
 						}
 					} else if (credentialId !== undefined) {

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -7,6 +7,7 @@ import {
 	AuthStorage,
 	type CredentialDisabledEvent,
 	SqliteAuthCredentialStore,
+	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
 import { removeWithRetries } from "../../utils/src/temp";
@@ -236,6 +237,111 @@ describe("AuthStorage OAuth refresh race", () => {
 		expect(stored).toHaveLength(2);
 		const oauth = stored.map(entry => entry.credential).filter(credential => credential.type === "oauth");
 		expect(oauth.map(credential => credential.refresh).sort()).toEqual(["refresh-a-rotated", "refresh-b-rotated"]);
+	});
+
+	test("preflight retries a peer-rotated credential instead of stranding it", async () => {
+		const staleExpires = Date.now() - 60_000;
+		const freshExpires = Date.now() + 60 * 60_000;
+
+		// A store WITHOUT durable-lease support: the lease path in
+		// #refreshOAuthCredentialUnshared wraps refresh in refreshStoredOAuthCredential,
+		// which absorbs a peer rotation itself. We want the definitive failure to reach
+		// #resolveOAuthSelection's own preflight catch so the "peer-rotated" outcome of
+		// #disableDefinitiveOAuthFailure is what's actually exercised.
+		const rows: StoredAuthCredential[] = [
+			{
+				id: 1,
+				provider: "unit-oauth-preflight-rotate",
+				credential: { type: "oauth", access: "stale-access", refresh: "stale-refresh", expires: staleExpires },
+				disabledCause: null,
+			},
+		];
+		const cache = new Map<string, { value: string; expiresAtSec: number }>();
+		const noLeaseStore: AuthCredentialStore = {
+			close() {},
+			listAuthCredentials(provider) {
+				return provider ? rows.filter(row => row.provider === provider) : rows;
+			},
+			updateAuthCredential(id, credential) {
+				const row = rows.find(entry => entry.id === id);
+				if (row) row.credential = credential;
+			},
+			deleteAuthCredential() {},
+			tryDisableAuthCredentialIfMatches() {
+				return false;
+			},
+			replaceAuthCredentialsForProvider() {
+				return rows;
+			},
+			upsertAuthCredentialForProvider() {
+				return rows;
+			},
+			deleteAuthCredentialsForProvider() {},
+			getCache(key) {
+				const entry = cache.get(key);
+				if (!entry) return null;
+				if (entry.expiresAtSec * 1000 <= Date.now()) return null;
+				return entry.value;
+			},
+			setCache(key, value, expiresAtSec) {
+				cache.set(key, { value, expiresAtSec });
+			},
+			cleanExpiredCache() {},
+		};
+
+		let refreshCalls = 0;
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-preflight-rotate",
+			name: "Unit OAuth Preflight Rotate",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: freshExpires };
+			},
+			async refreshToken(credentials) {
+				refreshCalls += 1;
+				if (credentials.refresh === "stale-refresh") {
+					// A peer completed its own refresh mid-flight and rotated the shared row;
+					// our stale refresh token is now dead (invalid_grant), but the persisted
+					// row holds the peer's freshly rotated credential.
+					rows[0]!.credential = {
+						type: "oauth",
+						access: "fresh-access-from-peer",
+						refresh: "fresh-refresh-from-peer",
+						expires: freshExpires,
+					};
+					throw new Error('HTTP 400 invalid_grant {"error":"invalid_grant"}');
+				}
+				return credentials;
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+
+		const events: CredentialDisabledEvent[] = [];
+		const storage = new AuthStorage(noLeaseStore, {
+			onCredentialDisabled: event => {
+				events.push(event);
+			},
+		});
+		await storage.reload();
+
+		const apiKey = await storage.getApiKey("unit-oauth-preflight-rotate", "session-preflight-rotate");
+
+		// The single stored credential was peer-rotated during preflight refresh. The
+		// resolve pass must pick up the reloaded fresh credential instead of adding the
+		// candidate to preflightFailures and returning undefined.
+		expect(apiKey).toBe("fresh-access-from-peer");
+		expect(events).toHaveLength(0);
+		// Preflight refreshed once and threw; the final pass reuses the fresh token
+		// synced from the reloaded row rather than replaying a second refresh.
+		expect(refreshCalls).toBe(1);
+		const stored = noLeaseStore.listAuthCredentials("unit-oauth-preflight-rotate");
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.credential.type).toBe("oauth");
+		if (stored[0]?.credential.type === "oauth") {
+			expect(stored[0].credential.refresh).toBe("fresh-refresh-from-peer");
+		}
 	});
 
 	test("coalesces concurrent refreshes for the same credential", async () => {


### PR DESCRIPTION
## Repro
With one Anthropic-style OAuth credential in a shared store and two `AuthStorage` instances, instance A refreshes first and rotates the refresh token; instance B enters `#resolveOAuthSelection` with its stale snapshot, its preflight refresh gets `invalid_grant`, and `#disableDefinitiveOAuthFailure` returns `"peer-rotated"` after reloading the fresh row. B nonetheless strands the candidate and `getApiKey` returns `undefined`. Reproduced deterministically with a non-lease store (so the definitive failure reaches the preflight catch rather than being absorbed by `refreshStoredOAuthCredential`): `bun test test/auth-storage-oauth-refresh-race.test.ts -t "preflight retries a peer-rotated credential"` fails `expect(apiKey).toBe("fresh-access-from-peer")` (received `undefined`) before the fix.

## Cause
`#resolveOAuthSelection`'s eager preflight refresh (`packages/ai/src/auth-storage.ts`, definitive-failure branch) called `#disableDefinitiveOAuthFailure` but discarded its return value, then ran `preflightFailures.add(candidate)` unconditionally. The final candidate pass skips every `preflightFailures` entry, so on `"peer-rotated"`/`"cas-lost"` the exact row the helper had just reloaded a valid token into was excluded from all passes; single-credential setups fell through to `return undefined`. `#tryOAuthCredential` (the other call site) already honored the outcome, so the two sites diverged after `13d0dd3a`.

## Fix
- Capture the `#disableDefinitiveOAuthFailure` outcome at the preflight call site.
- Only `preflightFailures.add(candidate)` when the outcome is `"disabled"`.
- On `"peer-rotated"`/`"cas-lost"`, re-sync the candidate onto the reloaded row via `#syncOAuthSelectionFromStore` and leave it eligible, so the final pass retries with the live token (mirrors `#tryOAuthCredential`'s peer-rotated re-resolve) — no wasted second provider round-trip.
- Added a regression test in `test/auth-storage-oauth-refresh-race.test.ts` and a CHANGELOG entry.

## Verification
`bun test test/auth-storage-oauth-refresh-race.test.ts test/auth-storage-check-credentials.test.ts test/auth-storage-credential-disabled-event.test.ts` → 46 pass, 0 fail. New test fails before the fix (`apiKey` `undefined`) and passes after; `refreshCalls === 1` confirms the final pass reuses the synced token instead of replaying a refresh. Pre-publish `bun check` passed via the push gate. Fixes #9194