### PR TITLE
fix(tui): stop fast typing from submitting a stale slash autocomplete…

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed graceful terminal shutdown leaving eligible finalized output in the mutable viewport instead of retiring it before shell handoff.
+- Fixed fast typing beating the debounced autocomplete refresh into submitting the stale popup selection: typing `/login` quickly after the `/lo` popup opened submitted `/loop` instead; Enter now only accepts a selection whose command name still matches the typed token and otherwise re-derives the completion from the live text.
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Fixed graceful terminal shutdown leaving eligible finalized output in the mutable viewport instead of retiring it before shell handoff.
-- Fixed fast typing beating the debounced autocomplete refresh into submitting the stale popup selection: typing `/login` quickly after the `/lo` popup opened submitted `/loop` instead; Enter now only accepts a selection whose command name still matches the typed token and otherwise re-derives the completion from the live text.
+- Fixed fast typing beating the debounced autocomplete refresh into submitting the stale popup selection: typing `/login` quickly after the `/lo` popup opened submitted `/loop` instead; Enter/Tab now only accept a selection that a fresh ranking for the typed token would still pick, and otherwise apply that fresh top-ranked completion.
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -442,6 +442,24 @@ export function midPromptSkillTokenMatches(lowerToken: string, name: string, des
 	return lowerName.startsWith(SKILL_NAMESPACE) && lowerName.slice(SKILL_NAMESPACE.length).startsWith(lowerToken);
 }
 
+/**
+ * Whether a submitted slash-command popup selection is still consistent with the
+ * live slash token at the cursor. Typing can outrun the debounced popup refresh,
+ * leaving the popup rendered for a shorter prefix while the token has already
+ * diverged (`/lo` popup, `/login` typed); accepting such a selection rewrites the
+ * typed token with the stale match (submitting `/loop` instead of `/login`).
+ * Uses the name/alias text matching from `buildSlashCommandCompletions`, and
+ * deliberately NOT its fuzzy-description matching: display descriptions fuzzy-
+ * match far too broadly at accept time (`loop` matches "Login: choose provider"),
+ * so a selection whose own value no longer matches the typed token is treated as
+ * stale. Callers re-derive the completion from the live token on rejection; that
+ * path applies the full ranking, including description matches.
+ */
+export function slashCommandTokenMatches(lowerToken: string, item: { value: string } | null | undefined): boolean {
+	if (!item) return false;
+	return scoreCommandTextMatch(lowerToken, item.value.toLowerCase()) > 0;
+}
+
 function buildMidPromptSkillCompletions(commands: CommandEntry[], lowerPrefix: string): AutocompleteItem[] {
 	return buildSlashCommandCompletions(
 		commands.filter(cmd => {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -442,24 +442,6 @@ export function midPromptSkillTokenMatches(lowerToken: string, name: string, des
 	return lowerName.startsWith(SKILL_NAMESPACE) && lowerName.slice(SKILL_NAMESPACE.length).startsWith(lowerToken);
 }
 
-/**
- * Whether a submitted slash-command popup selection is still consistent with the
- * live slash token at the cursor. Typing can outrun the debounced popup refresh,
- * leaving the popup rendered for a shorter prefix while the token has already
- * diverged (`/lo` popup, `/login` typed); accepting such a selection rewrites the
- * typed token with the stale match (submitting `/loop` instead of `/login`).
- * Uses the name/alias text matching from `buildSlashCommandCompletions`, and
- * deliberately NOT its fuzzy-description matching: display descriptions fuzzy-
- * match far too broadly at accept time (`loop` matches "Login: choose provider"),
- * so a selection whose own value no longer matches the typed token is treated as
- * stale. Callers re-derive the completion from the live token on rejection; that
- * path applies the full ranking, including description matches.
- */
-export function slashCommandTokenMatches(lowerToken: string, item: { value: string } | null | undefined): boolean {
-	if (!item) return false;
-	return scoreCommandTextMatch(lowerToken, item.value.toLowerCase()) > 0;
-}
-
 function buildMidPromptSkillCompletions(commands: CommandEntry[], lowerPrefix: string): AutocompleteItem[] {
 	return buildSlashCommandCompletions(
 		commands.filter(cmd => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -6,6 +6,7 @@ import {
 	findTrailingSlashCommandStart,
 	midPromptSkillTokenMatches,
 	SKILL_NAMESPACE,
+	slashCommandTokenMatches,
 } from "../autocomplete";
 import { BracketedPasteHandler, decodeReencodedPasteControls } from "../bracketed-paste";
 import { canonicalKeyId, getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -3275,11 +3276,15 @@ export class Editor implements Component, Focusable {
 	 * - Path branch is safe when the prefix is still a live suffix of the text; the
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
 	 * - Slash branch re-anchors when both the prefix and the current text carry a
-	 *   leading slash command and the current slash token is clean (no whitespace or
-	 *   inner slash), matching `applyCompletion`'s slash-branch guard. It only
-	 *   engages for command-shaped selections: absolute-path completions (`/tmp/fo`
-	 *   via the no-command-match fall-through) share the leading-slash prefix shape
-	 *   but must use the live-suffix path rule so the apply slice stays anchored.
+	 *   leading slash command, the current slash token is clean (no whitespace or
+	 *   inner slash), and the token still matches the selection itself, matching
+	 *   `applyCompletion`'s slash-branch guard. It only engages for command-shaped
+	 *   selections: absolute-path completions (`/tmp/fo` via the no-command-match
+	 *   fall-through) share the leading-slash prefix shape but must use the
+	 *   live-suffix path rule so the apply slice stays anchored. The token-match
+	 *   requirement rejects popups left stale by fast typing (prefix `/lo`, token
+	 *   `/login`), which `applyCompletion` would otherwise rewrite with the stale
+	 *   selection; Enter then falls through to the sync completion path.
 	 * - Mid-prompt skill branch re-anchors when the popup item is a skill and the
 	 *   current text still ends in a matching trailing slash token, preventing a
 	 *   stale selection from replacing a newer skill prefix.
@@ -3313,7 +3318,14 @@ export class Editor implements Component, Focusable {
 			const currentLeadingStart = findLeadingSlashCommandStart(currentTextBeforeCursor);
 			if (currentLeadingStart !== null) {
 				const token = currentTextBeforeCursor.slice(currentLeadingStart);
-				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
+				if (!token.includes(" ") && !token.slice(1).includes("/")) {
+					// Fast typing can outrun the 100 ms debounced popup refresh: the popup
+					// still shows matches for a shorter prefix while the live token has
+					// already diverged. Only accept when the live token still matches the
+					// selection itself, so `/login` typed past a `/lo` popup submits
+					// `/login` instead of the stale `/loop` selection.
+					return slashCommandTokenMatches(token.slice(1).toLowerCase(), item);
+				}
 			}
 			return false;
 		}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -6,7 +6,6 @@ import {
 	findTrailingSlashCommandStart,
 	midPromptSkillTokenMatches,
 	SKILL_NAMESPACE,
-	slashCommandTokenMatches,
 } from "../autocomplete";
 import { BracketedPasteHandler, decodeReencodedPasteControls } from "../bracketed-paste";
 import { canonicalKeyId, getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -1415,8 +1414,19 @@ export class Editor implements Component, Focusable {
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
-						// Autocomplete is stale - silently cancel; Tab has no fallback action here.
+						// Autocomplete is stale. For a stale slash-command popup, Tab does
+						// what a refreshed popup would: apply the fresh top-ranked completion
+						// for the live token (#9637 review). Otherwise silently cancel; Tab
+						// has no fallback action here.
+						if (!this.#isStaleSlashCommandPopup() || !this.#applySyncSlashCompletion(currentTextBeforeCursor)) {
+							this.#cancelAutocomplete();
+							return;
+						}
 						this.#cancelAutocomplete();
+						this.onAutocompleteUpdate?.();
+						if (this.onChange) {
+							this.onChange(this.getText());
+						}
 						return;
 					}
 					if (selected && this.#autocompleteProvider) {
@@ -1463,7 +1473,12 @@ export class Editor implements Component, Focusable {
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
-						// Autocomplete is stale - cancel and fall through to normal submission
+						// Autocomplete is stale. For a stale slash-command popup, re-derive
+						// the completion from the live token (fresh ranking, #9637 review)
+						// before submitting; then cancel and fall through in both cases.
+						if (this.#isStaleSlashCommandPopup()) {
+							this.#applySyncSlashCompletion(currentTextBeforeCursor);
+						}
 						this.#cancelAutocomplete();
 					} else {
 						if (selected && this.#autocompleteProvider) {
@@ -1491,7 +1506,12 @@ export class Editor implements Component, Focusable {
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
-						// Autocomplete is stale - cancel and fall through to normal submission
+						// Autocomplete is stale. For a stale slash-command popup, re-derive
+						// the completion from the live token (fresh ranking, #9637 review);
+						// then cancel and fall through to normal submission.
+						if (this.#isStaleSlashCommandPopup()) {
+							this.#applySyncSlashCompletion(currentTextBeforeCursor);
+						}
 						this.#cancelAutocomplete();
 					} else {
 						if (selected && this.#autocompleteProvider) {
@@ -3276,15 +3296,17 @@ export class Editor implements Component, Focusable {
 	 * - Path branch is safe when the prefix is still a live suffix of the text; the
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
 	 * - Slash branch re-anchors when both the prefix and the current text carry a
-	 *   leading slash command, the current slash token is clean (no whitespace or
-	 *   inner slash), and the token still matches the selection itself, matching
-	 *   `applyCompletion`'s slash-branch guard. It only engages for command-shaped
-	 *   selections: absolute-path completions (`/tmp/fo` via the no-command-match
-	 *   fall-through) share the leading-slash prefix shape but must use the
-	 *   live-suffix path rule so the apply slice stays anchored. The token-match
-	 *   requirement rejects popups left stale by fast typing (prefix `/lo`, token
-	 *   `/login`), which `applyCompletion` would otherwise rewrite with the stale
-	 *   selection; Enter then falls through to the sync completion path.
+	 *   leading slash command and the current slash token is clean (no whitespace
+	 *   or inner slash), matching `applyCompletion`'s slash-branch guard. It only
+	 *   engages for command-shaped selections: absolute-path completions
+	 *   (`/tmp/fo` via the no-command-match fall-through) share the leading-slash
+	 *   prefix shape but must use the live-suffix path rule so the apply slice
+	 *   stays anchored. A positive text match against the stale selection is not
+	 *   sufficient (issue #9637 review): the live token may rank a different
+	 *   command first (exact `log` outranks usage-heavy `login` for token `log`),
+	 *   so acceptance requires a fresh sync ranking for the live token to still
+	 *   select the same item; otherwise the accept paths re-derive the completion
+	 *   from the live token via #applySyncSlashCompletion.
 	 * - Mid-prompt skill branch re-anchors when the popup item is a skill and the
 	 *   current text still ends in a matching trailing slash token, preventing a
 	 *   stale selection from replacing a newer skill prefix.
@@ -3320,11 +3342,15 @@ export class Editor implements Component, Focusable {
 				const token = currentTextBeforeCursor.slice(currentLeadingStart);
 				if (!token.includes(" ") && !token.slice(1).includes("/")) {
 					// Fast typing can outrun the 100 ms debounced popup refresh: the popup
-					// still shows matches for a shorter prefix while the live token has
-					// already diverged. Only accept when the live token still matches the
-					// selection itself, so `/login` typed past a `/lo` popup submits
-					// `/login` instead of the stale `/loop` selection.
-					return slashCommandTokenMatches(token.slice(1).toLowerCase(), item);
+					// still shows the ranking for a shorter prefix while the live token has
+					// already diverged. A positive text match against the stale selection is
+					// not enough — the live token may rank a different command first (exact
+					// `log` outranks usage-heavy `login` for the token `log`). Only accept
+					// when a fresh sync ranking for the live token still selects this item;
+					// otherwise the accept paths re-derive the completion via
+					// #applySyncSlashCompletion.
+					const fresh = this.#autocompleteProvider?.trySyncSlashCompletion?.(currentTextBeforeCursor);
+					return !!item && !!fresh && fresh.items.length > 0 && fresh.items[0]!.value === item.value;
 				}
 			}
 			return false;
@@ -3335,6 +3361,42 @@ export class Editor implements Component, Focusable {
 		}
 
 		return currentTextBeforeCursor.endsWith(this.#autocompletePrefix);
+	}
+
+	/**
+	 * Whether the open popup is a stale leading-slash command popup (not a
+	 * path completion sharing the leading-slash prefix shape). Only these
+	 * popups re-derive their completion via #applySyncSlashCompletion.
+	 */
+	#isStaleSlashCommandPopup(): boolean {
+		return findLeadingSlashCommandStart(this.#autocompletePrefix) !== null && !this.#selectedCompletionIsPath();
+	}
+
+	/**
+	 * Apply the fresh top-ranked slash-command completion for the live
+	 * text-before-cursor, re-deriving what a refreshed popup would rank first.
+	 * Used by the Tab/Enter accept paths when the popup is stale (typing outran
+	 * the debounced refresh): instead of accepting the stale selection or
+	 * canceling outright, the accept does exactly what a refreshed popup would
+	 * have done. Returns false when no command matches the live token.
+	 */
+	#applySyncSlashCompletion(currentTextBeforeCursor: string): boolean {
+		const provider = this.#autocompleteProvider;
+		if (!provider?.trySyncSlashCompletion) return false;
+		const sync = provider.trySyncSlashCompletion(currentTextBeforeCursor);
+		if (!sync || sync.items.length === 0) return false;
+		const result = provider.applyCompletion(
+			this.#state.lines,
+			this.#state.cursorLine,
+			this.#state.cursorCol,
+			sync.items[0]!,
+			sync.prefix,
+		);
+		this.#state.lines = result.lines;
+		this.#state.cursorLine = result.cursorLine;
+		this.#setCursorCol(result.cursorCol);
+		result.onApplied?.();
+		return true;
 	}
 
 	/**

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -6,6 +6,7 @@ import {
 	findTrailingSlashCommandStart,
 	midPromptSkillTokenMatches,
 	SKILL_NAMESPACE,
+	scoreCommandTextMatch,
 } from "../autocomplete";
 import { BracketedPasteHandler, decodeReencodedPasteControls } from "../bracketed-paste";
 import { canonicalKeyId, getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -1416,8 +1417,10 @@ export class Editor implements Component, Focusable {
 					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
 						// Autocomplete is stale. For a stale slash-command popup, Tab does
 						// what a refreshed popup would: apply the fresh top-ranked completion
-						// for the live token (#9637 review). Otherwise silently cancel; Tab
-						// has no fallback action here.
+						// for the live token (#9637 review), then chain into argument
+						// completions the same way the fresh-selection path below does.
+						// Otherwise silently cancel; Tab has no fallback action here.
+						const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
 						if (!this.#isStaleSlashCommandPopup() || !this.#applySyncSlashCompletion(currentTextBeforeCursor)) {
 							this.#cancelAutocomplete();
 							return;
@@ -1426,6 +1429,9 @@ export class Editor implements Component, Focusable {
 						this.onAutocompleteUpdate?.();
 						if (this.onChange) {
 							this.onChange(this.getText());
+						}
+						if (shouldChainSlashCommandAutocomplete && this.#isCompletedSlashCommandAtCursor()) {
+							void this.#tryTriggerAutocomplete();
 						}
 						return;
 					}
@@ -3348,8 +3354,15 @@ export class Editor implements Component, Focusable {
 					// `log` outranks usage-heavy `login` for the token `log`). Only accept
 					// when a fresh sync ranking for the live token still selects this item;
 					// otherwise the accept paths re-derive the completion via
-					// #applySyncSlashCompletion.
-					const fresh = this.#autocompleteProvider?.trySyncSlashCompletion?.(currentTextBeforeCursor);
+					// #applySyncSlashCompletion. Providers without the optional sync ranker
+					// (extension wrappers delegating only the required provider methods)
+					// keep the older text-match acceptance: name/alias match against the
+					// selection, no fuzzy description hits.
+					const provider = this.#autocompleteProvider;
+					if (!provider?.trySyncSlashCompletion) {
+						return !!item && scoreCommandTextMatch(token.slice(1).toLowerCase(), item.value.toLowerCase()) > 0;
+					}
+					const fresh = provider.trySyncSlashCompletion(currentTextBeforeCursor);
 					return !!item && !!fresh && fresh.items.length > 0 && fresh.items[0]!.value === item.value;
 				}
 			}

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -1091,4 +1091,72 @@ describe("Editor fast-typing autocomplete race (stale popup accepted over typed 
 		expect(editor.getText()).toBe("/log ");
 		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
+
+	// Extension wrappers delegating only the required provider methods hide the
+	// optional trySyncSlashCompletion ranker; the accept paths must fall back to
+	// the older text-match acceptance instead of rejecting everything (#9637
+	// review).
+	class RankerlessWrapper implements AutocompleteProvider {
+		constructor(readonly inner: CombinedAutocompleteProvider) {}
+		getSuggestions(
+			lines: string[],
+			cursorLine: number,
+			cursorCol: number,
+			signal?: AbortSignal,
+		): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+			return this.inner.getSuggestions(lines, cursorLine, cursorCol, signal);
+		}
+		applyCompletion(lines: string[], cursorLine: number, cursorCol: number, item: AutocompleteItem, prefix: string) {
+			return this.inner.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+		}
+	}
+
+	it("keeps text-match acceptance for providers without the sync ranker", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new RankerlessWrapper(createUsageRankedProvider()));
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor); // popup selects "loop" via usage
+
+		// "lo" prefix-matches the stale selection; without a sync ranker the old
+		// acceptance behavior applies it rather than canceling.
+		for (const char of "lo") editor.handleInput(char);
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/loop");
+	});
+
+	it("chains into argument completions after a stale-Tab fresh completion", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[
+					{
+						name: "model",
+						description: "Pick the model",
+						getArgumentCompletions: async () => [{ value: "sonnet", label: "sonnet" }],
+					},
+					{ name: "mood", description: "Set the mood" },
+				],
+				"/tmp",
+				{ commandUsage: name => (name === "model" ? 10 : 0) },
+			),
+		);
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor); // popup selects "model" via usage
+
+		// Stale popup: "mode" outruns the debounce; the fresh ranking still picks
+		// model, applies it with its trailing space, and must reopen autocomplete
+		// for the command's arguments instead of requiring a second Tab.
+		for (const char of "mode") editor.handleInput(char);
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("/model ");
+		await untilAutocompleteShown(editor);
+	});
 });

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -1013,7 +1013,7 @@ describe("Editor fast-typing autocomplete race (stale popup accepted over typed 
 		for (const char of "login") editor.handleInput(char);
 		editor.handleInput("\t");
 
-		expect(editor.getText()).toBe("/login");
+		expect(editor.getText()).toBe("/login ");
 		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 
@@ -1045,5 +1045,50 @@ describe("Editor fast-typing autocomplete race (stale popup accepted over typed 
 		editor.handleInput("\r");
 
 		expect(submitted).toBe("/loop");
+	});
+
+	// Exact-command-vs-longer-command ranking race (#9637 review): the bare "/"
+	// popup selects the usage-heavy longer command, but the typed token is an
+	// exact match for the shorter one; accept must follow the fresh ranking.
+	function createOverlappingCommandsProvider(): CombinedAutocompleteProvider {
+		return new CombinedAutocompleteProvider(
+			[
+				{ name: "log", description: "Show the conversation log" },
+				{ name: "login", description: "Authenticate" },
+			],
+			"/tmp",
+			{ commandUsage: name => (name === "login" ? 10 : 0) },
+		);
+	}
+
+	it("Enter applies the fresh top-ranked command when the stale selection merely prefix-matches", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(createOverlappingCommandsProvider());
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor); // popup selects "login" via usage
+
+		for (const char of "log") editor.handleInput(char);
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/log");
+	});
+
+	it("Tab applies the fresh top-ranked command when the stale selection merely prefix-matches", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(createOverlappingCommandsProvider());
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor); // popup selects "login" via usage
+
+		for (const char of "log") editor.handleInput(char);
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("/log ");
+		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 });

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -952,3 +952,98 @@ describe("Editor autocomplete invalidation on destructive edits (issue #4295)", 
 		expect(submitted).toBe("hello");
 	});
 });
+
+describe("Editor fast-typing autocomplete race (stale popup accepted over typed text)", () => {
+	/** Popup provider whose `/`-popup ranks `loop` first via usage counts. */
+	function createUsageRankedProvider(): CombinedAutocompleteProvider {
+		return new CombinedAutocompleteProvider(
+			[
+				{ name: "login", description: "Authenticate" },
+				{ name: "loop", description: "Loop the current request" },
+			],
+			"/tmp",
+			{ commandUsage: name => (name === "loop" ? 10 : 0) },
+		);
+	}
+
+	it("submits what was typed, not the stale popup selection, when typing outruns the debounced refresh", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(createUsageRankedProvider());
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor);
+
+		// Type the rest of the command and press Enter within the same task, so the
+		// 100 ms debounced popup refresh never fires and the popup still shows the
+		// matches for the bare "/" prefix (selected: "loop" via usage ranking).
+		for (const char of "login") editor.handleInput(char);
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/login");
+	});
+
+	it("still accepts the popup selection when the typed token continues to match it", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(createUsageRankedProvider());
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor);
+
+		for (const char of "loop") editor.handleInput(char);
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/loop");
+	});
+
+	it("does not paste the stale popup selection on Tab after divergent typing", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(createUsageRankedProvider());
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor);
+
+		for (const char of "login") editor.handleInput(char);
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("/login");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
+	it("rejects a stale selection whose description fuzzy-matches the divergent token", async () => {
+		// Production shape of the race: the popup's rendered description (here
+		// "Login: choose provider") fuzzy-contains the typed token ("loop" matches
+		// via the o's in "choose" and the p in "provider"), so a description-aware
+		// accept-time guard would still accept the stale item and submit /login.
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[
+					{ name: "loop", description: "Toggle loop mode" },
+					{ name: "login", description: "Login: choose provider" },
+				],
+				"/tmp",
+				{ commandUsage: name => (name === "login" ? 10 : 0) },
+			),
+		);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor);
+
+		for (const char of "loop") editor.handleInput(char);
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/loop");
+	});
+});


### PR DESCRIPTION
 ## What
 
Currently, when typing a slash command, the last autocompletion gets submitted (that is, the stale popup selection is submitted) when the user presses Enter as opposed to what they actually typed in. An example is typing in `/login<ENTER>`; the autocompletion triggers `/loop` when `/lo` is typed. This happens with a very fast typist (around 100 - 140 WPM?) on a local instance of oh-my-pi running in WezTerm on either macOS or Linux. (Somewhere between 17.5.3 and 18.0.4, the priority reversed, so on 18.0.4 quickly typing `/loop<ENTER>` will get trigger `/login`.)

Another example is catching /models instead of /move.
 
## Why
 
When I'm typing I often end up tripping `/loop` instead of `/login`, etc. and this is highly annoying.

## Testing

Testing approach:
1. Ensure existing tests passed and nothing changed.
2. New test fails with current code base.
3. New test passes with fix.
4. Manual test by typing it over and over.

See issues #4295 and #4809 for more background on where this regression possibly entered.

The testing was run against both 17.5.3 (both manually and automated) and 18.0.4. The only difference observed was that 18.0.4 seemed to have a different autocompletion priority.

AI assistance used: oh-my-pi v17.3.5 with GLM-5.3.

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
