### PR TITLE
fix(ai): preserve codex chains across service tiers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex WebSocket continuations replaying full context whenever a turn toggled Fast mode, while preserving strict resets for model, instructions, tools, reasoning, verbosity, and response format changes.
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -3463,10 +3463,14 @@ function recordCodexTurnUsageDiagnostics(
 	CODEX_DEBUG && logger.debug("[codex] codex turn diagnostics", { diagnostics: state.stats.lastTurn });
 }
 
+const CODEX_CHAIN_TOP_LEVEL_EXCLUDE_MAP = {
+	service_tier: true,
+};
+
 /**
- * Shape the next websocket turn's request body: when the session's append
- * baseline is intact (same options, strict history prefix), chain via
- * `previous_response_id` + delta-only `input`; otherwise break the chain and
+ * Shape the next websocket turn's request body: when the session's strict
+ * history prefix is intact and request options other than the per-turn
+ * service_tier match, chain via previous_response_id + delta-only input;
  * replay the full transcript. SSE requests never chain — the HTTP endpoint's
  * request schema has no `previous_response_id` (codex-rs carries it only on
  * websocket `response.create` frames) and strict gateway validators 400 it
@@ -3478,7 +3482,12 @@ function buildCodexChainedRequestBody(
 ): RequestBody {
 	const chainable = state?.canAppend === true;
 	const appendInput = chainable
-		? buildResponsesDeltaInput(state.lastRequest, state.lastResponseItems, requestBody)
+		? buildResponsesDeltaInput(
+				state.lastRequest,
+				state.lastResponseItems,
+				requestBody,
+				CODEX_CHAIN_TOP_LEVEL_EXCLUDE_MAP,
+			)
 		: null;
 	if (appendInput && appendInput.length > 0 && state?.lastResponseId) {
 		return { ...requestBody, previous_response_id: state.lastResponseId, input: appendInput };

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3726,18 +3726,23 @@ export function populateResponsesUsageFromResponse(
  * A defined value differing across sides IS a difference; a key undefined or
  * absent on both stays equal. Nested values use full {@link Bun.deepEquals}.
  */
-function deepEqualsWithout(a: unknown, b: unknown, omitKeys?: Record<string, boolean>): boolean {
+function deepEqualsWithout(
+	a: unknown,
+	b: unknown,
+	omitKeys?: Readonly<Record<string, boolean>>,
+	additionalOmitKeys?: Readonly<Record<string, boolean>>,
+): boolean {
 	if (!a || !b || typeof a !== "object" || typeof b !== "object") return Bun.deepEquals(a, b);
 	const ao = a as Record<string, unknown>;
 	const bo = b as Record<string, unknown>;
 	for (const key in ao) {
-		if (omitKeys?.[key]) continue;
+		if (omitKeys?.[key] || additionalOmitKeys?.[key]) continue;
 		const av = ao[key];
 		const bv = bo[key];
 		if (av !== bv && !Bun.deepEquals(av, bv)) return false;
 	}
 	for (const key in bo) {
-		if (omitKeys?.[key]) continue;
+		if (omitKeys?.[key] || additionalOmitKeys?.[key]) continue;
 		if (bo[key] !== undefined && !(key in ao)) return false;
 	}
 	return true;
@@ -3782,10 +3787,11 @@ export function buildResponsesDeltaInput<TItem extends ResponseInputItem | Input
 	previous: { input?: TItem[] } | undefined,
 	previousResponseItems: readonly TItem[] | undefined,
 	current: { input?: TItem[] },
+	additionalTopLevelExcludeMap?: Readonly<Record<string, boolean>>,
 ): TItem[] | null {
 	if (!previous) return null;
 	if (!Array.isArray(previous.input) || !Array.isArray(current.input)) return null;
-	if (!deepEqualsWithout(previous, current, TOP_LEVEL_EXCLUDE_MAP)) {
+	if (!deepEqualsWithout(previous, current, TOP_LEVEL_EXCLUDE_MAP, additionalTopLevelExcludeMap)) {
 		return null;
 	}
 

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -3388,6 +3388,107 @@ describe("openai-codex streaming", () => {
 		expect(result.usage.premiumRequests).toBeUndefined();
 	});
 
+	it("continues websocket chains across Standard → Fast → Standard service tiers", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = vi.fn(async () => {
+			throw new Error("SSE fallback should not be called");
+		});
+
+		class CrossTierWebSocket extends MockWebSocket {
+			constructor(url: string, options?: { headers?: WsHeaders }) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			override send(data: string): void {
+				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
+				const responseIndex = sentRequests.length;
+				this.emitCodexResponse({
+					messageId: `msg_${responseIndex}`,
+					responseId: `resp_${responseIndex}`,
+					text: `Answer ${responseIndex}`,
+					terminalType: "response.completed",
+					includeCreated: true,
+				});
+			}
+		}
+
+		global.WebSocket = CrossTierWebSocket as unknown as typeof WebSocket;
+		const model: Model<"openai-codex-responses"> = buildModel({
+			id: "gpt-5.3-codex-spark",
+			name: "GPT-5.3 Codex Spark",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			preferWebsockets: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 128000,
+		});
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const baseOptions = {
+			fetch: fetchMock as FetchImpl,
+			apiKey: createCodexTestToken(),
+			sessionId: "ws-cross-tier-session",
+			providerSessionState,
+		};
+		const startedAt = Date.now();
+		const firstContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [{ role: "user", content: "First question", timestamp: startedAt }],
+		};
+		const firstResponse = await streamOpenAICodexResponses(model, firstContext, baseOptions).result();
+		const secondContext: Context = {
+			systemPrompt: firstContext.systemPrompt,
+			messages: [
+				...firstContext.messages,
+				firstResponse,
+				{ role: "user", content: "Second question", timestamp: startedAt + 1 },
+			],
+		};
+		const secondResponse = await streamOpenAICodexResponses(model, secondContext, {
+			...baseOptions,
+			serviceTier: "priority",
+		}).result();
+		const thirdContext: Context = {
+			systemPrompt: firstContext.systemPrompt,
+			messages: [
+				...secondContext.messages,
+				secondResponse,
+				{ role: "user", content: "Third question", timestamp: startedAt + 2 },
+			],
+		};
+		await streamOpenAICodexResponses(model, thirdContext, baseOptions).result();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(sentRequests).toHaveLength(3);
+		expect(sentRequests[0]?.service_tier).toBeUndefined();
+		expect(sentRequests[0]?.previous_response_id).toBeUndefined();
+		expect(JSON.stringify(sentRequests[0]?.input)).toContain("First question");
+		expect(sentRequests[1]?.service_tier).toBe("priority");
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_1");
+		expect(JSON.stringify(sentRequests[1]?.input)).toContain("Second question");
+		expect(JSON.stringify(sentRequests[1]?.input)).not.toContain("First question");
+		expect(sentRequests[2]?.service_tier).toBeUndefined();
+		expect(sentRequests[2]?.previous_response_id).toBe("resp_2");
+		expect(JSON.stringify(sentRequests[2]?.input)).toContain("Third question");
+		expect(JSON.stringify(sentRequests[2]?.input)).not.toContain("Second question");
+
+		const stats = getOpenAICodexWebSocketDebugStats(model, {
+			sessionId: "ws-cross-tier-session",
+			providerSessionState,
+		});
+		expect(stats?.fullContextRequests).toBe(1);
+		expect(stats?.deltaRequests).toBe(2);
+		expect(stats?.lastInputItems).toBe(1);
+		expect(stats?.lastDeltaInputItems).toBe(1);
+		expect(stats?.lastPreviousResponseId).toBe("resp_2");
+	});
+
 	it("records websocket delta request and usage diagnostics", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());

--- a/packages/ai/test/openai-responses-delta-input.test.ts
+++ b/packages/ai/test/openai-responses-delta-input.test.ts
@@ -114,6 +114,68 @@ describe("buildResponsesDeltaInput streaming-symbol scrub", () => {
 		expect(buildResponsesDeltaInput(previous, [items[1]], current)).toBeNull();
 	});
 
+	it("keeps service_tier chain-breaking unless the caller explicitly excludes it", () => {
+		const items = baselineItems();
+		const appended: ResponseInputItem = {
+			type: "message",
+			role: "user",
+			content: [{ type: "input_text", text: "follow-up" }],
+		};
+		const previous = { input: [items[0]!], service_tier: "default" };
+		const current = { input: [items[0]!, items[1]!, appended], service_tier: "priority" };
+
+		expect(buildResponsesDeltaInput(previous, [items[1]!], current)).toBeNull();
+		expect(buildResponsesDeltaInput(previous, [items[1]!], current, { service_tier: true })).toEqual([appended]);
+	});
+
+	const semanticOptionChanges = [
+		["model", { model: "gpt-before" }, { model: "gpt-after" }],
+		["instructions", { instructions: "before" }, { instructions: "after" }],
+		[
+			"tool schema",
+			{ tools: [{ type: "function", name: "lookup", parameters: { type: "object", properties: {} } }] },
+			{
+				tools: [
+					{
+						type: "function",
+						name: "lookup",
+						parameters: { type: "object", properties: { query: { type: "string" } } },
+					},
+				],
+			},
+		],
+		["reasoning mode", { reasoning: { effort: "low" } }, { reasoning: { effort: "high" } }],
+		["text verbosity", { text: { verbosity: "low" } }, { text: { verbosity: "high" } }],
+		[
+			"response format",
+			{ text: { format: { type: "text" } } },
+			{
+				text: {
+					format: {
+						type: "json_schema",
+						name: "result",
+						schema: { type: "object", properties: { result: { type: "string" } } },
+					},
+				},
+			},
+		],
+	] as const;
+
+	for (const [name, before, after] of semanticOptionChanges) {
+		it(`keeps a ${name} change chain-breaking when service_tier is excluded`, () => {
+			const items = baselineItems();
+			const appended: ResponseInputItem = {
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: "follow-up" }],
+			};
+			const previous = { input: [items[0]!], service_tier: "default", ...before };
+			const current = { input: [items[0]!, items[1]!, appended], service_tier: "priority", ...after };
+
+			expect(buildResponsesDeltaInput(previous, [items[1]!], current, { service_tier: true })).toBeNull();
+		});
+	}
+
 	it("treats assistant message phase as part of chained-prefix equality", () => {
 		const user = baselineItems()[0]!;
 		const previousAssistant: ResponseInputItem = {


### PR DESCRIPTION
## What

- Preserve Codex WebSocket `previous_response_id` chaining across Standard → Fast/priority → Standard when `service_tier` is the only changed top-level request option.
- Keep the exclusion explicit and caller-controlled, so platform OpenAI Responses remains strict by default.
- Keep model, instructions, tool schema, reasoning, text verbosity, and response-format changes chain-breaking.
- Add direct delta-comparison and stateful WebSocket regressions, plus an `[Unreleased]` changelog entry.

## Why

Contributor note: “I've been playing around with switching between modes - Standard > Fast > Standard and noticed that it is not maintaining the continuation and I think it's because service tier is changing.”

Codex Fast is a per-turn service-tier selection, not a semantic transcript change. Treating that one payload field as chain-breaking replayed the full context even though the WebSocket append baseline and all semantic request options still matched.

## Testing

Independent branch on current upstream `main` (`989271449953548f1a399789bfc7500003115ebc`):

```text
bun test packages/ai/test/openai-responses-delta-input.test.ts packages/ai/test/openai-codex-stream.test.ts packages/ai/test/openai-responses-stateful.test.ts
115 pass, 0 fail

bun --cwd=packages/ai run check:types
passed
```

Bounded live Codex OAuth trace (`openai-codex/gpt-5.6-sol`, Responses Lite, prewarmed WebSocket, reasoning low):

- Standard → priority → Standard
- 3 request frames: 1 full-context request, then 2 delta requests
- 0 retries and 0 fetch/provider fallbacks
- priority TTFT improved 19.795%; total time improved 4.464%

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)