### PR TITLE
fix(coding-agent): quote `references` column in extension parse cache SQL

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -583,7 +583,7 @@ function getExtensionParseCacheDb(): Database | null {
 		const db = new Database(cachePath, { create: true });
 		db.run("PRAGMA busy_timeout = 50");
 		db.run(
-			"CREATE TABLE IF NOT EXISTS extension_parse_cache (cache_key TEXT PRIMARY KEY, source_type TEXT NOT NULL, references TEXT NOT NULL, commonjs_named_exports TEXT NOT NULL, commonjs_reexport_specifiers TEXT NOT NULL)",
+			"CREATE TABLE IF NOT EXISTS extension_parse_cache (cache_key TEXT PRIMARY KEY, source_type TEXT NOT NULL, [references] TEXT NOT NULL, commonjs_named_exports TEXT NOT NULL, commonjs_reexport_specifiers TEXT NOT NULL)",
 		);
 		extensionParseCacheDb = db;
 		return db;
@@ -637,7 +637,7 @@ function writeExtensionSourceAnalysis(cacheKey: string, analysis: ExtensionSourc
 			const db = getExtensionParseCacheDb();
 			if (!db) return;
 			db.run(
-				"INSERT OR REPLACE INTO extension_parse_cache (cache_key, source_type, references, commonjs_named_exports, commonjs_reexport_specifiers) VALUES (?, ?, ?, ?, ?)",
+				"INSERT OR REPLACE INTO extension_parse_cache (cache_key, source_type, [references], commonjs_named_exports, commonjs_reexport_specifiers) VALUES (?, ?, ?, ?, ?)",
 				[
 					cacheKey,
 					analysis.sourceType,
@@ -668,7 +668,7 @@ function getExtensionSourceAnalysis(source: string, importerPath: string): Exten
 	try {
 		const row = db
 			?.query<ExtensionParseCacheRow, [string]>(
-				"SELECT source_type, references, commonjs_named_exports, commonjs_reexport_specifiers FROM extension_parse_cache WHERE cache_key = ?",
+				"SELECT source_type, [references], commonjs_named_exports, commonjs_reexport_specifiers FROM extension_parse_cache WHERE cache_key = ?",
 			)
 			.get(cacheKey);
 		if (row) {


### PR DESCRIPTION
## Bug

The legacy-pi extension source parse cache (`legacy-pi-extension-cache.db`) can never be created: the `CREATE TABLE` uses `references` as a bare column name, which is a SQLite reserved keyword (it starts a foreign-key clause):

```
near "references": syntax error
```

Result: `getExtensionParseCacheDb()` returns null every run, omp logs `legacy Pi extension parse cache unavailable`, and every startup re-parses all legacy extension sources via Babel — measured ~3.4s/run here with the default extension set.

## Fix

Quote the column using SQLite bracket-quoting `[references]` (avoids escaping inside the surrounding JS string literal) in all three statements: CREATE TABLE, INSERT, SELECT.

## Verification

Locally patched the same change into the compiled binary; the cache db then populates (55 rows, 36KB) and the `parse cache unavailable` log line disappears.