### PR TITLE
fix(ask): match checkbox state against raw option labels, not stripped row labels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed rich ask dialog checkboxes never visually checking for options whose labels themselves end with "(Recommended)"
+- Fixed rich ask dialog checkboxes never visually checking for options whose labels themselves end with "(Recommended)" ([#9452](https://github.com/can1357/oh-my-pi/issues/9452))
 
 ## [18.0.2] - 2026-08-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed rich ask dialog checkboxes never visually checking for options whose labels themselves end with "(Recommended)"
+
 ## [18.0.2] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -137,11 +137,6 @@ function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(value, max));
 }
 
-function stripRecommendedSuffix(label: string): string {
-	const suffix = " (Recommended)";
-	return label.endsWith(suffix) ? label.slice(0, -suffix.length) : label;
-}
-
 function questionTabLabel(question: ExtensionAskDialogQuestion, index: number): string {
 	const base = question.header?.trim() || question.id || `Q${index + 1}`;
 	return truncateToWidth(replaceTabs(base), MAX_HEADER_CHIP_WIDTH, Ellipsis.Unicode);
@@ -309,8 +304,9 @@ function renderRowLabel(
 ): string[] {
 	const isOption = rowItem.kind === "option";
 	const isOther = rowItem.kind === "other";
+	const option = rowItem.optionIndex !== undefined ? question.options[rowItem.optionIndex] : undefined;
 	const checked = isOption
-		? state.selectedOptions.has(stripRecommendedSuffix(rowItem.label))
+		? option !== undefined && state.selectedOptions.has(option.label)
 		: isOther && state.customInput !== undefined;
 	const color = selected ? "accent" : checked ? "toolOutput" : "text";
 	const marker = `${theme.fg(checked ? "success" : "dim", optionMarker(question, checked))} `;
@@ -637,7 +633,8 @@ export class AskDialogComponent implements Component {
 	}
 
 	#optionLabel(question: ExtensionAskDialogQuestion, label: string, index: number): string {
-		return question.recommended === index ? `${label} (Recommended)` : label;
+		if (question.recommended !== index) return label;
+		return label.endsWith(" (Recommended)") ? label : `${label} (Recommended)`;
 	}
 
 	#activeQuestionState(): { question: ExtensionAskDialogQuestion; state: QuestionState } | undefined {

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -227,6 +227,63 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option A"]);
 	});
 
+	it("multi-select: option whose own label ends with '(Recommended)' visibly toggles", () => {
+		const onSubmit = vi.fn();
+		const onCancel = vi.fn();
+		const onPrompt = vi.fn();
+
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose multiple?",
+				options: [{ label: "Generic loop (Recommended)" }, { label: "Option B" }],
+				multi: true,
+			},
+		];
+
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel,
+			onPrompt,
+		});
+
+		component.handleInput(SPACE);
+
+		// The checkbox must reflect the toggled-on state even though the
+		// label itself carries the "(Recommended)" marker.
+		expect(render(component)).toContain("☑");
+
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Generic loop (Recommended)"]);
+	});
+
+	it("recommended decoration is idempotent when the label already ends with '(Recommended)'", () => {
+		const onSubmit = vi.fn();
+		const onCancel = vi.fn();
+		const onPrompt = vi.fn();
+
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose multiple?",
+				options: [{ label: "Pick me (Recommended)" }, { label: "Option B" }],
+				multi: true,
+				recommended: 0,
+			},
+		];
+
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel,
+			onPrompt,
+		});
+
+		const out = render(component);
+		const matches = out.match(/\(Recommended\)/g) ?? [];
+		expect(matches.length).toBe(1);
+	});
+
 	it("tab-state persistence: answer question 0, Tab forward, Tab back, answer still present", () => {
 		const onSubmit = vi.fn();
 		const onCancel = vi.fn();


### PR DESCRIPTION
Fixes #9452.

## Problem

In the rich ask dialog, pressing Space on a multi-select option whose **own label** ends with `" (Recommended)"` never visibly toggles its checkbox — while plain rows toggle fine. Selection state actually toggles internally; only the rendered marker is stuck, so odd/even press counts silently decide the submitted result.

Root cause: the toggle handler stores the raw `option.label`, but `renderRowLabel` computed checked state as `state.selectedOptions.has(stripRecommendedSuffix(rowItem.label))`, assuming any `" (Recommended)"` suffix is dialog-added decoration (`#optionLabel` appends it when `question.recommended === index`). When the suffix is intrinsic to the model-provided label (LLMs frequently bake it in), stripping yields a string that never equals the stored raw key → `checked` permanently false for that row.

## Changes

- `renderRowLabel` now looks up the raw option label via `rowItem.optionIndex` instead of stripping the rendered row label; the now-dead `stripRecommendedSuffix` helper in this file is removed (the separate copy in `tools/ask.ts` stays — there the suffix genuinely is tool-added).
- `#optionLabel` is idempotent: labels already ending with `" (Recommended)"` are not double-suffixed when `recommended` points at them.
- Two regression tests in `test/modes/components/ask-dialog.test.ts`: intrinsic-suffix option visibly checks on Space and submits the raw label; recommended decoration does not double-suffix.
- Changelog entry under `[Unreleased] → Fixed`.

## Verification

- Pre-fix component repro at HEAD showed state toggled while render stayed `☐`; post-fix it renders checked.
- `bun check` clean.
- `bun test test/modes/components/ask-dialog.test.ts` — 43 pass (41 existing + 2 new); `test/tools/ask.test.ts` — 49 pass.
- End-to-end TUI drive (dev CLI under tmux): Space visibly flips U+F096 → U+F14A on the intrinsic-suffix row and on a plain row; submitted result preserves raw labels.
