### PR TITLE
fix(agent): resumed maintenance after speculative handoff

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Thinking-only length stops that overlap speculative handoff now resume compaction recovery instead of leaving the autonomous run idle.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2958,7 +2958,16 @@ export class AgentSession {
 			if (this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp === msg.timestamp) {
 				this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp = undefined;
 				this.#lastSuccessfulYieldToolCallId = undefined;
-				const speculationCompletion = this.#maintenance.speculationCompletion;
+				const model = this.model;
+				const requiresSpeculativeRecovery =
+					model !== undefined &&
+					msg.provider === model.provider &&
+					msg.model === model.id &&
+					(msg.stopReason === "length" ||
+						(msg.stopReason === "error" && AIError.isContextOverflow(msg, model.contextWindow ?? 0)));
+				const speculationCompletion = requiresSpeculativeRecovery
+					? this.#maintenance.speculationCompletion
+					: undefined;
 				if (!speculationCompletion) {
 					maintenanceRoute("skip-post-turn-maintenance");
 					await emitAgentEndNotification();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -667,6 +667,7 @@ export class AgentSession {
 	// Cursor exec, TUI listeners) is held back. Without this, a client that resumes
 	// on `agent_end` can fire its next `prompt` before #promptWithMessage's finally
 	#promptGeneration = 0;
+	#promptSequence = 0;
 	#pendingAgentEndEmit: AgentSessionEvent | undefined;
 	#inFlightSettledCallbacks: Array<() => void | Promise<void>> = [];
 	#sessionStopContinuationCount = 0;
@@ -2957,9 +2958,28 @@ export class AgentSession {
 			if (this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp === msg.timestamp) {
 				this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp = undefined;
 				this.#lastSuccessfulYieldToolCallId = undefined;
-				maintenanceRoute("skip-post-turn-maintenance");
-				await emitAgentEndNotification();
-				return;
+				const speculationCompletion = this.#maintenance.speculationCompletion;
+				if (!speculationCompletion) {
+					maintenanceRoute("skip-post-turn-maintenance");
+					await emitAgentEndNotification();
+					return;
+				}
+
+				const promptSequence = this.#promptSequence;
+				const promptGeneration = this.#promptGeneration;
+				maintenanceRoute("await-speculative-compaction");
+				await speculationCompletion;
+				if (
+					this.#isDisposed ||
+					this.#abortInProgress ||
+					this.#promptGeneration !== promptGeneration ||
+					this.#promptSequence !== promptSequence
+				) {
+					maintenanceRoute("skip-superseded-speculative-maintenance");
+					await emitAgentEndNotification();
+					return;
+				}
+				maintenanceRoute("resume-post-turn-maintenance");
 			}
 
 			const activeGoal = this.#goalModeState?.enabled === true && this.#goalModeState.goal.status === "active";
@@ -5702,6 +5722,7 @@ export class AgentSession {
 		// the typed text back to the host instead of losing it.
 		this.#beginInFlight();
 		const generation = this.#promptGeneration;
+		this.#promptSequence++;
 		try {
 			await this.#recovery.maybeRestoreRetryFallbackPrimary();
 			if (!(await this.#runUsageAwarePreflightForNextModelCall())) return false;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -370,6 +370,11 @@ export class SessionMaintenance {
 		return run.armed ? "armed" : "running";
 	}
 
+	/** Completion of the current speculative pass, used to resume maintenance skipped during its handoff. */
+	get speculationCompletion(): Promise<void> | undefined {
+		return this.#speculation?.promise;
+	}
+
 	/** Abort and discard any in-flight or armed speculative compaction. */
 	cancelSpeculation(): void {
 		const run = this.#speculation;

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { scheduler } from "node:timers/promises";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import { type CompactionPreparation, resolveThresholdTokens, shouldCompact } from "@oh-my-pi/pi-agent-core/compaction";
@@ -924,6 +925,88 @@ describe("AgentSession auto-compaction progress guard", () => {
 		expect(sessionManager.getBranch().at(-1)).toMatchObject({
 			type: "compaction",
 			summary: "handoff document",
+		});
+		expect(sessionManager.getBranch()).not.toContainEqual(
+			expect.objectContaining({
+				type: "message",
+				message: expect.objectContaining({
+					role: "assistant",
+					stopReason: "length",
+				}),
+			}),
+		);
+	});
+
+	it("resumes a thinking-only length stop after an overlapping speculative handoff", async () => {
+		session.settings.set("compaction.methodOrder", ["handoff"]);
+		session.settings.set("compaction.enabled", true);
+		session.settings.set("compaction.asyncEnabled", true);
+		session.settings.set("compaction.thresholdTokens", 150_000);
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.set("contextPromotion.enabled", false);
+		compactHookEnabled = false;
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const handoffStarted = Promise.withResolvers<void>();
+		const handoffResult = Promise.withResolvers<string>();
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockImplementation(async () => {
+			handoffStarted.resolve();
+			return handoffResult.promise;
+		});
+
+		const speculativeTrigger = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "working" }],
+			api: "anthropic-messages" as const,
+			provider: "anthropic" as const,
+			model: "claude-sonnet-4-5",
+			stopReason: "stop" as const,
+			usage: {
+				input: 143_000,
+				output: 1_000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 144_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		sessionManager.appendMessage(speculativeTrigger);
+		session.agent.emitExternalEvent({ type: "message_end", message: speculativeTrigger });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [speculativeTrigger] });
+		await handoffStarted.promise;
+		expect(session.compactionSpeculation).toBe("running");
+
+		await session.waitForIdle();
+		const lengthStop = {
+			role: "assistant" as const,
+			content: [{ type: "thinking" as const, thinking: "unfinished reasoning" }],
+			api: "anthropic-messages" as const,
+			provider: "anthropic" as const,
+			model: "claude-sonnet-4-5",
+			stopReason: "length" as const,
+			usage: {
+				input: 150_000,
+				output: 50_000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 200_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: speculativeTrigger.timestamp + 1,
+		};
+		sessionManager.appendMessage(lengthStop);
+		session.agent.emitExternalEvent({ type: "message_end", message: lengthStop });
+		await scheduler.yield();
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [lengthStop] });
+		await scheduler.yield();
+
+		handoffResult.resolve("speculative handoff");
+		await session.waitForIdle();
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(sessionManager.getBranch().at(-1)).toMatchObject({
+			type: "compaction",
+			summary: "speculative handoff",
 		});
 		expect(sessionManager.getBranch()).not.toContainEqual(
 			expect.objectContaining({

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -937,7 +937,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 		);
 	});
 
-	it("resumes a thinking-only length stop after an overlapping speculative handoff", async () => {
+	it("settles an overlapping successful stop but resumes a thinking-only length stop", async () => {
 		session.settings.set("compaction.methodOrder", ["handoff"]);
 		session.settings.set("compaction.enabled", true);
 		session.settings.set("compaction.asyncEnabled", true);
@@ -977,6 +977,34 @@ describe("AgentSession auto-compaction progress guard", () => {
 		expect(session.compactionSpeculation).toBe("running");
 
 		await session.waitForIdle();
+		const ordinaryStop = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "finished" }],
+			api: "anthropic-messages" as const,
+			provider: "anthropic" as const,
+			model: "claude-sonnet-4-5",
+			stopReason: "stop" as const,
+			usage: {
+				input: 143_000,
+				output: 2_000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 145_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: speculativeTrigger.timestamp + 1,
+		};
+		const ordinaryAgentEnd = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "agent_end") ordinaryAgentEnd.resolve();
+		});
+		sessionManager.appendMessage(ordinaryStop);
+		session.agent.emitExternalEvent({ type: "message_end", message: ordinaryStop });
+		await scheduler.yield();
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [ordinaryStop] });
+		await ordinaryAgentEnd.promise;
+		expect(session.compactionSpeculation).toBe("running");
+
 		const lengthStop = {
 			role: "assistant" as const,
 			content: [{ type: "thinking" as const, thinking: "unfinished reasoning" }],
@@ -992,7 +1020,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 				totalTokens: 200_000,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
-			timestamp: speculativeTrigger.timestamp + 1,
+			timestamp: speculativeTrigger.timestamp + 2,
 		};
 		sessionManager.appendMessage(lengthStop);
 		session.agent.emitExternalEvent({ type: "message_end", message: lengthStop });


### PR DESCRIPTION
## Repro
A gated speculative handoff followed by a thinking-only `stopReason: "length"` reproduces the lost continuation with `bun test packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts --test-name-pattern "overlapping speculative handoff"`: before the fix the handoff arms, but `Agent.continue` is never called.

## Cause
`AgentSession.#processAgentEvent` in `packages/coding-agent/src/session/agent-session.ts` returned from `skip-post-turn-maintenance` whenever `SessionHandoff` was generating. `SessionMaintenance.#runSpeculation` could subsequently arm the handoff result, but no edge resumed the skipped `length` recovery pass, leaving the autonomous run idle.

## Fix
- Expose the active speculative pass completion from `SessionMaintenance`.
- Await that pass when post-turn maintenance was skipped, then resume normal compaction and retry routing.
- Yield recovery ownership when an abort or a newer prompt supersedes the waiting turn.
- Cover a signed-thinking-shaped `length` stop overlapping a gated speculative handoff.

## Verification
`bun test packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts packages/coding-agent/test/compaction-speculation.test.ts` — 41 passed, 0 failed. `bun run check:types` in `packages/coding-agent` passed. The pre-publish `bun check` gate also passed.

Fixes #9529