### PR TITLE
fix(ai): pin Standard tier for cursor composer-2.5 selections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor `composer-2.5` selections silently serving the Fast variant by pinning the Standard tier with an explicit `{ id: "fast", value: "false" }` request parameter ([#9012](https://github.com/can1357/oh-my-pi/issues/9012)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -5208,6 +5208,15 @@ function resolveCursorWireModel(
 			parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: effort })],
 		};
 	}
+	// A bare `composer-2.5` id resolves to the Fast variant server-side
+	// (can1357/oh-my-pi#9012). Pin the Standard tier explicitly; `-fast`
+	// selections keep the Fast lane by omitting the parameter.
+	if (wireModelId === "composer-2.5") {
+		return {
+			modelId: wireModelId,
+			parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "fast", value: "false" })],
+		};
+	}
 	return { modelId: wireModelId, parameters: [] };
 }
 

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -58,6 +58,18 @@ describe("Cursor requestedModel wire shape", () => {
 		expect(payload.requestedModel?.parameters).toEqual([]);
 	});
 
+	it("pins the Standard tier for bare composer-2.5 (#9012)", async () => {
+		const payload = await capture(cursorModel("composer-2.5"));
+		expect(payload.requestedModel?.modelId).toBe("composer-2.5");
+		expect(payload.requestedModel?.parameters).toEqual([expect.objectContaining({ id: "fast", value: "false" })]);
+	});
+
+	it("keeps explicit composer-2.5-fast on the Fast lane with no parameters", async () => {
+		const payload = await capture(cursorModel("composer-2.5-fast"));
+		expect(payload.requestedModel?.modelId).toBe("composer-2.5-fast");
+		expect(payload.requestedModel?.parameters).toEqual([]);
+	});
+
 	it("does not translate non-OpenAI siblings (Claude effort schema is undecoded)", async () => {
 		const payload = await capture(cursorModel("claude-fable-5-low"));
 		expect(payload.requestedModel?.modelId).toBe("claude-fable-5-low");


### PR DESCRIPTION
Ref: #9012

## Problem

Selecting `cursor/composer-2.5` sends a bare `composer-2.5` model id with empty `parameters[]`. Per Cursor Support (quoted in #9012), a bare `composer-2.5` request resolves to the **Fast variant server-side** unless an explicit `{ id: "fast", value: "false" }` parameter pins the Standard tier. The proto already exposes `RequestedModel.parameters`, so the channel exists — omp just never populates it for this model.

Result: users who select Composer 2.5 get served (and see usage recorded as) `composer-2.5-fast`, and cannot reach the Standard tier at all.

## Change

In `resolveCursorWireModel` (`packages/ai/src/providers/cursor.ts`), emit the Standard-tier pin for the exact `composer-2.5` wire id:

- `cursor/composer-2.5` → `parameters: [{ id: "fast", value: "false" }]`
- `cursor/composer-2.5-fast` → unchanged (no parameter; keeps the Fast lane)
- all other ids (effort-suffixed, `discovered` wire mode) → unchanged

The condition is deliberately narrow to `composer-2.5` because only that model was verified against the live backend.

## Verification

End-to-end on omp 17.4.2 source, each case one real request, wire captured with `PI_REQ_DEBUG=1`, served model read from the server-echoed `modelName`:

| Selection | `RequestedModel.parameters` on wire | Served `modelName` |
|---|---|---|
| `cursor/composer-2.5` | `[{ id: "fast", value: "false" }]` | `composer-2.5` |
| `cursor/composer-2.5-fast` | `[]` | `composer-2.5-fast` |

Before the patch the same capture showed `parameters: []` → served `composer-2.5-fast`; after, the Cursor usage dashboard no longer records fast for the Standard-tier requests (the explicit `-fast` control still records fast, as expected).

Regression tests added in `packages/ai/test/cursor-requested-model.test.ts`:

```
bun test test/cursor-requested-model.test.ts   -> 6 pass, 0 fail
bun test test/cursor-effort-routing.test.ts \
         test/cursor-wire-model-fallback.test.ts -> 13 pass, 0 fail
```

Happy to adjust if maintainers prefer a different shape (e.g. a catalog flag per model instead of the hard-coded id).