### PR TITLE
fix(coding-agent): resolve custom-provider models with slash-containing IDs

### DIFF
--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -644,7 +644,37 @@ function findExactModelReferenceMatch(modelReference: string, availableModels: M
 		const provider = trimmedReference.substring(0, slashIndex).trim();
 		const modelId = trimmedReference.substring(slashIndex + 1).trim();
 		if (provider && modelId) {
-			return resolveProviderModelReference(provider, modelId, availableModels);
+			const resolved = resolveProviderModelReference(provider, modelId, availableModels);
+			if (resolved) {
+				// The provider/model split found a match.  But the full reference
+				// might also be a literal model ID on a custom provider whose IDs
+				// contain slashes (e.g. custom provider "my-custom" with model id
+				// "deepseek/deepseek-v4-flash").  When there is exactly one such
+				// bare-ID match on a non-bundled provider, prefer it directly —
+				// isProviderLockedCrossMatch would otherwise filter it out in the
+				// caller's bare-ID phase.
+				const lowerReference = trimmedReference.toLowerCase();
+				const bareMatches = availableModels.filter(m => m.id.toLowerCase() === lowerReference);
+				if (
+					bareMatches.length === 1 &&
+					bareMatches[0] !== resolved &&
+					getBundledModels(bareMatches[0].provider as GeneratedProvider).length === 0
+				) {
+					return bareMatches[0];
+				}
+				return resolved;
+			}
+
+			// The provider/model split failed.  If the prefix is NOT a known
+			// bundled provider, it is likely a custom provider whose model IDs
+			// contain slashes (e.g. custom provider "my-custom" with model id
+			// "deepseek/deepseek-v4-flash").  In that case, try the full
+			// reference as a literal model ID so the model can be found.
+			if (getBundledModels(provider.toLowerCase() as GeneratedProvider).length === 0) {
+				const lowerReference = trimmedReference.toLowerCase();
+				const bareMatches = availableModels.filter(m => m.id.toLowerCase() === lowerReference);
+				if (bareMatches.length === 1) return bareMatches[0];
+			}
 		}
 	}
 	return undefined;

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -325,7 +325,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 			}
 		}
 		const quotaProvider =
-			(advisor.model?.includes("/") ? advisor.model.split("/")[0] : null) ?? liveStat?.model?.provider;
+			liveStat?.model?.provider ?? (advisor.model?.includes("/") ? advisor.model.split("/")[0] : null);
 		if (this.#cachedReports && quotaProvider) {
 			const activeAccount = this.#cb.resolveActiveAccount?.(quotaProvider, liveStat?.sessionId);
 			const quota = formatCompactQuota(quotaProvider, this.#cachedReports, Date.now(), activeAccount);


### PR DESCRIPTION
## Repro

Register a custom provider (e.g. `my-custom`) in `models.yml` with a model whose ID contains a slash, e.g. `deepseek/deepseek-v4-flash`. Set `model: deepseek/deepseek-v4-flash` (or select it via `/model`). The request is routed to the built-in `deepseek` provider's `deepseek-v4-flash` model instead of the custom provider's model.

## Cause

`findExactModelReferenceMatch` in `model-resolver.ts` always splits the reference on the first `/`, treating the prefix as a provider name. When the model ID itself contains a slash (e.g. `deepseek/deepseek-v4-flash`), the system interprets `deepseek` as the provider and resolves to the built-in deepseek model. The custom provider's model — whose literal ID is `deepseek/deepseek-v4-flash` — is never considered. The existing bare-ID check in `matchModel` step 2 would find it, but `findExactModelReferenceMatch` returns early before that phase runs.

A secondary issue in `advisor-config.ts` extracts the provider name from `advisor.model.split("/")[0]`, which gives the wrong provider for slash-containing IDs.

## Fix

- In `findExactModelReferenceMatch`: after the provider/model split succeeds, check if the full reference also matches a literal model ID on a non-bundled provider. When there is exactly one such bare-ID match (and it differs from the provider-split result), return it directly — bypassing `isProviderLockedCrossMatch` which would otherwise filter it out.
- In `findExactModelReferenceMatch`: when the provider/model split fails and the prefix is not a known bundled provider, try the full reference as a literal model ID.
- In `advisor-config.ts`: prefer `liveStat?.model?.provider` (from the resolved model object) over `advisor.model.split("/")[0]` for the quota provider display.

## Verification

`bun test test/model-resolver.test.ts` — 158 pass, 0 fail. `bun check` passes (biome + types; only pre-existing unrelated TS errors in `packages/tui/test/virtual-terminal.ts`). Manually traced three scenarios:
1. Custom provider `my-custom` with model id `deepseek/deepseek-v4-flash` — resolves to custom model ✅
2. `anthropic/claude-opus-5` with only OpenRouter model available — returns `undefined` (provider lock intact) ✅
3. `Anthropic/Claude-Opus-5` (case-insensitive) — same lock behavior ✅

I reviewed the full diff and verified that the existing provider-lock and OpenRouter aggregator-shadowing tests all pass unchanged.

Fixes #8800