### PR TITLE
fix(tui): scan only the streaming tail for ref defs in markdown lexer

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed pasting an image in kitty occasionally spraying base64 text into the composer alongside the image attachment: a kitty OSC 5522 clipboard packet torn by the incomplete-escape flush is now discarded up to its terminator instead of being replayed as keystrokes.
 - Fixed Kitty OSC 66 headings activating before the host explicitly enables text sizing.
+- Markdown streaming renderer now scans only the mutable tail (not the full document) for reference-link definitions and CR on every frame, eliminating the O(n²) `RegExp.test` cost that accounted for ~26% CPU during active streaming ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1773,9 +1773,9 @@ export class Markdown
 		const hasPrefix =
 			prefix !== undefined && prefixTokens !== undefined && text.length > prefix.length && text.startsWith(prefix);
 		const refDefText = hasPrefix ? text.slice(prefix.length) : text;
-		const canStream = !HAS_REF_DEF.test(refDefText) && !text.includes("\r");
+		const canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
 		if (canStream && hasPrefix) {
-			const tailTokens = lexDocument(text.slice(prefix.length));
+			const tailTokens = lexDocument(refDefText);
 			const tokens = [...prefixTokens, ...tailTokens];
 			this.#freezeStablePrefix(text, tokens, { preserveExisting: true });
 			return tokens;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1763,16 +1763,18 @@ export class Markdown
 	// raw-span offsets). Every fallback is correctness-preserving — only speed
 	// differs; the render loop sees the identical token list either way.
 	#lexTokens(text: string): Token[] {
-		const canStream = !HAS_REF_DEF.test(text) && !text.includes("\r");
+		// When a frozen prefix exists, it was already verified ref-def-free when
+		// frozen (#freezeStablePrefix only runs when canStream was true). The prefix
+		// ends at a "\n\n" block boundary (stableBlockBoundary), so the tail starts
+		// at a fresh line — scanning only the tail for ref defs is sufficient and
+		// avoids re-scanning the growing prefix every frame (O(n²) → O(n) overall).
 		const prefix = this.#streamPrefixText;
 		const prefixTokens = this.#streamPrefixTokens;
-		if (
-			canStream &&
-			prefix !== undefined &&
-			prefixTokens !== undefined &&
-			text.length > prefix.length &&
-			text.startsWith(prefix)
-		) {
+		const hasPrefix =
+			prefix !== undefined && prefixTokens !== undefined && text.length > prefix.length && text.startsWith(prefix);
+		const refDefText = hasPrefix ? text.slice(prefix.length) : text;
+		const canStream = !HAS_REF_DEF.test(refDefText) && !text.includes("\r");
+		if (canStream && hasPrefix) {
 			const tailTokens = lexDocument(text.slice(prefix.length));
 			const tokens = [...prefixTokens, ...tailTokens];
 			this.#freezeStablePrefix(text, tokens, { preserveExisting: true });


### PR DESCRIPTION
## Problem

Issue #9048: `RegExp.test` accounts for 26% of CPU during active streaming. The profile shows `HAS_REF_DEF.test(text)` in `markdown.ts#lexTokens()` scanning the **full markdown text** every render frame (~30Hz) to check for reference-link definitions (`[label]: url`).

For a growing streamed message, this is O(n) per frame → O(n²) overall.

## Fix

When a frozen prefix exists (streaming mode), it was already verified ref-def-free when frozen (`#freezeStablePrefix` only runs when `canStream` was true). The prefix ends at a `\n\n` block boundary (`stableBlockBoundary`), so the tail starts at a fresh line. Scanning only the tail for ref defs is sufficient and avoids re-scanning the growing prefix every frame.

Reduces the regex cost from O(n) per frame (O(n²) overall) to O(tail) per frame (O(n) overall).

## Verification

- All 207 markdown tests pass
- All 31 streaming tests pass
- `bun check` clean
- No new TUI test failures (14 pre-existing WSL2/headless env failures unchanged)