### PR TITLE
fix(ai): preserve images for DeepSeek multimodal vision models

### DIFF
--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -79,6 +79,11 @@ export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean 
 	const name = (model.name ?? "").toLowerCase();
 	// DeepSeek OCR is a genuinely multimodal model served by Novita.
 	if (id.includes("deepseek-ocr") || name.includes("deepseek-ocr")) return false;
+	// `deepseek-v4-flash-vision-exp` and other DeepSeek SKUs whose id/name
+	// carry a multimodal `vision` marker are genuinely vision-capable on the
+	// upstream endpoint. The family-level guard below must not strip images
+	// from them; only known text-only DeepSeek models should be guarded.
+	if (id.includes("vision") || name.includes("vision")) return false;
 	return (
 		modelMatchesHost(model, "deepseekFamily") ||
 		isDeepseekModelIdOrName(model.id) ||

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -547,4 +547,30 @@ describe("openai-completions convertMessages", () => {
 			},
 		]);
 	});
+	it("preserves image_url for the multimodal DeepSeek V4 Flash Vision Exp model", () => {
+		const model = getBundledModel("deepseek", "deepseek-v4-flash-vision-exp") as Model<"openai-completions">;
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "What is in this screenshot?" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].content).toEqual([
+			{ type: "text", text: "What is in this screenshot?" },
+			{
+				type: "image_url",
+				image_url: { url: "data:image/png;base64,ZmFrZQ==" },
+			},
+		]);
+	});
 });


### PR DESCRIPTION
## Problem

The DeepSeek vision-guard treats **every** DeepSeek model as text-only (except `deepseek-ocr`), so the bundled multimodal `deepseek-v4-flash-vision-exp` model (`input: ["text", "image"]`) loses its images before they reach the wire. Sessions using it see:

```
[image omitted: model does not support vision]
```

This is a false negative: the upstream endpoint (`api.deepseek.com`) genuinely accepts `image_url` parts — verified against the live API.

## Fix

In `isTextOnlyDeepSeek` (`packages/ai/src/providers/vision-guard.ts`), broaden the existing exemption so any DeepSeek SKU whose id/name carries a `vision` marker is treated as vision-capable rather than text-only.

The family-level guard still applies to known text-only DeepSeek models (`v4-pro`, `v4-flash`, `chat`, `reasoner`), so the defensive behavior for misconfigured model entries / user overrides is preserved.

## Test

Added a regression case asserting `deepseek-v4-flash-vision-exp` preserves its `image_url` payload, alongside the existing `deepseek-ocr` case.

- `packages/ai/test/openai-completions-tool-result-images.test.ts`: 10 pass
- `packages/ai/test/issue-967-vision-guard.test.ts` + `deepseek-reasoning-content.test.ts`: 25 pass
- `packages/catalog/test`: 685 pass