### PR TITLE
feat(coding-agent): add opt-in skill visibility

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -55,7 +55,7 @@ Supported frontmatter fields on the skill type:
 - `description?: string`
 - `globs?: string[]`
 - `alwaysApply?: boolean`
-- `hide?: boolean`
+- `hide?: boolean` (author-controlled model visibility; `true` keeps the skill loaded but omits it from the model prompt)
 - `disableModelInvocation?: boolean` (Agent Skills equivalent of `hide`; normalized from kebab-case `disable-model-invocation`)
 - additional keys are preserved as unknown metadata
 
@@ -105,6 +105,7 @@ Dedup key is skill name. First item with a given name wins.
 - `disabledExtensions` entries with `skill:<name>`
 - `ignoredSkills` (exclude; glob patterns)
 - `includeSkills` (include allowlist; glob patterns; empty means include all)
+- `skills.optInSkills` (name-glob list; matched skills remain loaded but are hidden from the model prompt)
 
 Filter order is:
 
@@ -112,6 +113,8 @@ Filter order is:
 2. source enabled
 3. not ignored
 4. included (if include list present)
+
+`skills.optInSkills` is not a removal filter. After provider, custom-directory, and managed-skill discovery and name deduplication are complete, its Bun-style glob patterns are matched against each final resolved skill name. Matches are marked hidden from the model prompt but remain loaded and accessible through `skill://<name>` and `/skill:<name>`.
 
 The `agents` provider (`.agent[s]/skills`) is the canonical OMP-native location and has its own `enableAgentsUser`/`enableAgentsProject` toggles — disabling Claude/Codex/Pi does **not** turn it off. Providers without a dedicated toggle (`claude-plugins`, `opencode`, `github`, …) are enabled if **any** named third-party source toggle is enabled.
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4814,6 +4814,8 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.includeSkills": { type: "array", default: [] as string[] },
 
+	"skills.optInSkills": { type: "array", default: [] as string[] },
+
 	// Commands
 	"commands.enableClaudeUser": {
 		type: "boolean",
@@ -5764,6 +5766,7 @@ export interface SkillsSettings {
 	customDirectories?: string[];
 	ignoredSkills?: string[];
 	includeSkills?: string[];
+	optInSkills?: string[];
 	disabledExtensions?: string[];
 }
 

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -140,6 +140,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		customDirectories = [],
 		ignoredSkills = [],
 		includeSkills = [],
+		optInSkills = [],
 		disabledExtensions = [],
 	} = options;
 
@@ -191,6 +192,12 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	function matchesIgnorePatterns(name: string): boolean {
 		if (ignoredSkills.length === 0) return false;
 		return ignoredSkills.some(pattern => new Bun.Glob(pattern).match(name));
+	}
+
+	// Check if skill name matches any of the opt-in patterns
+	function matchesOptInPatterns(name: string): boolean {
+		if (optInSkills.length === 0) return false;
+		return optInSkills.some(pattern => new Bun.Glob(pattern).match(name));
 	}
 
 	const disabledSkillNames = new Set(
@@ -392,6 +399,9 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	}
 
 	const skills = Array.from(skillMap.values());
+	for (const skill of skills) {
+		if (matchesOptInPatterns(skill.name)) skill.hide = true;
+	}
 	// Deterministic ordering for prompt stability (case-insensitive, then exact name, then path).
 	skills.sort((a, b) => compareSkillOrder(a.name, a.filePath, b.name, b.filePath));
 	return {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -13,7 +13,7 @@ import {
 	type Skill,
 } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls/router";
-import { buildAvailableSlashCommands } from "@oh-my-pi/pi-coding-agent/slash-commands/available-commands";
+import { getSessionSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/get-commands-handler";
 import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -472,17 +472,24 @@ enabled: false
 
 		beforeEach(async () => {
 			tempSkillsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-opt-in-skills-"));
-			for (const [name, body] of [
-				["visible-skill", "Visible skill instructions."],
-				["manual-skill", "Manual skill instructions."],
+			for (const [directoryName, skillName, body] of [
+				["visible-skill", "visible-skill", "Visible skill instructions."],
+				["explicit-only-directory", "manual-skill", "Manual skill instructions."],
 			] as const) {
-				const skillDir = path.join(tempSkillsDir, name);
+				const skillDir = path.join(tempSkillsDir, directoryName);
 				await fs.mkdir(skillDir, { recursive: true });
 				await fs.writeFile(
 					path.join(skillDir, "SKILL.md"),
-					["---", `name: ${name}`, `description: ${name} description.`, "---", "", `# ${name}`, "", body].join(
-						"\n",
-					),
+					[
+						"---",
+						`name: ${skillName}`,
+						`description: ${skillName} description.`,
+						"---",
+						"",
+						`# ${skillName}`,
+						"",
+						body,
+					].join("\n"),
 				);
 			}
 		});
@@ -517,22 +524,17 @@ enabled: false
 				includeModelInPrompt: false,
 				personality: "none",
 			});
-			const commands = await buildAvailableSlashCommands(
-				{
-					customCommands: [],
-					skills,
-					skillsSettings,
-					setSlashCommands: () => {},
-					sessionManager: { getCwd: () => tempSkillsDir },
-				},
-				async () => [],
-			);
+			const commands = getSessionSlashCommands({
+				customCommands: [],
+				skills,
+				skillsSettings,
+			});
 			const manualSkillResource = await InternalUrlRouter.instance().resolve("skill://manual-skill", { skills });
 
 			return {
 				prompt: systemPrompt.join("\n"),
 				discoveredSkillNames: skills.map(skill => skill.name),
-				skillCommands: commands.filter(command => command.source === "skill").map(command => `/${command.name}`),
+				skillCommands: commands.filter(command => command.source === "skill").map(command => command.name),
 				manualSkillContent: manualSkillResource.content,
 			};
 		}
@@ -542,7 +544,7 @@ enabled: false
 
 			expect(observed.discoveredSkillNames).toEqual(["manual-skill", "visible-skill"]);
 			expect(observed.prompt).toContain("visible-skill");
-			expect(observed.skillCommands).toContain("/skill:manual-skill");
+			expect(observed.skillCommands).toContain("skill:manual-skill");
 			expect(observed.manualSkillContent).toContain("Manual skill instructions.");
 			expect(observed.prompt.includes("manual-skill")).toBe(false);
 		}

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -464,10 +464,6 @@ enabled: false
 	});
 
 	describe("opt-in skills", () => {
-		type OptInSkillsSettings = NonNullable<Parameters<typeof loadSkills>[0]> & {
-			optInSkills?: string[];
-		};
-
 		let tempSkillsDir: string;
 
 		beforeEach(async () => {
@@ -499,7 +495,7 @@ enabled: false
 		});
 
 		async function observeSkills(optInSkills?: string[]) {
-			const skillsSettings: OptInSkillsSettings = {
+			const skillsSettings: NonNullable<Parameters<typeof loadSkills>[0]> = {
 				...DISABLE_ALL_BUILTIN_SKILLS,
 				customDirectories: [tempSkillsDir],
 				enableSkillCommands: true,

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -12,6 +12,9 @@ import {
 	parseSkillInvocation,
 	type Skill,
 } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls/router";
+import { buildAvailableSlashCommands } from "@oh-my-pi/pi-coding-agent/slash-commands/available-commands";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const fixturesDir = path.resolve(import.meta.dirname, "fixtures/skills");
@@ -457,6 +460,117 @@ enabled: false
 				ignoredSkills: ["valid-skill"],
 			});
 			expect(skills.every(s => s.name !== "valid-skill")).toBe(true);
+		});
+	});
+
+	describe("opt-in skills", () => {
+		type OptInSkillsSettings = NonNullable<Parameters<typeof loadSkills>[0]> & {
+			optInSkills?: string[];
+		};
+
+		let tempSkillsDir: string;
+
+		beforeEach(async () => {
+			tempSkillsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-opt-in-skills-"));
+			for (const [name, body] of [
+				["visible-skill", "Visible skill instructions."],
+				["manual-skill", "Manual skill instructions."],
+			] as const) {
+				const skillDir = path.join(tempSkillsDir, name);
+				await fs.mkdir(skillDir, { recursive: true });
+				await fs.writeFile(
+					path.join(skillDir, "SKILL.md"),
+					["---", `name: ${name}`, `description: ${name} description.`, "---", "", `# ${name}`, "", body].join(
+						"\n",
+					),
+				);
+			}
+		});
+
+		afterEach(async () => {
+			await removeWithRetries(tempSkillsDir);
+		});
+
+		async function observeSkills(optInSkills?: string[]) {
+			const skillsSettings: OptInSkillsSettings = {
+				...DISABLE_ALL_BUILTIN_SKILLS,
+				customDirectories: [tempSkillsDir],
+				enableSkillCommands: true,
+				...(optInSkills === undefined ? {} : { optInSkills }),
+			};
+			const { skills, warnings } = await loadSkills(skillsSettings);
+			expect(warnings).toHaveLength(0);
+
+			const { systemPrompt } = await buildSystemPrompt({
+				cwd: tempSkillsDir,
+				contextFiles: [],
+				skillsSettings,
+				toolNames: ["read"],
+				workspaceTree: {
+					rootPath: tempSkillsDir,
+					rendered: "",
+					truncated: false,
+					totalLines: 0,
+					agentsMdFiles: [],
+				},
+				activeRepoContext: null,
+				includeModelInPrompt: false,
+				personality: "none",
+			});
+			const commands = await buildAvailableSlashCommands(
+				{
+					customCommands: [],
+					skills,
+					skillsSettings,
+					setSlashCommands: () => {},
+					sessionManager: { getCwd: () => tempSkillsDir },
+				},
+				async () => [],
+			);
+			const manualSkillResource = await InternalUrlRouter.instance().resolve("skill://manual-skill", { skills });
+
+			return {
+				prompt: systemPrompt.join("\n"),
+				discoveredSkillNames: skills.map(skill => skill.name),
+				skillCommands: commands.filter(command => command.source === "skill").map(command => `/${command.name}`),
+				manualSkillContent: manualSkillResource.content,
+			};
+		}
+
+		async function expectManualSkillToBeOptInOnly(pattern: string) {
+			const observed = await observeSkills([pattern]);
+
+			expect(observed.discoveredSkillNames).toEqual(["manual-skill", "visible-skill"]);
+			expect(observed.prompt).toContain("visible-skill");
+			expect(observed.skillCommands).toContain("/skill:manual-skill");
+			expect(observed.manualSkillContent).toContain("Manual skill instructions.");
+			expect(observed.prompt.includes("manual-skill")).toBe(false);
+		}
+
+		it("omits an exact opt-in skill from the prompt while keeping explicit access", async () => {
+			await expectManualSkillToBeOptInOnly("manual-skill");
+		});
+
+		it("omits a wildcard-matched opt-in skill from the prompt while keeping explicit access", async () => {
+			await expectManualSkillToBeOptInOnly("manual-*");
+		});
+
+		it("preserves current prompt and explicit access behavior for an empty opt-in array", async () => {
+			const withoutOptInSetting = await observeSkills();
+			const withEmptyOptInSetting = await observeSkills([]);
+			const summarize = (observed: Awaited<ReturnType<typeof observeSkills>>) => ({
+				visibleInPrompt: observed.prompt.includes("visible-skill"),
+				manualInPrompt: observed.prompt.includes("manual-skill"),
+				discoveredSkillNames: observed.discoveredSkillNames,
+				skillCommands: observed.skillCommands,
+				manualSkillContent: observed.manualSkillContent,
+			});
+
+			expect(summarize(withEmptyOptInSetting)).toEqual(summarize(withoutOptInSetting));
+			expect(summarize(withEmptyOptInSetting)).toMatchObject({
+				visibleInPrompt: true,
+				manualInPrompt: true,
+			});
 		});
 	});
 

--- a/packages/coding-agent/test/utils/changelog.test.ts
+++ b/packages/coding-agent/test/utils/changelog.test.ts
@@ -318,6 +318,8 @@ describe.skipIf(!hasPtyHarness)("interactive startup changelog PTY smoke", () =>
 						stderr: "pipe",
 						env: {
 							...process.env,
+							// The nested CLI must exercise production terminal behavior.
+							PI_TEST_RUNTIME: "0",
 							HOME: root,
 							XDG_CONFIG_HOME: path.join(root, "xdg-config"),
 							XDG_STATE_HOME: path.join(root, "xdg-state"),


### PR DESCRIPTION
## What

- add `skills.optInSkills` as Bun glob patterns matched against resolved skill names
- hide matching skills from model prompt metadata while retaining `/skill:<name>` and `skill://<name>` access
- cover exact, wildcard, empty/default, prompt, command, and internal-URL behavior
- document post-resolution visibility semantics
- isolate the changelog PTY smoke's nested production CLI from the test runner marker

## Why

Claude marketplace skills can be discovered by OMP even when Claude's `enabledPlugins` map disables their plugin. Users need a persistent OMP policy that keeps selected skills explicitly callable without letting their metadata trigger automatic model invocation.

The PTY test-only fix was required by deterministic pre-PR suite verification: the repository runner sets `PI_TEST_RUNTIME=1`, and the nested production CLI inherited it until this change reset that boundary to production semantics.

## Testing

- `bun test packages/coding-agent/test/skills.test.ts packages/coding-agent/test/system-prompt-inventory.test.ts` — 76 pass
- `bun --cwd=packages/coding-agent run check:types`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bun --cwd=packages/coding-agent run test` — all coding-agent chunks passed
- `bun --cwd=packages/coding-agent run build`
- built and installed `omp/17.3.5`; deployed binary matches the final build
- fresh RPC smoke: 0 configured Superpowers in the model prompt, `rca` and `refero-design` remain visible, all 14 Superpowers `/skill:` commands remain registered, and `/home/karls/.claude/plugins/cache/claude-plugins-official/superpowers/6.3.0/skills/using-superpowers/SKILL.md` resolves the active 6.3.0 body

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)