### PR TITLE
fix(coding-agent): preserve subagent output artifact on hub revival

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reviving a finished subagent with a `hub` message no longer overwrites its completed `agent://<id>` output with a "exited without calling yield" warning; revival/wake turns only rewrite the artifact when they produce a new `yield` result ([#9518](https://github.com/can1357/oh-my-pi/issues/9518)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2135,6 +2135,13 @@ interface FinalizeRunArgs {
 	eventBus?: EventBus;
 	parentToolCallId?: string;
 	detached?: boolean;
+	/**
+	 * This finalize is a revival/wake or explicit follow-up turn, not the initial
+	 * run. Such turns only (re)write `<id>.md` when they produce a real `yield`
+	 * result, so a conversational hub wake (which never yields) cannot clobber the
+	 * completed run's artifact with a missing-yield warning body (issue #9518).
+	 */
+	followUpTurn?: boolean;
 	sessionFile?: string;
 	startTime: number;
 }
@@ -2196,11 +2203,17 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		maxLines: MAX_OUTPUT_LINES,
 	});
 
-	// Write output artifact (input and jsonl already written in real-time)
-	// Compute output metadata for agent:// URL integration
+	// Write output artifact (input and jsonl already written in real-time).
+	// Compute output metadata for agent:// URL integration.
+	//
+	// A revival/follow-up turn only (re)writes <id>.md when it produced a real
+	// yield result. A subagent revived to answer a hub message never yields, so
+	// writing here would overwrite the completed run's authoritative artifact with
+	// a missing-yield warning body (issue #9518). The initial run is unaffected
+	// (followUpTurn is unset), preserving the documented missing-yield artifact.
 	let outputMeta: { lineCount: number; charCount: number } | undefined;
 	let outputPath: string | undefined;
-	if (args.artifactsDir) {
+	if (args.artifactsDir && (!args.followUpTurn || hasYield)) {
 		outputPath = path.join(args.artifactsDir, `${id}.md`);
 		try {
 			await Bun.write(outputPath, rawOutput);
@@ -2407,6 +2420,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 					eventBus: options.eventBus,
 					parentToolCallId: options.parentToolCallId,
 					detached: true,
+					followUpTurn: true,
 					sessionFile,
 					startTime: turnStartTime,
 				});
@@ -2554,7 +2568,11 @@ export interface FollowUpTurnOptions {
 	onProgress?: (progress: AgentProgress) => void;
 	eventBus?: EventBus;
 	parentToolCallId?: string;
-	/** When set, the turn's raw output is (re)written to `<artifactsDir>/<id>.md` so `agent://<id>` tracks the latest turn. */
+	/**
+	 * When set, a turn that produces a `yield` result (re)writes `<artifactsDir>/<id>.md`
+	 * so `agent://<id>` tracks the latest completion. A yield-less turn (e.g. a hub
+	 * wake answering a message) leaves the existing artifact intact (issue #9518).
+	 */
 	artifactsDir?: string;
 	/** Wall-clock cap in ms for this turn; 0 disables. */
 	maxRuntimeMs?: number;
@@ -2644,6 +2662,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		eventBus: options.eventBus,
 		parentToolCallId: options.parentToolCallId,
 		detached: true,
+		followUpTurn: true,
 		sessionFile,
 		startTime,
 	});

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -333,4 +333,56 @@ describe("persisted subagent revival", () => {
 		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
 	});
+
+	it("preserves the completed output artifact when a revived subagent answers a hub message without yielding", async () => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		const cwd = makeTempDir("@pi-revive-artifact-");
+		const sessionFile = await createPersistedSession(cwd);
+		MCPManager.setInstance({ getTools: () => [] } as unknown as MCPManager);
+		let handle: RevivedSessionHandle | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			handle = createRevivedSession([]);
+			return { session: handle.session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		AgentRegistry.global().register({
+			id: ref.id,
+			displayName: ref.displayName,
+			kind: "sub",
+			session: null,
+			sessionFile,
+			status: "parked",
+		});
+		const reviver = await createFactory(cwd)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		// The completed first run already wrote its report to <artifactsDir>/<id>.md
+		// (artifactsDir = parent sessionFile sans ".jsonl"; see createFactory).
+		const artifactPath = path.join(cwd, "parent", `${ref.id}.md`);
+		const completedReport = "# Completed report\n\nfull multi-paragraph body\n\nZZEND";
+		await Bun.write(artifactPath, completedReport);
+
+		const observer = handle?.observer();
+		expect(observer).toBeDefined();
+		const record: CustomMessage = {
+			role: "custom",
+			customType: "irc:incoming",
+			content: "thanks",
+			display: true,
+			details: { id: "irc-1", from: "Main", message: "thanks" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		// A wake turn answering a hub message never calls yield; finalization must
+		// not clobber the authoritative completion artifact with a warning body.
+		const finish = observer?.([record]);
+		await finish?.();
+
+		expect(await Bun.file(artifactPath).text()).toBe(completedReport);
+		AgentLifecycleManager.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+	});
 });


### PR DESCRIPTION
## Repro
Spawn a subagent that finishes normally (calls `yield`), then send it a `hub` message (e.g. `op="send", message="thanks"`). The revived subagent runs a wake turn to answer the message. Afterward `agent://<id>` — and the on-disk `<id>.md` artifact — contain only `SYSTEM WARNING: Subagent exited without calling yield tool after 3 reminders.`, silently destroying the completed report. Regression test: `bun test test/task/persisted-revive.test.ts -t "preserves the completed output artifact"`.

## Cause
`finalizeRunResult` in `packages/coding-agent/src/task/executor.ts` unconditionally rewrites `<id>.md` whenever `artifactsDir` is set. Both revival paths call it — the IRC/hub wake observer in `attachIrcWakeTurnMonitor` and `runSubagentFollowUpTurn`. A wake turn answering a hub message never calls `yield`, so `finalizeSubprocessOutput` returns the missing-yield warning as the raw output, which then overwrites the completed run's authoritative artifact. The warning is also factually wrong: `yield` was called on the initial run.

## Fix
- Added a `followUpTurn` flag to `FinalizeRunArgs`.
- Guarded the artifact write: `if (args.artifactsDir && (!args.followUpTurn || hasYield))` — revival/follow-up turns only (re)write `<id>.md` when they produce a real `yield` result. The initial run (`followUpTurn` unset) is unchanged, preserving the documented first-run missing-yield artifact.
- Set `followUpTurn: true` at both revival callsites (`attachIrcWakeTurnMonitor` observer, `runSubagentFollowUpTurn`).
- Updated the `FollowUpTurnOptions.artifactsDir` doc to reflect the yield-gated rewrite.
- Added a regression test driving the cold-revive IRC wake observer against a pre-existing completion artifact.

## Verification
`bun test test/task/persisted-revive.test.ts test/task/executor-warnings.test.ts` → 26 pass. Also ran `test/task/executor-subagent-reminders.test.ts test/task/executor-recent-output.test.ts test/task/structured-subagent.test.ts test/task/parallel.test.ts` → 59 pass. The new regression test fails before the fix (artifact overwritten with the 81-byte warning) and passes after. Fixes #9518