### PR TITLE
fix(coding-agent): suppress TTSR interruption errors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
+- Fixed interactive TTSR interruptions displaying successful rule injections as errors ([#9586](https://github.com/can1357/oh-my-pi/issues/9586)).
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1222,29 +1222,27 @@ export class EventController {
 			let errorMessage: string | undefined;
 			const aborted = this.ctx.streamingMessage.stopReason === "aborted";
 			const silentlyAborted = aborted && isSilentAbort(this.ctx.streamingMessage);
-			const ttsrSilenced = aborted && this.ctx.viewSession.isTtsrAbortPending;
-			if (aborted && !silentlyAborted && !ttsrSilenced) {
+			if (aborted && !silentlyAborted) {
 				// Resolve the operator-facing label: a user-interrupt (Esc) abort
 				// carries USER_INTERRUPT_LABEL on errorMessage (threaded through the
 				// AbortController), which is preserved verbatim; any other abort with
 				// no threaded reason falls back to the retry-aware generic label.
-				// AgentSession.#handleAgentEvent already stamped SILENT_ABORT_MARKER for
-				// the plan-compact transition before this controller ran, so reaching
-				// this branch implies the abort was NOT a silent internal transition.
+				// AgentSession.#handleAgentEvent already stamped the SilentAbort flag
+				// for expected internal transitions (plan-compact, TTSR rule
+				// interruption) before this controller ran, so reaching this branch
+				// implies the abort was NOT a silent internal transition.
 				errorMessage = resolveAbortLabel(this.ctx.streamingMessage, this.ctx.viewSession.retryAttempt);
 				this.ctx.streamingMessage.errorMessage = errorMessage;
 			}
-			const displayMessage: AssistantMessage =
-				silentlyAborted || ttsrSilenced
-					? {
-							// Silence the streaming render without mutating the persisted message.
-							// TTSR reasons describe internal control flow and must not reach the
-							// error presentation after the display-only stopReason downgrade.
-							...this.ctx.streamingMessage,
-							stopReason: "stop",
-							errorMessage: ttsrSilenced ? undefined : this.ctx.streamingMessage.errorMessage,
-						}
-					: this.ctx.streamingMessage;
+			const displayMessage: AssistantMessage = silentlyAborted
+				? {
+						// Silence the streaming render by downgrading stopReason to "stop" for
+						// display only — does NOT mutate the persisted message's stopReason
+						// (the structural SilentAbort flag drives replay-side suppression).
+						...this.ctx.streamingMessage,
+						stopReason: "stop",
+					}
+				: this.ctx.streamingMessage;
 			const displayTimeline = splitAssistantMessageToolTimeline(displayMessage);
 			this.ctx.streamingComponent.updateContent(displayTimeline.beforeTools);
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1237,11 +1237,12 @@ export class EventController {
 			const displayMessage: AssistantMessage =
 				silentlyAborted || ttsrSilenced
 					? {
-							// Silence the streaming render by downgrading stopReason to "stop" for
-							// display only — does NOT mutate the persisted message's stopReason
-							// (the marker on errorMessage drives replay-side suppression).
+							// Silence the streaming render without mutating the persisted message.
+							// TTSR reasons describe internal control flow and must not reach the
+							// error presentation after the display-only stopReason downgrade.
 							...this.ctx.streamingMessage,
 							stopReason: "stop",
+							errorMessage: ttsrSilenced ? undefined : this.ctx.streamingMessage.errorMessage,
 						}
 					: this.ctx.streamingMessage;
 			const displayTimeline = splitAssistantMessageToolTimeline(displayMessage);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2569,16 +2569,20 @@ export class AgentSession {
 		if (event.type === "message_end" && event.message.role === "assistant") {
 			this.#lastAssistantMessage = event.message;
 		}
-		// Plan-mode internal transition: stamp `SILENT_ABORT_MARKER` on the
-		// persisted message BEFORE the obfuscator's display-side copy below.
+		// Expected internal transitions stamp a structural suppression flag on the
+		// persisted message BEFORE the obfuscator's display-side copy below, so the
+		// streaming render and every history-replay path (resume, `/tree`, rebuild)
+		// branch identically through `shouldRenderAbortReason`.
 		// Invariant (must hold across refactors): this branch precedes the
 		// `let displayEvent = event; ... displayEvent = { ...event, message: { ...message, content: deobfuscated } }`
 		// block. After stamping, both `displayEvent.message` (via the spread)
 		// and `event.message` (in-place mutation, used by SessionManager
-		// persistence) carry the marker, guaranteeing streaming render and
-		// history replay branch identically. The one-shot flag is consumed
-		// here, scoped strictly to this aborted message_end; callers still clear it
-		// in `finally` so a leaked flag cannot silence a later unrelated abort.
+		// persistence) carry the flag. The one-shot plan flag is consumed here,
+		// scoped strictly to this aborted message_end; callers still clear it in
+		// `finally` so a leaked flag cannot silence a later unrelated abort. TTSR
+		// keys off the coordinator's live `abortPending` state instead of a
+		// one-shot flag: the aborted message_end always fires before the deferred
+		// retry clears it.
 		if (
 			event.type === "message_end" &&
 			event.message.role === "assistant" &&
@@ -2592,6 +2596,13 @@ export class AgentSession {
 			} else if (this.#pendingAbortErrorId) {
 				message.errorId = this.#pendingAbortErrorId;
 				this.#pendingAbortErrorId = undefined;
+			} else if (this.#ttsr.abortPending) {
+				// A TTSR rule interruption is control flow, not a failure: the turn
+				// re-runs and the injection surfaces via `TtsrNotificationComponent`.
+				// Suppress the abort line while keeping the rule reason on the
+				// message for transcript/debug (the structural flag drives
+				// suppression, not the text).
+				message.errorId = AIError.create(AIError.Flag.SilentAbort);
 			}
 		}
 

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -23,7 +23,7 @@ import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensi
 import { GoalRuntime } from "@oh-my-pi/pi-coding-agent/goals/runtime";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { convertToLlm, shouldRenderAbortReason } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
@@ -1075,6 +1075,20 @@ describe("AgentSession TTSR resume gate", () => {
 				: "";
 		expect(text).toContain("Tool execution was aborted: TTSR matched rule: no-unwrap");
 		expect(text).not.toContain("Request was aborted");
+
+		// The persisted aborted assistant turn must not render as an error on
+		// resume/`/tree`/rebuild: TTSR interruption is control flow, so AgentSession
+		// stamps the SilentAbort flag and `shouldRenderAbortReason` returns false.
+		const abortedAssistant = sessionManager
+			.getEntries()
+			.find(
+				entry =>
+					entry.type === "message" && entry.message.role === "assistant" && entry.message.stopReason === "aborted",
+			);
+		expect(abortedAssistant?.type).toBe("message");
+		if (abortedAssistant?.type === "message" && abortedAssistant.message.role === "assistant") {
+			expect(shouldRenderAbortReason(abortedAssistant.message)).toBe(false);
+		}
 	});
 
 	it("labels only the matching aborted tool placeholder with the TTSR rule reason", async () => {

--- a/packages/coding-agent/test/event-controller-abort-render.test.ts
+++ b/packages/coding-agent/test/event-controller-abort-render.test.ts
@@ -12,9 +12,9 @@
  *         aborted"; `updateContent` receives the original message ref.
  *   C2b errorMessage = USER_INTERRUPT_LABEL (threaded via AbortController) + aborted
  *       → the threaded reason is preserved verbatim, NOT replaced by the generic.
- *   C3  isTtsrAbortPending = true + aborted + threaded TTSR reason
- *       → `updateContent` receives a message with `stopReason: "stop"` and no
- *         `errorMessage`; the persisted message retains its reason.
+ *   C3  isTtsrAbortPending = true + aborted + SilentAbort flag + rule reason
+ *       → `updateContent` receives a message with `stopReason: "stop"`; the
+ *         persisted reason survives and the shared presentation renders nothing.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
@@ -22,6 +22,7 @@ import * as AIError from "@oh-my-pi/pi-ai/error";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { resolveAssistantErrorPresentation } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SILENT_ABORT_MARKER, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 
@@ -175,10 +176,15 @@ describe("EventController #handleMessageEnd abort labeling", () => {
 		expect(arg.stopReason).toBe("aborted");
 	});
 
-	it("C3: TTSR abort reason is omitted from the interactive display message", async () => {
+	it("C3: a TTSR abort (SilentAbort flag + rule reason) is suppressed live and on rebuild", async () => {
+		// AgentSession stamps the SilentAbort flag on TTSR aborts while keeping the
+		// rule reason text on the message. The controller must downgrade the display
+		// stopReason without overwriting the persisted reason, and the shared
+		// presentation path (resume, `/tree`, rebuild) must render nothing.
 		const message = makeAssistantMessage({
 			stopReason: "aborted",
 			errorMessage: "TTSR matched rule: no-unwrap",
+			errorId: AIError.create(AIError.Flag.SilentAbort),
 		});
 		const { controller, streamingComponent } = createFixture({
 			streamingMessage: message,
@@ -191,6 +197,7 @@ describe("EventController #handleMessageEnd abort labeling", () => {
 		expect(streamingComponent.updateContent).toHaveBeenCalledTimes(1);
 		const arg = streamingComponent.updateContent.mock.calls[0]![0] as AssistantMessage;
 		expect(arg.stopReason).toBe("stop");
-		expect(arg.errorMessage).toBeUndefined();
+		// Rebuild path: the persisted aborted message renders no error line.
+		expect(resolveAssistantErrorPresentation(message)).toEqual({ kind: "none" });
 	});
 });

--- a/packages/coding-agent/test/event-controller-abort-render.test.ts
+++ b/packages/coding-agent/test/event-controller-abort-render.test.ts
@@ -12,9 +12,9 @@
  *         aborted"; `updateContent` receives the original message ref.
  *   C2b errorMessage = USER_INTERRUPT_LABEL (threaded via AbortController) + aborted
  *       → the threaded reason is preserved verbatim, NOT replaced by the generic.
- *   C3  isTtsrAbortPending = true + aborted
- *       → `updateContent` receives a message with `stopReason: "stop"`;
- *         `errorMessage` is NOT set (TTSR existing behavior unchanged).
+ *   C3  isTtsrAbortPending = true + aborted + threaded TTSR reason
+ *       → `updateContent` receives a message with `stopReason: "stop"` and no
+ *         `errorMessage`; the persisted message retains its reason.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
@@ -175,8 +175,11 @@ describe("EventController #handleMessageEnd abort labeling", () => {
 		expect(arg.stopReason).toBe("aborted");
 	});
 
-	it("C3: isTtsrAbortPending=true + aborted -> updateContent stopReason='stop', errorMessage NOT set", async () => {
-		const message = makeAssistantMessage({ stopReason: "aborted", errorMessage: undefined });
+	it("C3: TTSR abort reason is omitted from the interactive display message", async () => {
+		const message = makeAssistantMessage({
+			stopReason: "aborted",
+			errorMessage: "TTSR matched rule: no-unwrap",
+		});
 		const { controller, streamingComponent } = createFixture({
 			streamingMessage: message,
 			isTtsrAbortPending: true,
@@ -184,9 +187,7 @@ describe("EventController #handleMessageEnd abort labeling", () => {
 
 		await controller.handleEvent({ type: "message_end", message });
 
-		// TTSR keeps its existing flag-only render path — `errorMessage` stays undefined,
-		// and the display copy gets `stopReason: "stop"`.
-		expect(message.errorMessage).toBeUndefined();
+		expect(message.errorMessage).toBe("TTSR matched rule: no-unwrap");
 		expect(streamingComponent.updateContent).toHaveBeenCalledTimes(1);
 		const arg = streamingComponent.updateContent.mock.calls[0]![0] as AssistantMessage;
 		expect(arg.stopReason).toBe("stop");


### PR DESCRIPTION
## Repro
An interrupted TTSR tool stream produces an assistant message with `stopReason: "aborted"` and a threaded `errorMessage` such as `TTSR matched rule: no-unwrap`. Running `bun test packages/coding-agent/test/event-controller-abort-render.test.ts` against the regression case reproduced the visible-error path: the display message retained that reason after its stop reason was downgraded to `stop`.

## Cause
`EventController.#handleMessageEnd` in `packages/coding-agent/src/modes/controllers/event-controller.ts` suppressed the aborted stop reason while `viewSession.isTtsrAbortPending` was true, but copied the internal TTSR `errorMessage` unchanged. `resolveAssistantErrorPresentation` therefore treated the reason as a full error even though the display-only stop reason was `stop`.

## Fix
- Clear the TTSR abort reason only on the interactive display copy while preserving the persisted assistant message.
- Cover a threaded `TTSR matched rule` reason in the event-controller abort rendering regression test.
- Record the user-visible correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/event-controller-abort-render.test.ts` passes: 5 tests, 21 assertions. The pre-publish `bun check` gate also passed. Fixes #9586