### PR TITLE
docs(mnemopi): clarify consolidation eligibility

### DIFF
--- a/docs/mnemosyne-memory-backend.md
+++ b/docs/mnemosyne-memory-backend.md
@@ -167,7 +167,7 @@ new Mnemopi({
 
 - The default shared database lives under the agent memories directory in `mnemopi/mnemopi.db`; project-scoped banks use sibling database paths under that Mnemopi directory.
 - `/memory clear` removes every scoped Mnemopi SQLite database and sidecar WAL/SHM files for the active configuration.
-- `/memory enqueue` forces retention of the current session, flushes pending fact extractions, and runs Mnemopi sleep/consolidation.
+- `/memory enqueue` forces retention of the current session, flushes pending fact extractions, and runs Mnemopi sleep/consolidation for eligible working-memory rows.
 - `/memory stats` and `/memory diagnose` render backend-specific bank statistics/diagnostics when the Mnemopi backend is active.
 - Subagents do not own separate Mnemopi retain loops; they alias the parent state when a parent Mnemopi state exists, and otherwise remain inert.
 - Backend startup is best-effort. If database/model initialization fails, the session continues with Mnemopi inert and logs a warning; memory tools then report that the backend is not initialized.
@@ -184,4 +184,4 @@ Aliased subagent states do not own or close the shared banks; the parent state o
 
 Interactive and print exits give this drain 1.5 seconds. If the budget expires, shutdown detaches the in-flight drain and arranges for handles to close when it settles rather than racing writes against closed databases. The process may exit first. Working-memory rows already written remain durable, but promotion or embedding for the last few turns can remain incomplete; earlier turn retention performed at agent end is unaffected.
 
-`/memory enqueue` is the explicit stronger durability boundary: it forces retention, flushes pending extraction, and runs full sleep/consolidation across the owned banks. Use it before exit when the latest material must be promoted rather than relying on the bounded normal shutdown path.
+`/memory enqueue` is the explicit stronger durability boundary: it forces retention, flushes pending extraction, and runs full sleep/consolidation across the owned banks. It does not bypass Mnemopi's age gate: `sleepAllSessions` selects unconsolidated working-memory rows older than half `workingMemoryTtlHours` (12 hours with the default 24-hour TTL). Fresh rows therefore remain in working memory after an immediate enqueue. Use the command before exit to force retention and flush pending work, or after the age gate to promote eligible rows; normal shutdown does not promote them.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed status text retaining hidden DCS, PM, and APC payloads after escape-sequence sanitization.
 - Fixed extension load errors truncating explicitly excluded package import specifiers.
 - Fixed subagents crashing before their first turn when an extension contributed a tool or skill without a `description`; the context-breakdown token estimate now coalesces missing descriptions and system-prompt sections instead of passing `undefined` to the tokenizer ([#9331](https://github.com/can1357/oh-my-pi/issues/9331)).
+- Clarified that Mnemopi `/memory enqueue` only promotes working memories older than half the configured TTL and that normal shutdown does not run bank sleep ([#9356](https://github.com/can1357/oh-my-pi/issues/9356)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -624,12 +624,10 @@ export class MnemopiSessionState {
 	}
 
 	/**
-	 * Drain in-flight fact extraction and run beam consolidation on every owned
-	 * bank, after capturing the current transcript. Mirrors the manual
-	 * `/memory enqueue` slash command, but stops short of closing the DBs so
-	 * callers can keep using the state. {@link dispose} composes this with the
-	 * close step so normal session shutdown promotes working memory to
-	 * episodic/gists/graph automatically (see issue #2320).
+	 * Capture the current transcript, drain in-flight fact extraction, and
+	 * optionally run beam consolidation on every owned bank. The explicit
+	 * `/memory enqueue` path requests full cross-session consolidation; disposal
+	 * composes the lighter retain-and-flush path with closing the DB handles.
 	 *
 	 * Aliased subagent states share `scoped` (and therefore the actual SQLite
 	 * banks) with their parent. `consolidate()` deliberately does NOT
@@ -637,13 +635,13 @@ export class MnemopiSessionState {
 	 * itself, and an explicit `/memory enqueue` invoked from within a subagent
 	 * still needs to flush extractions and sleep the parent's shared banks —
 	 * otherwise enqueue would report success while leaving the subagent's
-	 * retained memories unconsolidated until the parent eventually shuts down
+	 * retained memories unconsolidated until a later full consolidation request
 	 * (PR #2327 review).
 	 *
 	 * @param options.full - When true, run `sleepAllSessions` on every owned bank
 	 *  (the full cross-session consolidation used by `/memory enqueue`). When
-	 *  false (the default), run only `sleep` on the current session for a
-	 *  lighter, bounded shutdown pass.
+	 *  false (the default), run only `sleep` on the current session when bank
+	 *  sleep is enabled.
 	 * @param options.sleep - When false, skips the bank sleep step entirely.
 	 *  Used on the interactive shutdown path so `dispose` does not block on
 	 *  synchronous consolidation of old working rows from previous sessions.
@@ -668,8 +666,8 @@ export class MnemopiSessionState {
 	 * Release the per-session resources. Defaults to running a lighter
 	 * {@link consolidate} pass before closing handles: it retains the current
 	 * transcript and flushes in-flight extractions, but skips the synchronous
-	 * bank sleep so normal session shutdown returns promptly. Full promotion of
-	 * working memory into long-term storage is still performed by the explicit
+	 * bank sleep so normal session shutdown returns promptly. Full age-gated
+	 * promotion of eligible working memory is still requested by the explicit
 	 * `/memory enqueue` and backend enqueue paths. Callers that are about to
 	 * delete the DB files — e.g. `mnemopiBackend.clear` — pass
 	 * `{ consolidate: false }` to skip the retain/flush pass, since spending


### PR DESCRIPTION
## Repro
With a fresh in-memory Mnemopi bank, `bun -e 'import { Mnemopi } from "./packages/mnemopi/src/core/memory.ts"; const memory = new Mnemopi({ dbPath: ":memory:", sessionId: "fresh-session" }); memory.remember("Fresh working-memory row", { importance: 0.8 }); console.log(memory.sleepAllSessions(false)); memory.close();'` returns `status: "no_op"` and `No old working memories to consolidate`, while the backend guide recommended `/memory enqueue` when the latest material must be promoted.

## Cause
`MnemopiSessionState.dispose()` in `packages/coding-agent/src/mnemopi/state.ts` deliberately retains and flushes without bank sleep, while `sleepAllSessions()` in `packages/mnemopi/src/core/beam/consolidate.ts` only selects rows older than half `workingMemoryTtlHours`. `docs/mnemosyne-memory-backend.md` described the lighter shutdown path but omitted that the explicit full-consolidation path remains age-gated.

## Fix
- Document the half-TTL eligibility gate, its default 12-hour cutoff, and the behavior of fresh rows.
- Clarify when `/memory enqueue` forces durability work versus when it can promote rows.
- Align the exported lifecycle comments and Unreleased changelog with the user-facing guide.

## Verification
The reproduction completed with exit code 0 and observed `working_memory = 1`, `episodic_memory = 0`, and `status = "no_op"` for a fresh row. Re-read the rendered lifecycle section against `sleepAllSessions()` and `dispose()`; the `gh_push_branch` pre-publish gate completed `bun run fix` and `bun check`. Fixes #9356