### PR TITLE
fix(discovery): load marketplace plugin rules

### DIFF
--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -15,7 +15,7 @@ In the TUI, `/marketplace` with no arguments opens the interactive plugin browse
 
 A **marketplace** is a Git repository (or local directory) containing a catalog file at `.omp-plugin/marketplace.json` (preferred) or `.claude-plugin/marketplace.json` (Claude Code-compatible fallback). The catalog lists available plugins with their sources, descriptions, and metadata.
 
-A **plugin** is a directory containing Claude/OMP plugin content such as skills, commands, agents, hooks, tools, MCP servers, or LSP servers. Marketplace installs also load extension modules declared by `package.json` `omp.extensions`: installation symlinks the cached plugin into the scope's `node_modules` tree and records it in `omp-plugins.lock.json`, the same runtime surfaces used by npm-installed and `omp plugin link`ed plugins. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
+A **plugin** is a directory containing Claude/OMP plugin content such as skills, commands, agents, rules, hooks, tools, MCP servers, or LSP servers. Marketplace installs also load extension modules declared by `package.json` `omp.extensions`: installation symlinks the cached plugin into the scope's `node_modules` tree and records it in `omp-plugins.lock.json`, the same runtime surfaces used by npm-installed and `omp plugin link`ed plugins. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
 
 **Scopes**: marketplace plugins can be installed at two scopes:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed marketplace-installed plugins silently omitting their `rules/` directories from discovery ([#9702](https://github.com/can1357/oh-my-pi/issues/9702)).
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -11,12 +11,14 @@ import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type Hook, hookCapability } from "../capability/hook";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
+import { type Rule, ruleCapability } from "../capability/rule";
 import { type Skill, skillCapability } from "../capability/skill";
 import { type SlashCommand, slashCommandCapability } from "../capability/slash-command";
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import { legacyProviderAllowed } from "./agent-plugin-format";
 import {
+	buildRuleFromMarkdown,
 	type ClaudePluginRoot,
 	createSourceMeta,
 	expandEnvVarsDeep,
@@ -239,6 +241,29 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 			items.push(...result.items);
 			if (result.warnings) warnings.push(...result.warnings);
 		}
+	}
+	return { items, warnings };
+}
+
+// =============================================================================
+// Rules
+// =============================================================================
+
+async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
+	const { roots, warnings } = await allowedRoots(ctx, "other");
+	const results = await Promise.all(
+		roots.map(root =>
+			loadFilesFromDir<Rule>(ctx, path.join(root.path, "rules"), PROVIDER_ID, root.scope, {
+				extensions: ["md", "mdc"],
+				transform: (name, content, filePath, source) =>
+					buildRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
+			}),
+		),
+	);
+	const items: Rule[] = [];
+	for (const result of results) {
+		items.push(...result.items);
+		if (result.warnings) warnings.push(...result.warnings);
 	}
 	return { items, warnings };
 }
@@ -606,6 +631,14 @@ registerProvider<Skill>(skillCapability.id, {
 	description: "Load skills from Claude Code marketplace plugins (~/.claude/plugins/cache/)",
 	priority: PRIORITY,
 	load: loadSkills,
+});
+
+registerProvider<Rule>(ruleCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Load rules from marketplace plugin rules directories",
+	priority: PRIORITY,
+	load: loadRules,
 });
 
 registerProvider<SlashCommand>(slashCommandCapability.id, {

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -250,7 +250,8 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 // =============================================================================
 
 async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
-	const { roots, warnings } = await allowedRoots(ctx, "other");
+	const { roots, warnings: rootWarnings } = await allowedRoots(ctx, "other");
+	const warnings = [...rootWarnings];
 	const results = await Promise.all(
 		roots.map(root =>
 			loadFilesFromDir<Rule>(ctx, path.join(root.path, "rules"), PROVIDER_ID, root.scope, {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -14,6 +14,7 @@ import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { __resetDirsFromEnvForTests, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
 
@@ -533,6 +534,43 @@ describe("listClaudePluginRoots", () => {
 		const result = await listClaudePluginRoots(tempDir);
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0].scope).toBe("user");
+	});
+	test("loads rules from OMP marketplace plugins", async () => {
+		const pluginsDir = path.join(tempDir, ".omp", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "omp-rules");
+		await Promise.all([
+			fs.mkdir(pluginsDir, { recursive: true }),
+			fs.mkdir(path.join(pluginPath, "rules"), { recursive: true }),
+		]);
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"omp-rules@market": [
+						{
+							scope: "user",
+							installPath: pluginPath,
+							version: "1.0.0",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(
+			path.join(pluginPath, "package.json"),
+			JSON.stringify({ name: "omp-rules", omp: { extensions: ["./extension.ts"] } }),
+		);
+		await fs.writeFile(
+			path.join(pluginPath, "rules", "style.md"),
+			"---\ndescription: Marketplace style rule\n---\nUse tabs.\n",
+		);
+
+		const result = await loadCapability<Rule>("rules", { cwd: tempDir });
+		const found = result.all.find(rule => rule.name === "style");
+
+		expect(found?.description).toBe("Marketplace style rule");
+		expect(found?._source?.provider).toBe("claude-plugins");
 	});
 	test("reads skills directory from plugin manifest skills field", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");


### PR DESCRIPTION
## Repro

An OMP marketplace registry entry whose installed package declares `omp.extensions` and contains `rules/style.md` returns no `style` rule. Reproduced with `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts --test-name-pattern 'loads rules from OMP marketplace plugins'`: before the fix, the assertion received `undefined`.

## Cause

`listInstalledPluginRoots` in `packages/coding-agent/src/discovery/omp-extension-roots.ts` intentionally excludes marketplace realpaths so the same package is not presented by both native and Claude marketplace providers. `packages/coding-agent/src/discovery/claude-plugins.ts` owned those roots but registered no `ruleCapability` provider, so `rules/` had no discovery path.

## Fix

- Register marketplace `rules/` directories with `ruleCapability` through the existing `claude-plugins` provider.
- Parse `.md` and `.mdc` files with the shared rule builder used by native extension discovery.
- Add an OMP marketplace registry regression test and document rules as a marketplace plugin surface.
- Add the coding-agent changelog entry.

## Verification

`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` passes: 40 tests, 96 assertions. Skipped the pre-publish gate because `bun run fix` fails identically on an `origin/main` archive while building `audiopus_sys`: CMake is not installed in the workstation.

Fixes #9702