### PR TITLE
feat(agent): configurable Anthropic server-side fallback chain

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1907,6 +1907,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"providers.anthropic.serverSideFallbackModels": {
+		type: "array",
+		default: ["claude-opus-4-8"] as string[],
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Anthropic Server-Side Fallback Chain",
+			description:
+				'Ordered bare Anthropic model ids forwarded as the server-side `fallbacks` chain when Anthropic Server-Side Fallback is enabled, e.g. ["claude-opus-5", "claude-opus-4-8"]. These are API model ids, not provider/model selectors. An empty list sends no fallbacks even when the toggle is on; the API accepts at most three entries, so longer chains use the first three.',
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Interaction
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -13,7 +13,11 @@
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
 import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
 import { isAnthropicFableOrMythosModel } from "@oh-my-pi/pi-catalog/identity";
+import { logger } from "@oh-my-pi/pi-utils";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
+
+/** Anthropic `MessageCreateParams.fallbacks` accepts at most three entries. */
+const ANTHROPIC_MAX_FALLBACK_MODELS = 3;
 
 function timeoutSecondsToMs(value: number): number | undefined {
 	if (!Number.isFinite(value) || value < 0) return undefined;
@@ -51,16 +55,43 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const streamIdleTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamIdleTimeoutSeconds"));
 		// Server-side fallback (opt-in): when the user enables it AND the
 		// resolved model is a Claude Fable/Mythos on Anthropic's messages
-		// API, inject the `fallbacks: [{ model: "claude-opus-4-8" }]` chain.
+		// API, inject the `providers.anthropic.serverSideFallbackModels`
+		// chain (default `[{ model: "claude-opus-4-8" }]`) as `fallbacks`.
 		// The provider layer picks it up, sends the beta header, and honors
-		// the response signals. Every other model / API is untouched.
+		// the response signals. Every other model / API is untouched, and an
+		// empty configured chain sends nothing even with the toggle on.
 		const serverSideFallbackEnabled =
 			settings.get("providers.anthropic.serverSideFallback") &&
 			model.api === "anthropic-messages" &&
 			model.provider === "anthropic" &&
 			isAnthropicFableOrMythosModel(model.id);
+		// The wire contract allows at most three fallback entries
+		// (MessageCreateParams.fallbacks); an overlong chain would be rejected
+		// by the API instead of falling back, so cap deliberately and loudly.
+		// Non-string elements can arrive via YAML/CLI config (the generic array
+		// parser doesn't validate element types); drop them instead of throwing.
+		// Hand-edited YAML can supply a scalar/object where the schema expects an
+		// array; Settings.get returns the raw configured value, so guard the shape
+		// before filtering (non-arrays behave like an empty chain).
+		const rawFallbackModels = serverSideFallbackEnabled
+			? settings.get("providers.anthropic.serverSideFallbackModels")
+			: [];
+		const configuredFallbackModels = Array.isArray(rawFallbackModels)
+			? rawFallbackModels
+					.filter((id): id is string => typeof id === "string")
+					.map(id => id.trim())
+					.filter(id => id.length > 0)
+			: [];
+		if (configuredFallbackModels.length > ANTHROPIC_MAX_FALLBACK_MODELS) {
+			logger.warn("providers.anthropic.serverSideFallbackModels exceeds the wire limit; using the first three", {
+				configured: configuredFallbackModels.length,
+				limit: ANTHROPIC_MAX_FALLBACK_MODELS,
+			});
+		}
+		const serverSideFallbackModels = configuredFallbackModels.slice(0, ANTHROPIC_MAX_FALLBACK_MODELS);
 		const fallbacks =
-			streamOptions?.fallbacks ?? (serverSideFallbackEnabled ? [{ model: "claude-opus-4-8" }] : undefined);
+			streamOptions?.fallbacks ??
+			(serverSideFallbackModels.length > 0 ? serverSideFallbackModels.map(id => ({ model: id })) : undefined);
 		const merged: SimpleStreamOptions = {
 			...streamOptions,
 			openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -245,5 +245,83 @@ describe("createSettingsAwareStreamFn", () => {
 
 			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-sonnet-5" }]);
 		});
+
+		it("forwards a configured multi-model chain in order", () => {
+			const settings = Settings.isolated({
+				"providers.anthropic.serverSideFallback": true,
+				"providers.anthropic.serverSideFallbackModels": ["claude-opus-5", "claude-opus-4-8"],
+			});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-opus-5" }, { model: "claude-opus-4-8" }]);
+		});
+
+		it("drops non-string chain entries instead of throwing (YAML/CLI can inject them)", () => {
+			const settings = Settings.isolated({
+				"providers.anthropic.serverSideFallback": true,
+				"providers.anthropic.serverSideFallbackModels": [1, "claude-opus-5", null, "  "] as unknown as string[],
+			});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-opus-5" }]);
+		});
+
+		it("trims whitespace from configured chain entries before forwarding", () => {
+			const settings = Settings.isolated({
+				"providers.anthropic.serverSideFallback": true,
+				"providers.anthropic.serverSideFallbackModels": [" claude-opus-5 ", "\tclaude-opus-4-8\n"],
+			});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-opus-5" }, { model: "claude-opus-4-8" }]);
+		});
+
+		it("treats a non-array configured value as an empty chain instead of throwing", () => {
+			const settings = Settings.isolated({
+				"providers.anthropic.serverSideFallback": true,
+				"providers.anthropic.serverSideFallbackModels": "claude-opus-5" as unknown as string[],
+			});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toBeUndefined();
+		});
+
+		it("caps the forwarded chain at the wire limit of three entries", () => {
+			const settings = Settings.isolated({
+				"providers.anthropic.serverSideFallback": true,
+				"providers.anthropic.serverSideFallbackModels": ["m1", "m2", "m3", "m4", "m5"],
+			});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "m1" }, { model: "m2" }, { model: "m3" }]);
+		});
+
+		it("sends no fallbacks when the configured chain is empty, even with the toggle on", () => {
+			const settings = Settings.isolated({
+				"providers.anthropic.serverSideFallback": true,
+				"providers.anthropic.serverSideFallbackModels": [],
+			});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
## What

Adds `providers.anthropic.serverSideFallbackModels`: an ordered list of bare Anthropic model ids forwarded as the server-side `fallbacks` chain when `providers.anthropic.serverSideFallback` is enabled. Default stays `["claude-opus-4-8"]`, so behavior is unchanged unless configured. An empty list sends no fallbacks even with the toggle on; caller-supplied `streamOptions.fallbacks` still wins. The forwarded chain is capped at Anthropic's three-entry wire limit, non-string and blank entries are dropped, whitespace is trimmed, and a non-array configured value behaves as an empty chain instead of throwing.

## Why

The server-side fallback beta plumbing (#4182, `server-side-fallback-2026-06-01`) hardcodes the single-hop Opus 4.8 chain in `settings-stream-fn.ts`. Users running Fable want to express e.g. `fable-5 -> opus-5 -> opus-4-8` without forking. This makes the chain a plain setting while keeping the opt-in toggle as the gate.

## Testing

`env -u CLAUDE_CONFIG_DIR bun test test/settings-stream-fn.test.ts` (20 pass — cap-at-three, non-string-element, whitespace-trim, non-array-guard, multi-model-order and empty-list contract tests included), `env -u RUSTUP_TOOLCHAIN bun run check` clean (an inherited `RUSTUP_TOOLCHAIN` on this machine points the Rust formatter at the wrong toolchain and produces unrelated diffs in vendored code; clearing it is required for `check:rs` to run under the toolchain this repo pins).

Exercised the setting on the built CLI (`bun packages/coding-agent/src/cli.ts config ...`) rather than only through unit tests: `config get providers.anthropic.serverSideFallbackModels` returns the default `["claude-opus-4-8"]`; `config set providers.anthropic.serverSideFallbackModels '["claude-opus-5","claude-opus-4-8"]'` persists and reads back the configured chain; `config set ... '[]'` persists and reads back an empty chain; `config set ... '"claude-opus-4-8"'` (a bare string, not an array) is rejected at the config layer with `Invalid array JSON`; `config reset` restores the default.

---

- [x] `env -u RUSTUP_TOOLCHAIN bun run check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
