### PR TITLE
fix(models-config): preserve thinking.requiresEffort from models.yml

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -514,6 +514,11 @@ Request shaping:
 
 Reasoning / thinking:
 
+Custom model entries may define `thinking: { mode, efforts, defaultLevel, requiresEffort }`.
+`requiresEffort` defaults to auto-detection; set it to `false` only when the
+configured backend has been verified to accept an explicit reasoning-off
+request. This keeps the `:off` selector from being clamped to the lowest effort.
+
 - `supportsReasoningEffort` — accept `reasoning_effort`. Default: auto (off for Grok, Z.ai/Zhipu, and Xiaomi MiMo).
 - `supportsReasoningParams` — whether request shaping may send reasoning params at all. Default: auto (off for GitHub Copilot chat-completions).
 - `reasoningEffortMap` — partial map from internal effort levels (`minimal|low|medium|high|xhigh|max`) to provider-specific strings (e.g. Fireworks GLM maps `minimal -> "none"`).

--- a/packages/ai/test/requires-effort.test.ts
+++ b/packages/ai/test/requires-effort.test.ts
@@ -9,6 +9,11 @@ interface CapturedBody {
 	model?: string;
 	reasoning?: { enabled?: boolean; effort?: string };
 	reasoning_effort?: string;
+	chat_template_kwargs?: {
+		enable_thinking?: boolean;
+		preserve_thinking?: boolean;
+		reasoning_effort?: string;
+	};
 }
 
 const context: Context = {
@@ -30,6 +35,32 @@ function openRouterModel(thinking: ThinkingConfig): Model<"openai-completions"> 
 		cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
 		contextWindow: 1_048_576,
 		maxTokens: 65_535,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+function localQwenModel(): Model<"openai-completions"> {
+	return buildModel({
+		id: "qwen3.8-27b",
+		name: "Local Qwen 3.8",
+		api: "openai-completions",
+		provider: "local-qwen",
+		baseUrl: "http://127.0.0.1:18085/v1",
+		reasoning: true,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+			requiresEffort: false,
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262_144,
+		maxTokens: 32_768,
+		compat: {
+			thinkingFormat: "qwen-chat-template",
+			qwenTemplateReasoningEffort: true,
+			supportsReasoningEffort: true,
+			reasoningContentField: "reasoning_content",
+		},
 	} satisfies ModelSpec<"openai-completions">);
 }
 
@@ -89,6 +120,18 @@ describe("thinking.requiresEffort clamping", () => {
 		expect(off.reasoning).toBeUndefined();
 		const disabled = await captureBody(plain, { disableReasoning: true });
 		expect(disabled.reasoning).toEqual({ enabled: false });
+	});
+
+	it("allows strict off for local Qwen3.8 chat templates", async () => {
+		const model = localQwenModel();
+		expect(model.thinking?.requiresEffort).toBe(false);
+
+		const body = await captureBody(model, { disableReasoning: true });
+		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.chat_template_kwargs).toEqual({
+			preserve_thinking: true,
+			enable_thinking: false,
+		});
 	});
 
 	it("routes flag-free pairs off to the bare SKU and efforts to the thinking SKU", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,9 @@
 - Fixed Linux startup event loop delays caused by legacy extension cache fsync churn.
 - Fixed subagent advisors abandoning reviews on the final yield turn during session teardown.
 - Fixed `/todo` expand/collapse commands and corrected `/shake thinking` reporting.
+### Fixed
+
+- Custom model `thinking.requiresEffort: false` is now preserved from `models.yml`, allowing verified local Qwen chat templates to keep `:off` as strict `enable_thinking=false` instead of clamping it to the lowest effort.
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -105,6 +105,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 		"defaultLevel?": EffortSchema,
 		"effortMap?": ReasoningEffortMapSchema,
 		"supportsDisplay?": "boolean",
+		"requiresEffort?": "boolean",
 		// Legacy range vocabulary (pre-efforts configs).
 		"minLevel?": EffortSchema,
 		"maxLevel?": EffortSchema,
@@ -130,6 +131,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 				...(value.defaultLevel !== undefined && { defaultLevel: value.defaultLevel }),
 				...(value.effortMap !== undefined && { effortMap: value.effortMap }),
 				...(value.supportsDisplay !== undefined && { supportsDisplay: value.supportsDisplay }),
+				...(value.requiresEffort !== undefined && { requiresEffort: value.requiresEffort }),
 			};
 		});
 

--- a/packages/coding-agent/test/fixtures/models-config-validator-construction-probe.ts
+++ b/packages/coding-agent/test/fixtures/models-config-validator-construction-probe.ts
@@ -73,6 +73,7 @@ async function writeCustomConfig(): Promise<string> {
 									minLevel: "low",
 									maxLevel: "high",
 									defaultLevel: "medium",
+									requiresEffort: false,
 								},
 							},
 						],

--- a/packages/coding-agent/test/models-config-lazy-validator.test.ts
+++ b/packages/coding-agent/test/models-config-lazy-validator.test.ts
@@ -56,6 +56,7 @@ test("models config validation resources are retained only for a custom config",
 				mode: "effort",
 				efforts: ["low", "medium", "high"],
 				defaultLevel: "medium",
+				requiresEffort: false,
 			},
 		});
 		expect(custom.schemaIdentityStable).toBe(true);


### PR DESCRIPTION
## Problem

Local Qwen 3.8 served by llama.cpp accepts `chat_template_kwargs.enable_thinking=false` and correctly suppresses reasoning. But the models-config schema silently dropped `thinking.requiresEffort` from user-authored `models.yml` entries, so the catalog auto-detection (`isQwenTemplateReasoningEffortCompat` → `requiresEffort: true`) always won. `normalizeMandatoryReasoningOptions` then clamped every `:off` selector to the lowest supported effort: the UI showed off while the wire carried `enable_thinking: true, reasoning_effort: low`.

The auto-detection is correct for the official Alibaba/vLLM 3.8 template (it raises on `enable_thinking: false`) — the gap is that a verified local backend could not opt out.

## Fix

`ModelThinkingSchema` now accepts and preserves `requiresEffort`, mirroring how the other explicit thinking fields own the capability surface per the `resolveModelThinking` contract ("Explicit spec thinking … owns the capability surface"). A models.yml entry with:

```yaml
thinking:
  mode: effort
  efforts: [low, medium, xhigh]
  requiresEffort: false
```

keeps `:off` a strict `enable_thinking=false`.

## Verification

- New regression test in `requires-effort.test.ts`: local Qwen chat-template model with `requiresEffort: false` sends `chat_template_kwargs: {preserve_thinking: true, enable_thinking: false}` and no reasoning effort (RED on the old schema, GREEN after).
- `models-config-lazy-validator` round-trips the field through the real config pipeline.
- Live wire capture on Qwen3.8-27B @ llama.cpp: `medium → off → medium` via Shift+Tab in fresh and resumed sessions transmits `medium → enable_thinking=false → medium`; off turns produce no reasoning block. `--thinking off` and the `:off` selector both give the strict off (N=3 each).
- `tsgo --noEmit`: 0 errors; biome: clean; 47 tests pass across the four touched suites.