### PR TITLE
fix(catalog): enrich gateway-first opencode models

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed Cursor model discovery showing separate picker rows for pure effort-suffixed models beyond GPT-5.6 by collapsing each standard and Fast lane into one reasoning-effort model ([#9237](https://github.com/can1357/oh-my-pi/issues/9237)).
+- Fixed gateway-first OpenCode Zen and Go models missing context, output, image, and reasoning metadata by enriching live discovery from the current stencil catalog ([#9272](https://github.com/can1357/oh-my-pi/issues/9272)).
 
 ## [17.4.1] - 2026-08-21
 

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -63,13 +63,13 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 		}
 		case "opencode-go":
 		case "opencode-zen": {
-			// v2: muse-spark-1.2 rows cached before the reasoning/thinking
-			// recovery carry `reasoning: false` and must be refetched.
+			// v3: gateway-first rows cached before stencil enrichment carry null
+			// limits and `reasoning: false`; use a fresh namespace so they refetch.
 			const configuredBaseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
 			const trimmedBaseUrl = configuredBaseUrl.endsWith("/") ? configuredBaseUrl.slice(0, -1) : configuredBaseUrl;
 			const discoveryBaseUrl = trimmedBaseUrl.endsWith("/v1") ? trimmedBaseUrl : `${trimmedBaseUrl}/v1`;
 			const scope = `${options.apiKey ?? ""}\u0000${discoveryBaseUrl}`;
-			return `${providerId}:models-v2:${Bun.hash(scope).toString(36)}`;
+			return `${providerId}:models-v3:${Bun.hash(scope).toString(36)}`;
 		}
 		case "github-copilot": {
 			// Copilot model specs bake in the plan-specific endpoint (personal vs

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2594,6 +2594,16 @@ function openCodeModelManagerOptions(
 		];
 		return hints.includes("openai-responses") ? "openai-responses" : undefined;
 	};
+	const resolveApi = (id: string, defaultApi: Api): Api => {
+		const base = openCodeBaseModelId(id);
+		return (
+			apiOverrides[id] ??
+			(base ? apiOverrides[base] : undefined) ??
+			references.get(id)?.api ??
+			fallbackApi(id, base) ??
+			defaultApi
+		);
+	};
 	return {
 		providerId,
 		cacheProviderId: resolveModelCacheProviderId(providerId, { apiKey, baseUrl: discoveryBaseUrl }),
@@ -2604,6 +2614,18 @@ function openCodeModelManagerOptions(
 		// completions after the pin shipped). Sibling-catalog drift is bounded
 		// by the 2h cache TTL instead.
 		dropCachedModelIdsOnStaticMismatch: Object.keys(apiOverrides),
+		modelsDev: {
+			fetch: () => fetchWellKnownModels(config?.fetch),
+			map: payload => {
+				if (!isRecord(payload)) return [];
+				return mapModelsDevToModels(payload, OPENCODE_MODELS_DEV_DESCRIPTORS)
+					.filter(model => model.provider === providerId)
+					.map(model => {
+						const api = resolveApi(model.id, "openai-completions");
+						return { ...model, api, baseUrl: openCodeBaseUrlForApi(api, basePath) };
+					});
+			},
+		},
 		...(apiKey && {
 			fetchDynamicModels: () =>
 				fetchOpenAICompatibleModels<Api>({
@@ -2614,16 +2636,9 @@ function openCodeModelManagerOptions(
 					mapModel: (entry, defaults) => {
 						const reference = references.get(defaults.id);
 						const name = toModelName(entry.name, reference?.name ?? defaults.name);
-						const base = openCodeBaseModelId(defaults.id);
-						// Pins win over bundled references (stale bundled routes
-						// must not stick), and a base-id pin covers its billing
-						// variants; the responses fallback covers gateway-first ids.
-						const api =
-							apiOverrides[defaults.id] ??
-							(base ? apiOverrides[base] : undefined) ??
-							reference?.api ??
-							fallbackApi(defaults.id, base) ??
-							defaults.api;
+						// Pins and bundled routing hints win over the metadata-only
+						// stencil fallback; the fallback never selects a transport.
+						const api = resolveApi(defaults.id, defaults.api);
 						const baseUrl = openCodeBaseUrlForApi(api, basePath);
 						if (isMuseSparkModelId(defaults.id)) {
 							// Gateway lists these as bare ids with no capability
@@ -6255,6 +6270,29 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_GOOGLE_VERTEX: readonly ModelsDevProviderD
 	}),
 ];
 
+const OPENCODE_MODELS_DEV_DESCRIPTORS: readonly ModelsDevProviderDescriptor[] = [
+	openAiCompletionsDescriptor("opencode", "opencode-zen", "https://opencode.ai/zen/v1", {
+		filterModel: filterActiveToolCallModels,
+		resolveApi: (modelId, raw) =>
+			resolveApiByRules(
+				modelId,
+				raw,
+				OPENCODE_ZEN_API_RESOLUTION.rules,
+				OPENCODE_ZEN_API_RESOLUTION.defaultResolution,
+			),
+	}),
+	openAiCompletionsDescriptor("opencode-go", "opencode-go", "https://opencode.ai/zen/go/v1", {
+		filterModel: filterActiveToolCallModels,
+		resolveApi: (modelId, raw) =>
+			resolveApiByRules(
+				modelId,
+				raw,
+				OPENCODE_GO_API_RESOLUTION.rules,
+				OPENCODE_GO_API_RESOLUTION.defaultResolution,
+			),
+	}),
+];
+
 const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDescriptor[] = [
 	// --- Azure OpenAI ---
 	// OpenAI-family models hosted on Azure, served via the Responses API. baseUrl
@@ -6276,28 +6314,8 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDes
 	),
 	// --- Mistral ---
 	openAiCompletionsDescriptor("mistral", "mistral", "https://api.mistral.ai/v1"),
-	// --- OpenCode Zen ---
-	openAiCompletionsDescriptor("opencode", "opencode-zen", "https://opencode.ai/zen/v1", {
-		filterModel: filterActiveToolCallModels,
-		resolveApi: (modelId, raw) =>
-			resolveApiByRules(
-				modelId,
-				raw,
-				OPENCODE_ZEN_API_RESOLUTION.rules,
-				OPENCODE_ZEN_API_RESOLUTION.defaultResolution,
-			),
-	}),
-	// --- OpenCode Go ---
-	openAiCompletionsDescriptor("opencode-go", "opencode-go", "https://opencode.ai/zen/go/v1", {
-		filterModel: filterActiveToolCallModels,
-		resolveApi: (modelId, raw) =>
-			resolveApiByRules(
-				modelId,
-				raw,
-				OPENCODE_GO_API_RESOLUTION.rules,
-				OPENCODE_GO_API_RESOLUTION.defaultResolution,
-			),
-	}),
+	// --- OpenCode Zen / Go ---
+	...OPENCODE_MODELS_DEV_DESCRIPTORS,
 	// --- GitHub Copilot ---
 	openAiCompletionsDescriptor("github-copilot", "github-copilot", COPILOT_BASE_URL, {
 		defaultContextWindow: 128000,

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
+import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
@@ -120,6 +121,66 @@ describe("OpenCode provider discovery", () => {
 		expect(apiById.get("brand-new-model")).toBe("openai-completions");
 	});
 
+	test("enriches gateway-first ids from stencil without changing their route", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-zen-gateway-first-"));
+		try {
+			const options = opencodeZenModelManagerOptions({
+				apiKey: "zen-account-key",
+				fetch: async () => modelListResponse(["x-preview-f-free"]),
+			});
+			const modelsDev = options.modelsDev;
+			if (!modelsDev) throw new Error("OpenCode model manager did not configure stencil fallback");
+			const catalog = {
+				opencode: {
+					models: {
+						"x-preview-f-free": {
+							id: "x-preview-f-free",
+							name: "Ox Alpha Free (Unlimited)",
+							tool_call: true,
+							reasoning: true,
+							limit: { context: 1_000_000, output: 131_072 },
+							modalities: { input: ["text", "image", "video"], output: ["text"] },
+							provider: { npm: "@ai-sdk/anthropic" },
+						},
+					},
+				},
+			};
+			const managerOptions = {
+				...options,
+				cacheDbPath: path.join(tempDir, "models.db"),
+				modelsDev: { ...modelsDev, fetch: async () => catalog },
+			};
+			const online = await resolveProviderModels(managerOptions, "online");
+			const model = online.models.find(candidate => candidate.id === "x-preview-f-free");
+			expect(model).toMatchObject({
+				name: "Ox Alpha Free (Unlimited)",
+				api: "openai-completions",
+				baseUrl: "https://opencode.ai/zen/v1",
+				contextWindow: 1_000_000,
+				maxTokens: 131_072,
+				reasoning: true,
+				input: ["text", "image"],
+			});
+			if (!model) throw new Error("Gateway-first model was not resolved");
+			expect(getSupportedEfforts(model)).toEqual([
+				Effort.Minimal,
+				Effort.Low,
+				Effort.Medium,
+				Effort.High,
+				Effort.XHigh,
+			]);
+
+			const cached = await resolveProviderModels(managerOptions, "online-if-uncached");
+			expect(cached.models.find(candidate => candidate.id === model.id)).toMatchObject({
+				contextWindow: 1_000_000,
+				maxTokens: 131_072,
+				reasoning: true,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("recovers muse-spark thinking levels from live OpenCode Go discovery", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-go-muse-"));
 		try {
@@ -150,7 +211,8 @@ describe("OpenCode provider discovery", () => {
 			let freeFetches = 0;
 			const freeOptions = opencodeZenModelManagerOptions({
 				apiKey: "free-account-key",
-				fetch: async () => {
+				fetch: async input => {
+					if (String(input).includes("catalog.stencil.so")) return Response.json({});
 					freeFetches++;
 					return modelListResponse(LIVE_FREE_MODEL_IDS);
 				},
@@ -163,7 +225,8 @@ describe("OpenCode provider discovery", () => {
 			let paidFetches = 0;
 			const paidOptions = opencodeZenModelManagerOptions({
 				apiKey: "paid-account-key",
-				fetch: async () => {
+				fetch: async input => {
+					if (String(input).includes("catalog.stencil.so")) return Response.json({});
 					paidFetches++;
 					return modelListResponse(LIVE_PAID_MODEL_IDS);
 				},


### PR DESCRIPTION
## Repro
A temporary `packages/catalog/repro-9272.ts` harness fed `opencodeZenModelManagerOptions()` the gateway’s bare `x-preview-f-free` row and ran `bun packages/catalog/repro-9272.ts`; current `main` returned `{"contextWindow":null,"maxTokens":null,"reasoning":false}` despite the current stencil row carrying complete metadata.

## Cause
`openCodeModelManagerOptions()` in `packages/catalog/src/provider-models/openai-compat.ts` only joined live `/v1/models` rows against `createBundledReferenceMap()`. It did not configure `ModelManagerOptions.modelsDev`, so `resolveProviderModels()` had no stencil source to merge before the authoritative dynamic row, and the resulting bare row was persisted in the credential-scoped cache.

## Fix
- Reuse the OpenCode models.dev descriptors as a metadata fallback while normalizing their routes through the existing gateway override and sibling-reference rules.
- Advance the OpenCode cache namespace to `models-v3` so previously cached bare rows refresh immediately.
- Cover gateway-first metadata, effort levels, route preservation, and authoritative-cache reuse; document the fix in the catalog changelog.

## Verification
`bun test packages/catalog/test/opencode-provider.test.ts` passed: 8 tests, 0 failures. The fixed-path harness against the live stencil feed returned `{"contextWindow":1000000,"maxTokens":131072,"reasoning":true,"efforts":["minimal","low","medium","high","xhigh"]}`. `bun check` passed.

Fixes #9272