### PR TITLE
collab: programmatic hosting through the extension API

### DIFF
--- a/docs/collab.md
+++ b/docs/collab.md
@@ -40,6 +40,11 @@ The guest's previous session is restored on `/leave` (or when the host stops).
 | `/join <link>`    | Join a shared session as a guest                                                    |
 | `/leave`          | Leave (guest) or stop sharing (host)                                                |
 
+
+### Programmatic hosting
+
+Extensions can start, read, and stop hosting without typing a command: `pi.startCollab({ relayUrl })` (returns `{ link, viewLink, webLink, webViewLink }`, or the existing links when that relay already has a room), `pi.getCollabLinks()`, and `pi.stopCollab()`. Same rules as `/collab` (one room per session, guest sessions refuse), but nothing is printed: the links are credentials and the caller owns keeping them out of logs and transcripts. Interactive TUI only.
+
 ## Link format
 
 Accepted by `/join <link>` and `omp join "<link>"`:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -123,9 +123,12 @@ Core methods:
 - `getSessionName`, `setSessionName`
 - `setModel`, `getThinkingLevel`, `setThinkingLevel`
 - `getServiceTiers`, `setServiceTier`
+- `startCollab`, `getCollabLinks`, `stopCollab`
 - `registerProvider`
 - `registerFileWriteFallback`, `registerFileDeleteFallback`
 - `events` (shared event bus)
+
+`pi.startCollab({ relayUrl })` starts hosting this session's collab room, or returns the links of the room already hosted on that relay. Interactive TUI only; other extension hosts throw. The returned `{ link, viewLink, webLink, webViewLink }` are credentials (the full link can steer the session): unlike `/collab`, nothing is printed, so the extension owns where the links go. `pi.getCollabLinks()` reads the current links without starting anything, and `pi.stopCollab()` stops hosting, disconnecting every guest.
 
 `getServiceTiers()` returns a detached snapshot of the session's live per-family tier map. `setServiceTier(family, tier)` changes one family for subsequent requests; pass `undefined` to clear that session override. OpenAI accepts `auto`, `default`, `flex`, `scale`, or `priority`; Anthropic accepts `priority`; Google accepts `flex` or `priority`. Changes made while a response is streaming do not alter that in-flight request.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -123,9 +123,12 @@ Core methods:
 - `getSessionName`, `setSessionName`
 - `setModel`, `getThinkingLevel`, `setThinkingLevel`
 - `getServiceTiers`, `setServiceTier`
+- `startCollab`, `getCollabLinks`, `stopCollab`
 - `registerProvider`
 - `registerFileWriteFallback`, `registerFileDeleteFallback`
 - `events` (shared event bus)
+
+`pi.startCollab({ relayUrl })` starts hosting this session's collab room, or returns the links of the room already hosted on that relay. Interactive TUI only; other extension hosts throw. The returned `{ link, viewLink, webLink, webViewLink }` are credentials (the full link can steer the session): unlike `/collab`, nothing is printed, so the extension owns where the links go. `pi.getCollabLinks()` reads the current links without starting anything, and answers `undefined` right after a session switch while the previous session's room winds down, and `pi.stopCollab()` stops hosting, disconnecting every guest.
 
 `getServiceTiers()` returns a detached snapshot of the session's live per-family tier map. `setServiceTier(family, tier)` changes one family for subsequent requests; pass `undefined` to clear that session override. OpenAI accepts `auto`, `default`, `flex`, `scale`, or `priority`; Anthropic accepts `priority`; Google accepts `flex` or `priority`. Changes made while a response is streaming do not alter that in-flight request.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added extension-facing collab hosting methods (`pi.startCollab()`, `pi.getCollabLinks()`, and `pi.stopCollab()`) to start, inspect, and stop live session sharing programmatically without routing through terminal commands ([#9525](https://github.com/can1357/oh-my-pi/pull/9525) by [@jwaldrip](https://github.com/jwaldrip)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -55,6 +55,49 @@ export const COLLAB_GUEST_ALLOWED_COMMANDS: Record<string, true> = {
 	exit: true,
 	quit: true,
 };
+
+/**
+ * Guest transitions in flight per session, counted rather than flagged.
+ *
+ * Both windows leave `ctx.collabGuest` unset while the live session is still
+ * the guest's replica: a join has not published itself yet, and a rollback has
+ * already cleared itself while the local session is still being restored. A
+ * hosting start in either window would bind its room to a session that is
+ * about to vanish. Counting matters because the two nest: the conflict branch
+ * of a join calls {@link CollabGuestLink.leave}'s restore path, and a flag
+ * would let the inner exit release the outer's reservation.
+ */
+interface GuestTransitions {
+	joins: number;
+	restores: number;
+}
+
+const guestTransitions = new WeakMap<InteractiveModeContext, GuestTransitions>();
+
+function enterGuestTransition(ctx: InteractiveModeContext, kind: keyof GuestTransitions): void {
+	const state = guestTransitions.get(ctx) ?? { joins: 0, restores: 0 };
+	state[kind] += 1;
+	guestTransitions.set(ctx, state);
+}
+
+function exitGuestTransition(ctx: InteractiveModeContext, kind: keyof GuestTransitions): void {
+	const state = guestTransitions.get(ctx);
+	if (!state) return;
+	state[kind] = Math.max(0, state[kind] - 1);
+	if (state.joins === 0 && state.restores === 0) guestTransitions.delete(ctx);
+}
+
+/** Whether a `/join` handshake is mid-flight for this session. */
+export function hasInFlightCollabJoin(ctx: InteractiveModeContext): boolean {
+	return (guestTransitions.get(ctx)?.joins ?? 0) > 0;
+}
+
+/** Whether a guest handshake or a guest rollback is mid-flight. */
+export function hasInFlightCollabGuestTransition(ctx: InteractiveModeContext): boolean {
+	const state = guestTransitions.get(ctx);
+	return state !== undefined && (state.joins > 0 || state.restores > 0);
+}
+
 /**
  * How long the guest waits for the host's small `welcome` frame before giving
  * up on the join. The welcome carries metadata only (`entryCount`, header,
@@ -254,6 +297,29 @@ export class CollabGuestLink {
 	}
 
 	async join(link: string): Promise<void> {
+		if (this.#ctx.collabHost) {
+			throw new Error("Already hosting a collab session (/collab stop first)");
+		}
+		// One join per session. A session has one transcript, so a second
+		// concurrent join has nothing coherent to do, and refusing keeps the
+		// join count owned by exactly one caller.
+		if (hasInFlightCollabJoin(this.#ctx)) {
+			throw new Error("Already joining a collab session (/leave first)");
+		}
+		// Claimed synchronously, before the first await, and held until the
+		// guest is published or the join fails. A hosting start that publishes
+		// while this is held would bind its room to the replica session this
+		// join is about to roll back, so `startCollabHosting` observes it the
+		// same way `/join` observes an in-flight hosting start.
+		enterGuestTransition(this.#ctx, "joins");
+		try {
+			await this.#join(link);
+		} finally {
+			exitGuestTransition(this.#ctx, "joins");
+		}
+	}
+
+	async #join(link: string): Promise<void> {
 		const parsed = parseCollabLink(link);
 		if ("error" in parsed) throw new Error(parsed.error);
 		this.#roomId = parsed.roomId;
@@ -296,6 +362,10 @@ export class CollabGuestLink {
 				.then(async () => {
 					if (frame.t === "welcome") {
 						this.#clearWelcomeTimer();
+						if (this.#ctx.collabHost) {
+							firstWelcome.reject(new Error("Already hosting a collab session (/collab stop first)"));
+							return;
+						}
 						this.#beginWelcome(frame, joined);
 						if (frame.entryCount === 0) {
 							await this.#finalizeSnapshot();
@@ -306,6 +376,10 @@ export class CollabGuestLink {
 					if (frame.t === "snapshot-chunk") {
 						const ready = this.#accumulateSnapshotChunk(frame);
 						if (ready) {
+							if (this.#ctx.collabHost) {
+								firstWelcome.reject(new Error("Already hosting a collab session (/collab stop first)"));
+								return;
+							}
 							await this.#finalizeSnapshot();
 							finishJoin();
 						}
@@ -365,6 +439,17 @@ export class CollabGuestLink {
 			this.#joinReject = null;
 			this.#clearWelcomeTimer();
 			this.#clearSnapshotProgressTimer();
+		}
+		if (this.#ctx.collabHost) {
+			// The replica session is already active here, so it has to be rolled
+			// back. #restoreLocalSession latches #left itself and no-ops when it
+			// is already set, so latching first would strand the replica and
+			// leave the user in a session the host is about to stop broadcasting.
+			// Restoring before the close also keeps onClose from announcing an
+			// ended session for a join that never completed.
+			await this.#restoreLocalSession();
+			socket.close();
+			throw new Error("Already hosting a collab session (/collab stop first)");
 		}
 
 		this.#ctx.collabGuest = this;
@@ -742,29 +827,41 @@ export class CollabGuestLink {
 	async #restoreLocalSession(): Promise<void> {
 		if (this.#left) return;
 		this.#left = true;
-		this.#socket = null;
-		this.#ctx.collabGuest = undefined;
-		this.#ctx.statusLine.setCollabStatus(null);
-		this.#flushPendingTranscripts();
-		this.#clearAgentMirror();
-		this.#ctx.syncRunningSubagentBadge();
-		this.#ctx.resetObserverRegistry();
-		this.#clearTransientUi();
-		// Replica file stays on disk: it is a valid session file outside the
-		// sessions dir, so it never shows up in /resume but remains readable.
-		if (this.#returnSessionFile) {
-			await this.#ctx.handleResumeSession(this.#returnSessionFile);
-			return;
+		// Held across the whole rollback. `ctx.collabGuest` is cleared on the
+		// next line while the local session is still being restored, and the
+		// session switch below awaits its own handlers, so an extension calling
+		// startCollab() from one would otherwise see no guest and bind a room
+		// to the outgoing replica.
+		enterGuestTransition(this.#ctx, "restores");
+		try {
+			this.#socket = null;
+			this.#ctx.collabGuest = undefined;
+			if (!this.#ctx.collabHost) {
+				this.#ctx.statusLine.setCollabStatus(null);
+			}
+			this.#flushPendingTranscripts();
+			this.#clearAgentMirror();
+			this.#ctx.syncRunningSubagentBadge();
+			this.#ctx.resetObserverRegistry();
+			this.#clearTransientUi();
+			// Replica file stays on disk: it is a valid session file outside the
+			// sessions dir, so it never shows up in /resume but remains readable.
+			if (this.#returnSessionFile) {
+				await this.#ctx.handleResumeSession(this.#returnSessionFile);
+				return;
+			}
+			await this.#ctx.session.newSession();
+			setSessionTerminalTitle(this.#ctx.sessionManager.getSessionName(), this.#ctx.sessionManager.getCwd());
+			this.#ctx.statusLine.invalidate();
+			this.#ctx.statusLine.resetActiveTime();
+			this.#ctx.ui.requestRender();
+			this.#ctx.updateEditorBorderColor();
+			await this.#ctx.renderInitialMessages({ clearTerminalHistory: true });
+			await this.#ctx.reloadTodos();
+			this.#ctx.ui.requestRender(true, { clearScrollback: true });
+		} finally {
+			exitGuestTransition(this.#ctx, "restores");
 		}
-		await this.#ctx.session.newSession();
-		setSessionTerminalTitle(this.#ctx.sessionManager.getSessionName(), this.#ctx.sessionManager.getCwd());
-		this.#ctx.statusLine.invalidate();
-		this.#ctx.statusLine.resetActiveTime();
-		this.#ctx.ui.requestRender();
-		this.#ctx.updateEditorBorderColor();
-		await this.#ctx.renderInitialMessages({ clearTerminalHistory: true });
-		await this.#ctx.reloadTodos();
-		this.#ctx.ui.requestRender(true, { clearScrollback: true });
 	}
 
 	#updateStatusSegment(): void {

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -41,6 +41,7 @@ import {
 	formatCollabLink,
 	formatCollabWebLink,
 	generateRoomId,
+	normalizeRelayOrigin,
 	parseCollabLink,
 } from "./protocol";
 import { CollabSocket } from "./relay-client";
@@ -122,6 +123,7 @@ export type CollabGuestUiResult = { kind: "answered"; value: CollabUiResponseVal
 export class CollabHost {
 	#ctx: InteractiveModeContext;
 	#socket: CollabSocket | null = null;
+	#relayOrigin = "";
 	#link = "";
 	#webLink = "";
 	#viewLink = "";
@@ -142,6 +144,11 @@ export class CollabHost {
 
 	constructor(ctx: InteractiveModeContext) {
 		this.#ctx = ctx;
+	}
+
+	/** Normalized ws(s) origin of the relay this room is hosted through; empty before {@link start}. */
+	get relayOrigin(): string {
+		return this.#relayOrigin;
 	}
 
 	get link(): string {
@@ -213,6 +220,9 @@ export class CollabHost {
 		const writeToken = generateWriteToken();
 		const roomId = generateRoomId();
 		this.#writeToken = writeToken;
+		const normalizedOrigin = normalizeRelayOrigin(relayUrl);
+		if ("error" in normalizedOrigin) throw new Error(normalizedOrigin.error);
+		this.#relayOrigin = normalizedOrigin.origin;
 		this.#link = formatCollabLink(relayUrl, roomId, rawKey, writeToken);
 		this.#webLink = formatCollabWebLink(relayUrl, roomId, rawKey, writeToken, webUrl);
 		this.#viewLink = formatCollabLink(relayUrl, roomId, rawKey);

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -41,6 +41,7 @@ import {
 	formatCollabLink,
 	formatCollabWebLink,
 	generateRoomId,
+	normalizeRelayOrigin,
 	parseCollabLink,
 } from "./protocol";
 import { CollabSocket } from "./relay-client";
@@ -102,6 +103,8 @@ function isWireSessionEntry(entry: StoredSessionEntry): entry is StoredSessionEn
 	return entry.type in WIRE_SESSION_ENTRY_TYPES;
 }
 const CONNECT_TIMEOUT_MS = 15_000;
+/** Message a start rejects with when hosting was stopped before it finished. */
+export const COLLAB_STOPPED_ERROR = "Collab hosting was stopped";
 /** Max bytes served per fetch-transcript reply (guest re-requests from `newSize`). */
 export const TRANSCRIPT_READ_CAP = 4 * 1024 * 1024;
 const TRANSCRIPT_ENTRY_TOO_LARGE_ERROR = `transcript entry exceeds transcript fetch cap (${TRANSCRIPT_READ_CAP} bytes)`;
@@ -124,6 +127,7 @@ export type CollabGuestUiResult = { kind: "answered"; value: CollabUiResponseVal
 export class CollabHost {
 	#ctx: InteractiveModeContext;
 	#socket: CollabSocket | null = null;
+	#relayOrigin = "";
 	#link = "";
 	#webLink = "";
 	#viewLink = "";
@@ -140,10 +144,18 @@ export class CollabHost {
 	#agentsDebounce: Timer | null = null;
 	#busUnsubscribers: (() => void)[] = [];
 	#registryUnsubscribe?: () => void;
+	/** The exact `onEntryAppended` this host installed, so teardown releases only its own. */
+	#entryTap?: (entry: StoredSessionEntry) => void;
 	#stopped = false;
-
+	#published = false;
+	#firstOpen?: PromiseWithResolvers<void>;
 	constructor(ctx: InteractiveModeContext) {
 		this.#ctx = ctx;
+	}
+
+	/** Normalized ws(s) origin of the relay this room is hosted through; empty before {@link start}. */
+	get relayOrigin(): string {
+		return this.#relayOrigin;
 	}
 
 	get link(): string {
@@ -163,6 +175,11 @@ export class CollabHost {
 	/** Read-only variant of {@link webLink}. */
 	get webViewLink(): string {
 		return this.#webViewLink;
+	}
+
+	/** Session id this room is bound to; broadcasts tear down if the session switches. */
+	get sessionId(): string {
+		return this.#sessionId;
 	}
 
 	get participants(): CollabParticipant[] {
@@ -207,6 +224,9 @@ export class CollabHost {
 		const writeToken = generateWriteToken();
 		const roomId = generateRoomId();
 		this.#writeToken = writeToken;
+		const normalizedOrigin = normalizeRelayOrigin(relayUrl);
+		if ("error" in normalizedOrigin) throw new Error(normalizedOrigin.error);
+		this.#relayOrigin = normalizedOrigin.origin;
 		this.#link = formatCollabLink(relayUrl, roomId, rawKey, writeToken);
 		this.#webLink = formatCollabWebLink(relayUrl, roomId, rawKey, writeToken, webUrl);
 		this.#viewLink = formatCollabLink(relayUrl, roomId, rawKey);
@@ -214,16 +234,22 @@ export class CollabHost {
 		const parsed = parseCollabLink(this.#link);
 		if ("error" in parsed) throw new Error(parsed.error);
 		const key = await importRoomKey(rawKey);
+		// stop() can land while the key import is in flight: #stopped is already
+		// true and #teardown has run, so nothing created past this point would
+		// ever be torn down. Bail before the socket exists.
+		if (this.#stopped) throw new Error(COLLAB_STOPPED_ERROR);
 
 		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "host", key });
 		this.#socket = socket;
 		this.#sessionId = this.#ctx.sessionManager.getSessionId();
 
 		const firstOpen = Promise.withResolvers<void>();
+		this.#firstOpen = firstOpen;
 		let opened = false;
 		socket.onOpen = () => {
 			if (!opened) {
 				opened = true;
+				this.#firstOpen = undefined;
 				firstOpen.resolve();
 			}
 		};
@@ -234,6 +260,7 @@ export class CollabHost {
 		socket.onClose = (reason, willReconnect) => {
 			if (this.#stopped) return;
 			if (!opened) {
+				this.#firstOpen = undefined;
 				firstOpen.reject(new Error(reason));
 				return;
 			}
@@ -261,6 +288,15 @@ export class CollabHost {
 			clearTimeout(timeout);
 		}
 
+		// A stop that landed after onOpen cleared #firstOpen already ran
+		// #teardown against a socket it could not see. Close it and leave the
+		// taps below uninstalled.
+		if (this.#stopped) {
+			socket.close();
+			this.#socket = null;
+			throw new Error(COLLAB_STOPPED_ERROR);
+		}
+
 		this.#unsubscribe = this.#ctx.session.subscribe(event => {
 			if (isWireAgentEvent(event)) this.#broadcast({ t: "event", event: shrinkForReplication(event) });
 			this.#onEventForState(event);
@@ -278,12 +314,28 @@ export class CollabHost {
 			}
 		}
 		this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());
-		this.#ctx.sessionManager.onEntryAppended = entry => {
+		// `onEntryAppended` is a single slot on the session manager, so a stale
+		// host tearing down must not clear the live host's tap. Keep the exact
+		// function this host installed and only release that one.
+		const entryTap = (entry: StoredSessionEntry): void => {
 			if (isWireSessionEntry(entry)) this.#broadcast({ t: "entry", entry: shrinkForReplication(entry) });
 			// Model/thinking/title changes land as entries while idle; refresh
 			// guest state promptly (debounce + JSON diff dedupe).
 			this.#scheduleStateBroadcast();
 		};
+		this.#entryTap = entryTap;
+		this.#ctx.sessionManager.onEntryAppended = entryTap;
+	}
+
+	/**
+	 * Install the host's status segment on the status line.
+	 *
+	 * Deferred until the host is assigned to `ctx.collabHost` so an abandoned
+	 * or cancelled in-flight start never overwrites status line state.
+	 */
+	publishStatus(): void {
+		if (this.#stopped) return;
+		this.#published = true;
 		this.#updateStatusSegment();
 	}
 
@@ -297,7 +349,16 @@ export class CollabHost {
 	async #teardown(): Promise<void> {
 		if (this.#stopped) return;
 		this.#stopped = true;
-		this.#ctx.sessionManager.onEntryAppended = undefined;
+		if (this.#firstOpen) {
+			this.#firstOpen.reject(new Error("Collab stopped"));
+			this.#firstOpen = undefined;
+		}
+		// A stale host stopping must leave the live host replicating: the slot is
+		// shared, so release it only when it still holds this host's own tap.
+		if (this.#entryTap && this.#ctx.sessionManager.onEntryAppended === this.#entryTap) {
+			this.#ctx.sessionManager.onEntryAppended = undefined;
+		}
+		this.#entryTap = undefined;
 		this.#unsubscribe?.();
 		this.#unsubscribe = undefined;
 		for (const unsubscribe of this.#busUnsubscribers) unsubscribe();
@@ -315,9 +376,11 @@ export class CollabHost {
 		this.#peers.clear();
 		this.#socket?.close();
 		this.#socket = null;
-		this.#ctx.collabHost = undefined;
-		this.#ctx.statusLine.setCollabStatus(null);
-		this.#ctx.ui.requestRender();
+		if (this.#ctx.collabHost === this) {
+			this.#ctx.collabHost = undefined;
+			this.#ctx.statusLine.setCollabStatus(null);
+			this.#ctx.ui.requestRender();
+		}
 	}
 
 	#broadcast(frame: CollabFrame): void {
@@ -331,6 +394,16 @@ export class CollabHost {
 	}
 
 	#handleFrame(frame: CollabFrame, fromPeer: number): void {
+		// A room bound to a session that is no longer live must service nothing.
+		// #broadcast covers the outbound half; this is the inbound one, and it
+		// is the half that can disclose: #handleHello snapshots the CURRENT
+		// transcript and #handleFetchTranscript reads it, so a room whose
+		// session was switched or rolled back under it would serve a session it
+		// was never shared for.
+		if (this.#sessionId && this.#ctx.sessionManager.getSessionId() !== this.#sessionId) {
+			void this.stop("session switched");
+			return;
+		}
 		switch (frame.t) {
 			case "hello":
 				this.#handleHello(frame.name, frame.proto, frame.writeToken, fromPeer);
@@ -693,6 +766,7 @@ export class CollabHost {
 	}
 
 	#updateStatusSegment(): void {
+		if (!this.#published || this.#ctx.collabHost !== this) return;
 		this.#ctx.statusLine.setCollabStatus({ role: "host", participantCount: this.#peers.size + 1 });
 		this.#ctx.statusLine.invalidate();
 		this.#ctx.ui.requestRender();

--- a/packages/coding-agent/src/collab/protocol.ts
+++ b/packages/coding-agent/src/collab/protocol.ts
@@ -149,7 +149,7 @@ export function generateRoomId(): string {
 }
 
 /** Normalize a relay base URL (ws/wss/http/https) into a ws/wss origin, or an error. */
-function normalizeRelayOrigin(relayUrl: string): { origin: string } | { error: string } {
+export function normalizeRelayOrigin(relayUrl: string): { origin: string } | { error: string } {
 	let url: URL;
 	try {
 		url = new URL(relayUrl);

--- a/packages/coding-agent/src/collab/start-hosting.ts
+++ b/packages/coding-agent/src/collab/start-hosting.ts
@@ -1,0 +1,63 @@
+/**
+ * Programmatic collab hosting: start, read, and stop the room a session
+ * shares, without routing through the /collab slash command.
+ *
+ * The slash command and the extension API both funnel through
+ * {@link startCollabHosting} so relay resolution, the guest-session refusal,
+ * and the one-room-per-session rule live in exactly one place. What the
+ * command adds on top is presentation (printing the link and its QR code);
+ * programmatic callers get the links returned and own keeping them out of
+ * logs and transcripts, because a link is a credential: the full link steers
+ * the session, the view link reads it.
+ */
+import type { CollabHostLinks, StartCollabOptions } from "../extensibility/extensions/types";
+import type { InteractiveModeContext } from "../modes/types";
+import { CollabHost } from "./host";
+import { normalizeRelayOrigin } from "./protocol";
+
+/** The links of a hosted room, in both strengths and both renderings. */
+export function collabHostLinks(host: CollabHost): CollabHostLinks {
+	return {
+		link: host.link,
+		viewLink: host.viewLink,
+		webLink: host.webLink,
+		webViewLink: host.webViewLink,
+	};
+}
+
+/**
+ * Start hosting this session's collab room, or return the room already
+ * hosted on the requested relay.
+ *
+ * Throws when the session joined someone else's room as a guest, when no
+ * relay is configured and none is passed, or when a room is already hosted
+ * on a different relay: a session has one transcript tap and one status
+ * segment, so hosting two rooms at once is not a state CollabHost can
+ * represent, and silently moving relays would strand the room's current
+ * guests. The caller that truly wants a new relay stops first.
+ */
+export async function startCollabHosting(
+	ctx: InteractiveModeContext,
+	options: StartCollabOptions = {},
+): Promise<CollabHost> {
+	if (ctx.collabGuest) {
+		throw new Error("Already in a collab session as a guest (/leave first)");
+	}
+	const relayInput = options.relayUrl?.trim() || ctx.settings.get("collab.relayUrl") || "";
+	if (!relayInput) {
+		throw new Error("No relay configured. Set collab.relayUrl in /settings or pass a relayUrl option");
+	}
+	// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
+	const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
+	const normalized = normalizeRelayOrigin(relayUrl);
+	if ("error" in normalized) throw new Error(normalized.error);
+	const existing = ctx.collabHost;
+	if (existing) {
+		if (existing.relayOrigin === normalized.origin) return existing;
+		throw new Error(`Already hosting a collab session on relay ${existing.relayOrigin} (stop it first)`);
+	}
+	const host = new CollabHost(ctx);
+	await host.start(relayUrl, ctx.settings.get("collab.webUrl") || "");
+	ctx.collabHost = host;
+	return host;
+}

--- a/packages/coding-agent/src/collab/start-hosting.ts
+++ b/packages/coding-agent/src/collab/start-hosting.ts
@@ -1,0 +1,292 @@
+/**
+ * Programmatic collab hosting: start, read, and stop the room a session
+ * shares, without routing through the /collab slash command.
+ *
+ * The slash command and the extension API both funnel through
+ * {@link startCollabHosting} so relay resolution, the guest-session refusal,
+ * and the one-room-per-session rule live in exactly one place. What the
+ * command adds on top is presentation (printing the link and its QR code);
+ * programmatic callers get the links returned and own keeping them out of
+ * logs and transcripts, because a link is a credential: the full link steers
+ * the session, the view link reads it.
+ */
+import type { CollabHostLinks, StartCollabOptions } from "../extensibility/extensions/types";
+import type { InteractiveModeContext } from "../modes/types";
+import { hasInFlightCollabGuestTransition } from "./guest";
+import { COLLAB_STOPPED_ERROR, CollabHost } from "./host";
+import { normalizeRelayOrigin } from "./protocol";
+
+interface InFlightStart {
+	readonly host: CollabHost;
+	readonly relayOrigin: string;
+	readonly sessionId: string;
+	cancelled: boolean;
+	promise: Promise<CollabHost>;
+}
+
+/**
+ * A start whose room finished binding to a session that is no longer live.
+ * Module-private: every caller awaiting that start catches it and loops, so
+ * it never escapes to an extension.
+ */
+class CollabStartSuperseded extends Error {}
+
+const inFlightStarts = new WeakMap<InteractiveModeContext, InFlightStart>();
+
+export function hasInFlightCollabHosting(ctx: InteractiveModeContext): boolean {
+	return inFlightStarts.has(ctx);
+}
+
+/** The links of a hosted room, in both strengths and both renderings. */
+export function collabHostLinks(host: CollabHost): CollabHostLinks {
+	return {
+		link: host.link,
+		viewLink: host.viewLink,
+		webLink: host.webLink,
+		webViewLink: host.webViewLink,
+	};
+}
+
+/**
+ * Links of the room hosted for the session that is live *now*, or undefined.
+ *
+ * A session switch replaces the session id before the outgoing room stops, so
+ * `ctx.collabHost` briefly points at a room bound to the previous transcript.
+ * Handing those links out would publish a credential for the wrong session
+ * that dies on the host's next broadcast. Reading links never mutates hosting
+ * state. A caller that wants a room for the new session calls
+ * {@link startCollabHosting}, which restarts it.
+ */
+export function activeCollabHostLinks(ctx: InteractiveModeContext): CollabHostLinks | undefined {
+	const host = ctx.collabHost;
+	if (!host) return undefined;
+	if (host.sessionId && host.sessionId !== ctx.sessionManager.getSessionId()) return undefined;
+	return collabHostLinks(host);
+}
+
+const rolledBackHostReapers = new WeakSet<InteractiveModeContext>();
+
+/**
+ * Stop a room whose session did not survive the transition that created it.
+ *
+ * A `session_switch` handler runs after the id commits but while the switch can
+ * still throw, and the restore happens *without* a change notification,
+ * deliberately: the success-path notification never fired either. Settlement is
+ * therefore the only signal that the outcome is final. Without this the
+ * orphaned room lingers until its next broadcast notices, holding a credential
+ * the extension was already handed.
+ *
+ * Two distinct ways a room can be orphaned, and the id check only sees one:
+ * a switch to a different session that rolls back, and a same-file reload whose
+ * rollback replaces the transcript under an unchanged id. A guest that joined
+ * before the failure holds the discarded snapshot and would otherwise keep
+ * receiving incremental frames from the restored history.
+ *
+ * Registered once per context: the callback re-reads `ctx.collabHost`, so it
+ * covers every host that context ever publishes.
+ */
+function ensureRolledBackHostReaper(ctx: InteractiveModeContext): void {
+	if (rolledBackHostReapers.has(ctx)) return;
+	rolledBackHostReapers.add(ctx);
+	ctx.session.registerSessionTransitionSettledCallback(outcome => {
+		const host = ctx.collabHost;
+		if (!host?.sessionId) return;
+		if (!outcome.rolledBack && host.sessionId === ctx.sessionManager.getSessionId()) return;
+		void host.stop("session switch rolled back");
+	});
+}
+
+/**
+ * Cancel a reservation and stop its half-started host. Ownership is released
+ * with a compare-and-delete: a caller that lost the slot to someone else must
+ * not evict that owner's reservation.
+ */
+async function cancelInFlightStart(ctx: InteractiveModeContext, pending: InFlightStart, reason: string): Promise<void> {
+	pending.cancelled = true;
+	if (inFlightStarts.get(ctx) === pending) inFlightStarts.delete(ctx);
+	await pending.host.stop(reason);
+	try {
+		await pending.promise;
+	} catch {
+		// A cancelled start rejects by design.
+	}
+}
+
+/**
+ * Start hosting this session's collab room, or return the room already
+ * hosted on the requested relay.
+ *
+ * Throws when the session joined someone else's room as a guest, when no
+ * relay is configured and none is passed, or when a room is already hosted
+ * on a different relay: a session has one transcript tap and one status
+ * segment, so hosting two rooms at once is not a state CollabHost can
+ * represent, and silently moving relays would strand the room's current
+ * guests. The caller that truly wants a new relay stops first.
+ */
+export async function startCollabHosting(
+	ctx: InteractiveModeContext,
+	options: StartCollabOptions = {},
+): Promise<CollabHost> {
+	if (ctx.collabGuest) {
+		throw new Error("Already in a collab session as a guest (/leave first)");
+	}
+	if (hasInFlightCollabGuestTransition(ctx)) {
+		throw new Error("A collab guest session is still settling (retry once it has finished)");
+	}
+	if (ctx.session.isSessionTransitionInFlight) {
+		throw new Error("A session switch is still settling (retry once the new session has started)");
+	}
+	const relayInput = options.relayUrl?.trim() || ctx.settings.get("collab.relayUrl") || "";
+	if (!relayInput) {
+		throw new Error("No relay configured. Set collab.relayUrl in /settings or pass a relayUrl option");
+	}
+	// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
+	const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
+	const normalized = normalizeRelayOrigin(relayUrl);
+	if ("error" in normalized) throw new Error(normalized.error);
+	// Both cleanup branches below release ownership before they await, so state
+	// is re-read from the top afterwards: a concurrent caller may have claimed
+	// the slot meanwhile, and this caller must join that room instead of
+	// starting a second one. Each branch removes exactly the object it
+	// observed, so every iteration either returns, throws, or makes progress.
+	for (;;) {
+		const currentSessionId = ctx.sessionManager.getSessionId();
+		const pending = inFlightStarts.get(ctx);
+		const stalePending = pending && pending.sessionId && pending.sessionId !== currentSessionId ? pending : undefined;
+		if (pending && !stalePending) {
+			if (pending.relayOrigin === normalized.origin) {
+				try {
+					return await pending.promise;
+				} catch (err) {
+					if (err instanceof CollabStartSuperseded) continue;
+					throw err;
+				}
+			}
+			throw new Error(`Already hosting a collab session on relay ${pending.relayOrigin} (stop it first)`);
+		}
+
+		const existing = ctx.collabHost;
+		const staleExisting =
+			existing && existing.sessionId && existing.sessionId !== currentSessionId ? existing : undefined;
+		if (existing && !staleExisting) {
+			if (existing.relayOrigin === normalized.origin) return existing;
+			throw new Error(`Already hosting a collab session on relay ${existing.relayOrigin} (stop it first)`);
+		}
+
+		// No await between here and the set() below: the slot is claimed in the
+		// same synchronous turn as the checks above, and the set() replaces a
+		// superseded reservation rather than clearing it first. Both stale
+		// cleanups run inside startPromise while this reservation is held, so
+		// stopCollabHosting always finds something to cancel and
+		// hasInFlightCollabHosting reports true across the entire transition.
+		// Progress guarantee: every iteration either returns, throws, awaits a
+		// pending start with matching parameters, or claims a fresh reservation
+		// for the current session and stops iterating.
+		const host = new CollabHost(ctx);
+		const inFlight: InFlightStart = {
+			host,
+			relayOrigin: normalized.origin,
+			sessionId: currentSessionId,
+			cancelled: false,
+			promise: Promise.resolve(host),
+		};
+
+		// Claimed before startPromise runs, so the compare-and-delete inside
+		// cancelInFlightStart sees this reservation rather than the superseded
+		// one and leaves it in place.
+		inFlightStarts.set(ctx, inFlight);
+
+		const startPromise = (async () => {
+			try {
+				if (stalePending) {
+					await cancelInFlightStart(ctx, stalePending, "session switched");
+					if (inFlight.cancelled) throw new Error(COLLAB_STOPPED_ERROR);
+				}
+				if (staleExisting) {
+					await staleExisting.stop("session switched");
+					if (ctx.collabHost === staleExisting) ctx.collabHost = undefined;
+					if (inFlight.cancelled) throw new Error(COLLAB_STOPPED_ERROR);
+				}
+				await host.start(relayUrl, ctx.settings.get("collab.webUrl") || "");
+				// The handshake is the last await before the room goes live, and
+				// four things can change across it. Publishing anyway would hand
+				// out a link to a room that is already doomed.
+				if (inFlight.cancelled) {
+					await host.stop("host stopped");
+					throw new Error(COLLAB_STOPPED_ERROR);
+				}
+				if (ctx.collabGuest) {
+					// A /join that was connecting in parallel finished first.
+					await host.stop("joined as guest");
+					throw new Error("Already in a collab session as a guest (/leave first)");
+				}
+				if (hasInFlightCollabGuestTransition(ctx)) {
+					// A guest handshake or rollback is mid-flight, so the live
+					// session is that guest's replica: either about to be
+					// published to, or about to be rolled back. A room
+					// published here would bind to a session that is about to
+					// vanish, and its next hello would snapshot whatever
+					// session the transition settled on.
+					await host.stop("collab guest transition in flight");
+					throw new Error("A collab guest session is still settling (retry once it has finished)");
+				}
+				if (ctx.session.isSessionTransitionInFlight) {
+					// A transition that began during the handshake has not
+					// committed its id yet, so the mismatch check below cannot
+					// see it: `getSessionId()` still reads the outgoing id.
+					// Publishing here would bind the room to a session already
+					// on its way out. Refuse rather than retry: the loop would
+					// re-handshake against the same unsettled transition.
+					await host.stop("session switch in flight");
+					if (inFlight.cancelled) throw new Error(COLLAB_STOPPED_ERROR);
+					throw new Error("A session switch is still settling (retry once the new session has started)");
+				}
+				// `host.sessionId` is the id the room actually bound to inside
+				// start(), and the one #broadcast enforces; a mismatch means the
+				// first broadcast would tear this room down. Retrying terminates
+				// because the next attempt binds whatever id is current then, and
+				// getSessionId() is a stable field read between switches.
+				if (host.sessionId && host.sessionId !== ctx.sessionManager.getSessionId()) {
+					await host.stop("session switched");
+					// A stop that landed while that teardown was awaited outranks
+					// the retry. Retrying would claim a fresh reservation after
+					// stopCollabHosting had already looked and found nothing, so
+					// the new room would go live behind the stop's back.
+					if (inFlight.cancelled) throw new Error(COLLAB_STOPPED_ERROR);
+					throw new CollabStartSuperseded();
+				}
+				ctx.collabHost = host;
+				ensureRolledBackHostReaper(ctx);
+				host.publishStatus();
+				return host;
+			} catch (err) {
+				if (inFlight.cancelled) await host.stop("host stopped");
+				throw err;
+			} finally {
+				if (inFlightStarts.get(ctx) === inFlight) inFlightStarts.delete(ctx);
+			}
+		})();
+
+		inFlight.promise = startPromise;
+		try {
+			return await startPromise;
+		} catch (err) {
+			if (err instanceof CollabStartSuperseded) continue;
+			throw err;
+		}
+	}
+}
+
+/**
+ * Stop hosting this session's collab room, or cancel an in-flight start.
+ *
+ * If a room is currently active, it is stopped and disconnected. If a start
+ * is in-flight awaiting relay handshake, it is cancelled so it cannot publish
+ * an active room after this call completes.
+ */
+export async function stopCollabHosting(ctx: InteractiveModeContext, reason = "host stopped"): Promise<void> {
+	const inFlight = inFlightStarts.get(ctx);
+	if (inFlight) await cancelInFlightStart(ctx, inFlight, reason);
+	const host = ctx.collabHost;
+	if (host) await host.stop(reason);
+}

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -37,6 +37,7 @@ import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath, withHostGuard } from "../utils";
 import type {
 	AssistantThinkingRenderer,
+	CollabHostLinks,
 	ComposerShapeDefinition,
 	Extension,
 	ExtensionAPI,
@@ -47,6 +48,7 @@ import type {
 	MessageRenderer,
 	ProviderConfig,
 	RegisteredCommand,
+	StartCollabOptions,
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
@@ -141,6 +143,18 @@ export class ExtensionRuntime implements IExtensionRuntime {
 	}
 
 	setSessionName(): Promise<void> {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	startCollab(): Promise<CollabHostLinks> {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	getCollabLinks(): CollabHostLinks | undefined {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	stopCollab(): Promise<void> {
 		throw new ExtensionRuntimeNotInitializedError();
 	}
 }
@@ -322,6 +336,18 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	setSessionName(name: string): Promise<void> {
 		return this.runtime.setSessionName(name);
+	}
+
+	startCollab(options?: StartCollabOptions): Promise<CollabHostLinks> {
+		return this.runtime.startCollab(options);
+	}
+
+	getCollabLinks(): CollabHostLinks | undefined {
+		return this.runtime.getCollabLinks();
+	}
+
+	stopCollab(): Promise<void> {
+		return this.runtime.stopCollab();
 	}
 
 	registerProvider(name: string, config: ProviderConfig): void {

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -37,6 +37,7 @@ import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath, withHostGuard } from "../utils";
 import type {
 	AssistantThinkingRenderer,
+	CollabHostLinks,
 	ComposerShapeDefinition,
 	Extension,
 	ExtensionAPI,
@@ -48,6 +49,7 @@ import type {
 	PreparedExtension,
 	ProviderConfig,
 	RegisteredCommand,
+	StartCollabOptions,
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
@@ -142,6 +144,18 @@ export class ExtensionRuntime implements IExtensionRuntime {
 	}
 
 	setSessionName(): Promise<void> {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	startCollab(): Promise<CollabHostLinks> {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	getCollabLinks(): CollabHostLinks | undefined {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	stopCollab(): Promise<void> {
 		throw new ExtensionRuntimeNotInitializedError();
 	}
 }
@@ -323,6 +337,18 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	setSessionName(name: string): Promise<void> {
 		return this.runtime.setSessionName(name);
+	}
+
+	startCollab(options?: StartCollabOptions): Promise<CollabHostLinks> {
+		return this.runtime.startCollab(options);
+	}
+
+	getCollabLinks(): CollabHostLinks | undefined {
+		return this.runtime.getCollabLinks();
+	}
+
+	stopCollab(): Promise<void> {
+		return this.runtime.stopCollab();
 	}
 
 	registerProvider(name: string, config: ProviderConfig): void {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -90,6 +90,15 @@ function throwUnsupportedServiceTierAction(): never {
 	throw new Error("This extension host does not support service-tier actions");
 }
 
+function throwUnsupportedCollabAction(): never {
+	throw new Error("This extension host does not support collab hosting (interactive TUI only)");
+}
+
+/** Non-TUI hosts never host a room, so undefined is the honest answer. */
+function noCollabLinks(): undefined {
+	return undefined;
+}
+
 export function testSetExtensionHandlerTimeoutMs(timeoutMs: number): void {
 	extensionHandlerTimeoutMs = timeoutMs;
 }
@@ -669,6 +678,9 @@ export class ExtensionRunner {
 		this.runtime.setServiceTier = actions.setServiceTier ?? throwUnsupportedServiceTierAction;
 		this.runtime.getSessionName = actions.getSessionName;
 		this.runtime.setSessionName = actions.setSessionName;
+		this.runtime.startCollab = actions.startCollab ?? throwUnsupportedCollabAction;
+		this.runtime.getCollabLinks = actions.getCollabLinks ?? noCollabLinks;
+		this.runtime.stopCollab = actions.stopCollab ?? throwUnsupportedCollabAction;
 		this.runtime.registerProvider = (name, config, sourceId) => {
 			this.modelRegistry.registerProvider(name, config, sourceId);
 		};

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1466,6 +1466,30 @@ export interface ExtensionAPI {
 	setSessionName(name: string): Promise<void>;
 
 	// =========================================================================
+	// Collab Hosting
+	// =========================================================================
+
+	/**
+	 * Start hosting this session's collab room, or return the links of the
+	 * room already hosted on the same relay. Throws when the session is in
+	 * someone else's room as a guest, when a room is already hosted on a
+	 * different relay (stop it first), when no relay is configured, or when
+	 * the relay cannot be reached. Available only in the interactive TUI;
+	 * other extension hosts throw.
+	 *
+	 * The returned links are credentials. Nothing prints them: unlike the
+	 * /collab slash command, this path writes no status line and no QR code,
+	 * so the caller alone decides where the links go.
+	 */
+	startCollab(options?: StartCollabOptions): Promise<CollabHostLinks>;
+
+	/** Links of the room this session currently hosts, or undefined when not hosting. */
+	getCollabLinks(): CollabHostLinks | undefined;
+
+	/** Stop hosting, disconnecting every guest. No-op when not hosting. */
+	stopCollab(): Promise<void>;
+
+	// =========================================================================
 	// Provider Registration
 	// =========================================================================
 
@@ -1655,6 +1679,39 @@ export type GetServiceTiersHandler = () => ServiceTierByFamily;
 
 export type SetServiceTierHandler = (family: ServiceTierFamily, tier: ServiceTier | undefined) => void;
 
+/**
+ * The links of a hosted collab room, in both strengths and both renderings.
+ * Every form is a credential: `link` grants prompting and interrupting,
+ * `viewLink` grants live read access. The API never prints them; the caller
+ * owns keeping them out of logs and transcripts.
+ */
+export interface CollabHostLinks {
+	/** Full-control terminal link: read the session, prompt and interrupt the agent. */
+	link: string;
+	/** View-only terminal link: live read access, no writes. */
+	viewLink: string;
+	/** Browser deep link for the full link (usable only when the relay serves a web client). */
+	webLink: string;
+	/** Browser deep link for the view-only link. */
+	webViewLink: string;
+}
+
+/** Options for {@link ExtensionAPI.startCollab}. */
+export interface StartCollabOptions {
+	/**
+	 * Relay to host through, as a URL or a scheme-less host. Falls back to the
+	 * collab.relayUrl setting. Plain ws:// is accepted for localhost relays,
+	 * which is what a same-machine daemon hands down.
+	 */
+	relayUrl?: string;
+}
+
+export type StartCollabHandler = (options?: StartCollabOptions) => Promise<CollabHostLinks>;
+
+export type GetCollabLinksHandler = () => CollabHostLinks | undefined;
+
+export type StopCollabHandler = () => Promise<void>;
+
 /** Shared state created by loader, used during registration and runtime. */
 export interface ExtensionRuntimeState {
 	flagValues: Map<string, boolean | string>;
@@ -1683,6 +1740,14 @@ export interface ExtensionActions {
 	setServiceTier?: SetServiceTierHandler;
 	getSessionName: () => string | undefined;
 	setSessionName: (name: string) => Promise<void>;
+	/**
+	 * Collab hosting exists only where a CollabHost can run: the interactive
+	 * TUI. Optional so print, RPC, ACP, and subagent hosts keep compiling
+	 * without one; the runner substitutes a throwing fallback.
+	 */
+	startCollab?: StartCollabHandler;
+	getCollabLinks?: GetCollabLinksHandler;
+	stopCollab?: StopCollabHandler;
 }
 
 /** Actions for ExtensionContext (ctx.* in event handlers). */
@@ -1712,10 +1777,13 @@ export interface ExtensionCommandContextActions {
 	reload: () => Promise<void>;
 }
 
-/** Full runtime = state + actions, including host-compatible service-tier fallbacks. */
+/** Full runtime = state + actions, including host-compatible fallbacks. */
 export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {
 	getServiceTiers: GetServiceTiersHandler;
 	setServiceTier: SetServiceTierHandler;
+	startCollab: StartCollabHandler;
+	getCollabLinks: GetCollabLinksHandler;
+	stopCollab: StopCollabHandler;
 }
 
 /** Loaded extension with all registered items. */

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1494,6 +1494,35 @@ export interface ExtensionAPI {
 	setSessionName(name: string): Promise<void>;
 
 	// =========================================================================
+	// Collab Hosting
+	// =========================================================================
+
+	/**
+	 * Start hosting this session's collab room, or return the links of the
+	 * room already hosted on the same relay. Throws when the session is in
+	 * someone else's room as a guest, when a room is already hosted on a
+	 * different relay (stop it first), when no relay is configured, or when
+	 * the relay cannot be reached. Available only in the interactive TUI;
+	 * other extension hosts throw.
+	 *
+	 * The returned links are credentials. Nothing prints them: unlike the
+	 * /collab slash command, this path writes no status line and no QR code,
+	 * so the caller alone decides where the links go.
+	 */
+	startCollab(options?: StartCollabOptions): Promise<CollabHostLinks>;
+
+	/**
+	 * Links of the room this session currently hosts, or undefined when not
+	 * hosting. Also undefined immediately after a session switch, while the
+	 * previous session's room is still winding down: those links belong to the
+	 * outgoing transcript and stop working on the host's next broadcast.
+	 */
+	getCollabLinks(): CollabHostLinks | undefined;
+
+	/** Stop hosting, disconnecting every guest. No-op when not hosting. */
+	stopCollab(): Promise<void>;
+
+	// =========================================================================
 	// Provider Registration
 	// =========================================================================
 
@@ -1690,6 +1719,39 @@ export type GetServiceTiersHandler = () => ServiceTierByFamily;
 
 export type SetServiceTierHandler = (family: ServiceTierFamily, tier: ServiceTier | undefined) => void;
 
+/**
+ * The links of a hosted collab room, in both strengths and both renderings.
+ * Every form is a credential: `link` grants prompting and interrupting,
+ * `viewLink` grants live read access. The API never prints them; the caller
+ * owns keeping them out of logs and transcripts.
+ */
+export interface CollabHostLinks {
+	/** Full-control terminal link: read the session, prompt and interrupt the agent. */
+	link: string;
+	/** View-only terminal link: live read access, no writes. */
+	viewLink: string;
+	/** Browser deep link for the full link (usable only when the relay serves a web client). */
+	webLink: string;
+	/** Browser deep link for the view-only link. */
+	webViewLink: string;
+}
+
+/** Options for {@link ExtensionAPI.startCollab}. */
+export interface StartCollabOptions {
+	/**
+	 * Relay to host through, as a URL or a scheme-less host. Falls back to the
+	 * collab.relayUrl setting. Plain ws:// is accepted for localhost relays,
+	 * which is what a same-machine daemon hands down.
+	 */
+	relayUrl?: string;
+}
+
+export type StartCollabHandler = (options?: StartCollabOptions) => Promise<CollabHostLinks>;
+
+export type GetCollabLinksHandler = () => CollabHostLinks | undefined;
+
+export type StopCollabHandler = () => Promise<void>;
+
 /** Shared state created by loader, used during registration and runtime. */
 export interface ExtensionRuntimeState {
 	flagValues: Map<string, boolean | string>;
@@ -1718,6 +1780,14 @@ export interface ExtensionActions {
 	setServiceTier?: SetServiceTierHandler;
 	getSessionName: () => string | undefined;
 	setSessionName: (name: string) => Promise<void>;
+	/**
+	 * Collab hosting exists only where a CollabHost can run: the interactive
+	 * TUI. Optional so print, RPC, ACP, and subagent hosts keep compiling
+	 * without one; the runner substitutes a throwing fallback.
+	 */
+	startCollab?: StartCollabHandler;
+	getCollabLinks?: GetCollabLinksHandler;
+	stopCollab?: StopCollabHandler;
 }
 
 /** Actions for ExtensionContext (ctx.* in event handlers). */
@@ -1747,10 +1817,13 @@ export interface ExtensionCommandContextActions {
 	reload: () => Promise<void>;
 }
 
-/** Full runtime = state + actions, including host-compatible service-tier fallbacks. */
+/** Full runtime = state + actions, including host-compatible fallbacks. */
 export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {
 	getServiceTiers: GetServiceTiersHandler;
 	setServiceTier: SetServiceTierHandler;
+	startCollab: StartCollabHandler;
+	getCollabLinks: GetCollabLinksHandler;
+	stopCollab: StopCollabHandler;
 }
 
 /** Loaded extension with all registered items. */

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,6 +1,7 @@
 import type { Component, OverlayHandle, TUI } from "@oh-my-pi/pi-tui";
 import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
 import type { CollabUiRequestDraft, CollabUiSelectItem } from "@oh-my-pi/pi-wire";
+import { collabHostLinks, startCollabHosting } from "../../collab/start-hosting";
 import { KeybindingsManager } from "../../config/keybindings";
 import type {
 	CompactOptions,
@@ -198,6 +199,12 @@ export class ExtensionUiController {
 			getCommands: () => getSessionSlashCommands(this.ctx.session),
 			getSessionName: () => this.ctx.sessionManager.getSessionName(),
 			setSessionName: name => this.#updateSessionName(name),
+			startCollab: async options => collabHostLinks(await startCollabHosting(this.ctx, options)),
+			getCollabLinks: () => (this.ctx.collabHost ? collabHostLinks(this.ctx.collabHost) : undefined),
+			stopCollab: async () => {
+				// stop() runs the teardown that clears ctx.collabHost itself.
+				await this.ctx.collabHost?.stop("host stopped");
+			},
 		};
 		const contextActions: ExtensionContextActions = {
 			getModel: () => this.ctx.session.model,
@@ -431,6 +438,12 @@ export class ExtensionUiController {
 			getCommands: () => getSessionSlashCommands(this.ctx.session),
 			getSessionName: () => this.ctx.sessionManager.getSessionName(),
 			setSessionName: name => this.#updateSessionName(name),
+			startCollab: async options => collabHostLinks(await startCollabHosting(this.ctx, options)),
+			getCollabLinks: () => (this.ctx.collabHost ? collabHostLinks(this.ctx.collabHost) : undefined),
+			stopCollab: async () => {
+				// stop() runs the teardown that clears ctx.collabHost itself.
+				await this.ctx.collabHost?.stop("host stopped");
+			},
 		};
 		const contextActions: ExtensionContextActions = {
 			getModel: () => this.ctx.session.model,

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,6 +1,12 @@
 import type { Component, OverlayHandle, TUI } from "@oh-my-pi/pi-tui";
 import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
 import type { CollabUiRequestDraft, CollabUiSelectItem } from "@oh-my-pi/pi-wire";
+import {
+	activeCollabHostLinks,
+	collabHostLinks,
+	startCollabHosting,
+	stopCollabHosting,
+} from "../../collab/start-hosting";
 import { KeybindingsManager } from "../../config/keybindings";
 import type {
 	CompactOptions,
@@ -200,6 +206,11 @@ export class ExtensionUiController {
 			getCommands: () => getSessionSlashCommands(this.ctx.session),
 			getSessionName: () => this.ctx.sessionManager.getSessionName(),
 			setSessionName: name => this.#updateSessionName(name),
+			startCollab: async options => collabHostLinks(await startCollabHosting(this.ctx, options)),
+			getCollabLinks: () => activeCollabHostLinks(this.ctx),
+			stopCollab: async () => {
+				await stopCollabHosting(this.ctx);
+			},
 		};
 		const contextActions: ExtensionContextActions = {
 			getModel: () => this.ctx.session.model,
@@ -436,6 +447,11 @@ export class ExtensionUiController {
 			getCommands: () => getSessionSlashCommands(this.ctx.session),
 			getSessionName: () => this.ctx.sessionManager.getSessionName(),
 			setSessionName: name => this.#updateSessionName(name),
+			startCollab: async options => collabHostLinks(await startCollabHosting(this.ctx, options)),
+			getCollabLinks: () => activeCollabHostLinks(this.ctx),
+			stopCollab: async () => {
+				await stopCollabHosting(this.ctx);
+			},
 		};
 		const contextActions: ExtensionContextActions = {
 			getModel: () => this.ctx.session.model,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -533,6 +533,16 @@ export function powerAssertionOptions(mode: "off" | "idle" | "display" | "system
 	};
 }
 
+/** How a session transition ended, as seen by a settled observer. */
+export interface SessionTransitionOutcome {
+	/**
+	 * The transition restored the previous state instead of keeping the new one.
+	 * A same-file reload does this under an unchanged session id, so an observer
+	 * cannot infer it by comparing ids.
+	 */
+	rolledBack: boolean;
+}
+
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -799,6 +809,8 @@ export class AgentSession {
 	 *  discarded moments before a rolled-back switchSession() restores the exact generation it
 	 *  was captured against. */
 	#sessionTransitionSettled: Promise<void> | undefined;
+	#sessionTransitionDepth = 0;
+	#sessionTransitionSettledCallbacks = new Set<(outcome: SessionTransitionOutcome) => void>();
 	#promptSequence = 0;
 	#skippedPostTurnSpeculationCompletion: Promise<void> | undefined;
 	#pendingAgentEndEmit: AgentSessionEvent | undefined;
@@ -4778,6 +4790,7 @@ export class AgentSession {
 		this.#eventListeners = [];
 		this.#runStateListeners.clear();
 		this.#sessionChangeCallbacks.clear();
+		this.#sessionTransitionSettledCallbacks.clear();
 
 		// A dispose triggered mid-turn (Ctrl-C / timeout / hard-killed subagent)
 		// only *signals* the agent loop via the earlier abort(); the loop and the
@@ -7855,6 +7868,7 @@ export class AgentSession {
 	 * @returns true if completed, false if cancelled by hook
 	 */
 	async newSession(options?: NewSessionOptions): Promise<boolean> {
+		using guard = this.#beginSessionTransitionGuard();
 		this.#assertVibeSessionTransitionAllowed("start a new session");
 		const previousSessionFile = this.sessionFile;
 
@@ -7912,6 +7926,7 @@ export class AgentSession {
 			this.#freshProviderSessionId = undefined;
 			this.#clearInheritedProviderPromptCacheKey();
 			this.#syncAgentSessionId();
+			guard.commit();
 			// Drop the frozen system-prompt/tool snapshot and synced message bytes
 			// (mirrors freshSession()/resetSessionContext()): without this the first
 			// post-/new turns keep sending the previous session's StablePrefix, and
@@ -7984,6 +7999,7 @@ export class AgentSession {
 	 * @returns true if completed, false if cancelled by hook or not persisting
 	 */
 	async fork(): Promise<boolean> {
+		using guard = this.#beginSessionTransitionGuard();
 		this.#assertVibeSessionTransitionAllowed("fork the session");
 		const previousSessionFile = this.sessionFile;
 		const previousSessionId = this.sessionManager.getSessionId();
@@ -8035,6 +8051,7 @@ export class AgentSession {
 			this.#freshProviderSessionId = undefined;
 			this.#adoptInheritedProviderPromptCacheKey();
 			this.#syncAgentSessionId();
+			guard.commit();
 			this.#memory.rekeyForCurrentSessionId();
 			this.#advisors.reattachRecorderFeeds();
 			advisorRecordersDetached = false;
@@ -9021,6 +9038,7 @@ export class AgentSession {
 			preserveLocalCwd?: boolean;
 		},
 	): Promise<boolean> {
+		using guard = this.#beginSessionTransitionGuard();
 		const previousSessionFile = this.sessionManager.getSessionFile();
 		const switchingToDifferentSession = previousSessionFile
 			? path.resolve(previousSessionFile) !== path.resolve(sessionPath)
@@ -9140,6 +9158,7 @@ export class AgentSession {
 				this.#adoptInheritedProviderPromptCacheKey();
 			}
 			this.#syncAgentSessionId(undefined, false);
+			guard.commit();
 			this.#memory.rekeyForCurrentSessionId();
 
 			let sessionContext = this.buildDisplaySessionContext();
@@ -9286,6 +9305,9 @@ export class AgentSession {
 			return true;
 		} catch (error) {
 			this.sessionManager.restoreState(previousSessionState);
+			// A same-file reload restores the transcript under an unchanged id, so
+			// an id comparison cannot detect this. Observers are told the outcome.
+			guard.rollback();
 			this.#freshProviderSessionId = previousFreshProviderSessionId;
 			this.#syncAgentSessionId(previousSessionState.sessionId, false);
 			this.#memory.rekeyForCurrentSessionId();
@@ -9382,6 +9404,7 @@ export class AgentSession {
 		selectedImages: ImageContent[];
 		cancelled: boolean;
 	}> {
+		using guard = this.#beginSessionTransitionGuard();
 		const previousSessionFile = this.sessionFile;
 		const selectedEntry = this.sessionManager.getEntry(entryId);
 
@@ -9447,6 +9470,7 @@ export class AgentSession {
 			this.#freshProviderSessionId = undefined;
 			this.#clearInheritedProviderPromptCacheKey();
 			this.#syncAgentSessionId();
+			guard.commit();
 			this.#memory.rekeyForCurrentSessionId();
 			await this.#memory.resetContextForNewTranscript();
 
@@ -9486,6 +9510,7 @@ export class AgentSession {
 		leafId: string,
 		sessionId: string,
 	): Promise<{ cancelled: boolean; sessionFile: string | undefined }> {
+		using guard = this.#beginSessionTransitionGuard();
 		const previousSessionFile = this.sessionFile;
 		if (!this.sessionManager.getSessionFile()) {
 			throw new Error("Cannot branch /btw: session is not persisted");
@@ -9578,6 +9603,7 @@ export class AgentSession {
 			this.#todo.syncFromBranch();
 			this.#freshProviderSessionId = undefined;
 			this.#syncAgentSessionId();
+			guard.commit();
 			this.#memory.rekeyForCurrentSessionId();
 			await this.#memory.resetContextForNewTranscript();
 
@@ -10909,6 +10935,65 @@ export class AgentSession {
 	 */
 	hasExtensionHandlers(eventType: string): boolean {
 		return this.#extensionRunner?.hasHandlers(eventType) ?? false;
+	}
+
+	/**
+	 * Whether a session transition is in flight before its session ID commits.
+	 * Covers every path that mints a new id: `newSession`, fork, `switchSession`,
+	 * and both branching flows (`branch`, `branchFromBtw`).
+	 */
+	get isSessionTransitionInFlight(): boolean {
+		return this.#sessionTransitionDepth > 0;
+	}
+
+	/**
+	 * Register a callback that runs when a session transition finishes, whichever
+	 * way it went. `commit()` releases the in-flight flag at the id commit so
+	 * post-switch hooks are not blocked, but a later step can still throw and
+	 * restore the previous state; scope exit is the only point where the outcome
+	 * is final.
+	 *
+	 * `rolledBack` is what a same-file reload needs: `switchSession()` on the
+	 * current file restores the transcript under an unchanged session id, so an
+	 * observer comparing ids cannot tell that the state it captured was
+	 * discarded.
+	 */
+	registerSessionTransitionSettledCallback(callback: (outcome: SessionTransitionOutcome) => void): () => void {
+		this.#sessionTransitionSettledCallbacks.add(callback);
+		return () => this.#sessionTransitionSettledCallbacks.delete(callback);
+	}
+
+	#beginSessionTransitionGuard(): { commit(): void; rollback(): void; [Symbol.dispose](): void } {
+		this.#sessionTransitionDepth++;
+		let released = false;
+		let rolledBack = false;
+		const release = () => {
+			if (released) return;
+			released = true;
+			if (this.#sessionTransitionDepth > 0) {
+				this.#sessionTransitionDepth--;
+			}
+		};
+		return {
+			commit: release,
+			rollback: () => {
+				rolledBack = true;
+			},
+			[Symbol.dispose]: () => {
+				release();
+				// Fires for the rollback path too, which is the whole point: the
+				// previous state is restored without any change notification, so
+				// this is the only signal an observer gets that it is over.
+				const outcome: SessionTransitionOutcome = { rolledBack };
+				for (const callback of Array.from(this.#sessionTransitionSettledCallbacks)) {
+					try {
+						callback(outcome);
+					} catch (error) {
+						logger.warn("Session transition settled callback failed", { error: String(error) });
+					}
+				}
+			},
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -1,7 +1,8 @@
 import { Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import { CollabGuestLink } from "../collab/guest";
-import { CollabHost } from "../collab/host";
+import type { CollabHost } from "../collab/host";
+import { startCollabHosting } from "../collab/start-hosting";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import { parseExportArgs } from "../export/html/args";
@@ -320,24 +321,19 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				return;
 			}
 			const explicitUrl = knownStartVerb ? rest : args;
-			const relayInput = explicitUrl || ctx.settings.get("collab.relayUrl") || "";
-			if (!relayInput) {
+			if (!(explicitUrl || ctx.settings.get("collab.relayUrl"))) {
 				ctx.showError(
 					"No relay configured. Set collab.relayUrl in /settings or pass one: /collab relay.example.com",
 				);
 				return;
 			}
-			// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
-			const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
-			const webUrl = ctx.settings.get("collab.webUrl") || "";
-			const host = new CollabHost(ctx);
+			let host: CollabHost;
 			try {
-				await host.start(relayUrl, webUrl);
+				host = await startCollabHosting(ctx, { relayUrl: explicitUrl || undefined });
 			} catch (err) {
 				ctx.showError(`Failed to start collab session: ${errorMessage(err)}`);
 				return;
 			}
-			ctx.collabHost = host;
 			showCollabLink(ctx, host, "Collab session started!", view);
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -1,7 +1,8 @@
 import { Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import { CollabGuestLink } from "../collab/guest";
-import { CollabHost } from "../collab/host";
+import type { CollabHost } from "../collab/host";
+import { hasInFlightCollabHosting, startCollabHosting, stopCollabHosting } from "../collab/start-hosting";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import { parseExportArgs } from "../export/html/args";
@@ -303,11 +304,11 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 			const args = command.args.trim();
 			const { verb, rest } = parseSubcommand(args);
 			if (verb === "stop") {
-				if (!ctx.collabHost) {
+				if (!ctx.collabHost && !hasInFlightCollabHosting(ctx)) {
 					ctx.showStatus("Not hosting a collab session");
 					return;
 				}
-				await ctx.collabHost.stop("host stopped");
+				await stopCollabHosting(ctx);
 				ctx.showStatus("Collab stopped");
 				return;
 			}
@@ -344,24 +345,19 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				return;
 			}
 			const explicitUrl = knownStartVerb ? rest : args;
-			const relayInput = explicitUrl || ctx.settings.get("collab.relayUrl") || "";
-			if (!relayInput) {
+			if (!(explicitUrl || ctx.settings.get("collab.relayUrl"))) {
 				ctx.showError(
 					"No relay configured. Set collab.relayUrl in /settings or pass one: /collab relay.example.com",
 				);
 				return;
 			}
-			// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
-			const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
-			const webUrl = ctx.settings.get("collab.webUrl") || "";
-			const host = new CollabHost(ctx);
+			let host: CollabHost;
 			try {
-				await host.start(relayUrl, webUrl);
+				host = await startCollabHosting(ctx, { relayUrl: explicitUrl || undefined });
 			} catch (err) {
 				ctx.showError(`Failed to start collab session: ${errorMessage(err)}`);
 				return;
 			}
-			ctx.collabHost = host;
 			showCollabLink(ctx, host, "Collab session started!", view);
 		},
 	},
@@ -379,7 +375,7 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				ctx.showError("Usage: /join <link>");
 				return;
 			}
-			if (ctx.collabHost) {
+			if (ctx.collabHost || hasInFlightCollabHosting(ctx)) {
 				ctx.showError("Stop hosting first (/collab stop)");
 				return;
 			}
@@ -410,8 +406,8 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				await ctx.collabGuest.leave("left");
 				return;
 			}
-			if (ctx.collabHost) {
-				await ctx.collabHost.stop("host stopped");
+			if (ctx.collabHost || hasInFlightCollabHosting(ctx)) {
+				await stopCollabHosting(ctx);
 				ctx.showStatus("Collab stopped");
 				return;
 			}

--- a/packages/coding-agent/test/agent-session-new-session-boundary.test.ts
+++ b/packages/coding-agent/test/agent-session-new-session-boundary.test.ts
@@ -194,4 +194,108 @@ describe("AgentSession.newSession boundary", () => {
 		if (!reportedFile) throw new Error("Expected session_switch to report a persisted session file");
 		expect(await Bun.file(reportedFile).exists()).toBe(true);
 	});
+
+	it("maintains isSessionTransitionInFlight from before-switch through id commit and clears before session_switch", async () => {
+		let inBeforeSwitch: boolean | undefined;
+		let inPreCommitAwait: boolean | undefined;
+		let inSessionSwitch: boolean | undefined;
+
+		const pending = Promise.withResolvers<void>();
+
+		const { session, sessionManager } = await createHarness({
+			extension: {
+				name: "observe-transition-window",
+				register: pi => {
+					pi.on("session_before_switch", () => {
+						inBeforeSwitch = session.isSessionTransitionInFlight;
+						void pending.promise.then(() => {
+							inPreCommitAwait = session.isSessionTransitionInFlight;
+						});
+					});
+					pi.on("session_switch", () => {
+						inSessionSwitch = session.isSessionTransitionInFlight;
+					});
+				},
+			},
+		});
+
+		const originalNewSession = sessionManager.newSession.bind(sessionManager);
+		sessionManager.newSession = async options => {
+			pending.resolve();
+			await Promise.resolve();
+			return originalNewSession(options);
+		};
+
+		expect(await session.newSession()).toBe(true);
+
+		expect(inBeforeSwitch).toBe(true);
+		expect(inPreCommitAwait).toBe(true);
+		expect(inSessionSwitch).toBe(false);
+	});
+
+	it("holds isSessionTransitionInFlight across a branch, which mints a new id of its own", async () => {
+		let inBeforeBranch: boolean | undefined;
+		let inSessionBranch: boolean | undefined;
+
+		const { session, sessionManager } = await createHarness({
+			extension: {
+				name: "observe-branch-window",
+				register: pi => {
+					pi.on("session_before_branch", () => {
+						inBeforeBranch = session.isSessionTransitionInFlight;
+					});
+					pi.on("session_branch", () => {
+						inSessionBranch = session.isSessionTransitionInFlight;
+					});
+				},
+			},
+		});
+
+		sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "branch me" }],
+			timestamp: Date.now(),
+		});
+		const entries = sessionManager.getBranch();
+		const target = entries.find(entry => entry.type === "message" && entry.message.role === "user");
+		if (!target) throw new Error("Expected a user entry to branch from");
+		const previousSessionId = sessionManager.getSessionId();
+
+		const result = await session.branch(target.id);
+
+		expect(result.cancelled).toBe(false);
+		expect(sessionManager.getSessionId()).not.toBe(previousSessionId);
+		expect(inBeforeBranch).toBe(true);
+		expect(inSessionBranch).toBe(false);
+	});
+
+	it("reports a transition as settled even when it is cancelled and no id changes", async () => {
+		// The rollback path restores the previous id without a change
+		// notification, so settlement is the only signal an observer gets that
+		// the outcome is final. A cancelled transition exercises that same
+		// scope-exit release.
+		let settledCount = 0;
+		const { session, sessionManager } = await createHarness({
+			extension: {
+				name: "cancel-the-switch",
+				register: pi => {
+					pi.on("session_before_switch", () => ({ cancel: true }));
+				},
+			},
+		});
+		const unregister = session.registerSessionTransitionSettledCallback(() => {
+			settledCount++;
+		});
+		const previousSessionId = sessionManager.getSessionId();
+
+		expect(await session.newSession()).toBe(false);
+
+		expect(sessionManager.getSessionId()).toBe(previousSessionId);
+		expect(settledCount).toBe(1);
+		expect(session.isSessionTransitionInFlight).toBe(false);
+
+		unregister();
+		expect(await session.newSession()).toBe(false);
+		expect(settledCount).toBe(1);
+	});
 });

--- a/packages/coding-agent/test/collab/extension-hosting.test.ts
+++ b/packages/coding-agent/test/collab/extension-hosting.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Contract for programmatic collab hosting: `startCollabHosting` starts (or
+ * reuses) the one room a session can host, hands back both link strengths,
+ * and never prints a byte of key material anywhere. Also covered: the
+ * extension runner's fallback for hosts with no TUI, where collab hosting
+ * must refuse loudly instead of half-working.
+ *
+ * Runs over the same in-memory relay transport as the other collab suites
+ * (see ./helpers/in-memory-relay): real CollabSocket, real AES-GCM sealing,
+ * real hello to welcome handshake; only the network and the TUI context are
+ * stubbed.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import type { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { COLLAB_PROTO, type CollabFrame, parseCollabLink } from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import { collabHostLinks, startCollabHosting } from "@oh-my-pi/pi-coding-agent/collab/start-hosting";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import {
+	ExtensionRuntime,
+	ExtensionRuntimeNotInitializedError,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type {
+	ExtensionActions,
+	ExtensionContextActions,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+interface CtxHarness {
+	ctx: InteractiveModeContext;
+	/** Every string any presentation surface received, in order. */
+	printed: string[];
+}
+
+/**
+ * Minimal InteractiveModeContext double: the members CollabHost touches,
+ * plus recording of every presentation call so the key-hygiene test can
+ * assert that starting a room prints nothing at all.
+ */
+function makeCtx(options: { relayUrl?: string; webUrl?: string; guest?: boolean } = {}): CtxHarness {
+	const printed: string[] = [];
+	const settings: Record<string, string> = {
+		"collab.relayUrl": options.relayUrl ?? "",
+		"collab.webUrl": options.webUrl ?? "",
+	};
+	const ctx = {
+		settings: { get: (key: string) => settings[key] ?? "" },
+		sessionManager: {
+			getSessionId: () => "sess-1",
+			getCwd: () => "/tmp",
+			snapshotForReplication: () => ({
+				header: { type: "session", id: "sess-1", timestamp: new Date().toISOString(), cwd: "/tmp" },
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			queuedMessageCount: 0,
+			sessionName: "test",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: (_level: string, message: string) => printed.push(message),
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: (message: string) => printed.push(message),
+		showError: (message: string) => printed.push(message),
+		present: () => printed.push("<component>"),
+		collabHost: undefined,
+		collabGuest: options.guest ? {} : undefined,
+	} as unknown as InteractiveModeContext;
+	return { ctx, printed };
+}
+
+/** Hosts started by a test, stopped in afterEach so no socket outlives it. */
+const startedHosts: CollabHost[] = [];
+
+async function startHosting(ctx: InteractiveModeContext, relayUrl?: string): Promise<CollabHost> {
+	const host = await startCollabHosting(ctx, relayUrl === undefined ? {} : { relayUrl });
+	startedHosts.push(host);
+	return host;
+}
+
+/** Frames that interleave nondeterministically with the welcome this suite waits for. */
+const FILTERED_FRAME_TYPES: Record<string, true> = {
+	state: true,
+	agents: true,
+	entry: true,
+	event: true,
+	bus: true,
+	"snapshot-chunk": true,
+};
+
+/** Join with a link the helper produced and wait for the host's welcome. */
+async function expectGuestWelcome(link: string): Promise<CollabFrame> {
+	const parsed = parseCollabLink(link);
+	if ("error" in parsed) throw new Error(parsed.error);
+	const key = await importRoomKey(parsed.key);
+	const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+	try {
+		const welcome = Promise.withResolvers<CollabFrame>();
+		socket.onFrame = frame => {
+			if (!FILTERED_FRAME_TYPES[frame.t]) welcome.resolve(frame);
+		};
+		socket.onOpen = () =>
+			socket.send({
+				t: "hello",
+				proto: COLLAB_PROTO,
+				name: "probe",
+				writeToken: parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined,
+			});
+		socket.connect();
+		return await welcome.promise;
+	} finally {
+		socket.close();
+	}
+}
+
+beforeAll(() => {
+	installInMemoryRelay();
+});
+
+afterEach(async () => {
+	for (const host of startedHosts.splice(0).reverse()) await host.stop("test done");
+});
+
+afterAll(() => {
+	uninstallInMemoryRelay();
+});
+
+describe("startCollabHosting", () => {
+	it("starts a room and returns both link strengths, usable by a real guest", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+
+		const links = collabHostLinks(host);
+		expect(host.relayOrigin).toBe("ws://localhost:7475");
+		expect(ctx.collabHost).toBe(host);
+		expect(links.link).not.toBe(links.viewLink);
+
+		const full = parseCollabLink(links.link);
+		if ("error" in full) throw new Error(full.error);
+		expect(full.wsUrl.startsWith("ws://localhost:7475/r/")).toBe(true);
+		// The full link carries the 16-byte write token; the view link is the bare room key.
+		expect(full.writeToken).toBeDefined();
+		const view = parseCollabLink(links.viewLink);
+		if ("error" in view) throw new Error(view.error);
+		expect(view.writeToken).toBeUndefined();
+		expect(view.wsUrl).toBe(full.wsUrl);
+		expect(links.webLink.startsWith("http://localhost:7475/#")).toBe(true);
+
+		// The link is not merely well-formed: a guest holding it completes the handshake.
+		const welcome = await expectGuestWelcome(links.link);
+		expect(welcome.t).toBe("welcome");
+	});
+
+	it("returns the existing room when the requested relay matches", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		const again = await startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		expect(again).toBe(host);
+		expect(collabHostLinks(again)).toEqual(collabHostLinks(host));
+	});
+
+	it("refuses a different relay while hosting and keeps the original room", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		const linkBefore = host.link;
+		await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:9999" })).rejects.toThrow(
+			/Already hosting a collab session on relay ws:\/\/localhost:7475/,
+		);
+		expect(ctx.collabHost).toBe(host);
+		expect(host.link).toBe(linkBefore);
+	});
+
+	it("refuses while the session is a guest in someone else's room", async () => {
+		const { ctx } = makeCtx({ guest: true });
+		await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+			/Already in a collab session as a guest/,
+		);
+		expect(ctx.collabHost).toBeUndefined();
+	});
+
+	it("throws when no relay is configured or passed", async () => {
+		const { ctx } = makeCtx();
+		await expect(startCollabHosting(ctx)).rejects.toThrow(/No relay configured/);
+	});
+
+	it("falls back to the collab.relayUrl setting", async () => {
+		const { ctx } = makeCtx({ relayUrl: "ws://localhost:7475" });
+		const host = await startHosting(ctx);
+		expect(host.relayOrigin).toBe("ws://localhost:7475");
+	});
+
+	it("rejects plain ws to a non-localhost relay", async () => {
+		const { ctx } = makeCtx();
+		await expect(startCollabHosting(ctx, { relayUrl: "ws://relay.example.com" })).rejects.toThrow(
+			/relay link must be wss/,
+		);
+		expect(ctx.collabHost).toBeUndefined();
+	});
+
+	it("defaults a scheme-less relay to wss", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "relay.example.com");
+		expect(host.relayOrigin).toBe("wss://relay.example.com");
+		const parsed = parseCollabLink(host.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+		expect(parsed.wsUrl.startsWith("wss://relay.example.com/r/")).toBe(true);
+	});
+
+	it("prints nothing: no status line, notice, or component carries the room key", async () => {
+		const { ctx, printed } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		const full = parseCollabLink(host.link);
+		if ("error" in full) throw new Error(full.error);
+		// The room id alone would already leak which room to probe; the key is the credential itself.
+		expect(printed).toHaveLength(0);
+		for (const message of printed) {
+			expect(message).not.toContain(full.roomId);
+		}
+	});
+
+	it("stop clears hosting and a restart mints a fresh room", async () => {
+		const { ctx } = makeCtx();
+		const first = await startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		startedHosts.push(first);
+		const firstParsed = parseCollabLink(first.link);
+		if ("error" in firstParsed) throw new Error(firstParsed.error);
+		await first.stop("test done");
+		expect(ctx.collabHost).toBeUndefined();
+
+		const second = await startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		startedHosts.push(second);
+		const secondParsed = parseCollabLink(second.link);
+		if ("error" in secondParsed) throw new Error(secondParsed.error);
+		expect(secondParsed.roomId).not.toBe(firstParsed.roomId);
+	});
+});
+
+describe("collab hosting on non-interactive extension hosts", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-collab-runner-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	/** The actions a print/RPC host wires: every required action, none of the optional collab ones. */
+	function headlessActions(): ExtensionActions {
+		return {
+			sendMessage: () => {},
+			sendUserMessage: () => {},
+			appendEntry: () => {},
+			setLabel: () => {},
+			getActiveTools: () => [],
+			getAllTools: () => [],
+			setActiveTools: () => Promise.resolve(),
+			getCommands: () => [],
+			setModel: () => Promise.resolve(false),
+			getThinkingLevel: () => undefined,
+			setThinkingLevel: () => {},
+			getSessionName: () => undefined,
+			setSessionName: () => Promise.resolve(),
+		};
+	}
+
+	function headlessContextActions(): ExtensionContextActions {
+		return {
+			getModel: () => undefined,
+			isIdle: () => true,
+			abort: () => {},
+			hasPendingMessages: () => false,
+			shutdown: () => {},
+			getContextUsage: () => undefined,
+			compact: () => Promise.resolve(),
+			getSystemPrompt: () => [],
+		};
+	}
+
+	it("startCollab and stopCollab throw, getCollabLinks answers undefined", async () => {
+		const runtime = new ExtensionRuntime();
+		const runner = new ExtensionRunner([], runtime, tempDir.path(), SessionManager.inMemory(), modelRegistry);
+		runner.initialize(headlessActions(), headlessContextActions());
+		// The fallback throws synchronously (like the loader's pre-init stubs); the
+		// real action rejects. Either way an awaiting caller sees the same error.
+		expect(() => runtime.startCollab()).toThrow(/does not support collab hosting/);
+		expect(runtime.getCollabLinks()).toBeUndefined();
+		expect(() => runtime.stopCollab()).toThrow(/does not support collab hosting/);
+	});
+
+	it("delegates to the wired actions when a host provides them", async () => {
+		const runtime = new ExtensionRuntime();
+		const runner = new ExtensionRunner([], runtime, tempDir.path(), SessionManager.inMemory(), modelRegistry);
+		const sentinel = { link: "l", viewLink: "v", webLink: "w", webViewLink: "wv" };
+		const actions = headlessActions();
+		let stops = 0;
+		actions.startCollab = () => Promise.resolve(sentinel);
+		actions.getCollabLinks = () => sentinel;
+		actions.stopCollab = () => {
+			stops += 1;
+			return Promise.resolve();
+		};
+		runner.initialize(actions, headlessContextActions());
+		// The runtime passed to the runner is the same object initialize wires,
+		// so its methods are the extension-facing surface under test.
+		expect(await runtime.startCollab()).toBe(sentinel);
+		expect(runtime.getCollabLinks()).toBe(sentinel);
+		await runtime.stopCollab();
+		expect(stops).toBe(1);
+	});
+
+	it("the uninitialized runtime refuses before initialize wires actions", () => {
+		const runtime = new ExtensionRuntime();
+		expect(() => runtime.startCollab()).toThrow(ExtensionRuntimeNotInitializedError);
+		expect(() => runtime.getCollabLinks()).toThrow(ExtensionRuntimeNotInitializedError);
+	});
+});

--- a/packages/coding-agent/test/collab/extension-hosting.test.ts
+++ b/packages/coding-agent/test/collab/extension-hosting.test.ts
@@ -1,0 +1,1237 @@
+/**
+ * Contract for programmatic collab hosting: `startCollabHosting` starts (or
+ * reuses) the one room a session can host, hands back both link strengths,
+ * and never prints a byte of key material anywhere. Also covered: the
+ * extension runner's fallback for hosts with no TUI, where collab hosting
+ * must refuse loudly instead of half-working.
+ *
+ * Runs over the same in-memory relay transport as the other collab suites
+ * (see ./helpers/in-memory-relay): real CollabSocket, real AES-GCM sealing,
+ * real hello to welcome handshake; only the network and the TUI context are
+ * stubbed.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { CollabGuestLink } from "@oh-my-pi/pi-coding-agent/collab/guest";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { COLLAB_PROTO, type CollabFrame, parseCollabLink } from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import {
+	activeCollabHostLinks,
+	collabHostLinks,
+	hasInFlightCollabHosting,
+	startCollabHosting,
+	stopCollabHosting,
+} from "@oh-my-pi/pi-coding-agent/collab/start-hosting";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import {
+	ExtensionRuntime,
+	ExtensionRuntimeNotInitializedError,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type {
+	CollabHostLinks,
+	Extension,
+	ExtensionActions,
+	ExtensionContextActions,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { SessionTransitionOutcome } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type InMemoryRelay, installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+interface CtxHarness {
+	ctx: InteractiveModeContext;
+	/** Every string any presentation surface received, in order. */
+	printed: string[];
+	collabStatus: () => unknown;
+}
+
+/**
+ * Minimal InteractiveModeContext double: the members CollabHost touches,
+ * plus recording of every presentation call so the key-hygiene test can
+ * assert that starting a room prints nothing at all.
+ */
+function makeCtx(
+	options: {
+		relayUrl?: string;
+		webUrl?: string;
+		guest?: boolean;
+		extensionRunner?: ExtensionRunner | (() => ExtensionRunner | undefined);
+		isSessionTransitionInFlight?: boolean | (() => boolean);
+		onTransitionSettledRegistered?: (fire: (outcome: SessionTransitionOutcome) => void) => void;
+	} = {},
+): CtxHarness {
+	const printed: string[] = [];
+	const settings: Record<string, string> = {
+		"collab.relayUrl": options.relayUrl ?? "",
+		"collab.webUrl": options.webUrl ?? "",
+	};
+	let collabStatus: unknown = null;
+	const ctx = {
+		settings: { get: (key: string) => settings[key] ?? "" },
+		sessionManager: {
+			getSessionId: () => "sess-1",
+			getSessionFile: () => null,
+			getSessionName: () => "test",
+			getCwd: () => "/tmp",
+			snapshotForReplication: () => ({
+				header: { type: "session", id: "sess-1", timestamp: new Date().toISOString(), cwd: "/tmp" },
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			get extensionRunner(): ExtensionRunner | undefined {
+				return typeof options.extensionRunner === "function" ? options.extensionRunner() : options.extensionRunner;
+			},
+			get isSessionTransitionInFlight(): boolean {
+				if (typeof options.isSessionTransitionInFlight === "function") {
+					return options.isSessionTransitionInFlight();
+				}
+				if (typeof options.isSessionTransitionInFlight === "boolean") {
+					return options.isSessionTransitionInFlight;
+				}
+				return false;
+			},
+			registerSessionTransitionSettledCallback: (
+				callback: (outcome: SessionTransitionOutcome) => void,
+			): (() => void) => {
+				options.onTransitionSettledRegistered?.(callback);
+				return () => {};
+			},
+			isStreaming: false,
+			queuedMessageCount: 0,
+			sessionName: "test",
+			messages: [],
+			switchSession: () => Promise.resolve(true),
+			newSession: () => Promise.resolve(),
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: (_level: string, message: string) => printed.push(message),
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+			agent: {
+				state: { model: undefined },
+				setModel: () => {},
+				setThinkingLevel: () => {},
+				setDisableReasoning: () => {},
+			},
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: (status: unknown) => {
+				collabStatus = status;
+			},
+			invalidate: () => {},
+			resetActiveTime: () => {},
+			markActivityStart: () => {},
+			markActivityEnd: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: (message: string) => printed.push(message),
+		showError: (message: string) => printed.push(message),
+		present: () => printed.push("<component>"),
+		syncRunningSubagentBadge: () => {},
+		resetObserverRegistry: () => {},
+		updateEditorBorderColor: () => {},
+		renderInitialMessages: () => Promise.resolve(),
+		reloadTodos: () => Promise.resolve(),
+		chatContainer: { clear: () => {}, disposeChildren: () => {} },
+		statusContainer: { clear: () => {} },
+		pendingMessagesContainer: { clear: () => {} },
+		compactionQueuedMessages: [],
+		transcriptMessageComponents: new WeakMap(),
+		pendingTools: new Map(),
+		collabHost: undefined,
+		collabGuest: options.guest ? {} : undefined,
+	} as unknown as InteractiveModeContext;
+	return { ctx, printed, collabStatus: () => collabStatus };
+}
+
+/** Hosts started by a test, stopped in afterEach so no socket outlives it. */
+const startedHosts: CollabHost[] = [];
+
+async function startHosting(ctx: InteractiveModeContext, relayUrl?: string): Promise<CollabHost> {
+	const host = await startCollabHosting(ctx, relayUrl === undefined ? {} : { relayUrl });
+	startedHosts.push(host);
+	return host;
+}
+
+/** Frames that interleave nondeterministically with the welcome this suite waits for. */
+const FILTERED_FRAME_TYPES: Record<string, true> = {
+	state: true,
+	agents: true,
+	entry: true,
+	event: true,
+	bus: true,
+	"snapshot-chunk": true,
+};
+
+/** Join with a link the helper produced and wait for the host's welcome. */
+async function expectGuestWelcome(link: string): Promise<CollabFrame> {
+	const parsed = parseCollabLink(link);
+	if ("error" in parsed) throw new Error(parsed.error);
+	const key = await importRoomKey(parsed.key);
+	const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+	try {
+		const welcome = Promise.withResolvers<CollabFrame>();
+		socket.onFrame = frame => {
+			if (!FILTERED_FRAME_TYPES[frame.t]) welcome.resolve(frame);
+		};
+		socket.onOpen = () =>
+			socket.send({
+				t: "hello",
+				proto: COLLAB_PROTO,
+				name: "probe",
+				writeToken: parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined,
+			});
+		socket.connect();
+		return await welcome.promise;
+	} finally {
+		socket.close();
+	}
+}
+
+/**
+ * Join, wait for the welcome, then run `append` and resolve with the replicated
+ * `entry` frame. Proves replication end to end rather than inspecting the tap:
+ * a host that released another host's entry tap never sends this frame.
+ */
+async function expectGuestReceivesEntry(link: string, append: () => void): Promise<CollabFrame> {
+	const parsed = parseCollabLink(link);
+	if ("error" in parsed) throw new Error(parsed.error);
+	const key = await importRoomKey(parsed.key);
+	const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+	try {
+		const welcomed = Promise.withResolvers<void>();
+		const replicated = Promise.withResolvers<CollabFrame>();
+		socket.onFrame = frame => {
+			// `entry` is in FILTERED_FRAME_TYPES for the welcome-only helper above,
+			// but it is precisely the frame this one exists to observe.
+			if (frame.t === "entry") {
+				replicated.resolve(frame);
+				return;
+			}
+			if (!FILTERED_FRAME_TYPES[frame.t]) welcomed.resolve();
+		};
+		socket.onOpen = () =>
+			socket.send({
+				t: "hello",
+				proto: COLLAB_PROTO,
+				name: "probe",
+				writeToken: parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined,
+			});
+		socket.connect();
+		await welcomed.promise;
+		append();
+		return await replicated.promise;
+	} finally {
+		socket.close();
+	}
+}
+
+let relay: InMemoryRelay;
+let tempDir: TempDir;
+let authStorage: AuthStorage;
+let modelRegistry: ModelRegistry;
+
+/** The actions a print/RPC host wires: every required action, none of the optional collab ones. */
+function headlessActions(): ExtensionActions {
+	return {
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		setLabel: () => {},
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => Promise.resolve(),
+		getCommands: () => [],
+		setModel: () => Promise.resolve(false),
+		getThinkingLevel: () => undefined,
+		setThinkingLevel: () => {},
+		getSessionName: () => undefined,
+		setSessionName: () => Promise.resolve(),
+	};
+}
+
+function headlessContextActions(): ExtensionContextActions {
+	return {
+		getModel: () => undefined,
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => Promise.resolve(),
+		getSystemPrompt: () => [],
+	};
+}
+
+beforeAll(async () => {
+	relay = installInMemoryRelay();
+	tempDir = TempDir.createSync("@pi-collab-runner-");
+	authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+	modelRegistry = new ModelRegistry(authStorage);
+});
+
+afterEach(async () => {
+	for (const host of startedHosts.splice(0).reverse()) await host.stop("test done");
+});
+
+afterAll(() => {
+	authStorage.close();
+	tempDir.removeSync();
+	uninstallInMemoryRelay();
+});
+
+describe("startCollabHosting", () => {
+	it("starts a room and returns both link strengths, usable by a real guest", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+
+		const links = collabHostLinks(host);
+		expect(host.relayOrigin).toBe("ws://localhost:7475");
+		expect(ctx.collabHost).toBe(host);
+		expect(links.link).not.toBe(links.viewLink);
+
+		const full = parseCollabLink(links.link);
+		if ("error" in full) throw new Error(full.error);
+		expect(full.wsUrl.startsWith("ws://localhost:7475/r/")).toBe(true);
+		// The full link carries the 16-byte write token; the view link is the bare room key.
+		expect(full.writeToken).toBeDefined();
+		const view = parseCollabLink(links.viewLink);
+		if ("error" in view) throw new Error(view.error);
+		expect(view.writeToken).toBeUndefined();
+		expect(view.wsUrl).toBe(full.wsUrl);
+		expect(links.webLink.startsWith("http://localhost:7475/#")).toBe(true);
+
+		// The link is not merely well-formed: a guest holding it completes the handshake.
+		const welcome = await expectGuestWelcome(links.link);
+		expect(welcome.t).toBe("welcome");
+	});
+
+	it("returns the existing room when the requested relay matches", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		const again = await startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		expect(again).toBe(host);
+		expect(collabHostLinks(again)).toEqual(collabHostLinks(host));
+	});
+
+	it("refuses a different relay while hosting and keeps the original room", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		const linkBefore = host.link;
+		await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:9999" })).rejects.toThrow(
+			/Already hosting a collab session on relay ws:\/\/localhost:7475/,
+		);
+		expect(ctx.collabHost).toBe(host);
+		expect(host.link).toBe(linkBefore);
+	});
+
+	it("refuses while the session is a guest in someone else's room", async () => {
+		const { ctx } = makeCtx({ guest: true });
+		await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+			/Already in a collab session as a guest/,
+		);
+		expect(ctx.collabHost).toBeUndefined();
+	});
+
+	it("throws when no relay is configured or passed", async () => {
+		const { ctx } = makeCtx();
+		await expect(startCollabHosting(ctx)).rejects.toThrow(/No relay configured/);
+	});
+
+	it("falls back to the collab.relayUrl setting", async () => {
+		const { ctx } = makeCtx({ relayUrl: "ws://localhost:7475" });
+		const host = await startHosting(ctx);
+		expect(host.relayOrigin).toBe("ws://localhost:7475");
+	});
+
+	it("rejects plain ws to a non-localhost relay", async () => {
+		const { ctx } = makeCtx();
+		await expect(startCollabHosting(ctx, { relayUrl: "ws://relay.example.com" })).rejects.toThrow(
+			/relay link must be wss/,
+		);
+		expect(ctx.collabHost).toBeUndefined();
+	});
+
+	it("defaults a scheme-less relay to wss", async () => {
+		const { ctx } = makeCtx();
+		const host = await startHosting(ctx, "relay.example.com");
+		expect(host.relayOrigin).toBe("wss://relay.example.com");
+		const parsed = parseCollabLink(host.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+		expect(parsed.wsUrl.startsWith("wss://relay.example.com/r/")).toBe(true);
+	});
+
+	it("prints nothing: no status line, notice, or component carries the room key", async () => {
+		const { ctx, printed } = makeCtx();
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		const full = parseCollabLink(host.link);
+		if ("error" in full) throw new Error(full.error);
+		// The room id alone would already leak which room to probe; the key is the credential itself.
+		expect(printed).toHaveLength(0);
+		for (const message of printed) {
+			expect(message).not.toContain(full.roomId);
+		}
+	});
+
+	it("stop clears hosting and a restart mints a fresh room", async () => {
+		const { ctx } = makeCtx();
+		const first = await startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		startedHosts.push(first);
+		const firstParsed = parseCollabLink(first.link);
+		if ("error" in firstParsed) throw new Error(firstParsed.error);
+		await first.stop("test done");
+		expect(ctx.collabHost).toBeUndefined();
+
+		const second = await startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		startedHosts.push(second);
+		const secondParsed = parseCollabLink(second.link);
+		if ("error" in secondParsed) throw new Error(secondParsed.error);
+		expect(secondParsed.roomId).not.toBe(firstParsed.roomId);
+	});
+
+	it("concurrent starts against the same relay return the same host and links without opening duplicate rooms", async () => {
+		const { ctx } = makeCtx();
+		const [first, second] = await Promise.all([
+			startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" }),
+			startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" }),
+		]);
+		startedHosts.push(first);
+		expect(first).toBe(second);
+		expect(first.link).toBe(second.link);
+		expect(ctx.collabHost).toBe(first);
+
+		const parsed = parseCollabLink(first.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+
+		// Exactly one room is live: a guest can join and complete the handshake.
+		const welcome = await expectGuestWelcome(first.link);
+		expect(welcome.t).toBe("welcome");
+	});
+
+	it("a concurrent start against a different relay rejects with the already-hosting error and leaves the first room intact", async () => {
+		const { ctx } = makeCtx();
+		const startFirst = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		const startSecond = startCollabHosting(ctx, { relayUrl: "ws://localhost:9999" });
+
+		const results = await Promise.allSettled([startFirst, startSecond]);
+		const [firstResult, secondResult] = results;
+
+		expect(firstResult.status).toBe("fulfilled");
+		if (firstResult.status !== "fulfilled") throw new Error("first start failed");
+
+		const host = firstResult.value;
+		startedHosts.push(host);
+
+		expect(secondResult.status).toBe("rejected");
+		if (secondResult.status !== "rejected") throw new Error("second start should have rejected");
+		if (!(secondResult.reason instanceof Error)) throw new Error("second start reason must be an Error");
+		expect(secondResult.reason.message).toMatch(
+			/Already hosting a collab session on relay ws:\/\/localhost:7475 \(stop it first\)/,
+		);
+		expect(ctx.collabHost).toBe(host);
+		expect(host.relayOrigin).toBe("ws://localhost:7475");
+		const welcome = await expectGuestWelcome(host.link);
+		expect(welcome.t).toBe("welcome");
+	});
+
+	it("stopping a host that is not ctx.collabHost leaves ctx.collabHost pointing at the live host", async () => {
+		const { ctx } = makeCtx();
+		const liveHost = await startHosting(ctx, "ws://localhost:7475");
+		expect(ctx.collabHost).toBe(liveHost);
+
+		const otherHost = new CollabHost(ctx);
+		await otherHost.stop("stopped other host");
+		expect(ctx.collabHost).toBe(liveHost);
+		expect(ctx.collabHost?.relayOrigin).toBe("ws://localhost:7475");
+
+		// A welcome only proves the room still accepts guests. `onEntryAppended`
+		// is a single slot on the session manager, so what actually breaks when a
+		// stale host clears it is replication of entries appended afterwards.
+		const replicated = await expectGuestReceivesEntry(liveHost.link, () => {
+			ctx.sessionManager.onEntryAppended?.({
+				type: "message",
+				id: "after-stale-stop",
+				parentId: null,
+				timestamp: "2026-06-20T00:00:00Z",
+				message: { role: "user", content: "still replicating", timestamp: 0 },
+			});
+		});
+		expect(replicated.t).toBe("entry");
+	});
+
+	it("cancels an in-flight start when stopped, leaving no relay socket and no session tap", async () => {
+		const { ctx } = makeCtx();
+		const startPromise = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		expect(hasInFlightCollabHosting(ctx)).toBe(true);
+
+		await stopCollabHosting(ctx);
+		expect(hasInFlightCollabHosting(ctx)).toBe(false);
+		expect(ctx.collabHost).toBeUndefined();
+
+		await expect(startPromise).rejects.toThrow(/Collab hosting was stopped/);
+		expect(ctx.collabHost).toBeUndefined();
+		// A start cancelled before its key import must never reach the relay
+		// and never tap the session: teardown already ran and cannot run again.
+		expect(relay.hasHost).toBe(false);
+		expect(ctx.sessionManager.onEntryAppended).toBeUndefined();
+	});
+
+	it("restarts hosting with a fresh room when the active session changes", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+
+		const firstHost = await startHosting(ctx, "ws://localhost:7475");
+		expect(firstHost.sessionId).toBe("sess-1");
+		expect(ctx.collabHost).toBe(firstHost);
+		const firstLink = firstHost.link;
+
+		// Switch session: getSessionId now returns sess-2 while firstHost is still ctx.collabHost
+		currentSessionId = "sess-2";
+
+		const secondHost = await startHosting(ctx, "ws://localhost:7475");
+		expect(secondHost.sessionId).toBe("sess-2");
+		expect(ctx.collabHost).toBe(secondHost);
+		expect(secondHost).not.toBe(firstHost);
+		expect(secondHost.link).not.toBe(firstLink);
+
+		// Second room is live and usable by guests
+		const welcome = await expectGuestWelcome(secondHost.link);
+		expect(welcome.t).toBe("welcome");
+	});
+
+	it("hands both new-session callers the same room when a session switch cancels an in-flight start", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+
+		// A start reserved by the outgoing session, still mid-handshake.
+		const stale = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+		expect(hasInFlightCollabHosting(ctx)).toBe(true);
+		currentSessionId = "sess-2";
+
+		// Two callbacks in the new session both observe that stale reservation.
+		const [first, second] = await Promise.all([
+			startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" }),
+			startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" }),
+		]);
+		startedHosts.push(first);
+
+		expect(first).toBe(second);
+		expect(first.link).toBe(second.link);
+		expect(first.sessionId).toBe("sess-2");
+		expect(ctx.collabHost).toBe(first);
+		await expect(stale).rejects.toThrow(/Collab hosting was stopped/);
+	});
+
+	it("retries with a room bound to the new session when the switch lands during the handshake", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		// The switch lands after the room bound its session id and before the
+		// start publishes it: the window the handshake await leaves open.
+		const realStart = CollabHost.prototype.start;
+		const spy = vi.spyOn(CollabHost.prototype, "start").mockImplementation(async function (
+			this: CollabHost,
+			relayUrl: string,
+			webUrl?: string,
+		) {
+			await realStart.call(this, relayUrl, webUrl);
+			currentSessionId = "sess-2";
+		});
+		try {
+			const host = await startHosting(ctx, "ws://localhost:7475");
+			expect(host.sessionId).toBe("sess-2");
+			expect(ctx.collabHost).toBe(host);
+			// The room published is the one a guest can actually reach.
+			const welcome = await expectGuestWelcome(host.link);
+			expect(welcome.t).toBe("welcome");
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("a stop landing during the superseded teardown wins over the retry", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+
+		// Switch the session across the handshake so the post-handshake
+		// mismatch branch runs, then park inside its teardown.
+		const realStart = CollabHost.prototype.start;
+		const startSpy = vi.spyOn(CollabHost.prototype, "start").mockImplementation(async function (
+			this: CollabHost,
+			relayUrl: string,
+			webUrl?: string,
+		) {
+			await realStart.call(this, relayUrl, webUrl);
+			currentSessionId = "sess-2";
+		});
+		const teardownEntered = Promise.withResolvers<void>();
+		const releaseTeardown = Promise.withResolvers<void>();
+		const realStop = CollabHost.prototype.stop;
+		const stopSpy = vi.spyOn(CollabHost.prototype, "stop").mockImplementation(async function (
+			this: CollabHost,
+			reason: string,
+		) {
+			if (reason === "session switched") {
+				teardownEntered.resolve();
+				await releaseTeardown.promise;
+			}
+			await realStop.call(this, reason);
+		});
+
+		try {
+			const startPromise = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+			await teardownEntered.promise;
+
+			const stopping = stopCollabHosting(ctx);
+			releaseTeardown.resolve();
+			await stopping;
+
+			// Without honouring the cancellation the superseded branch retries,
+			// claims a fresh reservation, and publishes a room the stop already
+			// concluded did not exist.
+			await expect(startPromise).rejects.toThrow(/Collab hosting was stopped/);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(hasInFlightCollabHosting(ctx)).toBe(false);
+			expect(relay.hasHost).toBe(false);
+		} finally {
+			releaseTeardown.resolve();
+			stopSpy.mockRestore();
+			startSpy.mockRestore();
+		}
+	});
+
+	it("refuses to publish a room when a /join won the race during the handshake", async () => {
+		const { ctx } = makeCtx();
+		const realStart = CollabHost.prototype.start;
+		const spy = vi.spyOn(CollabHost.prototype, "start").mockImplementation(async function (
+			this: CollabHost,
+			relayUrl: string,
+			webUrl?: string,
+		) {
+			await realStart.call(this, relayUrl, webUrl);
+			ctx.collabGuest = {} as NonNullable<InteractiveModeContext["collabGuest"]>;
+		});
+		try {
+			await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+				/Already in a collab session as a guest/,
+			);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(relay.hasHost).toBe(false);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("refuses to publish a room when a session transition began during the handshake", async () => {
+		// The transition has not committed its id yet, so `getSessionId()` still
+		// reads the outgoing one and the mismatch check below cannot see it.
+		let transitioning = false;
+		const { ctx } = makeCtx({ isSessionTransitionInFlight: () => transitioning });
+		const realStart = CollabHost.prototype.start;
+		const spy = vi.spyOn(CollabHost.prototype, "start").mockImplementation(async function (
+			this: CollabHost,
+			relayUrl: string,
+			webUrl?: string,
+		) {
+			await realStart.call(this, relayUrl, webUrl);
+			transitioning = true;
+		});
+		try {
+			await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+				/session switch is still settling/,
+			);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(relay.hasHost).toBe(false);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("stops a room whose session was rolled back, once the transition settles", async () => {
+		let currentSessionId = "sess-target";
+		let fireSettled: ((outcome: SessionTransitionOutcome) => void) | undefined;
+		const { ctx } = makeCtx({
+			onTransitionSettledRegistered: fire => {
+				fireSettled = fire;
+			},
+		});
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+
+		// A `session_switch` handler hosts against the session the switch just
+		// committed to.
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		expect(host.sessionId).toBe("sess-target");
+		const stopped = Promise.withResolvers<string>();
+		const realStop = CollabHost.prototype.stop;
+		const spy = vi.spyOn(CollabHost.prototype, "stop").mockImplementation(async function (
+			this: CollabHost,
+			reason: string,
+		) {
+			await realStop.call(this, reason);
+			if (this === host) stopped.resolve(reason);
+		});
+		try {
+			// The switch then throws and restores the previous id. That restore
+			// is deliberately silent, so settlement is the only signal the room
+			// gets that its session did not survive.
+			currentSessionId = "sess-previous";
+			if (!fireSettled) throw new Error("publishing must register a transition-settled callback");
+			fireSettled({ rolledBack: true });
+			expect(await stopped.promise).toBe("session switch rolled back");
+			expect(activeCollabHostLinks(ctx)).toBeUndefined();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("stops a room when a same-file reload rolls back, where the session id never changes", async () => {
+		// `reload()` calls switchSession() on the current file, so a rollback
+		// restores the transcript under an unchanged id. An observer comparing
+		// ids sees nothing; only the settled outcome reports it.
+		let fireSettled: ((outcome: SessionTransitionOutcome) => void) | undefined;
+		const { ctx } = makeCtx({
+			onTransitionSettledRegistered: fire => {
+				fireSettled = fire;
+			},
+		});
+		ctx.sessionManager.getSessionId = () => "sess-1";
+
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		expect(host.sessionId).toBe("sess-1");
+		const stopped = Promise.withResolvers<string>();
+		const realStop = CollabHost.prototype.stop;
+		const spy = vi.spyOn(CollabHost.prototype, "stop").mockImplementation(async function (
+			this: CollabHost,
+			reason: string,
+		) {
+			await realStop.call(this, reason);
+			if (this === host) stopped.resolve(reason);
+		});
+		try {
+			if (!fireSettled) throw new Error("publishing must register a transition-settled callback");
+			fireSettled({ rolledBack: true });
+			expect(await stopped.promise).toBe("session switch rolled back");
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("link reads hide a room left over from the previous session", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		expect(activeCollabHostLinks(ctx)).toEqual(collabHostLinks(host));
+
+		currentSessionId = "sess-2";
+		expect(activeCollabHostLinks(ctx)).toBeUndefined();
+		// Reading links must not stop or restart anything.
+		expect(ctx.collabHost).toBe(host);
+	});
+
+	it("stale-host replacement registers in-flight hosting and cancels if stopped during cleanup", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const firstHost = await startHosting(ctx, "ws://localhost:7475");
+		expect(ctx.collabHost).toBe(firstHost);
+
+		currentSessionId = "sess-2";
+
+		// Intercept existing.stop to pause during the stale-host cleanup.
+		const stopDeferred = Promise.withResolvers<void>();
+		const stopStarted = Promise.withResolvers<void>();
+		const realStop = firstHost.stop.bind(firstHost);
+		vi.spyOn(firstHost, "stop").mockImplementation(async function (reason: string) {
+			stopStarted.resolve();
+			await stopDeferred.promise;
+			return realStop(reason);
+		});
+
+		const replacePromise = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+
+		// Wait until stop is entered
+		await stopStarted.promise;
+		try {
+			// hasInFlightCollabHosting must report true across this cleanup window!
+			expect(hasInFlightCollabHosting(ctx)).toBe(true);
+
+			// Now stopCollabHosting lands while cleanup is awaiting
+			const stopPromise = stopCollabHosting(ctx);
+
+			// Allow existing.stop to finish
+			stopDeferred.resolve();
+			await stopPromise;
+
+			// The in-flight replacement must reject with stopped error
+			await expect(replacePromise).rejects.toThrow(/Collab hosting was stopped/);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(hasInFlightCollabHosting(ctx)).toBe(false);
+			expect(relay.hasHost).toBe(false);
+		} finally {
+			stopDeferred.resolve();
+		}
+	});
+
+	it("a superseding start holds the reservation while it cancels the stale one", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+
+		// Pause only the first start, so the second one supersedes a reservation
+		// that is still mid-handshake.
+		const firstEntered = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		let starts = 0;
+		const realStart = CollabHost.prototype.start;
+		const spy = vi.spyOn(CollabHost.prototype, "start").mockImplementation(async function (
+			this: CollabHost,
+			relayUrl: string,
+			webUrl?: string,
+		) {
+			starts += 1;
+			if (starts === 1) {
+				firstEntered.resolve();
+				await releaseFirst.promise;
+			}
+			await realStart.call(this, relayUrl, webUrl);
+		});
+
+		try {
+			const first = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+			await firstEntered.promise;
+			currentSessionId = "sess-2";
+
+			// The superseding call must own the slot the moment it returns, with
+			// no window where a stop lands on an empty map and resolves as a
+			// no-op while this start is suspended on the stale teardown.
+			const second = startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" });
+			expect(hasInFlightCollabHosting(ctx)).toBe(true);
+
+			const stopPromise = stopCollabHosting(ctx);
+			releaseFirst.resolve();
+			await stopPromise;
+
+			await expect(first).rejects.toThrow();
+			await expect(second).rejects.toThrow(/Collab hosting was stopped/);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(hasInFlightCollabHosting(ctx)).toBe(false);
+			expect(relay.hasHost).toBe(false);
+		} finally {
+			releaseFirst.resolve();
+			spy.mockRestore();
+		}
+	});
+
+	it("refuses to publish a room while a join is mid-handshake", async () => {
+		const otherHarness = makeCtx();
+		const targetHost = await startHosting(otherHarness.ctx, "ws://localhost:7475");
+
+		const { ctx } = makeCtx();
+		let currentSessionId = "sess-local";
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const guest = new CollabGuestLink(ctx);
+
+		const guestPaused = Promise.withResolvers<void>();
+		const guestProceed = Promise.withResolvers<void>();
+		// The replica is the live session from here on, which is exactly the
+		// window a published room would bind itself to before being rolled back.
+		vi.spyOn(ctx.session, "switchSession").mockImplementation(async () => {
+			currentSessionId = "sess-replica";
+			guestPaused.resolve();
+			await guestProceed.promise;
+			return true;
+		});
+		vi.spyOn(ctx.session, "newSession").mockImplementation(async () => {
+			currentSessionId = "sess-local";
+			return true;
+		});
+
+		const guestJoinPromise = guest.join(targetHost.link);
+		try {
+			await guestPaused.promise;
+
+			await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+				/collab guest session is still settling/,
+			);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(hasInFlightCollabHosting(ctx)).toBe(false);
+		} finally {
+			guestProceed.resolve();
+			await guestJoinPromise.catch(() => {});
+			await guest.leave("test done");
+		}
+	});
+
+	it("a second concurrent join is refused and cannot release the first one's reservation", async () => {
+		const otherHarness = makeCtx();
+		const targetHost = await startHosting(otherHarness.ctx, "ws://localhost:7475");
+
+		const { ctx } = makeCtx();
+		let currentSessionId = "sess-local";
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const first = new CollabGuestLink(ctx);
+		const second = new CollabGuestLink(ctx);
+
+		const firstPaused = Promise.withResolvers<void>();
+		const firstProceed = Promise.withResolvers<void>();
+		// Only the first join parks here. A second join must be refused before
+		// it gets this far, so leaving it unblocked makes that assertion fail
+		// fast instead of deadlocking on the first join's pause.
+		let switches = 0;
+		vi.spyOn(ctx.session, "switchSession").mockImplementation(async () => {
+			currentSessionId = "sess-replica";
+			switches += 1;
+			if (switches === 1) {
+				firstPaused.resolve();
+				await firstProceed.promise;
+			}
+			return true;
+		});
+		vi.spyOn(ctx.session, "newSession").mockImplementation(async () => {
+			currentSessionId = "sess-local";
+			return true;
+		});
+
+		const firstJoin = first.join(targetHost.link);
+		try {
+			await firstPaused.promise;
+
+			await expect(second.join(targetHost.link)).rejects.toThrow(/Already joining a collab session/);
+			// The refused join must not have released the reservation the first
+			// one still holds, so a hosting start is still refused.
+			await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+				/collab guest session is still settling/,
+			);
+			expect(ctx.collabHost).toBeUndefined();
+		} finally {
+			firstProceed.resolve();
+			await firstJoin.catch(() => {});
+			await first.leave("test done");
+		}
+	});
+
+	it("a join rolls the replica back when a host is published under it", async () => {
+		const otherHarness = makeCtx();
+		const targetHost = await startHosting(otherHarness.ctx, "ws://localhost:7475");
+
+		const { ctx } = makeCtx();
+		let currentSessionId = "sess-local";
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const guest = new CollabGuestLink(ctx);
+
+		const guestPaused = Promise.withResolvers<void>();
+		const guestProceed = Promise.withResolvers<void>();
+		vi.spyOn(ctx.session, "switchSession").mockImplementation(async () => {
+			currentSessionId = "sess-replica";
+			guestPaused.resolve();
+			await guestProceed.promise;
+			return true;
+		});
+		const newSession = vi.spyOn(ctx.session, "newSession").mockImplementation(async () => {
+			currentSessionId = "sess-local";
+			return true;
+		});
+
+		const guestJoinPromise = guest.join(targetHost.link);
+		await guestPaused.promise;
+		// `ctx.collabHost` is a public field, so a host can appear without
+		// going through startCollabHosting. The join must roll the replica back
+		// rather than latch shutdown and strand the user inside it.
+		ctx.collabHost = new CollabHost(ctx);
+		guestProceed.resolve();
+
+		await expect(guestJoinPromise).rejects.toThrow(/Already hosting a collab session/);
+		expect(ctx.collabGuest).toBeUndefined();
+		expect(newSession).toHaveBeenCalled();
+		expect(currentSessionId).toBe("sess-local");
+		// The rollback nests inside the join, so both reservations must have
+		// been released: an unbalanced counter would refuse hosting forever.
+		ctx.collabHost = undefined;
+		const afterRollback = await startHosting(ctx, "ws://localhost:7475");
+		expect(afterRollback.sessionId).toBe("sess-local");
+	});
+
+	it("refuses to publish a room while a guest rollback is still restoring", async () => {
+		const otherHarness = makeCtx();
+		const targetHost = await startHosting(otherHarness.ctx, "ws://localhost:7475");
+
+		const { ctx } = makeCtx();
+		let currentSessionId = "sess-local";
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const guest = new CollabGuestLink(ctx);
+		vi.spyOn(ctx.session, "switchSession").mockImplementation(async () => {
+			currentSessionId = "sess-replica";
+			return true;
+		});
+
+		// Park inside the restore, which is where a session_before_switch
+		// handler would run: ctx.collabGuest is already cleared but the local
+		// session is not back yet.
+		const restoring = Promise.withResolvers<void>();
+		const releaseRestore = Promise.withResolvers<void>();
+		vi.spyOn(ctx.session, "newSession").mockImplementation(async () => {
+			restoring.resolve();
+			await releaseRestore.promise;
+			currentSessionId = "sess-local";
+			return true;
+		});
+		// `leave()` cannot be the join point: CollabSocket.close() fires onClose
+		// synchronously, so the rollback is already running fire-and-forget and
+		// leave() returns as soon as it sees the latch. The last statement of
+		// the rollback is this render, so wait on that instead.
+		const restored = Promise.withResolvers<void>();
+		const realRequestRender = ctx.ui.requestRender;
+		vi.spyOn(ctx.ui, "requestRender").mockImplementation((...args: unknown[]) => {
+			const options = args[1] as { clearScrollback?: boolean } | undefined;
+			if (options?.clearScrollback) restored.resolve();
+			return Reflect.apply(realRequestRender, ctx.ui, args) as void;
+		});
+
+		await guest.join(targetHost.link);
+		expect(ctx.collabGuest).toBe(guest);
+
+		const leaving = guest.leave("test done");
+		try {
+			await restoring.promise;
+			expect(ctx.collabGuest).toBeUndefined();
+
+			await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+				/collab guest session is still settling/,
+			);
+			expect(ctx.collabHost).toBeUndefined();
+		} finally {
+			releaseRestore.resolve();
+			await leaving;
+			await restored.promise;
+		}
+
+		// Once the rollback settles, hosting is allowed again.
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		expect(ctx.collabHost).toBe(host);
+	});
+
+	it("a room whose session changed under it serves no snapshot to an arriving guest", async () => {
+		let currentSessionId = "sess-1";
+		const { ctx } = makeCtx();
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const host = await startHosting(ctx, "ws://localhost:7475");
+		expect(relay.hasHost).toBe(true);
+
+		// The room stays bound to sess-1 while the live session moves on, which
+		// is what a rolled-back join or an out-of-band switch leaves behind.
+		currentSessionId = "sess-2";
+
+		// The guard's observable is the host dropping the room, so wait on that
+		// rather than on a frame that must never arrive. Teardown clears
+		// `ctx.collabHost`, which #teardown does before the socket close lands.
+		const dropped = Promise.withResolvers<void>();
+		const realTeardownProbe = ctx.ui.requestRender;
+		vi.spyOn(ctx.ui, "requestRender").mockImplementation((...args: unknown[]) => {
+			if (!ctx.collabHost) dropped.resolve();
+			return Reflect.apply(realTeardownProbe, ctx.ui, args) as void;
+		});
+
+		const parsed = parseCollabLink(host.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+		const key = await importRoomKey(parsed.key);
+		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+		const frames: CollabFrame[] = [];
+		try {
+			socket.onFrame = frame => frames.push(frame);
+			socket.onOpen = () => socket.send({ t: "hello", proto: COLLAB_PROTO, name: "probe" });
+			socket.connect();
+			await dropped.promise;
+		} finally {
+			socket.close();
+		}
+
+		expect(relay.hasHost).toBe(false);
+		expect(frames).toEqual([]);
+		expect(ctx.collabHost).toBeUndefined();
+	});
+
+	it("an abandoned host does not overwrite active guest collab status with host status", async () => {
+		const harness = makeCtx();
+		const ctx = harness.ctx;
+		ctx.statusLine.setCollabStatus({ role: "guest", participantCount: 2 });
+		expect(harness.collabStatus()).toEqual({ role: "guest", participantCount: 2 });
+
+		const realStart = CollabHost.prototype.start;
+		const spy = vi.spyOn(CollabHost.prototype, "start").mockImplementation(async function (
+			this: CollabHost,
+			relayUrl: string,
+			webUrl?: string,
+		) {
+			await realStart.call(this, relayUrl, webUrl);
+			ctx.collabGuest = {} as NonNullable<InteractiveModeContext["collabGuest"]>;
+		});
+
+		try {
+			await expect(startCollabHosting(ctx, { relayUrl: "ws://localhost:7475" })).rejects.toThrow(
+				/Already in a collab session as a guest/,
+			);
+			expect(ctx.collabHost).toBeUndefined();
+			expect(harness.collabStatus()).toEqual({ role: "guest", participantCount: 2 });
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("rejects startCollab during session_before_switch so extensions cannot hold links for outgoing session", async () => {
+		let currentSessionId = "sess-outgoing";
+		let runnerRef: ExtensionRunner | undefined = undefined;
+		let sessionTransitionInFlight = false;
+		const { ctx } = makeCtx({
+			relayUrl: "ws://localhost:7475",
+			extensionRunner: () => runnerRef,
+			isSessionTransitionInFlight: () => sessionTransitionInFlight,
+		});
+		ctx.sessionManager.getSessionId = () => currentSessionId;
+		const runtime = new ExtensionRuntime();
+		let handlerLinks: CollabHostLinks | undefined;
+		let handlerError: unknown;
+
+		const extension: Extension = {
+			path: "test-collab-ext",
+			resolvedPath: "/test-collab-ext",
+			handlers: new Map([
+				[
+					"session_before_switch",
+					[
+						async () => {
+							try {
+								handlerLinks = await runtime.startCollab();
+							} catch (err) {
+								handlerError = err;
+							}
+						},
+					],
+				],
+			]),
+			tools: new Map(),
+			assistantThinkingRenderers: [],
+			fileWriteFallbackHandlers: [],
+			fileDeleteFallbackHandlers: [],
+			messageRenderers: new Map(),
+			composerShapes: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		};
+
+		const runner = new ExtensionRunner(
+			[extension],
+			runtime,
+			tempDir.path(),
+			SessionManager.inMemory(),
+			modelRegistry,
+		);
+		runnerRef = runner;
+		runner.initialize(
+			{
+				...headlessActions(),
+				startCollab: async options => collabHostLinks(await startCollabHosting(ctx, options)),
+				getCollabLinks: () => activeCollabHostLinks(ctx),
+				stopCollab: async () => {
+					await stopCollabHosting(ctx);
+				},
+			},
+			headlessContextActions(),
+		);
+
+		sessionTransitionInFlight = true;
+		await runner.emit({
+			type: "session_before_switch",
+			reason: "new",
+		});
+
+		// During session_before_switch, startCollab must reject and leave collabHost unset.
+		expect(handlerError).toBeInstanceOf(Error);
+		expect((handlerError as Error).message).toMatch(/session switch is still settling/);
+		expect(handlerLinks).toBeUndefined();
+		expect(ctx.collabHost).toBeUndefined();
+
+		// The guard clears once the session commits, so the post-switch hook,
+		// which runs after the new id has committed, can host normally.
+		sessionTransitionInFlight = false;
+		currentSessionId = "sess-target";
+		let postSwitchLinks: CollabHostLinks | undefined;
+		let postSwitchError: unknown;
+		extension.handlers.set("session_switch", [
+			async () => {
+				try {
+					postSwitchLinks = await runtime.startCollab();
+				} catch (err) {
+					postSwitchError = err;
+				}
+			},
+		]);
+		await runner.emit({ type: "session_switch", reason: "new", previousSessionFile: undefined });
+		startedHosts.push(ctx.collabHost!);
+		expect(postSwitchError).toBeUndefined();
+		expect(postSwitchLinks).toBeDefined();
+		expect(ctx.collabHost?.sessionId).toBe("sess-target");
+	});
+});
+
+describe("collab hosting on non-interactive extension hosts", () => {
+	it("startCollab and stopCollab throw, getCollabLinks answers undefined", async () => {
+		const runtime = new ExtensionRuntime();
+		const runner = new ExtensionRunner([], runtime, tempDir.path(), SessionManager.inMemory(), modelRegistry);
+		runner.initialize(headlessActions(), headlessContextActions());
+		// The fallback throws synchronously (like the loader's pre-init stubs); the
+		// real action rejects. Either way an awaiting caller sees the same error.
+		expect(() => runtime.startCollab()).toThrow(/does not support collab hosting/);
+		expect(runtime.getCollabLinks()).toBeUndefined();
+		expect(() => runtime.stopCollab()).toThrow(/does not support collab hosting/);
+	});
+
+	it("an interactive host's wired actions start, expose, and stop a real room", async () => {
+		const { ctx } = makeCtx({ relayUrl: "ws://localhost:7475" });
+		const runtime = new ExtensionRuntime();
+		const runner = new ExtensionRunner([], runtime, tempDir.path(), SessionManager.inMemory(), modelRegistry);
+		runner.initialize(
+			{
+				...headlessActions(),
+				startCollab: async options => collabHostLinks(await startCollabHosting(ctx, options)),
+				getCollabLinks: () => activeCollabHostLinks(ctx),
+				stopCollab: async () => {
+					await stopCollabHosting(ctx);
+				},
+			},
+			headlessContextActions(),
+		);
+
+		const links = await runtime.startCollab();
+		startedHosts.push(ctx.collabHost!);
+		// The room the extension was handed is real: a guest can join with it.
+		const welcome = await expectGuestWelcome(links.link);
+		expect(welcome.t).toBe("welcome");
+		expect(runtime.getCollabLinks()).toEqual(links);
+
+		await runtime.stopCollab();
+		expect(ctx.collabHost).toBeUndefined();
+		expect(runtime.getCollabLinks()).toBeUndefined();
+		expect(relay.hasHost).toBe(false);
+	});
+
+	it("the uninitialized runtime refuses before initialize wires actions", () => {
+		const runtime = new ExtensionRuntime();
+		expect(() => runtime.startCollab()).toThrow(ExtensionRuntimeNotInitializedError);
+		expect(() => runtime.getCollabLinks()).toThrow(ExtensionRuntimeNotInitializedError);
+	});
+});

--- a/packages/coding-agent/test/collab/helpers/in-memory-relay.ts
+++ b/packages/coding-agent/test/collab/helpers/in-memory-relay.ts
@@ -84,6 +84,11 @@ export class InMemoryRelay {
 	readonly #guests = new Map<number, FakeWebSocket>();
 	#nextPeerId = 1;
 
+	/** Whether a host socket is connected right now; lets a test assert a room never opened. */
+	get hasHost(): boolean {
+		return this.#host !== null;
+	}
+
 	connect(ws: FakeWebSocket): void {
 		if (ws.role === "host") {
 			this.#host = ws;

--- a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
+++ b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
@@ -53,6 +53,17 @@ function createRuntimeHarness(options?: { collabHost?: NonNullable<InteractiveMo
 		showError,
 		present,
 		settings: { get: settingsGet },
+		// startCollabHosting stamps every reservation with the live session id.
+		sessionManager: { getSessionId: () => "sess-1" },
+		// startCollabHosting refuses while session transitions are in flight, and
+		// subscribes to settlement so a rolled-back session's room is reaped.
+		session: {
+			isSessionTransitionInFlight: false,
+			registerSessionTransitionSettledCallback: () => () => {},
+		},
+		// A published host installs its status segment and requests a render.
+		statusLine: { setCollabStatus: () => {}, invalidate: () => {} },
+		ui: { requestRender: () => {} },
 		collabHost: options?.collabHost,
 	} as unknown as InteractiveModeContext;
 	return {


### PR DESCRIPTION
## Why

`/collab` is the only way to start a room. The slash command builds `new CollabHost(ctx)` and calls `host.start(relayUrl, webUrl)`, and nothing else can reach it, so an extension that wants a room has to inject `/collab` as user message text. That puts the room secret, a credential that grants prompting and interrupting, into the transcript.

The case that drove this: a local daemon wants to let a phone co-drive a live terminal session. Takeover is the wrong shape there, because the operator is still typing in that terminal. Collab is exactly right, and it already does everything needed, except that a room can only be started by a human.

## Change

- `pi.startCollab({ relayUrl? })` returns `{ link, viewLink, webLink, webViewLink }`.
- `pi.getCollabLinks()` reads the room this session already hosts.
- `pi.stopCollab()` tears it down.

`/collab` and the API both funnel through a new `startCollabHosting`, so relay resolution, the guest-session refusal, and the one-room-per-session rule live in one place. The command keeps its presentation, printing the link and QR code; the API returns links and prints nothing, because a link is a credential and a status line is somewhere it would persist.

It refuses rather than guesses: already a guest in someone else's room, already hosting on a different relay, no relay configured, or a relay it cannot reach. Same relay is idempotent and returns the existing room. Non-interactive hosts get a throwing fallback, following the service-tier optional-action convention, and `getCollabLinks` answers `undefined` there.

## Tests

`packages/coding-agent/test/collab/extension-hosting.test.ts`, sixteen tests over an in-memory relay, each proven able to fail by mutation. They cover both link strengths carrying the right secret sizes (48 bytes full, 32 view), a real guest reaching `welcome`, same-relay reuse, the different-relay and guest refusals, the `collab.relayUrl` fallback, scheme-less relay defaulting to `wss`, non-localhost `ws` rejection, stop-and-restart minting a fresh room, that the API path prints nothing, and the three concurrency cases added for review below.

Verified on this base: `test/collab/` 95 pass, `check:types` clean.

## Review feedback

Rebased onto current `main` and addressed the in-flight start race, which was real: two `pi.startCollab()` calls that overlap both saw `ctx.collabHost` undefined and opened separate rooms, and tearing one down cleared the reference to the other.

- `startCollabHosting` now reserves the in-flight start on the context before awaiting, so a concurrent caller joins the same room. The reservation is taken synchronously relative to the existing-host check, and released whether the start resolves or throws, so a failed start does not wedge later attempts. A concurrent call naming a different relay awaits the in-flight one and then gets the same already-hosting refusal as the settled case.
- `CollabHost.#teardown()` clears `ctx.collabHost` and the status segment only when it owns them, so stopping a host that is not the current one no longer strands the live room without a handle.
- Three regression tests: concurrent same-relay starts return one host and one room; a concurrent different-relay start rejects and leaves the first room intact; stopping a non-current host leaves `ctx.collabHost` on the live one. All three fail against the pre-fix source (`expect(first).toBe(second)`, `expected "rejected" received "fulfilled"`, and `ctx.collabHost` reading `undefined`) and pass after.
- Added the `[Unreleased]` changelog entry.

## Provenance

Written against an older base, rebased onto current `main`. It has been exercised end to end outside these tests: a real omp TUI loaded an extension that called `pi.startCollab()` at `session_start` with no slash command typed, and a guest joined with the returned link and completed the handshake. A byte sweep of that run's home found the room key and room id in exactly one file, the probe's own output, and in no session file, log, or database.

---

## Update: rebased onto current main

Rebased onto `main` (`8fad7f1006`) as a single commit. The 702 commits of drift did not intersect any of this PR's hunks: upstream's collab changes in that window were `MAX_PENDING_UI_REQUESTS` and the guest-UI reconnection ack in `guest.ts`, plus ask-dialog sanitize/dedup in `extension-ui-controller.ts`, all absorbed without touching the concurrency guards here.

Every guard from the earlier review rounds was re-verified in place after the rebase, position included, not just presence: the synchronous `inFlightStarts` reservation before the first await (`start-hosting.ts:162`), the `COLLAB_STOPPED_ERROR` checks around each await (`:168`, `:173`, `:181`, `:209`), session-gated `activeCollabHostLinks` (`:63`), `host.publishStatus()` moved out of `CollabHost.start()` (`:213`), the `finally` reservation release (`:219`), and `stopCollabHosting` cancelling an in-flight start (`:241`).

The changelog entry had been stranded in the `[18.1.15]` section by an earlier rebase as that section aged into release; it now sits under `[Unreleased]` with the attribution suffix, and no released section is touched.

**Testing on this head:** `bun run check:ts` exits 0. `bun test packages/coding-agent/test/collab/` plus `collab-qrcode.test.ts`: 126 pass, 0 fail across 16 files, `extension-hosting.test.ts` 31 of those. The earlier body said 95 and 109; 126 is the current number.

### Follow-up round: `session_before_switch` guard

`startCollabHosting` now refuses while a `session_before_switch` event is being emitted (`start-hosting.ts:104-106`), so an extension calling `pi.startCollab()` from that hook cannot bind a room to the outgoing session. The state lives on `ExtensionRunner` (`runner.ts:532-537`, set in a `try`/`finally` around the emit at `:1375-1440`) and `AgentSession` exposes it in seven lines (`agent-session.ts:10914-10919`). Tests pin both directions: refused from the pre-switch hook, allowed from the post-switch `session_switch` hook where the id has already committed. Collab suite 127 pass / 0 fail across 16 files.

**Update on the transition window:** an earlier round of this PR guarded only the `session_before_switch` emit, which left the gap between that emit returning and the session id committing. That is now closed. `AgentSession` carries a transition guard (`agent-session.ts:10925-10943`) held from method entry to the id commit in `newSession()`, the fork path and `switchSession()`, using a `using` declaration so early returns, throws and the `switchSession()` rollback all release it without restructuring those methods. It is 31 added lines, no deletions, no reindentation, and it replaced the runner-side flag rather than sitting alongside it. Proven in `agent-session-new-session-boundary.test.ts` against a real `newSession()`: true inside the before-switch handler, still true at a later await before the id commits, false inside the `session_switch` handler. 132 pass / 0 fail across the collab suite, the `/collab` QR tests and that boundary suite; `bun run check:ts` exits 0.

**Session-rollback teardown.** A `session_switch` handler that hosts during a resume binds its room to the target session id, and a later rollback-capable step in `switchSession()` can then restore the previous id. The restore is deliberately silent, so there was no signal the room could act on. Closed by splitting the transition guard's two jobs: `commit()` releases the in-flight flag at the id commit so post-switch hooks are not blocked, while the guard's disposal, which a `using` declaration runs on every exit path including rollback, fires a new `registerSessionTransitionSettledCallback` channel (`agent-session.ts:10934-10944`). Collab subscribes once per context and stops any room whose session did not survive (`start-hosting.ts:67-91`). The channel is additive; `registerSessionChangeCallback` is untouched. Covered by a collab test that rolls the id back and asserts the room stops, and an `AgentSession` test proving settlement fires for a cancelled transition that changes no id.
