### PR TITLE
fix(task): normalize boolean agent overrides

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed task spawns crashing when legacy boolean per-agent prewalk or advisor overrides are present in `config.yml`.
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1995,6 +1995,23 @@ export class Settings {
 			delete raw["advisor.subagents"];
 		}
 
+		// Early per-agent toggles were persisted as booleans even though the
+		// runtime record contract is "on"/"off"/model pattern. Normalize each
+		// layer before merging so project-level false still overrides global true.
+		{
+			const taskObj = isRecord(raw.task) ? raw.task : undefined;
+			if (taskObj) {
+				for (const key of ["agentPrewalk", "agentAdvisor"]) {
+					const overrides = isRecord(taskObj[key]) ? taskObj[key] : undefined;
+					if (!overrides) continue;
+					for (const agentName in overrides) {
+						const value = overrides[agentName];
+						if (typeof value === "boolean") overrides[agentName] = value ? "on" : "off";
+					}
+				}
+			}
+		}
+
 		// v17 renames that used to nest under a boolean parent path:
 		//   dev.autoqa.consent -> dev.autoqaConsent
 		//   todo.reminders.max -> todo.remindersMax

--- a/packages/coding-agent/test/subagent-advisor.test.ts
+++ b/packages/coding-agent/test/subagent-advisor.test.ts
@@ -1,9 +1,6 @@
 /**
- * Per-agent subagent advisors: the `advisor.subagents` → `task.agentAdvisor`
- * settings migration (per-layer, so a project-level `false` keeps overriding a
- * global `true`), the subagent-settings advisor-off default that replaced the
- * old blanket toggle (spawns opt back in per agent), and discovery of nested
- * per-subagent `__advisor.jsonl` transcripts.
+ * Per-agent settings migrations, advisor defaults for spawned sessions, and
+ * discovery of nested per-subagent `__advisor.jsonl` transcripts.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
@@ -15,7 +12,7 @@ import { registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/p
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { createSubagentSettings } from "@oh-my-pi/pi-coding-agent/task/executor";
 
-describe("advisor.subagents migration", () => {
+describe("per-agent settings migrations", () => {
 	let agentDir = "";
 	afterEach(() => {
 		if (agentDir) fs.rmSync(agentDir, { recursive: true, force: true });
@@ -47,6 +44,14 @@ describe("advisor.subagents migration", () => {
 	it("keeps an explicit task.agentAdvisor entry over the legacy toggle", async () => {
 		const settings = await load('advisor:\n  subagents: true\ntask:\n  agentAdvisor:\n    task: "off"\n');
 		expect(settings.get("task.agentAdvisor")).toEqual({ task: "off" });
+	});
+
+	it("normalizes boolean per-agent prewalk and advisor overrides", async () => {
+		const settings = await load(
+			"task:\n  agentPrewalk:\n    librarian: true\n    task: false\n  agentAdvisor:\n    librarian: false\n    task: true\n",
+		);
+		expect(settings.get("task.agentPrewalk")).toEqual({ librarian: "on", task: "off" });
+		expect(settings.get("task.agentAdvisor")).toEqual({ librarian: "off", task: "on" });
 	});
 });
 


### PR DESCRIPTION
## Repro
With `task.agentPrewalk` or `task.agentAdvisor` containing YAML booleans, `bun -e 'import { resolveAgentPrewalkPattern } from "./packages/coding-agent/src/config/model-resolver.ts"; console.log(resolveAgentPrewalkPattern({ settingsOverride: true, agentPrewalk: false }))'` exits 1 with `TypeError: options.settingsOverride?.trim is not a function`.

## Cause
`Settings.#migrateRawSettings` in `packages/coding-agent/src/config/settings.ts` left boolean values inside records whose runtime contract is `"on" | "off" | model pattern`; task execution then passed those values to `resolveAgentPrewalkPattern` or `resolveAgentAdvisorSelection`, which call `.trim()`.

## Fix
- Normalize boolean entries in both per-agent records to `"on"` or `"off"` before settings layers merge.
- Cover true and false values for both prewalk and advisor records through YAML-loaded settings.
- Document the task-spawn fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/subagent-advisor.test.ts` passes 8 tests. `bun check` passes all packages. A manual YAML-load reproduction resolves boolean prewalk/advisor values to enabled or disabled selections without throwing.

Fixes #9203