### PR TITLE
fix(session): advertise resumable path in exit hint for foreign sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The exit/recovery resume hint now prints the explicit file path for a path-resumed session stored outside the managed sessions bucket (e.g. a pi transcript), instead of an `omp --resume <id>` that id-resolution can never match ([#9544](https://github.com/can1357/oh-my-pi/issues/9544)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -140,7 +140,7 @@ import { formatStartupChangelogSummary, type StartupChangelogSelection } from ".
 import { copyToClipboard } from "../utils/clipboard";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
-import { resumeCommand } from "../utils/resume-command";
+import { resumeCommandForSession } from "../utils/resume-command";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
 import { messageHasDisplayableThinking } from "../utils/thinking-display";
 import {
@@ -4654,7 +4654,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		const sessionId = this.sessionManager.getSessionId();
 		const sessionFile = this.sessionManager.getSessionFile();
 		if (sessionId && sessionFile && this.sessionManager.isSessionOnDisk()) {
-			process.stderr.write(`\n${chalk.dim(`Resume this session with ${resumeCommand(sessionId)}`)}\n`);
+			process.stderr.write(
+				`\n${chalk.dim(`Resume this session with ${resumeCommandForSession(sessionId, sessionFile)}`)}\n`,
+			);
 		}
 
 		await postmortem.quit(0);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -217,7 +217,7 @@ import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
 import { normalizeModelContextImages } from "../utils/image-loading";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
-import { resumeCommand } from "../utils/resume-command";
+import { resumeCommandForSession } from "../utils/resume-command";
 import { generateSessionTitle } from "../utils/title-generator";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
 import type { VibeModeState } from "../vibe/state";
@@ -1482,10 +1482,11 @@ export class AgentSession {
 		});
 		this.#cancelFatalRecoveryHint = postmortem.registerFatalRecoveryHint(() => {
 			const sessionId = this.sessionManager.getSessionId();
-			if (!sessionId || !this.sessionManager.getSessionFile()) return undefined;
+			const sessionFile = this.sessionManager.getSessionFile();
+			if (!sessionId || !sessionFile) return undefined;
 			return {
 				label: this.#agentId ?? (this.#agentKind === "main" ? "Main" : "Agent"),
-				command: resumeCommand(sessionId),
+				command: resumeCommandForSession(sessionId, sessionFile),
 			};
 		});
 

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -178,6 +178,20 @@ export function resolveManagedSessionRoot(sessionDir: string, cwd: string): stri
 }
 
 /**
+ * Whether a session file lives under the managed sessions root as a bucket
+ * child (`<sessionsRoot>/<encoded-cwd>/<file>.jsonl`) — the only on-disk layout
+ * that id-resolution can rediscover, since `resolveResumableSession` and
+ * `listAllSessions` enumerate bucket files exactly one level below the root. A
+ * path-resumed foreign file (e.g. a pi transcript under `~/.pi/agent/sessions`)
+ * stays at its original location, so a `--resume <id>` hint built from it can
+ * never match (issue #9544).
+ */
+export function isManagedSessionFile(sessionFile: string, sessionsRoot: string = getSessionsDir()): boolean {
+	const bucket = path.dirname(path.resolve(sessionFile));
+	return path.dirname(bucket) === path.resolve(sessionsRoot);
+}
+
+/**
  * Compute the default session directory for a cwd.
  * Classifies cwd by canonical location so symlink/alias paths resolve to the
  * same home-relative or temp-root directory names as their real targets.

--- a/packages/coding-agent/src/utils/resume-command.ts
+++ b/packages/coding-agent/src/utils/resume-command.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { APP_NAME, getActiveProfile } from "@oh-my-pi/pi-utils";
+import { APP_NAME, getActiveProfile, procmgr } from "@oh-my-pi/pi-utils";
 import { isManagedSessionFile } from "../session/session-paths";
 
 /**
@@ -32,10 +32,9 @@ export function resumeCommandForSession(sessionId: string, sessionFile: string):
 	if (isManagedSessionFile(sessionFile)) return resumeCommand(sessionId);
 	const profile = getActiveProfile();
 	const profileFlag = profile ? `--profile ${profile} ` : "";
-	return `${APP_NAME} ${profileFlag}--resume ${quoteResumePath(path.resolve(sessionFile))}`;
-}
-
-/** Single-quote a session path for a copy-pasteable hint; left bare when already shell-safe. */
-function quoteResumePath(value: string): string {
-	return /^[\w@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+	// Foreign session paths are pasted into the user's host shell: leave a
+	// shell-safe path bare, otherwise quote it per the host shell's rules.
+	const resolved = path.resolve(sessionFile);
+	const target = /^[\w@%+=:,./-]+$/.test(resolved) ? resolved : procmgr.quoteHostShellArg(resolved);
+	return `${APP_NAME} ${profileFlag}--resume ${target}`;
 }

--- a/packages/coding-agent/src/utils/resume-command.ts
+++ b/packages/coding-agent/src/utils/resume-command.ts
@@ -1,4 +1,6 @@
+import * as path from "node:path";
 import { APP_NAME, getActiveProfile } from "@oh-my-pi/pi-utils";
+import { isManagedSessionFile } from "../session/session-paths";
 
 /**
  * Build the shell command that resumes a session by id.
@@ -15,4 +17,25 @@ export function resumeCommand(sessionId: string): string {
 	const profile = getActiveProfile();
 	const profileFlag = profile ? `--profile ${profile} ` : "";
 	return `${APP_NAME} ${profileFlag}--resume ${sessionId}`;
+}
+
+/**
+ * Build the resume command a shutdown/recovery banner advertises for the active
+ * session. A managed session resolves by id, so the compact `--resume <id>`
+ * form is emitted. A path-resumed foreign session (e.g. a pi transcript opened
+ * by explicit path) is invisible to id lookup — {@link isManagedSessionFile}
+ * is false — so the hint carries the explicit file path, which the path branch
+ * of `--resume` opens directly. Without this the banner hands the user an
+ * unresolvable key (issue #9544).
+ */
+export function resumeCommandForSession(sessionId: string, sessionFile: string): string {
+	if (isManagedSessionFile(sessionFile)) return resumeCommand(sessionId);
+	const profile = getActiveProfile();
+	const profileFlag = profile ? `--profile ${profile} ` : "";
+	return `${APP_NAME} ${profileFlag}--resume ${quoteResumePath(path.resolve(sessionFile))}`;
+}
+
+/** Single-quote a session path for a copy-pasteable hint; left bare when already shell-safe. */
+function quoteResumePath(value: string): string {
+	return /^[\w@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/packages/coding-agent/test/utils/resume-command.test.ts
+++ b/packages/coding-agent/test/utils/resume-command.test.ts
@@ -1,6 +1,18 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import { resumeCommand } from "@oh-my-pi/pi-coding-agent/utils/resume-command";
-import { APP_NAME, getActiveProfile, setProfile } from "@oh-my-pi/pi-utils/dirs";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resumeCommand, resumeCommandForSession } from "@oh-my-pi/pi-coding-agent/utils/resume-command";
+import {
+	APP_NAME,
+	getActiveProfile,
+	getAgentDir,
+	getSessionsDir,
+	removeSyncWithRetries,
+	Snowflake,
+	setAgentDir,
+	setProfile,
+} from "@oh-my-pi/pi-utils";
 
 describe("resumeCommand", () => {
 	const originalProfile = getActiveProfile();
@@ -19,5 +31,49 @@ describe("resumeCommand", () => {
 		// without --profile fails with "Session not found" (issue #9018).
 		setProfile("personal");
 		expect(resumeCommand("abc123")).toBe(`${APP_NAME} --profile personal --resume abc123`);
+	});
+});
+
+describe("resumeCommandForSession", () => {
+	const originalProfile = getActiveProfile();
+	const originalAgentDir = getAgentDir();
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `resume-hint-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		setAgentDir(path.join(tempDir, "omp-agent"));
+		setProfile(undefined);
+	});
+
+	afterEach(() => {
+		setProfile(originalProfile);
+		setAgentDir(originalAgentDir);
+		removeSyncWithRetries(tempDir);
+	});
+
+	it("uses the compact --resume <id> form for a managed bucket session", () => {
+		const id = "0198abcd-ef01-2345-6789-abcdef012345";
+		const managed = path.join(getSessionsDir(), "--home-user-project--", `2026-01-01T00-00-00-000Z_${id}.jsonl`);
+		expect(resumeCommandForSession(id, managed)).toBe(`${APP_NAME} --resume ${id}`);
+	});
+
+	it("advertises the explicit path for a path-resumed foreign session id-resolution cannot find (#9544)", () => {
+		const id = "0198abcd-ef01-2345-6789-abcdef012345";
+		const foreign = path.join(tempDir, "pi", "agent", "sessions", "--home-user-project--", `2026-01-01_${id}.jsonl`);
+		expect(resumeCommandForSession(id, foreign)).toBe(`${APP_NAME} --resume ${foreign}`);
+	});
+
+	it("quotes a foreign path containing shell-significant characters", () => {
+		const id = "0198abcd-ef01-2345-6789-abcdef012345";
+		const foreign = path.join(tempDir, "my sessions", `2026-01-01_${id}.jsonl`);
+		expect(resumeCommandForSession(id, foreign)).toBe(`${APP_NAME} --resume '${foreign}'`);
+	});
+
+	it("carries the active profile into the foreign-path form", () => {
+		setProfile("personal");
+		const id = "0198abcd-ef01-2345-6789-abcdef012345";
+		const foreign = path.join(tempDir, "pi-session.jsonl");
+		expect(resumeCommandForSession(id, foreign)).toBe(`${APP_NAME} --profile personal --resume ${foreign}`);
 	});
 });

--- a/packages/coding-agent/test/utils/resume-command.test.ts
+++ b/packages/coding-agent/test/utils/resume-command.test.ts
@@ -4,9 +4,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { resumeCommand, resumeCommandForSession } from "@oh-my-pi/pi-coding-agent/utils/resume-command";
 import {
+	__resetDirsFromEnvForTests,
 	APP_NAME,
 	getActiveProfile,
-	getAgentDir,
 	getSessionsDir,
 	removeSyncWithRetries,
 	Snowflake,
@@ -35,20 +35,28 @@ describe("resumeCommand", () => {
 });
 
 describe("resumeCommandForSession", () => {
-	const originalProfile = getActiveProfile();
-	const originalAgentDir = getAgentDir();
+	// setAgentDir / setProfile rewrite process env and the dirs snapshot; capture
+	// and restore the exact env, then rebuild dirs from it, so a suite that starts
+	// under a named profile is not left in the default profile with a stale
+	// override for the next test file.
+	const ENV_KEYS = ["PI_CODING_AGENT_DIR", "OMP_PROFILE", "PI_PROFILE"] as const;
+	const originalEnv: Record<string, string | undefined> = {};
 	let tempDir: string;
 
 	beforeEach(() => {
+		for (const key of ENV_KEYS) originalEnv[key] = process.env[key];
 		tempDir = path.join(os.tmpdir(), `resume-hint-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		setAgentDir(path.join(tempDir, "omp-agent"));
-		setProfile(undefined);
 	});
 
 	afterEach(() => {
-		setProfile(originalProfile);
-		setAgentDir(originalAgentDir);
+		for (const key of ENV_KEYS) {
+			const value = originalEnv[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		__resetDirsFromEnvForTests();
 		removeSyncWithRetries(tempDir);
 	});
 

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -83,6 +83,23 @@ export function isPowerShell(shell: string): boolean {
 }
 
 /**
+ * Quote a single argument for a copy-pasteable command hint shown to the user
+ * (e.g. a resume/recovery banner). Targets the interactive host shell the user
+ * returns to, so it keys off {@link process.platform} rather than
+ * {@link getShellConfig} (which resolves the bash-tool shell, not the parent
+ * shell that launched the process). POSIX shells group single-quoted arguments
+ * (`'\''` escapes an embedded quote); cmd.exe does not treat single quotes
+ * specially, so a spaced path would split — Windows (cmd.exe and PowerShell
+ * both group double-quoted arguments) uses double quotes, doubling any embedded
+ * `"` (a Windows filename cannot contain `"`, so that only guards pathological
+ * input). `platform` is injectable for tests.
+ */
+export function quoteHostShellArg(value: string, platform: NodeJS.Platform = process.platform): string {
+	if (platform === "win32") return `"${value.replaceAll('"', '""')}"`;
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
  * Get shell prefix for wrapping commands (profilers, strace, etc.).
  */
 function getShellPrefix(): string | undefined {

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -82,21 +82,83 @@ export function isPowerShell(shell: string): boolean {
 	return basename === "powershell.exe" || basename === "powershell" || basename === "pwsh.exe" || basename === "pwsh";
 }
 
+/** Shell syntax used to quote command hints pasted into the launching shell. */
+export type HostShellQuoteStyle = "cmd" | "powershell" | "posix";
+
+function classifyHostShell(command: string | undefined): HostShellQuoteStyle | undefined {
+	if (!command) return undefined;
+	if (isPowerShell(command)) return "powershell";
+	if (isCmdShell(command)) return "cmd";
+	const basename = command
+		.replace(/\\/g, "/")
+		.split("/")
+		.pop()
+		?.toLowerCase()
+		.replace(/\.exe$/, "");
+	if (basename === "bash" || basename === "sh" || basename === "zsh" || basename === "fish") return "posix";
+	return undefined;
+}
+
+function getAncestorCommands(): string[] {
+	const commands: string[] = [];
+	const visited = new Set<number>();
+	let pid: number | null = process.ppid;
+	while (pid && pid > 0 && commands.length < 16 && !visited.has(pid)) {
+		visited.add(pid);
+		try {
+			const parent = Process.fromPid(pid);
+			if (!parent) break;
+			const command = parent.args()[0];
+			if (command) commands.push(command);
+			pid = parent.ppid;
+		} catch {
+			break;
+		}
+	}
+	return commands;
+}
+
 /**
- * Quote a single argument for a copy-pasteable command hint shown to the user
- * (e.g. a resume/recovery banner). Targets the interactive host shell the user
- * returns to, so it keys off {@link process.platform} rather than
- * {@link getShellConfig} (which resolves the bash-tool shell, not the parent
- * shell that launched the process). POSIX shells group single-quoted arguments
- * (`'\''` escapes an embedded quote); cmd.exe does not treat single quotes
- * specially, so a spaced path would split — Windows (cmd.exe and PowerShell
- * both group double-quoted arguments) uses double quotes, doubling any embedded
- * `"` (a Windows filename cannot contain `"`, so that only guards pathological
- * input). `platform` is injectable for tests.
+ * Detect the shell that launched the current process for copy-pasteable command
+ * hints. Windows does not export one canonical shell variable, so the nearest
+ * recognized process ancestor wins; inherited env is only a fallback when
+ * ancestry is unavailable. Parameters are injectable for tests.
  */
-export function quoteHostShellArg(value: string, platform: NodeJS.Platform = process.platform): string {
-	if (platform === "win32") return `"${value.replaceAll('"', '""')}"`;
-	return `'${value.replaceAll("'", "'\\''")}'`;
+export function detectHostShellQuoteStyle(
+	ancestorCommands: readonly string[] = getAncestorCommands(),
+	env: Record<string, string | undefined> = process.env,
+	platform: NodeJS.Platform = process.platform,
+): HostShellQuoteStyle {
+	if (platform !== "win32") return "posix";
+	for (const command of ancestorCommands) {
+		const style = classifyHostShell(command);
+		if (style) return style;
+	}
+	const envStyle = classifyHostShell(env.SHELL);
+	if (envStyle) return envStyle;
+	if (env.MSYSTEM) return "posix";
+	if (env.PSModulePath || env.PSMODULEPATH || env.psmodulepath || env.POWERSHELL_DISTRIBUTION_CHANNEL) {
+		return "powershell";
+	}
+	return "cmd";
+}
+
+/**
+ * Quote one argument for a command hint pasted into the launching shell.
+ * PowerShell and POSIX shells both have literal single-quote forms but escape
+ * embedded apostrophes differently. cmd.exe groups with double quotes and
+ * expands `%NAME%` / delayed `!NAME!` even inside them, so carets protect `%`,
+ * `!`, and literal carets before cmd parses the argument.
+ */
+export function quoteHostShellArg(value: string, style: HostShellQuoteStyle = detectHostShellQuoteStyle()): string {
+	switch (style) {
+		case "cmd":
+			return `"${value.replace(/[%!^]/g, "^$&").replaceAll('"', '\\"')}"`;
+		case "powershell":
+			return `'${value.replaceAll("'", "''")}'`;
+		case "posix":
+			return `'${value.replaceAll("'", "'\\''")}'`;
+	}
 }
 
 /**

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -3,7 +3,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, MAIN_CONFIG_FILENAMES } from "../src/dirs";
-import { getShellArgs, getShellConfig, quoteHostShellArg, resolveWindowsShell } from "../src/procmgr";
+import {
+	detectHostShellQuoteStyle,
+	getShellArgs,
+	getShellConfig,
+	quoteHostShellArg,
+	resolveWindowsShell,
+} from "../src/procmgr";
 
 describe("getShellConfig", () => {
 	it("directs invalid custom shell paths to the canonical config file", () => {
@@ -39,17 +45,44 @@ describe("getShellArgs", () => {
 	});
 });
 
-describe("quoteHostShellArg", () => {
-	it("single-quotes for POSIX host shells, escaping embedded quotes", () => {
-		expect(quoteHostShellArg("/home/u/my sessions/s.jsonl", "linux")).toBe("'/home/u/my sessions/s.jsonl'");
-		expect(quoteHostShellArg("a'b", "darwin")).toBe("'a'\\''b'");
+describe("detectHostShellQuoteStyle", () => {
+	it("uses the nearest recognized Windows shell ancestor", () => {
+		expect(
+			detectHostShellQuoteStyle(
+				["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "C:\\Windows\\explorer.exe"],
+				{},
+				"win32",
+			),
+		).toBe("powershell");
+		expect(
+			detectHostShellQuoteStyle(
+				["C:\\Program Files\\Git\\usr\\bin\\bash.exe", "C:\\Windows\\System32\\cmd.exe"],
+				{},
+				"win32",
+			),
+		).toBe("posix");
+		expect(detectHostShellQuoteStyle(["C:\\Windows\\System32\\cmd.exe"], {}, "win32")).toBe("cmd");
 	});
 
-	it("double-quotes on Windows so cmd.exe groups a spaced path instead of splitting it", () => {
-		// cmd.exe does not treat single quotes specially, so the POSIX form would
-		// hand `--resume` a split path; double quotes group in cmd.exe and PowerShell.
-		expect(quoteHostShellArg("C:\\Users\\a b\\s.jsonl", "win32")).toBe('"C:\\Users\\a b\\s.jsonl"');
-		expect(quoteHostShellArg('a"b', "win32")).toBe('"a""b"');
+	it("falls back to inherited shell markers when ancestry is unavailable", () => {
+		expect(detectHostShellQuoteStyle([], { SHELL: "C:\\Program Files\\Git\\bin\\bash.exe" }, "win32")).toBe("posix");
+		expect(detectHostShellQuoteStyle([], { PSModulePath: "C:\\Program Files\\PowerShell\\Modules" }, "win32")).toBe(
+			"powershell",
+		);
+		expect(detectHostShellQuoteStyle([], {}, "win32")).toBe("cmd");
+		expect(detectHostShellQuoteStyle([], {}, "darwin")).toBe("posix");
+	});
+});
+
+describe("quoteHostShellArg", () => {
+	it("uses the detected shell's literal quoting and escaping rules", () => {
+		expect(quoteHostShellArg("/home/u/$draft/a'b.jsonl", "posix")).toBe("'/home/u/$draft/a'\\''b.jsonl'");
+		expect(quoteHostShellArg("C:\\sessions\\$draft\\a'b.jsonl", "powershell")).toBe(
+			"'C:\\sessions\\$draft\\a''b.jsonl'",
+		);
+		expect(quoteHostShellArg("C:\\sessions\\%draft%\\!name!\\s.jsonl", "cmd")).toBe(
+			'"C:\\sessions\\^%draft^%\\^!name^!\\s.jsonl"',
+		);
 	});
 });
 

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, MAIN_CONFIG_FILENAMES } from "../src/dirs";
-import { getShellArgs, getShellConfig, resolveWindowsShell } from "../src/procmgr";
+import { getShellArgs, getShellConfig, quoteHostShellArg, resolveWindowsShell } from "../src/procmgr";
 
 describe("getShellConfig", () => {
 	it("directs invalid custom shell paths to the canonical config file", () => {
@@ -36,6 +36,20 @@ describe("getShellArgs", () => {
 		expect(getShellArgs("C:\\Windows\\System32\\cmd.exe", {})).toEqual(["/c"]);
 		expect(getShellArgs("/bin/bash", {})).toEqual(["-l", "-c"]);
 		expect(getShellArgs("/bin/bash", { PI_BASH_NO_LOGIN: "1" })).toEqual(["-c"]);
+	});
+});
+
+describe("quoteHostShellArg", () => {
+	it("single-quotes for POSIX host shells, escaping embedded quotes", () => {
+		expect(quoteHostShellArg("/home/u/my sessions/s.jsonl", "linux")).toBe("'/home/u/my sessions/s.jsonl'");
+		expect(quoteHostShellArg("a'b", "darwin")).toBe("'a'\\''b'");
+	});
+
+	it("double-quotes on Windows so cmd.exe groups a spaced path instead of splitting it", () => {
+		// cmd.exe does not treat single quotes specially, so the POSIX form would
+		// hand `--resume` a split path; double quotes group in cmd.exe and PowerShell.
+		expect(quoteHostShellArg("C:\\Users\\a b\\s.jsonl", "win32")).toBe('"C:\\Users\\a b\\s.jsonl"');
+		expect(quoteHostShellArg('a"b', "win32")).toBe('"a""b"');
 	});
 });
 


### PR DESCRIPTION
## Repro
Resuming a session by explicit path (`omp --resume ~/.pi/agent/sessions/<encoded-cwd>/<file>.jsonl`) keeps it at its foreign location and retains its header id. Run turns, quit the TUI, and the exit banner advertises `Resume this session with omp --resume <id>` — but `omp --resume <id-prefix>` then fails with `Session "..." not found.`. A unit repro (`cd packages/coding-agent && bun test test/utils/resume-command.test.ts`) opens a foreign-path session and confirms the header id is retained, the file is on disk, yet `resolveResumableSession(id, cwd)` returns `undefined`.

## Cause
`SessionManager.open(path)` (`main.ts:920-921`) leaves a path-resumed session at its foreign location. `InteractiveMode.shutdown` (`interactive-mode.ts:4656-4657`) and `AgentSession`'s fatal recovery hint (`agent-session.ts:1483-1490`) both build the banner from `resumeCommand(sessionId)`, gated only on `isSessionOnDisk()`. But `resolveResumableSession` / `listAllSessions` (`session-listing.ts`) enumerate only bucket files one level below `~/.omp/agent/sessions`, so an id for an out-of-bucket file can never match. Same class as #8860/#8915, for on-disk-but-out-of-bucket files.

## Fix
- Add `isManagedSessionFile()` in `session/session-paths.ts`: true only when the file is a bucket child of the managed sessions root — the only layout id-resolution can rediscover.
- Add `resumeCommandForSession(sessionId, sessionFile)` in `utils/resume-command.ts`: managed sessions keep the compact `--resume <id>` form; foreign sessions emit the explicit, shell-quoted file path (opened directly by the `--resume` path branch), carrying the active `--profile` prefix.
- Route both banners (`interactive-mode.ts` exit hint, `agent-session.ts` fatal recovery hint) through the new helper.
- Scope note: broader picker/id discoverability of foreign sessions (reporter's fixes #1/#2) overlaps enhancement #9267 and is intentionally out of scope.

## Verification
`cd packages/coding-agent && bun test test/utils/resume-command.test.ts test/main-session-resolution-error.test.ts test/main-cross-project-resume.test.ts test/slash-commands/resume.test.ts` → 26 pass, 0 fail. `bun check` clean. New tests assert the id form for managed sessions and the explicit (quoted when needed) path form for foreign sessions, with profile prefix carried. Fixes #9544