### PR TITLE
Allow folders to select OMP profiles automatically

### DIFF
--- a/docs/config-usage.md
+++ b/docs/config-usage.md
@@ -85,6 +85,21 @@ On macOS and Linux, an existing `$XDG_DATA_HOME/omp`, `$XDG_STATE_HOME/omp`, or 
 
 The other source bases are not profile-scoped and load identically under every profile: the external-tool bases (`~/.claude`, `~/.codex`, `~/.gemini`) belong to those tools, and the project-level bases (`<cwd>/.omp`, `<cwd>/.claude`, ...) are keyed to the working directory. Throughout this document, read `~/.omp/agent` as shorthand for the active profile's agent directory unless an environment override or XDG path is being discussed.
 
+### Folder bindings
+
+Bind a folder or Git repository to a profile so plain `omp` selects it automatically:
+
+```bash
+omp profile bind work [path]
+omp profile show [path]
+omp profile unbind [path]
+omp profile list
+```
+
+Bindings are stored in the profile-independent `~/.omp/profile-bindings.json`, never in the project. A Git binding uses the shared Git directory, so repository subdirectories and linked worktrees select the same profile. A non-Git folder binding applies to all of its subdirectories.
+
+Explicit selection always wins: `--profile`, then `OMP_PROFILE`, then `PI_PROFILE`, then a folder binding, then the default profile. Setting `OMP_PROFILE` to an empty value explicitly selects the default profile and disables automatic binding for that launch. Interactive startup and `/profile` show the active profile and its Anthropic account email.
+
 ## Important constraint
 
 The generic helpers in `src/config.ts` do **not** include `.pi` in source discovery order.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added an explicit append-only transcript declaration and width-independent stable-row API for components that can guarantee an immutable history prefix across later updates.
 - Added `:img` read selector to rasterize local SVG/SVGZ files for vision input.
+- Added folder bindings that automatically select an OMP profile when `omp` starts inside a bound directory or Git worktree. Interactive startup and `/profile` show the active profile and its Anthropic account email.
 - Added side-by-side image and SVG previews to `omp git`, including local Git LFS object resolution and explicit placeholders for unavailable or unsupported binary content.
 - Added the `omp if-bench` command: a zero-tool instruction-following and working-memory benchmark that drives one cached conversation per model, adding one more glyph array action every turn while a `nya{1,N}` directive moves through the prompt, with a live turn-ladder board and a ranked scoreboard
 - Added `q` shortcut to exit the git TUI
@@ -312,7 +313,6 @@
 - Pasted images and large text pastes appear in the composer as compact icon tokens instead of bracketed markers; the bracketed form remains the outgoing/stored format, and the transcript renders it back as the compact chip.
 - Deleting an attachment's inline token now removes the attachment from the submission (surviving image markers are renumbered).
 - Restored prompts (esc-esc, `/tree`, branch, queued-message dequeue, failed-submit recovery) collapse image markers back into clickable atomic chip tokens and re-materialize their file links instead of degrading to dead text.
-- Added folder bindings that automatically select an OMP profile when `omp` starts inside a bound directory or Git worktree. Interactive startup and `/profile` show the active profile and its Anthropic account email.
 
 ## [17.4.1] - 2026-08-21
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -312,6 +312,7 @@
 - Pasted images and large text pastes appear in the composer as compact icon tokens instead of bracketed markers; the bracketed form remains the outgoing/stored format, and the transcript renders it back as the compact chip.
 - Deleting an attachment's inline token now removes the attachment from the submission (surviving image markers are renumbered).
 - Restored prompts (esc-esc, `/tree`, branch, queued-message dequeue, failed-submit recovery) collapse image markers back into clickable atomic chip tokens and re-materialize their file links instead of degrading to dead text.
+- Added folder bindings that automatically select an OMP profile when `omp` starts inside a bound directory or Git worktree. Interactive startup and `/profile` show the active profile and its Anthropic account email.
 
 ## [17.4.1] - 2026-08-21
 

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -143,6 +143,11 @@ export const commands: CommandEntry[] = [
 		help: commandHelp.pluginHelp,
 	},
 	{
+		name: "profile",
+		load: () => import("./commands/profile").then(m => m.default),
+		help: commandHelp.profileHelp,
+	},
+	{
 		name: "ps",
 		load: () => import("./commands/ps").then(m => m.default),
 		help: commandHelp.psHelp,

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -14,6 +14,7 @@ try {
  * CLI entry point — registers all commands explicitly and delegates to the
  * lightweight CLI runner from pi-utils.
  */
+import * as path from "node:path";
 import { parentPort } from "node:worker_threads";
 import type { CliConfig, CommandMetadata } from "@oh-my-pi/pi-utils/cli";
 import {
@@ -29,7 +30,9 @@ import { setProcessName } from "@oh-my-pi/pi-utils/process-name";
 import { declareWorkerHostEntry, installWorkerInbox, isWorkerHostSelector } from "@oh-my-pi/pi-utils/worker-host";
 import { BLOB_BROKER_WORKER_ARG } from "./blob-broker/protocol";
 import { installProfileAlias, resolveProfileAliasCommandFromProcess } from "./cli/profile-alias";
+import { resolveExistingProfileBinding } from "./cli/profile-binding-resolver";
 import { extractProfileFlags } from "./cli/profile-bootstrap";
+import { setExplicitProfileSelection } from "./cli/profile-selection";
 import { startJsEvalProcess } from "./eval/js/process-entry";
 import type { WorkerInbound as JsWorkerInbound, WorkerOutbound as JsWorkerOutbound } from "./eval/js/worker-protocol";
 import { DAEMON_BROKER_WORKER_ARG } from "./launch/protocol";
@@ -343,23 +346,35 @@ async function runTinyWorker(): Promise<void> {
 export async function runCli(argv: string[]): Promise<void> {
 	let resolvedArgv = argv;
 	try {
+		setExplicitProfileSelection(undefined);
 		const extracted = extractProfileFlags(resolvedArgv);
 		resolvedArgv = extracted.argv;
+		const hasProfileEnv = process.env.OMP_PROFILE !== undefined || process.env.PI_PROFILE !== undefined;
 		if (extracted.profile !== undefined) {
 			setProfile(extracted.profile);
-		} else {
-			// No explicit --profile: activate any OMP_PROFILE/PI_PROFILE inherited
-			// from the environment. Module-load resolution deliberately swallows an
-			// invalid value to avoid an uncaught throw before this try/catch is in
-			// scope (see `readProfileFromEnvSafe` in dirs.ts), and callers may set
-			// OMP_PROFILE after importing this module (profile aliases/tests). Surfacing
-			// validation here turns `OMP_PROFILE=.. omp --version` into a clean error;
-			// calling setProfile keeps every later path helper on the env-selected
-			// profile instead of the default agent directory.
+			setExplicitProfileSelection({ profile: getActiveProfile(), source: "cli" });
+		} else if (hasProfileEnv) {
+			// Environment selectors are explicit even when empty: OMP_PROFILE=""
+			// deliberately selects the default profile and suppresses folder bindings.
+			// Module-load resolution swallows invalid values until this error boundary,
+			// so validate and apply them again here before profile-scoped imports.
 			setProfile(resolveProfileEnv(process.env.OMP_PROFILE, process.env.PI_PROFILE));
+			setExplicitProfileSelection({ profile: getActiveProfile(), source: "environment" });
+		} else if (extracted.command === "profile" || extracted.aliasName !== undefined) {
+			// Profile management must remain available even when the current folder is
+			// bound to a missing profile, so it can inspect, replace, or remove the binding.
+			// Alias validation must retain its explicit-profile requirement too.
+			setProfile(undefined);
+		} else {
+			const launchCwd = extracted.cwd ? path.resolve(process.cwd(), extracted.cwd) : process.cwd();
+			const bound = await resolveExistingProfileBinding(launchCwd);
+			setProfile(bound?.profile);
+		}
+		if (extracted.command === "profile" && extracted.cwd) {
+			process.chdir(path.resolve(process.cwd(), extracted.cwd));
 		}
 		if (extracted.aliasName !== undefined) {
-			const profile = extracted.profile ?? getActiveProfile();
+			const profile = extracted.profile ?? (hasProfileEnv ? getActiveProfile() : undefined);
 			if (!profile) {
 				throw new Error("--alias requires --profile <name> or OMP_PROFILE");
 			}

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -352,6 +352,7 @@ export async function runCli(argv: string[]): Promise<void> {
 		const hasProfileEnv = process.env.OMP_PROFILE !== undefined || process.env.PI_PROFILE !== undefined;
 		if (extracted.profile !== undefined) {
 			setProfile(extracted.profile);
+			if (getActiveProfile() === undefined) process.env.OMP_PROFILE = "";
 			setExplicitProfileSelection({ profile: getActiveProfile(), source: "cli" });
 		} else if (hasProfileEnv) {
 			// Environment selectors are explicit even when empty: OMP_PROFILE=""
@@ -359,6 +360,7 @@ export async function runCli(argv: string[]): Promise<void> {
 			// Module-load resolution swallows invalid values until this error boundary,
 			// so validate and apply them again here before profile-scoped imports.
 			setProfile(resolveProfileEnv(process.env.OMP_PROFILE, process.env.PI_PROFILE));
+			if (getActiveProfile() === undefined) process.env.OMP_PROFILE = "";
 			setExplicitProfileSelection({ profile: getActiveProfile(), source: "environment" });
 		} else if (extracted.command === "profile" || extracted.aliasName !== undefined) {
 			// Profile management must remain available even when the current folder is

--- a/packages/coding-agent/src/cli/command-help.ts
+++ b/packages/coding-agent/src/cli/command-help.ts
@@ -77,6 +77,7 @@ export const joinHelp = { description: "Join a shared collab session (same as /j
 export const modelsHelp = { description: "List, search, and refresh available models" } satisfies CommandMetadata;
 
 export const pluginHelp = { description: "Manage plugins (install, uninstall, list, etc.)" } satisfies CommandMetadata;
+export const profileHelp = { description: "Bind folders to OMP profiles" } satisfies CommandMetadata;
 
 export const psHelp = {
 	description: "List and control daemon-supervised background processes (logs, stop, kill, restart)",

--- a/packages/coding-agent/src/cli/profile-binding-resolver.ts
+++ b/packages/coding-agent/src/cli/profile-binding-resolver.ts
@@ -1,0 +1,191 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	getBaseConfigRootDir,
+	getProfileRootDir,
+	normalizePathForComparison,
+	normalizeProfileName,
+	pathIsWithin,
+	relativePathWithinRoot,
+} from "@oh-my-pi/pi-utils/dirs";
+import { isEnoent } from "@oh-my-pi/pi-utils/fs-error";
+import { resolveGitRepository } from "@oh-my-pi/pi-utils/git-repository";
+
+export const PROFILE_BINDINGS_VERSION = 1;
+const PROFILE_BINDINGS_FILENAME = "profile-bindings.json";
+
+export type ProfileBindingKind = "directory" | "git-common-dir";
+
+export interface ProfileBinding {
+	kind: ProfileBindingKind;
+	path: string;
+	profile: string;
+	/** Folder inside each checkout. Omitted when the whole repository is bound. */
+	subpath?: string;
+}
+
+export interface ProfileBindingsFile {
+	version: typeof PROFILE_BINDINGS_VERSION;
+	bindings: ProfileBinding[];
+}
+
+export interface ResolvedProfileBinding {
+	binding: ProfileBinding;
+	profile?: string;
+}
+
+export interface BindingTarget {
+	kind: ProfileBindingKind;
+	path: string;
+	subpath?: string;
+}
+
+export function getProfileBindingsPath(): string {
+	return path.join(getBaseConfigRootDir(), PROFILE_BINDINGS_FILENAME);
+}
+
+function emptyBindingsFile(): ProfileBindingsFile {
+	return { version: PROFILE_BINDINGS_VERSION, bindings: [] };
+}
+
+function isValidSubpath(value: unknown): value is string | undefined {
+	if (value === undefined) return true;
+	if (typeof value !== "string" || value.length === 0) return false;
+	const portable = value.replaceAll("\\", "/");
+	if (portable.startsWith("/") || /^[A-Za-z]:\//.test(portable)) return false;
+	const normalized = path.posix.normalize(portable);
+	return normalized !== "." && normalized !== ".." && !normalized.startsWith("../");
+}
+
+function isProfileBinding(value: unknown): value is ProfileBinding {
+	if (value === null || typeof value !== "object") return false;
+	const record = value as Record<string, unknown>;
+	if (
+		(record.kind !== "directory" && record.kind !== "git-common-dir") ||
+		typeof record.path !== "string" ||
+		!path.isAbsolute(record.path) ||
+		typeof record.profile !== "string" ||
+		record.profile.length === 0 ||
+		!isValidSubpath(record.subpath) ||
+		(record.kind === "directory" && record.subpath !== undefined)
+	) {
+		return false;
+	}
+	try {
+		normalizeProfileName(record.profile);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function parseBindingsFile(value: unknown, filePath: string): ProfileBindingsFile {
+	if (value === null || typeof value !== "object") {
+		throw new Error(`Invalid profile bindings file at ${filePath}: expected an object`);
+	}
+	const record = value as Record<string, unknown>;
+	if (record.version !== PROFILE_BINDINGS_VERSION) {
+		throw new Error(
+			`Unsupported profile bindings version at ${filePath}: expected ${PROFILE_BINDINGS_VERSION}, found ${String(record.version)}`,
+		);
+	}
+	if (!Array.isArray(record.bindings) || !record.bindings.every(isProfileBinding)) {
+		throw new Error(`Invalid profile bindings file at ${filePath}: "bindings" must be an array of folder bindings`);
+	}
+	return { version: PROFILE_BINDINGS_VERSION, bindings: record.bindings };
+}
+
+export async function loadProfileBindings(filePath: string = getProfileBindingsPath()): Promise<ProfileBindingsFile> {
+	try {
+		return parseBindingsFile(await Bun.file(filePath).json(), filePath);
+	} catch (error) {
+		if (isEnoent(error)) return emptyBindingsFile();
+		if (error instanceof SyntaxError) {
+			throw new Error(`Invalid JSON in profile bindings file at ${filePath}: ${error.message}`);
+		}
+		throw error;
+	}
+}
+
+export async function resolveBindingTarget(inputPath: string): Promise<BindingTarget> {
+	const absolutePath = path.resolve(inputPath);
+	try {
+		const stat = await fs.stat(absolutePath);
+		if (!stat.isDirectory()) throw new Error("path is not a directory");
+	} catch (error) {
+		throw new Error(`Cannot bind folder ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	const repository = await resolveGitRepository(absolutePath);
+	if (!repository) return { kind: "directory", path: normalizePathForComparison(absolutePath) };
+
+	const repoRoot = normalizePathForComparison(repository.repoRoot);
+	const folder = normalizePathForComparison(absolutePath);
+	const subpath = relativePathWithinRoot(repoRoot, folder) ?? undefined;
+	return {
+		kind: "git-common-dir",
+		path: normalizePathForComparison(repository.commonDir),
+		...(subpath ? { subpath } : {}),
+	};
+}
+
+export function storedProfileName(profile: string): string {
+	return normalizeProfileName(profile) ?? "default";
+}
+
+export async function assertProfileExists(profile: string): Promise<void> {
+	const normalized = normalizeProfileName(profile);
+	if (!normalized) return;
+	try {
+		if ((await fs.stat(getProfileRootDir(normalized))).isDirectory()) return;
+	} catch {}
+	throw new Error(`OMP profile "${normalized}" does not exist. Start it once with: omp --profile ${normalized}`);
+}
+
+function gitBindingMatches(binding: ProfileBinding, commonDir: string, repoRoot: string, folder: string): boolean {
+	if (binding.kind !== "git-common-dir" || binding.path !== commonDir) return false;
+	if (!binding.subpath) return pathIsWithin(repoRoot, folder);
+	const bindingRoot = normalizePathForComparison(
+		path.resolve(repoRoot, ...binding.subpath.replaceAll("\\", "/").split("/")),
+	);
+	return pathIsWithin(repoRoot, bindingRoot) && pathIsWithin(bindingRoot, folder);
+}
+
+export async function resolveProfileBindingFromData(
+	inputPath: string,
+	data: ProfileBindingsFile,
+): Promise<ResolvedProfileBinding | null> {
+	if (data.bindings.length === 0) return null;
+	const folder = normalizePathForComparison(path.resolve(inputPath));
+	const repository = await resolveGitRepository(folder);
+	if (repository) {
+		const commonDir = normalizePathForComparison(repository.commonDir);
+		const repoRoot = normalizePathForComparison(repository.repoRoot);
+		const gitBinding = data.bindings
+			.filter(binding => gitBindingMatches(binding, commonDir, repoRoot, folder))
+			.sort((left, right) => (right.subpath?.length ?? 0) - (left.subpath?.length ?? 0))[0];
+		if (gitBinding) return { binding: gitBinding, profile: normalizeProfileName(gitBinding.profile) };
+	}
+	const directoryBinding = data.bindings
+		.filter(binding => binding.kind === "directory" && pathIsWithin(binding.path, folder))
+		.sort((left, right) => right.path.length - left.path.length)[0];
+	if (!directoryBinding) return null;
+	return { binding: directoryBinding, profile: normalizeProfileName(directoryBinding.profile) };
+}
+
+export async function resolveProfileBinding(
+	inputPath: string = process.cwd(),
+	filePath: string = getProfileBindingsPath(),
+): Promise<ResolvedProfileBinding | null> {
+	return resolveProfileBindingFromData(inputPath, await loadProfileBindings(filePath));
+}
+
+export async function resolveExistingProfileBinding(
+	inputPath: string = process.cwd(),
+	filePath: string = getProfileBindingsPath(),
+): Promise<ResolvedProfileBinding | null> {
+	const resolved = await resolveProfileBinding(inputPath, filePath);
+	if (!resolved?.profile) return resolved;
+	await assertProfileExists(resolved.profile);
+	return resolved;
+}

--- a/packages/coding-agent/src/cli/profile-binding-resolver.ts
+++ b/packages/coding-agent/src/cli/profile-binding-resolver.ts
@@ -9,7 +9,7 @@ import {
 	relativePathWithinRoot,
 } from "@oh-my-pi/pi-utils/dirs";
 import { isEnoent } from "@oh-my-pi/pi-utils/fs-error";
-import { resolveGitRepository } from "@oh-my-pi/pi-utils/git-repository";
+import { type GitRepository, resolveGitRepository } from "@oh-my-pi/pi-utils/git-repository";
 
 export const PROFILE_BINDINGS_VERSION = 1;
 const PROFILE_BINDINGS_FILENAME = "profile-bindings.json";
@@ -116,11 +116,11 @@ export async function resolveBindingTarget(inputPath: string): Promise<BindingTa
 		throw new Error(`Cannot bind folder ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`);
 	}
 
-	const repository = await resolveGitRepository(absolutePath);
-	if (!repository) return { kind: "directory", path: normalizePathForComparison(absolutePath) };
+	const folder = normalizePathForComparison(absolutePath);
+	const repository = await resolveGitRepository(folder);
+	if (!repository) return { kind: "directory", path: folder };
 
 	const repoRoot = normalizePathForComparison(repository.repoRoot);
-	const folder = normalizePathForComparison(absolutePath);
 	const subpath = relativePathWithinRoot(repoRoot, folder) ?? undefined;
 	return {
 		kind: "git-common-dir",
@@ -142,13 +142,30 @@ export async function assertProfileExists(profile: string): Promise<void> {
 	throw new Error(`OMP profile "${normalized}" does not exist. Start it once with: omp --profile ${normalized}`);
 }
 
-function gitBindingMatches(binding: ProfileBinding, commonDir: string, repoRoot: string, folder: string): boolean {
-	if (binding.kind !== "git-common-dir" || binding.path !== commonDir) return false;
-	if (!binding.subpath) return pathIsWithin(repoRoot, folder);
+function gitBindingRoot(binding: ProfileBinding, commonDir: string, repoRoot: string): string | null {
+	if (binding.kind !== "git-common-dir" || binding.path !== commonDir) return null;
+	if (!binding.subpath) return repoRoot;
 	const bindingRoot = normalizePathForComparison(
 		path.resolve(repoRoot, ...binding.subpath.replaceAll("\\", "/").split("/")),
 	);
-	return pathIsWithin(repoRoot, bindingRoot) && pathIsWithin(bindingRoot, folder);
+	return pathIsWithin(repoRoot, bindingRoot) ? bindingRoot : null;
+}
+
+async function enclosingGitRepositories(folder: string): Promise<GitRepository[]> {
+	const repositories: GitRepository[] = [];
+	const seen = new Set<string>();
+	let searchFrom = folder;
+	while (true) {
+		const repository = await resolveGitRepository(searchFrom);
+		if (!repository) return repositories;
+		const key = `${normalizePathForComparison(repository.commonDir)}\0${normalizePathForComparison(repository.repoRoot)}`;
+		if (seen.has(key)) return repositories;
+		seen.add(key);
+		repositories.push(repository);
+		const parent = path.dirname(repository.repoRoot);
+		if (parent === repository.repoRoot) return repositories;
+		searchFrom = parent;
+	}
 }
 
 export async function resolveProfileBindingFromData(
@@ -157,15 +174,18 @@ export async function resolveProfileBindingFromData(
 ): Promise<ResolvedProfileBinding | null> {
 	if (data.bindings.length === 0) return null;
 	const folder = normalizePathForComparison(path.resolve(inputPath));
-	const repository = await resolveGitRepository(folder);
-	if (repository) {
+	const gitMatches: Array<{ binding: ProfileBinding; root: string }> = [];
+	for (const repository of await enclosingGitRepositories(folder)) {
 		const commonDir = normalizePathForComparison(repository.commonDir);
 		const repoRoot = normalizePathForComparison(repository.repoRoot);
-		const gitBinding = data.bindings
-			.filter(binding => gitBindingMatches(binding, commonDir, repoRoot, folder))
-			.sort((left, right) => (right.subpath?.length ?? 0) - (left.subpath?.length ?? 0))[0];
-		if (gitBinding) return { binding: gitBinding, profile: normalizeProfileName(gitBinding.profile) };
+		for (const binding of data.bindings) {
+			const root = gitBindingRoot(binding, commonDir, repoRoot);
+			if (root && pathIsWithin(root, folder)) gitMatches.push({ binding, root });
+		}
 	}
+	gitMatches.sort((left, right) => right.root.length - left.root.length);
+	const gitBinding = gitMatches[0]?.binding;
+	if (gitBinding) return { binding: gitBinding, profile: normalizeProfileName(gitBinding.profile) };
 	const directoryBinding = data.bindings
 		.filter(binding => binding.kind === "directory" && pathIsWithin(binding.path, folder))
 		.sort((left, right) => right.path.length - left.path.length)[0];

--- a/packages/coding-agent/src/cli/profile-bindings.ts
+++ b/packages/coding-agent/src/cli/profile-bindings.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { atomicWriteJson } from "@oh-my-pi/pi-utils/atomic-write";
+import { withFileLock } from "@oh-my-pi/pi-utils/file-lock";
+import {
+	assertProfileExists,
+	getProfileBindingsPath,
+	loadProfileBindings,
+	PROFILE_BINDINGS_VERSION,
+	type ProfileBinding,
+	resolveBindingTarget,
+	resolveProfileBindingFromData,
+	storedProfileName,
+} from "./profile-binding-resolver";
+
+export * from "./profile-binding-resolver";
+
+function bindingMatchesTarget(
+	binding: ProfileBinding,
+	target: Pick<ProfileBinding, "kind" | "path" | "subpath">,
+): boolean {
+	return binding.kind === target.kind && binding.path === target.path && binding.subpath === target.subpath;
+}
+
+export async function bindProfileToFolder(
+	profile: string,
+	inputPath: string = process.cwd(),
+	filePath: string = getProfileBindingsPath(),
+): Promise<ProfileBinding> {
+	const storedProfile = storedProfileName(profile);
+	await assertProfileExists(storedProfile);
+	const target = await resolveBindingTarget(inputPath);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+	const binding: ProfileBinding = { ...target, profile: storedProfile };
+	await withFileLock(filePath, async () => {
+		const data = await loadProfileBindings(filePath);
+		data.bindings = data.bindings.filter(item => !bindingMatchesTarget(item, target));
+		data.bindings.push(binding);
+		await atomicWriteJson(filePath, data);
+	});
+	return binding;
+}
+
+export async function unbindProfileFromFolder(
+	inputPath: string = process.cwd(),
+	filePath: string = getProfileBindingsPath(),
+): Promise<ProfileBinding | null> {
+	let removed: ProfileBinding | null = null;
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await withFileLock(filePath, async () => {
+		const data = await loadProfileBindings(filePath);
+		const selected = await resolveProfileBindingFromData(inputPath, data);
+		if (!selected) return;
+		const kept = data.bindings.filter(item => {
+			if (!bindingMatchesTarget(item, selected.binding)) return true;
+			removed = item;
+			return false;
+		});
+		await atomicWriteJson(filePath, { version: PROFILE_BINDINGS_VERSION, bindings: kept });
+	});
+	return removed;
+}
+
+export async function listProfileBindings(filePath: string = getProfileBindingsPath()): Promise<ProfileBinding[]> {
+	return (await loadProfileBindings(filePath)).bindings;
+}

--- a/packages/coding-agent/src/cli/profile-bootstrap.ts
+++ b/packages/coding-agent/src/cli/profile-bootstrap.ts
@@ -33,7 +33,7 @@
  * them also activates (`omp --print --profile work`).
  */
 
-import { isSubcommand, LAUNCH_FLAG_COMMANDS } from "../cli-commands";
+import { isSubcommand, LAUNCH_FLAG_COMMANDS, resolveCliArgv } from "../cli-commands";
 import {
 	EXTENSION_SHADOWABLE_STRING_FLAGS,
 	isUnknownLongValueCandidate,
@@ -57,6 +57,8 @@ export interface ProfileBootstrapResult {
 	argv: string[];
 	profile?: string;
 	aliasName?: string;
+	cwd?: string;
+	command?: string;
 }
 
 /**
@@ -78,6 +80,7 @@ export function extractProfileFlags(argv: readonly string[]): ProfileBootstrapRe
 	const stripped: string[] = [];
 	let profile: string | undefined;
 	let aliasName: string | undefined;
+	let cwd: string | undefined;
 	let passThrough = false;
 	let sawSubcommand = false;
 	let canDispatchSubcommand = true;
@@ -102,6 +105,12 @@ export function extractProfileFlags(argv: readonly string[]): ProfileBootstrapRe
 		// downstream tools without the bootstrap stealing them.
 		if (arg === "--") {
 			passThrough = true;
+			stripped.push(arg);
+			continue;
+		}
+
+		if (arg.startsWith("--cwd=")) {
+			cwd = arg.slice("--cwd=".length);
 			stripped.push(arg);
 			continue;
 		}
@@ -169,7 +178,9 @@ export function extractProfileFlags(argv: readonly string[]): ProfileBootstrapRe
 			canDispatchSubcommand = false;
 			stripped.push(arg);
 			if (index + 1 < argv.length) {
-				stripped.push(argv[index + 1]);
+				const value = argv[index + 1];
+				stripped.push(value);
+				if (arg === "--cwd") cwd = value;
 				index += 1;
 			}
 			continue;
@@ -225,5 +236,13 @@ export function extractProfileFlags(argv: readonly string[]): ProfileBootstrapRe
 		stripped.push(arg);
 	}
 
-	return { argv: stripped, profile, aliasName };
+	const routed = resolveCliArgv(stripped);
+	const command = "argv" in routed && LAUNCH_FLAG_COMMANDS[routed.argv[0]] !== true ? routed.argv[0] : undefined;
+	return {
+		argv: stripped,
+		profile,
+		aliasName,
+		...(cwd !== undefined ? { cwd } : {}),
+		...(command !== undefined && isSubcommand(command) ? { command } : {}),
+	};
 }

--- a/packages/coding-agent/src/cli/profile-cli.ts
+++ b/packages/coding-agent/src/cli/profile-cli.ts
@@ -1,0 +1,83 @@
+import chalk from "@oh-my-pi/pi-utils/chalk";
+import { shortenPath } from "../tools/render-utils";
+import {
+	bindProfileToFolder,
+	listProfileBindings,
+	type ProfileBinding,
+	resolveProfileBinding,
+	unbindProfileFromFolder,
+} from "./profile-bindings";
+import { getExplicitProfileSelection } from "./profile-selection";
+
+export type ProfileAction = "bind" | "list" | "list-bindings" | "show" | "unbind";
+
+export interface ProfileCommandOptions {
+	action: ProfileAction;
+	profile?: string;
+	path?: string;
+	json: boolean;
+}
+
+function bindingLabel(binding: ProfileBinding): string {
+	const base = shortenPath(binding.path);
+	return binding.subpath ? `${base} (${binding.subpath})` : base;
+}
+
+export async function runProfileCommand(options: ProfileCommandOptions): Promise<void> {
+	if (options.action === "bind") {
+		if (!options.profile) throw new Error("Usage: omp profile bind <profile> [path]");
+		const binding = await bindProfileToFolder(options.profile, options.path);
+		if (options.json) {
+			console.log(JSON.stringify(binding, null, 2));
+			return;
+		}
+		console.log(`Bound ${chalk.cyan(bindingLabel(binding))} to profile ${chalk.green(binding.profile)}.`);
+		return;
+	}
+
+	if (options.action === "unbind") {
+		const removed = await unbindProfileFromFolder(options.path);
+		if (options.json) {
+			console.log(JSON.stringify({ removed }, null, 2));
+			return;
+		}
+		if (!removed) {
+			console.log(chalk.dim("This folder has no profile binding."));
+			return;
+		}
+		console.log(
+			`Removed the ${chalk.green(removed.profile)} profile binding for ${chalk.cyan(bindingLabel(removed))}.`,
+		);
+		return;
+	}
+
+	if (options.action === "show") {
+		const explicit = getExplicitProfileSelection();
+		const resolved = explicit ? null : await resolveProfileBinding(options.path);
+		const profile = explicit?.profile ?? resolved?.binding.profile ?? "default";
+		const selectedBy = explicit?.source ?? (resolved ? "folder-binding" : "default");
+		if (options.json) {
+			console.log(
+				JSON.stringify({ profile, selectedBy, ...(resolved ? { binding: resolved.binding } : {}) }, null, 2),
+			);
+			return;
+		}
+		console.log(`Profile: ${chalk.green(profile)}`);
+		console.log(`Selected by: ${selectedBy === "folder-binding" ? "folder binding" : selectedBy}`);
+		if (resolved) console.log(`Folder: ${bindingLabel(resolved.binding)}`);
+		return;
+	}
+
+	const bindings = await listProfileBindings();
+	if (options.json) {
+		console.log(JSON.stringify(bindings, null, 2));
+		return;
+	}
+	if (bindings.length === 0) {
+		console.log(chalk.dim("No folder profile bindings."));
+		return;
+	}
+	for (const binding of bindings) {
+		console.log(`${chalk.green(binding.profile)}  ${bindingLabel(binding)}`);
+	}
+}

--- a/packages/coding-agent/src/cli/profile-selection.ts
+++ b/packages/coding-agent/src/cli/profile-selection.ts
@@ -1,0 +1,16 @@
+export type ExplicitProfileSource = "cli" | "environment";
+
+export interface ExplicitProfileSelection {
+	profile?: string;
+	source: ExplicitProfileSource;
+}
+
+let explicitSelection: ExplicitProfileSelection | undefined;
+
+export function setExplicitProfileSelection(selection: ExplicitProfileSelection | undefined): void {
+	explicitSelection = selection;
+}
+
+export function getExplicitProfileSelection(): ExplicitProfileSelection | undefined {
+	return explicitSelection;
+}

--- a/packages/coding-agent/src/commands/profile.ts
+++ b/packages/coding-agent/src/commands/profile.ts
@@ -1,0 +1,52 @@
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { profileHelp as commandHelp } from "../cli/command-help";
+import { type ProfileAction, runProfileCommand } from "../cli/profile-cli";
+
+const ACTIONS: ProfileAction[] = ["bind", "unbind", "show", "list", "list-bindings"];
+
+export default class Profile extends Command {
+	static description = commandHelp.description;
+
+	static args = {
+		action: Args.string({
+			description: "bind, unbind, show, or list",
+			required: false,
+			options: ACTIONS,
+			default: "show",
+		}),
+		value: Args.string({
+			description: "Profile name for bind; folder path for other actions",
+			required: false,
+		}),
+		path: Args.string({
+			description: "Folder path for bind",
+			required: false,
+		}),
+	};
+
+	static flags = {
+		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
+	};
+
+	static examples = [
+		"omp profile bind work",
+		"omp profile bind work <path>",
+		"omp profile show",
+		"omp profile unbind",
+		"omp profile list",
+	];
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Profile);
+		const action = args.action as ProfileAction;
+		if (action !== "bind" && args.path !== undefined) {
+			throw new Error(`Too many arguments for omp profile ${action}`);
+		}
+		await runProfileCommand({
+			action,
+			profile: action === "bind" ? args.value : undefined,
+			path: action === "bind" ? args.path : args.value,
+			json: flags.json ?? false,
+		});
+	}
+}

--- a/packages/coding-agent/src/commands/profile.ts
+++ b/packages/coding-agent/src/commands/profile.ts
@@ -39,7 +39,8 @@ export default class Profile extends Command {
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Profile);
 		const action = args.action as ProfileAction;
-		if (action !== "bind" && args.path !== undefined) {
+		const isList = action === "list" || action === "list-bindings";
+		if ((action !== "bind" && args.path !== undefined) || (isList && args.value !== undefined)) {
 			throw new Error(`Too many arguments for omp profile ${action}`);
 		}
 		await runProfileCommand({

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/registry.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/registry.ts
@@ -12,10 +12,9 @@
  * can fail with EPERM — fallback: unlink target then rename.
  */
 
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import { getPluginsDir, isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
+import { atomicWriteJson, getPluginsDir, isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
 
 export { getMarketplacesRegistryPath } from "@oh-my-pi/pi-utils";
 
@@ -36,37 +35,6 @@ export function getMarketplacesCacheDir(): string {
 
 export function getPluginsCacheDir(): string {
 	return path.join(getPluginsDir(), "cache", "plugins");
-}
-
-// ── Atomic write ─────────────────────────────────────────────────────
-
-async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
-	const content = `${JSON.stringify(data, null, 2)}\n`;
-	const tmpPath = `${filePath}.tmp`;
-
-	await Bun.write(tmpPath, content);
-
-	try {
-		await fs.rename(tmpPath, filePath);
-	} catch (err) {
-		// Windows EPERM fallback: unlink target, then rename
-		if ((err as NodeJS.ErrnoException).code === "EPERM") {
-			try {
-				await fs.unlink(filePath);
-			} catch {
-				// Target may not exist — that's fine
-			}
-			await fs.rename(tmpPath, filePath);
-		} else {
-			// Clean up tmp on unexpected errors
-			try {
-				await fs.unlink(tmpPath);
-			} catch {
-				// Best effort
-			}
-			throw err;
-		}
-	}
 }
 
 // ── Marketplaces registry ────────────────────────────────────────────

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -116,6 +116,7 @@ import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
 import { formatDuration } from "../slash-commands/helpers/format";
+import { getProfileReport } from "../slash-commands/helpers/profile-report";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { labelEchoesHandle } from "../task/label";
@@ -1162,22 +1163,26 @@ export class InteractiveMode implements InteractiveModeContext {
 			headerBefore.push(new Text(theme.fg("warning", `Warning: ${warning}`), 1, 0), new Spacer(1));
 		}
 		const headerAfter: Component[] = [];
-		if (!startupQuiet && this.#startupChangelog && settings.get("startup.changelogMode") !== "hidden") {
-			headerAfter.push(
-				new DynamicBorder(),
-				new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0),
-				new Spacer(1),
-			);
-			if (settings.get("startup.changelogMode") === "summary") {
-				const summary = formatStartupChangelogSummary(this.#startupChangelog).replace(
-					/\/changelog(?: full)?/g,
-					command => theme.bold(command),
+		if (!startupQuiet) {
+			const profileReport = getProfileReport(this.session.modelRegistry.authStorage, this.session.sessionId);
+			headerAfter.push(new Text(theme.fg("dim", profileReport), 1, 0), new Spacer(1));
+			if (this.#startupChangelog && settings.get("startup.changelogMode") !== "hidden") {
+				headerAfter.push(
+					new DynamicBorder(),
+					new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0),
+					new Spacer(1),
 				);
-				headerAfter.push(new Text(summary, 1, 0));
-			} else {
-				headerAfter.push(new Markdown(this.#startupChangelog.markdown?.trim() ?? "", 1, 0, getMarkdownTheme()));
+				if (settings.get("startup.changelogMode") === "summary") {
+					const summary = formatStartupChangelogSummary(this.#startupChangelog).replace(
+						/\/changelog(?: full)?/g,
+						command => theme.bold(command),
+					);
+					headerAfter.push(new Text(summary, 1, 0));
+				} else {
+					headerAfter.push(new Markdown(this.#startupChangelog.markdown?.trim() ?? "", 1, 0, getMarkdownTheme()));
+				}
+				headerAfter.push(new Spacer(1), new DynamicBorder());
 			}
-			headerAfter.push(new Spacer(1), new DynamicBorder());
 		}
 		this.composer.setHeaderExtras(headerBefore, headerAfter);
 		this.statusLine.watchBranch(() => {

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -13,6 +13,7 @@ import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
 import { handleMcpAcp } from "./helpers/mcp";
 import { commandConsumed, errorMessage, parseSubcommand, usage } from "./helpers/parse";
+import { getProfileReport } from "./helpers/profile-report";
 import { describeRedeemOutcome, type ResetUsageAccount, toResetUsageAccounts } from "./helpers/reset-usage";
 import { matchSessionPinAccounts, toSessionPinAccounts } from "./helpers/session-pin";
 import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-dashboard";
@@ -293,6 +294,20 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (_command, runtime) => {
 			await runtime.ctx.handleJobsCommand();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "profile",
+		description: "Show the active OMP profile and Anthropic account",
+		handle: async (_command, runtime) => {
+			await runtime.output(getProfileReport(runtime.session.modelRegistry.authStorage, runtime.session.sessionId));
+			return commandConsumed();
+		},
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showStatus(
+				getProfileReport(runtime.ctx.session.modelRegistry.authStorage, runtime.ctx.session.sessionId),
+			);
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/helpers/profile-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/profile-report.ts
@@ -1,9 +1,23 @@
 import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
+import { sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
 import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-storage";
+import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
+
+const PROFILE_REPORT_WIDTH = 120;
+
+function safeLabel(value: string): string {
+	return replaceTabs(sanitizeText(value).replace(/[\r\n]+/g, " ")).trim();
+}
 
 export function formatProfileReport(profile: string, identity: OAuthAccountIdentity | undefined): string {
-	const email = identity?.email;
-	return `Using profile ${profile} · Anthropic account: ${email ?? "not signed in"}`;
+	const account = identity
+		? (identity.email ?? identity.accountId ?? identity.orgName ?? identity.orgId ?? "signed in")
+		: "not signed in";
+	const accountLabel = safeLabel(account) || (identity ? "signed in" : "not signed in");
+	return truncateToWidth(
+		`Using profile ${safeLabel(profile)} · Anthropic account: ${accountLabel}`,
+		PROFILE_REPORT_WIDTH,
+	);
 }
 
 export function resolveProfileAnthropicIdentity(

--- a/packages/coding-agent/src/slash-commands/helpers/profile-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/profile-report.ts
@@ -24,10 +24,7 @@ export function resolveProfileAnthropicIdentity(
 	authStorage: AuthStorage,
 	sessionId: string,
 ): OAuthAccountIdentity | undefined {
-	const active = authStorage.getOAuthAccountIdentity("anthropic", sessionId);
-	if (active) return active;
-	const accounts = authStorage.listOAuthAccounts("anthropic", sessionId);
-	return accounts.length === 1 ? accounts[0] : undefined;
+	return authStorage.getOAuthAccountIdentity("anthropic", sessionId);
 }
 
 export function getProfileReport(authStorage: AuthStorage, sessionId: string): string {

--- a/packages/coding-agent/src/slash-commands/helpers/profile-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/profile-report.ts
@@ -1,0 +1,21 @@
+import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
+import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-storage";
+
+export function formatProfileReport(profile: string, identity: OAuthAccountIdentity | undefined): string {
+	const email = identity?.email;
+	return `Using profile ${profile} · Anthropic account: ${email ?? "not signed in"}`;
+}
+
+export function resolveProfileAnthropicIdentity(
+	authStorage: AuthStorage,
+	sessionId: string,
+): OAuthAccountIdentity | undefined {
+	const active = authStorage.getOAuthAccountIdentity("anthropic", sessionId);
+	if (active) return active;
+	const accounts = authStorage.listOAuthAccounts("anthropic", sessionId);
+	return accounts.length === 1 ? accounts[0] : undefined;
+}
+
+export function getProfileReport(authStorage: AuthStorage, sessionId: string): string {
+	return formatProfileReport(getActiveProfile() ?? "default", resolveProfileAnthropicIdentity(authStorage, sessionId));
+}

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -103,6 +103,11 @@ export interface CommitDetails {
 	readonly sha: string;
 }
 
+export interface InitOptions {
+	readonly initialBranch?: string;
+	readonly signal?: AbortSignal;
+}
+
 export interface CommitOptions {
 	readonly allowEmpty?: boolean;
 	readonly amend?: boolean;
@@ -1303,6 +1308,17 @@ export const diff = Object.assign(
 );
 
 // ════════════════════════════════════════════════════════════════════════════
+// API: repository setup
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Initialize a repository in an existing directory. */
+export async function init(cwd: string, options: InitOptions = {}): Promise<void> {
+	const args = ["init", "--quiet"];
+	if (options.initialBranch) args.push(`--initial-branch=${options.initialBranch}`);
+	await runEffect(cwd, args, { signal: options.signal });
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // API: status
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -2362,6 +2378,18 @@ export const head = {
 // ════════════════════════════════════════════════════════════════════════════
 
 export const repo = {
+	/** Resolve the repository common directory shared by linked worktrees. */
+	async commonDir(cwd: string, signal?: AbortSignal): Promise<string | null> {
+		const repository = await resolveRepository(cwd);
+		if (repository) return repository.commonDir;
+		const result = await git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+			readOnly: true,
+			signal,
+		});
+		if (result.exitCode !== 0) return null;
+		return result.stdout.trim() || null;
+	},
+
 	/** Resolve the repository root (may be a worktree root). */
 	async root(cwd: string, signal?: AbortSignal): Promise<string | null> {
 		const repository = await resolveRepository(cwd);

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1,7 +1,16 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $which, hasFsCode, isEacces, isEisdir, isEnoent, isEnotdir, Snowflake } from "@oh-my-pi/pi-utils";
+import { $which, hasFsCode, isEisdir, isEnoent, isEnotdir, Snowflake } from "@oh-my-pi/pi-utils";
+import {
+	type GitRepository,
+	isLinkedGitWorktreeSync as isLinkedWorktree,
+	parseGitDirPointer,
+	primaryGitRoot as primaryRootFromRepository,
+	primaryGitRootSync as primaryRootFromRepositorySync,
+	resolveGitRepository as resolveRepository,
+	resolveGitRepositorySync as resolveRepositorySync,
+} from "@oh-my-pi/pi-utils/git-repository";
 import type { Subprocess } from "bun";
 import {
 	parseDiffHunks as parseCommitDiffHunks,
@@ -25,14 +34,7 @@ export interface GitCommandResult {
 	truncated: boolean;
 }
 
-export interface GitRepository {
-	commonDir: string;
-	gitDir: string;
-	gitEntryPath: string;
-	headPath: string;
-	repoRoot: string;
-	isReftable?: boolean;
-}
+export type { GitRepository } from "@oh-my-pi/pi-utils/git-repository";
 
 export interface GitStatusSummary {
 	staged: number;
@@ -797,12 +799,6 @@ async function writeTempPatch(content: string): Promise<string> {
 // Internal: Repository resolution
 // ════════════════════════════════════════════════════════════════════════════
 
-type EntryType = "directory" | "file";
-
-function isPermissionError(err: unknown): boolean {
-	return isEacces(err) || hasFsCode(err, "EPERM");
-}
-
 function shouldRetry(err: unknown, n: number) {
 	if (isEnoent(err) || isEisdir(err) || isEnotdir(err) || hasFsCode(err, "ENFILE") || hasFsCode(err, "EMFILE"))
 		return false;
@@ -842,24 +838,6 @@ async function retryOnEintr<T>(op: () => Promise<T>): Promise<T | null> {
 	throw new Error("retryOnEintr: exhausted without resolution");
 }
 
-function getEntryTypeSync(gitEntryPath: string): EntryType | null {
-	return retryOnEintrSync(() => {
-		const stat = fs.statSync(gitEntryPath);
-		if (stat.isDirectory()) return "directory";
-		if (stat.isFile()) return "file";
-		return null;
-	});
-}
-
-async function getEntryType(gitEntryPath: string): Promise<EntryType | null> {
-	return retryOnEintr(async () => {
-		const stat = await fs.promises.stat(gitEntryPath);
-		if (stat.isDirectory()) return "directory";
-		if (stat.isFile()) return "file";
-		return null;
-	});
-}
-
 function readOptionalTextSync(filePath: string): string | null {
 	return retryOnEintrSync(() => fs.readFileSync(filePath, "utf8"));
 }
@@ -870,138 +848,6 @@ async function readOptionalText(filePath: string): Promise<string | null> {
 
 async function readOptionalBytes(filePath: string): Promise<Uint8Array | null> {
 	return retryOnEintr(async () => await Bun.file(filePath).bytes());
-}
-
-function parseGitDirPointer(content: string): string | null {
-	const match = /^gitdir:\s*(.+)\s*$/iu.exec(content.trim());
-	return match?.[1] ?? null;
-}
-
-function resolveGitDirSync(gitEntryPath: string, entryType: EntryType): string | null {
-	if (entryType === "directory") return gitEntryPath;
-	const content = readOptionalTextSync(gitEntryPath);
-	if (content === null) return null;
-	const parsed = parseGitDirPointer(content);
-	if (!parsed) return null;
-	const gitDir = path.resolve(path.dirname(gitEntryPath), parsed);
-	return getEntryTypeSync(gitDir) === "directory" ? gitDir : null;
-}
-
-async function resolveGitDir(gitEntryPath: string, entryType: EntryType): Promise<string | null> {
-	if (entryType === "directory") return gitEntryPath;
-	const content = await readOptionalText(gitEntryPath);
-	if (content === null) return null;
-	const parsed = parseGitDirPointer(content);
-	if (!parsed) return null;
-	const gitDir = path.resolve(path.dirname(gitEntryPath), parsed);
-	return (await getEntryType(gitDir)) === "directory" ? gitDir : null;
-}
-
-function resolveCommonDirSync(gitDir: string): string {
-	const content = readOptionalTextSync(path.join(gitDir, "commondir"));
-	const relative = content?.trim();
-	if (!relative) return gitDir;
-	return path.resolve(gitDir, relative);
-}
-
-async function resolveCommonDir(gitDir: string): Promise<string> {
-	const content = await readOptionalText(path.join(gitDir, "commondir"));
-	const relative = content?.trim();
-	if (!relative) return gitDir;
-	return path.resolve(gitDir, relative);
-}
-function isLinkedWorktree(repository: GitRepository): boolean {
-	return (
-		repository.gitDir !== repository.commonDir &&
-		getEntryTypeSync(path.join(repository.gitDir, "commondir")) === "file"
-	);
-}
-
-async function isLinkedWorktreeAsync(repository: GitRepository): Promise<boolean> {
-	return (
-		repository.gitDir !== repository.commonDir &&
-		(await getEntryType(path.join(repository.gitDir, "commondir"))) === "file"
-	);
-}
-
-function primaryRootFromRepositorySync(repository: GitRepository): string {
-	if (path.basename(repository.commonDir) === ".git") return path.dirname(repository.commonDir);
-	if (isLinkedWorktree(repository)) return repository.commonDir;
-	return repository.repoRoot;
-}
-
-async function primaryRootFromRepository(repository: GitRepository): Promise<string> {
-	if (path.basename(repository.commonDir) === ".git") return path.dirname(repository.commonDir);
-	if (await isLinkedWorktreeAsync(repository)) return repository.commonDir;
-	return repository.repoRoot;
-}
-
-function resolveRepoFromEntrySync(repoRoot: string, gitEntryPath: string, entryType: EntryType): GitRepository | null {
-	const gitDir = resolveGitDirSync(gitEntryPath, entryType);
-	if (!gitDir) return null;
-	return {
-		commonDir: resolveCommonDirSync(gitDir),
-		gitDir,
-		gitEntryPath,
-		headPath: path.join(gitDir, "HEAD"),
-		repoRoot,
-	};
-}
-
-async function resolveRepoFromEntry(
-	repoRoot: string,
-	gitEntryPath: string,
-	entryType: EntryType,
-): Promise<GitRepository | null> {
-	const gitDir = await resolveGitDir(gitEntryPath, entryType);
-	if (!gitDir) return null;
-	return {
-		commonDir: await resolveCommonDir(gitDir),
-		gitDir,
-		gitEntryPath,
-		headPath: path.join(gitDir, "HEAD"),
-		repoRoot,
-	};
-}
-
-function resolveRepositorySync(startDir: string): GitRepository | null {
-	let current = path.resolve(startDir);
-	while (true) {
-		const gitEntryPath = path.join(current, ".git");
-		const entryType = getEntryTypeSync(gitEntryPath);
-		if (entryType) {
-			try {
-				const repository = resolveRepoFromEntrySync(current, gitEntryPath, entryType);
-				if (repository) return repository;
-			} catch (err) {
-				if (entryType === "file" && isPermissionError(err)) return null;
-				throw err;
-			}
-		}
-		const parent = path.dirname(current);
-		if (parent === current) return null;
-		current = parent;
-	}
-}
-
-async function resolveRepository(startDir: string): Promise<GitRepository | null> {
-	let current = path.resolve(startDir);
-	while (true) {
-		const gitEntryPath = path.join(current, ".git");
-		const entryType = await getEntryType(gitEntryPath);
-		if (entryType) {
-			try {
-				const repository = await resolveRepoFromEntry(current, gitEntryPath, entryType);
-				if (repository) return repository;
-			} catch (err) {
-				if (entryType === "file" && isPermissionError(err)) return null;
-				throw err;
-			}
-		}
-		const parent = path.dirname(current);
-		if (parent === current) return null;
-		current = parent;
-	}
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/test/profile-bindings.test.ts
+++ b/packages/coding-agent/test/profile-bindings.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as url from "node:url";
+import { normalizePathForComparison, removeWithRetries } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+import {
+	bindProfileToFolder,
+	listProfileBindings,
+	resolveProfileBinding,
+	unbindProfileFromFolder,
+} from "../src/cli/profile-bindings";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-profile-bindings-"));
+	tempRoots.push(root);
+	return root;
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+	return new Response(stream).text();
+}
+
+async function runCliCommand(
+	args: string[],
+	home: string,
+	cwd: string,
+	envOverrides: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string }> {
+	const env: Record<string, string | undefined> = { ...process.env, HOME: home, NO_COLOR: "1", ...envOverrides };
+	if (!("OMP_PROFILE" in envOverrides)) delete env.OMP_PROFILE;
+	if (!("PI_PROFILE" in envOverrides)) delete env.PI_PROFILE;
+	delete env.PI_CODING_AGENT_DIR;
+	const processHandle = Bun.spawn([process.execPath, cliEntry, ...args], {
+		cwd,
+		env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		readStream(processHandle.stdout as ReadableStream<Uint8Array>),
+		readStream(processHandle.stderr as ReadableStream<Uint8Array>),
+		processHandle.exited,
+	]);
+	if (exitCode !== 0) throw new Error(`omp ${args.join(" ")} failed (${exitCode}): ${stderr}`);
+	return { stdout, stderr };
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(root => removeWithRetries(root)));
+});
+
+describe("folder profile bindings", () => {
+	it("selects the bound profile from a nested directory and removes it through the same public commands", async () => {
+		const root = await makeTempRoot();
+		const folder = path.join(root, "workspace");
+		const nested = path.join(folder, "packages", "api");
+		const bindingsPath = path.join(root, "config", "profile-bindings.json");
+		await fs.mkdir(nested, { recursive: true });
+
+		const binding = await bindProfileToFolder("default", folder, bindingsPath);
+		const resolved = await resolveProfileBinding(nested, bindingsPath);
+
+		expect(binding).toEqual({ kind: "directory", path: normalizePathForComparison(folder), profile: "default" });
+		expect(resolved?.binding).toEqual(binding);
+		expect(resolved?.profile).toBeUndefined();
+		expect(await listProfileBindings(bindingsPath)).toEqual([binding]);
+		expect(await unbindProfileFromFolder(nested, bindingsPath)).toEqual(binding);
+		expect(await resolveProfileBinding(nested, bindingsPath)).toBeNull();
+	});
+
+	it("uses one binding for a repository and its linked worktrees", async () => {
+		const root = await makeTempRoot();
+		const repository = path.join(root, "repository");
+		const worktree = path.join(root, "linked-worktree");
+		const bindingsPath = path.join(root, "config", "profile-bindings.json");
+		const boundFolder = path.join(repository, "packages", "work");
+		const siblingFolder = path.join(repository, "packages", "personal");
+		await fs.mkdir(boundFolder, { recursive: true });
+		await fs.mkdir(siblingFolder, { recursive: true });
+		await Bun.write(path.join(boundFolder, "README.md"), "work\n");
+		await Bun.write(path.join(siblingFolder, "README.md"), "personal\n");
+		await $`git init -q ${repository}`.quiet();
+		await $`git -C ${repository} config user.email test@example.com`.quiet();
+		await $`git -C ${repository} config user.name Test`.quiet();
+		await $`git -C ${repository} add .`.quiet();
+		await $`git -C ${repository} commit -qm initial`.quiet();
+		await $`git -C ${repository} worktree add -q ${worktree}`.quiet();
+
+		const binding = await bindProfileToFolder("default", boundFolder, bindingsPath);
+		const resolved = await resolveProfileBinding(path.join(worktree, "packages", "work"), bindingsPath);
+
+		expect(binding.kind).toBe("git-common-dir");
+		expect(binding.subpath).toBe(path.join("packages", "work"));
+		expect(resolved?.binding).toEqual(binding);
+		expect(await resolveProfileBinding(siblingFolder, bindingsPath)).toBeNull();
+	});
+
+	it("fails clearly when the bindings file is malformed", async () => {
+		const root = await makeTempRoot();
+		const bindingsPath = path.join(root, "profile-bindings.json");
+		await Bun.write(bindingsPath, "not-json");
+
+		await expect(resolveProfileBinding(root, bindingsPath)).rejects.toThrow("Invalid JSON in profile bindings file");
+	});
+
+	it.each(["../outside", "..\\outside", "nested/../../outside"])(
+		"rejects a Git binding subpath that escapes its checkout: %s",
+		async subpath => {
+			const root = await makeTempRoot();
+			const bindingsPath = path.join(root, "profile-bindings.json");
+			await Bun.write(
+				bindingsPath,
+				JSON.stringify({
+					version: 1,
+					bindings: [{ kind: "git-common-dir", path: root, profile: "default", subpath }],
+				}),
+			);
+
+			await expect(resolveProfileBinding(root, bindingsPath)).rejects.toThrow("Invalid profile bindings file");
+		},
+	);
+});
+
+describe("profile binding commands", () => {
+	it("binds, shows, lists, and removes a folder through the CLI", async () => {
+		const root = await makeTempRoot();
+		const home = path.join(root, "home");
+		const repository = path.join(root, "repository");
+		await fs.mkdir(path.join(home, ".omp", "profiles", "work", "agent"), { recursive: true });
+		await fs.mkdir(path.join(home, ".omp", "profiles", "personal", "agent"), { recursive: true });
+		await fs.mkdir(repository, { recursive: true });
+		await $`git init -q ${repository}`.quiet();
+
+		await runCliCommand(["profile", "bind", "work", repository], home, root);
+		const shown = await runCliCommand(["profile", "show", repository, "--json"], home, root);
+		const listed = await runCliCommand(["profile", "list", "--json"], home, root);
+		const cliOverride = await runCliCommand(
+			["--profile", "personal", "profile", "show", repository, "--json"],
+			home,
+			root,
+		);
+		const envOverride = await runCliCommand(["profile", "show", repository, "--json"], home, root, {
+			OMP_PROFILE: "personal",
+			PI_PROFILE: "work",
+		});
+		const legacyEnvOverride = await runCliCommand(["profile", "show", repository, "--json"], home, root, {
+			PI_PROFILE: "personal",
+		});
+		expect(JSON.parse(shown.stdout)).toMatchObject({ profile: "work", selectedBy: "folder-binding" });
+		expect(JSON.parse(listed.stdout)).toEqual([expect.objectContaining({ profile: "work" })]);
+		expect(JSON.parse(cliOverride.stdout)).toEqual({ profile: "personal", selectedBy: "cli" });
+		expect(JSON.parse(envOverride.stdout)).toEqual({ profile: "personal", selectedBy: "environment" });
+		expect(JSON.parse(legacyEnvOverride.stdout)).toEqual({ profile: "personal", selectedBy: "environment" });
+
+		await runCliCommand(["--cwd", repository, "profile", "unbind"], home, root);
+		const after = await runCliCommand(["profile", "show", repository, "--json"], home, root);
+		expect(JSON.parse(after.stdout)).toEqual({ profile: "default", selectedBy: "default" });
+	}, 30_000);
+
+	it("does not use a folder binding to satisfy --alias", async () => {
+		const root = await makeTempRoot();
+		const home = path.join(root, "home");
+		const bindingsPath = path.join(home, ".omp", "profile-bindings.json");
+		await fs.mkdir(path.dirname(bindingsPath), { recursive: true });
+		await Bun.write(
+			bindingsPath,
+			JSON.stringify({
+				version: 1,
+				bindings: [{ kind: "directory", path: root, profile: "missing" }],
+			}),
+		);
+
+		await expect(runCliCommand(["--alias", "foo"], home, root)).rejects.toThrow(
+			"--alias requires --profile <name> or OMP_PROFILE",
+		);
+	});
+});
+
+describe("profile binding bootstrap", () => {
+	it("loads the profile bound to --cwd before profile-scoped environment imports", async () => {
+		const root = await makeTempRoot();
+		const home = path.join(root, "home");
+		const repository = path.join(root, "repository");
+		const profileRoot = path.join(home, ".omp", "profiles", "work");
+		await fs.mkdir(repository, { recursive: true });
+		await fs.mkdir(path.join(home, ".omp", "agent"), { recursive: true });
+		await fs.mkdir(path.join(profileRoot, "agent"), { recursive: true });
+		await $`git init -q ${repository}`.quiet();
+		const commonDir = (await $`git -C ${repository} rev-parse --path-format=absolute --git-common-dir`.text()).trim();
+		await Bun.write(
+			path.join(home, ".omp", "profile-bindings.json"),
+			JSON.stringify({
+				version: 1,
+				bindings: [{ kind: "git-common-dir", path: commonDir, profile: "work" }],
+			}),
+		);
+		await Bun.write(path.join(home, ".omp", "agent", ".env"), "OMP_FOLDER_PROFILE_SENTINEL=default\n");
+		await Bun.write(path.join(profileRoot, "agent", ".env"), "OMP_FOLDER_PROFILE_SENTINEL=work\n");
+
+		const probePath = path.join(root, "probe.ts");
+		await Bun.write(
+			probePath,
+			[
+				`import { runCli } from ${JSON.stringify(url.pathToFileURL(cliEntry).href)};`,
+				`await runCli(["--cwd", ${JSON.stringify(repository)}, "--help"]);`,
+				`process.stdout.write("SENTINEL=" + (Bun.env.OMP_FOLDER_PROFILE_SENTINEL ?? ""));`,
+			].join("\n"),
+		);
+		const childEnv: Record<string, string | undefined> = { ...process.env, HOME: home, NO_COLOR: "1" };
+		delete childEnv.OMP_PROFILE;
+		delete childEnv.PI_PROFILE;
+		delete childEnv.PI_CODING_AGENT_DIR;
+		delete childEnv.OMP_FOLDER_PROFILE_SENTINEL;
+		const proc = Bun.spawn([process.execPath, probePath], {
+			cwd: repoRoot,
+			env: childEnv,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(stdout).toContain("SENTINEL=work");
+		expect(stdout).not.toContain("SENTINEL=default");
+
+		const explicitDefault = Bun.spawn([process.execPath, probePath], {
+			cwd: repoRoot,
+			env: { ...childEnv, OMP_PROFILE: "" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [defaultStdout, defaultStderr, defaultExitCode] = await Promise.all([
+			readStream(explicitDefault.stdout as ReadableStream<Uint8Array>),
+			readStream(explicitDefault.stderr as ReadableStream<Uint8Array>),
+			explicitDefault.exited,
+		]);
+		expect(defaultExitCode, defaultStderr).toBe(0);
+		expect(defaultStdout).toContain("SENTINEL=default");
+		expect(defaultStdout).not.toContain("SENTINEL=work");
+	}, 30_000);
+});

--- a/packages/coding-agent/test/profile-bindings.test.ts
+++ b/packages/coding-agent/test/profile-bindings.test.ts
@@ -1,26 +1,18 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
-import { normalizePathForComparison, removeWithRetries } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
+import { normalizePathForComparison, TempDir } from "@oh-my-pi/pi-utils";
 import {
 	bindProfileToFolder,
 	listProfileBindings,
 	resolveProfileBinding,
 	unbindProfileFromFolder,
 } from "../src/cli/profile-bindings";
+import * as git from "../src/utils/git";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
-const tempRoots: string[] = [];
-
-async function makeTempRoot(): Promise<string> {
-	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-profile-bindings-"));
-	tempRoots.push(root);
-	return root;
-}
 
 async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
 	return new Response(stream).text();
@@ -51,13 +43,10 @@ async function runCliCommand(
 	return { stdout, stderr };
 }
 
-afterEach(async () => {
-	await Promise.all(tempRoots.splice(0).map(root => removeWithRetries(root)));
-});
-
 describe("folder profile bindings", () => {
 	it("selects the bound profile from a nested directory and removes it through the same public commands", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const folder = path.join(root, "workspace");
 		const nested = path.join(folder, "packages", "api");
 		const bindingsPath = path.join(root, "config", "profile-bindings.json");
@@ -75,7 +64,8 @@ describe("folder profile bindings", () => {
 	});
 
 	it("uses one binding for a repository and its linked worktrees", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const repository = path.join(root, "repository");
 		const worktree = path.join(root, "linked-worktree");
 		const bindingsPath = path.join(root, "config", "profile-bindings.json");
@@ -85,12 +75,12 @@ describe("folder profile bindings", () => {
 		await fs.mkdir(siblingFolder, { recursive: true });
 		await Bun.write(path.join(boundFolder, "README.md"), "work\n");
 		await Bun.write(path.join(siblingFolder, "README.md"), "personal\n");
-		await $`git init -q ${repository}`.quiet();
-		await $`git -C ${repository} config user.email test@example.com`.quiet();
-		await $`git -C ${repository} config user.name Test`.quiet();
-		await $`git -C ${repository} add .`.quiet();
-		await $`git -C ${repository} commit -qm initial`.quiet();
-		await $`git -C ${repository} worktree add -q ${worktree}`.quiet();
+		await git.init(repository, { initialBranch: "main" });
+		await git.config.set(repository, "user.email", "test@example.com");
+		await git.config.set(repository, "user.name", "Test");
+		await git.stage.files(repository);
+		await git.commit(repository, "initial");
+		await git.worktree.add(repository, worktree, "HEAD", { detach: true });
 
 		const binding = await bindProfileToFolder("default", boundFolder, bindingsPath);
 		const resolved = await resolveProfileBinding(path.join(worktree, "packages", "work"), bindingsPath);
@@ -102,21 +92,23 @@ describe("folder profile bindings", () => {
 	});
 
 	it("inherits an outer repository binding inside a nested repository", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const outer = path.join(root, "outer");
 		const inner = path.join(outer, "packages", "inner");
 		const bindingsPath = path.join(root, "config", "profile-bindings.json");
 		await fs.mkdir(inner, { recursive: true });
-		await $`git init -q ${outer}`.quiet();
+		await git.init(outer, { initialBranch: "main" });
 		const binding = await bindProfileToFolder("default", outer, bindingsPath);
-		await $`git init -q ${inner}`.quiet();
+		await git.init(inner, { initialBranch: "main" });
 
 		expect((await resolveProfileBinding(inner, bindingsPath))?.binding).toEqual(binding);
 	});
 
 	it("binds a symlinked external folder without widening to the containing repository", async () => {
 		if (process.platform === "win32") return;
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const repository = path.join(root, "repository");
 		const external = path.join(root, "external");
 		const link = path.join(repository, "external-link");
@@ -124,7 +116,7 @@ describe("folder profile bindings", () => {
 		const bindingsPath = path.join(root, "config", "profile-bindings.json");
 		await fs.mkdir(external, { recursive: true });
 		await fs.mkdir(sibling, { recursive: true });
-		await $`git init -q ${repository}`.quiet();
+		await git.init(repository, { initialBranch: "main" });
 		await fs.symlink(external, link, "dir");
 
 		const binding = await bindProfileToFolder("default", link, bindingsPath);
@@ -133,7 +125,8 @@ describe("folder profile bindings", () => {
 	});
 
 	it("fails clearly when the bindings file is malformed", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const bindingsPath = path.join(root, "profile-bindings.json");
 		await Bun.write(bindingsPath, "not-json");
 
@@ -143,7 +136,8 @@ describe("folder profile bindings", () => {
 	it.each(["../outside", "..\\outside", "nested/../../outside"])(
 		"rejects a Git binding subpath that escapes its checkout: %s",
 		async subpath => {
-			const root = await makeTempRoot();
+			using tempDir = TempDir.createSync("@omp-profile-bindings-");
+			const root = tempDir.path();
 			const bindingsPath = path.join(root, "profile-bindings.json");
 			await Bun.write(
 				bindingsPath,
@@ -160,13 +154,14 @@ describe("folder profile bindings", () => {
 
 describe("profile binding commands", () => {
 	it("binds, shows, lists, and removes a folder through the CLI", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const home = path.join(root, "home");
 		const repository = path.join(root, "repository");
 		await fs.mkdir(path.join(home, ".omp", "profiles", "work", "agent"), { recursive: true });
 		await fs.mkdir(path.join(home, ".omp", "profiles", "personal", "agent"), { recursive: true });
 		await fs.mkdir(repository, { recursive: true });
-		await $`git init -q ${repository}`.quiet();
+		await git.init(repository, { initialBranch: "main" });
 
 		await runCliCommand(["profile", "bind", "work", repository], home, root);
 		const shown = await runCliCommand(["profile", "show", repository, "--json"], home, root);
@@ -195,14 +190,16 @@ describe("profile binding commands", () => {
 	}, 30_000);
 
 	it("rejects positional arguments for profile list", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		await expect(runCliCommand(["profile", "list", "unexpected"], path.join(root, "home"), root)).rejects.toThrow(
 			"Too many arguments for omp profile list",
 		);
 	});
 
 	it("does not use a folder binding to satisfy --alias", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const home = path.join(root, "home");
 		const bindingsPath = path.join(home, ".omp", "profile-bindings.json");
 		await fs.mkdir(path.dirname(bindingsPath), { recursive: true });
@@ -222,20 +219,23 @@ describe("profile binding commands", () => {
 
 describe("profile binding bootstrap", () => {
 	it("loads the profile bound to --cwd before profile-scoped environment imports", async () => {
-		const root = await makeTempRoot();
+		using tempDir = TempDir.createSync("@omp-profile-bindings-");
+		const root = tempDir.path();
 		const home = path.join(root, "home");
 		const repository = path.join(root, "repository");
 		const profileRoot = path.join(home, ".omp", "profiles", "work");
 		await fs.mkdir(repository, { recursive: true });
 		await fs.mkdir(path.join(home, ".omp", "agent"), { recursive: true });
 		await fs.mkdir(path.join(profileRoot, "agent"), { recursive: true });
-		await $`git init -q ${repository}`.quiet();
-		const commonDir = (await $`git -C ${repository} rev-parse --path-format=absolute --git-common-dir`.text()).trim();
+		await git.init(repository, { initialBranch: "main" });
+		const commonDir = await git.repo.commonDir(repository);
+		if (!commonDir) throw new Error("Git common directory not found");
+		const bindingPath = normalizePathForComparison(commonDir);
 		await Bun.write(
 			path.join(home, ".omp", "profile-bindings.json"),
 			JSON.stringify({
 				version: 1,
-				bindings: [{ kind: "git-common-dir", path: commonDir, profile: "work" }],
+				bindings: [{ kind: "git-common-dir", path: bindingPath, profile: "work" }],
 			}),
 		);
 		await Bun.write(path.join(home, ".omp", "agent", ".env"), "OMP_FOLDER_PROFILE_SENTINEL=default\n");
@@ -293,20 +293,21 @@ describe("profile binding bootstrap", () => {
 	])(
 		"preserves explicit default selection when a CLI process re-enters: $name",
 		async ({ parentArgs, env }) => {
-			const root = await makeTempRoot();
+			using tempDir = TempDir.createSync("@omp-profile-bindings-");
+			const root = tempDir.path();
 			const home = path.join(root, "home");
 			const repository = path.join(root, "repository");
 			const profileRoot = path.join(home, ".omp", "profiles", "work");
 			await fs.mkdir(repository, { recursive: true });
 			await fs.mkdir(path.join(home, ".omp", "agent"), { recursive: true });
 			await fs.mkdir(path.join(profileRoot, "agent"), { recursive: true });
-			await $`git init -q ${repository}`.quiet();
-			const commonDir = (
-				await $`git -C ${repository} rev-parse --path-format=absolute --git-common-dir`.text()
-			).trim();
+			await git.init(repository, { initialBranch: "main" });
+			const commonDir = await git.repo.commonDir(repository);
+			if (!commonDir) throw new Error("Git common directory not found");
+			const bindingPath = normalizePathForComparison(commonDir);
 			await Bun.write(
 				path.join(home, ".omp", "profile-bindings.json"),
-				JSON.stringify({ version: 1, bindings: [{ kind: "git-common-dir", path: commonDir, profile: "work" }] }),
+				JSON.stringify({ version: 1, bindings: [{ kind: "git-common-dir", path: bindingPath, profile: "work" }] }),
 			);
 			await Bun.write(path.join(home, ".omp", "agent", ".env"), "OMP_REENTRY_SENTINEL=default\n");
 			await Bun.write(path.join(profileRoot, "agent", ".env"), "OMP_REENTRY_SENTINEL=work\n");

--- a/packages/coding-agent/test/profile-bindings.test.ts
+++ b/packages/coding-agent/test/profile-bindings.test.ts
@@ -101,6 +101,37 @@ describe("folder profile bindings", () => {
 		expect(await resolveProfileBinding(siblingFolder, bindingsPath)).toBeNull();
 	});
 
+	it("inherits an outer repository binding inside a nested repository", async () => {
+		const root = await makeTempRoot();
+		const outer = path.join(root, "outer");
+		const inner = path.join(outer, "packages", "inner");
+		const bindingsPath = path.join(root, "config", "profile-bindings.json");
+		await fs.mkdir(inner, { recursive: true });
+		await $`git init -q ${outer}`.quiet();
+		const binding = await bindProfileToFolder("default", outer, bindingsPath);
+		await $`git init -q ${inner}`.quiet();
+
+		expect((await resolveProfileBinding(inner, bindingsPath))?.binding).toEqual(binding);
+	});
+
+	it("binds a symlinked external folder without widening to the containing repository", async () => {
+		if (process.platform === "win32") return;
+		const root = await makeTempRoot();
+		const repository = path.join(root, "repository");
+		const external = path.join(root, "external");
+		const link = path.join(repository, "external-link");
+		const sibling = path.join(repository, "sibling");
+		const bindingsPath = path.join(root, "config", "profile-bindings.json");
+		await fs.mkdir(external, { recursive: true });
+		await fs.mkdir(sibling, { recursive: true });
+		await $`git init -q ${repository}`.quiet();
+		await fs.symlink(external, link, "dir");
+
+		const binding = await bindProfileToFolder("default", link, bindingsPath);
+		expect(binding).toEqual({ kind: "directory", path: normalizePathForComparison(external), profile: "default" });
+		expect(await resolveProfileBinding(sibling, bindingsPath)).toBeNull();
+	});
+
 	it("fails clearly when the bindings file is malformed", async () => {
 		const root = await makeTempRoot();
 		const bindingsPath = path.join(root, "profile-bindings.json");
@@ -162,6 +193,13 @@ describe("profile binding commands", () => {
 		const after = await runCliCommand(["profile", "show", repository, "--json"], home, root);
 		expect(JSON.parse(after.stdout)).toEqual({ profile: "default", selectedBy: "default" });
 	}, 30_000);
+
+	it("rejects positional arguments for profile list", async () => {
+		const root = await makeTempRoot();
+		await expect(runCliCommand(["profile", "list", "unexpected"], path.join(root, "home"), root)).rejects.toThrow(
+			"Too many arguments for omp profile list",
+		);
+	});
 
 	it("does not use a folder binding to satisfy --alias", async () => {
 		const root = await makeTempRoot();
@@ -248,4 +286,77 @@ describe("profile binding bootstrap", () => {
 		expect(defaultStdout).toContain("SENTINEL=default");
 		expect(defaultStdout).not.toContain("SENTINEL=work");
 	}, 30_000);
+
+	it.each([
+		{ name: "--profile default", parentArgs: ["--profile", "default", "--version"], env: {} },
+		{ name: 'OMP_PROFILE=""', parentArgs: ["--version"], env: { OMP_PROFILE: "" } },
+	])(
+		"preserves explicit default selection when a CLI process re-enters: $name",
+		async ({ parentArgs, env }) => {
+			const root = await makeTempRoot();
+			const home = path.join(root, "home");
+			const repository = path.join(root, "repository");
+			const profileRoot = path.join(home, ".omp", "profiles", "work");
+			await fs.mkdir(repository, { recursive: true });
+			await fs.mkdir(path.join(home, ".omp", "agent"), { recursive: true });
+			await fs.mkdir(path.join(profileRoot, "agent"), { recursive: true });
+			await $`git init -q ${repository}`.quiet();
+			const commonDir = (
+				await $`git -C ${repository} rev-parse --path-format=absolute --git-common-dir`.text()
+			).trim();
+			await Bun.write(
+				path.join(home, ".omp", "profile-bindings.json"),
+				JSON.stringify({ version: 1, bindings: [{ kind: "git-common-dir", path: commonDir, profile: "work" }] }),
+			);
+			await Bun.write(path.join(home, ".omp", "agent", ".env"), "OMP_REENTRY_SENTINEL=default\n");
+			await Bun.write(path.join(profileRoot, "agent", ".env"), "OMP_REENTRY_SENTINEL=work\n");
+
+			const probePath = path.join(root, "reentry-probe.ts");
+			await Bun.write(
+				probePath,
+				[
+					`import { runCli } from ${JSON.stringify(url.pathToFileURL(cliEntry).href)};`,
+					`const repository = ${JSON.stringify(repository)};`,
+					`if (Bun.env.OMP_REENTRY_CHILD === "1") {`,
+					`  delete Bun.env.OMP_REENTRY_SENTINEL;`,
+					`  await runCli(["--cwd", repository, "--help"]);`,
+					`  process.stdout.write("SENTINEL=" + (Bun.env.OMP_REENTRY_SENTINEL ?? ""));`,
+					`} else {`,
+					`  await runCli(JSON.parse(Bun.env.OMP_REENTRY_PARENT_ARGS ?? "[]"));`,
+					`  const child = Bun.spawn([process.execPath, import.meta.path], {`,
+					`    cwd: repository, env: { ...process.env, OMP_REENTRY_CHILD: "1" }, stdout: "pipe", stderr: "pipe"`,
+					`  });`,
+					`  const [stdout, stderr, exitCode] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);`,
+					`  process.stdout.write(stdout); process.stderr.write(stderr); if (exitCode !== 0) process.exitCode = exitCode;`,
+					`}`,
+				].join("\n"),
+			);
+			const childEnv: Record<string, string | undefined> = {
+				...process.env,
+				HOME: home,
+				NO_COLOR: "1",
+				OMP_REENTRY_PARENT_ARGS: JSON.stringify(parentArgs),
+				...env,
+			};
+			if (!("OMP_PROFILE" in env)) delete childEnv.OMP_PROFILE;
+			delete childEnv.PI_PROFILE;
+			delete childEnv.PI_CODING_AGENT_DIR;
+			delete childEnv.OMP_REENTRY_SENTINEL;
+			const proc = Bun.spawn([process.execPath, probePath], {
+				cwd: repository,
+				env: childEnv,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				readStream(proc.stdout as ReadableStream<Uint8Array>),
+				readStream(proc.stderr as ReadableStream<Uint8Array>),
+				proc.exited,
+			]);
+			expect(exitCode, stderr).toBe(0);
+			expect(stdout).toContain("SENTINEL=default");
+			expect(stdout).not.toContain("SENTINEL=work");
+		},
+		30_000,
+	);
 });

--- a/packages/coding-agent/test/profile-bootstrap.test.ts
+++ b/packages/coding-agent/test/profile-bootstrap.test.ts
@@ -149,7 +149,15 @@ describe("extractProfileFlags", () => {
 		// bootstrap must not treat `--profile <path>` as a profile selection.
 		const result = extractProfileFlags(["grep", "--profile", "packages/coding-agent/src/cli.ts"]);
 		expect(result.profile).toBeUndefined();
+		expect(result.command).toBe("grep");
 		expect(result.argv).toEqual(["grep", "--profile", "packages/coding-agent/src/cli.ts"]);
+	});
+
+	it("identifies profile management behind a leading cwd flag", () => {
+		const result = extractProfileFlags(["--cwd", "/bound", "profile", "unbind"]);
+		expect(result.cwd).toBe("/bound");
+		expect(result.command).toBe("profile");
+		expect(result.argv).toEqual(["--cwd", "/bound", "profile", "unbind"]);
 	});
 
 	it("extracts a global --profile that precedes a subcommand", () => {

--- a/packages/coding-agent/test/profile-report.test.ts
+++ b/packages/coding-agent/test/profile-report.test.ts
@@ -19,6 +19,19 @@ describe("profile report", () => {
 		).toBe("Using profile claude-1 · Anthropic account: person@example.com");
 	});
 
+	it("shows a signed-in fallback when Anthropic provides no email", () => {
+		expect(formatProfileReport("claude-1", { accountId: "account-123" })).toBe(
+			"Using profile claude-1 · Anthropic account: account-123",
+		);
+	});
+
+	it("sanitizes and bounds account identity text", () => {
+		const report = formatProfileReport("claude-1", { email: `person@example.com\nINJECTED\t${"x".repeat(200)}` });
+		expect(report).not.toContain("\n");
+		expect(report).not.toContain("\t");
+		expect(report.length).toBeLessThanOrEqual(120);
+	});
+
 	it("finds the sole Anthropic account before the session routes to it", () => {
 		const authStorage = {
 			getOAuthAccountIdentity: () => undefined,

--- a/packages/coding-agent/test/profile-report.test.ts
+++ b/packages/coding-agent/test/profile-report.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { BUILTIN_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import {
+	formatProfileReport,
+	resolveProfileAnthropicIdentity,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/profile-report";
+
+describe("profile report", () => {
+	it("registers /profile", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find(command => command.name === "profile")?.description).toContain("Anthropic");
+	});
+
+	it("shows the profile and Anthropic account email", () => {
+		expect(
+			formatProfileReport("claude-1", {
+				email: "person@example.com",
+			}),
+		).toBe("Using profile claude-1 · Anthropic account: person@example.com");
+	});
+
+	it("finds the sole Anthropic account before the session routes to it", () => {
+		const authStorage = {
+			getOAuthAccountIdentity: () => undefined,
+			listOAuthAccounts: () => [{ position: 0, credentialId: 1, email: "person@example.com" }],
+		} as unknown as AuthStorage;
+		expect(resolveProfileAnthropicIdentity(authStorage, "session-1")?.email).toBe("person@example.com");
+	});
+
+	it("states when the profile has no Anthropic login", () => {
+		expect(formatProfileReport("claude-2", undefined)).toBe(
+			"Using profile claude-2 · Anthropic account: not signed in",
+		);
+	});
+});

--- a/packages/coding-agent/test/profile-report.test.ts
+++ b/packages/coding-agent/test/profile-report.test.ts
@@ -32,12 +32,19 @@ describe("profile report", () => {
 		expect(report.length).toBeLessThanOrEqual(120);
 	});
 
-	it("finds the sole Anthropic account before the session routes to it", () => {
+	it("shows the active Anthropic OAuth identity", () => {
 		const authStorage = {
-			getOAuthAccountIdentity: () => undefined,
-			listOAuthAccounts: () => [{ position: 0, credentialId: 1, email: "person@example.com" }],
+			getOAuthAccountIdentity: () => ({ email: "person@example.com" }),
 		} as unknown as AuthStorage;
 		expect(resolveProfileAnthropicIdentity(authStorage, "session-1")?.email).toBe("person@example.com");
+	});
+
+	it("does not infer an active account from stored OAuth credentials", () => {
+		const authStorage = {
+			getOAuthAccountIdentity: () => undefined,
+			listOAuthAccounts: () => [{ position: 0, credentialId: 1, email: "stored@example.com" }],
+		} as unknown as AuthStorage;
+		expect(resolveProfileAnthropicIdentity(authStorage, "session-1")).toBeUndefined();
 	});
 
 	it("states when the profile has no Anthropic login", () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -28,6 +28,9 @@
 ### Fixed
 
 - Made malformed advanced-serialization frames from a worker subprocess non-fatal: Bun surfaces an undecodable IPC frame as a process-level `uncaughtException` in the parent (oven-sh/bun#37287), which the postmortem handler treated as fatal and tore down every active session and subagent. The handler now recognizes the decode failure and, keeping the session alive, faults the active advanced-IPC worker subsystems so their clients reject in-flight requests and recycle the subprocess instead of awaiting forever — mirroring the existing ipc-send EPIPE containment. ([#9158](https://github.com/can1357/oh-my-pi/issues/9158))
+### Added
+
+- Added bootstrap-safe Git repository discovery and atomic JSON writes for profile bindings and other config registries.
 
 ## [17.4.1] - 2026-08-21
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Managed Chrome-for-Testing installs no longer fail extracting the ~269 MB `chrome` binary against the default 64 MiB archive-member cap; the trusted browser download now extracts with a ceiling sized for it. ([#9534](https://github.com/can1357/oh-my-pi/issues/9534))
+- Added bootstrap-safe Git repository discovery and atomic JSON writes for profile bindings and other config registries.
 
 ## [18.0.4] - 2026-08-24
 
@@ -28,10 +29,6 @@
 ### Fixed
 
 - Made malformed advanced-serialization frames from a worker subprocess non-fatal: Bun surfaces an undecodable IPC frame as a process-level `uncaughtException` in the parent (oven-sh/bun#37287), which the postmortem handler treated as fatal and tore down every active session and subagent. The handler now recognizes the decode failure and, keeping the session alive, faults the active advanced-IPC worker subsystems so their clients reject in-flight requests and recycle the subprocess instead of awaiting forever — mirroring the existing ipc-send EPIPE containment. ([#9158](https://github.com/can1357/oh-my-pi/issues/9158))
-### Added
-
-- Added bootstrap-safe Git repository discovery and atomic JSON writes for profile bindings and other config registries.
-
 ## [17.4.1] - 2026-08-21
 
 ### Added

--- a/packages/utils/src/atomic-write.ts
+++ b/packages/utils/src/atomic-write.ts
@@ -1,0 +1,19 @@
+import * as fs from "node:fs/promises";
+import { Snowflake } from "./snowflake";
+
+/** Write formatted JSON through a unique temporary file and atomically replace the target. */
+export async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
+	const tempPath = `${filePath}.tmp.${process.pid}.${Snowflake.next()}`;
+	try {
+		await Bun.write(tempPath, `${JSON.stringify(data, null, 2)}\n`);
+		try {
+			await fs.rename(tempPath, filePath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EPERM") throw error;
+			await fs.rm(filePath, { force: true });
+			await fs.rename(tempPath, filePath);
+		}
+	} finally {
+		await fs.rm(tempPath, { force: true });
+	}
+}

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -106,12 +106,13 @@ function readProfileFromEnvSafe(): string | undefined {
 	}
 }
 
-function getBaseConfigRoot(): string {
+/** Get the profile-independent config root directory (~/.omp). */
+export function getBaseConfigRootDir(): string {
 	return path.join(os.homedir(), getConfigDirName());
 }
 
 function getProfileConfigRoot(profile: string | undefined): string {
-	const root = getBaseConfigRoot();
+	const root = getBaseConfigRootDir();
 	return profile ? path.join(root, "profiles", profile) : root;
 }
 
@@ -877,7 +878,7 @@ export function getDaemonRuntimeDir(projectDir: string): string {
 
 /** Root directory containing every machine-global daemon service scope. */
 export function getGlobalDaemonRuntimeRoot(): string {
-	return path.join(getBaseConfigRoot(), "run", "daemons", "global");
+	return path.join(getBaseConfigRootDir(), "run", "daemons", "global");
 }
 
 /** Get a profile-independent runtime directory for a machine-global daemon service. */
@@ -964,7 +965,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  */
 export function getInstallId(): string {
 	if (cachedInstallId) return cachedInstallId;
-	const filePath = path.join(getBaseConfigRoot(), INSTALL_ID_FILE);
+	const filePath = path.join(getBaseConfigRootDir(), INSTALL_ID_FILE);
 
 	let observedInvalid = false;
 	try {

--- a/packages/utils/src/git-repository.ts
+++ b/packages/utils/src/git-repository.ts
@@ -1,0 +1,208 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { hasFsCode, isEacces, isEisdir, isEnoent, isEnotdir } from "./fs-error";
+
+export interface GitRepository {
+	commonDir: string;
+	gitDir: string;
+	gitEntryPath: string;
+	headPath: string;
+	repoRoot: string;
+	isReftable?: boolean;
+}
+
+type EntryType = "directory" | "file";
+const EINTR_MAX_RETRIES = 3;
+
+function isPermissionError(error: unknown): boolean {
+	return isEacces(error) || hasFsCode(error, "EPERM");
+}
+
+function shouldRetry(error: unknown, attempt: number): boolean {
+	if (
+		isEnoent(error) ||
+		isEisdir(error) ||
+		isEnotdir(error) ||
+		hasFsCode(error, "ENFILE") ||
+		hasFsCode(error, "EMFILE")
+	) {
+		return false;
+	}
+	if (hasFsCode(error, "EINTR")) return attempt < EINTR_MAX_RETRIES;
+	throw error;
+}
+
+function retryOnEintrSync<T>(operation: () => T): T | null {
+	for (let attempt = 0; attempt <= EINTR_MAX_RETRIES; attempt += 1) {
+		try {
+			return operation();
+		} catch (error) {
+			if (shouldRetry(error, attempt)) continue;
+			return null;
+		}
+	}
+	throw new Error("retryOnEintrSync: exhausted without resolution");
+}
+
+async function retryOnEintr<T>(operation: () => Promise<T>): Promise<T | null> {
+	for (let attempt = 0; attempt <= EINTR_MAX_RETRIES; attempt += 1) {
+		try {
+			return await operation();
+		} catch (error) {
+			if (shouldRetry(error, attempt)) continue;
+			return null;
+		}
+	}
+	throw new Error("retryOnEintr: exhausted without resolution");
+}
+
+function getEntryTypeSync(gitEntryPath: string): EntryType | null {
+	return retryOnEintrSync(() => {
+		const stat = fs.statSync(gitEntryPath);
+		if (stat.isDirectory()) return "directory";
+		if (stat.isFile()) return "file";
+		return null;
+	});
+}
+
+async function getEntryType(gitEntryPath: string): Promise<EntryType | null> {
+	return retryOnEintr(async () => {
+		const stat = await fs.promises.stat(gitEntryPath);
+		if (stat.isDirectory()) return "directory";
+		if (stat.isFile()) return "file";
+		return null;
+	});
+}
+
+function readOptionalTextSync(filePath: string): string | null {
+	return retryOnEintrSync(() => fs.readFileSync(filePath, "utf8"));
+}
+
+async function readOptionalText(filePath: string): Promise<string | null> {
+	return retryOnEintr(async () => await Bun.file(filePath).text());
+}
+
+export function parseGitDirPointer(content: string): string | null {
+	const match = /^gitdir:\s*(.+)\s*$/iu.exec(content.trim());
+	return match?.[1] ?? null;
+}
+
+function resolveGitDirSync(gitEntryPath: string, entryType: EntryType): string | null {
+	if (entryType === "directory") return gitEntryPath;
+	const parsed = parseGitDirPointer(readOptionalTextSync(gitEntryPath) ?? "");
+	if (!parsed) return null;
+	const gitDir = path.resolve(path.dirname(gitEntryPath), parsed);
+	return getEntryTypeSync(gitDir) === "directory" ? gitDir : null;
+}
+
+async function resolveGitDir(gitEntryPath: string, entryType: EntryType): Promise<string | null> {
+	if (entryType === "directory") return gitEntryPath;
+	const parsed = parseGitDirPointer((await readOptionalText(gitEntryPath)) ?? "");
+	if (!parsed) return null;
+	const gitDir = path.resolve(path.dirname(gitEntryPath), parsed);
+	return (await getEntryType(gitDir)) === "directory" ? gitDir : null;
+}
+
+function resolveCommonDirSync(gitDir: string): string {
+	const relative = readOptionalTextSync(path.join(gitDir, "commondir"))?.trim();
+	return relative ? path.resolve(gitDir, relative) : gitDir;
+}
+
+async function resolveCommonDir(gitDir: string): Promise<string> {
+	const relative = (await readOptionalText(path.join(gitDir, "commondir")))?.trim();
+	return relative ? path.resolve(gitDir, relative) : gitDir;
+}
+
+export function isLinkedGitWorktreeSync(repository: GitRepository): boolean {
+	return (
+		repository.gitDir !== repository.commonDir &&
+		getEntryTypeSync(path.join(repository.gitDir, "commondir")) === "file"
+	);
+}
+
+export async function isLinkedGitWorktree(repository: GitRepository): Promise<boolean> {
+	return (
+		repository.gitDir !== repository.commonDir &&
+		(await getEntryType(path.join(repository.gitDir, "commondir"))) === "file"
+	);
+}
+
+export function primaryGitRootSync(repository: GitRepository): string {
+	if (path.basename(repository.commonDir) === ".git") return path.dirname(repository.commonDir);
+	if (isLinkedGitWorktreeSync(repository)) return repository.commonDir;
+	return repository.repoRoot;
+}
+
+export async function primaryGitRoot(repository: GitRepository): Promise<string> {
+	if (path.basename(repository.commonDir) === ".git") return path.dirname(repository.commonDir);
+	if (await isLinkedGitWorktree(repository)) return repository.commonDir;
+	return repository.repoRoot;
+}
+
+function resolveRepoFromEntrySync(repoRoot: string, gitEntryPath: string, entryType: EntryType): GitRepository | null {
+	const gitDir = resolveGitDirSync(gitEntryPath, entryType);
+	if (!gitDir) return null;
+	return {
+		commonDir: resolveCommonDirSync(gitDir),
+		gitDir,
+		gitEntryPath,
+		headPath: path.join(gitDir, "HEAD"),
+		repoRoot,
+	};
+}
+
+async function resolveRepoFromEntry(
+	repoRoot: string,
+	gitEntryPath: string,
+	entryType: EntryType,
+): Promise<GitRepository | null> {
+	const gitDir = await resolveGitDir(gitEntryPath, entryType);
+	if (!gitDir) return null;
+	return {
+		commonDir: await resolveCommonDir(gitDir),
+		gitDir,
+		gitEntryPath,
+		headPath: path.join(gitDir, "HEAD"),
+		repoRoot,
+	};
+}
+
+export function resolveGitRepositorySync(startDir: string): GitRepository | null {
+	let current = path.resolve(startDir);
+	while (true) {
+		const gitEntryPath = path.join(current, ".git");
+		const entryType = getEntryTypeSync(gitEntryPath);
+		if (entryType) {
+			try {
+				const repository = resolveRepoFromEntrySync(current, gitEntryPath, entryType);
+				if (repository) return repository;
+			} catch (error) {
+				if (entryType === "file" && isPermissionError(error)) return null;
+				throw error;
+			}
+		}
+		const parent = path.dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+export async function resolveGitRepository(startDir: string): Promise<GitRepository | null> {
+	let current = path.resolve(startDir);
+	while (true) {
+		const gitEntryPath = path.join(current, ".git");
+		const entryType = await getEntryType(gitEntryPath);
+		if (entryType) {
+			try {
+				const repository = await resolveRepoFromEntry(current, gitEntryPath, entryType);
+				if (repository) return repository;
+			} catch (error) {
+				if (entryType === "file" && isPermissionError(error)) return null;
+				throw error;
+			}
+		}
+		const parent = path.dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export { once, untilAborted } from "./abortable";
 export * from "./async";
+export * from "./atomic-write";
 export * from "./binary";
 export * from "./color";
 export * from "./dirs";
@@ -9,6 +10,7 @@ export * from "./file-lock";
 export * from "./format";
 export * from "./frontmatter";
 export * from "./fs-error";
+export * from "./git-repository";
 export * from "./glob";
 export * from "./json";
 export * from "./json-parse";


### PR DESCRIPTION
## Summary

- add `omp profile bind`, `show`, `list`, and `unbind` commands
- select a bound profile before profile settings, credentials, and extensions load
- preserve explicit `--profile`, `OMP_PROFILE`, and `PI_PROFILE` precedence
- share Git folder bindings across linked worktrees without affecting sibling folders
- keep bindings in profile-independent OMP configuration outside repositories
- show the active profile and Anthropic account at startup and through `/profile`

## Testing

- `bun --cwd=packages/utils run check`
- 80 focused profile, bootstrap, CLI, marketplace-registry, Git, slash-command, and interactive-mode tests
- compiled binary verified against two profile-scoped Anthropic accounts
