### PR TITLE
fix(tui): resume preserve-mode unresolved width epochs from a structurally-proven committed boundary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `tui.resizeScrollback: preserve` re-emitting committed transcript rows when a tmux width epoch settled without a resolvable source boundary; recovery now resumes from the deepest transcript block structurally proven stable (identity, finalization, and version), never replaying already-committed rows into scrollback even when nothing can be proven at all, while Ctrl+O keeps its explicit full replay.
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -342,6 +342,75 @@ export class TranscriptContainer
 		return rows;
 	}
 
+	/**
+	 * Structural resume boundary for a preserve-mode replay that settled with
+	 * no logical source boundary. `committedRows` is the old-width committed
+	 * count in this container's own local coordinate space; the walk proves
+	 * stability the same way {@link resolveNativeScrollbackWidthEpoch} does
+	 * (component identity plus finalized + version match), but — unlike that
+	 * method — stops and returns the last proven boundary instead of failing
+	 * outright the moment one segment cannot be proven: a mutable/reflowed
+	 * block duplicates only itself and everything below it, never loses rows
+	 * above it. The still-live source segment is the only one that may
+	 * delegate into a nested resolver when the boundary lands inside it.
+	 */
+	resolveNativeScrollbackCommittedRows(boundary: unknown, committedRows: number): number | undefined {
+		if (typeof boundary !== "object" || boundary === null) return undefined;
+		const marker = this.#widthEpochBoundaries.get(boundary);
+		if (!marker) return undefined;
+		const capturedSegments: BlockSegment[] = [
+			...marker.precedingSegments,
+			marker.segment,
+			...marker.trailingSegments,
+		];
+		const sourceCapturedIndex = marker.precedingSegments.length;
+		let mapped = 0;
+		for (let i = 0; i < capturedSegments.length; i++) {
+			const captured = capturedSegments[i]!;
+			if (committedRows <= captured.startRow) return mapped;
+			const current = this.#segments[i];
+			const identityStable = current !== undefined && current.component === captured.component;
+			const fullyCovered = committedRows >= captured.startRow + captured.rowCount;
+			if (!fullyCovered) {
+				// committedRows lands inside this segment's old span. Only the
+				// still-live source segment delegates deeper; a partially
+				// covered leading/trailing segment ends the walk here.
+				if (
+					i === sourceCapturedIndex &&
+					identityStable &&
+					marker.childHasBoundary &&
+					marker.childBoundary !== undefined
+				) {
+					const child = current!.component as Component & Partial<NativeScrollbackWidthEpoch>;
+					if (typeof child.resolveNativeScrollbackCommittedRows === "function") {
+						let leadingTrimmedRows = 0;
+						while (
+							leadingTrimmedRows < captured.rawRef.length &&
+							isPlainBlank(captured.rawRef[leadingTrimmedRows]!)
+						) {
+							leadingTrimmedRows++;
+						}
+						const contributionRows = Math.max(
+							0,
+							Math.min(captured.contribution.length, committedRows - captured.startRow - captured.sep),
+						);
+						const childRows = child.resolveNativeScrollbackCommittedRows(
+							marker.childBoundary,
+							contributionRows + leadingTrimmedRows,
+						);
+						if (childRows !== undefined) mapped = this.#mapNativeScrollbackWidthEpochRows(current!, childRows);
+					}
+				}
+				return mapped;
+			}
+			if (!identityStable || !captured.finalized || !current!.finalized || current!.version !== captured.version) {
+				return mapped;
+			}
+			mapped = current!.startRow + current!.rowCount;
+		}
+		return mapped;
+	}
+
 	#mapNativeScrollbackWidthEpochRows(segment: BlockSegment, rawRows: number): number {
 		let leadingTrimmedRows = 0;
 		while (leadingTrimmedRows < segment.rawRef.length && isPlainBlank(segment.rawRef[leadingTrimmedRows]!)) {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed preserve-mode unresolved width recovery replaying committed rows after tmux client-size changes; it now resumes at the deepest row structurally proven (by component identity and finalization/version stability) to already be on the pane's native scrollback, falling back to the pre-resize committed boundary — never row zero — when nothing can be proven at all.
+
 ## [18.0.0] - 2026-08-22
 
 ### Breaking Changes

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -249,6 +249,18 @@ export interface NativeScrollbackWidthEpoch {
 	isNativeScrollbackWidthEpochAppendOnly?(boundary: unknown): boolean;
 	/** Changes when child structure mutates independently of width reflow. */
 	getNativeScrollbackWidthEpochRevision?(): number;
+	/**
+	 * Structural alternative to a textual/content scan for resuming a
+	 * `preserve`-mode replay without re-emitting native-scrollback history.
+	 * `committedRows` is the old-width committed-row count (this component's
+	 * own local coordinate space); the return value is the deepest
+	 * current-width row structurally proven — by component identity plus
+	 * finalization/version stability, never by row-count comparison alone —
+	 * to correspond to rows already committed to the tape at the old width.
+	 * Returns undefined when no boundary can be proven safe; callers must
+	 * treat that as "resume from 0" (duplication, never loss).
+	 */
+	resolveNativeScrollbackCommittedRows?(boundary: unknown, committedRows: number): number | undefined;
 }
 
 /**
@@ -1658,6 +1670,75 @@ export class TUI extends Container {
 			rows += candidate.rowCount;
 		}
 		return rows;
+	}
+
+	/**
+	 * Structural resume boundary for a preserve-mode replay that settled
+	 * unresolved (no logical source boundary at all). Unlike
+	 * {@link resolveNativeScrollbackWidthEpoch}, which requires every leading
+	 * segment to be provably stable before returning anything, this walks
+	 * leading segments only as far as they stay provably stable and returns
+	 * the deepest point reached — a leading segment that cannot be proven
+	 * stable, or that only partially absorbs `committedRows`, ends the walk
+	 * without invalidating the segments already proven. Duplicating rows
+	 * from an unproven point on is the accepted tradeoff; losing rows is not.
+	 *
+	 * Returning `mapped` (possibly `0`) from every early exit above is
+	 * intentional: a component that was CONSULTED and affirmatively could
+	 * not vouch for its own content (grew, changed, or lost identity) must
+	 * cause a real re-emit of the disputed range — the caller cannot tell
+	 * "proven 0" apart from "consulted and refused" here, and conflating
+	 * them into a seam-trusting skip would silently strand a genuine content
+	 * correction below the seam forever (it would never re-render into
+	 * scrollback). `undefined` is reserved for the one case with no opinion
+	 * to consult at all: no leading segment contributed anything AND the
+	 * segment's own component doesn't even implement this resolver — there
+	 * nothing was consulted, so nothing was disproven either, and the caller
+	 * may fall back to the frame-local committed seam instead of row zero.
+	 */
+	resolveNativeScrollbackCommittedRows(boundary: unknown, committedRows: number): number | undefined {
+		if (typeof boundary !== "object" || boundary === null) return undefined;
+		const marker = this.#rootWidthEpochBoundaries.get(boundary);
+		if (!marker) return undefined;
+		const segment = this.#frameSegments[marker.sourceIndex];
+		if (segment?.component !== marker.component) return undefined;
+		let oldRowsConsumed = 0;
+		let mapped = 0;
+		for (let index = 0; index < marker.leading.length; index++) {
+			if (committedRows <= oldRowsConsumed) return mapped;
+			const captured = marker.leading[index]!;
+			const current = this.#frameSegments[index];
+			const fullyCovered = committedRows >= oldRowsConsumed + captured.rowCount;
+			// A revisionless component reports no width-independent mutation
+			// signal, and its wrapped row count legitimately shrinks or grows
+			// on rewrap alone — an exact match would misclassify a merely
+			// reflowed segment as unstable (rewrapping this same content at a
+			// different width never keeps an identical row count in general).
+			// A row-count INCREASE cannot come from rewrapping alone shedding
+			// rows it never needed; it only means new content was appended
+			// during the settle window. Refuse to fold that growth into the
+			// proven boundary — a same-or-shrunk row count is the accepted
+			// proof of no growth; a component reporting a revision proves
+			// stability exactly, growth or not.
+			const stable =
+				current?.component === captured.component &&
+				(captured.revision === undefined
+					? current.rowCount <= captured.rowCount
+					: current.widthEpochRevision === captured.revision);
+			if (!fullyCovered || !stable) return mapped;
+			oldRowsConsumed += captured.rowCount;
+			mapped = current!.start + current!.rowCount;
+		}
+		if (committedRows <= oldRowsConsumed) return mapped;
+		const childSource = getNativeScrollbackWidthEpoch(marker.component);
+		if (typeof childSource?.resolveNativeScrollbackCommittedRows !== "function") {
+			return mapped === 0 ? undefined : mapped;
+		}
+		const childResolved = childSource.resolveNativeScrollbackCommittedRows(
+			marker.childBoundary,
+			committedRows - oldRowsConsumed,
+		);
+		return childResolved === undefined ? mapped : segment.start + childResolved;
 	}
 
 	#getNativeScrollbackWidthEpochCurrentRows(boundary: unknown): number | undefined {
@@ -3871,6 +3952,7 @@ export class TUI extends Container {
 				break;
 			}
 		}
+		const preservesScrollback = this.#resizeScrollbackMode === "preserve";
 		// Without a logical source boundary, pending growth folded into an
 		// overlay-covered width reset cannot be separated from reflow. Replay
 		// conservatively from row zero after the overlay closes: duplication is
@@ -3896,7 +3978,52 @@ export class TUI extends Container {
 				resizeHadPendingRender &&
 				widthEpochBoundary !== undefined &&
 				widthEpochSourceBoundary === undefined);
-		if (replayUnresolvedWidthEpoch) prevWindowTop = 0;
+		// Structural resume boundary: map the old-width committed-row count
+		// through the captured width-epoch marker into a current-width row
+		// structurally proven (component identity plus finalization/version
+		// stability) to already correspond to native history on the tape.
+		// `committedRows` must be in the SAME frame-local coordinate space the
+		// marker's captured segments were measured in. `#committedRows` is
+		// only that once no width epoch has ever settled; once a baseline
+		// exists it degrades to the opaque native-tape row count (see the
+		// `componentCommittedRows` comment in render()), which the resolver
+		// walk would misread as an old-frame row count on a second, later
+		// epoch (e.g. an oscillating resize) — proving rows structurally
+		// unreachable and losing them. `placementEpochWatermark`, captured
+		// above before this epoch's classification runs, is exactly that
+		// frame-local seam in both cases.
+		//
+		// Preserve's zero-growth contract: committed rows are NEVER
+		// re-emitted into native scrollback on ANY settled width epoch,
+		// resolved or unresolved. The resolver's only job is to let a
+		// provably stable prefix strictly below the seam refresh when it can
+		// prove one (a resolved boundary K < seam re-emits [K, seam) —
+		// content whose current-width form isn't yet proven — which is safe
+		// because it never re-emits past the seam); it never widens what
+		// counts as "already committed". So an undefined result (no
+		// component implements the resolver, or nothing past row zero could
+		// be proven) must fall back to the seam itself, not row zero —
+		// row zero would replay the entire committed transcript. Non-preserve
+		// modes keep the row-zero fallback below; only preserve carries this
+		// contract. Falling back to the seam means growth that accrued ABOVE
+		// it during the unresolved epoch, but that this frame's rewrap can't
+		// attribute to a proven boundary, stays viewport-only until it
+		// scrolls off or a later resolved epoch commits it: native
+		// scrollback may consequently miss unattributable growth, but never
+		// re-receives a row it already holds. That is the accepted preserve
+		// tradeoff — zero growth beats scrollback completeness — and Ctrl+O's
+		// explicit full copy remains the escape hatch. The fallback is
+		// clamped to `frameLength` because the seam was measured before this
+		// frame's rewrap and could exceed the rewrapped row count.
+		let unresolvedWidthEpochResume = 0;
+		if (replayUnresolvedWidthEpoch) {
+			if (preservesScrollback) {
+				const seamFallback = Math.max(0, Math.min(placementEpochWatermark, frameLength));
+				unresolvedWidthEpochResume =
+					this.resolveNativeScrollbackCommittedRows(widthEpochBoundary, placementEpochWatermark) ?? seamFallback;
+			}
+			prevWindowTop = preservesScrollback ? unresolvedWidthEpochResume : 0;
+		}
 
 		// 4. Classify. A resize is an explicit user gesture: normally the engine
 		// erases and replays so history rewraps at the new geometry (the reader
@@ -4193,9 +4320,16 @@ export class TUI extends Container {
 			let commitFrom: number;
 			let commitTo: number;
 			if (replayUnresolvedWidthEpoch) {
-				commitFrom = 0;
+				// Merge of upstream's commitCeiling clamp (native-scrollback pinned
+				// boundary) with preserve-mode's committed-boundary resume: never
+				// re-emit rows the pane already holds, and never commit past the
+				// pinned ceiling. `unresolvedWidthEpochResume` already carries the
+				// seam fallback (see above) when the resolver proved nothing, so
+				// an unresolved epoch commits at most [seam, windowTop) — pending
+				// growth only, never the committed prefix below the seam.
+				commitFrom = preservesScrollback ? Math.min(unresolvedWidthEpochResume, windowTop) : 0;
 				commitTo = Math.min(windowTop, commitCeiling);
-				scrollRows = commitTo;
+				scrollRows = Math.max(0, commitTo - commitFrom);
 			} else if (logicalAppend && !logicalPrefixAppend) {
 				const sourceWindowTop = Math.max(0, widthEpochSourceBoundary - height);
 				const logicalSuffixRows = Math.max(0, widthEpochCurrentRows - widthEpochSourceBoundary);

--- a/packages/tui/test/issue-2088-repro.test.ts
+++ b/packages/tui/test/issue-2088-repro.test.ts
@@ -72,6 +72,13 @@ class RevisionMutableLinesComponent implements Component {
 	}
 }
 
+// Rows a single line occupies when wrapped at `width` — matches the
+// `WrappingLinesComponent.render` loop's segment count exactly (zero for an
+// empty line, since that loop never executes for it).
+function wrappedRowCount(line: string, width: number): number {
+	return line.length === 0 ? 0 : Math.ceil(line.length / width);
+}
+
 class WrappingLinesComponent implements Component {
 	#lines: string[];
 
@@ -81,6 +88,10 @@ class WrappingLinesComponent implements Component {
 
 	setLines(lines: string[]): void {
 		this.#lines = [...lines];
+	}
+
+	linesSnapshot(): readonly string[] {
+		return this.#lines;
 	}
 
 	invalidate(): void {}
@@ -122,7 +133,67 @@ class RecoveringWrappingLinesComponent extends WrappingLinesComponent implements
 	}
 }
 
+// Simulates a leaf component with no logical live/settled distinction at all
+// (`resolveNativeScrollbackWidthEpoch` always fails — genuinely unresolved),
+// but one that can still structurally prove which of its OWN lines are
+// unchanged since the width epoch was captured: pure content identity on a
+// stable leading run, independent of the live/settled question the width
+// epoch itself cannot answer.
 class UnresolvedWrappingLinesComponent extends WrappingLinesComponent implements NativeScrollbackWidthEpoch {
+	#lastRenderedWidth = 0;
+	#captured: { lines: readonly string[]; width: number } | undefined;
+
+	override render(width: number): string[] {
+		this.#lastRenderedWidth = width;
+		return super.render(width);
+	}
+
+	captureNativeScrollbackWidthEpoch(): unknown {
+		this.#captured = { lines: this.linesSnapshot(), width: this.#lastRenderedWidth };
+		return {};
+	}
+
+	resolveNativeScrollbackWidthEpoch(): undefined {
+		return undefined;
+	}
+
+	getNativeScrollbackWidthEpochRows(): undefined {
+		return undefined;
+	}
+
+	resolveNativeScrollbackCommittedRows(_boundary: unknown, committedRows: number): number | undefined {
+		const captured = this.#captured;
+		if (!captured) return undefined;
+		const current = this.linesSnapshot();
+		let stableLines = 0;
+		while (
+			stableLines < captured.lines.length &&
+			stableLines < current.length &&
+			captured.lines[stableLines] === current[stableLines]
+		) {
+			stableLines++;
+		}
+		let oldRows = 0;
+		let coveredLines = 0;
+		for (let i = 0; i < stableLines; i++) {
+			const lineRows = wrappedRowCount(captured.lines[i]!, captured.width);
+			if (oldRows + lineRows > committedRows) break;
+			oldRows += lineRows;
+			coveredLines++;
+		}
+		if (coveredLines === 0) return undefined;
+		let newRows = 0;
+		for (let i = 0; i < coveredLines; i++) newRows += wrappedRowCount(captured.lines[i]!, this.#lastRenderedWidth);
+		return newRows;
+	}
+}
+
+// Same "genuinely unresolved" shape as `UnresolvedWrappingLinesComponent`,
+// but with no `resolveNativeScrollbackCommittedRows` at all — simulates a
+// component nobody has instrumented for structural committed-row proof, so
+// the resolver has no opinion to offer and preserve mode resumes at the
+// frame-local committed seam instead of row zero.
+class OpaqueUnresolvedComponent extends WrappingLinesComponent implements NativeScrollbackWidthEpoch {
 	captureNativeScrollbackWidthEpoch(): unknown {
 		return {};
 	}
@@ -2044,6 +2115,353 @@ describe("issue #2088: tmux pane-resize race produces viewport flash", () => {
 				}
 			} finally {
 				tui.stop();
+			}
+		});
+	});
+
+	it("does not re-emit committed rows for unresolved pending width epochs in preserve mode", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			const initial = Array.from(
+				{ length: 12 },
+				(_value, index) => `preserve-${index.toString().padStart(2, "0")} ${"I".repeat(20)}`,
+			);
+			const appended = Array.from(
+				{ length: 8 },
+				(_value, index) => `preserve-new-${index.toString().padStart(2, "0")}`,
+			);
+			const term = new VirtualTerminal(17, 6, 10_000);
+			const component = new UnresolvedWrappingLinesComponent(initial);
+			const tui = new TUI(term);
+			tui.setResizeScrollback("preserve");
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const historyBeforeResize = term.getScrollBuffer().map(line => line.trimEnd());
+				const committedMarker = "preserve-00";
+				const committedOccurrencesBeforeResize = historyBeforeResize.filter(line =>
+					line.includes(committedMarker),
+				).length;
+				expect(committedOccurrencesBeforeResize).toBeGreaterThan(0);
+
+				term.resize(40, 4);
+				component.setLines([...initial, ...appended]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				const historyAfterResize = term.getScrollBuffer().map(line => line.trimEnd());
+				expect(historyAfterResize.filter(line => line.includes(committedMarker))).toHaveLength(
+					committedOccurrencesBeforeResize,
+				);
+				expect(visible(term)).toEqual(appended.slice(-4));
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("resumes at the committed seam instead of row zero when nothing structurally proves a boundary", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			const initial = Array.from(
+				{ length: 12 },
+				(_value, index) => `opaque-${index.toString().padStart(2, "0")} ${"I".repeat(20)}`,
+			);
+			const appended = Array.from(
+				{ length: 8 },
+				(_value, index) => `opaque-new-${index.toString().padStart(2, "0")}`,
+			);
+			const term = new VirtualTerminal(17, 6, 10_000);
+			const component = new OpaqueUnresolvedComponent(initial);
+			const tui = new TUI(term);
+			tui.setResizeScrollback("preserve");
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const historyBeforeResize = term.getScrollBuffer().map(line => line.trimEnd());
+				const committedMarker = "opaque-00";
+				const committedOccurrencesBeforeResize = historyBeforeResize.filter(line =>
+					line.includes(committedMarker),
+				).length;
+				expect(committedOccurrencesBeforeResize).toBeGreaterThan(0);
+
+				const writes = captureWrites(term);
+				term.resize(40, 4);
+				component.setLines([...initial, ...appended]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				// No component in the chain implements the structural resolver, so
+				// the root resolver call returns undefined (no leading segment
+				// contributed anything, and the sole segment offers no opinion at
+				// all). Preserve's zero-growth contract now resumes at the
+				// frame-local committed seam instead of row zero: the bytes written
+				// during the settle never contain the already-committed marker —
+				// it is neither duplicated nor lost, simply never re-emitted.
+				const writtenBytes = writes.join("");
+				expect(writtenBytes.includes(committedMarker)).toBe(false);
+				const historyAfterResize = term.getScrollBuffer().map(line => line.trimEnd());
+				expect(historyAfterResize.filter(line => line.includes(committedMarker))).toHaveLength(
+					committedOccurrencesBeforeResize,
+				);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("bounds emission by pending growth plus viewport, never the whole transcript, when the resolver is undefined", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			// A transcript far taller than the viewport: a full-transcript replay
+			// (the pre-fix row-zero fallback) would write every one of these 100
+			// lines into scrollback again on top of what is already there.
+			const initial = Array.from(
+				{ length: 100 },
+				(_value, index) => `bulk-${index.toString().padStart(3, "0")} ${"I".repeat(20)}`,
+			);
+			const appended = Array.from({ length: 6 }, (_value, index) => `bulk-new-${index}`);
+			const height = 4;
+			const term = new VirtualTerminal(17, height, 10_000);
+			const component = new OpaqueUnresolvedComponent(initial);
+			const tui = new TUI(term);
+			tui.setResizeScrollback("preserve");
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const historyBeforeResize = term.getScrollBuffer().map(line => line.trimEnd());
+				const scrollbackRowsBeforeResize = historyBeforeResize.length;
+
+				term.resize(40, height);
+				component.setLines([...initial, ...appended]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				// The resolver has nothing to consult (same shape as the seam-resume
+				// test above) and resumes at the committed seam. Native scrollback
+				// growth from this single settled resize is bounded by the pending
+				// growth plus one viewport's worth of rewrap slack — never anywhere
+				// close to the 100-row transcript a row-zero replay would write.
+				const scrollbackRowsAfterResize = term.getScrollBuffer().length;
+				const scrollbackGrowth = scrollbackRowsAfterResize - scrollbackRowsBeforeResize;
+				expect(scrollbackGrowth).toBeLessThan(initial.length);
+				expect(scrollbackGrowth).toBeLessThanOrEqual(appended.length + height * 2);
+
+				// The already-committed prefix is never re-emitted either: bounded
+				// growth and zero re-emission are the same seam-resume mechanism.
+				const historyAfterResize = term.getScrollBuffer().map(line => line.trimEnd());
+				expect(historyAfterResize.filter(line => line.includes("bulk-000"))).toHaveLength(
+					historyBeforeResize.filter(line => line.includes("bulk-000")).length,
+				);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("stops at the last stable leading block when a later one turns mutable, duplicating only that block onward", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			const stableLines = Array.from({ length: 3 }, (_value, index) => `stable-${index} ${"S".repeat(20)}`);
+			const mutableLines = Array.from({ length: 3 }, (_value, index) => `mutable-${index} ${"M".repeat(20)}`);
+			const sourceLines = Array.from(
+				{ length: 6 },
+				(_value, index) => `source-${index.toString().padStart(2, "0")} ${"R".repeat(20)}`,
+			);
+			const appended = Array.from(
+				{ length: 8 },
+				(_value, index) => `source-new-${index.toString().padStart(2, "0")}`,
+			);
+
+			const term = new VirtualTerminal(17, 6, 10_000);
+			const stable = new WrappingLinesComponent(stableLines);
+			const mutable = new RevisionMutableLinesComponent(mutableLines);
+			const source = new UnresolvedWrappingLinesComponent(sourceLines);
+			const tui = new TUI(term);
+			tui.setResizeScrollback("preserve");
+			tui.addChild(stable);
+			tui.addChild(mutable);
+			tui.addChild(source);
+
+			try {
+				tui.start();
+				await settle(term);
+				const historyBeforeResize = term.getScrollBuffer().map(line => line.trimEnd());
+				const stableMarker = "stable-0";
+				const mutableMarker = "mutable-0";
+				const stableOccurrencesBefore = historyBeforeResize.filter(line => line.includes(stableMarker)).length;
+				const mutableOccurrencesBefore = historyBeforeResize.filter(line => line.includes(mutableMarker)).length;
+				expect(stableOccurrencesBefore).toBeGreaterThan(0);
+				expect(mutableOccurrencesBefore).toBeGreaterThan(0);
+
+				term.resize(40, 4);
+				// The mutable leading block changes during the settle window (a
+				// late correction), and the source keeps growing — both feed the
+				// unresolved-pending-render path.
+				mutable.setLines([...mutableLines, "mutable-late"]);
+				source.setLines([...sourceLines, ...appended]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				const historyAfterResize = term.getScrollBuffer().map(line => line.trimEnd());
+				// Stable precedes the mutable block, proven stable end to end:
+				// never duplicated.
+				expect(historyAfterResize.filter(line => line.includes(stableMarker))).toHaveLength(
+					stableOccurrencesBefore,
+				);
+				// The mutable block itself could not be proven stable (its
+				// width-epoch revision moved between capture and resolve): its
+				// already-committed rows are re-emitted rather than lost.
+				expect(historyAfterResize.filter(line => line.includes(mutableMarker)).length).toBeGreaterThan(
+					mutableOccurrencesBefore,
+				);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("retains rows across an oscillating two-epoch resize once the committed boundary goes opaque (roboomp repro)", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			const initial = Array.from(
+				{ length: 12 },
+				(_value, index) => `initial-${index.toString().padStart(2, "0")} ${"I".repeat(20)}`,
+			);
+			const first = Array.from({ length: 8 }, (_value, index) => `first-${index.toString().padStart(2, "0")}`);
+			const second = Array.from({ length: 8 }, (_value, index) => `second-${index.toString().padStart(2, "0")}`);
+			const term = new VirtualTerminal(17, 6, 10_000);
+			const component = new UnresolvedWrappingLinesComponent(initial);
+			const tui = new TUI(term);
+			tui.setResizeScrollback("preserve");
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				// Epoch one: 17 -> 40. `first` is appended during the settle
+				// debounce, so the epoch settles unresolved and resumes through
+				// the structural committed-rows resolver — establishing a
+				// width-epoch baseline that makes `#committedRows` an opaque
+				// native-tape count from here on (see the `componentCommittedRows`
+				// comment in `render()`).
+				term.resize(40, 4);
+				component.setLines([...initial, ...first]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				// Epoch two: 40 -> 17, oscillating back, with `second` appended
+				// the same way. Resolving this epoch against the opaque native
+				// ledger instead of the frame-local committed seam proves rows
+				// that were only ever visible (never committed), sinking
+				// `commitFrom` too deep and dropping the tail of `first`.
+				term.resize(17, 4);
+				component.setLines([...initial, ...first, ...second]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				const scrollback = term.getScrollBuffer().map(line => line.trimEnd());
+				const viewport = visible(term);
+				const union = [...scrollback, ...viewport];
+				for (const line of [...first, ...second]) {
+					expect(
+						union.some(bufferLine => bufferLine.includes(line)),
+						line,
+					).toBe(true);
+				}
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("stops at the prior proven boundary when a revisionless leading root grows during the settle debounce (codex P2 repro)", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			const leadingLines = ["lead-00", "lead-01", "lead-02"];
+			const sourceLines = Array.from(
+				{ length: 12 },
+				(_value, index) => `source-${index.toString().padStart(2, "0")} ${"S".repeat(20)}`,
+			);
+			const appended = Array.from(
+				{ length: 8 },
+				(_value, index) => `source-new-${index.toString().padStart(2, "0")}`,
+			);
+			const term = new VirtualTerminal(17, 6, 10_000);
+			const leading = new MutableLinesComponent(leadingLines);
+			const source = new UnresolvedWrappingLinesComponent(sourceLines);
+			const tui = new TUI(term);
+			tui.setResizeScrollback("preserve");
+			tui.addChild(leading);
+			tui.addChild(source);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				term.resize(40, 4);
+				// The leading root grows during the settle debounce without
+				// reporting a width-epoch revision — identity alone never proves
+				// it did not change size, so the resolver must not advance past
+				// it on that basis.
+				leading.setLines([...leadingLines, "lead-new"]);
+				source.setLines([...sourceLines, ...appended]);
+				tui.requestRender();
+				await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+				await settle(term);
+
+				const scrollback = term.getScrollBuffer().map(line => line.trimEnd());
+				const viewport = visible(term);
+				const union = [...scrollback, ...viewport];
+				expect(union.some(line => line.includes("lead-new"))).toBe(true);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("leaves append and rebuild resize scrollback modes unaffected by the structural resolver", async () => {
+		await withEnvPatch(TMUX_ENV, async () => {
+			for (const mode of ["append", "rebuild"] as const) {
+				const initial = Array.from(
+					{ length: 12 },
+					(_value, index) => `${mode}-${index.toString().padStart(2, "0")} ${"I".repeat(20)}`,
+				);
+				const appended = Array.from(
+					{ length: 8 },
+					(_value, index) => `${mode}-new-${index.toString().padStart(2, "0")}`,
+				);
+				const term = new VirtualTerminal(17, 6, 10_000);
+				// Same structurally-capable double the preserve-mode tests use above:
+				// proves append/rebuild never reach (or need) the new resolver —
+				// every width-changing resize classifies as a full paint before the
+				// preserve-only incremental branch that consults it is ever entered.
+				const component = new UnresolvedWrappingLinesComponent(initial);
+				const tui = new TUI(term);
+				tui.setResizeScrollback(mode);
+				tui.addChild(component);
+
+				try {
+					tui.start();
+					await settle(term);
+
+					term.resize(40, 4);
+					component.setLines([...initial, ...appended]);
+					tui.requestRender();
+					await Bun.sleep(DEBOUNCE_SETTLE_WAIT_MS);
+					await settle(term);
+
+					expect(visible(term)).toEqual(appended.slice(-4));
+				} finally {
+					tui.stop();
+				}
 			}
 		});
 	});


### PR DESCRIPTION
## What

Follow-up to #8725. When a width-resize epoch settles **unresolved** (no logical source boundary, render pending — e.g. a tmux window grouped across differently-sized clients while a turn is running), `tui.resizeScrollback: preserve` currently replays from row zero, re-emitting the entire committed transcript into pane scrollback.

This extends the `NativeScrollbackWidthEpoch` contract with an optional `resolveNativeScrollbackCommittedRows(boundary, committedRows)`: given the already-captured width-epoch marker and the old-width committed-row count, return the deepest current-width frame row *structurally proven* (component identity + finalized/version stability, walking `BlockSegment` records and delegating into the source component) to correspond to native history already on the tape. Preserve mode resumes emission from that boundary; `undefined` keeps the row-zero fallback — a too-shallow boundary duplicates rows, a too-deep one would lose them, so the resolver only answers when stability is proven. `append`/`rebuild` modes are untouched (they full-paint on width change before this path is reached).

## Why

The row-zero fallback makes preserve mode re-scroll the whole transcript on every oscillating resize — painful in long sessions viewed through grouped tmux clients. The resume boundary is derived structurally from the same marker data `captureNativeScrollbackWidthEpoch()` already records, not from text matching.

## Testing

`bun test test/issue-2088-repro.test.ts` (packages/tui) — 59 pass, including new tests for: row-zero fallback when nothing is provable, a mutable middle block truncating the proven boundary without invalidating earlier blocks, and append/rebuild staying unaffected. `env -u CLAUDE_CONFIG_DIR bun test test/tmux-width-resize-bounded.test.ts` (coding-agent) — 11 pass. `bun check` clean in both packages.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
