### PR TITLE
fix: avoid duplicate vibe exit journal entry

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3927,6 +3927,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#vibeModeOwnerScope = undefined;
 		this.lastAssistantUsage = undefined;
 		this.#updateVibeModeStatus();
+		this.sessionManager.appendModeChange("none");
 		this.showStatus(
 			killed > 0
 				? `Vibe mode disabled. Killed ${killed} worker session${killed === 1 ? "" : "s"}.`

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3927,7 +3927,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#vibeModeOwnerScope = undefined;
 		this.lastAssistantUsage = undefined;
 		this.#updateVibeModeStatus();
-		this.sessionManager.appendModeChange("none");
+		if (this.sessionManager.buildSessionContext().mode !== "none") this.sessionManager.appendModeChange("none");
 		this.showStatus(
 			killed > 0
 				? `Vibe mode disabled. Killed ${killed} worker session${killed === 1 ? "" : "s"}.`

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -144,6 +144,9 @@ describe("InteractiveMode vibe mode toggle", () => {
 	});
 
 	it("preserves the parent Todo tool and restores the exact pre-vibe toolset on exit", async () => {
+		// Keep this test focused on InteractiveMode's own journal transition;
+		// worker teardown has a separate persistence path.
+		vi.spyOn(VibeSessionRegistry.global(), "killAll").mockResolvedValue(0);
 		expect(session.getAllToolNames().toSorted()).toEqual(["read", "todo"]);
 		expect(session.getActiveToolNames()).toEqual([]);
 
@@ -164,6 +167,12 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(mode.vibeModeEnabled).toBe(false);
 		expect(session.getActiveToolNames()).toEqual([]);
 		expect(session.getAllToolNames().toSorted()).toEqual(["read", "todo"]);
+		expect(
+			session.sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "mode_change")
+				.map(entry => entry.mode),
+		).toEqual(["vibe", "none"]);
 	});
 
 	it("cancels an in-flight model turn before removing Vibe tools", async () => {

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -144,9 +144,6 @@ describe("InteractiveMode vibe mode toggle", () => {
 	});
 
 	it("preserves the parent Todo tool and restores the exact pre-vibe toolset on exit", async () => {
-		// Keep this test focused on InteractiveMode's own journal transition;
-		// worker teardown has a separate persistence path.
-		vi.spyOn(VibeSessionRegistry.global(), "killAll").mockResolvedValue(0);
 		expect(session.getAllToolNames().toSorted()).toEqual(["read", "todo"]);
 		expect(session.getActiveToolNames()).toEqual([]);
 


### PR DESCRIPTION
## What

Journalize the exit from vibe mode as a `mode_change` entry with mode `none`.

The write is guarded by the resolved mode because worker cleanup may already persist the same exit entry.

## Why

The vibe-mode entry is recorded in the session journal, but the exit was not reliably represented at the interactive-mode boundary. This left consumers such as the mode proposer and the double status line with stale mode information.

Vibe worker teardown can already persist the exit entry, so the interactive-mode path must avoid appending a duplicate.

## Testing

- `bun test packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts` — 14 pass.
- Manual PTY verification of `/vibe` on/off.
- The journal showed exactly one `vibe` entry followed by one `none` entry.

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
