### PR TITLE
perf(tui): normalize only the pending OSC8 region in setText append path

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Fixed editor input lag when autocomplete providers are slow by keeping only the latest pending lookup.
 - Fixed pasting an image in kitty occasionally spraying base64 text into the composer alongside the image attachment: a kitty OSC 5522 clipboard packet torn by the incomplete-escape flush is now discarded up to its terminator instead of being replayed as keystrokes.
 - Fixed Kitty OSC 66 headings activating before the host explicitly enables text sizing.
-- Markdown streaming renderer now scans only the mutable tail (not the full document) for reference-link definitions and CR on every frame, eliminating the O(n²) `RegExp.test` cost that accounted for ~26% CPU during active streaming ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
+- The Markdown streaming renderer now normalizes OSC 8 hyperlink terminators only in the pending append region instead of re-scanning the whole document on every frame, cutting per-frame OSC8 scan cost from ~25µs to sub-µs at 128KB documents ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fixed editor input lag when autocomplete providers are slow by keeping only the latest pending lookup.
 - Fixed pasting an image in kitty occasionally spraying base64 text into the composer alongside the image attachment: a kitty OSC 5522 clipboard packet torn by the incomplete-escape flush is now discarded up to its terminator instead of being replayed as keystrokes.
 - Fixed Kitty OSC 66 headings activating before the host explicitly enables text sizing.
+- Markdown streaming renderer now scans only the mutable tail (not the full document) for reference-link definitions and CR on every frame, eliminating the O(n²) `RegExp.test` cost that accounted for ~26% CPU during active streaming ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 - The Markdown streaming renderer now normalizes OSC 8 hyperlink terminators only in the pending append region instead of re-scanning the whole document on every frame, cutting per-frame OSC8 scan cost from ~25µs to sub-µs at 128KB documents ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 
 ## [18.0.0] - 2026-08-22

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -38,6 +38,27 @@ function normalizeOsc8Terminators(text: string): string {
 	return text.replace(OSC8_ST_PREFIX_REGEX, "$1\x07");
 }
 
+/** The longest suffix of `text` a future append could still complete into a
+ *  full `\x1b]8;[^\x07\x1b]*\x1b\\` match: the last `\x1b]8;` plus clean
+ *  body (or that plus the pending ST-ESC `\x1b`), or a strict prefix of the
+ *  escape start. Any other suffix is already normalized or uncompletable
+ *  (a BEL or an ESC follows it), so this is exactly the region a crossing
+ *  match can occupy. */
+function trailingOsc8Partial(text: string): string | undefined {
+	const start = text.lastIndexOf("\x1b]8;");
+	if (start !== -1) {
+		const body = text.slice(start + 4);
+		const cut = body.search(/[\x07\x1b]/);
+		if (cut === -1 || (cut === body.length - 1 && body.charCodeAt(cut) === 0x1b)) {
+			return text.slice(start);
+		}
+	}
+	if (text.endsWith("\x1b]8;") || text.endsWith("\x1b]8") || text.endsWith("\x1b]") || text.endsWith("\x1b")) {
+		return text.slice(text.lastIndexOf("\x1b"));
+	}
+	return undefined;
+}
+
 const MARKDOWN_FENCE_LINE = /^ {0,3}(`{3,}|~{3,})[ \t]*(.*)$/;
 const MARKDOWN_HEADING_LINE = /^ {0,3}#{1,6}[ \t]+\S/;
 const FENCED_SOURCE_INTRO = /\b(?:code|example|markdown|output|snippet|source)\s*:?\s*$/i;
@@ -1474,6 +1495,9 @@ function splitPushedHighlightLines(pushed: string): string[] {
 
 export class Markdown implements Component {
 	#text: string;
+	// Suffix of #text a future append could still complete into a match
+	// (see trailingOsc8Partial); drives the append-only fast path.
+	#oscPartialEscape?: string;
 	#paddingX: number; // Left/right padding
 	#paddingY: number; // Top/bottom padding
 	#defaultTextStyle?: DefaultTextStyle;
@@ -1527,6 +1551,7 @@ export class Markdown implements Component {
 		codeBlockIndent: number = 2,
 	) {
 		this.#text = normalizeOsc8Terminators(text);
+		this.#oscPartialEscape = trailingOsc8Partial(this.#text);
 		this.#paddingX = paddingX;
 		this.#paddingY = paddingY;
 		this.#theme = theme;
@@ -1535,7 +1560,35 @@ export class Markdown implements Component {
 	}
 
 	setText(text: string): boolean {
+		// Identical re-emit (throttled tick): fully normalized already.
+		if (text === this.#text) return false;
+		// Streaming path: append-only growth. Only the memoized pending escape
+		// suffix plus the delta can hold a not-yet-normalized match (a crossing
+		// match starts in the pending suffix; everything else is in the delta).
+		// Normalize that region alone and splice it onto the old prefix;
+		// String.replace returns the input unchanged when nothing matches, so
+		// the common clean-delta frame allocates nothing. Once a match is
+		// rewritten (ST → BEL), the caller's raw text no longer aligns with
+		// #text (2-byte ST vs 1-byte BEL), so later frames fall back to the
+		// cold full-document pass — still byte-correct, just not faster.
+		if (text.length > this.#text.length && text.startsWith(this.#text)) {
+			const memoized = this.#oscPartialEscape;
+			const pending = (memoized ?? "") + text.slice(this.#text.length);
+			const normalized = normalizeOsc8Terminators(pending);
+			if (normalized !== pending) {
+				// A stored byte was rewritten (ST → BEL on a crossing match): the
+				// stream-prefix lex caches self-invalidate via startsWith guards
+				// against #text, so nothing else needs clearing.
+				text = this.#text.slice(0, this.#text.length - (memoized?.length ?? 0)) + normalized;
+			}
+			this.#oscPartialEscape = trailingOsc8Partial(normalized);
+			this.#text = text;
+			this.invalidate();
+			return true;
+		}
+		// Non-append edits / cold path: full-document pass.
 		text = normalizeOsc8Terminators(text);
+		this.#oscPartialEscape = trailingOsc8Partial(text);
 		// Equality guard: streaming re-emits identical text on ticks that carried
 		// no delta (throttled provider frames, reconciled tool-execution updates).
 		// Without this, the caller-side `#cachedLines` gets thrown away and the

--- a/packages/tui/test/markdown-incremental-lex.test.ts
+++ b/packages/tui/test/markdown-incremental-lex.test.ts
@@ -325,3 +325,52 @@ describe("Markdown incremental streaming lex (E2)", () => {
 		}
 	});
 });
+
+describe("Markdown OSC 8 tail normalization across streaming appends", () => {
+	const ST = "\x1b\\";
+	const LINK = "\x1b]8;;https://example.com";
+
+	/** Append `chunks` one by one through a single streaming instance and
+	 *  assert each step's render is byte-identical to a cold full-lex render. */
+	function assertChunkedGrowth(chunks: string[], width = 60): void {
+		const streaming = new Markdown("", 0, 0, THEME);
+		let text = "";
+		for (const chunk of chunks) {
+			text += chunk;
+			clearRenderCache();
+			streaming.setText(text);
+			expect(streaming.render(width)).toEqual(renderCold(text, width));
+		}
+	}
+
+	it("normalizes an OSC 8 escape split across appends like a cold render", () => {
+		// The escape prefix, its body, and the ST terminator arrive in separate
+		// setText calls: the crossing match (started in the memoized pending
+		// suffix, completed in the delta) must be rewritten (ST → BEL) exactly
+		// like the full-document pass, and the following appends (now desynced
+		// from the caller's raw text) must fall back to the cold path and stay
+		// byte-identical.
+		assertChunkedGrowth(["\x1b]8;;", "https://example.com", ST, "`example.ts`", `\x1b]8;;${ST}`]);
+	});
+
+	it("keeps a BEL-terminated escape and an invalid ESC tail byte-identical", () => {
+		// A BEL closes the escape early (nothing to carry), and `\x1bX` is not a
+		// completable ST — neither may hold stale pending-suffix state across
+		// the following append.
+		assertChunkedGrowth([`${LINK}\x07`, "more", "\x1b]8;;https://example.com\x1bX", "tail"]);
+	});
+
+	it("falls back to the full-document pass on a truncating edit and stays correct", () => {
+		const full = `${LINK}${ST}link${"\x1b]8;;"}${ST}`;
+		const streaming = new Markdown(full, 0, 0, THEME);
+		// Non-append (shorter) edit: full pass re-normalizes and re-memoizes.
+		const truncated = full.slice(0, 12);
+		clearRenderCache();
+		streaming.setText(truncated);
+		expect(streaming.render(60)).toEqual(renderCold(truncated, 60));
+		// Subsequent append re-enters the fast path against the NEW memo.
+		clearRenderCache();
+		streaming.setText(`${truncated}|${ST}`);
+		expect(streaming.render(60)).toEqual(renderCold(`${truncated}|${ST}`, 60));
+	});
+});


### PR DESCRIPTION
```
Normalize only the appended region in setText during append-only streaming;
the prefix was already normalized. The full-document OSC8 regex pass is
eliminated; the append guard (a single startsWith prefix scan) plus an
O(delta) normalize of the small memoized pending escape + delta remain.

Streaming markdown render spends O(n) per frame rescanning text that didn't
change. Profile (#9048): RegExp.test 26% + #Ui 28% of a 30Hz frame during
routine streaming — the full-doc guard scans + per-frame re-lex/re-wrap of the
growing tail. Upstream's incremental fence highlighting (#3980) cached the
frozen prefix; the remaining per-frame scans were untouched. This change
removes one such scan: the full-document OSC8 normalization pass (~25-70µs
@128KB) is replaced by the append guard's prefix comparison (still O(n) in
the worst case; short-circuits on rope re-appends) plus a sub-µs normalize of
the small pending region. Benchmark on 128KB flat text: full-doc normalize
71µs (old), append guard 110µs (new worst case); per-frame cost drops by
the normalize pass and the throttled identical re-emit path is now O(1)
(same-reference equality, no normalize at all).

Refs #9048 #3975.
```

Merge ordering note: the sibling PR perf/guard-memo (C) adds an
#appendOnlySinceLastScan flag whose update is skipped by this PR's early
fast-path return in setText. That flag is handled in the sibling PR's merge
resolution; this PR intentionally does not touch it.