### PR TITLE
fix(coding-agent): race /mcp test config lookup against esc abort

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/mcp test` now reports cancellation immediately when Esc is pressed during a slow config lookup, instead of staying suspended until the read settles ([#9419](https://github.com/can1357/oh-my-pi/issues/9419)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1630,7 +1630,14 @@ export class MCPCommandController {
 			this.ctx.ui.requestRender();
 		});
 		try {
-			const found = await this.#resolveServerForAuth(name);
+			// Race the config read against Esc: a slow/stuck `#resolveServerForAuth()`
+			// (e.g. config on a network FS) must surface cancellation immediately
+			// via the catch branch below, not stay suspended until the read settles.
+			const found = await raceAbortSignal(
+				this.#resolveServerForAuth(name),
+				abortController.signal,
+				() => new DOMException("Aborted", "AbortError"),
+			);
 
 			if (!found) {
 				this.ctx.mcpTestEscapeHandlers.delete(handleEscape);

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -351,6 +351,52 @@ describe("interactive /mcp test", () => {
 		expect(mcpTestEscapeHandlers).toHaveLength(0);
 	});
 
+	it("cancels while the awaited lookup is still pending", async () => {
+		// The config read never settles (e.g. config on a stuck network FS).
+		const { promise: lookup } = Promise.withResolvers<{
+			mcpServers: Record<string, { type: string; command: string; args: string[] }>;
+		}>();
+		vi.spyOn(mcpConfigWriter, "readMCPConfigFile").mockReturnValue(lookup as never);
+		const presentCommandOutput = vi.fn();
+		const showStatus = vi.fn();
+		const mcpTestEscapeHandlers = new Set<() => void>();
+		const controller = new MCPCommandController({
+			mcpTestEscapeHandlers,
+			chatContainer: { addChild: vi.fn() },
+			present: vi.fn(),
+			presentCommandOutput,
+			ui: { requestRender: vi.fn() },
+			editor: {},
+			showError: vi.fn(),
+			showStatus,
+			session: { refreshMCPTools: vi.fn() },
+			mcpManager: {
+				getServerConfig: vi.fn(() => undefined),
+				getSource: vi.fn(() => undefined),
+				prepareConfig: vi.fn(async config => config),
+				getConnectionStatus: vi.fn(() => "connected"),
+			},
+		} as never);
+
+		const pending = controller.handle("/mcp test github");
+		expect(mcpTestEscapeHandlers).toHaveLength(1);
+
+		// Esc lands during the stuck read; consume like InputController does.
+		for (const handler of [...mcpTestEscapeHandlers]) {
+			mcpTestEscapeHandlers.delete(handler);
+			handler();
+		}
+
+		// The command must settle now, while the read is STILL pending — the
+		// lookup is never resolved. Racing the abort signal makes `handle`
+		// resolve; the old post-lookup check would hang until the read settled.
+		await pending;
+
+		expect(presentCommandOutput).not.toHaveBeenCalled();
+		expect(showStatus).toHaveBeenCalledWith(`Cancelled MCP test for "github"`);
+		expect(mcpTestEscapeHandlers).toHaveLength(0);
+	});
+
 	it("claims Esc ownership before the awaited server lookup", async () => {
 		const connection = {
 			name: "github",


### PR DESCRIPTION
## Repro
Pressing Esc during a slow or stuck `/mcp test` config lookup (e.g. config on a network filesystem) produced no `Cancelled MCP test for "<name>"` feedback until the read settled. A new regression test — a `readMCPConfigFile` spy that never resolves, Esc fired through the real dispatcher — times out at 5s on the current code:

```
bun test packages/coding-agent/test/issue-956-repro.test.ts -t "cancels while the awaited lookup is still pending"
(fail) interactive /mcp test > cancels while the awaited lookup is still pending [5010.73ms]
  ^ this test timed out after 5000ms.
```

## Cause
`MCPCommandController.#handleTest` awaited the server lookup without racing the abort signal:

```ts
const found = await this.#resolveServerForAuth(name); // mcp-command-controller.ts:1633
```

Esc correctly consumes ownership and aborts the controller, but the command stays suspended inside the awaited read; the `Cancelled MCP test` status only fires once the read settles and control reaches the post-lookup `signal.aborted` check. Closed #9171 had raced this lookup with the in-file `raceAbortSignal` helper (already used by the OAuth flow at `:980`); the #9174/#9309 lineage replaced it with the weaker post-lookup aborted check, regressing the immediate-feedback behavior.

## Fix
- Wrap `#resolveServerForAuth(name)` in `raceAbortSignal(..., abortController.signal, () => new DOMException("Aborted", "AbortError"))` so an abort rejects immediately and lands in the existing catch branch (`:1711`) → immediate `Cancelled MCP test` status and `Cancelled connection test` settle note while the read is still pending.
- Keep the post-await `signal.aborted` bailout for the microtask gap where the signal fires after the race settles.
- Add a regression test (`cancels while the awaited lookup is still pending`) asserting the command settles cancelled without the lookup ever resolving and `mcpTestEscapeHandlers` empties afterward.

## Verification
```
bun test packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/issue-956-repro.test.ts
 42 pass  0 fail
```
The new test times out at 5s when the race is reverted (mutation-checked). `bun check` is clean (enforced by the pre-publish gate).

Fixes #9419