### PR TITLE
fix(compaction): describe remote compaction summary as processed input tokens

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the remote-compaction summary mislabeling the compaction request's input usage as retained replay tokens; it now reads "Compaction processed N input tokens" ([#9585](https://github.com/can1357/oh-my-pi/issues/9585)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Changed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -1505,7 +1505,7 @@ function selectNativeCompactionError(previousError: unknown, nextError: unknown)
  * retained replacement history — so the wording describes processed input, not
  * retained context, to avoid implying the number is the post-compaction size.
  */
-export function formatRemoteCompactionSummary(inputTokens: number): string {
+function formatRemoteCompactionSummary(inputTokens: number): string {
 	return (
 		"Remote compaction preserved provider-native history for this session." +
 		(inputTokens > 0 ? ` Compaction processed ${inputTokens} input tokens.` : "")

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -1498,6 +1498,21 @@ function selectNativeCompactionError(previousError: unknown, nextError: unknown)
 }
 
 /**
+ * User-facing placeholder summary for a provider-native remote compaction.
+ *
+ * `inputTokens` is the compaction request's provider-reported input usage
+ * (persisted as `openaiRemoteCompaction.usedTokens`), NOT the size of the
+ * retained replacement history — so the wording describes processed input, not
+ * retained context, to avoid implying the number is the post-compaction size.
+ */
+export function formatRemoteCompactionSummary(inputTokens: number): string {
+	return (
+		"Remote compaction preserved provider-native history for this session." +
+		(inputTokens > 0 ? ` Compaction processed ${inputTokens} input tokens.` : "")
+	);
+}
+
+/**
  * Generate summaries for compaction using prepared data.
  * Returns CompactionResult - SessionManager adds id/parentId when saving.
  *
@@ -1711,10 +1726,8 @@ export async function compact(
 		// redundant LLM round. If a LATER compaction cannot reuse this payload,
 		// prepareCompaction re-expands the original messages and summarizes them
 		// locally then (see remotePreserveReusable).
-		const usedTokens = getCompactionV2PreserveData(preserveData)?.usedTokens ?? 0;
-		summary =
-			"Remote compaction preserved provider-native history for this session." +
-			(usedTokens > 0 ? ` Retained ${usedTokens} tokens in the provider replay payload.` : "");
+		const inputTokens = getCompactionV2PreserveData(preserveData)?.usedTokens ?? 0;
+		summary = formatRemoteCompactionSummary(inputTokens);
 	} else if (isSplitTurn && turnPrefixMessages.length > 0) {
 		// Generate both summaries in parallel
 		const [historyResult, turnPrefixResult] = await Promise.all([

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -5,7 +5,6 @@ import {
 	compact,
 	createFileOps,
 	DEFAULT_COMPACTION_SETTINGS,
-	formatRemoteCompactionSummary,
 	NativeCompactionError,
 	prepareCompaction,
 	type SessionEntry,
@@ -1928,7 +1927,9 @@ describe("compact() remote compaction failure handling", () => {
 		const remote = getCompactionV2PreserveData(result.preserveData);
 		expect(remote?.usedTokens).toBe(55);
 		expect(remote?.replacementHistory.at(-1)).toEqual(compactionItem);
-		expect(result.summary).toContain("Remote compaction preserved provider-native history");
+		expect(result.summary).toBe(
+			"Remote compaction preserved provider-native history for this session. Compaction processed 55 input tokens.",
+		);
 		expect(completeSpy).not.toHaveBeenCalled();
 	});
 
@@ -2339,24 +2340,5 @@ describe("compact() remote compaction failure handling", () => {
 			}),
 		).rejects.toThrow("Remote compaction failed");
 		expect(completeSpy).not.toHaveBeenCalled();
-	});
-});
-
-describe("formatRemoteCompactionSummary", () => {
-	test("describes the value as processed input tokens, not retained replay size", () => {
-		// `usedTokens` is the compaction request's input usage, not the retained
-		// replacement-history size — the wording must not imply the latter (#9585).
-		const summary = formatRemoteCompactionSummary(195633);
-		expect(summary).toBe(
-			"Remote compaction preserved provider-native history for this session. Compaction processed 195633 input tokens.",
-		);
-		expect(summary).not.toContain("Retained");
-		expect(summary).not.toContain("replay payload");
-	});
-
-	test("omits the token clause when input usage is unknown", () => {
-		expect(formatRemoteCompactionSummary(0)).toBe(
-			"Remote compaction preserved provider-native history for this session.",
-		);
 	});
 });

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -5,6 +5,7 @@ import {
 	compact,
 	createFileOps,
 	DEFAULT_COMPACTION_SETTINGS,
+	formatRemoteCompactionSummary,
 	NativeCompactionError,
 	prepareCompaction,
 	type SessionEntry,
@@ -2338,5 +2339,24 @@ describe("compact() remote compaction failure handling", () => {
 			}),
 		).rejects.toThrow("Remote compaction failed");
 		expect(completeSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("formatRemoteCompactionSummary", () => {
+	test("describes the value as processed input tokens, not retained replay size", () => {
+		// `usedTokens` is the compaction request's input usage, not the retained
+		// replacement-history size — the wording must not imply the latter (#9585).
+		const summary = formatRemoteCompactionSummary(195633);
+		expect(summary).toBe(
+			"Remote compaction preserved provider-native history for this session. Compaction processed 195633 input tokens.",
+		);
+		expect(summary).not.toContain("Retained");
+		expect(summary).not.toContain("replay payload");
+	});
+
+	test("omits the token clause when input usage is unknown", () => {
+		expect(formatRemoteCompactionSummary(0)).toBe(
+			"Remote compaction preserved provider-native history for this session.",
+		);
 	});
 });


### PR DESCRIPTION
## Repro
A provider-native remote compaction (OpenAI/Codex Responses V2) persists a placeholder summary. Building a `CompactionV2Response` with a single retained replacement-history item but `usage.inputTokens = 195633` (→ `usedTokens`), storing it via `storeCompactionV2PreserveData`, then rendering the summary reproduces the mislabel:

```
retained history items: 1
summary: Remote compaction preserved provider-native history for this session. Retained 195633 tokens in the provider replay payload.
```

The number is the compaction request's input usage, yet the wording implies it is the retained replay size, making an effective compaction look ineffective.

## Cause
`packages/agent/src/compaction/compaction-v2-streaming.ts` sets `CompactionV2Response.usedTokens = state.usage?.inputTokens ?? 0` (`finishCompactionV2Collection`) and persists it under `openaiRemoteCompaction.usedTokens`. `packages/agent/src/compaction/compaction.ts` read that value and rendered `Retained ${usedTokens} tokens in the provider replay payload.` — describing input usage as retained history size.

## Fix
- Add exported `formatRemoteCompactionSummary(inputTokens)` in `compaction.ts` that renders `Compaction processed N input tokens.` (and omits the clause when `N === 0`), with a doc comment stating `usedTokens` is input usage, not retained size.
- Use it at the `usedRemoteCompaction` branch in `compact()`; rename the local from `usedTokens` to `inputTokens`. The serialized `openaiRemoteCompaction.usedTokens` field is unchanged for session backwards compatibility.
- Changelog entry under `packages/agent` `[Unreleased] > Fixed`.

## Verification
`bun test packages/agent/test/remote-compaction.test.ts` → 50 pass, 0 fail (includes two new `formatRemoteCompactionSummary` regression tests asserting the processed-input wording and that the string no longer contains "Retained"/"replay payload"). Manually re-ran the repro above; summary now reads "Compaction processed 195633 input tokens."

Fixes #9585