### PR TITLE
fix(tui): distinguish session ids in status line

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -681,7 +681,7 @@ tui:
 | `statusLine.sessionAccent`  | boolean | `true`           | Tint the editor border with the session color.                            |
 | `statusLine.transparent`    | boolean | `false`          | Use the terminal background for the status line.                          |
 | `statusLine.showHookStatus` | boolean | `true`           | Show hook status messages.                                                |
-| `statusLine.segmentOptions.session.length` | number | `13` | Number of session UUID characters shown by the `session` segment. |
+| `statusLine.segmentOptions.session.length` | number | `13` | Number of session UUID characters shown by the `session` segment; values below `1` are clamped to `1`. |
 | `terminal.showImages`       | boolean | `true`           | Render images inline (when the terminal supports it).                     |
 | `images.autoResize`         | boolean | `true`           | Resize large images for model compatibility.                              |
 | `images.blockImages`        | boolean | `false`          | Never send images to providers.                                           |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -656,6 +656,9 @@ statusLine:
   separator: powerline-thin
   transparent: false
   showHookStatus: true
+  segmentOptions:
+    session:
+      length: 13
 
 terminal:
   showImages: true
@@ -678,6 +681,7 @@ tui:
 | `statusLine.sessionAccent`  | boolean | `true`           | Tint the editor border with the session color.                            |
 | `statusLine.transparent`    | boolean | `false`          | Use the terminal background for the status line.                          |
 | `statusLine.showHookStatus` | boolean | `true`           | Show hook status messages.                                                |
+| `statusLine.segmentOptions.session.length` | number | `13` | Number of session UUID characters shown by the `session` segment. |
 | `terminal.showImages`       | boolean | `true`           | Render images inline (when the terminal supports it).                     |
 | `images.autoResize`         | boolean | `true`           | Resize large images for model compatibility.                              |
 | `images.blockImages`        | boolean | `false`          | Never send images to providers.                                           |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the status-line session segment showing identical IDs for sessions created close together ([#9572](https://github.com/can1357/oh-my-pi/issues/9572)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -567,7 +567,7 @@ const sessionSegment: StatusLineSegment = {
 	render(ctx) {
 		const sessionManager = ctx.session.sessionManager;
 		const sessionId = sessionManager?.getSessionId?.();
-		const display = sessionId?.slice(0, 8) || "new";
+		const display = sessionId?.slice(0, ctx.options.session?.length ?? 13) || "new";
 
 		return { content: withIcon(theme.icon.session, display), visible: true };
 	},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -567,7 +567,7 @@ const sessionSegment: StatusLineSegment = {
 	render(ctx) {
 		const sessionManager = ctx.session.sessionManager;
 		const sessionId = sessionManager?.getSessionId?.();
-		const display = sessionId?.slice(0, ctx.options.session?.length ?? 13) || "new";
+		const display = sessionId?.slice(0, Math.max(1, ctx.options.session?.length ?? 13)) || "new";
 
 		return { content: withIcon(theme.icon.session, display), visible: true };
 	},

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -20,6 +20,7 @@ export interface CollabStatus {
 }
 
 export interface StatusLineSegmentOptions {
+	session?: { length?: number };
 	model?: { showThinkingLevel?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };

--- a/packages/coding-agent/test/status-line-session.test.ts
+++ b/packages/coding-agent/test/status-line-session.test.ts
@@ -1,0 +1,32 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function renderSessionId(sessionId: string, length?: number): string {
+	const ctx = {
+		session: { sessionManager: { getSessionId: () => sessionId } },
+		options: { session: length === undefined ? undefined : { length } },
+	} as unknown as SegmentContext;
+	const content = Bun.stripANSI(renderSegment("session", ctx).content);
+	return theme.icon.session ? content.slice(theme.icon.session.length + 1) : content;
+}
+
+describe("session status-line segment", () => {
+	it("distinguishes UUIDv7 sessions created within one 65-second prefix window", () => {
+		const first = renderSessionId("01a03242-993e-73f7-9bb9-4be42368e12f");
+		const second = renderSessionId("01a03242-e0d8-7074-806e-79104cd3e1d3");
+
+		expect(first).toBe("01a03242-993e");
+		expect(second).toBe("01a03242-e0d8");
+		expect(first).not.toBe(second);
+	});
+
+	it("honors the configured session prefix length", () => {
+		expect(renderSessionId("01a03242-993e-73f7-9bb9-4be42368e12f", 16)).toBe("01a03242-993e-73");
+	});
+});

--- a/packages/coding-agent/test/status-line-session.test.ts
+++ b/packages/coding-agent/test/status-line-session.test.ts
@@ -29,4 +29,11 @@ describe("session status-line segment", () => {
 	it("honors the configured session prefix length", () => {
 		expect(renderSessionId("01a03242-993e-73f7-9bb9-4be42368e12f", 16)).toBe("01a03242-993e-73");
 	});
+
+	it("clamps non-positive prefix lengths to one character", () => {
+		const sessionId = "01a03242-993e-73f7-9bb9-4be42368e12f";
+
+		expect(renderSessionId(sessionId, 0)).toBe("0");
+		expect(renderSessionId(sessionId, -1)).toBe("0");
+	});
 });


### PR DESCRIPTION
## Repro
Rendering `01a03242-993e-73f7-9bb9-4be42368e12f` and `01a03242-e0d8-7074-806e-79104cd3e1d3` through `renderSegment("session", ctx)` on current main produces `🆔 01a03242` for both; the reproduction used `bun --eval` to import `segments.ts`, initialize the theme, and print both rendered values.

## Cause
`sessionSegment.render` in `packages/coding-agent/src/modes/components/status-line/segments.ts` hard-coded `sessionId.slice(0, 8)`. For UUIDv7 IDs, those eight digits exclude the low 16 bits of the millisecond timestamp and therefore remain constant for roughly 65.5 seconds.

## Fix
- Render 13 characters by default, including all 12 UUIDv7 timestamp hex digits and the separator.
- Add `statusLine.segmentOptions.session.length` for explicit prefix sizing.
- Cover same-window UUIDv7 IDs and configured lengths; document the setting and record the fix in the changelog.

## Verification
`bun test packages/coding-agent/test/status-line-session.test.ts` passed: 2 tests, 0 failures. Re-running the reproduction rendered distinct values, `🆔 01a03242-993e` and `🆔 01a03242-e0d8`. Pre-publish `bun run fix` and `bun check` passed through the branch push gate.

Fixes #9572