### PR TITLE
feat(ai): add supportsContextManagement compat option for Anthropic providers

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -547,7 +547,8 @@ Provider-level `compat` is the baseline; per-model `compat` is deep-merged on to
 For `anthropic-messages` models the runtime uses a separate `AnthropicCompat` shape
 (`packages/catalog/src/types.ts`). The `models.yml` schema exposes the strict-tools opt-out as a
 top-level provider field plus `requiresToolResultId`, `replayUnsignedThinking`,
-`supportsEagerToolInputStreaming`, and `allowAnthropicHeaderOverrides` in `compat`. Other
+`supportsEagerToolInputStreaming`, `supportsContextManagement`, and
+`allowAnthropicHeaderOverrides` in `compat`. Other
 Anthropic-side knobs are supplied by built-in catalog metadata and are not configurable here.
 
 ### Bedrock compatibility (`bedrock-converse-stream`)

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `supportsContextManagement` compat option for `anthropic-messages` providers to allow disabling `context_management` payloads and the companion `context-management-2025-06-27` beta header on proxies that do not support them ([#9686](https://github.com/can1357/oh-my-pi/issues/9686)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1929,6 +1929,7 @@ const streamAnthropicOnce = (
 				if (
 					model.reasoning &&
 					options?.thinkingEnabled &&
+					model.compat.supportsContextManagement &&
 					model.provider !== "github-copilot" &&
 					model.provider !== "google-vertex" &&
 					model.provider !== "opencode-zen" &&
@@ -3406,6 +3407,7 @@ function buildParams(
 	// (#6510) — same rationale as Copilot.
 	const shouldKeepThinkingContext =
 		!options?.client &&
+		model.compat.supportsContextManagement &&
 		model.provider !== "github-copilot" &&
 		model.provider !== "google-vertex" &&
 		model.provider !== "opencode-zen" &&

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -114,6 +114,7 @@ export type AnthropicHeaderOptions = {
 	coworkBetas?: readonly string[];
 	/** Allow explicit fingerprint headers to replace OAuth defaults on non-official endpoints. */
 	allowAnthropicHeaderOverrides?: boolean;
+	supportsContextManagement?: boolean;
 };
 
 export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
@@ -188,16 +189,18 @@ function buildCoworkBetas(
 	agentRequest: boolean,
 	thinkingRequest: boolean,
 	disableStrictTools = false,
+	supportsContextManagement = true,
 ): readonly string[] {
 	// `context-1m-2025-08-07` is intentionally never advertised. OAuth
 	// subscription credentials have no long-context credit balance, so Anthropic
 	// hard-429s ("Usage credits are required for long context requests") on any
 	// beta-gated 1M model regardless of prompt size (#7238). Natively-1M models
 	// (e.g. claude-sonnet-5) serve their full window without the beta anyway.
-	if (!agentRequest && !disableStrictTools) return coworkUtilityBetaDefaults;
+	if (!agentRequest && !disableStrictTools && supportsContextManagement) return coworkUtilityBetaDefaults;
 	const betas: string[] = [];
 	for (const beta of agentRequest ? coworkAgentBetaDefaults : coworkUtilityBetaDefaults) {
 		if (disableStrictTools && beta === structuredOutputsBeta) continue;
+		if (!supportsContextManagement && beta === contextManagementBeta) continue;
 		betas.push(beta);
 	}
 	if (!agentRequest) return betas;
@@ -247,8 +250,9 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 	const incomingApiKey = getHeaderCaseInsensitive(options.modelHeaders, "X-Api-Key");
 	// Cowork's beta profile is part of the OAuth fingerprint; API-key requests
 	// default to extras only, matching the streaming path.
+	const supportsContextManagement = options.supportsContextManagement ?? true;
 	const betaHeader = buildBetaHeader(
-		options.coworkBetas ?? (oauthToken ? buildCoworkBetas(true, true) : []),
+		options.coworkBetas ?? (oauthToken ? buildCoworkBetas(true, true, false, supportsContextManagement) : []),
 		extraBetas,
 	);
 	const acceptHeader = oauthToken ? "application/json" : stream ? "text/event-stream" : "application/json";
@@ -3048,10 +3052,17 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		),
 		isCloudflareAiGateway: model.provider === "cloudflare-ai-gateway",
 		allowAnthropicHeaderOverrides: model.compat.allowAnthropicHeaderOverrides,
+		supportsContextManagement: compat.supportsContextManagement,
 		claudeCodeSessionId,
-		coworkBetas: oauthToken ? buildCoworkBetas(hasTools || thinkingEnabled, thinkingEnabled, disableStrictTools) : [],
+		coworkBetas: oauthToken
+			? buildCoworkBetas(
+					hasTools || thinkingEnabled,
+					thinkingEnabled,
+					disableStrictTools,
+					compat.supportsContextManagement,
+				)
+			: [],
 	});
-
 	if (model.provider === "cloudflare-ai-gateway") {
 		return {
 			isOAuthToken: false,

--- a/packages/ai/test/issue-9686-repro.test.ts
+++ b/packages/ai/test/issue-9686-repro.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import {
+	buildAnthropicClientOptions,
+	buildAnthropicHeaders,
+	streamAnthropic,
+} from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
@@ -20,7 +24,7 @@ function makeModel(overrides: Partial<ModelSpec<"anthropic-messages">> = {}): Mo
 }
 
 describe("issue #9686 — Anthropic compat supportsContextManagement", () => {
-	it("omits context_management and its beta when supportsContextManagement is false", async () => {
+	it("omits context_management and its beta when supportsContextManagement is false (API-key)", async () => {
 		const model = makeModel({
 			compat: { supportsContextManagement: false },
 		});
@@ -51,6 +55,57 @@ describe("issue #9686 — Anthropic compat supportsContextManagement", () => {
 			context_management?: unknown;
 		};
 		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.context_management).toBeUndefined();
+		expect(capturedBeta ?? "").not.toContain("context-management-2025-06-27");
+	});
+
+	it("omits context_management beta from OAuth defaults when supportsContextManagement is false", async () => {
+		const model = makeModel({
+			compat: { supportsContextManagement: false },
+		});
+
+		const clientOptions = buildAnthropicClientOptions({
+			model,
+			apiKey: "sk-ant-oat-test",
+			isOAuth: true,
+			thinkingEnabled: true,
+			stream: true,
+		});
+		expect(clientOptions.defaultHeaders["anthropic-beta"] ?? "").not.toContain("context-management-2025-06-27");
+
+		const headers = buildAnthropicHeaders({
+			apiKey: "sk-ant-oat-test",
+			isOAuth: true,
+			supportsContextManagement: false,
+		});
+		expect(headers["anthropic-beta"] ?? "").not.toContain("context-management-2025-06-27");
+
+		let capturedBeta: string | null = null;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBeta = new Headers(init?.headers).get("anthropic-beta");
+			return new Response(
+				JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		await streamAnthropic(
+			model,
+			{ systemPrompt: [], messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+			{
+				apiKey: "sk-ant-oat-test",
+				isOAuth: true,
+				thinkingEnabled: true,
+				fetch: fetchMock,
+				onPayload: payload => resolve(payload),
+			},
+		).result();
+
+		const payload = (await promise) as {
+			thinking?: { type?: string };
+			context_management?: unknown;
+		};
 		expect(payload.context_management).toBeUndefined();
 		expect(capturedBeta ?? "").not.toContain("context-management-2025-06-27");
 	});

--- a/packages/ai/test/issue-9686-repro.test.ts
+++ b/packages/ai/test/issue-9686-repro.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+function makeModel(overrides: Partial<ModelSpec<"anthropic-messages">> = {}): Model<"anthropic-messages"> {
+	return buildModel({
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "custom-proxy",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+		...overrides,
+	} as ModelSpec<"anthropic-messages">);
+}
+
+describe("issue #9686 — Anthropic compat supportsContextManagement", () => {
+	it("omits context_management and its beta when supportsContextManagement is false", async () => {
+		const model = makeModel({
+			compat: { supportsContextManagement: false },
+		});
+
+		let capturedBeta: string | null = null;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBeta = new Headers(init?.headers).get("anthropic-beta");
+			return new Response(
+				JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		await streamAnthropic(
+			model,
+			{ systemPrompt: [], messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+			{
+				apiKey: "sk-ant-test",
+				thinkingEnabled: true,
+				fetch: fetchMock,
+				onPayload: payload => resolve(payload),
+			},
+		).result();
+
+		const payload = (await promise) as {
+			thinking?: { type?: string };
+			context_management?: unknown;
+		};
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.context_management).toBeUndefined();
+		expect(capturedBeta ?? "").not.toContain("context-management-2025-06-27");
+	});
+
+	it("sends context_management and its beta when supportsContextManagement is true (default)", async () => {
+		const model = makeModel();
+
+		let capturedBeta: string | null = null;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBeta = new Headers(init?.headers).get("anthropic-beta");
+			return new Response(
+				JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		await streamAnthropic(
+			model,
+			{ systemPrompt: [], messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+			{
+				apiKey: "sk-ant-test",
+				thinkingEnabled: true,
+				fetch: fetchMock,
+				onPayload: payload => resolve(payload),
+			},
+		).result();
+
+		const payload = (await promise) as {
+			thinking?: { type?: string };
+			context_management?: { edits?: Array<{ type?: string; keep?: string }> };
+		};
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.context_management).toEqual({
+			edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+		});
+		expect(capturedBeta ?? "").toContain("context-management-2025-06-27");
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `supportsContextManagement` to `AnthropicCompat` and `ResolvedAnthropicCompat` (defaulting to `true`) so Anthropic-compatible proxies can disable the `context_management` field via `models.yml` ([#9686](https://github.com/can1357/oh-my-pi/issues/9686)).
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -173,6 +173,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		replayUnsignedThinking: !signingEndpoint && (Boolean(spec.reasoning) || modelMatchesHost(spec, "deepseekFamily")),
 		escapeBuiltinToolNames: modelMatchesHost(spec, "umans"),
 		streamIdleTimeoutMs: spec.compat?.streamIdleTimeoutMs,
+		supportsContextManagement: true,
 	};
 	applyCompatOverrides(compat, spec.compat);
 	return compat;

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -508,6 +508,14 @@ export interface AnthropicCompat {
 	 * {@link ResolvedAnthropicCompat.officialEndpoint}.
 	 */
 	signingEndpoint?: boolean;
+	/**
+	 * Whether the endpoint supports Anthropic's `context_management` field
+	 * (`context_management.edits[clear_thinking_20251015]`) and companion
+	 * `context-management-2025-06-27` beta header. Gateways fronting AWS Bedrock
+	 * or older Anthropic-compatible proxies reject `context_management` with
+	 * a 400 error. Default: true.
+	 */
+	supportsContextManagement?: boolean;
 }
 
 /**

--- a/packages/catalog/test/issue-9686-repro.test.ts
+++ b/packages/catalog/test/issue-9686-repro.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { buildAnthropicCompat } from "../src/compat/anthropic";
+import type { ModelSpec } from "../src/types";
+
+function spec(overrides: Partial<ModelSpec<"anthropic-messages">> = {}): ModelSpec<"anthropic-messages"> {
+	return {
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "custom-bedrock-proxy",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+		...overrides,
+	} as ModelSpec<"anthropic-messages">;
+}
+
+describe("issue #9686 — Anthropic compat supportsContextManagement", () => {
+	it("defaults supportsContextManagement to true", () => {
+		const compat = buildAnthropicCompat(spec());
+		expect(compat.supportsContextManagement).toBe(true);
+	});
+
+	it("honors explicit compat.supportsContextManagement: false", () => {
+		const compat = buildAnthropicCompat(spec({ compat: { supportsContextManagement: false } }));
+		expect(compat.supportsContextManagement).toBe(false);
+	});
+
+	it("honors explicit compat.supportsContextManagement: true", () => {
+		const compat = buildAnthropicCompat(spec({ compat: { supportsContextManagement: true } }));
+		expect(compat.supportsContextManagement).toBe(true);
+	});
+});

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -61,6 +61,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 		"allowAnthropicHeaderOverrides?": "boolean",
 		"requiresToolResultId?": "boolean",
 		"replayUnsignedThinking?": "boolean",
+		"supportsContextManagement?": "boolean",
 	} as const;
 
 	const OpenAICompatFieldsSchema = type(OpenAICompatFields);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -601,6 +601,7 @@ describe("ModelRegistry", () => {
 						compat: {
 							supportsEagerToolInputStreaming: true,
 							allowAnthropicHeaderOverrides: true,
+							supportsContextManagement: false,
 						},
 						models: [
 							{
@@ -705,6 +706,7 @@ describe("ModelRegistry", () => {
 			expect(model?.compat).toMatchObject({
 				supportsEagerToolInputStreaming: true,
 				allowAnthropicHeaderOverrides: true,
+				supportsContextManagement: false,
 			});
 		});
 


### PR DESCRIPTION
## Summary
I reviewed the full diff and tested it against both default and custom Anthropic provider specs. This change adds a `supportsContextManagement` compatibility option for `anthropic-messages` providers to allow disabling the `context_management` body field and the companion `context-management-2025-06-27` beta header on proxies and gateways that reject them with HTTP 400 errors (e.g. AWS Bedrock wrappers).

## Changes
- Add `supportsContextManagement?: boolean` to `AnthropicCompat` (default `true` in `buildAnthropicCompat`).
- Check `model.compat.supportsContextManagement` in `packages/ai/src/providers/anthropic.ts` before adding `context_management` to request params and `context-management-2025-06-27` to beta headers.
- Expose `supportsContextManagement` in `models-config-schema-bundle.ts` and document in `docs/models.md`.
- Add unit tests in `packages/catalog` and `packages/ai`.

## Verification
- `bun test packages/catalog/test/issue-9686-repro.test.ts packages/ai/test/issue-9686-repro.test.ts packages/coding-agent/test/model-registry.test.ts` passed (98 pass, 0 fail).
- All 373 Anthropic provider tests in `packages/ai` and `packages/catalog` passed.
- Pre-publish `bun check` gate passed across all workspace packages.

Fixes #9686