### PR TITLE
perf(coding-agent): incremental thinking-format on append (O(Δ) fold, exact-prefix verify)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Format streaming thinking blocks incrementally — O(1) per append tick instead of O(text²) full re-scan.
+- Format streaming thinking blocks incrementally — append ticks resume the fold over only the appended suffix instead of a full O(text²) re-scan, with exact prefix verification at memcmp speed and an 8 KiB resume cap that degrades pathological no-newline streams to the exact-match memo.
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Format streaming thinking blocks incrementally — O(1) per append tick instead of O(text²) full re-scan.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Format streaming thinking blocks incrementally — append ticks resume the fold over only the appended suffix instead of a full O(text²) re-scan, with exact prefix verification at memcmp speed and an 8 KiB resume cap that degrades pathological no-newline streams to the exact-match memo.
+ - Format streaming thinking blocks incrementally — append ticks re-fold only the appended suffix instead of a full O(text²) re-scan; each delta is verified against the previous text via exact prefix comparison (O(accumulated) at native memcmp speed), and an 8 KiB resume cap degrades pathological no-newline streams to the exact-match memo.
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -13,9 +13,16 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 // ever extends the trailing partial line), the fold resumes at the stored
 // line boundary — only the appended suffix is re-scanned, reusing the
 // committed output and the fence state captured entering that line. Append
-// detection is O(last line): the seam byte must still sit right after a
-// newline and the previous partial line must persist verbatim at its offset;
-// anything else takes the full-recompute path. The last input line is always
+// detection is exact: the stored text must be a verbatim prefix of the
+// incoming text, checked with `startsWith` (memcmp speed, O(previous text)
+// per genuinely-new text — deterministic, no unchecked byte a stream switch
+// could hide in; the repeated renders within one tick are answered by the
+// identity memo without rescanning). Anything else takes the full-recompute
+// path. A partial line that grows past {@link MAX_RESUME_PARTIAL_BYTES} with
+// no newline (seam stuck at 0) would otherwise refold the entire text every
+// tick; past the cap the checkpoint is retired and the slot degrades to the
+// identity memo — the pre-incremental asymptotics for that pathological
+// shape, bounded per call. The last input line is always
 // re-folded (never committed), so its transient effects — comment-noise
 // skipping, the prose ellipsis — are replayed under the new context instead
 // of leaking into the committed prefix. The committed output keeps the last
@@ -55,14 +62,26 @@ interface DisplayCache {
 	startLineByte: number;
 	/** fold state ENTERING that last line — the resume point for appends */
 	state: FoldState;
+	/** whether the fold checkpoint in {@link state} is valid to resume from */
+	resumable: boolean;
 }
 
 function freshFoldState(): FoldState {
-	return { committed: "", hasTail: false, tailLine: "", tailBlankSep: "", tailPred: false, emitted: 0, inFence: false, fenceChar: "", fenceLen: 0 };
+	return {
+		committed: "",
+		hasTail: false,
+		tailLine: "",
+		tailBlankSep: "",
+		tailPred: false,
+		emitted: 0,
+		inFence: false,
+		fenceChar: "",
+		fenceLen: 0,
+	};
 }
 
 function freshDisplayCache(): DisplayCache {
-	return { text: "", value: "", hadComment: false, startLineByte: 0, state: freshFoldState() };
+	return { text: "", value: "", hadComment: false, startLineByte: 0, state: freshFoldState(), resumable: true };
 }
 
 const proseCache = freshDisplayCache();
@@ -79,6 +98,16 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 	}
 	return "";
 }
+
+/**
+ * Resume cap: a trailing partial line longer than this retires the fold
+ * checkpoint. With no newline the seam sits at byte 0, so resuming would
+ * refold the entire text every tick — O(total)/tick, O(n²) per stream. Past
+ * the cap the slot falls back to the exact-key memo: O(1) on exact repeats,
+ * a full recompute on growth (the pre-incremental asymptotics for this
+ * pathological shape, bounded per call).
+ */
+const MAX_RESUME_PARTIAL_BYTES = 8192;
 
 // gpt-5.x reasoning summaries pad every summary part with an empty HTML
 // comment (`**Headline**\n\n<!-- -->`), streamed as a `<!--` delta followed by
@@ -97,32 +126,18 @@ function isCommentNoise(line: string, isLastLine: boolean): boolean {
 }
 
 /**
- * Whether `text` is an append of the previously formatted text. Verified in
- * O(last line): the stored seam must still sit right after a newline of
- * `text`, and the previous partial line must persist verbatim at its offset.
- * The prefix before the seam is a positional contract (streaming growth never
- * rewrites it) rather than something re-read on every tick; anchored
- * spot-checks (first byte, midpoint, trailing window) catch stream switches —
- * including the vacuous case where the previous text ended exactly at its
- * seam, leaving no partial line to compare.
+ * Whether `text` is an append of the previously formatted text: the stored
+ * text must be a verbatim prefix of `text`. Verified exactly with
+ * `startsWith` — its intrinsic compare runs at memcmp speed, and every byte
+ * of the previous text is checked, leaving no gap a stream switch could hide
+ * in (spot-check anchors were exploitable: texts crafted to match only at
+ * the sampled positions slipped through as false-positive appends). This
+ * reads O(previous text) per genuinely-new text; the repeated renders of one
+ * streaming tick never reach here — the identity memo answers them first.
  */
 function isAppend(cache: DisplayCache, text: string): boolean {
 	const prev = cache.text;
-	const seam = cache.startLineByte;
-	if (text.length < prev.length || prev.length === 0) return false;
-	if (seam > 0 && text.charCodeAt(seam - 1) !== 0x0a) return false;
-	for (let i = seam; i < prev.length; i++) {
-		if (text.charCodeAt(i) !== prev.charCodeAt(i)) return false;
-	}
-	if (seam > 0) {
-		if (text.charCodeAt(0) !== prev.charCodeAt(0)) return false;
-		const mid = seam >> 1;
-		if (text.charCodeAt(mid) !== prev.charCodeAt(mid)) return false;
-		for (let i = Math.max(1, seam - 32); i < seam; i++) {
-			if (text.charCodeAt(i) !== prev.charCodeAt(i)) return false;
-		}
-	}
-	return true;
+	return prev.length > 0 && text.startsWith(prev);
 }
 
 /** Fold one input line into the accumulator. Whitespace-only lines defer to the tail region. */
@@ -176,10 +191,13 @@ function renderFold(state: FoldState): string {
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
 	if (!text) return text;
 	const cache = proseOnly ? proseCache : rawCache;
+	// Identity memo first: the 2nd and 3rd renders of one streaming tick pass
+	// the same text and must not pay the prefix verification below.
+	if (text === cache.text) return cache.value;
 	let hasComment: boolean;
 	let fromByte: number;
 	let state: FoldState;
-	if (cache.text.length > 0 && text.length >= cache.text.length && isAppend(cache, text)) {
+	if (cache.resumable && isAppend(cache, text)) {
 		// Append: a `<!--` introduced by the suffix flips the noise gate, and a
 		// marker straddling the seam can start at most 3 bytes back — identical
 		// to rescanning the full text, at O(delta).
@@ -191,10 +209,20 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 		fromByte = 0;
 		state = freshFoldState();
 	}
-	// Raw mode without comments is the identity (fences pass through verbatim),
-	// so skip the fold entirely, as the previous full-scan shortcut did.
-	if (!proseOnly && !hasComment) return text;
-	if (text === cache.text) return cache.value;
+	// Raw mode without comments is the identity (fences pass through
+	// verbatim), so skip the fold entirely, as the previous full-scan shortcut
+	// did. Record the slot but leave the checkpoint cleared/non-resumable: no
+	// fold state entering the last line was ever computed, so a later append
+	// must recompute from scratch rather than resume from a stale checkpoint.
+	if (!proseOnly && !hasComment) {
+		cache.text = text;
+		cache.value = text;
+		cache.hadComment = false;
+		cache.startLineByte = 0;
+		cache.state = freshFoldState();
+		cache.resumable = false;
+		return text;
+	}
 
 	const lines = text.slice(fromByte).split("\n");
 	const last = lines.length - 1;
@@ -251,6 +279,11 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 	cache.value = formatted;
 	cache.hadComment = hasComment;
 	cache.startLineByte = text.lastIndexOf("\n") + 1;
+	// A trailing partial line past the cap means no newline ever arrived (the
+	// seam sits at 0 and resuming would refold the whole text every tick).
+	// Retire the checkpoint: later calls hit the identity memo on exact
+	// repeats and recompute fully on growth — bounded per call.
+	cache.resumable = text.length - cache.startLineByte <= MAX_RESUME_PARTIAL_BYTES;
 	return formatted;
 }
 

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -7,10 +7,66 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 // so each mode keeps its own slot. One entry per mode is enough for the common
 // case of one active thinking block and never regresses (a miss recomputes
 // exactly as before).
-let proseCacheKey = "";
-let proseCacheValue = "";
-let rawCacheKey = "";
-let rawCacheValue = "";
+//
+// Each slot also carries the fold state for incremental extension: when the
+// incoming text is an append of the previously formatted text (streaming only
+// ever extends the trailing partial line), the fold resumes at the stored
+// line boundary — only the appended suffix is re-scanned, reusing the
+// committed output and the fence state captured entering that line. Append
+// detection is O(last line): the seam byte must still sit right after a
+// newline and the previous partial line must persist verbatim at its offset;
+// anything else takes the full-recompute path. The last input line is always
+// re-folded (never committed), so its transient effects — comment-noise
+// skipping, the prose ellipsis — are replayed under the new context instead
+// of leaking into the committed prefix. The committed output keeps the last
+// non-blank line in a mutable tail slot so the prose ellipsis can rewrite it
+// without re-joining (or even touching) the committed prefix.
+
+/**
+ * Fold accumulator for the output produced so far. Output lines are appended
+ * once and frozen into `committed`; only the trailing region stays mutable.
+ */
+interface FoldState {
+	/** joined output lines before the last non-blank line, fully finalized */
+	committed: string;
+	/** whether a non-blank output line exists (kept in {@link tailLine}) */
+	hasTail: boolean;
+	/** the last non-blank output line — rewritten in place by the prose ellipsis */
+	tailLine: string;
+	/** raw blank output lines after `tailLine`, each prefixed by its separator */
+	tailBlankSep: string;
+	/** whether any output line precedes `tailLine` (a lone leading blank line leaves `committed` empty) */
+	tailPred: boolean;
+	/** output lines emitted so far */
+	emitted: number;
+	inFence: boolean;
+	fenceChar: string;
+	fenceLen: number;
+}
+
+interface DisplayCache {
+	/** last formatted text */
+	text: string;
+	/** formatted output for `text` */
+	value: string;
+	/** whether `text` contains `<!--` (extended incrementally on appends) */
+	hadComment: boolean;
+	/** byte offset of the start of the last (possibly partial) line of `text` */
+	startLineByte: number;
+	/** fold state ENTERING that last line — the resume point for appends */
+	state: FoldState;
+}
+
+function freshFoldState(): FoldState {
+	return { committed: "", hasTail: false, tailLine: "", tailBlankSep: "", tailPred: false, emitted: 0, inFence: false, fenceChar: "", fenceLen: 0 };
+}
+
+function freshDisplayCache(): DisplayCache {
+	return { text: "", value: "", hadComment: false, startLineByte: 0, state: freshFoldState() };
+}
+
+const proseCache = freshDisplayCache();
+const rawCache = freshDisplayCache();
 
 export function canonicalizeMessage(text: string | null | undefined): string {
 	if (!text) return "";
@@ -29,6 +85,7 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 // ` -->`. Comments with actual content are left untouched.
 const EMPTY_COMMENT_RE = /^<!--\s*-->$/;
 const OPEN_COMMENT_RE = /^<!--\s*$/;
+const FENCE = /^( {0,3})([`~]{3,})/;
 
 /**
  * Whether `line` is reasoning-summary comment noise: an empty HTML comment,
@@ -40,72 +97,134 @@ function isCommentNoise(line: string, isLastLine: boolean): boolean {
 }
 
 /**
+ * Whether `text` is an append of the previously formatted text. Verified in
+ * O(last line): the stored seam must still sit right after a newline of
+ * `text`, and the previous partial line must persist verbatim at its offset.
+ * The prefix before the seam is a positional contract (streaming growth never
+ * rewrites it) rather than something re-read on every tick; anchored
+ * spot-checks (first byte, midpoint, trailing window) catch stream switches —
+ * including the vacuous case where the previous text ended exactly at its
+ * seam, leaving no partial line to compare.
+ */
+function isAppend(cache: DisplayCache, text: string): boolean {
+	const prev = cache.text;
+	const seam = cache.startLineByte;
+	if (text.length < prev.length || prev.length === 0) return false;
+	if (seam > 0 && text.charCodeAt(seam - 1) !== 0x0a) return false;
+	for (let i = seam; i < prev.length; i++) {
+		if (text.charCodeAt(i) !== prev.charCodeAt(i)) return false;
+	}
+	if (seam > 0) {
+		if (text.charCodeAt(0) !== prev.charCodeAt(0)) return false;
+		const mid = seam >> 1;
+		if (text.charCodeAt(mid) !== prev.charCodeAt(mid)) return false;
+		for (let i = Math.max(1, seam - 32); i < seam; i++) {
+			if (text.charCodeAt(i) !== prev.charCodeAt(i)) return false;
+		}
+	}
+	return true;
+}
+
+/** Fold one input line into the accumulator. Whitespace-only lines defer to the tail region. */
+function pushFoldLine(state: FoldState, line: string): void {
+	state.emitted++;
+	if (line.trim() === "") {
+		// Blank lines are kept verbatim (a `" "` line still renders its space);
+		// they just never become the prose ellipsis target.
+		if (state.hasTail) state.tailBlankSep += "\n" + line;
+		else state.committed += (state.emitted > 1 ? "\n" : "") + line;
+		return;
+	}
+	if (state.hasTail) {
+		state.committed += (state.tailPred ? "\n" : "") + state.tailLine + state.tailBlankSep;
+		state.tailPred = true;
+	} else {
+		state.tailPred = state.emitted > 1;
+	}
+	state.tailLine = line;
+	state.hasTail = true;
+	state.tailBlankSep = "";
+}
+
+/** Prose-mode ellipsis: rewrite the last non-blank output line in place. */
+function appendFoldEllipsis(state: FoldState): void {
+	if (!state.hasTail) {
+		pushFoldLine(state, "...");
+		return;
+	}
+	const trimmed = state.tailLine.trimEnd();
+	if (trimmed.endsWith("...")) {
+		state.tailLine = trimmed;
+	} else if (trimmed.endsWith(".")) {
+		state.tailLine = `${trimmed.slice(0, -1)}...`;
+	} else {
+		state.tailLine = `${trimmed}...`;
+	}
+}
+
+/** Materialize the folded output from the committed prefix and the tail region. */
+function renderFold(state: FoldState): string {
+	if (!state.hasTail) return state.committed;
+	return state.committed + (state.tailPred ? "\n" : "") + state.tailLine + state.tailBlankSep;
+}
+
+/**
  * Thinking text prepared for display. Both modes drop empty `<!-- -->`
  * sentinel lines outside code fences (see {@link isCommentNoise}); prose-only
  * mode additionally elides fenced code down to a trailing ellipsis.
  */
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
 	if (!text) return text;
-	const hasComment = text.includes("<!--");
-	if (proseOnly) {
-		if (text === proseCacheKey) return proseCacheValue;
+	const cache = proseOnly ? proseCache : rawCache;
+	let hasComment: boolean;
+	let fromByte: number;
+	let state: FoldState;
+	if (cache.text.length > 0 && text.length >= cache.text.length && isAppend(cache, text)) {
+		// Append: a `<!--` introduced by the suffix flips the noise gate, and a
+		// marker straddling the seam can start at most 3 bytes back — identical
+		// to rescanning the full text, at O(delta).
+		hasComment = cache.hadComment || text.indexOf("<!--", Math.max(0, cache.text.length - 3)) !== -1;
+		fromByte = cache.startLineByte;
+		state = { ...cache.state };
 	} else {
-		if (!hasComment) return text;
-		if (text === rawCacheKey) return rawCacheValue;
+		hasComment = text.includes("<!--");
+		fromByte = 0;
+		state = freshFoldState();
 	}
+	// Raw mode without comments is the identity (fences pass through verbatim),
+	// so skip the fold entirely, as the previous full-scan shortcut did.
+	if (!proseOnly && !hasComment) return text;
+	if (text === cache.text) return cache.value;
 
-	const lines = text.split("\n");
-	const resultLines: string[] = [];
-	let inFence = false;
-	let fenceChar = "";
-	let fenceLen = 0;
-
-	const FENCE = /^( {0,3})([`~]{3,})/;
-	const appendEllipsis = () => {
-		let lastLineIdx = resultLines.length - 1;
-		while (lastLineIdx >= 0 && resultLines[lastLineIdx]!.trim() === "") {
-			lastLineIdx--;
-		}
-
-		if (lastLineIdx >= 0) {
-			const lastLine = resultLines[lastLineIdx]!;
-			const trimmed = lastLine.trimEnd();
-			if (trimmed.endsWith("...")) {
-				resultLines[lastLineIdx] = trimmed;
-			} else if (trimmed.endsWith(".")) {
-				resultLines[lastLineIdx] = `${trimmed.slice(0, -1)}...`;
-			} else {
-				resultLines[lastLineIdx] = `${trimmed}...`;
-			}
-		} else {
-			resultLines.push("...");
-		}
-	};
-
+	const lines = text.slice(fromByte).split("\n");
+	const last = lines.length - 1;
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i]!;
+		// Freeze the resume state entering the final (possibly partial) line;
+		// that line is re-folded from here on the next append.
+		if (i === last) cache.state = { ...state };
 
-		if (inFence) {
+		if (state.inFence) {
 			const close = FENCE.exec(line);
 			// A closing fence is the same char, at least as long, with nothing else on the line.
 			if (
 				close &&
-				close[2]![0] === fenceChar &&
-				close[2]!.length >= fenceLen &&
+				close[2]![0] === state.fenceChar &&
+				close[2]!.length >= state.fenceLen &&
 				line.slice(close[1]!.length + close[2]!.length).trim() === ""
 			) {
-				inFence = false;
-				fenceChar = "";
-				fenceLen = 0;
+				state.inFence = false;
+				state.fenceChar = "";
+				state.fenceLen = 0;
 			}
 			// Prose mode skips all fence lines; raw mode keeps them verbatim
 			// (comment markers inside fences are code, not noise).
-			if (!proseOnly) resultLines.push(line);
+			if (!proseOnly) pushFoldLine(state, line);
 			continue;
 		}
 
 		// Drop the whole line so `**Headline**\n\n<!-- -->` leaves no blank tail.
-		if (hasComment && isCommentNoise(line, i === lines.length - 1)) continue;
+		if (hasComment && isCommentNoise(line, i === last)) continue;
 
 		const open = FENCE.exec(line);
 		if (open) {
@@ -113,28 +232,25 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 			const ch = marker[0]!;
 			// A backtick fence's info string may not contain a backtick.
 			if (!(ch === "`" && line.slice(open[1]!.length + marker.length).includes("`"))) {
-				inFence = true;
-				fenceChar = ch;
-				fenceLen = marker.length;
+				state.inFence = true;
+				state.fenceChar = ch;
+				state.fenceLen = marker.length;
 				if (proseOnly) {
-					appendEllipsis();
+					appendFoldEllipsis(state);
 				} else {
-					resultLines.push(line);
+					pushFoldLine(state, line);
 				}
 				continue;
 			}
 		}
-		resultLines.push(line);
+		pushFoldLine(state, line);
 	}
 
-	const formatted = resultLines.join("\n");
-	if (proseOnly) {
-		proseCacheKey = text;
-		proseCacheValue = formatted;
-	} else {
-		rawCacheKey = text;
-		rawCacheValue = formatted;
-	}
+	const formatted = renderFold(state);
+	cache.text = text;
+	cache.value = formatted;
+	cache.hadComment = hasComment;
+	cache.startLineByte = text.lastIndexOf("\n") + 1;
 	return formatted;
 }
 

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -146,7 +146,7 @@ function pushFoldLine(state: FoldState, line: string): void {
 	if (line.trim() === "") {
 		// Blank lines are kept verbatim (a `" "` line still renders its space);
 		// they just never become the prose ellipsis target.
-		if (state.hasTail) state.tailBlankSep += "\n" + line;
+		if (state.hasTail) state.tailBlankSep += `\n${line}`;
 		else state.committed += (state.emitted > 1 ? "\n" : "") + line;
 		return;
 	}

--- a/packages/coding-agent/test/session/thinking-display.test.ts
+++ b/packages/coding-agent/test/session/thinking-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { canonicalizeMessage } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
+import { canonicalizeMessage, formatThinkingForDisplay } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
 
 describe("canonicalizeMessage", () => {
 	it("returns empty string for undefined, empty, or whitespace-only", () => {
@@ -22,5 +22,99 @@ describe("canonicalizeMessage", () => {
 		expect(canonicalizeMessage("hello.")).toBe("hello.");
 		expect(canonicalizeMessage(". hello .")).toBe(". hello .");
 		expect(canonicalizeMessage("a")).toBe("a");
+	});
+});
+
+// Streaming fixtures: prose with comment noise, fenced code, open fences,
+// tilde/backtick variants, trailing newlines, and degenerate shapes.
+const STREAM_FIXTURES = [
+	"hello",
+	"**Headline**\n\nSome reasoning with `inline` code.\n\nAnother thought.",
+	"line one\nline two\n\n\n",
+	"```js\nconst x = 1;\nconsole.log(x);\n```\nafter fence",
+	"```\nnever closed\nstill open",
+	"intro\n```js\ncode\n```\ntail with trailing.\n",
+	"Step 1.\n\n<!-- -->\nStep 2.\n",
+	"Step.\n\n<!--\nmore",
+	"a\nb\nc\n",
+	"start ```\n```\nend",
+	"```\n```",
+	"~~~\ntilde fence\n~~~\n",
+	"```\n\n```",
+	"`x\n```y\nz",
+];
+
+describe("formatThinkingForDisplay incremental streaming", () => {
+	// A text that cannot be a prefix of any fixture forces the next call to
+	// take the full-recompute fallback, giving a cold-cache reference value.
+	const DIRTY = "\u0000dirty\u0000\n<!--";
+
+	for (const proseOnly of [false, true]) {
+		for (const [idx, fixture] of STREAM_FIXTURES.entries()) {
+			it(`byte-identical to full recompute at every split point (mode=${proseOnly ? "prose" : "raw"}, fixture ${idx})`, () => {
+				const n = fixture.length;
+				// Reference: cold-start full recompute for every prefix.
+				const expected: string[] = [];
+				for (let i = 0; i <= n; i++) {
+					formatThinkingForDisplay(DIRTY, proseOnly);
+					expected[i] = formatThinkingForDisplay(fixture.slice(0, i), proseOnly);
+				}
+				// For every split point, feed the incremental stream up to it
+				// and compare every intermediate and final output.
+				for (let i = 1; i <= n; i++) {
+					formatThinkingForDisplay(DIRTY, proseOnly);
+					for (let j = 1; j <= i; j++) {
+						expect(formatThinkingForDisplay(fixture.slice(0, j), proseOnly)).toBe(expected[j]!);
+					}
+				}
+			});
+		}
+	}
+});
+
+describe("formatThinkingForDisplay streaming performance", () => {
+	// ~10 bytes/tick mixing prose, newlines, fences, and a comment marker so
+	// both modes exercise the fold path rather than a shortcut.
+	const CHUNKS = ["step ", "through the ", "plan:\n", "```js\n", "value += 1;\n", "```\n", "next idea\n", "with detail ", "and more.\n", "<!-- note\n"];
+	const TICKS = 5000;
+	const texts: string[] = [];
+	{
+		// Monotonically growing stream; joined per tick so fixtures are flat
+		// strings and timing measures the formatter rather than lazy rope
+		// flattening of `+=`-accumulated fixtures.
+		const parts: string[] = [];
+		for (let i = 0; i < TICKS; i++) {
+			parts.push(CHUNKS[i % CHUNKS.length]!);
+			texts.push(parts.join(""));
+		}
+	}
+	// Carries `<!--` so the raw-mode identity shortcut cannot skip poisoning
+	// the cache between timed calls.
+	const DIRTY_PERF = "\u0000perf-dirty\u0000\n<!--";
+
+	it(`incremental append stream beats per-tick recompute over ${TICKS} ticks (raw + prose)`, () => {
+		for (const proseOnly of [false, true]) {
+			// JIT warm-up on a shorter prefix of the same stream.
+			for (let i = 0; i < 500; i++) {
+				formatThinkingForDisplay(DIRTY_PERF, proseOnly);
+				formatThinkingForDisplay(texts[i]!, proseOnly);
+			}
+			let sink = "";
+			let t0 = performance.now();
+			for (const text of texts) sink = formatThinkingForDisplay(text, proseOnly);
+			const incrementalMs = performance.now() - t0;
+			// The streamed result must match one cold recompute of the full text.
+			formatThinkingForDisplay(DIRTY_PERF, proseOnly);
+			expect(sink).toBe(formatThinkingForDisplay(texts[TICKS - 1]!, proseOnly));
+			// Pre-PR baseline: a forced full re-scan per tick.
+			t0 = performance.now();
+			for (const text of texts) {
+				formatThinkingForDisplay(DIRTY_PERF, proseOnly);
+				sink = formatThinkingForDisplay(text, proseOnly);
+			}
+			const recomputeMs = performance.now() - t0;
+			expect(incrementalMs).toBeLessThan(recomputeMs / 2);
+			expect(incrementalMs).toBeLessThan(2000);
+		}
 	});
 });

--- a/packages/coding-agent/test/session/thinking-display.test.ts
+++ b/packages/coding-agent/test/session/thinking-display.test.ts
@@ -75,7 +75,18 @@ describe("formatThinkingForDisplay incremental streaming", () => {
 describe("formatThinkingForDisplay streaming performance", () => {
 	// ~10 bytes/tick mixing prose, newlines, fences, and a comment marker so
 	// both modes exercise the fold path rather than a shortcut.
-	const CHUNKS = ["step ", "through the ", "plan:\n", "```js\n", "value += 1;\n", "```\n", "next idea\n", "with detail ", "and more.\n", "<!-- note\n"];
+	const CHUNKS = [
+		"step ",
+		"through the ",
+		"plan:\n",
+		"```js\n",
+		"value += 1;\n",
+		"```\n",
+		"next idea\n",
+		"with detail ",
+		"and more.\n",
+		"<!-- note\n",
+	];
 	const TICKS = 5000;
 	const texts: string[] = [];
 	{
@@ -92,6 +103,8 @@ describe("formatThinkingForDisplay streaming performance", () => {
 	// the cache between timed calls.
 	const DIRTY_PERF = "\u0000perf-dirty\u0000\n<!--";
 
+	// The forced-recompute baseline phases alone take multiple seconds
+	// (quadratic work by design); run well clear of bun's 5s default timeout.
 	it(`incremental append stream beats per-tick recompute over ${TICKS} ticks (raw + prose)`, () => {
 		for (const proseOnly of [false, true]) {
 			// JIT warm-up on a shorter prefix of the same stream.
@@ -116,5 +129,233 @@ describe("formatThinkingForDisplay streaming performance", () => {
 			expect(incrementalMs).toBeLessThan(recomputeMs / 2);
 			expect(incrementalMs).toBeLessThan(2000);
 		}
+	}, 30000);
+});
+
+describe("formatThinkingForDisplay adversarial append detection", () => {
+	// The retired spot-check detector anchored on {first byte, midpoint,
+	// trailing 32-byte window}, leaving positions 1..seam-33 unchecked whenever
+	// seam >= 34. Seed geometry: first newline at index 41, so seam = 42 and
+	// the unchecked gap was [1, 9]. A mutation at ANY position in [1, seam)
+	// must produce exactly the cold-recompute output — never a stale
+	// committed prefix resumed from the unmutated seed.
+	const GAP_SEED_PROSE = `I${"B".repeat(40)}\n\`\`\`\ncode\nX`;
+	const GAP_SEED_RAW = `I${"B".repeat(40)}\n<!-- -->\nplain tail`;
+	const POISON_GAP = "\u0000gap-poison\u0000\n<!--";
+	const SEAM = 42;
+
+	for (const proseOnly of [false, true]) {
+		const seed = proseOnly ? GAP_SEED_PROSE : GAP_SEED_RAW;
+		it(`mutation anywhere in [1, seam) matches cold recompute (mode=${proseOnly ? "prose" : "raw"}, incl. retired gap [1, ${SEAM - 33}])`, () => {
+			for (let p = 1; p < SEAM; p++) {
+				const mutant = `${seed.slice(0, p)}${seed.charAt(p) === "Z" ? "Q" : "Z"}${seed.slice(p + 1)} more`;
+				formatThinkingForDisplay(POISON_GAP, proseOnly);
+				const cold = formatThinkingForDisplay(mutant, proseOnly);
+				formatThinkingForDisplay(POISON_GAP, proseOnly);
+				formatThinkingForDisplay(seed, proseOnly);
+				expect(formatThinkingForDisplay(mutant, proseOnly)).toBe(cold);
+			}
+		});
+	}
+});
+
+describe("formatThinkingForDisplay raw identity shortcut slot hygiene", () => {
+	const POISON_SHORTCUT = "\u0000shortcut-poison\u0000\n<!--";
+
+	it("shortcut records the slot but never leaves a resumable checkpoint", () => {
+		// Open fence behind an earlier newline, no comment yet: the raw
+		// identity shortcut fires and records the slot.
+		const base = "intro\n```\ncode line";
+		// The marker then arrives inside the still-open fence: raw mode keeps
+		// fence contents, but a resume from a bogus checkpoint claiming
+		// "not in fence" would drop it. The cleared checkpoint forces a
+		// recompute that matches the cold reference.
+		const grown = `${base}\n<!-- -->`;
+		formatThinkingForDisplay(POISON_SHORTCUT, false);
+		const coldGrown = formatThinkingForDisplay(grown, false);
+		expect(coldGrown).toContain("<!-- -->");
+		formatThinkingForDisplay(POISON_SHORTCUT, false);
+		formatThinkingForDisplay(base, false);
+		expect(formatThinkingForDisplay(grown, false)).toBe(coldGrown);
+
+		// An exact repeat of a shortcut text is served by the recorded memo.
+		formatThinkingForDisplay(POISON_SHORTCUT, false);
+		const once = formatThinkingForDisplay(base, false);
+		expect(formatThinkingForDisplay(base, false)).toBe(once);
+	});
+});
+
+describe("formatThinkingForDisplay seam-transition battery", () => {
+	// Long no-newline prefix crossing the 8KiB resume cap, then a fence
+	// transition, then multi-line appends continuing past a final newline;
+	// the comment marker appears only in the tail, so raw mode hands off from
+	// the identity shortcut to a folding state mid-stream. EVERY split point
+	// must match the cold recompute.
+	const POISON_BATTERY = "\u0000battery-poison\u0000\n<!--";
+
+	for (const proseOnly of [false, true]) {
+		it(`byte-identical at every split point across cap/fence/marker transitions (mode=${proseOnly ? "prose" : "raw"})`, () => {
+			const fixture = `${"x".repeat(8300)}\n\`\`\`js\nstep one\nstep two\n\`\`\`\ntail prose.\n<!-- -->\nappended`;
+			const n = fixture.length;
+			const refs: string[] = new Array(n + 1);
+			for (let i = 0; i <= n; i++) {
+				formatThinkingForDisplay(POISON_BATTERY, proseOnly);
+				refs[i] = formatThinkingForDisplay(fixture.slice(0, i), proseOnly);
+			}
+			formatThinkingForDisplay(POISON_BATTERY, proseOnly);
+			for (let i = 1; i <= n; i++) {
+				expect(formatThinkingForDisplay(fixture.slice(0, i), proseOnly)).toBe(refs[i]);
+			}
+		});
+	}
+});
+
+describe("formatThinkingForDisplay no-newline scaling", () => {
+	// Chunks deliberately never contain a newline: the seam stays at byte 0,
+	// the shape that refolded the whole text every tick before the resume
+	// cap. Streams here cross MAX_RESUME_PARTIAL_BYTES (8192) mid-run; later
+	// ticks degrade to the identity memo / full recompute — the pre-PR
+	// asymptotics for this pathological shape, bounded per call.
+	const NL_FREE_CHUNKS = ["word ", "token ", "and ", "more "];
+	const POISON_NL = "\u0000nl-poison\u0000\n<!--";
+	const buildTexts = (ticks: number, chunk?: string) => {
+		const parts: string[] = [];
+		const texts: string[] = [];
+		for (let i = 0; i < ticks; i++) {
+			parts.push(chunk ?? NL_FREE_CHUNKS[i % NL_FREE_CHUNKS.length]!);
+			texts.push(parts.join(""));
+		}
+		return texts;
+	};
+
+	it("growth stays cheaper than forced per-tick recompute and exact repeats stay memoized", () => {
+		for (const proseOnly of [false, true]) {
+			const texts = buildTexts(2400);
+			const final = texts[texts.length - 1]!;
+			for (const text of buildTexts(300)) {
+				formatThinkingForDisplay(POISON_NL, proseOnly);
+				formatThinkingForDisplay(text, proseOnly);
+			}
+			let sink = "";
+			let t0 = performance.now();
+			for (const text of texts) sink = formatThinkingForDisplay(text, proseOnly);
+			const growthMs = performance.now() - t0;
+			// Byte-identical through the cap transition.
+			formatThinkingForDisplay(POISON_NL, proseOnly);
+			expect(sink).toBe(formatThinkingForDisplay(final, proseOnly));
+			// Exact-repeat burst on the final (>cap) text: pure memo hits.
+			t0 = performance.now();
+			for (let i = 0; i < 2000; i++) formatThinkingForDisplay(final, proseOnly);
+			const repeatMs = performance.now() - t0;
+			// Ratio form: memo hits cost a fraction of one growth pass —
+			// robust under machine-load variance, unlike absolute bounds.
+			expect(repeatMs).toBeLessThan(growthMs / 4);
+			// Growth must not cost more than forcing a cold recompute per tick.
+			t0 = performance.now();
+			for (const text of texts) {
+				formatThinkingForDisplay(POISON_NL, proseOnly);
+				sink = formatThinkingForDisplay(text, proseOnly);
+			}
+			const baselineMs = performance.now() - t0;
+			expect(growthMs).toBeLessThan(baselineMs);
+		}
+	});
+
+	it("per-tick cost scales linearly with text size, not quadratically", () => {
+		for (const proseOnly of [false, true]) {
+			const timed = (targetBytes: number) => {
+				const texts = buildTexts(1200, "z".repeat(Math.ceil(targetBytes / 1200)));
+				const t0 = performance.now();
+				for (const text of texts) formatThinkingForDisplay(text, proseOnly);
+				return performance.now() - t0;
+			};
+			timed(4096); // JIT warm-up
+			const smallMs = timed(12 * 1024);
+			const bigMs = timed(24 * 1024);
+			// Doubling the size must not quadruple the time; generous absolute
+			// ceiling only guards pathological blowup (load variance is 2-3x).
+			expect(bigMs).toBeLessThan(smallMs * 3.5 + 20);
+			expect(bigMs).toBeLessThan(10000);
+		}
+	});
+});
+
+describe("formatThinkingForDisplay adversarial differential fuzz", () => {
+	// Deterministic xorshift32 — no flaky randomness. Generators target the
+	// two retired blind spots: mutations diverging inside the previously
+	// unchecked seam-gap region, and no-newline chains long enough to cross
+	// the resume cap. Every step judges the LIVE slot against a freshly
+	// poisoned cold reference.
+	const POISON_FUZZ = "\u0000fuzz-poison\u0000\n<!--";
+	const FRAGMENTS = [
+		"word ",
+		"plan:\n",
+		"```js\n",
+		"code;\n",
+		"```\n",
+		"<!-- -->\n",
+		"<!--\n",
+		" -->\n",
+		"tail.\n",
+		"~~~\n",
+		"`tick` ",
+		"> quote\n",
+		"\n",
+	];
+	const NL_FREE = ["word ", "token ", "and ", "-->", "<!--", "```", " . ", "Z"];
+
+	it("gap-divergent mutations, no-newline chains, shrinks and stream switches all match cold recompute (>4000 checks)", () => {
+		let s = 0x9e3779b9 | 0;
+		const rnd = () => {
+			s ^= s << 13;
+			s ^= s >>> 17;
+			s ^= s << 5;
+			s |= 0;
+			return (s >>> 0) / 4294967296;
+		};
+		const pick = (arr: string[]) => arr[Math.floor(rnd() * arr.length)]!;
+
+		let checks = 0;
+		const failures: string[] = [];
+		for (let trial = 0; trial < 220; trial++) {
+			for (const proseOnly of [false, true]) {
+				const noNewline = trial % 3 === 0;
+				let text = "";
+				for (let step = 0; step < 14; step++) {
+					const prev = text;
+					const roll = rnd();
+					if (prev.length === 0 || roll < 0.55) {
+						const frag =
+							noNewline && rnd() < 0.5
+								? "z".repeat(600 + Math.floor(rnd() * 900))
+								: pick(noNewline ? NL_FREE : FRAGMENTS);
+						text = prev + frag;
+					} else if (roll < 0.85 && prev.length > 2) {
+						// Mutate one byte, biased into [1, seam-33] — the region
+						// the retired spot-check anchors left unchecked.
+						const seam = prev.lastIndexOf("\n") + 1;
+						const limit = Math.max(1, Math.min(seam, prev.length) - 33);
+						const p = 1 + Math.floor(rnd() * limit);
+						if (p >= prev.length) text = prev + pick(FRAGMENTS);
+						else text = `${prev.slice(0, p)}${prev.charAt(p) === "Z" ? "Q" : "Z"}${prev.slice(p + 1)}`;
+					} else if (roll < 0.93 && prev.length > 4) {
+						text = prev.slice(0, 1 + Math.floor(rnd() * (prev.length - 1)));
+					} else {
+						text = pick(["", "```", "<!--"]);
+					}
+					if (!text) continue;
+
+					const actual = formatThinkingForDisplay(text, proseOnly);
+					formatThinkingForDisplay(POISON_FUZZ, proseOnly);
+					const expected = formatThinkingForDisplay(text, proseOnly);
+					checks++;
+					if (actual !== expected && failures.length < 5) {
+						failures.push(`trial=${trial} mode=${proseOnly ? "prose" : "raw"} step=${step} len=${text.length}`);
+					}
+				}
+			}
+		}
+		expect(failures).toEqual([]);
+		expect(checks).toBeGreaterThan(4000);
 	});
 });


### PR DESCRIPTION
## Problem

During thinking-block streaming, every reveal tick re-runs the full `formatThinkingForDisplay` pipeline over the entire growing text: the single-slot exact-key memo from #9426 misses on every tick (the key is the full text, which just grew), so each delta pays a complete `split('\n')` + line-by-line fence/comment scan. Over a stream that is O(text²) total — the profile reported in #9048. Measured on upstream/main: a 5000-tick multi-line stream costs **~2 seconds** of cumulative format CPU in both raw and prose modes.

## Change

- Per-mode memo slot now carries the fold checkpoint (`text`, `value`, `hadComment`, `startLineByte`, `state`, `resumable`) alongside the identity memo.
- On an append (`prev` is a verbatim prefix of incoming), only the appended suffix is re-folded: output lines are frozen into a committed prefix, and the fold state entering the last (partial) line is resumed at O(Δ).
- Append detection is exact: full-prefix `startsWith` verify at memcmp speed (O(prev) per genuinely-new text; disclosed cost). No unchecked gaps — the retired spot-check detector's blind region is covered.
- Repeated renders within one tick are answered by the identity memo in O(1).
- Pathological no-newline streams: a trailing partial line past 8 KiB retires the checkpoint and degrades to the exact-match memo — bounded work per call instead of unbounded refold.
- Raw+no-comment shortcut records its slot but clears the checkpoint (no stale-resume hazard).
- Output is byte-identical to a cold recompute at every step of a stream.

## Quantitative (baseline = upstream/main without this PR vs this PR)

Standalone harness mirroring the suite's perf-assert fixtures (same chunks/tick shapes); one process per side, median of 3, forced GC before each timed window, plus an in-harness guard asserting streamed output === cold recompute on every measurement. Dev box (i7-12700H, WSL2) under normal parallel load; absolute numbers on sub-25 ms rows carry 2–3× run-to-run variance.

| Scenario | Baseline (upstream/main) | With this PR | Δ |
|---|---|---|---|
| Multi-line stream, 5000 ticks (~50 KB final), raw — cumulative format CPU | 1,944–2,354 ms | 31.2–32.1 ms | **~65× faster** |
| Multi-line stream, 5000 ticks, prose — cumulative format CPU | 2,041–2,142 ms | 32.0–44.9 ms | **~55× faster** |
| No-newline pathological growth, prose, 1200 → 2400 → 4800 ticks | 1.3–1.4 / 3.9–7.5 / 17.6–23.8 ms | 1.8–4.1 / 5.8–10.7 / 15.8–22.1 ms | same order; per-tick refold bounded ≤ 8 KiB until the cap retires the checkpoint (bounded per call by design) |
| Exact-repeat burst, 2000 renders of final text | 0.86–1.09 ms | 0.62–0.85 ms | parity (both served by O(1) memo) |

Frame of reference: the win is the common streaming case — multi-line reasoning text — where per-tick full re-scan (O(text²)/stream) becomes O(Δ) fold + one memcmp verify (O(accumulated), memcpy-speed). The no-newline shape was already cheap-ish at memcmp speed on baseline and stays bounded here; it is not the target scenario.

Correctness evidence (same tree): suite **40 pass / 0 fail** (28,692 expect calls); byte-identical at every split point of an ~8.4 KB fixture across cap/fence/marker transitions, both modes (~16.8 k comparisons); 82 seam-gap mutation probes match cold recompute; 220-trial × 2-mode × 14-step adversarial differential fuzz (6,160 steps) — 0 failures.

## Tests & gates

- `bun test packages/coding-agent/test/session/thinking-display.test.ts` — 40 pass / 0 fail (includes perf asserts: incremental beats recompute ≥2×; linear-scaling ceiling; memo-hit ratio).
- `biome check` clean on touched files; `tsgo -p tsconfig.json --noEmit` clean (coding-agent workspace).

## Related

#9048, #9426
