### PR TITLE
fix(coding-agent): refresh todo HUD when re-attaching a session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the sticky Todo HUD freezing at an earlier snapshot after viewing a subagent and returning to the main session ([#9571](https://github.com/can1357/oh-my-pi/issues/9571)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -105,15 +105,12 @@ export class SessionFocusController {
 		});
 		this.ctx.statusLine.setSession(target, this.#focusedAgentId);
 		await this.ctx.renderInitialMessages({ clearTerminalHistory: true });
-		// Retarget the sticky Todo HUD too. It is driven by live `setTodos` events
-		// on the attached session, so a focus round-trip would otherwise leave it
-		// frozen at the pre-focus snapshot: while a subagent is focused the main
-		// session's `todo` completions never reach the HUD, and returning to the
-		// main session rebuilds the transcript from committed messages (current)
-		// but never refreshes the HUD. Reload it from the now-attached session's
-		// authoritative todo state, mirroring the transcript/status-line retarget
-		// above (issue #9571).
-		await this.ctx.reloadTodos();
+		// Retarget the sticky Todo HUD too. While a subagent is focused the main
+		// session's `todo` completions never reach this controller; returning to
+		// main must therefore reload its current state instead of retaining the
+		// pre-focus snapshot. Passing `target` also restores a focused subagent's
+		// own todos rather than overwriting them with the main session's list.
+		await this.ctx.reloadTodos(target);
 		// Sync the run-state title to the attached target: a streaming target has no
 		// agent_start incoming, so arm the loader/working title manually; an idle
 		// target would otherwise inherit the previous session's stuck spinner, so

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -105,6 +105,15 @@ export class SessionFocusController {
 		});
 		this.ctx.statusLine.setSession(target, this.#focusedAgentId);
 		await this.ctx.renderInitialMessages({ clearTerminalHistory: true });
+		// Retarget the sticky Todo HUD too. It is driven by live `setTodos` events
+		// on the attached session, so a focus round-trip would otherwise leave it
+		// frozen at the pre-focus snapshot: while a subagent is focused the main
+		// session's `todo` completions never reach the HUD, and returning to the
+		// main session rebuilds the transcript from committed messages (current)
+		// but never refreshes the HUD. Reload it from the now-attached session's
+		// authoritative todo state, mirroring the transcript/status-line retarget
+		// above (issue #9571).
+		await this.ctx.reloadTodos();
 		// Sync the run-state title to the attached target: a streaming target has no
 		// agent_start incoming, so arm the loader/working title manually; an idle
 		// target would otherwise inherit the previous session's stuck spinner, so

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2310,7 +2310,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			}),
 		}));
 		if (!mutated) return;
-		this.session.setTodoPhases(next);
+		this.viewSession.setTodoPhases(next);
 		this.setTodos(next);
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -620,6 +620,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	#nextAppearanceRequestToken = 1;
 	#appearanceRefreshRequest: { token: TerminalAppearanceRequestToken; deadline: number } | undefined;
 	todoPhases: TodoPhase[] = [];
+	/**
+	 * Session that owns the plan currently in {@link todoPhases}. Subagent
+	 * reconciliation persists back to this session — never blindly to
+	 * `viewSession`. During a focus attach `viewSession` flips to the destination
+	 * before `reloadTodos` refreshes the snapshot, so an observer flush in that
+	 * window would otherwise write the previous session's plan into the
+	 * destination's canonical todos (#9575 review).
+	 */
+	#todoPhasesOwner?: AgentSession;
 	hideThinkingBlock = false;
 	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
 	/** Whether the visible session has produced thinking content the user can reveal. */
@@ -2310,8 +2319,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			}),
 		}));
 		if (!mutated) return;
-		this.viewSession.setTodoPhases(next);
-		this.setTodos(next);
+		// Persist into the session that owns the snapshot we derived `next` from,
+		// not `viewSession`: the two diverge mid focus-attach, and writing to the
+		// destination there would clobber its canonical plan. Leaving the owner
+		// bound (rather than routing through `setTodos`, which rebinds it to
+		// `viewSession`) keeps a follow-up reconcile in the same window correct.
+		const owner = this.#todoPhasesOwner ?? this.session;
+		owner.setTodoPhases(next);
+		this.todoPhases = next;
+		this.#syncTodoAutoClearTimer();
+		this.#renderTodoList();
+		this.ui.requestRender();
 	}
 
 	#cancelTodoAutoClearTimer(): void {
@@ -2633,6 +2651,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async #loadTodoList(source: AgentSession = this.session): Promise<void> {
 		this.todoPhases = source.getTodoPhases();
+		this.#todoPhasesOwner = source;
 		this.#syncTodoAutoClearTimer();
 		this.#renderTodoList();
 	}
@@ -5619,6 +5638,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				},
 			];
 		}
+		this.#todoPhasesOwner = this.viewSession;
 		this.#syncTodoAutoClearTimer();
 		this.#renderTodoList();
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2631,8 +2631,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.subagentContainer.addChild(new Text(lines.join("\n"), 1, 0));
 	}
 
-	async #loadTodoList(): Promise<void> {
-		this.todoPhases = this.session.getTodoPhases();
+	async #loadTodoList(source: AgentSession = this.session): Promise<void> {
+		this.todoPhases = source.getTodoPhases();
 		this.#syncTodoAutoClearTimer();
 		this.#renderTodoList();
 	}
@@ -5624,8 +5624,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.requestRender();
 	}
 
-	async reloadTodos(): Promise<void> {
-		await this.#loadTodoList();
+	async reloadTodos(source: AgentSession = this.session): Promise<void> {
+		await this.#loadTodoList(source);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -362,7 +362,7 @@ export interface InteractiveModeContext {
 	updateEditorBorderColor(): void;
 	rebuildChatFromMessages(options?: { reuseSettledComponents?: boolean }): void;
 	setTodos(todos: TodoItem[] | TodoPhase[]): void;
-	reloadTodos(): Promise<void>;
+	reloadTodos(source?: AgentSession): Promise<void>;
 	toggleTodoExpansion(): void;
 
 	// Command handling

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -301,6 +301,61 @@ describe("InteractiveMode todo HUD persistence", () => {
 		}
 	});
 
+	it("reconciles into the snapshot's owning session even when viewSession has moved on", async () => {
+		// Reproduces the focus-attach window deterministically: the HUD snapshot is
+		// reloaded from the worker (making it the owner) while viewSession is still
+		// the main session. A subagent completing here must land in the worker, not
+		// be written over the main session's canonical plan (#9575 review).
+		await replaceMode();
+		setTodoClearDelay(-1);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		const mainPhases: TodoPhase[] = [
+			{ name: "Main plan", tasks: [{ content: "orchestrate the main work", status: "in_progress" }] },
+		];
+		session.setTodoPhases(mainPhases);
+		mode.setTodos(session.getTodoPhases());
+		await mode.init();
+
+		const workerDir = TempDir.createSync("@pi-owner-reconcile-");
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		const workerSession = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.create(workerDir.path(), workerDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		workerSession.setTodoPhases([
+			{ name: "Worker plan", tasks: [{ content: "run the delegated fix", status: "in_progress" }] },
+		]);
+		try {
+			// Owner := worker, viewSession still := main.
+			await mode.reloadTodos(workerSession);
+			expect(renderTodos(mode)).toContain("run the delegated fix");
+
+			vi.useFakeTimers();
+			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+				id: "DelegatedFixer",
+				index: 0,
+				agent: "task",
+				description: "run the delegated fix",
+				status: "completed",
+				detached: true,
+			});
+			vi.advanceTimersByTime(100);
+
+			expect(workerSession.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
+			expect(session.getTodoPhases()).toEqual(mainPhases);
+			expect(renderTodos(mode)).toContain("1/1");
+		} finally {
+			vi.useRealTimers();
+			await workerSession.dispose();
+			workerDir.removeSync();
+		}
+	});
+
 	it("completes a blocked todo when the detached subagent it waits on finishes", async () => {
 		await replaceMode();
 		setTodoClearDelay(-1);

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -148,6 +148,45 @@ describe("InteractiveMode todo HUD persistence", () => {
 		expect(renderTodos(mode)).toContain("done task");
 	});
 
+	it("reloads the visible HUD from the explicitly attached session", async () => {
+		setTodoClearDelay(-1);
+		const focusedDir = TempDir.createSync("@pi-focused-todo-");
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		const focusedSession = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.create(focusedDir.path(), focusedDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		try {
+			session.setTodoPhases([{ name: "Main plan", tasks: [{ content: "stale main task", status: "in_progress" }] }]);
+			mode.setTodos(session.getTodoPhases());
+			focusedSession.setTodoPhases([
+				{
+					name: "Worker plan",
+					tasks: [
+						{ content: "finished worker task", status: "completed" },
+						{ content: "current worker task", status: "in_progress" },
+					],
+				},
+			]);
+
+			await mode.reloadTodos(focusedSession);
+
+			const rendered = renderTodos(mode);
+			expect(rendered).toContain("Worker plan");
+			expect(rendered).toContain("1/2");
+			expect(rendered).toContain("current worker task");
+			expect(rendered).not.toContain("stale main task");
+		} finally {
+			await focusedSession.dispose();
+			focusedDir.removeSync();
+		}
+	});
+
 	it("clears closed todos after the configured delay", () => {
 		setTodoClearDelay(1);
 		vi.useFakeTimers();

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -5,6 +5,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -226,6 +227,78 @@ describe("InteractiveMode todo HUD persistence", () => {
 		vi.advanceTimersByTime(100);
 
 		expect(session.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
+	});
+
+	it("reconciles focused worker todos without overwriting the main session", async () => {
+		await replaceMode();
+		setTodoClearDelay(-1);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		const mainPhases: TodoPhase[] = [
+			{ name: "Main plan", tasks: [{ content: "orchestrate the main work", status: "in_progress" }] },
+		];
+		session.setTodoPhases(mainPhases);
+		mode.setTodos(session.getTodoPhases());
+		await mode.init();
+
+		const focusedDir = TempDir.createSync("@pi-focused-reconcile-");
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		const focusedSession = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.create(focusedDir.path(), focusedDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		focusedSession.setTodoPhases([
+			{
+				name: "Worker plan",
+				tasks: [
+					{ content: "apply nested review fixes", status: "pending" },
+					{ content: "verify worker changes", status: "in_progress" },
+				],
+			},
+		]);
+		const registry = AgentRegistry.global();
+		const agentId = "FocusedTodoParent";
+		const ref = registry.register({
+			id: agentId,
+			displayName: agentId,
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: focusedSession,
+			status: "running",
+		});
+		try {
+			await mode.focusAgentSession(agentId);
+			expect(renderTodos(mode)).toContain("apply nested review fixes");
+
+			vi.useFakeTimers();
+			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+				id: `${agentId}/NestedFixer`,
+				index: 0,
+				agent: "task",
+				description: "apply nested review fixes",
+				status: "completed",
+				detached: true,
+			});
+			vi.advanceTimersByTime(100);
+
+			expect(focusedSession.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
+			expect(session.getTodoPhases()).toEqual(mainPhases);
+			expect(renderTodos(mode)).toContain("1/2");
+
+			await mode.unfocusSession();
+			expect(renderTodos(mode)).toContain("orchestrate the main work");
+			expect(renderTodos(mode)).not.toContain("apply nested review fixes");
+		} finally {
+			vi.useRealTimers();
+			if (mode.focusedAgentId) await mode.unfocusSession();
+			registry.unregister(agentId, ref);
+			await focusedSession.dispose();
+			focusedDir.removeSync();
+		}
 	});
 
 	it("completes a blocked todo when the detached subagent it waits on finishes", async () => {

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -45,11 +45,11 @@ interface Harness {
 	main: SessionStub;
 	handledEvents: unknown[];
 	setSessionCalls: Array<[AgentSession, string | undefined]>;
+	reloadTodoSessions: AgentSession[];
 	counts: {
 		clearTransientSessionUi: () => number;
 		resetTranscriptAnchors: () => number;
 		renderInitialMessages: () => number;
-		reloadTodos: () => number;
 		mainUnsubscribe: () => number;
 	};
 }
@@ -58,10 +58,10 @@ function makeHarness(): Harness {
 	const main = makeSessionStub();
 	const handledEvents: unknown[] = [];
 	const setSessionCalls: Array<[AgentSession, string | undefined]> = [];
+	const reloadTodoSessions: AgentSession[] = [];
 	let clearTransientSessionUi = 0;
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
-	let reloadTodos = 0;
 	let mainUnsubscribe = 0;
 
 	const ctx = {
@@ -89,8 +89,8 @@ function makeHarness(): Harness {
 		renderInitialMessages: () => {
 			renderInitialMessages++;
 		},
-		reloadTodos: async () => {
-			reloadTodos++;
+		reloadTodos: async (source?: AgentSession) => {
+			reloadTodoSessions.push(source ?? main.session);
 		},
 		updateEditorBorderColor() {},
 		ui: { requestRender() {} },
@@ -109,11 +109,11 @@ function makeHarness(): Harness {
 		main,
 		handledEvents,
 		setSessionCalls,
+		reloadTodoSessions,
 		counts: {
 			clearTransientSessionUi: () => clearTransientSessionUi,
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
 			renderInitialMessages: () => renderInitialMessages,
-			reloadTodos: () => reloadTodos,
 			mainUnsubscribe: () => mainUnsubscribe,
 		},
 	};
@@ -142,7 +142,7 @@ describe("SessionFocusController", () => {
 		expect(h.counts.clearTransientSessionUi()).toBe(1);
 		expect(h.counts.resetTranscriptAnchors()).toBe(1);
 		expect(h.counts.renderInitialMessages()).toBe(1);
-		expect(h.counts.reloadTodos()).toBe(1);
+		expect(h.reloadTodoSessions).toEqual([worker.session]);
 		expect(h.setSessionCalls).toEqual([[worker.session, "Worker"]]);
 
 		const event = { type: "message_start", message: { role: "user" } };
@@ -161,13 +161,12 @@ describe("SessionFocusController", () => {
 		registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
 
 		await h.controller.focusAgent("Worker");
-		expect(h.counts.reloadTodos()).toBe(1);
+		expect(h.reloadTodoSessions).toEqual([worker.session]);
 
 		await h.controller.unfocus();
 		expect(h.controller.focusedAgentId).toBeUndefined();
 		expect(h.setSessionCalls.at(-1)).toEqual([h.main.session, undefined]);
-		// The return-to-main attach reloaded the HUD from the main session.
-		expect(h.counts.reloadTodos()).toBe(2);
+		expect(h.reloadTodoSessions).toEqual([worker.session, h.main.session]);
 	});
 
 	it("mid-turn attach synthesizes agent_start, and an orphaned assistant message_update gets a synthesized message_start", async () => {

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -49,6 +49,7 @@ interface Harness {
 		clearTransientSessionUi: () => number;
 		resetTranscriptAnchors: () => number;
 		renderInitialMessages: () => number;
+		reloadTodos: () => number;
 		mainUnsubscribe: () => number;
 	};
 }
@@ -60,6 +61,7 @@ function makeHarness(): Harness {
 	let clearTransientSessionUi = 0;
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
+	let reloadTodos = 0;
 	let mainUnsubscribe = 0;
 
 	const ctx = {
@@ -87,6 +89,9 @@ function makeHarness(): Harness {
 		renderInitialMessages: () => {
 			renderInitialMessages++;
 		},
+		reloadTodos: async () => {
+			reloadTodos++;
+		},
 		updateEditorBorderColor() {},
 		ui: { requestRender() {} },
 		showStatus() {},
@@ -108,6 +113,7 @@ function makeHarness(): Harness {
 			clearTransientSessionUi: () => clearTransientSessionUi,
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
 			renderInitialMessages: () => renderInitialMessages,
+			reloadTodos: () => reloadTodos,
 			mainUnsubscribe: () => mainUnsubscribe,
 		},
 	};
@@ -136,11 +142,32 @@ describe("SessionFocusController", () => {
 		expect(h.counts.clearTransientSessionUi()).toBe(1);
 		expect(h.counts.resetTranscriptAnchors()).toBe(1);
 		expect(h.counts.renderInitialMessages()).toBe(1);
+		expect(h.counts.reloadTodos()).toBe(1);
 		expect(h.setSessionCalls).toEqual([[worker.session, "Worker"]]);
 
 		const event = { type: "message_start", message: { role: "user" } };
 		await worker.emit(event);
 		expect(h.handledEvents).toEqual([event]);
+	});
+
+	it("re-attaching the main session refreshes the todo HUD so it can't freeze at the pre-focus snapshot (#9571)", async () => {
+		// While a subagent is focused the main session's `todo` completions never
+		// reach the HUD (the event subscription points at the subagent). Returning
+		// to the main session rebuilds the transcript from committed messages but
+		// must also reload the HUD, or it stays stuck on the pre-focus snapshot
+		// (e.g. a `todo init` 0/N) while the transcript shows current progress.
+		const h = makeHarness();
+		const worker = makeSessionStub();
+		registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
+
+		await h.controller.focusAgent("Worker");
+		expect(h.counts.reloadTodos()).toBe(1);
+
+		await h.controller.unfocus();
+		expect(h.controller.focusedAgentId).toBeUndefined();
+		expect(h.setSessionCalls.at(-1)).toEqual([h.main.session, undefined]);
+		// The return-to-main attach reloaded the HUD from the main session.
+		expect(h.counts.reloadTodos()).toBe(2);
 	});
 
 	it("mid-turn attach synthesizes agent_start, and an orphaned assistant message_update gets a synthesized message_start", async () => {


### PR DESCRIPTION
## Repro
On 18.0.4, the sticky Todo HUD can freeze at an earlier snapshot (e.g. `todo init` `I. … · 0/N`, all checkboxes unchecked) after `todo done` calls have already succeeded, while the transcript `todo` card and `session.getTodoPhases()` are current. The reporter's decisive detail: a `Returned to main session` (subagent view → main) happened between the last successful `done` and the frozen HUD. Reproduced with a `SessionFocusController` focus→unfocus round-trip: `bun test packages/coding-agent/test/session-focus-controller.test.ts` (fails when the HUD reload is absent, matching 18.0.4).

## Cause
`SessionFocusController.#attach()` (`packages/coding-agent/src/modes/controllers/session-focus-controller.ts`) retargets the transcript, the event subscription (`ctx.unsubscribe` → `target.subscribe`), and the status line onto the attached session, but never refreshes the sticky Todo HUD. The HUD's `this.todoPhases` is driven only by live `setTodos` events (`event-controller.ts:1656-1660`) plus `reloadTodos()`/init. While a subagent is focused the subscription points at the subagent, so the main session's `todo done` completions never reach `setTodos`; on `unfocus` → `#attach(main)`, `renderInitialMessages` rebuilds the transcript from committed messages (current) without touching the HUD, leaving it frozen at the pre-focus snapshot. A later main-session `done` re-paints it once the subscription is back on main (matches the reported recovery).

## Fix
- Add `await this.ctx.reloadTodos()` to `SessionFocusController.#attach()`, right after the transcript rebuild, so every focus/unfocus retarget also reloads the todo HUD from the now-attached session's authoritative state — mirroring the existing transcript/status-line retarget. This covers `focusAgent`, `focusParent`, `unfocus`, and the auto-unfocus on a focused agent being parked/removed.
- Extend the `SessionFocusController` test harness with a `reloadTodos` counter; assert the HUD is retargeted on focus, and add a regression test for the return-to-main path (#9571).
- Changelog entry under `[Unreleased] → Fixed`.

## Verification
`bun test packages/coding-agent/test/session-focus-controller.test.ts packages/coding-agent/test/interactive-mode-todo-clear.test.ts packages/coding-agent/test/event-controller-cursor-todo.test.ts` → `28 pass, 0 fail`. Confirmed the new/updated tests fail without the fix (`reloadTodos` count 0 vs expected 1/2) and pass with it. Fixes #9571