### PR TITLE
feat(coding-agent): expose extension UI requests and command output to RpcClient

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `RpcClient.onExtensionUiRequest`, `RpcClient.respondToExtensionUi`, and `RpcClient.onCommandOutput`, so an RPC host can render and answer extension UI requests (including tool approval) and surface builtin slash command output instead of having those frames dropped
 - Added side-by-side image and SVG previews to `omp git`, including local Git LFS object resolution and explicit placeholders for unavailable or unsupported binary content.
 - Added the `omp if-bench` command: a zero-tool instruction-following and working-memory benchmark that drives one cached conversation per model, adding one more glyph array action every turn while a `nya{1,N}` directive moves through the prompt, with a live turn-ladder board and a ranked scoreboard
 - Added `q` shortcut to exit the git TUI

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -23,6 +23,7 @@ import type {
 	RpcAvailableCommandsUpdateFrame,
 	RpcAvailableSlashCommand,
 	RpcCommand,
+	RpcCommandOutputFrame,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
 	RpcHandoffResult,
@@ -76,6 +77,8 @@ export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
 export type RpcAvailableCommandsUpdateListener = (commands: RpcAvailableSlashCommand[]) => void;
+export type RpcExtensionUiRequestListener = (request: RpcExtensionUIRequest) => void;
+export type RpcCommandOutputListener = (text: string) => void;
 
 export interface RpcClientToolContext<TDetails = unknown> {
 	toolCallId: string;
@@ -190,6 +193,11 @@ function isRpcAvailableCommandsUpdateFrame(value: unknown): value is RpcAvailabl
 	return value.type === "available_commands_update" && Array.isArray(value.commands);
 }
 
+function isRpcCommandOutputFrame(value: unknown): value is RpcCommandOutputFrame {
+	if (!isRecord(value)) return false;
+	return value.type === "command_output" && typeof value.text === "string";
+}
+
 function isRpcHostToolCallRequest(value: unknown): value is RpcHostToolCallRequest {
 	if (!isRecord(value)) return false;
 	return (
@@ -259,7 +267,8 @@ export class RpcClient {
 	#pendingHostToolCalls = new Map<string, { controller: AbortController }>();
 	#requestId = 0;
 	#protocolVersion: RpcProtocolVersion = 1;
-	#extensionUiListeners: Set<(req: RpcExtensionUIRequest) => void> = new Set();
+	#extensionUiListeners: Set<RpcExtensionUiRequestListener> = new Set();
+	#commandOutputListeners: Set<RpcCommandOutputListener> = new Set();
 	#abortController = new AbortController();
 
 	constructor(private options: RpcClientOptions = {}) {
@@ -536,6 +545,39 @@ export class RpcClient {
 	onAvailableCommandsUpdate(listener: RpcAvailableCommandsUpdateListener): () => void {
 		this.#availableCommandsUpdateListeners.add(listener);
 		return () => this.#availableCommandsUpdateListeners.delete(listener);
+	}
+
+	/**
+	 * Subscribe to extension UI requests emitted by the RPC server.
+	 *
+	 * Tool approval reaches a host through this channel: the tool wrapper asks
+	 * with `uiContext.select(prompt, ["Approve", "Deny"])`, so it arrives as an
+	 * ordinary `extension_ui_request` rather than a frame of its own. Every
+	 * blocking method (`select`, `confirm`, `input`, `editor`) must be answered
+	 * with {@link respondToExtensionUi}; the approval dialog carries no timeout,
+	 * so an unanswered request stalls the turn indefinitely.
+	 */
+	onExtensionUiRequest(listener: RpcExtensionUiRequestListener): () => void {
+		this.#extensionUiListeners.add(listener);
+		return () => this.#extensionUiListeners.delete(listener);
+	}
+
+	/**
+	 * Answer a pending extension UI request.
+	 *
+	 * Responses carrying an unknown or already-settled id are discarded by the
+	 * server, so answering twice is harmless.
+	 */
+	respondToExtensionUi(response: RpcExtensionUIResponse): void {
+		this.#writeFrame(response);
+	}
+
+	/**
+	 * Subscribe to text printed by builtin slash commands.
+	 */
+	onCommandOutput(listener: RpcCommandOutputListener): () => void {
+		this.#commandOutputListeners.add(listener);
+		return () => this.#commandOutputListeners.delete(listener);
 	}
 
 	/**
@@ -1077,6 +1119,13 @@ export class RpcClient {
 		if (isRpcAvailableCommandsUpdateFrame(data)) {
 			for (const listener of this.#availableCommandsUpdateListeners) {
 				listener(data.commands);
+			}
+			return;
+		}
+
+		if (isRpcCommandOutputFrame(data)) {
+			for (const listener of this.#commandOutputListeners) {
+				listener(data.text);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -556,6 +556,12 @@ export class RpcClient {
 	 * blocking method (`select`, `confirm`, `input`, `editor`) must be answered
 	 * with {@link respondToExtensionUi}; the approval dialog carries no timeout,
 	 * so an unanswered request stalls the turn indefinitely.
+	 *
+	 * {@link login} installs its own scoped listener for the duration of the auth
+	 * flow, so a persistent listener registered here also sees the `open_url` and
+	 * `input` requests that flow emits. Answering them from both is harmless — the
+	 * server discards a response whose id has already settled — but a host that
+	 * drives its own login UI may want to ignore requests while login is running.
 	 */
 	onExtensionUiRequest(listener: RpcExtensionUiRequestListener): () => void {
 		this.#extensionUiListeners.add(listener);

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -135,6 +135,12 @@ export interface RpcAvailableCommandsUpdateFrame {
 	commands: RpcAvailableSlashCommand[];
 }
 
+/** Text printed by a builtin slash command, emitted as the command runs. */
+export interface RpcCommandOutputFrame {
+	type: "command_output";
+	text: string;
+}
+
 export interface RpcPromptResultFrame {
 	type: "prompt_result";
 	id?: string;

--- a/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
+++ b/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
@@ -93,6 +93,13 @@ for await (const raw of console) {
 				continue;
 			}
 			if (Bun.env.MOCK_RPC_IGNORE_COMMANDS === "1") continue;
+			if (frame.type === "extension_ui_response") {
+				// Echoed so a test can observe that the answer reached the server,
+				// rather than only that the client wrote it to stdin.
+				writeFrame({ type: "command_output", text: `ui_response:${JSON.stringify(frame)}` });
+				continue;
+			}
+
 			const id = typeof frame.id === "string" ? frame.id : undefined;
 			if (frame.type === "negotiate_protocol" && frame.protocolVersion === 2) {
 				writeFrame({
@@ -180,6 +187,19 @@ for await (const raw of console) {
 					data,
 				});
 				continue;
+			}
+
+			if (Bun.env.MOCK_RPC_EXTENSION_UI === "1" && frame.type === "get_state") {
+				writeFrame({
+					type: "extension_ui_request",
+					id: "mock-ui-1",
+					method: "confirm",
+					title: "mock confirm",
+					message: "answer me",
+				});
+			}
+			if (Bun.env.MOCK_RPC_COMMAND_OUTPUT === "1" && frame.type === "get_state") {
+				writeFrame({ type: "command_output", text: "mock command output" });
 			}
 
 			writeFrame({

--- a/packages/coding-agent/test/rpc-client.extension-ui.test.ts
+++ b/packages/coding-agent/test/rpc-client.extension-ui.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import type { RpcExtensionUIRequest } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
+
+const MOCK_AGENT = path.join(import.meta.dir, "fixtures", "mock-rpc-agent.ts");
+
+/** Resolves once `predicate` holds, so a test never races the reader loop. */
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() > deadline) throw new Error("timed out waiting for a frame");
+		await Bun.sleep(10);
+	}
+}
+
+describe("RpcClient extension UI and command output", () => {
+	test("delivers extension UI requests to a host listener", async () => {
+		using client = new RpcClient({ cliPath: MOCK_AGENT, env: { MOCK_RPC_EXTENSION_UI: "1" } });
+		await client.start();
+
+		const seen: RpcExtensionUIRequest[] = [];
+		client.onExtensionUiRequest(request => seen.push(request));
+
+		await client.getState();
+		await waitFor(() => seen.length > 0);
+
+		expect(seen[0]).toMatchObject({ type: "extension_ui_request", id: "mock-ui-1", method: "confirm" });
+	}, 20_000);
+
+	test("sends an answer the server actually receives", async () => {
+		using client = new RpcClient({ cliPath: MOCK_AGENT, env: { MOCK_RPC_EXTENSION_UI: "1" } });
+		await client.start();
+
+		// The mock echoes any `extension_ui_response` back as `command_output`, so
+		// this asserts the answer reached the server rather than only that the
+		// client wrote it to stdin.
+		const echoes: string[] = [];
+		client.onCommandOutput(text => echoes.push(text));
+
+		const requests: RpcExtensionUIRequest[] = [];
+		client.onExtensionUiRequest(request => requests.push(request));
+
+		await client.getState();
+		await waitFor(() => requests.length > 0);
+
+		const request = requests[0];
+		if (!request) throw new Error("no extension UI request arrived");
+		client.respondToExtensionUi({ type: "extension_ui_response", id: request.id, confirmed: true });
+		await waitFor(() => echoes.some(text => text.startsWith("ui_response:")));
+
+		const echoed = echoes.find(text => text.startsWith("ui_response:")) ?? "";
+		expect(JSON.parse(echoed.slice("ui_response:".length))).toMatchObject({
+			type: "extension_ui_response",
+			id: "mock-ui-1",
+			confirmed: true,
+		});
+	}, 20_000);
+
+	test("unsubscribing stops delivery", async () => {
+		using client = new RpcClient({ cliPath: MOCK_AGENT, env: { MOCK_RPC_EXTENSION_UI: "1" } });
+		await client.start();
+
+		const seen: RpcExtensionUIRequest[] = [];
+		const unsubscribe = client.onExtensionUiRequest(request => seen.push(request));
+		unsubscribe();
+
+		const kept: RpcExtensionUIRequest[] = [];
+		client.onExtensionUiRequest(request => kept.push(request));
+
+		await client.getState();
+		await waitFor(() => kept.length > 0);
+
+		expect(seen).toHaveLength(0);
+	}, 20_000);
+
+	test("delivers builtin command output to a host listener", async () => {
+		using client = new RpcClient({ cliPath: MOCK_AGENT, env: { MOCK_RPC_COMMAND_OUTPUT: "1" } });
+		await client.start();
+
+		const output: string[] = [];
+		client.onCommandOutput(text => output.push(text));
+
+		await client.getState();
+		await waitFor(() => output.length > 0);
+
+		expect(output).toContain("mock command output");
+	}, 20_000);
+
+	test("a command_output frame is not mistaken for an agent event", async () => {
+		using client = new RpcClient({ cliPath: MOCK_AGENT, env: { MOCK_RPC_COMMAND_OUTPUT: "1" } });
+		await client.start();
+
+		const output: string[] = [];
+		const sessionEvents: unknown[] = [];
+		client.onCommandOutput(text => output.push(text));
+		client.onSessionEvent(event => sessionEvents.push(event));
+
+		await client.getState();
+		await waitFor(() => output.length > 0);
+
+		expect(sessionEvents).toHaveLength(0);
+	}, 20_000);
+});


### PR DESCRIPTION
I reviewed the full diff; this exposes two frames RpcClient already receives so an RPC host can show approval prompts and slash command output.

## What this adds

Three methods on `RpcClient`, plus a declared type for a frame the client already receives:

- `onExtensionUiRequest(listener)` and `respondToExtensionUi(response)`
- `onCommandOutput(listener)`
- `RpcCommandOutputFrame` in `rpc-types.ts`, beside `RpcAvailableCommandsUpdateFrame`

No existing behaviour changes; all three expose machinery that is already there.

## Why

Two classes of frame the RPC server already sends have no way to reach a host.

**Extension UI.** `#extensionUiListeners` is private and populated only inside `login()`. Any other `extension_ui_request` is dispatched to an empty listener set and dropped.

That channel is how tool approval reaches a host: the tool wrapper asks with `uiContext.select(prompt, ["Approve", "Deny"])` rather than emitting an approval frame of its own, and RPC mode registers a UI context with `hasUI: true`, so the agent takes the prompting path instead of the fail-fast one. The approval dialog is created without `dialogOptions`, so it carries no timeout either.

The result is that an embedder running any non-`yolo` approval mode gets a turn that stalls indefinitely with nothing on the wire explaining why. Provider safety checks reach the same path and ignore `yolo`.

**Command output.** `command_output` is emitted by ACP builtin dispatch in `rpc-mode.ts`, but it is not an agent event, so it matches no guard in `#handleLine` and is discarded. Every builtin that reports through it — `/model`, `/cost`, `/compact` — appears to an RPC host to do nothing at all.

`onCommandOutput` mirrors the existing `onAvailableCommandsUpdate` in shape and placement.

## Verification

**`bun check` passes** — biome and tsgo, from `packages/coding-agent`.

(An earlier revision of this description said I could not run it. That was a stale `node_modules` in my checkout; a clean `bun install` resolved it, and I have corrected the claim rather than leave it standing.)

**`bun test test/rpc-client.extension-ui.test.ts test/rpc-client.restart.test.ts` — 15 pass, 0 fail.** Five are the new tests; the other ten are the pre-existing lifecycle suite, included to show the mock-agent changes do not disturb the existing harness. Running them needs a prebuilt `pi-natives` binary, which I supplied from the published `@oh-my-pi/pi-natives-linux-x64` package rather than building the Rust toolchain.

**What I did exercise, end to end.** This exact logic has been running as a `patchedDependencies` patch against `@oh-my-pi/pi-coding-agent@18.0.1` in a GUI I am building on the RPC protocol, so each method has been driven against a real `omp --mode rpc` child process rather than a mock:

- **Extension UI, both directions.** A test extension raises `ui.confirm()` from `session_start`. Without the patch the frame is dropped and nothing renders. With it, the dialog reaches the browser, is answered by a click, and the extension emits a notice containing the value it received — so the answer demonstrably arrived back at the agent rather than merely being written to stdin.
- **Command output.** Sending `/model` produces `command_output`, which now reaches the host and renders. Before the patch that prompt appeared to do nothing.
- Both paths are covered by an automated suite there: 33 protocol checks against a live agent process, plus 42 browser checks.

One related observation that is **not** part of this PR, in case it is useful: a dialog *awaited* from `session_start` cannot be answered by any RPC host, because `readRpcInputFrames` only begins consuming stdin after startup completes, so the response sits unread in the pipe. Raising one without awaiting is fine. I left that alone since it is a separate change.

## Related

- can1357/oh-my-pi#5742 — GUI request; I described both gaps there.
- can1357/oh-my-pi#6460 — remote-access discussion, where the version pin these additions would remove was raised.
