### PR TITLE
docs: replaced unavailable README captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Originally built on [Mario Zechner](https://github.com/mariozechner)'s wonderful
 
 Most harnesses give the agent a Python sandbox and call it done. Ours runs persistent Python and a Bun worker, and either kernel can call back into the agent's own tools — read, search, task — over a loopback bridge. The agent loads a CSV with tool.read from inside Python, charts it from JavaScript, and never leaves the cell.
 
-![omp TUI: a single eval session with `[1/2] pandas describe` (Python) printing a real DataFrame.describe() table, followed by `[2/2] top scorer` (JavaScript) running a reduce. Footer: 'Both kernels ran in one session.'](https://omp.sh/captures/eval.webp)
+![omp TUI running Python code and rendering a chart.](assets/python.webp)
 
 ### 02 · LSP wired into every write
 
 Ask for a rename and you get a rename. The call goes through workspace/willRenameFiles, so re-exports, barrel files, and aliased imports update before the file moves. Everything your IDE knows, the agent knows.
 
-![omp TUI: `LSP references` returns five hits across three files for the symbol `formatBytes`, then `LSP rename` applies the change with edits to format.ts/report.ts/cli.ts, then a `Search formatBytes 0 matches` confirmation. Final line: 'Rename complete. Five edits across three files…'.](https://omp.sh/captures/lsp.webp)
+![omp TUI with TypeScript and Biome language servers active.](assets/lspv.webp)
 
 _[Read the LSP config docs](docs/lsp-config.md)_
 
@@ -230,8 +230,6 @@ omp reads the working tree through git_overview, git_file_diff, and git_hunk, th
 
 Sixteen internal schemes — `pr://`, `issue://`, `agent://`, `skill://`, `ssh://`, and the rest — resolve transparently inside every FS-shaped tool the agent already calls. `read pr://1428` returns the same shape as `read src/foo.ts`. `grep` walks a diff like a directory. `agent://<id>/findings.0.path` pulls a field out of a subagent's output by path.
 
-![omp TUI reading pr://can1357/oh-my-pi/1063 and then /diff/1, showing hunk headers, added lines, and a [MODIFIED] (+12 -0) summary.](https://omp.sh/captures/pr.webp)
-
 ### 18 · Conflict resolution, made easy.
 
 Each merge conflict becomes one URL. The agent writes `@theirs`, `@ours`, or `@base` to `conflict://N` and the file resolves cleanly. Bulk form: `conflict://*`.
@@ -251,8 +249,6 @@ _[Watch the capture ↗](https://omp.sh/clips/codemod.mp4)_
 ### 20 · Drives a _real browser_. _Or your Slack?_
 
 Stealth's on by default, so pages see a normal user instead of a headless bot. The same API drives any Electron app in place — point it at Slack and the agent reads your DMs the way it reads the web. Or skip the sandbox entirely: the browser relay extension lets the agent adopt the Chrome tabs you already have open, without stealing focus.
-
-![omp TUI driving the browser tool against DuckDuckGo](https://omp.sh/captures/browser.webp)
 
 ### 21 · Hands on the desktop itself
 
@@ -506,7 +502,7 @@ The TUI is the default surface. Tool calls render as cards, edits preview before
 
 The same prompt cards surface over ACP, so editors get the picker without writing one.
 
-![omp TUI: the ask tool renders an option picker with three choices, a (Recommended) badge on the first, and 'up/down navigate · enter select · esc cancel' footer.](https://omp.sh/captures/ask.webp)
+![omp TUI showing a multi-select question from the ask tool.](assets/ask.webp)
 
 ### SDK — embed in Node
 


### PR DESCRIPTION
## Repro

Running `curl --silent --show-error --head https://omp.sh/captures/eval.webp https://omp.sh/captures/lsp.webp https://omp.sh/captures/pr.webp https://omp.sh/captures/browser.webp https://omp.sh/captures/ask.webp https://omp.sh/clips/dap-poster.webp` returns `content-type: text/html; charset=utf-8` for all five `/captures/` responses, while the `/clips/` control returns `content-type: image/webp`.

## Cause

`README.md` embedded five files under `https://omp.sh/captures/`, but those assets are absent from the deployed site; its SPA fallback serves the homepage HTML with status 200, which GitHub rejects as non-image content.

## Fix

- Replaced the eval, LSP, and ask embeds with tracked WebP assets under `assets/`, with alt text matching those images.
- Removed the unavailable PR and browser embeds rather than retaining dead external references or substituting unrelated screenshots.

## Verification

`gh_push_branch` and `gh_open_pr` completed the repository pre-publish gate (`bun run fix` followed by `bun check`). The published branch’s GitHub-rendered README resolves the three replacement images to repository `raw/` paths and contains zero `omp.sh/captures/` references.

Fixes #9470