### PR TITLE
fix(coding-agent): apply extension env to user shells

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Applied registered extension shell environments to interactive `!` commands.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -598,6 +598,16 @@ export interface ToolSessionEvent {
 	previousSessionFile: string | undefined;
 }
 
+/** Shell invocation details supplied to a registered tool's environment hook. */
+export interface ToolShellEnvironmentContext {
+	command: string;
+	cwd: string;
+	env: Record<string, string | undefined>;
+}
+
+/** Supplies environment values for a user-initiated shell invocation. */
+export type ToolShellEnvironmentHook = (context: ToolShellEnvironmentContext) => Record<string, string> | undefined;
+
 /**
  * Tool definition for registerTool().
  */
@@ -629,6 +639,8 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/** Optional environment hook applied when the interactive user shell invokes this tool's shell surface. */
+	shellEnv?: ToolShellEnvironmentHook;
 	/** Execute the tool. */
 	execute(
 		toolCallId: string,

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -71,6 +71,7 @@ import type {
 	ReadToolResultEvent,
 	ToolDefinition,
 	ToolResultEvent,
+	ToolShellEnvironmentContext,
 	WriteToolResultEvent,
 } from "./extensions/types";
 import { Type } from "./legacy-typebox";
@@ -94,11 +95,7 @@ interface LegacyThemeLike {
 	bold(text: string): string;
 }
 
-export interface BashSpawnContext {
-	command: string;
-	cwd: string;
-	env: NodeJS.ProcessEnv;
-}
+export type BashSpawnContext = ToolShellEnvironmentContext;
 
 export type BashSpawnHook = (context: BashSpawnContext) => BashSpawnContext;
 
@@ -488,12 +485,30 @@ export function createReadTool(cwd: string, options?: ReadToolOptions): ToolDefi
 /** Create the legacy bash tool definition. */
 export function createBashToolDefinition(cwd: string, options?: BashToolOptions): ToolDefinition {
 	const tool = createRegistryTool(cwd, "bash");
+	const spawnHook = options?.spawnHook;
+	const shellEnv = spawnHook
+		? (spawn: ToolShellEnvironmentContext): Record<string, string> => {
+				const result = spawnHook(spawn);
+				// Legacy hooks conventionally return `{ ...context.env, EXTRA }`.
+				// The consumer applies this as per-command overrides on an already
+				// filtered base env, so forwarding the whole object would reintroduce
+				// everything filterChildShellEnv removed. Forward only entries the
+				// hook added or changed relative to the env it was handed.
+				const baseline = spawn.env;
+				return Object.fromEntries(
+					Object.entries(result.env).filter(
+						(entry): entry is [string, string] => typeof entry[1] === "string" && baseline[entry[0]] !== entry[1],
+					),
+				);
+			}
+		: undefined;
 	return markToolDefinition({
 		name: "bash",
 		label: "Bash",
 		description: tool.description,
 		parameters: legacyBashSchema,
 		approval: "exec",
+		...(shellEnv ? { shellEnv } : {}),
 		renderCall: (params, optionsArg, themeArg) => {
 			const theme = renderTheme(optionsArg, themeArg);
 			const command = stringField(params, "command") ?? "";

--- a/packages/coding-agent/src/session/bash-runner.ts
+++ b/packages/coding-agent/src/session/bash-runner.ts
@@ -91,6 +91,11 @@ export class BashRunner {
 				}
 			}
 
+			const shellEnv =
+				options?.useUserShell === true
+					? extensionRunner?.getRegisteredTool("bash")?.definition.shellEnv?.({ command, cwd, env: process.env })
+					: undefined;
+
 			const abortController = new AbortController();
 			this.#abortControllers.add(abortController);
 			let result: BashResult;
@@ -102,6 +107,7 @@ export class BashRunner {
 					cwd,
 					timeout: clampTimeout("bash", undefined, this.#host.settings.get("tools.maxTimeout")) * 1000,
 					onMinimizedSave: originalText => this.#saveOriginalArtifact(target, originalText),
+					env: shellEnv,
 					useUserShell: options?.useUserShell,
 				});
 			} finally {

--- a/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
+++ b/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
@@ -8,6 +8,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as bashExecutor from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { createBashTool } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -111,6 +112,54 @@ describe("AgentSession bash session ownership", () => {
 		await session.waitForIdle();
 
 		expect(session.messages.some(message => message.role === "bashExecution")).toBe(false);
+	});
+
+	it("applies the registered bash shell environment to user-shell commands", async () => {
+		const spawnHook = vi.fn(spawn => ({
+			...spawn,
+			env: { ...spawn.env, OMP_USER_SHELL_ENV: "extension-value" },
+		}));
+		const definition = createBashTool(tempDir.path(), { spawnHook });
+		const extensionRunner = {
+			hasHandlers: vi.fn(() => false),
+			getRegisteredTool: vi.fn((name: string) => (name === "bash" ? { definition } : undefined)),
+			emit: vi.fn().mockResolvedValue(undefined),
+			emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+		} as unknown as ExtensionRunner;
+		createSession(undefined, extensionRunner);
+
+		const result = await session.executeBash('printf "%s" "$OMP_USER_SHELL_ENV"', undefined, {
+			useUserShell: true,
+		});
+
+		expect(result.output).toBe("extension-value");
+		expect(spawnHook).toHaveBeenCalledWith(
+			expect.objectContaining({
+				command: 'printf "%s" "$OMP_USER_SHELL_ENV"',
+				cwd: tempDir.path(),
+			}),
+		);
+	});
+
+	it("does not run the shell environment hook when a user_bash handler replaces the result", async () => {
+		const spawnHook = vi.fn(() => {
+			throw new Error("shell env hook must not run when user_bash supplies a replacement result");
+		});
+		const definition = createBashTool(tempDir.path(), { spawnHook });
+		const emitUserBash = vi.fn().mockResolvedValue({ result: bashResult });
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "user_bash"),
+			emitUserBash,
+			getRegisteredTool: vi.fn((name: string) => (name === "bash" ? { definition } : undefined)),
+			emit: vi.fn().mockResolvedValue(undefined),
+			emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+		} as unknown as ExtensionRunner;
+		createSession(undefined, extensionRunner);
+
+		const result = await session.executeBash("replaced-command", undefined, { useUserShell: true });
+
+		expect(result).toEqual(bashResult);
+		expect(spawnHook).not.toHaveBeenCalled();
 	});
 
 	it("keeps a queued bash result on the branch discarded by an empty stop", async () => {
@@ -384,5 +433,19 @@ describe("AgentSession bash session ownership", () => {
 		expect(
 			session.messages.some(message => message.role === "bashExecution" && message.command === "old-branch-command"),
 		).toBe(false);
+	});
+});
+
+describe("legacy spawnHook shellEnv adapter", () => {
+	it("forwards only the hook's added or changed variables, not the spread baseline", () => {
+		const definition = createBashTool(process.cwd(), {
+			spawnHook: context => ({ ...context, env: { ...context.env, EXTRA: "1", CHANGED: "new" } }),
+		});
+		const result = definition.shellEnv?.({
+			command: "true",
+			cwd: process.cwd(),
+			env: { KEPT: "kept", CHANGED: "old" },
+		});
+		expect(result).toEqual({ EXTRA: "1", CHANGED: "new" });
 	});
 });


### PR DESCRIPTION
## What

Interactive `!` user shells now receive registered extension shell environments, matching what the `bash` tool's shells already get.

## Why

Extensions can register shell env (auth wrappers, PATH shims). The agent's own bash sessions honored it but a user dropping to `!` got a bare environment — commands that work for the agent fail for the user in the same session.

## Testing

`env -u CLAUDE_CONFIG_DIR bun test test/agent-session-bash-session-ownership.test.ts` (10 pass; regression test fails without the fix), `bun check` clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
