### PR TITLE
fix(coding-agent): restore discovery-backed models on session resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `omp --resume`/`--continue` now restores discovery-backed session models (models.yml `discovery:` providers such as `openai-models-list`/`litellm`) instead of silently falling back to the default role ([#9502](https://github.com/can1357/oh-my-pi/issues/9502)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -208,6 +208,7 @@ export class ModelRegistry {
 	#suppressedSelectors: Map<string, number> = new Map();
 	#backgroundRefresh?: Promise<void>;
 	#credentialScopedCacheHydration?: Promise<void>;
+	#configuredDiscoveryInFlight: Map<string, Promise<Model<Api>[]>> = new Map();
 	#policyReapply?: Promise<void>;
 	#lastDiscoveryWarnings: Map<string, string> = new Map();
 	// Runtime extension model overlays — persist across refresh() cycles so that
@@ -1254,7 +1255,9 @@ export class ModelRegistry {
 			selectedDiscoverableProviders.length === 0
 				? Promise.resolve<Model<Api>[]>([])
 				: Promise.all(
-						selectedDiscoverableProviders.map(provider => this.#discoverProviderModels(provider, strategy)),
+						selectedDiscoverableProviders.map(provider =>
+							this.#discoverProviderModelsCoalesced(provider, strategy),
+						),
 					).then(results => results.flat());
 		const [configuredDiscovered, builtInDiscovery] = await Promise.all([
 			configuredDiscoveriesPromise,
@@ -1310,6 +1313,27 @@ export class ModelRegistry {
 			this.#applyRuntimeProviderOverrides(withProviderGuardrails),
 		);
 		this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+	}
+
+	/**
+	 * Share a configured provider's discovery request between concurrent full
+	 * and provider-scoped refreshes using the same cache/network strategy.
+	 */
+	#discoverProviderModelsCoalesced(
+		providerConfig: DiscoveryProviderConfig,
+		strategy: ModelRefreshStrategy,
+	): Promise<Model<Api>[]> {
+		const key = `${providerConfig.provider}\0${strategy}`;
+		const inFlight = this.#configuredDiscoveryInFlight.get(key);
+		if (inFlight) return inFlight;
+
+		const discovery = this.#discoverProviderModels(providerConfig, strategy).finally(() => {
+			if (this.#configuredDiscoveryInFlight.get(key) === discovery) {
+				this.#configuredDiscoveryInFlight.delete(key);
+			}
+		});
+		this.#configuredDiscoveryInFlight.set(key, discovery);
+		return discovery;
 	}
 
 	#configuredDiscoveryCacheProviderId(providerConfig: DiscoveryProviderConfig): string {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -421,6 +421,25 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Refresh only the named discovery-backed providers, leaving every other
+	 * provider's discovered models and any in-flight runtime discovery untouched.
+	 *
+	 * Unlike {@link refreshProvider}, this does no static reload and never
+	 * re-fetches the other runtime managers, so restoring a saved
+	 * discovery-backed model (e.g. on `omp --resume`) cannot wait on — or
+	 * duplicate — an unrelated provider's network/OAuth work. Ids that are not
+	 * configured discovery providers are ignored by the underlying filter.
+	 */
+	async refreshDiscoverableProviders(
+		providerIds: Iterable<string>,
+		strategy: ModelRefreshStrategy = "online-if-uncached",
+	): Promise<void> {
+		const filter = new Set(providerIds);
+		if (filter.size === 0) return;
+		await this.#refreshRuntimeDiscoveries(strategy, filter);
+	}
+
+	/**
 	 * True when the provider's models expose context metadata that only appears
 	 * after a lazy load — llama.cpp's `meta.n_ctx` once a cold instance spins up
 	 * (#3310/#3311), LM Studio's `loaded_context_length` once it JIT-loads the

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2180,24 +2180,33 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				// The saved candidates weren't in the static+cached catalog. If any
 				// belongs to a discovery-backed provider that hasn't been fetched
 				// yet (models.yml `discovery:` — openai-models-list/litellm/proxy/…),
-				// trigger one cache-aware discovery pass and retry before resume
-				// silently downgrades to the default role. Mirrors the deferred
-				// `--model` (resolveModelDiscoveryFallbackNonRuntime) and default-role
-				// fallback paths, which already refresh discoverable providers.
+				// trigger a cache-aware discovery pass and retry before resume
+				// silently downgrades to the default role. Scope the refresh to the
+				// saved candidates' providers via `refreshProvider`: a full
+				// `refresh()` would preflight every configured provider (an
+				// unreachable OAuth broker could hang resume) and duplicate the
+				// runtime discovery already started above.
 				const discoverableProviders = new Set(modelRegistry.getDiscoverableProviders());
-				const hasDiscoverableCandidate =
-					discoverableProviders.size > 0 &&
-					sessionModelStrings.slice(0, sessionRetryLimit).some(sessionModelStr => {
+				const candidateProviders = new Set<string>();
+				if (discoverableProviders.size > 0) {
+					for (const sessionModelStr of sessionModelStrings.slice(0, sessionRetryLimit)) {
 						const parsedModel = parseModelString(sessionModelStr, {
 							allowMaxSuffix: true,
 							allowAutoAlias: true,
 							isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
 						});
-						return parsedModel ? discoverableProviders.has(parsedModel.provider) : false;
-					});
-				if (hasDiscoverableCandidate) {
+						if (parsedModel && discoverableProviders.has(parsedModel.provider)) {
+							candidateProviders.add(parsedModel.provider);
+						}
+					}
+				}
+				if (candidateProviders.size > 0) {
 					await logger.time("restoreSessionModelDiscoveryFallback", () =>
-						modelRegistry.refresh("online-if-uncached"),
+						Promise.all(
+							[...candidateProviders].map(provider =>
+								modelRegistry.refreshProvider(provider, "online-if-uncached"),
+							),
+						),
 					);
 					restoreSessionModel();
 				}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2144,33 +2144,62 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// honors the last active role in either case.
 		const sessionRetryLimit = restoredSessionModelIndex >= 0 ? restoredSessionModelIndex : sessionModelStrings.length;
 		if (!hasExplicitModel && sessionRetryLimit > 0) {
-			for (let i = 0; i < sessionRetryLimit; i++) {
-				const sessionModelStr = sessionModelStrings[i];
-				const parsedModel = parseModelString(sessionModelStr, {
-					allowMaxSuffix: true,
-					allowAutoAlias: true,
-					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
-				});
-				if (!parsedModel) continue;
-				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
-				if (restoredModel && hasModelAuth(restoredModel)) {
-					model = restoredModel;
-					modelFallbackMessage = undefined;
-					restoredSessionModelIndex = i;
-					restoredSessionThinkingLevel = parsedModel.thinkingLevel;
-					// Recompute thinking-level from scratch against the reclaimed
-					// model: any value derived from the earlier fallback model's
-					// `thinking.defaultLevel` must not become sticky.
-					thinkingLevel = pickInitialThinkingLevel(restoredModel);
-					autoThinking = thinkingLevel === AUTO_THINKING;
-					effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
-					effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
-						autoThinking
-							? resolveProvisionalAutoLevel(restoredModel)
-							: resolveThinkingLevelForModel(restoredModel, effectiveThinkingLevel),
+			const restoreSessionModel = (): boolean => {
+				for (let i = 0; i < sessionRetryLimit; i++) {
+					const sessionModelStr = sessionModelStrings[i];
+					const parsedModel = parseModelString(sessionModelStr, {
+						allowMaxSuffix: true,
+						allowAutoAlias: true,
+						isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+					});
+					if (!parsedModel) continue;
+					const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
+					if (restoredModel && hasModelAuth(restoredModel)) {
+						model = restoredModel;
+						modelFallbackMessage = undefined;
+						restoredSessionModelIndex = i;
+						restoredSessionThinkingLevel = parsedModel.thinkingLevel;
+						// Recompute thinking-level from scratch against the reclaimed
+						// model: any value derived from the earlier fallback model's
+						// `thinking.defaultLevel` must not become sticky.
+						thinkingLevel = pickInitialThinkingLevel(restoredModel);
+						autoThinking = thinkingLevel === AUTO_THINKING;
+						effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
+						effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
+							autoThinking
+								? resolveProvisionalAutoLevel(restoredModel)
+								: resolveThinkingLevelForModel(restoredModel, effectiveThinkingLevel),
+						);
+						preconnectModelHost(restoredModel.baseUrl);
+						return true;
+					}
+				}
+				return false;
+			};
+			if (!restoreSessionModel()) {
+				// The saved candidates weren't in the static+cached catalog. If any
+				// belongs to a discovery-backed provider that hasn't been fetched
+				// yet (models.yml `discovery:` — openai-models-list/litellm/proxy/…),
+				// trigger one cache-aware discovery pass and retry before resume
+				// silently downgrades to the default role. Mirrors the deferred
+				// `--model` (resolveModelDiscoveryFallbackNonRuntime) and default-role
+				// fallback paths, which already refresh discoverable providers.
+				const discoverableProviders = new Set(modelRegistry.getDiscoverableProviders());
+				const hasDiscoverableCandidate =
+					discoverableProviders.size > 0 &&
+					sessionModelStrings.slice(0, sessionRetryLimit).some(sessionModelStr => {
+						const parsedModel = parseModelString(sessionModelStr, {
+							allowMaxSuffix: true,
+							allowAutoAlias: true,
+							isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+						});
+						return parsedModel ? discoverableProviders.has(parsedModel.provider) : false;
+					});
+				if (hasDiscoverableCandidate) {
+					await logger.time("restoreSessionModelDiscoveryFallback", () =>
+						modelRegistry.refresh("online-if-uncached"),
 					);
-					preconnectModelHost(restoredModel.baseUrl);
-					break;
+					restoreSessionModel();
 				}
 			}
 		}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2180,12 +2180,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				// The saved candidates weren't in the static+cached catalog. If any
 				// belongs to a discovery-backed provider that hasn't been fetched
 				// yet (models.yml `discovery:` — openai-models-list/litellm/proxy/…),
-				// trigger a cache-aware discovery pass and retry before resume
-				// silently downgrades to the default role. Scope the refresh to the
-				// saved candidates' providers via `refreshProvider`: a full
-				// `refresh()` would preflight every configured provider (an
-				// unreachable OAuth broker could hang resume) and duplicate the
-				// runtime discovery already started above.
+				// trigger a cache-aware, provider-scoped discovery pass and retry
+				// before resume silently downgrades to the default role. The
+				// registry coalesces this with any matching request already running
+				// in the SDK's startup background refresh.
 				const discoverableProviders = new Set(modelRegistry.getDiscoverableProviders());
 				const candidateProviders = new Set<string>();
 				if (discoverableProviders.size > 0) {
@@ -2201,11 +2199,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					}
 				}
 				if (candidateProviders.size > 0) {
-					// Scoped to just these providers: `refreshDiscoverableProviders`
-					// skips the static reload and the all-other-runtime restore that
-					// `refreshProvider` performs, so resume never waits on (or
-					// double-fetches) an unrelated runtime provider already being
-					// discovered by `startRuntimeDiscovery` above.
+					// This skips the static reload and all-other-runtime restore
+					// performed by `refreshProvider`, so unrelated runtime providers
+					// continue independently.
 					await logger.time("restoreSessionModelDiscoveryFallback", () =>
 						modelRegistry.refreshDiscoverableProviders(candidateProviders, "online-if-uncached"),
 					);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2201,12 +2201,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					}
 				}
 				if (candidateProviders.size > 0) {
+					// Scoped to just these providers: `refreshDiscoverableProviders`
+					// skips the static reload and the all-other-runtime restore that
+					// `refreshProvider` performs, so resume never waits on (or
+					// double-fetches) an unrelated runtime provider already being
+					// discovered by `startRuntimeDiscovery` above.
 					await logger.time("restoreSessionModelDiscoveryFallback", () =>
-						Promise.all(
-							[...candidateProviders].map(provider =>
-								modelRegistry.refreshProvider(provider, "online-if-uncached"),
-							),
-						),
+						modelRegistry.refreshDiscoverableProviders(candidateProviders, "online-if-uncached"),
 					);
 					restoreSessionModel();
 				}

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -208,6 +208,43 @@ describe("ModelRegistry runtime discovery", () => {
 		};
 	}
 
+	test("scoped discovery coalesces with an in-flight background refresh", async () => {
+		writeRawModelsJson({
+			gateway: {
+				baseUrl: "http://127.0.0.1:9992",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "openai-models-list" },
+			},
+		});
+		const { promise, resolve } = Promise.withResolvers<Response>();
+		const started = Promise.withResolvers<void>();
+		let modelListCalls = 0;
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:9992/v1/models") {
+				modelListCalls++;
+				started.resolve();
+				return promise;
+			}
+			return new Response("", { status: 404 });
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+		registry.refreshInBackground();
+		await started.promise;
+		expect(modelListCalls).toBe(1);
+
+		const scopedRefresh = registry.refreshDiscoverableProviders(["gateway"], "online-if-uncached");
+		expect(modelListCalls).toBe(1);
+
+		resolve(Response.json({ data: [{ id: "dynamic-model", context_length: 65_536 }] }));
+		await Promise.all([scopedRefresh, registry.awaitBackgroundRefresh()]);
+
+		expect(modelListCalls).toBe(1);
+		expect(registry.find("gateway", "dynamic-model")).toBeDefined();
+	});
+
 	test("refreshProvider online refreshes expired anthropic OAuth before model discovery", async () => {
 		const { refreshCalls } = await useAuthStorageWithRefreshTracker();
 		await authStorage.set("anthropic", {

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1123,6 +1123,103 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("restores a discovery-backed session model instead of falling back to the default role", async () => {
+		// Regression: on `omp --resume`, the session-model restore probed
+		// candidates only against the static+cached catalog. A discovery-backed
+		// provider (models.yml `discovery:`) hasn't been fetched at that point, so
+		// the saved model failed to resolve and resume silently downgraded to
+		// modelRoles.default. The restore path now triggers a cache-aware
+		// discovery refresh when a saved candidate belongs to a discoverable
+		// provider.
+		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) {
+			throw new Error("Expected bundled anthropic default model");
+		}
+
+		const authStorage = createInMemoryAuthStorage();
+		authStoragesToClose.push(authStorage);
+		// A resolvable default role gives the buggy path a concrete model to wrongly
+		// fall back to (mirrors a real config with Claude as the default role).
+		authStorage.setRuntimeApiKey(defaultModel.provider, "test-key");
+
+		const modelsPath = path.join(tempDir, "models.yml");
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					gateway: {
+						baseUrl: "http://127.0.0.1:9994",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+
+		let modelListCalls = 0;
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:9994/v1/models") {
+				modelListCalls++;
+				return Response.json({ data: [{ id: "dynamic-model", context_length: 65_536 }] });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath, { fetch: fetchMock });
+
+		const targetSessionFile = path.join(tempDir, "resume-discovery-model.jsonl");
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-discovery", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "dynamic-model-change",
+					parentId: null,
+					timestamp,
+					model: "gateway/dynamic-model",
+					role: "default",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(
+			targetSessionFile,
+			path.join(tempDir, "resume-discovery-sessions"),
+		);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated({ modelRoles: { default: `${defaultModel.provider}/${defaultModel.id}` } }),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+		});
+
+		try {
+			expect(modelListCalls).toBeGreaterThan(0);
+			expect(session.model?.provider).toBe("gateway");
+			expect(session.model?.id).toBe("dynamic-model");
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	test("prefers the provider default over catalog order in the startup fallback", async () => {
 		// Regression: with an Anthropic key but no configured `default` role and no
 		// session/CLI model, the step-4 startup fallback used to pick the first

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1153,16 +1153,29 @@ describe("createAgentSession deferred model pattern resolution", () => {
 						auth: "none",
 						discovery: { type: "openai-models-list" },
 					},
+					// An unrelated discovery provider: the saved model does not belong
+					// to it, so the scoped resume refresh must never fetch its endpoint.
+					"other-gateway": {
+						baseUrl: "http://127.0.0.1:9993",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
 				},
 			}),
 		);
 
 		let modelListCalls = 0;
+		let otherListCalls = 0;
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
 			if (url === "http://127.0.0.1:9994/v1/models") {
 				modelListCalls++;
 				return Response.json({ data: [{ id: "dynamic-model", context_length: 65_536 }] });
+			}
+			if (url === "http://127.0.0.1:9993/v1/models") {
+				otherListCalls++;
+				return Response.json({ data: [{ id: "other-model", context_length: 65_536 }] });
 			}
 			throw new Error(`Unexpected URL: ${url}`);
 		};
@@ -1213,6 +1226,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 
 		try {
 			expect(modelListCalls).toBeGreaterThan(0);
+			expect(otherListCalls).toBe(0);
 			expect(session.model?.provider).toBe("gateway");
 			expect(session.model?.id).toBe("dynamic-model");
 		} finally {


### PR DESCRIPTION
## Repro
`omp --resume <id>` (and `--continue`) on a session whose last-active model came from a config-discovery provider (`providers.<name>.discovery` in `models.yml` — `openai-models-list`, `litellm`, `proxy`, …) silently restores `modelRoles.default` instead of the saved model. Reproduced with a regression test that resumes a session saved as `gateway/dynamic-model` (an `openai-models-list` provider) while a resolvable `modelRoles.default` (Claude) is configured: `bun test test/sdk-model-selection.test.ts -t "discovery-backed session model"`. With the pre-fix restore path the discovery `/v1/models` fetch is never issued (`modelListCalls === 0`) and `session.model` is the default role, not `gateway/dynamic-model`.

## Cause
Session-model restoration in `createAgentSession` (`packages/coding-agent/src/sdk.ts`) probes each saved candidate only with `modelRegistry.find(provider, id)` — first in the early pass (1490-1518) and again in the post-extension retry pass (2145-2176). `find` sees only the static + cached catalog; config-discovery providers have not been fetched at that point. Unlike the deferred `--model` path (`resolveModelDiscoveryFallbackNonRuntime`, 2215-2219) and the default-role fallback (2543), which both `await modelRegistry.refresh("online-if-uncached")` when `getDiscoverableProviders()` is non-empty, the restore loop never triggered discovery. So the saved model failed to resolve, `model` was filled by the settings default (1522), and the default-role block (2477) was skipped because `model` was already set.

## Fix
- Extracted the retry-pass loop into a `restoreSessionModel()` closure in `sdk.ts`.
- When the first retry finds nothing and any saved candidate (within the retry range) belongs to a provider in `modelRegistry.getDiscoverableProviders()`, `await modelRegistry.refresh("online-if-uncached")` once, then retry — mirroring the existing `--model`/default-role discovery-fallback pattern. The common path (candidate already in the catalog, or no discoverable candidate) skips the refresh.
- Added a regression test and a changelog entry.

## Verification
`bun test test/sdk-model-selection.test.ts` — 35 pass, 0 fail. Confirmed the new test fails (`modelListCalls === 0`) when the discovery-fallback branch is disabled and passes with it restored. `bun check` ran clean via the pre-publish gate.

Fixes #9502