### PR TITLE
feat(acp): expose message timestamps

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- ACP clients can now receive authoritative message timestamps during live streaming and session replay ([#9581](https://github.com/can1357/oh-my-pi/pull/9581) by [@AlexDochioiu](https://github.com/AlexDochioiu)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -88,6 +88,11 @@ import {
 	mapAgentSessionEventToAcpSessionUpdates,
 	normalizeReplayToolArguments,
 } from "./acp-event-mapper";
+import {
+	ACP_MESSAGE_TIMESTAMP_FORMAT,
+	ACP_MESSAGE_TIMESTAMP_META_KEY,
+	toAcpMessageTimestampMeta,
+} from "./acp-message-metadata";
 import { ACP_TERMINAL_AUTH_FLAG } from "./terminal-auth";
 
 const ACP_DEFAULT_MODE_ID = "default";
@@ -187,6 +192,7 @@ type ManagedSessionRecord = {
 type ReplayableMessage = {
 	role: string;
 	content?: unknown;
+	timestamp?: number;
 	errorMessage?: string;
 	toolCallId?: string;
 	toolName?: string;
@@ -656,6 +662,9 @@ export class AcpAgent implements Agent {
 			authMethods,
 			agentCapabilities: {
 				loadSession: true,
+				_meta: {
+					[ACP_MESSAGE_TIMESTAMP_META_KEY]: { format: ACP_MESSAGE_TIMESTAMP_FORMAT },
+				},
 				mcpCapabilities: {
 					http: true,
 					sse: true,
@@ -1500,6 +1509,7 @@ export class AcpAgent implements Agent {
 				sessionUpdate: "agent_message_chunk",
 				content: { type: "text", text },
 				messageId: record.liveMessageId,
+				...toAcpMessageTimestampMeta({ timestamp: lastAssistant.timestamp }),
 			},
 		});
 	}
@@ -1538,6 +1548,7 @@ export class AcpAgent implements Agent {
 				sessionUpdate: "agent_message_chunk",
 				content: { type: "text", text: errorMessage },
 				messageId: record.liveMessageId ?? crypto.randomUUID(),
+				...toAcpMessageTimestampMeta({ timestamp: lastAssistant.timestamp }),
 			},
 		});
 	}
@@ -2260,12 +2271,13 @@ export class AcpAgent implements Agent {
 			message.role === "custom" ||
 			message.role === "hookMessage"
 		) {
-			return this.#wrapReplayContent(
+			return this.#wrapReplayContent({
 				sessionId,
-				this.#extractReplayContent(message.content, undefined),
-				"user_message_chunk",
-				crypto.randomUUID(),
-			);
+				content: this.#extractReplayContent(message.content, undefined),
+				kind: "user_message_chunk",
+				messageId: crypto.randomUUID(),
+				timestamp: message.timestamp,
+			});
 		}
 		if (
 			message.role === "toolResult" &&
@@ -2291,12 +2303,13 @@ export class AcpAgent implements Agent {
 			message.role === "pythonExecution" ||
 			message.role === "compactionSummary"
 		) {
-			return this.#wrapReplayContent(
+			return this.#wrapReplayContent({
 				sessionId,
-				this.#extractReplayContent(message.content, undefined),
-				"user_message_chunk",
-				crypto.randomUUID(),
-			);
+				content: this.#extractReplayContent(message.content, undefined),
+				kind: "user_message_chunk",
+				messageId: crypto.randomUUID(),
+				timestamp: message.timestamp,
+			});
 		}
 		return [];
 	}
@@ -2310,6 +2323,7 @@ export class AcpAgent implements Agent {
 	): SessionNotification[] {
 		const notifications: SessionNotification[] = [];
 		const messageId = crypto.randomUUID();
+		const timestampMeta = toAcpMessageTimestampMeta({ timestamp: message.timestamp });
 		if (Array.isArray(message.content)) {
 			for (const item of message.content) {
 				if (typeof item !== "object" || item === null || !("type" in item)) {
@@ -2322,6 +2336,7 @@ export class AcpAgent implements Agent {
 							sessionUpdate: "agent_message_chunk",
 							content: { type: "text", text: item.text },
 							messageId,
+							...timestampMeta,
 						},
 					});
 					continue;
@@ -2339,6 +2354,7 @@ export class AcpAgent implements Agent {
 							sessionUpdate: "agent_message_chunk",
 							content: { type: "image", data: item.data, mimeType: item.mimeType },
 							messageId,
+							...timestampMeta,
 						},
 					});
 					continue;
@@ -2352,6 +2368,7 @@ export class AcpAgent implements Agent {
 							sessionUpdate: "agent_thought_chunk",
 							content: { type: "text", text: thinking },
 							messageId,
+							...timestampMeta,
 						},
 					});
 					continue;
@@ -2387,6 +2404,7 @@ export class AcpAgent implements Agent {
 					sessionUpdate: "agent_message_chunk",
 					content: { type: "text", text: message.errorMessage },
 					messageId,
+					...timestampMeta,
 				},
 			});
 		}
@@ -2446,18 +2464,27 @@ export class AcpAgent implements Agent {
 		return typeof value === "string" && value.length > 0 ? { path: value } : {};
 	}
 
-	#wrapReplayContent(
-		sessionId: string,
-		content: PromptRequest["prompt"],
-		kind: "agent_message_chunk" | "user_message_chunk",
-		messageId: string,
-	): SessionNotification[] {
+	#wrapReplayContent({
+		sessionId,
+		content,
+		kind,
+		messageId,
+		timestamp,
+	}: {
+		sessionId: string;
+		content: PromptRequest["prompt"];
+		kind: "agent_message_chunk" | "user_message_chunk";
+		messageId: string;
+		timestamp: number | undefined;
+	}): SessionNotification[] {
+		const timestampMeta = toAcpMessageTimestampMeta({ timestamp });
 		return content.map(block => ({
 			sessionId,
 			update: {
 				sessionUpdate: kind,
 				content: block,
 				messageId,
+				...timestampMeta,
 			},
 		}));
 	}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -180,6 +180,7 @@ type ManagedSessionRecord = {
 	liveMessageId: string | undefined;
 	liveMessageProgress: { textEmitted: boolean; thoughtEmitted: boolean } | undefined;
 	toolArgsById: Map<string, unknown>;
+	toolMessageTimestamps: Map<string, number>;
 	extensionsConfigured: boolean;
 	// Installed inside `#scheduleBootstrapUpdates` (post-race-guard); released
 	// in `#disposeSessionRecord`. Lives independent of any prompt turn.
@@ -206,6 +207,12 @@ type ReplayableToolItem = {
 	name?: unknown;
 	arguments?: unknown;
 	input?: unknown;
+};
+
+type ReplayToolState = {
+	callIds: Set<string>;
+	argsByCallId: Map<string, unknown>;
+	timestampsByCallId: Map<string, number>;
 };
 
 type MCPConfigMap = {
@@ -1345,6 +1352,7 @@ export class AcpAgent implements Agent {
 			liveMessageId: undefined,
 			liveMessageProgress: undefined,
 			toolArgsById: new Map(),
+			toolMessageTimestamps: new Map(),
 			extensionsConfigured: false,
 			closedError: undefined,
 			promptEventHandlers: new Set(),
@@ -1433,6 +1441,7 @@ export class AcpAgent implements Agent {
 			getMessageId: message => this.#getLiveMessageId(record, message),
 			getMessageProgress: message => this.#getLiveMessageProgress(record, message),
 			getToolArgs: toolCallId => record.toolArgsById.get(toolCallId),
+			getToolMessageTimestamp: toolCallId => record.toolMessageTimestamps.get(toolCallId),
 			cwd: record.session.sessionManager.getCwd(),
 			resolveImageData: resolveImageDataForAcp,
 		})) {
@@ -1451,6 +1460,7 @@ export class AcpAgent implements Agent {
 		}
 		if (event.type === "tool_execution_end") {
 			record.toolArgsById.delete(event.toolCallId);
+			record.toolMessageTimestamps.delete(event.toolCallId);
 		}
 		this.#clearLiveAssistantMessageAfterEvent(record, event);
 
@@ -1461,6 +1471,7 @@ export class AcpAgent implements Agent {
 			await this.#waitForAcpPromptIdle(record);
 			record.liveMessageId = undefined;
 			record.liveMessageProgress = undefined;
+			record.toolMessageTimestamps.clear();
 			this.#finishPrompt(record, {
 				stopReason: this.#resolveStopReason(event, promptTurn.cancelRequested),
 				usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
@@ -1569,10 +1580,17 @@ export class AcpAgent implements Agent {
 
 	#prepareLiveAssistantMessage(record: ManagedSessionRecord, event: AgentSessionEvent): void {
 		if (
-			(event.type === "message_start" || event.type === "message_update" || event.type === "message_end") &&
-			event.message.role === "assistant" &&
-			(event.type === "message_start" || !record.liveMessageId || !record.liveMessageProgress)
+			(event.type !== "message_start" && event.type !== "message_update" && event.type !== "message_end") ||
+			event.message.role !== "assistant"
 		) {
+			return;
+		}
+		for (const content of event.message.content) {
+			if (content.type === "toolCall") {
+				record.toolMessageTimestamps.set(content.id, event.message.timestamp);
+			}
+		}
+		if (event.type === "message_start" || !record.liveMessageId || !record.liveMessageProgress) {
 			record.liveMessageId = crypto.randomUUID();
 			record.liveMessageProgress = { textEmitted: false, thoughtEmitted: false };
 		}
@@ -2240,15 +2258,17 @@ export class AcpAgent implements Agent {
 
 	async #replaySessionHistory(record: ManagedSessionRecord): Promise<void> {
 		const cwd = record.session.sessionManager.getCwd();
-		const replayedToolCallIds = new Set<string>();
-		const replayedToolCallArgs = new Map<string, unknown>();
+		const replayTools: ReplayToolState = {
+			callIds: new Set(),
+			argsByCallId: new Map(),
+			timestampsByCallId: new Map(),
+		};
 		for (const message of record.session.sessionManager.buildSessionContext().messages as ReplayableMessage[]) {
 			for (const notification of this.#messageToReplayNotifications(
 				record.session.sessionId,
 				message,
 				cwd,
-				replayedToolCallIds,
-				replayedToolCallArgs,
+				replayTools,
 			)) {
 				await this.#connection.sessionUpdate(notification);
 			}
@@ -2259,11 +2279,10 @@ export class AcpAgent implements Agent {
 		sessionId: string,
 		message: ReplayableMessage,
 		cwd: string,
-		replayedToolCallIds: Set<string>,
-		replayedToolCallArgs: Map<string, unknown>,
+		replayTools: ReplayToolState,
 	): SessionNotification[] {
 		if (message.role === "assistant") {
-			return this.#replayAssistantMessage(sessionId, message, cwd, replayedToolCallIds, replayedToolCallArgs);
+			return this.#replayAssistantMessage(sessionId, message, cwd, replayTools);
 		}
 		if (
 			message.role === "user" ||
@@ -2293,8 +2312,9 @@ export class AcpAgent implements Agent {
 					toolName: message.toolName,
 				},
 				{
-					includeStart: !replayedToolCallIds.has(message.toolCallId),
-					toolArgs: replayedToolCallArgs.get(message.toolCallId),
+					includeStart: !replayTools.callIds.has(message.toolCallId),
+					toolArgs: replayTools.argsByCallId.get(message.toolCallId),
+					messageTimestamp: replayTools.timestampsByCallId.get(message.toolCallId) ?? message.timestamp,
 				},
 			);
 		}
@@ -2318,8 +2338,7 @@ export class AcpAgent implements Agent {
 		sessionId: string,
 		message: ReplayableMessage,
 		cwd: string,
-		replayedToolCallIds: Set<string>,
-		replayedToolCallArgs: Map<string, unknown>,
+		replayTools: ReplayToolState,
 	): SessionNotification[] {
 		const notifications: SessionNotification[] = [];
 		const messageId = crypto.randomUUID();
@@ -2380,6 +2399,9 @@ export class AcpAgent implements Agent {
 					typeof toolItem.name === "string"
 				) {
 					const args = this.#buildReplayAssistantToolArgs(toolItem);
+					if (message.timestamp !== undefined) {
+						replayTools.timestampsByCallId.set(toolItem.id, message.timestamp);
+					}
 					notifications.push(
 						...mapAgentSessionEventToAcpSessionUpdates(
 							{
@@ -2389,11 +2411,14 @@ export class AcpAgent implements Agent {
 								args,
 							},
 							sessionId,
-							{ cwd },
+							{
+								cwd,
+								getToolMessageTimestamp: toolCallId => replayTools.timestampsByCallId.get(toolCallId),
+							},
 						),
 					);
-					replayedToolCallIds.add(toolItem.id);
-					replayedToolCallArgs.set(toolItem.id, args);
+					replayTools.callIds.add(toolItem.id);
+					replayTools.argsByCallId.set(toolItem.id, args);
 				}
 			}
 		}
@@ -2425,9 +2450,11 @@ export class AcpAgent implements Agent {
 		sessionId: string,
 		cwd: string,
 		message: Required<Pick<ReplayableMessage, "toolCallId" | "toolName">> & ReplayableMessage,
-		options: { includeStart?: boolean; toolArgs?: unknown } = {},
+		options: { includeStart?: boolean; toolArgs?: unknown; messageTimestamp?: number } = {},
 	): SessionNotification[] {
 		const args = this.#buildReplayToolArgs(message.details);
+		const getToolMessageTimestamp = (toolCallId: string): number | undefined =>
+			toolCallId === message.toolCallId ? options.messageTimestamp : undefined;
 		const startEvent: AgentSessionEvent = {
 			type: "tool_execution_start",
 			toolCallId: message.toolCallId,
@@ -2448,12 +2475,16 @@ export class AcpAgent implements Agent {
 		const notifications = mapAgentSessionEventToAcpSessionUpdates(endEvent, sessionId, {
 			cwd,
 			getToolArgs: toolCallId => (toolCallId === message.toolCallId ? options.toolArgs : undefined),
+			getToolMessageTimestamp,
 			resolveImageData: (data, _mimeType) => resolveImageDataSync(this.#blobs, data),
 		});
 		if (options.includeStart === false) {
 			return notifications;
 		}
-		return [...mapAgentSessionEventToAcpSessionUpdates(startEvent, sessionId, { cwd }), ...notifications];
+		return [
+			...mapAgentSessionEventToAcpSessionUpdates(startEvent, sessionId, { cwd, getToolMessageTimestamp }),
+			...notifications,
+		];
 	}
 
 	#buildReplayToolArgs(details: unknown): { path?: string } {

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -22,6 +22,7 @@ interface AcpEventMapperOptions {
 	getMessageId?: (message: unknown) => string | undefined;
 	getMessageProgress?: (message: unknown) => MessageProgress | undefined;
 	getToolArgs?: (toolCallId: string) => unknown;
+	getToolMessageTimestamp?: (toolCallId: string) => number | undefined;
 	resolveImageData?: (data: string, mimeType: string | undefined) => string;
 	/**
 	 * Session cwd. Tool call locations sent to ACP clients must be absolute
@@ -221,13 +222,16 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return mapAssistantMessageEnd(event, sessionId, options);
 		case "tool_execution_start": {
 			if (isInternalHubMessageTool(event.toolName, event.args)) return [];
-			const update = buildToolCallStartUpdate({
-				toolCallId: event.toolCallId,
-				toolName: event.toolName,
-				args: event.args,
-				intent: event.intent,
-				cwd: options.cwd,
-			});
+			const update = {
+				...buildToolCallStartUpdate({
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					args: event.args,
+					intent: event.intent,
+					cwd: options.cwd,
+				}),
+				...toAcpMessageTimestampMeta({ timestamp: options.getToolMessageTimestamp?.(event.toolCallId) }),
+			};
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_update": {
@@ -241,6 +245,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 				toolCallId: event.toolCallId,
 				status: "in_progress",
 				rawOutput: event.partialResult,
+				...toAcpMessageTimestampMeta({ timestamp: options.getToolMessageTimestamp?.(event.toolCallId) }),
 			};
 			if (content.length > 0) {
 				update.content = content;
@@ -264,6 +269,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 				toolCallId: event.toolCallId,
 				status: event.isError ? "failed" : "completed",
 				rawOutput: event.result,
+				...toAcpMessageTimestampMeta({ timestamp: options.getToolMessageTimestamp?.(event.toolCallId) }),
 			};
 			if (content.length > 0) {
 				update.content = content;

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -11,6 +11,7 @@ import type { AgentSessionEvent } from "../../session/agent-session";
 import { resolveToCwd } from "../../tools/path-utils";
 import type { TodoStatus } from "../../tools/todo";
 import { canonicalizeMessage } from "../../utils/thinking-display";
+import { toAcpMessageTimestampMeta } from "./acp-message-metadata";
 
 interface MessageProgress {
 	textEmitted: boolean;
@@ -312,6 +313,7 @@ function mapAssistantMessageUpdate(
 					sessionUpdate: "agent_message_chunk",
 					content: event.assistantMessageEvent.content,
 					messageId: options.getMessageId?.(event.message),
+					...toAcpMessageTimestampMeta({ timestamp: event.message.timestamp }),
 				}),
 			];
 		case "text_delta":
@@ -363,6 +365,7 @@ function mapAssistantMessageUpdate(
 			sessionUpdate,
 			content: { type: "text", text },
 			messageId,
+			...toAcpMessageTimestampMeta({ timestamp: event.message.timestamp }),
 		}),
 	];
 }
@@ -390,6 +393,7 @@ function mapAssistantMessageEnd(
 			sessionUpdate: "agent_message_chunk",
 			content: { type: "text", text },
 			messageId,
+			...toAcpMessageTimestampMeta({ timestamp: event.message.timestamp }),
 		}),
 	];
 }

--- a/packages/coding-agent/src/modes/acp/acp-message-metadata.ts
+++ b/packages/coding-agent/src/modes/acp/acp-message-metadata.ts
@@ -2,6 +2,7 @@ import type { Meta } from "@oh-my-pi/pi-utils/acp";
 
 /** OMP extension carrying a message's authoritative Unix-epoch timestamp. */
 export const ACP_MESSAGE_TIMESTAMP_META_KEY = "omp.sh/messageTimestamp";
+/** Capability wire-format identifier for a numeric Unix-millisecond value. */
 export const ACP_MESSAGE_TIMESTAMP_FORMAT = "unix-ms";
 
 /**

--- a/packages/coding-agent/src/modes/acp/acp-message-metadata.ts
+++ b/packages/coding-agent/src/modes/acp/acp-message-metadata.ts
@@ -1,0 +1,14 @@
+import type { Meta } from "@oh-my-pi/pi-utils/acp";
+
+/** OMP extension carrying a message's authoritative Unix-epoch timestamp. */
+export const ACP_MESSAGE_TIMESTAMP_META_KEY = "omp.sh/messageTimestamp";
+export const ACP_MESSAGE_TIMESTAMP_FORMAT = "unix-ms";
+
+/**
+ * ACP v1 has no standard per-message timestamp. Keep OMP's source timestamp in
+ * namespaced metadata so clients can preserve it across live updates and replay.
+ */
+export function toAcpMessageTimestampMeta({ timestamp }: { timestamp: number | undefined }): Meta {
+	if (timestamp === undefined || !Number.isFinite(timestamp)) return {};
+	return { _meta: { [ACP_MESSAGE_TIMESTAMP_META_KEY]: timestamp } };
+}

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -453,6 +453,11 @@ function getChunkMessageId(notification: SessionNotification): string | undefine
 	return typeof update.messageId === "string" ? update.messageId : undefined;
 }
 
+function getChunkMessageTimestamp(notification: SessionNotification): number | undefined {
+	const timestamp = notification.update._meta?.["omp.sh/messageTimestamp"];
+	return typeof timestamp === "number" ? timestamp : undefined;
+}
+
 function expectAcpNotifications(updates: SessionNotification[]): void {
 	for (const update of updates) {
 		expectAcpStructure(zSessionNotification, update);
@@ -1080,12 +1085,21 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
-	it("replays messageIds and returns turn usage for prompts", async () => {
+	it("preserves message identity metadata across replay and live prompts", async () => {
 		const harness = await createHarness();
 		const stored = new FakeAgentSession(harness.cwdA);
+		const userTimestamp = 1_725_000_001_000;
+		const assistantTimestamp = 1_725_000_002_000;
 		harness.sessions.push(stored);
-		stored.sessionManager.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
-		stored.sessionManager.appendMessage(makeAssistantMessage("reply", "reasoning"));
+		stored.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			timestamp: userTimestamp,
+		});
+		stored.sessionManager.appendMessage({
+			...makeAssistantMessage("reply", "reasoning"),
+			timestamp: assistantTimestamp,
+		});
 		await stored.sessionManager.ensureOnDisk();
 		await stored.sessionManager.flush();
 
@@ -1107,6 +1121,7 @@ describe("ACP agent", () => {
 				update.update.sessionUpdate === "agent_message_chunk" ||
 				update.update.sessionUpdate === "agent_thought_chunk",
 		);
+		const replayUserChunks = replayChunks.filter(update => update.update.sessionUpdate === "user_message_chunk");
 
 		expect(
 			replayChunks.every(
@@ -1114,6 +1129,8 @@ describe("ACP agent", () => {
 			),
 		).toBe(true);
 		expect(new Set(replayAssistantChunks.map(update => getChunkMessageId(update))).size).toBe(1);
+		expect(replayUserChunks.map(getChunkMessageTimestamp)).toEqual([userTimestamp]);
+		expect(new Set(replayAssistantChunks.map(getChunkMessageTimestamp))).toEqual(new Set([assistantTimestamp]));
 
 		const live = await harness.agent.newSession({ cwd: harness.cwdB, mcpServers: [] });
 		const response = await harness.agent.prompt({
@@ -1135,7 +1152,10 @@ describe("ACP agent", () => {
 		});
 		expect(
 			liveChunks.some(
-				update => typeof getChunkMessageId(update) === "string" && getChunkMessageId(update)!.length > 0,
+				update =>
+					typeof getChunkMessageId(update) === "string" &&
+					getChunkMessageId(update)!.length > 0 &&
+					typeof getChunkMessageTimestamp(update) === "number",
 			),
 		).toBe(true);
 
@@ -1196,7 +1216,11 @@ describe("ACP agent", () => {
 		// the agent_end flush: thinking streams, then the turn ends. No
 		// text_delta and no message_end ever reach this subscriber — the final
 		// text exists only on the agent_end payload.
-		const assistantMessage = makeAssistantMessage("Final visible answer.", "Considering the greeting.");
+		const timestamp = 1_725_000_003_000;
+		const assistantMessage = {
+			...makeAssistantMessage("Final visible answer.", "Considering the greeting."),
+			timestamp,
+		};
 		session.prompt = async (text: string): Promise<boolean> => {
 			session.promptCalls.push(text);
 			session.isStreaming = true;
@@ -1237,6 +1261,7 @@ describe("ACP agent", () => {
 		);
 		// Flushed answer belongs to the same live message as the thought chunk.
 		expect(getChunkMessageId(messageChunks[0]!)).toBe(getChunkMessageId(thoughtChunks[0]!)!);
+		expect(getChunkMessageTimestamp(messageChunks[0]!)).toBe(timestamp);
 		expectAcpNotifications(harness.updates);
 
 		harness.abortController.abort();
@@ -1307,10 +1332,12 @@ describe("ACP agent", () => {
 
 		const errorText =
 			"GitHub Copilot rejected this model (HTTP 400 model_not_supported) after retries. Try again in a few seconds.";
+		const timestamp = 1_725_000_004_000;
 		const failedMessage = {
 			...makeAssistantMessage(""),
 			stopReason: "error" as const,
 			errorMessage: errorText,
+			timestamp,
 		};
 		session.prompt = async (text: string): Promise<boolean> => {
 			session.promptCalls.push(text);
@@ -1334,6 +1361,7 @@ describe("ACP agent", () => {
 		);
 		expect(messageChunks).toHaveLength(1);
 		expect(messageChunks[0]?.update).toEqual(expect.objectContaining({ content: { type: "text", text: errorText } }));
+		expect(getChunkMessageTimestamp(messageChunks[0]!)).toBe(timestamp);
 		expectAcpNotifications(harness.updates);
 
 		harness.abortController.abort();

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1418,9 +1418,100 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("preserves the owning message timestamp for a live tool-only assistant turn", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId);
+		if (!session) throw new Error("session not registered");
+
+		const timestamp = 1_725_000_005_000;
+		const toolCall = {
+			type: "toolCall" as const,
+			id: "toolu_live_only",
+			name: "bash",
+			arguments: { command: "printf ok" },
+		};
+		const assistantMessage = {
+			...makeAssistantMessage(""),
+			content: [toolCall],
+			stopReason: "toolUse" as const,
+			timestamp,
+		};
+		session.prompt = async (text: string): Promise<boolean> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			for (const listener of session.listeners()) {
+				listener({
+					type: "message_update",
+					message: assistantMessage,
+					assistantMessageEvent: { type: "toolcall_start", contentIndex: 0, partial: assistantMessage },
+				} as AgentSessionEvent);
+				listener({ type: "message_end", message: assistantMessage } as AgentSessionEvent);
+				listener({
+					type: "tool_execution_start",
+					toolCallId: toolCall.id,
+					toolName: toolCall.name,
+					args: toolCall.arguments,
+				} as AgentSessionEvent);
+				listener({
+					type: "tool_execution_update",
+					toolCallId: toolCall.id,
+					toolName: toolCall.name,
+					args: toolCall.arguments,
+					partialResult: { content: [{ type: "text", text: "running" }] },
+				} as AgentSessionEvent);
+				listener({
+					type: "tool_execution_end",
+					toolCallId: toolCall.id,
+					toolName: toolCall.name,
+					isError: false,
+					result: { content: [{ type: "text", text: "ok" }] },
+				} as AgentSessionEvent);
+			}
+			session.sessionManager.appendMessage(assistantMessage);
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+			return true;
+		};
+
+		const response = await harness.agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "Run the command" }],
+		});
+		expectAcpStructure(zPromptResponse, response);
+
+		const toolUpdates = harness.updates.filter(
+			notification =>
+				notification.sessionId === created.sessionId &&
+				"toolCallId" in notification.update &&
+				notification.update.toolCallId === toolCall.id,
+		);
+		expect(toolUpdates.map(notification => notification.update.sessionUpdate)).toEqual([
+			"tool_call",
+			"tool_call_update",
+			"tool_call_update",
+		]);
+		expect(toolUpdates.map(getChunkMessageTimestamp)).toEqual([timestamp, timestamp, timestamp]);
+		expect(
+			harness.updates.some(
+				notification =>
+					notification.sessionId === created.sessionId &&
+					(notification.update.sessionUpdate === "agent_message_chunk" ||
+						notification.update.sessionUpdate === "agent_thought_chunk"),
+			),
+		).toBe(false);
+		expectAcpNotifications(harness.updates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("replays assistant tool calls and matching results without duplicating the start", async () => {
 		const harness = await createHarness();
 		const stored = new FakeAgentSession(harness.cwdA);
+		const assistantTimestamp = 1_725_000_006_000;
 		harness.sessions.push(stored);
 		stored.sessionManager.appendMessage({ role: "user", content: "run tests", timestamp: Date.now() });
 		stored.sessionManager.appendMessage({
@@ -1445,7 +1536,7 @@ describe("ACP agent", () => {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "toolUse",
-			timestamp: Date.now(),
+			timestamp: assistantTimestamp,
 		});
 		stored.sessionManager.appendMessage({
 			role: "toolResult",
@@ -1453,7 +1544,7 @@ describe("ACP agent", () => {
 			toolName: "bash",
 			content: [{ type: "text", text: "tests passed" }],
 			isError: false,
-			timestamp: Date.now(),
+			timestamp: assistantTimestamp + 1_000,
 		});
 		await stored.sessionManager.ensureOnDisk();
 		await stored.sessionManager.flush();
@@ -1487,12 +1578,14 @@ describe("ACP agent", () => {
 			}),
 		);
 		expect(starts.some(update => "rawInput" in update && JSON.stringify(update.rawInput) === "{}")).toBe(false);
+		expect(starts[0]?._meta).toEqual({ "omp.sh/messageTimestamp": assistantTimestamp });
 		expect(completions).toHaveLength(1);
 		expect(completions[0]).toEqual(
 			expect.objectContaining({
 				content: expect.arrayContaining([{ type: "content", content: { type: "text", text: "tests passed" } }]),
 			}),
 		);
+		expect(completions[0]?._meta).toEqual({ "omp.sh/messageTimestamp": assistantTimestamp });
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -106,8 +106,9 @@ class ReplayTestSession {
 }
 
 describe("ACP event mapper", () => {
-	it("attaches a stable messageId to live assistant chunks", () => {
-		const assistantMessage = makeAssistantMessage("chunk");
+	it("attaches stable message identity metadata to live assistant chunks", () => {
+		const timestamp = 1_725_000_000_123;
+		const assistantMessage = { ...makeAssistantMessage("chunk"), timestamp };
 		const getMessageId = (message: unknown): string | undefined =>
 			message === assistantMessage ? "a80f1ff7-4f0a-4e6b-9f09-c94857b62a4a" : undefined;
 
@@ -129,20 +130,33 @@ describe("ACP event mapper", () => {
 			"session-1",
 			{ getMessageId },
 		);
+		const imageUpdates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "message_update",
+				message: assistantMessage,
+				assistantMessageEvent: {
+					type: "image_end",
+					content: { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+				},
+			} as AgentSessionEvent,
+			"session-1",
+			{ getMessageId },
+		);
 
+		const updates = [...textUpdates, ...thoughtUpdates, ...imageUpdates];
 		expect(textUpdates).toHaveLength(1);
 		expect(thoughtUpdates).toHaveLength(1);
-		expectAcpNotifications([...textUpdates, ...thoughtUpdates]);
-		expect(textUpdates[0] ? getChunkMessageId(textUpdates[0]) : undefined).toBe(
-			"a80f1ff7-4f0a-4e6b-9f09-c94857b62a4a",
-		);
-		expect(thoughtUpdates[0] ? getChunkMessageId(thoughtUpdates[0]) : undefined).toBe(
-			"a80f1ff7-4f0a-4e6b-9f09-c94857b62a4a",
-		);
+		expect(imageUpdates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		for (const update of updates) {
+			expect(getChunkMessageId(update)).toBe("a80f1ff7-4f0a-4e6b-9f09-c94857b62a4a");
+			expect(update.update._meta).toEqual({ "omp.sh/messageTimestamp": timestamp });
+		}
 	});
 
 	it("emits final assistant text when no text deltas were observed", () => {
-		const assistantMessage = makeAssistantMessage("final response");
+		const timestamp = 1_725_000_000_456;
+		const assistantMessage = { ...makeAssistantMessage("final response"), timestamp };
 		const progress = { textEmitted: false, thoughtEmitted: false };
 
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
@@ -161,11 +175,28 @@ describe("ACP event mapper", () => {
 					sessionUpdate: "agent_message_chunk",
 					content: { type: "text", text: "final response" },
 					messageId: undefined,
+					_meta: { "omp.sh/messageTimestamp": timestamp },
 				},
 			},
 		]);
 		expectAcpNotifications(updates);
 		expect(progress.textEmitted).toBe(true);
+	});
+
+	it("omits malformed timestamps instead of emitting invalid ACP metadata", () => {
+		const assistantMessage = { ...makeAssistantMessage("chunk"), timestamp: Number.NaN };
+
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "message_update",
+				message: assistantMessage,
+				assistantMessageEvent: { type: "text_delta", delta: "chunk" },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expect(updates[0]?.update._meta).toBeUndefined();
 	});
 
 	it("does not duplicate final assistant text after streaming deltas", () => {

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -246,6 +246,9 @@ describe("ACP initialize conformance", () => {
 		expect(response.agentCapabilities).toEqual(
 			expect.objectContaining({
 				loadSession: true,
+				_meta: {
+					"omp.sh/messageTimestamp": { format: "unix-ms" },
+				},
 				mcpCapabilities: expect.objectContaining({ http: true, sse: true }),
 				promptCapabilities: expect.objectContaining({ embeddedContext: true, image: true }),
 				sessionCapabilities: expect.objectContaining({


### PR DESCRIPTION
## Summary

- advertise OMP message-timestamp metadata during ACP initialization
- attach each source message's Unix-millisecond timestamp to live agent chunks and `session/load` replay chunks
- retain the owning assistant timestamp by `toolCallId` for live and replayed tool-only messages
- preserve timestamps on end-of-turn text/error fallback paths and omit invalid numeric values

> User-authored rationale: “Please expose OMP's authoritative per-message creation timestamps through the ACP boundary, for both live message updates and `session/load` replay.”

## Wire contract

OMP advertises the additive extension as:

```json
{
  "agentCapabilities": {
    "_meta": {
      "omp.sh/messageTimestamp": { "format": "unix-ms" }
    }
  }
}
```

Message-related updates then carry the original OMP timestamp:

```json
{
  "_meta": {
    "omp.sh/messageTimestamp": 1725000000123
  }
}
```

Standard ACP clients can ignore `_meta`; no ACP schema or persisted-session migration is required.

## Verification

- `bun test packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/acp-initialize-conformance.test.ts packages/coding-agent/test/acp-agent.test.ts` — 123 passed
- `bun --cwd=packages/coding-agent run check` — Biome passed; type checking reaches an unrelated existing `test/eval-code-mode-declarations.test.ts:109` `TS2769`
- source CLI ACP probe (`initialize` → `session/list` → `session/load`) — all 31 message chunks and all 90 tool updates carried numeric source timestamps; tool timestamps were stable by `toolCallId`
- `git diff --check` — passed

Fixes #9579
