### PR TITLE
fix(ai/proxy): applied PI_PROXY to global fetch and the Anthropic transport

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -129,6 +129,20 @@ Provider HTTP fetches resolve proxies in this order after applying `NO_PROXY` / 
 
 Provider proxy lookups are cached for the process lifetime. Localhost targets bypass the provider fetch wrapper.
 
+Scope differs between the two `PI_PROXY` forms:
+
+- `PI_PROXY` is installed on the process-wide `fetch` at CLI startup, so it also
+  covers requests made outside the provider fetch wrapper — OAuth token refresh
+  and login, usage probes, model discovery. Without that, a region-blocked token
+  endpoint returns `403 Request not allowed` on refresh even though the stream
+  itself is proxied.
+- `PI_PROXY_<PROVIDER>` applies only to that provider's requests, and overrides
+  `PI_PROXY` for them. It does not cover the non-provider-scoped calls above; set
+  `PI_PROXY` too if the provider blocks your region.
+
+Loopback, link-local, private-range (`10/8`, `172.16/12`, `192.168/16`), and
+`NO_PROXY` targets always bypass, so local model servers and MCP hosts stay direct.
+
 ### Anthropic Foundry Gateway (Azure / enterprise proxy)
 
 When `CLAUDE_CODE_USE_FOUNDRY` is enabled, Anthropic requests switch to Foundry mode:

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `PI_PROXY` covering only provider streams: OAuth token refresh and login, usage probes, and model discovery went out through the bare global `fetch` and ignored it, so a region-blocked token endpoint answered `403 Request not allowed` (Anthropic `/v1/oauth/token`) and disabled the credential while the proxied stream itself worked. `installGlobalProxyFetch()` now routes the process-wide `fetch` through `PI_PROXY`; a per-request proxy such as `PI_PROXY_<PROVIDER>` still wins, and loopback / private-range / `NO_PROXY` targets stay direct.
+- Fixed Anthropic inference ignoring every proxy setting. `coworkFetch` runs on `node:https`, whose Bun shim discards both `agent.createConnection` and `options.createConnection`: the CONNECT tunnel to `PI_PROXY` was built, TLS-negotiated, then abandoned, and the request dialed `api.anthropic.com` on the default route (measured at the proxy: 581 bytes of handshake, zero request bytes). On a region-blocked egress that returned `403 {"type":"forbidden","message":"Request not allowed"}` with the proxy apparently configured. Proxied requests now go through Bun's own `fetch`, which honors `init.proxy`, trading the Cowork TLS/header profile for a proxy that actually carries the traffic; the dead tunnel plumbing is gone from the transport. `node:http2` (Cursor) does honor `createConnection` and is unaffected.
+- Fixed `cowork-fetch` capturing `globalThis.fetch` at module load, so a proxy wrapper installed later in startup was ignored on its fallback path.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/ai/src/providers/cowork-fetch.ts
+++ b/packages/ai/src/providers/cowork-fetch.ts
@@ -3,8 +3,28 @@ import * as https from "node:https";
 import * as stream from "node:stream";
 import * as tls from "node:tls";
 import * as zlib from "node:zlib";
+import { logger } from "@oh-my-pi/pi-utils";
 import type { FetchImpl } from "../types";
-import { connectProxiedSocket } from "../utils/proxy";
+
+/** `host/path` for logging; query strings can carry keys. */
+function logTarget(input: string | URL | Request): string {
+	try {
+		const url = new URL(input instanceof Request ? input.url : input.toString());
+		return `${url.host}${url.pathname}`;
+	} catch {
+		return "<unparseable>";
+	}
+}
+
+/** Proxy host of a request init, or `"none"` when the request goes out direct. */
+function initProxy(init: RequestInit | undefined): string {
+	if (!init || !("proxy" in init) || typeof init.proxy !== "string") return "none";
+	try {
+		return new URL(init.proxy).host;
+	} catch {
+		return "<unparseable>";
+	}
+}
 
 type CoworkTlsOptions = {
 	ca?: string | string[];
@@ -22,13 +42,10 @@ type CoworkRequestInit = RequestInit & {
 
 type RequestBody = string | Uint8Array;
 
-type AgentLease = {
-	agent: https.Agent;
-	release?: () => void;
-};
-
 const directAgent = new https.Agent({ keepAlive: true });
-const fallbackFetch: FetchImpl = globalThis.fetch;
+
+/** Resolved at call time, so a proxy wrapper installed after this module loads is honored. */
+const fallbackFetch: FetchImpl = (input, init) => globalThis.fetch(input, init as RequestInit);
 
 function isHeaderRecord(headers: RequestInit["headers"]): headers is Record<string, string> {
 	return headers !== undefined && !(headers instanceof Headers) && !Array.isArray(headers);
@@ -76,19 +93,6 @@ function resolveTlsOptions(url: URL, options: CoworkTlsOptions | undefined): tls
 	return resolved;
 }
 
-async function acquireAgent(
-	url: URL,
-	proxy: string | undefined,
-	tlsOptions: tls.ConnectionOptions,
-	signal: AbortSignal | undefined,
-): Promise<AgentLease> {
-	if (!proxy) return { agent: directAgent };
-	const socket = await connectProxiedSocket(proxy, url.origin, { signal, tls: tlsOptions });
-	const agent = new https.Agent({ keepAlive: false });
-	agent.createConnection = () => socket;
-	return { agent, release: () => agent.destroy() };
-}
-
 function responseHeaders(message: IncomingMessage): Headers {
 	const headers = new Headers();
 	for (let index = 0; index < message.rawHeaders.length; index += 2) {
@@ -126,6 +130,9 @@ function createResponse(message: IncomingMessage, method: string): Response {
 	});
 }
 
+/** Response headers worth naming when a provider rejects a request; `cf-ray` names the edge PoP. */
+const DIAGNOSTIC_HEADERS = ["cf-ray", "cf-mitigated", "server", "request-id", "retry-after", "x-should-retry"];
+
 async function sendCoworkRequest(
 	url: URL,
 	init: CoworkRequestInit,
@@ -135,13 +142,11 @@ async function sendCoworkRequest(
 	const method = init.method ?? "GET";
 	const signal = init.signal ?? undefined;
 	const tlsOptions = resolveTlsOptions(url, init.tls);
-	const lease = await acquireAgent(url, init.proxy, tlsOptions, signal);
 	const headers = buildOrderedHeaders(url, sourceHeaders, body);
 	const result = Promise.withResolvers<Response>();
 	let request: ClientRequest | undefined;
 	const release = (): void => {
 		signal?.removeEventListener("abort", abort);
-		lease.release?.();
 	};
 	const abort = (): void => {
 		const reason = signal?.reason;
@@ -160,11 +165,24 @@ async function sendCoworkRequest(
 			path: `${url.pathname}${url.search}`,
 			method,
 			headers,
-			agent: lease.agent,
+			agent: directAgent,
 			...tlsOptions,
 		},
 		message => {
 			message.once("close", release);
+			const status = message.statusCode ?? 0;
+			if (status >= 400) {
+				logger.debug("cowork transport rejected", {
+					url: `${url.host}${url.pathname}`,
+					status,
+					headers: Object.fromEntries(
+						DIAGNOSTIC_HEADERS.filter(name => message.headers[name] !== undefined).map(name => [
+							name,
+							String(message.headers[name]),
+						]),
+					),
+				});
+			}
 			try {
 				result.resolve(createResponse(message, method));
 			} catch (error) {
@@ -182,20 +200,53 @@ async function sendCoworkRequest(
 	return result.promise;
 }
 
-/** Sends Cowork-profiled HTTPS requests with stable header order, HTTP/1.1, and streaming decompression. */
+/**
+ * Sends Cowork-profiled HTTPS requests with stable header order, HTTP/1.1, and streaming decompression.
+ *
+ * Proxied requests deliberately leave this transport. It runs on `node:https`,
+ * and Bun's shim ignores both `agent.createConnection` and
+ * `options.createConnection`: a CONNECT tunnel handed to it is silently
+ * discarded and the request dials the provider directly. That turned every
+ * `PI_PROXY` / `HTTPS_PROXY` setting into a no-op for Anthropic inference —
+ * the proxy looked configured, the traffic left on the default route, and a
+ * region-blocked egress answered `403 Request not allowed`. Bun's own `fetch`
+ * honors `init.proxy`, so a configured proxy wins over the Cowork profile.
+ */
 export const coworkFetch: FetchImpl = async (input, init) => {
-	if (input instanceof Request || init === undefined || !isHeaderRecord(init.headers)) {
+	if (
+		init === undefined ||
+		input instanceof Request ||
+		!isHeaderRecord(init.headers) ||
+		("proxy" in init && Boolean(init.proxy))
+	) {
+		// Reason is logged because the switch changes both the TLS fingerprint and
+		// who applies the proxy.
+		const reason =
+			init === undefined
+				? "no-init"
+				: input instanceof Request
+					? "request-object-input"
+					: !isHeaderRecord(init.headers)
+						? "headers-not-record"
+						: "proxy-configured";
+		logger.debug("cowork transport bypassed", { url: logTarget(input), reason, proxy: initProxy(init) });
 		return fallbackFetch(input, init);
 	}
 	let url: URL;
 	try {
 		url = new URL(input);
 	} catch {
+		logger.debug("cowork transport bypassed", { url: "<unparseable>", reason: "unparseable-url" });
 		return fallbackFetch(input, init);
 	}
-	if (url.protocol !== "https:") return fallbackFetch(input, init);
+	if (url.protocol !== "https:") {
+		logger.debug("cowork transport bypassed", { url: `${url.host}${url.pathname}`, reason: "not-https" });
+		return fallbackFetch(input, init);
+	}
 	const body = resolveBody(init.body);
-	if (init.body != null && body === undefined) return fallbackFetch(input, init);
-	const coworkInit: CoworkRequestInit = init;
-	return sendCoworkRequest(url, coworkInit, init.headers, body);
+	if (init.body != null && body === undefined) {
+		logger.debug("cowork transport bypassed", { url: `${url.host}${url.pathname}`, reason: "unsupported-body" });
+		return fallbackFetch(input, init);
+	}
+	return sendCoworkRequest(url, init, init.headers, body);
 };

--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -1,7 +1,20 @@
 import * as net from "node:net";
 import * as tls from "node:tls";
+import { logger } from "@oh-my-pi/pi-utils";
 import * as AIError from "../error";
 import type { FetchImpl } from "../types";
+
+/**
+ * Host:port of a proxy URL for logging. Proxy URLs can carry basic-auth
+ * credentials, so never log the raw value.
+ */
+function proxyLogTarget(proxyUrl: string): string {
+	try {
+		return new URL(proxyUrl).host;
+	} catch {
+		return "<unparseable>";
+	}
+}
 
 /**
  * Checks if a host is local or cloud metadata, which should always bypass the proxy
@@ -126,6 +139,14 @@ export function getProxyForProvider(provider: string): string | undefined {
 	const envKey = `PI_PROXY_${normalized}`;
 	const value = Bun.env[envKey] || Bun.env.PI_PROXY;
 	proxyCache.set(provider, value);
+	// Once per provider per process: a silently unproxied provider request is
+	// otherwise indistinguishable from a proxied one until the region block
+	// answers 403.
+	logger.debug("provider proxy resolved", {
+		provider,
+		source: Bun.env[envKey] ? envKey : value ? "PI_PROXY" : "none",
+		proxy: value ? proxyLogTarget(value) : undefined,
+	});
 	return value;
 }
 
@@ -140,15 +161,19 @@ export function getProxyForUrl(provider: string, url: URL): string | undefined {
 }
 
 /**
- * Wraps a fetch implementation to inject proxy options for non-local hosts.
+ * Wraps `fetchImpl` so non-local requests tunnel through `proxyUrl`.
+ * A caller-supplied `init.proxy` always wins, so stacked wrappers keep the
+ * innermost (most specific) proxy decision.
  */
-export function wrapFetchForProxy(fetchImpl: FetchImpl, provider: string): FetchImpl {
-	const proxyUrl = getProxyForProvider(provider);
+function wrapFetchWithProxyUrl(fetchImpl: FetchImpl, proxyUrl: string | undefined): FetchImpl {
 	if (!proxyUrl) {
 		return fetchImpl;
 	}
 
 	const wrapped = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+		if ((init as { proxy?: unknown } | undefined)?.proxy) {
+			return fetchImpl(input, init);
+		}
 		const urlStr = input instanceof Request ? input.url : input.toString();
 		let urlObj: URL;
 		try {
@@ -159,6 +184,14 @@ export function wrapFetchForProxy(fetchImpl: FetchImpl, provider: string): Fetch
 		}
 
 		if (shouldBypassProxy(urlObj)) {
+			// A NO_PROXY rule silencing a configured proxy is otherwise invisible
+			// until the unproxied egress is refused; local hosts are routine.
+			if (!isLocalOrMetadataHost(urlObj.hostname)) {
+				logger.debug("proxy bypassed by NO_PROXY", {
+					host: urlObj.host,
+					noProxy: Bun.env.NO_PROXY || Bun.env.no_proxy,
+				});
+			}
 			return fetchImpl(input, init);
 		}
 
@@ -170,6 +203,64 @@ export function wrapFetchForProxy(fetchImpl: FetchImpl, provider: string): Fetch
 		wrapped.preconnect = fetchImpl.preconnect;
 	}
 	return wrapped;
+}
+
+/**
+ * Wraps a fetch implementation to inject proxy options for non-local hosts.
+ */
+export function wrapFetchForProxy(fetchImpl: FetchImpl, provider: string): FetchImpl {
+	return wrapFetchWithProxyUrl(fetchImpl, getProxyForProvider(provider));
+}
+
+let globalProxyFetchInstalled = false;
+
+/** Test seam: re-arms {@link installGlobalProxyFetch}. */
+export function __resetGlobalProxyFetch(): void {
+	globalProxyFetchInstalled = false;
+}
+
+/**
+ * Routes the process-wide `globalThis.fetch` through `PI_PROXY`.
+ *
+ * Bun's native fetch resolves `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` by
+ * itself but knows nothing about `PI_PROXY`. Provider *streams* get their proxy
+ * from {@link wrapFetchForProxy}; every other provider-bound request — OAuth
+ * token refresh and login, usage probes, model discovery — goes out through the
+ * bare global `fetch` and would silently ignore `PI_PROXY`. That asymmetry is
+ * fatal wherever a provider geo-blocks its token endpoint: the stream is
+ * proxied, the refresh is not, and the credential dies with a 403.
+ *
+ * A per-request `proxy` (including `PI_PROXY_<PROVIDER>` injected by
+ * {@link wrapFetchForProxy}) still wins, and loopback / private-range /
+ * `NO_PROXY` targets bypass, so local model servers and MCP hosts are
+ * untouched. Idempotent; a no-op when `PI_PROXY` is unset.
+ */
+export function installGlobalProxyFetch(): void {
+	if (globalProxyFetchInstalled) return;
+	const proxyUrl = Bun.env.PI_PROXY?.trim();
+	// One line naming every proxy-relevant variable this process can see: a
+	// missing PI_PROXY and a NO_PROXY rule that silences it are otherwise
+	// indistinguishable from a working proxy that the peer rejected.
+	const env = {
+		PI_PROXY: proxyUrl ? proxyLogTarget(proxyUrl) : undefined,
+		PI_PROXY_ANTHROPIC: Bun.env.PI_PROXY_ANTHROPIC ? proxyLogTarget(Bun.env.PI_PROXY_ANTHROPIC) : undefined,
+		HTTPS_PROXY: Bun.env.HTTPS_PROXY || Bun.env.https_proxy ? "set" : undefined,
+		ALL_PROXY: Bun.env.ALL_PROXY || Bun.env.all_proxy ? "set" : undefined,
+		NO_PROXY: Bun.env.NO_PROXY || Bun.env.no_proxy,
+	};
+	if (!proxyUrl) {
+		logger.debug("global proxy fetch not installed", {
+			reason: "PI_PROXY unset",
+			env,
+		});
+		return;
+	}
+	globalProxyFetchInstalled = true;
+	globalThis.fetch = wrapFetchWithProxyUrl(globalThis.fetch, proxyUrl) as typeof globalThis.fetch;
+	logger.debug("global proxy fetch installed", {
+		proxy: proxyLogTarget(proxyUrl),
+		env,
+	});
 }
 
 export interface ConnectProxiedSocketOptions {
@@ -234,6 +325,12 @@ export async function connectProxiedSocket(
 		settled = true;
 		cleanup();
 		destroyInProgress();
+		logger.debug("proxy tunnel failed", {
+			proxy: `${proxyHost}:${proxyPort}`,
+			target: `${targetHost}:${targetPort}`,
+			error: String(error),
+			code: "code" in error ? String(error.code) : undefined,
+		});
 		reject(error);
 	};
 	const resolveOnce = (socket: tls.TLSSocket): void => {
@@ -247,6 +344,14 @@ export async function connectProxiedSocket(
 	const onTunnelError = (error: Error): void => rejectOnce(error);
 	const onTunnelReady = (): void => {
 		if (!tunnelSocket) return;
+		logger.debug("proxy tunnel established", {
+			proxy: `${proxyHost}:${proxyPort}`,
+			target: `${targetHost}:${targetPort}`,
+			peer: `${rawSocket?.remoteAddress ?? "?"}:${rawSocket?.remotePort ?? "?"}`,
+			localPort: rawSocket?.localPort,
+			alpn: tunnelSocket.alpnProtocol,
+			authorized: tunnelSocket.authorized,
+		});
 		resolveOnce(tunnelSocket);
 	};
 	const onProxyData = (chunk: Buffer): void => {
@@ -258,6 +363,11 @@ export async function connectProxiedSocket(
 		rawSocket.off("error", onRawError);
 
 		const firstLine = responseData.split("\r\n")[0];
+		logger.debug("proxy tunnel CONNECT reply", {
+			proxy: `${proxyHost}:${proxyPort}`,
+			target: `${targetHost}:${targetPort}`,
+			reply: firstLine,
+		});
 		if (!firstLine.includes(" 200 ")) {
 			rejectOnce(new AIError.ValidationError(`Proxy tunnel failed: ${firstLine}`));
 			return;
@@ -287,6 +397,11 @@ export async function connectProxiedSocket(
 
 		rawSocket.write(connectReq);
 		rawSocket.on("data", onProxyData);
+		logger.debug("proxy tunnel CONNECT sent", {
+			proxy: `${proxyHost}:${proxyPort}`,
+			target: `${targetHost}:${targetPort}`,
+			peer: `${rawSocket.remoteAddress ?? "?"}:${rawSocket.remotePort ?? "?"}`,
+		});
 	};
 
 	options?.signal?.addEventListener("abort", onAbort, { once: true });

--- a/packages/ai/test/cowork-fetch-proxy.test.ts
+++ b/packages/ai/test/cowork-fetch-proxy.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { coworkFetch } from "@oh-my-pi/pi-ai/providers/cowork-fetch";
+
+/**
+ * `coworkFetch` runs on `node:https`, whose Bun shim ignores
+ * `agent.createConnection` / `options.createConnection`. A CONNECT tunnel handed
+ * to it is dropped and the request dials the provider directly, so a configured
+ * proxy has to take the request off this transport entirely — otherwise every
+ * `PI_PROXY` setting is a silent no-op for Anthropic inference.
+ */
+describe("coworkFetch proxy handling", () => {
+	const nativeFetch = globalThis.fetch;
+	let calls: Array<{ url: string; proxy: unknown }>;
+
+	beforeEach(() => {
+		calls = [];
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			calls.push({
+				url: input instanceof Request ? input.url : String(input),
+				proxy: (init as { proxy?: unknown } | undefined)?.proxy,
+			});
+			return new Response("ok");
+		}) as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = nativeFetch;
+	});
+
+	it("delegates a proxied request to the global fetch, proxy option intact", async () => {
+		const response = await coworkFetch("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "{}",
+			proxy: "http://127.0.0.1:24560",
+		} as RequestInit);
+
+		expect(await response.text()).toBe("ok");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe("https://api.anthropic.com/v1/messages");
+		expect(calls[0].proxy).toBe("http://127.0.0.1:24560");
+	});
+
+	it("delegates Request-object input to the global fetch", async () => {
+		await coworkFetch(new Request("https://api.anthropic.com/v1/messages"));
+		expect(calls).toHaveLength(1);
+	});
+
+	it("delegates non-https targets to the global fetch", async () => {
+		await coworkFetch("http://api.anthropic.com/v1/messages", { headers: { accept: "*/*" } });
+		expect(calls).toHaveLength(1);
+	});
+
+	it("keeps unproxied https requests on the cowork transport", async () => {
+		// Unreachable loopback port: reaching the node:https path fails to connect
+		// instead of delegating, which is what proves the request stayed here.
+		await expect(coworkFetch("https://127.0.0.1:1/v1/messages", { headers: { accept: "*/*" } })).rejects.toThrow();
+		expect(calls).toHaveLength(0);
+	});
+});

--- a/packages/ai/test/proxy.test.ts
+++ b/packages/ai/test/proxy.test.ts
@@ -3,9 +3,11 @@ import * as net from "node:net";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import {
+	__resetGlobalProxyFetch,
 	connectProxiedSocket,
 	getProxyForProvider,
 	getProxyForUrl,
+	installGlobalProxyFetch,
 	isLocalOrMetadataHost,
 	shouldBypassProxy,
 	wrapFetchForProxy,
@@ -296,6 +298,65 @@ describe("wrapFetchForProxy", () => {
 		await wrapFetchForProxy(fetch, "wrap-badurl")("not a url");
 		expect(calls).toHaveLength(1);
 		expect(calls[0].proxy).toBeUndefined();
+	});
+});
+
+describe("installGlobalProxyFetch", () => {
+	const nativeFetch = globalThis.fetch;
+	let calls: Array<{ url: string; proxy: unknown }>;
+
+	beforeEach(() => {
+		calls = [];
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			calls.push({
+				url: input instanceof Request ? input.url : String(input),
+				proxy: (init as { proxy?: unknown } | undefined)?.proxy,
+			});
+			return new Response("ok");
+		}) as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = nativeFetch;
+		__resetGlobalProxyFetch();
+	});
+
+	it("routes bare global fetch through PI_PROXY", async () => {
+		Bun.env.PI_PROXY = PROXY;
+		installGlobalProxyFetch();
+		await fetch("https://api.anthropic.com/v1/oauth/token", { method: "POST" });
+		expect(calls[0].proxy).toBe(PROXY);
+	});
+
+	it("leaves global fetch untouched when PI_PROXY is unset", async () => {
+		const before = globalThis.fetch;
+		installGlobalProxyFetch();
+		expect(globalThis.fetch).toBe(before);
+		await fetch("https://api.anthropic.com/v1/oauth/token");
+		expect(calls[0].proxy).toBeUndefined();
+	});
+
+	it("keeps a caller-supplied proxy so PI_PROXY_<PROVIDER> still wins", async () => {
+		Bun.env.PI_PROXY = PROXY;
+		Bun.env.PI_PROXY_GLOBAL_PREC = "http://127.0.0.1:24561";
+		installGlobalProxyFetch();
+		await wrapFetchForProxy(globalThis.fetch, "global-prec")("https://api.anthropic.com/v1/messages");
+		expect(calls[0].proxy).toBe("http://127.0.0.1:24561");
+	});
+
+	it("bypasses loopback targets so local model servers stay direct", async () => {
+		Bun.env.PI_PROXY = PROXY;
+		installGlobalProxyFetch();
+		await fetch("http://127.0.0.1:11434/api/chat");
+		expect(calls[0].proxy).toBeUndefined();
+	});
+
+	it("installs once", async () => {
+		Bun.env.PI_PROXY = PROXY;
+		installGlobalProxyFetch();
+		const wrapped = globalThis.fetch;
+		installGlobalProxyFetch();
+		expect(globalThis.fetch).toBe(wrapped);
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `PI_PROXY` being ignored outside provider streams: the CLI now installs it on the process-wide `fetch` at startup, so OAuth token refresh/login, usage probes, and model discovery are proxied too. Combined with the Anthropic transport fix in `pi-ai`, a region-blocked machine reaching Anthropic through a proxy no longer fails with `403 Request not allowed`.
+
 ## [17.4.0] - 2026-08-20
 
 ### Added

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -393,6 +393,16 @@ export async function runCli(argv: string[]): Promise<void> {
 	// browser workers onto the same-realm inline fallback.
 	if (isProcessEntry) declareWorkerHostEntry();
 
+	// `PI_PROXY` must reach the bare global `fetch` before any provider call:
+	// OAuth refresh/login and usage probes never pass through
+	// `wrapFetchForProxy`, so without this they bypass the proxy and fail
+	// wherever the provider blocks the caller's region. Dynamically imported
+	// like every other dependency in this entry module: a static `pi-ai` import
+	// would load the provider graph before profile bootstrap and on paths
+	// (`--version`, worker selectors) that never touch the network.
+	const { installGlobalProxyFetch } = await import("@oh-my-pi/pi-ai/utils/proxy");
+	installGlobalProxyFetch();
+
 	if (resolvedArgv[0] === "--smoke-test") {
 		await runSmokeTest();
 		return;


### PR DESCRIPTION
## What

Makes `PI_PROXY` actually cover everything the CLI sends.

- `installGlobalProxyFetch()` (new, `@oh-my-pi/pi-ai/utils/proxy`) wraps the process-wide `fetch` with the `PI_PROXY` value; `cli.ts` calls it during startup, after profile bootstrap and before any provider call. A more specific proxy still wins (`PI_PROXY_<PROVIDER>`, explicit `init.proxy`), and loopback / private-range / `NO_PROXY` targets stay direct.
- `coworkFetch` now hands proxied requests to Bun's `fetch` instead of trying to tunnel on `node:https`, and no longer snapshots `globalThis.fetch` at module load. Unproxied requests keep the Cowork transport unchanged.
- Debug logging at each proxy decision point: resolution source, `NO_PROXY` bypass, tunnel established/failed, CONNECT reply, and `>= 400` cowork transport responses (with `cf-ray`/`cf-mitigated`). Proxy credentials and query strings are stripped before logging.
- `docs/environment-variables.md` documents the scope difference between `PI_PROXY` and `PI_PROXY_<PROVIDER>`.

## Why

Two separate holes made a configured proxy look applied while traffic left unproxied — both surfacing as `403 {"type":"forbidden","message":"Request not allowed"}` from a region-blocked egress.

1. **Only provider streams were proxied.** OAuth token refresh and login, usage probes, and model discovery use the bare global `fetch` and never pass through `wrapFetchForProxy`. A region-blocked `/v1/oauth/token` answered `403 Request not allowed` on refresh and the credential was disabled — while the proxied inference stream on the same box worked fine.
2. **Anthropic inference ignored proxies entirely.** `coworkFetch` runs on `node:https`, whose Bun shim discards both `agent.createConnection` and `options.createConnection`. The CONNECT tunnel to the proxy was opened and TLS-negotiated, then abandoned, and the request dialed `api.anthropic.com` on the default route. Measured at the proxy: 581 bytes of handshake, zero request bytes. Every `PI_PROXY` setting was a silent no-op for that path.

Fix (2) trades the Cowork TLS/header profile for a proxy that actually carries the traffic on proxied requests only; direct requests are untouched. `node:http2` (Cursor) is unaffected — it accepts an externally created socket.

## Testing

- `bun test packages/ai/test/proxy.test.ts packages/ai/test/cowork-fetch-proxy.test.ts` — 49 pass, 0 fail.
  - `installGlobalProxyFetch` suite: global `fetch` gets the proxy option, caller-supplied `init.proxy` wins, `NO_PROXY`/local hosts stay direct, install is idempotent.
  - New `cowork-fetch-proxy.test.ts`: proxied requests (and `Request`-object / non-https input) delegate to the global `fetch` with `init.proxy` intact; unproxied https requests stay on the `node:https` transport (proven by a connect failure to an unreachable loopback port rather than a delegated success).
- `bun check` passes (`check:ts` exit 0, biome clean).
- Manual: against a region-blocked egress with `PI_PROXY` set, Anthropic OAuth refresh and inference both succeed; proxy access log shows the request bytes it previously never received.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
