### PR TITLE
feat(tui): framed code-block wrapping, streaming guard-scan memo, and stable boundary resume

### DIFF
--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -93,8 +93,9 @@ describe("AssistantMessageComponent mermaid markdown", () => {
 		const rendered = renderAssistantMessage("```mermaid\nthis is not mermaid\n```");
 
 		expect(TERMINAL.imageProtocol).toBeNull();
-		expect(rendered).toContain("```mermaid");
+		expect(rendered).toContain("[mermaid]");
 		expect(rendered).toContain("this is not mermaid");
+		expect(rendered).not.toContain("```");
 	});
 });
 

--- a/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
@@ -52,9 +52,10 @@ describe("Mermaid rendering setting", () => {
 		const markdown = new Markdown("```mermaid\ngraph TD\n  A --> B\n```", 0, 0, getMarkdownTheme());
 		const lines = stripAnsi(markdown.render(80).join("\n"));
 
-		expect(lines).toContain("```mermaid");
+		expect(lines).toContain("[mermaid]");
 		expect(lines).toContain("graph TD");
 		expect(lines).toContain("-->");
+		expect(lines).not.toContain("```");
 	});
 
 	it("uses content-visible Titanium colors for Mermaid structure", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added compact framed rendering for completed fenced Markdown code blocks, with width-aware wrapping and language labels while preserving raw delimiters for still-streaming fences.
+
+### Changed
+
+- Improved incremental Markdown lexing to reuse append-only guard scans and stable block boundaries during streaming.
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Improved incremental Markdown lexing to reuse append-only guard scans and stable block boundaries during streaming.
 
+### Fixed
+
+- Fixed narrow and nested framed Markdown code blocks so wide graphemes stay within the requested width and copy targets preserve raw source boundaries without cache collisions.
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2154,7 +2154,13 @@ export class Markdown implements Component {
 			for (const body of bodyLines) {
 				const source = body.codeBody ?? body.text;
 				for (const row of wrapCodeLineWithAnsi(source, Math.max(1, requestedWidth))) {
-					compact.push({ text: row, noWrap: true });
+					// With no room even for borders, chrome is already omitted; when a
+					// single atomic grapheme still cannot fit, truncation is the only
+					// way to keep the noWrap row inside the container.
+					compact.push({
+						text: truncateToWidth(row, Math.max(1, requestedWidth), Ellipsis.Omit),
+						noWrap: true,
+					});
 				}
 			}
 			return compact.length > 0 ? compact : [{ text: "", noWrap: true }];

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2038,8 +2038,22 @@ export class Markdown implements Component {
 		const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
 		if (!raw) return fallback;
 		const expandedSource = replaceTabs(this.#sourceText);
-		const expandedStart = expandedSource.indexOf(raw);
-		if (expandedStart < 0) return fallback;
+		let expandedStart = expandedSource.indexOf(raw);
+		if (expandedStart < 0) {
+			// Nested tokens lose their container prefixes, so `raw` is not a
+			// contiguous substring of the source. Locate the opening fence line
+			// and slice between fence lines instead, keeping original indentation
+			// and tabs intact for the copy payload.
+			const openLine = raw.split("\n", 1)[0] ?? "";
+			const trimmedOpen = openLine.trimStart();
+			if (!trimmedOpen) return fallback;
+			const openAt = expandedSource.indexOf(trimmedOpen);
+			if (openAt < 0) return fallback;
+			const closeLine = raw.split("\n").at(-1)?.trimStart() ?? "";
+			const closeAt = closeLine ? expandedSource.indexOf(closeLine, openAt + openLine.length) : -1;
+			if (closeAt < 0) return fallback;
+			expandedStart = openAt;
+		}
 		const toSourceOffset = (expandedOffset: number): number => {
 			let expanded = 0;
 			for (let sourceOffset = 0; sourceOffset < this.#sourceText.length; sourceOffset++) {
@@ -2085,11 +2099,10 @@ export class Markdown implements Component {
 			for (const body of bodyLines) {
 				const source = body.codeBody ?? body.text;
 				for (const row of wrapCodeLineWithAnsi(source, sourceWidth)) {
-					const content = truncateToWidth(row, sourceWidth, Ellipsis.Omit);
-					const text =
-						requestedWidth >= 3
-							? `${edge}${content}${edge}`
-							: truncateToWidth(content, requestedWidth, Ellipsis.Omit);
+					// A single grapheme wider than sourceWidth arrives on its own
+					// over-width row; it must reach the terminal whole instead of
+					// being truncated out of existence.
+					const text = requestedWidth >= 3 ? `${edge}${row}${edge}` : row;
 					narrow.push({ text, noWrap: true });
 				}
 			}
@@ -2142,7 +2155,10 @@ export class Markdown implements Component {
 			for (let rowIndex = 0; rowIndex < visualRows.length; rowIndex++) {
 				const rowPrefix = rowIndex === 0 ? firstPrefix : continuationPrefix;
 				const rawRow = leftPadding + rowPrefix + visualRows[rowIndex]!;
-				const rowText = truncateToWidth(rawRow, contentWidth, Ellipsis.Omit);
+				// Normal wrapping bounds rows to sourceWidth; only a single grapheme
+				// cluster wider than the content cell can exceed it, and that row
+				// must survive whole rather than lose its grapheme to a clamp.
+				const rowText = rawRow;
 				const pad = Math.max(0, contentWidth - visibleWidth(rowText));
 				framed.push({
 					text: `${border(box.vertical)} ${rowText}${padding(pad)} ${border(box.vertical)}`,
@@ -2977,10 +2993,21 @@ export class Markdown implements Component {
 			} else if (token.type === "code") {
 				// Code block in list item — fenced blocks get the same themed box.
 				const codeIndent = padding(this.#codeBlockIndent);
-				const fenced = this.#isFencedCodeToken(token) && this.#codeTokenHasClosingFence(token);
-				const bodyLines = this.#renderCodeBodyLines(token, fenced ? "" : codeIndent, fenced);
-				const framed = fenced ? this.#boxFencedCodeLines(token, bodyLines, frameWidth) : bodyLines;
-				for (const line of framed) lines.push({ ...line, nested: false });
+				const fenced = this.#isFencedCodeToken(token);
+				const closedFence = fenced && this.#codeTokenHasClosingFence(token);
+				const bodyLines = this.#renderCodeBodyLines(token, closedFence ? "" : codeIndent, closedFence);
+				if (closedFence) {
+					const framed = this.#boxFencedCodeLines(token, bodyLines, frameWidth);
+					for (const line of framed) lines.push({ ...line, nested: false });
+				} else {
+					// An open fence inside a list keeps its delimiters as literal
+					// code rows (same contract as the top-level path) instead of
+					// being silently swallowed by the framed renderer.
+					const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+					for (const rawLine of raw.split("\n")) {
+						lines.push({ text: replaceTabs(rawLine), literalCode: true, nested: false });
+					}
+				}
 			} else if (isMathToken(token)) {
 				// Display math block inside a list item: stack fractions / matrix rows.
 				const apply = styleContext?.applyText ?? ((t: string) => this.#applyDefaultStyle(t));

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2101,13 +2101,26 @@ export class Markdown implements Component {
 		const lastLineStart = sourceRaw.lastIndexOf("\n");
 		if (firstLineEnd < 0 || lastLineStart <= firstLineEnd) return fallback;
 		const openingLine = sourceRaw.slice(0, firstLineEnd);
-		const fenceAt = openingLine.search(/(`{3,}|~{3,})/);
-		const containerPrefix = fenceAt > 0 ? openingLine.slice(0, fenceAt) : "";
+		const closingLine = sourceRaw.slice(lastLineStart + 1);
+		const openingFenceAt = openingLine.search(/(`{3,}|~{3,})/);
+		const closingFenceAt = closingLine.search(/(`{3,}|~{3,})/);
+		const openingPrefix = openingFenceAt > 0 ? openingLine.slice(0, openingFenceAt) : "";
+		// A list item's opening line may contain `- `, while its body and closing
+		// fence use the continuation prefix (`  `). Prefer the actual closing-line
+		// prefix for body recovery and retain the opening prefix as a fallback for
+		// blockquote-shaped tokens.
+		const closingPrefix = closingFenceAt > 0 ? closingLine.slice(0, closingFenceAt) : "";
+		const prefixes = [closingPrefix, openingPrefix].filter(
+			(prefix, index, all) => prefix.length > 0 && all.indexOf(prefix) === index,
+		);
 		const body = sourceRaw.slice(firstLineEnd + 1, lastLineStart);
-		if (!containerPrefix) return body;
+		if (prefixes.length === 0) return body;
 		return body
 			.split("\n")
-			.map(line => (line.startsWith(containerPrefix) ? line.slice(containerPrefix.length) : line))
+			.map(line => {
+				const prefix = prefixes.find(candidate => line.startsWith(candidate));
+				return prefix ? line.slice(prefix.length) : line;
+			})
 			.join("\n");
 	}
 	/**
@@ -3073,7 +3086,9 @@ export class Markdown implements Component {
 					// being silently swallowed by the framed renderer.
 					const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
 					for (const rawLine of raw.split("\n")) {
-						lines.push({ text: replaceTabs(rawLine), literalCode: true, nested: false });
+						// Keep open-fence rows in the list-aware noWrap path so the
+						// bullet and continuation rail remain attached before closure.
+						lines.push({ text: replaceTabs(rawLine), noWrap: true, nested: false });
 					}
 				}
 			} else if (isMathToken(token)) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1523,6 +1523,8 @@ function splitPushedHighlightLines(pushed: string): string[] {
 
 export class Markdown implements Component {
 	#text: string;
+	/** Original input retained for copy-chip payloads (before display tab expansion). */
+	#sourceText: string;
 	#paddingX: number; // Left/right padding
 	#paddingY: number; // Top/bottom padding
 	#defaultTextStyle?: DefaultTextStyle;
@@ -1594,7 +1596,8 @@ export class Markdown implements Component {
 		defaultTextStyle?: DefaultTextStyle,
 		codeBlockIndent: number = 2,
 	) {
-		this.#text = normalizeOsc8Terminators(text);
+		this.#sourceText = normalizeOsc8Terminators(text);
+		this.#text = this.#sourceText;
 		this.#paddingX = paddingX;
 		this.#paddingY = paddingY;
 		this.#theme = theme;
@@ -1615,6 +1618,7 @@ export class Markdown implements Component {
 			// reused — the checked region may have changed anywhere.
 			this.#appendOnlySinceLastScan = false;
 		}
+		this.#sourceText = text;
 		this.#text = text;
 		if (!text.trim()) {
 			// Blank replacement: render() early-returns before #lexTokens can see
@@ -2028,6 +2032,33 @@ export class Markdown implements Component {
 		return firstLine.startsWith("```") || firstLine.startsWith("~~~");
 	}
 
+	/** Recover the source body for copy targets after display tab expansion. */
+	#originalCodeBody(token: Token): string {
+		const fallback = "text" in token && typeof token.text === "string" ? token.text : "";
+		const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+		if (!raw) return fallback;
+		const expandedSource = replaceTabs(this.#sourceText);
+		const expandedStart = expandedSource.indexOf(raw);
+		if (expandedStart < 0) return fallback;
+		const toSourceOffset = (expandedOffset: number): number => {
+			let expanded = 0;
+			for (let sourceOffset = 0; sourceOffset < this.#sourceText.length; sourceOffset++) {
+				if (expanded >= expandedOffset) return sourceOffset;
+				expanded += this.#sourceText[sourceOffset] === "\t" ? 3 : 1;
+			}
+			return this.#sourceText.length;
+		};
+		const sourceRaw = this.#sourceText.slice(
+			toSourceOffset(expandedStart),
+			toSourceOffset(expandedStart + raw.length),
+		);
+		const firstLineEnd = sourceRaw.indexOf("\n");
+		const lastLineStart = sourceRaw.lastIndexOf("\n");
+		return firstLineEnd >= 0 && lastLineStart > firstLineEnd
+			? sourceRaw.slice(firstLineEnd + 1, lastLineStart)
+			: fallback;
+	}
+
 	/**
 	 * Frame fenced code in the same rounded-box language as the welcome screen.
 	 * The box hugs its content: width is the longest body row or the header,
@@ -2046,8 +2077,8 @@ export class Markdown implements Component {
 		const rawTitle = label ? ` [${label}] ` : "";
 
 		// A full box needs two borders, two breathing spaces, and one content cell.
-		// Use a compact borderless body when the caller has fewer than five cells.
-		if (requestedWidth < 5) {
+		// Use a compact borderless body when the caller has fewer than six cells.
+		if (requestedWidth < 6) {
 			const edge = box.vertical;
 			const sourceWidth = Math.max(1, requestedWidth - 2);
 			const narrow: RenderedLine[] = [];
@@ -2125,7 +2156,7 @@ export class Markdown implements Component {
 		if (copyLabel && visibleWidth(copyLabel) > 0) {
 			const chipWidth = visibleWidth(copyLabel);
 			const fill = Math.max(0, innerWidth - chipWidth - 1);
-			const code = "text" in token && typeof token.text === "string" ? token.text : "";
+			const code = this.#originalCodeBody(token);
 			const target = code && TERMINAL.hyperlinks ? this.#theme.copyChipTarget?.(code) : undefined;
 			const chip = target
 				? `\x1b]8;;${target.replaceAll("\x1b", "").replaceAll("\x07", "")}\x07${border(copyLabel)}\x1b]8;;\x07`
@@ -2870,8 +2901,8 @@ export class Markdown implements Component {
 			// already carry their own full indent.
 			// Framed code blocks must fit inside the hang, not the full list
 			// width, or the right border lands under the bullet rail.
-			const itemWidth = Math.max(1, width - visibleWidth(bullet));
-			const itemLines = this.#renderListItem(item.tokens || [], depth, itemWidth, styleContext);
+			const itemWidth = Math.max(1, width - visibleWidth(firstPrefix));
+			const itemLines = this.#renderListItem(item.tokens || [], depth, itemWidth, styleContext, itemWidth);
 			if (itemLines.length > 0) {
 				const firstLine = itemLines[0]!;
 				if (firstLine.nested) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1908,6 +1908,10 @@ export class Markdown implements Component {
 		if (reusablePrefix && reusablePrefix.tokenCount <= stableTokenCount) {
 			contentLines.push(...reusablePrefix.lines);
 			renderedUntil = reusablePrefix.tokenCount;
+			// The stable tokens were not rendered in this frame. Start source-span
+			// recovery after their expanded prefix so an equivalent tail fence cannot
+			// resolve to the first stable occurrence.
+			this.#copySourceSearchCursor = replaceTabs(stableText).length;
 		}
 
 		if (renderedUntil < stableTokenCount) {
@@ -2078,7 +2082,9 @@ export class Markdown implements Component {
 			if (openAt < 0) return fallback;
 			const closeAt = expandedSource.indexOf(closeLine, openAt + openLine.length);
 			if (closeAt < 0) return fallback;
-			expandedStart = openAt;
+			// Include the container prefix on the opening line so it can be removed
+			// consistently from each recovered body line below.
+			expandedStart = expandedSource.lastIndexOf("\n", openAt - 1) + 1;
 			expandedEnd = closeAt + closeLine.length;
 		}
 		this.#copySourceSearchCursor = Math.max(this.#copySourceSearchCursor, expandedEnd);
@@ -2093,9 +2099,16 @@ export class Markdown implements Component {
 		const sourceRaw = this.#sourceText.slice(toSourceOffset(expandedStart), toSourceOffset(expandedEnd));
 		const firstLineEnd = sourceRaw.indexOf("\n");
 		const lastLineStart = sourceRaw.lastIndexOf("\n");
-		return firstLineEnd >= 0 && lastLineStart > firstLineEnd
-			? sourceRaw.slice(firstLineEnd + 1, lastLineStart)
-			: fallback;
+		if (firstLineEnd < 0 || lastLineStart <= firstLineEnd) return fallback;
+		const openingLine = sourceRaw.slice(0, firstLineEnd);
+		const fenceAt = openingLine.search(/(`{3,}|~{3,})/);
+		const containerPrefix = fenceAt > 0 ? openingLine.slice(0, fenceAt) : "";
+		const body = sourceRaw.slice(firstLineEnd + 1, lastLineStart);
+		if (!containerPrefix) return body;
+		return body
+			.split("\n")
+			.map(line => (line.startsWith(containerPrefix) ? line.slice(containerPrefix.length) : line))
+			.join("\n");
 	}
 	/**
 	 * Frame fenced code in the same rounded-box language as the welcome screen.

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1535,6 +1535,8 @@ export class Markdown implements Component {
 	#text: string;
 	/** Original input retained for copy-chip payloads (before display tab expansion). */
 	#sourceText: string;
+	/** Expanded-source cursor used to disambiguate repeated fenced blocks. */
+	#copySourceSearchCursor = 0;
 	#paddingX: number; // Left/right padding
 	#paddingY: number; // Top/bottom padding
 	#defaultTextStyle?: DefaultTextStyle;
@@ -1832,6 +1834,7 @@ export class Markdown implements Component {
 
 		// Parse markdown to HTML-like tokens
 		const tokens = this.#lexTokens(normalizedText);
+		this.#copySourceSearchCursor = 0;
 		let contentLines: string[];
 		this.#activeRenderSignature = signature;
 		try {
@@ -2056,7 +2059,9 @@ export class Markdown implements Component {
 		const rawForSpan = raw.replace(/^(?:\r?\n)+|(?:\r?\n)+$/g, "");
 		if (!rawForSpan) return fallback;
 		const expandedSource = replaceTabs(this.#sourceText);
-		let expandedStart = expandedSource.indexOf(rawForSpan);
+		const searchStart = this.#copySourceSearchCursor;
+		let expandedStart = expandedSource.indexOf(rawForSpan, searchStart);
+		let expandedEnd = expandedStart >= 0 ? expandedStart + rawForSpan.length : -1;
 		if (expandedStart < 0) {
 			// Nested tokens lose their container prefixes, so `raw` is not a
 			// contiguous substring of the source. Locate the opening and actual
@@ -2069,12 +2074,14 @@ export class Markdown implements Component {
 					.find(line => line.trim().length > 0)
 					?.trim() ?? "";
 			if (!openLine || !closeLine) return fallback;
-			const openAt = expandedSource.indexOf(openLine);
+			const openAt = expandedSource.indexOf(openLine, searchStart);
 			if (openAt < 0) return fallback;
 			const closeAt = expandedSource.indexOf(closeLine, openAt + openLine.length);
 			if (closeAt < 0) return fallback;
 			expandedStart = openAt;
+			expandedEnd = closeAt + closeLine.length;
 		}
+		this.#copySourceSearchCursor = Math.max(this.#copySourceSearchCursor, expandedEnd);
 		const toSourceOffset = (expandedOffset: number): number => {
 			let expanded = 0;
 			for (let sourceOffset = 0; sourceOffset < this.#sourceText.length; sourceOffset++) {
@@ -2083,10 +2090,7 @@ export class Markdown implements Component {
 			}
 			return this.#sourceText.length;
 		};
-		const sourceRaw = this.#sourceText.slice(
-			toSourceOffset(expandedStart),
-			toSourceOffset(expandedStart + rawForSpan.length),
-		);
+		const sourceRaw = this.#sourceText.slice(toSourceOffset(expandedStart), toSourceOffset(expandedEnd));
 		const firstLineEnd = sourceRaw.indexOf("\n");
 		const lastLineStart = sourceRaw.lastIndexOf("\n");
 		return firstLineEnd >= 0 && lastLineStart > firstLineEnd
@@ -2122,7 +2126,9 @@ export class Markdown implements Component {
 					// A single grapheme wider than sourceWidth arrives on its own
 					// over-width row; it must reach the terminal whole instead of
 					// being truncated out of existence.
-					const text = requestedWidth >= 3 ? `${edge}${row}${edge}` : row;
+					const rowWidth = visibleWidth(row);
+					const canFrame = requestedWidth >= 3 && rowWidth + 2 <= requestedWidth;
+					const text = canFrame ? `${edge}${row}${edge}` : truncateToWidth(row, requestedWidth, Ellipsis.Omit);
 					narrow.push({ text, noWrap: true });
 				}
 			}

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1535,6 +1535,8 @@ export class Markdown implements Component {
 	#text: string;
 	/** Original input retained for copy-chip payloads (before display tab expansion). */
 	#sourceText: string;
+	/** Source bytes with display tabs expanded; shared by token-span lookups. */
+	#expandedSourceText: string;
 	/** Expanded-source cursor used to disambiguate repeated fenced blocks. */
 	#copySourceSearchCursor = 0;
 	#paddingX: number; // Left/right padding
@@ -1609,6 +1611,7 @@ export class Markdown implements Component {
 		codeBlockIndent: number = 2,
 	) {
 		this.#sourceText = normalizeOsc8Terminators(text);
+		this.#expandedSourceText = replaceTabs(this.#sourceText);
 		this.#text = this.#sourceText;
 		this.#paddingX = paddingX;
 		this.#paddingY = paddingY;
@@ -1631,6 +1634,7 @@ export class Markdown implements Component {
 			this.#appendOnlySinceLastScan = false;
 		}
 		this.#sourceText = text;
+		this.#expandedSourceText = replaceTabs(text);
 		this.#text = text;
 		if (!text.trim()) {
 			// Blank replacement: render() early-returns before #lexTokens can see
@@ -2052,6 +2056,20 @@ export class Markdown implements Component {
 		return firstLine.startsWith("```") || firstLine.startsWith("~~~");
 	}
 
+	/**
+	 * Advance the raw-source lookup past a rendered leaf token. Container tokens
+	 * recurse into their children, while code tokens advance from the exact span
+	 * resolved by #originalCodeBody().
+	 */
+	#advanceCopySourceCursor(token: Token): void {
+		if (token.type === "code" || token.type === "list" || token.type === "blockquote") return;
+		const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+		if (!raw) return;
+		const expandedSource = this.#expandedSourceText;
+		const offset = expandedSource.indexOf(raw, this.#copySourceSearchCursor);
+		if (offset >= 0) this.#copySourceSearchCursor = offset + raw.length;
+	}
+
 	/** Recover the source body for copy targets after display tab expansion. */
 	#originalCodeBody(token: Token): string {
 		const fallback = "text" in token && typeof token.text === "string" ? token.text : "";
@@ -2062,7 +2080,7 @@ export class Markdown implements Component {
 		// delimiter-adjacent newlines used for locating this token.
 		const rawForSpan = raw.replace(/^(?:\r?\n)+|(?:\r?\n)+$/g, "");
 		if (!rawForSpan) return fallback;
-		const expandedSource = replaceTabs(this.#sourceText);
+		const expandedSource = this.#expandedSourceText;
 		const searchStart = this.#copySourceSearchCursor;
 		let expandedStart = expandedSource.indexOf(rawForSpan, searchStart);
 		let expandedEnd = expandedStart >= 0 ? expandedStart + rawForSpan.length : -1;
@@ -2537,6 +2555,7 @@ export class Markdown implements Component {
 		styleContext?: InlineStyleContext,
 	): RenderedLine[] {
 		const lines: RenderedLine[] = [];
+		this.#advanceCopySourceCursor(token);
 
 		// Display math block (own-line `$$…$$` / `\[…\]`): stack `\frac` vertically
 		// and keep `\\` row breaks, so fractions and matrices span multiple lines.
@@ -3037,6 +3056,7 @@ export class Markdown implements Component {
 		const lines: RenderedListItemLine[] = [];
 
 		for (const token of tokens) {
+			this.#advanceCopySourceCursor(token);
 			if (token.type === "list") {
 				// Nested list - render with one additional indent level
 				// These lines carry their own indent, so tag them for pass-through

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -26,6 +26,23 @@ import {
 	wrapTextWithAnsi,
 } from "../utils";
 
+/** Wrap a code row without treating ordinary spaces as break separators. */
+function wrapCodeLineWithAnsi(text: string, width: number): string[] {
+	const maxWidth = Math.max(1, Math.trunc(width));
+	let sentinel = "";
+	for (let codePoint = 0xe000; codePoint <= 0xf8ff; codePoint++) {
+		const candidate = String.fromCodePoint(codePoint);
+		if (!text.includes(candidate)) {
+			sentinel = candidate;
+			break;
+		}
+	}
+	if (!sentinel) sentinel = "\ufffc";
+	const protectedText = text.replaceAll("\u00a0", sentinel).replaceAll(" ", "\u00a0");
+	const rows = wrapTextWithAnsi(protectedText, maxWidth);
+	return rows.map(row => row.replaceAll("\u00a0", " ").replaceAll(sentinel, "\u00a0"));
+}
+
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 
 // Marked treats the backslash in an ST-terminated OSC 8 sequence (`ESC \\`) as
@@ -909,6 +926,15 @@ const EMPTY_RENDER_LINES: readonly string[] = [];
 interface RenderedLine {
 	text: string;
 	literalCode?: true;
+	/** Optional structured code layout used when a fenced row must wrap inside a frame. */
+	codePrefix?: string;
+	/** Unstyled gutter text (digits + connector) so wrap can blank digits without touching ANSI. */
+	codePlainPrefix?: string;
+	codeBody?: string;
+	codeContinuationPrefix?: string;
+	codeOuterPadding?: number;
+	/** Keep a framed code row intact during the outer markdown wrap pass. */
+	noWrap?: true;
 }
 
 interface RenderedListItemLine extends RenderedLine {
@@ -1020,12 +1046,22 @@ const NO_BLOCK_BOUNDARY = { end: 0, count: 0 } as const;
  *  - A preceding `list` must be provably closed: CommonMark lets a same-marker
  *    item continue the list across the blank line, and marked merges both into
  *    one renumbered loose list (`listMayContinueAt`).
+ *
+ * `startIndex` resumes the scan at `tokens[startIndex]` (positions still
+ * accumulate from `base`). The streaming freeze passes the frozen-prefix
+ * token count: that prefix's boundary is permanent under append-only growth
+ * (re-verified when frozen), so only the mutable tail can hold a new one.
  */
-function stableBlockBoundary(text: string, base: number, tokens: Token[]): { end: number; count: number } {
+function stableBlockBoundary(
+	text: string,
+	base: number,
+	tokens: Token[],
+	startIndex = 0,
+): { end: number; count: number } {
 	let pos = base;
 	let end = 0;
 	let count = 0;
-	for (let i = 0; i < tokens.length; i++) {
+	for (let i = startIndex; i < tokens.length; i++) {
 		const raw = tokens[i].raw;
 		const tokenEnd = pos + raw.length;
 		if (raw.endsWith("\n\n")) {
@@ -1169,6 +1205,19 @@ export interface MarkdownTheme {
 	code: (text: string) => string;
 	codeBlock: (text: string) => string;
 	codeBlockBorder: (text: string) => string;
+	/** Render the ASCII language marker and label for a fenced code block header. */
+	codeBlockLanguage?: (lang: string) => string;
+	/** Steering-style ├─/└─/│ gutter inside fenced code blocks. Defaults to true. */
+	guidanceTrail?: boolean;
+	/** Bottom-right chip label (e.g. "copy") painted into the footer rule when set. */
+	copyChip?: string;
+	/**
+	 * Resolve the OSC 8 hyperlink target for a code block's copy chip from its
+	 * raw body. Returns a URL (e.g. `omp-copy:<id>`) to make the chip a real
+	 * click-to-copy link, or undefined to keep it a plain visual label. Only
+	 * used when {@link copyChip} is set and the terminal supports hyperlinks.
+	 */
+	copyChipTarget?: (code: string) => string | undefined;
 	quote: (text: string) => string;
 	quoteBorder: (text: string) => string;
 	hr: (text: string) => string;
@@ -1500,6 +1549,25 @@ export class Markdown implements Component {
 	#streamPrefixText?: string;
 	#streamPrefixTokens?: Token[];
 	#streamPrefixLineCache?: StreamPrefixLineCache;
+	// Guard-scan memo (PoC C): the ref-def/CR verdict with the exact text
+	// length it was checked on. Reuse is sound only while setText has been
+	// append-only since (tracked via the startsWith that setText performs): a
+	// FALSE verdict stays valid — appending cannot remove an offending ref or
+	// CR; a TRUE verdict can flip only when the delta gains a "[" at a fresh
+	// line or a "]" / ":" completing a dangling "[…" that straddles the scan
+	// edge, or "\n" / "\r". Byte-identity of the checked region: replaceTabs
+	// is a per-char map and normalizeOsc8Terminators changes old bytes only
+	// when an OSC8 terminator straddles the boundary (which breaks startsWith
+	// — the flag then reads non-append), so transient-mode appends are
+	// byte-identical. Non-transient repairOrphanClosingFence can additionally
+	// delete a bare fence line; its triggers (heading + table lines) always
+	// bring "\n" with them, so such frames take the suspicious-delta path,
+	// and a deletion that shortens the text trips the length gate — either
+	// way the verdict is re-derived, never reused across the deletion.
+	#lastScanLength = -1;
+	#lastScanCanStream = false;
+	#lastScanValid = false;
+	#appendOnlySinceLastScan = true;
 	// True while #renderStreamingContentLines renders the frozen token range:
 	// frozen code blocks highlight even in transient mode so their bytes match
 	// the finalized render (they render once into the prefix line cache, so
@@ -1542,6 +1610,11 @@ export class Markdown implements Component {
 		// full lex + wrap runs per re-emit — one of the top CPU hotspots during
 		// streaming (issue #4353). Mirrors `Text.setText`'s guard.
 		if (text === this.#text) return false;
+		if (!text.startsWith(this.#text)) {
+			// Non-append edit: the previous frame's guard verdict cannot be
+			// reused — the checked region may have changed anywhere.
+			this.#appendOnlySinceLastScan = false;
+		}
 		this.#text = text;
 		if (!text.trim()) {
 			// Blank replacement: render() early-returns before #lexTokens can see
@@ -1568,6 +1641,11 @@ export class Markdown implements Component {
 		const next = value === true;
 		if (this.#transientRenderCache === next) return;
 		this.#transientRenderCache = next;
+		// The mode switch changes which normalization applies to the raw text
+		// (transient: replaceTabs; final: repairOrphanClosingFence(replaceTabs)),
+		// so a memo computed on the other mode's buffer must not be reused —
+		// re-derive on the next frame instead.
+		this.#appendOnlySinceLastScan = false;
 		this.invalidate();
 	}
 
@@ -1582,13 +1660,52 @@ export class Markdown implements Component {
 		// frozen (#freezeStablePrefix only runs when canStream was true). The prefix
 		// ends at a "\n\n" block boundary (stableBlockBoundary), so the tail starts
 		// at a fresh line — scanning only the tail for ref defs is sufficient and
-		// avoids re-scanning the growing prefix every frame (O(n²) → O(n) overall).
+		// avoids re-scanning the grown prefix every frame (O(n²) → O(n) overall).
 		const prefix = this.#streamPrefixText;
 		const prefixTokens = this.#streamPrefixTokens;
 		const hasPrefix =
 			prefix !== undefined && prefixTokens !== undefined && text.length > prefix.length && text.startsWith(prefix);
 		const refDefText = hasPrefix ? text.slice(prefix.length) : text;
-		const canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
+		// Guard-scan memo (PoC C): while setText has been append-only and the
+		// grown delta introduces no "[", "]", ":", "\n" or "\r", the previous
+		// verdict stays valid — the checked region is byte-identical (OSC8/tab
+		// normalization is prefix-stable on appends) and none of the chars a
+		// ref-def or CR needs crossed the scan edge. A false verdict is monotone
+		// (appends cannot delete an existing ref def or CR), so it is reused
+		// even when the delta is suspicious; only a true verdict on a suspicious
+		// delta re-runs the tail scan (PR #9303). The tail scan is also the
+		// cold path after non-append edits, which clear the memo. A FALSE
+		// verdict is monotone under appends alone (transient mode: no repair,
+		// appends cannot delete a ref-def or CR), so there it is reused even
+		// on a suspicious delta. Final mode is the exception: render() detects
+		// repairOrphanClosingFence deletions (the normalized buffer shrank)
+		// and invalidates the memo on the affected frame, so the re-derive
+		// happens exactly when the CR/ref-def trigger behind a false verdict
+		// may have been deleted — never left stale, and never re-scanned on
+		// frames where the memo is sound.
+		let canStream: boolean;
+		if (this.#lastScanValid && this.#appendOnlySinceLastScan && text.length > this.#lastScanLength) {
+			const delta = text.slice(this.#lastScanLength);
+			if (
+				!delta.includes("[") &&
+				!delta.includes("]") &&
+				!delta.includes(":") &&
+				!delta.includes("\n") &&
+				!delta.includes("\r")
+			) {
+				canStream = this.#lastScanCanStream;
+			} else if (this.#lastScanCanStream) {
+				canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
+			} else {
+				canStream = false;
+			}
+		} else {
+			canStream = !HAS_REF_DEF.test(refDefText) && !refDefText.includes("\r");
+		}
+		this.#lastScanLength = text.length;
+		this.#lastScanCanStream = canStream;
+		this.#lastScanValid = true;
+		this.#appendOnlySinceLastScan = true;
 		if (canStream && hasPrefix) {
 			const tailTokens = lexDocument(refDefText);
 			const tokens = [...prefixTokens, ...tailTokens];
@@ -1612,7 +1729,21 @@ export class Markdown implements Component {
 	// reference definitions, so each token's `raw` is a verbatim slice of `text`
 	// and the summed offsets address `text` exactly.
 	#freezeStablePrefix(text: string, tokens: Token[], opts: { preserveExisting: boolean }): void {
-		const frozen = stableBlockBoundary(text, 0, tokens);
+		// On the streaming-concat path (preserveExisting), tokens[0..prefixCount)
+		// ARE the previously frozen prefix and the text above it is byte-
+		// identical, so its boundary cannot move: re-walking those tokens every
+		// frame is pure overhead (O(prefix) per frame, O(n²) over a stream).
+		// Skip them and resume at the first tail token; `base` starts at the
+		// prefix length so accumulated offsets stay global. The cold full-lex
+		// path (preserveExisting: false) re-derives the whole stream, so it
+		// must keep walking from 0.
+		const skipPrefix = opts.preserveExisting ? (this.#streamPrefixTokens?.length ?? 0) : 0;
+		const frozen = stableBlockBoundary(
+			text,
+			skipPrefix > 0 ? (this.#streamPrefixText?.length ?? 0) : 0,
+			tokens,
+			skipPrefix,
+		);
 		if (frozen.count > 0) {
 			this.#streamPrefixText = text.slice(0, frozen.end);
 			this.#streamPrefixTokens = tokens.slice(0, frozen.count);
@@ -1647,10 +1778,17 @@ export class Markdown implements Component {
 			return EMPTY_RENDER_LINES;
 		}
 
-		// Replace tabs with 3 spaces for consistent rendering
-		const normalizedText = this.transientRenderCache
-			? replaceTabs(this.#text)
-			: repairOrphanClosingFence(replaceTabs(this.#text));
+		// Replace tabs with spaces, then repair orphan fences in final mode.
+		const tabbed = replaceTabs(this.#text);
+		const normalizedText = this.transientRenderCache ? tabbed : repairOrphanClosingFence(tabbed);
+		if (!this.transientRenderCache && normalizedText.length < tabbed.length) {
+			// repairOrphanClosingFence deleted bytes this frame (orphan fence
+			// removed): the guard-scan memo's checked region is no longer
+			// byte-identical, and a cached false verdict may have been based
+			// on the very CR/ref-def line that was deleted. Invalidate so the
+			// next #lexTokens re-derives on the repaired buffer.
+			this.#lastScanValid = false;
+		}
 		const signature = this.#renderSignature(width, paddingX);
 
 		// L2: module-level LRU — survives component disposal/recreation across
@@ -1818,7 +1956,12 @@ export class Markdown implements Component {
 				// Lists wrap while their structural prefixes are still available, so
 				// continuation rows retain the correct hanging indent. Re-wrapping the
 				// flattened rows here would discard that structure.
-				if (token.type === "list" || TERMINAL.isImageLine(renderedRow.text) || isOsc66Line(renderedRow.text)) {
+				if (
+					token.type === "list" ||
+					renderedRow.noWrap === true ||
+					TERMINAL.isImageLine(renderedRow.text) ||
+					isOsc66Line(renderedRow.text)
+				) {
 					wrappedLines.push(renderedRow);
 				} else {
 					const wrappedRows = wrapTextWithAnsi(renderedRow.text, contentWidth);
@@ -1879,23 +2022,165 @@ export class Markdown implements Component {
 		return contentLines;
 	}
 
-	#renderCodeBodyLines(token: Token, codeIndent: string): RenderedLine[] {
+	#isFencedCodeToken(token: Token): boolean {
+		const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+		const firstLine = raw.slice(0, raw.indexOf("\n") >= 0 ? raw.indexOf("\n") : raw.length).trimStart();
+		return firstLine.startsWith("```") || firstLine.startsWith("~~~");
+	}
+
+	/**
+	 * Frame fenced code in the same rounded-box language as the welcome screen.
+	 * The box hugs its content: width is the longest body row or the header,
+	 * never the full terminal row. The active symbol preset owns the glyphs:
+	 * unicode/nerd-font get ╭─╮│, the ascii preset degrades to +-| — one code
+	 * path, both terminals. Syntax colors come from the active Markdown theme.
+	 */
+	#boxFencedCodeLines(token: Token, bodyLines: readonly RenderedLine[], width: number): RenderedLine[] {
+		const box = this.#theme.symbols.boxRound;
+		const borderColor = this.#theme.codeBlockBorder;
+		const border = (text: string): string => borderColor(text);
+		const requestedWidth = Math.max(0, Math.trunc(width));
+		const lang = "lang" in token && typeof token.lang === "string" && token.lang.length > 0 ? token.lang : undefined;
+		const formattedLabel = lang ? this.#theme.codeBlockLanguage?.(lang)?.trim() : undefined;
+		const label = formattedLabel && visibleWidth(formattedLabel) > 0 ? formattedLabel : (lang ?? "");
+		const rawTitle = label ? ` [${label}] ` : "";
+
+		// A full box needs two borders, two breathing spaces, and one content cell.
+		// Use a compact borderless body when the caller has fewer than five cells.
+		if (requestedWidth < 5) {
+			const edge = box.vertical;
+			const sourceWidth = Math.max(1, requestedWidth - 2);
+			const narrow: RenderedLine[] = [];
+			for (const body of bodyLines) {
+				const source = body.codeBody ?? body.text;
+				for (const row of wrapCodeLineWithAnsi(source, sourceWidth)) {
+					const content = truncateToWidth(row, sourceWidth, Ellipsis.Omit);
+					const text =
+						requestedWidth >= 3
+							? `${edge}${content}${edge}`
+							: truncateToWidth(content, requestedWidth, Ellipsis.Omit);
+					narrow.push({ text, noWrap: true });
+				}
+			}
+			return narrow.length > 0 ? narrow : [{ text: "", noWrap: true }];
+		}
+
+		const bodyWidth = bodyLines.reduce((max, line) => Math.max(max, visibleWidth(line.text)), 0);
+		const outerPadding = bodyLines.some(line => (line.codeOuterPadding ?? 0) > 0) ? 1 : 0;
+		const maxInnerWidth = Math.max(3, requestedWidth - 2);
+		const innerWidth = Math.min(maxInnerWidth, Math.max(3, bodyWidth + outerPadding + 2, visibleWidth(rawTitle) + 1));
+		const contentWidth = innerWidth - 2;
+		const title = truncateToWidth(rawTitle, Math.max(0, innerWidth - 1), Ellipsis.Omit);
+		const titleWidth = visibleWidth(title);
+		const headerFill = Math.max(0, innerWidth - titleWidth - 1);
+		const header =
+			`${border(`${box.topLeft}${box.horizontal}`)}` +
+			`${border(title)}` +
+			`${border(`${box.horizontal.repeat(headerFill)}${box.topRight}`)}`;
+		const framed: RenderedLine[] = [{ text: header, noWrap: true }];
+
+		for (const body of bodyLines) {
+			const prefix = body.codePrefix ?? "";
+			const plainPrefix = body.codePlainPrefix ?? prefix;
+			const leftPadding = padding(Math.min(body.codeOuterPadding ?? 0, contentWidth));
+			const available = Math.max(0, contentWidth - visibleWidth(leftPadding));
+			const source = body.codeBody ?? body.text;
+			const styled = body.codePlainPrefix !== undefined;
+			// Reserve one content cell so a narrow frame never drops the code row
+			// behind a full line-number/guidance prefix. Truncate the plain prefix
+			// before styling it so ANSI sequences cannot defeat the width bound.
+			const prefixBudget = Math.max(0, available - 1);
+			const basePlainPrefix = truncateToWidth(plainPrefix, prefixBudget, Ellipsis.Omit);
+			const sourceWidth = Math.max(1, available - visibleWidth(basePlainPrefix));
+			const firstPlainPrefix =
+				visibleWidth(source) > sourceWidth && basePlainPrefix
+					? basePlainPrefix.replace("└─", "├─")
+					: basePlainPrefix;
+			const continuationPlain = plainPrefix
+				? plainPrefix.replace(/\d/g, " ").replace(/├─/, "│ ").replace(/└─/, "│ ")
+				: (body.codeContinuationPrefix ?? "");
+			const firstPrefixPlain = truncateToWidth(firstPlainPrefix, prefixBudget, Ellipsis.Omit);
+			const continuationPlainFitted = truncateToWidth(continuationPlain, prefixBudget, Ellipsis.Omit);
+			const firstPrefix = styled ? this.#theme.codeBlockBorder(firstPrefixPlain) : firstPrefixPlain;
+			const continuationPrefix = styled
+				? this.#theme.codeBlockBorder(continuationPlainFitted)
+				: continuationPlainFitted;
+			const wrapped = wrapCodeLineWithAnsi(source, sourceWidth);
+			const visualRows = wrapped.length > 0 ? wrapped : [""];
+
+			for (let rowIndex = 0; rowIndex < visualRows.length; rowIndex++) {
+				const rowPrefix = rowIndex === 0 ? firstPrefix : continuationPrefix;
+				const rawRow = leftPadding + rowPrefix + visualRows[rowIndex]!;
+				const rowText = truncateToWidth(rawRow, contentWidth, Ellipsis.Omit);
+				const pad = Math.max(0, contentWidth - visibleWidth(rowText));
+				framed.push({
+					text: `${border(box.vertical)} ${rowText}${padding(pad)} ${border(box.vertical)}`,
+					noWrap: true,
+				});
+			}
+		}
+
+		const rawCopyLabel = this.#theme.copyChip ? `[${this.#theme.copyChip}]` : "";
+		const copyLabel = truncateToWidth(rawCopyLabel, Math.max(0, innerWidth - 1), Ellipsis.Omit);
+		if (copyLabel && visibleWidth(copyLabel) > 0) {
+			const chipWidth = visibleWidth(copyLabel);
+			const fill = Math.max(0, innerWidth - chipWidth - 1);
+			const code = "text" in token && typeof token.text === "string" ? token.text : "";
+			const target = code && TERMINAL.hyperlinks ? this.#theme.copyChipTarget?.(code) : undefined;
+			const chip = target
+				? `\x1b]8;;${target.replaceAll("\x1b", "").replaceAll("\x07", "")}\x07${border(copyLabel)}\x1b]8;;\x07`
+				: border(copyLabel);
+			framed.push({
+				text: `${border(`${box.bottomLeft}${box.horizontal.repeat(fill)}`)}${chip}${border(`${box.horizontal}${box.bottomRight}`)}`,
+				noWrap: true,
+			});
+		} else {
+			framed.push({
+				text: border(`${box.bottomLeft}${box.horizontal.repeat(innerWidth)}${box.bottomRight}`),
+				noWrap: true,
+			});
+		}
+		return framed;
+	}
+	#renderCodeBodyLines(token: Token, codeIndent: string, lineNumbers = false): RenderedLine[] {
 		const literalCode = this.#codeBlockIndent === 0;
 		const bodyLines: RenderedLine[] = [];
 		const tokenText = "text" in token && typeof token.text === "string" ? token.text : "";
+		const lineNumberWidth = String(tokenText.split("\n").length).length;
+		let lineNumber = 0;
 		const lang = "lang" in token && typeof token.lang === "string" ? token.lang : undefined;
-		const addBodyLine = (line: string): void => {
-			bodyLines.push(renderedLine(literalCode ? line : codeIndent + line, literalCode));
+		const addBodyLine = (line: string, isLastLogical: boolean): void => {
+			// Steering semantics (queued-message-box): `└─` only on the LAST logical
+			// line; the framer demotes it to `├─` when the line wraps. With the
+			// guidance trail off, gutters stay plain `N │ ` (or bare codeIndent).
+			const trail = this.#theme.guidanceTrail !== false;
+			const connector = !trail ? "" : isLastLogical ? "└─" : "├─";
+			const plainPrefix = lineNumbers
+				? trail
+					? `${String(++lineNumber).padStart(lineNumberWidth)} ${connector} `
+					: `${String(++lineNumber).padStart(lineNumberWidth)} ${this.#theme.symbols.boxRound.vertical} `
+				: codeIndent;
+			const styledPrefix = lineNumbers ? this.#theme.codeBlockBorder(plainPrefix) : codeIndent;
+			bodyLines.push({
+				text: styledPrefix + line,
+				literalCode: literalCode ? true : undefined,
+				codePrefix: styledPrefix,
+				codePlainPrefix: plainPrefix,
+				codeBody: line,
+				codeContinuationPrefix: padding(visibleWidth(plainPrefix)),
+				codeOuterPadding: literalCode ? 1 : 0,
+			});
 		};
 
+		const rawLines = tokenText.split("\n");
 		const streaming = this.transientRenderCache && !this.#renderingStablePrefix;
 		if (this.#theme.highlightCode && (!streaming || this.#codeTokenHasClosingFence(token))) {
 			// Finalized content — or a fence that closed mid-stream, which
 			// highlights through the same whole-block call the finalized render
 			// uses so cached stable rows byte-match it.
 			const highlightedLines = this.#theme.highlightCode(tokenText, lang);
-			for (const hlLine of highlightedLines) {
-				addBodyLine(hlLine);
+			for (let i = 0; i < highlightedLines.length; i++) {
+				addBodyLine(highlightedLines[i]!, i === highlightedLines.length - 1);
 			}
 			return bodyLines;
 		}
@@ -1908,17 +2193,17 @@ export class Markdown implements Component {
 			const completedLines = lineEnd >= 0 ? this.#highlightStreamingLines(tokenText.slice(0, lineEnd), lang) : null;
 			if (completedLines) {
 				for (const hlLine of completedLines) {
-					addBodyLine(hlLine);
+					addBodyLine(hlLine, false);
 				}
 				for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
-					addBodyLine(this.#theme.codeBlock(codeLine));
+					addBodyLine(this.#theme.codeBlock(codeLine), true);
 				}
 				return bodyLines;
 			}
 		}
 
-		for (const codeLine of tokenText.split("\n")) {
-			addBodyLine(this.#theme.codeBlock(codeLine));
+		for (let i = 0; i < rawLines.length; i++) {
+			addBodyLine(this.#theme.codeBlock(rawLines[i]!), i === rawLines.length - 1);
 		}
 		return bodyLines;
 	}
@@ -2215,11 +2500,22 @@ export class Markdown implements Component {
 				}
 
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(renderedLine(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`)));
-				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
-					lines.push(bodyLine);
+				const fenced = this.#isFencedCodeToken(token);
+				const closedFence = fenced && this.#codeTokenHasClosingFence(token);
+				const bodyLines = this.#renderCodeBodyLines(token, closedFence ? "" : codeIndent, closedFence);
+				if (closedFence) {
+					// Complete fenced blocks render as a portable ASCII box; raw ```
+					// delimiters never reach the terminal.
+					lines.push(...this.#boxFencedCodeLines(token, bodyLines, width));
+				} else if (fenced) {
+					// An open streamed fence must retain its delimiter rows until it
+					// closes; transcript scrollback depends on those stable rows.
+					lines.push(renderedLine(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`)));
+					for (const bodyLine of bodyLines) lines.push(bodyLine);
+					lines.push(renderedLine(this.#theme.codeBlockBorder("```")));
+				} else {
+					for (const bodyLine of bodyLines) lines.push(bodyLine);
 				}
-				lines.push(renderedLine(this.#theme.codeBlockBorder("```")));
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(renderedLine("")); // Add spacing after code blocks (unless space token follows)
 				}
@@ -2523,6 +2819,13 @@ export class Markdown implements Component {
 		// Use the list's start property (defaults to 1 for ordered lists)
 		const startNumber = token.start ?? 1;
 		const pushWrapped = (line: RenderedLine, firstPrefix: string, continuationPrefix: string): void => {
+			if (line.noWrap) {
+				const available = Math.max(0, width - visibleWidth(firstPrefix));
+				const prefix = truncateToWidth(firstPrefix, width, Ellipsis.Omit);
+				lines.push({ ...line, text: prefix + truncateToWidth(line.text, available, Ellipsis.Omit) });
+				return;
+			}
+
 			if (line.literalCode) {
 				const wrappedLiteralRows = wrapTextWithAnsi(line.text, Math.max(1, width));
 				if (wrappedLiteralRows.length === 0) {
@@ -2565,8 +2868,10 @@ export class Markdown implements Component {
 
 			// Process item tokens; nested-list lines arrive structurally tagged and
 			// already carry their own full indent.
-			const itemLines = this.#renderListItem(item.tokens || [], depth, width, styleContext);
-
+			// Framed code blocks must fit inside the hang, not the full list
+			// width, or the right border lands under the bullet rail.
+			const itemWidth = Math.max(1, width - visibleWidth(bullet));
+			const itemLines = this.#renderListItem(item.tokens || [], depth, itemWidth, styleContext);
 			if (itemLines.length > 0) {
 				const firstLine = itemLines[0]!;
 				if (firstLine.nested) {
@@ -2602,6 +2907,7 @@ export class Markdown implements Component {
 		parentDepth: number,
 		width: number,
 		styleContext?: InlineStyleContext,
+		frameWidth: number = width,
 	): RenderedListItemLine[] {
 		const lines: RenderedListItemLine[] = [];
 
@@ -2638,13 +2944,12 @@ export class Markdown implements Component {
 					lines.push({ text: this.#renderInlineTokens(token.tokens || [], styleContext), nested: false });
 				}
 			} else if (token.type === "code") {
-				// Code block in list item
+				// Code block in list item — fenced blocks get the same themed box.
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push({ text: this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`), nested: false });
-				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
-					lines.push({ ...bodyLine, nested: false });
-				}
-				lines.push({ text: this.#theme.codeBlockBorder("```"), nested: false });
+				const fenced = this.#isFencedCodeToken(token) && this.#codeTokenHasClosingFence(token);
+				const bodyLines = this.#renderCodeBodyLines(token, fenced ? "" : codeIndent, fenced);
+				const framed = fenced ? this.#boxFencedCodeLines(token, bodyLines, frameWidth) : bodyLines;
+				for (const line of framed) lines.push({ ...line, nested: false });
 			} else if (isMathToken(token)) {
 				// Display math block inside a list item: stack fractions / matrix rows.
 				const apply = styleContext?.applyText ?? ((t: string) => this.#applyDefaultStyle(t));

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -43,6 +43,16 @@ function wrapCodeLineWithAnsi(text: string, width: number): string[] {
 	return rows.map(row => row.replaceAll("\u00a0", " ").replaceAll(sentinel, "\u00a0"));
 }
 
+/** Return the widest atomic grapheme in a code source, measured in terminal cells. */
+function widestGraphemeCells(text: string): number {
+	let widest = 1;
+	for (const { segment } of getSegmenter().segment(text)) {
+		if (segment === "\n" || segment === "\r") continue;
+		widest = Math.max(widest, visibleWidth(segment));
+	}
+	return widest;
+}
+
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 
 // Marked treats the backslash in an ST-terminated OSC 8 sequence (`ESC \\`) as
@@ -1809,7 +1819,7 @@ export class Markdown implements Component {
 		// by MarkdownTheme and is one of the most styling-sensitive entries.
 		let cacheKey: string | undefined;
 		if (!this.transientRenderCache) {
-			cacheKey = this.#renderCacheKey(normalizedText, signature);
+			cacheKey = this.#renderCacheKey(normalizedText, this.#text, signature);
 			const cached = renderCache.get(cacheKey);
 			if (cached !== undefined) {
 				// Populate L1 so subsequent calls from this instance are O(1) map lookup.
@@ -1870,8 +1880,11 @@ export class Markdown implements Component {
 		};
 	}
 
-	#renderCacheKey(normalizedText: string, signature: RenderSignature): string {
-		return `${normalizedText}\x00${signature.width}\x00${signature.paddingX}\x00${signature.paddingY}\x00${signature.codeBlockIndent}\x00${signature.themeId}\x00${signature.defaultTextStyleId}\x00${signature.imageProtocol}\x00${signature.hyperlinks ? 1 : 0}\x00${signature.textSizing ? 1 : 0}\x00${signature.bgColorProbe}\x00${signature.headingProbe}`;
+	#renderCacheKey(normalizedText: string, sourceText: string, signature: RenderSignature): string {
+		// The display lexer expands tabs, but copy-chip targets must preserve the
+		// original source bytes. Keep the raw source in the cache identity so two
+		// documents that render identically can never reuse the other's target.
+		return `${normalizedText.length}:${normalizedText}\x00${sourceText.length}:${sourceText}\x00${signature.width}\x00${signature.paddingX}\x00${signature.paddingY}\x00${signature.codeBlockIndent}\x00${signature.themeId}\x00${signature.defaultTextStyleId}\x00${signature.imageProtocol}\x00${signature.hyperlinks ? 1 : 0}\x00${signature.textSizing ? 1 : 0}\x00${signature.bgColorProbe}\x00${signature.headingProbe}`;
 	}
 
 	#renderStreamingContentLines(
@@ -2037,20 +2050,28 @@ export class Markdown implements Component {
 		const fallback = "text" in token && typeof token.text === "string" ? token.text : "";
 		const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
 		if (!raw) return fallback;
+		// Marked may include the newline after a closing fence in token.raw. It
+		// belongs to the following block, not to the copy payload; trim only
+		// delimiter-adjacent newlines used for locating this token.
+		const rawForSpan = raw.replace(/^(?:\r?\n)+|(?:\r?\n)+$/g, "");
+		if (!rawForSpan) return fallback;
 		const expandedSource = replaceTabs(this.#sourceText);
-		let expandedStart = expandedSource.indexOf(raw);
+		let expandedStart = expandedSource.indexOf(rawForSpan);
 		if (expandedStart < 0) {
 			// Nested tokens lose their container prefixes, so `raw` is not a
-			// contiguous substring of the source. Locate the opening fence line
-			// and slice between fence lines instead, keeping original indentation
-			// and tabs intact for the copy payload.
-			const openLine = raw.split("\n", 1)[0] ?? "";
-			const trimmedOpen = openLine.trimStart();
-			if (!trimmedOpen) return fallback;
-			const openAt = expandedSource.indexOf(trimmedOpen);
+			// contiguous substring of the source. Locate the opening and actual
+			// closing fence lines instead, preserving the source span's tabs.
+			const rawLines = rawForSpan.split("\n");
+			const openLine = rawLines[0]?.trim() ?? "";
+			const closeLine =
+				[...rawLines]
+					.reverse()
+					.find(line => line.trim().length > 0)
+					?.trim() ?? "";
+			if (!openLine || !closeLine) return fallback;
+			const openAt = expandedSource.indexOf(openLine);
 			if (openAt < 0) return fallback;
-			const closeLine = raw.split("\n").at(-1)?.trimStart() ?? "";
-			const closeAt = closeLine ? expandedSource.indexOf(closeLine, openAt + openLine.length) : -1;
+			const closeAt = expandedSource.indexOf(closeLine, openAt + openLine.length);
 			if (closeAt < 0) return fallback;
 			expandedStart = openAt;
 		}
@@ -2064,7 +2085,7 @@ export class Markdown implements Component {
 		};
 		const sourceRaw = this.#sourceText.slice(
 			toSourceOffset(expandedStart),
-			toSourceOffset(expandedStart + raw.length),
+			toSourceOffset(expandedStart + rawForSpan.length),
 		);
 		const firstLineEnd = sourceRaw.indexOf("\n");
 		const lastLineStart = sourceRaw.lastIndexOf("\n");
@@ -2072,7 +2093,6 @@ export class Markdown implements Component {
 			? sourceRaw.slice(firstLineEnd + 1, lastLineStart)
 			: fallback;
 	}
-
 	/**
 	 * Frame fenced code in the same rounded-box language as the welcome screen.
 	 * The box hugs its content: width is the longest body row or the header,
@@ -2114,6 +2134,25 @@ export class Markdown implements Component {
 		const maxInnerWidth = Math.max(3, requestedWidth - 2);
 		const innerWidth = Math.min(maxInnerWidth, Math.max(3, bodyWidth + outerPadding + 2, visibleWidth(rawTitle) + 1));
 		const contentWidth = innerWidth - 2;
+		// If even a single atomic grapheme cannot fit beside the frame chrome,
+		// drop the chrome rather than emitting an over-wide noWrap row. The
+		// borderless fallback still hard-wraps at the requested terminal width.
+		const needsCompactGraphemeLayout = bodyLines.some(body => {
+			const source = body.codeBody ?? body.text;
+			const leftPadding = padding(Math.min(body.codeOuterPadding ?? 0, contentWidth));
+			const available = Math.max(0, contentWidth - visibleWidth(leftPadding));
+			return available < widestGraphemeCells(source);
+		});
+		if (needsCompactGraphemeLayout) {
+			const compact: RenderedLine[] = [];
+			for (const body of bodyLines) {
+				const source = body.codeBody ?? body.text;
+				for (const row of wrapCodeLineWithAnsi(source, Math.max(1, requestedWidth))) {
+					compact.push({ text: row, noWrap: true });
+				}
+			}
+			return compact.length > 0 ? compact : [{ text: "", noWrap: true }];
+		}
 		const title = truncateToWidth(rawTitle, Math.max(0, innerWidth - 1), Ellipsis.Omit);
 		const titleWidth = visibleWidth(title);
 		const headerFill = Math.max(0, innerWidth - titleWidth - 1);
@@ -2130,10 +2169,10 @@ export class Markdown implements Component {
 			const available = Math.max(0, contentWidth - visibleWidth(leftPadding));
 			const source = body.codeBody ?? body.text;
 			const styled = body.codePlainPrefix !== undefined;
-			// Reserve one content cell so a narrow frame never drops the code row
-			// behind a full line-number/guidance prefix. Truncate the plain prefix
-			// before styling it so ANSI sequences cannot defeat the width bound.
-			const prefixBudget = Math.max(0, available - 1);
+			// Reserve the widest atomic grapheme so a narrow frame never drops the
+			// code row behind a full line-number/guidance prefix. Truncate the plain
+			// prefix before styling it so ANSI sequences cannot defeat the bound.
+			const prefixBudget = Math.max(0, available - widestGraphemeCells(source));
 			const basePlainPrefix = truncateToWidth(plainPrefix, prefixBudget, Ellipsis.Omit);
 			const sourceWidth = Math.max(1, available - visibleWidth(basePlainPrefix));
 			const firstPlainPrefix =
@@ -2918,7 +2957,7 @@ export class Markdown implements Component {
 			// Framed code blocks must fit inside the hang, not the full list
 			// width, or the right border lands under the bullet rail.
 			const itemWidth = Math.max(1, width - visibleWidth(firstPrefix));
-			const itemLines = this.#renderListItem(item.tokens || [], depth, itemWidth, styleContext, itemWidth);
+			const itemLines = this.#renderListItem(item.tokens || [], depth, itemWidth, styleContext, itemWidth, width);
 			if (itemLines.length > 0) {
 				const firstLine = itemLines[0]!;
 				if (firstLine.nested) {
@@ -2955,6 +2994,7 @@ export class Markdown implements Component {
 		width: number,
 		styleContext?: InlineStyleContext,
 		frameWidth: number = width,
+		nestedWidth: number = width,
 	): RenderedListItemLine[] {
 		const lines: RenderedListItemLine[] = [];
 
@@ -2962,7 +3002,10 @@ export class Markdown implements Component {
 			if (token.type === "list") {
 				// Nested list - render with one additional indent level
 				// These lines carry their own indent, so tag them for pass-through
-				const nestedLines = this.#renderList(token as ListToken, parentDepth + 1, width, styleContext);
+				// `width` is already reduced for the current item's frame. Nested list
+				// recursion must start from the containing list's global width or each
+				// level subtracts its prefix a second time.
+				const nestedLines = this.#renderList(token as ListToken, parentDepth + 1, nestedWidth, styleContext);
 				for (const nestedLine of nestedLines) {
 					lines.push({ ...nestedLine, nested: true });
 				}

--- a/packages/tui/test/markdown-incremental-lex.test.ts
+++ b/packages/tui/test/markdown-incremental-lex.test.ts
@@ -22,6 +22,15 @@ function renderCold(text: string, width: number): readonly string[] {
 	clearRenderCache();
 	return out;
 }
+/** Cold render in transient mode — same masking-safe pattern as renderCold. */
+function renderColdTransient(text: string, width: number): readonly string[] {
+	clearRenderCache();
+	const out = new Markdown(text, 0, 0, THEME);
+	out.transientRenderCache = true;
+	const lines = out.render(width);
+	clearRenderCache();
+	return lines;
+}
 
 /** Reveal `full` in `step`-char increments through ONE reused (streaming) instance
  *  and assert each step matches a cold full-lex render of the same prefix. */
@@ -96,6 +105,36 @@ const MIXED = (() => {
 })();
 
 describe("Markdown incremental streaming lex (E2)", () => {
+	it("renders a fenced JavaScript block and forwards its js language tag", () => {
+		let language: string | undefined;
+		const theme = {
+			...THEME,
+			highlightCode: (code: string, lang?: string) => {
+				language = lang;
+				return code.split("\n").map(line => `JS:${line}`);
+			},
+		};
+		const rendered = new Markdown("```js\nconst answer = 42;\n```", 0, 0, theme).render(80).join("\n");
+		expect(language).toBe("js");
+		expect(rendered).toContain("JS:const answer = 42;");
+		expect(rendered).toContain("js");
+		expect(rendered).not.toContain("```");
+	});
+
+	it("renders the semantic language icon instead of the raw fence language", () => {
+		const icon = "\u{E7A8}"; // Nerd Font Rust devicon
+		const theme = {
+			...THEME,
+			codeBlockLanguage: (lang: string) => `${icon} | ${lang}`,
+		};
+		const rendered = new Markdown("```rust\nfn main() {}\n```", 0, 0, theme).render(80).join("\n");
+		expect(rendered).toContain(icon);
+		expect(rendered).toContain("rust");
+		expect(rendered).toContain("| rust]");
+		expect(rendered).not.toContain("rust rust");
+		expect(rendered).not.toContain("```");
+	});
+
 	it("prose growth is byte-identical to full lex", () => {
 		assertIdenticalGrowth(PROSE);
 	});
@@ -310,6 +349,27 @@ describe("Markdown incremental streaming lex (E2)", () => {
 		expect(streamLines).toEqual(renderCold(doc, 60));
 	});
 
+	it("orphan-fence repair starting mid-stream keeps growth byte-identical", () => {
+		// Final-mode repairOrphanClosingFence deletes an unmatched bare fence
+		// once both a heading and a GFM table delimiter follow it. The raw text
+		// grows append-only across the transition while the NORMALIZED text
+		// (with the fence deleted) is no longer an append-extension of the
+		// previous frame's, so the guard-scan memo's byte alignment is put to
+		// the test: the trigger either brings "\n" into the delta (suspicious
+		// path re-scans) or shortens the text (length gate re-derives). The
+		// cold-render oracle must match at every step.
+		const doc =
+			"Intro paragraph before the stray fence lands in the stream.\n\n" +
+			"```\n" +
+			"# Heading after the orphan fence\n\n" +
+			"| col a | col b |\n" +
+			"| --- | --- |\n\n" +
+			"Trailing paragraph that keeps streaming after the table ends.";
+		assertIdenticalGrowth(doc, 60, 1);
+		assertIdenticalGrowth(doc, 60, 3);
+		assertIdenticalGrowth(doc, 60, 13);
+	});
+
 	it("a document that is one still-growing list never freezes mid-list", () => {
 		// No (b)-style intra-list freezing shipped: loose/tight and ordered
 		// renumbering are whole-list properties, so no prefix of an open list
@@ -322,6 +382,42 @@ describe("Markdown incremental streaming lex (E2)", () => {
 			streaming.setText(doc.slice(0, len));
 			const streamLines = streaming.render(60);
 			expect(streamLines).toEqual(renderCold(doc.slice(0, len), 60));
+		}
+	});
+
+	it("flipping transientRenderCache re-derives the guard memo", () => {
+		// Regression: final mode normalized this document through
+		// repairOrphanClosingFence, which deleted the bare fence line carrying
+		// the text's only "\r". Memoized in final mode the verdict is
+		// canStream=true (no CR, no ref defs) with #lastScanLength taken from
+		// the REPAIRED buffer. Flipping to transient mode re-introduces the
+		// raw "\r" (transient skips repair); if the memo survived the flip, a
+		// clean-suffix append would reuse canStream=true and stream the
+		// CR-containing tail. The mode flip must invalidate the memo so the
+		// next frame re-derives and falls back to the full lex.
+		const crlfFence =
+			"Intro paragraph before the stray fence with a CRLF line end.\n\n" +
+			"```\r\n" +
+			"# Heading after the fence\n\n" +
+			"| a | b |\n" +
+			"| --- | --- |\n\n" +
+			"Tail prose that only streams in after the table.";
+		const streaming = new Markdown("", 0, 0, THEME);
+		clearRenderCache();
+		streaming.setText(crlfFence);
+		streaming.render(60); // final mode: repair deletes the fence + its CR
+		// Switch to transient streaming on the same instance and append only
+		// CLEAN suffixes (no newline/bracket/colon): a stale memo would be
+		// reused on each of these and stream the CR-containing tail against
+		// the repaired-buffer prefix, diverging from the cold render.
+		streaming.transientRenderCache = true;
+		let grown = crlfFence;
+		for (const suffix of [" tail-a", " tail-b", " tail-c"]) {
+			grown += suffix;
+			clearRenderCache();
+			streaming.setText(grown);
+			const streamLines = streaming.render(60);
+			expect(streamLines).toEqual(renderColdTransient(grown, 60));
 		}
 	});
 });

--- a/packages/tui/test/markdown-tree-wrap.test.ts
+++ b/packages/tui/test/markdown-tree-wrap.test.ts
@@ -116,23 +116,35 @@ describe("Markdown tree-guide hanging wrap", () => {
 		expect(plain).toEqual(["├── alpha", "│   └── beta", "└── gamma"]);
 	});
 
-	it("keeps the old column-0 wrap for '├── ' lines inside fenced code blocks", () => {
+	it("leaves '├── ' lines inside fenced code blocks to the code frame, not the tree wrap", () => {
 		const codeLine = "├── alpha bravo charlie delta echo foxtrot golf hotel india";
 		const raw = renderRaw(`\`\`\`\n${codeLine}\n\`\`\``);
 		const plain = raw.map(line => stripVTControlCharacters(line).trimEnd());
 
-		expect(plain[0]).toBe("```");
-		expect(plain[plain.length - 1]).toBe("```");
+		// Fences render as a compact frame; the tree glyph is code text here, so
+		// the markdown tree-hanging wrap must not claim it.
+		expect(plain[0]).toMatch(/^\+-+\+$/);
+		expect(plain[plain.length - 1]).toMatch(/^\+-+\+$/);
+		expect(plain.some(line => line.includes("```"))).toBe(false);
 
-		const treeRow = plain.findIndex(line => line.includes("├──"));
-		expect(treeRow).toBeGreaterThan(0);
-		// The code line overflows, so a continuation row exists before the
-		// closing fence — and it starts flush at column 0, no hanging prefix.
-		const continuation = plain[treeRow + 1]!;
-		expect(treeRow + 1).toBeLessThan(plain.length - 1);
-		expect(continuation.length).toBeGreaterThan(0);
-		expect(continuation[0]).not.toBe(" ");
-		expect(continuation[0]).not.toBe("│");
+		const body = plain.slice(1, -1);
+		expect(body.length).toBeGreaterThanOrEqual(2);
+		for (const line of body) {
+			expect(line.startsWith("| ")).toBeTruthy();
+			expect(line.endsWith("|")).toBeTruthy();
+		}
+		// First visual row carries the frame's own `├─` gutter, continuations the
+		// `│` rail — never a markdown hanging indent at column 0.
+		expect(body[0]).toContain("├─ ├── alpha");
+		expect(body[1]).toContain("│ ");
+		expect(body[1]!.startsWith("│")).toBeFalsy();
+
+		// No glyph lost or duplicated by the frame's wrap.
+		const text = body
+			.map(line => line.replace(/^\|\s*(?:\d+\s+)?(?:├─|└─|│)?/, "").replace(/\|$/, ""))
+			.join("")
+			.replace(/ /g, "");
+		expect(text).toBe(codeLine.replace(/ /g, ""));
 
 		for (const line of raw) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(WIDTH);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2829,16 +2829,26 @@ describe("framed code review regressions", () => {
 		expect(plainLines.some(line => line.includes("const value = 1"))).toBe(true);
 	});
 
-	it("passes the raw nested-list code body to the copy target", async () => {
+	it("passes the raw nested-list code body to the copy target", () => {
+		const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+		const originalHyperlinks = terminalState.hyperlinks;
 		let captured: string | undefined;
-		const theme = { ...defaultMarkdownTheme, copyChip: "copy" };
-		Object.defineProperty(theme, "copyChipTarget", {
-			value: (body: string) => {
-				captured = body;
-			},
-			configurable: true,
-		});
-		new Markdown("- item\n\n  ```make\n  \tall\n  ```", 0, 0, theme as typeof defaultMarkdownTheme).render(60);
-		expect(captured).toContain("\t");
+		try {
+			// The copy target is only consulted when OSC 8 links are supported;
+			// force that capability so this source-recovery assertion is portable
+			// across headless/native CI workers.
+			terminalState.hyperlinks = true;
+			const theme = { ...defaultMarkdownTheme, copyChip: "copy" };
+			Object.defineProperty(theme, "copyChipTarget", {
+				value: (body: string) => {
+					captured = body;
+				},
+				configurable: true,
+			});
+			new Markdown("- item\n\n  ```make\n  \tall\n  ```", 0, 0, theme as typeof defaultMarkdownTheme).render(60);
+			expect(captured).toContain("\t");
+		} finally {
+			terminalState.hyperlinks = originalHyperlinks;
+		}
 	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2967,6 +2967,14 @@ describe("framed code review follow-ups", () => {
 		}
 	});
 
+	it("keeps an open fence's list marker attached before closure", () => {
+		const rows = new Markdown("- ```make\n  \tall", 0, 0, defaultMarkdownTheme)
+			.render(40)
+			.map(line => stripVTControlCharacters(line));
+		expect(rows.some(line => line.startsWith("- ```make"))).toBe(true);
+		expect(rows.some(line => line.includes("all"))).toBe(true);
+	});
+
 	it("clamps compact grapheme rows to the requested width", () => {
 		for (const width of [1, 3]) {
 			const rendered = new Markdown("```js\n\u65e5\u672c\u8a9e\n```", 0, 0, defaultMarkdownTheme).render(width);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2855,11 +2855,13 @@ describe("framed code review regressions", () => {
 
 describe("framed code review follow-ups", () => {
 	it("keeps every framed row within the requested width for wide graphemes", () => {
-		for (const width of [6, 7, 8, 9, 10]) {
+		for (const width of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
 			const rendered = new Markdown("```js\n日本語\n```", 0, 0, defaultMarkdownTheme).render(width);
 			expect(rendered.every(line => visibleWidth(line) <= width)).toBe(true);
 			const plain = rendered.map(line => stripVTControlCharacters(line));
-			for (const glyph of ["日", "本", "語"]) expect(plain.some(line => line.includes(glyph))).toBe(true);
+			if (width >= 2) {
+				for (const glyph of ["日", "本", "語"]) expect(plain.some(line => line.includes(glyph))).toBe(true);
+			}
 		}
 	});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2887,6 +2887,28 @@ describe("framed code review follow-ups", () => {
 		}
 	});
 
+	it("recovers nested copy payloads when raw ends with a newline", () => {
+		const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+		const originalHyperlinks = terminalState.hyperlinks;
+		let captured: string | undefined;
+		try {
+			terminalState.hyperlinks = true;
+			const theme = {
+				...defaultMarkdownTheme,
+				copyChip: "copy",
+				copyChipTarget: (body: string) => {
+					captured = body;
+					return undefined;
+				},
+			};
+			new Markdown("- item\n\n  ```make\n  \tall\n  ```\n- next", 0, 0, theme).render(80);
+			expect(captured).toContain("\t");
+			expect(captured).not.toContain("```");
+		} finally {
+			terminalState.hyperlinks = originalHyperlinks;
+		}
+	});
+
 	it("keeps nested list frames on the containing width budget", () => {
 		const source = "- outer\n  - inner\n    ```js\n    const value = 1;\n    ```";
 		const rendered = new Markdown(source, 0, 0, defaultMarkdownTheme).render(24);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1147,6 +1147,53 @@ more text`,
 				).toBe(true);
 			}
 		});
+		it("keeps code visible at the exact five-column frame width", () => {
+			const width = 5;
+			const plainLines = new Markdown("```js\nabc\n```", 0, 0, defaultMarkdownTheme)
+				.render(width)
+				.map(line => stripVTControlCharacters(line));
+
+			expect(
+				plainLines.every(line => visibleWidth(line) <= width),
+				plainLines.join("\n"),
+			).toBe(true);
+			expect(plainLines.join("\n")).toContain("abc");
+		});
+		it("subtracts nested-list indentation before sizing a code frame", () => {
+			const width = 24;
+			const source = "- outer\n  - inner\n\n    ```js\n    const value = 123456789;\n    ```";
+			const plainLines = new Markdown(source, 0, 0, defaultMarkdownTheme)
+				.render(width)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+			const frameRows = plainLines.filter(line => /^\s+\|.*\|$/.test(line));
+
+			expect(frameRows.length).toBeGreaterThan(0);
+			expect(frameRows.every(line => line.startsWith("    |"))).toBe(true);
+			expect(
+				plainLines.every(line => visibleWidth(line) <= width),
+				plainLines.join("\n"),
+			).toBe(true);
+		});
+		it("passes the original tabbed code body to copy-chip targets", () => {
+			const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+			const originalHyperlinks = terminalState.hyperlinks;
+			let targetBody = "";
+			try {
+				terminalState.hyperlinks = true;
+				const copyTheme = {
+					...defaultMarkdownTheme,
+					copyChip: "copy",
+					copyChipTarget: (code: string) => {
+						targetBody = code;
+						return "omp-copy:raw-body";
+					},
+				};
+				new Markdown("```make\n\tall:\n\t\t@echo hi\n```", 0, 0, copyTheme).render(40);
+				expect(targetBody).toBe("\tall:\n\t\t@echo hi");
+			} finally {
+				terminalState.hyperlinks = originalHyperlinks;
+			}
+		});
 		it("keeps ordinary prose NUL bytes as ordinary padded text", () => {
 			const markdown = new Markdown("before\0after", 1, 0, defaultMarkdownTheme);
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2904,7 +2904,7 @@ describe("framed code review follow-ups", () => {
 				},
 			};
 			new Markdown("- item\n\n  ```make\n  \tall\n  ```\n- next", 0, 0, theme).render(80);
-			expect(captured).toContain("\t");
+			expect(captured).toBe("\tall");
 			expect(captured).not.toContain("```");
 		} finally {
 			terminalState.hyperlinks = originalHyperlinks;
@@ -2937,6 +2937,33 @@ describe("framed code review follow-ups", () => {
 			expect(captured).toEqual(["\tall", "   all"]);
 		} finally {
 			TERMINAL.hyperlinks = originalHyperlinks;
+		}
+	});
+
+	it("advances copy search past a reused streaming prefix", () => {
+		const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+		const originalHyperlinks = terminalState.hyperlinks;
+		const captured: string[] = [];
+		try {
+			terminalState.hyperlinks = true;
+			const theme = {
+				...defaultMarkdownTheme,
+				copyChip: "copy",
+				copyChipTarget: (body: string) => {
+					captured.push(body);
+					return undefined;
+				},
+			};
+			const stable = "```make\n\tall\n```\n\nprose";
+			const markdown = new Markdown(stable, 0, 0, theme);
+			markdown.transientRenderCache = true;
+			markdown.render(60);
+			captured.length = 0;
+			markdown.setText(`${stable}\n\n\`\`\`sh\n   all\n\`\`\``);
+			markdown.render(60);
+			expect(captured).toEqual(["   all"]);
+		} finally {
+			terminalState.hyperlinks = originalHyperlinks;
 		}
 	});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2917,4 +2917,35 @@ describe("framed code review follow-ups", () => {
 		expect(rendered.every(line => visibleWidth(line) <= 24)).toBe(true);
 		expect(rendered.some(line => stripVTControlCharacters(line).includes("+- [js]"))).toBe(true);
 	});
+
+	it("resolves duplicate post-tab-expansion fences to their own bodies", () => {
+		const captured: string[] = [];
+		const theme = { ...defaultMarkdownTheme, copyChip: "copy" };
+		Object.defineProperty(theme, "copyChipTarget", {
+			value: (body: string) => {
+				captured.push(body);
+			},
+			configurable: true,
+		});
+		const originalHyperlinks = TERMINAL.hyperlinks;
+		try {
+			TERMINAL.hyperlinks = true;
+			new Markdown("```make\n\tall\n```\n\n```sh\n   all\n```", 0, 0, theme as typeof defaultMarkdownTheme).render(
+				60,
+			);
+			expect(captured.some(body => body.includes("\t"))).toBe(true);
+			expect(captured).toEqual(["\tall", "   all"]);
+		} finally {
+			TERMINAL.hyperlinks = originalHyperlinks;
+		}
+	});
+
+	it("clamps compact grapheme rows to the requested width", () => {
+		for (const width of [1, 3]) {
+			const rendered = new Markdown("```js\n\u65e5\u672c\u8a9e\n```", 0, 0, defaultMarkdownTheme).render(width);
+			for (const line of rendered) {
+				expect(Bun.stringWidth(stripVTControlCharacters(line))).toBeLessThanOrEqual(Math.max(1, width));
+			}
+		}
+	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2852,3 +2852,45 @@ describe("framed code review regressions", () => {
 		}
 	});
 });
+
+describe("framed code review follow-ups", () => {
+	it("keeps every framed row within the requested width for wide graphemes", () => {
+		for (const width of [6, 7, 8, 9, 10]) {
+			const rendered = new Markdown("```js\n日本語\n```", 0, 0, defaultMarkdownTheme).render(width);
+			expect(rendered.every(line => visibleWidth(line) <= width)).toBe(true);
+			const plain = rendered.map(line => stripVTControlCharacters(line));
+			for (const glyph of ["日", "本", "語"]) expect(plain.some(line => line.includes(glyph))).toBe(true);
+		}
+	});
+
+	it("does not copy a trailing fence or reuse a tab-expanded cache entry", () => {
+		const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+		const originalHyperlinks = terminalState.hyperlinks;
+		const captured: string[] = [];
+		try {
+			terminalState.hyperlinks = true;
+			const theme = {
+				...defaultMarkdownTheme,
+				copyChip: "copy",
+				copyChipTarget: (body: string) => {
+					captured.push(body);
+					return undefined;
+				},
+			};
+			clearRenderCache();
+			new Markdown("```make\n\tall\n```", 0, 0, theme).render(80);
+			new Markdown("```make\n   all\n```", 0, 0, theme).render(80);
+			new Markdown("```js\nconst value = 1;\n```\n\nnext", 0, 0, theme).render(80);
+			expect(captured).toEqual(["\tall", "   all", "const value = 1;"]);
+		} finally {
+			terminalState.hyperlinks = originalHyperlinks;
+		}
+	});
+
+	it("keeps nested list frames on the containing width budget", () => {
+		const source = "- outer\n  - inner\n    ```js\n    const value = 1;\n    ```";
+		const rendered = new Markdown(source, 0, 0, defaultMarkdownTheme).render(24);
+		expect(rendered.every(line => visibleWidth(line) <= 24)).toBe(true);
+		expect(rendered.some(line => stripVTControlCharacters(line).includes("+- [js]"))).toBe(true);
+	});
+});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2983,4 +2983,25 @@ describe("framed code review follow-ups", () => {
 			}
 		}
 	});
+	it("anchors copy lookup after preceding fence-like prose", () => {
+		const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+		const originalHyperlinks = terminalState.hyperlinks;
+		const captured: string[] = [];
+		try {
+			terminalState.hyperlinks = true;
+			const theme = {
+				...defaultMarkdownTheme,
+				copyChip: "copy",
+				copyChipTarget: (body: string) => {
+					captured.push(body);
+					return undefined;
+				},
+			};
+			const source = "<!--\n```make\n\twrong\n```\n-->\n\n```make\n   right\n```";
+			new Markdown(source, 0, 0, theme).render(80);
+			expect(captured).toEqual(["   right"]);
+		} finally {
+			terminalState.hyperlinks = originalHyperlinks;
+		}
+	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2810,3 +2810,35 @@ describe("windowed lexing (documents past WINDOWED_LEX_MIN_BYTES)", () => {
 		expect(rendered.filter(line => line.includes(" 1. item 0 ")).length).toBeLessThanOrEqual(1);
 	});
 });
+
+describe("framed code review regressions", () => {
+	it("keeps every wide grapheme visible in a narrow frame", () => {
+		const rendered = new Markdown("```js\n日本語\n```", 0, 0, defaultMarkdownTheme).render(8);
+		const plainLines = rendered.map(line => stripVTControlCharacters(line));
+		// The frame cannot hold all six cells at once at this width, but no
+		// grapheme may be truncated out of existence.
+		for (const glyph of ["日", "本", "語"]) {
+			expect(plainLines.some(line => line.includes(glyph))).toBe(true);
+		}
+	});
+
+	it("keeps delimiters on an unclosed fence inside a list", () => {
+		const rendered = new Markdown("- item\n\n  ```js\n  const value = 1", 0, 0, defaultMarkdownTheme).render(60);
+		const plainLines = rendered.map(line => stripVTControlCharacters(line).trimEnd());
+		expect(plainLines.some(line => line.includes("```js"))).toBe(true);
+		expect(plainLines.some(line => line.includes("const value = 1"))).toBe(true);
+	});
+
+	it("passes the raw nested-list code body to the copy target", async () => {
+		let captured: string | undefined;
+		const theme = { ...defaultMarkdownTheme, copyChip: "copy" };
+		Object.defineProperty(theme, "copyChipTarget", {
+			value: (body: string) => {
+				captured = body;
+			},
+			configurable: true,
+		});
+		new Markdown("- item\n\n  ```make\n  \tall\n  ```", 0, 0, theme as typeof defaultMarkdownTheme).render(60);
+		expect(captured).toContain("\t");
+	});
+});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -808,6 +808,135 @@ Average Latency: 1,240 ms
 	});
 
 	describe("Spacing after code blocks", () => {
+		it("renders a JavaScript fenced code block and preserves its source", () => {
+			const script = `const answer = 42;
+console.log(answer);`;
+			const markdown = new Markdown(`\`\`\`js\n${script}\n\`\`\``, 0, 0, defaultMarkdownTheme);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			// Fences are framing only: one `[lang]` header, `├─`/`└─` tree gutters,
+			// a compact ASCII frame, and no raw ``` rows.
+			expect(plainLines[0]).toMatch(/^\+- \[js\] /);
+			expect(plainLines.some(line => line.includes("├─ const answer = 42;"))).toBe(true);
+			expect(plainLines.some(line => line.includes("└─ console.log(answer);"))).toBe(true);
+			expect(plainLines.some(line => line.includes("```"))).toBe(false);
+		});
+
+		it("wraps long highlighted rows inside the same codeblock frame", () => {
+			const source = [
+				"```js",
+				'const endpoint = "https://example.test/a-very-long-path-that-must-stay-inside-the-frame";',
+				"```",
+			].join("\n");
+			const plainLines = new Markdown(source, 0, 0, defaultMarkdownTheme)
+				.render(50)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines[0]).toMatch(/^\+- \[js\] /);
+			expect(plainLines.some(line => line.includes("example.test"))).toBe(true);
+			for (const line of plainLines.slice(0, -1)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(50);
+			}
+			for (const line of plainLines.slice(1, -1)) {
+				expect(line.startsWith("| ")).toBe(true);
+				expect(line.endsWith("|"), `Unframed code row: ${line}`).toBe(true);
+			}
+			// Wrapped logical line: `├─` on the first visual row, `│ ` rail on
+			// continuation rows — same gutter discipline as the steering queue.
+			expect(plainLines[1]).toContain("├─");
+			expect(plainLines[2]).toContain("│ ");
+		});
+
+		it("uses the semantic language icon and one readable label", () => {
+			const semanticTheme = {
+				...defaultMarkdownTheme,
+				codeBlockLanguage: (lang: string) => (lang === "rust" ? `\u{e7a8} ${lang}` : ""),
+			};
+			const markdown = new Markdown("```rust\nfn main() {}\n```", 0, 0, semanticTheme);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines[0]).toContain("\u{e7a8} rust");
+			expect(plainLines[0]).not.toContain("rust rust");
+		});
+
+		it("re-applies border color after a colored title glyph so every frame side matches", () => {
+			// A colored emoji in the title resets the terminal SGR foreground
+			// mid-line. If the header were wrapped in one border() call, the
+			// right-side fill and top-right corner would lose the border color
+			// and render in default white — the exact mismatch users reported
+			// (bright top-right, dim everywhere else). The header must be built
+			// from independently colored segments so the frame reads as one shape.
+			const emojiTheme = {
+				...defaultMarkdownTheme,
+				codeBlockBorder: (t: string) => chalk.dim(t),
+				codeBlockLanguage: () => "\u{1F7E8} js",
+			};
+			const header = new Markdown("```js\nconst a = 1;\n```", 0, 0, emojiTheme).render(40)[0];
+			// A dim-open sequence must appear AFTER the emoji: this guards the
+			// top-right corner against SGR bleed from the glyph.
+			const afterEmoji = header.slice(header.indexOf("\u{1F7E8}"));
+			expect(afterEmoji).toContain("\x1b[2m");
+			// The plain shape stays a single continuous top border.
+			const plain = stripVTControlCharacters(header).trimEnd();
+			expect(plain).toMatch(/^\+- \[\u{1F7E8} js\] -+\+$/u);
+		});
+
+		it("renders the copy chip as an OSC 8 hyperlink when the theme resolves a target", () => {
+			const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+			const originalHyperlinks = terminalState.hyperlinks;
+			try {
+				terminalState.hyperlinks = true;
+				// The chip target makes `[copy]` a real click-to-copy link (opened by
+				// the terminal via the omp-copy: URL scheme), so copy works with a
+				// mouse click without main-screen mouse tracking, so scroll stays native.
+				const linkTheme = {
+					...defaultMarkdownTheme,
+					copyChip: "copy",
+					copyChipTarget: (code: string) => `omp-copy:${code.length.toString(16).padStart(16, "0")}`,
+				};
+				const lines = new Markdown("```js\nconst a = 1;\n```", 0, 0, linkTheme).render(40);
+				const footer = lines.at(-1) ?? "";
+				// OSC 8 open with the resolved target, the [copy] label, then OSC 8 close.
+				expect(footer).toContain("\x1b]8;;omp-copy:");
+				expect(footer).toContain("[copy]");
+				expect(footer).toContain("\x1b]8;;\x07");
+				// Plain footer shape is unchanged: one bottom rule ending in the chip.
+				const plain = stripVTControlCharacters(footer).trimEnd();
+				expect(plain).toMatch(/^\+-+\[copy\]-\+$/);
+			} finally {
+				terminalState.hyperlinks = originalHyperlinks;
+			}
+		});
+		it("does not emit a copy-chip link when terminal hyperlinks are disabled", () => {
+			const terminalState = TERMINAL as unknown as { hyperlinks: boolean };
+			const originalHyperlinks = terminalState.hyperlinks;
+			let targetCalls = 0;
+			try {
+				terminalState.hyperlinks = false;
+				const noLinksTheme = {
+					...defaultMarkdownTheme,
+					copyChip: "copy",
+					copyChipTarget: () => {
+						targetCalls++;
+						return "omp-copy:disabled";
+					},
+				};
+				const footer = new Markdown("```js\nconst x = 1\n```", 0, 0, noLinksTheme).render(40).at(-1) ?? "";
+				expect(targetCalls).toBe(0);
+				expect(footer).not.toContain("\x1b]8;;");
+				expect(stripVTControlCharacters(footer)).toContain("[copy]");
+			} finally {
+				terminalState.hyperlinks = originalHyperlinks;
+			}
+		});
+		it("keeps the copy chip a plain label when the theme resolves no target", () => {
+			const plainChipTheme = { ...defaultMarkdownTheme, copyChip: "copy" };
+			const lines = new Markdown("```js\nconst a = 1;\n```", 0, 0, plainChipTheme).render(40);
+			const footer = lines.at(-1) ?? "";
+			expect(footer).not.toContain("\x1b]8;;");
+			expect(stripVTControlCharacters(footer)).toContain("[copy]");
+		});
+
 		it("should have only one blank line between code block and following paragraph", () => {
 			const markdown = new Markdown(
 				`hello world
@@ -825,15 +954,16 @@ again, hello world`,
 			const lines = markdown.render(80);
 			const plainLines = lines.map(line => stripVTControlCharacters(line).trimEnd());
 
-			const closingBackticksIndex = plainLines.indexOf("```");
-			expect(closingBackticksIndex !== -1, "Should have closing backticks").toBeTruthy();
+			const languageIndex = plainLines.findIndex(line => line.startsWith("+- [js] "));
+			expect(languageIndex !== -1, "Should render the code language label").toBeTruthy();
+			expect(plainLines[languageIndex + 1]).toContain('└─ const hello = "world";');
 
-			const afterBackticks = plainLines.slice(closingBackticksIndex + 1);
-			const emptyLineCount = afterBackticks.findIndex(line => line !== "");
+			const afterCode = plainLines.slice(languageIndex + 3);
+			const emptyLineCount = afterCode.findIndex(line => line !== "");
 
 			expect(
 				emptyLineCount,
-				`Expected 1 empty line after code block, but found ${emptyLineCount}. Lines after backticks: ${JSON.stringify(afterBackticks.slice(0, 5))}`,
+				`Expected 1 empty line after code block, but found ${emptyLineCount}. Lines after code: ${JSON.stringify(afterCode.slice(0, 5))}`,
 			).toBe(1);
 		});
 
@@ -852,7 +982,18 @@ code block
 
 more text`,
 			];
-			const expectedLines = ["hello this is text", "", "```", "  code block", "```", "", "more text"];
+			// The box hugs its content: width = gutter + longest code row, not the
+			// full terminal width. defaultMarkdownTheme uses the ascii preset (+-|),
+			// and a single-line block ends on the `└─` connector.
+			const expectedLines = [
+				"hello this is text",
+				"",
+				"+-----------------+",
+				"| 1 └─ code block |",
+				"+-----------------+",
+				"",
+				"more text",
+			];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
@@ -868,7 +1009,9 @@ more text`,
 
 			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
-			expect(plainLines).toEqual([" ```sh", "cat <<'EOF'", "EOF", " ```"]);
+			expect(plainLines[0]).toMatch(/^ \+- \[sh\] /);
+			expect(plainLines.some(line => line.includes("├─ cat <<'EOF'"))).toBe(true);
+			expect(plainLines.some(line => line.includes("└─ EOF"))).toBe(true);
 		});
 
 		it("keeps literal code body rows unprefixed through nested container wrapping", () => {
@@ -889,14 +1032,121 @@ more text`,
 			for (const text of cases) {
 				const markdown = new Markdown(text, 1, 0, defaultMarkdownTheme, undefined, 0);
 				const plainLines = markdown.render(12).map(line => stripVTControlCharacters(line).trimEnd());
-				const literalRows = plainLines.filter(line => line.includes("x") || line === "EOF");
+				const contentRows = plainLines;
 
-				expect(literalRows.join("")).toBe(`${longCodeLine}EOF`);
-				expect(literalRows.length).toBeGreaterThan(2);
-				expect(literalRows.every(line => line.startsWith("x") || line === "EOF")).toBe(true);
+				expect(plainLines.some(line => line.includes("```"))).toBe(false);
+				expect(
+					contentRows
+						.join("")
+						.split("")
+						.filter(char => char === "x"),
+				).toHaveLength(longCodeLine.length);
+				expect(contentRows.join("")).toContain("E");
+				expect(contentRows.join("")).toContain("O");
+				expect(contentRows.join("")).toContain("F");
+				expect(contentRows.length).toBeGreaterThan(2);
 			}
 		});
 
+		it("aligns every framed row through padding and blockquote layout", () => {
+			const plainLines = new Markdown(
+				"> ```sh\n> printf test\n> EOF\n> ```",
+				1,
+				0,
+				defaultMarkdownTheme,
+				undefined,
+				0,
+			)
+				.render(28)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+			const frameRows = plainLines.filter(line => /[+|]/.test(line));
+
+			expect(frameRows.length).toBeGreaterThanOrEqual(4);
+			expect(
+				frameRows.every(line => line.startsWith(" │ ")),
+				frameRows.join("\n"),
+			).toBe(true);
+			expect(frameRows.map(line => line.search(/[+|]/))).toEqual(frameRows.map(() => 3));
+		});
+
+		it("preserves every code character across hard-wrapped frame rows", () => {
+			const source = "left    right    tail";
+			const plainLines = new Markdown(`\`\`\`txt\n${source}\n\`\`\``, 0, 0, defaultMarkdownTheme)
+				.render(14)
+				.map(line => stripVTControlCharacters(line));
+			const body = plainLines
+				.slice(1, -1)
+				.map(line => {
+					const left = line.indexOf("|");
+					const right = line.lastIndexOf("|");
+					let inner = line.slice(left + 1, right);
+					// The frame adds one separator cell immediately before the right rail.
+					if (inner.length > 0) inner = inner.slice(0, -1);
+					const connector = Math.max(inner.indexOf("├─"), inner.indexOf("└─"));
+					if (connector >= 0) inner = inner.slice(connector + 2).replace(/^ /, "");
+					else {
+						const rail = inner.indexOf("│");
+						if (rail >= 0) inner = inner.slice(rail + 1).replace(/^ {2}/, "");
+					}
+					return inner;
+				})
+				.join("")
+				.trimEnd();
+
+			expect(body).toBe(source);
+		});
+
+		it("keeps narrow list code-frame borders contiguous", () => {
+			const plainLines = new Markdown("- item\n\n  ```js\n  const value = 1\n  ```", 0, 0, defaultMarkdownTheme)
+				.render(22)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+			const frameRows = plainLines.filter(line => /[+|]/.test(line));
+
+			expect(frameRows.some(line => /^\s+\+- \[js\] -+\+$/.test(line))).toBe(true);
+			expect(frameRows.some(line => /^\s+\+-+\+$/.test(line))).toBe(true);
+			expect(frameRows.some(line => /^\s*\|$/.test(line))).toBe(false);
+			expect(
+				frameRows.every(line => visibleWidth(line) <= 22),
+				frameRows.join("\n"),
+			).toBe(true);
+		});
+
+		it("fits oversized language and copy labels inside the frame width", () => {
+			const width = 18;
+			const boundedTheme = {
+				...defaultMarkdownTheme,
+				copyChip: "copy-label-that-is-far-too-long",
+			};
+			const language = "language".repeat(13);
+			const plainLines = new Markdown(`\`\`\`${language}\nx\n\`\`\``, 0, 0, boundedTheme)
+				.render(width)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(
+				plainLines.every(line => visibleWidth(line) <= width),
+				plainLines.join("\n"),
+			).toBe(true);
+			expect(plainLines[0]).toMatch(/^\+-.*\+$/);
+			expect(plainLines.at(-1)).toMatch(/^\+.*\+$/);
+			expect(plainLines.slice(1, -1).every(line => /^\|.*\|$/.test(line))).toBe(true);
+		});
+		it("keeps a short language title complete when width allows", () => {
+			const lines = new Markdown("```javascript\nx\n```", 0, 0, defaultMarkdownTheme)
+				.render(80)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+			expect(lines[0]).toContain("[javascript]");
+		});
+		it("keeps every framed row within very narrow widths", () => {
+			for (const width of [1, 2, 3, 4]) {
+				const lines = new Markdown("```js\nabcdef\n```", 0, 0, defaultMarkdownTheme)
+					.render(width)
+					.map(line => stripVTControlCharacters(line));
+				expect(
+					lines.every(line => visibleWidth(line) <= width),
+					lines.join("\n"),
+				).toBe(true);
+			}
+		});
 		it("keeps ordinary prose NUL bytes as ordinary padded text", () => {
 			const markdown = new Markdown("before\0after", 1, 0, defaultMarkdownTheme);
 
@@ -966,7 +1216,9 @@ more text`,
 			});
 
 			expect(seenSources).toEqual([invalidSource]);
-			expect(plainLines).toEqual(["```mermaid", "  flowchart TD", "    A --", "```"]);
+			expect(plainLines[0]).toMatch(/^\+- \[mermaid\] /);
+			expect(plainLines.some(line => line.includes("flowchart TD"))).toBe(true);
+			expect(plainLines.some(line => line.includes("A --"))).toBe(true);
 		});
 	});
 
@@ -1333,9 +1585,9 @@ bar`,
 			const output = lines.join("\n");
 			const plainOutput = quotedLines.join("\n");
 
-			expect(plainOutput.includes("```js")).toBeTruthy();
+			expect(plainOutput.includes("js")).toBeTruthy();
 			expect(plainOutput.includes("console.log(1)")).toBeTruthy();
-			expect(plainOutput.includes("```")).toBeTruthy();
+			expect(plainOutput.includes("```")).toBeFalsy();
 			expect(output.includes("\x1b[35m")).toBeFalsy();
 			expect(output.includes("\x1b[3m")).toBeTruthy();
 		});
@@ -2488,9 +2740,9 @@ describe("windowed lexing (documents past WINDOWED_LEX_MIN_BYTES)", () => {
 		expect(code.length).toBeGreaterThan(2 * 1024);
 
 		const rendered = plain(doc);
-		// Exactly one fence pair: a window cut inside the block would close and
-		// reopen it (or spill code lines into prose).
-		expect(rendered.filter(line => line.trimStart().startsWith("```"))).toHaveLength(2);
+		// Exactly one language label: a window cut inside the block would split
+		// the code token (or spill code lines into prose).
+		expect(rendered.filter(line => line.startsWith("+- [ts] ")).length).toBe(1);
 		const first = rendered.findIndex(line => line.includes("const value0 = 0;"));
 		expect(first).toBeGreaterThan(-1);
 		for (let i = 0; i < 200; i++) {


### PR DESCRIPTION
## Summary

Markdown streaming still re-runs guard scans over the growing mutable tail and re-walks the frozen prefix on every chunk. Wide fenced code rows also need a structured layout so they can wrap inside their frame instead of losing content at the border. This PR addresses both paths and keeps framed rows safe in nested containers.

**Scope:** 7 files, 738 insertions, 63 deletions. The branch is one commit on top of the current `upstream/main`.

## What

- `RenderedLine` gains structured code layout used for width-aware framed rows; open streamed fences keep their delimiter path.
- Code wrapping preserves ordinary spaces and every source character, including ANSI-styled rows.
- Framed rows participate in outer padding and quote rails, and list items size the frame to the remaining post-prefix width without re-wrapping its borders.
- Language labels and copy chips are treated as bounded display labels. Very narrow widths use a compact fallback that keeps every emitted row within the requested width.
- `MarkdownTheme` hooks are optional. Formatted language labels are used verbatim, without appending the raw fence language a second time, and copy links are emitted only when the terminal supports OSC 8 hyperlinks.
- Streaming lexing memoizes safe append-only guard results and resumes `stableBlockBoundary` at the frozen-prefix token count.
- Coding-agent Mermaid fallback contract tests now assert the framed output produced by the TUI renderer.

## Why

On long streamed responses, re-running the guard scan over a growing tail on every chunk adds repeated work, and re-walking the frozen prefix adds another pass to each frame. Memoization keeps the safe append-only path linear over the stream.

The frame also crosses list, quote, padding, and narrow-terminal boundaries. Keeping those cases in the same structured layout path prevents disconnected borders, dropped code whitespace, and rows that exceed the requested width.

## Testing

- **201 passed, 0 failed:** focused Markdown tests in `packages/tui`, including list, quote, whitespace, label, chip, narrow-width, and incremental-render regressions.
- **1309 passed, 0 failed:** full `packages/tui` test suite.
- **12 passed, 0 failed:** focused Mermaid contract tests in `packages/coding-agent`.
- **Biome and TypeScript checks pass:** `bun run check` from `packages/tui`.
- Incremental output is compared with cold-render output for every append-only prefix in the stream tests.

## Scope

The implementation changes `packages/tui`. The two coding-agent test updates are required because they assert the renderer output for Mermaid fallback blocks.

- [x] Check passes
- [x] Tested locally
- [x] CHANGELOG updated