### PR TITLE
fix(ai): preserve Cursor gateway tool arguments

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor tool calls through the OpenAI-compatible auth gateway losing their arguments when Cursor announced the complete argument map without streaming argument deltas ([#9479](https://github.com/can1357/oh-my-pi/issues/9479)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4260,7 +4260,7 @@ export function processInteractionUpdate(
 					// what the exec channel pairs its result under. Diverging here would
 					// name the block one thing and its result another.
 					name: args.toolName || args.name || "",
-					arguments: {},
+					arguments: decodeMcpArgsMap(args.args) ?? {},
 					[kStreamingBlockIndex]: output.content.length,
 					[kStreamingPartialJson]: "",
 					[kStreamingBlockKind]: "mcp",
@@ -4385,7 +4385,7 @@ export function processInteractionUpdate(
 				// Authoritative full parse of the accumulated argument buffer; the delta
 				// path throttles mid-stream parses, so `arguments` may lag the buffer.
 				const partial = settled[kStreamingPartialJson];
-				if (partial !== undefined) {
+				if (partial) {
 					settled.arguments = parseStreamingJson(partial);
 				}
 				const decodedArgs = decodeMcpArgsMap(selectMcpCall(toolCall)?.args?.args);

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4262,7 +4262,6 @@ export function processInteractionUpdate(
 					name: args.toolName || args.name || "",
 					arguments: decodeMcpArgsMap(args.args) ?? {},
 					[kStreamingBlockIndex]: output.content.length,
-					[kStreamingPartialJson]: "",
 					[kStreamingBlockKind]: "mcp",
 					[kStreamingEnvelopeId]: update.message.value.callId || undefined,
 				};

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -582,9 +582,9 @@ export function encodeStream(
 		async start(controller) {
 			// contentIndex (from pi-ai events) -> tool_calls index on the wire.
 			const toolIndexByContentIndex = new Map<number, number>();
-			// wire index -> id/name emitted on the start chunk, to detect late-arriving
-			// upstream id/name that needs a corrective chunk before the finish.
-			const sentToolMeta = new Map<number, { id: string; name: string }>();
+			// wire index -> metadata emitted so far, to detect values that need a
+			// concatenation-safe corrective chunk before the finish.
+			const sentToolMeta = new Map<number, { id: string; name: string; hasArgumentBytes: boolean }>();
 			let nextToolIndex = 0;
 			let hasToolCalls = false;
 			let finishReason: string = "stop";
@@ -620,7 +620,7 @@ export function encodeStream(
 							toolIndexByContentIndex.set(event.contentIndex, idx);
 							const partial = event.partial.content[event.contentIndex];
 							const call = partial && partial.type === "toolCall" ? partial : undefined;
-							sentToolMeta.set(idx, { id: call?.id ?? "", name: call?.name ?? "" });
+							sentToolMeta.set(idx, { id: call?.id ?? "", name: call?.name ?? "", hasArgumentBytes: false });
 							writeSse(
 								controller,
 								baseChunk(
@@ -643,6 +643,8 @@ export function encodeStream(
 						case "toolcall_delta": {
 							const idx = toolIndexByContentIndex.get(event.contentIndex);
 							if (idx === undefined) break;
+							const sent = sentToolMeta.get(idx);
+							if (sent && event.delta.length > 0) sent.hasArgumentBytes = true;
 							writeSse(
 								controller,
 								baseChunk({ tool_calls: [{ index: idx, function: { arguments: event.delta } }] }, null),
@@ -655,14 +657,17 @@ export function encodeStream(
 							if (idx === undefined) break;
 							const sent = sentToolMeta.get(idx);
 							if (sent === undefined) break;
-							// Upstream completions providers can receive the real id/name in a
-							// later chunk than toolcall_start. Emit a corrective chunk only when
-							// the streamed value was empty: accumulating clients concatenate
-							// string fields, so "" + value is the only safe correction.
+							// Upstream providers can settle id, name, or arguments after the
+							// start chunk. Emit corrections only for fields whose streamed
+							// value was empty: accumulating clients concatenate each field,
+							// so "" + value is the only safe correction.
 							const correctId = sent.id === "" && event.toolCall.id !== "" ? event.toolCall.id : undefined;
 							const correctName =
 								sent.name === "" && event.toolCall.name !== "" ? event.toolCall.name : undefined;
-							if (correctId !== undefined || correctName !== undefined) {
+							const correctArguments = sent.hasArgumentBytes
+								? undefined
+								: stringifyArgs(event.toolCall.arguments);
+							if (correctId !== undefined || correctName !== undefined || correctArguments !== undefined) {
 								writeSse(
 									controller,
 									baseChunk(
@@ -671,7 +676,16 @@ export function encodeStream(
 												{
 													index: idx,
 													...(correctId !== undefined ? { id: correctId } : {}),
-													...(correctName !== undefined ? { function: { name: correctName } } : {}),
+													...(correctName !== undefined || correctArguments !== undefined
+														? {
+																function: {
+																	...(correctName !== undefined ? { name: correctName } : {}),
+																	...(correctArguments !== undefined
+																		? { arguments: correctArguments }
+																		: {}),
+																},
+															}
+														: {}),
 												},
 											],
 										},

--- a/packages/ai/test/auth-gateway-openai-chat.test.ts
+++ b/packages/ai/test/auth-gateway-openai-chat.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { encodeResponse, encodeStream, parseRequest } from "@oh-my-pi/pi-ai/providers/openai-chat-server";
-import type { AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream } from "@oh-my-pi/pi-ai/types";
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	AssistantMessageEventStream,
+	ToolCall,
+} from "@oh-my-pi/pi-ai/types";
 
 function makeEventStream(events: AssistantMessageEvent[], final: AssistantMessage): AssistantMessageEventStream {
 	async function* iter() {
@@ -382,6 +387,42 @@ describe("auth-gateway openai-chat: encodeStream", () => {
 		const finishChunk = chunks[chunks.length - 1];
 		expect(finishChunk.choices[0].delta).toEqual({});
 		expect(finishChunk.choices[0].finish_reason).toBe("tool_calls");
+	});
+	it("emits settled tool arguments when the provider streams no argument deltas", async () => {
+		const partial = emptyAssistant();
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "call-weather",
+			name: "get_weather",
+			arguments: { city: "Paris" },
+		};
+		partial.content = [toolCall];
+		const events: AssistantMessageEvent[] = [
+			{ type: "toolcall_start", contentIndex: 0, partial },
+			{ type: "toolcall_end", contentIndex: 0, toolCall, partial },
+			{ type: "done", reason: "toolUse", message: { ...partial, stopReason: "toolUse" } },
+		];
+
+		const payloads = (await collectStream(encodeStream(makeEventStream(events, partial), "cursor/composer-2.5"))).map(
+			parseSseLine,
+		);
+
+		expect(payloads).toContainEqual(
+			expect.objectContaining({
+				choices: [
+					expect.objectContaining({
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									function: { arguments: '{"city":"Paris"}' },
+								},
+							],
+						},
+					}),
+				],
+			}),
+		);
 	});
 
 	it("emits an error envelope when the stream errors", async () => {

--- a/packages/ai/test/cursor-streaming-args.test.ts
+++ b/packages/ai/test/cursor-streaming-args.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	type BlockState,
+	flushOpenToolCalls,
 	mergeCursorMcpToolCallArgs,
 	processInteractionUpdate,
 	synthesizeCursorExecToolCall,
@@ -247,6 +248,24 @@ describe("processInteractionUpdate args_text_delta handling", () => {
 			name: "get_weather",
 			arguments: { city: "Paris" },
 		});
+		expect(h.captured.map(event => event.type)).toEqual(["toolcall_start", "toolcall_end"]);
+	});
+
+	it("preserves announced args when the stream ends before tool completion", () => {
+		const h = newHarness();
+		startMcpToolCall(h, "get_weather", "call-weather", {
+			city: new TextEncoder().encode(`"Paris"`),
+		});
+
+		flushOpenToolCalls(h.output, h.stream, h.state);
+
+		expect(h.output.content[0]).toMatchObject({
+			type: "toolCall",
+			id: "call-weather",
+			name: "get_weather",
+			arguments: { city: "Paris" },
+		});
+		expect(h.state.currentToolCall).toBeNull();
 		expect(h.captured.map(event => event.type)).toEqual(["toolcall_start", "toolcall_end"]);
 	});
 

--- a/packages/ai/test/cursor-streaming-args.test.ts
+++ b/packages/ai/test/cursor-streaming-args.test.ts
@@ -75,7 +75,7 @@ function newHarness(): Harness {
 	return { output, stream, captured, state, usageState: { sawTokenDelta: false } };
 }
 
-function startMcpToolCall(h: Harness, name: string, id = "call-1"): void {
+function startMcpToolCall(h: Harness, name: string, id = "call-1", args?: Record<string, Uint8Array>): void {
 	processInteractionUpdate(
 		{
 			message: {
@@ -83,7 +83,7 @@ function startMcpToolCall(h: Harness, name: string, id = "call-1"): void {
 				value: {
 					callId: id,
 					toolCall: {
-						mcpToolCall: { args: { name, toolName: name, toolCallId: id } },
+						mcpToolCall: { args: { name, toolName: name, toolCallId: id, args } },
 					},
 				},
 			},
@@ -233,6 +233,23 @@ describe("processInteractionUpdate content block ordering", () => {
 });
 
 describe("processInteractionUpdate args_text_delta handling", () => {
+	it("preserves announced args when Cursor streams no argument deltas", () => {
+		const h = newHarness();
+		startMcpToolCall(h, "get_weather", "call-weather", {
+			city: new TextEncoder().encode(`"Paris"`),
+		});
+
+		completeMcpToolCall(h, undefined);
+
+		expect(h.output.content[0]).toMatchObject({
+			type: "toolCall",
+			id: "call-weather",
+			name: "get_weather",
+			arguments: { city: "Paris" },
+		});
+		expect(h.captured.map(event => event.type)).toEqual(["toolcall_start", "toolcall_end"]);
+	});
+
 	it("treats cumulative argsTextDelta snapshots as snapshots, not append-only fragments", () => {
 		const h = newHarness();
 		startMcpToolCall(h, "task");


### PR DESCRIPTION
## Repro
A Cursor `toolCallStarted` fixture carrying `city=Paris`, followed by no `args_text_delta` frames, reproduced both failures with `bun test packages/ai/test/cursor-streaming-args.test.ts packages/ai/test/auth-gateway-openai-chat.test.ts --test-name-pattern 'preserves announced args|emits settled tool arguments'`: the provider finalized `arguments: {}` and the OpenAI SSE chunks concatenated to an empty argument string.

## Cause
`processInteractionUpdate()` in `packages/ai/src/providers/cursor.ts` initialized streamed MCP blocks with empty arguments and then parsed an empty partial-JSON buffer at completion, discarding the complete map from the announce frame. `encodeStream()` in `packages/ai/src/providers/openai-chat-server.ts` corrected late IDs and names at `toolcall_end`, but did not emit settled arguments when no argument bytes had streamed.

## Fix
- Decode the MCP announce frame directly into the streamed tool-call block.
- Preserve those seeded arguments when Cursor emits no argument deltas, while retaining the existing completion-frame merge.
- Track whether SSE argument bytes were emitted and send one concatenation-safe settled-argument correction when none were.
- Cover the provider and auth-gateway regression paths and document the user-visible fix.

## Verification
`bun test packages/ai/test/cursor-streaming-args.test.ts packages/ai/test/cursor-exec-handlers.test.ts packages/ai/test/auth-gateway-openai-chat.test.ts` passed: 78 tests, 0 failures. `bun run --cwd=packages/ai check` passed. The original focused reproduction now passes both tests.

Fixes #9479