### PR TITLE
docs(browser-relay): document relay scope for operators and relay semantics in the agent-facing tool prompt

### DIFF
--- a/docs/user-facing-packages.md
+++ b/docs/user-facing-packages.md
@@ -74,7 +74,9 @@ Sources: [`packages/browser-relay/README.md`](../packages/browser-relay/README.m
 
 - Package: private `@oh-my-pi/browser-relay`; user command: `omp browser-relay`.
 - Setup: run `omp browser-relay install`, load the unpacked extension from
-  `~/.omp/browser-relay/extension`, then set `browser.relay` or use `app.relay: true`.
+  `~/.omp/browser-relay/extension`, then opt in per call with `app.relay: true` — or set
+  `browser.relay`, which makes the relay the profile-wide default across projects (scope
+  details in the package README).
 - Behavior: the relay auto-starts through the global daemon broker; `app.target` selects a tab by
   URL/title substring, otherwise the visible tab is adopted.
 - Security/limits: it binds loopback; use `--token` when local processes are untrusted. Chrome

--- a/packages/browser-relay/CHANGELOG.md
+++ b/packages/browser-relay/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Documented the scope of the two relay opt-in paths: per-call `app.relay: true`, and the `browser.relay` setting as the profile-wide default across projects.
+
 ## [17.2.5] - 2026-08-03
 
 ### Added

--- a/packages/browser-relay/README.md
+++ b/packages/browser-relay/README.md
@@ -7,7 +7,9 @@ The companion relay server lives in the omp CLI (`omp browser-relay`, see `packa
 ## Setup
 
 1. `omp browser-relay install` — writes the bundled extension to `~/.omp/browser-relay/extension`, then load it via `chrome://extensions` → Developer mode → *Load unpacked*. (Or grab `omp-browser-relay-extension.zip` from GitHub releases.)
-2. `omp config set browser.relay true` — routes the browser tool through the relay. Per-call `app.relay: true` works without the setting.
+2. Opt in, one of two ways:
+   - **Per call** — pass `app.relay: true` on the `browser open` that needs your real browser. Works without any setting and persists nothing: the configured default for every other call and session stays whatever it already was.
+   - **As the default** — `omp config set browser.relay true` makes the relay the default for **every session using this profile, in every project** (project-level settings, `PI_BROWSER_RELAY`, and an explicit `app` choice still take precedence). Any session's ordinary browser call will then drive your real browser — including background sessions you aren't watching; without `app.target` such a call adopts the currently visible tab, and if it carries a `url` it navigates that tab away from what you were reading.
 
 That's it: the relay server auto-starts under omp's profile-independent global daemon broker the first time the browser tool needs it. Every relay consumer holds a broker lease, so one project exiting cannot interrupt another; the server stops after the last consumer across all projects exits. The extension badge turns **on** when connected. Run `omp browser-relay` manually only for `--token`, `--no-group`, or a non-default port — a relay already serving the port is adopted, never fought over.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - Standardized completed edit results on hashline-style path and numbered-preview output across edit modes.
+- Documented relay semantics in the browser tool's model-facing prompt: relay can engage via the `browser.relay` setting without `app.relay`, every relay open result says `on relay`, and the session is then inside the user's real logged-in browser with the conduct that follows.
 - Made `omp git` stream file contents into an off-thread native differ, paint complete lines immediately, progressively apply syntax highlighting, and defer large commit file statistics until after the first interactive frame.
 - Added `r` shortcut to refresh the git state
 - Added `s`/`u` shortcuts to stage/unstage files directly from the sidebar

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -20,7 +20,8 @@ Drives real Chromium tab; full puppeteer access via JS.
   - Raw request interception is run-scoped: run end removes `request` handlers, disables interception, releases held requests.
 
 - `app.path` → NEVER tamper with a real desktop app (no stealth patches).
-- `app.relay: true` → drive the user's own Chrome tabs via the omp browser relay (auto-started; needs the OMP Browser Relay extension installed). `app.target` picks a tab by URL/title substring; without it the visible tab is adopted without stealing focus.
+- `app.relay: true` → drive the user's own Chrome tabs via the omp browser relay (auto-started; needs the OMP Browser Relay extension installed). `app.target` picks a tab by URL/title substring; without it the visible tab is adopted — and an `open` carrying `url` NAVIGATES that adopted tab.
+- Relay can also engage without `app.relay` when the `browser.relay` setting is on; every relay open result says `on relay`. Either way you are inside the user's REAL logged-in browser: every tab, session, and click belongs to the user and sites attribute your actions to their account. Name a target (or create your own tab), never navigate the user's visible tab uninvited, take no consequential action the user didn't ask for, and `close` when done.
 - `close` releases the named tool session. It closes tool-owned headless pages and owned cmux surfaces, but NEVER closes pages in CDP-connected or relay browsers. Spawned-browser pages remain open unless `kill: true` terminates their process.
 - Selectors: CSS + puppeteer `aria/…`, `text/…`, `xpath/…`, `pierce/…`. Playwright-only pseudos (`:has-text()`, `:visible`) are REJECTED.
 </instruction>


### PR DESCRIPTION
## What

Documentation only — no behavior change. Documents the two relay opt-in paths and their different scopes, on both surfaces where that knowledge is consumed:

- `packages/browser-relay/README.md` — setup step 2 split into the two paths: per-call `app.relay: true` (works without any setting, persists nothing) vs the `browser.relay` setting (the default for every session using the profile, in every project; project-level settings, `PI_BROWSER_RELAY`, and an explicit `app` choice still take precedence), including what a no-`app.target` call does (adopts the visible tab; a `url` navigates it).
- `packages/coding-agent/src/prompts/tools/browser.md` (model-facing tool prompt) — two bullets: relay can engage via the setting without `app.relay`, and every relay open result says `on relay`; what that means (the user's real logged-in browser, actions attributed to the user's accounts) and the conduct that follows (name a target or create your own tab, don't navigate the visible tab uninvited, no consequential actions the user didn't ask for, `close` when done).
- `docs/user-facing-packages.md` — summary line aligned with the above.
- `packages/browser-relay/CHANGELOG.md` — `Unreleased → Changed` entry.

## Why

The docs currently present the two paths as interchangeable ("then set `browser.relay` or use `app.relay: true`") with no scope statement, and the tool prompt gives relay no meaning an agent can act on.

Observed on a live setup (WSL relay daemon, Windows Brave extension): with `browser.relay` left on after relay setup, a background session's routine no-`app` `browser open` carrying a `url` resolved to relay, adopted the tab the user was reading, and navigated it away. The session's transcript shows the `on relay` marker in the open result went unheeded — nothing in its tool prompt says what that marker means or implies. The user's first signal was their own browser moving.

**From the submitter** (written in Korean, translated to English with AI assistance):

> While I was trying out the browser relay, the global switch got enabled without my noticing; later, an agent working in a different session started operating my browser. That agent, however, understood itself to be using its own internal browser, not mine. This seemed to need an explanation.

> 원문: 브라우저 릴레이 사용 시도 과정에서 나도 모르는 새 전역 스위치가 켜졌고, 이후 다른 세션에서 작업하던 에이전트가 내 브라우저를 조작했다. 그러나 해당 에이전트는 내 브라우저가 아니라 자기 자신의 내부 브라우저를 사용한 것으로 인지하고 있었다. 이에 대한 설명이 필요해보인다.

**Note (intentionally out of scope)**: the deeper gap — an agent that never asked for the relay has no structural moment of awareness when a setting routes it there — likely wants a design decision (e.g. a confirmation or a stronger notice on implicit relay resolution). This PR only makes the existing documentation surfaces say what is true.

**Review gate (pre-PR)**: 2 independent review rounds. Round 1: two precision findings on the scope claims ("machine-wide" corrected to profile-wide with the precedence exceptions; an over-broad "everything else stays headless" guarantee removed) — both verified against the settings/kind-resolution code and addressed. Round 2 (model-facing prompt hunk only): clean; one non-blocking wording tightening applied ("every relay open result says `on relay`", since the marker is not unique to the implicit path).

## Testing

Docs-only; every factual claim was checked against the code at `969a94c1e`: setting scope and precedence (`src/tools/browser.ts` kind resolution, `relay/kind.ts`, settings layering), visible-tab adoption and `url` navigation on the adopted tab (`pickElectronTarget()`, tab-worker init), identical `on relay` result wording for both opt-in paths, and `Target.createTarget` → `createTab` backing the "create your own tab" guidance. The described incident is from a real transcript on this machine. `bun run check` (biome + tsgo) passes in `packages/browser-relay` and `packages/coding-agent`.

---

- [x] `bun check` passes (per-package `bun run check` in both touched packages; `check:rs` needs `cmake`, unavailable here and unrelated to a docs-only change)
- [x] Tested locally (claims verified against source as above; no behavior to test)
- [x] CHANGELOG updated (if user-facing)
