### PR TITLE
fix(stats): normalise partial legacy usage cost before insert

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stats sync crashing with a NOT NULL constraint error when legacy session files carry a partially-populated usage cost.
+
 ## [17.4.0] - 2026-08-20
 
 ### Changed

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -354,14 +354,28 @@ function calculateCatalogCost(provider: string, modelId: string, tokens: CostTok
 }
 
 function resolveStoredCost(stats: MessageStats): UsageCost {
-	// `usage.cost` was optional in older session files. Although current
-	// MessageStats requires it, parsed JSONL can still carry that legacy shape.
-	const storedCost: UsageCost | undefined = stats.usage.cost;
-	if (storedCost && storedCost.total !== 0) {
-		return storedCost;
-	}
+	// `usage.cost` was optional in older session files, and legacy payloads
+	// can carry a partially-populated cost object (e.g. only `total`). The
+	// messages table declares every cost_* column as REAL NOT NULL, so any
+	// missing field must be normalised here before binding into SQLite.
+	const raw: UsageCost | undefined = stats.usage.cost;
+	const normalize = (c: UsageCost | undefined): UsageCost => {
+		const input = c?.input ?? 0;
+		const output = c?.output ?? 0;
+		const cacheRead = c?.cacheRead ?? 0;
+		const cacheWrite = c?.cacheWrite ?? 0;
+		const total = c?.total ?? input + output + cacheRead + cacheWrite;
+		return { input, output, cacheRead, cacheWrite, total };
+	};
 
-	return calculateCatalogCost(stats.provider, stats.model, stats.usage) ?? storedCost ?? ZERO_USAGE_COST;
+	if (raw && (raw.total ?? 0) !== 0) return normalize(raw);
+
+	const catalogCost = calculateCatalogCost(stats.provider, stats.model, stats.usage);
+	if (catalogCost) return normalize(catalogCost);
+
+	if (raw) return normalize(raw);
+
+	return ZERO_USAGE_COST;
 }
 
 function calculateNoCacheInputCost(provider: string, modelId: string, tokens: CostTokens): number | null {

--- a/packages/stats/test/parser-malformed-entries.test.ts
+++ b/packages/stats/test/parser-malformed-entries.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { initDb, insertMessageStats, insertToolCalls } from "@oh-my-pi/omp-stats/db";
+import { getRecentRequests, initDb, insertMessageStats, insertToolCalls } from "@oh-my-pi/omp-stats/db";
 import { parseSessionFile } from "@oh-my-pi/omp-stats/parser";
 import { getSessionsDir } from "@oh-my-pi/pi-utils";
 import { installStatsTestIsolation } from "./helpers/temp-agent";
@@ -80,6 +80,29 @@ describe("malformed session entries", () => {
 
 		await initDb();
 		expect(insertMessageStats(result.stats)).toBe(1);
+	});
+
+	// Regression: legacy session files can carry a partially-populated
+	// `usage.cost` (e.g. only `total`). The parser passes such objects through
+	// untouched, and the raw cost used to bind NULL into the cost_* NOT NULL
+	// columns and crash the entire sync with SQLITE_CONSTRAINT_NOTNULL.
+	it("normalises a partial legacy usage.cost instead of failing the NOT NULL insert", async () => {
+		const file = await writeSession([
+			assistantEntry("a1", {
+				content: [],
+				stopReason: "stop",
+				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: { total: 1 } },
+			}),
+		]);
+
+		const result = await parseSessionFile(file);
+		expect(result.stats).toHaveLength(1);
+
+		await initDb();
+		expect(insertMessageStats(result.stats)).toBe(1);
+
+		const request = getRecentRequests(1)[0];
+		expect(request?.usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 1 });
 	});
 
 	it("skips assistant entries with no usage or model attribution", async () => {


### PR DESCRIPTION
## What

`omp stats` crashed the entire sync with `SQLiteError: NOT NULL constraint failed: messages.cost_input` (`SQLITE_CONSTRAINT_NOTNULL`) when a session file carried a partially-populated `usage.cost`. Legacy or crash-truncated session JSONL can contain e.g.

```json
"usage": { "input": 10, "output": 5, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 15, "cost": { "total": 1 } }
```

`resolveStoredCost` returned that raw object and `insertMessageStats` bound `undefined` into the `cost_* REAL NOT NULL` columns, aborting the transaction. Every cost field is now normalised on each return path, preserving stored-total precedence over catalog recalculation.

## Why

`usage.cost` was optional in older session files and the parser deliberately passes legacy shapes through, so partially-populated costs reach the DB layer intact. The messages table declares every `cost_*` column `REAL NOT NULL`, making the DB layer the single place where the NOT NULL contract can be enforced for both inserts and backfills.

## Testing

- Regression test in `packages/stats/test/parser-malformed-entries.test.ts` writes a session with `cost: { total: 1 }`, then asserts parse → insert → read-back persists `{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 1 }`. On `main` it fails with `NOT NULL constraint failed: messages.cost_input`; with this change it passes.
- `bun run check` passes in `packages/stats` (biome + `tsgo` for both tsconfigs).
- Full `packages/stats` suite: no new failures versus `main` (verified by running the suite on both; every delta-failure is a pre-existing Windows-only temp-dir teardown `EBUSY` after `closeDb()` that also reproduces on `main` and is invisible on Linux CI — it stems from `bun test` on Windows holding the sqlite fds past the 2s retry budget in `removeSyncWithRetries`).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)