### PR TITLE
fix(ai): normalize string systemPrompt in glyph codec

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed glyph tokenization crashing with `entries is not a function` when `Context.systemPrompt` arrived as a bare string (e.g. from legacy earendil-works extensions); it is now normalized to an array before iterating, matching every provider path ([#9384](https://github.com/can1357/oh-my-pi/issues/9384)).
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/ai/src/utils/glyph-codec.ts
+++ b/packages/ai/src/utils/glyph-codec.ts
@@ -62,7 +62,11 @@ export function applyGlyphCodec(context: Context): GlyphCodec {
 	let tools = context.tools;
 	let messages = context.messages;
 
-	const sourceSystemPrompt = context.systemPrompt;
+	// Context.systemPrompt is typed string[], but legacy (earendil-works)
+	// extensions pass a bare string; provider paths tolerate it via
+	// normalizeSystemPrompts, so normalize here before iterating.
+	const rawSystemPrompt = context.systemPrompt;
+	const sourceSystemPrompt = typeof rawSystemPrompt === "string" ? [rawSystemPrompt] : rawSystemPrompt;
 	if (sourceSystemPrompt !== undefined) {
 		let output = sourceSystemPrompt;
 		for (const [index, prompt] of sourceSystemPrompt.entries()) {

--- a/packages/ai/test/glyph-codec.test.ts
+++ b/packages/ai/test/glyph-codec.test.ts
@@ -117,6 +117,19 @@ describe("applyGlyphCodec", () => {
 		expect(JSON.stringify(codec.context)).not.toContain("<glyph-tokens>");
 	});
 
+	it("normalizes a bare-string systemPrompt from legacy extensions instead of crashing", () => {
+		const glyph = "\ue0a0";
+		// legacy earendil-works extensions type Context.systemPrompt as `string`
+		const context = { systemPrompt: `classify ${glyph}`, messages: [] } as unknown as Context;
+		const codec = applyGlyphCodec(context);
+
+		expect(codec.active).toBe(true);
+		expect(Array.isArray(codec.context.systemPrompt)).toBe(true);
+		const [encoded] = codec.context.systemPrompt ?? [];
+		expect(encoded).toContain("⟦Ue0a0⟧");
+		expect(decodeGlyphText(encoded ?? "")).toContain(`classify ${glyph}`);
+	});
+
 	it("makes a branded reapplication inert", () => {
 		const first = applyGlyphCodec({ messages: [{ role: "user", content: "\ue0a0", timestamp: 1 }] });
 		const second = applyGlyphCodec(first.context);


### PR DESCRIPTION
## Repro
Calling `applyGlyphCodec` on a `Context` whose `systemPrompt` is a bare string throws with a Claude (glyph-tokenizing) model. Reachable from legacy earendil-works extensions where `Context.systemPrompt` is typed `string` — e.g. the pi-automode guardrail extension's fast classifier calls `complete(model, { systemPrompt: "...", messages })`, the throw is caught, and auto mode fails closed, blocking every tool call.

```
bun -e 'applyGlyphCodec({ systemPrompt: "..." /* string */, messages: [] })'
# TypeError: sourceSystemPrompt.entries is not a function
```

## Cause
`applyGlyphCodec` (`packages/ai/src/utils/glyph-codec.ts`) read `context.systemPrompt` and assumed `string[]`, iterating with `.entries()` and index-assigning. A bare string passes the `!== undefined` guard, then `.entries()` fails. Every provider path normalizes first via `normalizeSystemPrompts` (`packages/ai/src/utils.ts`), which accepts `string | string[]`; glyph-codec was the only consumer that assumed the array shape.

## Fix
- In `applyGlyphCodec`, normalize `context.systemPrompt` to an array (`typeof === "string" ? [s] : s`) before iterating, so the branded context always carries the array shape. No behavior change for callers already passing `string[]`.
- Added a regression test in `packages/ai/test/glyph-codec.test.ts` asserting a bare-string `systemPrompt` is glyph-encoded and normalized to an array instead of crashing.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test test/glyph-codec.test.ts` (in `packages/ai`) → 12 pass, 0 fail. Manually confirmed the pre-fix throw and post-fix normalization via the same entrypoint.

Fixes #9384