### PR TITLE
fix(driver): report revived subagents as settled

### DIFF
--- a/crates/driver/src/chat.rs
+++ b/crates/driver/src/chat.rs
@@ -1856,9 +1856,8 @@ impl<C: TurnClient + Clone + Send + 'static> AgentsControlAuthority<C> {
 				Some(SubagentTerminalKind::Succeeded) => "completed",
 				Some(SubagentTerminalKind::Cancelled) => "cancelled",
 				Some(SubagentTerminalKind::RuntimeLimit) => "exhausted",
-				Some(SubagentTerminalKind::SchemaInvalid | SubagentTerminalKind::Failed) | None => {
-					"failed"
-				},
+				Some(SubagentTerminalKind::SchemaInvalid | SubagentTerminalKind::Failed) => "failed",
+				None => "settled",
 			},
 		}
 	}
@@ -6324,6 +6323,18 @@ mod tests {
 			model: "scripted".to_owned(),
 			..inference_pb::Outcome::default()
 		}
+	}
+
+	#[test]
+	fn revived_idle_generation_reports_settled() {
+		let state = SubagentRunState::new(sf!("revived-child"));
+		state.transition(SubagentLifecycle::Settled).unwrap();
+		state.transition(SubagentLifecycle::Parked).unwrap();
+		state.begin_generation().unwrap();
+		state.transition(SubagentLifecycle::Settled).unwrap();
+
+		assert!(state.terminal().is_none());
+		assert_eq!(AgentsControlAuthority::<ScriptedParentClient>::run_status(&state), "settled");
 	}
 
 	fn write_session(sessions_dir: &Path, root: &Path, prompt: &str, title: Option<&str>) -> Str {


### PR DESCRIPTION
## Summary

A successfully cold-revived subagent can currently appear as `failed` even though it is idle and ready.

This PR reports that state as `settled` instead.

## Why

Cold revival creates a fresh generation, rebuilds the child runtime, and returns it to the `Settled` lifecycle without a terminal outcome. The status projection currently treats the missing terminal outcome as a failure.

That makes a successful wake-up look like a crash to callers and dashboards.

## What this fixes

After this change:

- a revived idle agent with no terminal outcome reports `settled`;
- a completed agent still reports `completed`;
- a cancelled or exhausted agent keeps its existing status;
- an agent with a real failure terminal still reports `failed`.

In simple terms:

> Waking an agent up should not make it look like it failed.

## Big picture

Parking and revival are important once OMP can move agent execution between disposable or remote runtimes. The control plane needs to distinguish “ready for more work” from “broken” so human dashboards and automated routing see the same truth.

## Verification

- `just fmt-check-rust`
- `just check-pkg omp-driver`
- targeted regression test: passed

The full `just test-pkg omp-driver` command remains blocked on the checked-out `omp2` branch by the existing `#[tokio::test(start_paused = true)]` test configuration issue. I enabled Tokio's `test-util` feature locally only for the targeted test and removed that local change before committing.

## Scope

This changes only the public status projection and adds a regression test. It does not alter the revival lifecycle or runtime construction.
