### PR TITLE
fix(tui): wire todo HUD expansion commands

### DIFF
--- a/docs/tools/todo.md
+++ b/docs/tools/todo.md
@@ -121,6 +121,7 @@ The same file also exposes non-tool helpers used by `/todo`:
   - Transcript block is rendered by `todoToolRenderer` and merged with the call line.
   - `event-controller` updates the visible todo panel from successful results.
   - On error, `event-controller` shows `Todo update failed...`; the visible panel may stay stale until a later successful call.
+  - `/todo expand` shows every phase and task in the sticky HUD; `/todo collapse` restores its bounded preview. Both are display-only and leave todo state unchanged.
 - Background work / cancellation
   - Session-level auto-clear of `completed`/`abandoned` tasks was removed (the timer mutated canonical phases between tool calls); the TUI todo widget still clears closed entries after `tasks.todoClearDelay` (display-only, `packages/coding-agent/src/modes/interactive-mode.ts`).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the sticky Todo HUD being permanently collapsed; `/todo expand` now shows every phase and task, and `/todo collapse` restores the bounded preview ([#9493](https://github.com/can1357/oh-my-pi/issues/9493)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/todo-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/todo-command-controller.ts
@@ -18,6 +18,8 @@ const USAGE = [
 	"  /todo                              Show current todos",
 	"  /todo edit                         Open todos in $EDITOR",
 	"  /todo copy                         Copy todos as Markdown to clipboard",
+	"  /todo expand                       Show every phase and task in the HUD",
+	"  /todo collapse                     Restore the bounded HUD preview",
 	"  /todo export [<path>]              Write todos to file (default: TODO.md)",
 	"  /todo import [<path>]              Replace todos from file (default: TODO.md)",
 	"  /todo append [<phase>] <task...>   Append a task; phase fuzzy-matched or auto-created",
@@ -155,6 +157,12 @@ export class TodoCommandController {
 		const rest = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx + 1).trim();
 
 		switch (verb) {
+			case "expand":
+				if (!this.ctx.todoExpanded) this.ctx.toggleTodoExpansion();
+				return;
+			case "collapse":
+				if (this.ctx.todoExpanded) this.ctx.toggleTodoExpansion();
+				return;
 			case "edit":
 				await this.#editInExternalEditor();
 				return;

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -147,6 +147,8 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		subcommands: [
 			{ name: "edit", description: "Open todos in $EDITOR (Markdown round-trip)" },
 			{ name: "copy", description: "Copy todos as Markdown to clipboard" },
+			{ name: "expand", description: "Show every phase and task in the HUD" },
+			{ name: "collapse", description: "Restore the bounded HUD preview" },
 			{ name: "export", description: "Write todos as Markdown to a file (default: TODO.md)", usage: "[<path>]" },
 			{ name: "import", description: "Replace todos from a Markdown file (default: TODO.md)", usage: "[<path>]" },
 			{

--- a/packages/coding-agent/src/slash-commands/helpers/todo.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/todo.ts
@@ -105,6 +105,8 @@ const TODO_HELP_TEXT = [
 	"  /todo                              Show current todos",
 	"  /todo edit                         (TUI only) open in $EDITOR",
 	"  /todo copy                         Print todos as Markdown",
+	"  /todo expand                       (TUI only) expand the sticky HUD",
+	"  /todo collapse                     (TUI only) collapse the sticky HUD",
 	"  /todo export [<path>]              Write todos to file (default: TODO.md)",
 	"  /todo import [<path>]              Replace todos from file (default: TODO.md)",
 	"  /todo append [<phase>] <task...>   Append a task",
@@ -275,6 +277,9 @@ export async function handleTodoAcp(
 				"/todo edit requires the TUI editor; use /todo export then /todo import for non-interactive edits.",
 				runtime,
 			);
+		case "expand":
+		case "collapse":
+			return usage(`/todo ${verb} controls the interactive HUD and is unavailable in this mode.`, runtime);
 		case "help":
 		case "?":
 			await runtime.output(TODO_HELP_TEXT);

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -779,6 +779,13 @@ describe("wave 3 commands", () => {
 		expect(output[0]).toContain("TUI editor");
 	});
 
+	it("/todo expand: returns HUD-only usage message in ACP mode", async () => {
+		const { output, runtime } = createRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/todo expand", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("interactive HUD");
+	});
+
 	it("/todo unknown: returns usage message", async () => {
 		const { output, runtime } = createRuntime();
 		const result = await executeAcpBuiltinSlashCommand("/todo foobar", runtime);

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -9,7 +9,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task";
-import type { TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
+import type { TodoItem, TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -360,6 +360,33 @@ describe("InteractiveMode todo HUD anchor", () => {
 		// Hidden stages do not change the compact title.
 		const root = lines.find(line => line.includes("TODO"));
 		expect(root?.trim()).toBe("TODO");
+	});
+
+	it("expands and collapses the complete todo HUD through /todo", async () => {
+		mode.setTodos([
+			{
+				name: "Implementation",
+				tasks: Array.from(
+					{ length: 8 },
+					(_, index): TodoItem => ({
+						content: `Task ${index + 1}`,
+						status: index === 0 ? "in_progress" : "pending",
+					}),
+				),
+			},
+		]);
+
+		await mode.handleTodoCommand("expand");
+		await mode.handleTodoCommand("expand");
+
+		expect(renderTodos(mode)).toContain("Task 8");
+		expect(renderTodos(mode)).not.toContain("more todo");
+
+		await mode.handleTodoCommand("collapse");
+		await mode.handleTodoCommand("collapse");
+
+		expect(renderTodos(mode)).not.toContain("Task 8");
+		expect(renderTodos(mode)).toContain("3 more todos");
 	});
 
 	describe("compact todo for small terminal height (< 18 rows)", () => {


### PR DESCRIPTION
## Repro
Import an eight-task phase in the interactive TUI, then run `/todo expand`. Before this fix, `bun run gen:tool-views && bun test packages/coding-agent/test/interactive-mode-todo-clear.test.ts` fails because the HUD still renders Tasks 1–5 plus `… 3 more todos`, leaving Task 8 hidden.

## Cause
`InteractiveMode.toggleTodoExpansion()` in `packages/coding-agent/src/modes/interactive-mode.ts` updates `todoExpanded` and rerenders the HUD, but `TodoCommandController.handleTodoCommand()` in `packages/coding-agent/src/modes/controllers/todo-command-controller.ts` exposed no verb that invoked it, so the implemented expanded render branch was unreachable.

## Fix
- Add idempotent `/todo expand` and `/todo collapse` verbs backed by the existing HUD toggle.
- Advertise both verbs in `/todo help` and document their display-only behavior.
- Cover the full eight-task collapsed/expanded transition, including repeated commands.
- Add the user-facing fix to the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/interactive-mode-todo-clear.test.ts packages/coding-agent/test/modes/controllers/todo-command-controller.test.ts` — 27 pass, 0 fail. `bun run check` in `packages/coding-agent` — clean. Manual source-CLI TUI smoke: imported eight tasks, `/todo expand` rendered Task 8 with no overflow summary, and `/todo collapse` restored `… 3 more todos`.

Fixes #9493