### PR TITLE
test(coding-agent): fix red runtime/session job on main

### DIFF
--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -23,6 +23,7 @@ type SettingsOverrides = Partial<Record<SettingPath, unknown>>;
 const activeHarnesses: Harness[] = [];
 const sharedAuthStorage = createInMemoryAuthStorage();
 sharedAuthStorage.setRuntimeApiKey("mock", "test-key");
+sharedAuthStorage.setRuntimeApiKey("anthropic", "test-key");
 const sharedModelRegistry = new ModelRegistry(sharedAuthStorage);
 
 afterAll(() => {


### PR DESCRIPTION
`Test coding-agent runtime/session (TS)` is red on main. All 10 tests in `packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts` throw:

```
error: No API key found for anthropic.
  at #promptWithMessage (packages/coding-agent/src/session/agent-session.ts:5729)
```

**cause**

`7a55f26` changed the harness session model:

```ts
const model = getBundledModel("anthropic", "claude-sonnet-4-5") ?? mock;
```

The shared auth storage above it still only registers `mock`:

```ts
const sharedAuthStorage = createInMemoryAuthStorage();
sharedAuthStorage.setRuntimeApiKey("mock", "test-key");
```

So `#promptWithMessage` asks the registry for an anthropic key, gets nothing, and throws before any assertion runs. Responses still come from the mock, only the descriptor changed, so the harness just needs the matching key registered.

**fix**

One line: register `anthropic` alongside `mock`.

**verification**

Reproduced on a clean `origin/main` checkout at `b214f5a1` with zero diff (0 pass / 10 fail), then 10 pass / 0 fail with this line. Green main CI was `6c12098`; first red was `91e79b8`, and `7a55f26` is in that range.

Found while chasing the same red job on #8919, where it is the only remaining blocker.