### PR TITLE
perf(walker): single-flight directory scans in get_or_scan

### DIFF
--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -2,13 +2,15 @@
 
 use std::{
 	borrow::Cow,
+	collections::HashMap,
 	fmt,
 	path::{Path, PathBuf},
-	sync::LazyLock,
+	sync::{Arc, LazyLock},
 	time::{Duration, Instant},
 };
 
 use dashmap::DashMap;
+use parking_lot::{Condvar, Mutex};
 use rayon::{ThreadPool, prelude::*};
 
 use crate::{CollectedEntries, CollectedEntry, FileType, WalkError, WalkOptions};
@@ -48,6 +50,88 @@ static WALK_POOL: LazyLock<Option<ThreadPool>> = LazyLock::new(|| {
 		.ok()
 });
 static SCAN_CACHE: LazyLock<DashMap<CacheKey, CacheEntry>> = LazyLock::new(DashMap::new);
+
+/// Per-root count of underlying walks; single-flight regression tests only.
+#[cfg(test)]
+static TEST_WALK_COUNTS: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
+	LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(test)]
+fn record_test_walk(root: &Path) {
+	*TEST_WALK_COUNTS.lock().entry(root.to_path_buf()).or_default() += 1;
+}
+
+#[cfg(not(test))]
+const fn record_test_walk(_root: &Path) {}
+
+
+
+/// In-flight directory scans keyed like [`SCAN_CACHE`]; at most one walk runs
+/// per key at any time.
+static IN_FLIGHT_SCANS: LazyLock<Mutex<HashMap<CacheKey, Arc<ScanFlight>>>> =
+	LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Shared state of one in-flight directory scan.
+struct ScanFlight {
+	done:   Condvar,
+	/// `None` while the leader is walking, then the shared scan result.
+	result: Mutex<Option<Result<CollectedEntries, WalkError<String>>>>,
+}
+
+impl ScanFlight {
+	const fn new() -> Self {
+		Self { done: Condvar::new(), result: Mutex::new(None) }
+	}
+
+	/// Publish the scan result and wake every follower.
+	fn finish(&self, result: Result<CollectedEntries, WalkError<String>>) {
+		*self.result.lock() = Some(result);
+		self.done.notify_all();
+	}
+
+	/// Block until the leader publishes the result, then clone it.
+	fn wait_for_result(&self) -> Result<CollectedEntries, WalkError<String>> {
+		let mut guard = self.result.lock();
+		while guard.is_none() {
+			self.done.wait(&mut guard);
+		}
+		guard.as_ref().expect("result published before wakeup").clone()
+	}
+}
+
+/// Join the flight for `key`, starting one if no scan is running yet. Returns
+/// the shared flight plus whether this caller became its leader.
+fn join_or_start_scan(key: &CacheKey) -> (Arc<ScanFlight>, bool) {
+	let mut flights = IN_FLIGHT_SCANS.lock();
+	if let Some(flight) = flights.get(key).cloned() {
+		return (flight, false);
+	}
+	let flight = Arc::new(ScanFlight::new());
+	flights.insert(key.clone(), flight.clone());
+	(flight, true)
+}
+
+/// Deregisters a leader's flight when it finishes or unwinds. A leader that
+/// panics before publishing wakes its followers with an error instead of
+/// leaving them blocked forever.
+struct ScanLeader {
+	key:    CacheKey,
+	flight: Arc<ScanFlight>,
+}
+
+impl Drop for ScanLeader {
+	fn drop(&mut self) {
+		if IN_FLIGHT_SCANS.lock().remove(&self.key).is_some() {
+			let mut guard = self.flight.result.lock();
+			if guard.is_none() {
+				*guard = Some(Err(WalkError::Interrupted(
+					"concurrent directory scan aborted".to_string(),
+				)));
+				self.flight.done.notify_all();
+			}
+		}
+	}
+}
 
 fn env_uint<T>(name: &str, default: T, min: T, max: T) -> T
 where
@@ -273,6 +357,7 @@ where
 	E: fmt::Display,
 {
 	options.cache = false;
+	record_test_walk(root);
 	crate::collect_entries_native(root, options, || heartbeat().map_err(|err| err.to_string()))
 }
 
@@ -291,23 +376,55 @@ where
 	}
 
 	let key = cache_key(root, options);
-	let now = Instant::now();
 	if let Some(entry) = SCAN_CACHE.get(&key) {
-		let age = now.duration_since(entry.created_at);
+		let age = Instant::now().duration_since(entry.created_at);
 		if age < Duration::from_millis(ttl) {
 			return Ok(CollectedEntries {
 				entries:      entry.entries.clone(),
 				cache_age_ms: age.as_millis() as u64,
 			});
 		}
+		// The expired entry is deliberately left in place until a fresh scan
+		// replaces it: concurrent callers serve it stale-while-revalidate
+		// below, consistent with TTL semantics where data up to one TTL old
+		// is acceptable. A failed revalidation likewise keeps serving the
+		// stale snapshot instead of leaving later callers uncached.
 		drop(entry);
-		SCAN_CACHE.remove(&key);
 	}
 
-	let scan = collect_entries_uncached(root, options, heartbeat)?;
-	SCAN_CACHE.insert(key, CacheEntry { created_at: now, entries: scan.entries.clone() });
-	evict_oldest();
-	Ok(CollectedEntries { entries: scan.entries, cache_age_ms: 0 })
+	let (flight, is_leader) = join_or_start_scan(&key);
+
+	if !is_leader {
+		// Another thread owns this scan. Serve whatever the cache holds —
+		// possibly stale — rather than duplicating the walk; only callers
+		// with no cached snapshot block on the shared flight.
+		if let Some(entry) = SCAN_CACHE.get(&key) {
+			let age = Instant::now().duration_since(entry.created_at);
+			return Ok(CollectedEntries {
+				entries:      entry.entries.clone(),
+				cache_age_ms: age.as_millis() as u64,
+			});
+		}
+		return flight.wait_for_result();
+	}
+
+	// Leader: walk outside all locks, then publish to waiters and refresh
+	// the cache. Followers receive the same outcome, including errors.
+	let _leader = ScanLeader { key: key.clone(), flight: flight.clone() };
+	let scan = collect_entries_uncached(root, options, heartbeat);
+	flight.finish(scan.clone());
+
+	match scan {
+		Ok(entries) => {
+			SCAN_CACHE.insert(
+				key,
+				CacheEntry { created_at: Instant::now(), entries: entries.entries.clone() },
+			);
+			evict_oldest();
+			Ok(CollectedEntries { entries: entries.entries, cache_age_ms: 0 })
+		},
+		Err(err) => Err(err),
+	}
 }
 
 pub fn collect_entries<H, E>(
@@ -372,7 +489,10 @@ mod tests {
 	use std::{
 		fs,
 		path::{Path, PathBuf},
-		sync::atomic::{AtomicU64, Ordering},
+		sync::{
+			Arc,
+			atomic::{AtomicU64, Ordering},
+		},
 		time::{Duration, SystemTime, UNIX_EPOCH},
 	};
 
@@ -665,5 +785,39 @@ mod tests {
 			.expect("full scan includes file");
 		assert!(full_file.mtime.is_some(), "full scan should include mtime");
 		assert_eq!(full_file.size, Some(2.0));
+	}
+
+	#[test]
+	fn sixteen_threads_racing_cold_root_execute_one_walk() {
+		use std::sync::Barrier;
+
+		let dir = TempDirGuard::new();
+		for index in 0..64 {
+			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
+		}
+		super::invalidate_all();
+
+		let mut options = scan_options(true, true, crate::WalkDetail::Full);
+		options.cache = true;
+		let barrier = Arc::new(Barrier::new(16));
+		let handles: Vec<_> = (0..16)
+			.map(|_| {
+				let barrier = barrier.clone();
+				let root = dir.path().to_path_buf();
+				std::thread::spawn(move || {
+					barrier.wait();
+					super::collect_entries(&root, options, ok_heartbeat)
+						.expect("racing scan should succeed")
+						.entries
+						.len()
+				})
+			})
+			.collect();
+		for handle in handles {
+			assert_eq!(handle.join().unwrap(), 64, "every racing caller sees the full scan");
+		}
+
+		let walks = super::TEST_WALK_COUNTS.lock().get(dir.path()).copied().unwrap_or(0);
+		assert_eq!(walks, 1, "16 racing cold-start callers must trigger exactly one walk");
 	}
 }

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -58,44 +58,84 @@ static TEST_WALK_COUNTS: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
 
 #[cfg(test)]
 fn record_test_walk(root: &Path) {
-	*TEST_WALK_COUNTS.lock().entry(root.to_path_buf()).or_default() += 1;
+	*TEST_WALK_COUNTS
+		.lock()
+		.entry(root.to_path_buf())
+		.or_default() += 1;
 }
 
 #[cfg(not(test))]
 const fn record_test_walk(_root: &Path) {}
-
-
 
 /// In-flight directory scans keyed like [`SCAN_CACHE`]; at most one walk runs
 /// per key at any time.
 static IN_FLIGHT_SCANS: LazyLock<Mutex<HashMap<CacheKey, Arc<ScanFlight>>>> =
 	LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Outcome a finished flight leaves for its followers.
+enum FlightOutcome {
+	/// The leader completed; followers reuse this shared result verbatim.
+	Shared(Result<CollectedEntries, WalkError<String>>),
+	/// The leader failed on its own heartbeat (user cancel, per-call
+	/// timeout); followers rerun the walk themselves instead of inheriting
+	/// an error that never belonged to them.
+	Rerun,
+}
+
+/// How a follower's wait on a leader ended.
+enum FollowerOutcome {
+	/// Reuse the leader-published result.
+	Shared(Result<CollectedEntries, WalkError<String>>),
+	/// The leader failed; run this caller's own scan.
+	Rerun,
+	/// This follower's own heartbeat fired while blocked.
+	Interrupted(WalkError<String>),
+}
+
+/// How often a blocked follower polls its own heartbeat while waiting.
+const FOLLOWER_HEARTBEAT_POLL: Duration = Duration::from_millis(50);
+
 /// Shared state of one in-flight directory scan.
 struct ScanFlight {
-	done:   Condvar,
-	/// `None` while the leader is walking, then the shared scan result.
-	result: Mutex<Option<Result<CollectedEntries, WalkError<String>>>>,
+	done:    Condvar,
+	/// `None` while the leader is walking, then the shared flight outcome.
+	outcome: Mutex<Option<FlightOutcome>>,
 }
 
 impl ScanFlight {
 	const fn new() -> Self {
-		Self { done: Condvar::new(), result: Mutex::new(None) }
+		Self { done: Condvar::new(), outcome: Mutex::new(None) }
 	}
 
-	/// Publish the scan result and wake every follower.
-	fn finish(&self, result: Result<CollectedEntries, WalkError<String>>) {
-		*self.result.lock() = Some(result);
+	/// Publish the leader's outcome and wake every follower.
+	fn finish(&self, outcome: FlightOutcome) {
+		*self.outcome.lock() = Some(outcome);
 		self.done.notify_all();
 	}
 
-	/// Block until the leader publishes the result, then clone it.
-	fn wait_for_result(&self) -> Result<CollectedEntries, WalkError<String>> {
-		let mut guard = self.result.lock();
-		while guard.is_none() {
-			self.done.wait(&mut guard);
+	/// Block until the leader publishes, polling this caller's heartbeat so
+	/// a follower bails out with its own cancellation or timeout rather
+	/// than waiting out the leader's entire walk.
+	fn wait_for_leader<H, E>(&self, heartbeat: &H) -> FollowerOutcome
+	where
+		H: Fn() -> std::result::Result<(), E>,
+		E: fmt::Display,
+	{
+		let mut guard = self.outcome.lock();
+		loop {
+			if let Some(outcome) = guard.as_ref() {
+				return match outcome {
+					FlightOutcome::Shared(result) => FollowerOutcome::Shared(result.clone()),
+					FlightOutcome::Rerun => FollowerOutcome::Rerun,
+				};
+			}
+			drop(guard);
+			if let Err(err) = heartbeat() {
+				return FollowerOutcome::Interrupted(WalkError::Interrupted(err.to_string()));
+			}
+			guard = self.outcome.lock();
+			self.done.wait_for(&mut guard, FOLLOWER_HEARTBEAT_POLL);
 		}
-		guard.as_ref().expect("result published before wakeup").clone()
 	}
 }
 
@@ -122,11 +162,11 @@ struct ScanLeader {
 impl Drop for ScanLeader {
 	fn drop(&mut self) {
 		if IN_FLIGHT_SCANS.lock().remove(&self.key).is_some() {
-			let mut guard = self.flight.result.lock();
+			let mut guard = self.flight.outcome.lock();
 			if guard.is_none() {
-				*guard = Some(Err(WalkError::Interrupted(
+				*guard = Some(FlightOutcome::Shared(Err(WalkError::Interrupted(
 					"concurrent directory scan aborted".to_string(),
-				)));
+				))));
 				self.flight.done.notify_all();
 			}
 		}
@@ -405,25 +445,33 @@ where
 				cache_age_ms: age.as_millis() as u64,
 			});
 		}
-		return flight.wait_for_result();
+		return match flight.wait_for_leader(heartbeat) {
+			FollowerOutcome::Shared(result) => result,
+			FollowerOutcome::Interrupted(err) => Err(err),
+			FollowerOutcome::Rerun => collect_entries_uncached(root, options, heartbeat),
+		};
 	}
 
-	// Leader: walk outside all locks, then publish to waiters and refresh
-	// the cache. Followers receive the same outcome, including errors.
+	// Leader: walk outside all locks, then refresh the cache and publish.
 	let _leader = ScanLeader { key: key.clone(), flight: flight.clone() };
-	let scan = collect_entries_uncached(root, options, heartbeat);
-	flight.finish(scan.clone());
-
-	match scan {
+	match collect_entries_uncached(root, options, heartbeat) {
 		Ok(entries) => {
-			SCAN_CACHE.insert(
-				key,
-				CacheEntry { created_at: Instant::now(), entries: entries.entries.clone() },
-			);
+			flight.finish(FlightOutcome::Shared(Ok(entries.clone())));
+			SCAN_CACHE.insert(key, CacheEntry {
+				created_at: Instant::now(),
+				entries:    entries.entries.clone(),
+			});
 			evict_oldest();
 			Ok(CollectedEntries { entries: entries.entries, cache_age_ms: 0 })
 		},
-		Err(err) => Err(err),
+		Err(err) => {
+			// Never share this failure: it may come from the leader's own
+			// heartbeat (user cancel, per-call timeout), which unrelated
+			// followers must not inherit. Wake them to rerun the walk with
+			// their own heartbeats instead.
+			flight.finish(FlightOutcome::Rerun);
+			Err(err)
+		},
 	}
 }
 
@@ -817,7 +865,184 @@ mod tests {
 			assert_eq!(handle.join().unwrap(), 64, "every racing caller sees the full scan");
 		}
 
-		let walks = super::TEST_WALK_COUNTS.lock().get(dir.path()).copied().unwrap_or(0);
+		let walks = super::TEST_WALK_COUNTS
+			.lock()
+			.get(dir.path())
+			.copied()
+			.unwrap_or(0);
 		assert_eq!(walks, 1, "16 racing cold-start callers must trigger exactly one walk");
+	}
+
+	/// Blocks a scan's first heartbeat call until `send` fires, then fails
+	/// every subsequent call.
+	fn gated_heartbeat(
+		gate: Arc<std::sync::Mutex<Option<std::sync::mpsc::Receiver<()>>>>,
+		reason: &'static str,
+	) -> impl Fn() -> std::result::Result<(), String> + Send + 'static {
+		move || {
+			let mut slot = gate.lock().expect("gate lock");
+			match slot.take() {
+				Some(receiver) => {
+					let _ = receiver.recv();
+					drop(slot);
+					Err(reason.to_string())
+				},
+				None => Err(reason.to_string()),
+			}
+		}
+	}
+
+	fn cold_scan_options() -> crate::WalkOptions {
+		let mut options = scan_options(true, true, crate::WalkDetail::Full);
+		options.cache = true;
+		options
+	}
+
+	fn wait_for_flight(key: &super::CacheKey) -> Arc<super::ScanFlight> {
+		for _ in 0..400 {
+			let registered = super::IN_FLIGHT_SCANS.lock().get(key).cloned();
+			if let Some(flight) = registered {
+				return flight;
+			}
+			std::thread::sleep(Duration::from_millis(5));
+		}
+		panic!("leader never registered its flight");
+	}
+
+	#[test]
+	fn leader_heartbeat_failure_does_not_fail_concurrent_follower() {
+		use std::sync::mpsc;
+
+		let dir = TempDirGuard::new();
+		for index in 0..8 {
+			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
+		}
+		super::invalidate_all();
+
+		let options = cold_scan_options();
+		let key = super::cache_key(dir.path(), options);
+
+		let (gate_tx, gate_rx) = mpsc::channel::<()>();
+		let gate = Arc::new(std::sync::Mutex::new(Some(gate_rx)));
+		let leader_root = dir.path().to_path_buf();
+		let leader_options = cold_scan_options();
+		let leader_handle = std::thread::spawn(move || {
+			super::collect_entries(
+				&leader_root,
+				leader_options,
+				gated_heartbeat(gate, "leader cancelled"),
+			)
+		});
+		wait_for_flight(&key);
+
+		// The follower joins the live flight; its first heartbeat poll
+		// proves it is blocked in wait_for_leader.
+		let follower_polls = Arc::new(AtomicU64::new(0));
+		let poll_counter = follower_polls.clone();
+		let follower_root = dir.path().to_path_buf();
+		let follower_options = cold_scan_options();
+		let follower_handle = std::thread::spawn(move || {
+			let heartbeat = move || -> std::result::Result<(), String> {
+				poll_counter.fetch_add(1, Ordering::Relaxed);
+				Ok(())
+			};
+			super::collect_entries(&follower_root, follower_options, heartbeat)
+		});
+		for _ in 0..400 {
+			if follower_polls.load(Ordering::Relaxed) > 0 {
+				break;
+			}
+			std::thread::sleep(Duration::from_millis(5));
+		}
+		assert!(follower_polls.load(Ordering::Relaxed) > 0, "follower never joined the flight");
+
+		gate_tx.send(()).expect("release leader");
+		let leader_err = leader_handle
+			.join()
+			.unwrap()
+			.expect_err("leader should surface its own cancel");
+		assert!(
+			leader_err.to_string().contains("leader cancelled"),
+			"expected the leader's own cancellation, got: {leader_err}"
+		);
+
+		let follower_entries = follower_handle.join().unwrap().unwrap_or_else(|err| {
+			panic!("follower must not inherit the leader's cancellation, got: {err}")
+		});
+		assert_eq!(
+			follower_entries.entries.len(),
+			8,
+			"follower should complete its own scan with all entries"
+		);
+
+		let walks = super::TEST_WALK_COUNTS
+			.lock()
+			.get(dir.path())
+			.copied()
+			.unwrap_or(0);
+		assert_eq!(walks, 2, "cancelled leader plus follower rerun must total two walks");
+	}
+
+	#[test]
+	fn follower_enforces_own_heartbeat_while_blocked_on_leader() {
+		use std::sync::mpsc;
+
+		let dir = TempDirGuard::new();
+		for index in 0..8 {
+			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
+		}
+		super::invalidate_all();
+
+		let options = cold_scan_options();
+		let key = super::cache_key(dir.path(), options);
+
+		let (gate_tx, gate_rx) = mpsc::channel::<()>();
+		let gate = Arc::new(std::sync::Mutex::new(Some(gate_rx)));
+		let leader_root = dir.path().to_path_buf();
+		let leader_options = cold_scan_options();
+		let leader_handle = std::thread::spawn(move || {
+			super::collect_entries(
+				&leader_root,
+				leader_options,
+				gated_heartbeat(gate, "leader cancelled"),
+			)
+		});
+		wait_for_flight(&key);
+
+		// Allow a couple of wait-loop polls, then fire this caller's own
+		// timeout while the leader stays parked.
+		let poll_counter = Arc::new(AtomicU64::new(0));
+		let follower_root = dir.path().to_path_buf();
+		let follower_options = cold_scan_options();
+		let (result_tx, result_rx) = mpsc::channel();
+		std::thread::spawn(move || {
+			let heartbeat = move || -> std::result::Result<(), String> {
+				if poll_counter.fetch_add(1, Ordering::Relaxed) >= 2 {
+					return Err("follower timed out".to_string());
+				}
+				Ok(())
+			};
+			let _ =
+				result_tx.send(super::collect_entries(&follower_root, follower_options, heartbeat));
+		});
+
+		let result = result_rx
+			.recv_timeout(Duration::from_secs(10))
+			.expect("blocked follower ignored its own heartbeat and waited out the leader");
+		let err = result.expect_err("follower's own heartbeat fired; scan must fail");
+		assert!(
+			err.to_string().contains("follower timed out"),
+			"expected the follower's own timeout, got: {err}"
+		);
+
+		gate_tx.send(()).expect("release leader");
+		assert!(leader_handle.join().unwrap().is_err(), "released leader should still fail");
+
+		let walks = super::TEST_WALK_COUNTS
+			.lock()
+			.get(dir.path())
+			.copied()
+			.unwrap_or(0);
+		assert_eq!(walks, 1, "the follower bailed before running any walk of its own");
 	}
 }

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -528,14 +528,18 @@ where
 		}
 
 		// Leader: walk outside all locks, then refresh the cache and publish.
+		// Order matters: the cache entry MUST be inserted before `finish` wakes
+		// followers. A woken follower can mutate the filesystem and call
+		// `invalidate_path` before we insert, and an insert after that would
+		// resurrect entries the invalidation just removed.
 		match collect_entries_uncached(root, options, heartbeat) {
 			Ok(entries) => {
-				flight.finish(FlightOutcome::Shared(Ok(entries.clone())));
 				SCAN_CACHE.insert(key, CacheEntry {
 					created_at: Instant::now(),
 					entries:    entries.entries.clone(),
 				});
 				evict_oldest();
+				flight.finish(FlightOutcome::Shared(Ok(entries.clone())));
 				return Ok(CollectedEntries { entries: entries.entries, cache_age_ms: 0 });
 			},
 			Err(err @ WalkError::InvalidData { .. }) => {

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -1,5 +1,7 @@
 //! Shared walker scan cache used by owned-entry collection.
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
 	borrow::Cow,
 	collections::HashMap,
@@ -67,6 +69,42 @@ fn record_test_walk(root: &Path) {
 #[cfg(not(test))]
 const fn record_test_walk(_root: &Path) {}
 
+/// Test-only one-shot pause gates for deterministic concurrency regressions:
+/// a test arms `(point, root, gate)`, and the next caller reaching that
+/// point in [`get_or_scan`] for that root parks until the test opens it.
+#[cfg(test)]
+static TEST_PAUSE: LazyLock<Mutex<Option<PauseArm>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Shared gate flag plus its condvar for [`TEST_PAUSE`].
+#[cfg(test)]
+type PauseGate = Arc<(Mutex<bool>, Condvar)>;
+
+/// An armed pause gate: its [`get_or_scan`] point, scoped root, and gate.
+#[cfg(test)]
+type PauseArm = (&'static str, PathBuf, PauseGate);
+
+/// How many callers have entered an armed [`TEST_PAUSE`] gate.
+#[cfg(test)]
+static TEST_PAUSE_ARRIVALS: AtomicU64 = AtomicU64::new(0);
+
+/// Park this caller if a test armed a pause gate for `point` on `root`;
+/// consumed once.
+#[cfg(test)]
+fn test_pause(point: &'static str, root: &Path) {
+	let Some((armed, expected_root, gate)) = TEST_PAUSE.lock().take() else {
+		return;
+	};
+	if armed != point || expected_root != root {
+		*TEST_PAUSE.lock() = Some((armed, expected_root, gate));
+		return;
+	}
+	TEST_PAUSE_ARRIVALS.fetch_add(1, Ordering::Relaxed);
+	let (flag, arrived) = &*gate;
+	let mut open = flag.lock();
+	while !*open {
+		arrived.wait(&mut open);
+	}
+}
 /// In-flight directory scans keyed like [`SCAN_CACHE`]; at most one walk runs
 /// per key at any time.
 static IN_FLIGHT_SCANS: LazyLock<Mutex<HashMap<CacheKey, Arc<ScanFlight>>>> =
@@ -134,6 +172,11 @@ impl ScanFlight {
 				return FollowerOutcome::Interrupted(WalkError::Interrupted(err.to_string()));
 			}
 			guard = self.outcome.lock();
+			if guard.is_some() {
+				// The leader published while we ran the heartbeat without
+				// holding the lock; don't sleep out a full poll interval.
+				continue;
+			}
 			self.done.wait_for(&mut guard, FOLLOWER_HEARTBEAT_POLL);
 		}
 	}
@@ -416,62 +459,101 @@ where
 	}
 
 	let key = cache_key(root, options);
-	if let Some(entry) = SCAN_CACHE.get(&key) {
-		let age = Instant::now().duration_since(entry.created_at);
-		if age < Duration::from_millis(ttl) {
-			return Ok(CollectedEntries {
-				entries:      entry.entries.clone(),
-				cache_age_ms: age.as_millis() as u64,
-			});
-		}
-		// The expired entry is deliberately left in place until a fresh scan
-		// replaces it: concurrent callers serve it stale-while-revalidate
-		// below, consistent with TTL semantics where data up to one TTL old
-		// is acceptable. A failed revalidation likewise keeps serving the
-		// stale snapshot instead of leaving later callers uncached.
-		drop(entry);
-	}
-
-	let (flight, is_leader) = join_or_start_scan(&key);
-
-	if !is_leader {
-		// Another thread owns this scan. Serve whatever the cache holds —
-		// possibly stale — rather than duplicating the walk; only callers
-		// with no cached snapshot block on the shared flight.
+	loop {
 		if let Some(entry) = SCAN_CACHE.get(&key) {
 			let age = Instant::now().duration_since(entry.created_at);
-			return Ok(CollectedEntries {
-				entries:      entry.entries.clone(),
-				cache_age_ms: age.as_millis() as u64,
-			});
+			if age < Duration::from_millis(ttl) {
+				return Ok(CollectedEntries {
+					entries:      entry.entries.clone(),
+					cache_age_ms: age.as_millis() as u64,
+				});
+			}
+			// The expired entry is deliberately left in place until a fresh
+			// scan replaces it: concurrent callers serve it
+			// stale-while-revalidate below, consistent with TTL semantics
+			// where data up to one TTL old is acceptable. A failed
+			// revalidation likewise keeps serving the stale snapshot instead
+			// of leaving later callers uncached.
+			drop(entry);
 		}
-		return match flight.wait_for_leader(heartbeat) {
-			FollowerOutcome::Shared(result) => result,
-			FollowerOutcome::Interrupted(err) => Err(err),
-			FollowerOutcome::Rerun => collect_entries_uncached(root, options, heartbeat),
-		};
-	}
 
-	// Leader: walk outside all locks, then refresh the cache and publish.
-	let _leader = ScanLeader { key: key.clone(), flight: flight.clone() };
-	match collect_entries_uncached(root, options, heartbeat) {
-		Ok(entries) => {
-			flight.finish(FlightOutcome::Shared(Ok(entries.clone())));
-			SCAN_CACHE.insert(key, CacheEntry {
-				created_at: Instant::now(),
-				entries:    entries.entries.clone(),
-			});
-			evict_oldest();
-			Ok(CollectedEntries { entries: entries.entries, cache_age_ms: 0 })
-		},
-		Err(err) => {
-			// Never share this failure: it may come from the leader's own
-			// heartbeat (user cancel, per-call timeout), which unrelated
-			// followers must not inherit. Wake them to rerun the walk with
-			// their own heartbeats instead.
-			flight.finish(FlightOutcome::Rerun);
-			Err(err)
-		},
+		#[cfg(test)]
+		test_pause("before-join", root);
+
+		let (flight, is_leader) = join_or_start_scan(&key);
+
+		if !is_leader {
+			// Another thread owns this scan. Serve whatever the cache holds —
+			// possibly stale — rather than duplicating the walk; only callers
+			// with no cached snapshot block on the shared flight.
+			if let Some(entry) = SCAN_CACHE.get(&key) {
+				let age = Instant::now().duration_since(entry.created_at);
+				return Ok(CollectedEntries {
+					entries:      entry.entries.clone(),
+					cache_age_ms: age.as_millis() as u64,
+				});
+			}
+			return match flight.wait_for_leader(heartbeat) {
+				FollowerOutcome::Shared(result) => result,
+				FollowerOutcome::Interrupted(err) => Err(err),
+				// The leader died on its own heartbeat. Re-enter coordinated
+				// acquisition instead of walking unguarded, so concurrent
+				// rerunners still share one flight and one cached result.
+				FollowerOutcome::Rerun => continue,
+			};
+		}
+
+		// This caller owns the scan. Register the leader guard before the
+		// recheck below so an early return still deregisters the flight via
+		// [`ScanLeader`].
+		let _leader = ScanLeader { key: key.clone(), flight: flight.clone() };
+
+		#[cfg(test)]
+		test_pause("before-walk", root);
+
+		// Close the miss-to-leadership race: another caller may have finished
+		// the whole scan between our stale check above and acquiring
+		// leadership here. Serve that fresh snapshot instead of walking over
+		// it, and hand it to any follower already blocked on this flight.
+		if let Some(entry) = SCAN_CACHE.get(&key) {
+			let age = Instant::now().duration_since(entry.created_at);
+			if age < Duration::from_millis(ttl) {
+				let cached = CollectedEntries {
+					entries:      entry.entries.clone(),
+					cache_age_ms: age.as_millis() as u64,
+				};
+				flight.finish(FlightOutcome::Shared(Ok(cached.clone())));
+				return Ok(cached);
+			}
+		}
+
+		// Leader: walk outside all locks, then refresh the cache and publish.
+		match collect_entries_uncached(root, options, heartbeat) {
+			Ok(entries) => {
+				flight.finish(FlightOutcome::Shared(Ok(entries.clone())));
+				SCAN_CACHE.insert(key, CacheEntry {
+					created_at: Instant::now(),
+					entries:    entries.entries.clone(),
+				});
+				evict_oldest();
+				return Ok(CollectedEntries { entries: entries.entries, cache_age_ms: 0 });
+			},
+			Err(err @ WalkError::InvalidData { .. }) => {
+				// Scan-wide failure independent of any caller's heartbeat;
+				// every follower would hit it too. Share it once instead of
+				// sending each of them into a duplicate walk.
+				flight.finish(FlightOutcome::Shared(Err(err.clone())));
+				return Err(err);
+			},
+			Err(err) => {
+				// Never share this failure: it comes from the leader's own
+				// heartbeat (user cancel, per-call timeout), which unrelated
+				// followers must not inherit. Wake them to rerun the walk with
+				// their own heartbeats instead.
+				flight.finish(FlightOutcome::Rerun);
+				return Err(err);
+			},
+		}
 	}
 }
 
@@ -541,12 +623,12 @@ mod tests {
 			Arc,
 			atomic::{AtomicU64, Ordering},
 		},
-		time::{Duration, SystemTime, UNIX_EPOCH},
+		time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 	};
 
 	#[cfg(unix)]
 	use super::classify_file_type;
-	use crate::{CollectedEntry, FileType};
+	use crate::{CollectedEntry, FileType, WalkError};
 
 	static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -843,7 +925,6 @@ mod tests {
 		for index in 0..64 {
 			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
 		}
-		super::invalidate_all();
 
 		let mut options = scan_options(true, true, crate::WalkDetail::Full);
 		options.cache = true;
@@ -898,6 +979,38 @@ mod tests {
 		options
 	}
 
+	/// Opens an armed [`super::TEST_PAUSE`] gate on drop, even on panic.
+	struct PauseDisarm(Arc<(super::Mutex<bool>, super::Condvar)>);
+
+	impl Drop for PauseDisarm {
+		fn drop(&mut self) {
+			let (flag, arrived) = &*self.0;
+			*flag.lock() = true;
+			arrived.notify_all();
+		}
+	}
+
+	fn arm_pause(point: &'static str, root: &Path) -> PauseDisarm {
+		let gate = Arc::new((super::Mutex::new(false), super::Condvar::new()));
+		*super::TEST_PAUSE.lock() = Some((point, root.to_path_buf(), gate.clone()));
+		PauseDisarm(gate)
+	}
+
+	/// Blocks the first heartbeat call until `release` fires, then succeeds.
+	/// Lets a test park a leader mid-walk and let it finish cleanly after.
+	fn staged_heartbeat(
+		release: std::sync::mpsc::Receiver<()>,
+	) -> impl Fn() -> std::result::Result<(), String> + Send + 'static {
+		let armed = Arc::new(super::Mutex::new(Some(release)));
+		move || {
+			let staged = armed.lock().take();
+			if let Some(receiver) = staged {
+				let _ = receiver.recv();
+			}
+			Ok(())
+		}
+	}
+
 	fn wait_for_flight(key: &super::CacheKey) -> Arc<super::ScanFlight> {
 		for _ in 0..400 {
 			let registered = super::IN_FLIGHT_SCANS.lock().get(key).cloned();
@@ -917,11 +1030,9 @@ mod tests {
 		for index in 0..8 {
 			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
 		}
-		super::invalidate_all();
 
 		let options = cold_scan_options();
 		let key = super::cache_key(dir.path(), options);
-
 		let (gate_tx, gate_rx) = mpsc::channel::<()>();
 		let gate = Arc::new(std::sync::Mutex::new(Some(gate_rx)));
 		let leader_root = dir.path().to_path_buf();
@@ -991,7 +1102,6 @@ mod tests {
 		for index in 0..8 {
 			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
 		}
-		super::invalidate_all();
 
 		let options = cold_scan_options();
 		let key = super::cache_key(dir.path(), options);
@@ -1044,5 +1154,295 @@ mod tests {
 			.copied()
 			.unwrap_or(0);
 		assert_eq!(walks, 1, "the follower bailed before running any walk of its own");
+	}
+
+	/// Regression (A): after a cancelled leader, rerunning followers must
+	/// re-enter coordinated acquisition — exactly one new leader walks, the
+	/// rest share its cached result, and later callers must hit that cache.
+	#[test]
+	fn rerun_followers_reenter_coordinated_acquisition() {
+		use std::sync::mpsc;
+
+		let dir = TempDirGuard::new();
+		for index in 0..8 {
+			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
+		}
+
+		let options = cold_scan_options();
+		let key = super::cache_key(dir.path(), options);
+
+		let (gate_tx, gate_rx) = mpsc::channel::<()>();
+		let gate = Arc::new(std::sync::Mutex::new(Some(gate_rx)));
+		let leader_root = dir.path().to_path_buf();
+		let leader_options = cold_scan_options();
+		let leader_handle = std::thread::spawn(move || {
+			super::collect_entries(
+				&leader_root,
+				leader_options,
+				gated_heartbeat(gate, "leader cancelled"),
+			)
+		});
+		wait_for_flight(&key);
+
+		// Park two followers inside wait_for_leader so both receive the
+		// cancelled leader's Rerun broadcast while it is still registered.
+		let mut follower_polls = Vec::new();
+		let mut follower_handles = Vec::new();
+		for _ in 0..2 {
+			let polls = Arc::new(AtomicU64::new(0));
+			let poll_counter = polls.clone();
+			follower_polls.push(polls);
+			let follower_root = dir.path().to_path_buf();
+			let follower_options = cold_scan_options();
+			follower_handles.push(std::thread::spawn(move || {
+				let heartbeat = move || -> std::result::Result<(), String> {
+					poll_counter.fetch_add(1, Ordering::Relaxed);
+					Ok(())
+				};
+				super::collect_entries(&follower_root, follower_options, heartbeat)
+			}));
+		}
+		for polls in &follower_polls {
+			for _ in 0..400 {
+				if polls.load(Ordering::Relaxed) > 0 {
+					break;
+				}
+				std::thread::sleep(Duration::from_millis(5));
+			}
+			assert!(polls.load(Ordering::Relaxed) > 0, "follower never joined the flight");
+		}
+
+		gate_tx.send(()).expect("release leader");
+		leader_handle
+			.join()
+			.unwrap()
+			.expect_err("leader should surface its own cancel");
+
+		for handle in follower_handles {
+			let entries = handle
+				.join()
+				.unwrap()
+				.expect("rerunning follower must complete successfully");
+			assert_eq!(entries.entries.len(), 8);
+		}
+
+		// The coordinated rerun must publish its snapshot: a later caller
+		// resolves from cache instead of scanning a third time.
+		let later =
+			super::collect_entries(dir.path(), cold_scan_options(), ok_heartbeat).expect("later scan");
+		assert_eq!(later.entries.len(), 8);
+
+		let walks = super::TEST_WALK_COUNTS
+			.lock()
+			.get(dir.path())
+			.copied()
+			.unwrap_or(0);
+		assert_eq!(walks, 2, "cancelled leader plus exactly one shared rerun must total two walks");
+	}
+
+	/// Regression (B): an unskippable scan-wide failure is shared once with
+	/// blocked followers instead of being retried once per caller.
+	#[test]
+	fn scan_wide_failure_is_shared_with_waiting_followers() {
+		let dir = TempDirGuard::new();
+		let missing = dir.path().join("never-created");
+
+		// Hold the leader between flight registration and the walk so the
+		// followers below are provably blocked on its flight before it fails.
+		let disarm = arm_pause("before-walk", &missing);
+		let arrived_before = super::TEST_PAUSE_ARRIVALS.load(Ordering::Relaxed);
+
+		let leader_root = missing.clone();
+		let leader_handle = std::thread::spawn(move || {
+			super::collect_entries(&leader_root, cold_scan_options(), ok_heartbeat)
+		});
+
+		for _ in 0..400 {
+			if super::TEST_PAUSE_ARRIVALS.load(Ordering::Relaxed) > arrived_before {
+				break;
+			}
+			std::thread::sleep(Duration::from_millis(5));
+		}
+		assert!(
+			super::TEST_PAUSE_ARRIVALS.load(Ordering::Relaxed) > arrived_before,
+			"leader never reached the pre-walk pause"
+		);
+
+		let mut followers = Vec::new();
+		for _ in 0..3 {
+			let polls = Arc::new(AtomicU64::new(0));
+			let poll_counter = polls.clone();
+			let follower_root = missing.clone();
+			followers.push((
+				polls,
+				std::thread::spawn(move || {
+					let heartbeat = move || -> std::result::Result<(), String> {
+						poll_counter.fetch_add(1, Ordering::Relaxed);
+						Ok(())
+					};
+					super::collect_entries(&follower_root, cold_scan_options(), heartbeat)
+				}),
+			));
+		}
+		for (polls, _) in &followers {
+			for _ in 0..400 {
+				if polls.load(Ordering::Relaxed) > 0 {
+					break;
+				}
+				std::thread::sleep(Duration::from_millis(5));
+			}
+			assert!(polls.load(Ordering::Relaxed) > 0, "follower never joined the flight");
+		}
+		drop(disarm);
+
+		leader_handle
+			.join()
+			.unwrap()
+			.expect_err("missing root must fail the leader with a scan-wide InvalidData error");
+		for (_, handle) in followers {
+			let result = handle.join().unwrap();
+			assert!(
+				matches!(result, Err(WalkError::InvalidData { .. })),
+				"follower must inherit the shared InvalidData failure, got {result:?}"
+			);
+		}
+
+		let walks = super::TEST_WALK_COUNTS
+			.lock()
+			.get(&missing)
+			.copied()
+			.unwrap_or(0);
+		assert_eq!(
+			walks, 1,
+			"one unskippable failure must be shared with followers, not retried per caller"
+		);
+	}
+
+	/// Regression (E): a caller suspended in the miss-to-leadership window
+	/// while another scan completes must serve the fresh snapshot as leader
+	/// instead of walking over it.
+	#[test]
+	fn late_leader_serves_snapshot_completed_during_toctou_window() {
+		let dir = TempDirGuard::new();
+		for index in 0..4 {
+			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
+		}
+
+		let disarm = arm_pause("before-join", dir.path());
+		let arrived_before = super::TEST_PAUSE_ARRIVALS.load(Ordering::Relaxed);
+
+		let caller_root = dir.path().to_path_buf();
+		let caller_handle = std::thread::spawn(move || {
+			super::collect_entries(&caller_root, cold_scan_options(), ok_heartbeat)
+		});
+
+		for _ in 0..400 {
+			if super::TEST_PAUSE_ARRIVALS.load(Ordering::Relaxed) > arrived_before {
+				break;
+			}
+			std::thread::sleep(Duration::from_millis(5));
+		}
+		assert!(
+			super::TEST_PAUSE_ARRIVALS.load(Ordering::Relaxed) > arrived_before,
+			"caller never entered the miss-to-leadership window"
+		);
+
+		// Another caller completes the entire scan — cache insert, flight
+		// deregistration included — while the first caller is suspended.
+		let raced = super::collect_entries(dir.path(), cold_scan_options(), ok_heartbeat)
+			.expect("racing scan");
+		assert_eq!(raced.entries.len(), 4);
+
+		// Resume the suspended caller: it now acquires leadership of a fresh
+		// flight and must recheck the cache before walking.
+		drop(disarm);
+		let entries = caller_handle
+			.join()
+			.unwrap()
+			.expect("suspended caller should succeed");
+		assert_eq!(entries.entries.len(), 4);
+
+		let walks = super::TEST_WALK_COUNTS
+			.lock()
+			.get(dir.path())
+			.copied()
+			.unwrap_or(0);
+		assert_eq!(walks, 1, "caller that lost the toctou race must not walk again");
+	}
+
+	/// Regression (F): a follower whose heartbeat was running when the leader
+	/// published must return immediately, not sleep out another poll interval.
+	#[test]
+	fn follower_skips_poll_sleep_when_outcome_lands_during_heartbeat() {
+		use std::sync::mpsc;
+
+		let dir = TempDirGuard::new();
+		for index in 0..4 {
+			fs::write(dir.path().join(format!("file-{index}.txt")), "payload").unwrap();
+		}
+
+		let options = cold_scan_options();
+		let key = super::cache_key(dir.path(), options);
+
+		// Leader parks on its first heartbeat until we release it, then
+		// finishes its walk successfully and publishes the shared outcome.
+		let (gate_tx, gate_rx) = mpsc::channel::<()>();
+		let leader_root = dir.path().to_path_buf();
+		let leader_handle = std::thread::spawn(move || {
+			super::collect_entries(&leader_root, cold_scan_options(), staged_heartbeat(gate_rx))
+		});
+		wait_for_flight(&key);
+
+		// Follower parks inside its own heartbeat poll after finding no
+		// cached snapshot, exactly when the outcome lands.
+		let (parked_tx, parked_rx) = mpsc::channel::<()>();
+		let (release_tx, release_rx) = mpsc::channel::<()>();
+		let release_rx = std::sync::Mutex::new(release_rx);
+		let follower_root = dir.path().to_path_buf();
+		let follower_handle = std::thread::spawn(move || {
+			let heartbeat = move || -> std::result::Result<(), String> {
+				let _ = parked_tx.send(());
+				release_rx
+					.lock()
+					.expect("release lock")
+					.recv()
+					.map_err(|_| "release channel closed".to_string())?;
+				Ok(())
+			};
+			super::collect_entries(&follower_root, cold_scan_options(), heartbeat)
+		});
+		parked_rx
+			.recv_timeout(Duration::from_secs(5))
+			.expect("follower never parked in its heartbeat");
+
+		// Complete the leader and wait for the published outcome to be
+		// observable before releasing the still-parked follower.
+		gate_tx.send(()).expect("release leader");
+		let leader_entries = leader_handle
+			.join()
+			.unwrap()
+			.expect("leader should succeed");
+		assert_eq!(leader_entries.entries.len(), 4);
+		for _ in 0..400 {
+			if super::SCAN_CACHE.contains_key(&key) {
+				break;
+			}
+			std::thread::sleep(Duration::from_millis(5));
+		}
+		assert!(super::SCAN_CACHE.contains_key(&key), "leader never published the snapshot");
+
+		let started = Instant::now();
+		release_tx.send(()).expect("release follower");
+		let entries = follower_handle
+			.join()
+			.unwrap()
+			.expect("follower should reuse the shared result");
+		assert_eq!(entries.entries.len(), 4);
+
+		let elapsed = started.elapsed();
+		assert!(
+			elapsed < Duration::from_millis(40),
+			"follower slept out a 50ms poll interval despite a published outcome: {elapsed:?}"
+		);
 	}
 }

--- a/crates/pi-walker/src/lib.rs
+++ b/crates/pi-walker/src/lib.rs
@@ -2156,7 +2156,7 @@ const fn walk_decision_to_control(decision: WalkDecision) -> WalkControl {
 }
 
 /// Error returned by native traversal.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum WalkError<E> {
 	/// A caller-supplied heartbeat or visitor returned an error.
 	Interrupted(E),

--- a/docs/fs-scan-cache-architecture.md
+++ b/docs/fs-scan-cache-architecture.md
@@ -33,6 +33,8 @@ High-level `WalkRequest` filters, ranking, result limits, empty-recheck policy, 
 
 Collected entries contain normalized forward-slash relative paths and file types. `WalkDetail::Full` additionally requests mtime and regular-file size. Cancellation is delivered through the caller-supplied heartbeat.
 
+Cached scans of the same key are single-flight: the first caller (the leader) performs the walk outside all locks while later callers either serve the existing snapshot — even an expired one — or block on the leader when no snapshot exists yet. Blocked followers poll their own heartbeat, so their own cancellation or timeout ends their wait with their own `Interrupted` error rather than waiting out the leader's walk. A leader that fails on its own heartbeat does not propagate that error to followers; followers rerun the walk themselves, each bounded by its own heartbeat.
+
 Traversal-adjacent parallel work uses a shared Rayon pool:
 
 - `PI_WALK_WORKERS` defaults to `4`
@@ -52,7 +54,7 @@ With caching enabled:
 
 - TTL `0` bypasses cache and returns a fresh scan with `cache_age_ms = 0`.
 - A hit younger than TTL clones the stored entries and reports its age.
-- An expired entry is removed and replaced by a fresh scan.
+- An expired entry stays in place and is served stale-while-revalidate: the caller that triggers refresh walks fresh, while other concurrent callers keep receiving the expired snapshot until a successful scan replaces it. A failed revalidation likewise leaves the stale snapshot cached for later callers.
 - After insertion, entries above the configured maximum are evicted oldest-first by creation time.
 
 With caching disabled, collection scans fresh and neither reads nor populates the shared cache. It does not evict an existing cached entry for the same key.


### PR DESCRIPTION
## Summary
`get_or_scan` (crates/pi-walker/src/cache.rs) let N concurrent cold-start callers each run the full directory walk, and every TTL expiry triggered duplicate-walk bursts (glob+grep+fuzzy startup fan-out). An in-flight map now guarantees one leader walks while followers share the flight (blocking on Mutex+Condvar when uncached; stale-while-revalidate when racing a TTL-expired entry — documented loosening consistent with TTL semantics).

## Behavior
- Leader walks outside all locks; Drop guard deregisters + wakes followers on success OR error.
- Followers inherit the leader's result including errors (review-found heartbeat-error inheritance fixed; followers regained deadline/cancel handling).
- Errors publish to current followers only; subsequent callers start a fresh flight.

## Benchmark stats (base: `main` @ `a7e19be810`; branch predates the v18 rebase — no textual conflict, Rust sources in its scope unchanged by v18)

**Environment**: Ryzen 9 7950X3D (32 threads), CachyOS Linux, Bun 1.3.14, nightly-2026-08-08 (Rust). Sequential runs, ±5–10% noise.

16 barrier-synced threads racing `get_or_scan` on a cold temp root:

| Scenario | Before | After |
|---|---|---|
| ~2k-file root, wall time (median of 21 rounds) | 7.6ms | 7.5ms (parity) |
| ~20k files | 82.7ms | 84.3ms (parity) |
| process CPU, 21 rounds | 0.33s usr / 2.38s sys | 0.32s usr / 2.52s sys |

Honest reading: **wall-clock parity** — parallel walkers were already hiding the duplicated work. The win is deduplication: 16 racing callers execute exactly ONE underlying walk (test-enforced: `sixteen_threads_racing_cold_root_execute_one_...`), eliminating duplicated walk CPU and syscalls under startup bursts; follower CPU now waits on a Condvar instead of re-walking.

Related context from the repo sweep: the sibling PR #9387 found the same pool's `DEFAULT_WALK_WORKERS = 4` was the root cause of native grep's large-scan regression — that PR changes the pool width; this one changes concurrency *deduplication*. They are independent and compose.

## Tests
Full pi-walker suite green (31 lib + 7 integration, incl. the 16-thread dedup test); clippy zero warnings on touched code; `docs/fs-scan-cache-architecture.md` updated to match new expiry/sharing semantics.

## Trade-off (deliberate, documented)
TTL-expired entries serve stale to concurrent callers until refresh completes; failed revalidation keeps serving stale instead of uncaching.

---

## Review response (roboomp + codex-connector findings, all addressed)
- **Rerun bypassed flight+cache** → `get_or_scan` rewritten as retry loop; exactly one rerunner re-enters coordinated acquisition.
- **All errors mapped to Rerun** → `Interrupted` retries; scan-wide `InvalidData` published to followers like success-path errors.
- **TOCTOU redundant leadership walk** → cache rechecked inside the flight after leadership grant.
- **Lost notification (50ms follower stall)** → outcome predicate rechecked after lock reacquisition.
- **Global cache clears in tests** → removed; nanosecond-unique roots per crate pattern.
- **Core one-walk nondeterminism** (reviewer observed walks=3): root-caused to the TOCTOU; barrier-released test now deterministic — independently verified **10/10 consecutive passes** plus full crate suite green (35 lib + 7 integration).