### PR TITLE
test(utils): skip resolveWindowsShell cmd.exe fallback under WSL

### DIFF
--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -81,10 +81,13 @@ describe("resolveWindowsShell", () => {
 		expect(resolveWindowsShell({ ProgramFiles: programFiles, ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toBe(bash);
 	});
 
-	// On a real Windows host bash.exe/sh.exe may resolve from PATH before the
-	// cmd.exe fallback is reached, so the fallback contract is only
-	// deterministic off-Windows.
-	it.skipIf(process.platform === "win32")("falls back to cmd.exe instead of failing when no bash exists", () => {
+	// On a real Windows host — or under WSL, which inherits the Windows PATH —
+	// bash.exe/sh.exe may resolve from PATH before the cmd.exe fallback is
+	// reached, so the fallback contract is only deterministic off-Windows.
+	const isWindowsHost =
+		process.platform === "win32" ||
+		(process.platform === "linux" && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP));
+	it.skipIf(isWindowsHost)("falls back to cmd.exe instead of failing when no bash exists", () => {
 		expect(resolveWindowsShell({})).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(resolveWindowsShell({ ComSpec: "D:\\win\\cmd.exe" })).toBe("D:\\win\\cmd.exe");
 	});


### PR DESCRIPTION
## Repro
Running `bun test packages/utils/test/procmgr.test.ts` under WSL2 fails the `resolveWindowsShell > falls back to cmd.exe` case: it expects `C:\Windows\System32\cmd.exe` but gets `/mnt/c/WINDOWS/system32/bash.exe`. Simulating the WSL condition on Linux (a `bash.exe` on PATH + `WSL_DISTRO_NAME`) reproduces it: `PATH="<dir-with-bash.exe>:$PATH" WSL_DISTRO_NAME=Ubuntu bun test packages/utils/test/procmgr.test.ts` — the fallback assertion resolves the PATH `bash.exe` instead of cmd.exe and fails.

## Cause
The skip guard at `packages/utils/test/procmgr.test.ts:87` was `process.platform === "win32"` only. Under WSL `process.platform` is `"linux"`, so the skip never fired — but WSL inherits the Windows PATH, so `$which("bash.exe")` (`packages/utils/src/procmgr.ts:163`) resolves a Windows `bash.exe` before the `ComSpec`/cmd.exe fallback at `procmgr.ts:172`. The test's own comment already notes the fallback contract is only deterministic off-Windows; WSL is a Windows-adjacent host that the predicate omitted.

## Fix
- `packages/utils/test/procmgr.test.ts`: replace the inline `process.platform === "win32"` skip predicate with an `isWindowsHost` check that also treats WSL as a Windows host (`process.platform === "linux" && (WSL_DISTRO_NAME || WSL_INTEROP)`), matching the established marker check in `discovery/agents.ts:40` and `utils/clipboard.ts:65`.
- Update the accompanying comment to state WSL inherits the Windows PATH.
- Test-only: production `getShellConfig` calls `resolveWindowsShell` only under `process.platform === "win32"` (`procmgr.ts:202`), so WSL never triggers it at runtime; no production behavior changes.

## Verification
`bun test packages/utils/test/procmgr.test.ts` on Linux: 8 pass, 0 fail (fallback case runs). With WSL simulated (`PATH` bash.exe + `WSL_DISTRO_NAME=Ubuntu`): 7 pass, 1 skip, 0 fail — the fallback case now skips instead of failing. Fixes #9604