### PR TITLE
feat(stats): add per-request throughput to requests and overview

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-request throughput (Tokens/s) to the Requests tab and homepage recent-request surfaces.
 ## [18.0.1] - 2026-08-23
 
 ### Fixed

--- a/packages/stats/src/client/data/view-models.ts
+++ b/packages/stats/src/client/data/view-models.ts
@@ -257,3 +257,13 @@ export function buildToolRows(tools: ToolUsageStats[]): ToolRowView[] {
 		callsPercentage: maxCalls > 0 ? (t.calls / maxCalls) * 100 : 0,
 	}));
 }
+
+/**
+ * Calculate per-request throughput in tokens per second from output tokens and duration in ms.
+ * Returns null when duration is null, zero, or negative (invalid or unrecorded duration).
+ * Returns 0 when output is zero (and duration is positive).
+ */
+export function calculateTokensPerSecond(outputTokens: number, durationMs: number | null): number | null {
+	if (durationMs === null || durationMs <= 0) return null;
+	return (outputTokens * 1000) / durationMs;
+}

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -4,8 +4,15 @@ import { Line } from "react-chartjs-2";
 import { getOverviewStats, getRecentRequests } from "../api";
 import { AgentTokenShare } from "../components/AgentTokenShare";
 import { CHART_THEMES } from "../components/chart-shared";
-import { formatCost, formatDurationMs, formatInteger, formatRelativeTime } from "../data/formatters";
+import {
+	formatCost,
+	formatDurationMs,
+	formatInteger,
+	formatRelativeTime,
+	formatTokensPerSecond,
+} from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { calculateTokensPerSecond } from "../data/view-models";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, MetricCluster, Panel, Skeleton, StatusPill } from "../ui";
 import { useSystemTheme } from "../useSystemTheme";
@@ -156,6 +163,13 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
 			},
 			{
+				key: "tokensPerSecond",
+				header: "Tokens/s",
+				numeric: true,
+				render: (item: MessageStats) =>
+					formatTokensPerSecond(calculateTokensPerSecond(item.usage.output, item.duration)),
+			},
+			{
 				key: "cost",
 				header: "Cost",
 				numeric: true,
@@ -204,6 +218,12 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 				<div>
 					<div className="stats-mobile-card-label">Tokens</div>
 					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
+				</div>
+				<div>
+					<div className="stats-mobile-card-label">Tokens/s</div>
+					<div className="stats-mobile-card-value">
+						{formatTokensPerSecond(calculateTokensPerSecond(item.usage.output, item.duration))}
+					</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Duration</div>
@@ -274,6 +294,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 							<div className="stats-feed-ledger overflow-y-auto max-h-[280px] pr-2">
 								{previewRequests.map(req => {
 									const isError = !!req.errorMessage;
+									const tps = calculateTokensPerSecond(req.usage.output, req.duration);
 									return (
 										<div
 											key={req.id || `${req.sessionFile}-${req.entryId}`}
@@ -298,6 +319,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 													<div>{req.provider}</div>
 													<div>
 														{req.duration ? formatDurationMs(req.duration) : ""}{" "}
+														{tps !== null ? `· ${formatTokensPerSecond(tps)} tokens/s ` : ""}
 														{req.usage?.cost?.total ? `· ${formatCost(req.usage.cost.total, 4)}` : ""}
 													</div>
 												</div>

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -1,7 +1,14 @@
 import { useMemo } from "react";
 import { getRecentRequests } from "../api";
-import { formatCost, formatDurationMs, formatInteger, formatRelativeTime } from "../data/formatters";
+import {
+	formatCost,
+	formatDurationMs,
+	formatInteger,
+	formatRelativeTime,
+	formatTokensPerSecond,
+} from "../data/formatters";
 import { useResource } from "../data/useResource";
+import { calculateTokensPerSecond } from "../data/view-models";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
 
@@ -44,6 +51,13 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 				header: "Tokens",
 				numeric: true,
 				render: (item: MessageStats) => formatInteger(item.usage.totalTokens),
+			},
+			{
+				key: "tokensPerSecond",
+				header: "Tokens/s",
+				numeric: true,
+				render: (item: MessageStats) =>
+					formatTokensPerSecond(calculateTokensPerSecond(item.usage.output, item.duration)),
 			},
 			{
 				key: "cost",
@@ -94,6 +108,12 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 				<div>
 					<div className="stats-mobile-card-label">Tokens</div>
 					<div className="stats-mobile-card-value">{formatInteger(item.usage.totalTokens)}</div>
+				</div>
+				<div>
+					<div className="stats-mobile-card-label">Tokens/s</div>
+					<div className="stats-mobile-card-value">
+						{formatTokensPerSecond(calculateTokensPerSecond(item.usage.output, item.duration))}
+					</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Duration</div>

--- a/packages/stats/src/client/ui/RequestDrawer.tsx
+++ b/packages/stats/src/client/ui/RequestDrawer.tsx
@@ -1,7 +1,8 @@
 import { Clock, Coins, Gauge, Hash, Star, X, Zap } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { getRequestDetails } from "../api";
-import { formatCost, formatDurationMs, formatInteger } from "../data/formatters";
+import { formatCost, formatDurationMs, formatInteger, formatTokensPerSecond } from "../data/formatters";
+import { calculateTokensPerSecond } from "../data/view-models";
 import type { RequestDetails } from "../types";
 import { JsonBlock } from "./JsonBlock";
 import { Skeleton } from "./Skeleton";
@@ -187,7 +188,9 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 											Throughput
 										</div>
 										<div className="stats-drawer-metric-value">
-											{((details.usage.output * 1000) / details.duration).toFixed(1)}
+											{formatTokensPerSecond(
+												calculateTokensPerSecond(details.usage.output, details.duration),
+											)}
 										</div>
 										<div className="stats-drawer-metric-sub">tokens/second</div>
 									</div>

--- a/packages/stats/test/client-view-models.test.ts
+++ b/packages/stats/test/client-view-models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { buildAgentTokenShare, buildModelPerformanceLookup } from "../src/client/data/view-models";
+import {
+	buildAgentTokenShare,
+	buildModelPerformanceLookup,
+	calculateTokensPerSecond,
+} from "../src/client/data/view-models";
 import type { AgentTypeStats, ModelPerformancePoint } from "../src/shared-types";
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -74,5 +78,21 @@ describe("buildAgentTokenShare", () => {
 		const empty = buildAgentTokenShare([]);
 		expect(empty.totalTokens).toBe(0);
 		expect(empty.segments).toEqual([]);
+	});
+});
+
+describe("calculateTokensPerSecond", () => {
+	it("calculates throughput in tokens per second for valid output and duration", () => {
+		expect(calculateTokensPerSecond(80, 2000)).toBe(40);
+	});
+
+	it("returns 0 when output tokens is 0 and duration is positive", () => {
+		expect(calculateTokensPerSecond(0, 1000)).toBe(0);
+	});
+
+	it("returns null when duration is null, zero, or negative", () => {
+		expect(calculateTokensPerSecond(80, null)).toBeNull();
+		expect(calculateTokensPerSecond(80, 0)).toBeNull();
+		expect(calculateTokensPerSecond(80, -500)).toBeNull();
 	});
 });


### PR DESCRIPTION
## What

Adds per-request throughput (`Tokens/s`) to the `omp stats` dashboard:
- **Calculation helper (`packages/stats/src/client/data/view-models.ts`)**: Centralizes the per-request formula in `calculateTokensPerSecond(outputTokens, durationMs)`, computing `(outputTokens * 1000) / durationMs` for positive durations, `0` for zero output, and `null` for missing, zero, or negative durations.
- **Requests tab (`packages/stats/src/client/routes/RequestsRoute.tsx`)**: Adds numeric `Tokens/s` column immediately after `Tokens` in the desktop table and in the mobile card grid.
- **Homepage Overview (`packages/stats/src/client/routes/OverviewRoute.tsx`)**: Adds `Tokens/s` column and mobile card item in Recent Requests Preview, and displays `· <value> tokens/s` between duration and cost in Operational Feed rows with valid duration.
- **Request Details Drawer (`packages/stats/src/client/ui/RequestDrawer.tsx`)**: Replaces inline math with `calculateTokensPerSecond` and `formatTokensPerSecond`.

## Why

While `omp stats` already computed aggregate `Tokens/s` across an entire time range, individual requests only showed total tokens and duration. Adding per-request throughput gives immediate visibility into generation speed on recent requests and feed items without modifying database schema, backend types, or API endpoints.

## Testing

- Added unit tests in `packages/stats/test/client-view-models.test.ts` covering valid throughput calculations, zero output, and null/zero/negative durations.
- Ran `bun test packages/stats` (105 tests across 21 files pass).
- Ran `bun check` (`check:ts` and `check:rs` pass).
- Verified live rendering in Chromium across desktop (`1280x900`) and mobile (`375x812`) viewports for Overview, Requests table, Operational Feed, and Request Details Drawer.

<img width="3048" height="1574" alt="ooo-3" src="https://github.com/user-attachments/assets/67ffb04f-1af6-4b69-99be-ac5df860c422" />

<img width="4216" height="2246" alt="ooo-4" src="https://github.com/user-attachments/assets/f017a82a-02bd-4641-aa10-6fcd61a1faaa" />

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)