### PR TITLE
fix(omp-rpc): preserve assistant event types

### DIFF
--- a/python/omp-rpc/src/omp_rpc/protocol.py
+++ b/python/omp-rpc/src/omp_rpc/protocol.py
@@ -4,7 +4,7 @@ import base64
 import mimetypes
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Final, Literal, NotRequired, TypedDict, TypeAlias, cast
+from typing import Any, Final, Literal, NotRequired, TypeAlias, TypedDict, cast
 
 JsonPrimitive: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"]
@@ -323,12 +323,13 @@ def parse_assistant_message_event(payload: JsonObject) -> AssistantMessageEvent:
     )
     if event_type == "start":
         return AssistantMessageStartEvent(
+            type="start",
             partial=_parse_assistant_message(
                 _clone_json_object(
                     payload.get("partial"), field="assistantMessageEvent.partial"
                 ),
                 field="assistantMessageEvent.partial",
-            )
+            ),
         )
     if event_type in {"text_start", "thinking_start", "toolcall_start"}:
         partial = _parse_assistant_message(
@@ -341,12 +342,16 @@ def parse_assistant_message_event(payload: JsonObject) -> AssistantMessageEvent:
         if content_index is None:
             raise ValueError("assistantMessageEvent.contentIndex must be an integer")
         if event_type == "text_start":
-            return AssistantTextStartEvent(contentIndex=content_index, partial=partial)
+            return AssistantTextStartEvent(
+                type="text_start", contentIndex=content_index, partial=partial
+            )
         if event_type == "thinking_start":
             return AssistantThinkingStartEvent(
-                contentIndex=content_index, partial=partial
+                type="thinking_start", contentIndex=content_index, partial=partial
             )
-        return AssistantToolCallStartEvent(contentIndex=content_index, partial=partial)
+        return AssistantToolCallStartEvent(
+            type="toolcall_start", contentIndex=content_index, partial=partial
+        )
     if event_type in {"text_delta", "thinking_delta", "toolcall_delta"}:
         partial = _parse_assistant_message(
             _clone_json_object(
@@ -362,14 +367,23 @@ def parse_assistant_message_event(payload: JsonObject) -> AssistantMessageEvent:
             raise ValueError("assistantMessageEvent.delta must be a string")
         if event_type == "text_delta":
             return AssistantTextDeltaEvent(
-                contentIndex=content_index, delta=delta, partial=partial
+                type="text_delta",
+                contentIndex=content_index,
+                delta=delta,
+                partial=partial,
             )
         if event_type == "thinking_delta":
             return AssistantThinkingDeltaEvent(
-                contentIndex=content_index, delta=delta, partial=partial
+                type="thinking_delta",
+                contentIndex=content_index,
+                delta=delta,
+                partial=partial,
             )
         return AssistantToolCallDeltaEvent(
-            contentIndex=content_index, delta=delta, partial=partial
+            type="toolcall_delta",
+            contentIndex=content_index,
+            delta=delta,
+            partial=partial,
         )
     if event_type in {"text_end", "thinking_end"}:
         partial = _parse_assistant_message(
@@ -386,10 +400,16 @@ def parse_assistant_message_event(payload: JsonObject) -> AssistantMessageEvent:
             raise ValueError("assistantMessageEvent.content must be a string")
         if event_type == "text_end":
             return AssistantTextEndEvent(
-                contentIndex=content_index, content=content, partial=partial
+                type="text_end",
+                contentIndex=content_index,
+                content=content,
+                partial=partial,
             )
         return AssistantThinkingEndEvent(
-            contentIndex=content_index, content=content, partial=partial
+            type="thinking_end",
+            contentIndex=content_index,
+            content=content,
+            partial=partial,
         )
     if event_type == "toolcall_end":
         partial = _parse_assistant_message(
@@ -405,12 +425,14 @@ def parse_assistant_message_event(payload: JsonObject) -> AssistantMessageEvent:
             payload.get("toolCall"), field="assistantMessageEvent.toolCall"
         )
         return AssistantToolCallEndEvent(
+            type="toolcall_end",
             contentIndex=content_index,
             toolCall=cast(ToolCall, tool_call),
             partial=partial,
         )
     if event_type == "done":
         return AssistantDoneEvent(
+            type="done",
             reason=cast(
                 Literal["stop", "length", "toolUse"],
                 _require_literal(
@@ -427,6 +449,7 @@ def parse_assistant_message_event(payload: JsonObject) -> AssistantMessageEvent:
             ),
         )
     return AssistantErrorEvent(
+        type="error",
         reason=cast(
             Literal["aborted", "error"],
             _require_literal(

--- a/python/omp-rpc/tests/test_protocol.py
+++ b/python/omp-rpc/tests/test_protocol.py
@@ -7,6 +7,7 @@ from omp_rpc import (
     AutoCompactionEndEvent,
     AutoCompactionStartEvent,
     ExtensionUiRequest,
+    MessageUpdateEvent,
     SessionState,
     TodoReminderEvent,
     assistant_text,
@@ -17,6 +18,38 @@ from omp_rpc import (
 
 
 class ProtocolParsingTests(unittest.TestCase):
+    def test_parse_message_update_preserves_assistant_event_type(self) -> None:
+        assistant = {"role": "assistant"}
+        common = {"contentIndex": 0, "partial": assistant}
+        cases = {
+            "start": {"partial": assistant},
+            "text_start": common,
+            "thinking_start": common,
+            "toolcall_start": common,
+            "text_delta": {**common, "delta": "text"},
+            "thinking_delta": {**common, "delta": "thought"},
+            "toolcall_delta": {**common, "delta": "arguments"},
+            "text_end": {**common, "content": "text"},
+            "thinking_end": {**common, "content": "thought"},
+            "toolcall_end": {**common, "toolCall": {}},
+            "done": {"reason": "stop", "message": assistant},
+            "error": {"reason": "error", "error": assistant},
+        }
+
+        for event_type, event in cases.items():
+            with self.subTest(event_type=event_type):
+                parsed = parse_notification(
+                    {
+                        "type": "message_update",
+                        "message": assistant,
+                        "assistantMessageEvent": {"type": event_type, **event},
+                    }
+                )
+
+                self.assertIsInstance(parsed, MessageUpdateEvent)
+                assert isinstance(parsed, MessageUpdateEvent)
+                self.assertEqual(parsed.assistant_message_event["type"], event_type)
+
     def test_parse_session_state(self) -> None:
         state = parse_session_state(
             {


### PR DESCRIPTION
## What

Preserve the required `type` discriminator when parsing all assistant-message event variants in the Python `omp-rpc` client.

## Why

When omp-rpc passes on the messages received from omp's server, it checks the type (e.g. thinking_delta) but forgets to send it on. Downstream consumers of omp-rpc can therefore not tell what the type is of the event they're receiving.

## Testing

- `uv run --project python/omp-rpc --with pytest python -m pytest -q python/omp-rpc/tests` (67 passed, 14 subtests)
- `ruff format --check` on the changed Python files
- `ruff check --ignore TRY004` on the changed Python files (`TRY004` findings pre-exist in `protocol.py`)
- Reproduced through the public `parse_notification()` boundary for all 12 assistant event variants

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (no changelog exists for `python/omp-rpc`)
