### PR TITLE
fix(advisor): dedupe replayed transcript persistence and unblock resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Advisor transcripts no longer re-persist replayed "Session update" batches on every re-prime/retry, so `__advisor.jsonl` grows with new content instead of ballooning to multiple GB; resumed sessions load the advisor cost total off the critical path (no more minute-long `createAgentSession` hang), and the Agent Hub caps pathological advisor-transcript scans so one huge file can't stall `hub list` ([#9553](https://github.com/can1357/oh-my-pi/issues/9553)).
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/advisor/message-fingerprint.ts
+++ b/packages/coding-agent/src/advisor/message-fingerprint.ts
@@ -1,0 +1,55 @@
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+/**
+ * Field-selective identity hash for an advisor-visible message.
+ *
+ * Hashes every top-level field the advisor renderer actually reads (mirrors
+ * `AppendOnlyContextManager.#messageDigest`, issue #3406). Unrendered metadata
+ * (timestamp, usage, provider internals, message id) churns on provider
+ * round-trips and re-deliveries, so it is deliberately excluded: two messages
+ * with the same rendered content hash equal even when their ids/timestamps
+ * differ.
+ *
+ * Two consumers depend on this equality:
+ * - {@link AdvisorRuntime} tracks the delivered-prefix identity so an
+ *   equivalent clone does not trigger a full-transcript replay.
+ * - {@link AdvisorTranscriptRecorder} skips re-persisting a replayed
+ *   "session update" batch that carries no new content.
+ *
+ * Returns `undefined` when the payload cannot be serialized; callers treat that
+ * as "no identity" and fall back to always delivering/persisting.
+ */
+export function fingerprintMessage(message: AgentMessage): bigint | undefined {
+	try {
+		// Rendered fields (from session-history-format.ts): role, content,
+		// customType, display, isError, toolResult: cancelled/exitCode/output,
+		// custom: details, plus the execution/branch/compaction/file-mention fields
+		// the formatter reads: excludeFromContext, command (bashExecution), code
+		// (pythonExecution), summary + fromId (branch/compaction), files
+		// (fileMention).
+		const m = message as unknown as Record<string, unknown>;
+		const payload = JSON.stringify({
+			r: m.role ?? null,
+			c: m.content ?? null,
+			toolCallId: m.toolCallId ?? null,
+			toolName: m.toolName ?? null,
+			err: m.isError ?? null,
+			ct: m.customType ?? null,
+			disp: m.display ?? null,
+			cancel: m.cancelled ?? null,
+			exit: m.exitCode ?? null,
+			out: m.output ?? null,
+			det: m.details ?? null,
+			xfc: m.excludeFromContext ?? null,
+			cmd: m.command ?? null,
+			code: m.code ?? null,
+			sum: m.summary ?? null,
+			from: m.fromId ?? null,
+			files: m.files ?? null,
+		});
+		if (payload === undefined) return undefined;
+		return Bun.hash.wyhash(payload);
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -13,6 +13,7 @@ import {
 	PRIMARY_CONTEXT_CUSTOM_TYPES,
 } from "../session/session-history-format";
 import { ADVISOR_RENDER_OPTIONS, renderAdvisorDeltaChunks } from "./delta-split";
+import { fingerprintMessage } from "./message-fingerprint";
 
 /**
  * Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core
@@ -254,45 +255,6 @@ interface CatchupWaiter {
 interface DeliveredMessage {
 	message: AgentMessage;
 	fingerprint: bigint | undefined;
-}
-
-function fingerprintMessage(message: AgentMessage): bigint | undefined {
-	try {
-		// Field-selective fingerprint: hash every top-level field the advisor
-		// renderer actually reads (mirrors AppendOnlyContextManager.#messageDigest,
-		// issue #3406). Unrendered metadata (timestamp, usage, provider internals)
-		// churns on provider round-trips and would otherwise trigger a full
-		// transcript replay for a no-op change. Rendered fields (from
-		// session-history-format.ts): role, content, customType, display, isError,
-		// toolResult: cancelled/exitCode/output, custom: details, plus the
-		// execution/branch/compaction/file-mention fields the formatter reads:
-		// excludeFromContext, command (bashExecution), code (pythonExecution),
-		// summary + fromId (branch/compaction), files (fileMention).
-		const m = message as unknown as Record<string, unknown>;
-		const payload = JSON.stringify({
-			r: m.role ?? null,
-			c: m.content ?? null,
-			toolCallId: m.toolCallId ?? null,
-			toolName: m.toolName ?? null,
-			err: m.isError ?? null,
-			ct: m.customType ?? null,
-			disp: m.display ?? null,
-			cancel: m.cancelled ?? null,
-			exit: m.exitCode ?? null,
-			out: m.output ?? null,
-			det: m.details ?? null,
-			xfc: m.excludeFromContext ?? null,
-			cmd: m.command ?? null,
-			code: m.code ?? null,
-			sum: m.summary ?? null,
-			from: m.fromId ?? null,
-			files: m.files ?? null,
-		});
-		if (payload === undefined) return undefined;
-		return Bun.hash.wyhash(payload);
-	} catch {
-		return undefined;
-	}
 }
 
 export class AdvisorRuntime {

--- a/packages/coding-agent/src/advisor/transcript-recorder.ts
+++ b/packages/coding-agent/src/advisor/transcript-recorder.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { Message, UserMessage } from "@oh-my-pi/pi-ai";
@@ -34,56 +34,94 @@ export function isAdvisorTranscriptName(name: string): boolean {
 	);
 }
 
+/** Controls resume-time advisor transcript cost restoration. */
+export interface LoadAdvisorTranscriptCostsOptions {
+	/**
+	 * Runs synchronously after every transcript's byte length has been captured
+	 * and before parsing begins. Callers use this boundary to snapshot in-memory
+	 * costs; later appends are excluded from the disk totals.
+	 */
+	onSnapshot?: () => void;
+}
+
+interface AdvisorTranscriptCostFileSnapshot {
+	file: string;
+	slug: string;
+	maxBytes: number;
+}
+
 /**
- * Sum the advisor spend already persisted next to a primary session transcript,
+ * Sum advisor spend already persisted next to a primary session transcript,
  * keyed by advisor slug.
  *
- * The ledger a session keeps in memory only covers the current process, so a
- * resumed session would report zero until the next advisor turn. The recorded
- * transcripts are the durable copy of exactly the same finalized messages, so
- * they are read back through the shared loader - no lock, no writer, and no
- * second parser to keep in step with the session format.
+ * Each transcript is read only through the byte length captured before
+ * `onSnapshot` runs. This fixed prefix lets resume reconcile the persisted
+ * total with advisor turns billed while the asynchronous scan is running,
+ * without either dropping or double-counting those concurrent turns.
  *
  * Only the session's own advisors count: subagent advisors write to
  * `<session>/<SubId>/__advisor.jsonl`, and their spend belongs to the subagent,
  * not to this roster. Hence the scan stays at the top level of the directory.
  */
-export async function loadAdvisorTranscriptCosts(sessionFile: string | undefined): Promise<Map<string, number>> {
+export async function loadAdvisorTranscriptCosts(
+	sessionFile: string | undefined,
+	options: LoadAdvisorTranscriptCostsOptions = {},
+): Promise<Map<string, number>> {
+	const snapshots: AdvisorTranscriptCostFileSnapshot[] = [];
+	if (sessionFile?.endsWith(JSONL_SUFFIX)) {
+		const directory = sessionFile.slice(0, -JSONL_SUFFIX.length);
+		let dirents: fs.Dirent[] = [];
+		try {
+			dirents = fs.readdirSync(directory, { withFileTypes: true });
+		} catch {}
+		for (const dirent of dirents) {
+			if (!dirent.isFile() || !isAdvisorTranscriptName(dirent.name)) continue;
+			const file = path.join(directory, dirent.name);
+			try {
+				snapshots.push({
+					file,
+					slug:
+						dirent.name === ADVISOR_TRANSCRIPT_FILENAME
+							? ""
+							: dirent.name.slice(`${ADVISOR_TRANSCRIPT_STEM}.`.length, -JSONL_SUFFIX.length),
+					maxBytes: fs.statSync(file).size,
+				});
+			} catch {}
+		}
+	}
+	options.onSnapshot?.();
+
 	const costs = new Map<string, number>();
-	if (!sessionFile?.endsWith(JSONL_SUFFIX)) return costs;
-	const directory = sessionFile.slice(0, -JSONL_SUFFIX.length);
-	const dirents = await fs.readdir(directory, { withFileTypes: true }).catch(() => []);
-	for (const dirent of dirents) {
-		if (!dirent.isFile() || !isAdvisorTranscriptName(dirent.name)) continue;
-		const slug =
-			dirent.name === ADVISOR_TRANSCRIPT_FILENAME
-				? ""
-				: dirent.name.slice(`${ADVISOR_TRANSCRIPT_STEM}.`.length, -JSONL_SUFFIX.length);
+	for (const snapshot of snapshots) {
 		let total = 0;
 		let validHeader: boolean | undefined;
 		try {
-			await visitEntriesFromFileStream(path.join(directory, dirent.name), entry => {
-				const isObject = typeof entry === "object" && entry !== null;
-				if (validHeader === undefined) {
-					validHeader = isObject && entry.type === "session" && typeof entry.id === "string";
-					return;
-				}
-				// A syntactically valid but non-object entry (e.g. a bare `null`
-				// line) must cost only itself, not crash entry.type access and
-				// discard everything accumulated for this transcript.
-				if (!validHeader || !isObject || entry.type !== "message") return;
-				const message = entry.message;
-				if (!message || typeof message !== "object" || message.role !== "assistant") return;
-				// One malformed usage block must cost that entry only, not the
-				// whole transcript's total.
-				const total_ = message.usage?.cost?.total;
-				if (typeof total_ === "number" && Number.isFinite(total_)) total += total_;
-			});
+			await visitEntriesFromFileStream(
+				snapshot.file,
+				entry => {
+					const isObject = typeof entry === "object" && entry !== null;
+					if (validHeader === undefined) {
+						validHeader = isObject && entry.type === "session" && typeof entry.id === "string";
+						return;
+					}
+					// A syntactically valid but non-object entry (e.g. a bare
+					// `null` line) must cost only itself, not crash entry.type
+					// access and discard everything accumulated for this transcript.
+					if (!validHeader || !isObject || entry.type !== "message") return;
+					const message = entry.message;
+					if (!message || typeof message !== "object" || message.role !== "assistant") return;
+					// One malformed usage block must cost that entry only, not the
+					// whole transcript's total.
+					const total_ = message.usage?.cost?.total;
+					if (typeof total_ === "number" && Number.isFinite(total_)) total += total_;
+				},
+				{ maxBytes: snapshot.maxBytes },
+			);
 		} catch (err) {
-			logger.debug("advisor transcript cost read failed", { file: dirent.name, err: String(err) });
+			logger.debug("advisor transcript cost read failed", { file: path.basename(snapshot.file), err: String(err) });
 			continue;
 		}
-		if (total > 0) costs.set(slug, total);
+		if (total > 0) costs.set(snapshot.slug, total);
 	}
 	return costs;
 }

--- a/packages/coding-agent/src/advisor/transcript-recorder.ts
+++ b/packages/coding-agent/src/advisor/transcript-recorder.ts
@@ -5,6 +5,7 @@ import type { Message, UserMessage } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import { visitEntriesFromFileStream } from "../session/session-loader";
 import { SessionManager } from "../session/session-manager";
+import { fingerprintMessage } from "./message-fingerprint";
 
 /**
  * Reserved transcript stem for advisor session files. Chosen so it cannot
@@ -114,6 +115,18 @@ export class AdvisorTranscriptRecorder {
 	#filename: string;
 	/** Serializes the async open/close against synchronous appends so records land in order. */
 	#queue: Promise<void>;
+	/**
+	 * Fingerprints of user "session update" deltas already persisted to
+	 * {@link #dedupFile}. The advisor re-primes on every history rewrite
+	 * (compaction, resume, retry) and re-emits the SAME replay batch with fresh
+	 * ids/timestamps; those carry no usage, so skipping exact repeats keeps the
+	 * transcript O(new content) without dropping a billed assistant turn
+	 * (issue #9553). Reset when the target file changes so a session switch
+	 * starts a fresh dedup window.
+	 */
+	#seenUserFingerprints = new Set<bigint>();
+	/** Target file the {@link #seenUserFingerprints} window belongs to. */
+	#dedupFile: string | undefined;
 
 	/**
 	 * @param filename Transcript filename within the session dir. Defaults to
@@ -163,6 +176,22 @@ export class AdvisorTranscriptRecorder {
 		const sessionFile = this.resolveSessionFile();
 		if (!sessionFile?.endsWith(JSONL_SUFFIX)) return;
 		const file = path.join(sessionFile.slice(0, -JSONL_SUFFIX.length), this.#filename);
+		// A new target file starts a fresh dedup window: fingerprints from the
+		// prior session's replays must never suppress the new file's first update.
+		if (file !== this.#dedupFile) {
+			this.#dedupFile = file;
+			this.#seenUserFingerprints.clear();
+		}
+		// Drop a re-delivered replay batch: user deltas carry no usage, so an
+		// exact repeat adds nothing but bytes. Assistant/toolResult turns are the
+		// advisor's real (billed) work and are always persisted, even on retry.
+		if (message.role === "user") {
+			const fingerprint = fingerprintMessage(message);
+			if (fingerprint !== undefined) {
+				if (this.#seenUserFingerprints.has(fingerprint)) return;
+				this.#seenUserFingerprints.add(fingerprint);
+			}
+		}
 		const cwd = this.resolveCwd();
 		this.#enqueue(async () => {
 			if (file !== this.#file) {

--- a/packages/coding-agent/src/advisor/transcript-recorder.ts
+++ b/packages/coding-agent/src/advisor/transcript-recorder.ts
@@ -154,17 +154,20 @@ export class AdvisorTranscriptRecorder {
 	/** Serializes the async open/close against synchronous appends so records land in order. */
 	#queue: Promise<void>;
 	/**
-	 * Fingerprints of user "session update" deltas already persisted to
-	 * {@link #dedupFile}. The advisor re-primes on every history rewrite
-	 * (compaction, resume, retry) and re-emits the SAME replay batch with fresh
-	 * ids/timestamps; those carry no usage, so skipping exact repeats keeps the
-	 * transcript O(new content) without dropping a billed assistant turn
-	 * (issue #9553). Reset when the target file changes so a session switch
-	 * starts a fresh dedup window.
+	 * Ordered fingerprints of user "session update" deltas persisted since the
+	 * last committed advisor turn. The advisor re-delivers the identical batch on
+	 * every retry/overflow/refusal loop (issue #9553), and {@link #rollbackFailedTurn}
+	 * only cleans the agent's in-memory state — the recorder already wrote the
+	 * attempt. Matching a re-delivery positionally against this window skips the
+	 * duplicate while still persisting genuinely new content, including two
+	 * distinct deltas that happen to render identically (a repeated prompt, or two
+	 * tool runs with the same output).
 	 */
-	#seenUserFingerprints = new Set<bigint>();
-	/** Target file the {@link #seenUserFingerprints} window belongs to. */
-	#dedupFile: string | undefined;
+	#replayWindow: bigint[] = [];
+	/** Cursor into {@link #replayWindow}; reset at each delivery attempt via {@link beginTurn}. */
+	#replayCursor = 0;
+	/** Target file {@link #replayWindow} belongs to; a switch starts a fresh window. */
+	#windowFile: string | undefined;
 
 	/**
 	 * @param filename Transcript filename within the session dir. Defaults to
@@ -214,20 +217,33 @@ export class AdvisorTranscriptRecorder {
 		const sessionFile = this.resolveSessionFile();
 		if (!sessionFile?.endsWith(JSONL_SUFFIX)) return;
 		const file = path.join(sessionFile.slice(0, -JSONL_SUFFIX.length), this.#filename);
-		// A new target file starts a fresh dedup window: fingerprints from the
-		// prior session's replays must never suppress the new file's first update.
-		if (file !== this.#dedupFile) {
-			this.#dedupFile = file;
-			this.#seenUserFingerprints.clear();
+		// A new target file starts a fresh replay window: positions from the prior
+		// session's turns must never suppress the new file's first delta.
+		if (file !== this.#windowFile) {
+			this.#windowFile = file;
+			this.#replayWindow = [];
+			this.#replayCursor = 0;
 		}
-		// Drop a re-delivered replay batch: user deltas carry no usage, so an
-		// exact repeat adds nothing but bytes. Assistant/toolResult turns are the
-		// advisor's real (billed) work and are always persisted, even on retry.
+		// Skip a re-delivered user delta: on retry/overflow/refusal the advisor
+		// re-sends the identical batch in the same order, so a positional match
+		// against this turn's window is a replay that adds only bytes. New content
+		// — including a delta that renders like an earlier one — diverges from the
+		// window and is persisted. Assistant/tool turns are billed work: always
+		// written, so cost attribution and the Hub transcript stay intact.
 		if (message.role === "user") {
 			const fingerprint = fingerprintMessage(message);
 			if (fingerprint !== undefined) {
-				if (this.#seenUserFingerprints.has(fingerprint)) return;
-				this.#seenUserFingerprints.add(fingerprint);
+				if (this.#replayCursor < this.#replayWindow.length) {
+					if (this.#replayWindow[this.#replayCursor] === fingerprint) {
+						this.#replayCursor++;
+						return;
+					}
+					// Divergent retry (e.g. reasoning stripped after a refusal): the
+					// window no longer matches, so drop its stale tail and record anew.
+					this.#replayWindow.length = this.#replayCursor;
+				}
+				this.#replayWindow.push(fingerprint);
+				this.#replayCursor = this.#replayWindow.length;
 			}
 		}
 		const cwd = this.resolveCwd();
@@ -242,6 +258,25 @@ export class AdvisorTranscriptRecorder {
 			}
 			this.#manager?.appendMessage(persisted);
 		});
+	}
+
+	/**
+	 * Mark the start of one advisor delivery attempt. Rewinds the replay cursor so
+	 * a retry that re-sends the same batch matches this turn's window positionally
+	 * and is skipped, while the window itself (persisted-since-commit) is retained.
+	 */
+	beginTurn(): void {
+		this.#replayCursor = 0;
+	}
+
+	/**
+	 * Mark an advisor turn as committed (its output landed). Clears the replay
+	 * window so the next turn's deltas are recorded even when they render like a
+	 * committed one — only re-deliveries of an *uncommitted* turn are replays.
+	 */
+	commitTurn(): void {
+		this.#replayWindow = [];
+		this.#replayCursor = 0;
 	}
 
 	/** Flush pending writes (best-effort). */

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -19,6 +19,13 @@ import {
 
 /** Maximum prefix entries inspected for task metadata. */
 const MAX_METADATA_LINES = 64;
+/**
+ * Upper bound on records scanned to compute an advisor transcript's Hub metrics.
+ * Well above any healthy advisor file (post issue #9553 the file grows O(new
+ * content)); it exists only so a legacy multi-GB transcript can't stall the
+ * render thread when the Hub roster is built.
+ */
+const MAX_ADVISOR_HISTORY_LINES = 200_000;
 
 interface PersistedAgentMetadata {
 	activity?: string;
@@ -155,7 +162,17 @@ async function readPersistedAgentHistory(
 				const message = recordOf(record.message);
 				if (message?.role === "assistant") assistantById.set(id, assistantMetrics(message));
 			},
-			{ shouldContinue },
+			// Advisor transcripts are the one file that can grow pathologically large
+			// (issue #9553); cap their scan so one bad transcript can't stall the Hub
+			// on the render thread. Healthy advisor files sit far below this bound,
+			// so their metrics stay exact; a capped legacy file reports approximate
+			// (lower-bound) cost/tokens rather than freezing `hub list`.
+			{
+				shouldContinue,
+				maxRecords: isAdvisorTranscriptName(path.basename(transcript.sessionFile))
+					? MAX_ADVISOR_HISTORY_LINES
+					: undefined,
+			},
 		);
 	} catch {
 		return {};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -46,7 +46,6 @@ import {
 	discoverWatchdogFiles,
 	formatActiveRepoWatchdogPrompt,
 	formatAdvisorContextPrompt,
-	loadAdvisorTranscriptCosts,
 } from "./advisor";
 import { AsyncJobManager } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
@@ -3483,9 +3482,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// Owned only when this session created the manager; subagents receive a
 		// parent's manager via `options.mcpManager` and MUST NOT disconnect it.
 		const ownedMcpManager = options.mcpManager ? undefined : mcpManager;
-		// A resumed session already has advisor turns on disk; without this its
-		// status-line cost total would restart at zero for the rest of the session.
-		const initialAdvisorCosts = await loadAdvisorTranscriptCosts(sessionManager.getSessionFile());
+		// Advisor spend recorded before this resume is restored off the critical
+		// path below (issue #9553): a large advisor transcript would otherwise
+		// block createAgentSession for tens of seconds while the whole file is
+		// streamed and parsed on the main thread.
 		session = new AgentSession({
 			codeModeState,
 			advisorWatchdogPrompt,
@@ -3501,7 +3501,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			planYolo: options.planYolo,
 			serviceTierByFamily: initialServiceTierByFamily,
 			sessionManager,
-			initialAdvisorCosts,
 			settings,
 			autoApprove: options.autoApprove,
 			scoutAllowedBySpawnPolicy: isScoutSpawnable(undefined, options.spawns ?? "*"),
@@ -3601,6 +3600,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			titleSystemPrompt: options.titleSystemPrompt,
 		});
 		hasSession = true;
+		// Backfill the resumed advisor spend without blocking startup: the scan
+		// runs after the session is live, so `--resume` no longer scales with the
+		// advisor transcript size (issue #9553).
+		session.beginInitialAdvisorCostRestore();
 		// Extension factories normally register tools before session construction,
 		// but Pi-compatible extensions may discover them asynchronously from a
 		// session_start handler. Install those late registrations into the live

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -194,8 +194,6 @@ export interface AgentSessionConfig {
 	sideStreamFn?: StreamFn;
 	/** Stream wrapper for advisor requests. */
 	advisorStreamFn?: StreamFn;
-	/** Advisor spend already recorded for the session being opened, restored on resume. */
-	initialAdvisorCosts?: ReadonlyMap<string, number>;
 	/** Prefer websocket transport for OpenAI Codex requests when supported. */
 	preferWebsockets?: boolean;
 	/** Codex saved-reset coordinator; defaults to the process-wide singleton so concurrent sessions can't double-spend. Inject a fresh one in tests. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -519,6 +519,8 @@ export class AgentSession {
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
 	readonly #advisors: SessionAdvisors;
+	/** Resolves once the resume-time advisor spend backfill settles (issue #9553). */
+	#advisorCostRestore: Promise<void> = Promise.resolve();
 	#goalTurnCounter = 0;
 	#planReferenceSent = false;
 	#planReferencePath = "local://PLAN.md";
@@ -1546,7 +1548,6 @@ export class AgentSession {
 			configs: config.advisorConfigs,
 			streamFn: config.advisorStreamFn,
 			transformProviderContext: config.transformProviderContext,
-			initialCosts: config.initialAdvisorCosts,
 		});
 
 		const maintenanceHost: SessionMaintenanceHost = {
@@ -9660,6 +9661,35 @@ export class AgentSession {
 	/** Return cumulative cost recorded for the current session's advisor activity. */
 	getAdvisorCost(): number {
 		return this.#advisors.getAdvisorCost();
+	}
+
+	/**
+	 * Begin backfilling advisor spend recorded before this resume, off the
+	 * critical path (issue #9553). A large advisor transcript would otherwise
+	 * block session startup for tens of seconds while the whole file is streamed
+	 * and parsed; instead the status-line total hydrates once the scan settles.
+	 * The resulting promise is exposed via {@link advisorCostRestore} for tests
+	 * and headless callers that must observe the hydrated total.
+	 */
+	beginInitialAdvisorCostRestore(): void {
+		this.#advisorCostRestore = loadAdvisorTranscriptCosts(this.sessionFile)
+			.then(costs => this.restoreInitialAdvisorCosts(costs))
+			.catch(err => logger.debug("advisor cost restore failed", { err: String(err) }));
+	}
+
+	/** Resolves once {@link beginInitialAdvisorCostRestore}'s scan has settled. */
+	get advisorCostRestore(): Promise<void> {
+		return this.#advisorCostRestore;
+	}
+
+	/**
+	 * Seed persisted advisor spend into the status-line ledger. A slug already
+	 * billed this process keeps its accumulated value, so a late-settling scan
+	 * (see {@link beginInitialAdvisorCostRestore}) never clobbers or
+	 * double-counts a turn that finished first.
+	 */
+	restoreInitialAdvisorCosts(costs: ReadonlyMap<string, number>): void {
+		this.#advisors.restoreInitialCost(costs);
 	}
 	/** Return whether any active or configured advisor is running on an OAuth/subscription model. */
 	isAdvisorUsingSubscription(): boolean {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9672,8 +9672,12 @@ export class AgentSession {
 	 * and headless callers that must observe the hydrated total.
 	 */
 	beginInitialAdvisorCostRestore(): void {
+		const sessionId = this.sessionId;
 		this.#advisorCostRestore = loadAdvisorTranscriptCosts(this.sessionFile)
-			.then(costs => this.restoreInitialAdvisorCosts(costs))
+			.then(costs => {
+				if (this.sessionId !== sessionId) return;
+				this.restoreInitialAdvisorCosts(costs);
+			})
 			.catch(err => logger.debug("advisor cost restore failed", { err: String(err) }));
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9673,10 +9673,15 @@ export class AgentSession {
 	 */
 	beginInitialAdvisorCostRestore(): void {
 		const sessionId = this.sessionId;
-		this.#advisorCostRestore = loadAdvisorTranscriptCosts(this.sessionFile)
+		let costsAtSnapshot: ReadonlyMap<string, number> = new Map();
+		this.#advisorCostRestore = loadAdvisorTranscriptCosts(this.sessionFile, {
+			onSnapshot: () => {
+				costsAtSnapshot = this.#advisors.costSnapshot();
+			},
+		})
 			.then(costs => {
 				if (this.sessionId !== sessionId) return;
-				this.restoreInitialAdvisorCosts(costs);
+				this.restoreInitialAdvisorCosts(costs, costsAtSnapshot);
 			})
 			.catch(err => logger.debug("advisor cost restore failed", { err: String(err) }));
 	}
@@ -9687,13 +9692,16 @@ export class AgentSession {
 	}
 
 	/**
-	 * Seed persisted advisor spend into the status-line ledger. A slug already
-	 * billed this process keeps its accumulated value, so a late-settling scan
-	 * (see {@link beginInitialAdvisorCostRestore}) never clobbers or
-	 * double-counts a turn that finished first.
+	 * Restore persisted advisor spend plus the process-local delta billed after
+	 * `costsAtSnapshot`. The loader fixes every transcript's byte length before
+	 * capturing that baseline, so a turn completed while the scan runs is added
+	 * exactly once.
 	 */
-	restoreInitialAdvisorCosts(costs: ReadonlyMap<string, number>): void {
-		this.#advisors.restoreInitialCost(costs);
+	restoreInitialAdvisorCosts(
+		costs: ReadonlyMap<string, number>,
+		costsAtSnapshot: ReadonlyMap<string, number> = new Map(),
+	): void {
+		this.#advisors.restoreInitialCost(costs, costsAtSnapshot);
 	}
 	/** Return whether any active or configured advisor is running on an OAuth/subscription model. */
 	isAdvisorUsingSubscription(): boolean {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -443,17 +443,24 @@ export class SessionAdvisors {
 		this.#advisorCosts = new Map(costs);
 	}
 
+	/** Capture the per-advisor ledger at a transcript byte-snapshot boundary. */
+	costSnapshot(): ReadonlyMap<string, number> {
+		return new Map(this.#advisorCosts);
+	}
+
 	/**
-	 * Seed the persisted spend recorded before this session was resumed. Applied
-	 * off the critical path (see {@link AgentSession.restoreInitialAdvisorCosts}),
-	 * so a slug already billed this process — a turn that finished before the
-	 * transcript scan did — keeps its accumulated value instead of being
-	 * clobbered or double-counted.
+	 * Restore spend persisted at `costsAtSnapshot`, then add only the process-local
+	 * delta billed after that fixed transcript snapshot. This preserves turns
+	 * completed while the background scan runs without double-counting entries
+	 * the scan already includes.
 	 */
-	restoreInitialCost(costs: ReadonlyMap<string, number>): void {
-		for (const [slug, total] of costs) {
-			if (!this.#advisorCosts.has(slug)) this.#advisorCosts.set(slug, total);
+	restoreInitialCost(costs: ReadonlyMap<string, number>, costsAtSnapshot: ReadonlyMap<string, number>): void {
+		const restored = new Map(costs);
+		for (const [slug, current] of this.#advisorCosts) {
+			const accrued = current - (costsAtSnapshot.get(slug) ?? 0);
+			if (accrued > 0) restored.set(slug, (restored.get(slug) ?? 0) + accrued);
 		}
+		this.#advisorCosts = restored;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -217,8 +217,6 @@ export interface SessionAdvisorsOptions {
 	configs?: AdvisorConfig[];
 	streamFn?: StreamFn;
 	transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
-	/** Advisor spend already persisted for this session, restored on resume. */
-	initialCosts?: ReadonlyMap<string, number>;
 }
 
 /** Options accepted when an advisor injects a primary-session message. */
@@ -328,7 +326,6 @@ export class SessionAdvisors {
 		this.#advisorConfigs = options.configs;
 		this.#advisorStreamFn = options.streamFn;
 		this.#transformProviderContext = options.transformProviderContext;
-		if (options.initialCosts) this.#advisorCosts = new Map(options.initialCosts);
 		if (this.#advisorEnabled) this.#buildAdvisorRuntime();
 	}
 
@@ -444,6 +441,19 @@ export class SessionAdvisors {
 	/** Replace the ledger with the spend recorded for the session becoming active. */
 	restoreCost(costs: ReadonlyMap<string, number>): void {
 		this.#advisorCosts = new Map(costs);
+	}
+
+	/**
+	 * Seed the persisted spend recorded before this session was resumed. Applied
+	 * off the critical path (see {@link AgentSession.restoreInitialAdvisorCosts}),
+	 * so a slug already billed this process — a turn that finished before the
+	 * transcript scan did — keeps its accumulated value instead of being
+	 * clobbered or double-counted.
+	 */
+	restoreInitialCost(costs: ReadonlyMap<string, number>): void {
+		for (const [slug, total] of costs) {
+			if (!this.#advisorCosts.has(slug)) this.#advisorCosts.set(slug, total);
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -950,12 +950,16 @@ export class SessionAdvisors {
 				obfuscator: this.#host.obfuscator,
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
 				beginAdvisorUpdate: inProgress => {
+					advisorRef.recorder.beginTurn();
 					advisorRef.adviseTool.beginUpdate(inProgress);
 					advisorRef.emissionGuard.beginUpdate();
 				},
 				onTurnError: (error, failedMessages, signal) =>
 					this.#recoverAdvisorTurn(advisorRef, error, failedMessages, signal),
 				onTurnSuccess: async () => {
+					// Commit the delivered batch so retries of a failed turn stay deduped
+					// while this successful turn's context is persisted once (issue #9553).
+					advisorRef.recorder.commitTurn();
 					const fallback = advisorRef.retryFallback;
 					if (!advisorRef.retryFallbackPendingSuccess || !fallback) return;
 					advisorRef.retryFallbackPendingSuccess = false;

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -22,6 +22,8 @@ export interface VisitEntriesFromFileStreamOptions {
 	shouldContinue?: () => boolean;
 	/** Stop after this many valid or malformed JSONL records have been consumed. */
 	maxRecords?: number;
+	/** Read at most this many bytes from the file's current prefix. */
+	maxBytes?: number;
 	/** Yield to the macrotask queue after this many bytes have been consumed. */
 	yieldEveryBytes?: number;
 	/** Yield to the macrotask queue after this many entries have been visited. */
@@ -92,6 +94,7 @@ export async function visitEntriesFromFileStream(
 	let visitorThrew = false;
 	const yieldEveryBytes = Math.max(0, options.yieldEveryBytes ?? STREAM_YIELD_BYTES);
 	const yieldEveryEntries = Math.max(0, options.yieldEveryEntries ?? STREAM_YIELD_ENTRIES);
+	const maxBytes = Math.max(0, options.maxBytes ?? Number.POSITIVE_INFINITY);
 	// Byte buffer (NOT a decoded string): multibyte UTF-8 sequences that straddle
 	// a stream-chunk boundary stay intact, and Bun.JSONL.parseChunk accepts typed
 	// arrays directly. Only the unconsumed remainder is held (≤ one record + a
@@ -182,7 +185,9 @@ export async function visitEntriesFromFileStream(
 	};
 
 	try {
-		for await (const chunk of Bun.file(filePath).stream()) {
+		const file = Bun.file(filePath);
+		const source = Number.isFinite(maxBytes) ? file.slice(0, maxBytes) : file;
+		for await (const chunk of source.stream()) {
 			if (stopped) break;
 			bytesSinceYield += chunk.byteLength;
 			buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -17,6 +17,7 @@ import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import * as advisorModule from "../src/advisor";
 import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 describe("AgentSession advisor toggle", () => {
@@ -563,6 +564,20 @@ describe("AgentSession advisor toggle", () => {
 		// billed this process (issue #9553).
 		session.restoreInitialAdvisorCosts(new Map([["", 0.5]]));
 		expect(session.getAdvisorCost()).toBeCloseTo(0.25, 8);
+	});
+	it("ignores an initial cost restore after the active session changes", async () => {
+		const restore = Promise.withResolvers<Map<string, number>>();
+		const load = vi.spyOn(advisorModule, "loadAdvisorTranscriptCosts").mockReturnValue(restore.promise);
+		try {
+			session.beginInitialAdvisorCostRestore();
+			await session.newSession();
+			restore.resolve(new Map([["", 0.5]]));
+			await session.advisorCostRestore;
+
+			expect(session.getAdvisorCost()).toBe(0);
+		} finally {
+			load.mockRestore();
+		}
 	});
 	it("starts a new session with only post-transition advisor cost", async () => {
 		const advisor = enableAdvisor();

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -543,10 +543,26 @@ describe("AgentSession advisor toggle", () => {
 			enableLsp: false,
 		});
 		try {
+			// The scan runs off the critical path now (issue #9553), so await the
+			// backfill signal the session exposes rather than a wall-clock guess.
+			await result.session.advisorCostRestore;
 			expect(result.session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 		} finally {
 			await result.session.dispose();
 		}
+	});
+	it("seeds persisted advisor spend when no turn has been billed yet", () => {
+		enableAdvisor();
+		session.restoreInitialAdvisorCosts(new Map([["", 0.5]]));
+		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
+	});
+	it("keeps a turn billed before the resume scan finishes instead of clobbering it", () => {
+		const advisor = enableAdvisor();
+		appendAdvisorCost(advisor, 0.25, 1);
+		// A late-settling scan must not overwrite or double-count the turn already
+		// billed this process (issue #9553).
+		session.restoreInitialAdvisorCosts(new Map([["", 0.5]]));
+		expect(session.getAdvisorCost()).toBeCloseTo(0.25, 8);
 	});
 	it("starts a new session with only post-transition advisor cost", async () => {
 		const advisor = enableAdvisor();

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -557,17 +557,30 @@ describe("AgentSession advisor toggle", () => {
 		session.restoreInitialAdvisorCosts(new Map([["", 0.5]]));
 		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 	});
-	it("keeps a turn billed before the resume scan finishes instead of clobbering it", () => {
-		const advisor = enableAdvisor();
-		appendAdvisorCost(advisor, 0.25, 1);
-		// A late-settling scan must not overwrite or double-count the turn already
-		// billed this process (issue #9553).
-		session.restoreInitialAdvisorCosts(new Map([["", 0.5]]));
-		expect(session.getAdvisorCost()).toBeCloseTo(0.25, 8);
+	it("adds a turn billed while the resume scan is running to persisted spend", async () => {
+		const restore = Promise.withResolvers<Map<string, number>>();
+		const load = vi.spyOn(advisorModule, "loadAdvisorTranscriptCosts").mockImplementation((_file, options) => {
+			options?.onSnapshot?.();
+			return restore.promise;
+		});
+		try {
+			session.beginInitialAdvisorCostRestore();
+			const advisor = enableAdvisor();
+			appendAdvisorCost(advisor, 0.25, 1);
+			restore.resolve(new Map([["", 0.5]]));
+			await session.advisorCostRestore;
+
+			expect(session.getAdvisorCost()).toBeCloseTo(0.75, 8);
+		} finally {
+			load.mockRestore();
+		}
 	});
 	it("ignores an initial cost restore after the active session changes", async () => {
 		const restore = Promise.withResolvers<Map<string, number>>();
-		const load = vi.spyOn(advisorModule, "loadAdvisorTranscriptCosts").mockReturnValue(restore.promise);
+		const load = vi.spyOn(advisorModule, "loadAdvisorTranscriptCosts").mockImplementation((_file, options) => {
+			options?.onSnapshot?.();
+			return restore.promise;
+		});
 		try {
 			session.beginInitialAdvisorCostRestore();
 			await session.newSession();

--- a/packages/coding-agent/test/advisor/transcript-recorder.test.ts
+++ b/packages/coding-agent/test/advisor/transcript-recorder.test.ts
@@ -231,6 +231,34 @@ describe("AdvisorTranscriptRecorder", () => {
 		});
 	});
 
+	it("excludes transcript entries appended after the cost snapshot", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "sess.jsonl");
+			const recorder = new AdvisorTranscriptRecorder(
+				() => sessionFile,
+				() => dir,
+			);
+			recorder.record(assistantMessage("persisted before snapshot", 1, 0.25));
+			await recorder.close();
+
+			const transcript = path.join(dir, "sess", ADVISOR_TRANSCRIPT_FILENAME);
+			const appended = Promise.withResolvers<void>();
+			const costs = loadAdvisorTranscriptCosts(sessionFile, {
+				onSnapshot: () => {
+					const entry = JSON.stringify({
+						type: "message",
+						message: assistantMessage("billed after snapshot", 1, 0.5),
+					});
+					void fs.appendFile(transcript, `${entry}\n`).then(appended.resolve, appended.reject);
+				},
+			});
+			await appended.promise;
+
+			expect((await costs).get("")).toBeCloseTo(0.25, 8);
+			expect((await loadAdvisorTranscriptCosts(sessionFile)).get("")).toBeCloseTo(0.75, 8);
+		});
+	});
+
 	it("keeps valid costs when persisted entries are malformed", async () => {
 		await withTempDir(async dir => {
 			const sessionFile = path.join(dir, "sess.jsonl");

--- a/packages/coding-agent/test/advisor/transcript-recorder.test.ts
+++ b/packages/coding-agent/test/advisor/transcript-recorder.test.ts
@@ -164,6 +164,49 @@ describe("AdvisorTranscriptRecorder", () => {
 		});
 	});
 
+	it("drops re-delivered replay batches but keeps every billed assistant turn", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "sess.jsonl");
+			const recorder = new AdvisorTranscriptRecorder(
+				() => sessionFile,
+				() => dir,
+			);
+			// The advisor re-primes on every history rewrite and re-emits the SAME
+			// "session update" with fresh timestamps; each cycle still bills a
+			// distinct assistant turn.
+			for (let cycle = 0; cycle < 5; cycle++) {
+				recorder.record({ ...userMessage("### Session update"), timestamp: cycle + 1 } as AgentMessage);
+				recorder.record(assistantMessage(`advice ${cycle}`, 1, 0.1));
+			}
+			await recorder.close();
+
+			const messages = await readMessageEntries(path.join(dir, "sess", ADVISOR_TRANSCRIPT_FILENAME));
+			expect(messages.filter(m => m.message?.role === "user")).toHaveLength(1);
+			expect(messages.filter(m => m.message?.role === "assistant")).toHaveLength(5);
+			expect((await loadAdvisorTranscriptCosts(sessionFile)).get("")).toBeCloseTo(0.5, 8);
+		});
+	});
+
+	it("re-persists an identical replay after a session switch resets the dedup window", async () => {
+		await withTempDir(async dir => {
+			let sessionFile = path.join(dir, "first.jsonl");
+			const recorder = new AdvisorTranscriptRecorder(
+				() => sessionFile,
+				() => dir,
+			);
+			recorder.record(userMessage("### Session update"));
+			recorder.record(userMessage("### Session update")); // deduped within the first file
+			sessionFile = path.join(dir, "second.jsonl");
+			recorder.record(userMessage("### Session update")); // new file → fresh window
+			await recorder.close();
+
+			const first = await readMessageEntries(path.join(dir, "first", ADVISOR_TRANSCRIPT_FILENAME));
+			const second = await readMessageEntries(path.join(dir, "second", ADVISOR_TRANSCRIPT_FILENAME));
+			expect(first.filter(m => m.message?.role === "user")).toHaveLength(1);
+			expect(second.filter(m => m.message?.role === "user")).toHaveLength(1);
+		});
+	});
+
 	it("loads cumulative costs by advisor slug", async () => {
 		await withTempDir(async dir => {
 			const sessionFile = path.join(dir, "sess.jsonl");

--- a/packages/coding-agent/test/advisor/transcript-recorder.test.ts
+++ b/packages/coding-agent/test/advisor/transcript-recorder.test.ts
@@ -164,20 +164,21 @@ describe("AdvisorTranscriptRecorder", () => {
 		});
 	});
 
-	it("drops re-delivered replay batches but keeps every billed assistant turn", async () => {
+	it("skips a retried batch but keeps every billed assistant turn", async () => {
 		await withTempDir(async dir => {
 			const sessionFile = path.join(dir, "sess.jsonl");
 			const recorder = new AdvisorTranscriptRecorder(
 				() => sessionFile,
 				() => dir,
 			);
-			// The advisor re-primes on every history rewrite and re-emits the SAME
-			// "session update" with fresh timestamps; each cycle still bills a
-			// distinct assistant turn.
-			for (let cycle = 0; cycle < 5; cycle++) {
-				recorder.record({ ...userMessage("### Session update"), timestamp: cycle + 1 } as AgentMessage);
-				recorder.record(assistantMessage(`advice ${cycle}`, 1, 0.1));
+			// A failing advisor re-sends the identical batch each attempt; the turn
+			// only commits once it finally succeeds (issue #9553).
+			for (let attempt = 0; attempt < 5; attempt++) {
+				recorder.beginTurn();
+				recorder.record({ ...userMessage("### Session update"), timestamp: attempt + 1 } as AgentMessage);
+				recorder.record(assistantMessage(`attempt ${attempt}`, 1, 0.1));
 			}
+			recorder.commitTurn();
 			await recorder.close();
 
 			const messages = await readMessageEntries(path.join(dir, "sess", ADVISOR_TRANSCRIPT_FILENAME));
@@ -187,23 +188,46 @@ describe("AdvisorTranscriptRecorder", () => {
 		});
 	});
 
-	it("re-persists an identical replay after a session switch resets the dedup window", async () => {
+	it("keeps identical deltas that belong to distinct committed turns", async () => {
 		await withTempDir(async dir => {
-			let sessionFile = path.join(dir, "first.jsonl");
+			const sessionFile = path.join(dir, "sess.jsonl");
 			const recorder = new AdvisorTranscriptRecorder(
 				() => sessionFile,
 				() => dir,
 			);
-			recorder.record(userMessage("### Session update"));
-			recorder.record(userMessage("### Session update")); // deduped within the first file
-			sessionFile = path.join(dir, "second.jsonl");
-			recorder.record(userMessage("### Session update")); // new file → fresh window
+			// The user re-submits the same prompt across three separate turns: each
+			// renders an identical "Session update" yet is genuinely new content.
+			for (let turn = 0; turn < 3; turn++) {
+				recorder.beginTurn();
+				recorder.record(userMessage("### Session update"));
+				recorder.record(assistantMessage(`review ${turn}`, 1, 0.1));
+				recorder.commitTurn();
+			}
 			await recorder.close();
 
-			const first = await readMessageEntries(path.join(dir, "first", ADVISOR_TRANSCRIPT_FILENAME));
-			const second = await readMessageEntries(path.join(dir, "second", ADVISOR_TRANSCRIPT_FILENAME));
-			expect(first.filter(m => m.message?.role === "user")).toHaveLength(1);
-			expect(second.filter(m => m.message?.role === "user")).toHaveLength(1);
+			const messages = await readMessageEntries(path.join(dir, "sess", ADVISOR_TRANSCRIPT_FILENAME));
+			expect(messages.filter(m => m.message?.role === "user")).toHaveLength(3);
+		});
+	});
+
+	it("keeps identical deltas delivered within one turn", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "sess.jsonl");
+			const recorder = new AdvisorTranscriptRecorder(
+				() => sessionFile,
+				() => dir,
+			);
+			// Two tool runs with byte-identical output render two identical chunks in
+			// one delivery; both must persist (they are distinct positions, not a replay).
+			recorder.beginTurn();
+			recorder.record(userMessage("### Session update"));
+			recorder.record(userMessage("### Session update"));
+			recorder.record(assistantMessage("review", 1, 0.1));
+			recorder.commitTurn();
+			await recorder.close();
+
+			const messages = await readMessageEntries(path.join(dir, "sess", ADVISOR_TRANSCRIPT_FILENAME));
+			expect(messages.filter(m => m.message?.role === "user")).toHaveLength(2);
 		});
 	});
 


### PR DESCRIPTION
## Repro
With an advisor enabled and repeatedly re-priming (frequent compactions, or a failing/quota-exhausted advisor per #8908), `<session>/__advisor.jsonl` grows superlinearly and `omp --resume <id>` hangs in `createAgentSession` (startup watchdog fires `Still starting after 10s — phase: createAgentSession`). Driving the recorder with the same replayed batch reproduces the persistence bug directly:

```
$ bun repro-9553.ts   # 30 identical "### Session update" replays
persisted user 'Session update' entries: 1 (was 30 before fix)
persisted assistant/cost entries: 30 (all preserved)
FIX CONFIRMED
```

## Cause
`AdvisorTranscriptRecorder.record` (`advisor/transcript-recorder.ts`) is an unconditional append; `#attachAdvisorRecorderFeed` (`session/session-advisors.ts`) subscribes to every advisor `message_end`, including the re-delivered user "Session update" deltas. On each re-prime `AdvisorRuntime` resets the delivery cursor and replays the whole transcript, and `#clearSeenContext` defeats the upstream context dedup on retries, so each cycle re-persists the growing history — quadratic `__advisor.jsonl`. The bloated file then caused two follow-on stalls: `loadAdvisorTranscriptCosts` was awaited inline in `createAgentSession` (`sdk.ts`), and `readPersistedAgentHistory` (`registry/persisted-agents.ts`) streamed the whole advisor file on the render thread for `hub list`.

## Fix
- Extract `fingerprintMessage` into `advisor/message-fingerprint.ts`, shared by the runtime and the recorder.
- Dedupe re-delivered user replay deltas in `AdvisorTranscriptRecorder` by fingerprint (window reset per target file); assistant/toolResult (billed) turns always persist, so all cost entries are preserved.
- Move the resume-time advisor cost load off the critical path: `AgentSession.beginInitialAdvisorCostRestore` runs the scan fire-and-forget and exposes an awaitable `advisorCostRestore`; `restoreInitialAdvisorCosts` merges without clobbering a turn billed before the scan settles.
- Cap advisor-transcript history scans (`MAX_ADVISOR_HISTORY_LINES`) so a legacy huge file can't stall the Agent Hub.

## Verification
`bun test test/advisor/ test/advisor-toggle.test.ts test/advisor-context-maintenance.test.ts test/subagent-advisor.test.ts test/registry/persisted-agent-attribution.test.ts test/registry/persisted-mid-spawn-stub.test.ts test/tools/hub-list.test.ts test/agent-hub-advisor-scroll.test.ts test/agent-hub-ordering.test.ts` — all pass (326 tests). New regression tests: recorder drops re-delivered replays while keeping every billed assistant turn, resets its dedup window across a session switch, and `restoreInitialAdvisorCosts` seeds vs. never-clobbers a pre-scan turn. `bun run check:types` and `biome check` on the touched files are clean. Fixes #9553