### PR TITLE
fix(tui): open read-only transcript viewer on Enter for aborted Agent Hub agents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Agent Hub aborted rows failing to open their read-only transcript when selected with Enter.
+
 ## [17.4.4] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -1054,9 +1054,9 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#activateAgent(ref: AgentRef): void {
 		this.#notice = undefined;
 		const focusAgent = this.#focusAgent;
-		// Advisor refs are read-only transcripts with no live/ revivable session;
-		// open the in-hub chat view (file-backed) instead of trying to focus one.
-		if (ref.kind === "advisor" || this.#remote || !focusAgent) {
+		// Aborted agents and advisor refs are read-only transcripts with no
+		// revivable session; open the in-hub viewer instead of failing ensureLive.
+		if (ref.kind === "advisor" || ref.status === "aborted" || this.#remote || !focusAgent) {
 			this.openChat(ref.id);
 			return;
 		}


### PR DESCRIPTION
## What

Pressing Enter on an aborted Agent Hub row now opens the fullscreen read-only transcript viewer.

## Why

Aborted agents have no live or revivable session, so routing Enter through session focus caused `ensureLive` to fail instead of showing the saved transcript. I could not audit whats going on without parsing transcripts manually.

## Testing

- `bun check`
- `bun test packages/coding-agent/test/agent-hub-activate.test.ts`
- `git diff HEAD^ HEAD --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
