### PR TITLE
fix(tui): keep final replies visible under viewport pressure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Resolved cursor drift and text duplication caused by overlapping or out-of-bounds spelling ranges
 - Squeezed transcript tool rows no longer render as a bare unstyled `╭─ Hub` frame: a squeezed block keeps its real render whenever it fits the allocated rows, and blocks that genuinely overflow fold to a themed frame that names the tool's activity (e.g. `Hub · send → Main`).
+- Completed assistant replies remain represented in the live transcript when an older active block prevents scrollback retirement under viewport pressure ([#9508](https://github.com/can1357/oh-my-pi/issues/9508)).
 - Python/Ruby/Julia eval cells that hit their wall-clock timeout during a `parallel()`/`agent()`/`tool.*` fan-out no longer get their kernel force-killed (losing all session state): the timeout now aborts in-flight bridge calls so the runner unwinds as a clean KeyboardInterrupt and the kernel survives.
 - Multi-select ask options whose labels end in `(Recommended)` now show their checked state and avoid duplicate recommendation suffixes ([#9452](https://github.com/can1357/oh-my-pi/issues/9452)).
 

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -410,6 +410,13 @@ export class AssistantMessageComponent extends Container {
 	isTranscriptBlockFinalized(): boolean {
 		return this.#transcriptBlockFinalized;
 	}
+	/** Keep completed assistant prose represented when active-block overflow forces emergency rendering. */
+	isTranscriptBlockEmergencyVisible(): boolean {
+		if (!this.#transcriptBlockFinalized || !this.#lastMessage) return false;
+		return this.#lastMessage.content.some(
+			content => content.type === "text" && canonicalizeMessage(content.text).length > 0,
+		);
+	}
 
 	getTranscriptBlockVersion(): number {
 		return this.#blockVersion;

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -15,6 +15,8 @@ export interface TranscriptPresentationTarget {
 
 interface FinalizableBlock {
 	isTranscriptBlockFinalized?(): boolean;
+	/** Whether emergency pressure should reserve one viewport row for this settled block. */
+	isTranscriptBlockEmergencyVisible?(): boolean;
 }
 
 /**
@@ -275,7 +277,17 @@ export class TranscriptContainer extends Container {
 		}
 		if (hiddenActive > 0) output.push(`${hiddenActive} more transcript blocks active`);
 		const visibleRows = rows - output.length;
-		const visible = visibleRows > 0 ? live.slice(-visibleRows) : [];
+		let visible = visibleRows > 0 ? live.slice(-visibleRows) : [];
+		if (visibleRows > 0) {
+			const visibleStart = live.length - visibleRows;
+			for (let index = visibleStart - 1; index >= 0; index--) {
+				const entry = live[index]!;
+				const block = entry.component as Component & FinalizableBlock;
+				if (entry.state !== "settled" || block.isTranscriptBlockEmergencyVisible?.() !== true) continue;
+				visible = [entry, ...visible.slice(1)];
+				break;
+			}
+		}
 		for (const entry of visible) {
 			this.#setAllocation(entry.component, 1, frame);
 			output.push(entry.component.render(width)[0] ?? "");

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { Component } from "@oh-my-pi/pi-tui";
 
 class Block implements Component {
@@ -30,9 +33,31 @@ class Block implements Component {
 	}
 }
 
+const finalAnswer: AssistantMessage = {
+	role: "assistant",
+	content: [{ type: "text", text: "## Implemented" }],
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	model: "gpt-5.6-sol",
+	stopReason: "stop",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	timestamp: 1,
+};
+
 const frame = { tick: 0, now: 0 };
 
 describe("TranscriptContainer", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
 	it("keeps settled blocks live while the viewport has room", () => {
 		const transcript = new TranscriptContainer();
 		transcript.addChild(new Block(["settled"], true));
@@ -116,6 +141,19 @@ describe("TranscriptContainer", () => {
 		// The welcome header can consume the first history offer, leaving the
 		// settled transcript prefix live for one frame while it drains next.
 		expect(transcript.renderViewport(80, 1, frame)).toEqual(["current tool"]);
+	});
+	it("keeps a completed assistant answer visible behind an active prefix", () => {
+		const transcript = new TranscriptContainer();
+		transcript.addChild(new Block(["stale active"], false));
+		transcript.addChild(new AssistantMessageComponent(finalAnswer));
+		transcript.addChild(new Block(["continued turn"], false));
+		transcript.addChild(new Block(["task running"], false));
+
+		expect(transcript.peekFinalizedBatch(80, 3)).toBeUndefined();
+		const rows = transcript.renderViewport(80, 3, frame);
+		expect(rows[0]).toBe("1 more transcript blocks active");
+		expect(Bun.stripANSI(rows[1] ?? "").trim()).toBe("Implemented");
+		expect(rows[2]).toBe("task running");
 	});
 
 	it("permits removing settled blocks until they are offered or committed", () => {


### PR DESCRIPTION
## Repro
A transcript with an older active block, a settled final assistant answer, and two newer active blocks cannot retire the answer because history retirement is prefix-only. Run `cd packages/coding-agent && bun test test/modes/components/transcript-container.test.ts`; before the fix, the regression case renders `1 more transcript blocks active`, `continued turn`, and `task running`, omitting the settled `## Implemented` answer.

## Cause
`TranscriptContainer.peekFinalizedBatch()` in `packages/coding-agent/src/modes/components/transcript-container.ts` correctly stops at the first active entry to preserve ordered terminal history, but `TranscriptContainer.#renderEmergency()` then selected only the newest live entries with `live.slice(-visibleRows)`. Under block-count pressure, that combination left a settled assistant answer neither committed to scrollback nor represented in the live viewport.

## Fix
- Mark finalized `AssistantMessageComponent` blocks containing non-empty prose as emergency-visible.
- Reserve one emergency viewport row for the latest hidden completed assistant answer while retaining the newest active block.
- Add an integrated regression test using a real assistant message between an active prefix and continued tool activity.
- Document the user-visible correction in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/modes/components/transcript-container.test.ts test/event-controller-mixed-assistant-render.test.ts test/modes/components/assistant-message-error.test.ts` — 28 passed, 0 failed.

`cd packages/coding-agent && bun check` — Biome checked 2,754 files with no fixes; `tsgo -p tsconfig.json --noEmit` passed.

Fixes #9508