### PR TITLE
feat(update): show binary download progress

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+### Changed
+
+- `omp update` now reports byte, percentage, and transfer-rate progress during release binary downloads in TTY and non-TTY output.
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/cli/progress-reporter.ts
+++ b/packages/coding-agent/src/cli/progress-reporter.ts
@@ -1,3 +1,4 @@
+import { Ellipsis, truncateToWidth } from "@oh-my-pi/pi-tui";
 import { formatBytes } from "@oh-my-pi/pi-utils";
 
 const BAR_WIDTH = 16;
@@ -5,6 +6,7 @@ const BAR_WIDTH = 16;
 /** Minimal output contract used by the interactive progress reporter. */
 export interface ProgressOutput {
 	isTTY?: boolean;
+	columns?: number;
 	write(text: string): boolean;
 }
 
@@ -64,7 +66,13 @@ export interface DownloadProgressReporter {
 	finish(): void;
 }
 
-function formatDownloadProgress(label: string, received: number, total: number, elapsedMs: number): string {
+function formatDownloadProgress(
+	label: string,
+	received: number,
+	total: number,
+	elapsedMs: number,
+	maxWidth?: number,
+): string {
 	const ratio = total > 0 ? Math.min(received / total, 1) : 0;
 	const filled = Math.round(ratio * DOWNLOAD_BAR_WIDTH);
 	const bar = `${"█".repeat(filled)}${"░".repeat(DOWNLOAD_BAR_WIDTH - filled)}`;
@@ -72,9 +80,17 @@ function formatDownloadProgress(label: string, received: number, total: number, 
 		.toString()
 		.padStart(3, " ")}%`;
 	const rate = elapsedMs > 0 ? formatBytes((received * 1_000) / elapsedMs) : "0B";
-	return `${label} [${bar}] ${percent} ${formatBytes(received)} / ${formatBytes(total)} ${rate}/s`;
+	const line = `${label} [${bar}] ${percent} ${formatBytes(received)} / ${formatBytes(total)} ${rate}/s`;
+	return maxWidth === undefined ? line : truncateToWidth(line, maxWidth, Ellipsis.Omit);
 }
 
+function getDownloadProgressWidth(output: ProgressOutput): number | undefined {
+	if (output.isTTY !== true) return undefined;
+	const columns = output.columns;
+	const terminalWidth =
+		typeof columns === "number" && Number.isFinite(columns) && columns > 0 ? Math.trunc(columns) : 120;
+	return Math.max(1, terminalWidth - 1);
+}
 export function createDownloadProgressReporter(
 	label: string,
 	total: number,
@@ -82,6 +98,7 @@ export function createDownloadProgressReporter(
 	now: () => number = Date.now,
 ): DownloadProgressReporter {
 	const interactive = output.isTTY === true;
+	const maxWidth = getDownloadProgressWidth(output);
 	const boundedTotal = Math.max(total, 0);
 	const startedAt = now();
 	let lastRenderedAt = Number.NEGATIVE_INFINITY;
@@ -91,7 +108,7 @@ export function createDownloadProgressReporter(
 	const render = (force = false): void => {
 		const currentTime = now();
 		if (!force && currentTime - lastRenderedAt < DOWNLOAD_PROGRESS_INTERVAL_MS) return;
-		const line = formatDownloadProgress(label, received, boundedTotal, currentTime - startedAt);
+		const line = formatDownloadProgress(label, received, boundedTotal, currentTime - startedAt, maxWidth);
 		output.write(interactive ? `\r${line}\x1b[K` : `${line}\n`);
 		lastRenderedAt = currentTime;
 		rendered = true;
@@ -100,7 +117,7 @@ export function createDownloadProgressReporter(
 	return {
 		update(nextReceived) {
 			received = Math.max(received, Math.min(nextReceived, boundedTotal));
-			render(received >= boundedTotal);
+			render(boundedTotal > 0 && received >= boundedTotal);
 		},
 		finish() {
 			if (interactive && rendered) output.write("\n");

--- a/packages/coding-agent/src/cli/progress-reporter.ts
+++ b/packages/coding-agent/src/cli/progress-reporter.ts
@@ -1,3 +1,5 @@
+import { formatBytes } from "@oh-my-pi/pi-utils";
+
 const BAR_WIDTH = 16;
 
 /** Minimal output contract used by the interactive progress reporter. */
@@ -50,6 +52,58 @@ export function createProgressReporter(label: string, output: ProgressOutput = p
 			if (!rendered) return;
 			output.write("\n");
 			rendered = false;
+		},
+	};
+}
+
+const DOWNLOAD_BAR_WIDTH = 20;
+const DOWNLOAD_PROGRESS_INTERVAL_MS = 1_000;
+
+export interface DownloadProgressReporter {
+	update(received: number): void;
+	finish(): void;
+}
+
+function formatDownloadProgress(label: string, received: number, total: number, elapsedMs: number): string {
+	const ratio = total > 0 ? Math.min(received / total, 1) : 0;
+	const filled = Math.round(ratio * DOWNLOAD_BAR_WIDTH);
+	const bar = `${"█".repeat(filled)}${"░".repeat(DOWNLOAD_BAR_WIDTH - filled)}`;
+	const percent = `${Math.floor(ratio * 100)
+		.toString()
+		.padStart(3, " ")}%`;
+	const rate = elapsedMs > 0 ? formatBytes((received * 1_000) / elapsedMs) : "0B";
+	return `${label} [${bar}] ${percent} ${formatBytes(received)} / ${formatBytes(total)} ${rate}/s`;
+}
+
+export function createDownloadProgressReporter(
+	label: string,
+	total: number,
+	output: ProgressOutput = process.stdout,
+	now: () => number = Date.now,
+): DownloadProgressReporter {
+	const interactive = output.isTTY === true;
+	const boundedTotal = Math.max(total, 0);
+	const startedAt = now();
+	let lastRenderedAt = Number.NEGATIVE_INFINITY;
+	let received = 0;
+	let rendered = false;
+
+	const render = (force = false): void => {
+		const currentTime = now();
+		if (!force && currentTime - lastRenderedAt < DOWNLOAD_PROGRESS_INTERVAL_MS) return;
+		const line = formatDownloadProgress(label, received, boundedTotal, currentTime - startedAt);
+		output.write(interactive ? `\r${line}\x1b[K` : `${line}\n`);
+		lastRenderedAt = currentTime;
+		rendered = true;
+	};
+
+	return {
+		update(nextReceived) {
+			received = Math.max(received, Math.min(nextReceived, boundedTotal));
+			render(received >= boundedTotal);
+		},
+		finish() {
+			if (interactive && rendered) output.write("\n");
 		},
 	};
 }

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -22,6 +22,7 @@ import {
 	unsupportedProxyMessage,
 	withTimeoutSignal,
 } from "../utils/fetch-timeout";
+import { createDownloadProgressReporter } from "./progress-reporter";
 
 const REPO = "can1357/oh-my-pi";
 const PACKAGE = "@oh-my-pi/pi-coding-agent";
@@ -276,6 +277,7 @@ export interface VerifiedBinaryDownloadOptions {
 	expectedSize: number;
 	expectedDigest: string;
 	fetchImpl?: Fetch;
+	onProgress?: (received: number) => void;
 }
 
 /**
@@ -316,6 +318,7 @@ export async function downloadVerifiedBinary(options: VerifiedBinaryDownloadOpti
 				return;
 			}
 			hash.update(chunk);
+			options.onProgress?.(size);
 			callback(null, chunk);
 		},
 	});
@@ -337,6 +340,28 @@ export async function downloadVerifiedBinary(options: VerifiedBinaryDownloadOpti
 		}
 		if (isUnsupportedProxyError(err)) throw new Error(unsupportedProxyMessage(), { cause: err });
 		throw err;
+	}
+}
+
+async function downloadReleaseBinary(
+	asset: ReleaseBinaryAsset,
+	targetPath: string,
+	binaryName: string,
+	fetchImpl?: Fetch,
+): Promise<void> {
+	const progress = createDownloadProgressReporter(`Downloading ${binaryName}`, asset.size);
+	progress.update(0);
+	try {
+		await downloadVerifiedBinary({
+			url: asset.url,
+			targetPath,
+			expectedSize: asset.size,
+			expectedDigest: asset.digest,
+			fetchImpl,
+			onProgress: progress.update,
+		});
+	} finally {
+		progress.finish();
 	}
 }
 
@@ -1693,14 +1718,7 @@ export async function updateViaBinaryAt(
 	const tempPath = `${targetPath}.${attempt}.new`;
 	const backupPath = `${targetPath}.${attempt}.bak`;
 	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl, options.githubToken);
-	console.log(chalk.dim(`Downloading ${binaryName}…`));
-	await downloadVerifiedBinary({
-		url: asset.url,
-		targetPath: tempPath,
-		expectedSize: asset.size,
-		expectedDigest: asset.digest,
-		fetchImpl: options.fetchImpl,
-	});
+	await downloadReleaseBinary(asset, tempPath, binaryName, options.fetchImpl);
 	console.log(chalk.dim(`Verified ${asset.digest}`));
 
 	// Serialize the target swap and stale-artifact sweep per target so two
@@ -1778,14 +1796,7 @@ export async function updateViaShimTakeover(
 	const attempt = `${Date.now()}.${process.pid}.${updateAttemptSeq++}`;
 	const tempPath = `${exePath}.${attempt}.new`;
 	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl, options.githubToken);
-	console.log(chalk.dim(`Downloading ${binaryName}…`));
-	await downloadVerifiedBinary({
-		url: asset.url,
-		targetPath: tempPath,
-		expectedSize: asset.size,
-		expectedDigest: asset.digest,
-		fetchImpl: options.fetchImpl,
-	});
+	await downloadReleaseBinary(asset, tempPath, binaryName, options.fetchImpl);
 	console.log(chalk.dim(`Verified ${asset.digest}`));
 	const forwarded: Array<{ launcher: string; original: string }> = [];
 	const stuck: string[] = [];

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -5,6 +5,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as pluginCli from "@oh-my-pi/pi-coding-agent/cli/plugin-cli";
+import { createDownloadProgressReporter } from "@oh-my-pi/pi-coding-agent/cli/progress-reporter";
 import * as updateCli from "@oh-my-pi/pi-coding-agent/cli/update-cli";
 import {
 	buildBunInstallArgs,
@@ -744,6 +745,70 @@ describe("update-cli bun cache pruning", () => {
 	});
 });
 
+describe("update-cli download progress", () => {
+	it("renders throttled byte progress on TTY output", () => {
+		let now = 0;
+		const writes: string[] = [];
+		const progress = createDownloadProgressReporter(
+			"Downloading omp",
+			100,
+			{
+				isTTY: true,
+				write(text) {
+					writes.push(text);
+					return true;
+				},
+			},
+			() => now,
+		);
+
+		progress.update(0);
+		now = 100;
+		progress.update(50);
+		now = 1_000;
+		progress.update(50);
+		progress.update(100);
+		progress.finish();
+
+		expect(writes).toHaveLength(4);
+		expect(writes[0]).toContain("0%");
+		expect(writes[1]).toContain("50%");
+		expect(writes[2]).toContain("100B / 100B");
+		expect(writes[3]).toBe("\n");
+	});
+
+	it("emits periodic lines for non-TTY output", () => {
+		let now = 0;
+		const writes: string[] = [];
+		const progress = createDownloadProgressReporter(
+			"Downloading omp",
+			100,
+			{
+				isTTY: false,
+				write(text) {
+					writes.push(text);
+					return true;
+				},
+			},
+			() => now,
+		);
+
+		progress.update(0);
+		now = 500;
+		progress.update(50);
+		now = 1_000;
+		progress.update(50);
+		progress.update(100);
+		progress.finish();
+
+		expect(writes).toHaveLength(3);
+		expect(writes[0]).toContain("0%");
+		expect(writes[1]).toContain("50%");
+		expect(writes[2]).toContain("100B / 100B");
+		expect(writes.every(write => write.endsWith("\n"))).toBe(true);
+	});
+});
+
 describe("update-cli release binary integrity", () => {
 	const tag = "v17.1.2";
 	const binaryName = "omp-linux-x64";
@@ -768,6 +833,46 @@ describe("update-cli release binary integrity", () => {
 			],
 		};
 	}
+	it("reports binary download progress during an update", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+		const installed = "#!/bin/sh\necho omp/17.0.8\n";
+		const nextBinary = "#!/bin/sh\necho omp/17.1.2\n";
+		const nextDigest = `sha256:${createHash("sha256").update(nextBinary).digest("hex")}`;
+		await Bun.write(targetPath, installed);
+		await fs.chmod(targetPath, 0o755);
+
+		const writes: string[] = [];
+		spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+			writes.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+		const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
+			const requestUrl = String(input);
+			if (requestUrl.startsWith("https://api.github.com/")) {
+				return new Response(
+					JSON.stringify(
+						releaseAsset({
+							size: Buffer.byteLength(nextBinary),
+							digest: nextDigest,
+						}),
+					),
+				);
+			}
+			if (requestUrl === url) return new Response(nextBinary);
+			throw new Error(`Unexpected request: ${requestUrl}`);
+		};
+
+		await updateViaBinaryAt(targetPath, "17.1.2", {
+			binaryName,
+			fetchImpl,
+			verifyInstalledVersion: async () => ({ ok: true, actual: "17.1.2", path: targetPath }),
+		});
+
+		const output = writes.join("");
+		expect(output).toContain(`Downloading ${binaryName}`);
+		expect(output).toContain("100%");
+	});
 
 	it("selects an uploaded asset with a valid SHA-256 digest", () => {
 		expect(resolveReleaseBinaryAsset(releaseAsset(), tag, binaryName)).toEqual({
@@ -810,6 +915,7 @@ describe("update-cli release binary integrity", () => {
 	it("writes a download only after its size and digest match", async () => {
 		const dir = await makeTempDir();
 		const targetPath = path.join(dir, binaryName);
+		const progress: number[] = [];
 
 		await downloadVerifiedBinary({
 			url,
@@ -817,10 +923,12 @@ describe("update-cli release binary integrity", () => {
 			expectedSize: Buffer.byteLength(content),
 			expectedDigest: digest,
 			fetchImpl: async () => new Response(content),
+			onProgress: received => progress.push(received),
 		});
 
 		expect(await Bun.file(targetPath).text()).toBe(content);
 		expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o755);
+		expect(progress.at(-1)).toBe(Buffer.byteLength(content));
 	});
 
 	it("aborts the response stream as soon as it exceeds the expected size", async () => {

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -776,6 +776,29 @@ describe("update-cli download progress", () => {
 		expect(writes[2]).toContain("100B / 100B");
 		expect(writes[3]).toBe("\n");
 	});
+	it("bounds TTY progress to the output width", () => {
+		const writes: string[] = [];
+		const progress = createDownloadProgressReporter(
+			"Downloading omp-linux-musl-arm64",
+			123_456_789,
+			{
+				isTTY: true,
+				columns: 80,
+				write(text) {
+					writes.push(text);
+					return true;
+				},
+			},
+			() => 1_000,
+		);
+
+		progress.update(123_456_789);
+
+		const rendered = Bun.stripANSI(writes[0]!)
+			.replace(/^\r/, "")
+			.replace(/\x1b\[K$/, "");
+		expect(Bun.stringWidth(rendered)).toBeLessThanOrEqual(79);
+	});
 
 	it("emits periodic lines for non-TTY output", () => {
 		let now = 0;
@@ -806,6 +829,30 @@ describe("update-cli download progress", () => {
 		expect(writes[1]).toContain("50%");
 		expect(writes[2]).toContain("100B / 100B");
 		expect(writes.every(write => write.endsWith("\n"))).toBe(true);
+	});
+	it("throttles updates when the total size is zero", () => {
+		let now = 0;
+		const writes: string[] = [];
+		const progress = createDownloadProgressReporter(
+			"Downloading omp",
+			0,
+			{
+				isTTY: false,
+				write(text) {
+					writes.push(text);
+					return true;
+				},
+			},
+			() => now,
+		);
+
+		progress.update(0);
+		now = 100;
+		progress.update(0);
+		expect(writes).toHaveLength(1);
+		now = 1_000;
+		progress.update(0);
+		expect(writes).toHaveLength(2);
 	});
 });
 


### PR DESCRIPTION
Fixes #9499

## Summary

- report received bytes from the verified release-binary stream without changing size or SHA-256 verification;
- show a throttled byte/percentage/rate bar on TTY output;
- emit periodic newline-delimited progress on non-TTY output;
- cover both binary replacement and Windows shim-takeover download paths.

I reviewed the full diff; the progress callback is throttled at the reporter boundary and does not alter the download, size, digest, or replacement flow.

## Review follow-up

- bound TTY progress lines to the available terminal width with `@oh-my-pi/pi-tui`'s `truncateToWidth`;
- keep zero-size progress updates on the one-second throttle instead of forcing every chunk to render.

## Verification

- `bun test packages/coding-agent/test/update-cli.test.ts` — 88 pass
- `bun run check` from `packages/coding-agent` — passes
- `git diff --check` — passes