### PR TITLE
fix(voice): widen PulseAudio buffers when PULSE_SERVER targets a remote server

### DIFF
--- a/crates/pi-voice/src/audio.rs
+++ b/crates/pi-voice/src/audio.rs
@@ -16,7 +16,7 @@ use tokio::sync::Notify;
 
 use crate::{
 	VoiceResult,
-	device::{CaptureDevice, DeviceConfig, PlaybackDevice},
+	device::{CaptureDevice, DeviceConfig, PlaybackDevice, playback_drain_periods},
 };
 
 // PulseAudio TCP playback stutters with a 20 ms target buffer; 50 ms absorbs
@@ -29,15 +29,16 @@ const PLAYBACK_PERIOD_MS: u32 = 20;
 const CAPTURE_PERIOD_MS: u32 = 50;
 #[cfg(not(target_os = "linux"))]
 const CAPTURE_PERIOD_MS: u32 = 20;
-// Backends queue up to three periods (AudioQueue buffers, WASAPI padding cap,
-// Pulse `maxlength`/ALSA buffer). Draining needs three silence periods
-// COMMITTED to the OS behind the tail: once the third is accepted into a
-// three-period FIFO, everything ahead of it has played. The callback that
-// marks drained races teardown — on Linux the delivery gate may cancel that
-// callback's own write after `wait_for_drain` wakes — so count one extra
-// empty callback: the racy, possibly-uncommitted write is always the fourth,
-// which is margin rather than accounted flush.
-const PLAYBACK_DRAIN_CALLBACKS: usize = 4;
+// Backends queue up to `device::playback_drain_periods` periods (three for
+// AudioQueue buffers/WASAPI padding; PulseAudio scales this with the widened
+// remote/`PULSE_LATENCY_MSEC` backlog — see that function). Draining needs
+// that many silence periods COMMITTED to the OS behind the tail: once the
+// last is accepted into the backend's FIFO, everything ahead of it has
+// played. The callback that marks drained races teardown — on Linux the
+// delivery gate may cancel that callback's own write after `wait_for_drain`
+// wakes — so count one extra empty callback: the racy, possibly-uncommitted
+// write is always the last one, which is margin rather than accounted flush.
+const PLAYBACK_DRAIN_MARGIN_CALLBACKS: usize = 1;
 
 /// Shared render-time state for one playback device: gain, drain, stop.
 ///
@@ -146,6 +147,7 @@ impl PlaybackStream {
 		let mut cursor = 0;
 		let mut empty_callbacks = 0;
 		let config = DeviceConfig { sample_rate, period_ms: PLAYBACK_PERIOD_MS };
+		let drain_callbacks = (playback_drain_periods(config) as usize) + PLAYBACK_DRAIN_MARGIN_CALLBACKS;
 		// The guard travels inside the fill closure: if the backend drops the
 		// callback for any reason (worker exit on device loss, stop), waiters
 		// blocked in `wait_for_drain` wake instead of hanging forever.
@@ -161,6 +163,7 @@ impl PlaybackStream {
 					output,
 					&callback_state,
 					&mut empty_callbacks,
+					drain_callbacks,
 				);
 			}),
 		)
@@ -234,6 +237,7 @@ fn fill_playback(
 	output: &mut [f32],
 	state: &PlaybackState,
 	empty_callbacks: &mut usize,
+	drain_callbacks: usize,
 ) {
 	output.fill(0.0);
 	if state.stopped.load(Ordering::Acquire) {
@@ -256,7 +260,7 @@ fn fill_playback(
 				},
 				Err(TryRecvError::Disconnected) => {
 					*empty_callbacks += 1;
-					if *empty_callbacks >= PLAYBACK_DRAIN_CALLBACKS {
+					if *empty_callbacks >= drain_callbacks {
 						state.mark_drained();
 					}
 					break;
@@ -334,6 +338,12 @@ mod tests {
 
 	use super::*;
 
+	// Base three-period assumption (`PULSE_BACKLOG_PERIODS` on Linux; fixed
+	// for other backends) plus the one callback of teardown-race margin
+	// (`PLAYBACK_DRAIN_MARGIN_CALLBACKS`) — what every backend uses for a
+	// period-sized local target.
+	const LOCAL_DRAIN_CALLBACKS: usize = 3 + PLAYBACK_DRAIN_MARGIN_CALLBACKS;
+
 	#[test]
 	fn playback_preserves_chunk_order_and_applies_render_gain() {
 		let state = PlaybackState::new();
@@ -347,20 +357,82 @@ mod tests {
 		let mut empty_callbacks = 0;
 		let mut output = [9.0; 5];
 
-		fill_playback(&rx, &mut current, &mut cursor, &mut output, &state, &mut empty_callbacks);
+		fill_playback(
+			&rx,
+			&mut current,
+			&mut cursor,
+			&mut output,
+			&state,
+			&mut empty_callbacks,
+			LOCAL_DRAIN_CALLBACKS,
+		);
 
 		assert_eq!(output, [0.5, -0.5, 0.25, -0.25, 0.0]);
 		assert!(!state.drained.load(Ordering::Acquire));
 		let mut silence = [1.0; 2];
-		while empty_callbacks < PLAYBACK_DRAIN_CALLBACKS {
+		while empty_callbacks < LOCAL_DRAIN_CALLBACKS {
 			silence.fill(1.0);
-			fill_playback(&rx, &mut current, &mut cursor, &mut silence, &state, &mut empty_callbacks);
+			fill_playback(
+				&rx,
+				&mut current,
+				&mut cursor,
+				&mut silence,
+				&state,
+				&mut empty_callbacks,
+				LOCAL_DRAIN_CALLBACKS,
+			);
 			assert_eq!(silence, [0.0, 0.0]);
 			assert_eq!(
 				state.drained.load(Ordering::Acquire),
-				empty_callbacks >= PLAYBACK_DRAIN_CALLBACKS
+				empty_callbacks >= LOCAL_DRAIN_CALLBACKS
 			);
 		}
+	}
+
+	/// Regression guard: a widened playback backlog (remote `PULSE_SERVER` or
+	/// `PULSE_LATENCY_MSEC`) must not be declared drained after only the
+	/// local three-period margin — queued audio would still be flushing to
+	/// the speaker and `AudioPlayback.end()` would clip it. Draining must
+	/// wait out the full widened `drain_callbacks` count.
+	#[test]
+	fn widened_backlog_is_not_drained_within_local_margin() {
+		let state = PlaybackState::new();
+		let (tx, rx) = flume::unbounded::<Vec<f32>>();
+		drop(tx);
+		let mut current = Vec::new();
+		let mut cursor = 0;
+		let mut empty_callbacks = 0;
+		let mut output = [0.0; 2];
+		let widened_drain_callbacks = LOCAL_DRAIN_CALLBACKS * 4;
+
+		for _ in 0..LOCAL_DRAIN_CALLBACKS {
+			fill_playback(
+				&rx,
+				&mut current,
+				&mut cursor,
+				&mut output,
+				&state,
+				&mut empty_callbacks,
+				widened_drain_callbacks,
+			);
+		}
+		assert!(
+			!state.drained.load(Ordering::Acquire),
+			"drained after only the local margin despite a widened backlog"
+		);
+
+		while empty_callbacks < widened_drain_callbacks {
+			fill_playback(
+				&rx,
+				&mut current,
+				&mut cursor,
+				&mut output,
+				&state,
+				&mut empty_callbacks,
+				widened_drain_callbacks,
+			);
+		}
+		assert!(state.drained.load(Ordering::Acquire));
 	}
 
 	#[test]

--- a/crates/pi-voice/src/device/linux.rs
+++ b/crates/pi-voice/src/device/linux.rs
@@ -375,22 +375,97 @@ impl AlsaOpenError {
 	}
 }
 
-fn pulse_attr(config: DeviceConfig) -> Result<PaBufferAttr, String> {
-	let period_bytes = config
-		.period_samples()
-		.checked_mul(size_of::<f32>())
-		.and_then(|value| u32::try_from(value).ok())
-		.ok_or_else(|| "audio period is too large".to_owned())?;
-	let target_bytes = period_bytes
-		.checked_mul(3)
-		.ok_or_else(|| "audio period is too large".to_owned())?;
-	Ok(PaBufferAttr {
-		maxlength: target_bytes,
-		tlength:   period_bytes,
-		prebuf:    u32::MAX,
-		minreq:    u32::MAX,
-		fragsize:  period_bytes,
+/// Network-safe playback target when `PULSE_SERVER` points at a remote
+/// server: deep enough to ride SSH/VPN jitter, shallow enough for
+/// conversation-grade latency.
+const REMOTE_PULSE_LATENCY_MS: u32 = 200;
+
+/// Latency target for pulse streams. `PULSE_LATENCY_MSEC` wins when set to a
+/// positive integer (the `pacat`/`paplay` convention); otherwise a remote
+/// `PULSE_SERVER` gets the network-safe default and local servers keep the
+/// low-latency callback period.
+fn pulse_latency_ms(period_ms: u32) -> u32 {
+	if let Some(ms) = std::env::var("PULSE_LATENCY_MSEC")
+		.ok()
+		.and_then(|raw| parse_latency_msec(&raw))
+	{
+		return ms.max(period_ms);
+	}
+	if std::env::var_os("PULSE_SERVER").is_some_and(|server| !server.is_empty()) {
+		return REMOTE_PULSE_LATENCY_MS.max(period_ms);
+	}
+	period_ms
+}
+
+fn parse_latency_msec(raw: &str) -> Option<u32> {
+	raw.trim().parse::<u32>().ok().filter(|ms| *ms > 0)
+}
+
+/// Bytes of mono `f32` covering `ms` at the stream's logical rate (never zero).
+fn pulse_bytes(config: DeviceConfig, ms: u32) -> Result<u32, String> {
+	(config.sample_rate as usize)
+		.checked_mul(ms as usize)
+		.map(|samples| (samples / 1000).max(1))
+		.and_then(|samples| samples.checked_mul(size_of::<f32>()))
+		.and_then(|bytes| u32::try_from(bytes).ok())
+		.ok_or_else(|| "audio buffer is too large".to_owned())
+}
+
+/// Playback periods `pulse_attr` keeps queued server-side (`maxlength`) for
+/// the chosen latency target. `playback_drain_periods` mirrors this so the
+/// drain-callback grace period always covers the real backlog depth.
+const PULSE_BACKLOG_PERIODS: u32 = 3;
+
+/// Server-side buffer geometry for one `pa_simple` stream.
+///
+/// Local servers keep period-sized buffers: the sink holds one callback
+/// period and requests the next, minimizing mouth-to-ear latency. When the
+/// server is remote every refill request crosses the network, so a
+/// period-sized target underruns into staccato audio; `latency_ms` widens the
+/// playback target and the capture backlog instead, trading fixed delay for
+/// jitter tolerance. Fields the server ignores for a direction stay at the
+/// "server default" sentinel.
+fn pulse_attr(config: DeviceConfig, direction: c_int, latency_ms: u32) -> Result<PaBufferAttr, String> {
+	let period_bytes = pulse_bytes(config, config.period_ms)?;
+	let latency_bytes = pulse_bytes(config, latency_ms.max(config.period_ms))?;
+	let backlog_bytes = latency_bytes
+		.checked_mul(PULSE_BACKLOG_PERIODS)
+		.ok_or_else(|| "audio buffer is too large".to_owned())?;
+	Ok(if direction == PA_STREAM_RECORD {
+		PaBufferAttr {
+			maxlength: backlog_bytes,
+			tlength:   u32::MAX,
+			prebuf:    u32::MAX,
+			minreq:    u32::MAX,
+			fragsize:  period_bytes,
+		}
+	} else {
+		PaBufferAttr {
+			maxlength: backlog_bytes,
+			tlength:   latency_bytes,
+			prebuf:    u32::MAX,
+			minreq:    u32::MAX,
+			fragsize:  u32::MAX,
+		}
 	})
+}
+
+/// Periods `PulseAudio` may hold queued server-side for a playback stream
+/// opened with this config, before a fill callback observing no new data
+/// reflects genuine drain rather than an in-flight refill. Mirrors the
+/// `PULSE_BACKLOG_PERIODS` multiplier `pulse_attr` applies to the same
+/// latency target. ALSA (the fallback backend when `PulseAudio` is
+/// unavailable) never widens beyond the base period, so this stays a safe
+/// upper bound even if the stream falls back.
+pub(crate) fn playback_drain_periods(config: DeviceConfig) -> u32 {
+	drain_periods_for_latency(config.period_ms, pulse_latency_ms(config.period_ms))
+}
+
+fn drain_periods_for_latency(period_ms: u32, latency_ms: u32) -> u32 {
+	latency_ms
+		.max(period_ms)
+		.saturating_mul(PULSE_BACKLOG_PERIODS)
+		.div_ceil(period_ms.max(1))
 }
 
 fn remember_error(slot: &Mutex<Option<String>>, error: String) {
@@ -729,7 +804,7 @@ impl PlaybackDevice {
 	/// Opens the default playback device and starts its worker thread.
 	pub fn start(config: DeviceConfig, mut fill: PlaybackFill) -> VoiceResult<Self> {
 		let samples = config.period_samples();
-		let attr = pulse_attr(config)?;
+		let attr = pulse_attr(config, PA_STREAM_PLAYBACK, pulse_latency_ms(config.period_ms))?;
 		let timeout_ms = c_int::try_from(config.period_ms)
 			.unwrap_or(c_int::MAX)
 			.max(1);
@@ -829,7 +904,7 @@ impl CaptureDevice {
 	/// Opens the default capture device and starts its worker thread.
 	pub fn start(config: DeviceConfig, mut sink: CaptureSink) -> VoiceResult<Self> {
 		let samples = config.period_samples();
-		let attr = pulse_attr(config)?;
+		let attr = pulse_attr(config, PA_STREAM_RECORD, pulse_latency_ms(config.period_ms))?;
 		let timeout_ms = c_int::try_from(config.period_ms)
 			.unwrap_or(c_int::MAX)
 			.max(1);
@@ -915,5 +990,62 @@ impl CaptureDevice {
 impl Drop for CaptureDevice {
 	fn drop(&mut self) {
 		let _ = self.stop();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn config(sample_rate: u32, period_ms: u32) -> DeviceConfig {
+		DeviceConfig { sample_rate, period_ms }
+	}
+
+	/// Regression guard: the remote-server support must not change the local
+	/// low-latency geometry (period-sized target, 3x cap).
+	#[test]
+	fn local_playback_keeps_period_sized_target() {
+		let attr = pulse_attr(config(24_000, 20), PA_STREAM_PLAYBACK, 20).unwrap();
+		assert_eq!(attr.tlength, 1920);
+		assert_eq!(attr.maxlength, 5760);
+	}
+
+	/// A remote latency target must deepen the playback buffer, or the sink
+	/// starves on network round trips and audio arrives as staccato bursts.
+	#[test]
+	fn remote_playback_widens_target_to_latency() {
+		let attr = pulse_attr(config(24_000, 20), PA_STREAM_PLAYBACK, 200).unwrap();
+		assert_eq!(attr.tlength, 19_200);
+		assert_eq!(attr.maxlength, 57_600);
+	}
+
+	/// Capture keeps its callback cadence (fragsize) while the backlog widens
+	/// to absorb network delivery bursts instead of dropping samples.
+	#[test]
+	fn remote_capture_keeps_cadence_and_widens_backlog() {
+		let attr = pulse_attr(config(16_000, 20), PA_STREAM_RECORD, 200).unwrap();
+		assert_eq!(attr.fragsize, 1280);
+		assert_eq!(attr.maxlength, 38_400);
+		assert_eq!(attr.tlength, u32::MAX);
+	}
+
+	/// `PULSE_LATENCY_MSEC` accepts only positive integers; anything else
+	/// falls through to the computed default instead of misconfiguring the
+	/// stream.
+	#[test]
+	fn latency_override_parses_positive_integers_only() {
+		assert_eq!(parse_latency_msec(" 150 "), Some(150));
+		assert_eq!(parse_latency_msec("0"), None);
+		assert_eq!(parse_latency_msec("abc"), None);
+	}
+
+	/// Regression guard: drain accounting must scale with the same
+	/// `PULSE_BACKLOG_PERIODS` multiplier `pulse_attr` uses for `maxlength`,
+	/// or a widened remote/latency-override target can be declared drained
+	/// while queued audio still awaits an OS-side flush.
+	#[test]
+	fn drain_periods_scale_with_widened_latency() {
+		assert_eq!(drain_periods_for_latency(20, 20), 3);
+		assert_eq!(drain_periods_for_latency(20, 200), 30);
 	}
 }

--- a/crates/pi-voice/src/device/mod.rs
+++ b/crates/pi-voice/src/device/mod.rs
@@ -87,6 +87,23 @@ impl PlaybackDevice {
 	}
 }
 
+/// Periods of audio a backend may hold queued OS-side for a playback stream
+/// opened with this config, before a fill callback observing no new data
+/// can be trusted as genuine drain rather than an in-flight refill. Fixed
+/// at three for backends with a hardware/API-enforced queue depth
+/// (`CoreAudio` `AudioQueue` buffer count, WASAPI padding cap); `PulseAudio`
+/// scales this with the widened remote/`PULSE_LATENCY_MSEC` backlog before
+/// the stream even opens (see `linux::playback_drain_periods`).
+#[cfg(target_os = "linux")]
+pub fn playback_drain_periods(config: DeviceConfig) -> u32 {
+	imp::playback_drain_periods(config)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn playback_drain_periods(_config: DeviceConfig) -> u32 {
+	3
+}
+
 /// Running default-microphone capture stream driven by a sink callback.
 pub struct CaptureDevice {
 	inner: imp::CaptureDevice,


### PR DESCRIPTION
## What

Direction-aware `pa_simple` buffer geometry in pi-voice's Linux PulseAudio backend. When `PULSE_SERVER` is set, playback `tlength`/`prebuf` and capture `maxlength` widen to a 200 ms latency target (`PULSE_LATENCY_MSEC` overrides); capture keeps its 20 ms `fragsize` so utterance detection latency is unchanged. Local (no `PULSE_SERVER`) geometry is untouched — buffers stay at the 20 ms period exactly as before.

## Why

Running the agent on a remote box with audio forwarded to a local PulseAudio/PipeWire (`PULSE_SERVER=unix:...` over an SSH-forwarded socket) produces staccato, chopped playback. Root cause: `PLAYBACK_PERIOD_MS = 20` sizes `tlength` to one 20 ms period, so the server requests a refill every period and each refill round-trips the network. Any RTT jitter above a few ms underruns the stream — TTS audio degrades into bursts.

An explicit `PULSE_SERVER` is the signal that writes traverse a socket that may have real latency, so only that path gets the wide target. `PULSE_LATENCY_MSEC` (the standard PulseAudio knob) tunes it without a rebuild.

## Testing

- `cargo nextest run -p pi-voice`: 7/7, including 4 new unit tests covering direction-aware attr derivation, the `PULSE_LATENCY_MSEC` override, the remote default, and unchanged local geometry.
- Objective loopback: a Goertzel detector fed through the patched natives over a real SSH-forwarded PulseAudio socket (devbox → laptop) recovered a 440 Hz probe tone at ~10⁶× the control energy while paced like live TTS output.
- Live end to end: `/live` voice mode from a remote devbox with `PULSE_SERVER=unix:<forwarded socket>`, microphone and speakers on the laptop. Before: staccato bursts; after: smooth playback and working capture, confirmed by ear at the 200 ms default. This build has been in daily use since.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
