### PR TITLE
perf(natives): auto-size walker pool — fixes native grep large-content regression vs rg

### DIFF
--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -31,7 +31,8 @@ static EMPTY_RECHECK_MS: LazyLock<u64> =
 	LazyLock::new(|| env_uint("FS_SCAN_EMPTY_RECHECK_MS", 200, 0, u64::MAX));
 static MAX_CACHE_ENTRIES: LazyLock<usize> =
 	LazyLock::new(|| env_uint("FS_SCAN_CACHE_MAX_ENTRIES", 16, 0, usize::MAX));
-const DEFAULT_WALK_WORKERS: usize = 4;
+/// 0 means auto-detect from `available_parallelism()`; see `normalize_worker_count`.
+const DEFAULT_WALK_WORKERS: usize = 0;
 
 static WALK_WORKERS: LazyLock<usize> = LazyLock::new(|| {
 	normalize_worker_count(env_uint("PI_WALK_WORKERS", DEFAULT_WALK_WORKERS, 0, usize::MAX))

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Native macOS spellchecker now honors all active system dictionaries: misspelling detection uses automatic language identification and completions/guesses/corrections select the per-word language, so non-English text (e.g. Russian) is checked instead of only the shared checker's current language ([#9334](https://github.com/can1357/oh-my-pi/issues/9334)).
 - Fixed PTY command cancellation leaking zombie child processes: a race where cancellation after spawn only attempted a single non-blocking reap could miss processes still being reaped by the kernel, and an early heartbeat check that bailed out without killing or reaping the child. On Unix, cancellation now polls for the child briefly and hands any straggler to a detached reaper, so the process is always waited on without an unbounded wait.
 - Fixed installed CLIs losing desktop capture when the resolved prebuilt addon still exposes the pre-parity `DesktopSession` ABI. That ABI is now adapted behind the current session contract, legacy error codes are translated, and the adapter ships in the published native core package.
+- Native `grep` no longer lags behind ripgrep on very large directory scans (e.g. the full Cargo registry): filesystem traversal now auto-sizes its worker pool to the machine's available parallelism instead of a fixed 4 threads, making huge content scans ~2.3x faster.
 
 ## [18.0.0] - 2026-08-22
 


### PR DESCRIPTION
## Summary
Native grep was **2.1× slower than rg** on huge content scans (Cargo registry) while winning everywhere else. Root cause isolated by single-variable sweep: the shared pi-walker pool was hardcoded to `DEFAULT_WALK_WORKERS = 4` while rg uses `available_parallelism`. The pool now auto-detects; `PI_WALK_WORKERS` override still respected.


**Environment**: Ryzen 9 7950X3D (32 threads), CachyOS Linux, Bun 1.3.14, nightly-2026-08-08 (Rust). **Baseline**: measured A/B against `main` @ v18.0.0 (`07b176945d`) on 2026-08-22, sequential runs, ±5–10% noise.

## Causal sweep (everything else fixed)
4w=193ms · 8w=110ms · 12w=91ms · 16w=87ms · 24w=80ms · 32w(auto)=81ms — near-linear to auto parity.

## Benchmarks — A/B vs current `main` (v18.0.0, both addons rebuilt from their own sources, sequential)

| Scenario (native vs rg) | main @ v18.0.0 | This branch |
|---|---|---|
| Medium content (50 files) | 7.8× / 6.2× (seq/2x) | 6.6× / 5.2× |
| Medium filesWithMatches | 13.3× / 14.2× | **15.9× / 13.0×** |
| Large content (200+ files) | 1.1× / 1.4× slower(2x) | **1.3× / ~parity** |
| Large filesWithMatches | 2.3× / 1.5× | **3.5× / 2.5×** |
| Large count | 1.9× / 1.3× | **3.3× / 2.5×** |
| **Cargo registry (~62k files, 2.1GB)** | **2.1× SLOWER (both modes)** | **1.0–1.1× faster (parity band)** |

The regression is present on v18 main and eliminated here; no scenario regressed beyond noise. Rebuilt + re-verified after the v18 rebase under the new pinned toolchain (nightly-2026-08-08).

Ruled out during diagnosis: grep iteration already parallelizes (rayon); regex tier fallback NOT engaged; output assembly not dominant.

## Tests
38 grep tests green (parallel streaming, oversized prefix, cancellation); pi-walker suite green; clippy clean; nextest-compatible.

## Trade-offs (honest)
- Worst-case transient memory during giant greps scales with workers (~4MB buffers each → ~128MB at 32 workers vs 16MB before); small scans unaffected (≥256-file gate + follow-links/same-fs guards).
- mmap-based reads would widen margin further but remain off the table per #5205.

---

## Review response
Auto-detect failure fallback restored to 4 workers (auto sentinel separated); stale 'default 4' references updated in `grep-cli.ts --help` and both docs files.