### PR TITLE
fix(catalog): correct deepseek-v4-flash thinking-efforts ladder to [low, high, max]

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `deepseek-v4-flash` SKUs served over `openai-responses` (opencode-go) and `anthropic-messages` (umans, vercel-ai-gateway) transports exposing the generic five-tier effort ladder instead of the official `low/high/max` ([#9134](https://github.com/can1357/oh-my-pi/issues/9134)).
+
 ## [17.4.2] - 2026-08-21
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -390,6 +390,19 @@ function getModelDefinedEfforts<TApi extends Api>(
 	if (isOpenAICompatReasoningApi(spec.api) && isQwenTemplateReasoningEffortCompat(compat)) {
 		return QWEN38_TEMPLATE_REASONING_EFFORTS;
 	}
+	// DeepSeek V4 Flash served over non-OpenAI-compat transports: OpenCode Go
+	// forces its deepseek-v4-flash SKU onto openai-responses
+	// (OPENCODE_GO_API_ID_OVERRIDES), and umans / vercel-ai-gateway expose it
+	// via anthropic-messages gateways. Without this branch those SKUs fall
+	// through to inferFallbackEfforts and inherit the generic xhigh ladder
+	// even though the wire accepts low/high/max (#9134).
+	if (
+		(spec.api === "openai-responses" || spec.api === "anthropic-messages") &&
+		isDeepseekReasoningModel(spec) &&
+		isDeepseekV4FlashModelId(spec.id)
+	) {
+		return LOW_HIGH_MAX_REASONING_EFFORTS;
+	}
 	if (
 		(isOpenAICompatReasoningApi(spec.api) || (spec.api === "ollama-chat" && spec.provider === "ollama-cloud")) &&
 		isDeepseekReasoningModel(spec)

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -197990,11 +197990,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			},
 			"tokenizer": "deepseek-v3",
@@ -249699,11 +249697,9 @@
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			},
 			"input": [
@@ -263700,11 +263696,9 @@
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			},
 			"tokenizer": "deepseek-v3",
@@ -263747,11 +263741,9 @@
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			},
 			"tokenizer": "deepseek-v3",

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -1090,3 +1090,35 @@ describe("Qwen 3.8 local template effort ladder", () => {
 		expect(ollama.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.Max]);
 	});
 });
+
+describe("deepseek-v4-flash on non-OpenAI-compat transports (#9134)", () => {
+	it("exposes the official low/high/max ladder over openai-responses (opencode-go)", () => {
+		const model = createModel({
+			id: "deepseek-v4-flash",
+			api: "openai-responses",
+			provider: "opencode-go",
+			reasoning: true,
+		});
+		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+	});
+
+	it("exposes the official low/high/max ladder over anthropic-messages (umans gateway)", () => {
+		const model = createModel({
+			id: "umans-deepseek-v4-flash-0731",
+			api: "anthropic-messages",
+			provider: "umans",
+			reasoning: true,
+		});
+		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+	});
+
+	it("exposes the official low/high/max ladder over anthropic-messages (vercel-ai-gateway)", () => {
+		const model = createModel({
+			id: "deepseek/deepseek-v4-flash",
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+			reasoning: true,
+		});
+		expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.High, Effort.Max]);
+	});
+});


### PR DESCRIPTION
## Summary
Four bundled catalog entries exposed the generic 5-level thinking ladder (`minimal/low/medium/high/xhigh`) instead of the official DeepSeek V4 Flash efforts (`low/high/max`), making invalid levels selectable in the UI:

- `opencode-go/deepseek-v4-flash` — the entry reported in #9134 (`effort` mode)
- `umans/umans-deepseek-v4-flash-0731` (`budget` mode) — found while auditing every `deepseek-v4-flash` entry
- `vercel-ai-gateway/deepseek/deepseek-v4-flash` (`budget` mode)
- `vercel-ai-gateway/deepseek/deepseek-v4-flash-0731` (`budget` mode)

All other `deepseek-v4-flash` entries across the catalog already ship the correct ladder, consistent with `LOW_HIGH_MAX_REASONING_EFFORTS` in `docs/providers/provider-quirks.md`. `opencode-go/deepseek-v4-pro` was verified correct and left untouched.

## Validation
- `bun test packages/catalog/test/umans-provider.test.ts packages/catalog/test/vercel-ai-gateway-provider.test.ts packages/catalog/test/model-thinking.test.ts packages/catalog/test/build.test.ts` → **102 pass / 0 fail / 436 assertions** (Windows 11, bun 1.3.14)
- Programmatic audit of all 47 `deepseek-v4-flash*` entries in `models.json`: no remaining wrong ladders

Fixes #9134