### PR TITLE
fix(catalog): map opencode-go ox-alpha to low/high/max effort ladder

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `opencode-go/ox-alpha-free` sending `reasoning_effort: "xhigh"` for the top thinking tier, which the OpenCode Go gateway rejects; the model now uses the gateway's wire-exact `low`/`high`/`max` ladder with mandatory thinking so `--thinking max` reaches the real max tier ([#9349](https://github.com/can1357/oh-my-pi/issues/9349)).
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -186,7 +186,9 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		supportsAdaptiveThinkingDisplay(spec.id);
 	const needsRequiresEffort =
 		thinking.requiresEffort === undefined &&
-		(impliesMandatoryReasoning(parsed, spec.id) || isQwenTemplateReasoningEffortCompat(compat));
+		(impliesMandatoryReasoning(parsed, spec.id) ||
+			isQwenTemplateReasoningEffortCompat(compat) ||
+			isOpenCodeGatewayOxAlphaModel(spec));
 	const needsDefaultLevel =
 		thinking.defaultLevel === undefined && (isKimiK3ModelId(spec.id) || isGlm53ReasoningEffortModelId(spec.id));
 	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort && !needsDefaultLevel) {
@@ -239,7 +241,11 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 	) {
 		config.supportsDisplay = true;
 	}
-	if (impliesMandatoryReasoning(parsed, spec.id) || isQwenTemplateReasoningEffortCompat(compat)) {
+	if (
+		impliesMandatoryReasoning(parsed, spec.id) ||
+		isQwenTemplateReasoningEffortCompat(compat) ||
+		isOpenCodeGatewayOxAlphaModel(spec)
+	) {
 		config.requiresEffort = true;
 	}
 	return config;
@@ -357,6 +363,9 @@ function getModelDefinedEfforts<TApi extends Api>(
 		}
 	}
 	if (isKimiK3ModelId(spec.id)) {
+		return LOW_HIGH_MAX_REASONING_EFFORTS;
+	}
+	if (isOpenCodeGatewayOxAlphaModel(spec)) {
 		return LOW_HIGH_MAX_REASONING_EFFORTS;
 	}
 	if (isSakanaFuguReasoningModel(spec)) {
@@ -536,6 +545,22 @@ function inferDetectedEffortMap<TApi extends Api>(
 
 function isSakanaFuguReasoningModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
 	return spec.provider === "sakana" && /^fugu(?:$|-)/i.test(spec.id);
+}
+
+/**
+ * "Ox Alpha" stealth models on the OpenCode gateways (`opencode-go` /
+ * `opencode-zen`) reason through the wire-exact `low`/`high`/`max` ladder with
+ * mandatory thinking: the gateway rejects `minimal`/`medium`/`xhigh`
+ * (`[1210] ... please use low, high, or max`), the same dialect it already
+ * serves for GLM-5.3 and Kimi K3. Other hosts proxying an `ox-alpha` SKU
+ * (Kilo, NanoGPT, Venice, OpenRouter) expose their own vocabularies and are
+ * left untouched. See issue #9349.
+ */
+function isOpenCodeGatewayOxAlphaModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	return (
+		(spec.provider === "opencode-go" || spec.provider === "opencode-zen") &&
+		/(?:^|\/)ox-alpha(?:-|$)/i.test(bareModelId(spec.id))
+	);
 }
 
 function isDeepseekReasoningModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -204846,12 +204846,11 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
-				]
+					"max"
+				],
+				"requiresEffort": true
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -342,6 +342,54 @@ describe("model thinking derivation", () => {
 		expect(clampThinkingLevelForModel(bare, Effort.Max)).toBe(Effort.High);
 	});
 
+	it("normalizes OpenCode gateway ox-alpha onto the low/high/max ladder with mandatory thinking (issue #9349)", () => {
+		// The OpenCode Go gateway rejects minimal/medium/xhigh for ox-alpha
+		// (`[1210] ... please use low, high, or max`), so the stale
+		// minimal..xhigh surface the catalog shipped made the top tier
+		// unreachable: `max` clamped to `xhigh` and 400'd upstream.
+		const staleThinking = {
+			mode: "effort" as const,
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+		};
+		const oxAlpha = createModel({
+			id: "ox-alpha-free",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			thinking: staleThinking,
+		});
+
+		expect(oxAlpha.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			requiresEffort: true,
+		});
+		// The top tier now reaches the gateway's real `max` wire value instead
+		// of the rejected `xhigh`, and no selection can produce a rejected tier.
+		expect(oxAlpha.thinking?.effortMap).toBeUndefined();
+		expect(requireSupportedEffort(oxAlpha, Effort.Max)).toBe(Effort.Max);
+		expect(clampThinkingLevelForModel(oxAlpha, Effort.XHigh)).toBe(Effort.High);
+		expect(clampThinkingLevelForModel(oxAlpha, Effort.Medium)).toBe(Effort.Low);
+
+		// Other hosts proxying an ox-alpha SKU expose their own vocabularies and
+		// must not inherit the gateway ladder.
+		const kiloOxAlpha = createModel({
+			id: "stealth/ox-alpha",
+			api: "openai-completions",
+			provider: "kilo",
+			baseUrl: "https://api.kilo.ai/api/gateway",
+			thinking: staleThinking,
+		});
+		expect(getSupportedEfforts(kiloOxAlpha)).toEqual([
+			Effort.Minimal,
+			Effort.Low,
+			Effort.Medium,
+			Effort.High,
+			Effort.XHigh,
+		]);
+		expect(kiloOxAlpha.thinking?.requiresEffort).toBeUndefined();
+	});
+
 	it("encodes the Gemini 3 Pro effort gap and mandatory reasoning in metadata", () => {
 		const model = createModel({
 			id: "gemini-3-pro-preview",


### PR DESCRIPTION
## Repro
`opencode-go/ox-alpha-free` advertised `thinking.efforts = [minimal, low, medium, high, xhigh]` with no effort map, so `--thinking max` clamped to the top supported tier (`xhigh`) and serialized `reasoning_effort: "xhigh"`. The OpenCode Go gateway rejects that value (`[1210] This model always engages in thinking and cannot be disabled; please use low, high, or max`), making the model's max reasoning tier unreachable through OMP while OpenCode's own `--variant max` and OMP's `--thinking high` both work. Reproduced against the current tree:

```
efforts: ["minimal","low","medium","high","xhigh"]
clamp(max) => xhigh
wire reasoning_effort => xhigh
```

## Cause
The gateway's real reasoning vocabulary for this model is the wire-exact `low/high/max` ladder with mandatory thinking — the same dialect it already serves for GLM-5.3 and Kimi K3 — but `getModelDefinedEfforts` in `packages/catalog/src/model-thinking.ts` did not recognize the OpenCode gateway `ox-alpha` SKU, so the stale `minimal..xhigh` surface baked into `models.json` survived. With `max` outside the ladder, `clampThinkingLevelForModel` fell back to `xhigh`, and `mapOpenAIReasoningEffort` (`packages/ai/src/providers/openai-shared.ts`) passed it through verbatim.

## Fix
- Added `isOpenCodeGatewayOxAlphaModel(spec)` in `model-thinking.ts`, scoped to `opencode-go`/`opencode-zen` providers and an `ox-alpha` id.
- `getModelDefinedEfforts` now returns `LOW_HIGH_MAX_REASONING_EFFORTS` for it, and both `requiresEffort` deriver paths (`fillThinkingWireDefaults`, `deriveThinking`) flag mandatory thinking — matching the GLM-5.3/Kimi K3 handling on the same gateway.
- Regenerated the one affected bundled row (`opencode-go/ox-alpha-free`) in `models.json` via the generator's `rebakeModelThinking`; a full-snapshot re-bake confirmed this is the only entry whose `thinking` changes. Other hosts proxying an `ox-alpha` SKU (Kilo, NanoGPT, Venice, OpenRouter) keep their own vocabularies.
- Added a resolver-level regression test.

## Verification
`bun test packages/catalog/test/model-thinking.test.ts` → 40 pass; `bun test packages/catalog/test/generated-policies.test.ts` → 24 pass. Verified end-to-end against the bundled row: `low→low`, `high→high`, `max→max`, and `minimal`/`medium`/`xhigh` all clamp down to `low`/`low`/`high` — no selection can produce a gateway-rejected effort. Pre-publish `bun check` passed. Fixes #9349