### PR TITLE
fix(prompts): scope the delete-safety rule so clean cutover is not self-contradictory

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -190,7 +190,7 @@ Delegation preferred. Once design settles, SHOULD fan substantial work to `{{too
 - Fix source; NEVER suppress symptom/special-case input unless asked.
 - Clean cutover: migrate every caller; remove obsolete code/comments/aliases/re-exports/deprecated paths.
 - Prefer existing-file updates over new files. Review as user.
-{{#has tools "ask"}}- Ask before destructive commands/deleting code you didn't write.{{else}}- NEVER run destructive git commands/delete code you didn't write.{{/has}}
+{{#has tools "ask"}}- Ask before destructive commands/deleting unrelated code you didn't write; code the cutover obsoletes is in scope.{{else}}- NEVER run destructive git commands/delete unrelated code you didn't write; code the cutover obsoletes is in scope.{{/has}}
 
 # 5. Verify
 - NEVER yield non-trivial work without deliverable proof:


### PR DESCRIPTION
Fixes #8036

## Problem

`packages/coding-agent/src/prompts/system/system-prompt.md` gives the agent two rules that cannot both be satisfied.

**`# 4. Implement`** asks for a clean cutover, then immediately forbids the deletions that cutover requires:

```
- Clean cutover: migrate every caller; remove obsolete code/comments/aliases/re-exports/deprecated paths.
- Prefer existing-file updates over new files. Review as user.
{{#has tools "ask"}}- Ask before destructive commands/deleting code you didn't write.{{else}}- NEVER run destructive git commands/delete code you didn't write.{{/has}}
```

The `<contract>` block under **`§ Delivery`** doubles down:

```
- Default clean cutover: migrate every caller; no shims, aliases, deprecated paths.
```

In any pre-existing codebase the obsolete path a refactor replaces was, by definition, written by someone else. So:

- deleting the legacy path violates *"NEVER … delete code you didn't write"*, but
- leaving it violates *"remove obsolete code/…/deprecated paths"* and *"no shims, aliases, deprecated paths"*.

Both are stated in absolute terms (`NEVER`, `Default`), and neither carries an exception, so nothing in the prompt breaks the tie. Agents resolve it arbitrarily — some leave dead re-export shims behind and fail the cutover contract, others delete and consider themselves to have broken a `NEVER` rule.

## Fix

One line. Scope the safety rule to **unrelated** code and name the exception outright:

```diff
-{{#has tools "ask"}}- Ask before destructive commands/deleting code you didn't write.{{else}}- NEVER run destructive git commands/delete code you didn't write.{{/has}}
+{{#has tools "ask"}}- Ask before destructive commands/deleting unrelated code you didn't write; code the cutover obsoletes is in scope.{{else}}- NEVER run destructive git commands/delete unrelated code you didn't write; code the cutover obsoletes is in scope.{{/has}}
```

This keeps the rule doing its real job — guarding against collateral deletion of code outside the task — while no longer vetoing the cutover directive sitting one line above it.

## Notes

- Both branches of the `{{#has tools "ask"}}` fork are updated, so the ask-capable and ask-less prompts stay consistent with each other.
- The issue proposed adding `unrelated`; the trailing clause is included because `unrelated` alone still leaves the reader to infer that cutover-obsoleted code is related. Making it explicit removes the remaining ambiguity.
- Prompt text only — no behavioral code touched. The edited string has exactly one occurrence in the repo and no test asserts on it (the prompt itself forbids testing "source text").

## Verification

- Diff is +1/−1 across a single file; post-edit file is 14,733 bytes.
- No other prompt, doc, or test references the old wording.
