### PR TITLE
fix(coding-agent): authenticate Jina Reader requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Squeezed transcript tool rows no longer render as a bare unstyled `╭─ Hub` frame: a squeezed block keeps its real render whenever it fits the allocated rows, and blocks that genuinely overflow fold to a themed frame that names the tool's activity (e.g. `Hub · send → Main`).
 - Python/Ruby/Julia eval cells that hit their wall-clock timeout during a `parallel()`/`agent()`/`tool.*` fan-out no longer get their kernel force-killed (losing all session state): the timeout now aborts in-flight bridge calls so the runner unwinds as a clean KeyboardInterrupt and the kernel survives.
 - Multi-select ask options whose labels end in `(Recommended)` now show their checked state and avoid duplicate recommendation suffixes ([#9452](https://github.com/can1357/oh-my-pi/issues/9452)).
+- Jina Reader requests now use configured credentials for higher authenticated rate limits while remaining available anonymously ([#9431](https://github.com/can1357/oh-my-pi/issues/9431)).
 
 ## [18.0.2] - 2026-08-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Jina Reader requests now use configured credentials for higher authenticated rate limits while remaining available anonymously ([#9431](https://github.com/can1357/oh-my-pi/issues/9431)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added
@@ -14,7 +18,6 @@
 - Squeezed transcript tool rows no longer render as a bare unstyled `╭─ Hub` frame: a squeezed block keeps its real render whenever it fits the allocated rows, and blocks that genuinely overflow fold to a themed frame that names the tool's activity (e.g. `Hub · send → Main`).
 - Python/Ruby/Julia eval cells that hit their wall-clock timeout during a `parallel()`/`agent()`/`tool.*` fan-out no longer get their kernel force-killed (losing all session state): the timeout now aborts in-flight bridge calls so the runner unwinds as a clean KeyboardInterrupt and the kernel survives.
 - Multi-select ask options whose labels end in `(Recommended)` now show their checked state and avoid duplicate recommendation suffixes ([#9452](https://github.com/can1357/oh-my-pi/issues/9452)).
-- Jina Reader requests now use configured credentials for higher authenticated rate limits while remaining available anonymously ([#9431](https://github.com/can1357/oh-my-pi/issues/9431)).
 
 ## [18.0.2] - 2026-08-23
 

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import type { FetchImpl, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { type FetchImpl, getEnvApiKey, type ImageContent, type TextContent } from "@oh-my-pi/pi-ai";
 import { htmlToMarkdown } from "@oh-my-pi/pi-natives";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
 import { $which, ptree, truncate } from "@oh-my-pi/pi-utils";
@@ -25,6 +25,7 @@ import { extractWithParallel, findParallelApiKey, getParallelExtractContent } fr
 import type { RenderResult, SpecialHandler } from "../web/scrapers/types";
 import { finalizeOutput, loadPage, looksLikeHtml, MAX_BYTES, MAX_OUTPUT_CHARS } from "../web/scrapers/types";
 import { convertWithMarkit, fetchBinary } from "../web/scrapers/utils";
+import { findCredential } from "../web/search/providers/utils";
 import { applyListLimit } from "./list-limit";
 import { formatStyledArtifactReference, type OutputMeta } from "./output-meta";
 import { isReadableUrlPath, type LineRange, parseLineRanges } from "./path-utils";
@@ -665,11 +666,14 @@ export async function renderHtmlToText(
 			return firstDocument ? getParallelExtractContent(firstDocument) : null;
 		},
 		jina: async () => {
+			const apiKey = findCredential(storage, getEnvApiKey("jina"), "jina");
+			const headers: Record<string, string> = {
+				Accept: "text/markdown",
+				"X-No-Cache": "true",
+			};
+			if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 			const response = await fetchImpl(`https://r.jina.ai/${url}`, {
-				headers: {
-					Accept: "text/markdown",
-					"X-No-Cache": "true",
-				},
+				headers,
 				signal: remoteSignal(),
 			});
 			if (!response.ok) return null;

--- a/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
+++ b/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { renderHtmlToText } from "@oh-my-pi/pi-coding-agent/tools/fetch";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import { asGlobalFetch } from "../helpers/fetch-mock";
 
 /**
@@ -95,6 +98,71 @@ describe("renderHtmlToText: jina stall does not starve local fallbacks (#1449)",
 });
 
 describe("renderHtmlToText: Jina response validation", () => {
+	it("sends JINA_API_KEY as optional bearer authentication", async () => {
+		const originalApiKey = process.env.JINA_API_KEY;
+		process.env.JINA_API_KEY = "env-jina-key";
+		try {
+			const settings = Settings.isolated({ "providers.fetch": "jina" });
+			let requestHeaders: Headers | undefined;
+			const markdown = `# Authenticated article\n\n${"Substantive reader content. ".repeat(8)}`.trim();
+			const fetchMock = asGlobalFetch((_input, init) => {
+				requestHeaders = new Headers(init?.headers);
+				return new Response(`Markdown Content:\n${markdown}`);
+			});
+
+			const result = await renderHtmlToText(
+				"https://example.com/article",
+				"<html><body>short</body></html>",
+				1,
+				settings,
+				undefined,
+				null,
+				fetchMock,
+			);
+
+			expect(result.method).toBe("jina");
+			expect(requestHeaders?.get("authorization")).toBe("Bearer env-jina-key");
+		} finally {
+			if (originalApiKey === undefined) delete process.env.JINA_API_KEY;
+			else process.env.JINA_API_KEY = originalApiKey;
+		}
+	});
+
+	it("uses a stored Jina credential when the environment key is absent", async () => {
+		const originalApiKey = process.env.JINA_API_KEY;
+		delete process.env.JINA_API_KEY;
+		const tempDir = TempDir.createSync("@omp-jina-reader-auth-");
+		try {
+			const storage = await AgentStorage.open(path.join(tempDir.path(), "agent.db"));
+			storage.replaceAuthCredentialsForProvider("jina", [{ type: "api_key", key: "stored-jina-key" }]);
+			const settings = Settings.isolated({ "providers.fetch": "jina" });
+			let requestHeaders: Headers | undefined;
+			const markdown = `# Authenticated article\n\n${"Substantive reader content. ".repeat(8)}`.trim();
+			const fetchMock = asGlobalFetch((_input, init) => {
+				requestHeaders = new Headers(init?.headers);
+				return new Response(`Markdown Content:\n${markdown}`);
+			});
+
+			const result = await renderHtmlToText(
+				"https://example.com/article",
+				"<html><body>short</body></html>",
+				1,
+				settings,
+				undefined,
+				storage,
+				fetchMock,
+			);
+
+			expect(result.method).toBe("jina");
+			expect(requestHeaders?.get("authorization")).toBe("Bearer stored-jina-key");
+		} finally {
+			AgentStorage.resetInstance();
+			await tempDir.remove().catch(() => {});
+			if (originalApiKey === undefined) delete process.env.JINA_API_KEY;
+			else process.env.JINA_API_KEY = originalApiKey;
+		}
+	});
+
 	it("requests fresh markdown and strips the Jina metadata preamble", async () => {
 		const settings = Settings.isolated({ "providers.fetch": "jina" });
 		const markdown = `# Extracted article\n\n${"Substantive reader content. ".repeat(8)}`.trim();
@@ -117,6 +185,7 @@ describe("renderHtmlToText: Jina response validation", () => {
 		expect(result).toEqual({ content: markdown, ok: true, method: "jina" });
 		expect(requestHeaders?.get("accept")).toBe("text/markdown");
 		expect(requestHeaders?.get("x-no-cache")).toBe("true");
+		expect(requestHeaders?.get("authorization")).toBeNull();
 	});
 
 	for (const { label, readerBody, headers } of [


### PR DESCRIPTION
## Summary

- resolve optional Jina credentials from `JINA_API_KEY` or the stored `jina` auth entry
- attach `Authorization: Bearer ...` only when a credential exists, preserving anonymous Reader requests
- cover environment, stored, and anonymous request-header behavior

Fixes #9431

## Verification

- `bun test packages/coding-agent/test/tools/fetch-jina-stall.test.ts` (10 passed)
- `biome check .` in `packages/coding-agent` (2,752 files checked, clean)
- `bun run check:types` was attempted on the low-spec development host; it emitted no diagnostics before being interrupted after sustained resource saturation

The authentication behavior is verified with injected request mocks; no live Jina credential was used for E2E testing.