### PR TITLE
fix(eval): boot JS subprocess from safe cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- JS eval subprocesses now boot from a safe working directory when the agent cwd is inaccessible or removed, while retaining the package root required by SDK embedding.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import { logger, postmortem, Snowflake, workerHostEntry } from "@oh-my-pi/pi-utils";
 import {
 	createWorkerHandle,
@@ -699,8 +700,9 @@ function spawnBunWorker(): WorkerHandle {
 }
 
 function spawnJsProcess(): WorkerHandle {
+	const spawnCommand = resolveWorkerSpawnCmd(JS_EVAL_PROCESS_ARG);
 	const spawned = createWorkerSubprocess<WorkerOutbound>({
-		spawnCommand: resolveWorkerSpawnCmd(JS_EVAL_PROCESS_ARG),
+		spawnCommand: { ...spawnCommand, cwd: os.tmpdir() },
 		env: workerEnvFromParent(),
 		exitLabel: "JS eval worker",
 		detached: shouldDetachKernel(process.platform),

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -702,7 +702,7 @@ function spawnBunWorker(): WorkerHandle {
 function spawnJsProcess(): WorkerHandle {
 	const spawnCommand = resolveWorkerSpawnCmd(JS_EVAL_PROCESS_ARG);
 	const spawned = createWorkerSubprocess<WorkerOutbound>({
-		spawnCommand: { ...spawnCommand, cwd: os.tmpdir() },
+		spawnCommand: { ...spawnCommand, cwd: spawnCommand.cwd ?? os.tmpdir() },
 		env: workerEnvFromParent(),
 		exitLabel: "JS eval worker",
 		detached: shouldDetachKernel(process.platform),

--- a/packages/coding-agent/src/eval/js/process-entry.ts
+++ b/packages/coding-agent/src/eval/js/process-entry.ts
@@ -19,10 +19,9 @@ export function startJsEvalProcess(
 		},
 		{
 			mode: "isolated",
-			// The subprocess inherits the agent's cwd (or the package root under
-			// the `bun test` fallback of `resolveWorkerSpawnCmd`); mirror the
-			// session cwd so cell code using relative paths or spawning children
-			// resolves against the session's project. Worker threads cannot pass
+			// The subprocess boots from a safe cwd; mirror the session cwd so
+			// cell code using relative paths or spawning children resolves
+			// against the session's project. Worker threads cannot pass
 			// this — `process.chdir` is unavailable there.
 			chdir: cwd => process.chdir(cwd),
 			interceptUnhandledRejections,


### PR DESCRIPTION
Bun initializes the isolated JS eval process before WorkerCore can apply SessionSnapshot.cwd. If the host cwd is inaccessible or removed, Bun exits with Unexpected and OMP falls back to an unsafe inline worker.

Boot that subprocess from os.tmpdir(). WorkerCore still switches to the logical session cwd during init.

Verified with the compiled distribution smoke test and the installed TUI. The TUI completed a forced JavaScript eval after its live launch directory was removed, and its runtime log contained no subprocess-init, Worker-init, uv_cwd, or descriptor-limit error.