### PR TITLE
fix(acp): settle prompt turn when a residual prompt resolves locally

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed ACP `session/prompt` requests hanging forever when a builtin slash command's residual prompt (e.g. `/force:<tool> /some-command`) resolved locally, which also wedged all subsequent prompts on the session ([#9206](https://github.com/can1357/oh-my-pi/issues/9206)).
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -986,7 +986,18 @@ export class AcpAgent implements Agent {
 		});
 		if (builtinResult !== false) {
 			if ("prompt" in builtinResult) {
-				await record.session.prompt(builtinResult.prompt, { images });
+				const residualBaseline = new Set(record.extensionUserMessageTasks);
+				const residualAgentInvoked = await record.session.prompt(builtinResult.prompt, { images });
+				// A residual prompt can itself resolve locally (extension command,
+				// custom-TS command, file prompt template). No agent turn means no
+				// `agent_end`, so the prompt turn must be settled here — same pairing
+				// as the plain-prompt `!agentInvoked` path below — or the ACP
+				// `session/prompt` request never resolves (#9206).
+				if (!residualAgentInvoked) {
+					await this.#waitForExtensionUserMessages(record, residualBaseline);
+					await this.#waitForPromptEventHandlers(record);
+					this.#finishPrompt(record, { stopReason: "end_turn" });
+				}
 				return;
 			}
 			const promptTurn = record.promptTurn;

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2589,6 +2589,35 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("settles the prompt turn when a force residual prompt resolves locally (#9206)", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		// The residual prompt (e.g. an extension/custom-TS command) is handled
+		// locally: no agent turn starts, so `prompt()` returns false and no
+		// `agent_end` ever fires. The ACP turn must be settled by the trailing
+		// `#finishPrompt`, or the `session/prompt` request never resolves.
+		session.prompt = async (text: string): Promise<boolean> => {
+			session.promptCalls.push(text);
+			return false;
+		};
+
+		const response = await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000009",
+			prompt: [{ type: "text", text: "/force bash /local-command" }],
+		} as PromptRequest);
+
+		expectAcpStructure(zPromptResponse, response);
+		expect(response.stopReason).toBe("end_turn");
+		expect(session.forcedToolChoice).toBe("bash");
+		expect(session.promptCalls).toEqual(["/local-command"]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("installs the tool UI context when form elicitation is available", async () => {
 		const harness = await createHarness({ clientCapabilities: { elicitation: { form: {} } } });
 		const session = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });


### PR DESCRIPTION
## Repro
In ACP mode, send a prompt whose builtin returns a residual prompt that resolves locally — e.g. `/force bash /local-command`, where `/force` sets the forced tool choice and returns `{ prompt: "/local-command" }`, and the residual `/local-command` is handled locally (extension command, custom-TS command, or file prompt template) so `session.prompt()` returns `false` and no agent turn starts. The `session/prompt` JSON-RPC request never resolves; because prompts are serialized behind the prompt queue, every subsequent prompt on that session also blocks until the client restarts. Reproduced with a regression test: `bun test test/acp-agent.test.ts -t "residual prompt resolves locally"` times out after 5s against the unfixed code.

## Cause
`AcpAgent.#runPromptOrCommand` (`packages/coding-agent/src/modes/acp/acp-agent.ts`) awaited `record.session.prompt(builtinResult.prompt, …)` in the `{ prompt }` branch but discarded the returned `agentInvoked` flag and never called `#finishPrompt`. The prompt turn's promise (created via `Promise.withResolvers` in `prompt()`) is settled only by `#finishPrompt`, reached from the `agent_end` handler or the explicit trailing calls. On the residual-prompt local-only path neither ran, so the awaited promise stayed pending. The plain-prompt path just below already guards this with `if (!agentInvoked)`, and RPC mode routes the identical result through `watchAndReportLocalOnlyPromptResult` — this was an ACP-only omission.

## Fix
- Mirror the plain-prompt path in the `{ prompt }` branch: capture the extension-user-message baseline, await `session.prompt()`, and when the residual prompt was purely local (`!residualAgentInvoked`) drain extension user-messages and prompt event handlers, then call `#finishPrompt({ stopReason: "end_turn" })`.
- Add a regression test (`test/acp-agent.test.ts`) that stubs `session.prompt()` to resolve locally (returns `false`, no `agent_end`) and asserts the outer ACP `prompt()` settles with `end_turn`, the forced tool choice is set, and the residual prompt text is forwarded.

## Verification
`bun test packages/coding-agent/test/acp-agent.test.ts` — 75 pass, 0 fail (new test fails/times out at 5s without the fix, passes with it). The `bun run fix` + `bun check` pre-publish gate passed on push. Fixes #9206