### PR TITLE
feat(coding-agent): add native extension loading

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added `s`/`u` shortcuts to stage/unstage files directly from the sidebar
 - Added `space` shortcut as page down in the diff pane
 - Expanded `omp git` keyboard navigation: `alt+↓`/`alt+↑` jump hunks and roll into the adjacent file at the edges, `]`/`[` switch files, `←`/`→` collapse/expand sidebar directories, `enter` opens the selected file, vim motions (`j`/`k`/`h`/`l`/`g`/`G`) work in both panes, `1`–`4` pick a diff view directly, and `c` jumps to the commit form.
+- Added an `omp.extensionLoader: "native"` package-manifest opt-in that skips legacy Pi graph scanning and compatibility rewriting for OMP-native extensions.
 
 ### Fixed
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -31,7 +31,11 @@ import type { CustomMessagePayload } from "../../session/messages";
 import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../tools/file-write-fallback";
 import { EventBus } from "../../utils/event-bus";
 import * as TypeBox from "../legacy-typebox";
-import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/legacy-pi-compat";
+import {
+	installLegacyPiSpecifierShim,
+	loadLegacyPiModule,
+	loadNativeExtensionModule,
+} from "../plugins/legacy-pi-compat";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 
 import { resolvePath, withHostGuard } from "../utils";
@@ -55,34 +59,39 @@ installLegacyPiSpecifierShim();
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 type LoadedExtensionModule = ExtensionFactory | { default?: ExtensionFactory };
-let nativeExtensionLoadTag = 0;
+type ExtensionLoaderManifestCache = Map<string, Promise<boolean | null>>;
 
-async function usesNativeExtensionLoader(resolvedPath: string): Promise<boolean> {
+async function readNativeExtensionLoader(packageJsonPath: string): Promise<boolean | null> {
+	try {
+		const pkg = (await Bun.file(packageJsonPath).json()) as {
+			omp?: { extensionLoader?: unknown };
+			pi?: { extensionLoader?: unknown };
+		};
+		return (pkg.omp ?? pkg.pi)?.extensionLoader === "native";
+	} catch (error) {
+		return isEnoent(error) || isEacces(error) || hasFsCode(error, "EPERM") ? null : false;
+	}
+}
+
+async function usesNativeExtensionLoader(
+	resolvedPath: string,
+	manifestCache: ExtensionLoaderManifestCache,
+): Promise<boolean> {
 	let directory = path.dirname(resolvedPath);
 	while (true) {
 		const packageJsonPath = path.join(directory, "package.json");
-		try {
-			const pkg = (await Bun.file(packageJsonPath).json()) as {
-				omp?: { extensionLoader?: unknown };
-				pi?: { extensionLoader?: unknown };
-			};
-			return (pkg.omp ?? pkg.pi)?.extensionLoader === "native";
-		} catch (error) {
-			if (!(isEnoent(error) || isEacces(error) || hasFsCode(error, "EPERM"))) {
-				return false;
-			}
+		let lookup = manifestCache.get(packageJsonPath);
+		if (!lookup) {
+			lookup = readNativeExtensionLoader(packageJsonPath);
+			manifestCache.set(packageJsonPath, lookup);
 		}
+		const native = await lookup;
+		if (native !== null) return native;
+
 		const parent = path.dirname(directory);
 		if (parent === directory) return false;
 		directory = parent;
 	}
-}
-
-async function loadNativeExtensionModule(resolvedPath: string): Promise<unknown> {
-	nativeExtensionLoadTag += 1;
-	// Runtime-supplied extension paths require dynamic import. Native packages
-	// bypass legacy graph collection and compatibility source rewriting.
-	return import(`${resolvedPath}?omp-native=${nativeExtensionLoadTag}`);
 }
 
 function getExtensionFactory(module: LoadedExtensionModule): ExtensionFactory | null {
@@ -413,11 +422,15 @@ interface ImportedExtensionModule {
 	error: string | null;
 }
 
-async function importExtensionModule(extensionPath: string, cwd: string): Promise<ImportedExtensionModule> {
+async function importExtensionModule(
+	extensionPath: string,
+	cwd: string,
+	manifestCache: ExtensionLoaderManifestCache,
+): Promise<ImportedExtensionModule> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
 	try {
 		const module = (await withHostGuard(() =>
-			usesNativeExtensionLoader(resolvedPath).then(native =>
+			usesNativeExtensionLoader(resolvedPath, manifestCache).then(native =>
 				native ? loadNativeExtensionModule(resolvedPath) : loadLegacyPiModule(resolvedPath),
 			),
 		)) as LoadedExtensionModule;
@@ -490,8 +503,9 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 	const errors: Array<{ path: string; error: string }> = [];
 	const resolvedEventBus = eventBus ?? new EventBus();
 	const runtime = new ExtensionRuntime();
+	const manifestCache: ExtensionLoaderManifestCache = new Map();
 
-	const imported = await Promise.all(paths.map(extPath => importExtensionModule(extPath, cwd)));
+	const imported = await Promise.all(paths.map(extPath => importExtensionModule(extPath, cwd, manifestCache)));
 
 	for (let i = 0; i < paths.length; i++) {
 		const extPath = paths[i]!;

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -55,6 +55,35 @@ installLegacyPiSpecifierShim();
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 type LoadedExtensionModule = ExtensionFactory | { default?: ExtensionFactory };
+let nativeExtensionLoadTag = 0;
+
+async function usesNativeExtensionLoader(resolvedPath: string): Promise<boolean> {
+	let directory = path.dirname(resolvedPath);
+	while (true) {
+		const packageJsonPath = path.join(directory, "package.json");
+		try {
+			const pkg = (await Bun.file(packageJsonPath).json()) as {
+				omp?: { extensionLoader?: unknown };
+				pi?: { extensionLoader?: unknown };
+			};
+			return (pkg.omp ?? pkg.pi)?.extensionLoader === "native";
+		} catch (error) {
+			if (!(isEnoent(error) || isEacces(error) || hasFsCode(error, "EPERM"))) {
+				return false;
+			}
+		}
+		const parent = path.dirname(directory);
+		if (parent === directory) return false;
+		directory = parent;
+	}
+}
+
+async function loadNativeExtensionModule(resolvedPath: string): Promise<unknown> {
+	nativeExtensionLoadTag += 1;
+	// Runtime-supplied extension paths require dynamic import. Native packages
+	// bypass legacy graph collection and compatibility source rewriting.
+	return import(`${resolvedPath}?omp-native=${nativeExtensionLoadTag}`);
+}
 
 function getExtensionFactory(module: LoadedExtensionModule): ExtensionFactory | null {
 	const candidate = typeof module === "function" ? module : module.default;
@@ -387,7 +416,11 @@ interface ImportedExtensionModule {
 async function importExtensionModule(extensionPath: string, cwd: string): Promise<ImportedExtensionModule> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
 	try {
-		const module = (await withHostGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
+		const module = (await withHostGuard(() =>
+			usesNativeExtensionLoader(resolvedPath).then(native =>
+				native ? loadNativeExtensionModule(resolvedPath) : loadLegacyPiModule(resolvedPath),
+			),
+		)) as LoadedExtensionModule;
 		const factory = getExtensionFactory(module);
 
 		if (typeof factory !== "function") {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1178,16 +1178,22 @@ function toImportSpecifier(resolvedPath: string): string {
  * `node_modules` resolution. Host package rewrites (legacy
  * `@(scope)/pi-*`, TypeBox shim) always emit `file://` URLs because they resolve
  * to in-process host code that never changes between reloads.
+ *
+ * Native mode disables compatibility rewrites but retains relative graph-edge
+ * tagging, so every edited extension-owned module receives a fresh Bun identity.
  */
-async function rewriteLegacyExtensionSource(
+async function rewriteExtensionSource(
 	source: string,
 	importerPath: string,
 	mtimeTag: string | null = null,
 	resolvedImportMtimeTag: string | null = mtimeTag,
+	rewriteCompatibilitySpecifiers = true,
 ): Promise<string> {
-	// Compiled mode completes the override map from the build-supplied module
-	// keys on first use; every rewrite path must see the full map.
-	await ensureLegacyPiOverridesReady();
+	if (rewriteCompatibilitySpecifiers) {
+		// Compiled mode completes the override map from the build-supplied module
+		// keys on first use; every compatibility rewrite must see the full map.
+		await ensureLegacyPiOverridesReady();
+	}
 	const references = getExtensionSourceAnalysis(source, importerPath).references;
 	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
 	for (const reference of references) {
@@ -1195,25 +1201,27 @@ async function rewriteLegacyExtensionSource(
 
 		const specifier = reference.specifier;
 		let replacement: string | null = null;
-		const remappedSpecifier = remapLegacyPiSpecifier(specifier);
-		if (remappedSpecifier) {
-			try {
-				replacement = toImportSpecifier(resolveCanonicalPiSpecifier(remappedSpecifier));
-			} catch {
-				// Compiled fallback may be absent from a malformed build. Continue to
-				// the extension's on-disk peer dependency resolution below.
+		if (rewriteCompatibilitySpecifiers) {
+			const remappedSpecifier = remapLegacyPiSpecifier(specifier);
+			if (remappedSpecifier) {
+				try {
+					replacement = toImportSpecifier(resolveCanonicalPiSpecifier(remappedSpecifier));
+				} catch {
+					// Compiled fallback may be absent from a malformed build. Continue to
+					// the extension's on-disk peer dependency resolution below.
+				}
 			}
-		}
-		if (!replacement && TYPEBOX_SHIM_PATH && (specifier === "typebox" || specifier === "@sinclair/typebox")) {
-			replacement = toImportSpecifier(TYPEBOX_SHIM_PATH);
-		}
-		if (!replacement && specifier.startsWith("#")) {
-			const resolved = packageImportPath(specifier, await resolvePackageImportSpecifier(specifier, importerPath));
-			if (resolved) replacement = toGraphImportSpecifier(resolved, resolvedImportMtimeTag);
-		}
-		if (!replacement && isBareExtensionDependencySpecifier(specifier)) {
-			const resolved = await resolveExtensionBareDependency(specifier, importerPath);
-			if (resolved) replacement = toGraphImportSpecifier(resolved, resolvedImportMtimeTag);
+			if (!replacement && TYPEBOX_SHIM_PATH && (specifier === "typebox" || specifier === "@sinclair/typebox")) {
+				replacement = toImportSpecifier(TYPEBOX_SHIM_PATH);
+			}
+			if (!replacement && specifier.startsWith("#")) {
+				const resolved = packageImportPath(specifier, await resolvePackageImportSpecifier(specifier, importerPath));
+				if (resolved) replacement = toGraphImportSpecifier(resolved, resolvedImportMtimeTag);
+			}
+			if (!replacement && isBareExtensionDependencySpecifier(specifier)) {
+				const resolved = await resolveExtensionBareDependency(specifier, importerPath);
+				if (resolved) replacement = toGraphImportSpecifier(resolved, resolvedImportMtimeTag);
+			}
 		}
 		if (!replacement && mtimeTag && /^\.\.?\//.test(specifier) && !specifier.includes("?")) {
 			replacement = `${specifier}?mtime=${mtimeTag}`;
@@ -1223,7 +1231,7 @@ async function rewriteLegacyExtensionSource(
 		}
 	}
 	const withImports = applySpecifierReplacements(source, replacements);
-	return rewriteExtensionSpecifiers(withImports, importerPath);
+	return rewriteCompatibilitySpecifiers ? rewriteExtensionSpecifiers(withImports, importerPath) : withImports;
 }
 
 /** Test seam for compiled-binary legacy extension source rewriting. */
@@ -1233,7 +1241,7 @@ export async function __rewriteLegacyExtensionSourceForTests(
 	mtimeTag: string | null = null,
 	resolvedImportMtimeTag: string | null = mtimeTag,
 ): Promise<string> {
-	return rewriteLegacyExtensionSource(source, importerPath, mtimeTag, resolvedImportMtimeTag);
+	return rewriteExtensionSource(source, importerPath, mtimeTag, resolvedImportMtimeTag);
 }
 
 /**
@@ -2220,7 +2228,10 @@ interface ExtensionModuleGraph {
  * synchronous bridge. Resolved ESM imports inside third-party dependencies
  * omit the reload tag so their importer paths stay query-free.
  */
-async function collectExtensionModules(entryRealPath: string): Promise<ExtensionModuleGraph> {
+async function collectExtensionModules(
+	entryRealPath: string,
+	rewriteCompatibilitySpecifiers = true,
+): Promise<ExtensionModuleGraph> {
 	const modules = new Map<string, string>();
 	const commonJsPaths = new Set<string>();
 	const synchronousSourcePaths = new Set<string>();
@@ -2253,12 +2264,9 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 		}
 		modules.set(file, source);
 		const analysis = getExtensionSourceAnalysis(source, file);
-		const sourceIsCommonJs = await isGraphOwnedCommonJsModule(
-			file,
-			entryRealPath,
-			analysis.sourceType,
-			inheritedModuleKind,
-		);
+		const sourceIsCommonJs =
+			rewriteCompatibilitySpecifiers &&
+			(await isGraphOwnedCommonJsModule(file, entryRealPath, analysis.sourceType, inheritedModuleKind));
 		if (sourceIsCommonJs) {
 			commonJsPaths.add(file);
 		}
@@ -2266,6 +2274,9 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 		const references = analysis.references;
 		for (const reference of references) {
 			const specifier = reference.specifier;
+			if (!rewriteCompatibilitySpecifiers && (reference.kind !== "import" || !specifier.startsWith("."))) {
+				continue;
+			}
 			try {
 				let resolved: string | null = null;
 				let nextCacheBustResolvedImports = cacheBustResolvedImports;
@@ -2415,7 +2426,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 		if (commonJsPaths.has(modulePath)) {
 			modules.set(modulePath, await rewriteExtensionSpecifiers(source, modulePath, true));
 		} else if (synchronousSourcePaths.has(modulePath)) {
-			modules.set(modulePath, await rewriteLegacyExtensionSource(source, modulePath));
+			modules.set(modulePath, await rewriteExtensionSource(source, modulePath));
 		}
 	}
 	return {
@@ -2600,6 +2611,7 @@ async function installExtensionGraphHook(
 	commonJsPaths: Set<string>,
 	synchronousSourcePaths: ReadonlySet<string>,
 	cacheBustResolvedImportModules: ReadonlySet<string>,
+	rewriteCompatibilitySpecifiers: boolean,
 ): Promise<{ asyncModules: Map<string, string> }> {
 	const asyncModules = new Map<string, string>();
 	for (const [modulePath, source] of modules) {
@@ -2641,7 +2653,13 @@ async function installExtensionGraphHook(
 							raw = await Bun.file(sourcePath).text();
 						}
 						return {
-							contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag, resolvedImportMtimeTag),
+							contents: await rewriteExtensionSource(
+								raw,
+								sourcePath,
+								mtimeTag,
+								resolvedImportMtimeTag,
+								rewriteCompatibilitySpecifiers,
+							),
 							loader: getLoader(sourcePath),
 						};
 					})();
@@ -2702,13 +2720,16 @@ async function installExtensionGraphHook(
  * Returns a clearable handle to drop cached sources that weren't consumed
  * during the initial load; `undefined` when no new modules were discovered.
  */
-async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(): void } | undefined> {
+async function ensureExtensionGraphHook(
+	entryRealPath: string,
+	rewriteCompatibilitySpecifiers: boolean,
+): Promise<{ clear(): void } | undefined> {
 	const {
 		modules: currentModules,
 		commonJsPaths,
 		cacheBustResolvedImportModules: discoveredCacheBustModules,
 		synchronousSourcePaths,
-	} = await collectExtensionModules(entryRealPath);
+	} = await collectExtensionModules(entryRealPath, rewriteCompatibilitySpecifiers);
 	let cacheBustResolvedImportModules = extensionGraphCacheBustResolvedImportModules.get(entryRealPath);
 	if (!cacheBustResolvedImportModules) {
 		cacheBustResolvedImportModules = new Set<string>();
@@ -2729,7 +2750,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			// hooks installed while it was synchronous still serve it from this
 			// map — keep the pre-rewritten bytes fresh instead of serving the
 			// stale snapshot from the walk that flagged it.
-			synchronousModuleSources.set(modulePath, await rewriteLegacyExtensionSource(source, modulePath));
+			synchronousModuleSources.set(modulePath, await rewriteExtensionSource(source, modulePath));
 		}
 	}
 	let hookedModules = extensionGraphHookModules.get(entryRealPath);
@@ -2764,6 +2785,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			pendingCommonJsPaths,
 			pendingSynchronousSourcePaths,
 			cacheBustResolvedImportModules,
+			rewriteCompatibilitySpecifiers,
 		));
 		for (const modulePath of pendingModules.keys()) {
 			hookedModules.add(modulePath);
@@ -2782,25 +2804,26 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 }
 
 /**
- * Load a legacy Pi extension module from its real on-disk location.
+ * Load an extension module from its real on-disk location.
  *
  * The extension runs in place, so its `import.meta.url` is the real source file
- * and `__dirname`-relative `readFileSync` asset loads (HTML/CSS bundled next to
- * the entry) resolve exactly as they do under the original Pi runtime — no
- * temp-directory mirroring and no asset copying. An `onLoad` hook scoped to the
- * entry's source graph rewrites only host-resolved compatibility imports in the
- * extension's own source; everything else resolves natively.
+ * and `__dirname`-relative asset loads resolve without mirroring or copying.
+ * Both modes tag relative graph edges for same-process reloads. Legacy mode
+ * additionally rewrites compatibility imports; native mode leaves all other
+ * specifiers to Bun.
  */
-export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown> {
+async function loadExtensionModule(resolvedPath: string, rewriteCompatibilitySpecifiers: boolean): Promise<unknown> {
 	// Bun reports the realpath of a loaded module to `onLoad` and exposes it as
 	// `import.meta.url`. Resolve symlinks here too (macOS `/var`→`/private/var`,
 	// `bun link`/pnpm installs) so the rewrite filter matches the path Bun
 	// actually hands the hook.
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
-	await ensureLegacyPiOverridesReady();
-	const pendingSources = await ensureExtensionGraphHook(entryRealPath);
+	if (rewriteCompatibilitySpecifiers) {
+		await ensureLegacyPiOverridesReady();
+	}
+	const pendingSources = await ensureExtensionGraphHook(entryRealPath, rewriteCompatibilitySpecifiers);
 	try {
-		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
+		// Dynamic import is required: extension entry paths are user/plugin supplied at runtime.
 		// On POSIX, use the raw filesystem path so Bun keys the `?mtime`
 		// suffix as part of the module identity; Bun ignores query strings on
 		// `file://` specifiers, which would serve stale edited source.
@@ -2815,6 +2838,14 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 		// import time, not served from this load-time snapshot.
 		pendingSources?.clear();
 	}
+}
+
+export function loadNativeExtensionModule(resolvedPath: string): Promise<unknown> {
+	return loadExtensionModule(resolvedPath, false);
+}
+
+export function loadLegacyPiModule(resolvedPath: string): Promise<unknown> {
+	return loadExtensionModule(resolvedPath, true);
 }
 
 function getLoader(path: string): "js" | "jsx" | "ts" | "tsx" {

--- a/packages/coding-agent/src/extensibility/plugins/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/types.ts
@@ -38,6 +38,8 @@ export interface PluginManifest {
 	hooks?: string;
 	/** Extension entry points (relative paths from package root) */
 	extensions?: string[];
+	/** Load declared extensions without legacy Pi compatibility graph rewriting */
+	extensionLoader?: "native";
 	/** Command files (relative paths from package root) */
 	commands?: string[];
 

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -101,6 +101,42 @@ export default function(pi) {
 		}
 	});
 
+	it("bypasses legacy graph reads for native extension packages", async () => {
+		const cwd = tempDir.absolute();
+		const extDir = path.join(cwd, "native-ext");
+		fs.mkdirSync(extDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({
+				omp: {
+					extensionLoader: "native",
+					extensions: ["./index.ts"],
+				},
+			}),
+		);
+		const entryPath = path.join(extDir, "index.ts");
+		fs.writeFileSync(
+			entryPath,
+			`export default function(pi) {
+	pi.registerTool({
+		name: "native-tool",
+		label: "native-tool",
+		description: "Native extension tool",
+		parameters: pi.zod.object({}),
+		execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+	});
+}
+`,
+		);
+
+		const result = await loadExtensions([entryPath], cwd);
+
+		expect(result.errors).toEqual([]);
+		expect(result.extensions[0]?.tools.has("native-tool")).toBe(true);
+		const realEntryPath = fs.realpathSync(entryPath);
+		expect(reads.get(realEntryPath) ?? 0).toBe(0);
+	});
+
 	it("should read graph modules skipped by the initial import from disk at import time", async () => {
 		const cwd = tempDir.absolute();
 		const extDir = path.join(cwd, "ext");

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -101,7 +101,7 @@ export default function(pi) {
 		}
 	});
 
-	it("bypasses legacy graph reads for native extension packages", async () => {
+	it("loads native extension packages without compatibility rewrites", async () => {
 		const cwd = tempDir.absolute();
 		const extDir = path.join(cwd, "native-ext");
 		fs.mkdirSync(extDir, { recursive: true });
@@ -133,8 +133,60 @@ export default function(pi) {
 
 		expect(result.errors).toEqual([]);
 		expect(result.extensions[0]?.tools.has("native-tool")).toBe(true);
-		const realEntryPath = fs.realpathSync(entryPath);
-		expect(reads.get(realEntryPath) ?? 0).toBe(0);
+	});
+
+	it("reloads edited helpers across the native extension graph", async () => {
+		const cwd = tempDir.absolute();
+		const extDir = path.join(cwd, "native-reload");
+		fs.mkdirSync(extDir, { recursive: true });
+		fs.writeFileSync(path.join(extDir, "package.json"), JSON.stringify({ omp: { extensionLoader: "native" } }));
+		const helperPath = path.join(extDir, "helper.ts");
+		const entryPath = path.join(extDir, "index.ts");
+		fs.writeFileSync(helperPath, `export const toolName = "before";\n`);
+		fs.writeFileSync(
+			entryPath,
+			`import { toolName } from "./helper.ts";
+export default function(pi) {
+	pi.registerTool({
+		name: toolName,
+		label: toolName,
+		description: "Native reload tool",
+		parameters: pi.zod.object({}),
+		execute: async () => ({ content: [{ type: "text", text: toolName }] }),
+	});
+}
+`,
+		);
+
+		const before = await loadExtensions([entryPath], cwd);
+		expect(before.errors).toEqual([]);
+		expect(before.extensions[0]?.tools.has("before")).toBe(true);
+
+		fs.writeFileSync(helperPath, `export const toolName = "after";\n`);
+		const after = await loadExtensions([entryPath], cwd);
+
+		expect(after.errors).toEqual([]);
+		expect(after.extensions[0]?.tools.has("after")).toBe(true);
+		expect(after.extensions[0]?.tools.has("before")).toBe(false);
+	});
+
+	it("shares native package manifest reads across sibling entries", async () => {
+		const cwd = tempDir.absolute();
+		const extDir = path.join(cwd, "native-siblings");
+		fs.mkdirSync(extDir, { recursive: true });
+		const packageJsonPath = path.join(extDir, "package.json");
+		fs.writeFileSync(packageJsonPath, JSON.stringify({ omp: { extensionLoader: "native" } }));
+		const entries = ["first", "second"].map(name => {
+			const entryPath = path.join(extDir, `${name}.ts`);
+			fs.writeFileSync(entryPath, `export default function() {}\n`);
+			return entryPath;
+		});
+
+		const result = await loadExtensions(entries, cwd);
+
+		expect(result.errors).toEqual([]);
+		const realManifestPath = fs.realpathSync(packageJsonPath);
+		expect(reads.get(realManifestPath) ?? 0).toBe(1);
 	});
 
 	it("should read graph modules skipped by the initial import from disk at import time", async () => {


### PR DESCRIPTION
Adds an explicit native extension-loader manifest mode that bypasses legacy dependency-graph scanning and source rewriting. Includes loader regression coverage and changelog documentation.\n\nVerification: bun --cwd=packages/coding-agent run check