### PR TITLE
fix(stats): estimate public xai oauth costs

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed public xAI and matching SuperGrok models missing xAI's higher rate card for prompts reaching 200K tokens ([#9512](https://github.com/can1357/oh-my-pi/issues/9512)).
+
 ## [18.0.2] - 2026-08-23
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -34,6 +34,7 @@ import {
 	AIAND_STATIC_MODELS,
 	ALIBABA_TOKEN_PLAN_STATIC_MODELS,
 	ANTHROPIC_CURATED_FALLBACK_MODELS,
+	applyXaiCatalogPricing,
 	BEDROCK_MANTLE_STATIC_MODELS,
 	buildFireworksFastSeed,
 	buildXaiOAuthStaticSeed,
@@ -685,6 +686,7 @@ async function generateModels() {
 	}
 	allModels = applyUmansPricingFallback(allModels, modelsDevModels);
 	allModels = applyPremiumMultiplierOverrides(allModels);
+	allModels = applyXaiCatalogPricing(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyAntigravityPricingFallback(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -65726,13 +65726,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0639,
-				"output": 0.1278,
-				"cacheRead": 0.01278,
+				"input": 0.04,
+				"output": 0.08,
+				"cacheRead": 0.008,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -76031,8 +76031,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.25,
+				"input": 0.042,
+				"output": 0.22,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -81188,7 +81188,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 196608,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -96315,7 +96315,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121609,9 +121609,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.44,
-				"output": 1.32,
-				"cacheRead": 0.014,
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -129265,6 +129265,85 @@
 				"dropThinkingWhenReasoningEffort": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"Gemma-4-31B-MeroMero-v2": {
+			"id": "Gemma-4-31B-MeroMero-v2",
+			"name": "Gemma 4 31B MeroMero v2",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.08,
+				"output": 0.33,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false
+			}
 		},
 		"Gemma-4-31B-Musica-v1": {
 			"id": "Gemma-4-31B-Musica-v1",
@@ -152419,6 +152498,85 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false
+			}
+		},
+		"ornith-ai/ornith-1.5-9b": {
+			"id": "ornith-ai/ornith-1.5-9b",
+			"name": "Ornith 1.5 9B",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.05,
+				"output": 0.1,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -179081,7 +179239,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -214023,13 +214181,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.18,
-				"cacheRead": 0.028,
+				"input": 0.04,
+				"output": 0.08,
+				"cacheRead": 0.008,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 262144,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -220735,9 +220893,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05446,
-				"output": 0.10892,
-				"cacheRead": 0.010891999999999999,
+				"input": 0.04886,
+				"output": 0.09772,
+				"cacheRead": 0.009772,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -221067,9 +221225,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.413772,
-				"output": 0.827544,
-				"cacheRead": 0.034481000000000005,
+				"input": 0.396894,
+				"output": 0.793788,
+				"cacheRead": 0.0330745,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -227452,7 +227610,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -227461,9 +227619,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.06,
+				"input": 0.24,
+				"output": 0.96,
+				"cacheRead": 0.048,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -244829,7 +244987,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -248047,9 +248205,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
+				"input": 0.95,
 				"output": 4.05,
-				"cacheRead": 0.16999999999999998,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -256539,59 +256697,6 @@
 					"xhigh"
 				]
 			},
-			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
-			"compat": {
-				"officialEndpoint": false,
-				"signingEndpoint": false,
-				"disableStrictTools": false,
-				"disableAdaptiveThinking": false,
-				"allowAnthropicHeaderOverrides": false,
-				"supportsEagerToolInputStreaming": false,
-				"supportsLongCacheRetention": false,
-				"supportsMidConversationSystem": false,
-				"supportsForcedToolChoice": true,
-				"supportsSamplingParams": true,
-				"requiresToolResultId": false,
-				"requiresThinkingEnabled": false,
-				"replayUnsignedThinking": true,
-				"escapeBuiltinToolNames": true
-			},
-			"supportsComputerUseConfig": false,
-			"compatConfig": {
-				"escapeBuiltinToolNames": true
-			}
-		},
-		"umans-qwen3.8-27b-lab": {
-			"id": "umans-qwen3.8-27b-lab",
-			"requiresGlyphTokenization": false,
-			"name": "Umans Qwen3.8 27B (lab)",
-			"api": "anthropic-messages",
-			"provider": "umans",
-			"baseUrl": "https://api.code.umans.ai",
-			"reasoning": true,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 131071,
 			"tokenizer": "qwen3",
 			"supportsComputerUse": false,
 			"compat": {
@@ -272829,7 +272934,7 @@
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
 			"requiresGlyphTokenization": false,
-			"name": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -283105,7 +283210,15 @@
 				"input": 1.25,
 				"output": 2.5,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2.5,
+					"output": 5,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
@@ -283182,7 +283295,15 @@
 				"input": 1.25,
 				"output": 2.5,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2.5,
+					"output": 5,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
@@ -283504,7 +283625,15 @@
 				"input": 1.25,
 				"output": 2.5,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2.5,
+					"output": 5,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
@@ -283598,7 +283727,15 @@
 				"input": 2,
 				"output": 6,
 				"cacheRead": 0.3,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 0.6,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
@@ -283692,7 +283829,15 @@
 				"input": 2,
 				"output": 6,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 1,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
@@ -283859,7 +284004,15 @@
 				"input": 1,
 				"output": 2,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2,
+					"output": 4,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
@@ -284088,10 +284241,18 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2.5,
+					"output": 5,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
@@ -284168,10 +284329,18 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2.5,
+					"output": 5,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
@@ -284341,10 +284510,18 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2.5,
+					"output": 5,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
@@ -284438,10 +284615,18 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.3,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 0.6,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
@@ -284535,10 +284720,18 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 1,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
@@ -284709,10 +284902,18 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.2,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 2,
+					"output": 4,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -283380,7 +283380,15 @@
 				"input": 2,
 				"output": 6,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
@@ -283457,7 +283465,15 @@
 				"input": 2,
 				"output": 6,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
@@ -283534,7 +283550,15 @@
 				"input": 2,
 				"output": 6,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
@@ -284416,10 +284440,18 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.2,
+				"cacheWrite": 0,
+				"longContext": {
+					"inputThreshold": 200000,
+					"inputThresholdInclusive": true,
+					"input": 4,
+					"output": 12,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				}
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -1,5 +1,5 @@
 import MODELS from "./models.json" with { type: "json" };
-import type { Api, KnownProvider, Model, TokenCost, Usage } from "./types";
+import type { Api, KnownProvider, Model, ModelCost, TokenCost, Usage } from "./types";
 
 /**
  * Static bundled model registry loaded from `models.json`.
@@ -43,29 +43,38 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 	const models = getProviderModels(provider);
 	return models ? (Array.from(models.values()) as Model<Api>[]) : [];
 }
-function resolveTokenCost(cost: Model["cost"], promptInputTokens: number): TokenCost {
+function resolveTokenCost(cost: ModelCost, promptInputTokens: number): TokenCost {
 	const longContext = cost.longContext;
 	if (!longContext) return cost;
-	return promptInputTokens > longContext.inputThreshold ? longContext : cost;
+	const reachesThreshold =
+		promptInputTokens > longContext.inputThreshold ||
+		(longContext.inputThresholdInclusive === true && promptInputTokens === longContext.inputThreshold);
+	return reachesThreshold ? longContext : cost;
 }
 
 /** Price a prompt as fully uncached input under its active context-length tier. */
-export function calculateUncachedInputCost(cost: Model["cost"], promptInputTokens: number): number {
+export function calculateUncachedInputCost(cost: ModelCost, promptInputTokens: number): number {
 	const rates = resolveTokenCost(cost, promptInputTokens);
 	return (rates.input / 1_000_000) * promptInputTokens;
 }
 
-export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+/** Price one usage record from a token rate card, including active context tiers. */
+export function calculateUsageCost(cost: ModelCost, usage: Usage): Usage["cost"] {
 	const orchestration = usage.orchestration;
 	const promptInputTokens =
 		usage.input + usage.cacheRead + usage.cacheWrite + (orchestration?.input ?? 0) + (orchestration?.cacheRead ?? 0);
-	const rates = resolveTokenCost(model.cost, promptInputTokens);
+	const rates = resolveTokenCost(cost, promptInputTokens);
 	usage.cost.input = (rates.input / 1000000) * (usage.input + (orchestration?.input ?? 0));
 	usage.cost.output = (rates.output / 1000000) * (usage.output + (orchestration?.output ?? 0));
 	usage.cost.cacheRead = (rates.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0));
 	usage.cost.cacheWrite = cacheWriteCost(rates, usage);
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
+}
+
+/** Price one usage record from its model's token rate card. */
+export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+	return calculateUsageCost(model.cost, usage);
 }
 
 /**

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1315,6 +1315,93 @@ export interface XaiModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+const XAI_LONG_CONTEXT_COSTS: Readonly<Record<string, LongContextTokenCost>> = {
+	"grok-4.3": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 2.5,
+		output: 5,
+		cacheRead: 0.4,
+		cacheWrite: 0,
+	},
+	"grok-4.5": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 4,
+		output: 12,
+		cacheRead: 0.6,
+		cacheWrite: 0,
+	},
+	"grok-4.6": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 4,
+		output: 12,
+		cacheRead: 1,
+		cacheWrite: 0,
+	},
+	"grok-4.20-0309-reasoning": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 2.5,
+		output: 5,
+		cacheRead: 0.4,
+		cacheWrite: 0,
+	},
+	"grok-4.20-0309-non-reasoning": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 2.5,
+		output: 5,
+		cacheRead: 0.4,
+		cacheWrite: 0,
+	},
+	"grok-4.20-multi-agent-0309": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 2.5,
+		output: 5,
+		cacheRead: 0.4,
+		cacheWrite: 0,
+	},
+	"grok-build-0.1": {
+		inputThreshold: 200_000,
+		inputThresholdInclusive: true,
+		input: 2,
+		output: 4,
+		cacheRead: 0.4,
+		cacheWrite: 0,
+	},
+};
+
+function hasTokenPrice(model: ModelSpec): boolean {
+	const cost = model.cost;
+	return cost.input !== 0 || cost.output !== 0 || cost.cacheRead !== 0 || cost.cacheWrite !== 0;
+}
+
+/**
+ * Applies xAI's long-context rate card and mirrors exact public-model prices
+ * onto matching SuperGrok catalog rows.
+ */
+export function applyXaiCatalogPricing(models: readonly ModelSpec[]): ModelSpec[] {
+	const pricedModels = models.map(model => {
+		if (model.provider !== "xai") return model;
+		const longContext = XAI_LONG_CONTEXT_COSTS[model.id];
+		return longContext ? { ...model, cost: { ...model.cost, longContext } } : model;
+	});
+	const publicCosts = new Map(
+		pricedModels
+			.filter(model => model.provider === "xai" && hasTokenPrice(model))
+			.map(model => [model.id, model.cost]),
+	);
+
+	return pricedModels.map(model => {
+		if (model.provider !== "xai-oauth" || hasTokenPrice(model)) return model;
+		const publicCost = publicCosts.get(model.id);
+		return publicCost ? { ...model, cost: { ...publicCost } } : model;
+	});
+}
+
 export function xaiModelManagerOptions(config?: XaiModelManagerConfig): ModelManagerOptions<"openai-responses"> {
 	return {
 		...createOpenAICompatibleModelManagerOptions({

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1315,68 +1315,46 @@ export interface XaiModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
-const XAI_LONG_CONTEXT_COSTS: Readonly<Record<string, LongContextTokenCost>> = {
-	"grok-4.3": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 2.5,
-		output: 5,
-		cacheRead: 0.4,
-		cacheWrite: 0,
-	},
-	"grok-4.5": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 4,
-		output: 12,
-		cacheRead: 0.6,
-		cacheWrite: 0,
-	},
-	"grok-4.6": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 4,
-		output: 12,
-		cacheRead: 1,
-		cacheWrite: 0,
-	},
-	"grok-4.20-0309-reasoning": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 2.5,
-		output: 5,
-		cacheRead: 0.4,
-		cacheWrite: 0,
-	},
-	"grok-4.20-0309-non-reasoning": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 2.5,
-		output: 5,
-		cacheRead: 0.4,
-		cacheWrite: 0,
-	},
-	"grok-4.20-multi-agent-0309": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 2.5,
-		output: 5,
-		cacheRead: 0.4,
-		cacheWrite: 0,
-	},
-	"grok-build-0.1": {
-		inputThreshold: 200_000,
-		inputThresholdInclusive: true,
-		input: 2,
-		output: 4,
-		cacheRead: 0.4,
-		cacheWrite: 0,
-	},
+// xAI bills the whole request at 2x the base rates once the prompt reaches
+// 200K tokens, for every current Grok SKU that carries the two-tier card
+// (grok-4.3/4.5/4.6, every grok-4.20 variant, grok-build-0.1). Source:
+// docs.x.ai/developers/models. Computing the tier from the base keeps it in
+// lockstep with stencil.so price updates instead of a hand-maintained table.
+const XAI_LONG_CONTEXT_THRESHOLD = 200_000;
+const XAI_LONG_CONTEXT_MULTIPLIER = 2;
+
+// SuperGrok surfaces a few models under IDs that differ from their public
+// `xai` catalog equivalent, so the exact-ID price fallback misses them. Map
+// the OAuth ID to the paid ID it mirrors.
+const XAI_OAUTH_PRICE_ALIASES: Record<string, string> = {
+	"grok-4.20-multi-agent-0309": "grok-4.20-multi-agent-beta-latest",
 };
 
-function hasTokenPrice(model: ModelSpec): boolean {
-	const cost = model.cost;
+function xaiHasLongContextTier(modelId: string): boolean {
+	return (
+		modelId === "grok-4.3" ||
+		modelId === "grok-4.5" ||
+		modelId === "grok-4.6" ||
+		modelId === "grok-build-0.1" ||
+		modelId.startsWith("grok-4.20")
+	);
+}
+
+function hasTokenPrice(cost: ModelSpec["cost"]): boolean {
 	return cost.input !== 0 || cost.output !== 0 || cost.cacheRead !== 0 || cost.cacheWrite !== 0;
+}
+
+function withXaiLongContextTier(model: ModelSpec): ModelSpec {
+	if (!xaiHasLongContextTier(model.id) || !hasTokenPrice(model.cost)) return model;
+	const longContext: LongContextTokenCost = {
+		inputThreshold: XAI_LONG_CONTEXT_THRESHOLD,
+		inputThresholdInclusive: true,
+		input: model.cost.input * XAI_LONG_CONTEXT_MULTIPLIER,
+		output: model.cost.output * XAI_LONG_CONTEXT_MULTIPLIER,
+		cacheRead: model.cost.cacheRead * XAI_LONG_CONTEXT_MULTIPLIER,
+		cacheWrite: model.cost.cacheWrite * XAI_LONG_CONTEXT_MULTIPLIER,
+	};
+	return { ...model, cost: { ...model.cost, longContext } };
 }
 
 /**
@@ -1384,20 +1362,17 @@ function hasTokenPrice(model: ModelSpec): boolean {
  * onto matching SuperGrok catalog rows.
  */
 export function applyXaiCatalogPricing(models: readonly ModelSpec[]): ModelSpec[] {
-	const pricedModels = models.map(model => {
-		if (model.provider !== "xai") return model;
-		const longContext = XAI_LONG_CONTEXT_COSTS[model.id];
-		return longContext ? { ...model, cost: { ...model.cost, longContext } } : model;
-	});
+	const pricedModels = models.map(model => (model.provider === "xai" ? withXaiLongContextTier(model) : model));
 	const publicCosts = new Map(
 		pricedModels
-			.filter(model => model.provider === "xai" && hasTokenPrice(model))
+			.filter(model => model.provider === "xai" && hasTokenPrice(model.cost))
 			.map(model => [model.id, model.cost]),
 	);
 
 	return pricedModels.map(model => {
-		if (model.provider !== "xai-oauth" || hasTokenPrice(model)) return model;
-		const publicCost = publicCosts.get(model.id);
+		if (model.provider !== "xai-oauth" || hasTokenPrice(model.cost)) return model;
+		const alias = XAI_OAUTH_PRICE_ALIASES[model.id];
+		const publicCost = publicCosts.get(model.id) ?? (alias ? publicCosts.get(alias) : undefined);
 		return publicCost ? { ...model, cost: { ...publicCost } } : model;
 	});
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -847,12 +847,15 @@ export interface TokenCost {
 }
 
 /**
- * Rates applied to the full request when its prompt exceeds `inputThreshold`.
- * Prompt input is the sum of uncached, cached-read, cache-write, and
- * provider-orchestration input tokens.
+ * Rates applied to the full request when its prompt exceeds `inputThreshold`,
+ * or reaches it when `inputThresholdInclusive` is true. Prompt input is the
+ * sum of uncached, cached-read, cache-write, and provider-orchestration input
+ * tokens.
  */
 export interface LongContextTokenCost extends TokenCost {
 	inputThreshold: number;
+	/** Whether the long-context tier starts exactly at `inputThreshold`. */
+	inputThresholdInclusive?: boolean;
 }
 
 /** Base token rates plus an optional long-context tier. */

--- a/packages/catalog/test/xai-api-key-responses.test.ts
+++ b/packages/catalog/test/xai-api-key-responses.test.ts
@@ -103,6 +103,36 @@ describe("paid xai (XAI_API_KEY) Responses contract", () => {
 		expect(usage.cost.cacheRead).toBeCloseTo(0.06, 10);
 	});
 
+	it("bridges the SuperGrok multi-agent alias to its public xAI catalog price", () => {
+		// Paid catalog uses `grok-4.20-multi-agent-beta-latest`; SuperGrok exposes
+		// the same model as `grok-4.20-multi-agent-0309`, so an exact-ID fallback
+		// misses it. The alias bridge must copy the paid price (and its 200K tier).
+		const paidSpec: ModelSpec<"openai-responses"> = {
+			...XAI_RESPONSES_SPEC,
+			id: "grok-4.20-multi-agent-beta-latest",
+			name: "Grok 4.20 (Multi-Agent)",
+			cost: { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 },
+		};
+		const oauthSpec: ModelSpec<"openai-responses"> = {
+			...paidSpec,
+			id: "grok-4.20-multi-agent-0309",
+			provider: "xai-oauth",
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		};
+		const [paid, oauth] = applyXaiCatalogPricing([paidSpec, oauthSpec]);
+		if (!paid || !oauth) throw new Error("xAI pricing policy dropped a model");
+
+		expect(paid.cost.longContext).toEqual({
+			inputThreshold: 200_000,
+			inputThresholdInclusive: true,
+			input: 4,
+			output: 12,
+			cacheRead: 0.4,
+			cacheWrite: 0,
+		});
+		expect(oauth.cost).toEqual(paid.cost);
+	});
+
 	it("drops stale Chat Completions cache rows so Responses takes effect immediately", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-xai-completions-cache-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/catalog/test/xai-api-key-responses.test.ts
+++ b/packages/catalog/test/xai-api-key-responses.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
-import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { calculateCost, getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { CATALOG_PROVIDERS, DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
-import { xaiModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import { applyXaiCatalogPricing, xaiModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { ModelSpec, Usage } from "@oh-my-pi/pi-catalog/types";
 
 const XAI_RESPONSES_SPEC: ModelSpec<"openai-responses"> = {
 	id: "grok-4.5",
@@ -58,6 +59,48 @@ describe("paid xai (XAI_API_KEY) Responses contract", () => {
 			expect(model.api, `${model.provider}/${model.id}`).toBe("openai-responses");
 			expect(model.baseUrl).toBe("https://api.x.ai/v1");
 		}
+	});
+
+	it("prices public xAI and matching SuperGrok models with the 200K tier", () => {
+		const oauthSpec: ModelSpec<"openai-responses"> = {
+			...XAI_RESPONSES_SPEC,
+			provider: "xai-oauth",
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		};
+		const composerSpec: ModelSpec<"openai-responses"> = {
+			...oauthSpec,
+			id: "grok-composer-2.5-fast",
+			name: "Grok Composer 2.5 Fast",
+		};
+		const priced = applyXaiCatalogPricing([XAI_RESPONSES_SPEC, oauthSpec, composerSpec]);
+		const paid = priced[0];
+		const oauth = priced[1];
+		const composer = priced[2];
+		if (!paid || !oauth || !composer) throw new Error("xAI pricing policy dropped a model");
+
+		expect(paid.cost.longContext).toEqual({
+			inputThreshold: 200_000,
+			inputThresholdInclusive: true,
+			input: 4,
+			output: 12,
+			cacheRead: 0.6,
+			cacheWrite: 0,
+		});
+		expect(oauth.cost).toEqual(paid.cost);
+		expect(composer.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+
+		const usage: Usage = {
+			input: 100_000,
+			output: 1_000,
+			cacheRead: 100_000,
+			cacheWrite: 0,
+			totalTokens: 201_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		calculateCost(buildModel(oauth), usage);
+		expect(usage.cost.input).toBeCloseTo(0.4, 10);
+		expect(usage.cost.output).toBeCloseTo(0.012, 10);
+		expect(usage.cost.cacheRead).toBeCloseTo(0.06, 10);
 	});
 
 	it("drops stale Chat Completions cache rows so Responses takes effect immediately", async () => {

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -71,6 +71,27 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		expect(bundled["grok-composer-2.5-fast"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 	});
 
+	// SuperGrok's `grok-4.20-multi-agent-0309` mirrors the paid catalog's
+	// `grok-4.20-multi-agent-beta-latest` under a different ID; the price
+	// fallback must bridge the alias so the bundle carries its public rate card
+	// (including the inclusive 200K tier) instead of the subscription zero.
+	it("prices the multi-agent SuperGrok alias from its public xAI equivalent", () => {
+		expect(bundled["grok-4.20-multi-agent-0309"]?.cost).toEqual({
+			input: 2,
+			output: 6,
+			cacheRead: 0.2,
+			cacheWrite: 0,
+			longContext: {
+				inputThreshold: 200_000,
+				inputThresholdInclusive: true,
+				input: 4,
+				output: 12,
+				cacheRead: 0.4,
+				cacheWrite: 0,
+			},
+		});
+	});
+
 	// The OAuth surface's /v1/models reports no per-request output limit, so the
 	// curated catalog owns maxTokens — set to mirror each model's contextWindow
 	// (the openai-responses wire still clamps the actual request to

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1819,9 +1819,12 @@ export class ModelRegistry {
 			// Extended context off: cap models with a premium long-context price
 			// tier (e.g. GPT-5.6 bills 2x input above 272K) at the standard-pricing
 			// threshold so compaction fires before a request crosses into the tier.
-			// Explicit per-model `contextWindow` overrides reapply later in
-			// composition and win over this cap.
-			if (!extendedContext) {
+			// xai-oauth carries public xAI prices only for API-equivalent stats;
+			// SuperGrok requests remain subscription-backed, so its estimated tier
+			// must not constrain the runtime context window. Explicit per-model
+			// `contextWindow` overrides reapply later in composition and win over
+			// this cap.
+			if (!extendedContext && model.provider !== "xai-oauth") {
 				const threshold = model.cost.longContext?.inputThreshold;
 				if (threshold !== undefined && model.contextWindow !== null && model.contextWindow > threshold) {
 					model = applyModelOverride(model, { contextWindow: threshold });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1664,7 +1664,7 @@ describe("ModelRegistry", () => {
 		});
 	});
 	describe("extended context", () => {
-		test("off caps premium long-context models at the standard-pricing threshold", async () => {
+		test("off caps billable premium models without shrinking subscription estimates", async () => {
 			await Settings.init({ inMemory: true, overrides: { extendedContext: false } });
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
 
@@ -1673,6 +1673,8 @@ describe("ModelRegistry", () => {
 			expect(registry.find("openai-codex", "gpt-5.6-sol")?.contextWindow).toBe(272_000);
 			// Standard-priced 1M models (no long-context tier) keep their window.
 			expect(registry.find("anthropic", "claude-opus-4-8")?.contextWindow).toBe(1_000_000);
+			// SuperGrok carries public xAI tiers for stats estimates, not billing.
+			expect(registry.find("xai-oauth", "grok-4.20-0309-reasoning")?.contextWindow).toBe(2_000_000);
 		});
 
 		test("reapplyModelPolicies re-clamps and restores premium windows on toggle", async () => {

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed SuperGrok usage appearing free by applying matching public xAI API prices, including 200K-token rates, backfilling existing rows, labeling dollar values as API-equivalent estimates, and showing subscription-only models as N/A ([#9512](https://github.com/can1357/oh-my-pi/issues/9512)).
+
 ## [18.0.1] - 2026-08-23
 
 ### Fixed

--- a/packages/stats/README.md
+++ b/packages/stats/README.md
@@ -17,9 +17,11 @@ Local observability dashboard for AI usage statistics.
 | Cache Rate | `cache_read / (input + cache_read) * 100` |
 | Cache Savings | `(uncached prompt cost - actual prompt cost) / uncached prompt cost * 100` |
 | Error Rate | `count(stopReason=error) / total_calls * 100` |
-| Total Cost | Sum of `usage.cost.total` |
+| API-equivalent estimate | Sum of token usage priced with the matching public API rate card |
 | Avg Latency | Mean of `duration` |
 | TTFT | Mean of `ttft` (time to first token) |
+
+Subscription-backed models use matching public API prices when an exact public model exists; these values estimate API-equivalent usage rather than the user's bill. Subscription-only models without a public price are reported as N/A and excluded from dollar totals.
 
 ## Usage
 
@@ -72,7 +74,7 @@ console.log(stats.byModel[0].avgTokensPerSecond);
 
 The web dashboard provides:
 
-- Overall metrics cards (requests, cost, cache rate, cache savings, error rate, duration, tokens/s)
+- Overall metrics cards (requests, API-equivalent estimate, cache rate, cache savings, error rate, duration, tokens/s)
 - Time series chart showing requests and errors over time
 - Per-model breakdown table
 - Per-folder breakdown table

--- a/packages/stats/src/client/data/formatters.ts
+++ b/packages/stats/src/client/data/formatters.ts
@@ -1,4 +1,5 @@
 import { formatDistanceToNow } from "@oh-my-pi/pi-utils/dates";
+import type { MessageStats } from "../types";
 
 export function formatInteger(value: number): string {
 	return value.toLocaleString();
@@ -15,6 +16,18 @@ export function formatCost(value: number, digits?: number): string {
 		minimumFractionDigits: fractionDigits,
 		maximumFractionDigits: fractionDigits,
 	})}`;
+}
+
+/** Format an API-equivalent estimate, using N/A when all usage is unpriced. */
+export function formatEstimatedCost(value: number, unpricedRequests: number, digits?: number): string {
+	return value === 0 && unpricedRequests > 0 ? "N/A" : formatCost(value, digits);
+}
+
+/** Format one request's cost, distinguishing unpriced SuperGrok usage from free usage. */
+export function formatMessageCost(message: Pick<MessageStats, "provider" | "usage">, digits?: number): string {
+	const unpricedRequests =
+		message.provider === "xai-oauth" && message.usage.totalTokens > 0 && message.usage.cost.total === 0 ? 1 : 0;
+	return formatEstimatedCost(message.usage.cost.total, unpricedRequests, digits);
 }
 
 export function formatPercent(value: number, digits = 1): string {

--- a/packages/stats/src/client/data/view-models.ts
+++ b/packages/stats/src/client/data/view-models.ts
@@ -74,6 +74,7 @@ export function buildAgentTokenShare(stats: AgentTypeStats[]): AgentTokenShareVi
 
 export interface CostSummaryView {
 	totalCost: number;
+	unpricedRequests: number;
 	avgDailyCost: number;
 	topModelName: string;
 	topModelCost: number;
@@ -111,6 +112,7 @@ export interface FolderRowView extends FolderStats {
 
 export function buildCostSummary(costSeries: CostTimeSeriesPoint[]): CostSummaryView {
 	const totalCost = costSeries.reduce((sum, p) => sum + p.cost, 0);
+	const unpricedRequests = costSeries.reduce((sum, point) => sum + point.unpricedRequests, 0);
 	const dayBuckets = new Set(costSeries.map(p => p.timestamp)).size;
 	const avgDailyCost = dayBuckets > 0 ? totalCost / dayBuckets : 0;
 
@@ -130,6 +132,7 @@ export function buildCostSummary(costSeries: CostTimeSeriesPoint[]): CostSummary
 
 	return {
 		totalCost,
+		unpricedRequests,
 		avgDailyCost,
 		topModelName,
 		topModelCost,

--- a/packages/stats/src/client/routes/CostsRoute.tsx
+++ b/packages/stats/src/client/routes/CostsRoute.tsx
@@ -13,7 +13,7 @@ import {
 	MODEL_COLORS,
 	styleDatasets,
 } from "../components/chart-shared";
-import { formatCost } from "../data/formatters";
+import { formatCost, formatEstimatedCost } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildCostSummary } from "../data/view-models";
 import type { CostTimeSeriesPoint, TimeRange } from "../types";
@@ -54,12 +54,22 @@ function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }
 	const summary = useMemo(() => buildCostSummary(costSeries), [costSeries]);
 
 	const cards = [
-		{ label: "Total Cost", value: formatCost(summary.totalCost) },
-		{ label: "Average / Day", value: formatCost(summary.avgDailyCost) },
+		{
+			label: "API-equivalent estimate",
+			value: formatEstimatedCost(summary.totalCost, summary.unpricedRequests),
+			sub:
+				summary.unpricedRequests > 0
+					? `Excludes ${summary.unpricedRequests.toLocaleString()} unpriced subscription request${summary.unpricedRequests === 1 ? "" : "s"}`
+					: undefined,
+		},
+		{
+			label: "Average estimate / Day",
+			value: formatEstimatedCost(summary.avgDailyCost, summary.unpricedRequests),
+		},
 		{
 			label: "Top Model",
 			value: summary.topModelName || "—",
-			sub: summary.topModelName ? formatCost(summary.topModelCost) : undefined,
+			sub: summary.topModelName ? `API-equivalent estimate: ${formatCost(summary.topModelCost)}` : undefined,
 		},
 	];
 
@@ -71,7 +81,7 @@ function CostOverviewPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }
 					<p className="text-2xl font-bold stats-text-primary truncate" title={card.value}>
 						{card.value}
 					</p>
-					{card.sub && <p className="text-xs stats-text-muted mt-1 font-medium">Total spent: {card.sub}</p>}
+					{card.sub && <p className="text-xs stats-text-muted mt-1 font-medium">{card.sub}</p>}
 				</Panel>
 			))}
 		</div>
@@ -118,6 +128,10 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 	const [byModel, setByModel] = useState(false);
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
+	const unpricedRequests = useMemo(
+		() => costSeries.reduce((sum, point) => sum + point.unpricedRequests, 0),
+		[costSeries],
+	);
 
 	const chartData = useMemo(() => {
 		if (byModel) {
@@ -130,7 +144,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 				bucketToValue: bucket => bucket.total,
 			});
 		}
-		return buildAggregateTimeSeries<CostTimeSeriesPoint, { total: number }>(costSeries, "Cost", {
+		return buildAggregateTimeSeries<CostTimeSeriesPoint, { total: number }>(costSeries, "API-equivalent estimate", {
 			initBucket: () => ({ total: 0 }),
 			accumulate: (bucket, point) => {
 				bucket.total += point.cost;
@@ -143,7 +157,7 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 		return buildSharedPlugins({
 			chartTheme,
 			showLegend: byModel,
-			defaultLabel: "Cost",
+			defaultLabel: "API-equivalent estimate",
 			formatValue: v => `$${v.toFixed(2)}`,
 			footer: items => {
 				if (!byModel || items.length < 2) return undefined;
@@ -214,14 +228,18 @@ function CostTrendPanel({ costSeries }: { costSeries: CostTimeSeriesPoint[] }) {
 
 	return (
 		<Panel
-			title="Daily Cost"
-			subtitle="API spending over time"
+			title="Daily API-equivalent estimate"
+			subtitle={
+				unpricedRequests > 0
+					? `Public API rate-card value over time; excludes ${unpricedRequests.toLocaleString()} unpriced subscription request${unpricedRequests === 1 ? "" : "s"}`
+					: "Public API rate-card value over time"
+			}
 			actions={<SegmentedControl options={toggleOptions} value={byModel} onChange={setByModel} />}
 		>
 			<div className="h-[300px]">
 				{chartData.labels.length === 0 ? (
 					<div className="h-full flex items-center justify-center text-stats-muted text-sm">
-						No cost data available
+						No API-equivalent estimate data available
 					</div>
 				) : byModel && lineData ? (
 					<Line data={lineData} options={lineOptions} />

--- a/packages/stats/src/client/routes/ErrorsRoute.tsx
+++ b/packages/stats/src/client/routes/ErrorsRoute.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { getRecentErrors } from "../api";
-import { formatCost, formatInteger, formatRelativeTime } from "../data/formatters";
+import { formatInteger, formatMessageCost, formatRelativeTime } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
@@ -59,9 +59,9 @@ export function ErrorsRoute({ active, range, refreshTrigger, onRequestClick }: E
 			},
 			{
 				key: "cost",
-				header: "Cost",
+				header: "API-equivalent estimate",
 				numeric: true,
-				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
+				render: (item: MessageStats) => formatMessageCost(item, 4),
 			},
 		],
 		[],
@@ -82,8 +82,8 @@ export function ErrorsRoute({ active, range, refreshTrigger, onRequestClick }: E
 					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
-					<div className="stats-mobile-card-value">{formatCost(item.usage.cost.total, 4)}</div>
+					<div className="stats-mobile-card-label">API-equivalent estimate</div>
+					<div className="stats-mobile-card-value">{formatMessageCost(item, 4)}</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Tokens</div>

--- a/packages/stats/src/client/routes/ModelsRoute.tsx
+++ b/packages/stats/src/client/routes/ModelsRoute.tsx
@@ -18,6 +18,7 @@ import {
 	TrendEmpty,
 } from "../components/models-table-shared";
 import { formatRangeTick, rangeMeta } from "../components/range-meta";
+import { formatEstimatedCost } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildModelPerformanceLookup } from "../data/view-models";
 import type { ModelPerformancePoint, ModelStats, ModelTimeSeriesPoint, TimeRange } from "../types";
@@ -266,7 +267,7 @@ function ModelsTable({
 				columns={[
 					{ label: "Model" },
 					{ label: "Requests", align: "right" },
-					{ label: "Cost", align: "right" },
+					{ label: "API-equivalent estimate", align: "right" },
 					{ label: "Tokens", align: "right" },
 					{ label: "Tokens/s", align: "right" },
 					{ label: "TTFT", align: "right" },
@@ -295,7 +296,7 @@ function ModelsTable({
 									{model.totalRequests.toLocaleString()}
 								</div>,
 								<div key="cost" className="text-right text-[var(--text-secondary)] font-mono text-sm">
-									${model.totalCost.toFixed(2)}
+									{formatEstimatedCost(model.totalCost, model.unpricedRequests)}
 								</div>,
 								<div key="tokens" className="text-right text-[var(--text-secondary)] font-mono text-sm">
 									{(model.totalInputTokens + model.totalOutputTokens).toLocaleString()}

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -4,7 +4,7 @@ import { Line } from "react-chartjs-2";
 import { getOverviewStats, getRecentRequests } from "../api";
 import { AgentTokenShare } from "../components/AgentTokenShare";
 import { CHART_THEMES } from "../components/chart-shared";
-import { formatCost, formatDurationMs, formatInteger, formatRelativeTime } from "../data/formatters";
+import { formatDurationMs, formatInteger, formatMessageCost, formatRelativeTime } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, MetricCluster, Panel, Skeleton, StatusPill } from "../ui";
@@ -157,9 +157,9 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			},
 			{
 				key: "cost",
-				header: "Cost",
+				header: "API-equivalent estimate",
 				numeric: true,
-				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
+				render: (item: MessageStats) => formatMessageCost(item, 4),
 			},
 			{
 				key: "duration",
@@ -198,8 +198,8 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
-					<div className="stats-mobile-card-value">{formatCost(item.usage.cost.total, 4)}</div>
+					<div className="stats-mobile-card-label">API-equivalent estimate</div>
+					<div className="stats-mobile-card-value">{formatMessageCost(item, 4)}</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Tokens</div>
@@ -298,7 +298,7 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 													<div>{req.provider}</div>
 													<div>
 														{req.duration ? formatDurationMs(req.duration) : ""}{" "}
-														{req.usage?.cost?.total ? `· ${formatCost(req.usage.cost.total, 4)}` : ""}
+														{req.usage.totalTokens > 0 ? `· ${formatMessageCost(req, 4)}` : ""}
 													</div>
 												</div>
 												{isError && (

--- a/packages/stats/src/client/routes/ProjectsRoute.tsx
+++ b/packages/stats/src/client/routes/ProjectsRoute.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { getFolderStats } from "../api";
-import { formatCost, formatDurationMs, formatInteger, formatPercent } from "../data/formatters";
+import { formatDurationMs, formatEstimatedCost, formatInteger, formatPercent } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildFolderRows, type FolderRowView } from "../data/view-models";
 import type { TimeRange } from "../types";
@@ -60,11 +60,11 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 			},
 			{
 				key: "totalCost",
-				header: "Cost",
+				header: "API-equivalent estimate",
 				numeric: true,
 				render: (item: FolderRowView) => (
 					<div className="stats-text-right">
-						<div className="font-mono">{formatCost(item.totalCost)}</div>
+						<div className="font-mono">{formatEstimatedCost(item.totalCost, item.unpricedRequests)}</div>
 						<div className="stats-progress-bar-track mt-1 ml-auto w-24 h-1">
 							<div
 								className="stats-progress-bar-fill"
@@ -133,8 +133,10 @@ export function ProjectsRoute({ active, range, refreshTrigger }: ProjectsRoutePr
 					<div className="stats-mobile-card-value font-mono">{formatInteger(item.totalRequests)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
-					<div className="stats-mobile-card-value font-mono">{formatCost(item.totalCost)}</div>
+					<div className="stats-mobile-card-label">API-equivalent estimate</div>
+					<div className="stats-mobile-card-value font-mono">
+						{formatEstimatedCost(item.totalCost, item.unpricedRequests)}
+					</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Cache Rate</div>

--- a/packages/stats/src/client/routes/ProvidersRoute.tsx
+++ b/packages/stats/src/client/routes/ProvidersRoute.tsx
@@ -13,6 +13,7 @@ import {
 import {
 	formatCompact,
 	formatCost,
+	formatEstimatedCost,
 	formatInteger,
 	formatPercent,
 	formatRelativeTime,
@@ -69,6 +70,10 @@ export function ProvidersRoute({ active, range, refreshTrigger }: ProvidersRoute
 
 function ProviderTotalsPanel({ providers }: { providers: ProviderAggregate[] }) {
 	const grandTotal = useMemo(() => providers.reduce((sum, p) => sum + p.totalTokens, 0), [providers]);
+	const unpricedRequests = useMemo(
+		() => providers.reduce((sum, provider) => sum + provider.unpricedRequests, 0),
+		[providers],
+	);
 
 	const columns: DataTableColumn<ProviderAggregate>[] = [
 		{ key: "provider", header: "Provider", render: p => <span className="font-medium">{p.provider}</span> },
@@ -98,12 +103,24 @@ function ProviderTotalsPanel({ providers }: { providers: ProviderAggregate[] }) 
 			numeric: true,
 			render: p => formatPercent(grandTotal > 0 ? p.totalTokens / grandTotal : 0),
 		},
-		{ key: "cost", header: "Cost", numeric: true, render: p => formatCost(p.totalCost) },
+		{
+			key: "cost",
+			header: "API-equivalent estimate",
+			numeric: true,
+			render: provider => formatEstimatedCost(provider.totalCost, provider.unpricedRequests),
+		},
 		{ key: "tps", header: "Tok/s", numeric: true, render: p => formatTokensPerSecond(p.avgTokensPerSecond) },
 	];
 
 	return (
-		<Panel title="Provider Totals" subtitle="Token, request, and cost totals per provider over the active range">
+		<Panel
+			title="Provider Totals"
+			subtitle={
+				unpricedRequests > 0
+					? `Token, request, and API-equivalent estimates; excludes ${unpricedRequests.toLocaleString()} unpriced subscription request${unpricedRequests === 1 ? "" : "s"}`
+					: "Token, request, and API-equivalent estimates over the active range"
+			}
+		>
 			<DataTable
 				columns={columns}
 				data={providers}
@@ -122,6 +139,10 @@ function ProviderTrendPanel({ stats }: { stats: ProviderDashboardStats }) {
 	const [metric, setMetric] = useState<"tokens" | "cost">("tokens");
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
+	const unpricedRequests = useMemo(
+		() => stats.providers.reduce((sum, provider) => sum + provider.unpricedRequests, 0),
+		[stats.providers],
+	);
 
 	// buildTopNByModelSeries keys on `model`; feed it the provider name so we
 	// get the same top-N + "Other" rollup without a parallel implementation.
@@ -148,7 +169,7 @@ function ProviderTrendPanel({ stats }: { stats: ProviderDashboardStats }) {
 			plugins: buildSharedPlugins({
 				chartTheme,
 				showLegend: true,
-				defaultLabel: metric === "tokens" ? "Tokens" : "Cost",
+				defaultLabel: metric === "tokens" ? "Tokens" : "API-equivalent estimate",
 				formatValue,
 				footer: items => {
 					if (items.length < 2) return undefined;
@@ -174,12 +195,16 @@ function ProviderTrendPanel({ stats }: { stats: ProviderDashboardStats }) {
 	return (
 		<Panel
 			title="Burn by Provider"
-			subtitle="Stacked token/cost burn per provider over time"
+			subtitle={
+				metric === "cost" && unpricedRequests > 0
+					? `API-equivalent estimates over time; excludes ${unpricedRequests.toLocaleString()} unpriced subscription request${unpricedRequests === 1 ? "" : "s"}`
+					: "Stacked token or API-equivalent estimate burn over time"
+			}
 			actions={
 				<SegmentedControl
 					options={[
 						{ value: "tokens" as const, label: "Tokens" },
-						{ value: "cost" as const, label: "Cost" },
+						{ value: "cost" as const, label: "API-equivalent estimate" },
 					]}
 					value={metric}
 					onChange={setMetric}

--- a/packages/stats/src/client/routes/RequestsRoute.tsx
+++ b/packages/stats/src/client/routes/RequestsRoute.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { getRecentRequests } from "../api";
-import { formatCost, formatDurationMs, formatInteger, formatRelativeTime } from "../data/formatters";
+import { formatDurationMs, formatInteger, formatMessageCost, formatRelativeTime } from "../data/formatters";
 import { useResource } from "../data/useResource";
 import type { MessageStats, TimeRange } from "../types";
 import { AsyncBoundary, DataTable, Panel, StatusPill } from "../ui";
@@ -47,9 +47,9 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 			},
 			{
 				key: "cost",
-				header: "Cost",
+				header: "API-equivalent estimate",
 				numeric: true,
-				render: (item: MessageStats) => formatCost(item.usage.cost.total, 4),
+				render: (item: MessageStats) => formatMessageCost(item, 4),
 			},
 			{
 				key: "duration",
@@ -88,8 +88,8 @@ export function RequestsRoute({ active, refreshTrigger, onRequestClick }: Reques
 					<div className="stats-mobile-card-value">{formatRelativeTime(item.timestamp)}</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Cost</div>
-					<div className="stats-mobile-card-value">{formatCost(item.usage.cost.total, 4)}</div>
+					<div className="stats-mobile-card-label">API-equivalent estimate</div>
+					<div className="stats-mobile-card-value">{formatMessageCost(item, 4)}</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Tokens</div>

--- a/packages/stats/src/client/routes/ToolsRoute.tsx
+++ b/packages/stats/src/client/routes/ToolsRoute.tsx
@@ -3,7 +3,13 @@ import { Line } from "react-chartjs-2";
 import { getToolDashboardStats } from "../api";
 import { CHART_THEMES, MODEL_COLORS } from "../components/chart-shared";
 import { formatRangeTick, rangeMeta } from "../components/range-meta";
-import { formatCompact, formatCost, formatInteger, formatPercent, formatRelativeTime } from "../data/formatters";
+import {
+	formatCompact,
+	formatEstimatedCost,
+	formatInteger,
+	formatPercent,
+	formatRelativeTime,
+} from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildToolRows, type ToolRowView } from "../data/view-models";
 import type { TimeRange, ToolModelStats, ToolTimeSeriesPoint, ToolUsageStats } from "../types";
@@ -53,6 +59,7 @@ function ToolsSummaryPanel({ byTool }: { byTool: ToolUsageStats[] }) {
 		let tokens = 0;
 		let output = 0;
 		let cost = 0;
+		let unpricedRequests = 0;
 		let resultChars = 0;
 		let argsChars = 0;
 		for (const t of byTool) {
@@ -61,16 +68,17 @@ function ToolsSummaryPanel({ byTool }: { byTool: ToolUsageStats[] }) {
 			tokens += t.totalTokensShare;
 			output += t.outputTokensShare;
 			cost += t.costShare;
+			unpricedRequests += t.unpricedRequestsShare;
 			resultChars += t.resultChars;
 			argsChars += t.argsChars;
 		}
-		return { calls, errors, tokens, output, cost, resultChars, argsChars, tools: byTool.length };
+		return { calls, errors, tokens, output, cost, unpricedRequests, resultChars, argsChars, tools: byTool.length };
 	}, [byTool]);
 
 	return (
 		<Panel
 			title="Tool Usage"
-			subtitle="Tokens/cost are the invoking turns' real provider usage, split across each turn's tool calls"
+			subtitle="Tokens and API-equivalent estimates are split from invoking turns across each turn's tool calls"
 		>
 			<div className="stats-metric-cluster">
 				<div className="stats-metric-primary-grid">
@@ -89,8 +97,8 @@ function ToolsSummaryPanel({ byTool }: { byTool: ToolUsageStats[] }) {
 						</div>
 					</div>
 					<div className="stats-metric-card primary">
-						<div className="stats-metric-label">Attributed Cost</div>
-						<div className="stats-metric-value">{formatCost(totals.cost)}</div>
+						<div className="stats-metric-label">Attributed API-equivalent estimate</div>
+						<div className="stats-metric-value">{formatEstimatedCost(totals.cost, totals.unpricedRequests)}</div>
 					</div>
 				</div>
 
@@ -292,9 +300,11 @@ function ToolsTable({ byTool }: { byTool: ToolUsageStats[] }) {
 			},
 			{
 				key: "cost",
-				header: "Attr. Cost",
+				header: "Attr. API-equivalent estimate",
 				numeric: true,
-				render: (item: ToolRowView) => <span className="font-mono">{formatCost(item.costShare)}</span>,
+				render: (item: ToolRowView) => (
+					<span className="font-mono">{formatEstimatedCost(item.costShare, item.unpricedRequestsShare)}</span>
+				),
 			},
 			{
 				key: "resultChars",
@@ -336,8 +346,10 @@ function ToolsTable({ byTool }: { byTool: ToolUsageStats[] }) {
 					</div>
 				</div>
 				<div>
-					<div className="stats-mobile-card-label">Attr. Cost</div>
-					<div className="stats-mobile-card-value font-mono">{formatCost(item.costShare)}</div>
+					<div className="stats-mobile-card-label">Attr. API-equivalent estimate</div>
+					<div className="stats-mobile-card-value font-mono">
+						{formatEstimatedCost(item.costShare, item.unpricedRequestsShare)}
+					</div>
 				</div>
 				<div>
 					<div className="stats-mobile-card-label">Result Text</div>
@@ -422,10 +434,10 @@ function ToolModelPanel({ byToolModel }: { byToolModel: ToolModelStats[] }) {
 			},
 			{
 				key: "cost",
-				header: "Attr. Cost",
+				header: "Attr. API-equivalent estimate",
 				numeric: true,
 				render: (item: ToolModelStats & { errorRate: number }) => (
-					<span className="font-mono">{formatCost(item.costShare)}</span>
+					<span className="font-mono">{formatEstimatedCost(item.costShare, item.unpricedRequestsShare)}</span>
 				),
 			},
 		],

--- a/packages/stats/src/client/ui/MetricCluster.tsx
+++ b/packages/stats/src/client/ui/MetricCluster.tsx
@@ -1,7 +1,7 @@
 import {
 	formatCompact,
-	formatCost,
 	formatDurationMs,
+	formatEstimatedCost,
 	formatInteger,
 	formatPercent,
 	formatTokensPerSecond,
@@ -20,9 +20,13 @@ export function MetricCluster({ stats }: MetricClusterProps) {
 		<div className="stats-metric-cluster">
 			<div className="stats-metric-primary-grid">
 				<div className="stats-metric-card primary">
-					<div className="stats-metric-label">Total Cost</div>
+					<div className="stats-metric-label">API-equivalent estimate</div>
 					<div className="stats-metric-value">
-						{formatCost(stats.totalCost, stats.totalCost > 0 && stats.totalCost < 0.01 ? 4 : 2)}
+						{formatEstimatedCost(
+							stats.totalCost,
+							stats.unpricedRequests,
+							stats.totalCost > 0 && stats.totalCost < 0.01 ? 4 : 2,
+						)}
 					</div>
 				</div>
 				<div className="stats-metric-card primary">

--- a/packages/stats/src/client/ui/RequestDrawer.tsx
+++ b/packages/stats/src/client/ui/RequestDrawer.tsx
@@ -1,7 +1,7 @@
 import { Clock, Coins, Gauge, Hash, Star, X, Zap } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { getRequestDetails } from "../api";
-import { formatCost, formatDurationMs, formatInteger } from "../data/formatters";
+import { formatDurationMs, formatInteger, formatMessageCost } from "../data/formatters";
 import type { RequestDetails } from "../types";
 import { JsonBlock } from "./JsonBlock";
 import { Skeleton } from "./Skeleton";
@@ -138,9 +138,9 @@ export function RequestDrawer({ id, onClose }: RequestDrawerProps) {
 								<div className="stats-drawer-metric-card">
 									<div className="stats-drawer-metric-label">
 										<Coins size={14} className="stats-drawer-metric-icon" />
-										Cost
+										API-equivalent estimate
 									</div>
-									<div className="stats-drawer-metric-value">{formatCost(details.usage.cost.total, 4)}</div>
+									<div className="stats-drawer-metric-value">{formatMessageCost(details, 4)}</div>
 								</div>
 
 								<div className="stats-drawer-metric-card">

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1,8 +1,13 @@
 import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import type { Usage } from "@oh-my-pi/pi-ai";
-import type { GeneratedProvider } from "@oh-my-pi/pi-catalog/models";
-import { calculateUncachedInputCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import {
+	calculateUncachedInputCost,
+	calculateUsageCost,
+	type GeneratedProvider,
+	getBundledModel,
+} from "@oh-my-pi/pi-catalog/models";
+import type { ModelCost } from "@oh-my-pi/pi-catalog/types";
 import { getConfigRootDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
 import { classifyAgentType } from "./parser";
 import type {
@@ -31,9 +36,8 @@ import type {
 	UserMessageStats,
 } from "./types";
 
-type ModelCost = { input: number; output: number; cacheRead: number; cacheWrite: number };
 type UsageCost = Usage["cost"];
-type CostTokens = Pick<Usage, "input" | "output" | "cacheRead" | "cacheWrite" | "orchestration">;
+type CostTokens = Pick<Usage, "input" | "output" | "cacheRead" | "cacheWrite" | "orchestration" | "cttl">;
 
 const ZERO_USAGE_COST: UsageCost = {
 	input: 0,
@@ -42,6 +46,9 @@ const ZERO_USAGE_COST: UsageCost = {
 	cacheWrite: 0,
 	total: 0,
 };
+
+const UNPRICED_XAI_OAUTH_SQL =
+	"CASE WHEN provider = 'xai-oauth' AND total_tokens > 0 AND cost_total = 0 THEN 1 ELSE 0 END";
 
 interface CostBackfillRow {
 	id: number;
@@ -71,6 +78,7 @@ interface AggregatedStatsRow {
 	total_cache_write_tokens: number | null;
 	total_premium_requests: number | null;
 	total_cost: number | null;
+	unpriced_requests: number | null;
 	total_cached_prompt_cost: number | null;
 	total_no_cache_input_cost: number | null;
 	avg_duration: number | null;
@@ -87,6 +95,19 @@ interface ModelStatsRow extends AggregatedStatsRow {
 
 interface FolderStatsRow extends AggregatedStatsRow {
 	folder: string;
+}
+
+interface CostTimeSeriesRow {
+	bucket: number;
+	model: string;
+	provider: string;
+	cost: number | null;
+	unpriced_requests: number | null;
+	cost_input: number | null;
+	cost_output: number | null;
+	cost_cache_read: number | null;
+	cost_cache_write: number | null;
+	requests: number;
 }
 
 let db: Database | null = null;
@@ -325,10 +346,11 @@ function getCatalogCost(provider: string, modelId: string): ModelCost | null {
 		return primaryCost;
 	}
 
-	if (provider === "openai-codex") {
-		const openAICost = getBundledModelCost("openai", modelId);
-		if (openAICost && hasBillableCost(openAICost)) {
-			return openAICost;
+	const fallbackProvider = provider === "openai-codex" ? "openai" : provider === "xai-oauth" ? "xai" : null;
+	if (fallbackProvider) {
+		const fallbackCost = getBundledModelCost(fallbackProvider, modelId);
+		if (fallbackCost && hasBillableCost(fallbackCost)) {
+			return fallbackCost;
 		}
 	}
 
@@ -339,18 +361,20 @@ function calculateCatalogCost(provider: string, modelId: string, tokens: CostTok
 	const cost = getCatalogCost(provider, modelId);
 	if (!cost) return null;
 
-	const input = (cost.input / 1_000_000) * tokens.input;
-	const output = (cost.output / 1_000_000) * tokens.output;
-	const cacheRead = (cost.cacheRead / 1_000_000) * tokens.cacheRead;
-	const cacheWrite = (cost.cacheWrite / 1_000_000) * tokens.cacheWrite;
-
-	return {
-		input,
-		output,
-		cacheRead,
-		cacheWrite,
-		total: input + output + cacheRead + cacheWrite,
+	const orchestration = tokens.orchestration;
+	const usage: Usage = {
+		...tokens,
+		totalTokens:
+			tokens.input +
+			tokens.output +
+			tokens.cacheRead +
+			tokens.cacheWrite +
+			(orchestration?.input ?? 0) +
+			(orchestration?.output ?? 0) +
+			(orchestration?.cacheRead ?? 0),
+		cost: { ...ZERO_USAGE_COST },
 	};
+	return calculateUsageCost(cost, usage);
 }
 
 function normalizeUsageCost(cost: UsageCost): UsageCost {
@@ -570,6 +594,7 @@ function buildAggregatedStats(rows: AggregatedStatsRow[]): AggregatedStats {
 			cacheRate: 0,
 			cacheSavings: 0,
 			totalCost: 0,
+			unpricedRequests: 0,
 			totalPremiumRequests: 0,
 			avgDuration: null,
 			avgTtft: null,
@@ -604,6 +629,7 @@ function buildAggregatedStats(rows: AggregatedStatsRow[]): AggregatedStats {
 				: 0,
 		cacheSavings: noCacheInputCost > 0 ? (noCacheInputCost - cachedPromptCost) / noCacheInputCost : 0,
 		totalCost: row.total_cost || 0,
+		unpricedRequests: row.unpriced_requests || 0,
 		totalPremiumRequests,
 		avgDuration: row.avg_duration,
 		avgTtft: row.avg_ttft,
@@ -630,6 +656,7 @@ export function getOverallStats(cutoff?: number): AggregatedStats {
 			SUM(cache_write_tokens) as total_cache_write_tokens,
 			SUM(premium_requests) as total_premium_requests,
 			SUM(cost_total) as total_cost,
+			SUM(${UNPRICED_XAI_OAUTH_SQL}) as unpriced_requests,
 			SUM(CASE WHEN cost_no_cache_input > 0
 				THEN cost_input + cost_cache_read + cost_cache_write
 				ELSE 0 END) as total_cached_prompt_cost,
@@ -665,6 +692,7 @@ export function getStatsByModel(cutoff?: number): ModelStats[] {
 			SUM(cache_write_tokens) as total_cache_write_tokens,
 			SUM(premium_requests) as total_premium_requests,
 			SUM(cost_total) as total_cost,
+			SUM(${UNPRICED_XAI_OAUTH_SQL}) as unpriced_requests,
 			SUM(CASE WHEN cost_no_cache_input > 0
 				THEN cost_input + cost_cache_read + cost_cache_write
 				ELSE 0 END) as total_cached_prompt_cost,
@@ -706,6 +734,7 @@ export function getStatsByFolder(cutoff?: number): FolderStats[] {
 			SUM(cache_write_tokens) as total_cache_write_tokens,
 			SUM(premium_requests) as total_premium_requests,
 			SUM(cost_total) as total_cost,
+			SUM(${UNPRICED_XAI_OAUTH_SQL}) as unpriced_requests,
 			SUM(CASE WHEN cost_no_cache_input > 0
 				THEN cost_input + cost_cache_read + cost_cache_write
 				ELSE 0 END) as total_cached_prompt_cost,
@@ -854,6 +883,7 @@ export function getStatsByProvider(cutoff?: number | null): ProviderAggregate[] 
 			SUM(cache_write_tokens) as total_cache_write_tokens,
 			SUM(input_tokens + output_tokens + cache_read_tokens + cache_write_tokens) as total_tokens,
 			SUM(cost_total) as total_cost,
+			SUM(${UNPRICED_XAI_OAUTH_SQL}) as unpriced_requests,
 			SUM(premium_requests) as total_premium_requests,
 			AVG(CASE WHEN duration > 0 THEN output_tokens * 1000.0 / duration ELSE NULL END) as avg_tokens_per_second
 		FROM messages
@@ -873,6 +903,7 @@ export function getStatsByProvider(cutoff?: number | null): ProviderAggregate[] 
 		total_cache_write_tokens: number | null;
 		total_tokens: number | null;
 		total_cost: number | null;
+		unpriced_requests: number | null;
 		total_premium_requests: number | null;
 		avg_tokens_per_second: number | null;
 	}>;
@@ -887,6 +918,7 @@ export function getStatsByProvider(cutoff?: number | null): ProviderAggregate[] 
 		totalCacheWriteTokens: row.total_cache_write_tokens ?? 0,
 		totalTokens: row.total_tokens ?? 0,
 		totalCost: row.total_cost ?? 0,
+		unpricedRequests: row.unpriced_requests ?? 0,
 		totalPremiumRequests: row.total_premium_requests ?? 0,
 		avgTokensPerSecond: row.avg_tokens_per_second,
 	}));
@@ -949,6 +981,7 @@ export function getProviderTimeSeries(
 			provider,
 			SUM(input_tokens + output_tokens + cache_read_tokens + cache_write_tokens) as total_tokens,
 			SUM(cost_total) as cost,
+			SUM(${UNPRICED_XAI_OAUTH_SQL}) as unpriced_requests,
 			COUNT(*) as requests
 		FROM messages
 		${hasCutoff ? "WHERE timestamp >= ?" : ""}
@@ -962,6 +995,7 @@ export function getProviderTimeSeries(
 		provider: string;
 		total_tokens: number | null;
 		cost: number | null;
+		unpriced_requests: number | null;
 		requests: number;
 	}>;
 	return rows.map(row => ({
@@ -969,6 +1003,7 @@ export function getProviderTimeSeries(
 		provider: row.provider,
 		totalTokens: row.total_tokens ?? 0,
 		cost: row.cost ?? 0,
+		unpricedRequests: row.unpriced_requests ?? 0,
 		requests: row.requests,
 	}));
 }
@@ -1118,6 +1153,7 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
 			model,
 			provider,
 			SUM(cost_total) as cost,
+			SUM(${UNPRICED_XAI_OAUTH_SQL}) as unpriced_requests,
 			SUM(cost_input) as cost_input,
 			SUM(cost_output) as cost_output,
 			SUM(cost_cache_read) as cost_cache_read,
@@ -1129,16 +1165,17 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
 		ORDER BY bucket ASC
 	`);
 
-	const rows = hasCutoff ? (stmt.all(seriesCutoff) as any[]) : (stmt.all() as any[]);
+	const rows = (hasCutoff ? stmt.all(seriesCutoff) : stmt.all()) as CostTimeSeriesRow[];
 	return rows.map(row => ({
 		timestamp: row.bucket,
 		model: row.model,
 		provider: row.provider,
-		cost: row.cost,
-		costInput: row.cost_input,
-		costOutput: row.cost_output,
-		costCacheRead: row.cost_cache_read,
-		costCacheWrite: row.cost_cache_write,
+		cost: row.cost ?? 0,
+		unpricedRequests: row.unpriced_requests ?? 0,
+		costInput: row.cost_input ?? 0,
+		costOutput: row.cost_output ?? 0,
+		costCacheRead: row.cost_cache_read ?? 0,
+		costCacheWrite: row.cost_cache_write ?? 0,
 		requests: row.requests,
 	}));
 }
@@ -1700,6 +1737,8 @@ const TOOL_AGGREGATE_COLUMNS = `
 	SUM(COALESCE(m.total_tokens, 0) * 1.0 / t.calls_in_turn) as total_tokens_share,
 	SUM(COALESCE(m.output_tokens, 0) * 1.0 / t.calls_in_turn) as output_tokens_share,
 	SUM(COALESCE(m.cost_total, 0) / t.calls_in_turn) as cost_share,
+	SUM(CASE WHEN t.provider = 'xai-oauth' AND COALESCE(m.total_tokens, 0) > 0 AND COALESCE(m.cost_total, 0) = 0
+		THEN 1.0 / t.calls_in_turn ELSE 0 END) as unpriced_requests_share,
 	MAX(t.timestamp) as last_used
 `;
 
@@ -1714,6 +1753,7 @@ interface ToolAggregateRow {
 	total_tokens_share: number | null;
 	output_tokens_share: number | null;
 	cost_share: number | null;
+	unpriced_requests_share: number | null;
 	last_used: number;
 }
 
@@ -1727,6 +1767,7 @@ function rowToToolUsage(row: ToolAggregateRow): ToolUsageStats {
 		totalTokensShare: row.total_tokens_share ?? 0,
 		outputTokensShare: row.output_tokens_share ?? 0,
 		costShare: row.cost_share ?? 0,
+		unpricedRequestsShare: row.unpriced_requests_share ?? 0,
 		lastUsed: row.last_used,
 	};
 }

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -120,6 +120,12 @@ const PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY = "premium_requests_priority_v1";
 const AGENT_TYPE_BACKFILL_KEY = "agent_type_v1";
 const FORK_DEDUPE_KEY = "fork_dedupe_v1";
 const TOOL_CALLS_BACKFILL_KEY = "tool_calls_v1";
+// Older ingests dropped `Usage.orchestration` (never a stored column) when
+// pricing, so subscription models billed on orchestration tokens — multi-agent
+// Grok most notably — were priced from conversation buckets alone and could not
+// reach the inclusive 200K tier. A one-time full re-parse repairs them through
+// the cost-refreshing UPSERT in `insertMessageStats`.
+const COST_REINGEST_BACKFILL_KEY = "messages_cost_reingest_v1";
 function shouldResetBackfill(value: string | undefined): boolean {
 	return value !== BACKFILL_COMPLETE && value !== BACKFILL_PENDING;
 }
@@ -322,6 +328,7 @@ export async function initDb(): Promise<Database> {
 	}
 	backfillUserMessages(db);
 	backfillToolCalls(db);
+	backfillReingestCosts(db);
 	repairUserMessageLinks(db);
 	backfillPriorityPremiumRequests(db);
 	backfillAgentType(db);
@@ -510,8 +517,9 @@ export function setFileOffset(sessionFile: string, offset: number, lastModified:
  * aggregate. The `WHERE NOT EXISTS` clause skips inserts whose
  * `(entry_id, timestamp)` already exists under a different `session_file` —
  * first-write-wins across the lineage. Same-file re-syncs still hit the
- * `ON CONFLICT(session_file, entry_id)` upsert below so historical
- * `premium_requests` fix-ups continue to work.
+ * `ON CONFLICT(session_file, entry_id)` upsert below, which re-derives the
+ * stored cost (orchestration-aware) and keeps `premium_requests` monotonic, so
+ * a forced re-parse repairs historical `premium_requests` and cost fix-ups.
  */
 export function insertMessageStats(stats: MessageStats[]): number {
 	if (!db || stats.length === 0) return 0;
@@ -529,8 +537,13 @@ export function insertMessageStats(stats: MessageStats[]): number {
 			WHERE entry_id = ? AND timestamp = ? AND session_file <> ?
 		)
 		ON CONFLICT(session_file, entry_id) DO UPDATE SET
-			premium_requests = excluded.premium_requests
-		WHERE messages.premium_requests < excluded.premium_requests
+			premium_requests = MAX(messages.premium_requests, excluded.premium_requests),
+			cost_input = excluded.cost_input,
+			cost_output = excluded.cost_output,
+			cost_cache_read = excluded.cost_cache_read,
+			cost_cache_write = excluded.cost_cache_write,
+			cost_total = excluded.cost_total,
+			cost_no_cache_input = excluded.cost_no_cache_input
 	`);
 
 	let inserted = 0;
@@ -1254,6 +1267,29 @@ function backfillToolCalls(database: Database): void {
 }
 
 /**
+ * One-shot `file_offsets` wipe so the next sync re-parses every session and
+ * re-prices `messages` from source. Pre-fix ingests priced subscription rows
+ * from the four stored token buckets only, dropping `Usage.orchestration`
+ * (never a stored column), so multi-agent Grok and any other orchestration-
+ * billed model were understated and could not reach the inclusive 200K tier.
+ * The re-parse reruns the orchestration-aware pricing in `resolveStoredCost`
+ * and the cost-refreshing UPSERT in {@link insertMessageStats} writes it back.
+ * `messages`/`user_messages`/`tool_calls` re-inserts are idempotent, so the
+ * offset reset is safe. Same sentinel protocol as {@link backfillToolCalls}.
+ */
+function backfillReingestCosts(database: Database): void {
+	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(COST_REINGEST_BACKFILL_KEY) as
+		| { value: string }
+		| undefined;
+	if (!shouldResetBackfill(row?.value)) return;
+
+	database.run("DELETE FROM file_offsets");
+	database
+		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
+		.run(COST_REINGEST_BACKFILL_KEY, BACKFILL_PENDING);
+}
+
+/**
  * Reclassify pre-existing `messages` rows by agent type once, after the
  * `agent_type` column is added to an older database (every prior row defaulted
  * to 'main' on the ALTER). Classification is purely path-based — derived from
@@ -1378,6 +1414,7 @@ export function markSessionBackfillsComplete(): void {
 			TOOL_CALLS_BACKFILL_KEY,
 			USER_MESSAGE_LINKS_REPAIR_KEY,
 			PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY,
+			COST_REINGEST_BACKFILL_KEY,
 		]) {
 			markComplete.run(key, BACKFILL_COMPLETE);
 		}

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -39,10 +39,9 @@ export type {
 	ToolUsageStats,
 } from "./types";
 
-/**
- * Format cost in dollars.
- */
-function formatCost(n: number): string {
+/** Format an API-equivalent estimate in dollars, or N/A for unpriced usage. */
+function formatCost(n: number, unpricedRequests = 0): string {
+	if (n === 0 && unpricedRequests > 0) return "N/A";
 	if (n < 0.01) return `$${n.toFixed(4)}`;
 	if (n < 1) return `$${n.toFixed(3)}`;
 	return `$${n.toFixed(2)}`;
@@ -69,7 +68,7 @@ async function printStats(): Promise<void> {
 	console.log(`  Output Tokens: ${formatNumber(overall.totalOutputTokens)}`);
 	console.log(`  Cache Rate: ${formatPercent(overall.cacheRate)}`);
 	console.log(`  Cache Savings: ${formatPercent(overall.cacheSavings)}`);
-	console.log(`  Total Cost: ${formatCost(overall.totalCost)}`);
+	console.log(`  API-equivalent estimate: ${formatCost(overall.totalCost, overall.unpricedRequests)}`);
 	console.log(`  Premium Requests: ${formatNumber(normalizePremiumRequests(overall.totalPremiumRequests ?? 0))}`);
 	console.log(`  Avg Duration: ${overall.avgDuration !== null ? formatDuration(overall.avgDuration) : "-"}`);
 	console.log(`  Avg TTFT: ${overall.avgTtft !== null ? formatDuration(overall.avgTtft) : "-"}`);
@@ -78,18 +77,20 @@ async function printStats(): Promise<void> {
 	}
 
 	if (byModel.length > 0) {
-		console.log("\nBy Model:");
+		console.log("\nBy Model (API-equivalent estimates):");
 		for (const m of byModel.slice(0, 10)) {
 			console.log(
-				`  ${m.model}: ${formatNumber(m.totalRequests)} reqs, ${formatCost(m.totalCost)}, ${formatPercent(m.cacheRate)} cache rate, ${formatPercent(m.cacheSavings)} cache savings`,
+				`  ${m.model}: ${formatNumber(m.totalRequests)} reqs, ${formatCost(m.totalCost, m.unpricedRequests)}, ${formatPercent(m.cacheRate)} cache rate, ${formatPercent(m.cacheSavings)} cache savings`,
 			);
 		}
 	}
 
 	if (byFolder.length > 0) {
-		console.log("\nBy Folder:");
+		console.log("\nBy Folder (API-equivalent estimates):");
 		for (const f of byFolder.slice(0, 10)) {
-			console.log(`  ${f.folder}: ${formatNumber(f.totalRequests)} reqs, ${formatCost(f.totalCost)}`);
+			console.log(
+				`  ${f.folder}: ${formatNumber(f.totalRequests)} reqs, ${formatCost(f.totalCost, f.unpricedRequests)}`,
+			);
 		}
 	}
 

--- a/packages/stats/src/shared-types.ts
+++ b/packages/stats/src/shared-types.ts
@@ -34,6 +34,8 @@ export interface AggregatedStats {
 	cacheSavings: number;
 	/** Total cost */
 	totalCost: number;
+	/** Requests with token usage but no public-equivalent subscription price. */
+	unpricedRequests: number;
 	/** Total premium requests */
 	totalPremiumRequests: number;
 	/** Average duration in ms */
@@ -122,6 +124,8 @@ export interface CostTimeSeriesPoint {
 	provider: string;
 	/** Total cost for this bucket */
 	cost: number;
+	/** Requests excluded because no public-equivalent subscription price exists. */
+	unpricedRequests: number;
 	/** Cost breakdown */
 	costInput: number;
 	costOutput: number;
@@ -302,6 +306,8 @@ export interface ToolUsageStats {
 	outputTokensShare: number;
 	/** Cost (USD) of invoking turns, attributed per call share. */
 	costShare: number;
+	/** Share of unpriced subscription requests attributed to this tool. */
+	unpricedRequestsShare: number;
 	/** Unix ms of the most recent call in range. */
 	lastUsed: number;
 }
@@ -343,6 +349,8 @@ export interface ProviderAggregate {
 	/** Uncached input + cache reads + cache writes + output. */
 	totalTokens: number;
 	totalCost: number;
+	/** Requests excluded because no public-equivalent subscription price exists. */
+	unpricedRequests: number;
 	totalPremiumRequests: number;
 	avgTokensPerSecond: number | null;
 }
@@ -366,6 +374,8 @@ export interface ProviderTimeSeriesPoint {
 	provider: string;
 	totalTokens: number;
 	cost: number;
+	/** Requests excluded because no public-equivalent subscription price exists. */
+	unpricedRequests: number;
 	requests: number;
 }
 

--- a/packages/stats/test/client-view-models.test.ts
+++ b/packages/stats/test/client-view-models.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { formatEstimatedCost } from "../src/client/data/formatters";
 import { buildAgentTokenShare, buildModelPerformanceLookup } from "../src/client/data/view-models";
 import type { AgentTypeStats, ModelPerformancePoint } from "../src/shared-types";
 
@@ -30,6 +31,14 @@ describe("client view models", () => {
 		expect(series?.data.map(point => point.timestamp)).toEqual([DAY, DAY * 10]);
 		expect(series?.data.map(point => point.requests)).toEqual([1, 2]);
 		expect(series?.data.map(point => point.avgTtftSeconds)).toEqual([0.25, 0.5]);
+	});
+});
+
+describe("API-equivalent cost formatting", () => {
+	it("distinguishes unpriced subscription usage from a zero-dollar estimate", () => {
+		expect(formatEstimatedCost(0, 1)).toBe("N/A");
+		expect(formatEstimatedCost(0, 0)).toBe("$0");
+		expect(formatEstimatedCost(1.5, 1)).toBe("$1.50");
 	});
 });
 

--- a/packages/stats/test/db-cost.test.ts
+++ b/packages/stats/test/db-cost.test.ts
@@ -1,6 +1,15 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
-import { closeDb, getOverallStats, getRecentRequests, initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import {
+	closeDb,
+	getCostTimeSeries,
+	getOverallStats,
+	getRecentRequests,
+	getStatsByModel,
+	getStatsByProvider,
+	initDb,
+	insertMessageStats,
+} from "@oh-my-pi/omp-stats/db";
 import type { MessageStats } from "@oh-my-pi/omp-stats/types";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { getStatsDbPath } from "@oh-my-pi/pi-utils";
@@ -46,6 +55,29 @@ function expectedCodexGptCost() {
 	};
 }
 
+function createXaiOAuthStats(entryId: string): MessageStats {
+	const stats = createCodexGptStats(entryId);
+	return {
+		...stats,
+		model: "grok-4.6",
+		provider: "xai-oauth",
+		api: "openai-responses",
+	};
+}
+
+function expectedXaiGrokCost() {
+	const cost = getBundledModel("xai", "grok-4.6").cost;
+	const input = (cost.input / 1_000_000) * 1000;
+	const output = (cost.output / 1_000_000) * 500;
+	const cacheRead = (cost.cacheRead / 1_000_000) * 200;
+	return {
+		input,
+		output,
+		cacheRead,
+		total: input + output + cacheRead,
+	};
+}
+
 function createAnthropicCacheStats(entryId: string, cacheRead: number, cacheWrite: number): MessageStats {
 	const input = 1_000 - cacheRead - cacheWrite;
 	return {
@@ -72,7 +104,7 @@ function createAnthropicCacheStats(entryId: string, cacheRead: number, cacheWrit
 	};
 }
 
-describe("stats GPT cost correction", () => {
+describe("stats subscription cost correction", () => {
 	it("stores catalog-derived cost when OpenAI Codex session usage has zero cost", async () => {
 		await initDb();
 
@@ -87,50 +119,128 @@ describe("stats GPT cost correction", () => {
 		expect(request?.usage.cost.total).toBeCloseTo(expected.total, 8);
 	});
 
-	it("backfills existing zero-cost OpenAI Codex GPT rows on database init", async () => {
+	it("stores xAI API-equivalent cost when SuperGrok session usage has zero cost", async () => {
+		await initDb();
+
+		insertMessageStats([createXaiOAuthStats("xai-inserted")]);
+
+		const expected = expectedXaiGrokCost();
+		const request = getRecentRequests(1)[0];
+		expect(expected.total).toBeGreaterThan(0);
+		expect(request?.usage.cost.input).toBeCloseTo(expected.input, 8);
+		expect(request?.usage.cost.output).toBeCloseTo(expected.output, 8);
+		expect(request?.usage.cost.cacheRead).toBeCloseTo(expected.cacheRead, 8);
+		expect(request?.usage.cost.total).toBeCloseTo(expected.total, 8);
+	});
+
+	it("uses xAI's higher rate for SuperGrok prompts reaching 200K tokens", async () => {
+		await initDb();
+		const stats = createXaiOAuthStats("xai-long-context");
+		stats.usage = {
+			input: 100_000,
+			output: 1_000,
+			cacheRead: 100_000,
+			cacheWrite: 0,
+			totalTokens: 201_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		insertMessageStats([stats]);
+
+		const request = getRecentRequests(1)[0];
+		expect(request?.usage.cost.input).toBeCloseTo(0.4, 8);
+		expect(request?.usage.cost.output).toBeCloseTo(0.012, 8);
+		expect(request?.usage.cost.cacheRead).toBeCloseTo(0.1, 8);
+		expect(request?.usage.cost.total).toBeCloseTo(0.512, 8);
+	});
+
+	it("marks subscription-only SuperGrok usage as unpriced", async () => {
+		await initDb();
+		const stats = createXaiOAuthStats("xai-unpriced");
+		stats.model = "grok-composer-2.5-fast";
+
+		insertMessageStats([stats]);
+
+		expect(getRecentRequests(1)[0]?.usage.cost.total).toBe(0);
+		expect(getStatsByModel()[0]).toMatchObject({ totalCost: 0, unpricedRequests: 1 });
+		expect(getStatsByProvider()[0]).toMatchObject({ totalCost: 0, unpricedRequests: 1 });
+		expect(getCostTimeSeries()[0]).toMatchObject({ cost: 0, unpricedRequests: 1 });
+	});
+
+	it("backfills existing zero-cost subscription rows on database init", async () => {
 		await initDb();
 		closeDb();
 
 		const database = new Database(getStatsDbPath());
-		database
-			.prepare(`
-				INSERT INTO messages (
-					session_file, entry_id, folder, model, provider, api, timestamp,
-					duration, ttft, stop_reason, error_message,
-					input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, premium_requests,
-					cost_input, cost_output, cost_cache_read, cost_cache_write, cost_total
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			`)
-			.run(
-				"/tmp/session.jsonl",
-				"backfilled",
-				"/tmp/project",
-				"gpt-5.4",
-				"openai-codex",
-				"openai-codex-responses",
-				Date.now(),
-				1000,
-				100,
-				"stop",
-				null,
-				1000,
-				500,
-				200,
-				0,
-				1700,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-			);
+		const insert = database.prepare(`
+			INSERT INTO messages (
+				session_file, entry_id, folder, model, provider, api, timestamp,
+				duration, ttft, stop_reason, error_message,
+				input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, premium_requests,
+				cost_input, cost_output, cost_cache_read, cost_cache_write, cost_total
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`);
+		insert.run(
+			"/tmp/session.jsonl",
+			"codex-backfilled",
+			"/tmp/project",
+			"gpt-5.4",
+			"openai-codex",
+			"openai-codex-responses",
+			Date.now(),
+			1000,
+			100,
+			"stop",
+			null,
+			1000,
+			500,
+			200,
+			0,
+			1700,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		);
+		insert.run(
+			"/tmp/session.jsonl",
+			"xai-backfilled",
+			"/tmp/project",
+			"grok-4.6",
+			"xai-oauth",
+			"openai-responses",
+			Date.now(),
+			1000,
+			100,
+			"stop",
+			null,
+			1000,
+			500,
+			200,
+			0,
+			1700,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		);
 		database.close();
 
 		await initDb();
 
-		const request = getRecentRequests(1)[0];
-		expect(request?.usage.cost.total).toBeCloseTo(expectedCodexGptCost().total, 8);
+		const requests = getRecentRequests(2);
+		expect(requests.find(request => request.entryId === "codex-backfilled")?.usage.cost.total).toBeCloseTo(
+			expectedCodexGptCost().total,
+			8,
+		);
+		expect(requests.find(request => request.entryId === "xai-backfilled")?.usage.cost.total).toBeCloseTo(
+			expectedXaiGrokCost().total,
+			8,
+		);
 	});
 });
 

--- a/packages/stats/test/db-cost.test.ts
+++ b/packages/stats/test/db-cost.test.ts
@@ -242,6 +242,79 @@ describe("stats subscription cost correction", () => {
 			8,
 		);
 	});
+
+	it("refreshes a historically zero-cost multi-agent row with orchestration usage on re-ingest", async () => {
+		await initDb();
+		closeDb();
+
+		// Simulate a pre-fix ingest: the row was priced from the four stored
+		// token buckets only, so its orchestration usage was dropped and the
+		// cost persisted as $0.
+		const database = new Database(getStatsDbPath());
+		database
+			.prepare(`
+				INSERT INTO messages (
+					session_file, entry_id, folder, model, provider, api, timestamp,
+					duration, ttft, stop_reason, error_message,
+					input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, premium_requests,
+					cost_input, cost_output, cost_cache_read, cost_cache_write, cost_total
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`)
+			.run(
+				"/tmp/session.jsonl",
+				"multi-agent",
+				"/tmp/project",
+				"grok-4.20-multi-agent-0309",
+				"xai-oauth",
+				"openai-responses",
+				Date.now(),
+				1000,
+				100,
+				"stop",
+				null,
+				1000,
+				500,
+				200,
+				0,
+				302_700,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+			);
+		database.close();
+
+		await initDb();
+
+		// Re-ingest the same row with the orchestration counters the parser
+		// recovers from source; the cost-refreshing UPSERT must reprice it.
+		insertMessageStats([
+			{
+				...createXaiOAuthStats("multi-agent"),
+				model: "grok-4.20-multi-agent-0309",
+				usage: {
+					input: 1000,
+					output: 500,
+					cacheRead: 200,
+					cacheWrite: 0,
+					orchestration: { input: 300_000, output: 1000 },
+					totalTokens: 302_700,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+		]);
+
+		// Prompt input (1000 + 200 + 300000) crosses the inclusive 200K tier, so
+		// the whole request bills at 4/12/0.4; orchestration input/output are
+		// priced alongside the conversation buckets.
+		const request = getRecentRequests(1)[0];
+		expect(request?.usage.cost.input).toBeCloseTo((4 / 1e6) * 301_000, 8);
+		expect(request?.usage.cost.output).toBeCloseTo((12 / 1e6) * 1_500, 8);
+		expect(request?.usage.cost.cacheRead).toBeCloseTo((0.4 / 1e6) * 200, 8);
+		expect(request?.usage.cost.total).toBeCloseTo(1.22208, 8);
+	});
 });
 
 describe("stats cache metrics", () => {

--- a/packages/stats/test/overview-token-labels.test.tsx
+++ b/packages/stats/test/overview-token-labels.test.tsx
@@ -16,6 +16,7 @@ const stats: AggregatedStats = {
 	cacheRate: 0.75,
 	cacheSavings: 0.695,
 	totalCost: 0,
+	unpricedRequests: 0,
 	totalPremiumRequests: 0,
 	avgDuration: 1000,
 	avgTtft: 100,


### PR DESCRIPTION
## Repro
A zero-cost `xai-oauth/grok-4.6` usage row stayed at `$0` even though `xai/grok-4.6` has a public rate card. `bun test packages/stats/test/db-cost.test.ts` reproduced the failure: 1,000 input tokens expected `$0.002` but stored `$0`.

## Cause
`packages/stats/src/db.ts:getCatalogCost` only resolved the `openai-codex -> openai` fallback, while generated `xai-oauth` catalog rows retained subscription-zero rates. `calculateCatalogCost` also multiplied only the flat token rates, so it could not honor xAI's 200K prompt tier.

## Fix
- Apply xAI's documented inclusive 200K long-context rate cards and mirror exact `xai` model prices onto matching `xai-oauth` catalog rows.
- Resolve the same fallback while inserting and backfilling stats rows, using the catalog's tier-aware cost calculator.
- Track unpriced SuperGrok requests separately, render subscription-only models as N/A, and label dollar values as API-equivalent estimates across dashboard and CLI surfaces.
- Document the estimate semantics and add catalog/stats regressions for shared, long-context, historical, and unpriced usage.

## Verification
`bun test packages/catalog/test/xai-api-key-responses.test.ts packages/catalog/test/long-context-pricing.test.ts packages/stats/test/db-cost.test.ts packages/stats/test/client-view-models.test.ts packages/stats/test/overview-token-labels.test.tsx packages/stats/test/tool-stats.test.ts` passed: 25 tests, 195 assertions. `bun --cwd=packages/catalog run check` and `bun --cwd=packages/stats run check` passed; the push pre-publish `bun check` gate also passed. A seeded dashboard server built the client and returned `$0.0051` for `xai-oauth/grok-4.6` plus `unpricedRequests: 1` for `grok-composer-2.5-fast` from the costs, providers, and model APIs. Chromium was unavailable in the bot environment, so visual browser verification could not be performed.

Fixes #9512