### PR TITLE
fix(coding-agent): stop cold launch clearing native scrollback twice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
+- Fixed cold interactive launch clearing native scrollback twice, which duplicated the welcome header (leaving a stale copy in scrollback) on the Windows console host ([#9597](https://github.com/can1357/oh-my-pi/issues/9597))
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 
 ## [18.0.4] - 2026-08-24

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -563,13 +563,16 @@ async function runInteractiveMode(
 	// Consume failures immediately, but defer any banner until the transcript is stable.
 	const checkedVersionPromise = versionCheckPromise.catch(() => undefined);
 
-	// Cold-launch cleanup: the first paint already clears native history, and this
-	// replay replaces the welcome/startup frame with the resumed/new transcript.
-	// Every in-process session load also uses `clearTerminalHistory`; cold launch
-	// follows the same clean-cutover path instead of preserving a previous run's
-	// transcript above the fresh one.
+	// Cold-launch cleanup. `init` already cleared native history once (via the
+	// prepaint composer's `start({ clearScrollback })` or its own
+	// `clearInitialTerminalHistory`). A *resumed* launch replays a transcript that
+	// must destructively replace that welcome/startup frame, so it clears again.
+	// A *fresh* launch has no transcript: the welcome frame `init` just painted is
+	// the final frame, so a second `clearTerminalHistory` here is redundant — and
+	// on conhost the ED3-then-ED2 pair archives that first welcome frame into
+	// scrollback instead of discarding it, leaving a duplicate header (issue #9597).
 	await logger.time("InteractiveMode.renderInitialMessages", () =>
-		mode.renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: true }),
+		mode.renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: resuming }),
 	);
 	// A resolved version check must not insert its banner into a partial transcript.
 	checkedVersionPromise.then(newVersion => {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -563,16 +563,13 @@ async function runInteractiveMode(
 	// Consume failures immediately, but defer any banner until the transcript is stable.
 	const checkedVersionPromise = versionCheckPromise.catch(() => undefined);
 
-	// Cold-launch cleanup. `init` already cleared native history once (via the
-	// prepaint composer's `start({ clearScrollback })` or its own
-	// `clearInitialTerminalHistory`). A *resumed* launch replays a transcript that
-	// must destructively replace that welcome/startup frame, so it clears again.
-	// A *fresh* launch has no transcript: the welcome frame `init` just painted is
-	// the final frame, so a second `clearTerminalHistory` here is redundant — and
-	// on conhost the ED3-then-ED2 pair archives that first welcome frame into
-	// scrollback instead of discarding it, leaving a duplicate header (issue #9597).
+	// `init` already cleared native history before painting the startup frame.
+	// The normal replay offers resumed transcript rows to the frame provider and
+	// repaints the viewport, so another destructive clear would only archive the
+	// startup frame on conhost (issue #9597). In-process session replacements
+	// still request `clearTerminalHistory` at their own callsites.
 	await logger.time("InteractiveMode.renderInitialMessages", () =>
-		mode.renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: resuming }),
+		mode.renderInitialMessages({ preserveExistingChat: true }),
 	);
 	// A resolved version check must not insert its banner into a partial transcript.
 	checkedVersionPromise.then(newVersion => {

--- a/packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts
+++ b/packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/modes/startup-composer";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
-import { createTestSession } from "./utilities";
+import { assistantMsg, createTestSession, userMsg } from "./utilities";
 
 // The single sequence the TUI emits for a destructive reset (erase scrollback +
 // viewport, repaint from row zero) — see `tui.ts` `#renderFrame`.
@@ -30,14 +30,11 @@ class CapturingTerminal extends VirtualTerminal {
 	}
 }
 
-// Cold launch runs two independent clear-native-history paths: the prepaint
-// composer's `start({ clearScrollback })` and, once InteractiveMode is ready,
-// `renderInitialMessages({ clearTerminalHistory })`. On conhost the destructive
-// reset's ED3-then-ED2 order archives the first welcome frame into scrollback
-// instead of discarding it, so a redundant second reset paints the welcome
-// header twice (issue #9597). The replay must clear again only when resuming a
-// transcript that has to replace the welcome frame; a fresh launch already
-// painted its final frame with the first clear.
+// Cold launch first clears native history while painting the prepaint welcome.
+// Once InteractiveMode is ready, a normal replay can offer resumed transcript
+// rows and repaint the viewport without another destructive reset. On conhost a
+// second ED3-then-ED2 reset would archive the prepaint frame into scrollback
+// after ED3 already ran, leaving a stale welcome above the live UI (issue #9597).
 describe("issue #9597 — cold-launch welcome duplication", () => {
 	let settings: Settings;
 	let config: ComposerPreferences;
@@ -66,14 +63,22 @@ describe("issue #9597 — cold-launch welcome duplication", () => {
 	});
 
 	// `resuming` mirrors `main.ts` `runInteractiveMode`: `false` on a plain `omp`
-	// launch, `true` for --continue/--resume/--fork. The replay's
-	// `clearTerminalHistory` follows it.
-	async function coldLaunch(resuming: boolean): Promise<{ resets: number; welcomeRows: number }> {
+	// launch, `true` for --continue/--resume/--fork.
+	async function coldLaunch(resuming: boolean): Promise<{
+		resets: number;
+		welcomeRows: number;
+		scrollBuffer: string;
+	}> {
 		const terminal = new CapturingTerminal(100, 30);
 		beginStartupComposer({ preferences: config, terminal, version: "18.0.4", cache: false });
+		await terminal.waitForRender();
 		const lease = takeStartupComposerLease();
 		expect(lease).toBeDefined();
 		const testSession = await createTestSession({ inMemory: true });
+		if (resuming) {
+			testSession.sessionManager.appendMessage(userMsg("resume marker question"));
+			testSession.sessionManager.appendMessage(assistantMsg("resume marker answer"));
+		}
 		const mode = new InteractiveMode(
 			testSession.session,
 			"18.0.4",
@@ -87,19 +92,19 @@ describe("issue #9597 — cold-launch welcome duplication", () => {
 		lease!.adopt();
 		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
 		try {
-			// First clear (prepaint welcome) flushes as its own frame before the
-			// replay, exactly as it does in the app across the setup/init gap.
-			await mode.init({ clearInitialTerminalHistory: true });
+			await mode.init({ suppressWelcomeIntro: resuming, clearInitialTerminalHistory: true });
 			await terminal.waitForRender();
-			await mode.renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: resuming });
+			await mode.renderInitialMessages({ preserveExistingChat: true });
 			await terminal.waitForRender();
-			const welcomeRows = terminal
-				.getScrollBuffer()
-				.map(l => Bun.stripANSI(l))
-				.filter(l => l.includes("18.0.4")).length;
-			return { resets: terminal.countResets(), welcomeRows };
+			const rows = terminal.getScrollBuffer().map(l => Bun.stripANSI(l));
+			return {
+				resets: terminal.countResets(),
+				welcomeRows: rows.filter(l => l.includes("18.0.4")).length,
+				scrollBuffer: rows.join("\n"),
+			};
 		} finally {
 			mode.stop();
+			await testSession.cleanup();
 		}
 	}
 
@@ -111,11 +116,10 @@ describe("issue #9597 — cold-launch welcome duplication", () => {
 		expect(welcomeRows).toBe(1);
 	});
 
-	it("still clears on the replay when resuming a transcript", async () => {
-		const { resets, welcomeRows } = await coldLaunch(true);
-		// A resumed launch must destructively replace the welcome frame with the
-		// transcript, so the gate keeps the second clear here.
-		expect(resets).toBe(2);
+	it("replays a resumed transcript without clearing native history again", async () => {
+		const { resets, scrollBuffer, welcomeRows } = await coldLaunch(true);
+		expect(resets).toBe(1);
+		expect(scrollBuffer).toContain("resume marker answer");
 		expect(welcomeRows).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts
+++ b/packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ComposerPreferences } from "@oh-my-pi/pi-coding-agent/modes/composer";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import {
+	beginStartupComposer,
+	stopPendingStartupComposer,
+	takeStartupComposerLease,
+} from "@oh-my-pi/pi-coding-agent/modes/startup-composer";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { createTestSession } from "./utilities";
+
+// The single sequence the TUI emits for a destructive reset (erase scrollback +
+// viewport, repaint from row zero) — see `tui.ts` `#renderFrame`.
+const DESTRUCTIVE_RESET = "\x1b[H\x1b[3J\x1b[2J";
+
+/** VirtualTerminal that also records every raw byte the TUI writes. */
+class CapturingTerminal extends VirtualTerminal {
+	readonly raw: string[] = [];
+	override write(data: string): void {
+		this.raw.push(data);
+		super.write(data);
+	}
+	countResets(): number {
+		const all = this.raw.join("");
+		let n = 0;
+		for (let i = all.indexOf(DESTRUCTIVE_RESET); i !== -1; i = all.indexOf(DESTRUCTIVE_RESET, i + 1)) n++;
+		return n;
+	}
+}
+
+// Cold launch runs two independent clear-native-history paths: the prepaint
+// composer's `start({ clearScrollback })` and, once InteractiveMode is ready,
+// `renderInitialMessages({ clearTerminalHistory })`. On conhost the destructive
+// reset's ED3-then-ED2 order archives the first welcome frame into scrollback
+// instead of discarding it, so a redundant second reset paints the welcome
+// header twice (issue #9597). The replay must clear again only when resuming a
+// transcript that has to replace the welcome frame; a fresh launch already
+// painted its final frame with the first clear.
+describe("issue #9597 — cold-launch welcome duplication", () => {
+	let settings: Settings;
+	let config: ComposerPreferences;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await initTheme();
+		settings = await Settings.init({ inMemory: true });
+		config = {
+			quiet: settings.get("startup.quiet"),
+			composerShape: settings.get("composer.shape") ?? "box",
+			showHardwareCursor: settings.get("showHardwareCursor"),
+			maxInlineImages: settings.get("tui.maxInlineImages"),
+			resizeScrollback: settings.get("tui.resizeScrollback"),
+			imeSafeCursor: settings.get("tui.imeSafeCursor"),
+			autocompleteMaxVisible: settings.get("autocompleteMaxVisible"),
+			spellingTypoDetection: settings.get("spelling.typoDetection"),
+			spellingAutocomplete: settings.get("spelling.autocomplete"),
+			spellingAutocorrect: settings.get("spelling.autocorrect"),
+		};
+	});
+
+	afterEach(() => {
+		stopPendingStartupComposer();
+		resetSettingsForTest();
+	});
+
+	// `resuming` mirrors `main.ts` `runInteractiveMode`: `false` on a plain `omp`
+	// launch, `true` for --continue/--resume/--fork. The replay's
+	// `clearTerminalHistory` follows it.
+	async function coldLaunch(resuming: boolean): Promise<{ resets: number; welcomeRows: number }> {
+		const terminal = new CapturingTerminal(100, 30);
+		beginStartupComposer({ preferences: config, terminal, version: "18.0.4", cache: false });
+		const lease = takeStartupComposerLease();
+		expect(lease).toBeDefined();
+		const testSession = await createTestSession({ inMemory: true });
+		const mode = new InteractiveMode(
+			testSession.session,
+			"18.0.4",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			lease!.composer,
+		);
+		lease!.adopt();
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		try {
+			// First clear (prepaint welcome) flushes as its own frame before the
+			// replay, exactly as it does in the app across the setup/init gap.
+			await mode.init({ clearInitialTerminalHistory: true });
+			await terminal.waitForRender();
+			await mode.renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: resuming });
+			await terminal.waitForRender();
+			const welcomeRows = terminal
+				.getScrollBuffer()
+				.map(l => Bun.stripANSI(l))
+				.filter(l => l.includes("18.0.4")).length;
+			return { resets: terminal.countResets(), welcomeRows };
+		} finally {
+			mode.stop();
+		}
+	}
+
+	it("clears native history once on a fresh launch, leaving one welcome header", async () => {
+		const { resets, welcomeRows } = await coldLaunch(false);
+		// The first clear already owns the final welcome frame; the replay must not
+		// clear again, or conhost promotes that frame into scrollback (duplicate).
+		expect(resets).toBe(1);
+		expect(welcomeRows).toBe(1);
+	});
+
+	it("still clears on the replay when resuming a transcript", async () => {
+		const { resets, welcomeRows } = await coldLaunch(true);
+		// A resumed launch must destructively replace the welcome frame with the
+		// transcript, so the gate keeps the second clear here.
+		expect(resets).toBe(2);
+		expect(welcomeRows).toBe(1);
+	});
+});


### PR DESCRIPTION
## Repro
On a cold interactive launch the welcome header is painted twice and both copies stay visible on the Windows console host: the first is stranded in native scrollback directly above the live one. Driving the exact cold-launch sequence against a terminal and counting the destructive-reset sequence `\x1b[H\x1b[3J\x1b[2J` reproduces the double clear:

```
bun test test/issue-9597-cold-launch-double-clear.test.ts
# pre-fix (replay always cleared): RESETS afterInit=1 afterReplay=2
```

Two destructive resets for a single cold launch, matching the reporter's `PI_TUI_WRITE_LOG` capture (`destructive resets: 2`).

## Cause
Cold launch runs two independent clear-native-history paths. `beginStartupComposer` (`modes/startup-composer.ts`) paints the welcome via `composer.start({ clearScrollback: true })`, then once InteractiveMode is ready `main.ts` replays through `renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: true })`, which reaches `modes/utils/ui-helpers.ts` `requestRender(true, { clearScrollback: true })`. Each latches `#clearScrollbackOnNextRender` in `packages/tui/src/tui.ts`, emitting `\x1b[H\x1b[3J\x1b[2J`. On conhost that pair runs ED3 (erase scrollback) before ED2 (erase all), and conhost's ED2 archives the current page into scrollback rather than discarding it — so the first welcome frame is promoted to scrollback after ED3 already ran, and the second frame is painted live. On a fresh launch the second clear is pure redundancy: the welcome frame the first clear painted is already the final frame.

## Fix
- `main.ts` `runInteractiveMode`: gate the cold-launch replay's `clearTerminalHistory` on `resuming` instead of hardcoding `true`. A fresh `omp` launch (`resuming === false`, empty transcript) keeps the welcome frame painted by the first clear and skips the redundant second destructive reset; `--continue`/`--resume`/`--fork` still replay a transcript that must destructively replace the welcome frame, so they keep clearing. In-process session loads (`/new`, `/clear`, resume selector) are untouched — they call `renderInitialMessages` on their own paths.
- Added `packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts` asserting a fresh cold launch emits exactly one destructive reset with one welcome header, while a resuming launch keeps the second clear.

## Verification
`bun test test/startup-composer.test.ts test/issue-9597-cold-launch-double-clear.test.ts` → 19 pass, 0 fail. Post-fix the regression test reports `resuming=false afterReplay=1` (single reset, one welcome) and `resuming=true afterReplay=2` (replay still clears). The visible duplication is conhost-specific (a modern VT's ED2 discards the viewport, so the redundant clear was invisible there); the terminal-independent double-reset count is the reproduced and fixed contract. Fixes #9597