### PR TITLE
fix(browser-relay): open tabs silently and dock group at end of tab strip

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [Unreleased]
+
+### Fixed
+
+- Browser relay tabs now open silently in the background (without stealing the
+  current tab or focus) and their "omp" group docks at the end of the tab strip
+  instead of the far left, matching how a drive-by agent session is expected to
+  behave in the user's browser.
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt
+++ b/packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt
@@ -65,6 +65,12 @@ async function groupTabs(tabIds, title, color) {
       groupId = await chrome.tabs.group({ tabIds: ids });
     }
     await chrome.tabGroups.update(groupId, { title, color });
+    try {
+      const winTabs = await chrome.tabs.query({ windowId });
+      await chrome.tabGroups.move(groupId, { index: winTabs.length });
+    } catch (err) {
+      // Best-effort: keeping the group at the end of the tab strip is cosmetic.
+    }
     for (const id of ids)
       grouped[String(id)] = groupId;
   }
@@ -128,7 +134,7 @@ async function runRpc(msg) {
     case "send":
       return await chrome.debugger.sendCommand(msg.sessionId ? { tabId: msg.tabId, sessionId: msg.sessionId } : { tabId: msg.tabId }, msg.method, msg.params);
     case "createTab": {
-      const tab = await chrome.tabs.create({ url: msg.url });
+      const tab = await chrome.tabs.create({ url: msg.url, active: false });
       const snap = snapshot(tab);
       if (!snap)
         throw new Error("created tab has no id");


### PR DESCRIPTION
## What

Make the browser relay extension's `createTab` open tabs silently and dock the
"omp" tab group at the end of the tab strip.

Two small changes to `packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt`:

1. `chrome.tabs.create({ url })` → `chrome.tabs.create({ url, active: false })`
   — created tabs no longer steal the current tab or focus.
2. After grouping, `chrome.tabGroups.move(groupId, { index: winTabs.length })`
   moves the "omp" group to the end of the window's tab strip (best-effort;
   wrapped in try/catch since position is cosmetic).

## Why

The relay lets the agent drive the user's own Chrome. Opening a tab with
`active: true` (the Chrome default) yanks the user from whatever they were
reading to a new page — surprising and disruptive for a background automation
flow. Everything else about the relay already tries to be quiet (background
grouping, no stealing of focus on attach). Keeping the group at the far left
also jars with a normal "new tab appears at the end" expectation; docking at
the end of the strip makes the agent-created page read as an append, not an
overlay.

## Testing

Verified end-to-end in real Chrome via the relay (macOS, Chrome 151):

- Open a tab while Chrome is **not** in the foreground: the active tab/window
  stays untouched, the page appears inside the "omp" group.
- The group lands at the **right edge** of the tab strip (visual check of the
  tab bar).
- `Target.closeTarget` via the bridge closes the tab; the group disappears once
  the only member is closed. No residue in `GET /json/list`.
- The modified file parses as JS (`node` syntax check); it is a text asset
  imported with `with { type: "text" }` into `browser-relay-cli.ts`, so no TS
  compile surface is affected.

> [!NOTE]
> `bun check` could not be run in this environment (the `biome` binary is not
> installed and `bun run check:tools` exits 127). The change is a plain-JS
> text asset validated by syntax parse and the real-browser test above.

---

- [ ] `bun check` passes
- [x] Tested locally (real Chrome end-to-end)
- [x] CHANGELOG updated (user-facing behavior change)

---

*I reviewed the full diff and verified the silent-open and end-of-strip behaviour in my own Chrome before submitting.*
