### PR TITLE
fix(mnemopi): default blank database paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Subagents in a shared working tree no longer run formatters, linters, or project-wide builds/test suites unless their assignment asks for it; validation runs once by the main agent.
 ### Fixed
 
+- Fixed blank `mnemopi.dbPath` settings silently creating volatile memory banks instead of using persistent agent storage ([#9360](https://github.com/can1357/oh-my-pi/issues/9360)).
 - Fixed Kitty text-sized Markdown headings activating before `tui.textSizing` is enabled.
 - Fixed status text retaining hidden DCS, PM, and APC payloads after escape-sequence sanitization.
 - Fixed extension load errors truncating explicitly excluded package import specifiers.

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -44,7 +44,9 @@ export function loadMnemopiConfig(settings: Settings, agentDir: string): Mnemopi
 	const configuredDbPath = settings.get("mnemopi.dbPath");
 	const cwd = settings.getCwd();
 	const scoping = settings.get("mnemopi.scoping");
-	const dbPath = configuredDbPath ?? path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db");
+	const dbPath = configuredDbPath?.trim()
+		? configuredDbPath
+		: path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db");
 	const scope = computeMnemopiBankScope(settings.get("mnemopi.bank"), cwd, scoping);
 	const recallBanks =
 		scoping === "global" ? scope.recallBanks : extendRecallWithLegacyBanks(scope.recallBanks, dbPath, cwd);

--- a/packages/coding-agent/test/mnemopi-config.test.ts
+++ b/packages/coding-agent/test/mnemopi-config.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { loadMnemopiConfig } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
+import { loadMnemopiConfig, type MnemopiBackendConfig } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
+import { getMemoriesDir } from "@oh-my-pi/pi-utils";
 
 // `mnemopi.embeddingVariant` selects the concrete local embedding model, while an
 // explicit `mnemopi.embeddingModel` is an advanced override that wins. Scoping is
 // pinned to "global" so the resolver stays pure (no legacy-bank disk probing).
-function embeddingModelFor(overrides: Record<string, unknown>): string | undefined {
+function mnemopiConfigFor(
+	overrides: Record<string, unknown>,
+	agentDir = "/tmp/mnemopi-config-test",
+): MnemopiBackendConfig {
 	const settings = Settings.isolated({ "mnemopi.scoping": "global", ...overrides });
-	return loadMnemopiConfig(settings, "/tmp/mnemopi-embedding-variant-test").providerOptions.embeddingModel;
+	return loadMnemopiConfig(settings, agentDir);
+}
+
+function embeddingModelFor(overrides: Record<string, unknown>): string | undefined {
+	return mnemopiConfigFor(overrides).providerOptions.embeddingModel;
 }
 
 describe("loadMnemopiConfig embedding variant resolution", () => {
@@ -57,5 +66,15 @@ describe("loadMnemopiConfig embedding variant resolution", () => {
 			if (previous === undefined) delete Bun.env.MNEMOPI_EMBEDDING_MODEL;
 			else Bun.env.MNEMOPI_EMBEDDING_MODEL = previous;
 		}
+	});
+});
+
+describe("loadMnemopiConfig database path resolution", () => {
+	it("resolves a blank dbPath to persistent agent storage", () => {
+		const agentDir = "/tmp/mnemopi-blank-db-path-test";
+		const defaultPath = path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db");
+
+		expect(mnemopiConfigFor({ "mnemopi.dbPath": "" }, agentDir).dbPath).toBe(defaultPath);
+		expect(mnemopiConfigFor({ "mnemopi.dbPath": " \t " }, agentDir).dbPath).toBe(defaultPath);
 	});
 });


### PR DESCRIPTION
## Repro
With `mnemopi.dbPath` set to an empty string, run `bun -e 'import { Database } from \"bun:sqlite\"; import { Settings } from \"@oh-my-pi/pi-coding-agent/config/settings\"; import { loadMnemopiConfig } from \"@oh-my-pi/pi-coding-agent/mnemopi/config\"; const c = loadMnemopiConfig(Settings.isolated({ \"mnemopi.scoping\": \"global\", \"mnemopi.dbPath\": \"\" }), \"/tmp/mnemopi-empty-path-repro\"); console.log(JSON.stringify(c.dbPath)); const a = new Database(c.dbPath); a.exec(\"CREATE TABLE memories (value TEXT); INSERT INTO memories VALUES ('retained')\"); a.close(); const b = new Database(c.dbPath); console.log(b.query(\"SELECT value FROM memories\").get());'`. Before the fix it prints `\"\"` and the reopened query fails with `no such table: memories`.

## Cause
`loadMnemopiConfig` in `packages/coding-agent/src/mnemopi/config.ts` used nullish coalescing for `mnemopi.dbPath`, so empty and whitespace-only strings bypassed the documented persistent default and reached Bun SQLite as a volatile database path.

## Fix
- Treat empty and whitespace-only configured database paths as unset while preserving nonblank configured paths.
- Rename the focused config test file and cover blank-path resolution to the agent memories directory.
- Document the user-visible persistence fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/mnemopi-config.test.ts` passes: 7 tests, 0 failures. A manual SQLite close/reopen probe resolved the blank setting to `/tmp/mnemopi-empty-path-fixed/memories/mnemopi/mnemopi.db` and read back `retained`. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #9360