### PR TITLE
feat(coding-agent): configurable same-model retries before fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Settings menus now support click-to-toggle and drag-to-reorder for list items, as well as warning indicators and risk notes on sensitive options such as External Thinking.
 - Supervised process completion notices now render as compact single-line entries.
 - The todo HUD header now displays a consolidated progress bar showing task completion across all stages.
+- Retry fallback chains can now wait for a configurable number of same-model retries before switching providers or models.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1666,6 +1666,35 @@ export const SETTINGS_SCHEMA = {
 			description: "Allow retry recovery to switch to configured fallback models",
 		},
 	},
+	"retry.retryCurrentModelBeforeFallback": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Retry Before Model Fallback",
+			description: "Retry transient failures on the current model before switching to a configured fallback model",
+		},
+	},
+	"retry.retriesBeforeModelFallback": {
+		type: "number",
+		default: 3,
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Retries Before Model Fallback",
+			condition: "retryCurrentModelBeforeFallbackEnabled",
+			description:
+				"Number of same-model retries before switching to a configured fallback; limited by Retry Attempts",
+			options: [
+				{ value: "1", label: "1 retry" },
+				{ value: "2", label: "2 retries" },
+				{ value: "3", label: "3 retries" },
+				{ value: "5", label: "5 retries" },
+				{ value: "10", label: "10 retries" },
+			],
+		},
+	},
 	"retry.usageAwareFallback": {
 		type: "boolean",
 		default: false,
@@ -5889,6 +5918,8 @@ export interface RetrySettings {
 	baseDelayMs: number;
 	maxDelayMs: number;
 	modelFallback: boolean;
+	retryCurrentModelBeforeFallback: boolean;
+	retriesBeforeModelFallback: number;
 	usageAwareFallback: boolean;
 	usageReservePct: number;
 	usageReservePolicy: "confirm" | "auto" | "fail-closed";

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -139,6 +139,16 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	retryCurrentModelBeforeFallbackEnabled: () => {
+		try {
+			return (
+				Settings.instance.get("retry.modelFallback") === true &&
+				Settings.instance.get("retry.retryCurrentModelBeforeFallback") === true
+			);
+		} catch {
+			return false;
+		}
+	},
 	planModeEnabled: () => {
 		try {
 			return Settings.instance.get("plan.enabled");

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2020,7 +2020,7 @@ export class TurnRecovery {
 		// retry budget still bounds a genuinely stuck stream.
 		const thinkingLoop = AIError.is(id, AIError.Flag.ThinkingLoop);
 		const sameModelRetriesBeforeFallback = retrySettings.retryCurrentModelBeforeFallback
-			? Math.max(0, Math.floor(retrySettings.retriesBeforeModelFallback))
+			? Math.min(maxRetries, Math.max(0, Math.floor(retrySettings.retriesBeforeModelFallback)))
 			: 0;
 		if (
 			retryBudgetExhausted &&

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1918,7 +1918,7 @@ export class TurnRecovery {
 		const maxRetries = this.#isOpenRouterThinkingStreamClose(message)
 			? Math.min(retrySettings.maxRetries, 1)
 			: retrySettings.maxRetries;
-		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
+		let retryBudgetExhausted = this.#retryAttempt > maxRetries;
 
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
@@ -1993,6 +1993,10 @@ export class TurnRecovery {
 			}
 		}
 
+		if (usageLimitWaitMs === undefined && parsedRetryAfterMs !== undefined && parsedRetryAfterMs > delayMs) {
+			delayMs = parsedRetryAfterMs;
+		}
+
 		const allowModelFallback = options?.allowModelFallback !== false;
 		const currentModel = this.#host.model();
 		const currentSelector = currentModel
@@ -2017,12 +2021,21 @@ export class TurnRecovery {
 		const sameModelRetriesBeforeFallback = retrySettings.retryCurrentModelBeforeFallback
 			? Math.max(0, Math.floor(retrySettings.retriesBeforeModelFallback))
 			: 0;
+		if (
+			retryBudgetExhausted &&
+			this.#currentModelRetryAttempt < sameModelRetriesBeforeFallback &&
+			this.#activeRetryFallback &&
+			!classifierRefusal &&
+			!options?.hardErrorFallback
+		) {
+			this.#retryAttempt = 1;
+			retryBudgetExhausted = false;
+		}
 		const maxDelayMs = retrySettings.maxDelayMs;
 		const delayExceedsCap = maxDelayMs > 0 && delayMs > maxDelayMs;
 		const delayConfiguredFallback =
 			!options?.hardErrorFallback &&
 			!classifierRefusal &&
-			!retryBudgetExhausted &&
 			!delayExceedsCap &&
 			this.#currentModelRetryAttempt < sameModelRetriesBeforeFallback;
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {
@@ -2052,8 +2065,6 @@ export class TurnRecovery {
 			if (switchedModel) {
 				delayMs = 0;
 				this.#currentModelRetryAttempt = 0;
-			} else if (usageLimitWaitMs === undefined && parsedRetryAfterMs && parsedRetryAfterMs > delayMs) {
-				delayMs = parsedRetryAfterMs;
 			}
 		}
 
@@ -2075,9 +2086,10 @@ export class TurnRecovery {
 				this.resolveRetry(); // Resolve so waitForRetry() completes
 				return false;
 			}
-			// A fallback model gets a fresh retry budget. Credential rotation
-			// instead keeps the cumulative attempt count while bypassing the
-			// same-route budget: every distinct account must be tried first.
+			// A fallback model gets a fresh retry budget. Keep attempt 1 for the
+			// switch that is about to run so retry progress remains one-based;
+			// if that request fails, its first same-model retry is governed by
+			// the per-model counter instead of the exhausted prior route.
 			if (switchedModel) this.#retryAttempt = 1;
 		}
 		if ((classifierRefusal || accountPolicyDenial) && !switchedCredential && !switchedModel) {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -192,6 +192,7 @@ export class TurnRecovery {
 	readonly #host: TurnRecoveryHost;
 	#retryAbortController: AbortController | undefined;
 	#retryAttempt = 0;
+	#currentModelRetryAttempt = 0;
 	#retryPromise: Promise<void> | undefined;
 	#retryResolve: (() => void) | undefined;
 	#activeRetryFallback: ActiveRetryFallbackState | undefined;
@@ -2011,11 +2012,14 @@ export class TurnRecovery {
 		const sameModelRetriesBeforeFallback = retrySettings.retryCurrentModelBeforeFallback
 			? Math.max(0, Math.floor(retrySettings.retriesBeforeModelFallback))
 			: 0;
+		const maxDelayMs = retrySettings.maxDelayMs;
+		const delayExceedsCap = maxDelayMs > 0 && delayMs > maxDelayMs;
 		const delayConfiguredFallback =
 			!options?.hardErrorFallback &&
 			!classifierRefusal &&
 			!retryBudgetExhausted &&
-			this.#retryAttempt <= sameModelRetriesBeforeFallback;
+			!delayExceedsCap &&
+			this.#currentModelRetryAttempt < sameModelRetriesBeforeFallback;
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {
 			// A refusal chain stops at the retry budget: the exhausted-attempt
 			// last resort is for provider failures, not classifier decisions.
@@ -2042,6 +2046,7 @@ export class TurnRecovery {
 			}
 			if (switchedModel) {
 				delayMs = 0;
+				this.#currentModelRetryAttempt = 0;
 			} else if (usageLimitWaitMs === undefined && parsedRetryAfterMs && parsedRetryAfterMs > delayMs) {
 				delayMs = parsedRetryAfterMs;
 			}
@@ -2125,7 +2130,6 @@ export class TurnRecovery {
 		// subagent (or interactive session) silently hung. The original
 		// assistant error message is preserved in agent state so the caller
 		// can act on it.
-		const maxDelayMs = retrySettings.maxDelayMs;
 		if (maxDelayMs > 0 && delayMs > maxDelayMs && !switchedCredential && !switchedModel) {
 			await this.persistTerminalEmptyErrorTurn(message);
 			const attempt = this.#retryAttempt;
@@ -2139,6 +2143,9 @@ export class TurnRecovery {
 			this.#clearPendingRetryErrors();
 			this.resolveRetry();
 			return false;
+		}
+		if (!switchedCredential && !switchedModel) {
+			this.#currentModelRetryAttempt++;
 		}
 
 		await this.#recordPendingRetryError(message, id, { switchedCredential, switchedModel, delayMs });

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -248,6 +248,11 @@ export class TurnRecovery {
 		return this.#retryAttempt;
 	}
 
+	#resetRetryAttempts(): void {
+		this.#retryAttempt = 0;
+		this.#currentModelRetryAttempt = 0;
+	}
+
 	/** Promise settled when the active retry saga finishes. */
 	get retryPromise(): Promise<void> | undefined {
 		return this.#retryPromise;
@@ -377,14 +382,14 @@ export class TurnRecovery {
 			retryErrors,
 		});
 		this.#clearPendingRetryErrors();
-		this.#retryAttempt = 0;
+		this.#resetRetryAttempts();
 	}
 
 	/** Closes a failed retry saga when no compaction continuation took ownership. */
 	async onErrorSettledWithoutRetry(message: AssistantMessage, compaction: RecoveryCompactionResult): Promise<void> {
 		if (message.stopReason !== "error" || this.#retryAttempt === 0 || compaction.continuationScheduled) return;
 		const attempt = this.#retryAttempt;
-		this.#retryAttempt = 0;
+		this.#resetRetryAttempts();
 		await this.#host.emitSessionEvent({
 			type: "auto_retry_end",
 			success: false,
@@ -714,7 +719,7 @@ export class TurnRecovery {
 				finalError,
 			});
 			this.#clearPendingRetryErrors();
-			this.#retryAttempt = 0;
+			this.#resetRetryAttempts();
 			this.resolveRetry();
 			// A turn with no actionable output carries no transcript value, while its
 			// provider usage can anchor the next prompt at the full failed-request size
@@ -2066,7 +2071,7 @@ export class TurnRecovery {
 					retryErrors,
 				});
 				this.#clearPendingRetryErrors();
-				this.#retryAttempt = 0;
+				this.#resetRetryAttempts();
 				this.resolveRetry(); // Resolve so waitForRetry() completes
 				return false;
 			}
@@ -2093,7 +2098,7 @@ export class TurnRecovery {
 				});
 				this.#clearPendingRetryErrors();
 			}
-			this.#retryAttempt = 0;
+			this.#resetRetryAttempts();
 			this.resolveRetry();
 			return false;
 		}
@@ -2118,7 +2123,7 @@ export class TurnRecovery {
 				});
 				this.#clearPendingRetryErrors();
 			}
-			this.#retryAttempt = 0;
+			this.#resetRetryAttempts();
 			this.resolveRetry();
 			return false;
 		}
@@ -2133,7 +2138,7 @@ export class TurnRecovery {
 		if (maxDelayMs > 0 && delayMs > maxDelayMs && !switchedCredential && !switchedModel) {
 			await this.persistTerminalEmptyErrorTurn(message);
 			const attempt = this.#retryAttempt;
-			this.#retryAttempt = 0;
+			this.#resetRetryAttempts();
 			await this.#host.emitSessionEvent({
 				type: "auto_retry_end",
 				success: false,
@@ -2183,7 +2188,7 @@ export class TurnRecovery {
 			}
 			// Aborted during sleep - emit end event so UI can clean up
 			const attempt = this.#retryAttempt;
-			this.#retryAttempt = 0;
+			this.#resetRetryAttempts();
 			this.#retryAbortController = undefined;
 			await this.#host.emitSessionEvent({
 				type: "auto_retry_end",
@@ -2254,7 +2259,7 @@ export class TurnRecovery {
 	async #failRetryAfterLocalContinueError(message: AssistantMessage, error: unknown): Promise<void> {
 		if (this.#retryAttempt === 0) return;
 		const attempt = this.#retryAttempt;
-		this.#retryAttempt = 0;
+		this.#resetRetryAttempts();
 		const localError = error instanceof Error ? error.message : String(error);
 		await this.persistTerminalEmptyErrorTurn(message);
 		await this.#host.emitSessionEvent({
@@ -2377,7 +2382,7 @@ export class TurnRecovery {
 		}
 
 		// Reset retry budget for a fresh attempt
-		this.#retryAttempt = 0;
+		this.#resetRetryAttempts();
 
 		// Re-attempt the turn
 		this.#host.scheduleAgentContinue({ delayMs: 1 });

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2008,6 +2008,14 @@ export class TurnRecovery {
 		// contents, not model health (issue #8760). Keep it on the same model; the
 		// retry budget still bounds a genuinely stuck stream.
 		const thinkingLoop = AIError.is(id, AIError.Flag.ThinkingLoop);
+		const sameModelRetriesBeforeFallback = retrySettings.retryCurrentModelBeforeFallback
+			? Math.max(0, Math.floor(retrySettings.retriesBeforeModelFallback))
+			: 0;
+		const delayConfiguredFallback =
+			!options?.hardErrorFallback &&
+			!classifierRefusal &&
+			!retryBudgetExhausted &&
+			this.#retryAttempt <= sameModelRetriesBeforeFallback;
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {
 			// A refusal chain stops at the retry budget: the exhausted-attempt
 			// last resort is for provider failures, not classifier decisions.
@@ -2015,6 +2023,7 @@ export class TurnRecovery {
 				allowModelFallback &&
 				retrySettings.modelFallback &&
 				!thinkingLoop &&
+				!delayConfiguredFallback &&
 				!(retryBudgetExhausted && classifierRefusal)
 			) {
 				if (!classifierRefusal) {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1915,10 +1915,6 @@ export class TurnRecovery {
 		// (every rotation sets switchedCredential and skips it), so without
 		// this last resort a provider-wide usage cap never fails over to the
 		// configured chain.
-		const maxRetries = this.#isOpenRouterThinkingStreamClose(message)
-			? Math.min(retrySettings.maxRetries, 1)
-			: retrySettings.maxRetries;
-		let retryBudgetExhausted = this.#retryAttempt > maxRetries;
 
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
@@ -1929,6 +1925,11 @@ export class TurnRecovery {
 		const rateLimitReason = parseRateLimitReason(errorMessage);
 		const staleOpenAIResponsesReplayError = AIError.is(id, AIError.Flag.StaleResponsesItem);
 		const accountPolicyDenial = AIError.is(id, AIError.Flag.AccountPolicy);
+		const openRouterThinkingStreamClose = this.#isOpenRouterThinkingStreamClose(message);
+		const maxRetries = openRouterThinkingStreamClose
+			? Math.min(retrySettings.maxRetries, 1)
+			: retrySettings.maxRetries;
+		let retryBudgetExhausted = this.#retryAttempt > maxRetries;
 		const recordedUsageLimitOutcome = await this.#usageLimitOutcomes.get(message);
 		const parsedRetryAfterMs = this.#parseRetryAfterMsFromError(errorMessage);
 		let delayMs = staleOpenAIResponsesReplayError
@@ -2026,6 +2027,8 @@ export class TurnRecovery {
 			this.#currentModelRetryAttempt < sameModelRetriesBeforeFallback &&
 			this.#activeRetryFallback &&
 			!classifierRefusal &&
+			!accountPolicyDenial &&
+			!openRouterThinkingStreamClose &&
 			!options?.hardErrorFallback
 		) {
 			this.#retryAttempt = 1;
@@ -2036,6 +2039,7 @@ export class TurnRecovery {
 		const delayConfiguredFallback =
 			!options?.hardErrorFallback &&
 			!classifierRefusal &&
+			!accountPolicyDenial &&
 			!delayExceedsCap &&
 			this.#currentModelRetryAttempt < sameModelRetriesBeforeFallback;
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -680,6 +680,78 @@ describe("AgentSession retry delay cap", () => {
 		});
 	});
 
+	it("falls back immediately after the last Codex account denies the request by policy", async () => {
+		const primaryModel = getBundledModel("openai-codex", "gpt-5.6-sol");
+		const fallbackModel = getBundledModel("openai", "gpt-5.5");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled primary and fallback test models to exist");
+		}
+		const providerSessionId = "cyber-policy-fallback-after-rotation";
+
+		registerMockApi(RETRY_CAP_MOCK_API_SOURCE);
+		authStorage.setRuntimeApiKey("openai", "openai-fallback-key");
+		await authStorage.set("openai-codex", [{ type: "api_key", key: "codex-only-key" }]);
+
+		const requestedModels: string[] = [];
+		const primaryMock = createMockModel({
+			id: primaryModel.id,
+			provider: primaryModel.provider,
+			responses: [CYBER_POLICY_FAILURE],
+		});
+		const fallbackMock = createMockModel({
+			id: fallbackModel.id,
+			provider: fallbackModel.provider,
+			responses: [{ content: ["Recovered on policy-compatible fallback"], stopReason: "stop" }],
+		});
+		const agent = new Agent({
+			getApiKey: model => modelRegistry.resolver(model, providerSessionId),
+			sessionId: providerSessionId,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return requestedModel.provider === primaryModel.provider
+					? aiStream.streamSimple(primaryMock.model, context, options)
+					: aiStream.streamSimple(fallbackMock.model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.maxRetries": 3,
+			"retry.modelFallback": true,
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 3,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			providerSessionId,
+		});
+
+		await session.prompt("Continue authorized security work");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(session.model?.id).toBe(fallbackModel.id);
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered on policy-compatible fallback",
+		});
+	});
+
 	it("tries sibling Codex accounts before advisor model fallback on cyber-policy denials", async () => {
 		const mainModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const advisorModel = getBundledModel("openai-codex", "gpt-5.6-sol");
@@ -2123,6 +2195,8 @@ describe("AgentSession retry delay cap", () => {
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 10,
 			"retry.modelFallback": false,
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 3,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 		session = new AgentSession({

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -558,7 +558,7 @@ describe("AgentSession retry fallback", () => {
 			"retry.baseDelayMs": 1,
 			"retry.maxRetries": 1,
 			"retry.retryCurrentModelBeforeFallback": true,
-			"retry.retriesBeforeModelFallback": 1,
+			"retry.retriesBeforeModelFallback": 3,
 			"retry.fallbackChains": {
 				default: [
 					`${firstFallback.provider}/${firstFallback.id}`,

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -391,6 +391,72 @@ describe("AgentSession retry fallback", () => {
 		});
 	});
 
+	it("resets same-model retry allowance after a recovered turn", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		let primaryAttempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				primaryAttempts++;
+				mock.push(
+					primaryAttempts === 1 || primaryAttempts === 3
+						? { throw: "overloaded_error: provider returned error 503" }
+						: { content: [`Recovered primary attempt ${primaryAttempts}`] },
+				);
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 3,
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 1,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Recover once");
+		await session.waitForIdle();
+		await session.prompt("Recover independently");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+		]);
+		expect(session.model?.id).toBe(primaryModel.id);
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered primary attempt 4",
+		});
+	});
+
 	it("falls back immediately when the retry delay exceeds the configured cap", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -305,10 +305,11 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
-	it("retries the current model before applying a configured fallback when enabled", async () => {
+	it("retries every model before advancing through a configured fallback chain", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
-		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
-		if (!primaryModel || !fallbackModel) {
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !firstFallback || !secondFallback) {
 			throw new Error("Expected bundled test models to exist");
 		}
 
@@ -325,8 +326,8 @@ describe("AgentSession retry fallback", () => {
 			},
 			streamFn: (model, context, options) => {
 				requestedModels.push(`${model.provider}/${model.id}`);
-				if (model.provider === fallbackModel.provider && model.id === fallbackModel.id) {
-					mock.push({ content: ["Recovered on fallback"] });
+				if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+					mock.push({ content: ["Recovered on second fallback"] });
 				} else {
 					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				}
@@ -336,11 +337,14 @@ describe("AgentSession retry fallback", () => {
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 1,
-			"retry.maxRetries": 3,
+			"retry.maxRetries": 6,
 			"retry.retryCurrentModelBeforeFallback": true,
 			"retry.retriesBeforeModelFallback": 2,
 			"retry.fallbackChains": {
-				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+				default: [
+					`${firstFallback.provider}/${firstFallback.id}`,
+					`${secondFallback.provider}/${secondFallback.id}`,
+				],
 			},
 		});
 		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
@@ -355,26 +359,95 @@ describe("AgentSession retry fallback", () => {
 		});
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 
-		await session.prompt("Retry before fallback");
+		await session.prompt("Retry each model before fallback");
 		await session.waitForIdle();
 
 		expect(requestedModels).toEqual([
 			`${primaryModel.provider}/${primaryModel.id}`,
 			`${primaryModel.provider}/${primaryModel.id}`,
 			`${primaryModel.provider}/${primaryModel.id}`,
-			`${fallbackModel.provider}/${fallbackModel.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${secondFallback.provider}/${secondFallback.id}`,
 		]);
 		expect(fallbackAppliedEvents).toEqual([
 			{
 				type: "retry_fallback_applied",
 				from: `${primaryModel.provider}/${primaryModel.id}`,
-				to: `${fallbackModel.provider}/${fallbackModel.id}`,
+				to: `${firstFallback.provider}/${firstFallback.id}`,
+				role: "default",
+			},
+			{
+				type: "retry_fallback_applied",
+				from: `${firstFallback.provider}/${firstFallback.id}`,
+				to: `${secondFallback.provider}/${secondFallback.id}`,
 				role: "default",
 			},
 		]);
 		expect(getLastAssistantMessage(session).content).toContainEqual({
 			type: "text",
-			text: "Recovered on fallback",
+			text: "Recovered on second fallback",
+		});
+	});
+
+	it("falls back immediately when the retry delay exceeds the configured cap", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === fallbackModel.provider && model.id === fallbackModel.id) {
+					mock.push({ content: ["Recovered without waiting"] });
+				} else {
+					mock.push({ throw: "rate limit exceeded retry-after-ms=60000" });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.maxDelayMs": 100,
+			"retry.maxRetries": 3,
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 2,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Fallback rather than exceed the wait cap");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(waitSpy).toHaveBeenCalledWith(0, { signal: expect.any(AbortSignal) });
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered without waiting",
 		});
 	});
 

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -479,7 +479,7 @@ describe("AgentSession retry fallback", () => {
 				if (model.provider === fallbackModel.provider && model.id === fallbackModel.id) {
 					mock.push({ content: ["Recovered without waiting"] });
 				} else {
-					mock.push({ throw: "rate limit exceeded retry-after-ms=60000" });
+					mock.push({ throw: "overloaded_error: retry-after-ms=60000" });
 				}
 				return mock.stream(model, context, options);
 			},
@@ -514,6 +514,80 @@ describe("AgentSession retry fallback", () => {
 		expect(getLastAssistantMessage(session).content).toContainEqual({
 			type: "text",
 			text: "Recovered without waiting",
+		});
+	});
+
+	it("gives a fallback a fresh retry budget after the primary exhausts its budget", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !firstFallback || !secondFallback) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		let firstFallbackAttempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === firstFallback.provider && model.id === firstFallback.id) {
+					firstFallbackAttempts++;
+					mock.push(
+						firstFallbackAttempts === 1
+							? { throw: "overloaded_error: provider returned error 503" }
+							: { content: ["Recovered on first fallback retry"] },
+					);
+				} else if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+					mock.push({ content: ["Unexpected second fallback"] });
+				} else {
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 1,
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 1,
+			"retry.fallbackChains": {
+				default: [
+					`${firstFallback.provider}/${firstFallback.id}`,
+					`${secondFallback.provider}/${secondFallback.id}`,
+				],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Retry the fallback after budget reset");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+		]);
+		expect(session.model?.id).toBe(firstFallback.id);
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered on first fallback retry",
 		});
 	});
 

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -305,6 +305,79 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("retries the current model before applying a configured fallback when enabled", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === fallbackModel.provider && model.id === fallbackModel.id) {
+					mock.push({ content: ["Recovered on fallback"] });
+				} else {
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 3,
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 2,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") fallbackAppliedEvents.push(event);
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Retry before fallback");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${fallbackModel.provider}/${fallbackModel.id}`,
+				role: "default",
+			},
+		]);
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered on fallback",
+		});
+	});
+
 	it("hops to the chain owned by a fallback that is the last entry of the chain it came from", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
@@ -2089,6 +2162,8 @@ describe("AgentSession retry fallback", () => {
 			"retry.fallbackChains": {
 				"anthropic/*": [`${fallbackModel.provider}/${fallbackModel.id}`],
 			},
+			"retry.retryCurrentModelBeforeFallback": true,
+			"retry.retriesBeforeModelFallback": 3,
 		});
 
 		session = new AgentSession({
@@ -2107,8 +2182,8 @@ describe("AgentSession retry fallback", () => {
 		await session.prompt("Survive a hard error");
 		await session.waitForIdle();
 
-		// Exactly one attempt on the failing model: a hard error switches models
-		// immediately, it never backoff-retries the same model.
+		// A hard error cannot recover by retrying the same model, so delayed
+		// fallback applies only to retryable failures and this switch stays immediate.
 		expect(requestedModels).toEqual([
 			`${primaryModel.provider}/${primaryModel.id}`,
 			`${fallbackModel.provider}/${fallbackModel.id}`,


### PR DESCRIPTION
## Problem

When model fallback is enabled, transient retryable failures currently trigger an immediate switch to the configured fallback model on the first failure. In scenarios where transient provider errors (e.g. intermittent 429s, 5xxs, or momentary network hiccups) can resolve with an immediate same-model retry, switching models immediately degrades the session to a fallback model prematurely.

## Solution

Add configuration options to allow retrying the current model a configurable number of times before falling back to an alternative model:
- `retry.retryCurrentModelBeforeFallback`: boolean flag (defaults to `false`, preserving existing immediate fallback behavior).
- `retry.retriesBeforeModelFallback`: integer count (defaults to `3`) specifying how many retry attempts to make on the current model before selecting a fallback model.

Non-retryable hard errors, classifier refusals, and credential rotations continue to bypass this delay and switch immediately or rotate credentials first.

## Safety details

- Defaults to `false`, ensuring 100% backward compatibility with existing immediate fallback behavior.
- Hard errors (`hardErrorFallback` or classifier refusal) bypass same-model retry delays since retrying the exact same model cannot recover from them.
- Credential rotation retains precedence over model fallback.
- `retry.maxRetries` remains the upper ceiling across all retries in the turn.

## Changes

**Settings & Schema**
- Add `retry.retryCurrentModelBeforeFallback` and `retry.retriesBeforeModelFallback` to `SETTINGS_SCHEMA` and `RetrySettings` interface
- Add UI condition `retryCurrentModelBeforeFallbackEnabled` in settings definitions

**Turn Recovery**
- Track attempt counts against `sameModelRetriesBeforeFallback` before engaging configured fallback models

**Tests & Changelog**
- Add unit test in `agent-session-retry-fallback.test.ts` validating same-model retries before fallback
- Update `CHANGELOG.md` under `## [Unreleased]`

## Verification

- [x] `bun run check:ts` (clean across all packages)
- [x] `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` (77 passed, 0 failed)
