### PR TITLE
fix(tui): skip append resize replay on height-only grow

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed graceful terminal shutdown leaving eligible finalized output in the mutable viewport instead of retiring it before shell handoff.
 - Fixed a latched destructive scrollback rebuild (settled rebuild-mode resize, display reset) erasing and re-streaming the whole transcript during stop; the latch is dropped and shutdown writes only the un-retired tail.
+- Fixed `append` resize-scrollback mode duplicating committed history (including the editor/status rows) in native scrollback after a height-only terminal resize; the width-refresh replay now runs only when the width actually changed ([#9671](https://github.com/can1357/oh-my-pi/issues/9671)).
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2260,10 +2260,16 @@ export class TUI extends Container {
 			this.#altActive = false;
 			this.#altMouseTrackingActive = false;
 			this.#altPreviousLines = [];
-			// The alt buffer restore put the pre-overlay normal screen back; a
-			// geometry change while covered invalidates the diff baseline and the
-			// writer's dimension check forces the full anchored rewrite.
+			// The alt-buffer restore put the pre-overlay normal screen back. If
+			// that buffer resized while covered, its cursor moved with width
+			// rewrap or a height-grow scrollback pull, while our viewport anchor
+			// stayed frozen. Recover the restored cursor position before any
+			// provider repaint can overwrite history at the stale row.
 			if (width !== this.#altEnterWidth || height !== this.#altEnterHeight) {
+				if (this.#frameProvider !== undefined) {
+					this.#beginResizeAnchorProbe();
+					return;
+				}
 				this.#forceViewportRepaintOnNextRender = true;
 			}
 		} else if (wantMouseTracking !== this.#altMouseTrackingActive) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2008,6 +2008,14 @@ export class TUI extends Container {
 	 * Append mode leaves the terminal's prior copy in place and writes a
 	 * current-width copy below it. Rebuild mode routes through the destructive
 	 * reset latch so ED3 removes stale history before the same replay.
+	 *
+	 * The append replay only exists to refresh width-shredded scrollback: a
+	 * width change leaves the terminal's committed history wrapped at the old
+	 * width, so the copy below it is the intended fresh current-width render. A
+	 * height-only change reflows nothing (the terminal merely pulls rows back
+	 * out of scrollback), so replaying would write an identical duplicate — the
+	 * editor/status chrome included — below the retained copy. Skip it, matching
+	 * the `widthChanged`-gated commit-ledger logic in {@link #doRender}.
 	 */
 	#prepareResizeReplay(width: number, height: number): void {
 		const size = `${width}x${height}`;
@@ -2030,6 +2038,7 @@ export class TUI extends Container {
 			this.#prepareForcedRender(true);
 			return;
 		}
+		if (width === this.#previousWidth) return;
 		provider.beginHistoryReplay();
 		this.#forceViewportRepaintOnNextRender = true;
 	}

--- a/packages/tui/test/history-frame-plan.test.ts
+++ b/packages/tui/test/history-frame-plan.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { type TerminalFramePlan, type TerminalFrameProvider, TUI, type ViewportSize } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	type TerminalFramePlan,
+	type TerminalFrameProvider,
+	TUI,
+	type ViewportSize,
+} from "@oh-my-pi/pi-tui";
 import { VirtualRenderScheduler } from "./virtual-render-scheduler";
 import { VirtualTerminal } from "./virtual-terminal";
 
@@ -22,6 +28,12 @@ class Provider implements TerminalFrameProvider {
 	acknowledgeHistory(id: number): void {
 		this.acknowledged.push(id);
 		this.plan = { viewport: this.plan.viewport };
+	}
+}
+
+class FullscreenOverlay implements Component {
+	render(): string[] {
+		return ["fullscreen overlay"];
 	}
 }
 
@@ -72,14 +84,19 @@ class ResizeScheduler {
 class WidthReplayProvider implements TerminalFrameProvider {
 	#nextHistoryId = 1;
 	#retired = false;
+	readonly #historyRows: readonly string[];
 	resetCount = 0;
+
+	constructor(historyRows: readonly string[] = ["history-one", "history-two"]) {
+		this.#historyRows = historyRows;
+	}
 
 	renderFrame(viewport: ViewportSize): TerminalFramePlan {
 		const width = viewport.columns;
 		return {
 			history: this.#retired
 				? undefined
-				: { id: this.#nextHistoryId, rows: [`history-one@${width}`, `history-two@${width}`] },
+				: { id: this.#nextHistoryId, rows: this.#historyRows.map(row => `${row}@${width}`) },
 			viewport: [`editor@${width}`],
 		};
 	}
@@ -353,6 +370,32 @@ describe("terminal frame plans", () => {
 		const resized = plainBuffer(terminal);
 		expect(provider.resetCount).toBe(0);
 		expect(resized.filter(row => row === "history-one@20")).toEqual(["history-one@20"]);
+		tui.stop();
+	});
+
+	it("re-anchors retained history after a height grow behind a fullscreen overlay", async () => {
+		const history = Array.from({ length: 20 }, (_value, index) => `history-${index}`);
+		const terminal = new CountingTerminal(20, 4);
+		const provider = new WidthReplayProvider(history);
+		const renderScheduler = new VirtualRenderScheduler();
+		const tui = new TUI(terminal, undefined, { renderScheduler });
+		tui.setResizeScrollback("append");
+		tui.setFrameProvider(provider);
+		tui.start();
+		await renderScheduler.settle(terminal);
+
+		const overlay = tui.showOverlay(new FullscreenOverlay(), { fullscreen: true });
+		await renderScheduler.settle(terminal);
+		terminal.resize(20, 12);
+		await renderScheduler.settle(terminal);
+		terminal.writes.length = 0;
+		overlay.hide();
+		await renderScheduler.settle(terminal);
+
+		expect(terminal.writes.join("")).toContain("\x1b[6n");
+
+		expect(provider.resetCount).toBe(0);
+		expect(plainBuffer(terminal).filter(Boolean)).toEqual([...history.map(row => `${row}@20`), "editor@20"]);
 		tui.stop();
 	});
 

--- a/packages/tui/test/history-frame-plan.test.ts
+++ b/packages/tui/test/history-frame-plan.test.ts
@@ -335,6 +335,27 @@ describe("terminal frame plans", () => {
 		tui.stop();
 	});
 
+	it("does not duplicate current-width history on a height-only grow", async () => {
+		const terminal = new VirtualTerminal(20, 2);
+		const provider = new WidthReplayProvider();
+		const renderScheduler = new VirtualRenderScheduler();
+		const tui = new TUI(terminal, undefined, { renderScheduler });
+		tui.setResizeScrollback("append");
+		tui.setFrameProvider(provider);
+		tui.start();
+		await renderScheduler.settle(terminal);
+
+		expect(plainBuffer(terminal)).toContain("history-one@20");
+
+		terminal.resize(20, 6); // height-only grow: width unchanged, nothing rewraps
+		await renderScheduler.advance(terminal, 160);
+
+		const resized = plainBuffer(terminal);
+		expect(provider.resetCount).toBe(0);
+		expect(resized.filter(row => row === "history-one@20")).toEqual(["history-one@20"]);
+		tui.stop();
+	});
+
 	it("rebuilds current-width history without retaining stale rows", async () => {
 		const terminal = new VirtualTerminal(20, 2);
 		const provider = new WidthReplayProvider();


### PR DESCRIPTION
## Repro
With `resizeScrollback: "append"` and a session long enough to fill the screen, expanding the terminal to a much taller height (height-only resize, width unchanged) duplicates committed history in native scrollback — the editor/status chrome appears twice. Reproduced against the real `TUI` + `VirtualTerminal` harness: 20x2 terminal, history committed at width 20, then a settled height-only grow to `20x6`. Run: `cd packages/tui && bun test test/history-frame-plan.test.ts -t "height-only grow"`.

## Cause
`TUI.#prepareResizeReplay` (`packages/tui/src/tui.ts`) called `provider.beginHistoryReplay()` on any settled geometry change in `append` mode, re-offering all committed history as a fresh current-width copy below the retained one. That replay exists solely to refresh width-shredded scrollback (commit `43ab417`): a width change leaves the terminal's committed history wrapped at the old width, so the copy below is the intended fresh render. A height-only grow reflows nothing — the terminal merely pulls rows back out of scrollback — so the replay wrote an identical duplicate. The surrounding `#doRender` commit-ledger logic already encodes "only a width change rewraps" via `widthChanged` guards (commit `947d681`), but `#prepareResizeReplay` never got that guard.

## Fix
- Guard the `append` replay in `#prepareResizeReplay` with `if (width === this.#previousWidth) return;`, placed after the `rebuild` branch so it scopes to append only.
- Width changes still replay (stale-width refresh); `rebuild` mode (ED3 clear before replay) is untouched.
- Added regression test `does not duplicate current-width history on a height-only grow` in `packages/tui/test/history-frame-plan.test.ts` — asserts `resetCount === 0` and a single `history-one@20` after a `20x2 -> 20x6` grow.

## Verification
`cd packages/tui && bun test test/history-frame-plan.test.ts` → 10 pass, 0 fail (new test fails without the guard: `resetCount` Expected 0, Received 1). Full package suite `cd packages/tui && bun test` → 1303 pass, 0 fail. The existing width-replay and rebuild tests confirm those paths are unchanged.

Fixes #9671