### PR TITLE
fix(tui): select numbered menu option by pressing its digit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed numbered selector menus (e.g. `/review`) ignoring digit keys; pressing `1`–`9` now jumps to and selects that option ([#9710](https://github.com/can1357/oh-my-pi/issues/9710)).
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -633,6 +633,22 @@ export class HookSelectorComponent extends OverlayPanel {
 		return true;
 	}
 
+	/** Jump to (and, for single-select menus, immediately confirm) the option at
+	 *  1-based digit `1`–`9`. Skipped while type-to-search is active so digits
+	 *  stay searchable, and for out-of-range or disabled targets. Checkbox menus
+	 *  only move the cursor — confirmation stays on `enter`. Returns whether the
+	 *  keypress was consumed. */
+	#handleQuickSelect(keyData: string): boolean {
+		if (this.#isSearchEnabled()) return false;
+		if (keyData.length !== 1 || keyData < "1" || keyData > "9") return false;
+		const target = this.#filteredOptions[Number(keyData) - 1];
+		if (!target || this.#isDisabled(target.index)) return true;
+		this.#selectedIndex = Number(keyData) - 1;
+		this.#updateList();
+		if (this.#selectionMarker !== "checkbox") this.#onSelectCallback(target.option.label);
+		return true;
+	}
+
 	handleInput(keyData: string): void {
 		if (this.#countdown) {
 			this.#countdown.reset();
@@ -645,6 +661,10 @@ export class HookSelectorComponent extends OverlayPanel {
 		}
 
 		if (this.#handleSearchInput(keyData)) {
+			return;
+		}
+
+		if (this.#handleQuickSelect(keyData)) {
 			return;
 		}
 

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -239,6 +239,93 @@ describe("HookSelectorComponent", () => {
 		expect(selected).toBeUndefined();
 	});
 
+	it("selects and confirms the option at the pressed digit", () => {
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			"Pick one",
+			["First", "Second", "Third"],
+			option => {
+				selected = option;
+			},
+			() => {},
+		);
+
+		component.handleInput("3");
+
+		expect(selected).toBe("Third");
+	});
+
+	it("ignores a digit that targets a disabled option", () => {
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			"Pick one",
+			["First", "Disabled", "Third"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ disabledIndices: [1] },
+		);
+
+		component.handleInput("2");
+
+		expect(selected).toBeUndefined();
+	});
+
+	it("ignores a digit past the end of the list", () => {
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			"Pick one",
+			["First", "Second"],
+			option => {
+				selected = option;
+			},
+			() => {},
+		);
+
+		component.handleInput("9");
+
+		expect(selected).toBeUndefined();
+	});
+
+	it("moves the cursor without confirming on checkbox menus", () => {
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			"Pick many",
+			["First", "Second", "Third"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ selectionMarker: "checkbox" },
+		);
+
+		component.handleInput("2");
+		expect(selected).toBeUndefined();
+
+		component.handleInput("\n");
+		expect(selected).toBe("Second");
+	});
+
+	it("treats digits as search text once the list overflows", () => {
+		let selected: string | undefined;
+		const options = Array.from({ length: 20 }, (_, i) => `Option ${i + 1}`);
+		const component = new HookSelectorComponent(
+			"Pick one",
+			options,
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ maxVisible: 5 },
+		);
+
+		component.handleInput("1");
+
+		expect(selected).toBeUndefined();
+		expect(component.render(80).join("\n")).toContain("Search: 1");
+	});
+
 	it("renders disabled options dimmed", () => {
 		const component = new HookSelectorComponent(
 			"Pick one",


### PR DESCRIPTION
## Repro
Run `/review`, then press `1` to pick "Review against a base branch". Nothing happens. The mode menu labels its options `1.`–`4.`, implying digit selection, yet every digit keypress is a no-op. Reproduced in-process by driving `HookSelectorComponent` with the exact review labels: `component.handleInput("1")` leaves the select callback uninvoked (`undefined`).

## Cause
`HookSelectorComponent.handleInput` (`packages/coding-agent/src/modes/components/hook-selector.ts`) handles cancel / type-to-search / up-down / enter / left-right / external-editor but has no digit-to-index branch. The `/review` menu (`packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts:492-521`) has ~4 options, so fuzzy search is disabled (`#isSearchEnabled` = totalRows > maxVisible); a digit then matches none of the handled keys and falls through. When the list *does* overflow, a digit is consumed as search text — still not selection.

## Fix
- Add `#handleQuickSelect(keyData)` to `HookSelectorComponent`: while type-to-search is inactive, a `1`–`9` keypress jumps to that 1-based option and, for single-select menus, confirms it immediately; checkbox menus only move the cursor (confirmation stays on `enter`). Out-of-range and disabled targets are ignored but consume the key.
- Invoke it in `handleInput` after the search handler, so digits stay searchable when the list overflows.
- Matches the existing digit-select convention (`data >= "1" && data <= "9"`) already used by the setup-wizard theme scene and the settings selector.

## Verification
`bun test test/hook-selector-overflow.test.ts` — 22 pass (5 new: digit selects+confirms, ignores disabled target, ignores out-of-range, checkbox moves-not-confirms, digits-as-search-on-overflow). `bun test test/modes/components/hook-selector-slider.test.ts` — 8 pass. Pre-publish `bun check` gate passed on push. Fixes #9710