### PR TITLE
fix(models): hydrate credential-scoped startup caches

### DIFF
--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -5,6 +5,17 @@ export interface ModelCacheProviderIdOptions {
 	baseUrl?: string;
 }
 
+const CREDENTIAL_SCOPED_MODEL_CACHE_PROVIDERS: Readonly<Record<string, true>> = {
+	"opencode-go": true,
+	"opencode-zen": true,
+	"github-copilot": true,
+};
+
+/** Whether a provider's model-cache namespace requires its resolved credential. */
+export function isCredentialScopedModelCacheProvider(providerId: string): boolean {
+	return CREDENTIAL_SCOPED_MODEL_CACHE_PROVIDERS[providerId] === true;
+}
+
 export function getDefaultModelDiscoveryBaseUrl(providerId: string): string | undefined {
 	switch (providerId) {
 		case "ollama":

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
+- Fixed startup fallback-chain warnings for discovered OpenCode Zen, OpenCode Go, and GitHub Copilot models cached under credential-scoped IDs ([#9205](https://github.com/can1357/oh-my-pi/issues/9205)).
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.
 - Fixed external editor spawning (Ctrl+G, plan review, `/todo edit`) failing to attach to visible terminals for editors like `emacsclient`.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -26,6 +26,7 @@ import { getBundledModels, getBundledProviders } from "@oh-my-pi/pi-catalog/mode
 import {
 	googleAntigravityModelManagerOptions,
 	googleGeminiCliModelManagerOptions,
+	isCredentialScopedModelCacheProvider,
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
 	resolveModelCacheProviderId,
@@ -189,6 +190,7 @@ export class ModelRegistry {
 	#cacheDbPath?: string;
 	#suppressedSelectors: Map<string, number> = new Map();
 	#backgroundRefresh?: Promise<void>;
+	#credentialScopedCacheHydration?: Promise<void>;
 	#policyReapply?: Promise<void>;
 	#lastDiscoveryWarnings: Map<string, string> = new Map();
 	// Runtime extension model overlays — persist across refresh() cycles so that
@@ -285,6 +287,27 @@ export class ModelRegistry {
 		this.#reloadStaticModels();
 		this.#suppressedSelectors.clear();
 		await this.#refreshRuntimeDiscoveries(strategy);
+	}
+
+	/**
+	 * Hydrate credential-scoped built-in catalogs from their exact cache rows.
+	 *
+	 * The synchronous constructor cannot resolve credentials, so session startup
+	 * awaits this local-only, best-effort pass before validating model selectors.
+	 */
+	hydrateCredentialScopedModelCaches(): Promise<void> {
+		if (!this.#credentialScopedCacheHydration) {
+			const providerIds = new Set<string>();
+			for (const providerId of STARTUP_MODEL_CACHE_PROVIDER_IDS) {
+				if (isCredentialScopedModelCacheProvider(providerId)) providerIds.add(providerId);
+			}
+			this.#credentialScopedCacheHydration = this.#refreshRuntimeDiscoveries("offline", providerIds).catch(error => {
+				logger.debug("credential-scoped model cache hydration failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		}
+		return this.#credentialScopedCacheHydration;
 	}
 
 	/**
@@ -755,7 +778,7 @@ export class ModelRegistry {
 		const cachedModels: Model<Api>[] = [];
 		const authoritativeFreshProviders = new Set<string>();
 		for (const providerId of STARTUP_MODEL_CACHE_PROVIDER_IDS) {
-			if (configuredDiscoveryProviders.has(providerId)) {
+			if (configuredDiscoveryProviders.has(providerId) || isCredentialScopedModelCacheProvider(providerId)) {
 				continue;
 			}
 			const cacheProviderId = this.#resolveStartupModelCacheProviderId(providerId);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1287,6 +1287,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			startupCredentialDisabledEvents.push(event);
 		}
 	});
+	await modelRegistry.hydrateCredentialScopedModelCaches();
 	if (!options.modelRegistry) {
 		modelRegistry.refreshInBackground();
 	}

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -6,6 +6,7 @@ import { Effort, type FetchImpl } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { resolveModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
 import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
 import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { getModelMatchPreferences, resolveModelScope } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
@@ -178,6 +179,75 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			expect(session.model?.provider).toBe("runtime-provider");
 			expect(session.model?.id).toBe("cached-runtime-model");
 			expect(modelFallbackMessage).toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("hydrates credential-scoped model caches before fallback validation", async () => {
+		const authStorage = createInMemoryAuthStorage();
+		authStoragesToClose.push(authStorage);
+		const providers = [
+			{ id: "opencode-go", apiKey: "go-test-key", baseUrl: "https://opencode.ai/zen/go/v1" },
+			{ id: "opencode-zen", apiKey: "zen-test-key", baseUrl: "https://opencode.ai/zen/v1" },
+			{ id: "github-copilot", apiKey: "copilot-test-key", baseUrl: "https://api.githubcopilot.com" },
+		];
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		const modelsPath = path.join(tempDir, "models.yml");
+		const fallbackSelectors: string[] = [];
+		for (const provider of providers) {
+			authStorage.setRuntimeApiKey(provider.id, provider.apiKey);
+			const cachedModel = buildModel({
+				id: "discovered-only-model",
+				name: "Discovered Only Model",
+				api: "openai-responses",
+				provider: provider.id,
+				baseUrl: provider.baseUrl,
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 16_384,
+			});
+			writeModelCache(
+				resolveModelCacheProviderId(provider.id, { apiKey: provider.apiKey }),
+				Date.now(),
+				[cachedModel],
+				true,
+				"",
+				path.join(tempDir, "models.db"),
+			);
+			fallbackSelectors.push(`${provider.id}/${cachedModel.id}`);
+		}
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const settings = Settings.isolated({
+			"retry.fallbackChains": { default: fallbackSelectors },
+		});
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			extensions: [],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+			modelPattern: "openai/gpt-4o-mini",
+		});
+
+		try {
+			expect(session.configWarnings.filter(warning => warning.includes("discovered-only-model"))).toEqual([]);
 		} finally {
 			await session.dispose();
 		}


### PR DESCRIPTION
## Repro
Create an API-key-scoped `opencode-zen` cache row containing a discovered-only model, configure that selector in `retry.fallbackChains`, and start a session with `bun test packages/coding-agent/test/sdk-model-selection.test.ts --test-name-pattern 'hydrates credential-scoped model caches'`; before the fix, `session.configWarnings` contains the unknown-model warning.

## Cause
`ModelRegistry.#loadCachedStandardProviderModels()` in `packages/coding-agent/src/config/model-registry.ts` synchronously derived startup cache ids without credentials, while OpenCode Zen, OpenCode Go, and GitHub Copilot model-manager writers include the resolved credential via `resolveModelCacheProviderId()`. `createAgentSessionScoped()` reached `AgentSession` fallback validation before any asynchronous credential-aware discovery pass could merge those rows.

## Fix
- Identify credential-scoped cache providers through the catalog cache-id module and exclude their impossible keyless synchronous reads.
- Hydrate only those providers from SQLite with an offline credential-aware pass before session fallback validation.
- Cover all three credential-scoped providers with discovered-only cached fallback selectors.

## Verification
`bun test packages/coding-agent/test/sdk-model-selection.test.ts` passes: 31 tests, 98 assertions. `bun check` passes across all packages.

Fixes #9205