### PR TITLE
fix(ai): stop stripping images from multimodal DeepSeek SKUs

### DIFF
--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -66,6 +66,15 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
 }
 
 /**
+ * Multimodal markers that opt a DeepSeek SKU out of the text-only guard below.
+ *
+ * `deepseek-ocr` is served by Novita; `*vision*` covers the catalog's
+ * `deepseek-v4-flash-vision-exp` (issue #9623) and any future vision SKU that
+ * carries the marker in its id or display name.
+ */
+const DEEPSEEK_MULTIMODAL_MARKERS = ["deepseek-ocr", "vision"] as const;
+
+/**
  * Detect known text-only DeepSeek models served via OpenAI-compatible Chat
  * Completions endpoints whose server-side deserializers reject `image_url`
  * content parts with HTTP 400 (`unknown variant \`image_url\`, expected \`text\``).
@@ -73,12 +82,16 @@ export function isDashscopeCompatibleModeTextOnlyQwen(model: Model<"openai-compl
  * Used as a defensive override in `convertMessages` so misconfigured model
  * definitions or user overrides (e.g. `models.yml` claiming `input: [text, image]`)
  * do not crash the session with an unrecoverable 400.
+ *
+ * DeepSeek now ships genuinely multimodal SKUs, so an explicit multimodal
+ * marker in the id or name opts out of the blanket rule — otherwise the guard
+ * strips images from a model the bundled catalog itself declares as
+ * `input: [text, image]` (issue #9623).
  */
 export function isTextOnlyDeepSeek(model: Model<"openai-completions">): boolean {
 	const id = model.id.toLowerCase();
 	const name = (model.name ?? "").toLowerCase();
-	// DeepSeek OCR is a genuinely multimodal model served by Novita.
-	if (id.includes("deepseek-ocr") || name.includes("deepseek-ocr")) return false;
+	if (DEEPSEEK_MULTIMODAL_MARKERS.some(marker => id.includes(marker) || name.includes(marker))) return false;
 	return (
 		modelMatchesHost(model, "deepseekFamily") ||
 		isDeepseekModelIdOrName(model.id) ||

--- a/packages/ai/test/issue-9623-deepseek-vision.test.ts
+++ b/packages/ai/test/issue-9623-deepseek-vision.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { isOpenAICompletionsVisionSupported, isTextOnlyDeepSeek } from "@oh-my-pi/pi-ai/providers/vision-guard";
+import type { Model } from "@oh-my-pi/pi-ai/types";
+import { getBundledModel } from "@oh-my-pi/pi-catalog";
+
+function bundled(provider: "deepseek" | "opencode-go", id: string): Model<"openai-completions"> {
+	const model = getBundledModel<"openai-completions">(provider, id);
+	if (!model) throw new Error(`bundled model not found: ${provider}/${id}`);
+	if (model.api !== "openai-completions") throw new Error(`expected openai-completions, got ${model.api}`);
+	return model;
+}
+
+describe("issue #9623 DeepSeek vision guard", () => {
+	it("keeps images for bundled DeepSeek vision SKUs that declare image input", () => {
+		for (const provider of ["deepseek", "opencode-go"] as const) {
+			const model = bundled(provider, "deepseek-v4-flash-vision-exp");
+			expect(model.input).toContain("image");
+			expect(isTextOnlyDeepSeek(model)).toBe(false);
+			expect(isOpenAICompletionsVisionSupported(model)).toBe(true);
+		}
+	});
+
+	it("still strips images from text-only DeepSeek SKUs claiming image input", () => {
+		const textOnly = bundled("deepseek", "deepseek-v4-pro");
+		expect(textOnly.input).not.toContain("image");
+		expect(isTextOnlyDeepSeek(textOnly)).toBe(true);
+		expect(isOpenAICompletionsVisionSupported({ ...textOnly, input: ["text", "image"] })).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #9623.

## Problem

`isTextOnlyDeepSeek` treats every DeepSeek-family model as text-only, with `deepseek-ocr` as the sole escape hatch. The bundled catalog ships two SKUs that contradict it:

```
/deepseek/deepseek-v4-flash-vision-exp     {"api":"openai-completions","input":["text","image"]}
/opencode-go/deepseek-v4-flash-vision-exp  {"api":"openai-completions","input":["text","image"]}
```

`isOpenAICompletionsVisionSupported` returns `false` for both, so every image — attachments, screenshots, and image content blocks returned from tool results — is replaced with `NON_VISION_IMAGE_PLACEHOLDER`, while `omp models --json` reports the model as vision-capable. The failure surfaces as the model insisting it cannot see images, which reads as a tool or plugin bug.

## Change

Generalize the `deepseek-ocr` escape hatch into `DEEPSEEK_MULTIMODAL_MARKERS`, so an explicit multimodal marker in the id or display name opts a SKU out of the blanket rule. This mirrors the narrowing the sibling Qwen guard already received in #8019 / #8305: keep the defensive 400-guard for text-only chat SKUs, exempt the SKUs that are genuinely multimodal.

Deliberately kept as an id/name marker rather than trusting `model.input`: the guard exists precisely to defend against descriptors that claim `input: [text, image]` and then 400, and a `models.yml` override must still not be able to force images onto `deepseek-chat`.

## Test

`packages/ai/test/issue-9623-deepseek-vision.test.ts`, asserted against the real bundled catalog rows rather than hand-built models, so a catalog change cannot silently invalidate it:

- both `deepseek-v4-flash-vision-exp` entries declare image input, are not flagged text-only, and pass `isOpenAICompletionsVisionSupported`
- `deepseek-v4-pro` stays flagged, and still has images stripped when an override claims `input: [text, image]`

```
bun test packages/ai/test/issue-9623-deepseek-vision.test.ts packages/ai/test/issue-967-vision-guard.test.ts
 7 pass  0 fail
```

Full `bun test packages/ai/test`: `4185 pass, 332 skip, 1 fail` — the failure is `issue-6276-repro` (Bedrock guardrails) timing out at 5000 ms under full-suite parallelism; it passes standalone both with and without this change.
