### PR TITLE
test(tui): cover physical Option forward delete

### DIFF
--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -39,6 +39,20 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[127;5u"); // kitty CSI-u ctrl+backspace
 			expect(editor.getText()).toBe("alfa beta ");
 		});
+
+		it("deletes the next word for Ghostty's physical Option+Forward-Delete wire", () => {
+			setKittyProtocolActive(true);
+			try {
+				const editor = new Editor(defaultEditorTheme);
+				editor.setText("foo bar baz");
+				editor.handleInput("\x01"); // Ctrl+A
+				for (let i = 0; i < 3; i++) editor.handleInput("\x1b[C"); // After "foo"
+				editor.handleInput("\x1b[3;11~"); // Ghostty Option+Forward-Delete
+				expect(editor.getText()).toBe("foo baz");
+			} finally {
+				setKittyProtocolActive(false);
+			}
+		});
 	});
 
 	describe("Submit/newline keybindings", () => {


### PR DESCRIPTION
## Summary

- cover Ghostty/macOS physical Option+Forward-Delete (`ESC[3;11~`) through the actual Editor input path
- verify the existing decoder and keybinding route deletes the next word
- keep runtime behavior unchanged because the implementation was already correct

## Verification

- `bun test packages/tui/test/editor.test.ts packages/tui/test/keys.test.ts` — 202 passed, 0 failed
- `bun run --cwd packages/tui check`
- actual input smoke decoded both physical Option deletion wires and transformed `foo bar baz` to `foo baz`
