### PR TITLE
fix(coding-agent): bound collapsed edit diff rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed collapsed edit results with long wrapped diff lines growing beyond their rendered-row budget and corrupting native Windows terminal transcript layout ([#9302](https://github.com/can1357/oh-my-pi/issues/9302)).
+
 ## [17.4.4] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -693,20 +693,30 @@ function renderDiffSection(
 	diff: string,
 	rawPath: string,
 	expanded: boolean,
+	innerWidth: number,
 	uiTheme: Theme,
 	renderDiffFn: (t: string, o?: { filePath?: string }) => string,
-	cache?: RenderedStringCache,
+	renderCache?: RenderedStringCache,
+	sectionCache?: RenderedStringCache,
 ): string {
-	return cachedRenderedString(cache, uiTheme, expanded, rawPath, diff, () => {
+	return cachedRenderedString(sectionCache, uiTheme, expanded, `${rawPath}:${innerWidth}`, diff, () => {
 		const {
 			text: truncatedDiff,
 			hiddenHunks,
-			hiddenLines,
+			hiddenLines: logicallyHiddenLines,
 		} = expanded
 			? { text: diff, hiddenHunks: 0, hiddenLines: 0 }
 			: truncateDiffByHunk(diff, PREVIEW_LIMITS.DIFF_COLLAPSED_HUNKS, PREVIEW_LIMITS.DIFF_COLLAPSED_LINES);
 
-		let text = `\n${renderDiffFn(truncatedDiff, { filePath: rawPath })}`;
+		const renderedDiff = cachedRenderedString(renderCache, uiTheme, expanded, rawPath, truncatedDiff, () =>
+			renderDiffFn(truncatedDiff, { filePath: rawPath }),
+		);
+		const { text: visibleDiff, hiddenLines: visuallyHiddenLines } = expanded
+			? { text: renderedDiff, hiddenLines: 0 }
+			: sliceCollapsedDiffRows(renderedDiff, innerWidth, PREVIEW_LIMITS.DIFF_COLLAPSED_LINES);
+		const hiddenLines = logicallyHiddenLines + visuallyHiddenLines;
+
+		let text = `\n${visibleDiff}`;
 		if (!expanded && (hiddenHunks > 0 || hiddenLines > 0)) {
 			const remainder: string[] = [];
 			if (hiddenHunks > 0) remainder.push(`${hiddenHunks} more hunks`);
@@ -754,6 +764,33 @@ function wrapEditRendererLine(line: string, width: number): string[] {
 	return wrappedContent.map(
 		(segment, index) => `${startAnsi}${index === 0 ? prefix : continuationPrefix}${segment}\x1b[27m\x1b[39m`,
 	);
+}
+
+function sliceCollapsedDiffRows(
+	renderedDiff: string,
+	innerWidth: number,
+	maxRows: number,
+): { text: string; hiddenLines: number } {
+	const lines = renderedDiff.split("\n");
+	const visibleRows: string[] = [];
+	let completeLines = 0;
+
+	for (const line of lines) {
+		const wrapped = wrapEditRendererLine(line, innerWidth);
+		const remainingRows = maxRows - visibleRows.length;
+		if (wrapped.length <= remainingRows) {
+			visibleRows.push(...wrapped);
+			completeLines++;
+			continue;
+		}
+		if (remainingRows > 0) visibleRows.push(...wrapped.slice(0, remainingRows));
+		break;
+	}
+
+	return {
+		text: visibleRows.join("\n"),
+		hiddenLines: lines.length - completeLines,
+	};
 }
 
 export const editToolRenderer = {
@@ -912,6 +949,7 @@ function renderSingleFileResult(
 
 	let diffSectionRenderDiffFn: ((t: string, o?: { filePath?: string }) => string) | undefined;
 	const diffSectionCache = createRenderedStringCache();
+	const renderedDiffCache = createRenderedStringCache();
 	const statsSuffixCache = createRenderedStringCache();
 
 	return framedBlock(uiTheme, width => {
@@ -927,6 +965,7 @@ function renderSingleFileResult(
 		if (diffSectionRenderDiffFn !== renderDiffFn) {
 			diffSectionRenderDiffFn = renderDiffFn;
 			invalidateRenderedStringCache(diffSectionCache);
+			invalidateRenderedStringCache(renderedDiffCache);
 		}
 		const firstChangedLine =
 			(editDiffPreview && "firstChangedLine" in editDiffPreview ? editDiffPreview.firstChangedLine : undefined) ||
@@ -951,12 +990,22 @@ function renderSingleFileResult(
 			linkPath,
 			statsSuffix,
 		});
+		const innerWidth = Math.max(1, width - 2);
 
 		let body = "";
 		if (isError) {
 			if (errorText) body = uiTheme.fg("error", replaceTabs(errorText));
 		} else if (details?.diff) {
-			body = renderDiffSection(details.diff, rawPath, expanded, uiTheme, renderDiffFn, diffSectionCache);
+			body = renderDiffSection(
+				details.diff,
+				rawPath,
+				expanded,
+				innerWidth,
+				uiTheme,
+				renderDiffFn,
+				renderedDiffCache,
+				diffSectionCache,
+			);
 		} else if (details) {
 			// Authoritative result with no textual diff: a delete, a move-only
 			// rename, or a genuine no-op. The header already names the op
@@ -969,7 +1018,16 @@ function renderSingleFileResult(
 		} else if (editDiffPreview) {
 			if ("error" in editDiffPreview) body = uiTheme.fg("error", replaceTabs(editDiffPreview.error));
 			else if (editDiffPreview.diff)
-				body = renderDiffSection(editDiffPreview.diff, rawPath, expanded, uiTheme, renderDiffFn, diffSectionCache);
+				body = renderDiffSection(
+					editDiffPreview.diff,
+					rawPath,
+					expanded,
+					innerWidth,
+					uiTheme,
+					renderDiffFn,
+					renderedDiffCache,
+					diffSectionCache,
+				);
 		}
 		if (details?.diagnostics) {
 			body += formatDiagnostics(details.diagnostics, expanded, uiTheme, (fp: string) =>
@@ -980,7 +1038,6 @@ function renderSingleFileResult(
 		// Diff lines self-wrap with a continuation gutter; pre-wrap to the frame's
 		// inner width so renderOutputBlock's generic wrap is a no-op. Edit frames
 		// use a flush left border because code-frame gutters already provide padding.
-		const innerWidth = Math.max(1, width - 2);
 		const bodyLines = body.length > 0 ? body.split("\n").flatMap(line => wrapEditRendererLine(line, innerWidth)) : [];
 		while (bodyLines.length > 0 && bodyLines[0].trim() === "") bodyLines.shift();
 

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -529,6 +529,28 @@ describe("editToolRenderer", () => {
 		expect(rendered).toContain("960 more lines");
 	});
 
+	it("bounds a completed collapsed diff by rendered rows", async () => {
+		const uiTheme = await getUiTheme();
+		const tail = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".repeat(4);
+		const diff = Array.from({ length: 12 }, (_, index) => {
+			const line = index + 1;
+			return `-${line}|ROW_${line.toString().padStart(2, "0")}=${tail}\n+${line}|ROW_${line.toString().padStart(2, "0")}=changed-${tail}`;
+		}).join("\n");
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Updated long-lines.txt" }],
+				details: { diff, op: "update" },
+			},
+			{ expanded: false, isPartial: false, renderContext: { renderDiff } },
+			uiTheme,
+			{ file_path: "long-lines.txt" },
+		);
+
+		const lines = component.render(120).map(line => Bun.stripANSI(line));
+		expect(lines).toHaveLength(43);
+		expect(lines.join("\n")).toContain("more lines");
+	});
+
 	it("renders completed edit gutters without inherited frame padding", async () => {
 		const uiTheme = await getUiTheme();
 		const component = editToolRenderer.renderResult(


### PR DESCRIPTION
## Repro
A finalized collapsed edit containing 12 approximately 255-column replacement lines rendered 74 physical rows at 120 columns instead of the 43-row collapsed budget. Reproduced with `bun test packages/coding-agent/test/tools/edit-renderer.test.ts --test-name-pattern 'bounds a completed collapsed diff by rendered rows'`.

## Cause
`renderDiffSection()` in `packages/coding-agent/src/edit/renderer.ts` truncated finalized diffs by logical source lines, then `renderSingleFileResult()` applied gutter-aware wrapping afterward. Long retained lines therefore expanded without any physical-row bound.

## Fix
- Slice collapsed syntax-rendered diffs to the existing 40-row budget after gutter-aware wrapping.
- Preserve the expansion hint by counting source lines with hidden wrapped content alongside logically truncated lines.
- Cache syntax rendering independently from width-dependent row slicing.
- Add a renderer regression covering the reported 120-column long-line fixture and document the fix.

## Verification
`bun test packages/coding-agent/test/tools/edit-renderer.test.ts` passes: 31 tests, 113 assertions. The publish gate also completed `bun run fix` and `bun check`.

Fixes #9302