### PR TITLE
fix(browser): reaped spawned apps after failed opens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Failed `browser.open` calls now terminate OMP-spawned app process trees when no tab can be acquired.
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -325,7 +325,9 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 					}),
 				);
 			} catch (error) {
-				await releaseBrowser(browser, { kill: false });
+				await releaseBrowser(browser, {
+					kill: "subprocess" in browser && browser.subprocess !== undefined,
+				});
 				throw error;
 			}
 			await releaseBrowser(browser, { kill: false });

--- a/packages/coding-agent/test/tools/browser-open-lease.test.ts
+++ b/packages/coding-agent/test/tools/browser-open-lease.test.ts
@@ -11,8 +11,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
+import * as attach from "@oh-my-pi/pi-coding-agent/tools/browser/attach";
 import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
-import { getBrowsersMapForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import * as registry from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { getTabsMapForTest, releaseTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
 import { ToolAbortError, ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
@@ -87,7 +88,7 @@ describe("browser open — requested timeout bounds the whole acquisition (#6365
 		connectGate.resolve();
 		for (let i = 0; i < 20; i++) await Promise.resolve();
 		expect(closeSpy).toHaveBeenCalledTimes(1);
-		expect(getBrowsersMapForTest().size).toBe(0);
+		expect(registry.getBrowsersMapForTest().size).toBe(0);
 	});
 });
 
@@ -132,12 +133,51 @@ describe("browser open — caller cancellation rolls back the fresh browser (#63
 		// The open-acquisition lease rollback disposes the fresh browser exactly
 		// once and leaves nothing owned solely by the failed open.
 		expect(getTabsMapForTest().has("fresh")).toBe(false);
-		expect(getBrowsersMapForTest().size).toBe(0);
+		expect(registry.getBrowsersMapForTest().size).toBe(0);
 		expect(closeSpy).toHaveBeenCalledTimes(1);
 
 		// Let the orphaned acquisition unwind so it does not leak past the test.
 		openSplitGate.resolve();
 		await Promise.resolve();
+	});
+});
+
+describe("browser open — failed spawned-app acquisition reaps its owned process (#9537)", () => {
+	it("kills the OMP-spawned process when no page target can be published", async () => {
+		const disconnectSpy = vi.fn();
+		const browser = {
+			key: "spawned:/tmp/chrome-headless-shell",
+			kind: { kind: "spawned", path: "/tmp/chrome-headless-shell" },
+			refCount: 0,
+			browser: {
+				connected: true,
+				disconnect: disconnectSpy,
+				wsEndpoint: () => "ws://127.0.0.1/devtools/browser/test",
+				targets: () => [],
+				pages: async () => [],
+			},
+			pid: 4242,
+			subprocess: {},
+			stealth: { browserSession: null, override: null },
+		} as unknown as registry.BrowserHandle;
+		spyOn(registry, "acquireBrowser").mockResolvedValue(browser);
+		const killSpy = spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+
+		const tool = new BrowserTool(makeSession());
+		await expect(
+			tool.execute("call-no-page", {
+				action: "open",
+				name: "failed-open",
+				app: { path: "/tmp/chrome-headless-shell" },
+				timeout: 1,
+			}),
+		).rejects.toThrow("No page targets available on the attached browser");
+
+		expect(disconnectSpy).toHaveBeenCalledTimes(1);
+		expect(killSpy).toHaveBeenCalledTimes(1);
+		expect(killSpy.mock.calls[0]?.[0]).toBe(4242);
+		expect(registry.getBrowsersMapForTest().size).toBe(0);
+		expect(getTabsMapForTest().has("failed-open")).toBe(false);
 	});
 });
 
@@ -177,7 +217,7 @@ describe("browser open — concurrent different-name acquisitions each own a lea
 			(err: unknown) => ({ ok: false as const, err }),
 		);
 		await aEntered.promise;
-		expect(getBrowsersMapForTest().size).toBe(1);
+		expect(registry.getBrowsersMapForTest().size).toBe(1);
 
 		// Open B against the SAME browser (different tab name). It reuses the
 		// registry handle and takes its own lease; both are now parked.
@@ -201,7 +241,7 @@ describe("browser open — concurrent different-name acquisitions each own a lea
 
 		// B's browser survived A's rollback: still present, never closed, exactly
 		// one published tab. A's rollback closed only its own orphan surface.
-		expect(getBrowsersMapForTest().size).toBe(1);
+		expect(registry.getBrowsersMapForTest().size).toBe(1);
 		expect(closeSpy).not.toHaveBeenCalled();
 		expect(getTabsMapForTest().has("tab-b")).toBe(true);
 		expect(getTabsMapForTest().has("tab-a")).toBe(false);


### PR DESCRIPTION
## Repro
A spawned-app `BrowserTool.execute(open)` with an attached browser exposing no page targets throws `No page targets available on the attached browser`; before the fix, `bun test packages/coding-agent/test/tools/browser-open-lease.test.ts` observed that Puppeteer disconnected but `gracefulKillTreeOnce` received zero calls for the OMP-owned PID.

## Cause
`BrowserTool.#open()` in `packages/coding-agent/src/tools/browser.ts` released its acquisition lease with `kill: false` after `acquireTab()` failed. `disposeBrowserHandle()` in `packages/coding-agent/src/tools/browser/registry.ts` therefore disconnected the spawned handle and removed it from the browser registry without terminating its OMP-owned subprocess.

## Fix
- Kill the browser process during failed-open rollback only when the handle contains the subprocess launched by OMP.
- Cover the no-page-target failure through `BrowserTool.execute(open)`, including registry state and exact PID cleanup.
- Document the user-visible cleanup fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/browser-open-lease.test.ts` passes: 4 tests, 27 expectations. `bun --cwd=packages/coding-agent run check` passes. Pre-publish gate skipped: `bun run fix` fails on a clean `main` archive at `packages/ai/test/openai-responses-history-payload.test.ts:627` with the unrelated `noUnsafeOptionalChaining` diagnostic. Fixes #9537