### PR TITLE
fix(tui): repaint plugins settings tab after async list mounts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Settings → Plugins tab no longer renders empty on first open of a fresh session; the async plugin list now schedules a repaint when it mounts ([#9526](https://github.com/can1357/oh-my-pi/issues/9526)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -694,6 +694,12 @@ export class PluginSettingsComponent extends Container {
 		});
 
 		this.addChild(this.#viewComponent);
+
+		// The list mounts after the first frame (npm + marketplace listing is
+		// async and this method runs fire-and-forget), so ask for a repaint —
+		// otherwise the tab stays blank until an unrelated event forces a
+		// render, e.g. reopening /settings (issue #9526).
+		this.callbacks.requestRender?.();
 	}
 
 	#showPluginDetail(plugin: InstalledPlugin): void {

--- a/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
+++ b/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
@@ -190,6 +190,36 @@ describe("PluginSettingsComponent", () => {
 		}
 	});
 
+	it("schedules a render frame once the async plugin list mounts", async () => {
+		const npmListSpy = spyOn(PluginManager.prototype, "list").mockResolvedValue([]);
+		const listInstalledSpy = spyOn(MarketplaceManager.prototype, "listInstalledPlugins").mockResolvedValue([
+			marketplace("late@mkt"),
+		]);
+
+		try {
+			const mounted = Promise.withResolvers<void>();
+			let renders = 0;
+			const component = new PluginSettingsComponent(process.cwd(), {
+				onClose: () => {},
+				onPluginChanged: () => {},
+				requestRender: () => {
+					renders++;
+					mounted.resolve();
+				},
+			});
+
+			// No manual render() poll: the real TUI only repaints when the
+			// component asks for a frame. Without requestRender the list stays
+			// blank until an unrelated event forces a redraw (reopening /settings).
+			await mounted.promise;
+			expect(renders).toBeGreaterThanOrEqual(1);
+			expect(stripVTControlCharacters(component.render(120).join("\n"))).toContain("late@mkt");
+		} finally {
+			npmListSpy.mockRestore();
+			listInstalledSpy.mockRestore();
+		}
+	});
+
 	it("closes on Escape while the plugin list is still loading", async () => {
 		const pending = Promise.withResolvers<InstalledPlugin[]>();
 		const npmListSpy = spyOn(PluginManager.prototype, "list").mockReturnValue(pending.promise);


### PR DESCRIPTION
## Repro
Open `/settings` in a fresh session and switch to the Plugins tab: it shows no plugins. Closing settings and reopening `/settings` then lists them. Focused test:
`bun test test/modes/components/plugin-list-marketplace.test.ts -t "schedules a render frame"` hangs on the unfixed code because the component never asks for a repaint after the list loads.

## Cause
`PluginSettingsComponent.#showPluginList` (`packages/coding-agent/src/modes/components/plugin-settings.ts`) is invoked fire-and-forget from the constructor. It `await`s `PluginManager.list()` + `MarketplaceManager.listInstalledPlugins()`, then `addChild`s the `PluginListComponent`. The first frame renders before those promises resolve, and unlike the marketplace-detail path (which passes `requestRender` through), this method never called the plumbed `PluginSettingsCallbacks.requestRender`. With no frame scheduled, the tab stayed blank until an unrelated render — reopening `/settings` — forced a redraw.

## Fix
- Call `this.callbacks.requestRender?.()` in `#showPluginList` right after `addChild(this.#viewComponent)`, so the tab repaints as soon as the async plugin data resolves.
- Add a regression test asserting the component schedules a render frame once the list mounts, without manually polling `render()` (the poll masked the bug in existing tests).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/modes/components/plugin-list-marketplace.test.ts` → 13 pass, 0 fail. The new test hangs before the fix and passes after.

Fixes #9526