### PR TITLE
fix(natives): honor active macOS dictionaries in spellchecker

### DIFF
--- a/crates/pi-natives/src/spelling.rs
+++ b/crates/pi-natives/src/spelling.rs
@@ -24,7 +24,7 @@ mod platform {
 	use napi::{Error, Result, Status};
 	use objc2::rc::Retained;
 	use objc2_app_kit::NSSpellChecker;
-	use objc2_foundation::{NSArray, NSRange, NSString};
+	use objc2_foundation::{NSArray, NSRange, NSString, NSTextCheckingType};
 
 	use super::SpellingRange;
 
@@ -91,15 +91,28 @@ mod platform {
 	pub fn check(text: &str) -> Result<Vec<SpellingRange>> {
 		let checker = checker()?;
 		let text = NSString::from_str(text);
-		let text_len = text.length();
+		let full = NSRange { location: 0, length: text.length() };
+		// `checkString:...` honors `automaticallyIdentifiesLanguages`, selecting
+		// the dictionary per detected run; the legacy `checkSpellingOfString:`
+		// used only the shared checker's single current language (issue #9334).
+		// SAFETY: `options`/`orthography` are nil and `word_count` is null, all
+		// documented as valid; the returned array is retained by objc2.
+		let results = unsafe {
+			checker.checkString_range_types_options_inSpellDocumentWithTag_orthography_wordCount(
+				&text,
+				full,
+				NSTextCheckingType::Spelling.bits(),
+				None,
+				0,
+				None,
+				std::ptr::null_mut(),
+			)
+		};
 		let mut ranges = Vec::new();
-		let mut offset = 0usize;
-		while offset < text_len {
-			let starting_at = isize::try_from(offset)
-				.map_err(|_| Error::new(Status::InvalidArg, "spelling text is too large"))?;
-			let range = checker.checkSpellingOfString_startingAt(&text, starting_at);
-			if range.location >= NS_NOT_FOUND || range.length == 0 || range.location < offset {
-				break;
+		for result in results.iter() {
+			let range = result.range();
+			if range.length == 0 || range.location >= NS_NOT_FOUND {
+				continue;
 			}
 			ranges.push(SpellingRange {
 				start:  u32::try_from(range.location)
@@ -107,7 +120,6 @@ mod platform {
 				length: u32::try_from(range.length)
 					.map_err(|_| Error::new(Status::InvalidArg, "spelling range length is too large"))?,
 			});
-			offset = range.location.saturating_add(range.length);
 		}
 		Ok(ranges)
 	}
@@ -118,12 +130,25 @@ mod platform {
 			.unwrap_or_default()
 	}
 
+	/// Language macOS identifies for a word range, honoring automatic language
+	/// identification. Falls back to the shared checker's current language when
+	/// detection is inconclusive (issue #9334).
+	fn word_language(checker: &NSSpellChecker, text: &NSString, range: NSRange) -> Retained<NSString> {
+		checker
+			.languageForWordRange_inString_orthography(range, text, None)
+			.unwrap_or_else(|| checker.language())
+	}
+
 	pub fn completions(text: &str, start: u32, length: u32) -> Result<Vec<String>> {
 		let checker = checker()?;
 		let text = NSString::from_str(text);
 		let range = ns_range(start, length)?;
+		let language = word_language(&checker, &text, range);
 		let values = checker.completionsForPartialWordRange_inString_language_inSpellDocumentWithTag(
-			range, &text, None, 0,
+			range,
+			&text,
+			Some(&*language),
+			0,
 		);
 		Ok(strings(values))
 	}
@@ -132,8 +157,13 @@ mod platform {
 		let checker = checker()?;
 		let text = NSString::from_str(text);
 		let range = ns_range(start, length)?;
-		let values = checker
-			.guessesForWordRange_inString_language_inSpellDocumentWithTag(range, &text, None, 0);
+		let language = word_language(&checker, &text, range);
+		let values = checker.guessesForWordRange_inString_language_inSpellDocumentWithTag(
+			range,
+			&text,
+			Some(&*language),
+			0,
+		);
 		Ok(strings(values))
 	}
 
@@ -141,10 +171,11 @@ mod platform {
 		let checker = checker()?;
 		let text = NSString::from_str(text);
 		let range = ns_range(start, length)?;
+		let language = word_language(&checker, &text, range);
 		let value = checker.correctionForWordRange_inString_language_inSpellDocumentWithTag(
 			range,
 			&text,
-			&checker.language(),
+			&language,
 			0,
 		);
 		Ok(value.map(|value| value.to_string()))

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Native macOS spellchecker now honors all active system dictionaries: misspelling detection uses automatic language identification and completions/guesses/corrections select the per-word language, so non-English text (e.g. Russian) is checked instead of only the shared checker's current language ([#9334](https://github.com/can1357/oh-my-pi/issues/9334)).
+
 ## [18.0.0] - 2026-08-22
 
 ### Added


### PR DESCRIPTION
## Repro
On macOS with both `en-US` and `ru-RU` spelling dictionaries active, the prompt editor detects and suggests fixes for English misspellings but ignores Russian entirely. Isolated to the bundled native addon (`crates/pi-natives`):

```
macOSCheckSpelling("helllo world")   -> [{start:0,length:6}]
macOSCheckSpelling("превет мир")      -> []            // not detected
macOSCompleteWord("hel", 0, 3)        -> ["hello", ...]
macOSCompleteWord("прив", 0, 4)       -> []            // no candidates
macOSSpellingGuesses("превет", 0, 6)  -> []            // no guesses
```

## Cause
`crates/pi-natives/src/spelling.rs::checker()` sets `setAutomaticallyIdentifiesLanguages(true)`, but the call sites never used automatic identification. `check()` called the legacy `checkSpellingOfString:startingAt:`, which honors only the shared checker's *current* language (`en`). `completions()` and `guesses()` passed `language: None` (resolving to the Spelling-panel language, `en`), and `correction()` passed `checker.language()` (`en`). The active `ru-RU` AppleSpell dictionary was therefore never consulted for detection or suggestions.

## Fix
- `check()` now uses `checkString:range:types:options:inSpellDocumentWithTag:orthography:wordCount:` with `NSTextCheckingType.Spelling`, which respects automatic language identification and returns spelling ranges across the whole string in one pass.
- Added a `word_language()` helper that resolves the language macOS identifies for a word range via `languageForWordRange:inString:orthography:` (nil orthography → automatic identification), falling back to the shared checker's language only when detection is inconclusive.
- `completions()`, `guesses()`, and `correction()` now pass that per-word language instead of `None`/`checker.language()`.
- Changelog entry under `packages/natives` `[Unreleased] › Fixed`.

## Verification
The native spellchecker path is macOS-only (`#[cfg(target_os = "macos")]`), so it can't be executed on the Linux CI host (the backend compiles to a no-op there) and the C toolchain can't cross-build the full crate to Darwin. I validated every objc2 call in the fix by typechecking an isolated probe containing the exact rewritten functions against the pinned `objc2-app-kit`/`objc2-foundation` `0.3.2` bindings for the `aarch64-apple-darwin` target: `cargo check --target aarch64-apple-darwin` → clean compile. This corroborates the reporter's own finding that a direct `NSSpellChecker` call with `language: "ru"` correctly detects `превет`; the fix removes the hardcoded English path.

Fixes #9334