### PR TITLE
perf(tui): memoize streaming guard scan gated by delta content

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fixed pasting an image in kitty occasionally spraying base64 text into the composer alongside the image attachment: a kitty OSC 5522 clipboard packet torn by the incomplete-escape flush is now discarded up to its terminator instead of being replayed as keystrokes.
 - Fixed Kitty OSC 66 headings activating before the host explicitly enables text sizing.
 - Markdown streaming renderer now scans only the mutable tail (not the full document) for reference-link definitions and CR on every frame, eliminating the O(n²) `RegExp.test` cost that accounted for ~26% CPU during active streaming ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
+- Markdown streaming renderer now memoizes the ref-def/CR guard scan: while text grows append-only, only the delta is inspected for the characters a reference definition or CR needs, and a clean delta reuses the previous verdict. Guard cost drops from ~265µs to ~0.1µs per frame on a 128KB tight document ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1592,6 +1592,11 @@ export class Markdown implements Component {
 		const next = value === true;
 		if (this.#transientRenderCache === next) return;
 		this.#transientRenderCache = next;
+		// The mode switch changes which normalization applies to the raw text
+		// (transient: replaceTabs; final: repairOrphanClosingFence(replaceTabs)),
+		// so a memo computed on the other mode's buffer must not be reused —
+		// re-derive on the next frame instead.
+		this.#appendOnlySinceLastScan = false;
 		this.invalidate();
 	}
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1500,6 +1500,25 @@ export class Markdown implements Component {
 	#streamPrefixText?: string;
 	#streamPrefixTokens?: Token[];
 	#streamPrefixLineCache?: StreamPrefixLineCache;
+	// Guard-scan memo (PoC C): the ref-def/CR verdict with the exact text
+	// length it was checked on. Reuse is sound only while setText has been
+	// append-only since (tracked via the startsWith that setText performs): a
+	// FALSE verdict stays valid — appending cannot remove an offending ref or
+	// CR; a TRUE verdict can flip only when the delta gains a "[" at a fresh
+	// line or a "]" / ":" completing a dangling "[…" that straddles the scan
+	// edge, or "\n" / "\r". Byte-identity of the checked region: replaceTabs
+	// is a per-char map and normalizeOsc8Terminators changes old bytes only
+	// when an OSC8 terminator straddles the boundary (which breaks startsWith
+	// — the flag then reads non-append), so transient-mode appends are
+	// byte-identical. Non-transient repairOrphanClosingFence can additionally
+	// delete a bare fence line; its triggers (heading + table lines) always
+	// bring "\n" with them, so such frames take the suspicious-delta path,
+	// and a deletion that shortens the text trips the length gate — either
+	// way the verdict is re-derived, never reused across the deletion.
+	#lastScanLength = -1;
+	#lastScanCanStream = false;
+	#lastScanValid = false;
+	#appendOnlySinceLastScan = true;
 	// True while #renderStreamingContentLines renders the frozen token range:
 	// frozen code blocks highlight even in transient mode so their bytes match
 	// the finalized render (they render once into the prefix line cache, so
@@ -1542,6 +1561,11 @@ export class Markdown implements Component {
 		// full lex + wrap runs per re-emit — one of the top CPU hotspots during
 		// streaming (issue #4353). Mirrors `Text.setText`'s guard.
 		if (text === this.#text) return false;
+		if (!text.startsWith(this.#text)) {
+			// Non-append edit: the previous frame's guard verdict cannot be
+			// reused — the checked region may have changed anywhere.
+			this.#appendOnlySinceLastScan = false;
+		}
 		this.#text = text;
 		if (!text.trim()) {
 			// Blank replacement: render() early-returns before #lexTokens can see
@@ -1582,13 +1606,44 @@ export class Markdown implements Component {
 		// frozen (#freezeStablePrefix only runs when canStream was true). The prefix
 		// ends at a "\n\n" block boundary (stableBlockBoundary), so the tail starts
 		// at a fresh line — scanning only the tail for ref defs is sufficient and
-		// avoids re-scanning the growing prefix every frame (O(n²) → O(n) overall).
+		// avoids re-scanning the grown prefix every frame (O(n²) → O(n) overall).
 		const prefix = this.#streamPrefixText;
 		const prefixTokens = this.#streamPrefixTokens;
 		const hasPrefix =
 			prefix !== undefined && prefixTokens !== undefined && text.length > prefix.length && text.startsWith(prefix);
 		const refDefText = hasPrefix ? text.slice(prefix.length) : text;
-		const canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
+		// Guard-scan memo (PoC C): while setText has been append-only and the
+		// grown delta introduces no "[", "]", ":", "\n" or "\r", the previous
+		// verdict stays valid — the checked region is byte-identical (OSC8/tab
+		// normalization is prefix-stable on appends) and none of the chars a
+		// ref-def or CR needs crossed the scan edge. A false verdict is monotone
+		// (appends cannot delete an existing ref def or CR), so it is reused
+		// even when the delta is suspicious; only a true verdict on a suspicious
+		// delta re-runs the tail scan (PR #9303). The tail scan is also the
+		// cold path after non-append edits, which clear the memo.
+		let canStream: boolean;
+		if (this.#lastScanValid && this.#appendOnlySinceLastScan && text.length > this.#lastScanLength) {
+			const delta = text.slice(this.#lastScanLength);
+			if (
+				!delta.includes("[") &&
+				!delta.includes("]") &&
+				!delta.includes(":") &&
+				!delta.includes("\n") &&
+				!delta.includes("\r")
+			) {
+				canStream = this.#lastScanCanStream;
+			} else if (this.#lastScanCanStream) {
+				canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
+			} else {
+				canStream = false;
+			}
+		} else {
+			canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
+		}
+		this.#lastScanLength = text.length;
+		this.#lastScanCanStream = canStream;
+		this.#lastScanValid = true;
+		this.#appendOnlySinceLastScan = true;
 		if (canStream && hasPrefix) {
 			const tailTokens = lexDocument(refDefText);
 			const tokens = [...prefixTokens, ...tailTokens];

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1625,7 +1625,15 @@ export class Markdown implements Component {
 		// (appends cannot delete an existing ref def or CR), so it is reused
 		// even when the delta is suspicious; only a true verdict on a suspicious
 		// delta re-runs the tail scan (PR #9303). The tail scan is also the
-		// cold path after non-append edits, which clear the memo.
+		// cold path after non-append edits, which clear the memo. A FALSE
+		// verdict is monotone under appends alone (transient mode: no repair,
+		// appends cannot delete a ref-def or CR), so there it is reused even
+		// on a suspicious delta. Final mode is the exception: render() detects
+		// repairOrphanClosingFence deletions (the normalized buffer shrank)
+		// and invalidates the memo on the affected frame, so the re-derive
+		// happens exactly when the CR/ref-def trigger behind a false verdict
+		// may have been deleted — never left stale, and never re-scanned on
+		// frames where the memo is sound.
 		let canStream: boolean;
 		if (this.#lastScanValid && this.#appendOnlySinceLastScan && text.length > this.#lastScanLength) {
 			const delta = text.slice(this.#lastScanLength);
@@ -1707,10 +1715,17 @@ export class Markdown implements Component {
 			return EMPTY_RENDER_LINES;
 		}
 
-		// Replace tabs with 3 spaces for consistent rendering
-		const normalizedText = this.transientRenderCache
-			? replaceTabs(this.#text)
-			: repairOrphanClosingFence(replaceTabs(this.#text));
+		// Replace tabs with spaces, then repair orphan fences in final mode.
+		const tabbed = replaceTabs(this.#text);
+		const normalizedText = this.transientRenderCache ? tabbed : repairOrphanClosingFence(tabbed);
+		if (!this.transientRenderCache && normalizedText.length < tabbed.length) {
+			// repairOrphanClosingFence deleted bytes this frame (orphan fence
+			// removed): the guard-scan memo's checked region is no longer
+			// byte-identical, and a cached false verdict may have been based
+			// on the very CR/ref-def line that was deleted. Invalidate so the
+			// next #lexTokens re-derives on the repaired buffer.
+			this.#lastScanValid = false;
+		}
 		const signature = this.#renderSignature(width, paddingX);
 
 		// L2: module-level LRU — survives component disposal/recreation across

--- a/packages/tui/test/markdown-incremental-lex.test.ts
+++ b/packages/tui/test/markdown-incremental-lex.test.ts
@@ -22,6 +22,15 @@ function renderCold(text: string, width: number): readonly string[] {
 	clearRenderCache();
 	return out;
 }
+/** Cold render in transient mode — same masking-safe pattern as renderCold. */
+function renderColdTransient(text: string, width: number): readonly string[] {
+	clearRenderCache();
+	const out = new Markdown(text, 0, 0, THEME);
+	out.transientRenderCache = true;
+	const lines = out.render(width);
+	clearRenderCache();
+	return lines;
+}
 
 /** Reveal `full` in `step`-char increments through ONE reused (streaming) instance
  *  and assert each step matches a cold full-lex render of the same prefix. */
@@ -310,6 +319,27 @@ describe("Markdown incremental streaming lex (E2)", () => {
 		expect(streamLines).toEqual(renderCold(doc, 60));
 	});
 
+	it("orphan-fence repair starting mid-stream keeps growth byte-identical", () => {
+		// Final-mode repairOrphanClosingFence deletes an unmatched bare fence
+		// once both a heading and a GFM table delimiter follow it. The raw text
+		// grows append-only across the transition while the NORMALIZED text
+		// (with the fence deleted) is no longer an append-extension of the
+		// previous frame's, so the guard-scan memo's byte alignment is put to
+		// the test: the trigger either brings "\n" into the delta (suspicious
+		// path re-scans) or shortens the text (length gate re-derives). The
+		// cold-render oracle must match at every step.
+		const doc =
+			"Intro paragraph before the stray fence lands in the stream.\n\n" +
+			"```\n" +
+			"# Heading after the orphan fence\n\n" +
+			"| col a | col b |\n" +
+			"| --- | --- |\n\n" +
+			"Trailing paragraph that keeps streaming after the table ends.";
+		assertIdenticalGrowth(doc, 60, 1);
+		assertIdenticalGrowth(doc, 60, 3);
+		assertIdenticalGrowth(doc, 60, 13);
+	});
+
 	it("a document that is one still-growing list never freezes mid-list", () => {
 		// No (b)-style intra-list freezing shipped: loose/tight and ordered
 		// renumbering are whole-list properties, so no prefix of an open list
@@ -322,6 +352,42 @@ describe("Markdown incremental streaming lex (E2)", () => {
 			streaming.setText(doc.slice(0, len));
 			const streamLines = streaming.render(60);
 			expect(streamLines).toEqual(renderCold(doc.slice(0, len), 60));
+		}
+	});
+
+	it("flipping transientRenderCache re-derives the guard memo", () => {
+		// Regression: final mode normalized this document through
+		// repairOrphanClosingFence, which deleted the bare fence line carrying
+		// the text's only "\r". Memoized in final mode the verdict is
+		// canStream=true (no CR, no ref defs) with #lastScanLength taken from
+		// the REPAIRED buffer. Flipping to transient mode re-introduces the
+		// raw "\r" (transient skips repair); if the memo survived the flip, a
+		// clean-suffix append would reuse canStream=true and stream the
+		// CR-containing tail. The mode flip must invalidate the memo so the
+		// next frame re-derives and falls back to the full lex.
+		const crlfFence =
+			"Intro paragraph before the stray fence with a CRLF line end.\n\n" +
+			"```\r\n" +
+			"# Heading after the fence\n\n" +
+			"| a | b |\n" +
+			"| --- | --- |\n\n" +
+			"Tail prose that only streams in after the table.";
+		const streaming = new Markdown("", 0, 0, THEME);
+		clearRenderCache();
+		streaming.setText(crlfFence);
+		streaming.render(60); // final mode: repair deletes the fence + its CR
+		// Switch to transient streaming on the same instance and append only
+		// CLEAN suffixes (no newline/bracket/colon): a stale memo would be
+		// reused on each of these and stream the CR-containing tail against
+		// the repaired-buffer prefix, diverging from the cold render.
+		streaming.transientRenderCache = true;
+		let grown = crlfFence;
+		for (const suffix of [" tail-a", " tail-b", " tail-c"]) {
+			grown += suffix;
+			clearRenderCache();
+			streaming.setText(grown);
+			const streamLines = streaming.render(60);
+			expect(streamLines).toEqual(renderColdTransient(grown, 60));
 		}
 	});
 });


### PR DESCRIPTION
Memoize the HAS_REF_DEF / CR streaming guard: scan only the appended delta for
suspicious chars ([ ] : \n \r); reuse the previous verdict when the delta is
clean. Guard cost 265µs → 0.1µs/frame @128KB. 31 prod lines.

Streaming markdown render spends O(n) per frame rescanning text that didn't
change. Profile (#9048): RegExp.test 26% + #Ui 28% of a 30Hz frame during
routine streaming — the full-doc guard scans + per-frame re-lex/re-wrap of the
growing tail. Upstream's incremental fence highlighting (#3980) cached the
frozen prefix; the remaining per-frame scans were untouched. This change
removes one such scan, making it O(delta) (or O(1) on inert deltas).

Refs #9048 #3975.

No unrelated fixes included.
