### PR TITLE
feat(session): add TUI /archive for the current session

### DIFF
--- a/docs/session-operations-export-share-fork-resume.md
+++ b/docs/session-operations-export-share-fork-resume.md
@@ -225,7 +225,8 @@ same way `/new` does, then moves the previous `.jsonl` and artifacts through
 the same gzip + artifact relocation used by `omp gc --archive`. It then reuses
 that command's `history.db` / `stats.db` cleanup against the resolved sessions
 root so a retained fork in a custom `--session-dir` keeps shared stats, and
-`omp stats` does not keep counting the archived session.
+`omp stats` does not keep counting the archived session. A cleanup error is
+reported as a warning; the archive itself still counts as completed.
 
 The archive root follows the active session directory. Sessions under the
 default profile store go to `archive/sessions` next to `sessions`. A custom

--- a/docs/session-operations-export-share-fork-resume.md
+++ b/docs/session-operations-export-share-fork-resume.md
@@ -23,6 +23,7 @@ This document describes operator-visible behavior for session export, sharing, c
 | `/fresh`                                | Slash command (TUI/headless) | Yes (provider-facing in-memory id/state only) | No; keeps current session file/header                                                      | None                                                                                |
 | `/clear`                                | Interactive slash command    | Yes (clears live/model conversation context)  | No; retains session identity, metadata, transcript file, and full on-disk history          | Appends a durable `reset_boundary`                                                  |
 | `/drop`                                 | Interactive slash command    | Yes (starts an empty conversation)            | Attempts to delete the current persisted session and artifacts, then switches to a new one | None                                                                                |
+| `/archive`                              | Interactive slash command    | Yes (starts an empty conversation)            | Confirms, switches to a new session, then gzip-moves the previous session and artifacts into `archive/sessions` | Leaves `/resume`                                                    |
 | `/fork`                                 | Interactive slash command    | Yes (active session identity changes)         | Creates new session file and switches current session to it (persistent mode only)         | Copies artifact directory to new session namespace when present                     |
 | `--fork <id\|path>`                     | CLI startup                  | Yes after session creation                    | Creates a new session fork from the selected source into current cwd/session dir           | None                                                                                |
 | `/resume [id\|@claude\|@codex]`         | Interactive slash command    | Yes (active in-memory state replaced)         | Switches to a selected/matched session, or imports a selected foreign session              | None                                                                                |
@@ -212,6 +213,18 @@ from `/fresh`, which rotates provider stream state without clearing the
 conversation; `/new`, which creates a new session identity and transcript file;
 and `/drop`, which attempts to delete the old persisted session before starting
 a new one.
+
+## Archive
+
+Interactive `/archive` is TUI-only. It refuses while the parent session is
+streaming or a nested session is still live (`pending` / `interrupted` /
+`unknown`), asks for confirmation, starts a fresh session the same way `/new`
+does, then moves the previous `.jsonl` and artifacts through the same gzip +
+artifact relocation used by `omp gc --archive`.
+
+The archived file leaves the active sessions directory, so `/resume` no longer
+lists it. There is no `/unarchive` in this version; restore is a manual file
+move out of `~/.omp/archive/sessions/`.
 
 ## Fork
 

--- a/docs/session-operations-export-share-fork-resume.md
+++ b/docs/session-operations-export-share-fork-resume.md
@@ -216,13 +216,16 @@ a new one.
 
 ## Archive
 
-Interactive `/archive` is TUI-only. It refuses while the parent session is
-streaming or a nested session is still live (`pending` / `interrupted` /
-`unknown`), asks for confirmation, starts a fresh session the same way `/new`
-does, then moves the previous `.jsonl` and artifacts through the same gzip +
-artifact relocation used by `omp gc --archive`. It then reuses that command's
-`history.db` / `stats.db` cleanup so `omp stats` does not keep counting the
-archived session.
+Interactive `/archive` is TUI-only. It refuses when the session file has not
+been written yet (`isSessionOnDisk()` is false — the same lazy-persist gap as
+#8860), while the parent session is streaming, or a nested session is still
+live (`pending` / `interrupted` / `unknown`). Those refusals happen before
+confirmation and before switching. After confirm it starts a fresh session the
+same way `/new` does, then moves the previous `.jsonl` and artifacts through
+the same gzip + artifact relocation used by `omp gc --archive`. It then reuses
+that command's `history.db` / `stats.db` cleanup against the resolved sessions
+root so a retained fork in a custom `--session-dir` keeps shared stats, and
+`omp stats` does not keep counting the archived session.
 
 The archive root follows the active session directory. Sessions under the
 default profile store go to `archive/sessions` next to `sessions`. A custom

--- a/docs/session-operations-export-share-fork-resume.md
+++ b/docs/session-operations-export-share-fork-resume.md
@@ -23,7 +23,7 @@ This document describes operator-visible behavior for session export, sharing, c
 | `/fresh`                                | Slash command (TUI/headless) | Yes (provider-facing in-memory id/state only) | No; keeps current session file/header                                                      | None                                                                                |
 | `/clear`                                | Interactive slash command    | Yes (clears live/model conversation context)  | No; retains session identity, metadata, transcript file, and full on-disk history          | Appends a durable `reset_boundary`                                                  |
 | `/drop`                                 | Interactive slash command    | Yes (starts an empty conversation)            | Attempts to delete the current persisted session and artifacts, then switches to a new one | None                                                                                |
-| `/archive`                              | Interactive slash command    | Yes (starts an empty conversation)            | Confirms, switches to a new session, then gzip-moves the previous session and artifacts into `archive/sessions` | Leaves `/resume`                                                    |
+| `/archive`                              | Interactive slash command    | Yes (starts an empty conversation)            | Confirms, switches to a new session, then gzip-moves the previous session and artifacts into `archive/sessions` and prunes matching `history.db` / `stats.db` rows | Leaves `/resume`                                                    |
 | `/fork`                                 | Interactive slash command    | Yes (active session identity changes)         | Creates new session file and switches current session to it (persistent mode only)         | Copies artifact directory to new session namespace when present                     |
 | `--fork <id\|path>`                     | CLI startup                  | Yes after session creation                    | Creates a new session fork from the selected source into current cwd/session dir           | None                                                                                |
 | `/resume [id\|@claude\|@codex]`         | Interactive slash command    | Yes (active in-memory state replaced)         | Switches to a selected/matched session, or imports a selected foreign session              | None                                                                                |
@@ -220,11 +220,19 @@ Interactive `/archive` is TUI-only. It refuses while the parent session is
 streaming or a nested session is still live (`pending` / `interrupted` /
 `unknown`), asks for confirmation, starts a fresh session the same way `/new`
 does, then moves the previous `.jsonl` and artifacts through the same gzip +
-artifact relocation used by `omp gc --archive`.
+artifact relocation used by `omp gc --archive`. It then reuses that command's
+`history.db` / `stats.db` cleanup so `omp stats` does not keep counting the
+archived session.
+
+The archive root follows the active session directory. Sessions under the
+default profile store go to `archive/sessions` next to `sessions`. A custom
+`--session-dir` or an explicit path outside the profile store archives beside
+that directory. If the session file is not under the session manager directory
+or the default store, `/archive` refuses before switching.
 
 The archived file leaves the active sessions directory, so `/resume` no longer
 lists it. There is no `/unarchive` in this version; restore is a manual file
-move out of `~/.omp/archive/sessions/`.
+move out of the archive tree.
 
 ## Fork
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `/archive` slash command to confirm, start a fresh session, and move the previous session into the existing `omp gc --archive` store so it leaves the `/resume` picker ([#9029](https://github.com/can1357/oh-my-pi/issues/9029)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added the `/archive` slash command to confirm, start a fresh session, and move the previous session into the existing `omp gc --archive` store so it leaves the `/resume` picker. It honors `--session-dir` / explicit session paths and prunes matching `history.db` / `stats.db` rows ([#9029](https://github.com/can1357/oh-my-pi/issues/9029)).
+- Added the `/archive` slash command to confirm, start a fresh session, and move the previous session into the existing `omp gc --archive` store so it leaves the `/resume` picker. Unsaved sessions are refused before switching, and archiving from a custom session directory keeps shared stats on a remaining fork ([#9029](https://github.com/can1357/oh-my-pi/issues/9029)).
 
 ## [18.0.1] - 2026-08-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added the `/archive` slash command to confirm, start a fresh session, and move the previous session into the existing `omp gc --archive` store so it leaves the `/resume` picker ([#9029](https://github.com/can1357/oh-my-pi/issues/9029)).
+- Added the `/archive` slash command to confirm, start a fresh session, and move the previous session into the existing `omp gc --archive` store so it leaves the `/resume` picker. It honors `--session-dir` / explicit session paths and prunes matching `history.db` / `stats.db` rows ([#9029](https://github.com/can1357/oh-my-pi/issues/9029)).
 
 ## [18.0.1] - 2026-08-23
 

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { gunzipSync, gzipSync } from "node:zlib";
+import { gunzipSync } from "node:zlib";
 import { withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
 import {
 	getAgentDir,
@@ -15,6 +15,13 @@ import {
 import { Settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
 import { BLOB_HASH_RE } from "../session/blob-store";
+import {
+	getArchivedSessionsDir,
+	moveSessionWithArtifacts,
+	resolveArchiveDestination,
+	sessionArtifactsPath,
+	sessionHasLiveNestedSessions,
+} from "../session/session-archive";
 import { listSessionsReadOnly, type SessionInfo, type SessionStatus } from "../session/session-listing";
 import { FileSessionStorage } from "../session/session-storage";
 
@@ -198,10 +205,6 @@ export function collectGcErrors(result: GcResult): string[] {
 	];
 }
 
-function getArchivedSessionsDir(agentDir: string): string {
-	return path.join(path.dirname(getSessionsDir(agentDir)), "archive", "sessions");
-}
-
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -375,69 +378,11 @@ async function listActiveSessions(sessionsRoot: string): Promise<SessionInfo[]> 
 	return sessions;
 }
 
-async function listNestedSessionsReadOnly(artifactsRoot: string): Promise<SessionInfo[]> {
-	const files = await collectJsonlFiles(artifactsRoot);
-	const dirs = [...new Set(files.map(file => path.dirname(file)))].sort();
-	const storage = new FileSessionStorage();
-	const sessions: SessionInfo[] = [];
-	for (const dir of dirs) sessions.push(...(await listSessionsReadOnly(dir, storage)));
-	sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
-	return sessions;
-}
-
-async function hasLiveNestedSessions(session: SessionInfo, archiveBeforeMs: number): Promise<boolean> {
-	for (const nested of await listNestedSessionsReadOnly(sessionArtifactsPath(session.path))) {
-		if (nested.status && ACTIVE_STATUSES.has(nested.status)) return true;
-		if (nested.modified.getTime() > archiveBeforeMs) return true;
-	}
-	return false;
-}
-
-function archiveDestination(
-	archiveRoot: string,
-	sessionsRoot: string,
-	session: SessionInfo,
-): Omit<ArchiveCandidate, "session"> | null {
-	const sessionPath = session.path;
-	const relativePath = path.relative(sessionsRoot, sessionPath);
-	if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) return null;
-	if (!relativePath.endsWith(SESSION_SUFFIX)) return null;
-	return {
-		relativePath,
-		destinationPath: path.join(archiveRoot, `${relativePath}.gz`),
-	};
-}
-
 function sessionCwdKey(sessionsRoot: string, session: SessionInfo): string {
 	const relativePath = path.relative(sessionsRoot, session.path);
 	if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) return session.cwd || ".";
 	const dirname = path.dirname(relativePath);
 	return dirname === "." ? session.cwd || "." : dirname;
-}
-
-async function movePath(source: string, destination: string): Promise<void> {
-	await fs.mkdir(path.dirname(destination), { recursive: true });
-	try {
-		await fs.rename(source, destination);
-		return;
-	} catch (error) {
-		if (codeOf(error) !== "EXDEV") throw error;
-	}
-	const stat = await fs.stat(source);
-	if (stat.isDirectory()) {
-		await fs.cp(source, destination, { recursive: true });
-		await fs.rm(source, { recursive: true, force: true });
-		return;
-	}
-	await fs.copyFile(source, destination);
-	await fs.unlink(source);
-}
-
-function sessionArtifactsPath(sessionPath: string): string {
-	if (sessionPath.endsWith(COMPRESSED_SESSION_SUFFIX)) {
-		return sessionPath.slice(0, -COMPRESSED_SESSION_SUFFIX.length);
-	}
-	return sessionPath.slice(0, -SESSION_SUFFIX.length);
 }
 
 interface SessionLineageHeader {
@@ -491,66 +436,6 @@ async function readSessionLineageHeader(file: string): Promise<SessionLineageHea
 		if (header || lines.length >= 2) return header;
 	}
 	return undefined;
-}
-
-async function gzipSessionFile(source: string, destination: string): Promise<void> {
-	await fs.mkdir(path.dirname(destination), { recursive: true });
-	const tempPath = `${destination}.${process.pid}.${Date.now()}.tmp`;
-	let renamed = false;
-	try {
-		const compressed = gzipSync(await Bun.file(source).bytes(), { level: 9 });
-		await Bun.write(tempPath, compressed);
-		await fs.rename(tempPath, destination);
-		renamed = true;
-		await fs.unlink(source);
-	} catch (error) {
-		await fs.rm(tempPath, { force: true });
-		if (renamed) await fs.rm(destination, { force: true });
-		throw error;
-	}
-}
-
-async function restoreGzipSessionFile(source: string, destination: string): Promise<void> {
-	await fs.mkdir(path.dirname(destination), { recursive: true });
-	const decompressed = gunzipSync(await Bun.file(source).bytes());
-	await Bun.write(destination, decompressed);
-	await fs.unlink(source);
-}
-
-async function moveSessionWithArtifacts(candidate: ArchiveCandidate): Promise<void> {
-	const sourceSession = candidate.session.path;
-	const destSession = candidate.destinationPath;
-	const legacyDestSession = destSession.endsWith(".gz") ? destSession.slice(0, -".gz".length) : `${destSession}.gz`;
-	const sourceArtifacts = sessionArtifactsPath(sourceSession);
-	const destArtifacts = sessionArtifactsPath(destSession);
-	if (await pathExists(destSession)) throw new Error(`archive destination exists: ${destSession}`);
-	if (await pathExists(legacyDestSession)) throw new Error(`archive destination exists: ${legacyDestSession}`);
-	if ((await pathExists(sourceArtifacts)) && (await pathExists(destArtifacts))) {
-		throw new Error(`archive artifacts destination exists: ${destArtifacts}`);
-	}
-
-	const moved: Array<{ source: string; destination: string; compressed?: boolean }> = [];
-	try {
-		await gzipSessionFile(sourceSession, destSession);
-		moved.push({ source: sourceSession, destination: destSession, compressed: true });
-		if (await pathExists(sourceArtifacts)) {
-			await movePath(sourceArtifacts, destArtifacts);
-			moved.push({ source: sourceArtifacts, destination: destArtifacts });
-		}
-	} catch (error) {
-		for (const move of moved.reverse()) {
-			try {
-				if (move.compressed) {
-					await restoreGzipSessionFile(move.destination, move.source);
-				} else {
-					await movePath(move.destination, move.source);
-				}
-			} catch {
-				// Preserve the original failure; rollback failure is reported by the next scan.
-			}
-		}
-		throw error;
-	}
 }
 
 function sqliteNumber(value: number | bigint | null | undefined): number {
@@ -1250,7 +1135,7 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 			result.skippedActive += 1;
 			continue;
 		}
-		if (await hasLiveNestedSessions(session, archiveBeforeMs)) {
+		if (await sessionHasLiveNestedSessions(session.path, { recentlyModifiedAfterMs: archiveBeforeMs })) {
 			result.skippedActive += 1;
 			continue;
 		}
@@ -1269,7 +1154,7 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 			continue;
 		}
 		if (options.coldArchiveAfterDays > 0 && session.modified.getTime() > cutoffMs) continue;
-		const destination = archiveDestination(archiveRoot, sessionsRoot, session);
+		const destination = resolveArchiveDestination(session.path, sessionsRoot, archiveRoot);
 		if (!destination) continue;
 		candidates.push({ ...destination, session });
 	}
@@ -1281,7 +1166,7 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 	const archivedSessions: SessionInfo[] = [];
 	for (const candidate of candidates) {
 		try {
-			await moveSessionWithArtifacts(candidate);
+			await moveSessionWithArtifacts(candidate.session.path, candidate.destinationPath);
 			result.archived += 1;
 			archivedSessionIds.push(candidate.session.id);
 			archivedSessions.push(candidate.session);

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -16,13 +16,16 @@ import { Settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
 import { BLOB_HASH_RE } from "../session/blob-store";
 import {
+	COMPRESSED_SESSION_SUFFIX,
 	getArchivedSessionsDir,
+	LIVE_NESTED_STATUSES,
 	moveSessionWithArtifacts,
 	resolveArchiveDestination,
+	SESSION_SUFFIX,
 	sessionArtifactsPath,
 	sessionHasLiveNestedSessions,
 } from "../session/session-archive";
-import { listSessionsReadOnly, type SessionInfo, type SessionStatus } from "../session/session-listing";
+import { listSessionsReadOnly, type SessionInfo } from "../session/session-listing";
 import { FileSessionStorage } from "../session/session-storage";
 
 const BLOB_FILE_RE = /^([a-f0-9]{64})(?:\.[A-Za-z0-9][A-Za-z0-9._-]{0,31})?$/;
@@ -30,11 +33,8 @@ const BLOB_REF_RE = /\bblob:sha256:([a-f0-9]{64})\b/gi;
 const JSONL_GLOB = new Bun.Glob("**/*.jsonl");
 const JSONL_GZ_GLOB = new Bun.Glob("**/*.jsonl.gz");
 const JSONL_BACKUP_GLOB = new Bun.Glob("**/*.jsonl.*.bak");
-const ACTIVE_STATUSES: ReadonlySet<SessionStatus> = new Set(["pending", "interrupted", "unknown"]);
 const DAY_MS = 86_400_000;
 const GC_WRITE_GRACE_MS = 5 * 60_000;
-const SESSION_SUFFIX = ".jsonl";
-const COMPRESSED_SESSION_SUFFIX = ".jsonl.gz";
 const GC_LOCK_BREAKER_SUFFIX = ".break";
 
 export interface GcCommandFlags {
@@ -490,7 +490,7 @@ async function collectArchivedSessionIds(archiveRoot: string): Promise<string[]>
 }
 
 async function cleanupHistoryRowsForArchivedSessions(
-	options: ResolvedGcOptions,
+	options: { agentDir: string },
 	archiveRoot: string,
 	archivedSessionIds: string[],
 	result: ArchiveGcResult,
@@ -1039,7 +1039,7 @@ async function collectArchivedStatsSessions(
 }
 
 async function cleanupStatsRowsForArchivedSessions(
-	options: ResolvedGcOptions,
+	options: { agentDir: string },
 	archiveRoot: string,
 	newlyArchivedSessions: SessionInfo[],
 	result: ArchiveGcResult,
@@ -1105,6 +1105,50 @@ async function cleanupStatsRowsForArchivedSessions(
 	}
 }
 
+export async function cleanupRowsForArchivedSessions(
+	agentDir: string,
+	archiveRoot: string,
+	archivedSessions: readonly { id: string; path: string; parentSessionPath?: string }[],
+): Promise<Pick<ArchiveGcResult, "historyRowsDeleted" | "statsRowsDeleted" | "ftsRebuilt" | "errors">> {
+	const result: ArchiveGcResult = {
+		scanned: 0,
+		skippedActive: 0,
+		keptNewestGlobal: 0,
+		keptNewestPerCwd: 0,
+		wouldArchive: 0,
+		archived: 0,
+		historyRowsDeleted: 0,
+		statsRowsDeleted: 0,
+		ftsRebuilt: false,
+		errors: [],
+	};
+	const infos: SessionInfo[] = archivedSessions.map(session => ({
+		path: session.path,
+		id: session.id,
+		cwd: "",
+		created: new Date(0),
+		modified: new Date(0),
+		messageCount: 0,
+		size: 0,
+		firstMessage: "",
+		allMessagesText: "",
+		parentSessionPath: session.parentSessionPath,
+	}));
+	await cleanupHistoryRowsForArchivedSessions(
+		{ agentDir },
+		archiveRoot,
+		archivedSessions.map(session => session.id),
+		result,
+	);
+	await cleanupStatsRowsForArchivedSessions({ agentDir }, archiveRoot, infos, result);
+	return {
+		historyRowsDeleted: result.historyRowsDeleted,
+		statsRowsDeleted: result.statsRowsDeleted,
+		ftsRebuilt: result.ftsRebuilt,
+		errors: result.errors,
+	};
+}
+
 async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Promise<ArchiveGcResult> {
 	const sessionsRoot = getSessionsDir(options.agentDir);
 	const sessions = await listActiveSessions(sessionsRoot);
@@ -1127,7 +1171,7 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 	const archiveBeforeMs = Date.now() - GC_WRITE_GRACE_MS;
 
 	for (const session of sessions) {
-		if (session.status && ACTIVE_STATUSES.has(session.status)) {
+		if (session.status && LIVE_NESTED_STATUSES[session.status]) {
 			result.skippedActive += 1;
 			continue;
 		}

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -378,6 +378,25 @@ async function listActiveSessions(sessionsRoot: string): Promise<SessionInfo[]> 
 	return sessions;
 }
 
+function isPathInside(target: string, root: string): boolean {
+	const relative = path.relative(path.resolve(root), path.resolve(target));
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/** Sessions still live under `sessionsRoot`, excluding anything already in the archive tree. */
+async function listRetainedSessionsForCleanup(sessionsRoot: string, archiveRoot: string): Promise<SessionInfo[]> {
+	const storage = new FileSessionStorage();
+	const byPath = new Map<string, SessionInfo>();
+	for (const session of [
+		...(await listActiveSessions(sessionsRoot)),
+		...(await listSessionsReadOnly(sessionsRoot, storage)),
+	]) {
+		if (isPathInside(session.path, archiveRoot)) continue;
+		byPath.set(path.resolve(session.path), session);
+	}
+	return [...byPath.values()];
+}
+
 function sessionCwdKey(sessionsRoot: string, session: SessionInfo): string {
 	const relativePath = path.relative(sessionsRoot, session.path);
 	if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) return session.cwd || ".";
@@ -1041,6 +1060,7 @@ async function collectArchivedStatsSessions(
 async function cleanupStatsRowsForArchivedSessions(
 	options: { agentDir: string },
 	archiveRoot: string,
+	sessionsRoot: string,
 	newlyArchivedSessions: SessionInfo[],
 	result: ArchiveGcResult,
 ): Promise<void> {
@@ -1049,7 +1069,6 @@ async function cleanupStatsRowsForArchivedSessions(
 			? getStatsDbPath()
 			: path.join(options.agentDir, "stats.db");
 	if (!(await pathExists(dbPath))) return;
-	const sessionsRoot = getSessionsDir(options.agentDir);
 
 	const archivedByPath = new Map<string, StatsSession>();
 	for (const session of newlyArchivedSessions) {
@@ -1073,7 +1092,7 @@ async function cleanupStatsRowsForArchivedSessions(
 		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
 	}
 	try {
-		retainedSessions = await listActiveSessions(sessionsRoot);
+		retainedSessions = await listRetainedSessionsForCleanup(sessionsRoot, archiveRoot);
 	} catch (error) {
 		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
 		return;
@@ -1109,6 +1128,7 @@ export async function cleanupRowsForArchivedSessions(
 	agentDir: string,
 	archiveRoot: string,
 	archivedSessions: readonly { id: string; path: string; parentSessionPath?: string }[],
+	sessionsRoot: string = getSessionsDir(agentDir),
 ): Promise<Pick<ArchiveGcResult, "historyRowsDeleted" | "statsRowsDeleted" | "ftsRebuilt" | "errors">> {
 	const result: ArchiveGcResult = {
 		scanned: 0,
@@ -1140,7 +1160,7 @@ export async function cleanupRowsForArchivedSessions(
 		archivedSessions.map(session => session.id),
 		result,
 	);
-	await cleanupStatsRowsForArchivedSessions({ agentDir }, archiveRoot, infos, result);
+	await cleanupStatsRowsForArchivedSessions({ agentDir }, archiveRoot, sessionsRoot, infos, result);
 	return {
 		historyRowsDeleted: result.historyRowsDeleted,
 		statsRowsDeleted: result.statsRowsDeleted,
@@ -1220,7 +1240,7 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 	}
 
 	await cleanupHistoryRowsForArchivedSessions(options, archiveRoot, archivedSessionIds, result);
-	await cleanupStatsRowsForArchivedSessions(options, archiveRoot, archivedSessions, result);
+	await cleanupStatsRowsForArchivedSessions(options, archiveRoot, sessionsRoot, archivedSessions, result);
 	return result;
 }
 

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -17,6 +17,7 @@ import { getDefault } from "../config/settings-schema";
 import { BLOB_HASH_RE } from "../session/blob-store";
 import {
 	COMPRESSED_SESSION_SUFFIX,
+	collectGlobFiles,
 	getArchivedSessionsDir,
 	LIVE_NESTED_STATUSES,
 	moveSessionWithArtifacts,
@@ -246,46 +247,13 @@ async function readTextIfPresent(file: string): Promise<string> {
 	}
 }
 
-async function collectJsonlFiles(root: string): Promise<string[]> {
-	try {
-		const files = await Array.fromAsync(JSONL_GLOB.scan(root), name => path.join(root, name));
-		files.sort();
-		return files;
-	} catch (error) {
-		if (codeOf(error) === "ENOENT") return [];
-		throw error;
-	}
-}
-
-async function collectCompressedJsonlFiles(root: string): Promise<string[]> {
-	try {
-		const files = await Array.fromAsync(JSONL_GZ_GLOB.scan(root), name => path.join(root, name));
-		files.sort();
-		return files;
-	} catch (error) {
-		if (codeOf(error) === "ENOENT") return [];
-		throw error;
-	}
-}
-
-async function collectBackupJsonlFiles(root: string): Promise<string[]> {
-	try {
-		const files = await Array.fromAsync(JSONL_BACKUP_GLOB.scan(root), name => path.join(root, name));
-		files.sort();
-		return files;
-	} catch (error) {
-		if (codeOf(error) === "ENOENT") return [];
-		throw error;
-	}
-}
-
 async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<string>> {
 	const hashes = new Set<string>();
 	for (const root of sessionRoots) {
 		const files = [
-			...(await collectJsonlFiles(root)),
-			...(await collectCompressedJsonlFiles(root)),
-			...(await collectBackupJsonlFiles(root)),
+			...(await collectGlobFiles(root, JSONL_GLOB)),
+			...(await collectGlobFiles(root, JSONL_GZ_GLOB)),
+			...(await collectGlobFiles(root, JSONL_BACKUP_GLOB)),
 		];
 		for (const file of files) {
 			const text = await readTextIfPresent(file);
@@ -501,7 +469,7 @@ function deleteHistoryRowsForSessions(dbPath: string, sessionIds: string[]): { d
 
 async function collectArchivedSessionIds(archiveRoot: string): Promise<string[]> {
 	const ids = new Set<string>();
-	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
+	for (const file of await collectGlobFiles(archiveRoot, JSONL_GZ_GLOB)) {
 		const id = sessionLineageHeaderFromText(await readTextIfPresent(file))?.id;
 		if (id) ids.add(id);
 	}
@@ -1035,7 +1003,7 @@ async function collectArchivedStatsSessions(
 	onError: (file: string, error: unknown) => void,
 ): Promise<StatsSession[]> {
 	const sessions: StatsSession[] = [];
-	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
+	for (const file of await collectGlobFiles(archiveRoot, JSONL_GZ_GLOB)) {
 		const relative = path.relative(archiveRoot, file);
 		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
 		const sourcePath = path.join(sessionsRoot, relative.slice(0, -".gz".length));

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -11,7 +11,7 @@ import {
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
 import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi/pi-tui";
-import { formatDuration, logger, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, getSessionsDir, logger, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
 import { shouldEnableAppendOnlyContext } from "../../config/append-only-context-mode";
 import { type BashResult, isPersistentShellCdCommand } from "../../exec/bash-executor";
 import { type LoadedCustomShare, loadCustomShare } from "../../export/custom-share";
@@ -43,6 +43,11 @@ import { buildToolsMarkdown } from "../../modes/utils/tools-markdown";
 import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-storage";
 import type { CompactMode } from "../../session/compact-modes";
+import {
+	archiveSessionFile,
+	getArchivedSessionsDir,
+	sessionHasLiveNestedSessions,
+} from "../../session/session-archive";
 import type { NewSessionOptions } from "../../session/session-entries";
 import { formatShakeSummary, type ShakeMode, type ShakeResult } from "../../session/shake-types";
 import { formatActiveAccountLabel, limitMatchesActiveAccount } from "../../slash-commands/helpers/active-oauth-account";
@@ -921,7 +926,11 @@ export class CommandController {
 		}
 	}
 
-	async #runNewSessionFlow(options?: NewSessionOptions, label: string = "New session started"): Promise<void> {
+	async #runNewSessionFlow(
+		options?: NewSessionOptions,
+		label: string = "New session started",
+		afterSwitch?: () => Promise<unknown>,
+	): Promise<boolean> {
 		this.ctx.clearTransientSessionUi();
 
 		if (this.ctx.session.isCompacting) {
@@ -930,7 +939,7 @@ export class CommandController {
 				await Bun.sleep(10);
 			}
 		}
-		if (!(await this.ctx.session.newSession(options))) return;
+		if (!(await this.ctx.session.newSession(options))) return false;
 		this.ctx.resetObserverRegistry();
 		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 
@@ -940,9 +949,23 @@ export class CommandController {
 		this.ctx.clearTransientSessionUi();
 		this.ctx.resetTranscript();
 
+		if (afterSwitch) {
+			try {
+				await afterSwitch();
+			} catch (error) {
+				this.ctx.showError(
+					`Session switched, but archive failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+				await this.ctx.reloadTodos();
+				this.ctx.ui.requestRender(true, { clearScrollback: true });
+				return false;
+			}
+		}
+
 		this.ctx.present([new Spacer(1), new Text(`${theme.fg("accent", `${theme.status.success} ${label}`)}`, 1, 1)]);
 		await this.ctx.reloadTodos();
 		this.ctx.ui.requestRender(true, { clearScrollback: true });
+		return true;
 	}
 
 	async handleClearCommand(): Promise<void> {
@@ -998,6 +1021,34 @@ export class CommandController {
 			return;
 		}
 		await this.#runNewSessionFlow({ drop: true }, "Session dropped");
+	}
+
+	async handleArchiveCommand(): Promise<void> {
+		const sessionFile = this.ctx.sessionManager.getSessionFile();
+		if (!sessionFile) {
+			this.ctx.showError("Nothing to archive (in-memory session)");
+			return;
+		}
+		if (this.ctx.session.isStreaming) {
+			this.ctx.showWarning("Wait for the current response to finish or abort it before archiving.");
+			return;
+		}
+		if (await sessionHasLiveNestedSessions(sessionFile)) {
+			this.ctx.showWarning("Wait for nested sessions to finish before archiving.");
+			return;
+		}
+
+		const choice = await this.ctx.showHookSelector(
+			"Archive the current session?\nThe session will be removed from the normal /resume list\nand moved to the session archive.",
+			["Archive", "Cancel"],
+		);
+		if (choice !== "Archive") return;
+
+		this.ctx.prepareSessionSwitch();
+		const agentDir = this.ctx.settings.getAgentDir();
+		await this.#runNewSessionFlow(undefined, "Session archived", () =>
+			archiveSessionFile(sessionFile, getSessionsDir(agentDir), getArchivedSessionsDir(agentDir)),
+		);
 	}
 
 	async handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -11,7 +11,8 @@ import {
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
 import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi/pi-tui";
-import { formatDuration, getSessionsDir, logger, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, logger, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
+import { cleanupRowsForArchivedSessions } from "../../cli/gc-cli";
 import { shouldEnableAppendOnlyContext } from "../../config/append-only-context-mode";
 import { type BashResult, isPersistentShellCdCommand } from "../../exec/bash-executor";
 import { type LoadedCustomShare, loadCustomShare } from "../../export/custom-share";
@@ -44,8 +45,9 @@ import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-storage";
 import type { CompactMode } from "../../session/compact-modes";
 import {
+	archiveDestinationExists,
 	archiveSessionFile,
-	getArchivedSessionsDir,
+	resolveArchiveRoots,
 	sessionHasLiveNestedSessions,
 } from "../../session/session-archive";
 import type { NewSessionOptions } from "../../session/session-entries";
@@ -1038,17 +1040,39 @@ export class CommandController {
 			return;
 		}
 
+		const agentDir = this.ctx.settings.getAgentDir();
+		const roots = resolveArchiveRoots({
+			sessionFile,
+			sessionDir: this.ctx.sessionManager.getSessionDir(),
+			cwd: this.ctx.sessionManager.getCwd(),
+			agentDir,
+		});
+		if (!roots) {
+			this.ctx.showError("Cannot archive a session outside a sessions directory");
+			return;
+		}
+		if (await archiveDestinationExists(roots.destinationPath)) {
+			this.ctx.showError("Archive destination already exists");
+			return;
+		}
+
 		const choice = await this.ctx.showHookSelector(
 			"Archive the current session?\nThe session will be removed from the normal /resume list\nand moved to the session archive.",
 			["Archive", "Cancel"],
 		);
 		if (choice !== "Archive") return;
 
+		const sessionId = this.ctx.sessionManager.getSessionId();
 		this.ctx.prepareSessionSwitch();
-		const agentDir = this.ctx.settings.getAgentDir();
-		await this.#runNewSessionFlow(undefined, "Session archived", () =>
-			archiveSessionFile(sessionFile, getSessionsDir(agentDir), getArchivedSessionsDir(agentDir)),
-		);
+		await this.#runNewSessionFlow(undefined, "Session archived", async () => {
+			await archiveSessionFile(sessionFile, roots.sessionsRoot, roots.archiveRoot);
+			const cleanup = await cleanupRowsForArchivedSessions(agentDir, roots.archiveRoot, [
+				{ id: sessionId, path: sessionFile },
+			]);
+			if (cleanup.errors.length > 0) {
+				throw new Error(cleanup.errors.join("; "));
+			}
+		});
 	}
 
 	async handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1027,7 +1027,8 @@ export class CommandController {
 
 	async handleArchiveCommand(): Promise<void> {
 		const sessionFile = this.ctx.sessionManager.getSessionFile();
-		if (!sessionFile) {
+		// Lazy persistence allocates a path before the JSONL exists (#8860).
+		if (!sessionFile || !this.ctx.sessionManager.isSessionOnDisk()) {
 			this.ctx.showError("Nothing to archive (in-memory session)");
 			return;
 		}
@@ -1066,9 +1067,12 @@ export class CommandController {
 		this.ctx.prepareSessionSwitch();
 		await this.#runNewSessionFlow(undefined, "Session archived", async () => {
 			await archiveSessionFile(sessionFile, roots.sessionsRoot, roots.archiveRoot);
-			const cleanup = await cleanupRowsForArchivedSessions(agentDir, roots.archiveRoot, [
-				{ id: sessionId, path: sessionFile },
-			]);
+			const cleanup = await cleanupRowsForArchivedSessions(
+				agentDir,
+				roots.archiveRoot,
+				[{ id: sessionId, path: sessionFile }],
+				roots.sessionsRoot,
+			);
 			if (cleanup.errors.length > 0) {
 				throw new Error(cleanup.errors.join("; "));
 			}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1074,7 +1074,7 @@ export class CommandController {
 				roots.sessionsRoot,
 			);
 			if (cleanup.errors.length > 0) {
-				throw new Error(cleanup.errors.join("; "));
+				this.ctx.showWarning(`Database cleanup failed: ${cleanup.errors.join("; ")}`);
 			}
 		});
 	}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1052,7 +1052,7 @@ export class CommandController {
 			this.ctx.showError("Cannot archive a session outside a sessions directory");
 			return;
 		}
-		if (await archiveDestinationExists(roots.destinationPath)) {
+		if (await archiveDestinationExists(sessionFile, roots.destinationPath)) {
 			this.ctx.showError("Archive destination already exists");
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -5157,7 +5157,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		return true;
 	}
 
-	#prepareSessionSwitch(): void {
+	prepareSessionSwitch(): void {
 		this.#btwController.dispose();
 		this.#omfgController.dispose();
 		this.#cleanseController.dispose();
@@ -5168,7 +5168,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleClearCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#prepareSessionSwitch();
+		this.prepareSessionSwitch();
 		await this.#commandController.handleClearCommand();
 	}
 
@@ -5182,8 +5182,13 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleDropCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#prepareSessionSwitch();
+		this.prepareSessionSwitch();
 		await this.#commandController.handleDropCommand();
+	}
+
+	async handleArchiveCommand(): Promise<void> {
+		if (this.#vibeSessionTransitionBlocked()) return;
+		await this.#commandController.handleArchiveCommand();
 	}
 
 	async handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -384,6 +384,8 @@ export interface InteractiveModeContext {
 	handleFreshCommand(): Promise<void>;
 	handleResetContextCommand(): Promise<void>;
 	handleDropCommand(): Promise<void>;
+	handleArchiveCommand(): Promise<void>;
+	prepareSessionSwitch(): void;
 	handleForkCommand(): Promise<void>;
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;
 	handlePythonCommand(code: string, excludeFromContext?: boolean): Promise<void>;

--- a/packages/coding-agent/src/session/session-archive.ts
+++ b/packages/coding-agent/src/session/session-archive.ts
@@ -3,19 +3,71 @@ import * as path from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { getSessionsDir, hasFsCode, isEnoent } from "@oh-my-pi/pi-utils";
 import { listSessionsReadOnly, type SessionInfo } from "./session-listing";
+import { resolveManagedSessionRoot } from "./session-paths";
 import { FileSessionStorage } from "./session-storage";
 
 const JSONL_GLOB = new Bun.Glob("**/*.jsonl");
-const LIVE_NESTED_STATUSES: Record<string, true> = {
+export const LIVE_NESTED_STATUSES: Record<string, true> = {
 	pending: true,
 	interrupted: true,
 	unknown: true,
 };
-const SESSION_SUFFIX = ".jsonl";
-const COMPRESSED_SESSION_SUFFIX = ".jsonl.gz";
+export const SESSION_SUFFIX = ".jsonl";
+export const COMPRESSED_SESSION_SUFFIX = ".jsonl.gz";
+
+export function archivedSessionsDirForRoot(sessionsRoot: string): string {
+	if (path.basename(sessionsRoot) === "sessions") {
+		return path.join(path.dirname(sessionsRoot), "archive", "sessions");
+	}
+	return path.join(sessionsRoot, "archive");
+}
 
 export function getArchivedSessionsDir(agentDir: string): string {
-	return path.join(path.dirname(getSessionsDir(agentDir)), "archive", "sessions");
+	return archivedSessionsDirForRoot(getSessionsDir(agentDir));
+}
+
+/**
+ * Pick the sessions root that actually contains `sessionFile`, then the matching
+ * archive tree. Default profile sessions keep `../archive/sessions`; a custom
+ * `--session-dir` archives beside that directory. Returns null when the file is
+ * not under the session manager directory or the default store.
+ */
+export function resolveArchiveRoots(input: {
+	sessionFile: string;
+	sessionDir: string;
+	cwd: string;
+	agentDir: string;
+}): { sessionsRoot: string; archiveRoot: string; destinationPath: string } | null {
+	const sessionFile = path.resolve(input.sessionFile);
+	const sessionDir = path.resolve(input.sessionDir);
+	const candidates: string[] = [path.resolve(getSessionsDir(input.agentDir))];
+	const managedRoot = resolveManagedSessionRoot(sessionDir, input.cwd);
+	if (managedRoot) candidates.push(path.resolve(managedRoot));
+	if (path.basename(sessionDir) === "sessions") {
+		candidates.push(sessionDir);
+	} else if (path.basename(path.dirname(sessionDir)) === "sessions") {
+		candidates.push(path.dirname(sessionDir));
+	}
+	candidates.push(sessionDir);
+
+	const seen = new Set<string>();
+	for (const sessionsRoot of candidates) {
+		if (seen.has(sessionsRoot)) continue;
+		seen.add(sessionsRoot);
+		const archiveRoot = archivedSessionsDirForRoot(sessionsRoot);
+		const destination = resolveArchiveDestination(sessionFile, sessionsRoot, archiveRoot);
+		if (destination) {
+			return { sessionsRoot, archiveRoot, destinationPath: destination.destinationPath };
+		}
+	}
+	return null;
+}
+
+export async function archiveDestinationExists(destinationPath: string): Promise<boolean> {
+	const legacyDestSession = destinationPath.endsWith(".gz")
+		? destinationPath.slice(0, -".gz".length)
+		: `${destinationPath}.gz`;
+	return (await pathExists(destinationPath)) || (await pathExists(legacyDestSession));
 }
 
 export function sessionArtifactsPath(sessionPath: string): string {

--- a/packages/coding-agent/src/session/session-archive.ts
+++ b/packages/coding-agent/src/session/session-archive.ts
@@ -63,11 +63,14 @@ export function resolveArchiveRoots(input: {
 	return null;
 }
 
-export async function archiveDestinationExists(destinationPath: string): Promise<boolean> {
+export async function archiveDestinationExists(sourceSession: string, destinationPath: string): Promise<boolean> {
 	const legacyDestSession = destinationPath.endsWith(".gz")
 		? destinationPath.slice(0, -".gz".length)
 		: `${destinationPath}.gz`;
-	return (await pathExists(destinationPath)) || (await pathExists(legacyDestSession));
+	if ((await pathExists(destinationPath)) || (await pathExists(legacyDestSession))) return true;
+	const sourceArtifacts = sessionArtifactsPath(sourceSession);
+	const destArtifacts = sessionArtifactsPath(destinationPath);
+	return (await pathExists(sourceArtifacts)) && (await pathExists(destArtifacts));
 }
 
 export function sessionArtifactsPath(sessionPath: string): string {

--- a/packages/coding-agent/src/session/session-archive.ts
+++ b/packages/coding-agent/src/session/session-archive.ts
@@ -1,0 +1,174 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { getSessionsDir, hasFsCode, isEnoent } from "@oh-my-pi/pi-utils";
+import { listSessionsReadOnly, type SessionInfo } from "./session-listing";
+import { FileSessionStorage } from "./session-storage";
+
+const JSONL_GLOB = new Bun.Glob("**/*.jsonl");
+const LIVE_NESTED_STATUSES: Record<string, true> = {
+	pending: true,
+	interrupted: true,
+	unknown: true,
+};
+const SESSION_SUFFIX = ".jsonl";
+const COMPRESSED_SESSION_SUFFIX = ".jsonl.gz";
+
+export function getArchivedSessionsDir(agentDir: string): string {
+	return path.join(path.dirname(getSessionsDir(agentDir)), "archive", "sessions");
+}
+
+export function sessionArtifactsPath(sessionPath: string): string {
+	if (sessionPath.endsWith(COMPRESSED_SESSION_SUFFIX)) {
+		return sessionPath.slice(0, -COMPRESSED_SESSION_SUFFIX.length);
+	}
+	return sessionPath.slice(0, -SESSION_SUFFIX.length);
+}
+
+export function resolveArchiveDestination(
+	sessionPath: string,
+	sessionsRoot: string,
+	archiveRoot: string,
+): { relativePath: string; destinationPath: string } | null {
+	const relativePath = path.relative(sessionsRoot, sessionPath);
+	if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) return null;
+	if (!relativePath.endsWith(SESSION_SUFFIX)) return null;
+	return {
+		relativePath,
+		destinationPath: path.join(archiveRoot, `${relativePath}.gz`),
+	};
+}
+
+export async function archiveSessionFile(
+	sessionPath: string,
+	sessionsRoot: string,
+	archiveRoot: string,
+): Promise<string> {
+	const destination = resolveArchiveDestination(sessionPath, sessionsRoot, archiveRoot);
+	if (!destination) throw new Error(`session is outside the sessions directory: ${sessionPath}`);
+	await moveSessionWithArtifacts(sessionPath, destination.destinationPath);
+	return destination.destinationPath;
+}
+
+export async function sessionHasLiveNestedSessions(
+	sessionPath: string,
+	options?: { recentlyModifiedAfterMs?: number },
+): Promise<boolean> {
+	for (const nested of await listNestedSessionsReadOnly(sessionArtifactsPath(sessionPath))) {
+		if (nested.status && LIVE_NESTED_STATUSES[nested.status]) return true;
+		if (
+			options?.recentlyModifiedAfterMs !== undefined &&
+			nested.modified.getTime() > options.recentlyModifiedAfterMs
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export async function moveSessionWithArtifacts(sourceSession: string, destSession: string): Promise<void> {
+	const legacyDestSession = destSession.endsWith(".gz") ? destSession.slice(0, -".gz".length) : `${destSession}.gz`;
+	const sourceArtifacts = sessionArtifactsPath(sourceSession);
+	const destArtifacts = sessionArtifactsPath(destSession);
+	if (await pathExists(destSession)) throw new Error(`archive destination exists: ${destSession}`);
+	if (await pathExists(legacyDestSession)) throw new Error(`archive destination exists: ${legacyDestSession}`);
+	if ((await pathExists(sourceArtifacts)) && (await pathExists(destArtifacts))) {
+		throw new Error(`archive artifacts destination exists: ${destArtifacts}`);
+	}
+
+	const moved: Array<{ source: string; destination: string; compressed?: boolean }> = [];
+	try {
+		await gzipSessionFile(sourceSession, destSession);
+		moved.push({ source: sourceSession, destination: destSession, compressed: true });
+		if (await pathExists(sourceArtifacts)) {
+			await movePath(sourceArtifacts, destArtifacts);
+			moved.push({ source: sourceArtifacts, destination: destArtifacts });
+		}
+	} catch (error) {
+		for (const move of moved.reverse()) {
+			try {
+				if (move.compressed) {
+					await restoreGzipSessionFile(move.destination, move.source);
+				} else {
+					await movePath(move.destination, move.source);
+				}
+			} catch {
+				// Preserve the original failure; rollback failure is reported by the next scan.
+			}
+		}
+		throw error;
+	}
+}
+
+async function pathExists(target: string): Promise<boolean> {
+	try {
+		await fs.stat(target);
+		return true;
+	} catch (error) {
+		if (isEnoent(error)) return false;
+		throw error;
+	}
+}
+
+async function collectJsonlFiles(root: string): Promise<string[]> {
+	try {
+		const files = await Array.fromAsync(JSONL_GLOB.scan(root), name => path.join(root, name));
+		files.sort();
+		return files;
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw error;
+	}
+}
+
+async function listNestedSessionsReadOnly(artifactsRoot: string) {
+	const files = await collectJsonlFiles(artifactsRoot);
+	const dirs = [...new Set(files.map(file => path.dirname(file)))].sort();
+	const storage = new FileSessionStorage();
+	const sessions: SessionInfo[] = [];
+	for (const dir of dirs) sessions.push(...(await listSessionsReadOnly(dir, storage)));
+	sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
+	return sessions;
+}
+
+async function movePath(source: string, destination: string): Promise<void> {
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	try {
+		await fs.rename(source, destination);
+		return;
+	} catch (error) {
+		if (!hasFsCode(error, "EXDEV")) throw error;
+	}
+	const stat = await fs.stat(source);
+	if (stat.isDirectory()) {
+		await fs.cp(source, destination, { recursive: true });
+		await fs.rm(source, { recursive: true, force: true });
+		return;
+	}
+	await fs.copyFile(source, destination);
+	await fs.unlink(source);
+}
+
+async function gzipSessionFile(source: string, destination: string): Promise<void> {
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	const tempPath = `${destination}.${process.pid}.${Date.now()}.tmp`;
+	let renamed = false;
+	try {
+		const compressed = gzipSync(await Bun.file(source).bytes(), { level: 9 });
+		await Bun.write(tempPath, compressed);
+		await fs.rename(tempPath, destination);
+		renamed = true;
+		await fs.unlink(source);
+	} catch (error) {
+		await fs.rm(tempPath, { force: true });
+		if (renamed) await fs.rm(destination, { force: true });
+		throw error;
+	}
+}
+
+async function restoreGzipSessionFile(source: string, destination: string): Promise<void> {
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	const decompressed = gunzipSync(await Bun.file(source).bytes());
+	await Bun.write(destination, decompressed);
+	await fs.unlink(source);
+}

--- a/packages/coding-agent/src/session/session-archive.ts
+++ b/packages/coding-agent/src/session/session-archive.ts
@@ -162,9 +162,9 @@ async function pathExists(target: string): Promise<boolean> {
 	}
 }
 
-async function collectJsonlFiles(root: string): Promise<string[]> {
+export async function collectGlobFiles(root: string, glob: Bun.Glob): Promise<string[]> {
 	try {
-		const files = await Array.fromAsync(JSONL_GLOB.scan(root), name => path.join(root, name));
+		const files = await Array.fromAsync(glob.scan(root), name => path.join(root, name));
 		files.sort();
 		return files;
 	} catch (error) {
@@ -174,7 +174,7 @@ async function collectJsonlFiles(root: string): Promise<string[]> {
 }
 
 async function listNestedSessionsReadOnly(artifactsRoot: string) {
-	const files = await collectJsonlFiles(artifactsRoot);
+	const files = await collectGlobFiles(artifactsRoot, JSONL_GLOB);
 	const dirs = [...new Set(files.map(file => path.dirname(file)))].sort();
 	const storage = new FileSessionStorage();
 	const sessions: SessionInfo[] = [];

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -128,6 +128,19 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		},
 	},
 	{
+		name: "archive",
+		icon: "folderMove",
+		description: "Archive the current session and start a new one",
+		getTuiAutocompleteDescription: runtime =>
+			runtime.ctx.session.isStreaming
+				? "Archive: unavailable while streaming"
+				: "Archive: move current session out of /resume",
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleArchiveCommand();
+		},
+	},
+	{
 		name: "compact",
 		icon: "compress",
 		description: "Manually compact the session context",

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -551,6 +551,7 @@ describe("ACP builtin slash commands", () => {
 			"/btw hi",
 			"/new",
 			"/drop",
+			"/archive",
 			"/fork",
 		];
 		for (const cmd of removedCommands) {

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -627,10 +627,11 @@ describe("InteractiveMode vibe mode toggle", () => {
 
 		await expect(mode.handleClearCommand()).resolves.toBeUndefined();
 		await expect(mode.handleDropCommand()).resolves.toBeUndefined();
+		await expect(mode.handleArchiveCommand()).resolves.toBeUndefined();
 		await expect(mode.handleForkCommand()).resolves.toBeUndefined();
 		await expect(mode.handleMoveCommand(path.join(tempDir.path(), "other-project"))).resolves.toBeUndefined();
 
-		expect(warning).toHaveBeenCalledTimes(4);
+		expect(warning).toHaveBeenCalledTimes(5);
 		expect(warning).toHaveBeenCalledWith("Exit vibe mode first.");
 		expect(session.sessionFile).toBe(sessionFile);
 		expect(mode.vibeModeEnabled).toBe(true);

--- a/packages/coding-agent/test/session-archive.test.ts
+++ b/packages/coding-agent/test/session-archive.test.ts
@@ -155,16 +155,29 @@ describe("resolveArchiveRoots", () => {
 
 describe("archiveDestinationExists", () => {
 	test("detects a gzip or legacy uncompressed destination", async () => {
+		const source = path.join(root, "sessions", "done.jsonl");
 		const destination = path.join(root, "archive", "done.jsonl.gz");
-		expect(await archiveDestinationExists(destination)).toBe(false);
+		expect(await archiveDestinationExists(source, destination)).toBe(false);
 
 		await fs.mkdir(path.dirname(destination), { recursive: true });
 		await Bun.write(destination, "gz");
-		expect(await archiveDestinationExists(destination)).toBe(true);
+		expect(await archiveDestinationExists(source, destination)).toBe(true);
 
 		await fs.unlink(destination);
 		await Bun.write(destination.slice(0, -".gz".length), "plain");
-		expect(await archiveDestinationExists(destination)).toBe(true);
+		expect(await archiveDestinationExists(source, destination)).toBe(true);
+	});
+
+	test("detects a leftover destination artifact directory when the source has artifacts", async () => {
+		const source = path.join(root, "sessions", "done.jsonl");
+		const destination = path.join(root, "archive", "done.jsonl.gz");
+		await fs.mkdir(source.slice(0, -".jsonl".length), { recursive: true });
+		await fs.mkdir(destination.slice(0, -".jsonl.gz".length), { recursive: true });
+
+		expect(await archiveDestinationExists(source, destination)).toBe(true);
+
+		await fs.rm(source.slice(0, -".jsonl".length), { recursive: true });
+		expect(await archiveDestinationExists(source, destination)).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/session-archive.test.ts
+++ b/packages/coding-agent/test/session-archive.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+	archiveSessionFile,
+	getArchivedSessionsDir,
+	sessionHasLiveNestedSessions,
+} from "@oh-my-pi/pi-coding-agent/session/session-archive";
+import { getSessionsDir } from "@oh-my-pi/pi-utils";
+
+let root: string;
+
+beforeEach(async () => {
+	root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-session-archive-"));
+});
+
+afterEach(async () => {
+	await fs.rm(root, { recursive: true, force: true });
+});
+
+function sessionText(id: string, status: "complete" | "pending"): string {
+	const lines = [
+		JSON.stringify({ type: "session", version: 3, id, timestamp: "2026-01-01T00:00:00.000Z", cwd: "/tmp" }),
+	];
+	if (status === "complete") {
+		lines.push(JSON.stringify({ type: "message", message: { role: "assistant", content: [] } }));
+	} else {
+		lines.push(JSON.stringify({ type: "message", message: { role: "user", content: "waiting" } }));
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+async function writeSession(project: string, id: string, status: "complete" | "pending"): Promise<string> {
+	const file = path.join(getSessionsDir(root), project, `${id}.jsonl`);
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	await Bun.write(file, sessionText(id, status));
+	return file;
+}
+
+describe("archiveSessionFile", () => {
+	test("gzips the session and moves artifacts into the archive tree", async () => {
+		const session = await writeSession("project", "done", "complete");
+		const artifacts = session.slice(0, -".jsonl".length);
+		await fs.mkdir(artifacts, { recursive: true });
+		await Bun.write(path.join(artifacts, "0.bash.log"), "artifact");
+
+		const destination = await archiveSessionFile(session, getSessionsDir(root), getArchivedSessionsDir(root));
+
+		expect(destination).toBe(path.join(root, "archive", "sessions", "project", "done.jsonl.gz"));
+		expect(await Bun.file(session).exists()).toBe(false);
+		expect(await Bun.file(path.join(artifacts, "0.bash.log")).exists()).toBe(false);
+		expect(await Bun.file(destination).exists()).toBe(true);
+		expect(new TextDecoder().decode(gunzipSync(await Bun.file(destination).bytes()))).toContain('"done"');
+		expect(await Bun.file(path.join(destination.slice(0, -".jsonl.gz".length), "0.bash.log")).exists()).toBe(true);
+	});
+
+	test("refuses a path outside the sessions directory", async () => {
+		const outside = path.join(root, "other", "done.jsonl");
+		await fs.mkdir(path.dirname(outside), { recursive: true });
+		await Bun.write(outside, sessionText("done", "complete"));
+
+		await expect(archiveSessionFile(outside, getSessionsDir(root), getArchivedSessionsDir(root))).rejects.toThrow(
+			"outside the sessions directory",
+		);
+		expect(await Bun.file(outside).exists()).toBe(true);
+	});
+
+	test("leaves the source in place when the archive destination already exists", async () => {
+		const session = await writeSession("project", "done", "complete");
+		const destination = path.join(getArchivedSessionsDir(root), "project", "done.jsonl.gz");
+		await fs.mkdir(path.dirname(destination), { recursive: true });
+		await Bun.write(destination, "already-there");
+
+		await expect(archiveSessionFile(session, getSessionsDir(root), getArchivedSessionsDir(root))).rejects.toThrow(
+			"archive destination exists",
+		);
+		expect(await Bun.file(session).exists()).toBe(true);
+		expect(await Bun.file(destination).text()).toBe("already-there");
+	});
+});
+
+describe("sessionHasLiveNestedSessions", () => {
+	test("reports pending nested sessions and ignores completed ones", async () => {
+		const parent = await writeSession("project", "parent", "complete");
+		const artifacts = parent.slice(0, -".jsonl".length);
+		await fs.mkdir(artifacts, { recursive: true });
+		await Bun.write(path.join(artifacts, "child.jsonl"), sessionText("child", "pending"));
+
+		expect(await sessionHasLiveNestedSessions(parent)).toBe(true);
+
+		await Bun.write(path.join(artifacts, "child.jsonl"), sessionText("child", "complete"));
+		expect(await sessionHasLiveNestedSessions(parent)).toBe(false);
+	});
+
+	test("treats a recently modified completed nested session as live when a cutoff is set", async () => {
+		const parent = await writeSession("project", "parent", "complete");
+		const artifacts = parent.slice(0, -".jsonl".length);
+		await fs.mkdir(artifacts, { recursive: true });
+		await Bun.write(path.join(artifacts, "child.jsonl"), sessionText("child", "complete"));
+
+		expect(await sessionHasLiveNestedSessions(parent, { recentlyModifiedAfterMs: Date.now() - 60_000 })).toBe(true);
+		expect(await sessionHasLiveNestedSessions(parent, { recentlyModifiedAfterMs: Date.now() + 60_000 })).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/session-archive.test.ts
+++ b/packages/coding-agent/test/session-archive.test.ts
@@ -208,6 +208,106 @@ describe("cleanupRowsForArchivedSessions", () => {
 		).toEqual(["keep-me"]);
 		historyCheck.close();
 	});
+
+	test("transfers shared stats to a retained fork in a custom session directory", async () => {
+		const sessionDir = path.join(root, "custom-sessions");
+		await fs.mkdir(sessionDir, { recursive: true });
+		const timestamp = "2026-06-26T12:00:00.000Z";
+		const timestampMs = Date.parse(timestamp);
+		const parent = path.join(sessionDir, "parent.jsonl");
+		const child = path.join(sessionDir, "child.jsonl");
+		const sharedUser = {
+			type: "message",
+			id: "shared-user",
+			parentId: null,
+			timestamp,
+			message: { role: "user", content: "shared" },
+		};
+		const sharedAssistant = {
+			type: "message",
+			id: "shared-assistant",
+			parentId: "shared-user",
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		await Bun.write(
+			parent,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "parent-session", timestamp, cwd: "/tmp" }),
+				JSON.stringify(sharedUser),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		await Bun.write(
+			child,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "child-session",
+					timestamp,
+					cwd: "/tmp",
+					parentSession: parent,
+				}),
+				JSON.stringify(sharedUser),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+
+		const statsPath = path.join(root, "stats.db");
+		const db = new Database(statsPath);
+		db.run(
+			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run(
+			"CREATE TABLE user_messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run(
+			"CREATE TABLE tool_calls (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, tool_call_id TEXT NOT NULL, UNIQUE(session_file, tool_call_id))",
+		);
+		db.run(
+			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
+		);
+		db.prepare("INSERT INTO messages (session_file, entry_id, timestamp) VALUES (?, ?, ?)").run(
+			parent,
+			"shared-assistant",
+			timestampMs,
+		);
+		db.prepare("INSERT INTO user_messages (session_file, entry_id, timestamp) VALUES (?, ?, ?)").run(
+			parent,
+			"shared-user",
+			timestampMs,
+		);
+		db.prepare("INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)").run(parent, 1, 1);
+		const childStat = await fs.stat(child);
+		db.prepare("INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)").run(
+			child,
+			childStat.size,
+			childStat.mtimeMs,
+		);
+		db.close();
+
+		const archiveRoot = path.join(sessionDir, "archive");
+		await archiveSessionFile(parent, sessionDir, archiveRoot);
+		const cleanup = await cleanupRowsForArchivedSessions(
+			root,
+			archiveRoot,
+			[{ id: "parent-session", path: parent }],
+			sessionDir,
+		);
+
+		expect(cleanup.errors).toEqual([]);
+		const check = new Database(statsPath);
+		expect(check.prepare("SELECT session_file, entry_id FROM messages").all()).toEqual([
+			{ session_file: child, entry_id: "shared-assistant" },
+		]);
+		expect(check.prepare("SELECT session_file, entry_id FROM user_messages").all()).toEqual([
+			{ session_file: child, entry_id: "shared-user" },
+		]);
+		check.close();
+	});
 });
 
 describe("sessionHasLiveNestedSessions", () => {

--- a/packages/coding-agent/test/session-archive.test.ts
+++ b/packages/coding-agent/test/session-archive.test.ts
@@ -1,14 +1,18 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { gunzipSync } from "node:zlib";
+import { cleanupRowsForArchivedSessions } from "@oh-my-pi/pi-coding-agent/cli/gc-cli";
 import {
+	archiveDestinationExists,
 	archiveSessionFile,
 	getArchivedSessionsDir,
+	resolveArchiveRoots,
 	sessionHasLiveNestedSessions,
 } from "@oh-my-pi/pi-coding-agent/session/session-archive";
-import { getSessionsDir } from "@oh-my-pi/pi-utils";
+import { getHistoryDbPath, getSessionsDir } from "@oh-my-pi/pi-utils";
 
 let root: string;
 
@@ -78,6 +82,131 @@ describe("archiveSessionFile", () => {
 		);
 		expect(await Bun.file(session).exists()).toBe(true);
 		expect(await Bun.file(destination).text()).toBe("already-there");
+	});
+});
+
+describe("resolveArchiveRoots", () => {
+	test("keeps the default profile archive layout", () => {
+		const sessionFile = path.join(getSessionsDir(root), "project", "abc.jsonl");
+		const sessionDir = path.dirname(sessionFile);
+
+		expect(
+			resolveArchiveRoots({
+				sessionFile,
+				sessionDir,
+				cwd: "/unrelated",
+				agentDir: root,
+			}),
+		).toEqual({
+			sessionsRoot: getSessionsDir(root),
+			archiveRoot: getArchivedSessionsDir(root),
+			destinationPath: path.join(getArchivedSessionsDir(root), "project", "abc.jsonl.gz"),
+		});
+	});
+
+	test("archives beside a custom session directory", () => {
+		const sessionDir = path.join(root, "custom-sessions");
+		const sessionFile = path.join(sessionDir, "abc.jsonl");
+
+		expect(
+			resolveArchiveRoots({
+				sessionFile,
+				sessionDir,
+				cwd: "/tmp/project",
+				agentDir: root,
+			}),
+		).toEqual({
+			sessionsRoot: sessionDir,
+			archiveRoot: path.join(sessionDir, "archive"),
+			destinationPath: path.join(sessionDir, "archive", "abc.jsonl.gz"),
+		});
+	});
+
+	test("preserves cwd-key layout under a custom sessions root", () => {
+		const sessionsRoot = path.join(root, "alt", "sessions");
+		const sessionDir = path.join(sessionsRoot, "project");
+		const sessionFile = path.join(sessionDir, "abc.jsonl");
+
+		expect(
+			resolveArchiveRoots({
+				sessionFile,
+				sessionDir,
+				cwd: "/tmp/project",
+				agentDir: root,
+			}),
+		).toEqual({
+			sessionsRoot,
+			archiveRoot: path.join(root, "alt", "archive", "sessions"),
+			destinationPath: path.join(root, "alt", "archive", "sessions", "project", "abc.jsonl.gz"),
+		});
+	});
+
+	test("returns null when the session file is not under the session directory", () => {
+		expect(
+			resolveArchiveRoots({
+				sessionFile: path.join(root, "other", "abc.jsonl"),
+				sessionDir: path.join(getSessionsDir(root), "project"),
+				cwd: "/tmp",
+				agentDir: root,
+			}),
+		).toBeNull();
+	});
+});
+
+describe("archiveDestinationExists", () => {
+	test("detects a gzip or legacy uncompressed destination", async () => {
+		const destination = path.join(root, "archive", "done.jsonl.gz");
+		expect(await archiveDestinationExists(destination)).toBe(false);
+
+		await fs.mkdir(path.dirname(destination), { recursive: true });
+		await Bun.write(destination, "gz");
+		expect(await archiveDestinationExists(destination)).toBe(true);
+
+		await fs.unlink(destination);
+		await Bun.write(destination.slice(0, -".gz".length), "plain");
+		expect(await archiveDestinationExists(destination)).toBe(true);
+	});
+});
+
+describe("cleanupRowsForArchivedSessions", () => {
+	test("removes history and stats rows after a session is archived", async () => {
+		const session = await writeSession("project", "archive-me", "complete");
+		const historyPath = getHistoryDbPath(root);
+		await fs.mkdir(path.dirname(historyPath), { recursive: true });
+		const history = new Database(historyPath);
+		history.run("CREATE TABLE history (id INTEGER PRIMARY KEY AUTOINCREMENT, prompt TEXT NOT NULL, session_id TEXT)");
+		history.run("INSERT INTO history (prompt, session_id) VALUES ('old prompt', 'archive-me')");
+		history.run("INSERT INTO history (prompt, session_id) VALUES ('keep', 'keep-me')");
+		history.close();
+
+		const statsPath = path.join(root, "stats.db");
+		const stats = new Database(statsPath);
+		for (const table of ["messages", "user_messages", "tool_calls", "file_offsets"] as const) {
+			stats.run(`CREATE TABLE ${table} (session_file TEXT NOT NULL)`);
+			stats.run(`INSERT INTO ${table} (session_file) VALUES (?)`, [session]);
+			stats.run(`INSERT INTO ${table} (session_file) VALUES (?)`, [
+				path.join(getSessionsDir(root), "project", "keep.jsonl"),
+			]);
+		}
+		stats.close();
+
+		const destination = await archiveSessionFile(session, getSessionsDir(root), getArchivedSessionsDir(root));
+		const cleanup = await cleanupRowsForArchivedSessions(root, getArchivedSessionsDir(root), [
+			{ id: "archive-me", path: session },
+		]);
+
+		expect(destination).toBe(path.join(getArchivedSessionsDir(root), "project", "archive-me.jsonl.gz"));
+		expect(cleanup.errors).toEqual([]);
+		expect(cleanup.historyRowsDeleted).toBe(1);
+		expect(cleanup.statsRowsDeleted).toBe(4);
+
+		const historyCheck = new Database(historyPath);
+		expect(
+			(
+				historyCheck.prepare("SELECT session_id FROM history ORDER BY id").all() as Array<{ session_id: string }>
+			).map(row => row.session_id),
+		).toEqual(["keep-me"]);
+		historyCheck.close();
 	});
 });
 


### PR DESCRIPTION
/archive reuses the gc store and I archived a real session with it.

## What

Add a TUI-only `/archive` command that archives the current session
into the existing `omp gc --archive` store (gzipped JSONL + artifacts)
and starts a fresh session, so the old one leaves `/resume` without
being deleted.

## Why

There is no interactive way to archive the session you are in.
`omp gc --archive` only moves cold sessions. Fixes #9029.

## Testing

- `session-archive` / `gc-cli` / ACP TUI-only / vibe refusal tests
- Isolated InteractiveMode `/archive` path (confirm, cancel, nested refuse)
- Real CLI TUI: `/archive` → confirm → `Session archived`; file landed in
  `~/.omp/archive/sessions/` and disappeared from active sessions
- Manual archive of a live `/mnt/c/Users/admin` session looked correct

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)