### PR TITLE
fix(lsp): isolate clients by full server identity across reloads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed LSP clients with different process arguments, initialization options, or settings sharing the first configuration's process, and made `lsp reload *` replace and stop clients created from superseded configurations ([#8382](https://github.com/can1357/oh-my-pi/issues/8382), [#8384](https://github.com/can1357/oh-my-pi/issues/8384))
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1468,7 +1468,9 @@ export async function shutdownClientInstance(client: LspClient): Promise<boolean
 	}
 
 	client.proc.kill();
-	return await waitForExit(client, EXIT_TIMEOUT_MS);
+	const exited = await waitForExit(client, EXIT_TIMEOUT_MS);
+	if (!exited && !clients.has(client.name)) clients.set(client.name, client);
+	return exited;
 }
 
 /**

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -31,6 +31,7 @@ interface PendingClient {
 	token: symbol;
 }
 const clientLocks = new Map<string, PendingClient>();
+const invalidatedClientKeys = new Set<string>();
 const fileOperationLocks = new Map<string, Promise<void>>();
 
 /** Negative cache of recent init failures so a broken server fails fast instead of re-spawning per call. */
@@ -859,19 +860,35 @@ function clientKey(config: ServerConfig, cwd: string): string {
  * config would stay registered and running — the idle checker that would
  * eventually reap it is opt-in and off by default.
  */
-export async function shutdownStaleClients(cwd: string, configs: readonly ServerConfig[]): Promise<string[]> {
+export async function shutdownStaleClients(
+	cwd: string,
+	configs: readonly ServerConfig[],
+	signal?: AbortSignal,
+): Promise<string[]> {
 	const fresh = new Set(configs.map(config => clientKey(config, cwd)));
+	for (const key of fresh) invalidatedClientKeys.delete(key);
 	const resolvedCwd = path.resolve(cwd);
-	// A pre-init client exists only in clientLocks. Wait for stale initializers
-	// before scanning clients so they cannot publish behind this cleanup and run
-	// concurrently with the replacement started by reload *.
+	// Tombstone stale identities before awaiting initialization. Existing
+	// callers keep sharing their in-flight promise; later callers cannot spawn
+	// another stale process while reload is blocked on teardown.
 	const stalePending = Array.from(clientLocks.entries()).filter(
 		([key, pending]) => path.resolve(pending.cwd) === resolvedCwd && !fresh.has(key),
 	);
-	for (const [key, pending] of stalePending) {
-		if (clientLocks.get(key) === pending) clientLocks.delete(key);
+	for (const [key] of stalePending) invalidatedClientKeys.add(key);
+	for (const client of clients.values()) {
+		if (path.resolve(client.cwd) === resolvedCwd && !fresh.has(client.name)) {
+			invalidatedClientKeys.add(client.name);
+		}
 	}
-	await Promise.allSettled(stalePending.map(([, pending]) => pending.promise));
+	await Promise.all(
+		stalePending.map(async ([, pending]) => {
+			try {
+				await untilAborted(signal, pending.promise);
+			} catch {
+				throwIfAborted(signal);
+			}
+		}),
+	);
 
 	const stale = Array.from(clients.values()).filter(
 		client => path.resolve(client.cwd) === resolvedCwd && !fresh.has(client.name),
@@ -909,10 +926,9 @@ export async function getOrCreateClient(
 	signal?: AbortSignal,
 ): Promise<LspClient> {
 	const key = clientKey(config, cwd);
-
 	// Check if client already exists
 	const existingClient = clients.get(key);
-	if (existingClient) {
+	if (existingClient && !invalidatedClientKeys.has(key)) {
 		existingClient.lastActivity = Date.now();
 		return existingClient;
 	}
@@ -921,6 +937,9 @@ export async function getOrCreateClient(
 	const existingLock = clientLocks.get(key);
 	if (existingLock) {
 		return existingLock.promise;
+	}
+	if (invalidatedClientKeys.has(key)) {
+		throw new Error(`LSP configuration was superseded during reload: ${config.command}`);
 	}
 
 	// Fail fast on a recent deterministic init failure instead of re-spawning
@@ -1056,6 +1075,9 @@ export async function getOrCreateClient(
 			// Publish only after init succeeds: pre-init clients are reachable
 			// solely through clientLocks, so concurrent callers (warmup vs first
 			// tool call) wait for init instead of using an unacknowledged client.
+			if (invalidatedClientKeys.has(key)) {
+				throw new Error(`LSP configuration was superseded during initialization: ${config.command}`);
+			}
 			clients.set(key, client);
 			initFailures.delete(key);
 			return client;
@@ -1602,6 +1624,7 @@ export async function sendNotification(
  */
 export async function shutdownAll(): Promise<void> {
 	stopIdleChecker();
+	invalidatedClientKeys.clear();
 	const clientsToShutdown = Array.from(clients.values());
 	clients.clear();
 	// Mid-initialize clients live only in clientLocks (publication is deferred

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -841,7 +841,12 @@ const EXIT_TIMEOUT_MS = 1_000;
  */
 function clientKey(config: ServerConfig, cwd: string): string {
 	const spawnCommand = config.resolvedCommand ?? config.command;
-	const identity = stableStringifyJson([config.args ?? [], config.initOptions ?? null, config.settings ?? null]);
+	const identity = stableStringifyJson([
+		config.args ?? [],
+		config.initOptions ?? null,
+		config.settings ?? null,
+		config.languageId ?? null,
+	]);
 	return `${spawnCommand}:${cwd}:${identity}`;
 }
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -24,7 +24,13 @@ import { detectLanguageId, EquivalentUriMap, fileToUri, uriToFile } from "./util
 // =============================================================================
 
 const clients = new Map<string, LspClient>();
-const clientLocks = new Map<string, Promise<LspClient>>();
+interface PendingClient {
+	promise: Promise<LspClient>;
+	cwd: string;
+	config: ServerConfig;
+	token: symbol;
+}
+const clientLocks = new Map<string, PendingClient>();
 const fileOperationLocks = new Map<string, Promise<void>>();
 
 /** Negative cache of recent init failures so a broken server fails fast instead of re-spawning per call. */
@@ -851,6 +857,17 @@ function clientKey(config: ServerConfig, cwd: string): string {
 export async function shutdownStaleClients(cwd: string, configs: readonly ServerConfig[]): Promise<string[]> {
 	const fresh = new Set(configs.map(config => clientKey(config, cwd)));
 	const resolvedCwd = path.resolve(cwd);
+	// A pre-init client exists only in clientLocks. Wait for stale initializers
+	// before scanning clients so they cannot publish behind this cleanup and run
+	// concurrently with the replacement started by reload *.
+	const stalePending = Array.from(clientLocks.entries()).filter(
+		([key, pending]) => path.resolve(pending.cwd) === resolvedCwd && !fresh.has(key),
+	);
+	for (const [key, pending] of stalePending) {
+		if (clientLocks.get(key) === pending) clientLocks.delete(key);
+	}
+	await Promise.allSettled(stalePending.map(([, pending]) => pending.promise));
+
 	const stale = Array.from(clients.values()).filter(
 		client => path.resolve(client.cwd) === resolvedCwd && !fresh.has(client.name),
 	);
@@ -898,7 +915,7 @@ export async function getOrCreateClient(
 	// Check if another coroutine is already creating this client
 	const existingLock = clientLocks.get(key);
 	if (existingLock) {
-		return existingLock;
+		return existingLock.promise;
 	}
 
 	// Fail fast on a recent deterministic init failure instead of re-spawning
@@ -912,6 +929,7 @@ export async function getOrCreateClient(
 	}
 
 	// Create new client with lock
+	const lockToken = Symbol();
 	const clientPromise = (async () => {
 		const baseCommand = config.resolvedCommand ?? config.command;
 		const baseArgs = config.args ?? [];
@@ -970,7 +988,7 @@ export async function getOrCreateClient(
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(() => {
 			if (clients.get(key) === client) clients.delete(key);
-			if (clientLocks.get(key) === clientPromise) clientLocks.delete(key);
+			if (clientLocks.get(key)?.token === lockToken) clientLocks.delete(key);
 			client.resolveProjectLoaded();
 
 			// Reject any pending requests — the server is gone, they will never complete.
@@ -1051,11 +1069,11 @@ export async function getOrCreateClient(
 			}
 			throw err;
 		} finally {
-			clientLocks.delete(key);
+			if (clientLocks.get(key)?.token === lockToken) clientLocks.delete(key);
 		}
 	})();
 
-	clientLocks.set(key, clientPromise);
+	clientLocks.set(key, { promise: clientPromise, cwd, config, token: lockToken });
 	return clientPromise;
 }
 
@@ -1075,7 +1093,7 @@ export async function getActiveOrPendingClient(
 	const pending = clientLocks.get(clientKey(config, cwd));
 	if (!pending) return undefined;
 	try {
-		return await untilAborted(signal, pending);
+		return await untilAborted(signal, pending.promise);
 	} catch {
 		throwIfAborted(signal);
 		return undefined;
@@ -1584,7 +1602,7 @@ export async function shutdownAll(): Promise<void> {
 	// Mid-initialize clients live only in clientLocks (publication is deferred
 	// until init succeeds) — without this, their server processes outlive
 	// shutdown. Failed init promises already cleaned up after themselves.
-	const pendingClients = Array.from(clientLocks.values());
+	const pendingClients = Array.from(clientLocks.values(), pending => pending.promise);
 	clientLocks.clear();
 	const seen = new Set<LspClient>(clientsToShutdown);
 	await Promise.allSettled([

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { isEnoent, logger, postmortem, ptree, untilAborted } from "@oh-my-pi/pi-utils";
+import { isEnoent, logger, postmortem, ptree, stableStringifyJson, untilAborted } from "@oh-my-pi/pi-utils";
 import { MessageFramer } from "../jsonrpc/message-framing";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { applyWorkspaceEdit, type ExecutedWorkspaceChange } from "./edits";
@@ -823,8 +823,46 @@ const PROJECT_LOAD_TIMEOUT_MS = 15_000;
 const SHUTDOWN_TIMEOUT_MS = 5_000;
 const EXIT_TIMEOUT_MS = 1_000;
 
+/**
+ * Identity of a server process *and* its initialization: everything that makes
+ * two configs unsafe to share one client. `command` + `cwd` alone handed a
+ * config with different args/settings the client another config had spawned
+ * (#8382), and left a changed config resolving to the stale client after
+ * `reload *` (#8384). The command component mirrors the spawn site
+ * (`resolvedCommand ?? command`), so two configs naming the same binary
+ * differently still share, while the same name resolving to different binaries
+ * does not. JSON-encoded so no value can forge the separator.
+ */
 function clientKey(config: ServerConfig, cwd: string): string {
-	return `${config.command}:${cwd}`;
+	const spawnCommand = config.resolvedCommand ?? config.command;
+	const identity = stableStringifyJson([config.args ?? [], config.initOptions ?? null, config.settings ?? null]);
+	return `${spawnCommand}:${cwd}:${identity}`;
+}
+
+/**
+ * Shut down clients for `cwd` whose identity is absent from `configs`, and
+ * return the server commands torn down.
+ *
+ * `reload *` re-reads config from disk. Identity-aware keys make a changed
+ * server resolve to a fresh client, but the process spawned from the old
+ * config would stay registered and running — the idle checker that would
+ * eventually reap it is opt-in and off by default.
+ */
+export async function shutdownStaleClients(cwd: string, configs: readonly ServerConfig[]): Promise<string[]> {
+	const fresh = new Set(configs.map(config => clientKey(config, cwd)));
+	const resolvedCwd = path.resolve(cwd);
+	const stale = Array.from(clients.values()).filter(
+		client => path.resolve(client.cwd) === resolvedCwd && !fresh.has(client.name),
+	);
+	const results = await Promise.all(stale.map(client => shutdownClientInstance(client)));
+	const failed = stale.filter((_client, index) => results[index] !== true);
+	if (failed.length > 0) {
+		throw new Error(
+			"Failed to stop LSP server(s) with superseded configuration: " +
+				failed.map(client => client.config.command).join(", "),
+		);
+	}
+	return stale.map(client => client.config.command);
 }
 
 /** Allow an explicit user reload to retry a matching initialization failure immediately. */

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -1037,6 +1037,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			const stopped = await shutdownStaleClients(
 				this.session.cwd,
 				servers.map(([, serverConfig]) => serverConfig),
+				signal,
 			);
 			if (servers.length === 0) {
 				return {

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -26,6 +26,7 @@ import {
 	refreshFile,
 	sendNotification,
 	sendRequest,
+	shutdownStaleClients,
 	waitForProjectLoaded,
 } from "./client";
 import { getLinterClient } from "./clients";
@@ -1029,6 +1030,14 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			configCache.delete(this.session.cwd);
 			const refreshedConfig = getConfig(this.session.cwd);
 			const servers = getLspServers(refreshedConfig);
+			// Identity-aware client keys make a changed server resolve to a fresh
+			// client below, but the process spawned from the superseded config
+			// would stay registered and running otherwise (#8384). This also
+			// clears every old client when the refreshed config removes all servers.
+			const stopped = await shutdownStaleClients(
+				this.session.cwd,
+				servers.map(([, serverConfig]) => serverConfig),
+			);
 			if (servers.length === 0) {
 				return {
 					content: [{ type: "text", text: "No language server found for this action" }],
@@ -1036,6 +1045,11 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				};
 			}
 			const outputs: string[] = [];
+			if (stopped.length > 0) {
+				outputs.push(
+					"Stopped " + stopped.length + " server(s) with superseded configuration: " + stopped.join(", "),
+				);
+			}
 			for (const [workspaceServerName, workspaceServerConfig] of servers) {
 				throwIfAborted(signal);
 				clearInitializationFailure(workspaceServerConfig, this.session.cwd);

--- a/packages/coding-agent/src/mcp/tool-cache.ts
+++ b/packages/coding-agent/src/mcp/tool-cache.ts
@@ -3,7 +3,7 @@
  *
  * Stores tool definitions per server in agent.db for fast startup.
  */
-import { isRecord, logger } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, stableStringifyJson } from "@oh-my-pi/pi-utils";
 import type { AgentStorage } from "../session/agent-storage";
 import type { MCPServerConfig, MCPToolDefinition } from "./types";
 
@@ -17,24 +17,6 @@ type MCPToolCachePayload = {
 	tools: MCPToolDefinition[];
 };
 
-function stableClone(value: unknown): unknown {
-	if (Array.isArray(value)) {
-		return value.map(item => stableClone(item));
-	}
-	if (isRecord(value)) {
-		const sorted: Record<string, unknown> = {};
-		for (const key of Object.keys(value).sort()) {
-			sorted[key] = stableClone(value[key]);
-		}
-		return sorted;
-	}
-	return value;
-}
-
-function stableStringify(value: unknown): string {
-	return JSON.stringify(stableClone(value));
-}
-
 function toHex(buffer: ArrayBuffer): string {
 	const bytes = new Uint8Array(buffer);
 	let output = "";
@@ -45,7 +27,7 @@ function toHex(buffer: ArrayBuffer): string {
 }
 
 async function hashConfig(config: MCPServerConfig): Promise<string> {
-	const stable = stableStringify(config);
+	const stable = stableStringifyJson(config);
 	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(stable));
 	return toHex(digest);
 }

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3661,6 +3661,10 @@ describe("lsp regressions", () => {
 				rootMarkers: [],
 			};
 			const oldClientPromise = lspClient.getOrCreateClient(oldConfig, tempDir.path(), 1_000);
+			const oldOutcome = oldClientPromise.then(
+				() => "resolved",
+				error => String(error),
+			);
 			const initialize = await oldServer.waitFor(message => message.method === "initialize");
 
 			const newServer = installHandshakeLsp();
@@ -3671,16 +3675,55 @@ describe("lsp regressions", () => {
 			});
 			const tool = new LspTool(makeLspSession(tempDir.path()));
 			const reload = tool.execute("reload-pending-client", { action: "reload", file: "*" });
+			const concurrentOldOutcome = lspClient.getOrCreateClient(oldConfig, tempDir.path(), 1_000).then(
+				() => "resolved",
+				error => String(error),
+			);
 			await Bun.sleep(0);
 			expect(newServer.received.some(message => message.method === "initialize")).toBe(false);
-
 			oldServer.send({ jsonrpc: "2.0", id: initialize.id, result: { capabilities: {} } });
-			await oldClientPromise;
+			expect(await oldOutcome).toContain("superseded during initialization");
+			expect(await concurrentOldOutcome).toContain("superseded during initialization");
 			const result = await reload;
 
-			expect(oldServer.received.map(message => message.method)).toContain("shutdown");
+			expect(oldServer.killed).toBe(true);
+			expect(oldServer.received.filter(message => message.method === "initialize")).toHaveLength(1);
 			expect(newServer.received.map(message => message.method)).toContain("initialize");
 			expect(textResult(result)).toContain("Reloaded fake-lsp");
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
+	it("workspace reload deadline interrupts a stale pending initializer and prevents late publication", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-reload-pending-abort-");
+		try {
+			const oldServer = installFakeLsp(() => {});
+			const oldConfig: ServerConfig = {
+				command: "fake-lsp",
+				args: ["--mode", "old"],
+				fileTypes: [".ts"],
+				rootMarkers: [],
+			};
+			const oldClientPromise = lspClient.getOrCreateClient(oldConfig, tempDir.path());
+			const oldOutcome = oldClientPromise.then(
+				() => "resolved",
+				error => String(error),
+			);
+			const initialize = await oldServer.waitFor(message => message.method === "initialize");
+			const newConfig: ServerConfig = { ...oldConfig, args: ["--mode", "new"] };
+			const controller = new AbortController();
+			const reason = new Error("reload cancelled");
+			const cleanup = lspClient.shutdownStaleClients(tempDir.path(), [newConfig], controller.signal);
+			await Bun.sleep(0);
+			controller.abort(reason);
+			await expect(cleanup).rejects.toBeInstanceOf(ToolAbortError);
+
+			// The original caller did not carry the reload signal. Even after its
+			// initialize response arrives, the tombstone prevents stale publish.
+			oldServer.send({ jsonrpc: "2.0", id: initialize.id, result: { capabilities: {} } });
+			expect(await oldOutcome).toContain("superseded during initialization");
 		} finally {
 			await lspClient.shutdownAll();
 			tempDir.removeSync();

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -4093,7 +4093,7 @@ describe("lsp regressions", () => {
 		it("shutdownClientInstance reports a failed teardown when the process outlives the kill", async () => {
 			const tempDir = TempDir.createSync("@omp-lsp-teardown-delayed-");
 			try {
-				installFakeLsp(
+				const server = installFakeLsp(
 					(message, srv) => {
 						if (message.method === "initialize") {
 							srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
@@ -4109,6 +4109,10 @@ describe("lsp regressions", () => {
 
 				const exited = await lspClient.shutdownClientInstance(client);
 				expect(exited).toBe(false);
+				expect(lspClient.getActiveClients().some(s => s.name === config.command)).toBe(true);
+
+				server.exit(0);
+				await Bun.sleep(0);
 				expect(lspClient.getActiveClients().some(s => s.name === config.command)).toBe(false);
 			} finally {
 				vi.restoreAllMocks();

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3632,6 +3632,49 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("workspace reload waits for a stale pending client before starting its replacement", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-reload-pending-");
+		try {
+			const oldServer = installFakeLsp((message, server) => {
+				if (message.method === "shutdown") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					server.exit(0);
+				}
+			});
+			const oldConfig: ServerConfig = {
+				command: "fake-lsp",
+				args: ["--mode", "old"],
+				fileTypes: [".ts"],
+				rootMarkers: [],
+			};
+			const oldClientPromise = lspClient.getOrCreateClient(oldConfig, tempDir.path(), 1_000);
+			const initialize = await oldServer.waitFor(message => message.method === "initialize");
+
+			const newServer = installHandshakeLsp();
+			const newConfig: ServerConfig = { ...oldConfig, args: ["--mode", "new"] };
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "fake-lsp": newConfig },
+				idleTimeoutMs: undefined,
+			});
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			const reload = tool.execute("reload-pending-client", { action: "reload", file: "*" });
+			await Bun.sleep(0);
+			expect(newServer.received.some(message => message.method === "initialize")).toBe(false);
+
+			oldServer.send({ jsonrpc: "2.0", id: initialize.id, result: { capabilities: {} } });
+			await oldClientPromise;
+			const result = await reload;
+
+			expect(oldServer.received.map(message => message.method)).toContain("shutdown");
+			expect(newServer.received.map(message => message.method)).toContain("initialize");
+			expect(textResult(result)).toContain("Reloaded fake-lsp");
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("workspace reload rediscovers LSP servers after an empty config was cached", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-reload-redetect-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -393,10 +393,22 @@ describe("lsp regressions", () => {
 				tempDir.path(),
 				1_000,
 			);
+			const languageServer = installHandshakeLsp();
+			const differentLanguage = await lspClient.getOrCreateClient(
+				{ ...base, languageId: "typescriptreact" },
+				tempDir.path(),
+				1_000,
+			);
+			const filePath = path.join(tempDir.path(), "component.ts");
+			await Bun.write(filePath, "export const component = true;\n");
+			await lspClient.ensureFileOpen(differentLanguage, filePath);
+			const didOpen = await languageServer.waitFor(message => message.method === "textDocument/didOpen");
+			expect(didOpen.params).toMatchObject({ textDocument: { languageId: "typescriptreact" } });
 
 			expect(differentArgs).not.toBe(baseClient);
 			expect(differentInit).not.toBe(baseClient);
 			expect(differentSettings).not.toBe(baseClient);
+			expect(differentLanguage).not.toBe(baseClient);
 		} finally {
 			await lspClient.shutdownAll();
 			tempDir.removeSync();

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -230,6 +230,19 @@ function installFakeLsp(handler: FakeLspHandler, options?: FakeLspOptions): Fake
 	return server;
 }
 
+/** LSP fake that completes initialize and graceful shutdown handshakes. */
+function installHandshakeLsp(): FakeLspServer {
+	return installFakeLsp((message, server) => {
+		if (message.method === "initialize") {
+			server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+		} else if (message.method === "shutdown") {
+			server.send({ jsonrpc: "2.0", id: message.id, result: null });
+		} else if (message.method === "exit") {
+			server.exit(0);
+		}
+	});
+}
+
 type BunSpawnOptions = Bun.SpawnOptions.SpawnOptions<
 	Bun.SpawnOptions.Writable,
 	Bun.SpawnOptions.Readable,
@@ -333,6 +346,61 @@ describe("lsp regressions", () => {
 				},
 			},
 		});
+	});
+
+	it("keeps equivalent LSP configs shared but isolates distinct process and initialization semantics", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-client-identity-");
+		try {
+			installHandshakeLsp();
+			const base: ServerConfig = {
+				command: "fake-lsp",
+				args: ["--mode", "base"],
+				fileTypes: [".ts"],
+				rootMarkers: [],
+				initOptions: { nested: { beta: 2, alpha: 1 } },
+				settings: { diagnostics: { enabled: true, severity: "warning" } },
+			};
+			const baseClient = await lspClient.getOrCreateClient(base, tempDir.path(), 1_000);
+
+			// Object insertion order is not semantic: a canonical-equivalent config
+			// must still share the same process.
+			const equivalent = await lspClient.getOrCreateClient(
+				{
+					...base,
+					initOptions: { nested: { alpha: 1, beta: 2 } },
+					settings: { diagnostics: { severity: "warning", enabled: true } },
+				},
+				tempDir.path(),
+				1_000,
+			);
+			expect(equivalent).toBe(baseClient);
+
+			installHandshakeLsp();
+			const differentArgs = await lspClient.getOrCreateClient(
+				{ ...base, args: ["--mode", "other"] },
+				tempDir.path(),
+				1_000,
+			);
+			installHandshakeLsp();
+			const differentInit = await lspClient.getOrCreateClient(
+				{ ...base, initOptions: { nested: { alpha: 99, beta: 2 } } },
+				tempDir.path(),
+				1_000,
+			);
+			installHandshakeLsp();
+			const differentSettings = await lspClient.getOrCreateClient(
+				{ ...base, settings: { diagnostics: { enabled: false, severity: "warning" } } },
+				tempDir.path(),
+				1_000,
+			);
+
+			expect(differentArgs).not.toBe(baseClient);
+			expect(differentInit).not.toBe(baseClient);
+			expect(differentSettings).not.toBe(baseClient);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
 	});
 
 	it("uses a custom server languageId for disk and in-memory document opens", async () => {
@@ -3510,6 +3578,56 @@ describe("lsp regressions", () => {
 			expect(output).toContain("Renamed");
 		} finally {
 			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
+	it("workspace reload replaces a client whose process or initialization config changed", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-reload-identity-");
+		try {
+			const oldServer = installHandshakeLsp();
+			const oldConfig: ServerConfig = {
+				command: "fake-lsp",
+				args: ["--mode", "old"],
+				fileTypes: [".ts"],
+				rootMarkers: [],
+				initOptions: { generation: 1 },
+				settings: { diagnostics: false },
+			};
+			const oldClient = await lspClient.getOrCreateClient(oldConfig, tempDir.path(), 1_000);
+
+			const newServer = installHandshakeLsp();
+			const newConfig: ServerConfig = {
+				...oldConfig,
+				args: ["--mode", "new"],
+				initOptions: { generation: 2 },
+				settings: { diagnostics: true },
+			};
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "fake-lsp": newConfig },
+				idleTimeoutMs: undefined,
+			});
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			const result = await tool.execute("reload-client-identity", { action: "reload", file: "*" });
+			const newClient = await lspClient.getActiveOrPendingClient(newConfig, tempDir.path());
+
+			expect(newClient).toBeDefined();
+			expect(newClient).not.toBe(oldClient);
+			expect(oldServer.received.map(message => message.method)).toContain("shutdown");
+			expect(oldServer.received.map(message => message.method)).toContain("exit");
+			expect(newServer.received.map(message => message.method)).toContain("initialize");
+			expect(newServer.received).toContainEqual(
+				expect.objectContaining({
+					method: "workspace/didChangeConfiguration",
+					params: { settings: { diagnostics: true } },
+				}),
+			);
+			const output = textResult(result);
+			expect(output).toContain("Stopped 1 server(s) with superseded configuration: fake-lsp");
+			expect(output).toContain("Reloaded fake-lsp");
+		} finally {
+			await lspClient.shutdownAll();
 			tempDir.removeSync();
 		}
 	});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `stableStringifyJson` for deterministic serialization of nested JSON-shaped data.
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -21,3 +21,26 @@ export function tryParseJson<T = unknown>(content: string): T | null {
 export function stringifyJson(value: unknown, space?: string | number): string | undefined {
 	return JSON.stringify(value, (_key, item) => (typeof item === "bigint" ? item.toString() : item), space);
 }
+
+function stableJsonClone(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableJsonClone);
+	if (value !== null && typeof value === "object") {
+		const sorted: Record<string, unknown> = {};
+		for (const key of Object.keys(value).sort()) {
+			sorted[key] = stableJsonClone(Reflect.get(value, key));
+		}
+		return sorted;
+	}
+	return value;
+}
+
+/**
+ * Deterministically serialize JSON-shaped data by sorting object keys at every
+ * depth while preserving array order. Throws for values JSON cannot represent
+ * as a top-level value instead of returning an easy-to-misuse undefined.
+ */
+export function stableStringifyJson(value: unknown): string {
+	const serialized = JSON.stringify(stableJsonClone(value));
+	if (serialized === undefined) throw new TypeError("Value is not JSON-serializable");
+	return serialized;
+}

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -25,7 +25,7 @@ export function stringifyJson(value: unknown, space?: string | number): string |
 function stableJsonClone(value: unknown): unknown {
 	if (Array.isArray(value)) return value.map(stableJsonClone);
 	if (value !== null && typeof value === "object") {
-		const sorted: Record<string, unknown> = {};
+		const sorted = Object.create(null) as Record<string, unknown>;
 		for (const key of Object.keys(value).sort()) {
 			sorted[key] = stableJsonClone(Reflect.get(value, key));
 		}

--- a/packages/utils/test/json.test.ts
+++ b/packages/utils/test/json.test.ts
@@ -10,6 +10,13 @@ describe("stableStringifyJson", () => {
 		expect(stableStringifyJson({ args: ["--a", "--b"] })).not.toBe(stableStringifyJson({ args: ["--b", "--a"] }));
 	});
 
+	it("preserves __proto__ as an ordinary own JSON key", () => {
+		const value: unknown = JSON.parse('{"__proto__":{"x":1}}');
+
+		expect(stableStringifyJson(value)).toBe('{"__proto__":{"x":1}}');
+		expect(stableStringifyJson(value)).not.toBe(stableStringifyJson({}));
+	});
+
 	it("rejects a top-level value JSON cannot serialize", () => {
 		expect(() => stableStringifyJson(undefined)).toThrow("Value is not JSON-serializable");
 	});

--- a/packages/utils/test/json.test.ts
+++ b/packages/utils/test/json.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { stableStringifyJson } from "@oh-my-pi/pi-utils/json";
+
+describe("stableStringifyJson", () => {
+	it("canonicalizes nested object key order while preserving array order", () => {
+		const left = { settings: { beta: 2, alpha: { z: true, a: false } }, args: ["--b", "--a"] };
+		const right = { args: ["--b", "--a"], settings: { alpha: { a: false, z: true }, beta: 2 } };
+
+		expect(stableStringifyJson(left)).toBe(stableStringifyJson(right));
+		expect(stableStringifyJson({ args: ["--a", "--b"] })).not.toBe(stableStringifyJson({ args: ["--b", "--a"] }));
+	});
+
+	it("rejects a top-level value JSON cannot serialize", () => {
+		expect(() => stableStringifyJson(undefined)).toThrow("Value is not JSON-serializable");
+	});
+});


### PR DESCRIPTION
Fixes #8382.
Fixes #8384.

This covers the **process-local client half** deliberately left out of #9226. The mux identity on current `main` is already full (`command + args + cwd + sorted env`); `client.ts` still keyed only on `command:cwd`.

## Problem

`getOrCreateClient()` keyed the process-local registry on:

```ts
function clientKey(config: ServerConfig, cwd: string): string {
  return `${config.command}:${cwd}`;
}
```

Two configs sharing a command and cwd therefore reused one client even when their process or initialization semantics differed (`args`, `initOptions`, `settings`). The first config silently won.

`lsp reload *` re-read config from disk, but a changed config produced the same key and got the old client back. Even if the key were broadened alone, the old process would remain registered and running forever while the idle checker is disabled (its default).

## Fix

### Identity-aware local registry

The key now includes:

- actual spawn command (`resolvedCommand ?? command`);
- cwd;
- args;
- initialization options;
- settings.

Nested JSON objects are canonicalized before keying, so equivalent configs with different object insertion order still share one client; array order remains semantic.

The repository already had an unexported stable serializer in the MCP cache. Per the central-utility rule, this PR moves that implementation to `@oh-my-pi/pi-utils/json` as `stableStringifyJson` and reuses it from both MCP and LSP instead of adding a second copy. MCP cache semantics are unchanged.

### Reload lifecycle

After `reload *` refreshes config, it shuts down clients in that cwd whose identity is absent from the refreshed set **before** creating replacements. This also cleans all old clients when the refreshed config contains zero servers.

Teardown is load-bearing: if a stale process cannot be confirmed stopped, reload fails rather than starting a competing process over it.

The result reports which superseded servers were stopped, then sends `workspace/didChangeConfiguration` to the fresh client using the fresh settings.

## Tests

`lsp-regressions.test.ts` drives real process-local clients through the existing in-memory JSON-RPC transport:

1. canonical-equivalent nested configs share one client;
2. distinct args, init options, and settings each get a distinct client;
3. `reload *` with changed args/init/settings gracefully shuts down the old server (`shutdown` then `exit`), starts a new client, and sends the new settings to it.

`packages/utils/test/json.test.ts` pins recursive key canonicalization, array-order preservation, and rejection of an unserializable top-level value.

Verification:

- focused client identity + reload tests: 2 pass, 0 fail;
- stable JSON tests: 2 pass, 0 fail;
- MCP cache regression: 1 pass, 0 fail;
- full `lsp-regressions.test.ts`: 100 pass, 1 environment-only failure (`fs.symlinkSync` EPERM on Windows without developer mode, in the unrelated same-file rename test);
- negative control (stashing only `client.ts` + `tool.ts`): both new LSP tests fail — distinct configs reuse the same object and reload returns the old client;
- `bun run check:ts`: every workspace exits 0 (tsgo + biome clean).