### PR TITLE
fix(task): prevent unreadable and duplicate results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
+- Fixed child task completions linking unreadable artifacts and `hub jobs` replaying result bodies that were already delivered ([#9646](https://github.com/can1357/oh-my-pi/issues/9646)).
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -148,6 +148,7 @@ export class AsyncJobManager {
 	readonly #inFlightDeliveries: AsyncJobDelivery[] = [];
 	readonly #suppressedDeliveries = new Set<string>();
 	readonly #watchedJobs = new Set<string>();
+	readonly #consumedJobResults = new Set<string>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #pollEscalation = new Map<string | undefined, PollEscalationState>();
 	readonly #deliverySinks = new Map<string, AsyncJobDeliverySink>();
@@ -214,6 +215,7 @@ export class AsyncJobManager {
 
 		const id = this.#resolveJobId(options?.id);
 		this.#suppressedDeliveries.delete(id);
+		this.#consumedJobResults.delete(id);
 		const abortController = new AbortController();
 		const startTime = Date.now();
 
@@ -396,6 +398,27 @@ export class AsyncJobManager {
 		);
 		this.#notifyDeliveryQueueChanged();
 		return before - this.#deliveries.length;
+	}
+
+	/**
+	 * Mark settled job results as recovered by a foreground snapshot.
+	 *
+	 * Suppresses queued delivery and marks retained bodies as consumed so later
+	 * snapshots report execution state without replaying the same result.
+	 */
+	consumeJobResults(jobIds: string[]): number {
+		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
+		this.acknowledgeDeliveries(uniqueJobIds);
+		let consumed = 0;
+		for (const jobId of uniqueJobIds) {
+			if (this.#consumeJobResult(jobId)) consumed += 1;
+		}
+		return consumed;
+	}
+
+	/** True once a result was auto-delivered or recovered by a foreground snapshot. */
+	isJobResultConsumed(jobId: string): boolean {
+		return this.#consumedJobResults.has(jobId);
 	}
 
 	/**
@@ -613,9 +636,18 @@ export class AsyncJobManager {
 		this.#inFlightDeliveries.length = 0;
 		this.#suppressedDeliveries.clear();
 		this.#watchedJobs.clear();
+		this.#consumedJobResults.clear();
 		this.#pollEscalation.clear();
 		this.#deliverySinks.clear();
 		return jobsSettled && drained;
+	}
+
+	#consumeJobResult(jobId: string): boolean {
+		const job = this.#jobs.get(jobId);
+		if (!job || job.status === "running" || this.#consumedJobResults.has(jobId)) return false;
+		if (job.resultText === undefined && job.errorText === undefined) return false;
+		this.#consumedJobResults.add(jobId);
+		return true;
 	}
 
 	#resolveJobId(preferredId?: string): string {
@@ -648,6 +680,7 @@ export class AsyncJobManager {
 		this.#evictionTimers.delete(jobId);
 		this.#suppressedDeliveries.delete(jobId);
 		this.#watchedJobs.delete(jobId);
+		this.#consumedJobResults.delete(jobId);
 		return this.#jobs.delete(jobId);
 	}
 
@@ -817,6 +850,7 @@ export class AsyncJobManager {
 			this.#inFlightDeliveries.push(delivery);
 			try {
 				await sink(delivery.jobId, delivery.text, this.#jobs.get(delivery.jobId));
+				this.#consumeJobResult(delivery.jobId);
 			} catch (error) {
 				delivery.attempt += 1;
 				delivery.lastError = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -855,7 +855,7 @@ export class AsyncJobManager {
 				delivery.attempt += 1;
 				delivery.lastError = error instanceof Error ? error.message : String(error);
 				delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
-				if (!this.isDeliverySuppressed(delivery.jobId)) {
+				if (!this.isDeliverySuppressed(delivery.jobId) && this.#jobs.has(delivery.jobId)) {
 					this.#queueDelivery(delivery);
 				}
 				logger.warn("Async job completion delivery failed", {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -22,13 +22,11 @@ import {
 	getAgentDir,
 	getLastChangelogVersionPath,
 	getProjectDir,
-	hasFsCode,
 	isEnoent,
 	logger,
 	MAIN_CONFIG_FILENAMES,
 	procmgr,
 	setWorktreesDir,
-	toError,
 } from "@oh-my-pi/pi-utils";
 import { withFileLock } from "@oh-my-pi/pi-utils/file-lock";
 import { JSONC, YAML } from "bun";
@@ -40,6 +38,7 @@ import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset }
 import { AgentStorage } from "../session/agent-storage";
 import { type CompactionMethod, DEFAULT_COMPACTION_METHOD_ORDER } from "../session/compaction-methods";
 import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-providers";
+import { replaceFileAtomically } from "../utils/atomic-file";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { INSPECT_IMAGE_MODES } from "../utils/inspect-image-mode";
 import { isSearchProviderId, SEARCH_PROVIDER_ORDER } from "../web/search/types";
@@ -2200,56 +2199,11 @@ export class Settings {
 			} finally {
 				await handle.close();
 			}
-			try {
-				await fs.promises.rename(tempPath, filePath);
-			} catch (error) {
-				if (!hasFsCode(error, "EPERM")) throw error;
-				await this.#replaceYamlAfterEperm(tempPath, filePath, error);
-			}
+			await replaceFileAtomically(tempPath, filePath);
 			removeTemp = false;
 		} finally {
 			if (removeTemp) {
 				await fs.promises.rm(tempPath, { force: true }).catch(() => {});
-			}
-		}
-	}
-	async #replaceYamlAfterEperm(tempPath: string, filePath: string, renameError: unknown): Promise<void> {
-		const backupPath = `${filePath}.${process.pid}.${randomUUID()}.bak`;
-		try {
-			await fs.promises.rename(filePath, backupPath);
-		} catch (error) {
-			if (isEnoent(error)) {
-				await fs.promises.rename(tempPath, filePath);
-				return;
-			}
-			throw renameError;
-		}
-
-		try {
-			await fs.promises.rename(tempPath, filePath);
-		} catch (replaceError) {
-			try {
-				await fs.promises.rename(backupPath, filePath);
-			} catch (rollbackError) {
-				throw new Error(
-					`Failed to replace settings file after EPERM (original: ${toError(renameError).message}; retry: ${
-						toError(replaceError).message
-					}; rollback: ${toError(rollbackError).message})`,
-					{ cause: toError(renameError) },
-				);
-			}
-			throw replaceError;
-		}
-
-		try {
-			await fs.promises.rm(backupPath);
-		} catch (error) {
-			if (!isEnoent(error)) {
-				logger.warn("Settings: failed to remove atomic-write backup", {
-					path: filePath,
-					backupPath,
-					error: toError(error).message,
-				});
 			}
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1945,9 +1945,9 @@ export class AgentSession {
 
 	/**
 	 * Delivery sink for async jobs owned by this agent: format the result
-	 * (spilling oversized output to an artifact) and enqueue it as an
-	 * async-result follow-up on the yield queue. The queue's idle flush starts
-	 * the follow-up turn when the session is between turns.
+	 * (spilling oversized output to an artifact), enqueue it as an async-result
+	 * follow-up, and settle only after the yield queue injects or discards it.
+	 * This keeps the job body recoverable through `hub` while injection is pending.
 	 */
 	async #deliverAsyncJobResult(manager: AsyncJobManager, jobId: string, text: string, job?: AsyncJob): Promise<void> {
 		if (this.#isDisposed) return;
@@ -1962,7 +1962,13 @@ export class AgentSession {
 		if (epoch !== this.#asyncDeliveryEpoch) return;
 		if (manager.isDeliverySuppressed(jobId)) return;
 		const durationMs = job ? Math.max(0, Date.now() - job.startTime) : undefined;
-		this.yieldQueue.enqueue<AsyncResultEntry>("async-result", { jobId, result: formatted, job, durationMs, epoch });
+		await this.yieldQueue.enqueueWithReceipt<AsyncResultEntry>("async-result", {
+			jobId,
+			result: formatted,
+			job,
+			durationMs,
+			epoch,
+		});
 	}
 
 	async #formatAsyncResultForFollowUp(result: string): Promise<string> {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -245,6 +245,7 @@ import type {
 	SessionStats,
 	UsageFallbackConfirmer,
 } from "./agent-session-types";
+import { writeArtifact } from "./artifacts";
 import {
 	ASYNC_INLINE_RESULT_MAX_CHARS,
 	ASYNC_PREVIEW_MAX_CHARS,
@@ -1972,7 +1973,7 @@ export class AgentSession {
 		try {
 			const { path: artifactPath, id: artifactId } = await this.sessionManager.allocateArtifactPath("async");
 			if (artifactPath && artifactId) {
-				await Bun.write(artifactPath, result);
+				await writeArtifact(artifactPath, result);
 				return `${preview}\nFull output: artifact://${artifactId}`;
 			}
 		} catch (error) {

--- a/packages/coding-agent/src/session/artifacts.ts
+++ b/packages/coding-agent/src/session/artifacts.ts
@@ -26,6 +26,25 @@ function sanitizeToolType(toolType: string): string {
 }
 
 /**
+ * Persist an artifact only when the filesystem confirms the complete payload is readable.
+ *
+ * Returns the verified UTF-8 byte count.
+ */
+export async function writeArtifact(path: string, content: string): Promise<number> {
+	const expectedBytes = Buffer.byteLength(content);
+	const writtenBytes = await Bun.write(path, content);
+	if (writtenBytes !== expectedBytes) {
+		throw new Error(`Artifact write incomplete: wrote ${writtenBytes} of ${expectedBytes} bytes`);
+	}
+	const file = Bun.file(path);
+	if (file.size !== expectedBytes) {
+		throw new Error(`Artifact size mismatch: found ${file.size} of ${expectedBytes} bytes`);
+	}
+	await file.slice(0, Math.min(expectedBytes, 1)).arrayBuffer();
+	return expectedBytes;
+}
+
+/**
  * Manages artifact storage for a session.
  *
  * Artifacts are stored with sequential IDs in the session's artifact directory.
@@ -115,7 +134,7 @@ export class ArtifactManager {
 	 */
 	async save(content: string, toolType: string): Promise<string> {
 		const { id, path } = await this.allocatePath(toolType);
-		await Bun.write(path, content);
+		await writeArtifact(path, content);
 		return id;
 	}
 

--- a/packages/coding-agent/src/session/artifacts.ts
+++ b/packages/coding-agent/src/session/artifacts.ts
@@ -6,6 +6,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { replaceFileAtomically } from "../utils/atomic-file";
 
 /**
  * Sanitize a tool name for safe use as the middle segment of the artifact
@@ -53,7 +54,7 @@ export async function writeArtifact(path: string, content: string): Promise<numb
 			throw new Error(`Artifact size mismatch: found ${file.size} of ${expectedBytes} bytes`);
 		}
 		await file.slice(0, Math.min(expectedBytes, 1)).arrayBuffer();
-		await fs.rename(tempPath, path);
+		await replaceFileAtomically(tempPath, path);
 	} catch (error) {
 		await fs.rm(tempPath, { force: true });
 		throw error;

--- a/packages/coding-agent/src/session/artifacts.ts
+++ b/packages/coding-agent/src/session/artifacts.ts
@@ -26,21 +26,38 @@ function sanitizeToolType(toolType: string): string {
 }
 
 /**
- * Persist an artifact only when the filesystem confirms the complete payload is readable.
+ * Persist an artifact only when the filesystem confirms the complete payload is
+ * readable, then swap it into place atomically.
+ *
+ * Content is staged to a temporary sibling and verified (byte count, on-disk
+ * size, readability) before an atomic `rename` publishes it. `agent://<id>`
+ * discovers `${id}.md` by scanning the artifacts directory rather than reading
+ * `result.outputPath`, so a direct in-place write that fell short would leave a
+ * truncated file resolvable as incomplete output and a failed follow-up write
+ * would destroy the prior valid artifact. Staging keeps both hazards out: on
+ * any failure the temp file is removed and the existing artifact at `path` is
+ * untouched.
  *
  * Returns the verified UTF-8 byte count.
  */
 export async function writeArtifact(path: string, content: string): Promise<number> {
 	const expectedBytes = Buffer.byteLength(content);
-	const writtenBytes = await Bun.write(path, content);
-	if (writtenBytes !== expectedBytes) {
-		throw new Error(`Artifact write incomplete: wrote ${writtenBytes} of ${expectedBytes} bytes`);
+	const tempPath = `${path}.tmp-${crypto.randomUUID()}`;
+	try {
+		const writtenBytes = await Bun.write(tempPath, content);
+		if (writtenBytes !== expectedBytes) {
+			throw new Error(`Artifact write incomplete: wrote ${writtenBytes} of ${expectedBytes} bytes`);
+		}
+		const file = Bun.file(tempPath);
+		if (file.size !== expectedBytes) {
+			throw new Error(`Artifact size mismatch: found ${file.size} of ${expectedBytes} bytes`);
+		}
+		await file.slice(0, Math.min(expectedBytes, 1)).arrayBuffer();
+		await fs.rename(tempPath, path);
+	} catch (error) {
+		await fs.rm(tempPath, { force: true });
+		throw error;
 	}
-	const file = Bun.file(path);
-	if (file.size !== expectedBytes) {
-		throw new Error(`Artifact size mismatch: found ${file.size} of ${expectedBytes} bytes`);
-	}
-	await file.slice(0, Math.min(expectedBytes, 1)).arrayBuffer();
 	return expectedBytes;
 }
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -43,7 +43,7 @@ import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-life
 import { AgentRegistry } from "../registry/agent-registry";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "../sdk";
 import type { AgentSession, AgentSessionEvent, Prewalk } from "../session/agent-session";
-import type { ArtifactManager } from "../session/artifacts";
+import { type ArtifactManager, writeArtifact } from "../session/artifacts";
 import { ASYNC_RESULT_MESSAGE_TYPE } from "../session/async-job-delivery";
 import type { AuthStorage } from "../session/auth-storage";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../session/messages";
@@ -2214,15 +2214,20 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 	let outputMeta: { lineCount: number; charCount: number } | undefined;
 	let outputPath: string | undefined;
 	if (args.artifactsDir && (!args.followUpTurn || hasYield)) {
-		outputPath = path.join(args.artifactsDir, `${id}.md`);
+		const candidatePath = path.join(args.artifactsDir, `${id}.md`);
 		try {
-			await Bun.write(outputPath, rawOutput);
+			await writeArtifact(candidatePath, rawOutput);
+			outputPath = candidatePath;
 			outputMeta = {
 				lineCount: rawOutput.split("\n").length,
 				charCount: rawOutput.length,
 			};
-		} catch {
-			// Non-fatal
+		} catch (error) {
+			logger.warn("Failed to persist subagent output artifact", {
+				agentId: id,
+				path: candidatePath,
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1490,7 +1490,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const fullOutputThreshold = 5000;
 		let preview = output;
 		let truncated = false;
-		if (outputCharCount > fullOutputThreshold) {
+		if (outputCharCount > fullOutputThreshold && result.outputPath) {
 			const slice = output.slice(0, fullOutputThreshold);
 			const lastNewline = slice.lastIndexOf("\n");
 			preview = lastNewline >= 0 ? slice.slice(0, lastNewline) : slice;

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -159,6 +159,7 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 	return jobs.map(j => {
 		const current = session.asyncJobManager?.getJob(j.id);
 		const latest = current ?? j;
+		const resultConsumed = session.asyncJobManager?.isJobResultConsumed(latest.id) === true;
 		let resolvedModel: string | undefined;
 		if (latest.type === "task") {
 			const progressValue = latest.latestDetails?.progress;
@@ -187,8 +188,8 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 			label: latest.label,
 			durationMs: Math.max(0, now - latest.startTime),
 			...(resolvedModel ? { resolvedModel } : {}),
-			...(latest.resultText ? { resultText: latest.resultText } : {}),
-			...(latest.errorText ? { errorText: latest.errorText } : {}),
+			...(!resultConsumed && latest.resultText ? { resultText: latest.resultText } : {}),
+			...(!resultConsumed && latest.errorText ? { errorText: latest.errorText } : {}),
 		};
 	});
 }
@@ -209,8 +210,9 @@ export function buildJobResult(
 		return true;
 	});
 	const jobResults = snapshotJobs(session, uniqueJobs);
+	const alreadyConsumed = new Set(jobResults.filter(job => manager.isJobResultConsumed(job.id)).map(job => job.id));
 
-	manager.acknowledgeDeliveries(jobResults.filter(j => j.status !== "running").map(j => j.id));
+	manager.consumeJobResults(jobResults.filter(j => j.status !== "running").map(j => j.id));
 
 	const completed = jobResults.filter(j => j.status !== "running");
 	const running = jobResults.filter(j => j.status === "running");
@@ -228,6 +230,13 @@ export function buildJobResult(
 		for (const j of completed) {
 			lines.push(`### ${j.id} [${j.type}] — ${j.status}`);
 			lines.push(`Label: ${j.label}`);
+			if (j.status !== "cancelled") {
+				lines.push(
+					alreadyConsumed.has(j.id)
+						? "Delivery: already delivered or recovered."
+						: "Delivery: not auto-delivered; recovered by this snapshot.",
+				);
+			}
 			if (j.resultText) {
 				lines.push("```", j.resultText, "```");
 			}

--- a/packages/coding-agent/src/utils/atomic-file.ts
+++ b/packages/coding-agent/src/utils/atomic-file.ts
@@ -1,0 +1,61 @@
+import * as fs from "node:fs/promises";
+import { hasFsCode, isEexist, isEnoent, logger, toError } from "@oh-my-pi/pi-utils";
+
+/**
+ * Publish a staged sibling file atomically, preserving an existing destination
+ * across Windows `EPERM`/`EEXIST` replacement failures.
+ */
+export async function replaceFileAtomically(tempPath: string, targetPath: string): Promise<void> {
+	try {
+		await fs.rename(tempPath, targetPath);
+		return;
+	} catch (error) {
+		if (!hasFsCode(error, "EPERM") && !isEexist(error)) throw error;
+		await replaceAfterWindowsRenameFailure(tempPath, targetPath, error);
+	}
+}
+
+async function replaceAfterWindowsRenameFailure(
+	tempPath: string,
+	targetPath: string,
+	renameError: unknown,
+): Promise<void> {
+	const backupPath = `${targetPath}.${process.pid}.${crypto.randomUUID()}.bak`;
+	try {
+		await fs.rename(targetPath, backupPath);
+	} catch (error) {
+		if (isEnoent(error)) {
+			await fs.rename(tempPath, targetPath);
+			return;
+		}
+		throw renameError;
+	}
+
+	try {
+		await fs.rename(tempPath, targetPath);
+	} catch (replaceError) {
+		try {
+			await fs.rename(backupPath, targetPath);
+		} catch (rollbackError) {
+			throw new Error(
+				`Failed to replace file after ${toError(renameError).message} (retry: ${
+					toError(replaceError).message
+				}; rollback: ${toError(rollbackError).message})`,
+				{ cause: toError(renameError) },
+			);
+		}
+		throw replaceError;
+	}
+
+	try {
+		await fs.rm(backupPath);
+	} catch (error) {
+		if (!isEnoent(error)) {
+			logger.warn("Failed to remove atomic replacement backup", {
+				path: targetPath,
+				backupPath,
+				error: toError(error).message,
+			});
+		}
+	}
+}

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -19,6 +19,17 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 
+function observeAsyncResultEnqueue(session: AgentSession): Promise<void> {
+	const queued = Promise.withResolvers<void>();
+	const enqueue = session.yieldQueue.enqueueWithReceipt.bind(session.yieldQueue);
+	vi.spyOn(session.yieldQueue, "enqueueWithReceipt").mockImplementation((kind, entry) => {
+		const receipt = enqueue(kind, entry);
+		if (kind === "async-result") queued.resolve();
+		return receipt;
+	});
+	return queued.promise;
+}
+
 describe("AgentSession owner-routed async delivery", () => {
 	let session: AgentSession;
 	const authStorages: AuthStorage[] = [];
@@ -215,18 +226,21 @@ describe("AgentSession owner-routed async delivery", () => {
 			agentId: "Main",
 			ownedAsyncJobManager: manager,
 		});
+		const resultQueued = observeAsyncResultEnqueue(session);
 
-		// Complete a job and push its result all the way onto the yield queue, so a
-		// follow-up turn is pending injection into the (soon-to-be-replaced) session.
+		// Complete a job while no turn is available to inject its queued result.
+		// The job body stays retained until either the queue commits it or a hub
+		// snapshot recovers it.
 		manager.register("task", "prior session", async () => "STALE ASYNC RESULT", {
 			id: "prior-session-job",
 			ownerId: "Main",
 		});
 		await manager.waitForOwnerJobs("Main");
-		await manager.drainDeliveries({ filter: { ownerId: "Main" } });
+		await resultQueued;
 		expect(session.hasPendingAsyncWork()).toBe(true);
 
 		expect(await session.newSession()).toBe(true);
+		await manager.drainDeliveries({ timeoutMs: 1_000, filter: { ownerId: "Main" } });
 		expect(session.hasPendingAsyncWork()).toBe(false);
 
 		// A fresh turn in the replacement session must not carry the prior result.
@@ -301,7 +315,7 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(session.hasPendingAsyncWork()).toBe(false);
 	});
 
-	it("still reports pending async work while a delivered result awaits injection", async () => {
+	it("keeps delivery pending until the queued follow-up is injected", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
 		const agent = new Agent({
@@ -325,24 +339,21 @@ describe("AgentSession owner-routed async delivery", () => {
 			asyncJobManager: manager,
 		});
 
+		const resultQueued = observeAsyncResultEnqueue(session);
 		const gate = Promise.withResolvers<string>();
 		manager.register("bash", "gated job", () => gate.promise, { id: "sub-job", ownerId: "SubAgent" });
 		gate.resolve("job finished: QUEUED RESULT");
 		await manager.waitForOwnerJobs("SubAgent");
-		await manager.drainDeliveries({ filter: { ownerId: "SubAgent" } });
 
-		// The manager has fully handed off — no running jobs, no queued or
-		// in-flight deliveries — but the async-result follow-up still sits on
-		// the session's yield queue awaiting the (delayed) idle flush / next
-		// step boundary. A terminal yield observed in this window MUST still
-		// count as pending async work, or the run driver terminates and the
-		// delivered result is silently dropped from the final report.
+		await resultQueued;
 		expect(session.hasPendingAsyncWork()).toBe(true);
+		expect(manager.isJobResultConsumed("sub-job")).toBe(false);
 
-		// Settling drains the queued follow-up into a real turn and only then
-		// reaches quiescence.
 		await session.settleAsyncWork();
+
 		expect(session.hasPendingAsyncWork()).toBe(false);
+		expect(manager.isJobResultConsumed("sub-job")).toBe(true);
+		expect(mock.calls.some(call => JSON.stringify(call.context.messages).includes("QUEUED RESULT"))).toBe(true);
 	});
 
 	it("keeps the event loop live until a delayed idle flush runs", async () => {

--- a/packages/coding-agent/test/artifacts-integrity.test.ts
+++ b/packages/coding-agent/test/artifacts-integrity.test.ts
@@ -64,4 +64,27 @@ describe("ArtifactManager write integrity", () => {
 		expect(await Bun.file(destination).text()).toBe("original valid report");
 		expect(await fs.readdir(dir)).toEqual(["Worker.md"]);
 	});
+
+	it("replaces an existing artifact when Windows rejects rename-over-target", async () => {
+		const dir = freshDir();
+		await fs.mkdir(dir, { recursive: true });
+		const destination = path.join(dir, "Worker.md");
+		await writeArtifact(destination, "original report");
+
+		const rename = fs.rename.bind(fs);
+		let injected = false;
+		vi.spyOn(fs, "rename").mockImplementation(async (source, target) => {
+			if (!injected && String(source).includes(".tmp-") && String(target) === destination) {
+				injected = true;
+				throw Object.assign(new Error("injected Windows replacement failure"), { code: "EEXIST" });
+			}
+			await rename(source, target);
+		});
+
+		await writeArtifact(destination, "replacement report");
+
+		expect(injected).toBe(true);
+		expect(await Bun.file(destination).text()).toBe("replacement report");
+		expect(await fs.readdir(dir)).toEqual(["Worker.md"]);
+	});
 });

--- a/packages/coding-agent/test/artifacts-integrity.test.ts
+++ b/packages/coding-agent/test/artifacts-integrity.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ArtifactManager } from "@oh-my-pi/pi-coding-agent/session/artifacts";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+
+describe("ArtifactManager write integrity", () => {
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		for (const dir of dirs.splice(0)) removeSyncWithRetries(dir);
+	});
+
+	it("rejects a short write instead of publishing an unreadable artifact id", async () => {
+		const dir = path.join(os.tmpdir(), `omp-artifact-integrity-${crypto.randomUUID()}`);
+		dirs.push(dir);
+		const manager = new ArtifactManager(dir);
+		vi.spyOn(Bun, "write").mockResolvedValue(1);
+
+		await expect(manager.save("complete report", "task")).rejects.toThrow(
+			"Artifact write incomplete: wrote 1 of 15 bytes",
+		);
+	});
+});

--- a/packages/coding-agent/test/artifacts-integrity.test.ts
+++ b/packages/coding-agent/test/artifacts-integrity.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ArtifactManager } from "@oh-my-pi/pi-coding-agent/session/artifacts";
+import { ArtifactManager, writeArtifact } from "@oh-my-pi/pi-coding-agent/session/artifacts";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 describe("ArtifactManager write integrity", () => {
 	const dirs: string[] = [];
+
+	function freshDir(): string {
+		const dir = path.join(os.tmpdir(), `omp-artifact-integrity-${crypto.randomUUID()}`);
+		dirs.push(dir);
+		return dir;
+	}
 
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -13,13 +20,48 @@ describe("ArtifactManager write integrity", () => {
 	});
 
 	it("rejects a short write instead of publishing an unreadable artifact id", async () => {
-		const dir = path.join(os.tmpdir(), `omp-artifact-integrity-${crypto.randomUUID()}`);
-		dirs.push(dir);
-		const manager = new ArtifactManager(dir);
+		const manager = new ArtifactManager(freshDir());
 		vi.spyOn(Bun, "write").mockResolvedValue(1);
 
 		await expect(manager.save("complete report", "task")).rejects.toThrow(
 			"Artifact write incomplete: wrote 1 of 15 bytes",
 		);
+	});
+
+	it("leaves no discoverable file when the staged write falls short", async () => {
+		const dir = freshDir();
+		await fs.mkdir(dir, { recursive: true });
+		const destination = path.join(dir, "Worker.md");
+		// Faithfully model a short write: partial bytes land on the staging file,
+		// and Bun.write reports fewer bytes than requested.
+		const realWrite = Bun.write.bind(Bun);
+		vi.spyOn(Bun, "write").mockImplementation(async (target, content) => {
+			await realWrite(target as string, String(content).slice(0, 3));
+			return 3;
+		});
+
+		await expect(writeArtifact(destination, "full report body")).rejects.toThrow("Artifact write incomplete");
+
+		// Neither the destination nor a leftover staging file survives, so
+		// agent:// / artifact:// scans cannot resolve a truncated artifact.
+		expect(await fs.readdir(dir)).toEqual([]);
+	});
+
+	it("preserves the prior artifact when a follow-up write fails", async () => {
+		const dir = freshDir();
+		await fs.mkdir(dir, { recursive: true });
+		const destination = path.join(dir, "Worker.md");
+		await writeArtifact(destination, "original valid report");
+
+		const realWrite = Bun.write.bind(Bun);
+		vi.spyOn(Bun, "write").mockImplementation(async (target, content) => {
+			await realWrite(target as string, String(content).slice(0, 2));
+			return 2;
+		});
+
+		await expect(writeArtifact(destination, "replacement report")).rejects.toThrow("Artifact write incomplete");
+
+		expect(await Bun.file(destination).text()).toBe("original valid report");
+		expect(await fs.readdir(dir)).toEqual(["Worker.md"]);
 	});
 });

--- a/packages/coding-agent/test/job-tool-agent-roster.test.ts
+++ b/packages/coding-agent/test/job-tool-agent-roster.test.ts
@@ -75,6 +75,46 @@ describe("hub jobs snapshot", () => {
 		expect((result.details as CoordinationDetails)?.jobs).toEqual([]);
 	});
 
+	test("omits result bodies already auto-delivered to the owning agent", async () => {
+		const manager = createManager();
+		const deliveries: string[] = [];
+		manager.registerDeliverySink("Main", (_jobId, text) => {
+			deliveries.push(text);
+		});
+		const jobId = manager.register("eval", "completed cell", async () => "already delivered eval body", {
+			ownerId: "Main",
+		});
+		await manager.getJob(jobId)!.promise;
+		await manager.drainDeliveries({ timeoutMs: 200, filter: { ownerId: "Main" } });
+
+		const tool = new HubTool(createToolSession({ manager, agentId: "Main" }));
+		const result = await tool.execute("call", { op: "jobs" });
+
+		expect(deliveries).toEqual(["already delivered eval body"]);
+		expect(resultText(result)).not.toContain("already delivered eval body");
+		expect(resultText(result)).toContain("Delivery: already delivered or recovered.");
+		expect((result.details as CoordinationDetails)?.jobs?.[0]?.resultText).toBeUndefined();
+	});
+
+	test("returns an undelivered result body once for manual recovery", async () => {
+		const manager = createManager();
+		const jobId = manager.register("task", "orphaned child", async () => "recover this child report", {
+			ownerId: "Main",
+		});
+		await manager.getJob(jobId)!.promise;
+		await manager.drainDeliveries({ timeoutMs: 200, filter: { ownerId: "Main" } });
+
+		const tool = new HubTool(createToolSession({ manager, agentId: "Main" }));
+		const recovered = await tool.execute("first", { op: "jobs" });
+		const consumed = await tool.execute("second", { op: "jobs" });
+
+		expect(resultText(recovered)).toContain("recover this child report");
+		expect(resultText(recovered)).toContain("Delivery: not auto-delivered; recovered by this snapshot.");
+		expect(resultText(consumed)).not.toContain("recover this child report");
+		expect(resultText(consumed)).toContain("Delivery: already delivered or recovered.");
+		expect((consumed.details as CoordinationDetails)?.jobs?.[0]?.resultText).toBeUndefined();
+	});
+
 	test("list surfaces running subagents that have no backing job", async () => {
 		const registry = new AgentRegistry();
 		registerRunningSub(registry, "Worker");

--- a/packages/coding-agent/test/job-tool-agent-roster.test.ts
+++ b/packages/coding-agent/test/job-tool-agent-roster.test.ts
@@ -96,6 +96,32 @@ describe("hub jobs snapshot", () => {
 		expect((result.details as CoordinationDetails)?.jobs?.[0]?.resultText).toBeUndefined();
 	});
 
+	test("recovers a result while auto-delivery still awaits consumer injection", async () => {
+		const manager = createManager();
+		const deliveryStarted = Promise.withResolvers<void>();
+		const allowInjection = Promise.withResolvers<void>();
+		const injected: string[] = [];
+		manager.registerDeliverySink("Main", async (jobId, text) => {
+			deliveryStarted.resolve();
+			await allowInjection.promise;
+			if (!manager.isDeliverySuppressed(jobId)) injected.push(text);
+		});
+		const jobId = manager.register("task", "queued child", async () => "queued child report", {
+			ownerId: "Main",
+		});
+		await manager.getJob(jobId)!.promise;
+		await deliveryStarted.promise;
+
+		const tool = new HubTool(createToolSession({ manager, agentId: "Main" }));
+		const recovered = await tool.execute("recover", { op: "jobs" });
+		allowInjection.resolve();
+		await manager.drainDeliveries({ timeoutMs: 200, filter: { ownerId: "Main" } });
+
+		expect(resultText(recovered)).toContain("queued child report");
+		expect(resultText(recovered)).toContain("Delivery: not auto-delivered; recovered by this snapshot.");
+		expect(injected).toEqual([]);
+	});
+
 	test("returns an undelivered result body once for manual recovery", async () => {
 		const manager = createManager();
 		const jobId = manager.register("task", "orphaned child", async () => "recover this child report", {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
@@ -298,9 +299,9 @@ describe("Settings", () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			const canonicalConfigPath = await fs.promises.realpath(getConfigPath());
-			const rename = fs.promises.rename.bind(fs.promises);
+			const rename = fsp.rename.bind(fsp);
 			let injected = false;
-			vi.spyOn(fs.promises, "rename").mockImplementation(async (source, target) => {
+			vi.spyOn(fsp, "rename").mockImplementation(async (source, target) => {
 				if (!injected && String(source).endsWith(".tmp") && String(target) === canonicalConfigPath) {
 					injected = true;
 					throw new FsCodeError("EPERM", "injected Windows replacement failure");

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -614,6 +614,27 @@ describe("task.batch spawning", () => {
 		]);
 	});
 
+	it("keeps a long result inline when no readable output artifact exists", async () => {
+		mockDiscovery();
+		const fullOutput = `REPORT:${"x".repeat(6_000)}:END`;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options =>
+			makeResult(options.id ?? "?", {
+				output: fullOutput,
+				outputMeta: { lineCount: 1, charCount: fullOutput.length },
+			}),
+		);
+
+		const tool = await TaskTool.create(createSession({ settings: { "async.enabled": false, "task.batch": false } }));
+		const result = await tool.execute("tc-missing-artifact", {
+			name: "MissingArtifact",
+			task: "Return a long report.",
+		} as TaskParams);
+		const text = getFirstText(result);
+
+		expect(text).not.toContain("agent://MissingArtifact");
+		expect(text).toContain(":END");
+	});
+
 	it("settles the batch async aggregate when a queued spawn is cancelled mid-flight", async () => {
 		mockDiscovery();
 		const started: string[] = [];


### PR DESCRIPTION
## Repro
A short artifact write was accepted as successful, so a completed child could publish a result link whose bytes were absent; `bun test packages/coding-agent/test/artifacts-integrity.test.ts` reproduced this with `Bun.write` reporting 1 of 15 bytes while `ArtifactManager.save()` still resolved. Auto-delivered async job bodies also remained on retained job rows and reappeared in later `hub jobs` snapshots.

## Cause
`writeArtifact` did not exist: `ArtifactManager.save()`, `AgentSession.#formatAsyncResultForFollowUp()`, and `finalizeRunResult()` trusted `Bun.write()` without checking its byte count or reopening the file, while `finalizeRunResult()` assigned `outputPath` before the write. `AsyncJobManager.#deliverDelivery()` retained successful delivery bodies without a consumed state, and `buildJobResult()` replayed every retained body.

## Fix
- Verify the artifact's written byte count, on-disk size, and readability before publishing its ID or path.
- Keep long task results inline when no verified artifact path exists.
- Track auto-delivered and manually recovered job results as consumed, omit consumed bodies from later snapshots, and render whether a result was already delivered or recovered by the current snapshot.
- Add regressions for short writes, missing task artifacts, duplicate Eval bodies, and one-time manual recovery.

## Verification
`bun test packages/coding-agent/test/artifacts-integrity.test.ts packages/coding-agent/test/artifacts-concurrency.test.ts packages/coding-agent/test/task/task-batch.test.ts packages/coding-agent/test/job-tool-agent-roster.test.ts packages/coding-agent/test/async-job-manager.test.ts packages/coding-agent/test/agent-session-async-delivery.test.ts packages/coding-agent/test/tools/hub-wait.test.ts` passed: 74 tests, 0 failures. `bun run check:ts` passed. `bun check` fails identically on `main` because the environment cannot execute CMake for `audiopus_sys`; the pre-publish gate was skipped after verifying that default-branch failure.

Fixes #9646