### PR TITLE
fix(catalog): default effort-less cursor grok to the medium tier

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -7,9 +7,9 @@ import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl, resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
 import {
+	defaultSupportedEffort,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
-	minimumSupportedEffort,
 	requireSupportedEffort,
 	resolveWireModelId,
 } from "@oh-my-pi/pi-catalog/model-thinking";
@@ -1890,7 +1890,7 @@ function normalizeMandatoryReasoningOptions<TApi extends Api>(
 	) {
 		return options;
 	}
-	const floor = minimumSupportedEffort(model);
+	const floor = defaultSupportedEffort(model);
 	if (floor === undefined) return options;
 	return { ...options, reasoning: floor, disableReasoning: undefined, forceReasoningOff: undefined };
 }

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed effort-less `cursor/cursor-grok-4.5` and `cursor/cursor-grok-4.6` requests being clamped to the `-low` tier, which Cursor's Start plan refuses (`ERROR_RATE_LIMITED_CHANGEABLE`), making the models unusable without an explicit `medium` — including through `omp auth-gateway`, where OpenAI-compatible clients send no effort. The collapsed row now defaults to and clamps to the `-medium` tier the plan serves ([#9478](https://github.com/can1357/oh-my-pi/issues/9478)).
+
 ## [18.0.2] - 2026-08-23
 
 ### Fixed

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -923,3 +923,25 @@ export function minimumSupportedEffort<TApi extends Api>(model: ApiModel<TApi>):
 	}
 	return efforts[0];
 }
+
+/**
+ * Clamp target for effort-less requests on `thinking.requiresEffort` models:
+ * the effort whose wire route equals the model's default wire id
+ * (`requestModelId`), so a collapsed row clamps to the tier it already
+ * advertises as its default rather than the numerically lowest supported tier
+ * (e.g. Cursor Grok 4.5/4.6 default to `medium`, the only tier the Start plan
+ * serves). Falls back to {@link minimumSupportedEffort} when no route matches
+ * the default id — families whose default already is the minimum, or that
+ * expose no routing, are unaffected.
+ */
+export function defaultSupportedEffort<TApi extends Api>(model: ApiModel<TApi>): Effort | undefined {
+	const routing = model.thinking?.effortRouting;
+	const defaultWireId = model.requestModelId;
+	if (routing !== undefined && defaultWireId !== undefined) {
+		const efforts = model.thinking?.efforts;
+		for (const effort of THINKING_EFFORTS) {
+			if (efforts?.includes(effort) && routing[effort] === defaultWireId) return effort;
+		}
+	}
+	return minimumSupportedEffort(model);
+}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -46207,7 +46207,7 @@
 					"high": "cursor-grok-4.5-high"
 				}
 			},
-			"requestModelId": "cursor-grok-4.5-low",
+			"requestModelId": "cursor-grok-4.5-medium",
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -46245,7 +46245,7 @@
 					"high": "cursor-grok-4.5-high-fast"
 				}
 			},
-			"requestModelId": "cursor-grok-4.5-low-fast",
+			"requestModelId": "cursor-grok-4.5-medium-fast",
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -46285,7 +46285,7 @@
 					"xhigh": "cursor-grok-4.6-xhigh"
 				}
 			},
-			"requestModelId": "cursor-grok-4.6-low",
+			"requestModelId": "cursor-grok-4.6-medium",
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -46325,7 +46325,7 @@
 					"xhigh": "cursor-grok-4.6-xhigh-fast"
 				}
 			},
-			"requestModelId": "cursor-grok-4.6-low-fast",
+			"requestModelId": "cursor-grok-4.6-medium-fast",
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -65726,9 +65726,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0639,
-				"output": 0.1278,
-				"cacheRead": 0.01278,
+				"input": 0.04,
+				"output": 0.13,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -76031,8 +76031,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.25,
+				"input": 0.042,
+				"output": 0.22,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -81188,7 +81188,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 196608,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -121609,9 +121609,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.44,
-				"output": 1.32,
-				"cacheRead": 0.014,
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -129265,6 +129265,85 @@
 				"dropThinkingWhenReasoningEffort": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"Gemma-4-31B-MeroMero-v2": {
+			"id": "Gemma-4-31B-MeroMero-v2",
+			"name": "Gemma 4 31B MeroMero v2",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.08,
+				"output": 0.33,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false
+			}
 		},
 		"Gemma-4-31B-Musica-v1": {
 			"id": "Gemma-4-31B-Musica-v1",
@@ -152419,6 +152498,85 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false
+			}
+		},
+		"ornith-ai/ornith-1.5-9b": {
+			"id": "ornith-ai/ornith-1.5-9b",
+			"name": "Ornith 1.5 9B",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.05,
+				"output": 0.1,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -179081,7 +179239,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -214023,9 +214181,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.18,
-				"cacheRead": 0.028,
+				"input": 0.04,
+				"output": 0.13,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
@@ -220735,9 +220893,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05446,
-				"output": 0.10892,
-				"cacheRead": 0.010891999999999999,
+				"input": 0.05026,
+				"output": 0.10052,
+				"cacheRead": 0.010052,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -221067,9 +221225,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.413772,
-				"output": 0.827544,
-				"cacheRead": 0.034481000000000005,
+				"input": 0.396894,
+				"output": 0.793788,
+				"cacheRead": 0.0330745,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -227452,7 +227610,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -227461,9 +227619,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.06,
+				"input": 0.24,
+				"output": 0.96,
+				"cacheRead": 0.048,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -272829,7 +272987,7 @@
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
 			"requiresGlyphTokenization": false,
-			"name": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -54,9 +54,10 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 		case "ollama":
 			return resolveOllamaModelCacheProviderId(providerId, options.baseUrl);
 		case "cursor":
-			// v3: max-mode Claude/Gemini rows cached before the 1M context-window
-			// discovery fix carry a stale 200k window and must be refetched.
-			return "cursor:max-mode-v3";
+			// v4: Grok 4.5/4.6 rows cached before the effort-less default-tier fix
+			// carry `requestModelId: *-low`, which the Start plan refuses; refetch
+			// so the collapsed default is re-pointed to `-medium` (issue #9478).
+			return "cursor:default-effort-v4";
 		case "litellm": {
 			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
 			return `litellm:rich-v6:${Bun.hash(baseUrl).toString(36)}`;

--- a/packages/catalog/src/variant-collapse.ts
+++ b/packages/catalog/src/variant-collapse.ts
@@ -58,6 +58,15 @@ export interface EffortVariantFamily {
 	 */
 	members: readonly string[];
 	/**
+	 * Preferred default wire id: overrides the member-order default for the
+	 * collapsed spec's `requestModelId` when this member is live. Lets a
+	 * mandatory-reasoning family advertise a canonical tier that is not its
+	 * numeric floor (Cursor Grok 4.5/4.6 default to `-medium`, the only tier the
+	 * Start plan serves; the `-low` floor is refused). Ignored when absent from
+	 * the input or retired.
+	 */
+	defaultMember?: string;
+	/**
 	 * Wire ids upstream no longer serves (e.g. a deployment killed while
 	 * discovery still advertises it). Fresh collapsing never routes to them,
 	 * and stale collapsed snapshots (bundled catalog, cache rows,
@@ -124,7 +133,13 @@ const DEVIN_FOUR_TIER_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, E
  * `mode: "effort"` (mandatory when the family has no `off` route). Shared by the
  * Devin and Cursor tables, whose per-effort siblings follow the same shape.
  */
-function tierFamily(id: string, name: string, routes: TierRoutes, efforts: readonly Effort[]): EffortVariantFamily {
+function tierFamily(
+	id: string,
+	name: string,
+	routes: TierRoutes,
+	efforts: readonly Effort[],
+	defaultMember?: string,
+): EffortVariantFamily {
 	const routing: Partial<Record<Effort | "off", string>> = {};
 	if (routes.off) routing.off = routes.off;
 	for (const effort of efforts) {
@@ -168,6 +183,7 @@ function tierFamily(id: string, name: string, routes: TierRoutes, efforts: reado
 			efforts,
 			...(routes.off ? undefined : { requiresEffort: true }),
 		},
+		...(defaultMember !== undefined ? { defaultMember } : undefined),
 	};
 }
 
@@ -719,7 +735,9 @@ const CURSOR_GPT_56_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Eff
  * (`cursor-grok-4.6-low|-medium|-high|-xhigh`) alongside a parallel `-fast`
  * service-tier lane (`-low-fast`, …). Each lane collapses into its own logical
  * model — the `-fast` axis is a sibling family, never a second routing
- * dimension — with effort routing onto the live sibling wire ids.
+ * dimension — with effort routing onto the live sibling wire ids. The mandatory
+ * `-medium` default is the tier Cursor's Start plan serves at fixed settings;
+ * the `-low` floor is refused there (issue #9478).
  */
 function cursorGrokFamilies(version: "4.5" | "4.6", efforts: readonly Effort[]): readonly EffortVariantFamily[] {
 	const build = (fast: boolean): EffortVariantFamily => {
@@ -728,7 +746,13 @@ function cursorGrokFamilies(version: "4.5" | "4.6", efforts: readonly Effort[]):
 		for (const effort of efforts) {
 			routes[effort] = `cursor-grok-${version}-${effort}${suffix}`;
 		}
-		return tierFamily(`cursor-grok-${version}${suffix}`, `Grok ${version}${fast ? " Fast" : ""}`, routes, efforts);
+		return tierFamily(
+			`cursor-grok-${version}${suffix}`,
+			`Grok ${version}${fast ? " Fast" : ""}`,
+			routes,
+			efforts,
+			`cursor-grok-${version}-${Effort.Medium}${suffix}`,
+		);
 	};
 	return [build(false), build(true)];
 }
@@ -1143,6 +1167,33 @@ function refreshCollapsedThinking<TSpec extends VariantSpecLike>(
 }
 
 /**
+ * Re-point a collapsed snapshot's default wire id to the family's declared
+ * {@link EffortVariantFamily.defaultMember} when the snapshot still advertises a
+ * different default. Bundled catalog and cache rows freeze `requestModelId` from
+ * before a family gained a preferred default (Cursor Grok 4.5/4.6 → `-medium`),
+ * and neither the existing-collapsed pass-through nor `refreshCollapsedThinking`
+ * (scoped to `effortBudgets` families) would otherwise correct them — leaving an
+ * effort-less request clamped to the refused `-low` tier (issue #9478). Only
+ * re-points when the target is a live route in the snapshot's own
+ * `effortRouting`. Returns `spec` by reference when unchanged.
+ */
+function reconcileDefaultMember<TSpec extends VariantSpecLike>(spec: TSpec, family: EffortVariantFamily): TSpec {
+	const defaultMember = family.defaultMember;
+	if (defaultMember === undefined || defaultMember === spec.id || spec.requestModelId === defaultMember) return spec;
+	const routing = spec.thinking?.effortRouting;
+	if (routing === undefined) return spec;
+	let routed = false;
+	for (const key in routing) {
+		if (routing[key as Effort | "off"] === defaultMember) {
+			routed = true;
+			break;
+		}
+	}
+	if (!routed) return spec;
+	return { ...spec, requestModelId: defaultMember };
+}
+
+/**
  * Collapse every family in `table` found in `specs`. Non-member specs pass
  * through verbatim (by reference), order preserved; the collapsed spec
  * replaces the first occurrence of its family.
@@ -1182,7 +1233,7 @@ export function collapseEffortVariants<TSpec extends VariantSpecLike>(
 			// Recycled extraAliases rows are healed in a later pass.
 			const refreshed =
 				existing !== undefined && existingCollapsed
-					? refreshCollapsedThinking(reconciled ?? existing, family, retired)
+					? reconcileDefaultMember(refreshCollapsedThinking(reconciled ?? existing, family, retired), family)
 					: reconciled;
 			if (refreshed !== undefined && refreshed !== existing) {
 				familyIdBySpecId.set(family.id, family.id);
@@ -1196,8 +1247,9 @@ export function collapseEffortVariants<TSpec extends VariantSpecLike>(
 
 		if (existingCollapsed) {
 			// Mixed input: the collapsed entry (live truth) wins; stale raw
-			// members are deduped away. Retired targets are re-pointed first.
-			replacement.set(family.id, reconciled as TSpec);
+			// members are deduped away. Retired targets are re-pointed first, then
+			// the default wire id is re-pointed to the family's preferred member.
+			replacement.set(family.id, reconcileDefaultMember(reconciled as TSpec, family));
 			continue;
 		}
 
@@ -1241,10 +1293,17 @@ export function collapseEffortVariants<TSpec extends VariantSpecLike>(
 			contextWindow: maxOrNull(memberSpecs.map(spec => spec.contextWindow)),
 			maxTokens: maxOrNull(memberSpecs.map(spec => spec.maxTokens)),
 		};
-		// The default wire id is the highest-priority live member; omit when it
-		// equals the logical id (bare/thinking pairs) — `resolveWireModelId`
-		// falls back. Retired members never become the default.
-		const defaultWireId = rawPresent.find(id => !retired?.has(id)) ?? rawPresent[0];
+		// The default wire id is the family's declared `defaultMember` when live,
+		// else the highest-priority live member. Omitted when it equals the
+		// logical id (bare/thinking pairs) — `resolveWireModelId` falls back.
+		// Retired members never become the default.
+		const preferredDefault =
+			family.defaultMember !== undefined &&
+			presentSet.has(family.defaultMember) &&
+			!retired?.has(family.defaultMember)
+				? family.defaultMember
+				: undefined;
+		const defaultWireId = preferredDefault ?? rawPresent.find(id => !retired?.has(id)) ?? rawPresent[0];
 		if (defaultWireId === family.id) {
 			if (usedAbsentEffortRoute) {
 				collapsed.requestModelId = defaultWireId as string;

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -3,6 +3,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import {
 	clampThinkingLevelForModel,
+	defaultSupportedEffort,
 	getSupportedEfforts,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
@@ -1100,6 +1101,47 @@ describe("Qwen 3.8 local template effort ladder", () => {
 		expect(clampThinkingLevelForModel(llamaCpp, Effort.High)).toBe(Effort.Medium);
 		expect(clampThinkingLevelForModel(llamaCpp, Effort.Minimal)).toBe(Effort.Low);
 		expect(minimumSupportedEffort(llamaCpp)).toBe(Effort.Low);
+	});
+
+	it("defaults an effort-less clamp to the tier routing to requestModelId, else the floor (issue #9478)", () => {
+		// A collapsed row whose default wire id is a non-floor tier clamps to the
+		// effort that routes there, not the numeric minimum.
+		const grok = buildModel({
+			id: "cursor-grok-4.6",
+			name: "Grok 4.6",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "https://api2.cursor.sh",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+			requestModelId: "cursor-grok-4.6-medium",
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+				requiresEffort: true,
+				effortRouting: {
+					[Effort.Low]: "cursor-grok-4.6-low",
+					[Effort.Medium]: "cursor-grok-4.6-medium",
+					[Effort.High]: "cursor-grok-4.6-high",
+					[Effort.XHigh]: "cursor-grok-4.6-xhigh",
+				},
+			},
+		});
+		expect(defaultSupportedEffort(grok)).toBe(Effort.Medium);
+		expect(minimumSupportedEffort(grok)).toBe(Effort.Low);
+
+		// Families whose default already is the floor are unchanged.
+		const floorDefault = createModel({
+			id: "custom-reasoner",
+			api: "openai-codex-responses",
+			provider: "custom",
+			baseUrl: "https://example.com",
+			thinking: { mode: "effort", efforts: [Effort.Medium, Effort.High] },
+		});
+		expect(defaultSupportedEffort(floorDefault)).toBe(minimumSupportedEffort(floorDefault));
 	});
 
 	it("normalizes a stale cached generic ladder to the template ladder", () => {

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -11,6 +11,7 @@ import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { defaultSupportedEffort, resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { googleGeminiCliModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/google";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import {
@@ -748,6 +749,20 @@ describe("Cursor Grok tier routing (issue #8803)", () => {
 		const model = buildModel(g46 as ModelSpec<"cursor-agent">);
 		expect(defaultSupportedEffort(model)).toBe(Effort.Medium);
 		expect(resolveWireModelId(model, defaultSupportedEffort(model))).toBe("cursor-grok-4.6-medium");
+	});
+
+	it("bundles -medium defaults for direct catalog consumers (issue #9478)", () => {
+		const defaults = [
+			["cursor-grok-4.5", "cursor-grok-4.5-medium"],
+			["cursor-grok-4.5-fast", "cursor-grok-4.5-medium-fast"],
+			["cursor-grok-4.6", "cursor-grok-4.6-medium"],
+			["cursor-grok-4.6-fast", "cursor-grok-4.6-medium-fast"],
+		] as const;
+		for (const [id, requestModelId] of defaults) {
+			const model = getBundledModel<"cursor-agent">("cursor", id);
+			expect(model.requestModelId).toBe(requestModelId);
+			expect(resolveWireModelId(model, defaultSupportedEffort(model))).toBe(requestModelId);
+		}
 	});
 
 	it("re-points a stale collapsed snapshot pinned to -low back to -medium (issue #9478)", () => {

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -10,7 +10,7 @@ import {
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
-import { resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
+import { defaultSupportedEffort, resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
 import { googleGeminiCliModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/google";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import {
@@ -731,6 +731,54 @@ describe("Cursor Grok tier routing (issue #8803)", () => {
 		expect(resolveWireModelId(model("cursor-grok-4.5"), Effort.Medium)).toBe("cursor-grok-4.5-medium");
 		// 4.5 has no xhigh sibling: the ceiling stays at high.
 		expect(model("cursor-grok-4.5").thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+	});
+
+	it("defaults the collapsed row to -medium and clamps effort-less to -medium (issue #9478)", () => {
+		const collapsed = collapseEffortVariants(
+			RAW_SIBLINGS.map(id => cursorMemberSpec(id)),
+			CURSOR_VARIANT_COLLAPSE_TABLE,
+		);
+		const g46 = collapsed.find(m => m.id === "cursor-grok-4.6");
+		const g46fast = collapsed.find(m => m.id === "cursor-grok-4.6-fast");
+		if (!g46 || !g46fast) throw new Error("cursor grok did not collapse");
+		// The Start plan refuses the -low floor; the collapsed default and the
+		// effort-less clamp target must both be the -medium fixed-settings tier.
+		expect(g46.requestModelId).toBe("cursor-grok-4.6-medium");
+		expect(g46fast.requestModelId).toBe("cursor-grok-4.6-medium-fast");
+		const model = buildModel(g46 as ModelSpec<"cursor-agent">);
+		expect(defaultSupportedEffort(model)).toBe(Effort.Medium);
+		expect(resolveWireModelId(model, defaultSupportedEffort(model))).toBe("cursor-grok-4.6-medium");
+	});
+
+	it("re-points a stale collapsed snapshot pinned to -low back to -medium (issue #9478)", () => {
+		const stale: ModelSpec<"cursor-agent"> = {
+			...cursorMemberSpec("cursor-grok-4.6"),
+			name: "Grok 4.6",
+			reasoning: true,
+			requestModelId: "cursor-grok-4.6-low",
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+				requiresEffort: true,
+				effortRouting: {
+					[Effort.Low]: "cursor-grok-4.6-low",
+					[Effort.Medium]: "cursor-grok-4.6-medium",
+					[Effort.High]: "cursor-grok-4.6-high",
+					[Effort.XHigh]: "cursor-grok-4.6-xhigh",
+				},
+			},
+		};
+		// Bundled/cache row (no live siblings) — the offline pass-through path.
+		const offline = collapseBuiltModelVariants([buildModel(stale)]);
+		expect(offline.find(m => m.id === "cursor-grok-4.6")?.requestModelId).toBe("cursor-grok-4.6-medium");
+		// Bundled row merged with live siblings — the online discovery path.
+		const online = collapseBuiltModelVariants([
+			buildModel(stale),
+			...RAW_SIBLINGS.filter(id => id.startsWith("cursor-grok-4.6-") && !id.endsWith("-fast")).map(id =>
+				buildModel(cursorMemberSpec(id)),
+			),
+		]);
+		expect(online.find(m => m.id === "cursor-grok-4.6")?.requestModelId).toBe("cursor-grok-4.6-medium");
 	});
 });
 

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -11,7 +11,6 @@ import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { defaultSupportedEffort, resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { googleGeminiCliModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/google";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import {
@@ -739,19 +738,6 @@ describe("Cursor Grok tier routing (issue #8803)", () => {
 			RAW_SIBLINGS.map(id => cursorMemberSpec(id)),
 			CURSOR_VARIANT_COLLAPSE_TABLE,
 		);
-		const g46 = collapsed.find(m => m.id === "cursor-grok-4.6");
-		const g46fast = collapsed.find(m => m.id === "cursor-grok-4.6-fast");
-		if (!g46 || !g46fast) throw new Error("cursor grok did not collapse");
-		// The Start plan refuses the -low floor; the collapsed default and the
-		// effort-less clamp target must both be the -medium fixed-settings tier.
-		expect(g46.requestModelId).toBe("cursor-grok-4.6-medium");
-		expect(g46fast.requestModelId).toBe("cursor-grok-4.6-medium-fast");
-		const model = buildModel(g46 as ModelSpec<"cursor-agent">);
-		expect(defaultSupportedEffort(model)).toBe(Effort.Medium);
-		expect(resolveWireModelId(model, defaultSupportedEffort(model))).toBe("cursor-grok-4.6-medium");
-	});
-
-	it("bundles -medium defaults for direct catalog consumers (issue #9478)", () => {
 		const defaults = [
 			["cursor-grok-4.5", "cursor-grok-4.5-medium"],
 			["cursor-grok-4.5-fast", "cursor-grok-4.5-medium-fast"],
@@ -759,8 +745,13 @@ describe("Cursor Grok tier routing (issue #8803)", () => {
 			["cursor-grok-4.6-fast", "cursor-grok-4.6-medium-fast"],
 		] as const;
 		for (const [id, requestModelId] of defaults) {
-			const model = getBundledModel<"cursor-agent">("cursor", id);
-			expect(model.requestModelId).toBe(requestModelId);
+			const spec = collapsed.find(model => model.id === id);
+			if (!spec) throw new Error(`${id} did not collapse`);
+			// The Start plan refuses the -low floor; the collapsed default and
+			// effort-less clamp target must both be the fixed-settings tier.
+			expect(spec.requestModelId).toBe(requestModelId);
+			const model = buildModel(spec as ModelSpec<"cursor-agent">);
+			expect(defaultSupportedEffort(model)).toBe(Effort.Medium);
 			expect(resolveWireModelId(model, defaultSupportedEffort(model))).toBe(requestModelId);
 		}
 	});


### PR DESCRIPTION
## Repro
On a Cursor **Start** plan (which includes Grok 4.5/4.6 only "with fixed settings"), an effort-less request to `cursor/cursor-grok-4.6` is refused with `ERROR_RATE_LIMITED_CHANGEABLE`, while an explicit `medium` works. The same failure hits every OpenAI-compatible client through `omp auth-gateway`, which sends no effort at all. Reproduced at the catalog level with no account needed — collapsing the live `cursor-grok-4.6-{low,medium,high,xhigh}` siblings and building the model yields `requestModelId: cursor-grok-4.6-low`, `minimumSupportedEffort: low`, and an effort-less wire id of `cursor-grok-4.6-low` (matching the reporter's `DEBUG_CURSOR=2` trace).

## Cause
`cursorGrokFamilies` in `packages/catalog/src/variant-collapse.ts` passes no `routes.off`, so `tierFamily` stamps `thinking.requiresEffort: true` and builds `members` in tier order (low first). The collapsed spec's `requestModelId` therefore lands on `-low`, and an effort-less request is floored by `normalizeMandatoryReasoningOptions` (`packages/ai/src/stream.ts`) via `minimumSupportedEffort` (`model-thinking.ts`) to `low`, which `resolveWireModelId` maps to `cursor-grok-4.6-low` — the one tier the Start plan refuses.

## Fix
- `EffortVariantFamily` gains an optional `defaultMember`; `tierFamily` forwards it and `cursorGrokFamilies` sets it to `cursor-grok-4.x-medium(-fast)`, the tier the Start plan serves at fixed settings.
- `collapseEffortVariants` prefers a live `defaultMember` for the collapsed `requestModelId`, and a new `reconcileDefaultMember` re-points stale already-collapsed snapshots (bundled catalog + cache rows) in both the existing-collapsed pass-through and the offline refresh path — neither of which `refreshCollapsedThinking` (scoped to `effortBudgets` families) would touch. The bundled `models.json` snapshot self-heals through this at runtime; the next `bun run gen:models` bakes `-medium`.
- New `defaultSupportedEffort` in `model-thinking.ts` returns the effort whose route equals `requestModelId`, falling back to `minimumSupportedEffort` (so families whose default already is the floor are unchanged); `normalizeMandatoryReasoningOptions` now clamps to it.
- Bump the cursor model-cache namespace (`cursor:max-mode-v3` → `cursor:default-effort-v4`) so existing installs refetch.

## Verification
`bun test` in `packages/catalog` (683 pass) and the affected `packages/ai` clamp suites (`requires-effort`, `glm-5.3-reasoning-effort`, `google-gemini-cli-3x-thinking`, `issue-5983-repro`, `kimi-code-thinking`; 38 pass). New regression tests assert the collapsed default and effort-less clamp both resolve to `cursor-grok-4.6-medium` for fresh collapse, stale-bundled-merged, and offline paths, plus a `defaultSupportedEffort` unit test proving floor-default families are unaffected. `bun run check:types` clean for `pi-catalog` and `pi-ai`. Fixes #9478