### PR TITLE
fix(tui): show checked state for recommended-suffixed options

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-select ask options whose labels end in `(Recommended)` now show their checked state and avoid duplicate recommendation suffixes ([#9452](https://github.com/can1357/oh-my-pi/issues/9452)).
+
 ## [18.0.2] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -137,11 +137,6 @@ function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(value, max));
 }
 
-function stripRecommendedSuffix(label: string): string {
-	const suffix = " (Recommended)";
-	return label.endsWith(suffix) ? label.slice(0, -suffix.length) : label;
-}
-
 function questionTabLabel(question: ExtensionAskDialogQuestion, index: number): string {
 	const base = question.header?.trim() || question.id || `Q${index + 1}`;
 	return truncateToWidth(replaceTabs(base), MAX_HEADER_CHIP_WIDTH, Ellipsis.Unicode);
@@ -309,9 +304,9 @@ function renderRowLabel(
 ): string[] {
 	const isOption = rowItem.kind === "option";
 	const isOther = rowItem.kind === "other";
-	const checked = isOption
-		? state.selectedOptions.has(stripRecommendedSuffix(rowItem.label))
-		: isOther && state.customInput !== undefined;
+	const option = isOption ? question.options[rowItem.optionIndex ?? -1] : undefined;
+	const checked =
+		option !== undefined ? state.selectedOptions.has(option.label) : isOther && state.customInput !== undefined;
 	const color = selected ? "accent" : checked ? "toolOutput" : "text";
 	const marker = `${theme.fg(checked ? "success" : "dim", optionMarker(question, checked))} `;
 	const cursor = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
@@ -637,7 +632,9 @@ export class AskDialogComponent implements Component {
 	}
 
 	#optionLabel(question: ExtensionAskDialogQuestion, label: string, index: number): string {
-		return question.recommended === index ? `${label} (Recommended)` : label;
+		const suffix = " (Recommended)";
+		if (question.recommended !== index || label.endsWith(suffix)) return label;
+		return `${label}${suffix}`;
 	}
 
 	#activeQuestionState(): { question: ExtensionAskDialogQuestion; state: QuestionState } | undefined {

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -227,6 +227,48 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option A"]);
 	});
 
+	it("multi-select: intrinsic Recommended suffix visibly follows selection state", () => {
+		const onSubmit = vi.fn();
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "target",
+					question: "Choose multiple?",
+					options: [{ label: "Generic MLE loop (Recommended)" }, { label: "Amazon-style (LPs)" }],
+					multi: true,
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt: vi.fn() },
+		);
+
+		component.handleInput(SPACE);
+		expect(render(component)).toContain("❯ ☑ Generic MLE loop (Recommended)");
+
+		component.handleInput(SPACE);
+		expect(render(component)).toContain("❯ ☐ Generic MLE loop (Recommended)");
+
+		component.handleInput(SPACE);
+		component.handleInput(ENTER);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Generic MLE loop (Recommended)"]);
+	});
+
+	it("renders an intrinsic Recommended suffix only once for the recommended option", () => {
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "target",
+					question: "Choose one?",
+					options: [{ label: "Generic MLE loop (Recommended)" }, { label: "Amazon-style (LPs)" }],
+					recommended: 0,
+				},
+			],
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+		);
+
+		expect(render(component)).toContain("Generic MLE loop (Recommended)");
+		expect(render(component)).not.toContain("Generic MLE loop (Recommended) (Recommended)");
+	});
+
 	it("tab-state persistence: answer question 0, Tab forward, Tab back, answer still present", () => {
 		const onSubmit = vi.fn();
 		const onCancel = vi.fn();


### PR DESCRIPTION
## Repro

Instantiate `AskDialogComponent` with `multi: true` and an option labeled `Generic MLE loop (Recommended)`, then press Space. The exact component probe was `bun -e '<instantiate AskDialogComponent, press Space, render, press Enter, and print selectedOptions>'`; before the fix it rendered `❯ ☐ Generic MLE loop (Recommended)` while submitting the same raw label in `selectedOptions`.

## Cause

`renderRowLabel` in `packages/coding-agent/src/modes/components/ask-dialog.ts` stripped ` (Recommended)` from the rendered row label before checking `QuestionState.selectedOptions`, but `#handleQuestionInput` stores the raw option label. `#optionLabel` also appended the suffix without checking whether the raw label already contained it.

## Fix

- Resolve each option row through `optionIndex` and check selection against the raw option label.
- Make recommendation decoration idempotent and remove the obsolete suffix-stripping helper.
- Cover visible on/off toggles, raw-label submission, and duplicate-suffix rendering with component regressions.
- Add an Unreleased changelog entry.

## Verification

`bun test packages/coding-agent/test/modes/components/ask-dialog.test.ts` passes: 43 tests, 0 failures. The component probe now renders `❯ ☑ Generic MLE loop (Recommended)` and submits `["Generic MLE loop (Recommended)"]`. Skipped the pre-publish gate: `bun run fix` and `bun check` fail identically on `main` because `audiopus_sys` cannot invoke the missing `cmake` binary; TypeScript formatting completed and changed only the issue files before that failure.

Fixes #9452