### PR TITLE
fix(ai): read vertex cachedContentTokenCount as cache-read source

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible streaming usage parsing to read Vertex/Gemini cache hits reported in `cachedContentTokenCount`, so `cacheRead` and derived cost reflect prompt caching through gateways fronting Vertex AI ([#9713](https://github.com/can1357/oh-my-pi/issues/9713)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -149,6 +149,9 @@ type OpenAICompletionsUsageLike = {
 	prompt_cache_miss_tokens?: unknown;
 	prompt_tokens_details?: unknown;
 	completion_tokens_details?: unknown;
+	// Vertex/Gemini reports cache hits here (camelCase) when fronted by an
+	// OpenAI-compatible gateway; the OpenAI-shaped cached fields stay absent.
+	cachedContentTokenCount?: unknown;
 };
 
 type OpenAICompletionsPromptTokenDetails = {
@@ -171,6 +174,7 @@ function hasPositiveCacheReadTokenField(rawUsage: object): boolean {
 	const usageLike = rawUsage as OpenAICompletionsUsageLike;
 	if (typeof usageLike.cached_tokens === "number" && usageLike.cached_tokens > 0) return true;
 	if (typeof usageLike.prompt_cache_hit_tokens === "number" && usageLike.prompt_cache_hit_tokens > 0) return true;
+	if (typeof usageLike.cachedContentTokenCount === "number" && usageLike.cachedContentTokenCount > 0) return true;
 
 	const rawPromptTokenDetails = usageLike.prompt_tokens_details;
 	if (typeof rawPromptTokenDetails !== "object" || rawPromptTokenDetails === null) return false;
@@ -1774,13 +1778,19 @@ export function parseChunkUsage(
 	const promptCacheHitTokens = usageLike.prompt_cache_hit_tokens;
 	const promptCacheMissTokens = usageLike.prompt_cache_miss_tokens;
 	const promptTokenCachedTokens = promptTokenDetails?.cached_tokens;
+	const cachedContentTokenCount = usageLike.cachedContentTokenCount;
 	const completionReasoningTokens = completionTokenDetails?.reasoning_tokens;
 	const cacheWriteTokens = promptTokenDetails?.cache_write_tokens;
 	const outputTokens = typeof completionTokens === "number" ? completionTokens : 0;
 	const accounting = calculateOpenAIUsageAccounting({
 		promptTokens: typeof promptTokens === "number" ? promptTokens : 0,
 		outputTokens,
-		cachedTokens: firstPositiveNumber(cachedTokens, promptCacheHitTokens, promptTokenCachedTokens),
+		cachedTokens: firstPositiveNumber(
+			cachedTokens,
+			promptCacheHitTokens,
+			promptTokenCachedTokens,
+			cachedContentTokenCount,
+		),
 		reasoningTokens: typeof completionReasoningTokens === "number" ? completionReasoningTokens : 0,
 		cacheWriteOpenRouter: typeof cacheWriteTokens === "number" ? cacheWriteTokens : undefined,
 		cacheWriteDeepSeek: typeof promptCacheMissTokens === "number" ? promptCacheMissTokens : undefined,

--- a/packages/ai/test/usage-attribution.test.ts
+++ b/packages/ai/test/usage-attribution.test.ts
@@ -127,6 +127,27 @@ describe("openai-completions parseChunkUsage", () => {
 		expect(usage.totalTokens).toBe(6_250);
 	});
 
+	it("reads Vertex/Gemini cachedContentTokenCount as a cache-read source", () => {
+		// Vertex AI (and gateways fronting it) report cache hits in
+		// usage.cachedContentTokenCount (camelCase) with no OpenAI-shaped
+		// cached_tokens field. promptTokenCount/prompt_tokens includes the
+		// cached portion, so input = prompt_tokens - cachedContentTokenCount.
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 33_006,
+				completion_tokens: 110,
+				total_tokens: 33_116,
+				cachedContentTokenCount: 28_639,
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.cacheRead).toBe(28_639);
+		expect(usage.input).toBe(4_367);
+		expect(usage.totalTokens).toBe(33_116);
+	});
+
 	it("maps DeepSeek prompt_cache_hit_tokens + prompt_cache_miss_tokens correctly", () => {
 		// DeepSeek (https://api-docs.deepseek.com/api/create-chat-completion)
 		// exposes cache hit/miss at the top level where prompt_tokens = hit + miss.


### PR DESCRIPTION
## Repro
Gemini models routed through an OpenAI-compatible gateway (`api: openai-completions`) fronting Vertex AI always report `cacheRead: 0`, even when the upstream serves most of the prefix from cache. Feeding the exact Vertex usage shape from the report into `parseChunkUsage` (`prompt_tokens: 33006`, `cachedContentTokenCount: 28639`) yields `cacheRead: 0`, `input: 33006` — the whole prefix priced at input rate. Reproduced with a focused unit test against `packages/ai/src/providers/openai-completions.ts`.

## Cause
Vertex/Gemini reports cache hits in `usage.cachedContentTokenCount` (camelCase, Google's documented field) with none of the OpenAI-shaped cached fields populated. `parseChunkUsage` in `packages/ai/src/providers/openai-completions.ts` only fed `cached_tokens`, `prompt_cache_hit_tokens`, and `prompt_tokens_details.cached_tokens` into `firstPositiveNumber` (L1788), and `hasPositiveCacheReadTokenField` (L173) had the same gap — so the field was never read and `cacheRead` stayed 0. This is the read-side mirror of #1845 (the send-side `cache_control` gap).

## Fix
- Add `cachedContentTokenCount?: unknown` to `OpenAICompletionsUsageLike`.
- Extend the `parseChunkUsage` candidate list: `firstPositiveNumber(cachedTokens, promptCacheHitTokens, promptTokenCachedTokens, cachedContentTokenCount)`. Since `prompt_tokens`/`promptTokenCount` already includes the cached portion, the existing `input = prompt_tokens - cachedTokens` subtraction yields correct uncached input with no double-counting.
- Add the same field to `hasPositiveCacheReadTokenField` so the trailing-usage-details wait path agrees.
- `firstPositiveNumber` skips absent/zero values, so providers that never send the field are unaffected.

## Verification
`bun test test/usage-attribution.test.ts test/openai-completions-compat.test.ts` in `packages/ai` — 95 pass, 0 fail. Added a regression test in `usage-attribution.test.ts` asserting the Vertex shape produces `cacheRead: 28639`, `input: 4367`. Pre-publish `bun check` gate passed.

Fixes #9713