### PR TITLE
fix(utils): contain uncaught worker IPC EPIPE

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept the main session alive when Bun surfaces an optional-worker IPC send `EPIPE` through `uncaughtException` instead of `unhandledRejection`.
+
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -343,6 +343,13 @@ if (isMainThread) {
 				logger.warn("Ignoring expected cleanup exception", { err });
 				return;
 			}
+			// Bun can surface a worker IPC send race through uncaughtException
+			// instead of unhandledRejection. Apply the same optional-worker
+			// containment in either global error channel.
+			if (isIpcSendEpipe(err)) {
+				logger.warn("Ignoring EPIPE from worker IPC send; optional subsystem will self-recover", { err });
+				return;
+			}
 			// A malformed advanced-serialization frame from a worker subprocess
 			// surfaces here as a process-level uncaughtException (oven-sh/bun#37287)
 			// rather than in the channel's ipc() callback, and Bun gives no way to

--- a/packages/utils/test/postmortem-epipe.test.ts
+++ b/packages/utils/test/postmortem-epipe.test.ts
@@ -4,8 +4,27 @@ import { postmortem } from "@oh-my-pi/pi-utils";
 
 const childFlag = "--stdio-epipe-child";
 const raceChildFlag = "--stdio-epipe-race-child";
+const uncaughtIpcChildFlag = "--uncaught-ipc-epipe-child";
+const unrelatedUncaughtChildFlag = "--unrelated-uncaught-child";
+const unrelatedUncaughtChildFlagIndex = process.argv.indexOf(unrelatedUncaughtChildFlag);
+const uncaughtIpcChildFlagIndex = process.argv.indexOf(uncaughtIpcChildFlag);
 const childFlagIndex = process.argv.indexOf(childFlag);
-if (childFlagIndex >= 0) {
+if (unrelatedUncaughtChildFlagIndex >= 0) {
+	setImmediate(() => {
+		throw new Error("unrelated fatal exception");
+	});
+	await Bun.sleep(200);
+	process.exit(0);
+} else if (uncaughtIpcChildFlagIndex >= 0) {
+	const marker = process.argv[uncaughtIpcChildFlagIndex + 1];
+	if (!marker) throw new Error("Missing survival marker path");
+	setImmediate(() => {
+		throw Object.assign(new Error("broken pipe"), { code: "EPIPE", syscall: "send" });
+	});
+	await Bun.sleep(100);
+	await Bun.write(marker, "survived uncaught worker IPC EPIPE");
+	process.exit(0);
+} else if (childFlagIndex >= 0) {
 	const marker = process.argv[childFlagIndex + 1];
 	if (!marker) throw new Error("Missing cleanup marker path");
 	postmortem.registerStdioDisconnectHandling();
@@ -56,6 +75,43 @@ describe("postmortem broken-pipe handling", () => {
 		expect(postmortem.classifyBrokenPipe(makeErr({ code: "ENOENT", syscall: "send" }))).toBeUndefined();
 		expect(postmortem.classifyBrokenPipe(new Error("boom"))).toBeUndefined();
 		expect(postmortem.classifyBrokenPipe(makeErr({ code: undefined, syscall: undefined }))).toBeUndefined();
+	});
+
+	it("keeps the process alive when Bun surfaces worker IPC EPIPE as an uncaught exception", async () => {
+		const marker = `/tmp/omp-postmortem-uncaught-ipc-${process.pid}-${Date.now()}`;
+		const child = Bun.spawn([process.execPath, "run", import.meta.path, uncaughtIpcChildFlag, marker], {
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		try {
+			const [exitCode, stdout, stderr] = await Promise.all([
+				child.exited,
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+			]);
+			expect(exitCode, stderr).toBe(0);
+			expect(stdout).toBe("");
+			expect(stderr).toBe("");
+			expect(await Bun.file(marker).text()).toBe("survived uncaught worker IPC EPIPE");
+		} finally {
+			child.kill();
+			await child.exited;
+			await Bun.file(marker)
+				.delete()
+				.catch(() => {});
+		}
+	});
+
+	it("keeps unrelated uncaught exceptions fatal", async () => {
+		const child = Bun.spawn([process.execPath, "run", import.meta.path, unrelatedUncaughtChildFlag], {
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("[Uncaught Exception] Error: unrelated fatal exception");
 	});
 
 	it("awaits cleanup and exits successfully when a registered stdio peer disconnects", async () => {


### PR DESCRIPTION
## Summary

- contain optional-worker IPC `EPIPE` surfaced by Bun through `uncaughtException`
- reuse the existing `code === "EPIPE" && syscall === "send"` classifier already applied to `unhandledRejection`
- keep unrelated uncaught exceptions and stdio `write` EPIPE on the fatal path
- add process-level positive and negative regression coverage

## Root cause

Bun can surface a failed worker `send()` as a process-level uncaught exception rather than an unhandled rejection. The latter was already recoverable, but the former entered fatal teardown and aborted the primary session plus active subagents.

## Verification

- `bun test packages/utils/test/postmortem-epipe.test.ts` — 6 passed
- `bun --cwd=packages/utils test` — 801 passed, 1 network test skipped, 0 failed
- `bun --cwd=packages/utils run check` — Biome and types passed
- compiled-binary synthetic uncaught IPC EPIPE turn completed
- installed-binary two-subagent acceptance turn completed with normal child disposal

## Scope

Exactly three files: postmortem handling, its regression test, and the utils changelog.