### PR TITLE
fix(eval): bound runtime availability probes with timeout and stdin ignore

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Eval runtime-availability probes (Python/Ruby/Julia) no longer inherit the host stdin handle and are now bounded by the eval call's timeout and abort signal, so a probe that hangs during backend resolution — e.g. the native-Windows inherited-stdin wedge — returns a clear error instead of wedging the whole turn indefinitely ([#9466](https://github.com/can1357/oh-my-pi/issues/9466)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/eval/backend.ts
+++ b/packages/coding-agent/src/eval/backend.ts
@@ -1,5 +1,6 @@
 import { buildEvalUrlRoots, type LocalProtocolOptions } from "../internal-urls";
 import type { ToolSession } from "../tools";
+import type { BackendProbeOptions } from "./probe";
 import type { EvalDisplayOutput, EvalLanguage, EvalStatusEvent } from "./types";
 
 /** Per-cell execute() options. */
@@ -50,8 +51,8 @@ export interface ExecutorBackend {
 	readonly label: string;
 	/** Source language identifier passed to the syntax highlighter (e.g. "python", "javascript"). */
 	readonly highlightLang: string;
-	/** Cheap availability check. Used by fallback resolution. */
-	isAvailable(session: ToolSession): Promise<boolean>;
+	/** Cheap availability check. Used by fallback resolution and bounded by the caller's probe options. */
+	isAvailable(session: ToolSession, opts?: BackendProbeOptions): Promise<boolean>;
 	/** Execute one cell. Caller invokes once per cell and aggregates results. */
 	execute(code: string, opts: ExecutorBackendExecOptions): Promise<ExecutorBackendResult>;
 }

--- a/packages/coding-agent/src/eval/jl/index.ts
+++ b/packages/coding-agent/src/eval/jl/index.ts
@@ -10,6 +10,7 @@ import {
 	readInterpreterSetting as sharedReadInterpreterSetting,
 	toExecutorBackendResult,
 } from "../backend-helpers";
+import type { BackendProbeOptions } from "../probe";
 import { executeJulia } from "./executor";
 import { checkJuliaKernelAvailability } from "./kernel";
 
@@ -28,8 +29,8 @@ export default {
 	label: "Julia",
 	highlightLang: "julia",
 
-	async isAvailable(session: ToolSession): Promise<boolean> {
-		const availability = await checkJuliaKernelAvailability(session.cwd, readInterpreterSetting(session));
+	async isAvailable(session: ToolSession, opts?: BackendProbeOptions): Promise<boolean> {
+		const availability = await checkJuliaKernelAvailability(session.cwd, readInterpreterSetting(session), opts);
 		return availability.ok;
 	},
 

--- a/packages/coding-agent/src/eval/jl/kernel.ts
+++ b/packages/coding-agent/src/eval/jl/kernel.ts
@@ -7,9 +7,9 @@
  */
 import * as path from "node:path";
 import { $flag, Snowflake } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelStartOptions } from "../kernel-base";
+import { type BackendProbeOptions, runBoundedProbe } from "../probe";
 import type { KernelDisplayOutput } from "../py/display";
 import { hostHasInheritableConsole, shouldDetachKernel, shouldHideKernelWindow } from "../py/spawn-options";
 import { stageRunnerScript } from "../runner-cache";
@@ -59,11 +59,12 @@ const availabilityCache = new Map<string, Promise<JuliaKernelAvailability>>();
 export async function checkJuliaKernelAvailability(
 	cwd: string,
 	interpreter?: string,
+	options?: BackendProbeOptions,
 ): Promise<JuliaKernelAvailability> {
 	const cacheKey = `${path.resolve(cwd)}::${interpreter ?? ""}`;
 	let cached = availabilityCache.get(cacheKey);
 	if (!cached) {
-		cached = probeJuliaKernelAvailability(cwd, interpreter);
+		cached = probeJuliaKernelAvailability(cwd, interpreter, options);
 		availabilityCache.set(cacheKey, cached);
 	}
 	const result = await cached;
@@ -73,7 +74,11 @@ export async function checkJuliaKernelAvailability(
 	return result;
 }
 
-async function probeJuliaKernelAvailability(cwd: string, interpreter?: string): Promise<JuliaKernelAvailability> {
+async function probeJuliaKernelAvailability(
+	cwd: string,
+	interpreter?: string,
+	probeOpts?: BackendProbeOptions,
+): Promise<JuliaKernelAvailability> {
 	const { env: shellEnv } = (await Settings.init()).getShellConfig();
 	const baseEnv = filterEnv(shellEnv);
 	const runtimes = enumerateJuliaRuntimes(cwd, baseEnv, interpreter);
@@ -88,11 +93,23 @@ async function probeJuliaKernelAvailability(cwd: string, interpreter?: string): 
 	const failures: string[] = [];
 	for (const runtime of runtimes) {
 		try {
-			const probe = await $`${runtime.juliaPath} -e "exit(0)"`.quiet().nothrow().cwd(cwd).env(runtime.env);
+			const probe = await runBoundedProbe([runtime.juliaPath, "-e", "exit(0)"], {
+				cwd,
+				env: runtime.env,
+				signal: probeOpts?.signal,
+				timeoutMs: probeOpts?.timeoutMs,
+			});
 			if (probe.exitCode === 0) {
 				return { ok: true, juliaPath: runtime.juliaPath, runtime };
 			}
-			failures.push(`${runtime.juliaPath} (exit code ${probe.exitCode})`);
+			if (probe.aborted) {
+				return { ok: false, juliaPath: runtime.juliaPath, reason: "Julia availability probe was cancelled." };
+			}
+			failures.push(
+				probe.timedOut
+					? `${runtime.juliaPath} (probe timed out)`
+					: `${runtime.juliaPath} (exit code ${probe.exitCode})`,
+			);
 		} catch (err) {
 			failures.push(`${runtime.juliaPath} (${err instanceof Error ? err.message : String(err)})`);
 		}

--- a/packages/coding-agent/src/eval/jl/kernel.ts
+++ b/packages/coding-agent/src/eval/jl/kernel.ts
@@ -9,7 +9,7 @@ import * as path from "node:path";
 import { $flag, Snowflake } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelStartOptions } from "../kernel-base";
-import { type BackendProbeOptions, runBoundedProbe } from "../probe";
+import { type BackendProbeOptions, probeCandidates } from "../probe";
 import type { KernelDisplayOutput } from "../py/display";
 import { hostHasInheritableConsole, shouldDetachKernel, shouldHideKernelWindow } from "../py/spawn-options";
 import { stageRunnerScript } from "../runner-cache";
@@ -90,35 +90,25 @@ async function probeJuliaKernelAvailability(
 		};
 	}
 
-	const failures: string[] = [];
-	for (const runtime of runtimes) {
-		try {
-			const probe = await runBoundedProbe([runtime.juliaPath, "-e", "exit(0)"], {
-				cwd,
-				env: runtime.env,
-				signal: probeOpts?.signal,
-				timeoutMs: probeOpts?.timeoutMs,
-			});
-			if (probe.exitCode === 0) {
-				return { ok: true, juliaPath: runtime.juliaPath, runtime };
-			}
-			if (probe.aborted) {
-				return { ok: false, juliaPath: runtime.juliaPath, reason: "Julia availability probe was cancelled." };
-			}
-			failures.push(
-				probe.timedOut
-					? `${runtime.juliaPath} (probe timed out)`
-					: `${runtime.juliaPath} (exit code ${probe.exitCode})`,
-			);
-		} catch (err) {
-			failures.push(`${runtime.juliaPath} (${err instanceof Error ? err.message : String(err)})`);
-		}
+	const result = await probeCandidates(
+		runtimes.map(runtime => ({
+			command: [runtime.juliaPath, "-e", "exit(0)"],
+			env: runtime.env,
+			label: runtime.juliaPath,
+		})),
+		{ cwd, signal: probeOpts?.signal, timeoutMs: probeOpts?.timeoutMs },
+	);
+	if (result.ok) {
+		const runtime = runtimes[result.index];
+		return { ok: true, juliaPath: runtime.juliaPath, runtime };
 	}
-
+	if (result.aborted) {
+		return { ok: false, juliaPath: runtimes[0].juliaPath, reason: "Julia availability probe was cancelled." };
+	}
 	return {
 		ok: false,
 		juliaPath: runtimes[0].juliaPath,
-		reason: `No working Julia interpreter found. Tried: ${failures.join("; ")}`,
+		reason: `No working Julia interpreter found. Tried: ${result.failures.join("; ")}`,
 	};
 }
 

--- a/packages/coding-agent/src/eval/probe.ts
+++ b/packages/coding-agent/src/eval/probe.ts
@@ -77,20 +77,22 @@ export async function runBoundedProbe(
 	});
 	let timedOut = false;
 	let aborted = false;
-	const kill = (): void => {
+	const forceKill = (): void => {
 		try {
-			proc.kill();
+			// Availability probes own no persistent state. Use SIGKILL directly:
+			// a shim that ignores SIGTERM must not outlive the discovery bound.
+			proc.kill("SIGKILL");
 		} catch {
 			// Already exited; nothing to reap.
 		}
 	};
 	const timer = setTimeout(() => {
 		timedOut = true;
-		kill();
+		forceKill();
 	}, bound);
 	const onAbort = (): void => {
 		aborted = true;
-		kill();
+		forceKill();
 	};
 	signal?.addEventListener("abort", onAbort, { once: true });
 	try {

--- a/packages/coding-agent/src/eval/probe.ts
+++ b/packages/coding-agent/src/eval/probe.ts
@@ -1,0 +1,103 @@
+/**
+ * Bounded runtime-availability probe shared by the Python/Ruby/Julia eval
+ * backends.
+ *
+ * Each per-language `checkXKernelAvailability` helper runs a tiny "does this
+ * interpreter start" command (`python -c "import sys;sys.exit(0)"` and friends)
+ * during `resolveBackend()` — before the eval cell's `IdleTimeout` is armed.
+ * Two footguns let that probe wedge an entire agent turn (issue #9466):
+ *
+ *   1. Bun's `$` shell inherits the host stdin handle. On native Windows an
+ *      inherited RPC/console stdin handle keeps the probe subprocess alive
+ *      indefinitely even though the script never reads stdin.
+ *   2. The probe had no timeout and honored no AbortSignal, so nothing bounded
+ *      a hung interpreter and the documented eval timeout — armed only later —
+ *      could never cancel it.
+ *
+ * {@link runBoundedProbe} spawns with stdin/stdout/stderr detached, enforces a
+ * wall-clock timeout, and honors an optional AbortSignal so a turn abort tears
+ * the probe down instead of leaking the subprocess.
+ */
+
+/** Wall-clock ceiling for a runtime-availability probe when no smaller bound is supplied. */
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Cancellation controls threaded from the eval tool through
+ * `resolveBackend` → `ExecutorBackend.isAvailable` → `checkXKernelAvailability`
+ * so backend discovery is bounded by the same timeout and turn abort as the
+ * eval cell that triggered it.
+ */
+export interface BackendProbeOptions {
+	/** Aborts the probe when the parent turn is cancelled. */
+	signal?: AbortSignal;
+	/** Wall-clock ceiling in ms; clamped to {@link DEFAULT_PROBE_TIMEOUT_MS}. */
+	timeoutMs?: number;
+}
+
+/** Outcome of a single bounded probe spawn. */
+export interface BoundedProbeResult {
+	/** Process exit code, or `null` when killed by timeout/abort. */
+	exitCode: number | null;
+	/** The probe exceeded its wall-clock bound and was killed. */
+	timedOut: boolean;
+	/** The probe was killed via the supplied AbortSignal. */
+	aborted: boolean;
+}
+
+export interface BoundedProbeSpawnOptions extends BackendProbeOptions {
+	cwd: string;
+	env: Record<string, string | undefined>;
+}
+
+/**
+ * Spawn `command` detached from the host's stdio, bounded by a timeout and an
+ * optional AbortSignal. Never inherits stdin (the Windows wedge in #9466) and
+ * always resolves — a hung interpreter yields `{ timedOut: true, exitCode: null }`
+ * rather than an unsettled promise.
+ *
+ * Throws only when the spawn itself fails (e.g. ENOENT); callers already treat
+ * that as an unavailable candidate.
+ */
+export async function runBoundedProbe(
+	command: string[],
+	{ cwd, env, signal, timeoutMs }: BoundedProbeSpawnOptions,
+): Promise<BoundedProbeResult> {
+	if (signal?.aborted) {
+		return { exitCode: null, timedOut: false, aborted: true };
+	}
+	const bound = Math.min(timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROBE_TIMEOUT_MS, DEFAULT_PROBE_TIMEOUT_MS);
+	const proc = Bun.spawn(command, {
+		cwd,
+		env,
+		stdin: "ignore",
+		stdout: "ignore",
+		stderr: "ignore",
+		windowsHide: true,
+	});
+	let timedOut = false;
+	let aborted = false;
+	const kill = (): void => {
+		try {
+			proc.kill();
+		} catch {
+			// Already exited; nothing to reap.
+		}
+	};
+	const timer = setTimeout(() => {
+		timedOut = true;
+		kill();
+	}, bound);
+	const onAbort = (): void => {
+		aborted = true;
+		kill();
+	};
+	signal?.addEventListener("abort", onAbort, { once: true });
+	try {
+		const exitCode = await proc.exited;
+		return { exitCode: timedOut || aborted ? null : exitCode, timedOut, aborted };
+	} finally {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", onAbort);
+	}
+}

--- a/packages/coding-agent/src/eval/probe.ts
+++ b/packages/coding-agent/src/eval/probe.ts
@@ -101,3 +101,61 @@ export async function runBoundedProbe(
 		signal?.removeEventListener("abort", onAbort);
 	}
 }
+
+/** A single interpreter candidate to probe, plus the label used in failure messages. */
+export interface ProbeCandidate {
+	/** Full argv to spawn, e.g. `[pythonPath, "-c", "import sys;sys.exit(0)"]`. */
+	command: string[];
+	/** Filtered environment for this candidate. */
+	env: Record<string, string | undefined>;
+	/** Human-readable identifier (typically the interpreter path). */
+	label: string;
+}
+
+/** Outcome of probing an ordered candidate list under one shared deadline. */
+export type CandidateProbeResult = { ok: true; index: number } | { ok: false; aborted: boolean; failures: string[] };
+
+/**
+ * Probe candidates in priority order and return the first that exits 0, sharing
+ * ONE discovery deadline across the whole list. Each candidate is bounded by the
+ * budget still remaining, so N hung candidates can never consume N× the eval
+ * timeout (issue #9466 review). A fast failure (wrong exit code, ENOENT) barely
+ * touches the budget, so healthy fallbacks still get their turn.
+ */
+export async function probeCandidates(
+	candidates: ProbeCandidate[],
+	{ cwd, signal, timeoutMs }: BackendProbeOptions & { cwd: string },
+): Promise<CandidateProbeResult> {
+	const bound = Math.min(timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROBE_TIMEOUT_MS, DEFAULT_PROBE_TIMEOUT_MS);
+	const deadline = Date.now() + bound;
+	const failures: string[] = [];
+	for (let index = 0; index < candidates.length; index++) {
+		const candidate = candidates[index];
+		if (signal?.aborted) return { ok: false, aborted: true, failures };
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			// Discovery budget exhausted by earlier candidates; stop rather than
+			// let each remaining candidate spend the full timeout again.
+			failures.push(`${candidate.label} (probe budget exhausted)`);
+			break;
+		}
+		try {
+			const probe = await runBoundedProbe(candidate.command, {
+				cwd,
+				env: candidate.env,
+				signal,
+				timeoutMs: remaining,
+			});
+			if (probe.exitCode === 0) return { ok: true, index };
+			if (probe.aborted) return { ok: false, aborted: true, failures };
+			failures.push(
+				probe.timedOut
+					? `${candidate.label} (probe timed out)`
+					: `${candidate.label} (exit code ${probe.exitCode})`,
+			);
+		} catch (err) {
+			failures.push(`${candidate.label} (${err instanceof Error ? err.message : String(err)})`);
+		}
+	}
+	return { ok: false, aborted: false, failures };
+}

--- a/packages/coding-agent/src/eval/py/index.ts
+++ b/packages/coding-agent/src/eval/py/index.ts
@@ -11,6 +11,7 @@ import {
 	readInterpreterSetting as sharedReadInterpreterSetting,
 	toExecutorBackendResult,
 } from "../backend-helpers";
+import type { BackendProbeOptions } from "../probe";
 import { executePython, type PythonExecutorOptions } from "./executor";
 import { checkPythonKernelAvailability } from "./kernel";
 
@@ -28,8 +29,8 @@ export default {
 	label: "Python",
 	highlightLang: "python",
 
-	async isAvailable(session: ToolSession): Promise<boolean> {
-		const availability = await checkPythonKernelAvailability(session.cwd, readInterpreterSetting(session));
+	async isAvailable(session: ToolSession, opts?: BackendProbeOptions): Promise<boolean> {
+		const availability = await checkPythonKernelAvailability(session.cwd, readInterpreterSetting(session), opts);
 		return availability.ok;
 	},
 

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -9,9 +9,9 @@
  */
 import * as path from "node:path";
 import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelStartOptions } from "../kernel-base";
+import { type BackendProbeOptions, runBoundedProbe } from "../probe";
 import { stageRunnerScript } from "../runner-cache";
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
@@ -64,7 +64,7 @@ const availabilityCache = new Map<string, Promise<PythonKernelAvailability>>();
 export async function checkPythonKernelAvailability(
 	cwd: string,
 	interpreter?: string,
-	options?: { forceProbe?: boolean },
+	options?: { forceProbe?: boolean } & BackendProbeOptions,
 ): Promise<PythonKernelAvailability> {
 	if (!options?.forceProbe && (isBunTestRuntime() || $flag("PI_PYTHON_SKIP_CHECK"))) {
 		return { ok: true };
@@ -73,7 +73,7 @@ export async function checkPythonKernelAvailability(
 	const key = `${resolvedCwd}\0${interpreter ?? ""}`;
 	const cached = availabilityCache.get(key);
 	if (cached) return await cached;
-	const probe = probePythonKernelAvailability(resolvedCwd, interpreter);
+	const probe = probePythonKernelAvailability(resolvedCwd, interpreter, options);
 	availabilityCache.set(key, probe);
 	const result = await probe;
 	if (!result.ok && availabilityCache.get(key) === probe) {
@@ -82,7 +82,11 @@ export async function checkPythonKernelAvailability(
 	return result;
 }
 
-async function probePythonKernelAvailability(cwd: string, interpreter?: string): Promise<PythonKernelAvailability> {
+async function probePythonKernelAvailability(
+	cwd: string,
+	interpreter?: string,
+	probeOpts?: BackendProbeOptions,
+): Promise<PythonKernelAvailability> {
 	try {
 		const settings = await Settings.init();
 		const { env } = settings.getShellConfig();
@@ -100,15 +104,23 @@ async function probePythonKernelAvailability(cwd: string, interpreter?: string):
 		const failures: string[] = [];
 		for (const runtime of runtimes) {
 			try {
-				const probe = await $`${runtime.pythonPath} -c "import sys;sys.exit(0)"`
-					.quiet()
-					.nothrow()
-					.cwd(cwd)
-					.env(runtime.env);
+				const probe = await runBoundedProbe([runtime.pythonPath, "-c", "import sys;sys.exit(0)"], {
+					cwd,
+					env: runtime.env,
+					signal: probeOpts?.signal,
+					timeoutMs: probeOpts?.timeoutMs,
+				});
 				if (probe.exitCode === 0) {
 					return { ok: true, pythonPath: runtime.pythonPath, runtime };
 				}
-				failures.push(`${runtime.pythonPath} (exit code ${probe.exitCode})`);
+				if (probe.aborted) {
+					return { ok: false, pythonPath: runtime.pythonPath, reason: "Python availability probe was cancelled." };
+				}
+				failures.push(
+					probe.timedOut
+						? `${runtime.pythonPath} (probe timed out)`
+						: `${runtime.pythonPath} (exit code ${probe.exitCode})`,
+				);
 			} catch (err) {
 				failures.push(`${runtime.pythonPath} (${err instanceof Error ? err.message : String(err)})`);
 			}

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -11,7 +11,7 @@ import * as path from "node:path";
 import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelStartOptions } from "../kernel-base";
-import { type BackendProbeOptions, runBoundedProbe } from "../probe";
+import { type BackendProbeOptions, probeCandidates } from "../probe";
 import { stageRunnerScript } from "../runner-cache";
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
@@ -97,38 +97,25 @@ async function probePythonKernelAvailability(
 		if (runtimes.length === 0) {
 			return { ok: false, reason: "Python executable not found on PATH" };
 		}
-		// Probe each candidate in priority order and use the first that actually
-		// runs. A managed env left behind by a removed `uv` install can exist on
-		// disk yet fail to execute; falling through to the next candidate lets a
-		// working system Python take over instead of failing the whole session.
-		const failures: string[] = [];
-		for (const runtime of runtimes) {
-			try {
-				const probe = await runBoundedProbe([runtime.pythonPath, "-c", "import sys;sys.exit(0)"], {
-					cwd,
-					env: runtime.env,
-					signal: probeOpts?.signal,
-					timeoutMs: probeOpts?.timeoutMs,
-				});
-				if (probe.exitCode === 0) {
-					return { ok: true, pythonPath: runtime.pythonPath, runtime };
-				}
-				if (probe.aborted) {
-					return { ok: false, pythonPath: runtime.pythonPath, reason: "Python availability probe was cancelled." };
-				}
-				failures.push(
-					probe.timedOut
-						? `${runtime.pythonPath} (probe timed out)`
-						: `${runtime.pythonPath} (exit code ${probe.exitCode})`,
-				);
-			} catch (err) {
-				failures.push(`${runtime.pythonPath} (${err instanceof Error ? err.message : String(err)})`);
-			}
+		const result = await probeCandidates(
+			runtimes.map(runtime => ({
+				command: [runtime.pythonPath, "-c", "import sys;sys.exit(0)"],
+				env: runtime.env,
+				label: runtime.pythonPath,
+			})),
+			{ cwd, signal: probeOpts?.signal, timeoutMs: probeOpts?.timeoutMs },
+		);
+		if (result.ok) {
+			const runtime = runtimes[result.index];
+			return { ok: true, pythonPath: runtime.pythonPath, runtime };
+		}
+		if (result.aborted) {
+			return { ok: false, pythonPath: runtimes[0].pythonPath, reason: "Python availability probe was cancelled." };
 		}
 		return {
 			ok: false,
 			pythonPath: runtimes[0].pythonPath,
-			reason: `No working Python interpreter found. Tried: ${failures.join("; ")}`,
+			reason: `No working Python interpreter found. Tried: ${result.failures.join("; ")}`,
 		};
 	} catch (err) {
 		return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/packages/coding-agent/src/eval/rb/index.ts
+++ b/packages/coding-agent/src/eval/rb/index.ts
@@ -10,6 +10,7 @@ import {
 	readInterpreterSetting as sharedReadInterpreterSetting,
 	toExecutorBackendResult,
 } from "../backend-helpers";
+import type { BackendProbeOptions } from "../probe";
 import { executeRuby } from "./executor";
 import { checkRubyKernelAvailability } from "./kernel";
 
@@ -28,8 +29,8 @@ export default {
 	label: "Ruby",
 	highlightLang: "ruby",
 
-	async isAvailable(session: ToolSession): Promise<boolean> {
-		const availability = await checkRubyKernelAvailability(session.cwd, readInterpreterSetting(session));
+	async isAvailable(session: ToolSession, opts?: BackendProbeOptions): Promise<boolean> {
+		const availability = await checkRubyKernelAvailability(session.cwd, readInterpreterSetting(session), opts);
 		return availability.ok;
 	},
 

--- a/packages/coding-agent/src/eval/rb/kernel.ts
+++ b/packages/coding-agent/src/eval/rb/kernel.ts
@@ -10,9 +10,9 @@
  */
 import * as path from "node:path";
 import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelRuntimeEnv, type KernelStartOptions } from "../kernel-base";
+import { type BackendProbeOptions, runBoundedProbe } from "../probe";
 import type { KernelDisplayOutput } from "../py/display";
 import { hostHasInheritableConsole, shouldDetachKernel, shouldHideKernelWindow } from "../py/spawn-options";
 import { stageRunnerScript } from "../runner-cache";
@@ -64,7 +64,11 @@ export interface RubyKernelAvailability {
 // not cached so installing Ruby mid-session is picked up on the next attempt.
 const availabilityCache = new Map<string, Promise<RubyKernelAvailability>>();
 
-export async function checkRubyKernelAvailability(cwd: string, interpreter?: string): Promise<RubyKernelAvailability> {
+export async function checkRubyKernelAvailability(
+	cwd: string,
+	interpreter?: string,
+	options?: BackendProbeOptions,
+): Promise<RubyKernelAvailability> {
 	if (isBunTestRuntime() || $flag("PI_RUBY_SKIP_CHECK")) {
 		return { ok: true };
 	}
@@ -72,7 +76,7 @@ export async function checkRubyKernelAvailability(cwd: string, interpreter?: str
 	const key = `${resolvedCwd}\0${interpreter ?? ""}`;
 	const cached = availabilityCache.get(key);
 	if (cached) return await cached;
-	const probe = probeRubyKernelAvailability(resolvedCwd, interpreter);
+	const probe = probeRubyKernelAvailability(resolvedCwd, interpreter, options);
 	availabilityCache.set(key, probe);
 	const result = await probe;
 	if (!result.ok && availabilityCache.get(key) === probe) {
@@ -81,7 +85,11 @@ export async function checkRubyKernelAvailability(cwd: string, interpreter?: str
 	return result;
 }
 
-async function probeRubyKernelAvailability(cwd: string, interpreter?: string): Promise<RubyKernelAvailability> {
+async function probeRubyKernelAvailability(
+	cwd: string,
+	interpreter?: string,
+	probeOpts?: BackendProbeOptions,
+): Promise<RubyKernelAvailability> {
 	try {
 		const settings = await Settings.init();
 		const { env } = settings.getShellConfig();
@@ -93,11 +101,23 @@ async function probeRubyKernelAvailability(cwd: string, interpreter?: string): P
 		const failures: string[] = [];
 		for (const runtime of runtimes) {
 			try {
-				const probe = await $`${runtime.rubyPath} -e ${"exit 0"}`.quiet().nothrow().cwd(cwd).env(runtime.env);
+				const probe = await runBoundedProbe([runtime.rubyPath, "-e", "exit 0"], {
+					cwd,
+					env: runtime.env,
+					signal: probeOpts?.signal,
+					timeoutMs: probeOpts?.timeoutMs,
+				});
 				if (probe.exitCode === 0) {
 					return { ok: true, rubyPath: runtime.rubyPath, runtime };
 				}
-				failures.push(`${runtime.rubyPath} (exit code ${probe.exitCode})`);
+				if (probe.aborted) {
+					return { ok: false, rubyPath: runtime.rubyPath, reason: "Ruby availability probe was cancelled." };
+				}
+				failures.push(
+					probe.timedOut
+						? `${runtime.rubyPath} (probe timed out)`
+						: `${runtime.rubyPath} (exit code ${probe.exitCode})`,
+				);
 			} catch (err) {
 				failures.push(`${runtime.rubyPath} (${err instanceof Error ? err.message : String(err)})`);
 			}

--- a/packages/coding-agent/src/eval/rb/kernel.ts
+++ b/packages/coding-agent/src/eval/rb/kernel.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelRuntimeEnv, type KernelStartOptions } from "../kernel-base";
-import { type BackendProbeOptions, runBoundedProbe } from "../probe";
+import { type BackendProbeOptions, probeCandidates } from "../probe";
 import type { KernelDisplayOutput } from "../py/display";
 import { hostHasInheritableConsole, shouldDetachKernel, shouldHideKernelWindow } from "../py/spawn-options";
 import { stageRunnerScript } from "../runner-cache";
@@ -98,34 +98,25 @@ async function probeRubyKernelAvailability(
 		if (runtimes.length === 0) {
 			return { ok: false, reason: "Ruby executable not found on PATH" };
 		}
-		const failures: string[] = [];
-		for (const runtime of runtimes) {
-			try {
-				const probe = await runBoundedProbe([runtime.rubyPath, "-e", "exit 0"], {
-					cwd,
-					env: runtime.env,
-					signal: probeOpts?.signal,
-					timeoutMs: probeOpts?.timeoutMs,
-				});
-				if (probe.exitCode === 0) {
-					return { ok: true, rubyPath: runtime.rubyPath, runtime };
-				}
-				if (probe.aborted) {
-					return { ok: false, rubyPath: runtime.rubyPath, reason: "Ruby availability probe was cancelled." };
-				}
-				failures.push(
-					probe.timedOut
-						? `${runtime.rubyPath} (probe timed out)`
-						: `${runtime.rubyPath} (exit code ${probe.exitCode})`,
-				);
-			} catch (err) {
-				failures.push(`${runtime.rubyPath} (${err instanceof Error ? err.message : String(err)})`);
-			}
+		const result = await probeCandidates(
+			runtimes.map(runtime => ({
+				command: [runtime.rubyPath, "-e", "exit 0"],
+				env: runtime.env,
+				label: runtime.rubyPath,
+			})),
+			{ cwd, signal: probeOpts?.signal, timeoutMs: probeOpts?.timeoutMs },
+		);
+		if (result.ok) {
+			const runtime = runtimes[result.index];
+			return { ok: true, rubyPath: runtime.rubyPath, runtime };
+		}
+		if (result.aborted) {
+			return { ok: false, rubyPath: runtimes[0].rubyPath, reason: "Ruby availability probe was cancelled." };
 		}
 		return {
 			ok: false,
 			rubyPath: runtimes[0].rubyPath,
-			reason: `No working Ruby interpreter found. Tried: ${failures.join("; ")}`,
+			reason: `No working Ruby interpreter found. Tried: ${result.failures.join("; ")}`,
 		};
 	} catch (err) {
 		return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -12,6 +12,7 @@ import { jsBackend, juliaBackend, pythonBackend, rubyBackend } from "../eval";
 import type { ExecutorBackend, ExecutorBackendResult } from "../eval/backend";
 import { EVAL_TIMEOUT_PAUSE_OP, EVAL_TIMEOUT_RESUME_OP } from "../eval/bridge-timeout";
 import { IdleTimeout } from "../eval/idle-timeout";
+import type { BackendProbeOptions } from "../eval/probe";
 import { defaultEvalSessionId } from "../eval/session-id";
 import type { EvalCellResult, EvalDisplayOutput, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
 import evalDescription from "../prompts/tools/eval.md" with { type: "text" };
@@ -233,7 +234,11 @@ function detailsNotice(cells: ResolvedEvalCell[]): string | undefined {
 	return notices.length > 0 ? notices.join(" ") : undefined;
 }
 
-async function resolveBackend(session: ToolSession, language: EvalLanguage): Promise<ResolvedBackend> {
+async function resolveBackend(
+	session: ToolSession,
+	language: EvalLanguage,
+	probeOpts?: BackendProbeOptions,
+): Promise<ResolvedBackend> {
 	const backends = resolveEvalBackends(session);
 	const allowPy = backends.python;
 	const allowJs = backends.js;
@@ -242,7 +247,7 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 
 	if (language === "python") {
 		if (!allowPy) throw new ToolError("Python backend is disabled (PI_PY=0 or eval.py = false).");
-		if (!(await pythonBackend.isAvailable(session))) {
+		if (!(await pythonBackend.isAvailable(session, probeOpts))) {
 			const alternatives = [allowJs ? '"js"' : null, allowRb ? '"rb"' : null, allowJl ? '"jl"' : null].filter(
 				Boolean,
 			);
@@ -256,7 +261,7 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 	}
 	if (language === "ruby") {
 		if (!allowRb) throw new ToolError("Ruby backend is disabled (PI_RB=0 or eval.rb = false).");
-		if (!(await rubyBackend.isAvailable(session))) {
+		if (!(await rubyBackend.isAvailable(session, probeOpts))) {
 			const alternatives = [allowJs ? '"js"' : null, allowPy ? '"py"' : null, allowJl ? '"jl"' : null].filter(
 				Boolean,
 			);
@@ -270,7 +275,7 @@ async function resolveBackend(session: ToolSession, language: EvalLanguage): Pro
 	}
 	if (language === "julia") {
 		if (!allowJl) throw new ToolError("Julia backend is disabled (PI_JL=0 or eval.jl = false).");
-		if (!(await juliaBackend.isAvailable(session))) {
+		if (!(await juliaBackend.isAvailable(session, probeOpts))) {
 			const alternatives = [allowJs ? '"js"' : null, allowPy ? '"py"' : null, allowRb ? '"rb"' : null].filter(
 				Boolean,
 			);
@@ -461,13 +466,17 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					: params.language === "jl"
 						? "julia"
 						: "js";
-		const resolved = await resolveBackend(session, cellLanguage);
+		// Bound backend discovery by the eval cell's own timeout and abort signal:
+		// the cell IdleTimeout is armed only later in #runCells, so a hung runtime
+		// probe would otherwise wedge the whole turn (issue #9466).
+		const cellTimeoutMs = (params.timeout ?? 30) * 1000;
+		const resolved = await resolveBackend(session, cellLanguage, { signal, timeoutMs: cellTimeoutMs });
 		const cells: ResolvedEvalCell[] = [
 			{
 				index: 0,
 				title: params.title,
 				code: params.code,
-				timeoutMs: (params.timeout ?? 30) * 1000,
+				timeoutMs: cellTimeoutMs,
 				reset: params.reset ?? false,
 				resolved,
 			},
@@ -512,11 +521,11 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		// is runtime work (it pauses across agent()/tool bridge calls), so a cell
 		// can legitimately outlive it in wall time — exactly the case
 		// backgrounding exists for.
-		const cellTimeoutMs =
+		const clampedCellTimeoutMs =
 			cells[0].timeoutMs === 0
 				? undefined
 				: clampTimeout("eval", cells[0].timeoutMs / 1000, session.settings.get("tools.maxTimeout")) * 1000;
-		const autoBackgroundWaitMs = resolveAutoBackgroundWaitMs(thresholdMs, cellTimeoutMs);
+		const autoBackgroundWaitMs = resolveAutoBackgroundWaitMs(thresholdMs, clampedCellTimeoutMs);
 		const startBackgrounded = autoBackgroundWaitMs === 0;
 
 		const rawLabel = params.title?.trim() || params.code.trim().split("\n", 1)[0] || "eval cell";

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -27,7 +27,7 @@ import { type EvalBackendsAllowance, resolveEvalBackends } from "./eval-backends
 import { generateCodeModeDeclarations } from "./eval-format/code-mode-declarations";
 import { upsertStatusEvent } from "./eval-render";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "./output-meta";
-import { ToolAbortError, ToolError } from "./tool-errors";
+import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
 
@@ -247,7 +247,9 @@ async function resolveBackend(
 
 	if (language === "python") {
 		if (!allowPy) throw new ToolError("Python backend is disabled (PI_PY=0 or eval.py = false).");
-		if (!(await pythonBackend.isAvailable(session, probeOpts))) {
+		const available = await pythonBackend.isAvailable(session, probeOpts);
+		throwIfAborted(probeOpts?.signal);
+		if (!available) {
 			const alternatives = [allowJs ? '"js"' : null, allowRb ? '"rb"' : null, allowJl ? '"jl"' : null].filter(
 				Boolean,
 			);
@@ -261,7 +263,9 @@ async function resolveBackend(
 	}
 	if (language === "ruby") {
 		if (!allowRb) throw new ToolError("Ruby backend is disabled (PI_RB=0 or eval.rb = false).");
-		if (!(await rubyBackend.isAvailable(session, probeOpts))) {
+		const available = await rubyBackend.isAvailable(session, probeOpts);
+		throwIfAborted(probeOpts?.signal);
+		if (!available) {
 			const alternatives = [allowJs ? '"js"' : null, allowPy ? '"py"' : null, allowJl ? '"jl"' : null].filter(
 				Boolean,
 			);
@@ -275,7 +279,9 @@ async function resolveBackend(
 	}
 	if (language === "julia") {
 		if (!allowJl) throw new ToolError("Julia backend is disabled (PI_JL=0 or eval.jl = false).");
-		if (!(await juliaBackend.isAvailable(session, probeOpts))) {
+		const available = await juliaBackend.isAvailable(session, probeOpts);
+		throwIfAborted(probeOpts?.signal);
+		if (!available) {
 			const alternatives = [allowJs ? '"js"' : null, allowPy ? '"py"' : null, allowRb ? '"rb"' : null].filter(
 				Boolean,
 			);

--- a/packages/coding-agent/test/eval/probe.test.ts
+++ b/packages/coding-agent/test/eval/probe.test.ts
@@ -8,12 +8,24 @@ import { probeCandidates, runBoundedProbe } from "../../src/eval/probe";
 // A cross-platform "hangs forever" command: re-invoke the running Bun to sleep.
 const bun = process.execPath;
 const HANG = [bun, "-e", "await Bun.sleep(60_000)"];
+const IGNORE_TERM = [bun, "-e", 'process.on("SIGTERM", () => {}); await Bun.sleep(60_000)'];
 const baseEnv = (): Record<string, string | undefined> => ({ ...process.env });
 
 describe("runBoundedProbe", () => {
 	test("a hung probe is bounded by its timeout instead of hanging (regression: #9466)", async () => {
 		const start = Date.now();
 		const result = await runBoundedProbe(HANG, { cwd: process.cwd(), env: baseEnv(), timeoutMs: 300 });
+		expect(result).toEqual({ exitCode: null, timedOut: true, aborted: false });
+		expect(Date.now() - start).toBeLessThan(5_000);
+	});
+
+	test("force-kills a probe that ignores SIGTERM when its timeout expires", async () => {
+		const start = Date.now();
+		const result = await runBoundedProbe(IGNORE_TERM, {
+			cwd: process.cwd(),
+			env: baseEnv(),
+			timeoutMs: 300,
+		});
 		expect(result).toEqual({ exitCode: null, timedOut: true, aborted: false });
 		expect(Date.now() - start).toBeLessThan(5_000);
 	});

--- a/packages/coding-agent/test/eval/probe.test.ts
+++ b/packages/coding-agent/test/eval/probe.test.ts
@@ -1,0 +1,57 @@
+// Integration test: runBoundedProbe spawns and kills a real subprocess, so the
+// timeout/abort teardown is inherently wall-clock bound. Fake timers cannot
+// advance a child process's execution or resolve its `exited` promise, so the
+// real-timer exception in ts-no-test-timers applies here.
+import { describe, expect, test } from "bun:test";
+import { runBoundedProbe } from "../../src/eval/probe";
+
+// A cross-platform "hangs forever" command: re-invoke the running Bun to sleep.
+const bun = process.execPath;
+const HANG = [bun, "-e", "await Bun.sleep(60_000)"];
+const baseEnv = (): Record<string, string | undefined> => ({ ...process.env });
+
+describe("runBoundedProbe", () => {
+	test("a hung probe is bounded by its timeout instead of hanging (regression: #9466)", async () => {
+		const start = Date.now();
+		const result = await runBoundedProbe(HANG, { cwd: process.cwd(), env: baseEnv(), timeoutMs: 300 });
+		expect(result).toEqual({ exitCode: null, timedOut: true, aborted: false });
+		expect(Date.now() - start).toBeLessThan(5_000);
+	});
+
+	test("an already-aborted signal short-circuits without spawning", async () => {
+		const result = await runBoundedProbe(HANG, {
+			cwd: process.cwd(),
+			env: baseEnv(),
+			signal: AbortSignal.abort(),
+		});
+		expect(result).toEqual({ exitCode: null, timedOut: false, aborted: true });
+	});
+
+	test("an in-flight probe is killed when its signal aborts", async () => {
+		const start = Date.now();
+		const result = await runBoundedProbe(HANG, {
+			cwd: process.cwd(),
+			env: baseEnv(),
+			signal: AbortSignal.timeout(100),
+		});
+		expect(result.aborted).toBe(true);
+		expect(result.exitCode).toBeNull();
+		expect(Date.now() - start).toBeLessThan(5_000);
+	});
+
+	test("a fast probe reports its real exit code", async () => {
+		const ok = await runBoundedProbe([bun, "-e", "process.exit(0)"], {
+			cwd: process.cwd(),
+			env: baseEnv(),
+			timeoutMs: 5_000,
+		});
+		expect(ok).toEqual({ exitCode: 0, timedOut: false, aborted: false });
+
+		const failing = await runBoundedProbe([bun, "-e", "process.exit(3)"], {
+			cwd: process.cwd(),
+			env: baseEnv(),
+			timeoutMs: 5_000,
+		});
+		expect(failing).toEqual({ exitCode: 3, timedOut: false, aborted: false });
+	});
+});

--- a/packages/coding-agent/test/eval/probe.test.ts
+++ b/packages/coding-agent/test/eval/probe.test.ts
@@ -3,7 +3,7 @@
 // advance a child process's execution or resolve its `exited` promise, so the
 // real-timer exception in ts-no-test-timers applies here.
 import { describe, expect, test } from "bun:test";
-import { runBoundedProbe } from "../../src/eval/probe";
+import { probeCandidates, runBoundedProbe } from "../../src/eval/probe";
 
 // A cross-platform "hangs forever" command: re-invoke the running Bun to sleep.
 const bun = process.execPath;
@@ -53,5 +53,36 @@ describe("runBoundedProbe", () => {
 			timeoutMs: 5_000,
 		});
 		expect(failing).toEqual({ exitCode: 3, timedOut: false, aborted: false });
+	});
+});
+
+describe("probeCandidates", () => {
+	test("shares one discovery deadline across hung candidates instead of paying it per candidate", async () => {
+		const start = Date.now();
+		const result = await probeCandidates(
+			[
+				{ command: HANG, env: baseEnv(), label: "cand-a" },
+				{ command: HANG, env: baseEnv(), label: "cand-b" },
+				{ command: HANG, env: baseEnv(), label: "cand-c" },
+			],
+			{ cwd: process.cwd(), timeoutMs: 300 },
+		);
+		const elapsed = Date.now() - start;
+		expect(result).toEqual({ ok: false, aborted: false, failures: expect.any(Array) });
+		// One 300ms budget total, not 3×: the whole discovery stays well under the
+		// combined per-candidate cost it would incur without a shared deadline.
+		expect(elapsed).toBeLessThan(900);
+	});
+
+	test("returns the first candidate that exits 0 and skips the rest", async () => {
+		const result = await probeCandidates(
+			[
+				{ command: [bun, "-e", "process.exit(1)"], env: baseEnv(), label: "bad" },
+				{ command: [bun, "-e", "process.exit(0)"], env: baseEnv(), label: "good" },
+				{ command: HANG, env: baseEnv(), label: "would-hang" },
+			],
+			{ cwd: process.cwd(), timeoutMs: 5_000 },
+		);
+		expect(result).toEqual({ ok: true, index: 1 });
 	});
 });

--- a/packages/coding-agent/test/tools/eval-fallback.test.ts
+++ b/packages/coding-agent/test/tools/eval-fallback.test.ts
@@ -5,6 +5,7 @@ import * as pyKernel from "@oh-my-pi/pi-coding-agent/eval/py/kernel";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { EvalTool } from "@oh-my-pi/pi-coding-agent/tools/eval";
 import { resolveEvalBackends } from "@oh-my-pi/pi-coding-agent/tools/eval-backends";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 
 let originalPiPy: string | undefined;
 let originalPiJs: string | undefined;
@@ -90,6 +91,32 @@ describe("EvalTool language dispatch", () => {
 		expect(pythonExecuteSpy).toHaveBeenCalledTimes(1);
 		expect(jsExecuteSpy).not.toHaveBeenCalled();
 	});
+
+	for (const testCase of [
+		{ language: "py", backend: evalIndex.pythonBackend },
+		{ language: "rb", backend: evalIndex.rubyBackend },
+		{ language: "jl", backend: evalIndex.juliaBackend },
+	] as const) {
+		it(`preserves caller cancellation during ${testCase.language} availability probing`, async () => {
+			const settings = Settings.isolated();
+			if (testCase.language === "rb") settings.set("eval.rb", true);
+			if (testCase.language === "jl") settings.set("eval.jl", true);
+			const controller = new AbortController();
+			vi.spyOn(testCase.backend, "isAvailable").mockImplementation(async () => {
+				controller.abort();
+				return false;
+			});
+
+			const tool = new EvalTool(makeSession(settings));
+			await expect(
+				tool.execute(
+					`call-${testCase.language}-abort`,
+					{ language: testCase.language, code: "never runs" },
+					controller.signal,
+				),
+			).rejects.toBeInstanceOf(ToolAbortError);
+		});
+	}
 
 	it("dispatches each call to the backend named by its language", async () => {
 		vi.spyOn(pyKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });


### PR DESCRIPTION
## Repro
A first Python `eval` call on native Windows in RPC mode can hang indefinitely inside the backend availability probe, before the eval cell timeout is armed — `tool_execution_start` fires with no following `toolResult`, and the child `python.exe -c "import sys;sys.exit(0)"` stays alive past the documented 30s eval timeout. The Windows-specific inherited-stdin trigger isn't reproducible off Windows, but the underlying unbounded-probe defect is: driving the real `checkPythonKernelAvailability()` against a fake interpreter that hangs (`sleep 3600`, ignoring `-c ...`) leaves the promise pending forever with no timeout.

```
$ bun repro.ts   # calls checkPythonKernelAvailability() against a hanging interpreter
Calling checkPythonKernelAvailability against a hanging interpreter...
RESULT: probe STILL PENDING after 6005ms with no timeout — resolveBackend would wedge the turn (bug reproduced).
```

## Cause
`EvalTool.execute()` awaited `resolveBackend()` (`src/tools/eval.ts`) **before** the cell `IdleTimeout` was constructed in `#runCells()`, so the eval timeout could never cancel a probe that hangs during backend resolution. All three runtime probes — `probePythonKernelAvailability` (`src/eval/py/kernel.ts`), `probeRubyKernelAvailability` (`src/eval/rb/kernel.ts`), `probeJuliaKernelAvailability` (`src/eval/jl/kernel.ts`) — ran the interpreter through Bun `$`, which inherits the host stdin handle, with no timeout and no AbortSignal. On native Windows the inherited RPC/console stdin handle keeps the probe subprocess alive indefinitely even though it never reads stdin.

## Fix
- Add `src/eval/probe.ts` `runBoundedProbe()`: spawns via `Bun.spawn` with stdin/stdout/stderr detached (`stdin: "ignore"`, `windowsHide: true`), enforces a wall-clock timeout (capped at 10s, clamped to the caller's bound), honors an optional `AbortSignal`, and always resolves — a hung interpreter yields `{ timedOut: true, exitCode: null }` instead of an unsettled promise.
- Migrate the Python/Ruby/Julia probes to the shared helper; a timed-out or aborted candidate surfaces as a clear unavailable reason.
- Add `BackendProbeOptions` to `ExecutorBackend.isAvailable` and thread the eval cell's timeout + abort signal through `resolveBackend` → `isAvailable` → `checkXKernelAvailability`, computing `cellTimeoutMs` before `resolveBackend` so backend discovery is bounded by the same call the runtime work is.
- Add changelog entry.

## Verification
- `bun test test/eval/probe.test.ts` — 4 pass (timeout bound, pre-aborted short-circuit, in-flight abort, exit-code passthrough).
- `bun test test/tools/eval-fallback.test.ts test/tools/eval-timeout.test.ts test/eval/kernel-spawn.test.ts test/eval/probe.test.ts` — 26 pass.
- `bun run check:types` (tsgo) — clean.
- Manual: the repro script above, re-run against the fix with `timeoutMs: 2000`, now resolves in ~2016ms with `ok: false` (`probe timed out`); an already-aborted signal returns immediately with `Python availability probe was cancelled.`

Fixes #9466