### PR TITLE
fix(task): keep a task branch that already holds the agent's commits (#8868)

### DIFF
--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -54,6 +54,32 @@ function rememberAgentArtifacts(result: SingleResult): SingleResult {
 	return result;
 }
 
+/**
+ * Decide the fate of a half-built task branch after apply-back threw.
+ *
+ * Returns the branch name when it carries at least one commit past `baseSha`
+ * — the caller must keep it, because the isolation worktree that also held
+ * those objects is about to be torn down. Returns `undefined` after deleting
+ * a branch that is absent, empty, or still pinned at the baseline, preserving
+ * the original stale-branch cleanup for the cases where nothing is at stake.
+ *
+ * `revList.range` throws when the branch does not exist, which is the common
+ * "commitToBranch failed before it created anything" path; that is treated as
+ * "nothing to rescue".
+ */
+async function rescueTaskBranch(repoRoot: string, branchName: string, baseSha: string): Promise<string | undefined> {
+	let carriedCommits = 0;
+	try {
+		carriedCommits = (await git.revList.range(repoRoot, baseSha, branchName)).length;
+	} catch {
+		// Branch missing, or the baseline is unreadable — nothing to rescue.
+		carriedCommits = 0;
+	}
+	if (carriedCommits > 0) return branchName;
+	await git.branch.tryDelete(repoRoot, branchName);
+	return undefined;
+}
+
 /** Resolved repo + baseline used by every isolated spawn in a single call. */
 export interface IsolationContext {
 	repoRoot: string;
@@ -142,9 +168,10 @@ async function writeIsolationPatch(
  * Run a subagent inside an isolation worktree and capture its changes.
  *
  * Branch mode: on success, commits the diff onto `omp/task/${agentId}` and
- * returns `branchName` + `nestedPatches`. On commit failure the branch is
- * deleted, the still-live isolation diff is written to `${artifactsDir}/${agentId}.patch`,
- * and `result.error` carries the merge-failure message.
+ * returns `branchName` + `nestedPatches`. On commit failure the still-live
+ * isolation diff is written to `${artifactsDir}/${agentId}.patch`, the task
+ * branch is kept when it already carries commits (deleted otherwise), and
+ * `result.error` carries the merge-failure message plus recovery hint.
  *
  * Patch mode: on success, writes `${artifactsDir}/${agentId}.patch` and
  * returns `patchPath` + `nestedPatches`.
@@ -189,9 +216,22 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 					nestedPatches: commitResult?.nestedPatches,
 				});
 			} catch (mergeErr) {
-				// Agent succeeded but branch commit failed — clean up stale branch.
+				// Agent succeeded but the branch commit failed. `commitToBranch`
+				// is not atomic: the clean-baseline path fetches the agent's
+				// commits into the parent ODB and creates `omp/task/<id>` before
+				// it commits the leftover working-tree delta, so a throw from
+				// that trailing step leaves behind a branch that already holds
+				// every commit the agent made. The isolation worktree — the only
+				// other copy of those objects — is destroyed by the `finally`
+				// below, so deleting the branch unconditionally turned a
+				// recoverable merge conflict into permanent loss of committed
+				// work (#8868). Delete only when nothing is at stake.
+				const baseSha = taskBaseline.root.headCommit;
 				const branchName = `omp/task/${opts.agentId}`;
-				await git.branch.tryDelete(opts.context.repoRoot, branchName);
+				const rescueBranch = await rescueTaskBranch(opts.context.repoRoot, branchName, baseSha);
+				const rescueNote = rescueBranch
+					? ` The agent's commits are preserved on branch ${rescueBranch} — merge or cherry-pick it manually.`
+					: "";
 				const msg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
 				try {
 					const patchResult = await writeIsolationPatch(
@@ -204,13 +244,13 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 						...result,
 						patchPath: patchResult.patchPath,
 						nestedPatches: patchResult.nestedPatches,
-						error: `Merge failed: ${msg}`,
+						error: `Merge failed: ${msg}.${rescueNote}`,
 					});
 				} catch (patchErr) {
 					const patchMsg = patchErr instanceof Error ? patchErr.message : String(patchErr);
 					return rememberAgentArtifacts({
 						...result,
-						error: `Merge failed: ${msg}; patch capture failed: ${patchMsg}`,
+						error: `Merge failed: ${msg}; patch capture failed: ${patchMsg}.${rescueNote}`,
 					});
 				}
 			}
@@ -285,7 +325,7 @@ export async function mergeIsolatedChanges(opts: IsolationMergeOptions): Promise
 			if (!result.branchName && result.exitCode === 0 && !result.aborted && result.error) {
 				const patchList = result.patchPath ? `\nPatch artifact:\n- ${result.patchPath}` : "";
 				return {
-					summary: `\n\n<system-notification>Branch merge failed before a task branch could be created: ${result.error}\nTask outputs are preserved but changes were not applied.${patchList}</system-notification>`,
+					summary: `\n\n<system-notification>Branch merge failed while capturing the task branch: ${result.error}\nTask outputs are preserved but changes were not applied.${patchList}</system-notification>`,
 					changesApplied: false,
 					hadAnyChanges: false,
 					mergedBranchForNestedPatches: false,

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -115,6 +115,8 @@ describe("runIsolatedSubprocess", () => {
 			session: null,
 			status: "parked",
 		});
+		// No branch was ever created, so the rescue probe finds nothing to keep.
+		vi.spyOn(gitModule.revList, "range").mockRejectedValue(new Error("unknown revision"));
 		const deleteSpy = vi.spyOn(gitModule.branch, "tryDelete").mockResolvedValue(true);
 
 		const outcome = await runIsolatedSubprocess({
@@ -147,6 +149,79 @@ describe("runIsolatedSubprocess", () => {
 		expect(deleteSpy).toHaveBeenCalledWith(repoRoot, "omp/task/PreserveBranchFailure");
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 		expect(AgentRegistry.global().get("PreserveBranchFailure")?.history?.patchPath).toBe(patchPath);
+	});
+
+	it("keeps the task branch when it already carries the agent's commits", async () => {
+		// Regression for #8868: `commitToBranch` fetches the agent's commits into
+		// the parent ODB and creates `omp/task/<id>` before it commits the leftover
+		// working-tree delta. A throw from that trailing step used to delete the
+		// branch while the isolation worktree — the only other copy — was torn
+		// down in `finally`, losing committed work outright.
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolation-rescue-"));
+		tempRoots.push(repoRoot);
+		const isolationDir = path.join(repoRoot, "isolated");
+		const artifactsDir = path.join(repoRoot, "artifacts");
+		const baseline = {
+			root: {
+				repoRoot,
+				headCommit: "base",
+				staged: "",
+				unstaged: "",
+				untracked: [],
+				untrackedPatch: "",
+			},
+			nested: [],
+		};
+
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: isolationDir,
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(result({ id: "RescueBranchCommits" }));
+		vi.spyOn(worktreeModule, "commitToBranch").mockRejectedValue(
+			new Error("git apply --3way failed for task RescueBranchCommits"),
+		);
+		vi.spyOn(worktreeModule, "captureDeltaPatch").mockResolvedValue({ rootPatch: "", nestedPatches: [] });
+		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
+		AgentRegistry.global().register({
+			id: "RescueBranchCommits",
+			displayName: "RescueBranchCommits",
+			kind: "sub",
+			session: null,
+			status: "parked",
+		});
+		const rangeSpy = vi.spyOn(gitModule.revList, "range").mockResolvedValue(["commit-a", "commit-b"]);
+		const deleteSpy = vi.spyOn(gitModule.branch, "tryDelete").mockResolvedValue(true);
+
+		const outcome = await runIsolatedSubprocess({
+			baseOptions: {
+				cwd: repoRoot,
+				agent: {
+					name: "task",
+					description: "Task agent",
+					systemPrompt: "test",
+					source: "bundled",
+				},
+				task: "Do work",
+				index: 0,
+				id: "RescueBranchCommits",
+			},
+			context: { repoRoot, baseline },
+			preferredBackend: undefined,
+			agentId: "RescueBranchCommits",
+			mergeMode: "branch",
+			artifactsDir,
+			buildFailureResult: err => result({ exitCode: 1, error: String(err) }),
+		});
+
+		expect(rangeSpy).toHaveBeenCalledWith(repoRoot, "base", "omp/task/RescueBranchCommits");
+		expect(deleteSpy).not.toHaveBeenCalled();
+		expect(outcome.error).toContain("git apply --3way failed");
+		expect(outcome.error).toContain("preserved on branch omp/task/RescueBranchCommits");
+		expect(outcome.error).toContain("cherry-pick");
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps an isolated worktree until deferred child cleanup settles", async () => {
@@ -245,10 +320,24 @@ describe("mergeIsolatedChanges", () => {
 		expect(outcome.changesApplied).toBe(false);
 		expect(outcome.hadAnyChanges).toBe(false);
 		expect(outcome.mergedBranchForNestedPatches).toBe(false);
-		expect(outcome.summary).toContain("Branch merge failed before a task branch could be created");
+		expect(outcome.summary).toContain("Branch merge failed while capturing the task branch");
 		expect(outcome.summary).toContain("git apply --3way failed");
 		expect(outcome.summary).toContain("/repo/artifacts/dirty-context.patch");
 		expect(outcome.summary).not.toContain("No changes to apply");
+	});
+
+	it("relays the rescued task branch into the merge summary", async () => {
+		const outcome = await mergeIsolatedChanges({
+			repoRoot: "/repo",
+			mergeMode: "branch",
+			result: result({
+				error: "Merge failed: conflict. The agent's commits are preserved on branch omp/task/Rescued — merge or cherry-pick it manually.",
+			}),
+		});
+
+		expect(outcome.changesApplied).toBe(false);
+		expect(outcome.summary).toContain("omp/task/Rescued");
+		expect(outcome.summary).toContain("cherry-pick");
 	});
 
 	it("treats already-applied patch-mode diffs as successful no-ops", async () => {


### PR DESCRIPTION
Fixes #8868.

## Symptom

A subagent running in an isolated worktree does real work and commits it. The apply-back step then fails (`git apply --3way failed for task <id>`), and the commits are **gone** — `git cat-file -t <sha>` reports `Not a valid object name`. The reporter lost a full subagent session this way on omp 17.2.12.

## Root cause

`worktree.ts → commitToBranch()` is not atomic. On the clean-baseline path it first runs

```
git fetch <isolationDir> HEAD refs/heads/omp/task/<agentId>
```

which **already copies the agent's commit objects into the parent ODB and creates the branch**. Only afterwards does it add a worktree and commit the leftover working-tree delta. When that trailing step throws, we are left with a perfectly good branch carrying the committed work.

But `runIsolatedSubprocess`'s `catch (mergeErr)` deleted `omp/task/<agentId>` **unconditionally** ("clean up stale branch"), and the `finally` block always `fs.rm`s the isolation clone. Deleting the only reachable ref made the objects unreachable, and destroying the clone removed the only other copy. A recoverable conflict became permanent data loss.

## Fix

Probe before deleting. New helper `rescueTaskBranch(repoRoot, branchName, baseSha)`:

- `git rev-list baseSha..branchName` — if it yields **any** commits, the branch carries work: **keep it** and return its name.
- If it yields none (or throws, e.g. the branch was never created), the branch is genuinely stale: `branch.tryDelete` as before.

The rescued branch name is appended to `result.error` (`The agent's commits are preserved on branch omp/task/<id> — merge or cherry-pick it manually.`), which `mergeIsolatedChanges` already interpolates into the user-facing summary, so the operator is told exactly where the work is.

Also reworded the branch-mode failure headline from `Branch merge failed before a task branch could be created` to `Branch merge failed while capturing the task branch` — the old wording is factually wrong once a branch survives.

Patch-mode capture is unchanged, and stale-branch cleanup for the genuine no-commits case is preserved, so no branch litter is introduced.

## Tests

- New: *keeps the task branch when it already carries the agent's commits* — mocks `revList.range` to return two commits, asserts `branch.tryDelete` is **not** called and the error carries the branch name plus recovery instructions.
- New: *relays the rescued task branch into the merge summary*.
- Existing *preserves branch-mode output as a patch when branch transfer fails* still asserts `tryDelete` **is** called (no branch was created), now with an explicit `revList.range` rejection so the path is deterministic.
- Updated the one assertion that pinned the old headline wording.

## Follow-up (not in this PR)

When `result.exitCode !== 0`, `runIsolatedSubprocess` captures **nothing** — no branch, no patch — and then destroys the worktree, so a failed or aborted subagent still loses all of its work. That deserves its own issue.