### PR TITLE
fix(agent): review subagent final yield in advisor

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `onTurnEnd` now runs for a turn stopped by a terminal-tool-result abort (e.g. a subagent's final `yield`) instead of being skipped as an external abort, so per-turn bookkeeping observes the yield turn.
+
 ## [18.0.0] - 2026-08-22
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -623,6 +623,15 @@ function buildAgentEndEvent(
  * Push a `turn_end` event and run the awaited per-turn hook when the run is
  * still healthy. The hook is skipped for externally aborted or errored turns so
  * a user interrupt does not hang on a background backlog wait.
+ *
+ * A {@link TERMINAL_TOOL_RESULT_ABORT_REASON} abort is the exception: it is a
+ * graceful yield (e.g. a subagent's final `yield` tool), not a user interrupt.
+ * The completed tool batch is persisted and the turn must still reach
+ * `onTurnEnd` so per-turn bookkeeping — notably advisor review of the yield
+ * delta (#9505) — runs exactly as it does for a plain end-of-turn message. The
+ * hook receives no signal in that case so downstream waits (advisor catch-up)
+ * behave identically to a normal final turn instead of short-circuiting on the
+ * spent abort.
  */
 async function emitTurnEnd(
 	stream: EventStream<AgentEvent, AgentMessage[]>,
@@ -635,10 +644,16 @@ async function emitTurnEnd(
 	runHookOnAbortedMessage = false,
 ): Promise<void> {
 	stream.push({ type: "turn_end", message, toolResults });
+	const terminalYield = signal?.reason === TERMINAL_TOOL_RESULT_ABORT_REASON;
 	const isAbortedOrError =
 		message.role === "assistant" && (message.stopReason === "aborted" || message.stopReason === "error");
-	if (signal?.aborted || (isAbortedOrError && !runHookOnAbortedMessage)) return;
-	await config.onTurnEnd?.(currentContext.messages, signal, { message, toolResults, willContinue: false, ...context });
+	if ((signal?.aborted && !terminalYield) || (isAbortedOrError && !runHookOnAbortedMessage)) return;
+	await config.onTurnEnd?.(currentContext.messages, terminalYield ? undefined : signal, {
+		message,
+		toolResults,
+		willContinue: false,
+		...context,
+	});
 }
 
 function createGateStopMessage(model: Model, reason: string | undefined): AssistantMessage {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -4414,6 +4414,48 @@ describe("agentLoopContinue with AgentMessage", () => {
 		).toBe(false);
 	});
 
+	it("runs onTurnEnd for a terminal-yield turn without a spent abort signal", async () => {
+		const toolSchema = type({ value: "string" });
+		const controller = new AbortController();
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "yield",
+			label: "Yield",
+			description: "Yield tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return { content: [{ type: "text", text: params.value }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "yield-1", name: "yield", arguments: { value: "final answer" } }] },
+				{ content: ["must not be reached"] },
+			],
+		});
+		const turnEndCalls: Array<{ willContinue: boolean | undefined; signalAborted: boolean }> = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			afterToolCall: async () => {
+				controller.abort(TERMINAL_TOOL_RESULT_ABORT_REASON);
+			},
+			onTurnEnd: (_messages, signal, ctx) => {
+				turnEndCalls.push({ willContinue: ctx?.willContinue, signalAborted: signal?.aborted === true });
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("go")], context, config, controller.signal, mock.stream);
+		for await (const event of stream) events.push(event);
+
+		// The terminal-yield abort must not suppress per-turn bookkeeping: the
+		// hook runs once for the yield turn, marked complete (willContinue:false)
+		// and with no aborted signal so downstream waits behave like a plain turn.
+		expect(mock.calls).toHaveLength(1);
+		expect(turnEndCalls).toEqual([{ willContinue: false, signalAborted: false }]);
+	});
+
 	it("preserves an external abort boundary when a completed tool ignores cancellation", async () => {
 		const toolSchema = type({ value: "string" });
 		const controller = new AbortController();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Subagent advisors now review the final `yield`: the yield turn is delivered to the advisor and its review is drained before the subagent session is disposed, instead of being abandoned at teardown ([#9505](https://github.com/can1357/oh-my-pi/issues/9505)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2445,6 +2445,15 @@ export async function finalizeSubagentLifecycle(args: {
 	const ownsRef = Boolean(ref && ref.session === args.session);
 	const cleanupDeadlineAt = args.cleanupDeadlineAt ?? Date.now() + 5000;
 	const disposeSession = async (): Promise<void> => {
+		// On a graceful finish (e.g. a `yield`) the advisor's review of the final
+		// turn was enqueued at turn end but may still be draining. Give it a
+		// chance to land in the transcript before the runtime is torn down —
+		// mirroring print mode's headless drain — bounded by the shared cleanup
+		// deadline. Hard aborts skip this to keep kill teardown fast.
+		if (!args.aborted) {
+			args.session.prepareForHeadlessAdvisorDrain();
+			await args.session.waitForAdvisorCatchup(Math.max(0, cleanupDeadlineAt - Date.now()));
+		}
 		const disposal = args.session.dispose();
 		const remainingMs = Math.max(0, cleanupDeadlineAt - Date.now());
 		try {

--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -402,9 +402,18 @@ describe("runEvalAgent", () => {
 	it("unregisters eval subagents through the bridge cleanup path", async () => {
 		AgentRegistry.resetGlobalForTests();
 		mockAgents();
+		const order: string[] = [];
 		let disposed = false;
 		const cleanupSession = {
+			prepareForHeadlessAdvisorDrain: () => {
+				order.push("prepare");
+			},
+			waitForAdvisorCatchup: async () => {
+				order.push("catchup");
+				return true;
+			},
 			dispose: async () => {
+				order.push("dispose");
 				disposed = true;
 			},
 		} as unknown as AgentSession;
@@ -431,6 +440,9 @@ describe("runEvalAgent", () => {
 		await runEvalAgent({ prompt: "hello", label: "Cleanup" }, { session: makeSession() });
 
 		expect(disposed).toBe(true);
+		// The advisor's final-turn review is drained before the runtime is torn
+		// down (#9505): a graceful subagent finish must not abandon the yield.
+		expect(order).toEqual(["prepare", "catchup", "dispose"]);
 		expect(AgentRegistry.global().get("Cleanup")).toBeUndefined();
 		expect(
 			AgentRegistry.global()


### PR DESCRIPTION
## Repro
A task subagent with an advisor (`advisor.enabled: true`, `task.agentAdvisor: { task: "on" }`, `advisor.syncBacklog: "1"`) that does some work and then yields never gets its final `yield` turn reviewed: `<session>/<SubId>/__advisor.jsonl` records mid-run reviews but not the turn producing the yield, and a single-turn subagent whose only turn is the yield produces no advisor transcript at all. An agent-loop-level repro asserting `onTurnEnd` fires on a terminal-yield turn fails (0 calls) before the fix.

## Cause
A subagent yields by marking its `yield` tool result terminal, which fires `agent.abort(TERMINAL_TOOL_RESULT_ABORT_REASON)` (`agent-session.ts` `#afterToolCall` / `#dispatchAgentEvent`). In `packages/agent/src/agent-loop.ts`, `emitTurnEnd()` bails on `signal?.aborted` before invoking the `onTurnEnd` hook — a guard meant for external/user interrupts. The terminal-yield abort trips that guard, so `onTurnEnd` (and thus `SessionAdvisors.onPrimaryTurnEnd`) never runs for the yield turn and the final delta is never enqueued to the advisor. Separately, subagent teardown (`finalizeSubagentLifecycle` in `packages/coding-agent/src/task/executor.ts`) disposes the session with no advisor drain, unlike print mode's `waitForAdvisorCatchup`.

## Fix
- `emitTurnEnd` (`packages/agent/src/agent-loop.ts`): detect `signal.reason === TERMINAL_TOOL_RESULT_ABORT_REASON` and treat it as a graceful yield rather than an external abort — do not skip the hook, and pass `undefined` as the signal so downstream advisor catch-up waits behave identically to a normal final turn.
- `finalizeSubagentLifecycle` (`packages/coding-agent/src/task/executor.ts`): on a graceful (non-aborted) finish, call `prepareForHeadlessAdvisorDrain()` + `waitForAdvisorCatchup()` (bounded by the existing cleanup deadline) before `session.dispose()`; hard aborts still skip the drain for fast kill teardown.
- Changelog entries under `[Unreleased]` in both packages.

## Verification
- `bun test packages/agent/test/agent-loop.test.ts` — 101 pass, including new `runs onTurnEnd for a terminal-yield turn without a spent abort signal`.
- `bun test packages/coding-agent/test/eval/agent-bridge-policy.test.ts` — 42 pass; the eval-bridge cleanup test now asserts the advisor drain runs before dispose (`prepare` → `catchup` → `dispose`).
- `bun test packages/coding-agent/test/agent-session-advisor-suppression.test.ts .../modes/noninteractive-dispose.test.ts .../silent-abort-print-mode.test.ts .../print-mode-json-flush.test.ts .../print-mode-working-indicator.test.ts` — all green.

Fixes #9505