### PR TITLE
fix(utils): grow mermaid-ascii canvas by the subgraph drawing offset

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Mermaid ASCII renderer throwing on left-to-right diagrams containing a `subgraph`, which made the fenced block fall back to raw source in the terminal. `offsetDrawingForSubgraphs` shifts every drawing coordinate to make room for subgraph borders that extend past the origin, but the canvas had already been sized from the pre-shift grid extents, so edges routed to the outermost column wrote past the allocation and `drawLine` threw on the missing column. The canvas and role canvas now grow by the same shift. ([#9340](https://github.com/can1357/oh-my-pi/issues/9340))
+
 ## [17.4.2] - 2026-08-21
 
 ### Fixed

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/grid.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/grid.ts
@@ -11,7 +11,14 @@ import type {
   GridCoord, DrawingCoord, Direction, AsciiGraph, AsciiNode, AsciiSubgraph,
 } from './types'
 import { gridKey } from './types'
-import { mkCanvas, setCanvasSizeToGrid, setRoleCanvasSizeToGrid } from './canvas'
+import {
+  getCanvasSize,
+  increaseRoleCanvasSize,
+  increaseSize,
+  mkCanvas,
+  setCanvasSizeToGrid,
+  setRoleCanvasSizeToGrid,
+} from './canvas'
 import { determinePath, determineLabelLine } from './edge-routing'
 import { analyzeEdgeBundles, processBundles } from './edge-bundling'
 import { drawBox } from './draw'
@@ -374,6 +381,14 @@ export function offsetDrawingForSubgraphs(graph: AsciiGraph): void {
       node.drawingCoord.y += offsetY
     }
   }
+
+  // The canvas was sized from the pre-shift grid extents, but every drawing
+  // coordinate — including edge path endpoints, which gridToDrawingCoord
+  // offsets on read — now sits `offset` cells further out. Grow it to match,
+  // or drawing the rightmost/bottom-most edges writes past the allocation.
+  const [maxX, maxY] = getCanvasSize(graph.canvas)
+  increaseSize(graph.canvas, maxX + offsetX, maxY + offsetY)
+  increaseRoleCanvasSize(graph.roleCanvas, maxX + offsetX, maxY + offsetY)
 }
 
 // ============================================================================

--- a/packages/utils/test/mermaid-ascii.test.ts
+++ b/packages/utils/test/mermaid-ascii.test.ts
@@ -80,6 +80,39 @@ describe("renderMermaidAscii", () => {
 		expect(rendered).toContain("Audit");
 	});
 
+	it("renders left-to-right diagrams whose subgraph shifts drawing past the grid extents", () => {
+		// The subgraph border extends past the origin, so layout shifts every
+		// drawing coordinate right/down after the canvas was already sized from
+		// the raw grid. Edges routed to the far column then land outside the
+		// allocation, which used to throw and drop the whole diagram.
+		const rendered = renderMermaidAscii(
+			[
+				"graph LR",
+				"  subgraph S[Done]",
+				"    A",
+				"  end",
+				"  A --> C",
+				"  A --> D",
+				"  D --> E",
+				"  C --> F",
+				"  F --> G",
+				"  D --> G",
+			].join("\n"),
+			{ colorMode: "none" },
+		);
+
+		expect(rendered).toContain("Done");
+		for (const label of ["A", "C", "D", "E", "F", "G"]) {
+			expect(rendered).toContain(label);
+		}
+		// Every row must be padded to the shifted width, not truncated at the
+		// pre-shift canvas edge.
+		const rows = rendered.split("\n");
+		for (const row of rows) {
+			expect(row.length).toBe(rows[0]!.length);
+		}
+	});
+
 	it("returns null when the destination attachment point is enclosed", () => {
 		const node: AsciiNode = {
 			name: "blocker",


### PR DESCRIPTION
Fixes #9340.

## Problem

Any `graph LR` / `flowchart LR` diagram containing a `subgraph` plus enough edges to route around it throws inside the vendored Mermaid ASCII renderer. `renderMermaidAsciiSafe()` swallows the throw and returns `null`, so the fenced block silently renders as raw source in the terminal — and `mermaid-cache.ts` memoizes the failure, so it never retries within the session.

```
TypeError: undefined is not an object (evaluating 'canvas[x][from.y] = hChar')
    at drawLine (packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts:303:14)
    at drawPath (draw.ts:478) -> drawArrow (draw.ts:395) -> drawGraph (draw.ts:1346)
    at renderMermaidASCII (ascii/index.ts:168)
```

## Cause

`createMapping` sizes the canvas *before* it shifts the drawing:

```ts
setCanvasSizeToGrid(graph.canvas, graph.columnWidth, graph.rowHeight)   // sum of raw grid extents
setRoleCanvasSizeToGrid(graph.roleCanvas, graph.columnWidth, graph.rowHeight)
calculateSubgraphBoundingBoxes(graph)
offsetDrawingForSubgraphs(graph)                                       // shifts coords, canvas unchanged
```

`offsetDrawingForSubgraphs` makes room for subgraph borders that extend past the origin by setting `graph.offsetX/offsetY` and shifting subgraph boxes and `node.drawingCoord`. Because `gridToDrawingCoord` adds those offsets on every read, edge path endpoints move too — but the outermost `offsetX` columns and `offsetY` rows were never allocated. `drawLine` is the only drawing path that writes without a bounds check (`drawText` and `drawSubgraphLabel` both guard), so that is where the miss surfaces.

Instrumented on `main`, the overflow is exactly the shift:

```
LAYOUT: offsetX=2 offsetY=4 canvasW=27 canvasH=25
OOB:    x=27 canvasW=27 from={"x":24,"y":11} to={"x":28,"y":11} offFrom=1 offTo=-1
```

This also accounts for the two facts that look inconvenient: `TD` survives because its vertical branches stay within rows that later `mergeCanvases` calls grow, and dropping the `subgraph` survives because `offsetDrawingForSubgraphs` returns early when there are none, leaving both offsets at 0.

## Change

Grow the canvas and role canvas by the same shift at the end of `offsetDrawingForSubgraphs`. Three lines plus the import; no behavioural change for diagrams that were already rendering, since the offsets are 0 whenever no subgraph border crosses the origin.

I deliberately left `drawLine` unguarded rather than adding a defensive clamp — a bounds check there would convert any future sizing miss into a silent cosmetic gap instead of a loud failure. Happy to add one if you would rather have the belt and braces.

## Verification

- New regression test in `packages/utils/test/mermaid-ascii.test.ts` covering the minimal LR-with-subgraph case. Confirmed non-vacuous: it fails with the exact `canvas[x][from.y]` TypeError when the `grid.ts` change is stashed, and asserts every serialized row is padded to the shifted width rather than truncated at the old edge.
- `bun test packages/utils/test/mermaid-ascii.test.ts packages/utils/test/mermaid` → **196 pass / 0 fail** across 7 files (195 before this PR's test).
- `bunx tsc --noEmit -p packages/utils` → clean.

The diagram from the originating report now renders:

```text
┌────────────────────┐
│       Done         │
│ ┌────────────────┐ │   ┌──────────────────┐     ┌───────────────────┐
│ │  PO-715 uids   ├─┼┬─►│ PO-718 link gate ├──┬─►│   PO-728 delete   │
│ └────────┬───────┘ ││  └──────────────────┘  │  └─────────┬─────────┘
│          └─────────┼┤            ┌───────────┘            └───────────┐
│ ┌────────────────┐ ││  ┌─────────┴────────┐     ┌───────────────────┐ │
│ │ PO-716 folders ├─┼┼─►│ PO-719 keep-list ├────►│   PO-727 NetBird  │ │
│ └────────┬───────┘ ││  └─────────┬────────┘     └───────────────────┘ │
└──────────┼─────────┘│            │                                    │
```

Distinct from #5293 (bounded pathfinder, already fixed): that one hangs in `getPath` before layout completes, this one throws in `drawGraph` after layout succeeds.
