### PR TITLE
fix(tui): prioritize transcript text over tool cards under viewport pressure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Fixed
 
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
+- Fixed a growing task/tool card clipping already-visible assistant text when both share a height-constrained live viewport; surplus rows now fill ordinary transcript blocks before dynamic tool activity, which collapses to its compact form under pressure ([#9718](https://github.com/can1357/oh-my-pi/issues/9718)).
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.
 - Fixed an orphaned foreground tool card surviving a later agent turn and pinning the entire transcript outside native scrollback; new turns now seal abandoned cards while preserving background-task updates.

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -260,7 +260,18 @@ export class TranscriptContainer extends Container {
 
 		const allocation: number[] = new Array(shown.length).fill(1);
 		let surplus = capacity - shown.length;
-		for (let index = shown.length - 1; index >= 0 && surplus > 0; index--) {
+		// Surplus rows favor ordinary transcript blocks over dynamic tool-activity
+		// cards (newest-first within each class), so a growing tool card collapses to
+		// its compact form instead of clipping already-visible assistant text (#9718).
+		const order: number[] = [];
+		for (let index = shown.length - 1; index >= 0; index--) {
+			if (!isToolActivityComponent(shown[index]!.entry.component)) order.push(index);
+		}
+		for (let index = shown.length - 1; index >= 0; index--) {
+			if (isToolActivityComponent(shown[index]!.entry.component)) order.push(index);
+		}
+		for (const index of order) {
+			if (surplus <= 0) break;
 			const extra = Math.min(Math.max(0, blocks[index]!.length - 1), surplus);
 			allocation[index] += extra;
 			surplus -= extra;

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -33,6 +33,11 @@ class Block implements Component {
 	}
 }
 
+/** A live block the container recognizes as dynamic tool-activity. */
+class ToolBlock extends Block {
+	setToolActivityVisible(): void {}
+}
+
 function literalStableRow(row: string): TranscriptStableRow {
 	return { key: row };
 }
@@ -307,6 +312,21 @@ describe("TranscriptContainer", () => {
 		// stealing a base row each; the older block keeps its tail rows.
 		const out = transcript.renderViewport(80, 10, frame);
 		expect(out).toEqual(["A3", "A4", "B1", "B2", "B3", "B4", "C1", "C2", "C3", "C4"]);
+	});
+
+	it("gives surplus rows to assistant text before a growing tool card (issue 9718)", () => {
+		const transcript = new TranscriptContainer();
+		const assistant = new Block(["A1", "A2", "A3", "A4"], false);
+		const tool = new ToolBlock(["T1", "T2", "T3", "T4"], false);
+		transcript.addChild(assistant);
+		transcript.addChild(tool);
+		// Capacity 5 cannot fit both blocks in full. Surplus (3 rows) goes to the
+		// assistant block first; the tool card collapses to its one-row minimum
+		// instead of clipping already-visible assistant text.
+		const out = transcript.renderViewport(80, 5, frame);
+		expect(out).toEqual(["A1", "A2", "A3", "A4", "T4"]);
+		expect(assistant.allocations.at(-1)).toBe(4);
+		expect(tool.allocations.at(-1)).toBe(1);
 	});
 
 	it("permits removing settled blocks until they are offered or committed", () => {


### PR DESCRIPTION
## Repro
When assistant text and a growing task/tool activity card share a height-constrained live viewport, the card takes nearly all surplus rows and earlier assistant text is clipped out of view until the card settles. Reproduced at the allocator level by feeding an assistant block (4 rows) + a tool-activity block (4 rows) into `TranscriptContainer.renderViewport(80, 5, frame)`: the output was `["A4","T1","T2","T3","T4"]` — only one assistant row survived.

## Cause
`TranscriptContainer.renderViewport()` (`packages/coding-agent/src/modes/components/transcript-container.ts`) seeds every visible live block with one base row, then distributes the remaining capacity newest-first. The newest live block is commonly the active tool/task card, so it greedily consumed the surplus up to its full height while older assistant blocks stayed clamped to their single base row (their tails sliced off before emission). This was introduced with the capacity-driven viewport in 18.0.1 (commit `1949c798`).

## Fix
- Replace the single newest-first surplus loop with a two-class ordering: build a distribution order of non-tool transcript blocks (newest-first) followed by tool-activity blocks (newest-first), using the existing `isToolActivityComponent()` predicate.
- Distribute surplus rows along that order, so ordinary transcript text is filled before dynamic tool cards. A growing tool card collapses to its compact one-row form (via `ToolExecution`'s existing squeeze path) instead of clipping assistant text. Layout order and newest-first behavior within each class are preserved.
- Added a regression test (`gives surplus rows to assistant text before a growing tool card (issue 9718)`).

## Verification
`bun test test/modes/components/transcript-container.test.ts` → 22 pass / 0 fail; the new test asserts capacity-5 output `["A1","A2","A3","A4","T4"]` with allocations assistant=4, tool=1. Fixes #9718