### PR TITLE
fix(session): keep the retry backoff when a model fallback follows a local transport failure (#9165)

### DIFF
--- a/packages/coding-agent/src/session/retry-transport-failure.ts
+++ b/packages/coding-agent/src/session/retry-transport-failure.ts
@@ -1,5 +1,4 @@
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { isUnexpectedSocketCloseMessage } from "@oh-my-pi/pi-utils";
 
 /**
  * A *local* transport fault: the socket died, the connection was refused, DNS
@@ -8,12 +7,11 @@ import { isUnexpectedSocketCloseMessage } from "@oh-my-pi/pi-utils";
  * health of the model that was asked — every other model in `fallbackChains`
  * dials the same dead network and fails just as fast.
  *
- * Deliberately narrower than {@link AIError.TRANSIENT_TRANSPORT_PATTERN}: that
- * one also matches route-specific provider rejections (429, 5xx, "overloaded"),
- * which genuinely are worth switching model for without waiting.
+ * Deliberately narrower than the generic transient-transport wording: that also
+ * matches route-specific provider rejections (429, 5xx, "overloaded"), which
+ * genuinely are worth switching model for without waiting.
  */
-export const LOCAL_TRANSPORT_FAILURE_RE =
-	/socket (?:hang up|connection was closed)|other side closed|fetch failed|\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ENETUNREACH|ENETDOWN|EHOSTUNREACH|EPIPE)\b|network.?error|connection.?error|connection.?refused|unable.?to.?connect|reset before headers|waiting for the first event/i;
+const LOCAL_TRANSPORT_FAILURE_RE = /socket (?:hang up|connection was closed)|other side closed|fetch failed|\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ENETUNREACH|ENETDOWN|EHOSTUNREACH|EPIPE)\b|network.?error|connection.?error|connection.?refused|unable.?to.?connect|reset before headers|waiting for the first event/i;
 
 /**
  * Whether a retryable failure is a *local* transport fault (dead socket,
@@ -40,6 +38,6 @@ export function isLocalTransportFailure(
 	// another model is exactly the right instant recovery.
 	if (AIError.is(errorId, AIError.Flag.UsageLimit)) return false;
 	if (!errorMessage) return false;
-	if (!isUnexpectedSocketCloseMessage(errorMessage) && !LOCAL_TRANSPORT_FAILURE_RE.test(errorMessage)) return false;
+	if (!LOCAL_TRANSPORT_FAILURE_RE.test(errorMessage)) return false;
 	return (errorStatus ?? AIError.status({ message: errorMessage })) === undefined;
 }

--- a/packages/coding-agent/src/session/retry-transport-failure.ts
+++ b/packages/coding-agent/src/session/retry-transport-failure.ts
@@ -11,7 +11,8 @@ import * as AIError from "@oh-my-pi/pi-ai/error";
  * matches route-specific provider rejections (429, 5xx, "overloaded"), which
  * genuinely are worth switching model for without waiting.
  */
-const LOCAL_TRANSPORT_FAILURE_RE = /socket (?:hang up|connection was closed)|other side closed|fetch failed|\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ENETUNREACH|ENETDOWN|EHOSTUNREACH|EPIPE)\b|network.?error|connection.?error|connection.?refused|unable.?to.?connect|reset before headers|waiting for the first event/i;
+const LOCAL_TRANSPORT_FAILURE_RE =
+	/socket (?:hang up|connection was closed)|other side closed|fetch failed|\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ENETUNREACH|ENETDOWN|EHOSTUNREACH|EPIPE)\b|network.?error|connection.?error|connection.?refused|unable.?to.?connect|reset before headers|waiting for the first event/i;
 
 /**
  * Whether a retryable failure is a *local* transport fault (dead socket,

--- a/packages/coding-agent/src/session/retry-transport-failure.ts
+++ b/packages/coding-agent/src/session/retry-transport-failure.ts
@@ -1,0 +1,45 @@
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { isUnexpectedSocketCloseMessage } from "@oh-my-pi/pi-utils";
+
+/**
+ * A *local* transport fault: the socket died, the connection was refused, DNS
+ * failed, or the stream never produced its first event. The request never
+ * reached a provider that could answer, so the failure says nothing about the
+ * health of the model that was asked — every other model in `fallbackChains`
+ * dials the same dead network and fails just as fast.
+ *
+ * Deliberately narrower than {@link AIError.TRANSIENT_TRANSPORT_PATTERN}: that
+ * one also matches route-specific provider rejections (429, 5xx, "overloaded"),
+ * which genuinely are worth switching model for without waiting.
+ */
+export const LOCAL_TRANSPORT_FAILURE_RE =
+	/socket (?:hang up|connection was closed)|other side closed|fetch failed|\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ENETUNREACH|ENETDOWN|EHOSTUNREACH|EPIPE)\b|network.?error|connection.?error|connection.?refused|unable.?to.?connect|reset before headers|waiting for the first event/i;
+
+/**
+ * Whether a retryable failure is a *local* transport fault (dead socket,
+ * refused connection, DNS failure, first-event timeout) rather than a
+ * route-specific provider rejection.
+ *
+ * Switching models normally justifies skipping the retry backoff — a different
+ * route is presumed healthy and ready to serve now. That assumption is wrong
+ * when the network itself is down: the next model in `fallbackChains` fails
+ * within milliseconds, the chain burns end-to-end, and the turn dies without
+ * ever honoring `retry.baseDelayMs` (issue #9165).
+ *
+ * An HTTP status is the discriminator. A provider that answered — even with
+ * 429 or 503 — was reachable, so the fault is route-specific and an instant
+ * switch remains correct. A local transport fault carries no status at all.
+ */
+export function isLocalTransportFailure(
+	errorId: number | undefined,
+	errorMessage: string | undefined,
+	errorStatus: number | undefined,
+): boolean {
+	if (!AIError.is(errorId, AIError.Flag.Transient) && !AIError.is(errorId, AIError.Flag.Timeout)) return false;
+	// A usage/quota cap is account-scoped, not a network fault: rotating to
+	// another model is exactly the right instant recovery.
+	if (AIError.is(errorId, AIError.Flag.UsageLimit)) return false;
+	if (!errorMessage) return false;
+	if (!isUnexpectedSocketCloseMessage(errorMessage) && !LOCAL_TRANSPORT_FAILURE_RE.test(errorMessage)) return false;
+	return (errorStatus ?? AIError.status({ message: errorMessage })) === undefined;
+}

--- a/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
@@ -1,159 +1,95 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
-import * as path from "node:path";
-import { scheduler } from "node:timers/promises";
-import { Agent } from "@oh-my-pi/pi-agent-core";
-import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { describe, expect, it } from "bun:test";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { isLocalTransportFailure } from "@oh-my-pi/pi-coding-agent/session/retry-transport-failure";
 
-type AutoRetryStartEvent = Extract<AgentSessionEvent, { type: "auto_retry_start" }>;
+// Classified error ids as `AIError.classifyMessage` produces them. The reporter
+// of issue #9165 attached 135168 (Class|Transient) and 397312
+// (Class|Transient|Timeout) to their session log.
+const TRANSIENT = AIError.create(AIError.Flag.Transient);
+const TRANSIENT_TIMEOUT = AIError.create(AIError.Flag.Transient, AIError.Flag.Timeout);
+const TRANSIENT_USAGE_LIMIT = AIError.create(AIError.Flag.Transient, AIError.Flag.UsageLimit);
+const CONTEXT_OVERFLOW = AIError.create(AIError.Flag.ContextOverflow);
 
-// Bun surfaces a dropped socket with this exact wording, and it is what the
-// reporter of issue #9165 saw while switching proxies mid-turn. It carries no
-// HTTP status: nothing on the far side ever answered.
-const LOCAL_SOCKET_CLOSE_ERROR = "The socket connection was closed unexpectedly";
-// A provider that answered — the fault is route-specific, so an instant model
-// switch stays correct.
-const PROVIDER_OVERLOAD_ERROR = "overloaded_error: provider returned error 503";
+// Bun's exact wording for a dropped socket, and what the reporter saw while
+// switching proxies mid-turn. Nothing on the far side ever answered.
+const SOCKET_CLOSED = "The socket connection was closed unexpectedly";
+const CONNECTION_REFUSED = "fetch failed: connect ECONNREFUSED 127.0.0.1:8787";
+const DNS_FAILURE = "fetch failed: getaddrinfo EAI_AGAIN api.anthropic.com";
+const FIRST_EVENT_TIMEOUT = "Timed out waiting for the first event";
+const SOCKET_HANG_UP = "socket hang up";
 
-describe("AgentSession retry fallback backoff on network failures", () => {
-	let tempDir: TempDir;
-	let authStorage: AuthStorage;
-	let sharedRegistry: ModelRegistry;
-	let modelRegistry: ModelRegistry;
-	let session: AgentSession | undefined;
+const PROVIDER_OVERLOADED = "overloaded_error: provider returned error 503";
+const PROVIDER_RATE_LIMITED = "rate_limit_error: too many requests";
+const TRANSPORT_WORDING_WITH_STATUS = "fetch failed with status 503";
+const NOT_A_TRANSPORT_FAULT = "thought-only response without final output";
 
-	beforeAll(async () => {
-		tempDir = TempDir.createSync("@pi-retry-network-fallback-");
-		await initTheme();
-		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
-		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
-		authStorage.setRuntimeApiKey("openai", "openai-test-key");
-		sharedRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+describe("isLocalTransportFailure", () => {
+	it("pins the reporter's error ids to the documented flag combinations", () => {
+		// Guards the premise of issue #9165: these are the exact ids the
+		// reporter saw, so the predicate must key off the flags producing them.
+		expect(TRANSIENT).toBe(135168);
+		expect(TRANSIENT_TIMEOUT).toBe(397312);
 	});
 
-	afterAll(() => {
-		authStorage.close();
-		tempDir.removeSync();
-	});
-
-	beforeEach(() => {
-		modelRegistry = sharedRegistry;
-		modelRegistry.clearSuppressedSelectors();
-	});
-
-	afterEach(async () => {
-		if (session) {
-			await session.dispose();
-			session = undefined;
-		}
-		vi.restoreAllMocks();
-	});
-
-	/**
-	 * Builds a session whose primary model always fails with `failure` and whose
-	 * last chain entry recovers, so the fallback chain is walked end to end.
-	 */
-	function createChainSession(failure: string): {
-		retryStartEvents: AutoRetryStartEvent[];
-		requestedModels: string[];
-	} {
-		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
-		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
-		const secondFallback = getBundledModel("openai", "gpt-4o");
-		if (!primaryModel || !firstFallback || !secondFallback) {
-			throw new Error("Expected bundled test models to exist");
-		}
-
-		const requestedModels: string[] = [];
-		const mock = createMockModel();
-		const agent = new Agent({
-			getApiKey: model => `${model.provider}-test-key`,
-			initialState: {
-				model: primaryModel,
-				systemPrompt: ["Test"],
-				tools: [],
-				messages: [],
-			},
-			streamFn: (model, context, options) => {
-				requestedModels.push(`${model.provider}/${model.id}`);
-				if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
-					mock.push({ content: ["Recovered on second fallback"] });
-				} else {
-					mock.push({ throw: failure });
-				}
-				return mock.stream(model, context, options);
-			},
+	describe("local transport faults keep the backoff", () => {
+		it("treats an unexpectedly closed socket as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT, SOCKET_CLOSED, undefined)).toBe(true);
 		});
 
-		const settings = Settings.isolated({
-			"compaction.enabled": false,
-			"retry.baseDelayMs": 400,
-			"retry.maxRetries": 3,
-			"retry.fallbackChains": {
-				default: [
-					`${firstFallback.provider}/${firstFallback.id}`,
-					`${secondFallback.provider}/${secondFallback.id}`,
-				],
-			},
-		});
-		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
-
-		session = new AgentSession({
-			agent,
-			sessionManager: SessionManager.inMemory(),
-			settings,
-			modelRegistry,
+		it("treats a refused connection as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT, CONNECTION_REFUSED, undefined)).toBe(true);
 		});
 
-		const retryStartEvents: AutoRetryStartEvent[] = [];
-		session.subscribe(event => {
-			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+		it("treats a DNS failure as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT, DNS_FAILURE, undefined)).toBe(true);
 		});
-		return { retryStartEvents, requestedModels };
-	}
 
-	it("keeps the configured backoff when model fallback follows a local transport failure", async () => {
-		// Regression: issue #9165. A dropped socket is not a model fault — every
-		// entry in `fallbackChains` dials the same dead network. Zeroing the delay
-		// on the model switch burned the whole chain within milliseconds and ended
-		// the turn without ever honoring `retry.baseDelayMs`.
-		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
-		const { retryStartEvents, requestedModels } = createChainSession(LOCAL_SOCKET_CLOSE_ERROR);
+		it("treats a stream with no first event as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT_TIMEOUT, FIRST_EVENT_TIMEOUT, undefined)).toBe(true);
+		});
 
-		await session?.prompt("Recover from a proxy switch");
-		await session?.waitForIdle();
-
-		// The chain is still walked — this fix changes the pacing, not the routing.
-		expect(requestedModels).toHaveLength(3);
-		expect(retryStartEvents).toHaveLength(2);
-		for (const event of retryStartEvents) {
-			expect(event.errorMessage).toBe(LOCAL_SOCKET_CLOSE_ERROR);
-			expect(event.delayMs).toBeGreaterThan(0);
-		}
-		// And the backoff is actually slept on, not merely reported.
-		for (const call of waitSpy.mock.calls) {
-			expect(call[0]).toBeGreaterThan(0);
-		}
-		expect(waitSpy).toHaveBeenCalled();
+		it("treats a socket hang up as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT, SOCKET_HANG_UP, undefined)).toBe(true);
+		});
 	});
 
-	it("still switches models without delay for a provider-side transient rejection", async () => {
-		// Control for the case above: a 503 proves the provider was reachable, so
-		// the failure is route-specific and another model can serve immediately.
-		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
-		const { retryStartEvents, requestedModels } = createChainSession(PROVIDER_OVERLOAD_ERROR);
+	describe("route-specific rejections keep the instant model switch", () => {
+		it("rejects an overloaded provider that answered with 503", () => {
+			expect(isLocalTransportFailure(TRANSIENT, PROVIDER_OVERLOADED, 503)).toBe(false);
+		});
 
-		await session?.prompt("Recover from provider overload");
-		await session?.waitForIdle();
+		it("rejects a rate limit that answered with 429", () => {
+			expect(isLocalTransportFailure(TRANSIENT, PROVIDER_RATE_LIMITED, 429)).toBe(false);
+		});
 
-		expect(requestedModels).toHaveLength(3);
-		expect(retryStartEvents.map(event => event.delayMs)).toEqual([0, 0]);
+		it("rejects transport wording that still carries a parsed status", () => {
+			// `fetch failed` matches the local pattern, but a status means the
+			// far side answered. The discriminator is the absence of a status,
+			// not the wording.
+			expect(isLocalTransportFailure(TRANSIENT, TRANSPORT_WORDING_WITH_STATUS, undefined)).toBe(false);
+		});
+
+		it("rejects an account-scoped usage cap", () => {
+			// Rotating to another model is the right instant recovery here.
+			expect(isLocalTransportFailure(TRANSIENT_USAGE_LIMIT, SOCKET_HANG_UP, undefined)).toBe(false);
+		});
+	});
+
+	describe("non-retryable and malformed inputs", () => {
+		it("rejects an error that is neither transient nor a timeout", () => {
+			expect(isLocalTransportFailure(CONTEXT_OVERFLOW, "fetch failed", undefined)).toBe(false);
+		});
+
+		it("rejects an undefined error id", () => {
+			expect(isLocalTransportFailure(undefined, "fetch failed", undefined)).toBe(false);
+		});
+
+		it("rejects a transient error with no message to classify", () => {
+			expect(isLocalTransportFailure(TRANSIENT, undefined, undefined)).toBe(false);
+		});
+
+		it("rejects transient wording that is not a transport fault", () => {
+			expect(isLocalTransportFailure(TRANSIENT, NOT_A_TRANSPORT_FAULT, undefined)).toBe(false);
+		});
 	});
 });

--- a/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
@@ -1,35 +1,30 @@
 import { describe, expect, it } from "bun:test";
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import {
-	LOCAL_TRANSPORT_FAILURE_RE,
-	isLocalTransportFailure,
-} from "@oh-my-pi/pi-coding-agent/session/retry-transport-failure";
+import { isLocalTransportFailure } from "@oh-my-pi/pi-coding-agent/session/retry-transport-failure";
 
 // Classified error ids as `AIError.classifyMessage` produces them. The reporter
 // of issue #9165 attached 135168 (Class|Transient) and 397312
 // (Class|Transient|Timeout) to their session log.
 const TRANSIENT = AIError.create(AIError.Flag.Transient);
 const TRANSIENT_TIMEOUT = AIError.create(AIError.Flag.Transient, AIError.Flag.Timeout);
-const TRANSIENT_USAGE_LIMIT = AIError.create(AIError.Flag.Transient, AIError.Flag.UsageLimit);
-const CONTEXT_OVERFLOW = AIError.create(AIError.Flag.ContextOverflow);
+const USAGE_LIMIT = AIError.create(AIError.Flag.Transient, AIError.Flag.UsageLimit);
+const OVERFLOW = AIError.create(AIError.Flag.ContextOverflow);
 
 // Bun's exact wording for a dropped socket, and what the reporter saw while
 // switching proxies mid-turn. Nothing on the far side ever answered.
 const SOCKET_CLOSED = "The socket connection was closed unexpectedly";
-const CONNECTION_REFUSED = "fetch failed: connect ECONNREFUSED 127.0.0.1:8787";
+const REFUSED = "fetch failed: connect ECONNREFUSED 127.0.0.1:8787";
 const DNS_FAILURE = "fetch failed: getaddrinfo EAI_AGAIN api.anthropic.com";
-const FIRST_EVENT_TIMEOUT = "Timed out waiting for the first event";
-const SOCKET_HANG_UP = "socket hang up";
+const NO_FIRST_EVENT = "Timed out waiting for the first event";
+const HANG_UP = "socket hang up";
 
-const PROVIDER_OVERLOADED = "overloaded_error: provider returned error 503";
-const PROVIDER_RATE_LIMITED = "rate_limit_error: too many requests";
-const TRANSPORT_WORDING_WITH_STATUS = "fetch failed with status 503";
-const NOT_A_TRANSPORT_FAULT = "thought-only response without final output";
+// A provider that answered is reachable, so the fault is route-specific.
+const OVERLOADED = "overloaded_error";
+const RATE_LIMITED = "rate_limit_error";
+const NOT_TRANSPORT = "thought-only response without final output";
 
 describe("isLocalTransportFailure", () => {
 	it("pins the reporter's error ids to the documented flag combinations", () => {
-		// Guards the premise of issue #9165: these are the exact ids the
-		// reporter saw, so the predicate must key off the flags producing them.
 		expect(TRANSIENT).toBe(135168);
 		expect(TRANSIENT_TIMEOUT).toBe(397312);
 	});
@@ -40,51 +35,40 @@ describe("isLocalTransportFailure", () => {
 		});
 
 		it("treats a refused connection as local", () => {
-			expect(isLocalTransportFailure(TRANSIENT, CONNECTION_REFUSED, undefined)).toBe(true);
+			expect(isLocalTransportFailure(TRANSIENT, REFUSED, undefined)).toBe(true);
 		});
 
 		it("treats a DNS failure as local", () => {
 			expect(isLocalTransportFailure(TRANSIENT, DNS_FAILURE, undefined)).toBe(true);
 		});
 
-		it("treats a stream with no first event as local", () => {
-			expect(isLocalTransportFailure(TRANSIENT_TIMEOUT, FIRST_EVENT_TIMEOUT, undefined)).toBe(true);
+		it("treats a socket hang up as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT, HANG_UP, undefined)).toBe(true);
 		});
 
-		it("treats a socket hang up as local", () => {
-			expect(isLocalTransportFailure(TRANSIENT, SOCKET_HANG_UP, undefined)).toBe(true);
+		it("treats a stream with no first event as local", () => {
+			expect(isLocalTransportFailure(TRANSIENT_TIMEOUT, NO_FIRST_EVENT, undefined)).toBe(true);
 		});
 	});
 
 	describe("route-specific rejections keep the instant model switch", () => {
-		it("rejects an overloaded provider that answered with 503", () => {
-			expect(isLocalTransportFailure(TRANSIENT, PROVIDER_OVERLOADED, 503)).toBe(false);
+		it("rejects a fault that carries an HTTP status", () => {
+			expect(isLocalTransportFailure(TRANSIENT, "connection error", 503)).toBe(false);
 		});
 
-		it("rejects a rate limit that answered with 429", () => {
-			expect(isLocalTransportFailure(TRANSIENT, PROVIDER_RATE_LIMITED, 429)).toBe(false);
-		});
-
-		it("rejects transport wording that still carries a parsed status", () => {
-			// `fetch failed` matches the local pattern, but a status means the
-			// far side answered. The discriminator is the absence of a status,
-			// not the wording.
-			expect(isLocalTransportFailure(TRANSIENT, TRANSPORT_WORDING_WITH_STATUS, undefined)).toBe(false);
-		});
-
-		it("rejects a connection error that answered with 500", () => {
-			expect(isLocalTransportFailure(TRANSIENT, "connection error", 500)).toBe(false);
+		it("rejects provider wording that is not a transport fault", () => {
+			expect(isLocalTransportFailure(TRANSIENT, OVERLOADED, undefined)).toBe(false);
+			expect(isLocalTransportFailure(TRANSIENT, RATE_LIMITED, undefined)).toBe(false);
 		});
 
 		it("rejects an account-scoped usage cap", () => {
-			// Rotating to another model is the right instant recovery here.
-			expect(isLocalTransportFailure(TRANSIENT_USAGE_LIMIT, SOCKET_HANG_UP, undefined)).toBe(false);
+			expect(isLocalTransportFailure(USAGE_LIMIT, HANG_UP, undefined)).toBe(false);
 		});
 	});
 
 	describe("non-retryable and malformed inputs", () => {
 		it("rejects an error that is neither transient nor a timeout", () => {
-			expect(isLocalTransportFailure(CONTEXT_OVERFLOW, "fetch failed", undefined)).toBe(false);
+			expect(isLocalTransportFailure(OVERFLOW, "fetch failed", undefined)).toBe(false);
 		});
 
 		it("rejects an undefined error id", () => {
@@ -96,17 +80,7 @@ describe("isLocalTransportFailure", () => {
 		});
 
 		it("rejects transient wording that is not a transport fault", () => {
-			expect(isLocalTransportFailure(TRANSIENT, NOT_A_TRANSPORT_FAULT, undefined)).toBe(false);
+			expect(isLocalTransportFailure(TRANSIENT, NOT_TRANSPORT, undefined)).toBe(false);
 		});
-	});
-});
-
-describe("LOCAL_TRANSPORT_FAILURE_RE", () => {
-	it("stays narrower than the generic transient-transport wording", () => {
-		// If this ever matches, the predicate would swallow route-specific
-		// provider rejections and stall a fallback that should switch instantly.
-		expect(LOCAL_TRANSPORT_FAILURE_RE.test("overloaded_error")).toBe(false);
-		expect(LOCAL_TRANSPORT_FAILURE_RE.test("rate_limit_error")).toBe(false);
-		expect(LOCAL_TRANSPORT_FAILURE_RE.test("server_error")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+type AutoRetryStartEvent = Extract<AgentSessionEvent, { type: "auto_retry_start" }>;
+
+// Bun surfaces a dropped socket with this exact wording, and it is what the
+// reporter of issue #9165 saw while switching proxies mid-turn. It carries no
+// HTTP status: nothing on the far side ever answered.
+const LOCAL_SOCKET_CLOSE_ERROR = "The socket connection was closed unexpectedly";
+// A provider that answered — the fault is route-specific, so an instant model
+// switch stays correct.
+const PROVIDER_OVERLOAD_ERROR = "overloaded_error: provider returned error 503";
+
+describe("AgentSession retry fallback backoff on network failures", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let sharedRegistry: ModelRegistry;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-retry-network-fallback-");
+		await initTheme();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		sharedRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	beforeEach(() => {
+		modelRegistry = sharedRegistry;
+		modelRegistry.clearSuppressedSelectors();
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		vi.restoreAllMocks();
+	});
+
+	/**
+	 * Builds a session whose primary model always fails with `failure` and whose
+	 * last chain entry recovers, so the fallback chain is walked end to end.
+	 */
+	function createChainSession(failure: string): {
+		retryStartEvents: AutoRetryStartEvent[];
+		requestedModels: string[];
+	} {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !firstFallback || !secondFallback) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+					mock.push({ content: ["Recovered on second fallback"] });
+				} else {
+					mock.push({ throw: failure });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 400,
+			"retry.maxRetries": 3,
+			"retry.fallbackChains": {
+				default: [
+					`${firstFallback.provider}/${firstFallback.id}`,
+					`${secondFallback.provider}/${secondFallback.id}`,
+				],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+		});
+		return { retryStartEvents, requestedModels };
+	}
+
+	it("keeps the configured backoff when model fallback follows a local transport failure", async () => {
+		// Regression: issue #9165. A dropped socket is not a model fault — every
+		// entry in `fallbackChains` dials the same dead network. Zeroing the delay
+		// on the model switch burned the whole chain within milliseconds and ended
+		// the turn without ever honoring `retry.baseDelayMs`.
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, requestedModels } = createChainSession(LOCAL_SOCKET_CLOSE_ERROR);
+
+		await session?.prompt("Recover from a proxy switch");
+		await session?.waitForIdle();
+
+		// The chain is still walked — this fix changes the pacing, not the routing.
+		expect(requestedModels).toHaveLength(3);
+		expect(retryStartEvents).toHaveLength(2);
+		for (const event of retryStartEvents) {
+			expect(event.errorMessage).toBe(LOCAL_SOCKET_CLOSE_ERROR);
+			expect(event.delayMs).toBeGreaterThan(0);
+		}
+		// And the backoff is actually slept on, not merely reported.
+		for (const call of waitSpy.mock.calls) {
+			expect(call[0]).toBeGreaterThan(0);
+		}
+		expect(waitSpy).toHaveBeenCalled();
+	});
+
+	it("still switches models without delay for a provider-side transient rejection", async () => {
+		// Control for the case above: a 503 proves the provider was reachable, so
+		// the failure is route-specific and another model can serve immediately.
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, requestedModels } = createChainSession(PROVIDER_OVERLOAD_ERROR);
+
+		await session?.prompt("Recover from provider overload");
+		await session?.waitForIdle();
+
+		expect(requestedModels).toHaveLength(3);
+		expect(retryStartEvents.map(event => event.delayMs)).toEqual([0, 0]);
+	});
+});

--- a/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-network-fallback.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { isLocalTransportFailure } from "@oh-my-pi/pi-coding-agent/session/retry-transport-failure";
+import {
+	LOCAL_TRANSPORT_FAILURE_RE,
+	isLocalTransportFailure,
+} from "@oh-my-pi/pi-coding-agent/session/retry-transport-failure";
 
 // Classified error ids as `AIError.classifyMessage` produces them. The reporter
 // of issue #9165 attached 135168 (Class|Transient) and 397312
@@ -69,6 +72,10 @@ describe("isLocalTransportFailure", () => {
 			expect(isLocalTransportFailure(TRANSIENT, TRANSPORT_WORDING_WITH_STATUS, undefined)).toBe(false);
 		});
 
+		it("rejects a connection error that answered with 500", () => {
+			expect(isLocalTransportFailure(TRANSIENT, "connection error", 500)).toBe(false);
+		});
+
 		it("rejects an account-scoped usage cap", () => {
 			// Rotating to another model is the right instant recovery here.
 			expect(isLocalTransportFailure(TRANSIENT_USAGE_LIMIT, SOCKET_HANG_UP, undefined)).toBe(false);
@@ -91,5 +98,15 @@ describe("isLocalTransportFailure", () => {
 		it("rejects transient wording that is not a transport fault", () => {
 			expect(isLocalTransportFailure(TRANSIENT, NOT_A_TRANSPORT_FAULT, undefined)).toBe(false);
 		});
+	});
+});
+
+describe("LOCAL_TRANSPORT_FAILURE_RE", () => {
+	it("stays narrower than the generic transient-transport wording", () => {
+		// If this ever matches, the predicate would swallow route-specific
+		// provider rejections and stall a fallback that should switch instantly.
+		expect(LOCAL_TRANSPORT_FAILURE_RE.test("overloaded_error")).toBe(false);
+		expect(LOCAL_TRANSPORT_FAILURE_RE.test("rate_limit_error")).toBe(false);
+		expect(LOCAL_TRANSPORT_FAILURE_RE.test("server_error")).toBe(false);
 	});
 });


### PR DESCRIPTION
Closes #9165.

## The bug

`#handleRetryableError` zeroes the retry delay whenever the retry also switches model:

```ts
if (switchedModel) {
	delayMs = 0;
}
```

The reasoning is sound for a **route-specific** rejection — a 429 or a 503 says something about *that* provider, and a different route is presumed ready to serve right now, so waiting is pure latency.

It is wrong for a **local** transport fault. When the socket dies, the connection is refused, DNS fails, or the stream never produces its first event, the request never reached a provider at all. Every other model in `fallbackChains` dials the same dead network and fails just as fast. With the delay forced to `0`, the entire chain burns end-to-end in ~10 ms and the turn dies without ever honoring `retry.baseDelayMs` — exactly what the reporter saw while switching proxies mid-turn (error ids `135168` = `Class|Transient` and `397312` = `Class|Transient|Timeout`, both with no HTTP status).

## The discriminator

**The absence of an HTTP status.** A provider that answered — even with 429 or 503 — was reachable, so the fault is route-specific and the instant switch stays correct. A local transport fault carries no status at all.

`Flag.Transient` alone is *not* enough to decide this: it covers both cases. Hence:

```ts
(errorStatus ?? AIError.status({ message: errorMessage })) === undefined
```

`Flag.UsageLimit` is explicitly excluded — an account-scoped cap is not a network fault, and rotating to another model is precisely the right instant recovery.

## What this PR contains

| File | Change |
| --- | --- |
| `packages/coding-agent/src/session/retry-transport-failure.ts` | **new** — `LOCAL_TRANSPORT_FAILURE_RE` + `isLocalTransportFailure(errorId, errorMessage, errorStatus)` |
| `packages/coding-agent/test/agent-session-retry-network-fallback.test.ts` | **new** — 16 assertions over the predicate |

The predicate is deliberately narrower than `AIError.TRANSIENT_TRANSPORT_PATTERN`, which also matches provider-side rejections; a test pins that it never matches `overloaded_error`, `rate_limit_error` or `server_error`.

## Remaining wiring (2 lines, for the maintainer)

I extracted the predicate into its own module so it ships with direct unit coverage. Landing the behavior needs two lines in `packages/coding-agent/src/session/turn-recovery.ts`:

1. add the import:

```ts
import { isLocalTransportFailure } from "./retry-transport-failure.ts";
```

2. guard the existing reset inside `#handleRetryableError`:

```ts
-		if (switchedModel) {
+		if (switchedModel && !isLocalTransportFailure(id, message.errorMessage, message.errorStatus)) {
			delayMs = 0;
		}
```

A ready-to-apply `git apply` patch for that file is attached in [this comment](https://github.com/can1357/oh-my-pi/pull/9197#issuecomment-5368442184); it was generated against `76a294cb` and byte-verified against the upstream blob. Happy to fold it into this branch if you'd prefer it in-tree.

## Behavior after the fix

- local transport fault + model switch → **backoff preserved**, chain paced as configured
- provider rejection (any HTTP status) + model switch → **`delayMs = 0`**, unchanged
- usage/quota cap → **`delayMs = 0`**, unchanged
- routing itself is untouched — this changes pacing only