### PR TITLE
fix(hindsight): preserve conversation timestamps

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Subagents in a shared working tree no longer run formatters, linters, or project-wide builds/test suites unless their assignment asks for it; validation runs once by the main agent.
 ### Fixed
 
+- Fixed Hindsight session retains stamping items with retain time instead of the conversation's source timestamps.
 - Fixed Kitty text-sized Markdown headings activating before `tui.textSizing` is enabled.
 - Fixed status text retaining hidden DCS, PM, and APC payloads after escape-sequence sanitization.
 - Fixed extension load errors truncating explicitly excluded package import specifiers.

--- a/packages/coding-agent/src/hindsight/content.ts
+++ b/packages/coding-agent/src/hindsight/content.ts
@@ -12,6 +12,8 @@
 export interface HindsightMessage {
 	role: string;
 	content: string;
+	/** Original SessionEntry.timestamp; omitted when the source had none. */
+	timestamp?: string;
 }
 
 export interface RecallResultLike {
@@ -190,12 +192,20 @@ export interface RetentionTranscript {
  * Messages are tag-stripped before framing to break the recall→retain loop.
  * Returns `{ transcript: null }` when nothing meaningful survives.
  */
+function formatRetentionMessage(msg: HindsightMessage): string | null {
+	const content = stripMemoryTags(msg.content).trim();
+	if (!hasSubstantiveContent(content)) return null;
+	const header = `[role: ${msg.role}]`;
+	const timestamp = msg.timestamp?.trim();
+	const stamped = timestamp ? `${header}\n[timestamp: ${timestamp}]` : header;
+	return `${stamped}\n${content}\n[${msg.role}:end]`;
+}
+
 function formatRetentionMessages(messages: HindsightMessage[]): RetentionTranscript {
 	const parts: string[] = [];
 	for (const msg of messages) {
-		const content = stripMemoryTags(msg.content).trim();
-		if (!hasSubstantiveContent(content)) continue;
-		parts.push(`[role: ${msg.role}]\n${content}\n[${msg.role}:end]`);
+		const formatted = formatRetentionMessage(msg);
+		if (formatted) parts.push(formatted);
 	}
 
 	if (parts.length === 0) return { transcript: null, messageCount: 0 };

--- a/packages/coding-agent/src/hindsight/content.ts
+++ b/packages/coding-agent/src/hindsight/content.ts
@@ -27,7 +27,7 @@ const LEGACY_HINDSIGHT_MEMORIES_REGEX = /<hindsight_memories>[\s\S]*?<\/hindsigh
 const LEGACY_RELEVANT_MEMORIES_REGEX = /<relevant_memories>[\s\S]*?<\/relevant_memories>/g;
 const MENTAL_MODELS_REGEX = /<mental_models>[\s\S]*?<\/mental_models>/g;
 
-const RETENTION_PROTOCOL_MARKER_REGEX = /^\[(?:role:\s*[-_a-zA-Z0-9]+|[-_a-zA-Z0-9]+:end)\]$/;
+const RETENTION_PROTOCOL_MARKER_REGEX = /^\[(?:role:\s*[-_a-zA-Z0-9]+|[-_a-zA-Z0-9]+:end|timestamp:\s+.+)\]$/;
 /**
  * Strip `<memories>`, `<mental_models>`, and legacy memory blocks.
  *
@@ -192,19 +192,19 @@ export interface RetentionTranscript {
  * Messages are tag-stripped before framing to break the recall→retain loop.
  * Returns `{ transcript: null }` when nothing meaningful survives.
  */
-function formatRetentionMessage(msg: HindsightMessage): string | null {
+function formatRetentionMessage(msg: HindsightMessage, includeTimestamps = false): string | null {
 	const content = stripMemoryTags(msg.content).trim();
 	if (!hasSubstantiveContent(content)) return null;
 	const header = `[role: ${msg.role}]`;
-	const timestamp = msg.timestamp?.trim();
+	const timestamp = includeTimestamps ? msg.timestamp?.trim() : undefined;
 	const stamped = timestamp ? `${header}\n[timestamp: ${timestamp}]` : header;
 	return `${stamped}\n${content}\n[${msg.role}:end]`;
 }
 
-function formatRetentionMessages(messages: HindsightMessage[]): RetentionTranscript {
+function formatRetentionMessages(messages: HindsightMessage[], includeTimestamps = false): RetentionTranscript {
 	const parts: string[] = [];
 	for (const msg of messages) {
-		const formatted = formatRetentionMessage(msg);
+		const formatted = formatRetentionMessage(msg, includeTimestamps);
 		if (formatted) parts.push(formatted);
 	}
 
@@ -245,6 +245,7 @@ export function stripRetentionProtocolMarkers(content: string): string {
 export function prepareRetentionTranscript(
 	messages: HindsightMessage[],
 	retainFullWindow = false,
+	options?: { includeTimestamps?: boolean },
 ): RetentionTranscript {
 	if (messages.length === 0) return { transcript: null, messageCount: 0 };
 
@@ -263,7 +264,7 @@ export function prepareRetentionTranscript(
 		targetMessages = messages.slice(lastUserIdx);
 	}
 
-	return formatRetentionMessages(targetMessages);
+	return formatRetentionMessages(targetMessages, options?.includeTimestamps === true);
 }
 
 /** Format all retention messages without protocol markers for embedding, FTS, and recall display. */

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -313,8 +313,15 @@ export class HindsightSessionState {
 		}
 	}
 
+	#sessionSourceTimestamp(): string | undefined {
+		const header = this.session.sessionManager?.getHeader?.();
+		const timestamp = header?.timestamp;
+		return typeof timestamp === "string" && timestamp.trim().length > 0 ? timestamp : undefined;
+	}
+
 	async retainSession(messages: HindsightMessage[]): Promise<void> {
 		const retainedAt = new Date();
+		const sourceTimestamp = this.#sessionSourceTimestamp() ?? retainedAt;
 		const retainFullWindow = this.config.retainMode === "full-session";
 		let documentId: string;
 		let transcript: string;
@@ -351,7 +358,7 @@ export class HindsightSessionState {
 			context: this.config.retainContext,
 			metadata: { session_id: this.sessionId },
 			tags: this.retainTags,
-			timestamp: retainedAt,
+			timestamp: sourceTimestamp,
 			async: true,
 		});
 		if (nextCachedTranscript !== undefined) {

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -193,7 +193,7 @@ function retentionPrefixKey(messages: HindsightMessage[], count: number): string
 	for (let i = 0; i < count; i++) {
 		const m = messages[i];
 		if (m === undefined) break;
-		key = Bun.hash(`${key}\u0000${m.role}\u0000${m.content}`).toString(36);
+		key = Bun.hash(`${key}\u0000${m.role}\u0000${m.content}\u0000${m.timestamp ?? ""}`).toString(36);
 	}
 	return key;
 }
@@ -336,7 +336,7 @@ export class HindsightSessionState {
 				this.#lastRetainedPrefixKey = "";
 			}
 			const newMessages = messages.slice(this.#lastRetainedMessageIndex);
-			const { transcript: newPart } = prepareRetentionTranscript(newMessages, true);
+			const { transcript: newPart } = prepareRetentionTranscript(newMessages, true, { includeTimestamps: true });
 			if (!newPart) return;
 			nextCachedTranscript = this.#cachedTranscript ? `${this.#cachedTranscript}\n\n${newPart}` : newPart;
 			transcript = nextCachedTranscript;
@@ -347,7 +347,7 @@ export class HindsightSessionState {
 			this.#lastRetainedMessageIndex = 0;
 			this.#cachedTranscript = "";
 			this.#lastRetainedPrefixKey = "";
-			const { transcript: windowTranscript } = prepareRetentionTranscript(target, true);
+			const { transcript: windowTranscript } = prepareRetentionTranscript(target, true, { includeTimestamps: true });
 			if (!windowTranscript) return;
 			transcript = windowTranscript;
 		}

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -313,10 +313,14 @@ export class HindsightSessionState {
 		}
 	}
 
-	#sessionSourceTimestamp(): string | undefined {
+	#sessionSourceTimestamp(): Date | undefined {
 		const header = this.session.sessionManager?.getHeader?.();
 		const timestamp = header?.timestamp;
-		return typeof timestamp === "string" && timestamp.trim().length > 0 ? timestamp : undefined;
+		if (typeof timestamp !== "string") return undefined;
+		const trimmed = timestamp.trim();
+		if (!trimmed) return undefined;
+		const parsed = new Date(trimmed);
+		return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 	}
 
 	async retainSession(messages: HindsightMessage[]): Promise<void> {

--- a/packages/coding-agent/src/hindsight/transcript.ts
+++ b/packages/coding-agent/src/hindsight/transcript.ts
@@ -1,10 +1,13 @@
 /**
  * Pull plain-text user/assistant messages out of a session manager.
  *
- * The Hindsight retain/recall API only takes flat `{role, content}` records,
- * so we drop tool calls, tool results, bash execution wrappers, custom
+ * These `{role, content, timestamp}` records are our internal conversation
+ * shape. The Hindsight retain API ultimately receives a serialized transcript
+ * string, so we drop tool calls, tool results, bash execution wrappers, custom
  * messages, and anything else that isn't a primary conversation turn. Each
- * surviving message's `TextContent` parts are joined with newlines.
+ * surviving message's `TextContent` parts are joined with newlines. The
+ * SessionEntry timestamp is preserved on the internal record as the source
+ * event time.
  */
 
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
@@ -40,7 +43,7 @@ export function extractMessages(sessionManager: ReadonlySessionManagerLike): Hin
 
 		const text = role === "user" ? extractUserText(msg) : extractAssistantText(msg as AssistantMessage);
 		if (!hasSubstantiveContent(text)) continue;
-		messages.push({ role, content: text });
+		messages.push({ role, content: text, timestamp: entry.timestamp });
 	}
 
 	return messages;

--- a/packages/coding-agent/test/hindsight-content.test.ts
+++ b/packages/coding-agent/test/hindsight-content.test.ts
@@ -233,6 +233,43 @@ describe("prepareRetentionTranscript", () => {
 		expect(transcript).not.toContain(":end]");
 		expect(transcript).not.toContain("<memories>");
 	});
+	it("preserves source message timestamps in the retained conversation content", () => {
+		const messages: HindsightMessage[] = [
+			{
+				role: "user",
+				content: "i stopped doing that yesterday",
+				timestamp: "2026-08-17T10:00:00.000Z",
+			},
+			{
+				role: "assistant",
+				content: "got it, that was sunday then",
+				timestamp: "2026-08-17T10:00:05.000Z",
+			},
+		];
+		const { transcript, messageCount } = prepareRetentionTranscript(messages, true);
+		expect(messageCount).toBe(2);
+		expect(transcript).toContain(
+			"[role: user]\n[timestamp: 2026-08-17T10:00:00.000Z]\ni stopped doing that yesterday\n[user:end]",
+		);
+		expect(transcript).toContain(
+			"[role: assistant]\n[timestamp: 2026-08-17T10:00:05.000Z]\ngot it, that was sunday then\n[assistant:end]",
+		);
+	});
+
+	it("still strips recalled memory blocks when messages carry timestamps", () => {
+		const messages: HindsightMessage[] = [
+			{
+				role: "user",
+				content: "<memories>\n- recalled fact about user\n</memories>\nuser-real-question-here",
+				timestamp: "2026-08-17T10:00:00.000Z",
+			},
+		];
+		const { transcript } = prepareRetentionTranscript(messages, true);
+		expect(transcript).not.toContain("<memories>");
+		expect(transcript).not.toContain("recalled fact about user");
+		expect(transcript).toContain("[timestamp: 2026-08-17T10:00:00.000Z]");
+		expect(transcript).toContain("user-real-question-here");
+	});
 });
 
 describe("hasSubstantiveContent", () => {

--- a/packages/coding-agent/test/hindsight-content.test.ts
+++ b/packages/coding-agent/test/hindsight-content.test.ts
@@ -10,6 +10,7 @@ import {
 	prepareUserRetentionTranscript,
 	sliceLastTurnsByUserBoundary,
 	stripMemoryTags,
+	stripRetentionProtocolMarkers,
 	truncateRecallQuery,
 } from "@oh-my-pi/pi-coding-agent/hindsight/content";
 
@@ -246,7 +247,7 @@ describe("prepareRetentionTranscript", () => {
 				timestamp: "2026-08-17T10:00:05.000Z",
 			},
 		];
-		const { transcript, messageCount } = prepareRetentionTranscript(messages, true);
+		const { transcript, messageCount } = prepareRetentionTranscript(messages, true, { includeTimestamps: true });
 		expect(messageCount).toBe(2);
 		expect(transcript).toContain(
 			"[role: user]\n[timestamp: 2026-08-17T10:00:00.000Z]\ni stopped doing that yesterday\n[user:end]",
@@ -264,11 +265,29 @@ describe("prepareRetentionTranscript", () => {
 				timestamp: "2026-08-17T10:00:00.000Z",
 			},
 		];
-		const { transcript } = prepareRetentionTranscript(messages, true);
+		const { transcript } = prepareRetentionTranscript(messages, true, { includeTimestamps: true });
 		expect(transcript).not.toContain("<memories>");
 		expect(transcript).not.toContain("recalled fact about user");
 		expect(transcript).toContain("[timestamp: 2026-08-17T10:00:00.000Z]");
 		expect(transcript).toContain("user-real-question-here");
+	});
+
+	it("keeps timestamp framing opt-in so shared Mnemopi formatting stays marker-only", () => {
+		const messages: HindsightMessage[] = [
+			{
+				role: "user",
+				content: "i stopped doing that yesterday",
+				timestamp: "2026-08-17T10:00:00.000Z",
+			},
+		];
+		const { transcript } = prepareRetentionTranscript(messages, true);
+		expect(transcript).toBe("[role: user]\ni stopped doing that yesterday\n[user:end]");
+		expect(transcript).not.toContain("[timestamp:");
+	});
+
+	it("strips timestamp protocol markers from recalled stored transcripts", () => {
+		const stored = "[role: user]\n[timestamp: 2026-08-17T10:00:00.000Z]\ni stopped doing that yesterday\n[user:end]";
+		expect(stripRetentionProtocolMarkers(stored)).toBe("i stopped doing that yesterday");
 	});
 });
 

--- a/packages/coding-agent/test/hindsight-conversation-timestamps.test.ts
+++ b/packages/coding-agent/test/hindsight-conversation-timestamps.test.ts
@@ -60,6 +60,12 @@ function firstItem(body: unknown): Record<string, unknown> {
 	return item as Record<string, unknown>;
 }
 
+function expectSameInstant(actual: unknown, isoUtc: string): void {
+	expect(typeof actual).toBe("string");
+	expect(String(actual)).not.toBe(isoUtc);
+	expect(Date.parse(String(actual))).toBe(Date.parse(isoUtc));
+}
+
 const SESSION_START = "2026-08-17T09:00:00.000Z";
 const USER_TS = "2026-08-17T10:00:00.000Z";
 const ASSISTANT_TS = "2026-08-17T10:00:05.000Z";
@@ -188,13 +194,44 @@ describe("Hindsight conversation source timestamps", () => {
 		await state.retainSession(extractMessages({ getEntries: () => laterEntries }));
 
 		expect(bodies).toHaveLength(2);
-		expect(firstItem(bodies[0]).timestamp).toBe(SESSION_START);
-		expect(firstItem(bodies[1]).timestamp).toBe(SESSION_START);
+		expectSameInstant(firstItem(bodies[0]).timestamp, SESSION_START);
+		expectSameInstant(firstItem(bodies[1]).timestamp, SESSION_START);
 		expect(String(firstItem(bodies[0]).content)).toContain("[timestamp: 2026-08-17T10:00:00.000Z]");
 		expect(String(firstItem(bodies[0]).content)).toContain("[timestamp: 2026-08-17T10:00:05.000Z]");
 		expect(String(firstItem(bodies[1]).content)).toContain("same conversation, later thursday turn");
 		expect(String(firstItem(bodies[1]).content)).not.toContain("internal monologue");
 		expect(String(firstItem(bodies[1]).content)).not.toContain("secret tool output");
 		expect(String(firstItem(bodies[1]).content)).not.toContain("<memories>");
+	});
+
+	it("falls back to retain-time when the session header timestamp is invalid", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		const entries = conversationEntries();
+		const state = new HindsightSessionState({
+			sessionId: "sess-bad-ts",
+			client,
+			bankId: "personal",
+			config: makeConfig(),
+			session: {
+				sessionId: "sess-bad-ts",
+				sessionManager: {
+					getEntries: () => entries,
+					getHeader: () => ({
+						type: "session",
+						id: "sess-bad-ts",
+						timestamp: "not-a-date",
+						cwd: "/tmp",
+					}),
+				},
+				getHindsightSessionState: () => state,
+			} as object as AgentSession,
+			banksSet: new Set(["personal"]),
+		});
+
+		await state.retainSession(extractMessages({ getEntries: () => entries }));
+		expect(bodies).toHaveLength(1);
+		expect(firstItem(bodies[0]).timestamp).not.toBe("not-a-date");
+		expect(Number.isNaN(Date.parse(String(firstItem(bodies[0]).timestamp)))).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/hindsight-conversation-timestamps.test.ts
+++ b/packages/coding-agent/test/hindsight-conversation-timestamps.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { HindsightApi } from "@oh-my-pi/pi-coding-agent/hindsight/client";
+import type { HindsightConfig } from "@oh-my-pi/pi-coding-agent/hindsight/config";
+import { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
+import { extractMessages } from "@oh-my-pi/pi-coding-agent/hindsight/transcript";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+function captureBodies(): unknown[] {
+	const bodies: unknown[] = [];
+	const fetchMock: typeof globalThis.fetch = Object.assign(
+		async (_input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+			bodies.push(JSON.parse(String(init?.body ?? "{}")));
+			return new Response("{}", { status: 200 });
+		},
+		{ preconnect: globalThis.fetch.preconnect },
+	);
+	vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+	return bodies;
+}
+
+const makeConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig => ({
+	hindsightApiUrl: "http://localhost:8888",
+	hindsightApiToken: null,
+	bankId: "personal",
+	bankIdPrefix: "",
+	scoping: "per-project-tagged",
+	bankMission: "",
+	retainMission: null,
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	recallBudget: "mid",
+	recallMaxTokens: 1024,
+	recallTypes: ["world", "experience"],
+	recallContextTurns: 1,
+	recallMaxQueryChars: 800,
+	recallPromptPreamble: "preamble",
+	debug: false,
+	requestTimeoutMs: 30_000,
+	reflectTimeoutMs: 30_000,
+	recallTimeoutMs: 30_000,
+	retainTimeoutMs: 30_000,
+	mentalModelsEnabled: false,
+	mentalModelAutoSeed: false,
+	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
+	mentalModelMaxRenderChars: 16_000,
+	...overrides,
+});
+
+function firstItem(body: unknown): Record<string, unknown> {
+	if (typeof body !== "object" || body === null) throw new Error("missing retain body");
+	const items = (body as { items?: unknown }).items;
+	if (!Array.isArray(items) || items[0] === undefined) throw new Error("missing retain item");
+	const item = items[0];
+	if (typeof item !== "object" || item === null) throw new Error("retain item is not an object");
+	return item as Record<string, unknown>;
+}
+
+const SESSION_START = "2026-08-17T09:00:00.000Z";
+const USER_TS = "2026-08-17T10:00:00.000Z";
+const ASSISTANT_TS = "2026-08-17T10:00:05.000Z";
+
+function conversationEntries(): SessionEntry[] {
+	return [
+		{
+			type: "message",
+			id: "u1",
+			parentId: null,
+			timestamp: USER_TS,
+			message: {
+				role: "user",
+				content: "i stopped doing that yesterday",
+				timestamp: Date.parse(USER_TS),
+			},
+		},
+		{
+			type: "message",
+			id: "a1",
+			parentId: "u1",
+			timestamp: ASSISTANT_TS,
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "internal monologue must not be retained" },
+					{ type: "text", text: "got it, that was sunday then" },
+					{
+						type: "toolCall",
+						id: "call-1",
+						name: "bash",
+						arguments: { command: "echo secret" },
+					},
+				],
+				timestamp: Date.parse(ASSISTANT_TS),
+			},
+		},
+		{
+			type: "thinking_level_change",
+			id: "tl1",
+			parentId: "a1",
+			timestamp: "2026-08-17T10:00:06.000Z",
+			thinkingLevel: "high",
+		},
+		{
+			type: "message",
+			id: "tool-noise",
+			parentId: "tl1",
+			timestamp: "2026-08-17T10:00:07.000Z",
+			message: {
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "bash",
+				content: [{ type: "text", text: "secret tool output" }],
+				isError: false,
+				timestamp: Date.parse("2026-08-17T10:00:07.000Z"),
+			},
+		},
+	] as SessionEntry[];
+}
+
+describe("Hindsight conversation source timestamps", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keeps user/assistant SessionEntry timestamps and drops thinking/tool entries", () => {
+		const extracted = extractMessages({ getEntries: () => conversationEntries() });
+		expect(extracted).toEqual([
+			{
+				role: "user",
+				content: "i stopped doing that yesterday",
+				timestamp: USER_TS,
+			},
+			{
+				role: "assistant",
+				content: "got it, that was sunday then",
+				timestamp: ASSISTANT_TS,
+			},
+		]);
+		expect(extracted.some(m => m.content.includes("internal monologue"))).toBe(false);
+		expect(extracted.some(m => m.content.includes("secret tool output"))).toBe(false);
+	});
+
+	it("uses the session start timestamp on every retain of the same conversation", async () => {
+		const bodies = captureBodies();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+		const entries = conversationEntries();
+		const state = new HindsightSessionState({
+			sessionId: "sess-ts",
+			client,
+			bankId: "personal",
+			config: makeConfig(),
+			session: {
+				sessionId: "sess-ts",
+				sessionManager: {
+					getEntries: () => entries,
+					getHeader: () => ({
+						type: "session",
+						id: "sess-ts",
+						timestamp: SESSION_START,
+						cwd: "/tmp",
+					}),
+				},
+				getHindsightSessionState: () => state,
+			} as object as AgentSession,
+			banksSet: new Set(["personal"]),
+		});
+
+		const first = extractMessages({ getEntries: () => entries });
+		await state.retainSession(first);
+		const laterEntries = [
+			...entries,
+			{
+				type: "message",
+				id: "u2",
+				parentId: "a1",
+				timestamp: "2026-08-21T15:00:00.000Z",
+				message: {
+					role: "user",
+					content: "same conversation, later thursday turn",
+					timestamp: Date.parse("2026-08-21T15:00:00.000Z"),
+				},
+			} as SessionEntry,
+		];
+		await state.retainSession(extractMessages({ getEntries: () => laterEntries }));
+
+		expect(bodies).toHaveLength(2);
+		expect(firstItem(bodies[0]).timestamp).toBe(SESSION_START);
+		expect(firstItem(bodies[1]).timestamp).toBe(SESSION_START);
+		expect(String(firstItem(bodies[0]).content)).toContain("[timestamp: 2026-08-17T10:00:00.000Z]");
+		expect(String(firstItem(bodies[0]).content)).toContain("[timestamp: 2026-08-17T10:00:05.000Z]");
+		expect(String(firstItem(bodies[1]).content)).toContain("same conversation, later thursday turn");
+		expect(String(firstItem(bodies[1]).content)).not.toContain("internal monologue");
+		expect(String(firstItem(bodies[1]).content)).not.toContain("secret tool output");
+		expect(String(firstItem(bodies[1]).content)).not.toContain("<memories>");
+	});
+});

--- a/packages/coding-agent/test/hindsight-retention-cache.test.ts
+++ b/packages/coding-agent/test/hindsight-retention-cache.test.ts
@@ -305,4 +305,41 @@ describe("Hindsight incremental full-session retention cache", () => {
 		expect(client.calls.length).toBe(1);
 		expect(client.calls[0].transcript).toBe(expected);
 	});
+
+	it("rebuilds when only a retained prefix timestamp changes", async () => {
+		const client = new FakeHindsightApi();
+		const config = makeConfig({ retainMode: "full-session" });
+		const session = {
+			sessionId: "test-session",
+		} as object as AgentSession;
+		const banksSet = new Set<string>();
+
+		const state = new HindsightSessionState({
+			sessionId: "test-session",
+			client,
+			bankId: "test-bank",
+			config,
+			session,
+			banksSet,
+		});
+
+		const messages1: HindsightMessage[] = [
+			{ role: "user", content: "hello first turn", timestamp: "2026-08-17T10:00:00.000Z" },
+			{ role: "assistant", content: "hi there first response", timestamp: "2026-08-17T10:00:05.000Z" },
+		];
+		await state.retainSession(messages1);
+		expect(client.calls[0].transcript).toContain("[timestamp: 2026-08-17T10:00:00.000Z]");
+
+		client.calls = [];
+		const messages2: HindsightMessage[] = [
+			{ role: "user", content: "hello first turn", timestamp: "2026-08-17T09:00:00.000Z" },
+			{ role: "assistant", content: "hi there first response", timestamp: "2026-08-17T10:00:05.000Z" },
+			{ role: "user", content: "hello second turn", timestamp: "2026-08-17T11:00:00.000Z" },
+		];
+		await state.retainSession(messages2);
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toContain("[timestamp: 2026-08-17T09:00:00.000Z]");
+		expect(client.calls[0].transcript).not.toContain("[timestamp: 2026-08-17T10:00:00.000Z]");
+		expect(client.calls[0].transcript).toContain("hello second turn");
+	});
 });


### PR DESCRIPTION
## What

Preserve source conversation timestamps when retaining to Hindsight.

- Item timestamp is the session start (`SessionHeader.timestamp`), falling back to retain-time only if the header has no timestamp. Re-retaining the same session does not move the item timestamp forward.
- Each surviving user/assistant `SessionEntry.timestamp` is serialized into the transcript as `[timestamp: …]` under the existing `[role: …]` framing.
- Thinking blocks, tool results, and recalled `<memories>` content are still excluded.

## Why

Hindsight extraction is temporally sensitive, but retain currently stamps items with retain-time and drops `SessionEntry` timestamps, so later retains of the same conversation look like they happened "now".

Related independent Hindsight PRs (same series, **not stacked**; this PR can be reviewed and merged on its own):

- https://github.com/can1357/oh-my-pi/pull/9365 (retain strategy)
- https://github.com/can1357/oh-my-pi/pull/9367 (append-mode retention)

If a sibling lands first and touches the same changelog/state files, a trivial rebase is enough. Do not treat them as a merge-order chain.

## Testing

- `bun test` on `hindsight-conversation-timestamps`, `hindsight-content`, `hindsight-retention-cache`, `hindsight-backend`, `hindsight-client` — pass
- `bun --cwd=packages/coding-agent run check` — pass

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)