### PR TITLE
fix(cursor): keep MCP string hashes as strings

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor MCP history replay aborting when a string argument looks like a JSON number (`1e234567` → `Infinity`). Hash-like tokens stay strings; leftover non-finite values encode as null instead of failing the turn.
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -3153,6 +3153,12 @@ function parseToolArgsJson(text: string): unknown {
 	if (!trimmed) {
 		return text;
 	}
+	// Only unwrap objects/arrays/quoted strings. Bare tokens such as hex hashes
+	// ("57785654", "1e234567") are valid JSON numbers — the latter is Infinity.
+	const start = trimmed[0];
+	if (start !== "{" && start !== "[" && start !== '"') {
+		return text;
+	}
 	try {
 		return parseJsonWithRepair<unknown>(trimmed);
 	} catch {
@@ -3165,6 +3171,9 @@ function decodeMcpArgValue(value: Uint8Array): unknown {
 		const jsonValue = decodeJsonValue(value);
 		if (typeof jsonValue === "string") {
 			return parseToolArgsJson(jsonValue);
+		}
+		if (typeof jsonValue === "number" && !Number.isFinite(jsonValue)) {
+			return null;
 		}
 		return jsonValue;
 	} catch {}
@@ -4771,10 +4780,15 @@ function encodeCursorMcpArguments(toolCall: ToolCall): Record<string, Uint8Array
 	for (const name in toolCall.arguments) {
 		const value = toolCall.arguments[name];
 		if (value === undefined) continue;
-		if (!isJsonValue(value)) {
-			throw new AIError.ValidationError(`Cursor tool argument ${toolCall.name}.${name} is not JSON-serializable`);
+		if (isJsonValue(value)) {
+			encoded[name] = encodeJsonValue(value);
+			continue;
 		}
-		encoded[name] = encodeJsonValue(value);
+		// Non-finite numbers (hash strings re-parsed as Infinity) used to abort
+		// the whole Cursor turn, including history replay and compaction.
+		if (typeof value === "number") {
+			encoded[name] = encodeJsonValue(null);
+		}
 	}
 	return encoded;
 }

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -666,6 +666,35 @@ describe("Cursor history encoding", () => {
 		]);
 	});
 
+	it("encodes non-finite MCP args instead of aborting history replay (#9394)", () => {
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Edit.", timestamp: 1 },
+			cursorAssistant(
+				"cursor-composer-2.5",
+				[
+					{
+						type: "toolCall",
+						id: "call-edit",
+						name: "mcp__example",
+						arguments: { expectedHash: Number.POSITIVE_INFINITY },
+					},
+				],
+				2,
+				"toolUse",
+			),
+			{
+				role: "toolResult",
+				toolCallId: "call-edit",
+				toolName: "mcp__example",
+				content: [{ type: "text", text: "ok" }],
+				isError: false,
+				timestamp: 3,
+			},
+			{ role: "user", content: "Continue.", timestamp: 4 },
+		];
+		expect(() => buildCursorHistoryForTest(messages)).not.toThrow();
+	});
+
 	it("preserves same-model K3 thinking and paired tool structure in request history", () => {
 		const messages: Context["messages"] = [
 			{ role: "user", content: "Inspect package.json", timestamp: 1 },

--- a/packages/ai/test/cursor-streaming-args.test.ts
+++ b/packages/ai/test/cursor-streaming-args.test.ts
@@ -10,6 +10,7 @@ import {
 import type { AssistantMessage, AssistantMessageEvent } from "@oh-my-pi/pi-ai/types";
 import { getStreamingPartialJson, kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { encodeJsonValue } from "@oh-my-pi/pi-catalog/discovery/protobuf";
 
 interface Harness {
 	output: AssistantMessage;
@@ -358,6 +359,19 @@ describe("processInteractionUpdate args_text_delta handling", () => {
 			tasks: [{ assignment: "do A" }, { assignment: "do B" }],
 			context: "ctx",
 		});
+	});
+
+	it("does not parse hex-like MCP string args as JSON numbers (#9394)", () => {
+		const h = newHarness();
+		startMcpToolCall(h, "mcp__example");
+		completeMcpToolCall(h, {
+			expectedHash: encodeJsonValue("1e234567"),
+			edits: encodeJsonValue('{"a":1}'),
+		});
+		const finalBlock = h.output.content[0];
+		expect(finalBlock?.type).toBe("toolCall");
+		if (finalBlock?.type !== "toolCall") throw new Error("expected toolCall block");
+		expect(finalBlock.arguments).toEqual({ expectedHash: "1e234567", edits: { a: 1 } });
 	});
 });
 


### PR DESCRIPTION
## What

Stop Cursor MCP history replay from throwing `not JSON-serializable` when a string tool arg looks like a JSON number.

I reviewed the full diff; this is the same path that killed the live Cursor turn (and then handoff) once a hex `expectedHash` such as `1e234567` had been parsed as `Infinity`.

## Why

Fixes #9394.

`decodeMcpArgValue` re-parsed every protobuf string with `JSON.parse`. Tokens like `1e234567` become `Infinity`. The next `encodeCursorMcpArguments` then aborted the whole request, including compaction.

## Testing

- Reproduced on a live `cursor-agent` session: first turn completed, the next turn and handoff failed with `Cursor tool argument mcp__ecoport_scripts.expectedHash is not JSON-serializable`. Session JSONL had `expectedHash: null` (`JSON.stringify(Infinity)`).
- Confirmed `JSON.parse("1e234567") === Infinity` and that skipping bare-token unwrap leaves the hash a string.
- Added a decode test (`1e234567` stays a string; object unwrap still works) and an encode test (`Infinity` no longer throws from `buildCursorHistoryForTest`).
- `packages/ai` `tsgo --noEmit` passes. Full `bun test` for these Cursor files needs the 18.0 natives addon, which this machine cannot build (`xutf` requires nightly).

---

- [x] `bun check` passes (`packages/ai` typecheck; biome on the touched files)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
