### PR TITLE
docs(cli): document model role arguments

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -82,7 +82,7 @@ Argument handling:
 
 | Flag | Description |
 | --- | --- |
-| `--model <id>` | Model to use (fuzzy match: `opus`, `gpt-5.2`, or `openai/gpt-5.2`). |
+| `--model <id-or-role>` | Model or configured role to use (role: `slow` or `@slow`; fuzzy model match: `opus`, `gpt-5.2`, or `openai/gpt-5.2`). |
 | `--smol <id>` | Smol/fast model for lightweight tasks (or `PI_SMOL_MODEL`). |
 | `--slow <id>` | Slow/reasoning model for thorough analysis (or `PI_SLOW_MODEL`). |
 | `--plan <id>` | Plan model for architectural planning (or `PI_PLAN_MODEL`). |

--- a/packages/coding-agent/test/rpc-client.restart.test.ts
+++ b/packages/coding-agent/test/rpc-client.restart.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
 import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
-import { ptree, TempDir } from "@oh-my-pi/pi-utils";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 const MOCK_AGENT = path.join(import.meta.dir, "fixtures", "mock-rpc-agent.ts");
 


### PR DESCRIPTION
## Repro
`docs/cli-reference.md` described `--model <id>` only as a fuzzy model match, while `bun test packages/coding-agent/test/model-resolver.test.ts --test-name-pattern "resolves bare configured role names from --model"` passed and confirmed that configured role names are accepted.

## Cause
The `--model` row in `docs/cli-reference.md` predated configured-role resolution in `resolveCliModel` (`packages/coding-agent/src/config/model-resolver.ts`) and documented only its concrete-model matching path.

## Fix
- Document configured role names and explicit role aliases as accepted `--model` arguments.
- Retain the existing fuzzy model selector examples.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts --test-name-pattern "resolves bare configured role names from --model"` passed (1 test, 0 failures). The pre-publish gate also completed `bun run fix` and `bun check`.

Fixes #9399