### PR TITLE
fix(tui): handle unknown compaction source tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed expanded compaction summaries claiming context grew from zero tokens when the provider did not report pre-compaction usage ([#9293](https://github.com/can1357/oh-my-pi/issues/9293)).
+
 ## [17.4.3] - 2026-08-21
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/components/compaction-summary-message.ts
@@ -135,15 +135,19 @@ export class CompactionSummaryMessageComponent implements Component {
 	}
 
 	#detailMarkdown(): string {
-		const tokenStr =
-			this.message.tokensAfter !== undefined
-				? `${this.message.tokensBefore.toLocaleString()} to ${this.message.tokensAfter.toLocaleString()}`
-				: this.message.tokensBefore.toLocaleString();
+		const tokenLine =
+			this.message.tokensBefore > 0
+				? this.message.tokensAfter !== undefined
+					? `Compacted from ${this.message.tokensBefore.toLocaleString()} to ${this.message.tokensAfter.toLocaleString()} tokens`
+					: `Compacted from ${this.message.tokensBefore.toLocaleString()} tokens`
+				: this.message.tokensAfter !== undefined
+					? `Compacted to ${this.message.tokensAfter.toLocaleString()} tokens`
+					: "Compacted context";
 		const frameCount = this.message.images?.length ?? 0;
 		const frameNote =
 			frameCount > 0 ? `\n\n_${frameCount} snapcompact frame${frameCount === 1 ? "" : "s"} attached_` : "";
 		const warningNote = this.message.warning ? `\n\n${theme.icon.warning} **Warning:** ${this.message.warning}` : "";
-		return `**Compacted from ${tokenStr} tokens**${warningNote}\n\n${this.message.summary}${frameNote}`;
+		return `**${tokenLine}**${warningNote}\n\n${this.message.summary}${frameNote}`;
 	}
 }
 

--- a/packages/coding-agent/test/modes/components/compaction-divider.test.ts
+++ b/packages/coding-agent/test/modes/components/compaction-divider.test.ts
@@ -59,6 +59,19 @@ describe("CompactionSummaryMessageComponent", () => {
 		expect(rule).not.toContain("→");
 	});
 
+	it("does not render missing pre-compaction usage as a literal zero", () => {
+		const component = new CompactionSummaryMessageComponent(
+			createCompactionSummaryMessage(SUMMARY, 0, new Date().toISOString(), {
+				method: "handoff",
+				tokensAfter: 48_573,
+			}),
+		);
+		component.setExpanded(true);
+		const text = Bun.stripANSI(component.render(80).join("\n"));
+		expect(text).toContain("Compacted to 48,573 tokens");
+		expect(text).not.toContain("Compacted from 0");
+	});
+
 	it("expanded: reveals the summary (and snapcompact frame count) below the divider", () => {
 		const component = makeComponent([{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" }]);
 		component.setExpanded(true);


### PR DESCRIPTION
## Repro
Create a `CompactionSummaryMessage` with the missing-usage sentinel `tokensBefore: 0`, `tokensAfter: 48_573`, expand `CompactionSummaryMessageComponent`, and render it: `bun -e 'import { createCompactionSummaryMessage } from "./packages/agent/src/compaction/messages.ts"; import { CompactionSummaryMessageComponent } from "./packages/coding-agent/src/modes/components/compaction-summary-message.ts"; import { initTheme } from "./packages/coding-agent/src/modes/theme/theme.ts"; await initTheme(); const component = new CompactionSummaryMessageComponent(createCompactionSummaryMessage("handoff summary", 0, new Date(0).toISOString(), { method: "handoff", tokensAfter: 48_573 })); component.setExpanded(true); console.log(Bun.stripANSI(component.render(100).join("\n")));'`. Before the fix, the expanded block printed `Compacted from 0 to 48,573 tokens`.

## Cause
`CompactionSummaryMessageComponent.#detailMarkdown()` in `packages/coding-agent/src/modes/components/compaction-summary-message.ts` formatted `tokensBefore` as a literal count even when `prepareCompaction()` used zero to represent unavailable provider usage. The collapsed divider already treated nonpositive source usage as unknown.

## Fix
- Render known source and destination counts as the existing `from … to …` message.
- Render a known destination without source usage as `Compacted to … tokens`; avoid inventing a zero-token source.
- Add renderer regression coverage and a coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/modes/components/compaction-divider.test.ts` passes: 7 tests, 0 failures. Re-running the reproduction prints `Compacted to 48,573 tokens`. The publish gate also completed `bun run fix` and `bun check`.

Fixes #9293