### PR TITLE
fix(prompts): describe the pending-only todo auto-promotion rule (#8121)

### DIFF
--- a/packages/coding-agent/src/prompts/tools/todo.md
+++ b/packages/coding-agent/src/prompts/tools/todo.md
@@ -1,6 +1,6 @@
 **Tasks: verbatim content strings, NEVER auto-generated IDs; no "task-1"/"task-N". Pass content in `task`.**
 
-Each completion: earliest still-open task (phase order) auto-promotes to `in_progress`. Out-of-order completion may move pointer back to an earlier phase—expected; completed tasks NEVER revert.
+After each op: if nothing is `in_progress`, the earliest `pending` task (phase order) auto-promotes to `in_progress`; if several are `in_progress`, only the earliest stays. Blocked tasks NEVER auto-promote—`unblock` first. Out-of-order completion may move pointer back to an earlier phase—expected; completed tasks NEVER revert.
 
 ## Operations
 
@@ -11,7 +11,7 @@ Each completion: earliest still-open task (phase order) auto-promotes to `in_pro
 |`start`|`task`|Mark in progress|
 |`done`|`task` or `phase`|Mark completed|
 |`drop`|`task` or `phase`|Mark abandoned|
-|`block`|`task` or `phase`; optional `reason`|Mark blocked: open, awaiting external input; excluded from stop-time incomplete-todo reminder|
+|`block`|`task` or `phase`; optional `reason`|Mark blocked: awaiting external input; never auto-promotes; excluded from stop-time incomplete-todo reminder|
 |`unblock`|`task` or `phase`|Blocked task → `pending`|
 |`rm`|optional `task` or `phase`|Remove task/phase; omit both → clear|
 |`append`|`phase`; `items: string[]`|Append tasks to phase; lazily creates phase|
@@ -26,7 +26,7 @@ Each completion: earliest still-open task (phase order) auto-promotes to `in_pro
 
 - Mark tasks done immediately after finishing; complete phases in order.
 - NEVER make a todo call the turn's only tool call. Batch with real work: `init` with first reads/edits; each `done`/`start` with next action. Solo todo turns waste a round trip.
-- Waiting on something you can't act on—a user decision, another agent, external service: `block` task (optional `reason`); remains tracked but avoids stop reminder. `unblock` when actionable. If blocker agent-actionable, `append` an unblocking task instead.
+- Waiting on something you can't act on—a user decision, another agent, external service: `block` task (optional `reason`); remains tracked but avoids stop reminder. Blocking the active task hands `in_progress` to the next `pending` task, never back to the blocked one. `unblock` when actionable. If blocker agent-actionable, `append` an unblocking task instead.
 - Keep introduced `task`/`phase` strings stable.
 - Lost exact task text: `view` echoes list; NEVER guess from memory.
 


### PR DESCRIPTION
Fixes #8121.

**Prompt-only change. Runtime behaviour is unchanged and no test needed to change** — the contract is already pinned by `test/tools/todo.test.ts → “does not auto-promote a blocked task to in_progress”`.

## The mismatch

`src/prompts/tools/todo.md` told the model:

> Each completion: earliest **still-open** task (phase order) auto-promotes to `in_progress`.

and two rows later defined `block` as *“Mark blocked: **open**, awaiting external input”*. Read together, blocked tasks look like auto-promotion candidates.

The runtime says otherwise, in two independent places in `src/tools/todo.ts`:

- `normalizeInProgressTask()` promotes `orderedTasks.find(task => task.status === "pending")` — strictly `pending`.
- `nextActionableTask()` returns the first `in_progress`, else the first `pending`; `blocked` is skipped on both branches.

So an agent that blocks its active task cannot tell from the contract whether the blocked task restarts or the next pending one advances.

## Two further inaccuracies in the same sentence

While correcting `still-open` → `pending` I fixed two more drifts the issue's *“should also remain accurate for successful state-changing operations that normalize task state, not only `done`”* points at:

1. **“Each completion” is too narrow.** `normalizeInProgressTask()` is invoked from `applyParams()`, `applyOpsToPhases()` and `markdownToPhases()` — i.e. after **every** op, not just `done`. Blocking the active task re-points the cursor with no completion involved at all.
2. **The promotion is conditional and the multi-`in_progress` collapse was undocumented.** Promotion only happens when nothing is `in_progress`; when several are, all but the earliest are demoted back to `pending`.

## New wording

> After each op: if nothing is `in_progress`, the earliest `pending` task (phase order) auto-promotes to `in_progress`; if several are `in_progress`, only the earliest stays. Blocked tasks NEVER auto-promote—`unblock` first. Out-of-order completion may move pointer back to an earlier phase—expected; completed tasks NEVER revert.

Plus:

- the `block` row drops the misleading `open,` and gains `never auto-promotes`;
- the blocking rule under **Rules** now states the consequence explicitly: *“Blocking the active task hands `in_progress` to the next `pending` task, never back to the blocked one.”*

## Verification

Matches the issue's stated check — `init [a,b]` then `block a` leaves `a` blocked and promotes `b` to `in_progress`, which is exactly what the description now predicts. Terse house style preserved; the file grew by 3 lines net.