### PR TITLE
fix(ai): scope Cursor plan refusals by model

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor plan-entitlement refusals repeatedly reselecting an account that cannot serve the requested model; denied credentials are now blocked only for that model and rotation converges on an eligible sibling ([#9488](https://github.com/can1357/oh-my-pi/issues/9488)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1028,9 +1028,13 @@ function resolveOpenAICodexPlanRequirement(provider: string, modelId: string | u
 }
 
 const MODEL_ACCOUNT_POLICY_BLOCK_SCOPE_PREFIX = "model-policy:";
+const MODEL_ACCOUNT_POLICY_PROVIDERS: Readonly<Record<string, true>> = {
+	"openai-codex": true,
+	cursor: true,
+};
 
 function modelAccountPolicyBlockScope(provider: string, modelId: string | undefined): string | undefined {
-	if (provider !== "openai-codex" || typeof modelId !== "string") return undefined;
+	if (!Object.hasOwn(MODEL_ACCOUNT_POLICY_PROVIDERS, provider) || typeof modelId !== "string") return undefined;
 	const separator = modelId.lastIndexOf("/");
 	const bareModelId = (separator === -1 ? modelId : modelId.slice(separator + 1)).trim().toLowerCase();
 	if (!bareModelId || bareModelId.includes("\0")) return undefined;
@@ -6393,8 +6397,8 @@ export class AuthStorage {
 	 * - usage-limit / account-rate-limit error → {@link AuthStorage.markUsageLimitReached}
 	 *   (temporary block via its own backoff — default plus server usage-report
 	 *   reset; sticky left intact so the next resolve re-ranks around the block).
-	 * - exact Codex model-entitlement denial → temporarily block only that
-	 *   requested model after provider/model identity matches, then rotate.
+	 * - exact model-entitlement denial (Codex ChatGPT account or Cursor plan) →
+	 *   temporarily block only that requested model, then rotate.
 	 * - other account-scoped policy denial → temporarily block that account
 	 *   without marking its credential suspect, then rotate through siblings.
 	 * - otherwise (hard 401 / auth failure) → mark the credential suspect (or
@@ -6411,7 +6415,8 @@ export class AuthStorage {
 		const error = options?.error;
 		const status = AIError.status(error);
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
-		if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
+		const accountPolicy = AIError.isAccountPolicyError(error);
+		if (!accountPolicy && (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message))) {
 			// Thread the provider-specified reset window (e.g. Devin "Your limit
 			// will reset in 13 minutes") into the block duration so the credential
 			// is not reselected and hammered while the cap remains active.
@@ -6436,15 +6441,17 @@ export class AuthStorage {
 		const deniedModel = AIError.codexChatGPTAccountPolicyModel(error);
 		const exactCodexModelPolicy =
 			deniedModel !== undefined && AIError.isCodexChatGPTAccountPolicyError(error, provider, options?.modelId);
+		const exactCursorModelPolicy = AIError.isCursorPlanAccountPolicyError(error, provider);
+		const exactModelPolicy = exactCodexModelPolicy || exactCursorModelPolicy;
 		// The exact sentence is provider-controlled input. A non-Codex provider,
 		// absent request model, or mismatched model must not turn it into either a
 		// global block or a hard-auth invalidation.
 		if (deniedModel !== undefined && !exactCodexModelPolicy) return false;
-		if (exactCodexModelPolicy || AIError.isAccountPolicyError(error)) {
-			const modelPolicyScope = exactCodexModelPolicy
+		if (exactModelPolicy || accountPolicy) {
+			const modelPolicyScope = exactModelPolicy
 				? modelAccountPolicyBlockScope(provider, options?.modelId)
 				: undefined;
-			if (exactCodexModelPolicy && modelPolicyScope === undefined) return false;
+			if (exactModelPolicy && modelPolicyScope === undefined) return false;
 			const routing = this.#credentialBlockRouting(
 				provider,
 				sessionCredential.type,

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -118,6 +118,12 @@ const ACCOUNT_POLICY_PATTERN = /\bcyber_policy\b|trusted access for cyber/i;
 const CODEX_CHATGPT_ACCOUNT_MODEL_POLICY_PATTERN =
 	/\bThe ['"]([^'"\r\n]+)['"] model is not supported when using Codex with a ChatGPT account\./i;
 const CODEX_CHATGPT_ACCOUNT_MODEL_MAX_LENGTH = 256;
+const CURSOR_PLAN_POLICY_MARKER_PATTERN = /\bERROR_RATE_LIMITED_CHANGEABLE\b/i;
+const CURSOR_PLAN_POLICY_PATTERN = /\bNamed models unavailable\b|\bModel unavailable on\b|\bFree plans can only use\b/i;
+
+function isCursorPlanPolicyText(text: string): boolean {
+	return CURSOR_PLAN_POLICY_MARKER_PATTERN.test(text) && CURSOR_PLAN_POLICY_PATTERN.test(text);
+}
 
 function normalizeCodexChatGPTAccountPolicyModel(modelId: string | undefined): string | undefined {
 	if (typeof modelId !== "string") return undefined;
@@ -399,7 +405,8 @@ function classifyText(
 		if (isContentBlockedText(errorMessage)) kinds |= Flag.ContentBlocked;
 		if (
 			ACCOUNT_POLICY_PATTERN.test(errorMessage) ||
-			isCodexChatGPTAccountPolicyText(errorMessage, provider, modelId)
+			isCodexChatGPTAccountPolicyText(errorMessage, provider, modelId) ||
+			isCursorPlanPolicyText(errorMessage)
 		) {
 			kinds |= Flag.AccountPolicy | Flag.ContentBlocked;
 		}
@@ -584,6 +591,22 @@ export function isCodexChatGPTAccountPolicyError(
 	const deniedIdentity = normalizeCodexChatGPTAccountPolicyModel(deniedModel);
 	const requestedIdentity = normalizeCodexChatGPTAccountPolicyModel(modelId);
 	return provider === "openai-codex" && deniedIdentity !== undefined && deniedIdentity === requestedIdentity;
+}
+
+/** Whether Cursor returned a non-retryable plan entitlement denial for this account. */
+export function isCursorPlanAccountPolicyError(error: unknown, provider: string, depth = 0): boolean {
+	if (provider !== "cursor" || depth > 6) return false;
+	if (typeof error === "string") return isCursorPlanPolicyText(error);
+	if (!error || typeof error !== "object") return false;
+	if (
+		"errorMessage" in error &&
+		typeof error.errorMessage === "string" &&
+		isCursorPlanPolicyText(error.errorMessage)
+	) {
+		return true;
+	}
+	if ("message" in error && typeof error.message === "string" && isCursorPlanPolicyText(error.message)) return true;
+	return "cause" in error && isCursorPlanAccountPolicyError(error.cause, provider, depth + 1);
 }
 
 /**

--- a/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
+++ b/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
@@ -18,6 +18,10 @@ const CODEX_PROVIDER = "openai-codex";
 const DAYBREAK_MODEL = "gpt-daybreak-blue-latest";
 const CODEX_CHATGPT_MODEL_DENIAL =
 	"The 'gpt-daybreak-blue-latest' model is not supported when using Codex with a ChatGPT account. (code=invalid_request_error)";
+const CURSOR_PROVIDER = "cursor";
+const CURSOR_MODEL = "cursor-grok-4.6";
+const CURSOR_PLAN_DENIAL =
+	'Connect error resource_exhausted: Error [details: {"error":"ERROR_RATE_LIMITED_CHANGEABLE","details":{"title":"Named models unavailable","detail":"Free plans can only use Auto."}}]';
 function farExpiry(): number {
 	return Date.now() + 60 * 60_000;
 }
@@ -611,6 +615,71 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 				modelId: "gpt-5.3-codex",
 			}),
 		).toBe("daybreak-denied");
+	});
+
+	test("Cursor plan denial blocks only that model and rotates to a sibling", async () => {
+		if (!store) throw new Error("test setup failed");
+		const cursorStorage = new AuthStorage(store, { usageProviderResolver: () => undefined });
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials[CURSOR_PROVIDER];
+			if (!credential) return null;
+			return { apiKey: credential.access, newCredentials: credential };
+		});
+		await cursorStorage.set(CURSOR_PROVIDER, [
+			{
+				type: "oauth",
+				access: "cursor-plan-denied",
+				refresh: "ref-A",
+				expires: farExpiry(),
+				accountId: "account-A",
+			},
+			{
+				type: "oauth",
+				access: "cursor-plan-sibling",
+				refresh: "ref-B",
+				expires: farExpiry(),
+				accountId: "account-B",
+			},
+		]);
+
+		const sessionId = "cursor-model-policy";
+		const first = await cursorStorage.getApiKey(CURSOR_PROVIDER, sessionId, { modelId: CURSOR_MODEL });
+		expect(first).toBe("cursor-plan-denied");
+		const usageLimitSpy = vi.spyOn(cursorStorage, "markUsageLimitReached");
+		const rotated = await cursorStorage.rotateSessionCredential(CURSOR_PROVIDER, sessionId, {
+			error: new Error(CURSOR_PLAN_DENIAL),
+			modelId: CURSOR_MODEL,
+			apiKey: first,
+		});
+
+		expect(rotated).toBe(true);
+		expect(usageLimitSpy).not.toHaveBeenCalled();
+		expect(await cursorStorage.getApiKey(CURSOR_PROVIDER, sessionId, { modelId: CURSOR_MODEL })).toBe(
+			"cursor-plan-sibling",
+		);
+
+		const deniedRow = store
+			.listAuthCredentials(CURSOR_PROVIDER)
+			.find(row => row.credential.type === "oauth" && row.credential.access === "cursor-plan-denied");
+		if (!deniedRow) throw new Error("denied credential row missing");
+		const modelBlock = store.getCredentialBlock?.(
+			deniedRow.id,
+			`${CURSOR_PROVIDER}:oauth`,
+			"model-policy:cursor-grok-4.6",
+		);
+		expect(typeof modelBlock).toBe("number");
+		expect(store.getCredentialBlock?.(deniedRow.id, `${CURSOR_PROVIDER}:oauth`, "")).toBeUndefined();
+
+		const otherModelStorage = new AuthStorage(store, { usageProviderResolver: () => undefined });
+		await otherModelStorage.reload();
+		const otherModelSelections = new Set<string>();
+		for (let index = 0; index < 6; index += 1) {
+			const selected = await otherModelStorage.getApiKey(CURSOR_PROVIDER, `cursor-included-model-${index}`, {
+				modelId: "composer-2.5",
+			});
+			if (selected) otherModelSelections.add(selected);
+		}
+		expect(otherModelSelections.has("cursor-plan-denied")).toBe(true);
 	});
 
 	test("rotateSessionCredential treats structured usage codes as quota blocks despite generic messages", async () => {

--- a/packages/ai/test/error-id.test.ts
+++ b/packages/ai/test/error-id.test.ts
@@ -148,6 +148,32 @@ describe("error-id classification", () => {
 		expect(AIError.codexChatGPTAccountPolicyModel(oversized)).toBeUndefined();
 		expect(AIError.is(AIError.classifyMessage(oversized), AIError.Flag.AccountPolicy)).toBe(false);
 	});
+	it("classifies only Cursor plan-gate resource exhaustion as account policy", () => {
+		for (const errorMessage of [
+			'Connect error resource_exhausted: Error [details: {"error":"ERROR_RATE_LIMITED_CHANGEABLE","details":{"title":"Named models unavailable","detail":"Free plans can only use Auto."}}]',
+			'Connect error resource_exhausted: Error [details: {"error":"ERROR_RATE_LIMITED_CHANGEABLE","details":{"title":"Model unavailable on Start","detail":"Switch to an included model to continue."}}]',
+		]) {
+			const id = AIError.classifyMessage(
+				message({
+					provider: "cursor",
+					model: "cursor-grok-4.6",
+					errorMessage,
+				}),
+			);
+			expect(AIError.is(id, AIError.Flag.AccountPolicy)).toBe(true);
+			expect(AIError.is(id, AIError.Flag.ContentBlocked)).toBe(true);
+			expect(AIError.retriable(id)).toBe(false);
+		}
+
+		for (const errorMessage of [
+			"Connect error resource_exhausted: Error",
+			'Connect error resource_exhausted: Error [details: {"details":{"title":"Named models unavailable"}}]',
+			'Connect error resource_exhausted: Error [details: {"error":"ERROR_RATE_LIMITED_CHANGEABLE","details":{"title":"Temporary capacity unavailable"}}]',
+		]) {
+			const id = AIError.classifyMessage(message({ provider: "cursor", model: "cursor-grok-4.6", errorMessage }));
+			expect(AIError.is(id, AIError.Flag.AccountPolicy)).toBe(false);
+		}
+	});
 
 	it("keeps raw status fallback unclassified", () => {
 		const id = 503;


### PR DESCRIPTION
## Repro

A two-credential `AuthStorage` fixture sends Cursor's `ERROR_RATE_LIMITED_CHANGEABLE` plan-gate body for `cursor-grok-4.6`; `bun test packages/ai/test/error-id.test.ts packages/ai/test/auth-storage-force-refresh-rotate.test.ts --test-name-pattern "Cursor plan"` reproduced the bug with 0 pass / 2 fail because the body lacked `Flag.AccountPolicy` and rotation called `markUsageLimitReached`.

## Cause

`packages/ai/src/error/flags.ts` classified the entire Connect `resource_exhausted` body only as transient capacity/usage-limit, while `modelAccountPolicyBlockScope` and the account-policy branch in `packages/ai/src/auth-storage.ts` limited model-scoped blocks to exact Codex ChatGPT-account denials. The usage-limit branch therefore ran first and persisted an unscoped Cursor credential block.

## Fix

- Recognize Cursor plan gates only when `ERROR_RATE_LIMITED_CHANGEABLE` appears with a named-model or plan-unavailable marker.
- Route those denials through account-policy rotation and persist `model-policy:<model>` blocks for Cursor credentials.
- Preserve bare `resource_exhausted` capacity behavior and add classifier plus two-credential pool regression coverage.
- Document the user-visible fix in the AI changelog.

## Verification

`bun test packages/ai/test/error-id.test.ts packages/ai/test/auth-storage-force-refresh-rotate.test.ts packages/ai/test/rate-limit-utils.test.ts` passed: 102 tests, 392 assertions. `bun run check:ts` passed. `bun check` fails identically on clean `main` because `audiopus_sys` cannot execute missing `cmake`; the pre-publish gate was skipped for that unrelated environment failure.

Fixes #9488