### PR TITLE
fix(lsp): check every detected language in workspace diagnostics

### DIFF
--- a/packages/coding-agent/src/lsp/workspace-diagnostics.ts
+++ b/packages/coding-agent/src/lsp/workspace-diagnostics.ts
@@ -3,11 +3,20 @@ import path from "node:path";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 
 /** Project type detection result */
-interface ProjectType {
+export interface ProjectType {
 	type: "rust" | "typescript" | "go" | "python" | "unknown";
 	command?: string[];
 	description: string;
 }
+
+/**
+ * How many workspace checkers may run at once.
+ *
+ * Checkers like `cargo check` and `tsc` are each CPU- and memory-hungry and
+ * already parallelize internally, so a polyglot root runs them a couple at a
+ * time rather than launching every toolchain at once.
+ */
+const MAX_CONCURRENT_CHECKERS = 2;
 
 /** Convert a `go.work` use directory into the package pattern `go build` needs. */
 function goWorkspaceBuildPattern(diskPath: string): string | null {
@@ -80,38 +89,53 @@ async function resolveGoWorkspaceDiagnosticsCommand(cwd: string, signal?: AbortS
 	}
 }
 
-/** Detect project type from root markers */
-async function detectProjectType(cwd: string, signal?: AbortSignal): Promise<ProjectType> {
-	// Check for Rust (Cargo.toml)
-	if (fs.existsSync(path.join(cwd, "Cargo.toml"))) {
-		return { type: "rust", command: ["cargo", "check", "--message-format=short"], description: "Rust (cargo check)" };
+/**
+ * Detect every project type present at the workspace root.
+ *
+ * Detection used to return on the first matching marker, so a polyglot root
+ * (for example `Cargo.toml` alongside `tsconfig.json`) only ever ran the
+ * highest-priority checker and silently skipped the rest: the workspace was
+ * reported as verified while whole languages went unchecked. Every marker is
+ * collected instead, in the original priority order, so single-language roots
+ * keep their exact previous result while polyglot roots check everything.
+ *
+ * `go.work` still wins over `go.mod` and `pyproject.toml` over
+ * `pyrightconfig.json` — those pairs are two markers for one toolchain, not
+ * two separate languages.
+ */
+export async function detectProjectTypes(cwd: string, signal?: AbortSignal): Promise<ProjectType[]> {
+	const detected: ProjectType[] = [];
+	const marker = (name: string) => fs.existsSync(path.join(cwd, name));
+
+	if (marker("Cargo.toml")) {
+		const command = ["cargo", "check", "--message-format=short"];
+		detected.push({ type: "rust", command, description: "Rust (cargo check)" });
 	}
 
-	// Check for TypeScript (tsconfig.json)
-	if (fs.existsSync(path.join(cwd, "tsconfig.json"))) {
-		return { type: "typescript", command: ["npx", "tsc", "--noEmit"], description: "TypeScript (tsc --noEmit)" };
+	if (marker("tsconfig.json")) {
+		const command = ["npx", "tsc", "--noEmit"];
+		detected.push({ type: "typescript", command, description: "TypeScript (tsc --noEmit)" });
 	}
 
 	// Check for Go workspaces before single-module Go projects.
-	if (fs.existsSync(path.join(cwd, "go.work"))) {
-		return {
+	if (marker("go.work")) {
+		detected.push({
 			type: "go",
 			command: await resolveGoWorkspaceDiagnosticsCommand(cwd, signal),
 			description: "Go workspace (go build)",
-		};
+		});
+	} else if (marker("go.mod")) {
+		detected.push({ type: "go", command: ["go", "build", "./..."], description: "Go (go build)" });
 	}
 
-	// Check for Go (go.mod)
-	if (fs.existsSync(path.join(cwd, "go.mod"))) {
-		return { type: "go", command: ["go", "build", "./..."], description: "Go (go build)" };
+	if (marker("pyproject.toml") || marker("pyrightconfig.json")) {
+		detected.push({ type: "python", command: ["pyright"], description: "Python (pyright)" });
 	}
 
-	// Check for Python (pyproject.toml or pyrightconfig.json)
-	if (fs.existsSync(path.join(cwd, "pyproject.toml")) || fs.existsSync(path.join(cwd, "pyrightconfig.json"))) {
-		return { type: "python", command: ["pyright"], description: "Python (pyright)" };
+	if (detected.length === 0) {
+		return [{ type: "unknown", description: "Unknown project type" }];
 	}
-
-	return { type: "unknown", description: "Unknown project type" };
+	return detected;
 }
 
 /** Interpret an empty checker result without mistaking a crash for a clean workspace. */
@@ -125,21 +149,52 @@ export function interpretEmptyDiagnosticsResult(
 	return `Failed to run ${command.join(" ")}: the checker ${detail} without reporting anything, so the workspace was not verified`;
 }
 
-/** Run workspace diagnostics command and parse output */
-export async function runWorkspaceDiagnostics(
-	cwd: string,
-	signal?: AbortSignal,
-): Promise<{ output: string; projectType: ProjectType }> {
-	throwIfAborted(signal);
-	const projectType = await detectProjectType(cwd, signal);
-	if (!projectType.command) {
-		return {
-			output: `Cannot detect project type. Supported: Rust (Cargo.toml), TypeScript (tsconfig.json), Go (go.work/go.mod), Python (pyproject.toml)`,
-			projectType,
-		};
+/** Join per-language descriptions for the aggregate header. */
+export function combineProjectDescriptions(projectTypes: readonly ProjectType[]): string {
+	return projectTypes.map(projectType => projectType.description).join(" + ");
+}
+
+/**
+ * Label each section when more than one checker ran.
+ *
+ * A single detected language keeps the bare output it has always produced, so
+ * existing callers and their expectations are untouched.
+ */
+export function combineDiagnosticsOutputs(sections: readonly { description: string; output: string }[]): string {
+	if (sections.length === 1) return sections[0]?.output ?? "";
+	return sections.map(section => `=== ${section.description} ===\n${section.output}`).join("\n\n");
+}
+
+/** Run a bounded number of tasks at a time, preserving input order in the results. */
+async function mapWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	run: (item: T) => Promise<R>,
+): Promise<R[]> {
+	const results: R[] = new Array(items.length);
+	let cursor = 0;
+
+	const worker = async (): Promise<void> => {
+		while (true) {
+			const index = cursor++;
+			const item = items[index];
+			if (index >= items.length || item === undefined) return;
+			results[index] = await run(item);
+		}
+	};
+
+	await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+	return results;
+}
+
+/** Run one language's checker and render its output. */
+async function runProjectDiagnostics(cwd: string, projectType: ProjectType, signal?: AbortSignal): Promise<string> {
+	const command = projectType.command;
+	if (!command) {
+		return "Cannot detect project type. Supported: Rust (Cargo.toml), TypeScript (tsconfig.json), Go (go.work/go.mod), Python (pyproject.toml)";
 	}
 	try {
-		const proc = Bun.spawn(projectType.command, {
+		const proc = Bun.spawn(command, {
 			cwd,
 			stdout: "pipe",
 			stderr: "pipe",
@@ -169,17 +224,15 @@ export async function runWorkspaceDiagnostics(
 				// tsc/cargo/pyright report diagnostics and still falls through to
 				// the branch below. Mirrors the exit-status gate
 				// `resolveGoWorkspaceDiagnosticsCommand` already applies above.
-				return {
-					output: interpretEmptyDiagnosticsResult(exitCode, proc.signalCode, projectType.command),
-					projectType,
-				};
+				return interpretEmptyDiagnosticsResult(exitCode, proc.signalCode, command);
 			}
-			// Limit output length
+			// Limit output length. The cap is per language so a noisy checker
+			// cannot crowd its siblings out of a polyglot report.
 			const lines = combined.split("\n");
 			if (lines.length > 50) {
-				return { output: `${lines.slice(0, 50).join("\n")}\n[…${lines.length - 50}ln elided…]`, projectType };
+				return `${lines.slice(0, 50).join("\n")}\n[…${lines.length - 50}ln elided…]`;
 			}
-			return { output: combined, projectType };
+			return combined;
 		} finally {
 			signal?.removeEventListener("abort", abortHandler);
 		}
@@ -187,6 +240,27 @@ export async function runWorkspaceDiagnostics(
 		if (signal?.aborted) {
 			throw new ToolAbortError();
 		}
-		return { output: `Failed to run ${projectType.command.join(" ")}: ${e}`, projectType };
+		return `Failed to run ${command.join(" ")}: ${e}`;
 	}
+}
+
+/** Run workspace diagnostics command and parse output */
+export async function runWorkspaceDiagnostics(
+	cwd: string,
+	signal?: AbortSignal,
+): Promise<{ output: string; projectType: ProjectType; projectTypes: ProjectType[] }> {
+	throwIfAborted(signal);
+	const projectTypes = await detectProjectTypes(cwd, signal);
+	const primary = projectTypes[0] ?? { type: "unknown" as const, description: "Unknown project type" };
+	// Keep the single-language shape byte-identical; only name every checker
+	// when more than one actually ran.
+	const projectType =
+		projectTypes.length > 1 ? { ...primary, description: combineProjectDescriptions(projectTypes) } : primary;
+
+	const outputs = await mapWithConcurrency(projectTypes, MAX_CONCURRENT_CHECKERS, async detectedType => ({
+		description: detectedType.description,
+		output: await runProjectDiagnostics(cwd, detectedType, signal),
+	}));
+
+	return { output: combineDiagnosticsOutputs(outputs), projectType, projectTypes };
 }

--- a/packages/coding-agent/test/workspace-diagnostics.test.ts
+++ b/packages/coding-agent/test/workspace-diagnostics.test.ts
@@ -1,7 +1,33 @@
-import { describe, expect, test } from "bun:test";
-import { interpretEmptyDiagnosticsResult } from "../src/lsp/workspace-diagnostics";
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import path from "node:path";
+import {
+	combineDiagnosticsOutputs,
+	combineProjectDescriptions,
+	detectProjectTypes,
+	interpretEmptyDiagnosticsResult,
+} from "../src/lsp/workspace-diagnostics";
 
 const command = ["npx", "tsc", "--noEmit"];
+
+const roots: string[] = [];
+
+/** Build a throwaway workspace root containing exactly the given marker files. */
+function makeRoot(...markers: string[]): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "omp-workspace-diagnostics-"));
+	roots.push(root);
+	for (const marker of markers) {
+		fs.writeFileSync(path.join(root, marker), "");
+	}
+	return root;
+}
+
+afterAll(() => {
+	for (const root of roots) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
 
 describe("interpretEmptyDiagnosticsResult", () => {
 	test("reports a silent non-zero exit as an unverified workspace", () => {
@@ -18,5 +44,91 @@ describe("interpretEmptyDiagnosticsResult", () => {
 
 	test("preserves the clean-workspace result for a successful silent checker", () => {
 		expect(interpretEmptyDiagnosticsResult(0, null, command)).toBe("No issues found");
+	});
+});
+
+describe("detectProjectTypes", () => {
+	// #8385: detection returned on the first matching marker, so a root holding
+	// both `Cargo.toml` and `tsconfig.json` only ever ran cargo and reported the
+	// workspace verified while TypeScript was never checked at all.
+	test("detects every language in a polyglot root instead of only the first", async () => {
+		const detected = await detectProjectTypes(makeRoot("Cargo.toml", "tsconfig.json"));
+
+		const descriptions = detected.map(entry => entry.description);
+		expect(detected.map(entry => entry.type)).toEqual(["rust", "typescript"]);
+		expect(descriptions).toEqual(["Rust (cargo check)", "TypeScript (tsc --noEmit)"]);
+		for (const entry of detected) {
+			expect(entry.command?.length ?? 0).toBeGreaterThan(0);
+		}
+	});
+
+	test("keeps priority order across all four supported toolchains", async () => {
+		const markers = ["Cargo.toml", "tsconfig.json", "go.mod", "pyproject.toml"];
+		const detected = await detectProjectTypes(makeRoot(...markers));
+
+		expect(detected.map(entry => entry.type)).toEqual(["rust", "typescript", "go", "python"]);
+	});
+
+	test("returns a single entry for a single-language root", async () => {
+		const detected = await detectProjectTypes(makeRoot("tsconfig.json"));
+
+		expect(detected).toHaveLength(1);
+		expect(detected[0]?.type).toBe("typescript");
+		expect(detected[0]?.command).toEqual(["npx", "tsc", "--noEmit"]);
+	});
+
+	test("treats go.work and go.mod as one toolchain, preferring the workspace", async () => {
+		const detected = await detectProjectTypes(makeRoot("go.work", "go.mod"));
+
+		expect(detected).toHaveLength(1);
+		expect(detected[0]?.type).toBe("go");
+		expect(detected[0]?.description).toBe("Go workspace (go build)");
+	});
+
+	test("treats pyproject.toml and pyrightconfig.json as one toolchain", async () => {
+		const detected = await detectProjectTypes(makeRoot("pyproject.toml", "pyrightconfig.json"));
+
+		expect(detected).toHaveLength(1);
+		expect(detected[0]?.type).toBe("python");
+	});
+
+	test("reports a single unknown entry when no marker is present", async () => {
+		const detected = await detectProjectTypes(makeRoot());
+
+		expect(detected).toHaveLength(1);
+		expect(detected[0]?.type).toBe("unknown");
+		expect(detected[0]?.command).toBeUndefined();
+	});
+});
+
+describe("combineProjectDescriptions", () => {
+	test("names every checker that ran", () => {
+		const combined = combineProjectDescriptions([
+			{ type: "rust", description: "Rust (cargo check)" },
+			{ type: "typescript", description: "TypeScript (tsc --noEmit)" },
+		]);
+
+		expect(combined).toBe("Rust (cargo check) + TypeScript (tsc --noEmit)");
+	});
+
+	test("leaves a single description untouched", () => {
+		expect(combineProjectDescriptions([{ type: "go", description: "Go (go build)" }])).toBe("Go (go build)");
+	});
+});
+
+describe("combineDiagnosticsOutputs", () => {
+	test("keeps a single language's output bare", () => {
+		const rust = { description: "Rust (cargo check)", output: "No issues found" };
+
+		expect(combineDiagnosticsOutputs([rust])).toBe("No issues found");
+	});
+
+	test("labels each language so a failure is attributable to its checker", () => {
+		const rust = { description: "Rust (cargo check)", output: "No issues found" };
+		const ts = { description: "TypeScript (tsc --noEmit)", output: "src/a.ts(1,1): error TS2304" };
+		const expected =
+			"=== Rust (cargo check) ===\nNo issues found\n\n=== TypeScript (tsc --noEmit) ===\nsrc/a.ts(1,1): error TS2304";
+
+		expect(combineDiagnosticsOutputs([rust, ts])).toBe(expected);
 	});
 });


### PR DESCRIPTION
Fixes #8385

## The bug

`detectProjectType()` in `packages/coding-agent/src/lsp/workspace-diagnostics.ts` was a chain of `if (fs.existsSync(...)) return { ... }`, so it yielded exactly **one** `ProjectType`. `runWorkspaceDiagnostics` then spawned only that single checker.

On a polyglot root the consequence is silent and dangerous: with both `Cargo.toml` and `tsconfig.json` present, only `cargo check` ever runs. TypeScript is **never** checked — yet the tool still reports

```
Workspace diagnostics (Rust (cargo check)):
No issues found
```

The agent reads that as "the workspace is clean" when an entire language was never inspected. This repo is itself such a workspace (`Cargo.toml` + `tsconfig.json` at the root), so the bug reproduces on `oh-my-pi` directly.

This is distinct from #5038, which corrected `go.work` detection *within* the Go branch — the dispatcher itself stayed singular.

## The fix

- **`detectProjectTypes()`** (new, exported) collects **every** matching marker, in the original priority order. `go.work` still wins over `go.mod`, and `pyproject.toml`/`pyrightconfig.json` still collapse to one entry — those pairs are two markers for one toolchain, not two languages. No markers ⇒ a single `unknown` entry, exactly as before.
- **`runProjectDiagnostics()`** is the previous single-run body extracted verbatim: same spawn options, same abort handling, same empty-output guard via `interpretEmptyDiagnosticsResult`, same 50-line cap. The cap is now applied **per language**, so a noisy checker cannot crowd its siblings out of the report.
- **`mapWithConcurrency()`** runs at most `MAX_CONCURRENT_CHECKERS = 2` at a time and preserves input order. `cargo check` and `tsc` are each CPU- and memory-hungry and already parallelize internally, so launching every toolchain at once would be counterproductive.
- Per-language failures stay isolated: `runProjectDiagnostics` catches and renders its own error as that section's text, so one missing toolchain no longer hides the other languages' results. `ToolAbortError` still propagates.

## Backwards compatibility

The return shape is **purely additive** — `{ output, projectType, projectTypes }`. The sole consumer (`packages/coding-agent/src/lsp/tool.ts:249-262`) reads only `result.projectType.description` and `result.output`, so **`tool.ts` is unchanged by this PR**.

- **Single language** (the overwhelmingly common case): `combineDiagnosticsOutputs` returns the bare output byte-identically and `projectType` is the detected type unchanged. Output is indistinguishable from before.
- **Multiple languages**: each section is labelled `=== <description> ===`, and `projectType.description` becomes `Rust (cargo check) + TypeScript (tsc --noEmit)` so the existing header in `tool.ts` names every checker that actually ran.
- `interpretEmptyDiagnosticsResult` is untouched, so the three existing tests over it still pass unmodified.

## Tests

`packages/coding-agent/test/workspace-diagnostics.test.ts` keeps its three existing tests verbatim and adds coverage that needs no process spawning:

- polyglot root (`Cargo.toml` + `tsconfig.json`) ⇒ **both** detected, Rust first — the reporter's exact case
- all four toolchains present ⇒ priority order preserved
- single-marker root ⇒ exactly one entry with an unchanged command
- `go.work` + `go.mod` ⇒ one Go entry, workspace preferred
- `pyproject.toml` + `pyrightconfig.json` ⇒ one Python entry
- no markers ⇒ one `unknown` entry with no command
- `combineDiagnosticsOutputs` with one section ⇒ bare output (the compatibility guarantee); with two ⇒ labelled sections
- `combineProjectDescriptions` ⇒ `" + "` join

Opened as a draft for maintainer review.