### PR TITLE
docs: add consolidated CLI reference page

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,7 +46,8 @@ omp --continue "What did we discuss?"
 Argument handling:
 
 - `@<path>` attaches a file or image to the initial message.
-- A lone `-` is read as the stdin marker (piped prompt).
+- Non-TTY stdin is read automatically as the initial prompt; do not add a `-`
+  marker.
 - `--` ends flag parsing; everything after it is literal message text, even if it
   looks like a flag.
 
@@ -176,7 +177,7 @@ omp -p --print-thoughts "Explain your reasoning for this refactor"
 omp -p --mode json "List every TODO in src/" > todos.json
 
 # Pipe a prompt via stdin
-echo "review this diff" | omp -p -
+echo "review this diff" | omp -p
 ```
 
 Related flags for headless runs:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,248 @@
+# CLI reference
+
+`omp` is invoked as:
+
+```sh
+omp [command] [flags] [messages...]
+```
+
+When the first non-flag argument is **not** a registered subcommand, `omp`
+routes to the default [`launch`](#launch-the-default-command) command and treats
+the arguments as the initial prompt. So `omp "fix the build"` launches a session
+with that message, while `omp models` runs the `models` subcommand.
+
+Every command and flag is discoverable at runtime:
+
+- `omp --help` lists all subcommands.
+- `omp <command> --help` prints that command's flags and examples.
+
+This page is the consolidated reference for the shared **launch surface** (the
+flags accepted by `omp` / `omp launch`) and every top-level **subcommand**.
+Per-subcommand flags (for example `omp auth-broker --json`) are documented by
+each command's `--help`.
+
+## Launch (the default command)
+
+`omp` and `omp launch` start a coding session. Positional arguments become the
+initial message(s):
+
+```sh
+# Interactive session
+omp
+
+# Interactive session with an initial prompt
+omp "List all .ts files in src/"
+
+# Attach files/images to the initial message (prefix with @)
+omp @prompt.md @image.png "What color is the sky?"
+
+# Non-interactive: process the prompt and exit (headless / print mode)
+omp -p "List all .ts files in src/"
+
+# Continue the previous session
+omp --continue "What did we discuss?"
+```
+
+Argument handling:
+
+- `@<path>` attaches a file or image to the initial message.
+- A lone `-` is read as the stdin marker (piped prompt).
+- `--` ends flag parsing; everything after it is literal message text, even if it
+  looks like a flag.
+
+### Launch flags
+
+#### Session and workspace
+
+| Flag | Description |
+| --- | --- |
+| `--cwd <dir>` | Directory to start in (overrides the launch cwd). |
+| `--add-dir <dir>` | Add a workspace directory beyond the working directory (repeatable). |
+| `--allow-home` | Allow starting in `~` without auto-switching to a temp dir. |
+| `--profile <name>` | Use an isolated profile for auth, sessions, settings, and caches. |
+| `--alias <name>` | Create a shell shortcut for the selected profile and exit. |
+| `--config <file>` | Load an extra `config.yml`-style overlay for this run (repeatable). |
+| `--session-dir <dir>` | Directory for session storage and lookup. |
+| `--no-session` | Don't save the session (ephemeral). |
+
+#### Session history
+
+| Flag | Description |
+| --- | --- |
+| `--continue`, `-c` | Continue the previous session. |
+| `--resume [id]`, `-r`, `--session [id]` | Resume a session by ID prefix or path, or open the picker when no value is given. |
+| `--fork <session>` | Fork a saved session (by ID prefix or path) into a new session. See [session operations](./session-operations-export-share-fork-resume.md). |
+| `--from-claude` | Import a Claude Code session into OMP. |
+| `--from-codex` | Import a Codex session into OMP. |
+| `--export <session>` | Export a session file to HTML and exit. |
+| `--no-title` | Disable title auto-generation (equivalent to the `PI_NO_TITLE` [environment variable](./environment-variables.md)). |
+
+#### Model selection
+
+| Flag | Description |
+| --- | --- |
+| `--model <id>` | Model to use (fuzzy match: `opus`, `gpt-5.2`, or `openai/gpt-5.2`). |
+| `--smol <id>` | Smol/fast model for lightweight tasks (or `PI_SMOL_MODEL`). |
+| `--slow <id>` | Slow/reasoning model for thorough analysis (or `PI_SLOW_MODEL`). |
+| `--plan <id>` | Plan model for architectural planning (or `PI_PLAN_MODEL`). |
+| `--models <a,b,c>` | Comma-separated model patterns for `Ctrl+P` cycling. |
+| `--provider <name>` | Provider to use (legacy; prefer `--model`). |
+| `--api-key <key>` | API key (defaults to env vars). |
+| `--provider-session-id <id>` | Reuse a specific provider-side session id for continuity and cache scoping. |
+| `--prompt-cache-key <key>` | Override the provider prompt-cache key for this session. |
+| `--service-tier <tier>` | OpenAI service tier for this session (`none` omits `service_tier`). |
+
+See [providers](./providers.md) and [models](./models.md) for model resolution.
+
+#### Thinking and reasoning
+
+| Flag | Description |
+| --- | --- |
+| `--thinking <level>` | Set the thinking level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`. |
+| `--hide-thinking` | Hide thinking blocks in TUI output (display only; does not disable model thinking). |
+| `--print-thoughts` | Include thinking blocks in print-mode text output. |
+| `--external-thinking` | Use a private scratchpad while disabling supported GPT/Claude/Gemini reasoning. Use at your own risk: providers have flagged this request shape as abuse. |
+
+#### Prewalk and plan modes
+
+| Flag | Description |
+| --- | --- |
+| `--prewalk` | Switch to a fast/cheap model at the first edit/write after the plan's todo list exists (default off; see `prewalk.enabled`). |
+| `--no-prewalk` | Disable prewalk even if `prewalk.enabled` is set. |
+| `--prewalk-into <id>` | Target model for prewalk (default the `smol` role). |
+| `--plan-yolo` | Force read-only plan mode at start, auto-approve the plan on the model's first resolve call, then switch to `--plan-yolo-into` to implement it. |
+| `--plan-yolo-into <id>` | Target model for plan-yolo execution (default the `smol` role). |
+
+#### Tools, approvals, and runtime
+
+| Flag | Description |
+| --- | --- |
+| `--tools <a,b,c>` | Comma-separated list of tools to enable (default: all). |
+| `--no-tools` | Disable all built-in tools. |
+| `--no-lsp` | Disable LSP tools, formatting, and diagnostics. |
+| `--no-pty` | Disable PTY-based interactive bash execution. |
+| `--approval-mode <mode>` | Override `tools.approvalMode` for this session (`always-ask`, `write`, or `yolo`). See [approval mode](./approval-mode.md). |
+| `--auto-approve`, `--yolo` | Auto-approve all tool calls (skip approval prompts). |
+| `--advisor` | Enable the advisor runtime (passively reviews each turn and injects notes). See [advisor / watchdog](./advisor-watchdog.md). |
+| `--max-time <duration>` | Stop the session after this duration (e.g. `600`, `10m`, `1h`). |
+
+#### Extensions, hooks, skills, and rules
+
+| Flag | Description |
+| --- | --- |
+| `--extension <path>`, `-e <path>` | Load an extension (repeatable). See [extensions](./extensions.md). |
+| `--hook <path>` | Load a hook/extension file (repeatable). See [hooks](./hooks.md). |
+| `--trusted-extension <abs-path>` | Load a trusted extension from an absolute path (repeatable; cannot be combined with `--extension`/`-e`/`--hook`). |
+| `--plugin-dir <dir>` | Add a local plugin directory to discovery (repeatable). |
+| `--no-extensions` | Disable extension discovery (explicit `-e` paths still work). |
+| `--skills <globs>` | Comma-separated glob patterns to filter [skills](./skills.md) (e.g. `git-*,docker`). |
+| `--no-skills` | Disable skills discovery and loading. |
+| `--no-rules` | Disable rules discovery and loading. See [context files](./context-files.md). |
+
+#### System prompt
+
+| Flag | Description |
+| --- | --- |
+| `--system-prompt <text\|file>` | System prompt (default: coding assistant prompt). See [system prompt customization](./system-prompt-customization.md). |
+| `--append-system-prompt <text\|file>` | Append text or file contents to the system prompt. |
+
+#### Output mode
+
+| Flag | Description |
+| --- | --- |
+| `--mode <mode>` | Output/transport mode: `text` (default), `json`, `rpc`, `acp`, or `rpc-ui`. See [output modes](#output-modes---mode). |
+
+#### Information
+
+| Flag | Description |
+| --- | --- |
+| `--help`, `-h` | Show help for `omp` or a subcommand and exit. |
+| `--version`, `-v` | Print the installed version and exit. |
+
+### Headless / print mode
+
+`--print` / `-p` runs `omp` non-interactively: it processes the prompt, streams
+the result to stdout, and exits without entering the TUI. This is the entry point
+for scripting and automation.
+
+```sh
+# Print the answer and exit
+omp -p "Summarize the changes in the last commit"
+
+# Include the model's thinking blocks in the printed text
+omp -p --print-thoughts "Explain your reasoning for this refactor"
+
+# Machine-readable output for pipelines
+omp -p --mode json "List every TODO in src/" > todos.json
+
+# Pipe a prompt via stdin
+echo "review this diff" | omp -p -
+```
+
+Related flags for headless runs:
+
+- `--print-thoughts` — include thinking blocks in the printed text output.
+- `--mode json` — emit structured events instead of rendered text.
+- `--no-title` — skip title auto-generation (also `PI_NO_TITLE`).
+- `--max-time <duration>` — bound the run.
+
+The [advisor / watchdog](./advisor-watchdog.md#headless-runs) doc describes
+print-mode disposal semantics when the advisor runtime is enabled.
+
+### Output modes (`--mode`)
+
+| Mode | Description |
+| --- | --- |
+| `text` | Default. Rendered text output (TUI when interactive, plain text under `--print`). |
+| `json` | Structured JSON event stream, for headless/machine consumption. |
+| `rpc` | JSON-RPC server over stdio. See [RPC](./rpc.md). |
+| `rpc-ui` | RPC transport with UI extension events enabled. |
+| `acp` | Agent Client Protocol server over stdio. Equivalent to the [`acp`](#subcommands) subcommand; see [approval mode → ACP sessions](./approval-mode.md#acp-sessions). |
+
+## Subcommands
+
+Run `omp <command> --help` for each command's own flags and examples.
+
+| Command | Purpose | See also |
+| --- | --- | --- |
+| `launch` | Start a coding session (the default command). | [Launch flags](#launch-flags) |
+| `acp` | Run Oh My Pi as an ACP (Agent Client Protocol) server over stdio. | [approval mode](./approval-mode.md#acp-sessions) |
+| `auth-broker` | Manage the omp auth-broker (credential vault). | [auth broker / gateway](./auth-broker-gateway.md) |
+| `auth-gateway` | Run an auth-gateway forward proxy backed by the configured broker. | [auth broker / gateway](./auth-broker-gateway.md) |
+| `agents` | Manage bundled task agents. | [task agent discovery](./task-agent-discovery.md) |
+| `bench` | Benchmark models with the same prompt: time-to-first-token and generation throughput (tokens/s). | |
+| `browser-relay` | Run the local CDP relay that lets the browser tool drive your own Chrome tabs. | [computer use](./computer-use.md) |
+| `cleanse` | Detect and fix project diagnostics with weighted parallel subagents. | |
+| `commit` | Generate a commit message and update changelogs. | |
+| `completions` | Print a shell completion script (bash, zsh, or fish). | |
+| `compress` | Rewrite a text file into the dense prompt register, reporting what it drops. | |
+| `config` | Manage configuration settings. | [config usage](./config-usage.md), [settings](./settings.md) |
+| `dry-balance` | Dry-run OAuth account balancing across random session ids. | |
+| `gc` | Run storage garbage collection. | |
+| `grep` | Test the grep tool from the CLI. (The [`grep` tool](./tools/grep.md) is a separate agent tool.) | |
+| `gallery` | Preview tool renderers across streaming, in-progress, success, and failure states. | |
+| `grievances` | View, clean, or push reported tool issues (auto-QA grievances). | |
+| `install` | Install or link an extension package (alias of `plugin install` / `plugin link`). | [extensions](./extensions.md) |
+| `join` | Join a shared collab session (same as `/join`). | [collab](./collab.md) |
+| `models` | List, search, and refresh available models. | [models](./models.md) |
+| `plugin` | Manage plugins (install, uninstall, list, etc.). | [extensions](./extensions.md), [marketplace](./marketplace.md) |
+| `ps` | List and control daemon-supervised background processes (logs, stop, kill, restart). | |
+| `say` | Synthesize text with the local TTS engine and play it through the speakers. | [tts tool](./tools/tts.md) |
+| `share` | Share a saved session via an encrypted link (same as the `/share` slash command). | [session operations](./session-operations-export-share-fork-resume.md) |
+| `setup` | Run onboarding setup or install dependencies for optional features. | |
+| `shell` | Interactive shell console. | |
+| `read` | Show what the read tool will return for a path, URL, or internal URI. (The [`read` tool](./tools/read.md) is a separate agent tool.) | |
+| `ssh` | Manage SSH host configurations. | |
+| `stats` | View usage statistics. | |
+| `update` | Check for and install updates. | |
+| `usage` | Show provider usage limits for every authenticated account. | |
+| `tiny-models` | Download tiny local models (session titles + memory). | [local models](./local-models.md) |
+| `token` | Get the API key or OAuth token for a provider. | [secrets](./secrets.md) |
+| `ttsr` | Inspect and test Time-Traveling Stream Rules (TTSR). (Covers the CLI command; the [TTSR feature](./ttsr-injection-lifecycle.md) is documented separately.) | |
+| `worktree`, `wt` | List or clear agent-managed git worktrees (`~/.omp/wt`). | |
+| `search`, `q` | Test web search providers from the CLI. | [web_search tool](./tools/web_search.md) |
+
+> `install`, `join`, `browser-relay`, `auth-gateway`, and `tiny-models` are also
+> reachable through related mechanisms (the `plugin` command, the `/join` slash
+> command, and so on). The table lists each as it is registered in
+> `packages/coding-agent/src/cli-commands.ts`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a consolidated CLI reference (`docs/cli-reference.md`) documenting every top-level subcommand and launch flag, including headless print mode (`--print`/`-p`, `--print-thoughts`) ([#9252](https://github.com/can1357/oh-my-pi/issues/9252))
+
 ## [17.4.1] - 2026-08-21
 
 ### Added


### PR DESCRIPTION
## Repro
`omp` registers 37 subcommands (`packages/coding-agent/src/cli-commands.ts`) and the launch parser accepts ~59 flags (`packages/coding-agent/src/cli/flag-tables.ts`, `packages/coding-agent/src/cli/args.ts`), but `docs/` had no consolidated CLI reference and much of the surface was discoverable only via `--help` or source. Headless/print mode was the sharpest gap: `grep -rl 'print-thoughts' docs | wc -l` returned `0` and no `docs/cli-reference*` file existed.

## Cause
Documentation coverage gap, not a code defect. Subcommand descriptions live in `cli/command-help.ts` and launch-flag descriptions in `commands/launch-help.ts`, surfaced only through per-command `--help`; nothing under `docs/` mirrored them, so `--print`/`-p`/`--print-thoughts` and 22 other flags plus 23 subcommands had no reference entry.

## Fix
- Add `docs/cli-reference.md`:
  - Launch invocation, positional/`@file`/stdin/`--` handling, examples.
  - Full launch-flag reference grouped by function (session, history, models, thinking, prewalk/plan, tools/approvals, extensions/skills/rules, system prompt, output mode, info), descriptions sourced verbatim from `launch-help.ts` where available.
  - Dedicated headless/print-mode section covering `--print`/`-p`, `--print-thoughts`, `--mode json`, `--no-title`, `--max-time`.
  - `--mode` value table (`text`/`json`/`rpc`/`rpc-ui`/`acp`) linking `rpc.md` and `approval-mode.md`.
  - Subcommand table for all 37 registered commands (`__complete` omitted as hidden/internal) with authoritative descriptions and cross-links to existing detailed docs; notes distinguishing `omp read`/`omp grep`/`omp ttsr`/`omp share` from the similarly named tools/feature/slash-command.
- Add `packages/coding-agent/CHANGELOG.md` `[Unreleased] > Added` entry.

## Verification
Coverage script confirms all 38 command tokens (incl. `wt`/`q` aliases) and all 64 flag tokens appear in the page; a link checker confirms all 28 relative doc links resolve, including `#acp-sessions` and `#headless-runs` anchors. Doc-only change (no TypeScript touched). Fixes #9252