### PR TITLE
fix(settings): non-object project leaves no longer shadow settings groups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Project settings from shared capability files (e.g. `.claude/settings.json`) no longer shadow an entire settings group when a foreign non-object leaf collides with a group prefix — Claude Code's `"tui": "fullscreen"` used to silently replace every `tui.*` setting for sessions rooted in that project. Such values are now dropped with a warning naming the setting and source file.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -141,6 +141,52 @@ function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
 	current[segments[segments.length - 1]] = value;
 }
 
+/**
+ * Dotted-path prefixes that name settings groups (e.g. "tui" for "tui.*").
+ * A prefix may simultaneously be a schema leaf ("model", "providers", …);
+ * those accept scalar values and are excluded from shadow detection.
+ */
+const SETTINGS_GROUP_ONLY_PREFIXES: Readonly<Record<string, true>> = (() => {
+	const prefixes: Record<string, true> = {};
+	for (const key of Object.keys(SETTINGS_SCHEMA)) {
+		for (let dot = key.indexOf("."); dot !== -1; dot = key.indexOf(".", dot + 1)) {
+			prefixes[key.slice(0, dot)] = true;
+		}
+	}
+	for (const key of Object.keys(SETTINGS_SCHEMA)) delete prefixes[key];
+	return prefixes;
+})();
+
+/**
+ * Drop entries from capability-provided project settings whose non-object
+ * value would shadow an entire settings group. `.claude/settings.json` is
+ * shared with other tools, and a foreign leaf like `"tui": "fullscreen"`
+ * deep-merges over omp's `tui` group, silently replacing every `tui.*`
+ * setting for sessions rooted in that project. Values at schema leaves,
+ * unknown keys, and well-formed nested objects pass through unchanged.
+ */
+export function dropSettingsGroupShadows(data: RawSettings, sourcePath: string, basePrefix = ""): RawSettings {
+	const result: RawSettings = {};
+	for (const key of Object.keys(data)) {
+		const value = data[key];
+		const path = basePrefix === "" ? key : `${basePrefix}.${key}`;
+		if (!Object.hasOwn(SETTINGS_GROUP_ONLY_PREFIXES, path)) {
+			result[key] = value;
+			continue;
+		}
+		if (typeof value !== "object" || value === null || Array.isArray(value)) {
+			logger.warn("Settings: ignoring project setting that would shadow a settings group", {
+				setting: path,
+				value,
+				source: sourcePath,
+			});
+			continue;
+		}
+		result[key] = dropSettingsGroupShadows(value as RawSettings, sourcePath, path);
+	}
+	return result;
+}
+
 export function normalizeProviderMaxInFlightRequests(value: unknown): Record<string, number> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
 	const normalized: Record<string, number> = {};
@@ -1365,7 +1411,7 @@ export class Settings {
 			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
 			for (const item of result.items as SettingsCapabilityItem[]) {
 				if (item.level === "project") {
-					merged = this.#deepMerge(merged, item.data as RawSettings);
+					merged = this.#deepMerge(merged, dropSettingsGroupShadows(item.data as RawSettings, item.path));
 					if (Object.hasOwn(item.data, "shellPath")) shellPathSource = item.path;
 				}
 			}

--- a/packages/coding-agent/test/settings-group-shadowing.test.ts
+++ b/packages/coding-agent/test/settings-group-shadowing.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { dropSettingsGroupShadows } from "@oh-my-pi/pi-coding-agent/config/settings";
+
+describe("dropSettingsGroupShadows", () => {
+	it("drops a non-object leaf that would shadow a settings group", () => {
+		// `.claude/settings.json` is shared with other tools; Claude Code's own
+		// `"tui": "fullscreen"` must not replace omp's whole `tui.*` group.
+		const result = dropSettingsGroupShadows({ tui: "fullscreen" }, "/proj/.claude/settings.json");
+		expect(result).toEqual({});
+	});
+
+	it("keeps well-formed nested objects for a settings group", () => {
+		const result = dropSettingsGroupShadows(
+			{ tui: { resizeScrollback: "preserve" } },
+			"/proj/.claude/settings.json",
+		);
+		expect(result).toEqual({ tui: { resizeScrollback: "preserve" } });
+	});
+
+	it("drops nested non-object shadows without discarding valid siblings", () => {
+		const result = dropSettingsGroupShadows(
+			{ auth: { broker: "nonsense" }, autoResume: true },
+			"/proj/.claude/settings.json",
+		);
+		expect(result).toEqual({ auth: {}, autoResume: true });
+	});
+
+	it("drops Claude Code's top-level model string, which would shadow omp's model.* group", () => {
+		// Claude Code writes `"model": "opus"` at the top level; omp has no bare
+		// `model` leaf, only `model.*` settings, so the string is a shadow too.
+		const result = dropSettingsGroupShadows({ model: "opus" }, "/proj/.claude/settings.json");
+		expect(result).toEqual({});
+	});
+	it("passes unknown keys through untouched", () => {
+		const result = dropSettingsGroupShadows(
+			{ permissions: { allow: ["Bash"] }, $schema: "https://json.schemastore.org/claude-code-settings.json" },
+			"/proj/.claude/settings.json",
+		);
+		expect(result).toEqual({
+			permissions: { allow: ["Bash"] },
+			$schema: "https://json.schemastore.org/claude-code-settings.json",
+		});
+	});
+
+	it("preserves arrays at non-group paths", () => {
+		const result = dropSettingsGroupShadows({ cycleOrder: ["a", "b"] }, "/proj/.claude/settings.json");
+		expect(result).toEqual({ cycleOrder: ["a", "b"] });
+	});
+});


### PR DESCRIPTION
I discovered this while running on a remote machine that requires tui re-configuration for high performance, which the `.claude/settings.json` merging clobbers.

## Bug

The Claude-compat settings provider (`discovery/claude.ts`) parses `.claude/settings.json` and hands the **whole raw object** to the settings capability; `Settings.#readProjectSettings` deep-merges every project-level item, and `#deepMerge` lets a non-object override replace an object wholesale. Nothing between `JSON.parse` and the merge filters fields, so any foreign leaf that collides with an omp settings-group prefix silently wipes that entire group for sessions rooted in the project.

This is not hypothetical — Claude Code's own documented settings collide twice:

- `"tui": "fullscreen"` (Claude Code's terminal mode) replaces omp's entire `tui.*` group
- `"model": "opus"` collides with omp's `model.*` group the same way

Repro against a released build:

```bash
mkdir -p /tmp/x/agent /tmp/x/proj/.claude
printf 'tui:\n  resizeScrollback: preserve\n' > /tmp/x/agent/config.yml
printf '{"tui": "fullscreen"}' > /tmp/x/proj/.claude/settings.json
cd /tmp/x/proj && PI_CODING_AGENT_DIR=/tmp/x/agent omp config get tui.resizeScrollback
# → append (the default) — the configured "preserve" is silently gone
```

Remove the `"tui"` key and the same command prints `preserve`. There is no warning or any other indication; the settings just stop applying in that project.

## Fix (conservative)

Drop capability-provided values that are non-objects sitting at a dotted-path group prefix before the merge, and warn with the setting name and source file:

```
Settings: ignoring project setting that would shadow a settings group  setting=tui value=fullscreen source=/proj/.claude/settings.json
```

Group prefixes are derived from `SETTINGS_SCHEMA` at module init. Paths that are simultaneously schema leaves are exempt (none exist today; the guard stays correct if one is added). Schema leaves, unknown keys, and well-formed nested objects pass through unchanged, so legitimate Claude-compat settings are unaffected.

## Alternative, if you prefer it

The deeper issue is that the Claude/Cursor/Codex providers merge a foreign tool's entire config and rely on the namespaces never colliding. A stricter fix is a per-provider whitelist of the fields omp actually supports, translating known keys and dropping the rest. That's a bigger behavioral change, so this PR takes the minimal guard; happy to rework it into the whitelist shape instead if that's the direction you want.

## Verification

- Before/after repro above: unpatched returns `append` (shadowed), patched returns `preserve` and logs the warning.
- `test/settings-group-shadowing.test.ts`: 6 unit tests covering the shadow drop, nested shadows, dual leaf/prefix passthrough, unknown keys, and arrays.
- `tsc --noEmit` and biome clean on the touched files.
