### PR TITLE
fix(cursor): apply thinking-effort routing to wire model id

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor thinking-effort selection being cosmetic: collapsed effort-routed families (GPT-5.6 Luna/Sol/Terra, Grok 4.5/4.6) now send the effort-routed wire model id instead of always pinning the `-none` off tier ([#9246](https://github.com/can1357/oh-my-pi/issues/9246)).
+
 ## [17.4.1] - 2026-08-21
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -330,6 +330,8 @@ export interface CursorOptions extends StreamOptions {
 	conversationId?: string;
 	execHandlers?: CursorExecHandlers;
 	onToolResult?: CursorToolResultHandler;
+	/** Wire model id selected after thinking-effort routing (`resolveWireModelId`). */
+	wireModelId?: string;
 }
 
 const CONNECT_END_STREAM_FLAG = 0b00000010;
@@ -5117,7 +5119,7 @@ export async function buildGrpcRequest(
 		turns,
 	});
 
-	const wireModelId = model.requestModelId ?? model.id;
+	const wireModelId = options?.wireModelId ?? model.requestModelId ?? model.id;
 	const cursorMaxMode = model.cursorMaxMode === true;
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: wireModelId,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -2309,10 +2309,16 @@ function mapOptionsForApi<TApi extends Api>(
 		case "cursor-agent": {
 			const execHandlers = options?.cursorExecHandlers ?? options?.execHandlers;
 			const onToolResult = options?.cursorOnToolResult ?? execHandlers?.onToolResult;
+			const cursorModel = model as Model<"cursor-agent">;
+			const effort =
+				options?.reasoning && !options.disableReasoning && !options.forceReasoningOff && cursorModel.reasoning
+					? requireSupportedEffort(cursorModel, options.reasoning)
+					: undefined;
 			return castApi<"cursor-agent">({
 				...base,
 				execHandlers,
 				onToolResult,
+				wireModelId: resolveWireModelId(cursorModel, effort),
 			});
 		}
 

--- a/packages/ai/test/cursor-effort-routing.test.ts
+++ b/packages/ai/test/cursor-effort-routing.test.ts
@@ -1,0 +1,75 @@
+// Regression (#9246): the cursor transport hard-pinned every request to
+// `model.requestModelId` (the collapsed `-none` off tier), so thinking-effort
+// selection never reached the wire. `mapOptionsForApi` now resolves the effort
+// to a routed wire id and `buildGrpcRequest` sends `options.wireModelId` on both
+// `requestedModel` and `modelDetails`, keeping the logical id only as the
+// display id. buildGrpcRequest is exercised directly (the transport is HTTP/2)
+// and the serialized run request is decoded back from the wire bytes.
+import { describe, expect, it } from "bun:test";
+import { buildGrpcRequest } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { AgentClientMessageSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { fromBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+
+const model: Model<"cursor-agent"> = buildModel({
+	id: "gpt-5.6-terra",
+	name: "GPT-5.6 Terra",
+	api: "cursor-agent",
+	provider: "cursor",
+	baseUrl: "https://api2.cursor.sh",
+	reasoning: true,
+	requestModelId: "gpt-5.6-terra-none",
+	thinking: {
+		mode: "effort",
+		efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+		effortRouting: {
+			off: "gpt-5.6-terra-none",
+			[Effort.Low]: "gpt-5.6-terra-low",
+			[Effort.Medium]: "gpt-5.6-terra-medium",
+			[Effort.High]: "gpt-5.6-terra-high",
+			[Effort.XHigh]: "gpt-5.6-terra-xhigh",
+			[Effort.Max]: "gpt-5.6-terra-max",
+		},
+	},
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_000,
+});
+
+const context: Context = {
+	messages: [{ role: "user", content: "Say hello", timestamp: 0 }],
+};
+
+function decodeRunRequest(requestBytes: Uint8Array): { case: string; value: Record<string, any> } {
+	const decoded = fromBinary(AgentClientMessageSchema, requestBytes);
+	return decoded.message as unknown as { case: string; value: Record<string, any> };
+}
+
+describe("cursor effort routing", () => {
+	it("sends the effort-routed wire id, not the collapsed off tier", async () => {
+		const { requestBytes } = await buildGrpcRequest(
+			model,
+			context,
+			{ wireModelId: "gpt-5.6-terra-medium" },
+			{ conversationId: "conv-1", blobStore: new Map() },
+		);
+		const run = decodeRunRequest(requestBytes).value;
+		expect(run.requestedModel.modelId).toBe("gpt-5.6-terra-medium");
+		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra-medium");
+		// Logical id stays as the display id for local attribution.
+		expect(run.modelDetails.displayModelId).toBe("gpt-5.6-terra");
+	});
+
+	it("falls back to requestModelId when no wire id is routed", async () => {
+		const { requestBytes } = await buildGrpcRequest(model, context, undefined, {
+			conversationId: "conv-2",
+			blobStore: new Map(),
+		});
+		const run = decodeRunRequest(requestBytes).value;
+		expect(run.requestedModel.modelId).toBe("gpt-5.6-terra-none");
+		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra-none");
+	});
+});


### PR DESCRIPTION
## Repro
With a collapsed `cursor/gpt-5.6-terra` spec (`thinking.effortRouting` from #9026), setting thinking to `medium`/`xhigh` never changes the wire model. Driving `buildGrpcRequest` with `options.reasoning = "medium"` and decoding the `AgentClientMessage` wire bytes shows:

```
resolveWireModelId(model, 'medium') = gpt-5.6-terra-medium
wire requestedModel.modelId       = gpt-5.6-terra-none
wire modelDetails.modelId         = gpt-5.6-terra-none
```

Every turn is sent as the collapsed default `requestModelId` (`gpt-5.6-terra-none`, the explicit no-reasoning SKU), so the thinking control is cosmetic and the model runs with reasoning off.

## Cause
The `cursor-agent` branch of `mapOptionsForApi` (`packages/ai/src/stream.ts`) never resolved the effort — unlike `devin-agent`, which computes `resolveWireModelId(model, effort)` and passes `chatModelUid`. `buildGrpcRequest` (`packages/ai/src/providers/cursor.ts`) then hard-pinned `const wireModelId = model.requestModelId ?? model.id`, which for a collapsed family is the `-none` off tier, so `thinking.effortRouting` was never consulted at request time.

## Fix
- Add `wireModelId?: string` to `CursorOptions` (mirrors `DevinOptions.chatModelUid`).
- Resolve the effort in the `cursor-agent` case of `mapOptionsForApi` (guarding `disableReasoning`/`forceReasoningOff` and non-reasoning models) and pass `wireModelId: resolveWireModelId(cursorModel, effort)`.
- `buildGrpcRequest` now sends `options?.wireModelId ?? model.requestModelId ?? model.id` on both `requestedModel.modelId` and `modelDetails.modelId`; `displayModelId` stays the logical id.
- Add `packages/ai/test/cursor-effort-routing.test.ts` and a CHANGELOG entry.

## Verification
`bun test test/cursor-*.test.ts` in `packages/ai` — 264 pass, 0 fail (includes the new `cursor-effort-routing.test.ts`, which decodes the wire bytes and asserts the routed id is sent and falls back to `requestModelId` when unset). Pre-publish `bun check` passed via `gh_push_branch`.

Fixes #9246