### PR TITLE
fix(coding-agent): rebuild scoped models after background discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
+- Fixed interactive `/models` and Ctrl+P cycling omitting an `enabledModels`/`--models` model discovered by a background provider refresh (e.g. `opencode-go/ox-alpha-free`) after startup, by rebuilding the scoped list once discovery completes ([#9220](https://github.com/can1357/oh-my-pi/issues/9220)).
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.
 - Fixed external editor spawning (Ctrl+G, plan review, `/todo edit`) failing to attach to visible terminals for editors like `emacsclient`.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -707,25 +707,29 @@ async function switchToResumedProject(
 
 /**
  * Resolve the effective model allow-list from an explicit `--models` scope or,
- * failing that, the active project's `enabledModels`. Re-run after a resume
+ * failing that, the active project's `enabledModels`. A totally collapsed scope
+ * gets one cache-aware discovery pass before session construction: otherwise an
+ * all-discovery `--models` launch can select an unrelated static model before the
+ * later background rebuild activates the requested scope. Re-run after a resume
  * switches projects so the destination project's settings-derived scope wins
  * over the launch directory's.
  */
-async function resolveScopedModels(
+export async function resolveScopedModels(
 	parsed: Args,
-	modelRegistry: ModelRegistry,
+	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getDiscoverableProviders" | "refresh">,
 	activeSettings: Settings,
 ): Promise<ScopedModel[]> {
 	const modelPatterns = parsed.models ?? activeSettings.get("enabledModels");
 	if (!modelPatterns || modelPatterns.length === 0) {
 		return [];
 	}
-	return await resolveModelScope(
-		modelPatterns,
-		modelRegistry,
-		getModelMatchPreferences(activeSettings),
-		activeSettings,
-	);
+	const preferences = getModelMatchPreferences(activeSettings);
+	const scopedModels = await resolveModelScope(modelPatterns, modelRegistry, preferences, activeSettings);
+	if (scopedModels.length > 0 || modelRegistry.getDiscoverableProviders().length === 0) {
+		return scopedModels;
+	}
+	await modelRegistry.refresh("online-if-uncached");
+	return await resolveModelScope(modelPatterns, modelRegistry, preferences, activeSettings);
 }
 
 /**
@@ -772,10 +776,10 @@ export interface ScopedModelSink {
  * the frozen scoped `/models` list even though it is in `enabledModels`, invokable
  * via `--model`, and listed by `omp models find`. Once the initial refresh settles,
  * re-resolve the scope and, when the set changed, push the fuller list into the
- * session so the scoped picker and Ctrl+P cycle include it. Only augments an
- * already-active scope; a scope that resolved to zero models is left to the SDK's
- * discovery fallback. Fire-and-forget — never blocks the prompt on discovery
- * latency. Issue #9220.
+ * session so the scoped picker and Ctrl+P cycle include it. A scope that resolved
+ * to zero models may become active here when the startup discovery pass returned
+ * no models but the background pass succeeded. Fire-and-forget — never blocks the
+ * prompt on background discovery latency. Issue #9220.
  */
 export async function rebuildScopedModelsAfterDiscovery(
 	session: ScopedModelSink,
@@ -783,7 +787,6 @@ export async function rebuildScopedModelsAfterDiscovery(
 	modelRegistry: Pick<ModelRegistry, "getAvailable" | "awaitBackgroundRefresh">,
 	activeSettings: Settings,
 ): Promise<void> {
-	if (session.scopedModels.length === 0) return;
 	const patterns = parsed.models ?? activeSettings.get("enabledModels");
 	if (!patterns || patterns.length === 0) return;
 	await modelRegistry.awaitBackgroundRefresh();
@@ -1811,10 +1814,12 @@ export async function runRootCommand(
 
 		// Runtime provider discovery (opencode-go, models.yml `discovery:`, proxies)
 		// populates the registry AFTER the scope was snapshotted at startup; re-resolve
-		// once it settles so a newly-discovered enabledModels model joins the scoped
-		// /models list and Ctrl+P cycle (issue #9220). Fire-and-forget: the prompt must
-		// never block on discovery latency.
-		if (isInteractive && scopedModels.length > 0) {
+		// once it settles so newly-discovered configured models join the scoped
+		// /models list and Ctrl+P cycle, including scopes that initially resolved
+		// empty (issue #9220). Fire-and-forget: the prompt must never block on the
+		// background pass.
+		const configuredScope = parsedArgs.models ?? settingsInstance.get("enabledModels");
+		if (isInteractive && configuredScope.length > 0) {
 			void rebuildScopedModelsAfterDiscovery(session, parsedArgs, modelRegistry, settingsInstance).catch(error =>
 				logger.warn("Scoped model rebuild after discovery failed", { error: String(error) }),
 			);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -710,9 +710,13 @@ async function switchToResumedProject(
  * failing that, the active project's `enabledModels`. A totally collapsed scope
  * gets one cache-aware discovery pass before session construction: otherwise an
  * all-discovery `--models` launch can select an unrelated static model before the
- * later background rebuild activates the requested scope. Re-run after a resume
- * switches projects so the destination project's settings-derived scope wins
- * over the launch directory's.
+ * later background rebuild activates the requested scope. The pass only helps
+ * providers already known to be discoverable (models.yml `discovery:`, runtime
+ * managers); a scope naming only extension-supplied models stays empty here
+ * because those providers register during `createAgentSession` — that case is
+ * covered by deferring to the SDK's `modelPattern` resolution in
+ * {@link buildSessionOptions}. Re-run after a resume switches projects so the
+ * destination project's settings-derived scope wins over the launch directory's.
  */
 export async function resolveScopedModels(
 	parsed: Args,
@@ -1121,6 +1125,17 @@ export async function buildSessionOptions(
 		// escape it — keep pinning the first scoped model there.
 		deferredDefaultRole = !options.model && Boolean(remembered) && !((parsed.models?.length ?? 0) > 0);
 		if (!options.model && !deferredDefaultRole) options.model = scopedModels[0].model;
+	} else if ((parsed.models?.length ?? 0) > 0 && !restoringSession) {
+		// A CLI `--models` scope that resolved to zero models at startup: its
+		// selectors name only models supplied by extension providers (or discovery)
+		// that register during createAgentSession, so nothing matched the
+		// pre-session catalog and `getDiscoverableProviders()` did not yet list the
+		// provider for resolveScopedModels' pre-refresh. Defer the choice to the
+		// SDK's post-extension resolution — the same `modelPattern` path a deferred
+		// `--model` uses — so the initial model is picked from the requested scope
+		// instead of an unrelated fallback. The fire-and-forget rebuild then
+		// activates the scoped list once discovery settles (issue #9220).
+		options.modelPattern = parsed.models;
 	}
 
 	if (parsed.noPrewalk && (parsed.prewalk || parsed.prewalkInto !== undefined)) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -7,8 +7,8 @@
 import * as fsSync from "node:fs";
 import * as os from "node:os";
 import { createInterface } from "node:readline/promises";
-import { EventLoopKeepalive } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { EventLoopKeepalive, type ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { ImageContent, Model } from "@oh-my-pi/pi-ai";
 import {
 	$env,
 	directoryExists,
@@ -728,6 +728,77 @@ async function resolveScopedModels(
 	);
 }
 
+/**
+ * Map resolver scope entries to the session's Ctrl+P cycle shape, filling in the
+ * configured default thinking level for entries without an explicit `:level`
+ * suffix. `auto` is session-level only, so it is coerced to a concrete default here.
+ */
+export function toSessionScopedModels(
+	scopedModels: readonly ScopedModel[],
+	activeSettings: Settings,
+): Array<{ model: Model; thinkingLevel?: ThinkingLevel }> {
+	if (scopedModels.length === 0) return [];
+	const defaultThinkingLevel = concreteThinkingLevel(
+		parseConfiguredThinkingLevel(activeSettings.get("defaultThinkingLevel")),
+	);
+	return scopedModels.map(scopedModel => ({
+		model: scopedModel.model,
+		thinkingLevel: scopedModel.explicitThinkingLevel
+			? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
+			: defaultThinkingLevel,
+	}));
+}
+
+/** Whether two scope lists reference the same set of models (order-independent). */
+function sameScopedModelSet(a: ReadonlyArray<{ model: Model }>, b: ReadonlyArray<{ model: Model }>): boolean {
+	if (a.length !== b.length) return false;
+	const keys = new Set(a.map(entry => `${entry.model.provider}/${entry.model.id}`));
+	return b.every(entry => keys.has(`${entry.model.provider}/${entry.model.id}`));
+}
+
+/** Minimal session surface the post-discovery scope rebuild mutates. */
+export interface ScopedModelSink {
+	readonly isDisposed: boolean;
+	readonly scopedModels: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void;
+}
+
+/**
+ * Startup resolves the `--models`/`enabledModels` scope from the model registry
+ * before background provider discovery runs — `createSession` fires
+ * `refreshInBackground()` only after the session is built — so a scoped selector
+ * whose model first materializes through runtime discovery (e.g.
+ * `opencode-go/ox-alpha-free` on a fresh launch with no cache row) is absent from
+ * the frozen scoped `/models` list even though it is in `enabledModels`, invokable
+ * via `--model`, and listed by `omp models find`. Once the initial refresh settles,
+ * re-resolve the scope and, when the set changed, push the fuller list into the
+ * session so the scoped picker and Ctrl+P cycle include it. Only augments an
+ * already-active scope; a scope that resolved to zero models is left to the SDK's
+ * discovery fallback. Fire-and-forget — never blocks the prompt on discovery
+ * latency. Issue #9220.
+ */
+export async function rebuildScopedModelsAfterDiscovery(
+	session: ScopedModelSink,
+	parsed: Args,
+	modelRegistry: Pick<ModelRegistry, "getAvailable" | "awaitBackgroundRefresh">,
+	activeSettings: Settings,
+): Promise<void> {
+	if (session.scopedModels.length === 0) return;
+	const patterns = parsed.models ?? activeSettings.get("enabledModels");
+	if (!patterns || patterns.length === 0) return;
+	await modelRegistry.awaitBackgroundRefresh();
+	if (session.isDisposed) return;
+	const rebuilt = await resolveModelScope(
+		patterns,
+		modelRegistry,
+		getModelMatchPreferences(activeSettings),
+		activeSettings,
+	);
+	const mapped = toSessionScopedModels(rebuilt, activeSettings);
+	if (mapped.length === 0 || sameScopedModelSet(session.scopedModels, mapped)) return;
+	session.setScopedModels(mapped);
+}
+
 async function getChangelogForDisplay(
 	parsed: Args,
 	mode: SettingValue<"startup.changelogMode">,
@@ -1115,19 +1186,9 @@ export async function buildSessionOptions(
 		options.thinkingLevel = scopedModels[0].thinkingLevel;
 	}
 
-	// Scoped models for Ctrl+P cycling - fill in default thinking levels when not explicit
+	// Scoped models for Ctrl+P cycling — fill in default thinking levels when not explicit.
 	if (scopedModels.length > 0) {
-		// `auto` is a session-level concept only; per-scoped-model (Ctrl+P) thinking
-		// overrides stay concrete, so coerce the auto default to "unset" here.
-		const defaultThinkingLevel = concreteThinkingLevel(
-			parseConfiguredThinkingLevel(activeSettings.get("defaultThinkingLevel")),
-		);
-		options.scopedModels = scopedModels.map(scopedModel => ({
-			model: scopedModel.model,
-			thinkingLevel: scopedModel.explicitThinkingLevel
-				? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
-				: defaultThinkingLevel,
-		}));
+		options.scopedModels = toSessionScopedModels(scopedModels, activeSettings);
 	}
 
 	// API key from CLI - set in authStorage
@@ -1746,6 +1807,17 @@ export async function runRootCommand(
 		);
 		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
+		}
+
+		// Runtime provider discovery (opencode-go, models.yml `discovery:`, proxies)
+		// populates the registry AFTER the scope was snapshotted at startup; re-resolve
+		// once it settles so a newly-discovered enabledModels model joins the scoped
+		// /models list and Ctrl+P cycle (issue #9220). Fire-and-forget: the prompt must
+		// never block on discovery latency.
+		if (isInteractive && scopedModels.length > 0) {
+			void rebuildScopedModelsAfterDiscovery(session, parsedArgs, modelRegistry, settingsInstance).catch(error =>
+				logger.warn("Scoped model rebuild after discovery failed", { error: String(error) }),
+			);
 		}
 
 		if (modelFallbackMessage) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4958,6 +4958,11 @@ export class AgentSession {
 		return this.#models.scopedModels;
 	}
 
+	/** Replace the Ctrl+P/`/models` cycle scope (post-discovery rebuild; see {@link ModelControls.setScopedModels}). */
+	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
+		this.#models.setScopedModels(scopedModels);
+	}
+
 	/** Prompt templates */
 	getPlanModeState(): PlanModeState | undefined {
 		return this.#planModeState;

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -138,6 +138,16 @@ export class ModelControls {
 		return this.#scopedModels;
 	}
 
+	/**
+	 * Replace the Ctrl+P cycle scope. Startup resolves the scope before background
+	 * provider discovery runs; the CLI re-pushes the fuller list here once discovery
+	 * completes so a newly-discovered `enabledModels` model joins the cycle and the
+	 * scoped `/models` picker (issue #9220).
+	 */
+	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
+		this.#scopedModels = scopedModels;
+	}
+
 	/** Live per-provider-family service-tier selection. */
 	get serviceTierByFamily(): ServiceTierByFamily {
 		return this.#serviceTierByFamily;

--- a/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
+++ b/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { resolveModelScope } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	rebuildScopedModelsAfterDiscovery,
+	type ScopedModelSink,
+	toSessionScopedModels,
+} from "@oh-my-pi/pi-coding-agent/main";
+
+function model(id: string): Model<Api> {
+	return buildModel({
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider: "prov",
+		baseUrl: "https://example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	});
+}
+
+/** Mutable stand-in for {@link ModelRegistry}: `available` grows to mimic a background discovery pass. */
+class FakeRegistry {
+	available: Model<Api>[];
+	constructor(initial: Model<Api>[]) {
+		this.available = initial;
+	}
+	getAvailable(): Model<Api>[] {
+		return this.available;
+	}
+	async awaitBackgroundRefresh(): Promise<void> {}
+}
+
+class FakeSession implements ScopedModelSink {
+	isDisposed = false;
+	scopedModels: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	setCalls = 0;
+	constructor(initial: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>) {
+		this.scopedModels = initial;
+	}
+	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
+		this.setCalls += 1;
+		this.scopedModels = scopedModels;
+	}
+}
+
+async function startupScope(
+	patterns: string[],
+	registry: FakeRegistry,
+	settings: Settings,
+): Promise<Array<{ model: Model; thinkingLevel?: ThinkingLevel }>> {
+	return toSessionScopedModels(await resolveModelScope(patterns, registry, undefined, settings), settings);
+}
+
+describe("rebuildScopedModelsAfterDiscovery", () => {
+	it("adds an enabledModels model that only materializes after background discovery", async () => {
+		const settings = Settings.isolated({ enabledModels: ["prov/a", "prov/b"] });
+		const registry = new FakeRegistry([model("a")]);
+		// Startup resolves the scope before discovery: `prov/b` is not yet available.
+		const session = new FakeSession(await startupScope(["prov/a", "prov/b"], registry, settings));
+		expect(session.scopedModels.map(s => s.model.id)).toEqual(["a"]);
+
+		// Background discovery completes and populates the registry.
+		registry.available = [model("a"), model("b")];
+		await rebuildScopedModelsAfterDiscovery(session, parseArgs([]), registry, settings);
+
+		expect(session.setCalls).toBe(1);
+		expect(session.scopedModels.map(s => s.model.id)).toEqual(["a", "b"]);
+	});
+
+	it("leaves the scope untouched when discovery adds nothing matching", async () => {
+		const settings = Settings.isolated({ enabledModels: ["prov/a", "prov/b"] });
+		const registry = new FakeRegistry([model("a"), model("b")]);
+		const session = new FakeSession(await startupScope(["prov/a", "prov/b"], registry, settings));
+		const before = session.scopedModels;
+
+		// A later discovery pass adds an unrelated, out-of-scope model.
+		registry.available = [model("a"), model("b"), model("c")];
+		await rebuildScopedModelsAfterDiscovery(session, parseArgs([]), registry, settings);
+
+		expect(session.setCalls).toBe(0);
+		expect(session.scopedModels).toBe(before);
+	});
+
+	it("does not promote an empty (collapsed) scope into a scoped session", async () => {
+		const settings = Settings.isolated({ enabledModels: ["prov/b"] });
+		const registry = new FakeRegistry([model("a")]);
+		// `prov/b` matches nothing at startup, so no scope is active.
+		const session = new FakeSession(await startupScope(["prov/b"], registry, settings));
+		expect(session.scopedModels).toHaveLength(0);
+
+		registry.available = [model("a"), model("b")];
+		await rebuildScopedModelsAfterDiscovery(session, parseArgs([]), registry, settings);
+
+		// Turning a collapsed scope into a live one is the SDK discovery-fallback's job.
+		expect(session.setCalls).toBe(0);
+		expect(session.scopedModels).toHaveLength(0);
+	});
+
+	it("re-resolves an explicit --models scope against the discovery-backed catalog", async () => {
+		const settings = Settings.isolated();
+		const registry = new FakeRegistry([model("a")]);
+		const session = new FakeSession(await startupScope(["prov/a", "prov/b"], registry, settings));
+		expect(session.scopedModels.map(s => s.model.id)).toEqual(["a"]);
+
+		registry.available = [model("a"), model("b")];
+		await rebuildScopedModelsAfterDiscovery(session, parseArgs(["--models", "prov/a,prov/b"]), registry, settings);
+
+		expect(session.scopedModels.map(s => s.model.id)).toEqual(["a", "b"]);
+	});
+
+	it("skips the rebuild once the session is disposed", async () => {
+		const settings = Settings.isolated({ enabledModels: ["prov/a", "prov/b"] });
+		const registry = new FakeRegistry([model("a")]);
+		const session = new FakeSession(await startupScope(["prov/a", "prov/b"], registry, settings));
+		session.isDisposed = true;
+
+		registry.available = [model("a"), model("b")];
+		await rebuildScopedModelsAfterDiscovery(session, parseArgs([]), registry, settings);
+
+		expect(session.setCalls).toBe(0);
+		expect(session.scopedModels.map(s => s.model.id)).toEqual(["a"]);
+	});
+});

--- a/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
+++ b/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
@@ -1,16 +1,21 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Api, Model } from "@oh-my-pi/pi-ai";
+import type { Api, AuthStorage, Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resolveModelScope } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
+	buildSessionOptions,
 	rebuildScopedModelsAfterDiscovery,
 	resolveScopedModels,
 	type ScopedModelSink,
 	toSessionScopedModels,
 } from "@oh-my-pi/pi-coding-agent/main";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 function model(id: string): Model<Api> {
 	return buildModel({
@@ -154,5 +159,53 @@ describe("resolveScopedModels", () => {
 
 		expect(registry.refreshCalls).toBe(1);
 		expect(scoped.map(entry => entry.model.id)).toEqual(["b"]);
+	});
+});
+
+describe("buildSessionOptions --models scope selection", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+
+	beforeAll(async () => {
+		tempDir = await TempDir.create("@main-rebuild-scoped-models-");
+		authStorage = createInMemoryAuthStorage();
+	});
+
+	afterAll(async () => {
+		authStorage.close();
+		await tempDir.remove();
+	});
+
+	function registry(): ModelRegistry {
+		return new ModelRegistry(authStorage, tempDir.join("models.yml"));
+	}
+
+	it("defers a --models scope that resolved empty to the SDK modelPattern path", async () => {
+		const parsed = parseArgs(["--models", "extprov/model-x,extprov/model-y"]);
+
+		// Empty `scopedModels` mimics an all-extension scope: the provider is not
+		// registered until createAgentSession, so nothing matched at startup.
+		const options = await buildSessionOptions(parsed, [], SessionManager.inMemory(), registry(), Settings.isolated());
+
+		expect(options.model).toBeUndefined();
+		expect(options.modelPattern).toEqual(["extprov/model-x", "extprov/model-y"]);
+		expect(options.scopedModels).toBeUndefined();
+	});
+
+	it("pins the first scoped model and sets no deferred pattern when the scope resolved", async () => {
+		const parsed = parseArgs(["--models", "prov/a"]);
+		const scoped = await resolveModelScope(["prov/a"], { getAvailable: () => [model("a")] }, undefined);
+
+		const options = await buildSessionOptions(
+			parsed,
+			scoped,
+			SessionManager.inMemory(),
+			registry(),
+			Settings.isolated(),
+		);
+
+		expect(options.modelPattern).toBeUndefined();
+		expect(options.model?.id).toBe("a");
+		expect(options.scopedModels?.map(entry => entry.model.id)).toEqual(["a"]);
 	});
 });

--- a/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
+++ b/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
@@ -7,6 +7,7 @@ import { resolveModelScope } from "@oh-my-pi/pi-coding-agent/config/model-resolv
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	rebuildScopedModelsAfterDiscovery,
+	resolveScopedModels,
 	type ScopedModelSink,
 	toSessionScopedModels,
 } from "@oh-my-pi/pi-coding-agent/main";
@@ -26,16 +27,29 @@ function model(id: string): Model<Api> {
 	});
 }
 
-/** Mutable stand-in for {@link ModelRegistry}: `available` grows to mimic a background discovery pass. */
+/** Mutable stand-in for {@link ModelRegistry}: `available` grows to mimic provider discovery. */
 class FakeRegistry {
 	available: Model<Api>[];
-	constructor(initial: Model<Api>[]) {
+	discoverableProviders = ["prov"];
+	refreshCalls = 0;
+	onRefresh: (() => void) | undefined;
+	constructor(initial: Model<Api>[], onRefresh?: () => void) {
 		this.available = initial;
+		this.onRefresh = onRefresh;
 	}
 	getAvailable(): Model<Api>[] {
 		return this.available;
 	}
-	async awaitBackgroundRefresh(): Promise<void> {}
+	getDiscoverableProviders(): string[] {
+		return this.discoverableProviders;
+	}
+	async refresh(): Promise<void> {
+		this.refreshCalls += 1;
+		this.onRefresh?.();
+	}
+	async awaitBackgroundRefresh(): Promise<void> {
+		this.onRefresh?.();
+	}
 }
 
 class FakeSession implements ScopedModelSink {
@@ -89,19 +103,18 @@ describe("rebuildScopedModelsAfterDiscovery", () => {
 		expect(session.scopedModels).toBe(before);
 	});
 
-	it("does not promote an empty (collapsed) scope into a scoped session", async () => {
+	it("activates a scope that resolved empty once background discovery finds its model", async () => {
 		const settings = Settings.isolated({ enabledModels: ["prov/b"] });
 		const registry = new FakeRegistry([model("a")]);
-		// `prov/b` matches nothing at startup, so no scope is active.
+		// `prov/b` matches nothing at startup, so the session initially looks unscoped.
 		const session = new FakeSession(await startupScope(["prov/b"], registry, settings));
 		expect(session.scopedModels).toHaveLength(0);
 
 		registry.available = [model("a"), model("b")];
 		await rebuildScopedModelsAfterDiscovery(session, parseArgs([]), registry, settings);
 
-		// Turning a collapsed scope into a live one is the SDK discovery-fallback's job.
-		expect(session.setCalls).toBe(0);
-		expect(session.scopedModels).toHaveLength(0);
+		expect(session.setCalls).toBe(1);
+		expect(session.scopedModels.map(s => s.model.id)).toEqual(["b"]);
 	});
 
 	it("re-resolves an explicit --models scope against the discovery-backed catalog", async () => {
@@ -127,5 +140,19 @@ describe("rebuildScopedModelsAfterDiscovery", () => {
 
 		expect(session.setCalls).toBe(0);
 		expect(session.scopedModels.map(s => s.model.id)).toEqual(["a"]);
+	});
+});
+
+describe("resolveScopedModels", () => {
+	it("refreshes a collapsed all-discovery --models scope before session model selection", async () => {
+		const settings = Settings.isolated();
+		const registry = new FakeRegistry([], () => {
+			registry.available = [model("b")];
+		});
+
+		const scoped = await resolveScopedModels(parseArgs(["--models", "prov/b"]), registry, settings);
+
+		expect(registry.refreshCalls).toBe(1);
+		expect(scoped.map(entry => entry.model.id)).toEqual(["b"]);
 	});
 });


### PR DESCRIPTION
## Repro
On a fresh interactive launch, a model added to `enabledModels` for a runtime-discovered provider (e.g. `opencode-go/ox-alpha-free`) is absent from the scoped `/models` list and Ctrl+P cycle, even though it is present in `enabledModels`, resolvable via `omp models find`, and invokable with `--model`. `enabledModels` had 15 entries but the scoped list showed 14. Reproduced at the resolver level: with `enabledModels=["prov/a","prov/b"]` and the registry exposing only `prov/a` at startup, `resolveModelScope` → `toSessionScopedModels` yields the frozen snapshot `["a"]`; after discovery adds `prov/b` the snapshot never grows. Run: `bun test test/main-rebuild-scoped-models.test.ts`.

## Cause
The scoped list is a one-shot startup snapshot. `resolveScopedModels` (`packages/coding-agent/src/main.ts`) resolves `--models`/`enabledModels` from `modelRegistry.getAvailable()` and freezes the result into `ModelControls` (`session/model-controls.ts`). But `createSession` fires `modelRegistry.refreshInBackground()` only *after* the session is built, and `getAvailable()` at that instant reflects only the bundled + synchronously-cached catalog — a first-time runtime-discovered model is not yet present. When background discovery later populates it, the scoped snapshot is never rebuilt. Deferred `--model` resolution (`sdk.ts`) and RPC `get_available_models`/`set_model` (`modes/rpc/rpc-mode.ts`) both `await modelRegistry.awaitBackgroundRefresh()` first, which is why direct invocation works; the interactive scoped path had no equivalent. Distinct from #8245, whose retry fires only on *total* scope collapse (zero matches) — here 14 of 15 selectors resolve, so that path never triggers.

## Fix
- `ModelControls.setScopedModels` + `AgentSession.setScopedModels`: mutators to replace the Ctrl+P/scoped cycle set post-startup (`session/model-controls.ts`, `session/agent-session.ts`).
- `main.ts`: extract `toSessionScopedModels` (shared by `buildSessionOptions` and the rebuild) and add `rebuildScopedModelsAfterDiscovery`, which awaits the initial refresh, re-resolves the same scope patterns against the now-populated registry, and pushes the fuller list into the session when the set changed. Only augments an already-active scope (a collapsed/empty scope is left to the SDK discovery fallback) and never blocks the prompt on discovery latency.
- `main.ts`: schedule it fire-and-forget after session creation for interactive sessions with an active scope.

## Verification
`bun test test/main-rebuild-scoped-models.test.ts` — 5 pass (grows the scope after discovery, no-op when nothing matching is added, does not promote a collapsed scope, re-resolves an explicit `--models` scope, skips when disposed). `bun test test/main-model-scope-notification.test.ts test/model-resolver.test.ts test/cli-service-tier-flag.test.ts test/cli-explicit-extension-isolation.test.ts` — 170 pass. `bun check` clean. Fixes #9220.