### PR TITLE
fix: keep thinking-loop armed after tool calls and queue streamed xd:// previews

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Fixed
 
+- Fixed thinking-loop detection going silent after the first streamed tool call, so Grok/xAI reasoning loops that continue after a tool call starts still abort and retry instead of spinning until you press Esc.
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed thinking-loop detection going silent after the first streamed tool call, so Grok/xAI reasoning loops that continue after a tool call starts still abort and retry instead of spinning until you press Esc.
+
 ## [17.4.3] - 2026-08-21
 
 ### Fixed
@@ -28,7 +32,6 @@
 
 ### Fixed
 
-- Fixed thinking-loop detection going silent after the first streamed tool call, so Grok/xAI reasoning loops that continue after a tool call starts still abort and retry instead of spinning until you press Esc.
 - Fixed OpenAI Codex requests failing with HTTP 401 data residency errors on enterprise ChatGPT workspaces when connecting from a different region via VPN or proxy.
 - Fixed concurrent xAI OAuth token refreshes revoking shared credentials across multiple processes.
 - Fixed Amazon Bedrock Converse multi-turn conversations failing on models like Amazon Nova due to unsigned reasoning content in replayed turns.

--- a/packages/ai/src/utils/thinking-loop.ts
+++ b/packages/ai/src/utils/thinking-loop.ts
@@ -407,10 +407,15 @@ export function guardThinkingLoopStream(
 					if (thinkingArmed) {
 						detail = thinkingDetector.flush();
 					}
-				} else if (event.type === "text_start" || event.type === "text_delta") {
-					thinkingArmed = false;
-					textStarted = true;
-					if (textArmed && event.type === "text_delta") {
+				} else if (event.type === "text_start") {
+					// Responses emits this as soon as an empty message item is added.
+					// No visible answer text yet — do not latch the thinking detector.
+				} else if (event.type === "text_delta") {
+					if (event.delta.length > 0) {
+						thinkingArmed = false;
+						textStarted = true;
+					}
+					if (textArmed) {
 						detail = textDetector.push(event.delta);
 					}
 				} else if (event.type === "toolcall_start" || event.type === "toolcall_delta") {

--- a/packages/ai/src/utils/thinking-loop.ts
+++ b/packages/ai/src/utils/thinking-loop.ts
@@ -34,12 +34,16 @@
  *    {@link GeminiHeaderRunDetector}.
  *
  * Scope: exact cycles are guarded for every model; semantic heuristics remain
- * limited to Gemini, DeepSeek, and Grok family streams before any tool call.
- * Native thinking is checked first; assistant text can also be checked for
- * providers that surface reasoning as visible prose. On a hit the failed turn is
- * emitted as an empty retryable stream-stall error; result-awaiting callers
- * (`complete`, `completeSimple`) re-sample at most three guarded attempts and
- * then fail closed. Disable detection with `PI_NO_THINKING_LOOP_GUARD=1`.
+ * limited to Gemini, DeepSeek, and Grok family streams. Thinking stays armed
+ * after a tool call starts — xAI/Grok can keep emitting `thinking_delta` after
+ * `toolcall_start`, and those deltas count as stream progress so the idle
+ * watchdog never fires. Visible assistant text still latches the thinking
+ * detector off. Native thinking is checked first; assistant text can also be
+ * checked for providers that surface reasoning as visible prose. On a hit the
+ * failed turn is emitted as an empty retryable stream-stall error;
+ * result-awaiting callers (`complete`, `completeSimple`) re-sample at most
+ * three guarded attempts and then fail closed. Disable detection with
+ * `PI_NO_THINKING_LOOP_GUARD=1`.
  */
 import { modelFamilyToken } from "@oh-my-pi/pi-catalog/identity";
 import { logger } from "@oh-my-pi/pi-utils";
@@ -386,21 +390,30 @@ export function guardThinkingLoopStream(
 	void (async () => {
 		let thinkingArmed = true;
 		let textArmed = checkAssistantContent;
+		let textStarted = false;
 		try {
 			for await (const event of inner) {
 				let detail: string | null = null;
-				if (thinkingArmed && event.type === "thinking_delta") {
-					detail = thinkingDetector.push(event.delta);
-				} else if (thinkingArmed && event.type === "thinking_end") {
-					detail = thinkingDetector.flush();
-					thinkingArmed = false;
+				if (event.type === "thinking_delta") {
+					// Re-arm after thinking_end / toolcall_start unless visible answer
+					// text has already latched the detector off. Grok/xAI Responses can
+					// keep reasoning after the first toolcall_start; those deltas still
+					// count as stream progress while the TUI sits on a streamed preview.
+					if (!textStarted) {
+						thinkingArmed = true;
+						detail = thinkingDetector.push(event.delta);
+					}
+				} else if (event.type === "thinking_end") {
+					if (thinkingArmed) {
+						detail = thinkingDetector.flush();
+					}
 				} else if (event.type === "text_start" || event.type === "text_delta") {
 					thinkingArmed = false;
+					textStarted = true;
 					if (textArmed && event.type === "text_delta") {
 						detail = textDetector.push(event.delta);
 					}
 				} else if (event.type === "toolcall_start" || event.type === "toolcall_delta") {
-					thinkingArmed = false;
 					textArmed = false;
 				} else if (event.type === "done") {
 					if (thinkingArmed) {

--- a/packages/ai/test/thinking-loop.test.ts
+++ b/packages/ai/test/thinking-loop.test.ts
@@ -527,6 +527,89 @@ describe("withThinkingLoopGuard (Vertex transport)", () => {
 		expect(isRetryableError(new Error(result.errorMessage))).toBe(true);
 	});
 });
+
+describe("withThinkingLoopGuard (thinking after toolcall)", () => {
+	test("trips on a thinking loop that continues after toolcall_start", async () => {
+		const model = { api: "openai-responses", provider: "xai-oauth", id: "grok-4.6" } as unknown as Model<Api>;
+		const partial = { role: "assistant", content: [] } as unknown as AssistantMessage;
+
+		const guarded = withThinkingLoopGuard(model, undefined, () => {
+			const inner = new AssistantMessageEventStream();
+			const events: AssistantMessageEvent[] = [
+				{ type: "start", partial },
+				{ type: "thinking_start", contentIndex: 0, partial },
+				{ type: "thinking_delta", contentIndex: 0, delta: "I'll search the cargo gate next.\n\n", partial },
+				{ type: "toolcall_start", contentIndex: 1, partial },
+				{ type: "thinking_delta", contentIndex: 0, delta: nearDuplicateLoop(12), partial },
+				{ type: "thinking_end", contentIndex: 0, content: "", partial },
+				{ type: "done", reason: "stop", message: partial },
+			];
+			for (const event of events) inner.push(event);
+			inner.end({ ...partial, stopReason: "stop" });
+			return inner;
+		});
+
+		const result = await guarded.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.content).toEqual([]);
+		expect(result.errorMessage).toContain(THINKING_LOOP_ERROR_MARKER);
+		expect(AIError.is(result.errorId, AIError.Flag.ThinkingLoop)).toBe(true);
+	});
+
+	test("re-arms thinking after thinking_end when more reasoning arrives after a tool call", async () => {
+		const model = { api: "openai-responses", provider: "xai-oauth", id: "grok-4.6" } as unknown as Model<Api>;
+		const partial = { role: "assistant", content: [] } as unknown as AssistantMessage;
+
+		const guarded = withThinkingLoopGuard(model, undefined, () => {
+			const inner = new AssistantMessageEventStream();
+			const events: AssistantMessageEvent[] = [
+				{ type: "start", partial },
+				{ type: "thinking_start", contentIndex: 0, partial },
+				{ type: "thinking_delta", contentIndex: 0, delta: "I'll read the thumper cargo function.\n\n", partial },
+				{ type: "thinking_end", contentIndex: 0, content: "", partial },
+				{ type: "toolcall_start", contentIndex: 1, partial },
+				{ type: "thinking_start", contentIndex: 2, partial },
+				{ type: "thinking_delta", contentIndex: 2, delta: nearDuplicateLoop(12), partial },
+				{ type: "thinking_end", contentIndex: 2, content: "", partial },
+				{ type: "done", reason: "stop", message: partial },
+			];
+			for (const event of events) inner.push(event);
+			inner.end({ ...partial, stopReason: "stop" });
+			return inner;
+		});
+
+		const result = await guarded.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.content).toEqual([]);
+		expect(result.errorMessage).toContain(THINKING_LOOP_ERROR_MARKER);
+	});
+
+	test("does not re-arm thinking after visible answer text even if a tool call already started", async () => {
+		const model = { api: "openai-responses", provider: "xai-oauth", id: "grok-4.6" } as unknown as Model<Api>;
+		const partial = { role: "assistant", content: [] } as unknown as AssistantMessage;
+
+		const guarded = withThinkingLoopGuard(model, undefined, () => {
+			const inner = new AssistantMessageEventStream();
+			const events: AssistantMessageEvent[] = [
+				{ type: "start", partial },
+				{ type: "toolcall_start", contentIndex: 0, partial },
+				{ type: "text_start", contentIndex: 1, partial },
+				{ type: "text_delta", contentIndex: 1, delta: "Here is the final answer.", partial },
+				{ type: "thinking_start", contentIndex: 2, partial },
+				{ type: "thinking_delta", contentIndex: 2, delta: nearDuplicateLoop(12), partial },
+				{ type: "thinking_end", contentIndex: 2, content: "", partial },
+				{ type: "done", reason: "stop", message: { ...partial, stopReason: "stop" } },
+			];
+			for (const event of events) inner.push(event);
+			inner.end({ ...partial, stopReason: "stop" });
+			return inner;
+		});
+
+		const result = await guarded.result();
+		expect(result.stopReason).toBe("stop");
+	});
+});
+
 describe("isLoopGuardedModel", () => {
 	test("guards Gemini, DeepSeek, and Grok model-id families only", () => {
 		const gemini = createMockModel({ provider: "openrouter", id: "google/gemini-3.5-flash" }).model;

--- a/packages/ai/test/thinking-loop.test.ts
+++ b/packages/ai/test/thinking-loop.test.ts
@@ -608,6 +608,33 @@ describe("withThinkingLoopGuard (thinking after toolcall)", () => {
 		const result = await guarded.result();
 		expect(result.stopReason).toBe("stop");
 	});
+
+	test("does not latch thinking off on text_start before any visible answer text", async () => {
+		const model = { api: "openai-responses", provider: "xai-oauth", id: "grok-4.6" } as unknown as Model<Api>;
+		const partial = { role: "assistant", content: [] } as unknown as AssistantMessage;
+
+		const guarded = withThinkingLoopGuard(model, undefined, () => {
+			const inner = new AssistantMessageEventStream();
+			const events: AssistantMessageEvent[] = [
+				{ type: "start", partial },
+				{ type: "toolcall_start", contentIndex: 0, partial },
+				{ type: "text_start", contentIndex: 1, partial },
+				{ type: "thinking_start", contentIndex: 2, partial },
+				{ type: "thinking_delta", contentIndex: 2, delta: nearDuplicateLoop(12), partial },
+				{ type: "thinking_end", contentIndex: 2, content: "", partial },
+				{ type: "done", reason: "stop", message: { ...partial, stopReason: "stop" } },
+			];
+			for (const event of events) inner.push(event);
+			inner.end({ ...partial, stopReason: "stop" });
+			return inner;
+		});
+
+		const result = await guarded.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.content).toEqual([]);
+		expect(result.errorMessage).toContain(THINKING_LOOP_ERROR_MARKER);
+		expect(AIError.is(result.errorId, AIError.Flag.ThinkingLoop)).toBe(true);
+	});
 });
 
 describe("isLoopGuardedModel", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -96,6 +96,7 @@
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 - Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
+- Fixed streamed `xd://` device writes (including MCP tools) looking like a hung in-flight call while the model is still thinking; they now show as queued until the tool actually starts.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed streamed `xd://` device writes (including MCP tools) looking like a hung in-flight call while the model is still thinking; they now show as queued until the tool actually starts.
+
 ## [17.4.3] - 2026-08-21
 
 ### Fixed
@@ -96,7 +100,6 @@
 - `/retry` and `/handoff` now work over ACP, so editor clients (Zed) list them and can run them instead of sending the text to the model.
 - Added `qwenTemplateReasoningEffort` to the `models.yml` `compat` schema, so the auto-enabled Qwen 3.8+ template effort dialect (`chat_template_kwargs.reasoning_effort`) can be switched off per provider/model for strict local servers that reject unknown `chat_template_kwargs`.
 - Extensions can provide a normalized `usage` provider through `pi.registerProvider()`. Its reports now flow through AuthStorage caching, history, and usage displays, and the override is removed when the extension provider is unregistered.
-- Fixed streamed `xd://` device writes (including MCP tools) looking like a hung in-flight call while the model is still thinking; they now show as queued until the tool actually starts.
 
 ## [17.4.0] - 2026-08-20
 

--- a/packages/coding-agent/src/cli/gallery-cli.ts
+++ b/packages/coding-agent/src/cli/gallery-cli.ts
@@ -162,6 +162,7 @@ export async function renderGalleryState(
 
 	if (state !== "streaming") {
 		component.setArgsComplete();
+		component.setExecutionStarted();
 	}
 	if (state === "success") {
 		component.updateResult(fixture.result, false);

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -160,6 +160,12 @@ export interface RenderResultOptions {
 	isPartial: boolean;
 	/** Current spinner frame index for animated elements (0-9, only provided during partial results) */
 	spinnerFrame?: number;
+	/**
+	 * True once arguments are final and the tool is about to execute
+	 * (`tool_execution_start` / `setArgsComplete`). Streamed call previews
+	 * before this should not look like a live in-flight call.
+	 */
+	argsComplete?: boolean;
 }
 
 export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -161,11 +161,15 @@ export interface RenderResultOptions {
 	/** Current spinner frame index for animated elements (0-9, only provided during partial results) */
 	spinnerFrame?: number;
 	/**
-	 * True once arguments are final and the tool is about to execute
-	 * (`tool_execution_start` / `setArgsComplete`). Streamed call previews
-	 * before this should not look like a live in-flight call.
+	 * True once arguments are final (`message_end` / `setArgsComplete`).
+	 * Exclusive tools can sit here while an earlier call still runs.
 	 */
 	argsComplete?: boolean;
+	/**
+	 * True once this specific call has begun executing (`tool_execution_start`).
+	 * Streamed `xd://` previews stay queued until this is set.
+	 */
+	executionStarted?: boolean;
 }
 
 export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -496,6 +496,10 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
+	setExecutionStarted(_toolCallId?: string): void {
+		this.#updateDisplay();
+	}
+
 	setExpanded(expanded: boolean): void {
 		this.#expanded = expanded;
 		this.#updateDisplay();

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -448,10 +448,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		spinnerFrame?: number;
 		expanded: boolean;
 		isPartial: boolean;
+		argsComplete?: boolean;
 		renderContext?: Record<string, unknown>;
 	} = {
 		expanded: false,
 		isPartial: true,
+		argsComplete: false,
 	};
 
 	constructor(
@@ -522,9 +524,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 * This triggers an immediate final diff computation for edit-like tools.
 	 */
 	setArgsComplete(_toolCallId?: string): void {
+		const alreadyComplete = this.#argsComplete;
 		this.#argsComplete = true;
 		this.#updateSpinnerAnimation();
 		this.#schedulePreviewDiff();
+		if (alreadyComplete) return;
+		this.#displayInputVersion++;
+		this.#updateDisplay();
 	}
 
 	/**
@@ -1004,7 +1010,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// TUI startup, so a result rendered before it lands must re-shape once it
 		// does (it gates Image children vs text fallback in #rebuildDisplay); keyed
 		// here for the same reason markdown.ts keys its render cache on it.
-		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${this.#backgroundTaskFrozenStyled}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}`;
+		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${this.#backgroundTaskFrozenStyled}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}`;
 		if (key === this.#lastDisplayKey && this.#displayBuilt) return;
 		this.#lastDisplayKey = key;
 
@@ -1072,6 +1078,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// Sync shared mutable render state for component closures
 		this.#renderState.expanded = this.#expanded;
 		this.#renderState.isPartial = this.#isPartial;
+		this.#renderState.argsComplete = this.#argsComplete;
 		this.#renderState.spinnerFrame = this.#spinnerFrame;
 
 		// Non-self-framing tools (custom/extension renderers and the generic

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -266,6 +266,7 @@ export interface ToolExecutionHandle extends Component {
 		toolCallId?: string,
 	): void;
 	setArgsComplete(toolCallId?: string): void;
+	setExecutionStarted(toolCallId?: string): void;
 	setExpanded(expanded: boolean): void;
 	setToolActivityVisible(visible: boolean): void;
 	/** Freeze the block as final history: stop spinners and let it commit to scrollback. */
@@ -407,6 +408,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#todoStrikeInterval?: NodeJS.Timeout;
 	// Track if args are still being streamed (for edit/write spinner)
 	#argsComplete = false;
+	#executionStarted = false;
 	// Sealed once the tool reaches a terminal state (result delivered, or the
 	// turn abandoned it without one). Drives `isTranscriptBlockFinalized`: until
 	// sealed the block stays in the transcript's repaintable live region so a
@@ -449,11 +451,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		expanded: boolean;
 		isPartial: boolean;
 		argsComplete?: boolean;
+		executionStarted?: boolean;
 		renderContext?: Record<string, unknown>;
 	} = {
 		expanded: false,
 		isPartial: true,
 		argsComplete: false,
+		executionStarted: false,
 	};
 
 	constructor(
@@ -529,6 +533,21 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#updateSpinnerAnimation();
 		this.#schedulePreviewDiff();
 		if (alreadyComplete) return;
+		this.#displayInputVersion++;
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Signal that this specific call has begun executing (`tool_execution_start`).
+	 * Distinct from {@link setArgsComplete}: exclusive writes are marked complete
+	 * at `message_end` but stay queued until this fires for that call.
+	 */
+	setExecutionStarted(_toolCallId?: string): void {
+		if (this.#executionStarted) return;
+		this.#executionStarted = true;
+		this.#argsComplete = true;
+		this.#updateSpinnerAnimation();
+		this.#schedulePreviewDiff();
 		this.#displayInputVersion++;
 		this.#updateDisplay();
 	}
@@ -1010,7 +1029,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// TUI startup, so a result rendered before it lands must re-shape once it
 		// does (it gates Image children vs text fallback in #rebuildDisplay); keyed
 		// here for the same reason markdown.ts keys its render cache on it.
-		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${this.#backgroundTaskFrozenStyled}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}`;
+		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#executionStarted ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${this.#backgroundTaskFrozenStyled}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}`;
 		if (key === this.#lastDisplayKey && this.#displayBuilt) return;
 		this.#lastDisplayKey = key;
 
@@ -1079,6 +1098,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#renderState.expanded = this.#expanded;
 		this.#renderState.isPartial = this.#isPartial;
 		this.#renderState.argsComplete = this.#argsComplete;
+		this.#renderState.executionStarted = this.#executionStarted;
 		this.#renderState.spinnerFrame = this.#spinnerFrame;
 
 		// Non-self-framing tools (custom/extension renderers and the generic

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -116,6 +116,7 @@ export class EventController {
 	// those calls arrive so the normal no-pending path cannot recreate the
 	// retracted card below the rewind's fresh blocks (#6879).
 	#retractedToolCallIds = new Set<string>();
+	#executionStartedCallIds = new Set<string>();
 	// Cards settled by a synthetic aborted/error `tool_execution_end` (agent-loop
 	// emits one per never-run call on a terminal error/abort). They stay visible
 	// for a genuinely terminal failure, but if an auto-retry then supersedes the
@@ -407,6 +408,9 @@ export class EventController {
 		// The reveal controller is id-keyed; drop the stale target so the loop's
 		// setTarget/bind under the new id owns the paced reveal.
 		this.#toolArgsReveal.finish(oldId);
+		if (this.#executionStartedCallIds.delete(oldId)) {
+			this.#executionStartedCallIds.add(newId);
+		}
 		const readArgs = this.#readToolCallArgs.get(oldId);
 		if (readArgs !== undefined) {
 			this.#readToolCallArgs.delete(oldId);
@@ -624,6 +628,12 @@ export class EventController {
 		this.#pendingMessageUpdate = undefined;
 		await this.handleEvent(event);
 	}
+
+	/** Whether `#handleToolExecutionStart` has fired for this call id this turn. */
+	hasToolExecutionStarted(toolCallId: string): boolean {
+		return this.#executionStartedCallIds.has(toolCallId);
+	}
+
 	/**
 	 * Clear every transcript-anchored/turn-scoped piece of state. Used by the
 	 * session focus proxy when re-pointing the transcript at another session:
@@ -643,6 +653,7 @@ export class EventController {
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
 		this.#retractedToolCallIds.clear();
+		this.#executionStartedCallIds.clear();
 		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
@@ -738,6 +749,7 @@ export class EventController {
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
 		this.#retractedToolCallIds.clear();
+		this.#executionStartedCallIds.clear();
 		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
@@ -1404,6 +1416,8 @@ export class EventController {
 				event.toolCallId,
 			);
 			component.setArgsComplete(event.toolCallId);
+			component.setExecutionStarted(event.toolCallId);
+			this.#executionStartedCallIds.add(event.toolCallId);
 			component.setExpanded(this.ctx.toolOutputExpanded);
 			this.ctx.chatContainer.addChild(component);
 			this.ctx.pendingTools.set(event.toolCallId, component);
@@ -1427,6 +1441,10 @@ export class EventController {
 				if (typeof component.setArgsComplete === "function") {
 					component.setArgsComplete(event.toolCallId);
 				}
+				if (typeof component.setExecutionStarted === "function") {
+					component.setExecutionStarted(event.toolCallId);
+				}
+				this.#executionStartedCallIds.add(event.toolCallId);
 				this.ctx.ui.requestRender();
 			}
 		}
@@ -1520,6 +1538,7 @@ export class EventController {
 		// assistant message. The matching card was deliberately retracted at
 		// message_end; consume the completion instead of recreating/updating UI.
 		if (this.#retractedToolCallIds.delete(event.toolCallId)) return;
+		this.#executionStartedCallIds.delete(event.toolCallId);
 		// A synthetic aborted/error completion (agent-loop's placeholder for a
 		// never-run call on a terminal error/abort) settles the card in place so a
 		// terminal failure stays visible. Remember it so `#handleAutoRetryStart`
@@ -1778,6 +1797,7 @@ export class EventController {
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
 		this.#retractedToolCallIds.clear();
+		this.#executionStartedCallIds.clear();
 		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -725,6 +725,9 @@ export class UiHelpers {
 		if (this.ctx.viewSession.isStreaming) {
 			for (const [toolCallId, component] of this.ctx.pendingTools) {
 				component.setArgsComplete(toolCallId);
+				if (this.ctx.eventController?.hasToolExecutionStarted(toolCallId)) {
+					component.setExecutionStarted(toolCallId);
+				}
 			}
 		} else {
 			for (const component of this.ctx.pendingTools.values()) {

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1587,7 +1587,8 @@ export const writeToolRenderer = {
 		const rawPath =
 			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "";
 		// Render NOTHING until the streamed path arrives and provably is not an
-		// xd:// device; xd:// writes then delegate to the mounted tool's renderer.
+		// xd:// device. Device writes then render as queued until execution starts,
+		// after which they delegate to the mounted tool's renderer.
 		// A present-but-malformed path (array/object from a bad provider parse)
 		// is definitively not xd:// — fall through to the legacy frame.
 		if (args.path === undefined && args.file_path === undefined) return undefined;

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -35,6 +35,7 @@ import { type Component, Container, Text } from "@oh-my-pi/pi-tui";
 import { parseStreamingJson } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { XD_URL_PREFIX } from "../internal-urls/xd-protocol";
+import { parseMCPToolName } from "../mcp/tool-bridge";
 import type { Theme } from "../modes/theme/theme";
 import { truncateHeadBytes } from "../session/streaming-output";
 import { resolveToolTier, type ToolTier } from "./approval";
@@ -496,11 +497,8 @@ function resolveDeviceRenderer(
 /** Human label for a device write: mounted tool label, else `server/tool` for MCP names. */
 function displayDeviceLabel(name: string, mounted?: { label?: string }): string {
 	if (mounted?.label) return mounted.label;
-	if (name.startsWith("mcp__")) {
-		const rest = name.slice("mcp__".length);
-		const split = rest.indexOf("_");
-		if (split > 0) return `${rest.slice(0, split)}/${rest.slice(split + 1)}`;
-	}
+	const parsed = parseMCPToolName(name);
+	if (parsed) return `${parsed.serverName}/${parsed.toolName}`;
 	return name;
 }
 
@@ -529,11 +527,13 @@ function renderQueuedXdevCall(
 
 /**
  * Streaming-safe call preview for an `xd://` write. Until the write actually
- * executes (`argsComplete` / `tool_execution_start`), show a queued/planning
+ * executes (`executionStarted` / `tool_execution_start`), show a queued/planning
  * card so Grok-style think-after-toolcall stalls do not look like a hung
- * inner tool. Once execution starts, forward the decoded inner args to the
- * mounted tool's renderer (session instance first, then the static map).
- * Returns `undefined` (render nothing) when no renderer produces output.
+ * inner tool. `argsComplete` alone is not enough: exclusive writes can sit
+ * complete at `message_end` while an earlier call still runs. Once execution
+ * starts, forward the decoded inner args to the mounted tool's renderer
+ * (session instance first, then the static map). Returns `undefined` (render
+ * nothing) when no renderer produces output.
  */
 export function renderXdevCall(
 	name: string,
@@ -544,7 +544,7 @@ export function renderXdevCall(
 ): Component | undefined {
 	const mounted = resolveMounted?.(name);
 	const args = decodeInnerArgs(content);
-	if (!options.argsComplete) {
+	if (!options.executionStarted) {
 		return renderQueuedXdevCall(displayDeviceLabel(name, mounted), args, options, theme);
 	}
 	const renderer = resolveDeviceRenderer(name, mounted);

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -25,8 +25,9 @@
  * `read xd://<tool>` remains for on-demand re-fetch.
  *
  * Rendering: the write renderer draws NOTHING until the streamed `path` is
- * known and provably does not target `xd://`; device writes then delegate to
- * the wrapped tool's own renderer with the decoded inner args.
+ * known and provably does not target `xd://`. Device writes then show as
+ * queued/planning until `tool_execution_start`, and only then delegate to the
+ * wrapped tool's own renderer with the decoded inner args.
  */
 import type { AgentToolContext, AgentToolResult, AgentToolUpdateCallback, ToolLoadMode } from "@oh-my-pi/pi-agent-core";
 import { type Tool as AiTool, jsonSchemaToTypeScript, toolWireSchema, validateToolArguments } from "@oh-my-pi/pi-ai";
@@ -492,10 +493,47 @@ function resolveDeviceRenderer(
 	return rendererLookup?.(name);
 }
 
+/** Human label for a device write: mounted tool label, else `server/tool` for MCP names. */
+function displayDeviceLabel(name: string, mounted?: { label?: string }): string {
+	if (mounted?.label) return mounted.label;
+	if (name.startsWith("mcp__")) {
+		const rest = name.slice("mcp__".length);
+		const split = rest.indexOf("_");
+		if (split > 0) return `${rest.slice(0, split)}/${rest.slice(split + 1)}`;
+	}
+	return name;
+}
+
+/** Drop the streaming-decode bookkeeping key before showing inner args. */
+function displayDeviceArgs(args: Record<string, unknown>): Record<string, unknown> {
+	const { __partialJson: _partial, ...rest } = args;
+	return rest;
+}
+
+/** Pre-execution card so a streamed `xd://` write does not look like a hung MCP call. */
+function renderQueuedXdevCall(
+	label: string,
+	args: Record<string, unknown>,
+	options: RenderResultOptions,
+	theme: Theme,
+): Component {
+	return renderDefaultToolExecution(
+		{
+			label: `queued ${label}`,
+			args: displayDeviceArgs(args),
+			options: { ...options, isPartial: true, spinnerFrame: undefined },
+		},
+		theme,
+	);
+}
+
 /**
- * Streaming-safe call preview for an `xd://` write: forwards the decoded inner
- * args to the mounted tool's renderer (session instance first, then the static
- * map). Returns `undefined` (render nothing) when no renderer produces output.
+ * Streaming-safe call preview for an `xd://` write. Until the write actually
+ * executes (`argsComplete` / `tool_execution_start`), show a queued/planning
+ * card so Grok-style think-after-toolcall stalls do not look like a hung
+ * inner tool. Once execution starts, forward the decoded inner args to the
+ * mounted tool's renderer (session instance first, then the static map).
+ * Returns `undefined` (render nothing) when no renderer produces output.
  */
 export function renderXdevCall(
 	name: string,
@@ -505,8 +543,11 @@ export function renderXdevCall(
 	resolveMounted?: (name: string) => Tool | undefined,
 ): Component | undefined {
 	const mounted = resolveMounted?.(name);
-	const renderer = resolveDeviceRenderer(name, mounted);
 	const args = decodeInnerArgs(content);
+	if (!options.argsComplete) {
+		return renderQueuedXdevCall(displayDeviceLabel(name, mounted), args, options, theme);
+	}
+	const renderer = resolveDeviceRenderer(name, mounted);
 	if (renderer?.renderCall) {
 		return renderer.renderCall(args, options, theme);
 	}

--- a/packages/coding-agent/test/modes/controllers/event-controller-xdev-queue.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-xdev-queue.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Exclusive `write xd://…` calls stay queued after `message_end` (which marks
+ * every pending call args-complete) until that call's own `tool_execution_start`.
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function makeStreamingMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "xai-oauth",
+		model: "grok-4.6",
+		stopReason: "toolUse",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+function deviceWrite(id: string, name: string, inner: Record<string, unknown>) {
+	return {
+		type: "toolCall" as const,
+		id,
+		name: "write",
+		arguments: {
+			path: `xd://${name}`,
+			content: JSON.stringify(inner),
+		},
+	};
+}
+
+function createFixture(streamingMessage: AssistantMessage) {
+	const pendingTools = new Map<string, ToolExecutionComponent>();
+	const ctx = {
+		isInitialized: true,
+		init: vi.fn(async () => {}),
+		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn(), resetDisplay: vi.fn() },
+		settings,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		streamingComponent: { updateContent: vi.fn(), markTranscriptBlockFinalized: vi.fn() },
+		streamingMessage,
+		transcriptMessageComponents: new WeakMap(),
+		pendingTools,
+		noteDisplayableThinkingContent: vi.fn(() => false),
+		chatContainer: { addChild: vi.fn(), isBlockUncommitted: () => true },
+		toolOutputExpanded: false,
+		lastAssistantUsage: undefined,
+		showPinnedError: vi.fn(),
+		session: {
+			getToolByName: () => undefined,
+			hasBuiltInTool: () => true,
+			isTtsrAbortPending: false,
+			retryAttempt: 0,
+		},
+		viewSession: {
+			getToolByName: () => undefined,
+			hasBuiltInTool: () => true,
+			isTtsrAbortPending: false,
+			retryAttempt: 0,
+		},
+		sessionManager: { getCwd: () => process.cwd() },
+	} as unknown as InteractiveModeContext;
+
+	const controller = new EventController(ctx);
+	ctx.eventController = controller;
+	return { controller, pendingTools };
+}
+
+function cardText(pendingTools: Map<string, ToolExecutionComponent>, id: string): string {
+	const component = pendingTools.get(id);
+	if (!component) throw new Error(`expected pending tool ${id}`);
+	return Bun.stripANSI(component.render(120).join("\n"));
+}
+
+describe("EventController queues exclusive device writes until execution starts", () => {
+	afterEach(() => {
+		resetSettingsForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("keeps the second exclusive xd:// write queued after message_end until its own start", async () => {
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		settings.set("display.smoothStreaming", false);
+
+		const searchArgs = { action: "grep_all", pattern: "Broken", scope: "game.StarterPlayer" };
+		const scriptsArgs = { action: "get_source", instancePath: "game.Workspace.Thumper" };
+		const streaming = makeStreamingMessage([
+			deviceWrite("write-1", "mcp__ecoport_search", searchArgs),
+			deviceWrite("write-2", "mcp__ecoport_scripts", scriptsArgs),
+		]);
+		const { controller, pendingTools } = createFixture(streaming);
+
+		await controller.handleEvent({
+			type: "message_update",
+			message: streaming,
+			assistantMessageEvent: undefined as never,
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		expect(pendingTools.size).toBe(2);
+		expect(cardText(pendingTools, "write-1")).toContain("queued");
+		expect(cardText(pendingTools, "write-1")).toContain("ecoport/search");
+		expect(cardText(pendingTools, "write-2")).toContain("queued");
+		expect(cardText(pendingTools, "write-2")).toContain("ecoport/scripts");
+
+		await controller.handleEvent({
+			type: "message_end",
+			message: streaming,
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+		expect(cardText(pendingTools, "write-1")).toContain("queued");
+		expect(cardText(pendingTools, "write-2")).toContain("queued");
+		expect(controller.hasToolExecutionStarted("write-1")).toBe(false);
+		expect(controller.hasToolExecutionStarted("write-2")).toBe(false);
+
+		await controller.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: "write-1",
+			toolName: "write",
+			args: deviceWrite("write-1", "mcp__ecoport_search", searchArgs).arguments,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		expect(controller.hasToolExecutionStarted("write-1")).toBe(true);
+		expect(controller.hasToolExecutionStarted("write-2")).toBe(false);
+		expect(cardText(pendingTools, "write-1")).not.toContain("queued");
+		expect(cardText(pendingTools, "write-2")).toContain("queued");
+
+		await controller.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: "write-2",
+			toolName: "write",
+			args: deviceWrite("write-2", "mcp__ecoport_scripts", scriptsArgs).arguments,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		expect(controller.hasToolExecutionStarted("write-2")).toBe(true);
+		expect(cardText(pendingTools, "write-2")).not.toContain("queued");
+	});
+});

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -319,11 +319,20 @@ describe("read and write route xd:// device URLs", () => {
 		expect(queuedText).toContain("queued");
 		expect(queuedText).toContain("ast_edit");
 
+		// Args can be final at message_end while an earlier exclusive write still
+		// runs — keep the queued card until this call's tool_execution_start.
+		const argsCompleteOnly = writeToolRenderer.renderCall(
+			{ path: "xd://ast_edit", content },
+			{ ...options, argsComplete: true },
+			uiTheme,
+		);
+		expect(Bun.stripANSI(argsCompleteOnly!.render(80).join("\n"))).toContain("queued");
+
 		// Same payload after tool_execution_start: delegate to the inner renderer
 		// instead of throwing ReferenceError inside a generic Write frame.
 		const executing = writeToolRenderer.renderCall(
 			{ path: "xd://ast_edit", content },
-			{ ...options, argsComplete: true },
+			{ ...options, argsComplete: true, executionStarted: true },
 			uiTheme,
 		);
 		expect(executing).toBeDefined();

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -296,7 +296,7 @@ describe("read and write route xd:// device URLs", () => {
 		}
 	});
 
-	it("renderCall withholds a partial xd:// URL, then delegates once settled", async () => {
+	it("renderCall withholds a partial xd:// URL, then queues until execution starts", async () => {
 		await themeModule.initTheme();
 		const uiTheme = (await themeModule.getThemeByName("dark")) ?? (await themeModule.getThemeByName("light"));
 		if (!uiTheme) throw new Error("expected an initialized theme");
@@ -311,10 +311,47 @@ describe("read and write route xd:// device URLs", () => {
 		// never sees a half-typed "xd://ast_" frame.
 		expect(writeToolRenderer.renderCall({ path: "xd://ast_e" }, options, uiTheme)).toBeUndefined();
 
-		// Path settled + content streaming: delegate to the mounted tool's renderer
+		// Path settled + content streaming, but the write has not executed yet:
+		// show a queued card instead of the inner tool's in-flight renderer.
+		const queued = writeToolRenderer.renderCall({ path: "xd://ast_edit", content }, options, uiTheme);
+		expect(queued).toBeDefined();
+		const queuedText = Bun.stripANSI(queued!.render(80).join("\n"));
+		expect(queuedText).toContain("queued");
+		expect(queuedText).toContain("ast_edit");
+
+		// Same payload after tool_execution_start: delegate to the inner renderer
 		// instead of throwing ReferenceError inside a generic Write frame.
-		const rendered = writeToolRenderer.renderCall({ path: "xd://ast_edit", content }, options, uiTheme);
-		expect(rendered).toBeDefined();
+		const executing = writeToolRenderer.renderCall(
+			{ path: "xd://ast_edit", content },
+			{ ...options, argsComplete: true },
+			uiTheme,
+		);
+		expect(executing).toBeDefined();
+		const executingText = Bun.stripANSI(executing!.render(80).join("\n"));
+		expect(executingText).not.toContain("queued");
+	});
+
+	it("renders streamed MCP device writes as queued until execution starts", async () => {
+		await themeModule.initTheme();
+		const uiTheme = (await themeModule.getThemeByName("dark")) ?? (await themeModule.getThemeByName("light"));
+		if (!uiTheme) throw new Error("expected an initialized theme");
+		const content = JSON.stringify({
+			action: "grep_all",
+			pattern: "Broken",
+			scope: "game.StarterPlayer",
+			studio: "AED Content Development",
+			maxResults: 20,
+		});
+		const queued = writeToolRenderer.renderCall(
+			{ path: "xd://mcp__ecoport_search", content },
+			{ expanded: false, isPartial: true },
+			uiTheme,
+		);
+		expect(queued).toBeDefined();
+		const queuedText = Bun.stripANSI(queued!.render(120).join("\n"));
+		expect(queuedText).toContain("queued");
+		expect(queuedText).toContain("ecoport/search");
+		expect(queuedText).toContain("Broken");
 	});
 
 	it("renders device execution errors as the mounted tool instead of write", async () => {


### PR DESCRIPTION
I reviewed the full diff; this is the Grok 4.6 xhigh stall we traced in a live AED session — the TUI sat on `[*] ecoport/search` while the model was still thinking after starting a streamed `write xd://mcp__*` call, and the thinking-loop detector had already disarmed.

## Problem

There is no existing GitHub issue for this. It is a current `main` bug:

1. `guardThinkingLoopStream` disarms on the first `toolcall_start` / `toolcall_delta`.
2. xAI Responses can keep emitting `thinking_delta` after that. Those events still count as stream progress, so the idle watchdog never fires.
3. Discoverable MCP tools are invoked as `write` to `xd://mcp__…`. The write renderer immediately delegates to the inner tool card, so a streamed preview looks like a hung MCP call (`[*] ecoport/search`) even though the tool has not executed yet.

In the live `xai-oauth/grok-4.6` xhigh session, the last tool result landed at 10:51:56 and Esc aborted at 10:54:41 (~165s) with a streamed device write on screen and no recorded usage. The same session later hit `Thinking loop detected: … repeated an exact 45-character cycle 4× back-to-back` at 10:57:59 — that detector only works if it is still armed.

## Fix

- Keep thinking-loop detection armed for `thinking_delta` after a tool call starts. Visible answer text still latches it off.
- Pass `argsComplete` through the tool-execution render state (set on `tool_execution_start` / `setArgsComplete`).
- Render streamed `xd://` device writes as `queued <label>` until execution starts, then delegate to the inner renderer as before.

## Verification

- Reproduced from the live AED jsonl (`2026-08-21T08-55-52-039Z_01a02388-a1e7-715b-8d17-0fbbae65f1f0`) and from `upstream/main` source: the detector still disarms at `toolcall_start`, and completed `xd://`/MCP dispatches in that session were 2–200ms.
- `bun test test/thinking-loop.test.ts` in `packages/ai` (40 pass), including new cases for thinking after `toolcall_start`, re-arm after `thinking_end`, and the visible-text latch.
- `bun test test/write-xdev-dispatch.test.ts test/modes/components/tool-execution.test.ts test/agent-session-thinking-loop-retry.test.ts` in `packages/coding-agent` (25 pass). Queued MCP preview now shows `queued ecoport/search` instead of a live inner-tool card.

Esc remains the right recovery if the model is just thinking for a long time without looping. Dropping `[xhi]` to high/medium is still the practical operational mitigation.