### PR TITLE
fix(ai): preserve Cursor MCP arguments during replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor sessions aborting on the next turn or during compaction after MCP tools returned numeric-looking string arguments ([#9394](https://github.com/can1357/oh-my-pi/issues/9394)).
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -3164,7 +3164,8 @@ function decodeMcpArgValue(value: Uint8Array): unknown {
 	try {
 		const jsonValue = decodeJsonValue(value);
 		if (typeof jsonValue === "string") {
-			return parseToolArgsJson(jsonValue);
+			const first = jsonValue.trimStart()[0];
+			return first === "{" || first === "[" || first === '"' ? parseToolArgsJson(jsonValue) : jsonValue;
 		}
 		return jsonValue;
 	} catch {}
@@ -4482,6 +4483,17 @@ export function buildCursorRequestContextRules(systemPrompt: readonly string[] |
  */
 const CURSOR_NATIVE_TOOL_NAMES = new Set(["bash", "read", "write", "delete", "ls", "grep", "todo"]);
 
+function isJsonValue(value: unknown): value is JsonValue {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(isJsonValue);
+	if (!isRecord(value)) return false;
+	for (const key in value) {
+		if (!isJsonValue(value[key])) return false;
+	}
+	return true;
+}
+
 export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
 	if (!tools || tools.length === 0) {
 		return [];
@@ -4621,7 +4633,7 @@ function buildCursorAssistantContent(
 				type: "tool-call",
 				toolCallId: item.id,
 				toolName: item.name,
-				args: item.arguments,
+				args: normalizeCursorMcpArguments(item.arguments),
 			});
 		}
 	}
@@ -4755,26 +4767,44 @@ function buildRootPromptMessagesJson(
 	return entries;
 }
 
-function isJsonValue(value: unknown): value is JsonValue {
-	if (value === null || typeof value === "string" || typeof value === "boolean") return true;
-	if (typeof value === "number") return Number.isFinite(value);
-	if (Array.isArray(value)) return value.every(isJsonValue);
-	if (!isRecord(value)) return false;
-	for (const key in value) {
-		if (!isJsonValue(value[key])) return false;
+function normalizeCursorMcpArgument(value: unknown, seen: Set<object>): JsonValue | undefined {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+	if (typeof value === "number") return Number.isFinite(value) ? value : null;
+	if (typeof value !== "object") return undefined;
+	if (seen.has(value)) return undefined;
+
+	seen.add(value);
+	try {
+		if (Array.isArray(value)) {
+			return value.map(item => normalizeCursorMcpArgument(item, seen) ?? null);
+		}
+		if (!isRecord(value)) return undefined;
+		const normalized: Record<string, JsonValue> = {};
+		for (const key in value) {
+			const normalizedItem = normalizeCursorMcpArgument(value[key], seen);
+			if (normalizedItem !== undefined) normalized[key] = normalizedItem;
+		}
+		return normalized;
+	} finally {
+		seen.delete(value);
 	}
-	return true;
+}
+
+function normalizeCursorMcpArguments(args: Record<string, unknown>): Record<string, JsonValue> {
+	const normalized: Record<string, JsonValue> = {};
+	const seen = new Set<object>();
+	for (const name in args) {
+		const normalizedValue = normalizeCursorMcpArgument(args[name], seen);
+		if (normalizedValue !== undefined) normalized[name] = normalizedValue;
+	}
+	return normalized;
 }
 
 function encodeCursorMcpArguments(toolCall: ToolCall): Record<string, Uint8Array> {
 	const encoded: Record<string, Uint8Array> = {};
-	for (const name in toolCall.arguments) {
-		const value = toolCall.arguments[name];
-		if (value === undefined) continue;
-		if (!isJsonValue(value)) {
-			throw new AIError.ValidationError(`Cursor tool argument ${toolCall.name}.${name} is not JSON-serializable`);
-		}
-		encoded[name] = encodeJsonValue(value);
+	const normalized = normalizeCursorMcpArguments(toolCall.arguments);
+	for (const name in normalized) {
+		encoded[name] = encodeJsonValue(normalized[name]);
 	}
 	return encoded;
 }

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4779,7 +4779,7 @@ function normalizeCursorMcpArgument(value: unknown, seen: Set<object>): JsonValu
 			return value.map(item => normalizeCursorMcpArgument(item, seen) ?? null);
 		}
 		if (!isRecord(value)) return undefined;
-		const normalized: Record<string, JsonValue> = {};
+		const normalized: Record<string, JsonValue> = Object.create(null);
 		for (const key in value) {
 			const normalizedItem = normalizeCursorMcpArgument(value[key], seen);
 			if (normalizedItem !== undefined) normalized[key] = normalizedItem;
@@ -4791,7 +4791,7 @@ function normalizeCursorMcpArgument(value: unknown, seen: Set<object>): JsonValu
 }
 
 function normalizeCursorMcpArguments(args: Record<string, unknown>): Record<string, JsonValue> {
-	const normalized: Record<string, JsonValue> = {};
+	const normalized: Record<string, JsonValue> = Object.create(null);
 	const seen = new Set<object>();
 	for (const name in args) {
 		const normalizedValue = normalizeCursorMcpArgument(args[name], seen);

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4801,7 +4801,7 @@ function normalizeCursorMcpArguments(args: Record<string, unknown>): Record<stri
 }
 
 function encodeCursorMcpArguments(toolCall: ToolCall): Record<string, Uint8Array> {
-	const encoded: Record<string, Uint8Array> = {};
+	const encoded: Record<string, Uint8Array> = Object.create(null);
 	const normalized = normalizeCursorMcpArguments(toolCall.arguments);
 	for (const name in normalized) {
 		encoded[name] = encodeJsonValue(normalized[name]);

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4781,6 +4781,7 @@ function normalizeCursorMcpArgument(value: unknown, seen: Set<object>): JsonValu
 		if (!isRecord(value)) return undefined;
 		const normalized: Record<string, JsonValue> = Object.create(null);
 		for (const key in value) {
+			if (!Object.hasOwn(value, key)) continue;
 			const normalizedItem = normalizeCursorMcpArgument(value[key], seen);
 			if (normalizedItem !== undefined) normalized[key] = normalizedItem;
 		}
@@ -4794,6 +4795,7 @@ function normalizeCursorMcpArguments(args: Record<string, unknown>): Record<stri
 	const normalized: Record<string, JsonValue> = Object.create(null);
 	const seen = new Set<object>();
 	for (const name in args) {
+		if (!Object.hasOwn(args, name)) continue;
 		const normalizedValue = normalizeCursorMcpArgument(args[name], seen);
 		if (normalizedValue !== undefined) normalized[name] = normalizedValue;
 	}

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -708,6 +708,32 @@ describe("Cursor history encoding", () => {
 		});
 	});
 
+	it("keeps a __proto__ argument key as an own property during replay", () => {
+		// A JSON.parse'd object carries `__proto__` as an own enumerable data
+		// key. Building the normalized record with a plain `{}` would route the
+		// assignment through the prototype setter and drop the key.
+		const pollutedArguments = JSON.parse('{"__proto__":{"polluted":true},"safe":"ok"}') as Record<string, unknown>;
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Run the MCP tool.", timestamp: 1 },
+			cursorAssistant(
+				"cursor-composer-2.5",
+				[{ type: "toolCall", id: "call-mcp", name: "mcp__example_tool", arguments: pollutedArguments }],
+				2,
+				"toolUse",
+			),
+			{ role: "user", content: "Continue.", timestamp: 3 },
+		];
+
+		const history = buildCursorHistoryForTest(messages);
+		const assistant = history.rootPromptMessagesJson[1] as {
+			content: { args: Record<string, unknown> }[];
+		};
+		const args = assistant.content[0].args;
+		expect(Object.hasOwn(args, "__proto__")).toBe(true);
+		expect(args["__proto__"]).toEqual({ polluted: true });
+		expect(args["safe"]).toBe("ok");
+	});
+
 	it("preserves same-model K3 thinking and paired tool structure in request history", () => {
 		const messages: Context["messages"] = [
 			{ role: "user", content: "Inspect package.json", timestamp: 1 },

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -732,6 +732,15 @@ describe("Cursor history encoding", () => {
 		expect(Object.hasOwn(args, "__proto__")).toBe(true);
 		expect(args["__proto__"]).toEqual({ polluted: true });
 		expect(args["safe"]).toBe("ok");
+
+		// The protobuf argument map must carry the same own keys — a plain `{}`
+		// map would retarget its prototype to the encoded bytes and replay
+		// inherited numeric indices instead of `__proto__`.
+		const step = history.turnStepMessagesJson[0][0] as {
+			toolCall: { mcpToolCall: { args: { args: Record<string, string> } } };
+		};
+		const encodedArgs = step.toolCall.mcpToolCall.args.args;
+		expect(Object.keys(encodedArgs).sort()).toEqual(["__proto__", "safe"]);
 	});
 
 	it("preserves same-model K3 thinking and paired tool structure in request history", () => {

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -33,7 +33,7 @@ import {
 	ReadResultSchema,
 	ReadSuccessSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
-import { create } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+import { create, encodeJsonValue } from "@oh-my-pi/pi-catalog/discovery/protobuf";
 import { logger } from "@oh-my-pi/pi-utils";
 
 afterEach(() => {
@@ -666,6 +666,48 @@ describe("Cursor history encoding", () => {
 		]);
 	});
 
+	it("normalizes non-JSON MCP arguments instead of aborting history replay", () => {
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Run the MCP tool.", timestamp: 1 },
+			cursorAssistant(
+				"cursor-composer-2.5",
+				[
+					{
+						type: "toolCall",
+						id: "call-mcp",
+						name: "mcp__example_tool",
+						arguments: {
+							expectedHash: Number.POSITIVE_INFINITY,
+							notANumber: Number.NaN,
+							counter: 10n,
+							nested: { value: Number.NEGATIVE_INFINITY, list: [1, 2n, Number.NaN] },
+						},
+					},
+				],
+				2,
+				"toolUse",
+			),
+			{ role: "user", content: "Continue.", timestamp: 3 },
+		];
+
+		const history = buildCursorHistoryForTest(messages);
+		expect(history.rootPromptMessagesJson[1]).toEqual({
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					toolCallId: "call-mcp",
+					toolName: "mcp__example_tool",
+					args: {
+						expectedHash: null,
+						notANumber: null,
+						nested: { value: null, list: [1, null, null] },
+					},
+				},
+			],
+		});
+	});
+
 	it("preserves same-model K3 thinking and paired tool structure in request history", () => {
 		const messages: Context["messages"] = [
 			{ role: "user", content: "Inspect package.json", timestamp: 1 },
@@ -1239,7 +1281,7 @@ describe("Cursor exec local-work tracking (issue #4593)", () => {
 		expect(written.length).toBe(1);
 	});
 
-	it("synthesizes an MCP call when the exec frame precedes its streamed block", async () => {
+	it("synthesizes an MCP call while preserving opaque string arguments", async () => {
 		const output = cursorAssistantMessage();
 		const stream = new AssistantMessageEventStream();
 		const state = newBlockState();
@@ -1257,7 +1299,16 @@ describe("Cursor exec local-work tracking (issue #4593)", () => {
 							toolName: "mcp__fixture_report",
 							toolCallId: "call-mcp-1",
 							providerIdentifier: "pi-agent",
-							args: { query: new TextEncoder().encode(JSON.stringify("latest chess news")) },
+							args: {
+								query: new TextEncoder().encode(JSON.stringify("latest chess news")),
+								numericHash: encodeJsonValue("57785654"),
+								exponentHash: encodeJsonValue("1e234567"),
+								booleanToken: encodeJsonValue("true"),
+								nullToken: encodeJsonValue("null"),
+								nested: encodeJsonValue('{"enabled":true}'),
+								array: encodeJsonValue("[1,2]"),
+								quoted: encodeJsonValue('"label"'),
+							},
 						}),
 					},
 				}),
@@ -1304,7 +1355,16 @@ describe("Cursor exec local-work tracking (issue #4593)", () => {
 			type: "toolCall",
 			id: "call-mcp-1",
 			name: "mcp__fixture_report",
-			arguments: { query: "latest chess news" },
+			arguments: {
+				query: "latest chess news",
+				numericHash: "57785654",
+				exponentHash: "1e234567",
+				booleanToken: "true",
+				nullToken: "null",
+				nested: { enabled: true },
+				array: [1, 2],
+				quoted: "label",
+			},
 		});
 		expect(output.content[1]).toMatchObject({ type: "text", text: "Final synthesized answer" });
 		expect(state.resolvedMcpToolCallIds.has("call-mcp-1")).toBe(true);

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -743,6 +743,51 @@ describe("Cursor history encoding", () => {
 		expect(Object.keys(encodedArgs).sort()).toEqual(["__proto__", "safe"]);
 	});
 
+	it("excludes enumerable prototype properties from MCP history replay", () => {
+		const nested: Record<string, unknown> = Object.create({ inheritedNested: "drop" });
+		nested.own = "keep";
+		const inheritedArguments: Record<string, unknown> = Object.create({ admin: true });
+		inheritedArguments.safe = "ok";
+		inheritedArguments.nested = nested;
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Run the MCP tool.", timestamp: 1 },
+			cursorAssistant(
+				"cursor-composer-2.5",
+				[{ type: "toolCall", id: "call-mcp", name: "mcp__example_tool", arguments: inheritedArguments }],
+				2,
+				"toolUse",
+			),
+			{ role: "user", content: "Continue.", timestamp: 3 },
+		];
+
+		const history = buildCursorHistoryForTest(messages);
+		expect(history.rootPromptMessagesJson[1]).toEqual({
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					toolCallId: "call-mcp",
+					toolName: "mcp__example_tool",
+					args: { safe: "ok", nested: { own: "keep" } },
+				},
+			],
+		});
+		expect(history.turnStepMessagesJson[0][0]).toEqual({
+			toolCall: {
+				toolCallId: "call-mcp",
+				mcpToolCall: {
+					args: {
+						name: "mcp__example_tool",
+						args: { safe: expect.any(String), nested: expect.any(String) },
+						toolCallId: "call-mcp",
+						providerIdentifier: "pi-agent",
+						toolName: "mcp__example_tool",
+					},
+				},
+			},
+		});
+	});
+
 	it("preserves same-model K3 thinking and paired tool structure in request history", () => {
 		const messages: Context["messages"] = [
 			{ role: "user", content: "Inspect package.json", timestamp: 1 },

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed protobuf map decoding corrupting entries when a key is `__proto__`, which dropped that argument and replayed spurious numeric arguments ([#9394](https://github.com/can1357/oh-my-pi/issues/9394)).
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/catalog/src/discovery/protobuf.ts
+++ b/packages/catalog/src/discovery/protobuf.ts
@@ -374,7 +374,7 @@ function compileMapField(desc: MapFieldDesc): CompiledField {
 	return {
 		number,
 		initDefault(message) {
-			Reflect.set(message, name, {});
+			Reflect.set(message, name, Object.create(null));
 		},
 		encode(message, writer) {
 			const input = Reflect.get(message, name);
@@ -425,7 +425,7 @@ function compileMapField(desc: MapFieldDesc): CompiledField {
 		toJson(message, output) {
 			const input = Reflect.get(message, name);
 			if (!isMessageObject(input)) return;
-			const mapOutput: { [key: string]: JsonValue } = {};
+			const mapOutput: { [key: string]: JsonValue } = Object.create(null);
 			for (const entryKey in input) {
 				mapOutput[entryKey] = valCodec.toJson(input[entryKey]);
 			}
@@ -685,7 +685,7 @@ function arrayField(message: object, name: string): unknown[] {
 function mapField(message: object, name: string): Record<string, unknown> {
 	const value = Reflect.get(message, name);
 	if (isRecord(value)) return value;
-	const map: Record<string, unknown> = {};
+	const map: Record<string, unknown> = Object.create(null);
 	Reflect.set(message, name, map);
 	return map;
 }

--- a/packages/catalog/test/protobuf.test.ts
+++ b/packages/catalog/test/protobuf.test.ts
@@ -38,6 +38,14 @@ const NodeSchema: MessageCodec<Node> = pb<Node>("test.Node", [
 	{ no: 2, name: "child", kind: "message", T: () => NodeSchema },
 ]);
 
+interface StringMap extends ProtoMessage {
+	entries: Record<string, string>;
+}
+
+const StringMapSchema = pb<StringMap>("test.StringMap", [
+	{ no: 1, name: "entries", kind: "map", K: "string", V: "string" },
+]);
+
 it("preserves selected oneofs and explicit optional defaults", () => {
 	const decoded = EnvelopeSchema.decode(
 		EnvelopeSchema.encode({ enabled: false, choice: { case: "text", value: "hello" } }),
@@ -65,4 +73,20 @@ it("resolves recursive static message descriptors on demand", () => {
 	);
 
 	expect(decoded.child?.child?.label).toBe("leaf");
+});
+
+it("round-trips a map whose key is __proto__ without prototype pollution", () => {
+	// An object-literal `__proto__` sets the prototype instead of an own key,
+	// so build the entries through JSON.parse to get a genuine own data key.
+	const entries = JSON.parse('{"__proto__":"polluted","safe":"ok"}') as Record<string, string>;
+	const decoded = StringMapSchema.decode(StringMapSchema.encode({ entries }));
+
+	expect(Object.getPrototypeOf(decoded.entries)).toBeNull();
+	expect(Object.keys(decoded.entries).sort()).toEqual(["__proto__", "safe"]);
+	expect(decoded.entries["__proto__"]).toBe("polluted");
+	expect(decoded.entries["safe"]).toBe("ok");
+
+	const json = StringMapSchema.toJson(decoded) as { entries: Record<string, string> };
+	expect(Object.keys(json.entries).sort()).toEqual(["__proto__", "safe"]);
+	expect(json.entries["__proto__"]).toBe("polluted");
 });


### PR DESCRIPTION
## Repro
A Cursor assistant history containing an MCP call with `arguments: { expectedHash: Number.POSITIVE_INFINITY }` made `buildCursorHistoryForTest()` throw `Cursor tool argument mcp__example_tool.expectedHash is not JSON-serializable` before provider output. The regression is exercised with `bun test packages/ai/test/cursor-exec-handlers.test.ts -t "normalizes non-JSON MCP arguments instead of aborting history replay"`.

## Cause
`decodeMcpArgValue()` in `packages/ai/src/providers/cursor.ts` reparsed every protobuf string as bare JSON, converting numeric-looking opaque strings into numbers and overflowing exponent strings to `Infinity`. `encodeCursorMcpArguments()` then rejected the non-finite value while rebuilding Cursor history; root-prompt JSON serialization could independently fail on unsupported values such as `bigint`.

## Fix
- Preserve bare protobuf strings, including numeric, boolean, and null-like tokens, while continuing to unwrap double-encoded objects, arrays, and quoted strings.
- Normalize Cursor MCP history arguments once for both root-prompt JSON and protobuf encoding: non-finite numbers become `null`, unsupported object properties are omitted, and unsupported array entries become `null`.
- Cover opaque string decoding, structured unwrapping, and replay of non-finite numbers and bigint values; document the user-visible fix in the AI changelog.

## Verification
`bun test packages/ai/test/cursor-exec-handlers.test.ts packages/ai/test/cursor-streaming-args.test.ts` passed: 61 tests, 0 failures. `bun run check` in `packages/ai` passed, and the original `buildCursorHistoryForTest()` smoke script now prints `history encoded`. Skipped the repository pre-publish gate because `bun check` also fails on `main` for unrelated pre-existing formatting in `scripts/gen-nix-bun.ts` and `crates/pi-natives/src/spelling.rs`; both failures were reproduced directly from `origin/main`.

Fixes #9394