### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -1,5 +1,32 @@
 # MCP configuration in OMP
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 This guide explains how to add, edit, and validate MCP servers for the OMP coding agent.
 
 Source of truth in code:
@@ -542,11 +569,6 @@ Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT, v0.6.0+)
 
 ### Pair
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
-gbr-agent version    # need v0.6.0+
-gbr-agent pair && gbr-agent run
-```
 
 Phone: Build Remote Agent → scan QR **or** type the printed 8-char code.
 Unpair in the app before changing PCs.
@@ -587,3 +609,10 @@ curl -sS http://127.0.0.1:8788/v1/sessions
 - GitHub MCP server: https://github.com/github/github-mcp-server
 - Slack MCP server docs: https://docs.slack.dev/ai/slack-mcp-server/
 - Build Remote Agent: https://grokbuildremote.com/
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -528,9 +528,62 @@ The runtime/config writer accepts `:` in names used by marketplace plugins. The 
 
 Malformed JSON or a missing/invalid server map makes that provider contribute no entries from the file; depending on the provider, OMP records a discovery warning or logs the parse failure rather than failing the session. Correct the JSON shape, then run `/mcp reload` and `/mcp list`.
 
+## Build Remote Agent (phone pairing)
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+Pair a phone running **Build Remote Agent** to this desktop `omp` session.
+Protocol `gbr/1`. The phone is spectator + veto, not orchestrator. Attach only
+via loopback Bot API `http://127.0.0.1:8788` after `gbr-agent run`, or MCP
+stdio `gbr-mcp`. Never put mailbox keys in MCP config.
+
+Website: https://grokbuildremote.com/
+Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT, v0.6.0+)
+
+### Pair
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Phone: Build Remote Agent → scan QR **or** type the printed 8-char code.
+Unpair in the app before changing PCs.
+
+### MCP snippet (`.omp/mcp.json` or `~/.omp/agent/mcp.json`)
+
+Clone and install `gbr-mcp` once, then use an **absolute** path to `gbr-mcp.js`:
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+```
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
+  "mcpServers": {
+    "gbr": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+    }
+  }
+}
+```
+
+Or `/mcp add` → stdio → command `node` → the same script. HTTP attach without MCP:
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
 ## References
 
 - MCP transport spec: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
 - Filesystem server package: https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem
 - GitHub MCP server: https://github.com/github/github-mcp-server
 - Slack MCP server docs: https://docs.slack.dev/ai/slack-mcp-server/
+- Build Remote Agent: https://grokbuildremote.com/


### PR DESCRIPTION
Add **Build Remote Agent** as a pairing device for this desktop agent.

Build Remote Agent is an independent product by Linespotting AB. Not affiliated with xAI or SpaceX. Protocol `gbr/1`. The phone is a spectator + veto, not an orchestrator. Attach surface is only `http://127.0.0.1:8788` after `gbr-agent run`, or MCP stdio `gbr-mcp`.

## How to use

1. Install: `curl -fsSL https://grokbuildremote.com/install.sh | bash` (Windows: `irm https://grokbuildremote.com/install.ps1 | iex`)
2. `gbr-agent version` — need **v0.6.0+**
3. `gbr-agent pair && gbr-agent run` (QR in browser + printed 8-char code)
4. Phone: Build Remote Agent → scan QR **or** type the 8-char code
5. Attach: `curl -sS http://127.0.0.1:8788/health` or MCP stdio `gbr-mcp`

Docs: https://grokbuildremote.com/ · Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents

This PR is docs/config only. No mailbox keys. No product-runtime changes.