### PR TITLE
fix(coding-agent): resolve composer cache to XDG_CACHE

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the composer speculative startup cache ignoring `XDG_CACHE_HOME`
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/modes/composer-cache.ts
+++ b/packages/coding-agent/src/modes/composer-cache.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getAgentDir } from "@oh-my-pi/pi-utils/dirs";
+import { getComposerCacheDir } from "@oh-my-pi/pi-utils/dirs";
 import type { LspServerInfo, RecentSession } from "./components/welcome";
 import type { ComposerPreferences } from "./composer";
 import type { SymbolPreset } from "./theme/theme";
@@ -31,7 +31,7 @@ export interface ComposerStartupCache {
 
 function projectCacheDir(cwd: string): string {
 	const key = Bun.hash.wyhash(path.resolve(cwd)).toString(16).padStart(16, "0");
-	return path.join(getAgentDir(), "cache", "composer", key);
+	return path.join(getComposerCacheDir(), key);
 }
 
 function readFile(file: string): string | undefined {

--- a/packages/coding-agent/test/composer-cache.test.ts
+++ b/packages/coding-agent/test/composer-cache.test.ts
@@ -10,14 +10,14 @@ import {
 	writeComposerUiCache,
 	writeComposerWelcomeCache,
 } from "@oh-my-pi/pi-coding-agent/modes/composer-cache";
-import { getAgentDir } from "@oh-my-pi/pi-utils/dirs";
+import { getComposerCacheDir } from "@oh-my-pi/pi-utils/dirs";
 
 describe("composer startup cache", () => {
 	it("round-trips per-project UI, recent-session JSONL, and LSP speculation", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-composer-cache-"));
 		const otherCwd = `${cwd}-other`;
 		const key = Bun.hash.wyhash(path.resolve(cwd)).toString(16).padStart(16, "0");
-		const cacheDir = path.join(getAgentDir(), "cache", "composer", key);
+		const cacheDir = path.join(getComposerCacheDir(), key);
 		try {
 			const preferences = { ...COMPOSER_DEFAULTS, composerShape: "rail", autocompleteMaxVisible: 7 };
 			const recentSessions = [{ name: "cached work", timeAgo: "3m ago" }];

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exported `getComposerCacheDir` to resolve the per-project composer speculative cache directory under the XDG cache category, so the coding-agent composer startup cache honors `XDG_CACHE_HOME` like the other agent caches.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -782,6 +782,10 @@ export function getTinyModelsCacheDir(agentDir?: string): string {
 export function getDocumentConversionCacheDir(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, path.join("cache", "document-conversions"), "cache");
 }
+/** Get the per-project composer speculative cache directory (~/.omp/agent/cache/composer; XDG default: $XDG_CACHE_HOME/omp/cache/composer). */
+export function getComposerCacheDir(agentDir?: string): string {
+	return dirs.agentSubdir(agentDir, path.join("cache", "composer"), "cache");
+}
 
 /** Get the sessions directory (~/.omp/agent/sessions). */
 export function getSessionsDir(agentDir?: string): string {

--- a/packages/utils/test/dirs-cache.test.ts
+++ b/packages/utils/test/dirs-cache.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	__resetDirsFromEnvForTests,
 	getActiveProfile,
+	getComposerCacheDir,
 	getConfigDirName,
 	getDocumentConversionCacheDir,
 	getMarketplacesRegistryPath,
@@ -59,6 +60,18 @@ describe("document conversion cache directory", () => {
 		expect(getDocumentConversionCacheDir()).toBe(
 			path.join(process.env.XDG_CACHE_HOME, "omp", "cache", "document-conversions"),
 		);
+	});
+
+	it("routes getComposerCacheDir to $XDG_CACHE_HOME/omp/cache/composer", async () => {
+		if (process.platform === "win32") return;
+
+		process.env.XDG_CACHE_HOME = path.join(tempRoot, "cache");
+		await fs.mkdir(path.join(process.env.XDG_CACHE_HOME, "omp"), { recursive: true });
+
+		const defaultAgentDir = path.join(os.homedir(), getConfigDirName(), "agent");
+		setAgentDir(defaultAgentDir);
+
+		expect(getComposerCacheDir()).toBe(path.join(process.env.XDG_CACHE_HOME, "omp", "cache", "composer"));
 	});
 
 	it("stays under a custom PI_CODING_AGENT_DIR", () => {


### PR DESCRIPTION
## What

<!-- Brief description of the change -->
fix `cache/composer` to right place with xdg
## Why
comon fix
<!-- Motivation, context, or link to issue (fixes #N) -->

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
