### PR TITLE
fix(slash-commands): dispatch /compact in the background so RPC abort can overtake it

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -137,24 +137,36 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		handle: async (command, runtime) => {
 			const parsed = parseCompactArgs(command.args);
 			if ("error" in parsed) return usage(parsed.error, runtime);
-			const before = runtime.session.getContextUsage?.();
-			const beforeTokens = before?.tokens;
-			try {
-				await runtime.session.compact(parsed.instructions, parsed.mode ? { mode: parsed.mode } : undefined);
-			} catch (err) {
-				// Compaction precondition failures (no model, already compacted, too
-				// small) and provider errors propagate as plain Errors; surface them
-				// via runtime.output so they don't fail the ACP prompt turn.
-				return usage(`Compaction failed: ${errorMessage(err)}`, runtime);
+			const runCompact = async (): Promise<void> => {
+				const before = runtime.session.getContextUsage?.();
+				const beforeTokens = before?.tokens;
+				try {
+					await runtime.session.compact(parsed.instructions, parsed.mode ? { mode: parsed.mode } : undefined);
+				} catch (err) {
+					// Compaction precondition failures (no model, already compacted, too
+					// small) and provider errors propagate as plain Errors; surface them
+					// via runtime.output so they don't fail the ACP prompt turn.
+					await runtime.output(`Compaction failed: ${errorMessage(err)}`);
+					return;
+				}
+				const after = runtime.session.getContextUsage?.();
+				const afterTokens = after?.tokens;
+				if (beforeTokens != null && afterTokens != null) {
+					const saved = beforeTokens - afterTokens;
+					await runtime.output(`Compaction complete. Tokens: ${beforeTokens} -> ${afterTokens} (saved ${saved}).`);
+				} else {
+					await runtime.output("Compaction complete.");
+				}
+			};
+			// `/compact` is provider-backed: it calls the model to summarize. RPC's
+			// prompt API must return immediately so its serialized command queue stays
+			// free for `abort` — the same contract `/handoff` uses. Hosts that omit the
+			// hook (ACP, TUI) keep the inline await.
+			if (runtime.runCommandInBackground) {
+				runtime.runCommandInBackground(runCompact);
+				return commandConsumed();
 			}
-			const after = runtime.session.getContextUsage?.();
-			const afterTokens = after?.tokens;
-			if (beforeTokens != null && afterTokens != null) {
-				const saved = beforeTokens - afterTokens;
-				await runtime.output(`Compaction complete. Tokens: ${beforeTokens} -> ${afterTokens} (saved ${saved}).`);
-			} else {
-				await runtime.output("Compaction complete.");
-			}
+			await runCompact();
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {

--- a/packages/coding-agent/test/slash-commands/compact.test.ts
+++ b/packages/coding-agent/test/slash-commands/compact.test.ts
@@ -95,3 +95,66 @@ describe("/compact dispatch (TUI)", () => {
 		expect(h.showWarning).toHaveBeenCalled();
 	});
 });
+
+describe("/compact background dispatch (RPC)", () => {
+	it("leaves the command queue free while compaction runs", async () => {
+		// `/compact` is provider-backed, so RPC must get its prompt response back
+		// immediately; otherwise the serialized command queue stays blocked for the
+		// whole model round-trip and a follow-up `abort` can never be dequeued.
+		const compactStarted = Promise.withResolvers<void>();
+		const compactFinished = Promise.withResolvers<void>();
+		const h = acpRuntime();
+		h.compact.mockImplementation(async () => {
+			compactStarted.resolve();
+			await compactFinished.promise;
+		});
+		const backgroundTasks: Promise<void>[] = [];
+		h.runtime.runCommandInBackground = task => {
+			backgroundTasks.push(task());
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		await compactStarted.promise;
+		expect(result).toEqual({ consumed: true });
+		expect(h.output).not.toHaveBeenCalled();
+
+		compactFinished.resolve();
+		await Promise.all(backgroundTasks);
+		expect(h.output).toHaveBeenCalledWith("Compaction complete.");
+	});
+
+	it("keeps the inline await when the host has no background hook", async () => {
+		const h = acpRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(h.output).toHaveBeenCalledWith("Compaction complete.");
+	});
+
+	it("surfaces compaction failures raised on the background path", async () => {
+		const h = acpRuntime();
+		h.compact.mockImplementation(async () => {
+			throw new Error("No model selected");
+		});
+		const backgroundTasks: Promise<void>[] = [];
+		h.runtime.runCommandInBackground = task => {
+			backgroundTasks.push(task());
+		};
+		const result = await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		expect(result).toEqual({ consumed: true });
+		await Promise.all(backgroundTasks);
+		expect(h.output).toHaveBeenCalledWith("Compaction failed: No model selected");
+	});
+
+	it("keeps argument validation on the prompt response path", async () => {
+		// Validation belongs to the response that carried the bad arguments, so it
+		// must not be deferred into the background task.
+		const h = acpRuntime();
+		const backgroundTasks: Promise<void>[] = [];
+		h.runtime.runCommandInBackground = task => {
+			backgroundTasks.push(task());
+		};
+		await executeAcpBuiltinSlashCommand("/compact snapcompact keep the diffs", h.runtime);
+		expect(backgroundTasks).toHaveLength(0);
+		expect(h.compact).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes #9200.

## Problem

`b1243e0e` ("fix(rpc): keep handoff prompt response non-blocking") added the `runCommandInBackground` hook to `SlashCommandRuntime`. Its contract in `slash-commands/types.ts` says RPC provides the hook **"for provider-backed commands because its prompt API must return immediately and leave the serialized queue free for `abort`"**.

Only `/handoff` was converted. `/compact` is equally provider-backed (it runs an LLM summarization round-trip) and still `await`s `runtime.session.compact(...)` inline.

Over RPC that holds the serialized command queue for the entire model round-trip, so a follow-up `abort` can never be dequeued:

- `modes/rpc/rpc-mode.ts:1003` — the hook is provided: `runCommandInBackground: task => shutdownCoordinator.track(task())`
- `modes/rpc/rpc-mode.ts:995` — the builtin is awaited inside the serialized dispatcher
- `modes/rpc/rpc-mode.ts:331` — only `bash` is background-dispatched today
- `modes/rpc/rpc-mode.ts:1491` — "ordinary commands serialize through inputDispatcher, and bash remains background-dispatched so abort_bash can overtake it"
- `modes/rpc/rpc-mode.ts:1056` — `case "abort"` runs on that same serialized queue
- `modes/rpc/rpc-mode.ts:278` — `dispatchRpcControlFrame` does **not** include `abort`, so there is no bypass

Net effect: `/compact` is uninterruptible over RPC. This is the same class of defect as the already-accepted-and-fixed #4027 / #4079 (`abort_bash` queued behind its own bash).

## Fix

In `slash-commands/builtin-lifecycle.ts`, mirror the `/handoff` spec directly below it:

1. Keep `parseCompactArgs` validation **synchronous** — a bad-argument error belongs to the response that carried the bad arguments, not to a detached task.
2. Move the provider work into a `runCompact` closure.
3. Dispatch via `runtime.runCommandInBackground` when the host provides it; otherwise fall back to the existing inline `await`, so TUI and every non-RPC host are byte-for-byte unchanged.

The failure branch's `return usage(...)` becomes `await runtime.output(...)` + a bare `return`, which is behaviour-preserving: `usage(text, runtime)` is exactly `await runtime.output(text); return commandConsumed();` (`slash-commands/helpers/parse.ts`).

## Tests

Appended a `/compact background dispatch (RPC)` block to the existing `test/slash-commands/compact.test.ts` (existing cases untouched):

- the command queue is released **before** compaction finishes — fails on `main`, passes here
- the inline `await` is preserved when the host provides no background hook
- background failures still reach the user through `runtime.output`
- argument validation stays on the prompt response path (no background task is spawned)

## Risk

Low and additive. No behaviour change for any host that does not provide `runCommandInBackground`; on RPC the task is tracked by `shutdownCoordinator`, exactly as `/handoff` already is.