### PR TITLE
fix(rpc): background-dispatch /compact so abort can interrupt it

### DIFF
--- a/packages/agent/src/compaction/errors.ts
+++ b/packages/agent/src/compaction/errors.ts
@@ -13,8 +13,8 @@
 export class CompactionCancelledError extends Error {
 	override readonly name = "CompactionCancelledError" as const;
 
-	constructor(message = "Compaction cancelled") {
-		super(message);
+	constructor(message = "Compaction cancelled", options?: ErrorOptions) {
+		super(message, options);
 	}
 }
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed `/compact` over RPC blocking the serialized command queue for the full summarization round-trip, so a follow-up `abort` could not interrupt it ([#9200](https://github.com/can1357/oh-my-pi/issues/9200)).
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4825,7 +4825,7 @@ export class AgentSession {
 
 	/** Cancel active manual, automatic, and handoff maintenance, preserving an optional source reason. */
 	abortCompaction(reason?: unknown): void {
-		this.#maintenance.abortCompaction(reason);
+		void this.#maintenance.abortCompaction(reason);
 	}
 
 	/** Trigger idle compaction through the automatic maintenance flow. */
@@ -6819,6 +6819,7 @@ export class AgentSession {
 			// Abort the handoff first so generic compaction cancellation cannot replace
 			// the harness reason with an unreasoned "Handoff cancelled".
 			this.#handoff.abortHandoff(new Error(options?.reason ?? "Handoff aborted by session"));
+			let manualCompactionCleanup: Promise<void> | undefined;
 			if (options?.preserveCompaction) {
 				// Manual `/compact` installed its own #compactionAbortController before
 				// this internal abort and must keep it alive (that marker is what makes
@@ -6828,7 +6829,7 @@ export class AgentSession {
 				// appendCompaction/replaceMessages, double-rewriting session history.
 				this.#maintenance.abortAutomaticCompaction();
 			} else {
-				this.abortCompaction(options?.reason);
+				manualCompactionCleanup = this.#maintenance.abortCompaction(options?.reason);
 			}
 			this.abortBash();
 			this.abortEval();
@@ -6836,6 +6837,10 @@ export class AgentSession {
 			this.agent.abort(options?.reason);
 			await postPromptDrain;
 			await this.agent.waitForIdle();
+			// `/compact` disconnects the agent subscription until its finally block.
+			// Do not let abort-and-replace callers start a new prompt before that cleanup
+			// finishes, or the replacement turn's events are neither forwarded nor persisted.
+			await manualCompactionCleanup;
 			await this.#drainAutolearnCapture();
 			await this.#goalRuntime.onTaskAborted({ reason: options?.goalReason ?? "interrupted" });
 			// Clear prompt-in-flight state: waitForIdle resolves when the agent loop's finally

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4823,9 +4823,9 @@ export class AgentSession {
 		return this.#maintenance.compact(customInstructions, options);
 	}
 
-	/** Cancel active manual, automatic, and handoff maintenance. */
-	abortCompaction(): void {
-		this.#maintenance.abortCompaction();
+	/** Cancel active manual, automatic, and handoff maintenance, preserving an optional source reason. */
+	abortCompaction(reason?: unknown): void {
+		this.#maintenance.abortCompaction(reason);
 	}
 
 	/** Trigger idle compaction through the automatic maintenance flow. */
@@ -6828,7 +6828,7 @@ export class AgentSession {
 				// appendCompaction/replaceMessages, double-rewriting session history.
 				this.#maintenance.abortAutomaticCompaction();
 			} else {
-				this.abortCompaction();
+				this.abortCompaction(options?.reason);
 			}
 			this.abortBash();
 			this.abortEval();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5436,6 +5436,12 @@ export class AgentSession {
 	 * the ACP agent) use this to know whether to expect an `agent_end` event.
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<boolean> {
+		// A manual `/compact` runs with the agent subscription disconnected until its
+		// cleanup finally re-drains the preserved queues. Starting a turn before then
+		// would neither persist nor forward its events and could race the in-flight
+		// history rewrite. `abort` still overtakes compaction; ordinary prompts wait
+		// here. No-op when no manual compaction is active.
+		await this.#maintenance.manualCompactionCleanup;
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		// Slash/custom-command handling below rewrites `text`; keep the original
 		// so a dropped prompt is handed back exactly as the user typed it.

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1075,6 +1075,16 @@ export class SessionMaintenance {
 		return manualCompactionCleanup;
 	}
 
+	/**
+	 * Resolves once an in-flight manual compaction has reconnected the agent
+	 * subscription and re-drained its preserved queues; `undefined` when no manual
+	 * compaction is active. Callers that must not start a turn against the
+	 * disconnected session (e.g. ordinary prompts) await this first.
+	 */
+	get manualCompactionCleanup(): Promise<void> | undefined {
+		return this.#manualCompactionCleanup;
+	}
+
 	/** Cancel only automatic maintenance while preserving a manual compaction. */
 	abortAutomaticCompaction(): void {
 		this.#autoCompactionAbortController?.abort();

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -320,6 +320,8 @@ export interface SessionMaintenanceHost {
 /** Owns compaction, pruning, shake, promotion, and automatic context maintenance. */
 export class SessionMaintenance {
 	#compactionAbortController: AbortController | undefined;
+	/** Resolves after an active manual compaction has reconnected the agent subscription. */
+	#manualCompactionCleanup: Promise<void> | undefined;
 	#autoCompactionAbortController: AbortController | undefined;
 	/**
 	 * Live tool-loop contexts parked after mid-turn maintenance hit a no-progress
@@ -674,8 +676,10 @@ export class SessionMaintenance {
 		let compactionCommitted = false;
 		let methodAttempted = false;
 		const compactionAbortController = retryController ?? new AbortController();
+		const manualCompactionCleanup = ownsCompactionController ? Promise.withResolvers<void>() : undefined;
 		if (ownsCompactionController) {
 			this.#compactionAbortController = compactionAbortController;
+			this.#manualCompactionCleanup = manualCompactionCleanup?.promise;
 		}
 		// A manual pass supersedes any background speculation; running both would
 		// double-bill the summarizer and race the commit.
@@ -1025,6 +1029,10 @@ export class SessionMaintenance {
 				// queues, so nothing else resumes them: re-drain now that the listener is back
 				// and `isCompacting` is false, or the queued turn hangs until the next prompt.
 				this.#host.drainStrandedQueuedMessages();
+				if (this.#manualCompactionCleanup === manualCompactionCleanup?.promise) {
+					this.#manualCompactionCleanup = undefined;
+				}
+				manualCompactionCleanup?.resolve();
 			}
 		}
 	}
@@ -1055,11 +1063,16 @@ export class SessionMaintenance {
 		}
 	}
 
-	/** Cancel in-progress context maintenance, preserving an optional source reason. */
-	abortCompaction(reason?: unknown): void {
+	/**
+	 * Cancel in-progress context maintenance and return the active manual pass's
+	 * cleanup barrier. The barrier resolves only after its agent subscription reconnects.
+	 */
+	abortCompaction(reason?: unknown): Promise<void> | undefined {
+		const manualCompactionCleanup = this.#manualCompactionCleanup;
 		this.#compactionAbortController?.abort(reason);
 		this.#autoCompactionAbortController?.abort(reason);
 		this.#host.abortHandoff();
+		return manualCompactionCleanup;
 	}
 
 	/** Cancel only automatic maintenance while preserving a manual compaction. */

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -949,17 +949,24 @@ export class SessionMaintenance {
 					preserveData = mergeLlmCompactionPreserveData(compactionPrep.preserveData, result.preserveData);
 				} catch (err) {
 					if (err instanceof CompactionCancelledError) {
-						throw err;
+						if (!compactionAbortController.signal.aborted || err.cause !== undefined) throw err;
+						throw new CompactionCancelledError(err.message, {
+							cause: compactionAbortController.signal.reason,
+						});
 					}
 					if (compactionAbortController.signal.aborted && err instanceof Error && err.name === "AbortError") {
-						throw new CompactionCancelledError();
+						throw new CompactionCancelledError(undefined, {
+							cause: compactionAbortController.signal.reason,
+						});
 					}
 					throw err;
 				}
 			}
 
 			if (compactionAbortController.signal.aborted) {
-				throw new CompactionCancelledError();
+				throw new CompactionCancelledError(undefined, {
+					cause: compactionAbortController.signal.reason,
+				});
 			}
 
 			compactionCommitted = true;
@@ -1048,12 +1055,10 @@ export class SessionMaintenance {
 		}
 	}
 
-	/**
-	 * Cancel in-progress context maintenance (manual compaction, auto-compaction, or auto-handoff).
-	 */
-	abortCompaction(): void {
-		this.#compactionAbortController?.abort();
-		this.#autoCompactionAbortController?.abort();
+	/** Cancel in-progress context maintenance, preserving an optional source reason. */
+	abortCompaction(reason?: unknown): void {
+		this.#compactionAbortController?.abort(reason);
+		this.#autoCompactionAbortController?.abort(reason);
 		this.#host.abortHandoff();
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { CompactionCancelledError } from "@oh-my-pi/pi-agent-core/compaction";
 import { logger, setProjectDir } from "@oh-my-pi/pi-utils";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
@@ -137,24 +138,41 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		handle: async (command, runtime) => {
 			const parsed = parseCompactArgs(command.args);
 			if ("error" in parsed) return usage(parsed.error, runtime);
-			const before = runtime.session.getContextUsage?.();
-			const beforeTokens = before?.tokens;
-			try {
-				await runtime.session.compact(parsed.instructions, parsed.mode ? { mode: parsed.mode } : undefined);
-			} catch (err) {
-				// Compaction precondition failures (no model, already compacted, too
-				// small) and provider errors propagate as plain Errors; surface them
-				// via runtime.output so they don't fail the ACP prompt turn.
-				return usage(`Compaction failed: ${errorMessage(err)}`, runtime);
+			const runCompact = async (): Promise<void> => {
+				const before = runtime.session.getContextUsage?.();
+				const beforeTokens = before?.tokens;
+				try {
+					await runtime.session.compact(parsed.instructions, parsed.mode ? { mode: parsed.mode } : undefined);
+				} catch (err) {
+					// A user interrupt (RPC `abort`, ACP `session/cancel`) aborts the
+					// in-flight compaction, surfacing as CompactionCancelledError. The
+					// client already saw the interrupt it sent; emitting anything here
+					// would append an out-of-turn chunk, so stay silent — mirroring
+					// /handoff's USER_INTERRUPT_LABEL path.
+					if (err instanceof CompactionCancelledError) return;
+					// Compaction precondition failures (no model, already compacted, too
+					// small) and provider errors propagate as plain Errors; surface them
+					// via runtime.output so they don't fail the ACP prompt turn.
+					await runtime.output(`Compaction failed: ${errorMessage(err)}`);
+					return;
+				}
+				const after = runtime.session.getContextUsage?.();
+				const afterTokens = after?.tokens;
+				if (beforeTokens != null && afterTokens != null) {
+					const saved = beforeTokens - afterTokens;
+					await runtime.output(`Compaction complete. Tokens: ${beforeTokens} -> ${afterTokens} (saved ${saved}).`);
+				} else {
+					await runtime.output("Compaction complete.");
+				}
+			};
+			// Provider-backed: background-dispatch under RPC so the serialized command
+			// queue stays free for `abort` (SlashCommandRuntime.runCommandInBackground).
+			// ACP/TUI have no such hook and keep the inline await.
+			if (runtime.runCommandInBackground) {
+				runtime.runCommandInBackground(runCompact);
+				return commandConsumed();
 			}
-			const after = runtime.session.getContextUsage?.();
-			const afterTokens = after?.tokens;
-			if (beforeTokens != null && afterTokens != null) {
-				const saved = beforeTokens - afterTokens;
-				await runtime.output(`Compaction complete. Tokens: ${beforeTokens} -> ${afterTokens} (saved ${saved}).`);
-			} else {
-				await runtime.output("Compaction complete.");
-			}
+			await runCompact();
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -144,12 +144,12 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 				try {
 					await runtime.session.compact(parsed.instructions, parsed.mode ? { mode: parsed.mode } : undefined);
 				} catch (err) {
-					// A user interrupt (RPC `abort`, ACP `session/cancel`) aborts the
-					// in-flight compaction, surfacing as CompactionCancelledError. The
-					// client already saw the interrupt it sent; emitting anything here
-					// would append an out-of-turn chunk, so stay silent — mirroring
-					// /handoff's USER_INTERRUPT_LABEL path.
-					if (err instanceof CompactionCancelledError) return;
+					// RPC `abort` and ACP `session/cancel` propagate their explicit
+					// USER_INTERRUPT_LABEL through the compaction abort signal. The client
+					// already saw the interrupt it sent; emitting anything here would
+					// append an out-of-turn chunk. Other cancellations (including an
+					// extension veto) remain visible.
+					if (err instanceof CompactionCancelledError && err.cause === USER_INTERRUPT_LABEL) return;
 					// Compaction precondition failures (no model, already compacted, too
 					// small) and provider errors propagate as plain Errors; surface them
 					// via runtime.output so they don't fail the ACP prompt turn.

--- a/packages/coding-agent/test/agent-session-compaction-cancellation.test.ts
+++ b/packages/coding-agent/test/agent-session-compaction-cancellation.test.ts
@@ -134,4 +134,34 @@ describe("AgentSession compaction cancellation source", () => {
 		const error = await cancellation;
 		expect(error.cause).toBe(USER_INTERRUPT_LABEL);
 	});
+
+	it("blocks an ordinary prompt until manual compaction cleanup resolves", async () => {
+		const started = Promise.withResolvers<void>();
+		const gate = Promise.withResolvers<void>();
+		session = await createSession("park", started.resolve, gate.promise);
+
+		// The turn dispatch seam: prompt() must not reach it while compaction holds
+		// the agent subscription disconnected.
+		const agentPrompt = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {});
+
+		const compaction = session.compact();
+		await started.promise;
+
+		let promptSettled = false;
+		const promptPromise = session.prompt("normal prompt").then(result => {
+			promptSettled = true;
+			return result;
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(session.isCompacting).toBe(true);
+		expect(agentPrompt).not.toHaveBeenCalled();
+		expect(promptSettled).toBe(false);
+
+		gate.resolve();
+		await compaction;
+		await promptPromise;
+		expect(agentPrompt).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/agent-session-compaction-cancellation.test.ts
+++ b/packages/coding-agent/test/agent-session-compaction-cancellation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent, CompactionCancelledError } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -110,18 +110,28 @@ describe("AgentSession compaction cancellation source", () => {
 		expect(error.cause).toBeUndefined();
 	});
 
-	it("carries the user-interrupt reason from the real abort path", async () => {
+	it("waits for manual compaction cleanup before starting a replacement prompt", async () => {
 		const started = Promise.withResolvers<void>();
 		const gate = Promise.withResolvers<void>();
 		session = await createSession("park", started.resolve, gate.promise);
 
-		const compactPromise = session.compact();
+		const cancellation = cancellationFrom(session.compact());
 		await started.promise;
-		const abortPromise = session.abort({ reason: USER_INTERRUPT_LABEL });
-		gate.resolve();
-		await abortPromise;
+		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(true);
+		const abortAndPrompt = session
+			.abort({ reason: USER_INTERRUPT_LABEL })
+			.then(() => session.prompt("replacement prompt"));
 
-		const error = await cancellationFrom(compactPromise);
+		await Promise.resolve();
+		expect(prompt).not.toHaveBeenCalled();
+		expect(session.isCompacting).toBe(true);
+
+		gate.resolve();
+		await abortAndPrompt;
+		expect(session.isCompacting).toBe(false);
+		expect(prompt).toHaveBeenCalledWith("replacement prompt");
+
+		const error = await cancellation;
 		expect(error.cause).toBe(USER_INTERRUPT_LABEL);
 	});
 });

--- a/packages/coding-agent/test/agent-session-compaction-cancellation.test.ts
+++ b/packages/coding-agent/test/agent-session-compaction-cancellation.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Agent, CompactionCancelledError } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+type HookMode = "extension-veto" | "park";
+
+describe("AgentSession compaction cancellation source", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-compaction-cancellation-");
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	async function createSession(mode: HookMode, entered?: () => void, gate?: Promise<void>): Promise<AgentSession> {
+		const runtime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => {
+				pi.on("session_before_compact", async event => {
+					if (mode === "extension-veto") return { cancel: true };
+					entered?.();
+					await gate;
+					return {
+						compaction: {
+							summary: "compacted",
+							shortSummary: undefined,
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					};
+				});
+			},
+			tempDir.path(),
+			new EventBus(),
+			runtime,
+			"compaction-cancellation-source",
+		);
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		const modelRegistry = new ModelRegistry(authStorage);
+		const extensionRunner = new ExtensionRunner([extension], runtime, tempDir.path(), sessionManager, modelRegistry);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic model");
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+
+		sessionManager.appendMessage({ role: "user", content: "first turn", timestamp: Date.now() });
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "first answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		sessionManager.appendMessage({ role: "user", content: "second turn", timestamp: Date.now() });
+
+		return new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.keepRecentTokens": 1 }),
+			modelRegistry,
+			extensionRunner,
+		});
+	}
+
+	async function cancellationFrom(promise: Promise<unknown>): Promise<CompactionCancelledError> {
+		try {
+			await promise;
+		} catch (error) {
+			if (error instanceof CompactionCancelledError) return error;
+			throw error;
+		}
+		throw new Error("Expected compaction cancellation");
+	}
+
+	it("leaves extension vetoes unmarked as user interrupts", async () => {
+		session = await createSession("extension-veto");
+
+		const error = await cancellationFrom(session.compact());
+		expect(error.cause).toBeUndefined();
+	});
+
+	it("carries the user-interrupt reason from the real abort path", async () => {
+		const started = Promise.withResolvers<void>();
+		const gate = Promise.withResolvers<void>();
+		session = await createSession("park", started.resolve, gate.promise);
+
+		const compactPromise = session.compact();
+		await started.promise;
+		const abortPromise = session.abort({ reason: USER_INTERRUPT_LABEL });
+		gate.resolve();
+		await abortPromise;
+
+		const error = await cancellationFrom(compactPromise);
+		expect(error.cause).toBe(USER_INTERRUPT_LABEL);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/compact.test.ts
+++ b/packages/coding-agent/test/slash-commands/compact.test.ts
@@ -3,6 +3,7 @@ import { CompactionCancelledError } from "@oh-my-pi/pi-agent-core/compaction";
 import type { CompactOptions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { CompactMode } from "@oh-my-pi/pi-coding-agent/session/compact-modes";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import {
 	ACP_BUILTIN_SLASH_COMMANDS,
 	executeAcpBuiltinSlashCommand,
@@ -95,7 +96,7 @@ describe("/compact dispatch (ACP)", () => {
 	it("stays silent when compaction is cancelled by a user interrupt", async () => {
 		const h = acpRuntime();
 		h.compact.mockImplementation(async () => {
-			throw new CompactionCancelledError();
+			throw new CompactionCancelledError(undefined, { cause: USER_INTERRUPT_LABEL });
 		});
 		const backgroundTasks: Promise<void>[] = [];
 		h.runtime.runCommandInBackground = task => {
@@ -106,6 +107,16 @@ describe("/compact dispatch (ACP)", () => {
 		expect(result).toEqual({ consumed: true });
 		await Promise.all(backgroundTasks);
 		expect(h.output).not.toHaveBeenCalled();
+	});
+
+	it("surfaces extension cancellation instead of treating it as a user interrupt", async () => {
+		const h = acpRuntime();
+		h.compact.mockImplementation(async () => {
+			throw new CompactionCancelledError();
+		});
+
+		await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Compaction failed: Compaction cancelled");
 	});
 
 	it("surfaces other failures behind the Compaction failed prefix", async () => {

--- a/packages/coding-agent/test/slash-commands/compact.test.ts
+++ b/packages/coding-agent/test/slash-commands/compact.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
+import { CompactionCancelledError } from "@oh-my-pi/pi-agent-core/compaction";
 import type { CompactOptions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { CompactMode } from "@oh-my-pi/pi-coding-agent/session/compact-modes";
@@ -64,6 +65,57 @@ describe("/compact dispatch (ACP)", () => {
 		expect(h.compact).not.toHaveBeenCalled();
 		expect(result).toEqual({ consumed: true });
 		expect((h.output.mock.calls[0]?.[0] as string) ?? "").toContain("snapcompact");
+	});
+
+	it("leaves the RPC command queue free while compaction runs", async () => {
+		const compactStarted = Promise.withResolvers<void>();
+		const compactFinished = Promise.withResolvers<void>();
+		const h = acpRuntime();
+		h.compact.mockImplementation(async () => {
+			compactStarted.resolve();
+			await compactFinished.promise;
+		});
+		const backgroundTasks: Promise<void>[] = [];
+		h.runtime.runCommandInBackground = task => {
+			backgroundTasks.push(task());
+		};
+
+		// The dispatcher must resolve before compaction finishes so the RPC
+		// serialized queue can dequeue a follow-up abort.
+		const result = await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		await compactStarted.promise;
+		expect(result).toEqual({ consumed: true });
+		expect(h.output).not.toHaveBeenCalled();
+
+		compactFinished.resolve();
+		await Promise.all(backgroundTasks);
+		expect(h.output).toHaveBeenCalledWith("Compaction complete.");
+	});
+
+	it("stays silent when compaction is cancelled by a user interrupt", async () => {
+		const h = acpRuntime();
+		h.compact.mockImplementation(async () => {
+			throw new CompactionCancelledError();
+		});
+		const backgroundTasks: Promise<void>[] = [];
+		h.runtime.runCommandInBackground = task => {
+			backgroundTasks.push(task());
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		expect(result).toEqual({ consumed: true });
+		await Promise.all(backgroundTasks);
+		expect(h.output).not.toHaveBeenCalled();
+	});
+
+	it("surfaces other failures behind the Compaction failed prefix", async () => {
+		const h = acpRuntime();
+		h.compact.mockImplementation(async () => {
+			throw new Error("no model selected");
+		});
+
+		await executeAcpBuiltinSlashCommand("/compact", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Compaction failed: no model selected");
 	});
 
 	it("advertises the mode subcommands and input hint to ACP clients", () => {


### PR DESCRIPTION
## Repro
Over RPC, invoking `/compact` parks the serialized command queue for the entire summarization round-trip: `executeAcpBuiltinSlashCommand("/compact")` never resolves until `session.compact()` finishes, so a follow-up `abort` frame stays queued and cannot interrupt it. A test that supplies `runCommandInBackground` and blocks `session.compact()` proves the dispatcher stays blocked: `bun test test/slash-commands/compact.test.ts` (new case "leaves the RPC command queue free while compaction runs").

## Cause
`runCommandInBackground` (`SlashCommandRuntime`, `slash-commands/types.ts`) exists so provider-backed slash commands don't hold RPC's prompt response; b1243e0e converted `/handoff` but left `/compact` awaiting `runtime.session.compact()` inline in `slash-commands/builtin-lifecycle.ts`. `modes/rpc/rpc-mode.ts` awaits `executeAcpBuiltinSlashCommand` in the `prompt` handler (L995) and `abort` (L1056) is an ordinary queued command, not a control frame — so it cannot be dequeued while `/compact` runs.

## Fix
- Keep `parseCompactArgs` validation synchronous so argument errors still ride the prompt response and never reach the provider.
- Move the provider work into a `runCompact` closure and dispatch it through `runtime.runCommandInBackground` when the host provides it (RPC), else keep the inline `await` (ACP/TUI unaffected).
- Inside the closure, report failures via `runtime.output(...)`. A user interrupt now aborts the in-flight compaction (`AgentSession.abort()` → `abortCompaction()`), surfacing as `CompactionCancelledError`; swallow it so no misleading out-of-turn "Compaction failed" chunk trails the abort — mirroring `/handoff`'s `USER_INTERRUPT_LABEL` path.

## Verification
`bun test test/slash-commands/` — 140 pass, 0 fail. New regression cases: queue stays free during compaction, cancellation stays silent, other failures surface behind the `Compaction failed:` prefix. Existing `/handoff` and `/compact` suites still green.

Fixes #9200