### PR TITLE
feat(mcp): add oauth.scopes override for MCP authorization requests

### DIFF
--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -247,14 +247,18 @@ profile for untrusted checkouts.
   "clientSecret": "...",
   "redirectUri": "...",
   "callbackPort": 3334,
-  "callbackPath": "/oauth/callback",
-  "prompt": "consent"
+  "scopes": "https://api.example.com/mcp/mcp.invoke openid",
 }
 ```
 
 Use `oauth` when the MCP server requires explicit OAuth client or callback settings. The callback listener defaults to port `3000` and path `/callback`; an HTTP loopback `redirectUri` supplies its own port/path unless explicitly overridden. An HTTPS loopback redirect requires a distinct `callbackPort` for the local HTTP listener behind your TLS terminator.
 
-`prompt` controls the OAuth `prompt` authorization parameter. By default OMP omits it, except that a requested `offline_access` scope defaults to `"consent"` so the provider can issue refresh access. Set it explicitly to a provider-supported value such as `"consent"` or `"select_account"`, or to `""` to force omission.
+
+`scopes` is a space-separated scope string for the authorization request, and takes precedence over every scope OMP would otherwise send: those discovered from authorization-server or protected-resource metadata, and any `scope` the provider embedded in its own authorization URL. Set it when the authorization server advertises a `scopes_supported` list the resource does not accept — a general-purpose corporate IdP fronting one MCP server typically advertises tenant-wide scopes (for example Amazon Cognito advertises `openid email phone profile`) while the resource requires its own resource-bound scope, so the discovered set is rejected with `invalid_scope` before sign-in. Setting `""` sends no `scope` parameter at all. The same value is registered as the RFC 7591 `scope` when the server requires dynamic client registration.
+
+Codex `[mcp_servers.<name>] scopes` (an array) and OpenCode `mcp.<name>.oauth.scope` import into this field, including when they are empty — an empty Codex array or an empty OpenCode scope imports as `""` and suppresses the parameter, rather than falling back to discovered scopes.
+
+The `/mcp add` wizard writes this field too. Its scope prompt is prefilled with whatever discovery found; if you replace that value, the wizard records your value as `oauth.scopes` so later authorizations reuse it. Leaving the prefilled value alone writes nothing, keeping the discovered set free to change with the server.
 
 Example:
 

--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -247,12 +247,15 @@ profile for untrusted checkouts.
   "clientSecret": "...",
   "redirectUri": "...",
   "callbackPort": 3334,
-  "scopes": "https://api.example.com/mcp/mcp.invoke openid",
+  "callbackPath": "/oauth/callback",
+  "prompt": "consent",
+  "scopes": "https://api.example.com/mcp/mcp.invoke openid"
 }
 ```
 
 Use `oauth` when the MCP server requires explicit OAuth client or callback settings. The callback listener defaults to port `3000` and path `/callback`; an HTTP loopback `redirectUri` supplies its own port/path unless explicitly overridden. An HTTPS loopback redirect requires a distinct `callbackPort` for the local HTTP listener behind your TLS terminator.
 
+`prompt` controls the OAuth `prompt` authorization parameter. By default OMP omits it, except that a requested `offline_access` scope defaults to `"consent"` so the provider can issue refresh access. Set it explicitly to a provider-supported value such as `"consent"` or `"select_account"`, or to `""` to force omission.
 
 `scopes` is a space-separated scope string for the authorization request, and takes precedence over every scope OMP would otherwise send: those discovered from authorization-server or protected-resource metadata, and any `scope` the provider embedded in its own authorization URL. Set it when the authorization server advertises a `scopes_supported` list the resource does not accept — a general-purpose corporate IdP fronting one MCP server typically advertises tenant-wide scopes (for example Amazon Cognito advertises `openid email phone profile`) while the resource requires its own resource-bound scope, so the discovered set is rejected with `invalid_scope` before sign-in. Setting `""` sends no `scope` parameter at all. The same value is registered as the RFC 7591 `scope` when the server requires dynamic client registration.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Configured discovery providers with `authHeader` now preserve cached models across application restarts.
 - Added repeat read warning hints when identical file content is read multiple times.
 - Explicit DAP adapters can now attach without a PID or port when `attachDefaults` provide the target arguments.
-- Added `isProjectTrusted()` compatibility shim to `ExtensionContext` for extensions targeting upstream per-directory trust gates.
+- Added an `oauth.scopes` field to per-server MCP configuration that takes precedence over the scopes discovered from authorization-server or protected-resource metadata (and over a `scope` embedded in the provider's authorization URL), so an MCP server behind a general-purpose corporate IdP can request its own resource-bound scope instead of the tenant-wide `scopes_supported` list the resource rejects; `""` sends no `scope` parameter at all ([#7841](https://github.com/can1357/oh-my-pi/issues/7841))
+- Codex `[mcp_servers.<name>] scopes` and OpenCode `mcp.<name>.oauth.scope` now import into `oauth.scopes` instead of being dropped ([#7841](https://github.com/can1357/oh-my-pi/issues/7841))
 
 ### Changed
 
@@ -31,7 +32,7 @@
 - The todo HUD header now displays a consolidated progress bar showing task completion across all stages.
 
 ### Fixed
-
+- Fixed OAuth scopes entered in the `/mcp add` wizard being used for that one authorization and then discarded, so `/mcp reauth` fell back to the discovered scopes the user had replaced; the wizard now records them as `oauth.scopes` ([#7841](https://github.com/can1357/oh-my-pi/issues/7841))
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Configured discovery providers with `authHeader` now preserve cached models across application restarts.
 - Added repeat read warning hints when identical file content is read multiple times.
 - Explicit DAP adapters can now attach without a PID or port when `attachDefaults` provide the target arguments.
+- Added `isProjectTrusted()` compatibility shim to `ExtensionContext` for extensions targeting upstream per-directory trust gates.
 - Added an `oauth.scopes` field to per-server MCP configuration that takes precedence over the scopes discovered from authorization-server or protected-resource metadata (and over a `scope` embedded in the provider's authorization URL), so an MCP server behind a general-purpose corporate IdP can request its own resource-bound scope instead of the tenant-wide `scopes_supported` list the resource rejects; `""` sends no `scope` parameter at all ([#7841](https://github.com/can1357/oh-my-pi/issues/7841))
 - Codex `[mcp_servers.<name>] scopes` and OpenCode `mcp.<name>.oauth.scope` now import into `oauth.scopes` instead of being dropped ([#7841](https://github.com/can1357/oh-my-pi/issues/7841))
 

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -53,13 +53,14 @@ export interface MCPServer {
 		clientSecret?: string;
 		resource?: string;
 	};
-	/** OAuth configuration (clientId, clientSecret, redirectUri, callbackPort, callbackPath, prompt) for servers requiring explicit client credentials */
+	/** OAuth configuration (clientId, clientSecret, redirectUri, callbackPort, callbackPath, scopes, prompt) for servers requiring explicit client credentials */
 	oauth?: {
 		clientId?: string;
 		clientSecret?: string;
 		redirectUri?: string;
 		callbackPort?: number;
 		callbackPath?: string;
+		scopes?: string;
 		prompt?: string;
 	};
 	/** Transport type */

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -99,6 +99,10 @@
         "callbackPath": {
           "type": "string"
         },
+        "scopes": {
+          "type": "string",
+          "description": "Space-separated OAuth scopes for the authorization request. Takes precedence over scopes discovered from authorization-server or protected-resource metadata and over a `scope` embedded in the provider's authorization URL; set to \"\" to send no `scope` parameter."
+        },
         "prompt": {
           "type": "string",
           "description": "OAuth `prompt` parameter sent during authorization (default: omit unless the requested scope contains `offline_access`, which sends \"consent\"; set to \"\" to always omit)."

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -190,6 +190,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 							redirectUri?: string;
 							callbackPort?: number;
 							callbackPath?: string;
+							scopes?: string;
 							prompt?: string;
 					  }
 					| undefined,

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -143,7 +143,7 @@ interface CodexMCPConfig {
 	startup_timeout_sec?: number;
 	tool_timeout_sec?: number;
 	enabled_tools?: string[];
-	disabled_tools?: string[];
+	scopes?: string[]; // OAuth scopes for the authorization request
 }
 
 function extractMCPServersFromToml(
@@ -223,6 +223,17 @@ function extractMCPServersFromToml(
 		// Map Codex tool_timeout_sec (seconds) to MCPServer timeout (milliseconds)
 		if (typeof config.tool_timeout_sec === "number" && config.tool_timeout_sec > 0) {
 			server.timeout = config.tool_timeout_sec * 1000;
+		}
+
+		// Codex lists OAuth scopes as an array; the canonical field holds the
+		// space-separated form the authorization request sends. An empty array is
+		// preserved as `""` rather than dropped: like `oauth.scopes: ""` it
+		// suppresses the `scope` parameter, which is a different request than
+		// sending discovered scopes.
+		if (Array.isArray(config.scopes)) {
+			server.oauth = {
+				scopes: config.scopes.filter(scope => typeof scope === "string" && scope.trim() !== "").join(" "),
+			};
 		}
 		result[name] = server;
 	}

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -47,6 +47,7 @@ interface MCPConfigFile {
 				redirectUri?: string;
 				callbackPort?: number;
 				callbackPath?: string;
+				scopes?: string;
 				prompt?: string;
 			};
 		}

--- a/packages/coding-agent/src/discovery/opencode.ts
+++ b/packages/coding-agent/src/discovery/opencode.ts
@@ -194,8 +194,9 @@ interface OpenCodeMCPConfig {
 	environment?: Record<string, string>;
 	url?: string;
 	headers?: Record<string, string>;
-	enabled?: boolean;
 	timeout?: number;
+	enabled?: boolean;
+	oauth?: { scope?: string } | false;
 }
 
 function stringArray(value: unknown): string[] | undefined {
@@ -300,15 +301,25 @@ function buildMCPServer(name: string, serverConfig: OpenCodeMCPConfig, source: O
 	} else if (serverConfig.command) {
 		transport = "stdio";
 	}
-
 	const command = normalizeCommand(serverConfig.command, serverConfig.args);
 	const env = stringRecord(serverConfig.environment) ?? stringRecord(serverConfig.env);
+
+	// OpenCode's singular `oauth.scope` is the same space-separated authorization
+	// scope string as the canonical `oauth.scopes`. `oauth: false` carries no
+	// scope, so it maps to no OAuth config at all. An empty `scope` is preserved
+	// rather than dropped: like `oauth.scopes: ""` it suppresses the `scope`
+	// parameter, which is a different request than sending discovered scopes.
+	const scopes =
+		typeof serverConfig.oauth === "object" && typeof serverConfig.oauth?.scope === "string"
+			? serverConfig.oauth.scope.trim()
+			: undefined;
 
 	return {
 		name,
 		command: command.command,
 		args: command.args,
 		env,
+		oauth: scopes === undefined ? undefined : { scopes },
 		url: typeof serverConfig.url === "string" ? serverConfig.url : undefined,
 		headers: serverConfig.headers && typeof serverConfig.headers === "object" ? serverConfig.headers : undefined,
 		enabled: serverConfig.enabled,

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -436,7 +436,7 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 		if (this.#resolvedClientId && !existingClientId) {
 			params.set("client_id", this.#resolvedClientId);
 		}
-	if (this.config.scopeOverride !== undefined) {
+		if (this.config.scopeOverride !== undefined) {
 			// An explicit override outranks a scope the provider embedded in its
 			// authorization URL: that embedded value is what the IdP advertises,
 			// not what the resource accepts.

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -304,8 +304,19 @@ export interface MCPOAuthConfig {
 	clientId?: string;
 	/** Client secret (optional for PKCE flows) */
 	clientSecret?: string;
-	/** OAuth scopes (space-separated) */
+	/**
+	 * OAuth scopes (space-separated) discovered from metadata or the challenge.
+	 * Applied only when {@link authorizationUrl} carries no `scope` of its own.
+	 */
 	scopes?: string;
+	/**
+	 * Explicit per-server scope override (`oauth.scopes` in MCP config). Unlike
+	 * {@link scopes} it replaces a `scope` already embedded in
+	 * {@link authorizationUrl}, because a general-purpose IdP fronting one MCP
+	 * server advertises tenant-wide scopes the resource rejects. Set to `""` to
+	 * send no `scope` parameter at all.
+	 */
+	scopeOverride?: string;
 	/**
 	 * `prompt` parameter for the authorization request. By default the parameter
 	 * is omitted, matching the reference MCP SDK, except for `offline_access`
@@ -425,7 +436,13 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 		if (this.#resolvedClientId && !existingClientId) {
 			params.set("client_id", this.#resolvedClientId);
 		}
-		if (this.config.scopes && !params.get("scope")) {
+	if (this.config.scopeOverride !== undefined) {
+			// An explicit override outranks a scope the provider embedded in its
+			// authorization URL: that embedded value is what the IdP advertises,
+			// not what the resource accepts.
+			if (this.config.scopeOverride) params.set("scope", this.config.scopeOverride);
+			else params.delete("scope");
+		} else if (this.config.scopes && !params.get("scope")) {
 			params.set("scope", this.config.scopes);
 		}
 		const prompt = this.config.prompt ?? (hasOAuthScope(params.get("scope"), "offline_access") ? "consent" : "");
@@ -596,9 +613,11 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 	 * probe surfaces a message that names the endpoint and status instead of
 	 * the historical opaque "OAuth provider requires client_id".
 	 *
-	 * Includes {@link MCPOAuthConfig.scopes} as RFC 7591 `scope` when set so
-	 * providers that bind DCR clients to registered scopes only (e.g. Clerk)
-	 * accept the later authorize request for the same scope set.
+	 * Includes the scopes the authorize request will carry
+	 * ({@link MCPOAuthConfig.scopeOverride}, else {@link MCPOAuthConfig.scopes})
+	 * as RFC 7591 `scope` when set, so providers that bind DCR clients to
+	 * registered scopes only (e.g. Clerk) accept the later authorize request for
+	 * the same scope set.
 	 */
 	async #tryRegisterClient(redirectUri: string): Promise<void> {
 		const registrationEndpoint = this.config.registrationUrl ?? (await this.#resolveRegistrationEndpoint());
@@ -613,7 +632,7 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 				token_endpoint_auth_method: "none",
 				application_type: "native",
 			};
-			const scope = this.config.scopes?.trim();
+		const scope = (this.config.scopeOverride ?? this.config.scopes)?.trim();
 			if (scope) {
 				registrationBody.scope = scope;
 			}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -89,6 +89,17 @@ interface MCPServerConfigBase {
 		redirectUri?: string;
 		callbackPort?: number;
 		callbackPath?: string;
+		/**
+		 * Space-separated OAuth scopes for the authorization request. Takes
+		 * precedence over the scopes discovered from authorization-server or
+		 * protected-resource metadata and over a `scope` embedded in the
+		 * provider's authorization URL, which is required when an authorization
+		 * server advertises tenant-wide `scopes_supported` that the resource does
+		 * not accept (e.g. Cognito advertising `openid email phone profile` while
+		 * the resource requires its own resource-bound scope). `""` sends no
+		 * `scope` parameter at all.
+		 */
+		scopes?: string;
 		/** `prompt` param for the authorization request (default "consent"; "" to omit) */
 		prompt?: string;
 	};

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -1219,7 +1219,9 @@ export class MCPAddWizard extends OverlayPanel {
 				this.#state.oauthScopes,
 				{
 					serverUrl: this.#state.url || undefined,
-				scopeOverride: this.#oauthScopeOverride(),
+					scopeOverride: this.#oauthScopeOverride(),
+					registrationUrl: this.#state.oauthRegistrationUrl || undefined,
+					resource: oauthResource || undefined,
 					abortSignal: this.#oauthAbort.signal,
 				},
 			);

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -56,14 +56,21 @@ interface MCPAddWizardOAuthOptions {
 	resource?: string;
 	registrationUrl?: string;
 	/**
+	 * Scopes the user entered in place of the discovered set, forwarded as the
+	 * authoritative `oauth.scopes` override so they also outrank a `scope`
+	 * embedded in the authorization URL. Absent when the user kept whatever
+	 * discovery produced.
+	 */
+	scopeOverride?: string;
+	/**
 	 * External cancellation source. Aborting it tears down the in-flight OAuth
 	 * flow and surfaces a neutral cancellation error. The wizard wires its own
 	 * controller here so Esc cancels the OAuth wait instead of stepping back
 	 * through the form (the wizard is focused, so the editor's Esc hook does
-	 * not fire).
 	 */
 	abortSignal?: AbortSignal;
 }
+
 
 interface WizardState {
 	name: string;
@@ -78,6 +85,12 @@ interface WizardState {
 	oauthClientId: string;
 	oauthClientSecret: string;
 	oauthScopes: string;
+	/**
+	 * Scopes discovery prefilled into {@link WizardState.oauthScopes}, so an
+	 * untouched value can be told apart from one the user chose. Only the
+	 * latter is persisted as an `oauth.scopes` override.
+	 */
+	oauthScopesDiscovered: string;
 	oauthResource: string;
 	oauthCredentialId: string | null;
 	apiKey: string;
@@ -110,6 +123,7 @@ export class MCPAddWizard extends OverlayPanel {
 		oauthClientId: "",
 		oauthClientSecret: "",
 		oauthScopes: "",
+		oauthScopesDiscovered: "",
 		oauthResource: "",
 		oauthCredentialId: null,
 		apiKey: "",
@@ -1013,7 +1027,8 @@ export class MCPAddWizard extends OverlayPanel {
 					this.#state.oauthTokenUrl = oauth.tokenUrl;
 					this.#state.oauthRegistrationUrl = oauth.registrationUrl || "";
 					this.#state.oauthClientId = oauth.clientId || "";
-					this.#state.oauthScopes = oauth.scopes || "";
+				this.#state.oauthScopes = oauth.scopes || "";
+				this.#state.oauthScopesDiscovered = this.#state.oauthScopes;
 					this.#state.oauthResource = oauth.resource || (this.#state.transport === "stdio" ? "" : this.#state.url);
 					this.#state.authMethod = "oauth";
 
@@ -1056,6 +1071,28 @@ export class MCPAddWizard extends OverlayPanel {
 		}
 	}
 
+	/**
+	 * Scopes the user chose over the discovered set, or `undefined` when they
+	 * kept discovery's answer. Persisting only a user-chosen value keeps
+	 * discovery results out of the config file, where they would freeze and
+	 * later shadow whatever the server advertises.
+	 */
+	#oauthScopeOverride(): string | undefined {
+		if (this.#state.authMethod !== "oauth") return undefined;
+		if (this.#state.oauthScopes === this.#state.oauthScopesDiscovered) return undefined;
+		return this.#state.oauthScopes;
+	}
+
+	/**
+	 * Persist a user-chosen scope override on the config so later
+	 * authorizations — notably `/mcp reauth` — reuse it instead of falling back
+	 * to discovery and re-requesting the set the user rejected.
+	 */
+	#applyOAuthScopeOverride(config: MCPServerConfig): void {
+		const scopes = this.#oauthScopeOverride();
+		if (scopes === undefined) return;
+		config.oauth = { ...config.oauth, scopes };
+	}
 	/**
 	 * Build a server config from current wizard state for connection testing (no auth).
 	 */
@@ -1182,8 +1219,7 @@ export class MCPAddWizard extends OverlayPanel {
 				this.#state.oauthScopes,
 				{
 					serverUrl: this.#state.url || undefined,
-					registrationUrl: this.#state.oauthRegistrationUrl || undefined,
-					resource: oauthResource || undefined,
+				scopeOverride: this.#oauthScopeOverride(),
 					abortSignal: this.#oauthAbort.signal,
 				},
 			);
@@ -1351,8 +1387,10 @@ export class MCPAddWizard extends OverlayPanel {
 				};
 			}
 
-			return config;
-		}
+		this.#applyOAuthScopeOverride(config);
+
+		return config;
+	}
 
 		// HTTP or SSE — use concrete type
 		const config: MCPHttpServerConfig | MCPSseServerConfig = {
@@ -1389,6 +1427,8 @@ export class MCPAddWizard extends OverlayPanel {
 				};
 			}
 		}
+
+		this.#applyOAuthScopeOverride(config);
 
 		return config;
 	}

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -728,8 +728,7 @@ export class MCPCommandController {
 								{
 									callbackPort: finalConfig.oauth?.callbackPort,
 									callbackPath: finalConfig.oauth?.callbackPath,
-									redirectUri: finalConfig.oauth?.redirectUri,
-									prompt: finalConfig.oauth?.prompt,
+								scopeOverride: finalConfig.oauth?.scopes,
 									registrationUrl: oauth.registrationUrl,
 									serverUrl: finalConfig.url,
 									resource: oauthResource,
@@ -809,6 +808,11 @@ export class MCPCommandController {
 		opts?: {
 			callbackPort?: number;
 			callbackPath?: string;
+			/**
+			 * Configured `oauth.scopes`, which outranks both `scopes` and any
+			 * `scope` embedded in the authorization URL. `""` sends no scope.
+			 */
+			scopeOverride?: string;
 			redirectUri?: string;
 			prompt?: string;
 			serverUrl?: string;
@@ -881,6 +885,7 @@ export class MCPCommandController {
 					clientId: resolvedClientId,
 					clientSecret: resolvedClientSecret,
 					scopes: scopes || undefined,
+					scopeOverride: opts?.scopeOverride,
 					prompt: opts?.prompt,
 					redirectUri: opts?.redirectUri,
 					callbackPort: opts?.callbackPort,
@@ -1898,8 +1903,7 @@ export class MCPCommandController {
 				{
 					callbackPort: found.config.oauth?.callbackPort,
 					callbackPath: found.config.oauth?.callbackPath,
-					redirectUri: found.config.oauth?.redirectUri,
-					prompt: found.config.oauth?.prompt,
+					scopeOverride: runtimeBaseConfig.oauth?.scopes,
 					registrationUrl: oauth.registrationUrl,
 					serverUrl,
 					resource: oauthResource,

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -728,7 +728,9 @@ export class MCPCommandController {
 								{
 									callbackPort: finalConfig.oauth?.callbackPort,
 									callbackPath: finalConfig.oauth?.callbackPath,
-								scopeOverride: finalConfig.oauth?.scopes,
+									redirectUri: finalConfig.oauth?.redirectUri,
+									prompt: finalConfig.oauth?.prompt,
+									scopeOverride: finalConfig.oauth?.scopes,
 									registrationUrl: oauth.registrationUrl,
 									serverUrl: finalConfig.url,
 									resource: oauthResource,
@@ -1903,6 +1905,8 @@ export class MCPCommandController {
 				{
 					callbackPort: found.config.oauth?.callbackPort,
 					callbackPath: found.config.oauth?.callbackPath,
+					redirectUri: found.config.oauth?.redirectUri,
+					prompt: found.config.oauth?.prompt,
 					scopeOverride: runtimeBaseConfig.oauth?.scopes,
 					registrationUrl: oauth.registrationUrl,
 					serverUrl,

--- a/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
+++ b/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
@@ -147,3 +147,31 @@ test("path-like command resolves against a subdirectory cwd, not the config dire
 	expect(nested?.cwd).toBe(path.join(codexDir, "server"));
 	expect(nested?.command).toBe(path.join(codexDir, "server", "bin", "mcp"));
 });
+
+test("Codex OAuth scopes import as the space-separated authorization scope string", async () => {
+	const codexDir = path.join(tempHome, ".codex");
+	await fs.writeFile(
+		path.join(codexDir, "config.toml"),
+		[
+			"[mcp_servers.gateway]",
+			'url = "https://gateway.example.com/mcp"',
+			'scopes = ["https://gateway.example.com/mcp/mcp.invoke", "openid"]',
+			"",
+			"[mcp_servers.suppressed]",
+			'url = "https://suppressed.example.com/mcp"',
+			"scopes = []",
+			"",
+			"[mcp_servers.plain]",
+			'url = "https://plain.example.com/mcp"',
+			"",
+		].join("\n"),
+	);
+
+	const servers = await loadCodexServers();
+
+	expect(servers.find(server => server.name === "gateway")?.oauth).toEqual({
+		scopes: "https://gateway.example.com/mcp/mcp.invoke openid",
+	});
+	expect(servers.find(server => server.name === "suppressed")?.oauth).toEqual({ scopes: "" });
+	expect(servers.find(server => server.name === "plain")?.oauth).toBeUndefined();
+});

--- a/packages/coding-agent/test/discovery/opencode.test.ts
+++ b/packages/coding-agent/test/discovery/opencode.test.ts
@@ -333,4 +333,31 @@ describe("OpenCode MCP discovery", () => {
 			delete Bun.env.OMP_TEST_MCP_PATH;
 		}
 	});
+
+	test("imports OpenCode oauth.scope as the canonical oauth.scopes override", async () => {
+		await fs.writeFile(
+			path.join(tempDir, "opencode.json"),
+			JSON.stringify({
+				mcp: {
+					gateway: {
+						type: "remote",
+						url: "https://gateway.example.com/mcp",
+						oauth: { clientId: "gateway-client", scope: "https://gateway.example.com/mcp/mcp.invoke openid" },
+					},
+					suppressed: { type: "remote", url: "https://suppressed.example.com/mcp", oauth: { scope: "" } },
+					noauth: { type: "remote", url: "https://plain.example.com/mcp", oauth: false },
+					plain: { type: "remote", url: "https://bare.example.com/mcp" },
+				},
+			}),
+		);
+
+		const servers = await loadOpenCodeMcpConfig(tempDir);
+
+		expect(servers.find(item => item.name === "gateway")?.oauth).toEqual({
+			scopes: "https://gateway.example.com/mcp/mcp.invoke openid",
+		});
+		expect(servers.find(item => item.name === "suppressed")?.oauth).toEqual({ scopes: "" });
+		expect(servers.find(item => item.name === "noauth")?.oauth).toBeUndefined();
+		expect(servers.find(item => item.name === "plain")?.oauth).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/mcp-add-wizard-oauth-scopes.test.ts
+++ b/packages/coding-agent/test/mcp-add-wizard-oauth-scopes.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { MCPAddWizard, type MCPAddWizardOAuthResult } from "@oh-my-pi/pi-coding-agent/modes/components/mcp-add-wizard";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+const ENTER = "\r";
+const ESCAPE = "\x1b";
+const DOWN = "\x1b[B";
+const BACKSPACE = "\x7f";
+
+/** Resource-bound scopes discovery returns (after #9100, resource scopes win). */
+const DISCOVERED_SCOPES = "https://gateway.example.com/mcp/mcp.invoke";
+/** Scopes the user substitutes for the discovered set. */
+const CHOSEN_SCOPES = "https://gateway.example.com/mcp/mcp.invoke openid";
+
+let server: Bun.Server<undefined> | null = null;
+
+beforeEach(async () => {
+	await initTheme(false, "unicode", false, "titanium", "light");
+});
+
+afterEach(() => {
+	server?.stop(true);
+	server = null;
+});
+
+/**
+ * Serve the metadata pair that reproduces the precedence the override exists
+ * for: the resource advertises one resource-bound scope while its authorization
+ * server advertises a tenant-wide list, and discovery resolves to the latter.
+ */
+function startMetadataServer(): string {
+	server = Bun.serve({
+		port: 0,
+		fetch(request) {
+			const { pathname, origin } = new URL(request.url);
+			if (pathname === "/.well-known/oauth-protected-resource") {
+				return Response.json({
+					resource: `${origin}/mcp`,
+					authorization_servers: [origin],
+					scopes_supported: ["https://gateway.example.com/mcp/mcp.invoke"],
+				});
+			}
+			if (pathname === "/.well-known/oauth-authorization-server") {
+				return Response.json({
+					issuer: origin,
+					authorization_endpoint: `${origin}/authorize`,
+					token_endpoint: `${origin}/token`,
+					client_id: "discovered-client",
+					scopes_supported: ["openid", "email", "phone", "profile"],
+				});
+			}
+			return new Response("not found", { status: 404 });
+		},
+	});
+	return server.url.origin;
+}
+
+/**
+ * Drive `/mcp add` to the point where the user replaces the scopes discovery
+ * chose, then authorizes again.
+ *
+ * Two things are observable, and losing either one returns the user to the
+ * scopes they rejected: the second authorization must carry their scopes as an
+ * override (so it also outranks a `scope` embedded in the authorization URL),
+ * and the saved config must record them so a later `/mcp reauth` does not fall
+ * back to discovery.
+ */
+test("scopes chosen in the wizard reach the retry and the saved config", async () => {
+	const origin = startMetadataServer();
+
+	const oauthCalls: Array<{ scopes: string; scopeOverride: string | undefined }> = [];
+	let probeCount = 0;
+	let savedConfig: MCPServerConfig | null = null;
+
+	const wizard = new MCPAddWizard(
+		(_name, config) => {
+			savedConfig = config;
+		},
+		() => {},
+		async (_authUrl, _tokenUrl, _clientId, _clientSecret, scopes, options): Promise<MCPAddWizardOAuthResult> => {
+			oauthCalls.push({ scopes, scopeOverride: options?.scopeOverride });
+			return { credentialId: "cred-1" };
+		},
+		async () => {
+			if (++probeCount === 1) {
+				throw new Error(
+					`HTTP 401: Unauthorized (WWW-Authenticate: Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource")`,
+				);
+			}
+		},
+		() => {},
+		"gateway",
+	);
+
+	wizard.handleInput(DOWN);
+	wizard.handleInput(ENTER);
+
+	for (const char of `${origin}/mcp`) wizard.handleInput(char);
+	wizard.handleInput(ENTER);
+
+	await waitFor(() => oauthCalls.length === 1, "the first authorization");
+	await waitFor(() => probeCount === 2, "the post-authorization health check");
+	await Bun.sleep(1200);
+
+	wizard.handleInput(ESCAPE);
+	for (let i = 0; i < DISCOVERED_SCOPES.length; i++) wizard.handleInput(BACKSPACE);
+	for (const char of CHOSEN_SCOPES) wizard.handleInput(char);
+	wizard.handleInput(ENTER);
+
+	await waitFor(() => oauthCalls.length === 2, "the second authorization");
+	await Bun.sleep(1200);
+
+	wizard.handleInput(ENTER);
+	wizard.handleInput(ENTER);
+	await waitFor(() => savedConfig !== null, "the wizard to save the server");
+
+	expect(oauthCalls[0]).toEqual({ scopes: DISCOVERED_SCOPES, scopeOverride: undefined });
+	expect(oauthCalls[1]).toEqual({ scopes: CHOSEN_SCOPES, scopeOverride: CHOSEN_SCOPES });
+	expect((savedConfig as unknown as MCPServerConfig).oauth?.scopes).toBe(CHOSEN_SCOPES);
+}, 30_000);
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (!predicate()) {
+		if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+		await Bun.sleep(10);
+	}
+}

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -303,6 +303,101 @@ describe("/mcp auth commands", () => {
 		expect(new URL(authorizationUrl).searchParams.get("resource")).toBe("https://gateway.example.com/mcp");
 	});
 
+	/**
+	 * Answer an auth challenge for a server whose authorization server advertises
+	 * tenant-wide `scopes_supported` (`openid email phone profile`) while the
+	 * resource advertises its own resource-bound scope, and report the `scope`
+	 * the resulting authorize request carries. Without a configured override the
+	 * tenant-wide list wins and the provider rejects the request with
+	 * `invalid_scope` before sign-in.
+	 */
+	async function scopeSentForOAuthConfig(
+		oauth: Record<string, unknown>,
+		authorizationEndpoint = "https://auth.example.com/authorize",
+	): Promise<string | null> {
+		await Bun.write(
+			configPath,
+			`${JSON.stringify({ mcpServers: { envserver: { type: "http", url: RAW_SERVER_URL, oauth } } }, null, 2)}\n`,
+		);
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(new Error("HTTP 401: Unauthorized"));
+
+		const resourceMetadataUrl = "https://gateway.example.com/.well-known/oauth-protected-resource";
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request): Promise<Response> => {
+				const url = String(input);
+				if (url === resourceMetadataUrl) {
+					return new Response(
+						JSON.stringify({
+							resource: "https://gateway.example.com/mcp",
+							authorization_servers: ["https://auth.example.com"],
+							scopes_supported: ["https://gateway.example.com/mcp/mcp.invoke"],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+					return new Response(
+						JSON.stringify({
+							authorization_endpoint: authorizationEndpoint,
+							token_endpoint: "https://auth.example.com/token",
+							client_id: "challenge-client",
+							scopes_supported: ["openid", "email", "phone", "profile"],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		let authorizationUrl = "";
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrl = (await this.generateAuthUrl("state", "http://127.0.0.1:53192/callback")).url;
+			return {
+				access: "fresh-access",
+				refresh: "fresh-refresh",
+				expires: Date.now() + 3_600_000,
+			};
+		});
+
+		const { controller, showError } = createController(authStorage);
+		await controller.handleMCPAuthChallenge("envserver", {
+			wwwAuthenticate: [`Bearer resource_metadata="${resourceMetadataUrl}"`],
+		});
+		expect(showError).not.toHaveBeenCalled();
+		return new URL(authorizationUrl).searchParams.get("scope");
+	}
+
+	test("configured oauth.scopes take precedence over discovered authorization-server scopes", async () => {
+		const scope = await scopeSentForOAuthConfig({ scopes: "https://gateway.example.com/mcp/mcp.invoke openid" });
+
+		expect(scope).toBe("https://gateway.example.com/mcp/mcp.invoke openid");
+	});
+
+	test("configured oauth.scopes replace a scope embedded in the discovered authorization endpoint", async () => {
+		const scope = await scopeSentForOAuthConfig(
+			{ scopes: "https://gateway.example.com/mcp/mcp.invoke openid" },
+			"https://auth.example.com/authorize?scope=server-default",
+		);
+
+		expect(scope).toBe("https://gateway.example.com/mcp/mcp.invoke openid");
+	});
+
+	test("empty oauth.scopes send no scope parameter even when the authorization endpoint embeds one", async () => {
+		const scope = await scopeSentForOAuthConfig(
+			{ scopes: "" },
+			"https://auth.example.com/authorize?scope=server-default",
+		);
+
+		expect(scope).toBeNull();
+	});
+
 	test("reauthorizes on a tool challenge even when the anonymous handshake succeeds", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -109,6 +109,80 @@ describe("mcp oauth flow", () => {
 		expect(authUrl.searchParams.get("client_id")).toBe("registered-client-id");
 	});
 
+	it("keeps a scope already embedded in the authorization URL over discovered scopes", async () => {
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://provider.example/authorize?scope=server-default",
+				tokenUrl: "https://provider.example/token",
+				clientId: "client-id",
+				scopes: "openid email phone profile",
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("s", "http://127.0.0.1:53185/callback");
+
+		expect(new URL(url).searchParams.get("scope")).toBe("server-default");
+	});
+
+	it("replaces a scope embedded in the authorization URL with the configured override", async () => {
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://provider.example/authorize?scope=server-default",
+				tokenUrl: "https://provider.example/token",
+				clientId: "client-id",
+				scopes: "openid email phone profile",
+				scopeOverride: "https://gateway.example.com/mcp/mcp.invoke openid",
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("s", "http://127.0.0.1:53186/callback");
+
+		expect(new URL(url).searchParams.get("scope")).toBe("https://gateway.example.com/mcp/mcp.invoke openid");
+	});
+
+	it("removes an embedded scope when the override is the empty string", async () => {
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://provider.example/authorize?scope=server-default",
+				tokenUrl: "https://provider.example/token",
+				clientId: "client-id",
+				scopes: "openid email phone profile",
+				scopeOverride: "",
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("s", "http://127.0.0.1:53187/callback");
+
+		expect(new URL(url).searchParams.has("scope")).toBe(false);
+	});
+
+	it("registers the override rather than the discovered scopes with dynamic client registration", async () => {
+		let registrationPayload: Record<string, unknown> | null = null;
+		const scopeOverride = "https://gateway.example.com/mcp/mcp.invoke openid";
+
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://www.figma.com/oauth/mcp",
+				tokenUrl: "https://api.figma.com/v1/oauth/token",
+				registrationUrl: "https://www.figma.com/oauth/register",
+				scopes: "openid email phone profile",
+				scopeOverride,
+				fetch: mockFigmaRegistration(payload => {
+					registrationPayload = payload;
+				}),
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("test-state", "http://127.0.0.1:53188/callback");
+
+		expect((registrationPayload as { scope?: string } | null)?.scope).toBe(scopeOverride);
+		expect(new URL(url).searchParams.get("scope")).toBe(scopeOverride);
+	});
+
 	it("omits prompt by default so provider-specific reauth pages can use returning grants", async () => {
 		const flow = new MCPOAuthFlow(
 			{


### PR DESCRIPTION
## What

Adds an optional `oauth.scopes` field to per-server MCP configuration, as proposed in #7841. It is a space-separated scope string that takes precedence over the scopes OMP would otherwise send, and it applies to the initial OAuth connection and to `/mcp reauth`. Token refresh continues to use the provider-issued grant. Omitting the field leaves discovery behavior unchanged.

Supersedes #8475 — same feature, rebased on current main (217 commits ahead of the original branch), with both blocking review issues resolved and the wizard test updated for the #9100 discovery-precedence fix that landed in the meantime.

## Why

`discoverOAuthEndpoints` resolves scopes from the authorization server's `scopes_supported` list. For a general-purpose IdP fronting one MCP server that only has 4 scopses mapped, the discovered set is rejected with `invalid_scope` before sign-in. The #9100 fix handles the case where the protected-resource metadata advertises its own `scopes_supported`, but servers that publish no resource metadata still send the full issuer catalogue.

An explicit `oauth.scopes` value solves both cases:

```json
"oauth": { "clientId": "grafana-mcp", "scopes": "openid email profile offline_access" }
```

## Review issues from #8475 (both resolved)

**Blocking — empty override did not suppress embedded scope.** The `generateAuthUrl` scope handling now checks `scopeOverride` before falling through to `scopes` or the embedded `scope` parameter. `scopeOverride === ""` calls `params.delete("scope")`, removing any scope the provider embedded in its authorization URL. Covered by `oauth-flow.test.ts` ("removes an embedded scope when the override is the empty string") and `mcp-command-reauth.test.ts` ("empty oauth.scopes send no scope parameter even when the authorization endpoint embeds one").

**Should-fix — Codex/OpenCode importers dropped their native scope settings.** Both importers now map into `oauth.scopes`:
- Codex `[mcp_servers.<name>] scopes` (array) → space-joined `oauth.scopes`; empty array → `""`.
- OpenCode `mcp.<name>.oauth.scope` (string) → `oauth.scopes`; empty string → `""`; `oauth: false` → no oauth config.

Covered by `codex-mcp-cwd.test.ts` and `opencode.test.ts`.

## Changes since #8475

- Rebased on current `main` (includes #9100 — RFC 9728 resource scopes now win over auth-server catalogue).
- Updated `mcp-add-wizard-oauth-scopes.test.ts`: the wizard test's first authorization now expects the resource-bound scopes (#9100 changes what discovery returns), not the tenant-wide auth-server scopes the original test assumed.
- No other logic changes — the two review fixes were already present in the #8475 branch's final revision; the maintainer's review comments were on an earlier iteration.

## Testing

`bunx tsc --noEmit` — clean.
`bun test` focused suites — 82 pass, 0 fail:

- `oauth-flow.test.ts` (51 pass, including 5 new: embedded scope preservation, override replacement, empty override removal, DCR override registration)
- `mcp-command-reauth.test.ts` (16 pass, including 3 new: configured scopes precedence, embedded scope replacement, empty scopes suppression)
- `discovery/codex-mcp-cwd.test.ts` (5 pass, including 1 new: Codex scopes array import)
- `discovery/opencode.test.ts` (9 pass, including 1 new: OpenCode oauth.scope import)
- `mcp-add-wizard-oauth-scopes.test.ts` (1 pass: wizard scope override reaches retry and saved config)

End-to-end check against the MCP metadata shape (Keycloak realm advertising 72 scopes, `grafana-mcp` client mapped for 4): with `oauth.scopes: "openid email profile offline_access"`, the authorization request sends exactly those 4 scopes instead of the 72-scope catalogue.

Closes #7841.