### PR TITLE
fix(tui): hide advisor XML in session tree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### Fixed
 
-- Fixed advisor notes exposing their model-facing XML wrappers in the `/tree` session view.
+- Fixed advisor notes in the `/tree` session view exposing their model-facing XML wrapper; rows now read `advisor (name, severity): note` in plain text.
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed advisor notes exposing their model-facing XML wrappers in the `/tree` session view.
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -10,6 +10,7 @@ import {
 	TruncatedText,
 	truncateToWidth,
 } from "@oh-my-pi/pi-tui";
+import { isRecord } from "@oh-my-pi/pi-utils";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import {
@@ -58,6 +59,15 @@ type FilterMode = TreeFilterMode;
 interface ToolCallInfo {
 	name: string;
 	arguments: Record<string, unknown>;
+}
+
+function advisorNoteText(details: unknown): string {
+	if (!isRecord(details) || !Array.isArray(details.notes)) return "";
+	const notes: string[] = [];
+	for (const note of details.notes) {
+		if (isRecord(note) && typeof note.note === "string") notes.push(note.note);
+	}
+	return notes.join(" ");
 }
 
 class TreeList implements Component {
@@ -372,11 +382,13 @@ class TreeList implements Component {
 			}
 			case "custom_message": {
 				parts.push(entry.customType);
-				if (typeof entry.content === "string") {
-					parts.push(entry.content);
-				} else {
-					parts.push(this.#extractContent(entry.content));
-				}
+				const content =
+					entry.customType === "advisor"
+						? advisorNoteText(entry.details)
+						: typeof entry.content === "string"
+							? entry.content
+							: this.#extractContent(entry.content);
+				if (content) parts.push(content);
 				break;
 			}
 			case "compaction":
@@ -664,12 +676,14 @@ class TreeList implements Component {
 			}
 			case "custom_message": {
 				const content =
-					typeof entry.content === "string"
-						? entry.content
-						: entry.content
-								.filter((c): c is { type: "text"; text: string } => c.type === "text")
-								.map(c => c.text)
-								.join("");
+					entry.customType === "advisor"
+						? advisorNoteText(entry.details)
+						: typeof entry.content === "string"
+							? entry.content
+							: entry.content
+									.filter((c): c is { type: "text"; text: string } => c.type === "text")
+									.map(c => c.text)
+									.join("");
 				result = theme.fg("customMessageLabel", `[${entry.customType}]: `) + normalize(content);
 				break;
 			}

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -10,7 +10,7 @@ import {
 	TruncatedText,
 	truncateToWidth,
 } from "@oh-my-pi/pi-tui";
-import { isRecord } from "@oh-my-pi/pi-utils";
+import { isRecord, sanitizeText } from "@oh-my-pi/pi-utils";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import {
@@ -70,6 +70,18 @@ interface AdvisorTreeDisplay {
 }
 
 /**
+ * Collapse a raw advisor field (a `WATCHDOG.yml`-supplied name or severity) to
+ * a single safe line: strip ANSI/control characters via the shared sanitizer,
+ * then fold the tab/newline it intentionally preserves into spaces so the value
+ * cannot split or misalign a session-tree row.
+ */
+function sanitizeAdvisorField(value: string): string {
+	return sanitizeText(value)
+		.replace(/[\n\t]/g, " ")
+		.trim();
+}
+
+/**
  * Extract display metadata from an advisor custom-message's `details.notes`,
  * ignoring the model-facing `<advisory>` wrapper stored in `content`. Collects
  * distinct non-default advisor names and severities so the tree row can tag the
@@ -83,16 +95,13 @@ function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
 	for (const note of details.notes) {
 		if (!isRecord(note)) continue;
 		if (typeof note.note === "string") notes.push(note.note);
-		if (
-			typeof note.advisor === "string" &&
-			note.advisor &&
-			note.advisor !== "default" &&
-			!advisors.includes(note.advisor)
-		) {
-			advisors.push(note.advisor);
+		if (typeof note.advisor === "string") {
+			const name = sanitizeAdvisorField(note.advisor);
+			if (name && name !== "default" && !advisors.includes(name)) advisors.push(name);
 		}
-		if (typeof note.severity === "string" && note.severity && !severities.includes(note.severity)) {
-			severities.push(note.severity);
+		if (typeof note.severity === "string") {
+			const severity = sanitizeAdvisorField(note.severity);
+			if (severity && !severities.includes(severity)) severities.push(severity);
 		}
 	}
 	return { qualifier: [...advisors, ...severities].join(", "), text: notes.join(" ") };

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -61,13 +61,41 @@ interface ToolCallInfo {
 	arguments: Record<string, unknown>;
 }
 
-function advisorNoteText(details: unknown): string {
-	if (!isRecord(details) || !Array.isArray(details.notes)) return "";
+/** Advisor note metadata surfaced on a single session-tree row. */
+interface AdvisorTreeDisplay {
+	/** Non-default advisor names then severities, comma-joined (e.g. `sec, blocker`). */
+	qualifier: string;
+	/** Note bodies joined into one line. */
+	text: string;
+}
+
+/**
+ * Extract display metadata from an advisor custom-message's `details.notes`,
+ * ignoring the model-facing `<advisory>` wrapper stored in `content`. Collects
+ * distinct non-default advisor names and severities so the tree row can tag the
+ * note the way its transcript card does.
+ */
+function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
+	if (!isRecord(details) || !Array.isArray(details.notes)) return { qualifier: "", text: "" };
 	const notes: string[] = [];
+	const advisors: string[] = [];
+	const severities: string[] = [];
 	for (const note of details.notes) {
-		if (isRecord(note) && typeof note.note === "string") notes.push(note.note);
+		if (!isRecord(note)) continue;
+		if (typeof note.note === "string") notes.push(note.note);
+		if (
+			typeof note.advisor === "string" &&
+			note.advisor &&
+			note.advisor !== "default" &&
+			!advisors.includes(note.advisor)
+		) {
+			advisors.push(note.advisor);
+		}
+		if (typeof note.severity === "string" && note.severity && !severities.includes(note.severity)) {
+			severities.push(note.severity);
+		}
 	}
-	return notes.join(" ");
+	return { qualifier: [...advisors, ...severities].join(", "), text: notes.join(" ") };
 }
 
 class TreeList implements Component {
@@ -382,13 +410,14 @@ class TreeList implements Component {
 			}
 			case "custom_message": {
 				parts.push(entry.customType);
-				const content =
-					entry.customType === "advisor"
-						? advisorNoteText(entry.details)
-						: typeof entry.content === "string"
-							? entry.content
-							: this.#extractContent(entry.content);
-				if (content) parts.push(content);
+				if (entry.customType === "advisor") {
+					const { qualifier, text } = advisorTreeDisplay(entry.details);
+					if (qualifier) parts.push(qualifier);
+					if (text) parts.push(text);
+				} else {
+					const content = typeof entry.content === "string" ? entry.content : this.#extractContent(entry.content);
+					if (content) parts.push(content);
+				}
 				break;
 			}
 			case "compaction":
@@ -675,15 +704,19 @@ class TreeList implements Component {
 				break;
 			}
 			case "custom_message": {
+				if (entry.customType === "advisor") {
+					const { qualifier, text } = advisorTreeDisplay(entry.details);
+					const label = qualifier ? `advisor (${qualifier}): ` : "advisor: ";
+					result = theme.fg("customMessageLabel", label) + normalize(text);
+					break;
+				}
 				const content =
-					entry.customType === "advisor"
-						? advisorNoteText(entry.details)
-						: typeof entry.content === "string"
-							? entry.content
-							: entry.content
-									.filter((c): c is { type: "text"; text: string } => c.type === "text")
-									.map(c => c.text)
-									.join("");
+					typeof entry.content === "string"
+						? entry.content
+						: entry.content
+								.filter((c): c is { type: "text"; text: string } => c.type === "text")
+								.map(c => c.text)
+								.join("");
 				result = theme.fg("customMessageLabel", `[${entry.customType}]: `) + normalize(content);
 				break;
 			}

--- a/packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+function render(tree: SessionTreeNode[]): string {
+	const selector = new TreeSelectorComponent(
+		tree,
+		tree[0]?.entry.id ?? null,
+		60,
+		() => {},
+		() => {},
+	);
+	return Bun.stripANSI(selector.render(120).join("\n"));
+}
+
+describe("TreeSelectorComponent advisor message rendering", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("shows advisor notes without their model-facing XML wrapper", () => {
+		const details = {
+			notes: [{ note: "Check error handling.", severity: "concern" }],
+		};
+		const tree: SessionTreeNode[] = [
+			{
+				entry: {
+					type: "custom_message",
+					id: "advisor-entry",
+					parentId: null,
+					timestamp: "2026-08-25T00:00:00.000Z",
+					customType: "advisor",
+					content:
+						'<advisory severity="concern" guidance="weigh, don\'t blindly obey">\nCheck error handling.\n</advisory>',
+					details,
+					display: true,
+				},
+				children: [],
+			},
+		];
+
+		const rendered = render(tree);
+
+		expect(rendered).toContain("[advisor]: Check error handling.");
+		expect(rendered).not.toContain("<advisory");
+		expect(rendered).not.toContain("</advisory>");
+	});
+});

--- a/packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts
@@ -3,6 +3,31 @@ import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/component
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 
+interface AdvisorNoteFixture {
+	note: string;
+	severity?: "nit" | "concern" | "blocker";
+	advisor?: string;
+}
+
+function advisorTree(...notes: AdvisorNoteFixture[]): SessionTreeNode[] {
+	return [
+		{
+			entry: {
+				type: "custom_message",
+				id: "advisor-entry",
+				parentId: null,
+				timestamp: "2026-08-25T00:00:00.000Z",
+				customType: "advisor",
+				// Model-facing wrapper that must never surface in the tree row.
+				content: notes.map(n => `<advisory severity="${n.severity ?? ""}">\n${n.note}\n</advisory>`).join("\n"),
+				details: { notes },
+				display: true,
+			},
+			children: [],
+		},
+	];
+}
+
 function render(tree: SessionTreeNode[]): string {
 	const selector = new TreeSelectorComponent(
 		tree,
@@ -19,31 +44,25 @@ describe("TreeSelectorComponent advisor message rendering", () => {
 		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
 	});
 
-	it("shows advisor notes without their model-facing XML wrapper", () => {
-		const details = {
-			notes: [{ note: "Check error handling.", severity: "concern" }],
-		};
-		const tree: SessionTreeNode[] = [
-			{
-				entry: {
-					type: "custom_message",
-					id: "advisor-entry",
-					parentId: null,
-					timestamp: "2026-08-25T00:00:00.000Z",
-					customType: "advisor",
-					content:
-						'<advisory severity="concern" guidance="weigh, don\'t blindly obey">\nCheck error handling.\n</advisory>',
-					details,
-					display: true,
-				},
-				children: [],
-			},
-		];
+	it("shows advisor notes with severity and without their model-facing XML wrapper", () => {
+		const rendered = render(advisorTree({ note: "Check error handling.", severity: "concern" }));
 
-		const rendered = render(tree);
-
-		expect(rendered).toContain("[advisor]: Check error handling.");
+		expect(rendered).toContain("advisor (concern): Check error handling.");
+		expect(rendered).not.toContain("[advisor]");
 		expect(rendered).not.toContain("<advisory");
 		expect(rendered).not.toContain("</advisory>");
+	});
+
+	it("tags a named advisor with its name before the severity", () => {
+		const rendered = render(advisorTree({ note: "Nitpick.", severity: "nit", advisor: "sec" }));
+
+		expect(rendered).toContain("advisor (sec, nit): Nitpick.");
+	});
+
+	it("omits the qualifier for a default advisor with no severity", () => {
+		const rendered = render(advisorTree({ note: "Continue.", advisor: "default" }));
+
+		expect(rendered).toContain("advisor: Continue.");
+		expect(rendered).not.toContain("advisor (");
 	});
 });

--- a/packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts
@@ -65,4 +65,12 @@ describe("TreeSelectorComponent advisor message rendering", () => {
 		expect(rendered).toContain("advisor: Continue.");
 		expect(rendered).not.toContain("advisor (");
 	});
+
+	it("folds tabs/newlines in a WATCHDOG-supplied advisor name into a single-line qualifier", () => {
+		const rendered = render(advisorTree({ note: "Careful.", severity: "blocker", advisor: "sec\tteam\nlead" }));
+
+		expect(rendered).toContain("advisor (sec team lead, blocker): Careful.");
+		expect(rendered).not.toContain("\t");
+		expect(rendered.split("\n").filter(line => line.includes("advisor ("))).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Repro
Enable the advisor, produce an advisor note, then open `/tree`. The focused regression reproduces the failure with `bun test packages/coding-agent/test/modes/components/tree-selector-advisor.test.ts`: before the fix the tree row rendered `[advisor]: <advisory …>Check error handling.</advisory>`.

## Cause
`TreeList.#getEntryDisplayText()` in `packages/coding-agent/src/modes/components/tree-selector.ts` used every custom message's persisted `content` as display text. Advisor `content` intentionally contains model-facing `<advisory>` markup, while its plain display notes live in `details.notes`.

## Fix
- Render advisor tree rows from persisted note metadata instead of model-facing content.
- Use the same plain note text for tree search.
- Add a focused regression test and user-facing changelog entry.

## Verification
`bun test packages/coding-agent/test/modes/components/tree-selector*.test.ts` passed 21 tests; `bun run check:types` passed in `packages/coding-agent`; the pre-publish `bun run fix` and `bun check` gate passed. Fixes #9708