### PR TITLE
fix(cursor): make #8345 conversation rotation actually recover retry/resume turns

### DIFF
--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -327,13 +327,15 @@ const warnedCursorKimiK3ReplayMessages = new Set<string>();
 /**
  * Base conversation id → rotated wire id (#8345). Cursor's backend can pin a
  * per-conversation rejection (bare `resource_exhausted`, zero tokens) to one
- * conversationId forever; the session is then unusable until /fork mints a
- * new id. On the first such failure the id is rotated once and the cached
- * state migrates, so the retry loop's next attempt starts a fresh
- * conversation — the same recovery /fork performs. Keyed by the base id the
- * caller derived, so a failed rotation is never repeated.
+ * conversationId forever. On such a failure the id is rotated and the next
+ * attempt rebuilds a fresh conversation from `context` (no cached-state
+ * migration). A failed rotation is not repeated, so real account exhaustion
+ * is not hidden. After the rotated id completes a turn, a later poison of
+ * that id is allowed to rotate again.
  */
 const rotatedConversationIds = new Map<string, string>();
+const successfulRotatedConversationIds = new Set<string>();
+const freshRotatedConversationIds = new Set<string>();
 
 export interface CursorOptions extends StreamOptions {
 	customSystemPrompt?: string;
@@ -355,6 +357,7 @@ interface CursorRequestState {
 	conversationId: string;
 	blobStore: Map<string, Uint8Array>;
 	conversationState?: ConversationStateStructure;
+	rotatedFresh?: boolean;
 }
 
 interface CursorGrpcRequest {
@@ -680,9 +683,10 @@ function streamCursorWithWireMode(
 
 			baseConversationId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
 			conversationId = rotatedConversationIds.get(baseConversationId) ?? baseConversationId;
+			const rotatedFresh = freshRotatedConversationIds.has(conversationId);
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
-			const cachedState = conversationStateCache.get(conversationId);
+			const cachedState = rotatedFresh ? undefined : conversationStateCache.get(conversationId);
 			const builtRequest = await buildGrpcRequestForWireMode(
 				model,
 				context,
@@ -691,6 +695,7 @@ function streamCursorWithWireMode(
 					conversationId,
 					blobStore,
 					conversationState: cachedState,
+					rotatedFresh,
 				},
 				wireMode,
 			);
@@ -872,6 +877,10 @@ function streamCursorWithWireMode(
 						// Application completion is not protocol success; wait for a clean HTTP/2 end.
 						if (isTurnEnded) {
 							sawTurnEnded = true;
+							if (conversationId && baseConversationId && conversationId !== baseConversationId) {
+								successfulRotatedConversationIds.add(conversationId);
+								freshRotatedConversationIds.delete(conversationId);
+							}
 						}
 					} catch (e) {
 						log("error", "parseServerMessage", { error: String(e) });
@@ -1013,25 +1022,29 @@ function streamCursorWithWireMode(
 			const result = await AIError.finalize(error, { api: model.api, signal: options?.signal });
 			// #8345: a server-side per-conversation rejection surfaces as a bare
 			// resource_exhausted with zero tokens — the conversation is poisoned,
-			// not the account (sibling conversations keep working). Rotate the
-			// wire id once and migrate the cached state so the next attempt (the
-			// caller's retry loop) starts a fresh conversation, exactly like
-			// /fork. Only the first failure rotates; repeated failures keep the
-			// rotated id so a genuine account-level exhaustion is not hidden.
+			// not the account. Rotate the wire id and rebuild from `context` on
+			// the next attempt (the caller's retry loop). Do not migrate cached
+			// side-state: pendingToolCalls from a mid-turn checkpoint re-poison
+			// the new id. One rotation per failure streak; a new rotation is
+			// allowed only after the current rotated id completed a turn.
+			const currentRotated = rotatedConversationIds.get(baseConversationId);
+			const canRotate = currentRotated === undefined || successfulRotatedConversationIds.has(currentRotated);
 			if (
 				conversationId !== undefined &&
 				baseConversationId !== undefined &&
 				usageState !== undefined &&
 				!usageState.sawTokenDelta &&
 				RESOURCE_EXHAUSTED_PATTERN.test(result.message) &&
-				!rotatedConversationIds.has(baseConversationId)
+				canRotate
 			) {
 				const rotated = crypto.randomUUID();
 				rotatedConversationIds.set(baseConversationId, rotated);
-				const state = conversationStateCache.get(conversationId);
-				if (state) conversationStateCache.set(rotated, state);
-				const blobs = conversationBlobStores.get(conversationId);
-				if (blobs) conversationBlobStores.set(rotated, blobs);
+				freshRotatedConversationIds.add(rotated);
+				logger.debug("cursor conversation rotated", {
+					base: baseConversationId,
+					from: conversationId,
+					to: rotated,
+				});
 			}
 			output.stopReason = result.stopReason;
 			output.errorStatus = result.status;
@@ -5210,10 +5223,18 @@ async function buildGrpcRequestForWireMode(
 		storeCursorBlob(blobStore, new TextEncoder().encode(json)),
 	);
 
-	const activeUserMessageIndex = context.messages.length - 1;
-	const activeMessage = context.messages[activeUserMessageIndex];
-	const activeUserMessage =
+	const lastUserMessageIndex = findLastUserMessageIndex(context.messages);
+	let activeUserMessageIndex = context.messages.length - 1;
+	let activeMessage = context.messages[activeUserMessageIndex];
+	let activeUserMessage =
 		activeMessage?.role === "user" || activeMessage?.role === "developer" ? activeMessage : undefined;
+	if (state.rotatedFresh && !activeUserMessage && lastUserMessageIndex >= 0) {
+		activeUserMessageIndex = lastUserMessageIndex;
+		const lastUser = context.messages[lastUserMessageIndex];
+		if (lastUser.role === "user" || lastUser.role === "developer") {
+			activeUserMessage = lastUser;
+		}
+	}
 	let userContent: string | (TextContent | ImageContent)[] | undefined;
 	let userText = "";
 	let hasUserImages = false;

--- a/packages/ai/test/cursor-conversation-rotate.test.ts
+++ b/packages/ai/test/cursor-conversation-rotate.test.ts
@@ -58,6 +58,58 @@ function decodeConversationId(chunk: Buffer): string | undefined {
 	return msg.message.value.conversationId;
 }
 
+type WireRequest = {
+	conversationId?: string;
+	action?: string;
+	pendingToolCalls: number;
+};
+
+function decodeRunRequest(chunk: Buffer): WireRequest | undefined {
+	const msg = fromBinary(AgentClientMessageSchema, chunk.subarray(5));
+	if (msg.message.case !== "runRequest") return undefined;
+	const req = msg.message.value;
+	return {
+		conversationId: req.conversationId,
+		action: req.action?.action.case,
+		pendingToolCalls: req.conversationState?.pendingToolCalls?.length ?? 0,
+	};
+}
+
+/** /retry after restart: trailing tool results, no active user message. */
+function resumeContext(): Context {
+	return {
+		messages: [
+			{ role: "user", content: "Use the read tool.", timestamp: 1 },
+			{
+				role: "assistant",
+				api: "cursor-agent",
+				provider: "cursor",
+				model: "cursor-rotation-fixture",
+				content: [{ type: "toolCall", id: "call-read", name: "read", arguments: { path: "package.json" } }],
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: 2,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call-read",
+				toolName: "read",
+				content: [{ type: "text", text: "package contents" }],
+				isError: false,
+				timestamp: 3,
+			},
+		],
+	};
+}
+
+
 /** First request ends with a bare resource_exhausted; later ones turn normally. */
 async function startServer(seenConversationIds: string[]): Promise<string> {
 	server = http2.createServer();
@@ -72,6 +124,44 @@ async function startServer(seenConversationIds: string[]): Promise<string> {
 			if (conversationId !== undefined) seenConversationIds.push(conversationId);
 			requestCount++;
 			if (requestCount === 1) {
+				stream.respond({ ":status": 200, "content-type": "application/connect+proto" }, { waitForTrailers: true });
+				stream.once("wantTrailers", () => {
+					stream.sendTrailers({ "grpc-status": "8", "grpc-message": "resource_exhausted" });
+				});
+				stream.end();
+			} else {
+				stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+				stream.write(textDeltaFrame("recovered"));
+				stream.write(turnEndedFrame());
+				stream.end();
+			}
+		});
+	});
+
+	const listening = Promise.withResolvers<void>();
+	server.once("error", listening.reject);
+	server.listen(0, "127.0.0.1", listening.resolve);
+	await listening.promise;
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("expected the fixture server to bind a tcp port");
+	return `http://127.0.0.1:${address.port}`;
+}
+
+/** Scripted fixture: each entry is reject (grpc 8) or a normal turn. */
+async function startScriptedServer(seen: WireRequest[], script: Array<"reject" | "ok">): Promise<string> {
+	server = http2.createServer();
+	server.on("session", session => {
+		sessions.add(session);
+		session.on("close", () => sessions.delete(session));
+	});
+	let requestCount = 0;
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
+		stream.on("data", (chunk: Buffer) => {
+			const decoded = decodeRunRequest(chunk);
+			if (decoded !== undefined) seen.push(decoded);
+			requestCount++;
+			const decision = script[Math.min(requestCount - 1, script.length - 1)] ?? "reject";
+			if (decision === "reject") {
 				stream.respond({ ":status": 200, "content-type": "application/connect+proto" }, { waitForTrailers: true });
 				stream.once("wantTrailers", () => {
 					stream.sendTrailers({ "grpc-status": "8", "grpc-message": "resource_exhausted" });
@@ -124,8 +214,12 @@ function makeModel(baseUrl: string): Model<"cursor-agent"> {
 const context: Context = { messages: [{ role: "user", content: "hello", timestamp: 1 }] };
 
 /** Drain a stream and return its terminal event (done / error). */
-async function runToEnd(baseUrl: string, sessionId: string): Promise<{ type: "done" | "error"; message?: string }> {
-	const stream = streamCursor(makeModel(baseUrl), context, { apiKey: "test-token", sessionId });
+async function runToEnd(
+	baseUrl: string,
+	sessionId: string,
+	ctx: Context = context,
+): Promise<{ type: "done" | "error"; message?: string }> {
+	const stream = streamCursor(makeModel(baseUrl), ctx, { apiKey: "test-token", sessionId });
 	let terminal: { type: "done" | "error"; message?: string } = { type: "done" };
 	for await (const event of stream) {
 		if (event.type === "error") {
@@ -199,4 +293,46 @@ describe("Cursor conversationId rotation (issue #8345)", () => {
 		expect(seenConversationIds[1]).toBe(seenConversationIds[2]);
 		expect(seenConversationIds[1]).not.toBe("sess-sticky");
 	});
+
+	it("rotated retry recovers a resume-action turn", async () => {
+		const seen: WireRequest[] = [];
+		const baseUrl = await startScriptedServer(seen, ["reject", "ok"]);
+		const ctx = resumeContext();
+
+		const first = await runToEnd(baseUrl, "sess-resume", ctx);
+		expect(first.type).toBe("error");
+		expect(first.message).toMatch(/resource.?exhausted/i);
+
+		const second = await runToEnd(baseUrl, "sess-resume", ctx);
+		expect(second.type).toBe("done");
+
+		expect(seen).toHaveLength(2);
+		expect(seen[0]?.conversationId).toBe("sess-resume");
+		expect(seen[0]?.action).toBe("resumeAction");
+		expect(seen[1]?.conversationId).not.toBe(seen[0]?.conversationId);
+		expect(seen[1]?.action).toBe("userMessageAction");
+		expect(seen[1]?.pendingToolCalls).toBe(0);
+	});
+
+	it("re-rotates when the rotated conversation is poisoned later", async () => {
+		const seen: WireRequest[] = [];
+		const baseUrl = await startScriptedServer(seen, ["reject", "ok", "reject", "ok"]);
+
+		const first = await runToEnd(baseUrl, "sess-rerotate");
+		expect(first.type).toBe("error");
+		const second = await runToEnd(baseUrl, "sess-rerotate");
+		expect(second.type).toBe("done");
+		const third = await runToEnd(baseUrl, "sess-rerotate");
+		expect(third.type).toBe("error");
+		const fourth = await runToEnd(baseUrl, "sess-rerotate");
+		expect(fourth.type).toBe("done");
+
+		expect(seen).toHaveLength(4);
+		expect(seen[0]?.conversationId).toBe("sess-rerotate");
+		expect(seen[1]?.conversationId).not.toBe(seen[0]?.conversationId);
+		expect(seen[2]?.conversationId).toBe(seen[1]?.conversationId);
+		expect(seen[3]?.conversationId).not.toBe(seen[1]?.conversationId);
+		expect(seen[3]?.conversationId).not.toBe(seen[0]?.conversationId);
+	});
+
 });


### PR DESCRIPTION
## Summary

`#8345` rotation does not recover a real omp pane after Esc-abort or a mid-turn restart.

On 2026-08-23 the rejection was scoped to the wire `conversationId`, not the account, not request size, and not the sibling-slug wire shape.

Same account (`rhews03@gmx.com`), same model (`cursor/claude-fable-5-xhigh`), same minutes:

1. `omp -p --no-session --no-tools … "Reply with exactly: pong"` → pong in 10s.
2. The same 1.3MB session under a fresh session id → pong in 10.5s.
3. The same replay with the full tool/extension env (pid 41992) → success in 19s.
4. Pane 8040 on the original session id, restarted 10:14:18 AEST → first request failed 17s later, then failed every ~70s from 10:14:35 through 11:11+ (50+ minutes). The shipped one-shot rotator was already in that process.

A later same-id replay of `01a023a6` still died in 10s with `Connect error resource_exhausted: Error`. A new process with this patch logged `cursor conversation rotated` (`01a023a6` → a new UUID) on that first failure.

This makes omp unusable for tens of minutes after Esc-abort or a pane restart mid-turn.

## Defect

The current rotator does four things that keep the pane stuck:

1. It migrates `conversationStateCache` and `conversationBlobStores` onto the new id. Mid-turn checkpoints can carry `pendingToolCalls`. That side-state re-poisons the new conversation.
2. `/retry` after restart has no active user message, so `buildGrpcRequest` emits a bare `resumeAction` against a conversation id the server has never seen. The server answers with the same bare `resource_exhausted`.
3. The map gate rotates once forever. If the rotated id is later poisoned, the pane never rotates again.
4. Rotation is silent. Pane logs cannot show that a rotate happened.

## Fix

- Do not migrate cached state or blobs. Rebuild from `context`.
- If the rotated id has no active user message, replay the last user message as `userMessageAction`.
- Keep one rotation per failure streak. Allow a new rotation only after the current rotated id completes a `turnEnded`.
- Log `cursor conversation rotated` with `{ base, from, to }` at debug.

A failed rotation is never repeated, so a real account-level capacity window is not hidden.

## Abort hygiene

`AgentClientMessage` has `conversationAction` / empty `CancelAction`. A mid-stream send before `h2Request.close()` is not reliable: HTTP/2 `close()` sends RST_STREAM and drops the frame. This PR does not send it. Rotation is the recovery. Prevention stays server-side.

## Tests

`packages/ai/test/cursor-conversation-rotate.test.ts`

- existing single-rotation recovery stays green
- existing once-forever-on-failed-rotation stays green
- rotated retry of a resume-action context (`/retry` shape) sends a new id and `userMessageAction`
- after a successful rotated turn, a later poison of that id rotates again

## Refs

- #8345 / PR #8349 (original rotator)
- #9164 sibling-slug `528384` is a different bug. A sibling slug was accepted live in this window. This PR does not change slug handling.
- #9164 note on long-session transcript replay / `/fork` still 528384 is out of scope here.

## Live recovery for current panes

Restart every long-lived omp pane so it loads this code. A stuck pane can recover now with Esc + `/fork` even before the restart.
