### PR TITLE
fix(coding-agent): normalize yaml mapping headers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed terminal resizes lagging on large transcripts: the transient resize repaint now renders only the visible tail instead of the entire committed transcript per resize event.
 - Fixed cache-miss dividers crashing completed streamed assistant messages after stable rows had entered native history; cache-miss status now trails the assistant output.
 - Fixed quitting re-streaming the entire committed transcript when a resize-triggered scrollback replay was still pending; shutdown now flushes only genuinely un-retired rows.
+- Fixed settings, migrated config, and keybindings YAML rewrites emitting trailing spaces on nested mapping headers.
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row

--- a/packages/coding-agent/src/config/config-file.ts
+++ b/packages/coding-agent/src/config/config-file.ts
@@ -4,6 +4,13 @@ import { OmpErrors, type Type } from "@oh-my-pi/omptype";
 import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
 
+const YAML_MAPPING_HEADER_TRAILING_SPACE = /: +$/gm;
+
+/** Serialize config YAML without Bun's trailing space on block mapping headers. */
+export function stringifyYamlConfig(value: unknown): string {
+	return YAML.stringify(value, null, 2).replace(YAML_MAPPING_HEADER_TRAILING_SPACE, ":");
+}
+
 /** Minimal subset of the AJV ConfigSchemaError shape this module actually relies on. */
 interface ConfigSchemaError {
 	instancePath: string;
@@ -46,7 +53,7 @@ function migrateJsonToYml(jsonPath: string, ymlPath: string) {
 			migratedPaths.add(key);
 			return;
 		}
-		fs.writeFileSync(ymlPath, YAML.stringify(parsed, null, 2));
+		fs.writeFileSync(ymlPath, stringifyYamlConfig(parsed));
 		migratedPaths.add(key);
 	} catch (error) {
 		logger.warn("migrateJsonToYml: migration failed", { error: String(error) });

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -11,6 +11,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { getActiveProfile, getAgentDir, getProfileRootDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
+import { stringifyYamlConfig } from "./config-file";
 
 /**
  * Application-level keybindings (coding agent specific).
@@ -418,7 +419,7 @@ function loadRawConfig(filePath: string): unknown {
 
 function writeKeybindingsConfig(filePath: string, config: KeybindingsConfig): boolean {
 	try {
-		fs.writeFileSync(filePath, YAML.stringify(config, null, 2), "utf-8");
+		fs.writeFileSync(filePath, stringifyYamlConfig(config), "utf-8");
 		logger.debug("Migrated keybindings config", { path: filePath });
 		return true;
 	} catch (error) {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -43,6 +43,7 @@ import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-pro
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { INSPECT_IMAGE_MODES } from "../utils/inspect-image-mode";
 import { isSearchProviderId, SEARCH_PROVIDER_ORDER } from "../web/search/types";
+import { stringifyYamlConfig } from "./config-file";
 import {
 	type BashInterceptorRule,
 	type GroupPrefix,
@@ -2195,7 +2196,7 @@ export class Settings {
 			const handle = await fs.promises.open(tempPath, "wx", 0o600);
 			removeTemp = true;
 			try {
-				await handle.writeFile(YAML.stringify(settings, null, 2), "utf8");
+				await handle.writeFile(stringifyYamlConfig(settings), "utf8");
 				await handle.sync();
 			} finally {
 				await handle.close();

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -127,6 +127,25 @@ describe("Settings", () => {
 			expect(await Bun.file(yamlConfigPath).exists()).toBe(false);
 			expect((await readSettings()).setupVersion).toBe(1);
 		});
+
+		it("writes mapping headers without trailing whitespace and preserves multiline values", async () => {
+			const multiline = ["first line", "scalar line ending in colon: ", "third line "].join("\n");
+			const custom = {
+				"quoted:key": { nested: [{ value: multiline }] },
+				emptyObject: {},
+				emptyArray: [],
+				emptyString: "",
+			};
+			await writeSettings({ custom, theme: { dark: "anthracite" } });
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			settings.set("theme.dark", "titanium");
+			await settings.flush();
+
+			const content = await Bun.file(getConfigPath()).text();
+			expect(content).not.toMatch(/: +$/m);
+			expect(YAML.parse(content)).toEqual({ custom, theme: { dark: "titanium" } });
+		});
 	});
 
 	describe("shell configuration errors", () => {


### PR DESCRIPTION
## What

- Serialize OMP-owned config YAML through one shared helper.
- Normalize Bun-emitted block-mapping headers from `key: ` to `key:` for settings persistence, JSON migration, and keybindings migration.
- Preserve scalar values and whitespace; do not globally trim serialized YAML.
- Add nested mapping/array, colon-bearing key, empty value, multiline scalar, and exact parse-round-trip coverage, plus an `[Unreleased]` changelog entry.

## Why

Contributor note: “We need to make sure our yaml remains written without trailing whitespace.”

Bun's YAML serializer emits a trailing space when a mapping value continues as a nested block. OMP rewrites its own config files through three paths, so each path could reintroduce lines such as `providers: `.

## Testing

Upstream `main` advanced after publication. Rebuilt on 2026-08-24 from exact base `969a94c1eeccb1b7528cd5621934bca1908ab622` as prepared tip `9aab112784a57e7ff76db7ddd7214ff9b09e3a86`:

```text
bun test packages/coding-agent/test/settings-manager.test.ts
90 pass, 0 fail

bun --cwd=packages/coding-agent run check:types
passed
```

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)