### PR TITLE
perf(coding-agent): incremental formatThinkingForDisplay for streaming thinking blocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Thinking-block display formatting is now incremental during streaming: growing thinking text resumes the fold at the last line boundary instead of re-scanning the whole block every tick.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -7,10 +7,35 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 // so each mode keeps its own slot. One entry per mode is enough for the common
 // case of one active thinking block and never regresses (a miss recomputes
 // exactly as before).
-let proseCacheKey = "";
-let proseCacheValue = "";
-let rawCacheKey = "";
-let rawCacheValue = "";
+//
+// Each slot also enables incremental extension for the streaming case: when
+// text.startsWith(cache.text) the fold resumes at the last (possibly partial)
+// line boundary — only the appended suffix is re-scanned, reusing the folded
+// prefix and the fence state stored for that boundary. The last input line is
+// always re-folded (never committed), so its transient effects — comment-noise
+// skipping, the prose ellipsis — are replayed under the new context instead of
+// leaking into the memoized prefix.
+interface DisplayCache {
+	/** last formatted text */
+	text: string;
+	/** formatted output for `text` */
+	value: string;
+	/** folded output lines for all but the last line of `text` */
+	result: string[];
+	/** number of newline-terminated lines of `text` = split count - 1 */
+	lineCount: number;
+	/** fence state at the `result` boundary (entering the last line) */
+	inFence: boolean;
+	fenceChar: string;
+	fenceLen: number;
+}
+
+function freshDisplayCache(): DisplayCache {
+	return { text: "", value: "", result: [], lineCount: 0, inFence: false, fenceChar: "", fenceLen: 0 };
+}
+
+const proseCache = freshDisplayCache();
+const rawCache = freshDisplayCache();
 
 export function canonicalizeMessage(text: string | null | undefined): string {
 	if (!text) return "";
@@ -48,17 +73,19 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 	if (!text) return text;
 	const hasComment = text.includes("<!--");
 	if (proseOnly) {
-		if (text === proseCacheKey) return proseCacheValue;
+		if (text === proseCache.text) return proseCache.value;
 	} else {
 		if (!hasComment) return text;
-		if (text === rawCacheKey) return rawCacheValue;
+		if (text === rawCache.text) return rawCache.value;
 	}
 
+	const cache = proseOnly ? proseCache : rawCache;
 	const lines = text.split("\n");
-	const resultLines: string[] = [];
-	let inFence = false;
-	let fenceChar = "";
-	let fenceLen = 0;
+	const resuming = cache.text.length > 0 && text.startsWith(cache.text);
+	const resultLines = resuming ? cache.result : [];
+	let inFence = resuming ? cache.inFence : false;
+	let fenceChar = resuming ? cache.fenceChar : "";
+	let fenceLen = resuming ? cache.fenceLen : 0;
 
 	const FENCE = /^( {0,3})([`~]{3,})/;
 	const appendEllipsis = () => {
@@ -82,8 +109,21 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 		}
 	};
 
-	for (let i = 0; i < lines.length; i++) {
+	// Fold state entering the last line: the result and fence state produced
+	// by the newline-terminated lines only. Committed as the next boundary.
+	let boundaryResult: string[] | null = null;
+	let boundaryInFence = false;
+	let boundaryFenceChar = "";
+	let boundaryFenceLen = 0;
+
+	for (let i = resuming ? cache.lineCount : 0; i < lines.length; i++) {
 		const line = lines[i]!;
+		if (i === lines.length - 1) {
+			boundaryResult = resultLines.slice();
+			boundaryInFence = inFence;
+			boundaryFenceChar = fenceChar;
+			boundaryFenceLen = fenceLen;
+		}
 
 		if (inFence) {
 			const close = FENCE.exec(line);
@@ -128,13 +168,13 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 	}
 
 	const formatted = resultLines.join("\n");
-	if (proseOnly) {
-		proseCacheKey = text;
-		proseCacheValue = formatted;
-	} else {
-		rawCacheKey = text;
-		rawCacheValue = formatted;
-	}
+	cache.text = text;
+	cache.value = formatted;
+	cache.result = boundaryResult ?? resultLines;
+	cache.lineCount = lines.length - 1;
+	cache.inFence = boundaryInFence;
+	cache.fenceChar = boundaryFenceChar;
+	cache.fenceLen = boundaryFenceLen;
 	return formatted;
 }
 

--- a/packages/coding-agent/test/session/thinking-display.test.ts
+++ b/packages/coding-agent/test/session/thinking-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { canonicalizeMessage } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
+import { canonicalizeMessage, formatThinkingForDisplay } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
 
 describe("canonicalizeMessage", () => {
 	it("returns empty string for undefined, empty, or whitespace-only", () => {
@@ -23,4 +23,51 @@ describe("canonicalizeMessage", () => {
 		expect(canonicalizeMessage(". hello .")).toBe(". hello .");
 		expect(canonicalizeMessage("a")).toBe("a");
 	});
+});
+
+// Streaming fixtures: prose with comment noise, fenced code, open fences,
+// tilde/backtick variants, trailing newlines, and degenerate shapes.
+const STREAM_FIXTURES = [
+	"hello",
+	"**Headline**\n\nSome reasoning with `inline` code.\n\nAnother thought.",
+	"line one\nline two\n\n\n",
+	"```js\nconst x = 1;\nconsole.log(x);\n```\nafter fence",
+	"```\nnever closed\nstill open",
+	"intro\n```js\ncode\n```\ntail with trailing.\n",
+	"Step 1.\n\n<!-- -->\nStep 2.\n",
+	"Step.\n\n<!--\nmore",
+	"a\nb\nc\n",
+	"start ```\n```\nend",
+	"```\n```",
+	"~~~\ntilde fence\n~~~\n",
+	"```\n\n```",
+	"`x\n```y\nz",
+];
+
+describe("formatThinkingForDisplay incremental streaming", () => {
+	// A text that cannot be a prefix of any fixture forces the next call to
+	// take the full-recompute fallback, giving a cold-cache reference value.
+	const DIRTY = "\u0000dirty\u0000\n<!--";
+
+	for (const proseOnly of [false, true]) {
+		for (const [idx, fixture] of STREAM_FIXTURES.entries()) {
+			it(`byte-identical to full recompute at every split point (mode=${proseOnly ? "prose" : "raw"}, fixture ${idx})`, () => {
+				const n = fixture.length;
+				// Reference: cold-start full recompute for every prefix.
+				const expected: string[] = [];
+				for (let i = 0; i <= n; i++) {
+					formatThinkingForDisplay(DIRTY, proseOnly);
+					expected[i] = formatThinkingForDisplay(fixture.slice(0, i), proseOnly);
+				}
+				// For every split point, feed the incremental stream up to it
+				// and compare every intermediate and final output.
+				for (let i = 1; i <= n; i++) {
+					formatThinkingForDisplay(DIRTY, proseOnly);
+					for (let j = 1; j <= i; j++) {
+						expect(formatThinkingForDisplay(fixture.slice(0, j), proseOnly)).toBe(expected[j]!);
+					}
+				}
+			});
+		}
+	}
 });


### PR DESCRIPTION
## Problem

`formatThinkingForDisplay` re-runs the full `split('\n')` + line-by-line fence scan over the entire (growing) thinking text on every streaming tick while a thinking block is being revealed — O(text) per delta, O(text²) per stream. The existing exact-key memo slot misses every tick where the text grew, which is precisely the common streaming case.

## Change

- The per-mode memo slot now stores the previously formatted result together with its raw prefix and fence-loop state (`inFence` / `fenceChar` / `fenceLen`).
- On append (new text starts with the cached raw prefix), only the suffix is re-folded, resuming from the last newline boundary; the last partial line is always reprocessed so in-progress lines stay live.
- Any non-append text or flip falls back to the full recompute.

**Invariant:** the incremental result is byte-identical to the previous full re-scan at every step — same folded lines, same fence handling, same output.

## Verification

- `bun test test/session/thinking-display.test.ts test/modes/components/prose-only-thinking.test.ts`: **38 pass / 0 fail**, including the split-point battery (~11.9k assertions) that checks byte-identity at every append position.
- `bun check` (biome + tsgo): clean.
- Note: assistant-message component suites in this worktree fail for a pre-existing missing-built-dep environment reason unrelated to this change; not run here.

Related: #9048
