### PR TITLE
fix(coding-agent): skip inaccessible git metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed startup crashes when temporary Git worktrees point to repository metadata that the current user cannot access.
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $which, hasFsCode, isEisdir, isEnoent, isEnotdir, Snowflake } from "@oh-my-pi/pi-utils";
+import { $which, hasFsCode, isEacces, isEisdir, isEnoent, isEnotdir, Snowflake } from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
 import {
 	parseDiffHunks as parseCommitDiffHunks,
@@ -696,6 +696,10 @@ async function writeTempPatch(content: string): Promise<string> {
 
 type EntryType = "directory" | "file";
 
+function isPermissionError(err: unknown): boolean {
+	return isEacces(err) || hasFsCode(err, "EPERM");
+}
+
 function shouldRetry(err: unknown, n: number) {
 	if (isEnoent(err) || isEisdir(err) || isEnotdir(err) || hasFsCode(err, "ENFILE") || hasFsCode(err, "EMFILE"))
 		return false;
@@ -708,8 +712,8 @@ function shouldRetry(err: unknown, n: number) {
  * Bounded retry for synchronous I/O against `EINTR`. POSIX permits short syscalls
  * to be interrupted by signals; when that happens libc traditionally retries.
  * Node's sync wrappers surface the raw `EINTR` so we replicate the retry locally.
- * Any other error (and persistent EINTR after `EINTR_MAX_RETRIES`) is rethrown
- * for the caller's normal "optional metadata" classifier to handle.
+ * Path absence, path-type mismatches, descriptor exhaustion, and exhausted
+ * `EINTR` retries return `null`. Other errors are rethrown.
  */
 const EINTR_MAX_RETRIES = 3;
 function retryOnEintrSync<T>(op: () => T): T | null {
@@ -863,8 +867,13 @@ function resolveRepositorySync(startDir: string): GitRepository | null {
 		const gitEntryPath = path.join(current, ".git");
 		const entryType = getEntryTypeSync(gitEntryPath);
 		if (entryType) {
-			const repository = resolveRepoFromEntrySync(current, gitEntryPath, entryType);
-			if (repository) return repository;
+			try {
+				const repository = resolveRepoFromEntrySync(current, gitEntryPath, entryType);
+				if (repository) return repository;
+			} catch (err) {
+				if (entryType === "file" && isPermissionError(err)) return null;
+				throw err;
+			}
 		}
 		const parent = path.dirname(current);
 		if (parent === current) return null;
@@ -878,8 +887,13 @@ async function resolveRepository(startDir: string): Promise<GitRepository | null
 		const gitEntryPath = path.join(current, ".git");
 		const entryType = await getEntryType(gitEntryPath);
 		if (entryType) {
-			const repository = await resolveRepoFromEntry(current, gitEntryPath, entryType);
-			if (repository) return repository;
+			try {
+				const repository = await resolveRepoFromEntry(current, gitEntryPath, entryType);
+				if (repository) return repository;
+			} catch (err) {
+				if (entryType === "file" && isPermissionError(err)) return null;
+				throw err;
+			}
 		}
 		const parent = path.dirname(current);
 		if (parent === current) return null;

--- a/packages/coding-agent/test/git-linked-worktree.test.ts
+++ b/packages/coding-agent/test/git-linked-worktree.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -20,7 +20,7 @@ function linkWorktree(project: string, worktreeRoot: string): void {
 	fs.writeFileSync(path.join(worktreeRoot, ".git"), `gitdir: ${path.relative(worktreeRoot, gitDir)}\n`, "utf8");
 }
 
-describe("git repo.linkedWorktreeSync", () => {
+describe("git linked worktree resolution", () => {
 	let tempRoot: string;
 
 	beforeEach(() => {
@@ -28,6 +28,7 @@ describe("git repo.linkedWorktreeSync", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		fs.rmSync(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 	});
 
@@ -61,5 +62,32 @@ describe("git repo.linkedWorktreeSync", () => {
 		fs.mkdirSync(bare, { recursive: true });
 
 		expect(repo.linkedWorktreeSync(bare)).toBeNull();
+	});
+
+	it("stops at an inaccessible linked worktree instead of resolving an outer repository", async () => {
+		const worktreeRoot = path.join(tempRoot, "foreign-worktree");
+		const gitDir = path.join(tempRoot, "foreign-home", "repo", ".git", "worktrees", "foreign-worktree");
+		fs.mkdirSync(worktreeRoot, { recursive: true });
+		fs.mkdirSync(path.join(tempRoot, ".git"));
+		fs.writeFileSync(path.join(worktreeRoot, ".git"), `gitdir: ${gitDir}\n`, "utf8");
+
+		const statSync = fs.statSync;
+		vi.spyOn(fs, "statSync").mockImplementation(((target: fs.PathLike) => {
+			if (path.resolve(target.toString()) === gitDir) {
+				throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+			}
+			return statSync(target);
+		}) as typeof fs.statSync);
+		expect(repo.resolveSync(worktreeRoot)).toBeNull();
+
+		vi.restoreAllMocks();
+		const stat = fs.promises.stat;
+		vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike) => {
+			if (path.resolve(target.toString()) === gitDir) {
+				throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+			}
+			return stat(target);
+		}) as typeof fs.promises.stat);
+		expect(await repo.resolve(worktreeRoot)).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -667,6 +667,28 @@ describe("detachGitDir", () => {
 		expect(await runGit(wt, ["rev-parse", "omp-fetched"])).toBe(taskCommit);
 	});
 
+	it("keeps shared git metadata intact when the index cannot be read", async () => {
+		const { wt, commonDir } = await makeLinkedWorktree();
+		const iso = await copyTree(wt);
+		const gitEntry = path.join(iso, ".git");
+		const pointerBefore = await fs.readFile(gitEntry, "utf8");
+		const indexPath = await runGit(iso, ["rev-parse", "--path-format=absolute", "--git-path", "index"]);
+		const bunFile = Bun.file;
+		vi.spyOn(Bun, "file").mockImplementation(((file: string | URL, options?: BlobPropertyBag) => {
+			const handle = bunFile(file, options);
+			if (file.toString() === indexPath) {
+				vi.spyOn(handle, "bytes").mockRejectedValue(
+					Object.assign(new Error("permission denied"), { code: "EACCES" }),
+				);
+			}
+			return handle;
+		}) as typeof Bun.file);
+
+		await expect(git.detachGitDir(iso, commonDir)).rejects.toMatchObject({ code: "EACCES" });
+		expect(await fs.readFile(gitEntry, "utf8")).toBe(pointerBefore);
+		expect(await runGit(iso, ["status", "--porcelain=v1"])).toBe("");
+	});
+
 	it("leaves an already-independent full-copy checkout untouched", async () => {
 		const src = await fs.mkdtemp(path.join(os.tmpdir(), "omp-detach-src-"));
 		tempDirs.push(src);


### PR DESCRIPTION
## What

- Skip `EACCES` and `EPERM` only while resolving linked-worktree `.git` pointers.
- Stop repository discovery at an inaccessible pointer instead of selecting an outer checkout.
- Keep permission errors fatal when isolation reads the index or other snapshot metadata.
- Test discovery and detachment behavior.
- Add a coding-agent changelog entry.

## Why

omp fails to start with an unhandled exception during its branch-watching initialization.

A worktree under a shared temporary directory can point into another user's repository. Following that pointer raises `EACCES` or `EPERM` when the current user cannot traverse the repository path. The error used to escape the Git metadata probe and stop startup before the TUI opened.

## Testing

- `bun check`
- `bun test packages/coding-agent/test/git-linked-worktree.test.ts packages/coding-agent/test/task/worktree.test.ts`
- Created an inaccessible worktree pointer inside an outer repository. Confirmed that sync and async resolution returned `null` instead of throwing or selecting the outer repository.
- Simulated `EACCES` while detachment read a copied worktree index. Confirmed that detachment rejected the operation, preserved the `.git` pointer, and left Git status usable.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
