### PR TITLE
fix(browser-relay): derive /json/version webSocketDebuggerUrl from the Host header

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed remote browser relay endpoints advertising a client-local CDP WebSocket URL: `/json/version` now reflects a valid request `Host` and falls back to the relay's loopback address when it is absent or unusable.
+
 ## [18.0.1] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/relay/server.ts
+++ b/packages/coding-agent/src/tools/browser/relay/server.ts
@@ -43,6 +43,16 @@ const WS_KEEPALIVE_MS = 30_000;
 const MAX_PAYLOAD_BYTES = 256 * 1024 * 1024;
 /** Default appearance of the omp tab group. */
 const DEFAULT_GROUP = { title: "omp", color: "cyan" } as const;
+/** True when `raw` can serve as the authority of a `ws://` URL: no whitespace,
+ *  slashes, userinfo, fragments, or control characters, and URL-parseable. */
+function isWsAuthority(raw: string): boolean {
+	if (/[\s/\\@#?]|[\x00-\x1f]/.test(raw)) return false;
+	try {
+		return new URL(`ws://${raw}`).host.length > 0;
+	} catch {
+		return false;
+	}
+}
 
 /** Start the relay server on 127.0.0.1. Throws if the port is taken. */
 export function startRelayServer(opts: RelayServerOptions): RelayServer {
@@ -56,7 +66,14 @@ export function startRelayServer(opts: RelayServerOptions): RelayServer {
 		hostname: "127.0.0.1",
 		port: opts.port,
 		fetch(req, srv): Response | undefined {
-			const url = new URL(req.url);
+			const fallback = `127.0.0.1:${opts.port}`;
+			const rawHost = req.headers.get("host")?.trim();
+			const host = rawHost && isWsAuthority(rawHost) ? rawHost : fallback;
+			const requestUrl =
+				rawHost && rawHost !== host && req.url.startsWith(`http://${rawHost}`)
+					? req.url.slice(`http://${rawHost}`.length)
+					: req.url;
+			const url = new URL(requestUrl, `http://${fallback}`);
 			const path = url.pathname.replace(/\/+$/, "") || "/";
 			if (path === "/cdp") {
 				// Browsers set Origin on websocket upgrades; native CDP clients
@@ -83,7 +100,7 @@ export function startRelayServer(opts: RelayServerOptions): RelayServer {
 				if (!bridge.ready) {
 					return Response.json({ error: "relay extension is not connected" }, { status: 503 });
 				}
-				return Response.json(bridge.versionInfo(`ws://127.0.0.1:${opts.port}/cdp`));
+				return Response.json(bridge.versionInfo(`ws://${host}/cdp`));
 			}
 			if (path === "/json" || path === "/json/list") {
 				return Response.json(bridge.listTargets());

--- a/packages/coding-agent/test/tools/browser-relay-server.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-server.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { findFreeCdpPort } from "@oh-my-pi/pi-coding-agent/tools/browser/attach";
+import { type RelayServer, startRelayServer } from "@oh-my-pi/pi-coding-agent/tools/browser/relay/server";
+
+const EXTENSION_HELLO = {
+	t: "hello",
+	userAgent: "test",
+	browserVersion: "Chrome/151.0.0.0",
+	tabs: [],
+	attachedTabIds: [],
+} as const;
+
+async function rawGet(port: number, requestBytes: string): Promise<string> {
+	const { promise, resolve, reject } = Promise.withResolvers<string>();
+	let response = "";
+	await Bun.connect({
+		hostname: "127.0.0.1",
+		port,
+		socket: {
+			open(socket) {
+				socket.write(requestBytes);
+			},
+			data(_socket, chunk) {
+				response += chunk.toString("latin1");
+			},
+			error(_socket, error) {
+				reject(error);
+			},
+			close() {
+				resolve(response);
+			},
+		},
+	});
+	return promise;
+}
+
+function decodeChunkedBody(body: string): string {
+	let decoded = "";
+	let offset = 0;
+	while (true) {
+		const lineEnd = body.indexOf("\r\n", offset);
+		if (lineEnd === -1) throw new Error("Invalid chunked response: missing chunk size");
+		const lengthText = body.slice(offset, lineEnd).split(";", 1)[0]!;
+		const length = Number.parseInt(lengthText, 16);
+		if (!Number.isFinite(length) || length < 0) throw new Error("Invalid chunked response: invalid chunk size");
+		offset = lineEnd + 2;
+		if (length === 0) return decoded;
+		if (body.length < offset + length + 2) throw new Error("Invalid chunked response: truncated chunk");
+		decoded += body.slice(offset, offset + length);
+		offset += length;
+		if (body.slice(offset, offset + 2) !== "\r\n")
+			throw new Error("Invalid chunked response: missing chunk terminator");
+		offset += 2;
+	}
+}
+
+function parseVersion(response: string): Record<string, string> {
+	const boundary = response.indexOf("\r\n\r\n");
+	if (boundary === -1) throw new Error("Invalid HTTP response: missing header boundary");
+	const headers = response.slice(0, boundary);
+	const body = response.slice(boundary + 4);
+	expect(headers).toContain("200");
+	return JSON.parse(/\r\ntransfer-encoding:\s*chunked\b/i.test(headers) ? decodeChunkedBody(body) : body) as Record<
+		string,
+		string
+	>;
+}
+
+async function connectExtension(port: number): Promise<WebSocket> {
+	const { promise, resolve, reject } = Promise.withResolvers<WebSocket>();
+	const ws = new WebSocket(`ws://127.0.0.1:${port}/ext`);
+	ws.addEventListener(
+		"open",
+		() => {
+			ws.send(JSON.stringify(EXTENSION_HELLO));
+			resolve(ws);
+		},
+		{ once: true },
+	);
+	ws.addEventListener("error", () => reject(new Error("Extension socket failed to connect")), { once: true });
+	return promise;
+}
+
+async function waitForDiscovery(port: number): Promise<void> {
+	const deadline = Date.now() + 1_000;
+	while (Date.now() < deadline) {
+		const response = await fetch(`http://127.0.0.1:${port}/json/version`);
+		if (response.status === 200) return;
+	}
+	throw new Error("Relay discovery endpoint did not become ready");
+}
+
+describe("browser relay discovery endpoint", () => {
+	let relay: RelayServer | undefined;
+	let extension: WebSocket | undefined;
+
+	afterEach(() => {
+		extension?.close();
+		relay?.stop();
+		extension = undefined;
+		relay = undefined;
+	});
+
+	async function startReadyRelay(): Promise<number> {
+		const port = await findFreeCdpPort();
+		relay = startRelayServer({ port });
+		extension = await connectExtension(port);
+		await waitForDiscovery(port);
+		return port;
+	}
+
+	it("advertises the requested Host authority so a remote Puppeteer client dials the relay", async () => {
+		const port = await startReadyRelay();
+		const response = await rawGet(
+			port,
+			"GET /json/version HTTP/1.1\r\nHost: 100.100.92.97:12803\r\nConnection: close\r\n\r\n",
+		);
+		expect(parseVersion(response).webSocketDebuggerUrl).toBe("ws://100.100.92.97:12803/cdp");
+	});
+
+	it("uses the loopback discovery URL when an HTTP/1.0 request has no Host header", async () => {
+		const port = await startReadyRelay();
+		const response = await rawGet(port, "GET /json/version HTTP/1.0\r\n\r\n");
+		expect(parseVersion(response).webSocketDebuggerUrl).toBe(`ws://127.0.0.1:${port}/cdp`);
+	});
+
+	it("uses the loopback discovery URL when Host is empty", async () => {
+		const port = await startReadyRelay();
+		const response = await rawGet(port, "GET /json/version HTTP/1.1\r\nHost: \r\nConnection: close\r\n\r\n");
+		expect(parseVersion(response).webSocketDebuggerUrl).toBe(`ws://127.0.0.1:${port}/cdp`);
+	});
+
+	it("uses the loopback discovery URL when Host would produce an unusable WebSocket authority", async () => {
+		const port = await startReadyRelay();
+		const response = await rawGet(
+			port,
+			"GET /json/version HTTP/1.1\r\nHost: bad/host@evil\r\nConnection: close\r\n\r\n",
+		);
+		expect(parseVersion(response).webSocketDebuggerUrl).toBe(`ws://127.0.0.1:${port}/cdp`);
+	});
+
+	it("reports 503 while the extension handshake is pending so the relay daemon keeps polling", async () => {
+		const port = await findFreeCdpPort();
+		relay = startRelayServer({ port });
+		const response = await fetch(`http://127.0.0.1:${port}/json/version`);
+		expect(response.status).toBe(503);
+	});
+});


### PR DESCRIPTION
Discovered this while implementing a mechanism for extending the browser-relay workflow to remote development machines.

## What

`GET /json/version` on the browser relay hardcoded `webSocketDebuggerUrl` to `ws://127.0.0.1:<port>/cdp`. That is correct only when the CDP client shares a host with the browser. A remote client is told to dial *its own* loopback, where nothing is listening, so the connection can never succeed.

Real Chrome derives the discovery authority from the request, so this does the same: use the request `Host` when it is a usable `ws://` authority, and fall back to `127.0.0.1:<port>` when it is absent, empty, or malformed. The validator rejects whitespace, slashes, userinfo, fragments, and control characters before the value reaches the URL, so a hostile `Host` cannot rewrite the advertised URL into something else.

Clients that build their own WebSocket URL from the endpoint they already dialed are unaffected — this only fixes clients that trust the advertised URL, which includes Puppeteer and therefore omp's own browser tool with `app.relay`.

## Why

Any relay reached through port forwarding, a mesh VPN, or a container boundary is unusable with a Puppeteer-based client today. Concretely: a relay listening on a laptop and reached from another machine over Tailscale answers a request that arrived on `100.100.92.97:12803` with `webSocketDebuggerUrl: ws://127.0.0.1:9224/cdp`, and the client dials its own loopback and fails.

## Testing

`bun check` clean in `packages/coding-agent`; `bun test test/tools/browser-relay-server.test.ts` — 5 pass. The tests drive raw sockets (not `fetch`) so they can send a request with no `Host` header at all, covering: remote `Host` reflected, HTTP/1.0 with no `Host` → loopback, empty `Host` → loopback, `Host: bad/host@evil` → loopback, and 503 while the extension handshake is pending.

Behavior exercised directly, not just via tests — same relay code, same request shape, with and without the patch:

```
# with this change
remote Host: 100.100.92.97:12803  ->  ws://100.100.92.97:12803/cdp
loopback request                  ->  ws://127.0.0.1:<port>/cdp

# before this change (server.ts from main)
remote Host: 100.100.92.97:12803  ->  ws://127.0.0.1:<port>/cdp   # client dials itself
loopback request                  ->  ws://127.0.0.1:<port>/cdp
```

The live reproduction that motivated it: `curl -s http://100.100.92.97:12803/json/version` from a second machine returns the loopback URL on `main`, and the reachable authority with this change, which is what lets a Puppeteer client connect.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
