### PR TITLE
fix(coding-agent): consume /mcp test esc ownership and retire stale hint after settle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Fixed accurate benchmark input token counts on providers with automatic prompt caching.
 - Fixed C# files incorrectly displaying D3.js icons in edit results ([#9323](https://github.com/can1357/oh-my-pi/issues/9323)).
 - Fixed incorrect token delta reporting in expanded context compaction summaries when pre-compaction usage was omitted by the provider ([#9293](https://github.com/can1357/oh-my-pi/issues/9293)).
+### Fixed
+
+- Fixed `/mcp test` leaving a stale "(esc to cancel)" hint after the test finished and swallowing Esc presses during the grace window; the hint now stops advertising Esc once the test settles, a late Esc shows an "already finished" status instead of silently doing nothing, and one Esc press consumes the cancellation ownership so the next Esc reaches the running turn ([#9173](https://github.com/can1357/oh-my-pi/issues/9173)).
 
 ## [17.4.4] - 2026-08-22
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -319,7 +319,12 @@ export class InputController {
 			// `/mcp test` advertises Esc until each owner's post-settlement grace expires.
 			// Cancel every overlapping test before any main-turn or side-channel action.
 			if (this.ctx.mcpTestEscapeHandlers.size > 0) {
-				for (const handler of this.ctx.mcpTestEscapeHandlers) handler();
+				// One Esc cancels every advertised /mcp test and consumes the ownership;
+				// the next Esc must reach the actions below instead of being swallowed
+				// by a stale registration or grace timer.
+				const handlers = [...this.ctx.mcpTestEscapeHandlers];
+				this.ctx.mcpTestEscapeHandlers.clear();
+				for (const handler of handlers) handler();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -61,6 +61,7 @@ import { copyToClipboard } from "../../utils/clipboard";
 import { isTimeoutError } from "../../utils/fetch-timeout";
 import { openPath } from "../../utils/open";
 import { ChatBlock } from "../components/chat-block";
+import { DynamicBorder } from "../components/dynamic-border";
 import { MCPAddWizard } from "../components/mcp-add-wizard";
 import { TranscriptBlock } from "../components/transcript-container";
 import { parseCommandArgs } from "../shared";
@@ -1575,7 +1576,14 @@ export class MCPCommandController {
 		}
 
 		const abortController = new AbortController();
-		const handleEscape = (): void => abortController.abort();
+		let settled = false;
+		const handleEscape = (): void => {
+			if (settled) {
+				this.ctx.showStatus(`MCP test for "${name}" already finished`);
+				return;
+			}
+			abortController.abort();
+		};
 
 		// Claim Esc before the first await: a slow `#resolveServerForAuth()` (e.g.
 		// config on a network filesystem) must not let Esc fall through to the
@@ -1587,6 +1595,7 @@ export class MCPCommandController {
 		// screen; a pre-hint failure must release Esc immediately so it is not
 		// swallowed for a prompt the user never saw.
 		let hintShown = false;
+		let hintText: Text | undefined;
 		try {
 			const found = await this.#resolveServerForAuth(name);
 
@@ -1605,9 +1614,13 @@ export class MCPCommandController {
 				return;
 			}
 
-			this.#showMessage(
-				["", theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), ""].join("\n"),
-			);
+			const hintBlock = new TranscriptBlock();
+			hintBlock.addChild(new DynamicBorder());
+			const text = new Text(`Testing connection to "${name}"... (esc to cancel)`, 1, 1);
+			hintBlock.addChild(text);
+			hintBlock.addChild(new DynamicBorder());
+			this.ctx.presentCommandOutput(hintBlock);
+			hintText = text;
 			hintShown = true;
 
 			// Resolve auth config if needed
@@ -1670,6 +1683,14 @@ export class MCPCommandController {
 
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
+			settled = true;
+			if (hintShown) {
+				// The test can no longer be cancelled: stop advertising Esc so a
+				// later press cannot be mistaken for test cancellation and abort
+				// the running agent turn after the grace expires.
+				hintText?.setText(`Tested connection to "${name}".`);
+				this.ctx.ui.requestRender();
+			}
 			if (this.ctx.mcpTestEscapeHandlers.has(handleEscape)) {
 				if (hintShown) {
 					const timer = setTimeout(() => {

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1620,16 +1620,15 @@ export class MCPCommandController {
 		// read as if it completed.
 		let settleNote = `Tested connection to "${name}".`;
 		// Cancellation can land while later awaits (auth prepareConfig, connect)
-		// are still unwinding. Rewrite the hint the moment it happens: the
-		// dispatcher already consumed the ownership, so the hint must not keep
-		// advertising esc for a test that can no longer be cancelled.
+		// are still unwinding. Drop the esc affordance the moment it happens —
+		// the dispatcher already consumed the ownership — but claim no outcome:
+		// whether this abort actually stops the test is only known once the
+		// signal-observing awaits settle (e.g. an abort landing during
+		// #syncManagerConnection does not stop it).
 		abortController.signal.addEventListener("abort", () => {
-			if (settled) return;
-			settleNote = `Cancelled connection test for "${name}".`;
-			if (hintShown) {
-				hintText?.setText(theme.fg("muted", settleNote));
-				this.ctx.ui.requestRender();
-			}
+			if (settled || !hintShown) return;
+			hintText?.setText(theme.fg("muted", `Testing connection to "${name}"...`));
+			this.ctx.ui.requestRender();
 		});
 		try {
 			const found = await this.#resolveServerForAuth(name);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -72,6 +72,25 @@ import { groupBySource, parseRemoveArgs, readScopeFlag, showCommandMessage } fro
 const MCP_MANUAL_INPUT_PROVIDER_ID = "mcp";
 const MCP_MANUAL_LOGIN_TIP = "Headless? Paste the redirect URL or code with /login <value>.";
 const MCP_TEST_ESCAPE_GRACE_MS = 5_000;
+
+/**
+ * Hint block for an in-flight `/mcp test`. Stays unfinalized (so
+ * TranscriptContainer keeps re-rendering it, even once scrolled into the
+ * native-scrollback live-region seam) until settlement seals its final text.
+ * A plain TranscriptBlock would be treated as immutable after finalize and a
+ * settled rewrite could be lost to committed-history replay.
+ */
+class MutableHintBlock extends TranscriptBlock {
+	#sealed = false;
+
+	isTranscriptBlockFinalized(): boolean {
+		return this.#sealed;
+	}
+
+	seal(): void {
+		this.#sealed = true;
+	}
+}
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string, onTimeout?: () => void): Promise<T> {
 	const { promise: timeoutPromise, reject } = Promise.withResolvers<T>();
 	const timer = setTimeout(() => {
@@ -1596,6 +1615,22 @@ export class MCPCommandController {
 		// swallowed for a prompt the user never saw.
 		let hintShown = false;
 		let hintText: Text | undefined;
+		let hintBlock: MutableHintBlock | undefined;
+		// Outcome-branched settled text: a cancelled or failed test must not
+		// read as if it completed.
+		let settleNote = `Tested connection to "${name}".`;
+		// Cancellation can land while later awaits (auth prepareConfig, connect)
+		// are still unwinding. Rewrite the hint the moment it happens: the
+		// dispatcher already consumed the ownership, so the hint must not keep
+		// advertising esc for a test that can no longer be cancelled.
+		abortController.signal.addEventListener("abort", () => {
+			if (settled) return;
+			settleNote = `Cancelled connection test for "${name}".`;
+			if (hintShown) {
+				hintText?.setText(theme.fg("muted", settleNote));
+				this.ctx.ui.requestRender();
+			}
+		});
 		try {
 			const found = await this.#resolveServerForAuth(name);
 
@@ -1614,9 +1649,18 @@ export class MCPCommandController {
 				return;
 			}
 
-			const hintBlock = new TranscriptBlock();
+			// Esc may have been consumed during the awaited lookup, before any
+			// hint existed. Bail out instead of advertising a cancellation that
+			// is already gone.
+			if (abortController.signal.aborted) {
+				this.ctx.mcpTestEscapeHandlers.delete(handleEscape);
+				this.ctx.showStatus(`Cancelled MCP test for "${name}"`);
+				return;
+			}
+
+			hintBlock = new MutableHintBlock();
 			hintBlock.addChild(new DynamicBorder());
-			const text = new Text(`Testing connection to "${name}"... (esc to cancel)`, 1, 1);
+			const text = new Text(theme.fg("muted", `Testing connection to "${name}"... (esc to cancel)`), 1, 1);
 			hintBlock.addChild(text);
 			hintBlock.addChild(new DynamicBorder());
 			this.ctx.presentCommandOutput(hintBlock);
@@ -1661,6 +1705,7 @@ export class MCPCommandController {
 			this.#showMessage(lines.join("\n"));
 		} catch (error) {
 			if (abortController.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+				settleNote = `Cancelled connection test for "${name}".`;
 				this.ctx.showStatus(`Cancelled MCP test for "${name}"`);
 				return;
 			}
@@ -1677,19 +1722,21 @@ export class MCPCommandController {
 				helpText = "\n\nTip: Check that the server is running and the URL/port is correct.";
 			} else if (errorMsg.includes("timeout")) {
 				helpText = "\n\nTip: The server may be slow or unresponsive. Try increasing the timeout.";
-			} else if (errorMsg.includes("401") || errorMsg.includes("403")) {
-				helpText = "\n\nTip: Check your authentication credentials.";
 			}
 
+			settleNote = `Connection test for "${name}" failed.`;
 			this.ctx.showError(`Failed to connect to "${name}": ${errorMsg}${helpText}`);
 		} finally {
 			settled = true;
 			if (hintShown) {
 				// The test can no longer be cancelled: stop advertising Esc so a
 				// later press cannot be mistaken for test cancellation and abort
-				// the running agent turn after the grace expires.
-				hintText?.setText(`Tested connection to "${name}".`);
+				// the running agent turn after the grace expires. Sealing the
+				// block after the final text lets TranscriptContainer treat it
+				// as immutable history from here on.
+				hintText?.setText(theme.fg("muted", settleNote));
 				this.ctx.ui.requestRender();
+				hintBlock?.seal();
 			}
 			if (this.ctx.mcpTestEscapeHandlers.has(handleEscape)) {
 				if (hintShown) {

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -447,7 +447,7 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
-	it("keeps every overlapping /mcp test cancellable before aborting the stream", () => {
+	it("keeps every overlapping /mcp test cancellable and consumes ownership on dispatch", () => {
 		const { ctx, editor, spies } = createContext();
 		mutableSessionState(ctx).isStreaming = true;
 		const firstTestEscapeHandler = vi.fn();
@@ -462,13 +462,16 @@ describe("InputController escape behavior", () => {
 		expect(firstTestEscapeHandler).toHaveBeenCalledTimes(1);
 		expect(latestTestEscapeHandler).toHaveBeenCalledTimes(1);
 		expect(spies.abort).not.toHaveBeenCalled();
+		// One press consumes the ownership: the next Esc must reach the stream
+		// abort below instead of being swallowed by stale registrations.
+		expect(ctx.mcpTestEscapeHandlers.size).toBe(0);
 
-		ctx.mcpTestEscapeHandlers.delete(latestTestEscapeHandler);
 		editor.onEscape?.();
 
-		expect(firstTestEscapeHandler).toHaveBeenCalledTimes(2);
+		expect(firstTestEscapeHandler).toHaveBeenCalledTimes(1);
 		expect(latestTestEscapeHandler).toHaveBeenCalledTimes(1);
-		expect(spies.abort).not.toHaveBeenCalled();
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
 	});
 
 	it("dismisses an active /btw panel before aborting the main stream", () => {

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -236,6 +236,76 @@ describe("interactive /mcp test", () => {
 		expect(presented[0]?.isTranscriptBlockFinalized()).toBe(true);
 	});
 
+	it("treats an abort landing during manager sync as a completed test", async () => {
+		const transport = {
+			connected: true,
+			request: vi.fn(),
+			notify: vi.fn(),
+			close: vi.fn(async () => {}),
+		};
+		const connection = {
+			name: "github",
+			config: { type: "stdio" as const, command: "github-mcp-server", args: ["serve"] },
+			transport,
+			serverInfo: { name: "GitHub MCP", version: "1.0.0" },
+			capabilities: {},
+		};
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
+		const showStatus = vi.fn();
+		const presented: RenderableBlock[] = [];
+		const { promise: hintPresented, resolve: hintResolve } = Promise.withResolvers<void>();
+		const { promise: syncStarted, resolve: syncStartedResolve } = Promise.withResolvers<void>();
+		const { promise: syncGate, resolve: syncResolve } = Promise.withResolvers<void>();
+		const mcpTestEscapeHandlers = new Set<() => void>();
+		const controller = new MCPCommandController({
+			mcpTestEscapeHandlers,
+			chatContainer: { addChild: vi.fn() },
+			present: vi.fn(),
+			presentCommandOutput: (content: unknown) => {
+				if (typeof (content as { render?: unknown }).render === "function") {
+					presented.push(content as RenderableBlock);
+					hintResolve();
+				}
+			},
+			ui: { requestRender: vi.fn() },
+			editor: {},
+			showError: vi.fn(),
+			showStatus,
+			session: { refreshMCPTools: vi.fn() },
+			mcpManager: {
+				prepareConfig: vi.fn(async config => config),
+				getConnectionStatus: vi.fn(() => "disconnected"),
+				connectServers: vi.fn(async () => {
+					syncStartedResolve();
+					await syncGate;
+					return {};
+				}),
+			},
+		} as never);
+
+		const pending = controller.handle("/mcp test github");
+		await hintPresented;
+
+		// Wait until the test is past listTools and inside #syncManagerConnection:
+		// an abort here does not observe the signal, so the flow still completes.
+		await syncStarted;
+		for (const handler of [...mcpTestEscapeHandlers]) {
+			mcpTestEscapeHandlers.delete(handler);
+			handler();
+		}
+		syncResolve({});
+		await pending;
+
+		const rendered = presented.map(block => block.render(80).join("\n")).join("\n");
+		expect(rendered).toContain(`Successfully connected to "github"`);
+		expect(rendered).toContain(`Tested connection to "github".`);
+		expect(rendered).not.toContain("Cancelled connection test");
+		expect(showStatus).not.toHaveBeenCalledWith(`Cancelled MCP test for "github"`);
+		expect(presented[0]?.isTranscriptBlockFinalized()).toBe(true);
+	});
+
 	it("aborts during the awaited lookup without ever advertising esc", async () => {
 		const { promise: lookup, resolve } = Promise.withResolvers<{
 			mcpServers: Record<string, { type: string; command: string; args: string[] }>;

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -295,7 +295,7 @@ describe("interactive /mcp test", () => {
 			mcpTestEscapeHandlers.delete(handler);
 			handler();
 		}
-		syncResolve({});
+		syncResolve();
 		await pending;
 
 		const rendered = presented.map(block => block.render(80).join("\n")).join("\n");

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -77,6 +77,7 @@ describe("interactive /mcp test", () => {
 		const showStatus = vi.fn();
 		const requestRender = vi.fn();
 		const addChild = vi.fn();
+		const presented: { render: (width: number) => readonly string[] }[] = [];
 		const refreshMCPTools = vi.fn();
 		const connectToServer = vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
 		const listTools = vi.spyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
@@ -90,7 +91,12 @@ describe("interactive /mcp test", () => {
 				requestRender();
 			},
 			presentCommandOutput: (content: unknown) => {
-				for (const item of Array.isArray(content) ? content : [content]) addChild(item);
+				for (const item of Array.isArray(content) ? content : [content]) {
+					addChild(item);
+					if (typeof (item as { render?: unknown }).render === "function") {
+						presented.push(item as { render: (width: number) => readonly string[] });
+					}
+				}
 				requestRender();
 			},
 			ui: { requestRender },
@@ -108,10 +114,25 @@ describe("interactive /mcp test", () => {
 		const signal = connectToServer.mock.calls[0]?.[2]?.signal;
 		expect(signal?.aborted).toBe(false);
 		expect(mcpTestEscapeHandlers).toHaveLength(1);
-		for (const handler of mcpTestEscapeHandlers) handler();
-		expect(signal?.aborted).toBe(true);
+
+		// The settled hint must stop advertising Esc the moment cancellation is
+		// impossible, or a later press kills the running agent turn instead.
+		const rendered = presented.map(block => block.render(80).join("\n")).join("\n");
+		expect(rendered).toContain(`Tested connection to "github".`);
+		expect(rendered).not.toContain("(esc to cancel)");
+
+		// The grace window still holds while untouched...
 		vi.advanceTimersByTime(4_999);
 		expect(mcpTestEscapeHandlers).toHaveLength(1);
+
+		// ...and a press inside it gives feedback instead of silently aborting
+		// the (already-settled) test controller.
+		for (const handler of [...mcpTestEscapeHandlers]) {
+			mcpTestEscapeHandlers.delete(handler); // mirrors InputController's consume-on-dispatch
+			handler();
+		}
+		expect(showStatus).toHaveBeenCalledWith(`MCP test for "github" already finished`);
+		expect(signal?.aborted).toBe(false);
 		vi.advanceTimersByTime(1);
 		expect(mcpTestEscapeHandlers).toHaveLength(0);
 
@@ -124,6 +145,62 @@ describe("interactive /mcp test", () => {
 		expect(listTools).toHaveBeenCalledWith(connection, expect.objectContaining({ signal: expect.any(AbortSignal) }));
 		expect(disconnectServer).toHaveBeenCalledWith(connection);
 		expect(requestRender).toHaveBeenCalled();
+	});
+
+	it("cancelling a pending test consumes Esc ownership without a grace window", async () => {
+		const connectToServer = vi.spyOn(mcpClient, "connectToServer").mockImplementation((_name, _config, options) => {
+			const { promise, reject } = Promise.withResolvers<never>();
+			const signal = options?.signal;
+			if (!signal) return promise;
+			const abort = () => {
+				const error = new Error("aborted");
+				error.name = "AbortError";
+				reject(error);
+			};
+			// Esc can fire while earlier awaits (config lookup) are still pending,
+			// so the signal may already be aborted when the connection starts.
+			if (signal.aborted) {
+				abort();
+			} else {
+				signal.addEventListener("abort", abort);
+			}
+			return promise;
+		});
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
+		const showStatus = vi.fn();
+		const mcpTestEscapeHandlers = new Set<() => void>();
+		const controller = new MCPCommandController({
+			mcpTestEscapeHandlers,
+			chatContainer: { addChild: vi.fn() },
+			present: vi.fn(),
+			presentCommandOutput: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			editor: {},
+			showError: vi.fn(),
+			showStatus,
+			session: { refreshMCPTools: vi.fn() },
+			mcpManager: {
+				prepareConfig: vi.fn(async config => config),
+				getConnectionStatus: vi.fn(() => "connected"),
+			},
+		} as never);
+
+		const pending = controller.handle("/mcp test github");
+		expect(mcpTestEscapeHandlers).toHaveLength(1);
+
+		// Consume like InputController does: clear the set, then fire.
+		for (const handler of [...mcpTestEscapeHandlers]) {
+			mcpTestEscapeHandlers.delete(handler);
+			handler();
+		}
+		await pending;
+
+		expect(showStatus).toHaveBeenCalledWith(`Cancelled MCP test for "github"`);
+		expect(showStatus).not.toHaveBeenCalledWith(`MCP test for "github" already finished`);
+		// Ownership was consumed by the press: the finally block must NOT re-arm
+		// a 5s grace window that would silently swallow the next Esc.
+		expect(mcpTestEscapeHandlers).toHaveLength(0);
+		expect(connectToServer).toHaveBeenCalledTimes(1);
 	});
 
 	it("claims Esc ownership before the awaited server lookup", async () => {

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -12,6 +12,11 @@ const originalProjectDir = getProjectDir();
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
+type RenderableBlock = {
+	render: (width: number) => readonly string[];
+	isTranscriptBlockFinalized: () => boolean;
+};
+
 describe("interactive /mcp test", () => {
 	let projectDir = "";
 	let agentDir = "";
@@ -167,13 +172,24 @@ describe("interactive /mcp test", () => {
 			return promise;
 		});
 		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
+		const { promise: lookup, resolve: resolveLookup } = Promise.withResolvers<{
+			mcpServers: Record<string, { type: string; command: string; args: string[] }>;
+		}>();
+		vi.spyOn(mcpConfigWriter, "readMCPConfigFile").mockReturnValue(lookup as never);
 		const showStatus = vi.fn();
+		const presented: RenderableBlock[] = [];
+		const { promise: hintPresented, resolve: hintResolve } = Promise.withResolvers<void>();
 		const mcpTestEscapeHandlers = new Set<() => void>();
 		const controller = new MCPCommandController({
 			mcpTestEscapeHandlers,
 			chatContainer: { addChild: vi.fn() },
 			present: vi.fn(),
-			presentCommandOutput: vi.fn(),
+			presentCommandOutput: (content: unknown) => {
+				if (typeof (content as { render?: unknown }).render === "function") {
+					presented.push(content as RenderableBlock);
+					hintResolve();
+				}
+			},
 			ui: { requestRender: vi.fn() },
 			editor: {},
 			showError: vi.fn(),
@@ -188,6 +204,15 @@ describe("interactive /mcp test", () => {
 		const pending = controller.handle("/mcp test github");
 		expect(mcpTestEscapeHandlers).toHaveLength(1);
 
+		resolveLookup({
+			mcpServers: { github: { type: "stdio", command: "github-mcp-server", args: ["serve"] } },
+		});
+		// Let the hint render before cancelling: this exercises the post-hint
+		// cancellation path (connect still pending), not the pre-hint bailout.
+		await hintPresented;
+		// keeps re-rendering it (post-settlement rewrite stays visible).
+		expect(presented[0]?.isTranscriptBlockFinalized()).toBe(false);
+
 		// Consume like InputController does: clear the set, then fire.
 		for (const handler of [...mcpTestEscapeHandlers]) {
 			mcpTestEscapeHandlers.delete(handler);
@@ -201,6 +226,59 @@ describe("interactive /mcp test", () => {
 		// a 5s grace window that would silently swallow the next Esc.
 		expect(mcpTestEscapeHandlers).toHaveLength(0);
 		expect(connectToServer).toHaveBeenCalledTimes(1);
+
+		// The hint must stop advertising esc immediately on cancellation, read
+		// as cancelled (not completed), and be sealed for scrollback history.
+		expect(presented).toHaveLength(1);
+		const rendered = presented.map(block => block.render(80).join("\n")).join("\n");
+		expect(rendered).toContain(`Cancelled connection test for "github".`);
+		expect(rendered).not.toContain("(esc to cancel)");
+		expect(presented[0]?.isTranscriptBlockFinalized()).toBe(true);
+	});
+
+	it("aborts during the awaited lookup without ever advertising esc", async () => {
+		const { promise: lookup, resolve } = Promise.withResolvers<{
+			mcpServers: Record<string, { type: string; command: string; args: string[] }>;
+		}>();
+		vi.spyOn(mcpConfigWriter, "readMCPConfigFile").mockReturnValue(lookup as never);
+		const presentCommandOutput = vi.fn();
+		const showStatus = vi.fn();
+		const mcpTestEscapeHandlers = new Set<() => void>();
+		const controller = new MCPCommandController({
+			mcpTestEscapeHandlers,
+			chatContainer: { addChild: vi.fn() },
+			present: vi.fn(),
+			presentCommandOutput,
+			ui: { requestRender: vi.fn() },
+			editor: {},
+			showError: vi.fn(),
+			showStatus,
+			session: { refreshMCPTools: vi.fn() },
+			mcpManager: {
+				getServerConfig: vi.fn(() => undefined),
+				getSource: vi.fn(() => undefined),
+				prepareConfig: vi.fn(async config => config),
+				getConnectionStatus: vi.fn(() => "connected"),
+			},
+		} as never);
+
+		const pending = controller.handle("/mcp test github");
+		expect(mcpTestEscapeHandlers).toHaveLength(1);
+
+		// Esc lands while the config lookup is still awaiting: the dispatcher
+		// consumes ownership, and the resumed handler must not render a hint.
+		for (const handler of [...mcpTestEscapeHandlers]) {
+			mcpTestEscapeHandlers.delete(handler);
+			handler();
+		}
+		resolve({
+			mcpServers: { github: { type: "stdio", command: "github-mcp-server", args: ["serve"] } },
+		});
+		await pending;
+
+		expect(presentCommandOutput).not.toHaveBeenCalled();
+		expect(showStatus).toHaveBeenCalledWith(`Cancelled MCP test for "github"`);
+		expect(mcpTestEscapeHandlers).toHaveLength(0);
 	});
 
 	it("claims Esc ownership before the awaited server lookup", async () => {


### PR DESCRIPTION
Fixes the residual behavior reported in #9173 that still reproduces on v17.4.2 after #9174: pressing Esc while the `/mcp test` hint is still visible can abort the running agent turn.

## Root cause

#9174 routed `/mcp test` Esc ownership through `ctx.mcpTestEscapeHandlers` with a 5s post-settlement grace window, but left three gaps that together reproduce the original symptom:

1. **Stale advertisement** — the `(esc to cancel)` hint is a permanent transcript block that is never rewritten when the test settles. After the grace expires, Esc falls through to the streaming-turn abort while the UI still advertises test cancellation.
2. **Silent swallow** — within the grace window, Esc invokes `abortController.abort()` on an already-settled controller: a silent no-op, and the handler is never removed on dispatch. Esc appears dead, then the first post-grace press kills the turn.
3. **Ownership never consumed** — the dispatcher iterates the handler set without removing entries, so even a genuinely-used cancellation leaves stale registrations.

## Changes

- `InputController` dispatcher (`setupKeyHandlers`): snapshot + clear `mcpTestEscapeHandlers` before invoking, so one Esc press cancels every advertised test and is consumed; the next Esc reaches the stream abort.
- `MCPCommandController.#handleTest`:
  - the hint is rendered with a capturable `Text` and rewritten to `Tested connection to "<name>".` on settlement, so the screen never advertises Esc once cancellation is impossible (works in both the mounted-transcript and streaming-deferred preview paths, which render the live component);
  - a post-settlement grace press shows `MCP test for "<name>" already finished` instead of silently aborting;
  - the existing identity-guarded `finally` logic prevents grace re-arm after the handler was consumed.

## Testing

- Extended `test/input-controller-escape.test.ts` (dispatcher consumes ownership; follow-up press aborts the stream) and `test/issue-956-repro.test.ts` (post-settlement press gives feedback, not abort; rendered hint drops the esc mention; cancelling a pending test consumes ownership with no grace re-arm). 39 tests pass across both suites.
- `bun check` clean.
