### PR TITLE
fix(tui): disambiguate session IDs in the status line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the status-line session segment showing identical IDs for sessions created close together by displaying a 13-character prefix by default and supporting `statusLine.segmentOptions.session.length` overrides ([#9572](https://github.com/can1357/oh-my-pi/issues/9572)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -567,7 +567,8 @@ const sessionSegment: StatusLineSegment = {
 	render(ctx) {
 		const sessionManager = ctx.session.sessionManager;
 		const sessionId = sessionManager?.getSessionId?.();
-		const display = sessionId?.slice(0, 8) || "new";
+		const length = Math.max(1, Math.trunc(ctx.options.session?.length ?? 13));
+		const display = sessionId?.slice(0, length) || "new";
 
 		return { content: withIcon(theme.icon.session, display), visible: true };
 	},

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -20,6 +20,7 @@ export interface CollabStatus {
 }
 
 export interface StatusLineSegmentOptions {
+	session?: { length?: number };
 	model?: { showThinkingLevel?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };

--- a/packages/coding-agent/test/status-line-session.test.ts
+++ b/packages/coding-agent/test/status-line-session.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+const COLLIDING_SESSION_IDS = ["01a03242-993e-73f7-9bb9-4be42368e12f", "01a03242-e0d8-7074-806e-79104cd3e1d3"] as const;
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function renderSession(sessionId: string, length?: number): string {
+	const ctx = {
+		session: { sessionManager: { getSessionId: () => sessionId } },
+		options: length === undefined ? {} : { session: { length } },
+	} as unknown as SegmentContext;
+	return Bun.stripANSI(renderSegment("session", ctx).content);
+}
+
+describe("session status-line segment", () => {
+	it("distinguishes nearby UUIDv7 sessions by default", () => {
+		const [first, second] = COLLIDING_SESSION_IDS.map(id => renderSession(id));
+
+		expect(first).toContain("01a03242-993e");
+		expect(second).toContain("01a03242-e0d8");
+		expect(first).not.toBe(second);
+	});
+
+	it("honors a configured prefix length", () => {
+		expect(renderSession(COLLIDING_SESSION_IDS[0], 8)).toContain("01a03242");
+		expect(renderSession(COLLIDING_SESSION_IDS[0], 8)).not.toContain("01a03242-993e");
+	});
+
+	it("clamps configured prefix lengths to at least one character", () => {
+		expect(renderSession(COLLIDING_SESSION_IDS[0], 0)).not.toContain("new");
+		expect(renderSession(COLLIDING_SESSION_IDS[0], 0)).toContain("0");
+	});
+});


### PR DESCRIPTION
## What

- display 13 characters of the session UUID in the built-in `session` status-line segment by default
- support `statusLine.segmentOptions.session.length` overrides, clamped to at least one character
- add regression coverage for two real sessions whose previous 8-character displays collided

## Why

The hard-coded 8-character prefix made nearby UUIDv7 sessions appear identical. Fixes #9572.

I reviewed the full diff; this keeps full UUIDs unchanged internally while making the compact footer identifier distinguish sessions created seconds apart.

## Testing

- `bun run check` in `packages/coding-agent`
- `bun test packages/coding-agent/test/status-line-*.test.ts` — 173 pass, 0 fail
- real PTY smoke: resumed `01a03275-d9ed-7030-81e6-3d012e284461` through the source CLI and observed `01a03275-d9ed` in the rendered TUI status line

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)