### PR TITLE
fix(utils): filter mode-local dotenv from child shells

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed child shell environments inheriting Bun-autoloaded `.env.<mode>.local` values from the launch directory. ([#9290](https://github.com/can1357/oh-my-pi/issues/9290))
+
 ## [17.4.2] - 2026-08-21
 
 ### Fixed

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -105,11 +105,13 @@ export function filterChildShellEnv(
 	const nodeEnvName = `.env.${env.NODE_ENV || "development"}`;
 	const modeEnv = parseEnvFile(path.join(cwd, nodeEnvName));
 	const localEnv = parseEnvFile(path.join(cwd, ".env.local"));
-	const launchEnv = { ...projectEnv, ...modeEnv, ...localEnv };
+	const modeLocalEnv = parseEnvFile(path.join(cwd, `${nodeEnvName}.local`));
+	const launchEnv = { ...projectEnv, ...modeEnv, ...localEnv, ...modeLocalEnv };
 	const expandedLaunchEnv = {
 		...expandDotenvValues(projectEnv, result),
 		...expandDotenvValues(modeEnv, result),
 		...expandDotenvValues(localEnv, result),
+		...expandDotenvValues(modeLocalEnv, result),
 	};
 	for (const key in launchEnv) {
 		const launchValue = launchEnvValues?.get(key);

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	$envExact,
+	filterChildShellEnv,
 	filterProcessEnv,
 	getDbBusyTimeoutMs,
 	parseEnvFile,
@@ -165,6 +166,26 @@ describe("filterProcessEnv", () => {
 			"ProgramFiles(x86)": "C:\\Program Files (x86)",
 			"CommonProgramFiles(x86)": "C:\\Program Files (x86)\\Common Files",
 		});
+	});
+});
+
+describe("filterChildShellEnv", () => {
+	it("drops values Bun loaded from the default mode-local dotenv file", () => {
+		const cwd = path.dirname(writeTempEnv(""));
+		fs.writeFileSync(
+			path.join(cwd, ".env.development.local"),
+			"OMP_DOTENV_REPRO_MARKER=synthetic-mode-local-value\n",
+		);
+
+		const child = filterChildShellEnv(
+			{
+				OMP_DOTENV_REPRO_MARKER: "synthetic-mode-local-value",
+				UNCHANGED: "parent-value",
+			},
+			cwd,
+		);
+
+		expect(child).toEqual({ UNCHANGED: "parent-value" });
 	});
 });
 


### PR DESCRIPTION
## Repro
With `NODE_ENV` unset, create `.env.development.local` containing `OMP_DOTENV_REPRO_MARKER=synthetic-mode-local-value`, then run `env -u NODE_ENV bun repro.ts`, where the script passes `process.env` through `filterChildShellEnv(process.env, process.cwd())`; before this fix both the process and child environments contain the marker.

## Cause
`filterChildShellEnv` in `packages/utils/src/env.ts` parsed `.env`, `.env.<mode>`, and `.env.local`, but omitted Bun's higher-precedence `.env.<mode>.local` launch file, so its keys never entered the provenance filtering loop.

## Fix
- Parse `.env.<mode>.local` and include its values last in Bun precedence order.
- Include expanded mode-local values in best-effort value matching.
- Cover the default development mode with a synthetic marker regression test and document the fix.

## Verification
`bun test packages/utils/test/env.test.ts` passed: 18 tests, 0 failures. Re-running `env -u NODE_ENV bun repro.ts` returned `processSaw: synthetic-mode-local-value` and `childSaw: null`. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #9290