### PR TITLE
fix(ai): classify Fireworks mid-generation NaN 400 as transient

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a Fireworks-hosted model aborting mid-generation with an HTTP 400 `Floating point NaN (not-a-number) is detected in generation` killing the turn instead of retrying; this model-side numerical fault is now classified transient and retried, matching the existing treatment of Copilot fleet-skew 400s ([#9458](https://github.com/can1357/oh-my-pi/issues/9458)).
+
 ## [18.0.2] - 2026-08-23
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -165,6 +165,15 @@ const COPILOT_TRANSIENT_MODEL_CODES: Record<string, true> = {
 	model_not_supported: true,
 };
 const COPILOT_TRANSIENT_MODEL_PATTERN = /model_not_supported/i;
+// Fireworks (and other OpenAI-compat backends) can abort mid-generation with an
+// HTTP 400 `invalid_request_error` whose body reports a model-side numerical
+// fault: "Floating point NaN (not-a-number) is detected in generation". Despite
+// the request-validation wrapper this is a decode-time logits overflow, not a
+// bad request — a byte-identical replay of the same payload succeeds. The fault
+// fires before any content is emitted, so retry is replay-safe. Kept narrow
+// (both the NaN wording and "detected in generation") so it cannot swallow
+// genuine request-validation 400s.
+const GENERATION_NAN_PATTERN = /floating[ _-]?point nan\b.*\bdetected in generation/is;
 // Anthropic strict-tool grammar too large / schema too complex (400 invalid_request_error).
 // Feature-gated deployments (Azure Foundry, Baseten, …) reject `strict: true`
 // tools outright when the hosted model lacks structured outputs, e.g.
@@ -435,6 +444,9 @@ function classifyText(
 
 		// Copilot's `model_not_supported` fleet-skew rejection is transient.
 		if (statusClean === 400 && COPILOT_TRANSIENT_MODEL_PATTERN.test(cleanMessage)) kinds |= Flag.Transient;
+		// Fireworks mid-generation NaN 400 is a model-side decode fault, not a bad
+		// request; a byte-identical replay succeeds, so treat it as transient.
+		if (statusClean === 400 && GENERATION_NAN_PATTERN.test(cleanMessage)) kinds |= Flag.Transient;
 		if (matchesStrictToolsRejection(cleanMessage, statusClean)) kinds |= Flag.Grammar;
 		if (matchesFastModeUnsupported(cleanMessage, statusClean)) kinds |= Flag.FastModeUnsupported;
 	}

--- a/packages/ai/test/error-aierr.test.ts
+++ b/packages/ai/test/error-aierr.test.ts
@@ -117,22 +117,6 @@ describe("AIError.classify — structural provider errors", () => {
 		const err = new AIError.ProviderResponseError("upstream error", { provider: "google", kind: "output" });
 		expect(AIError.retriable(AIError.classify(err))).toBe(false);
 	});
-
-	it("classifies a Fireworks mid-generation NaN 400 as transient + retryable", () => {
-		const body =
-			'400 {"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"Floating point NaN (not-a-number) is detected in generation. This is a model-side numerical error."}}';
-		const id = AIError.classify(new AIError.ProviderHttpError(body, 400, { code: "invalid_request_error" }));
-		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
-		expect(AIError.retriable(id)).toBe(true);
-	});
-
-	it("does not treat a genuine request-validation 400 as transient", () => {
-		const body =
-			'400 {"error":{"type":"invalid_request_error","message":"Invalid value for \'temperature\': must be <= 2."}}';
-		const id = AIError.classify(new AIError.ProviderHttpError(body, 400, { code: "invalid_request_error" }));
-		expect(AIError.is(id, AIError.Flag.Transient)).toBe(false);
-		expect(AIError.retriable(id)).toBe(false);
-	});
 });
 
 describe("AIError.finalize", () => {

--- a/packages/ai/test/error-aierr.test.ts
+++ b/packages/ai/test/error-aierr.test.ts
@@ -117,6 +117,22 @@ describe("AIError.classify — structural provider errors", () => {
 		const err = new AIError.ProviderResponseError("upstream error", { provider: "google", kind: "output" });
 		expect(AIError.retriable(AIError.classify(err))).toBe(false);
 	});
+
+	it("classifies a Fireworks mid-generation NaN 400 as transient + retryable", () => {
+		const body =
+			'400 {"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"Floating point NaN (not-a-number) is detected in generation. This is a model-side numerical error."}}';
+		const id = AIError.classify(new AIError.ProviderHttpError(body, 400, { code: "invalid_request_error" }));
+		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.retriable(id)).toBe(true);
+	});
+
+	it("does not treat a genuine request-validation 400 as transient", () => {
+		const body =
+			'400 {"error":{"type":"invalid_request_error","message":"Invalid value for \'temperature\': must be <= 2."}}';
+		const id = AIError.classify(new AIError.ProviderHttpError(body, 400, { code: "invalid_request_error" }));
+		expect(AIError.is(id, AIError.Flag.Transient)).toBe(false);
+		expect(AIError.retriable(id)).toBe(false);
+	});
 });
 
 describe("AIError.finalize", () => {

--- a/packages/ai/test/openai-completions-generation-nan.test.ts
+++ b/packages/ai/test/openai-completions-generation-nan.test.ts
@@ -1,0 +1,76 @@
+// Fireworks (and other OpenAI-compat backends) can abort mid-generation with an
+// HTTP 400 whose body is shaped like a request-validation error but reports a
+// model-side numerical fault: "Floating point NaN (not-a-number) is detected in
+// generation". A byte-identical replay of the same request succeeds, so the turn
+// must surface as a retryable provider error rather than a terminal 400. This
+// drives the real OpenAI-compat path (HTTP response -> SDK APIError -> finalized
+// AssistantMessage) instead of instantiating the error class directly, so a
+// regression in status/body propagation is caught, not masked.
+import { describe, expect, it } from "bun:test";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+const completionsModel = {
+	...(getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">),
+	api: "openai-completions",
+} satisfies Model<"openai-completions">;
+
+function baseContext(): Context {
+	return { messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] };
+}
+
+function jsonErrorFetch(status: number, body: unknown): FetchImpl {
+	async function mockFetch(_input: string | URL | Request, _init?: RequestInit): Promise<Response> {
+		return new Response(JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	}
+	return mockFetch as typeof fetch;
+}
+
+describe("Fireworks mid-generation NaN 400", () => {
+	it("surfaces a retryable provider error through the completions path", async () => {
+		const fetchMock = jsonErrorFetch(400, {
+			error: {
+				object: "error",
+				type: "invalid_request_error",
+				code: "invalid_request_error",
+				message:
+					"Floating point NaN (not-a-number) is detected in generation. This is a model-side numerical error.",
+			},
+		});
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(AIError.retriable(result.errorId)).toBe(true);
+		expect(AIError.is(result.errorId, AIError.Flag.Transient)).toBe(true);
+		// The classification survives a re-classify from the persisted message
+		// fields (the form loop-level salvage sees after the Error is gone).
+		const reId = AIError.classifyMessage({ errorId: result.errorId, errorMessage: result.errorMessage });
+		expect(AIError.retriable(reId)).toBe(true);
+	}, 10_000);
+
+	it("keeps a genuine request-validation 400 terminal", async () => {
+		const fetchMock = jsonErrorFetch(400, {
+			error: { type: "invalid_request_error", message: "Invalid value for 'temperature': must be <= 2." },
+		});
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(AIError.retriable(result.errorId)).toBe(false);
+		expect(AIError.is(result.errorId, AIError.Flag.Transient)).toBe(false);
+		const reId = AIError.classifyMessage({ errorId: result.errorId, errorMessage: result.errorMessage });
+		expect(AIError.retriable(reId)).toBe(false);
+	}, 10_000);
+});


### PR DESCRIPTION
## Repro
A Fireworks-hosted model (e.g. `factory/kimi-k3`) can abort mid-generation with an HTTP 400 whose body is `{"error":{"type":"invalid_request_error","code":"invalid_request_error","message":"Floating point NaN (not-a-number) is detected in generation. ..."}}`. Despite the request-validation wrapper it is a decode-time logits overflow, not a bad request — the reporter captured the exact payload and a byte-identical replay returned HTTP 200. Feeding the body through the classifier reproduces the defect: `AIError.classify(new ProviderHttpError(body, 400, { code: "invalid_request_error" }))` yields `transient? false  retriable? false`, so the turn dies with a user-visible error.

## Cause
`classifyText` in `packages/ai/src/error/flags.ts` matches no pattern for this body, so it falls through to the generic terminal-4xx path in `classify`/`retriable`. `isRetryableOneshotFailure` (`packages/ai/src/oneshot-retry.ts`) keys retry off `Flag.Transient`, which is never set — the neighbouring Copilot `model_not_supported` fleet-skew 400 is the only 400 already exempted there.

## Fix
- Add `GENERATION_NAN_PATTERN` in `flags.ts`, deliberately narrow (requires both the NaN wording and `detected in generation`) so it cannot swallow genuine request-validation 400s.
- Set `Flag.Transient` on a status-400 message matching that pattern, directly beside the existing Copilot line.
- Regression tests in `packages/ai/test/error-aierr.test.ts`: the NaN 400 is now transient + retryable, and a genuine parameter-validation 400 stays terminal.
- Changelog entry under `packages/ai/CHANGELOG.md` `[Unreleased]`.

## Verification
`bun test test/error-aierr.test.ts test/error-id.test.ts test/error-transient-status-boundary.test.ts` in `packages/ai` — 40 pass, 0 fail. The new NaN-400 case now classifies transient + retryable; the validation-400 case remains terminal. Fixes #9458