### PR TITLE
fix(browsers): extract managed chrome past 64 MiB member cap

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Managed Chrome-for-Testing installs no longer fail extracting the ~269 MB `chrome` binary against the default 64 MiB archive-member cap; the trusted browser download now extracts with a ceiling sized for it. ([#9534](https://github.com/can1357/oh-my-pi/issues/9534))
+
 ## [18.0.1] - 2026-08-23
 
 ### Fixed

--- a/packages/utils/src/browsers.ts
+++ b/packages/utils/src/browsers.ts
@@ -4,10 +4,22 @@ import type * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { extractArchive } from "./ar";
+import { type ArchiveLimits, extractArchive } from "./ar";
 
 const CHROME_FOR_TESTING_BASE_URL = "https://storage.googleapis.com/chrome-for-testing-public";
 const CHROME_METADATA_BASE_URL = "https://googlechromelabs.github.io/chrome-for-testing";
+
+/**
+ * Archive ceilings for the managed browser download. The default archive
+ * limits (64 MiB per member / 256 MiB in memory) guard against attacker-
+ * controlled archives, but the Chrome-for-Testing binary is a trusted
+ * first-party download whose `chrome` executable already exceeds both
+ * (~269 MB and growing), so extraction gets a ceiling sized for it.
+ */
+const BROWSER_ARCHIVE_LIMITS: Partial<ArchiveLimits> = {
+	maxMemberSize: 1024 * 1024 * 1024,
+	maxInMemorySize: 1024 * 1024 * 1024,
+};
 
 /** Supported browser products. */
 export enum Browser {
@@ -242,7 +254,7 @@ export async function install(options: InstallOptions): Promise<InstalledBrowser
 			archivePath,
 			options.downloadProgressCallback,
 		);
-		await extractArchive(archivePath, stagingPath);
+		await extractArchive(archivePath, stagingPath, { limits: BROWSER_ARCHIVE_LIMITS });
 		await fsp.mkdir(path.dirname(installPath), { recursive: true });
 		await fsp.rm(installPath, { recursive: true, force: true });
 		await fsp.rename(stagingPath, installPath);

--- a/packages/utils/test/browsers.test.ts
+++ b/packages/utils/test/browsers.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { encodeArchive } from "../src/ar";
 import {
 	Browser,
 	BrowserPlatform,
@@ -128,6 +129,28 @@ test("install streams and extracts stored, deflated, nested, executable, and sym
 		expect(progress.length).toBeGreaterThan(0);
 		expect(progress.at(-1)?.downloadedBytes).toBe(fixture.size);
 		expect(progress.at(-1)?.totalBytes).toBe(fixture.size);
+	} finally {
+		server.stop(true);
+	}
+});
+
+test("install extracts a member larger than the default 64 MiB archive cap", async () => {
+	// Regression for #9534: the managed Chrome-for-Testing binary (~269 MB)
+	// exceeds DEFAULT_ARCHIVE_LIMITS.maxMemberSize (64 MiB), so install() must
+	// extract with a ceiling sized for the trusted download.
+	const root = await makeRoot();
+	const bigSize = 65 * 1024 * 1024; // > 64 MiB default member cap
+	const zip = await encodeArchive("zip", [["chrome-linux64/chrome", new Uint8Array(bigSize)]]);
+	const server = Bun.serve({ port: 0, fetch: () => new Response(new Blob([zip])) });
+	try {
+		const installed = await install({
+			browser: Browser.CHROME,
+			platform: BrowserPlatform.LINUX,
+			buildId: BUILD_ID,
+			cacheDir: root,
+			baseUrl: String(server.url),
+		});
+		expect((await fs.stat(installed.executablePath)).size).toBe(bigSize);
 	} finally {
 		server.stop(true);
 	}


### PR DESCRIPTION
## Repro
On a Linux/WSL host with no system Chrome/Chromium on `PATH` and an empty Puppeteer cache, the first `xd://browser` `open` triggers a managed Chrome-for-Testing install that aborts before any tab opens: `Failed to install Chromium for puppeteer: Archive member 'chrome-linux64/chrome' is too large to extract in memory (268.7MB > 64.0MB limit)`. Reproduced with a minimal ZIP holding a single 70 MiB `chrome-linux64/chrome` member fed to the same `extractArchive()` call `install()` makes: `Archive member 'chrome-linux64/chrome' is too large to extract in memory (70.0MB > 64.0MB limit)`.

## Cause
`install()` (`packages/utils/src/browsers.ts:257`) called `extractArchive(archivePath, stagingPath)` with the default archive limits. `ArchiveReader.readFile()` enforces `DEFAULT_ARCHIVE_LIMITS.maxMemberSize` = 64 MiB (`packages/utils/src/ar/limits.ts:30`, also checked at ZIP index time in `zip.ts:507`). That ceiling exists to guard against attacker-controlled archives inflating memory, but it was being applied to the first-party Chrome-for-Testing download, whose `chrome` binary (~269 MB) exceeds both the member cap and the 256 MiB in-memory cap.

## Fix
- Add `BROWSER_ARCHIVE_LIMITS` in `packages/utils/src/browsers.ts` raising `maxMemberSize`/`maxInMemorySize` to 1 GiB, sized for the trusted browser binary with growth headroom.
- Pass `{ limits: BROWSER_ARCHIVE_LIMITS }` to the `extractArchive()` call in `install()`.
- Add a regression test asserting `install()` extracts a member larger than the default 64 MiB cap (fails without the fix).

## Verification
`bun test test/browsers.test.ts` (in `packages/utils`) — 11 pass, 1 skip. Verified the new test fails without the limits override (`ArchiveError: ... 65.0MB > 64.0MB limit`) and passes with it. Fixes #9534