### PR TITLE
fix(browser): guarded handle actions fail fast instead of stalling the cell

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser handles from `tab.id()`/`tab.ref()`/`tab.waitFor()` now fail fast with a named per-op error (e.g. `handle.click() timed out after 8000ms`) instead of letting a stalled `(await tab.id(n)).click()` consume the whole browser cell ([#9535](https://github.com/can1357/oh-my-pi/issues/9535)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -345,35 +345,64 @@ const GUARDED_HANDLE_METHODS = [
 	"scrollIntoView",
 ] as const satisfies readonly (keyof ElementHandle)[];
 
+type GuardedHandleMethod = (typeof GUARDED_HANDLE_METHODS)[number];
+type RawHandleMethod = (...args: unknown[]) => Promise<unknown>;
+
+interface RawHandleMethods {
+	interactive: Partial<Record<GuardedHandleMethod, RawHandleMethod>>;
+	type: ElementHandle["type"];
+}
+
+/** Symbol-keyed original methods travel with each cached handle without enumerating or colliding. */
+const RAW_HANDLE_METHODS = Symbol("browser.rawHandleMethods");
+
+type HandleWithRawMethods = ActionableHandle & { [RAW_HANDLE_METHODS]?: RawHandleMethods };
+
 /**
  * Attach `fill()` to a puppeteer ElementHandle before handing it to user code and,
  * when a `guard` is supplied, route every interactive method ({@link GUARDED_HANDLE_METHODS})
  * through the same fail-fast per-op wrapper as the selector-based helpers — so
  * `(await tab.id(n)).click()` fails fast with `handle.click() timed out after …ms`
- * instead of stalling until the whole browser cell expires. Puppeteer handles expose
+ * instead of stalling until the whole browser cell expires. Repeated enrichment is
+ * idempotent: cached handles are always rewrapped from their original bound methods,
+ * never from wrappers retaining an earlier run's guard. Puppeteer handles expose
  * `type()` but no `fill()`; the `fill()` semantics mirror the selector-based
  * `tab.fill()`: focus, clear any existing value, then type.
  */
 export function toActionableHandle(handle: ElementHandle, guard?: HandleOpGuard): ActionableHandle {
-	const enriched = handle as ActionableHandle;
+	const enriched = handle as HandleWithRawMethods;
+	const methods = enriched as unknown as Partial<Record<GuardedHandleMethod, RawHandleMethod>>;
+	const preserved = enriched[RAW_HANDLE_METHODS];
 	if (!guard) {
-		enriched.fill = value => fillViaHandle(enriched, value);
+		if (preserved) {
+			for (const method of GUARDED_HANDLE_METHODS) {
+				const original = preserved.interactive[method];
+				if (original) methods[method] = original;
+			}
+		}
+		enriched.fill = value => fillViaHandle(enriched, value, undefined, preserved?.type);
 		return enriched;
 	}
-	// Capture the raw typer before shadowing so the guarded fill runs as a single op
-	// rather than re-entering the guard through the now-wrapped `type`.
-	const rawType = enriched.type.bind(enriched);
-	const methods = enriched as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>;
+
+	let originals = preserved;
+	if (!originals) {
+		const interactive: Partial<Record<GuardedHandleMethod, RawHandleMethod>> = {};
+		for (const method of GUARDED_HANDLE_METHODS) {
+			const original = methods[method];
+			if (typeof original === "function") interactive[method] = original.bind(enriched);
+		}
+		originals = { interactive, type: enriched.type.bind(enriched) };
+		enriched[RAW_HANDLE_METHODS] = originals;
+	}
+
 	for (const method of GUARDED_HANDLE_METHODS) {
-		const raw = methods[method];
-		if (typeof raw !== "function") continue;
-		const bound = raw.bind(enriched);
-		methods[method] = (...args) => guard(`handle.${method}()`, signal => untilAborted(signal, () => bound(...args)));
+		const original = originals.interactive[method];
+		if (!original) continue;
+		methods[method] = (...args) =>
+			guard(`handle.${method}()`, signal => untilAborted(signal, () => original(...args)));
 	}
 	enriched.fill = value =>
-		guard<void>("handle.fill()", signal =>
-			fillViaHandle(enriched, value, signal, text => rawType(text, { delay: 0 })),
-		);
+		guard<void>("handle.fill()", signal => fillViaHandle(enriched, value, signal, originals.type));
 	return enriched;
 }
 

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -331,10 +331,12 @@ export type ActionableHandle = ElementHandle & { fill(value: string): Promise<vo
 export type HandleOpGuard = <T>(label: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>;
 
 /**
- * Interactive `ElementHandle` methods that dispatch input or navigation and can
- * stall on a busy page. When {@link toActionableHandle} is given a guard, each is
- * routed through the per-op fail-fast wrapper; without it the inherited puppeteer
- * method runs outside the op map and a stall consumes the whole cell (issue #9535).
+ * Every `ElementHandle` method that dispatches input, pointer/touch, drag, or navigation
+ * work and can therefore stall on a busy page. When {@link toActionableHandle} is given a
+ * guard, each is routed through the per-op fail-fast wrapper; without it the inherited
+ * puppeteer method runs outside the op map and a stall consumes the whole cell (issue #9535).
+ * Pure reads (`boundingBox`, `screenshot`, `evaluate`, queries) are omitted — they are not
+ * user-driven actions and keep their native puppeteer behavior.
  */
 const GUARDED_HANDLE_METHODS = [
 	"click",
@@ -346,6 +348,15 @@ const GUARDED_HANDLE_METHODS = [
 	"select",
 	"uploadFile",
 	"scrollIntoView",
+	"drag",
+	"dragEnter",
+	"dragOver",
+	"drop",
+	"dragAndDrop",
+	"touchStart",
+	"touchMove",
+	"touchEnd",
+	"autofill",
 ] as const satisfies readonly (keyof ElementHandle)[];
 
 type GuardedHandleMethod = (typeof GUARDED_HANDLE_METHODS)[number];

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -11,6 +11,7 @@ import type {
 	ElementHandle,
 	ElementScreenshotOptions,
 	HTTPResponse,
+	KeyboardTypeOptions,
 	KeyInput,
 	Page,
 	SerializedAXNode,
@@ -167,6 +168,8 @@ const ZERO_MATCH_FAIL_FAST_MS = 2_000;
 const ZERO_MATCH_POLL_MS = 250;
 /** Cleanup must settle inside the supervisor's 750ms post-run grace window. */
 const REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS = 500;
+/** Bound cleanup window after a timed-out raw handle action. */
+const HANDLE_ACTION_INVALIDATION_TIMEOUT_MS = 500;
 
 export interface OpTimeouts {
 	/** Largest per-op deadline allowed — strictly below the cell budget. */
@@ -351,12 +354,43 @@ type RawHandleMethod = (...args: unknown[]) => Promise<unknown>;
 interface RawHandleMethods {
 	interactive: Partial<Record<GuardedHandleMethod, RawHandleMethod>>;
 	type: ElementHandle["type"];
+	invalidatedBy?: string;
 }
 
 /** Symbol-keyed original methods travel with each cached handle without enumerating or colliding. */
 const RAW_HANDLE_METHODS = Symbol("browser.rawHandleMethods");
 
 type HandleWithRawMethods = ActionableHandle & { [RAW_HANDLE_METHODS]?: RawHandleMethods };
+
+async function runGuardedHandleAction<T>(
+	handle: ElementHandle,
+	state: RawHandleMethods,
+	label: string,
+	signal: AbortSignal,
+	action: () => Promise<T>,
+	invalidate?: () => Promise<void>,
+): Promise<T> {
+	if (state.invalidatedBy) {
+		throw new ToolError(
+			`${label} cannot run: this handle was invalidated after ${state.invalidatedBy} timed out; ` +
+				"run tab.observe() or tab.ariaSnapshot() to resolve a fresh handle",
+		);
+	}
+	const pending = action();
+	try {
+		return await untilAborted(signal, () => pending);
+	} catch (error) {
+		if (!signal.aborted) throw error;
+		state.invalidatedBy = label;
+		void pending.catch(() => undefined);
+		await withTimeout(
+			Promise.all([handle.dispose().catch(() => undefined), invalidate?.().catch(() => undefined)]),
+			HANDLE_ACTION_INVALIDATION_TIMEOUT_MS,
+			`Timed out invalidating ${label}`,
+		).catch(() => undefined);
+		throw error;
+	}
+}
 
 /**
  * Attach `fill()` to a puppeteer ElementHandle before handing it to user code and,
@@ -365,11 +399,17 @@ type HandleWithRawMethods = ActionableHandle & { [RAW_HANDLE_METHODS]?: RawHandl
  * `(await tab.id(n)).click()` fails fast with `handle.click() timed out after …ms`
  * instead of stalling until the whole browser cell expires. Repeated enrichment is
  * idempotent: cached handles are always rewrapped from their original bound methods,
- * never from wrappers retaining an earlier run's guard. Puppeteer handles expose
+ * never from wrappers retaining an earlier run's guard. A timed-out action invalidates
+ * and disposes its handle before surfacing the named error, so catching it cannot
+ * dispatch a duplicate retry through the stale handle. Puppeteer handles expose
  * `type()` but no `fill()`; the `fill()` semantics mirror the selector-based
  * `tab.fill()`: focus, clear any existing value, then type.
  */
-export function toActionableHandle(handle: ElementHandle, guard?: HandleOpGuard): ActionableHandle {
+export function toActionableHandle(
+	handle: ElementHandle,
+	guard?: HandleOpGuard,
+	invalidate?: () => Promise<void>,
+): ActionableHandle {
 	const enriched = handle as HandleWithRawMethods;
 	const methods = enriched as unknown as Partial<Record<GuardedHandleMethod, RawHandleMethod>>;
 	const preserved = enriched[RAW_HANDLE_METHODS];
@@ -396,14 +436,63 @@ export function toActionableHandle(handle: ElementHandle, guard?: HandleOpGuard)
 	}
 
 	for (const method of GUARDED_HANDLE_METHODS) {
+		if (method === "type") continue;
 		const original = originals.interactive[method];
 		if (!original) continue;
 		methods[method] = (...args) =>
-			guard(`handle.${method}()`, signal => untilAborted(signal, () => original(...args)));
+			guard(`handle.${method}()`, signal =>
+				runGuardedHandleAction(
+					enriched,
+					originals,
+					`handle.${method}()`,
+					signal,
+					() => original(...args),
+					invalidate,
+				),
+			);
 	}
+	enriched.type = (text, options) =>
+		guard<void>("handle.type()", signal =>
+			runGuardedHandleAction(
+				enriched,
+				originals,
+				"handle.type()",
+				signal,
+				() => typeViaHandle(enriched, text, options, signal),
+				invalidate,
+			),
+		);
 	enriched.fill = value =>
-		guard<void>("handle.fill()", signal => fillViaHandle(enriched, value, signal, originals.type));
+		guard<void>("handle.fill()", signal =>
+			runGuardedHandleAction(
+				enriched,
+				originals,
+				"handle.fill()",
+				signal,
+				() => fillViaHandle(enriched, value, signal, text => typeViaHandle(enriched, text, { delay: 0 }, signal)),
+				invalidate,
+			),
+		);
 	return enriched;
+}
+
+/** Focus once, then type one code point at a time so abort stops before the next key dispatch. */
+async function typeViaHandle(
+	handle: ElementHandle,
+	text: string,
+	options: Readonly<KeyboardTypeOptions> | undefined,
+	signal: AbortSignal,
+): Promise<void> {
+	await untilAborted(signal, () =>
+		handle.evaluate(el => {
+			const node = el as unknown as { focus?: () => void };
+			node.focus?.();
+		}),
+	);
+	for (const character of text) {
+		throwIfAborted(signal);
+		await untilAborted(signal, () => handle.frame.page().keyboard.type(character, options));
+	}
 }
 
 /** Focus, clear any existing value, then retype — shared by `tab.fill(aria-ref)` and enriched handles. */
@@ -1436,7 +1525,16 @@ export class WorkerCore {
 		// Hand user-facing handles the fail-fast per-op guard so their interactive
 		// methods (`.click()`, `.type()`, …) can't outrun the cell budget (issue #9535).
 		const enrich = (handle: ElementHandle): ActionableHandle =>
-			toActionableHandle(handle, (label, fn) => op(label, actionOpMs, fn));
+			toActionableHandle(
+				handle,
+				(label, fn) => op(label, actionOpMs, fn),
+				async () => {
+					// Raw Puppeteer actions have no AbortSignal. Poison + dispose every
+					// cached handle and stop navigation before reporting a recoverable timeout.
+					this.#clearElementCache();
+					await this.#stopLoading();
+				},
+			);
 		return {
 			name,
 			page,

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -320,18 +320,70 @@ function asElementHandle(handle: unknown): ElementHandle | null {
 export type ActionableHandle = ElementHandle & { fill(value: string): Promise<void> };
 
 /**
- * Attach `fill()` to a puppeteer ElementHandle before handing it to user code.
- * Puppeteer handles expose `type()` but no `fill()`; the semantics mirror the
- * selector-based `tab.fill()`: focus, clear any existing value, then type.
+ * A named per-op guard: runs `fn` inside the active run's fail-fast deadline and
+ * in-flight tracking (the same wrapper `tab.click(selector)` uses), so a stalled
+ * handle action rejects with a named error before the cell budget instead of
+ * hanging on puppeteer's protocol timeout.
  */
-export function toActionableHandle(handle: ElementHandle): ActionableHandle {
+export type HandleOpGuard = <T>(label: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>;
+
+/**
+ * Interactive `ElementHandle` methods that dispatch input or navigation and can
+ * stall on a busy page. When {@link toActionableHandle} is given a guard, each is
+ * routed through the per-op fail-fast wrapper; without it the inherited puppeteer
+ * method runs outside the op map and a stall consumes the whole cell (issue #9535).
+ */
+const GUARDED_HANDLE_METHODS = [
+	"click",
+	"type",
+	"hover",
+	"tap",
+	"focus",
+	"press",
+	"select",
+	"uploadFile",
+	"scrollIntoView",
+] as const satisfies readonly (keyof ElementHandle)[];
+
+/**
+ * Attach `fill()` to a puppeteer ElementHandle before handing it to user code and,
+ * when a `guard` is supplied, route every interactive method ({@link GUARDED_HANDLE_METHODS})
+ * through the same fail-fast per-op wrapper as the selector-based helpers — so
+ * `(await tab.id(n)).click()` fails fast with `handle.click() timed out after …ms`
+ * instead of stalling until the whole browser cell expires. Puppeteer handles expose
+ * `type()` but no `fill()`; the `fill()` semantics mirror the selector-based
+ * `tab.fill()`: focus, clear any existing value, then type.
+ */
+export function toActionableHandle(handle: ElementHandle, guard?: HandleOpGuard): ActionableHandle {
 	const enriched = handle as ActionableHandle;
-	enriched.fill = value => fillViaHandle(enriched, value);
+	if (!guard) {
+		enriched.fill = value => fillViaHandle(enriched, value);
+		return enriched;
+	}
+	// Capture the raw typer before shadowing so the guarded fill runs as a single op
+	// rather than re-entering the guard through the now-wrapped `type`.
+	const rawType = enriched.type.bind(enriched);
+	const methods = enriched as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>;
+	for (const method of GUARDED_HANDLE_METHODS) {
+		const raw = methods[method];
+		if (typeof raw !== "function") continue;
+		const bound = raw.bind(enriched);
+		methods[method] = (...args) => guard(`handle.${method}()`, signal => untilAborted(signal, () => bound(...args)));
+	}
+	enriched.fill = value =>
+		guard<void>("handle.fill()", signal =>
+			fillViaHandle(enriched, value, signal, text => rawType(text, { delay: 0 })),
+		);
 	return enriched;
 }
 
 /** Focus, clear any existing value, then retype — shared by `tab.fill(aria-ref)` and enriched handles. */
-async function fillViaHandle(handle: ElementHandle, value: string, signal?: AbortSignal): Promise<void> {
+async function fillViaHandle(
+	handle: ElementHandle,
+	value: string,
+	signal?: AbortSignal,
+	type: (text: string) => Promise<unknown> = text => handle.type(text, { delay: 0 }),
+): Promise<void> {
 	await untilAborted(signal, () =>
 		handle.evaluate(el => {
 			const node = el as unknown as { value?: string; focus?: () => void };
@@ -339,7 +391,7 @@ async function fillViaHandle(handle: ElementHandle, value: string, signal?: Abor
 			if ("value" in node) node.value = "";
 		}),
 	);
-	await untilAborted(signal, () => handle.type(value, { delay: 0 }));
+	await untilAborted(signal, () => type(value));
 }
 
 /**
@@ -1352,6 +1404,10 @@ export class WorkerCore {
 			fn: (sig: AbortSignal) => Promise<T>,
 			selectorOpts?: { selector?: string; zeroMatchAfterMs?: number },
 		): Promise<T> => markHandled(this.#runOp(active, label, signal, perOpMs, fn, selectorOpts));
+		// Hand user-facing handles the fail-fast per-op guard so their interactive
+		// methods (`.click()`, `.type()`, …) can't outrun the cell budget (issue #9535).
+		const enrich = (handle: ElementHandle): ActionableHandle =>
+			toActionableHandle(handle, (label, fn) => op(label, actionOpMs, fn));
 		return {
 			name,
 			page,
@@ -1506,7 +1562,7 @@ export class WorkerCore {
 				return op(
 					`tab.waitFor(${JSON.stringify(selector)})`,
 					w,
-					async sig => toActionableHandle(await this.#resolveActionHandle(selector, w, sig)),
+					async sig => enrich(await this.#resolveActionHandle(selector, w, sig)),
 					{ selector, zeroMatchAfterMs: opts?.timeout === undefined ? ZERO_MATCH_FAIL_FAST_MS : undefined },
 				);
 			},
@@ -1516,8 +1572,7 @@ export class WorkerCore {
 					`tab.waitForSelector(${JSON.stringify(selector)})`,
 					w,
 					async sig => {
-						if (parseAriaRefSelector(selector) !== null)
-							return toActionableHandle(await this.#resolveAriaRef(selector));
+						if (parseAriaRefSelector(selector) !== null) return enrich(await this.#resolveAriaRef(selector));
 						const handle = (await untilAborted(sig, () =>
 							page.waitForSelector(normalizeSelector(selector), {
 								timeout: w,
@@ -1526,7 +1581,7 @@ export class WorkerCore {
 								signal: sig,
 							}),
 						)) as ElementHandle | null;
-						return handle ? toActionableHandle(handle) : null;
+						return handle ? enrich(handle) : null;
 					},
 					{
 						selector,
@@ -1597,8 +1652,8 @@ export class WorkerCore {
 				const w = waitMs(opts?.timeout);
 				return op("tab.waitForResponse()", w, sig => this.#waitForResponse(pattern, w, sig));
 			},
-			id: async id => toActionableHandle(await this.#resolveCachedHandle(id)),
-			ref: async id => toActionableHandle(await this.#resolveAriaRef(id)),
+			id: async id => enrich(await this.#resolveCachedHandle(id)),
+			ref: async id => enrich(await this.#resolveAriaRef(id)),
 		};
 	}
 

--- a/packages/coding-agent/test/tools/browser-run-output.test.ts
+++ b/packages/coding-agent/test/tools/browser-run-output.test.ts
@@ -166,6 +166,34 @@ describe("browser handle enrichment — guarded actions", () => {
 		// fill() drives type() internally via the raw method, so it is guarded once, not nested.
 		expect(labels).toEqual(["handle.fill()"]);
 	});
+
+	it("rewraps a cached handle from its original methods for each browser run", async () => {
+		let clicks = 0;
+		const stub = {
+			click: async () => {
+				clicks++;
+			},
+			type: async () => {},
+			evaluate: async () => {},
+		} as unknown as ElementHandle;
+		const firstLabels: string[] = [];
+		const firstGuard: HandleOpGuard = (label, fn) => {
+			firstLabels.push(label);
+			return fn(AbortSignal.abort(new Error("first run ended")));
+		};
+		const secondLabels: string[] = [];
+		const secondGuard: HandleOpGuard = (label, fn) => {
+			secondLabels.push(label);
+			return fn(new AbortController().signal);
+		};
+
+		toActionableHandle(stub, firstGuard);
+		await toActionableHandle(stub, secondGuard).click();
+
+		expect(clicks).toBe(1);
+		expect(firstLabels).toEqual([]);
+		expect(secondLabels).toEqual(["handle.click()"]);
+	});
 });
 
 // A selector op's fail-fast timeout must diagnose *why*: a missing element (consent

--- a/packages/coding-agent/test/tools/browser-run-output.test.ts
+++ b/packages/coding-agent/test/tools/browser-run-output.test.ts
@@ -113,11 +113,76 @@ describe("browser handle enrichment — guarded actions", () => {
 			click: () => new Promise<void>(() => {}), // never settles — a busy popup/navigation stall
 			type: async () => {},
 			evaluate: async () => {},
+			dispose: async () => {},
 		} as unknown as ElementHandle;
 		const { guard, labels } = makeGuard(50);
 
 		await expect(toActionableHandle(stub, guard).click()).rejects.toThrow("handle.click() timed out after 50ms");
 		expect(labels).toEqual(["handle.click()"]);
+	});
+
+	it("invalidates a timed-out handle before rejecting and blocks a caught retry", async () => {
+		let clicks = 0;
+		let disposed = false;
+		let cacheCleared = false;
+		const stub = {
+			click: () => {
+				clicks++;
+				return new Promise<void>(() => {});
+			},
+			type: async () => {},
+			evaluate: async () => {},
+			dispose: async () => {
+				disposed = true;
+			},
+		} as unknown as ElementHandle;
+		const { guard } = makeGuard(50);
+		const handle = toActionableHandle(stub, guard, async () => {
+			cacheCleared = true;
+		});
+
+		await expect(handle.click()).rejects.toThrow("handle.click() timed out after 50ms");
+		expect(disposed).toBe(true);
+		expect(cacheCleared).toBe(true);
+		await expect(handle.click()).rejects.toThrow("this handle was invalidated after handle.click() timed out");
+		expect(clicks).toBe(1);
+	});
+
+	it("stops handle.type() before dispatching more characters after timeout", async () => {
+		const typed: string[] = [];
+		const firstStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const firstFinished = Promise.withResolvers<void>();
+		const stub = {
+			type: async () => {},
+			evaluate: async (fn: (el: unknown) => unknown) => {
+				fn({ focus: () => {} });
+			},
+			frame: {
+				page: () => ({
+					keyboard: {
+						type: async (character: string) => {
+							firstStarted.resolve();
+							await releaseFirst.promise;
+							typed.push(character);
+							firstFinished.resolve();
+						},
+					},
+				}),
+			},
+			dispose: async () => {},
+		} as unknown as ElementHandle;
+		const deadline = new AbortController();
+		const guard: HandleOpGuard = (_label, fn) => fn(deadline.signal);
+		const action = toActionableHandle(stub, guard).type("abc");
+
+		await firstStarted.promise;
+		deadline.abort(new Error("action deadline"));
+		await expect(action).rejects.toThrow("action deadline");
+		releaseFirst.resolve();
+		await firstFinished.promise;
+
+		expect(typed).toEqual(["a"]);
 	});
 
 	it("passes arguments and return values through the guarded method unchanged", async () => {
@@ -153,8 +218,15 @@ describe("browser handle enrichment — guarded actions", () => {
 					},
 				});
 			},
-			type: async (text: string) => {
-				node.value += text;
+			type: async () => {},
+			frame: {
+				page: () => ({
+					keyboard: {
+						type: async (text: string) => {
+							node.value += text;
+						},
+					},
+				}),
 			},
 		} as unknown as ElementHandle;
 		const { guard, labels } = makeGuard(1_000);
@@ -163,7 +235,7 @@ describe("browser handle enrichment — guarded actions", () => {
 
 		expect(node.value).toBe("fresh");
 		expect(node.focused).toBe(true);
-		// fill() drives type() internally via the raw method, so it is guarded once, not nested.
+		// fill() drives the signal-aware typer internally, so it is guarded once, not nested.
 		expect(labels).toEqual(["handle.fill()"]);
 	});
 

--- a/packages/coding-agent/test/tools/browser-run-output.test.ts
+++ b/packages/coding-agent/test/tools/browser-run-output.test.ts
@@ -202,6 +202,26 @@ describe("browser handle enrichment — guarded actions", () => {
 		expect(labels).toEqual(["handle.select()"]);
 	});
 
+	it("guards drag and touch input methods, not just click/type", async () => {
+		const makeStalled = (method: string): ElementHandle =>
+			({
+				[method]: () => new Promise<void>(() => {}), // stalled CDP input
+				type: async () => {},
+				evaluate: async () => {},
+				dispose: async () => {},
+			}) as unknown as ElementHandle;
+		const { guard, labels } = makeGuard(50);
+
+		const drag = toActionableHandle(makeStalled("drag"), guard) as unknown as Record<string, () => Promise<void>>;
+		await expect(drag.drag!()).rejects.toThrow("handle.drag() timed out after 50ms");
+		const touch = toActionableHandle(makeStalled("touchStart"), guard) as unknown as Record<
+			string,
+			() => Promise<void>
+		>;
+		await expect(touch.touchStart!()).rejects.toThrow("handle.touchStart() timed out after 50ms");
+		expect(labels).toEqual(["handle.drag()", "handle.touchStart()"]);
+	});
+
 	it("runs the guarded fill as a single op without re-entering the wrapped type()", async () => {
 		const node = { value: "old", focused: false };
 		const stub = {

--- a/packages/coding-agent/test/tools/browser-run-output.test.ts
+++ b/packages/coding-agent/test/tools/browser-run-output.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { RunOutput } from "@oh-my-pi/pi-coding-agent/tools/browser/run-output";
-import { formatSelectorMatchHint, toActionableHandle } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-worker";
+import {
+	formatSelectorMatchHint,
+	type HandleOpGuard,
+	toActionableHandle,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/tab-worker";
 import type { ElementHandle } from "puppeteer-core";
 
 // Regression coverage for the invisible-output failure mode: `display("string")`,
@@ -81,6 +85,86 @@ describe("browser handle enrichment — fill()", () => {
 		expect(calls).toEqual(["evaluate", "type"]);
 		expect(node.focused).toBe(true);
 		expect(node.value).toBe("fresh");
+	});
+});
+
+// Regression (#9535): handles from tab.id()/tab.ref()/tab.waitFor() used to return raw
+// puppeteer methods that ran outside the per-op guard, so a stalled `(await tab.id(n)).click()`
+// consumed the whole 30s cell instead of failing fast with a named per-op error. A guard now
+// routes each interactive method through the same fail-fast wrapper as tab.click(selector).
+describe("browser handle enrichment — guarded actions", () => {
+	// Minimal stand-in for #runOp: names the op, installs a per-op deadline, and rewrites an
+	// abort into the same `<label> timed out after <ms>ms` shape the real guard surfaces.
+	const makeGuard = (perOpMs: number): { guard: HandleOpGuard; labels: string[] } => {
+		const labels: string[] = [];
+		const guard: HandleOpGuard = (label, fn) => {
+			labels.push(label);
+			const timeout = AbortSignal.timeout(perOpMs);
+			return fn(timeout).catch((err: unknown) => {
+				if (timeout.aborted) throw new Error(`${label} timed out after ${perOpMs}ms`);
+				throw err;
+			});
+		};
+		return { guard, labels };
+	};
+
+	it("fails a stalled handle.click() fast with a named error instead of hanging", async () => {
+		const stub = {
+			click: () => new Promise<void>(() => {}), // never settles — a busy popup/navigation stall
+			type: async () => {},
+			evaluate: async () => {},
+		} as unknown as ElementHandle;
+		const { guard, labels } = makeGuard(50);
+
+		await expect(toActionableHandle(stub, guard).click()).rejects.toThrow("handle.click() timed out after 50ms");
+		expect(labels).toEqual(["handle.click()"]);
+	});
+
+	it("passes arguments and return values through the guarded method unchanged", async () => {
+		let calls = 0;
+		const stub = {
+			select: async (...values: string[]) => {
+				calls++;
+				return values;
+			},
+			type: async () => {},
+			evaluate: async () => {},
+		} as unknown as ElementHandle;
+		const { guard, labels } = makeGuard(1_000);
+
+		expect(await toActionableHandle(stub, guard).select("a", "b")).toEqual(["a", "b"]);
+		expect(calls).toBe(1);
+		expect(labels).toEqual(["handle.select()"]);
+	});
+
+	it("runs the guarded fill as a single op without re-entering the wrapped type()", async () => {
+		const node = { value: "old", focused: false };
+		const stub = {
+			evaluate: async (fn: (el: unknown) => unknown) => {
+				fn({
+					get value() {
+						return node.value;
+					},
+					set value(v: string) {
+						node.value = v;
+					},
+					focus: () => {
+						node.focused = true;
+					},
+				});
+			},
+			type: async (text: string) => {
+				node.value += text;
+			},
+		} as unknown as ElementHandle;
+		const { guard, labels } = makeGuard(1_000);
+
+		await toActionableHandle(stub, guard).fill("fresh");
+
+		expect(node.value).toBe("fresh");
+		expect(node.focused).toBe(true);
+		// fill() drives type() internally via the raw method, so it is guarded once, not nested.
+		expect(labels).toEqual(["handle.fill()"]);
 	});
 });
 


### PR DESCRIPTION
## Repro
A click made through the documented direct-handle form `await (await tab.id(n)).click()` (or `tab.ref(id)` / `tab.waitFor*` handles) stays pending until the whole 30s `browser.run` cell expires when the target page keeps the click CDP call busy (popup/navigation), instead of failing fast with a named per-op error. Minimal repro drives a handle whose `click()` never settles: after `ACTION_OP_TIMEOUT_MS` (8s) + 1s margin the click is still `pending` — `handle.click state after 9001ms: pending`.

## Cause
`tab.id()` / `tab.ref()` / `tab.waitFor*` return the raw puppeteer `ElementHandle` through `toActionableHandle()` in `packages/coding-agent/src/tools/browser/tab-worker.ts`, which only attached `fill()`. Every other interactive method (`click`, `type`, `hover`, `focus`, `press`, `tap`, `select`, `uploadFile`, `scrollIntoView`) was the inherited puppeteer method, invoked from user `run` code entirely outside the `#runOp`/`op(...)` wrapper. So it carried no per-op deadline, was never registered in the in-flight op map, and was bounded only by puppeteer's protocol timeout — well past the cell budget. Only `tab.click(selector)` and the other selector helpers were guarded. (The cmux/relay backend is unaffected: `CmuxElementHandle.click()` delegates to the guarded `tab.click(selector)`.)

## Fix
- `toActionableHandle(handle, guard?)` now accepts an optional per-op guard; `#createTabApi` builds `enrich()` from `op(label, actionOpMs, fn)` and hands it to every user-facing handle return (`id`, `ref`, `waitFor`, `waitForSelector`).
- With a guard, each interactive method in `GUARDED_HANDLE_METHODS` is routed through the same fail-fast wrapper as `tab.click(selector)`, so a stall rejects with a named error like `handle.click() timed out after 8000ms` and is tracked in the in-flight op map.
- `fillViaHandle` takes an explicit `type` function so the guarded `fill()` uses the raw typer and stays a single op rather than re-entering the guard through the now-wrapped `type`.
- Added `## [Unreleased]` changelog entry.

## Verification
`bun test test/tools/browser-run-output.test.ts test/tools/browser-tab-timeouts.test.ts` — pass (new `browser handle enrichment — guarded actions` describe covers fail-fast, argument/return passthrough, and single-op fill). `bun run check:ts` — exit 0 across all workspaces including `pi-coding-agent`. Fixes #9535