### PR TITLE
fix(coding-agent): auto-continue tool turns dropped by premature gateway stream closes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-continue turns that die mid-tool-call with `OpenAI completions stream closed before a finish_reason was received` (and the Responses/Azure "closed before a terminal response event" variants): premature gateway stream closes now classify like idle stalls and HTTP/2 resets, so a resolved tool turn is continued after its preserved partial output instead of surfacing the error.
+
 ## [17.4.1] - 2026-08-21
 
 ### Added

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -76,6 +76,11 @@ const USAGE_PREFLIGHT_BLOCKED_PREFIX = "Usage preflight blocked:";
 const STREAM_STALL_ERROR_RE = /stream stall/i;
 const HTTP2_STREAM_RESET_ERROR_RE =
 	/stream closed with error code\s+nghttp2_(?:internal_error|refused_stream)|nghttp2_(?:internal_error|refused_stream)|HTTP2(?:StreamReset|RefusedStream)/i;
+// Gateway closes the SSE stream mid-generation without a terminal chunk
+// (openai-completions "finish_reason", openai/azure responses "terminal
+// response event"). Same transport-failure class as the stall/reset entries:
+// retriable, and eligible for preserved-turn continuation on resolved tool turns.
+const PREMATURE_STREAM_CLOSE_ERROR_RE = /stream closed before a (?:finish_reason|terminal response event)/i;
 const IMMUTABLE_ANTHROPIC_THINKING_ERROR_PATTERN =
 	/messages\.\d+\.content\.\d+.*\b(?:thinking|redacted_thinking)\b.*\blatest assistant message cannot be modified\b/is;
 
@@ -1148,10 +1153,11 @@ export class TurnRecovery {
 	}
 
 	/**
-	 * Classify a reasonless abort, idle stream stall, or HTTP/2 stream reset whose
-	 * emitted tool calls all have results. The failed assistant/tool-result pair
-	 * stays in context so continuation cannot replay completed side effects;
-	 * synthetic results tell the next turn that an unexecuted call must be reissued.
+	 * Classify a reasonless abort, idle stream stall, HTTP/2 stream reset, or
+	 * premature stream close whose emitted tool calls all have results. The failed
+	 * assistant/tool-result pair stays in context so continuation cannot replay
+	 * completed side effects; synthetic results tell the next turn that an
+	 * unexecuted call must be reissued.
 	 */
 	classifyResolvedInterruptedToolTurn(message: AssistantMessage): "reasonless-abort" | "stream-stall" | undefined {
 		const id = this.#classifyRetryMessage(message);
@@ -1173,7 +1179,18 @@ export class TurnRecovery {
 			!this.#host.abortInProgress() &&
 			!this.#host.isDisposed() &&
 			!this.#host.streamingEditAbortTriggered();
-		if (!reasonlessAbort && !streamStall && !transportReset) return undefined;
+		// A premature gateway close (no finish_reason/terminal event) is the same
+		// transport-failure class as the stall/reset cases: mid-generation death.
+		// Preserved-turn continuation lets the retry resume after the partial
+		// output instead of surfacing the error or replaying rendered content.
+		const prematureClose =
+			message.stopReason === "error" &&
+			PREMATURE_STREAM_CLOSE_ERROR_RE.test(errorMessage) &&
+			AIError.retriable(id) &&
+			!this.#host.abortInProgress() &&
+			!this.#host.isDisposed() &&
+			!this.#host.streamingEditAbortTriggered();
+		if (!reasonlessAbort && !streamStall && !transportReset && !prematureClose) return undefined;
 		if (reasonlessAbort && genericAbort) message.errorId = AIError.create(AIError.Flag.Abort);
 
 		// Idle stall and HTTP/2 RST both close the Cursor Connect stream:

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -649,6 +649,89 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		});
 	});
 
+	describe("premature stream close after resolved tool calls", () => {
+		const completionsClose = "OpenAI completions stream closed before a finish_reason was received";
+		const responsesClose = "OpenAI responses stream closed before a terminal response event was received";
+
+		function gatewayMessage(content: AssistantMessage["content"], errorMessage: string): AssistantMessage {
+			const message = makeMessage(content, model);
+			message.provider = "opencode-go";
+			message.errorMessage = errorMessage;
+			// Production persists the Transient flag that ProviderResponseError(kind:
+			// "incomplete-stream") attaches; the bare message text classifies as 0.
+			message.errorId = AIError.create(AIError.Flag.Transient);
+			return message;
+		}
+
+		function recoveryForClose(message: AssistantMessage, tail: readonly AgentMessage[]): TurnRecovery {
+			return new TurnRecovery(createHost(model, modelRegistry, { messages: [message as AgentMessage, ...tail] }));
+		}
+
+		it("continues a premature completions close after a resolved tool call", () => {
+			const message = gatewayMessage(
+				[{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "pwd" } }],
+				completionsClose,
+			);
+			const recovery = recoveryForClose(message, [
+				{
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "bash",
+					content: [{ type: "text", text: "Tool call was not executed." }],
+					isError: true,
+					details: { __synthetic: true, source: "assistant_stop_error", executed: false },
+					timestamp: Date.now(),
+				},
+			]);
+			expect(recovery.classifyResolvedInterruptedToolTurn(message)).toBe("stream-stall");
+		});
+
+		it("continues a premature responses close after a resolved tool call", () => {
+			const message = gatewayMessage(
+				[{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "pwd" } }],
+				responsesClose,
+			);
+			const recovery = recoveryForClose(message, [
+				{
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "bash",
+					content: [{ type: "text", text: "Tool call was not executed." }],
+					isError: true,
+					details: { __synthetic: true, source: "assistant_stop_error", executed: false },
+					timestamp: Date.now(),
+				},
+			]);
+			expect(recovery.classifyResolvedInterruptedToolTurn(message)).toBe("stream-stall");
+		});
+
+		it("does not continue a premature close whose tool call has no result", () => {
+			const message = gatewayMessage(
+				[{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "pwd" } }],
+				completionsClose,
+			);
+			expect(recoveryForClose(message, []).classifyResolvedInterruptedToolTurn(message)).toBeUndefined();
+		});
+
+		it("does not continue an unrelated provider error", () => {
+			const message = gatewayMessage(
+				[{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "pwd" } }],
+				"Provider returned 500 boom",
+			);
+			const recovery = recoveryForClose(message, [
+				{
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "bash",
+					content: [{ type: "text", text: "/workspace" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			]);
+			expect(recovery.classifyResolvedInterruptedToolTurn(message)).toBeUndefined();
+		});
+	});
+
 	it("maps an ephemeral fallback hop to the default chain instead of a shared later-listed role", () => {
 		const vision = getBundledModel("openai", "gpt-4o-mini");
 		if (!vision) throw new Error("Expected bundled model gpt-4o-mini");


### PR DESCRIPTION
## Problem

OpenAI-compatible gateways sometimes close the SSE stream mid-generation without a terminal chunk. The provider then fails the turn with:

```
OpenAI completions stream closed before a finish_reason was received
```

Observed in the wild on `opencode-go/ox-alpha-free` (whose documented endpoint is `/zen/go/v1/chat/completions`, so the transport routing is correct — the gateway genuinely drops streams). Same failure shape as #8957's muse-spark reports, but transient rather than deterministic.

Recovery already handles this correctly for drops **before** any content (empty-completion retry) and **during thinking-only** output (thinking partials are replay-safe). But once committed text or a tool call was streamed, the error always surfaced:

- `isRetryableError` vetoes the replay via `#hasReplayUnsafeOutput` (correctly — re-rendering visible output would duplicate it), and
- `classifyResolvedInterruptedToolTurn` only recognized idle stalls (`/stream stall/i`) and HTTP/2 resets as continuation-eligible transport failures.

## Fix

Classify premature stream closes as the same transport-failure class as stalls/resets. New `PREMATURE_STREAM_CLOSE_ERROR_RE` matches the three known phrasings:

- `OpenAI completions stream closed before a finish_reason was received`
- `OpenAI responses stream closed before a terminal response event was received`
- Azure variant of the same message

A premature close whose emitted tool calls all have paired results now resolves as `"stream-stall"`, taking the existing preserved-turn continuation path: the failed assistant turn stays in context with its synthetic `executed: false` results, and the retry resumes after the partial output. No duplication of rendered content, no replayed side effects; backoff, retry budget, and model-fallback policy are unchanged.

Drops with unpaired tool calls or non-transient classifications still surface, as before.

## Testing

- Added a `premature stream close after resolved tool calls` describe block to `packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts` covering: completions phrasing → `stream-stall`, responses phrasing → `stream-stall`, unpaired tool call → `undefined`, unrelated error → `undefined`. Test messages set `errorId` to the Transient flag because that is what production persists (`ProviderResponseError(kind: "incomplete-stream")` attaches it at construction; the bare text classifies as 0).
- Full file: 48 pass, 0 fail.
- `bun run check` in `packages/coding-agent`: biome + `tsgo --noEmit` clean.
- Applied the patch to a local install running `opencode-go/ox-alpha-free` and ran a normal `omp --print` turn end-to-end; the patched bundle launches and completes turns normally. This smoke did NOT force a premature close, so recovery behavior itself is covered by the classifier tests above.

## Scope note

Text-only turns (committed text, no tool calls) still surface the error, matching the existing behavior of stall/reset errors on such turns; continuing those safely needs different machinery than the tool-result pairing this lane relies on.