### PR TITLE
fix(tui): drop Kitty image protocol inside Paseo terminals

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -11,7 +11,8 @@
 - History replay batches now bottom-split into leading viewport space and serialize the complete replay remainder plus final viewport in one synchronous terminal write.
 
 ### Fixed
-- Fixed image previews rendering as PUA garbage inside Paseo terminals by dropping the Kitty image protocol when `PASEO_TERMINAL_ID` is present ([#9724](https://github.com/can1357/oh-my-pi/pull/9724) by [@aproto9787](https://github.com/aproto9787)).
+
+- Fixed image previews rendering as PUA garbage inside Paseo terminals by dropping the Kitty image protocol when `PASEO_TERMINAL_ID` is present.
 
 - Fixed graceful terminal shutdown leaving eligible finalized output in the mutable viewport instead of retiring it before shell handoff.
 - Fixed a latched destructive scrollback rebuild (settled rebuild-mode resize, display reset) erasing and re-streaming the whole transcript during stop; the latch is dropped and shutdown writes only the un-retired tail.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -11,6 +11,7 @@
 - History replay batches now bottom-split into leading viewport space and serialize the complete replay remainder plus final viewport in one synchronous terminal write.
 
 ### Fixed
+- Fixed image previews rendering as PUA garbage inside Paseo terminals by dropping the Kitty image protocol when `PASEO_TERMINAL_ID` is present ([#9724](https://github.com/can1357/oh-my-pi/pull/9724) by [@aproto9787](https://github.com/aproto9787)).
 
 - Fixed graceful terminal shutdown leaving eligible finalized output in the mutable viewport instead of retiring it before shell handoff.
 - Fixed a latched destructive scrollback rebuild (settled rebuild-mode resize, display reset) erasing and re-streaming the whole transcript during stop; the latch is dropped and shutdown writes only the un-retired tail.

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -446,10 +446,14 @@ export function shouldEnableHyperlinksByDefault(
 	return true;
 }
 
-function getFallbackImageProtocol(terminalId: TerminalId): ImageProtocol | null {
-	if (!process.stdout.isTTY) return null;
+function getFallbackImageProtocol(
+	terminalId: TerminalId,
+	env: NodeJS.ProcessEnv = Bun.env,
+	isTTY: boolean = process.stdout.isTTY === true,
+): ImageProtocol | null {
+	if (!isTTY) return null;
 	if (terminalId === "vscode" || terminalId === "alacritty") return null;
-	const term = Bun.env.TERM?.toLowerCase() ?? "";
+	const term = env.TERM?.toLowerCase() ?? "";
 	if (term.includes("screen") || term.includes("tmux") || term.includes("ghostty")) {
 		return ImageProtocol.Kitty;
 	}
@@ -480,6 +484,39 @@ export function resolveWarpImageProtocol(
  */
 export function isPaseoEmbedder(env: NodeJS.ProcessEnv = Bun.env): boolean {
 	return Boolean(env.PASEO_TERMINAL_ID);
+}
+
+/**
+ * Resolve the image protocol for a non-forced runtime: static per-terminal
+ * support (with Warp's platform carve-out), then the multiplexer fallback,
+ * then the Paseo embedder carve-out. `isTTY` is injectable because the
+ * fallback only fires on a real TTY — a piped subprocess cannot exercise
+ * that path, so regression tests call this directly.
+ */
+export function resolveImageProtocol(
+	terminalId: TerminalId,
+	env: NodeJS.ProcessEnv = Bun.env,
+	isTTY: boolean = process.stdout.isTTY === true,
+): ImageProtocol | null {
+	let imageProtocol: ImageProtocol | null;
+	if (terminalId === "warp") {
+		// Warp advertises Kitty graphics on macOS/Linux only; drop it on win32.
+		imageProtocol = resolveWarpImageProtocol(process.platform, env);
+	} else {
+		imageProtocol = getTerminalInfo(terminalId).imageProtocol;
+		if (!imageProtocol) {
+			const fallbackImageProtocol = getFallbackImageProtocol(terminalId, env, isTTY);
+			if (fallbackImageProtocol) imageProtocol = fallbackImageProtocol;
+		}
+	}
+	// Paseo's xterm.js renderer draws neither Kitty APC nor placeholders —
+	// applied after the multiplexer fallback so tmux/screen inside a Paseo
+	// pane cannot restore Kitty via getFallbackImageProtocol
+	// (getpaseo/paseo#3850).
+	if (imageProtocol !== null && isPaseoEmbedder(env)) {
+		return null;
+	}
+	return imageProtocol;
 }
 
 function getWarpTerminalInfo(platform: NodeJS.Platform, env: NodeJS.ProcessEnv = Bun.env): TerminalInfo {
@@ -584,15 +621,8 @@ export const TERMINAL: RuntimeTerminal = (() => {
 	const forcedImageProtocol = getForcedImageProtocol();
 	if (forcedImageProtocol !== undefined) {
 		resolved.imageProtocol = forcedImageProtocol;
-	} else if (resolved.id === "warp") {
-		// Warp advertises Kitty graphics on macOS/Linux only; drop it on win32.
-		resolved.imageProtocol = resolveWarpImageProtocol();
-	} else if (resolved.imageProtocol !== null && isPaseoEmbedder(Bun.env)) {
-		// Paseo's xterm.js renderer draws neither Kitty APC nor placeholders.
-		resolved.imageProtocol = null;
-	} else if (!resolved.imageProtocol) {
-		const fallbackImageProtocol = getFallbackImageProtocol(resolved.id);
-		if (fallbackImageProtocol) resolved.imageProtocol = fallbackImageProtocol;
+	} else {
+		resolved.imageProtocol = resolveImageProtocol(resolved.id, Bun.env, process.stdout.isTTY === true);
 	}
 	// Hyperlink (OSC 8) capability. The static per-terminal flag lives on
 	// KNOWN_TERMINALS; shouldEnableHyperlinksByDefault folds in runtime context —

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -470,6 +470,18 @@ export function resolveWarpImageProtocol(
 	return windowsHost ? null : ImageProtocol.Kitty;
 }
 
+/**
+ * Paseo (getpaseo/paseo) hardcodes `TERM_PROGRAM=kitty` into every PTY
+ * (`buildTerminalEnvironment`) while its xterm.js renderer implements neither
+ * Kitty graphics nor Unicode placeholders — trusting the advertisement turns
+ * image previews into literal PUA garbage (getpaseo/paseo#3850). Paseo
+ * injects `PASEO_TERMINAL_ID` into every terminal it hosts, which makes a
+ * reliable embedder signal.
+ */
+export function isPaseoEmbedder(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	return Boolean(env.PASEO_TERMINAL_ID);
+}
+
 function getWarpTerminalInfo(platform: NodeJS.Platform, env: NodeJS.ProcessEnv = Bun.env): TerminalInfo {
 	return new TerminalInfo(
 		"warp",
@@ -575,6 +587,9 @@ export const TERMINAL: RuntimeTerminal = (() => {
 	} else if (resolved.id === "warp") {
 		// Warp advertises Kitty graphics on macOS/Linux only; drop it on win32.
 		resolved.imageProtocol = resolveWarpImageProtocol();
+	} else if (resolved.imageProtocol !== null && isPaseoEmbedder(Bun.env)) {
+		// Paseo's xterm.js renderer draws neither Kitty APC nor placeholders.
+		resolved.imageProtocol = null;
 	} else if (!resolved.imageProtocol) {
 		const fallbackImageProtocol = getFallbackImageProtocol(resolved.id);
 		if (fallbackImageProtocol) resolved.imageProtocol = fallbackImageProtocol;

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -6,6 +6,7 @@ import {
 	ImageProtocol,
 	isPaseoEmbedder,
 	NotifyProtocol,
+	resolveImageProtocol,
 	resolveWarpImageProtocol,
 	shouldEnableHyperlinksByDefault,
 	shouldEnableSynchronizedOutputByDefault,
@@ -217,6 +218,14 @@ describe("Paseo embedder carve-out", () => {
 	it("detects Paseo via PASEO_TERMINAL_ID", () => {
 		expect(isPaseoEmbedder({})).toBe(false);
 		expect(isPaseoEmbedder({ PASEO_TERMINAL_ID: "term-1" })).toBe(true);
+	});
+
+	it("drops the multiplexer-restored Kitty fallback inside Paseo", () => {
+		// Regression (getpaseo/paseo#3850): tmux inside a Paseo pane resolves to
+		// base (null static protocol) and TERM=tmux-* would restore Kitty via
+		// the fallback — the embedder carve-out must win over the fallback.
+		expect(resolveImageProtocol("base", { TERM: "tmux-256color", PASEO_TERMINAL_ID: "term-1" }, true)).toBeNull();
+		expect(resolveImageProtocol("base", { TERM: "tmux-256color" }, true)).toBe(ImageProtocol.Kitty);
 	});
 
 	it("drops Kitty graphics when Paseo hosts the terminal", async () => {

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
 	getTerminalInfo,
 	hyperlinksUserOverride,
 	ImageProtocol,
+	isPaseoEmbedder,
 	NotifyProtocol,
 	resolveWarpImageProtocol,
 	shouldEnableHyperlinksByDefault,
@@ -209,6 +210,85 @@ console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProto
 		expect(shouldEnableSynchronizedOutputByDefault({}, "warp")).toBe(false);
 		expect(shouldEnableHyperlinksByDefault({}, "warp")).toBe(false);
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1" }, "warp")).toBe(true);
+	});
+});
+
+describe("Paseo embedder carve-out", () => {
+	it("detects Paseo via PASEO_TERMINAL_ID", () => {
+		expect(isPaseoEmbedder({})).toBe(false);
+		expect(isPaseoEmbedder({ PASEO_TERMINAL_ID: "term-1" })).toBe(true);
+	});
+
+	it("drops Kitty graphics when Paseo hosts the terminal", async () => {
+		const env: Record<string, string | undefined> = {
+			...Bun.env,
+			TERM_PROGRAM: "kitty",
+			PASEO_TERMINAL_ID: "term-1",
+		};
+		for (const key of [
+			"PI_FORCE_IMAGE_PROTOCOL",
+			"KITTY_WINDOW_ID",
+			"GHOSTTY_RESOURCES_DIR",
+			"WEZTERM_PANE",
+			"ITERM_SESSION_ID",
+			"VSCODE_PID",
+			"ALACRITTY_WINDOW_ID",
+		]) {
+			delete env[key];
+		}
+
+		const proc = Bun.spawn({
+			cmd: [
+				process.execPath,
+				"--eval",
+				`import { ImageProtocol, TERMINAL, TERMINAL_ID } from "@oh-my-pi/pi-tui/terminal-capabilities";
+console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProtocol, expected: ImageProtocol.Kitty }));`,
+			],
+			env,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+		const resolved = JSON.parse(stdout) as { id: string; imageProtocol: string | null };
+		expect(resolved.id).toBe("kitty");
+		// Paseo's xterm.js renderer implements neither Kitty graphics nor
+		// Unicode placeholders (getpaseo/paseo#3850).
+		expect(resolved.imageProtocol).toBeNull();
+	});
+
+	it("keeps Kitty graphics for a real kitty without PASEO_TERMINAL_ID", async () => {
+		const env: Record<string, string | undefined> = { ...Bun.env, TERM_PROGRAM: "kitty" };
+		for (const key of ["PI_FORCE_IMAGE_PROTOCOL", "PASEO_TERMINAL_ID"]) delete env[key];
+
+		const proc = Bun.spawn({
+			cmd: [
+				process.execPath,
+				"--eval",
+				`import { ImageProtocol, TERMINAL, TERMINAL_ID } from "@oh-my-pi/pi-tui/terminal-capabilities";
+console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProtocol, expected: ImageProtocol.Kitty }));`,
+			],
+			env,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+		const resolved = JSON.parse(stdout) as { id: string; imageProtocol: string | null; expected: string };
+		expect(resolved.id).toBe("kitty");
+		expect(resolved.imageProtocol).toBe(resolved.expected);
 	});
 });
 

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -214,6 +214,29 @@ console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProto
 	});
 });
 
+/**
+ * Build a child-process env for the TERMINAL resolution subprocesses: inherits
+ * the runner's environment, strips every terminal-identification marker and
+ * image-protocol pin, then applies the caller's overrides. Keeps the suite
+ * independent of which terminal it runs inside (full-suite safe).
+ */
+function subprocessEnv(overrides: Record<string, string | undefined>): Record<string, string | undefined> {
+	const env: Record<string, string | undefined> = { ...Bun.env };
+	for (const key of [
+		"PI_FORCE_IMAGE_PROTOCOL",
+		"PASEO_TERMINAL_ID",
+		"KITTY_WINDOW_ID",
+		"GHOSTTY_RESOURCES_DIR",
+		"WEZTERM_PANE",
+		"ITERM_SESSION_ID",
+		"VSCODE_PID",
+		"ALACRITTY_WINDOW_ID",
+	]) {
+		delete env[key];
+	}
+	return { ...env, ...overrides };
+}
+
 describe("Paseo embedder carve-out", () => {
 	it("detects Paseo via PASEO_TERMINAL_ID", () => {
 		expect(isPaseoEmbedder({})).toBe(false);
@@ -229,22 +252,7 @@ describe("Paseo embedder carve-out", () => {
 	});
 
 	it("drops Kitty graphics when Paseo hosts the terminal", async () => {
-		const env: Record<string, string | undefined> = {
-			...Bun.env,
-			TERM_PROGRAM: "kitty",
-			PASEO_TERMINAL_ID: "term-1",
-		};
-		for (const key of [
-			"PI_FORCE_IMAGE_PROTOCOL",
-			"KITTY_WINDOW_ID",
-			"GHOSTTY_RESOURCES_DIR",
-			"WEZTERM_PANE",
-			"ITERM_SESSION_ID",
-			"VSCODE_PID",
-			"ALACRITTY_WINDOW_ID",
-		]) {
-			delete env[key];
-		}
+		const env = subprocessEnv({ TERM_PROGRAM: "kitty", PASEO_TERMINAL_ID: "term-1" });
 
 		const proc = Bun.spawn({
 			cmd: [
@@ -273,8 +281,7 @@ console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProto
 	});
 
 	it("keeps Kitty graphics for a real kitty without PASEO_TERMINAL_ID", async () => {
-		const env: Record<string, string | undefined> = { ...Bun.env, TERM_PROGRAM: "kitty" };
-		for (const key of ["PI_FORCE_IMAGE_PROTOCOL", "PASEO_TERMINAL_ID"]) delete env[key];
+		const env = subprocessEnv({ TERM_PROGRAM: "kitty" });
 
 		const proc = Bun.spawn({
 			cmd: [


### PR DESCRIPTION
## Problem

Paseo (getpaseo/paseo) hardcodes `TERM_PROGRAM=kitty` into every PTY it hosts (`buildTerminalEnvironment` in `packages/server/src/terminal/terminal.ts`), but its xterm.js renderer implements neither Kitty graphics nor Kitty Unicode placeholders. An OMP session inside a Paseo terminal therefore resolves its terminal id to `kitty`, emits Kitty graphics APC + `U+10EEEE` placeholder grids for image previews, and the pane fills with literal PUA garbage (the APC payload is swallowed, the placeholders are painted as text).

Root-cause write-up with repro: getpaseo/paseo#3850

## Fix

Same bug class as Warp's Windows build (which ships Kitty graphics only on macOS/Linux — see `resolveWarpImageProtocol`): trust the embedder signal over the terminal impersonation.

Paseo injects `PASEO_TERMINAL_ID` into every terminal it hosts (`terminal-manager.js`), which gives a reliable carve-out that can't false-positive on a real kitty:

- `isPaseoEmbedder(env)` — detects the Paseo embedder via `PASEO_TERMINAL_ID`.
- `TERMINAL` init: when a static image protocol resolved and the process runs inside Paseo, drop it to `null`. Images then take the existing text fallback (`imageFallback`); no APC or placeholder sequences are emitted.

## Behavior after

| Environment | Before | After |
|---|---|---|
| OMP in a Paseo pane | PUA garbage wall | text fallback (file reference) |
| Real kitty / ghostty / wezterm | Kitty images | unchanged |
| `PI_FORCE_IMAGE_PROTOCOL` set | forced | unchanged (force wins, as before) |

## Tests

3 new cases in `terminal-capabilities.test.ts` (mirroring the Warp subprocess pattern):

- `isPaseoEmbedder` unit detection
- subprocess resolution: `TERM_PROGRAM=kitty` + `PASEO_TERMINAL_ID` → `TERMINAL.imageProtocol === null`
- subprocess resolution: `TERM_PROGRAM=kitty` without `PASEO_TERMINAL_ID` → still `ImageProtocol.Kitty`

`bun run check` (biome + tsgo) clean; `bun test test/terminal-capabilities.test.ts` 40 pass / 0 fail.

## Known limitation

`PASEO_TERMINAL_ID` propagates into terminals nested inside a Paseo pane (e.g. launching a real kitty from a Paseo-hosted shell), where graphics would now be disabled unnecessarily. That nesting is rare and the degradation is graceful (text fallback, no garbage).
