### PR TITLE
fix(ai): exempt DeepSeek official vision models from text-only guard

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DeepSeek's official vision model `deepseek-v4-flash-vision-exp` having every image stripped from outbound Chat Completions requests: `isTextOnlyDeepSeek` (vision guard, introduced for legacy DeepSeek endpoints that reject `image_url` with HTTP 400) now exempts model IDs/names carrying the official `vision` marker, so images reach `api.deepseek.com` instead of being replaced by the non-vision placeholder. Text-only DeepSeek models with a misconfigured `input: [text, image]` remain scrubbed.
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -79,6 +79,15 @@ export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean 
 	const name = (model.name ?? "").toLowerCase();
 	// DeepSeek OCR is a genuinely multimodal model served by Novita.
 	if (id.includes("deepseek-ocr") || name.includes("deepseek-ocr")) return false;
+	// DeepSeek's official vision models (e.g. `deepseek-v4-flash-vision-exp`)
+	// accept `image_url` parts on api.deepseek.com — see the official Vision
+	// guide. Exempt them like deepseek-ocr so the defensive text-only override
+	// doesn't strip images from a genuinely vision-capable official model
+	// (mirrors the qwen*-max >=3.8 exemption added in issue #8305). The
+	// exemption keys on the official `vision` naming, not on `input`, so a
+	// misconfigured `models.yml` claiming vision for a text-only DeepSeek model
+	// still gets scrubbed.
+	if (/\bvision\b/.test(id) || /\bvision\b/.test(name)) return false;
 	return (
 		modelMatchesHost(model, "deepseekFamily") ||
 		isDeepseekModelIdOrName(model.id) ||

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -7,7 +7,10 @@ import {
 	appendResponsesToolResultMessages,
 	convertResponsesInputContent,
 } from "@oh-my-pi/pi-ai/providers/openai-shared";
-import { NON_VISION_IMAGE_PLACEHOLDER } from "@oh-my-pi/pi-ai/providers/vision-guard";
+import {
+	isOpenAICompletionsVisionSupported,
+	NON_VISION_IMAGE_PLACEHOLDER,
+} from "@oh-my-pi/pi-ai/providers/vision-guard";
 import type { Api, AssistantMessage, Context, Model, ModelSpec, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ResolvedOpenAICompat } from "@oh-my-pi/pi-catalog/types";
@@ -300,5 +303,81 @@ describe("issue #967 vision guard", () => {
 				},
 			],
 		});
+		});
 	});
-});
+
+	describe("DeepSeek official vision model exemption", () => {
+		const deepseekVisionModel = buildModel({
+			id: "deepseek-v4-flash-vision-exp",
+			name: "DeepSeek V4 Flash Vision Exp",
+			api: "openai-completions",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
+			contextWindow: 1_000_000,
+			maxTokens: 384_000,
+		} as ModelSpec<"openai-completions">);
+
+		it("keeps image parts for the official deepseek vision model", () => {
+			expect(isOpenAICompletionsVisionSupported(deepseekVisionModel)).toBe(true);
+
+			const context: Context = {
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "what is in this image?" },
+							{ type: "image", mimeType: "image/png", data: "ZmFrZQ==" },
+						],
+						timestamp: 1,
+					},
+				],
+			};
+			const messages = convertOpenAICompletionsMessages(deepseekVisionModel, context, compat);
+			expect(countTaggedValues(messages, "image_url")).toBe(1);
+			expect(JSON.stringify(messages)).not.toContain(NON_VISION_IMAGE_PLACEHOLDER);
+		});
+
+		it("still scrubs a text-only DeepSeek model flagged vision by a user override", () => {
+			const overridden = buildModel({
+				id: "deepseek-v4-flash",
+				name: "DeepSeek V4 Flash",
+				api: "openai-completions",
+				provider: "deepseek",
+				baseUrl: "https://api.deepseek.com",
+				reasoning: true,
+				// Misconfigured models.yml override claiming vision for a text-only model.
+				input: ["text", "image"],
+				cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
+				contextWindow: 1_000_000,
+				maxTokens: 384_000,
+			} as ModelSpec<"openai-completions">);
+
+			expect(isOpenAICompletionsVisionSupported(overridden)).toBe(false);
+
+			const context: Context = {
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "plot summary" },
+							{ type: "image", mimeType: "image/png", data: "ZmFrZQ==" },
+						],
+						timestamp: 1,
+					},
+				],
+			};
+			const messages = convertOpenAICompletionsMessages(overridden, context, compat);
+			expect(countTaggedValues(messages, "image_url")).toBe(0);
+			expect(messages[0]).toMatchObject({
+				role: "user",
+				content: [
+					{ type: "text", text: "plot summary" },
+					{ type: "text", text: NON_VISION_IMAGE_PLACEHOLDER },
+				],
+			});
+		});
+	});
+


### PR DESCRIPTION
## Summary

DeepSeek's flagship vision model `deepseek-v4-flash-vision-exp` is treated as text-only by `isTextOnlyDeepSeek` in `packages/ai/src/providers/vision-guard.ts`, so every image in user messages and tool results is stripped and replaced by `[image omitted: model does not support vision]` before the request reaches `api.deepseek.com`.

## Root cause

`isTextOnlyDeepSeek` was added when DeepSeek endpoints rejected `image_url` with HTTP 400 (`unknown variant "image_url", expected "text"`). It returns true for **any** DeepSeek-provider model except `deepseek-ocr`. DeepSeek has since shipped an official vision model — `deepseek-v4-flash-vision-exp` accepts image parts over OpenAI-compatible Chat Completions (official [Vision guide](https://api-docs.deepseek.com/guides/vision); supported formats JPEG/PNG/GIF/WebP). The guard was never updated to exempt it.

Note: the guard deliberately overrides `model.input` claims, so `models.yml` `modelOverrides: { input: [text, image] }` cannot work around it — even `inspect_image`-style image reading ends up scrubbed. This mirrors the qwen*-max >= 3.8 exemption added in #8305 after DashScope made Qwen-Max multimodal.

## Change

Exempt officially vision-named DeepSeek models (id/name containing `vision`) from the text-only guard. The exemption keys on the official `vision` naming, **not** on `input`, so a misconfigured `models.yml` claiming vision for a text-only DeepSeek model (e.g. `deepseek-v4-flash`) still gets scrubbed and cannot drive the session into a 400.

## Verification

- 2 new cases in `issue-967-vision-guard.test.ts`:
  - `deepseek-v4-flash-vision-exp` keeps `image_url` on the wire (no placeholder).
  - `deepseek-v4-flash` with a misconfigured `input: [text, image]` override is still scrubbed.
- Test file: 7/7 pass (5 existing + 2 new).
- Full `packages/ai` suite: 4173 pass / 331 skip / 2 fail — both failures are environment-dependent and unrelated to this change (llama.cpp local test fails to connect `localhost:8081`, Bedrock guardrails test hits a 5s timeout).