### PR TITLE
fix(coding-agent): drop duplicated rawContent from spilled tool results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row
+- Fixed large tool payloads being persisted twice on disk when an `eval` cell called an MCP tool: the spilled result no longer re-embeds the full `details.rawContent`, so the dedicated MCP artifact sidecar is the single durable copy ([#9687](https://github.com/can1357/oh-my-pi/issues/9687)).
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -794,6 +794,17 @@ async function spillLargeResultToArtifact(
 	const newMeta: OutputMeta = { ...(existingMeta ?? {}), truncation: truncationMeta };
 	const newDetails = { ...(result.details ?? {}), meta: newMeta };
 
+	// The full payload now lives in the spilled artifact. Some tools duplicate
+	// that same text verbatim inside `details` — MCP results carry a second copy
+	// under `details.rawContent` (mcp/tool-bridge.ts). Left in place, every
+	// consumer that serializes `details` re-persists the whole payload: the eval
+	// bridge forwards it into `jsonOutputs`, which lands byte-for-byte in both the
+	// main session JSONL and the `.eval.log` sidecar alongside the dedicated MCP
+	// sidecar. Drop it so the artifact stays the single durable copy. See #9687.
+	if (newDetails.rawContent !== undefined) {
+		delete newDetails.rawContent;
+	}
+
 	return { ...result, content: newContent, details: newDetails };
 }
 

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -794,16 +794,22 @@ async function spillLargeResultToArtifact(
 	const newMeta: OutputMeta = { ...(existingMeta ?? {}), truncation: truncationMeta };
 	const newDetails = { ...(result.details ?? {}), meta: newMeta };
 
-	// MCP details keep a second copy of the payload the spill just bounded. Prune
-	// every part already represented elsewhere so `details.rawContent` cannot
-	// re-inflate the on-disk size: text blocks and `resource.text` are captured
-	// verbatim by the artifact, and image data survives on the result content
-	// (and eval's `images`). Resource URI/MIME/blob metadata has no other home,
-	// so it is retained.
-	const rawContent = newDetails.rawContent;
-	if (Array.isArray(rawContent)) {
+	// Prune the raw payload only MCP results duplicate into `details.rawContent`.
+	// Identify them by the required `serverName` + `mcpToolName` markers (the same
+	// signature the MCP renderer uses) so a property-name collision on an
+	// SDK/extension tool's intentionally unconstrained details can never trigger
+	// this transformation. Everything already stored elsewhere is dropped so
+	// `rawContent` cannot re-inflate the on-disk size: text blocks and
+	// `resource.text` are captured verbatim by the artifact, and image data
+	// survives on the result content (and eval's `images`). Resource URI/MIME/blob
+	// metadata has no other home, so it is retained.
+	if (
+		typeof newDetails.serverName === "string" &&
+		typeof newDetails.mcpToolName === "string" &&
+		Array.isArray(newDetails.rawContent)
+	) {
 		const structuredContent: unknown[] = [];
-		for (const block of rawContent) {
+		for (const block of newDetails.rawContent) {
 			if (!isRecord(block)) {
 				structuredContent.push(block);
 				continue;

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -794,14 +794,31 @@ async function spillLargeResultToArtifact(
 	const newMeta: OutputMeta = { ...(existingMeta ?? {}), truncation: truncationMeta };
 	const newDetails = { ...(result.details ?? {}), meta: newMeta };
 
-	// MCP details repeat text blocks already captured by the artifact. Remove
-	// only those duplicated strings: resource and image blocks retain structure
-	// (URI, MIME metadata, blobs) that the formatted artifact cannot represent.
+	// MCP details keep a second copy of the payload the spill just bounded. Prune
+	// every part already represented elsewhere so `details.rawContent` cannot
+	// re-inflate the on-disk size: text blocks and `resource.text` are captured
+	// verbatim by the artifact, and image data survives on the result content
+	// (and eval's `images`). Resource URI/MIME/blob metadata has no other home,
+	// so it is retained.
 	const rawContent = newDetails.rawContent;
 	if (Array.isArray(rawContent)) {
-		const structuredContent = rawContent.filter(
-			(block: unknown) => !(isRecord(block) && block.type === "text" && typeof block.text === "string"),
-		);
+		const structuredContent: unknown[] = [];
+		for (const block of rawContent) {
+			if (!isRecord(block)) {
+				structuredContent.push(block);
+				continue;
+			}
+			// Text and image payloads live in the artifact / result content.
+			if (block.type === "text" || block.type === "image") continue;
+			// Resource text is folded into the artifact; keep the rest of the resource.
+			if (block.type === "resource" && isRecord(block.resource) && "text" in block.resource) {
+				const resource = { ...block.resource };
+				delete resource.text;
+				structuredContent.push({ ...block, resource });
+				continue;
+			}
+			structuredContent.push(block);
+		}
 		if (structuredContent.length > 0) {
 			newDetails.rawContent = structuredContent;
 		} else {

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -12,7 +12,7 @@ import type {
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
-import { logger } from "@oh-my-pi/pi-utils";
+import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import { getDefault, type Settings } from "../config/settings";
 import { formatGroupedDiagnosticMessages } from "../lsp/utils";
 import type { Theme } from "../modes/theme/theme";
@@ -794,15 +794,19 @@ async function spillLargeResultToArtifact(
 	const newMeta: OutputMeta = { ...(existingMeta ?? {}), truncation: truncationMeta };
 	const newDetails = { ...(result.details ?? {}), meta: newMeta };
 
-	// The full payload now lives in the spilled artifact. Some tools duplicate
-	// that same text verbatim inside `details` — MCP results carry a second copy
-	// under `details.rawContent` (mcp/tool-bridge.ts). Left in place, every
-	// consumer that serializes `details` re-persists the whole payload: the eval
-	// bridge forwards it into `jsonOutputs`, which lands byte-for-byte in both the
-	// main session JSONL and the `.eval.log` sidecar alongside the dedicated MCP
-	// sidecar. Drop it so the artifact stays the single durable copy. See #9687.
-	if (newDetails.rawContent !== undefined) {
-		delete newDetails.rawContent;
+	// MCP details repeat text blocks already captured by the artifact. Remove
+	// only those duplicated strings: resource and image blocks retain structure
+	// (URI, MIME metadata, blobs) that the formatted artifact cannot represent.
+	const rawContent = newDetails.rawContent;
+	if (Array.isArray(rawContent)) {
+		const structuredContent = rawContent.filter(
+			(block: unknown) => !(isRecord(block) && block.type === "text" && typeof block.text === "string"),
+		);
+		if (structuredContent.length > 0) {
+			newDetails.rawContent = structuredContent;
+		} else {
+			delete newDetails.rawContent;
+		}
 	}
 
 	return { ...result, content: newContent, details: newDetails };

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -970,12 +970,11 @@ describe("Coding Agent Tools", () => {
 			}
 		});
 
-		it("should drop a spilled result's duplicated details.rawContent (#9687)", async () => {
+		it("should drop duplicated raw text while preserving structured MCP content (#9687)", async () => {
 			// MCP results carry a verbatim second copy of their content text under
-			// `details.rawContent`. When the spill truncates the content and writes
-			// the dedicated MCP sidecar, that raw copy must not survive on `details`
-			// — otherwise every consumer that serializes it (eval's jsonOutputs →
-			// main JSONL + `.eval.log`) re-persists the whole payload byte-for-byte.
+			// `details.rawContent`. The spill artifact replaces that text copy, but
+			// resource and image entries retain structure unavailable in the
+			// formatted artifact and must remain visible to eval callers.
 			const spillSettings = Settings.isolated({
 				"tools.artifactSpillThreshold": 20,
 				"tools.artifactTailBytes": 64,
@@ -991,16 +990,28 @@ describe("Coding Agent Tools", () => {
 			};
 
 			const payload = "SEARCH RESULT LINE\n".repeat(4000);
+			const resource = {
+				type: "resource" as const,
+				resource: {
+					uri: "file:///workspace/result.bin",
+					mimeType: "application/octet-stream",
+					blob: "AAECAw==",
+				},
+			};
+			const image = { type: "image" as const, data: "iVBORw0KGgo=", mimeType: "image/png" };
 			const mcpTool = {
 				name: "mcp__server__tool",
 				description: "fake mcp tool returning a large structured payload",
 				async execute() {
 					return {
-						content: [{ type: "text" as const, text: payload }],
+						content: [
+							{ type: "text" as const, text: payload },
+							{ type: "image" as const, data: image.data, mimeType: image.mimeType },
+						],
 						details: {
 							serverName: "server",
 							mcpToolName: "tool",
-							rawContent: [{ type: "text", text: payload }],
+							rawContent: [{ type: "text", text: payload }, resource, image],
 						},
 					};
 				},
@@ -1014,8 +1025,8 @@ describe("Coding Agent Tools", () => {
 				expect(truncation?.artifactId).toBeDefined();
 				expect(Buffer.byteLength(getTextOutput(result), "utf-8")).toBeLessThan(Buffer.byteLength(payload, "utf-8"));
 
-				// The full payload lives once, in the artifact — not re-embedded in details.
-				expect(result.details?.rawContent).toBeUndefined();
+				// Only the raw text has a complete representation in the artifact.
+				expect(result.details?.rawContent).toEqual([resource, image]);
 
 				const artifactPath = path.join(
 					spillManager.getArtifactsDir()!,

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1047,6 +1047,55 @@ describe("Coding Agent Tools", () => {
 			}
 		});
 
+		it("should not prune details.rawContent for non-MCP tool results (#9689)", async () => {
+			// SDK/extension tools share this spill wrapper and their `details` payload
+			// is unconstrained. A tool that happens to name a field `rawContent` must
+			// keep it verbatim: only the MCP bridge (serverName + mcpToolName) mirrors
+			// its content there, so a bare property-name collision must not lose data.
+			const spillSettings = Settings.isolated({
+				"tools.artifactSpillThreshold": 20,
+				"tools.artifactTailBytes": 64,
+				"tools.artifactTailLines": 10,
+				"tools.artifactHeadBytes": 64,
+			});
+			const spillManager = SessionManager.create(testDir, path.join(testDir, "sdk-spill-sessions"));
+			await spillManager.ensureOnDisk();
+			const context = {
+				...createTestToolContext(["custom_sdk_tool"]),
+				settings: spillSettings,
+				sessionManager: spillManager,
+			};
+
+			const payload = "SDK OUTPUT LINE\n".repeat(4000);
+			// No serverName/mcpToolName markers → not an MCP result.
+			const rawContent = [
+				{ type: "text", text: "extension-owned text that must survive" },
+				{ type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+			];
+			const sdkTool = {
+				name: "custom_sdk_tool",
+				description: "fake sdk tool that uses details.rawContent for its own data",
+				async execute() {
+					return {
+						content: [{ type: "text" as const, text: payload }],
+						details: { rawContent },
+					};
+				},
+			};
+
+			try {
+				const wrapped = wrapToolWithMetaNotice(sdkTool as unknown as AgentTool);
+				const result = await wrapped.execute("sdk-call", {}, undefined, undefined, context);
+
+				// Spill still fired on the oversized content.
+				expect(result.details?.meta?.truncation?.artifactId).toBeDefined();
+				// The tool's own rawContent is left untouched.
+				expect(result.details?.rawContent).toEqual(rawContent);
+			} finally {
+				await spillManager.close();
+			}
+		});
+
 		it("should render directories as a two-level tree without capping root entries", async () => {
 			const childDir = path.join(testDir, "child");
 			const base = Date.now() - 60_000;

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import * as zlib from "node:zlib";
-import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import type { AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { DEFAULT_BASH_INTERCEPTOR_RULES, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
@@ -965,6 +965,63 @@ describe("Coding Agent Tools", () => {
 				);
 				expect(getTextOutput(artifactResult)).toContain(line);
 				expect(saveArtifact).not.toHaveBeenCalled();
+			} finally {
+				await spillManager.close();
+			}
+		});
+
+		it("should drop a spilled result's duplicated details.rawContent (#9687)", async () => {
+			// MCP results carry a verbatim second copy of their content text under
+			// `details.rawContent`. When the spill truncates the content and writes
+			// the dedicated MCP sidecar, that raw copy must not survive on `details`
+			// — otherwise every consumer that serializes it (eval's jsonOutputs →
+			// main JSONL + `.eval.log`) re-persists the whole payload byte-for-byte.
+			const spillSettings = Settings.isolated({
+				"tools.artifactSpillThreshold": 20,
+				"tools.artifactTailBytes": 64,
+				"tools.artifactTailLines": 10,
+				"tools.artifactHeadBytes": 64,
+			});
+			const spillManager = SessionManager.create(testDir, path.join(testDir, "mcp-spill-sessions"));
+			await spillManager.ensureOnDisk();
+			const context = {
+				...createTestToolContext(["mcp__server__tool"]),
+				settings: spillSettings,
+				sessionManager: spillManager,
+			};
+
+			const payload = "SEARCH RESULT LINE\n".repeat(4000);
+			const mcpTool = {
+				name: "mcp__server__tool",
+				description: "fake mcp tool returning a large structured payload",
+				async execute() {
+					return {
+						content: [{ type: "text" as const, text: payload }],
+						details: {
+							serverName: "server",
+							mcpToolName: "tool",
+							rawContent: [{ type: "text", text: payload }],
+						},
+					};
+				},
+			};
+
+			try {
+				const wrapped = wrapToolWithMetaNotice(mcpTool as unknown as AgentTool);
+				const result = await wrapped.execute("mcp-call", {}, undefined, undefined, context);
+
+				const truncation = result.details?.meta?.truncation;
+				expect(truncation?.artifactId).toBeDefined();
+				expect(Buffer.byteLength(getTextOutput(result), "utf-8")).toBeLessThan(Buffer.byteLength(payload, "utf-8"));
+
+				// The full payload lives once, in the artifact — not re-embedded in details.
+				expect(result.details?.rawContent).toBeUndefined();
+
+				const artifactPath = path.join(
+					spillManager.getArtifactsDir()!,
+					`${truncation.artifactId}.mcp__server__tool.log`,
+				);
+				expect(await Bun.file(artifactPath).text()).toBe(payload);
 			} finally {
 				await spillManager.close();
 			}

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -970,11 +970,12 @@ describe("Coding Agent Tools", () => {
 			}
 		});
 
-		it("should drop duplicated raw text while preserving structured MCP content (#9687)", async () => {
-			// MCP results carry a verbatim second copy of their content text under
-			// `details.rawContent`. The spill artifact replaces that text copy, but
-			// resource and image entries retain structure unavailable in the
-			// formatted artifact and must remain visible to eval callers.
+		it("should strip payloads duplicated by structured MCP blocks (#9687)", async () => {
+			// MCP results carry a second copy of the payload under `details.rawContent`.
+			// Everything already stored elsewhere must be pruned so it cannot re-inflate
+			// on-disk size: text and `resource.text` land in the spill artifact, image
+			// data survives on the result content. Only resource URI/MIME/blob metadata,
+			// which has no other home, is retained.
 			const spillSettings = Settings.isolated({
 				"tools.artifactSpillThreshold": 20,
 				"tools.artifactTailBytes": 64,
@@ -990,13 +991,14 @@ describe("Coding Agent Tools", () => {
 			};
 
 			const payload = "SEARCH RESULT LINE\n".repeat(4000);
+			const resourceMeta = {
+				uri: "file:///workspace/result.bin",
+				mimeType: "application/octet-stream",
+				blob: "AAECAw==",
+			};
 			const resource = {
 				type: "resource" as const,
-				resource: {
-					uri: "file:///workspace/result.bin",
-					mimeType: "application/octet-stream",
-					blob: "AAECAw==",
-				},
+				resource: { ...resourceMeta, text: "duplicated resource body\n".repeat(200) },
 			};
 			const image = { type: "image" as const, data: "iVBORw0KGgo=", mimeType: "image/png" };
 			const mcpTool = {
@@ -1025,8 +1027,15 @@ describe("Coding Agent Tools", () => {
 				expect(truncation?.artifactId).toBeDefined();
 				expect(Buffer.byteLength(getTextOutput(result), "utf-8")).toBeLessThan(Buffer.byteLength(payload, "utf-8"));
 
-				// Only the raw text has a complete representation in the artifact.
-				expect(result.details?.rawContent).toEqual([resource, image]);
+				// Text and image are represented elsewhere; only resource metadata
+				// (without the artifact-stored text) survives on details.rawContent.
+				expect(result.details?.rawContent).toEqual([{ type: "resource", resource: resourceMeta }]);
+				// The image block is preserved on the result content.
+				expect(result.content).toContainEqual({
+					type: "image",
+					data: image.data,
+					mimeType: image.mimeType,
+				});
 
 				const artifactPath = path.join(
 					spillManager.getArtifactsDir()!,


### PR DESCRIPTION
## Repro
An `eval` cell that calls an MCP tool returning a large structured payload persists the same raw payload twice in the session artifact directory: once as the dedicated `<index>.mcp__<server>_<tool>.log` sidecar, and again inside `<index>.eval.log` under the nested result's `details.rawContent[0].text` (also in the main JSONL). The copies are byte-for-byte identical. Reproduced with a bun test that wraps a tool returning a large payload whose `details.rawContent` is a verbatim copy of its content:

```
bun test test/tools.test.ts -t "duplicated details.rawContent"
```

## Cause
The centralized large-output spill `spillLargeResultToArtifact` (`packages/coding-agent/src/tools/output-meta.ts`) exists to bound a tool result to head+tail plus an `artifact://` reference and write the dedicated sidecar. It truncates `result.content` but leaves `result.details` untouched. MCP results duplicate their full, untruncated content into `details.rawContent` (`packages/coding-agent/src/mcp/tool-bridge.ts` `buildResult`: `rawContent: result.content`). The eval JS bridge `callSessionTool` (`packages/coding-agent/src/eval/js/tool-bridge.ts`) forwards `details` verbatim, so the full payload is re-persisted into eval `jsonOutputs` → main JSONL and the `.eval.log` sidecar. No code reads `MCPToolDetails.rawContent`, so the second copy is pure on-disk amplification, and it defeats the spill's own hardening goal.

## Fix
- In `spillLargeResultToArtifact`, after building `newDetails`, drop `details.rawContent` when a result spills — the artifact already holds the full payload, so it becomes the single durable copy. This fixes both eval-nested and direct MCP calls at the single enforcement point.
- Added a regression test in `packages/coding-agent/test/tools.test.ts` that wraps a tool returning a large payload with a duplicated `details.rawContent`, asserts the content is truncated with an artifact reference, the artifact holds the full payload once, and `details.rawContent` is gone.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/tools.test.ts` → 139 pass, 1 skip, 0 fail. The new test fails before the fix (full payload retained on `details.rawContent`) and passes after. The secondary `statusEvents` observation (root vs `cells[i]`) is the deliberate aggregate-plus-per-cell shape the eval renderer reads for multi-cell evals and is left unchanged. Fixes #9687