### PR TITLE
fix(update): use platform-aware reinstall hint in rename migration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed `omp update` showing the POSIX `curl … | sh` reinstall command on Windows when a package-rename migration failed verification; it now uses the platform-aware PowerShell hint ([#9619](https://github.com/can1357/oh-my-pi/issues/9619))
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1481,7 +1481,7 @@ export async function migrateRenamedInstall(release: ReleaseInfo, steps: RenameM
 	}
 	if (!verification.ok) {
 		throw new Error(
-			`${formatVerificationFailure(verification, release.version)}; reinstall with: curl -fsSL https://omp.sh/install | sh`,
+			`${formatVerificationFailure(verification, release.version)}; reinstall with: ${installerHint()}`,
 		);
 	}
 	printVerifiedVersion(release.version);

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -566,6 +566,21 @@ describe("migrateRenamedInstall transaction", () => {
 		await expect(migrateRenamedInstall(release, steps)).rejects.toThrow("curl -fsSL https://omp.sh/install");
 		expect(calls).toEqual(["install", "removeOld", "verify", "install", "verify"]);
 	});
+
+	it("uses the platform-aware PowerShell reinstall hint on Windows", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+		if (!platformDescriptor) throw new Error("process.platform descriptor missing");
+		Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+		try {
+			const { steps } = scriptedSteps({ install: [0, 0], verify: [false, false] });
+			const promise = migrateRenamedInstall(release, steps);
+			await expect(promise).rejects.toThrow("irm https://omp.sh/install.ps1");
+			await expect(promise).rejects.not.toThrow("| sh");
+		} finally {
+			Object.defineProperty(process, "platform", platformDescriptor);
+		}
+	});
 });
 
 describe("update-cli bun install command", () => {


### PR DESCRIPTION
## Repro
When `omp update` goes through a package-rename migration (`migrateRenamedInstall`) and the post-install version verification fails, the thrown error tells the user to reinstall with the POSIX pipeline `curl -fsSL https://omp.sh/install | sh` regardless of platform. On Windows that command is unusable in PowerShell/cmd. Reproduced by invoking `migrateRenamedInstall` with `process.platform` forced to `win32` and a step set whose `verify()` always fails — the error message is `... reinstall with: curl -fsSL https://omp.sh/install | sh`.

## Cause
`packages/coding-agent/src/cli/update-cli.ts`, `migrateRenamedInstall()` hardcoded the Unix reinstall command in its final `throw new Error(...)`, bypassing the existing platform-aware `installerHint()` helper that every other reinstall-hint site (`printVerificationFailure`, `updateViaManager`) already routes through.

## Fix
- Replace the hardcoded `curl -fsSL https://omp.sh/install | sh` string in `migrateRenamedInstall()` with `installerHint()`, which returns the PowerShell one-liner on `win32` and the POSIX one-liner elsewhere.
- Add a regression test in `test/update-cli.test.ts` asserting that under `win32` the failure message contains `irm https://omp.sh/install.ps1` and does not contain `| sh`.

## Verification
`bun test test/update-cli.test.ts -t "migrateRenamedInstall transaction"` → 6 pass, 0 fail (5 existing + new win32 test). Fixes #9619