### PR TITLE
fix(catalog): preserve non-reasoning extraBody fields and expose binary thinking toggle for chat-template models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed `applyOpenAIExtraBody` re-enabling reasoning on a disabled turn when the model's `extraBody` carries a top-level dialect toggle (`enable_thinking`, `reasoning_effort`, `reasoning`) that conflicts with the encoder's disabled shape; those keys are now stripped alongside the existing reasoning-only fields, and a `constructor`/`toString`-named `extraBody` key no longer reads as an inherited truthy match.
+- Fixed `applyOpenAIExtraBody` re-enabling reasoning on a disabled turn when a model's `extraBody` carries conflicting top-level or `chat_template_kwargs` dialect controls; those controls are now stripped while unrelated configuration is preserved, and a `constructor`/`toString`-named `extraBody` key no longer reads as an inherited truthy match.
 - Captured bounded Devin Connect trailer details and request-shape evidence for diagnosing intermittent `invalid_argument` stream rejections ([#4218](https://github.com/can1357/oh-my-pi/issues/4218)).
 - Fixed abandoned `auth-broker-snapshot.enc.*.tmp` files accumulating in the cache directory when a process exited mid-write; stale temp files are now swept on each cache write.
 - Fixed Cursor GPT effort models failing with `not_found` on accounts that require the discovered effort-specific model id ([#9287](https://github.com/can1357/oh-my-pi/issues/9287)).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed `applyOpenAIExtraBody` re-enabling reasoning on a disabled turn when the model's `extraBody` carries a top-level dialect toggle (`enable_thinking`, `reasoning_effort`, `reasoning`) that conflicts with the encoder's disabled shape; those keys are now stripped alongside the existing reasoning-only fields, and a `constructor`/`toString`-named `extraBody` key no longer reads as an inherited truthy match.
 - Captured bounded Devin Connect trailer details and request-shape evidence for diagnosing intermittent `invalid_argument` stream rejections ([#4218](https://github.com/can1357/oh-my-pi/issues/4218)).
 - Fixed abandoned `auth-broker-snapshot.enc.*.tmp` files accumulating in the cache directory when a process exited mid-write; stale temp files are now swept on each cache write.
 - Fixed Cursor GPT effort models failing with `not_found` on accounts that require the discovered effort-specific model id ([#9287](https://github.com/can1357/oh-my-pi/issues/9287)).

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1733,6 +1733,7 @@ function buildParams(
 
 	applyOpenAIExtraBody(params, compat.extraBody, {
 		dropThinkingWhenReasoningEffort: compat.dropThinkingWhenReasoningEffort,
+		reasoningDisabled: finalPolicy.reasoning.disabled,
 	});
 	applyOpenAIChatCompletionsPromptCachePolicy(params, model, options);
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -713,28 +713,40 @@ export interface OpenAIExtraBodyOptions {
 	 */
 	dropThinkingWhenReasoningEffort?: boolean;
 	/**
-	 * When true, strip reasoning-specific keys from `extraBody` before
+	 * When true, strip every reasoning-control key from `extraBody` before
 	 * merging instead of skipping the merge entirely. `extraBody` is an
 	 * arbitrary record that commonly carries gateway-routing hints and
 	 * controller fields with no relation to reasoning; dropping the whole
 	 * blob on a reasoning-disable would also drop those unrelated fields
-	 * and could misroute the request. Only the known reasoning-only keys
-	 * (`thinking`, `parse_reasoning`, `include_reasoning`) are removed; the
-	 * rest flows through unchanged.
+	 * and could misroute the request. Only the known reasoning-control keys
+	 * (`REASONING_ONLY_EXTRA_BODY_KEYS`) are removed — including top-level
+	 * dialect toggles (`enable_thinking`, `reasoning_effort`, `reasoning`)
+	 * that could otherwise re-enable reasoning after the encoder already
+	 * wrote its disabled shape; the rest flows through unchanged.
 	 */
 	reasoningDisabled?: boolean;
 }
 
 /**
- * Reasoning-specific `extraBody` keys that are no-ops once reasoning is
- * disabled. Stripped from the blob before merging when `reasoningDisabled`
- * is set; every other key (gateway routing, controller fields, …) survives.
+ * Reasoning-control `extraBody` keys that must not survive a reasoning
+ * disable. Covers the no-op reasoning-only fields plus every top-level
+ * dialect toggle `encodeChatCompletionsDisabledReasoning` can write
+ * (`enable_thinking`, `reasoning_effort`, `reasoning`) so a caller-supplied
+ * `extraBody` cannot re-enable reasoning via `Object.assign` after the
+ * encoder already wrote the disabled shape. Stripped from the blob before
+ * merging when `reasoningDisabled` is set; every other key (gateway
+ * routing, controller fields, …) survives. A `Set` with `.has()` avoids the
+ * prototype-lookup hazard of a plain object index (`constructor`,
+ * `toString`, … would otherwise read as inherited truthy members).
  */
-const REASONING_ONLY_EXTRA_BODY_KEYS: Record<string, true> = {
-	thinking: true,
-	parse_reasoning: true,
-	include_reasoning: true,
-};
+const REASONING_ONLY_EXTRA_BODY_KEYS = new Set([
+	"thinking",
+	"parse_reasoning",
+	"include_reasoning",
+	"enable_thinking",
+	"reasoning_effort",
+	"reasoning",
+]);
 
 /**
  * Merge a compat/options `extraBody` blob into the request params. An encoded
@@ -742,7 +754,7 @@ const REASONING_ONLY_EXTRA_BODY_KEYS: Record<string, true> = {
  * an explicit per-turn Thinking Off selection cannot be re-enabled by config.
  * When `dropThinkingWhenReasoningEffort` is set and `reasoning_effort` is
  * present, delete the conflicting `thinking` toggle (Fireworks rejects both).
- * When `reasoningDisabled` is set, strip only the reasoning-specific keys
+ * When `reasoningDisabled` is set, strip only the reasoning-control keys
  * from the blob before merging so unrelated provider-required configuration
  * (gateway routing, controller fields, …) still reaches the request.
  */
@@ -754,7 +766,7 @@ export function applyOpenAIExtraBody<P extends object>(
 	if (!extraBody) return;
 	const encodedVeniceParameters = params.venice_parameters;
 	const mergedExtraBody = options?.reasoningDisabled
-		? Object.fromEntries(Object.entries(extraBody).filter(([key]) => !REASONING_ONLY_EXTRA_BODY_KEYS[key]))
+		? Object.fromEntries(Object.entries(extraBody).filter(([key]) => !REASONING_ONLY_EXTRA_BODY_KEYS.has(key)))
 		: extraBody;
 	Object.assign(params, mergedExtraBody);
 	if (encodedVeniceParameters?.disable_thinking === true) {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -764,10 +764,16 @@ function splitReasoningDisabledExtraBody(extraBody: Record<string, unknown>): {
 	let chatTemplateKwargs: Record<string, unknown> | undefined;
 	for (const [key, value] of Object.entries(extraBody)) {
 		if (REASONING_ONLY_EXTRA_BODY_KEYS.has(key)) continue;
-		if (key === "chat_template_kwargs" && isRecord(value)) {
-			chatTemplateKwargs = Object.fromEntries(
-				Object.entries(value).filter(([kwarg]) => !REASONING_ONLY_CHAT_TEMPLATE_KWARG_KEYS.has(kwarg)),
-			);
+		if (key === "chat_template_kwargs") {
+			// Only sanitize object-shaped kwargs; a non-record value (null,
+			// array, primitive) would otherwise land in `values` and clobber
+			// the encoder's disabled `chat_template_kwargs` via `Object.assign`.
+			// Drop it so the encoder shape survives.
+			if (isRecord(value)) {
+				chatTemplateKwargs = Object.fromEntries(
+					Object.entries(value).filter(([kwarg]) => !REASONING_ONLY_CHAT_TEMPLATE_KWARG_KEYS.has(kwarg)),
+				);
+			}
 			continue;
 		}
 		values[key] = value;

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -712,7 +712,29 @@ export interface OpenAIExtraBodyOptions {
 	 * `reasoning_effort`; drop `thinking` when the effort field carries the level.
 	 */
 	dropThinkingWhenReasoningEffort?: boolean;
+	/**
+	 * When true, strip reasoning-specific keys from `extraBody` before
+	 * merging instead of skipping the merge entirely. `extraBody` is an
+	 * arbitrary record that commonly carries gateway-routing hints and
+	 * controller fields with no relation to reasoning; dropping the whole
+	 * blob on a reasoning-disable would also drop those unrelated fields
+	 * and could misroute the request. Only the known reasoning-only keys
+	 * (`thinking`, `parse_reasoning`, `include_reasoning`) are removed; the
+	 * rest flows through unchanged.
+	 */
+	reasoningDisabled?: boolean;
 }
+
+/**
+ * Reasoning-specific `extraBody` keys that are no-ops once reasoning is
+ * disabled. Stripped from the blob before merging when `reasoningDisabled`
+ * is set; every other key (gateway routing, controller fields, …) survives.
+ */
+const REASONING_ONLY_EXTRA_BODY_KEYS: Record<string, true> = {
+	thinking: true,
+	parse_reasoning: true,
+	include_reasoning: true,
+};
 
 /**
  * Merge a compat/options `extraBody` blob into the request params. An encoded
@@ -720,6 +742,9 @@ export interface OpenAIExtraBodyOptions {
  * an explicit per-turn Thinking Off selection cannot be re-enabled by config.
  * When `dropThinkingWhenReasoningEffort` is set and `reasoning_effort` is
  * present, delete the conflicting `thinking` toggle (Fireworks rejects both).
+ * When `reasoningDisabled` is set, strip only the reasoning-specific keys
+ * from the blob before merging so unrelated provider-required configuration
+ * (gateway routing, controller fields, …) still reaches the request.
  */
 export function applyOpenAIExtraBody<P extends object>(
 	params: P & { venice_parameters?: Record<string, unknown> },
@@ -728,9 +753,12 @@ export function applyOpenAIExtraBody<P extends object>(
 ): void {
 	if (!extraBody) return;
 	const encodedVeniceParameters = params.venice_parameters;
-	Object.assign(params, extraBody);
+	const mergedExtraBody = options?.reasoningDisabled
+		? Object.fromEntries(Object.entries(extraBody).filter(([key]) => !REASONING_ONLY_EXTRA_BODY_KEYS[key]))
+		: extraBody;
+	Object.assign(params, mergedExtraBody);
 	if (encodedVeniceParameters?.disable_thinking === true) {
-		const configuredVeniceParameters = extraBody.venice_parameters;
+		const configuredVeniceParameters = mergedExtraBody.venice_parameters;
 		params.venice_parameters = {
 			...(isRecord(configuredVeniceParameters) ? configuredVeniceParameters : {}),
 			...encodedVeniceParameters,

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -749,6 +749,33 @@ const REASONING_ONLY_EXTRA_BODY_KEYS = new Set([
 ]);
 
 /**
+ * `chat_template_kwargs` can carry the same Qwen reasoning controls as the
+ * top-level request body. When the encoder has disabled reasoning, remove the
+ * nested controls before merging provider config and retain the encoder's
+ * already-written kwargs over any duplicate config values.
+ */
+const REASONING_ONLY_CHAT_TEMPLATE_KWARG_KEYS = new Set(["enable_thinking", "reasoning_effort"]);
+
+function splitReasoningDisabledExtraBody(extraBody: Record<string, unknown>): {
+	values: Record<string, unknown>;
+	chatTemplateKwargs?: Record<string, unknown>;
+} {
+	const values: Record<string, unknown> = {};
+	let chatTemplateKwargs: Record<string, unknown> | undefined;
+	for (const [key, value] of Object.entries(extraBody)) {
+		if (REASONING_ONLY_EXTRA_BODY_KEYS.has(key)) continue;
+		if (key === "chat_template_kwargs" && isRecord(value)) {
+			chatTemplateKwargs = Object.fromEntries(
+				Object.entries(value).filter(([kwarg]) => !REASONING_ONLY_CHAT_TEMPLATE_KWARG_KEYS.has(kwarg)),
+			);
+			continue;
+		}
+		values[key] = value;
+	}
+	return { values, chatTemplateKwargs };
+}
+
+/**
  * Merge a compat/options `extraBody` blob into the request params. An encoded
  * Venice disable signal takes precedence over static `venice_parameters`, so
  * an explicit per-turn Thinking Off selection cannot be re-enabled by config.
@@ -765,10 +792,17 @@ export function applyOpenAIExtraBody<P extends object>(
 ): void {
 	if (!extraBody) return;
 	const encodedVeniceParameters = params.venice_parameters;
-	const mergedExtraBody = options?.reasoningDisabled
-		? Object.fromEntries(Object.entries(extraBody).filter(([key]) => !REASONING_ONLY_EXTRA_BODY_KEYS.has(key)))
-		: extraBody;
+	const { values: mergedExtraBody, chatTemplateKwargs } = options?.reasoningDisabled
+		? splitReasoningDisabledExtraBody(extraBody)
+		: { values: extraBody };
 	Object.assign(params, mergedExtraBody);
+	if (chatTemplateKwargs !== undefined) {
+		const shaped = params as P & { chat_template_kwargs?: Record<string, unknown> };
+		shaped.chat_template_kwargs = {
+			...chatTemplateKwargs,
+			...shaped.chat_template_kwargs,
+		};
+	}
 	if (encodedVeniceParameters?.disable_thinking === true) {
 		const configuredVeniceParameters = mergedExtraBody.venice_parameters;
 		params.venice_parameters = {

--- a/packages/ai/test/openai-completions-disable-reasoning.test.ts
+++ b/packages/ai/test/openai-completions-disable-reasoning.test.ts
@@ -206,6 +206,37 @@ describe("OpenAI completions disableReasoning and thinking dialects", () => {
 		const payload = (await promise) as Record<string, unknown>;
 		expect(payload.chat_template_kwargs).toEqual({ enable_thinking: true });
 	});
+
+	it("keeps Qwen chat-template reasoning disabled when extraBody carries a nested override", async () => {
+		const model = buildModel({
+			id: "qwen-ct-extra-body-reasoner",
+			name: "Qwen Chat Template Extra Body Reasoner",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://proxy.example.com/v1",
+			reasoning: true,
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				supportsReasoningParams: true,
+				extraBody: {
+					chat_template_kwargs: {
+						enable_thinking: true,
+						reasoning_effort: "high",
+						custom_template_option: "keep-me",
+					},
+					gateway: "route-a",
+				},
+			},
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+
+		const payload = await captureDisableReasoningPayload(model);
+		expect(payload.chat_template_kwargs).toEqual({ enable_thinking: false, custom_template_option: "keep-me" });
+		expect(payload.gateway).toBe("route-a");
+	});
 	it("does not emit enable_thinking or chat_template_kwargs for the bundled Fireworks Qwen model without reasoning", async () => {
 		// Reproduces the raw 400 from `fireworks/qwen3.7-plus`: before the fix the
 		// `qwen/*` id pattern forced `thinkingFormat: "qwen"`, so an effort-less

--- a/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
+++ b/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
@@ -19,4 +19,39 @@ describe("applyOpenAIExtraBody reasoningDisabled", () => {
 		expect(params.thinking).toEqual({ type: "enabled" });
 		expect(params.provider).toEqual({ order: ["foo"] });
 	});
+
+	it("strips top-level dialect toggles that could re-enable reasoning after the disabled encoding", () => {
+		// Reproduces the reported Qwen payload: the encoder already wrote
+		// `chat_template_kwargs.enable_thinking: false` for the disabled turn,
+		// but a caller-supplied extraBody carrying `enable_thinking: true` and
+		// `reasoning_effort` must not survive the merge and flip it back on.
+		// Unrelated gateway-routing fields (`gateway`) must still pass through.
+		const params: Record<string, unknown> = { chat_template_kwargs: { enable_thinking: false } };
+		applyOpenAIExtraBody(
+			params,
+			{ enable_thinking: true, reasoning_effort: "high", reasoning: { effort: "high" }, gateway: "route-a" },
+			{ reasoningDisabled: true },
+		);
+
+		expect(params.enable_thinking).toBeUndefined();
+		expect(params.reasoning_effort).toBeUndefined();
+		expect(params.reasoning).toBeUndefined();
+		expect(params.chat_template_kwargs).toEqual({ enable_thinking: false });
+		expect(params.gateway).toBe("route-a");
+	});
+
+	it("does not treat inherited Object.prototype members as reasoning keys", () => {
+		// A plain-object index (`REASONING_ONLY_EXTRA_BODY_KEYS[key]`) would read
+		// `constructor`/`toString` off the prototype chain as truthy and silently
+		// drop them even though they are not reasoning controls; the Set-backed
+		// lookup must only match the explicit reasoning-control key list.
+		const params: Record<string, unknown> = {};
+		applyOpenAIExtraBody(params, { constructor: "keep-me", toString: "also-keep", thinking: { type: "enabled" } }, {
+			reasoningDisabled: true,
+		});
+
+		expect(params["constructor"]).toBe("keep-me");
+		expect(params["toString"]).toBe("also-keep");
+		expect(params.thinking).toBeUndefined();
+	});
 });

--- a/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
+++ b/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
@@ -4,9 +4,13 @@ import { applyOpenAIExtraBody } from "@oh-my-pi/pi-ai/providers/openai-shared";
 describe("applyOpenAIExtraBody reasoningDisabled", () => {
 	it("strips only reasoning-only keys, preserving unrelated extraBody fields", () => {
 		const params: Record<string, unknown> = {};
-		applyOpenAIExtraBody(params, { thinking: { type: "enabled" }, provider: { order: ["foo"] } }, {
-			reasoningDisabled: true,
-		});
+		applyOpenAIExtraBody(
+			params,
+			{ thinking: { type: "enabled" }, provider: { order: ["foo"] } },
+			{
+				reasoningDisabled: true,
+			},
+		);
 
 		expect(params.thinking).toBeUndefined();
 		expect(params.provider).toEqual({ order: ["foo"] });
@@ -40,18 +44,50 @@ describe("applyOpenAIExtraBody reasoningDisabled", () => {
 		expect(params.gateway).toBe("route-a");
 	});
 
+	it("preserves the encoder's disabled chat-template toggle while merging unrelated nested kwargs", () => {
+		// The extra body is merged after the dialect encoder. A nested Qwen
+		// `enable_thinking: true` must not clobber the disabled turn, but static
+		// template configuration unrelated to reasoning still belongs on the wire.
+		const params: Record<string, unknown> = {
+			chat_template_kwargs: { enable_thinking: false, preserve_thinking: true },
+		};
+		applyOpenAIExtraBody(
+			params,
+			{
+				chat_template_kwargs: {
+					enable_thinking: true,
+					reasoning_effort: "high",
+					custom_template_option: "keep-me",
+				},
+				gateway: "route-a",
+			},
+			{ reasoningDisabled: true },
+		);
+
+		expect(params.chat_template_kwargs).toEqual({
+			enable_thinking: false,
+			preserve_thinking: true,
+			custom_template_option: "keep-me",
+		});
+		expect(params.gateway).toBe("route-a");
+	});
+
 	it("does not treat inherited Object.prototype members as reasoning keys", () => {
 		// A plain-object index (`REASONING_ONLY_EXTRA_BODY_KEYS[key]`) would read
 		// `constructor`/`toString` off the prototype chain as truthy and silently
 		// drop them even though they are not reasoning controls; the Set-backed
 		// lookup must only match the explicit reasoning-control key list.
 		const params: Record<string, unknown> = {};
-		applyOpenAIExtraBody(params, { constructor: "keep-me", toString: "also-keep", thinking: { type: "enabled" } }, {
-			reasoningDisabled: true,
-		});
+		applyOpenAIExtraBody(
+			params,
+			{ constructor: "keep-me", toString: "also-keep", thinking: { type: "enabled" } },
+			{
+				reasoningDisabled: true,
+			},
+		);
 
-		expect(params["constructor"]).toBe("keep-me");
-		expect(params["toString"]).toBe("also-keep");
+		expect(Object.getOwnPropertyDescriptor(params, "constructor")?.value).toBe("keep-me");
+		expect(Object.getOwnPropertyDescriptor(params, "toString")?.value).toBe("also-keep");
 		expect(params.thinking).toBeUndefined();
 	});
 });

--- a/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
+++ b/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
@@ -72,6 +72,25 @@ describe("applyOpenAIExtraBody reasoningDisabled", () => {
 		expect(params.gateway).toBe("route-a");
 	});
 
+	it("drops a non-record chat_template_kwargs instead of clobbering the encoder disabled shape", () => {
+		// null, arrays, or primitives at extraBody.chat_template_kwargs must not
+		// survive into the merged values; otherwise Object.assign overwrites the
+		// encoder's `{ enable_thinking: false }` and the server defaults to
+		// thinking-on (or rejects the malformed payload).
+		for (const malformed of [null, ["enable_thinking", true], "false", 42]) {
+			const params: Record<string, unknown> = {
+				chat_template_kwargs: { enable_thinking: false },
+			};
+			applyOpenAIExtraBody(
+				params,
+				{ chat_template_kwargs: malformed, gateway: "route-a" },
+				{ reasoningDisabled: true },
+			);
+			expect(params.chat_template_kwargs).toEqual({ enable_thinking: false });
+			expect(params.gateway).toBe("route-a");
+		}
+	});
+
 	it("does not treat inherited Object.prototype members as reasoning keys", () => {
 		// A plain-object index (`REASONING_ONLY_EXTRA_BODY_KEYS[key]`) would read
 		// `constructor`/`toString` off the prototype chain as truthy and silently

--- a/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
+++ b/packages/ai/test/openai-extra-body-reasoning-disabled.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { applyOpenAIExtraBody } from "@oh-my-pi/pi-ai/providers/openai-shared";
+
+describe("applyOpenAIExtraBody reasoningDisabled", () => {
+	it("strips only reasoning-only keys, preserving unrelated extraBody fields", () => {
+		const params: Record<string, unknown> = {};
+		applyOpenAIExtraBody(params, { thinking: { type: "enabled" }, provider: { order: ["foo"] } }, {
+			reasoningDisabled: true,
+		});
+
+		expect(params.thinking).toBeUndefined();
+		expect(params.provider).toEqual({ order: ["foo"] });
+	});
+
+	it("merges the full extraBody blob (including reasoning keys) when reasoningDisabled is not set", () => {
+		const params: Record<string, unknown> = {};
+		applyOpenAIExtraBody(params, { thinking: { type: "enabled" }, provider: { order: ["foo"] } });
+
+		expect(params.thinking).toEqual({ type: "enabled" });
+		expect(params.provider).toEqual({ order: ["foo"] });
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed chat-template reasoning dialects that expose only a binary `enable_thinking` toggle showing a fake multi-tier effort ladder in the picker; the ladder now collapses to one selectable tier when no effort field reaches the wire.
 - Fixed `opencode-go/ox-alpha-free` sending `reasoning_effort: "xhigh"` for the top thinking tier, which the OpenCode Go gateway rejects; the model now uses the gateway's wire-exact `low`/`high`/`max` ladder with mandatory thinking so `--thinking max` reaches the real max tier ([#9349](https://github.com/can1357/oh-my-pi/issues/9349)).
 - Fixed Venice-hosted Qwen models (e.g. `venice/qwen3-6-35b-a3b`) failing with `400 Invalid request parameters`. Reasoning levels now use the accepted OpenAI-style `reasoning_effort` field, while Thinking Off sends Venice's explicit `venice_parameters.disable_thinking` flag ([#9345](https://github.com/can1357/oh-my-pi/issues/9345)).
 - Fixed gateway-first OpenCode Zen and Go models missing context, output, image, and reasoning metadata by enriching live discovery from the current stencil catalog ([#9272](https://github.com/can1357/oh-my-pi/issues/9272)).

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed chat-template reasoning dialects that expose only a binary `enable_thinking` toggle showing a fake multi-tier effort ladder in the picker; the ladder now collapses to one selectable tier when no effort field reaches the wire.
+- Fixed effort-routed models on Qwen chat-template backends showing only one selectable thinking tier, which made all other routed upstream models unreachable; effort levels that switch between distinct upstream models now keep their tiers.
 - Fixed `opencode-go/ox-alpha-free` sending `reasoning_effort: "xhigh"` for the top thinking tier, which the OpenCode Go gateway rejects; the model now uses the gateway's wire-exact `low`/`high`/`max` ladder with mandatory thinking so `--thinking max` reaches the real max tier ([#9349](https://github.com/can1357/oh-my-pi/issues/9349)).
 - Fixed Venice-hosted Qwen models (e.g. `venice/qwen3-6-35b-a3b`) failing with `400 Invalid request parameters`. Reasoning levels now use the accepted OpenAI-style `reasoning_effort` field, while Thinking Off sends Venice's explicit `venice_parameters.disable_thinking` flag ([#9345](https://github.com/can1357/oh-my-pi/issues/9345)).
 - Fixed gateway-first OpenCode Zen and Go models missing context, output, image, and reasoning metadata by enriching live discovery from the current stencil catalog ([#9272](https://github.com/can1357/oh-my-pi/issues/9272)).

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -149,15 +149,18 @@ export function resolveModelThinking<TApi extends Api>(
 ): ThinkingConfig | undefined {
 	if (!spec.reasoning) return undefined;
 	if (omitsWireReasoningEffort(spec.api, compat)) return undefined;
+	let thinking: ThinkingConfig;
 	if (spec.thinking && Array.isArray(spec.thinking.efforts) && spec.thinking.efforts.length > 0) {
-		return fillThinkingWireDefaults(spec, compat, spec.thinking);
+		thinking = fillThinkingWireDefaults(spec, compat, spec.thinking);
+	} else {
+		// Cascade selects effort only by routing to a sibling model id, so a
+		// Devin model with no explicit routed thinking has no controllable
+		// surface — never fabricate an effort ladder from identity.
+		if ((compat as ResolvedDevinCompat | undefined)?.trustExplicitThinkingOnly === true) return undefined;
+		// Empty/malformed explicit metadata is treated as absent — infer instead.
+		thinking = deriveThinking(spec, compat);
 	}
-	// Cascade selects effort only by routing to a sibling model id, so a Devin
-	// model with no explicit routed thinking has no controllable surface —
-	// never fabricate an effort ladder from identity.
-	if ((compat as ResolvedDevinCompat | undefined)?.trustExplicitThinkingOnly === true) return undefined;
-	// Empty/malformed explicit metadata is treated as absent — infer instead.
-	return deriveThinking(spec, compat);
+	return collapseQwenTemplateBinaryThinking(thinking, spec, compat);
 }
 
 /**
@@ -259,13 +262,58 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
  * (xAI Grok off the `isGrokReasoningEffortCapable` allowlist: grok-build,
  * grok-4.20-0309-reasoning). openai-completions keeps its thinking config even
  * without effort support — binary thinking formats (zai/qwen) drive reasoning
- * through other request fields.
+ * through other request fields, and qwen-chat-template models whose compat
+ * omits `reasoning_effort` entirely collapse to a single binary toggle in
+ * `collapseQwenTemplateBinaryThinking` rather than dropping thinking here.
  */
 function omitsWireReasoningEffort(api: Api, compat: CompatOf<Api>): boolean {
 	if (api !== "openai-responses" && api !== "openai-codex-responses" && api !== "azure-openai-responses") {
 		return false;
 	}
 	return (compat as ResolvedOpenAIResponsesCompat | undefined)?.supportsReasoningEffort === false;
+}
+
+/**
+ * True for openai-completions/openrouter models whose chat template exposes
+ * reasoning only through the binary `chat_template_kwargs.enable_thinking`
+ * toggle, with no effort-tier field anywhere on the wire: `thinkingFormat`
+ * resolves to the Qwen chat-template dialect, `omitReasoningEffort` is set
+ * (the top-level field is suppressed), and the template-kwarg effort escape
+ * hatch (`qwenTemplateReasoningEffort`) is not enabled. Backends that DO
+ * route the ladder through `chat_template_kwargs.reasoning_effort` set that
+ * escape hatch and keep their genuine multi-tier surface.
+ */
+function isQwenTemplateBinaryThinking(api: Api, compat: CompatOf<Api>): boolean {
+	if (api !== "openai-completions" && api !== "openrouter") return false;
+	const resolved = compat as ResolvedOpenAICompat | undefined;
+	return (
+		resolved?.thinkingFormat === "qwen-chat-template" &&
+		resolved?.omitReasoningEffort === true &&
+		resolved?.qwenTemplateReasoningEffort !== true
+	);
+}
+
+/**
+ * Collapse a bundled multi-tier effort ladder to a single tier for
+ * qwen-chat-template models whose wire body carries only the binary
+ * `enable_thinking` toggle. Without this, every tier produces an
+ * identical request body, so the picker offered a fake multi-tier ladder
+ * with no distinguishable effect; a single tier gives it one real on/off
+ * control instead. The kept tier is the model's `defaultLevel` when set,
+ * else the highest bundled effort; the per-tier `effortMap` no longer
+ * applies to a collapsed single-tier ladder and is dropped.
+ */
+function collapseQwenTemplateBinaryThinking<TApi extends Api>(
+	thinking: ThinkingConfig,
+	spec: ModelSpec<TApi>,
+	compat: CompatOf<TApi>,
+): ThinkingConfig {
+	if (!isQwenTemplateBinaryThinking(spec.api, compat)) return thinking;
+	if (thinking.efforts.length <= 1) return thinking;
+	const tier = thinking.defaultLevel ?? thinking.efforts[thinking.efforts.length - 1];
+	const collapsed: ThinkingConfig = { ...thinking, efforts: [tier] };
+	delete collapsed.effortMap;
+	return collapsed;
 }
 
 function inferEffortMap<TApi extends Api>(

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -276,21 +276,24 @@ function omitsWireReasoningEffort(api: Api, compat: CompatOf<Api>): boolean {
 /**
  * True for openai-completions/openrouter models whose chat template exposes
  * reasoning only through the binary `chat_template_kwargs.enable_thinking`
- * toggle, with no effort-tier field anywhere on the wire: `thinkingFormat`
- * resolves to the Qwen chat-template dialect, `omitReasoningEffort` is set
- * (the top-level field is suppressed), and the template-kwarg effort escape
- * hatch (`qwenTemplateReasoningEffort`) is not enabled. Backends that DO
- * route the ladder through `chat_template_kwargs.reasoning_effort` set that
- * escape hatch and keep their genuine multi-tier surface.
+ * toggle, with no effort-tier field anywhere on the wire. Mirrors the actual
+ * dispatch key `applyChatCompletionsCompatPolicy` switches on rather than
+ * `omitReasoningEffort`: the encoder's `qwen-template-false` branch always
+ * writes `chat_template_kwargs.enable_thinking` and only adds an effort kwarg
+ * when `qwenTemplateReasoningEffort` is true — it never reads
+ * `omitReasoningEffort` (that flag only gates the unrelated `default` branch,
+ * which `reasoningDisableMode: "qwen-template-false"` never falls into).
+ * Checking `omitReasoningEffort` here left every bundled qwen-chat-template
+ * model uncollapsed in practice, since `buildOpenAICompat` defaults it to
+ * `false` for any Qwen host that reports `supportsReasoningEffort: true`.
+ * Backends that DO route the ladder through
+ * `chat_template_kwargs.reasoning_effort` set `qwenTemplateReasoningEffort`
+ * and keep their genuine multi-tier surface.
  */
 function isQwenTemplateBinaryThinking(api: Api, compat: CompatOf<Api>): boolean {
 	if (api !== "openai-completions" && api !== "openrouter") return false;
 	const resolved = compat as ResolvedOpenAICompat | undefined;
-	return (
-		resolved?.thinkingFormat === "qwen-chat-template" &&
-		resolved?.omitReasoningEffort === true &&
-		resolved?.qwenTemplateReasoningEffort !== true
-	);
+	return resolved?.reasoningDisableMode === "qwen-template-false" && resolved?.qwenTemplateReasoningEffort !== true;
 }
 
 /**

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -305,6 +305,14 @@ function isQwenTemplateBinaryThinking(api: Api, compat: CompatOf<Api>): boolean 
  * control instead. The kept tier is the model's `defaultLevel` when set,
  * else the highest bundled effort; the per-tier `effortMap` no longer
  * applies to a collapsed single-tier ladder and is dropped.
+ *
+ * Effort-routed models are exempt when their tiers resolve to DISTINCT
+ * upstream wire ids: `effortRouting` maps each tier to a wire model
+ * (`resolveWireModelId`) that the request serializes, so the tiers are
+ * wire-distinct and collapsing would strand every routed upstream except
+ * the kept tier. Uniform routing — the X/X-thinking pair shape, where
+ * every tier routes to the same id — still produces identical bodies
+ * per tier and still collapses; only wire-distinct routing survives.
  */
 function collapseQwenTemplateBinaryThinking<TApi extends Api>(
 	thinking: ThinkingConfig,
@@ -313,6 +321,10 @@ function collapseQwenTemplateBinaryThinking<TApi extends Api>(
 ): ThinkingConfig {
 	if (!isQwenTemplateBinaryThinking(spec.api, compat)) return thinking;
 	if (thinking.efforts.length <= 1) return thinking;
+	const routedWireIds = new Set(
+		thinking.efforts.map(effort => thinking.effortRouting?.[effort] ?? spec.requestModelId ?? spec.id),
+	);
+	if (routedWireIds.size > 1) return thinking;
 	const tier = thinking.defaultLevel ?? thinking.efforts[thinking.efforts.length - 1];
 	const collapsed: ThinkingConfig = { ...thinking, efforts: [tier] };
 	delete collapsed.effortMap;

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -1162,3 +1162,72 @@ describe("Qwen 3.8 local template effort ladder", () => {
 		expect(ollama.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.Max]);
 	});
 });
+
+describe("qwen-chat-template binary thinking toggle collapse", () => {
+	it("collapses a bundled multi-tier ladder to one tier when the wire exposes only the enable_thinking toggle", () => {
+		// omitReasoningEffort suppresses the top-level field and
+		// qwenTemplateReasoningEffort is not set, so neither the top-level
+		// nor the chat_template_kwargs effort surface reaches the wire —
+		// every tier would otherwise produce an identical request body.
+		const model = createModel({
+			id: "qwen3.8-30b",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://strict-gateway.example.com/v1",
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				omitReasoningEffort: true,
+				qwenTemplateReasoningEffort: false,
+			},
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High],
+				defaultLevel: Effort.Medium,
+			},
+		});
+
+		expect(model.thinking?.efforts).toEqual([Effort.Medium]);
+		expect(model.thinking?.effortMap).toBeUndefined();
+	});
+
+	it("keeps the full ladder when a template-kwarg or top-level effort field is supported", () => {
+		// qwenTemplateReasoningEffort: true means the ladder still reaches
+		// the wire via chat_template_kwargs.reasoning_effort — must not collapse.
+		// (The wire-exact low/medium/xhigh tiers for this dialect are enforced
+		// independently of the collapse logic under test here.)
+		const templateEffort = createModel({
+			id: "qwen3.8-30b",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "http://localhost:8080/v1",
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				omitReasoningEffort: true,
+				qwenTemplateReasoningEffort: true,
+			},
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High],
+			},
+		});
+		expect(templateEffort.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.XHigh]);
+
+		// omitReasoningEffort: false means the top-level reasoning_effort
+		// field is accepted — must not collapse either.
+		const topLevelEffort = createModel({
+			id: "qwen3.8-30b",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://gateway.example.com/v1",
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				omitReasoningEffort: false,
+			},
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High],
+			},
+		});
+		expect(topLevelEffort.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+	});
+});

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -1190,7 +1190,7 @@ describe("qwen-chat-template binary thinking toggle collapse", () => {
 		expect(model.thinking?.effortMap).toBeUndefined();
 	});
 
-	it("keeps the full ladder when a template-kwarg or top-level effort field is supported", () => {
+	it("keeps the full ladder only when chat_template_kwargs.reasoning_effort actually reaches the wire", () => {
 		// qwenTemplateReasoningEffort: true means the ladder still reaches
 		// the wire via chat_template_kwargs.reasoning_effort — must not collapse.
 		// (The wire-exact low/medium/xhigh tiers for this dialect are enforced
@@ -1211,9 +1211,19 @@ describe("qwen-chat-template binary thinking toggle collapse", () => {
 			},
 		});
 		expect(templateEffort.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.XHigh]);
+	});
 
-		// omitReasoningEffort: false means the top-level reasoning_effort
-		// field is accepted — must not collapse either.
+	it("collapses even when omitReasoningEffort: false, because the qwen-template-false encoder never reads that flag", () => {
+		// `omitReasoningEffort` only gates the `default` switch branch in
+		// `applyChatCompletionsCompatPolicy`; the `qwen-template-false` branch
+		// (which every qwen-chat-template model's `reasoningDisableMode`
+		// resolves to) always writes `chat_template_kwargs.enable_thinking`
+		// and only adds an effort kwarg when `qwenTemplateReasoningEffort` is
+		// true. A real NVIDIA NIM-hosted Qwen model reports
+		// `supportsReasoningEffort: true` (so `omitReasoningEffort` defaults
+		// to `false`) yet has no local `qwenTemplateReasoningEffort` escape
+		// hatch — every requested tier previously produced an identical
+		// request body despite the ladder claiming three selectable tiers.
 		const topLevelEffort = createModel({
 			id: "qwen3.8-30b",
 			api: "openai-completions",
@@ -1226,8 +1236,10 @@ describe("qwen-chat-template binary thinking toggle collapse", () => {
 			thinking: {
 				mode: "effort",
 				efforts: [Effort.Low, Effort.Medium, Effort.High],
+				defaultLevel: Effort.Medium,
 			},
 		});
-		expect(topLevelEffort.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+		expect(topLevelEffort.thinking?.efforts).toEqual([Effort.Medium]);
+		expect(topLevelEffort.thinking?.effortMap).toBeUndefined();
 	});
 });

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -1242,4 +1242,62 @@ describe("qwen-chat-template binary thinking toggle collapse", () => {
 		expect(topLevelEffort.thinking?.efforts).toEqual([Effort.Medium]);
 		expect(topLevelEffort.thinking?.effortMap).toBeUndefined();
 	});
+
+	it("keeps effort-routed tiers that resolve to distinct upstream wire ids", () => {
+		// effortRouting maps each tier to a wire model that the request
+		// serializes (resolveWireModelId), so tiers routing to distinct
+		// upstream ids are wire-distinct and must keep their ladder —
+		// collapsing would strand every routed upstream except the kept
+		// tier behind a picker that can no longer select them.
+		const routed = createModel({
+			id: "qwen3.8-30b",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://gateway.example.com/v1",
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				omitReasoningEffort: true,
+			},
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High],
+				effortRouting: {
+					[Effort.Low]: "qwen3.8-30b-low",
+					[Effort.Medium]: "qwen3.8-30b-medium",
+					[Effort.High]: "qwen3.8-30b-high",
+				},
+			},
+		});
+		expect(routed.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+		expect(routed.thinking?.effortRouting).not.toBeUndefined();
+	});
+
+	it("still collapses routed ladders whose tiers all send the same wire id", () => {
+		// The variant-collapse X/X-thinking pair shape: every tier routes
+		// to the same upstream id, so tiers stay body-identical and the
+		// fake-ladder collapse must still apply.
+		const uniformlyRouted = createModel({
+			id: "qwen3.8-30b",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://gateway.example.com/v1",
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				omitReasoningEffort: true,
+			},
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High],
+				defaultLevel: Effort.Medium,
+				effortRouting: {
+					off: "qwen3.8-30b",
+					[Effort.Low]: "qwen3.8-30b-thinking",
+					[Effort.Medium]: "qwen3.8-30b-thinking",
+					[Effort.High]: "qwen3.8-30b-thinking",
+				},
+			},
+		});
+		expect(uniformlyRouted.thinking?.efforts).toEqual([Effort.Medium]);
+		expect(uniformlyRouted.thinking?.effortMap).toBeUndefined();
+	});
 });


### PR DESCRIPTION
This fixes two related issues in the generic OpenAI-compatible reasoning path. Neither change is tied to a specific provider integration.

`applyOpenAIExtraBody` previously dropped the entire `extraBody` blob whenever reasoning was disabled, guarding against sending stale `thinking`/`parse_reasoning`/`include_reasoning` fields. But `extraBody` is an arbitrary record that can also carry unrelated gateway-routing hints or controller fields, and dropping the whole thing on a reasoning-disable silently discarded those too, which could misroute the request. The fix strips only the known reasoning-only keys before merging, so everything else in `extraBody` still reaches the request.

Separately, some chat-template reasoning dialects (the Qwen chat-template family) expose reasoning purely through a binary `chat_template_kwargs.enable_thinking` toggle, with no effort-tier field anywhere on the wire. When a model's compat resolves `thinkingFormat: 'qwen-chat-template'` with `omitReasoningEffort: true` and no `qwenTemplateReasoningEffort` escape hatch, every tier in a bundled multi-tier effort ladder produces an identical request body, so the picker showed a fake multi-tier ladder with no actual effect. `resolveModelThinking` now collapses that ladder down to a single tier (the model's default level, or the highest bundled effort) so the picker offers one real on/off control instead.

Both changes trigger purely off existing generic `OpenAICompat` fields already present in the codebase (`thinkingFormat`, `omitReasoningEffort`, `qwenTemplateReasoningEffort`). No new provider identifiers or host-specific branches were added.

Added regression tests covering: (1) `reasoningDisabled` preserves unrelated `extraBody` keys while dropping only reasoning-specific ones, and (2) the effort ladder collapses under the toggle-only condition but stays intact when either a template-kwarg or top-level effort field is supported.