### PR TITLE
test(coding-agent): isolate WSL host context discovery

### DIFF
--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -24,6 +24,7 @@ describe("disabledExtensions runtime filtering", () => {
 	let originalAgentDirEnv: string | undefined;
 	let originalOmpProfileEnv: string | undefined;
 	let originalPiProfileEnv: string | undefined;
+	let originalUserProfile: string | undefined;
 
 	beforeEach(async () => {
 		resetSettingsForTest();
@@ -31,8 +32,10 @@ describe("disabledExtensions runtime filtering", () => {
 		originalOmpProfileEnv = process.env.OMP_PROFILE;
 		originalPiProfileEnv = process.env.PI_PROFILE;
 		originalHome = process.env.HOME;
+		originalUserProfile = process.env.USERPROFILE;
 		tempHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-disabled-ext-home-"));
 		process.env.HOME = tempHomeDir;
+		process.env.USERPROFILE = tempHomeDir;
 		vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir);
 		setAgentDir(path.join(tempHomeDir, ".omp", "agent"));
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-disabled-ext-"));
@@ -56,6 +59,7 @@ describe("disabledExtensions runtime filtering", () => {
 		restoreEnvValue("OMP_PROFILE", originalOmpProfileEnv);
 		restoreEnvValue("PI_PROFILE", originalPiProfileEnv);
 		restoreEnvValue("PI_CODING_AGENT_DIR", originalAgentDirEnv);
+		restoreEnvValue("USERPROFILE", originalUserProfile);
 		__resetDirsFromEnvForTests();
 		await removeWithRetries(tempHomeDir);
 		await removeWithRetries(tempDir);


### PR DESCRIPTION
## What changed

Set `USERPROFILE` to the test temporary home while disabled-extension discovery runs, then restore the original value.

## Why

On WSL, the test could discover the real Windows `.agents/AGENTS.md` instead of using the isolated test home.

## Verification

- 6 disabled-extension tests passed
- Biome passes
- Type checks pass