### PR TITLE
perf(agent): memoize AppendOnlyContextManager message digests by object identity

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed Anthropic Claude tool calls containing provider-visible private-use icon glyphs by reversibly tokenizing glyphs at the wire boundary and rejecting model-invented or unresolved glyph tokens before execution.
 - Fixed agent identity confusion after session handoffs by clarifying context framing and ensuring successor instances seamlessly resume existing execution plans.
 
+### Changed
+
+- Append-only context mode no longer re-serializes the entire already-synced history on every LLM call; per-message digests are memoized by message identity, keeping per-call sync cost flat as conversations grow.
+
 ## [17.4.1] - 2026-08-21
 
 ### Fixed

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -16,7 +16,8 @@
 
 import type { Context, Message, Tool } from "@oh-my-pi/pi-ai";
 import { normalizeTools } from "./agent-loop";
-import type { AgentContext } from "./types";
+import { messageEstimateVersion } from "./compaction/message-cache";
+import type { AgentContext, AgentMessage } from "./types";
 
 // ---------------------------------------------------------------------------
 // StablePrefix (formerly ImmutablePrefix)
@@ -177,6 +178,26 @@ export class AppendOnlyContextManager {
 	 * point on every subsequent turn.
 	 */
 	#messageDigests: number[] = [];
+	/**
+	 * Digests memoized by message object identity, validated by the message's
+	 * estimate version ({@link messageEstimateVersion}). Synced message objects
+	 * are stable between calls: converted fragments are cached per session
+	 * message identity and handed back unchanged on every call, so an unchanged
+	 * history re-hits this memo instead of re-serializing every previously-
+	 * synced message on each LLM call.
+	 *
+	 * Owner-side rewrites (prune/shake/strip-images) mutate messages IN PLACE
+	 * under stable identity — for assistant pass-through fragments the log
+	 * aliases the very object being mutated — so a bare identity memo would
+	 * serve pre-mutation bytes forever. Those owners MUST call
+	 * `invalidateMessageCache`, which bumps the symbol-keyed version tag
+	 * this memo validates before every hit; a version mismatch recomputes from
+	 * actual bytes and the sync diverges exactly as if a fresh object had
+	 * arrived. Mutating a synced message without that bump violates the
+	 * cache-coherence contract shared with the tokenizer and convert caches
+	 * (see `compaction/message-cache.ts`) and is unsupported.
+	 */
+	#digestMemo = new WeakMap<object, { version: number; digest: number }>();
 
 	build(context: AgentContext, options: BuildOptions): Context {
 		this.prefix.build(context, options);
@@ -290,6 +311,9 @@ export class AppendOnlyContextManager {
 	#messageDigest(msg: unknown): number {
 		if (!msg || typeof msg !== "object") return 0;
 		const m = msg as Record<string, unknown>;
+		const version = messageEstimateVersion(m as AgentMessage);
+		const cached = this.#digestMemo.get(m);
+		if (cached !== undefined && cached.version === version) return cached.digest;
 		const payload = JSON.stringify({
 			r: m.role ?? null,
 			c: m.content ?? null,
@@ -304,7 +328,9 @@ export class AppendOnlyContextManager {
 		for (let j = 0; j < payload.length; j++) {
 			hash = ((hash << 5) - hash + payload.charCodeAt(j)) | 0;
 		}
-		return hash >>> 0;
+		const hash32 = hash >>> 0;
+		this.#digestMemo.set(m, { version, digest: hash32 });
+		return hash32;
 	}
 }
 

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
 import { AppendOnlyContextManager, AppendOnlyLog, StablePrefix } from "@oh-my-pi/pi-agent-core/append-only-context";
+import { invalidateMessageCache } from "@oh-my-pi/pi-agent-core/compaction/message-cache";
 import type { AgentContext, AgentTool } from "@oh-my-pi/pi-agent-core/types";
 import type { Message, Tool, ToolExample } from "@oh-my-pi/pi-ai";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -739,6 +740,114 @@ describe("message sync", () => {
 		const r2 = mgr.build(ctx, BUILD_OPTS);
 		expect(r2.messages).toHaveLength(1);
 		expect(r2.messages[0]!.content).toBe("new turn");
+	});
+	it("keeps sync decisions byte-faithful across steady-state, growth, rewrite, and revert", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		// Partial message literals — syncMessages digests structural fields only.
+		const msgs: Message[] = [];
+		for (let i = 0; i < 4; i++) {
+			msgs.push({ role: "user", content: `q${i}` } as unknown as Message);
+			msgs.push({ role: "assistant", content: `a${i}` } as unknown as Message);
+		}
+		mgr.syncMessages(msgs);
+		expect([...mgr.log.entries()]).toEqual(msgs);
+
+		// Steady state: the pipeline hands back the same converted objects every
+		// call; the on-the-wire history must not move.
+		mgr.syncMessages(msgs);
+		expect([...mgr.log.entries()]).toEqual(msgs);
+
+		// Growth: prefix entries keep their identity, only the tail is added.
+		const before = [...mgr.log.entries()];
+		const tail = { role: "assistant", content: "new turn" } as unknown as Message;
+		msgs.push(tail);
+		mgr.syncMessages(msgs);
+		let entries = mgr.log.entries();
+		expect(entries.length).toBe(msgs.length);
+		expect(entries[entries.length - 1]).toBe(tail);
+		for (let i = 0; i < before.length; i++) expect(entries[i]).toBe(before[i]);
+
+		// Rewrite: one message's bytes change (fresh fragment objects); the log
+		// keeps the byte-stable prefix and replaces everything from the change.
+		const split = 5;
+		const rewritten = msgs.map((m, i) =>
+			i === split ? ({ role: m.role, content: "[pruned]" } as unknown as Message) : m,
+		);
+		mgr.syncMessages(rewritten);
+		entries = mgr.log.entries();
+		for (let i = 0; i < split; i++) expect(entries[i]).toBe(before[i]);
+		for (let i = split; i < rewritten.length; i++) expect(entries[i]).toBe(rewritten[i]);
+
+		// Revert: the original bytes return as fresh objects; the wire must show
+		// exactly those bytes again, in order.
+		const reverted = structuredClone(rewritten);
+		reverted[split] = { role: "assistant", content: "a2" } as unknown as Message;
+		mgr.syncMessages(reverted);
+		expect([...mgr.log.entries()]).toEqual(reverted);
+		const built = mgr.build(makeContext(), BUILD_OPTS);
+		expect(built.messages).toEqual(reverted);
+	});
+
+	it("re-syncs an in-place rewritten message once invalidation bumps its version", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		const raw = { role: "assistant", content: [{ type: "text", text: "original" }] };
+		const msg = raw as unknown as Message;
+		mgr.syncMessages([msg]);
+		expect(mgr.log.entries()[0]).toBe(msg);
+
+		// Owner-side in-place rewrite under stable identity (prune/shake/
+		// strip-images seam): the log aliases the very object being mutated, so
+		// the memo must not keep serving pre-mutation bytes.
+		raw.content = [{ type: "text", text: "[redacted]" }];
+		invalidateMessageCache(msg);
+		mgr.syncMessages([msg]);
+		expect(mgr.log.entries()[0]).toBe(msg);
+
+		// A later replay restores the ORIGINAL bytes as a fresh object. The
+		// manager must diverge here and put the replayed bytes on the wire —
+		// not the stale aliased object whose digest matched the old bytes.
+		const reverted = {
+			role: "assistant",
+			content: [{ type: "text", text: "original" }],
+		} as unknown as Message;
+		mgr.syncMessages([reverted]);
+		const built = mgr.build(makeContext(), BUILD_OPTS);
+		expect(built.messages[0]).toBe(reverted);
+		expect(built.messages[0]!.content).toEqual([{ type: "text", text: "original" }]);
+	});
+
+	it("treats fresh-object clones with identical bytes as stable and still detects real rewrites", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext(), BUILD_OPTS);
+
+		const originals = [
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
+		] as unknown as Message[];
+		mgr.syncMessages(originals);
+
+		// Every call can re-normalize history into fresh objects (cerebras
+		// thinking-strip, transformContext re-render); identical bytes must keep
+		// the on-the-wire prefix objects stable.
+		const clones = structuredClone(originals);
+		mgr.syncMessages(clones);
+		let entries = mgr.log.entries();
+		expect(entries[0]).toBe(originals[0]);
+		expect(entries[1]).toBe(originals[1]);
+
+		// A real byte rewrite reaches sync as fresh fragment objects (owner
+		// invalidation recomputes the cached conversion) and must still diverge
+		// at exactly the changed message.
+		const rewritten = structuredClone(originals);
+		rewritten[1].content = "[pruned]";
+		mgr.syncMessages(rewritten);
+		entries = mgr.log.entries();
+		expect(entries[0]).toBe(originals[0]);
+		expect(entries[1]).toBe(rewritten[1]);
 	});
 });
 


### PR DESCRIPTION
## Summary
Parity + observability for OpenRouter sticky routing:

1. Chat Completions requests to OpenRouter now send `session_id` — same normalization as the Responses path (`session_` prefix, 256-char cap, `cacheRetention: "none"` opt-out) — so sticky upstream affinity no longer depends on which transport is selected.
2. When an OpenRouter request carries non-empty `provider.order`, one `logger.warn` per process explains that upstream **skips session-affinity endpoint prioritization while `order` is set** (openrouter-web `packages/routing/endpoints/prioritize-endpoints-by-session.ts:589-597`), degrading prompt-cache hit rate.

**Environment**: Ryzen 9 7950X3D (32 threads), CachyOS Linux, Bun 1.3.14, nightly-2026-08-08 (Rust). **Baseline**: measured A/B against `main` @ v18.0.0 (`07b176945d`) on 2026-08-22, sequential runs, ±5–10% noise.

## Benchmark stats (context + client-side impact)

This change has **no measurable local throughput cost** — it adds one static string field to the wire body. Measured client-side context from the repo sweep (same machine/method as the sibling perf PRs):

| Measurement | Value |
|---|---|
| SSE parse cost per chunk (client, `readSseJson`) | 0.98µs/chunk (raw `JSON.parse` floor: 0.67µs) — unaffected by this change |
| Wire-size delta per request | +~30–40 bytes (`session_id` string) |
| Full `packages/ai` test suite | 4059 pass / 3 pre-existing environmental failures (identical to main baseline) |
| `openrouter-sticky-session.test.ts` (post-v18-rebase) | 5 pass / 0 fail |

The **intended** effect is upstream, and deliberately not claimed as a local benchmark: prompt-cache hit rate on OpenRouter-routed requests. Cache hits are the dominant TTFT/input-cost lever for long coding sessions; the two silent stickiness killers this fixes (no affinity key on the fallback transport; `provider.order` disabling affinity) manifest as colder caches and higher bills, not as client CPU. Verifying the upstream effect requires instrumented live-traffic measurement against OpenRouter, which is follow-up work.

## Changes
- `packages/ai/src/providers/openai-shared.ts`: `OpenAICompletionsParams.session_id?`; warning helper gated on `compat.isOpenRouterHost`; test-only reset seam.
- `packages/ai/src/providers/openai-completions.ts`: set `params.session_id` via `getOpenRouterResponsesSessionId(options)` when host is OpenRouter.
- Tests: wire parity vs Responses value; absence on non-OpenRouter hosts; once-per-process warn (full-suite-safe reset seam); `cacheRetention:"none"` opt-out.
- Existing dual-surface parity expectations updated for the new field. Rebased onto v18.0.0 (upstream ai error-handling refactor).

---

## Review response
Order-warning now latches only when session affinity is actually active for the request; latch reset seam restored in `afterEach` (full-suite safe).