### PR TITLE
fix(coding-agent): re-read AGENTS.md on /clear and /new

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fixed unreadable colors in macOS Terminal.app by using its supported 256-color mode ([#9162](https://github.com/can1357/oh-my-pi/issues/9162)).
+- Fixed `/clear` and `/new` keeping a stale `AGENTS.md` (and other context files) in the system prompt; a new session now re-reads them from disk ([#9273](https://github.com/can1357/oh-my-pi/issues/9273)).
 - Fixed Esc after a fast `/mcp test` result aborting the active agent turn instead of consuming the advertised cancellation input ([#9173](https://github.com/can1357/oh-my-pi/issues/9173)).
 - Fixed task spawns crashing when legacy boolean per-agent prewalk or advisor overrides are present in `config.yml`.
 - Fixed ACP `session/prompt` requests hanging forever when a builtin slash command's residual prompt (e.g. `/force:<tool> /some-command`) resolved locally, which also wedged all subsequent prompts on the session ([#9206](https://github.com/can1357/oh-my-pi/issues/9206)).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -99,6 +99,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, type AsyncJob, AsyncJobManager } from "../async";
+import { reset as resetCapabilities } from "../capability";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
 import type { ResolvedModelRoleValue } from "../config/model-resolver";
@@ -6968,8 +6969,14 @@ export class AgentSession {
 			this.#advisors.resetSessionState();
 			advisorRecordersDetached = false;
 			this.#reconnectToAgent();
-			// The workspace-roots block must reflect the new session's directory set,
-			// not the previous session's — refresh before the next turn goes out.
+			// Drop the process-lifetime context-file cache so the rebuild re-reads
+			// AGENTS.md and friends from disk: the user may have edited them since
+			// the previous session started, and refreshBaseSystemPrompt() re-runs
+			// discovery but would otherwise hit stale cached bytes (issue #9273).
+			// The workspace-roots block must also reflect the new session's
+			// directory set, not the previous session's — refresh before the next
+			// turn goes out.
+			resetCapabilities();
 			await this.refreshBaseSystemPrompt();
 
 			// Emit session_switch event with reason "new" to hooks

--- a/packages/coding-agent/test/agent-session-context-file-reload.test.ts
+++ b/packages/coding-agent/test/agent-session-context-file-reload.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { Api, Model, ModelSpec } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function buildLocalModel(api: string): Model<Api> {
+	return buildModel({
+		id: "context-reload-model",
+		name: "Context Reload Model",
+		api,
+		provider: "managed-primary",
+		baseUrl: "http://127.0.0.1:8080/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 4096,
+		maxTokens: 1024,
+	} as ModelSpec<Api>) as Model<Api>;
+}
+
+describe("AgentSession context-file reload on session reset", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Regression for #9273: /clear and /new (both go through newSession) must
+	// re-read AGENTS.md from disk. Context-file discovery reads through the
+	// process-lifetime cache in capability/fs.ts; before the fix that cache was
+	// only cleared on chdir, so an edited AGENTS.md stayed stale until restart.
+	it("re-reads an edited AGENTS.md into the base prompt after newSession()", async () => {
+		using tempDir = TempDir.createSync("@pi-context-reload-");
+		const marker = Bun.nanoseconds().toString(36);
+		const original = `ORIGINAL_RULES_${marker}`;
+		const updated = `UPDATED_RULES_${marker}`;
+		const agentsMd = path.join(tempDir.path(), "AGENTS.md");
+		await fs.writeFile(agentsMd, original);
+
+		const api = `context-reload-${marker}`;
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("managed-primary", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model: buildLocalModel(api),
+			disableExtensionDiscovery: true,
+			skills: [],
+			// contextFiles intentionally omitted so discovery runs against disk.
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			await session.refreshBaseSystemPrompt();
+			expect(session.systemPrompt.join("\n")).toContain(original);
+
+			// User edits AGENTS.md mid-session.
+			await fs.writeFile(agentsMd, updated);
+
+			// /clear and /new both funnel through newSession().
+			expect(await session.newSession()).toBe(true);
+
+			const rebuilt = session.systemPrompt.join("\n");
+			expect(rebuilt).toContain(updated);
+			expect(rebuilt).not.toContain(original);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
Edit `AGENTS.md` in the project root during an active session, then run `/clear` or `/new`. The rebuilt system prompt keeps the pre-edit `AGENTS.md`; the updated rules never appear until the process is restarted. Minimal repro against the exact function the prompt rebuild calls: `discoverContextFiles(dir)` returns the original content, editing `AGENTS.md` on disk, then `discoverContextFiles(dir)` again still returns the original content (fresh content only appears after `capability.reset()`).

## Cause
The report's `handleClearCommand` trace is off by one level: `/clear` and `/new` do rebuild the prompt — `handleClearCommand()` → `#runNewSessionFlow()` → `session.newSession()`, and `newSession()` already calls `refreshBaseSystemPrompt()` (`session/agent-session.ts`), which re-runs `discoverContextFiles()` inside the `rebuildSystemPrompt` closure (`sdk.ts`). The stale content comes from `capability/fs.ts`: `readFile` caches every path in a process-lifetime `contentCache` that is only cleared by `capability.reset()`, which ran solely on `/move` (chdir) and ACP plugin reload — never on session reset. So the re-discovery re-reads the same cached bytes and the edited `AGENTS.md` never surfaces.

## Fix
- `session/agent-session.ts`: call `resetCapabilities()` (the `reset` export of `../capability`) in `newSession()` immediately before the `refreshBaseSystemPrompt()` rebuild, so discovery re-reads context files from disk. Placing it in `newSession()` covers `/clear`, `/new`, `/drop`, and the ACP/collab/RPC new-session paths uniformly.
- `CHANGELOG.md`: user-facing Fixed entry.

## Verification
`bun test test/agent-session-context-file-reload.test.ts` — new regression test builds a session over a temp dir with an `AGENTS.md`, asserts the base prompt contains it, edits the file, calls `newSession()`, and asserts the prompt now contains the new content and not the old. Confirmed it fails without the fix (stale) and passes with it. Also ran the newSession-adjacent suites (`agent-session-message-pipeline`, `agent-session-fresh`, `agent-session-bash-session-ownership`, `agent-session-new-session-queued-steer`, `agent-session-async-delivery`, `agent-session-checkpoint-rewind-branch`, `advisor-toggle`) and the capability/context suites: all green. Fixes #9273