### PR TITLE
feat(coding-agent): show elapsed wall time next to live tool timeouts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Running bash and eval commands now show elapsed wall time next to the timeout footer.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/eval/types.ts
+++ b/packages/coding-agent/src/eval/types.ts
@@ -51,4 +51,6 @@ export interface EvalToolDetails {
 		jobId: string;
 		type: "eval";
 	};
+	/** Epoch ms when execute started; live footer uses this, not approval wait. */
+	startedAtMs?: number;
 }

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -15,6 +15,7 @@ import {
 	truncateToWidth,
 } from "@oh-my-pi/pi-tui";
 import { getProjectDir, isRecord, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { isSettingsInitialized, settings } from "../../config/settings";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
 import type { Theme } from "../../modes/theme/theme";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
@@ -30,6 +31,7 @@ import {
 	toolRenderers,
 } from "../../tools/renderers";
 import { TODO_STRIKE_TOTAL_FRAMES, type TodoToolDetails } from "../../tools/todo";
+import { resolveDisplayTimeout } from "../../tools/tool-timeouts";
 import type { XdevState } from "../../tools/xdev";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
 import { convertImageToPng } from "../../utils/image-loading";
@@ -419,6 +421,8 @@ export class ToolExecutionComponent extends Container {
 	#executionStartedAtNow: number | undefined;
 	// Epoch ms for live timeout footers. Distinct from the presentation clock.
 	#startedAtMs?: number;
+	// Frozen Date.now() after seal() so a still-partial abort row does not keep ticking.
+	#elapsedNowMs?: number;
 	// Wall clock captured whenever a task card is rebuilt.
 	#taskRenderNowMs = Date.now();
 	// Set on each `render()` when the last painted pending shape must be
@@ -885,6 +889,7 @@ export class ToolExecutionComponent extends Container {
 	seal(): void {
 		if (this.#sealed) return;
 		this.#sealed = true;
+		this.#elapsedNowMs ??= Date.now();
 		this.#blockVersion++;
 		this.#displaceableByToolName = undefined;
 		this.stopAnimation();
@@ -1403,15 +1408,21 @@ export class ToolExecutionComponent extends Container {
 		return { ...(renderArgs as Record<string, unknown>), previewDiff: first.diff };
 	}
 
+	#applyLiveElapsed(context: Record<string, unknown>): void {
+		const detailsStarted = (this.#result?.details as { startedAtMs?: unknown } | undefined)?.startedAtMs;
+		if (typeof detailsStarted === "number" && Number.isFinite(detailsStarted)) {
+			this.#startedAtMs = detailsStarted;
+		}
+		if (this.#startedAtMs !== undefined) context.startedAtMs = this.#startedAtMs;
+		if (this.#elapsedNowMs !== undefined) context.nowMs = this.#elapsedNowMs;
+	}
+
 	/**
 	 * Build render context for tools that need extra state (bash, python, edit)
 	 */
 	#buildRenderContext(): Record<string, unknown> {
 		const context: Record<string, unknown> = {};
-		const normalizeTimeoutSeconds = (value: unknown, maxSeconds: number): number | undefined => {
-			if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-			return Math.max(1, Math.min(maxSeconds, value));
-		};
+		const maxTimeout = isSettingsInitialized() ? settings.get("tools.maxTimeout") : undefined;
 
 		if (this.#toolName === "bash") {
 			// Bash needs render context even before a result exists. The renderer uses the pending-call args
@@ -1420,29 +1431,30 @@ export class ToolExecutionComponent extends Container {
 				// Pass raw output and expanded state - renderer handles width-aware truncation
 				const output = this.#getTextOutput().trimEnd();
 				context.output = output;
-				const detailsStarted = (this.#result.details as { startedAtMs?: unknown } | undefined)?.startedAtMs;
-				if (typeof detailsStarted === "number" && Number.isFinite(detailsStarted)) {
-					this.#startedAtMs = detailsStarted;
-				}
 			}
-			if (this.#startedAtMs !== undefined) context.startedAtMs = this.#startedAtMs;
+			this.#applyLiveElapsed(context);
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;
-			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 3600);
+			context.timeout = resolveDisplayTimeout(
+				"bash",
+				typeof this.#args?.timeout === "number" && Number.isFinite(this.#args.timeout)
+					? this.#args.timeout
+					: undefined,
+				maxTimeout,
+			);
 		} else if (this.#toolName === "eval" && this.#result) {
 			const output = this.#getTextOutput().trimEnd();
 			context.output = output;
 			context.expanded = this.#expanded;
 			context.previewLines = EVAL_DEFAULT_PREVIEW_LINES;
-			context.timeout = normalizeTimeoutSeconds(
-				this.#args?.timeout ?? (Array.isArray(this.#args?.cells) ? this.#args.cells[0]?.timeout : undefined),
-				3600,
-			);
-			const detailsStarted = (this.#result.details as { startedAtMs?: unknown } | undefined)?.startedAtMs;
-			if (typeof detailsStarted === "number" && Number.isFinite(detailsStarted)) {
-				this.#startedAtMs = detailsStarted;
-			}
-			if (this.#startedAtMs !== undefined) context.startedAtMs = this.#startedAtMs;
+			const evalTimeout =
+				typeof this.#args?.timeout === "number" && Number.isFinite(this.#args.timeout)
+					? this.#args.timeout
+					: typeof this.#args?.cells?.[0]?.timeout === "number" && Number.isFinite(this.#args.cells[0].timeout)
+						? this.#args.cells[0].timeout
+						: undefined;
+			context.timeout = resolveDisplayTimeout("eval", evalTimeout, maxTimeout);
+			this.#applyLiveElapsed(context);
 		} else if (this.#toolName === "task") {
 			// Once a result snapshot exists the task renderer's `renderResult`
 			// draws every dispatched agent as a progress/result line, so tell

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -417,6 +417,8 @@ export class ToolExecutionComponent extends Container {
 	// Execution start on the presentation clock (performance.now domain, the
 	// same domain as AnimationFrame.now supplied by the transcript allocator).
 	#executionStartedAtNow: number | undefined;
+	// Epoch ms for live timeout footers. Distinct from the presentation clock.
+	#startedAtMs?: number;
 	// Wall clock captured whenever a task card is rebuilt.
 	#taskRenderNowMs = Date.now();
 	// Set on each `render()` when the last painted pending shape must be
@@ -524,6 +526,7 @@ export class ToolExecutionComponent extends Container {
 		if (this.#executionStarted) return;
 		this.#executionStarted = true;
 		this.#executionStartedAtNow = performance.now();
+		this.#startedAtMs = Date.now();
 		this.#argsComplete = true;
 		this.#updateSpinnerAnimation();
 		this.#schedulePreviewDiff();
@@ -1417,7 +1420,12 @@ export class ToolExecutionComponent extends Container {
 				// Pass raw output and expanded state - renderer handles width-aware truncation
 				const output = this.#getTextOutput().trimEnd();
 				context.output = output;
+				const detailsStarted = (this.#result.details as { startedAtMs?: unknown } | undefined)?.startedAtMs;
+				if (typeof detailsStarted === "number" && Number.isFinite(detailsStarted)) {
+					this.#startedAtMs = detailsStarted;
+				}
 			}
+			if (this.#startedAtMs !== undefined) context.startedAtMs = this.#startedAtMs;
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;
 			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 3600);
@@ -1426,6 +1434,15 @@ export class ToolExecutionComponent extends Container {
 			context.output = output;
 			context.expanded = this.#expanded;
 			context.previewLines = EVAL_DEFAULT_PREVIEW_LINES;
+			context.timeout = normalizeTimeoutSeconds(
+				this.#args?.timeout ?? (Array.isArray(this.#args?.cells) ? this.#args.cells[0]?.timeout : undefined),
+				3600,
+			);
+			const detailsStarted = (this.#result.details as { startedAtMs?: unknown } | undefined)?.startedAtMs;
+			if (typeof detailsStarted === "number" && Number.isFinite(detailsStarted)) {
+				this.#startedAtMs = detailsStarted;
+			}
+			if (this.#startedAtMs !== undefined) context.startedAtMs = this.#startedAtMs;
 		} else if (this.#toolName === "task") {
 			// Once a result snapshot exists the task renderer's `renderResult`
 			// draws every dispatched agent as a progress/result line, so tell

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1808,7 +1808,8 @@ export const bashToolRenderer = {
 		resolveEnv: args => args?.env,
 		showHeader: false,
 	}),
-	// Live timeout footer consumes elapsed seconds; tick only when a timeout is
-	// on the call so headerless pending previews stay idle.
-	animatedPartialResult: (args: BashRenderArgs | undefined) => typeof args?.timeout === "number" && args.timeout > 0,
+	// Live timeout footer consumes elapsed seconds. Tick whenever a deadline
+	// is in force, including the 300s default when the model omits `timeout`.
+	// `timeout: 0` disables the deadline; async snapshots stay static.
+	animatedPartialResult: (args: BashRenderArgs | undefined) => args?.async !== true && args?.timeout !== 0,
 };

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -54,6 +54,7 @@ import {
 	formatToolWorkingDirectory,
 	previewWindowRows,
 	replaceTabs,
+	resolveLiveElapsedSeconds,
 } from "./render-utils";
 import { extractLeadingCdTarget, tokenizeShellSegments } from "./shell-tokenize";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -348,6 +349,8 @@ export interface BashToolDetails {
 	requestedTimeoutSeconds?: number;
 	timeoutDisabled?: boolean;
 	wallTimeMs?: number;
+	/** Epoch ms when execute started; live footer uses this until wallTimeMs lands. */
+	startedAtMs?: number;
 	/** Exit code of a command that ran to completion but failed (non-zero). */
 	exitCode?: number;
 	/** True when the command was killed by its timeout deadline (not a failure). */
@@ -1007,6 +1010,16 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			if (timeoutClampNotice) pendingNotices.push(timeoutClampNotice);
 		}
 
+		const startedAtMs = Date.now();
+		const onStreamUpdate: AgentToolUpdateCallback<BashToolDetails> | undefined = onUpdate
+			? update => {
+					onUpdate({
+						...update,
+						details: { startedAtMs, ...update.details },
+					});
+				}
+			: undefined;
+
 		if (asyncRequested) {
 			if (!this.session.asyncJobManager) {
 				throw new ToolError("Async job manager unavailable for this session.");
@@ -1020,7 +1033,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				notices: pendingNotices,
 
 				resolvedEnv,
-				onUpdate,
+				onUpdate: onStreamUpdate,
 				forwardUpdates: false,
 			});
 			return this.#buildBackgroundStartResult(job.jobId, "", timeoutSec, {
@@ -1058,7 +1071,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				notices: pendingNotices,
 
 				resolvedEnv,
-				onUpdate,
+				onUpdate: onStreamUpdate,
 				forwardUpdates: !startBackgrounded,
 			});
 			if (startBackgrounded) {
@@ -1227,7 +1240,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				handle = createRaced.handle;
 
 				// Emit partial update so the editor can embed the live terminal card.
-				onUpdate?.({ content: [], details: { terminalId: handle.terminalId } });
+				onStreamUpdate?.({ content: [], details: { terminalId: handle.terminalId } });
 
 				const exitPromise = handle.waitForExit();
 				let exitStatus!: ClientBridgeTerminalExitStatus;
@@ -1309,7 +1322,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 						continue;
 					}
 					lastPolledOutput = pollOutput;
-					onUpdate?.({
+					onStreamUpdate?.({
 						content: [{ type: "text", text: pollOutput.output }],
 						details: { terminalId: handle.terminalId },
 					});
@@ -1411,7 +1424,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					env: resolvedEnv,
 					artifactPath,
 					artifactId,
-					onChunk: streamTailUpdates(tailBuffer, onUpdate),
+					onChunk: streamTailUpdates(tailBuffer, onStreamUpdate),
 					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
 				});
 		const wallTimeMs = performance.now() - wallTimeStart;
@@ -1469,6 +1482,10 @@ export interface BashRenderContext {
 	previewLines?: number;
 	/** Timeout in seconds */
 	timeout?: number;
+	/** Epoch ms when the command started; live footer elapsed source. */
+	startedAtMs?: number;
+	/** Frozen clock for committed rows; omit while the block is still live. */
+	nowMs?: number;
 }
 
 export interface ShellRendererConfig<TArgs> {
@@ -1609,6 +1626,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 			let cachedIsPartial: boolean | undefined;
 			let cachedLines: readonly string[] | undefined;
 			let cachedPreviewWindow: number | undefined;
+			let cachedLiveWallSeconds: number | undefined;
 
 			return markFramedBlockComponent({
 				render: (width: number): readonly string[] => {
@@ -1624,6 +1642,13 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 
 					const isPartial = options.isPartial === true;
 					const previewWindow = previewWindowRows();
+					const startedAtMs = details?.startedAtMs ?? renderContext?.startedAtMs;
+					const liveWallSeconds = resolveLiveElapsedSeconds({
+						isPartial,
+						startedAtMs,
+						nowMs: renderContext?.nowMs,
+						hasFinalWall: details?.wallTimeMs !== undefined,
+					});
 
 					if (
 						cachedLines !== undefined &&
@@ -1632,7 +1657,8 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 						cachedExpanded === expanded &&
 						cachedRawOutput === rawOutput &&
 						cachedIsPartial === isPartial &&
-						cachedPreviewWindow === previewWindow
+						cachedPreviewWindow === previewWindow &&
+						cachedLiveWallSeconds === liveWallSeconds
 					) {
 						return cachedLines;
 					}
@@ -1656,6 +1682,8 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					}
 					if (wallTimeMs !== undefined) {
 						statsParts.push(`Wall: ${formatWallTimeSeconds(wallTimeMs)}s`);
+					} else if (liveWallSeconds !== undefined) {
+						statsParts.push(`Wall: ${liveWallSeconds}s`);
 					}
 					if (timeoutDisabled) {
 						statsParts.push("Timeout: disabled");
@@ -1750,6 +1778,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					cachedRawOutput = rawOutput;
 					cachedIsPartial = isPartial;
 					cachedPreviewWindow = previewWindow;
+					cachedLiveWallSeconds = liveWallSeconds;
 					cachedLines = framed;
 					return framed;
 				},
@@ -1762,6 +1791,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					cachedRawOutput = undefined;
 					cachedIsPartial = undefined;
 					cachedPreviewWindow = undefined;
+					cachedLiveWallSeconds = undefined;
 				},
 			});
 		},
@@ -1770,10 +1800,15 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 	};
 }
 
-export const bashToolRenderer = createShellRenderer<BashRenderArgs>({
-	resolveTitle: () => "Bash",
-	resolveCommand: args => args?.command,
-	resolveCwd: args => args?.cwd,
-	resolveEnv: args => args?.env,
-	showHeader: false,
-});
+export const bashToolRenderer = {
+	...createShellRenderer<BashRenderArgs>({
+		resolveTitle: () => "Bash",
+		resolveCommand: args => args?.command,
+		resolveCwd: args => args?.cwd,
+		resolveEnv: args => args?.env,
+		showHeader: false,
+	}),
+	// Live timeout footer consumes elapsed seconds; tick only when a timeout is
+	// on the call so headerless pending previews stay idle.
+	animatedPartialResult: (args: BashRenderArgs | undefined) => typeof args?.timeout === "number" && args.timeout > 0,
+};

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -37,6 +37,7 @@ import {
 	formatTitle,
 	previewWindowRows,
 	replaceTabs,
+	resolveLiveElapsedSeconds,
 	shortenPath,
 	truncateToWidth,
 	wrapBrackets,
@@ -60,6 +61,7 @@ interface EvalRenderArgs {
 	language?: string;
 	code?: string;
 	title?: string;
+	timeout?: number;
 	cells?: EvalRenderCellArg[];
 	__partialJson?: string;
 }
@@ -69,6 +71,8 @@ interface EvalRenderContext {
 	expanded?: boolean;
 	previewLines?: number;
 	timeout?: number;
+	startedAtMs?: number;
+	nowMs?: number;
 }
 
 interface EvalRenderCell {
@@ -82,6 +86,23 @@ function normalizeRenderLanguage(value: string | undefined): EvalLanguage {
 	if (value === "rb" || value === "ruby") return "ruby";
 	if (value === "jl" || value === "julia") return "julia";
 	return "python";
+}
+
+function evalTimeoutFooter(
+	renderContext: EvalRenderContext | undefined,
+	isPartial: boolean,
+	uiTheme: Theme,
+): string | undefined {
+	const timeoutSeconds = renderContext?.timeout;
+	if (typeof timeoutSeconds !== "number") return undefined;
+	const elapsed = resolveLiveElapsedSeconds({
+		isPartial,
+		startedAtMs: renderContext?.startedAtMs,
+		nowMs: renderContext?.nowMs,
+	});
+	const label =
+		elapsed === undefined ? `Timeout: ${timeoutSeconds}s` : `Wall: ${elapsed}s | Timeout: ${timeoutSeconds}s`;
+	return uiTheme.fg("dim", wrapBrackets(label, uiTheme));
 }
 
 function getRenderCells(args: EvalRenderArgs | undefined): EvalRenderCell[] {
@@ -576,11 +597,8 @@ export const evalToolRenderer = {
 			return labelOutputs ? [uiTheme.fg("dim", `display[${index + 1}]`), ...body] : body;
 		});
 
-		const timeoutSeconds = options.renderContext?.timeout;
-		const timeoutLine =
-			typeof timeoutSeconds === "number"
-				? uiTheme.fg("dim", wrapBrackets(`Timeout: ${timeoutSeconds}s`, uiTheme))
-				: undefined;
+		const timeoutFooter = (): string | undefined =>
+			evalTimeoutFooter(options.renderContext, options.isPartial === true, uiTheme);
 		let warningLine: string | undefined;
 		if (details?.meta?.truncation) {
 			warningLine = formatStyledTruncationWarning(details.meta, uiTheme) ?? undefined;
@@ -606,7 +624,8 @@ export const evalToolRenderer = {
 						options.renderContext?.previewLines ?? EVAL_DEFAULT_PREVIEW_LINES,
 						previewWindowRows(),
 					);
-					const key = `${expanded}|${previewLines}|${options.spinnerFrame}|${previewWindowRows()}`;
+					const timeoutLine = timeoutFooter();
+					const key = `${expanded}|${previewLines}|${options.spinnerFrame}|${previewWindowRows()}|${timeoutLine ?? ""}`;
 					if (cached && cached.key === key && cached.width === width) {
 						return cached.result;
 					}
@@ -700,7 +719,7 @@ export const evalToolRenderer = {
 		);
 
 		if (!combinedOutput && statusLines.length === 0) {
-			const lines = [timeoutLine, noticeLine, asyncLine, warningLine].filter(Boolean) as string[];
+			const lines = [timeoutFooter(), noticeLine, asyncLine, warningLine].filter(Boolean) as string[];
 			return new Text(lines.join("\n"), 0, 0);
 		}
 
@@ -708,7 +727,7 @@ export const evalToolRenderer = {
 			const lines = [
 				uiTheme.fg("dim", "Status"),
 				...statusLines,
-				timeoutLine,
+				timeoutFooter(),
 				noticeLine,
 				asyncLine,
 				warningLine,
@@ -724,7 +743,7 @@ export const evalToolRenderer = {
 			const lines = [
 				styledOutput,
 				...(statusLines.length > 0 ? [uiTheme.fg("dim", "Status"), ...statusLines] : []),
-				timeoutLine,
+				timeoutFooter(),
 				noticeLine,
 				asyncLine,
 				warningLine,
@@ -772,6 +791,7 @@ export const evalToolRenderer = {
 						outputLines.push(truncateToWidth(statusLine, width));
 					}
 				}
+				const timeoutLine = timeoutFooter();
 				if (timeoutLine) {
 					outputLines.push(truncateToWidth(timeoutLine, width));
 				}

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -94,7 +94,7 @@ function evalTimeoutFooter(
 	uiTheme: Theme,
 ): string | undefined {
 	const timeoutSeconds = renderContext?.timeout;
-	if (typeof timeoutSeconds !== "number") return undefined;
+	if (typeof timeoutSeconds !== "number" || timeoutSeconds <= 0) return undefined;
 	const elapsed = resolveLiveElapsedSeconds({
 		isPartial,
 		startedAtMs: renderContext?.startedAtMs,

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -475,9 +475,10 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const languages = uniqueEvalLanguages(cells);
 		const notice = detailsNotice(cells);
 		const sessionAbortController = new AbortController();
+		const startedAtMs = Date.now();
 		const emitToolUpdate = onUpdate
 			? (text: string, details: EvalToolDetails): void => {
-					onUpdate({ content: [{ type: "text", text }], details });
+					onUpdate({ content: [{ type: "text", text }], details: { startedAtMs, ...details } });
 				}
 			: undefined;
 		const run = (

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -144,6 +144,19 @@ export function getDomain(url: string): string {
 
 export { formatAge, formatBytes, formatCount, formatDuration, pluralize } from "@oh-my-pi/pi-utils";
 
+/** Whole-second elapsed for a live timeout footer. Frozen `nowMs` wins so committed rows cannot drift. */
+export function resolveLiveElapsedSeconds(args: {
+	isPartial: boolean;
+	startedAtMs?: number;
+	nowMs?: number;
+	hasFinalWall?: boolean;
+}): number | undefined {
+	if (!args.isPartial || args.hasFinalWall) return undefined;
+	if (typeof args.startedAtMs !== "number" || !Number.isFinite(args.startedAtMs)) return undefined;
+	const now = typeof args.nowMs === "number" && Number.isFinite(args.nowMs) ? args.nowMs : Date.now();
+	return Math.floor(Math.max(0, now - args.startedAtMs) / 1000);
+}
+
 // =============================================================================
 // Theme Helper Utilities
 // =============================================================================

--- a/packages/coding-agent/src/tools/tool-timeouts.ts
+++ b/packages/coding-agent/src/tools/tool-timeouts.ts
@@ -36,3 +36,20 @@ export function clampTimeout(tool: ToolWithTimeout, rawTimeout?: number, maxTime
 	const capped = maxTimeout !== undefined && maxTimeout > 0 ? Math.min(timeout, maxTimeout) : timeout;
 	return Math.max(config.min, Math.min(config.max, capped));
 }
+
+/**
+ * Timeout seconds for a live/result footer.
+ *
+ * `0` is the explicit disabled contract: no deadline and no footer.
+ * Omitted uses the tool default. Any other finite value is {@link clampTimeout}.
+ */
+export function resolveDisplayTimeout(
+	tool: ToolWithTimeout,
+	rawTimeout?: number,
+	maxTimeout?: number,
+): number | undefined {
+	if (rawTimeout === 0) return undefined;
+	if (rawTimeout === undefined) return clampTimeout(tool, undefined, maxTimeout);
+	if (!Number.isFinite(rawTimeout)) return undefined;
+	return clampTimeout(tool, rawTimeout, maxTimeout);
+}

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -353,4 +353,123 @@ describe("ToolExecutionComponent live preview spinners", () => {
 			component.stopAnimation();
 		}
 	});
+
+	it("ticks live bash results that use the default timeout", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const requestComponentRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 60" },
+			{},
+			undefined,
+			{ requestRender, requestComponentRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "waiting" }],
+					details: { timeoutSeconds: 300, startedAtMs: Date.now() },
+				},
+				true,
+			);
+			requestRender.mockClear();
+			requestComponentRender.mockClear();
+			vi.advanceTimersByTime(500);
+			expect(requestComponentRender).toHaveBeenCalled();
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
+	it("freezes live wall after seal on a still-partial result", () => {
+		const startedAtMs = 1_700_000_000_000;
+		const now = vi.spyOn(Date, "now").mockReturnValue(startedAtMs + 1_000);
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 60", timeout: 60 },
+			{},
+			undefined,
+			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "waiting" }],
+					details: { timeoutSeconds: 60, startedAtMs },
+				},
+				true,
+			);
+			expect(stripVTControlCharacters(component.render(120).join("\n"))).toContain("Wall: 1s");
+			component.seal();
+			now.mockReturnValue(startedAtMs + 12_000);
+			const sealed = stripVTControlCharacters(component.render(120).join("\n"));
+			expect(sealed).toContain("Wall: 1s");
+			expect(sealed).not.toContain("Wall: 12s");
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
+	it("shows the default eval timeout when the call omits timeout", () => {
+		const component = new ToolExecutionComponent(
+			"eval",
+			{ language: "py", code: "1" },
+			{},
+			undefined,
+			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "" }],
+					details: {
+						language: "python",
+						languages: ["python"],
+						cells: [{ index: 0, code: "1", language: "python", output: "", status: "running" }],
+					},
+				},
+				true,
+			);
+			expect(stripVTControlCharacters(component.render(120).join("\n"))).toContain("Timeout: 30s");
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
+	it("hides the eval timeout footer when timeout is 0", () => {
+		const component = new ToolExecutionComponent(
+			"eval",
+			{ language: "py", code: "1", timeout: 0 },
+			{},
+			undefined,
+			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "" }],
+					details: {
+						language: "python",
+						languages: ["python"],
+						cells: [{ index: 0, code: "1", language: "python", output: "", status: "running" }],
+					},
+				},
+				true,
+			);
+			const rendered = stripVTControlCharacters(component.render(120).join("\n"));
+			expect(rendered).not.toContain("Timeout:");
+			expect(rendered).not.toContain("Wall:");
+		} finally {
+			component.stopAnimation();
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -81,6 +81,36 @@ describe("ToolExecutionComponent live preview spinners", () => {
 		}
 	});
 
+	it("ticks live bash results that show a timeout footer", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const requestComponentRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 600", timeout: 1400 },
+			{},
+			undefined,
+			{ requestRender, requestComponentRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "waiting" }],
+					details: { timeoutSeconds: 1400, startedAtMs: Date.now() },
+				},
+				true,
+			);
+			requestRender.mockClear();
+			requestComponentRender.mockClear();
+			vi.advanceTimersByTime(500);
+			expect(requestComponentRender).toHaveBeenCalled();
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
 	it("does not tick detached async bash result snapshots", () => {
 		vi.useFakeTimers();
 		const requestRender = vi.fn();

--- a/packages/coding-agent/test/tools/bash-sixel-render.test.ts
+++ b/packages/coding-agent/test/tools/bash-sixel-render.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { RenderResultOptions } from "@oh-my-pi/pi-agent-core";
@@ -26,6 +26,7 @@ describe("bashToolRenderer", () => {
 
 	afterEach(() => {
 		terminal.imageProtocol = originalProtocol;
+		vi.restoreAllMocks();
 	});
 
 	it("shows rendered env assignments in the command preview", async () => {
@@ -230,6 +231,47 @@ describe("bashToolRenderer", () => {
 		expect(rendered).toContain("Wall: 0.02s");
 		expect(rendered).toContain("Timeout: 300s");
 		expect(rendered).not.toContain("Exit:");
+	});
+
+	it("renders live elapsed wall time next to the timeout while the command is running", async () => {
+		const startedAtMs = 1_700_000_000_000;
+		vi.spyOn(Date, "now").mockReturnValue(startedAtMs + 42_000);
+		const component = bashToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "waiting; dumpfiles=0" }],
+				details: { timeoutSeconds: 1400, startedAtMs },
+				isError: false,
+			},
+			{ expanded: false, isPartial: true, renderContext: { timeout: 1400, startedAtMs } },
+			uiTheme,
+			{ command: "sleep 1400", timeout: 1400 },
+		);
+		const rendered = sanitizeText(component.render(120).join("\n"));
+		expect(rendered).toContain("Wall: 42s");
+		expect(rendered).toContain("Timeout: 1400s");
+	});
+
+	it("advances the live wall label when another second elapses", async () => {
+		const startedAtMs = 1_700_000_000_000;
+		const now = vi.spyOn(Date, "now").mockReturnValue(startedAtMs + 1_000);
+		const component = bashToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "waiting" }],
+				details: { startedAtMs },
+				isError: false,
+			},
+			{ expanded: false, isPartial: true, renderContext: { timeout: 1400, startedAtMs } },
+			uiTheme,
+			{ command: "sleep 1400", timeout: 1400 },
+		);
+		const first = component.render(120);
+		expect(sanitizeText(first.join("\n"))).toContain("Wall: 1s");
+		expect(component.render(120)).toBe(first);
+
+		now.mockReturnValue(startedAtMs + 2_400);
+		const second = component.render(120);
+		expect(second).not.toBe(first);
+		expect(sanitizeText(second.join("\n"))).toContain("Wall: 2s");
 	});
 
 	it("bypasses truncation/styling for SIXEL lines", async () => {

--- a/packages/coding-agent/test/tools/eval-code-preview.test.ts
+++ b/packages/coding-agent/test/tools/eval-code-preview.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { EvalToolDetails } from "@oh-my-pi/pi-coding-agent/eval/types";
 import { getThemeByName, setThemeInstance, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -29,6 +29,10 @@ describe("eval renderer: viewport tail window for cell code", () => {
 
 	afterAll(() => {
 		resetSettingsForTest();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	function renderResult(expanded: boolean): string {
@@ -92,6 +96,21 @@ describe("eval renderer: viewport tail window for cell code", () => {
 		const rendered = Bun.stripANSI(component.render(120).join("\n"));
 		expect(rendered).toContain("Wall: 12s");
 		expect(rendered).toContain("Timeout: 30s");
-		vi.restoreAllMocks();
+	});
+
+	it("omits the timeout footer when the deadline is disabled", () => {
+		const details: EvalToolDetails = {
+			language: "python",
+			languages: ["python"],
+			cells: [{ index: 0, code: "1", language: "python", output: "", status: "running" }],
+		};
+		const component = evalToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{ expanded: false, isPartial: true, renderContext: { timeout: 0 } },
+			theme,
+		);
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).not.toContain("Timeout:");
+		expect(rendered).not.toContain("Wall:");
 	});
 });

--- a/packages/coding-agent/test/tools/eval-code-preview.test.ts
+++ b/packages/coding-agent/test/tools/eval-code-preview.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { EvalToolDetails } from "@oh-my-pi/pi-coding-agent/eval/types";
 import { getThemeByName, setThemeInstance, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -70,5 +70,28 @@ describe("eval renderer: viewport tail window for cell code", () => {
 		expect(rendered).toContain(lastLine);
 		expect(rendered).toContain("earlier line");
 		expect(rendered).not.toContain(firstLine);
+	});
+
+	it("renders live wall time next to the timeout while a cell is running", () => {
+		const startedAtMs = 1_700_000_000_000;
+		vi.spyOn(Date, "now").mockReturnValue(startedAtMs + 12_000);
+		const details: EvalToolDetails = {
+			language: "python",
+			languages: ["python"],
+			cells: [{ index: 0, code: "time.sleep(30)", language: "python", output: "", status: "running" }],
+		};
+		const component = evalToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{
+				expanded: false,
+				isPartial: true,
+				renderContext: { timeout: 30, startedAtMs },
+			},
+			theme,
+		);
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("Wall: 12s");
+		expect(rendered).toContain("Timeout: 30s");
+		vi.restoreAllMocks();
 	});
 });

--- a/packages/coding-agent/test/tools/tool-timeouts.test.ts
+++ b/packages/coding-agent/test/tools/tool-timeouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { clampTimeout, TOOL_TIMEOUTS } from "@oh-my-pi/pi-coding-agent/tools/tool-timeouts";
+import { clampTimeout, resolveDisplayTimeout, TOOL_TIMEOUTS } from "@oh-my-pi/pi-coding-agent/tools/tool-timeouts";
 
 describe("clampTimeout", () => {
 	it("returns the per-tool default when no raw timeout is given", () => {
@@ -36,5 +36,28 @@ describe("clampTimeout", () => {
 		// maxTimeout under the floor cannot drive the effective timeout below
 		// the tool's own minimum (bash min = 1s).
 		expect(clampTimeout("bash", undefined, 0.1)).toBe(TOOL_TIMEOUTS.bash.min);
+	});
+});
+
+describe("resolveDisplayTimeout", () => {
+	it("uses the per-tool default when the agent omits timeout", () => {
+		expect(resolveDisplayTimeout("bash")).toBe(TOOL_TIMEOUTS.bash.default);
+		expect(resolveDisplayTimeout("eval")).toBe(TOOL_TIMEOUTS.eval.default);
+	});
+
+	it("returns undefined when timeout is explicitly disabled", () => {
+		expect(resolveDisplayTimeout("bash", 0)).toBeUndefined();
+		expect(resolveDisplayTimeout("eval", 0)).toBeUndefined();
+	});
+
+	it("clamps a finite timeout the same way execute does", () => {
+		expect(resolveDisplayTimeout("bash", 1400)).toBe(1400);
+		expect(resolveDisplayTimeout("bash", 999_999)).toBe(TOOL_TIMEOUTS.bash.max);
+		expect(resolveDisplayTimeout("eval", 0.1)).toBe(TOOL_TIMEOUTS.eval.min);
+	});
+
+	it("applies a positive global maxTimeout ceiling", () => {
+		expect(resolveDisplayTimeout("bash", undefined, 30)).toBe(30);
+		expect(resolveDisplayTimeout("eval", 120, 20)).toBe(20);
 	});
 });


### PR DESCRIPTION
its nice to see the elapsed time instead of just the timeout on cli call

## What

Live `bash` and `eval` output now shows elapsed wall time next to the timeout footer, so a long command reads `[Wall: 42s | Timeout: 1400s]` instead of only the deadline.

The clock starts when the tool begins executing, ticks once a second while the call is live, and yields to the existing two-decimal `Wall:` once the result lands.

## Why

A 1400s bash timeout with no elapsed time makes it impossible to tell how close the command is to being killed.

## Testing

- `bun check` clean in `packages/coding-agent`.
- `bun test test/tools/bash-sixel-render.test.ts test/tools/eval-code-preview.test.ts test/modes/components/tool-execution-spinner.test.ts` → 34 pass, 0 fail.
- Used it in a real session on a long-running bash call: the footer showed elapsed next to `Timeout: 1400s` and advanced while the command ran.

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)