### PR TITLE
perf(coding-agent): coalesce caught-up streaming reveal renders to the reveal cadence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Cap streaming markdown renders at the reveal cadence when reveal is caught up; provider deltas accumulate and flush per tick instead of rendering per token.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
@@ -222,6 +222,7 @@ export class StreamingRevealController {
 	#component: StreamingRevealComponent | undefined;
 	#timer: NodeJS.Timeout | undefined;
 	#revealed = 0;
+	#targetDirty = false;
 	#hideThinkingBlock = false;
 	#proseOnlyThinking = true;
 	#smoothStreaming = true;
@@ -299,8 +300,19 @@ export class StreamingRevealController {
 		if (this.#revealed > total) {
 			this.#revealed = total;
 		}
-		this.#renderCurrent();
-		this.#syncTimer(total);
+		if (this.#revealed < total) {
+			// Behind: the running reveal tick renders the newest target at the
+			// cadence; skip the redundant per-delta render (the reveal cadence
+			// bounds markdown work even when the provider deltas arrive faster).
+			this.#targetDirty = false;
+			this.#syncTimer(total);
+			return;
+		}
+		// Caught up: defer the render to the next reveal tick so a burst of
+		// post-catch-up deltas coalesces into one render instead of one per
+		// token. The tick always renders the latest target — nothing is lost.
+		if (!this.#timer) this.#startTimer();
+		this.#targetDirty = true;
 	}
 
 	stop(): void {
@@ -308,6 +320,7 @@ export class StreamingRevealController {
 		this.#target = undefined;
 		this.#component = undefined;
 		this.#revealed = 0;
+		this.#targetDirty = false;
 		this.#unitCounter.reset();
 	}
 
@@ -384,6 +397,12 @@ export class StreamingRevealController {
 		}
 		const total = this.#visibleUnits(target);
 		if (this.#revealed >= total) {
+			if (this.#targetDirty) {
+				this.#targetDirty = false;
+				this.#revealed = total;
+				this.#renderCurrent();
+				this.#requestRender(component);
+			}
 			this.#stopTimer();
 			return;
 		}

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -422,3 +422,124 @@ describe("BlockUnitCounter.slice", () => {
 		}
 	});
 });
+
+describe("frame-skip coalescing", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("coalesces caught-up target deltas to at most one render per reveal frame", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+		const base = "abcdefghij";
+		const tail = "x".repeat(30);
+		const fullText = base + tail;
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: base }]));
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 10);
+		expect(textAt(latestMessage(component), 0)).toBe(base);
+
+		// 30 deltas at 5x the reveal cadence (each 1 unit of growth).
+		const before = component.messages.length;
+		let text = base;
+		for (let i = 0; i < 30; i++) {
+			text += tail[i];
+			controller.setTarget(makeMessage([{ type: "text", text }]));
+			vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS / 5);
+		}
+		const burstRenders = component.messages.length - before;
+		expect(burstRenders).toBeLessThanOrEqual(
+			Math.ceil((30 * STREAMING_REVEAL_FRAME_MS) / 5 / STREAMING_REVEAL_FRAME_MS) + 1,
+		);
+		expect(burstRenders).toBeLessThan(30);
+
+		// The final drain renders the full text.
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 20);
+		expect(textAt(latestMessage(component), 0)).toBe(fullText);
+	});
+
+	it("renders toolCall targets synchronously even when a drain is pending", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
+		expect(textAt(latestMessage(component), 0)).toBe("hi");
+
+		// Same reveal budget as "hi" -> caught up: drain is deferred to a tick.
+		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]));
+		const pending = component.messages.length;
+		expect(textAt(latestMessage(component), 0)).toBe("hi");
+		controller.setTarget(
+			makeMessage([
+				{ type: "text", text: "yo" },
+				{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } },
+			]),
+		);
+		// The toolCall boundary still renders synchronously, before any tick.
+		expect(component.messages.length).toBe(pending + 1);
+		expect(textAt(latestMessage(component), 0)).toBe("yo");
+		expect(latestMessage(component).content.at(-1)?.type).toBe("toolCall");
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 4);
+		expect(component.messages.length).toBe(pending + 1);
+	});
+
+	it("keeps synchronous per-setTarget renders when smooth streaming is off", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController({ smooth: false });
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "one" }]));
+		const before = component.messages.length;
+		controller.setTarget(makeMessage([{ type: "text", text: "one two" }]));
+
+		expect(component.messages.length).toBe(before + 1);
+		expect(textAt(latestMessage(component), 0)).toBe("one two");
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 5);
+		expect(component.messages.length).toBe(before + 1);
+	});
+
+	it("flushes the trailing delta at the next tick and stops the timer", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
+		expect(textAt(latestMessage(component), 0)).toBe("hi");
+
+		controller.setTarget(makeMessage([{ type: "text", text: "hi!" }]));
+		const before = component.messages.length;
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
+		expect(component.messages.length).toBe(before + 1);
+		expect(textAt(latestMessage(component), 0)).toBe("hi!");
+
+		const flushed = component.messages.length;
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 4);
+		expect(component.messages.length).toBe(flushed);
+	});
+
+	it("re-arms the timer for caught-up deltas and renders nothing while idle", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
+		expect(textAt(latestMessage(component), 0)).toBe("hi");
+
+		// Caught up: "yo" has the same reveal budget, so the render is deferred.
+		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]));
+		const before = component.messages.length;
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
+		expect(component.messages.length).toBe(before + 1);
+		expect(textAt(latestMessage(component), 0)).toBe("yo");
+
+		// No further deltas: subsequent ticks render nothing.
+		const drained = component.messages.length;
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 4);
+		expect(component.messages.length).toBe(drained);
+	});
+});


### PR DESCRIPTION
## Problem

During assistant streaming, every provider `text_delta` synchronously drives
`setTarget` → `#renderCurrent` → `updateContent` → `Markdown.setText` — even
when smooth reveal has **caught up** (`#revealed >= total`, the common
slow-provider case). The reveal tick (33 ms) adds renders on top; it never
coalesces them. Terminal *paint* is capped (~30 fps + adaptive backpressure,
#4145), but the per-delta build/setText/markdown-invalidate work runs at the
provider token rate — 50–300+ renders/s of redundant work. This is the
remaining uncapped lever in the #9048 streaming-CPU profile, orthogonal to
the per-frame cost cuts (#9417/#9418/#9423/#9426/#9432): those shrink the
cost per render, this caps the render count.

## Change

`StreamingRevealController.setTarget` (packages/coding-agent/src/modes/controllers/streaming-reveal.ts):

- **Behind** (`#revealed < total`): drop the redundant synchronous
  `renderCurrent` — the running reveal tick already renders the newest
  target at the cadence (`#build` slices at `#revealed`, so per-delta
  renders were byte-identical no-ops).
- **Caught up**: set `#targetDirty`, re-arm the timer; `#tick` drains once
  (render the latest target, component-scoped `requestRender`, stop).
- Eager paths unchanged and synchronous: `toolCall` boundary
  force-complete, `smoothStreaming=false`, `resyncVisibility` (user toggle).
- `stop()` resets the flag; `begin()` resets via `stop()`.

Nothing is lost: the drain always renders the **latest** `#target`; the
final `message_end` render is unchanged. Added latency is bounded by one
reveal tick (≤33 ms) and only in the caught-up case.

## Verification

- New tests (streaming-reveal.test.ts): 30 deltas @5× cadence → ≤7 renders
  (was 36) with the final payload carrying the full text; toolCall target
  still synchronous; smooth-off still synchronous; trailing flush exactly
  +1 render then timer stops; re-arm from caught-up; idle ticks render
  nothing.
- `bun test` streaming-reveal 26/26, tool-args-reveal + event-controller
  suites 20/20 + 12/12; `biome check` + `tsgo --noEmit` clean.
- Fail-proof: coalescing/eager/re-arm tests fail against the unpatched
  controller.

Related: #9048. Follows the merged per-frame wave (#9303, #9417, #9418,
#9423, #9426, #9432).