### PR TITLE
fix(lsp/mux): key shared servers on the full spawn identity (args + env)

### DIFF
--- a/packages/coding-agent/src/lsp/mux/protocol.ts
+++ b/packages/coding-agent/src/lsp/mux/protocol.ts
@@ -81,7 +81,7 @@ export interface MuxConnectParams {
 
 /** Handshake result. */
 export interface MuxConnectResult {
-	/** Server identity key inside the mux (`${command}:${cwd}`). */
+	/** Server identity key inside the mux; covers command, args, cwd, and env. */
 	key: string;
 	/** True when this handshake spawned the server process. */
 	spawned: boolean;
@@ -89,7 +89,22 @@ export interface MuxConnectResult {
 	pid?: number;
 }
 
-/** Server identity key used by the mux registry. */
-export function muxServerKey(command: string, cwd: string): string {
-	return `${command}:${cwd}`;
+/**
+ * Server identity key used by the mux registry.
+ *
+ * Every input that changes what the spawned process actually *is* belongs in
+ * this key: the registry spawns `[command, ...args]` in `cwd` with
+ * `{ ...Bun.env, ...env }`, so two links that agree on command and cwd but
+ * differ in args or env are not interchangeable. Keying on command and cwd
+ * alone let an idle server started with one argument set be handed to a link
+ * that asked for another, silently serving the wrong configuration from a
+ * process the client believed it had configured.
+ *
+ * Env keys are sorted so object insertion order never splits one identity in
+ * two, and the parts are JSON-encoded so no separator can be forged from a
+ * value (`["--log-level", "4"]` stays distinct from `["--log-level 4"]`).
+ */
+export function muxServerKey(params: MuxConnectParams): string {
+	const envEntries = Object.entries(params.env ?? {}).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+	return JSON.stringify([params.command, params.args, params.cwd, envEntries]);
 }

--- a/packages/coding-agent/src/lsp/mux/server.ts
+++ b/packages/coding-agent/src/lsp/mux/server.ts
@@ -319,7 +319,7 @@ export class LspMuxServer {
 				this.#sendSession(session, rpcError(message.id, -32602, "invalid mux connect params"));
 				return;
 			}
-			const key = muxServerKey(params.command, params.cwd);
+			const key = muxServerKey(params);
 			let server = [...this.#servers].find(candidate => candidate.key === key && candidate.sessions.size === 0);
 			if (server && server.proc.exitCode !== null) {
 				this.#serverExited(server);

--- a/packages/coding-agent/test/lsp/mux-server-key.test.ts
+++ b/packages/coding-agent/test/lsp/mux-server-key.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { type MuxConnectParams, muxServerKey } from "@oh-my-pi/pi-coding-agent/lsp/mux/protocol";
+
+const base: MuxConnectParams = {
+	command: "typescript-language-server",
+	args: ["--stdio"],
+	cwd: "/workspace/project",
+};
+
+describe("muxServerKey", () => {
+	it("is stable across equal-by-value handshake parameters", () => {
+		expect(muxServerKey({ ...base })).toBe(muxServerKey({ ...base, args: [...base.args] }));
+	});
+
+	it("still separates servers by command and by cwd", () => {
+		expect(muxServerKey({ ...base, command: "rust-analyzer" })).not.toBe(muxServerKey(base));
+		expect(muxServerKey({ ...base, cwd: "/workspace/other" })).not.toBe(muxServerKey(base));
+	});
+
+	it("separates servers that differ only in args", () => {
+		// The registry reuses an idle server purely by key, so an args-only
+		// difference must not collide — a server started with extra flags is a
+		// different process than one started without them.
+		const verbose = muxServerKey({ ...base, args: ["--stdio", "--log-level", "4"] });
+		expect(verbose).not.toBe(muxServerKey(base));
+	});
+
+	it("keeps split and joined arguments distinct", () => {
+		const split = muxServerKey({ ...base, args: ["--log-level", "4"] });
+		const joined = muxServerKey({ ...base, args: ["--log-level 4"] });
+		expect(split).not.toBe(joined);
+	});
+
+	it("separates servers that differ only in env", () => {
+		const tuned = muxServerKey({ ...base, env: { NODE_OPTIONS: "--max-old-space-size=8192" } });
+		expect(tuned).not.toBe(muxServerKey(base));
+	});
+
+	it("treats env key order as irrelevant", () => {
+		const forward = muxServerKey({ ...base, env: { A: "1", B: "2" } });
+		const reverse = muxServerKey({ ...base, env: { B: "2", A: "1" } });
+		expect(forward).toBe(reverse);
+	});
+
+	it("treats an absent env as an empty env", () => {
+		expect(muxServerKey({ ...base, env: {} })).toBe(muxServerKey(base));
+	});
+});


### PR DESCRIPTION
Fixes the **mux half** of #8382.

## The bug

`muxServerKey()` built a shared-server identity out of only two of the four things that determine what actually gets spawned:

```ts
export function muxServerKey(command: string, cwd: string): string {
	return `${command}:${cwd}`;
}
```

But `ServerInstance` spawns with all four:

```ts
this.proc = ptree.spawn([params.command, ...params.args], {
	cwd: params.cwd,
	stdin: "pipe",
	env: { ...Bun.env, ...params.env },
});
```

`args` and `env` were dropped on the floor. The registry then reuses a child purely by key:

```ts
let server = [...this.#servers].find(candidate => candidate.key === key && candidate.sessions.size === 0);
```

So an **idle** server that was started with one argument/env set gets handed to a link that asked for a different one. The caller receives `spawned: false` and a `pid` for a process that does not match its own handshake — which is exactly the `samePid: true` symptom reported in #8382. Nothing downstream re-checks; the mismatch is silent for the life of the process.

The window is narrow but entirely reachable in normal use: any two projects under the same `cwd` that pass different server flags, or the same server launched once with and once without a tuned `NODE_OPTIONS`, collide.

## The fix

Hand `muxServerKey` the whole `MuxConnectParams` and key on everything that reaches `spawn`:

```ts
export function muxServerKey(params: MuxConnectParams): string {
	const envEntries = Object.entries(params.env ?? {}).sort((a, b) => (a[0] < b[0] ? -1 : 1));
	return JSON.stringify([params.command, params.args, params.cwd, envEntries]);
}
```

Two deliberate details:

- **Env keys are sorted.** `env` arrives as a plain object, so insertion order varies between callers that mean the same thing. Without sorting, one logical server would split into two children.
- **The key is JSON, not a delimiter join.** With a separator, a value can forge one: `["--log-level", "4"]` and `["--log-level 4"]` are different spawns that must not share a process. JSON encoding makes that unforgeable.

I used exact JSON rather than hashing it. A hash collision here would silently reuse the wrong process — the precise failure this PR exists to remove — and these keys are short-lived and few, so there is nothing to gain by trading correctness for length.

The call site is a one-line change; `parseConnectParams` already produces the full `MuxConnectParams`, so nothing else moves.

## Tests

`muxServerKey` had **no direct coverage at all**, which is how the drop survived. `packages/coding-agent/test/lsp/mux-server-key.test.ts` pins the identity contract in both directions:

- stable across equal-by-value params (no spurious respawns)
- still separates by `command` and by `cwd` (no regression)
- separates on an args-only difference
- split vs joined arguments stay distinct
- separates on an env-only difference
- env key order is irrelevant
- absent `env` is equivalent to `{}`

## Scope

This PR is deliberately **only the mux half** of #8382. The issue also points at `client.ts:699-736`; that path is untouched here and is worth a separate look, so please don't read this as closing the whole report unless you agree the client side is already correct.

---

Draft for review — happy to adjust the key encoding or split the test file if you'd prefer it elsewhere.