### PR TITLE
fix(tui): correct csharp edit icon

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Code blocks now syntax-highlight live while the response streams instead of staying plain until the block settles
+- Fixed edit results showing the D3.js Nerd Font icon for C# files instead of the C# icon ([#9323](https://github.com/can1357/oh-my-pi/issues/9323)).
 - Fixed `/shake thinking` reporting "Nothing to shake" after removing reasoning; it now reports the dropped count and leaves thinking-only turns empty.
 - Fixed session teardown occasionally losing pending input drafts during shutdown
 - Fixed streaming edit failures caused by trailing partial lines

--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -960,7 +960,7 @@ const NERD_SYMBOLS: SymbolMap = {
 	"lang.java": "\u{E738}",
 	"lang.c": "\u{E61E}",
 	"lang.cpp": "\u{E61D}",
-	"lang.csharp": "\u{E7BC}",
+	"lang.csharp": "\u{E7B2}",
 	"lang.ruby": "\u{E791}",
 	"lang.julia": "\u{E624}",
 	"lang.php": "\u{E608}",

--- a/packages/coding-agent/test/theme-nerd-symbols.test.ts
+++ b/packages/coding-agent/test/theme-nerd-symbols.test.ts
@@ -23,7 +23,7 @@ afterEach(async () => {
 	tempAgentDir = undefined;
 });
 
-it("uses the Nerd Fonts v3 Material Design session icon", async () => {
+it("uses the Nerd Fonts v3 session and C# icons", async () => {
 	originalAgentDir = getAgentDir();
 	originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
 	tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-nerd-symbols-"));
@@ -38,6 +38,7 @@ it("uses the Nerd Fonts v3 Material Design session icon", async () => {
 
 	const theme = await getThemeByName(customThemeName);
 	expect(theme?.symbol("icon.session")).toBe("\u{f0051}");
+	expect(theme?.getLangIcon("csharp")).toBe("\u{e7b2}");
 });
 
 it("resolves subscription and advisor icons in Nerd Font mode", async () => {


### PR DESCRIPTION
## Repro
Rendering a `.cs` edit in Nerd Font mode resolves `lang.csharp` to the D3.js glyph. The minimal probe `bun -e 'import { SYMBOL_PRESETS } from "./packages/coding-agent/src/modes/theme/symbols.ts"; const icon = SYMBOL_PRESETS.nerd["lang.csharp"]; const actual = icon.codePointAt(0)?.toString(16).toUpperCase(); console.log(`lang.csharp: U+${actual}`); console.log("expected: U+E7B2"); process.exit(actual === "E7B2" ? 0 : 1);'` printed U+E7BC and exited 1 before the fix.

## Cause
`packages/coding-agent/src/modes/theme/symbols.ts` assigned U+E7BC (`nf-dev-d3js`) to the Nerd Font `lang.csharp` symbol. `Theme.getLangIcon()` then supplied that symbol to the edit header renderer for `.cs` paths.

## Fix
- Map `lang.csharp` to Nerd Fonts’ C# devicon at U+E7B2.
- Cover C# resolution through the Nerd Font theme test.
- Document the user-visible correction in the coding-agent changelog.

## Verification
The focused codepoint probe now prints `lang.csharp: U+E7B2` and exits 0. `bun test packages/coding-agent/test/theme-nerd-symbols.test.ts` could not start because dependencies are absent; `bun install --frozen-lockfile` fails identically on clean `main` because `kitty-vt-wasm@^0.2.0` is not published. `bun check` likewise fails identically on clean `main` because Biome is unavailable, so the pre-publish gate was skipped.

Fixes #9323