### PR TITLE
fix(coding-agent): guard context-breakdown token estimate against missing descriptions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagents crashing before their first turn when an extension contributed a tool or skill without a `description`; the context-breakdown token estimate now coalesces missing descriptions and system-prompt sections instead of passing `undefined` to the tokenizer ([#9331](https://github.com/can1357/oh-my-pi/issues/9331)).
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -212,7 +212,8 @@ export function computeNonMessageTokens(session: NonMessageTokenSource, tokenize
 	if (entry.tokens !== undefined) return entry.tokens;
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const tools = session.agent?.state?.tools ?? EMPTY_TOOLS;
-	const tokens = tokenizer.countTokens(systemPromptParts) + estimateToolSchemaTokens(tools, tokenizer);
+	const tokens =
+		tokenizer.countTokens(systemPromptParts.map(part => part ?? "")) + estimateToolSchemaTokens(tools, tokenizer);
 	entry.tokens = tokens;
 	return tokens;
 }

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -213,7 +213,8 @@ export function computeNonMessageTokens(session: NonMessageTokenSource, tokenize
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const tools = session.agent?.state?.tools ?? EMPTY_TOOLS;
 	const tokens =
-		tokenizer.countTokens(systemPromptParts.map(part => part ?? "")) + estimateToolSchemaTokens(tools, tokenizer);
+		tokenizer.countTokens(Array.from(systemPromptParts, part => part ?? "")) +
+		estimateToolSchemaTokens(tools, tokenizer);
 	entry.tokens = tokens;
 	return tokens;
 }
@@ -239,7 +240,7 @@ export function computeNonMessageBreakdown(
 	const skillsTokens = estimateSkillsTokens(renderedSkills(session.skills ?? EMPTY_SKILLS, tools), tokenizer);
 	const toolsTokens = estimateToolSchemaTokens(tools, tokenizer);
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
-	const systemContextTokens = tokenizer.countTokens(systemPromptParts.slice(1).map(part => part ?? ""));
+	const systemContextTokens = tokenizer.countTokens(Array.from(systemPromptParts.slice(1), part => part ?? ""));
 	const systemPromptTokens = Math.max(0, tokenizer.countTokens(systemPromptParts[0] ?? "") - skillsTokens);
 	const breakdown = { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
 	entry.breakdown = breakdown;

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -116,7 +116,7 @@ export function estimateSkillsTokens(skills: readonly Skill[], tokenizer: Tokeni
 	for (const skill of skills) {
 		// "- name: description\n" wire framing tokenizes ~identically to the
 		// concatenated form, so encode each piece separately and sum.
-		fragments.push(skill.name, skill.description);
+		fragments.push(skill.name, skill.description ?? "");
 	}
 	return tokenizer.countTokens(fragments);
 }
@@ -127,7 +127,7 @@ export function estimateToolSchemaTokens(
 ): number {
 	const fragments: string[] = [];
 	for (const tool of tools) {
-		fragments.push(tool.name, tool.description);
+		fragments.push(tool.name, tool.description ?? "");
 		try {
 			const wireTool: AiTool = {
 				name: tool.name,
@@ -238,7 +238,7 @@ export function computeNonMessageBreakdown(
 	const skillsTokens = estimateSkillsTokens(renderedSkills(session.skills ?? EMPTY_SKILLS, tools), tokenizer);
 	const toolsTokens = estimateToolSchemaTokens(tools, tokenizer);
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
-	const systemContextTokens = tokenizer.countTokens(systemPromptParts.slice(1));
+	const systemContextTokens = tokenizer.countTokens(systemPromptParts.slice(1).map(part => part ?? ""));
 	const systemPromptTokens = Math.max(0, tokenizer.countTokens(systemPromptParts[0] ?? "") - skillsTokens);
 	const breakdown = { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
 	entry.breakdown = breakdown;

--- a/packages/coding-agent/test/context-consolidation.test.ts
+++ b/packages/coding-agent/test/context-consolidation.test.ts
@@ -59,6 +59,7 @@ describe("Context usage consolidation", () => {
 	function createSession(
 		tempDir: TempDir,
 		messages: AgentMessage[] = [],
+		systemPrompt: string[] = ["You are a helpful assistant."],
 	): { session: AgentSession; sessionManager: SessionManager; agent: Agent } {
 		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
 		for (const msg of messages) {
@@ -69,7 +70,7 @@ describe("Context usage consolidation", () => {
 			getApiKey: () => "test-key",
 			initialState: {
 				model: mockModel,
-				systemPrompt: ["You are a helpful assistant."],
+				systemPrompt,
 				tools: [],
 				messages,
 			},
@@ -544,6 +545,25 @@ describe("Context usage consolidation", () => {
 		expect(typeof cu?.tokens).toBe("number");
 		expect(cu?.percent).not.toBeNull();
 		expect(typeof cu?.percent).toBe("number");
+
+		await tempDir.remove();
+	});
+
+	// A before_agent_start extension can hand back a system-prompt array with a
+	// missing (undefined) section. getContextBreakdown funnels that array into
+	// both estimate paths — computeNonMessageBreakdown AND the collapsed
+	// computeNonMessageTokens — so the whole call must tolerate it rather than
+	// throwing "Failed to measure JavaScript string" and killing the session
+	// (issue #9331).
+	it("tolerates an undefined system-prompt section without throwing", async () => {
+		const tempDir = TempDir.createSync("@malformed-prompt-");
+		const malformed = ["You are a helpful assistant.", undefined as unknown as string, "trailing context"];
+		const { session } = createSession(tempDir, [], malformed);
+
+		const breakdown = session.getContextBreakdown();
+		expect(breakdown).toBeDefined();
+		expect(Number.isFinite(breakdown?.systemContextTokens ?? Number.NaN)).toBe(true);
+		expect(breakdown?.usedTokens ?? -1).toBeGreaterThanOrEqual(0);
 
 		await tempDir.remove();
 	});

--- a/packages/coding-agent/test/modes/context-usage.test.ts
+++ b/packages/coding-agent/test/modes/context-usage.test.ts
@@ -177,3 +177,47 @@ describe("computeNonMessageBreakdown skills filtering", () => {
 		expect(b.systemPromptTokens).toBe(computeNonMessageBreakdown(session([], []), tokenizer).systemPromptTokens);
 	});
 });
+
+/**
+ * Contract: a tool, skill, or system-prompt section with a missing
+ * (`undefined`) description/text must not crash the token estimate. Extensions
+ * can contribute tools whose `description` is absent at runtime (the field is
+ * typed `string` but the extension API does not enforce it); before the guard,
+ * the `undefined` fragment reached the tokenizer and threw, killing every
+ * subagent before its first turn (issue #9331). Each path must instead yield a
+ * finite, non-negative estimate.
+ */
+describe("non-message estimates tolerate a missing description", () => {
+	const readTool = { name: "read", description: "read files", parameters: {} };
+
+	it("estimateToolSchemaTokens does not throw on an undefined tool description", () => {
+		const tokens = estimateToolSchemaTokens(
+			[{ name: "lens_tool", description: undefined, parameters: {} } as never],
+			tokenizer,
+		);
+		expect(Number.isFinite(tokens)).toBe(true);
+		expect(tokens).toBeGreaterThanOrEqual(0);
+	});
+
+	it("computeNonMessageBreakdown does not throw on an undefined skill description", () => {
+		const session = {
+			systemPrompt: ["You are an agent."],
+			agent: { state: { tools: [readTool] } },
+			skills: [{ name: "lens", description: undefined, filePath: "/s/l.md" }],
+		} as never;
+		const b = computeNonMessageBreakdown(session, tokenizer);
+		expect(Number.isFinite(b.skillsTokens)).toBe(true);
+		expect(b.skillsTokens).toBeGreaterThanOrEqual(0);
+	});
+
+	it("computeNonMessageBreakdown does not throw on an undefined system-context section", () => {
+		const session = {
+			systemPrompt: ["primary prompt", undefined, "trailing context"],
+			agent: { state: { tools: [readTool] } },
+			skills: [],
+		} as never;
+		const b = computeNonMessageBreakdown(session, tokenizer);
+		expect(Number.isFinite(b.systemContextTokens)).toBe(true);
+		expect(b.systemContextTokens).toBeGreaterThanOrEqual(0);
+	});
+});


### PR DESCRIPTION
## Repro
With a third-party extension contributing a tool (or skill) whose `description` is undefined at runtime, every `task`-tool subagent dies ~1s in, before its first model turn, while the parent session is unaffected. Minimal driver against the offending helpers:

```ts
import { Tokenizer } from "@oh-my-pi/pi-agent-core";
import { estimateSkillsTokens, estimateToolSchemaTokens } from "../src/modes/utils/context-usage";
const t = new Tokenizer();
estimateToolSchemaTokens([{ name: "lens_tool", description: undefined, parameters: {} }], t);
estimateSkillsTokens([{ name: "s", description: undefined }], t);
```

Both throw `TypeError: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received undefined` (JS estimator); in a compiled binary the array reaches the native counter, which reports `Failed to measure JavaScript string` — the two stacks in #9331.

## Cause
`packages/coding-agent/src/modes/utils/context-usage.ts` builds a `string[]` fragment array and hands it to `tokenizer.countTokens`. Three pushes were unguarded: `estimateSkillsTokens` (`skill.description`), `estimateToolSchemaTokens` (`tool.description`), and `computeNonMessageBreakdown`'s `systemPromptParts.slice(1)`. `Tool.description` is typed `string` but the extension API does not enforce it, so an `undefined` element reached the tokenizer and threw inside `getContextBreakdown` → `runPrePromptCompactionIfNeeded`, killing the subagent. The neighboring fields (`parameters ?? {}`, the `JSON.stringify` try/catch, `systemPromptParts[0] ?? ""`) were already defended — these three were an inconsistent oversight.

## Fix
- `estimateSkillsTokens`: push `skill.description ?? ""`.
- `estimateToolSchemaTokens`: push `tool.description ?? ""`.
- `computeNonMessageBreakdown`: coalesce the system-context walk with `.slice(1).map(part => part ?? "")`.
- Added a regression block in `test/modes/context-usage.test.ts` covering all three paths (undefined tool description, undefined skill description, undefined system-context section).

## Verification
`bun test packages/coding-agent/test/modes/context-usage.test.ts` → 12 pass, 0 fail. The three new cases each threw before the guard and now yield finite non-negative estimates.

Fixes #9331