### PR TITLE
feat(tui): tick the auto-retry countdown down instead of freezing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed the auto-retry countdown freezing on its initial seconds value: the delay was rendered once when the loader was created, so a long provider-stated wait (rate-limit resets, quota windows) looked stuck while the background timer ran. The remaining time now ticks down on every spinner frame.
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -2,7 +2,7 @@ import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { type Component, Loader, TERMINAL } from "@oh-my-pi/pi-tui";
-import { logger, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, logger, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import { extractTextContent } from "../../commit/utils";
 import { settings } from "../../config/settings";
@@ -1994,12 +1994,16 @@ export class EventController {
 			this.#restorePinnedErrorInline = true;
 			this.ctx.clearPinnedError();
 		}
-		const delaySeconds = Math.round(event.delayMs / 1000);
+		const retryStartMs = Date.now();
+		const retryLabel = `Retrying (${event.attempt}/${event.maxAttempts})`;
 		this.ctx.retryLoader = new Loader(
 			this.ctx.ui,
 			spinner => theme.fg("warning", spinner),
 			text => theme.fg("muted", text),
-			`Retrying (${event.attempt}/${event.maxAttempts}) in ${delaySeconds}s…${this.#maintenanceEscHint()}`,
+			() => {
+				const remaining = Math.max(0, event.delayMs - (Date.now() - retryStartMs));
+				return `${retryLabel} in ${formatDuration(remaining)}…${this.#maintenanceEscHint()}`;
+			},
 			getSymbolTheme().spinnerFrames,
 		);
 		this.ctx.statusContainer.addChild(this.ctx.retryLoader);

--- a/packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-loader-recovery.test.ts
@@ -198,6 +198,34 @@ describe("EventController loader recovery after overflow maintenance", () => {
 		expect(statusContainer.children).toContain(ctx.loadingAnimation);
 	});
 
+	it("ticks the auto-retry countdown down on spinner ticks instead of freezing", async () => {
+		const { ctx, streamState } = createContext();
+		const controller = new EventController(ctx);
+		const visible = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+		streamState.isStreaming = true;
+		await controller.handleEvent(RETRY_START);
+		expect(ctx.retryLoader).toBeDefined();
+
+		// Initial paint shows the full delay: RETRY_START carries delayMs 1000.
+		const first = visible(ctx.retryLoader!.render(80).join("\n"));
+		expect(first).toContain("Retrying (1/3) in 1.0s");
+
+		// 400ms of spinner ticks re-evaluate the closure: 600ms remain. A
+		// static label (the pre-fix banner) would still read "1.0s" here.
+		vi.advanceTimersByTime(400);
+		const second = visible(ctx.retryLoader!.render(80).join("\n"));
+		expect(second).toContain("in 600ms");
+		expect(second).not.toContain("in 1.0s");
+
+		// Past the deadline the remaining wait clamps at zero.
+		vi.advanceTimersByTime(2_000);
+		const third = visible(ctx.retryLoader!.render(80).join("\n"));
+		expect(third).toContain("in 0ms");
+
+		ctx.retryLoader!.stop();
+	});
+
 	it("re-shows the Working… loader after a subagent task completes while the session keeps streaming", async () => {
 		const { ctx, streamState, statusContainer, workingLoaders } = createContext();
 		const controller = new EventController(ctx);

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Renamed TerminalFrameProvider.resetHistory to beginHistoryReplay
 
+### Added
+
+- `Loader` now accepts a `() => string` message; the function is re-evaluated on each spinner tick so dynamic labels (live countdowns) advance in sync with the glyph instead of freezing on the initial value. Static strings remain the zero-cost path (`setText` short-circuits on unchanged content).
+
 ### Fixed
 
 - Fixed graceful terminal shutdown leaving eligible finalized output in the mutable viewport instead of retiring it before shell handoff.

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -32,7 +32,7 @@ export class Loader extends Text {
 		ui: TUI,
 		private spinnerColorFn: ColorFn,
 		private messageColorFn: LoaderMessageColorFn,
-		private message: string = "Loading...",
+		private message: string | (() => string) = "Loading...",
 		spinnerFrames?: string[],
 	) {
 		super("", 1, 0);
@@ -149,11 +149,18 @@ export class Loader extends Text {
 		}, delayMs);
 		this.#intervalId = timer;
 	}
-	/** Re-wrap the underlying Text only when its message or frame width changes. */
+	#resolveMessage(): string {
+		return typeof this.message === "function" ? this.message() : this.message;
+	}
+
+	/** Re-wrap the underlying Text only when its message or frame width changes.
+	 * When {@link message} is a function it is re-evaluated on every spinner
+	 * tick, so a dynamic label (e.g. a live countdown) advances in sync with
+	 * the glyph instead of freezing on the initial value. */
 	#syncText(): boolean {
 		const layoutFrame = this.#layoutFrames[this.#currentFrame];
 		this.#layoutFrame = layoutFrame;
-		return this.setText(`${layoutFrame} ${this.message}`);
+		return this.setText(`${layoutFrame} ${this.#resolveMessage()}`);
 	}
 
 	#requestPaint() {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -286,4 +286,30 @@ describe("Loader component", () => {
 		expect(container.children).toEqual([]);
 		tui.stop();
 	});
+	it("re-evaluates a dynamic message function on each spinner tick", () => {
+		vi.useFakeTimers();
+		const ui = { requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
+		let step = 0;
+		const loader = new Loader(
+			ui as unknown as TUI,
+			t => t,
+			t => t,
+			() => `step ${step}`,
+			["0", "1", "2", "3"],
+		);
+
+		// Initial sync at construction evaluates the function once.
+		expect(loader.render(20).join("\n")).toContain("step 0");
+
+		// Mutating the closure source alone does not repaint — the function
+		// is only re-evaluated when the spinner ticks and #syncText runs.
+		step = 1;
+		expect(loader.render(20).join("\n")).toContain("step 0");
+
+		vi.advanceTimersByTime(80); // first spinner advance re-evaluates the fn
+		expect(loader.render(20).join("\n")).toContain("step 1");
+		expect(loader.render(20).join("\n")).not.toContain("step 0");
+
+		loader.stop();
+	});
 });


### PR DESCRIPTION
`Loader` messages can now be `() => string`, re-evaluated on every spinner tick; the auto-retry banner uses this to recompute the remaining wait from the deadline each frame.

## What

- `Loader` accepts a `() => string` message alongside static strings; the function is re-evaluated on each spinner tick so dynamic labels advance with the glyph. Static strings keep the zero-cost path (`setText` short-circuits on unchanged content).
- The retry banner (`event-controller.ts`) passes a closure computing `event.delayMs - (Date.now() - retryStartMs)` via `formatDuration`, so a provider-stated multi-hour wait counts down live instead of showing the initial seconds value until the timer fires.
- Changelog entries in `packages/tui` (Added) and `packages/coding-agent` (Fixed) under `[Unreleased]`.

## Why

I ran into this while waiting out a multi-hour quota reset: the countdown showed the same number for over an hour while the background timer ran.

## Testing

- `bun test packages/tui/test/loader.test.ts` — pass, incl. new "re-evaluates a dynamic message function on each spinner tick" (mutating the closure source alone does not repaint; the fn re-evaluates when the spinner advances).
- Ran a real session locally against a provider-stated multi-hour wait: the `Retrying (N/M) in …` banner recomputed the remaining time on every spinner frame instead of sitting on the initial value, reached `0ms`, and the retry fired on schedule with the session resuming cleanly. No visual glitches around the spinner glyph during the whole wait.
- `bun check` passes.