### PR TITLE
fix(cursor): survive long Cursor capacity windows and socket resets

### DIFF
--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -14,6 +14,7 @@ import {
 	isUsageLimitStatus,
 	matchesUsageLimitText,
 	parseRateLimitReason,
+	RESOURCE_EXHAUSTED_PATTERN,
 } from "./rate-limit";
 
 export const Flag = {
@@ -107,7 +108,7 @@ const TRANSIENT_ENVELOPE_PATTERN = /anthropic stream envelope error:/i;
 const TRANSIENT_ENVELOPE_BEFORE_START_PATTERN = /before message_start/i;
 export const STREAM_READ_ERROR_PATTERN = /stream[_ -]?read[_ -]?error/i;
 export const TRANSIENT_TRANSPORT_PATTERN =
-	/\b(?:no[_ -]?capacity|(?:high|peak)[ _-]?demand|(?:at|over|insufficient)[ _-]?capacity|capacity[ _-]?(?:exceeded|exhausted)|peak[ _-]?load)\b|overloaded|provider.?returned.?error|rate.?limit|too many requests|\b(?:429|500|502|503|504)\b|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|unable.?to.?connect\.\s*is the computer able to access the url\?|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|nghttp2_(?:internal_error|refused_stream)|stream closed with error code nghttp2_(?:internal_error|refused_stream)|malformed.?function.?call/i;
+	/\b(?:no[_ -]?capacity|(?:high|peak)[ _-]?demand|(?:at|over|insufficient)[ _-]?capacity|capacity[ _-]?(?:exceeded|exhausted)|peak[ _-]?load)\b|overloaded|provider.?returned.?error|rate.?limit|too many requests|\b(?:429|500|502|503|504)\b|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|unable.?to.?connect\.\s*is the computer able to access the url\?|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|nghttp2_(?:internal_error|refused_stream)|stream closed with error code nghttp2_(?:internal_error|refused_stream)|malformed.?function.?call|\bECONN(?:RESET|REFUSED|ABORTED)\b|\bETIMEDOUT\b|\bEPIPE\b|\bEHOSTUNREACH\b|\bENETUNREACH\b|\bENETDOWN\b/i;
 const AUTH_FAILURE_PATTERN =
 	/\b(?:401|403|unauthorized|forbidden|authentication|auth[_ ]?unavailable|no auth available|(?:invalid|no)[_ ]?api[_ ]?key)\b/i;
 const MALFORMED_FUNCTION_CALL_PATTERN = /\bmalformed.?function.?call\b/i;
@@ -412,13 +413,14 @@ function classifyText(
 		// usage limit, mirroring isUsageLimitOutcome.
 		const isBillingCapStatus = statusClean === 402;
 		const concurrencyExcluded = reason === "CONCURRENT_LIMIT" && !isBillingCapStatus;
-		if (
-			!concurrencyExcluded &&
-			(matchesUsageLimitText(cleanMessage) ||
-				((statusClean === 403 || statusClean === undefined) && isAccountScopedCapText(cleanMessage)) ||
-				(isLimitStatus &&
-					(isOpaque || reason === "QUOTA_EXHAUSTED" || (isBillingCapStatus && reason === "CONCURRENT_LIMIT"))))
-		) {
+		const usageLimitMessage = cleanMessage.replace(RESOURCE_EXHAUSTED_PATTERN, "");
+		const usageLimitHit =
+			matchesUsageLimitText(cleanMessage) ||
+			((statusClean === 403 || statusClean === undefined) && isAccountScopedCapText(cleanMessage)) ||
+			(isLimitStatus &&
+				(isOpaque || reason === "QUOTA_EXHAUSTED" || (isBillingCapStatus && reason === "CONCURRENT_LIMIT")));
+		const bareCapacityExhausted = reason === "MODEL_CAPACITY_EXHAUSTED" && !matchesUsageLimitText(usageLimitMessage);
+		if (!concurrencyExcluded && usageLimitHit && !bareCapacityExhausted) {
 			kinds |= Flag.UsageLimit;
 		}
 
@@ -427,8 +429,9 @@ function classifyText(
 		// A concurrency cap (e.g. Vertex "Online prediction concurrent requests
 		// quota exceeded") is transient — shed-and-backoff. The bare wording need
 		// not match TRANSIENT_TRANSPORT_PATTERN, so flag it explicitly to keep
-		// AIError.retriable from treating the temporary cap as terminal.
-		if (reason === "CONCURRENT_LIMIT") kinds |= Flag.Transient;
+		// AIError.retriable from treating the temporary cap as terminal. Bare
+		// Connect resource_exhausted is MODEL_CAPACITY_EXHAUSTED: same lane.
+		if (reason === "CONCURRENT_LIMIT" || reason === "MODEL_CAPACITY_EXHAUSTED") kinds |= Flag.Transient;
 		if ((api === "openai-responses" || api === "openai-codex-responses") && isStaleResponsesText(errorMessage)) {
 			kinds |= Flag.StaleResponsesItem;
 		}

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -37,7 +37,7 @@ const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b
 // while HTTP bodies use the phrase ("resource exhausted"). Strip either form
 // before classifying explicit details; an otherwise opaque status is transient
 // model capacity, while quota/rate-limit/server wording remains authoritative.
-const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/gi;
+export const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/gi;
 const CONCURRENT_LIMIT_PATTERN =
 	// Require an actual cap signal near "concurrent". "Too many concurrent
 	// requests" is itself a cap signal; bare feature rejections such as

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -405,6 +405,42 @@ function frameConnectMessage(data: Uint8Array, flags = 0): Buffer {
 	return frame;
 }
 
+function parseRetryDelaySeconds(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+		return Math.trunc(value);
+	}
+	if (typeof value === "object" && value !== null && "seconds" in value) {
+		const seconds = Number(value.seconds);
+		if (Number.isFinite(seconds) && seconds >= 0) return Math.trunc(seconds);
+	}
+	if (typeof value !== "string") return undefined;
+	const match = /^(\d+(?:\.\d+)?)s?$/.exec(value.trim());
+	if (!match) return undefined;
+	return Math.trunc(Number(match[1]));
+}
+
+function extractConnectRetryAfterSeconds(error: unknown): number | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const fromMember = parseRetryDelaySeconds(
+		("retry-after" in error ? error["retry-after"] : undefined) ??
+			("retryAfter" in error ? error.retryAfter : undefined) ??
+			("retryDelay" in error ? error.retryDelay : undefined),
+	);
+	if (fromMember !== undefined) return fromMember;
+	if (!("details" in error) || !Array.isArray(error.details)) return undefined;
+	for (const detail of error.details) {
+		if (!detail || typeof detail !== "object") continue;
+		const seconds = parseRetryDelaySeconds(
+			("retryDelay" in detail ? detail.retryDelay : undefined) ??
+				("retry_delay" in detail ? detail.retry_delay : undefined) ??
+				("retry-after" in detail ? detail["retry-after"] : undefined),
+		);
+		if (seconds !== undefined) return seconds;
+	}
+	return undefined;
+}
+
+
 class ConnectEndStreamError extends AIError.ProviderResponseError {
 	readonly diagnosticMessage: string;
 
@@ -421,7 +457,9 @@ function parseConnectEndStream(data: Uint8Array): Error | null {
 		if (error) {
 			const code = typeof error.code === "string" ? error.code : "unknown";
 			const message = typeof error.message === "string" ? error.message : "Unknown error";
-			const classificationMessage = `Connect error ${code}: ${message}`;
+			const retryAfterSeconds = extractConnectRetryAfterSeconds(error);
+			const suffix = retryAfterSeconds !== undefined ? ` (retry-after: ${retryAfterSeconds}s)` : "";
+			const classificationMessage = `Connect error ${code}: ${message}${suffix}`;
 			return new ConnectEndStreamError(classificationMessage, formatConnectEndStreamError(error));
 		}
 		return null;

--- a/packages/ai/test/cursor-terminal-error.test.ts
+++ b/packages/ai/test/cursor-terminal-error.test.ts
@@ -23,6 +23,7 @@ const CONNECT_END_STREAM_FLAG = 0b00000010;
 type Scenario =
 	| { kind: "success" }
 	| { kind: "connect-error-after-turn" }
+	| { kind: "connect-error-retry-after" }
 	| { kind: "connect-detailed-error-after-turn" }
 	| { kind: "connect-classification-detail-after-turn" }
 	| { kind: "grpc-trailer-after-turn" }
@@ -240,6 +241,19 @@ async function startServer(): Promise<string> {
 			return;
 		}
 
+		if (scenario.kind === "connect-error-retry-after") {
+			stream.write(
+				connectEndErrorFrame("resource_exhausted", "Error", [
+					{
+						"@type": "type.googleapis.com/google.rpc.RetryInfo",
+						retryDelay: "60s",
+					},
+				]),
+			);
+			stream.end();
+			return;
+		}
+
 		if (scenario.kind === "connect-detailed-error-after-turn") {
 			stream.write(
 				connectEndErrorFrame("invalid_argument", "Error", [
@@ -397,6 +411,16 @@ describe("Cursor terminal lifecycle after turnEnded", () => {
 		expect(eventTypes).not.toContain("done");
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toContain("Cursor stream ended before turnEnded");
+	});
+
+	it("appends retry-after from Connect RetryInfo onto the error message", async () => {
+		scenario = { kind: "connect-error-retry-after" };
+		const baseUrl = await startServer();
+		const { result } = await collectStream(makeModel(baseUrl));
+		expect(result.stopReason).toBe("error");
+		expect(`${result.errorClassificationMessage ?? ""} ${result.errorMessage ?? ""}`).toContain(
+			"(retry-after: 60s)",
+		);
 	});
 
 	it("pairs and closes a server-owned call the dying stream left open", async () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -615,3 +615,41 @@ describe("calculateRateLimitBackoffMs", () => {
 		expect(calculateRateLimitBackoffMs("CONCURRENT_LIMIT")).toBe(5_000);
 	});
 });
+
+describe("classify bare Cursor resource_exhausted", () => {
+	it("treats bare Connect resource_exhausted as transient, not a usage limit", () => {
+		const message = "Connect error resource_exhausted: Error";
+		const id = classify(message);
+		expect(is(id, Flag.Transient)).toBe(true);
+		expect(is(id, Flag.UsageLimit)).toBe(false);
+		expect(retriable(id)).toBe(true);
+		expect(isUsageLimit(message)).toBe(false);
+	});
+
+	it("keeps quota-worded resource_exhausted as a usage limit", () => {
+		const message = "Connect error resource_exhausted: Quota exceeded for this account";
+		const id = classify(message);
+		expect(is(id, Flag.UsageLimit)).toBe(true);
+	});
+});
+
+
+describe("classify raw socket errno codes", () => {
+	it("classifies raw socket errno codes as retriable", () => {
+		for (const message of [
+			"read ECONNRESET",
+			"connect ECONNREFUSED 127.0.0.1:443",
+			"connect ECONNABORTED 1.2.3.4:443",
+			"write EPIPE",
+			"connect ETIMEDOUT 1.2.3.4:443",
+			"connect EHOSTUNREACH 1.2.3.4:443",
+			"connect ENETUNREACH 1.2.3.4:443",
+		]) {
+			const id = classify(message);
+			expect(is(id, Flag.Transient)).toBe(true);
+			expect(retriable(id)).toBe(true);
+			expect(is(id, Flag.UsageLimit)).toBe(false);
+		}
+	});
+});
+

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -762,10 +762,15 @@ export class EventController {
 		// Restore terminal errors in transcript history when their banner clears.
 		// Recoverable empty-output attempts are discarded by session recovery and
 		// must stay hidden rather than resurfacing as a stale inline error.
-		if (this.#restorePinnedErrorInline) this.#pinnedErrorComponent?.setErrorPinned(false);
-		this.#pinnedErrorComponent = undefined;
-		this.#pinnedErrorMessage = undefined;
-		this.#restorePinnedErrorInline = true;
+		// While a retry saga is outstanding the failed attempt is not terminal:
+		// keep its inline row suppressed and the refs tracked so auto_retry_end
+		// can compact it (success) or promote it into a banner (terminal).
+		if (!this.#retryPending) {
+			if (this.#restorePinnedErrorInline) this.#pinnedErrorComponent?.setErrorPinned(false);
+			this.#pinnedErrorComponent = undefined;
+			this.#pinnedErrorMessage = undefined;
+			this.#restorePinnedErrorInline = true;
+		}
 		this.ctx.clearPinnedError();
 		if (this.ctx.retryLoader) {
 			this.ctx.retryLoader.stop();
@@ -1999,6 +2004,13 @@ export class EventController {
 			this.#pinnedErrorComponent = undefined;
 			this.#pinnedErrorMessage = undefined;
 			this.#restorePinnedErrorInline = true;
+			this.ctx.clearPinnedError();
+		} else if (this.#pinnedErrorComponent) {
+			// A retry is outstanding: the "Retrying (n/m) in Xs" loader below is the
+			// visible state, so the red fixed-region banner comes down for the wait.
+			// The component refs stay tracked — a terminal auto_retry_end still
+			// promotes the final error into one banner, and the inline row stays
+			// suppressed until retry recovery dims or restores it.
 			this.ctx.clearPinnedError();
 		}
 		const delaySeconds = Math.round(event.delayMs / 1000);

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -22,7 +22,7 @@ import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@oh-my-pi/pi-
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
+import { extractRetryHint, isUnexpectedSocketCloseMessage, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelStringWithRouting, resolveModelOverride } from "../config/model-resolver";
 
@@ -71,6 +71,12 @@ const UNEXPECTED_STOP_MAX_RETRIES = 3;
 const UNEXPECTED_STOP_TIMEOUT_MS = 4000;
 const EMPTY_STOP_MAX_RETRIES = 3;
 const SIBLING_UNBLOCK_BUFFER_MS = 1_000;
+// Attempt floor for capacity/rate-window transients (e.g. Cursor
+// "Connect error resource_exhausted"): ~60 waits of 45-75s (~45-75 min)
+// cover the observed provider windows (Cursor local/burst rate limits refill
+// on an hours scale; 2026-08-21 logged a 27-minute and then a 34+ minute
+// rejection window — the latter outlasted the previous 30-attempt floor).
+const CAPACITY_MAX_RETRIES = 60;
 const NON_WHITESPACE_RE = /\S/;
 const USAGE_PREFLIGHT_BLOCKED_PREFIX = "Usage preflight blocked:";
 const STREAM_STALL_ERROR_RE = /stream stall/i;
@@ -83,6 +89,15 @@ const HTTP2_STREAM_RESET_ERROR_RE =
 const PREMATURE_STREAM_CLOSE_ERROR_RE = /stream closed before a (?:finish_reason|terminal response event)/i;
 const IMMUTABLE_ANTHROPIC_THINKING_ERROR_PATTERN =
 	/messages\.\d+\.content\.\d+.*\b(?:thinking|redacted_thinking)\b.*\blatest assistant message cannot be modified\b/is;
+
+function isDroppedStreamErrorMessage(message: string | undefined): boolean {
+	if (!message) return false;
+	if (STREAM_STALL_ERROR_RE.test(message)) return true;
+	if (isUnexpectedSocketCloseMessage(message)) return true;
+	return /stream ended before turnEnded|timed out while waiting for the first event|stalled while waiting for the next event|getaddrinfo|ENOTFOUND/i.test(
+		message,
+	);
+}
 
 function hasNonWhitespace(value: string): boolean {
 	return NON_WHITESPACE_RE.test(value);
@@ -197,6 +212,12 @@ export class TurnRecovery {
 	readonly #host: TurnRecoveryHost;
 	#retryAbortController: AbortController | undefined;
 	#retryAttempt = 0;
+	// True once any attempt in the CURRENT saga was capacity-class: the floor
+	// must stay engaged for the rest of the saga so a single interleaved
+	// non-capacity transient (e.g. "read ECONNRESET" on attempt 8) cannot fail
+	// the turn against the small user budget mid-outage. Reset when a new saga
+	// starts (first attempt), not per-error.
+	#capacityFloorSticky = false;
 	#retryPromise: Promise<void> | undefined;
 	#retryResolve: (() => void) | undefined;
 	#activeRetryFallback: ActiveRetryFallbackState | undefined;
@@ -590,6 +611,20 @@ export class TurnRecovery {
 			attempt: this.#retryAttempt,
 			note,
 		});
+		// Persist the superseded marker immediately instead of deferring to the
+		// saga-end pass: a process exit mid-saga (user restart during a provider
+		// outage) otherwise leaves every failed attempt unmarked on disk, so the
+		// resumed transcript re-renders them as full red error rows and replays
+		// the empty error turns into model context. Saga success later upgrades
+		// these markers to "recovered".
+		branchEntry.message.retryRecovery = {
+			kind: "auto-retry",
+			status: "superseded",
+			attempt: this.#retryAttempt,
+			recovery,
+			note,
+		};
+		await this.#host.sessionManager.rewriteEntries();
 	}
 
 	async #markPendingRetryErrors(
@@ -1171,7 +1206,7 @@ export class TurnRecovery {
 			((message.stopReason === "aborted" && AIError.is(id, AIError.Flag.Abort)) || genericAbort);
 		const errorMessage = message.errorMessage ?? "";
 		const streamStall =
-			message.stopReason === "error" && STREAM_STALL_ERROR_RE.test(errorMessage) && AIError.retriable(id);
+			message.stopReason === "error" && isDroppedStreamErrorMessage(errorMessage) && AIError.retriable(id);
 		const transportReset =
 			message.stopReason === "error" &&
 			HTTP2_STREAM_RESET_ERROR_RE.test(errorMessage) &&
@@ -1911,6 +1946,7 @@ export class TurnRecovery {
 
 		const generation = this.#host.promptGeneration();
 		this.#retryAttempt++;
+		if (this.#retryAttempt === 1) this.#capacityFloorSticky = false;
 
 		// Create retry promise on first attempt so waitForRetry() can await it
 		// Ensure only one promise exists (avoid orphaned promises from concurrent calls)
@@ -1926,18 +1962,32 @@ export class TurnRecovery {
 		// (every rotation sets switchedCredential and skips it), so without
 		// this last resort a provider-wide usage cap never fails over to the
 		// configured chain.
-		const maxRetries = this.#isOpenRouterThinkingStreamClose(message)
-			? Math.min(retrySettings.maxRetries, 1)
-			: retrySettings.maxRetries;
-		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
-
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
+		const rateLimitReason = parseRateLimitReason(errorMessage);
+		const capacityClassRetry =
+			!AIError.is(id, AIError.Flag.UsageLimit) &&
+			(rateLimitReason === "CONCURRENT_LIMIT" ||
+				rateLimitReason === "RATE_LIMIT_EXCEEDED" ||
+				rateLimitReason === "MODEL_CAPACITY_EXHAUSTED");
+		if (capacityClassRetry) this.#capacityFloorSticky = true;
+		const openRouterThinkingStreamClose = this.#isOpenRouterThinkingStreamClose(message);
+		let maxRetries = openRouterThinkingStreamClose ? Math.min(retrySettings.maxRetries, 1) : retrySettings.maxRetries;
+		const escapeHatchConfigured =
+			retrySettings.modelFallback && Object.keys(this.#getRetryFallbackChains()).length > 0;
+		if (
+			(capacityClassRetry || this.#capacityFloorSticky) &&
+			!escapeHatchConfigured &&
+			!openRouterThinkingStreamClose
+		) {
+			maxRetries = Math.max(maxRetries, CAPACITY_MAX_RETRIES);
+		}
+		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
+
 		const preserveFailedTurn =
 			options?.preserveFailedTurn === true ||
 			((classifierRefusal || AIError.is(id, AIError.Flag.MalformedFunctionCall)) &&
 				this.#unexecutedToolCallsReplaySafe(message));
-		const rateLimitReason = parseRateLimitReason(errorMessage);
 		const staleOpenAIResponsesReplayError = AIError.is(id, AIError.Flag.StaleResponsesItem);
 		const accountPolicyDenial = AIError.is(id, AIError.Flag.AccountPolicy);
 		const recordedUsageLimitOutcome = await this.#usageLimitOutcomes.get(message);
@@ -1951,14 +2001,16 @@ export class TurnRecovery {
 		// budget before either window can clear. An explicit provider
 		// retry-after is authoritative in both directions, so the heuristic
 		// window only applies when the error carries no parsed timing.
-		if (
-			!staleOpenAIResponsesReplayError &&
-			!AIError.is(id, AIError.Flag.UsageLimit) &&
-			parsedRetryAfterMs === undefined &&
-			(rateLimitReason === "CONCURRENT_LIMIT" || rateLimitReason === "RATE_LIMIT_EXCEEDED")
-		) {
-			const reasonBackoffMs = calculateRateLimitBackoffMs(rateLimitReason);
-			if (reasonBackoffMs > delayMs) delayMs = reasonBackoffMs;
+		if (!staleOpenAIResponsesReplayError && capacityClassRetry) {
+			const maxDelayMs = retrySettings.maxDelayMs;
+			if (parsedRetryAfterMs !== undefined && parsedRetryAfterMs <= 120_000) {
+				const capped = maxDelayMs > 0 ? Math.min(parsedRetryAfterMs, maxDelayMs) : parsedRetryAfterMs;
+				if (capped > delayMs) delayMs = capped;
+			} else if (parsedRetryAfterMs === undefined) {
+				let reasonBackoffMs = calculateRateLimitBackoffMs(rateLimitReason);
+				if (maxDelayMs > 0) reasonBackoffMs = Math.min(reasonBackoffMs, maxDelayMs);
+				if (reasonBackoffMs > delayMs) delayMs = reasonBackoffMs;
+			}
 		}
 		let switchedCredential = false;
 		let switchedModel = false;

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -2215,4 +2215,189 @@ describe("AgentSession retry delay cap", () => {
 		expect(last.stopReason).toBe("stop");
 		expect(last.content).toContainEqual({ type: "text", text: "recovered after default 502 retry budget" });
 	});
+
+	it("keeps retrying capacity-exhausted errors past a small maxRetries budget", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const mock = createMockModel();
+		let attempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				attempts += 1;
+				mock.push(
+					attempts <= 4
+						? { throw: "Connect error resource_exhausted: Error" }
+						: { content: ["recovered after capacity window cleared"] },
+				);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.maxRetries": 2 });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Trigger a capacity outage longer than maxRetries");
+		await session.waitForIdle();
+
+		expect(attempts).toBe(5);
+		expect(retryStartEvents).toHaveLength(4);
+		expect(retryStartEvents.map(event => event.delayMs)).toEqual(new Array(4).fill(45_000));
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 4 });
+		const last = lastAssistant(session);
+		expect(last.stopReason).toBe("stop");
+		expect(last.errorMessage ?? "").not.toContain("Retry budget exhausted");
+		expect(last.content).toContainEqual({ type: "text", text: "recovered after capacity window cleared" });
+	});
+
+	it("survives an interleaved socket reset during a capacity retry saga", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const mock = createMockModel();
+		let attempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				attempts += 1;
+				let step: { throw: string } | { content: string[] };
+				if (attempts <= 3) step = { throw: "Connect error resource_exhausted: Error" };
+				else if (attempts === 4) step = { throw: "read ECONNRESET" };
+				else step = { content: ["recovered after socket reset"] };
+				mock.push(step);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.maxRetries": 2 });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Trigger a capacity outage with an interleaved reset");
+		await session.waitForIdle();
+
+		expect(attempts).toBe(5);
+		expect(retryStartEvents).toHaveLength(4);
+		expect(retryStartEvents.map(event => event.delayMs)).toEqual([45_000, 45_000, 45_000, 4_000]);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 4 });
+		const last = lastAssistant(session);
+		expect(last.stopReason).toBe("stop");
+		expect(last.errorMessage ?? "").not.toContain("Retry budget exhausted");
+		expect(last.content).toContainEqual({ type: "text", text: "recovered after socket reset" });
+	});
+
+	it("persists superseded markers on failed attempts before the saga ends", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const errorMarkerStatuses = () =>
+			session.sessionManager
+				.getBranch()
+				.flatMap(entry =>
+					entry.type === "message" && entry.message.role === "assistant" && entry.message.stopReason === "error"
+						? [entry.message.retryRecovery?.status]
+						: [],
+				);
+
+		const mock = createMockModel();
+		let attempts = 0;
+		let midSagaMarkers: (string | undefined)[] | undefined;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				attempts += 1;
+				if (attempts === 3) {
+					midSagaMarkers = errorMarkerStatuses();
+				}
+				mock.push(
+					attempts <= 2
+						? { throw: "Connect error resource_exhausted: Error" }
+						: { content: ["recovered after mid-saga snapshot"] },
+				);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Trigger two capacity failures and inspect mid-saga persistence");
+		await session.waitForIdle();
+
+		expect(attempts).toBe(3);
+		expect(midSagaMarkers?.length).toBeGreaterThanOrEqual(1);
+		expect(midSagaMarkers).toEqual(midSagaMarkers?.map(() => "superseded"));
+		const finalMarkers = errorMarkerStatuses();
+		expect(finalMarkers.length).toBeGreaterThanOrEqual(1);
+		expect(finalMarkers).toEqual(finalMarkers.map(() => "recovered"));
+	});
+
 });

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2253,6 +2253,7 @@ describe("AgentSession retry fallback", () => {
 			settings,
 			modelRegistry,
 		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
 		session.subscribe(event => {
 			if (event.type === "retry_fallback_applied") {
@@ -2993,6 +2994,7 @@ describe("AgentSession retry fallback", () => {
 			settings,
 			modelRegistry,
 		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
 
 		await session.prompt("Retry once, then hit a classifier refusal with no fallback");
@@ -3140,7 +3142,9 @@ describe("AgentSession retry fallback", () => {
 		expect(retryStartEvents).toHaveLength(1);
 		expect(retryStartEvents[0]).toMatchObject({
 			attempt: 1,
-			maxAttempts: 1,
+			// Rate-window transients get the capacity attempt floor when model
+			// fallback is disabled; the configured maxRetries of 1 is overridden.
+			maxAttempts: 60,
 			delayMs: 200,
 			errorMessage: "rate limit exceeded retry-after-ms=200",
 		});

--- a/packages/coding-agent/test/agent-session-retry-recovery.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-recovery.test.ts
@@ -285,8 +285,12 @@ describe("AgentSession retry recovery", () => {
 		}
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
 
+		// A generic transport 502 (NOT capacity-class): capacity errors now get
+		// a higher attempt floor when model fallback is disabled, so they no
+		// longer exhaust a 1-retry budget.
+		const budgetError = "502 bad gateway upstream_error";
 		const mock = createMockModel({
-			responses: [{ throw: RETRIABLE_SERVER_ERROR }, { throw: RETRIABLE_SERVER_ERROR }],
+			responses: [{ throw: budgetError }, { throw: budgetError }],
 		});
 		const agent = new Agent({
 			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
@@ -345,7 +349,7 @@ describe("AgentSession retry recovery", () => {
 			throw new Error("Expected an aggregated terminal error message");
 		}
 		expect(terminalError.retryRecovery).toBeUndefined();
-		expect(terminalErrorText).toBe(`Retry budget exhausted after 1 retry: ${RETRIABLE_SERVER_ERROR}`);
+		expect(terminalErrorText).toBe(`Retry budget exhausted after 1 retry: ${budgetError}`);
 		expect(resolveAssistantErrorPresentation(terminalError)).toEqual({
 			kind: "full",
 			text: terminalErrorText,


### PR DESCRIPTION
## Summary

On 2026-08-21 two live omp panes on `cursor/claude-fable-5-xhigh` sat in `Connect error resource_exhausted: Error` for 27 minutes (session `01a023ba`) and 34 minutes (session `01a023a6`). The user retry budget was 2–10 attempts. The provider window outlasted it. A later `read ECONNRESET` in the same saga was classified terminal and killed the wait.

This PR ports the field-proven local-patches resilience (conn-fix-5 tasks 2–5) onto current main.

## What landed

1. Bare Connect `resource_exhausted` is `MODEL_CAPACITY_EXHAUSTED`, not an account quota. `#7033` made the error retriable but still set `Flag.UsageLimit`, which blocked the only Cursor credential and skipped the capacity floor. Quota-worded bodies stay usage limits.
2. Capacity-class retries get a floor of 60 attempts (~45–75 min). The floor stays sticky for the rest of the saga so an interleaved socket reset cannot fall back to the small user budget.
3. Raw socket errno codes (`ECONNRESET`, `ECONNREFUSED`, `ECONNABORTED`, `ETIMEDOUT`, `EPIPE`, `EHOSTUNREACH`, `ENETUNREACH`, `ENETDOWN`) are transient.
4. `google.rpc.RetryInfo.retryDelay` is copied onto the Cursor error as `(retry-after: Ns)`.
5. Superseded retry markers persist mid-saga. A restart mid-outage no longer re-renders every failed attempt as a full red error row.
6. Dropped-stream errors (`stream ended before turnEnded`, unexpected socket close, first-event timeout) resume on the same model.
7. The failed-attempt banner and inline error stay hidden while `Retrying (n/m)` is visible.

## Skipped (follow-up)

- Native compact 404 fallback (`0ab41d1eb`). Main restructured compaction.

## Tests

`bun test` on:

- `packages/ai/test/rate-limit-utils.test.ts`
- `packages/ai/test/cursor-terminal-error.test.ts`
- `packages/coding-agent/test/agent-session-retry-cap.test.ts`
- `packages/coding-agent/test/agent-session-retry-recovery.test.ts`
- `packages/coding-agent/test/agent-session-retry-fallback.test.ts`
- `packages/coding-agent/test/event-controller-error-banner.test.ts`

208 pass.

## Related

Headline rotation fix is a separate PR: https://github.com/can1357/oh-my-pi/pull/9412
