### PR TITLE
fix(ai): honor [DONE] sentinel as clean completion in openai-completions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible completions hosts that stream content then terminate with the `[DONE]` sentinel while omitting (or `null`ing) `finish_reason` failing every turn with `OpenAI completions stream closed before a finish_reason was received`; a `[DONE]`-terminated stream now finalizes as a clean stop and only a genuine transport EOF (no `[DONE]`, no finish reason) surfaces the incomplete-stream error ([#9433](https://github.com/can1357/oh-my-pi/issues/9433)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Changed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -603,26 +603,31 @@ const streamOpenAICompletionsOnce = (
 		);
 		const { requestAbortController, requestSignal } = abortTracker;
 		const onSseEvent = options?.onSseEvent;
-		const rawSseObserver = onSseEvent
-			? (event: RawSseEvent) => {
-					if (!event.event && event.data && event.data !== "[DONE]") {
-						try {
-							const parsed = JSON.parse(event.data);
-							const resolvedEvent =
-								typeof parsed.type === "string"
-									? parsed.type
-									: typeof parsed.object === "string"
-										? parsed.object
-										: null;
-							if (resolvedEvent) {
-								event.event = resolvedEvent;
-								event.raw = [`event: ${resolvedEvent}`, ...event.raw];
-							}
-						} catch {}
-					}
-					onSseEvent(event, model);
+		// Track the OpenAI `[DONE]` sentinel independently of `onSseEvent`: it is
+		// the streaming protocol's terminal signal, so a stream that ends with it
+		// completed by server agreement even when no `finish_reason` chunk arrived.
+		let sawDoneSentinel = false;
+		const rawSseObserver = (event: RawSseEvent) => {
+			if (event.data === "[DONE]") sawDoneSentinel = true;
+			if (onSseEvent) {
+				if (!event.event && event.data && event.data !== "[DONE]") {
+					try {
+						const parsed = JSON.parse(event.data);
+						const resolvedEvent =
+							typeof parsed.type === "string"
+								? parsed.type
+								: typeof parsed.object === "string"
+									? parsed.object
+									: null;
+						if (resolvedEvent) {
+							event.event = resolvedEvent;
+							event.raw = [`event: ${resolvedEvent}`, ...event.raw];
+						}
+					} catch {}
 				}
-			: undefined;
+				onSseEvent(event, model);
+			}
+		};
 		// Assigned once the block helpers exist (they are scoped to the `try`);
 		// the catch handler uses it to close open blocks before emitting the
 		// terminal error so both exit paths obey the same block lifecycle.
@@ -1301,7 +1306,15 @@ const streamOpenAICompletionsOnce = (
 			// Detect premature stream closure before the normal block-finalization
 			// sweep. Throwing after that sweep would make the error handler emit a
 			// second text_end/thinking_end for the same partial block.
-			if (streamFinishedAt === undefined && output.content.length > 0) {
+			//
+			// Only a genuine truncation — transport EOF with neither a
+			// `finish_reason` chunk nor the `[DONE]` sentinel — is incomplete. A
+			// stream terminated by `[DONE]` completed by server agreement; some
+			// OpenAI-compatible hosts omit or `null` the `finish_reason` and rely on
+			// `[DONE]` alone, so finalize those as the default `stop`
+			// (mapStopReason(null)) instead of surfacing a false incomplete-stream
+			// error and retrying every turn.
+			if (streamFinishedAt === undefined && !sawDoneSentinel && output.content.length > 0) {
 				throw new AIError.ProviderResponseError(
 					"OpenAI completions stream closed before a finish_reason was received",
 					{ provider: model.provider, kind: "incomplete-stream" },

--- a/packages/ai/test/issue-9433-repro.test.ts
+++ b/packages/ai/test/issue-9433-repro.test.ts
@@ -44,27 +44,30 @@ async function run(frames: readonly unknown[]) {
 describe("issue #9433 — [DONE]-terminated completions without finish_reason", () => {
 	// Each shape is a real OpenAI-compatible host behavior that previously threw
 	// incomplete-stream; all three reach `[DONE]` and must finalize as a clean stop.
-	const doneTerminated: readonly (readonly [string, readonly unknown[]])[] = [
+	const doneTerminated: readonly (readonly [string, readonly unknown[], string])[] = [
 		[
 			"no terminal finish chunk, just [DONE]",
 			[{ choices: [{ delta: { content: "Hel" } }] }, { choices: [{ delta: { content: "lo" } }] }, "[DONE]"],
+			"Hello",
 		],
 		[
 			"trailing finish_reason:null then [DONE]",
 			[{ choices: [{ delta: { content: "Hel" } }] }, { choices: [{ delta: {}, finish_reason: null }] }, "[DONE]"],
+			"Hel",
 		],
 		[
 			"trailing empty choices:[] then [DONE]",
 			[{ choices: [{ delta: { content: "Hel" } }] }, { choices: [] }, "[DONE]"],
+			"Hel",
 		],
 	];
 
-	for (const [label, frames] of doneTerminated) {
+	for (const [label, frames, expectedText] of doneTerminated) {
 		it(`finalizes as a clean stop with content preserved (${label})`, async () => {
 			const result = await run(frames);
 			expect(result.stopReason).toBe("stop");
 			expect(result.errorMessage).toBeUndefined();
-			expect(result.text.length).toBeGreaterThan(0);
+			expect(result.text).toBe(expectedText);
 		});
 	}
 

--- a/packages/ai/test/issue-9433-repro.test.ts
+++ b/packages/ai/test/issue-9433-repro.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// Issue #9433: the openai-completions consumer threw
+// `OpenAI completions stream closed before a finish_reason was received` whenever
+// a stream ended after emitting content without a truthy `finish_reason`. Many
+// OpenAI-compatible hosts stream content, then terminate with the `[DONE]`
+// sentinel while omitting (or `null`ing) `finish_reason`. `[DONE]` is the
+// streaming protocol's terminal signal, so those turns completed by server
+// agreement and must finalize cleanly; only a genuine transport EOF (no `[DONE]`)
+// is a truncated/incomplete stream.
+
+const model = buildModel({
+	id: "test-model",
+	name: "Test",
+	api: "openai-completions",
+	provider: "litellm",
+	baseUrl: "http://127.0.0.1:4000/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 100_000,
+	maxTokens: 8_000,
+});
+
+const context: Context = { messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+
+function fetchFor(frames: readonly unknown[]): FetchImpl {
+	const body = frames.map(f => `data: ${typeof f === "string" ? f : JSON.stringify(f)}\n\n`).join("");
+	return Object.assign(
+		async (): Promise<Response> => new Response(body, { headers: { "content-type": "text/event-stream" } }),
+		{ preconnect: fetch.preconnect },
+	);
+}
+
+async function run(frames: readonly unknown[]) {
+	const msg = await streamOpenAICompletions(model, context, { apiKey: "k", fetch: fetchFor(frames) }).result();
+	const text = msg.content.reduce((acc, block) => (block.type === "text" ? acc + block.text : acc), "");
+	return { stopReason: msg.stopReason, errorMessage: msg.errorMessage, text };
+}
+
+describe("issue #9433 — [DONE]-terminated completions without finish_reason", () => {
+	// Each shape is a real OpenAI-compatible host behavior that previously threw
+	// incomplete-stream; all three reach `[DONE]` and must finalize as a clean stop.
+	const doneTerminated: readonly (readonly [string, readonly unknown[]])[] = [
+		[
+			"no terminal finish chunk, just [DONE]",
+			[{ choices: [{ delta: { content: "Hel" } }] }, { choices: [{ delta: { content: "lo" } }] }, "[DONE]"],
+		],
+		[
+			"trailing finish_reason:null then [DONE]",
+			[{ choices: [{ delta: { content: "Hel" } }] }, { choices: [{ delta: {}, finish_reason: null }] }, "[DONE]"],
+		],
+		[
+			"trailing empty choices:[] then [DONE]",
+			[{ choices: [{ delta: { content: "Hel" } }] }, { choices: [] }, "[DONE]"],
+		],
+	];
+
+	for (const [label, frames] of doneTerminated) {
+		it(`finalizes as a clean stop with content preserved (${label})`, async () => {
+			const result = await run(frames);
+			expect(result.stopReason).toBe("stop");
+			expect(result.errorMessage).toBeUndefined();
+			expect(result.text.length).toBeGreaterThan(0);
+		});
+	}
+
+	it("promotes a [DONE]-terminated tool-call turn without finish_reason to toolUse", async () => {
+		const msg = await streamOpenAICompletions(model, context, {
+			apiKey: "k",
+			fetch: fetchFor([
+				{
+					choices: [
+						{
+							delta: {
+								tool_calls: [{ index: 0, id: "call_1", function: { name: "foo", arguments: '{"a":1}' } }],
+							},
+						},
+					],
+				},
+				"[DONE]",
+			]),
+		}).result();
+		expect(msg.stopReason).toBe("toolUse");
+		expect(msg.errorMessage).toBeUndefined();
+		expect(msg.content.some(block => block.type === "toolCall")).toBe(true);
+	});
+
+	it("still surfaces incomplete-stream on a genuine EOF (no [DONE], no finish_reason)", async () => {
+		const result = await run([
+			{ choices: [{ delta: { content: "Hel" } }] },
+			{ choices: [{ delta: { content: "lo" } }] },
+		]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("OpenAI completions stream closed before a finish_reason was received");
+	});
+});


### PR DESCRIPTION
## Repro
A mocked-`fetch` harness feeds SSE payloads through `streamOpenAICompletions` and reads the resolved `stopReason`. Any OpenAI-compatible host that streams content and then terminates with `data: [DONE]` while omitting or `null`ing `finish_reason` resolves to `stopReason: "error"` with `OpenAI completions stream closed before a finish_reason was received`; only a genuine transport EOF (no `[DONE]`) is a real truncation.

```
bun test packages/ai/test/issue-9433-repro.test.ts
```

## Cause
`streamOpenAICompletionsOnce` in `packages/ai/src/providers/openai-completions.ts` flips `streamFinishedAt` only on a truthy `choice.finish_reason`. The post-loop guard then threw `ProviderResponseError { kind: "incomplete-stream" }` whenever `streamFinishedAt === undefined && output.content.length > 0`, without distinguishing a `[DONE]`-terminated stream (server-agreed completion) from a real transport EOF. `readSseJson` returns on both `[DONE]` and EOF, so the consumer had no completion signal — and the existing `mapStopReason(null) => "stop"` branch was dead code, confirming a `null`/omitted finish on an otherwise-complete stream was meant to be a clean stop.

## Fix
- Track the `[DONE]` sentinel in an always-installed SSE observer (`sawDoneSentinel`), independent of the caller's `onSseEvent`.
- The guard now raises incomplete-stream only when `[DONE]` was NOT observed (genuine EOF); a `[DONE]`-terminated stream falls through to normal finalization and keeps the default `stop`. Tool-call turns still promote to `toolUse`.
- Added `packages/ai/test/issue-9433-repro.test.ts` covering the three `[DONE]`-terminated wire shapes (no finish chunk / trailing `finish_reason: null` / trailing empty `choices: []`), the tool-call promotion, and the retained genuine-EOF error; changelog entry.

## Verification
`bun test packages/ai/test/issue-9433-repro.test.ts` → 5 pass. `bun run --filter '@oh-my-pi/pi-ai' check` → clean (tsgo types + biome). Full `bun test` in `packages/ai`: only pre-existing unrelated failures (`proxy.test.ts` env-ordering, `issue-6276` Bedrock 5s timeout), both pass in isolation. Skipped pre-publish gate (`skip_checks=true`): `bun check`/`bun run fix` fail on `check:rs`/`fix:rs` because the `cmake` binary is absent from this environment (`failed to execute command: No such file or directory ... is cmake not installed?`) — a branch-independent toolchain gap, and this diff is TypeScript-only. Fixes #9433