### PR TITLE
fix(builtins): enabled arm hash acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5028,6 +5028,8 @@ dependencies = [
  "rustix 1.1.4",
  "self_cell",
  "serde_json",
+ "sha2",
+ "sha3",
  "similar 3.2.0",
  "smallvec",
  "strum",
@@ -6113,6 +6115,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/pi-builtins/Cargo.toml
+++ b/crates/pi-builtins/Cargo.toml
@@ -158,6 +158,11 @@ rlimit = "0.11.0"
 rustix = { version = "1.1.4", features = ["fs", "process", "time"] }
 uucore = { version = "0.8.0", features = ["fsxattr", "safe-traversal"] }
 
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+# Enable runtime-dispatched ARMv8 hash instructions for uucore's checksum implementations.
+sha2 = { version = "0.10", features = ["asm"] }
+sha3 = { version = "0.10", features = ["asm"] }
+
 [target."cfg(windows)".dependencies]
 notify = "=8.2.0"
 rustix = { version = "1.1.4", features = ["fs", "process", "time"] }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Resolved cursor drift and text duplication caused by overlapping or out-of-bounds spelling ranges
 - Squeezed transcript tool rows no longer render as a bare unstyled `╭─ Hub` frame: a squeezed block keeps its real render whenever it fits the allocated rows, and blocks that genuinely overflow fold to a themed frame that names the tool's activity (e.g. `Hub · send → Main`).
 - Python/Ruby/Julia eval cells that hit their wall-clock timeout during a `parallel()`/`agent()`/`tool.*` fan-out no longer get their kernel force-killed (losing all session state): the timeout now aborts in-flight bridge calls so the runner unwinds as a clean KeyboardInterrupt and the kernel survives.
+- Accelerated SHA-2 and SHA-3 checksum builtins on ARM64 CPUs that support the corresponding hardware instructions ([#9554](https://github.com/can1357/oh-my-pi/issues/9554)).
 - Multi-select ask options whose labels end in `(Recommended)` now show their checked state and avoid duplicate recommendation suffixes ([#9452](https://github.com/can1357/oh-my-pi/issues/9452)).
 
 ## [18.0.2] - 2026-08-23


### PR DESCRIPTION
## Repro

On the pre-fix tree, `cargo tree -p pi-builtins -e features -i sha2 --depth 1` listed only `default` and `std`; therefore `sha2` 0.10.9 compiled its software backend on `aarch64`, matching the reporter’s `sha256sum` throughput gap against `/usr/bin/sha256sum`.

## Cause

`crates/pi-builtins/Cargo.toml` received `sha2` and `sha3` transitively through `uucore`’s `sum` feature but did not activate either crate’s `asm` feature. `sha2::sha256` requires that feature to compile its AArch64 backend; the backend performs runtime CPU-feature detection before executing SHA instructions.

## Fix

- Enable `sha2/asm` and `sha3/asm` through AArch64-only direct dependencies in `pi-builtins`.
- Lock the resulting `sha2-asm` dependency.
- Document the ARM64 checksum acceleration in the coding-agent changelog.

## Verification

`cargo nextest run -p pi-builtins --status-level=fail --final-status-level=fail` passed all 1,100 tests. `cargo check -p pi-builtins` passed. `cargo tree -p pi-builtins --target aarch64-unknown-linux-gnu -e features -i sha2 --depth 1` now lists `asm` and `sha2-asm`; the equivalent SHA-3 check lists `asm`. The pre-publish `bun check` gate passed.

Fixes #9554