### PR TITLE
fix(tui): preserve retired welcome rows across resize

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed retired welcome-screen rows disappearing from terminal history after a resize.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -1,15 +1,18 @@
 import {
 	type Component,
 	Container,
+	isInsideTerminalMultiplexer,
 	ProcessTerminal,
 	type ResizeScrollbackMode,
 	Spacer,
+	sliceWithWidth,
 	type Terminal,
 	type TerminalFramePlan,
 	type TerminalFrameProvider,
 	TUI,
 	type TUIOptions,
 	type ViewportSize,
+	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import { CustomEditor } from "./components/custom-editor";
 import { type AnimationFrame, TranscriptContainer } from "./components/transcript-container";
@@ -130,6 +133,15 @@ export class Composer implements TerminalFrameProvider {
 	// The welcome header retires to terminal history exactly once, after the
 	// intro settles; until then it renders as mutable viewport chrome.
 	#headerRetired = false;
+	// Exact hard rows accepted into native history. Resize-alt paints reflow
+	// these rows rather than recomposing the header, because a wider terminal
+	// never joins hard tip wraps that were committed at the original width.
+	#retiredHeaderRows: readonly string[] | undefined;
+	// Hard-row prefix currently above the native viewport. The first resize
+	// frame may pull part of it down before the normal buffer is borrowed.
+	#retiredHeaderStart = 0;
+	#resizeRetiredHeaderStart: number | undefined;
+	#lastNormalRows = 0;
 	#lastInterruptAt = 0;
 	#started = false;
 	#stopped = false;
@@ -186,6 +198,11 @@ export class Composer implements TerminalFrameProvider {
 		if (!this.#started || this.#stopped) return { viewport: [] };
 		const width = Math.max(1, viewport.columns);
 		const rows = Math.max(0, viewport.rows);
+		if (this.#resizeRetiredHeaderStart !== undefined) {
+			this.#retiredHeaderStart = this.#resizeRetiredHeaderStart;
+			this.#resizeRetiredHeaderStart = undefined;
+		}
+		this.#lastNormalRows = rows;
 		const roots = this.#runtimeMounted
 			? [...this.#runtimeChildren, this.#statusHost]
 			: [this.#header, this.#bootstrapInputGap, this.editor, this.#statusHost];
@@ -208,6 +225,10 @@ export class Composer implements TerminalFrameProvider {
 		const frame: AnimationFrame = { now, tick: Math.floor(now / 80) };
 		const active = transcript.renderViewport(width, Math.max(0, rows - before.length - after.length), frame);
 		const composed = [...before, ...active, ...after];
+		if (history !== undefined && this.#offeredHistory?.source === "header") {
+			const visibleHeaderRows = Math.max(0, rows - composed.length);
+			this.#retiredHeaderStart = Math.max(0, history.rows.length - visibleHeaderRows);
+		}
 		return {
 			history,
 			viewport: composed.length <= rows ? composed : composed.slice(-rows),
@@ -218,8 +239,12 @@ export class Composer implements TerminalFrameProvider {
 	acknowledgeHistory(id: number): void {
 		const offered = this.#offeredHistory;
 		if (offered === undefined || offered.id !== id) return;
-		if (offered.source === "header") this.#headerRetired = true;
-		else offered.source.transcript.acknowledgeFinalizedBatch(offered.source.transcriptId);
+		if (offered.source === "header") {
+			this.#headerRetired = true;
+			this.#retiredHeaderRows = offered.rows;
+		} else {
+			offered.source.transcript.acknowledgeFinalizedBatch(offered.source.transcriptId);
+		}
 		this.#offeredHistory = undefined;
 	}
 
@@ -231,7 +256,17 @@ export class Composer implements TerminalFrameProvider {
 		const tail = this.#runtimeMounted
 			? this.#renderRoots([...this.#runtimeChildren, this.#statusHost], width)
 			: this.#renderRoots([this.#bootstrapInputGap, this.editor, this.#statusHost], width);
-		const rendered = [...this.#header.render(width), ...(this.#headerRetired ? [""] : []), ...tail];
+		let header: readonly string[];
+		if (this.#headerRetired) {
+			this.#resizeRetiredHeaderStart ??= Math.max(
+				0,
+				this.#retiredHeaderStart - Math.max(0, rows - this.#lastNormalRows),
+			);
+			header = this.#reflowRetiredHeader(width, this.#resizeRetiredHeaderStart);
+		} else {
+			header = this.#header.render(width);
+		}
+		const rendered = [...header, ...tail];
 		return rendered.length <= rows ? rendered : rendered.slice(rendered.length - rows);
 	}
 
@@ -239,6 +274,9 @@ export class Composer implements TerminalFrameProvider {
 	resetHistory(): void {
 		this.#offeredHistory = undefined;
 		this.#headerRetired = false;
+		this.#retiredHeaderRows = undefined;
+		this.#retiredHeaderStart = 0;
+		this.#resizeRetiredHeaderStart = undefined;
 		for (const child of this.#runtimeChildren) {
 			if (child instanceof TranscriptContainer) child.resetRetirement();
 		}
@@ -283,6 +321,30 @@ export class Composer implements TerminalFrameProvider {
 		const rows: string[] = [];
 		for (const root of roots) rows.push(...root.render(width));
 		return rows;
+	}
+
+	/** Reflow accepted hard rows exactly as the restored terminal buffer will. */
+	#reflowRetiredHeader(width: number, start: number): string[] {
+		const lines = this.#retiredHeaderRows;
+		if (!lines) return [];
+		if (isInsideTerminalMultiplexer()) return lines.slice(start);
+		const reflowed: string[] = [];
+		const columns = Math.max(1, width);
+		for (let index = start; index < lines.length; index++) {
+			const line = lines[index]!;
+			const lineWidth = visibleWidth(line);
+			if (lineWidth === 0) {
+				reflowed.push("");
+				continue;
+			}
+			for (let column = 0; column < lineWidth; ) {
+				let slice = sliceWithWidth(line, column, columns, true);
+				if (slice.width === 0) slice = sliceWithWidth(line, column, columns);
+				reflowed.push(slice.text);
+				column += Math.max(1, slice.width);
+			}
+		}
+		return reflowed;
 	}
 
 	/** Live editor whose draft survives startup and session adoption. */

--- a/packages/coding-agent/test/welcome-history-resize.test.ts
+++ b/packages/coding-agent/test/welcome-history-resize.test.ts
@@ -1,10 +1,13 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
 import { COMPOSER_DEFAULTS, Composer } from "@oh-my-pi/pi-coding-agent/modes/composer";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import type { Component, RenderScheduler } from "@oh-my-pi/pi-tui";
+import { type Component, type RenderScheduler, visibleWidth } from "@oh-my-pi/pi-tui";
 import { VirtualRenderScheduler } from "../../tui/test/virtual-render-scheduler";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
+
+withoutTerminalMultiplexer();
 
 class ResizeScheduler implements RenderScheduler {
 	#now = 0;
@@ -83,12 +86,32 @@ function expectOneExactEditor(rows: readonly string[], status: string): number {
 	return top;
 }
 
+function startRetiredWelcome(modelName: string): { composer: Composer; terminal: TrackingTerminal } {
+	const terminal = new TrackingTerminal(80, 12);
+	const composer = new Composer({
+		terminal,
+		tuiOptions: { renderScheduler: new ResizeScheduler() },
+		preferences: { ...COMPOSER_DEFAULTS, quiet: false, resizeScrollback: "preserve" },
+		welcome: { version: "test", modelName, providerName: "test-provider" },
+	});
+	composer.setRuntimeChildren([new TranscriptContainer(), new MutableComposerTail()]);
+	composer.start({ playWelcomeIntro: false });
+	return { composer, terminal };
+}
+
 beforeAll(async () => {
 	await initTheme();
 });
 
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 describe("composer welcome native-history resize", () => {
 	it("keeps one exact editor rectangle and retired welcome through repeated thinking and resize frames", async () => {
+		// Select the long auth-broker tip: it retires as three hard rows at
+		// width 80 and must not be recomposed into fewer rows after widening.
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
 		const terminal = new TrackingTerminal(80, 12);
 		const scheduler = new ResizeScheduler();
 		const composer = new Composer({
@@ -188,6 +211,46 @@ describe("composer welcome native-history resize", () => {
 		expect(offered).toHaveLength(1);
 		expect(acknowledged).toHaveLength(1);
 		expect(terminal.writes.slice(writesAfterRetirement).some(write => write.includes("\x1b[3J"))).toBe(false);
+		composer.ui.stop();
+	});
+
+	it("preserves a wide glyph that straddles a retired-row resize boundary", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const { composer, terminal } = startRetiredWelcome("model-aaaa界-tail");
+		const accepted = plainBuffer(terminal).find(row => row.includes("界"));
+		expect(accepted).toBeDefined();
+		const glyphIndex = accepted!.indexOf("界");
+		const width = visibleWidth(accepted!.slice(0, glyphIndex)) + 1;
+		expect(width).toBeLessThan(80);
+
+		const resizeFrame = composer.renderResizeFrame({ columns: width, rows: 200 }).map(row => Bun.stripANSI(row));
+		expect(countRows(resizeFrame, "界")).toBe(1);
+
+		terminal.resize(width, 200);
+
+		const transient = terminal.getViewport().map(row => Bun.stripANSI(row));
+		expect(countRows(transient, "界")).toBe(1);
+		composer.ui.stop();
+	});
+	it("clips retired hard rows instead of reflowing them inside a multiplexer", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		Bun.env.TMUX = "/tmp/tmux-test/default,1,0";
+		const marker = "MUX-SUFFIX";
+		const { composer, terminal } = startRetiredWelcome(`model-aaaa${marker}`);
+		const accepted = plainBuffer(terminal).find(row => row.includes(marker));
+		expect(accepted).toBeDefined();
+		expect(visibleWidth(accepted!)).toBeLessThanOrEqual(80);
+		const markerIndex = accepted!.indexOf(marker);
+		const width = visibleWidth(accepted!.slice(0, markerIndex)) - 1;
+		expect(width).toBeGreaterThan(1);
+
+		const resizeFrame = composer.renderResizeFrame({ columns: width, rows: 200 }).map(row => Bun.stripANSI(row));
+		expect(countRows(resizeFrame, marker)).toBe(1);
+
+		terminal.resize(width, 200);
+
+		const transient = terminal.getViewport().map(row => Bun.stripANSI(row));
+		expect(countRows(transient, marker)).toBe(0);
 		composer.ui.stop();
 	});
 	it("rebuilds retired transcript rows at the settled width by default", async () => {


### PR DESCRIPTION
## What changed

Retain retired welcome-screen rows during terminal resize history recovery so they do not disappear.

## Why

Resize recovery could drop rows retired from the welcome screen, leaving incomplete terminal history after a resize.

## Verification

- Bun 1.4: `welcome-history-resize.test.ts`
- 2 tests passed, 352 assertions
- Repeated 200 times, totaling 35,200 assertions
- TUI checks and type checks pass