### PR TITLE
fix(ai): exempt multimodal DeepSeek SKUs from text-only vision guard

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the text-only DeepSeek guard stripping images (`[image omitted: model does not support vision]`) from genuinely multimodal DeepSeek models such as `deepseek-v4-flash-vision-exp`; the override now exempts vision SKUs (`ocr`/`vision`/`vl`) instead of every DeepSeek model ([#9595](https://github.com/can1357/oh-my-pi/issues/9595)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -66,6 +66,16 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 }
 
 /**
+ * Vision markers in a DeepSeek model id/name that indicate a genuinely
+ * multimodal SKU (`deepseek-ocr`/`deepseek-ocr2`, `deepseek-vl`/`deepseek-vl2`,
+ * `deepseek-v4-flash-vision-exp`). Trailing version digits are allowed on the
+ * `ocr`/`vl` markers so attached-suffix aliases still match; the tokens are
+ * bounded so text-only SKUs (`deepseek-chat`, `deepseek-reasoner`,
+ * `deepseek-v4-flash`) never match.
+ */
+const DEEPSEEK_VISION_MARKER = /\b(?:ocr\d*|vision|vl\d*)\b/;
+
+/**
  * Detect known text-only DeepSeek models served via OpenAI-compatible Chat
  * Completions endpoints whose server-side deserializers reject `image_url`
  * content parts with HTTP 400 (`unknown variant \`image_url\`, expected \`text\``).
@@ -77,8 +87,12 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean {
 	const id = model.id.toLowerCase();
 	const name = (model.name ?? "").toLowerCase();
-	// DeepSeek OCR is a genuinely multimodal model served by Novita.
-	if (id.includes("deepseek-ocr") || name.includes("deepseek-ocr")) return false;
+	// Genuinely multimodal DeepSeek SKUs accept `image_url` and must keep their
+	// images: DeepSeek-OCR (Novita), DeepSeek-VL, and DeepSeek V4 Flash Vision
+	// (issue #9595). Detect them by the vision marker in the id/name rather than
+	// the model's own `input`, because a misconfigured text-only DeepSeek carries
+	// the same `input: [text, image]` this override exists to defend against.
+	if (DEEPSEEK_VISION_MARKER.test(id) || DEEPSEEK_VISION_MARKER.test(name)) return false;
 	return (
 		modelMatchesHost(model, "deepseekFamily") ||
 		isDeepseekModelIdOrName(model.id) ||

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -547,4 +547,69 @@ describe("openai-completions convertMessages", () => {
 			},
 		]);
 	});
+	it("preserves image_url for the bundled DeepSeek V4 Flash Vision model", () => {
+		// Regression for #9595: the text-only DeepSeek guard must not strip images
+		// from a genuinely multimodal DeepSeek SKU declaring `input: [text, image]`.
+		const model = getBundledModel("deepseek", "deepseek-v4-flash-vision-exp") as Model<"openai-completions">;
+		expect(model.input).toContain("image");
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Describe this screenshot" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].content).toEqual([
+			{ type: "text", text: "Describe this screenshot" },
+			{
+				type: "image_url",
+				image_url: { url: "data:image/png;base64,ZmFrZQ==" },
+			},
+		]);
+	});
+	it("preserves image_url for DeepSeek vision SKUs with attached version digits", () => {
+		// Regression for the #9596 review: the vision-marker exemption must cover
+		// attached-suffix aliases (`deepseek-ocr2`, `deepseek-vl2`) the old
+		// `includes("deepseek-ocr")` check matched, not just hyphenated variants.
+		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+		for (const id of ["deepseek-ocr2", "deepseek-vl2"]) {
+			const model: Model<"openai-completions"> = {
+				...baseModel,
+				id,
+				name: id,
+				provider: "deepseek",
+				baseUrl: "https://api.deepseek.com",
+				api: "openai-completions",
+				input: ["text", "image"],
+			};
+			const context: Context = {
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "Read this document" },
+							{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+						],
+						timestamp: Date.now(),
+					},
+				],
+			};
+
+			const messages = convertMessages(model, context, compat);
+
+			expect(messages[0].content).toEqual([
+				{ type: "text", text: "Read this document" },
+				{ type: "image_url", image_url: { url: "data:image/png;base64,ZmFrZQ==" } },
+			]);
+		}
+	});
 });


### PR DESCRIPTION
## Repro
Sending any image to a genuinely multimodal DeepSeek model — e.g. the bundled `deepseek/deepseek-v4-flash-vision-exp` (catalog declares `input: ["text", "image"]`) — replaces it with the placeholder `[image omitted: model does not support vision]`, so the model never sees the screenshot. Building the bundled spec and running the guard reproduces it:

```
input: [ 'text', 'image' ]
isTextOnlyDeepSeek: true
visionSupported: false
```

## Cause
`isTextOnlyDeepSeek` in `packages/ai/src/providers/vision-guard.ts` (added in `4068e52097`, released 18.0.1) matches every DeepSeek model via `modelMatchesHost(deepseekFamily)` / `isDeepseekModelIdOrName` / `provider === "deepseek"`, with only a `deepseek-ocr` exemption. `isOpenAICompletionsVisionSupported` then vetoes image content for all of them regardless of the model's own `input` declaration, so `convertMessages` swaps every image for the placeholder — overreaching onto genuine vision SKUs, the same defect fixed for DashScope qwen in #8305/#8307.

## Fix
- Generalize the `deepseek-ocr`-only exemption in `isTextOnlyDeepSeek` to a `DEEPSEEK_VISION_MARKER` regex (`\b(?:ocr|vision|vl\d*)\b`) matching genuine multimodal SKUs (`deepseek-ocr`, `deepseek-vl`/`deepseek-vl2`, `deepseek-v4-flash-vision-exp`) in the id/name; text-only SKUs (`deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash`/`-pro`) still match the override.
- Add a regression test preserving `image_url` for the bundled `deepseek/deepseek-v4-flash-vision-exp`, alongside the existing OCR-preservation test.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test packages/ai/test/openai-completions-tool-result-images.test.ts packages/ai/test/issue-967-vision-guard.test.ts` → 15 pass / 0 fail. Also confirmed via the guard directly: `deepseek-v4-flash-vision-exp`, `deepseek-ocr`, `deepseek-vl`, `deepseek-vl2` now report `visionSupported=true`, while `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash`, `deepseek-v4-pro` remain `false`. Fixes #9595