### PR TITLE
fix(driver): check agent capacity before starting a subagent

### DIFF
--- a/crates/driver/src/subagent/supervisor.rs
+++ b/crates/driver/src/subagent/supervisor.rs
@@ -13,7 +13,7 @@ use flume::Receiver;
 use omp_agent::{
 	AbortHandle, Agent, AgentError, AgentEvent, AgentNode, AgentRunSummary, AgentStatus, AgentTree,
 	AgentTreeLimits, Interrupt, InterruptClass, InterruptSource, JobBoard, MailboxSender,
-	SubagentActivity, SubagentActivityKind, SubagentDisposition, SubagentLifecycle,
+	SpawnPermit, SubagentActivity, SubagentActivityKind, SubagentDisposition, SubagentLifecycle,
 	SubagentProgressSnapshot, SubagentRunState, SubagentStateError, SubagentTerminalKind,
 	SubagentTerminalStatus, TurnClient, TurnId,
 };
@@ -761,15 +761,7 @@ async fn run_child<C: TurnClient + Clone + Send + 'static>(
 	turn_id: TurnId,
 	settings: &TaskSettings,
 ) -> Result<AgentRunSummary, SupervisorError> {
-	let first_turn = state.lifecycle() == SubagentLifecycle::Created;
-	let reopening = state.lifecycle() == SubagentLifecycle::Parked;
-	match state.lifecycle() {
-		SubagentLifecycle::Created => state.transition(SubagentLifecycle::Starting)?,
-		SubagentLifecycle::Settled | SubagentLifecycle::Parked => {
-			state.begin_generation()?;
-		},
-		lifecycle => return Err(SupervisorError::NotIdleState { id: node.id.clone(), lifecycle }),
-	}
+	let (permit, first_turn, reopening) = admit_run(tree, state, &node.id).await?;
 	if runtime.is_none() {
 		let factory =
 			reviver.ok_or_else(|| SupervisorError::RevivalUnavailable { id: node.id.clone() })?;
@@ -808,7 +800,6 @@ async fn run_child<C: TurnClient + Clone + Send + 'static>(
 	if first_turn || reopening {
 		record_lifecycle(runtime, state, &node.id, "turn-started", None)?;
 	}
-	let permit = tree.admit(1).await?;
 	state.transition(SubagentLifecycle::Running)?;
 	state.record_activity(SubagentActivity {
 		kind: Some(if first_turn {
@@ -891,6 +882,31 @@ async fn run_child<C: TurnClient + Clone + Send + 'static>(
 			Err(error)
 		},
 	}
+}
+
+async fn admit_run(
+	tree: &AgentTree,
+	state: &SubagentRunState,
+	id: &Str,
+) -> Result<(SpawnPermit, bool, bool), SupervisorError> {
+	let lifecycle = state.lifecycle();
+	let (first_turn, reopening) = match lifecycle {
+		SubagentLifecycle::Created => (true, false),
+		SubagentLifecycle::Settled => (false, false),
+		SubagentLifecycle::Parked => (false, true),
+		lifecycle => {
+			return Err(SupervisorError::NotIdleState { id: id.clone(), lifecycle });
+		},
+	};
+	let permit = tree.admit(1).await?;
+	match lifecycle {
+		SubagentLifecycle::Created => state.transition(SubagentLifecycle::Starting)?,
+		SubagentLifecycle::Settled | SubagentLifecycle::Parked => {
+			state.begin_generation()?;
+		},
+		_ => unreachable!("active subagent lifecycle was rejected before admission"),
+	}
+	Ok((permit, first_turn, reopening))
 }
 
 fn record_lifecycle<C: TurnClient + Clone>(
@@ -1310,5 +1326,25 @@ mod tests {
 			budget_killed.terminal().map(|terminal| terminal.kind),
 			Some(SubagentTerminalKind::Failed)
 		);
+	}
+
+	#[tokio::test]
+	async fn admission_refusal_does_not_start_or_reopen_a_generation() {
+		let tree = AgentTree::new(2, 1, 0);
+		let _active = tree.admit(1).await.unwrap();
+		let id = sf!("queued-child");
+		let state = SubagentRunState::new(id.clone());
+
+		let result = admit_run(&tree, &state, &id).await;
+		assert!(matches!(result, Err(SupervisorError::Admission(_))));
+		assert_eq!(state.lifecycle(), SubagentLifecycle::Created);
+
+		state.transition(SubagentLifecycle::Settled).unwrap();
+		state.transition(SubagentLifecycle::Parked).unwrap();
+		let generation = state.generation();
+		let result = admit_run(&tree, &state, &id).await;
+		assert!(matches!(result, Err(SupervisorError::Admission(_))));
+		assert_eq!(state.lifecycle(), SubagentLifecycle::Parked);
+		assert_eq!(state.generation(), generation);
 	}
 }


### PR DESCRIPTION
## Summary

OMP2 currently begins starting a subagent before confirming that the system has room to run it.

This PR changes the order:

1. Check for available capacity.
2. Wait or reject if the system is full.
3. Start the subagent only after capacity is granted.
4. Hold that capacity for the duration of the run.

## Why

Today, OMP2 can mark an agent as starting, prepare its runtime, and write a `turn-started` record before receiving a concurrency slot.

If admission is rejected, the agent can be left halfway between waiting and running. That can create:

- phantom running agents;
- inaccurate lifecycle records;
- resources prepared for work that never started;
- agents that cannot be retried because their state remains `Starting`.

## What this fixes

After this change, queued or rejected agents remain safely in their previous state. OMP2 does not prepare their runtime or report that they started until there is actual capacity to run them.

In simple terms:

> Check that there is room before starting the agent.

The regression test covers both a brand-new agent and a parked agent being rejected by a full admission queue. Their lifecycle and generation remain unchanged.

## Big picture

OMP should be the reliable control plane for agent workers. Whether execution later runs locally, in a Daytona-style sandbox, or on a remote fleet—and whether a human watches through cmux or another terminal dashboard—the lifecycle record needs to reflect what actually happened.

Admission first, execution second is the foundation for that separation.

## Verification

- `just fmt-check-rust`
- `just check-pkg omp-driver`
- targeted regression test: passed

The full `just test-pkg omp-driver` command is currently blocked on the checked-out `omp2` branch by an existing test configuration issue: a `#[tokio::test(start_paused = true)]` test requires Tokio's `test-util` feature, which the driver test target does not enable. I enabled that feature locally only to run the targeted regression test, then removed the local change.

## Scope

This is a focused lifecycle and admission-ordering fix. It does not add sandbox providers, remote workers, Kubernetes scheduling, or terminal-control changes.
