### PR TITLE
fix(coding-agent): interrupt in-flight turn on plan-mode exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed exiting plan mode mid-turn not taking effect until the agent produced a plan; a user exit now interrupts the in-flight turn immediately ([#9699](https://github.com/can1357/oh-my-pi/issues/9699))
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -110,6 +110,7 @@ import {
 import type { CompactMode } from "../session/compact-modes";
 import type { ForeignSessionSource } from "../session/foreign-session-store";
 import { HistoryStorage } from "../session/history-storage";
+import { USER_INTERRUPT_LABEL } from "../session/messages";
 import type { SessionContext } from "../session/session-context";
 import { getRecentSessions } from "../session/session-listing";
 import type { SessionManager } from "../session/session-manager";
@@ -3148,7 +3149,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// (issue #8326).
 		if (options?.interruptActiveTurn && this.session.isStreaming) {
 			await this.session.runModeExitTeardown(async () => {
-				await this.session.abort();
+				await this.session.abort({ reason: USER_INTERRUPT_LABEL });
 				await this.#tearDownPlanMode(options);
 			});
 			return;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3129,11 +3129,38 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async #exitPlanMode(options?: { silent?: boolean; paused?: boolean; deferModelRestore?: boolean }): Promise<void> {
+	async #exitPlanMode(options?: {
+		silent?: boolean;
+		paused?: boolean;
+		deferModelRestore?: boolean;
+		interruptActiveTurn?: boolean;
+	}): Promise<void> {
 		if (!this.planModeEnabled) {
 			return;
 		}
+		// A mid-turn user exit must land on the CURRENTLY streaming turn, not only
+		// the next one. The turn-start `plan-mode-active.md` block orders the model
+		// to keep planning until it writes a plan to `xd://propose`, so without
+		// interrupting the live turn the agent keeps acting in plan mode until it
+		// emits a plan (issue #9699). Mirror `#exitVibeMode`: abort inside
+		// `runModeExitTeardown` so a queued steer/follow-up cannot restart on the
+		// still-live plan toolset before teardown restores the previous tools
+		// (issue #8326).
+		if (options?.interruptActiveTurn && this.session.isStreaming) {
+			await this.session.runModeExitTeardown(async () => {
+				await this.session.abort();
+				await this.#tearDownPlanMode(options);
+			});
+			return;
+		}
+		await this.#tearDownPlanMode(options);
+	}
 
+	async #tearDownPlanMode(options?: {
+		silent?: boolean;
+		paused?: boolean;
+		deferModelRestore?: boolean;
+	}): Promise<void> {
 		const planModeState = this.session.getPlanModeState();
 		const planModeTools = this.session.getEnabledToolNames();
 		const planModeMountedTools = this.session.getMountedXdevToolNames();
@@ -3771,7 +3798,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				);
 				if (!confirmed) return false;
 			}
-			await this.#exitPlanMode({ paused: true });
+			await this.#exitPlanMode({ paused: true, interruptActiveTurn: true });
 			return false;
 		}
 		if (this.planModePaused && !initialPrompt) {

--- a/packages/coding-agent/test/interactive-mode-plan-mode-exit.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-mode-exit.test.ts
@@ -18,6 +18,7 @@ import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mod
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -76,13 +77,17 @@ describe("InteractiveMode plan mode exit", () => {
 
 	it("aborts the in-flight turn when exited mid-stream", async () => {
 		const started = Promise.withResolvers<void>();
+		let abortReason: unknown;
 		streamFn = (_model, _context, options) => {
 			const stream = new AssistantMessageEventStream();
 			queueMicrotask(() => {
 				stream.push({ type: "start", partial: createAssistantMessage("") });
 				options?.signal?.addEventListener(
 					"abort",
-					() => stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") }),
+					() => {
+						abortReason = options.signal?.reason;
+						stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") });
+					},
 					{ once: true },
 				);
 				started.resolve();
@@ -104,5 +109,6 @@ describe("InteractiveMode plan mode exit", () => {
 		expect(mode.planModeEnabled).toBe(false);
 		expect(session.isStreaming).toBe(false);
 		expect(session.getPlanModeState()).toBeUndefined();
+		expect(abortReason).toBe(USER_INTERRUPT_LABEL);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-mode-exit.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-mode-exit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Contract: exiting plan mode while a model turn is streaming interrupts that
+ * turn immediately, rather than only affecting the next turn.
+ *
+ * Regression for #9699: `#enterPlanMode` steers a fresh plan context into a live
+ * turn, but `#exitPlanMode` used to clear state without touching the in-flight
+ * turn. The turn-start `plan-mode-active.md` block orders the model to keep
+ * planning until it writes a plan, so a mid-turn user exit appeared to do nothing
+ * — the agent kept acting in plan mode until it produced a plan. Exit must now
+ * abort the streaming turn (mirroring `#exitVibeMode`).
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent, type StreamFn } from "@oh-my-pi/pi-agent-core";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage, createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+describe("InteractiveMode plan mode exit", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let streamFn: StreamFn | undefined;
+	let mode: InteractiveMode;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		await initTheme();
+		tempDir = TempDir.createSync("@pi-plan-exit-");
+		authStorage = createInMemoryAuthStorage();
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		// prompt() preflights credentials via modelRegistry.getApiKey; the in-memory
+		// auth storage has no anthropic key, so stub it.
+		vi.spyOn(modelRegistry, "getApiKey").mockResolvedValue("test-key");
+		streamFn = undefined;
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+				streamFn: (...args) => {
+					if (!streamFn) throw new Error("No test stream configured");
+					return streamFn(...args);
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({}),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test", undefined, undefined, undefined, undefined, new EventBus());
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		await session?.dispose();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("aborts the in-flight turn when exited mid-stream", async () => {
+		const started = Promise.withResolvers<void>();
+		streamFn = (_model, _context, options) => {
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial: createAssistantMessage("") });
+				options?.signal?.addEventListener(
+					"abort",
+					() => stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") }),
+					{ once: true },
+				);
+				started.resolve();
+			});
+			return stream;
+		};
+
+		await mode.handlePlanModeCommand();
+		expect(mode.planModeEnabled).toBe(true);
+
+		const prompt = session.prompt("Investigate and plan");
+		await started.promise;
+		expect(session.isStreaming).toBe(true);
+
+		// Exit plan mode while the turn is still streaming.
+		await mode.handlePlanModeCommand();
+		await prompt;
+
+		expect(mode.planModeEnabled).toBe(false);
+		expect(session.isStreaming).toBe(false);
+		expect(session.getPlanModeState()).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
Enable plan mode and let the agent investigate/task-plan across several tool calls, then exit plan mode (`/plan` or `Alt+Shift+P`) while the turn is still streaming. The exit appears to do nothing: the agent keeps behaving as if still in plan mode until it finally outputs a plan. Reproduced with a behavioral test — enter plan mode, start a streaming turn, exit mid-stream: without the fix the turn never ends after exit (`bun test test/interactive-mode-plan-mode-exit.test.ts` times out at 5s).

## Cause
Plan mode is a session-side toggle, not a model tool. Each turn `AgentSession.#buildPlanModeMessage()` injects `plan-mode-active.md`, whose `<critical>` block orders the model to keep planning until it writes a plan to `xd://propose`. `InteractiveMode.#enterPlanMode` steers a fresh plan context into a live turn when `session.isStreaming` (`interactive-mode.ts:3083`), but `#exitPlanMode` had no symmetric branch — it cleared `PlanModeState` and restored tools for the *next* turn only, leaving the in-flight turn running under the turn-start plan instructions.

## Fix
- Split `#exitPlanMode`'s teardown into `#tearDownPlanMode` and add an `interruptActiveTurn` option.
- When a user-initiated exit occurs mid-stream, abort the in-flight turn inside `session.runModeExitTeardown(...)`, mirroring `#exitVibeMode`, so a queued steer/follow-up cannot restart on the still-live plan toolset (issue #8326).
- Pass `interruptActiveTurn: true` from the `handlePlanModeCommand` user-toggle exit path; the approval/save callers keep the previous next-turn semantics.

## Verification
`bun test test/interactive-mode-plan-mode-exit.test.ts test/interactive-mode-plan-review.test.ts test/interactive-mode-vibe-toggle.test.ts test/interactive-mode-default-plan-mode.test.ts` — 88 pass, 0 fail. The new regression test asserts a mid-stream exit aborts the turn (`session.isStreaming` returns to `false`) and clears plan state; it times out against the pre-fix code. Fixes #9699