### PR TITLE
fix(browser): keep live broker-owned attachments pooled at refCount 0 (#7900)

### DIFF
--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -318,15 +318,39 @@ export function holdBrowser(handle: BrowserHandle): void {
 	handle.refCount++;
 }
 
+/**
+ * A broker-owned headless handle is a pooled *attachment*, not an owned
+ * process: `disposeBrowserHandle` only drops our CDP link, because the shared
+ * daemon owns the Chromium. Evicting such a handle at refCount 0 therefore
+ * throws away a live, reusable attachment — the next `acquireBrowser` finds an
+ * empty pool and re-attaches, and each `newPage()` on the new attachment costs
+ * another renderer tree that the previous `disconnect()` never reclaimed. That
+ * is the per-call process growth in issue #7900.
+ *
+ * Returns the handle when it is a live broker attachment that should stay
+ * pooled for reuse, otherwise null.
+ */
+function livePooledAttachment(handle: BrowserHandle): PuppeteerBrowserHandle | null {
+	if ("client" in handle) return null;
+	if (handle.kind.kind !== "headless") return null;
+	if (!handle.sharedDaemon) return null;
+	return handle.browser.connected ? handle : null;
+}
+
 export async function releaseBrowser(handle: BrowserHandle, opts: ReleaseBrowserOptions): Promise<void> {
 	handle.refCount = Math.max(0, handle.refCount - 1);
-	if (handle.refCount === 0) {
-		// Only evict if the registry still points at THIS handle. After a disconnect,
-		// `acquireBrowser` may have already replaced the entry with a fresh live handle
-		// under the same key; deleting blindly would orphan that new browser.
-		if (browsers.get(handle.key) === handle) browsers.delete(handle.key);
-		await disposeBrowserHandle(handle, opts);
-	}
+	if (handle.refCount !== 0) return;
+	// Keep live broker-owned attachments pooled so the next acquisition reuses
+	// the Chromium the daemon already has running instead of re-attaching (and
+	// stranding the previous renderer tree). `acquireBrowser` still evicts and
+	// disposes this entry the moment `browser.connected` goes false, and an
+	// explicit `kill` still tears down here. (Issue #7900.)
+	if (!opts.kill && livePooledAttachment(handle) !== null) return;
+	// Only evict if the registry still points at THIS handle. After a disconnect,
+	// `acquireBrowser` may have already replaced the entry with a fresh live handle
+	// under the same key; deleting blindly would orphan that new browser.
+	if (browsers.get(handle.key) === handle) browsers.delete(handle.key);
+	await disposeBrowserHandle(handle, opts);
 }
 
 async function disposeBrowserHandle(handle: BrowserHandle, opts: ReleaseBrowserOptions): Promise<void> {

--- a/packages/coding-agent/test/tools/browser-shared-pool-reuse.test.ts
+++ b/packages/coding-agent/test/tools/browser-shared-pool-reuse.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test for issue #7900: `web_search` grows the Chromium process
+ * tree by one full browser per call.
+ *
+ * `releaseBrowser` evicted the handle from the module-global `browsers` map on
+ * every transition to refCount 0. For the shared-daemon headless kind,
+ * `disposeBrowserHandle` deliberately only drops this process's CDP link (the
+ * broker owns the Chromium), so eviction threw away a live, reusable
+ * attachment: the next `acquireBrowser` found an empty pool and re-attached,
+ * while the renderer tree behind the previous attachment was never reclaimed.
+ *
+ * The pool must retain a *live* broker-owned attachment at refCount 0, and
+ * must still tear down when the caller asks to kill, when the attachment is
+ * already disconnected, or for any non-broker browser kind.
+ *
+ * Handles are hand-built and seeded directly into the registry map (same
+ * approach as browser-dispose-timeout.test.ts) so no real broker, socket, or
+ * Chromium is needed.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	type BrowserHandle,
+	getBrowsersMapForTest,
+	releaseBrowser,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+
+interface Probe {
+	handle: BrowserHandle;
+	disconnectCalls: () => number;
+	closeCalls: () => number;
+}
+
+/** Headless handle attached to the project-shared broker Chromium. */
+function makeSharedHeadlessHandle(opts?: { connected?: boolean }): Probe {
+	let disconnectCalls = 0;
+	let closeCalls = 0;
+	const handle = {
+		key: "headless:1",
+		kind: { kind: "headless", headless: true },
+		refCount: 1,
+		sharedDaemon: { name: "omp.browser.headless", projectDir: "/tmp/omp-7900" },
+		browser: {
+			connected: opts?.connected ?? true,
+			process: () => null,
+			disconnect: () => {
+				disconnectCalls++;
+			},
+			close: async () => {
+				closeCalls++;
+			},
+		},
+		stealth: { browserSession: null, override: null },
+	} as unknown as BrowserHandle;
+	return { handle, disconnectCalls: () => disconnectCalls, closeCalls: () => closeCalls };
+}
+
+/** Process-local headless launch (no broker) — OMP owns this Chromium. */
+function makeProcessLocalHeadlessHandle(): Probe {
+	let disconnectCalls = 0;
+	let closeCalls = 0;
+	const handle = {
+		key: "headless:1",
+		kind: { kind: "headless", headless: true },
+		refCount: 1,
+		browser: {
+			connected: true,
+			process: () => null,
+			disconnect: () => {
+				disconnectCalls++;
+			},
+			close: async () => {
+				closeCalls++;
+			},
+		},
+		stealth: { browserSession: null, override: null },
+	} as unknown as BrowserHandle;
+	return { handle, disconnectCalls: () => disconnectCalls, closeCalls: () => closeCalls };
+}
+
+function registry(): Map<string, BrowserHandle> {
+	return getBrowsersMapForTest() as Map<string, BrowserHandle>;
+}
+
+function publish(handle: BrowserHandle): void {
+	registry().set(handle.key, handle);
+}
+
+describe("browser registry — broker-owned headless attachments stay pooled (issue #7900)", () => {
+	afterEach(() => {
+		registry().clear();
+	});
+
+	it("retains a live shared-daemon handle in the pool at refCount 0", async () => {
+		const { handle, disconnectCalls, closeCalls } = makeSharedHeadlessHandle();
+		publish(handle);
+
+		await releaseBrowser(handle, { kill: false });
+
+		expect(handle.refCount).toBe(0);
+		// The whole point: the next acquireBrowser("headless:1") must find this
+		// attachment and reuse the broker's Chromium instead of re-attaching.
+		expect(registry().get("headless:1")).toBe(handle);
+		// Dropping the CDP link is what stranded the previous renderer tree.
+		expect(disconnectCalls()).toBe(0);
+		expect(closeCalls()).toBe(0);
+	});
+
+	it("reuses the pooled attachment across repeated acquire/release cycles", async () => {
+		const { handle, disconnectCalls } = makeSharedHeadlessHandle();
+		publish(handle);
+
+		// Ten `web_search` calls in a row: hold + release against the same handle.
+		for (let i = 0; i < 10; i++) {
+			handle.refCount++;
+			await releaseBrowser(handle, { kill: false });
+		}
+
+		expect(registry().size).toBe(1);
+		expect(registry().get("headless:1")).toBe(handle);
+		expect(disconnectCalls()).toBe(0);
+	});
+
+	it("disposes a shared-daemon handle whose attachment is already dead", async () => {
+		const { handle } = makeSharedHeadlessHandle({ connected: false });
+		publish(handle);
+
+		await releaseBrowser(handle, { kill: false });
+
+		// A dead attachment is worthless to the next acquisition; it must not
+		// be handed out, so it is evicted as before.
+		expect(registry().has("headless:1")).toBe(false);
+	});
+
+	it("still tears down a shared-daemon handle on an explicit kill", async () => {
+		const { handle, disconnectCalls } = makeSharedHeadlessHandle();
+		publish(handle);
+
+		await releaseBrowser(handle, { kill: true });
+
+		expect(registry().has("headless:1")).toBe(false);
+		expect(disconnectCalls()).toBe(1);
+	});
+
+	it("leaves process-local headless teardown unchanged (guards issue #5260)", async () => {
+		const { handle, closeCalls } = makeProcessLocalHeadlessHandle();
+		publish(handle);
+
+		await releaseBrowser(handle, { kill: false });
+
+		// No broker owns this Chromium — OMP must still close it and evict.
+		expect(registry().has("headless:1")).toBe(false);
+		expect(closeCalls()).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes #7900 — `web_search` grows the Chromium process tree by one full browser per call.

Supersedes #9319 and #9321 (both branched from a fork `main` that carried unrelated commits). This PR is branched directly from `abe6fec3` and touches **2 files only**.

## Root cause

`releaseBrowser()` evicted the handle from the module-global `browsers` map on **every** transition to refCount 0:

```ts
handle.refCount = Math.max(0, handle.refCount - 1);
if (handle.refCount === 0) {
  if (browsers.get(handle.key) === handle) browsers.delete(handle.key);
  await disposeBrowserHandle(handle, opts);
}
```

For the shared-daemon headless kind that is wrong, because `disposeBrowserHandle()` deliberately does **not** close the browser — the broker owns the Chromium, so it only calls `browser.disconnect()`:

```ts
if (handle.sharedDaemon) {
  if (handle.browser.connected) handle.browser.disconnect();
  return;
}
```

So the pool is emptied while the Chromium keeps running. The next `acquireBrowser()` finds no entry and re-attaches, and every `newPage()` on the fresh attachment costs another renderer tree that the previous `disconnect()` never reclaimed.

`browseHtmlPage()` releases with `{ kill: false }` in its `finally`, so this fires **once per `web_search`** — matching the reported one-browser-per-call growth.

## The fix

`livePooledAttachment()` identifies a live broker-owned headless handle, and `releaseBrowser()` retains it in the pool instead of evicting:

```ts
if (handle.refCount !== 0) return;
if (!opts.kill && livePooledAttachment(handle) !== null) return;
```

Safety of retention: `acquireBrowser()` already evicts and disposes any pooled entry whose `browser.connected` has gone false, so a dead broker attachment can never be handed out.

## Teardown paths deliberately left unchanged

| Path | Behaviour |
|---|---|
| explicit `kill: true` | evicts + disposes (unchanged) |
| attachment already disconnected | evicts + disposes (unchanged) |
| process-local headless (no `sharedDaemon`) | closes + evicts — **guards #5260** |
| cmux handles | `client.close()` + evict — **guards #3963** |
| `connected` / `relay` | disconnect + evict (unchanged) |

## Tests

Adds `packages/coding-agent/test/tools/browser-shared-pool-reuse.test.ts` (5 cases):

1. live shared-daemon handle stays in the pool at refCount 0, with **0** `disconnect()` and **0** `close()` calls
2. 10 consecutive acquire/release cycles reuse the same handle; registry size stays 1
3. a shared-daemon handle with a dead attachment is still evicted
4. `kill: true` still evicts and disconnects
5. process-local headless still closes and evicts (#5260 non-regression)

Handles are hand-built and seeded via `getBrowsersMapForTest()` — the same approach as the existing `browser-dispose-timeout.test.ts` — so no broker, socket, or real Chromium is required. `scripts/ci-test-ts.ts` routes `*browser*.test.ts` into the coding-agent native/unit bucket automatically, so no test registration change is needed.

## CI note (pre-existing, unrelated to this PR)

All `bun install` jobs on this repo currently fail on `main` for **every** PR:

```
error: No version matching "^0.2.0" found for specifier "kitty-vt-wasm" (but package exists)
error: kitty-vt-wasm@catalog: failed to resolve
```

Evidence this is not caused by this change:

- `bun.lock` was last regenerated at **2026-08-22T00:43:51Z** in `a7e19be81039c110ba943af1281666dc7b0810b0`.
- `561d212726ac00f66df1dec53c4ffe46fa96b130` ("feat(tui): enabled kitty-vt-wasm engine and tests, dropping workarounds", **2026-08-22T04:26:36Z**) swapped the catalog dependency `ghostty-web: ^0.4.0` → `kitty-vt-wasm: ^0.2.0` in both the root `package.json` and `packages/tui/package.json` **without regenerating `bun.lock`** — 3 h 43 min of drift.
- Unrelated PR #9316 fails identically; in both PRs the non-bun jobs (`Build native addons (bazel)`, `Evaluate flake`, `Resolve release metadata`) are green while all 9 bun-install jobs are red.
- This exact head tree is **fully green** on a fork run: 11 success / 10 skipped / 0 failed.

Resolving it needs either `kitty-vt-wasm@0.2.x` published, the catalog range corrected, or a regenerated `bun.lock` — a maintainer-side change, so it is intentionally not attempted here.
