### PR TITLE
fix(test): register an anthropic runtime key for the unexpected-stop guard harness

### DIFF
--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -23,6 +23,11 @@ type SettingsOverrides = Partial<Record<SettingPath, unknown>>;
 const activeHarnesses: Harness[] = [];
 const sharedAuthStorage = createInMemoryAuthStorage();
 sharedAuthStorage.setRuntimeApiKey("mock", "test-key");
+// `createHarness` streams mock responses through a bundled Anthropic model so the session
+// sees realistic model metadata. AgentSession resolves the key through `ModelRegistry`, not
+// through `Agent.getApiKey`, so that provider needs a runtime key of its own; without it
+// every `session.prompt()` throws "No API key found for anthropic".
+sharedAuthStorage.setRuntimeApiKey("anthropic", "test-key");
 const sharedModelRegistry = new ModelRegistry(sharedAuthStorage);
 
 afterAll(() => {


### PR DESCRIPTION
## Summary

`Test coding-agent runtime/session (TS)` is currently **red on every pull request** built against `main`. This is a one-line test-harness fix.

## Symptom

```
✗ packages/coding-agent (runtime/session bucket; 286 files; parallel=1 chunk 7/29; 10 files) [6.7s]
    — test/agent-session-unexpected-stop-guard.test.ts (+9 more)

error: No API key found for anthropic.
Use /login, set an API key environment variable, or create /home/runner/.omp/agent/agent.db
      at #promptWithMessage (packages/coding-agent/src/session/agent-session.ts:5729:15)
      at async prompt (packages/coding-agent/src/session/agent-session.ts:5595:28)
```

All **10** cases in `AgentSession unexpected stop guard` fail with the identical error. 28 of 29 chunks pass; only chunk 7 fails.

## Root cause

`7a55f26c` ("feat(coding-agent): added mechanical and smart unexpected-stop detection modes") changed `createHarness` to run the mock stream through a bundled Anthropic model so the session sees realistic model metadata:

```ts
const model = getBundledModel("anthropic", "claude-sonnet-4-5") ?? mock;
```

The immediately preceding commit `543d2998` still passed `model: mock`.

The shared auth storage, however, still registers a runtime key for **only** the `mock` provider:

```ts
const sharedAuthStorage = createInMemoryAuthStorage();
sharedAuthStorage.setRuntimeApiKey("mock", "test-key");
```

The harness does supply `getApiKey: () => "test-key"` to `Agent`, but `AgentSession` does not use that callback for this check — `#promptWithMessage` resolves the key through the registry instead:

```ts
const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
if (!apiKey) throw new Error(...);
```

`this.model` is now the bundled **anthropic** model, the registry has no `anthropic` key, so every `session.prompt()` throws before any assertion runs.

## Why `main` looks green

The push workflow for `main` only seeds caches (`Seed bun store cache`, `Seed darwin release bazel cache: …`) and `Evaluate flake`; the TS test buckets run under `pull_request`. So the regression never surfaced on the default branch and only appears on PRs, where CI builds the merge commit.

This also explains the confusing timeline on unrelated PRs: runs started before `7a55f26c` (05:27:02Z) are green, and every run after it is red.

## Fix

Register a runtime key for `anthropic` alongside `mock`.

```diff
 sharedAuthStorage.setRuntimeApiKey("mock", "test-key");
+sharedAuthStorage.setRuntimeApiKey("anthropic", "test-key");
```

## Scope

- Test-only. No production code touched.
- No assertion, response fixture, or setting override changed.
- Diff is **+5 / −0** in a single file (1 code line + a 4-line explanatory comment).

Opened as a draft for maintainer review — happy to fold this into whichever branch you prefer, or to switch it to deriving the provider from the bundled model if you'd rather it be drift-proof.