### PR TITLE
Add /updates shortcut for ephemeral session updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/updates [optional focus]` to request an ephemeral `/btw` recap of completed work, current progress, blockers, evidence, and the next action.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added
@@ -16,7 +20,6 @@
 - Added Yolo-Auto to `/login` and documented the `YOLO_AUTO_API_KEY` environment variable.
 - Updated the OpenRouter `/login` flow to support browser-based sign-in and automatic API-key provisioning, while retaining support for pasted `sk-or-…` keys.
 - Added DeepInfra support for the `image_gen` and `tts` tools, including provider selection and MP3 or WAV output for text-to-speech.
-- Added `/updates [optional focus]` to request an ephemeral `/btw` recap of completed work, current progress, blockers, evidence, and the next action.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added Yolo-Auto to `/login` and documented the `YOLO_AUTO_API_KEY` environment variable.
 - Updated the OpenRouter `/login` flow to support browser-based sign-in and automatic API-key provisioning, while retaining support for pasted `sk-or-…` keys.
 - Added DeepInfra support for the `image_gen` and `tts` tools, including provider selection and MP3 or WAV output for text-to-speech.
+- Added `/updates [optional focus]` to request an ephemeral `/btw` recap of completed work, current progress, blockers, evidence, and the next action.
 
 ### Changed
 

--- a/packages/coding-agent/src/prompts/system/session-update.md
+++ b/packages/coding-agent/src/prompts/system/session-update.md
@@ -1,0 +1,5 @@
+Catch me up on the current work. Briefly cover what completed, what is in progress, blockers or risks, the strongest evidence, and the next concrete action.
+{{#if focus}}
+
+Focus especially on: {{focus}}
+{{/if}}

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -52,6 +52,10 @@ function formatWorkspaceDirectories(runtime: SlashCommandRuntime, note?: string)
 	return note ? `${note}\n${lines.join("\n")}` : lines.join("\n");
 }
 
+const SESSION_UPDATE_QUESTION =
+	"Catch me up on the current work. Briefly cover what completed, what is in progress, " +
+	"blockers or risks, the strongest evidence, and the next concrete action.";
+
 export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "ssh",
@@ -359,6 +363,19 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
 			const question = command.text.slice(`/${command.name}`.length).trim();
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleBtwCommand(question);
+		},
+	},
+	{
+		name: "updates",
+		icon: "question",
+		description: "Show a concise ephemeral update for the current session",
+		inlineHint: "[focus]",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			const focus = command.text.slice(`/${command.name}`.length).trim();
+			const question = focus ? `${SESSION_UPDATE_QUESTION} Focus especially on: ${focus}` : SESSION_UPDATE_QUESTION;
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleBtwCommand(question);
 		},

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -1,9 +1,10 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { CompactionCancelledError } from "@oh-my-pi/pi-agent-core/compaction";
-import { logger, setProjectDir } from "@oh-my-pi/pi-utils";
+import { logger, prompt, setProjectDir } from "@oh-my-pi/pi-utils";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
+import sessionUpdatePrompt from "../prompts/system/session-update.md" with { type: "text" };
 import type { FreshSessionResult, HandoffResult } from "../session/agent-session";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { USER_INTERRUPT_LABEL } from "../session/messages";
@@ -51,10 +52,6 @@ function formatWorkspaceDirectories(runtime: SlashCommandRuntime, note?: string)
 	const lines = ["Workspace directories:", `  ${cwd} (working directory)`, ...additional.map(d => `  ${d}`)];
 	return note ? `${note}\n${lines.join("\n")}` : lines.join("\n");
 }
-
-const SESSION_UPDATE_QUESTION =
-	"Catch me up on the current work. Briefly cover what completed, what is in progress, " +
-	"blockers or risks, the strongest evidence, and the next concrete action.";
 
 export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
@@ -375,7 +372,7 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
 			const focus = command.text.slice(`/${command.name}`.length).trim();
-			const question = focus ? `${SESSION_UPDATE_QUESTION} Focus especially on: ${focus}` : SESSION_UPDATE_QUESTION;
+			const question = prompt.render(sessionUpdatePrompt, { focus }).trim();
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleBtwCommand(question);
 		},

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -371,7 +371,7 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		inlineHint: "[focus]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
-			const focus = command.text.slice(`/${command.name}`.length).trim();
+			const focus = command.args.trim();
 			const question = prompt.render(sessionUpdatePrompt, { focus }).trim();
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleBtwCommand(question);

--- a/packages/coding-agent/test/slash-commands/btw.test.ts
+++ b/packages/coding-agent/test/slash-commands/btw.test.ts
@@ -52,3 +52,28 @@ describe("/btw slash command", () => {
 		expect(harness.handleBtwCommand).toHaveBeenCalledWith("");
 	});
 });
+
+describe("/updates slash command", () => {
+	const updateQuestion =
+		"Catch me up on the current work. Briefly cover what completed, what is in progress, " +
+		"blockers or risks, the strongest evidence, and the next concrete action.";
+
+	it("routes the default update question through the interactive btw handler", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/updates", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.handleBtwCommand).toHaveBeenCalledWith(updateQuestion);
+	});
+
+	it("appends an optional focus to the update question", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/updates test failures", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.handleBtwCommand).toHaveBeenCalledWith(`${updateQuestion} Focus especially on: test failures`);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/btw.test.ts
+++ b/packages/coding-agent/test/slash-commands/btw.test.ts
@@ -64,10 +64,10 @@ describe("/updates slash command", () => {
 		expect(harness.handleBtwCommand).toHaveBeenCalledTimes(1);
 	});
 
-	it("appends an optional focus to the update question", async () => {
+	it("accepts a colon-separated optional focus", async () => {
 		const harness = createRuntime();
 
-		const handled = await executeBuiltinSlashCommand("/updates test failures", harness.runtime);
+		const handled = await executeBuiltinSlashCommand("/updates:test failures", harness.runtime);
 
 		expect(handled).toBe(true);
 		expect(harness.handleBtwCommand).toHaveBeenCalledWith(expect.stringContaining("test failures"));

--- a/packages/coding-agent/test/slash-commands/btw.test.ts
+++ b/packages/coding-agent/test/slash-commands/btw.test.ts
@@ -54,10 +54,6 @@ describe("/btw slash command", () => {
 });
 
 describe("/updates slash command", () => {
-	const updateQuestion =
-		"Catch me up on the current work. Briefly cover what completed, what is in progress, " +
-		"blockers or risks, the strongest evidence, and the next concrete action.";
-
 	it("routes the default update question through the interactive btw handler", async () => {
 		const harness = createRuntime();
 
@@ -65,7 +61,7 @@ describe("/updates slash command", () => {
 
 		expect(handled).toBe(true);
 		expect(harness.setText).toHaveBeenCalledWith("");
-		expect(harness.handleBtwCommand).toHaveBeenCalledWith(updateQuestion);
+		expect(harness.handleBtwCommand).toHaveBeenCalledTimes(1);
 	});
 
 	it("appends an optional focus to the update question", async () => {
@@ -74,6 +70,6 @@ describe("/updates slash command", () => {
 		const handled = await executeBuiltinSlashCommand("/updates test failures", harness.runtime);
 
 		expect(handled).toBe(true);
-		expect(harness.handleBtwCommand).toHaveBeenCalledWith(`${updateQuestion} Focus especially on: test failures`);
+		expect(harness.handleBtwCommand).toHaveBeenCalledWith(expect.stringContaining("test failures"));
 	});
 });


### PR DESCRIPTION
## Summary
- Add `/updates [optional focus]` as a TUI-only shortcut that reuses the existing `/btw` handler, so status recaps stay ephemeral and do not interrupt or enter the main conversation.
- Keep the model-facing recap in a static Handlebars prompt, accept whitespace or colon-separated focus text, cover routing/focus behavior, and document the command in the changelog.

## Requester note
> “Can you add a slash skill to OMP that can quickly be used as a shorthand to call `/btw` along with a message to give updates—basically instead of using `/btw can you please catch me up with the updates`?”

The requester reviewed and approved the complete current four-file diff, including the reviewer-requested prompt, test, changelog, and parsed-argument changes.

## Validation
- **Passed — focused slash-command behavior:** 5 tests, 13 assertions.
  - Command: `bun test packages/coding-agent/test/slash-commands/btw.test.ts`
- **Passed — formatting and lint checks for both TypeScript files.**
  - Command: `npx --yes @biomejs/biome@2.5.3 check packages/coding-agent/src/slash-commands/builtin-lifecycle.ts packages/coding-agent/test/slash-commands/btw.test.ts`
- **Exercised the user-facing flow:** a local compatibility extension routed `/updates` through a real OMP TUI; the `/btw` panel rendered and the fallback command handler did not run.