### PR TITLE
fix(utils): grow mermaid canvas for subgraph offsets

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Mermaid ASCII rendering for left-to-right diagrams with subgraphs and routed edges. ([#9340](https://github.com/can1357/oh-my-pi/issues/9340))
+
 ## [17.4.2] - 2026-08-21
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Mermaid ASCII rendering for left-to-right diagrams with subgraphs and routed edges. ([#9340](https://github.com/can1357/oh-my-pi/issues/9340))
+
 ## [18.1.13] - 2026-09-07
 
 ### Fixed

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/grid.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/grid.ts
@@ -11,7 +11,14 @@ import type {
   GridCoord, DrawingCoord, Direction, AsciiGraph, AsciiNode, AsciiSubgraph,
 } from './types'
 import { gridKey } from './types'
-import { mkCanvas, setCanvasSizeToGrid, setRoleCanvasSizeToGrid } from './canvas'
+import {
+  getCanvasSize,
+  increaseRoleCanvasSize,
+  increaseSize,
+  mkCanvas,
+  setCanvasSizeToGrid,
+  setRoleCanvasSizeToGrid,
+} from './canvas'
 import { determinePath, determineLabelLine } from './edge-routing'
 import { analyzeEdgeBundles, processBundles } from './edge-bundling'
 import { drawBox } from './draw'
@@ -374,6 +381,10 @@ export function offsetDrawingForSubgraphs(graph: AsciiGraph): void {
       node.drawingCoord.y += offsetY
     }
   }
+
+  const [maxX, maxY] = getCanvasSize(graph.canvas)
+  increaseSize(graph.canvas, maxX + offsetX, maxY + offsetY)
+  increaseRoleCanvasSize(graph.roleCanvas, maxX + offsetX, maxY + offsetY)
 }
 
 // ============================================================================

--- a/packages/utils/test/mermaid-ascii.test.ts
+++ b/packages/utils/test/mermaid-ascii.test.ts
@@ -13,6 +13,27 @@ describe("renderMermaidAscii", () => {
 		expect(rendered).not.toContain("──A─");
 	});
 
+	it("renders routed LR edges after shifting a subgraph from negative coordinates", () => {
+		const rendered = renderMermaidAscii(
+			[
+				"graph LR",
+				"  subgraph S[Done]",
+				"    A",
+				"  end",
+				"  A --> C",
+				"  A --> D",
+				"  D --> E",
+				"  C --> F",
+				"  F --> G",
+				"  D --> G",
+			].join("\n"),
+			{ colorMode: "none" },
+		);
+
+		expect(rendered).toContain("│ Done  │");
+		expect(rendered).toContain("└──────►│ G │");
+	});
+
 	it("renders Unicode and ASCII state pseudostates with distinct UML markers", () => {
 		const source = ["stateDiagram-v2", "  [*] --> Created", "  Created --> [*]"].join("\n");
 		const unicode = renderMermaidAscii(source, { colorMode: "none" });


### PR DESCRIPTION
## Repro
Running `bun -e 'import { renderMermaidASCII } from "./packages/utils/src/vendor/mermaid-ascii/index"; console.log(renderMermaidASCII(`graph LR\n  subgraph S[Done]\n    A\n  end\n  A --> C\n  A --> D\n  D --> E\n  C --> F\n  F --> G\n  D --> G`));'` throws from `drawLine` when the routed edge reaches a column outside the pre-offset canvas.

## Cause
`offsetDrawingForSubgraphs` in `packages/utils/src/vendor/mermaid-ascii/ascii/grid.ts` shifted subgraph boxes, node coordinates, and every grid-to-drawing coordinate by `offsetX`/`offsetY` after `setCanvasSizeToGrid` had fixed the canvas dimensions, leaving the shifted right and bottom extents unallocated.

## Fix
- Grow the drawing and role canvases by the applied subgraph offsets.
- Cover the reported LR subgraph routing failure with a renderer regression test.
- Record the user-visible fix in the utils changelog.

## Verification
`bun test packages/utils/test/mermaid-ascii.test.ts packages/utils/test/mermaid` passes: 196 tests, 0 failures. The direct renderer harness now returns ASCII art for the reported diagram, and the pre-publish `bun check` gate passes. Fixes #9340