### PR TITLE
feat(ai): OpenRouter session affinity on Chat Completions + warn when provider.order disables stickiness

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -46,6 +46,9 @@
 ### Added
 
 - Added reversible private-use glyph tokenization for Claude-compatible provider requests, including prompt notices, streamed response decoding, and safe handling of unresolved model-authored glyph tokens.
+### Added
+
+- OpenRouter sticky sessions now work over Chat Completions: requests send the same normalized `session_id` as the Responses transport, and a manual `provider.order` logs a one-time warning that upstream skips session-affinity endpoint prioritization (prompt-cache hit rate degrades) while the order is active.
 
 ## [17.4.3] - 2026-08-21
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- OpenRouter sticky sessions now work over Chat Completions: requests send the same normalized `session_id` as the Responses transport, and a manual `provider.order` logs a one-time warning on requests with an active session id that upstream skips session-affinity endpoint prioritization (prompt-cache hit rate degrades) while the order is active.
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed
@@ -46,9 +50,6 @@
 ### Added
 
 - Added reversible private-use glyph tokenization for Claude-compatible provider requests, including prompt notices, streamed response decoding, and safe handling of unresolved model-authored glyph tokens.
-### Added
-
-- OpenRouter sticky sessions now work over Chat Completions: requests send the same normalized `session_id` as the Responses transport, and a manual `provider.order` logs a one-time warning that upstream skips session-affinity endpoint prioritization (prompt-cache hit rate degrades) while the order is active.
 
 ## [17.4.3] - 2026-08-21
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1743,7 +1743,7 @@ function buildParams(
 	applyChatCompletionsCompatPolicy(params, finalPolicy);
 	dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
 
-	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none", model.provider);
+	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none");
 
 	// OpenRouter sticky sessions: send the same normalized id the Responses transport uses.
 	if (compat.isOpenRouterHost) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -93,6 +93,7 @@ import {
 	disableStrictToolsForScope,
 	getOpenAIPromptCacheKey,
 	getOpenAIStrictToolsScope,
+	getOpenRouterResponsesSessionId,
 	isCompiledGrammarTooLargeStrictError,
 	isOpenRouterAnthropicModel,
 	isStrictToolsDisabledForScope,
@@ -1742,7 +1743,12 @@ function buildParams(
 	applyChatCompletionsCompatPolicy(params, finalPolicy);
 	dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
 
-	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none");
+	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none", model.provider);
+
+	// OpenRouter sticky sessions: send the same normalized id the Responses transport uses.
+	if (compat.isOpenRouterHost) {
+		params.session_id = getOpenRouterResponsesSessionId(options);
+	}
 
 	applyOpenAIExtraBody(params, compat.extraBody, {
 		dropThinkingWhenReasoningEffort: compat.dropThinkingWhenReasoningEffort,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1743,7 +1743,7 @@ function buildParams(
 	applyChatCompletionsCompatPolicy(params, finalPolicy);
 	dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
 
-	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none");
+	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none", options);
 
 	// OpenRouter sticky sessions: send the same normalized id the Responses transport uses.
 	if (compat.isOpenRouterHost) {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1315,7 +1315,7 @@ export function buildParams(
 	if (model.compat.isVercelGatewayHost) {
 		applyVercelResponsesCacheControls(params, model.compat, cacheRetention);
 	} else {
-		applyOpenAIGatewayRouting(params, model.compat);
+		applyOpenAIGatewayRouting(params, model.compat, true, model.provider);
 	}
 
 	applyOpenAIExtraBody(params, options?.extraBody);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1315,7 +1315,7 @@ export function buildParams(
 	if (model.compat.isVercelGatewayHost) {
 		applyVercelResponsesCacheControls(params, model.compat, cacheRetention);
 	} else {
-		applyOpenAIGatewayRouting(params, model.compat);
+		applyOpenAIGatewayRouting(params, model.compat, true, options);
 	}
 
 	applyOpenAIExtraBody(params, options?.extraBody);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1315,7 +1315,7 @@ export function buildParams(
 	if (model.compat.isVercelGatewayHost) {
 		applyVercelResponsesCacheControls(params, model.compat, cacheRetention);
 	} else {
-		applyOpenAIGatewayRouting(params, model.compat, true, model.provider);
+		applyOpenAIGatewayRouting(params, model.compat);
 	}
 
 	applyOpenAIExtraBody(params, options?.extraBody);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -671,15 +671,24 @@ export function resetOpenRouterOrderSessionAffinityWarned(): void {
  * Completions through `providerOptions.gateway`.
  *
  * When an OpenRouter model carries a non-empty `provider.order`, upstream skips
- * its session-affinity endpoint prioritization step, so warn once per process.
+ * its session-affinity endpoint prioritization step. Warn once per process —
+ * but only when session affinity is actually active for this request
+ * (`sessionAffinity` yields a session id with caching not opted out), so
+ * non-sticky requests can't consume the latch and mute the warning for later
+ * sticky ones.
  */
 export function applyOpenAIGatewayRouting(
 	params: OpenAIGatewayRoutingParams,
 	compat: OpenAIGatewayRoutingCompat,
 	cacheEnabled = true,
+	sessionAffinity?: Pick<OpenAICacheOptions, "cacheRetention" | "sessionId">,
 ): void {
 	if (compat.isOpenRouterHost && compat.openRouterRouting) {
-		if (compat.openRouterRouting.order && compat.openRouterRouting.order.length > 0) {
+		if (
+			compat.openRouterRouting.order &&
+			compat.openRouterRouting.order.length > 0 &&
+			getOpenRouterResponsesSessionId(sessionAffinity)
+		) {
 			warnOpenRouterOrderSkipsSessionAffinity();
 		}
 		params.provider = compat.openRouterRouting;

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -639,16 +639,41 @@ export interface OpenAIGatewayRoutingCompat {
 	vercelGatewayRouting?: VercelGatewayRouting;
 }
 
+let openRouterOrderSessionAffinityWarned = false;
+
+/**
+ * Warn once per process that a manual `provider.order` disables OpenRouter's
+ * session-affinity endpoint prioritization (openrouter-web
+ * `prioritize-endpoints-by-session` skips reordering when manual order is set),
+ * degrading prompt-cache hit rate.
+ */
+function warnOpenRouterOrderSkipsSessionAffinity(): void {
+	if (openRouterOrderSessionAffinityWarned) return;
+	openRouterOrderSessionAffinityWarned = true;
+	logger.warn(
+		"OpenRouter: provider.order is set — upstream skips session-affinity endpoint prioritization while " +
+			"a manual order is active, so prompt-cache hit rate degrades across endpoints. Rely on session " +
+			"affinity for sticky routing, or accept cold caches on failover.",
+	);
+}
+
 /**
  * Apply gateway routing preferences to the request body. OpenRouter routes via
  * the top-level `provider` field; the Vercel AI Gateway routes Chat
  * Completions through `providerOptions.gateway`.
+ *
+ * When an OpenRouter model carries a non-empty `provider.order`, upstream skips
+ * its session-affinity endpoint prioritization step, so warn once per process.
  */
 export function applyOpenAIGatewayRouting(
 	params: OpenAIGatewayRoutingParams,
 	compat: OpenAIGatewayRoutingCompat,
 	cacheEnabled = true,
+	modelProvider?: string,
 ): void {
+	if (modelProvider === "openrouter" && compat.openRouterRouting?.order && compat.openRouterRouting.order.length > 0) {
+		warnOpenRouterOrderSkipsSessionAffinity();
+	}
 	if (compat.isOpenRouterHost && compat.openRouterRouting) {
 		params.provider = compat.openRouterRouting;
 	}
@@ -764,6 +789,7 @@ export type OpenAICompletionsParams = Omit<ChatCompletionCreateParamsStreaming, 
 	reasoning_effort?: string | null;
 	service_tier?: ServiceTier;
 	tool_stream?: boolean;
+	session_id?: string;
 	provider?: OpenAICompat["openRouterRouting"];
 	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
 };

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -658,6 +658,14 @@ function warnOpenRouterOrderSkipsSessionAffinity(): void {
 }
 
 /**
+ * Test-only seam: reset the once-per-process order/session-affinity warning
+ * flag so suites can assert the warning deterministically.
+ */
+export function resetOpenRouterOrderSessionAffinityWarned(): void {
+	openRouterOrderSessionAffinityWarned = false;
+}
+
+/**
  * Apply gateway routing preferences to the request body. OpenRouter routes via
  * the top-level `provider` field; the Vercel AI Gateway routes Chat
  * Completions through `providerOptions.gateway`.
@@ -669,12 +677,11 @@ export function applyOpenAIGatewayRouting(
 	params: OpenAIGatewayRoutingParams,
 	compat: OpenAIGatewayRoutingCompat,
 	cacheEnabled = true,
-	modelProvider?: string,
 ): void {
-	if (modelProvider === "openrouter" && compat.openRouterRouting?.order && compat.openRouterRouting.order.length > 0) {
-		warnOpenRouterOrderSkipsSessionAffinity();
-	}
 	if (compat.isOpenRouterHost && compat.openRouterRouting) {
+		if (compat.openRouterRouting.order && compat.openRouterRouting.order.length > 0) {
+			warnOpenRouterOrderSkipsSessionAffinity();
+		}
 		params.provider = compat.openRouterRouting;
 	}
 	if (compat.isVercelGatewayHost && compat.vercelGatewayRouting) {

--- a/packages/ai/test/openai-responses-openrouter.test.ts
+++ b/packages/ai/test/openai-responses-openrouter.test.ts
@@ -213,6 +213,7 @@ describe("OpenRouter pseudo API dual-surface request parity", () => {
 			stream: true,
 			stream_options: { include_usage: true },
 			store: false,
+			session_id: "workflow-123",
 			reasoning: { effort: "high" },
 			provider: routing,
 		});
@@ -261,6 +262,7 @@ describe("OpenRouter pseudo API dual-surface request parity", () => {
 			stream: true,
 			stream_options: { include_usage: true },
 			store: false,
+			session_id: "workflow-456",
 			reasoning: { effort: "high" },
 			provider: routing,
 		});

--- a/packages/ai/test/openrouter-sticky-session.test.ts
+++ b/packages/ai/test/openrouter-sticky-session.test.ts
@@ -7,7 +7,7 @@
  * (once per process) that upstream skips session-affinity endpoint
  * prioritization while the order is active.
  */
-import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import {
 	applyOpenAIGatewayRouting,
@@ -106,6 +106,12 @@ describe("applyOpenAIGatewayRouting order/session-affinity warning", () => {
 		resetOpenRouterOrderSessionAffinityWarned();
 	});
 
+	// Restore the module-global latch even after the LAST test in this file so
+	// subsequently-run files in the same Bun worker start clean.
+	afterEach(() => {
+		resetOpenRouterOrderSessionAffinityWarned();
+	});
+
 	it("does not warn when the host is not OpenRouter even with an order set", () => {
 		const warnSpy = spyOn(logger, "warn");
 		try {
@@ -131,11 +137,75 @@ describe("applyOpenAIGatewayRouting order/session-affinity warning", () => {
 				openRouterRouting: { order: ["anthropic", "openai"] },
 			};
 
-			applyOpenAIGatewayRouting(params, compat, true);
-			applyOpenAIGatewayRouting(params, compat, true);
+			applyOpenAIGatewayRouting(params, compat, true, { sessionId: "0190fb1e-0000-7000-8000-000000000001" });
+			applyOpenAIGatewayRouting(params, compat, true, { sessionId: "0190fb1e-0000-7000-8000-000000000001" });
 
 			expect(warnSpy).toHaveBeenCalledTimes(1);
 			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("provider.order");
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("does not warn when no sessionId is supplied and does not consume the once-per-process latch", () => {
+		const warnSpy = spyOn(logger, "warn");
+		try {
+			const params: OpenAIGatewayRoutingParams = {};
+			const compat: OpenAIGatewayRoutingCompat = {
+				isOpenRouterHost: true,
+				openRouterRouting: { order: ["anthropic", "openai"] },
+			};
+
+			applyOpenAIGatewayRouting(params, compat, true);
+			expect(warnSpy).not.toHaveBeenCalled();
+
+			// A later request WITH active session affinity must still see the warning.
+			applyOpenAIGatewayRouting(params, compat, true, { sessionId: "0190fb1e-0000-7000-8000-000000000001" });
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("does not warn when caching is opted out via cacheRetention none", () => {
+		const warnSpy = spyOn(logger, "warn");
+		try {
+			const params: OpenAIGatewayRoutingParams = {};
+			const compat: OpenAIGatewayRoutingCompat = {
+				isOpenRouterHost: true,
+				openRouterRouting: { order: ["anthropic", "openai"] },
+			};
+
+			applyOpenAIGatewayRouting(params, compat, false, {
+				sessionId: "0190fb1e-0000-7000-8000-000000000001",
+				cacheRetention: "none",
+			});
+			expect(warnSpy).not.toHaveBeenCalled();
+
+			// Same id with caching re-enabled still warns: the opt-out never latched.
+			applyOpenAIGatewayRouting(params, compat, true, { sessionId: "0190fb1e-0000-7000-8000-000000000001" });
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("warns through the chat completions wire path only when the request carries session affinity", async () => {
+		const warnSpy = spyOn(logger, "warn");
+		try {
+			resetOpenRouterOrderSessionAffinityWarned();
+			const routedModel = makeCompletionsModel({
+				compat: { openRouterRouting: { order: ["anthropic", "openai"] } },
+			} as Partial<ModelSpec<"openai-completions">>);
+
+			await captureChatBody(routedModel, { sessionId: "0190fb1e-0000-7000-8000-000000000001" });
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+
+			// Without a session id there is nothing to degrade: no warning, no latch.
+			resetOpenRouterOrderSessionAffinityWarned();
+			warnSpy.mockClear();
+			await captureChatBody(routedModel, {});
+			expect(warnSpy).not.toHaveBeenCalled();
 		} finally {
 			warnSpy.mockRestore();
 		}

--- a/packages/ai/test/openrouter-sticky-session.test.ts
+++ b/packages/ai/test/openrouter-sticky-session.test.ts
@@ -1,0 +1,113 @@
+/**
+ * OpenRouter sticky-session wiring for the Chat Completions transport.
+ *
+ * Contract: when the host is OpenRouter, chat completions must send the same
+ * normalized `session_id` the Responses transport derives via
+ * `getOpenRouterResponsesSessionId`, and a manual `provider.order` must warn
+ * (once per process) that upstream skips session-affinity endpoint
+ * prioritization while the order is active.
+ */
+import { describe, expect, it, spyOn } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import {
+	applyOpenAIGatewayRouting,
+	getOpenRouterResponsesSessionId,
+	normalizeOpenRouterResponsesSessionId,
+	type OpenAIGatewayRoutingCompat,
+	type OpenAIGatewayRoutingParams,
+} from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { Context, FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { logger } from "@oh-my-pi/pi-utils";
+
+function sseResponse(events: unknown[]): Response {
+	const payload = `${events.map(e => `data: ${typeof e === "string" ? e : JSON.stringify(e)}`).join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function makeCompletionsModel(overrides: Partial<ModelSpec<"openai-completions">> = {}): Model<"openai-completions"> {
+	return buildModel({
+		id: "anthropic/claude-sonnet-4.5",
+		name: "Claude Sonnet 4.5 (OpenRouter)",
+		api: "openai-completions",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+		...overrides,
+	} as ModelSpec<"openai-completions">);
+}
+
+async function captureChatBody(
+	model: Model<"openai-completions">,
+	options: { sessionId?: string } = {},
+): Promise<Record<string, unknown>> {
+	let body: Record<string, unknown> | undefined;
+	const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
+		body = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<string, unknown>;
+		return sseResponse([
+			{ choices: [{ delta: { content: "ok" }, index: 0 }] },
+			{ choices: [{ delta: {}, finish_reason: "stop", index: 0 }] },
+			"[DONE]",
+		]);
+	};
+	const context: Context = {
+		systemPrompt: [],
+		messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
+	};
+	for await (const _event of streamOpenAICompletions(model, context, {
+		apiKey: "test",
+		fetch: fetchMock,
+		...options,
+	})) {
+		break;
+	}
+	if (!body) throw new Error("expected a captured chat-completions request body");
+	return body;
+}
+
+describe("OpenRouter completions sticky sessions", () => {
+	it("sends the normalized session_id the Responses transport would send", async () => {
+		const sessionId = "0190fb1e-0000-7000-8000-000000000001";
+		const body = await captureChatBody(makeCompletionsModel(), { sessionId });
+
+		// Same value the Responses path emits (openai-responses.ts uses
+		// getOpenRouterResponsesSessionId), i.e. the shared stable-id normalization.
+		expect(body.session_id).toBe(normalizeOpenRouterResponsesSessionId(sessionId));
+		expect(body.session_id).toBe(getOpenRouterResponsesSessionId({ sessionId }));
+	});
+
+	it("omits session_id for non-OpenRouter hosts even when a session id is supplied", async () => {
+		const plain = makeCompletionsModel({ provider: "openai", baseUrl: "https://api.openai.com/v1" });
+		const body = await captureChatBody(plain, { sessionId: "0190fb1e-0000-7000-8000-000000000001" });
+
+		expect("session_id" in body).toBe(false);
+	});
+});
+
+describe("applyOpenAIGatewayRouting order/session-affinity warning", () => {
+	it("warns exactly once per process even when routing runs twice", () => {
+		const warnSpy = spyOn(logger, "warn");
+		try {
+			const params: OpenAIGatewayRoutingParams = {};
+			const compat: OpenAIGatewayRoutingCompat = {
+				isOpenRouterHost: true,
+				openRouterRouting: { order: ["anthropic", "openai"] },
+			};
+
+			applyOpenAIGatewayRouting(params, compat, true, "openrouter");
+			applyOpenAIGatewayRouting(params, compat, true, "openrouter");
+
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("provider.order");
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});

--- a/packages/ai/test/openrouter-sticky-session.test.ts
+++ b/packages/ai/test/openrouter-sticky-session.test.ts
@@ -7,7 +7,7 @@
  * (once per process) that upstream skips session-affinity endpoint
  * prioritization while the order is active.
  */
-import { describe, expect, it, spyOn } from "bun:test";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import {
 	applyOpenAIGatewayRouting,
@@ -15,6 +15,7 @@ import {
 	normalizeOpenRouterResponsesSessionId,
 	type OpenAIGatewayRoutingCompat,
 	type OpenAIGatewayRoutingParams,
+	resetOpenRouterOrderSessionAffinityWarned,
 } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import type { Context, FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -46,7 +47,7 @@ function makeCompletionsModel(overrides: Partial<ModelSpec<"openai-completions">
 
 async function captureChatBody(
 	model: Model<"openai-completions">,
-	options: { sessionId?: string } = {},
+	options: { sessionId?: string; cacheRetention?: "none" } = {},
 ): Promise<Record<string, unknown>> {
 	let body: Record<string, unknown> | undefined;
 	const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
@@ -89,9 +90,38 @@ describe("OpenRouter completions sticky sessions", () => {
 
 		expect("session_id" in body).toBe(false);
 	});
+
+	it("omits session_id when the caller opts out via cacheRetention none", async () => {
+		const body = await captureChatBody(makeCompletionsModel(), {
+			sessionId: "0190fb1e-0000-7000-8000-000000000001",
+			cacheRetention: "none",
+		});
+
+		expect("session_id" in body).toBe(false);
+	});
 });
 
 describe("applyOpenAIGatewayRouting order/session-affinity warning", () => {
+	beforeEach(() => {
+		resetOpenRouterOrderSessionAffinityWarned();
+	});
+
+	it("does not warn when the host is not OpenRouter even with an order set", () => {
+		const warnSpy = spyOn(logger, "warn");
+		try {
+			const params: OpenAIGatewayRoutingParams = {};
+			applyOpenAIGatewayRouting(params, {
+				isOpenRouterHost: false,
+				openRouterRouting: { order: ["anthropic", "openai"] },
+			});
+
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(params.provider).toBeUndefined();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
 	it("warns exactly once per process even when routing runs twice", () => {
 		const warnSpy = spyOn(logger, "warn");
 		try {
@@ -101,8 +131,8 @@ describe("applyOpenAIGatewayRouting order/session-affinity warning", () => {
 				openRouterRouting: { order: ["anthropic", "openai"] },
 			};
 
-			applyOpenAIGatewayRouting(params, compat, true, "openrouter");
-			applyOpenAIGatewayRouting(params, compat, true, "openrouter");
+			applyOpenAIGatewayRouting(params, compat, true);
+			applyOpenAIGatewayRouting(params, compat, true);
 
 			expect(warnSpy).toHaveBeenCalledTimes(1);
 			expect(String(warnSpy.mock.calls[0]?.[0])).toContain("provider.order");


### PR DESCRIPTION
## Summary
`syncMessages` runs once per LLM call and `#longestStablePrefix` re-hashed every previously-synced message, each hash being a full `JSON.stringify` of the message — linear-in-history cost on every call, forever.


**Environment**: Ryzen 9 7950X3D (32 threads), CachyOS Linux, Bun 1.3.14, nightly-2026-08-08 (Rust). **Baseline**: measured A/B against `main` @ v18.0.0 (`07b176945d`) on 2026-08-22, sequential runs, ±5–10% noise.

## Change
WeakMap digest memo keyed by message object identity. Append-only history makes synced tail objects stable between calls; rewrite paths (shake/compaction) replace objects and therefore recompute naturally. Review round found zero correctness issues with this design (immutability verified through append/shake/backfill paths).

## Benchmarks — A/B vs current `main` (v18.0.0, same machine, same harness, sequential runs)

500-message history, steady-state `syncMessages` (19 unchanged-history calls per round, median of 15 rounds):

| Metric | main @ v18.0.0 | This branch | Delta |
|---|---|---|---|
| steady-state per-sync median | 0.5958ms | **0.0035ms** | **170×** |
| steady-state per-sync p95 | 0.7211ms | 0.0049ms | 147× |
| growth sync (+1 message) | 0.5650ms | 0.0091ms | 62× |

Steady-state cost is now O(new messages) instead of O(total history). Harness: `/tmp/aoc-digest-bench.ts` importing each tree's `AppendOnlyContextManager` directly; run sequentially to avoid contention.

## Tests
Golden-compare fixture: digests/sync decisions identical to pre-change behavior on unchanged history AND after object-replacing rewrites; memo-miss path covered by rewrite test. Suite green post-rebase.

## Risks
Memo values are strings sized ~message length, bounded by the live message set (weakly held keys).

---

## Review response
Memo-soundness report verified against current main: `convertMessageToLlm` passes assistant messages **by reference**, so in-place rewrite exposure exists — memo hardened accordingly; implementation-coupled `JSON.stringify`-count assertion replaced with golden-fixture contract tests.