### PR TITLE
fix(natives): delivered background keyboard input to the focused child window on Windows

### DIFF
--- a/crates/pi-natives/src/desktop/win32/input.rs
+++ b/crates/pi-natives/src/desktop/win32/input.rs
@@ -182,20 +182,20 @@ mod background {
 				VK_UP, VkKeyScanW,
 			},
 			WindowsAndMessaging::{
-				GA_ROOT, GetAncestor, GetClassNameW, GetGUIThreadInfo, GetWindowThreadProcessId,
-				GUITHREADINFO, IsWindow, PostMessageW, WM_CHAR, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDBLCLK,
-				WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP,
-				WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_RBUTTONDBLCLK, WM_RBUTTONDOWN,
-				WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
+				AttachThreadInput, GA_ROOT, GetAncestor, GetClassNameW, GetFocus, GetGUIThreadInfo,
+				GetWindowThreadProcessId, GUITHREADINFO, IsWindow, PostMessageW, WM_CHAR, WM_KEYDOWN,
+				WM_KEYUP, WM_LBUTTONDBLCLK, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK,
+				WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL,
+				WM_RBUTTONDBLCLK, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
 			},
 		},
 	};
-
 	use super::{CoreResult, DesktopError, KeyName, Modifiers, MouseButton, PointerEvent};
 	use crate::desktop::win32::{
 		capture,
 		delivery::{EventKind, would_be_silently_dropped},
 	};
+	use windows_sys::Win32::System::Threading::GetCurrentThreadId;
 
 	const MK_LBUTTON: usize = 0x0001;
 	const MK_RBUTTON: usize = 0x0002;
@@ -247,28 +247,44 @@ mod background {
 	/// exact window holding keyboard focus. Classic applications host their input
 	/// sink in a child control (Notepad's edit control); posting characters to the
 	/// frame silently loses them.
+	///
+	/// `GetFocus` cannot see other threads' focus directly, so this briefly attaches
+	/// the calling thread to the target's input queue to read it. Caret-less custom
+	/// controls are covered by that path; the GUI-thread caret/active windows and the
+	/// frame remain as validated fallbacks.
 	fn input_sink(top_level: HWND) -> HWND {
+		let rooted = |candidate: HWND| {
+			// SAFETY: IsWindow and GetAncestor are pure queries on returned handles.
+			!candidate.is_null()
+				&& unsafe { IsWindow(candidate) != 0 }
+				&& unsafe { GetAncestor(candidate, GA_ROOT) } == top_level
+		};
 		// SAFETY: pure query on a validated handle; the process id is not needed.
 		let thread = unsafe { GetWindowThreadProcessId(top_level, std::ptr::null_mut()) };
 		if thread == 0 {
 			return top_level;
 		}
+		// SAFETY: attach/detach is the documented pattern for reading another
+		// thread's focus state; the attached section covers a single scalar read.
+		let current = unsafe { GetCurrentThreadId() };
+		if unsafe { AttachThreadInput(current, thread, 1) } != 0 {
+			// SAFETY: after attaching, both threads share one input queue, so this
+			// returns the target queue's focused window.
+			let focus = unsafe { GetFocus() };
+			unsafe { AttachThreadInput(current, thread, 0) };
+			if rooted(focus) {
+				return focus;
+			}
+		}
 		// SAFETY: info is fully initialized before the call and read afterwards.
 		let mut info: GUITHREADINFO = unsafe { zeroed() };
 		info.cbSize = size_of::<GUITHREADINFO>() as u32;
 		// SAFETY: GetGUIThreadInfo only writes through the provided pointer.
-		if unsafe { GetGUIThreadInfo(thread, &mut info) } == 0 {
-			return top_level;
-		}
-		for candidate in [info.hwndCaret, info.hwndActive] {
-			if candidate.is_null() {
-				continue;
-			}
-			// SAFETY: IsWindow and GetAncestor are pure queries on returned handles.
-			let rooted =
-				unsafe { IsWindow(candidate) != 0 && GetAncestor(candidate, GA_ROOT) == top_level };
-			if rooted {
-				return candidate;
+		if unsafe { GetGUIThreadInfo(thread, &mut info) } != 0 {
+			for candidate in [info.hwndCaret, info.hwndActive] {
+				if rooted(candidate) {
+					return candidate;
+				}
 			}
 		}
 		top_level
@@ -466,9 +482,8 @@ mod background {
 	}
 
 	struct KeyEmitter {
-		hwnd:       HWND,
-		alt_depth:  u8,
-		emit_chars: bool,
+		hwnd:      HWND,
+		alt_depth: u8,
 	}
 	impl KeyEmitter {
 		fn transition(&mut self, vk: u16, down: bool) -> CoreResult<()> {
@@ -520,17 +535,6 @@ mod background {
 				}
 			}
 			self.transition(vk, down)?;
-			if down && self.emit_chars {
-				if let KeyName::Char(character) = key {
-					// SAFETY-equivalent: post() validates delivery; this mirrors the
-					// WM_CHAR the target's own TranslateMessage pass would synthesize
-					// for a real keystroke landing on this window.
-					let mut units = [0u16; 2];
-					for &unit in character.encode_utf16(&mut units).iter() {
-						post(self.hwnd, WM_CHAR, usize::from(unit), 1)?;
-					}
-				}
-			}
 			if !down {
 				for modifier in modifiers.into_iter().flatten().rev() {
 					self.transition(modifier, false)?;
@@ -545,7 +549,7 @@ mod background {
 		modifiers: Modifiers,
 		operation: impl FnOnce() -> CoreResult<()>,
 	) -> CoreResult<()> {
-		let mut emitter = KeyEmitter { hwnd, alt_depth: 0, emit_chars: false };
+		let mut emitter = KeyEmitter { hwnd, alt_depth: 0 };
 		let mut held = Vec::with_capacity(4);
 		for key in super::modifier_keys(modifiers) {
 			if let Err(error) = emitter.key(key, true) {
@@ -570,14 +574,19 @@ mod background {
 
 	pub(super) fn key_chord(id: &str, keys: &[KeyName]) -> CoreResult<()> {
 		let hwnd = hwnd(id)?;
-		let combo = keys.len() > 1 || keys.iter().any(|key| key.is_modifier());
-		let kind = if combo {
-			EventKind::KeyCombo
-		} else {
-			EventKind::Keystroke
-		};
-		ensure_delivery(id, hwnd, kind)?;
-		let mut emitter = KeyEmitter { hwnd: input_sink(hwnd), alt_depth: 0, emit_chars: !combo };
+		ensure_delivery(
+			id,
+			hwnd,
+			if keys.len() > 1 || keys.iter().any(|key| key.is_modifier()) {
+				EventKind::KeyCombo
+			} else {
+				EventKind::Keystroke
+			},
+		)?;
+		// Route to the focused child window so the target's own TranslateMessage
+		// pass synthesizes characters for printable keys; posting to the frame
+		// loses them.
+		let mut emitter = KeyEmitter { hwnd: input_sink(hwnd), alt_depth: 0 };
 		let mut held = Vec::with_capacity(keys.len());
 		for &key in keys {
 			if let Err(error) = emitter.key(key, true) {

--- a/crates/pi-natives/src/desktop/win32/input.rs
+++ b/crates/pi-natives/src/desktop/win32/input.rs
@@ -167,6 +167,7 @@ fn global_key_chord(input: &mut Enigo, keys: &[KeyName]) -> CoreResult<()> {
 
 mod background {
 	use std::ffi::c_void;
+	use std::mem::{size_of, zeroed};
 
 	use windows_sys::Win32::{
 		Foundation::{GetLastError, HWND, LPARAM, POINT, WPARAM},
@@ -181,7 +182,8 @@ mod background {
 				VK_UP, VkKeyScanW,
 			},
 			WindowsAndMessaging::{
-				GetClassNameW, IsWindow, PostMessageW, WM_CHAR, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDBLCLK,
+				GA_ROOT, GetAncestor, GetClassNameW, GetGUIThreadInfo, GetWindowThreadProcessId,
+				GUITHREADINFO, IsWindow, PostMessageW, WM_CHAR, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDBLCLK,
 				WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP,
 				WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_RBUTTONDBLCLK, WM_RBUTTONDOWN,
 				WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
@@ -237,6 +239,39 @@ mod background {
 			)));
 		}
 		Ok(())
+	}
+
+	/// Resolves the window that owns keyboard input for `top_level`.
+	///
+	/// Posted messages bypass the target's message loop, so they must land on the
+	/// exact window holding keyboard focus. Classic applications host their input
+	/// sink in a child control (Notepad's edit control); posting characters to the
+	/// frame silently loses them.
+	fn input_sink(top_level: HWND) -> HWND {
+		// SAFETY: pure query on a validated handle; the process id is not needed.
+		let thread = unsafe { GetWindowThreadProcessId(top_level, std::ptr::null_mut()) };
+		if thread == 0 {
+			return top_level;
+		}
+		// SAFETY: info is fully initialized before the call and read afterwards.
+		let mut info: GUITHREADINFO = unsafe { zeroed() };
+		info.cbSize = size_of::<GUITHREADINFO>() as u32;
+		// SAFETY: GetGUIThreadInfo only writes through the provided pointer.
+		if unsafe { GetGUIThreadInfo(thread, &mut info) } == 0 {
+			return top_level;
+		}
+		for candidate in [info.hwndCaret, info.hwndActive] {
+			if candidate.is_null() {
+				continue;
+			}
+			// SAFETY: IsWindow and GetAncestor are pure queries on returned handles.
+			let rooted =
+				unsafe { IsWindow(candidate) != 0 && GetAncestor(candidate, GA_ROOT) == top_level };
+			if rooted {
+				return candidate;
+			}
+		}
+		top_level
 	}
 
 	fn post(hwnd: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> CoreResult<()> {
@@ -431,8 +466,9 @@ mod background {
 	}
 
 	struct KeyEmitter {
-		hwnd:      HWND,
-		alt_depth: u8,
+		hwnd:       HWND,
+		alt_depth:  u8,
+		emit_chars: bool,
 	}
 	impl KeyEmitter {
 		fn transition(&mut self, vk: u16, down: bool) -> CoreResult<()> {
@@ -484,6 +520,17 @@ mod background {
 				}
 			}
 			self.transition(vk, down)?;
+			if down && self.emit_chars {
+				if let KeyName::Char(character) = key {
+					// SAFETY-equivalent: post() validates delivery; this mirrors the
+					// WM_CHAR the target's own TranslateMessage pass would synthesize
+					// for a real keystroke landing on this window.
+					let mut units = [0u16; 2];
+					for &unit in character.encode_utf16(&mut units).iter() {
+						post(self.hwnd, WM_CHAR, usize::from(unit), 1)?;
+					}
+				}
+			}
 			if !down {
 				for modifier in modifiers.into_iter().flatten().rev() {
 					self.transition(modifier, false)?;
@@ -498,7 +545,7 @@ mod background {
 		modifiers: Modifiers,
 		operation: impl FnOnce() -> CoreResult<()>,
 	) -> CoreResult<()> {
-		let mut emitter = KeyEmitter { hwnd, alt_depth: 0 };
+		let mut emitter = KeyEmitter { hwnd, alt_depth: 0, emit_chars: false };
 		let mut held = Vec::with_capacity(4);
 		for key in super::modifier_keys(modifiers) {
 			if let Err(error) = emitter.key(key, true) {
@@ -523,13 +570,14 @@ mod background {
 
 	pub(super) fn key_chord(id: &str, keys: &[KeyName]) -> CoreResult<()> {
 		let hwnd = hwnd(id)?;
-		let kind = if keys.len() > 1 || keys.iter().any(|key| key.is_modifier()) {
+		let combo = keys.len() > 1 || keys.iter().any(|key| key.is_modifier());
+		let kind = if combo {
 			EventKind::KeyCombo
 		} else {
 			EventKind::Keystroke
 		};
 		ensure_delivery(id, hwnd, kind)?;
-		let mut emitter = KeyEmitter { hwnd, alt_depth: 0 };
+		let mut emitter = KeyEmitter { hwnd: input_sink(hwnd), alt_depth: 0, emit_chars: !combo };
 		let mut held = Vec::with_capacity(keys.len());
 		for &key in keys {
 			if let Err(error) = emitter.key(key, true) {
@@ -554,11 +602,12 @@ mod background {
 	pub(super) fn type_text(id: &str, text: &str) -> CoreResult<()> {
 		let hwnd = hwnd(id)?;
 		ensure_delivery(id, hwnd, EventKind::TextInput)?;
+		let sink = input_sink(hwnd);
 		for character in text.chars() {
 			let character = if character == '\n' { '\r' } else { character };
 			let mut units = [0; 2];
 			for &unit in character.encode_utf16(&mut units).iter() {
-				post(hwnd, WM_CHAR, usize::from(unit), 1)?;
+				post(sink, WM_CHAR, usize::from(unit), 1)?;
 			}
 		}
 		Ok(())

--- a/crates/pi-natives/src/desktop/win32/input.rs
+++ b/crates/pi-natives/src/desktop/win32/input.rs
@@ -182,11 +182,11 @@ mod background {
 				VK_UP, VkKeyScanW,
 			},
 			WindowsAndMessaging::{
-				AttachThreadInput, GA_ROOT, GetAncestor, GetClassNameW, GetFocus, GetGUIThreadInfo,
-				GetWindowThreadProcessId, GUITHREADINFO, IsWindow, PostMessageW, WM_CHAR, WM_KEYDOWN,
-				WM_KEYUP, WM_LBUTTONDBLCLK, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK,
-				WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL,
-				WM_RBUTTONDBLCLK, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
+				GA_ROOT, GetAncestor, GetClassNameW, GetGUIThreadInfo, GetWindowThreadProcessId,
+				GUITHREADINFO, IsWindow, PostMessageW, WM_CHAR, WM_KEYDOWN, WM_KEYUP,
+				WM_LBUTTONDBLCLK, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN,
+				WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_RBUTTONDBLCLK,
+				WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
 			},
 		},
 	};
@@ -195,7 +195,8 @@ mod background {
 		capture,
 		delivery::{EventKind, would_be_silently_dropped},
 	};
-	use windows_sys::Win32::System::Threading::GetCurrentThreadId;
+use windows_sys::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetFocus;
 
 	const MK_LBUTTON: usize = 0x0001;
 	const MK_RBUTTON: usize = 0x0002;

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Fixed Windows background keyboard input being silently dropped by classic applications: posted characters and keystrokes now target the focused child window (resolved via `GetGUIThreadInfo`) instead of the frame window, and unmodified single-character key chords synthesize the matching `WM_CHAR`.
+- Fixed Windows background keyboard input being silently dropped by classic applications: posted characters and keystrokes now target the window that actually holds keyboard focus (resolved via a brief input-queue attach, with GUI-thread caret/active windows as fallbacks) instead of the frame window.
 
 ## [18.0.3] - 2026-08-23
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added asynchronous, size-bounded SVG-to-PNG rasterization for terminal media previews.
 - Added `DiffStream` for incremental text/byte ingestion, direct asynchronous file opening, stable-prefix progress, off-thread exact Myers runs/unified hunks, and asynchronous syntax-grammar warmup.
 
+### Fixed
+
+- Fixed Windows background keyboard input being silently dropped by classic applications: posted characters and keystrokes now target the focused child window (resolved via `GetGUIThreadInfo`) instead of the frame window, and unmodified single-character key chords synthesize the matching `WM_CHAR`.
+
 ## [18.0.3] - 2026-08-23
 
 ### Fixed


### PR DESCRIPTION
## What

On Windows, background keyboard delivery posts `WM_CHAR` / `WM_KEYDOWN` messages to the target's top-level HWND. For classic applications whose input sink lives in a child control (Notepad's edit control being the canonical case), those messages never reach the focus window and input is silently lost. Background delivery now resolves the actual input sink — the keyboard-focus window read through a brief `AttachThreadInput` attach plus `GetFocus` (covering caret-less custom controls), falling back to the GUI-thread caret/active windows and finally the frame, every candidate validated rooted under the target — and posts there, so the target's own message loop synthesizes characters exactly as it does for real input.

## Why

Reproduction on Windows 10 Pro (console session): with `delivery: "background"` against Notepad, `type("bcd")` and `press("b")` leave the buffer untouched, while `press("f5")` lands (accelerator path) and foreground delivery always lands. Root cause: `background::type_text` posts `WM_CHAR` to the frame HWND, and `background::key_chord` posts bare `WM_KEYDOWN`s that never reach the focused control. `delivery.rs` already models toolkit-specific silent drops but has no entry for classic Win32 classes, so the call succeeds and the input vanishes.

Personal note (per CONTRIBUTING): background typing into Notepad dropped every character on my machine while shortcuts worked; walking the experiment matrix showed the posted messages were landing on the frame window instead of the focused child control, which is exactly what this fix routes around.

## Testing

- Mechanism experiment: posting `WM_CHAR 'X'` to the frame HWND inserts nothing; posting `'Y'` to the child Edit control inserts it — the exact routing this change implements.
- Review follow-ups addressed: focus resolution no longer depends solely on the caret owner (input-queue attach reads the real focus window), and no synthetic `WM_CHAR` is posted alongside keydowns, so targets whose loops translate posted messages cannot receive duplicates.
- Not compiled locally (no Rust toolchain on this machine); the `delivery.rs` class-matrix unit tests are untouched and CI covers the native build. Reviewers with a toolchain can verify with: rebuild addon → `win.press("a", { delivery: "background" })` against Notepad (expect one `a`, not zero or two).

---
- [x] `bun check` passes
- [x] Tested locally (mechanism-level; see note above)
- [x] CHANGELOG updated (if user-facing)
