### PR TITLE
fix(cursor): retry discovered effort ids after not_found

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor GPT effort models failing with `not_found` on accounts that require the discovered effort-specific model id ([#9287](https://github.com/can1357/oh-my-pi/issues/9287)).
+
 ## [17.4.3] - 2026-08-21
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -357,6 +357,11 @@ interface CursorGrpcRequest {
 	conversationState: ConversationStateStructure;
 }
 
+interface CursorTransportRequest extends CursorGrpcRequest {
+	/** Exact discovery id eligible for a retry because the normalized effort payload was serialized unchanged. */
+	fallbackWireModelId?: string;
+}
+
 const CONNECT_END_STREAM_FLAG = 0b00000010;
 
 interface CursorLogEntry {
@@ -645,6 +650,7 @@ function streamCursorWithWireMode(
 		let baseConversationId: string | undefined;
 		let conversationId: string | undefined;
 		let usageState: UsageState | undefined;
+		let serializedFallbackWireModelId: string | undefined;
 		try {
 			const apiKey = options?.apiKey;
 			if (!apiKey) {
@@ -656,7 +662,7 @@ function streamCursorWithWireMode(
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
 			const cachedState = conversationStateCache.get(conversationId);
-			const { requestBytes, conversationState } = await buildGrpcRequestForWireMode(
+			const builtRequest = await buildGrpcRequestForWireMode(
 				model,
 				context,
 				options,
@@ -667,6 +673,8 @@ function streamCursorWithWireMode(
 				},
 				wireMode,
 			);
+			const { requestBytes, conversationState } = builtRequest;
+			serializedFallbackWireModelId = builtRequest.fallbackWireModelId;
 			conversationStateCache.set(conversationId, conversationState);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
 			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
@@ -919,16 +927,12 @@ function streamCursorWithWireMode(
 			});
 			stream.end();
 		} catch (error) {
-			const discoveredWireModelId = options?.wireModelId ?? model.requestModelId ?? model.id;
-			const normalizedWireModel = resolveCursorWireModel(model, options?.wireModelId, "normalized");
 			const fallbackWireModelId =
 				wireMode === "normalized" &&
 				!sawServerMessage &&
 				error instanceof Error &&
-				CURSOR_MODEL_NOT_FOUND_PATTERN.test(error.message) &&
-				normalizedWireModel.parameters.length > 0 &&
-				normalizedWireModel.modelId !== discoveredWireModelId
-					? discoveredWireModelId
+				CURSOR_MODEL_NOT_FOUND_PATTERN.test(error.message)
+					? serializedFallbackWireModelId
 					: undefined;
 			if (fallbackWireModelId !== undefined) {
 				if (heartbeatTimer) {
@@ -5133,7 +5137,7 @@ async function buildGrpcRequestForWireMode(
 	options: CursorOptions | undefined,
 	state: CursorRequestState,
 	wireMode: CursorWireMode,
-): Promise<CursorGrpcRequest> {
+): Promise<CursorTransportRequest> {
 	const blobStore = state.blobStore;
 
 	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt).map(json =>
@@ -5264,6 +5268,21 @@ async function buildGrpcRequestForWireMode(
 	const replacementRequest = await options?.onPayload?.(runRequest, model);
 	if (replacementRequest !== undefined) runRequest = replacementRequest as typeof runRequest;
 
+	const discoveredWireModelId = options?.wireModelId ?? model.requestModelId ?? model.id;
+	const serializedParameters = runRequest.requestedModel?.parameters;
+	const normalizedEffortPayloadSerialized =
+		wireMode === "normalized" &&
+		wireParameters.length > 0 &&
+		wireModelId !== discoveredWireModelId &&
+		runRequest.requestedModel?.modelId === wireModelId &&
+		runRequest.modelDetails?.modelId === wireModelId &&
+		serializedParameters?.length === wireParameters.length &&
+		serializedParameters.every((parameter, index) => {
+			const expected = wireParameters[index];
+			return expected !== undefined && parameter.id === expected.id && parameter.value === expected.value;
+		});
+	const fallbackWireModelId = normalizedEffortPayloadSerialized ? discoveredWireModelId : undefined;
+
 	const clientMessage = create(AgentClientMessageSchema, {
 		message: { case: "runRequest", value: runRequest },
 	});
@@ -5282,7 +5301,7 @@ async function buildGrpcRequestForWireMode(
 		detail: detail || undefined,
 	});
 
-	return { requestBytes, blobStore, conversationState };
+	return { requestBytes, blobStore, conversationState, fallbackWireModelId };
 }
 
 /** Builds the normalized Cursor Run request used by transport callers and request inspection hooks. */

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -939,12 +939,21 @@ function streamCursorWithWireMode(
 				h2Client?.close();
 
 				const fallbackStream = streamCursorWithWireMode(model, context, options, "discovered");
-				for await (const event of fallbackStream) {
-					if (event.type === "start") continue;
-					stream.push(event);
+				// The lazy watchdog observes THIS outer stream; the fallback's exec
+				// bridge marks the inner stream busy via `trackLocalWork`. Forward
+				// that busy state so a local tool on the retry turn is not aborted as
+				// a stalled provider stream (#4593 protection must survive the retry).
+				stream.forwardLocalWorkFrom(fallbackStream);
+				try {
+					for await (const event of fallbackStream) {
+						if (event.type === "start") continue;
+						stream.push(event);
+					}
+					const fallbackResult = await fallbackStream.result();
+					if (!stream.resultSettled) stream.end(fallbackResult);
+				} finally {
+					stream.forwardLocalWorkFrom(undefined);
 				}
-				const fallbackResult = await fallbackStream.result();
-				if (!stream.resultSettled) stream.end(fallbackResult);
 				return;
 			}
 			// Same reason as the success path: the Agent finalizes the synthesized

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -618,7 +618,11 @@ function streamCursorWithWireMode(
 		let h2Settled = false;
 		let sawTurnEnded = false;
 		let endStreamError: Error | null = null;
-		let sawServerMessage = false;
+		// Blocks the discovered-id retry once the turn produced observable output or
+		// ran a side effect (streamed content/tool call, exec bridge, permission
+		// reply). Pure keepalive heartbeats never set it, so a `not_found` that
+		// arrives after a heartbeat but before any real work still falls back.
+		let sawProgressOrSideEffect = false;
 		// Reachable from the catch: a stream that dies mid-turn must still close
 		// and pair the blocks it left open, and `state` itself is scoped to the
 		// try below.
@@ -815,10 +819,14 @@ function streamCursorWithWireMode(
 
 					try {
 						const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
-						sawServerMessage = true;
-						const isTurnEnded =
-							serverMessage.message.case === "interactionUpdate" &&
-							serverMessage.message.value.message?.case === "turnEnded";
+						const interaction =
+							serverMessage.message.case === "interactionUpdate" ? serverMessage.message.value : undefined;
+						const interactionCase = interaction?.message?.case;
+						// A heartbeat is a pure keepalive `processInteractionUpdate` ignores;
+						// every other frame is progress or a side effect that must block the
+						// discovered-id retry.
+						if (interactionCase !== "heartbeat") sawProgressOrSideEffect = true;
+						const isTurnEnded = interactionCase === "turnEnded";
 						// Dispatch is fire-and-forget so the socket keeps draining while a
 						// handler runs, but the promise is tracked: `done` must not be
 						// pushed while an exec handler is still resolving, or the Agent
@@ -929,7 +937,7 @@ function streamCursorWithWireMode(
 		} catch (error) {
 			const fallbackWireModelId =
 				wireMode === "normalized" &&
-				!sawServerMessage &&
+				!sawProgressOrSideEffect &&
 				error instanceof Error &&
 				CURSOR_MODEL_NOT_FOUND_PATTERN.test(error.message)
 					? serializedFallbackWireModelId

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -316,6 +316,8 @@ const CURSOR_PROXY_TUNNEL_TIMEOUT_MS = 30_000;
 const NOT_IMPLEMENTED_SUFFIX = "not implemented by this client";
 /** Bare gRPC `resource_exhausted` end-streams (also inside a Connect error message). */
 const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
+/** Model-resolution failures that can safely retry the exact discovery id before any server output. */
+const CURSOR_MODEL_NOT_FOUND_PATTERN = /^(?:Connect error not_found:|gRPC error 5:)/i;
 const NOT_IMPLEMENTED = `Not implemented by this client`;
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
@@ -339,6 +341,20 @@ export interface CursorOptions extends StreamOptions {
 	onToolResult?: CursorToolResultHandler;
 	/** Wire model id selected after thinking-effort routing (`resolveWireModelId`). */
 	wireModelId?: string;
+}
+
+type CursorWireMode = "normalized" | "discovered";
+
+interface CursorRequestState {
+	conversationId: string;
+	blobStore: Map<string, Uint8Array>;
+	conversationState?: ConversationStateStructure;
+}
+
+interface CursorGrpcRequest {
+	requestBytes: Uint8Array;
+	blobStore: Map<string, Uint8Array>;
+	conversationState: ConversationStateStructure;
 }
 
 const CONNECT_END_STREAM_FLAG = 0b00000010;
@@ -526,11 +542,12 @@ function omitTypeName(record: Record<string, unknown>): Record<string, unknown> 
 	return rest;
 }
 
-export const streamCursor: StreamFunction<"cursor-agent"> = (
+function streamCursorWithWireMode(
 	model: Model<"cursor-agent">,
 	context: Context,
-	options?: CursorOptions,
-): AssistantMessageEventStream => {
+	options: CursorOptions | undefined,
+	wireMode: CursorWireMode,
+): AssistantMessageEventStream {
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {
@@ -596,6 +613,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 		let h2Settled = false;
 		let sawTurnEnded = false;
 		let endStreamError: Error | null = null;
+		let sawServerMessage = false;
 		// Reachable from the catch: a stream that dies mid-turn must still close
 		// and pair the blocks it left open, and `state` itself is scoped to the
 		// try below.
@@ -638,11 +656,17 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
 			const cachedState = conversationStateCache.get(conversationId);
-			const { requestBytes, conversationState } = await buildGrpcRequest(model, context, options, {
-				conversationId,
-				blobStore,
-				conversationState: cachedState,
-			});
+			const { requestBytes, conversationState } = await buildGrpcRequestForWireMode(
+				model,
+				context,
+				options,
+				{
+					conversationId,
+					blobStore,
+					conversationState: cachedState,
+				},
+				wireMode,
+			);
 			conversationStateCache.set(conversationId, conversationState);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
 			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
@@ -783,6 +807,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 
 					try {
 						const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
+						sawServerMessage = true;
 						const isTurnEnded =
 							serverMessage.message.case === "interactionUpdate" &&
 							serverMessage.message.value.message?.case === "turnEnded";
@@ -894,6 +919,34 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			});
 			stream.end();
 		} catch (error) {
+			const discoveredWireModelId = options?.wireModelId ?? model.requestModelId ?? model.id;
+			const normalizedWireModel = resolveCursorWireModel(model, options?.wireModelId, "normalized");
+			const fallbackWireModelId =
+				wireMode === "normalized" &&
+				!sawServerMessage &&
+				error instanceof Error &&
+				CURSOR_MODEL_NOT_FOUND_PATTERN.test(error.message) &&
+				normalizedWireModel.parameters.length > 0 &&
+				normalizedWireModel.modelId !== discoveredWireModelId
+					? discoveredWireModelId
+					: undefined;
+			if (fallbackWireModelId !== undefined) {
+				if (heartbeatTimer) {
+					clearInterval(heartbeatTimer);
+					heartbeatTimer = null;
+				}
+				h2Request?.close();
+				h2Client?.close();
+
+				const fallbackStream = streamCursorWithWireMode(model, context, options, "discovered");
+				for await (const event of fallbackStream) {
+					if (event.type === "start") continue;
+					stream.push(event);
+				}
+				const fallbackResult = await fallbackStream.result();
+				if (!stream.resultSettled) stream.end(fallbackResult);
+				return;
+			}
 			// Same reason as the success path: the Agent finalizes the synthesized
 			// call from this terminal error and clears its Cursor result buffer, so
 			// a handler still running would land its real result after `agent_end`
@@ -959,7 +1012,11 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 	})();
 
 	return stream;
-};
+}
+
+/** Streams a Cursor Agent turn, retrying a discovered effort id when its normalized wire id is unavailable. */
+export const streamCursor: StreamFunction<"cursor-agent"> = (model, context, options) =>
+	streamCursorWithWireMode(model, context, options, "normalized");
 
 export type ToolCallState = ToolCall & {
 	[kStreamingBlockIndex]: number;
@@ -5039,12 +5096,14 @@ function extractImages(content: (TextContent | ImageContent)[]) {
  */
 function resolveCursorWireModel(
 	model: Model<"cursor-agent">,
-	requestModelId?: string,
+	requestModelId: string | undefined,
+	wireMode: CursorWireMode = "normalized",
 ): {
 	modelId: string;
 	parameters: RequestedModel_ModelParameterbytes[];
 } {
 	const wireModelId = requestModelId ?? model.requestModelId ?? model.id;
+	if (wireMode === "discovered") return { modelId: wireModelId, parameters: [] };
 	// Cursor's fast lane follows the effort token (`-high-fast`), while the
 	// standard lane ends at it (`-high`). Preserve the lane in the base id.
 	const match = /^(.*)-(minimal|low|medium|high|xhigh|max)(-fast)?$/.exec(wireModelId);
@@ -5059,20 +5118,13 @@ function resolveCursorWireModel(
 	return { modelId: wireModelId, parameters: [] };
 }
 
-export async function buildGrpcRequest(
+async function buildGrpcRequestForWireMode(
 	model: Model<"cursor-agent">,
 	context: Context,
 	options: CursorOptions | undefined,
-	state: {
-		conversationId: string;
-		blobStore: Map<string, Uint8Array>;
-		conversationState?: ConversationStateStructure;
-	},
-): Promise<{
-	requestBytes: Uint8Array;
-	blobStore: Map<string, Uint8Array>;
-	conversationState: ConversationStateStructure;
-}> {
+	state: CursorRequestState,
+	wireMode: CursorWireMode,
+): Promise<CursorGrpcRequest> {
 	const blobStore = state.blobStore;
 
 	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt).map(json =>
@@ -5165,7 +5217,11 @@ export async function buildGrpcRequest(
 		turns,
 	});
 
-	const { modelId: wireModelId, parameters: wireParameters } = resolveCursorWireModel(model, options?.wireModelId);
+	const { modelId: wireModelId, parameters: wireParameters } = resolveCursorWireModel(
+		model,
+		options?.wireModelId,
+		wireMode,
+	);
 	const cursorMaxMode = model.cursorMaxMode === true;
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: wireModelId,
@@ -5218,6 +5274,16 @@ export async function buildGrpcRequest(
 	});
 
 	return { requestBytes, blobStore, conversationState };
+}
+
+/** Builds the normalized Cursor Run request used by transport callers and request inspection hooks. */
+export async function buildGrpcRequest(
+	model: Model<"cursor-agent">,
+	context: Context,
+	options: CursorOptions | undefined,
+	state: CursorRequestState,
+): Promise<CursorGrpcRequest> {
+	return buildGrpcRequestForWireMode(model, context, options, state, "normalized");
 }
 
 function hasImages(content: (TextContent | ImageContent)[]): boolean {

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -1,6 +1,11 @@
 import * as AIError from "../error";
 import type { AssistantMessage, AssistantMessageEvent } from "../types";
 
+/** Anything a stream watchdog can consult for in-flight consumer-side local work. */
+export interface LocalWorkSource {
+	readonly hasPendingLocalWork: boolean;
+}
+
 // Generic event stream class for async iteration
 export class EventStream<T, R = T> implements AsyncIterable<T> {
 	queue: T[] = [];
@@ -18,6 +23,13 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	 * not a provider stall; idle watchdogs consult {@link hasPendingLocalWork}.
 	 */
 	#pendingLocalWork = 0;
+	/**
+	 * A downstream stream whose local work also counts as ours — set when this
+	 * stream forwards another stream's events (e.g. the Cursor discovered-id
+	 * retry drains an inner stream), so the watchdog on this stream sees the
+	 * inner exec bridge's busy state instead of aborting a healthy tool run.
+	 */
+	#localWorkDelegate: LocalWorkSource | undefined;
 	finalResultPromise: Promise<R>;
 	resolveFinalResult!: (result: R) => void;
 	rejectFinalResult!: (err: unknown) => void;
@@ -125,9 +137,19 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		return this.finalResultPromise;
 	}
 
-	/** True while local work tracked via {@link trackLocalWork} is pending. */
+	/** True while local work tracked via {@link trackLocalWork} — on this stream or a forwarded delegate — is pending. */
 	get hasPendingLocalWork(): boolean {
-		return this.#pendingLocalWork > 0;
+		return this.#pendingLocalWork > 0 || (this.#localWorkDelegate?.hasPendingLocalWork ?? false);
+	}
+
+	/**
+	 * Count `source`'s pending local work as this stream's own. Used when this
+	 * stream forwards another's events (Cursor discovered-id retry) so the
+	 * watchdog does not abort a live tool run happening on the inner stream.
+	 * Pass `undefined` to detach once forwarding ends.
+	 */
+	forwardLocalWorkFrom(source: LocalWorkSource | undefined): void {
+		this.#localWorkDelegate = source;
 	}
 
 	/**

--- a/packages/ai/test/cursor-wire-model-fallback.test.ts
+++ b/packages/ai/test/cursor-wire-model-fallback.test.ts
@@ -8,6 +8,7 @@ import {
 	type AgentRunRequest,
 	AgentServerMessageSchema,
 	ExecServerMessageSchema,
+	HeartbeatUpdateSchema,
 	InteractionUpdateSchema,
 	ReadArgsSchema,
 	TextDeltaUpdateSchema,
@@ -19,7 +20,7 @@ import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 const CONNECT_END_STREAM_FLAG = 0b00000010;
 
 type Response =
-	| { kind: "error"; code: string; message: string; partialText?: string }
+	| { kind: "error"; code: string; message: string; partialText?: string; heartbeat?: boolean }
 	| { kind: "success"; text: string }
 	| { kind: "exec-success" };
 
@@ -59,6 +60,21 @@ function turnEndedFrame(): Buffer {
 				message: {
 					case: "turnEnded",
 					value: create(TurnEndedUpdateSchema, {}),
+				},
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function heartbeatFrame(): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: {
+					case: "heartbeat",
+					value: create(HeartbeatUpdateSchema, {}),
 				},
 			}),
 		},
@@ -136,7 +152,8 @@ async function startServer(): Promise<string> {
 				stream.end(Buffer.concat([execReadRequestFrame(), turnEndedFrame()]));
 				return;
 			}
-			const frames = response.partialText ? [textDeltaFrame(response.partialText)] : [];
+			const frames = response.heartbeat ? [heartbeatFrame()] : [];
+			if (response.partialText) frames.push(textDeltaFrame(response.partialText));
 			frames.push(connectErrorFrame(response.code, response.message));
 			stream.end(Buffer.concat(frames));
 		};
@@ -224,6 +241,19 @@ describe("Cursor discovered effort wire fallback", () => {
 		expect(requests[1].requestedModel?.modelId).toBe("gpt-5.6-sol-medium");
 		expect(requests[1].requestedModel?.parameters).toEqual([]);
 		expect(requests[1].modelDetails?.modelId).toBe("gpt-5.6-sol-medium");
+	});
+
+	it("still retries when a heartbeat precedes the not_found", async () => {
+		responses = [
+			{ kind: "error", code: "not_found", message: "Error", heartbeat: true },
+			{ kind: "success", text: "OK" },
+		];
+		const baseUrl = await startServer();
+		const { result } = await runStream(baseUrl);
+
+		expect(result.stopReason).toBe("stop");
+		expect(requests).toHaveLength(2);
+		expect(requests[1].requestedModel?.modelId).toBe("gpt-5.6-sol-medium");
 	});
 
 	it.each([

--- a/packages/ai/test/cursor-wire-model-fallback.test.ts
+++ b/packages/ai/test/cursor-wire-model-fallback.test.ts
@@ -97,6 +97,10 @@ function decodeRunRequest(frame: Buffer): AgentRunRequest {
 	return clientMessage.message.value;
 }
 
+function isAgentRunRequest(payload: unknown): payload is AgentRunRequest {
+	return payload !== null && typeof payload === "object" && "$typeName" in payload;
+}
+
 async function startServer(): Promise<string> {
 	server = http2.createServer();
 	server.on("session", session => {
@@ -233,6 +237,40 @@ describe("Cursor discovered effort wire fallback", () => {
 
 		expect(result.stopReason).toBe("error");
 		expect(requests).toHaveLength(1);
+	});
+
+	it("does not retry when onPayload replaced the normalized effort model", async () => {
+		responses = [{ kind: "error", code: "not_found", message: "hook model unavailable" }];
+		const baseUrl = await startServer();
+		let hookCalls = 0;
+		const stream = streamCursor(makeModel(baseUrl), context, {
+			apiKey: "test-token",
+			sessionId: crypto.randomUUID(),
+			wireModelId: "gpt-5.6-sol-medium",
+			onPayload: payload => {
+				hookCalls++;
+				if (!isAgentRunRequest(payload)) throw new Error("expected Cursor AgentRunRequest payload");
+				return {
+					...payload,
+					requestedModel: payload.requestedModel
+						? { ...payload.requestedModel, modelId: "hook-selected-model" }
+						: undefined,
+					modelDetails: payload.modelDetails
+						? { ...payload.modelDetails, modelId: "hook-selected-model" }
+						: undefined,
+				};
+			},
+		});
+		for await (const _event of stream) {
+			// drain to completion
+		}
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(hookCalls).toBe(1);
+		expect(requests).toHaveLength(1);
+		expect(requests[0].requestedModel?.modelId).toBe("hook-selected-model");
+		expect(requests[0].modelDetails?.modelId).toBe("hook-selected-model");
 	});
 
 	it("attempts the discovered sibling at most once", async () => {

--- a/packages/ai/test/cursor-wire-model-fallback.test.ts
+++ b/packages/ai/test/cursor-wire-model-fallback.test.ts
@@ -7,7 +7,9 @@ import {
 	AgentClientMessageSchema,
 	type AgentRunRequest,
 	AgentServerMessageSchema,
+	ExecServerMessageSchema,
 	InteractionUpdateSchema,
+	ReadArgsSchema,
 	TextDeltaUpdateSchema,
 	TurnEndedUpdateSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
@@ -18,7 +20,8 @@ const CONNECT_END_STREAM_FLAG = 0b00000010;
 
 type Response =
 	| { kind: "error"; code: string; message: string; partialText?: string }
-	| { kind: "success"; text: string };
+	| { kind: "success"; text: string }
+	| { kind: "exec-success" };
 
 let server: http2.Http2Server | undefined;
 const sessions = new Set<http2.Http2Session>();
@@ -56,6 +59,23 @@ function turnEndedFrame(): Buffer {
 				message: {
 					case: "turnEnded",
 					value: create(TurnEndedUpdateSchema, {}),
+				},
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function execReadRequestFrame(): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "execServerMessage",
+			value: create(ExecServerMessageSchema, {
+				id: 1,
+				execId: "exec-fallback",
+				message: {
+					case: "readArgs",
+					value: create(ReadArgsSchema, { path: "/tmp/fallback", toolCallId: "call-fallback" }),
 				},
 			}),
 		},
@@ -106,6 +126,10 @@ async function startServer(): Promise<string> {
 			});
 			if (response.kind === "success") {
 				stream.end(Buffer.concat([textDeltaFrame(response.text), turnEndedFrame()]));
+				return;
+			}
+			if (response.kind === "exec-success") {
+				stream.end(Buffer.concat([execReadRequestFrame(), turnEndedFrame()]));
 				return;
 			}
 			const frames = response.partialText ? [textDeltaFrame(response.partialText)] : [];
@@ -232,5 +256,49 @@ describe("Cursor discovered effort wire fallback", () => {
 		expect(result.stopReason).toBe("error");
 		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "partial" })]);
 		expect(requests).toHaveLength(1);
+	});
+
+	it("keeps the fallback turn's exec bridge busy state on the watched outer stream", async () => {
+		responses = [{ kind: "error", code: "not_found", message: "Error" }, { kind: "exec-success" }];
+		const baseUrl = await startServer();
+		const execStarted = Promise.withResolvers<void>();
+		const releaseExec = Promise.withResolvers<void>();
+		const stream = streamCursor(makeModel(baseUrl), context, {
+			apiKey: "test-token",
+			sessionId: crypto.randomUUID(),
+			wireModelId: "gpt-5.6-sol-medium",
+			execHandlers: {
+				async read() {
+					execStarted.resolve();
+					await releaseExec.promise;
+					return {
+						role: "toolResult",
+						toolCallId: "call-fallback",
+						toolName: "read",
+						content: [{ type: "text", text: "file body" }],
+						isError: false,
+						timestamp: 1,
+					};
+				},
+			},
+		});
+		const drain = (async () => {
+			for await (const _event of stream) {
+				// drain to completion
+			}
+			return stream.result();
+		})();
+
+		await execStarted.promise;
+		// The watchdog reads the outer stream; the exec bridge marked the inner
+		// fallback stream busy. Without forwarding, this would read false and the
+		// idle watchdog would abort a healthy tool run.
+		expect(stream.hasPendingLocalWork).toBe(true);
+		releaseExec.resolve();
+
+		const result = await drain;
+		expect(result.stopReason).toBe("stop");
+		expect(stream.hasPendingLocalWork).toBe(false);
+		expect(requests).toHaveLength(2);
 	});
 });

--- a/packages/ai/test/cursor-wire-model-fallback.test.ts
+++ b/packages/ai/test/cursor-wire-model-fallback.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as http2 from "node:http2";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	AgentClientMessageSchema,
+	type AgentRunRequest,
+	AgentServerMessageSchema,
+	InteractionUpdateSchema,
+	TextDeltaUpdateSchema,
+	TurnEndedUpdateSchema,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { create, fromBinary, toBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+const CONNECT_END_STREAM_FLAG = 0b00000010;
+
+type Response =
+	| { kind: "error"; code: string; message: string; partialText?: string }
+	| { kind: "success"; text: string };
+
+let server: http2.Http2Server | undefined;
+const sessions = new Set<http2.Http2Session>();
+let responses: Response[] = [];
+let requests: AgentRunRequest[] = [];
+
+function frameConnectMessage(data: Uint8Array, flags = 0): Buffer {
+	const frame = Buffer.alloc(5 + data.length);
+	frame[0] = flags;
+	frame.writeUInt32BE(data.length, 1);
+	frame.set(data, 5);
+	return frame;
+}
+
+function textDeltaFrame(text: string): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: {
+					case: "textDelta",
+					value: create(TextDeltaUpdateSchema, { text }),
+				},
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function turnEndedFrame(): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: {
+					case: "turnEnded",
+					value: create(TurnEndedUpdateSchema, {}),
+				},
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function connectErrorFrame(code: string, message: string): Buffer {
+	const payload = Buffer.from(JSON.stringify({ error: { code, message } }), "utf8");
+	return frameConnectMessage(payload, CONNECT_END_STREAM_FLAG);
+}
+
+function decodeRunRequest(frame: Buffer): AgentRunRequest {
+	const length = frame.readUInt32BE(1);
+	const clientMessage = fromBinary(AgentClientMessageSchema, frame.subarray(5, 5 + length));
+	if (clientMessage.message.case !== "runRequest") {
+		throw new Error(`expected runRequest, received ${clientMessage.message.case ?? "empty message"}`);
+	}
+	return clientMessage.message.value;
+}
+
+async function startServer(): Promise<string> {
+	server = http2.createServer();
+	server.on("session", session => {
+		sessions.add(session);
+		session.on("close", () => sessions.delete(session));
+	});
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
+		let pending: Buffer = Buffer.alloc(0);
+		const onData = (chunk: Buffer): void => {
+			pending = pending.length === 0 ? chunk : Buffer.concat([pending, chunk]);
+			if (pending.length < 5) return;
+			const length = pending.readUInt32BE(1);
+			if (pending.length < 5 + length) return;
+			stream.off("data", onData);
+
+			requests.push(decodeRunRequest(pending));
+			const response = responses[requests.length - 1];
+			if (!response) {
+				stream.respond({ ":status": 500 });
+				stream.end();
+				return;
+			}
+
+			stream.respond({
+				":status": 200,
+				"content-type": "application/connect+proto",
+			});
+			if (response.kind === "success") {
+				stream.end(Buffer.concat([textDeltaFrame(response.text), turnEndedFrame()]));
+				return;
+			}
+			const frames = response.partialText ? [textDeltaFrame(response.partialText)] : [];
+			frames.push(connectErrorFrame(response.code, response.message));
+			stream.end(Buffer.concat(frames));
+		};
+		stream.on("data", onData);
+	});
+
+	const listening = Promise.withResolvers<void>();
+	server.once("error", listening.reject);
+	server.listen(0, "127.0.0.1", listening.resolve);
+	await listening.promise;
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("expected Cursor fallback fixture to bind a TCP port");
+	}
+	return `http://127.0.0.1:${address.port}`;
+}
+
+function makeModel(baseUrl: string): Model<"cursor-agent"> {
+	return buildModel({
+		id: "gpt-5.6-sol",
+		requestModelId: "gpt-5.6-sol-none",
+		name: "GPT-5.6 Sol",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 64_000,
+	} satisfies ModelSpec<"cursor-agent">);
+}
+
+const context: Context = {
+	messages: [{ role: "user", content: "Reply only: OK", timestamp: 1 }],
+};
+
+async function runStream(baseUrl: string): Promise<{ events: string[]; result: AssistantMessage }> {
+	const stream = streamCursor(makeModel(baseUrl), context, {
+		apiKey: "test-token",
+		sessionId: crypto.randomUUID(),
+		wireModelId: "gpt-5.6-sol-medium",
+	});
+	const events: string[] = [];
+	for await (const event of stream) events.push(event.type);
+	return { events, result: await stream.result() };
+}
+
+async function stopServer(): Promise<void> {
+	for (const session of sessions) session.destroy();
+	sessions.clear();
+	if (!server) return;
+	const closing = server;
+	server = undefined;
+	const closed = Promise.withResolvers<void>();
+	closing.close(error => {
+		if (error) closed.reject(error);
+		else closed.resolve();
+	});
+	await closed.promise;
+}
+
+afterEach(async () => {
+	responses = [];
+	requests = [];
+	await stopServer();
+});
+
+describe("Cursor discovered effort wire fallback", () => {
+	it("retries not_found once with the exact discovered sibling id", async () => {
+		responses = [
+			{ kind: "error", code: "not_found", message: "Error" },
+			{ kind: "success", text: "OK" },
+		];
+		const baseUrl = await startServer();
+		const { events, result } = await runStream(baseUrl);
+
+		expect(events.filter(event => event === "start")).toHaveLength(1);
+		expect(result.stopReason).toBe("stop");
+		expect(requests).toHaveLength(2);
+		expect(requests[0].requestedModel?.modelId).toBe("gpt-5.6-sol");
+		expect(requests[0].requestedModel?.parameters).toEqual([
+			expect.objectContaining({ id: "reasoning", value: "medium" }),
+		]);
+		expect(requests[1].requestedModel?.modelId).toBe("gpt-5.6-sol-medium");
+		expect(requests[1].requestedModel?.parameters).toEqual([]);
+		expect(requests[1].modelDetails?.modelId).toBe("gpt-5.6-sol-medium");
+	});
+
+	it.each([
+		["permission_denied", "authentication"],
+		["resource_exhausted", "quota"],
+		["unavailable", "network"],
+	])("does not retry %s %s errors", async code => {
+		responses = [{ kind: "error", code, message: "Error" }];
+		const baseUrl = await startServer();
+		const { result } = await runStream(baseUrl);
+
+		expect(result.stopReason).toBe("error");
+		expect(requests).toHaveLength(1);
+	});
+
+	it("attempts the discovered sibling at most once", async () => {
+		responses = [
+			{ kind: "error", code: "not_found", message: "normalized unavailable" },
+			{ kind: "error", code: "not_found", message: "sibling unavailable" },
+		];
+		const baseUrl = await startServer();
+		const { result } = await runStream(baseUrl);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("sibling unavailable");
+		expect(requests).toHaveLength(2);
+	});
+
+	it("does not retry after the server emits partial output", async () => {
+		responses = [{ kind: "error", code: "not_found", message: "late failure", partialText: "partial" }];
+		const baseUrl = await startServer();
+		const { result } = await runStream(baseUrl);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "partial" })]);
+		expect(requests).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Repro
On 17.4.2, `bunx @oh-my-pi/pi-coding-agent@17.4.2 --model cursor/gpt-5.6-sol --thinking medium --no-tools --no-session --max-time 45s -p 'Reply only: OK'` rewrites the discovered `gpt-5.6-sol-medium` route to `gpt-5.6-sol` plus `reasoning=medium`, then terminates on Cursor's Connect `not_found`. A local HTTP/2 Run fixture reproduced the same request and terminal error with one request and no compatibility retry.

## Cause
`resolveCursorWireModel` in `packages/ai/src/providers/cursor.ts` always normalized OpenAI-family effort sibling ids before `buildGrpcRequestForWireMode` serialized the Run request. That shape matches accounts covered by #9164, but discards the exact id returned by discovery on accounts where Cursor only routes the sibling slug; `streamCursorWithWireMode` previously surfaced `not_found` without trying the retained route.

## Fix
- Retry a normalized Cursor effort request once with the exact discovered sibling id when the server returns Connect `not_found` or gRPC status 5 before any server message.
- Keep authentication, quota, network, repeated `not_found`, and partial-output failures terminal, and forward one logical event stream without a duplicate `start`.
- Add HTTP/2 transport coverage for the successful compatibility path, exact fallback payload, negative error classes, one-retry bound, and partial-output guard.
- Record the user-visible regression fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/cursor-wire-model-fallback.test.ts` — 6 pass.

`bun test packages/ai/test/cursor-wire-model-fallback.test.ts packages/ai/test/cursor-requested-model.test.ts packages/ai/test/cursor-effort-routing.test.ts packages/ai/test/cursor-terminal-error.test.ts packages/ai/test/cursor-conversation-rotate.test.ts` — 26 pass.

`bun run check:types` in `packages/ai` — clean. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #9287