### PR TITLE
fix(coding-agent): drain cancelled glob and read scans

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 
+- Fixed timed-out or interrupted glob searches keeping native filesystem workers alive and blocking subsequent agent turns.
 - Fixed regional HTTP 401 data-residency errors during Codex chat, web search, and image generation requests by passing token residency metadata on requests.
 - Fixed macOS SSH ControlMaster socket creation failures caused by `sun_path` length limits when using named profiles.
 - Fixed an issue where Nix-packaged builds failed to load on-demand native addons (`onnxruntime-node`/`sherpa-onnx`) due to missing shared C++ runtime library paths.

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -96,6 +96,8 @@ export interface GlobToolOptions {
 	rootPathAlias?: boolean;
 	/** Native glob binding. Override only in tests. */
 	nativeGlob?: typeof natives.glob;
+	/** Filesystem stat used before native scans. Override only in tests. */
+	stat?: typeof fs.promises.stat;
 	/** Native and user-facing scan timeout. Override only in tests. */
 	timeoutMs?: number;
 }
@@ -104,6 +106,11 @@ interface GlobTarget {
 	searchPath: string;
 	globPattern: string;
 	hasGlob: boolean;
+}
+
+interface NativePreparedTarget {
+	target: GlobTarget;
+	result?: Array<{ path: string; mtime: number }>;
 }
 
 export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
@@ -144,6 +151,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 	readonly #customOps?: GlobOperations;
 	readonly #rootPathAlias: boolean;
 	readonly #nativeGlob: typeof natives.glob;
+	readonly #stat: typeof fs.promises.stat;
 	readonly #timeoutMs: number;
 
 	constructor(
@@ -153,6 +161,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 		this.#customOps = options?.operations;
 		this.#rootPathAlias = options?.rootPathAlias === true;
 		this.#nativeGlob = options?.nativeGlob ?? natives.glob;
+		this.#stat = options?.stat ?? fs.promises.stat;
 		this.#timeoutMs = options?.timeoutMs ?? DEFAULT_GLOB_TIMEOUT_MS;
 		if (!Number.isFinite(this.#timeoutMs) || this.#timeoutMs <= 0) {
 			throw new TypeError("Glob timeout must be a positive number");
@@ -169,11 +178,18 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 		const { path: pathInput, limit, hidden, gitignore } = params;
 
 		throwIfAborted(signal);
-		// Native scans receive the abort signal directly and must settle before
-		// execute returns. Custom operations have no signal API, so retain their
-		// immediate-abort wrapper.
-		const immediateAbortSignal = this.#customOps?.glob ? signal : undefined;
-		return untilAborted(immediateAbortSignal, async () => {
+		// Preparation still rejects immediately on caller abort. Once every
+		// filesystem stat has settled, detach this proxy before launching native
+		// scans so execute can drain each worker through the real caller signal.
+		// Custom operations have no signal API and keep immediate abort coverage
+		// for their entire execution.
+		const preparationController = !this.#customOps?.glob && signal ? new AbortController() : undefined;
+		const abortPreparation = (): void => preparationController?.abort();
+		if (preparationController && signal) {
+			signal.addEventListener("abort", abortPreparation, { once: true });
+		}
+		const immediateAbortSignal = this.#customOps?.glob ? signal : preparationController?.signal;
+		const execution = untilAborted(immediateAbortSignal, async () => {
 			const formatScopePath = (targetPath: string): string => formatPathRelativeToCwd(targetPath, this.session.cwd);
 			const scopedPaths = toPathList(pathInput);
 			const effectivePaths = scopedPaths.length > 0 ? scopedPaths : ["."];
@@ -391,6 +407,40 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 				return buildResult(merged);
 			}
 
+			const preparedTargets: NativePreparedTarget[] = await Promise.all(
+				targets.map(async target => {
+					throwIfAborted(signal);
+					let stat: fs.Stats;
+					try {
+						stat = await this.#stat(target.searchPath);
+					} catch (err) {
+						// ENAMETOOLONG can never name a real target; surface a clean
+						// "Path not found" instead of leaking the raw errno (issue #7597).
+						if (isEnoent(err) || hasFsCode(err, "ENAMETOOLONG")) {
+							if (isSingle) throw new ToolError(`Path not found: ${scopePath}`);
+							return { target, result: [] };
+						}
+						throw err;
+					}
+					if (!target.hasGlob && stat.isFile()) {
+						return {
+							target,
+							result: [{ path: formatScopePath(target.searchPath), mtime: stat.mtimeMs }],
+						};
+					}
+					if (!stat.isDirectory()) {
+						if (isSingle) throw new ToolError(`Path is not a directory: ${target.searchPath}`);
+						return { target, result: [] };
+					}
+					return { target };
+				}),
+			);
+			const nativeScanPending = preparedTargets.some(prepared => prepared.result === undefined);
+			if (nativeScanPending && preparationController && signal) {
+				signal.removeEventListener("abort", abortPreparation);
+			}
+			throwIfAborted(signal);
+
 			const onUpdateMatches: string[] = [];
 			const onUpdateMtimes: number[] = [];
 			const updateIntervalMs = 200;
@@ -425,27 +475,9 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 				};
 
 			let timedOut = false;
-			const runTarget = async (target: GlobTarget): Promise<Array<{ path: string; mtime: number }>> => {
-				throwIfAborted(signal);
-				let stat: fs.Stats;
-				try {
-					stat = await fs.promises.stat(target.searchPath);
-				} catch (err) {
-					// ENAMETOOLONG can never name a real target; surface a clean
-					// "Path not found" instead of leaking the raw errno (issue #7597).
-					if (isEnoent(err) || hasFsCode(err, "ENAMETOOLONG")) {
-						if (isSingle) throw new ToolError(`Path not found: ${scopePath}`);
-						return [];
-					}
-					throw err;
-				}
-				if (!target.hasGlob && stat.isFile()) {
-					return [{ path: formatScopePath(target.searchPath), mtime: stat.mtimeMs }];
-				}
-				if (!stat.isDirectory()) {
-					if (isSingle) throw new ToolError(`Path is not a directory: ${target.searchPath}`);
-					return [];
-				}
+			const runTarget = async (prepared: NativePreparedTarget): Promise<Array<{ path: string; mtime: number }>> => {
+				if (prepared.result) return prepared.result;
+				const { target } = prepared;
 				try {
 					const result = await this.#nativeGlob(
 						{
@@ -495,7 +527,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 				}
 			};
 
-			const settledTargets = await Promise.allSettled(targets.map(runTarget));
+			const settledTargets = await Promise.allSettled(preparedTargets.map(runTarget));
 			const perTarget = settledTargets.map(result => {
 				if (result.status === "rejected") throw result.reason;
 				return result.value;
@@ -534,6 +566,9 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 			}
 			merged.sort((a, b) => b.mtime - a.mtime);
 			return buildResult(merged.map(entry => entry.path));
+		});
+		return execution.finally(() => {
+			signal?.removeEventListener("abort", abortPreparation);
 		});
 	}
 }

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -94,6 +94,10 @@ export interface GlobToolOptions {
 	operations?: GlobOperations;
 	/** Remap slash-only paths to the session cwd before root-search validation. */
 	rootPathAlias?: boolean;
+	/** Native glob binding. Override only in tests. */
+	nativeGlob?: typeof natives.glob;
+	/** Native and user-facing scan timeout. Override only in tests. */
+	timeoutMs?: number;
 }
 
 interface GlobTarget {
@@ -139,6 +143,8 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 
 	readonly #customOps?: GlobOperations;
 	readonly #rootPathAlias: boolean;
+	readonly #nativeGlob: typeof natives.glob;
+	readonly #timeoutMs: number;
 
 	constructor(
 		private readonly session: ToolSession,
@@ -146,6 +152,11 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 	) {
 		this.#customOps = options?.operations;
 		this.#rootPathAlias = options?.rootPathAlias === true;
+		this.#nativeGlob = options?.nativeGlob ?? natives.glob;
+		this.#timeoutMs = options?.timeoutMs ?? DEFAULT_GLOB_TIMEOUT_MS;
+		if (!Number.isFinite(this.#timeoutMs) || this.#timeoutMs <= 0) {
+			throw new TypeError("Glob timeout must be a positive number");
+		}
 	}
 
 	async execute(
@@ -157,7 +168,12 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 	): Promise<AgentToolResult<GlobToolDetails>> {
 		const { path: pathInput, limit, hidden, gitignore } = params;
 
-		return untilAborted(signal, async () => {
+		throwIfAborted(signal);
+		// Native scans receive the abort signal directly and must settle before
+		// execute returns. Custom operations have no signal API, so retain their
+		// immediate-abort wrapper.
+		const immediateAbortSignal = this.#customOps?.glob ? signal : undefined;
+		return untilAborted(immediateAbortSignal, async () => {
 			const formatScopePath = (targetPath: string): string => formatPathRelativeToCwd(targetPath, this.session.cwd);
 			const scopedPaths = toPathList(pathInput);
 			const effectivePaths = scopedPaths.length > 0 ? scopedPaths : ["."];
@@ -269,7 +285,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 			const effectiveLimit = Math.min(MAX_LIMIT, Math.max(1, Math.floor(requestedLimit)));
 			const includeHidden = hidden ?? true;
 			const useGitignore = gitignore ?? true;
-			const timeoutMs = DEFAULT_GLOB_TIMEOUT_MS;
+			const timeoutMs = this.#timeoutMs;
 			const timeoutSignal = AbortSignal.timeout(timeoutMs);
 			const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 			const formatMatchPath = (matchPath: string, base: string, fileType?: natives.FileType): string => {
@@ -431,26 +447,25 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 					return [];
 				}
 				try {
-					const result = await untilAborted(combinedSignal, () =>
-						natives.glob(
-							{
-								pattern: target.globPattern,
-								path: target.searchPath,
-								hidden: includeHidden,
-								maxResults: effectiveLimit,
-								sortByMtime: true,
-								gitignore: useGitignore,
-								// parseFindPattern explicitly prepends "**/" when the user's
-								// pattern begins with a glob (so `*.ts` becomes `**/*.ts`).
-								// Anything that arrives here without "**/" was scoped to a
-								// single directory by the user (e.g. `dir/*`); disable the
-								// native auto-recursion so `dir/*` does not silently match
-								// `dir/sub/nested.ts`.
-								recursive: false,
-								signal: combinedSignal,
-							},
-							makeOnMatch(target.searchPath),
-						),
+					const result = await this.#nativeGlob(
+						{
+							pattern: target.globPattern,
+							path: target.searchPath,
+							hidden: includeHidden,
+							maxResults: effectiveLimit,
+							sortByMtime: true,
+							gitignore: useGitignore,
+							// parseFindPattern explicitly prepends "**/" when the user's
+							// pattern begins with a glob (so `*.ts` becomes `**/*.ts`).
+							// Anything that arrives here without "**/" was scoped to a
+							// single directory by the user (e.g. `dir/*`); disable the
+							// native auto-recursion so `dir/*` does not silently match
+							// `dir/sub/nested.ts`.
+							recursive: false,
+							signal: combinedSignal,
+							timeoutMs,
+						},
+						makeOnMatch(target.searchPath),
 					);
 					throwIfAborted(signal);
 					const out: Array<{ path: string; mtime: number }> = [];
@@ -463,8 +478,14 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 					}
 					return out;
 				} catch (error) {
-					if (error instanceof Error && error.name === "AbortError") {
-						if (timeoutSignal.aborted && !signal?.aborted) {
+					const nativeAbort =
+						error instanceof Error &&
+						(error.name === "AbortError" || error.name === "TimeoutError" || error.message.includes("Aborted:"));
+					if (nativeAbort) {
+						if (
+							!signal?.aborted &&
+							(timeoutSignal.aborted || (error instanceof Error && error.message.includes("Aborted: Timeout")))
+						) {
 							timedOut = true;
 							return [];
 						}
@@ -474,7 +495,11 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 				}
 			};
 
-			const perTarget = await Promise.all(targets.map(runTarget));
+			const settledTargets = await Promise.allSettled(targets.map(runTarget));
+			const perTarget = settledTargets.map(result => {
+				if (result.status === "rejected") throw result.reason;
+				return result.value;
+			});
 
 			if (timedOut) {
 				// Drain the partial matches accumulated during streaming and return them

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { glob } from "@oh-my-pi/pi-natives";
-import { hasFsCode, isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix, untilAborted } from "@oh-my-pi/pi-utils";
+import { hasFsCode, isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -1343,19 +1343,16 @@ export async function findUniqueWorkspaceSuffix(
 
 	let matches: string[];
 	try {
-		const result = await untilAborted(combinedSignal, () =>
-			glob({
-				pattern: `**/${escapeGlobMetachars(normalized)}`,
-				path: cwd,
-				hidden: true,
-			}),
-		);
+		const result = await glob({
+			pattern: `**/${escapeGlobMetachars(normalized)}`,
+			path: cwd,
+			hidden: true,
+			signal: combinedSignal,
+			timeoutMs: WORKSPACE_SUFFIX_TIMEOUT_MS,
+		});
 		matches = result.matches.map(match => match.path);
-	} catch (error) {
-		if (error instanceof Error && error.name === "AbortError") {
-			if (!signal?.aborted) return null;
-			throw new ToolAbortError();
-		}
+	} catch {
+		if (signal?.aborted) throw new ToolAbortError();
 		return null;
 	}
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -1326,14 +1326,11 @@ function escapeGlobMetachars(value: string): string {
 	return value.replace(/[*?[{]/g, "[$&]");
 }
 
-/**
- * Find a unique workspace entry whose trailing path matches a missing authored path.
- * Returns `null` for no match, ambiguity, timeout, or scan failure.
- */
-export async function findUniqueWorkspaceSuffix(
+async function findUniqueWorkspaceSuffixWithGlob(
 	rawPath: string,
 	cwd: string,
-	signal?: AbortSignal,
+	signal: AbortSignal | undefined,
+	globImpl: typeof glob,
 ): Promise<{ absolutePath: string; displayPath: string } | null> {
 	const normalized = rawPath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
 	if (!normalized) return null;
@@ -1343,13 +1340,14 @@ export async function findUniqueWorkspaceSuffix(
 
 	let matches: string[];
 	try {
-		const result = await glob({
+		const result = await globImpl({
 			pattern: `**/${escapeGlobMetachars(normalized)}`,
 			path: cwd,
 			hidden: true,
 			signal: combinedSignal,
 			timeoutMs: WORKSPACE_SUFFIX_TIMEOUT_MS,
 		});
+		if (signal?.aborted) throw new ToolAbortError();
 		matches = result.matches.map(match => match.path);
 	} catch {
 		if (signal?.aborted) throw new ToolAbortError();
@@ -1361,6 +1359,28 @@ export async function findUniqueWorkspaceSuffix(
 		absolutePath: path.resolve(cwd, matches[0]),
 		displayPath: matches[0],
 	};
+}
+
+/**
+ * Find a unique workspace entry whose trailing path matches a missing authored path.
+ * Returns `null` for no match, ambiguity, timeout, or scan failure.
+ */
+export async function findUniqueWorkspaceSuffix(
+	rawPath: string,
+	cwd: string,
+	signal?: AbortSignal,
+): Promise<{ absolutePath: string; displayPath: string } | null> {
+	return findUniqueWorkspaceSuffixWithGlob(rawPath, cwd, signal, glob);
+}
+
+/** Exercise the post-native cancellation boundary without a real filesystem walk. */
+export async function findUniqueWorkspaceSuffixWithGlobForTest(
+	rawPath: string,
+	cwd: string,
+	signal: AbortSignal | undefined,
+	globImpl: typeof glob,
+): Promise<{ absolutePath: string; displayPath: string } | null> {
+	return findUniqueWorkspaceSuffixWithGlob(rawPath, cwd, signal, globImpl);
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1227,6 +1227,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			isDirectory = stat.isDirectory();
 		} catch (error) {
 			if (isNotFoundError(error)) {
+				// A documented semicolon list is explicit user scope, while suffix
+				// matching is only fuzzy recovery. Fan the list out before a broad
+				// workspace scan, but only after literal/archive/sqlite resolution so
+				// real resources containing semicolons retain precedence.
+				if (readPath.includes(";")) {
+					const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+					if (delimitedResult) return delimitedResult;
+				}
 				// Attempt unique suffix resolution before falling back to the approved-plan
 				// alias or fuzzy suggestions. Existing workspace files retain precedence.
 				if (!isRemoteMountPath(absolutePath)) {

--- a/packages/coding-agent/test/tools/glob.test.ts
+++ b/packages/coding-agent/test/tools/glob.test.ts
@@ -1,20 +1,24 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 import { Settings } from "../../src/config/settings";
 import type { ToolSession } from "../../src/tools";
 import { GlobTool } from "../../src/tools/glob";
-import { ToolError } from "../../src/tools/tool-errors";
+import { ToolAbortError, ToolError } from "../../src/tools/tool-errors";
 
-const ROOT_SEARCH_ERROR = "Searching from root directory '/' is not allowed";
-
-async function expectRootSearchRejected(searchPath: string): Promise<void> {
-	const session: ToolSession = {
-		cwd: process.cwd(),
+function createSession(cwd = process.cwd()): ToolSession {
+	return {
+		cwd,
 		hasUI: false,
 		settings: Settings.isolated({}),
 		getSessionFile: () => null,
 		getSessionSpawns: () => null,
 	};
-	const tool = new GlobTool(session);
+}
+
+const ROOT_SEARCH_ERROR = "Searching from root directory '/' is not allowed";
+
+async function expectRootSearchRejected(searchPath: string): Promise<void> {
+	const tool = new GlobTool(createSession());
 	let thrown: unknown;
 	try {
 		await tool.execute("glob-root-regression", { path: searchPath });
@@ -33,5 +37,102 @@ async function expectRootSearchRejected(searchPath: string): Promise<void> {
 describe("GlobTool.execute", () => {
 	test.each(["/", "//"])("rejects bare root search path %s", async searchPath => {
 		await expectRootSearchRejected(searchPath);
+	});
+
+	test("does not finish a timeout until the native scan has stopped", async () => {
+		const started = Promise.withResolvers<void>();
+		const timeoutObserved = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		let nativeSettled = false;
+		const tool = new GlobTool(createSession(), {
+			timeoutMs: 100,
+			nativeGlob: async options => {
+				const nativeSignal = options.signal as AbortSignal | undefined;
+				if (!nativeSignal) {
+					started.resolve();
+					timeoutObserved.resolve();
+					throw new Error("Missing native cancellation signal");
+				}
+				nativeSignal.addEventListener("abort", () => timeoutObserved.resolve(), { once: true });
+				started.resolve();
+				await timeoutObserved.promise;
+				await release.promise;
+				nativeSettled = true;
+				throw new Error("GenericFailure, Aborted: Timeout");
+			},
+		});
+
+		const execution = tool.execute("glob-timeout-cleanup", { path: "." });
+		await started.promise;
+		await timeoutObserved.promise;
+		const stateBeforeCleanup = await Promise.race([
+			execution.then(
+				() => "settled",
+				() => "settled",
+			),
+			Promise.resolve("pending"),
+		]);
+		expect(stateBeforeCleanup).toBe("pending");
+
+		release.resolve();
+		const result = await execution;
+
+		expect(nativeSettled).toBe(true);
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+		expect(text).toContain("Glob timed out after 0.1s");
+	});
+
+	test("waits for every native scan to settle before rejecting an abort", async () => {
+		const controller = new AbortController();
+		const allStarted = Promise.withResolvers<void>();
+		const allAborted = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		let startedCount = 0;
+		let abortedCount = 0;
+		let settledCount = 0;
+		const tool = new GlobTool(createSession(), {
+			timeoutMs: 5000,
+			nativeGlob: async options => {
+				const nativeSignal = options.signal as AbortSignal | undefined;
+				if (!nativeSignal) throw new Error("Missing native cancellation signal");
+				const abortObserved = Promise.withResolvers<void>();
+				nativeSignal.addEventListener(
+					"abort",
+					() => {
+						abortedCount += 1;
+						if (abortedCount === 2) allAborted.resolve();
+						abortObserved.resolve();
+					},
+					{ once: true },
+				);
+				startedCount += 1;
+				if (startedCount === 2) allStarted.resolve();
+				await abortObserved.promise;
+				await release.promise;
+				settledCount += 1;
+				throw new Error("GenericFailure, Aborted: Signal");
+			},
+		});
+		const execution = tool.execute(
+			"glob-abort-cleanup",
+			{ path: `.; ${path.dirname(process.cwd())}` },
+			controller.signal,
+		);
+
+		await allStarted.promise;
+		controller.abort();
+		await allAborted.promise;
+		const stateBeforeCleanup = await Promise.race([
+			execution.then(
+				() => "settled",
+				() => "settled",
+			),
+			Promise.resolve("pending"),
+		]);
+		expect(stateBeforeCleanup).toBe("pending");
+
+		release.resolve();
+		await expect(execution).rejects.toBeInstanceOf(ToolAbortError);
+		expect(settledCount).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/tools/glob.test.ts
+++ b/packages/coding-agent/test/tools/glob.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
+import { FileType } from "@oh-my-pi/pi-natives";
 import { Settings } from "../../src/config/settings";
 import type { ToolSession } from "../../src/tools";
 import { GlobTool } from "../../src/tools/glob";
+import { findUniqueWorkspaceSuffixWithGlobForTest } from "../../src/tools/path-utils";
 import { ToolAbortError, ToolError } from "../../src/tools/tool-errors";
 
 function createSession(cwd = process.cwd()): ToolSession {
@@ -39,6 +41,41 @@ describe("GlobTool.execute", () => {
 		await expectRootSearchRejected(searchPath);
 	});
 
+	test("rejects a caller abort during preparation without launching a native scan", async () => {
+		const controller = new AbortController();
+		const statStarted = Promise.withResolvers<void>();
+		const releaseStat = Promise.withResolvers<void>();
+		const statSettled = Promise.withResolvers<void>();
+		let nativeStarted = false;
+		const tool = new GlobTool(createSession(), {
+			stat: async () => {
+				statStarted.resolve();
+				try {
+					await releaseStat.promise;
+					throw new Error("Released blocked stat");
+				} finally {
+					statSettled.resolve();
+				}
+			},
+			nativeGlob: async () => {
+				nativeStarted = true;
+				return { matches: [], totalMatches: 0 };
+			},
+		});
+		const execution = tool.execute("glob-preparation-abort", { path: "." }, controller.signal);
+
+		await statStarted.promise;
+		try {
+			controller.abort();
+			await expect(execution).rejects.toThrow("Aborted");
+			expect(nativeStarted).toBe(false);
+		} finally {
+			releaseStat.resolve();
+			await statSettled.promise;
+		}
+		expect(nativeStarted).toBe(false);
+	});
+
 	test("does not finish a timeout until the native scan has stopped", async () => {
 		const started = Promise.withResolvers<void>();
 		const timeoutObserved = Promise.withResolvers<void>();
@@ -47,12 +84,12 @@ describe("GlobTool.execute", () => {
 		const tool = new GlobTool(createSession(), {
 			timeoutMs: 100,
 			nativeGlob: async options => {
-				const nativeSignal = options.signal as AbortSignal | undefined;
-				if (!nativeSignal) {
+				if (!(options.signal instanceof AbortSignal)) {
 					started.resolve();
 					timeoutObserved.resolve();
 					throw new Error("Missing native cancellation signal");
 				}
+				const nativeSignal = options.signal;
 				nativeSignal.addEventListener("abort", () => timeoutObserved.resolve(), { once: true });
 				started.resolve();
 				await timeoutObserved.promise;
@@ -93,8 +130,8 @@ describe("GlobTool.execute", () => {
 		const tool = new GlobTool(createSession(), {
 			timeoutMs: 5000,
 			nativeGlob: async options => {
-				const nativeSignal = options.signal as AbortSignal | undefined;
-				if (!nativeSignal) throw new Error("Missing native cancellation signal");
+				if (!(options.signal instanceof AbortSignal)) throw new Error("Missing native cancellation signal");
+				const nativeSignal = options.signal;
 				const abortObserved = Promise.withResolvers<void>();
 				nativeSignal.addEventListener(
 					"abort",
@@ -134,5 +171,28 @@ describe("GlobTool.execute", () => {
 		release.resolve();
 		await expect(execution).rejects.toBeInstanceOf(ToolAbortError);
 		expect(settledCount).toBe(2);
+	});
+	test("suffix recovery rejects a caller abort after native completion", async () => {
+		const controller = new AbortController();
+		const nativeCompleted = Promise.withResolvers<void>();
+		const releaseResult = Promise.withResolvers<void>();
+		const execution = findUniqueWorkspaceSuffixWithGlobForTest(
+			"target.ts",
+			"/workspace",
+			controller.signal,
+			async () => {
+				nativeCompleted.resolve();
+				await releaseResult.promise;
+				return {
+					matches: [{ path: "nested/target.ts", fileType: FileType.File }],
+					totalMatches: 1,
+				};
+			},
+		);
+
+		await nativeCompleted.promise;
+		controller.abort();
+		releaseResult.resolve();
+		await expect(execution).rejects.toBeInstanceOf(ToolAbortError);
 	});
 });

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -536,6 +536,32 @@ describe("tool path arrays", () => {
 		expect(details?.notes).toEqual(["Note: interpreted as 2 paths: apps/grep.txt, packages/grep.txt"]);
 	});
 
+	it("read treats semicolon lists as explicit scope before fuzzy suffix recovery", async () => {
+		const decoyRoot = path.join(tempDir, "decoy");
+		const decoyPath = path.join(decoyRoot, "apps", "grep.txt; packages", "grep.txt");
+		await fs.mkdir(path.dirname(decoyPath), { recursive: true });
+		await Bun.write(decoyPath, "fuzzy-decoy\n");
+
+		try {
+			const tools = await createTools(createTestSession(tempDir));
+			const tool = tools.find(entry => entry.name === "read");
+			expect(tool).toBeDefined();
+			if (!tool) throw new Error("Missing read tool");
+
+			const result = await tool.execute("read-semicolon-delimited", {
+				path: "apps/grep.txt; packages/grep.txt",
+			});
+			const text = getText(result);
+
+			expect(text).toContain("Note: interpreted as 2 paths: apps/grep.txt, packages/grep.txt");
+			expect(text).toContain("shared-needle apps");
+			expect(text).toContain("shared-needle packages");
+			expect(text).not.toContain("fuzzy-decoy");
+		} finally {
+			await removeWithRetries(decoyRoot);
+		}
+	});
+
 	it("read keeps readable delimited paths when peers are missing", async () => {
 		const tools = await createTools(createTestSession(tempDir));
 		const tool = tools.find(entry => entry.name === "read");


### PR DESCRIPTION
## Problem

`GlobTool` can return after its JavaScript timeout or abort while one or more native filesystem scans keep walking. The agent remains busy and later input queues behind the abandoned native work. The same failure is reachable through `read` when a semicolon-delimited path list falls into fuzzy suffix recovery.

Contributor statement from Matthew, in his own words:

> My conductor keeps freezing for me—it looks like it takes 30 or 40 minutes before it becomes active again.

Matthew has asked me to open this PR and will review the submitted diff and behavior.

## Change

- pass the combined timeout/user abort signal into every native glob scan
- wait for all parallel native scans to settle before returning or rejecting
- classify native abort/timeout errors consistently while retaining already streamed matches
- resolve explicit semicolon-delimited `read` paths before fuzzy suffix search
- pass cancellation through `read` suffix recovery
- add timeout, user-abort, parallel-drain, and multi-read regressions
- document the fix in the coding-agent changelog

## Verification

- focused glob and path-list suites: 35 passed, 0 failed
- coding-agent TypeScript/package check passed
- pre-fix slow-filesystem smoke reproduced a timed-out call whose native worker continued scanning
- patched smoke returned after cleanup and an immediate follow-up glob completed normally
- compiled `omp read 'fileA:range; fileB:range'` smoke returned both files with exit 0 in 1.393s
- the patched binary has also resumed the affected live conductor session successfully