### PR TITLE
fix(lsp): classify rename_file stat failures instead of assuming absence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed `lsp rename_file` reporting an unreadable source path as "does not exist", and renaming onto a destination whose existence check failed for any reason other than the path being free ([#8381](https://github.com/can1357/oh-my-pi/issues/8381))
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -502,7 +502,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			}
 
 			try {
-				await fs.promises.stat(dest);
+				await fs.promises.lstat(dest);
 				return {
 					content: [
 						{

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -7,7 +7,7 @@ import type {
 	AgentToolUpdateCallback,
 	ToolApprovalDecision,
 } from "@oh-my-pi/pi-agent-core";
-import { logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { isEnoent, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type Theme, theme } from "../modes/theme/theme";
 import lspDescription from "../prompts/tools/lsp.md" with { type: "text" };
 import type { ToolSession } from "../tools";
@@ -467,26 +467,26 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			let sourceStat: fs.Stats;
 			try {
 				sourceStat = await fs.promises.stat(source);
-			} catch {
+			} catch (err) {
+				// Only ENOENT means "missing". Reporting EACCES/ELOOP/EIO as a
+				// missing path sends the caller hunting the wrong problem — and
+				// silently invites them to recreate a file that is already there.
+				const relSource = formatPathRelativeToCwd(source, this.session.cwd);
 				return {
 					content: [
 						{
 							type: "text",
-							text: `Error: source path does not exist: ${formatPathRelativeToCwd(source, this.session.cwd)}`,
+							text: isEnoent(err)
+								? `Error: source path does not exist: ${relSource}`
+								: `Error: cannot read source path ${relSource}: ${err instanceof Error ? err.message : String(err)}`,
 						},
 					],
 					details: { action, success: false, request: params },
 				};
 			}
 
-			let destExists = false;
 			try {
 				await fs.promises.stat(dest);
-				destExists = true;
-			} catch {
-				// expected: destination must not exist
-			}
-			if (destExists) {
 				return {
 					content: [
 						{
@@ -496,6 +496,21 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 					],
 					details: { action, success: false, request: params },
 				};
+			} catch (err) {
+				// ENOENT is the success case: the destination is free. Any other
+				// failure means we never established that, so renaming onto it
+				// could clobber a file we simply could not see.
+				if (!isEnoent(err)) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `Error: cannot read destination path ${formatPathRelativeToCwd(dest, this.session.cwd)}: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+						details: { action, success: false, request: params },
+					};
+				}
 			}
 
 			const enumerated = await enumerateRenamePairs(source, dest);

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -7,12 +7,13 @@ import type {
 	AgentToolUpdateCallback,
 	ToolApprovalDecision,
 } from "@oh-my-pi/pi-agent-core";
-import { isEnoent, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { isEnoent, isFsError, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type Theme, theme } from "../modes/theme/theme";
 import lspDescription from "../prompts/tools/lsp.md" with { type: "text" };
 import type { ToolSession } from "../tools";
 import { truncateForPrompt } from "../tools/approval";
 import { formatPathRelativeToCwd, resolveToCwd } from "../tools/path-utils";
+import { replaceTabs, shortenPath } from "../tools/render-utils";
 import { ToolAbortError, ToolError, throwIfAborted } from "../tools/tool-errors";
 import { clampTimeout } from "../tools/tool-timeouts";
 import {
@@ -144,6 +145,17 @@ async function enumerateRenamePairs(
 		});
 	}
 	return { pairs, directory: true, exceeded: false };
+}
+
+function formatRenameStatPath(filePath: string, cwd: string): string {
+	return replaceTabs(shortenPath(formatPathRelativeToCwd(filePath, cwd)));
+}
+
+/** Filesystem error detail safe for model/TUI output: never echo raw paths. */
+function formatRenameStatError(error: unknown): string {
+	if (!isFsError(error)) return "unknown filesystem error";
+	const syscall = error.syscall ? ` during ${replaceTabs(error.syscall)}` : "";
+	return `${replaceTabs(error.code)}${syscall}`;
 }
 
 /**
@@ -471,14 +483,14 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				// Only ENOENT means "missing". Reporting EACCES/ELOOP/EIO as a
 				// missing path sends the caller hunting the wrong problem — and
 				// silently invites them to recreate a file that is already there.
-				const relSource = formatPathRelativeToCwd(source, this.session.cwd);
+				const relSource = formatRenameStatPath(source, this.session.cwd);
 				return {
 					content: [
 						{
 							type: "text",
 							text: isEnoent(err)
 								? `Error: source path does not exist: ${relSource}`
-								: `Error: cannot read source path ${relSource}: ${err instanceof Error ? err.message : String(err)}`,
+								: `Error: cannot read source path ${relSource}: ${formatRenameStatError(err)}`,
 						},
 					],
 					details: { action, success: false, request: params },
@@ -491,7 +503,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 					content: [
 						{
 							type: "text",
-							text: `Error: destination already exists: ${formatPathRelativeToCwd(dest, this.session.cwd)}`,
+							text: `Error: destination already exists: ${formatRenameStatPath(dest, this.session.cwd)}`,
 						},
 					],
 					details: { action, success: false, request: params },
@@ -505,7 +517,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						content: [
 							{
 								type: "text",
-								text: `Error: cannot read destination path ${formatPathRelativeToCwd(dest, this.session.cwd)}: ${err instanceof Error ? err.message : String(err)}`,
+								text: `Error: cannot read destination path ${formatRenameStatPath(dest, this.session.cwd)}: ${formatRenameStatError(err)}`,
 							},
 						],
 						details: { action, success: false, request: params },

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -148,7 +148,11 @@ async function enumerateRenamePairs(
 }
 
 function formatRenameStatPath(filePath: string, cwd: string): string {
-	return replaceTabs(shortenPath(formatPathRelativeToCwd(filePath, cwd)));
+	const relative = formatPathRelativeToCwd(filePath, cwd);
+	// formatPathRelativeToCwd normalizes Windows separators. Shorten the
+	// original native path first when it stayed absolute so home matching uses
+	// the same separator form as os.homedir().
+	return replaceTabs(path.isAbsolute(relative) ? shortenPath(filePath) : relative);
 }
 
 /** Filesystem error detail safe for model/TUI output: never echo raw paths. */

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -716,7 +716,11 @@ export function shortenPath(filePath: unknown, homeDir?: string): string {
 		return "";
 	}
 	const home = homeDir ?? os.homedir();
-	if (home && filePath.startsWith(home)) {
+	const windowsStyle = /^[A-Za-z]:[\\/]/.test(home) || home.startsWith("\\\\");
+	const hasHomePrefix = windowsStyle
+		? filePath.toLowerCase().startsWith(home.toLowerCase())
+		: filePath.startsWith(home);
+	if (home && hasHomePrefix) {
 		const suffix = filePath.slice(home.length);
 		if (suffix === "" || suffix.startsWith(path.posix.sep) || suffix.startsWith(path.win32.sep)) {
 			return `~${suffix.replaceAll(path.win32.sep, path.posix.sep)}`;

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3595,6 +3595,37 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("shortens an outside-cwd Windows home path before separator normalization", async () => {
+		if (!lspHomeOverride) throw new Error("Expected isolated home");
+		const cwd = path.join(lspHomeOverride, "project");
+		const sourceFile = path.join(lspHomeOverride, "other", "locked.ts");
+		const destFile = path.join(lspHomeOverride, "other", "renamed.ts");
+		fs.mkdirSync(path.dirname(sourceFile), { recursive: true });
+		fs.mkdirSync(cwd, { recursive: true });
+		await Bun.write(sourceFile, "export const a = 1;\n");
+		const realStat = fs.promises.stat;
+		vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike) => {
+			if (target === sourceFile) {
+				throw Object.assign(new Error(`permission denied: ${sourceFile}`), {
+					code: "EACCES",
+					path: sourceFile,
+					syscall: "stat",
+				});
+			}
+			return await realStat(target);
+		}) as typeof fs.promises.stat);
+
+		const result = await new LspTool(makeLspSession(cwd)).execute("rename-home-eacces", {
+			action: "rename_file",
+			file: sourceFile,
+			new_name: destFile,
+			timeout: 5,
+		});
+		const output = textResult(result);
+		expect(output).toContain("cannot read source path ~");
+		expect(output).not.toContain(lspHomeOverride);
+	});
+
 	it("workspace reload rediscovers LSP servers after an empty config was cached", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-reload-redetect-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3514,6 +3514,71 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("rename_file reports an unreadable source as a read failure, not a missing path", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rename-source-eacces-");
+		try {
+			const sourceFile = path.join(tempDir.path(), "locked.ts");
+			const destFile = path.join(tempDir.path(), "renamed.ts");
+			await Bun.write(sourceFile, "export const a = 1;\n");
+
+			// EACCES is not ENOENT: the file is there, we just can't read it.
+			const realStat = fs.promises.stat;
+			vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike) => {
+				if (target === sourceFile) throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+				return await realStat(target);
+			}) as typeof fs.promises.stat);
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			const result = await tool.execute("rename-source-eacces", {
+				action: "rename_file",
+				file: sourceFile,
+				new_name: destFile,
+				timeout: 5,
+			});
+
+			const output = textResult(result);
+			expect(output).toContain("cannot read source path");
+			expect(output).toContain("permission denied");
+			expect(output).not.toContain("does not exist");
+			expect(result.details).toMatchObject({ action: "rename_file", success: false });
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
+	it("rename_file refuses to rename when the destination cannot be inspected", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rename-dest-eacces-");
+		try {
+			const sourceFile = path.join(tempDir.path(), "old.ts");
+			const destFile = path.join(tempDir.path(), "new.ts");
+			await Bun.write(sourceFile, "export const a = 1;\n");
+
+			// A failed destination probe never established that the path is free,
+			// so treating it as absent would rename onto a file we cannot see.
+			const realStat = fs.promises.stat;
+			vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike) => {
+				if (target === destFile) throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+				return await realStat(target);
+			}) as typeof fs.promises.stat);
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			const result = await tool.execute("rename-dest-eacces", {
+				action: "rename_file",
+				file: sourceFile,
+				new_name: destFile,
+				timeout: 5,
+			});
+
+			expect(textResult(result)).toContain("cannot read destination path");
+			expect(result.details).toMatchObject({ action: "rename_file", success: false });
+			expect(fs.existsSync(sourceFile)).toBe(true);
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("workspace reload rediscovers LSP servers after an empty config was cached", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-reload-redetect-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3595,6 +3595,36 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("rename_file treats a dangling destination symlink as an existing path", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rename-dangling-dest-");
+		try {
+			const sourceFile = path.join(tempDir.path(), "old.ts");
+			const destFile = path.join(tempDir.path(), "dangling.ts");
+			await Bun.write(sourceFile, "export const a = 1;\n");
+			const sourceStat = await fs.promises.stat(sourceFile);
+			const realLstat = fs.promises.lstat;
+			const lstatSpy = vi.spyOn(fs.promises, "lstat").mockImplementation((async (target: fs.PathLike) => {
+				if (target === destFile) return sourceStat;
+				return await realLstat(target);
+			}) as typeof fs.promises.lstat);
+
+			const result = await new LspTool(makeLspSession(tempDir.path())).execute("rename-dangling-dest", {
+				action: "rename_file",
+				file: sourceFile,
+				new_name: destFile,
+				timeout: 5,
+			});
+
+			expect(textResult(result)).toContain("destination already exists: dangling.ts");
+			expect(lstatSpy).toHaveBeenCalledWith(destFile);
+			expect(fs.existsSync(sourceFile)).toBe(true);
+			expect(fs.existsSync(destFile)).toBe(false);
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("shortens an outside-cwd Windows home path before separator normalization", async () => {
 		if (!lspHomeOverride) throw new Error("Expected isolated home");
 		const cwd = path.join(lspHomeOverride, "project");

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3524,7 +3524,13 @@ describe("lsp regressions", () => {
 			// EACCES is not ENOENT: the file is there, we just can't read it.
 			const realStat = fs.promises.stat;
 			vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike) => {
-				if (target === sourceFile) throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+				if (target === sourceFile) {
+					throw Object.assign(new Error(`permission denied: ${sourceFile}\tsecret`), {
+						code: "EACCES",
+						path: sourceFile,
+						syscall: "stat",
+					});
+				}
 				return await realStat(target);
 			}) as typeof fs.promises.stat);
 
@@ -3537,8 +3543,9 @@ describe("lsp regressions", () => {
 			});
 
 			const output = textResult(result);
-			expect(output).toContain("cannot read source path");
-			expect(output).toContain("permission denied");
+			expect(output).toContain("cannot read source path locked.ts: EACCES during stat");
+			expect(output).not.toContain(tempDir.path());
+			expect(output).not.toContain("\t");
 			expect(output).not.toContain("does not exist");
 			expect(result.details).toMatchObject({ action: "rename_file", success: false });
 		} finally {
@@ -3558,7 +3565,13 @@ describe("lsp regressions", () => {
 			// so treating it as absent would rename onto a file we cannot see.
 			const realStat = fs.promises.stat;
 			vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike) => {
-				if (target === destFile) throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+				if (target === destFile) {
+					throw Object.assign(new Error(`permission denied: ${destFile}\tsecret`), {
+						code: "EACCES",
+						path: destFile,
+						syscall: "stat",
+					});
+				}
 				return await realStat(target);
 			}) as typeof fs.promises.stat);
 
@@ -3570,7 +3583,10 @@ describe("lsp regressions", () => {
 				timeout: 5,
 			});
 
-			expect(textResult(result)).toContain("cannot read destination path");
+			const output = textResult(result);
+			expect(output).toContain("cannot read destination path new.ts: EACCES during stat");
+			expect(output).not.toContain(tempDir.path());
+			expect(output).not.toContain("\t");
 			expect(result.details).toMatchObject({ action: "rename_file", success: false });
 			expect(fs.existsSync(sourceFile)).toBe(true);
 		} finally {

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -110,6 +110,11 @@ describe("formatScreenshot", () => {
 		expect(shortenPath(String.raw`C:\Users\me\projects\demo`, home)).toBe("~/projects/demo");
 	});
 
+	it("shortens Windows home paths case-insensitively", () => {
+		const home = String.raw`C:\Users\Alice`;
+		expect(shortenPath(String.raw`c:\users\alice\projects\demo`, home)).toBe("~/projects/demo");
+	});
+
 	it("does not shorten paths outside the home boundary", () => {
 		const home = String.raw`C:\Users\me`;
 		const sibling = String.raw`C:\Users\me2\projects\demo`;


### PR DESCRIPTION
Fixes #8381.

## Problem

Both existence probes in `lsp rename_file` (`src/lsp/tool.ts`) swallowed every `stat` error with a bare `catch`.

**Source probe** reported any failure as `source path does not exist`, so EACCES / ELOOP / EIO sent the caller hunting a missing file that was in fact right there.

**Destination probe** was the worse half: a failed `stat` fell into the `// expected: destination must not exist` branch, so a path we never managed to inspect was treated as free and the rename proceeded onto it.

```ts
let destExists = false;
try {
	await fs.promises.stat(dest);
	destExists = true;
} catch {
	// expected: destination must not exist   <- EACCES lands here too
}
```

## Fix

Classify with `isEnoent` from `@oh-my-pi/pi-utils` (the central helper this repo already mandates for exactly this): only ENOENT means absent.

- Source unreadable for any other reason -> reported as a read failure carrying the underlying message, instead of a false "does not exist".
- Destination unreadable for any other reason -> the rename is refused, because a failed probe never established that the path was free.

The destination branch keeps ENOENT as its success case, so the normal path is unchanged.

## Tests

Two cases in `test/tools/lsp-regressions.test.ts`, each pinning one branch, using the file-local `vi.spyOn(fs.promises, "stat")` pattern already used elsewhere in this repo (`git-linked-worktree.test.ts`) so nothing leaks across files:

1. **unreadable source** -> output contains `cannot read source path` plus the underlying reason, and explicitly **not** `does not exist`;
2. **unreadable destination** -> the operation fails and the source file is still in place.

Negative control (stashing only `src/lsp/tool.ts`) reds both, and case 2 fails with the exact dangerous behavior this fixes:

```
expect(received).toContain("cannot read destination path")
Received: "Renamed old.ts -> new.ts\n  Renamed old.ts -> new.ts"
```

Verification:

- `bun test test/tools/lsp-regressions.test.ts` -> 98 pass, 1 fail; the single failure is a pre-existing environment limitation on my machine (`fs.symlinkSync` EPERM on Windows without developer mode, in the unrelated "rename target resolves to the same file" test) and is unaffected by this change.
- `bun run check:ts` -> every workspace exits 0 (tsgo + biome clean).