### PR TITLE
fix(browser): release relay attachment on explicit session detach

### DIFF
--- a/packages/browser-relay/extension/background.ts
+++ b/packages/browser-relay/extension/background.ts
@@ -19,6 +19,7 @@ const RECONNECT_MAX_MS = 10_000;
 let ws: WebSocket | null = null;
 let reconnectDelay = RECONNECT_MIN_MS;
 let pingTimer: NodeJS.Timeout | null = null;
+const relayInitiatedDetachTabs = new Set<number>();
 
 interface RelaySettings {
 	port: number;
@@ -157,8 +158,14 @@ async function runRpc(msg: Extract<RelayToExtMessage, { t: "rpc" }>): Promise<un
 			await chrome.debugger.attach({ tabId: msg.tabId }, "1.3");
 			return {};
 		case "detach":
-			await chrome.debugger.detach({ tabId: msg.tabId });
-			return {};
+			relayInitiatedDetachTabs.add(msg.tabId);
+			try {
+				await chrome.debugger.detach({ tabId: msg.tabId });
+				return {};
+			} catch (error) {
+				relayInitiatedDetachTabs.delete(msg.tabId);
+				throw error;
+			}
 		case "send":
 			return await chrome.debugger.sendCommand(
 				msg.sessionId ? { tabId: msg.tabId, sessionId: msg.sessionId } : { tabId: msg.tabId },
@@ -250,7 +257,8 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
 
 chrome.debugger.onDetach.addListener((source, reason) => {
 	if (source.tabId === undefined) return;
-	post({ t: "detached", tabId: source.tabId, reason });
+	const relayInitiated = relayInitiatedDetachTabs.delete(source.tabId);
+	post({ t: "detached", tabId: source.tabId, reason, relayInitiated });
 });
 
 chrome.tabs.onCreated.addListener(tab => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed the browser relay leaving Chrome's debugging infobar up after a client released a tab's last session with `Target.detachFromTarget`: the attachment is now dropped, so dismissing a stale infobar no longer blocks the relay from driving that tab ([#9613](https://github.com/can1357/oh-my-pi/issues/9613))
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -211,10 +211,19 @@ export class RelayBridge {
 
 	// ---- extension lifecycle -------------------------------------------------
 
+	#rejectPendingExtensionRpcs(message: string): void {
+		for (const pending of this.#pendingRpc.values()) {
+			clearTimeout(pending.timer);
+			pending.reject(new Error(message));
+		}
+		this.#pendingRpc.clear();
+	}
+
 	/** A new extension socket connected; replaces any previous one. */
 	extConnected(socket: RelaySocket): void {
 		if (this.#ext && this.#ext !== socket) {
 			this.#log("replacing extension socket");
+			this.#rejectPendingExtensionRpcs("relay extension replaced");
 			this.#ext.close();
 		}
 		this.#ext = socket;
@@ -224,11 +233,7 @@ export class RelayBridge {
 		if (this.#ext !== socket) return;
 		this.#ext = null;
 		this.#extInfo = null;
-		for (const pending of this.#pendingRpc.values()) {
-			clearTimeout(pending.timer);
-			pending.reject(new Error("relay extension disconnected"));
-		}
-		this.#pendingRpc.clear();
+		this.#rejectPendingExtensionRpcs("relay extension disconnected");
 		for (const tab of this.#tabs.values()) {
 			tab.attached = false;
 			tab.attaching = null;

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -87,6 +87,8 @@ class TabState {
 	/** Whether targets for this tab were announced to discovering connections. */
 	announced = false;
 	attaching: Promise<boolean> | null = null;
+	/** Relay-initiated detach in flight; reattach serializes behind it. */
+	detaching: Promise<void> | null = null;
 	/** True after the relay put this tab in the omp group; `ompGroupId` holds that group. */
 	grouped = false;
 	/** Group RPC in flight — suppresses duplicate requests from load-time tabUpdated bursts. */
@@ -649,6 +651,13 @@ export class RelayBridge {
 	#onTabDetached(tabId: number, reason: string): void {
 		const tab = this.#tabs.get(tabId);
 		if (!tab) return;
+		// chrome.debugger.detach emits onDetach before its RPC result. A release
+		// we initiated clears attached first, so its echo is expected — banning
+		// here would retract a live target and block its next attachment.
+		if (!tab.attached) {
+			tab.attaching = null;
+			return;
+		}
 		this.#log("tab detached", { tabId, reason });
 		tab.attached = false;
 		tab.attaching = null;
@@ -841,7 +850,7 @@ export class RelayBridge {
 	}
 
 	/**
-	 * Release the tab's `chrome.debugger` attachment once no downstream session
+	 * Release the tab's chrome.debugger attachment once no downstream session
 	 * holds it. Inert while the long-lived registry connection still holds one.
 	 */
 	#detachIfUnheld(tabId: number): void {
@@ -849,7 +858,13 @@ export class RelayBridge {
 		const tab = this.#tabs.get(tabId);
 		if (!tab?.attached) return;
 		tab.attached = false;
-		void this.#rpc({ op: "detach", tabId }).catch(() => {});
+		const done = this.#rpc({ op: "detach", tabId })
+			.then(() => {})
+			.catch(() => {})
+			.finally(() => {
+				if (tab.detaching === done) tab.detaching = null;
+			});
+		tab.detaching = done;
 	}
 
 	/** Connections currently holding any session on a tab. */
@@ -872,6 +887,9 @@ export class RelayBridge {
 	}
 
 	async #ensureAttached(tab: TabState): Promise<boolean> {
+		// The extension emits the detach echo before resolving the RPC. Awaiting
+		// prevents a replacement attach racing either operation.
+		while (tab.detaching) await tab.detaching;
 		if (tab.attached) return true;
 		if (tab.banned || !this.#ext) return false;
 		if (tab.attaching) return await tab.attaching;

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -337,14 +337,7 @@ export class RelayBridge {
 		}
 		conn.claims.clear();
 		// Drop the debugger (and its infobar) from tabs nobody drives anymore.
-		for (const tabId of touched) {
-			if (this.#sessionHolders(tabId).length > 0) continue;
-			const tab = this.#tabs.get(tabId);
-			if (tab?.attached) {
-				tab.attached = false;
-				void this.#rpc({ op: "detach", tabId }).catch(() => {});
-			}
-		}
+		for (const tabId of touched) this.#detachIfUnheld(tabId);
 		this.#log("cdp client closed", { conn: connId });
 	}
 
@@ -841,6 +834,22 @@ export class RelayBridge {
 		conn.sessions.delete(sessionId);
 		const targetId = ref.kind === "tab" ? tabTargetId(ref.tabId) : pageTargetId(ref.tabId);
 		this.#emit(conn, "Target.detachedFromTarget", { sessionId, targetId }, parentSessionId);
+		// An explicit release of the last session must drop the attachment too,
+		// or it outlives every downstream session: the infobar stays up, and
+		// dismissing it bans the tab for the rest of the epoch.
+		this.#detachIfUnheld(ref.tabId);
+	}
+
+	/**
+	 * Release the tab's `chrome.debugger` attachment once no downstream session
+	 * holds it. Inert while the long-lived registry connection still holds one.
+	 */
+	#detachIfUnheld(tabId: number): void {
+		if (this.#sessionHolders(tabId).length > 0) return;
+		const tab = this.#tabs.get(tabId);
+		if (!tab?.attached) return;
+		tab.attached = false;
+		void this.#rpc({ op: "detach", tabId }).catch(() => {});
 	}
 
 	/** Connections currently holding any session on a tab. */

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -651,10 +651,10 @@ export class RelayBridge {
 	#onTabDetached(tabId: number, reason: string): void {
 		const tab = this.#tabs.get(tabId);
 		if (!tab) return;
-		// chrome.debugger.detach emits onDetach before its RPC result. A release
-		// we initiated clears attached first, so its echo is expected — banning
-		// here would retract a live target and block its next attachment.
-		if (!tab.attached) {
+		// chrome.debugger.detach emits onDetach before its RPC result. Only a
+		// detach we explicitly track is an expected echo; attached=false alone
+		// also describes a failed restart reattachment, which must retract.
+		if (tab.detaching) {
 			tab.attaching = null;
 			return;
 		}

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -89,9 +89,6 @@ class TabState {
 	attaching: Promise<boolean> | null = null;
 	/** Relay-initiated detach in flight; reattach serializes behind it. */
 	detaching: Promise<void> | null = null;
-	/** Expected chrome.debugger.onDetach echo, independent of the RPC wait. */
-	expectingDetachEcho = false;
-	detachEchoTimer: NodeJS.Timeout | null = null;
 	/** True after the relay put this tab in the omp group; `ompGroupId` holds that group. */
 	grouped = false;
 	/** Group RPC in flight — suppresses duplicate requests from load-time tabUpdated bursts. */
@@ -277,7 +274,7 @@ export class RelayBridge {
 				this.#onCdpEvent(msg.tabId, msg.sessionId, msg.method, msg.params);
 				return;
 			case "detached":
-				this.#onTabDetached(msg.tabId, msg.reason);
+				this.#onTabDetached(msg.tabId, msg.reason, msg.relayInitiated === true);
 				return;
 			case "tabCreated":
 				this.#onTabUpsert(msg.tab);
@@ -313,7 +310,7 @@ export class RelayBridge {
 			// connections still hold sessions: restore them best-effort.
 			if (wasAttached && !tab.attached && this.#sessionHolders(tab.tabId).length > 0) {
 				void this.#ensureAttached(tab).then(ok => {
-					if (!ok) this.#onTabDetached(tab.tabId, "reattach_failed");
+					if (!ok) this.#onTabDetached(tab.tabId, "reattach_failed", false);
 				});
 			}
 		}
@@ -656,18 +653,13 @@ export class RelayBridge {
 		}
 	}
 
-	#onTabDetached(tabId: number, reason: string): void {
+	#onTabDetached(tabId: number, reason: string, relayInitiated: boolean): void {
 		const tab = this.#tabs.get(tabId);
 		if (!tab) return;
-		// Relay-initiated detach can outlive its RPC/socket. Keep callback
-		// correlation separate from the promise used to serialize reattach.
-		if (tab.expectingDetachEcho) {
-			tab.expectingDetachEcho = false;
-			if (tab.detachEchoTimer) clearTimeout(tab.detachEchoTimer);
-			tab.detachEchoTimer = null;
-			tab.attaching = null;
-			return;
-		}
+		// Explicit source attribution comes from the extension that executed
+		// chrome.debugger.detach, so socket replacement cannot confuse this
+		// with a user cancellation or mutate an unrelated attach promise.
+		if (relayInitiated) return;
 		this.#log("tab detached", { tabId, reason });
 		tab.attached = false;
 		tab.attaching = null;
@@ -684,7 +676,6 @@ export class RelayBridge {
 		this.#retractTab(tab);
 		this.#tabs.delete(tabId);
 		for (const conn of this.#conns.values()) conn.claims.delete(tabId);
-		if (tab.detachEchoTimer) clearTimeout(tab.detachEchoTimer);
 	}
 
 	#onTabUpsert(snap: TabSnapshot, opts: { silent?: boolean } = {}): void {
@@ -869,13 +860,6 @@ export class RelayBridge {
 		const tab = this.#tabs.get(tabId);
 		if (!tab?.attached) return;
 		tab.attached = false;
-		tab.expectingDetachEcho = true;
-		if (tab.detachEchoTimer) clearTimeout(tab.detachEchoTimer);
-		tab.detachEchoTimer = setTimeout(() => {
-			tab.expectingDetachEcho = false;
-			tab.detachEchoTimer = null;
-		}, RPC_TIMEOUT_MS);
-		tab.detachEchoTimer.unref();
 		const done = this.#rpc({ op: "detach", tabId })
 			.then(() => {})
 			.catch(() => {})

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -89,6 +89,9 @@ class TabState {
 	attaching: Promise<boolean> | null = null;
 	/** Relay-initiated detach in flight; reattach serializes behind it. */
 	detaching: Promise<void> | null = null;
+	/** Expected chrome.debugger.onDetach echo, independent of the RPC wait. */
+	expectingDetachEcho = false;
+	detachEchoTimer: NodeJS.Timeout | null = null;
 	/** True after the relay put this tab in the omp group; `ompGroupId` holds that group. */
 	grouped = false;
 	/** Group RPC in flight — suppresses duplicate requests from load-time tabUpdated bursts. */
@@ -656,10 +659,12 @@ export class RelayBridge {
 	#onTabDetached(tabId: number, reason: string): void {
 		const tab = this.#tabs.get(tabId);
 		if (!tab) return;
-		// chrome.debugger.detach emits onDetach before its RPC result. Only a
-		// detach we explicitly track is an expected echo; attached=false alone
-		// also describes a failed restart reattachment, which must retract.
-		if (tab.detaching) {
+		// Relay-initiated detach can outlive its RPC/socket. Keep callback
+		// correlation separate from the promise used to serialize reattach.
+		if (tab.expectingDetachEcho) {
+			tab.expectingDetachEcho = false;
+			if (tab.detachEchoTimer) clearTimeout(tab.detachEchoTimer);
+			tab.detachEchoTimer = null;
 			tab.attaching = null;
 			return;
 		}
@@ -679,6 +684,7 @@ export class RelayBridge {
 		this.#retractTab(tab);
 		this.#tabs.delete(tabId);
 		for (const conn of this.#conns.values()) conn.claims.delete(tabId);
+		if (tab.detachEchoTimer) clearTimeout(tab.detachEchoTimer);
 	}
 
 	#onTabUpsert(snap: TabSnapshot, opts: { silent?: boolean } = {}): void {
@@ -863,6 +869,13 @@ export class RelayBridge {
 		const tab = this.#tabs.get(tabId);
 		if (!tab?.attached) return;
 		tab.attached = false;
+		tab.expectingDetachEcho = true;
+		if (tab.detachEchoTimer) clearTimeout(tab.detachEchoTimer);
+		tab.detachEchoTimer = setTimeout(() => {
+			tab.expectingDetachEcho = false;
+			tab.detachEchoTimer = null;
+		}, RPC_TIMEOUT_MS);
+		tab.detachEchoTimer.unref();
 		const done = this.#rpc({ op: "detach", tabId })
 			.then(() => {})
 			.catch(() => {})

--- a/packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt
+++ b/packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt
@@ -6,6 +6,7 @@ var RECONNECT_MAX_MS = 1e4;
 var ws = null;
 var reconnectDelay = RECONNECT_MIN_MS;
 var pingTimer = null;
+var relayInitiatedDetachTabs = new Set;
 async function loadSettings() {
   const stored = await chrome.storage.local.get({ port: DEFAULT_PORT, token: "" });
   const port = Number(stored.port);
@@ -123,8 +124,14 @@ async function runRpc(msg) {
       await chrome.debugger.attach({ tabId: msg.tabId }, "1.3");
       return {};
     case "detach":
-      await chrome.debugger.detach({ tabId: msg.tabId });
-      return {};
+      relayInitiatedDetachTabs.add(msg.tabId);
+      try {
+        await chrome.debugger.detach({ tabId: msg.tabId });
+        return {};
+      } catch (error) {
+        relayInitiatedDetachTabs.delete(msg.tabId);
+        throw error;
+      }
     case "send":
       return await chrome.debugger.sendCommand(msg.sessionId ? { tabId: msg.tabId, sessionId: msg.sessionId } : { tabId: msg.tabId }, msg.method, msg.params);
     case "createTab": {
@@ -210,7 +217,8 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
 chrome.debugger.onDetach.addListener((source, reason) => {
   if (source.tabId === undefined)
     return;
-  post({ t: "detached", tabId: source.tabId, reason });
+  const relayInitiated = relayInitiatedDetachTabs.delete(source.tabId);
+  post({ t: "detached", tabId: source.tabId, reason, relayInitiated });
 });
 chrome.tabs.onCreated.addListener((tab) => {
   const snap = snapshot(tab);

--- a/packages/coding-agent/src/tools/browser/relay/protocol.ts
+++ b/packages/coding-agent/src/tools/browser/relay/protocol.ts
@@ -46,7 +46,7 @@ export type ExtToRelayMessage =
 			attachedTabIds: number[];
 	  }
 	| { t: "cdpEvent"; tabId: number; sessionId?: string; method: string; params?: Record<string, unknown> }
-	| { t: "detached"; tabId: number; reason: string }
+	| { t: "detached"; tabId: number; reason: string; relayInitiated?: boolean }
 	| { t: "tabCreated"; tab: TabSnapshot }
 	| { t: "tabUpdated"; tab: TabSnapshot }
 	| { t: "tabRemoved"; tabId: number }

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -88,6 +88,14 @@ function ack(bridge: RelayBridge, socket: FakeExtSocket, op: RelayRpcRequest["op
 	}
 }
 
+/** Reject every unanswered extension RPC of op. */
+function reject(bridge: RelayBridge, socket: FakeExtSocket, op: RelayRpcRequest["op"], error: string): void {
+	for (const rpc of socket.pending(op)) {
+		socket.markAcked(rpc.id);
+		bridge.extMessage(socket, JSON.stringify({ t: "rpcResult", id: rpc.id, ok: false, error }));
+	}
+}
+
 /** Flush the rpc .then() microtask chains (no timers involved). */
 async function flush(): Promise<void> {
 	for (let i = 0; i < 5; i++) await Promise.resolve();
@@ -401,5 +409,30 @@ describe("RelayBridge attachment release", () => {
 		);
 		await flush();
 		expect(ext.rpcs("detach").map(rpc => rpc.tabId)).toEqual([1]);
+	});
+
+	it("retracts held sessions when reconnect reattachment fails", async () => {
+		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+
+		const replacement = new FakeExtSocket();
+		connect(bridge, replacement, [tab({ tabId: 1 })]);
+		expect(replacement.pending("attach")).toHaveLength(1);
+		reject(bridge, replacement, "attach", "debugger unavailable");
+		await flush();
+
+		const detached = cdp.messages.find(
+			message =>
+				message.method === "Target.detachedFromTarget" &&
+				message.params !== null &&
+				typeof message.params === "object" &&
+				"sessionId" in message.params &&
+				message.params.sessionId === sessionId,
+		);
+		expect(detached).toBeDefined();
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -435,4 +435,35 @@ describe("RelayBridge attachment release", () => {
 		);
 		expect(detached).toBeDefined();
 	});
+
+	it("clears an in-flight detach immediately when the extension socket is replaced", async () => {
+		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId } }),
+		);
+		await flush();
+		expect(ext.pending("detach")).toHaveLength(1);
+
+		const replacement = new FakeExtSocket();
+		connect(bridge, replacement, [tab({ tabId: 1 })]);
+		const reattachId = ++msgSeq;
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: reattachId, method: "Target.attachToTarget", params: { targetId: "PAGE1" } }),
+		);
+		await flush();
+
+		// Reattachment reaches the replacement immediately; it does not wait
+		// for the old socket's unreachable detach result or its 20s timeout.
+		expect(replacement.pending("attach")).toHaveLength(1);
+		ack(bridge, replacement, "attach");
+		await flush();
+		expect(cdp.sessionFor(reattachId)).toBeDefined();
+	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -294,22 +294,66 @@ describe("RelayBridge tab grouping", () => {
 });
 
 describe("RelayBridge attachment release", () => {
-	it("detaches the debugger when an explicit Target.detachFromTarget releases the last session", async () => {
+	it("detaches cleanly on explicit last-session release and permits reattachment", async () => {
 		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
 		const ext = new FakeExtSocket();
 		connect(bridge, ext, [tab({ tabId: 1 })]);
 		const cdp = new FakeCdpSocket();
 		const connId = bridge.cdpConnected(cdp);
 		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
-		// Releasing the last session explicitly must drop the attachment the
-		// same way closing the socket while holding it does; otherwise the
-		// chrome.debugger attachment and its infobar outlive every session.
 		bridge.cdpMessage(
 			connId,
 			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId } }),
 		);
 		await flush();
 		expect(ext.rpcs("detach").map(rpc => rpc.tabId)).toEqual([1]);
+
+		// Mirror Chrome: onDetach reaches the bridge before detach's RPC result.
+		// This echo is expected and must not ban/retract the live target.
+		bridge.extMessage(ext, JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed" }));
+		ack(bridge, ext, "detach");
+		await flush();
+
+		const reattachId = ++msgSeq;
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: reattachId, method: "Target.attachToTarget", params: { targetId: "PAGE1" } }),
+		);
+		ack(bridge, ext, "attach");
+		await flush();
+		expect(cdp.sessionFor(reattachId)).toBeDefined();
+		expect(cdp.messages.some(message => message.method === "Target.targetDestroyed")).toBe(false);
+	});
+
+	it("serializes immediate reattachment behind the detach RPC and its echo", async () => {
+		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId } }),
+		);
+		await flush();
+
+		const reattachId = ++msgSeq;
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: reattachId, method: "Target.attachToTarget", params: { targetId: "PAGE1" } }),
+		);
+		await flush();
+		// Only the initial attach has reached the extension while detach is pending.
+		expect(ext.rpcs("attach")).toHaveLength(1);
+
+		bridge.extMessage(ext, JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed" }));
+		ack(bridge, ext, "detach");
+		await flush();
+		expect(ext.rpcs("attach")).toHaveLength(2);
+		ack(bridge, ext, "attach");
+		await flush();
+		expect(cdp.sessionFor(reattachId)).toBeDefined();
 	});
 
 	it("keeps the attachment while another connection still holds a session on the tab", async () => {

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -318,7 +318,10 @@ describe("RelayBridge attachment release", () => {
 
 		// Mirror Chrome: onDetach reaches the bridge before detach's RPC result.
 		// This echo is expected and must not ban/retract the live target.
-		bridge.extMessage(ext, JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed" }));
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed", relayInitiated: true }),
+		);
 		ack(bridge, ext, "detach");
 		await flush();
 
@@ -355,7 +358,10 @@ describe("RelayBridge attachment release", () => {
 		// Only the initial attach has reached the extension while detach is pending.
 		expect(ext.rpcs("attach")).toHaveLength(1);
 
-		bridge.extMessage(ext, JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed" }));
+		bridge.extMessage(
+			ext,
+			JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed", relayInitiated: true }),
+		);
 		ack(bridge, ext, "detach");
 		await flush();
 		expect(ext.rpcs("attach")).toHaveLength(2);
@@ -470,7 +476,10 @@ describe("RelayBridge attachment release", () => {
 		// The old chrome.debugger.detach finishes after replacement attach and
 		// sends its callback through the new global extension socket. Correlation
 		// must survive the rejected RPC so this cannot retract the new session.
-		bridge.extMessage(replacement, JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed" }));
+		bridge.extMessage(
+			replacement,
+			JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed", relayInitiated: true }),
+		);
 		await flush();
 		const replacementDetach = cdp.messages.find(
 			message =>
@@ -481,5 +490,19 @@ describe("RelayBridge attachment release", () => {
 				message.params.sessionId === replacementSession,
 		);
 		expect(replacementDetach).toBeUndefined();
+
+		// A later genuine user cancellation has no relay attribution and must
+		// still retract the replacement session.
+		bridge.extMessage(replacement, JSON.stringify({ t: "detached", tabId: 1, reason: "canceled_by_user" }));
+		await flush();
+		const userDetach = cdp.messages.find(
+			message =>
+				message.method === "Target.detachedFromTarget" &&
+				message.params !== null &&
+				typeof message.params === "object" &&
+				"sessionId" in message.params &&
+				message.params.sessionId === replacementSession,
+		);
+		expect(userDetach).toBeDefined();
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -40,6 +40,18 @@ class FakeCdpSocket implements RelaySocket {
 		const result = msg && "result" in msg && msg.result && typeof msg.result === "object" ? msg.result : undefined;
 		return result && "sessionId" in result && typeof result.sessionId === "string" ? result.sessionId : undefined;
 	}
+	/** Session ids the bridge announced through `Target.attachedToTarget`. */
+	attachedSessions(): string[] {
+		const out: string[] = [];
+		for (const msg of this.messages) {
+			if (msg.method !== "Target.attachedToTarget") continue;
+			const params = msg.params;
+			if (params && typeof params === "object" && "sessionId" in params && typeof params.sessionId === "string") {
+				out.push(params.sessionId);
+			}
+		}
+		return out;
+	}
 }
 
 function tab(overrides: Partial<TabSnapshot> & { tabId: number }): TabSnapshot {
@@ -278,5 +290,72 @@ describe("RelayBridge tab grouping", () => {
 		const groups = ext2.rpcs("group");
 		expect(groups).toHaveLength(1);
 		expect(groups[0]!.tabIds).toEqual([1]);
+	});
+});
+
+describe("RelayBridge attachment release", () => {
+	it("detaches the debugger when an explicit Target.detachFromTarget releases the last session", async () => {
+		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+		// Releasing the last session explicitly must drop the attachment the
+		// same way closing the socket while holding it does; otherwise the
+		// chrome.debugger attachment and its infobar outlive every session.
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId } }),
+		);
+		await flush();
+		expect(ext.rpcs("detach").map(rpc => rpc.tabId)).toEqual([1]);
+	});
+
+	it("keeps the attachment while another connection still holds a session on the tab", async () => {
+		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		// Long-lived registry connection: holds a session on the tab throughout.
+		const registry = new FakeCdpSocket();
+		const registryConn = bridge.cdpConnected(registry);
+		await attachPage(bridge, ext, registry, registryConn, 1);
+		const worker = new FakeCdpSocket();
+		const workerConn = bridge.cdpConnected(worker);
+		const sessionId = await attachPage(bridge, ext, worker, workerConn, 1);
+		bridge.cdpMessage(
+			workerConn,
+			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId } }),
+		);
+		await flush();
+		expect(ext.rpcs("detach")).toHaveLength(0);
+	});
+
+	it("detaches once the tab session released alongside the page session leaves no holder", async () => {
+		const bridge = new RelayBridge({ group: { title: "omp", color: "cyan" } });
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		// setAutoAttach mints a tab session; attachToTarget adds a page session.
+		bridge.cdpMessage(connId, JSON.stringify({ id: ++msgSeq, method: "Target.setAutoAttach" }));
+		ack(bridge, ext, "attach");
+		await flush();
+		const pageSession = await attachPage(bridge, ext, cdp, connId, 1);
+		const tabSession = cdp.attachedSessions().find(id => id !== pageSession);
+		if (!tabSession) throw new Error("setAutoAttach did not mint a tab session");
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId: pageSession } }),
+		);
+		await flush();
+		// The tab session still holds the attachment.
+		expect(ext.rpcs("detach")).toHaveLength(0);
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: ++msgSeq, method: "Target.detachFromTarget", params: { sessionId: tabSession } }),
+		);
+		await flush();
+		expect(ext.rpcs("detach").map(rpc => rpc.tabId)).toEqual([1]);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -464,6 +464,22 @@ describe("RelayBridge attachment release", () => {
 		expect(replacement.pending("attach")).toHaveLength(1);
 		ack(bridge, replacement, "attach");
 		await flush();
-		expect(cdp.sessionFor(reattachId)).toBeDefined();
+		const replacementSession = cdp.sessionFor(reattachId);
+		expect(replacementSession).toBeDefined();
+
+		// The old chrome.debugger.detach finishes after replacement attach and
+		// sends its callback through the new global extension socket. Correlation
+		// must survive the rejected RPC so this cannot retract the new session.
+		bridge.extMessage(replacement, JSON.stringify({ t: "detached", tabId: 1, reason: "target_closed" }));
+		await flush();
+		const replacementDetach = cdp.messages.find(
+			message =>
+				message.method === "Target.detachedFromTarget" &&
+				message.params !== null &&
+				typeof message.params === "object" &&
+				"sessionId" in message.params &&
+				message.params.sessionId === replacementSession,
+		);
+		expect(replacementDetach).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Fixes #9613.

## Problem

`#releaseSession()` (`packages/coding-agent/src/tools/browser/relay/bridge.ts`) — the handler behind both `Target.detachFromTarget` variants — deleted the downstream pseudo-session and emitted `Target.detachedFromTarget` back to the client, but never told the extension. The only caller of the upstream `{op: "detach"}` RPC was `cdpClosed()`, which iterates the sessions the *closing* connection still holds, so a client that released its sessions before disconnecting left nothing to iterate.

Result: releasing a tab's last session explicitly left the `chrome.debugger` attachment alive. Chrome's *"OMP Browser Relay started debugging this browser"* infobar stayed up with no downstream session behind it, and dismissing it fired `onDetach` → `#onTabDetached()` → `banned = true`, locking the relay out of that tab for the rest of the epoch.

| client behavior | upstream detach sent (before) | after |
| --- | --- | --- |
| `detachFromTarget` each session, then close | no | **yes** |
| close the socket while still holding sessions | yes | yes |

## Fix

Extract the zero-holders rule `cdpClosed()` already applied into `#detachIfUnheld(tabId)` and call it from both release paths — one rule, one implementation. It stays inert while the long-lived registry connection holds a session on the tab (per the design note above `cdpClosed()`), and fires when the final holder releases its last session.

Safe with respect to the ban path: `chrome.debugger.onDetach` only fires when the *browser* terminates a session (tab closed, DevTools opened, user dismissing the infobar), not for a `detach()` the extension itself issues — which is why the pre-existing `cdpClosed()` detach never banned tabs either.

## Tests

Three cases in a new `describe("RelayBridge attachment release")` in `test/tools/browser-relay-bridge.test.ts`, each covering a distinct branch:

1. explicit `Target.detachFromTarget` of the last session → exactly one upstream `detach` for that tab;
2. another connection still holds a session on the tab → no detach (keeps the registry connection from being torn out from under a worker);
3. tab-session + page-session on one connection → releasing the page session does not detach, releasing the tab session does. Proves the check counts holders, not release calls.

Verification:

- `bun test test/tools/browser-relay-bridge.test.ts` → 13 pass, 0 fail.
- Negative control: stashing only `bridge.ts` reds cases 1 and 3 with `expect([]).toEqual([1])` — the exact symptom in the issue.
- `bun run check:ts` → every workspace exits 0 (tsgo + biome clean).

Complementary to, and non-overlapping with, #9009 / #8930: the `AttachmentGuard` there reclaims attachments orphaned because the relay went away. Here both relay and extension stay alive and connected, so that guard never arms, and it does not touch `#releaseSession()`.