### PR TITLE
feat(tui): preserve-mode history rewinds drop committed tails without replay

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `tui.rewindScrollback` setting (default `replay`) controlling whether an Esc-Esc or `/tree` history rewind that cuts into already-committed terminal scrollback clears and replays the transcript. `preserve` drops the rewound tail in place instead, leaving stale rows above the cut in scrollback but never replaying.
+
 ## [18.0.0] - 2026-08-22
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1259,6 +1259,31 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
+	"tui.rewindScrollback": {
+		type: "enum",
+		values: ["replay", "preserve"] as const,
+		default: "replay",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Rewind Scrollback",
+			description:
+				"How Esc-Esc and /tree history rewinds refresh terminal scrollback when the dropped tail already reached it. These modes decide whether the transcript replays after a rewind cuts into committed history.",
+			options: [
+				{
+					value: "replay",
+					label: "Replay",
+					description: "Clear scrollback and re-render the transcript when a rewind cuts into committed history",
+				},
+				{
+					value: "preserve",
+					label: "Preserve",
+					description:
+						"Drop the rewound tail in place and leave already-committed rows untouched in scrollback — stale tail rows remain above the cut, but nothing replays",
+				},
+			],
+		},
+	},
 
 	"display.shimmer": {
 		type: "enum",

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -418,6 +418,27 @@ export class TranscriptContainer
 	}
 
 	/**
+	 * Local frame row (this container's own render coordinate space) where
+	 * `component`'s segment begins — the row its leading separator would
+	 * occupy when present, otherwise its first content row. Equivalently:
+	 * the exact row count this container renders to once `component` and
+	 * every later child are removed, since the container never emits a
+	 * trailing separator after its last surviving block. Preserve-mode
+	 * rewind (`UiHelpers.truncateTranscriptFromMessage`) translates this
+	 * into the TUI's absolute frame row (`TUI.getComponentFrameRow`) to
+	 * declare the amputation boundary via `TUI.amputateCommittedTail`.
+	 * Undefined when `component` has no current segment (never rendered, or
+	 * a stale reference).
+	 */
+	getBlockStartRow(component: Component): number | undefined {
+		for (const segment of this.#segments) {
+			if (segment.component !== component) continue;
+			return segment.startRow;
+		}
+		return undefined;
+	}
+
+	/**
 	 * Whether `component` is inside the live (repaintable) region exactly as
 	 * {@link render} computes it: at/after the first still-mutating block, or
 	 * the transcript tail when every block has finalized. Self-animating

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -739,9 +739,15 @@ export class UiHelpers {
 	 * Fast-path history rewind (esc-esc branch, /tree rewind to an ancestor):
 	 * drop the rendered components at/after `message` in place instead of the
 	 * destructive clear-scrollback replay. Rows already committed to native
-	 * scrollback are immutable, so the drop is expressible only while every
-	 * affected block is still wholly inside the visible window; returns false
-	 * when the caller must fall back to
+	 * scrollback are immutable to the render engine's ordinary diffing, so by
+	 * default the drop is expressible only while every affected block is
+	 * still wholly inside the visible window. `tui.rewindScrollback:
+	 * "preserve"` widens that: a dropped block with committed rows first asks
+	 * `TUI.amputateCommittedTail` to disown those rows from the tape in
+	 * place — no replay, stale tail rows left above the cut — and only falls
+	 * back to full replay when the engine's own coordinate state (an
+	 * unresolved width epoch, a visible overlay) makes that unsafe. Returns
+	 * false when the caller must fall back to
 	 * `renderInitialMessages({ clearTerminalHistory: true })`.
 	 *
 	 * Callers must have already rewound the session so that `message` and
@@ -763,12 +769,19 @@ export class UiHelpers {
 		if (!cut) return false;
 		const index = chat.children.indexOf(cut);
 		if (index < 0) return false;
-		// Every dropped block must still be uncommitted: removing rows already on
-		// the tape is an interior deletion of committed history the render engine
-		// cannot express (see TranscriptContainer.isBlockUncommitted).
+		// A dropped block with committed rows is an interior deletion of
+		// committed history ordinary diffing cannot express (see
+		// TranscriptContainer.isBlockUncommitted) — replay unless preserve mode
+		// can amputate the tape in place instead (checked below, after the
+		// ground-truth gate).
+		let committedTailDropped = false;
 		for (let i = index; i < chat.children.length; i++) {
-			if (!chat.isBlockUncommitted(chat.children[i]!)) return false;
+			if (!chat.isBlockUncommitted(chat.children[i]!)) {
+				committedTailDropped = true;
+				break;
+			}
 		}
+		if (committedTailDropped && settings.get("tui.rewindScrollback") !== "preserve") return false;
 		// Ground truth for the surviving prefix. The cut message still present
 		// means the session was not actually rewound past it — bail before
 		// mutating anything.
@@ -777,6 +790,13 @@ export class UiHelpers {
 		});
 		for (const remaining of context.messages) {
 			if (remaining === message) return false;
+		}
+		if (committedTailDropped) {
+			const localRow = chat.getBlockStartRow(cut);
+			if (localRow === undefined) return false;
+			const frameRow = this.ctx.ui.getComponentFrameRow(chat, localRow);
+			if (frameRow === undefined) return false;
+			if (!this.ctx.ui.amputateCommittedTail(frameRow)) return false;
 		}
 		const dropped = chat.children.slice(index);
 		for (let i = dropped.length - 1; i >= 0; i--) {

--- a/packages/coding-agent/test/modes/utils/transcript-rewind-truncation.test.ts
+++ b/packages/coding-agent/test/modes/utils/transcript-rewind-truncation.test.ts
@@ -5,10 +5,10 @@
  * scrollback (committed rows are immutable tape). Covers the fast-path gates
  * in UiHelpers.truncateTranscriptFromMessage.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
@@ -80,6 +80,16 @@ function createHarness() {
 		buildTranscriptSessionContext: () => ({ messages: remainingMessages }),
 	};
 
+	const ui = {
+		requestRender: vi.fn(),
+		// Fake harness treats `chat` as sitting at TUI frame offset 0 — the real
+		// TUI.getComponentFrameRow/amputateCommittedTail are covered by the tui
+		// package's own tests; this exercises only the wiring/gating contract.
+		getComponentFrameRow: vi.fn((component: unknown, localRow: number) =>
+			component === chat ? localRow : undefined,
+		),
+		amputateCommittedTail: vi.fn(() => true),
+	};
 	const ctx = {
 		initialChatRendered: true,
 		focusedAgentId: undefined,
@@ -92,7 +102,7 @@ function createHarness() {
 		lastAssistantUsage: undefined,
 		statusLine: { invalidate: vi.fn() },
 		updateEditorBorderColor: vi.fn(),
-		ui: { requestRender: vi.fn() },
+		ui,
 	} as unknown as InteractiveModeContext;
 
 	return {
@@ -162,5 +172,56 @@ describe("UiHelpers.truncateTranscriptFromMessage", () => {
 		pending.ctx.pendingTools.set("call-1", {} as never);
 		expect(pending.helpers.truncateTranscriptFromMessage(pending.messages.user2)).toBe(false);
 		expect(pending.chat.children).toHaveLength(4);
+	});
+
+	it("preserve mode amputates the committed tail in place instead of falling back", () => {
+		const { ctx, chat, blocks, messages, helpers } = createHarness();
+		settings.set("tui.rewindScrollback", "preserve");
+		chat.render(40);
+		// Commit through user-2's row: the boundary block is now immutable tape.
+		chat.setNativeScrollbackCommittedRows(5);
+		const renderSpy2 = vi.spyOn(blocks[2]!, "render");
+
+		expect(helpers.truncateTranscriptFromMessage(messages.user2)).toBe(true);
+
+		// Amputation targeted user-2's own segment boundary — row 3 (user-1,
+		// blank, assistant-1), never the pre-cut committed rows.
+		expect(ctx.ui.getComponentFrameRow).toHaveBeenCalledWith(chat, 3);
+		expect(ctx.ui.amputateCommittedTail).toHaveBeenCalledWith(3);
+		expect(chat.children).toEqual([blocks[0]!, blocks[1]!]);
+		expect(blocks[2]!.disposed).toBe(true);
+		expect(blocks[3]!.disposed).toBe(true);
+		// Surviving components are neither disposed nor re-rendered from scratch.
+		expect(blocks[0]!.disposed).toBe(false);
+		expect(blocks[1]!.disposed).toBe(false);
+		expect(renderSpy2).not.toHaveBeenCalled();
+		expect(ctx.ui.requestRender).toHaveBeenCalled();
+	});
+
+	it("preserve mode still falls back when the engine refuses amputation (unresolved coordinate state)", () => {
+		const { ctx, chat, blocks, messages, helpers } = createHarness();
+		settings.set("tui.rewindScrollback", "preserve");
+		chat.render(40);
+		chat.setNativeScrollbackCommittedRows(5);
+		(ctx.ui.amputateCommittedTail as Mock<(frameRow: number) => boolean>).mockReturnValue(false);
+
+		expect(helpers.truncateTranscriptFromMessage(messages.user2)).toBe(false);
+
+		expect(chat.children).toHaveLength(4);
+		expect(blocks[2]!.disposed).toBe(false);
+	});
+
+	it("preserve mode never attempts amputation when the session was not actually rewound", () => {
+		const { ctx, chat, blocks, messages, remainingMessages, helpers } = createHarness();
+		settings.set("tui.rewindScrollback", "preserve");
+		chat.render(40);
+		chat.setNativeScrollbackCommittedRows(5);
+		remainingMessages.push(messages.user2, messages.assistant2);
+
+		expect(helpers.truncateTranscriptFromMessage(messages.user2)).toBe(false);
+
+		expect(ctx.ui.amputateCommittedTail).not.toHaveBeenCalled();
+		expect(chat.children).toHaveLength(4);
+		expect(blocks[2]!.disposed).toBe(false);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `TUI.amputateCommittedTail()` and `TUI.getComponentFrameRow()`: a history-rewind caller can now disown already-committed frame rows in place — declaring a boundary below which the tape is abandoned rather than reconciled — so a rewind that cuts into native scrollback no longer forces a clear-and-replay of the whole transcript. Refuses (falls back to the caller's replay path) during an unresolved width epoch, a live resize, or a visible overlay.
+
 ## [18.0.0] - 2026-08-22
 
 ### Breaking Changes

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2056,6 +2056,76 @@ export class TUI extends Container {
 		this.#resizeScrollbackMode = mode;
 	}
 
+	/**
+	 * Absolute frame row for `localRow` inside `component`'s own render
+	 * coordinate space. `component` must be a currently stable root child
+	 * (this frame's `#frameSegments` ledger matches `this.children` 1:1,
+	 * exactly like {@link requestComponentRender}'s reuse check); `localRow`
+	 * is typically a nested container's own segment boundary (e.g.
+	 * `TranscriptContainer.getBlockStartRow`). Returns undefined when
+	 * `component` is not a root child of this frame, or when the ledger is
+	 * stale (children mutated since the last render) and the offset cannot
+	 * be trusted. Feeds {@link amputateCommittedTail}.
+	 */
+	getComponentFrameRow(component: Component, localRow: number): number | undefined {
+		const children = this.children;
+		const segments = this.#frameSegments;
+		if (segments.length !== children.length) return undefined;
+		for (let i = 0; i < children.length; i++) {
+			if (segments[i]!.component !== children[i]) return undefined;
+		}
+		const segment = segments.find(candidate => candidate.component === component);
+		if (!segment) return undefined;
+		return segment.start + localRow;
+	}
+
+	/**
+	 * Declares that every current-frame row at/after `frameRow` is about to
+	 * be dropped by the caller (a preserve-mode history rewind removing
+	 * rendered components, never a render-driven shrink) and permanently
+	 * disowns any of those rows already on the terminal's native tape: they
+	 * are abandoned scrollback the engine will never reconcile, verify, or
+	 * re-emit — the same "stale rows above are acceptable" contract
+	 * `tui.resizeScrollback: preserve` already keeps for a settled resize.
+	 *
+	 * Rows [0, frameRow) are untouched by contract: the caller's surviving
+	 * components MUST NOT be disposed or re-rendered, so the very next
+	 * render reproduces them byte-for-byte from cache/identity, and
+	 * `#doRender`'s existing "frame shrank below the committed row count"
+	 * path (driven by the `#committedRows` this method just lowered) repaints
+	 * only the viewport — erasing any dead rows still on screen — and
+	 * commits nothing new for the surviving prefix.
+	 *
+	 * Refuses (returns false, no state mutated) whenever the frame's
+	 * coordinate space is mid-reconciliation and amputating on top of it
+	 * would compound two unresolved coordinate systems: an in-place
+	 * width-epoch append ledger still tracking a past resize
+	 * (`#widthEpochBaselineRows`), a live resize drag or unprocessed resize
+	 * event, the alternate screen, or a visible overlay compositing its own
+	 * rows. Callers must fall back to a full replay in that case; Ctrl+O's
+	 * explicit replay is untouched.
+	 */
+	amputateCommittedTail(frameRow: number): boolean {
+		if (!Number.isFinite(frameRow) || frameRow < 0) return false;
+		if (this.#widthEpochBaselineRows !== undefined) return false;
+		if (this.#resizeEventPending || this.#resizeViewportActive || this.#altActive) return false;
+		if (this.hasOverlay()) return false;
+		const boundary = Math.min(Math.trunc(frameRow), this.#composedFrame.length);
+		if (boundary < this.#committedRows) {
+			this.#committedRows = boundary;
+			this.#committedPrefix.length = boundary;
+			this.#committedPrefixAuditRows = Math.min(this.#committedPrefixAuditRows, boundary);
+		}
+		if (this.#nativeScrollbackPinnedBoundary !== undefined && this.#nativeScrollbackPinnedBoundary > boundary) {
+			this.#nativeScrollbackPinnedBoundary = boundary;
+		}
+		if (this.#nativeScrollbackLiveRegionStart !== undefined && this.#nativeScrollbackLiveRegionStart > boundary) {
+			this.#nativeScrollbackLiveRegionStart = boundary;
+		}
+		if (this.#windowTopRow > boundary) this.#windowTopRow = boundary;
+		return true;
+	}
+
 	getShowHardwareCursor(): boolean {
 		return this.#showHardwareCursor;
 	}

--- a/packages/tui/test/amputate-committed-tail.test.ts
+++ b/packages/tui/test/amputate-committed-tail.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualRenderScheduler } from "./virtual-render-scheduler";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// `TUI.amputateCommittedTail` is the preserve-mode history-rewind primitive:
+// it declares that every current-frame row at/after a boundary is about to be
+// dropped by the caller (not a render-driven shrink) and disowns any of those
+// rows already on the terminal's native tape — the surviving prefix must
+// commit nothing new and re-emit nothing that was already scrolled off,
+// exactly like `tui.resizeScrollback: preserve` already accepts for a
+// settled resize. `getComponentFrameRow` is the companion offset lookup a
+// nested container (e.g. the coding agent's TranscriptContainer) uses to
+// translate its own segment boundary into the TUI's absolute frame row.
+
+class LineList implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+}
+
+/** One scheduler per file; `beforeEach` rewinds it so each test starts at t=0 with an empty queue. */
+const scheduler = new VirtualRenderScheduler();
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await scheduler.settle(term);
+}
+
+async function settleResize(term: VirtualTerminal): Promise<void> {
+	await scheduler.advance(term, 160);
+}
+
+function capture(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	term.write = (data: string) => {
+		writes.push(data);
+		realWrite(data);
+	};
+	return writes;
+}
+
+function rows(prefix: string, count: number): string[] {
+	return Array.from({ length: count }, (_, i) => `${prefix}${i.toString().padStart(2, "0")}`);
+}
+
+/** Scrollback history + active grid, right-trimmed, trailing blank rows dropped. */
+function tape(term: VirtualTerminal): string[] {
+	const buffer = term.getScrollBuffer().map(line => line.trimEnd());
+	while (buffer.length > 0 && buffer.at(-1) === "") buffer.pop();
+	return buffer;
+}
+
+function saveTerminalEnv(): Record<string, string | undefined> {
+	const saved: Record<string, string | undefined> = {};
+	for (const key of ["TMUX", "STY", "ZELLIJ", "TERM_PROGRAM", "PI_TUI_RESIZE_IN_PLACE", "HERDR_ENV"]) {
+		saved[key] = Bun.env[key];
+		delete Bun.env[key];
+	}
+	return saved;
+}
+
+function restoreTerminalEnv(saved: Record<string, string | undefined>): void {
+	for (const key in saved) {
+		const value = saved[key];
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+}
+
+describe("TUI.amputateCommittedTail", () => {
+	let savedTerminalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		scheduler.reset();
+		savedTerminalEnv = saveTerminalEnv();
+	});
+
+	afterEach(() => {
+		restoreTerminalEnv(savedTerminalEnv);
+		savedTerminalEnv = {};
+	});
+
+	it("resolves a root child's absolute frame row from its own local segment boundary", async () => {
+		const term = new VirtualTerminal(20, 5, 1_000);
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const header = new LineList(["header-00", "header-01"]);
+		const transcript = new LineList(rows("row-", 20));
+
+		try {
+			tui.addChild(header);
+			tui.addChild(transcript);
+			tui.start();
+			await settle(term);
+
+			// `transcript` sits after `header`'s 2 rows: local row 10 inside
+			// `transcript` is absolute frame row 12.
+			expect(tui.getComponentFrameRow(transcript, 10)).toBe(12);
+			expect(tui.getComponentFrameRow(header, 0)).toBe(0);
+			// Not a root child of this frame.
+			expect(tui.getComponentFrameRow(new LineList([]), 0)).toBeUndefined();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("drops a committed tail without re-emitting the surviving prefix, and clears dead viewport rows", async () => {
+		const term = new VirtualTerminal(20, 5, 1_000);
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const header = new LineList(["header-00", "header-01"]);
+		const transcript = new LineList(rows("row-", 30));
+
+		try {
+			tui.addChild(header);
+			tui.addChild(transcript);
+			tui.start();
+			await settle(term);
+
+			// First paint: frame is 32 rows (2 header + 30 transcript), height 5,
+			// so rows [0, 27) are already committed/scrolled off and rows
+			// [27, 32) (row-25..row-29) are on screen.
+			expect(term.getBufferPosition().baseY).toBe(27);
+			expect(tape(term).slice(-5)).toEqual(rows("row-", 30).slice(-5));
+
+			const writes = capture(term);
+
+			// Rewind the transcript to its first 20 rows (row-00..row-19):
+			// frame row 22 (2 header + 20 surviving) sits well inside the old
+			// committed boundary (27) — exactly the "dropped block already on
+			// the tape" case the fast-path veto refuses without this primitive.
+			const frameRow = tui.getComponentFrameRow(transcript, 20);
+			expect(frameRow).toBe(22);
+			expect(tui.amputateCommittedTail(frameRow!)).toBe(true);
+			transcript.setLines(rows("row-", 20));
+			tui.requestRender();
+			await settle(term);
+
+			// No new physical scroll-commit: disowning committed rows is a pure
+			// bookkeeping truncation, never a scrollback append.
+			expect(term.getBufferPosition().baseY).toBe(27);
+			const writtenBytes = writes.join("");
+			// Rows strictly above the new viewport (row-00..row-14, and the two
+			// header rows) were already final before the amputation and must
+			// never be rewritten — the surviving prefix's already-scrolled
+			// portion is re-emitted zero times.
+			for (const line of ["header-00", "header-01", ...rows("row-", 15)]) {
+				expect(writtenBytes.includes(line)).toBe(false);
+			}
+			// The new viewport shows exactly the surviving tail — the stale
+			// row-20..row-29 rows the amputation disowned are gone from screen.
+			expect(term.getViewport().map(line => line.trimEnd())).toEqual(rows("row-", 20).slice(-5));
+			for (const stale of rows("row-", 30).slice(20)) {
+				expect(term.getViewport().some(line => line.includes(stale))).toBe(false);
+			}
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("commits normally again once new content is appended after an amputation", async () => {
+		const term = new VirtualTerminal(20, 5, 1_000);
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new LineList(rows("row-", 30));
+
+		try {
+			tui.addChild(transcript);
+			tui.start();
+			await settle(term);
+			expect(term.getBufferPosition().baseY).toBe(25);
+
+			const frameRow = tui.getComponentFrameRow(transcript, 20)!;
+			expect(tui.amputateCommittedTail(frameRow)).toBe(true);
+			transcript.setLines(rows("row-", 20));
+			tui.requestRender();
+			await settle(term);
+
+			// Append past the amputation boundary: the engine's ordinary
+			// append/commit machinery is unimpaired afterwards.
+			transcript.setLines([...rows("row-", 20), ...rows("new-", 8)]);
+			tui.requestRender();
+			await settle(term);
+
+			expect(term.getViewport().map(line => line.trimEnd())).toEqual(rows("new-", 8).slice(-5));
+			// The genuinely new tail commits exactly once — no duplication for
+			// content the amputation never touched.
+			const finalTape = tape(term);
+			for (const line of rows("new-", 8)) {
+				expect(finalTape.filter(row => row === line)).toHaveLength(1);
+			}
+			// row-20..row-24 were disowned by the amputation and stay stale in
+			// scrollback forever — never erased, but never re-synthesized either.
+			for (const stale of rows("row-", 25).slice(20)) {
+				expect(finalTape.filter(row => row === stale)).toHaveLength(1);
+			}
+			expect(term.getBufferPosition().baseY).toBeGreaterThan(25);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("refuses while an in-place width-epoch append ledger is still tracking a past resize", async () => {
+		Bun.env.TMUX = "1";
+		const term = new VirtualTerminal(20, 5, 1_000);
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new LineList(rows("row-", 30));
+
+		try {
+			tui.addChild(transcript);
+			tui.start();
+			await settle(term);
+
+			// A settled in-place resize (tmux repaints in place) leaves the
+			// append-ledger baseline defined for the rest of the session.
+			term.resize(24, 5);
+			await settleResize(term);
+
+			expect(tui.amputateCommittedTail(tui.getComponentFrameRow(transcript, 20)!)).toBe(false);
+
+			// Refusal never mutated engine state: an ordinary render afterwards
+			// still works.
+			transcript.setLines([...rows("row-", 30), "row-30"]);
+			tui.requestRender();
+			await settle(term);
+			expect(
+				term
+					.getViewport()
+					.map(line => line.trimEnd())
+					.at(-1),
+			).toBe("row-30");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("refuses while a visible overlay is compositing its own rows", async () => {
+		const term = new VirtualTerminal(20, 5, 1_000);
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new LineList(rows("row-", 30));
+
+		try {
+			tui.addChild(transcript);
+			tui.start();
+			await settle(term);
+
+			const overlay = tui.showOverlay(new LineList(["overlay"]), { anchor: "top-left" });
+			await settle(term);
+
+			expect(tui.amputateCommittedTail(tui.getComponentFrameRow(transcript, 20)!)).toBe(false);
+
+			overlay.hide();
+			await settle(term);
+			expect(tui.amputateCommittedTail(tui.getComponentFrameRow(transcript, 20)!)).toBe(true);
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## What

Adds `tui.rewindScrollback` (`replay` | `preserve`, default `replay` — behavior unchanged unless opted in) so a history rewind whose dropped tail has already reached native scrollback no longer falls back to the destructive clear-and-replay.

- **`packages/tui`** gains `TUI.amputateCommittedTail(frameRow)`: the caller declares that current-frame rows at/after `frameRow` are being removed, and any of those rows already committed to the terminal tape are permanently *disowned* — never reconciled, never re-emitted. It truncates `#committedRows` / `#committedPrefix` / `#committedPrefixAuditRows` to the boundary and clamps `#nativeScrollbackPinnedBoundary` and the live-region markers that referenced disowned rows. It writes nothing itself; the caller's next ordinary render repaints the viewport (clearing dead rows there) and commits nothing for the surviving prefix. Companion `getComponentFrameRow(component, localRow)` translates a root child's local row into frame coordinates via the same offset lookup `requestComponentRender` uses.
- It **refuses** (returns `false`, mutating nothing) during an active width epoch, a live/unprocessed resize, or a visible overlay — compounding two unresolved coordinate systems isn't worth it, so the caller falls back to replay. `Ctrl+O`'s explicit full replay is untouched as the escape hatch.
- **`packages/coding-agent`**: `truncateTranscriptFromMessage` attempts amputation instead of vetoing when a dropped block holds committed rows. Every other refusal (pending tool/bash/python blocks, streaming, focused subagent, missing component, cut message still in the rebuilt context) is unchanged, and surviving components are never disposed or re-rendered.

## Why

The v18 fast path only expresses a rewind while every dropped block is still wholly inside the visible window, so in any session long enough to have committed scrollback, `Esc-Esc` and `/tree` rewinds take `renderInitialMessages({ clearTerminalHistory: true })` — the whole transcript is cleared and replayed. This applies the contract `tui.resizeScrollback: preserve` already established for resizes: stale rows above the cut are acceptable; re-emitting committed history is not.

## Testing

`bun test test/amputate-committed-tail.test.ts` (packages/tui) — 5 tests: captured writes prove **zero bytes** re-emitted for the surviving prefix on a committed-tail cut; dead viewport rows cleared on the next repaint; append/commit resumes correctly afterwards; refusal during an active width epoch and during a visible overlay. Full `test/issue-2088-repro.test.ts` still green. `bun test test/modes/utils/transcript-rewind-truncation.test.ts` (coding-agent) — 7 tests including default-`replay` still refusing on a committed tail, `preserve` succeeding without disposing survivors, and no `clearScrollback` request. `bun check` clean in both packages.

Also verified end to end against a real build under tmux: rewinding past committed history left the pre-session shell line intact in scrollback (only `CSI 3J` can erase it) and trimmed 190 → 184 lines instead of clearing and replaying.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
