### PR TITLE
fix(edit): correct sloppy retry and approval paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed status text retaining hidden DCS, PM, and APC payloads after escape-sequence sanitization.
 - Fixed extension load errors truncating explicitly excluded package import specifiers.
 - Fixed subagents crashing before their first turn when an extension contributed a tool or skill without a `description`; the context-breakdown token estimate now coalesces missing descriptions and system-prompt sections instead of passing `undefined` to the tokenizer ([#9331](https://github.com/can1357/oh-my-pi/issues/9331)).
+- Fixed edit retries suggesting the same invalid payload and permission prompts showing unknown paths for sloppy edits ([#9350](https://github.com/can1357/oh-my-pi/issues/9350)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -384,6 +384,9 @@ function extractApprovalPath(args: unknown): string {
 
 		const applyPatchMatch = /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/m.exec(input);
 		if (applyPatchMatch?.[1]) return applyPatchMatch[1].trim();
+
+		const sloppyPath = splitSloppySections(input)[0]?.path;
+		if (sloppyPath) return sloppyPath;
 	}
 
 	const targetPath = record.path;

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -375,32 +375,49 @@ async function executeSinglePathEntries(
 	};
 }
 
-function extractApprovalPath(args: unknown): string {
+/**
+ * Every target path a payload will touch, for approval tiering and display.
+ * Multi-file hashline / apply_patch / sloppy payloads report one entry per
+ * section so a mixed internal+workspace call cannot be under-classified.
+ */
+function extractApprovalPaths(args: unknown): string[] {
 	const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
 	const input = typeof record.input === "string" ? record.input : undefined;
 	if (input) {
-		const hashlineMatch = /^\[([^#\r\n]+)(?:#[0-9a-fA-F]{4})?\]/m.exec(input);
-		if (hashlineMatch?.[1]) return hashlineMatch[1];
+		const hashlinePaths = [...input.matchAll(/^\[([^#\r\n]+)(?:#[0-9a-fA-F]{4})?\]/gm)]
+			.map(match => match[1])
+			.filter((path): path is string => typeof path === "string" && path.length > 0);
+		if (hashlinePaths.length > 0) return hashlinePaths;
 
-		const applyPatchMatch = /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/m.exec(input);
-		if (applyPatchMatch?.[1]) return applyPatchMatch[1].trim();
+		const applyPatchPaths = [...input.matchAll(/^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm)]
+			.map(match => match[1]?.trim())
+			.filter((path): path is string => typeof path === "string" && path.length > 0);
+		if (applyPatchPaths.length > 0) return applyPatchPaths;
 
-		const sloppyPath = splitSloppySections(input)[0]?.path;
-		if (sloppyPath) return sloppyPath;
+		const sloppyPaths = splitSloppySections(input)
+			.map(section => section.path)
+			.filter(path => path.length > 0);
+		if (sloppyPaths.length > 0) return sloppyPaths;
 	}
 
 	const targetPath = record.path;
-	return typeof targetPath === "string" && targetPath.length > 0 ? targetPath : "(unknown)";
+	return typeof targetPath === "string" && targetPath.length > 0 ? [targetPath] : [];
 }
 
 export class EditTool implements AgentTool<TInput> {
 	readonly approval = (args: unknown) => {
-		const targetPath = extractApprovalPath(args);
-		return targetPath !== "(unknown)" && isInternalUrlPath(targetPath) ? "read" : "write";
+		// Internal-resource edits (memory://, skill://, local://, …) are read-tier,
+		// but a payload that also targets a real workspace file must stay write-tier
+		// so the always-ask prompt still fires — `executeSloppy` writes every section
+		// regardless of the first one's scheme (#9353 review).
+		const targets = extractApprovalPaths(args);
+		return targets.length > 0 && targets.every(target => isInternalUrlPath(target)) ? "read" : "write";
 	};
-	readonly formatApprovalDetails = (args: unknown): string[] => [
-		`File: ${truncateForPrompt(extractApprovalPath(args))}`,
-	];
+	readonly formatApprovalDetails = (args: unknown): string[] => {
+		const targets = extractApprovalPaths(args);
+		if (targets.length === 0) return ["File: (unknown)"];
+		return targets.map(target => `File: ${truncateForPrompt(target)}`);
+	};
 	readonly name = "edit";
 	readonly label = "Edit";
 	readonly loadMode = "essential";

--- a/packages/coding-agent/src/edit/sloppy.test.ts
+++ b/packages/coding-agent/src/edit/sloppy.test.ts
@@ -301,14 +301,19 @@ describe("sloppy v8", () => {
 		);
 	});
 
-	test("fails closed on a marker-less op that already matches the file", () => {
-		// A restated unchanged line asserts nothing; the merged dialect keeps the
-		// fail-closed separator diagnosis instead of silently skipping.
+	test("returns one fill-in payload when a marker-less operation needs a rewrite", () => {
 		const content = "keep();\nconst limit = options.limit;\n";
+		let message = "";
 
-		expect(() =>
-			applySloppy(content, "§\nkeep();\n§\nconst limit = options⟪.│?.⟫limit;", { path: "i.ts", notes: [] }),
-		).toThrow(/needs »/);
+		try {
+			applySloppy(content, "§\nkeep();\n§\nconst limit = options⟪.│?.⟫limit;", { path: "i.ts", notes: [] });
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toContain("Operation 1 needs ».");
+		expect(message.match(/Copy-ready corrected payload/g)).toHaveLength(1);
+		expect(message).toContain("Copy-ready corrected payload (fill in the new text):\n§\nkeep();\n»\n<new text>");
 	});
 
 	test("collapses back-to-back duplicates when desired text matches both copies", () => {

--- a/packages/coding-agent/src/edit/sloppy.ts
+++ b/packages/coding-agent/src/edit/sloppy.ts
@@ -1034,7 +1034,7 @@ function parseOperations(input: string, content: string): Operation[] {
 				// No block resembles the desired text; keep the fail-closed error.
 			}
 		}
-		const needsSeparator = `Operation ${operations.length + 1} needs ${REWRITE_HEADER}. Retry:\n${OPENER}\n${patternLines.join("\n")}\n${REWRITE_HEADER}\n<new text>`;
+		const needsSeparator = `Operation ${operations.length + 1} needs ${REWRITE_HEADER}.\nCopy-ready corrected payload (fill in the new text):\n${OPENER}\n${patternLines.join("\n")}\n${REWRITE_HEADER}\n<new text>`;
 		// A multiline pattern-only block may be the delete half of a move; assume
 		// deletion now, justified post-parse only when another op re-emits it.
 		const normalizedPattern = normalizeText(sourcePatternText).text;

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -168,7 +168,7 @@ describe("MCP fallback and prompt formatting", () => {
 		expect(truncateForPrompt("abcdefgh", 5)).toBe("abcde[…3ch elided…]");
 	});
 
-	it("shows the file from a sloppy edit section header", () => {
+	function sloppyEditTool(): EditTool {
 		const session: ToolSession = {
 			cwd: ".",
 			hasUI: false,
@@ -176,10 +176,30 @@ describe("MCP fallback and prompt formatting", () => {
 			getSessionSpawns: () => "*",
 			settings: Settings.isolated(),
 		};
-		const editTool = new EditTool(session, "sloppy");
-		const input = "§src/config.go\n§\nold\n»\nnew";
+		return new EditTool(session, "sloppy");
+	}
 
-		expect(formatApprovalPrompt(editTool, { input })).toBe("Allow tool: edit\nFile: src/config.go");
+	it("shows the file from a sloppy edit section header", () => {
+		const input = "§src/config.go\n§\nold\n»\nnew";
+		expect(formatApprovalPrompt(sloppyEditTool(), { input })).toBe("Allow tool: edit\nFile: src/config.go");
+	});
+
+	it("keeps a mixed internal+workspace sloppy payload at write tier", () => {
+		const editTool = sloppyEditTool();
+		const input = "§local://notes\n§\nold\n»\nnew\n§src/config.go\n§\nold\n»\nnew";
+		// Section 0 is internal; the workspace section must still force write tier
+		// and an always-ask prompt because executeSloppy writes both.
+		expect(editTool.approval?.({ input })).toBe("write");
+		expect(formatApprovalPrompt(editTool, { input }).split("\n")).toEqual([
+			"Allow tool: edit",
+			"File: local://notes",
+			"File: src/config.go",
+		]);
+	});
+
+	it("keeps an all-internal sloppy payload at read tier", () => {
+		const input = "§local://notes\n§\nold\n»\nnew\n§local://scratch\n§\nold\n»\nnew";
+		expect(sloppyEditTool().approval?.({ input })).toBe("read");
 	});
 });
 

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentTool, ToolApproval } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
 import { LSP_READONLY_ACTIONS } from "@oh-my-pi/pi-coding-agent/lsp";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	type ApprovalMode,
 	formatApprovalPrompt,
@@ -163,6 +166,20 @@ describe("MCP fallback and prompt formatting", () => {
 	it("truncates prompt details without touching short strings", () => {
 		expect(truncateForPrompt("hello", 10)).toBe("hello");
 		expect(truncateForPrompt("abcdefgh", 5)).toBe("abcde[…3ch elided…]");
+	});
+
+	it("shows the file from a sloppy edit section header", () => {
+		const session: ToolSession = {
+			cwd: ".",
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const editTool = new EditTool(session, "sloppy");
+		const input = "§src/config.go\n§\nold\n»\nnew";
+
+		expect(formatApprovalPrompt(editTool, { input })).toBe("Allow tool: edit\nFile: src/config.go");
 	});
 });
 


### PR DESCRIPTION
## Repro
On 18.0.0, a sloppy edit containing only a MATCH block produces one useful fill-in skeleton and then incorrectly appends the original invalid payload as another `Copy-ready corrected payload`; formatting approval details for `{ input: "§config.go\n§\nold\n»\nnew" }` reports `File: (unknown)`. Reproduced from the repository with `bun -e 'import { applySloppy } from "./packages/coding-agent/src/edit/sloppy.ts"; applySloppy("old\n", "§\nold", { path: "config.go", notes: [] })'` and an `EditTool.formatApprovalDetails` call using that sloppy section input.

## Cause
`applySloppy()` in `packages/coding-agent/src/edit/sloppy.ts` treated the missing-separator fill-in skeleton as an ordinary parse error and appended the invalid input again. `extractApprovalPath()` in `packages/coding-agent/src/edit/index.ts` recognized hashline and apply-patch headers but did not resolve sloppy `§path` sections.

## Fix
- Mark missing-separator diagnostics as their own copy-ready fill-in payload so the outer error handler does not append invalid input.
- Resolve approval paths through the existing sloppy section parser.
- Cover both user-visible diagnostics and approval prompt output, and add the Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/src/edit/sloppy.test.ts packages/coding-agent/test/tools/approval.test.ts` passed: 200 tests, 343 assertions. A manual reporter-shaped smoke check printed `single corrected payload; File: config.go`. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #9350