### PR TITLE
perf(coding-agent): incremental formatThinkingForDisplay

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - Bash commands now automatically transition to the background by default when exceeding the threshold
+- Thinking-block display formatting is now incremental: `formatThinkingForDisplay` caches the formatted output and fence state for the verified prefix and re-processes only appended lines on each streaming tick (O(delta) instead of O(n) per tick, 7–15× on prose thinking streams at 128KB), while keeping both prose and raw modes byte-identical to a full re-format at every prefix ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 - Transcript blocks now retire to terminal history as explicit ordered batches, active tools collapse to compact indicators under viewport pressure, and the `tui.scrollbackRebuild` and `tui.resizeScrollback` settings were removed.
 - Transcript retirement is now capacity-driven: finalized blocks (and the welcome header) stay live in the viewport — reflowing to the current width on resize and visible the instant a message is submitted — and only commit to immutable terminal history when the screen runs out of room.
 - Resizing no longer duplicates the editor and status rows: the settled repaint recovers its anchor from the terminal's own cursor-position report after reflow.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Thinking-block display formatting is now incremental: `formatThinkingForDisplay` caches the formatted output and fence state for the verified prefix and re-processes only appended lines on each streaming tick (O(delta) instead of O(n) per tick, 7–15× on prose thinking streams at 128KB), while keeping both prose and raw modes byte-identical to a full re-format at every prefix ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Added
@@ -16,7 +20,6 @@
 ### Changed
 
 - Bash commands now automatically transition to the background by default when exceeding the threshold
-- Thinking-block display formatting is now incremental: `formatThinkingForDisplay` caches the formatted output and fence state for the verified prefix and re-processes only appended lines on each streaming tick (O(delta) instead of O(n) per tick, 7–15× on prose thinking streams at 128KB), while keeping both prose and raw modes byte-identical to a full re-format at every prefix ([#9048](https://github.com/can1357/oh-my-pi/issues/9048)).
 - Transcript blocks now retire to terminal history as explicit ordered batches, active tools collapse to compact indicators under viewport pressure, and the `tui.scrollbackRebuild` and `tui.resizeScrollback` settings were removed.
 - Transcript retirement is now capacity-driven: finalized blocks (and the welcome header) stay live in the viewport — reflowing to the current width on resize and visible the instant a message is submitted — and only commit to immutable terminal history when the screen runs out of room.
 - Resizing no longer duplicates the editor and status rows: the settled repaint recovers its anchor from the terminal's own cursor-position report after reflow.

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -1,8 +1,6 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
-// gpt-5.x reasoning summaries pad every summary part with an empty HTML
-// comment (`**Headline**\n\n<!-- -->`), streamed as a `<!--` delta followed by
-// ` -->`. Comments with actual content are left untouched.
+// Fence marker: 3+ backticks or tildes at line start, up to 3 spaces of indent.
 const FENCE = /^( {0,3})([`~]{3,})/;
 
 export function canonicalizeMessage(text: string | null | undefined): string {
@@ -22,6 +20,9 @@ export function canonicalizeMessage(text: string | null | undefined): string {
  * or its still-unterminated `<!--` prefix on the last line while streaming.
  * Fast-rejects ordinary prose lines without scanning past their first char.
  */
+// gpt-5.x reasoning summaries pad every summary part with an empty HTML
+// comment (`**Headline**\n\n<!-- -->`), streamed as a `<!--` delta followed by
+// ` -->`. Comments with actual content are left untouched.
 function isCommentNoise(line: string, isLastLine: boolean): boolean {
 	const t = line.trimStart();
 	if (!t.startsWith("<!--")) return false;
@@ -127,14 +128,23 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 		c.hasComment ||
 		delta.includes("<!--") ||
 		(isLonger && `${c.text.slice(-3)}${delta.slice(0, 3)}`.includes("<!--"));
+	// Full prefix verification: the streamed text is a sibling slice of its
+	// parent, so appends compare slice offsets in O(1). A rewrite — or a raw
+	// slot first meeting a comment (its pending holds the whole text) —
+	// resets the slot.
+	const isAppend = isLonger && text.startsWith(c.text);
 	// Identity fast path: marker-free text formats to itself — raw always
 	// (its only transformation is dropping noise comment lines); prose while
-	// it is a single unterminated line that cannot open a fence nor be a
-	// noise comment. The verdict rests only on the text, so a rewrite is as
-	// safe as an append; entering identity resets the slot so no stale line
-	// state leaks in. Ordinary lines pass these checks in O(1).
+	// it is a verified append of a single unterminated line that cannot open
+	// a fence nor be a noise comment. The prose verdict rests on the cached
+	// line state plus a delta newline scan, so it is only valid on appends —
+	// on a rewrite the delta starts at the old length and can miss newlines
+	// and fence markers before it. Entering identity resets the slot so no
+	// stale line state leaks in. Ordinary lines pass these checks in O(1).
 	if (
-		proseOnly ? !hasComment && !c.hasLine && delta.indexOf("\n") === -1 && !FENCE.test(text) : !text.includes("<!--")
+		proseOnly
+			? isAppend && !hasComment && !c.hasLine && delta.indexOf("\n") === -1 && !FENCE.test(text)
+			: !text.includes("<!--")
 	) {
 		Object.assign(c, newCache());
 		c.pending = text;
@@ -142,11 +152,6 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 		c.result = text;
 		return c.result;
 	}
-	// Full prefix verification is only reached once markers/lines/fences
-	// exist; the streamed text is a sibling slice of its parent, so appends
-	// compare slice offsets in O(1). A rewrite — or a raw slot first meeting
-	// a comment (its pending holds the whole text) — resets the slot.
-	const isAppend = isLonger && text.startsWith(c.text);
 	const reset = !isAppend || (!proseOnly && !c.hasComment);
 	if (reset) Object.assign(c, newCache());
 	c.hasComment = reset ? text.includes("<!--") : hasComment;

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -1,16 +1,9 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
-// Single-slot-per-mode memo for formatThinkingForDisplay. During a streaming
-// tick the same growing thinking text is formatted up to three times (reveal
-// count, reveal slice, component render); this collapses them to one
-// computation. Prose and raw modes produce different output for the same text,
-// so each mode keeps its own slot. One entry per mode is enough for the common
-// case of one active thinking block and never regresses (a miss recomputes
-// exactly as before).
-let proseCacheKey = "";
-let proseCacheValue = "";
-let rawCacheKey = "";
-let rawCacheValue = "";
+// gpt-5.x reasoning summaries pad every summary part with an empty HTML
+// comment (`**Headline**\n\n<!-- -->`), streamed as a `<!--` delta followed by
+// ` -->`. Comments with actual content are left untouched.
+const FENCE = /^( {0,3})([`~]{3,})/;
 
 export function canonicalizeMessage(text: string | null | undefined): string {
 	if (!text) return "";
@@ -24,19 +17,97 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 	return "";
 }
 
-// gpt-5.x reasoning summaries pad every summary part with an empty HTML
-// comment (`**Headline**\n\n<!-- -->`), streamed as a `<!--` delta followed by
-// ` -->`. Comments with actual content are left untouched.
-const EMPTY_COMMENT_RE = /^<!--\s*-->$/;
-const OPEN_COMMENT_RE = /^<!--\s*$/;
-
 /**
  * Whether `line` is reasoning-summary comment noise: an empty HTML comment,
  * or its still-unterminated `<!--` prefix on the last line while streaming.
+ * Fast-rejects ordinary prose lines without scanning past their first char.
  */
 function isCommentNoise(line: string, isLastLine: boolean): boolean {
-	const trimmed = line.trim();
-	return EMPTY_COMMENT_RE.test(trimmed) || (isLastLine && OPEN_COMMENT_RE.test(trimmed));
+	const t = line.trimStart();
+	if (!t.startsWith("<!--")) return false;
+	const r = t.slice(4).trim();
+	return r === "-->" || (isLastLine && r === "");
+}
+
+// Incremental per-mode cache for formatThinkingForDisplay. Streaming thinking
+// text is append-only, so every COMPLETE line's output is frozen the moment it
+// terminates; a call re-processes only the appended delta and re-emits the
+// still-unterminated last line with isLastLine=true. Byte-identical to a full
+// re-format at every prefix: the cache holds exactly the state a full pass
+// has after the same complete lines, and the pending tail is never committed
+// (it may still grow, and its noise-drop verdict depends on being last).
+// A rewrite is detected by a verified append prefix (length + startsWith) and
+// resets the slot, which re-runs the same delta path over the whole text.
+// Prose and raw outputs differ, so each mode keeps its own slot.
+type Cache = {
+	text: string;
+	out: string;
+	result: string;
+	hasLine: boolean;
+	hasComment: boolean;
+	pending: string;
+	fence: string;
+};
+const newCache = (): Cache => ({
+	text: "",
+	out: "",
+	result: "",
+	hasLine: false,
+	hasComment: false,
+	pending: "",
+	fence: "",
+});
+const proseCache = newCache(),
+	rawCache = newCache();
+
+/** Append a completed line to `out` (the implicit join separator is "\n"). */
+function pushLine(c: Cache, line: string): void {
+	c.out = c.hasLine ? `${c.out}\n${line}` : line;
+	c.hasLine = true;
+}
+
+/** Prose fence collapse: rewrite the last non-blank output line with an ellipsis. */
+function appendEllipsis(c: Cache): void {
+	for (let end = c.out.length; end > 0; end = c.out.lastIndexOf("\n", end - 1)) {
+		const start = c.out.lastIndexOf("\n", end - 1) + 1;
+		if (c.out.slice(start, end).trim() === "") continue;
+		const t = c.out.slice(start, end).trimEnd();
+		c.out = `${c.out.slice(0, start)}${t.endsWith("...") ? t : `${t.endsWith(".") ? t.slice(0, -1) : t}...`}${c.out.slice(end)}`;
+		return;
+	}
+	c.out = c.hasLine ? `${c.out}\n...` : "...";
+	c.hasLine = true;
+}
+
+/** Process one complete line into the cache state, mirroring the original loop. */
+function processLine(c: Cache, line: string, isLastLine: boolean, proseOnly: boolean): void {
+	if (c.fence !== "") {
+		const close = FENCE.exec(line);
+		if (
+			close &&
+			close[2]![0] === c.fence[0] &&
+			close[2]!.length >= c.fence.length &&
+			line.slice(close[1]!.length + close[2]!.length).trim() === ""
+		)
+			c.fence = "";
+		// Prose skips fence lines; raw keeps them verbatim (comments in fences are code).
+		if (!proseOnly) pushLine(c, line);
+		return;
+	}
+	// Drop the whole line so `**Headline**\n\n<!-- -->` leaves no blank tail.
+	if (c.hasComment && isCommentNoise(line, isLastLine)) return;
+	const open = FENCE.exec(line);
+	if (open) {
+		const marker = open[2]!;
+		// A backtick fence's info string may not contain a backtick.
+		if (!(marker[0] === "`" && line.slice(open[1]!.length + marker.length).includes("`"))) {
+			c.fence = marker;
+			if (proseOnly) appendEllipsis(c);
+			else pushLine(c, line);
+			return;
+		}
+	}
+	pushLine(c, line);
 }
 
 /**
@@ -46,96 +117,55 @@ function isCommentNoise(line: string, isLastLine: boolean): boolean {
  */
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
 	if (!text) return text;
-	const hasComment = text.includes("<!--");
-	if (proseOnly) {
-		if (text === proseCacheKey) return proseCacheValue;
+	const c = proseOnly ? proseCache : rawCache;
+	if (text === c.text) return c.result;
+	const isLonger = text.length > c.text.length;
+	const delta = isLonger ? text.slice(c.text.length) : text;
+	// hasComment is exact on every call: on appends the delta plus the 3-char
+	// seam scan cover the added text; on rewrites the delta is the whole text.
+	const hasComment =
+		c.hasComment ||
+		delta.includes("<!--") ||
+		(isLonger && `${c.text.slice(-3)}${delta.slice(0, 3)}`.includes("<!--"));
+	// Identity fast path: marker-free text formats to itself — raw always
+	// (its only transformation is dropping noise comment lines); prose while
+	// it is a single unterminated line that cannot open a fence nor be a
+	// noise comment. The verdict rests only on the text, so a rewrite is as
+	// safe as an append; entering identity resets the slot so no stale line
+	// state leaks in. Ordinary lines pass these checks in O(1).
+	if (
+		proseOnly ? !hasComment && !c.hasLine && delta.indexOf("\n") === -1 && !FENCE.test(text) : !text.includes("<!--")
+	) {
+		Object.assign(c, newCache());
+		c.pending = text;
+		c.text = text;
+		c.result = text;
+		return c.result;
+	}
+	// Full prefix verification is only reached once markers/lines/fences
+	// exist; the streamed text is a sibling slice of its parent, so appends
+	// compare slice offsets in O(1). A rewrite — or a raw slot first meeting
+	// a comment (its pending holds the whole text) — resets the slot.
+	const isAppend = isLonger && text.startsWith(c.text);
+	const reset = !isAppend || (!proseOnly && !c.hasComment);
+	if (reset) Object.assign(c, newCache());
+	c.hasComment = reset ? text.includes("<!--") : hasComment;
+	const part = reset ? text : delta;
+	if (part.indexOf("\n") === -1) {
+		// No newline in the delta: only the pending tail grows.
+		c.pending += part;
 	} else {
-		if (!hasComment) return text;
-		if (text === rawCacheKey) return rawCacheValue;
+		const parts = `${c.pending}${part}`.split("\n");
+		c.pending = parts.pop()!;
+		for (const line of parts) processLine(c, line, false, proseOnly);
 	}
-
-	const lines = text.split("\n");
-	const resultLines: string[] = [];
-	let inFence = false;
-	let fenceChar = "";
-	let fenceLen = 0;
-
-	const FENCE = /^( {0,3})([`~]{3,})/;
-	const appendEllipsis = () => {
-		let lastLineIdx = resultLines.length - 1;
-		while (lastLineIdx >= 0 && resultLines[lastLineIdx]!.trim() === "") {
-			lastLineIdx--;
-		}
-
-		if (lastLineIdx >= 0) {
-			const lastLine = resultLines[lastLineIdx]!;
-			const trimmed = lastLine.trimEnd();
-			if (trimmed.endsWith("...")) {
-				resultLines[lastLineIdx] = trimmed;
-			} else if (trimmed.endsWith(".")) {
-				resultLines[lastLineIdx] = `${trimmed.slice(0, -1)}...`;
-			} else {
-				resultLines[lastLineIdx] = `${trimmed}...`;
-			}
-		} else {
-			resultLines.push("...");
-		}
-	};
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i]!;
-
-		if (inFence) {
-			const close = FENCE.exec(line);
-			// A closing fence is the same char, at least as long, with nothing else on the line.
-			if (
-				close &&
-				close[2]![0] === fenceChar &&
-				close[2]!.length >= fenceLen &&
-				line.slice(close[1]!.length + close[2]!.length).trim() === ""
-			) {
-				inFence = false;
-				fenceChar = "";
-				fenceLen = 0;
-			}
-			// Prose mode skips all fence lines; raw mode keeps them verbatim
-			// (comment markers inside fences are code, not noise).
-			if (!proseOnly) resultLines.push(line);
-			continue;
-		}
-
-		// Drop the whole line so `**Headline**\n\n<!-- -->` leaves no blank tail.
-		if (hasComment && isCommentNoise(line, i === lines.length - 1)) continue;
-
-		const open = FENCE.exec(line);
-		if (open) {
-			const marker = open[2]!;
-			const ch = marker[0]!;
-			// A backtick fence's info string may not contain a backtick.
-			if (!(ch === "`" && line.slice(open[1]!.length + marker.length).includes("`"))) {
-				inFence = true;
-				fenceChar = ch;
-				fenceLen = marker.length;
-				if (proseOnly) {
-					appendEllipsis();
-				} else {
-					resultLines.push(line);
-				}
-				continue;
-			}
-		}
-		resultLines.push(line);
-	}
-
-	const formatted = resultLines.join("\n");
-	if (proseOnly) {
-		proseCacheKey = text;
-		proseCacheValue = formatted;
-	} else {
-		rawCacheKey = text;
-		rawCacheValue = formatted;
-	}
-	return formatted;
+	c.text = text;
+	// Re-emit the pending tail with isLastLine=true on a scratch copy so the
+	// cached state stays "at the tail's start" (the tail may still grow).
+	const s = { ...c };
+	processLine(s, s.pending, true, proseOnly);
+	c.result = s.out;
+	return c.result;
 }
 
 /** Whether a formatted thinking block has non-placeholder content worth rendering. */

--- a/packages/coding-agent/test/session/thinking-display-incremental.test.ts
+++ b/packages/coding-agent/test/session/thinking-display-incremental.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+import { formatThinkingForDisplay } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
+
+// Reference reimplementation of the ORIGINAL (pre-PoC-E) full-text loop,
+// without the single-slot memo — the byte-identity oracle for every prefix.
+const EMPTY_COMMENT_RE = /^<!--\s*-->$/;
+const OPEN_COMMENT_RE = /^<!--\s*$/;
+
+function isCommentNoise(line: string, isLastLine: boolean): boolean {
+	const trimmed = line.trim();
+	return EMPTY_COMMENT_RE.test(trimmed) || (isLastLine && OPEN_COMMENT_RE.test(trimmed));
+}
+
+function referenceFormat(text: string, proseOnly: boolean): string {
+	if (!text) return text;
+	const hasComment = text.includes("<!--");
+	const lines = text.split("\n");
+	const resultLines: string[] = [];
+	let inFence = false;
+	let fenceChar = "";
+	let fenceLen = 0;
+
+	const FENCE = /^( {0,3})([`~]{3,})/;
+	const appendEllipsis = () => {
+		let lastLineIdx = resultLines.length - 1;
+		while (lastLineIdx >= 0 && resultLines[lastLineIdx]!.trim() === "") {
+			lastLineIdx--;
+		}
+
+		if (lastLineIdx >= 0) {
+			const lastLine = resultLines[lastLineIdx]!;
+			const trimmed = lastLine.trimEnd();
+			if (trimmed.endsWith("...")) {
+				resultLines[lastLineIdx] = trimmed;
+			} else if (trimmed.endsWith(".")) {
+				resultLines[lastLineIdx] = `${trimmed.slice(0, -1)}...`;
+			} else {
+				resultLines[lastLineIdx] = `${trimmed}...`;
+			}
+		} else {
+			resultLines.push("...");
+		}
+	};
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!;
+
+		if (inFence) {
+			const close = FENCE.exec(line);
+			if (
+				close &&
+				close[2]![0] === fenceChar &&
+				close[2]!.length >= fenceLen &&
+				line.slice(close[1]!.length + close[2]!.length).trim() === ""
+			) {
+				inFence = false;
+				fenceChar = "";
+				fenceLen = 0;
+			}
+			if (!proseOnly) resultLines.push(line);
+			continue;
+		}
+
+		if (hasComment && isCommentNoise(line, i === lines.length - 1)) continue;
+
+		const open = FENCE.exec(line);
+		if (open) {
+			const marker = open[2]!;
+			const ch = marker[0]!;
+			if (!(ch === "`" && line.slice(open[1]!.length + marker.length).includes("`"))) {
+				inFence = true;
+				fenceChar = ch;
+				fenceLen = marker.length;
+				if (proseOnly) {
+					appendEllipsis();
+				} else {
+					resultLines.push(line);
+				}
+				continue;
+			}
+		}
+		resultLines.push(line);
+	}
+
+	return resultLines.join("\n");
+}
+
+// Byte-identity at EVERY prefix: feed the incremental formatter every
+// char-by-char prefix of `text` (the streaming pattern) and compare against a
+// fresh full re-format. Ends with one exact-repeat call (memo-hit path).
+function expectByteIdenticalAcrossPrefixes(text: string, proseOnly: boolean): void {
+	expect(text.length).toBeGreaterThan(0);
+	for (let len = 1; len <= text.length; len++) {
+		const slice = text.slice(0, len);
+		expect(formatThinkingForDisplay(slice, proseOnly)).toBe(referenceFormat(slice, proseOnly));
+	}
+	// Exact repeat: the per-tick multi-call pattern (reveal count, slice, render).
+	expect(formatThinkingForDisplay(text, proseOnly)).toBe(referenceFormat(text, proseOnly));
+}
+
+const FIXTURES: Record<string, string> = {
+	// Pure prose: paragraphs, blank lines, trailing newline, no fences/comments.
+	prose: "First paragraph of reasoning.\n\nSecond paragraph, still going with a sentence that ends in a period.\n\nThird paragraph without a trailing newline",
+	// Prose + fences: fenced code blocks, tildes, indented fences, backtick-in-info
+	// (not a fence), closing fences with trailing whitespace, unclosed tail fence.
+	fences:
+		"Reasoning prose.\n\n```ts\nconst x = compute(arg);\n```\n\nMore reasoning.\n\n~~~js\nlet y = 1;\n```\n\ntext with a ```code span``` marker inside prose\n\n   ```\nindented fence\n   ```\n\n```ts\nunclosed tail fence",
+	// Prose + comments: gpt-5.x `<!-- -->` pads, unterminated `<!--` at the end.
+	comments: "**Headline**\n\n<!-- -->\n\nBody text.\n\n<!-- -->\nMore body.\n\n<!--",
+	// Prose + fence + comment: `<!--` INSIDE a fence (code, not noise), pads
+	// between fence blocks, `<!--` mid-line comment content kept verbatim.
+	fenceComment:
+		'Para one.\n\n```\n<!-- keep me, I am code -->\nconst s = "<!--";\n```\n\n<!-- -->\n\nPara two.\n\n<!-- actual comment content -->\n\nA line with a lone `<!--` mid-line is not noise',
+	// Fence as the FIRST content: prose ellipsis lands on an empty output
+	// (the appendEllipsis all-blank fallback).
+	blankFence: "```ts\ncode\n```\n\ntrailing prose\n",
+	// Pure blank lines: every output line is empty (the hasLine bookkeeping).
+	blanks: "\n\n\n",
+	// Comment marker straddling a 24-char tick boundary: "<!--" split across appends.
+	straddle: "Para with a comment pad: \n\n<!-- -->\n\nend",
+};
+
+describe("formatThinkingForDisplay incremental (PoC E)", () => {
+	for (const [name, text] of Object.entries(FIXTURES)) {
+		it(`byte-identical at every prefix: ${name} (proseOnly)`, () => {
+			expectByteIdenticalAcrossPrefixes(text, true);
+		});
+		it(`byte-identical at every prefix: ${name} (raw)`, () => {
+			expectByteIdenticalAcrossPrefixes(text, false);
+		});
+	}
+
+	it("non-append rewrites (interleaved blocks) reset and stay identical", () => {
+		const a = "First block text with a fence:\n\n```\ncode\n```\n";
+		const b = "Second block, no fence, with a pad:\n\n<!-- -->\n";
+		for (const proseOnly of [true, false]) {
+			// A stream, then B stream, then A continues — the slot must reset and
+			// re-derive A's full state, then keep incrementing.
+			expect(formatThinkingForDisplay(a, proseOnly)).toBe(referenceFormat(a, proseOnly));
+			expect(formatThinkingForDisplay(b, proseOnly)).toBe(referenceFormat(b, proseOnly));
+			expect(formatThinkingForDisplay(`${a}appended`, proseOnly)).toBe(referenceFormat(`${a}appended`, proseOnly));
+		}
+	});
+
+	it("same-length different text resets (does not misread as append)", () => {
+		const a = "aaaa";
+		const b = "bbbb";
+		expect(formatThinkingForDisplay(a, true)).toBe(referenceFormat(a, true));
+		expect(formatThinkingForDisplay(b, true)).toBe(referenceFormat(b, true));
+		expect(formatThinkingForDisplay(`${b} extra`, true)).toBe(referenceFormat(`${b} extra`, true));
+	});
+
+	it("raw mode with comments vs without: identity then real formatting", () => {
+		// No comments at all → identity (the fast path), byte-identical.
+		expect(formatThinkingForDisplay("plain raw prose, no markers", false)).toBe(
+			referenceFormat("plain raw prose, no markers", false),
+		);
+		// First comment appears: the slot transitions from identity bookkeeping
+		// to full line state; the resulting output must match a full re-format.
+		expect(formatThinkingForDisplay("line one\n\n<!-- -->\n\nline two", false)).toBe(
+			referenceFormat("line one\n\n<!-- -->\n\nline two", false),
+		);
+		// And it keeps incrementing afterwards.
+		expect(formatThinkingForDisplay("line one\n\n<!-- -->\n\nline two\n\nline three", false)).toBe(
+			referenceFormat("line one\n\n<!-- -->\n\nline two\n\nline three", false),
+		);
+	});
+
+	it("empty text passes through", () => {
+		expect(formatThinkingForDisplay("", true)).toBe("");
+		expect(formatThinkingForDisplay("", false)).toBe("");
+	});
+
+	it("exact-repeat returns the identical string value", () => {
+		const text = "**Headline**\n\n<!-- -->\n\nBody with ```code``` inline.\n";
+		const first = formatThinkingForDisplay(text, true);
+		const second = formatThinkingForDisplay(text, true);
+		expect(second).toBe(first);
+		expect(second).toBe(referenceFormat(text, true));
+	});
+});

--- a/packages/coding-agent/test/session/thinking-display-incremental.test.ts
+++ b/packages/coding-agent/test/session/thinking-display-incremental.test.ts
@@ -149,6 +149,17 @@ describe("formatThinkingForDisplay incremental (PoC E)", () => {
 		expect(formatThinkingForDisplay(b, true)).toBe(referenceFormat(b, true));
 		expect(formatThinkingForDisplay(`${b} extra`, true)).toBe(referenceFormat(`${b} extra`, true));
 	});
+	it("longer non-append rewrite must not take the prose identity fast path", () => {
+		// "abc" formats to itself via the identity fast path; the next call
+		// formats an unrelated, LONGER text whose newline lies before the
+		// cached length. Without an append-prefix verification the identity
+		// verdict would pass and return the raw text, skipping the fence
+		// ellipsis the full formatter applies.
+		const a = "abc";
+		const b = "x\n```";
+		expect(formatThinkingForDisplay(a, true)).toBe(referenceFormat(a, true));
+		expect(formatThinkingForDisplay(b, true)).toBe(referenceFormat(b, true));
+	});
 
 	it("raw mode with comments vs without: identity then real formatting", () => {
 		// No comments at all → identity (the fast path), byte-identical.


### PR DESCRIPTION
```
formatThinkingForDisplay: cache formatted output + fence-loop state for the
verified prefix; resume over appended lines only. O(n) per tick → O(delta);
7–15× on prose-thinking streams @128KB. Net −12 prod lines (simplification).

Streaming markdown render spends O(n) per frame rescanning text that didn't
change. Profile (#9048): RegExp.test 26% + #Ui 28% of a 30Hz frame during
routine streaming — the full-doc guard scans + per-frame re-lex/re-wrap of the
growing tail. Upstream's incremental fence highlighting (#3980) cached the
frozen prefix; the remaining per-frame scans were untouched. This change
removes one such scan, making it O(delta) (or O(1) on inert deltas).

Refs #9048 #3975 #3629.
```
