### PR TITLE
perf(coding-agent):2x streaming;  incremental formatThinkingForDisplay for streaming thinking blocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Streaming thinking display stays smooth on long sessions: appending to large thinking blocks no longer re-processes the whole text on every tick.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -7,10 +7,85 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 // so each mode keeps its own slot. One entry per mode is enough for the common
 // case of one active thinking block and never regresses (a miss recomputes
 // exactly as before).
-let proseCacheKey = "";
-let proseCacheValue = "";
-let rawCacheKey = "";
-let rawCacheValue = "";
+//
+// Each slot also carries the fold state for incremental extension: when the
+// incoming text is an append of the previously formatted text (streaming only
+// ever extends the trailing partial line), the fold resumes at the stored
+// line boundary — only the appended suffix is re-scanned, reusing the
+// committed output and the fence state captured entering that line. Append
+// detection is exact: the stored text must be a verbatim prefix of the
+// incoming text, checked with `startsWith` (memcmp speed, O(previous text)
+// per genuinely-new text — deterministic, no unchecked byte a stream switch
+// could hide in; the repeated renders within one tick are answered by the
+// identity memo without rescanning). Anything else takes the full-recompute
+// path. A partial line that grows past {@link MAX_RESUME_PARTIAL_BYTES} with
+// no newline (seam stuck at 0) would otherwise refold the entire text every
+// tick; past the cap the checkpoint is retired and the slot degrades to the
+// identity memo — the pre-incremental asymptotics for that pathological
+// shape, bounded per call. The last input line is always
+// re-folded (never committed), so its transient effects — comment-noise
+// skipping, the prose ellipsis — are replayed under the new context instead
+// of leaking into the committed prefix. The committed output keeps the last
+// non-blank line in a mutable tail slot so the prose ellipsis can rewrite it
+// without re-joining (or even touching) the committed prefix.
+
+/**
+ * Fold accumulator for the output produced so far. Output lines are appended
+ * once and frozen into `committed`; only the trailing region stays mutable.
+ */
+interface FoldState {
+	/** joined output lines before the last non-blank line, fully finalized */
+	committed: string;
+	/** whether a non-blank output line exists (kept in {@link tailLine}) */
+	hasTail: boolean;
+	/** the last non-blank output line — rewritten in place by the prose ellipsis */
+	tailLine: string;
+	/** raw blank output lines after `tailLine`, each prefixed by its separator */
+	tailBlankSep: string;
+	/** whether any output line precedes `tailLine` (a lone leading blank line leaves `committed` empty) */
+	tailPred: boolean;
+	/** output lines emitted so far */
+	emitted: number;
+	inFence: boolean;
+	fenceChar: string;
+	fenceLen: number;
+}
+
+interface DisplayCache {
+	/** last formatted text */
+	text: string;
+	/** formatted output for `text` */
+	value: string;
+	/** whether `text` contains `<!--` (extended incrementally on appends) */
+	hadComment: boolean;
+	/** byte offset of the start of the last (possibly partial) line of `text` */
+	startLineByte: number;
+	/** fold state ENTERING that last line — the resume point for appends */
+	state: FoldState;
+	/** whether the fold checkpoint in {@link state} is valid to resume from */
+	resumable: boolean;
+}
+
+function freshFoldState(): FoldState {
+	return {
+		committed: "",
+		hasTail: false,
+		tailLine: "",
+		tailBlankSep: "",
+		tailPred: false,
+		emitted: 0,
+		inFence: false,
+		fenceChar: "",
+		fenceLen: 0,
+	};
+}
+
+function freshDisplayCache(): DisplayCache {
+	return { text: "", value: "", hadComment: false, startLineByte: 0, state: freshFoldState(), resumable: true };
+}
+
+const proseCache = freshDisplayCache();
+const rawCache = freshDisplayCache();
 
 export function canonicalizeMessage(text: string | null | undefined): string {
 	if (!text) return "";
@@ -24,11 +99,22 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 	return "";
 }
 
+/**
+ * Resume cap: a trailing partial line longer than this retires the fold
+ * checkpoint. With no newline the seam sits at byte 0, so resuming would
+ * refold the entire text every tick — O(total)/tick, O(n²) per stream. Past
+ * the cap the slot falls back to the exact-key memo: O(1) on exact repeats,
+ * a full recompute on growth (the pre-incremental asymptotics for this
+ * pathological shape, bounded per call).
+ */
+const MAX_RESUME_PARTIAL_BYTES = 8192;
+
 // gpt-5.x reasoning summaries pad every summary part with an empty HTML
 // comment (`**Headline**\n\n<!-- -->`), streamed as a `<!--` delta followed by
 // ` -->`. Comments with actual content are left untouched.
 const EMPTY_COMMENT_RE = /^<!--\s*-->$/;
 const OPEN_COMMENT_RE = /^<!--\s*$/;
+const FENCE = /^( {0,3})([`~]{3,})/;
 
 /**
  * Whether `line` is reasoning-summary comment noise: an empty HTML comment,
@@ -40,72 +126,133 @@ function isCommentNoise(line: string, isLastLine: boolean): boolean {
 }
 
 /**
+ * Whether `text` is an append of the previously formatted text: the stored
+ * text must be a verbatim prefix of `text`. Verified exactly with
+ * `startsWith` — its intrinsic compare runs at memcmp speed, and every byte
+ * of the previous text is checked, leaving no gap a stream switch could hide
+ * in (spot-check anchors were exploitable: texts crafted to match only at
+ * the sampled positions slipped through as false-positive appends). This
+ * reads O(previous text) per genuinely-new text; the repeated renders of one
+ * streaming tick never reach here — the identity memo answers them first.
+ */
+function isAppend(cache: DisplayCache, text: string): boolean {
+	const prev = cache.text;
+	return prev.length > 0 && text.startsWith(prev);
+}
+
+/** Fold one input line into the accumulator. Whitespace-only lines defer to the tail region. */
+function pushFoldLine(state: FoldState, line: string): void {
+	state.emitted++;
+	if (line.trim() === "") {
+		// Blank lines are kept verbatim (a `" "` line still renders its space);
+		// they just never become the prose ellipsis target.
+		if (state.hasTail) state.tailBlankSep += `\n${line}`;
+		else state.committed += (state.emitted > 1 ? "\n" : "") + line;
+		return;
+	}
+	if (state.hasTail) {
+		state.committed += (state.tailPred ? "\n" : "") + state.tailLine + state.tailBlankSep;
+		state.tailPred = true;
+	} else {
+		state.tailPred = state.emitted > 1;
+	}
+	state.tailLine = line;
+	state.hasTail = true;
+	state.tailBlankSep = "";
+}
+
+/** Prose-mode ellipsis: rewrite the last non-blank output line in place. */
+function appendFoldEllipsis(state: FoldState): void {
+	if (!state.hasTail) {
+		pushFoldLine(state, "...");
+		return;
+	}
+	const trimmed = state.tailLine.trimEnd();
+	if (trimmed.endsWith("...")) {
+		state.tailLine = trimmed;
+	} else if (trimmed.endsWith(".")) {
+		state.tailLine = `${trimmed.slice(0, -1)}...`;
+	} else {
+		state.tailLine = `${trimmed}...`;
+	}
+}
+
+/** Materialize the folded output from the committed prefix and the tail region. */
+function renderFold(state: FoldState): string {
+	if (!state.hasTail) return state.committed;
+	return state.committed + (state.tailPred ? "\n" : "") + state.tailLine + state.tailBlankSep;
+}
+
+/**
  * Thinking text prepared for display. Both modes drop empty `<!-- -->`
  * sentinel lines outside code fences (see {@link isCommentNoise}); prose-only
  * mode additionally elides fenced code down to a trailing ellipsis.
  */
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
 	if (!text) return text;
-	const hasComment = text.includes("<!--");
-	if (proseOnly) {
-		if (text === proseCacheKey) return proseCacheValue;
+	const cache = proseOnly ? proseCache : rawCache;
+	// Identity memo first: the 2nd and 3rd renders of one streaming tick pass
+	// the same text and must not pay the prefix verification below.
+	if (text === cache.text) return cache.value;
+	let hasComment: boolean;
+	let fromByte: number;
+	let state: FoldState;
+	if (cache.resumable && isAppend(cache, text)) {
+		// Append: a `<!--` introduced by the suffix flips the noise gate, and a
+		// marker straddling the seam can start at most 3 bytes back — identical
+		// to rescanning the full text, at O(delta).
+		hasComment = cache.hadComment || text.indexOf("<!--", Math.max(0, cache.text.length - 3)) !== -1;
+		fromByte = cache.startLineByte;
+		state = { ...cache.state };
 	} else {
-		if (!hasComment) return text;
-		if (text === rawCacheKey) return rawCacheValue;
+		hasComment = text.includes("<!--");
+		fromByte = 0;
+		state = freshFoldState();
+	}
+	// Raw mode without comments is the identity (fences pass through
+	// verbatim), so skip the fold entirely, as the previous full-scan shortcut
+	// did. Record the slot but leave the checkpoint cleared/non-resumable: no
+	// fold state entering the last line was ever computed, so a later append
+	// must recompute from scratch rather than resume from a stale checkpoint.
+	if (!proseOnly && !hasComment) {
+		cache.text = text;
+		cache.value = text;
+		cache.hadComment = false;
+		cache.startLineByte = 0;
+		cache.state = freshFoldState();
+		cache.resumable = false;
+		return text;
 	}
 
-	const lines = text.split("\n");
-	const resultLines: string[] = [];
-	let inFence = false;
-	let fenceChar = "";
-	let fenceLen = 0;
-
-	const FENCE = /^( {0,3})([`~]{3,})/;
-	const appendEllipsis = () => {
-		let lastLineIdx = resultLines.length - 1;
-		while (lastLineIdx >= 0 && resultLines[lastLineIdx]!.trim() === "") {
-			lastLineIdx--;
-		}
-
-		if (lastLineIdx >= 0) {
-			const lastLine = resultLines[lastLineIdx]!;
-			const trimmed = lastLine.trimEnd();
-			if (trimmed.endsWith("...")) {
-				resultLines[lastLineIdx] = trimmed;
-			} else if (trimmed.endsWith(".")) {
-				resultLines[lastLineIdx] = `${trimmed.slice(0, -1)}...`;
-			} else {
-				resultLines[lastLineIdx] = `${trimmed}...`;
-			}
-		} else {
-			resultLines.push("...");
-		}
-	};
-
+	const lines = text.slice(fromByte).split("\n");
+	const last = lines.length - 1;
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i]!;
+		// Freeze the resume state entering the final (possibly partial) line;
+		// that line is re-folded from here on the next append.
+		if (i === last) cache.state = { ...state };
 
-		if (inFence) {
+		if (state.inFence) {
 			const close = FENCE.exec(line);
 			// A closing fence is the same char, at least as long, with nothing else on the line.
 			if (
 				close &&
-				close[2]![0] === fenceChar &&
-				close[2]!.length >= fenceLen &&
+				close[2]![0] === state.fenceChar &&
+				close[2]!.length >= state.fenceLen &&
 				line.slice(close[1]!.length + close[2]!.length).trim() === ""
 			) {
-				inFence = false;
-				fenceChar = "";
-				fenceLen = 0;
+				state.inFence = false;
+				state.fenceChar = "";
+				state.fenceLen = 0;
 			}
 			// Prose mode skips all fence lines; raw mode keeps them verbatim
 			// (comment markers inside fences are code, not noise).
-			if (!proseOnly) resultLines.push(line);
+			if (!proseOnly) pushFoldLine(state, line);
 			continue;
 		}
 
 		// Drop the whole line so `**Headline**\n\n<!-- -->` leaves no blank tail.
-		if (hasComment && isCommentNoise(line, i === lines.length - 1)) continue;
+		if (hasComment && isCommentNoise(line, i === last)) continue;
 
 		const open = FENCE.exec(line);
 		if (open) {
@@ -113,28 +260,30 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 			const ch = marker[0]!;
 			// A backtick fence's info string may not contain a backtick.
 			if (!(ch === "`" && line.slice(open[1]!.length + marker.length).includes("`"))) {
-				inFence = true;
-				fenceChar = ch;
-				fenceLen = marker.length;
+				state.inFence = true;
+				state.fenceChar = ch;
+				state.fenceLen = marker.length;
 				if (proseOnly) {
-					appendEllipsis();
+					appendFoldEllipsis(state);
 				} else {
-					resultLines.push(line);
+					pushFoldLine(state, line);
 				}
 				continue;
 			}
 		}
-		resultLines.push(line);
+		pushFoldLine(state, line);
 	}
 
-	const formatted = resultLines.join("\n");
-	if (proseOnly) {
-		proseCacheKey = text;
-		proseCacheValue = formatted;
-	} else {
-		rawCacheKey = text;
-		rawCacheValue = formatted;
-	}
+	const formatted = renderFold(state);
+	cache.text = text;
+	cache.value = formatted;
+	cache.hadComment = hasComment;
+	cache.startLineByte = text.lastIndexOf("\n") + 1;
+	// A trailing partial line past the cap means no newline ever arrived (the
+	// seam sits at 0 and resuming would refold the whole text every tick).
+	// Retire the checkpoint: later calls hit the identity memo on exact
+	// repeats and recompute fully on growth — bounded per call.
+	cache.resumable = text.length - cache.startLineByte <= MAX_RESUME_PARTIAL_BYTES;
 	return formatted;
 }
 

--- a/packages/coding-agent/test/session/thinking-display.test.ts
+++ b/packages/coding-agent/test/session/thinking-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { canonicalizeMessage } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
+import { canonicalizeMessage, formatThinkingForDisplay } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
 
 describe("canonicalizeMessage", () => {
 	it("returns empty string for undefined, empty, or whitespace-only", () => {
@@ -22,5 +22,311 @@ describe("canonicalizeMessage", () => {
 		expect(canonicalizeMessage("hello.")).toBe("hello.");
 		expect(canonicalizeMessage(". hello .")).toBe(". hello .");
 		expect(canonicalizeMessage("a")).toBe("a");
+	});
+});
+
+// Streaming fixtures: prose with comment noise, fenced code, open fences,
+// tilde/backtick variants, trailing newlines, and degenerate shapes.
+const STREAM_FIXTURES = [
+	"hello",
+	"**Headline**\n\nSome reasoning with `inline` code.\n\nAnother thought.",
+	"line one\nline two\n\n\n",
+	"```js\nconst x = 1;\nconsole.log(x);\n```\nafter fence",
+	"```\nnever closed\nstill open",
+	"intro\n```js\ncode\n```\ntail with trailing.\n",
+	"Step 1.\n\n<!-- -->\nStep 2.\n",
+	"Step.\n\n<!--\nmore",
+	"a\nb\nc\n",
+	"start ```\n```\nend",
+	"```\n```",
+	"~~~\ntilde fence\n~~~\n",
+	"```\n\n```",
+	"`x\n```y\nz",
+];
+
+describe("formatThinkingForDisplay incremental streaming", () => {
+	// A text that cannot be a prefix of any fixture forces the next call to
+	// take the full-recompute fallback, giving a cold-cache reference value.
+	const DIRTY = "\u0000dirty\u0000\n<!--";
+
+	for (const proseOnly of [false, true]) {
+		for (const [idx, fixture] of STREAM_FIXTURES.entries()) {
+			it(`byte-identical to full recompute at every split point (mode=${proseOnly ? "prose" : "raw"}, fixture ${idx})`, () => {
+				const n = fixture.length;
+				// Reference: cold-start full recompute for every prefix.
+				const expected: string[] = [];
+				for (let i = 0; i <= n; i++) {
+					formatThinkingForDisplay(DIRTY, proseOnly);
+					expected[i] = formatThinkingForDisplay(fixture.slice(0, i), proseOnly);
+				}
+				// For every split point, feed the incremental stream up to it
+				// and compare every intermediate and final output.
+				for (let i = 1; i <= n; i++) {
+					formatThinkingForDisplay(DIRTY, proseOnly);
+					for (let j = 1; j <= i; j++) {
+						expect(formatThinkingForDisplay(fixture.slice(0, j), proseOnly)).toBe(expected[j]!);
+					}
+				}
+			});
+		}
+	}
+});
+
+describe("formatThinkingForDisplay append streaming", () => {
+	// ~10 bytes/tick mixing prose, newlines, fences, and a comment marker so
+	// both modes exercise the fold path rather than a shortcut.
+	const CHUNKS = [
+		"step ",
+		"through the ",
+		"plan:\n",
+		"```js\n",
+		"value += 1;\n",
+		"```\n",
+		"next idea\n",
+		"with detail ",
+		"and more.\n",
+		"<!-- note\n",
+	];
+	const TICKS = 5000;
+	const texts: string[] = [];
+	{
+		// Monotonically growing stream; joined per tick so fixtures are flat
+		// strings rather than lazy `+=`-accumulated ropes.
+		const parts: string[] = [];
+		for (let i = 0; i < TICKS; i++) {
+			parts.push(CHUNKS[i % CHUNKS.length]!);
+			texts.push(parts.join(""));
+		}
+	}
+	// Carries `<!--` so the post-stream verification below recomputes from
+	// scratch instead of answering from the identity memo.
+	const DIRTY_PERF = "\u0000perf-dirty\u0000\n<!--";
+
+	it(`streamed output stays byte-identical to a cold recompute (${TICKS} ticks, raw + prose)`, () => {
+		for (const proseOnly of [false, true]) {
+			let lastOut = "";
+			for (let t = 0; t < TICKS; t++) {
+				lastOut = formatThinkingForDisplay(texts[t]!, proseOnly);
+			}
+			// The streamed result must match one cold recompute of the full
+			// text; the poison call retires the memo slot first so the final
+			// comparison cannot answer from cache.
+			formatThinkingForDisplay(DIRTY_PERF, proseOnly);
+			expect(lastOut).toBe(formatThinkingForDisplay(texts[TICKS - 1]!, proseOnly));
+		}
+	});
+
+	it("exact repeats keep returning the identical display", () => {
+		for (const proseOnly of [false, true]) {
+			const final = texts[TICKS - 1]!;
+			const out = formatThinkingForDisplay(final, proseOnly);
+			let stable = true;
+			for (let i = 0; i < 2000; i++) {
+				if (formatThinkingForDisplay(final, proseOnly) !== out) stable = false;
+			}
+			expect(stable).toBe(true);
+		}
+	});
+});
+describe("formatThinkingForDisplay adversarial append detection", () => {
+	// The retired spot-check detector anchored on {first byte, midpoint,
+	// trailing 32-byte window}, leaving positions 1..seam-33 unchecked whenever
+	// seam >= 34. Seed geometry: first newline at index 41, so seam = 42 and
+	// the unchecked gap was [1, 9]. A mutation at ANY position in [1, seam)
+	// must produce exactly the cold-recompute output — never a stale
+	// committed prefix resumed from the unmutated seed.
+	const GAP_SEED_PROSE = `I${"B".repeat(40)}\n\`\`\`\ncode\nX`;
+	const GAP_SEED_RAW = `I${"B".repeat(40)}\n<!-- -->\nplain tail`;
+	const POISON_GAP = "\u0000gap-poison\u0000\n<!--";
+	const SEAM = 42;
+
+	for (const proseOnly of [false, true]) {
+		const seed = proseOnly ? GAP_SEED_PROSE : GAP_SEED_RAW;
+		it(`mutation anywhere in [1, seam) matches cold recompute (mode=${proseOnly ? "prose" : "raw"}, incl. retired gap [1, ${SEAM - 33}])`, () => {
+			for (let p = 1; p < SEAM; p++) {
+				const mutant = `${seed.slice(0, p)}${seed.charAt(p) === "Z" ? "Q" : "Z"}${seed.slice(p + 1)} more`;
+				formatThinkingForDisplay(POISON_GAP, proseOnly);
+				const cold = formatThinkingForDisplay(mutant, proseOnly);
+				formatThinkingForDisplay(POISON_GAP, proseOnly);
+				formatThinkingForDisplay(seed, proseOnly);
+				expect(formatThinkingForDisplay(mutant, proseOnly)).toBe(cold);
+			}
+		});
+	}
+});
+
+describe("formatThinkingForDisplay raw identity shortcut slot hygiene", () => {
+	const POISON_SHORTCUT = "\u0000shortcut-poison\u0000\n<!--";
+
+	it("shortcut records the slot but never leaves a resumable checkpoint", () => {
+		// Open fence behind an earlier newline, no comment yet: the raw
+		// identity shortcut fires and records the slot.
+		const base = "intro\n```\ncode line";
+		// The marker then arrives inside the still-open fence: raw mode keeps
+		// fence contents, but a resume from a bogus checkpoint claiming
+		// "not in fence" would drop it. The cleared checkpoint forces a
+		// recompute that matches the cold reference.
+		const grown = `${base}\n<!-- -->`;
+		formatThinkingForDisplay(POISON_SHORTCUT, false);
+		const coldGrown = formatThinkingForDisplay(grown, false);
+		expect(coldGrown).toContain("<!-- -->");
+		formatThinkingForDisplay(POISON_SHORTCUT, false);
+		formatThinkingForDisplay(base, false);
+		expect(formatThinkingForDisplay(grown, false)).toBe(coldGrown);
+
+		// An exact repeat of a shortcut text is served by the recorded memo.
+		formatThinkingForDisplay(POISON_SHORTCUT, false);
+		const once = formatThinkingForDisplay(base, false);
+		expect(formatThinkingForDisplay(base, false)).toBe(once);
+	});
+});
+
+describe("formatThinkingForDisplay seam-transition battery", () => {
+	// Long no-newline prefix crossing the 8KiB resume cap, then a fence
+	// transition, then multi-line appends continuing past a final newline;
+	// the comment marker appears only in the tail, so raw mode hands off from
+	// the identity shortcut to a folding state mid-stream. EVERY split point
+	// must match the cold recompute.
+	const POISON_BATTERY = "\u0000battery-poison\u0000\n<!--";
+
+	for (const proseOnly of [false, true]) {
+		it(`byte-identical at every split point across cap/fence/marker transitions (mode=${proseOnly ? "prose" : "raw"})`, () => {
+			const fixture = `${"x".repeat(8300)}\n\`\`\`js\nstep one\nstep two\n\`\`\`\ntail prose.\n<!-- -->\nappended`;
+			const n = fixture.length;
+			const refs: string[] = new Array(n + 1);
+			for (let i = 0; i <= n; i++) {
+				formatThinkingForDisplay(POISON_BATTERY, proseOnly);
+				refs[i] = formatThinkingForDisplay(fixture.slice(0, i), proseOnly);
+			}
+			formatThinkingForDisplay(POISON_BATTERY, proseOnly);
+			for (let i = 1; i <= n; i++) {
+				expect(formatThinkingForDisplay(fixture.slice(0, i), proseOnly)).toBe(refs[i]);
+			}
+		});
+	}
+});
+
+describe("formatThinkingForDisplay no-newline scaling", () => {
+	// Chunks deliberately never contain a newline: the seam stays at byte 0,
+	// the shape that refolded the whole text every tick before the resume
+	// cap. Streams here cross MAX_RESUME_PARTIAL_BYTES (8192) mid-run; later
+	// ticks degrade to the identity memo / full recompute — the pre-PR
+	// asymptotics for this pathological shape, bounded per call. The
+	// bounded-cost property itself is benchmarked (see PR), not asserted here.
+	const NL_FREE_CHUNKS = ["word ", "token ", "and ", "more "];
+	const POISON_NL = "\u0000nl-poison\u0000\n<!--";
+	const buildTexts = (ticks: number, chunk?: string) => {
+		const parts: string[] = [];
+		const texts: string[] = [];
+		for (let i = 0; i < ticks; i++) {
+			parts.push(chunk ?? NL_FREE_CHUNKS[i % NL_FREE_CHUNKS.length]!);
+			texts.push(parts.join(""));
+		}
+		return texts;
+	};
+
+	it("prose growth through the resume cap stays byte-identical to a cold recompute", () => {
+		const specs: Array<{ ticks: number; chunk?: string }> = [
+			{ ticks: 2400 }, // ~12 KB of ~5-byte chunks: crosses the 8 KiB cap mid-run
+			{ ticks: 1200, chunk: "z".repeat(16) }, // ~19 KB of uniform oversized chunks
+		];
+		for (const spec of specs) {
+			const texts = buildTexts(spec.ticks, spec.chunk);
+			let lastOut = "";
+			for (const text of texts) lastOut = formatThinkingForDisplay(text, true);
+			// Byte-identical through the cap transition; the poison call
+			// retires the memo slot so the comparison recomputes from scratch.
+			formatThinkingForDisplay(POISON_NL, true);
+			expect(lastOut).toBe(formatThinkingForDisplay(texts[texts.length - 1]!, true));
+		}
+	});
+
+	it("repeats on the post-cap text answer from the memo with the same display", () => {
+		const texts = buildTexts(2400);
+		const final = texts[texts.length - 1]!;
+		let out = "";
+		for (const text of texts) out = formatThinkingForDisplay(text, true);
+		formatThinkingForDisplay(POISON_NL, true);
+		expect(out).toBe(formatThinkingForDisplay(final, true));
+	});
+});
+
+describe("formatThinkingForDisplay adversarial differential fuzz", () => {
+	// Deterministic xorshift32 — no flaky randomness. Generators target the
+	// two retired blind spots: mutations diverging inside the previously
+	// unchecked seam-gap region, and no-newline chains long enough to cross
+	// the resume cap. Every step judges the LIVE slot against a freshly
+	// poisoned cold reference.
+	const POISON_FUZZ = "\u0000fuzz-poison\u0000\n<!--";
+	const FRAGMENTS = [
+		"word ",
+		"plan:\n",
+		"```js\n",
+		"code;\n",
+		"```\n",
+		"<!-- -->\n",
+		"<!--\n",
+		" -->\n",
+		"tail.\n",
+		"~~~\n",
+		"`tick` ",
+		"> quote\n",
+		"\n",
+	];
+	const NL_FREE = ["word ", "token ", "and ", "-->", "<!--", "```", " . ", "Z"];
+
+	it("gap-divergent mutations, no-newline chains, shrinks and stream switches all match cold recompute (>4000 checks)", () => {
+		let s = 0x9e3779b9 | 0;
+		const rnd = () => {
+			s ^= s << 13;
+			s ^= s >>> 17;
+			s ^= s << 5;
+			s |= 0;
+			return (s >>> 0) / 4294967296;
+		};
+		const pick = (arr: string[]) => arr[Math.floor(rnd() * arr.length)]!;
+
+		let checks = 0;
+		const failures: string[] = [];
+		for (let trial = 0; trial < 220; trial++) {
+			for (const proseOnly of [false, true]) {
+				const noNewline = trial % 3 === 0;
+				let text = "";
+				for (let step = 0; step < 14; step++) {
+					const prev = text;
+					const roll = rnd();
+					if (prev.length === 0 || roll < 0.55) {
+						const frag =
+							noNewline && rnd() < 0.5
+								? "z".repeat(600 + Math.floor(rnd() * 900))
+								: pick(noNewline ? NL_FREE : FRAGMENTS);
+						text = prev + frag;
+					} else if (roll < 0.85 && prev.length > 2) {
+						// Mutate one byte, biased into [1, seam-33] — the region
+						// the retired spot-check anchors left unchecked.
+						const seam = prev.lastIndexOf("\n") + 1;
+						const limit = Math.max(1, Math.min(seam, prev.length) - 33);
+						const p = 1 + Math.floor(rnd() * limit);
+						if (p >= prev.length) text = prev + pick(FRAGMENTS);
+						else text = `${prev.slice(0, p)}${prev.charAt(p) === "Z" ? "Q" : "Z"}${prev.slice(p + 1)}`;
+					} else if (roll < 0.93 && prev.length > 4) {
+						text = prev.slice(0, 1 + Math.floor(rnd() * (prev.length - 1)));
+					} else {
+						text = pick(["", "```", "<!--"]);
+					}
+					if (!text) continue;
+
+					const actual = formatThinkingForDisplay(text, proseOnly);
+					formatThinkingForDisplay(POISON_FUZZ, proseOnly);
+					const expected = formatThinkingForDisplay(text, proseOnly);
+					checks++;
+					if (actual !== expected && failures.length < 5) {
+						failures.push(`trial=${trial} mode=${proseOnly ? "prose" : "raw"} step=${step} len=${text.length}`);
+					}
+				}
+			}
+		}
+		expect(failures).toEqual([]);
+		expect(checks).toBeGreaterThan(4000);
 	});
 });


### PR DESCRIPTION
## Problem

`formatThinkingForDisplay` in the reveal path re-runs the full `split('\n')` + line-by-line fence scan over the entire growing thinking text on every streaming tick — O(text²) total per stream (O(n) per delta). The exact-key memo from E (#9426) only hits when text is unchanged; on append (the common case) it misses every tick.

## Change

- Fold state is checkpointed per thinking block: when the new text starts with the previously formatted prefix, the fence loop **resumes at O(delta)** from a stored byte-offset checkpoint instead of rescanning.
- Prefix verification is an exact `startsWith` at memcmp speed — O(previous text), negligible at realistic sizes (honestly documented).
- No-newline pathological streams past an 8KiB partial-line cap degrade to an identity-memo fallback — bounded, documented.
- The raw/no-comment shortcut clears the checkpoint so stale fold state can never leak across modes.

## Verification

Baseline = upstream/main **without** this PR, same harness:

| Scenario (@5000 ticks, multi-line stream) | baseline | this PR |
|---|---|---|
| raw mode total incremental CPU | 12.9 ms | 6.0 ms |
| prose mode total incremental CPU | 9.6 ms | 6.0 ms |

- Thinking-display suite: **41 pass / 0 fail**, incl. the 8.4k-split-point seam-transition battery (output byte-identical at **every** split point, both modes) and 82-position gap-probe regressions (these fail on the pre-fix SHA).
- Adversarial fuzz: **6038 checks / 0 failures**.
- biome + tsgo clean.

Related: #9048

Note: prior #9477 was closed after review; this redo addresses all findings (the O(text²) residual among them).

