### PR TITLE
feat(status-line): opt-in provider prefix for the model segment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Status line model segment can prefix the active provider (`statusLine.segmentOptions.model.showProvider`), telling apart identical model names served through different providers/gateways. Off by default.
+
 ## [18.0.1] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -121,6 +121,12 @@ const modelSegment: StatusLineSegment = {
 		if (modelName.startsWith("Claude ")) {
 			modelName = modelName.slice(7);
 		}
+		// Prefix the provider on opt-in: gateways and proxies expose the same
+		// model name under different providers, and the bare name cannot tell
+		// which one is actually serving the session.
+		if (opts.showProvider && state.model?.provider) {
+			modelName = `${state.model.provider}/${modelName}`;
+		}
 
 		// Resolve the current thinking-level display ("◉ xhigh", "⟳ auto", …)
 		// when the model supports thinking and the segment isn't hiding it.

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -20,7 +20,7 @@ export interface CollabStatus {
 }
 
 export interface StatusLineSegmentOptions {
-	model?: { showThinkingLevel?: boolean };
+	model?: { showThinkingLevel?: boolean; showProvider?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -8,10 +8,14 @@ beforeAll(async () => {
 	await initTheme();
 });
 
-function createModelContext(advisorActive: boolean): SegmentContext {
+function createModelContext(
+	advisorActive: boolean,
+	model: { id: string; name: string; provider?: string } = { id: "test-model", name: "Test Model" },
+	options: SegmentContext["options"] = {},
+): SegmentContext {
 	return {
 		session: {
-			state: { model: { id: "test-model", name: "Test Model" } },
+			state: { model },
 			isFastModeActive: () => false,
 			isAutoThinking: false,
 			autoResolvedThinkingLevel: () => undefined,
@@ -23,7 +27,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		} as unknown as SegmentContext["session"],
 		width: 120,
 		compactThinkingLevel: false,
-		options: {},
+		options,
 		planMode: null,
 		loopMode: null,
 		prewalk: null,
@@ -57,6 +61,34 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		usage: null,
 	};
 }
+
+describe("status line model segment provider prefix", () => {
+	it("stays off by default even when the model carries a provider", () => {
+		const ctx = createModelContext(false, { id: "gpt-5.5", name: "GPT-5.5", provider: "qg-gateway" });
+		expect(Bun.stripANSI(renderSegment("model", ctx).content)).not.toContain("qg-gateway/");
+	});
+
+	it("distinguishes identical model names from different providers when opted in", () => {
+		const opts = { model: { showProvider: true } };
+		const qg = createModelContext(false, { id: "gpt-5.5", name: "GPT-5.5", provider: "qg-gateway" }, opts);
+		const official = createModelContext(false, { id: "gpt-5.5", name: "GPT-5.5", provider: "openai-codex" }, opts);
+
+		const qgContent = Bun.stripANSI(renderSegment("model", qg).content);
+		const officialContent = Bun.stripANSI(renderSegment("model", official).content);
+		expect(qgContent).toContain("qg-gateway/GPT-5.5");
+		expect(officialContent).toContain("openai-codex/GPT-5.5");
+		expect(qgContent).not.toBe(officialContent);
+	});
+
+	it("leaves a provider-less model untouched when opted in", () => {
+		const ctx = createModelContext(
+			false,
+			{ id: "test-model", name: "Test Model" },
+			{ model: { showProvider: true } },
+		);
+		expect(Bun.stripANSI(renderSegment("model", ctx).content)).toContain("Test Model");
+	});
+});
 
 describe("status line model segment advisor badge", () => {
 	it("appends a success-colored advisor symbol when all advisors run", () => {


### PR DESCRIPTION
Gateways and proxies frequently serve a model under the same display name as the official provider, and the model segment only renders the bare name — the status line cannot tell which provider is actually serving the session.

This adds `statusLine.segmentOptions.model.showProvider` (default off). When enabled and the active model carries a provider id, the segment renders `provider/ModelName`. Provider-less models and non-opted-in status lines render exactly as before.

## Verification
- `bun test test/status-line` — 173 pass / 0 fail across 16 files
- negative control: with the segment change stashed, the new opt-in test fails (1 fail), proving it guards the behavior
- `bun run check:ts` — clean
- biome — clean
