### PR TITLE
fix(coding-agent): bound model-facing agent roster

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed `hub list` and child peer rosters dumping every parked agent into model context: the default view is now running+idle with truthful running/idle/parked/shown/truncated counts restored once from the root session, and parked names require `status: "parked"`.
 - Fixed resize and display replays, ensuring stable rendering and full transcript flushing on agent shutdown
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -35,9 +35,10 @@ You can reach other live agents via the `hub` tool. Your id is `{{ircSelfId}}`. 
 {{ircPeers}}
 
 Use `hub` messaging only for quick coordination, never long-form content. Address peers by id or use `"all"` to broadcast.
-- Discovery: the roster above shows each peer and what it is doing now; `hub` op:"list" refreshes it.
+- Discovery: the roster above shows live (running+idle) peers and a parked count, never parked names or task labels. `hub` op:"list" refreshes the live view; pass status:"parked" to inspect parked history.
 - Coordination: before you edit a file or start work a sibling may already own, message that peer first — overlapping edits collide.
 - Follow-up: answer a peer's question with a short reply (set `replyTo`); use `await` only when you genuinely cannot proceed without the answer.
+- Parked history: omitted from this roster. `hub` op:"list" status:"parked" lists ids; `send` to a known parked id revives it. `history://<id>` and `agent://<id>` stay readable.
 {{/if}}
 
 § Completion

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -36,7 +36,7 @@ You can reach other live agents via the `hub` tool. Your id is `{{ircSelfId}}`. 
 
 Use `hub` messaging only for quick coordination, never long-form content. Address peers by id or use `"all"` to broadcast.
 - Discovery: the roster above shows live (running+idle) peers and a parked count, never parked names or task labels. `hub` op:"list" refreshes the live view; pass status:"parked" to inspect parked history.
-- Coordination: before you edit a file or start work a sibling may already own, message that peer first — overlapping edits collide.
+- Coordination: before you edit a file or start work a sibling may already own, message that peer first — overlapping edits collide. Idle peers are not gone: messaging them wakes them.
 - Follow-up: answer a peer's question with a short reply (set `replyTo`); use `await` only when you genuinely cannot proceed without the answer.
 - Parked history: omitted from this roster. `hub` op:"list" status:"parked" lists ids; `send` to a known parked id revives it. `history://<id>` and `agent://<id>` stay readable.
 {{/if}}

--- a/packages/coding-agent/src/prompts/tools/hub.md
+++ b/packages/coding-agent/src/prompts/tools/hub.md
@@ -1,5 +1,5 @@
 Agent coordination: peer messaging, background-job control, and supervised long-running processes. Main agent is `Main`; subagents inherit task ID.
-Use `op: "list"` to discover peers. Address peers by exact roster ID — NEVER invent names.
+Use `op: "list"` to discover live peers. Default is running+idle plus running/idle/parked/shown/truncated counts — never an unbounded parked name dump. Pass `status: "parked"` for parked archaeology; optional `limit` bounds rows (default 32, max 100). Address peers by exact roster ID — NEVER invent names. `send` to a known parked id still revives it; `history://<id>` and `agent://<id>` stay readable.
 
 # Messaging & Jobs
 

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
 import { ADVISOR_TRANSCRIPT_FILENAME, isAdvisorTranscriptName } from "../advisor/transcript-recorder";
 import { resolveExplicitModelRole } from "../config/model-resolver";
 import { assistantTurnProducedOutput } from "../session/messages";
@@ -324,49 +325,82 @@ async function readPersistedVibeChildIds(sessionFile: string, shouldContinue: ()
 	}
 }
 
-const persistedRosterLatches = new WeakMap<AgentRegistry, Promise<void>>();
+const persistedRosterLatches = new WeakMap<AgentRegistry, { root: string; pending: Promise<void> }>();
 
 async function resolveRootSessionFile(registry: AgentRegistry, hint?: string | null): Promise<string | undefined> {
-	const mainFile = registry.get(MAIN_AGENT_ID)?.sessionFile;
 	const candidate =
-		typeof mainFile === "string" && mainFile.endsWith(".jsonl")
-			? mainFile
-			: typeof hint === "string" && hint.endsWith(".jsonl")
-				? hint
-				: undefined;
+		typeof hint === "string" && hint.endsWith(".jsonl")
+			? hint
+			: (() => {
+					const mainFile = registry.get(MAIN_AGENT_ID)?.sessionFile;
+					return typeof mainFile === "string" && mainFile.endsWith(".jsonl") ? mainFile : undefined;
+				})();
 	if (candidate === undefined) return undefined;
-	let current: string = path.resolve(candidate);
+	let current = path.resolve(candidate);
 	for (let depth = 0; depth < 8; depth++) {
-		const parentFile: string = `${path.dirname(current)}.jsonl`;
+		const parentFile = `${path.dirname(current)}.jsonl`;
 		if (!(await Bun.file(parentFile).exists())) return current;
 		current = parentFile;
 	}
 	return current;
 }
 
+function rosterScanError(error: unknown): string {
+	const text = error instanceof Error ? error.message : String(error);
+	return text.length <= 200 ? text : `${text.slice(0, 197)}...`;
+}
+
+function sessionFileBelongsToRoot(sessionFile: string, rootSessionFile: string): boolean {
+	const file = path.resolve(sessionFile);
+	const root = path.resolve(rootSessionFile);
+	const artifactRoot = root.slice(0, -".jsonl".length);
+	return file === root || file.startsWith(`${artifactRoot}${path.sep}`);
+}
+
+/** Keep old parked trees out of a new/current session's model-facing roster. */
+export function isCurrentSessionRosterRef(
+	ref: { status: string; sessionFile: string | null },
+	rootSessionFile: string | undefined,
+): boolean {
+	if (ref.status !== "parked" || !rootSessionFile || !ref.sessionFile) return true;
+	return sessionFileBelongsToRoot(ref.sessionFile, rootSessionFile);
+}
+
 /**
- * Restore parked sibling transcripts from the interactive root session once
- * per registry. Live in-memory peers do not skip the scan; an empty tree is
- * not scanned again.
+ * Restore parked sibling transcripts once per current root session. A session
+ * switch on the same process-global registry gets a new scan. IO failure
+ * degrades roster counts, never task startup, and remains retryable.
  */
-export function ensurePersistedRoster(registry: AgentRegistry, sessionFileHint?: string | null): Promise<void> {
+export async function ensurePersistedRoster(
+	registry: AgentRegistry,
+	sessionFileHint?: string | null,
+): Promise<string | undefined> {
+	let root: string | undefined;
+	try {
+		root = await resolveRootSessionFile(registry, sessionFileHint);
+	} catch (error) {
+		logger.warn("Persisted agent roster root resolution failed; using in-memory peers", {
+			error: rosterScanError(error),
+		});
+		return undefined;
+	}
+	if (!root) return undefined;
 	const existing = persistedRosterLatches.get(registry);
-	if (existing) return existing;
-	const pending = (async () => {
-		try {
-			const root = await resolveRootSessionFile(registry, sessionFileHint);
-			if (!root) {
-				persistedRosterLatches.delete(registry);
-				return;
-			}
-			await registerPersistedSubagents(registry, root);
-		} catch (error) {
-			persistedRosterLatches.delete(registry);
-			throw error;
-		}
-	})();
-	persistedRosterLatches.set(registry, pending);
-	return pending;
+	if (existing?.root === root) {
+		await existing.pending;
+		return root;
+	}
+	const pending = registerPersistedSubagents(registry, root).catch(error => {
+		const current = persistedRosterLatches.get(registry);
+		if (current?.root === root) persistedRosterLatches.delete(registry);
+		logger.warn("Persisted agent roster scan failed; using in-memory peers", {
+			rootSessionFile: root,
+			error: rosterScanError(error),
+		});
+	});
+	persistedRosterLatches.set(registry, { root, pending });
+	await pending;
+	return root;
 }
 
 /** Register persisted subagent and advisor transcripts as parked registry refs. */

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -122,6 +122,21 @@ function assistantMetrics(message: Record<string, unknown>): AssistantMetrics {
 	};
 }
 
+/**
+ * Distinguish a filesystem open/read fault (EACCES/EMFILE/EIO — any coded
+ * errno except ENOENT) from content incompleteness. Malformed and truncated
+ * JSONL records never surface as errors: the stream visitor skips them
+ * in-band. ENOENT is the tolerated optional-file race (a transcript listed by
+ * readdir can vanish before its metadata is read). So a coded non-ENOENT
+ * error means the read itself failed and must propagate — dropping the
+ * roster latch so the next call retries — instead of masquerading as an
+ * incomplete transcript.
+ */
+function isFilesystemError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | null)?.code;
+	return typeof code === "string" && code !== "ENOENT";
+}
+
 async function readPersistedAgentHistory(
 	transcript: PersistedTranscript,
 	shouldContinue: () => boolean,
@@ -158,7 +173,12 @@ async function readPersistedAgentHistory(
 			},
 			{ shouldContinue },
 		);
-	} catch {
+	} catch (error) {
+		// Malformed and truncated records are skipped in-band; a vanished file
+		// (ENOENT) degrades to empty history. Any other filesystem fault is
+		// transient and surfaces to the caller instead of masquerading as a
+		// transcript with no history.
+		if (isFilesystemError(error)) throw error;
 		return {};
 	}
 
@@ -239,7 +259,14 @@ async function readPersistedAgentHistory(
  * multi-megabyte historical transcript just to populate one roster row.
  */
 async function readPersistedAgentMetadata(sessionFile: string): Promise<PersistedAgentMetadata> {
-	const stat = fs.promises.stat(sessionFile).catch(() => undefined);
+	const stat = fs.promises.stat(sessionFile).catch(error => {
+		// A transcript listed by readdir can vanish before its metadata is read
+		// (session switch or compaction): ENOENT is the tolerated optional-file
+		// race. Any other stat failure (EACCES/EMFILE/EIO) is a filesystem fault
+		// that must surface so the roster latch drops and the next call retries.
+		if (isFilesystemError(error)) throw error;
+		return undefined;
+	});
 	const artifactBase = sessionFile.slice(0, -".jsonl".length);
 	const outputPath = `${artifactBase}.md`;
 	const patchPath = `${artifactBase}.patch`;
@@ -291,9 +318,14 @@ async function readPersistedAgentMetadata(sessionFile: string): Promise<Persiste
 			},
 			{ maxRecords: MAX_METADATA_LINES },
 		);
-	} catch {
-		// A readable transcript is still useful even when its optional metadata
-		// prefix is malformed.
+	} catch (error) {
+		// Malformed and truncated records are skipped in-band by the stream
+		// visitor, so the only errors reaching this catch are filesystem
+		// faults. ENOENT races degrade to an incomplete record; transient
+		// faults (EACCES/EMFILE/EIO) surface so the roster latch drops and the
+		// next call retries. A readable transcript with a malformed metadata
+		// prefix still yields what it can.
+		if (isFilesystemError(error)) throw error;
 	}
 	const [file, [hasOutput, hasPatch]] = await Promise.all([stat, artifactFiles]);
 	return {

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -457,8 +457,10 @@ async function registerPersistedSubagentsFromDir(
 	let entries: fs.Dirent[];
 	try {
 		entries = await fs.promises.readdir(dir, { withFileTypes: true });
-	} catch {
-		return;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return;
+		throw error;
 	}
 	if (!shouldContinue()) return;
 	let entriesSinceYield = 0;

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -390,14 +390,17 @@ export async function ensurePersistedRoster(
 		await existing.pending;
 		return root;
 	}
-	const pending = registerPersistedSubagents(registry, root).catch(error => {
-		const current = persistedRosterLatches.get(registry);
-		if (current?.root === root) persistedRosterLatches.delete(registry);
-		logger.warn("Persisted agent roster scan failed; using in-memory peers", {
-			rootSessionFile: root,
-			error: rosterScanError(error),
+	const previous = existing?.pending ?? Promise.resolve();
+	const pending = previous
+		.then(() => registerPersistedSubagents(registry, root, { hydrateHistory: false }))
+		.catch(error => {
+			const current = persistedRosterLatches.get(registry);
+			if (current?.root === root) persistedRosterLatches.delete(registry);
+			logger.warn("Persisted agent roster scan failed; using in-memory peers", {
+				rootSessionFile: root,
+				error: rosterScanError(error),
+			});
 		});
-	});
 	persistedRosterLatches.set(registry, { root, pending });
 	await pending;
 	return root;
@@ -407,17 +410,26 @@ export async function ensurePersistedRoster(
 export async function registerPersistedSubagents(
 	registry: AgentRegistry,
 	sessionFile: string | null | undefined,
-	options: { shouldContinue?: () => boolean } = {},
+	options: { shouldContinue?: () => boolean; hydrateHistory?: boolean } = {},
 ): Promise<void> {
 	if (!sessionFile?.endsWith(".jsonl")) return;
 	const shouldContinue = options.shouldContinue ?? (() => true);
+	const hydrateHistory = options.hydrateHistory ?? true;
 	if (!shouldContinue()) return;
 	const vibeOwnedIds = await readPersistedVibeChildIds(sessionFile, shouldContinue);
 	if (!shouldContinue()) return;
 	const root = sessionFile.slice(0, -6);
 	const transcripts: PersistedTranscript[] = [];
-	await registerPersistedSubagentsFromDir(registry, root, undefined, vibeOwnedIds, transcripts, shouldContinue);
-	if (!shouldContinue()) return;
+	await registerPersistedSubagentsFromDir(
+		registry,
+		root,
+		undefined,
+		vibeOwnedIds,
+		transcripts,
+		shouldContinue,
+		sessionFile,
+	);
+	if (!hydrateHistory || !shouldContinue()) return;
 	let nextTranscript = 0;
 	const workers = Array.from({ length: Math.min(4, transcripts.length) }, async () => {
 		for (;;) {
@@ -440,6 +452,7 @@ async function registerPersistedSubagentsFromDir(
 	vibeOwnedIds: ReadonlySet<string>,
 	transcripts: PersistedTranscript[],
 	shouldContinue: () => boolean,
+	rootSessionFile: string,
 ): Promise<void> {
 	if (!shouldContinue()) return;
 	let entries: fs.Dirent[];
@@ -498,11 +511,19 @@ async function registerPersistedSubagentsFromDir(
 					createdAt: metadata.createdAt,
 					lastActivity: metadata.lastActivity,
 				});
+			} else if (existing) {
+				transcripts.push({
+					id: advisorId,
+					sessionFile,
+					createdAt: existing.createdAt,
+					lastActivity: existing.lastActivity,
+				});
 			}
 			continue;
 		}
 		const id = entry.name.slice(0, -6);
-		if (vibeOwnedIds.has(id) && registry.get(id)?.sessionFile !== sessionFile) continue;
+		const existing = registry.get(id);
+		if (vibeOwnedIds.has(id) && existing?.sessionFile !== sessionFile) continue;
 		let tombstoned = false;
 		try {
 			await fs.promises.access(getAgentTombstonePath(sessionFile));
@@ -511,22 +532,41 @@ async function registerPersistedSubagentsFromDir(
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") continue;
 		}
 		if (!shouldContinue()) return;
-		if (!registry.get(id)) {
+		const replaceable =
+			existing !== undefined &&
+			existing.kind === "sub" &&
+			existing.status === "parked" &&
+			existing.session === null &&
+			typeof existing.sessionFile === "string" &&
+			!sessionFileBelongsToRoot(existing.sessionFile, rootSessionFile);
+		if (existing && !replaceable) {
+			if (existing.sessionFile === sessionFile) {
+				transcripts.push({
+					id,
+					sessionFile,
+					createdAt: existing.createdAt,
+					lastActivity: existing.lastActivity,
+				});
+			}
+		} else {
+			const expected = existing ?? null;
 			const metadata = await readPersistedAgentMetadata(sessionFile);
 			if (!shouldContinue()) return;
 			// Metadata reads yield. A spawn may claim the id while this scan is
 			// inspecting the file; never replace that live generation with a
 			// transcript-derived parked ref.
-			const unclaimed = !registry.get(id);
+			const current = registry.get(id);
+			const stillUnclaimed = expected === null && !current;
+			const stillReplaceable =
+				expected !== null && current === expected && current.status === "parked" && current.session === null;
 			// SessionManager.open writes title+session before createAgentSession
 			// claims the id. Parking that stub makes the spawn's expectedAgentRef:null
 			// CAS fail with "already owned by another session generation".
-			if (unclaimed && metadata.incomplete && !tombstoned) continue;
-			if (unclaimed) {
-				registry.register({
+			if ((stillUnclaimed || stillReplaceable) && !(metadata.incomplete && !tombstoned)) {
+				const input = {
 					id,
 					displayName: id,
-					kind: "sub",
+					kind: "sub" as const,
 					parentId: parentId ?? MAIN_AGENT_ID,
 					session: null,
 					sessionFile,
@@ -534,15 +574,18 @@ async function registerPersistedSubagentsFromDir(
 					createdAt: metadata.createdAt,
 					lastActivity: metadata.lastActivity,
 					history: metadata.history,
-					status: tombstoned ? "aborted" : "parked",
-				});
-				const ref = registry.get(id);
-				transcripts.push({
-					id,
-					sessionFile,
-					createdAt: ref?.createdAt,
-					lastActivity: ref?.lastActivity,
-				});
+					status: tombstoned ? ("aborted" as const) : ("parked" as const),
+				};
+				const vacated = stillUnclaimed || (expected !== null && registry.unregister(id, expected));
+				if (vacated && registry.registerIfAvailable(input, null)) {
+					const ref = registry.get(id);
+					transcripts.push({
+						id,
+						sessionFile,
+						createdAt: ref?.createdAt,
+						lastActivity: ref?.lastActivity,
+					});
+				}
 			}
 		}
 		await registerPersistedSubagentsFromDir(
@@ -552,6 +595,7 @@ async function registerPersistedSubagentsFromDir(
 			vibeOwnedIds,
 			transcripts,
 			shouldContinue,
+			rootSessionFile,
 		);
 	}
 }

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -337,12 +337,11 @@ async function resolveRootSessionFile(registry: AgentRegistry, hint?: string | n
 				})();
 	if (candidate === undefined) return undefined;
 	let current = path.resolve(candidate);
-	for (let depth = 0; depth < 8; depth++) {
+	for (;;) {
 		const parentFile = `${path.dirname(current)}.jsonl`;
-		if (!(await Bun.file(parentFile).exists())) return current;
+		if (parentFile === current || !(await Bun.file(parentFile).exists())) return current;
 		current = parentFile;
 	}
-	return current;
 }
 
 function rosterScanError(error: unknown): string {

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -352,7 +352,8 @@ async function readPersistedVibeChildIds(sessionFile: string, shouldContinue: ()
 			{ shouldContinue },
 		);
 		return ids;
-	} catch {
+	} catch (error) {
+		if (isFilesystemError(error)) throw error;
 		return new Set();
 	}
 }
@@ -562,7 +563,7 @@ async function registerPersistedSubagentsFromDir(
 			await fs.promises.access(getAgentTombstonePath(sessionFile));
 			tombstoned = true;
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") continue;
+			if (isFilesystemError(error)) throw error;
 		}
 		if (!shouldContinue()) return;
 		const replaceable =

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -324,6 +324,51 @@ async function readPersistedVibeChildIds(sessionFile: string, shouldContinue: ()
 	}
 }
 
+const persistedRosterLatches = new WeakMap<AgentRegistry, Promise<void>>();
+
+async function resolveRootSessionFile(registry: AgentRegistry, hint?: string | null): Promise<string | undefined> {
+	const mainFile = registry.get(MAIN_AGENT_ID)?.sessionFile;
+	const candidate =
+		typeof mainFile === "string" && mainFile.endsWith(".jsonl")
+			? mainFile
+			: typeof hint === "string" && hint.endsWith(".jsonl")
+				? hint
+				: undefined;
+	if (candidate === undefined) return undefined;
+	let current: string = path.resolve(candidate);
+	for (let depth = 0; depth < 8; depth++) {
+		const parentFile: string = `${path.dirname(current)}.jsonl`;
+		if (!(await Bun.file(parentFile).exists())) return current;
+		current = parentFile;
+	}
+	return current;
+}
+
+/**
+ * Restore parked sibling transcripts from the interactive root session once
+ * per registry. Live in-memory peers do not skip the scan; an empty tree is
+ * not scanned again.
+ */
+export function ensurePersistedRoster(registry: AgentRegistry, sessionFileHint?: string | null): Promise<void> {
+	const existing = persistedRosterLatches.get(registry);
+	if (existing) return existing;
+	const pending = (async () => {
+		try {
+			const root = await resolveRootSessionFile(registry, sessionFileHint);
+			if (!root) {
+				persistedRosterLatches.delete(registry);
+				return;
+			}
+			await registerPersistedSubagents(registry, root);
+		} catch (error) {
+			persistedRosterLatches.delete(registry);
+			throw error;
+		}
+	})();
+	persistedRosterLatches.set(registry, pending);
+	return pending;
+}
+
 /** Register persisted subagent and advisor transcripts as parked registry refs. */
 export async function registerPersistedSubagents(
 	registry: AgentRegistry,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -302,13 +302,8 @@ function formatIrcPeerRoster(registry: AgentRegistry, selfId: string, rootSessio
 			);
 		}
 	}
-	if (live.some(peer => peer.status === "idle")) {
-		lines.push("Idle peers are not gone: messaging them wakes them.");
-	}
 	if (parkedCount > 0) {
-		lines.push(
-			`${parkedCount} parked peer(s) omitted. Query with \`hub\` op:"list" status:"parked"; send to a known id, \`history://<id>\`, or \`agent://<id>\` still works.`,
-		);
+		lines.push(`${parkedCount} parked peer(s) omitted.`);
 	}
 	return lines.join("\n");
 }

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -40,8 +40,8 @@ import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pendi
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
 import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-lifecycle";
-import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
-import { ensurePersistedRoster } from "../registry/persisted-agents";
+import { AgentRegistry } from "../registry/agent-registry";
+import { ensurePersistedRoster, isCurrentSessionRosterRef } from "../registry/persisted-agents";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "../sdk";
 import type { AgentSession, AgentSessionEvent, Prewalk } from "../session/agent-session";
 import type { ArtifactManager } from "../session/artifacts";
@@ -279,11 +279,18 @@ function installSubagentRetryFallbackChain(args: {
 	return role;
 }
 
-function formatIrcPeerRoster(registry: AgentRegistry, selfId: string): string {
+function formatIrcPeerRoster(registry: AgentRegistry, selfId: string, rootSessionFile?: string): string {
 	const live = registry.listVisibleTo(selfId);
 	let parkedCount = 0;
 	for (const ref of registry.list()) {
-		if (ref.id !== selfId && ref.kind !== "advisor" && ref.status === "parked") parkedCount++;
+		if (
+			ref.id !== selfId &&
+			ref.kind !== "advisor" &&
+			ref.status === "parked" &&
+			isCurrentSessionRosterRef(ref, rootSessionFile)
+		) {
+			parkedCount++;
+		}
 	}
 	const lines: string[] = [];
 	if (live.length === 0) {
@@ -309,9 +316,11 @@ function formatIrcPeerRoster(registry: AgentRegistry, selfId: string): string {
 export async function renderIrcPeerRoster(
 	selfId: string,
 	registry: AgentRegistry = AgentRegistry.global(),
+	sessionFileHint?: string | null,
 ): Promise<string> {
-	await ensurePersistedRoster(registry, registry.get(selfId)?.sessionFile ?? registry.get(MAIN_AGENT_ID)?.sessionFile);
-	return formatIrcPeerRoster(registry, selfId);
+	const hint = sessionFileHint ?? registry.get(selfId)?.sessionFile;
+	const root = await ensurePersistedRoster(registry, hint);
+	return formatIrcPeerRoster(registry, selfId, root);
 }
 
 function withAbortTimeout<T>(
@@ -3108,6 +3117,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			const { normalized: normalizedOutputSchema } = normalizeSchema(outputSchema);
+			let ircPeers = "";
 
 			// Captured by the lifecycle reviver: rebuilding an equivalent session from
 			// the same JSONL file re-invokes createAgentSession with the exact options
@@ -3154,7 +3164,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						worktree: worktree ?? "",
 						outputSchema: normalizedOutputSchema,
 						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
-						ircPeers: ircEnabled ? formatIrcPeerRoster(AgentRegistry.global(), id) : "",
+						ircPeers,
 						ircSelfId: ircEnabled ? id : "",
 					});
 					return defaultPrompt.length === 0
@@ -3193,11 +3203,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 			sessionOpenedAt = performance.now();
 			if (ircEnabled) {
-				await ensurePersistedRoster(
+				ircPeers = await renderIrcPeerRoster(
+					id,
 					AgentRegistry.global(),
-					AgentRegistry.global().get(MAIN_AGENT_ID)?.sessionFile ??
-						AgentRegistry.global().get(id)?.sessionFile ??
-						sessionFile,
+					sessionManager.getSessionFile() ?? sessionFile,
 				);
 			}
 
@@ -3231,11 +3240,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						reopened.adoptArtifactManager(options.parentArtifactManager);
 					}
 					if (ircEnabled) {
-						await ensurePersistedRoster(
+						ircPeers = await renderIrcPeerRoster(
+							id,
 							AgentRegistry.global(),
-							AgentRegistry.global().get(MAIN_AGENT_ID)?.sessionFile ??
-								AgentRegistry.global().get(id)?.sessionFile ??
-								sessionFile,
+							reopened.getSessionFile() ?? sessionFile,
 						);
 					}
 					const { session: revived } = await createAgentSession(

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -40,7 +40,8 @@ import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pendi
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
 import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-lifecycle";
-import { AgentRegistry } from "../registry/agent-registry";
+import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import { ensurePersistedRoster } from "../registry/persisted-agents";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "../sdk";
 import type { AgentSession, AgentSessionEvent, Prewalk } from "../session/agent-session";
 import type { ArtifactManager } from "../session/artifacts";
@@ -278,19 +279,39 @@ function installSubagentRetryFallbackChain(args: {
 	return role;
 }
 
-function renderIrcPeerRoster(selfId: string): string {
-	const peers = AgentRegistry.global()
-		.list()
-		.filter(ref => ref.id !== selfId && ref.status !== "aborted" && ref.kind !== "advisor");
-	if (peers.length === 0) return "- (no other agents)";
-	const lines = peers.map(
-		peer =>
-			`- \`${peer.id}\` — ${peer.displayName} (${peer.kind}, ${peer.status})${peer.activity ? `: ${peer.activity}` : ""}`,
-	);
-	if (peers.some(peer => peer.status === "idle" || peer.status === "parked")) {
-		lines.push("Idle/parked peers are not gone: messaging them wakes (or revives) them.");
+function formatIrcPeerRoster(registry: AgentRegistry, selfId: string): string {
+	const live = registry.listVisibleTo(selfId);
+	let parkedCount = 0;
+	for (const ref of registry.list()) {
+		if (ref.id !== selfId && ref.kind !== "advisor" && ref.status === "parked") parkedCount++;
+	}
+	const lines: string[] = [];
+	if (live.length === 0) {
+		lines.push(parkedCount > 0 ? "- (no live agents)" : "- (no other agents)");
+	} else {
+		for (const peer of live) {
+			lines.push(
+				`- \`${peer.id}\` — ${peer.displayName} (${peer.kind}, ${peer.status})${peer.activity ? `: ${peer.activity}` : ""}`,
+			);
+		}
+	}
+	if (live.some(peer => peer.status === "idle")) {
+		lines.push("Idle peers are not gone: messaging them wakes them.");
+	}
+	if (parkedCount > 0) {
+		lines.push(
+			`${parkedCount} parked peer(s) omitted. Query with \`hub\` op:"list" status:"parked"; send to a known id, \`history://<id>\`, or \`agent://<id>\` still works.`,
+		);
 	}
 	return lines.join("\n");
+}
+
+export async function renderIrcPeerRoster(
+	selfId: string,
+	registry: AgentRegistry = AgentRegistry.global(),
+): Promise<string> {
+	await ensurePersistedRoster(registry, registry.get(selfId)?.sessionFile ?? registry.get(MAIN_AGENT_ID)?.sessionFile);
+	return formatIrcPeerRoster(registry, selfId);
 }
 
 function withAbortTimeout<T>(
@@ -3133,7 +3154,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						worktree: worktree ?? "",
 						outputSchema: normalizedOutputSchema,
 						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
-						ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
+						ircPeers: ircEnabled ? formatIrcPeerRoster(AgentRegistry.global(), id) : "",
 						ircSelfId: ircEnabled ? id : "",
 					});
 					return defaultPrompt.length === 0
@@ -3171,6 +3192,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				sessionManager.adoptArtifactManager(options.parentArtifactManager);
 			}
 			sessionOpenedAt = performance.now();
+			if (ircEnabled) {
+				await ensurePersistedRoster(
+					AgentRegistry.global(),
+					AgentRegistry.global().get(MAIN_AGENT_ID)?.sessionFile ??
+						AgentRegistry.global().get(id)?.sessionFile ??
+						sessionFile,
+				);
+			}
 
 			const sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
 			let session: AgentSession;
@@ -3200,6 +3229,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					});
 					if (options.parentArtifactManager) {
 						reopened.adoptArtifactManager(options.parentArtifactManager);
+					}
+					if (ircEnabled) {
+						await ensurePersistedRoster(
+							AgentRegistry.global(),
+							AgentRegistry.global().get(MAIN_AGENT_ID)?.sessionFile ??
+								AgentRegistry.global().get(id)?.sessionFile ??
+								sessionFile,
+						);
 					}
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -265,10 +265,15 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 			case "list": {
 				const messaging = this.#messaging();
 				if (!messaging) return hubErrorResult("Peer messaging is unavailable in this session.", { op: "list" });
-				return executeList(messaging.registry, messaging.senderId, {
-					status: params.status,
-					limit: params.limit,
-				});
+				return executeList(
+					messaging.registry,
+					messaging.senderId,
+					{
+						status: params.status,
+						limit: params.limit,
+					},
+					this.session.getSessionFile(),
+				);
 			}
 			case "send": {
 				const toPeer = params.to?.trim();

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -54,11 +54,13 @@ import {
 	launchRenderResult,
 } from "./launch";
 import {
+	DEFAULT_HUB_LIST_LIMIT,
 	drainPendingInbox,
 	executeInbox,
 	executeList,
 	executeMessageWait,
 	executeSend,
+	MAX_HUB_LIST_LIMIT,
 	messageResult,
 	messagingRenderCall,
 	messagingRenderResult,
@@ -83,6 +85,10 @@ const hubSchema = type({
 	"ids?": type("string[]").describe("wait: job ids to watch (omit = all running jobs); cancel: job ids to kill"),
 	"timeoutMs?": type("number").describe("wait (messages/jobs): timeout in milliseconds (0 waits indefinitely)"),
 	"peek?": type("boolean").describe("inbox: list messages without consuming them"),
+	"status?": type("'running' | 'idle' | 'parked'").describe("list: filter by status; omit for running+idle"),
+	"limit?": type("number > 0").describe(
+		`list: max peer rows; default ${DEFAULT_HUB_LIST_LIMIT}, max ${MAX_HUB_LIST_LIMIT}`,
+	),
 	"name?": type("string <= 48").describe("process ops: stable project-scoped launch name"),
 	"application?": type("string > 0").describe("start: executable or application path"),
 	"args?": type("string[]").describe("start: argv passed directly to the application"),
@@ -172,6 +178,10 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 			call: { op: "list" },
 		},
 		{
+			caption: "Inspect parked peer history",
+			call: { op: "list", status: "parked" },
+		},
+		{
 			caption: "Fire-and-forget DM — same send wakes idle/parked peers",
 			call: {
 				op: "send",
@@ -255,7 +265,10 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 			case "list": {
 				const messaging = this.#messaging();
 				if (!messaging) return hubErrorResult("Peer messaging is unavailable in this session.", { op: "list" });
-				return executeList(messaging.registry, messaging.senderId);
+				return executeList(messaging.registry, messaging.senderId, {
+					status: params.status,
+					limit: params.limit,
+				});
 			}
 			case "send": {
 				const toPeer = params.to?.trim();

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -733,7 +733,7 @@ function renderListResult(details: Partial<CoordinationDetails>, expanded: boole
 	const rosterCounts = details.counts;
 	if (peers.length === 0) {
 		const meta =
-			rosterCounts && rosterCounts.parked > 0
+			rosterCounts && rosterCounts.running + rosterCounts.idle + rosterCounts.parked > 0
 				? [
 						`${rosterCounts.running} running`,
 						`${rosterCounts.idle} idle`,

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -17,7 +17,7 @@ import type { RenderResultOptions } from "../../extensibility/custom-tools/types
 import { IrcBus, type IrcDeliveryReceipt, type IrcMessage } from "../../irc/bus";
 import type { Theme } from "../../modes/theme/theme";
 import { type AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
-import { ensurePersistedRoster } from "../../registry/persisted-agents";
+import { ensurePersistedRoster, isCurrentSessionRosterRef } from "../../registry/persisted-agents";
 import { canSpawnAtDepth } from "../../task/types";
 import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import {
@@ -60,9 +60,21 @@ function resolveHubListLimit(limit: number | undefined): number {
 	return Math.min(Math.max(1, Math.floor(limit)), MAX_HUB_LIST_LIMIT);
 }
 
-function selectListRefs(registry: AgentRegistry, senderId: string, status: HubListStatus | undefined) {
+function selectListRefs(
+	registry: AgentRegistry,
+	senderId: string,
+	status: HubListStatus | undefined,
+	rootSessionFile: string | undefined,
+) {
 	if (status === "parked") {
-		return registry.list().filter(ref => isAddressablePeer(ref, senderId) && ref.status === "parked");
+		return registry
+			.list()
+			.filter(
+				ref =>
+					isAddressablePeer(ref, senderId) &&
+					ref.status === "parked" &&
+					isCurrentSessionRosterRef(ref, rootSessionFile),
+			);
 	}
 	const live = registry.listVisibleTo(senderId);
 	return status ? live.filter(ref => ref.status === status) : live;
@@ -147,10 +159,12 @@ export async function executeList(
 	senderId: string,
 	params: HubListParams = {},
 ): Promise<AgentToolResult<CoordinationDetails>> {
-	await ensurePersistedRoster(registry, registry.get(senderId)?.sessionFile);
-	const refs = registry.list();
+	const rootSessionFile = await ensurePersistedRoster(registry, registry.get(senderId)?.sessionFile);
+	const refs = registry
+		.list()
+		.filter(ref => isAddressablePeer(ref, senderId) && isCurrentSessionRosterRef(ref, rootSessionFile));
 
-	const selected = selectListRefs(registry, senderId, params.status);
+	const selected = selectListRefs(registry, senderId, params.status, rootSessionFile);
 	selected.sort(
 		(a, b) =>
 			(LIST_STATUS_ORDER[a.status] ?? 9) - (LIST_STATUS_ORDER[b.status] ?? 9) || b.lastActivity - a.lastActivity,

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -158,8 +158,12 @@ export async function executeList(
 	registry: AgentRegistry,
 	senderId: string,
 	params: HubListParams = {},
+	sessionFileHint?: string | null,
 ): Promise<AgentToolResult<CoordinationDetails>> {
-	const rootSessionFile = await ensurePersistedRoster(registry, registry.get(senderId)?.sessionFile);
+	const rootSessionFile = await ensurePersistedRoster(
+		registry,
+		sessionFileHint ?? registry.get(senderId)?.sessionFile,
+	);
 	const refs = registry
 		.list()
 		.filter(ref => isAddressablePeer(ref, senderId) && isCurrentSessionRosterRef(ref, rootSessionFile));

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -6,7 +6,7 @@
  * lifecycle manager, injecting a non-interrupting aside into busy ones) and
  * returns delivery receipts immediately. Replies are real turns by the
  * recipient, observed with `wait` (or the `await: true` send sugar). `inbox`
- * drains pending messages; `list` shows every addressable peer.
+ * drains pending messages; `list` shows actionable running+idle peers by default.
  */
 
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
@@ -17,7 +17,7 @@ import type { RenderResultOptions } from "../../extensibility/custom-tools/types
 import { IrcBus, type IrcDeliveryReceipt, type IrcMessage } from "../../irc/bus";
 import type { Theme } from "../../modes/theme/theme";
 import { type AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
-import { registerPersistedSubagents } from "../../registry/persisted-agents";
+import { ensurePersistedRoster } from "../../registry/persisted-agents";
 import { canSpawnAtDepth } from "../../task/types";
 import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import {
@@ -29,9 +29,64 @@ import {
 	replaceTabs,
 	type ToolUIColor,
 } from "../render-utils";
-import { type CoordinationDetails, type HubRenderArgs, hubErrorResult } from "./types";
+import {
+	type CoordinationDetails,
+	type HubListStatus,
+	type HubRenderArgs,
+	type HubRosterCounts,
+	hubErrorResult,
+} from "./types";
 
 export const DEFAULT_IRC_TIMEOUT_MS = 120_000;
+
+/** Default model-facing roster page. Large enough for live siblings, far below parked leakage. */
+export const DEFAULT_HUB_LIST_LIMIT = 32;
+/** Hard cap so even explicit parked archaeology cannot dump hundreds of names. */
+export const MAX_HUB_LIST_LIMIT = 100;
+
+const LIST_STATUS_ORDER: Record<string, number> = { running: 0, idle: 1, parked: 2 };
+
+export interface HubListParams {
+	status?: HubListStatus;
+	limit?: number;
+}
+
+function isAddressablePeer(ref: { id: string; kind: string; status: string }, senderId: string): boolean {
+	return ref.id !== senderId && ref.kind !== "advisor" && ref.status !== "aborted";
+}
+
+function resolveHubListLimit(limit: number | undefined): number {
+	if (limit === undefined || !Number.isFinite(limit) || limit <= 0) return DEFAULT_HUB_LIST_LIMIT;
+	return Math.min(Math.max(1, Math.floor(limit)), MAX_HUB_LIST_LIMIT);
+}
+
+function selectListRefs(registry: AgentRegistry, senderId: string, status: HubListStatus | undefined) {
+	if (status === "parked") {
+		return registry.list().filter(ref => isAddressablePeer(ref, senderId) && ref.status === "parked");
+	}
+	const live = registry.listVisibleTo(senderId);
+	return status ? live.filter(ref => ref.status === status) : live;
+}
+
+function countAddressable(refs: { status: string }[]): Pick<HubRosterCounts, "running" | "idle" | "parked"> {
+	const counts = { running: 0, idle: 0, parked: 0 };
+	for (const ref of refs) {
+		if (ref.status === "running") counts.running++;
+		else if (ref.status === "idle") counts.idle++;
+		else if (ref.status === "parked") counts.parked++;
+	}
+	return counts;
+}
+
+function formatRosterSummary(counts: HubRosterCounts, emptyNoun: string): string {
+	const tally = `running ${counts.running}, idle ${counts.idle}, parked ${counts.parked}; shown ${counts.shown}, truncated ${counts.truncated}`;
+	if (counts.shown === 0) {
+		return counts.running + counts.idle + counts.parked === 0
+			? `No other agents (${tally}).`
+			: `No ${emptyNoun} (${tally}).`;
+	}
+	return `${counts.shown} peer(s) (${tally}):`;
+}
 
 /**
  * Messaging availability: there must be someone to chat with. True for every
@@ -83,54 +138,64 @@ export function messageResult(senderId: string, waited: IrcMessage): AgentToolRe
 }
 
 /**
- * List every addressable peer, restoring parked refs from disk when a resumed
- * session has no in-memory roster.
+ * List addressable peers. Default is running+idle with a conservative bound.
+ * One latched restore from the root session file runs before counts, even
+ * when live siblings are already in memory.
  */
 export async function executeList(
 	registry: AgentRegistry,
 	senderId: string,
+	params: HubListParams = {},
 ): Promise<AgentToolResult<CoordinationDetails>> {
-	let refs = registry.list();
-	if (!refs.some(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")) {
-		await registerPersistedSubagents(registry, registry.get(senderId)?.sessionFile);
-		refs = registry.list();
-	}
+	await ensurePersistedRoster(registry, registry.get(senderId)?.sessionFile);
+	const refs = registry.list();
+
+	const selected = selectListRefs(registry, senderId, params.status);
+	selected.sort(
+		(a, b) =>
+			(LIST_STATUS_ORDER[a.status] ?? 9) - (LIST_STATUS_ORDER[b.status] ?? 9) || b.lastActivity - a.lastActivity,
+	);
+	const limit = resolveHubListLimit(params.limit);
+	const truncated = Math.max(0, selected.length - limit);
+	const shownRefs = truncated > 0 ? selected.slice(0, limit) : selected;
+	const counts: HubRosterCounts = {
+		...countAddressable(refs.filter(ref => isAddressablePeer(ref, senderId))),
+		shown: shownRefs.length,
+		truncated,
+	};
 
 	const bus = IrcBus.global();
-	const peers = refs
-		.filter(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")
-		.map(ref => ({
-			id: ref.id,
-			displayName: ref.displayName,
-			kind: ref.kind,
-			status: ref.status,
-			parentId: ref.parentId,
-			unread: bus.unreadCount(ref.id),
-			lastActivity: ref.lastActivity,
-			activity: ref.activity,
-		}));
-	const lines: string[] = [];
-	if (peers.length === 0) {
-		lines.push("No other agents.");
-	} else {
-		lines.push(`${peers.length} peer(s):`);
-		for (const peer of peers) {
-			const extras = [
-				peer.activity || undefined,
-				peer.unread > 0 ? `unread ${peer.unread}` : undefined,
-				peer.parentId ? `parent ${peer.parentId}` : undefined,
-				`active ${formatDuration(Date.now() - peer.lastActivity)} ago`,
-			].filter(Boolean);
-			lines.push(`- ${peer.id} [${peer.displayName} · ${peer.kind} · ${peer.status}] — ${extras.join(", ")}`);
-		}
-		if (peers.some(peer => peer.status === "parked")) {
-			lines.push("");
-			lines.push("Parked agents are revived automatically when you message them.");
-		}
+	const peers = shownRefs.map(ref => ({
+		id: ref.id,
+		displayName: ref.displayName,
+		kind: ref.kind,
+		status: ref.status,
+		parentId: ref.parentId,
+		unread: bus.unreadCount(ref.id),
+		lastActivity: ref.lastActivity,
+		activity: ref.activity,
+	}));
+	const lines = [formatRosterSummary(counts, params.status ? `${params.status} peers` : "actionable peers")];
+	for (const peer of peers) {
+		const extras = [
+			peer.activity || undefined,
+			peer.unread > 0 ? `unread ${peer.unread}` : undefined,
+			peer.parentId ? `parent ${peer.parentId}` : undefined,
+			`active ${formatDuration(Date.now() - peer.lastActivity)} ago`,
+		].filter(Boolean);
+		lines.push(`- ${peer.id} [${peer.displayName} · ${peer.kind} · ${peer.status}] — ${extras.join(", ")}`);
+	}
+	if (counts.parked > 0) {
+		lines.push("");
+		lines.push(
+			params.status === "parked"
+				? "Parked agents are revived automatically when you message them."
+				: 'Parked agents remain queryable with status="parked" and are revived automatically when you message them.',
+		);
 	}
 	return {
 		content: [{ type: "text", text: lines.join("\n") }],
-		details: { op: "list", from: senderId, peers },
+		details: { op: "list", from: senderId, peers, counts },
 	};
 }
 
@@ -354,8 +419,6 @@ export function executeInbox(
 const BODY_LINES_COLLAPSED = 2;
 const BODY_LINES_EXPANDED = 12;
 const BODY_LINE_WIDTH = 100;
-
-const PEER_STATUS_ORDER: Record<string, number> = { running: 0, idle: 1, parked: 2 };
 
 function ircGlyph(theme: Theme): string {
 	return theme.styledSymbol("tool.irc", "accent");
@@ -647,14 +710,31 @@ function renderInboxResult(
 function renderListResult(details: Partial<CoordinationDetails>, expanded: boolean, theme: Theme): string[] {
 	const peers = [...(details.peers ?? [])].sort(
 		(a, b) =>
-			(PEER_STATUS_ORDER[a.status] ?? 9) - (PEER_STATUS_ORDER[b.status] ?? 9) || b.lastActivity - a.lastActivity,
+			(LIST_STATUS_ORDER[a.status] ?? 9) - (LIST_STATUS_ORDER[b.status] ?? 9) || b.lastActivity - a.lastActivity,
 	);
+	const rosterCounts = details.counts;
 	if (peers.length === 0) {
-		return [renderStatusLine({ icon: "info", title: "IRC peers", meta: ["no other agents"] }, theme)];
+		const meta =
+			rosterCounts && rosterCounts.parked > 0
+				? [
+						`${rosterCounts.running} running`,
+						`${rosterCounts.idle} idle`,
+						`${rosterCounts.parked} parked`,
+						...(rosterCounts.truncated > 0 ? [`${rosterCounts.truncated} truncated`] : []),
+					]
+				: ["no other agents"];
+		return [renderStatusLine({ icon: "info", title: "IRC peers", meta }, theme)];
 	}
 	const counts = new Map<string, number>();
 	for (const peer of peers) counts.set(peer.status, (counts.get(peer.status) ?? 0) + 1);
-	const meta = [...counts].map(([status, count]) => `${count} ${status}`);
+	const meta = rosterCounts
+		? [
+				`${rosterCounts.running} running`,
+				`${rosterCounts.idle} idle`,
+				`${rosterCounts.parked} parked`,
+				...(rosterCounts.truncated > 0 ? [`${rosterCounts.truncated} truncated`] : []),
+			]
+		: [...counts].map(([status, count]) => `${count} ${status}`);
 	const unreadTotal = peers.reduce((sum, peer) => sum + peer.unread, 0);
 	if (unreadTotal > 0) meta.push(theme.fg("warning", `${unreadTotal} unread`));
 	const header = renderStatusLine({ iconOverride: ircGlyph(theme), title: "IRC peers", meta }, theme);
@@ -677,7 +757,6 @@ function renderListResult(details: Partial<CoordinationDetails>, expanded: boole
 	);
 	return [header, ...items];
 }
-
 function buildResultLines(
 	result: { content: Array<{ type: string; text?: string }>; isError?: boolean },
 	details: Partial<CoordinationDetails>,

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -40,6 +40,18 @@ export interface HubPeerInfo {
 	activity?: string;
 }
 
+/** Status values `op:"list"` can filter on. Advisor is a kind, not a status. */
+export type HubListStatus = "running" | "idle" | "parked";
+
+/** Addressable roster tallies always returned by `op:"list"`. */
+export interface HubRosterCounts {
+	running: number;
+	idle: number;
+	parked: number;
+	shown: number;
+	truncated: number;
+}
+
 /** Background-job row surfaced by `wait`/`cancel`/`jobs` results. */
 export interface JobSnapshot {
 	id: string;
@@ -93,6 +105,8 @@ export interface CoordinationDetails {
 	waited?: IrcMessage | null;
 	inbox?: IrcMessage[];
 	peers?: HubPeerInfo[];
+	/** Present on `op:"list"`: addressable running/idle/parked plus page size. */
+	counts?: HubRosterCounts;
 	jobs?: JobSnapshot[];
 	cancelled?: { id: string; status: CancelStatus }[];
 	/** Running subagents not represented by a job row in this result. */

--- a/packages/coding-agent/test/prompt-templates.test.ts
+++ b/packages/coding-agent/test/prompt-templates.test.ts
@@ -415,6 +415,13 @@ describe("subagent peer roster prompt", () => {
 			activity: "editing auth.ts",
 		});
 		registry.register({
+			id: "IdleReviewer",
+			displayName: "reviewer",
+			kind: "sub",
+			session: null,
+			status: "idle",
+		});
+		registry.register({
 			id: "ParkedSecretId",
 			displayName: "secret parked label",
 			kind: "sub",
@@ -432,6 +439,12 @@ describe("subagent peer roster prompt", () => {
 		});
 		expect(rendered).toContain("LiveWorker");
 		expect(rendered).toContain("editing auth.ts");
+		expect(rendered).toContain("IdleReviewer");
+		expect(rendered).toContain("1 parked peer(s) omitted");
+		expect(rendered).toContain("Idle peers are not gone: messaging them wakes them.");
+		expect(rendered).toContain('status:"parked"');
+		expect(rendered).toContain("history://");
+		expect(rendered).toContain("agent://");
 		expect(rendered).not.toContain("ParkedSecretId");
 		expect(rendered).not.toContain("secret parked label");
 		expect(rendered).not.toContain("reviewing classified.diff");

--- a/packages/coding-agent/test/prompt-templates.test.ts
+++ b/packages/coding-agent/test/prompt-templates.test.ts
@@ -13,6 +13,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { expandPromptTemplate, type PromptTemplate } from "@oh-my-pi/pi-coding-agent/config/prompt-templates";
 import { expandSlashCommand, type FileSlashCommand } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
+import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { renderIrcPeerRoster } from "@oh-my-pi/pi-coding-agent/task/executor";
 import { parseCommandArgs, substituteArgs } from "@oh-my-pi/pi-coding-agent/utils/command-args";
 import { prompt } from "@oh-my-pi/pi-utils";
 
@@ -395,17 +397,43 @@ describe("renderYieldSchema", () => {
 describe("subagent peer roster prompt", () => {
 	const templatePath = path.resolve(import.meta.dir, "../src/prompts/system/subagent-system-prompt.md");
 
-	test("documents parked archaeology and revival when a live roster is present", async () => {
+	test("production prompt includes live peers and omits parked identity and activity", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "implementer",
+			kind: "sub",
+			session: null,
+			status: "running",
+			activity: "editing auth.ts",
+		});
+		registry.register({
+			id: "ParkedSecretId",
+			displayName: "secret parked label",
+			kind: "sub",
+			session: null,
+			status: "parked",
+			activity: "reviewing classified.diff",
+		});
+
 		const templateSource = await fs.readFile(templatePath, "utf-8");
+		const ircPeers = await renderIrcPeerRoster("Child", registry);
 		const rendered = prompt.render(templateSource, {
 			agent: "test-agent",
 			ircSelfId: "Child",
-			ircPeers: "- `LiveWorker` — task (sub, running)\n1 parked peer(s) omitted.",
+			ircPeers,
 		});
 		expect(rendered).toContain("LiveWorker");
-		expect(rendered).toContain('status:"parked"');
-		expect(rendered).toContain("history://");
-		expect(rendered).toContain("agent://");
-		expect(rendered).toContain("never parked names");
+		expect(rendered).toContain("editing auth.ts");
+		expect(rendered).not.toContain("ParkedSecretId");
+		expect(rendered).not.toContain("secret parked label");
+		expect(rendered).not.toContain("reviewing classified.diff");
 	});
 });

--- a/packages/coding-agent/test/prompt-templates.test.ts
+++ b/packages/coding-agent/test/prompt-templates.test.ts
@@ -391,3 +391,21 @@ describe("renderYieldSchema", () => {
 		expect(rendered).not.toContain("Your terminal `yield` MUST use exactly this shape");
 	});
 });
+
+describe("subagent peer roster prompt", () => {
+	const templatePath = path.resolve(import.meta.dir, "../src/prompts/system/subagent-system-prompt.md");
+
+	test("documents parked archaeology and revival when a live roster is present", async () => {
+		const templateSource = await fs.readFile(templatePath, "utf-8");
+		const rendered = prompt.render(templateSource, {
+			agent: "test-agent",
+			ircSelfId: "Child",
+			ircPeers: "- `LiveWorker` — task (sub, running)\n1 parked peer(s) omitted.",
+		});
+		expect(rendered).toContain("LiveWorker");
+		expect(rendered).toContain('status:"parked"');
+		expect(rendered).toContain("history://");
+		expect(rendered).toContain("agent://");
+		expect(rendered).toContain("never parked names");
+	});
+});

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -408,6 +408,54 @@ describe("hub list", () => {
 		expect(promptRoster).not.toContain("SecondWorker");
 	});
 
+	it("climbs more than nine nested session levels to count a parked top-level sibling", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-deep-nest-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await writeParkedTranscript(path.join(dir, "main", "ParkedScout.jsonl"), "parked", "reviewing classified.diff");
+
+		let nestedDir = path.join(dir, "main");
+		let deepSessionFile = sessionFile;
+		for (let level = 1; level <= 10; level++) {
+			deepSessionFile = path.join(nestedDir, `L${level}.jsonl`);
+			await Bun.write(deepSessionFile, `${sessionHeader(`L${level}`)}\n`);
+			nestedDir = path.join(nestedDir, `L${level}`);
+		}
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		registry.register({
+			id: "DeepChild",
+			displayName: "task",
+			kind: "sub",
+			parentId: "L9",
+			session: null,
+			sessionFile: deepSessionFile,
+			status: "idle",
+		});
+
+		const listed = await executeList(registry, "DeepChild");
+		if (!listed.details) throw new Error("Expected coordination details");
+		expect(listed.details.counts?.parked).toBe(1);
+		expect(listed.details.peers?.map(peer => peer.id)).toEqual([MAIN_AGENT_ID]);
+		expect(listText(listed)).not.toContain("ParkedScout");
+		expect(registry.get("ParkedScout")?.status).toBe("parked");
+
+		const roster = await renderIrcPeerRoster("DeepChild", registry, deepSessionFile);
+		expect(roster).toContain("1 parked peer(s) omitted");
+		expect(roster).toContain("`Main`");
+		expect(roster).not.toContain("ParkedScout");
+		expect(roster).not.toContain("reviewing classified.diff");
+	});
+
 	it("counts a disk-only parked sibling when a live sibling is already in memory", async () => {
 		using tempDir = TempDir.createSync("@omp-hub-list-live-disk-");
 		const dir = tempDir.path();

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { HistoryProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/history-protocol";
@@ -291,6 +292,110 @@ describe("hub list", () => {
 		if (!result.details) throw new Error("Expected coordination details");
 		expect(result.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
 		expect(result.details.counts?.idle).toBe(1);
+	});
+
+	it("retries persisted roster scan after a transient readdir failure", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-readdir-retry-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await writeParkedTranscript(path.join(dir, "main", "ParkedScout.jsonl"), "parked", "reviewing classified.diff");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			status: "idle",
+		});
+
+		const readdirSpy = spyOn(fs.promises, "readdir").mockRejectedValueOnce(
+			Object.assign(new Error("too many open files"), { code: "EMFILE" }),
+		);
+		try {
+			const first = await executeList(registry, MAIN_AGENT_ID);
+			if (!first.details) throw new Error("Expected coordination details");
+			expect(first.isError).toBeFalsy();
+			expect(first.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
+			expect(first.details.counts).toEqual({
+				running: 0,
+				idle: 1,
+				parked: 0,
+				shown: 1,
+				truncated: 0,
+			});
+			expect(registry.get("ParkedScout")).toBeUndefined();
+			expect(listText(first)).not.toContain("ParkedScout");
+
+			const second = await executeList(registry, MAIN_AGENT_ID);
+			if (!second.details) throw new Error("Expected coordination details");
+			expect(second.isError).toBeFalsy();
+			expect(second.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
+			expect(second.details.counts).toEqual({
+				running: 0,
+				idle: 1,
+				parked: 1,
+				shown: 1,
+				truncated: 0,
+			});
+			expect(registry.get("ParkedScout")?.status).toBe("parked");
+			expect(listText(second)).not.toContain("ParkedScout");
+		} finally {
+			readdirSpy.mockRestore();
+		}
+	});
+
+	it("latches an empty persisted roster when the optional subagent directory is missing", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-enoent-latch-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			status: "idle",
+		});
+
+		const first = await executeList(registry, MAIN_AGENT_ID);
+		if (!first.details) throw new Error("Expected coordination details");
+		expect(first.isError).toBeFalsy();
+		expect(first.details.counts).toEqual({
+			running: 0,
+			idle: 1,
+			parked: 0,
+			shown: 1,
+			truncated: 0,
+		});
+
+		await writeParkedTranscript(path.join(dir, "main", "ParkedScout.jsonl"), "parked", "reviewing classified.diff");
+		const second = await executeList(registry, MAIN_AGENT_ID);
+		if (!second.details) throw new Error("Expected coordination details");
+		expect(second.isError).toBeFalsy();
+		expect(second.details.counts?.parked).toBe(0);
+		expect(registry.get("ParkedScout")).toBeUndefined();
 	});
 
 	it("schema rejects aborted and advisor list filters", () => {

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -355,6 +355,130 @@ describe("hub list", () => {
 		}
 	});
 
+	it("drops the latch and re-reads after a transient metadata read failure", async () => {
+		for (const code of ["EMFILE", "EACCES"] as const) {
+			using tempDir = TempDir.createSync(`@omp-hub-list-metadata-${code}-`);
+			const dir = tempDir.path();
+			const sessionFile = path.join(dir, "main.jsonl");
+			await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+			const transcriptFile = path.join(dir, "main", "ParkedScout.jsonl");
+			await writeParkedTranscript(transcriptFile, "parked", "reviewing classified.diff");
+
+			const registry = new AgentRegistry();
+			registry.register({
+				id: MAIN_AGENT_ID,
+				displayName: MAIN_AGENT_ID,
+				kind: "main",
+				session: null,
+				sessionFile,
+				status: "running",
+			});
+			registry.register({
+				id: "LiveWorker",
+				displayName: "task",
+				kind: "sub",
+				parentId: MAIN_AGENT_ID,
+				session: null,
+				status: "idle",
+			});
+
+			const statSpy = spyOn(fs.promises, "stat").mockRejectedValueOnce(
+				Object.assign(new Error(code === "EMFILE" ? "too many open files" : "permission denied"), { code }),
+			);
+			try {
+				const first = await executeList(registry, MAIN_AGENT_ID);
+				if (!first.details) throw new Error("Expected coordination details");
+				expect(first.isError).toBeFalsy();
+				expect(first.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
+				expect(first.details.counts).toEqual({
+					running: 0,
+					idle: 1,
+					parked: 0,
+					shown: 1,
+					truncated: 0,
+				});
+				expect(registry.get("ParkedScout")).toBeUndefined();
+				expect(listText(first)).not.toContain("ParkedScout");
+
+				// The failed scan must not latch: the next call re-reads the same
+				// transcript and registers it as parked.
+				const second = await executeList(registry, MAIN_AGENT_ID);
+				if (!second.details) throw new Error("Expected coordination details");
+				expect(second.isError).toBeFalsy();
+				expect(second.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
+				expect(second.details.counts).toEqual({
+					running: 0,
+					idle: 1,
+					parked: 1,
+					shown: 1,
+					truncated: 0,
+				});
+				expect(registry.get("ParkedScout")?.status).toBe("parked");
+				expect(listText(second)).not.toContain("ParkedScout");
+			} finally {
+				statSpy.mockRestore();
+			}
+		}
+	});
+
+	it("tolerates a transcript vanishing between readdir and its metadata read", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-metadata-enoent-race-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		const transcriptFile = path.join(dir, "main", "ParkedScout.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await writeParkedTranscript(transcriptFile, "parked", "reviewing classified.diff");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			status: "idle",
+		});
+
+		const accessSpy = spyOn(fs.promises, "access").mockImplementationOnce(async () => {
+			// The transcript existed when readdir listed it; it is gone by the
+			// time the metadata read runs (session switch or compaction).
+			await fs.promises.rm(transcriptFile);
+			throw Object.assign(new Error("no such file or directory"), { code: "ENOENT" });
+		});
+		try {
+			const first = await executeList(registry, MAIN_AGENT_ID);
+			if (!first.details) throw new Error("Expected coordination details");
+			expect(first.isError).toBeFalsy();
+			expect(first.details.counts).toEqual({
+				running: 0,
+				idle: 1,
+				parked: 0,
+				shown: 1,
+				truncated: 0,
+			});
+			expect(registry.get("ParkedScout")).toBeUndefined();
+
+			// ENOENT is a stable state, not a transient fault: the completed
+			// scan latches, so a reappearing transcript is not re-scanned.
+			await writeParkedTranscript(transcriptFile, "parked", "reviewing classified.diff");
+			const second = await executeList(registry, MAIN_AGENT_ID);
+			if (!second.details) throw new Error("Expected coordination details");
+			expect(second.isError).toBeFalsy();
+			expect(second.details.counts?.parked).toBe(0);
+			expect(registry.get("ParkedScout")).toBeUndefined();
+		} finally {
+			accessSpy.mockRestore();
+		}
+	});
+
 	it("latches an empty persisted roster when the optional subagent directory is missing", async () => {
 		using tempDir = TempDir.createSync("@omp-hub-list-enoent-latch-");
 		const dir = tempDir.path();

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -265,6 +265,31 @@ describe("hub list", () => {
 		});
 	});
 
+	it("keeps actionable peers available when persisted roster IO is invalid", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile: "\0invalid.jsonl",
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			status: "idle",
+		});
+
+		const result = await executeList(registry, MAIN_AGENT_ID);
+		if (!result.details) throw new Error("Expected coordination details");
+		expect(result.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
+		expect(result.details.counts?.idle).toBe(1);
+	});
+
 	it("schema rejects aborted and advisor list filters", () => {
 		const tool = new HubTool(makeToolSession(new AgentRegistry(), MAIN_AGENT_ID));
 		expect(() => tool.parameters.assert({ op: "list", status: "aborted" })).toThrow();
@@ -330,6 +355,54 @@ describe("hub list", () => {
 		]);
 		expect(listText(parked)).toContain("Worker");
 		expect(listText(parked)).toContain("parked");
+	});
+
+	it("rescans and scopes parked peers when one registry switches root sessions", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-session-switch-");
+		const firstSession = path.join(tempDir.path(), "first.jsonl");
+		const secondSession = path.join(tempDir.path(), "second.jsonl");
+		await Bun.write(firstSession, `${sessionHeader("first")}\n`);
+		await Bun.write(secondSession, `${sessionHeader("second")}\n`);
+		await writeParkedTranscript(path.join(tempDir.path(), "first", "FirstWorker.jsonl"), "first-worker", "first");
+		await writeParkedTranscript(path.join(tempDir.path(), "second", "SecondWorker.jsonl"), "second-worker", "second");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile: firstSession,
+			status: "running",
+		});
+		const first = await executeList(registry, MAIN_AGENT_ID, { status: "parked" });
+		if (!first.details) throw new Error("Expected coordination details");
+		expect(first.details.peers?.map(peer => peer.id)).toEqual(["FirstWorker"]);
+
+		const hintedRoster = await renderIrcPeerRoster("HintedChild", registry, secondSession);
+		expect(hintedRoster).toContain("1 parked peer(s) omitted");
+		expect(registry.get("SecondWorker")).toBeDefined();
+		expect(hintedRoster).not.toContain("FirstWorker");
+		expect(hintedRoster).not.toContain("SecondWorker");
+		registry.unregister(MAIN_AGENT_ID);
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile: secondSession,
+			status: "running",
+		});
+		const second = await executeList(registry, MAIN_AGENT_ID, { status: "parked" });
+		if (!second.details) throw new Error("Expected coordination details");
+		expect(second.details.peers?.map(peer => peer.id)).toEqual(["SecondWorker"]);
+		expect(second.details.counts?.parked).toBe(1);
+		expect(registry.get("FirstWorker")).toBeDefined();
+
+		const promptRoster = await renderIrcPeerRoster(MAIN_AGENT_ID, registry, secondSession);
+		expect(promptRoster).toContain("1 parked peer(s) omitted");
+		expect(promptRoster).not.toContain("FirstWorker");
+		expect(promptRoster).not.toContain("SecondWorker");
 	});
 
 	it("counts a disk-only parked sibling when a live sibling is already in memory", async () => {

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -6,7 +6,7 @@ import { HistoryProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/
 import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
 import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
-import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { AgentRegistry, getAgentTombstonePath, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { ensurePersistedRoster, registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/persisted-agents";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
@@ -352,6 +352,105 @@ describe("hub list", () => {
 			expect(listText(second)).not.toContain("ParkedScout");
 		} finally {
 			readdirSpy.mockRestore();
+		}
+	});
+
+	it("retries persisted roster scan after a root transcript read failure", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-vibe-read-retry-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		const transcriptFile = path.join(dir, "main", "ParkedScout.jsonl");
+		await fs.promises.mkdir(sessionFile);
+		await writeParkedTranscript(transcriptFile, "parked", "reviewing classified.diff");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+
+		const first = await executeList(registry, MAIN_AGENT_ID);
+		if (!first.details) throw new Error("Expected coordination details");
+		expect(first.isError).toBeFalsy();
+		expect(first.details.counts).toEqual({
+			running: 0,
+			idle: 0,
+			parked: 0,
+			shown: 0,
+			truncated: 0,
+		});
+		expect(registry.get("ParkedScout")).toBeUndefined();
+
+		await fs.promises.rmdir(sessionFile);
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+
+		const second = await executeList(registry, MAIN_AGENT_ID);
+		if (!second.details) throw new Error("Expected coordination details");
+		expect(second.isError).toBeFalsy();
+		expect(second.details.counts).toEqual({
+			running: 0,
+			idle: 0,
+			parked: 1,
+			shown: 0,
+			truncated: 0,
+		});
+		expect(registry.get("ParkedScout")?.status).toBe("parked");
+		expect(listText(second)).not.toContain("ParkedScout");
+	});
+
+	it("retries persisted roster scan after a tombstone access failure", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-tombstone-retry-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		const transcriptFile = path.join(dir, "main", "ParkedScout.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await writeParkedTranscript(transcriptFile, "parked", "reviewing classified.diff");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+
+		const accessSpy = spyOn(fs.promises, "access").mockImplementationOnce(async target => {
+			expect(target).toBe(getAgentTombstonePath(transcriptFile));
+			throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+		});
+		try {
+			const first = await executeList(registry, MAIN_AGENT_ID);
+			if (!first.details) throw new Error("Expected coordination details");
+			expect(first.isError).toBeFalsy();
+			expect(first.details.counts).toEqual({
+				running: 0,
+				idle: 0,
+				parked: 0,
+				shown: 0,
+				truncated: 0,
+			});
+			expect(registry.get("ParkedScout")).toBeUndefined();
+
+			const second = await executeList(registry, MAIN_AGENT_ID);
+			if (!second.details) throw new Error("Expected coordination details");
+			expect(second.isError).toBeFalsy();
+			expect(second.details.counts).toEqual({
+				running: 0,
+				idle: 0,
+				parked: 1,
+				shown: 0,
+				truncated: 0,
+			});
+			expect(registry.get("ParkedScout")?.status).toBe("parked");
+			expect(listText(second)).not.toContain("ParkedScout");
+		} finally {
+			accessSpy.mockRestore();
 		}
 	});
 

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { HistoryProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/history-protocol";
+import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
 import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { ensurePersistedRoster, registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/persisted-agents";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { renderIrcPeerRoster } from "@oh-my-pi/pi-coding-agent/task/executor";
@@ -53,11 +56,11 @@ function listText(result: { content: Array<{ type: string; text?: string }> }): 
 	return text;
 }
 
-function makeToolSession(registry: AgentRegistry, agentId: string): ToolSession {
+function makeToolSession(registry: AgentRegistry, agentId: string, sessionFile: string | null = null): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
-		getSessionFile: () => null,
+		getSessionFile: () => sessionFile,
 		getSessionSpawns: () => "*",
 		settings: Settings.isolated(),
 		agentRegistry: registry,
@@ -513,6 +516,373 @@ describe("hub list", () => {
 			AgentLifecycleManager.resetGlobalForTests();
 			IrcBus.resetGlobalForTests();
 		}
+	});
+});
+
+describe("hub list session authority", () => {
+	it("uses HubTool getSessionFile when Main's registry ref still points at the old root", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-stale-main-");
+		const firstSession = path.join(tempDir.path(), "first.jsonl");
+		const secondSession = path.join(tempDir.path(), "second.jsonl");
+		await Bun.write(firstSession, `${sessionHeader("first")}\n`);
+		await Bun.write(secondSession, `${sessionHeader("second")}\n`);
+		await writeParkedTranscript(path.join(tempDir.path(), "first", "FirstWorker.jsonl"), "first-worker", "first");
+		await writeParkedTranscript(path.join(tempDir.path(), "second", "SecondWorker.jsonl"), "second-worker", "second");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile: firstSession,
+			status: "running",
+		});
+		const tool = new HubTool(makeToolSession(registry, MAIN_AGENT_ID, secondSession));
+		const listed = await tool.execute("list-switch", { op: "list", status: "parked" });
+		if (!listed.details || !("peers" in listed.details)) throw new Error("Expected list details");
+		expect(listed.details.peers?.map(peer => peer.id)).toEqual(["SecondWorker"]);
+		expect(listText(listed)).not.toContain("FirstWorker");
+		expect(registry.get(MAIN_AGENT_ID)?.sessionFile).toBe(firstSession);
+	});
+
+	it("replaces a detached old-root parked sub so send and history target the current file", async () => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+		try {
+			using tempDir = TempDir.createSync("@omp-hub-replace-current-");
+			const firstSession = path.join(tempDir.path(), "first.jsonl");
+			const secondSession = path.join(tempDir.path(), "second.jsonl");
+			const oldWorker = path.join(tempDir.path(), "first", "Worker.jsonl");
+			const newWorker = path.join(tempDir.path(), "second", "Worker.jsonl");
+			await Bun.write(firstSession, `${sessionHeader("first")}\n`);
+			await Bun.write(secondSession, `${sessionHeader("second")}\n`);
+			await Bun.write(
+				oldWorker,
+				`${[
+					sessionHeader("old-worker"),
+					JSON.stringify({
+						type: "session_init",
+						id: "si-old",
+						parentId: null,
+						timestamp: "2026-08-13T17:14:49.000Z",
+						systemPrompt: "review",
+						task: "old-secret-task-body",
+						tools: ["read"],
+					}),
+					JSON.stringify({
+						type: "message",
+						id: "old-user",
+						parentId: null,
+						timestamp: "2026-08-13T17:14:50.000Z",
+						message: { role: "user", content: "old-secret-user-line", timestamp: 1 },
+					}),
+				].join("\n")}\n`,
+			);
+			await Bun.write(
+				newWorker,
+				`${[
+					sessionHeader("worker"),
+					JSON.stringify({
+						type: "session_init",
+						id: "si-new",
+						parentId: null,
+						timestamp: "2026-08-13T17:14:49.000Z",
+						systemPrompt: "review",
+						task: "new-current-task-body",
+						tools: ["read"],
+					}),
+					JSON.stringify({
+						type: "message",
+						id: "new-user",
+						parentId: null,
+						timestamp: "2026-08-13T17:14:50.000Z",
+						message: { role: "user", content: "new-current-user-line", timestamp: 1 },
+					}),
+				].join("\n")}\n`,
+			);
+
+			const registry = AgentRegistry.global();
+			registry.register({
+				id: MAIN_AGENT_ID,
+				displayName: MAIN_AGENT_ID,
+				kind: "main",
+				session: null,
+				sessionFile: firstSession,
+				status: "running",
+			});
+			registry.register({
+				id: "Worker",
+				displayName: "task",
+				kind: "sub",
+				session: null,
+				sessionFile: oldWorker,
+				status: "parked",
+				activity: "old-secret-task-body",
+			});
+
+			const tool = new HubTool(makeToolSession(registry, MAIN_AGENT_ID, secondSession));
+			const listed = await tool.execute("list-replace", { op: "list", status: "parked" });
+			if (!listed.details || !("peers" in listed.details)) throw new Error("Expected list details");
+			expect(registry.get("Worker")?.sessionFile).toBe(newWorker);
+			expect(listed.details.peers?.map(peer => peer.id)).toEqual(["Worker"]);
+
+			const history = await new HistoryProtocolHandler().resolve(parseInternalUrl("history://Worker"));
+			expect(history.sourcePath).toBe(newWorker);
+			expect(history.content).toContain("new-current-user-line");
+			expect(history.content).not.toContain("old-secret-user-line");
+
+			const delivered: string[] = [];
+			const revived = {
+				isStreaming: false,
+				deliverIrcMessage: async (msg: { body: string }) => {
+					delivered.push(msg.body);
+					return "woken";
+				},
+			} as unknown as AgentSession;
+			AgentLifecycleManager.global().adopt("Worker", {
+				idleTtlMs: 0,
+				revive: async () => revived,
+			});
+			const sent = await executeSend(
+				{ registry, senderId: MAIN_AGENT_ID, settings: Settings.isolated() },
+				{ to: "Worker", message: "wake current" },
+			);
+			expect(sent.isError).toBeFalsy();
+			expect(sent.details?.receipts).toEqual([{ to: "Worker", outcome: "revived" }]);
+			expect(delivered).toEqual(["wake current"]);
+		} finally {
+			AgentRegistry.resetGlobalForTests();
+			AgentLifecycleManager.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		}
+	});
+
+	it("preserves live, aborted, advisor, vibe-owned, and nested same-root collisions", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-preserve-collisions-");
+		const dir = tempDir.path();
+		const currentSession = path.join(dir, "current.jsonl");
+		const oldLive = path.join(dir, "old", "LiveTwin.jsonl");
+		const oldIdle = path.join(dir, "old", "IdleTwin.jsonl");
+		const oldDead = path.join(dir, "old", "DeadTwin.jsonl");
+		const oldAdvisor = path.join(dir, "old", "AdvisorTwin.jsonl");
+		const oldVibe = path.join(dir, "old", "VibeKid.jsonl");
+		await Bun.write(
+			currentSession,
+			`${[
+				sessionHeader("current"),
+				JSON.stringify({
+					type: "custom",
+					customType: "vibe-session-lifecycle",
+					data: {
+						version: 1,
+						id: "VibeKid",
+						ownerId: MAIN_AGENT_ID,
+						parentSessionId: "current",
+						action: "spawn",
+						cli: "fast",
+						agent: "task",
+						childSessionFile: "VibeKid.jsonl",
+						createdAt: 1,
+					},
+				}),
+			].join("\n")}\n`,
+		);
+		await writeParkedTranscript(path.join(dir, "current", "LiveTwin.jsonl"), "live", "steal-live");
+		await writeParkedTranscript(path.join(dir, "current", "IdleTwin.jsonl"), "idle", "steal-idle");
+		await writeParkedTranscript(path.join(dir, "current", "DeadTwin.jsonl"), "dead", "steal-dead");
+		await writeParkedTranscript(path.join(dir, "current", "AdvisorTwin.jsonl"), "advisor", "steal-advisor");
+		await writeParkedTranscript(path.join(dir, "current", "VibeKid.jsonl"), "vibe", "steal-vibe");
+		await writeParkedTranscript(path.join(dir, "current", "Outer.jsonl"), "outer", "outer-visible-task");
+		await writeParkedTranscript(path.join(dir, "current", "Outer", "Outer.jsonl"), "nested", "nested-steal-task");
+
+		const registry = new AgentRegistry();
+		const liveSession = {} as AgentSession;
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile: currentSession,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveTwin",
+			displayName: "task",
+			kind: "sub",
+			session: liveSession,
+			sessionFile: oldLive,
+			status: "running",
+		});
+		registry.register({
+			id: "IdleTwin",
+			displayName: "task",
+			kind: "sub",
+			session: liveSession,
+			sessionFile: oldIdle,
+			status: "idle",
+		});
+		registry.register({
+			id: "DeadTwin",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: oldDead,
+			status: "aborted",
+		});
+		registry.register({
+			id: "AdvisorTwin",
+			displayName: "advisor",
+			kind: "advisor",
+			session: null,
+			sessionFile: oldAdvisor,
+			status: "parked",
+		});
+		registry.register({
+			id: "VibeKid",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: oldVibe,
+			status: "parked",
+		});
+
+		await executeList(registry, MAIN_AGENT_ID, { status: "parked" }, currentSession);
+		expect(registry.get("LiveTwin")?.status).toBe("running");
+		expect(registry.get("LiveTwin")?.session).toBe(liveSession);
+		expect(registry.get("LiveTwin")?.sessionFile).toBe(oldLive);
+		expect(registry.get("IdleTwin")?.status).toBe("idle");
+		expect(registry.get("IdleTwin")?.sessionFile).toBe(oldIdle);
+		expect(registry.get("DeadTwin")?.status).toBe("aborted");
+		expect(registry.get("DeadTwin")?.sessionFile).toBe(oldDead);
+		expect(registry.get("AdvisorTwin")?.kind).toBe("advisor");
+		expect(registry.get("AdvisorTwin")?.sessionFile).toBe(oldAdvisor);
+		expect(registry.get("VibeKid")?.sessionFile).toBe(oldVibe);
+		expect(registry.get("Outer")?.sessionFile).toBe(path.join(dir, "current", "Outer.jsonl"));
+		expect(registry.get("Outer")?.activity).toContain("outer-visible-task");
+		expect(registry.get("Outer")?.activity).not.toContain("nested-steal-task");
+	});
+
+	it("does not replace through an incomplete stub or a spawn that claims the id mid-scan", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-no-replace-race-");
+		const dir = tempDir.path();
+		const currentSession = path.join(dir, "current.jsonl");
+		const oldIncomplete = path.join(dir, "old", "IncompleteTwin.jsonl");
+		const oldRace = path.join(dir, "old", "RaceTwin.jsonl");
+		const newRace = path.join(dir, "current", "RaceTwin.jsonl");
+		await Bun.write(currentSession, `${sessionHeader("current")}\n`);
+		await writeParkedTranscript(oldIncomplete, "old-incomplete", "keep-old-incomplete");
+		await writeParkedTranscript(oldRace, "old-race", "keep-old-race");
+		await Bun.write(path.join(dir, "current", "IncompleteTwin.jsonl"), `${sessionHeader("incomplete")}\n`);
+		await writeParkedTranscript(newRace, "race", "steal-race");
+
+		const registry = new AgentRegistry();
+		const liveSession = {} as AgentSession;
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile: currentSession,
+			status: "running",
+		});
+		const incomplete = registry.register({
+			id: "IncompleteTwin",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: oldIncomplete,
+			status: "parked",
+		});
+		const parkedRace = registry.register({
+			id: "RaceTwin",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: oldRace,
+			status: "parked",
+		});
+		const originalGet = registry.get.bind(registry);
+		let injectClaim = true;
+		registry.get = id => {
+			const current = originalGet(id);
+			if (id === "RaceTwin" && injectClaim && current === parkedRace) {
+				injectClaim = false;
+				queueMicrotask(() => {
+					registry.unregister("RaceTwin", parkedRace);
+					registry.register({
+						id: "RaceTwin",
+						displayName: "task",
+						kind: "sub",
+						session: liveSession,
+						sessionFile: newRace,
+						status: "running",
+					});
+				});
+			}
+			return current;
+		};
+
+		await executeList(registry, MAIN_AGENT_ID, { status: "parked" }, currentSession);
+		expect(originalGet("IncompleteTwin")).toBe(incomplete);
+		expect(originalGet("IncompleteTwin")?.sessionFile).toBe(oldIncomplete);
+		expect(originalGet("RaceTwin")?.status).toBe("running");
+		expect(originalGet("RaceTwin")?.session).toBe(liveSession);
+	});
+
+	it("keeps ensurePersistedRoster metadata-only and hydrates on a later explicit register", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-hydrate-later-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		const workerFile = path.join(dir, "main", "Worker.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await Bun.write(
+			workerFile,
+			`${[
+				sessionHeader("worker"),
+				JSON.stringify({
+					type: "session_init",
+					id: "si-worker",
+					parentId: null,
+					timestamp: "2026-08-13T17:14:49.000Z",
+					systemPrompt: "review",
+					task: "hydrate later",
+					tools: ["read"],
+				}),
+				JSON.stringify({
+					type: "message",
+					id: "a1",
+					parentId: "si-worker",
+					timestamp: "2026-08-13T17:14:50.000Z",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "done" }],
+						provider: "anthropic",
+						model: "claude-sonnet-5",
+						stopReason: "stop",
+						usage: { input: 10, output: 20, totalTokens: 30, cost: { total: 0.5 } },
+					},
+				}),
+			].join("\n")}\n`,
+		);
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		await ensurePersistedRoster(registry, sessionFile);
+		expect(registry.get("Worker")?.sessionFile).toBe(workerFile);
+		expect(registry.get("Worker")?.history?.metrics).toBeUndefined();
+
+		await registerPersistedSubagents(registry, sessionFile);
+		expect(registry.get("Worker")?.history?.metrics?.tokens).toBe(30);
+		expect(registry.get("Worker")?.history?.metrics?.requests).toBe(1);
 	});
 });
 

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -1093,9 +1093,9 @@ describe("child system prompt roster", () => {
 		expect(text).toContain("editing auth.ts");
 		expect(text).toContain("IdleReviewer");
 		expect(text).toContain("1 parked peer(s) omitted");
-		expect(text).toContain('status:"parked"');
-		expect(text).toContain("history://");
-		expect(text).toContain("agent://");
+		expect(text).not.toContain("Idle peers are not gone");
+		expect(text).not.toContain("history://");
+		expect(text).not.toContain("agent://");
 		expect(text).not.toContain("ParkedScout");
 		expect(text).not.toContain("secret parked label");
 		expect(text).not.toContain("reviewing classified.diff");

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
-import { executeList } from "@oh-my-pi/pi-coding-agent/tools/hub/messaging";
+import { renderIrcPeerRoster } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { HubTool } from "@oh-my-pi/pi-coding-agent/tools/hub";
+import {
+	DEFAULT_HUB_LIST_LIMIT,
+	executeList,
+	executeSend,
+	MAX_HUB_LIST_LIMIT,
+} from "@oh-my-pi/pi-coding-agent/tools/hub/messaging";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 function sessionHeader(id: string): string {
@@ -15,8 +27,252 @@ function sessionHeader(id: string): string {
 	});
 }
 
+async function writeParkedTranscript(sessionFile: string, id: string, task: string): Promise<void> {
+	await Bun.write(
+		sessionFile,
+		`${[
+			sessionHeader(id),
+			JSON.stringify({
+				type: "session_init",
+				id: `si-${id}`,
+				parentId: null,
+				timestamp: "2026-08-13T17:14:49.000Z",
+				systemPrompt: "review",
+				task,
+				tools: ["read"],
+			}),
+		].join("\n")}\n`,
+	);
+}
+
+function listText(result: { content: Array<{ type: string; text?: string }> }): string {
+	const content = result.content[0];
+	if (content?.type !== "text") throw new Error("Expected text result");
+	const text = content.text;
+	if (typeof text !== "string") throw new Error("Expected text result");
+	return text;
+}
+
+function makeToolSession(registry: AgentRegistry, agentId: string): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		agentRegistry: registry,
+		getAgentId: () => agentId,
+	};
+}
+
 describe("hub list", () => {
-	it("restores persisted peers after the process registry is lost", async () => {
+	it("defaults to running+idle peers and reports parked counts without parked names", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		registry.register({
+			id: "AuthLoader",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			status: "running",
+			activity: "auditing tokens",
+		});
+		registry.register({
+			id: "IdleWorker",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			status: "idle",
+		});
+		registry.register({
+			id: "ParkedScout",
+			displayName: "secret parked label",
+			kind: "sub",
+			session: null,
+			status: "parked",
+			activity: "reviewing classified.diff",
+		});
+
+		const result = await executeList(registry, MAIN_AGENT_ID);
+		if (!result.details) throw new Error("Expected coordination details");
+
+		expect(result.details.peers?.map(peer => peer.id)).toEqual(["AuthLoader", "IdleWorker"]);
+		expect(result.details.counts).toEqual({
+			running: 1,
+			idle: 1,
+			parked: 1,
+			shown: 2,
+			truncated: 0,
+		});
+		const text = listText(result);
+		expect(text).toContain("AuthLoader");
+		expect(text).toContain("IdleWorker");
+		expect(text).toContain("parked 1");
+		expect(text).toContain('status="parked"');
+		expect(text).not.toContain("ParkedScout");
+		expect(text).not.toContain("secret parked label");
+		expect(text).not.toContain("reviewing classified.diff");
+	});
+
+	it("lists parked peers only when status=parked is requested", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		registry.register({ id: "Live", displayName: "task", kind: "sub", session: null, status: "idle" });
+		registry.register({
+			id: "ParkedScout",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			status: "parked",
+		});
+
+		const result = await executeList(registry, MAIN_AGENT_ID, { status: "parked" });
+		if (!result.details) throw new Error("Expected coordination details");
+
+		expect(result.details.peers).toEqual([
+			expect.objectContaining({
+				id: "ParkedScout",
+				status: "parked",
+				parentId: MAIN_AGENT_ID,
+			}),
+		]);
+		expect(result.details.counts).toEqual({
+			running: 0,
+			idle: 1,
+			parked: 1,
+			shown: 1,
+			truncated: 0,
+		});
+		expect(listText(result)).toContain("Parked agents are revived automatically");
+	});
+
+	it("bounds the page and reports truncated without a cursor", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		const extra = 5;
+		for (let index = 0; index < DEFAULT_HUB_LIST_LIMIT + extra; index++) {
+			registry.register({
+				id: `Idle${index}`,
+				displayName: "task",
+				kind: "sub",
+				session: null,
+				status: "idle",
+				lastActivity: index,
+			});
+		}
+
+		const result = await executeList(registry, MAIN_AGENT_ID);
+		if (!result.details) throw new Error("Expected coordination details");
+
+		expect(result.details.peers).toHaveLength(DEFAULT_HUB_LIST_LIMIT);
+		expect(result.details.counts).toEqual({
+			running: 0,
+			idle: DEFAULT_HUB_LIST_LIMIT + extra,
+			parked: 0,
+			shown: DEFAULT_HUB_LIST_LIMIT,
+			truncated: extra,
+		});
+		expect(result.details.peers?.[0]?.id).toBe(`Idle${DEFAULT_HUB_LIST_LIMIT + extra - 1}`);
+		expect(result.details).not.toHaveProperty("cursor");
+		expect(listText(result)).toContain(`truncated ${extra}`);
+	});
+
+	it("clamps an explicit limit so parked archaeology cannot dump hundreds of names", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		const extra = 20;
+		for (let index = 0; index < MAX_HUB_LIST_LIMIT + extra; index++) {
+			registry.register({
+				id: `Parked${index}`,
+				displayName: "task",
+				kind: "sub",
+				session: null,
+				status: "parked",
+				lastActivity: index,
+			});
+		}
+
+		const result = await executeList(registry, MAIN_AGENT_ID, { status: "parked", limit: 500 });
+		if (!result.details) throw new Error("Expected coordination details");
+
+		expect(result.details.peers).toHaveLength(MAX_HUB_LIST_LIMIT);
+		expect(result.details.counts).toEqual({
+			running: 0,
+			idle: 0,
+			parked: MAX_HUB_LIST_LIMIT + extra,
+			shown: MAX_HUB_LIST_LIMIT,
+			truncated: extra,
+		});
+	});
+
+	it("excludes aborted and advisor refs from every list view", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		registry.register({ id: "Worker", displayName: "task", kind: "sub", session: null, status: "idle" });
+		registry.register({
+			id: `${MAIN_AGENT_ID}/advisor`,
+			displayName: "advisor",
+			kind: "advisor",
+			session: null,
+			status: "parked",
+		});
+		registry.register({ id: "Dead", displayName: "task", kind: "sub", session: null, status: "aborted" });
+
+		const listed = await executeList(registry, MAIN_AGENT_ID);
+		const parked = await executeList(registry, MAIN_AGENT_ID, { status: "parked" });
+		if (!listed.details || !parked.details) throw new Error("Expected coordination details");
+
+		expect(listed.details.peers?.map(peer => peer.id)).toEqual(["Worker"]);
+		expect(parked.details.peers).toEqual([]);
+		expect(listed.details.counts).toEqual({
+			running: 0,
+			idle: 1,
+			parked: 0,
+			shown: 1,
+			truncated: 0,
+		});
+	});
+
+	it("schema rejects aborted and advisor list filters", () => {
+		const tool = new HubTool(makeToolSession(new AgentRegistry(), MAIN_AGENT_ID));
+		expect(() => tool.parameters.assert({ op: "list", status: "aborted" })).toThrow();
+		expect(() => tool.parameters.assert({ op: "list", status: "advisor" })).toThrow();
+		expect(tool.parameters.assert({ op: "list", status: "parked" })).toEqual({ op: "list", status: "parked" });
+	});
+
+	it("restores persisted peers after the process registry is lost without leaking them into the default view", async () => {
 		using tempDir = TempDir.createSync("@omp-hub-list-persisted-");
 		const sessionFile = path.join(tempDir.path(), "main.jsonl");
 		const workerSessionFile = path.join(tempDir.path(), "main", "Worker.jsonl");
@@ -49,10 +305,22 @@ describe("hub list", () => {
 			status: "running",
 		});
 
-		const result = await executeList(registry, MAIN_AGENT_ID);
-		if (!result.details) throw new Error("Expected coordination details");
+		const listed = await executeList(registry, MAIN_AGENT_ID);
+		if (!listed.details) throw new Error("Expected coordination details");
+		expect(listed.details.peers).toEqual([]);
+		expect(listed.details.counts).toEqual({
+			running: 0,
+			idle: 0,
+			parked: 1,
+			shown: 0,
+			truncated: 0,
+		});
+		expect(listText(listed)).not.toContain("Worker");
+		expect(registry.get("Worker")?.sessionFile).toBe(workerSessionFile);
 
-		expect(result.details.peers).toEqual([
+		const parked = await executeList(registry, MAIN_AGENT_ID, { status: "parked" });
+		if (!parked.details) throw new Error("Expected coordination details");
+		expect(parked.details.peers).toEqual([
 			expect.objectContaining({
 				id: "Worker",
 				kind: "sub",
@@ -60,10 +328,216 @@ describe("hub list", () => {
 				parentId: MAIN_AGENT_ID,
 			}),
 		]);
-		const content = result.content[0];
-		if (content?.type !== "text") throw new Error("Expected text result");
-		expect(content.text).toContain("Worker");
-		expect(content.text).toContain("parked");
-		expect(registry.get("Worker")?.sessionFile).toBe(workerSessionFile);
+		expect(listText(parked)).toContain("Worker");
+		expect(listText(parked)).toContain("parked");
+	});
+
+	it("counts a disk-only parked sibling when a live sibling is already in memory", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-live-disk-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		const liveSessionFile = path.join(dir, "main", "LiveWorker.jsonl");
+		const parkedSessionFile = path.join(dir, "main", "ParkedScout.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await writeParkedTranscript(parkedSessionFile, "parked", "reviewing classified.diff");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			sessionFile: liveSessionFile,
+			status: "idle",
+		});
+
+		const listed = await executeList(registry, MAIN_AGENT_ID);
+		if (!listed.details) throw new Error("Expected coordination details");
+		expect(listed.details.peers?.map(peer => peer.id)).toEqual(["LiveWorker"]);
+		expect(listed.details.counts).toEqual({
+			running: 0,
+			idle: 1,
+			parked: 1,
+			shown: 1,
+			truncated: 0,
+		});
+		expect(listText(listed)).not.toContain("ParkedScout");
+		expect(listText(listed)).not.toContain("reviewing classified.diff");
+
+		const fromChild = await executeList(registry, "LiveWorker");
+		if (!fromChild.details) throw new Error("Expected coordination details");
+		expect(fromChild.details.counts?.parked).toBe(1);
+		expect(fromChild.details.peers?.map(peer => peer.id)).not.toContain("ParkedScout");
+	});
+
+	it("clamps a positive fractional limit to at least one row", async () => {
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		registry.register({ id: "IdleWorker", displayName: "task", kind: "sub", session: null, status: "idle" });
+
+		const result = await executeList(registry, MAIN_AGENT_ID, { limit: 0.9 });
+		if (!result.details) throw new Error("Expected coordination details");
+		expect(result.details.peers).toHaveLength(1);
+		expect(result.details.counts?.shown).toBe(1);
+		expect(result.details.counts?.truncated).toBe(0);
+	});
+
+	it("send still revives a known parked id omitted from the default list", async () => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+		try {
+			const registry = AgentRegistry.global();
+			registry.register({
+				id: MAIN_AGENT_ID,
+				displayName: MAIN_AGENT_ID,
+				kind: "main",
+				session: null,
+				status: "running",
+			});
+			registry.register({ id: "Sleeper", displayName: "task", kind: "sub", session: null, status: "parked" });
+			const delivered: string[] = [];
+			const revived = {
+				isStreaming: false,
+				deliverIrcMessage: async (msg: { body: string }) => {
+					delivered.push(msg.body);
+					return "woken";
+				},
+			} as unknown as AgentSession;
+			AgentLifecycleManager.global().adopt("Sleeper", {
+				idleTtlMs: 0,
+				revive: async () => revived,
+			});
+
+			const listed = await executeList(registry, MAIN_AGENT_ID);
+			expect(listed.details?.peers?.map(peer => peer.id)).not.toContain("Sleeper");
+
+			const sent = await executeSend(
+				{ registry, senderId: MAIN_AGENT_ID, settings: Settings.isolated() },
+				{ to: "Sleeper", message: "wake up" },
+			);
+			expect(sent.isError).toBeFalsy();
+			expect(sent.details?.receipts).toEqual([{ to: "Sleeper", outcome: "revived" }]);
+			expect(delivered).toEqual(["wake up"]);
+			expect(registry.get("Sleeper")?.status).not.toBe("parked");
+		} finally {
+			AgentRegistry.resetGlobalForTests();
+			AgentLifecycleManager.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		}
+	});
+});
+
+describe("child system prompt roster", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+	});
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("enumerates running+idle peers and one parked count, never parked names or task labels", async () => {
+		const registry = AgentRegistry.global();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "implementer",
+			kind: "sub",
+			session: null,
+			status: "running",
+			activity: "editing auth.ts",
+		});
+		registry.register({
+			id: "IdleReviewer",
+			displayName: "reviewer",
+			kind: "sub",
+			session: null,
+			status: "idle",
+		});
+		registry.register({
+			id: "ParkedScout",
+			displayName: "secret parked label",
+			kind: "sub",
+			session: null,
+			status: "parked",
+			activity: "reviewing classified.diff",
+		});
+		registry.register({
+			id: `${MAIN_AGENT_ID}/advisor`,
+			displayName: "advisor",
+			kind: "advisor",
+			session: null,
+			status: "parked",
+			activity: "advisor-only gist",
+		});
+
+		const text = await renderIrcPeerRoster("Child");
+		expect(text).toContain("LiveWorker");
+		expect(text).toContain("editing auth.ts");
+		expect(text).toContain("IdleReviewer");
+		expect(text).toContain("1 parked peer(s) omitted");
+		expect(text).toContain('status:"parked"');
+		expect(text).toContain("history://");
+		expect(text).toContain("agent://");
+		expect(text).not.toContain("ParkedScout");
+		expect(text).not.toContain("secret parked label");
+		expect(text).not.toContain("reviewing classified.diff");
+		expect(text).not.toContain("advisor-only gist");
+	});
+
+	it("counts a disk-only parked sibling from the root tree without naming it", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-roster-live-disk-");
+		const dir = tempDir.path();
+		const sessionFile = path.join(dir, "main.jsonl");
+		const liveSessionFile = path.join(dir, "main", "LiveWorker.jsonl");
+		const parkedSessionFile = path.join(dir, "main", "ParkedScout.jsonl");
+		await Bun.write(sessionFile, `${sessionHeader("main")}\n`);
+		await writeParkedTranscript(parkedSessionFile, "parked", "reviewing classified.diff");
+
+		const registry = AgentRegistry.global();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+		registry.register({
+			id: "LiveWorker",
+			displayName: "task",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: null,
+			sessionFile: liveSessionFile,
+			status: "idle",
+		});
+
+		const text = await renderIrcPeerRoster("LiveWorker", registry);
+		expect(text).toContain("1 parked peer(s) omitted");
+		expect(text).toContain("`Main`");
+		expect(text).not.toContain("ParkedScout");
+		expect(text).not.toContain("reviewing classified.diff");
 	});
 });

--- a/packages/coding-agent/test/tools/irc-renderer.test.ts
+++ b/packages/coding-agent/test/tools/irc-renderer.test.ts
@@ -266,26 +266,58 @@ describe("hubToolRenderer list", () => {
 		expect(row).toContain("auditing the token refresh path");
 	});
 
-	it("uses details.counts when the page is empty but parked peers exist", async () => {
+	it("renders supplied totals on an empty filtered page whenever any roster count is nonzero", async () => {
 		const uiTheme = await theme();
-		const rendered = lines(
-			hubToolRenderer.renderResult(
-				{
-					content: [{ type: "text", text: "" }],
-					details: {
-						op: "list",
-						from: "Main",
-						peers: [],
-						counts: { running: 0, idle: 0, parked: 3, shown: 0, truncated: 0 },
-					} satisfies CoordinationDetails,
-				},
-				{ expanded: false, isPartial: false },
-				uiTheme,
-				{ op: "list" },
-			),
-		);
-		expect(rendered[0]).toContain("3 parked");
-		expect(rendered[0]).not.toContain("no other agents");
+		const cases: Array<{
+			counts: { running: number; idle: number; parked: number; shown: number; truncated: number };
+			contains: string[];
+			absent?: string[];
+		}> = [
+			{
+				counts: { running: 2, idle: 0, parked: 0, shown: 0, truncated: 0 },
+				contains: ["2 running", "0 idle", "0 parked"],
+				absent: ["no other agents"],
+			},
+			{
+				counts: { running: 0, idle: 4, parked: 0, shown: 0, truncated: 0 },
+				contains: ["0 running", "4 idle", "0 parked"],
+				absent: ["no other agents"],
+			},
+			{
+				counts: { running: 0, idle: 0, parked: 3, shown: 0, truncated: 0 },
+				contains: ["0 running", "0 idle", "3 parked"],
+				absent: ["no other agents"],
+			},
+			{
+				counts: { running: 1, idle: 2, parked: 0, shown: 0, truncated: 3 },
+				contains: ["1 running", "2 idle", "0 parked", "3 truncated"],
+				absent: ["no other agents"],
+			},
+			{
+				counts: { running: 0, idle: 0, parked: 0, shown: 0, truncated: 0 },
+				contains: ["no other agents"],
+			},
+		];
+		for (const testCase of cases) {
+			const rendered = lines(
+				hubToolRenderer.renderResult(
+					{
+						content: [{ type: "text", text: "" }],
+						details: {
+							op: "list",
+							from: "Main",
+							peers: [],
+							counts: testCase.counts,
+						} satisfies CoordinationDetails,
+					},
+					{ expanded: false, isPartial: false },
+					uiTheme,
+					{ op: "list" },
+				),
+			);
+			for (const snippet of testCase.contains) expect(rendered[0]).toContain(snippet);
+			for (const snippet of testCase.absent ?? []) expect(rendered[0]).not.toContain(snippet);
+		}
 	});
 });
 

--- a/packages/coding-agent/test/tools/irc-renderer.test.ts
+++ b/packages/coding-agent/test/tools/irc-renderer.test.ts
@@ -265,6 +265,28 @@ describe("hubToolRenderer list", () => {
 		expect(row).toContain("Auth-flow security reviewer");
 		expect(row).toContain("auditing the token refresh path");
 	});
+
+	it("uses details.counts when the page is empty but parked peers exist", async () => {
+		const uiTheme = await theme();
+		const rendered = lines(
+			hubToolRenderer.renderResult(
+				{
+					content: [{ type: "text", text: "" }],
+					details: {
+						op: "list",
+						from: "Main",
+						peers: [],
+						counts: { running: 0, idle: 0, parked: 3, shown: 0, truncated: 0 },
+					} satisfies CoordinationDetails,
+				},
+				{ expanded: false, isPartial: false },
+				uiTheme,
+				{ op: "list" },
+			),
+		);
+		expect(rendered[0]).toContain("3 parked");
+		expect(rendered[0]).not.toContain("no other agents");
+	});
 });
 
 describe("hubToolRenderer body truncation", () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -621,7 +621,7 @@ describe("IRC", () => {
 			expect(tool.interruptible({ op: "send", await: true })).toBe(false);
 		});
 
-		it("op=list includes parked peers, unread counts, and parent ids", async () => {
+		it("op=list defaults to live peers and reports parked counts without parked names", async () => {
 			const sub = makeFakeSession();
 			registry.register({
 				id: "0-AuthLoader",
@@ -642,10 +642,18 @@ describe("IRC", () => {
 			expect(details?.op).toBe("list");
 			expect(details?.peers).toMatchObject([
 				{ id: "0-AuthLoader", status: "running", parentId: "0-Main", unread: 1 },
-				{ id: "0-Parked", status: "parked", unread: 0 },
 			]);
+			expect(details?.peers?.some(peer => peer.id === "0-Parked")).toBe(false);
+			expect(details?.counts).toEqual({
+				running: 1,
+				idle: 0,
+				parked: 1,
+				shown: 1,
+				truncated: 0,
+			});
 			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
-			expect(text).toContain("Parked agents are revived automatically");
+			expect(text).toContain('status="parked"');
+			expect(text).not.toContain("0-Parked");
 		});
 
 		it("op=list hides advisor-kind refs from the peer roster", async () => {


### PR DESCRIPTION
## Problem
Long-lived sessions rehydrate every historical parked subagent. Bare hub list and every child system prompt then enumerate all parked names/activity. A live case reached 660 peers: 13 actionable and 647 parked.

## Change
- default hub list shows running + idle peers only, bounded to 32
- optional status and limit expose bounded parked archaeology explicitly
- counts report running, idle, parked, shown, and truncated
- child prompts enumerate actionable peers plus a parked count, never parked names
- one latched root-session restore keeps disk-only parked counts truthful
- direct send/revive, history://, agent://, Agent Hub, advisors, and tombstones stay unchanged

## Proof
- focused coding-agent tests: 147 passed
- bun check: passed across all TS/Rust workspaces
- source-mode omp --smoke-test: passed
- independent adversarial review: passed after fixing disk-only sibling counts, fractional limits, and empty-page rendering

No retention, GC, transcript deletion, or retire API is added.