### PR TITLE
fix(ai): exempt DeepSeek vision SKUs from text-only image guard

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed DeepSeek vision SKUs (`deepseek-v4-flash-vision-exp`, any `-vision-` id) losing image input after the text-only DeepSeek guard: genuinely multimodal ids now keep `image_url` parts while text-only DeepSeek endpoints still strip them.
+
 
 ## [18.0.1] - 2026-08-23
 

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -4,6 +4,10 @@ import { isDeepseekModelIdOrName, isQwenModelId } from "@oh-my-pi/pi-catalog/ide
 import type { ImageContent, Model, TextContent } from "../types";
 
 export const NON_VISION_IMAGE_PLACEHOLDER = "[image omitted: model does not support vision]";
+// `vision` delimited by non-alphanumerics, so `deepseek-v4-flash-vision-exp`
+// and `deepseek_vision` match but `deepseek-r1-revision-0528` does not.
+// Inputs are lowercased before testing.
+const VISION_TOKEN = /(?<![a-z0-9])vision(?![a-z0-9])/;
 
 export function partitionVisionContent(
 	content: ReadonlyArray<TextContent | ImageContent>,
@@ -79,9 +83,10 @@ export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean 
 	const name = (model.name ?? "").toLowerCase();
 	// DeepSeek OCR and the multimodal vision SKUs (deepseek-v4-flash-vision-exp,
 	// future -vision- ids) genuinely accept image_url parts; same marker as the
-	// catalog's deepseek mapModel heuristic.
+	// catalog's deepseek mapModel heuristic. `vision` must be a bounded token:
+	// `revision` contains it as a substring and must stay guarded.
 	if (id.includes("deepseek-ocr") || name.includes("deepseek-ocr")) return false;
-	if (id.includes("vision") || name.includes("vision")) return false;
+	if (VISION_TOKEN.test(id) || VISION_TOKEN.test(name)) return false;
 	return (
 		modelMatchesHost(model, "deepseekFamily") ||
 		isDeepseekModelIdOrName(model.id) ||

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -77,8 +77,11 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean {
 	const id = model.id.toLowerCase();
 	const name = (model.name ?? "").toLowerCase();
-	// DeepSeek OCR is a genuinely multimodal model served by Novita.
+	// DeepSeek OCR and the multimodal vision SKUs (deepseek-v4-flash-vision-exp,
+	// future -vision- ids) genuinely accept image_url parts; same marker as the
+	// catalog's deepseek mapModel heuristic.
 	if (id.includes("deepseek-ocr") || name.includes("deepseek-ocr")) return false;
+	if (id.includes("vision") || name.includes("vision")) return false;
 	return (
 		modelMatchesHost(model, "deepseekFamily") ||
 		isDeepseekModelIdOrName(model.id) ||

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -450,6 +450,8 @@ describe("openai-completions convertMessages", () => {
 			{ id: "deepseek-chat", provider: "deepseek", baseUrl: "https://api.deepseek.com" },
 			{ id: "deepseek-reasoner", provider: "deepseek", baseUrl: "https://api.deepseek.com" },
 			{ id: "deepseek-ai/DeepSeek-V4-Pro", provider: "custom-proxy", baseUrl: "https://llm-proxy.example.com/v1" },
+			// `vision` inside `revision` is a substring, not a multimodal token.
+			{ id: "deepseek-r1-revision-0528", provider: "custom-proxy", baseUrl: "https://llm-proxy.example.com/v1" },
 		];
 
 		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -452,6 +452,8 @@ describe("openai-completions convertMessages", () => {
 			{ id: "deepseek-ai/DeepSeek-V4-Pro", provider: "custom-proxy", baseUrl: "https://llm-proxy.example.com/v1" },
 			// `vision` inside `revision` is a substring, not a multimodal token.
 			{ id: "deepseek-r1-revision-0528", provider: "custom-proxy", baseUrl: "https://llm-proxy.example.com/v1" },
+			// `vision` inside `provisioned` is a substring, not a multimodal token.
+			{ id: "deepseek-v4-provisioned", provider: "custom-proxy", baseUrl: "https://llm-proxy.example.com/v1" },
 		];
 
 		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
@@ -551,18 +553,8 @@ describe("openai-completions convertMessages", () => {
 	});
 	it("preserves image_url for the multimodal DeepSeek vision SKU", () => {
 		// deepseek-v4-flash-vision-exp is genuinely multimodal: the blanket
-		// DeepSeek text-only guard must not strip its image parts. Built inline
-		// because the bundled catalog does not carry the SKU yet.
-		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
-		const model: Model<"openai-completions"> = {
-			...baseModel,
-			id: "deepseek-v4-flash-vision-exp",
-			name: "DeepSeek V4 Flash Vision Exp",
-			provider: "deepseek" as Model<"openai-completions">["provider"],
-			baseUrl: "https://api.deepseek.com",
-			api: "openai-completions",
-			input: ["text", "image"],
-		};
+		// DeepSeek text-only guard must not strip its image parts.
+		const model = getBundledModel("deepseek", "deepseek-v4-flash-vision-exp") as Model<"openai-completions">;
 		const context: Context = {
 			messages: [
 				{

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -547,4 +547,42 @@ describe("openai-completions convertMessages", () => {
 			},
 		]);
 	});
+	it("preserves image_url for the multimodal DeepSeek vision SKU", () => {
+		// deepseek-v4-flash-vision-exp is genuinely multimodal: the blanket
+		// DeepSeek text-only guard must not strip its image parts. Built inline
+		// because the bundled catalog does not carry the SKU yet.
+		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			id: "deepseek-v4-flash-vision-exp",
+			name: "DeepSeek V4 Flash Vision Exp",
+			provider: "deepseek" as Model<"openai-completions">["provider"],
+			baseUrl: "https://api.deepseek.com",
+			api: "openai-completions",
+			input: ["text", "image"],
+		};
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Describe this image" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].content).toEqual([
+			{ type: "text", text: "Describe this image" },
+			{
+				type: "image_url",
+				image_url: { url: "data:image/png;base64,ZmFrZQ==" },
+			},
+		]);
+	});
 });


### PR DESCRIPTION
## Problem

`isTextOnlyDeepSeek()` in `packages/ai/src/providers/vision-guard.ts` classifies **every** DeepSeek model as text-only (only `deepseek-ocr` is exempted), so `isOpenAICompletionsVisionSupported()` returns `false` even for genuinely multimodal SKUs. `convertMessages` in `openai-completions` then strips `image_url` parts and injects `[image omitted: model does not support vision]`.

`deepseek-v4-flash-vision-exp` is DeepSeek's multimodal vision SKU (official [Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing) page: images billed as input tokens; [models.dev](https://models.dev) and stencil.so now list it under the `deepseek` provider with `modalities.input: ["text","image"]`, reasoning, 1M/384K). Any user-configured entry (e.g. `models.yml` with `input: [text, image]`) — and the catalog row once the next `gen:models` picks it up — hits the blanket guard and silently loses all image input.

Repro (pre-fix):

```ts
const model = buildModel({ id: "deepseek-v4-flash-vision-exp", input: ["text","image"], provider: "deepseek", ... });
isOpenAICompletionsVisionSupported(model); // false -> images stripped
```

## Fix

Exempt genuinely multimodal DeepSeek SKUs in `isTextOnlyDeepSeek` by the `vision` token in id/name — the same marker the catalog's deepseek `mapModel` heuristic uses, mirroring the existing `deepseek-ocr` exemption. Text-only DeepSeek SKUs (`deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-pro`, `deepseek-v4-flash`, proxied `deepseek-ai/*`) still strip `image_url` exactly as before, so the HTTP-400 protection from #9236's guard is unchanged.

## Testing

- New regression test in `openai-completions-tool-result-images.test.ts`: a `deepseek-v4-flash-vision-exp` model keeps its `image_url` parts through `convertMessages` (built inline — the bundled catalog does not carry the SKU yet).
- Existing guard tests still pass: text-only DeepSeek ids strip images, OCR/Qwen/Ollama counter-cases unchanged (24/24 across the three vision-guard test files).
- biome clean on changed files.