### PR TITLE
fix(copy): let `/copy` reach the messages you typed (#7976)

### DIFF
--- a/packages/coding-agent/src/modes/utils/copy-targets.ts
+++ b/packages/coding-agent/src/modes/utils/copy-targets.ts
@@ -32,7 +32,7 @@ export interface LastCommand {
  * `children` to drill into.
  */
 export interface CopyTarget {
-	/** Stable id (e.g. "msg:1", "msg:1:code:0", "msg:1:quote:0", "msg:1:all", "cmd:1"). */
+	/** Stable id (e.g. "msg:1", "msg:1:code:0", "msg:1:quote:0", "msg:1:all", "you:1", "cmd:1"). */
 	id: string;
 	label: string;
 	/** Dim annotation: line/block counts, language, or tool name. */
@@ -55,8 +55,25 @@ export interface CopySource {
 	getLastVisibleHandoffText(): string | undefined;
 }
 
-/** Cap on how many recent assistant messages the picker lists. */
+/** Cap on how many recent messages of each kind (assistant, user) the picker lists. */
 const MAX_MESSAGES = 50;
+
+/** Whose turn produced a message target; also selects the target id namespace. */
+type MessageKind = "assistant" | "user";
+
+/**
+ * Openers of the synthetic "user" turns the runtime injects (environment
+ * context, skills, token budget, model switch). Nobody typed these, so `/copy`
+ * hides them. Mirrors the contextual filter the compaction retention pass uses.
+ */
+const CONTEXTUAL_USER_PREFIXES = [
+	"<environment_context>",
+	"<user_instructions>",
+	"<additional_context>",
+	"<skills",
+	"<token_budget>",
+	"<model_switch>",
+];
 
 const OPEN_FENCE_RE = /^```([^\n]*)$/;
 const CLOSE_FENCE_RE = /^```/;
@@ -200,6 +217,28 @@ function assistantText(msg: AgentMessage): string | undefined {
 	return text.trim() || undefined;
 }
 
+/**
+ * Text a human actually typed in a user turn, or undefined when the message is
+ * empty or is one of the contextual blocks the runtime injects as a "user"
+ * turn. User content is a bare string on some transports and text/image blocks
+ * on others, so both shapes are handled.
+ */
+function userText(msg: AgentMessage): string | undefined {
+	if (msg.role !== "user") return undefined;
+	let text = "";
+	if (typeof msg.content === "string") {
+		text = msg.content;
+	} else {
+		for (const content of msg.content) {
+			if (content.type === "text") text += content.text;
+		}
+	}
+	const trimmed = text.trim();
+	if (!trimmed) return undefined;
+	const probe = trimmed.toLowerCase();
+	return CONTEXTUAL_USER_PREFIXES.some(prefix => probe.startsWith(prefix)) ? undefined : trimmed;
+}
+
 function pluralLines(text: string): string {
 	const count = text.length === 0 ? 0 : text.split("\n").length;
 	return `${count} line${count === 1 ? "" : "s"}`;
@@ -227,17 +266,27 @@ function blockSummaryHint(text: string, codeCount: number, quoteCount: number): 
 	return parts.join(" · ");
 }
 
-/** Build the target node for one assistant message: a leaf when it has no
+/** Status line shown after copying a whole message, by whose turn it was. */
+function messageCopyLabel(kind: MessageKind, rank: number): string {
+	const subject = `${kind === "user" ? "your " : ""}${rank === 1 ? "last message" : "message"}`;
+	return `Copied ${subject} to clipboard`;
+}
+
+/** Build the target node for one message: a leaf when it has no
  * drillable blocks, otherwise a group exposing the full message plus each
- * fenced code block and `>`-quoted block (de-prefixed) as a child target. */
-function messageTarget(text: string, rank: number): CopyTarget {
-	const id = `msg:${rank}`;
+ * fenced code block and `>`-quoted block (de-prefixed) as a child target.
+ * `kind` picks the id namespace so assistant and user entries never collide. */
+function messageTarget(text: string, rank: number, kind: MessageKind = "assistant"): CopyTarget {
+	const id = kind === "user" ? `you:${rank}` : `msg:${rank}`;
 	const label = firstLine(text);
 	const blocks = extractBlocks(text);
-	const messageCopy = rank === 1 ? "Copied last message to clipboard" : "Copied message to clipboard";
+	const messageCopy = messageCopyLabel(kind, rank);
+	// User entries are tagged in the hint so the two streams stay tellable apart.
+	const hintPrefix = kind === "user" ? "you · " : "";
 
 	if (blocks.length === 0) {
-		return { id, label, hint: pluralLines(text), preview: text, content: text, copyMessage: messageCopy };
+		const hint = `${hintPrefix}${pluralLines(text)}`;
+		return { id, label, hint, preview: text, content: text, copyMessage: messageCopy };
 	}
 
 	// The message node itself copies the full message; each block is a child
@@ -295,7 +344,7 @@ function messageTarget(text: string, rank: number): CopyTarget {
 		});
 	}
 
-	const hint = blockSummaryHint(text, codeBlocks.length, quoteBlocks.length);
+	const hint = `${hintPrefix}${blockSummaryHint(text, codeBlocks.length, quoteBlocks.length)}`;
 	return { id, label, hint, preview: text, content: text, copyMessage: messageCopy, children };
 }
 
@@ -317,15 +366,16 @@ function commandTarget(command: LastCommand, rank: number): CopyTarget {
 }
 
 /**
- * Assemble the unified `/copy` target tree: recent assistant messages
- * (most recent first, each drillable into its code blocks), runnable command
- * targets interleaved after the assistant message that issued them, and a
- * fresh-handoff fallback when no assistant message exists yet.
+ * Assemble the unified `/copy` target tree: recent assistant and user messages
+ * (most recent first, each drillable into its code and quote blocks), runnable
+ * command targets interleaved after the assistant message that issued them, and
+ * a fresh-handoff fallback when no assistant message exists yet.
  */
 export function buildCopyTargets(source: CopySource): CopyTarget[] {
 	const targets: CopyTarget[] = [];
 	const pendingCommands: LastCommand[] = [];
 	let messageRank = 0;
+	let userRank = 0;
 	let commandRank = 0;
 
 	const appendCommands = (commands: readonly LastCommand[]) => {
@@ -337,6 +387,18 @@ export function buildCopyTargets(source: CopySource): CopyTarget[] {
 
 	for (let i = source.messages.length - 1; i >= 0 && messageRank < MAX_MESSAGES; i--) {
 		const msg = source.messages[i];
+
+		if (msg.role === "user") {
+			// Your own turns are copy targets too: before #7976 the prompt you
+			// typed was structurally unreachable from the picker.
+			if (userRank >= MAX_MESSAGES) continue;
+			const typed = userText(msg);
+			if (!typed) continue;
+			userRank += 1;
+			targets.push(messageTarget(typed, userRank, "user"));
+			continue;
+		}
+
 		if (msg.role !== "assistant") continue;
 
 		const toolCalls = msg.content.filter((c): c is ToolCall => c.type === "toolCall");

--- a/packages/coding-agent/test/modes/utils/copy-targets.test.ts
+++ b/packages/coding-agent/test/modes/utils/copy-targets.test.ts
@@ -25,6 +25,10 @@ function assistantText(text: string): AgentMessage {
 	return { role: "assistant", content: [{ type: "text", text }] } as unknown as AgentMessage;
 }
 
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }] } as unknown as AgentMessage;
+}
+
 function assistantCalls(toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>): AgentMessage {
 	return {
 		role: "assistant",
@@ -166,7 +170,7 @@ describe("buildCopyTargets", () => {
 		expect(msg?.children?.find(c => c.id === "msg:1:all-quotes")?.content).toBe("q one\n\nq two");
 	});
 
-	it("skips tool-only assistant turns and non-assistant messages", () => {
+	it("skips tool-only assistant turns and keeps user turns in their own namespace", () => {
 		const messages = [
 			{ role: "user", content: [{ type: "text", text: "hi" }] },
 			assistantCalls([{ name: "read", arguments: { path: "x" } }]),
@@ -174,6 +178,59 @@ describe("buildCopyTargets", () => {
 		] as unknown as AgentMessage[];
 		const targets = buildCopyTargets(source({ messages }));
 		expect(targets.filter(t => t.id.startsWith("msg:")).map(t => t.label)).toEqual(["real answer"]);
+		expect(targets.filter(t => t.id.startsWith("you:")).map(t => t.label)).toEqual(["hi"]);
+	});
+
+	it("lists the prompts you typed so the original request stays copyable (#7976)", () => {
+		const targets = buildCopyTargets(
+			source({
+				messages: [
+					userMessage("first prompt I wrote"),
+					assistantText("an answer"),
+					userMessage("follow-up prompt"),
+				] as unknown as AgentMessage[],
+			}),
+		);
+
+		// Every user turn is reachable, newest first — including the very first
+		// prompt, which the picker could never surface before.
+		expect(targets.filter(t => t.id.startsWith("you:")).map(t => t.id)).toEqual(["you:1", "you:2"]);
+		expect(byId(targets, "you:1")?.content).toBe("follow-up prompt");
+		expect(byId(targets, "you:2")?.content).toBe("first prompt I wrote");
+		expect(byId(targets, "you:1")?.hint).toBe("you · 1 line");
+		expect(byId(targets, "you:1")?.copyMessage).toBe("Copied your last message to clipboard");
+		expect(byId(targets, "you:2")?.copyMessage).toBe("Copied your message to clipboard");
+
+		// Assistant ranking and copy messages are untouched by the new entries.
+		expect(byId(targets, "msg:1")?.content).toBe("an answer");
+		expect(byId(targets, "msg:1")?.copyMessage).toBe("Copied last message to clipboard");
+	});
+
+	it("drills a user message into its blocks without colliding with assistant ids", () => {
+		const text = "run this\n```sh\nbun test\n```";
+		const targets = buildCopyTargets(source({ messages: [userMessage(text)] as unknown as AgentMessage[] }));
+		const mine = byId(targets, "you:1");
+		expect(mine?.content).toBe(text);
+		expect(mine?.hint).toBe("you · 4 lines · 1 code");
+		expect(mine?.children?.map(c => c.id)).toEqual(["you:1:code:0"]);
+		expect(mine?.children?.[0]?.content).toBe("bun test");
+		expect(byId(targets, "msg:1")).toBeUndefined();
+	});
+
+	it("hides the contextual user turns the runtime injects", () => {
+		const messages = [
+			userMessage("<environment_context>\ncwd: /repo"),
+			userMessage("<skills>\nfoo"),
+			{ role: "user", content: [{ type: "text", text: "   " }] },
+			userMessage("what I actually asked"),
+		] as unknown as AgentMessage[];
+		const targets = buildCopyTargets(source({ messages }));
+		expect(targets.filter(t => t.id.startsWith("you:")).map(t => t.content)).toEqual(["what I actually asked"]);
+	});
+
+	it("reads user turns whose content is a bare string", () => {
+		const messages = [{ role: "user", content: "plain string prompt" }] as unknown as AgentMessage[];
+		expect(byId(buildCopyTargets(source({ messages })), "you:1")?.content).toBe("plain string prompt");
 	});
 
 	it("falls back to handoff context only when there are no assistant messages", () => {


### PR DESCRIPTION
Fixes #7976.

## The bug

The reporter asked for something that turns out to be *structurally impossible*, not merely hard to find:

> I cannot copy the raw markdown of some messages, especially for example the original prompt that I wrote.

`buildCopyTargets()` in `packages/coding-agent/src/modes/utils/copy-targets.ts` walks the transcript newest-first and immediately discards every non-assistant turn:

```ts
for (let i = source.messages.length - 1; i >= 0 && messageRank < MAX_MESSAGES; i--) {
	const msg = source.messages[i];
	if (msg.role !== "assistant") continue;   // <- user turns can never become targets
```

So no user turn ever becomes a `CopyTarget`. The `/resume` angle in the report is incidental — the prompt you typed is unreachable from the picker in *any* session, fresh or resumed. The existing test suite even pinned this (`"skips tool-only assistant turns and non-assistant messages"`), which is why it never showed up as a failure.

## The fix

User turns now build targets through the **same** `messageTarget()` machinery, so they drill into their fenced code blocks and `>`-quoted blocks exactly like assistant messages do — handy when you paste a snippet and want it back.

Three details worth reviewing:

1. **Separate id namespace.** User entries are `you:<rank>` (and `you:1:code:0`, …) rather than `msg:<rank>`, so the two streams cannot collide and callers keying off `msg:` keep working unchanged. Their hint is prefixed `you · ` and the status line reads `Copied your last message to clipboard`, so the picker stays unambiguous.

2. **Injected turns stay hidden.** The runtime sends environment context, skills, token budget and model-switch blocks as `user` messages. Listing those would be noise, so they are filtered with the same prefix list `packages/agent/src/compaction/compaction-v2-streaming.ts` already uses for its retention filter (`isContextualUserMessage`). The list is duplicated rather than imported because it lives in a different package and is not exported — happy to export and share it instead if you'd prefer one source of truth.

3. **Both content shapes.** User `content` is a bare `string` on some transports and `(TextContent | ImageContent)[]` on others (same split `userMessageText()` in `chat-transcript-builder.ts` handles). Both are read.

## Assistant behaviour is unchanged

Same ranking, same ids, same hints, same copy messages, same `pendingCommands` interleaving, same handoff fallback. `messageTarget()` gained a defaulted third parameter, so with `kind: "assistant"` every output is byte-identical. The per-kind `MAX_MESSAGES` cap is applied independently, so the assistant list length is also unchanged.

## Tests

All existing cases in `packages/coding-agent/test/modes/utils/copy-targets.test.ts` are kept. The one that asserted non-assistant messages are dropped is **renamed and extended** rather than deleted — its `msg:`-filtered assertion still holds, which is exactly the point being made. Added:

- the reporter's case: every user turn is copyable, newest-first, **including the first prompt in the transcript**
- assistant ranks and copy messages are unaffected when user entries are present
- a user message drills into its code blocks under `you:1:code:0` with no `msg:` collision
- injected `<environment_context>` / `<skills>` turns and whitespace-only turns stay hidden
- bare-string user content is read

## Notes for the reviewer

The module docstring and the `MAX_MESSAGES` comment both said *"assistant messages"*, so this could be read as by-design. I've treated it as a bug because #7976 is triaged `bug` + `enhancement` and the reporter's ask is explicitly to copy their own prompt; the comments are updated to match the new contract. If you'd rather gate this behind a flag or an argument to `/copy`, say the word and I'll rework it.