### PR TITLE
test(tui): neutralize terminal-multiplexer env in 7 unscoped suites

### DIFF
--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -20,6 +20,10 @@ import {
 	TERMINAL,
 	wrapTmuxPassthrough,
 } from "@oh-my-pi/pi-tui/terminal-capabilities";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
+
+withoutTerminalMultiplexer();
+
 import { VirtualTerminal } from "./virtual-terminal";
 
 type MutableTerminalInfo = { id: string; imageProtocol: ImageProtocol | null };

--- a/packages/tui/test/image-clip.test.ts
+++ b/packages/tui/test/image-clip.test.ts
@@ -13,7 +13,10 @@ import {
 	TERMINAL,
 	wrapTmuxPassthrough,
 } from "@oh-my-pi/pi-tui/terminal-capabilities";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualTerminal } from "./virtual-terminal";
+
+withoutTerminalMultiplexer();
 
 type MutableTerminalInfo = { id: string; imageProtocol: ImageProtocol | null };
 const terminal = TERMINAL as unknown as MutableTerminalInfo;

--- a/packages/tui/test/issue-2115-repro.test.ts
+++ b/packages/tui/test/issue-2115-repro.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { type Component, type RenderScheduler, type RenderTimer, TUI } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualTerminal } from "./virtual-terminal";
+
+withoutTerminalMultiplexer();
 
 // Regression test for https://github.com/can1357/oh-my-pi/issues/2115
 //

--- a/packages/tui/test/issue-4863-repro.test.ts
+++ b/packages/tui/test/issue-4863-repro.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualTerminal } from "./virtual-terminal";
+
+withoutTerminalMultiplexer();
 
 // Regression probe for https://github.com/can1357/oh-my-pi/issues/4863
 //

--- a/packages/tui/test/issue-8318-repro.test.ts
+++ b/packages/tui/test/issue-8318-repro.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
 import { type Component, type NativeScrollbackLiveRegion, TUI } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualTerminal } from "./virtual-terminal";
+
+withoutTerminalMultiplexer();
 
 // Kitty OSC 66 text-sizing marker and the erase sequences the renderer emits.
 // A scale-`s` heading renders `s` cells tall and `visibleWidth` cells wide, so

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -9,7 +9,10 @@ import {
 	TERMINAL,
 	TUI,
 } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualTerminal } from "./virtual-terminal";
+
+withoutTerminalMultiplexer();
 
 class MutableLinesComponent implements Component {
 	#lines: string[];

--- a/packages/tui/test/streaming-scrollback-defer.test.ts
+++ b/packages/tui/test/streaming-scrollback-defer.test.ts
@@ -7,8 +7,11 @@ import {
 	type NativeScrollbackLiveRegion,
 	TUI,
 } from "@oh-my-pi/pi-tui";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
 import { VirtualRenderScheduler } from "./virtual-render-scheduler";
 import { VirtualTerminal } from "./virtual-terminal";
+
+withoutTerminalMultiplexer();
 
 // Law-encoding suite for native-scrollback commits.
 //


### PR DESCRIPTION
## What

Call the suite's own `withoutTerminalMultiplexer()` helper in 7 test files that assert destructive full-paint behavior without it: `image-budget`, `image-clip`, `issue-2115-repro`, `issue-4863-repro`, `issue-8318-repro`, `render-regressions`, `streaming-scrollback-defer`. One import + one module-scope call per file, same pattern as `component-render` and `overlay-scroll`.

## Why

These files expect an ED3 scrollback clear and native-scrollback rebuilds. Inside tmux/screen/zellij/CMUX, `isMultiplexerSession()` turns on the safety path that intentionally suppresses the destructive clear, so every such test fails on any multiplexer host. In a CMUX session the suite is 53 red, all 53 in these 7 files.

## Testing

- 7 files were 53/53 red under a CMUX host env; now 0 failures.
- Full `packages/tui` suite: 1541 tests, 0 fail, 3 skip.
- `bun run check:ts` clean.

- [x] Tests pass
- [x] Type check clean
- [x] No functional changes (test-only)
