### PR TITLE
fix(agent): bound Copilot incomplete stream retries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Copilot Grok 4.6 Responses streams that repeatedly close after thinking now stop after one same-model retry instead of consuming the full retry budget ([#9427](https://github.com/can1357/oh-my-pi/issues/9427)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1246,15 +1246,22 @@ export class TurnRecovery {
 	}
 
 	/**
-	 * OpenRouter can repeatedly close Gemini streams at the reasoning-to-payload
-	 * transition. One retry covers a transient edge failure; the normal ten-retry
-	 * budget would otherwise re-run the same expensive reasoning cycle unchanged.
+	 * Known provider routes can repeatedly close after completing an expensive
+	 * reasoning phase. One retry covers a transient edge failure; the normal
+	 * ten-retry budget would otherwise replay the same reasoning cycle unchanged.
 	 */
-	#isOpenRouterThinkingStreamClose(message: AssistantMessage): boolean {
+	#isBoundedThinkingStreamClose(message: AssistantMessage): boolean {
+		if (!message.content.some(block => block.type === "thinking" && block.thinking.trim().length > 0)) {
+			return false;
+		}
+		const errorMessage = message.errorMessage ?? "";
 		return (
-			message.provider === "openrouter" &&
-			/server_error:\s*stream closed with reason:\s*error/i.test(message.errorMessage ?? "") &&
-			message.content.some(block => block.type === "thinking" && block.thinking.trim().length > 0)
+			(message.provider === "openrouter" &&
+				/server_error:\s*stream closed with reason:\s*error/i.test(errorMessage)) ||
+			(message.provider === "github-copilot" &&
+				message.model === "grok-4.6" &&
+				message.api === "openai-responses" &&
+				/OpenAI responses stream closed before a terminal response event was received/i.test(errorMessage))
 		);
 	}
 
@@ -1926,7 +1933,7 @@ export class TurnRecovery {
 		// (every rotation sets switchedCredential and skips it), so without
 		// this last resort a provider-wide usage cap never fails over to the
 		// configured chain.
-		const maxRetries = this.#isOpenRouterThinkingStreamClose(message)
+		const maxRetries = this.#isBoundedThinkingStreamClose(message)
 			? Math.min(retrySettings.maxRetries, 1)
 			: retrySettings.maxRetries;
 		const retryBudgetExhausted = this.#retryAttempt > maxRetries;

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -2,13 +2,22 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import type { ApiKeyResolveContext, AssistantMessage, ToolCall, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type {
+	ApiKeyResolveContext,
+	AssistantMessage,
+	TextContent,
+	ThinkingContent,
+	ToolCall,
+	ToolResultMessage,
+} from "@oh-my-pi/pi-ai";
 import { unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import { createMockModel, type MockResponse, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import * as aiStream from "@oh-my-pi/pi-ai/stream";
 import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { Model } from "@oh-my-pi/pi-catalog/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -77,7 +86,7 @@ describe("AgentSession retry delay cap", () => {
 		for (const provider of ["anthropic", "openai-codex"]) {
 			await authStorage.remove(provider);
 		}
-		for (const provider of ["anthropic", "openai", "openai-codex", "openrouter", "cursor"]) {
+		for (const provider of ["anthropic", "openai", "openai-codex", "openrouter", "github-copilot", "cursor"]) {
 			authStorage.removeRuntimeApiKey(provider);
 		}
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
@@ -2084,38 +2093,75 @@ describe("AgentSession retry delay cap", () => {
 		expect(last.stopReason).toBe("aborted");
 	});
 
-	it("caps repeated OpenRouter stream closes after streamed thinking at one retry", async () => {
-		const model = getBundledModel("openrouter", "~google/gemini-flash-latest");
-		if (!model) {
-			throw new Error("Expected bundled OpenRouter Gemini test model to exist");
-		}
-		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
-
-		const mock = createMockModel({
-			provider: "openrouter",
-			responses: [
-				{
-					content: [{ type: "thinking", thinking: "reasoning attempt 1" }],
-					stopReason: "error",
-					errorMessage: "server_error: stream closed with reason: error",
-				},
-				{
-					content: [{ type: "thinking", thinking: "reasoning attempt 2" }],
-					stopReason: "error",
-					errorMessage: "server_error: stream closed with reason: error",
-				},
-				{ content: ["must remain unused"] },
-			],
-		});
+	async function expectThinkingStreamCloseRetryCap(options: {
+		model: Model;
+		errorMessage: string;
+		prompt: string;
+	}): Promise<void> {
+		authStorage.setRuntimeApiKey(options.model.provider, `${options.model.provider}-test-key`);
+		let calls = 0;
 		const agent = new Agent({
 			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
 			initialState: {
-				model,
+				model: options.model,
 				systemPrompt: ["Test"],
 				tools: [],
 				messages: [],
 			},
-			streamFn: (requestedModel, context, options) => mock.stream(requestedModel, context, options),
+			streamFn: requestedModel => {
+				calls++;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const usage: AssistantMessage["usage"] = {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					};
+					if (calls > 2) {
+						const text: TextContent = { type: "text", text: "must remain unused" };
+						const message: AssistantMessage = {
+							role: "assistant",
+							content: [text],
+							api: requestedModel.api,
+							provider: requestedModel.provider,
+							model: requestedModel.id,
+							usage,
+							stopReason: "stop",
+							timestamp: Date.now(),
+						};
+						stream.push({ type: "start", partial: message });
+						stream.push({ type: "text_start", contentIndex: 0, partial: message });
+						stream.push({ type: "text_delta", contentIndex: 0, delta: text.text, partial: message });
+						stream.push({ type: "text_end", contentIndex: 0, content: text.text, partial: message });
+						stream.push({ type: "done", reason: "stop", message });
+						return;
+					}
+					const thinking: ThinkingContent = { type: "thinking", thinking: "" };
+					const message: AssistantMessage = {
+						role: "assistant",
+						content: [thinking],
+						api: requestedModel.api,
+						provider: requestedModel.provider,
+						model: requestedModel.id,
+						usage,
+						stopReason: "error",
+						errorMessage: options.errorMessage,
+						errorId: AIError.create(AIError.Flag.Transient),
+						timestamp: Date.now(),
+					};
+					const delta = `reasoning attempt ${calls}`;
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "thinking_start", contentIndex: 0, partial: message });
+					thinking.thinking = delta;
+					stream.push({ type: "thinking_delta", contentIndex: 0, delta, partial: message });
+					stream.push({ type: "thinking_end", contentIndex: 0, content: thinking.thinking, partial: message });
+					stream.push({ type: "error", reason: "error", error: message });
+				});
+				return stream;
+			},
 		});
 
 		const settings = Settings.isolated({
@@ -2124,7 +2170,7 @@ describe("AgentSession retry delay cap", () => {
 			"retry.maxRetries": 10,
 			"retry.modelFallback": false,
 		});
-		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		settings.setModelRole("default", `${options.model.provider}/${options.model.id}`);
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
@@ -2140,18 +2186,40 @@ describe("AgentSession retry delay cap", () => {
 			if (event.type === "auto_retry_end") retryEndEvents.push(event);
 		});
 
-		await session.prompt("Trigger OpenRouter reasoning transition failure");
+		await session.prompt(options.prompt);
 		await session.waitForIdle();
 
-		expect(mock.calls).toHaveLength(2);
+		expect(calls).toBe(2);
 		expect(retryStartEvents).toHaveLength(1);
 		expect(retryStartEvents[0]).toMatchObject({ attempt: 1, maxAttempts: 1 });
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: false, attempt: 1 });
-		expect(lastAssistant(session).errorMessage).toBe(
-			"Retry budget exhausted after 1 retry: server_error: stream closed with reason: error",
-		);
+		expect(lastAssistant(session).errorMessage).toBe(`Retry budget exhausted after 1 retry: ${options.errorMessage}`);
 		expect(session.isRetrying).toBe(false);
+	}
+
+	it("caps repeated OpenRouter stream closes after streamed thinking at one retry", async () => {
+		const model = getBundledModel("openrouter", "~google/gemini-flash-latest");
+		if (!model) {
+			throw new Error("Expected bundled OpenRouter Gemini test model to exist");
+		}
+		await expectThinkingStreamCloseRetryCap({
+			model,
+			errorMessage: "server_error: stream closed with reason: error",
+			prompt: "Trigger OpenRouter reasoning transition failure",
+		});
+	});
+
+	it("caps repeated Copilot Grok Responses closes after streamed thinking at one retry", async () => {
+		const model = getBundledModel("github-copilot", "grok-4.6");
+		if (!model) {
+			throw new Error("Expected bundled Copilot Grok 4.6 test model to exist");
+		}
+		await expectThinkingStreamCloseRetryCap({
+			model,
+			errorMessage: "OpenAI responses stream closed before a terminal response event was received",
+			prompt: "Trigger Copilot Grok Responses incomplete stream",
+		});
 	});
 
 	it("defaults 502 auto-retry to ten capped backoff attempts", async () => {


### PR DESCRIPTION
## Repro
A mocked `github-copilot/grok-4.6` `openai-responses` turn emits thinking and then `OpenAI responses stream closed before a terminal response event was received` with the production transient error classification. With `retry.maxRetries: 10` and `retry.modelFallback: false`, `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts -t "caps repeated Copilot Grok Responses closes"` failed because TurnRecovery issued a third same-model call instead of stopping after one retry.

## Cause
`TurnRecovery.#handleRetryableError` in `packages/coding-agent/src/session/turn-recovery.ts` applied the full configured retry budget to this Copilot/model/API failure. The existing bounded reasoning-stream predicate recognized only OpenRouter’s equivalent repeated reasoning-transition close, so Copilot Grok 4.6 replayed the same expensive thinking-only turn unchanged.

## Fix
- Generalize the bounded reasoning-stream predicate while preserving the OpenRouter rule.
- Recognize only `github-copilot/grok-4.6` on `openai-responses` with the terminal-event close and streamed thinking, then cap same-model recovery at one retry.
- Add an AgentSession regression for the fallback-disabled route and document the user-visible change.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-cap.test.ts` passes: 28 tests, 0 failures. The publish gate also completed `bun run fix` and `bun check` successfully. Fixes #9427