### PR TITLE
fix(task): preserve successful subagent yield across deferred cleanup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed `agent()` (and other subagent spawns) discarding a valid terminal `yield` as `cleanup exceeded N ms` when teardown (e.g. a slow advisor review) drained past the cleanup deadline; a successful run now keeps its result and the late cleanup is handed off asynchronously ([#9670](https://github.com/can1357/oh-my-pi/issues/9670)).
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3377,8 +3377,16 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			let deferredSessionShutdown: Promise<void> | undefined;
 			const deferCleanup = (completion: Promise<void>): void => {
 				lateCleanups.push(completion);
+				// The run's terminal outcome (a successful `yield`, or a genuine
+				// abort) is already settled; `aborted` reflects the authoritative
+				// run status after the abort-signal reconciliation below. Late
+				// cleanup (advisor drain, session disposal, owner-job reaping)
+				// draining past the deadline is orthogonal — it MUST NOT downgrade
+				// a non-aborted run to `aborted`, which discarded valid `agent()`
+				// results (issue #9670). The deferred work still completes
+				// asynchronously via `lateCleanups`/`onCleanupDeferred`.
+				if (!aborted) return;
 				exitCode = 1;
-				aborted = true;
 				abortReasonText = `cleanup exceeded ${cleanupGraceMs} ms`;
 				error ??= `Task aborted. Cleanup did not finish within ${cleanupGraceMs} ms. ${cleanupChangeStatus}`;
 			};

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -207,13 +207,12 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 			},
 		});
 		opts.onSubprocessResult?.(result);
-		// Deferred cleanup no longer implies an aborted run: a successful `yield`
-		// whose teardown drains past the grace window returns exitCode 0 with a
-		// pending `deferredCleanup` (issue #9670). Capture branch/patch here
-		// regardless — the isolation worktree is still on disk (its teardown is
-		// deferred to the `finally` below, which waits for `deferredCleanup`
-		// before removing it), so skipping capture would let the `finally`
-		// delete the agent's edits and report a false, changeless completion.
+		// A successful result cannot be captured while deferred owner jobs or
+		// shutdown hooks may still write the worktree. Failed runs skip capture,
+		// so their cleanup remains asynchronous.
+		if (deferredCleanup && result.exitCode === 0) {
+			await deferredCleanup;
+		}
 		if (opts.mergeMode === "branch" && result.exitCode === 0) {
 			try {
 				const commitResult = await commitToBranch(

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -207,7 +207,13 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 			},
 		});
 		opts.onSubprocessResult?.(result);
-		if (deferredCleanup) return result;
+		// Deferred cleanup no longer implies an aborted run: a successful `yield`
+		// whose teardown drains past the grace window returns exitCode 0 with a
+		// pending `deferredCleanup` (issue #9670). Capture branch/patch here
+		// regardless — the isolation worktree is still on disk (its teardown is
+		// deferred to the `finally` below, which waits for `deferredCleanup`
+		// before removing it), so skipping capture would let the `finally`
+		// delete the agent's edits and report a false, changeless completion.
 		if (opts.mergeMode === "branch" && result.exitCode === 0) {
 			try {
 				const commitResult = await commitToBranch(

--- a/packages/coding-agent/test/task/executor-async-quiescence.test.ts
+++ b/packages/coding-agent/test/task/executor-async-quiescence.test.ts
@@ -307,7 +307,7 @@ describe("runSubprocess async quiescence fresh-yield contract", () => {
 		expect(result.output).toContain("done");
 	});
 
-	it("returns an aborted result after cleanup grace and waits for every late resource", async () => {
+	it("preserves a successful yield across deferred cleanup and waits for every late resource", async () => {
 		const abortStarted = Promise.withResolvers<void>();
 		const abortGate = Promise.withResolvers<void>();
 		const disposeGate = Promise.withResolvers<void>();
@@ -362,12 +362,12 @@ describe("runSubprocess async quiescence fresh-yield contract", () => {
 		// exercises the deadline/deferred-ownership transition without sleeping.
 
 		const result = await run;
-		expect(result.exitCode).toBe(1);
-		expect(result.aborted).toBe(true);
-		expect(result.abortReason).toBe("cleanup exceeded 0 ms");
-		expect(result.error).toBe(
-			"Task aborted. Cleanup did not finish within 0 ms. This task was not isolated, so its changes may remain in the working directory.",
-		);
+		// The run yielded successfully; a teardown that drains past the cleanup
+		// deadline is handed off asynchronously and MUST NOT overwrite the
+		// successful outcome with an aborted status (issue #9670).
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.abortReason).toBeUndefined();
 		expect(result.output).toContain("yielded output");
 		expect(result.usage?.totalTokens).toBe(7);
 		expect(lateJobId).toBeDefined();

--- a/packages/coding-agent/test/task/executor-deferred-cleanup.test.ts
+++ b/packages/coding-agent/test/task/executor-deferred-cleanup.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Deferred-cleanup outcome contract (issue #9670).
+ *
+ * When a subagent's teardown (advisor catch-up, session disposal, owner-job
+ * reaping) drains past the shared cleanup deadline, `runSubprocess` hands the
+ * remaining work off asynchronously. That hand-off MUST NOT rewrite the run's
+ * terminal outcome: a successful `yield` stays a success, and a genuinely
+ * aborted run stays aborted. Previously the deferral unconditionally forced
+ * `aborted`/exitCode 1, so a valid `agent()` result was discarded as
+ * `RuntimeError: cleanup exceeded N ms`.
+ *
+ * The deferred-cleanup path is exercised deterministically with a blocking
+ * teardown and a zero grace, so no wall-clock timers are needed.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+const baseAgent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+
+function assistantStop(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Minimal mock session whose teardown (`abort`/`dispose`) can be blocked to
+ * force the deferred-cleanup path, and whose first prompt runs `onPrompt` to
+ * either yield or trigger a caller-signal abort.
+ */
+function mockSession(opts: {
+	onPrompt: (emit: (event: AgentSessionEvent) => void) => void;
+	abort?: () => Promise<void>;
+	dispose?: () => Promise<void>;
+}): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const state = { messages: [] as AssistantMessage[] };
+	const emit = (event: AgentSessionEvent) => {
+		for (const l of [...listeners]) l(event);
+	};
+	return {
+		state,
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["read", "yield"],
+		getEnabledToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (l: (event: AgentSessionEvent) => void) => {
+			listeners.push(l);
+			return () => {
+				const i = listeners.indexOf(l);
+				if (i >= 0) listeners.splice(i, 1);
+			};
+		},
+		prompt: async () => {
+			const msg = assistantStop("done");
+			state.messages.push(msg);
+			emit({ type: "message_end", message: msg } as AgentSessionEvent);
+			opts.onPrompt(emit);
+		},
+		waitForIdle: async () => {},
+		prepareForHeadlessAdvisorDrain: () => {},
+		waitForAdvisorCatchup: async () => true,
+		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
+		hasPendingAsyncWork: () => false,
+		getAsyncJobSnapshot: () => ({ running: [], recent: [] }),
+		settleAsyncWork: async () => {},
+		abort: opts.abort ?? (async () => {}),
+		dispose: opts.dispose ?? (async () => {}),
+		setIrcWakeTurnObserver: () => {},
+		subscribeRunState: () => () => {},
+	} as unknown as AgentSession;
+}
+
+function emitYield(emit: (event: AgentSessionEvent) => void, data: unknown): void {
+	emit({
+		type: "tool_execution_end",
+		toolCallId: "yield-1",
+		toolName: "yield",
+		result: {
+			content: [{ type: "text", text: "Result submitted." }],
+			details: { status: "success", data },
+		},
+	} as AgentSessionEvent);
+}
+
+describe("runSubprocess deferred cleanup outcome (issue #9670)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("preserves a successful yield when disposal is deferred past the cleanup deadline", async () => {
+		const disposeGate = Promise.withResolvers<void>();
+		const session = mockSession({
+			onPrompt: emit => emitYield(emit, { ok: true }),
+			// Disposal never settles within the (zero) grace window.
+			dispose: () => disposeGate.promise,
+		});
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+			session,
+			extensionsResult: {} as unknown as LoadExtensionsResult,
+			setToolUIContext: () => {},
+			eventBus: new EventBus(),
+		} as CreateAgentSessionResult);
+
+		let deferredCleanup: Promise<void> | undefined;
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do the work",
+			index: 0,
+			id: "issue-9670-success",
+			keepAlive: false,
+			cleanupGraceMs: 0,
+			onCleanupDeferred: completion => {
+				deferredCleanup = completion;
+			},
+		});
+
+		// The deferred teardown must not overwrite the successful yield.
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.abortReason).toBeUndefined();
+		expect(result.error).toBeUndefined();
+		expect(result.output).toContain('"ok": true');
+		// The teardown was still handed off, not dropped.
+		expect(deferredCleanup).toBeDefined();
+		disposeGate.resolve();
+		await deferredCleanup;
+	});
+
+	it("keeps a genuinely aborted run aborted when its cleanup is deferred", async () => {
+		const controller = new AbortController();
+		const abortGate = Promise.withResolvers<void>();
+		const session = mockSession({
+			// The caller cancels mid-run before any yield: a genuine abort.
+			onPrompt: () => controller.abort(),
+			// The session's abort cleanup never settles within the grace window.
+			abort: () => abortGate.promise,
+		});
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+			session,
+			extensionsResult: {} as unknown as LoadExtensionsResult,
+			setToolUIContext: () => {},
+			eventBus: new EventBus(),
+		} as CreateAgentSessionResult);
+
+		let deferredCleanup: Promise<void> | undefined;
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do the work",
+			index: 0,
+			id: "issue-9670-aborted",
+			keepAlive: false,
+			signal: controller.signal,
+			cleanupGraceMs: 0,
+			onCleanupDeferred: completion => {
+				deferredCleanup = completion;
+			},
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(result.exitCode).toBe(1);
+		expect(result.abortReason).toBe("cleanup exceeded 0 ms");
+		expect(deferredCleanup).toBeDefined();
+		abortGate.resolve();
+		await deferredCleanup;
+	});
+});

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -285,6 +285,71 @@ describe("runIsolatedSubprocess", () => {
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("captures a successful yield's patch when child cleanup is deferred (issue #9670)", async () => {
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolation-defer-ok-"));
+		tempRoots.push(artifactsDir);
+		const rootPatch = "diff --git a/task.txt b/task.txt\n--- a/task.txt\n+++ b/task.txt\n@@ -1 +1 @@\n-old\n+new\n";
+		const cleanupGate = Promise.withResolvers<void>();
+		const baseline = {
+			root: {
+				repoRoot: "/repo",
+				headCommit: "base",
+				staged: "",
+				unstaged: "",
+				untracked: [],
+				untrackedPatch: "",
+			},
+			nested: [],
+		};
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: "/repo/isolated",
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		// A successful yield whose teardown drains past the grace window returns
+		// exitCode 0 with a pending deferred cleanup.
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			options.onCleanupDeferred?.(cleanupGate.promise);
+			return result({ id: "DeferredSuccess", exitCode: 0 });
+		});
+		const captureSpy = vi.spyOn(worktreeModule, "captureDeltaPatch").mockResolvedValue({
+			rootPatch,
+			nestedPatches: [],
+		});
+		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
+
+		const outcome = await runIsolatedSubprocess({
+			baseOptions: {
+				cwd: "/repo",
+				agent: { name: "task", description: "Task agent", systemPrompt: "test", source: "bundled" },
+				task: "Do work",
+				index: 0,
+				id: "DeferredSuccess",
+			},
+			context: { repoRoot: "/repo", baseline },
+			preferredBackend: undefined,
+			agentId: "DeferredSuccess",
+			mergeMode: "patch",
+			artifactsDir,
+			buildFailureResult: err => result({ exitCode: 1, error: String(err) }),
+		});
+
+		const patchPath = path.join(artifactsDir, "DeferredSuccess.patch");
+		// The successful result is preserved and its work captured, not discarded.
+		expect(outcome.exitCode).toBe(0);
+		expect(outcome.patchPath).toBe(patchPath);
+		expect(await Bun.file(patchPath).text()).toBe(rootPatch);
+		expect(captureSpy).toHaveBeenCalledWith("/repo/isolated", baseline);
+		// Worktree teardown stays deferred until the late cleanup settles.
+		expect(cleanupSpy).not.toHaveBeenCalled();
+		cleanupGate.resolve();
+		await cleanupGate.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("observes real child usage before fallible isolation cleanup", async () => {
 		const childResult = result({
 			exitCode: 1,

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -319,7 +319,7 @@ describe("runIsolatedSubprocess", () => {
 		});
 		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
 
-		const outcome = await runIsolatedSubprocess({
+		const run = runIsolatedSubprocess({
 			baseOptions: {
 				cwd: "/repo",
 				agent: { name: "task", description: "Task agent", systemPrompt: "test", source: "bundled" },
@@ -335,16 +335,18 @@ describe("runIsolatedSubprocess", () => {
 			buildFailureResult: err => result({ exitCode: 1, error: String(err) }),
 		});
 
+		// Capture waits until every deferred writer has settled.
+		await Promise.resolve();
+		expect(captureSpy).not.toHaveBeenCalled();
+		expect(cleanupSpy).not.toHaveBeenCalled();
+		cleanupGate.resolve();
+		const outcome = await run;
+
 		const patchPath = path.join(artifactsDir, "DeferredSuccess.patch");
-		// The successful result is preserved and its work captured, not discarded.
 		expect(outcome.exitCode).toBe(0);
 		expect(outcome.patchPath).toBe(patchPath);
 		expect(await Bun.file(patchPath).text()).toBe(rootPatch);
 		expect(captureSpy).toHaveBeenCalledWith("/repo/isolated", baseline);
-		// Worktree teardown stays deferred until the late cleanup settles.
-		expect(cleanupSpy).not.toHaveBeenCalled();
-		cleanupGate.resolve();
-		await cleanupGate.promise;
 		await Promise.resolve();
 		await Promise.resolve();
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Repro
A subagent submits a schema-valid terminal `yield` (`details.status: success`), then its teardown — advisor catch-up, session disposal, or owner-job reaping — drains past the shared cleanup deadline (PR #9506's advisor catch-up consuming the window is one real-world cause). The run's successful result is overwritten with an aborted status, and the eval `agent()` bridge throws `RuntimeError: cleanup exceeded 10000 ms`, discarding the submitted value. Reproduced with `bun test test/task/executor-deferred-cleanup.test.ts`: a successful yield plus a blocking dispose at `cleanupGraceMs=0` returned `exitCode=1`/`aborted=true` instead of the yielded value.

## Cause
`runSubprocess`'s `finally` block in `packages/coding-agent/src/task/executor.ts` defines `deferCleanup()`, which unconditionally set `exitCode=1`, `aborted=true`, and `abortReason="cleanup exceeded N ms"` whenever late cleanup was handed off. That conflates "cleanup drained slowly" with "run aborted" — introduced to bound a genuinely *hanging* teardown, but it also clobbered runs that had already produced a valid terminal `yield`. `finalizeRunResult()` then reports `wasAborted` from `done.aborted`, and `agent-bridge.ts:168` (`if (result.exitCode !== 0 || result.error || result.aborted)`) throws, so the valid payload is lost.

## Fix
- `deferCleanup()` now keys the outcome downgrade on the authoritative run status (`aborted`, already reconciled from `monitor.isAbortedRun()` in the preceding abort-signal block) instead of mutating unconditionally. A non-aborted run keeps its result; a genuinely aborted run still reports aborted with the cleanup reason.
- The deferred work is still handed off asynchronously via `lateCleanups`/`onCleanupDeferred`/`trackLateCleanup` — only the visible run outcome is preserved.
- Retargeted the `executor-async-quiescence` test that encoded the old "aborted after cleanup grace" contract to assert the successful yield is preserved while late resources are still owned and awaited.
- Added `executor-deferred-cleanup.test.ts` covering both branches: a deferred-teardown success stays a success, and a caller-signal abort with a blocked teardown stays aborted.

## Verification
`bun test test/task test/eval/agent-bridge.test.ts test/eval/agent-bridge-policy.test.ts` — 436 pass, 0 fail. `bun check` — clean. Fixes #9670