### PR TITLE
perf(tui): skip tail re-lex on inert markdown deltas (fast-tail splice)

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -953,12 +953,151 @@ function renderedLinesCacheSize(lines: readonly string[]): number {
 	return Math.max(1, size);
 }
 
+// ---------------------------------------------------------------------------
+// Fast-tail (B+) hazard gates
+// ---------------------------------------------------------------------------
+// Tier-1 eligibility: the appended delta is "markdown-inert" — it cannot open
+// or close an inline token, change block structure, or shift a swatch
+// boundary. A delta carrying a marker is re-lexed through the REAL inline
+// pipeline so self-contained marker pairs render styled — exactly what a full
+// re-lex of the grown row produces. `_` is included but narrowed: an
+// intraword `_` is literal per CommonMark flanking rules, so only FLANKED
+// underscores disarm (FAST_ROW_UNDERSCORE_RE on the row text, plus the
+// delta-edge trailingDelimiterSeamHazard check).
+const FAST_DELTA_RE = /[\n\r\\[`<!*_~$#&@\x1b]/;
+
+// Disarm when the captured row's RAW tail ends in trailing whitespace (wrap
+// trims it; appending a char moves the trim boundary), a trailing backslash
+// (it can become an escape once the delta supplies the next char — the `\\`
+// clause covers that escape-completion hazard), or a full/partial hex swatch
+// run (a `#` + 3-8 hex is a swatch glyph; the byte range may shift).
+const FAST_RUN_END_RE = /(?:[ \t\\]|#[0-9a-fA-F]{3,8}|#+)$/i;
+
+// A partial `#` + 1-2 hex digits can grow into a 3-8 digit swatch glyph
+// across the seam (delta hex digits are inert).
+const FAST_SWATCH_SEAM_RE = /#[0-9a-fA-F]{0,2}$/;
+
+// A partial HTML entity at the seam (`&am` + delta `p;`) OR a complete
+// numeric entity (`&#35;`, `&#x1f600;`) — which decodes to `#`, a swatch
+// lead — would normalize to different bytes than the plain concat.
+const FAST_ENTITY_SEAM_RE = /&(?:[A-Za-z0-9#]{0,31}|#[0-9]{1,7};|#[xX][0-9a-fA-F]{1,6};)$/;
+
+// A bare URL/email anywhere in the delta or across the seam (a URL the regex
+// cut at a trailing delimiter can re-link once the delta supplies more chars;
+// a protocol head ending at the seam completes in the delta) makes the full
+// re-lex autolink while the plain concat would not.
+const FAST_URL_ANYWHERE_RE = /(?:https?|ftp):\/\/|www\.[A-Za-z0-9]|[A-Za-z0-9._%+-]+@/i;
+
+// A bare-URL/email PREFIX may end at the seam and complete in the delta
+// (`ht` + `tps://x`, `foo@` + `bar.com`).
+const FAST_URL_PREFIX_SEAM_RE = /(?:https?|ftp):?\/{0,2}$|www\.$|[A-Za-z0-9._+-]+@[A-Za-z0-9._+-]*$/;
+
+// Inline-markup delimiters that survive into rendered output as LITERAL text
+// when unpaired. The fast path detects open constructs by walking the REAL
+// inline token stream (capture) and the delta's inline token stream (frame):
+// any top-level `text` token still carrying one of these bytes holds an open
+// delimiter, so a later delta could close it and a full re-lex would restyle
+// the seam. Closed pairs tokenize into styled tokens and never appear here.
+// `_` is excluded (intraword `_` is inert); a FLANKED underscore is caught
+// by FAST_ROW_UNDERSCORE_RE on the raw text (SGR bytes precede text, so word
+// boundaries are invisible after styling).
+const FAST_LITERAL_MARKER_RE = /[*~`[\]<>()$&#]/;
+
+// A flanking underscore (start-of-line or preceded by a non-word char) can
+// open an emphasis that a future delta closes. Only flanked `_` is a
+// delimiter; intraword `_` (a_b) is literal.
+const FAST_ROW_UNDERSCORE_RE = /(?:^|[^\w])_/;
+
+// A paragraph's LAST line can complete into a different block kind under an
+// inert delta (ATX heading, blockquote, bullet marker, HR, ref-def) — disarm
+// when the grown line starts one (ref-def grammar: REF_DEF_LINE_RE).
+const FAST_LINE_START_HAZARD_RE =
+	// `-` is placed LAST so it is a literal, not a range bound. The other
+	// chars are in ASCENDING code-point order (no reversed ranges that
+	// rely on engine leniency): * + = – — ─ ━ ═ then the literal `-`.
+	/^ {0,3}(?:#{1,6}(?:[ \t]|$)|>|\d{1,9}[.)](?:[ \t]|$)|[*+=–—─━═-](?:[ \t]|$)|(?:[*+=–—─━═-][ \t]*){2,}[ \t]*$)/;
+/** @internal exported for tests — counts fast-tail splice frames. A future
+ *  regression that silently disarms the fast path (e.g. an over-broad gate)
+ *  leaves byte-identity intact but drops the counter to zero. */
+export let fastTailSplices = 0;
+/** @internal exported for tests — resets the splice counter. */
+export function resetFastTailSplices(): void {
+	fastTailSplices = 0;
+}
+
+/** @internal exported for tests — the grown-line-start block-kind gate. */
+export function fastLineStartHazard(grownLine: string): boolean {
+	return FAST_LINE_START_HAZARD_RE.test(grownLine) || REF_DEF_LINE_RE.test(grownLine);
+}
+
+/** Seam hazards between the captured raw row tail and the delta: the row must
+ *  not end in a wrap-trim, escape, swatch, entity, or URL/email prefix, and
+ *  must hold no unbalanced bracket an inert delta could close into a link. */
+function fastTailSeamSafe(raw: string): boolean {
+	if (FAST_RUN_END_RE.test(raw)) return false;
+	if (FAST_SWATCH_SEAM_RE.test(raw)) return false;
+	if (FAST_ENTITY_SEAM_RE.test(raw)) return false;
+	// Entities decode before swatch/whitespace detection (`&#35;ab` → `#ab`,
+	// `&nbsp;` → ` `): scan the DECODED tail so an entity-indirected swatch
+	// lead OR a decoded trailing space (wrap-trim boundary shifts) disarms.
+	// Autolinks are lex-time on RAW text, so URL prefix stays raw.
+	const rawTail = raw.length > 32 ? raw.slice(-32) : raw;
+	const decodedTail = normalizeHtmlEntitiesForTerminal(rawTail);
+	if (decodedTail !== rawTail && (FAST_RUN_END_RE.test(decodedTail) || FAST_SWATCH_SEAM_RE.test(decodedTail))) {
+		return false;
+	}
+	if (FAST_URL_PREFIX_SEAM_RE.test(raw)) return false;
+	if (raw.endsWith("]") || raw.lastIndexOf("[") > raw.lastIndexOf("]")) return false;
+	if (raw.lastIndexOf("(") > raw.lastIndexOf(")") || raw.lastIndexOf("<") > raw.lastIndexOf(">")) return false;
+	return true;
+}
+// Fast-tail (B+) recipe: captured frame state for the next inert-delta splice.
+interface FastTailRecipe {
+	readonly lines: readonly string[]; // frame rows at capture
+	readonly source: string; // raw #text at capture (append-only predicate)
+	readonly width: number; // contentWidth at capture
+	rowText: string; // RENDERED last wrap-output row (re-wrap input)
+	rowRaw: string; // RAW tail source backing that row (seam scan)
+	rowStart: number; // result[] index of the replaced row
+	rowEnd: number; // exclusive result[] index
+	readonly signature: RenderSignature; // full render signature at capture (bgColor etc.)
+}
+
+/** True when the inline token stream holds an OPEN construct: a `text` token
+ * that still carries a literal delimiter (an unpaired `*`/`` ` ``/`[`/… or a
+ * flanking `_`), or raw HTML. Closed constructs are styled tokens whose
+ * delimiters are absent from their text. An open means a FUTURE delta could
+ * close it — the fast path disarms so the splice always matches a full lex. */
+function inlineHasOpen(tokens: readonly Token[]): boolean {
+	for (const token of tokens) {
+		if (isMathToken(token)) continue;
+		if (token.type === "codespan") continue; // styled leaf; its content cannot re-pair
+		if (token.type === "html") return true; // raw HTML — conservative
+		if (token.type === "text") {
+			const text = "text" in token && typeof token.text === "string" ? token.text : "";
+			if (FAST_LITERAL_MARKER_RE.test(text) || FAST_ROW_UNDERSCORE_RE.test(text)) return true;
+		}
+		if ("tokens" in token && Array.isArray(token.tokens)) {
+			if (inlineHasOpen(token.tokens as Token[])) return true;
+		}
+	}
+	return false;
+}
+
+/** Isolated inline lex of a same-line delta. A single-line delta has no block
+ * structure, so the isolated inline pass equals the full lex's inline pass
+ * (marked's paragraph tokens run the same `inlineTokens` entry point). */
+function lexInlineTokens(text: string): Token[] {
+	return new Lexer(markdownParser.defaults).inlineTokens(text);
+}
+
 // A reference-link definition (`[label]: dest`) resolves across the whole
 // document, so a split lex cannot reproduce it — disable the streaming fast path
 // when one is present (rare in streamed output). The label may contain
 // backslash-escaped characters (`[a\]b]: x`), so escapes are matched explicitly;
 // over-matching is safe (it only costs the fast path), under-matching is not.
-const HAS_REF_DEF = /^ {0,3}\[(?:\\.|[^\]\\])+\]:/m;
+const REF_DEF_LINE_RE = /^ {0,3}\[(?:\\.|[^\]\\])+\]:/;
+const HAS_REF_DEF = new RegExp(REF_DEF_LINE_RE.source, "m");
 
 // marked's list tokenizer (Tokenizer.list, marked v18) continues a list across
 // blank lines only when the remaining source matches
@@ -1620,6 +1759,9 @@ export class Markdown implements Component {
 	#renderingStablePrefix = false;
 	#streamingHighlightCache?: StreamingHighlightCache;
 	#activeRenderSignature?: RenderSignature;
+	#fastTail?: FastTailRecipe; // undefined = disarmed
+	// B+ capture plumbing: #renderContentLines records the last rendered paragraph row.
+	#lastTailCapture?: { kind: "paragraph"; open: boolean; rowInput: string; rowRaw: string };
 	#ignoreTight = false;
 	setIgnoreTight(ignore: boolean): this {
 		this.#ignoreTight = ignore;
@@ -1694,6 +1836,9 @@ export class Markdown implements Component {
 			this.#streamPrefixTokens = undefined;
 			this.#streamPrefixLineCache = undefined;
 			this.#tailRowCache = undefined;
+			// B+: the captured fast-path rows index the replaced content — drop
+			// the recipe so a fresh stream cannot splice onto stale rows.
+			this.#fastTail = undefined;
 		}
 		this.invalidate();
 		return true;
@@ -1717,6 +1862,11 @@ export class Markdown implements Component {
 		// so a memo computed on the other mode's buffer must not be reused —
 		// re-derive on the next frame instead.
 		this.#appendOnlySinceLastScan = false;
+		// B+ reset site: a transient flip (finalize, or a fresh stream on
+		// rewound text) means the next render re-lexes from the current
+		// source — drop the fast-path recipe so stale rows cannot be served
+		// across the transition.
+		this.#fastTail = undefined;
 		this.invalidate();
 	}
 
@@ -1863,6 +2013,126 @@ export class Markdown implements Component {
 			this.#lastScanValid = false;
 		}
 		const signature = this.#renderSignature(width, paddingX);
+		// B+ fast path: an append-only, same-line delta re-renders ONLY the
+		// last content row (the paragraph's trailing wrapped row) with the
+		// grown source, so the new text shows every frame while staying
+		// byte-identical to a cold full render (the full re-lex produces the
+		// same grown inline tokens and the same wrap). The previous frame's
+		// rows live in #fastTail.lines — the L1 #cachedLines was invalidated
+		// by setText, so the fast path cannot read it back. An inert delta
+		// has no "\n", so the frozen prefix cannot advance and the rows above
+		// the spliced span stay byte-identical.
+		if (
+			this.transientRenderCache &&
+			this.#fastTail !== undefined &&
+			contentWidth === this.#fastTail.width &&
+			this.#text.length > this.#fastTail.source.length &&
+			this.#text.startsWith(this.#fastTail.source)
+		) {
+			// Re-probe signature (pure) and require equality — a bgColor/theme
+			// change (width-constant) must not splice rows of the stale recipe.
+			const recipe = this.#fastTail;
+			if (!this.#signatureEquals(signature, recipe.signature)) {
+				this.#fastTail = undefined;
+			} else {
+				const delta = this.#text.slice(recipe.source.length);
+				const deltaTabs = replaceTabs(delta);
+				// Seam window contains the delta, so one URL/email scan catches both.
+				const seamSafe = fastTailSeamSafe(recipe.rowRaw);
+				const seamWindow =
+					recipe.rowRaw.slice(Math.max(recipe.rowRaw.lastIndexOf(" "), recipe.rowRaw.lastIndexOf("\t")) + 1) +
+					deltaTabs;
+				// A paragraph's last line can complete into a different block
+				// kind under an inert delta — disarm (single gate helper, kept
+				// in sync with the exported test surface).
+				const grownLine = recipe.rowRaw.slice(recipe.rowRaw.lastIndexOf("\n") + 1) + deltaTabs;
+				const lineStartHazard = fastLineStartHazard(grownLine);
+				// Only same-line deltas splice; marker deltas re-lex through the
+				// REAL inline pipeline so self-contained pairs render styled.
+				const hardDelta = /[\n\r\x1b]/.test(delta);
+				const markerDelta = FAST_DELTA_RE.test(delta);
+				// A delta starting/ending `_` after a word char pairs in isolation
+				// but stays intraword-literal in the full text. Symmetrically, a
+				// row ending with a closing delimiter (`_`, `*`, `~`) followed by
+				// a word-char delta makes the delimiter intraword / non-flanking in
+				// the joined text — the cold render drops the emphasis, but the
+				// splice keeps it. A row ending `$` (closed inline math) followed
+				// by a digit is invalidated by the anti-currency rule ($x$123 is
+				// literal, not math) — disarm.
+				const trailingDelimiterSeamHazard =
+					(markerDelta && (deltaTabs.startsWith("_") || deltaTabs.endsWith("_")) && /\w$/.test(recipe.rowRaw)) ||
+					(!markerDelta && /[*~_]$/.test(recipe.rowRaw) && /^\w/.test(deltaTabs)) ||
+					(!markerDelta && recipe.rowRaw.endsWith("$") && /^[0-9]/.test(deltaTabs));
+				// A delta opening a pairing char when the captured row ENDS with the
+				// same char can re-pair across the seam: cold lex of the joined run
+				// makes ONE token (x *a**b* → em("a**b")), the splice keeps two.
+				// An image marker (`x!` + `[a](u)`) re-pairs the same way.
+				const pairSeamHazard =
+					markerDelta &&
+					((/^[*~`]/.test(deltaTabs) && /[*~`]$/.test(recipe.rowRaw)) ||
+						// "x!" + "[a](u)": cold lexes text("x") + image(alt); the splice would
+						// keep "x!" + a styled link byte-run.
+						(deltaTabs.startsWith("[") && recipe.rowRaw.endsWith("!")));
+				const deltaTokens = markerDelta && !hardDelta ? lexInlineTokens(deltaTabs) : null;
+				if (
+					seamSafe &&
+					!lineStartHazard &&
+					!hardDelta &&
+					!trailingDelimiterSeamHazard &&
+					(!markerDelta || (!this.#lastTailCapture?.open && !pairSeamHazard && !inlineHasOpen(deltaTokens!))) &&
+					!FAST_URL_ANYWHERE_RE.test(seamWindow)
+				) {
+					// Same text paths a full re-lex applies: real pipeline for marker
+					// deltas, plain swatch/entity render for inert deltas.
+					const { applyText } = this.#getDefaultInlineStyleContext();
+					const grown =
+						recipe.rowText +
+						(markerDelta
+							? this.#renderInlineTokens(deltaTokens!)
+							: renderTextWithSwatches(
+									normalizeHtmlEntitiesForTerminal(deltaTabs),
+									applyText,
+									this.#theme.symbols.colorSwatch || DEFAULT_COLOR_SWATCH_GLYPH,
+								));
+					const wrapped = wrapTextWithAnsi(grown, contentWidth);
+					const fastPaddingX = this.#ignoreTight ? this.#paddingX : getPaddingX(this.#paddingX);
+					const leftMargin = padding(fastPaddingX);
+					const rightMargin = padding(fastPaddingX);
+					const bgFn = this.#defaultTextStyle?.bgColor;
+					const fastRows: string[] = [];
+					for (const row of wrapped) {
+						const withMargins = leftMargin + row + rightMargin;
+						fastRows.push(
+							bgFn
+								? applyBackgroundToLine(withMargins, width, bgFn)
+								: withMargins + padding(Math.max(0, width - visibleWidth(withMargins))),
+						);
+					}
+					// Splice onto the previous frame's rows (new array — parent may
+					// hold the old one).
+					const prev = recipe.lines;
+					const fastResult = [...prev.slice(0, recipe.rowStart), ...fastRows, ...prev.slice(recipe.rowEnd)];
+					this.#cachedText = this.#text;
+					this.#cachedWidth = width;
+					this.#cachedLines = fastResult;
+					this.#fastTail = {
+						lines: fastResult,
+						source: this.#text,
+						width: recipe.width,
+						rowText: wrapped[wrapped.length - 1] ?? "",
+						rowRaw: recipe.rowRaw + deltaTabs,
+						rowStart: recipe.rowStart + wrapped.length - 1,
+						rowEnd: recipe.rowStart + wrapped.length,
+						signature: recipe.signature,
+					};
+					fastTailSplices++;
+					return fastResult;
+				}
+			}
+			// Hazard → disarm until the next real render re-captures.
+			this.#fastTail = undefined;
+		}
+		// Replace tabs with 3 spaces for consistent rendering
 
 		// L2: module-level LRU — survives component disposal/recreation across
 		// session-tree navigations. Key encodes every dimension that affects the
@@ -1913,6 +2183,37 @@ export class Markdown implements Component {
 		this.#cachedWidth = width;
 		this.#cachedLines = result;
 
+		const fastEligible =
+			this.transientRenderCache &&
+			contentLines.length > 0 &&
+			// B+ invariant: only the FINAL #renderContentLines call captures;
+			// the all-cache-hit prefix path clears #lastTailCapture at its top.
+			this.#lastTailCapture !== undefined &&
+			this.#lastTailCapture.kind === "paragraph" &&
+			// Run-level default styling (color/bold/italic/strikethrough/
+			// underline) disarms: the splice yields two ANSI runs where a cold
+			// render yields one; bgColor is line-level and stays eligible.
+			!this.#defaultTextStyle?.color &&
+			!this.#defaultTextStyle?.bold &&
+			!this.#defaultTextStyle?.italic &&
+			!this.#defaultTextStyle?.strikethrough &&
+			!this.#defaultTextStyle?.underline;
+		if (fastEligible && this.#lastTailCapture !== undefined) {
+			const capture = this.#lastTailCapture;
+			this.#fastTail = {
+				lines: result,
+				source: this.#text,
+				width: contentWidth,
+				rowText: capture.rowInput,
+				rowRaw: capture.rowRaw,
+				rowStart: signature.paddingY + contentLines.length - 1,
+				rowEnd: signature.paddingY + contentLines.length,
+				signature,
+			};
+		} else {
+			this.#fastTail = undefined;
+		}
+
 		// Update L2 module-level LRU so future instances with the same key skip
 		// the marked.lexer + highlightCode (Rust FFI) work entirely.
 		if (cacheKey !== undefined) {
@@ -1937,6 +2238,10 @@ export class Markdown implements Component {
 			bgColorProbe,
 			headingProbe,
 		};
+	}
+	// All-primitive signature — compare via the canonical render-cache encoding.
+	#signatureEquals(a: RenderSignature, b: RenderSignature): boolean {
+		return this.#renderCacheKey("", a) === this.#renderCacheKey("", b);
 	}
 
 	#renderCacheKey(normalizedText: string, signature: RenderSignature): string {
@@ -2114,6 +2419,9 @@ export class Markdown implements Component {
 		signature: RenderSignature,
 		tailRecorder?: TailRenderRecorder,
 	): string[] {
+		// A non-capturing final call must not serve a stale recipe, so the
+		// B+ plumbing is cleared up front; the per-token capture re-fills it.
+		if (end === tokens.length) this.#lastTailCapture = undefined;
 		const wrappedLines: RenderedLine[] = [];
 		// Wrapped-row span per absolute token index. Call-local: stale values
 		// are never read across renders.
@@ -2141,6 +2449,36 @@ export class Markdown implements Component {
 				}
 			}
 			tokenWrappedRowCounts[i] = wrappedLines.length - tokenWrappedRowStart;
+			// B+ capture hook: the LAST token of the FINAL call is the frame's
+			// true trailing content row — record its rendered last row and raw
+			// tail so render() can build the fast-path recipe. The frozen
+			// prefix call (end < tokens.length) must never capture.
+			if (end === tokens.length && i === end - 1 && token.type === "paragraph") {
+				const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+				const lastLine = renderedTokenLines[renderedTokenLines.length - 1];
+				// Display math, a newline-terminated paragraph (a fresh line
+				// grows next frame — the captured row is not the mutable tail),
+				// or a tree-guide/OSC-8/OSC-66 trailing row are not
+				// self-contained.
+				if (
+					soleDisplayMath(token.tokens) ||
+					raw.endsWith("\n") ||
+					!lastLine ||
+					TREE_GUIDE_ANCHOR_RE.test(lastLine.text) ||
+					lastLine.text.includes("\x1b]") ||
+					TERMINAL.isImageLine(lastLine.text) ||
+					isOsc66Line(lastLine.text)
+				) {
+					continue;
+				}
+				const wrappedLast = wrappedLines[wrappedLines.length - 1];
+				this.#lastTailCapture = {
+					kind: "paragraph",
+					rowInput: wrappedLast?.text ?? lastLine.text,
+					rowRaw: raw.slice(raw.lastIndexOf("\n") + 1),
+					open: inlineHasOpen(token.tokens ?? []),
+				};
+			}
 		}
 
 		const leftMargin = padding(signature.paddingX);

--- a/packages/tui/test/markdown-bplus-fast-path.test.ts
+++ b/packages/tui/test/markdown-bplus-fast-path.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "bun:test";
+import {
+	clearRenderCache,
+	type DefaultTextStyle,
+	fastLineStartHazard,
+	fastTailSplices,
+	Markdown,
+	resetFastTailSplices,
+} from "@oh-my-pi/pi-tui/components/markdown";
+import { defaultMarkdownTheme } from "./test-themes.js";
+
+// B+ fast-tail contract: when a transient streaming frame's last content row
+// came from a paragraph, an append-only same-line delta re-renders ONLY that
+// row (splice of the re-wrapped grown row onto the previous frame's rows)
+// instead of re-lexing the whole tail. The observable contract is BYTE
+// IDENTITY with a cold full render at EVERY frame (the new text shows every
+// frame — no B-style lag) plus correct disarming on style/structural hazards
+// and reset on finalize/width/flip transitions. These tests encode that
+// matrix; the adversarial seam gates (URL/entity/swatch/ref-def/OSC-8/`*`
+// marker completion, bgColor signature swaps) are covered HERE — each hazard
+// is streamed across the splice seam so the disarming frame lands mid-stream.
+
+const THEME = defaultMarkdownTheme;
+
+function renderCold(text: string, width: number, defaultTextStyle?: DefaultTextStyle): readonly string[] {
+	clearRenderCache();
+	const out = new Markdown(text, 0, 0, THEME, defaultTextStyle).render(width);
+	clearRenderCache();
+	return out;
+}
+
+interface RevealOptions {
+	/** Render width (default 60). */
+	width?: number;
+	/** Reveal `full` in `step`-char increments (default 1 — every split lands on a frame, including seam straddles). */
+	step?: number;
+	/** Default text style passed through to BOTH the streaming instance and the cold oracle. */
+	defaultTextStyle?: DefaultTextStyle;
+	/** Reuse this streaming instance instead of creating a fresh one (for stateful callers). */
+	streaming?: Markdown;
+}
+
+/** Reveal `full` in `step`-char increments through ONE reused transient
+ *  (streaming) instance; assert EVERY frame is byte-identical to a cold full
+ *  render of the same prefix (byte identity = the new text is visible — no
+ *  lag). The streaming instance must go through its own incremental path
+ *  every step, so the cold oracle always re-lexes. The styled variant passes
+ *  a `defaultTextStyle` so the same loop covers run-styled paths; the plain
+ *  path omits it. */
+function assertByteIdentityEveryFrame(full: string, opts: RevealOptions = {}): void {
+	const { width = 60, step = 1, defaultTextStyle, streaming = new Markdown("", 0, 0, THEME, defaultTextStyle) } = opts;
+	streaming.transientRenderCache = true;
+	for (let len = 1; len <= full.length; len += step) {
+		const slice = full.slice(0, len);
+		clearRenderCache();
+		streaming.setText(slice);
+		expect(streaming.render(width)).toEqual(renderCold(slice, width, defaultTextStyle));
+	}
+	clearRenderCache();
+	streaming.setText(full);
+	expect(streaming.render(width)).toEqual(renderCold(full, width, defaultTextStyle));
+}
+
+describe("B+ fast-tail paragraph re-wrap", () => {
+	it("prose reveal shows new text every frame (no lag)", () => {
+		// Inert prose deltas with no style markers: the fast path re-wraps the
+		// growing last row every frame.
+		assertByteIdentityEveryFrame(
+			"This is a plain prose paragraph that streams in one character at a time without any markdown styling markers.",
+		);
+	});
+
+	it("run-level default style disarms fast path (single ANSI run contract)", () => {
+		// With a run-level defaultTextStyle (color/italic — as streamed
+		// thinking and colored assistant content use), a splice would
+		// concatenate a pre-styled row with a separately styled delta: two
+		// ANSI runs where a cold render produces one. The fast path must not
+		// engage — every frame stays byte-identical to cold.
+		const style = { color: (t: string) => `\x1b[35m${t}\x1b[39m`, italic: true };
+		assertByteIdentityEveryFrame("a styled streaming paragraph grows one character at a time", {
+			defaultTextStyle: style,
+		});
+	});
+
+	it("intraword underscore deltas stay on the fast path (narrowed gate)", () => {
+		// `_` inside a word is literal per CommonMark flanking rules — the
+		// delta `_` must NOT force a full re-lex every frame; the grown row
+		// re-wraps with the literal underscore byte-identical to cold.
+		assertByteIdentityEveryFrame("measure the raw_word_delta against the baseline at every frame");
+	});
+
+	it("open emphasis closed by a later delta re-lexes the grown row", () => {
+		// A row holding an OPEN `*` disarms any marker delta; the closing `*`
+		// frame re-lexes so the whole span renders styled, not as a stale
+		// literal row.
+		assertByteIdentityEveryFrame("the *whole span* must render emphasized, not stale");
+	});
+
+	it("paragraph completing into a list marker disarms (line-start hazard)", () => {
+		// `abc\n1. item` lexes as paragraph + LIST, not one paragraph — the
+		// grown-line start check must disarm so the splice never renders the
+		// list as paragraph text.
+		assertByteIdentityEveryFrame("abc\n1. item");
+	});
+
+	it("finalize after fast-path frames is byte-identical to cold", () => {
+		const full = "finalizing a streaming paragraph must match the cold render exactly";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 3) {
+			clearRenderCache();
+			streaming.setText(full.slice(0, len));
+			streaming.render(60);
+		}
+		streaming.transientRenderCache = false;
+		clearRenderCache();
+		streaming.setText(full);
+		expect(streaming.render(60)).toEqual(renderCold(full, 60));
+	});
+
+	it("width change after fast-path frames re-lexes at new width", () => {
+		const full = "a streamed paragraph that must reflow cleanly when the terminal width changes mid-stream";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 3) {
+			clearRenderCache();
+			streaming.setText(full.slice(0, len));
+			streaming.render(80);
+		}
+		clearRenderCache();
+		streaming.setText(full);
+		expect(streaming.render(40)).toEqual(renderCold(full, 40));
+	});
+
+	it("first frame is cold (no fast path)", () => {
+		const fresh = new Markdown("hello world", 0, 0, THEME);
+		fresh.transientRenderCache = true;
+		clearRenderCache();
+		expect(fresh.render(60)).toEqual(renderCold("hello world", 60));
+	});
+
+	it("overflow long word re-wraps identically (break_long_word parity)", () => {
+		assertByteIdentityEveryFrame(
+			"A verylongwordthatcannotfitwithintherowwidthandmustbesplitbysomeheuristicacrossthelines",
+			{ width: 40 },
+		);
+	});
+
+	it("CRLF delta disarms fast path", () => {
+		assertByteIdentityEveryFrame("first line\r\nsecond line");
+	});
+
+	it("transientRenderCache flip mid-stream drops fast path", () => {
+		const full = "flipping transient off and back on must never serve a stale fast-path row";
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		for (let len = 1; len <= full.length; len += 3) {
+			clearRenderCache();
+			streaming.setText(full.slice(0, len));
+			streaming.render(60);
+		}
+		streaming.transientRenderCache = false;
+		streaming.transientRenderCache = true;
+		clearRenderCache();
+		streaming.setText(full);
+		expect(streaming.render(60)).toEqual(renderCold(full, 60));
+	});
+
+	it("URL head straddling the seam disarms, then byte-identity re-establishes", () => {
+		// `https:/` ends a captured row; the delta `/` completes `https://`.
+		// The seam gates (FAST_URL_PREFIX_SEAM_RE on the row tail plus the
+		// seam-window URL scan) must NOT splice the seam — the next frame
+		// falls through to a full re-lex and byte-identity re-establishes.
+		assertByteIdentityEveryFrame("see the docs at https://example.com/guide for detail");
+	});
+
+	it("HTML entity split across the seam never half-normalizes", () => {
+		// `&am` ends the captured row and `p;` arrives in the delta
+		// (FAST_ENTITY_SEAM_RE). The seam must disarm so the entity only
+		// normalizes once complete — every frame byte-identical to cold.
+		assertByteIdentityEveryFrame("fish &amp; chips");
+	});
+
+	it("hex swatch across the seam renders atomically, never partial", () => {
+		// `#1a` straddles the seam; `2b3c` arrives later. FAST_SWATCH_SEAM_RE
+		// (a `#` + 0-2 hex tail) and FAST_RUN_END_RE (a complete hex head)
+		// must disarm so the swatch glyph appears only when the run is
+		// complete, never as a stale partial row.
+		assertByteIdentityEveryFrame("the accent color is #1a2b3c here");
+	});
+
+	it("paragraph line completing into a ref-def disarms (line-start gate)", () => {
+		// The second block's last line grows `[lab` → `[label]: https://…`.
+		// Reference definitions lex to a different token shape, so the
+		// line-start gate (REF_DEF_LINE_RE) must disarm the crossing frame —
+		// byte identity holds at every step.
+		assertByteIdentityEveryFrame("intro words\n\n[label]: https://example.com");
+	});
+
+	it("OSC-8 hyperlink trailing row is skipped by capture, stays byte-identical", () => {
+		// The tail-row capture skips rows whose rendered text contains an
+		// OSC-8 sequence (`\x1b]`), so the hyperlink row always re-renders
+		// whole; the reveal stays byte-identical at every frame.
+		assertByteIdentityEveryFrame("see \x1b]8;;https://example.com\x07link\x1b]8;;\x07 here");
+	});
+
+	it("unordered `*` marker completing into a list item disarms (line-start hazard)", () => {
+		// A paragraph line that grows `*` → `* item one` completes a list
+		// marker when the space arrives — the grown-line start check must
+		// disarm that frame so the block re-lexes as a LIST, never a stale
+		// paragraph splice. (A lone `*` reveal is just the first-frame-cold
+		// case already covered above.)
+		assertByteIdentityEveryFrame("note:\n\n* item one");
+	});
+
+	it("bgColor signature change between frames re-renders with the new style", () => {
+		// defaultTextStyle is passed to the constructor by reference and
+		// exposes no setter, so the public mutation path is swapping bgColor
+		// on that same object. A fast recipe armed under the OLD bgColor must
+		// not serve rows styled with it once the signature changes: the next
+		// render must equal a cold render under the NEW bgColor (never a
+		// splice of the old).
+		const style = { bgColor: (t: string) => `\x1b[48;5;52m${t}\x1b[0m` };
+		const base = "This is a fairly long styled paragraph that wraps onto several rows";
+		const streaming = new Markdown("", 0, 0, THEME, style);
+		assertByteIdentityEveryFrame(base, { width: 20, step: 3, defaultTextStyle: style, streaming });
+		style.bgColor = (t: string) => `\x1b[48;5;22m${t}\x1b[0m`;
+		const grown = `${base} and more`;
+		clearRenderCache();
+		streaming.setText(grown);
+		expect(streaming.render(20)).toEqual(renderCold(grown, 20, style));
+	});
+	/** Stream the exact `parts` frames through one transient instance and
+	 *  assert the LAST frame is byte-identical to a cold render of `full`.
+	 *  The two-frame sequence is required: the failing splice frame needs the
+	 *  whole cross-seam delta in ONE setText call (the per-char reveal helper
+	 *  cannot produce it). */
+	function assertSpliceParts(parts: string[], full: string, width = 60): void {
+		const streaming = new Markdown("", 0, 0, THEME);
+		streaming.transientRenderCache = true;
+		let out: readonly string[] = [];
+		for (const p of parts) {
+			clearRenderCache();
+			streaming.setText(p);
+			out = streaming.render(width);
+		}
+		expect(out).toEqual(renderCold(full, width));
+		clearRenderCache();
+	}
+
+	it("closed * pair delta does not re-pair across the seam", () => {
+		// Row "x *a*" ends in a closed `*`; delta `*b*` OPENS with `*`. A
+		// splice renders em(a)+em(b) where the cold lex of "x *a**b*" makes
+		// ONE token (em("a**b")). pairSeamHazard must disarm that frame.
+		assertSpliceParts(["x *a*", "x *a**b*"], "x *a**b*");
+	});
+
+	it("closed ** pair delta does not re-pair", () => {
+		// Same re-pairing with a strong delimiter: cold lex renders literal
+		// `**b*` tail, not a strong run — the splice must disarm.
+		assertSpliceParts(["x **a**", "x **a****b**"], "x **a****b**");
+	});
+
+	it("closed ~~ pair delta does not re-pair", () => {
+		// Strikethrough mirrors the `*` case: one cold token vs two spliced
+		// styled runs across the seam.
+		assertSpliceParts(["x ~~a~~", "x ~~a~~~~b~~"], "x ~~a~~~~b~~");
+	});
+
+	it("box-drawing HR completing across the seam disarms", () => {
+		// A blank-line-preceded `══` line grows one `═` into `═══`, which the
+		// cold lex parses as an HR (customHr block); the grown-line start gate
+		// must disarm so the splice never renders it as paragraph text.
+		assertSpliceParts(["abc\n\n══", "abc\n\n═══"], "abc\n\n═══");
+	});
+
+	it("numeric entity decoding to # disarms", () => {
+		// `&#35;` at the row end decodes to `#` — a swatch lead — so an inert
+		// delta could re-swatch; the seam gate must disarm the crossing frame.
+		assertSpliceParts(["&#35;", "&#35;abc"], "&#35;abc");
+	});
+
+	it("image marker completing across the seam disarms", () => {
+		assertSpliceParts(["x!", "x![a](u)"], "x![a](u)");
+	});
+
+	it("entity-decoded swatch lead mid-row disarms", () => {
+		assertSpliceParts(["x &#35;ab", "x &#35;abc"], "x &#35;abc");
+	});
+
+	it("row-ending underscore followed by word delta disarms (intraword re-flank)", () => {
+		assertSpliceParts(["_foo_", "_foo_b"], "_foo_b");
+	});
+
+	it("row-ending star followed by word delta disarms (flank re-eval)", () => {
+		assertSpliceParts(["*a.*", "*a.*b"], "*a.*b");
+	});
+
+	it("row-ending tilde pair followed by word delta disarms", () => {
+		assertSpliceParts(["~~a.~~", "~~a.~~b"], "~~a.~~b");
+	});
+
+	it("row-ending math delimiter followed by digit disarms (anti-currency)", () => {
+		assertSpliceParts(["the value is $x$", "the value is $x$123"], "the value is $x$123");
+	});
+});
+
+it("line-start hazard does not fire on prose (char-class range regression)", () => {
+	// A `-` placed mid-class (`[*+-…]`) parses `+`-`─` as U+002B..U+2500,
+	// matching ASCII letters — the gate would disarm every prose frame and
+	// the fast path would never engage. Prose lines must stay safe.
+	for (const line of ["hello world", "a b c", "the quick brown fox", "plain text here", "foo", "x y z"]) {
+		expect(fastLineStartHazard(line)).toBe(false);
+	}
+});
+
+it("line-start hazard fires on block markers and HRs", () => {
+	for (const line of ["# h", "> q", "1. x", "- a", "+ a", "---", "***", "═══", "───", "==="]) {
+		expect(fastLineStartHazard(line)).toBe(true);
+	}
+});
+
+it("line-start hazard fires on a ref-def", () => {
+	expect(fastLineStartHazard("[label]: https://x")).toBe(true);
+});
+
+it("fast path engages on a prose reveal (splice counter > 0)", () => {
+	// A regression that silently disarms every frame (e.g. an over-broad
+	// line-start gate matching all ASCII) leaves byte-identity intact but
+	// drops the splice count to zero — invisible to the byte-identity suite.
+	// This asserts the fast path actually runs on plain streaming prose.
+	const prose =
+		"This is a plain prose paragraph that streams in one character at a time without any markdown styling markers.";
+	const streaming = new Markdown("", 0, 0, THEME);
+	streaming.transientRenderCache = true;
+	resetFastTailSplices();
+	for (let len = 1; len <= prose.length; len++) {
+		clearRenderCache();
+		streaming.setText(prose.slice(0, len));
+		streaming.render(60);
+	}
+	expect(fastTailSplices).toBeGreaterThan(0);
+	resetFastTailSplices();
+});


### PR DESCRIPTION
## Problem

Markdown streaming re-lexes the entire tail on every inert delta (text append), even though only the last row changes. For long paragraphs this is the dominant cost (#9048 perf evidence).

## Approach

When a transient streaming frame's last content row came from a paragraph, an append-only same-line delta re-renders ONLY that row — a splice of the re-wrapped grown row onto the previous frame's cached rows — instead of re-lexing the whole tail. The splice is **byte-identical to a cold full render at every frame** (the new text shows every frame — no lag). On any hazard that could change the token shape, the fast path disarms with a full-relex fallback.

## Hazard gates (every gate has a load-bearing test)

| Gate | Disarms when |
|------|--------------|
| Line-start block-kind | Grown line starts ATX heading, blockquote, list marker, HR (`*+-─━═–—=`), or ref-def |
| Seam URL/email | Raw or decoded tail contains a protocol head, `www.`, or email prefix |
| Entity seam | Partial or complete numeric entity at row end (`&am`, `&#35;`, `&#x23;`) |
| Decoded-tail swatch | Entity decodes to `#` mid-row (`&#35;ab` → `#ab` → swatch lead) |
| Decoded-tail run-end | Entity decodes to trailing space (`&nbsp;` → wrap-trim shift) |
| Cross-seam pair re-pair | Delta opens `*`/`~`/`` ` ``/`[` when row ends with the matching close char |
| Image marker | Row ends `!` + delta starts `[` (image completion across seam) |
| Underscore flanking | Delta starts/ends `_` after a word char |
| Open inline construct | Delta's inline token stream holds an unclosed delimiter |
| Wrap-trim/escape/run-end | Row tail ends in whitespace, backslash, or partial hex swatch |
| Signature/width/reset | bgColor, theme, width mismatch, or cache flip |

## Byte-identity contract

Every frame of every reveal is asserted byte-identical to a cold full render of the same prefix. A shared `assertByteIdentityEveryFrame` helper (step-1 reveal through one transient instance) and a 2-frame `assertSpliceParts` helper (explicit seam-staging for multi-char deltas that step-1 cannot reach) cover every gate. A splice-engagement counter (`fastTailSplices`) asserts the fast path actually runs — a regression that silently disarms (e.g. an over-broad gate matching all ASCII) is caught.

## Benchmark (median-of-3, interleaved, width=100, identity theme)

| Case | Frames | Plain p50 | B+ p50 | Engage% | Saves% |
|------|--------|-----------|--------|---------|--------|
| pureProse:32KB@24 | 1365 | 4.42ms | 0.79ms | 86.4% | **72.0%** |
| emphasis:32KB@24 | 1365 | 643.93ms | 1.30ms | 58.7% | **57.4%** |
| tight:32KB@24 | 1365 | 17.91ms | 11.64ms | 22.1% | **32.6%** |
| tightStream:32KB@24 | 1365 | 293.75ms | 75.65ms | 33.5% | **21.6%** |
| tight:128KB@72 | 1820 | 65.71ms | 51.02ms | 12.4% | **16.5%** |
| singleParagraph:32KB@24 | 1365 | 35.50ms | 32.75ms | 0.0% | 10.7% |
| realistic:8KB@24 | 341 | 0.42ms | 0.31ms | 21.7% | 10.1% |
| realistic:32KB@24 | 1365 | 0.46ms | 0.39ms | 22.9% | 5.5% |
| realistic:128KB@72 | 1820 | 0.56ms | 0.57ms | 13.4% | 2.1% |
| refdef:32KB@24 | 1364 | 0.32ms | 0.32ms | 22.8% | -0.7% |

**Notes**: `tight:128KB@72` rerun under quiet load (loadavg <1); first run under load 84 showed −62.3% (scheduler noise — p90 282→494ms). `refdef` is net-neutral (the fast path's gate overhead ≈ the skipped lex at this size). Run-level styled streams (thinking traces, colored assistant content) disarm entirely — the gain materializes for unstyled content.

## Tests (29 deterministic, zero wall-clock)

- 25 byte-identity + seam-fixture tests (step-1 reveal + 2-frame splice for every gate)
- 3 gate unit tests (line-start hazard: prose-safe, block-marker/HR-fire, ref-def)
- 1 splice-engagement assertion (counter > 0 on prose reveal)

## Review history

Successor to closed PR #9509, addressing all its review threads. Five rounds of adversarial review (fresh reviewer each round) resolved: cross-seam pair re-pairing (`*`/`~`/`` ` ``), image marker (`!`+`[`), box-drawing HR chars, entity-decoded swatch lead, char-class range bug (killed the fast path), dead decoded-URL arm, and splice-engagement test coverage.