### PR TITLE
fix(hub): bare `wait` must consume an already-queued bus message

### DIFF
--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -300,6 +300,18 @@ export class IrcBus {
 		return mailbox;
 	}
 
+	/**
+	 * Consume the OLDEST pending message for `agentId` (optionally restricted
+	 * to `from`), leaving the rest of the mailbox intact. This is the exact
+	 * atomic step `wait` performs on entry, exposed for callers that must not
+	 * block: peeking with `inbox` and consuming afterwards would open a window
+	 * for a concurrent consumer of the same mailbox to take the message in
+	 * between, and a plain `inbox` drain would swallow the whole backlog.
+	 */
+	take(agentId: string, from?: string): IrcMessage | undefined {
+		return this.#takeFromMailbox(agentId, from);
+	}
+
 	unreadCount(agentId: string): number {
 		return this.#mailboxes.get(agentId)?.length ?? 0;
 	}

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -371,6 +371,14 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 		if (!manager || runningJobs.length === 0) {
 			// No job legs: pure message wait — or nothing to block on at all.
 			if (!messaging) return nothingToWaitForResult(this.session);
+			// The bus mailbox is a separate store from the session-pending buffer
+			// drained above, and only `executeMessageWait` below ever reads it. A
+			// peer that sends and then stops running leaves its message queued
+			// there, so without this take the liveness gate would answer "nothing
+			// to wait for" while `hub inbox` hands back the very message being
+			// waited on. Single atomic take: the rest of the backlog stays queued.
+			const queued = IrcBus.global().take(messaging.senderId, from);
+			if (queued) return messageResult(messaging.senderId, queued);
 			if (!from) {
 				// A bare wait can only be satisfied by a running peer eventually
 				// sending something; with none, return the snapshot immediately

--- a/packages/coding-agent/test/tools/hub-wait.test.ts
+++ b/packages/coding-agent/test/tools/hub-wait.test.ts
@@ -134,4 +134,35 @@ describe("hub unified wait", () => {
 		expect(text).toContain("Zombie");
 		expect(text).toContain("no turn in flight");
 	});
+
+	test("bare wait returns a message already queued on the bus", async () => {
+		const registry = AgentRegistry.global();
+		// A recipient whose live hand-off throws is the only way a message
+		// reaches the mailbox: `IrcBus.send` buffers solely from that catch.
+		registry.register({
+			id: SELF_ID,
+			displayName: "main",
+			kind: "main",
+			session: {
+				deliverIrcMessage: () => Promise.reject(new Error("session disposed")),
+			},
+		} as unknown as Parameters<AgentRegistry["register"]>[0]);
+		// Idle peer: nothing is running, so the liveness gate would otherwise
+		// short-circuit the wait before the mailbox is ever consulted.
+		registry.register({ id: "Peer", displayName: "task", kind: "sub", session: null, status: "idle" });
+
+		const receipt = await IrcBus.global().send({ from: "Peer", to: SELF_ID, body: "picked up the lock" });
+		expect(receipt.outcome).toBe("failed");
+		expect(IrcBus.global().unreadCount(SELF_ID)).toBe(1);
+
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const result = await new HubTool(makeSession(manager)).execute("call_5", { op: "wait" });
+		const details = result.details as CoordinationDetails;
+
+		expect(details.op).toBe("wait");
+		expect(details.waited?.from).toBe("Peer");
+		expect(details.waited?.body).toBe("picked up the lock");
+		// Consumed, not merely peeked.
+		expect(IrcBus.global().unreadCount(SELF_ID)).toBe(0);
+	});
 });


### PR DESCRIPTION
Fixes #8120.

## Problem

`hub wait` can report **"Nothing to wait for"** while `hub inbox` would hand back a message that is sitting in the recipient's `IrcBus` mailbox.

The two stores are independent:

| store | written by | read by |
| --- | --- | --- |
| session-pending inbox | `AgentSession` buffering | `drainPendingInbox()` |
| `IrcBus` mailbox | `IrcBus.#enqueue` (failed live hand-off) | `IrcBus.wait()` / `inbox()` |

`executeInbox()` merges both, which is why `inbox` sees the message. `#executeWait()` does not:

1. the fast path at the top drains only the **session-pending** buffer;
2. in the `!manager || runningJobs.length === 0` branch a **bare** wait (no `from`) computes `hasRunningPeer` and returns `nothingToWaitForResult(...)` **before** `executeMessageWait()` — the only path that ever touches the bus.

Race that reaches it: a peer `send`s, the live hand-off throws (recipient disposed / mid-shutdown) so `IrcBus` buffers the message, the peer then goes idle. The recipient's next bare `hub wait` sees no running peers and gives up on a mailbox that is not empty.

## Fix

Take at most **one** matching queued message before the liveness gate:

```ts
const queued = IrcBus.global().take(messaging.senderId, from);
if (queued) return messageResult(messaging.senderId, queued);
```

`IrcBus.take()` is a new thin public wrapper over the existing private `#takeFromMailbox` — the exact atomic step `IrcBus.wait()` already performs on entry. Doing it this way matters:

- **atomic** — peeking with `inbox({peek:true})` and consuming afterwards leaves a window for a concurrent consumer of the same mailbox;
- **single message** — a plain `inbox()` drain would swallow the whole backlog into one wait result.

Behaviour deltas are limited to the previously-broken case: an empty mailbox still returns immediately (`take` yields `undefined`), the remaining backlog stays queued, and `from`-filtered waits keep their filter. Other paths were already correct because they route through `IrcBus.wait()`, which drains pending mail before parking a waiter and before its liveness abort check.

## Tests

New case in `test/tools/hub-wait.test.ts`: register the recipient with a session whose `deliverIrcMessage` rejects (the only route into `#enqueue`), `send` from an **idle** peer, then assert the bare `wait` returns that message and that `unreadCount` drops to 0. The sibling test *"bare wait with no jobs and no running peers returns immediately"* still passes, pinning the no-regression side.

## Notes

- Diagnosis in the issue thread by @alloevil was accurate; this ships an atomic single-take rather than the suggested peek-then-consume, for the reason above.
- Adjacent prior art: #7503, #6906, PR #7845.

Draft — for maintainer review.
