### PR TITLE
fix(ai): keep Cursor usage buckets that report no numeric cap

### DIFF
--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -295,42 +295,49 @@ export function parseCursorUsage(payload: unknown, fetchedAt = Date.now()): Usag
 			toNumber(value.amountLimit) ??
 			toNumber(value.usdLimit);
 
-		if (usedVal !== undefined && limitVal !== undefined) {
-			const isUsd =
-				key === "planUsage" ||
-				key.toLowerCase().includes("usd") ||
-				key.toLowerCase().includes("billing") ||
-				key.toLowerCase().includes("stripe");
+		if (usedVal === undefined) continue;
 
-			const unit = isUsd ? "usd" : "requests";
-			const cleanBucket = key.toLowerCase().trim();
-			const limitId = isUsd ? `cursor:usd:${cleanBucket}` : `cursor:requests:${cleanBucket}`;
+		const isUsd =
+			key === "planUsage" ||
+			key.toLowerCase().includes("usd") ||
+			key.toLowerCase().includes("billing") ||
+			key.toLowerCase().includes("stripe");
 
-			const label = isUsd ? `${key} spend` : `${key} requests`;
+		const unit = isUsd ? "usd" : "requests";
+		const cleanBucket = key.toLowerCase().trim();
+		const limitId = isUsd ? `cursor:usd:${cleanBucket}` : `cursor:requests:${cleanBucket}`;
 
-			const amount: UsageAmount = {
+		const label = isUsd ? `${key} spend` : `${key} requests`;
+
+		// Some Cursor plans report no legacy numeric cap (`maxRequestUsage: null`).
+		// Emit an uncapped, used-only meter for those buckets instead of dropping
+		// them, which used to collapse the whole account to "no usage data".
+		let amount: UsageAmount;
+		if (limitVal === undefined) {
+			amount = { used: usedVal, unit };
+		} else {
+			const remaining = Math.max(0, limitVal - usedVal);
+			amount = {
 				used: usedVal,
 				limit: limitVal,
-				remaining: Math.max(0, limitVal - usedVal),
+				remaining,
 				usedFraction: limitVal > 0 ? usedVal / limitVal : 0,
-				remainingFraction: limitVal > 0 ? Math.max(0, limitVal - usedVal) / limitVal : 0,
+				remainingFraction: limitVal > 0 ? remaining / limitVal : 0,
 				unit,
 			};
-
-			const status = usageStatus(amount.usedFraction);
-
-			limits.push({
-				id: limitId,
-				label,
-				scope: {
-					provider: "cursor",
-					...(window ? { windowId: window.id } : {}),
-				},
-				...(window ? { window } : {}),
-				amount,
-				status,
-			});
 		}
+
+		limits.push({
+			id: limitId,
+			label,
+			scope: {
+				provider: "cursor",
+				...(window ? { windowId: window.id } : {}),
+			},
+			...(window ? { window } : {}),
+			amount,
+			...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
+		});
 	}
 
 	if (limits.length === 0) {

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -25,6 +25,53 @@ describe("cursor usage provider", () => {
 			expect(parseCursorUsage(payload)).toBeNull();
 		});
 
+		it("emits an uncapped used-only bucket when the request limit is null", () => {
+			// Exact sanitized payload reported in #6381: the plan has no legacy cap.
+			const payload = {
+				"gpt-4": {
+					numRequests: 0,
+					numRequestsTotal: 0,
+					numTokens: 0,
+					maxTokenUsage: null,
+					maxRequestUsage: null,
+				},
+				startOfMonth: "2026-07-23T01:19:45.000Z",
+			};
+
+			const report = parseCursorUsage(payload);
+			expect(report).not.toBeNull();
+			expect(report?.limits).toHaveLength(1);
+
+			const limit = report?.limits[0];
+			expect(limit?.id).toBe("cursor:requests:gpt-4");
+			expect(limit?.label).toBe("gpt-4 requests");
+			expect(limit?.amount).toEqual({ used: 0, unit: "requests" });
+			expect(limit?.status).toBeUndefined();
+			expect(limit?.window?.resetsAt).toBe(Date.parse("2026-08-23T01:19:45.000Z"));
+		});
+
+		it("keeps capped and uncapped buckets side by side", () => {
+			const payload = {
+				"gpt-4": {
+					numRequests: 12,
+					maxRequestUsage: null,
+				},
+				"claude-3-5-sonnet": {
+					used: 80,
+					limit: 100,
+				},
+			};
+
+			const report = parseCursorUsage(payload);
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:requests:gpt-4",
+				"cursor:requests:claude-3-5-sonnet",
+			]);
+			expect(report?.limits[0]?.amount).toEqual({ used: 12, unit: "requests" });
+			expect(report?.limits[1]?.amount.limit).toBe(100);
+			expect(report?.limits[1]?.status).toBe("ok");
+		});
+
 		it("parses request-count buckets with stable IDs and labels", () => {
 			const payload = {
 				"gpt-4": {
@@ -602,8 +649,14 @@ describe("cursor usage provider", () => {
 				accountId: "account_123",
 				projectId: "project_123",
 			});
-			expect(report?.limits).toHaveLength(1);
-			expect(report?.limits[0]).toMatchObject({
+			// The legacy bucket is uncapped (`maxRequestUsage: null`) but still reported,
+			// so it merges ahead of the personal summary instead of vanishing (#6381).
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:requests:gpt-4",
+				"cursor:usd:individual-overall",
+			]);
+			expect(report?.limits[0]?.amount).toEqual({ used: 0, unit: "requests" });
+			expect(report?.limits[1]).toMatchObject({
 				id: "cursor:usd:individual-overall",
 				amount: {
 					used: 20,
@@ -612,7 +665,10 @@ describe("cursor usage provider", () => {
 					unit: "usd",
 				},
 			});
-			expect(report?.raw).toEqual(usageSummaryPayload);
+			expect(report?.raw).toEqual({
+				authUsage: authUsagePayload,
+				usageSummary: usageSummaryPayload,
+			});
 		});
 
 		it("ignores a profile email returned for a different subject", async () => {


### PR DESCRIPTION
Fixes #6381.

## Problem

On Cursor plans that no longer publish a legacy request cap, `/auth/usage` returns buckets like:

```json
{
  "gpt-4": { "numRequests": 0, "numRequestsTotal": 0, "numTokens": 0, "maxTokenUsage": null, "maxRequestUsage": null },
  "startOfMonth": "2026-07-23T01:19:45.000Z"
}
```

`parseCursorUsage` only emitted a limit when **both** `used` and `limit` were numeric:

```ts
if (usedVal !== undefined && limitVal !== undefined) { ... }
```

With `maxRequestUsage: null` every bucket was skipped, `limits.length === 0`, the parser returned `null`, and the CLI printed `○ OAuth account — no usage data` even though the account had perfectly good usage data.

## Fix

Only `used` is required now. When the limit is absent we emit an **uncapped, used-only** amount and omit `status` (there is no fraction to derive it from):

```ts
if (usedVal === undefined) continue;
...
let amount: UsageAmount;
if (limitVal === undefined) {
	amount = { used: usedVal, unit };
} else {
	/* unchanged capped math */
}
```

This is exactly the shape `parseCursorCentsBucket` already produces for `limit: null` dollar buckets (see the existing test *“emits uncapped used-only dollar usage when the limit is null”*), so the rendering layer already handles limit-less amounts — no display changes needed.

## Tests

- New: *“emits an uncapped used-only bucket when the request limit is null”* — the exact sanitized payload from the issue.
- New: *“keeps capped and uncapped buckets side by side”*.
- **Revised (please read):** *“fetches personal usage and profile email with a WorkOS cookie”* pinned the buggy behaviour — its `authUsage` fixture also carries `maxRequestUsage: null`, so it asserted a **1**-limit report with `raw === usageSummaryPayload`. With the fix the legacy report is non-null, so it now merges ahead of the personal summary (**2** limits) and `raw` becomes `{ authUsage, usageSummary }` — identical to the neighbouring *“merges legacy request usage before personal usage”* test. The assertions were updated accordingly; no other test changed.

Additive and behaviour-preserving for every payload where both fields are numeric.