### PR TITLE
fix(advisor): bound repeated tool calls in the advisor's own loop

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed advisors repeating one failing tool call without any bound: the `model.toolCallLoopGuard.*` settings now govern the advisor's own loop too, redirecting it at the configured threshold ([#9491](https://github.com/can1357/oh-my-pi/issues/9491))
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/advisor/index.ts
+++ b/packages/coding-agent/src/advisor/index.ts
@@ -1,6 +1,7 @@
 export * from "./advise-tool";
 export * from "./config";
 export * from "./emission-guard";
+export * from "./loop-guard";
 export * from "./runtime";
 export * from "./transcript-recorder";
 export * from "./watchdog";

--- a/packages/coding-agent/src/advisor/loop-guard.ts
+++ b/packages/coding-agent/src/advisor/loop-guard.ts
@@ -14,6 +14,8 @@ export interface AdvisorLoopGuardHost {
 	liveMessages(): AgentMessage[];
 	/** Appends to the advisor agent's live context. */
 	appendMessage(message: AgentMessage): void;
+	/** Stops the current advisor update after it ignores one corrective. */
+	abort(reason: Error): void;
 }
 
 /**
@@ -30,11 +32,18 @@ export class AdvisorLoopGuard {
 	readonly #host: AdvisorLoopGuardHost;
 	#guard: ToolCallLoopGuard | undefined;
 	#guardSettingsKey: string | undefined;
+	#redirectIssued = false;
 
 	constructor(host: AdvisorLoopGuardHost) {
 		this.#host = host;
 	}
 
+	/** Clear detector and escalation state at an advisor update/context boundary. */
+	reset(): void {
+		this.#guard = undefined;
+		this.#guardSettingsKey = undefined;
+		this.#redirectIssued = false;
+	}
 	/** Records one completed advisor turn and injects a redirect when calls repeat. */
 	recordTurn(messages: AgentMessage[], context: AgentTurnEndContext | undefined): void {
 		if (context?.message.role !== "assistant") return;
@@ -43,11 +52,26 @@ export class AdvisorLoopGuard {
 			toolResults: context.toolResults,
 		});
 		if (!detection) return;
+		if (this.#redirectIssued) {
+			logger.warn("advisor ignored tool-call loop redirect; aborting update", {
+				advisor: this.#host.name,
+				toolName: detection.toolName,
+				count: detection.count,
+			});
+			this.#host.abort(new Error(`Advisor repeated ${detection.toolName} after a loop redirect`));
+			this.reset();
+			return;
+		}
 		logger.warn("advisor tool-call loop detected", {
 			advisor: this.#host.name,
 			toolName: detection.toolName,
 			count: detection.count,
 		});
+		this.#redirectIssued = true;
+		// Re-arm after the first corrective. If it is ignored, the same bound
+		// trips again and hard-stops this update instead of running forever.
+		this.#guard = undefined;
+		this.#guardSettingsKey = undefined;
 		// A `user` message, not the primary's custom one: the advisor agent runs
 		// the default LLM converter, which keeps only LLM-native roles — a custom
 		// message would be dropped before the request and correct nothing.
@@ -66,8 +90,7 @@ export class AdvisorLoopGuard {
 
 	#activeGuard(): ToolCallLoopGuard | undefined {
 		if (this.#host.settings.get("model.toolCallLoopGuard.enabled") !== true) {
-			this.#guard = undefined;
-			this.#guardSettingsKey = undefined;
+			this.reset();
 			return undefined;
 		}
 		const threshold = this.#host.settings.get("model.toolCallLoopGuard.threshold");

--- a/packages/coding-agent/src/advisor/loop-guard.ts
+++ b/packages/coding-agent/src/advisor/loop-guard.ts
@@ -1,0 +1,84 @@
+import type { AgentMessage, AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
+import type { UserMessage } from "@oh-my-pi/pi-ai";
+import { ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { Settings } from "../config/settings";
+import { renderToolCallLoopRedirect } from "../session/tool-call-loop-redirect";
+
+/** Capabilities the advisor loop guard borrows from its agent. */
+export interface AdvisorLoopGuardHost {
+	settings: Settings;
+	/** Advisor name, for log attribution only. */
+	name: string;
+	/** The advisor agent's live context array. */
+	liveMessages(): AgentMessage[];
+	/** Appends to the advisor agent's live context. */
+	appendMessage(message: AgentMessage): void;
+}
+
+/**
+ * Bounds repeated identical tool calls inside an advisor's own `Agent` loop.
+ *
+ * Advisors drive a private loop that never passes through the primary session's
+ * `LoopGuards`, so a model reissuing one failing call had no bound at all:
+ * `AdvisorRuntime` counts whole-turn provider failures, which a turn that
+ * *succeeds* while burning dozens of identical failing tool calls never trips.
+ * Reuses the primary's `model.toolCallLoopGuard.*` settings and corrective so
+ * one knob governs both loops (issue #9491).
+ */
+export class AdvisorLoopGuard {
+	readonly #host: AdvisorLoopGuardHost;
+	#guard: ToolCallLoopGuard | undefined;
+	#guardSettingsKey: string | undefined;
+
+	constructor(host: AdvisorLoopGuardHost) {
+		this.#host = host;
+	}
+
+	/** Records one completed advisor turn and injects a redirect when calls repeat. */
+	recordTurn(messages: AgentMessage[], context: AgentTurnEndContext | undefined): void {
+		if (context?.message.role !== "assistant") return;
+		const detection = this.#activeGuard()?.recordTurn({
+			message: context.message,
+			toolResults: context.toolResults,
+		});
+		if (!detection) return;
+		logger.warn("advisor tool-call loop detected", {
+			advisor: this.#host.name,
+			toolName: detection.toolName,
+			count: detection.count,
+		});
+		// A `user` message, not the primary's custom one: the advisor agent runs
+		// the default LLM converter, which keeps only LLM-native roles — a custom
+		// message would be dropped before the request and correct nothing.
+		const redirect: UserMessage = {
+			role: "user",
+			content: [{ type: "text", text: renderToolCallLoopRedirect(detection) }],
+			synthetic: true,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		messages.push(redirect);
+		// The loop hands over its live array; a caller passing a detached snapshot
+		// still needs the corrective in the context the next request reads.
+		if (this.#host.liveMessages() !== messages) this.#host.appendMessage(redirect);
+	}
+
+	#activeGuard(): ToolCallLoopGuard | undefined {
+		if (this.#host.settings.get("model.toolCallLoopGuard.enabled") !== true) {
+			this.#guard = undefined;
+			this.#guardSettingsKey = undefined;
+			return undefined;
+		}
+		const threshold = this.#host.settings.get("model.toolCallLoopGuard.threshold");
+		const exemptTools = this.#host.settings
+			.get("model.toolCallLoopGuard.exemptTools")
+			.filter((tool): tool is string => typeof tool === "string" && tool.length > 0);
+		const settingsKey = `${threshold}:${JSON.stringify(exemptTools)}`;
+		if (!this.#guard || this.#guardSettingsKey !== settingsKey) {
+			this.#guard = new ToolCallLoopGuard({ threshold, exemptTools });
+			this.#guardSettingsKey = settingsKey;
+		}
+		return this.#guard;
+	}
+}

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -883,6 +883,7 @@ export class SessionAdvisors {
 				name: advisorName,
 				liveMessages: () => advisorAgent.state.messages,
 				appendMessage: message => advisorAgent.appendMessage(message),
+				abort: reason => advisorAgent.abort(reason),
 			});
 			advisorAgent.setOnTurnEnd((messages, signal, context) => {
 				if (signal?.aborted) return;
@@ -892,6 +893,7 @@ export class SessionAdvisors {
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {
 					let quarantined: string | undefined;
+					advisorLoopGuard.reset();
 					try {
 						quarantinedAdvisorOutput = undefined;
 						// Multi-message input (candidate 4) must serialize deterministically
@@ -914,6 +916,7 @@ export class SessionAdvisors {
 				},
 				abort: reason => advisorAgent.abort(reason),
 				reset: () => {
+					advisorLoopGuard.reset();
 					advisorAgent.reset();
 					appendOnlyContext.log.clear();
 				},

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -875,6 +875,7 @@ export class SessionAdvisors {
 				serviceTierResolver: advisorServiceTierResolver,
 			});
 			advisorAgent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
+			let advisorLoopGuardStopped = false;
 			// The advisor's own loop needs the same repeated-tool-call bound the
 			// primary gets from `LoopGuards`; nothing else stops it reissuing one
 			// failing call until the update is abandoned.
@@ -883,7 +884,10 @@ export class SessionAdvisors {
 				name: advisorName,
 				liveMessages: () => advisorAgent.state.messages,
 				appendMessage: message => advisorAgent.appendMessage(message),
-				abort: reason => advisorAgent.abort(reason),
+				abort: reason => {
+					advisorLoopGuardStopped = true;
+					advisorAgent.abort(reason);
+				},
 			});
 			advisorAgent.setOnTurnEnd((messages, signal, context) => {
 				if (signal?.aborted) return;
@@ -894,6 +898,7 @@ export class SessionAdvisors {
 				prompt: async input => {
 					let quarantined: string | undefined;
 					advisorLoopGuard.reset();
+					advisorLoopGuardStopped = false;
 					try {
 						quarantinedAdvisorOutput = undefined;
 						// Multi-message input (candidate 4) must serialize deterministically
@@ -909,6 +914,12 @@ export class SessionAdvisors {
 						else await advisorAgent.prompt(input);
 						quarantined = quarantinedAdvisorOutput;
 					} finally {
+						if (advisorLoopGuardStopped) {
+							// A loop guard stop is a deliberate, bounded silent review, not
+							// a provider failure for AdvisorRuntime to retry/fallback.
+							advisorAgent.state.error = undefined;
+							advisorLoopGuardStopped = false;
+						}
 						quarantinedAdvisorOutput = undefined;
 						currentAdvisorInput = "";
 					}
@@ -917,6 +928,7 @@ export class SessionAdvisors {
 				abort: reason => advisorAgent.abort(reason),
 				reset: () => {
 					advisorLoopGuard.reset();
+					advisorLoopGuardStopped = false;
 					advisorAgent.reset();
 					appendOnlyContext.log.clear();
 				},

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -42,6 +42,7 @@ import {
 	type AdvisorAgent,
 	type AdvisorConfig,
 	AdvisorEmissionGuard,
+	AdvisorLoopGuard,
 	type AdvisorMessageDetails,
 	type AdvisorNote,
 	AdvisorOutputQuarantinedError,
@@ -874,6 +875,19 @@ export class SessionAdvisors {
 				serviceTierResolver: advisorServiceTierResolver,
 			});
 			advisorAgent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
+			// The advisor's own loop needs the same repeated-tool-call bound the
+			// primary gets from `LoopGuards`; nothing else stops it reissuing one
+			// failing call until the update is abandoned.
+			const advisorLoopGuard = new AdvisorLoopGuard({
+				settings: this.#host.settings,
+				name: advisorName,
+				liveMessages: () => advisorAgent.state.messages,
+				appendMessage: message => advisorAgent.appendMessage(message),
+			});
+			advisorAgent.setOnTurnEnd((messages, signal, context) => {
+				if (signal?.aborted) return;
+				advisorLoopGuard.recordTurn(messages, context);
+			});
 
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {

--- a/packages/coding-agent/src/session/stream-guards.ts
+++ b/packages/coding-agent/src/session/stream-guards.ts
@@ -8,17 +8,20 @@ import type { Settings } from "../config/settings";
 import { normalizeDiff, normalizeToLF, ParseError, previewPatch, stripBom } from "../edit";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import geminiToolReminderTemplate from "../prompts/system/gemini-tool-call-reminder.md" with { type: "text" };
-import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redirect.md" with { type: "text" };
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import { isInternalUrlPath, normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
 import { ToolError } from "../tools/tool-errors";
 import type { CustomMessage } from "./messages";
 import type { SessionManager } from "./session-manager";
+import {
+	renderToolCallLoopRedirect,
+	TOOL_CALL_LOOP_REDIRECT_TYPE,
+	toolCallLoopRedirectDetails,
+} from "./tool-call-loop-redirect";
 
 const GEMINI_HEADER_INTERRUPT_REASON = "Interrupted: emit a tool call instead of more planning";
 const GEMINI_TOOL_REMINDER_TYPE = "gemini-tool-call-reminder";
-const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
 
 /** Capabilities borrowed by the session's streaming and loop guards. */
 export interface StreamGuardsHost {
@@ -403,19 +406,9 @@ export class LoopGuards {
 	}
 
 	#injectToolCallLoopRedirect(messages: AgentMessage[], detection: RepeatedToolCallDetection): void {
-		const content = prompt.render(toolCallLoopRedirectTemplate, {
-			tool_name: detection.toolName,
-			count: detection.count,
-			arguments_summary: detection.argumentsSummary,
-			result_summary: detection.resultSummary || "(no text result)",
-		});
-		const details = {
-			toolName: detection.toolName,
-			count: detection.count,
-			argumentsSummary: detection.argumentsSummary,
-			resultSummary: detection.resultSummary,
-		};
 		logger.warn("cross-turn tool-call loop detected", { toolName: detection.toolName, count: detection.count });
+		const content = renderToolCallLoopRedirect(detection);
+		const details = toolCallLoopRedirectDetails(detection);
 		const redirectMessage: CustomMessage = {
 			role: "custom",
 			customType: TOOL_CALL_LOOP_REDIRECT_TYPE,

--- a/packages/coding-agent/src/session/tool-call-loop-redirect.ts
+++ b/packages/coding-agent/src/session/tool-call-loop-redirect.ts
@@ -1,0 +1,38 @@
+import type { RepeatedToolCallDetection } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import { prompt } from "@oh-my-pi/pi-utils";
+import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redirect.md" with { type: "text" };
+
+export const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
+
+/** Structured record of the loop a redirect was issued for. */
+export interface ToolCallLoopRedirectDetails {
+	toolName: string;
+	count: number;
+	argumentsSummary: string;
+	resultSummary: string;
+}
+
+/**
+ * Renders the corrective a repeated tool call earns. Shared by the primary
+ * session's `LoopGuards` and the advisor's own loop guard: both bounds speak
+ * with one wording, while each wraps it in the message shape its own agent
+ * converts to LLM context (the primary maps custom messages, the advisor runs
+ * the default converter that keeps only LLM-native roles).
+ */
+export function renderToolCallLoopRedirect(detection: RepeatedToolCallDetection): string {
+	return prompt.render(toolCallLoopRedirectTemplate, {
+		tool_name: detection.toolName,
+		count: detection.count,
+		arguments_summary: detection.argumentsSummary,
+		result_summary: detection.resultSummary || "(no text result)",
+	});
+}
+
+export function toolCallLoopRedirectDetails(detection: RepeatedToolCallDetection): ToolCallLoopRedirectDetails {
+	return {
+		toolName: detection.toolName,
+		count: detection.count,
+		argumentsSummary: detection.argumentsSummary,
+		resultSummary: detection.resultSummary,
+	};
+}

--- a/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
@@ -58,16 +58,19 @@ describe("advisor tool-call loop guard", () => {
 	 * Live advisor agent built through the real `SessionAdvisors` path, driven by
 	 * a stream that repeats one identical failing tool call forever.
 	 */
-	function createAdvisor(guardSettings: Record<string, unknown>): { advisor: Agent; contexts: Context[] } {
+	function createAdvisor(
+		guardSettings: Record<string, unknown>,
+		maxRepeatedTurns = 8,
+	): { advisor: Agent; contexts: Context[] } {
 		const primaryMock = createMockModel({ provider: "anthropic", responses: [{ content: ["primary complete"] }] });
 		const advisorMock = createMockModel({ provider: "anthropic" });
 		const contexts: Context[] = [];
 		let turn = 0;
 		const advisorStreamFn: typeof advisorMock.stream = (_model, context) => {
 			contexts.push(context);
-			// Stop once the corrective lands so a broken guard fails on the
-			// assertion rather than looping until the test times out.
-			const repeating = turn < 8 && !JSON.stringify(context.messages).includes("tool_call_loop_detected");
+			// Deliberately ignore the corrective. The enabled guard must hard-stop
+			// this stream; the finite ceiling keeps the disabled control bounded.
+			const repeating = turn < maxRepeatedTurns;
 			turn++;
 			const message: AssistantMessage = repeating
 				? {
@@ -120,25 +123,28 @@ describe("advisor tool-call loop guard", () => {
 	}
 
 	it("redirects the advisor's own repeated tool call and reaches its next request", async () => {
-		const { advisor, contexts } = createAdvisor({
-			"model.toolCallLoopGuard.enabled": true,
-			"model.toolCallLoopGuard.threshold": 3,
-		});
+		const { advisor, contexts } = createAdvisor(
+			{
+				"model.toolCallLoopGuard.enabled": true,
+				"model.toolCallLoopGuard.threshold": 3,
+			},
+			20,
+		);
 
 		await advisor.prompt("review the current update");
 
-		// Threshold 3 => two clean turns, the third trips the bound.
-		const redirects = contexts.filter(context =>
-			JSON.stringify(context.messages).includes("tool_call_loop_detected"),
-		);
-		expect(redirects).toHaveLength(1);
-		const delivered = JSON.stringify(redirects[0]!.messages);
+		// First threshold injects one corrective; ignoring it re-arms the
+		// detector, and the second threshold aborts. The agent loop observes the
+		// abort after one already-scheduled request, bounding twenty repeats at 7.
+		expect(contexts).toHaveLength(7);
+		const delivered = JSON.stringify(contexts[3]!.messages);
 		expect(delivered).toContain("You called `read` 3 consecutive times");
 		expect(delivered).toContain("ENOENT: no such file or directory");
-		// The advisor's context uses the default LLM converter, so the corrective
-		// only survives as an LLM-native role.
+		const redirects = advisor.state.messages.filter(
+			message => message.role === "user" && JSON.stringify(message.content).includes("tool_call_loop_detected"),
+		);
+		expect(redirects).toHaveLength(1);
 		expect(advisor.state.messages.filter(message => message.role === "custom")).toHaveLength(0);
-		expect(advisor.state.messages.at(-1)?.role).toBe("assistant");
 	});
 
 	it("leaves the advisor unbounded when the shared loop guard is disabled", async () => {

--- a/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Context } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} satisfies AssistantMessage["usage"];
+
+/** Advisor-visible tool that fails the same way on every call. */
+const failingReadTool: AgentTool = {
+	name: "read",
+	label: "Read",
+	description: "Mock read tool",
+	parameters: type({ "path?": "string" }),
+	execute: async () => ({
+		content: [{ type: "text" as const, text: "ENOENT: no such file or directory" }],
+		isError: true,
+	}),
+};
+
+describe("advisor tool-call loop guard", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeAll(() => {
+		tempDir = TempDir.createSync("@pi-advisor-tool-call-loop-guard-");
+		authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		session = undefined;
+	});
+
+	afterAll(async () => {
+		authStorage.close();
+		await tempDir.remove();
+	});
+
+	/**
+	 * Live advisor agent built through the real `SessionAdvisors` path, driven by
+	 * a stream that repeats one identical failing tool call forever.
+	 */
+	function createAdvisor(guardSettings: Record<string, unknown>): { advisor: Agent; contexts: Context[] } {
+		const primaryMock = createMockModel({ provider: "anthropic", responses: [{ content: ["primary complete"] }] });
+		const advisorMock = createMockModel({ provider: "anthropic" });
+		const contexts: Context[] = [];
+		let turn = 0;
+		const advisorStreamFn: typeof advisorMock.stream = (_model, context) => {
+			contexts.push(context);
+			// Stop once the corrective lands so a broken guard fails on the
+			// assertion rather than looping until the test times out.
+			const repeating = turn < 8 && !JSON.stringify(context.messages).includes("tool_call_loop_detected");
+			turn++;
+			const message: AssistantMessage = repeating
+				? {
+						role: "assistant",
+						content: [{ type: "toolCall", id: `tc-${turn}`, name: "read", arguments: { path: "missing.ts" } }],
+						api: advisorMock.api,
+						provider: advisorMock.provider,
+						model: advisorMock.id,
+						usage: zeroUsage,
+						stopReason: "toolUse",
+						timestamp: Date.now(),
+					}
+				: {
+						role: "assistant",
+						content: [{ type: "text", text: "Stopped repeating." }],
+						api: advisorMock.api,
+						provider: advisorMock.provider,
+						model: advisorMock.id,
+						usage: zeroUsage,
+						stopReason: "stop",
+						timestamp: Date.now(),
+					};
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial: message });
+				stream.push({ type: "done", reason: repeating ? "toolUse" : "stop", message });
+			});
+			return stream;
+		};
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false, ...guardSettings });
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: primaryMock, systemPrompt: [], tools: [] },
+				streamFn: primaryMock.stream,
+			}),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			advisorTools: [failingReadTool],
+			advisorStreamFn,
+		});
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent to be active");
+		advisor.setModel(advisorMock);
+		return { advisor, contexts };
+	}
+
+	it("redirects the advisor's own repeated tool call and reaches its next request", async () => {
+		const { advisor, contexts } = createAdvisor({
+			"model.toolCallLoopGuard.enabled": true,
+			"model.toolCallLoopGuard.threshold": 3,
+		});
+
+		await advisor.prompt("review the current update");
+
+		// Threshold 3 => two clean turns, the third trips the bound.
+		const redirects = contexts.filter(context =>
+			JSON.stringify(context.messages).includes("tool_call_loop_detected"),
+		);
+		expect(redirects).toHaveLength(1);
+		const delivered = JSON.stringify(redirects[0]!.messages);
+		expect(delivered).toContain("You called `read` 3 consecutive times");
+		expect(delivered).toContain("ENOENT: no such file or directory");
+		// The advisor's context uses the default LLM converter, so the corrective
+		// only survives as an LLM-native role.
+		expect(advisor.state.messages.filter(message => message.role === "custom")).toHaveLength(0);
+		expect(advisor.state.messages.at(-1)?.role).toBe("assistant");
+	});
+
+	it("leaves the advisor unbounded when the shared loop guard is disabled", async () => {
+		const { advisor, contexts } = createAdvisor({ "model.toolCallLoopGuard.enabled": false });
+
+		await advisor.prompt("review the current update");
+
+		expect(contexts.some(context => JSON.stringify(context.messages).includes("tool_call_loop_detected"))).toBe(
+			false,
+		);
+		// Nine requests: eight repeated tool-call turns plus the final stop.
+		expect(contexts).toHaveLength(9);
+	});
+});

--- a/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
@@ -102,7 +102,12 @@ describe("advisor tool-call loop guard", () => {
 			return stream;
 		};
 		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
-		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false, ...guardSettings });
+		const settings = Settings.isolated({
+			"advisor.syncBacklog": "1",
+			"compaction.enabled": false,
+			"todo.enabled": false,
+			...guardSettings,
+		});
 		session = new AgentSession({
 			agent: new Agent({
 				getApiKey: () => "test-key",
@@ -132,7 +137,9 @@ describe("advisor tool-call loop guard", () => {
 			20,
 		);
 
-		await advisor.prompt("review the current update");
+		if (!session) throw new Error("Expected live session");
+		await session.prompt("review the current update");
+		expect(await session.waitForAdvisorCatchup(2_000)).toBe(true);
 
 		// First threshold injects one corrective; ignoring it re-arms the
 		// detector, and the second threshold aborts. The agent loop observes the
@@ -146,6 +153,7 @@ describe("advisor tool-call loop guard", () => {
 		);
 		expect(redirects).toHaveLength(1);
 		expect(advisor.state.messages.filter(message => message.role === "custom")).toHaveLength(0);
+		expect(advisor.state.error).toBeUndefined();
 	});
 
 	it("starts repetition counting fresh after an advisor context reset", () => {

--- a/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
-import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, Context } from "@oh-my-pi/pi-ai";
+import { Agent, type AgentMessage, type AgentTool, type AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Context, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -10,6 +10,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { AdvisorLoopGuard } from "../src/advisor/loop-guard";
 import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 
 const zeroUsage = {
@@ -145,6 +146,52 @@ describe("advisor tool-call loop guard", () => {
 		);
 		expect(redirects).toHaveLength(1);
 		expect(advisor.state.messages.filter(message => message.role === "custom")).toHaveLength(0);
+	});
+
+	it("starts repetition counting fresh after an advisor context reset", () => {
+		const settings = Settings.isolated({
+			"model.toolCallLoopGuard.enabled": true,
+			"model.toolCallLoopGuard.threshold": 3,
+		});
+		const messages: AgentMessage[] = [];
+		const guard = new AdvisorLoopGuard({
+			settings,
+			name: "test",
+			liveMessages: () => messages,
+			appendMessage: message => messages.push(message),
+			abort: () => {},
+		});
+		const turn = (id: string): AgentTurnEndContext => {
+			const message: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "toolCall", id, name: "read", arguments: { path: "missing.ts" } }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "test",
+				usage: zeroUsage,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			};
+			const result: ToolResultMessage = {
+				role: "toolResult",
+				toolCallId: id,
+				toolName: "read",
+				content: [{ type: "text", text: "ENOENT" }],
+				isError: true,
+				timestamp: Date.now(),
+			};
+			return { message, toolResults: [result], willContinue: true };
+		};
+
+		guard.recordTurn(messages, turn("before-1"));
+		guard.recordTurn(messages, turn("before-2"));
+		guard.reset();
+		guard.recordTurn(messages, turn("after-1"));
+		guard.recordTurn(messages, turn("after-2"));
+		expect(messages).toHaveLength(0);
+		guard.recordTurn(messages, turn("after-3"));
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.role).toBe("user");
 	});
 
 	it("leaves the advisor unbounded when the shared loop guard is disabled", async () => {


### PR DESCRIPTION
Addresses item 3 of #9491 (the advisor half of the tool-call loop breaker; the other items in that issue are untouched).

## Problem

`ToolCallLoopGuard` is wired only into the primary session, in `StreamGuards.recordTurn` (`session/agent-session.ts` -> `session/stream-guards.ts`). Advisors drive a private `Agent` loop that never passes through it, and `AdvisorRuntime`'s only bound is `#consecutiveFailures` over **whole-turn provider failures** — which a turn that *succeeds* while burning dozens of identical failing tool calls never trips.

Net effect: an advisor could reissue one failing call indefinitely with no bound at all (40 consecutive failing `read`s in the report). Grepping `ToolCallLoopGuard` confirms it: the only non-test references are `packages/ai/src/utils/tool-call-loop-guard.ts` and `session/stream-guards.ts` — nothing under `advisor/`.

## Fix

`AdvisorLoopGuard` (`src/advisor/loop-guard.ts`), registered on the advisor agent via `setOnTurnEnd` at its construction site in `session-advisors.ts` — the same seam `AgentSession` uses for the primary.

Two deliberate choices:

- **Same knob, not a new one.** It reads the existing `model.toolCallLoopGuard.{enabled,threshold,exemptTools}`, so one setting governs both loops and there is no new settings surface to document.
- **The corrective is a `user` message, not the primary's custom one.** The advisor agent is built without `convertToLlm`, so it runs `defaultConvertToLlm`, which keeps only LLM-native roles (`user`/`assistant`/`toolResult`). A `role: "custom"` message would be silently dropped before the request and correct nothing — the guard would look wired while doing nothing. This is asserted in the test.

The shared template render and detail shape move to `session/tool-call-loop-redirect.ts` so both bounds speak with one wording instead of importing `prompts/system/tool-call-loop-redirect.md` at two sites. No behavior change on the primary path.

## Tests

`test/advisor-tool-call-loop-guard.test.ts` drives a **live advisor built through the real `SessionAdvisors` path** (`session.setAdvisorEnabled(true)` -> `session.getAdvisorAgent()`), against a stream that repeats one identical failing `read` call:

1. at `threshold: 3` the corrective is delivered exactly once, its rendered text reaches the advisor's **next request context** (the repeated tool name and count, plus the tool's error text), and it survives conversion — the assertion that no `custom` message is left in the advisor context is what pins the message-shape decision above;
2. with the guard disabled the loop stays unbounded (nine requests), so the setting is proved to gate the new path rather than the test passing for ambient reasons.

Because the harness goes through the real build path, the test also covers the `setOnTurnEnd` registration itself.

Verification:

- `bun test test/advisor-tool-call-loop-guard.test.ts test/agent-session-tool-call-loop-guard.test.ts test/advisor-context-maintenance.test.ts test/advisor-toggle.test.ts test/advisor/` -> 270 pass, 0 fail (13 files) — includes the primary loop-guard suite, which covers the extracted module.
- Negative control: stashing only `session-advisors.ts` (dropping the registration) reds case 1 with `Expected length: 1 / Received length: 0` — the test detects exactly the missing wiring this PR adds.
- `bun run check:ts` -> every workspace exits 0 (tsgo + biome clean).