### PR TITLE
feat(coding-agent): add native skill routing

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -130,14 +130,19 @@ The `agents` provider (`.agent[s]/skills`) is the canonical OMP-native location 
 
 System prompt construction (`src/system-prompt.ts`) uses discovered skills as follows:
 
-- if `read` tool is available:
-  - include discovered skills list in prompt, excluding skills with `hide: true`
-- otherwise:
-  - omit discovered list
+- if `read` is not available, omit the discovered skills list
+- otherwise apply `skills.promptMode`:
+  - `all` (default): include every non-hidden discovered skill
+  - `core`: include skills from OMP-native providers (`native`, `agents`, and `omp-managed`)
+  - `allowlist`: include only names matching `skills.promptSkills` glob patterns
+- exclude skills with `hide: true` from every prompt mode
 
-`hide: true` does not disable the skill. Hidden skills are still loaded and remain reachable through `skill://<name>` and `/skill:<name>` when skill commands are enabled.
+Prompt filtering changes only system-prompt summaries. Discovery remains complete, so
+explicit `skill://` reads, `/skill:<name>` commands, and local `skill_search` can still
+use non-hidden skills that are not listed in the prompt.
 
-Task tool subagents receive the session's discovered/provided skills list via normal session creation; there is no per-task skill pinning override.
+`skill_search` searches local discovered skill metadata, returns ranked `skill://` URLs,
+and does not fetch network content. Use `read` on a returned URL to load full instructions.
 
 ### Interactive `/skill:<name>` commands
 

--- a/docs/tools/skill-search.md
+++ b/docs/tools/skill-search.md
@@ -1,0 +1,43 @@
+# skill_search
+
+> Search locally discovered skill metadata and return ranked `skill://...` URLs.
+
+## Source
+- Entry: `packages/coding-agent/src/tools/skill-search.ts`
+- Model-facing prompt: `packages/coding-agent/src/prompts/tools/skill-search.md`
+- Skill discovery and ordering: `packages/coding-agent/src/extensibility/skills.ts`
+
+## Registration / Visibility
+- Tool metadata: `approval = "read"`, `strict = true`, `loadMode = "discoverable"`.
+- Registration requires `skills.enabled != false` and a session that has or explicitly requests `read`.
+- Ordinary sessions with `tools.xdev = true` mount it under `xd://skill_search`; explicitly requested tools remain top-level.
+- The tool searches all active, non-hidden discovered skills, including skills omitted from the system prompt by `skills.promptMode`.
+
+## Inputs
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `query` | `string` | Yes | Skill name or capability to search for. |
+
+## Outputs
+- Matching results return up to eight ranked rows containing the skill name, description, `skill://<name>` URL, source, and numeric score.
+- Text output lists each matching URL and tells the model to use `read` on the highest-ranked URL.
+- No match returns `No matching skills found.`, an empty `details.results` array, and `useless = true`.
+
+## Ranking
+1. The query, skill name, and description are lowercased and split into Unicode letter/number tokens.
+2. Each exact name-token match adds 6 points; a name-token prefix adds 3.
+3. Each exact description-token match adds 3 points; a description-token prefix adds 1.
+4. Zero-score entries are removed. Remaining entries sort by score, then the stable skill ordering used by discovery.
+5. Hidden skills are removed before results are returned.
+
+## Side Effects
+- Filesystem: none. The tool searches the session's in-memory skill metadata.
+- Network: none.
+- Session state: read-only. It uses the session's live skill getter, so completed skill refreshes are visible to later calls.
+
+## Limits & Caps
+- Results are capped at eight.
+- Empty or punctuation-only queries return no matches.
+- Search does not inspect or return skill bodies. Use `read` with a returned `skill://...` URL for full instructions.
+- Search does not fetch network content or discover new skill directories; `refreshSkills()` owns rediscovery.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added prompt-scoped skill exposure settings (`skills.promptMode` and `skills.promptSkills`) plus local `skill_search` discovery over loaded metadata.
 - Fixed core skill prompt filtering to retain `.agent[s]` provider skills and aligned context usage accounting with the filtered prompt.
 - Serialized concurrent skill rediscovery so overlapping reloads cannot commit stale skill or prompt state.
+- Fixed live skill enable/disable changes to reconcile `skill_search`, encoded reserved characters in discovered skill URLs, and kept config-only allowlists out of the settings selector.
 
 ## [18.0.1] - 2026-08-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Added prompt-scoped skill exposure settings (`skills.promptMode` and `skills.promptSkills`) plus local `skill_search` discovery over loaded metadata.
+- Fixed core skill prompt filtering to retain `.agent[s]` provider skills and aligned context usage accounting with the filtered prompt.
+- Serialized concurrent skill rediscovery so overlapping reloads cannot commit stale skill or prompt state.
 
 ## [18.0.1] - 2026-08-23
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5145,7 +5145,12 @@ export const SETTINGS_SCHEMA = {
 			tab: "tasks",
 			group: "Commands & Skills",
 			label: "Prompt Skill Exposure",
-			description: "Choose which discovered skill summaries enter system prompts",
+			description:
+				"Choose all or core skill summaries. Configure allowlist mode and skills.promptSkills glob patterns in config.yml.",
+			options: [
+				{ value: "all", label: "All", description: "Include every visible discovered skill summary" },
+				{ value: "core", label: "Core", description: "Include built-in and managed skill summaries only" },
+			],
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5137,6 +5137,20 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.includeSkills": { type: "array", default: [] as string[] },
 
+	"skills.promptMode": {
+		type: "enum",
+		values: ["all", "core", "allowlist"] as const,
+		default: "all",
+		ui: {
+			tab: "tasks",
+			group: "Commands & Skills",
+			label: "Prompt Skill Exposure",
+			description: "Choose which discovered skill summaries enter system prompts",
+		},
+	},
+
+	"skills.promptSkills": { type: "array", default: [] as string[] },
+
 	// Commands
 	"commands.enableClaudeUser": {
 		type: "boolean",
@@ -6120,6 +6134,8 @@ export interface SkillsSettings {
 	customDirectories?: string[];
 	ignoredSkills?: string[];
 	includeSkills?: string[];
+	promptMode?: "all" | "core" | "allowlist";
+	promptSkills?: string[];
 	disabledExtensions?: string[];
 }
 

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -66,6 +66,55 @@ export function resetActiveSkillsForTests(): void {
 	activeSkills = [];
 }
 
+const CORE_SKILL_PROVIDERS: Record<string, true> = {
+	native: true,
+	agents: true,
+	[MANAGED_SKILLS_PROVIDER_ID]: true,
+};
+
+/**
+ * Select skill summaries for the system prompt without changing discovery.
+ * Explicit `skill://` loads, slash commands, and local search still use the
+ * complete active skill snapshot.
+ */
+export function filterSkillsForPrompt(
+	skills: readonly Skill[],
+	settings?: Pick<SkillsSettings, "promptMode" | "promptSkills">,
+): Skill[] {
+	const mode = settings?.promptMode ?? "all";
+	if (mode === "all") return [...skills];
+
+	if (mode === "core") {
+		return skills.filter(skill => {
+			const provider = skill._source?.provider ?? skill.source.split(":", 1)[0];
+			return CORE_SKILL_PROVIDERS[provider] === true;
+		});
+	}
+
+	const patterns = settings?.promptSkills ?? [];
+	if (patterns.length === 0) return [];
+	const globs = patterns.map(pattern => new Bun.Glob(pattern));
+	return skills.filter(skill => globs.some(glob => glob.match(skill.name)));
+}
+
+/**
+ * Skills actually listed in the rendered system prompt, composing
+ * {@link filterSkillsForPrompt} with the two renderer gates: the `read` tool
+ * must be present so the model can fetch skill content, and skills with
+ * frontmatter `hide: true` (still loadable via `skill://` and `/skill:<name>`)
+ * are excluded. Single source for the prompt renderer (system-prompt.ts) and
+ * context accounting (context-usage.ts) so both stay aligned with the
+ * provider-facing prompt.
+ */
+export function selectSkillsForPrompt(
+	skills: readonly Skill[],
+	hasReadTool: boolean,
+	settings?: Pick<SkillsSettings, "promptMode" | "promptSkills">,
+): Skill[] {
+	if (!hasReadTool) return [];
+	return filterSkillsForPrompt(skills, settings).filter(skill => skill.hide !== true);
+}
+
 /**
  * Whether `name` is already claimed by an active authored (non-managed) skill.
  *

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -477,6 +477,24 @@ export class SelectorController {
 					this.ctx.showError(`Failed to apply personality: ${err}`);
 				});
 				break;
+			case "skills.enabled":
+			case "skills.enableSkillCommands":
+			case "skills.enableCodexUser":
+			case "skills.enableClaudeUser":
+			case "skills.enableClaudeProject":
+			case "skills.enablePiUser":
+			case "skills.enablePiProject":
+			case "skills.enableAgentsUser":
+			case "skills.enableAgentsProject":
+			case "skills.customDirectories":
+			case "skills.ignoredSkills":
+			case "skills.includeSkills":
+			case "skills.promptMode":
+			case "skills.promptSkills":
+				void this.ctx.refreshSkillState().catch(err => {
+					this.ctx.showError(`Failed to apply skill setting: ${err}`);
+				});
+				break;
 			case "tools.xdevDocs":
 				void this.ctx.session.refreshBaseSystemPrompt().catch(err => {
 					this.ctx.showError(`Failed to apply xd:// prompt docs setting: ${err}`);

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -4,7 +4,8 @@ import { effectiveReserveTokens, resolveThresholdTokens } from "@oh-my-pi/pi-age
 import type { Tool as AiTool, Model } from "@oh-my-pi/pi-ai";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { formatNumber } from "@oh-my-pi/pi-utils";
-import type { Skill } from "../../extensibility/skills";
+import type { SkillsSettings } from "../../config/settings";
+import { type Skill, selectSkillsForPrompt } from "../../extensibility/skills";
 import type { AgentSession } from "../../session/agent-session";
 import { resolveSpeculationMethod } from "../../session/compaction-methods";
 import { estimateInlineSavings, type SnapcompactSavingsEstimate } from "../../session/snapcompact-inline";
@@ -89,27 +90,12 @@ export interface NonMessageTokenSource {
 		};
 	};
 	readonly skills?: readonly Skill[];
+	readonly skillsSettings?: Pick<SkillsSettings, "promptMode" | "promptSkills">;
 }
 
 const EMPTY_STRING_PARTS: string[] = [];
 const EMPTY_TOOLS: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">> = [];
 const EMPTY_SKILLS: readonly Skill[] = [];
-
-/**
- * Skills actually rendered into the system prompt, mirroring the filter in
- * `buildSystemPrompt` (`system-prompt.ts`): the `read` tool must be present so
- * the model can fetch skill content, and skills with frontmatter `hide: true`
- * (or `disable-model-invocation`, normalized onto `hide`) are excluded.
- * Accounting must count only these so the Skills category and the System-prompt
- * subtraction stay aligned with the provider-facing prompt.
- */
-function renderedSkills(
-	skills: readonly Skill[],
-	tools: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">>,
-): readonly Skill[] {
-	if (!tools.some(tool => tool.name === "read")) return EMPTY_SKILLS;
-	return skills.filter(skill => skill.hide !== true);
-}
 
 export function estimateSkillsTokens(skills: readonly Skill[], tokenizer: Tokenizer): number {
 	const fragments: string[] = [];
@@ -176,6 +162,7 @@ interface NonMessageTokenCache {
 	// The Agent swaps its Tokenizer instance when the model's encoding changes,
 	// so instance identity doubles as the encoding key.
 	tokenizerRef: Tokenizer;
+	skillsSettingsRef: Pick<SkillsSettings, "promptMode" | "promptSkills"> | undefined;
 	tokens: number | undefined;
 	breakdown:
 		| {
@@ -198,17 +185,27 @@ function nonMessageTokenCacheEntry(session: NonMessageTokenSource, tokenizer: To
 	const systemPromptRef = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const toolsRef = session.agent?.state?.tools ?? EMPTY_TOOLS;
 	const skillsRef = session.skills ?? EMPTY_SKILLS;
+	const skillsSettingsRef = session.skillsSettings;
 	let entry = cachedSession[NON_MESSAGE_TOKEN_CACHE];
 	if (
 		entry &&
 		entry.systemPromptRef === systemPromptRef &&
 		entry.toolsRef === toolsRef &&
 		entry.skillsRef === skillsRef &&
-		entry.tokenizerRef === tokenizer
+		entry.tokenizerRef === tokenizer &&
+		entry.skillsSettingsRef === skillsSettingsRef
 	) {
 		return entry;
 	}
-	entry = { systemPromptRef, toolsRef, skillsRef, tokenizerRef: tokenizer, tokens: undefined, breakdown: undefined };
+	entry = {
+		systemPromptRef,
+		toolsRef,
+		skillsRef,
+		tokenizerRef: tokenizer,
+		skillsSettingsRef,
+		tokens: undefined,
+		breakdown: undefined,
+	};
 	cachedSession[NON_MESSAGE_TOKEN_CACHE] = entry;
 	return entry;
 }
@@ -243,7 +240,12 @@ export function computeNonMessageBreakdown(
 	const entry = nonMessageTokenCacheEntry(session, tokenizer);
 	if (entry.breakdown) return entry.breakdown;
 	const tools = session.agent?.state?.tools ?? EMPTY_TOOLS;
-	const skillsTokens = estimateSkillsTokens(renderedSkills(session.skills ?? EMPTY_SKILLS, tools), tokenizer);
+	// selectSkillsForPrompt keeps this count aligned with the provider-facing prompt.
+	const hasReadTool = tools.some(tool => tool.name === "read");
+	const skillsTokens = estimateSkillsTokens(
+		selectSkillsForPrompt(session.skills ?? EMPTY_SKILLS, hasReadTool, session.skillsSettings),
+		tokenizer,
+	);
 	const toolsTokens = estimateToolSchemaTokens(tools, tokenizer);
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const systemContextTokens = tokenizer.countTokens(Array.from(systemPromptParts.slice(1), part => part ?? ""));

--- a/packages/coding-agent/src/prompts/tools/skill-search.md
+++ b/packages/coding-agent/src/prompts/tools/skill-search.md
@@ -1,0 +1,1 @@
+Search the metadata for discovered skills by name or capability. Returns ranked `skill://...` URLs. Use `read` on a returned URL to load the full skill instructions. Searches only local discovered skills and does not fetch network content.

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -246,6 +246,8 @@ export class SessionTools {
 	#skillWarnings: SkillWarning[];
 	#skillsSettings: SkillsSettings | undefined;
 	#skillsReloadable: boolean;
+	#skillRefreshTail: Promise<void> = Promise.resolve();
+
 	#acpPermissionDecisions = new Map<string, "allow_always" | "reject_always">();
 
 	constructor(host: SessionToolsHost, options: SessionToolsOptions) {
@@ -1162,7 +1164,13 @@ export class SessionTools {
 	}
 
 	/** Rediscovers reloadable skills and refreshes prompt metadata. */
-	async refreshSkills(): Promise<void> {
+	refreshSkills(): Promise<void> {
+		const refresh = this.#skillRefreshTail.then(() => this.#refreshSkills());
+		this.#skillRefreshTail = refresh.catch(() => {});
+		return refresh;
+	}
+
+	async #refreshSkills(): Promise<void> {
 		resetCapabilities();
 		if (this.#skillsReloadable) {
 			const skillsSettings = this.#host.settings.getGroup("skills");
@@ -1489,6 +1497,9 @@ export class SessionTools {
 
 	async #refreshBaseSystemPrompt(): Promise<void> {
 		if (this.#host.isDisposed() || !this.#rebuildSystemPrompt) return;
+		if (this.#skillsSettings) {
+			this.#skillsSettings = this.#host.settings.getGroup("skills");
+		}
 		const activeToolNames = this.getActiveToolNames();
 		const promptToolNames =
 			this.#codeModeDirectWireSignature === undefined ? activeToolNames : this.getEnabledToolNames();

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -21,6 +21,7 @@ import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
 import { computerExposureMode } from "../tools/computer/exposure";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
+import { SkillSearchTool } from "../tools/skill-search";
 import { supportsExternalThinking } from "../tools/think";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
 import { isMountableUnderXdev, listXdevTools, type XdevState, xdevDocsFor, xdevEntries } from "../tools/xdev";
@@ -1187,8 +1188,41 @@ export class SessionTools {
 				setActiveSkills(this.#skills);
 			}
 		}
-		await this.refreshBaseSystemPrompt();
-		this.#host.notifyCommandMetadataChanged();
+
+		await this.runToolRegistryMutation(async () => {
+			const currentToolNames = this.getEnabledToolNames();
+			let nextToolNames = currentToolNames;
+			const skillSearch = this.#toolRegistry.get("skill_search");
+			const builtInSkillSearch = skillSearch !== undefined && this.#builtInToolNames.has("skill_search");
+			if (this.#host.settings.get("skills.enabled") === false) {
+				if (builtInSkillSearch && currentToolNames.includes("skill_search")) {
+					nextToolNames = currentToolNames.filter(name => name !== "skill_search");
+				}
+			} else {
+				const originalToolNames = this.#presentationPinnedToolNames;
+				const readAllowed =
+					currentToolNames.includes("read") &&
+					(originalToolNames === undefined ||
+						(originalToolNames.has("read") && originalToolNames.has("skill_search")));
+				if (readAllowed) {
+					if (!skillSearch) {
+						const tool = this.#wrapRuntimeTool(new SkillSearchTool(this) as AgentTool<any, any, any>);
+						this.#toolRegistry.set(tool.name, tool);
+						this.#builtInToolNames.add(tool.name);
+						nextToolNames = [...currentToolNames, tool.name];
+					} else if (builtInSkillSearch && !currentToolNames.includes("skill_search")) {
+						nextToolNames = [...currentToolNames, "skill_search"];
+					}
+				}
+			}
+
+			if (nextToolNames !== currentToolNames) {
+				await this.#applyActiveToolsByName(nextToolNames);
+			} else {
+				await this.#refreshBaseSystemPrompt();
+			}
+			this.#host.notifyCommandMetadataChanged();
+		});
 	}
 
 	/** Selects enabled tools, ignoring names absent from the registry. */

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -23,7 +23,7 @@ import { findConfigFile } from "./config";
 import type { Personality, SkillsSettings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import { expandAtImports } from "./discovery/at-imports";
-import { loadSkills, type Skill } from "./extensibility/skills";
+import { loadSkills, type Skill, selectSkillsForPrompt } from "./extensibility/skills";
 import { hasObsidian } from "./internal-urls/vault-protocol";
 import activeRepoContextTemplate from "./prompts/system/active-repo-context.md" with { type: "text" };
 import computerSafetyPrompt from "./prompts/system/computer-safety.md" with { type: "text" };
@@ -937,11 +937,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 				}),
 			);
 
-	// Filter skills for the rendered system prompt:
-	// - require the `read` tool so the model can actually fetch skill content;
-	// - drop skills with frontmatter `hide: true` (still loadable via skill:// and /skill:<name>).
-	const hasRead = toolNames.includes("read");
-	const filteredSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
+	// Skills listed in the rendered prompt: read-tool gate, prompt-mode
+	// filter, and `hide: true` drop are all owned by selectSkillsForPrompt.
+	const filteredSkills = selectSkillsForPrompt(skills, toolNames.includes("read"), skillsSettings);
 
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -27,6 +27,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"recall",
 	"reflect",
 	"learn",
+	"skill_search",
 	"manage_skill",
 ] as const;
 

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -62,6 +62,7 @@ import { wrapToolWithMetaNotice } from "./output-meta";
 import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
 import { SecurityScanTool } from "./security-scan";
+import { SkillSearchTool } from "./skill-search";
 import { supportsExternalThinking, ThinkTool } from "./think";
 import { type TodoPhase, TodoTool } from "./todo";
 import { WriteTool } from "./write";
@@ -104,6 +105,7 @@ export * from "./report-tool-issue";
 export * from "./resolve";
 export * from "./review";
 export * from "./security-scan";
+export * from "./skill-search";
 export * from "./think";
 export * from "./todo";
 export * from "./tts";
@@ -455,6 +457,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	recall: MemoryRecallTool.createIf,
 	reflect: MemoryReflectTool.createIf,
 	learn: LearnTool.createIf,
+	skill_search: s => new SkillSearchTool(s),
 	manage_skill: ManageSkillTool.createIf,
 };
 
@@ -643,6 +646,11 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			return ["hindsight", "mnemopi"].includes(session.settings.get("memory.backend") ?? "");
 		}
 		if (name === "memory_edit") return session.settings.get("memory.backend") === "mnemopi";
+		if (name === "skill_search")
+			return (
+				session.settings.get("skills.enabled") !== false &&
+				(requestedTools === undefined || requestedTools.includes("read"))
+			);
 		if (name === "manage_skill")
 			return (
 				session.settings.get("autolearn.enabled") &&

--- a/packages/coding-agent/src/tools/skill-search.ts
+++ b/packages/coding-agent/src/tools/skill-search.ts
@@ -1,0 +1,105 @@
+import { type } from "@oh-my-pi/omptype";
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { compareSkillOrder } from "../discovery/helpers";
+import type { Skill } from "../extensibility/skills";
+import skillSearchDescription from "../prompts/tools/skill-search.md" with { type: "text" };
+import type { ToolSession } from ".";
+
+const skillSearchSchema = type({
+	query: type("string").describe("skill name or capability to search for"),
+});
+
+export type SkillSearchParams = typeof skillSearchSchema.infer;
+
+export interface SkillSearchMatch {
+	name: string;
+	description: string;
+	path: string;
+	source: string;
+	score: number;
+}
+
+const MAX_RESULTS = 8;
+
+function tokens(value: string): string[] {
+	return value
+		.toLowerCase()
+		.split(/[^\p{L}\p{N}]+/u)
+		.filter(Boolean);
+}
+
+function scoreSkill(queryTokens: readonly string[], skill: Pick<Skill, "name" | "description">): number {
+	const nameTokens = tokens(skill.name);
+	const descriptionTokens = tokens(skill.description);
+	let score = 0;
+
+	for (const queryToken of queryTokens) {
+		if (nameTokens.includes(queryToken)) score += 6;
+		else if (nameTokens.some(token => token.startsWith(queryToken))) score += 3;
+
+		if (descriptionTokens.includes(queryToken)) score += 3;
+		else if (descriptionTokens.some(token => token.startsWith(queryToken))) score += 1;
+	}
+
+	return score;
+}
+
+export function searchSkills(skills: readonly Skill[], query: string, limit = MAX_RESULTS): SkillSearchMatch[] {
+	const queryTokens = tokens(query);
+	if (queryTokens.length === 0) return [];
+
+	return skills
+		.filter(skill => skill.hide !== true)
+		.map(skill => ({
+			skill,
+			score: scoreSkill(queryTokens, skill),
+		}))
+		.filter(match => match.score > 0)
+		.sort(
+			(a, b) =>
+				b.score - a.score || compareSkillOrder(a.skill.name, a.skill.filePath, b.skill.name, b.skill.filePath),
+		)
+		.slice(0, limit)
+		.map(({ skill, score }) => ({
+			name: skill.name,
+			description: skill.description,
+			path: `skill://${skill.name}`,
+			source: skill.source,
+			score,
+		}));
+}
+
+export class SkillSearchTool implements AgentTool<typeof skillSearchSchema> {
+	readonly name = "skill_search";
+	readonly approval = "read" as const;
+	readonly label = "Skill Search";
+	readonly description = skillSearchDescription;
+	readonly parameters = skillSearchSchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable" as const;
+	readonly summary = "Search local skill metadata";
+
+	constructor(private readonly session: Pick<ToolSession, "skills">) {}
+
+	async execute(_id: string, params: SkillSearchParams): Promise<AgentToolResult> {
+		const matches = searchSkills(this.session.skills ?? [], params.query);
+		if (matches.length === 0) {
+			return {
+				content: [{ type: "text", text: "No matching skills found." }],
+				details: { query: params.query, results: [] },
+				useless: true,
+			};
+		}
+
+		const lines = [
+			`Found ${matches.length} matching ${matches.length === 1 ? "skill" : "skills"}:`,
+			...matches.map(match => `- ${match.path} (${match.score}): ${match.description}`),
+			`Use read with ${matches[0].path} to load the full skill instructions.`,
+		];
+
+		return {
+			content: [{ type: "text", text: lines.join("\n") }],
+			details: { query: params.query, results: matches },
+		};
+	}
+}

--- a/packages/coding-agent/src/tools/skill-search.ts
+++ b/packages/coding-agent/src/tools/skill-search.ts
@@ -63,7 +63,7 @@ export function searchSkills(skills: readonly Skill[], query: string, limit = MA
 		.map(({ skill, score }) => ({
 			name: skill.name,
 			description: skill.description,
-			path: `skill://${skill.name}`,
+			path: `skill://${encodeURIComponent(skill.name)}`,
 			source: skill.source,
 			score,
 		}));

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -80,6 +80,16 @@ describe("settings layout", () => {
 		expect(values).toEqual([...SETTINGS_SCHEMA["snapcompact.shape"].values]);
 	});
 
+	it("does not offer allowlist mode without an editable prompt-skill list", () => {
+		const def = getSettingsForTab("tasks").find(def => def.path === "skills.promptMode");
+
+		expect(def?.type).toBe("submenu");
+		if (def?.type !== "submenu") throw new Error("skills.promptMode should render as a submenu");
+		expect(def.options.map(option => option.value)).toEqual(["all", "core"]);
+		expect(def.description).toContain("config.yml");
+		expect(def.description).toContain("skills.promptSkills");
+	});
+
 	it("hides advisor dependent settings when advisor is disabled", () => {
 		const advisorDependentPaths: SettingPath[] = ["advisor.syncBacklog", "advisor.immuneTurns"];
 		const advisorDependentPathSet = new Set(advisorDependentPaths);

--- a/packages/coding-agent/test/modes/context-usage.test.ts
+++ b/packages/coding-agent/test/modes/context-usage.test.ts
@@ -13,6 +13,7 @@ import {
 	type ContextBreakdown,
 	computeNonMessageBreakdown,
 	computeNonMessageTokens,
+	estimateSkillsTokens,
 	estimateToolSchemaTokens,
 	renderContextUsage,
 } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
@@ -221,8 +222,8 @@ describe("computeNonMessageBreakdown skills filtering", () => {
 	// First prompt block as rendered: only the visible skill appears.
 	const renderedPrompt = "You are an agent.\nSkills:\n- vis: small visible skill\n";
 
-	function session(tools: unknown[], skills: unknown[]) {
-		return { systemPrompt: [renderedPrompt], agent: { state: { tools } }, skills } as never;
+	function session(tools: unknown[], skills: unknown[], skillsSettings?: unknown) {
+		return { systemPrompt: [renderedPrompt], agent: { state: { tools } }, skills, skillsSettings } as never;
 	}
 
 	it("excludes hidden skills and does not clamp System prompt to 0", () => {
@@ -237,6 +238,48 @@ describe("computeNonMessageBreakdown skills filtering", () => {
 		const b = computeNonMessageBreakdown(session([], [hidden, visible]), tokenizer);
 		expect(b.skillsTokens).toBe(0);
 		expect(b.systemPromptTokens).toBe(computeNonMessageBreakdown(session([], []), tokenizer).systemPromptTokens);
+	});
+	it("counts only skills selected by core prompt mode", () => {
+		const native = {
+			name: "native",
+			description: "native skill",
+			filePath: "/s/native.md",
+			baseDir: "/s",
+			source: "native",
+		};
+		const local = {
+			name: "local",
+			description: "local skill",
+			filePath: "/s/local.md",
+			baseDir: "/s",
+			source: "test",
+		};
+		const b = computeNonMessageBreakdown(session([readTool], [native, local], { promptMode: "core" }), tokenizer);
+
+		expect(b.skillsTokens).toBe(estimateSkillsTokens([native], tokenizer));
+	});
+
+	it("counts only skills selected by the prompt allowlist", () => {
+		const selected = {
+			name: "selected-workflow",
+			description: "selected skill",
+			filePath: "/s/selected.md",
+			baseDir: "/s",
+			source: "test",
+		};
+		const omitted = {
+			name: "other-workflow",
+			description: "other skill",
+			filePath: "/s/other.md",
+			baseDir: "/s",
+			source: "test",
+		};
+		const b = computeNonMessageBreakdown(
+			session([readTool], [selected, omitted], { promptMode: "allowlist", promptSkills: ["selected-*"] }),
+			tokenizer,
+		);
+
+		expect(b.skillsTokens).toBe(estimateSkillsTokens([selected], tokenizer));
 	});
 });
 

--- a/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
@@ -17,4 +17,22 @@ describe("SelectorController prompt-affecting settings", () => {
 		expect(refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
+
+	it("refreshes skill state when skill prompt scope changes", async () => {
+		const refreshBaseSystemPrompt = vi.fn(async () => {});
+		const refreshSkillState = vi.fn(async () => {});
+		const ctx = {
+			session: { refreshBaseSystemPrompt },
+			refreshSkillState,
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.handleSettingChange("skills.promptMode", "core");
+		await Promise.resolve();
+
+		expect(refreshSkillState).toHaveBeenCalledTimes(1);
+		expect(refreshBaseSystemPrompt).not.toHaveBeenCalled();
+		expect(ctx.showError).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -136,10 +136,11 @@ Loaded via symbolic link.
 		);
 
 		const previousAgentDir = getAgentDir();
-		setAgentDir(path.join(tempHomeDir, ".omp", "agent"));
+		const userAgentDir = path.join(tempHomeDir, ".omp", "agent");
+		setAgentDir(userAgentDir);
 		const baseSessionOptions = {
 			cwd: tempDir,
-			agentDir: path.join(tempHomeDir, ".omp", "agent"),
+			agentDir: userAgentDir,
 			modelRegistry: sharedModelRegistry,
 			additionalExtensionPaths: [explicitPackage],
 			enableMCP: false,
@@ -212,6 +213,7 @@ Loaded via symbolic link.
 			agentDir: tempDir,
 			sessionManager: SessionManager.inMemory(tempDir),
 			modelRegistry: sharedModelRegistry,
+			enableMCP: false,
 			settings: createIsolatedSkillsSettings(),
 		});
 
@@ -241,7 +243,7 @@ This skill is added after session creation.
 		await session.refreshSkills();
 
 		expect(session.skills.some((s: Skill) => s.name === "runtime-added-skill")).toBe(false);
-	});
+	}, 15_000);
 
 	it("manage_skill hot-registers managed skills in the active session", async () => {
 		const originalAgentDir = getAgentDir();
@@ -254,6 +256,7 @@ This skill is added after session creation.
 			agentDir: managedAgentDir,
 			sessionManager: SessionManager.inMemory(tempDir),
 			modelRegistry: sharedModelRegistry,
+			enableMCP: false,
 			settings,
 		});
 		let commandMetadataChanges = 0;

--- a/packages/coding-agent/test/session-tools-refresh-skills.test.ts
+++ b/packages/coding-agent/test/session-tools-refresh-skills.test.ts
@@ -4,6 +4,7 @@ import { Settings } from "../src/config/settings";
 import type { LoadSkillsResult, Skill } from "../src/extensibility/skills";
 import * as skillsModule from "../src/extensibility/skills";
 import { SessionTools, type SessionToolsHost } from "../src/session/session-tools";
+import { createTools, type ToolSession } from "../src/tools";
 
 type Deferred<T> = {
 	promise: Promise<T>;
@@ -33,9 +34,9 @@ type SessionToolsTestOptions = {
 
 function makeSessionTools(options: SessionToolsTestOptions = {}): SessionTools {
 	const settings = Settings.isolated({
-		"skills.enabled": true,
 		includeModelInPrompt: false,
 	});
+	settings.set("skills.enabled", true);
 	const host = {
 		agent: {
 			state: { tools: [] },
@@ -70,7 +71,97 @@ function makeSessionTools(options: SessionToolsTestOptions = {}): SessionTools {
 	});
 }
 
+type SkillToolSurface = {
+	settings: Settings;
+	registry: Map<string, AgentTool>;
+	sessionTools: SessionTools;
+};
+
+async function makeSkillToolSurface(skillsEnabled: boolean): Promise<SkillToolSurface> {
+	const settings = Settings.isolated({
+		"tools.xdev": false,
+		includeModelInPrompt: false,
+	});
+	settings.set("skills.enabled", skillsEnabled);
+	const toolSession = {
+		cwd: "/tmp/session",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings,
+		skills: [],
+		skipPythonPreflight: true,
+	} as unknown as ToolSession;
+	const initialTools = await createTools(toolSession, ["skill_search", "read"]);
+	const registry = toolSession.toolRegistry ?? new Map(initialTools.map(tool => [tool.name, tool]));
+	const agentState: { tools: AgentTool[] } = { tools: initialTools };
+	const host = {
+		agent: {
+			state: agentState,
+			setSystemPrompt: () => {},
+			setTools: (tools: AgentTool[]) => {
+				agentState.tools = tools;
+			},
+		} as unknown as Agent,
+		sessionManager: { getCwd: () => "/tmp/session" },
+		settings,
+		agentKind: () => "sub" as const,
+		model: () => undefined,
+		isDisposed: () => false,
+		isStreaming: () => false,
+		queuedMessageCount: () => 0,
+		planModeEnabled: () => false,
+		extensionRunner: () => undefined,
+		clientBridge: () => undefined,
+		modelRegistry: {},
+		memoryBackendSession: () => undefined,
+		clearInheritedProviderPromptCacheKey: () => undefined,
+		clearMemoryPromotionSnapshot: () => undefined,
+		captureMemoryPromotionSnapshot: () => undefined,
+		notifyCommandMetadataChanged: () => {},
+		localProtocolOptions: () => ({}),
+		getInspectImageModeOverride: () => undefined,
+		setInspectImageModeOverride: () => undefined,
+	} as unknown as SessionToolsHost;
+	const sessionTools = new SessionTools(host, {
+		toolRegistry: registry,
+		builtInToolNames: registry.keys(),
+		baseSystemPrompt: ["initial"],
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["rebuilt"] }),
+		skillsReloadable: true,
+	});
+	return { settings, registry, sessionTools };
+}
+
 afterEach(() => vi.restoreAllMocks());
+
+describe("SessionTools.refreshSkills", () => {
+	it("adds skill_search to the active model-facing surface when skills are enabled at runtime", async () => {
+		vi.spyOn(skillsModule, "loadSkills").mockResolvedValue({ skills: [], warnings: [] });
+		const surface = await makeSkillToolSurface(false);
+
+		surface.settings.set("skills.enabled", true);
+		await surface.sessionTools.refreshSkills();
+
+		expect(surface.registry.has("skill_search")).toBe(true);
+		expect(surface.sessionTools.getActiveToolNames()).toContain("read");
+		expect(surface.sessionTools.getActiveToolNames()).toContain("skill_search");
+		expect(surface.sessionTools.getToolForEvalBridge("skill_search")).toBeDefined();
+	});
+
+	it("removes skill_search from the active model-facing surface when skills are disabled at runtime", async () => {
+		vi.spyOn(skillsModule, "loadSkills").mockResolvedValue({ skills: [], warnings: [] });
+		const surface = await makeSkillToolSurface(true);
+		expect(surface.sessionTools.getActiveToolNames()).toContain("skill_search");
+
+		surface.settings.set("skills.enabled", false);
+		await surface.sessionTools.refreshSkills();
+
+		expect(surface.registry.has("skill_search")).toBe(true);
+		expect(surface.sessionTools.getActiveToolNames()).not.toContain("skill_search");
+		expect(surface.sessionTools.getToolForEvalBridge("skill_search")).toBeUndefined();
+	});
+});
 
 describe("SessionTools.refreshSkills", () => {
 	it("serializes concurrent reloads and keeps completion order deterministic", async () => {

--- a/packages/coding-agent/test/session-tools-refresh-skills.test.ts
+++ b/packages/coding-agent/test/session-tools-refresh-skills.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { Agent, AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "../src/config/settings";
+import type { LoadSkillsResult, Skill } from "../src/extensibility/skills";
+import * as skillsModule from "../src/extensibility/skills";
+import { SessionTools, type SessionToolsHost } from "../src/session/session-tools";
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+	return Promise.withResolvers<T>();
+}
+
+function makeSkill(name: string): Skill {
+	return {
+		name,
+		description: name,
+		filePath: `/tmp/${name}/SKILL.md`,
+		baseDir: `/tmp/${name}`,
+		source: "test",
+	};
+}
+
+type SessionToolsTestOptions = {
+	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
+	onNotify?: () => void;
+	onSetSystemPrompt?: (prompt: string[]) => void;
+};
+
+function makeSessionTools(options: SessionToolsTestOptions = {}): SessionTools {
+	const settings = Settings.isolated({
+		"skills.enabled": true,
+		includeModelInPrompt: false,
+	});
+	const host = {
+		agent: {
+			state: { tools: [] },
+			setSystemPrompt: (prompt: string[]) => options.onSetSystemPrompt?.(prompt),
+		} as unknown as Agent,
+		sessionManager: { getCwd: () => "/tmp/session" },
+		settings,
+		agentKind: () => "sub" as const,
+		model: () => undefined,
+		isDisposed: () => false,
+		isStreaming: () => false,
+		queuedMessageCount: () => 0,
+		planModeEnabled: () => false,
+		extensionRunner: () => undefined,
+		clientBridge: () => undefined,
+		modelRegistry: {},
+		memoryBackendSession: () => undefined,
+		clearInheritedProviderPromptCacheKey: () => undefined,
+		clearMemoryPromotionSnapshot: () => undefined,
+		captureMemoryPromotionSnapshot: () => undefined,
+		notifyCommandMetadataChanged: () => options.onNotify?.(),
+		localProtocolOptions: () => ({}),
+		getInspectImageModeOverride: () => undefined,
+		setInspectImageModeOverride: () => undefined,
+	} as unknown as SessionToolsHost;
+
+	return new SessionTools(host, {
+		toolRegistry: new Map<string, AgentTool>(),
+		baseSystemPrompt: ["initial"],
+		rebuildSystemPrompt: options.rebuildSystemPrompt ?? (async () => ({ systemPrompt: ["rebuilt"] })),
+		skillsReloadable: true,
+	});
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("SessionTools.refreshSkills", () => {
+	it("serializes concurrent reloads and keeps completion order deterministic", async () => {
+		const first = deferred<LoadSkillsResult>();
+		const second = deferred<LoadSkillsResult>();
+		const results = [first, second];
+		let calls = 0;
+		vi.spyOn(skillsModule, "loadSkills").mockImplementation(async () => {
+			const result = results[calls++];
+			if (!result) throw new Error("unexpected third skill reload");
+			return result.promise;
+		});
+
+		const sessionTools = makeSessionTools();
+		const refreshOne = sessionTools.refreshSkills();
+		await Promise.resolve();
+		expect(calls).toBe(1);
+
+		const refreshTwo = sessionTools.refreshSkills();
+		await Promise.resolve();
+		expect(calls).toBe(1);
+
+		first.resolve({ skills: [makeSkill("first")], warnings: [] });
+		await refreshOne;
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(calls).toBe(2);
+
+		second.resolve({ skills: [makeSkill("second")], warnings: [] });
+		await Promise.all([refreshOne, refreshTwo]);
+
+		expect(sessionTools.skills.map(skill => skill.name)).toEqual(["second"]);
+	});
+	it("awaits each prompt rebuild and metadata notification in queue order", async () => {
+		const firstLoad = deferred<LoadSkillsResult>();
+		const secondLoad = deferred<LoadSkillsResult>();
+		const firstLoadStarted = deferred<true>();
+		const secondLoadStarted = deferred<true>();
+		const firstPrompt = deferred<{ systemPrompt: string[] }>();
+		const secondPrompt = deferred<{ systemPrompt: string[] }>();
+		const firstPromptStarted = deferred<true>();
+		const secondPromptStarted = deferred<true>();
+		const loads = [firstLoad, secondLoad];
+		let loadCalls = 0;
+		let promptCalls = 0;
+		let sessionTools!: SessionTools;
+		const promptStates: string[] = [];
+		const notifications: string[] = [];
+		const appliedPrompts: string[] = [];
+		vi.spyOn(skillsModule, "loadSkills").mockImplementation(async () => {
+			const result = loads[loadCalls];
+			if (!result) throw new Error("unexpected third skill reload");
+			loadCalls += 1;
+			if (loadCalls === 1) firstLoadStarted.resolve(true);
+			if (loadCalls === 2) secondLoadStarted.resolve(true);
+			return result.promise;
+		});
+
+		sessionTools = makeSessionTools({
+			rebuildSystemPrompt: async () => {
+				const isFirstPrompt = promptCalls++ === 0;
+				const prompt = isFirstPrompt ? firstPrompt : secondPrompt;
+				(isFirstPrompt ? firstPromptStarted : secondPromptStarted).resolve(true);
+				promptStates.push(sessionTools.skills[0]?.name ?? "none");
+				return prompt.promise;
+			},
+			onNotify: () => notifications.push(sessionTools.skills[0]?.name ?? "none"),
+			onSetSystemPrompt: prompt => appliedPrompts.push(prompt[0] ?? ""),
+		});
+		const refreshOne = sessionTools.refreshSkills();
+		const refreshTwo = sessionTools.refreshSkills();
+		let firstSettled = false;
+		let secondSettled = false;
+		void refreshOne.then(
+			() => {
+				firstSettled = true;
+			},
+			() => {
+				firstSettled = true;
+			},
+		);
+		void refreshTwo.then(
+			() => {
+				secondSettled = true;
+			},
+			() => {
+				secondSettled = true;
+			},
+		);
+
+		await firstLoadStarted.promise;
+		firstLoad.resolve({ skills: [makeSkill("first")], warnings: [] });
+		await firstPromptStarted.promise;
+		expect(promptStates).toEqual(["first"]);
+		expect(firstSettled).toBe(false);
+		expect(secondSettled).toBe(false);
+
+		expect(loadCalls).toBe(1);
+
+		firstPrompt.resolve({ systemPrompt: ["first-prompt"] });
+		await refreshOne;
+		expect(firstSettled).toBe(true);
+		expect(notifications).toEqual(["first"]);
+		expect(sessionTools.baseSystemPrompt).toEqual(["first-prompt"]);
+
+		await secondLoadStarted.promise;
+		secondLoad.resolve({ skills: [makeSkill("second")], warnings: [] });
+		await secondPromptStarted.promise;
+		expect(promptStates).toEqual(["first", "second"]);
+		expect(secondSettled).toBe(false);
+		expect(notifications).toEqual(["first"]);
+
+		secondPrompt.resolve({ systemPrompt: ["second-prompt"] });
+		await refreshTwo;
+		expect(secondSettled).toBe(true);
+		expect(notifications).toEqual(["first", "second"]);
+		expect(appliedPrompts).toEqual(["first-prompt", "second-prompt"]);
+		expect(sessionTools.baseSystemPrompt).toEqual(["second-prompt"]);
+	});
+
+	it("continues queued reloads after an earlier reload fails", async () => {
+		const first = deferred<LoadSkillsResult>();
+		const second = deferred<LoadSkillsResult>();
+		const results = [first, second];
+		let calls = 0;
+		vi.spyOn(skillsModule, "loadSkills").mockImplementation(async () => {
+			const result = results[calls++];
+			if (!result) throw new Error("unexpected third skill reload");
+			return result.promise;
+		});
+
+		const sessionTools = makeSessionTools();
+		const refreshOne = sessionTools.refreshSkills();
+		const refreshTwo = sessionTools.refreshSkills();
+
+		first.reject(new Error("reload failed"));
+		await expect(refreshOne).rejects.toThrow("reload failed");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(calls).toBe(2);
+
+		second.resolve({ skills: [makeSkill("recovered")], warnings: [] });
+		await refreshTwo;
+
+		expect(sessionTools.skills.map(skill => skill.name)).toEqual(["recovered"]);
+	});
+});

--- a/packages/coding-agent/test/skill-search.test.ts
+++ b/packages/coding-agent/test/skill-search.test.ts
@@ -41,6 +41,17 @@ describe("skill_search tool", () => {
 		expect(text).not.toContain("# full skill body");
 	});
 
+	it("percent-encodes reserved characters in skill URLs", async () => {
+		const tool = makeTool([skill("ops#blue", "Operate the blue environment")]);
+
+		const result = await tool.execute("call-reserved-name", { query: "ops blue" });
+		const text = textOf(result);
+
+		expect(text).toContain("skill://ops%23blue");
+		expect(text).toContain("Use read with skill://ops%23blue");
+		expect(text).not.toContain("skill://ops#blue");
+	});
+
 	it("does not expose hidden skills through model search", async () => {
 		const tool = makeTool([skill("secret-workflow", "Private workflow", true)]);
 

--- a/packages/coding-agent/test/skill-search.test.ts
+++ b/packages/coding-agent/test/skill-search.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { Skill } from "../src/extensibility/skills";
+import type { ToolSession } from "../src/tools";
+import { SkillSearchTool } from "../src/tools/skill-search";
+
+function skill(name: string, description: string, hide = false): Skill {
+	return {
+		name,
+		description,
+		filePath: `/skills/${name}/SKILL.md`,
+		baseDir: `/skills/${name}`,
+		source: "test",
+		hide,
+	};
+}
+
+function makeTool(skills: readonly Skill[]): SkillSearchTool {
+	return new SkillSearchTool({ skills } as ToolSession);
+}
+
+function textOf(result: AgentToolResult): string {
+	return result.content.find(part => part.type === "text")?.text ?? "";
+}
+
+describe("skill_search tool", () => {
+	it("returns ranked metadata and skill URLs without loading skill bodies", async () => {
+		const tool = makeTool([
+			skill("frontend-design", "Design polished interfaces"),
+			skill("react-testing", "Test React components with Vitest"),
+			skill("postgres", "Design and tune PostgreSQL schemas"),
+		]);
+
+		const result = await tool.execute("call-1", { query: "react testing" });
+		const text = textOf(result);
+
+		expect(text).toContain("skill://react-testing");
+		expect(text).toContain("Test React components with Vitest");
+		expect(text).toContain("Use read with skill://react-testing");
+		expect(text).not.toContain("frontend-design");
+		expect(text).not.toContain("# full skill body");
+	});
+
+	it("does not expose hidden skills through model search", async () => {
+		const tool = makeTool([skill("secret-workflow", "Private workflow", true)]);
+
+		const result = await tool.execute("call-2", { query: "secret workflow" });
+
+		expect(textOf(result)).toBe("No matching skills found.");
+		expect(result.useless).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -6,6 +6,7 @@ import { type Skill as CapabilitySkill, skillCapability } from "@oh-my-pi/pi-cod
 import { getCapability } from "@oh-my-pi/pi-coding-agent/discovery";
 import { getWslWindowsHomeCandidate, runHostProbe } from "@oh-my-pi/pi-coding-agent/discovery/agents";
 import {
+	filterSkillsForPrompt,
 	type LoadSkillsResult,
 	loadSkills,
 	loadSkillsFromDir,
@@ -46,6 +47,48 @@ const DISABLE_ALL_BUILTIN_SKILLS = {
 } as const;
 
 describe("skills", () => {
+	function makeSkill(name: string, description: string, source: string, hide = false): Skill {
+		return {
+			name,
+			description,
+			filePath: `/tmp/${name}/SKILL.md`,
+			baseDir: `/tmp/${name}`,
+			source,
+			hide,
+		};
+	}
+
+	describe("skill prompt filtering", () => {
+		it("keeps native agent-directory skills in core mode", () => {
+			const skills = [
+				makeSkill("native-skill", "Native workflow", "native"),
+				makeSkill("agents-skill", "Agent-directory workflow", "agents"),
+				makeSkill("managed-skill", "Managed workflow", "omp-managed"),
+				makeSkill("local-skill", "Local workflow", "test"),
+			];
+
+			expect(filterSkillsForPrompt(skills, { promptMode: "core" }).map(skill => skill.name)).toEqual([
+				"native-skill",
+				"agents-skill",
+				"managed-skill",
+			]);
+			expect(skills).toHaveLength(4);
+		});
+
+		it("matches allowlisted skill names with globs", () => {
+			const skills = [
+				makeSkill("frontend-design", "UI", "test"),
+				makeSkill("frontend-testing", "Tests", "test"),
+				makeSkill("backend-design", "API", "test"),
+			];
+
+			expect(
+				filterSkillsForPrompt(skills, { promptMode: "allowlist", promptSkills: ["frontend-*"] }).map(
+					skill => skill.name,
+				),
+			).toEqual(["frontend-design", "frontend-testing"]);
+		});
+	});
 	describe("loadSkillsFromDir", () => {
 		let fixtureRoot: LoadSkillsResult;
 

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -609,6 +609,95 @@ describe("system prompt tool inventory", () => {
 
 		expect(text).toContain("- prompt-authoring: Prompt authoring workflow");
 	});
+	it("limits the system prompt to OMP-owned skills in core mode", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [
+				{
+					name: "omp-native",
+					description: "OMP-native workflow",
+					filePath: path.join(tempDir, "omp-native", "SKILL.md"),
+					baseDir: path.join(tempDir, "omp-native"),
+					source: "native:user",
+					_source: {
+						provider: "native",
+						providerName: "OMP",
+						path: path.join(tempDir, "omp-native", "SKILL.md"),
+						level: "user",
+					},
+				},
+				{
+					name: "managed-workflow",
+					description: "Managed workflow",
+					filePath: path.join(tempDir, "managed-workflow", "SKILL.md"),
+					baseDir: path.join(tempDir, "managed-workflow"),
+					source: "omp-managed:user",
+					_source: {
+						provider: "omp-managed",
+						providerName: "Managed Skills",
+						path: path.join(tempDir, "managed-workflow", "SKILL.md"),
+						level: "user",
+					},
+				},
+				{
+					name: "claude-workflow",
+					description: "Claude workflow",
+					filePath: path.join(tempDir, "claude-workflow", "SKILL.md"),
+					baseDir: path.join(tempDir, "claude-workflow"),
+					source: "claude:user",
+					_source: {
+						provider: "claude",
+						providerName: "Claude Code",
+						path: path.join(tempDir, "claude-workflow", "SKILL.md"),
+						level: "user",
+					},
+				},
+			],
+			rules: [],
+			toolNames: ["read"],
+			tools: TOOLS,
+			skillsSettings: { promptMode: "core" },
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+		});
+		const text = systemPrompt.join("\n\n");
+
+		expect(text).toContain("omp-native");
+		expect(text).toContain("managed-workflow");
+		expect(text).not.toContain("claude-workflow");
+	});
+
+	it("limits the system prompt to configured skill patterns in allowlist mode", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [
+				{
+					name: "research-web",
+					description: "Research workflow",
+					filePath: path.join(tempDir, "research-web", "SKILL.md"),
+					baseDir: path.join(tempDir, "research-web"),
+					source: "native:user",
+				},
+				{
+					name: "frontend-design",
+					description: "Frontend workflow",
+					filePath: path.join(tempDir, "frontend-design", "SKILL.md"),
+					baseDir: path.join(tempDir, "frontend-design"),
+					source: "native:user",
+				},
+			],
+			rules: [],
+			toolNames: ["read"],
+			tools: TOOLS,
+			skillsSettings: { promptMode: "allowlist", promptSkills: ["research-*"] },
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+		});
+		const text = systemPrompt.join("\n\n");
+
+		expect(text).toContain("research-web");
+		expect(text).not.toContain("frontend-design");
+	});
 
 	it("omits skills when active tool names exclude read", async () => {
 		const { systemPrompt } = await buildSystemPrompt({

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -148,6 +148,22 @@ describe("createTools", () => {
 		expect(names).toEqual(["read", "write"]);
 	});
 
+	it("gates skill search on the skill setting and read access", async () => {
+		const withoutRead = await createTools(createTestSession(), ["skill_search"]);
+		expect(withoutRead.map(tool => tool.name)).toEqual([]);
+
+		const withRead = await createTools(createTestSession(), ["skill_search", "read"]);
+		expect(withRead.map(tool => tool.name)).toEqual(["skill_search", "read"]);
+
+		const disabled = await createTools(
+			createTestSession({
+				settings: createSettingsWithOverrides({ "skills.enabled": false }),
+			}),
+			["skill_search", "read"],
+		);
+		expect(disabled.map(tool => tool.name)).toEqual(["read"]);
+	});
+
 	it("creates xd:// presentation state without remounting explicitly requested built-ins", async () => {
 		const session = createTestSession();
 		const tools = await createTools(session, ["read", "lsp", "write"]);


### PR DESCRIPTION
## What

- Add prompt-scoped skill exposure modes: `all`, `core`, and config-driven `allowlist`.
- Add a discoverable `skill_search` tool that searches loaded skill metadata and returns resolvable `skill://` URLs.
- Keep prompt filtering and context-token accounting on the same selector.
- Reconcile `skill_search` on live `skills.enabled` changes, serialize concurrent skill reloads, preserve provider skills in core mode, and encode reserved skill-name characters.

## Why

Large skill catalogs currently consume prompt space even when only a small subset is relevant. This keeps full discovery and explicit `skill://` loading while allowing bounded prompt exposure and local metadata search.

Positioning against the published frontier: JIT-Agent ([arXiv:2608.25593](https://arxiv.org/abs/2608.25593)) formalizes the agent harness as a four-module protocol and shows learned per-task capability orchestration is worth +7.7 to +8.8 points on average across GLM-5.2/DeepSeek backbones. This PR is the deterministic, zero-inference end of that same axis: the capability-orchestration (F) module expressed as bounded prompt exposure plus metadata search — a foundation a learned orchestrator can sit on top of, with no model requirement of its own.

## Testing

- `bun run check`
- Focused routing suite: 173 passed, 5 skipped, 0 failed

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)