### PR TITLE
fix(tui): recognize Orca's Hangul jamo width

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed editor input lag when autocomplete providers are slow by keeping only the latest pending lookup.
 - Fixed pasting an image in kitty occasionally spraying base64 text into the composer alongside the image attachment: a kitty OSC 5522 clipboard packet torn by the incomplete-escape flush is now discarded up to its terminator instead of being replayed as keystrokes.
 - Fixed Kitty OSC 66 headings activating before the host explicitly enables text sizing.
+- Fixed Korean IME cursor drift in Orca by matching its two-cell Hangul Compatibility Jamo rendering ([#9397](https://github.com/can1357/oh-my-pi/issues/9397)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -34,6 +34,7 @@ export type TerminalId =
 	| "vscode"
 	| "alacritty"
 	| "warp"
+	| "orca"
 	| "base"
 	| "trueColor";
 
@@ -493,6 +494,7 @@ const KNOWN_TERMINALS = Object.freeze({
 	iterm2: new TerminalInfo("iterm2", ImageProtocol.Iterm2, true, true, NotifyProtocol.Osc9),
 	vscode: new TerminalInfo("vscode", null, true, true, NotifyProtocol.Bell),
 	alacritty: new TerminalInfo("alacritty", null, true, true, NotifyProtocol.Bell),
+	orca: new TerminalInfo("orca", null, true, false, NotifyProtocol.Bell, false, false, false, 2),
 	// Warp identifies via TERM_PROGRAM=WarpTerminal and ships the Kitty graphics
 	// protocol on macOS/Linux (direct placement only — no Unicode placeholders, so
 	// detectKittyUnicodePlaceholdersSupport correctly excludes it). It does not
@@ -534,6 +536,7 @@ export function detectTerminalId(env: NodeJS.ProcessEnv = Bun.env): TerminalId {
 		if (caseEq(TERM_PROGRAM, "vscode")) return "vscode";
 		if (caseEq(TERM_PROGRAM, "alacritty")) return "alacritty";
 		if (caseEq(TERM_PROGRAM, "warpterminal")) return "warp";
+		if (caseEq(TERM_PROGRAM, "orca")) return "orca";
 	}
 
 	if (TERM?.toLowerCase().includes("ghostty")) return "ghostty";

--- a/packages/tui/test/terminal-jamo-width-probe.test.ts
+++ b/packages/tui/test/terminal-jamo-width-probe.test.ts
@@ -6,10 +6,10 @@ function jamoWidthFor(env: NodeJS.ProcessEnv): "platform" | "unicode" | 1 | 2 {
 }
 
 describe("Hangul Compatibility Jamo width terminal capability", () => {
-	it("forces wide for Ghostty, narrow for Warp, and the platform default otherwise", () => {
-		// Ghostty follows UAX#11 and renders Hangul Compatibility Jamo at 2 cells;
-		// Warp renders them at 1 cell. Every other terminal keeps the platform
-		// default (macOS narrow, otherwise UAX#11).
+	it("uses terminal-specific widths for Hangul Compatibility Jamo", () => {
+		// Ghostty and Orca follow UAX#11 and render Hangul Compatibility Jamo at
+		// 2 cells; Warp renders them at 1 cell. Every other terminal keeps the
+		// platform default (macOS narrow, otherwise UAX#11).
 		expect(jamoWidthFor({ GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app" })).toBe(2);
 		expect(jamoWidthFor({ TERM_PROGRAM: "ghostty" })).toBe(2);
 		// Ghostty identified only via TERM (env-filtered shells that drop
@@ -17,6 +17,7 @@ describe("Hangul Compatibility Jamo width terminal capability", () => {
 		// the Ghostty detection in terminal-capabilities.ts.
 		expect(jamoWidthFor({ TERM: "xterm-ghostty" })).toBe(2);
 		expect(jamoWidthFor({ TERM_PROGRAM: "WarpTerminal" })).toBe(1);
+		expect(jamoWidthFor({ TERM_PROGRAM: "Orca", TERM: "xterm-256color", COLORTERM: "truecolor" })).toBe(2);
 		expect(jamoWidthFor({ TERM_PROGRAM: "iTerm.app" })).toBe("platform");
 		expect(jamoWidthFor({ TERM_PROGRAM: "Apple_Terminal" })).toBe("platform");
 		expect(jamoWidthFor({})).toBe("platform");


### PR DESCRIPTION
## Repro

With `TERM_PROGRAM=Orca TERM=xterm-256color COLORTERM=truecolor`, run `bun -e 'import { detectTerminalId, getTerminalInfo } from "./packages/tui/src/terminal-capabilities.ts"; const env = { TERM_PROGRAM: "Orca", TERM: "xterm-256color", COLORTERM: "truecolor" }; const id = detectTerminalId(env); console.log(JSON.stringify({ id, hangulJamoWidth: getTerminalInfo(id).hangulJamoWidth }));'`. Before this change it prints `{"id":"trueColor","hangulJamoWidth":"platform"}`, which selects the one-cell macOS fallback while Orca renders Compatibility Jamo in two cells.

## Cause

`detectTerminalId()` in `packages/tui/src/terminal-capabilities.ts` did not recognize Orca's `TERM_PROGRAM`, so `COLORTERM=truecolor` selected the generic `trueColor` capability and its platform-dependent Hangul Compatibility Jamo width.

## Fix

- Add a conservative `orca` terminal capability with true color and two-cell Hangul Compatibility Jamo rendering.
- Recognize `TERM_PROGRAM=Orca` case-insensitively before the generic true-color fallback.
- Cover Orca's environment in the terminal Jamo-width regression test and document the user-visible fix.

## Verification

`bun test packages/tui/test/terminal-jamo-width-probe.test.ts packages/tui/test/terminal-capabilities.test.ts` passes: 38 tests, 0 failures. Re-running the repro prints `{"id":"orca","hangulJamoWidth":2}`. The pre-publish gate also completed `bun run fix` and `bun check`.

Fixes #9397