### PR TITLE
fix(ai): recognize provider message history limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider message-count limit errors being misclassified as payload rejections instead of recoverable context overflows ([#9629](https://github.com/can1357/oh-my-pi/issues/9629)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -99,6 +99,7 @@ const CONTEXT_OVERFLOW_EVIDENCE_PATTERNS = [
 	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 	/prompt filled the context window/i, // Ollama OpenAI-compatible empty length completion
 	/exceeds the limit of \d+ tokens?\b/i,
+	/chat history exceeds the \d+-message limit/i, // Provider message-count cap
 ] as const;
 // Numeric limit pattern — also matches media budgets, so must never veto a payload flag (#9235).
 const GENERIC_LIMIT_OVERFLOW_PATTERN = /exceeds the limit of \d+/i;

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -69,6 +69,15 @@ describe("isContextOverflow/isPayloadRejection - HTTP 413 variants", () => {
 		expect(isPayloadRejection(message)).toBe(false);
 	});
 
+	it("classifies provider chat-history count limits as overflow, not payload rejection", () => {
+		const message = createErrorMessage("413 Chat history exceeds the 800-message limit");
+		message.errorStatus = 413;
+		AIError.classifyMessage(message);
+
+		expect(isContextOverflow(message)).toBe(true);
+		expect(isPayloadRejection(message)).toBe(false);
+	});
+
 	it("keeps request_too_large carrying token-count evidence classified as overflow", () => {
 		const message = createErrorMessage("request_too_large: prompt is too long: 300000 tokens > 200000 maximum");
 		expect(isContextOverflow(message)).toBe(true);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed long sessions becoming unrecoverable when a provider rejects histories over its message-count limit ([#9629](https://github.com/can1357/oh-my-pi/issues/9629)).
 
 ## [18.0.4] - 2026-08-24
 


### PR DESCRIPTION
## Repro
On current `main`, `bun -e 'import { isContextOverflow } from "./packages/ai/src/error/flags.ts"; console.log(isContextOverflow({ stopReason: "error", errorMessage: "413 Chat history exceeds the 800-message limit" }));'` printed `false`, demonstrating that the reported provider rejection bypassed context-overflow recovery.

## Cause
`CONTEXT_OVERFLOW_EVIDENCE_PATTERNS` in `packages/ai/src/error/flags.ts` covered token and byte-oriented limits but not provider chat-history message-count caps. The HTTP 413 therefore remained a payload rejection instead of reaching the coding-agent session's existing compaction-and-retry path.

## Fix
- Classify explicit chat-history message-count cap errors as context overflow evidence.
- Add a regression test proving the 413 is an overflow and not a byte/media payload rejection.
- Document the recovered long-session behavior in the AI and coding-agent changelogs.

## Verification
`bun test packages/ai/test/overflow-utils.test.ts` passed 39 tests with 0 failures. Re-running the exact classifier repro printed `true`. The pre-publish gate also completed `bun run fix` and `bun check`.

Fixes #9629