### PR TITLE
fix(prompting): prefer physical Windows GPUs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed Windows workstation context reporting first-listed virtual display adapters instead of the physical GPU ([#9675](https://github.com/can1357/oh-my-pi/issues/9675)).
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -164,13 +164,18 @@ function renderActiveRepoContextPrompt(activeRepoContext: ActiveRepoContext | nu
 		.trim();
 }
 
-function parseWmicTable(output: string, header: string): string | null {
-	const lines = output
+function parseWindowsGpuModel(output: string): string | null {
+	const adapters = output
 		.split("\n")
 		.map(line => line.trim())
-		.filter(Boolean);
-	const filtered = lines.filter(line => line.toLowerCase() !== header.toLowerCase());
-	return filtered[0] ?? null;
+		.filter(line => Boolean(line) && line.toLowerCase() !== "name");
+	const physicalAdapters = adapters.filter(adapter => !/\b(?:virtual|mirror|remote|citrix)\b/i.test(adapter));
+	return (
+		physicalAdapters.find(adapter => /\b(?:nvidia|amd|radeon|intel)\b/i.test(adapter)) ??
+		physicalAdapters[0] ??
+		adapters[0] ??
+		null
+	);
 }
 
 const SYSTEM_PROMPT_PREP_TIMEOUT_MS = 5000;
@@ -224,7 +229,7 @@ async function getGpuModel(): Promise<string | null> {
 	switch (process.platform) {
 		case "win32": {
 			const output = await runGpuProbe(["wmic", "path", "win32_VideoController", "get", "name"]);
-			return output ? parseWmicTable(output, "Name") : null;
+			return output ? parseWindowsGpuModel(output) : null;
 		}
 		case "linux": {
 			const output = await runGpuProbe(["lspci"]);

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -282,6 +282,14 @@ function getTerminalName(): string | undefined {
 	return term ?? undefined;
 }
 
+/**
+ * On-disk cache schema version. Bumped when detection logic changes so stored
+ * selections from an older parser are rejected and re-probed instead of served
+ * indefinitely — e.g. the Windows virtual-adapter filtering added for #9675,
+ * which would otherwise keep returning a cached virtual GPU after upgrade.
+ */
+const GPU_CACHE_VERSION = 1;
+
 /** Cached GPU probe result. */
 interface GpuCache {
 	gpu: string | null;
@@ -291,7 +299,7 @@ async function loadGpuCache(): Promise<GpuCache | null> {
 	try {
 		const cachePath = getGpuCachePath();
 		const content = await Bun.file(cachePath).json();
-		if (content && typeof content === "object" && "gpu" in content) {
+		if (content && typeof content === "object" && content.version === GPU_CACHE_VERSION && "gpu" in content) {
 			const gpu = content.gpu;
 			return { gpu: typeof gpu === "string" ? gpu : null };
 		}
@@ -304,7 +312,7 @@ async function loadGpuCache(): Promise<GpuCache | null> {
 async function saveGpuCache(info: GpuCache): Promise<void> {
 	try {
 		const cachePath = getGpuCachePath();
-		await Bun.write(cachePath, JSON.stringify(info, null, "\t"));
+		await Bun.write(cachePath, JSON.stringify({ version: GPU_CACHE_VERSION, gpu: info.gpu }, null, "\t"));
 	} catch {
 		// Silently ignore cache write failures
 	}

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -18,6 +18,7 @@ async function runProbeScenario(options: {
 	holdStdoutOpen?: boolean;
 	descendantHoldsStdout?: boolean;
 	validOutput?: string;
+	legacyCache?: string;
 }): Promise<ProbeRunResult> {
 	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-gpu-probe-"));
 	try {
@@ -32,6 +33,9 @@ async function runProbeScenario(options: {
 			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_VALID_OUTPUT" ]; then printf "%s\\n" "$OMP_GPU_PROBE_VALID_OUTPUT"; fi\nif [ "$OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & exit 0; fi\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
 		await fs.chmod(probePath, 0o755);
+		if (options.legacyCache !== undefined) {
+			await Bun.write(path.join(cacheRoot, "omp", "gpu_cache.json"), options.legacyCache);
+		}
 
 		const scenarioPath = path.join(tempRoot, "scenario.ts");
 		await Bun.write(
@@ -121,14 +125,14 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 	it("caches empty GPU probe results", async () => {
 		const result = await runProbeScenario({ runs: 2 });
 
-		expect(result.cached).toEqual({ gpu: null });
+		expect(result.cached).toEqual({ version: 1, gpu: null });
 		expect(result.count).toBe(1);
 	}, 15_000);
 
 	it("kills the GPU probe at the prep deadline", async () => {
 		const result = await runProbeScenario({ runs: 1, sleepSeconds: 12, holdStdoutOpen: true });
 
-		expect(result.cached).toEqual({ gpu: null });
+		expect(result.cached).toEqual({ version: 1, gpu: null });
 		// Probe is SIGKILLed at ~4.5s and the drain wait is bounded, so in-child
 		// time sits near the deadline; waiting on the descendant would push it
 		// past the 12s sleep.
@@ -143,7 +147,7 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 	it("does not wait on stdout held by a descendant after a successful probe", async () => {
 		const result = await runProbeScenario({ runs: 1, sleepSeconds: 8, descendantHoldsStdout: true });
 
-		expect(result.cached).toEqual({ gpu: null });
+		expect(result.cached).toEqual({ version: 1, gpu: null });
 		// Probe exits 0 immediately but leaves a backgrounded sleep holding the stdout
 		// pipe. The success path MUST bound the drain wait, not block until sleep exits.
 		expect(result.elapsedMs).toBeLessThan(2000);
@@ -162,7 +166,7 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 
 		// Probe exited 0 with valid output before bg sleep held stdout open.
 		// Captured stdout MUST be cached, not discarded as if the probe failed.
-		expect(result.cached).toEqual({ gpu: "02.0 VGA compatible controller: NVIDIA TestGPU" });
+		expect(result.cached).toEqual({ version: 1, gpu: "02.0 VGA compatible controller: NVIDIA TestGPU" });
 		expect(result.elapsedMs).toBeLessThan(2000);
 		// Budgets bun spawn/startup overhead; blocking on the descendant would
 		// take at least the 8s sleep.
@@ -176,7 +180,7 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 			validOutput: "Name\nGameViewer Virtual Display Adapter\nNVIDIA GeForce RTX 2080 Ti",
 		});
 
-		expect(result.cached).toEqual({ gpu: "NVIDIA GeForce RTX 2080 Ti" });
+		expect(result.cached).toEqual({ version: 1, gpu: "NVIDIA GeForce RTX 2080 Ti" });
 		expect(result.count).toBe(1);
 	});
 
@@ -187,7 +191,21 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 			validOutput: "Name\nRemote Display Adapter\nCitrix Virtual Adapter",
 		});
 
-		expect(result.cached).toEqual({ gpu: "Remote Display Adapter" });
+		expect(result.cached).toEqual({ version: 1, gpu: "Remote Display Adapter" });
+		expect(result.count).toBe(1);
+	});
+
+	it("rejects a pre-versioning cache and re-probes the Windows GPU", async () => {
+		const result = await runProbeScenario({
+			runs: 1,
+			platform: "win32",
+			validOutput: "Name\nGameViewer Virtual Display Adapter\nNVIDIA GeForce RTX 2080 Ti",
+			legacyCache: JSON.stringify({ gpu: "GameViewer Virtual Display Adapter" }),
+		});
+
+		// The old unversioned cache holds the virtual adapter the previous parser
+		// picked; it MUST be discarded and re-probed, not served indefinitely.
+		expect(result.cached).toEqual({ version: 1, gpu: "NVIDIA GeForce RTX 2080 Ti" });
 		expect(result.count).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -13,6 +13,7 @@ interface ProbeRunResult {
 
 async function runProbeScenario(options: {
 	runs: number;
+	platform?: "linux" | "win32";
 	sleepSeconds?: number;
 	holdStdoutOpen?: boolean;
 	descendantHoldsStdout?: boolean;
@@ -25,12 +26,12 @@ async function runProbeScenario(options: {
 		const probeCountPath = path.join(tempRoot, "probe-count");
 		await fs.mkdir(binDir, { recursive: true });
 		await fs.mkdir(path.join(cacheRoot, "omp"), { recursive: true });
-		const lspciPath = path.join(binDir, "lspci");
+		const probePath = path.join(binDir, options.platform === "win32" ? "wmic" : "lspci");
 		await Bun.write(
-			lspciPath,
+			probePath,
 			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_VALID_OUTPUT" ]; then printf "%s\\n" "$OMP_GPU_PROBE_VALID_OUTPUT"; fi\nif [ "$OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & exit 0; fi\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
-		await fs.chmod(lspciPath, 0o755);
+		await fs.chmod(probePath, 0o755);
 
 		const scenarioPath = path.join(tempRoot, "scenario.ts");
 		await Bun.write(
@@ -38,6 +39,7 @@ async function runProbeScenario(options: {
 			`import { getGpuCachePath, refreshDirsFromEnv } from ${JSON.stringify(path.resolve(import.meta.dir, "../../utils/src/index.ts"))};
 import { buildSystemPrompt } from ${JSON.stringify(path.join(import.meta.dir, "../src/system-prompt.ts"))};
 
+Object.defineProperty(process, "platform", { value: ${JSON.stringify(options.platform ?? "linux")} });
 refreshDirsFromEnv();
 const buildOptions = {
 	contextFiles: [],
@@ -66,13 +68,14 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 
 		const env: Record<string, string | undefined> = {
 			...process.env,
+			HOME: tempRoot,
 			PATH: `${binDir}:${process.env.PATH ?? ""}`,
 			XDG_CACHE_HOME: cacheRoot,
 			OMP_GPU_PROBE_COUNT: probeCountPath,
 			OMP_GPU_PROBE_RUNS: String(options.runs),
 		};
-		// Strip inherited dirs-resolver overrides so XDG_CACHE_HOME above wins and
-		// the test cannot touch the developer/CI profile's real gpu_cache.json.
+		// Strip inherited dirs-resolver overrides so the temporary HOME/XDG roots
+		// win and the test cannot touch the developer/CI profile's real gpu_cache.json.
 		for (const key of ["PI_CODING_AGENT_DIR", "OMP_PROFILE", "PI_PROFILE", "PI_CONFIG_DIR"]) {
 			delete env[key];
 		}
@@ -165,6 +168,28 @@ describe.skipIf(process.platform !== "linux")("system prompt GPU probe", () => {
 		// take at least the 8s sleep.
 		expect(result.childElapsedMs).toBeLessThan(5000);
 	}, 20_000);
+
+	it("prefers a physical Windows GPU over first-listed virtual adapters", async () => {
+		const result = await runProbeScenario({
+			runs: 1,
+			platform: "win32",
+			validOutput: "Name\nGameViewer Virtual Display Adapter\nNVIDIA GeForce RTX 2080 Ti",
+		});
+
+		expect(result.cached).toEqual({ gpu: "NVIDIA GeForce RTX 2080 Ti" });
+		expect(result.count).toBe(1);
+	});
+
+	it("keeps the first Windows adapter when every adapter is virtual", async () => {
+		const result = await runProbeScenario({
+			runs: 1,
+			platform: "win32",
+			validOutput: "Name\nRemote Display Adapter\nCitrix Virtual Adapter",
+		});
+
+		expect(result.cached).toEqual({ gpu: "Remote Display Adapter" });
+		expect(result.count).toBe(1);
+	});
 });
 
 describe.skipIf(process.platform !== "linux")("system prompt CPU model", () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -33,9 +33,6 @@ async function runProbeScenario(options: {
 			'#!/usr/bin/env sh\nprintf x >> "$OMP_GPU_PROBE_COUNT"\nif [ -n "$OMP_GPU_PROBE_VALID_OUTPUT" ]; then printf "%s\\n" "$OMP_GPU_PROBE_VALID_OUTPUT"; fi\nif [ "$OMP_GPU_PROBE_DESCENDANT_HOLDS_STDOUT" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & exit 0; fi\nif [ "$OMP_GPU_PROBE_HOLD_STDOUT_OPEN" = "true" ]; then sleep "$OMP_GPU_PROBE_SLEEP" & wait "$!"; fi\nif [ -n "$OMP_GPU_PROBE_SLEEP" ]; then exec sleep "$OMP_GPU_PROBE_SLEEP"; fi\nexit 0\n',
 		);
 		await fs.chmod(probePath, 0o755);
-		if (options.legacyCache !== undefined) {
-			await Bun.write(path.join(cacheRoot, "omp", "gpu_cache.json"), options.legacyCache);
-		}
 
 		const scenarioPath = path.join(tempRoot, "scenario.ts");
 		await Bun.write(
@@ -45,6 +42,8 @@ import { buildSystemPrompt } from ${JSON.stringify(path.join(import.meta.dir, ".
 
 Object.defineProperty(process, "platform", { value: ${JSON.stringify(options.platform ?? "linux")} });
 refreshDirsFromEnv();
+const legacyCache = process.env.OMP_GPU_PROBE_LEGACY_CACHE;
+if (legacyCache !== undefined) await Bun.write(getGpuCachePath(), legacyCache);
 const buildOptions = {
 	contextFiles: [],
 	skills: [],
@@ -102,6 +101,11 @@ console.log(JSON.stringify({ elapsedMs: Math.round(performance.now() - startedAt
 			env.OMP_GPU_PROBE_VALID_OUTPUT = options.validOutput;
 		} else {
 			delete env.OMP_GPU_PROBE_VALID_OUTPUT;
+		}
+		if (options.legacyCache !== undefined) {
+			env.OMP_GPU_PROBE_LEGACY_CACHE = options.legacyCache;
+		} else {
+			delete env.OMP_GPU_PROBE_LEGACY_CACHE;
 		}
 
 		const childStartedAt = performance.now();


### PR DESCRIPTION
## Repro
Run `bun test packages/coding-agent/test/system-prompt.test.ts`; the added Windows scenario feeds `wmic` the reporter's ordered rows (`GameViewer Virtual Display Adapter`, then `NVIDIA GeForce RTX 2080 Ti`). Before the fix, the scenario cached `GameViewer Virtual Display Adapter`.

## Cause
The Windows branch of `getGpuModel()` in `packages/coding-agent/src/system-prompt.ts` passed WMI's table to `parseWmicTable()`, which removed the `Name` header and unconditionally returned the first remaining row. WMI does not order physical adapters ahead of virtual display drivers.

## Fix
- Filter virtual, mirror, remote, and Citrix adapter rows before selecting the Windows GPU.
- Prefer NVIDIA, AMD/Radeon, or Intel names among the remaining adapters.
- Preserve the first original row as a fallback when every adapter is filtered.
- Cover physical selection and all-virtual fallback through the workstation GPU probe.

## Verification
`bun test packages/coding-agent/test/system-prompt.test.ts` passes: 8 tests, 18 assertions. Re-running the original fake-WMI scenario caches `NVIDIA GeForce RTX 2080 Ti`.

Fixes #9675