### PR TITLE
fix(worktree): move session into checked out worktree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Single PR worktree checkouts now move the active session to the external worktree before returning.
 
 ## [17.4.1] - 2026-08-21
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -475,6 +475,7 @@ async function runInteractiveMode(
 	initialMessage?: string,
 	initialImages?: ImageContent[],
 	joinLink?: string,
+	onModeReady?: (mode: InteractiveMode) => void,
 ): Promise<void> {
 	const mode = new InteractiveMode(
 		session,
@@ -485,6 +486,7 @@ async function runInteractiveMode(
 		mcpManager,
 		eventBus,
 	);
+	onModeReady?.(mode);
 
 	// Cold-launch gate: the full setup wizard (every scene + the overlay and
 	// their TUI/OAuth/search/theme deps) is heavy, yet the common case only needs
@@ -1253,6 +1255,7 @@ export async function runRootCommand(
 		process.exit(1);
 	}
 	const mode = parsedArgs.mode || "text";
+	let activeInteractiveMode: InteractiveMode | undefined;
 	// RPC owns stdin. Claim its singleton stream before plugin/extension discovery can load an in-process consumer.
 	const rpcInput = mode === "rpc" || mode === "rpc-ui" ? claimRpcInput() : undefined;
 
@@ -1583,6 +1586,13 @@ export async function runRootCommand(
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
 	sessionOptions.settings = settingsInstance;
+	if (mode === "text") {
+		sessionOptions.moveToCwd = async newCwd => {
+			if (!sessionManager) return;
+			await sessionManager.moveTo(newCwd);
+			await activeInteractiveMode?.applyCwdChange(newCwd);
+		};
+	}
 
 	// OTEL: register global OTLP exporters when an endpoint is configured via
 	// env, then switch on the agent loop's telemetry hooks so traces, run-level
@@ -1818,6 +1828,9 @@ export async function runRootCommand(
 				initialMessage,
 				initialImages,
 				parsedArgs.join,
+				modeInstance => {
+					activeInteractiveMode = modeInstance;
+				},
 			);
 		} else {
 			// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1677,6 +1677,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			get cwd() {
 				return sessionManager.getCwd();
 			},
+			moveToCwd: newCwd => sessionManager.moveTo(newCwd),
 			isToolActive: name => activeToolNames.has(name),
 			setActiveToolNames,
 			toolRegistry,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -545,9 +545,11 @@ export interface CreateAgentSessionOptions {
 	/** Inherited eval executor session id for subagents sharing parent eval state. */
 	parentEvalSessionId?: string;
 
+	/** Session move callback used by worktree-aware tools. */
+	moveToCwd?: (cwd: string) => Promise<void>;
+
 	/** Session manager. Default: session stored under the configured agentDir sessions root */
 	sessionManager?: SessionManager;
-
 	/** Override local:// protocol options for subagent local:// sharing. Default: uses the session's own artifacts dir and session ID. */
 	localProtocolOptions?: LocalProtocolOptions;
 
@@ -1677,7 +1679,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			get cwd() {
 				return sessionManager.getCwd();
 			},
-			moveToCwd: newCwd => sessionManager.moveTo(newCwd),
+			moveToCwd: options.moveToCwd,
 			isToolActive: name => activeToolNames.has(name),
 			setActiveToolNames,
 			toolRegistry,

--- a/packages/coding-agent/src/tools/gh-pr-checkout.ts
+++ b/packages/coding-agent/src/tools/gh-pr-checkout.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { getWorktreeDir, hashPath, isEnoent } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, hashPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import * as git from "../utils/git";
 import type { ToolSession } from ".";
 import type { GhPrCheckoutSummary, GhToolDetails } from "./gh";
@@ -327,8 +327,23 @@ export async function executePrCheckout(
 
 	if (!isMulti) {
 		const [outcome] = outcomes;
-		await session.moveToCwd?.(outcome.worktreePath);
-		return buildTextResult(formatPrCheckoutResult(outcome), outcome.data.url, {
+		let moveWarning: string | undefined;
+		if (session.moveToCwd) {
+			try {
+				await session.moveToCwd(outcome.worktreePath);
+			} catch (error) {
+				const reason = error instanceof Error ? error.message : String(error);
+				logger.warn("PR checkout succeeded but moving the session failed", {
+					worktreePath: outcome.worktreePath,
+					error: reason,
+				});
+				moveWarning = `Warning: worktree checked out at ${outcome.worktreePath}, but the session was not moved: ${reason}`;
+			}
+		} else {
+			moveWarning = "Warning: this host does not support moving the session into the checked-out worktree.";
+		}
+		const text = [formatPrCheckoutResult(outcome), moveWarning].filter(Boolean).join("\n\n");
+		return buildTextResult(text, outcome.data.url, {
 			repo: repo ?? outcome.data.headRepository?.nameWithOwner,
 			branch: outcome.localBranch,
 			worktreePath: outcome.worktreePath,

--- a/packages/coding-agent/src/tools/gh-pr-checkout.ts
+++ b/packages/coding-agent/src/tools/gh-pr-checkout.ts
@@ -327,6 +327,7 @@ export async function executePrCheckout(
 
 	if (!isMulti) {
 		const [outcome] = outcomes;
+		await session.moveToCwd?.(outcome.worktreePath);
 		return buildTextResult(formatPrCheckoutResult(outcome), outcome.data.url, {
 			repo: repo ?? outcome.data.headRepository?.nameWithOwner,
 			branch: outcome.localBranch,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -155,6 +155,8 @@ export interface DeferredDiagnosticsEntry {
 export interface ToolSession {
 	/** Current working directory */
 	cwd: string;
+	/** Move the persisted session and its tool cwd to a worktree. */
+	moveToCwd?: (cwd: string) => Promise<void>;
 	/** Additional workspace directories beyond cwd (multi-root), forwarded to subagents. */
 	additionalDirectories?: string[];
 	/** Whether UI is available */

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1111,6 +1111,43 @@ describe("github tool", () => {
 			expect(moveToCwd).toHaveBeenCalledWith(worktreePath);
 		});
 
+		it("reports a completed checkout when moving the session fails", async () => {
+			vi.spyOn(git.github, "json")
+				.mockResolvedValueOnce({
+					number: 125,
+					title: "Session move failure",
+					url: "https://github.com/base/repo/pull/125",
+					baseRefName: "main",
+					headRefName: fixture.headRefName,
+					headRefOid: fixture.headRefOid,
+					headRepository: { nameWithOwner: "contrib/repo" },
+					headRepositoryOwner: { login: "contrib" },
+					isCrossRepository: true,
+					maintainerCanModify: true,
+				})
+				.mockResolvedValueOnce({
+					nameWithOwner: "contrib/repo",
+					sshUrl: fixture.forkBare,
+					url: fixture.forkBare,
+				});
+
+			const session = {
+				...createSession(fixture.repoRoot),
+				moveToCwd: async () => {
+					throw new Error("session move denied");
+				},
+			} as ToolSession;
+			const tool = new GithubTool(session);
+			const result = await tool.execute("pr-checkout-session-move-failure", {
+				op: "pr_checkout",
+				pr: "125",
+			});
+
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+			expect(text).toContain("Checked Out Pull Request #125");
+			expect(text).toContain("session was not moved: session move denied");
+		});
+
 		// These assertions are non-mutating (a no-op add and rejected adds), so
 		// reuse the checkout fixture instead of cloning another repository.
 		describe("git.remote.add idempotency", () => {
@@ -1370,7 +1407,9 @@ echo ok
 					maintainerCanModify: true,
 				});
 
-			const tool = new GithubTool(createSession(fixture.repoRoot));
+			const moveToCwd = vi.fn(async (_cwd: string) => {});
+			const session = { ...createSession(fixture.repoRoot), moveToCwd } as ToolSession;
+			const tool = new GithubTool(session);
 			const result = await tool.execute("pr-checkout", { op: "pr_checkout", pr: ["100", "200"] });
 			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 			const primaryRoot = (await git.repo.primaryRoot(fixture.repoRoot)) ?? fixture.repoRoot;
@@ -1394,6 +1433,7 @@ echo ok
 			expect(summaries?.length).toBe(2);
 			expect(summaries?.map(s => s.prNumber)).toEqual([100, 200]);
 			expect(summaries?.every(s => s.reused === false)).toBe(true);
+			expect(moveToCwd).not.toHaveBeenCalled();
 		}, 30_000);
 
 		describe("pr_push without checkout metadata", () => {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1081,6 +1081,36 @@ describe("github tool", () => {
 			expect(runGit(worktreePath, ["branch", "--show-current"])).toBe("pr-123");
 		});
 
+		it("moves the session to a single checked-out worktree", async () => {
+			vi.spyOn(git.github, "json")
+				.mockResolvedValueOnce({
+					number: 124,
+					title: "Session move",
+					url: "https://github.com/base/repo/pull/124",
+					baseRefName: "main",
+					headRefName: fixture.headRefName,
+					headRefOid: fixture.headRefOid,
+					headRepository: { nameWithOwner: "contrib/repo" },
+					headRepositoryOwner: { login: "contrib" },
+					isCrossRepository: true,
+					maintainerCanModify: true,
+				})
+				.mockResolvedValueOnce({
+					nameWithOwner: "contrib/repo",
+					sshUrl: fixture.forkBare,
+					url: fixture.forkBare,
+				});
+
+			const moveToCwd = vi.fn(async (_cwd: string) => {});
+			const session = { ...createSession(fixture.repoRoot), moveToCwd } as ToolSession;
+			const tool = new GithubTool(session);
+			await tool.execute("pr-checkout-session-move", { op: "pr_checkout", pr: "124" });
+
+			const primaryRoot = (await git.repo.primaryRoot(fixture.repoRoot)) ?? fixture.repoRoot;
+			const worktreePath = await expectedWorktreePath(tempHome.home, primaryRoot, "pr-124");
+			expect(moveToCwd).toHaveBeenCalledWith(worktreePath);
+		});
+
 		// These assertions are non-mutating (a no-op add and rejected adds), so
 		// reuse the checkout fixture instead of cloning another repository.
 		describe("git.remote.add idempotency", () => {


### PR DESCRIPTION
## Summary

- add a host-owned, session-scoped `moveToCwd` capability to `ToolSession`;
- let `createAgentSession` receive and expose that host callback without assuming how a host refreshes cwd-derived state;
- move the active session into the external worktree after a single `pr_checkout` in supported text/interactive hosts;
- interactive mode routes the move through `SessionManager.moveTo` plus `InteractiveMode.applyCwdChange`, refreshing project settings, skills, slash commands, terminal/status-line state, and other cwd-derived state;
- protocol hosts that cannot renegotiate cwd (ACP/RPC) do not opt into automatic movement;
- make session-move failure non-fatal after checkout and surface a warning;
- leave multi-PR checkout results unchanged because there is no single destination to adopt;
- preserve the existing LSP implementation, which roots clients from the session cwd.

## Why

OMP already creates official external worktrees under the configured worktree base. The missing integration was that `pr_checkout` returned the worktree path while leaving the active session rooted at the original checkout. Subsequent LSP calls therefore indexed the wrong project. The fix belongs at the session/worktree host seam, not inside the LSP tool.

## Verification

- `bun test test/tools/gh.test.ts` — 52 passed
- `bun test test/tools/lsp-regressions.test.ts` — 97 passed
- `bun run check` — pass
- `git diff --check` — pass

Coverage includes successful single-checkout movement, non-fatal movement failure, and no movement for multi-PR checkout.