### PR TITLE
fix(agent,coding-agent): escalated auto-shake before falling back to a costlier method

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ESCALATED_SHAKE_CONFIG`, a shake preset with the manual preset's reach that keeps the live tail and artifact recovery reads protected, for callers that need one deeper pass before falling back to a costlier compaction method ([#9705](https://github.com/can1357/oh-my-pi/pull/9705) by [@srobroek](https://github.com/srobroek)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Changed

--- a/packages/agent/src/compaction/shake.ts
+++ b/packages/agent/src/compaction/shake.ts
@@ -73,6 +73,20 @@ export const RESCUE_SHAKE_CONFIG: ShakeConfig = {
 	protectedTools: [...AGGRESSIVE_SHAKE_CONFIG.protectedTools, isArtifactRecoveryToolResult],
 };
 
+/**
+ * Auto-compaction escalation: the manual preset's reach with its recent tail
+ * kept, tried once when the conservative pass is about to fall through to a
+ * lossy or paid compaction method. Artifact recovery reads stay protected —
+ * automatic mode must never elide the reads used to recover already-elided
+ * content, which is what separates this from {@link AGGRESSIVE_SHAKE_CONFIG}.
+ */
+export const ESCALATED_SHAKE_CONFIG: ShakeConfig = {
+	...RESCUE_SHAKE_CONFIG,
+	// Unlike rescue, this runs before the situation is a dead end, so the live
+	// tail the agent is currently working from stays intact (#7776).
+	protectTokens: AGGRESSIVE_SHAKE_CONFIG.protectTokens,
+};
+
 /** Rough token cost of a placeholder line; used only for the savings gate. */
 const PLACEHOLDER_TOKEN_ESTIMATE = 16;
 

--- a/packages/agent/test/shake.test.ts
+++ b/packages/agent/test/shake.test.ts
@@ -7,6 +7,7 @@ import {
 	applyShakeRegions,
 	collectShakeRegions,
 	DEFAULT_SHAKE_CONFIG,
+	ESCALATED_SHAKE_CONFIG,
 	RESCUE_SHAKE_CONFIG,
 } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, TextContent, ToolCall, ToolResultMessage } from "@oh-my-pi/pi-ai";
@@ -237,6 +238,44 @@ describe("shake config presets", () => {
 		const regions = collectShakeRegions([recent], tokenizer, RESCUE_SHAKE_CONFIG);
 		expect(regions).toHaveLength(1);
 		expect(regions[0].entry).toBe(recent);
+	});
+
+	test("escalated preset reaches the regions the auto preset's protect window hides", () => {
+		// The state automatic compaction gets stuck in once earlier shakes have
+		// elided old history: every remaining eligible result sits inside the auto
+		// preset's 16k window, so it reclaims nothing and the caller would advance
+		// to a lossy or paid method. 12 × ~980 tokens keeps the whole branch under
+		// 16k while leaving the oldest entries outside the escalated 4k tail.
+		const entries: SessionEntry[] = [];
+		for (let index = 0; index < 12; index++) {
+			entries.push(messageEntry(toolResultMessage("bash", `row ${index} payload `.repeat(280))));
+		}
+		expect(collectShakeRegions(entries, tokenizer, DEFAULT_SHAKE_CONFIG)).toHaveLength(0);
+
+		const escalated = collectShakeRegions(entries, tokenizer, ESCALATED_SHAKE_CONFIG);
+		const savings = escalated.reduce((total, region) => total + region.tokens, 0);
+		// Worth the pass: more than the savings floor the auto preset never met.
+		expect(savings).toBeGreaterThan(DEFAULT_SHAKE_CONFIG.minSavings);
+		// The live tail survives — escalation is not the dead-end rescue.
+		expect(escalated.map(region => region.entry)).not.toContain(entries[entries.length - 1]);
+	});
+
+	test("escalated preset keeps the artifact recovery reads the manual preset drops", () => {
+		const call = messageEntry(
+			assistantMessage([{ type: "toolCall", id: "tc-artifact", name: "read", arguments: { path: "artifact://7" } }]),
+		);
+		const recovery = messageEntry(toolResultMessage("read", "recovered ".repeat(600), { toolCallId: "tc-artifact" }));
+		// Pushes the recovery read out of the 4k tail both presets share, so the
+		// protected-tools list is the only thing that can still separate them.
+		const tail = messageEntry(toolResultMessage("bash", "tail row payload ".repeat(1_500)));
+		const entries = [call, recovery, tail];
+
+		expect(collectShakeRegions(entries, tokenizer, ESCALATED_SHAKE_CONFIG).map(region => region.entry)).not.toContain(
+			recovery,
+		);
+		expect(collectShakeRegions(entries, tokenizer, AGGRESSIVE_SHAKE_CONFIG).map(region => region.entry)).toContain(
+			recovery,
+		);
 	});
 
 	test("empty branch yields no regions", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed automatic compaction advancing to a lossy or paid method when the conservative shake pass reclaimed nothing; it now tries one deeper shake pass first, keeping the live tail and artifact recovery reads intact ([#9705](https://github.com/can1357/oh-my-pi/pull/9705) by [@srobroek](https://github.com/srobroek)).
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -25,6 +25,7 @@ import {
 	createCompactionSummaryMessage,
 	DEFAULT_SHAKE_CONFIG,
 	type CompactionSettings as EngineCompactionSettings,
+	ESCALATED_SHAKE_CONFIG,
 	effectiveReserveTokens,
 	invalidateMessageCache,
 	isTranscriptUsageAnchor,
@@ -3866,7 +3867,8 @@ export class SessionMaintenance {
 				);
 				return COMPACTION_CHECK_NONE;
 			}
-			const reclaimed = result.toolResultsDropped + result.blocksDropped > 0;
+			let reclaimed = result.toolResultsDropped + result.blocksDropped > 0;
+			let tokensFreed = result.tokensFreed;
 			// Detect the dead-loop reported in issues #2119/#2275: the threshold check
 			// fires, shake runs, but residual context is still above the configured
 			// threshold. The next agent_end would re-trigger shake, which has nothing
@@ -3889,22 +3891,60 @@ export class SessionMaintenance {
 			// even though the post-prune history is already inside the recovery band.
 			const contextWindow = this.#model?.contextWindow ?? 0;
 			const compactionSettings = this.#host.settings.getGroup("compaction");
-			let stillOverThreshold = false;
-			if (contextWindow > 0) {
+			const stillOverThreshold = (): boolean => {
+				if (contextWindow <= 0) return false;
 				if (typeof triggerContextTokens === "number" && Number.isFinite(triggerContextTokens)) {
-					const correctedTokens = Math.max(0, triggerContextTokens - result.tokensFreed);
+					const correctedTokens = Math.max(0, triggerContextTokens - tokensFreed);
 					const thresholdTokens = resolveThresholdTokens(contextWindow, compactionSettings);
 					const recoveryBand = Math.floor(thresholdTokens * COMPACTION_RECOVERY_BAND);
-					stillOverThreshold = correctedTokens > recoveryBand;
-				} else {
-					const postShakeTokens = this.#host.getContextUsage({ contextWindow })?.tokens ?? 0;
-					stillOverThreshold = shouldCompact(postShakeTokens, contextWindow, compactionSettings);
+					return correctedTokens > recoveryBand;
+				}
+				const postShakeTokens = this.#host.getContextUsage({ contextWindow })?.tokens ?? 0;
+				return shouldCompact(postShakeTokens, contextWindow, compactionSettings);
+			};
+			const wouldFallBack = (): boolean =>
+				reason !== "idle" && ((reason === "overflow" && !reclaimed) || stillOverThreshold());
+
+			let shouldFallBack = wouldFallBack();
+			if (shouldFallBack) {
+				// Falling through here is expensive: snapcompact re-encodes history
+				// into images (lossy, spends the media budget, rewrites the whole
+				// prompt cache) and handoff costs a model call. The conservative pass
+				// is usually out of *reach* rather than out of material — once earlier
+				// shakes have elided old history, the only eligible regions left sit
+				// inside its 16k protected tail. So try one deeper pass first: free,
+				// reversible via the artifact link, and still protecting the artifact
+				// recovery reads the agent needs to get elided content back. One
+				// attempt only, no loop; "idle" never reaches here.
+				const escalated = await this.#host.shake("elide", { config: ESCALATED_SHAKE_CONFIG, signal });
+				if (signal.aborted) {
+					await this.#emitLifecycleEvent(
+						{
+							type: "auto_compaction_end",
+							action,
+							result: undefined,
+							aborted: true,
+							willRetry: false,
+						},
+						detachPostCommit,
+					);
+					return COMPACTION_CHECK_NONE;
+				}
+				if (escalated.toolResultsDropped + escalated.blocksDropped > 0) {
+					reclaimed = true;
+					tokensFreed += escalated.tokensFreed;
+					shouldFallBack = wouldFallBack();
+					logger.debug("Auto-shake escalated past the conservative protect window", {
+						tokensFreed: escalated.tokensFreed,
+						toolResultsDropped: escalated.toolResultsDropped,
+						blocksDropped: escalated.blocksDropped,
+						resolved: !shouldFallBack,
+					});
 				}
 			}
-			const shouldFallBack = reason !== "idle" && ((reason === "overflow" && !reclaimed) || stillOverThreshold);
 			if (shouldFallBack) {
 				const errorMessage = reclaimed
-					? `Auto-shake reclaimed ~${result.tokensFreed} tokens but context is still above the threshold; trying the next preferred compaction method.`
+					? `Auto-shake reclaimed ~${tokensFreed} tokens but context is still above the threshold; trying the next preferred compaction method.`
 					: "Auto-shake found nothing eligible to drop; trying the next preferred compaction method.";
 				await this.#emitLifecycleEvent(
 					{

--- a/packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts
@@ -543,7 +543,8 @@ describe("AgentSession mid-run threshold compaction", () => {
 		expect(providerOutcome).toBe("dispatched");
 		expect(promptOutcome).toBe("settled");
 		expect(compactSpy).toHaveBeenCalledTimes(1);
-		if (shakeSpy) expect(shakeSpy).toHaveBeenCalledTimes(1);
+		// Bounded at the conservative pass plus one escalated retry — not a loop.
+		if (shakeSpy) expect(shakeSpy).toHaveBeenCalledTimes(2);
 		expect(observedContexts[1].join("\n")).toContain("MID-RUN-COMPACTED-WITHOUT-WAITING-ON-LIFECYCLE");
 	});
 

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentMessage, RESCUE_SHAKE_CONFIG, Tokenizer } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { DEFAULT_SHAKE_CONFIG, ESCALATED_SHAKE_CONFIG } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, ImageContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -644,9 +645,10 @@ describe("AgentSession shake", () => {
 			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
 			await session.waitForIdle();
 
-			// Shake fires once. The pre-fix bug auto-continued, which would re-trigger shake
-			// on the next agent_end. The fix replaces that loop with a one-shot fallback.
-			expect(shakeSpy).toHaveBeenCalledTimes(1);
+			// One maintenance pass: the conservative config then the escalated one. The
+			// pre-fix bug auto-continued, which would re-trigger shake on the next
+			// agent_end. The fix replaces that loop with a one-shot fallback.
+			expect(shakeSpy).toHaveBeenCalledTimes(2);
 
 			const shakeEnd = events.find(
 				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
@@ -655,6 +657,114 @@ describe("AgentSession shake", () => {
 			expect(shakeEnd?.errorMessage).toMatch(/trying the next preferred compaction method/i);
 
 			// Fallback enters the context-full path so the situation actually resolves.
+			const fullStart = events.find(
+				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
+			);
+			expect(fullStart).toBeDefined();
+		});
+
+		it("escalates past the protect window before advancing when the conservative pass reclaims nothing", async () => {
+			session.settings.set("compaction.methodOrder", ["shake", "soft"]);
+			session.settings.set("compaction.thresholdPercent", 1);
+			session.settings.set("contextPromotion.enabled", false);
+
+			// The tail-only-eligible state: the 16k protect window hides everything
+			// that is left, so the conservative pass reclaims nothing. Advancing here
+			// would spend a lossy snapcompact (or a paid handoff) on work the free
+			// escalated pass can still do.
+			const shakeSpy = vi.spyOn(session, "shake").mockImplementation(async (_mode, opts) => ({
+				mode: "elide" as const,
+				toolResultsDropped: opts?.config === ESCALATED_SHAKE_CONFIG ? 1 : 0,
+				blocksDropped: 0,
+				tokensFreed: opts?.config === ESCALATED_SHAKE_CONFIG ? 10_000 : 0,
+			}));
+
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: {
+					input: 10_000,
+					output: 1_000,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 11_000,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			};
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await session.waitForIdle();
+
+			// Conservative pass, then exactly one escalated pass — no loop.
+			expect(shakeSpy.mock.calls.map(call => call[1]?.config)).toEqual([
+				DEFAULT_SHAKE_CONFIG,
+				ESCALATED_SHAKE_CONFIG,
+			]);
+
+			// The escalated savings brought context inside the recovery band, so the
+			// paid tier is never reached.
+			const fullStart = events.find(
+				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
+			);
+			expect(fullStart).toBeUndefined();
+
+			// Both passes live inside one lifecycle pair.
+			expect(events.filter(e => e.type === "auto_compaction_start")).toHaveLength(1);
+			const end = events.filter(e => e.type === "auto_compaction_end") as Array<{
+				errorMessage?: string;
+				skipped?: boolean;
+			}>;
+			expect(end).toHaveLength(1);
+			expect(end[0].errorMessage).toBeUndefined();
+			expect(end[0].skipped).toBe(false);
+		});
+
+		it("advances anyway when the escalated pass reclaims too little to clear the threshold", async () => {
+			session.settings.set("compaction.methodOrder", ["shake", "soft"]);
+			session.settings.set("compaction.thresholdPercent", 1);
+			session.settings.set("contextPromotion.enabled", false);
+
+			const shakeSpy = vi.spyOn(session, "shake").mockImplementation(async (_mode, opts) => ({
+				mode: "elide" as const,
+				toolResultsDropped: opts?.config === ESCALATED_SHAKE_CONFIG ? 1 : 0,
+				blocksDropped: 0,
+				tokensFreed: opts?.config === ESCALATED_SHAKE_CONFIG ? 500 : 0,
+			}));
+
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: {
+					input: 10_000,
+					output: 1_000,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 11_000,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			};
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await session.waitForIdle();
+
+			expect(shakeSpy).toHaveBeenCalledTimes(2);
+
+			// The escalated savings are credited to the fall-through decision, so the
+			// notice reports what was actually reclaimed instead of "nothing eligible".
+			const shakeEnd = events.find(
+				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
+			) as { errorMessage?: string; skipped?: boolean } | undefined;
+			expect(shakeEnd?.errorMessage).toBe(
+				"Auto-shake reclaimed ~500 tokens but context is still above the threshold; trying the next preferred compaction method.",
+			);
+			expect(shakeEnd?.skipped).toBe(false);
+
 			const fullStart = events.find(
 				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
 			);
@@ -698,7 +808,8 @@ describe("AgentSession shake", () => {
 			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
 			await session.waitForIdle();
 
-			expect(shakeSpy).toHaveBeenCalledTimes(1);
+			// Conservative pass plus the one escalated retry that precedes fall-through.
+			expect(shakeSpy).toHaveBeenCalledTimes(2);
 
 			const shakeEnd = events.find(
 				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
@@ -823,7 +934,8 @@ describe("AgentSession shake", () => {
 
 			await session.prompt("small pending prompt", { skipCompactionCheck: true });
 
-			expect(shakeSpy).toHaveBeenCalledTimes(1);
+			// Conservative pass plus the one escalated retry that precedes fall-through.
+			expect(shakeSpy).toHaveBeenCalledTimes(2);
 			expect(compactSpy).toHaveBeenCalled();
 			const fullStart = events.find(
 				event => event.type === "auto_compaction_start" && (event as { action?: string }).action === "context-full",


### PR DESCRIPTION
I instrumented context fill-rate on a long session and saw another compaction method run immediately after every automatic shake. The cause is tier selection. The automatic path only ever runs the conservative shake preset, so it gives up while a free deeper pass is still available. This change makes it try that pass first.

## What changed

At the point where automatic compaction would advance to the next configured method, it now attempts one further shake pass. That pass uses the manual preset's reach, keeps the live tail, and keeps artifact recovery reads protected. It then recomputes the advance decision from the savings of both passes together. Only if the deeper pass also fails does maintenance advance.

Bounds on the new behavior:

- One escalated attempt per auto-shake call, with no loop and no recursion.
- Both passes report inside the existing `auto_compaction_start` / `auto_compaction_end` pair. No second lifecycle pair.
- The `idle` trigger never escalates, because it never reaches the advance branch.
- Manual `/shake` stays as it is.
- The dead-end rescue path stays as it is.
- `compaction.methodOrder` semantics stay as they are.

## Why the old behavior was wrong

`shake` ships three presets. The automatic path passed only the conservative one. That preset keeps the newest 16k tokens intact. It also needs 4k of estimated savings before it acts.

Together those two guards create a dead spot:

1. Earlier shakes elide the older history.
2. Only regions inside the 16k protected tail stay eligible.
3. The conservative pass finds nothing outside that window, so it reclaims zero.
4. Zero misses its own 4k savings floor, so the pass reports nothing to drop.
5. Thousands of elidable tokens still sit outside a 4k tail. The added unit test measures 7,840 of them in one branch.

Where maintenance went instead depends on `compaction.methodOrder`:

- Under the shipped default (`remote, snapcompact, handoff, shake, soft`) the next method is `soft`. That summarizes in place and calls a compaction model.
- Where an operator puts `shake` first, which is the arrangement that makes shake the cheap first-line defense, the next method is `snapcompact` or `handoff`. `snapcompact` archives history onto dense bitmap images. That re-encode loses fidelity, and a per-request payload budget bounds it. `handoff` costs another model call.

So the session spent a lossy transformation or a paid call. A free elision could still do that work, and its placeholder embeds an `artifact://` recovery link.

One asymmetry is deliberate. The escalated preset keeps artifact recovery reads protected, and that is the only respect in which it differs from the manual `/shake` preset. Eliding a `read artifact://<id>` result strips the content the agent uses to recover already-elided material. That trades a saving for a recovery loop.

I claim no prompt-cache saving. Like the next method, the escalated pass rewrites stored history and replaces the agent's messages, so either path discards the cached prefix. The difference is that the elision reverses mechanically and costs no model call.

## Evidence

Reporter-side observation, and explicitly not a controlled benchmark: an instrumented session on a 1M-context model with a 200k compaction threshold logged 54 automatic shake events. A snapcompact followed every one, in the same maintenance pass. That run was a fill-rate experiment, not a study of this defect. Treat it as consistent with the dead spot, not as a measurement of it.

The mechanical half reproduces without a session, and the added unit test pins it. A branch of 12 tool results at roughly 980 tokens each totals under 16k. The conservative preset returns no regions. The escalated preset returns 8 regions worth 7,840 tokens, past the 4k floor the conservative pass could not reach.

## Test plan

Added, in `packages/agent/test/shake.test.ts`:

- the 12-result branch, asserting zero regions under the conservative preset and 7,840 tokens under the escalated one. The newest entry stays excluded, which proves the live tail survives.
- an artifact recovery read placed outside the 4k tail both presets share. The escalated preset keeps it. The manual preset drops it.

Added, in `packages/coding-agent/test/shake.test.ts`:

- a threshold pass whose conservative shake reclaims nothing and whose escalated shake reclaims enough. It asserts the order of the two configs, that the run never enters the paid tier, and that it emits one lifecycle pair.
- the same shape with the escalated pass reclaiming too little. Maintenance still advances, and the notice reports the escalated savings instead of "found nothing eligible".

Both new cases fail on the unmodified tree. I reverted only the `session-maintenance.ts` change and re-ran, which gave 5 failures: the 2 new cases plus 3 older assertions that count shake calls on the advance path.

I updated those 3 assertions from one call to two, in `packages/coding-agent/test/shake.test.ts` (the #2119 and #2275 regressions, and the pre-prompt advance case) and in `packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts`. Each one pins "one shot, not a loop", and each still does. The bound is now the conservative pass plus one escalated retry.

I ran these commands:

```
bun test packages/agent/test/shake.test.ts                                   21 pass, 0 fail
bun test packages/coding-agent/test/shake.test.ts                            20 pass, 0 fail
bun test packages/coding-agent/test/agent-session-goal-midrun-compaction.test.ts    13 pass, 0 fail
bun test <5 further compaction files>                                        55 pass, 0 fail
bun test <6 further shake and protection files>                              68 pass, 0 fail
bun --cwd=packages/agent run check:types                                     clean
bun --cwd=packages/coding-agent run check:types                              clean
bun x biome check <changed files>                                            clean
```

The 11 further files are the ones that mock `session.shake` or drive compaction method selection:

- auto-compaction progress guard, mid-turn dead-end, snapcompact frame dead-end
- compaction speculation, snapcompact auto-fallback, handoff
- auto-compaction queue, context consolidation
- tool protection, plan protection, the `/shake` slash command

I did not run repo-wide `bun check` or the full suite. Because `cmake` is absent, `cargo` on this machine cannot build `crates/pi-natives`. So I ran against the prebuilt `pi_natives.darwin-arm64.node` from the published package. As a control for that addon, every test file in the list passes on it unmodified, before my change.

## Open question

Should a settings key gate this, or is an unconditional retry right?

I left it unconditional on purpose. The retry is reachable only on a path that already decided to spend something more expensive, and it costs no model call. It does change what an operator sees: one extra shake pass, and a deeper elision than the automatic tier reached before. If you prefer it opt-in or opt-out, name the default you want. I did not introduce a setting on your behalf.

## Adjacent work

- #7043 ("Shake doesn't shake enough") is related but distinct. That issue concerns on-disk session weight, which shake relocates to an artifact rather than shrinking. This change concerns which shake tier the automatic path selects.
- #6352 (periodic shake interval) and #8277 (incomplete-output recovery gating) both touch `session-maintenance.ts` and `shake.test.ts`, at different decision points. Neither changes shake tier selection. Expect a textual rebase at most, not a semantic conflict.
