### PR TITLE
fix(catalog): point the Synthetic default at a model the catalog still has

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `synthetic` provider's default model still pointing at the retired `hf:zai-org/GLM-5.1`; an account with only `SYNTHETIC_API_KEY` opened on whichever model sorted first (`hf:moonshotai/Kimi-K3`) instead of the provider default, which is now the bundled `hf:zai-org/GLM-5.2`.
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -413,7 +413,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "synthetic",
-		defaultModel: "hf:zai-org/GLM-5.1",
+		defaultModel: "hf:zai-org/GLM-5.2",
 		envVars: ["SYNTHETIC_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => syntheticModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,

--- a/packages/catalog/test/provider-default-models.test.ts
+++ b/packages/catalog/test/provider-default-models.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { type GeneratedProvider, getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { CATALOG_PROVIDERS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+
+/**
+ * Providers whose bundled slice is one account's credential-scoped snapshot
+ * rather than a public catalog, so a declared default missing from the bundle
+ * is not proof the id is gone upstream. `devin` discovers through an
+ * authenticated `GetCliModelConfigs` RPC; its snapshot carries only the SKUs
+ * that account could see.
+ */
+const CREDENTIAL_SCOPED_SNAPSHOT_PROVIDERS = new Set(["devin"]);
+
+describe("provider default models", () => {
+	// A bundled slice is the catalog's own snapshot of what a provider serves.
+	// When one exists, the declared `defaultModel` has to be in it: that id is
+	// what `pickDefaultAvailableModel` matches on, so a default that no longer
+	// exists demotes the provider to "no default" and first-run selection falls
+	// through to whatever model happens to sort first.
+	//
+	// Providers with no bundled slice at all (local engines, discovery-only
+	// backends) are out of scope — they resolve their catalog at runtime.
+	test.each(
+		CATALOG_PROVIDERS.filter(
+			provider =>
+				!CREDENTIAL_SCOPED_SNAPSHOT_PROVIDERS.has(provider.id) &&
+				getBundledModels(provider.id as GeneratedProvider).length > 0,
+		).map(provider => [provider.id, provider.defaultModel] as const),
+	)("%s declares a bundled default model (%s)", (providerId, defaultModel) => {
+		const ids = getBundledModels(providerId as GeneratedProvider).map(model => model.id);
+		expect(ids).toContain(defaultModel);
+	});
+});

--- a/packages/coding-agent/test/provider-default-selection.test.ts
+++ b/packages/coding-agent/test/provider-default-selection.test.ts
@@ -10,13 +10,22 @@ describe("provider default selection", () => {
 	 * provider's declared default and falls through to `availableModels[0]`
 	 * when nothing matches. Synthetic's default pointed at `hf:zai-org/GLM-5.1`
 	 * after the provider moved to GLM-5.2, so an account with only
-	 * `SYNTHETIC_API_KEY` opened on `hf:moonshotai/Kimi-K3` — first in catalog
-	 * order — instead of the declared default.
+	 * `SYNTHETIC_API_KEY` opened on whichever model sorted first instead of the
+	 * declared default.
+	 *
+	 * The default is moved to the back of the availability list rather than
+	 * relying on catalog order, so the assertion keeps proving that the picker
+	 * overrides position — not that `gen:models` happens to sort some other
+	 * model first.
 	 */
-	test("picks Synthetic's declared default over catalog order", () => {
-		const available = getBundledModels("synthetic") as Model<Api>[];
-		expect(available.length).toBeGreaterThan(0);
-		expect(available[0]?.id).not.toBe(DEFAULT_MODEL_PER_PROVIDER.synthetic);
+	test("picks Synthetic's declared default over availability order", () => {
+		const bundled = getBundledModels("synthetic") as Model<Api>[];
+		const declaredDefault = bundled.find(model => model.id === DEFAULT_MODEL_PER_PROVIDER.synthetic);
+		expect(declaredDefault).toBeDefined();
+		if (!declaredDefault) return;
+
+		const available = [...bundled.filter(model => model !== declaredDefault), declaredDefault];
+		expect(available.length).toBeGreaterThan(1);
 
 		const picked = pickDefaultAvailableModel(available);
 

--- a/packages/coding-agent/test/provider-default-selection.test.ts
+++ b/packages/coding-agent/test/provider-default-selection.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
+import { pickDefaultAvailableModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+
+describe("provider default selection", () => {
+	/**
+	 * `pickDefaultAvailableModel` prefers the first model whose id equals its
+	 * provider's declared default and falls through to `availableModels[0]`
+	 * when nothing matches. Synthetic's default pointed at `hf:zai-org/GLM-5.1`
+	 * after the provider moved to GLM-5.2, so an account with only
+	 * `SYNTHETIC_API_KEY` opened on `hf:moonshotai/Kimi-K3` — first in catalog
+	 * order — instead of the declared default.
+	 */
+	test("picks Synthetic's declared default over catalog order", () => {
+		const available = getBundledModels("synthetic") as Model<Api>[];
+		expect(available.length).toBeGreaterThan(0);
+		expect(available[0]?.id).not.toBe(DEFAULT_MODEL_PER_PROVIDER.synthetic);
+
+		const picked = pickDefaultAvailableModel(available);
+
+		expect(picked?.id).toBe(DEFAULT_MODEL_PER_PROVIDER.synthetic);
+	});
+});


### PR DESCRIPTION
## Summary

`synthetic`'s declared `defaultModel` is `hf:zai-org/GLM-5.1`, a model the provider has replaced with GLM-5.2. The bundled catalog carries `hf:zai-org/GLM-5.2` (and a fresh `bun run gen:models` still produces 5.2, never 5.1), so the declared default matches nothing.

That is not a cosmetic mismatch. `pickDefaultAvailableModel` (`packages/coding-agent/src/config/model-resolver.ts`) picks the first model whose id equals its provider's declared default and otherwise falls through to `availableModels[0]`. With the default unmatchable, an account whose only credential is `SYNTHETIC_API_KEY` opens on `hf:moonshotai/Kimi-K3` — first in catalog order — instead of the provider's intended default.

## Changes

- `packages/catalog/src/provider-models/descriptors.ts` — `synthetic` default `hf:zai-org/GLM-5.1` → `hf:zai-org/GLM-5.2`.
- `packages/catalog/test/provider-default-models.test.ts` — contract test: every provider that ships a bundled slice must declare a `defaultModel` that exists in it. Providers with no bundled slice (local engines, discovery-only backends) are out of scope; they resolve their catalog at runtime.
- `packages/coding-agent/test/provider-default-selection.test.ts` — behavioral regression test driving the real picker over the real bundled catalog.
- `packages/catalog/CHANGELOG.md`.

## One case left alone, for maintainer input

The same audit shows `devin` declaring `swe-1-6` while its bundled slice holds only `swe-1-6-slow`. I did **not** change it: Devin's catalog comes from credential-scoped `GetCliModelConfigs` RPC discovery, so its bundled snapshot is one account's view and a missing id is not proof the SKU is gone upstream. The contract test excludes `devin` with that reasoning spelled out. If the fast SKU is in fact retired, the default should follow — happy to fold that in if you confirm.

## Verification

- Reproduced first: both new tests fail on `main` (`Expected: "hf:zai-org/GLM-5.1"`, `Received: "hf:moonshotai/Kimi-K3"` from the picker) and pass with the one-line default change.
- `bun check` — passes.
- `packages/catalog`: 746 pass, 0 fail. `packages/coding-agent`: `model-resolver.test.ts` + `sdk-model-selection.test.ts` 193 pass, 0 fail.
- No live Synthetic account here, so the end-to-end check is the selection path itself, exercised against the shipped bundled catalog rather than a mock.

## AI assistance

Found and implemented with an AI agent under my direction; scope and the decision to submit are mine.
