### PR TITLE
fix(ai): preserve Codex turn state across continuations

### DIFF
--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -1285,14 +1285,16 @@ describe("Responses Lite remote compaction", () => {
 		}
 	});
 
-	test("V2 compaction over WebSocket captures a refreshed mid-turn x-codex-turn-state", async () => {
+	test("V2 compaction over WebSocket keeps the first mid-turn x-codex-turn-state", async () => {
 		const midTurnCompaction = { ...TEST_CODEX_COMPACTION, phase: "mid_turn" as const };
 		const providerSessionState = new Map<string, ProviderSessionState>();
 		let responseCount = 0;
 		const webSocket = installCodexCompactionWebSocket({
 			respond: socket => {
 				responseCount += 1;
-				socket.emit({ type: "response.metadata", headers: { "x-codex-turn-state": "refreshed-turn-state" } });
+				// The handshake already seeded `compaction-state-0`; a later
+				// response value must not replace the turn's first sticky token.
+				socket.emit({ type: "response.metadata", headers: { "x-codex-turn-state": "later-turn-state" } });
 				for (const event of compactionV2Events(`enc-metadata-${responseCount}`)) socket.emit(event);
 			},
 		});
@@ -1319,7 +1321,7 @@ describe("Responses Lite remote compaction", () => {
 			const clientMetadata = isRecord(secondRequest?.client_metadata) ? secondRequest.client_metadata : undefined;
 			expect(webSocket.sockets).toHaveLength(1);
 			expect(webSocket.sockets[0]?.sent).toHaveLength(2);
-			expect(clientMetadata?.["x-codex-turn-state"]).toBe("refreshed-turn-state");
+			expect(clientMetadata?.["x-codex-turn-state"]).toBe("compaction-state-0");
 			expect(getOpenAICodexTransportDetails(model, { sessionId, providerSessionState })).toMatchObject({
 				hasTurnState: true,
 			});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex continuations, retries, and compaction replacing or dropping the turn-scoped sticky-routing token ([#9277](https://github.com/can1357/oh-my-pi/issues/9277)).
+
 ## [17.4.2] - 2026-08-21
 
 ### Added

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -491,7 +491,7 @@ interface CodexMetadataSessionState {
 	turnStartedAtUnixMs?: number;
 	compactionOperationId?: string;
 	reuseTurnForNextRequest?: boolean;
-	turnState: CodexTurnStateCell;
+	turnStates: Map<string, CodexTurnStateCell>;
 }
 
 interface CodexCompatibilityIdentity {
@@ -544,7 +544,7 @@ function createCodexMetadataSessionState(sessionId: string): CodexMetadataSessio
 		sessionId,
 		threadId: crypto.randomUUID(),
 		windowId: crypto.randomUUID(),
-		turnState: {},
+		turnStates: new Map(),
 	};
 }
 
@@ -557,6 +557,18 @@ function getOrCreateCodexMetadataSessionState(
 	if (existing) return existing;
 	const created = createCodexMetadataSessionState(sessionId);
 	providerState.metadataSessions.set(sessionId, created);
+	return created;
+}
+
+function getOrCreateCodexTurnState(
+	session: CodexMetadataSessionState,
+	compatibilityKey: string | undefined,
+): CodexTurnStateCell {
+	if (!compatibilityKey) return {};
+	const existing = session.turnStates.get(compatibilityKey);
+	if (existing) return existing;
+	const created: CodexTurnStateCell = {};
+	session.turnStates.set(compatibilityKey, created);
 	return created;
 }
 
@@ -1456,12 +1468,13 @@ function createCodexRequestContext(
 	const metadataSessionId = transportSessionId ?? crypto.randomUUID();
 	const metadataSession = getOrCreateCodexMetadataSessionState(metadataSessionId, providerSessionState);
 	const compaction = options?.codexCompaction;
-	// Standalone compaction owns a throwaway turn. Pre-turn compaction starts
-	// the live turn that the next sampling request deliberately reuses.
-	const turnState = compaction?.phase === "standalone_turn" ? {} : metadataSession.turnState;
 	const requestKind: OpenAICodexRequestKind = compaction ? "compaction" : "turn";
 	const startNewTurn = resolveCodexStartNewTurn(metadataSession, requestKind, compaction, contextOptions.startNewTurn);
-	if (startNewTurn) turnState.value = undefined;
+	const standaloneCompaction = compaction?.phase === "standalone_turn";
+	if (startNewTurn && !standaloneCompaction) metadataSession.turnStates.clear();
+	// Standalone compaction owns a throwaway turn. Every live cell is isolated by
+	// the same credential/backend/model/Lite key as its transport session.
+	const turnState = standaloneCompaction ? {} : getOrCreateCodexTurnState(metadataSession, sessionKey);
 	const requestMetadata = createCodexRequestMetadata(metadataSession, requestKind, {
 		startNewTurn,
 		turnStartedAtUnixMs: compaction
@@ -3000,6 +3013,7 @@ export async function prewarmOpenAICodexResponses(
 		transportSessionId ?? crypto.randomUUID(),
 		providerSessionState,
 	);
+	const turnState = getOrCreateCodexTurnState(metadataSession, sessionKey);
 	const codexClientVersion = CODEX_CLIENT_VERSION;
 	const requestIdentity = createCodexCompatibilityIdentity(metadataSession);
 	const attestation = await getCodexAttestationHeader(accountId);
@@ -3013,7 +3027,7 @@ export async function prewarmOpenAICodexResponses(
 		promptCacheKey,
 		"websocket",
 		state,
-		metadataSession.turnState,
+		turnState,
 		responsesLite,
 		requestIdentity,
 		attestation,
@@ -3022,7 +3036,7 @@ export async function prewarmOpenAICodexResponses(
 		"prewarmCodex:establishWs",
 		getOrCreateCodexWebSocketConnection,
 		state,
-		metadataSession.turnState,
+		turnState,
 		toWebSocketUrl(url),
 		headers,
 		model.provider,
@@ -3181,8 +3195,17 @@ export function getOpenAICodexTransportDetails(
 	const state = getCodexWebSocketStateForPublicSession(model, options);
 	const providerSessionState = getCodexProviderSessionState(options?.providerSessionState);
 	const sessionId = normalizeOpenAIPromptCacheKey(options?.sessionId);
-	const hasTurnState =
-		sessionId !== undefined && providerSessionState?.metadataSessions.get(sessionId)?.turnState.value !== undefined;
+	let hasTurnState = false;
+	if (sessionId) {
+		const metadataSession = providerSessionState?.metadataSessions.get(sessionId);
+		if (metadataSession) {
+			for (const cell of metadataSession.turnStates.values()) {
+				if (cell.value === undefined) continue;
+				hasTurnState = true;
+				break;
+			}
+		}
+	}
 
 	return {
 		websocketPreferred,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -572,6 +572,21 @@ function getOrCreateCodexTurnState(
 	return created;
 }
 
+/**
+ * Drop every compatibility-scoped sticky-routing token when a fresh logical
+ * turn begins, mirroring codex-rs's per-turn `OnceLock`. Standalone compaction
+ * owns a throwaway cell, so it never disturbs the live turn's tokens. Runs on
+ * every entry path that opens a turn — the normal stream (`createCodexRequestContext`)
+ * and the raw compaction routes (`createOpenAICodexCompatibilityMetadata`).
+ */
+function clearCodexTurnStatesForNewTurn(
+	session: CodexMetadataSessionState,
+	startNewTurn: boolean,
+	compaction: CodexCompactionRequestContext | undefined,
+): void {
+	if (startNewTurn && compaction?.phase !== "standalone_turn") session.turnStates.clear();
+}
+
 function createCodexCompatibilityIdentity(session: CodexMetadataSessionState): CodexCompatibilityIdentity {
 	return {
 		installationId: getInstallId(),
@@ -717,6 +732,7 @@ export function createOpenAICodexCompatibilityMetadata(
 		options.compaction,
 		options.startNewTurn,
 	);
+	clearCodexTurnStatesForNewTurn(session, startNewTurn, options.compaction);
 	const metadata = createCodexRequestMetadata(session, options.requestKind, {
 		startNewTurn,
 		turnStartedAtUnixMs: options.turnStartedAtUnixMs ?? (startNewTurn || !session.turnId ? Date.now() : undefined),
@@ -1471,7 +1487,7 @@ function createCodexRequestContext(
 	const requestKind: OpenAICodexRequestKind = compaction ? "compaction" : "turn";
 	const startNewTurn = resolveCodexStartNewTurn(metadataSession, requestKind, compaction, contextOptions.startNewTurn);
 	const standaloneCompaction = compaction?.phase === "standalone_turn";
-	if (startNewTurn && !standaloneCompaction) metadataSession.turnStates.clear();
+	clearCodexTurnStatesForNewTurn(metadataSession, startNewTurn, compaction);
 	// Standalone compaction owns a throwaway turn. Every live cell is isolated by
 	// the same credential/backend/model/Lite key as its transport session.
 	const turnState = standaloneCompaction ? {} : getOrCreateCodexTurnState(metadataSession, sessionKey);

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -451,10 +451,9 @@ export interface OpenAICodexWebSocketDebugStats {
 }
 
 /**
- * Per-session transport state shared by BOTH transports: websocket turn
- * chaining (`previous_response_id` baseline), turn-state/models-etag headers,
- * websocket connection pooling, and debug stats. The name is historical — SSE-only
- * sessions use it too.
+ * Per-session transport state shared by both transports: WebSocket turn
+ * chaining, models-etag headers, connection pooling, and debug stats. The name
+ * is historical — SSE-only sessions use it too.
  */
 type CodexWebSocketSessionState = {
 	disableWebsocket: boolean;
@@ -462,7 +461,6 @@ type CodexWebSocketSessionState = {
 	lastResponseId?: string;
 	lastResponseItems?: InputItem[];
 	canAppend: boolean;
-	turnState?: string;
 	modelsEtag?: string;
 	connection?: CodexWebSocketConnection;
 	lastTransport?: CodexTransport;
@@ -471,6 +469,10 @@ type CodexWebSocketSessionState = {
 	prewarmed: boolean;
 	stats: OpenAICodexWebSocketDebugStats;
 };
+
+interface CodexTurnStateCell {
+	value?: string;
+}
 
 interface CodexProviderSessionState extends ProviderSessionState {
 	webSocketSessions: Map<string, CodexWebSocketSessionState>;
@@ -489,6 +491,7 @@ interface CodexMetadataSessionState {
 	turnStartedAtUnixMs?: number;
 	compactionOperationId?: string;
 	reuseTurnForNextRequest?: boolean;
+	turnState: CodexTurnStateCell;
 }
 
 interface CodexCompatibilityIdentity {
@@ -541,6 +544,7 @@ function createCodexMetadataSessionState(sessionId: string): CodexMetadataSessio
 		sessionId,
 		threadId: crypto.randomUUID(),
 		windowId: crypto.randomUUID(),
+		turnState: {},
 	};
 }
 
@@ -728,7 +732,6 @@ export function resetOpenAICodexHistoryAfterCompaction(options: OpenAICodexCompa
 	if (!isCodexProviderSessionState(providerState)) return;
 	for (const websocketState of providerState.webSocketSessions.values()) {
 		resetCodexWebSocketAppendState(websocketState);
-		if (options.compaction.phase !== "mid_turn") websocketState.turnState = undefined;
 	}
 	const sessionId = normalizeOpenAIPromptCacheKey(options.sessionId);
 	if (!sessionId) return;
@@ -750,6 +753,7 @@ interface CodexRequestContext {
 	providerSessionState?: CodexProviderSessionState;
 	isolatedTransportState?: CodexProviderSessionState;
 	websocketState?: CodexWebSocketSessionState;
+	turnState: CodexTurnStateCell;
 	responsesLite: boolean;
 	requestMetadata?: CodexRequestMetadata;
 	transformedBody: RequestBody;
@@ -1112,17 +1116,18 @@ function toCodexHeaders(value: unknown): Headers | undefined {
 }
 
 function updateCodexSessionMetadataFromHeaders(
+	turnState: CodexTurnStateCell | undefined,
 	state: CodexWebSocketSessionState | undefined,
 	headers: Headers | Record<string, string> | null | undefined,
 ): void {
-	if (!state || !headers) return;
+	if ((!turnState && !state) || !headers) return;
 	const resolvedHeaders = headers instanceof Headers ? headers : new Headers(headers);
-	const turnState = resolvedHeaders.get(X_CODEX_TURN_STATE_HEADER);
-	if (turnState && turnState.length > 0) {
-		state.turnState = turnState;
+	const responseTurnState = resolvedHeaders.get(X_CODEX_TURN_STATE_HEADER);
+	if (turnState && turnState.value === undefined && responseTurnState && responseTurnState.length > 0) {
+		turnState.value = responseTurnState;
 	}
 	const modelsEtag = resolvedHeaders.get(X_MODELS_ETAG_HEADER);
-	if (modelsEtag && modelsEtag.length > 0) {
+	if (state && modelsEtag && modelsEtag.length > 0) {
 		state.modelsEtag = modelsEtag;
 	}
 }
@@ -1446,19 +1451,17 @@ function createCodexRequestContext(
 			: sharedWebsocketState;
 	if (isolatedTransportState && websocketState && sharedWebsocketState) {
 		websocketState.disableWebsocket = sharedWebsocketState.disableWebsocket;
-		websocketState.turnState = sharedWebsocketState.turnState;
 		websocketState.modelsEtag = sharedWebsocketState.modelsEtag;
 	}
 	const metadataSessionId = transportSessionId ?? crypto.randomUUID();
 	const metadataSession = getOrCreateCodexMetadataSessionState(metadataSessionId, providerSessionState);
 	const compaction = options?.codexCompaction;
+	// Standalone compaction owns a throwaway turn. Pre-turn compaction starts
+	// the live turn that the next sampling request deliberately reuses.
+	const turnState = compaction?.phase === "standalone_turn" ? {} : metadataSession.turnState;
 	const requestKind: OpenAICodexRequestKind = compaction ? "compaction" : "turn";
 	const startNewTurn = resolveCodexStartNewTurn(metadataSession, requestKind, compaction, contextOptions.startNewTurn);
-	if (websocketState && startNewTurn) {
-		// Codex scopes turn-state to one turn. Mid-turn compaction preserves it;
-		// a pre-turn or standalone compaction starts without it.
-		websocketState.turnState = undefined;
-	}
+	if (startNewTurn) turnState.value = undefined;
 	const requestMetadata = createCodexRequestMetadata(metadataSession, requestKind, {
 		startNewTurn,
 		turnStartedAtUnixMs: compaction
@@ -1482,6 +1485,7 @@ function createCodexRequestContext(
 		providerSessionState,
 		isolatedTransportState,
 		websocketState,
+		turnState,
 		responsesLite,
 		requestMetadata,
 		codexClientVersion,
@@ -1669,7 +1673,7 @@ async function* streamCodexCompactionEvents(
 ): AsyncGenerator<Record<string, unknown>> {
 	let completed = false;
 	const websocketState = requestContext.websocketState;
-	const previousTurnState = websocketState?.turnState;
+	const previousTurnState = requestContext.turnState.value;
 	const previousModelsEtag = websocketState?.modelsEtag;
 	try {
 		if (initial.transport === "websocket") {
@@ -1686,50 +1690,51 @@ async function* streamCodexCompactionEvents(
 				if (state) recordCodexWebSocketFailure(state, true);
 				const fallback = await openCodexSseTransport(model, requestContext, requestSetup, options, state);
 				if (state) state.lastTransport = fallback.transport;
-				yield* drainCodexCompactionEvents(fallback.eventStream, requestContext.websocketState);
+				yield* drainCodexCompactionEvents(fallback.eventStream, requestContext);
 				completed = true;
 				return;
 			}
 			// Apply metadata only once the WebSocket attempt succeeded: a discarded
 			// attempt must not leak its `x-codex-turn-state` into the session.
 			for (const event of bufferedEvents) {
-				applyCodexCompactionResponseMetadata(requestContext.websocketState, event);
+				applyCodexCompactionResponseMetadata(requestContext, event);
 				yield event;
 			}
 		} else {
-			yield* drainCodexCompactionEvents(initial.eventStream, requestContext.websocketState);
+			yield* drainCodexCompactionEvents(initial.eventStream, requestContext);
 		}
 		completed = true;
 	} finally {
 		if (!completed) {
 			requestSetup.requestAbortController.abort();
-			if (websocketState) {
-				websocketState.turnState = previousTurnState;
-				websocketState.modelsEtag = previousModelsEtag;
-			}
+			requestContext.turnState.value = previousTurnState;
+			if (websocketState) websocketState.modelsEtag = previousModelsEtag;
 		}
 	}
 }
 
 /**
- * Capture `x-codex-turn-state`/`x-models-etag` refreshes carried by a
- * `response.metadata` frame so a mid-turn compaction leaves the live session on
- * the latest turn state, matching the normal Codex stream processor.
+ * Capture `x-codex-turn-state`/`x-models-etag` response metadata after a
+ * compaction attempt succeeds.
  */
 function applyCodexCompactionResponseMetadata(
-	state: CodexWebSocketSessionState | undefined,
+	requestContext: CodexRequestContext,
 	event: Record<string, unknown>,
 ): void {
-	if (!state || event.type !== "response.metadata") return;
-	updateCodexSessionMetadataFromHeaders(state, toCodexHeaders(event.headers));
+	if (event.type !== "response.metadata") return;
+	updateCodexSessionMetadataFromHeaders(
+		requestContext.turnState,
+		requestContext.websocketState,
+		toCodexHeaders(event.headers),
+	);
 }
 
 async function* drainCodexCompactionEvents(
 	events: AsyncGenerator<Record<string, unknown>>,
-	state: CodexWebSocketSessionState | undefined,
+	requestContext: CodexRequestContext,
 ): AsyncGenerator<Record<string, unknown>> {
 	for await (const event of events) {
-		applyCodexCompactionResponseMetadata(state, event);
+		applyCodexCompactionResponseMetadata(requestContext, event);
 		yield event;
 	}
 }
@@ -1756,8 +1761,8 @@ async function openCodexWebSocketTransport(
 	if (requestContext.responsesLite) {
 		websocketClientMetadata[CODEX_WS_RESPONSES_LITE_CLIENT_METADATA_KEY] = "true";
 	}
-	if (websocketState.turnState) {
-		websocketClientMetadata[X_CODEX_TURN_STATE_HEADER] = websocketState.turnState;
+	if (requestContext.turnState.value) {
+		websocketClientMetadata[X_CODEX_TURN_STATE_HEADER] = requestContext.turnState.value;
 	}
 	let websocketRequest = {
 		type: "response.create",
@@ -1777,6 +1782,7 @@ async function openCodexWebSocketTransport(
 		requestContext.transportSessionId,
 		"websocket",
 		websocketState,
+		requestContext.turnState,
 		requestContext.responsesLite,
 		requestContext.requestMetadata,
 		await getCodexAttestationHeader(requestContext.accountId),
@@ -1805,6 +1811,7 @@ async function openCodexWebSocketTransport(
 		});
 	const websocketConnection = await getOrCreateCodexWebSocketConnection(
 		websocketState,
+		requestContext.turnState,
 		toWebSocketUrl(requestContext.url),
 		websocketHeaders,
 		model.provider,
@@ -1875,6 +1882,7 @@ async function openCodexSseTransport(
 				requestContext.transportSessionId,
 				wireBody,
 				state,
+				requestContext.turnState,
 				requestContext.responsesLite,
 				requestContext.codexClientVersion,
 				requestContext.requestMetadata,
@@ -1988,7 +1996,6 @@ async function handleCodexStreamFailure(context: CodexStreamFailureContext, erro
 	const { output } = context;
 	if (context.requestContext.websocketState) {
 		resetCodexWebSocketAppendState(context.requestContext.websocketState);
-		context.requestContext.websocketState.turnState = undefined;
 		context.requestContext.websocketState.modelsEtag = undefined;
 	}
 	const result = await AIError.finalize(error, {
@@ -2274,9 +2281,13 @@ class CodexStreamProcessor {
 			// The WebSocket transport has no per-response HTTP headers; codex-rs
 			// mirrors them into this event's `headers` and reads
 			// `x-codex-turn-state` from there (ResponsesStreamEvent::turn_state).
-			// Pick up the refresh so same-turn follow-ups echo the latest turn
-			// state on either transport.
-			updateCodexSessionMetadataFromHeaders(this.requestContext.websocketState, toCodexHeaders(rawEvent.headers));
+			// Capture only the first non-empty value so same-turn follow-ups keep
+			// the server's original sticky-routing token on either transport.
+			updateCodexSessionMetadataFromHeaders(
+				this.requestContext.turnState,
+				this.requestContext.websocketState,
+				toCodexHeaders(rawEvent.headers),
+			);
 			const moderation = asRecord(rawEvent.metadata)?.[CODEX_MODERATION_METADATA_KEY];
 			if (moderation !== undefined) {
 				try {
@@ -2545,7 +2556,6 @@ class CodexStreamProcessor {
 		const websocketState = this.requestContext.websocketState;
 		if (websocketState) {
 			resetCodexWebSocketAppendState(websocketState);
-			websocketState.turnState = undefined;
 			websocketState.modelsEtag = undefined;
 		}
 
@@ -2671,7 +2681,6 @@ class CodexStreamProcessor {
 
 		this.runtime.providerRetryAttempt += 1;
 		resetCodexWebSocketAppendState(websocketState);
-		websocketState.turnState = undefined;
 		websocketState.modelsEtag = undefined;
 		this.runtime.resetAccumulators();
 		this.runtime.sawTerminalEvent = false;
@@ -2755,7 +2764,6 @@ class CodexStreamProcessor {
 		const websocketState = this.requestContext.websocketState;
 		if (websocketState) {
 			resetCodexWebSocketAppendState(websocketState);
-			websocketState.turnState = undefined;
 			websocketState.modelsEtag = undefined;
 		}
 
@@ -2832,7 +2840,6 @@ class CodexStreamProcessor {
 		if (!this.runtime.sawTerminalEvent) {
 			if (this.requestContext.websocketState) {
 				resetCodexWebSocketAppendState(this.requestContext.websocketState);
-				this.requestContext.websocketState.turnState = undefined;
 				this.requestContext.websocketState.modelsEtag = undefined;
 			}
 			CODEX_DEBUG &&
@@ -2840,7 +2847,7 @@ class CodexStreamProcessor {
 					transport: this.runtime.transport,
 					terminalEventSeen: this.runtime.sawTerminalEvent,
 					unexpectedStreamEnd: true,
-					sentTurnStateHeader: Boolean(this.requestContext.websocketState?.turnState),
+					sentTurnStateHeader: Boolean(this.requestContext.turnState.value),
 					sentModelsEtagHeader: Boolean(this.requestContext.websocketState?.modelsEtag),
 				});
 			throw new CodexProviderStreamError("Codex stream ended before terminal completion event", false);
@@ -2929,6 +2936,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						url: "",
 						requestHeaders: {},
 						codexClientVersion: CODEX_CLIENT_VERSION,
+						turnState: {},
 						responsesLite: options?.responsesLite === true,
 						transformedBody: { model: model.id },
 						rawRequestDump: {
@@ -3005,6 +3013,7 @@ export async function prewarmOpenAICodexResponses(
 		promptCacheKey,
 		"websocket",
 		state,
+		metadataSession.turnState,
 		responsesLite,
 		requestIdentity,
 		attestation,
@@ -3013,6 +3022,7 @@ export async function prewarmOpenAICodexResponses(
 		"prewarmCodex:establishWs",
 		getOrCreateCodexWebSocketConnection,
 		state,
+		metadataSession.turnState,
 		toWebSocketUrl(url),
 		headers,
 		model.provider,
@@ -3169,6 +3179,10 @@ export function getOpenAICodexTransportDetails(
 				? false
 				: options?.preferWebsockets === true || model.preferWebsockets === true;
 	const state = getCodexWebSocketStateForPublicSession(model, options);
+	const providerSessionState = getCodexProviderSessionState(options?.providerSessionState);
+	const sessionId = normalizeOpenAIPromptCacheKey(options?.sessionId);
+	const hasTurnState =
+		sessionId !== undefined && providerSessionState?.metadataSessions.get(sessionId)?.turnState.value !== undefined;
 
 	return {
 		websocketPreferred,
@@ -3179,7 +3193,7 @@ export function getOpenAICodexTransportDetails(
 		canAppend: state?.canAppend ?? false,
 		prewarmed: state?.prewarmed ?? false,
 		hasSessionState: state !== undefined,
-		hasTurnState: state?.turnState !== undefined,
+		hasTurnState,
 		lastFallbackAt: state?.lastFallbackAt,
 	};
 }
@@ -3435,11 +3449,9 @@ function buildCodexChainedRequestBody(
 		// mutated or options changed — break the chain.
 		CODEX_DEBUG &&
 			logger.debug("[codex] codex append reset", {
-				hadTurnStateHeader: Boolean(state.turnState),
 				hadModelsEtagHeader: Boolean(state.modelsEtag),
 			});
 		resetCodexWebSocketAppendState(state);
-		state.turnState = undefined;
 		state.modelsEtag = undefined;
 	}
 	return requestBody;
@@ -4058,6 +4070,7 @@ class CodexWebSocketConnection {
 
 async function getOrCreateCodexWebSocketConnection(
 	state: CodexWebSocketSessionState,
+	turnState: CodexTurnStateCell,
 	url: string,
 	headers: Headers,
 	provider: string,
@@ -4104,7 +4117,7 @@ async function getOrCreateCodexWebSocketConnection(
 	logger.time("codexWs:newSocket");
 	state.connection = new CodexWebSocketConnection(url, headerRecord, {
 		onHandshakeHeaders: handshakeHeaders => {
-			updateCodexSessionMetadataFromHeaders(state, handshakeHeaders);
+			updateCodexSessionMetadataFromHeaders(turnState, state, handshakeHeaders);
 		},
 		proxy,
 	});
@@ -4138,6 +4151,7 @@ async function openCodexSseEventStream(
 	sessionId: string | undefined,
 	body: RequestBody,
 	state: CodexWebSocketSessionState | undefined,
+	turnState: CodexTurnStateCell,
 	responsesLite: boolean,
 	codexClientVersion: string,
 	requestMetadata: CodexRequestMetadata | undefined,
@@ -4155,6 +4169,7 @@ async function openCodexSseEventStream(
 		sessionId,
 		"sse",
 		state,
+		turnState,
 		responsesLite,
 		requestMetadata,
 		await getCodexAttestationHeader(accountId),
@@ -4231,7 +4246,7 @@ async function openCodexSseEventStream(
 	if (!response.ok) {
 		throw await CodexApiError.fromResponse(response);
 	}
-	updateCodexSessionMetadataFromHeaders(state, response.headers);
+	updateCodexSessionMetadataFromHeaders(turnState, state, response.headers);
 	if (!response.body) {
 		throw new CodexProviderStreamError("No response body", false);
 	}
@@ -4248,6 +4263,7 @@ function createCodexHeaders(
 	sessionId?: string,
 	transport: CodexTransport = "sse",
 	state?: CodexWebSocketSessionState,
+	turnState?: CodexTurnStateCell,
 	responsesLite = false,
 	requestMetadata?: CodexCompatibilityIdentity,
 	attestation?: string,
@@ -4295,8 +4311,8 @@ function createCodexHeaders(
 		headers.delete(OPENAI_HEADERS.WINDOW_ID);
 		headers.delete(OPENAI_HEADERS.TURN_METADATA);
 	}
-	if (state?.turnState) {
-		headers.set(X_CODEX_TURN_STATE_HEADER, state.turnState);
+	if (turnState?.value) {
+		headers.set(X_CODEX_TURN_STATE_HEADER, turnState.value);
 	} else {
 		headers.delete(X_CODEX_TURN_STATE_HEADER);
 	}

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -5436,6 +5436,112 @@ describe("openai-codex streaming", () => {
 		expect(requestTurnStates).toEqual([null, "turn-state-1", "turn-state-1", null]);
 	});
 
+	it("isolates turn-state by credential, backend, model, and Responses Lite mode", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const firstModel: Model<"openai-codex-responses"> = {
+			...createCodexTestModel("https://chatgpt.com/backend-api"),
+			preferWebsockets: false,
+		};
+		const firstApiKey = createCodexTestToken("account-a");
+		const variants: Array<{
+			name: string;
+			model: Model<"openai-codex-responses">;
+			apiKey: string;
+			responsesLite: boolean;
+		}> = [
+			{
+				name: "credential",
+				model: firstModel,
+				apiKey: createCodexTestToken("account-b"),
+				responsesLite: false,
+			},
+			{
+				name: "backend",
+				model: { ...firstModel, baseUrl: "https://codex.example/backend-api" },
+				apiKey: firstApiKey,
+				responsesLite: false,
+			},
+			{
+				name: "model",
+				model: { ...firstModel, id: "gpt-5.4-codex", name: "GPT-5.4 Codex" },
+				apiKey: firstApiKey,
+				responsesLite: false,
+			},
+			{
+				name: "Responses Lite mode",
+				model: firstModel,
+				apiKey: firstApiKey,
+				responsesLite: true,
+			},
+		];
+
+		for (const [index, variant] of variants.entries()) {
+			const requestTurnStates: Array<string | null> = [];
+			let requestCount = 0;
+			const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+				const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+				requestTurnStates.push(headers.get("x-codex-turn-state"));
+				const sse =
+					requestCount === 0
+						? `${[
+								`data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "fc_identity", call_id: "call_identity", name: "read_file", arguments: "" } })}`,
+								`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "fc_identity", call_id: "call_identity", name: "read_file", arguments: '{"path":"README.md"}' } })}`,
+								`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: DEFAULT_USAGE } })}`,
+							].join("\n\n")}\n\n`
+						: createCompletedCodexSse("Done");
+				requestCount += 1;
+				const responseHeaders = new Headers({ "content-type": "text/event-stream" });
+				if (requestCount === 1) responseHeaders.set("x-codex-turn-state", "account-a-turn-state");
+				return new Response(sse, { status: 200, headers: responseHeaders });
+			});
+			const providerSessionState = new Map<string, ProviderSessionState>();
+			const sessionId = `turn-state-identity-${index}`;
+			const firstUser = { role: "user" as const, content: "Read the file", timestamp: Date.now() };
+			const first = await streamOpenAICodexResponses(
+				firstModel,
+				{ systemPrompt: ["You are a helpful assistant."], messages: [firstUser] },
+				{
+					apiKey: firstApiKey,
+					fetch: fetchMock as FetchImpl,
+					sessionId,
+					providerSessionState,
+					responsesLite: false,
+				},
+			).result();
+			const toolCall = first.content.find(
+				(c): c is Extract<(typeof first.content)[number], { type: "toolCall" }> => c.type === "toolCall",
+			);
+			await streamOpenAICodexResponses(
+				variant.model,
+				{
+					systemPrompt: ["You are a helpful assistant."],
+					messages: [
+						firstUser,
+						first,
+						{
+							role: "toolResult",
+							toolCallId: toolCall!.id,
+							toolName: toolCall!.name,
+							content: [{ type: "text", text: "file contents" }],
+							isError: false,
+							timestamp: Date.now(),
+						},
+					],
+				},
+				{
+					apiKey: variant.apiKey,
+					fetch: fetchMock as FetchImpl,
+					sessionId,
+					providerSessionState,
+					responsesLite: variant.responsesLite,
+				},
+			).result();
+
+			expect({ [variant.name]: requestTurnStates }).toEqual({ [variant.name]: [null, null] });
+		}
+	});
+
 	it("isolates standalone compaction from a live turn-state", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -3,6 +3,7 @@ import { scheduler } from "node:timers/promises";
 import { streamSimple } from "@oh-my-pi/pi-ai";
 import {
 	buildTransformedCodexRequestBody,
+	createOpenAICodexCompatibilityMetadata,
 	getOpenAICodexTransportDetails,
 	getOpenAICodexWebSocketDebugStats,
 	prewarmOpenAICodexResponses,
@@ -5623,6 +5624,87 @@ describe("openai-codex streaming", () => {
 		).result();
 
 		expect(requestTurnStates).toEqual([null, null, "live-turn-state"]);
+	});
+
+	it("drops stale turn-state when direct pre-turn compaction opens the next turn", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const requestTurnStates: Array<string | null> = [];
+		let requestCount = 0;
+		const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+			const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+			requestTurnStates.push(headers.get("x-codex-turn-state"));
+			const sse =
+				requestCount === 0
+					? `${[
+							`data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "fc_live", call_id: "call_live", name: "read_file", arguments: "" } })}`,
+							`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "fc_live", call_id: "call_live", name: "read_file", arguments: '{"path":"README.md"}' } })}`,
+							`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: DEFAULT_USAGE } })}`,
+						].join("\n\n")}\n\n`
+					: createCompletedCodexSse("Done");
+			requestCount += 1;
+			const responseHeaders = new Headers({ "content-type": "text/event-stream" });
+			if (requestCount === 1) responseHeaders.set("x-codex-turn-state", "stale-turn-state");
+			return new Response(sse, { status: 200, headers: responseHeaders });
+		});
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const sessionId = "direct-pre-turn-compaction-session";
+		const options = {
+			apiKey: createCodexTestToken(),
+			fetch: fetchMock as FetchImpl,
+			sessionId,
+			providerSessionState,
+		};
+		const firstUser = { role: "user" as const, content: "Read the file", timestamp: Date.now() };
+		const first = await streamOpenAICodexResponses(
+			model,
+			{ systemPrompt: ["You are a helpful assistant."], messages: [firstUser] },
+			options,
+		).result();
+		const toolCall = first.content.find(
+			(c): c is Extract<(typeof first.content)[number], { type: "toolCall" }> => c.type === "toolCall",
+		);
+		// Direct `/responses/compact` compaction reuses the compatibility helper
+		// instead of the stream request-context path.
+		const compaction: CodexCompactionRequestContext = {
+			operationId: "direct-pre-turn-operation",
+			trigger: "auto",
+			reason: "context_limit",
+			implementation: "responses_compact",
+			phase: "pre_turn",
+			strategy: "memento",
+		};
+		createOpenAICodexCompatibilityMetadata({
+			sessionId,
+			providerSessionState,
+			requestKind: "compaction",
+			compaction,
+		});
+		resetOpenAICodexHistoryAfterCompaction({ providerSessionState, sessionId, compaction });
+		// The post-compaction sampling turn reuses the compaction turn; it must not
+		// replay the previous turn's sticky token.
+		await streamOpenAICodexResponses(
+			model,
+			{
+				systemPrompt: ["You are a helpful assistant."],
+				messages: [
+					firstUser,
+					first,
+					{
+						role: "toolResult",
+						toolCallId: toolCall!.id,
+						toolName: toolCall!.name,
+						content: [{ type: "text", text: "file contents" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			options,
+		).result();
+
+		expect(requestTurnStates).toEqual([null, null]);
 	});
 
 	it("captures x-codex-turn-state from response.metadata event headers", async () => {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -3183,7 +3183,7 @@ describe("openai-codex streaming", () => {
 		expect(continuationMetadata["x-codex-turn-metadata"]).toBe(continuationHeaders.get("x-codex-turn-metadata"));
 	});
 
-	it("clears stale main turn-state after pre-turn compaction", async () => {
+	it("seeds the first sample from pre-turn compaction turn-state", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());
 		const token = createCodexTestToken();
@@ -3191,13 +3191,15 @@ describe("openai-codex streaming", () => {
 		let websocketRequestCount = 0;
 
 		class PreTurnCompactionWebSocket extends MockWebSocket {
-			handshakeHeaders = {
-				"x-codex-turn-state": "stale-main-turn-state",
-				"x-models-etag": "models-etag-1",
-			};
+			handshakeHeaders: WsHeaders;
 
 			constructor(url: string, options?: { headers?: WsHeaders }) {
 				super(url, options);
+				this.handshakeHeaders = {
+					"x-codex-turn-state":
+						websocketInstances.length === 0 ? "stale-main-turn-state" : "compaction-turn-state",
+					"x-models-etag": "models-etag-1",
+				};
 				websocketInstances.push(this);
 				queueMicrotask(() => {
 					this.readyState = MockWebSocket.OPEN;
@@ -3281,7 +3283,7 @@ describe("openai-codex streaming", () => {
 				}),
 			).toMatchObject({
 				websocketConnected: true,
-				hasTurnState: false,
+				hasTurnState: true,
 			});
 			await streamOpenAICodexResponses(
 				sseModel,
@@ -3297,7 +3299,7 @@ describe("openai-codex streaming", () => {
 				},
 			).result();
 			expect(fetchMock).toHaveBeenCalledTimes(1);
-			expect(sseHeaders?.get("x-codex-turn-state")).toBeNull();
+			expect(sseHeaders?.get("x-codex-turn-state")).toBe("compaction-turn-state");
 		} finally {
 			for (const state of providerSessionState.values()) state.close();
 			providerSessionState.clear();
@@ -3896,6 +3898,104 @@ describe("openai-codex streaming", () => {
 		expect(JSON.stringify(thirdInput)).not.toContain("First question");
 	});
 
+	it("preserves turn-state when append matching falls back to full context", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = vi.fn(async () => {
+			throw new Error("SSE fallback should not be called");
+		});
+
+		class AppendMismatchWebSocket extends MockWebSocket {
+			constructor(url: string, options?: { headers?: WsHeaders }) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			override send(data: string): void {
+				const parsed: unknown = JSON.parse(data);
+				const request = requireRecord(parsed, "websocket request");
+				sentRequests.push(request);
+				if (sentRequests.length === 1) {
+					this.sendJson({
+						type: "response.metadata",
+						headers: { "x-codex-turn-state": "sticky-turn-state" },
+					});
+					this.sendJson({ type: "response.created", response: { id: "resp_1" } });
+					this.sendJson({
+						type: "response.output_item.added",
+						item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read_file", arguments: "" },
+					});
+					this.sendJson({
+						type: "response.output_item.done",
+						item: {
+							type: "function_call",
+							id: "fc_1",
+							call_id: "call_1",
+							name: "read_file",
+							arguments: '{"path":"README.md"}',
+						},
+					});
+					this.sendJson({
+						type: "response.completed",
+						response: { id: "resp_1", status: "completed", usage: DEFAULT_USAGE },
+					});
+					return;
+				}
+				this.emitCodexResponse({
+					messageId: "msg_2",
+					responseId: "resp_2",
+					text: "Done",
+					terminalType: "response.completed",
+					includeCreated: true,
+				});
+			}
+		}
+
+		global.WebSocket = AppendMismatchWebSocket as unknown as typeof WebSocket;
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const firstUser = { role: "user" as const, content: "Read the file", timestamp: Date.now() };
+		const options = {
+			fetch: fetchMock as FetchImpl,
+			apiKey: createCodexTestToken(),
+			sessionId: "ws-append-mismatch-session",
+			providerSessionState,
+		};
+		const first = await streamOpenAICodexResponses(
+			model,
+			{ systemPrompt: ["Initial instructions"], messages: [firstUser] },
+			options,
+		).result();
+		const toolCall = first.content.find(
+			(c): c is Extract<(typeof first.content)[number], { type: "toolCall" }> => c.type === "toolCall",
+		);
+		const toolResult = {
+			role: "toolResult" as const,
+			toolCallId: toolCall!.id,
+			toolName: toolCall!.name,
+			content: [{ type: "text" as const, text: "file contents" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		await streamOpenAICodexResponses(
+			model,
+			{
+				systemPrompt: ["Changed instructions force a full-context replay"],
+				messages: [firstUser, first, toolResult],
+			},
+			options,
+		).result();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(sentRequests).toHaveLength(2);
+		expect(sentRequests[1]?.previous_response_id).toBeUndefined();
+		expect(JSON.stringify(sentRequests[1]?.input)).toContain("Read the file");
+		const metadata = requireRecord(sentRequests[1]?.client_metadata, "continuation client_metadata");
+		expect(metadata["x-codex-turn-state"]).toBe("sticky-turn-state");
+	});
+
 	it("retries websocket continuations with full context when previous_response_id expires", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());
@@ -3930,6 +4030,10 @@ describe("openai-codex streaming", () => {
 				if (requestIndex === 2) {
 					expect(request.previous_response_id).toBe("resp_1");
 					this.sendJson({
+						type: "response.metadata",
+						headers: { "x-codex-turn-state": "retry-turn-state" },
+					});
+					this.sendJson({
 						type: "error",
 						code: "previous_response_not_found",
 						message: "Previous response with id 'resp_1' not found.",
@@ -3939,6 +4043,8 @@ describe("openai-codex streaming", () => {
 
 				if (requestIndex === 3) {
 					expect(request.previous_response_id).toBeUndefined();
+					const metadata = requireRecord(request.client_metadata, "retry client_metadata");
+					expect(metadata["x-codex-turn-state"]).toBe("retry-turn-state");
 					this.emitCodexResponse({
 						messageId: "msg_3",
 						responseId: "resp_3",
@@ -5234,10 +5340,10 @@ describe("openai-codex streaming", () => {
 			const index = callCount;
 			callCount += 1;
 			const sse =
-				index === 0
+				index < 2
 					? `${[
-							`data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read_file", arguments: "" } })}`,
-							`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read_file", arguments: '{"path":"README.md"}' } })}`,
+							`data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: `fc_${index + 1}`, call_id: `call_${index + 1}`, name: "read_file", arguments: "" } })}`,
+							`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: `fc_${index + 1}`, call_id: `call_${index + 1}`, name: "read_file", arguments: '{"path":"README.md"}' } })}`,
 							`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8, input_tokens_details: { cached_tokens: 0 } } } })}`,
 						].join("\n\n")}\n\n`
 					: `${[
@@ -5245,7 +5351,8 @@ describe("openai-codex streaming", () => {
 							`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "message", id: `msg_${index}`, role: "assistant", status: "completed", content: [{ type: "output_text", text: "Done" }] } })}`,
 							`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8, input_tokens_details: { cached_tokens: 0 } } } })}`,
 						].join("\n\n")}\n\n`;
-			// Every response mints a turn state; only within-turn follow-ups may echo it.
+			// Each response may return a different value, but the first non-empty
+			// value remains sticky for the logical turn.
 			const responseHeaders = new Headers({ "content-type": "text/event-stream" });
 			responseHeaders.set("x-codex-turn-state", `turn-state-${index + 1}`);
 			return new Response(sse, { status: 200, headers: responseHeaders });
@@ -5286,13 +5393,29 @@ describe("openai-codex streaming", () => {
 			isError: false,
 			timestamp: Date.now(),
 		};
-		// Tool-loop follow-up within the same turn replays the captured turn state.
+		// Tool-loop follow-ups within the same turn replay the first captured turn state.
 		const second = await streamOpenAICodexResponses(
 			model,
 			{ systemPrompt, messages: [firstUser, first, toolResult] },
 			options,
 		).result();
-		// A new user turn starts without it, even though the previous response minted one.
+		const secondToolCall = second.content.find(
+			(c): c is Extract<(typeof second.content)[number], { type: "toolCall" }> => c.type === "toolCall",
+		);
+		const secondToolResult = {
+			role: "toolResult" as const,
+			toolCallId: secondToolCall!.id,
+			toolName: secondToolCall!.name,
+			content: [{ type: "text" as const, text: "more file contents" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+		const third = await streamOpenAICodexResponses(
+			model,
+			{ systemPrompt, messages: [firstUser, first, toolResult, second, secondToolResult] },
+			options,
+		).result();
+		// A new user turn starts without it, even though later responses returned other values.
 		await streamOpenAICodexResponses(
 			model,
 			{
@@ -5302,13 +5425,98 @@ describe("openai-codex streaming", () => {
 					first,
 					toolResult,
 					second,
+					secondToolResult,
+					third,
 					{ role: "user" as const, content: "Next task", timestamp: Date.now() + 1 },
 				],
 			},
 			options,
 		).result();
 
-		expect(requestTurnStates).toEqual([null, "turn-state-1", null]);
+		expect(requestTurnStates).toEqual([null, "turn-state-1", "turn-state-1", null]);
+	});
+
+	it("isolates standalone compaction from a live turn-state", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const requestTurnStates: Array<string | null> = [];
+		let requestCount = 0;
+		const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+			const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+			requestTurnStates.push(headers.get("x-codex-turn-state"));
+			const index = requestCount;
+			requestCount += 1;
+			const sse =
+				index === 0
+					? `${[
+							`data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "fc_live", call_id: "call_live", name: "read_file", arguments: "" } })}`,
+							`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "fc_live", call_id: "call_live", name: "read_file", arguments: '{"path":"README.md"}' } })}`,
+							`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: DEFAULT_USAGE } })}`,
+						].join("\n\n")}\n\n`
+					: createCompletedCodexSse("Done");
+			const responseHeaders = new Headers({ "content-type": "text/event-stream" });
+			responseHeaders.set(
+				"x-codex-turn-state",
+				index === 0 ? "live-turn-state" : index === 1 ? "standalone-turn-state" : "continuation-turn-state",
+			);
+			return new Response(sse, { status: 200, headers: responseHeaders });
+		});
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const sessionId = "standalone-isolation-session";
+		const firstUser = { role: "user" as const, content: "Read the file", timestamp: Date.now() };
+		const options = {
+			apiKey: createCodexTestToken(),
+			fetch: fetchMock as FetchImpl,
+			sessionId,
+			providerSessionState,
+		};
+		const first = await streamOpenAICodexResponses(
+			model,
+			{ systemPrompt: ["You are a helpful assistant."], messages: [firstUser] },
+			options,
+		).result();
+		const toolCall = first.content.find(
+			(c): c is Extract<(typeof first.content)[number], { type: "toolCall" }> => c.type === "toolCall",
+		);
+		const standalone: CodexCompactionRequestContext = {
+			operationId: "standalone-isolation-operation",
+			trigger: "manual",
+			reason: "user_requested",
+			implementation: "responses",
+			phase: "standalone_turn",
+			strategy: "memento",
+		};
+		await streamOpenAICodexResponses(model, createCodexTestContext(), {
+			...options,
+			codexCompaction: standalone,
+		}).result();
+		resetOpenAICodexHistoryAfterCompaction({
+			providerSessionState,
+			sessionId,
+			compaction: standalone,
+		});
+		await streamOpenAICodexResponses(
+			model,
+			{
+				systemPrompt: ["You are a helpful assistant."],
+				messages: [
+					firstUser,
+					first,
+					{
+						role: "toolResult",
+						toolCallId: toolCall!.id,
+						toolName: toolCall!.name,
+						content: [{ type: "text", text: "file contents" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			options,
+		).result();
+
+		expect(requestTurnStates).toEqual([null, null, "live-turn-state"]);
 	});
 
 	it("captures x-codex-turn-state from response.metadata event headers", async () => {


### PR DESCRIPTION
## Repro
A focused SSE provider mock returned `x-codex-turn-state: turn-state-1`, then `turn-state-2`, across two same-turn tool responses. `bun test packages/ai/test/openai-codex-stream.test.ts --test-name-pattern "scopes x-codex-turn-state"` showed the third request sending `turn-state-2` instead of retaining `turn-state-1`.

## Cause
`packages/ai/src/providers/openai-codex-responses.ts` stored `turnState` on `CodexWebSocketSessionState`, so `updateCodexSessionMetadataFromHeaders()` overwrote it on every response and append/retry/history resets cleared it independently of the logical turn tracked by `CodexMetadataSessionState`; isolated pre-turn compaction also discarded the value before the sampling request reused that turn.

## Fix
- Move sticky-routing ownership into a first-write-only cell on the logical Codex metadata session.
- Preserve the cell across append fallback and retries, let pre-turn compaction seed the reused sampling turn, and give standalone compaction an isolated cell.
- Cover response replacement, append mismatch, retry, pre-turn compaction, standalone isolation, and cross-turn clearing.
- Document the user-visible fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/openai-codex-stream.test.ts` — 84 passed.

`bun test packages/ai/test/openai-codex*.test.ts packages/ai/test/providers/openai-codex-error.test.ts` — 188 passed.

`bun check` — passed.

Fixes #9277