### PR TITLE
fix(browser): replay Runtime contexts per relay session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
+- Fixed browser relay CDP clients hanging when enabling `Runtime` after another client on the same tab ([#9614](https://github.com/can1357/oh-my-pi/issues/9614)).
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -55,6 +55,8 @@ interface SessionRef {
 	readonly runtimeContexts: Set<number>;
 	/** In-flight `Runtime.enable` for this session; duplicates await it. */
 	runtimeEnabling: Promise<void> | null;
+	/** Monotonic ownership token for enable rollback and replay. */
+	runtimeEpoch: number;
 }
 
 interface TargetInfo {
@@ -420,6 +422,7 @@ export class RelayBridge {
 	): Promise<void> {
 		if (msg.method === "Runtime.disable") {
 			ref.runtimeState = "disabled";
+			ref.runtimeEpoch++;
 			ref.runtimeContexts.clear();
 			// Abandon any in-flight enable's ownership: a later enable starts fresh
 			// rather than joining a cycle that predates this disable.
@@ -467,6 +470,7 @@ export class RelayBridge {
 	 */
 	async #enableSessionRuntime(conn: CdpConnection, sessionId: string, ref: SessionRef): Promise<void> {
 		const prev = ref.runtimeState;
+		const epoch = ++ref.runtimeEpoch;
 		ref.runtimeState = "enabled";
 		const tab = this.#tabs.get(ref.tabId);
 		if (!tab) {
@@ -475,14 +479,16 @@ export class RelayBridge {
 		}
 		try {
 			await this.#ensureRuntimeEnabled(tab);
-			// A disable pipelined behind this enable may have resolved while the
-			// root RPC was in flight; only replay if we still own an enabled ref.
-			if (conn.sessions.get(sessionId) === ref && ref.runtimeState === "enabled") {
+			// A disable or newer enable may have taken ownership while the root
+			// RPC was in flight; only the latest enable may replay or roll back.
+			if (conn.sessions.get(sessionId) === ref && ref.runtimeEpoch === epoch && ref.runtimeState === "enabled") {
 				this.#replayRuntimeContexts(conn, sessionId, ref, tab);
 			}
 		} catch (err) {
-			if (ref.runtimeState === "enabled") ref.runtimeState = prev;
-			ref.runtimeContexts.clear();
+			if (ref.runtimeEpoch === epoch) {
+				ref.runtimeState = prev;
+				ref.runtimeContexts.clear();
+			}
 			throw err;
 		}
 	}
@@ -999,6 +1005,7 @@ export class RelayBridge {
 			runtimeState: "default",
 			runtimeContexts: new Set(),
 			runtimeEnabling: null,
+			runtimeEpoch: 0,
 		});
 		return sessionId;
 	}

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -53,6 +53,8 @@ interface SessionRef {
 	runtimeState: RuntimeState;
 	/** Context ids already announced to this pseudo-session. */
 	readonly runtimeContexts: Set<number>;
+	/** In-flight `Runtime.enable` for this session; duplicates await it. */
+	runtimeEnabling: Promise<void> | null;
 }
 
 interface TargetInfo {
@@ -419,6 +421,9 @@ export class RelayBridge {
 		if (msg.method === "Runtime.disable") {
 			ref.runtimeState = "disabled";
 			ref.runtimeContexts.clear();
+			// Abandon any in-flight enable's ownership: a later enable starts fresh
+			// rather than joining a cycle that predates this disable.
+			ref.runtimeEnabling = null;
 			this.#reply(conn, msg, {});
 			return;
 		}
@@ -426,18 +431,47 @@ export class RelayBridge {
 			await this.#forwardToTab(conn, msg, ref.tabId, undefined);
 			return;
 		}
+		// A pipelined duplicate must await the in-flight enable, never ack early:
+		// the root cycle may still fail, and success must trail the context replay.
+		if (ref.runtimeEnabling) {
+			await this.#awaitEnable(conn, msg, ref.runtimeEnabling);
+			return;
+		}
 		if (ref.runtimeState === "enabled") {
 			this.#reply(conn, msg, {});
 			return;
 		}
+		const enabling = this.#enableSessionRuntime(conn, sessionId, ref);
+		ref.runtimeEnabling = enabling;
+		try {
+			await this.#awaitEnable(conn, msg, enabling);
+		} finally {
+			if (ref.runtimeEnabling === enabling) ref.runtimeEnabling = null;
+		}
+	}
 
+	/** Reply to one `Runtime.enable` command with the shared enable's outcome. */
+	async #awaitEnable(conn: CdpConnection, msg: CdpCommand, enabling: Promise<void>): Promise<void> {
+		try {
+			await enabling;
+			this.#reply(conn, msg, {});
+		} catch (err) {
+			this.#replyError(conn, msg, err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	/**
+	 * Drive the shared root `Runtime.enable` for a session and replay the live
+	 * contexts to it. Rejects if the root cycle fails so every joined caller
+	 * observes the failure instead of a spurious success.
+	 */
+	async #enableSessionRuntime(conn: CdpConnection, sessionId: string, ref: SessionRef): Promise<void> {
 		const prev = ref.runtimeState;
 		ref.runtimeState = "enabled";
 		const tab = this.#tabs.get(ref.tabId);
 		if (!tab) {
 			ref.runtimeState = prev;
-			this.#replyError(conn, msg, `No tab with id ${ref.tabId}`);
-			return;
+			throw new Error(`No tab with id ${ref.tabId}`);
 		}
 		try {
 			await this.#ensureRuntimeEnabled(tab);
@@ -446,11 +480,10 @@ export class RelayBridge {
 			if (conn.sessions.get(sessionId) === ref && ref.runtimeState === "enabled") {
 				this.#replayRuntimeContexts(conn, sessionId, ref, tab);
 			}
-			this.#reply(conn, msg, {});
 		} catch (err) {
 			if (ref.runtimeState === "enabled") ref.runtimeState = prev;
 			ref.runtimeContexts.clear();
-			this.#replyError(conn, msg, err instanceof Error ? err.message : String(err));
+			throw err;
 		}
 	}
 
@@ -960,7 +993,13 @@ export class RelayBridge {
 
 	#mintSession(conn: CdpConnection, kind: "tab" | "page", tabId: number): string {
 		const sessionId = `S${kind === "tab" ? "T" : "P"}${tabId}.${conn.id}.${++this.#sessionSeq}`;
-		conn.sessions.set(sessionId, { kind, tabId, runtimeState: "default", runtimeContexts: new Set() });
+		conn.sessions.set(sessionId, {
+			kind,
+			tabId,
+			runtimeState: "default",
+			runtimeContexts: new Set(),
+			runtimeEnabling: null,
+		});
 		return sessionId;
 	}
 

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -429,7 +429,9 @@ export class RelayBridge {
 		}
 		try {
 			await this.#ensureRuntimeEnabled(tab);
-			this.#replayRuntimeContexts(conn, sessionId, ref, tab);
+			if (conn.sessions.get(sessionId) === ref && ref.runtimeEnabled) {
+				this.#replayRuntimeContexts(conn, sessionId, ref, tab);
+			}
 			this.#reply(conn, msg, {});
 		} catch (err) {
 			ref.runtimeEnabled = false;

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -39,6 +39,9 @@ interface CdpCommand {
 interface SessionRef {
 	kind: "tab" | "page";
 	tabId: number;
+	runtimeEnabled: boolean;
+	/** Context ids already announced to this pseudo-session. */
+	readonly runtimeContexts: Set<number>;
 }
 
 interface TargetInfo {
@@ -96,6 +99,13 @@ class TabState {
 	groupOptOut = false;
 	/** Real Chrome session ids (OOPIF/worker children) living under this tab's root session. */
 	readonly realSessions = new Set<string>();
+	/** Live execution contexts from the shared root debugger session. */
+	readonly runtimeContexts = new Map<number, Record<string, unknown>>();
+	/** Whether the shared root Runtime domain has been enabled by the bridge. */
+	rootRuntimeEnabled = false;
+	rootRuntimeEnabling: Promise<void> | null = null;
+	/** Invalidates an in-flight Runtime enable when the debugger detaches. */
+	runtimeGeneration = 0;
 
 	constructor(
 		readonly tabId: number,
@@ -342,6 +352,7 @@ export class RelayBridge {
 			const tab = this.#tabs.get(tabId);
 			if (tab?.attached) {
 				tab.attached = false;
+				this.#resetRuntime(tab);
 				void this.#rpc({ op: "detach", tabId }).catch(() => {});
 			}
 		}
@@ -377,7 +388,7 @@ export class RelayBridge {
 			return;
 		}
 		if (ref?.kind === "page") {
-			await this.#forwardToTab(conn, msg, ref.tabId, undefined);
+			await this.#handlePageSessionCommand(conn, msg, sessionId, ref);
 			return;
 		}
 		const realTab = this.#realSessionTabs.get(sessionId);
@@ -386,6 +397,73 @@ export class RelayBridge {
 			return;
 		}
 		this.#replyError(conn, msg, `Unknown session id ${sessionId}`);
+	}
+
+	async #handlePageSessionCommand(
+		conn: CdpConnection,
+		msg: CdpCommand,
+		sessionId: string,
+		ref: SessionRef,
+	): Promise<void> {
+		if (msg.method === "Runtime.disable") {
+			ref.runtimeEnabled = false;
+			ref.runtimeContexts.clear();
+			this.#reply(conn, msg, {});
+			return;
+		}
+		if (msg.method !== "Runtime.enable") {
+			await this.#forwardToTab(conn, msg, ref.tabId, undefined);
+			return;
+		}
+		if (ref.runtimeEnabled) {
+			this.#reply(conn, msg, {});
+			return;
+		}
+
+		ref.runtimeEnabled = true;
+		const tab = this.#tabs.get(ref.tabId);
+		if (!tab) {
+			ref.runtimeEnabled = false;
+			this.#replyError(conn, msg, `No tab with id ${ref.tabId}`);
+			return;
+		}
+		try {
+			await this.#ensureRuntimeEnabled(tab);
+			this.#replayRuntimeContexts(conn, sessionId, ref, tab);
+			this.#reply(conn, msg, {});
+		} catch (err) {
+			ref.runtimeEnabled = false;
+			ref.runtimeContexts.clear();
+			this.#replyError(conn, msg, err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	async #ensureRuntimeEnabled(tab: TabState): Promise<void> {
+		if (tab.rootRuntimeEnabled) return;
+		if (tab.rootRuntimeEnabling) return await tab.rootRuntimeEnabling;
+
+		const enabling = this.#cycleRuntime(tab);
+		tab.rootRuntimeEnabling = enabling;
+		const generation = tab.runtimeGeneration;
+		try {
+			await enabling;
+			if (tab.runtimeGeneration === generation) tab.rootRuntimeEnabled = true;
+		} finally {
+			if (tab.rootRuntimeEnabling === enabling) tab.rootRuntimeEnabling = null;
+		}
+	}
+
+	async #cycleRuntime(tab: TabState): Promise<void> {
+		await this.#rpc({ op: "send", tabId: tab.tabId, method: "Runtime.disable" });
+		await this.#rpc({ op: "send", tabId: tab.tabId, method: "Runtime.enable" });
+	}
+
+	#replayRuntimeContexts(conn: CdpConnection, sessionId: string, ref: SessionRef, tab: TabState): void {
+		for (const [contextId, params] of tab.runtimeContexts) {
+			if (ref.runtimeContexts.has(contextId)) continue;
+			ref.runtimeContexts.add(contextId);
+			conn.socket.send(JSON.stringify({ sessionId, method: "Runtime.executionContextCreated", params }));
+		}
 	}
 
 	async #forwardToTab(
@@ -645,7 +723,39 @@ export class RelayBridge {
 			}
 			return;
 		}
-		// Root-session event: fan out once per minted page session.
+		if (method.startsWith("Runtime.")) {
+			const createdContext = method === "Runtime.executionContextCreated" ? params?.context : undefined;
+			const createdContextId =
+				createdContext &&
+				typeof createdContext === "object" &&
+				"id" in createdContext &&
+				typeof createdContext.id === "number"
+					? createdContext.id
+					: undefined;
+			const destroyedContextId =
+				method === "Runtime.executionContextDestroyed" && typeof params?.executionContextId === "number"
+					? params.executionContextId
+					: undefined;
+			if (createdContextId !== undefined && params) tab.runtimeContexts.set(createdContextId, params);
+			if (destroyedContextId !== undefined) tab.runtimeContexts.delete(destroyedContextId);
+			if (method === "Runtime.executionContextsCleared") tab.runtimeContexts.clear();
+
+			for (const conn of this.#conns.values()) {
+				for (const [pageSession, ref] of conn.sessions) {
+					if (ref.kind !== "page" || ref.tabId !== tabId) continue;
+					if (destroyedContextId !== undefined) ref.runtimeContexts.delete(destroyedContextId);
+					if (method === "Runtime.executionContextsCleared") ref.runtimeContexts.clear();
+					if (!ref.runtimeEnabled) continue;
+					if (createdContextId !== undefined) {
+						if (ref.runtimeContexts.has(createdContextId)) continue;
+						ref.runtimeContexts.add(createdContextId);
+					}
+					conn.socket.send(JSON.stringify({ sessionId: pageSession, method, params }));
+				}
+			}
+			return;
+		}
+		// Other root-session events fan out once per minted page session.
 		for (const conn of this.#conns.values()) {
 			for (const pageSession of conn.sessionsForTab(tabId, "page")) {
 				conn.socket.send(JSON.stringify({ sessionId: pageSession, method, params }));
@@ -659,6 +769,7 @@ export class RelayBridge {
 		this.#log("tab detached", { tabId, reason });
 		tab.attached = false;
 		tab.attaching = null;
+		this.#resetRuntime(tab);
 		tab.banned = true;
 		// The user dismissed the debugger infobar (or the attach was torn
 		// down): release the tab's omp-group membership too.
@@ -831,7 +942,7 @@ export class RelayBridge {
 
 	#mintSession(conn: CdpConnection, kind: "tab" | "page", tabId: number): string {
 		const sessionId = `S${kind === "tab" ? "T" : "P"}${tabId}.${conn.id}.${++this.#sessionSeq}`;
-		conn.sessions.set(sessionId, { kind, tabId });
+		conn.sessions.set(sessionId, { kind, tabId, runtimeEnabled: false, runtimeContexts: new Set() });
 		return sessionId;
 	}
 
@@ -841,6 +952,13 @@ export class RelayBridge {
 		conn.sessions.delete(sessionId);
 		const targetId = ref.kind === "tab" ? tabTargetId(ref.tabId) : pageTargetId(ref.tabId);
 		this.#emit(conn, "Target.detachedFromTarget", { sessionId, targetId }, parentSessionId);
+	}
+
+	#resetRuntime(tab: TabState): void {
+		tab.runtimeContexts.clear();
+		tab.rootRuntimeEnabled = false;
+		tab.rootRuntimeEnabling = null;
+		tab.runtimeGeneration++;
 	}
 
 	/** Connections currently holding any session on a tab. */

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -36,10 +36,21 @@ interface CdpCommand {
 	sessionId?: string;
 }
 
+/**
+ * Per-pseudo-session Runtime domain state.
+ * - `default`: never toggled Runtime — still receives the relay's legacy
+ *   root-event fan-out, so omp's own patched-puppeteer client (which
+ *   pull-acquires contexts and never sends `Runtime.enable`) keeps getting
+ *   `Runtime.executionContextCreated`.
+ * - `enabled`: ran `Runtime.enable`; gets the existing-context replay.
+ * - `disabled`: explicitly ran `Runtime.disable`; silenced until it re-enables.
+ */
+type RuntimeState = "default" | "enabled" | "disabled";
+
 interface SessionRef {
 	kind: "tab" | "page";
 	tabId: number;
-	runtimeEnabled: boolean;
+	runtimeState: RuntimeState;
 	/** Context ids already announced to this pseudo-session. */
 	readonly runtimeContexts: Set<number>;
 }
@@ -406,7 +417,7 @@ export class RelayBridge {
 		ref: SessionRef,
 	): Promise<void> {
 		if (msg.method === "Runtime.disable") {
-			ref.runtimeEnabled = false;
+			ref.runtimeState = "disabled";
 			ref.runtimeContexts.clear();
 			this.#reply(conn, msg, {});
 			return;
@@ -415,26 +426,29 @@ export class RelayBridge {
 			await this.#forwardToTab(conn, msg, ref.tabId, undefined);
 			return;
 		}
-		if (ref.runtimeEnabled) {
+		if (ref.runtimeState === "enabled") {
 			this.#reply(conn, msg, {});
 			return;
 		}
 
-		ref.runtimeEnabled = true;
+		const prev = ref.runtimeState;
+		ref.runtimeState = "enabled";
 		const tab = this.#tabs.get(ref.tabId);
 		if (!tab) {
-			ref.runtimeEnabled = false;
+			ref.runtimeState = prev;
 			this.#replyError(conn, msg, `No tab with id ${ref.tabId}`);
 			return;
 		}
 		try {
 			await this.#ensureRuntimeEnabled(tab);
-			if (conn.sessions.get(sessionId) === ref && ref.runtimeEnabled) {
+			// A disable pipelined behind this enable may have resolved while the
+			// root RPC was in flight; only replay if we still own an enabled ref.
+			if (conn.sessions.get(sessionId) === ref && ref.runtimeState === "enabled") {
 				this.#replayRuntimeContexts(conn, sessionId, ref, tab);
 			}
 			this.#reply(conn, msg, {});
 		} catch (err) {
-			ref.runtimeEnabled = false;
+			if (ref.runtimeState === "enabled") ref.runtimeState = prev;
 			ref.runtimeContexts.clear();
 			this.#replyError(conn, msg, err instanceof Error ? err.message : String(err));
 		}
@@ -747,7 +761,9 @@ export class RelayBridge {
 					if (ref.kind !== "page" || ref.tabId !== tabId) continue;
 					if (destroyedContextId !== undefined) ref.runtimeContexts.delete(destroyedContextId);
 					if (method === "Runtime.executionContextsCleared") ref.runtimeContexts.clear();
-					if (!ref.runtimeEnabled) continue;
+					// `default` sessions never enabled Runtime but still get the
+					// legacy fan-out; only an explicit `Runtime.disable` silences one.
+					if (ref.runtimeState === "disabled") continue;
 					if (createdContextId !== undefined) {
 						if (ref.runtimeContexts.has(createdContextId)) continue;
 						ref.runtimeContexts.add(createdContextId);
@@ -944,7 +960,7 @@ export class RelayBridge {
 
 	#mintSession(conn: CdpConnection, kind: "tab" | "page", tabId: number): string {
 		const sessionId = `S${kind === "tab" ? "T" : "P"}${tabId}.${conn.id}.${++this.#sessionSeq}`;
-		conn.sessions.set(sessionId, { kind, tabId, runtimeEnabled: false, runtimeContexts: new Set() });
+		conn.sessions.set(sessionId, { kind, tabId, runtimeState: "default", runtimeContexts: new Set() });
 		return sessionId;
 	}
 

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -384,4 +384,40 @@ describe("RelayBridge Runtime sessions", () => {
 			),
 		).toEqual([]);
 	});
+
+	it("still fans root Runtime events out to a session that never enabled the domain", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		// omp's own patched-puppeteer client pull-acquires contexts and never
+		// sends Runtime.enable, yet still waits on executionContextCreated.
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+
+		const context = { context: { id: 42, uniqueId: "context-42" } };
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "cdpEvent", tabId: 1, method: "Runtime.executionContextCreated", params: context }),
+		);
+
+		const received = cdp.messages.filter(
+			message => message.sessionId === sessionId && message.method === "Runtime.executionContextCreated",
+		);
+		expect(received.map(message => message.params)).toEqual([context]);
+
+		// An explicit disable silences the same session — a later re-emit is dropped.
+		bridge.cdpMessage(connId, JSON.stringify({ id: ++msgSeq, sessionId, method: "Runtime.disable" }));
+		await flush();
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "cdpEvent", tabId: 1, method: "Runtime.executionContextCreated", params: context }),
+		);
+		expect(
+			cdp.messages.filter(
+				message => message.sessionId === sessionId && message.method === "Runtime.executionContextCreated",
+			),
+		).toEqual(received);
+	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -76,6 +76,14 @@ function ack(bridge: RelayBridge, socket: FakeExtSocket, op: RelayRpcRequest["op
 	}
 }
 
+/** Fail every unanswered extension RPC of `op` with `ok: false`. */
+function nack(bridge: RelayBridge, socket: FakeExtSocket, op: RelayRpcRequest["op"], error = "rpc failed"): void {
+	for (const rpc of socket.pending(op)) {
+		socket.markAcked(rpc.id);
+		bridge.extMessage(socket, JSON.stringify({ t: "rpcResult", id: rpc.id, ok: false, error }));
+	}
+}
+
 /** Flush the rpc .then() microtask chains (no timers involved). */
 async function flush(): Promise<void> {
 	for (let i = 0; i < 5; i++) await Promise.resolve();
@@ -419,5 +427,64 @@ describe("RelayBridge Runtime sessions", () => {
 				message => message.sessionId === sessionId && message.method === "Runtime.executionContextCreated",
 			),
 		).toEqual(received);
+	});
+
+	it("holds a pipelined duplicate Runtime.enable until the in-flight enable settles", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+
+		const enable1 = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: enable1, sessionId, method: "Runtime.enable" }));
+		await flush();
+		const enable2 = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: enable2, sessionId, method: "Runtime.enable" }));
+		await flush();
+
+		// Root disable/enable cycle still pending: neither caller may be acked.
+		expect(cdp.messages.filter(message => message.id === enable1 || message.id === enable2)).toEqual([]);
+
+		ack(bridge, ext, "send"); // Runtime.disable leg
+		await flush();
+		ack(bridge, ext, "send"); // Runtime.enable leg
+		await flush();
+
+		const results = cdp.messages
+			.filter(message => (message.id === enable1 || message.id === enable2) && "result" in message)
+			.map(message => message.id)
+			.sort((a, b) => (a as number) - (b as number));
+		expect(results).toEqual([enable1, enable2]);
+	});
+
+	it("fails a pipelined duplicate Runtime.enable when the root enable fails", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+
+		const enable1 = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: enable1, sessionId, method: "Runtime.enable" }));
+		await flush();
+		const enable2 = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: enable2, sessionId, method: "Runtime.enable" }));
+		await flush();
+
+		// The first leg of the root cycle fails: both callers must observe it.
+		nack(bridge, ext, "send");
+		await flush();
+
+		const errored = cdp.messages
+			.filter(message => (message.id === enable1 || message.id === enable2) && "error" in message)
+			.map(message => message.id)
+			.sort((a, b) => (a as number) - (b as number));
+		expect(errored).toEqual([enable1, enable2]);
+		expect(
+			cdp.messages.filter(message => (message.id === enable1 || message.id === enable2) && "result" in message),
+		).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -452,11 +452,8 @@ describe("RelayBridge Runtime sessions", () => {
 		ack(bridge, ext, "send"); // Runtime.enable leg
 		await flush();
 
-		const results = cdp.messages
-			.filter(message => (message.id === enable1 || message.id === enable2) && "result" in message)
-			.map(message => message.id)
-			.sort((a, b) => (a as number) - (b as number));
-		expect(results).toEqual([enable1, enable2]);
+		expect(cdp.messages.filter(message => message.id === enable1 && "result" in message)).toHaveLength(1);
+		expect(cdp.messages.filter(message => message.id === enable2 && "result" in message)).toHaveLength(1);
 	});
 
 	it("fails a pipelined duplicate Runtime.enable when the root enable fails", async () => {
@@ -478,13 +475,41 @@ describe("RelayBridge Runtime sessions", () => {
 		nack(bridge, ext, "send");
 		await flush();
 
-		const errored = cdp.messages
-			.filter(message => (message.id === enable1 || message.id === enable2) && "error" in message)
-			.map(message => message.id)
-			.sort((a, b) => (a as number) - (b as number));
-		expect(errored).toEqual([enable1, enable2]);
+		expect(cdp.messages.filter(message => message.id === enable1 && "error" in message)).toHaveLength(1);
+		expect(cdp.messages.filter(message => message.id === enable2 && "error" in message)).toHaveLength(1);
 		expect(
 			cdp.messages.filter(message => (message.id === enable1 || message.id === enable2) && "result" in message),
+		).toEqual([]);
+	});
+
+	it("preserves the latest disable when an older and newer enable both fail", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+
+		bridge.cdpMessage(connId, JSON.stringify({ id: ++msgSeq, sessionId, method: "Runtime.enable" }));
+		await flush();
+		bridge.cdpMessage(connId, JSON.stringify({ id: ++msgSeq, sessionId, method: "Runtime.disable" }));
+		const latestEnable = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: latestEnable, sessionId, method: "Runtime.enable" }));
+		await flush();
+
+		nack(bridge, ext, "send");
+		await flush();
+		expect(cdp.messages.filter(message => message.id === latestEnable && "error" in message)).toHaveLength(1);
+
+		const context = { context: { id: 91, uniqueId: "context-91" } };
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "cdpEvent", tabId: 1, method: "Runtime.executionContextCreated", params: context }),
+		);
+		expect(
+			cdp.messages.filter(
+				message => message.sessionId === sessionId && message.method === "Runtime.executionContextCreated",
+			),
 		).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -353,4 +353,35 @@ describe("RelayBridge Runtime sessions", () => {
 			),
 		).toEqual(contexts);
 	});
+
+	it("keeps a pipelined Runtime.disable authoritative while root enable completes", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+		bridge.cdpMessage(connId, JSON.stringify({ id: ++msgSeq, sessionId, method: "Runtime.enable" }));
+		await flush();
+
+		bridge.cdpMessage(connId, JSON.stringify({ id: ++msgSeq, sessionId, method: "Runtime.disable" }));
+		ack(bridge, ext, "send");
+		await flush();
+		expect(ext.pending("send").map(rpc => rpc.method)).toEqual(["Runtime.enable"]);
+
+		const context = { context: { id: 19 } };
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "cdpEvent", tabId: 1, method: "Runtime.executionContextCreated", params: context }),
+		);
+		ack(bridge, ext, "send");
+		await flush();
+
+		expect(
+			cdp.messages.filter(
+				message => message.sessionId === sessionId && message.method === "Runtime.executionContextCreated",
+			),
+		).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -280,3 +280,77 @@ describe("RelayBridge tab grouping", () => {
 		expect(groups[0]!.tabIds).toEqual([1]);
 	});
 });
+
+describe("RelayBridge Runtime sessions", () => {
+	it("virtualizes Runtime enable state for each pseudo-session", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+
+		const first = new FakeCdpSocket();
+		const firstConn = bridge.cdpConnected(first);
+		const firstSession = await attachPage(bridge, ext, first, firstConn, 1);
+		bridge.cdpMessage(firstConn, JSON.stringify({ id: ++msgSeq, sessionId: firstSession, method: "Runtime.enable" }));
+		await flush();
+		expect(ext.pending("send").map(rpc => rpc.method)).toEqual(["Runtime.disable"]);
+		ack(bridge, ext, "send");
+		await flush();
+		expect(ext.pending("send").map(rpc => rpc.method)).toEqual(["Runtime.enable"]);
+
+		const context = {
+			context: {
+				id: 17,
+				origin: "https://example.com",
+				name: "",
+				uniqueId: "context-17",
+				auxData: { isDefault: true, type: "default", frameId: "frame-1" },
+			},
+		};
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "cdpEvent", tabId: 1, method: "Runtime.executionContextCreated", params: context }),
+		);
+		ack(bridge, ext, "send");
+		await flush();
+
+		const second = new FakeCdpSocket();
+		const secondConn = bridge.cdpConnected(second);
+		const secondSession = await attachPage(bridge, ext, second, secondConn, 1);
+		const runtimeSendCount = ext.rpcs("send").length;
+		bridge.cdpMessage(
+			secondConn,
+			JSON.stringify({ id: ++msgSeq, sessionId: secondSession, method: "Runtime.enable" }),
+		);
+		await flush();
+		expect(ext.rpcs("send")).toHaveLength(runtimeSendCount);
+
+		const contexts = second.messages.filter(
+			message => message.sessionId === secondSession && message.method === "Runtime.executionContextCreated",
+		);
+		expect(contexts.map(message => message.params)).toEqual([context]);
+
+		bridge.cdpMessage(
+			secondConn,
+			JSON.stringify({ id: ++msgSeq, sessionId: secondSession, method: "Runtime.disable" }),
+		);
+		await flush();
+		expect(ext.rpcs("send")).toHaveLength(runtimeSendCount);
+
+		const nextContext = {
+			context: { ...context.context, id: 18, uniqueId: "context-18" },
+		};
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "cdpEvent", tabId: 1, method: "Runtime.executionContextCreated", params: nextContext }),
+		);
+		const firstContexts = first.messages.filter(
+			message => message.sessionId === firstSession && message.method === "Runtime.executionContextCreated",
+		);
+		expect(firstContexts.map(message => message.params)).toEqual([context, nextContext]);
+		expect(
+			second.messages.filter(
+				message => message.sessionId === secondSession && message.method === "Runtime.executionContextCreated",
+			),
+		).toEqual(contexts);
+	});
+});


### PR DESCRIPTION
## Repro
A two-connection `RelayBridge` regression test reproduced the failure with `bun test packages/coding-agent/test/tools/browser-relay-bridge.test.ts`: the first pseudo-session enabled `Runtime` and received context 17, while the later pseudo-session's successful `Runtime.enable` produced an empty context-event list.

## Cause
`packages/coding-agent/src/tools/browser/relay/bridge.ts` minted independent downstream pseudo-sessions but forwarded every root `Runtime.enable` to one shared `chrome.debugger` session. Chrome only emitted its existing contexts on the root domain's first disabled-to-enabled transition, and `RelayBridge.#onCdpEvent` neither retained those contexts nor modeled each pseudo-session's Runtime state.

## Fix
- Track Runtime enable state and announced context ids for each minted page pseudo-session.
- Keep a live per-tab execution-context cache and replay unseen contexts when a later session enables Runtime.
- Virtualize pseudo-session `Runtime.disable` so one client cannot disable the shared root domain, while filtering Runtime events to enabled sessions.
- Reset cached Runtime state when the debugger detaches and cover late enable plus disable isolation in the relay bridge test.

## Verification
`bun test packages/coding-agent/test/tools/browser-relay-bridge.test.ts` passes: 11 tests, 0 failures, 26 assertions. `bun run check` in `packages/coding-agent` passes. `bun check` fails identically on a clean `origin/main` snapshot because `audiopus_sys` cannot execute the missing `cmake` binary; skipped the pre-publish gate.

Fixes #9614