### PR TITLE
fix(stats): query only folder stats in folder endpoint

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Projects dashboard folder endpoint running unrelated dashboard aggregations when loading folder statistics.
+
 ## [17.4.0] - 2026-08-20
 
 ### Changed

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -43,6 +43,7 @@ import type { SyncWorkerRequest, SyncWorkerResponse } from "./sync-worker";
 import type {
 	BehaviorDashboardStats,
 	DashboardStats,
+	FolderStats,
 	MessageStats,
 	ProviderDashboardStats,
 	RequestDetails,
@@ -478,6 +479,13 @@ export async function getCostDashboardStats(range?: string | null): Promise<Pick
 		costSeries: getCostTimeSeries(costSeriesDays, cutoff),
 	};
 }
+
+export async function getFolderStats(range?: string | null): Promise<FolderStats[]> {
+	await initDb();
+	const { cutoff } = getTimeRangeConfig(range);
+	return getStatsByFolder(cutoff ?? undefined);
+}
+
 export async function getRecentRequests(limit?: number): Promise<MessageStats[]> {
 	await initDb();
 	return dbGetRecentRequests(limit);

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -8,6 +8,7 @@ import {
 	getBehaviorDashboardStats,
 	getCostDashboardStats,
 	getDashboardStats,
+	getFolderStats,
 	getModelDashboardStats,
 	getOverviewStats,
 	getProviderDashboardStats,
@@ -253,8 +254,8 @@ export async function handleApi(req: Request): Promise<Response> {
 	}
 
 	if (path === "/api/stats/folders") {
-		const stats = await getDashboardStats(range);
-		return Response.json(stats.byFolder);
+		const stats = await getFolderStats(range);
+		return Response.json(stats);
 	}
 
 	if (path === "/api/stats/timeseries") {

--- a/packages/stats/test/db-range.test.ts
+++ b/packages/stats/test/db-range.test.ts
@@ -99,13 +99,17 @@ describe("getDashboardStats time range", () => {
 	});
 
 	it("returns range-filtered folder stats through the HTTP API", async () => {
-		await initDb();
+		const db = await initDb();
 
 		const now = Date.now();
 		insertMessageStats([
 			makeMessage(now, "api-folder-within-24h", "/tmp/current-project"),
 			makeMessage(now - 48 * 60 * 60 * 1000, "api-folder-outside-24h", "/tmp/older-project"),
 		]);
+
+		// The legacy dashboard path reads this in getStatsByAgentType; the folder query does not.
+		db.run("DROP INDEX idx_messages_timestamp_agent_type");
+		db.run("ALTER TABLE messages DROP COLUMN agent_type");
 
 		const folders = await readFolderStats(
 			await handleApi(new Request("http://stats.test/api/stats/folders?range=24h")),

--- a/packages/stats/test/db-range.test.ts
+++ b/packages/stats/test/db-range.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { getDashboardStats } from "@oh-my-pi/omp-stats/aggregator";
+import { getDashboardStats, getFolderStats } from "@oh-my-pi/omp-stats/aggregator";
 import { initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
-import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import type { FolderStats, MessageStats } from "@oh-my-pi/omp-stats/types";
+import { handleApi } from "../src/server";
 import { installStatsTestIsolation } from "./helpers/temp-agent";
 
 installStatsTestIsolation("@pi-stats-db-range-");
 
-function makeMessage(timestamp: number, entryId: string): MessageStats {
+function makeMessage(timestamp: number, entryId: string, folder = "/tmp/project"): MessageStats {
 	return {
 		sessionFile: "/tmp/session.jsonl",
 		entryId,
-		folder: "/tmp/project",
+		folder,
 		model: "gpt-5.4",
 		provider: "openai-codex",
 		api: "openai-codex-responses",
@@ -35,6 +36,11 @@ function makeMessage(timestamp: number, entryId: string): MessageStats {
 		},
 		agentType: "main",
 	};
+}
+
+async function readFolderStats(response: Response): Promise<FolderStats[]> {
+	expect(response.status).toBe(200);
+	return response.json() as Promise<FolderStats[]>;
 }
 
 describe("getDashboardStats time range", () => {
@@ -68,5 +74,42 @@ describe("getDashboardStats time range", () => {
 
 		const stats = await getDashboardStats("last century");
 		expect(stats.overall.totalRequests).toBe(1);
+	});
+
+	it("filters dedicated folder stats by selected range", async () => {
+		await initDb();
+
+		const now = Date.now();
+		insertMessageStats([
+			makeMessage(now, "folder-within-24h", "/tmp/current-project"),
+			makeMessage(now - 48 * 60 * 60 * 1000, "folder-outside-24h", "/tmp/older-project"),
+		]);
+
+		const dayStats = await getFolderStats("24h");
+		expect(dayStats).toEqual([expect.objectContaining({ folder: "/tmp/current-project", totalRequests: 1 })]);
+
+		const allStats = await getFolderStats("all");
+		expect(allStats).toHaveLength(2);
+		expect(allStats).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ folder: "/tmp/current-project", totalRequests: 1 }),
+				expect.objectContaining({ folder: "/tmp/older-project", totalRequests: 1 }),
+			]),
+		);
+	});
+
+	it("returns range-filtered folder stats through the HTTP API", async () => {
+		await initDb();
+
+		const now = Date.now();
+		insertMessageStats([
+			makeMessage(now, "api-folder-within-24h", "/tmp/current-project"),
+			makeMessage(now - 48 * 60 * 60 * 1000, "api-folder-outside-24h", "/tmp/older-project"),
+		]);
+
+		const folders = await readFolderStats(
+			await handleApi(new Request("http://stats.test/api/stats/folders?range=24h")),
+		);
+		expect(folders).toEqual([expect.objectContaining({ folder: "/tmp/current-project", totalRequests: 1 })]);
 	});
 });


### PR DESCRIPTION
## What

I noticed that switching time ranges in the Projects stats view became noticeably sluggish with roughly 1 GB of local stats data, and I reviewed this patch to ensure the endpoint now runs only the folder aggregation it returns.

- Route `/api/stats/folders` through a dedicated range-aware folder aggregator so it runs only the aggregation required for folder statistics.

## Why

- The Projects dashboard previously computed unrelated dashboard aggregates even though this endpoint returns only folder statistics.

## Testing

- `bun test test/db-range.test.ts`
- `bun --cwd=packages/stats run check`
- `bun test test/db-range.test.ts --test-name-pattern "returns range-filtered folder stats through the HTTP API"`
- `bun check`: blocked by existing formatting errors outside this change in `crates/pi-natives/src/highlight.rs`, `packages/coding-agent/src/edit/sloppy.ts`, and `packages/coding-agent/src/edit/streaming.ts`.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
