### PR TITLE
fix(agent): preserve post-snapshot remote compaction turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed status text retaining hidden DCS, PM, and APC payloads after escape-sequence sanitization.
 - Fixed extension load errors truncating explicitly excluded package import specifiers.
 - Fixed subagents crashing before their first turn when an extension contributed a tool or skill without a `description`; the context-breakdown token estimate now coalesces missing descriptions and system-prompt sections instead of passing `undefined` to the tokenizer ([#9331](https://github.com/can1357/oh-my-pi/issues/9331)).
+- Fixed asynchronous V2 remote compaction dropping user and tool messages added after its speculative snapshot ([#9351](https://github.com/can1357/oh-my-pi/issues/9351)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -451,6 +451,13 @@ export function buildSessionContext(
 					appendMessage(entry);
 				}
 			}
+		} else if (compaction.providerReplayThroughEntryId) {
+			const replayThroughIdx = path.findIndex(entry => entry.id === compaction.providerReplayThroughEntryId);
+			if (replayThroughIdx >= 0 && replayThroughIdx < compactionIdx) {
+				for (let i = replayThroughIdx + 1; i < compactionIdx; i++) {
+					appendMessage(path[i]);
+				}
+			}
 		}
 
 		// Display transcript: emit the summary at the chronological compaction

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -104,6 +104,8 @@ export interface CompactionEntry<T = unknown> extends SessionEntryBase {
 	tokensAfter?: number;
 	/** Method that produced this entry; absent on legacy sessions and extension-provided compactions. */
 	method?: CompactionMethod;
+	/** Last branch entry represented by provider-native replay history; later entries replay normally. */
+	providerReplayThroughEntryId?: string;
 	/** Extension-specific data (e.g., ArtifactIndex, version markers for structured compaction) */
 	details?: T;
 	/** Hook-provided data to persist across compaction */

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1421,6 +1421,7 @@ export class SessionMaintenance {
 		preserveData: Record<string, unknown> | undefined;
 		method: CompactionMethod | undefined;
 		codexCompaction: CodexCompactionContext | undefined;
+		providerReplayThroughEntryId?: string;
 		advisorResetReason: string;
 		detachExtensionEmit?: boolean;
 	}): Promise<CompactionEntry | undefined> {
@@ -1434,6 +1435,7 @@ export class SessionMaintenance {
 				fromExtension: args.fromExtension,
 				preserveData: args.preserveData,
 				method: args.method,
+				providerReplayThroughEntryId: args.providerReplayThroughEntryId,
 				tokensAfter: this.#projectCompactedContextTokens(args),
 			},
 		);
@@ -2902,6 +2904,9 @@ export class SessionMaintenance {
 					fromExtension: false,
 					codexCompaction: armedSpec.codexCompaction,
 					method: armedSpec.method,
+					providerReplayThroughEntryId: armedSpec.result.preserveData?.openaiRemoteCompaction
+						? armedSpec.snapshotLeafId
+						: undefined,
 					action,
 					reason,
 					willRetry,
@@ -3581,6 +3586,7 @@ export class SessionMaintenance {
 		fromExtension: boolean;
 		codexCompaction: CodexCompactionContext | undefined;
 		method: CompactionMethod | undefined;
+		providerReplayThroughEntryId?: string;
 		action: "context-full" | "handoff" | "snapcompact" | "remote";
 		reason: "overflow" | "threshold" | "idle" | "incomplete";
 		willRetry: boolean;
@@ -3619,6 +3625,7 @@ export class SessionMaintenance {
 			preserveData: args.preserveData,
 			codexCompaction: args.codexCompaction,
 			method: args.method,
+			providerReplayThroughEntryId: args.providerReplayThroughEntryId,
 			advisorResetReason: "auto-compaction",
 			detachExtensionEmit: detachPostCommit,
 		});

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2247,6 +2247,7 @@ export class SessionManager {
 			fromExtension?: boolean;
 			preserveData?: Record<string, unknown>;
 			method?: CompactionMethod;
+			providerReplayThroughEntryId?: string;
 			tokensAfter?: number;
 		} = {},
 	): string {
@@ -2259,6 +2260,7 @@ export class SessionManager {
 			tokensBefore,
 			tokensAfter: options.tokensAfter,
 			method: options.method,
+			providerReplayThroughEntryId: options.providerReplayThroughEntryId,
 			details: options.details,
 			fromExtension: options.fromExtension,
 			preserveData: options.preserveData,

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -43,8 +43,10 @@ describe("async speculative compaction", () => {
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
 	let model: Model;
+	let defaultModel: Model;
 	let sessionManager: SessionManager;
 	let maintenance: SessionMaintenance;
+	let agent: Agent;
 	let events: string[];
 
 	function appendSummarizableConversation(): void {
@@ -60,7 +62,7 @@ describe("async speculative compaction", () => {
 	function createMaintenance(
 		options: { asyncEnabled?: boolean; methodOrder?: CompactionMethod[] } = {},
 	): SessionMaintenance {
-		const agent = new Agent({
+		agent = new Agent({
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 		});
 		const settings = Settings.isolated({
@@ -108,7 +110,7 @@ describe("async speculative compaction", () => {
 			disconnectFromAgent: () => {},
 			reconnectToAgent: () => {},
 			drainStrandedQueuedMessages: () => {},
-			buildDisplaySessionContext: () => ({ messages: [] }),
+			buildDisplaySessionContext: () => sessionManager.buildSessionContext(),
 			convertToLlmForSideRequest: (messages: AgentMessage[]) => messages as never,
 			obfuscateTextForProvider: (text: string | undefined) => text,
 			obfuscatePreparationForProvider: <T>(preparation: T) => preparation,
@@ -150,10 +152,12 @@ describe("async speculative compaction", () => {
 		modelRegistry = new ModelRegistry(authStorage);
 		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!bundled) throw new Error("Expected built-in model");
-		model = { ...bundled, contextWindow: CONTEXT_WINDOW };
+		defaultModel = { ...bundled, contextWindow: CONTEXT_WINDOW };
+		model = defaultModel;
 	});
 
 	beforeEach(() => {
+		model = defaultModel;
 		sessionManager = SessionManager.inMemory();
 		events = [];
 		appendSummarizableConversation();
@@ -202,6 +206,68 @@ describe("async speculative compaction", () => {
 		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("armed summary");
 		expect(compactSpy).toHaveBeenCalledTimes(1);
 		expect(events).toEqual(expect.arrayContaining(["auto_compaction_start", "auto_compaction_end"]));
+	});
+
+	it("replays a user turn appended while remote compaction is in flight", async () => {
+		const bundled = getBundledModel("openai", "gpt-5");
+		if (!bundled) throw new Error("Expected built-in OpenAI model");
+		model = { ...bundled, contextWindow: CONTEXT_WINDOW };
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		maintenance = createMaintenance({ methodOrder: ["remote"] });
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => {
+			started.resolve();
+			await release.promise;
+			return {
+				summary: "remote speculative summary",
+				firstKeptEntryId: preparation.firstKeptEntryId,
+				tokensBefore: preparation.tokensBefore,
+				details: {},
+				preserveData: {
+					openaiRemoteCompaction: {
+						version: "v2",
+						provider: model.provider,
+						replacementHistory: [{ type: "compaction_summary", summary: "snapshot" }],
+						usedTokens: 1_000,
+					},
+				},
+			};
+		});
+
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await started.promise;
+		sessionManager.appendMessage(userMessage("post-snapshot request"));
+		sessionManager.appendMessage({
+			...assistantMessage("", model),
+			content: [{ type: "toolCall", id: "call-after-snapshot", name: "read", arguments: { path: "src/index.ts" } }],
+			stopReason: "toolUse",
+		});
+		sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "call-after-snapshot",
+			toolName: "read",
+			content: [{ type: "text", text: "file contents" }],
+			isError: false,
+			timestamp: Date.now(),
+		});
+		release.resolve();
+		await waitForState("armed");
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, { triggerContextTokens: THRESHOLD });
+
+		expect(agent.state.messages.map(message => message.role)).toEqual([
+			"compactionSummary",
+			"user",
+			"assistant",
+			"toolResult",
+		]);
+		expect(agent.state.messages[1]).toEqual(
+			expect.objectContaining({
+				role: "user",
+				content: [{ type: "text", text: "post-snapshot request" }],
+			}),
+		);
 	});
 
 	it("discards an armed summary after a reset boundary and re-summarizes the new branch", async () => {


### PR DESCRIPTION
## Repro
A delayed V2 remote speculation was started, `post-snapshot request` plus an assistant tool call/result were appended to the branch, and the armed result was applied with `bun test packages/coding-agent/test/compaction-speculation.test.ts`. Before the fix, the rebuilt live context contained only `[compactionSummary]` instead of `[compactionSummary, user, assistant, toolResult]`.

## Cause
`SessionMaintenance.#armedSpeculationValid` correctly permits the captured leaf to remain an ancestor of the active branch, but `buildSessionContext` in `packages/coding-agent/src/session/session-context.ts` treated provider-native replacement history as covering every entry before the later compaction entry. It therefore suppressed descendants appended after the speculative snapshot.

## Fix
- Persist the last branch entry covered by speculative provider replay history on the compaction entry.
- Replay the exact pre-compaction suffix after the provider-native replacement payload while leaving transcript rendering unchanged.
- Add a delayed V2 remote compaction regression test covering an intervening user request and tool exchange.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/compaction-speculation.test.ts` passes (11 tests); `bun test packages/coding-agent/test/session-manager/build-context.test.ts` passes (30 tests); `bun run check` in `packages/coding-agent` passes. Skipped the pre-publish gate because `bun check` fails identically on a clean `origin/main` archive for unrelated formatting in `crates/pi-natives/src/spelling.rs` and `scripts/gen-nix-bun.ts`.

Fixes #9351