### PR TITLE
fix(goals): register goal tool when goal mode enabled at runtime

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed goal mode failing to start (`No such tool: xd://goal`) when `goal.enabled` was turned on after the session had already started; the `goal` tool is now registered lazily on goal-mode entry ([#9444](https://github.com/can1357/oh-my-pi/issues/9444)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2793,6 +2793,31 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			return writeRegistration;
 		};
 
+		// Goal mode can be enabled after the session was created (settings UI,
+		// `/set goal.enabled true`). The eager registration above only runs at
+		// creation, so a runtime enable would leave the registry without `goal`
+		// and `#enterGoalMode`'s `setActiveToolsByName([...tools, "goal"])` would
+		// silently drop the unknown name — goal mode starts, the model is told to
+		// use the `goal` tool, and the call fails (issue #9444). Register it
+		// lazily on demand, mirroring `ensureWriteRegistered`.
+		let goalRegistration: Promise<boolean> | undefined;
+		const ensureGoalRegistered = (): Promise<boolean> => {
+			if (toolRegistry.has("goal")) return Promise.resolve(true);
+			if (restrictToolNames || !settings.get("goal.enabled")) return Promise.resolve(false);
+			goalRegistration ??= (async () => {
+				const goalTool = await logger.time("createTools:goal:session", HIDDEN_TOOLS.goal, toolSession);
+				if (!goalTool || toolRegistry.has("goal")) return toolRegistry.has("goal");
+				const nativeGoal = wrapToolWithMetaNotice(goalTool);
+				toolRegistry.set(goalTool.name, new ExtensionToolWrapper(nativeGoal, extensionRunner) as Tool);
+				builtInRegistryToolNames.add(goalTool.name);
+				nativeToolsByName.set(goalTool.name, nativeGoal);
+				return true;
+			})().finally(() => {
+				goalRegistration = undefined;
+			});
+			return goalRegistration;
+		};
+
 		// Existing staged/device paths need write registered before active-set assembly.
 		// Deferred MCP also registers it now, but refresh activates it only after a server connects.
 		// xd:// mounts never register write: xdev state only exists when the session
@@ -3535,6 +3560,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			presentationPinnedToolNames: explicitlyRequestedToolNameSet,
 			setActiveToolNames: setSessionActiveToolNames,
 			ensureWriteRegistered,
+			ensureGoalRegistered,
 			getMcpServerInstructions: mcpManager
 				? () => {
 						const raw = mcpManager.getServerInstructions();

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -184,6 +184,8 @@ export interface AgentSessionConfig {
 	setActiveToolNames?: (names: Iterable<string>) => void;
 	/** Registers the write transport when runtime xdev mounts first need it. */
 	ensureWriteRegistered?: () => Promise<boolean>;
+	/** Registers the hidden `goal` tool when goal mode is enabled at runtime. */
+	ensureGoalRegistered?: () => Promise<boolean>;
 	/** Current session pre-LLM message transform pipeline. */
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	/** Provider request transform applied after message conversion. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1345,6 +1345,7 @@ export class AgentSession {
 			mcpManagerToolNames: config.mcpManagerToolNames,
 			presentationPinnedToolNames: config.presentationPinnedToolNames,
 			ensureWriteRegistered: config.ensureWriteRegistered,
+			ensureGoalRegistered: config.ensureGoalRegistered,
 			rebuildSystemPrompt: config.rebuildSystemPrompt,
 			getMcpServerInstructions: config.getMcpServerInstructions,
 			xdev: config.xdev,

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -80,6 +80,8 @@ interface SessionToolsOptions {
 	/** MCP tool names whose current registry entries came from the manager snapshot. */
 	mcpManagerToolNames?: Iterable<string>;
 	ensureWriteRegistered?: () => Promise<boolean>;
+	/** Registers the hidden `goal` tool when goal mode is enabled at runtime. */
+	ensureGoalRegistered?: () => Promise<boolean>;
 	rebuildSystemPrompt?: (
 		toolNames: string[],
 		tools: Map<string, AgentTool>,
@@ -242,6 +244,7 @@ export class SessionTools {
 	#getMcpServerInstructions: SessionToolsOptions["getMcpServerInstructions"];
 	#setActiveToolNames: SessionToolsOptions["setActiveToolNames"];
 	#ensureWriteRegistered: SessionToolsOptions["ensureWriteRegistered"];
+	#ensureGoalRegistered: SessionToolsOptions["ensureGoalRegistered"];
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
 	#skillsSettings: SkillsSettings | undefined;
@@ -270,6 +273,7 @@ export class SessionTools {
 		}
 		this.#presentationPinnedToolNames = options.presentationPinnedToolNames;
 		this.#ensureWriteRegistered = options.ensureWriteRegistered;
+		this.#ensureGoalRegistered = options.ensureGoalRegistered;
 		this.#rebuildSystemPrompt = options.rebuildSystemPrompt;
 		this.#getMcpServerInstructions = options.getMcpServerInstructions;
 		this.#xdev = options.xdev;
@@ -838,6 +842,14 @@ export class SessionTools {
 			const writeRegistration = this.#ensureWriteRegistered?.();
 			builtInWriteAvailable = writeRegistration ? (await untilAborted(signal, writeRegistration)) === true : false;
 			if (builtInWriteAvailable) this.#builtInToolNames.add("write");
+		}
+		// Goal mode may have been enabled after session creation, leaving the
+		// registry without `goal`. Register it before resolving the selection so
+		// `#enterGoalMode`'s `[...tools, "goal"]` request is honored instead of
+		// silently dropped (issue #9444).
+		if (toolNames.includes("goal") && !this.#toolRegistry.has("goal")) {
+			const goalRegistration = this.#ensureGoalRegistered?.();
+			if (goalRegistration) await untilAborted(signal, goalRegistration);
 		}
 		const selectedTools = toolNames.flatMap(name => {
 			const tool = this.#toolRegistry.get(name);

--- a/packages/coding-agent/test/goal-tool-runtime-enable.test.ts
+++ b/packages/coding-agent/test/goal-tool-runtime-enable.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+describe("goal tool registration when goal mode is enabled at runtime", () => {
+	let tempDir: TempDir;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-repro-9444-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		session = undefined;
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	async function makeSession(goalEnabledAtStartup: boolean): Promise<AgentSession> {
+		const authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		const settings = Settings.instance;
+		settings.set("async.enabled", false);
+		settings.set("tools.xdev", true);
+		settings.set("goal.enabled", goalEnabledAtStartup);
+		const { session: created } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager,
+			authStorage,
+			modelRegistry,
+			settings,
+			model: getBundledModel("anthropic", "claude-sonnet-4-5"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			workspaceTree: {
+				rootPath: tempDir.path(),
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: [],
+			},
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		return created;
+	}
+
+	/** Mirror InteractiveMode.#enterGoalMode's tool operations. */
+	async function enterGoalMode(s: AgentSession): Promise<void> {
+		const previousTools = s.getEnabledToolNames().filter(n => n !== "goal");
+		const state = await s.goalRuntime.createGoal({ objective: "test goal" });
+		await s.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+		s.setGoalModeState(state);
+	}
+
+	it("exposes the goal tool when goal.enabled is set at startup", async () => {
+		session = await makeSession(true);
+		await enterGoalMode(session);
+		expect(session.getEnabledToolNames()).toContain("goal");
+	});
+
+	it("exposes the goal tool when goal.enabled is turned on after session start", async () => {
+		// Regression for #9444: enabling goal mode at runtime (settings UI / config
+		// reload) left the tool registry without `goal`, so entering goal mode
+		// silently dropped the name and `xd://goal` failed with "No such tool".
+		session = await makeSession(false);
+		Settings.instance.set("goal.enabled", true);
+
+		await enterGoalMode(session);
+
+		expect(session.getEnabledToolNames()).toContain("goal");
+
+		// The failing path in the report: a real xd://goal dispatch via the write
+		// transport must now resolve the tool instead of throwing.
+		const writeTool = session.agent.state.tools.find(t => t.name === "write");
+		expect(writeTool).toBeDefined();
+		const result = await writeTool!.execute("call_goal", {
+			path: "xd://goal",
+			content: JSON.stringify({ op: "get" }),
+		} as never);
+		expect(result.isError ?? false).toBe(false);
+		const text = result.content?.map(c => ("text" in c && typeof c.text === "string" ? c.text : "")).join("\n");
+		expect(text).toContain("test goal");
+	});
+});


### PR DESCRIPTION
## Repro
With goal mode disabled at startup, enable it during the session (settings UI / `/set goal.enabled true` / config reload) and run `/goal set <objective>`. Goal mode turns on and the model receives the goal-mode-active instructions, but the required `goal` call fails with `No such tool: xd://goal. Mounted devices: ...`. Reproduced on current `main` (== 18.0.1) via `packages/coding-agent/test/goal-tool-runtime-enable.test.ts`, which drives `createAgentSession` with `goal.enabled=false`, flips it on at runtime, performs the exact tool operations of `InteractiveMode.#enterGoalMode`, and then dispatches `xd://goal` through the write transport.

## Cause
The built-in `goal` tool is registered into the session tool registry only once, at session creation (`packages/coding-agent/src/sdk.ts`), gated on `settings.get("goal.enabled")` at that instant. When goal mode is enabled after the session starts, nothing ever registers the tool. `#enterGoalMode` then calls `session.setActiveToolsByName([...previousTools, "goal"])`, but `#applyActiveToolsByName` resolves names against the registry and silently drops `goal` because it isn't present — goal mode still enables and the model is told to use a tool that does not exist. The `requestedActiveToolNames` filter noted in the issue is intentional (goal is re-added on goal-mode entry); the real defect is the missing lazy registration.

## Fix
- Add an `ensureGoalRegistered` lazy-registration hook in `sdk.ts`, mirroring the existing `ensureWriteRegistered` hook: it creates, meta-wraps, and `ExtensionToolWrapper`-wraps the `goal` tool into the canonical registry (plus `builtInRegistryToolNames` / `nativeToolsByName`) on demand, gated on `goal.enabled` and `!restrictToolNames`.
- Thread the hook through `AgentSessionConfig` (`agent-session-types.ts`), `AgentSession` (`agent-session.ts`), and `SessionTools` (`session-tools.ts`).
- In `#applyActiveToolsByName`, when `goal` is requested but absent from the registry, invoke the hook before resolving the selection, so every goal-mode entry path (fresh `/goal set`, reload, guided-goal) honors the request instead of dropping it.
- Add a regression test and a CHANGELOG entry.

## Verification
`bun test test/goal-tool-runtime-enable.test.ts` — 2 pass (startup + runtime-enable). Confirmed the runtime-enable case fails without the fix (via `git stash` of the four source files) and passes with it. Also ran `test/agent-session-tool-rebuild-skip.test.ts`, `test/agent-session-acp-permission.test.ts`, `test/interactive-mode-default-plan-mode.test.ts` (80 pass total) and `bun run check:types` clean. Fixes #9444