### PR TITLE
fix(tui): do not crash streaming fences when HighlightStream is missing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,12 +24,14 @@
 
 ### Fixed
 
+- Fixed the TUI crashing with `undefined is not a constructor` while streaming a highlighted code fence against a stale local `pi-natives` addon that does not export `HighlightStream`.
 - Fixed double-Esc (session tree / branch selector) appearing dead on long sessions: opening it no longer replays the entire transcript through the terminal (which blocked for tens of seconds on PTY backpressure and cleared native scrollback), only the viewport repaints.
 - Fixed prompt history duplicates: each prompt is now stored once with its latest project path, session ID, and submission time, and session resume or transcript rebuilds no longer repopulate persistent history.
 - `/models` no longer shows dead sidebar tabs for unconfigured Ollama, llama.cpp, and LM Studio endpoints; explicitly configured endpoints remain visible for diagnosis ([#2761](https://github.com/can1357/oh-my-pi/issues/2761)).
 - Fixed prompt input lag under CPU load while file and macOS spelling completions are active.
 - Fixed blank `mnemopi.dbPath` settings silently creating volatile memory banks instead of using persistent agent storage ([#9360](https://github.com/can1357/oh-my-pi/issues/9360)).
 - Fixed legacy Pi extensions being reparsed on every startup because their persistent parse cache could not be created ([#9339](https://github.com/can1357/oh-my-pi/pull/9339) by [@walodayeet](https://github.com/walodayeet)).
+- Fixed streamed `xd://` device writes (including MCP tools) looking like a hung in-flight call while the model is still thinking; they now show as queued until the tool actually starts.
 - Fixed Kitty text-sized Markdown headings activating before `tui.textSizing` is enabled.
 - Fixed terminal-title updates racing the TUI's off-thread output pump, which could tear an escape sequence mid-frame and print the title (e.g. `0;π ∴ <session title>`) into the editor line as if typed.
 - Fixed the edit tool corrupting files on unified-diff-shaped payloads: missing-separator recovery no longer hijacks `-`/`+` bodies (which deleted matched anchors and duplicated the surrounding block); they now flow to the unified-diff reinterpretation.

--- a/packages/coding-agent/src/modes/theme/tui-adapters.ts
+++ b/packages/coding-agent/src/modes/theme/tui-adapters.ts
@@ -199,7 +199,16 @@ export function getMarkdownTheme(): MarkdownTheme {
 		createHighlightStream: (lang?: string) => {
 			const validLang = lang && nativeSupportsLanguage(lang) ? lang : undefined;
 			if (!validLang) return null;
-			return new NativeHighlightStream(validLang, getHighlightColors(theme));
+			// Workspace loads skip the natives version sentinel, so a stale local
+			// `.node` can omit `HighlightStream` after a pull. napi constructors can
+			// also throw. Match `highlightCached`: degrade to the unhighlighted
+			// streaming path instead of aborting the TUI render.
+			try {
+				if (typeof NativeHighlightStream !== "function") return null;
+				return new NativeHighlightStream(validLang, getHighlightColors(theme));
+			} catch {
+				return null;
+			}
 		},
 	};
 	cachedMarkdownTheme = markdownTheme;

--- a/packages/coding-agent/test/modes/theme/highlight-stream.test.ts
+++ b/packages/coding-agent/test/modes/theme/highlight-stream.test.ts
@@ -1,0 +1,32 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { Markdown } from "@oh-my-pi/pi-tui";
+import { Settings } from "../../../src/config/settings";
+import { getMarkdownTheme, getThemeByName, setThemeInstance } from "../../../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+	const theme = await getThemeByName("dark");
+	if (!theme) throw new Error("theme unavailable");
+	setThemeInstance(theme);
+});
+
+describe("markdown highlight stream", () => {
+	it("does not throw when creating a stream for a supported language", () => {
+		const factory = getMarkdownTheme().createHighlightStream;
+		expect(factory).toBeTypeOf("function");
+		expect(() => factory?.("lua")).not.toThrow();
+		expect(() => factory?.("python")).not.toThrow();
+	});
+
+	it("renders a streaming lua fence without aborting", () => {
+		const markdown = new Markdown("```lua\nlocal x = 1\nmore", 0, 0, getMarkdownTheme());
+		markdown.transientRenderCache = true;
+		let lines: string[] = [];
+		expect(() => {
+			lines = markdown.render(80);
+		}).not.toThrow();
+		const plain = stripVTControlCharacters(lines.join("\n"));
+		expect(plain).toContain("local x = 1");
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed Markdown render aborting the TUI when `createHighlightStream` throws; open fences now fall back to the unhighlighted path.
 - Fixed consecutive prompt submissions being skipped by persistent history, allowing the latest project metadata to replace the previous entry without duplicating editor navigation history.
 - Fixed fuzzy matching so a qualifying whole-word hit is not hidden by an earlier mid-word occurrence ([#8465](https://github.com/can1357/oh-my-pi/pull/8465) by [@Mustaqeem66](https://github.com/Mustaqeem66)).
 - Fixed stray characters appearing in the terminal viewport during title updates

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2313,7 +2313,15 @@ export class Markdown
 	 */
 	#createHighlightStream(lang: string | undefined): HighlightStreamSession | null {
 		const factory = this.#theme.createHighlightStream;
-		if (factory) return factory(lang);
+		if (factory) {
+			try {
+				return factory(lang);
+			} catch {
+				// Render must not throw: a broken theme factory (stale natives
+				// `HighlightStream`, napi error) falls through to the unhighlighted
+				// path / diff-family per-line emulation below.
+			}
+		}
 		const highlightCode = this.#theme.highlightCode;
 		if (!highlightCode) return null;
 		const normalizedLang = lang?.toLowerCase();

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2122,6 +2122,23 @@ describe("Module-level LRU render cache", () => {
 		expect(plain).not.toContain("S<");
 		expect(plain).not.toContain("F<");
 	});
+
+	it("keeps an open fence plain when the highlight stream factory throws", () => {
+		clearRenderCache();
+		const themeWithStream = {
+			...defaultMarkdownTheme,
+			highlightCode: (code: string, _lang?: string): string[] => [`F<${code}>`],
+			createHighlightStream: (_lang?: string) => {
+				throw new TypeError("undefined is not a constructor");
+			},
+		};
+
+		const markdown = new Markdown("```lua\nlocal x = 1\nmore", 0, 0, themeWithStream);
+		markdown.transientRenderCache = true;
+		const plain = stripVTControlCharacters(markdown.render(80).join("\n"));
+		expect(plain).toContain("local x = 1");
+		expect(plain).not.toContain("F<");
+	});
 });
 
 describe("OSC 66 text-sizing headings", () => {


### PR DESCRIPTION
## What

Stop the TUI from dying while streaming a highlighted code fence when `HighlightStream` is missing or throws.

I reviewed the full diff; this is the crash I hit locally while streaming a lua fence — `NativeHighlightStream` was `undefined` on a stale natives addon and `new NativeHighlightStream(...)` aborted the whole UI.

## Why

Fixes #9402.

Workspace loads skip the natives version sentinel so a stale local `.node` still boots after a pull. The JS wrapper then exports `HighlightStream = undefined`. `supportsLanguage("lua")` is still true, so `createHighlightStream` takes the constructor path.

`highlightCached` already try/catches native `highlightCode`. The streaming factory did not, and Markdown render had no catch around the factory either.

## Testing

- Reproduced on a source checkout: `typeof HighlightStream === "undefined"` while `supportsLanguage("lua") === true`. Calling `new NativeHighlightStream(...)` threw the exact TypeError from #9402.
- After the change, `getMarkdownTheme().createHighlightStream("lua")` returns `null` instead of throwing, and rendering ` ```lua\nlocal x = 1\nmore ` with `transientRenderCache` no longer aborts.
- `bun test packages/tui/test/markdown.test.ts packages/coding-agent/test/modes/theme/highlight-stream.test.ts` — 151 pass, including a throwing-factory fence and a streaming lua fence through `getMarkdownTheme()`.
- `bunx biome check` on the touched files — clean.

Closed fences still highlight through one-shot `highlightCode`. Incremental highlighting of open fences needs a rebuilt natives addon (`bun --cwd=packages/natives run build`); this PR only stops the crash.

---

- [x] `bun check` passes (biome on touched files; targeted tests)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
