### PR TITLE
fix(edit): restore diff result colors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### Fixed
 
+- Restored red/green and syntax highlighting in edit-tool result bodies ([#9439](https://github.com/can1357/oh-my-pi/issues/9439)).
+
 - Fixed UI jitter in the edit tool gutter by reserving space for line counts
 - Edit-tool add lines written directly above a `` gap now insert under their anchor line instead of splicing at the post-gap anchor, often mid-line without a newline.
 - Edit-tool add lines may contain literal selection-marker glyphs; such payloads previously failed with an unusable corrected payload.

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -171,10 +171,6 @@ export interface EditRenderContext {
 
 const EDIT_STREAMING_PREVIEW_LINES = 12;
 
-function plainDiffRender(diffText: string): string {
-	return diffText;
-}
-
 /**
  * Lazily grown per-file preview cache slots: the file count of a streaming
  * multi-file patch is discovered mid-stream, so a fixed-size array would
@@ -1005,7 +1001,7 @@ function renderSingleFileResult(
 		// for an empty-diff delete/move/no-op result mislabels the card. Fall
 		// back to the preview only when no details exist yet.
 		const editDiffPreview = details ? undefined : renderContext?.editDiffPreview;
-		const renderDiffFn = renderContext?.renderDiff ?? plainDiffRender;
+		const renderDiffFn = renderContext?.renderDiff ?? renderDiffColored;
 
 		if (diffSectionRenderDiffFn !== renderDiffFn) {
 			diffSectionRenderDiffFn = renderDiffFn;

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -483,7 +483,7 @@ function formatStreamingDiff(
 			// which would make every streaming update scale with the complete diff.
 			rendered += `${uiTheme.fg("dim", "… (content above)")}\n`;
 		}
-		rendered += renderDiffColored(tail.content, { filePath: rawPath });
+		rendered += renderDiffColored(tail.content, { filePath: rawPath, theme: uiTheme });
 		return rendered;
 	});
 	// The animated glyph rides this trailing line — inside the transcript's
@@ -794,9 +794,9 @@ function wrapEditRendererLine(line: string, width: number): string[] {
 	// Gutter shapes produced by formatCodeFrameLine: "-315│", " 313│", "+322│",
 	// plus the deduplicated forms "   +│" and "    │" whose repeated line number
 	// renderDiff blanked (single-line replacement pairs and insert-then-context
-	// runs) — all │-separated. ASCII "|" gutters exist only in raw canonical
-	// diff rows passed through by the plain fallback ("-42|old", " 42|ctx"),
-	// which always carry a marker column ("+"/"-"/space) and a line number. So
+	// runs) — all │-separated. ASCII "|" gutters may arrive from injected
+	// renderers that preserve raw canonical rows; those always carry a marker
+	// column ("+"/"-"/space) and a line number. So
 	// the number is optional for "│", while "|" requires the full canonical
 	// shape; anything else (a body line merely starting with "|", error text
 	// like "123|…") is not a diff row and wraps generically.
@@ -988,6 +988,9 @@ function renderSingleFileResult(
 		return renderInlineEditRow(uiTheme, { op, rename, rawPath, linkPath, pending: false });
 	}
 
+	const renderFallbackDiff = (diffText: string, diffOptions?: { filePath?: string }): string =>
+		renderDiffColored(diffText, { filePath: diffOptions?.filePath, theme: uiTheme });
+
 	let diffSectionRenderDiffFn: ((t: string, o?: { filePath?: string }) => string) | undefined;
 	const diffSectionCache = createRenderedStringCache();
 	const renderedDiffCache = createRenderedStringCache();
@@ -1001,7 +1004,7 @@ function renderSingleFileResult(
 		// for an empty-diff delete/move/no-op result mislabels the card. Fall
 		// back to the preview only when no details exist yet.
 		const editDiffPreview = details ? undefined : renderContext?.editDiffPreview;
-		const renderDiffFn = renderContext?.renderDiff ?? renderDiffColored;
+		const renderDiffFn = renderContext?.renderDiff ?? renderFallbackDiff;
 
 		if (diffSectionRenderDiffFn !== renderDiffFn) {
 			diffSectionRenderDiffFn = renderDiffFn;

--- a/packages/coding-agent/src/modes/components/diff.ts
+++ b/packages/coding-agent/src/modes/components/diff.ts
@@ -1,6 +1,6 @@
 import { diffWords } from "@oh-my-pi/pi-natives";
 import { DEFAULT_TAB_WIDTH, sanitizeText } from "@oh-my-pi/pi-utils";
-import { getLanguageFromPath, highlightCode, theme } from "../../modes/theme/theme";
+import { theme as activeTheme, getLanguageFromPath, highlightCode, type Theme } from "../../modes/theme/theme";
 import { type CodeFrameMarker, formatCodeFrameLine, replaceTabs } from "../../tools/render-utils";
 
 /** SGR dim on / normal intensity — additive, preserves fg/bg colors. */
@@ -52,7 +52,11 @@ function parseDiffLine(line: string): { prefix: CodeFrameMarker; lineNum: string
  * Uses diffWords which groups whitespace with adjacent words for cleaner highlighting.
  * Strips leading whitespace from inverse to avoid highlighting indentation.
  */
-function renderIntraLineDiff(oldContent: string, newContent: string): { removedLine: string; addedLine: string } {
+function renderIntraLineDiff(
+	oldContent: string,
+	newContent: string,
+	renderTheme: Theme,
+): { removedLine: string; addedLine: string } {
 	const wordDiff = diffWords(oldContent, newContent);
 
 	let removedLine = "";
@@ -71,7 +75,7 @@ function renderIntraLineDiff(oldContent: string, newContent: string): { removedL
 				isFirstRemoved = false;
 			}
 			if (value) {
-				removedLine += theme.inverse(value);
+				removedLine += renderTheme.inverse(value);
 			}
 		} else if (part.added) {
 			let value = part.value;
@@ -83,7 +87,7 @@ function renderIntraLineDiff(oldContent: string, newContent: string): { removedL
 				isFirstAdded = false;
 			}
 			if (value) {
-				addedLine += theme.inverse(value);
+				addedLine += renderTheme.inverse(value);
 			}
 		} else {
 			removedLine += part.value;
@@ -97,6 +101,8 @@ function renderIntraLineDiff(oldContent: string, newContent: string): { removedL
 export interface RenderDiffOptions {
 	/** File path used to resolve indentation (.editorconfig + defaults) */
 	filePath?: string;
+	/** Theme used for diff colors and syntax highlighting; defaults to the active TUI theme. */
+	theme?: Theme;
 }
 
 /**
@@ -106,6 +112,7 @@ export interface RenderDiffOptions {
  * - Added lines: green, with inverse on changed tokens
  */
 export function renderDiff(diffText: string, options: RenderDiffOptions = {}): string {
+	const renderTheme = options.theme ?? activeTheme;
 	const lines = sanitizeText(diffText).split("\n");
 	const result: string[] = [];
 	const parsedLines = lines.map(parseDiffLine);
@@ -123,7 +130,7 @@ export function renderDiff(diffText: string, options: RenderDiffOptions = {}): s
 	// Batch-highlight context (unedited) lines so consecutive lines tokenize
 	// with full multi-line context. Highlighting is a no-op when no language
 	// can be detected from the file path.
-	const contextHighlights = highlightContextLines(parsedLines, options.filePath);
+	const contextHighlights = highlightContextLines(parsedLines, options.filePath, renderTheme);
 	// Track the line number rendered on the previous emitted line so we can
 	// blank out duplicate gutters. Two cases trigger this:
 	//  1. Single-line replacement (`-N` followed by `+N`) — the `+N` repeats `N`.
@@ -153,7 +160,7 @@ export function renderDiff(diffText: string, options: RenderDiffOptions = {}): s
 			// unicode ellipsis.
 			const trimmed = line.trim();
 			const isGapRow = trimmed.length === 0 || trimmed === "..." || trimmed === "…";
-			result.push(theme.fg("toolDiffContext", isGapRow ? "…" : replaceTabs(line)));
+			result.push(renderTheme.fg("toolDiffContext", isGapRow ? "…" : replaceTabs(line)));
 			i++;
 			continue;
 		}
@@ -182,27 +189,32 @@ export function renderDiff(diffText: string, options: RenderDiffOptions = {}): s
 				const { removedLine, addedLine } = renderIntraLineDiff(
 					replaceTabs(removed.content),
 					replaceTabs(added.content),
+					renderTheme,
 				);
 
-				result.push(theme.fg("toolDiffRemoved", formatLine("-", removed.lineNum, visualizeIndent(removedLine))));
-				result.push(theme.fg("toolDiffAdded", formatLine("+", added.lineNum, visualizeIndent(addedLine))));
+				result.push(
+					renderTheme.fg("toolDiffRemoved", formatLine("-", removed.lineNum, visualizeIndent(removedLine))),
+				);
+				result.push(renderTheme.fg("toolDiffAdded", formatLine("+", added.lineNum, visualizeIndent(addedLine))));
 			} else {
 				for (const removed of removedLines) {
 					result.push(
-						theme.fg("toolDiffRemoved", formatLine("-", removed.lineNum, visualizeIndent(removed.content))),
+						renderTheme.fg("toolDiffRemoved", formatLine("-", removed.lineNum, visualizeIndent(removed.content))),
 					);
 				}
 				for (const added of addedLines) {
-					result.push(theme.fg("toolDiffAdded", formatLine("+", added.lineNum, visualizeIndent(added.content))));
+					result.push(
+						renderTheme.fg("toolDiffAdded", formatLine("+", added.lineNum, visualizeIndent(added.content))),
+					);
 				}
 			}
 		} else if (parsed.prefix === "+") {
-			result.push(theme.fg("toolDiffAdded", formatLine("+", parsed.lineNum, visualizeIndent(parsed.content))));
+			result.push(renderTheme.fg("toolDiffAdded", formatLine("+", parsed.lineNum, visualizeIndent(parsed.content))));
 			i++;
 		} else {
 			const highlighted = contextHighlights.get(i);
 			const content = highlighted !== undefined ? replaceTabs(highlighted) : visualizeIndent(parsed.content);
-			result.push(theme.fg("toolDiffContext", formatLine(" ", parsed.lineNum, content)));
+			result.push(renderTheme.fg("toolDiffContext", formatLine(" ", parsed.lineNum, content)));
 			i++;
 		}
 	}
@@ -219,6 +231,7 @@ export function renderDiff(diffText: string, options: RenderDiffOptions = {}): s
 function highlightContextLines(
 	parsedLines: Array<{ prefix: CodeFrameMarker; lineNum: string; content: string } | null>,
 	filePath: string | undefined,
+	renderTheme: Theme,
 ): Map<number, string> {
 	const map = new Map<number, string>();
 	const lang = filePath ? getLanguageFromPath(filePath) : undefined;
@@ -228,7 +241,7 @@ function highlightContextLines(
 	let runContents: string[] = [];
 	const flush = () => {
 		if (runContents.length === 0) return;
-		const highlighted = highlightCode(runContents.join("\n"), lang);
+		const highlighted = highlightCode(runContents.join("\n"), lang, renderTheme);
 		for (let k = 0; k < runIndices.length; k++) {
 			map.set(runIndices[k], highlighted[k] ?? runContents[k]);
 		}

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -483,8 +483,11 @@ describe("editToolRenderer", () => {
 		expect(rendered).toContain("plain streamed text");
 	});
 
-	it("colors completed diff rows when the injected diff renderer is unavailable", async () => {
-		const uiTheme = await getUiTheme();
+	it("uses the supplied theme when the injected diff renderer is unavailable", async () => {
+		const activeTheme = await getUiTheme();
+		const uiTheme = await themeModule.getThemeByName("light");
+		if (!uiTheme) throw new Error("Built-in light theme is unavailable");
+		expect(uiTheme.fg("toolDiffAdded", "COLOR")).not.toBe(activeTheme.fg("toolDiffAdded", "COLOR"));
 		const component = editToolRenderer.renderResult(
 			{
 				content: [{ type: "text", text: "Updated demo.ts" }],

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -483,6 +483,28 @@ describe("editToolRenderer", () => {
 		expect(rendered).toContain("plain streamed text");
 	});
 
+	it("colors completed diff rows when the injected diff renderer is unavailable", async () => {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Updated demo.ts" }],
+				details: { diff: "-1|const oldValue = 1;\n\n+2|const newValue = 2;", op: "update", path: "demo.ts" },
+			},
+			{ expanded: true, isPartial: false, renderContext: { editMode: "hashline" } },
+			uiTheme,
+			{ file_path: "demo.ts" },
+		);
+
+		const rows = component.render(160);
+		const removedRow = rows.find(row => row.includes("oldValue"));
+		const addedRow = rows.find(row => row.includes("newValue"));
+		const removedColor = uiTheme.fg("toolDiffRemoved", "COLOR").split("COLOR")[0];
+		const addedColor = uiTheme.fg("toolDiffAdded", "COLOR").split("COLOR")[0];
+
+		expect(removedRow).toContain(removedColor);
+		expect(addedRow).toContain(addedColor);
+	});
+
 	it("renders change stats inline on the result header with no separate metadata or stats row", async () => {
 		const uiTheme = await getUiTheme();
 		const diff = [" 115│ ctx", "-116│ old", "+117│ new one", "+118│ new two"].join("\n");
@@ -805,32 +827,5 @@ describe("editToolRenderer diff line wrapping", () => {
 		expect(bodyRows.length).toBeGreaterThanOrEqual(2);
 		expect(bodyRows[0]).toMatch(/^│123\| /);
 		for (const row of bodyRows.slice(1)) expect(row).not.toMatch(/^│\s*\|/);
-	});
-
-	it("keeps the numbered ASCII-pipe gutter for canonical rows through the plain fallback", async () => {
-		// Without renderContext the plain fallback passes canonical rows through
-		// verbatim; a numbered "-42|" row must still take the gutter path and
-		// carry an "   |" continuation gutter, not generic prose wrapping.
-		const uiTheme = await getUiTheme();
-		const component = editToolRenderer.renderResult(
-			{
-				content: [{ type: "text", text: "Updated demo.ts" }],
-				details: {
-					diff: "-42|    the previous synopsis paragraph rambled across quarterly reconciliation notes enumerating every provisional ledger amendment the archival committee had deferred pending review by the regional custodians",
-					op: "update",
-					path: "demo.ts",
-				},
-			},
-			{ expanded: true, isPartial: false },
-			uiTheme,
-			{ file_path: "demo.ts" },
-		);
-
-		const rows = component.render(100).map(row => Bun.stripANSI(row));
-		const bodyRows = rows.slice(1, -1);
-		// Precondition: the row actually wrapped past its first visual line.
-		expect(bodyRows.length).toBeGreaterThanOrEqual(2);
-		expect(bodyRows[0]).toMatch(/^│-42\|/);
-		for (const row of bodyRows.slice(1)) expect(row).toMatch(/^│\s+\|/);
 	});
 });


### PR DESCRIPTION
## Repro
A completed edit result rendered through `editToolRenderer.renderResult` without an injected `renderContext.renderDiff` reproduced the screenshot: header stats remained green/red, but canonical `-N|` and `+N|` body rows had no diff-color ANSI. `bun test packages/coding-agent/test/tools/edit-renderer.test.ts --test-name-pattern 'injected diff renderer'` failed before the fix because the removed row lacked the theme’s `toolDiffRemoved` foreground sequence.

## Cause
`renderSingleFileResult` in `packages/coding-agent/src/edit/renderer.ts` selected `plainDiffRender` whenever the caller did not inject a diff renderer. That fallback preserved canonical rows as unstyled text, bypassing the normal red/green and syntax-highlighted `renderDiff` path.

## Fix
- Use the standard colored diff renderer when no contextual renderer is injected.
- Add regression coverage requiring removed and added result rows to contain their theme foreground sequences.
- Remove the obsolete test that required the plain fallback and document the user-visible fix.

## Verification
- `bun test packages/coding-agent/test/tools/edit-renderer.test.ts` — 31 passed, 0 failed.
- `bun packages/coding-agent/src/cli.ts gallery --tool edit --state success --width 120` — rendered the completed edit through the production TUI gallery.
- `bun run check:ts` — passed for all TypeScript workspaces.
- Skipped the pre-publish gate: `bun run fix` fails identically on a clean `origin/main` snapshot because `audiopus_sys` falls back to a CMake build while `cmake` is unavailable in this runner; the TypeScript formatter completed successfully.

Fixes #9439