### PR TITLE
fix(update): use platform-aware reinstall hint in rename migration

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1481,7 +1481,7 @@ export async function migrateRenamedInstall(release: ReleaseInfo, steps: RenameM
 	}
 	if (!verification.ok) {
 		throw new Error(
-			`${formatVerificationFailure(verification, release.version)}; reinstall with: curl -fsSL https://omp.sh/install | sh`,
+			`${formatVerificationFailure(verification, release.version)}; reinstall with: ${installerHint()}`,
 		);
 	}
 	printVerifiedVersion(release.version);


### PR DESCRIPTION
Fixes #9619

## What
`migrateRenamedInstall()` in `packages/coding-agent/src/cli/update-cli.ts` hardcoded the Unix reinstall command (`curl -fsSL https://omp.sh/install | sh`) in its verification-failure message, so on Windows a failed package-rename update printed an unusable POSIX command.

## Change
Use the existing platform-aware `installerHint()` helper instead — it already returns the PowerShell one-liner on win32 and the `sh` command on unix, and is used correctly at the other reinstall-hint sites in this file (`updateViaManager`, `runUpdateCommand`).

```diff
 throw new Error(
-    `${formatVerificationFailure(verification, release.version)}; reinstall with: curl -fsSL https://omp.sh/install | sh`,
+    `${formatVerificationFailure(verification, release.version)}; reinstall with: ${installerHint()}`,
 );
```

## Test plan
- Windows: after a rename-migration verification failure, the hint is `& ([scriptblock]::Create((irm https://omp.sh/install.ps1))) -Binary`.
- Unix: unchanged (`curl -fsSL https://omp.sh/install | sh -s -- --binary`).

One-line change; no behavioral change to the update logic itself.