### PR TITLE
fix(stats): reclaim legacy dashboards by HTTP identity

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reclaimed lingering stats dashboards from older releases using their versioned HTTP identity when process command lines are unavailable, so upgrades no longer leave `omp stats` blocked by an opaque Bun listener.
+
 ## [18.0.1] - 2026-08-23
 
 ### Fixed

--- a/packages/stats/src/port-conflict.ts
+++ b/packages/stats/src/port-conflict.ts
@@ -26,7 +26,7 @@ export const STATS_DASHBOARD_SECURITY_VERSION = "3";
 /** IPv4 loopback address shared by the dashboard server and reuse probe. */
 export const STATS_DASHBOARD_HOSTNAME = "127.0.0.1";
 
-type StatsDashboardProbe = "reusable" | "occupied" | "unreachable";
+type StatsDashboardProbe = "reusable" | "replaceable" | "occupied" | "unreachable";
 
 async function probeStatsDashboard(port: number, hostname: string): Promise<StatsDashboardProbe> {
 	const probeHostname = hostname === "0.0.0.0" ? STATS_DASHBOARD_HOSTNAME : hostname === "::" ? "::1" : hostname;
@@ -35,13 +35,22 @@ async function probeStatsDashboard(port: number, hostname: string): Promise<Stat
 		const response = await fetch(`http://${urlHostname}:${port}/api/stats/models`, {
 			signal: AbortSignal.timeout(STATS_PROBE_TIMEOUT_MS),
 		});
+		const dashboardVersionHeader = response.headers.get(STATS_DASHBOARD_HEADER);
+		const dashboardVersion = dashboardVersionHeader === null ? Number.NaN : Number(dashboardVersionHeader);
+		// Never replace a newer dashboard: an older CLI must not downgrade it.
+		const replaceable =
+			response.status === 200 &&
+			Number.isSafeInteger(dashboardVersion) &&
+			dashboardVersion > 0 &&
+			dashboardVersion <= Number(STATS_DASHBOARD_SECURITY_VERSION);
 		const reusable =
 			response.status === 200 &&
-			response.headers.get(STATS_DASHBOARD_HEADER) === STATS_DASHBOARD_SECURITY_VERSION &&
+			dashboardVersionHeader === STATS_DASHBOARD_SECURITY_VERSION &&
 			response.headers.get(STATS_DASHBOARD_HOSTNAME_HEADER) === hostname &&
 			!response.headers.has("Access-Control-Allow-Origin");
 		await response.body?.cancel();
-		return reusable ? "reusable" : "occupied";
+		if (reusable) return "reusable";
+		return replaceable ? "replaceable" : "occupied";
 	} catch {
 		return "unreachable";
 	}
@@ -218,7 +227,7 @@ async function terminatePortHolder(holder: PortHolder): Promise<void> {
 	await Bun.sleep(PROCESS_EXIT_POLL_MS);
 }
 
-async function reclaimStatsPort(port: number): Promise<"retry"> {
+async function reclaimStatsPort(port: number, hasDashboardIdentity = false): Promise<"retry"> {
 	const holder = await findPortHolder(port);
 	if (!holder) {
 		throw new Error(`Port ${port} is in use, but the listening process could not be identified.`);
@@ -238,7 +247,7 @@ async function reclaimStatsPort(port: number): Promise<"retry"> {
 		/\/packages\/stats\/src\/index\.ts(?:["'\s]|$)/.test(normalizedCommand) ||
 		(normalizedImage === "omp" && /(?:^|\s)stats(?:\s|$)/.test(normalizedCommand)) ||
 		/(?:^|\/)omp(?:\.exe)?["'\s]+stats(?:["'\s]|$)/.test(normalizedCommand);
-	if (!STATS_RUNTIME_IMAGES[normalizedImage] || !hasStatsIdentity) {
+	if (!STATS_RUNTIME_IMAGES[normalizedImage] || (!hasStatsIdentity && !hasDashboardIdentity)) {
 		throw new Error(
 			`Port ${port} is in use by ${holder.image} (PID ${holder.pid}), which is not identifiable as an omp stats dashboard; refusing to stop it.`,
 		);
@@ -257,12 +266,14 @@ export async function prepareStatsPort(port: number, hostname = STATS_DASHBOARD_
 	if (port === 0) return "retry";
 	const probe = await probeStatsDashboard(port, hostname);
 	if (probe === "reusable") return "reuse";
+	if (probe === "replaceable") return reclaimStatsPort(port, true);
 	if (probe === "occupied") return reclaimStatsPort(port);
 	return "retry";
 }
 
 /** Reuse or reclaim a listener found after the server bind reports EADDRINUSE. */
 export async function recoverStatsPort(port: number, hostname = STATS_DASHBOARD_HOSTNAME): Promise<"retry" | "reuse"> {
-	if ((await probeStatsDashboard(port, hostname)) === "reusable") return "reuse";
-	return reclaimStatsPort(port);
+	const probe = await probeStatsDashboard(port, hostname);
+	if (probe === "reusable") return "reuse";
+	return reclaimStatsPort(port, probe === "replaceable");
 }

--- a/packages/stats/test/server-port-conflict.test.ts
+++ b/packages/stats/test/server-port-conflict.test.ts
@@ -154,20 +154,22 @@ describe("startServer port conflicts", () => {
 
 	for (const fixture of [
 		{
-			name: "reclaims a version 1 dashboard with wildcard CORS",
+			name: "reclaims a version 1 dashboard without command identity",
 			response: `Response.json([], { headers: { "${STATS_DASHBOARD_HEADER}": "1", "Access-Control-Allow-Origin": "*" } })`,
 			hostname: "0.0.0.0",
+			statsOwned: false,
 		},
 		{
 			name: "reclaims a headerless legacy dashboard",
 			response: "Response.json([])",
 			hostname: STATS_DASHBOARD_HOSTNAME,
+			statsOwned: true,
 		},
 	]) {
 		it(fixture.name, async () => {
 			const holder = await startBunHolder(fixture.response, {
 				hostname: fixture.hostname,
-				statsOwned: true,
+				statsOwned: fixture.statsOwned,
 			});
 			const server = await startServer(holder.port);
 
@@ -182,6 +184,16 @@ describe("startServer port conflicts", () => {
 			}
 		});
 	}
+
+	it("refuses to stop a newer dashboard without command identity", async () => {
+		const newerVersion = String(Number(STATS_DASHBOARD_SECURITY_VERSION) + 1);
+		const holder = await startBunHolder(
+			`Response.json([], { headers: { "${STATS_DASHBOARD_HEADER}": "${newerVersion}" } })`,
+		);
+
+		await expect(startServer(holder.port)).rejects.toThrow("not identifiable as an omp stats dashboard");
+		expect(holder.child.exitCode).toBeNull();
+	});
 
 	it("refuses to stop a foreign 200 responder", async () => {
 		const holder = await startBunHolder('Response.json({ app: "spa" })');


### PR DESCRIPTION
## What

- Treat a responding stats dashboard with a recognized current-or-older identity version as owned even when its process command line is unavailable.
- Reclaim only allowlisted Bun, Node, or OMP runtimes, and continue refusing unrelated or newer dashboard listeners.
- Cover the upgrade regression and the newer-dashboard downgrade guard.

## Why

Older dashboards intentionally fail the current security-version reuse check, but an opaque `bun.exe` command line also prevented the replacement path from proving ownership. The versioned HTTP marker is the stronger dashboard-specific identity and lets the upgraded CLI replace that listener without broadening termination to arbitrary Bun services.

I think I had the dashboard lingering from a prior version, and updating broke it, so I wasn't able to run the dashboard again.

## Testing

- Reproduced before the fix with a version-1 dashboard listener whose Bun process had no stats command identity: startup refused to stop `bun.exe`.
- Repeated the same scenario after the fix: the old process exited, the replacement advertised security version 3, and wildcard CORS was absent.
- `bun test test` in `packages/stats`
- `bun run check` in `packages/stats`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
