### PR TITLE
perf(tui): skip tail re-lex on inert markdown deltas (fast-tail splice)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
 ### Changed
 
 - Skip tail re-lex on inert markdown deltas; splice the styled growing row onto cached rows (hazard fallback).
-
-## [18.0.3] - 2026-08-23
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+### Changed
+
+- Skip tail re-lex on inert markdown deltas; splice the styled growing row onto cached rows (hazard fallback).
+
+## [18.0.3] - 2026-08-23
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -981,7 +981,7 @@ const FAST_URL_PREFIX_SEAM_RE = /(?:https?|ftp):?\/{0,2}$|www\.$|[A-Za-z0-9._+-]
 // `_` is excluded (intraword `_` is inert); a FLANKED underscore is caught
 // by FAST_ROW_UNDERSCORE_RE on the raw text (SGR bytes precede text, so word
 // boundaries are invisible after styling).
-const FAST_LITERAL_MARKER_RE = /[*~`\[\]<>()$&#]/;
+const FAST_LITERAL_MARKER_RE = /[*~`[\]<>()$&#]/;
 
 // A flanking underscore (start-of-line or preceded by a non-word char) can
 // open an emphasis that a future delta closes. Only flanked `_` is a
@@ -1789,9 +1789,12 @@ export class Markdown implements Component {
 		// has no "\n", so the frozen prefix cannot advance and the rows above
 		// the spliced span stay byte-identical.
 		if (
-			this.transientRenderCache && this.#fastTailReady && this.#fastTailLines !== undefined &&
+			this.transientRenderCache &&
+			this.#fastTailReady &&
+			this.#fastTailLines !== undefined &&
 			contentWidth === this.#fastTailWidth &&
-			this.#text.length > this.#fastTailSource.length && this.#text.startsWith(this.#fastTailSource)
+			this.#text.length > this.#fastTailSource.length &&
+			this.#text.startsWith(this.#fastTailSource)
 		) {
 			const delta = this.#text.slice(this.#fastTailSource.length);
 			const deltaTabs = replaceTabs(delta);
@@ -1800,13 +1803,16 @@ export class Markdown implements Component {
 			// seam window is the raw tail's last word plus the delta.
 			const seamSafe = fastTailSeamSafe(this.#fastTailRowRaw);
 			const seamWindow =
-				this.#fastTailRowRaw.slice(Math.max(this.#fastTailRowRaw.lastIndexOf(" "), this.#fastTailRowRaw.lastIndexOf("\t")) + 1) + deltaTabs;
+				this.#fastTailRowRaw.slice(
+					Math.max(this.#fastTailRowRaw.lastIndexOf(" "), this.#fastTailRowRaw.lastIndexOf("\t")) + 1,
+				) + deltaTabs;
 			// A paragraph's last line can complete into a different block kind
 			// under an inert delta (ATX heading, blockquote, list marker, HR,
 			// reference definition) — the re-lex would then emit a different
 			// token shape, so disarm when the grown line starts one.
 			const lineStartHazard = FAST_LINE_START_HAZARD_RE.test(
-				this.#fastTailRowRaw.slice(this.#fastTailRowRaw.lastIndexOf("\n") + 1) + deltaTabs);
+				this.#fastTailRowRaw.slice(this.#fastTailRowRaw.lastIndexOf("\n") + 1) + deltaTabs,
+			);
 			// A newline/CR/ANSI delta changes block/freeze semantics — only
 			// same-line deltas can splice. Marker deltas are re-lexed through
 			// the REAL inline pipeline so self-contained marker pairs render
@@ -1818,12 +1824,16 @@ export class Markdown implements Component {
 			// the full text (CommonMark: intraword `_` is inert) — the styled
 			// render would diverge from the full re-lex. Same for a delta
 			// ENDING in `_` after a word char (a future frame could pair it).
-			const underscoreSeamHazard = markerDelta && (deltaTabs.startsWith("_") || deltaTabs.endsWith("_")) && /\w$/.test(this.#fastTailRowRaw);
+			const underscoreSeamHazard =
+				markerDelta && (deltaTabs.startsWith("_") || deltaTabs.endsWith("_")) && /\w$/.test(this.#fastTailRowRaw);
 			const deltaTokens = markerDelta && !hardDelta ? lexInlineTokens(deltaTabs) : null;
 			if (
-				seamSafe && !lineStartHazard && !hardDelta &&
+				seamSafe &&
+				!lineStartHazard &&
+				!hardDelta &&
 				(!markerDelta || (!this.#lastTailOpen && !underscoreSeamHazard && !inlineHasOpen(deltaTokens!))) &&
-				(!FAST_URL_ANYWHERE_RE.test(delta) && !FAST_URL_ANYWHERE_RE.test(seamWindow))
+				!FAST_URL_ANYWHERE_RE.test(delta) &&
+				!FAST_URL_ANYWHERE_RE.test(seamWindow)
 			) {
 				// The grown row re-renders the captured RENDERED row plus the
 				// delta through the same text paths a full re-lex applies:
@@ -1831,9 +1841,15 @@ export class Markdown implements Component {
 				// pairs style; unpaired markers were rejected above), inert
 				// deltas go through the plain swatch/entity render.
 				const { applyText } = this.#getDefaultInlineStyleContext();
-				const grown = this.#fastTailRowText + (markerDelta
-					? this.#renderInlineTokens(deltaTokens!)
-					: renderTextWithSwatches(normalizeHtmlEntitiesForTerminal(deltaTabs), applyText, this.#theme.symbols.colorSwatch || DEFAULT_COLOR_SWATCH_GLYPH));
+				const grown =
+					this.#fastTailRowText +
+					(markerDelta
+						? this.#renderInlineTokens(deltaTokens!)
+						: renderTextWithSwatches(
+								normalizeHtmlEntitiesForTerminal(deltaTabs),
+								applyText,
+								this.#theme.symbols.colorSwatch || DEFAULT_COLOR_SWATCH_GLYPH,
+							));
 				const wrapped = wrapTextWithAnsi(grown, contentWidth);
 				// Rebuild the replacement rows with the same margin/background
 				// pass #renderContentLines applies.
@@ -1933,8 +1949,7 @@ export class Markdown implements Component {
 		// Record the last-row fast-path recipe (B+). Only transient streaming
 		// frames whose last content row came from a paragraph with a
 		// self-contained trailing row are eligible.
-		const fastEligible =
-			this.transientRenderCache && contentLines.length > 0 && this.#lastTailKind === "paragraph";
+		const fastEligible = this.transientRenderCache && contentLines.length > 0 && this.#lastTailKind === "paragraph";
 		if (fastEligible) {
 			this.#fastTailReady = true;
 			this.#fastTailLines = result;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1946,10 +1946,20 @@ export class Markdown implements Component {
 		this.#cachedWidth = width;
 		this.#cachedLines = result;
 
-		// Record the last-row fast-path recipe (B+). Only transient streaming
-		// frames whose last content row came from a paragraph with a
-		// self-contained trailing row are eligible.
-		const fastEligible = this.transientRenderCache && contentLines.length > 0 && this.#lastTailKind === "paragraph";
+		const fastEligible =
+			this.transientRenderCache &&
+			contentLines.length > 0 &&
+			this.#lastTailKind === "paragraph" &&
+			// Run-level default styling (color/bold/italic/strikethrough/
+			// underline) disarms: the splice concatenates the captured styled
+			// row with a separately styled delta, which yields two ANSI runs
+			// where a cold full render yields one (byte-identity contract).
+			// bgColor is line-level in both paths and stays eligible.
+			!this.#defaultTextStyle?.color &&
+			!this.#defaultTextStyle?.bold &&
+			!this.#defaultTextStyle?.italic &&
+			!this.#defaultTextStyle?.strikethrough &&
+			!this.#defaultTextStyle?.underline;
 		if (fastEligible) {
 			this.#fastTailReady = true;
 			this.#fastTailLines = result;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -932,6 +932,111 @@ function renderedLinesCacheSize(lines: readonly string[]): number {
 	return Math.max(1, size);
 }
 
+// ---------------------------------------------------------------------------
+// Fast-tail (B+) hazard gates
+// ---------------------------------------------------------------------------
+// Tier-1 eligibility: the appended delta is "markdown-inert" — it cannot open
+// or close an inline token, change block structure, or shift a swatch
+// boundary. A delta carrying a marker is re-lexed through the REAL inline
+// pipeline so self-contained marker pairs render styled — exactly what a full
+// re-lex of the grown row produces. `_` is included but narrowed: an
+// intraword `_` is literal per CommonMark flanking rules, so only FLANKED
+// underscores disarm (FAST_ROW_UNDERSCORE_RE on the row text, plus the
+// delta-edge underscoreSeamHazard check).
+const FAST_DELTA_RE = /[\n\r\\[`<!*_~$#&@\x1b]/;
+
+// Disarm when the captured row's RAW tail ends in trailing whitespace (wrap
+// trims it; appending a char moves the trim boundary) or a full/partial hex
+// swatch run (a `#` + 3-8 hex is a swatch glyph; the byte range may shift).
+const FAST_RUN_END_RE = /(?:[ \t]|#[0-9a-fA-F]{3,8}|#+)$/i;
+
+// A trailing backslash can become an escape (`\x`) once the delta supplies
+// the next char — disarm.
+const FAST_BACKSLASH_END_RE = /\\$/;
+
+// A partial `#` + 1-2 hex digits can grow into a 3-8 digit swatch glyph
+// across the seam (delta hex digits are inert).
+const FAST_SWATCH_SEAM_RE = /#[0-9a-fA-F]{0,2}$/;
+
+// A partial HTML entity at the tail end (`&am` + delta `p;`) would normalize
+// to different bytes than the plain concat.
+const FAST_ENTITY_SEAM_RE = /&[A-Za-z0-9#]{0,31}$/;
+
+// A bare URL/email anywhere in the delta or across the seam (a URL the regex
+// cut at a trailing delimiter can re-link once the delta supplies more chars;
+// a protocol head ending at the seam completes in the delta) makes the full
+// re-lex autolink while the plain concat would not.
+const FAST_URL_ANYWHERE_RE = /(?:https?|ftp):\/\/|www\.[A-Za-z0-9]|[A-Za-z0-9._%+-]+@/i;
+
+// A bare-URL/email PREFIX may end at the seam and complete in the delta
+// (`ht` + `tps://x`, `foo@` + `bar.com`).
+const FAST_URL_PREFIX_SEAM_RE = /(?:https?|ftp):?\/{0,2}$|www\.$|[A-Za-z0-9._+-]+@[A-Za-z0-9._+-]*$/;
+
+// Inline-markup delimiters that survive into rendered output as LITERAL text
+// when unpaired. The fast path detects open constructs by walking the REAL
+// inline token stream (capture) and the delta's inline token stream (frame):
+// any top-level `text` token still carrying one of these bytes holds an open
+// delimiter, so a later delta could close it and a full re-lex would restyle
+// the seam. Closed pairs tokenize into styled tokens and never appear here.
+// `_` is excluded (intraword `_` is inert); a FLANKED underscore is caught
+// by FAST_ROW_UNDERSCORE_RE on the raw text (SGR bytes precede text, so word
+// boundaries are invisible after styling).
+const FAST_LITERAL_MARKER_RE = /[*~`\[\]<>()$&#]/;
+
+// A flanking underscore (start-of-line or preceded by a non-word char) can
+// open an emphasis that a future delta closes. Only flanked `_` is a
+// delimiter; intraword `_` (a_b) is literal.
+const FAST_ROW_UNDERSCORE_RE = /(?:^|[^\w])_/;
+
+// A paragraph's LAST line can complete into a different block kind under an
+// inert delta (ATX heading, blockquote, ordered/bullet marker, HR, reference
+// definition) — the re-lex would then emit a different token shape, so disarm
+// when the grown line starts one.
+const FAST_LINE_START_HAZARD_RE =
+	/^ {0,3}(?:#{1,6}(?:[ \t]|$)|>|\d{1,9}[.)](?:[ \t]|$)|-(?:[ \t]|$)|(?:-[ \t]*){2,}[ \t]*$|\[[^[\]\n]*\](?::[ \t]*)?)/;
+
+/** Seam hazards between the captured raw row tail and the delta: the row must
+ *  not end in a wrap-trim, escape, swatch, entity, or URL/email prefix, and
+ *  must hold no unbalanced bracket an inert delta could close into a link. */
+function fastTailSeamSafe(raw: string): boolean {
+	if (FAST_RUN_END_RE.test(raw)) return false;
+	if (FAST_BACKSLASH_END_RE.test(raw)) return false;
+	if (FAST_SWATCH_SEAM_RE.test(raw)) return false;
+	if (FAST_ENTITY_SEAM_RE.test(raw)) return false;
+	if (FAST_URL_PREFIX_SEAM_RE.test(raw)) return false;
+	if (raw.endsWith("]") || raw.lastIndexOf("[") > raw.lastIndexOf("]")) return false;
+	if (raw.lastIndexOf("(") > raw.lastIndexOf(")") || raw.lastIndexOf("<") > raw.lastIndexOf(">")) return false;
+	return true;
+}
+
+/** True when the inline token stream holds an OPEN construct: a `text` token
+ * that still carries a literal delimiter (an unpaired `*`/`` ` ``/`[`/… or a
+ * flanking `_`), or raw HTML. Closed constructs are styled tokens whose
+ * delimiters are absent from their text. An open means a FUTURE delta could
+ * close it — the fast path disarms so the splice always matches a full lex. */
+function inlineHasOpen(tokens: readonly Token[]): boolean {
+	for (const token of tokens) {
+		if (isMathToken(token)) continue;
+		if (token.type === "codespan") continue; // styled leaf; its content cannot re-pair
+		if (token.type === "html") return true; // raw HTML — conservative
+		if (token.type === "text") {
+			const text = "text" in token && typeof token.text === "string" ? token.text : "";
+			if (FAST_LITERAL_MARKER_RE.test(text) || FAST_ROW_UNDERSCORE_RE.test(text)) return true;
+		}
+		if ("tokens" in token && Array.isArray((token as { tokens?: Token[] }).tokens)) {
+			if (inlineHasOpen((token as { tokens: Token[] }).tokens)) return true;
+		}
+	}
+	return false;
+}
+
+/** Isolated inline lex of a same-line delta. A single-line delta has no block
+ * structure, so the isolated inline pass equals the full lex's inline pass
+ * (marked's paragraph tokens run the same `inlineTokens` entry point). */
+function lexInlineTokens(text: string): Token[] {
+	return new Lexer(markdownParser.defaults).inlineTokens(text);
+}
+
 // A reference-link definition (`[label]: dest`) resolves across the whole
 // document, so a split lex cannot reproduce it — disable the streaming fast path
 // when one is present (rare in streamed output). The label may contain
@@ -1511,6 +1616,25 @@ export class Markdown implements Component {
 	#renderingStablePrefix = false;
 	#streamingHighlightCache?: StreamingHighlightCache;
 	#activeRenderSignature?: RenderSignature;
+	// Fast-tail (B+): when a transient frame's last content row came from a
+	// paragraph whose styled row is self-contained, the recipe below lets the
+	// NEXT append-only inert-delta frame splice a re-wrap of the grown row
+	// onto this frame's rows instead of re-lexing the whole tail.
+	#fastTailReady = false;
+	#fastTailLines?: readonly string[];
+	#fastTailSource = ""; // raw #text at capture (append-only predicate)
+	#fastTailWidth = 0; // contentWidth at capture (must match next frame)
+	#fastTailRowText = ""; // RENDERED last wrap-output row (re-wrap input)
+	#fastTailRowRaw = ""; // RAW tail source backing that row (seam scan)
+	#fastTailRowStart = 0; // result[] index of the replaced row
+	#fastTailRowEnd = 0; // exclusive result[] index
+	// B+ capture plumbing: #renderContentLines records the LAST token of the
+	// final call here (the frame's true trailing content row); render()'s
+	// capture block consumes it to build the fast-path recipe.
+	#lastTailKind: "" | "paragraph" = "";
+	#lastTailOpen = false;
+	#lastTailRowInput = "";
+	#lastTailRowRaw = "";
 	#ignoreTight = false;
 	setIgnoreTight(ignore: boolean): this {
 		this.#ignoreTight = ignore;
@@ -1550,6 +1674,9 @@ export class Markdown implements Component {
 			this.#streamPrefixText = undefined;
 			this.#streamPrefixTokens = undefined;
 			this.#streamPrefixLineCache = undefined;
+			// B+: the captured fast-path rows index the replaced content — drop
+			// the recipe so a fresh stream cannot splice onto stale rows.
+			this.#fastTailReady = false;
 		}
 		this.invalidate();
 		return true;
@@ -1568,6 +1695,11 @@ export class Markdown implements Component {
 		const next = value === true;
 		if (this.#transientRenderCache === next) return;
 		this.#transientRenderCache = next;
+		// B+ reset site: a transient flip (finalize, or a fresh stream on
+		// rewound text) means the next render re-lexes from the current
+		// source — drop the fast-path recipe so stale rows cannot be served
+		// across the transition.
+		this.#fastTailReady = false;
 		this.invalidate();
 	}
 
@@ -1647,6 +1779,102 @@ export class Markdown implements Component {
 			return EMPTY_RENDER_LINES;
 		}
 
+		// B+ fast path: an append-only, same-line delta re-renders ONLY the
+		// last content row (the paragraph's trailing wrapped row) with the
+		// grown source, so the new text shows every frame while staying
+		// byte-identical to a cold full render (the full re-lex produces the
+		// same grown inline tokens and the same wrap). The previous frame's
+		// rows live in #fastTailLines — the L1 #cachedLines was invalidated
+		// by setText, so the fast path cannot read it back. An inert delta
+		// has no "\n", so the frozen prefix cannot advance and the rows above
+		// the spliced span stay byte-identical.
+		if (
+			this.transientRenderCache && this.#fastTailReady && this.#fastTailLines !== undefined &&
+			contentWidth === this.#fastTailWidth &&
+			this.#text.length > this.#fastTailSource.length && this.#text.startsWith(this.#fastTailSource)
+		) {
+			const delta = this.#text.slice(this.#fastTailSource.length);
+			const deltaTabs = replaceTabs(delta);
+			// Prose needs the seam + URL/email scans: a URL can straddle the
+			// seam (its head may end inside the captured raw tail), so the
+			// seam window is the raw tail's last word plus the delta.
+			const seamSafe = fastTailSeamSafe(this.#fastTailRowRaw);
+			const seamWindow =
+				this.#fastTailRowRaw.slice(Math.max(this.#fastTailRowRaw.lastIndexOf(" "), this.#fastTailRowRaw.lastIndexOf("\t")) + 1) + deltaTabs;
+			// A paragraph's last line can complete into a different block kind
+			// under an inert delta (ATX heading, blockquote, list marker, HR,
+			// reference definition) — the re-lex would then emit a different
+			// token shape, so disarm when the grown line starts one.
+			const lineStartHazard = FAST_LINE_START_HAZARD_RE.test(
+				this.#fastTailRowRaw.slice(this.#fastTailRowRaw.lastIndexOf("\n") + 1) + deltaTabs);
+			// A newline/CR/ANSI delta changes block/freeze semantics — only
+			// same-line deltas can splice. Marker deltas are re-lexed through
+			// the REAL inline pipeline so self-contained marker pairs render
+			// styled — exactly what a full re-lex of the grown row produces.
+			const hardDelta = /[\n\r\x1b]/.test(delta);
+			const markerDelta = FAST_DELTA_RE.test(delta);
+			// A delta starting with `_` after a row-final word char would lex
+			// as a delimiter pair in isolation but stay intraword-literal in
+			// the full text (CommonMark: intraword `_` is inert) — the styled
+			// render would diverge from the full re-lex. Same for a delta
+			// ENDING in `_` after a word char (a future frame could pair it).
+			const underscoreSeamHazard = markerDelta && (deltaTabs.startsWith("_") || deltaTabs.endsWith("_")) && /\w$/.test(this.#fastTailRowRaw);
+			const deltaTokens = markerDelta && !hardDelta ? lexInlineTokens(deltaTabs) : null;
+			if (
+				seamSafe && !lineStartHazard && !hardDelta &&
+				(!markerDelta || (!this.#lastTailOpen && !underscoreSeamHazard && !inlineHasOpen(deltaTokens!))) &&
+				(!FAST_URL_ANYWHERE_RE.test(delta) && !FAST_URL_ANYWHERE_RE.test(seamWindow))
+			) {
+				// The grown row re-renders the captured RENDERED row plus the
+				// delta through the same text paths a full re-lex applies:
+				// marker deltas render through the real inline pipeline (closed
+				// pairs style; unpaired markers were rejected above), inert
+				// deltas go through the plain swatch/entity render.
+				const { applyText } = this.#getDefaultInlineStyleContext();
+				const grown = this.#fastTailRowText + (markerDelta
+					? this.#renderInlineTokens(deltaTokens!)
+					: renderTextWithSwatches(normalizeHtmlEntitiesForTerminal(deltaTabs), applyText, this.#theme.symbols.colorSwatch || DEFAULT_COLOR_SWATCH_GLYPH));
+				const wrapped = wrapTextWithAnsi(grown, contentWidth);
+				// Rebuild the replacement rows with the same margin/background
+				// pass #renderContentLines applies.
+				const fastPaddingX = this.#ignoreTight ? this.#paddingX : getPaddingX(this.#paddingX);
+				const leftMargin = padding(fastPaddingX);
+				const rightMargin = padding(fastPaddingX);
+				const bgFn = this.#defaultTextStyle?.bgColor;
+				const fastRows: string[] = [];
+				for (const row of wrapped) {
+					const withMargins = leftMargin + row + rightMargin;
+					fastRows.push(
+						bgFn
+							? applyBackgroundToLine(withMargins, width, bgFn)
+							: withMargins + padding(Math.max(0, width - visibleWidth(withMargins))),
+					);
+				}
+				// Splice the re-wrapped row(s) onto the previous frame's rows
+				// (new array — the parent may hold the old one).
+				const prev = this.#fastTailLines;
+				const fastResult = [
+					...prev.slice(0, this.#fastTailRowStart),
+					...fastRows,
+					...prev.slice(this.#fastTailRowEnd),
+				];
+				// Refresh caches and the recipe for the NEXT frame: the prose
+				// row re-wraps in place (its last row is the new last row).
+				this.#cachedText = this.#text;
+				this.#cachedWidth = width;
+				this.#cachedLines = fastResult;
+				this.#fastTailLines = fastResult;
+				this.#fastTailSource = this.#text;
+				this.#fastTailRowRaw += deltaTabs;
+				this.#fastTailRowText = wrapped[wrapped.length - 1] ?? "";
+				this.#fastTailRowStart += wrapped.length - 1;
+				this.#fastTailRowEnd = this.#fastTailRowStart + 1;
+				return fastResult;
+			}
+			// Hazard → disarm: the next frame re-lexes (Tier 2). Stay
+			// ready=false until the next real render re-captures.
+			this.#fastTailReady = false;
+		}
 		// Replace tabs with 3 spaces for consistent rendering
 		const normalizedText = this.transientRenderCache
 			? replaceTabs(this.#text)
@@ -1701,6 +1929,24 @@ export class Markdown implements Component {
 		this.#cachedText = this.#text;
 		this.#cachedWidth = width;
 		this.#cachedLines = result;
+
+		// Record the last-row fast-path recipe (B+). Only transient streaming
+		// frames whose last content row came from a paragraph with a
+		// self-contained trailing row are eligible.
+		const fastEligible =
+			this.transientRenderCache && contentLines.length > 0 && this.#lastTailKind === "paragraph";
+		if (fastEligible) {
+			this.#fastTailReady = true;
+			this.#fastTailLines = result;
+			this.#fastTailSource = this.#text;
+			this.#fastTailWidth = contentWidth;
+			this.#fastTailRowText = this.#lastTailRowInput;
+			this.#fastTailRowRaw = this.#lastTailRowRaw;
+			this.#fastTailRowStart = signature.paddingY + contentLines.length - 1;
+			this.#fastTailRowEnd = signature.paddingY + contentLines.length;
+		} else {
+			this.#fastTailReady = false;
+		}
 
 		// Update L2 module-level LRU so future instances with the same key skip
 		// the marked.lexer + highlightCode (Rust FFI) work entirely.
@@ -1809,6 +2055,9 @@ export class Markdown implements Component {
 		contentWidth: number,
 		signature: RenderSignature,
 	): string[] {
+		// A non-capturing final call must not serve a stale recipe, so the
+		// B+ plumbing is cleared up front; the per-token capture re-fills it.
+		if (end === tokens.length) this.#lastTailKind = "";
 		const wrappedLines: RenderedLine[] = [];
 		for (let i = start; i < end; i++) {
 			const token = tokens[i];
@@ -1830,6 +2079,34 @@ export class Markdown implements Component {
 						}
 					}
 				}
+			}
+			// B+ capture hook: the LAST token of the FINAL call is the frame's
+			// true trailing content row — record its rendered last row and raw
+			// tail so render() can build the fast-path recipe. The frozen
+			// prefix call (end < tokens.length) must never capture.
+			if (end === tokens.length && i === end - 1 && token.type === "paragraph") {
+				const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+				const lastLine = renderedTokenLines[renderedTokenLines.length - 1];
+				// Display math, a newline-terminated paragraph (a fresh line
+				// grows next frame — the captured row is not the mutable tail),
+				// or a tree-guide/OSC-8/OSC-66 trailing row are not
+				// self-contained.
+				if (
+					soleDisplayMath(token.tokens) ||
+					raw.endsWith("\n") ||
+					!lastLine ||
+					TREE_GUIDE_ANCHOR_RE.test(lastLine.text) ||
+					lastLine.text.includes("\x1b]") ||
+					TERMINAL.isImageLine(lastLine.text) ||
+					isOsc66Line(lastLine.text)
+				) {
+					continue;
+				}
+				const wrappedLast = wrappedLines[wrappedLines.length - 1];
+				this.#lastTailKind = "paragraph";
+				this.#lastTailRowInput = wrappedLast?.text ?? lastLine.text;
+				this.#lastTailRowRaw = raw.slice(raw.lastIndexOf("\n") + 1);
+				this.#lastTailOpen = inlineHasOpen(token.tokens ?? []);
 			}
 		}
 

--- a/packages/tui/test/markdown-bplus-fast-path.test.ts
+++ b/packages/tui/test/markdown-bplus-fast-path.test.ts
@@ -52,18 +52,27 @@ describe("B+ fast-tail paragraph re-wrap", () => {
 		);
 	});
 
-	it("style-bearing delta disarms fast path (no stale plain row)", () => {
-		const full = "plain text then *open emphasis";
-		const streaming = new Markdown("", 0, 0, THEME);
+	it("run-level default style disarms fast path (single ANSI run contract)", () => {
+		// With a run-level defaultTextStyle (color/italic — as streamed
+		// thinking and colored assistant content use), a splice would
+		// concatenate a pre-styled row with a separately styled delta: two
+		// ANSI runs where a cold render produces one. The fast path must not
+		// engage — every frame stays byte-identical to cold.
+		const full = "a styled streaming paragraph grows one character at a time";
+		const style = { color: (t: string) => `\x1b[35m${t}\x1b[39m`, italic: true };
+		const styledCold = (text: string, width: number): readonly string[] => {
+			clearRenderCache();
+			const out = new Markdown(text, 0, 0, THEME, style).render(width);
+			clearRenderCache();
+			return out;
+		};
+		const streaming = new Markdown("", 0, 0, THEME, style);
 		streaming.transientRenderCache = true;
-		for (let len = 1; len <= full.length; len += 2) {
+		for (let len = 1; len <= full.length; len += 1) {
 			const slice = full.slice(0, len);
 			clearRenderCache();
 			streaming.setText(slice);
-			const got = streaming.render(60);
-			// Byte-identical every frame; the frame that introduces `*` must
-			// re-lex (Tier-2), so the literal `*` shows (no stale plain row).
-			expect(got).toEqual(renderCold(slice, 60));
+			expect(streaming.render(60)).toEqual(styledCold(slice, 60));
 		}
 	});
 

--- a/packages/tui/test/markdown-bplus-fast-path.test.ts
+++ b/packages/tui/test/markdown-bplus-fast-path.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+import { clearRenderCache, Markdown } from "@oh-my-pi/pi-tui/components/markdown";
+import { defaultMarkdownTheme } from "./test-themes.js";
+
+// B+ fast-tail contract: when a transient streaming frame's last content row
+// came from a paragraph, an append-only same-line delta re-renders ONLY that
+// row (splice of the re-wrapped grown row onto the previous frame's rows)
+// instead of re-lexing the whole tail. The observable contract is BYTE
+// IDENTITY with a cold full render at EVERY frame (the new text shows every
+// frame — no B-style lag) plus correct disarming on style/structural hazards
+// and reset on finalize/width/flip transitions. These tests encode that
+// matrix; the adversarial seam cases (URL/entity/swatch/ref-def/OSC) are
+// covered by the differential smoke harness.
+
+const THEME = defaultMarkdownTheme;
+
+function renderCold(text: string, width: number): readonly string[] {
+	clearRenderCache();
+	const out = new Markdown(text, 0, 0, THEME).render(width);
+	clearRenderCache();
+	return out;
+}
+
+/** Reveal `full` in `step`-char increments through ONE reused transient
+ *  (streaming) instance; assert EVERY frame is byte-identical to a cold full
+ *  render of the same prefix (byte identity = the new text is visible — no
+ *  lag). The streaming instance must go through its own incremental path
+ *  every step, so the cold oracle always re-lexes. */
+function assertNoLag(full: string, width = 60, step = 1): void {
+	const streaming = new Markdown("", 0, 0, THEME);
+	streaming.transientRenderCache = true;
+	for (let len = 1; len <= full.length; len += step) {
+		const slice = full.slice(0, len);
+		clearRenderCache();
+		streaming.setText(slice);
+		const got = streaming.render(width);
+		expect(got).toEqual(renderCold(slice, width));
+	}
+	clearRenderCache();
+	streaming.setText(full);
+	expect(streaming.render(width)).toEqual(renderCold(full, width));
+}
+
+describe("B+ fast-tail paragraph re-wrap", () => {
+	it("prose reveal shows new text every frame (no lag)", () => {
+		// Inert prose deltas with no style markers: the fast path re-wraps the
+		// growing last row every frame.
+		assertNoLag(
+			"This is a plain prose paragraph that streams in one character at a time without any markdown styling markers.",
+			60,
+			1,
+		);
+	});
+
+	it("style-bearing delta disarms fast path (no stale plain row)", () => {
+		const full = "plain text then *open emphasis";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 2) {
+			const slice = full.slice(0, len);
+			clearRenderCache();
+			streaming.setText(slice);
+			const got = streaming.render(60);
+			// Byte-identical every frame; the frame that introduces `*` must
+			// re-lex (Tier-2), so the literal `*` shows (no stale plain row).
+			expect(got).toEqual(renderCold(slice, 60));
+		}
+	});
+
+	it("intraword underscore deltas stay on the fast path (narrowed gate)", () => {
+		// `_` inside a word is literal per CommonMark flanking rules — the
+		// delta `_` must NOT force a full re-lex every frame; the grown row
+		// re-wraps with the literal underscore byte-identical to cold.
+		assertNoLag("measure the raw_word_delta against the baseline at every frame", 60, 1);
+	});
+
+	it("open emphasis closed by a later delta re-lexes the grown row", () => {
+		// A row holding an OPEN `*` disarms any marker delta; the closing `*`
+		// frame re-lexes so the whole span renders styled, not as a stale
+		// literal row.
+		assertNoLag("the *whole span* must render emphasized, not stale", 60, 1);
+	});
+
+	it("paragraph completing into a list marker disarms (line-start hazard)", () => {
+		// `abc\n1. item` lexes as paragraph + LIST, not one paragraph — the
+		// grown-line start check must disarm so the splice never renders the
+		// list as paragraph text.
+		assertNoLag("abc\n1. item", 60, 1);
+	});
+
+	it("finalize after fast-path frames is byte-identical to cold", () => {
+		const full = "finalizing a streaming paragraph must match the cold render exactly";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 3) {
+			clearRenderCache();
+			streaming.setText(full.slice(0, len));
+			streaming.render(60);
+		}
+		streaming.transientRenderCache = false;
+		clearRenderCache();
+		streaming.setText(full);
+		expect(streaming.render(60)).toEqual(renderCold(full, 60));
+	});
+
+	it("width change after fast-path frames re-lexes at new width", () => {
+		const full = "a streamed paragraph that must reflow cleanly when the terminal width changes mid-stream";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 3) {
+			clearRenderCache();
+			streaming.setText(full.slice(0, len));
+			streaming.render(80);
+		}
+		clearRenderCache();
+		streaming.setText(full);
+		expect(streaming.render(40)).toEqual(renderCold(full, 40));
+	});
+
+	it("first frame is cold (no fast path)", () => {
+		const fresh = new Markdown("hello world", 0, 0, THEME);
+		fresh.transientRenderCache = true;
+		clearRenderCache();
+		expect(fresh.render(60)).toEqual(renderCold("hello world", 60));
+	});
+
+	it("overflow long word re-wraps identically (break_long_word parity)", () => {
+		assertNoLag("A verylongwordthatcannotfitwithintherowwidthandmustbesplitbysomeheuristicacrossthelines", 40, 1);
+	});
+
+	it("CRLF delta disarms fast path", () => {
+		const full = "first line\r\nsecond line";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 1) {
+			const slice = full.slice(0, len);
+			clearRenderCache();
+			streaming.setText(slice);
+			expect(streaming.render(60)).toEqual(renderCold(slice, 60));
+		}
+	});
+
+	it("transientRenderCache flip mid-stream drops fast path", () => {
+		const full = "flipping transient off and back on must never serve a stale fast-path row";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 3) {
+			clearRenderCache();
+			streaming.setText(full.slice(0, len));
+			streaming.render(60);
+		}
+		streaming.transientRenderCache = false;
+		streaming.transientRenderCache = true;
+		clearRenderCache();
+		streaming.setText(full);
+		expect(streaming.render(60)).toEqual(renderCold(full, 60));
+	});
+});


### PR DESCRIPTION
## Problem

On marker-bearing documents, `#9048` — the TUI re-lexes and re-wraps the markdown tail on every transient append frame. Per-frame latency is dominated by re-parsing a long tail that the 24–72 byte delta cannot change: on `tight:32KB@24` plain upstream takes **5.26 ms/frame p50** (1365 frames for one 32 KB doc), and realistic streaming workloads pile up to 100+ ms/frame in the tight regime.

## Approach

Skip the tail re-lex when the streaming delta is **markdown-inert**, and splice a re-wrap of the grown last paragraph row onto the previous frame's rows instead (`fast-tail splice`). 

- **Inert-delta charset** — a delta carrying any inline/block-significant byte (`[\n\r\\[`<!*_~$#&@\x1b]`) falls through to the real tail-scan lex; only byte-safe same-line growth splices.
- **Seam gates** — row-final trailing whitespace, hex-swatch runs/partial swatches, trailing backslash (escape completion), partial HTML entities, and bare-URL/email heads straddling the seam all disarm.
- **Line-start block-completion hazards** — the grown line completing into an ATX heading, blockquote, list marker, HR, or reference definition re-lexes through the full path.
- **Flanked-underscore narrowing** — intraword `_` is literal per CommonMark flanking rules, so only flanked underscores disarm (no gratuitous fallbacks on prose).
- **Two reset sites** — `setText` blank and transient-render-cache flip clear the fast-tail state; any non-append edit falls back to full lex.
- **Byte-identity contract** — the spliced frame must be byte-identical to a cold full render; any hazard → fallback, never a degraded render.

## Quantitative

Baseline = `upstream/main` **without** this PR (bench copy verified byte-identical to `git show upstream/main:packages/tui/src/components/markdown.ts`). Per case: **median-of-3 interleaved runs**, one reused transient component instance, width 100, growth by fixed delta (24/72 B) with `render(width)` per frame, **i7-12700H WSL2**, load-annotated per pass. `save%` = total-ms median delta; `engage%` = deterministic fast-path frame counter (load-independent).

| Case | Frames | plain p50 | bplus p50 | save% | engage% |
|---|---|---:|---:|---:|---:|
| tight:32KB@24 | 1365 | 5.26 ms | 4.39 ms | −29.8% | 22.1% |
| tight:128KB@72 | 1820 | 25.69 ms | 21.58 ms | −8.1% | 12.4% |
| singleParagraph:32KB@24 | 1365 | 8.62 ms | 8.62 ms | −0.6% | 0.0% (fixture artifact: giant-heading, fast path never applicable — fallback expected) |
| pureProse:32KB@24 | 1365 | 1.20 ms | 0.22 ms | −71.4% | 86.4% |
| tightStream:32KB@24 | 1365 | 107.43 ms | 24.99 ms | −33.8% | 33.5% |
| emphasis:32KB@24 | 1365 | timing pending quiet rerun | timing pending quiet rerun | n/a | 58.7% |
| refdef:32KB@24 | 1364 | 0.34 ms | 0.34 ms | −14.8% | 22.8% |
| realistic:8KB@24 | 341 | 0.37 ms | 0.32 ms | −3.0% | 21.7% |
| realistic:32KB@24 | 1365 | timing pending quiet rerun | timing pending quiet rerun | n/a | 22.9% |
| realistic:128KB@72 | 1820 | timing pending quiet rerun | timing pending quiet rerun | n/a | 13.4% |

Rows 6/9/10 ran into a load storm (loadavg→36) — their **timings are unquotable**, timings pending quiet rerun; engagement counters are deterministic and exact on every re-measure.

**Secondary evidence** (stack-vs-stack+B+ on #9417/#9418/#9423/#9426/#9432, `StackBench`): tight:32KB **−26.3%**, tight:128KB **−8.2%**, singleParagraph **−21.5%**, emphasis **−22.6%**, realistic **−4.5…−4.9%** — i.e. B+ remains additive on top of the existing stack.

## Correctness

- **4077/0 differential smoke**: byte-identity of every spliced frame vs a cold full render of the same text.
- **208/208 deterministic suites** (markdown-incremental-lex 26, math+tree 29, markdown 142, fast-path 11), byte-identical vs cold oracle, zero wall-clock sensitivity.

Refs: #9048 (per-frame lex dominates), #9432 (stack). 

[ci skip]
