### PR TITLE
fix(tui): drop empty transcript blocks from viewport composition

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed finalized transcript blocks rendering as runs of blank lines under viewport pressure: empty live blocks (hidden tool activity, content-less streaming blocks) no longer reserve viewport rows or emit blank rows ([#9483](https://github.com/can1357/oh-my-pi/issues/9483)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -144,22 +144,28 @@ export class TranscriptContainer extends Container {
 		const live = this.#liveEntries();
 		const capacity = Math.max(0, Math.trunc(rows));
 		if (live.length === 0 || capacity === 0) return EMPTY_ROWS;
-		if (live.length > capacity) return this.#renderEmergency(live, width, capacity, frame);
 
-		// Full-height pass first: within capacity, live blocks render whole.
-		const blocks: (readonly string[])[] = new Array(live.length);
+		// Full-height pass first: measure every live block whole. Empty blocks
+		// (hidden tool activity under display.hideToolActivity, content-less
+		// streaming blocks) occupy no viewport rows, so they are dropped here and
+		// never reach the pressure/emergency paths — otherwise they would reserve
+		// a base row (over-truncating real text) or emit a blank row per block.
+		const shown: TranscriptEntry[] = [];
+		const blocks: (readonly string[])[] = [];
 		let total = 0;
-		let visible = 0;
-		for (let index = 0; index < live.length; index++) {
-			this.#setAllocation(live[index]!.component, Number.MAX_SAFE_INTEGER, frame);
-			const rendered = trimBlankEdges(live[index]!.component.render(width));
-			blocks[index] = rendered;
-			if (rendered.length > 0) total += rendered.length + (visible++ > 0 ? 1 : 0);
+		for (const entry of live) {
+			this.#setAllocation(entry.component, Number.MAX_SAFE_INTEGER, frame);
+			const rendered = trimBlankEdges(entry.component.render(width));
+			if (rendered.length === 0) continue;
+			total += rendered.length + (shown.length > 0 ? 1 : 0);
+			shown.push(entry);
+			blocks.push(rendered);
 		}
+		if (shown.length === 0) return EMPTY_ROWS;
+		if (shown.length > capacity) return this.#renderEmergency(shown, width, capacity, frame);
 		if (total <= capacity) {
 			const output: string[] = [];
 			for (const rendered of blocks) {
-				if (rendered.length === 0) continue;
 				if (output.length > 0) output.push("");
 				output.push(...rendered);
 			}
@@ -169,18 +175,18 @@ export class TranscriptContainer extends Container {
 		// Pressure: one row minimum per block, surplus to the newest blocks first,
 		// separators dropped. Tool blocks re-render compact below three rows; text
 		// blocks keep their latest rows visible.
-		const allocation: number[] = new Array(live.length).fill(1);
-		let surplus = capacity - live.length;
-		for (let index = live.length - 1; index >= 0 && surplus > 0; index--) {
+		const allocation: number[] = new Array(shown.length).fill(1);
+		let surplus = capacity - shown.length;
+		for (let index = shown.length - 1; index >= 0 && surplus > 0; index--) {
 			const extra = Math.min(Math.max(0, blocks[index]!.length - 1), surplus);
 			allocation[index] += extra;
 			surplus -= extra;
 		}
 		const output: string[] = [];
-		for (let index = 0; index < live.length; index++) {
+		for (let index = 0; index < shown.length; index++) {
 			const allocated = allocation[index]!;
-			this.#setAllocation(live[index]!.component, allocated, frame);
-			const rendered = trimBlankEdges(live[index]!.component.render(width));
+			this.#setAllocation(shown[index]!.component, allocated, frame);
+			const rendered = trimBlankEdges(shown[index]!.component.render(width));
 			if (rendered.length <= allocated) output.push(...rendered);
 			else output.push(...rendered.slice(rendered.length - allocated));
 		}
@@ -262,23 +268,25 @@ export class TranscriptContainer extends Container {
 	}
 
 	#renderEmergency(
-		live: readonly TranscriptEntry[],
+		shown: readonly TranscriptEntry[],
 		width: number,
 		rows: number,
 		frame: AnimationFrame,
 	): readonly string[] {
 		const output: string[] = [];
-		const hiddenCount = Math.max(0, live.length - rows);
+		const hiddenCount = Math.max(0, shown.length - rows);
 		let hiddenActive = 0;
 		for (let index = 0; index < hiddenCount; index++) {
-			if (live[index]!.state === "active") hiddenActive++;
+			if (shown[index]!.state === "active") hiddenActive++;
 		}
 		if (hiddenActive > 0) output.push(`${hiddenActive} more transcript blocks active`);
 		const visibleRows = rows - output.length;
-		const visible = visibleRows > 0 ? live.slice(-visibleRows) : [];
+		const visible = visibleRows > 0 ? shown.slice(-visibleRows) : [];
+		// Callers pass only non-empty blocks; trim residual edge blanks so each
+		// block contributes its first real row instead of a reserved blank.
 		for (const entry of visible) {
 			this.#setAllocation(entry.component, 1, frame);
-			output.push(entry.component.render(width)[0] ?? "");
+			output.push(trimBlankEdges(entry.component.render(width))[0] ?? "");
 		}
 		return output.slice(0, rows);
 	}

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -117,6 +117,33 @@ describe("TranscriptContainer", () => {
 		// settled transcript prefix live for one frame while it drains next.
 		expect(transcript.renderViewport(80, 1, frame)).toEqual(["current tool"]);
 	});
+	it("excludes empty blocks so pressure never emits blank rows (issue 9483)", () => {
+		const transcript = new TranscriptContainer();
+		// Text blocks interleaved with empty (hidden tool-activity) blocks that
+		// render nothing but stay live until retired.
+		for (let i = 0; i < 6; i++) {
+			transcript.addChild(new Block([`t${i}a`, `t${i}b`, `t${i}c`], true));
+			for (let j = 0; j < 8; j++) transcript.addChild(new Block([], true));
+		}
+		// Emergency path: more non-empty blocks than rows. Every row carries real
+		// text — no block's tail is dropped as blank padding.
+		const out = transcript.renderViewport(80, 12, frame);
+		expect(out).toHaveLength(12);
+		expect(out.every(row => /\S/.test(row))).toBe(true);
+	});
+
+	it("empty blocks do not reserve capacity from real text under pressure (issue 9483)", () => {
+		const transcript = new TranscriptContainer();
+		transcript.addChild(new Block(["A1", "A2", "A3", "A4"], true));
+		transcript.addChild(new Block([], true));
+		transcript.addChild(new Block(["B1", "B2", "B3", "B4"], true));
+		transcript.addChild(new Block([], true));
+		transcript.addChild(new Block(["C1", "C2", "C3", "C4"], true));
+		// Capacity 10 fits all real content once the two empty blocks stop
+		// stealing a base row each; the older block keeps its tail rows.
+		const out = transcript.renderViewport(80, 10, frame);
+		expect(out).toEqual(["A3", "A4", "B1", "B2", "B3", "B4", "C1", "C2", "C3", "C4"]);
+	});
 
 	it("permits removing settled blocks until they are offered or committed", () => {
 		const transcript = new TranscriptContainer();


### PR DESCRIPTION
## Repro
Under viewport pressure with `display.hideToolActivity: true` and several concurrent agents, finalized transcript blocks stop being fully painted: only the first rows are drawn and the remaining rows appear as blank lines, with the blank run growing as live blocks accumulate. Reproduced deterministically (platform-independent) with a `TranscriptContainer.renderViewport` fixture of 6 text blocks each followed by 8 empty (hidden-tool) blocks at capacity 12, which produced an 8-row blank run around a single visible text row: `["","","","text-5-a","","","","","","","",""]`.

## Cause
`TranscriptContainer.renderViewport` (`packages/coding-agent/src/modes/components/transcript-container.ts`) counted empty (zero-row) live blocks toward viewport capacity. Empty blocks come from hidden tool activity (tool-activity components render nothing under `display.hideToolActivity: true`) and content-less streaming blocks; both stay live until retired. The emergency path (`live.length > capacity`) emitted `component.render(width)[0] ?? ""` per block, so a run of empty blocks became a run of blank rows; the pressure path (`total > capacity`) reserved a base row per block via `allocation.fill(1)`, stealing capacity from real text and over-truncating it.

## Fix
- Measure every live block at full height once, up front, and skip zero-height blocks so they never reach the pressure or emergency paths.
- Drive the emergency threshold, pressure allocation, and full-height join off that filtered non-empty set (`shown`) instead of the raw live list.
- Trim residual edge blanks in `#renderEmergency` so each shown block contributes its first real row.

## Verification
`bun test test/modes/components/transcript-container.test.ts` — 11 pass (adds two regression tests: emergency path emits no blank rows with interleaved empty blocks; pressure path no longer lets empty blocks steal capacity from real text). `packages/tui` `bun test test/history-frame-plan.test.ts` — 7 pass. Pre-existing, unrelated failures in `test/modes/**` stem from a missing `tool-views.generated.js` build artifact (produced by the `gen:tool-views` prepack step, absent in a fresh worktree) and are untouched by this change.

Fixes #9483