### PR TITLE
fix(docs): resolve dead ../ links rejected by omp:// in two docs pages

### DIFF
--- a/docs/non-compaction-retry-policy.md
+++ b/docs/non-compaction-retry-policy.md
@@ -2,7 +2,7 @@
 
 This document describes the standard API-error retry path coordinated by `AgentSession` and implemented by `TurnRecovery`.
 
-It explicitly excludes context-overflow recovery via auto-compaction. Overflow is handled by compaction logic and is documented separately in [`compaction.md`](../docs/compaction.md).
+It explicitly excludes context-overflow recovery via auto-compaction. Overflow is handled by compaction logic and is documented separately in [`compaction.md`](./compaction.md).
 
 ## Implementation files
 

--- a/docs/session-tree-plan.md
+++ b/docs/session-tree-plan.md
@@ -1,6 +1,6 @@
 # Session tree architecture (current)
 
-Reference: [session.md](../docs/session.md)
+Reference: [session.md](./session.md)
 
 This document describes how session tree navigation works today: in-memory tree model, leaf movement rules, branching behavior, and extension/event integration.
 


### PR DESCRIPTION
## Context

Issue #9254 reports that `omp://` rejects any path containing `..`, making 16 documentation cross-references dead in-harness. The `omp://` resolver guard is in `packages/coding-agent/src/internal-urls/omp-protocol.ts`:

```ts
const normalized = path.posix.normalize(filename.replaceAll("\\", "/"));
if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
    throw new Error("Path traversal (..) is not allowed in omp:// URLs");
}
```

## Changes

This PR fixes the trivial subset only — the two docs→docs links written with a spurious `../docs/` prefix even though both targets sit alongside their referrer:

| Doc | Before | After |
| --- | --- | --- |
| `docs/non-compaction-retry-policy.md:5` | `[compaction.md](../docs/compaction.md)` | `[compaction.md](./compaction.md)` |
| `docs/session-tree-plan.md:3` | `[session.md](../docs/session.md)` | `[session.md](./session.md)` |

## Evidence

Probe run via `InternalUrlRouter` (`packages/coding-agent`):

```
router.resolve("omp://../docs/compaction.md") -> throws "Path traversal (..) is not allowed in omp:// URLs"
router.resolve("omp://../docs/session.md")    -> throws "Path traversal (..) is not allowed in omp:// URLs"
router.resolve("omp://compaction.md")         -> resolves, content length > 0
router.resolve("omp://session.md")            -> resolves, content length > 0
 1 pass / 0 fail (4 expect() calls)
```

Existing suite unchanged and passing:

```
bun test test/internal-urls/omp-protocol.test.ts
 2 pass / 0 fail
```

## Out of scope

The remaining 14 dead links point outside `docs/` (`../packages/...`, `../python/...`). They require a design decision — resolver support for repo-relative documentation links or rewriting them as inline path text — and are intentionally not addressed here.

Partially addresses #9254