### PR TITLE
feat(coding-agent): support extension all-model Code Mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Plan review can save a plan to a chosen path and start a new session.
+- Added provider-agnostic Code Mode opt-in and live hidden-tool declarations for extension eval replacements, gated on a same-name native eval transport.
 - Added the `/pin` slash command to pin and unpin sessions so they stay at the top of the `--resume` picker UI.
 - Optional edit parse-regression capture appends the before/after content, model, variant, and arguments to `~/.omp/agent/edit-blackbox.jsonl` when `edit.blackbox.enabled` is enabled.
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -556,6 +556,14 @@ export class ExtensionRunner {
 		return this.#nativeToolResolver?.(name) !== undefined;
 	}
 
+	/** Whether the native built-in can currently carry Code Mode bridge calls. */
+	nativeToolSupportsCodeModeTransport(name: string): boolean {
+		const tool = this.#nativeToolResolver?.(name)?.tool as
+			| (AgentTool & { supportsCodeModeTransport?: () => boolean })
+			| undefined;
+		return tool?.supportsCodeModeTransport?.() ?? false;
+	}
+
 	/**
 	 * Run the native built-in of `name` with `params` and return its result — the delegation target
 	 * of a same-tool `ctx.invokeTool`. Calls the unwrapped native `execute` directly with the loop's

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -598,6 +598,12 @@ export interface ToolSessionEvent {
 	previousSessionFile: string | undefined;
 }
 
+/** Live Code Mode metadata supplied by the session to an eval replacement. */
+export interface CodeModeBridge {
+	/** Current declarations for tools hidden behind eval, or undefined while Code Mode is inactive. */
+	getDeclarations(): string | undefined;
+}
+
 /**
  * Tool definition for registerTool().
  */
@@ -625,6 +631,12 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	/** Structured-output strict grammar opt-in/out. `false` is meaningful: OpenAI-family
 	 *  serializers preserve an explicit `strict: false` on the wire (#4336/#4340). */
 	strict?: boolean;
+	/** Activate Code Mode for every model while this eval replacement is registered. */
+	codeModeActivation?: "all-models";
+	/** Return true only when this eval replacement can call enabled tools through the native bridge. */
+	supportsCodeModeTransport?: () => boolean;
+	/** Receive the host-owned live declarations for tools hidden behind this eval replacement. */
+	setCodeModeBridge?: (bridge: CodeModeBridge) => void;
 	/** MCP server name for discovery/search metadata when this tool fronts an MCP server. */
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -160,6 +160,20 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 	}
 
 	/**
+	 * Code Mode may hide every non-keep tool, so an extension replacement must
+	 * both declare bridge support and have a native same-name delegation target.
+	 */
+	supportsCodeModeTransport(): boolean {
+		const target = this.tool as AgentTool<TParameters, TDetails> & {
+			supportsCodeModeTransport?: () => boolean;
+		};
+		return (
+			this.runner.nativeToolSupportsCodeModeTransport(this.tool.name) &&
+			(target.supportsCodeModeTransport?.() ?? false)
+		);
+	}
+
+	/**
 	 * Forward browser mode changes when available.
 	 */
 	restartForModeChange(): Promise<void> {

--- a/packages/coding-agent/src/session/code-mode.ts
+++ b/packages/coding-agent/src/session/code-mode.ts
@@ -1,7 +1,7 @@
 /**
- * Codex Code Mode: collapse the direct tool surface for code_mode_only models
- * to a small keep-set and expose every other session tool through the eval
- * bridge, mirroring codex-rs ToolMode::CodeModeOnly.
+ * Collapse the direct tool list to a small keep-set and expose every other
+ * session tool through an eval bridge. Native Codex models and trusted eval
+ * extensions can activate it.
  */
 
 /** Tool names that always stay directly model-visible under code mode. */
@@ -23,15 +23,18 @@ export function resolveCodeMode(args: {
 	provider: string;
 	toolMode?: string;
 	setting: "off" | "on" | "auto";
+	extensionActivation?: "all-models";
 	extraDirectTools?: readonly string[];
 	enabledToolNames: readonly string[];
 	evalTransportAvailable: boolean;
 }): CodeModeResolution {
-	const active =
+	const nativeCodexActivation =
 		args.provider === "openai-codex" &&
+		(args.setting === "on" || (args.setting === "auto" && args.toolMode === "code_mode_only"));
+	const active =
 		args.enabledToolNames.includes("eval") &&
 		args.evalTransportAvailable &&
-		(args.setting === "on" || (args.setting === "auto" && args.toolMode === "code_mode_only"));
+		(args.extensionActivation === "all-models" || nativeCodexActivation);
 	if (!active) return { active: false, directToolNames: new Set(args.enabledToolNames) };
 	const direct = new Set<string>();
 	for (const name of args.enabledToolNames) {

--- a/packages/coding-agent/src/session/code-mode.ts
+++ b/packages/coding-agent/src/session/code-mode.ts
@@ -19,7 +19,7 @@ export interface CodeModeResolution {
 	directToolNames: Set<string>;
 }
 
-export function resolveCodeMode(args: {
+export interface ResolveCodeModeArgs {
 	provider: string;
 	toolMode?: string;
 	setting: "off" | "on" | "auto";
@@ -27,7 +27,9 @@ export function resolveCodeMode(args: {
 	extraDirectTools?: readonly string[];
 	enabledToolNames: readonly string[];
 	evalTransportAvailable: boolean;
-}): CodeModeResolution {
+}
+
+export function resolveCodeMode(args: ResolveCodeModeArgs): CodeModeResolution {
 	const nativeCodexActivation =
 		args.provider === "openai-codex" &&
 		(args.setting === "on" || (args.setting === "auto" && args.toolMode === "code_mode_only"));

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -8,7 +8,7 @@ import { formatModelString } from "../config/model-resolver";
 import type { Settings, SkillsSettings } from "../config/settings";
 import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
 import { CustomToolAdapter } from "../extensibility/custom-tools/wrapper";
-import type { ExtensionRunner, SourceInfo, ToolInfo } from "../extensibility/extensions";
+import type { CodeModeBridge, ExtensionRunner, SourceInfo, ToolInfo } from "../extensibility/extensions";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "../extensibility/skills";
 import { type LocalProtocolOptions, XD_URL_PREFIX } from "../internal-urls";
@@ -20,6 +20,7 @@ import xdevMountNoticePrompt from "../prompts/system/xdev-mount-notice.md" with 
 import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
 import { computerExposureMode } from "../tools/computer/exposure";
+import { generateCodeModeDeclarations } from "../tools/eval-format/code-mode-declarations";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { supportsExternalThinking } from "../tools/think";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
@@ -182,9 +183,18 @@ interface XdevMountNoticeDetails {
 	removed: string[];
 }
 
+interface CodeModeEvalTool extends AgentTool {
+	codeModeActivation?: "all-models";
+	supportsCodeModeTransport?: () => boolean;
+	setCodeModeBridge?: (bridge: CodeModeBridge) => void;
+}
+
 /** Owns tool registration, presentation, prompt rebuilding, skills, and permissions. */
 export class SessionTools {
 	readonly #host: SessionToolsHost;
+	readonly #codeModeBridge: CodeModeBridge = {
+		getDeclarations: () => this.#codeModeDeclarations(),
+	};
 	#autoApprove: boolean;
 	#toolRegistry: Map<string, AgentTool>;
 	#createVibeTools: (() => AgentTool[]) | undefined;
@@ -399,15 +409,38 @@ export class SessionTools {
 		return this.getEnabledToolNames();
 	}
 
-	#hasCodeModeEvalTransport(): boolean {
-		const evalTool = this.#toolRegistry.get("eval") as
-			| (AgentTool & { supportsCodeModeTransport?: () => boolean })
-			| undefined;
-		if (!evalTool) return false;
-		// A replacement `eval` that cannot state the capability cannot be assumed
-		// to run `tool.<name>()`; demoting the direct surface behind it would
-		// leave every other tool unreachable.
-		return evalTool.supportsCodeModeTransport?.() ?? false;
+	#codeModeEvalCapability(): { activation?: "all-models"; transportAvailable: boolean } {
+		const evalTool = this.#toolRegistry.get("eval") as CodeModeEvalTool | undefined;
+		if (!evalTool) return { transportAvailable: false };
+		evalTool.setCodeModeBridge?.(this.#codeModeBridge);
+		// Extension wrappers gate this claim on a native same-name delegation target.
+		return {
+			activation: evalTool.codeModeActivation,
+			transportAvailable: evalTool.supportsCodeModeTransport?.() ?? false,
+		};
+	}
+
+	#codeModeDeclarations(): string | undefined {
+		const evalTool = this.#toolRegistry.get("eval") as CodeModeEvalTool | undefined;
+		if (!evalTool) return undefined;
+		const enabledToolNames = this.getEnabledToolNames();
+		const codeMode = resolveCodeMode({
+			provider: this.#host.model()?.provider ?? "",
+			toolMode: this.#host.model()?.toolMode,
+			setting: this.#host.settings.get("providers.openai-codex.codeMode"),
+			extensionActivation: evalTool.codeModeActivation,
+			extraDirectTools: this.#host.settings.get("providers.openai-codex.codeModeDirectTools"),
+			enabledToolNames,
+			evalTransportAvailable: evalTool.supportsCodeModeTransport?.() ?? false,
+		});
+		if (!codeMode.active) return undefined;
+		return generateCodeModeDeclarations(
+			enabledToolNames.flatMap(name => {
+				if (codeMode.directToolNames.has(name)) return [];
+				const tool = this.#toolRegistry.get(name);
+				return tool ? [{ name, parameters: tool.parameters }] : [];
+			}),
+		);
 	}
 
 	/**
@@ -642,19 +675,22 @@ export class SessionTools {
 	/** Whether a model transition crosses a Code Mode presentation boundary. */
 	codeModeChangesBetween(previousModel: Model | undefined, nextModel: Model): boolean {
 		const enabledToolNames = this.getEnabledToolNames();
+		const codeModeEval = this.#codeModeEvalCapability();
 		const setting = this.#host.settings.get("providers.openai-codex.codeMode");
 		const extraDirectTools = this.#host.settings.get("providers.openai-codex.codeModeDirectTools");
-		const resolve = (model: Model | undefined) =>
+		const resolve = (model: Model) =>
 			resolveCodeMode({
-				provider: model?.provider ?? "",
-				toolMode: model?.toolMode,
+				provider: model.provider,
+				toolMode: model.toolMode,
 				setting,
+				extensionActivation: codeModeEval.activation,
 				extraDirectTools,
 				enabledToolNames,
-				evalTransportAvailable: this.#hasCodeModeEvalTransport(),
+				evalTransportAvailable: codeModeEval.transportAvailable,
 			});
-		const previous = resolve(previousModel);
 		const next = resolve(nextModel);
+		if (!previousModel) return next.active;
+		const previous = resolve(previousModel);
 		if (previous.active !== next.active) return true;
 		if (!next.active) return false;
 		if (previous.directToolNames.size !== next.directToolNames.size) return true;
@@ -825,13 +861,15 @@ export class SessionTools {
 		toolNames = normalizeToolNames(toolNames);
 		const injectEval = this.#toolRegistry.has("eval") && !toolNames.includes("eval");
 		const codeModeToolNames = injectEval ? [...toolNames, "eval"] : toolNames;
+		const codeModeEval = this.#codeModeEvalCapability();
 		const codeMode = resolveCodeMode({
 			provider: this.#host.model()?.provider ?? "",
 			toolMode: this.#host.model()?.toolMode,
 			setting: this.#host.settings.get("providers.openai-codex.codeMode"),
+			extensionActivation: codeModeEval.activation,
 			extraDirectTools: this.#host.settings.get("providers.openai-codex.codeModeDirectTools"),
 			enabledToolNames: codeModeToolNames,
-			evalTransportAvailable: this.#hasCodeModeEvalTransport(),
+			evalTransportAvailable: codeModeEval.transportAvailable,
 		});
 		const nextCodeModeInjectedEval = codeMode.active && injectEval;
 		if (codeMode.active) toolNames = codeModeToolNames;

--- a/packages/coding-agent/test/provider-agnostic-code-mode.test.ts
+++ b/packages/coding-agent/test/provider-agnostic-code-mode.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "bun:test";
+import { ExtensionToolWrapper } from "../src/extensibility/extensions/wrapper";
+import { resolveCodeMode } from "../src/session/code-mode";
+import { SessionTools, type SessionToolsHost } from "../src/session/session-tools";
+
+const enabledToolNames = ["eval", "todo", "read", "bash"];
+
+function resolve(provider: string, overrides: Partial<Parameters<typeof resolveCodeMode>[0]> = {}) {
+	return resolveCodeMode({
+		provider,
+		setting: "off",
+		enabledToolNames,
+		evalTransportAvailable: true,
+		...overrides,
+	});
+}
+
+describe("provider-agnostic extension Code Mode", () => {
+	for (const provider of ["anthropic", "google-antigravity", "openai", "openai-codex", "xai-oauth"]) {
+		it(`activates for ${provider}`, () => {
+			const result = resolve(provider, { extensionActivation: "all-models" });
+			expect(result.active).toBe(true);
+			expect([...result.directToolNames]).toEqual(["eval", "todo"]);
+		});
+	}
+
+	it("fails closed when the eval replacement cannot reach the native tool bridge", () => {
+		const result = resolve("anthropic", {
+			extensionActivation: "all-models",
+			evalTransportAvailable: false,
+		});
+		expect(result.active).toBe(false);
+		expect([...result.directToolNames]).toEqual(enabledToolNames);
+	});
+
+	it("gates extension bridge claims on the native same-name transport capability", () => {
+		const replacement = {
+			name: "eval",
+			supportsCodeModeTransport: () => true,
+		};
+		let nativeAvailable = false;
+		const wrapped = new ExtensionToolWrapper(
+			replacement as never,
+			{
+				nativeToolSupportsCodeModeTransport: () => nativeAvailable,
+			} as never,
+		);
+
+		expect(wrapped.supportsCodeModeTransport()).toBe(false);
+		nativeAvailable = true;
+		expect(wrapped.supportsCodeModeTransport()).toBe(true);
+		nativeAvailable = false;
+		expect(wrapped.supportsCodeModeTransport()).toBe(false);
+	});
+
+	it("does not change non-Codex behavior without an extension opt-in", () => {
+		expect(resolve("anthropic", { setting: "on" }).active).toBe(false);
+	});
+
+	it("forwards the live bridge through the extension tool wrapper", () => {
+		let receivedBridge: { getDeclarations(): string | undefined } | undefined;
+		const replacement = {
+			name: "eval",
+			codeModeActivation: "all-models",
+			supportsCodeModeTransport: () => receivedBridge !== undefined,
+			setCodeModeBridge: (bridge: typeof receivedBridge) => {
+				receivedBridge = bridge;
+			},
+		};
+		const wrapped = new ExtensionToolWrapper(
+			replacement as never,
+			{
+				nativeToolSupportsCodeModeTransport: () => true,
+			} as never,
+		);
+		const host = {
+			agent: { state: { tools: [wrapped] } },
+			settings: {
+				get: (key: string) => (key === "providers.openai-codex.codeModeDirectTools" ? [] : "off"),
+			},
+			model: () => ({ provider: "anthropic" }),
+		} as unknown as SessionToolsHost;
+		const sessionTools = new SessionTools(host, {
+			toolRegistry: new Map([["eval", wrapped]]),
+			baseSystemPrompt: [],
+		} as never);
+
+		expect(sessionTools.codeModeChangesBetween(undefined, { provider: "anthropic" } as never)).toBe(true);
+		expect(receivedBridge).toBeDefined();
+	});
+
+	it("reconciles initial all-model activation before the first provider request", () => {
+		const evalTool = {
+			name: "eval",
+			codeModeActivation: "all-models",
+			supportsCodeModeTransport: () => true,
+		};
+		const readTool = { name: "read" };
+		const host = {
+			agent: { state: { tools: [evalTool, readTool] } },
+			settings: {
+				get: (key: string) => (key === "providers.openai-codex.codeModeDirectTools" ? [] : "off"),
+			},
+			model: () => undefined,
+		} as unknown as SessionToolsHost;
+		const sessionTools = new SessionTools(host, {
+			toolRegistry: new Map([
+				["eval", evalTool],
+				["read", readTool],
+			]),
+			baseSystemPrompt: [],
+		} as never);
+
+		expect(sessionTools.codeModeChangesBetween(undefined, { provider: "anthropic" } as never)).toBe(true);
+		expect(
+			sessionTools.codeModeChangesBetween({ provider: "anthropic" } as never, { provider: "xai-oauth" } as never),
+		).toBe(false);
+	});
+
+	it("supplies live declarations for hidden tool schemas", () => {
+		let bridge: { getDeclarations(): string | undefined } | undefined;
+		const evalTool = {
+			name: "eval",
+			codeModeActivation: "all-models",
+			supportsCodeModeTransport: () => bridge !== undefined,
+			setCodeModeBridge: (next: typeof bridge) => {
+				bridge = next;
+			},
+		};
+		const readTool = {
+			name: "read",
+			parameters: {
+				type: "object",
+				properties: { path: { type: "string" } },
+				required: ["path"],
+			},
+		};
+		const batchTool = {
+			name: "batch",
+			parameters: {
+				type: "object",
+				properties: { paths: { type: "array", items: { type: "string" } } },
+				required: ["paths"],
+			},
+		};
+		const host = {
+			agent: { state: { tools: [evalTool, readTool, batchTool] } },
+			settings: {
+				get: (key: string) => (key === "providers.openai-codex.codeModeDirectTools" ? [] : "off"),
+			},
+			model: () => ({ provider: "anthropic" }),
+		} as unknown as SessionToolsHost;
+		const sessionTools = new SessionTools(host, {
+			toolRegistry: new Map<string, unknown>([
+				["eval", evalTool],
+				["read", readTool],
+				["batch", batchTool],
+			]),
+			baseSystemPrompt: [],
+		} as never);
+
+		expect(sessionTools.codeModeChangesBetween(undefined, { provider: "anthropic" } as never)).toBe(true);
+		const declarations = bridge?.getDeclarations();
+		expect(declarations).toContain("read(args: { path: string }): Promise<unknown>;");
+		expect(declarations).toContain("batch(args: { paths: string[] }): Promise<unknown>;");
+		expect(declarations).not.toContain("eval(args:");
+	});
+
+	it("keeps native Codex activation unchanged", () => {
+		expect(resolve("openai-codex", { setting: "on" }).active).toBe(true);
+		expect(resolve("openai-codex", { setting: "auto", toolMode: "code_mode_only" }).active).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/provider-agnostic-code-mode.test.ts
+++ b/packages/coding-agent/test/provider-agnostic-code-mode.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { ExtensionToolWrapper } from "../src/extensibility/extensions/wrapper";
-import { resolveCodeMode } from "../src/session/code-mode";
+import { type ResolveCodeModeArgs, resolveCodeMode } from "../src/session/code-mode";
 import { SessionTools, type SessionToolsHost } from "../src/session/session-tools";
 
 const enabledToolNames = ["eval", "todo", "read", "bash"];
 
-function resolve(provider: string, overrides: Partial<Parameters<typeof resolveCodeMode>[0]> = {}) {
+function resolve(provider: string, overrides: Partial<ResolveCodeModeArgs> = {}) {
 	return resolveCodeMode({
 		provider,
 		setting: "off",


### PR DESCRIPTION
## Summary

- allow trusted replacement `eval` extensions to activate Code Mode for every provider
- supply live host-owned hidden-tool declarations through the extension bridge
- fail closed unless a same-name native eval transport is currently available, preserving direct tools when native JavaScript is disabled
- add provider-agnostic session and transport coverage

## Verification

- `bun test ./packages/coding-agent/test/provider-agnostic-code-mode.test.ts ./packages/coding-agent/test/extensions-runner.test.ts ./packages/coding-agent/test/eval-code-mode-declarations.test.ts ./packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts ./packages/coding-agent/test/session-code-mode.test.ts` — 141 passed
- `bun --cwd=packages/coding-agent run check`
- direct-tool fallback smoke with native JavaScript disabled

## Scope

No merge, release, or deployment is included.
