### PR TITLE
fix(coding-agent): unify Mnemopi per-project bank derivation across git worktrees and jj workspaces

### DIFF
--- a/docs/mnemosyne-memory-backend.md
+++ b/docs/mnemosyne-memory-backend.md
@@ -45,7 +45,7 @@ Read the full content and metadata for a recalled result with `read memory://<me
 | ----------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `memory.backend`              | `off`              | Set to `mnemopi` to enable this backend.                                                                                                                                                                                                                                               |
 | `mnemopi.dbPath`              | agent memories dir | Optional SQLite database path.                                                                                                                                                                                                                                                         |
-| `mnemopi.bank`                | unset              | Optional shared bank base name passed to `Mnemopi`; the coding-agent wrapper scopes from this base according to `mnemopi.scoping`. Unset → shared bank `default`; per-project modes derive a project bank from the working-directory basename plus a stable hash of its absolute path. |
+| `mnemopi.bank`                | unset              | Optional shared bank base name passed to `Mnemopi`; the coding-agent wrapper scopes from this base according to `mnemopi.scoping`. Unset → shared bank `default`; per-project modes derive a project bank from the resolved primary project root's basename plus a stable hash of that resolved path (see [Scoping](#scoping)). |
 | `mnemopi.scoping`             | `per-project`      | Memory visibility mode: `global` = one shared bank, `per-project` = isolated project memory, `per-project-tagged` = project-local writes plus global recall visibility.                                                                                                                |
 | `mnemopi.autoRecall`          | `true`             | Recall memory on the first turn of a session.                                                                                                                                                                                                                                          |
 | `mnemopi.autoRetain`          | `true`             | Retain completed turns automatically.                                                                                                                                                                                                                                                  |
@@ -73,10 +73,28 @@ Read the full content and metadata for a recalled result with `read memory://<me
 The coding-agent wrapper applies scoping on top of the underlying `Mnemopi` package:
 
 - `global` uses one shared bank for recall and writes.
-- `per-project` writes to and recalls from a bank derived from the current working directory alone — its basename plus a stable hash of its absolute path, independent of the surrounding git layout.
+- `per-project` writes to and recalls from a bank derived from the current working directory's **resolved primary project root** — its basename plus a stable hash of that resolved path.
 - `per-project-tagged` writes to the project-local bank and recalls from both the project-local bank and the shared global bank, with duplicate recall results merged.
 
 The combined project-plus-global behavior lives in the wrapper. The `@oh-my-pi/pi-mnemopi` package itself still exposes banks and constructor options directly, including `bank` for selecting a bank name. Project-local banks other than the shared bank are stored as sibling bank databases managed by Mnemopi's `BankManager`.
+
+### Project root resolution
+
+The resolved primary project root mirrors the Hindsight backend's `projectLabel` (`hindsight/bank.ts`), so both backends collapse the same repository layouts to one location:
+
+1. A plain git checkout resolves to itself.
+2. A linked git worktree (`git worktree add`) resolves to the primary checkout's common `.git` directory's parent, via `git.repo.primaryRootSync`.
+3. A colocated Jujutsu workspace (`jj workspace add --colocate`, the default when the parent workspace is colocated) is implemented by jj as a real git worktree, so case 2 already covers it.
+4. A non-colocated Jujutsu workspace (no `.git` at all) resolves through its `.jj/repo` file — which `jj workspace add` points at the primary workspace's `.jj/repo` — via `jj.repo.primaryRootSync`.
+5. A directory outside any git or jj repository resolves to itself, unchanged.
+
+Every linked worktree or workspace of one repository therefore derives the same per-project bank, matching how `per-project`/`per-project-tagged` already behave for Hindsight.
+
+### Migration from the previous per-worktree scheme
+
+Before this change, `per-project`/`per-project-tagged` derived the project bank from the raw working directory alone, so each git worktree or jj workspace of one repository had its own isolated bank. Existing installs therefore have one legacy bank per worktree/workspace, named from that worktree's own path, instead of one shared bank named from the primary checkout.
+
+No bank is renamed or merged automatically — `BankManager.renameBank` refuses when the destination bank already exists, which the primary checkout's bank normally does, so an automatic rename/merge across every worktree cannot be done safely in general. Instead, the existing legacy-bank rescue (`extendRecallWithLegacyBanks`, originally added for #2412) already widens recall to include any sibling bank under `<dbDir>/banks/` whose `working_memory` rows are all tagged with the active cwd, so old per-worktree banks keep showing up in recall from the worktree they were written from. New writes go to the new shared, primary-root-derived bank. Installs that want every worktree's old memories consolidated into the new shared bank immediately can do so manually with Mnemopi's bank tools (rename each old per-worktree bank directory under `<dbDir>/banks/` into the new bank name, or merge their contents) before starting a session in the affected repository.
 
 ## LLM and embeddings
 

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
+import * as git from "../utils/git";
+import * as jj from "../utils/jj";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
 
@@ -122,8 +124,8 @@ export interface MnemopiBankScope {
  *
  * Mnemopi has no tag-filtered recall, so `per-project-tagged` maps to a
  * project-local write bank plus a shared recall-visible bank. The project
- * bank is derived purely from {@link cwd} — see {@link projectBank} for the
- * stability contract.
+ * bank is derived from {@link cwd}'s resolved primary project root — see
+ * {@link projectBank} for the stability contract.
  */
 export function computeMnemopiBankScope(
 	configured: string | undefined,
@@ -165,19 +167,71 @@ function sharedBank(configured: string | undefined): string {
 }
 
 /**
- * Derive the per-project bank id from `cwd` alone.
+ * Derive the per-project bank id from the resolved primary project root.
  *
- * Earlier versions resolved the enclosing git root before hashing, which
- * made the bank id unstable: removing or adding a `.git` anywhere above the
- * cwd repointed the same conversation directory to a different bank and
- * fragmented memories (#2412). The git lookup is gone here; the rescue path
- * for already-fragmented installs lives in {@link extendRecallWithLegacyBanks}.
+ * Earlier versions hashed the enclosing git root before it was resolved to a
+ * *primary* checkout, which made the bank id unstable: removing or adding a
+ * `.git` anywhere above the cwd repointed the same conversation directory to
+ * a different bank and fragmented memories (#2412). The fix at the time
+ * dropped git resolution entirely and hashed the raw cwd, which traded that
+ * instability for a worse one: every git worktree or jj workspace of the
+ * same repository got its own isolated bank.
+ *
+ * {@link resolveProjectRoot} restores git/jj resolution, but only ever
+ * widens to a *primary* checkout root (mirroring the Hindsight backend's
+ * `projectLabel` in `hindsight/bank.ts`), never to an arbitrary ancestor —
+ * a stray or unrelated `.git`/`.jj` above the project root still does not
+ * resolve to a repository unless it actually is one. Any bank a resolution
+ * change strands is recovered the same way #2412 fragmentation was: once
+ * every row in an orphaned bank tags the same cwd, `extendRecallWithLegacyBanks`
+ * widens recall to include it.
  */
 function projectBank(configured: string | undefined, cwd: string): string {
-	const projectRoot = path.resolve(cwd || ".");
+	const projectRoot = resolveProjectRoot(path.resolve(cwd || "."));
 	const project = projectBankSegment(projectRoot);
 	const base = sanitizeBankName(configured);
 	return limitBankName(base ? `${base}-${project}` : project);
+}
+
+/**
+ * Resolve the primary project root for bank derivation: the repository's
+ * primary checkout root, so every linked git worktree, colocated jj
+ * workspace (`jj workspace add --colocate` creates a real git worktree, so
+ * git resolution already covers it), and non-colocated jj workspace
+ * resolves to the same directory. Falls back to `directory` itself outside
+ * any repository, preserving the plain cwd-based behavior from #2412.
+ *
+ * Git is not always tried first: when `directory` sits inside a pure jj
+ * workspace nested under an unrelated *outer* Git checkout (the topology
+ * {@link jj.isPureJjRepo} documents as real), the jj workspace root is the
+ * nearer ancestor and must win, or the inner project would derive the
+ * outer checkout's bank and mix memories `per-project` is meant to isolate.
+ * {@link isNearerAncestor} performs the same nearest-root comparison
+ * `isPureJjRepo` uses, synchronously.
+ */
+function resolveProjectRoot(directory: string): string {
+	const gitRoot = git.repo.resolveSync(directory)?.repoRoot ?? null;
+	const jjRoot = jj.repo.rootSync(directory);
+	if (jjRoot !== null && (gitRoot === null || isNearerAncestor(jjRoot, gitRoot))) {
+		return jj.repo.primaryRootSync(directory) ?? directory;
+	}
+	return git.repo.primaryRootSync(directory) ?? jj.repo.primaryRootSync(directory) ?? directory;
+}
+
+/**
+ * Return `true` when `candidate` is a strict descendant of `other` — i.e.
+ * nearer to the queried directory. Both arguments must already be resolved
+ * absolute paths without a trailing separator.
+ */
+function isNearerAncestor(candidate: string, other: string): boolean {
+	const rel = path.relative(other, candidate);
+	if (rel === "" || rel === ".") return false;
+	// A literal ".." component means `path.relative` had to walk upward, i.e.
+	// `candidate` is not under `other` at all. A directory whose *name*
+	// happens to start with ".." (e.g. `..jj-project`) is a genuine
+	// descendant and must not be rejected by a bare `startsWith("..")` check.
+	if (rel === ".." || rel.startsWith(`..${path.sep}`)) return false;
+	return !path.isAbsolute(rel);
 }
 
 function projectBankSegment(projectRoot: string): string {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -931,15 +931,28 @@ async function isLinkedWorktreeAsync(repository: GitRepository): Promise<boolean
 	);
 }
 
+/**
+ * Resolve the primary checkout root for a linked worktree whose common dir
+ * is itself relocated via `core.worktree` — a submodule's internal git dir
+ * (`<super>/.git/modules/<name>`) or any `--separate-git-dir` checkout. Such
+ * a common dir has no ordinary parent-directory relationship to its work
+ * tree, so the `.git`-basename and bare-worktree heuristics below would
+ * otherwise return the common dir itself, splitting the submodule's primary
+ * checkout from its own linked worktrees onto different primary roots.
+ */
 function primaryRootFromRepositorySync(repository: GitRepository): string {
 	if (path.basename(repository.commonDir) === ".git") return path.dirname(repository.commonDir);
-	if (isLinkedWorktree(repository)) return repository.commonDir;
+	if (isLinkedWorktree(repository)) {
+		return resolveConfiguredWorktreeSync(repository.commonDir) ?? repository.commonDir;
+	}
 	return repository.repoRoot;
 }
 
 async function primaryRootFromRepository(repository: GitRepository): Promise<string> {
 	if (path.basename(repository.commonDir) === ".git") return path.dirname(repository.commonDir);
-	if (await isLinkedWorktreeAsync(repository)) return repository.commonDir;
+	if (await isLinkedWorktreeAsync(repository)) {
+		return (await resolveConfiguredWorktree(repository.commonDir)) ?? repository.commonDir;
+	}
 	return repository.repoRoot;
 }
 
@@ -1078,6 +1091,50 @@ function parseGitConfigHasReftable(content: string): boolean {
 		}
 	}
 	return false;
+}
+
+/**
+ * Parse a git-dir's `config` file for an explicit `core.worktree` override —
+ * the mechanism `git submodule` and `git init --separate-git-dir` both use to
+ * point a git dir at a work tree that isn't its own parent directory. Returns
+ * the raw (possibly relative) value, or `null` when unset.
+ */
+function parseGitConfigWorktree(content: string): string | null {
+	let inCore = false;
+	for (const line of content.split("\n")) {
+		const trimmed = stripGitConfigComments(line);
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			const section = trimmed.slice(1, -1).trim().toLowerCase();
+			inCore = section === "core";
+			continue;
+		}
+		if (!inCore) continue;
+		const eqIndex = trimmed.indexOf("=");
+		if (eqIndex === -1) continue;
+		const key = trimmed.slice(0, eqIndex).trim().toLowerCase();
+		if (key !== "worktree") continue;
+		let value = trimmed.slice(eqIndex + 1).trim();
+		if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1).trim();
+		return value || null;
+	}
+	return null;
+}
+
+/**
+ * Resolve a git-dir's `core.worktree` override to an absolute path, or
+ * `null` when the git dir has none (the ordinary case for ordinary
+ * checkouts and linked worktrees of them).
+ */
+function resolveConfiguredWorktreeSync(gitDir: string): string | null {
+	const content = readOptionalTextSync(path.join(gitDir, "config"));
+	const worktree = content ? parseGitConfigWorktree(content) : null;
+	return worktree ? path.resolve(gitDir, worktree) : null;
+}
+
+async function resolveConfiguredWorktree(gitDir: string): Promise<string | null> {
+	const content = await readOptionalText(path.join(gitDir, "config"));
+	const worktree = content ? parseGitConfigWorktree(content) : null;
+	return worktree ? path.resolve(gitDir, worktree) : null;
 }
 
 function isReftableRepoSync(repository: GitRepository): boolean {

--- a/packages/coding-agent/src/utils/jj.ts
+++ b/packages/coding-agent/src/utils/jj.ts
@@ -266,6 +266,17 @@ async function resolveRepoDir(root: string): Promise<string> {
 	return repoPath;
 }
 
+/** Sync sibling of {@link resolveRepoDir}, for callers needing a synchronous primary-root lookup (e.g. bank/tag derivation). */
+function resolveRepoDirSync(root: string): string {
+	const jjDir = path.join(root, ".jj");
+	const repoPath = path.join(jjDir, "repo");
+	if (fs.statSync(repoPath).isFile()) {
+		const target = fs.readFileSync(repoPath, "utf8").trim();
+		return path.resolve(jjDir, target);
+	}
+	return repoPath;
+}
+
 async function repositoryFromRoot(root: string): Promise<JjRepository> {
 	return {
 		repoRoot: root,
@@ -356,6 +367,20 @@ export const repo = {
 	 */
 	rootSync(cwd: string): string | null {
 		return findWorkspaceRootSync(cwd) ?? null;
+	},
+
+	/**
+	 * Resolve the primary workspace root synchronously — the directory whose
+	 * `.jj/repo` is the actual repo store, following the file indirection used
+	 * by non-default workspaces created with `jj workspace add`. A colocated
+	 * workspace already gets a real Git worktree (`jj workspace add --colocate`
+	 * shells out to `git worktree add`), so `git.repo.primaryRootSync` resolves
+	 * those; this covers the non-colocated case, where no `.git` exists at all.
+	 * Returns `null` when `cwd` is outside a Jujutsu workspace.
+	 */
+	primaryRootSync(cwd: string): string | null {
+		const root = findWorkspaceRootSync(cwd);
+		return root ? path.dirname(path.dirname(resolveRepoDirSync(root))) : null;
 	},
 
 	/** Resolve the current Jujutsu workspace root, or `null` when `cwd` is not in a JJ repository. */

--- a/packages/coding-agent/test/git-linked-worktree.test.ts
+++ b/packages/coding-agent/test/git-linked-worktree.test.ts
@@ -20,6 +20,38 @@ function linkWorktree(project: string, worktreeRoot: string): void {
 	fs.writeFileSync(path.join(worktreeRoot, ".git"), `gitdir: ${path.relative(worktreeRoot, gitDir)}\n`, "utf8");
 }
 
+// Builds the on-disk shape of a linked worktree created *from within a
+// checked-out submodule*: the submodule's own git dir lives at
+// `<super>/.git/modules/<name>` (not `<checkout>/.git`) and points back at
+// its checkout via `core.worktree` in its `config` file — the same
+// indirection `git init --separate-git-dir` uses. A worktree of that
+// submodule therefore has a common dir whose basename is the submodule
+// name, not `.git`, and whose own `core.worktree` (inherited from the
+// common dir's config) must be followed to reach the submodule checkout.
+function linkSubmoduleWorktree(superRoot: string, submoduleCheckout: string, worktreeRoot: string): void {
+	const commonDir = path.join(superRoot, ".git", "modules", path.basename(submoduleCheckout));
+	fs.mkdirSync(commonDir, { recursive: true });
+	fs.mkdirSync(submoduleCheckout, { recursive: true });
+	fs.writeFileSync(path.join(commonDir, "HEAD"), "ref: refs/heads/main\n", "utf8");
+	fs.writeFileSync(
+		path.join(commonDir, "config"),
+		`[core]\n\tworktree = ${path.relative(commonDir, submoduleCheckout)}\n`,
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(submoduleCheckout, ".git"),
+		`gitdir: ${path.relative(submoduleCheckout, commonDir)}\n`,
+		"utf8",
+	);
+
+	const gitDir = path.join(commonDir, "worktrees", path.basename(worktreeRoot));
+	fs.mkdirSync(gitDir, { recursive: true });
+	fs.mkdirSync(worktreeRoot, { recursive: true });
+	fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/feature\n", "utf8");
+	fs.writeFileSync(path.join(gitDir, "commondir"), `${path.relative(gitDir, commonDir)}\n`, "utf8");
+	fs.writeFileSync(path.join(worktreeRoot, ".git"), `gitdir: ${path.relative(worktreeRoot, gitDir)}\n`, "utf8");
+}
+
 describe("git linked worktree resolution", () => {
 	let tempRoot: string;
 
@@ -89,5 +121,15 @@ describe("git linked worktree resolution", () => {
 			return stat(target);
 		}) as typeof fs.promises.stat);
 		expect(await repo.resolve(worktreeRoot)).toBeNull();
+	});
+
+	it("resolves a worktree of a submodule to the submodule's own checkout, not the internal .git/modules store", () => {
+		const superRoot = path.join(tempRoot, "super");
+		const submoduleCheckout = path.join(superRoot, "sub");
+		const worktreeRoot = path.join(tempRoot, ".tree", "sub", "xx");
+		linkSubmoduleWorktree(superRoot, submoduleCheckout, worktreeRoot);
+
+		expect(repo.primaryRootSync(worktreeRoot)).toBe(submoduleCheckout);
+		expect(repo.primaryRootSync(submoduleCheckout)).toBe(submoduleCheckout);
 	});
 });

--- a/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
+++ b/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
@@ -6,6 +6,60 @@ import * as path from "node:path";
 import { computeMnemopiBankScope, extendRecallWithLegacyBanks } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
 import { removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
 
+// Isolate `git` invocations in this file from the host's global config —
+// `~/.gitconfig` commit signing or template hooks would otherwise turn the
+// worktree fixture's `git init`/`git commit`/`git worktree add` into a flaky
+// dance. Restored in `afterAll` below so later files sharing this worker
+// don't inherit a disabled global git config.
+const savedGitEnv = {
+	GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
+	GIT_CONFIG_SYSTEM: process.env.GIT_CONFIG_SYSTEM,
+	GIT_CONFIG_NOSYSTEM: process.env.GIT_CONFIG_NOSYSTEM,
+	GIT_TERMINAL_PROMPT: process.env.GIT_TERMINAL_PROMPT,
+	GIT_ASKPASS: process.env.GIT_ASKPASS,
+	XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+};
+process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+process.env.GIT_CONFIG_NOSYSTEM = "1";
+process.env.GIT_TERMINAL_PROMPT = "0";
+process.env.GIT_ASKPASS = "true";
+delete process.env.XDG_CONFIG_HOME;
+
+function runGit(cwd: string, args: string[]): string {
+	const result = Bun.spawnSync(["git", ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: "Test User",
+			GIT_AUTHOR_EMAIL: "test@example.com",
+			GIT_COMMITTER_NAME: "Test User",
+			GIT_COMMITTER_EMAIL: "test@example.com",
+		},
+	});
+	if (result.exitCode !== 0) {
+		const stderr = new TextDecoder().decode(result.stderr).trim();
+		const stdout = new TextDecoder().decode(result.stdout).trim();
+		throw new Error(`git ${args.join(" ")} failed: ${stderr || stdout || `exit ${result.exitCode}`}`);
+	}
+	return new TextDecoder().decode(result.stdout).trim();
+}
+
+/**
+ * Write a `.jj/repo` FILE pointing at `primaryJjRepoDir`, matching the shape
+ * `jj workspace add` writes for a non-default workspace (content is a path
+ * relative to the workspace's own `.jj` dir). No real `jj` binary is
+ * invoked — this mirrors the manual-fixture convention in
+ * `test/utils/jj.test.ts` rather than depending on `jj` being installed.
+ */
+async function writeJjWorkspacePointer(workspaceRoot: string, primaryJjRepoDir: string): Promise<void> {
+	const jjDir = path.join(workspaceRoot, ".jj");
+	await fs.mkdir(jjDir, { recursive: true });
+	await fs.writeFile(path.join(jjDir, "repo"), path.relative(jjDir, primaryJjRepoDir));
+}
+
 // Set up a fixture filesystem we can reuse across the two regression
 // suites — same shape as `~/.omp/memories/mnemopi/` on a real install.
 let rootDir: TempDir;
@@ -24,6 +78,10 @@ beforeAll(async () => {
 afterAll(async () => {
 	await Bun.sleep(0);
 	await rootDir.remove();
+	for (const [key, value] of Object.entries(savedGitEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
 });
 
 // Schema mirrors the subset of `packages/mnemopi/src/core/beam/schema.ts`
@@ -145,5 +203,159 @@ describe("extendRecallWithLegacyBanks edge cases", () => {
 		const out = extendRecallWithLegacyBanks(["active"], mainDbPath, path.join(rootDir.path(), "some", "cwd"));
 		expect(out).toContain("active");
 		expect(out).not.toContain("corrupt-C");
+	});
+});
+
+// Regression: linked git worktrees, colocated jj workspaces (which
+// `jj workspace add --colocate` implements as a real git worktree, verified
+// against the `jj` CLI directly — no separate fixture needed here), and
+// non-colocated jj workspaces of one repository all used to get their own
+// isolated per-project bank. Ports the Hindsight backend's `projectLabel`
+// fix for #2232 (`git.repo.primaryRootSync`, plus the new
+// `jj.repo.primaryRootSync` for the non-colocated case) into
+// `projectBank`/`resolveProjectRoot`.
+describe("computeMnemopiBankScope worktree/workspace collapsing", () => {
+	let baseDir: TempDir;
+	let primaryRoot: string;
+	let gitWorktreeRoot: string;
+	let jjWorkspaceRoot: string;
+	let nonRepoDir: string;
+
+	beforeAll(async () => {
+		baseDir = await TempDir.create("@mnemopi-worktree-");
+		primaryRoot = baseDir.join("myrepo");
+		gitWorktreeRoot = baseDir.join("myrepo-worktree");
+		jjWorkspaceRoot = baseDir.join("myrepo-jj-plain");
+		nonRepoDir = baseDir.join("not-a-repo");
+		await fs.mkdir(primaryRoot, { recursive: true });
+		await fs.mkdir(nonRepoDir, { recursive: true });
+		runGit(primaryRoot, ["-c", "init.defaultBranch=main", "init"]);
+		await fs.writeFile(path.join(primaryRoot, "README.md"), "hi\n");
+		runGit(primaryRoot, ["add", "-A"]);
+		runGit(primaryRoot, ["commit", "-m", "base"]);
+		runGit(primaryRoot, ["worktree", "add", gitWorktreeRoot, "-b", "feature-x"]);
+		// Colocated-jj shape: the primary's `.jj/repo` is a directory (the
+		// default workspace), the linked worktree's is a FILE pointing back at
+		// it — same as `jj workspace add --colocate` on top of this git
+		// worktree would produce.
+		await fs.mkdir(path.join(primaryRoot, ".jj", "repo", "store"), { recursive: true });
+		await writeJjWorkspacePointer(gitWorktreeRoot, path.join(primaryRoot, ".jj", "repo"));
+		// Non-colocated jj workspace: only `.jj/repo`, no `.git` anywhere.
+		await writeJjWorkspacePointer(jjWorkspaceRoot, path.join(primaryRoot, ".jj", "repo"));
+	});
+
+	afterAll(async () => {
+		if (baseDir) await baseDir.remove();
+	});
+
+	it("emits the same per-project bank from the primary checkout and a linked git worktree", () => {
+		const fromPrimary = computeMnemopiBankScope(undefined, primaryRoot, "per-project").bank;
+		const fromWorktree = computeMnemopiBankScope(undefined, gitWorktreeRoot, "per-project").bank;
+		expect(fromWorktree).toBe(fromPrimary);
+		expect(fromPrimary).toBe(`myrepo-${Bun.hash(primaryRoot).toString(36)}`);
+	});
+
+	it("emits the same per-project bank from a non-colocated jj workspace", () => {
+		const fromPrimary = computeMnemopiBankScope(undefined, primaryRoot, "per-project").bank;
+		const fromWorkspace = computeMnemopiBankScope(undefined, jjWorkspaceRoot, "per-project").bank;
+		expect(fromWorkspace).toBe(fromPrimary);
+	});
+
+	it("keeps per-project-tagged recall scoped to the collapsed project bank across worktree and workspace", () => {
+		const fromPrimary = computeMnemopiBankScope(undefined, primaryRoot, "per-project-tagged");
+		const fromWorktree = computeMnemopiBankScope(undefined, gitWorktreeRoot, "per-project-tagged");
+		const fromWorkspace = computeMnemopiBankScope(undefined, jjWorkspaceRoot, "per-project-tagged");
+		expect(fromWorktree).toEqual(fromPrimary);
+		expect(fromWorkspace).toEqual(fromPrimary);
+	});
+
+	it("preserves the plain cwd-hash fallback outside any git/jj repository", () => {
+		const bank = computeMnemopiBankScope(undefined, nonRepoDir, "per-project").bank;
+		expect(bank).toBe(`not-a-repo-${Bun.hash(nonRepoDir).toString(36)}`);
+	});
+});
+
+// Regression: a pure jj workspace nested under an *unrelated* outer Git
+// checkout — the topology `jj.isPureJjRepo` documents as real — used to
+// derive its bank from the outer checkout, because `resolveProjectRoot`
+// always tried Git resolution before Jujutsu. The nearer VCS root (the
+// jj workspace, since it sits deeper than the unrelated outer `.git`) must
+// win, or the inner project's memories mix into the outer checkout's bank.
+describe("computeMnemopiBankScope pure jj nested under an unrelated outer git checkout", () => {
+	let baseDir: TempDir;
+	let outerGitRoot: string;
+	let jjPrimaryRoot: string;
+	let nestedJjRoot: string;
+
+	beforeAll(async () => {
+		baseDir = await TempDir.create("@mnemopi-nested-jj-");
+		outerGitRoot = baseDir.join("outer-repo");
+		jjPrimaryRoot = baseDir.join("jj-primary");
+		nestedJjRoot = path.join(outerGitRoot, "nested-jj-workspace");
+		await fs.mkdir(outerGitRoot, { recursive: true });
+		await fs.mkdir(nestedJjRoot, { recursive: true });
+		runGit(outerGitRoot, ["-c", "init.defaultBranch=main", "init"]);
+		await fs.writeFile(path.join(outerGitRoot, "README.md"), "hi\n");
+		runGit(outerGitRoot, ["add", "-A"]);
+		runGit(outerGitRoot, ["commit", "-m", "base"]);
+		// An unrelated, wholly separate non-colocated jj repository (no `.git` anywhere).
+		await fs.mkdir(path.join(jjPrimaryRoot, ".jj", "repo", "store"), { recursive: true });
+		// Lives inside the outer git checkout's tree but is its own jj workspace
+		// pointed at the unrelated jj-primary repo above.
+		await writeJjWorkspacePointer(nestedJjRoot, path.join(jjPrimaryRoot, ".jj", "repo"));
+	});
+
+	afterAll(async () => {
+		if (baseDir) await baseDir.remove();
+	});
+
+	it("derives the bank from the nearer jj workspace root, not the outer git checkout", () => {
+		const fromNestedJj = computeMnemopiBankScope(undefined, nestedJjRoot, "per-project").bank;
+		const fromJjPrimary = computeMnemopiBankScope(undefined, jjPrimaryRoot, "per-project").bank;
+		const fromOuterGit = computeMnemopiBankScope(undefined, outerGitRoot, "per-project").bank;
+		expect(fromNestedJj).toBe(fromJjPrimary);
+		expect(fromNestedJj).not.toBe(fromOuterGit);
+	});
+});
+
+// Regression: `isNearerAncestor` used to reject a jj workspace as a
+// descendant whenever its `path.relative` result merely *started with* the
+// two-character string "..", which also matches directory names like
+// `..jj-workspace` that are not a parent traversal at all. That false
+// rejection made the nearer jj workspace lose to the unrelated outer git
+// checkout, exactly like the topology above but with a dotdot-prefixed
+// workspace directory name standing in for the ordinary "outer git wins"
+// bug this suite already covers.
+describe("computeMnemopiBankScope nested jj workspace name starting with '..'", () => {
+	let baseDir: TempDir;
+	let outerGitRoot: string;
+	let jjPrimaryRoot: string;
+	let nestedJjRoot: string;
+
+	beforeAll(async () => {
+		baseDir = await TempDir.create("@mnemopi-dotdot-jj-");
+		outerGitRoot = baseDir.join("outer-repo");
+		jjPrimaryRoot = baseDir.join("jj-primary");
+		nestedJjRoot = path.join(outerGitRoot, "..jj-workspace");
+		await fs.mkdir(outerGitRoot, { recursive: true });
+		await fs.mkdir(nestedJjRoot, { recursive: true });
+		runGit(outerGitRoot, ["-c", "init.defaultBranch=main", "init"]);
+		await fs.writeFile(path.join(outerGitRoot, "README.md"), "hi\n");
+		runGit(outerGitRoot, ["add", "-A"]);
+		runGit(outerGitRoot, ["commit", "-m", "base"]);
+		await fs.mkdir(path.join(jjPrimaryRoot, ".jj", "repo", "store"), { recursive: true });
+		await writeJjWorkspacePointer(nestedJjRoot, path.join(jjPrimaryRoot, ".jj", "repo"));
+	});
+
+	afterAll(async () => {
+		if (baseDir) await baseDir.remove();
+	});
+
+	it("still treats the dotdot-prefixed workspace as the nearer root, not the outer git checkout", () => {
+		const fromNestedJj = computeMnemopiBankScope(undefined, nestedJjRoot, "per-project").bank;
+		const fromJjPrimary = computeMnemopiBankScope(undefined, jjPrimaryRoot, "per-project").bank;
+		const fromOuterGit = computeMnemopiBankScope(undefined, outerGitRoot, "per-project").bank;
+		expect(fromNestedJj).toBe(fromJjPrimary);
+		expect(fromNestedJj).not.toBe(fromOuterGit);
 	});
 });


### PR DESCRIPTION
## What

Mnemopi's `per-project`/`per-project-tagged` bank derivation (`packages/coding-agent/src/mnemopi/config.ts`) hashed the raw working directory alone. `docs/mnemosyne-memory-backend.md` documented this explicitly: per-project banks were "independent of the surrounding git layout." That meant every git worktree or jj workspace of the same repository got its own isolated memory bank instead of sharing one.

The Hindsight backend already solved the equivalent problem for `#2232`: `projectLabel()` in `hindsight/bank.ts` resolves the repository's *primary* checkout root before deriving the project tag/bank id, so linked worktrees collapse onto one project. This PR ports the same resolution into Mnemopi:

- `projectBank()` now resolves the primary project root via a new `resolveProjectRoot()` before hashing, instead of hashing the raw cwd.
- `resolveProjectRoot()` delegates to the native `vcs.repo(directory)?.primaryRoot()` (`@oh-my-pi/pi-natives/vcs`, backed by `crates/pi-vcs`), the same discovery both git and jj checkouts already share elsewhere in the codebase, then canonicalizes the result (`fs.realpathSync`) so a symlinked alias of a checkout collapses onto the same bank as its real path. Directories outside any repository keep the prior cwd-based fallback.
- `hindsight/bank.ts` is untouched — only its already-shipped resolution approach is reused (through the shared native discovery), not its file.
- `computeMnemopiBankScope` resolves the project root only for `per-project`/`per-project-tagged`; `global` scoping returns before that resolution runs, since it never reads the result.

While this sat in review, `chatgpt-codex-connector` and `roboomp` (automated PR review, not human maintainers) found and I fixed several edge cases in the native git/jj discovery this depends on, across three review rounds: a `--separate-git-dir` checkout's linked worktree disagreeing with direct access on its primary root, a repeated `core.worktree` config line resolving to the first occurrence instead of git's own last-wins precedence, a quoted `core.worktree` value's backslash escapes passing through undecoded, the same escapes going undecoded when git instead writes that value *unquoted* (the exact form git 2.43 uses for a submodule checkout path containing a quote), the migration doc recommending a bank-merge procedure `BankManager` cannot actually perform (no merge operation, `renameBank` refuses an existing destination), and a section header followed by an inline `#`/`;` comment (`[core] # note`) being rejected by the same requirement that a header line end in `]`. A second round also caught this PR's own test fixture disabling the host's git config via a file-scoped `process.env` mutation instead of scoping it to each spawned `git` invocation. Each has its own commit with a red/green test.

## Why

Isolating memory per worktree defeats the purpose of `per-project` scoping for anyone who works across multiple worktrees or jj workspaces of the same repository — that's exactly the layout `git worktree`/`jj workspace add` exist for, and the isolation was an accidental side effect of the raw-cwd hash, not a deliberate choice: the working directory it replaced (hashing the enclosing git root) was undone for `#2412` because it was *unbounded* — any `.git` appearing or disappearing above the cwd repointed the bank — not because per-worktree isolation was the intended behavior. Bounding the resolution to the primary *checkout* root only (never an arbitrary ancestor) keeps `#2412`'s stability fix while restoring the sharing Hindsight already has.

`roboomp`'s review flagged this as reversing a previously-documented contract and asked for an explicit sign-off, since Mnemopi could deliberately isolate per-worktree memory instead. That's a fair question for the maintainer to weigh in on; the PR's own position is stated above and in the "Project root resolution" section this PR adds to `docs/mnemosyne-memory-backend.md`. It is not a fork-specific concern — the same worktree/workspace layout exists for anyone using this project's own git/jj integration.

## Testing

`packages/coding-agent/test/mnemopi-bank-derivation.test.ts` and `packages/coding-agent/test/git-linked-worktree.test.ts` cover, with real `git` CLI fixtures plus manual `.jj/repo`/git-internals fixtures matching this repo's existing conventions:

- a primary checkout and a linked git worktree derive the same per-project bank;
- a non-colocated jj workspace derives the same bank as its primary;
- a pure jj workspace nested under an unrelated outer git checkout resolves to its own jj primary, not the outer checkout, including when the workspace directory name itself starts with `..`;
- a worktree of a git submodule, and a worktree of a `--separate-git-dir` checkout, resolve to the same primary root as direct access;
- a symlinked alias of a checkout collapses onto the same bank as its real path;
- `global` scoping never invokes VCS resolution;
- the exploratory legacy-bank scan's cap cannot strand a worktree's deterministically-named previous bank;
- `per-project-tagged` scope objects match across all worktree/workspace cases, and the plain cwd-hash fallback is unchanged outside any repository.

`crates/pi-vcs/src/git/mod.rs` adds unit tests for the `core.worktree` config parser: repeated-key precedence, escape decoding in both the quoted and the unquoted-with-escapes forms git itself writes, and a section header followed by a trailing `#`/`;` comment on the same line.

Ran locally on this head: `bun run check` (oxlint + oxfmt + per-workspace `tsgo` + `cargo check`) passes; `bun run check:rs` passes; `bun test packages/coding-agent/test/mnemopi-bank-derivation.test.ts packages/coding-agent/test/git-linked-worktree.test.ts` passes (25/25); `bun run test:rs` runs 2778 Rust tests (up from 2776 with this round's two new `core_worktree` cases) and passes except the same pre-existing `jj::ops::tests::jj_portable_status_log_and_numstat_match_cli_fixture` failure (a jj-CLI-version-sensitive rename-detection assertion in a module this PR does not touch) plus occasional one-off timeouts, under this machine's own background load, in `pi-shell`/`pi-natives` tests this PR does not touch (`pidwait_returns_after_the_matching_process_exits`, `kill_builtin_signals_every_process_in_a_jobspec_pipeline`, `tty_writer::tests::pending_tracks_partial_drain_progress`) that did not reproduce on a clean rerun; `bun run test:ts` passes except four pre-existing, unrelated, timing-sensitive failures split across two files in `packages/tui/test/` (`kitty-keyboard-da1-ordering.test.ts` and `notifications.test.ts`, both terminal escape-sequence/handshake timing — the split between the two varies by run, the total of 4 does not; neither file is in Mnemopi or VCS discovery).


I additionally drove this end to end through the built CLI itself, with a real `git init` checkout plus a real `git worktree add` linked worktree (no fixtures), a throwaway `--profile` for isolated storage, and `memory.backend: mnemopi` in a `--config` overlay:

```
$ bun packages/coding-agent/src/cli.ts -p --no-session --profile mnemopi-9424-cli-proof --cwd <primary-checkout> --config mnemopi-overlay.yml --tools=retain --auto-approve --model haiku \
    "Use the retain tool right now to store this exact fact, verbatim: integration-test-marker-9424-<ts> ..."
Working...
Done. Fact stored in long-term memory.

$ bun packages/coding-agent/src/cli.ts -p --no-session --profile mnemopi-9424-cli-proof --cwd <linked-worktree> --config mnemopi-overlay.yml --tools=recall --auto-approve --model haiku \
    "Use the recall tool right now to search for: integration-test-marker-9424-<ts>. Report exactly what you find, including the full text of any matching memory."
Working...
**Found:**

The recall tool located the integration test marker in long-term memory. The exact matching memory is:

integration-test-marker-9424-<ts> integration-test fact for PR 9424 verification

This fact was stored during the current session (2026-09-13) as a retained memory entry (id: f46a907c843ce3b3).

$ ls ~/.omp/profiles/mnemopi-9424-cli-proof/agent/memories/mnemopi/banks/
myrepo-9424-cli-3q5f5rj0jtu1j
```

One bank directory, shared by both sessions; the fact retained from the primary checkout was recalled from the linked worktree. Deleted the throwaway profile and repos afterward; nothing else on this machine was touched.
---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution

