### PR TITLE
fix(browser): reap a dead shared-browser daemon before replacing it

### DIFF
--- a/packages/coding-agent/src/tools/browser/shared-daemon.ts
+++ b/packages/coding-agent/src/tools/browser/shared-daemon.ts
@@ -39,6 +39,17 @@ export function sharedBrowserDaemonName(headless: boolean): string {
 	return headless ? "omp.browser.headless" : "omp.browser.headed";
 }
 
+/**
+ * Terminal daemon records that cannot be attached to. A dead record is not
+ * proof that the Chromium the broker launched is gone: on Windows the root
+ * process is observed exiting (`failed`, exit code 255) while its child tree
+ * stays alive, so these must be stopped before a replacement start rather than
+ * silently started over (issue #7900).
+ */
+export function isDeadDaemonRecord(snapshot: DaemonSnapshot): boolean {
+	return snapshot.state === "exited" || snapshot.state === "failed";
+}
+
 function wsEndpointOf(snapshot: DaemonSnapshot | undefined): string | undefined {
 	return snapshot?.readyMatch?.match(/ws:\/\/\S+/)?.[0];
 }
@@ -84,7 +95,7 @@ export async function ensureSharedBrowser(opts: {
 	for (let attempt = 0; attempt < ENSURE_ATTEMPTS; attempt++) {
 		throwIfAborted(opts.signal);
 		const existing = await describeQuietly(client, name, "Shared browser", opts.signal);
-		if (existing && existing.state !== "exited" && existing.state !== "failed") {
+		if (existing && !isDeadDaemonRecord(existing)) {
 			const settled =
 				existing.readyAt !== undefined ? existing : await waitReady(client, name, "Shared browser", opts.signal);
 			const wsEndpoint = wsEndpointOf(settled);
@@ -96,6 +107,12 @@ export async function ensureSharedBrowser(opts: {
 			await stopQuietly(client, name, "Shared browser", opts.signal);
 			continue;
 		}
+		// Starting over a terminal record leaks whatever survived it: the broker
+		// forgets the old generation, so the Chromium tree that outlived its root
+		// process is never reaped and every subsequent acquisition spawns another
+		// one (issue #7900). Stop first — the broker owns the tree kill, and
+		// stopping an already-dead daemon is a no-op.
+		if (existing) await stopQuietly(client, name, "Shared browser", opts.signal);
 		try {
 			const started = await client.request(
 				{

--- a/packages/coding-agent/test/tools/browser-shared-daemon.test.ts
+++ b/packages/coding-agent/test/tools/browser-shared-daemon.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import type { DaemonSnapshot } from "../../src/launch/protocol";
+import { isDeadDaemonRecord, sharedBrowserDaemonName } from "../../src/tools/browser/shared-daemon";
+
+function snapshot(state: DaemonSnapshot["state"], overrides: Partial<DaemonSnapshot> = {}): DaemonSnapshot {
+	return {
+		name: "omp.browser.headless",
+		id: "daemon-1",
+		state,
+		createdAt: 0,
+		startedAt: 0,
+		restartCount: 0,
+		outputBytes: 0,
+		persist: false,
+		detached: false,
+		...overrides,
+	};
+}
+
+describe("shared browser daemon records", () => {
+	test("attachable states are never reclaimed", () => {
+		for (const state of ["starting", "running", "ready", "restarting", "stopping"] as const) {
+			expect(isDeadDaemonRecord(snapshot(state))).toBe(false);
+		}
+	});
+
+	test("terminal records are reclaimed before a replacement start", () => {
+		expect(isDeadDaemonRecord(snapshot("exited"))).toBe(true);
+		// The Windows leak in issue #7900: the broker reports `failed` with exit
+		// code 255 shortly after a successful start, while the Chromium tree it
+		// launched is still alive and must be stopped before the next start.
+		expect(isDeadDaemonRecord(snapshot("failed", { exitCode: 255, readyAt: 1 }))).toBe(true);
+	});
+
+	test("daemon name is stable per headless mode", () => {
+		expect(sharedBrowserDaemonName(true)).toBe("omp.browser.headless");
+		expect(sharedBrowserDaemonName(false)).toBe("omp.browser.headed");
+	});
+});


### PR DESCRIPTION
Fixes the leak half of #7900 — every `web_search` / browser call orphaning another headless Chromium process tree on Windows.

## Root cause

Credit to @roboomp, whose comment on the issue corrected the original diagnosis. The reporter blamed pool eviction in `registry.ts`; that is by-design and harmless, and their suggested "close the browser on release" fix was explicitly rejected as unviable. The real failure is that `ensureSharedBrowser` never reuses the daemon **and** never reaps the previous one.

The reporter's follow-up measurements pin it down: `omp.browser.headless/meta.json` ends `"state":"failed","exitCode":255,"restartCount":0` after **every** call, while the Chromium tree from the previous call is **still alive** (a 17:52 spawn happened while the 17:28 tree kept running until 18:04). The root process exits; its children survive.

In `ensureSharedBrowser` the attempt loop only stops the daemon on the *live record but unreachable Chrome* path:

```ts
const existing = await describeQuietly(...);
if (existing && existing.state !== "exited" && existing.state !== "failed") {
   // reuse if probeEndpoint succeeds, else stopQuietly + continue
}
try { await client.request({ op: "start", ... }); ... }
```

When the record **is** `exited`/`failed`, control falls straight through to `start` with **no `stopQuietly`**. The broker forgets that generation, so the process tree that outlived its root is never reaped — and the next acquisition spawns yet another one. Unbounded growth, exactly as measured.

## The change

1. Export a documented predicate `isDeadDaemonRecord(snapshot)` (`exited` | `failed`) and use it in the reuse guard — behaviour there is unchanged.
2. Before the replacement `start`, `if (existing) await stopQuietly(client, name, ...)`.

`stopQuietly` is best-effort and swallows broker errors, and stopping an already-dead daemon is a no-op, so a healthy host sees no behavioural difference. The `if (existing)` guard avoids a pointless stop when the daemon was never registered.

## Scope / open question

This fixes the **leak**: a dead record can no longer strand a live Chromium tree. It does **not** explain *why* the daemon reports `failed` with exit code 255 on that Windows host in the first place — i.e. why the reuse branch is never taken. That is a separate question for maintainers, and I did not want to guess at it inside this PR. With this change the failure mode degrades from "unbounded orphaned Chromiums" to "one relaunch per call", which is survivable.

## Tests

`ensureSharedBrowser` reaches `daemonClientForProject` and `resolveSharedBrowserLaunchSpec` with no injection seam, and only 1 of ~280 test files in this package uses `mock.module`, so module mocking looked against the house style. Instead the reclaim decision is covered directly via the exported predicate: `packages/coding-agent/test/tools/browser-shared-daemon.test.ts` asserts all 7 `DaemonState` values plus `sharedBrowserDaemonName(true|false)`. Happy to restructure toward an injectable seam if you'd prefer a full integration test.

Opened as a draft for review.