### PR TITLE
fix(ai): recover fenced thinking responses

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recovered OpenAI-compatible Responses turns that wrap leaked thinking and the entire Markdown answer in one HTML fence, restoring the thinking block and preserving the answer's intended inner code fences.
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -2667,6 +2667,32 @@ function getOpenAIResponsesTerminalEvent(event: ResponseStreamEvent): OpenAIResp
 		: undefined;
 }
 
+const FENCED_THINKING_RESPONSE = /^```html[ \t]*\r?\n<(thinking|think)>\r?\n?([\s\S]*?)<\/\1>([\s\S]*)\r?\n```[ \t]*$/u;
+
+/**
+ * Recover a rare OpenAI-compatible failure where the model puts leaked
+ * thinking and its entire Markdown answer inside one `html` fence. The normal
+ * stream healer correctly ignores thinking tags inside code, so repair only
+ * this exact whole-response envelope after the terminal event: the outer fence
+ * disappears, inner answer fences keep their original meaning, and unsigned
+ * reasoning returns to a thinking block instead of conversation text.
+ */
+function repairFencedThinkingResponse(output: AssistantMessage): void {
+	for (let index = 0; index < output.content.length; index++) {
+		const block = output.content[index];
+		if (block?.type !== "text") continue;
+		const match = FENCED_THINKING_RESPONSE.exec(block.text);
+		if (!match) continue;
+		const thinking = match[2]!.trim();
+		const visibleText = match[3]!.replace(/^\r?\n/u, "");
+		const replacement: Array<ThinkingContent | TextContent> = [];
+		if (thinking) replacement.push({ type: "thinking", thinking });
+		replacement.push({ ...block, text: visibleText });
+		output.content.splice(index, 1, ...replacement);
+		index += replacement.length - 1;
+	}
+}
+
 export interface ProcessResponsesStreamOptions {
 	onFirstToken?: () => void;
 	onOutputItemDone?: (item: ResponseOutputItem) => void;
@@ -3300,7 +3326,13 @@ export async function processResponsesStream<TApi extends Api>(
 				(response as { end_turn?: boolean } | undefined)?.end_turn,
 				shouldPromoteIncompleteToolUse,
 			);
-			// A completed provider-hosted web search that yielded no visible answer
+			if (
+				model.compat !== undefined &&
+				"streamMarkupHealingPattern" in model.compat &&
+				model.compat.streamMarkupHealingPattern === "thinking"
+			) {
+				repairFencedThinkingResponse(output);
+			}
 			// (no text, image, or client tool call) is progress, not a dead end:
 			// pause the turn so the agent loop re-samples with the search results
 			// instead of silently ending. Reasoning/native output items are preserved

--- a/packages/ai/test/openai-responses-stream-terminal.test.ts
+++ b/packages/ai/test/openai-responses-stream-terminal.test.ts
@@ -28,6 +28,21 @@ function makeModel(): Model<"openai-responses"> {
 	});
 }
 
+function makeOpenRouterHealingModel(): Model<"openai-responses"> {
+	return buildModel({
+		api: "openai-responses",
+		name: "Ox Alpha",
+		id: "stealth/ox-alpha",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+		input: ["text"],
+		reasoning: true,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	});
+}
+
 function makeOutput(): AssistantMessage {
 	return {
 		role: "assistant",
@@ -118,6 +133,73 @@ describe("processResponsesStream: terminal events", () => {
 		expect(output.usage.output).toBe(9);
 		expect(output.usage.totalTokens).toBe(16);
 		expect(output.content).toEqual([expect.objectContaining({ type: "text", text: "Hello, trunc" })]);
+	});
+
+	test("unwraps a whole-response HTML fence around leaked thinking", async () => {
+		const output = makeOutput();
+		const stream = { push: () => {}, end: () => {} } as never;
+		const malformed = [
+			"```html",
+			"<thinking>",
+			"Assessing production constraints",
+			"</thinking>Visible answer.",
+			"",
+			"```",
+			"step one",
+			"step two",
+			"```",
+			"",
+			"Final paragraph.",
+			"```",
+		].join("\n");
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "message", id: "msg_wrapped", role: "assistant", status: "in_progress", content: [] },
+				},
+				{
+					type: "response.content_part.added",
+					output_index: 0,
+					item_id: "msg_wrapped",
+					part: { type: "output_text", text: "", annotations: [] },
+				},
+				{
+					type: "response.output_text.delta",
+					output_index: 0,
+					item_id: "msg_wrapped",
+					delta: malformed,
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: {
+						type: "message",
+						id: "msg_wrapped",
+						role: "assistant",
+						status: "completed",
+						content: [{ type: "output_text", text: malformed, annotations: [] }],
+					},
+				},
+				{
+					type: "response.completed",
+					response: { id: "resp_wrapped", status: "completed" },
+				},
+			]),
+			output,
+			stream,
+			makeOpenRouterHealingModel(),
+		);
+
+		expect(output.content).toEqual([
+			{ type: "thinking", thinking: "Assessing production constraints" },
+			expect.objectContaining({
+				type: "text",
+				text: "Visible answer.\n\n```\nstep one\nstep two\n```\n\nFinal paragraph.",
+			}),
+		]);
 	});
 
 	test("promotes max-output incomplete function calls with strict-complete arguments", async () => {


### PR DESCRIPTION
User report: «новая модель не форматируется правильно».

## Problem

An OpenRouter Responses turn from `stealth/ox-alpha` returned this shape in its visible text channel:

````text
```html
<thinking>
private reasoning
</thinking>Visible Markdown answer.

```
intended inner code block
```

Final paragraph.
```
````

The top-level HTML fence changed the meaning of the answer's intended inner fences. OMP rendered the first part as HTML code, the intended code block as prose, and the final part as another code block. It also stored the leaked thinking as conversation text.

This was rare in the reported session: 1 malformed turn among 247 Ox Alpha assistant turns.

## Cause

`streamMarkupHealingPattern: "thinking"` correctly ignores thinking tags inside legitimate code fences. The whole-response wrapper therefore cannot be repaired during ordinary in-band scanning. The Responses terminal path had no exact final-response recovery for this provider failure.

## Fix

At the terminal Responses event, when the resolved model compat enables thinking markup healing:

- match only a complete `html` fence whose first content is one `<thinking>` or `<think>` envelope and whose last line closes the outer fence;
- move the leaked reasoning into an unsigned thinking block;
- remove only the outer fence;
- retain every inner fence and the text signature.

Incomplete streams and ordinary HTML examples do not match the full envelope.

## Verification

- The regression failed before the fix with the full response left in one text block.
- `bun --cwd=packages/ai run check` — clean.
- 102 focused Responses/OpenRouter/markup-healing tests pass.
- Full AI run: 4066 pass; 3 Cursor tests hit the default 5 s timeout. Those 9 Cursor tests pass in isolation with a 30 s timeout.
- The exact reported 2,772-character payload normalizes to `[thinking, text]`; visible Markdown has 2 intended fences instead of 4 and starts with the expected Russian prose.
