### PR TITLE
fix(acp): stop dumping structured tool progress as JSON content

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- ACP `hub wait` (and other structured tool progress) no longer renders a raw JSON envelope as the tool row: an empty-text result envelope whose data already rides the frame as `rawOutput` no longer falls back to serializing the whole value into a `content` text block ([#9511](https://github.com/can1357/oh-my-pi/issues/9511)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -979,9 +979,12 @@ function extractReadableText(value: unknown): string | undefined {
 		if (text.length > 0) {
 			return normalizeText(text);
 		}
-		if (hasBinaryContentBlock(contentBlocks)) {
-			return undefined;
-		}
+		// A structured result envelope (`{ content: [...] }`) whose blocks carry no
+		// plain text has nothing readable to surface, and its data already rides the
+		// ACP frame as `rawOutput`. Serializing the whole envelope to JSON would just
+		// render a raw blob as the tool row (e.g. hub wait progress, issue #9511), so
+		// stop here instead of falling through to the JSON fallback.
+		return undefined;
 	}
 	if (extractDetailsImages(value)) {
 		return undefined;
@@ -1032,13 +1035,6 @@ function getContentType(value: unknown): string | undefined {
 	}
 	const type = (value as TypedValue).type;
 	return typeof type === "string" ? type : undefined;
-}
-
-function hasBinaryContentBlock(blocks: unknown[]): boolean {
-	return blocks.some(block => {
-		const type = getContentType(block);
-		return type === "image" || type === "audio";
-	});
 }
 
 function extractStringProperty<T extends object>(value: unknown, key: keyof T): string | undefined {

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -650,6 +650,43 @@ describe("ACP event mapper", () => {
 		});
 	});
 
+	it("does not serialize a hub wait progress envelope into content text", () => {
+		const partialResult = {
+			content: [{ type: "text", text: "" }],
+			details: {
+				op: "wait",
+				jobs: [
+					{ id: "bash_1", state: "running" },
+					{ id: "bash_2", state: "running" },
+				],
+			},
+		};
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_update",
+				toolCallId: "tc-hub-wait",
+				toolName: "hub",
+				args: { op: "wait", i: "waiting for jobs" },
+				partialResult,
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			sessionUpdate: string;
+			content?: unknown;
+			rawOutput?: unknown;
+		};
+		expect(update.sessionUpdate).toBe("tool_call_update");
+		// The job details already ride the frame as structured rawOutput.
+		expect(update.rawOutput).toEqual(partialResult);
+		// An empty-text envelope must not be dumped as a JSON blob display row.
+		expect(update.content).toBeUndefined();
+		expect(JSON.stringify(update.content ?? [])).not.toContain('"op":"wait"');
+	});
+
 	it("keeps terminal content alongside readable text", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{


### PR DESCRIPTION
## Repro
Over ACP, `hub wait` emits a `tool_call_update` roughly every 500ms while waiting on background jobs. Feeding such a frame's partial result (`{ content: [{ type: "text", text: "" }], details: { op: "wait", jobs: [...] } }`) through `mapAgentSessionEventToAcpSessionUpdates` produces a `content` block that is `JSON.stringify` of the whole envelope, so clients render a raw JSON blob as the tool row for the entire wait (minutes at `timeoutMs: 600000`, ~1200 near-identical frames).

## Cause
`extractReadableText` (`packages/coding-agent/src/modes/acp/acp-event-mapper.ts`) falls through to `safeJsonStringify(value)` when a structured result envelope's content blocks yield no plain text. A `hub wait` partial has an empty text block plus structured `details`, so nothing readable is found and the whole value is serialized into a text block via `extractToolCallContent` in the `tool_execution_update` mapping. The data is already present on the frame as `rawOutput`.

## Fix
- In `extractReadableText`, when the value is a content envelope (`{ content: [...] }`) whose blocks carry no plain text, return `undefined` instead of falling through to the JSON serialization. The structured data still rides the ACP frame as `rawOutput`, and the client keeps the readable title from the initial `tool_call`.
- Removed the now-unused `hasBinaryContentBlock` helper (the blanket early return subsumes the binary-block guard).
- Added a regression test asserting a `hub wait` progress update carries structured `rawOutput` but no JSON-blob `content`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/acp-event-mapper.test.ts` — 41 pass, 0 fail. Manually confirmed via the mapper that the wait update now has `content: undefined` with `rawOutput` intact, real text still surfaces, and non-envelope raw objects still get the JSON fallback.

Fixes #9511