### PR TITLE
fix(fetch): forward Jina Reader credentials

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Jina Reader fetch backend so `JINA_API_KEY` and stored `jina` credentials are sent as bearer auth when configured.
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import type { FetchImpl, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { type FetchImpl, getEnvApiKey, type ImageContent, type TextContent } from "@oh-my-pi/pi-ai";
 import { htmlToMarkdown } from "@oh-my-pi/pi-natives";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
 import { $which, ptree, truncate } from "@oh-my-pi/pi-utils";
@@ -25,6 +25,7 @@ import { extractWithParallel, findParallelApiKey, getParallelExtractContent } fr
 import type { RenderResult, SpecialHandler } from "../web/scrapers/types";
 import { finalizeOutput, loadPage, looksLikeHtml, MAX_BYTES, MAX_OUTPUT_CHARS } from "../web/scrapers/types";
 import { convertWithMarkit, fetchBinary } from "../web/scrapers/utils";
+import { findCredential } from "../web/search/providers/utils";
 import { applyListLimit } from "./list-limit";
 import { formatStyledArtifactReference, type OutputMeta } from "./output-meta";
 import { isReadableUrlPath, type LineRange, parseLineRanges } from "./path-utils";
@@ -665,11 +666,14 @@ export async function renderHtmlToText(
 			return firstDocument ? getParallelExtractContent(firstDocument) : null;
 		},
 		jina: async () => {
+			const jinaApiKey = findCredential(storage, getEnvApiKey("jina"), "jina");
+			const headers: Record<string, string> = {
+				Accept: "text/markdown",
+				"X-No-Cache": "true",
+			};
+			if (jinaApiKey) headers.Authorization = `Bearer ${jinaApiKey}`;
 			const response = await fetchImpl(`https://r.jina.ai/${url}`, {
-				headers: {
-					Accept: "text/markdown",
-					"X-No-Cache": "true",
-				},
+				headers,
 				signal: remoteSignal(),
 			});
 			if (!response.ok) return null;

--- a/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
+++ b/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { renderHtmlToText } from "@oh-my-pi/pi-coding-agent/tools/fetch";
 import { asGlobalFetch } from "../helpers/fetch-mock";
+
+const originalJinaApiKey = Bun.env.JINA_API_KEY;
+
+beforeEach(() => {
+	delete Bun.env.JINA_API_KEY;
+});
+
+afterEach(() => {
+	if (originalJinaApiKey === undefined) delete Bun.env.JINA_API_KEY;
+	else Bun.env.JINA_API_KEY = originalJinaApiKey;
+});
 
 /**
  * Regression test for #1449: a stalled Jina reader request must not prevent
@@ -117,6 +129,62 @@ describe("renderHtmlToText: Jina response validation", () => {
 		expect(result).toEqual({ content: markdown, ok: true, method: "jina" });
 		expect(requestHeaders?.get("accept")).toBe("text/markdown");
 		expect(requestHeaders?.get("x-no-cache")).toBe("true");
+		expect(requestHeaders?.get("authorization")).toBeNull();
+	});
+
+	it("forwards stored Jina credentials to reader requests", async () => {
+		const settings = Settings.isolated({ "providers.fetch": "jina" });
+		const markdown = `# Extracted article\n\n${"Substantive reader content. ".repeat(8)}`.trim();
+		let requestHeaders: Headers | undefined;
+		const fetchMock = asGlobalFetch((_input, init) => {
+			requestHeaders = new Headers(init?.headers);
+			return new Response(`Title: Example\nURL Source: https://example.com/article\nMarkdown Content:\n${markdown}`);
+		});
+		const storage = {
+			listAuthCredentials: () => [
+				{
+					id: 1,
+					credential: { type: "api_key", key: "stored-jina-key" },
+				},
+			],
+		} as unknown as AgentStorage;
+
+		const result = await renderHtmlToText(
+			"https://example.com/article",
+			"<html><body>short</body></html>",
+			1,
+			settings,
+			undefined,
+			storage,
+			fetchMock,
+		);
+
+		expect(result).toEqual({ content: markdown, ok: true, method: "jina" });
+		expect(requestHeaders?.get("authorization")).toBe("Bearer stored-jina-key");
+	});
+
+	it("forwards JINA_API_KEY to reader requests", async () => {
+		Bun.env.JINA_API_KEY = "env-jina-key";
+		const settings = Settings.isolated({ "providers.fetch": "jina" });
+		const markdown = `# Extracted article\n\n${"Substantive reader content. ".repeat(8)}`.trim();
+		let requestHeaders: Headers | undefined;
+		const fetchMock = asGlobalFetch((_input, init) => {
+			requestHeaders = new Headers(init?.headers);
+			return new Response(`Title: Example\nURL Source: https://example.com/article\nMarkdown Content:\n${markdown}`);
+		});
+
+		const result = await renderHtmlToText(
+			"https://example.com/article",
+			"<html><body>short</body></html>",
+			1,
+			settings,
+			undefined,
+			null,
+			fetchMock,
+		);
+
+		expect(result).toEqual({ content: markdown, ok: true, method: "jina" });
+		expect(requestHeaders?.get("authorization")).toBe("Bearer env-jina-key");
 	});
 
 	for (const { label, readerBody, headers } of [


### PR DESCRIPTION
Fixes #9431

`providers.fetch: jina` anunciaba soporte para `JINA_API_KEY`, pero el backend de fetch no enviaba autenticación a `r.jina.ai`. Este cambio añade autorización Bearer opcional desde `JINA_API_KEY` o credenciales almacenadas para `jina`, conservando las peticiones anónimas.

I reviewed the full diff; this keeps the existing reader fallback behavior and only changes the Jina request headers.

Verification:
- `bun test packages/coding-agent/test/tools/fetch-jina-stall.test.ts` — 10 pass
- `bun run check` desde `packages/coding-agent` — pasa