### PR TITLE
fix(theme): improved obsidian muted text contrast

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Fixed
 
+- Fixed Obsidian theme task instructions and usage-limit text blending into dark backgrounds.
+
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/modes/theme/defaults/obsidian.json
+++ b/packages/coding-agent/src/modes/theme/defaults/obsidian.json
@@ -23,7 +23,7 @@
 		"success": "jade",
 		"error": "crimson",
 		"warning": "gold",
-		"muted": "smoke",
+		"muted": "#8a857f",
 		"dim": "#4a4642",
 		"text": "",
 		"thinkingText": "silver",

--- a/packages/coding-agent/test/issue-9712-obsidian-muted-contrast.test.ts
+++ b/packages/coding-agent/test/issue-9712-obsidian-muted-contrast.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { relativeLuminance } from "@oh-my-pi/pi-utils";
+import { resolveVarRefs } from "../src/modes/theme/color";
+import { loadTheme, loadThemeJson } from "../src/modes/theme/loader";
+
+const MIN_TEXT_CONTRAST = 4.5;
+
+function contrastRatio(foreground: string | number, background: string | number): number {
+	const foregroundLuminance = relativeLuminance(foreground);
+	const backgroundLuminance = relativeLuminance(background);
+	if (foregroundLuminance === undefined || backgroundLuminance === undefined) {
+		throw new Error("Obsidian has an invalid muted text or background color");
+	}
+	return (
+		(Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+		(Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+	);
+}
+
+describe("Obsidian muted text contrast (#9712)", () => {
+	test("task instructions and usage limits remain readable on their backgrounds", async () => {
+		const [theme, themeJson] = await Promise.all([
+			loadTheme("obsidian", { mode: "truecolor" }),
+			loadThemeJson("obsidian"),
+		]);
+		const pageBgToken = themeJson.export?.pageBg;
+		if (pageBgToken === undefined) throw new Error("Obsidian does not define export.pageBg");
+
+		const muted = theme.getColorHex("muted");
+		const surfaces: [string, string | number][] = [
+			["task/page", resolveVarRefs(pageBgToken, themeJson.vars ?? {})],
+			["usage/status", theme.getBgHex("statusLineBg")],
+		];
+		for (const [name, background] of surfaces) {
+			expect(contrastRatio(muted, background), name).toBeGreaterThanOrEqual(MIN_TEXT_CONTRAST);
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With Obsidian active, task assignments and low-usage status text resolve through the `muted` role. Running `bun test packages/coding-agent/test/issue-9712-obsidian-muted-contrast.test.ts` against the original palette fails because `#2b2825` has only 1.34:1 contrast on the task/page background and 1.21:1 on the status-line background.

## Cause
`packages/coding-agent/src/modes/theme/defaults/obsidian.json` mapped `colors.muted` to the near-background `smoke` variable. `createMarkdownSectionRenderer` in `src/task/render.ts` and `usageSegment` in `src/modes/components/status-line/segments.ts` both intentionally render this secondary text through `muted`, so the palette mapping made both surfaces illegible.

## Fix
- Raise Obsidian’s `muted` foreground to `#8a857f`, preserving the subdued neutral palette while clearing 4.5:1 contrast on both affected backgrounds.
- Add a regression test resolving the real theme tokens and checking the task/page and usage/status surfaces.
- Document the user-visible fix under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/issue-9712-obsidian-muted-contrast.test.ts` passes (1 test, 2 assertions). A direct render of `renderCall` and `SEGMENTS.usage` completed with Obsidian active; the resulting ratios are 5.38:1 on the task/page background and 4.84:1 on the status-line background. The pre-publish gate completed `bun run fix` and `bun check`.

Fixes #9712