### PR TITLE
docs(hub): name the regex dialect for ready.log, grep, and pattern

### DIFF
--- a/packages/coding-agent/src/prompts/tools/hub.md
+++ b/packages/coding-agent/src/prompts/tools/hub.md
@@ -23,12 +23,12 @@ Background jobs auto-deliver when they finish. You NEVER need to poll; if `jobs`
 Project-scoped long-running processes shared by every omp instance in the same directory. A long-running service, watcher, debugger, REPL, or process needing later input MUST use `op:"start"`, not `bash`.
 
 - **`start`** launches `application` + `args` directly. `cwd` defaults to the session directory; `pty` defaults true.
-  - `ready.log` is a regex; `ready.port` is a TCP port. Both supplied? BOTH MUST pass. `ready.timeout` is seconds. Readiness MUST be observed; process creation alone is not readiness.
+  - `ready.log` is a JavaScript `RegExp` compiled with the `u` flag; PCRE inline modifiers such as `(?i)` are REJECTED — use `[Rr]eady` instead. `ready.port` is a TCP port. Both supplied? BOTH MUST pass. `ready.timeout` is seconds. Readiness MUST be observed; process creation alone is not readiness.
   - Names are unique per project directory. A completed name MAY be started again; a live name MUST be stopped or restarted.
   - `restart` policy defaults `no`; `on-failure` and `always` use bounded backoff.
   - `persist: true` opts out of last-omp teardown; `detached: true` survives broker shutdown and all omp exits (implies persist, disables PTY input). Omit both unless their survival guarantees are required.
 - **`ps`**, **`logs`**, **`wait`** (with `name`), **`send`** (with `name`), **`stop`**, **`restart`**, and **`describe`** address the stable `name`.
-- **`logs`** defaults to the last 100 lines. `head: true` reads the beginning. `grep` is a regex. `follow: true` waits for output after `cursor`; reuse the returned cursor on the next call.
-- **`wait`** with `name` blocks until readiness/exit/`pattern` or `timeout` (seconds).
+- **`logs`** defaults to the last 100 lines. `head: true` reads the beginning. `grep` is a JavaScript `RegExp` compiled with the `u` flag (no inline modifiers such as `(?i)`). `follow: true` waits for output after `cursor`; reuse the returned cursor on the next call.
+- **`wait`** with `name` blocks until readiness/exit/`pattern` or `timeout` (seconds). `pattern` is a JavaScript `RegExp` compiled with the `u` flag (no inline modifiers such as `(?i)`).
 - **`send`** with `name`: `text` writes stdin (`enter` defaults true); `keys` supports ENTER, TAB, ESCAPE, CTRL_C, CTRL_D, UP, DOWN, LEFT, RIGHT; `signal` supports SIGINT, SIGTERM, SIGHUP, SIGQUIT, SIGKILL. PTY input is serialized; writes share one input stream.
 - **`stop`** performs graceful process-tree termination before hard-kill; NEVER kill an unverified PID through bash. **`restart`** reuses the retained launch spec.


### PR DESCRIPTION
Closes #8893 (partially — see **Scope** below).

## Problem

Hub exposes three agent-authored regex fields — `ready.log` (`start`), `grep` (`logs`), and `pattern` (`wait` with `name`) — and the broker compiles all of them with `new RegExp(value, "u")`. The contract the model actually reads only ever says **"a regex"**, with no dialect named.

That is under-specified, and models resolve the ambiguity the way most regex ecosystems do: they emit a PCRE inline modifier. The result is a hard reject with an error that names no remedy:

```
Invalid wait regex: Invalid regular expression: unrecognized character after (?
```

Observed on `omp/17.3.7`. It costs a full round trip every time, and nothing in the tool description tells the model what to do differently.

@roboomp confirmed the premise on the issue, pointing at the `new RegExp(value, "u")` call sites in `packages/coding-agent/src/launch/broker.ts` (lines 263, 626/657, 1065, 1271) and at the three field descriptions, and noted that the tool-facing wording is "exactly the wording a model reads".

## Change

`packages/coding-agent/src/prompts/tools/hub.md` — the rendered tool description — now names the dialect at all three sites:

- `ready.log` — "a JavaScript `RegExp` compiled with the `u` flag; PCRE inline modifiers such as `(?i)` are REJECTED — use `[Rr]eady` instead."
- `grep` — "a JavaScript `RegExp` compiled with the `u` flag (no inline modifiers such as `(?i)`)."
- `pattern` — same clause appended to the existing `wait`-with-`name` line.

The reporter's suggested wording was:

> JavaScript-compatible regular expression compiled with Unicode (`u`) mode. Inline modifiers such as `(?i)` are unsupported.

This keeps that meaning but stays terse, because @roboomp flagged token budget as a real constraint for a tool this large. The `[Rr]eady` example is included deliberately: naming the constraint without naming the alternative still leaves the model guessing on the next turn.

Docs-only. No behaviour change, no schema type change, no runtime code touched.

## Scope — what is deliberately *not* here

1. **Actionable broker error messages.** The second half of the issue asks that `Invalid wait regex: …` suggest the JS-compatible form. That belongs in `packages/coding-agent/src/launch/broker.ts`, which is well past the size I can safely submit through this workflow, so it is left as follow-up. @roboomp already offered to take it.
2. **The `.describe()` strings in `packages/coding-agent/src/tools/hub/index.ts`.** Those are the terse ArkType schema labels; the rendered prompt in this PR is the longer-form contract and is where an explanation fits without bloating every schema dump. Happy to mirror a short `(JS RegExp, u flag)` suffix into the schema too if a maintainer prefers it there — say the word and I'll push it to this branch.

## Verification

- `search_code` confirms no test asserts these description strings, so there is no fixture to update.
- Draft until a maintainer confirms the wording and the scope split above.
