### PR TITLE
fix(coding-agent): reclaim the Windows console title after another process hijacks it

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows: the terminal/tab title is now reclaimed automatically when another attached process (e.g. an npm `cmd` shim's `title %COMSPEC%` or a child writing `process.title`) overwrites it mid-session
+
 ## [18.0.2] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -37,11 +37,18 @@ function writeTitleSequence(seq: string): void {
 
 interface WindowsConsoleTitleApi {
 	set(title: string): boolean;
+	/** Current console title; `""` when it is empty or the call reports failure. */
+	get(): string;
 	close(): void;
 }
 
 let windowsConsoleTitleApi: WindowsConsoleTitleApi | null | undefined;
 let lastTerminalTitle: string | undefined;
+/** Whether {@link lastTerminalTitle} was written via `SetConsoleTitleW` (vs the OSC fallback). */
+let lastTerminalTitleNativelySet = false;
+
+/** WCHAR capacity for GetConsoleTitleW; terminal titles are short, so 2048 is ample. */
+const CONSOLE_TITLE_WCHAR_CAPACITY = 2048;
 
 function getWindowsConsoleTitleApi(): WindowsConsoleTitleApi | null {
 	if (process.platform !== "win32") return null;
@@ -49,11 +56,19 @@ function getWindowsConsoleTitleApi(): WindowsConsoleTitleApi | null {
 	try {
 		const kernel32 = dlopen("kernel32.dll", {
 			SetConsoleTitleW: { args: [FFIType.ptr], returns: FFIType.bool },
+			GetConsoleTitleW: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.u32 },
 		});
 		windowsConsoleTitleApi = {
 			set(title) {
 				const wideTitle = Buffer.from(`${title}\0`, "utf16le");
 				return kernel32.symbols.SetConsoleTitleW(ptr(wideTitle));
+			},
+			get() {
+				const wideTitle = Buffer.alloc(CONSOLE_TITLE_WCHAR_CAPACITY * 2);
+				const chars = kernel32.symbols.GetConsoleTitleW(ptr(wideTitle), CONSOLE_TITLE_WCHAR_CAPACITY);
+				// A zero return means failure or an empty title; either way it can
+				// never equal the expected non-empty title, so report "" (drifted).
+				return chars === 0 ? "" : wideTitle.toString("utf16le", 0, chars * 2);
 			},
 			close: () => kernel32.close(),
 		};
@@ -73,6 +88,30 @@ function setWindowsConsoleTitle(title: string): boolean {
 			api.close();
 		} catch {
 			// Ignore cleanup failures after the native title path has already failed.
+		}
+		windowsConsoleTitleApi = null;
+		return false;
+	}
+}
+
+/**
+ * On Windows the console title is shared mutable state: any attached process
+ * can overwrite it (an npm `cmd` shim's `title %COMSPEC%`, a child setting
+ * `process.title`, …). Compare the cached expectation against the live console
+ * title so a hijacked tab is repaired on the next title emit instead of being
+ * skipped by the dedup fast path. Reads that cannot be performed (FFI missing,
+ * non-Windows) report no drift, preserving the old behavior.
+ */
+function windowsConsoleTitleDrifted(expected: string): boolean {
+	const api = getWindowsConsoleTitleApi();
+	if (!api) return false;
+	try {
+		return api.get() !== expected;
+	} catch {
+		try {
+			api.close();
+		} catch {
+			// Ignore cleanup failures after the native title read has already failed.
 		}
 		windowsConsoleTitleApi = null;
 		return false;
@@ -455,13 +494,19 @@ export function formatSessionTerminalTitle(sessionName: string | undefined, cwd?
 /**
  * Set the terminal title through the native Win32 API or OSC 0.
  *
- * Repeating the same sanitized title is a no-op on every platform.
+ * Repeating the same sanitized title is a no-op — except on Windows, where the
+ * console title is shared mutable state: when the previous write went through
+ * `SetConsoleTitleW` and another attached process has overwritten the title
+ * since, the cached title is re-emitted to reclaim the tab (see
+ * {@link windowsConsoleTitleDrifted}). On the OSC fallback path dedup stays a
+ * pure no-op.
  */
 export function setTerminalTitle(title: string): void {
 	if (!process.stdout.isTTY || isTerminalHeadless()) return;
 	const next = sanitizeTerminalTitlePart(title) ?? DEFAULT_TERMINAL_TITLE;
-	if (next === lastTerminalTitle) return;
-	if (!setWindowsConsoleTitle(next)) writeTitleSequence(`\x1b]0;${next}\x07`);
+	if (next === lastTerminalTitle && !(lastTerminalTitleNativelySet && windowsConsoleTitleDrifted(next))) return;
+	lastTerminalTitleNativelySet = setWindowsConsoleTitle(next);
+	if (!lastTerminalTitleNativelySet) writeTitleSequence(`\x1b]0;${next}\x07`);
 	lastTerminalTitle = next;
 }
 
@@ -599,6 +644,7 @@ export function disposeTerminalTitleState(): void {
 	stopTerminalTitleSpinner();
 	disposeWindowsConsoleTitleApi();
 	lastTerminalTitle = undefined;
+	lastTerminalTitleNativelySet = false;
 }
 
 /**

--- a/packages/coding-agent/test/terminal-title-test-utils.ts
+++ b/packages/coding-agent/test/terminal-title-test-utils.ts
@@ -1,9 +1,17 @@
 import * as ffi from "bun:ffi";
 import { spyOn } from "bun:test";
 
-/** Controls the fake `SetConsoleTitleW` implementation installed for a test. */
+/**
+ * Controls the fake `kernel32.dll` console-title implementation installed for a
+ * test. `set()` calls are recorded in {@link titles}; {@link current} is what
+ * `GetConsoleTitleW` reports back, and a successful `set()` updates it so the
+ * console retains the write like the real one does. Point tests can overwrite
+ * `current` directly to simulate an external attached process hijacking the
+ * shared console title mid-session.
+ */
 export interface WindowsConsoleTitleMock {
 	readonly titles: string[];
+	current: string;
 	succeeds: boolean;
 	restore(): void;
 }
@@ -19,27 +27,43 @@ function readWideTitle(pointer: ffi.Pointer): string {
 
 /** Installs a type-safe `kernel32.dll` FFI double until {@link WindowsConsoleTitleMock.restore} runs. */
 export function mockWindowsConsoleTitle(): WindowsConsoleTitleMock {
-	let callback: ffi.JSCallback | undefined;
+	let setCallback: ffi.JSCallback | undefined;
+	let getCallback: ffi.JSCallback | undefined;
 	const mock: WindowsConsoleTitleMock = {
 		titles: [],
+		current: "",
 		succeeds: false,
 		restore() {
 			dlopenSpy.mockRestore();
-			callback?.close();
+			setCallback?.close();
+			getCallback?.close();
 		},
 	};
 	const dlopenSpy = spyOn(ffi, "dlopen").mockImplementation((_name, symbols) => {
-		callback = new ffi.JSCallback(
+		setCallback = new ffi.JSCallback(
 			(pointer: ffi.Pointer) => {
 				if (!mock.succeeds) return false;
-				mock.titles.push(readWideTitle(pointer));
+				const title = readWideTitle(pointer);
+				mock.titles.push(title);
+				mock.current = title;
 				return true;
 			},
 			{ args: [ffi.FFIType.ptr], returns: ffi.FFIType.bool },
 		);
-		const definition: unknown = Reflect.get(symbols, "SetConsoleTitleW");
-		if (!definition || typeof definition !== "object") throw new Error("SetConsoleTitleW binding missing");
-		Reflect.set(definition, "ptr", callback.ptr);
+		getCallback = new ffi.JSCallback(
+			(pointer: ffi.Pointer, sizeChars: number) => {
+				if (sizeChars <= 0) return 0;
+				const capped = mock.current.slice(0, sizeChars - 1);
+				ffi.toBuffer(pointer, 0, sizeChars * 2).write(`${capped}\0`, "utf16le");
+				return capped.length;
+			},
+			{ args: [ffi.FFIType.ptr, ffi.FFIType.u32], returns: ffi.FFIType.u32 },
+		);
+		for (const name of ["SetConsoleTitleW", "GetConsoleTitleW"] as const) {
+			const definition: unknown = Reflect.get(symbols, name);
+			if (!definition || typeof definition !== "object") throw new Error(`${name} binding missing`);
+			Reflect.set(definition, "ptr", name === "SetConsoleTitleW" ? setCallback.ptr : getCallback.ptr);
+		}
 		return ffi.linkSymbols(symbols);
 	});
 	return mock;

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -768,4 +768,50 @@ describe("terminal title runtime", () => {
 			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
 		}
 	});
+
+	it("re-emits an unchanged title after another process hijacks the Windows console title", () => {
+		// CONTRACT (regression): on Windows the console title is shared mutable
+		// state — an npm `cmd` shim's `title %COMSPEC%` or a child setting
+		// `process.title` overwrites the tab title while omp keeps running. A
+		// dedup-skipped emit must compare the cached title against the live
+		// console title and re-write it when they diverge, reclaiming the tab
+		// instead of staying hijacked until the next title change.
+		const originalPlatform = process.platform;
+		const native = windowsTitleMock;
+		if (!native) throw new Error("Windows console title mock not initialized");
+		native.succeeds = true;
+		try {
+			Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+			setTerminalTitle("π > my-project");
+			setTerminalTitle("π > my-project");
+			// No drift: the dedup fast path still suppresses the second write.
+			expect(native.titles).toEqual(["π > my-project"]);
+
+			// An attached process overwrites the shared console title.
+			native.current = "C:\\WINDOWS\\system32\\cmd.exe ";
+
+			setTerminalTitle("π > my-project");
+			expect(native.titles).toEqual(["π > my-project", "π > my-project"]);
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+		}
+	});
+
+	it("keeps OSC-fallback dedup a pure no-op even when the console title differs", () => {
+		// CONTRACT: the drift check only guards titles written via
+		// SetConsoleTitleW. When the previous write fell back to OSC (no FFI),
+		// there is no live console title to compare against, so repeating the
+		// same title must not re-emit.
+		const native = windowsTitleMock;
+		if (!native) throw new Error("Windows console title mock not initialized");
+		native.succeeds = false;
+		native.current = "hijacked by someone else";
+
+		setTerminalTitle("osc fallback title");
+		setTerminalTitle("osc fallback title");
+
+		expect(emittedTitles()).toEqual(["osc fallback title"]);
+		expect(writes).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Problem

On Windows, omp's Windows Terminal tab title sometimes turns into `C:\WINDOWS\system32\cmd.exe ` (the value of `%COMSPEC%`, plus a trailing space) and stays stuck until that session's title next changes.

The console title is **shared mutable state**: any process attached to the same console can overwrite it. The common trigger on Windows is npm's `.cmd` shim template, which contains `title %COMSPEC%` — when omp spawns such a shim attached to the shared console (MCP servers, npx-style launches), the shim immediately overwrites the tab title. A child writing `process.title` does the same.

`setTerminalTitle` dedupes repeated writes (introduced with the `SetConsoleTitleW` switch: *"Reduced terminal-title update overhead by deduplicating unchanged titles on every platform"*). Once the title is hijacked, the next emit computes the same string, hits `next === lastTerminalTitle`, and skips the write — the tab stays hijacked until a label/state change produces a different string.

## Fix

Before honoring the dedup fast path, compare the cached title against the live console title via `GetConsoleTitleW` and re-emit on divergence:

- The drift check only runs when the previous write went through `SetConsoleTitleW` (tracked by a flag). On the OSC fallback path there is no live console title to read back, so dedup stays a pure no-op there.
- Reads that cannot be performed (FFI unavailable, non-Windows) report no drift — identical behavior to before.
- Cost: one native read per dedup-hit; on Windows the working-state spinner is disabled, so `setTerminalTitle` runs only on label/state changes.

## Verification

Reproduced in a **real Windows console** with the actual module (no mocks): the driver writes the title natively, then an attached `cmd /d /c "title C:\WINDOWS\system32\cmd.exe "` hijacks it (byte-for-byte what an npm shim does), then re-emits the **same** title:

| step | pre-fix | post-fix |
|---|---|---|
| 1. `setTerminalTitle("π > verify-project")` | `π > verify-project` | `π > verify-project` |
| 2. attached cmd.exe hijacks the title | `C:\WINDOWS\system32\cmd.exe ` | `C:\WINDOWS\system32\cmd.exe ` |
| 3. re-emit the **same** title | `C:\WINDOWS\system32\cmd.exe ` — stuck, dedup skipped the write | `π > verify-project` — reclaimed |
| 4. another identical emit (no drift) | unchanged | unchanged — dedup still a no-op |

- `bun test test/title-generator.test.ts test/terminal-title-state.test.ts`: **44 pass, 0 fail** (1 pre-existing `skipIf(isConPTYHosted())` skip on Windows; it runs on CI), including two new regression tests: hijack → reclaim, and OSC-fallback dedup stays a pure no-op.
- `bun run lint`, `bun run check:types`: clean. `biome check` clean on changed files.
- Remaining full-suite failures on my Windows machine are pre-existing/environmental (symlink semantics, network-dependent timeouts) — reproduced identically on a pristine checkout before applying this change.

<!-- TODO(author): replace this comment with at least one sentence in your own words explaining what changed and why (CONTRIBUTING requirement) -->
