### PR TITLE
fix(browser-relay): detach upstream on explicit last-session release

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed the browser relay leaving a tab's `chrome.debugger` attachment (and its "started debugging this browser" infobar) orphaned when a client released its last session with `Target.detachFromTarget` before disconnecting ([#9613](https://github.com/can1357/oh-my-pi/issues/9613))
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -87,6 +87,8 @@ class TabState {
 	/** Whether targets for this tab were announced to discovering connections. */
 	announced = false;
 	attaching: Promise<boolean> | null = null;
+	/** Relay-initiated detach in flight; reattach serializes behind it so the new attach never races the pending detach or its onDetach echo. */
+	detaching: Promise<void> | null = null;
 	/** True after the relay put this tab in the omp group; `ompGroupId` holds that group. */
 	grouped = false;
 	/** Group RPC in flight — suppresses duplicate requests from load-time tabUpdated bursts. */
@@ -340,10 +342,7 @@ export class RelayBridge {
 		for (const tabId of touched) {
 			if (this.#sessionHolders(tabId).length > 0) continue;
 			const tab = this.#tabs.get(tabId);
-			if (tab?.attached) {
-				tab.attached = false;
-				void this.#rpc({ op: "detach", tabId }).catch(() => {});
-			}
+			if (tab) this.#detachTab(tab);
 		}
 		this.#log("cdp client closed", { conn: connId });
 	}
@@ -859,10 +858,24 @@ export class RelayBridge {
 		// connection still holds a session on the tab.
 		if (this.#sessionHolders(ref.tabId).length > 0) return;
 		const tab = this.#tabs.get(ref.tabId);
-		if (tab?.attached) {
-			tab.attached = false;
-			void this.#rpc({ op: "detach", tabId: ref.tabId }).catch(() => {});
-		}
+		if (tab) this.#detachTab(tab);
+	}
+
+	/**
+	 * Drop `chrome.debugger` (and its infobar) from a tab nobody drives anymore,
+	 * tracking the in-flight RPC on {@link TabState.detaching} so a concurrent
+	 * reattach serializes behind it instead of racing the detach.
+	 */
+	#detachTab(tab: TabState): void {
+		if (!tab.attached) return;
+		tab.attached = false;
+		const done = this.#rpc({ op: "detach", tabId: tab.tabId })
+			.then(() => {})
+			.catch(() => {})
+			.finally(() => {
+				if (tab.detaching === done) tab.detaching = null;
+			});
+		tab.detaching = done;
 	}
 
 	/** Connections currently holding any session on a tab. */
@@ -885,6 +898,12 @@ export class RelayBridge {
 	}
 
 	async #ensureAttached(tab: TabState): Promise<boolean> {
+		// Serialize behind an in-flight relay-initiated detach: attaching before
+		// the detach RPC (and any onDetach echo) settles races Chrome — the new
+		// attach can fail and ban the tab, or the stale detach event can retract
+		// the freshly created session. Awaiting drains the echo first, since the
+		// extension posts `detached` before the detach RPC result.
+		while (tab.detaching) await tab.detaching;
 		if (tab.attached) return true;
 		if (tab.banned || !this.#ext) return false;
 		if (tab.attaching) return await tab.attaching;

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -656,6 +656,18 @@ export class RelayBridge {
 	#onTabDetached(tabId: number, reason: string): void {
 		const tab = this.#tabs.get(tabId);
 		if (!tab) return;
+		// A detach we initiated (#releaseSession/cdpClosed dropping the debugger
+		// once no holder remains) clears tab.attached *before* sending the RPC.
+		// If the extension echoes chrome.debugger.onDetach back as `detached`,
+		// it arrives here for a tab we no longer consider attached: that is a
+		// clean release, not the user dismissing the infobar or DevTools
+		// stealing the session. Banning + retracting it would destroy a still-
+		// live target for the connected discovery client and block re-attach
+		// for the rest of the epoch, so treat it as a no-op.
+		if (!tab.attached) {
+			tab.attaching = null;
+			return;
+		}
 		this.#log("tab detached", { tabId, reason });
 		tab.attached = false;
 		tab.attaching = null;

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -841,6 +841,16 @@ export class RelayBridge {
 		conn.sessions.delete(sessionId);
 		const targetId = ref.kind === "tab" ? tabTargetId(ref.tabId) : pageTargetId(ref.tabId);
 		this.#emit(conn, "Target.detachedFromTarget", { sessionId, targetId }, parentSessionId);
+		// Same zero-holders rule cdpClosed() applies: once the final holder
+		// releases its last session, drop the debugger (and its infobar) from a
+		// tab nobody drives anymore. Inert while the long-lived registry
+		// connection still holds a session on the tab.
+		if (this.#sessionHolders(ref.tabId).length > 0) return;
+		const tab = this.#tabs.get(ref.tabId);
+		if (tab?.attached) {
+			tab.attached = false;
+			void this.#rpc({ op: "detach", tabId: ref.tabId }).catch(() => {});
+		}
 	}
 
 	/** Connections currently holding any session on a tab. */

--- a/packages/coding-agent/test/tools/browser-relay-server.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-server.test.ts
@@ -171,6 +171,11 @@ async function connectScriptedExtension(port: number, tabs: TabSnapshot[]): Prom
 		if (msg.t !== "rpc") return;
 		const { id, t: _t, ...rpc } = msg;
 		rpcs.push(rpc);
+		// Mirror Chrome: chrome.debugger.detach() would fire onDetach, which the
+		// real extension forwards as `detached` before the RPC settles.
+		if (rpc.op === "detach") {
+			ws.send(JSON.stringify({ t: "detached", tabId: rpc.tabId, reason: "target_closed" } satisfies ExtToRelayMessage));
+		}
 		ws.send(JSON.stringify({ t: "rpcResult", id, ok: true, result: {} } satisfies ExtToRelayMessage));
 	});
 	await opened.promise;
@@ -282,5 +287,21 @@ describe("browser relay session detach", () => {
 		// Marker attach on tab 2 through the surviving holder flushes the ext socket.
 		await b.send("Target.attachToTarget", { targetId: "PAGE2", flatten: true });
 		expect(rpcs.filter(rpc => rpc.op === "detach" && rpc.tabId === 1)).toHaveLength(0);
+	});
+
+	it("re-attaches a tab after the extension echoes the relay-initiated detach", async () => {
+		const { port } = await startReadyRelay();
+		const client = await openClient(port);
+		const attached = await client.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+
+		await client.send("Target.detachFromTarget", { sessionId: attached.result?.sessionId });
+		// Marker attach on tab 2 is FIFO-ordered after the tab-1 detach and its
+		// `detached` echo, so once it resolves the echo has been processed.
+		await client.send("Target.attachToTarget", { targetId: "PAGE2", flatten: true });
+
+		// The echo must not have banned the tab: re-attach still succeeds.
+		const reattached = await client.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+		expect(reattached.error).toBeUndefined();
+		expect(typeof reattached.result?.sessionId).toBe("string");
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-server.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-server.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { findFreeCdpPort } from "@oh-my-pi/pi-coding-agent/tools/browser/attach";
+import type {
+	ExtToRelayMessage,
+	RelayRpcRequest,
+	RelayToExtMessage,
+	TabSnapshot,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/relay/protocol";
 import { type RelayServer, startRelayServer } from "@oh-my-pi/pi-coding-agent/tools/browser/relay/server";
 
 const EXTENSION_HELLO = {
@@ -144,5 +150,137 @@ describe("browser relay discovery endpoint", () => {
 		relay = startRelayServer({ port });
 		const response = await fetch(`http://127.0.0.1:${port}/json/version`);
 		expect(response.status).toBe(503);
+	});
+});
+
+interface ScriptedExtension {
+	ws: WebSocket;
+	/** Every RPC the relay drove the extension with, in arrival order. */
+	rpcs: RelayRpcRequest[];
+}
+
+/** Extension that acknowledges every RPC and records it, so tests can assert relay-driven upstream traffic. */
+async function connectScriptedExtension(port: number, tabs: TabSnapshot[]): Promise<ScriptedExtension> {
+	const rpcs: RelayRpcRequest[] = [];
+	const opened = Promise.withResolvers<void>();
+	const ws = new WebSocket(`ws://127.0.0.1:${port}/ext`);
+	ws.addEventListener("open", () => opened.resolve(), { once: true });
+	ws.addEventListener("error", () => opened.reject(new Error("Extension socket failed to connect")), { once: true });
+	ws.addEventListener("message", event => {
+		const msg = JSON.parse(String(event.data)) as RelayToExtMessage;
+		if (msg.t !== "rpc") return;
+		const { id, t: _t, ...rpc } = msg;
+		rpcs.push(rpc);
+		ws.send(JSON.stringify({ t: "rpcResult", id, ok: true, result: {} } satisfies ExtToRelayMessage));
+	});
+	await opened.promise;
+	ws.send(
+		JSON.stringify({
+			t: "hello",
+			userAgent: "test",
+			browserVersion: "Chrome/150.0.0.0",
+			tabs,
+			attachedTabIds: [],
+		} satisfies ExtToRelayMessage),
+	);
+	return { ws, rpcs };
+}
+
+interface CdpResponse {
+	id: number;
+	result?: Record<string, unknown>;
+	error?: unknown;
+}
+
+interface CdpClient {
+	ws: WebSocket;
+	send(method: string, params?: Record<string, unknown>): Promise<CdpResponse>;
+}
+
+/** Minimal downstream CDP client: numbered request/response over the /cdp socket. */
+async function connectCdpClient(port: number): Promise<CdpClient> {
+	const opened = Promise.withResolvers<void>();
+	const ws = new WebSocket(`ws://127.0.0.1:${port}/cdp`);
+	ws.addEventListener("open", () => opened.resolve(), { once: true });
+	ws.addEventListener("error", () => opened.reject(new Error("CDP socket failed to connect")), { once: true });
+	await opened.promise;
+	let nextId = 0;
+	const pending = new Map<number, (msg: CdpResponse) => void>();
+	ws.addEventListener("message", event => {
+		const msg = JSON.parse(String(event.data)) as CdpResponse;
+		if (typeof msg.id === "number") pending.get(msg.id)?.(msg);
+	});
+	const send = (method: string, params: Record<string, unknown> = {}): Promise<CdpResponse> => {
+		const id = ++nextId;
+		const { promise, resolve } = Promise.withResolvers<CdpResponse>();
+		pending.set(id, resolve);
+		ws.send(JSON.stringify({ id, method, params }));
+		return promise;
+	};
+	return { ws, send };
+}
+
+function fakeTab(tabId: number, url: string): TabSnapshot {
+	return { tabId, url, title: url, active: tabId === 1, windowId: 1, pinned: false, groupId: -1 };
+}
+
+describe("browser relay session detach", () => {
+	let relay: RelayServer | undefined;
+	let extension: WebSocket | undefined;
+	const clients: WebSocket[] = [];
+
+	afterEach(() => {
+		for (const ws of clients) ws.close();
+		clients.length = 0;
+		extension?.close();
+		relay?.stop();
+		extension = undefined;
+		relay = undefined;
+	});
+
+	// Two tabs so a later attach on tab 2 can serve as a deterministic marker:
+	// the ext socket is FIFO, so once the tab-2 attach round-trips, any upstream
+	// detach the tab-1 release dispatched is already recorded.
+	async function startReadyRelay(): Promise<{ port: number; rpcs: RelayRpcRequest[] }> {
+		const port = await findFreeCdpPort();
+		relay = startRelayServer({ port });
+		const ext = await connectScriptedExtension(port, [
+			fakeTab(1, "https://one.example/"),
+			fakeTab(2, "https://two.example/"),
+		]);
+		extension = ext.ws;
+		await waitForDiscovery(port);
+		return { port, rpcs: ext.rpcs };
+	}
+
+	async function openClient(port: number): Promise<CdpClient> {
+		const client = await connectCdpClient(port);
+		clients.push(client.ws);
+		return client;
+	}
+
+	it("detaches the tab upstream when the last session is released via Target.detachFromTarget", async () => {
+		const { port, rpcs } = await startReadyRelay();
+		const client = await openClient(port);
+		const attached = await client.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+		expect(typeof attached.result?.sessionId).toBe("string");
+
+		await client.send("Target.detachFromTarget", { sessionId: attached.result?.sessionId });
+		// Marker attach on tab 2 — once it resolves the tab-1 detach (if any) is recorded.
+		await client.send("Target.attachToTarget", { targetId: "PAGE2", flatten: true });
+		expect(rpcs.filter(rpc => rpc.op === "detach" && rpc.tabId === 1)).toHaveLength(1);
+	});
+
+	it("keeps the tab attached while another connection still holds a session", async () => {
+		const { port, rpcs } = await startReadyRelay();
+		const a = await openClient(port);
+		const b = await openClient(port);
+		const attachedA = await a.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+		await b.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+
+		await a.send("Target.detachFromTarget", { sessionId: attachedA.result?.sessionId });
+		// Marker attach on tab 2 through the surviving holder flushes the ext socket.
+		await b.send("Target.attachToTarget", { targetId: "PAGE2", flatten: true });
+		expect(rpcs.filter(rpc => rpc.op === "detach" && rpc.tabId === 1)).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-server.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-server.test.ts
@@ -157,24 +157,37 @@ interface ScriptedExtension {
 	ws: WebSocket;
 	/** Every RPC the relay drove the extension with, in arrival order. */
 	rpcs: RelayRpcRequest[];
+	/** Settle any detach RPCs withheld via the `deferDetach` option (echo + result). */
+	flushDetach(): void;
 }
 
 /** Extension that acknowledges every RPC and records it, so tests can assert relay-driven upstream traffic. */
-async function connectScriptedExtension(port: number, tabs: TabSnapshot[]): Promise<ScriptedExtension> {
+async function connectScriptedExtension(
+	port: number,
+	tabs: TabSnapshot[],
+	opts: { deferDetach?: boolean } = {},
+): Promise<ScriptedExtension> {
 	const rpcs: RelayRpcRequest[] = [];
+	const withheld: Array<{ id: number; tabId: number }> = [];
 	const opened = Promise.withResolvers<void>();
 	const ws = new WebSocket(`ws://127.0.0.1:${port}/ext`);
 	ws.addEventListener("open", () => opened.resolve(), { once: true });
 	ws.addEventListener("error", () => opened.reject(new Error("Extension socket failed to connect")), { once: true });
+	// Mirror Chrome: chrome.debugger.detach() would fire onDetach, which the real
+	// extension forwards as `detached` before the detach RPC result settles.
+	const settleDetach = (id: number, tabId: number): void => {
+		ws.send(JSON.stringify({ t: "detached", tabId, reason: "target_closed" } satisfies ExtToRelayMessage));
+		ws.send(JSON.stringify({ t: "rpcResult", id, ok: true, result: {} } satisfies ExtToRelayMessage));
+	};
 	ws.addEventListener("message", event => {
 		const msg = JSON.parse(String(event.data)) as RelayToExtMessage;
 		if (msg.t !== "rpc") return;
 		const { id, t: _t, ...rpc } = msg;
 		rpcs.push(rpc);
-		// Mirror Chrome: chrome.debugger.detach() would fire onDetach, which the
-		// real extension forwards as `detached` before the RPC settles.
 		if (rpc.op === "detach") {
-			ws.send(JSON.stringify({ t: "detached", tabId: rpc.tabId, reason: "target_closed" } satisfies ExtToRelayMessage));
+			if (opts.deferDetach) withheld.push({ id, tabId: rpc.tabId });
+			else settleDetach(id, rpc.tabId);
+			return;
 		}
 		ws.send(JSON.stringify({ t: "rpcResult", id, ok: true, result: {} } satisfies ExtToRelayMessage));
 	});
@@ -188,7 +201,10 @@ async function connectScriptedExtension(port: number, tabs: TabSnapshot[]): Prom
 			attachedTabIds: [],
 		} satisfies ExtToRelayMessage),
 	);
-	return { ws, rpcs };
+	const flushDetach = (): void => {
+		for (const { id, tabId } of withheld.splice(0)) settleDetach(id, tabId);
+	};
+	return { ws, rpcs, flushDetach };
 }
 
 interface CdpResponse {
@@ -246,16 +262,19 @@ describe("browser relay session detach", () => {
 	// Two tabs so a later attach on tab 2 can serve as a deterministic marker:
 	// the ext socket is FIFO, so once the tab-2 attach round-trips, any upstream
 	// detach the tab-1 release dispatched is already recorded.
-	async function startReadyRelay(): Promise<{ port: number; rpcs: RelayRpcRequest[] }> {
+	async function startReadyRelay(
+		opts: { deferDetach?: boolean } = {},
+	): Promise<{ port: number; rpcs: RelayRpcRequest[]; ext: ScriptedExtension }> {
 		const port = await findFreeCdpPort();
 		relay = startRelayServer({ port });
-		const ext = await connectScriptedExtension(port, [
-			fakeTab(1, "https://one.example/"),
-			fakeTab(2, "https://two.example/"),
-		]);
+		const ext = await connectScriptedExtension(
+			port,
+			[fakeTab(1, "https://one.example/"), fakeTab(2, "https://two.example/")],
+			opts,
+		);
 		extension = ext.ws;
 		await waitForDiscovery(port);
-		return { port, rpcs: ext.rpcs };
+		return { port, rpcs: ext.rpcs, ext };
 	}
 
 	async function openClient(port: number): Promise<CdpClient> {
@@ -303,5 +322,29 @@ describe("browser relay session detach", () => {
 		const reattached = await client.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
 		expect(reattached.error).toBeUndefined();
 		expect(typeof reattached.result?.sessionId).toBe("string");
+	});
+
+	it("serializes a reattach behind an in-flight relay-initiated detach", async () => {
+		const { port, rpcs, ext } = await startReadyRelay({ deferDetach: true });
+		const a = await openClient(port);
+		const attached = await a.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+		// Release the last session; the detach RPC is now in flight (withheld).
+		await a.send("Target.detachFromTarget", { sessionId: attached.result?.sessionId });
+
+		// A second client reattaches while the detach is unresolved.
+		const b = await openClient(port);
+		const reattach = b.send("Target.attachToTarget", { targetId: "PAGE1", flatten: true });
+		// Browser.getVersion never parks, so once it replies the relay has already
+		// processed b's attach and is waiting on the pending detach: no new attach
+		// RPC has gone out yet — only the original one.
+		await b.send("Browser.getVersion");
+		expect(rpcs.filter(rpc => rpc.op === "attach" && rpc.tabId === 1)).toHaveLength(1);
+
+		// Settle the detach; the serialized reattach now proceeds and succeeds.
+		ext.flushDetach();
+		const reattached = await reattach;
+		expect(reattached.error).toBeUndefined();
+		expect(typeof reattached.result?.sessionId).toBe("string");
+		expect(rpcs.filter(rpc => rpc.op === "attach" && rpc.tabId === 1)).toHaveLength(2);
 	});
 });


### PR DESCRIPTION
## Repro
When the final downstream holder of a tab releases all its sessions with `Target.detachFromTarget` before disconnecting, the tab's `chrome.debugger` attachment stays alive — Chrome's "OMP Browser Relay started debugging this browser" infobar remains up while relay and extension are both connected. Reproduced with the reporter's scripted-extension harness (run in `packages/coding-agent`):

```
detach-then-close  → upstream detach(tab1): 0     ← attachment orphaned
close-while-holding → upstream detach(tab2): 1
```

## Cause
`RelayBridge.#releaseSession()` (`packages/coding-agent/src/tools/browser/relay/bridge.ts`) — the handler behind both `Target.detachFromTarget` variants — deleted the downstream pseudo-session and emitted `Target.detachedFromTarget` back to the client, but never checked remaining holders and never sent the upstream `{op: "detach"}` RPC. The only place that dropped the debugger was `cdpClosed()`, which iterates the sessions a *closing* connection still holds; a client that already released its sessions has nothing left to iterate, so the extension's attachment was left orphaned.

## Fix
- After `#releaseSession()` removes the session, apply the same zero-holders rule `cdpClosed()` already uses: if `#sessionHolders(tabId)` is empty and the tab is still attached, set `tab.attached = false` and send the upstream `{op: "detach"}` best-effort. It stays inert while the long-lived registry connection still holds a session on the tab, and fires when the final holder releases its last session.
- Added two regression tests in `test/tools/browser-relay-server.test.ts` driving a scripted extension: releasing the last session via `Target.detachFromTarget` sends exactly one upstream detach; releasing one session while another connection still holds one sends none.

## Verification
`bun test test/tools/browser-relay-server.test.ts` → 7 pass, 0 fail. `bun check` TypeScript passes clean; `check:rs` fails only because `cmake` is absent from this environment (`is cmake not installed?`) while building `audiopus_sys` — unrelated to this TypeScript-only change, so the pre-publish gate was skipped. Fixes #9613