### PR TITLE
feat(coding-agent): resolve OpenRouter @preset/ model selectors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenRouter routing variants (`:nitro`/`:floor`/`:online`/`:exacto`) are no longer appended to `@preset/` model ids, in any casing.
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -547,6 +547,7 @@ export function isOpenRouterAnthropicModel(model: OpenAIModelIdentity): boolean 
  */
 export function applyOpenRouterRoutingVariant(modelId: string, variant: string | undefined): string {
 	if (!variant) return modelId;
+	if (modelId.toLowerCase().includes("@preset/")) return modelId;
 	const lastSlash = modelId.lastIndexOf("/");
 	const lastColon = modelId.lastIndexOf(":");
 	if (lastColon > lastSlash) return modelId;

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -2344,6 +2344,18 @@ describe("applyOpenRouterRoutingVariant", () => {
 	it("appends the variant when the id has no slash separator", () => {
 		expect(applyOpenRouterRoutingVariant("opaque-id", "nitro")).toBe("opaque-id:nitro");
 	});
+
+	it("does not append routing variants to OpenRouter preset ids", () => {
+		expect(applyOpenRouterRoutingVariant("@preset/free", "nitro")).toBe("@preset/free");
+		expect(applyOpenRouterRoutingVariant("@preset/free", "floor")).toBe("@preset/free");
+		expect(applyOpenRouterRoutingVariant("@PRESET/free", "nitro")).toBe("@PRESET/free");
+		expect(applyOpenRouterRoutingVariant("openai/gpt-4@preset/email-copywriter", "exacto")).toBe(
+			"openai/gpt-4@preset/email-copywriter",
+		);
+		expect(applyOpenRouterRoutingVariant("anthropic/claude-haiku-latest", "nitro")).toBe(
+			"anthropic/claude-haiku-latest:nitro",
+		);
+	});
 });
 
 describe("anthropic cache control for OpenAI-compatible chat completions", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added a third state to the git TUI whitespace toggle (`b`): beyond ignoring whitespace-only line changes, it hides formatting-only changes (indentation, line splits/joins, blank lines) and import-only changes in TypeScript/JavaScript, Rust, and Go
 - Compressed single-child directory chains in the sidebar tree view
 - Split pure additions (new/untracked files) into their own list below tracked changes in each git TUI file section, separated by a rule; addition rows drop the redundant status letter and deleted files render struck through
+- Added support for OpenRouter preset selectors (`openrouter/@preset/{slug}`): they now resolve in the CLI, `modelRoles`, and `omp bench`, sending wire id `@preset/{slug}` over the dedicated OpenRouter transport without appending a routing-variant suffix (`:nitro`/`:floor`/`:online`/`:exacto`) or inheriting catalog model metadata.
 
 ### Changed
 

--- a/packages/coding-agent/src/auto-thinking/classifier.ts
+++ b/packages/coding-agent/src/auto-thinking/classifier.ts
@@ -112,7 +112,12 @@ export async function classifyDifficulty(
 }
 
 async function classifyOnline(input: string, deps: ClassifyDifficultyDeps, ceiling: Effort): Promise<Effort> {
-	const resolved = resolveRoleSelection(["tiny", "smol"], deps.settings, deps.registry.getAvailable());
+	const resolved = resolveRoleSelection(
+		["tiny", "smol"],
+		deps.settings,
+		deps.registry.getAvailable(),
+		(provider, modelId) => deps.registry.find(provider, modelId),
+	);
 	const model = resolved?.model;
 	if (!model) {
 		throw new Error("auto-thinking: no tiny/smol model available for classification");

--- a/packages/coding-agent/src/cli/dry-balance-cli.ts
+++ b/packages/coding-agent/src/cli/dry-balance-cli.ts
@@ -17,6 +17,7 @@ import { formatDuration, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { ModelRegistry } from "../config/model-registry";
 import {
+	createScopeAwareModelResolver,
 	formatModelString,
 	getModelMatchPreferences,
 	resolveAllowedModels,
@@ -72,6 +73,7 @@ export interface DryBalanceModelRegistry {
 	authStorage: DryBalanceAuthStorage;
 	getAll(): Model<Api>[];
 	getAvailable(): Model<Api>[];
+	find?: (provider: string, modelId: string) => Model<Api> | undefined;
 	getApiKey(model: Model<Api>, sessionId?: string): Promise<string | undefined>;
 }
 
@@ -570,9 +572,11 @@ async function resolveDryBalanceModel(
 		);
 	}
 
+	const modelScopeFiltered = (settings?.get("enabledModels")?.length ?? 0) > 0;
 	const defaultRoleSpec = resolveModelRoleValue(settings?.getModelRole("default"), allowedModels, {
 		settings,
 		matchPreferences: preferences,
+		resolveProviderModelReference: createScopeAwareModelResolver(modelRegistry, allowedModels, modelScopeFiltered),
 	});
 	if (defaultRoleSpec.model) {
 		return { model: defaultRoleSpec.model, warning: defaultRoleSpec.warning };

--- a/packages/coding-agent/src/commit/model-selection.ts
+++ b/packages/coding-agent/src/commit/model-selection.ts
@@ -41,9 +41,16 @@ export async function resolvePrimaryModel(
 ): Promise<ResolvedCommitModel> {
 	const available = modelRegistry.getAvailable();
 	const matchPreferences = getModelMatchPreferences(settings);
+	const resolveReference = modelRegistry.find
+		? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+		: undefined;
 	const resolved = override
-		? resolveModelRoleValue(override, available, { settings, matchPreferences })
-		: resolveRoleSelection(["commit", "smol", ...MODEL_ROLE_IDS], settings, available);
+		? resolveModelRoleValue(override, available, {
+				settings,
+				matchPreferences,
+				resolveProviderModelReference: resolveReference,
+			})
+		: resolveRoleSelection(["commit", "smol", ...MODEL_ROLE_IDS], settings, available, resolveReference);
 	const model = resolved?.model;
 	if (!model) {
 		throw new Error("No model available for commit generation");
@@ -66,7 +73,12 @@ export async function resolveSmolModel(
 	fallbackApiKey: ApiKey,
 ): Promise<ResolvedCommitModel> {
 	const available = modelRegistry.getAvailable();
-	const resolvedSmol = resolveRoleSelection(["smol"], settings, available);
+	const resolvedSmol = resolveRoleSelection(
+		["smol"],
+		settings,
+		available,
+		modelRegistry.find ? (provider, modelId) => modelRegistry.find!(provider, modelId) : undefined,
+	);
 	if (resolvedSmol?.model) {
 		const apiKey = await modelRegistry.getApiKey(resolvedSmol.model);
 		if (apiKey) {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -101,6 +101,7 @@ import {
 	withRuntimeDynamicModelsTimeout,
 } from "./model-provider-discovery";
 
+export type { ProviderOverride } from "./model-patch";
 export { mergeDiscoveredModel } from "./model-patch";
 export {
 	isAuthenticated,
@@ -1763,6 +1764,35 @@ export class ModelRegistry {
 		});
 	}
 
+	/**
+	 * Apply a configured per-model override to a synthesized preset model.
+	 * Presets are virtual references, so `#applyModelOverrides` (which runs over
+	 * catalog rows) never reaches them; honoring `modelOverrides` for the preset
+	 * id lets a user opt into capabilities the neutral default omits (e.g.
+	 * `input: ["text", "image"]` for a vision-capable routed preset).
+	 */
+	#applyPresetOverride(provider: string, modelId: string, preset: Model<Api>): Model<Api> {
+		if (!modelId.trim().toLowerCase().startsWith("@preset/")) return preset;
+		const normalizedProvider = provider.trim().toLowerCase();
+		const normalizedModelId = modelId.trim().toLowerCase();
+		let overrides: Map<string, ModelOverride> | undefined;
+		for (const [key, map] of this.#modelOverrides) {
+			if (key.toLowerCase() === normalizedProvider) {
+				overrides = map;
+				break;
+			}
+		}
+		if (!overrides) return preset;
+		let override: ModelOverride | undefined;
+		for (const [key, value] of overrides) {
+			if (key.toLowerCase() === normalizedModelId) {
+				override = value;
+				break;
+			}
+		}
+		return override ? applyModelOverride(preset, override) : preset;
+	}
+
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
 		return {
 			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
@@ -2080,7 +2110,14 @@ export class ModelRegistry {
 	 * Find a model by provider and ID.
 	 */
 	find(provider: string, modelId: string): Model<Api> | undefined {
-		return resolveProviderModelReference(provider, modelId, this.#modelsForProviderLookup(provider));
+		const resolved = resolveProviderModelReference(
+			provider,
+			modelId,
+			this.#modelsForProviderLookup(provider),
+			this.getProviderOverride(provider),
+		);
+		if (!resolved) return resolved;
+		return this.#applyPresetOverride(provider, modelId, resolved);
 	}
 
 	/**
@@ -2093,10 +2130,45 @@ export class ModelRegistry {
 	 * Get provider-level headers without including per-model overrides.
 	 */
 	getProviderHeaders(provider: string): Record<string, string> | undefined {
-		return createLiveConfigHeaders([
-			this.#providerOverrides.get(provider)?.headers,
-			this.#runtimeProviderOverrides.get(provider)?.headers,
-		]);
+		// getProviderOverride already folds config + runtime overrides (runtime
+		// winning) case-insensitively; expose the merged headers directly.
+		return this.getProviderOverride(provider)?.headers;
+	}
+
+	/**
+	 * Get the merged provider-level override (config overrides merged with
+	 * runtime-registered overrides, runtime winning) — `baseUrl`, `headers`,
+	 * `apiKey`/`authHeader`, `compat`, `remoteCompaction`, `transport`, and
+	 * guardrail fields — without any per-model `modelOverrides`. Used to
+	 * synthesize virtual model references (e.g. OpenRouter `@preset/` ids) so
+	 * they carry the provider's transport configuration but never inherit
+	 * metadata that `modelOverrides` attached to individual catalog rows.
+	 */
+	getProviderOverride(provider: string): ProviderOverride | undefined {
+		const normalized = provider.trim().toLowerCase();
+		// Provider keys are stored verbatim (as configured/registered); selectors
+		// reach here with the caller's spelling, so match case-insensitively —
+		// e.g. `OPENROUTER/@preset/free` must find the `openrouter` override.
+		const findOverride = (map: Map<string, ProviderOverride>): ProviderOverride | undefined => {
+			const exact = map.get(normalized);
+			if (exact) return exact;
+			for (const [key, value] of map) {
+				if (key.toLowerCase() === normalized) return value;
+			}
+			return undefined;
+		};
+		const baseOverride = findOverride(this.#providerOverrides);
+		const runtimeOverride = findOverride(this.#runtimeProviderOverrides);
+		if (!baseOverride && !runtimeOverride) return undefined;
+		const merged = this.#mergeProviderOverride(baseOverride, runtimeOverride ?? {});
+		// Materialize live header values (env vars / `!command` expressions) and
+		// fold authHeader/apiKey into an `Authorization` header BEFORE consumers
+		// read them — `getProviderHeaders`/`getApiKeyAndHeaders` and preset
+		// synthesis must never see raw `models.yml` placeholders.
+		return {
+			...merged,
+			headers: mergeAuthHeaderSources([merged.headers], merged.authHeader, merged.apiKey),
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -16,8 +16,9 @@
  */
 
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Api, Effort, KnownProvider, Model, ModelSpec } from "@oh-my-pi/pi-ai";
+import type { Api, KnownProvider, Model, ModelSpec } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
 import { buildModelProviderPriorityRank } from "@oh-my-pi/pi-catalog/identity";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
@@ -36,7 +37,9 @@ import {
 	parseThinkingLevel,
 	resolveThinkingLevelForModel,
 } from "../thinking";
-import { isAuthenticated, kNoAuth, type ModelRegistry } from "./model-registry";
+import { createLiveConfigHeaders } from "./model-config-values";
+import { DISCOVERY_DEFAULT_CONTEXT_WINDOW, DISCOVERY_DEFAULT_MAX_TOKENS } from "./model-discovery";
+import { isAuthenticated, kNoAuth, type ModelRegistry, type ProviderOverride } from "./model-registry";
 import {
 	DEFAULT_MODEL_ROLE_ALIAS,
 	formatModelRoleAlias,
@@ -297,6 +300,74 @@ function cloneModelWithRequestedId(model: Model<Api>, requestedId: string): Mode
 	};
 }
 
+const OPENROUTER_PROVIDER = "openrouter";
+const OPENROUTER_PRESET_PREFIX = "@preset/";
+
+function isOpenRouterPresetModelId(modelId: string): boolean {
+	const trimmed = modelId.trim();
+	if (!trimmed.toLowerCase().startsWith(OPENROUTER_PRESET_PREFIX)) return false;
+	const slug = trimmed.slice(OPENROUTER_PRESET_PREFIX.length);
+	return slug.length > 0 && !slug.includes(":") && !slug.includes("@") && !slug.includes("/");
+}
+
+function resolveOpenRouterPresetModel(
+	modelId: string,
+	availableModels: readonly Model<Api>[],
+	providerOverride?: ProviderOverride,
+): Model<Api> | undefined {
+	const requestedId = modelId.trim();
+	if (!isOpenRouterPresetModelId(requestedId)) return undefined;
+
+	// The catalog row is only an existence check and canonical baseUrl fallback:
+	// all transport metadata (headers/auth, transport, compat, remoteCompaction)
+	// comes from the provider-level override, never from a specific row, because
+	// `modelOverrides` attach per-model transport to individual catalog rows and
+	// the first row would leak them into every preset request.
+	const template = availableModels.find(model => model.provider.toLowerCase() === OPENROUTER_PROVIDER);
+	if (!template && !providerOverride) return undefined;
+	const baseUrl = providerOverride?.baseUrl ?? template?.baseUrl;
+	if (!baseUrl) return undefined;
+	const headers = createLiveConfigHeaders([providerOverride?.headers], {
+		authHeader: providerOverride?.authHeader,
+		apiKeyConfig: providerOverride?.apiKey,
+	});
+
+	const presetId = `${OPENROUTER_PRESET_PREFIX}${requestedId.slice(OPENROUTER_PRESET_PREFIX.length)}`;
+	return buildModel({
+		id: presetId,
+		requestModelId: presetId,
+		name: presetId,
+		api: "openrouter",
+		provider: OPENROUTER_PROVIDER,
+		baseUrl,
+		...(headers ? { headers } : {}),
+		...(providerOverride?.transport !== undefined ? { transport: providerOverride.transport } : {}),
+		...(providerOverride?.compat ? { compat: providerOverride.compat as ModelSpec<"openrouter">["compat"] } : {}),
+		...(providerOverride?.remoteCompaction
+			? { remoteCompaction: providerOverride.remoteCompaction as ModelSpec<"openrouter">["remoteCompaction"] }
+			: {}),
+		reasoning: true,
+		thinking: {
+			mode: "budget",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+		},
+		// Presets route to an arbitrary upstream model whose window/modality is
+		// unknown at synthesis time. A `null` window disables proactive
+		// compaction (SessionMaintenance gates on `contextWindow > 0`), so use
+		// the same conservative window defaults as discovery for unknown-window
+		// models. Modality stays text-only by default: the routed upstream may
+		// be text-only, and declaring image capability universally would turn
+		// attachments on such a preset into wire errors. A vision-capable preset
+		// opts in by configuring a per-model override for the preset id
+		// (e.g. `modelOverrides` with `input: ["text", "image"]`), which
+		// `ModelRegistry.find` applies to the synthesized preset.
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: DISCOVERY_DEFAULT_CONTEXT_WINDOW,
+		maxTokens: DISCOVERY_DEFAULT_MAX_TOKENS,
+	} satisfies ModelSpec<"openrouter">);
+}
+
 const AMAZON_BEDROCK_PROVIDER = "amazon-bedrock";
 const BEDROCK_INFERENCE_PROFILE_ARN =
 	/^arn:aws(?:-[a-z]+)*:bedrock:[a-z0-9-]+:[0-9]*:(?:application-inference-profile|inference-profile)\/[a-z0-9][a-z0-9._:-]*$/i;
@@ -406,6 +477,7 @@ export function resolveProviderModelReference(
 	provider: string,
 	modelId: string,
 	availableModels: readonly Model<Api>[],
+	providerOverride?: ProviderOverride,
 ): Model<Api> | undefined {
 	const normalizedProvider = provider.trim().toLowerCase();
 	const normalizedModelId = modelId.trim().toLowerCase();
@@ -453,6 +525,9 @@ export function resolveProviderModelReference(
 		}
 	}
 
+	const preset = resolveOpenRouterPresetModel(modelId, availableModels, providerOverride);
+	if (preset) return preset;
+
 	return undefined;
 }
 
@@ -465,8 +540,35 @@ export interface ModelMatchPreferences {
 	deprioritizeProviders?: string[];
 }
 
-export type ModelLookupRegistry = Pick<ModelRegistry, "getAvailable">;
-type CliModelRegistry = Pick<ModelRegistry, "getAll" | "getAvailable">;
+export type ModelLookupRegistry = Pick<ModelRegistry, "getAvailable"> & Partial<Pick<ModelRegistry, "find">>;
+export type ModelReferenceResolver = (provider: string, modelId: string) => Model<Api> | undefined;
+
+/**
+ * Build a registry-backed resolver that refuses models outside an
+ * `enabledModels` candidate scope. When `scopeFiltered` is true, a resolved
+ * model (e.g. a synthetic `@preset/…`) is only returned when it is already in
+ * `candidateSet` — an admitted preset is added there by
+ * `includeSyntheticAllowedModels`, so set membership is the authoritative
+ * scope check and an unadmitted preset cannot leak past `enabledModels`.
+ */
+export function createScopeAwareModelResolver(
+	registry: { find?: (provider: string, modelId: string) => Model<Api> | undefined },
+	candidateSet: readonly Model<Api>[],
+	scopeFiltered: boolean,
+): ModelReferenceResolver | undefined {
+	const find = registry.find?.bind(registry);
+	if (!find) return undefined;
+	return (provider, modelId) => {
+		const resolved = find(provider, modelId);
+		if (!resolved) return undefined;
+		if (scopeFiltered && !candidateSet.some(m => m.provider === resolved.provider && m.id === resolved.id)) {
+			return undefined;
+		}
+		return resolved;
+	};
+}
+
+type CliModelRegistry = Pick<ModelRegistry, "getAll" | "getAvailable"> & Partial<Pick<ModelRegistry, "find">>;
 type InitialModelRegistry = Pick<ModelRegistry, "getAvailable" | "find">;
 type RestorableModelRegistry = Pick<ModelRegistry, "getAvailable" | "find" | "getApiKey">;
 
@@ -476,11 +578,13 @@ interface ModelPreferenceContext {
 	providerPriorityRank: Map<string, number>;
 	deprioritizedProviders: Set<string>;
 	modelOrder: Map<string, number>;
+	resolveProviderModelReference?: ModelReferenceResolver;
 }
 
 function buildPreferenceContext(
 	availableModels: Model<Api>[],
 	preferences: ModelMatchPreferences | undefined,
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): ModelPreferenceContext {
 	const modelUsageRank = new Map<string, number>();
 	const providerUsageRank = new Map<string, number>();
@@ -502,7 +606,14 @@ function buildPreferenceContext(
 		modelOrder.set(formatModelString(availableModels[i]), i);
 	}
 
-	return { modelUsageRank, providerUsageRank, providerPriorityRank, deprioritizedProviders, modelOrder };
+	return {
+		modelUsageRank,
+		providerUsageRank,
+		providerPriorityRank,
+		deprioritizedProviders,
+		modelOrder,
+		resolveProviderModelReference,
+	};
 }
 
 export function getModelMatchPreferences(
@@ -633,10 +744,23 @@ function isProviderLockedCrossMatch(pattern: string, matchedModel: Model<Api>): 
 /**
  * Find an exact explicit provider/model match.
  */
-function findExactModelReferenceMatch(modelReference: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+function findExactModelReferenceMatch(
+	modelReference: string,
+	availableModels: Model<Api>[],
+	resolveReference?: ModelReferenceResolver,
+): Model<Api> | undefined {
 	const trimmedReference = modelReference.trim();
 	if (!trimmedReference) {
 		return undefined;
+	}
+
+	// A bare `@preset/{slug}` is an OpenRouter account-side preset reference
+	// (no provider prefix). Route it to the openrouter provider so the upstream
+	// routing base (`@preset/free` from `@preset/free@cerebras`) can re-resolve.
+	if (trimmedReference.toLowerCase().startsWith(OPENROUTER_PRESET_PREFIX)) {
+		return resolveReference && availableModels.some(model => model.provider.toLowerCase() === OPENROUTER_PROVIDER)
+			? resolveReference(OPENROUTER_PROVIDER, trimmedReference)
+			: resolveProviderModelReference(OPENROUTER_PROVIDER, trimmedReference, availableModels);
 	}
 
 	const slashIndex = trimmedReference.indexOf("/");
@@ -644,6 +768,19 @@ function findExactModelReferenceMatch(modelReference: string, availableModels: M
 		const provider = trimmedReference.substring(0, slashIndex).trim();
 		const modelId = trimmedReference.substring(slashIndex + 1).trim();
 		if (provider && modelId) {
+			// The registry resolver applies ONLY to preset ids: presets are
+			// synthetic (never in `availableModels`) and carry provider settings
+			// + `modelOverrides`. For any catalog model, keep the candidate-
+			// authoritative array resolver so `enabledModels` exclusions hold
+			// (e.g. `openrouter/model-a` enabled, role `openrouter/model-b`
+			// must NOT resolve the excluded `model-b` via the full catalog).
+			const isPreset = modelId.trim().toLowerCase().startsWith(OPENROUTER_PRESET_PREFIX);
+			if (isPreset) {
+				return resolveReference &&
+					availableModels.some(model => model.provider.toLowerCase() === provider.toLowerCase())
+					? resolveReference(provider, modelId)
+					: resolveProviderModelReference(provider, modelId, availableModels);
+			}
 			return resolveProviderModelReference(provider, modelId, availableModels);
 		}
 	}
@@ -671,7 +808,11 @@ function matchModel(
 	context: ModelPreferenceContext,
 	options?: { exactOnly?: boolean },
 ): Model<Api> | undefined {
-	const exactRefMatch = findExactModelReferenceMatch(modelPattern, availableModels);
+	const exactRefMatch = findExactModelReferenceMatch(
+		modelPattern,
+		availableModels,
+		context.resolveProviderModelReference,
+	);
 	if (exactRefMatch) {
 		return exactRefMatch;
 	}
@@ -925,11 +1066,12 @@ export function parseModelPattern(
 	availableModels: Model<Api>[],
 	preferences?: ModelMatchPreferences,
 	options?: { allowInvalidThinkingSelectorFallback?: boolean },
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): ParsedModelResult {
 	return matchPatternWithContext(
 		pattern,
 		availableModels,
-		buildPreferenceContext(availableModels, preferences),
+		buildPreferenceContext(availableModels, preferences, resolveProviderModelReference),
 		options,
 	);
 }
@@ -1287,7 +1429,12 @@ export interface ResolvedModelRoleValue {
 export function resolveModelRoleValue(
 	roleValue: string | undefined,
 	availableModels: Model<Api>[],
-	options?: { settings?: Settings; roleLookup?: ModelRoleLookup; matchPreferences?: ModelMatchPreferences },
+	options?: {
+		settings?: Settings;
+		roleLookup?: ModelRoleLookup;
+		matchPreferences?: ModelMatchPreferences;
+		resolveProviderModelReference?: ModelReferenceResolver;
+	},
 ): ResolvedModelRoleValue {
 	if (!roleValue) {
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
@@ -1308,7 +1455,11 @@ export function resolveModelRoleValue(
 	// Build the O(n) preference context (model-order map over all available
 	// models) once and reuse it across every fallback pattern instead of
 	// rebuilding it per pattern inside parseModelPattern.
-	const preferenceContext = buildPreferenceContext(availableModels, matchPreferences);
+	const preferenceContext = buildPreferenceContext(
+		availableModels,
+		matchPreferences,
+		options?.resolveProviderModelReference,
+	);
 	for (const [patternIndex, effectivePattern] of effectivePatterns.entries()) {
 		const resolved = matchPatternWithContext(effectivePattern, availableModels, preferenceContext);
 		if (resolved.model) {
@@ -1382,6 +1533,7 @@ export function resolveModelFromString(
 	value: string,
 	available: Model<Api>[],
 	matchPreferences?: ModelMatchPreferences,
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): Model<Api> | undefined {
 	const exact = available.find(model => `${model.provider}/${model.id}` === value);
 	if (exact) return exact;
@@ -1393,7 +1545,7 @@ export function resolveModelFromString(
 		const parsedExact = available.find(model => model.provider === parsed.provider && model.id === parsed.id);
 		if (parsedExact) return parsedExact;
 	}
-	return parseModelPattern(value, available, matchPreferences).model;
+	return parseModelPattern(value, available, matchPreferences, undefined, resolveProviderModelReference).model;
 }
 
 /**
@@ -1432,6 +1584,9 @@ export function resolveModelOverride(
 	if (modelPatterns.length === 0) return { explicitThinkingLevel: false };
 	const availableModels = modelRegistry.getAvailable();
 	const matchPreferences = getModelMatchPreferences(settings);
+	const resolveReference = modelRegistry.find
+		? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+		: undefined;
 	let warning: string | undefined;
 	for (const pattern of modelPatterns) {
 		const {
@@ -1442,6 +1597,7 @@ export function resolveModelOverride(
 		} = resolveModelRoleValue(pattern, availableModels, {
 			settings,
 			matchPreferences,
+			resolveProviderModelReference: resolveReference,
 		});
 		if (model) {
 			return { model, thinkingLevel, explicitThinkingLevel, warning: patternWarning };
@@ -1522,12 +1678,14 @@ export function resolveRoleSelection(
 	roles: readonly string[],
 	settings: Settings,
 	availableModels: Model<Api>[],
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): { model: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
 	const matchPreferences = getModelMatchPreferences(settings);
 	for (const role of roles) {
 		const resolved = resolveModelRoleValue(settings.getModelRole(role), availableModels, {
 			settings,
 			matchPreferences,
+			resolveProviderModelReference,
 		});
 		if (resolved.model) {
 			return { model: resolved.model, thinkingLevel: resolved.thinkingLevel };
@@ -1547,10 +1705,12 @@ export function resolveRoleSelection(
 export function resolveAdvisorRoleSelection(
 	settings: Settings,
 	availableModels: Model<Api>[],
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): { model: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
 	const resolved = resolveModelRoleValue(formatModelRoleAlias("advisor"), availableModels, {
 		settings,
 		matchPreferences: getModelMatchPreferences(settings),
+		resolveProviderModelReference,
 	});
 	return resolved.model ? { model: resolved.model, thinkingLevel: resolved.thinkingLevel } : undefined;
 }
@@ -1568,12 +1728,15 @@ export function resolveAdvisorRoleSelection(
  */
 export async function resolveModelScope(
 	patterns: string[],
-	modelRegistry: Pick<ModelRegistry, "getAvailable">,
+	modelRegistry: Pick<ModelRegistry, "getAvailable"> & Partial<Pick<ModelRegistry, "find">>,
 	preferences?: ModelMatchPreferences,
 	settings?: Settings,
 ): Promise<ScopedModel[]> {
 	const availableModels = modelRegistry.getAvailable();
-	const context = buildPreferenceContext(availableModels, preferences);
+	const resolveReference = modelRegistry.find
+		? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+		: undefined;
+	const context = buildPreferenceContext(availableModels, preferences, resolveReference);
 	const scopedModels: ScopedModel[] = [];
 	const addScopedModel = (model: Model<Api>, thinkingLevel: ThinkingLevel | undefined, explicit: boolean) => {
 		if (scopedModels.some(sm => modelsAreEqual(sm.model, model))) return;
@@ -1613,7 +1776,11 @@ export async function resolveModelScope(
 		// entry exactly like `--model` would pick. (Bare `*` stays a match-all
 		// glob above; scope semantics, not the default-role alias.)
 		if (settings && modelRoleAliasPrefixLength(pattern) !== undefined) {
-			const resolved = resolveModelRoleValue(pattern, availableModels, { settings, matchPreferences: preferences });
+			const resolved = resolveModelRoleValue(pattern, availableModels, {
+				settings,
+				matchPreferences: preferences,
+				resolveProviderModelReference: resolveReference,
+			});
 			if (resolved.warning) logger.warn(resolved.warning);
 			if (!resolved.model) {
 				logger.warn(`No models match pattern "${pattern}"`);
@@ -1706,10 +1873,11 @@ export function filterAvailableModelsByEnabledPatterns(
 	available: Model<Api>[],
 	patterns: readonly string[],
 	settings?: Settings,
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): Model<Api>[] {
 	if (patterns.length === 0) return available;
 
-	const context = buildPreferenceContext(available, undefined);
+	const context = buildPreferenceContext(available, undefined, resolveProviderModelReference);
 	const allowedModels: Model<Api>[] = [];
 	const addAllowed = (model: Model<Api>) => {
 		allowedModels.push(model);
@@ -1725,7 +1893,10 @@ export function filterAvailableModelsByEnabledPatterns(
 
 		// Mirror resolveModelScope: role aliases resolve to the role's model.
 		if (settings && modelRoleAliasPrefixLength(pattern) !== undefined) {
-			const { model } = resolveModelRoleValue(pattern, available, { settings });
+			const { model } = resolveModelRoleValue(pattern, available, {
+				settings,
+				resolveProviderModelReference,
+			});
 			if (model) addAllowed(model);
 			continue;
 		}
@@ -1743,9 +1914,10 @@ function findExactCliModel(
 	allModels: Model<Api>[],
 	availableModels: Model<Api>[],
 	options?: { catalogFallback?: boolean },
+	resolveProviderModelReference?: ModelReferenceResolver,
 ): Model<Api> | undefined {
 	// Explicit provider/id references stay authoritative against the full catalog.
-	const referenced = findExactModelReferenceMatch(selector, allModels);
+	const referenced = findExactModelReferenceMatch(selector, allModels, resolveProviderModelReference);
 	if (referenced) return referenced;
 
 	// Flat-id (or full-selector-string) matches prefer authenticated providers,
@@ -1820,6 +1992,9 @@ export function resolveCliModel(options: {
 	}
 
 	const availableModels = preferredModels ?? modelRegistry.getAvailable();
+	const resolveReference = modelRegistry.find
+		? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+		: undefined;
 	const providerMap = new Map<string, string>();
 	for (const model of allModels) {
 		providerMap.set(model.provider.toLowerCase(), model.provider);
@@ -1837,7 +2012,13 @@ export function resolveCliModel(options: {
 
 	const trimmedModel = cliModel.trim();
 	if (!provider) {
-		const exact = findExactCliModel(trimmedModel, allModels, availableModels, { catalogFallback: false });
+		const exact = findExactCliModel(
+			trimmedModel,
+			allModels,
+			availableModels,
+			{ catalogFallback: false },
+			resolveReference,
+		);
 		if (exact) {
 			return {
 				model: exact,
@@ -1853,7 +2034,13 @@ export function resolveCliModel(options: {
 			MAX_THINKING_SUFFIX_OPTIONS,
 		);
 		if (exactThinkingLevel) {
-			const exactSuffixed = findExactCliModel(exactBase, allModels, availableModels, { catalogFallback: false });
+			const exactSuffixed = findExactCliModel(
+				exactBase,
+				allModels,
+				availableModels,
+				{ catalogFallback: false },
+				resolveReference,
+			);
 			if (exactSuffixed) {
 				return {
 					model: exactSuffixed,
@@ -1889,12 +2076,14 @@ export function resolveCliModel(options: {
 			const availableResolved = resolveModelRoleValue(roleSelector, availableModels, {
 				settings,
 				matchPreferences: preferences,
+				resolveProviderModelReference: resolveReference,
 			});
 			const resolved = availableResolved.model
 				? availableResolved
 				: resolveModelRoleValue(roleSelector, allModels, {
 						settings,
 						matchPreferences: preferences,
+						resolveProviderModelReference: resolveReference,
 					});
 			if (resolved.model) {
 				return {
@@ -1942,7 +2131,9 @@ export function resolveCliModel(options: {
 	}
 
 	if (provider) {
-		const exactProviderMatch = resolveProviderModelReference(provider, pattern, allModels);
+		const exactProviderMatch = resolveReference
+			? resolveReference(provider, pattern)
+			: resolveProviderModelReference(provider, pattern, allModels);
 		if (exactProviderMatch) {
 			return {
 				model: exactProviderMatch,
@@ -1955,13 +2146,25 @@ export function resolveCliModel(options: {
 	}
 
 	const candidates = provider ? allModels.filter(model => model.provider === provider) : availableModels;
-	let parsed = parseModelPattern(pattern, candidates, preferences, {
-		allowInvalidThinkingSelectorFallback: false,
-	});
-	if (!parsed.model && !provider) {
-		parsed = parseModelPattern(pattern, allModels, preferences, {
+	let parsed = parseModelPattern(
+		pattern,
+		candidates,
+		preferences,
+		{
 			allowInvalidThinkingSelectorFallback: false,
-		});
+		},
+		resolveReference,
+	);
+	if (!parsed.model && !provider) {
+		parsed = parseModelPattern(
+			pattern,
+			allModels,
+			preferences,
+			{
+				allowInvalidThinkingSelectorFallback: false,
+			},
+			resolveReference,
+		);
 	}
 	const { model, thinkingLevel, warning, upstream } = parsed;
 
@@ -2151,10 +2354,13 @@ export async function findSmolModel(
 ): Promise<Model<Api> | undefined> {
 	const availableModels = modelRegistry.getAvailable();
 	if (availableModels.length === 0) return undefined;
+	const resolveReference = modelRegistry.find
+		? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+		: undefined;
 
 	// 1. Try saved model from settings
 	if (savedModel) {
-		const match = resolveModelFromString(savedModel, availableModels, undefined);
+		const match = resolveModelFromString(savedModel, availableModels, undefined, resolveReference);
 		if (match) return match;
 	}
 
@@ -2165,7 +2371,7 @@ export async function findSmolModel(
 		if (providerMatch) return providerMatch;
 
 		// Try exact match first
-		const exactMatch = parseModelPattern(pattern, availableModels, undefined).model;
+		const exactMatch = parseModelPattern(pattern, availableModels, undefined, undefined, resolveReference).model;
 		if (exactMatch) return exactMatch;
 
 		// Try fuzzy match (substring)
@@ -2191,17 +2397,20 @@ export async function findSlowModel(
 ): Promise<Model<Api> | undefined> {
 	const availableModels = modelRegistry.getAvailable();
 	if (availableModels.length === 0) return undefined;
+	const resolveReference = modelRegistry.find
+		? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+		: undefined;
 
 	// 1. Try saved model from settings
 	if (savedModel) {
-		const match = resolveModelFromString(savedModel, availableModels, undefined);
+		const match = resolveModelFromString(savedModel, availableModels, undefined, resolveReference);
 		if (match) return match;
 	}
 
 	// 2. Try priority chain
 	for (const pattern of MODEL_PRIO.slow) {
 		// Try exact match first
-		const exactMatch = parseModelPattern(pattern, availableModels, undefined).model;
+		const exactMatch = parseModelPattern(pattern, availableModels, undefined, undefined, resolveReference).model;
 		if (exactMatch) return exactMatch;
 
 		// Try fuzzy match (substring)

--- a/packages/coding-agent/src/edit/auto-repair.ts
+++ b/packages/coding-agent/src/edit/auto-repair.ts
@@ -288,7 +288,9 @@ export async function attemptEditAutoRepair(options: {
 	if (!session.settings.get("edit.autoRepair.enabled")) return undefined;
 	const registry = session.modelRegistry;
 	if (!registry) return undefined;
-	const model = resolveRoleSelection(["smol"], session.settings, registry.getAvailable())?.model;
+	const model = resolveRoleSelection(["smol"], session.settings, registry.getAvailable(), (provider, modelId) =>
+		registry.find(provider, modelId),
+	)?.model;
 	if (!model) return undefined;
 	const sessionId = session.getSessionId?.() ?? undefined;
 	// Resolve the key eagerly so the session-sticky credential is recorded and

--- a/packages/coding-agent/src/eval/completion-bridge.ts
+++ b/packages/coding-agent/src/eval/completion-bridge.ts
@@ -76,7 +76,9 @@ function resolveTierModel(tier: CompletionTier, session: ToolSession): Model<Api
 	const resolve = (pattern: string | undefined): Model<Api> | undefined => {
 		if (!pattern) return undefined;
 		const expanded = expandRoleAlias(pattern, session.settings);
-		return resolveModelFromString(expanded, available, matchPreferences);
+		return resolveModelFromString(expanded, available, matchPreferences, (provider, modelId) =>
+			modelRegistry.find(provider, modelId),
+		);
 	};
 
 	if (tier === "default") {

--- a/packages/coding-agent/src/extensibility/extensions/model-api.ts
+++ b/packages/coding-agent/src/extensibility/extensions/model-api.ts
@@ -33,6 +33,12 @@ export function createExtensionModelQuery(
 			resolveModelRoleValue(spec, modelRegistry.getAvailable(), {
 				settings,
 				matchPreferences: getModelMatchPreferences(settings),
+				...(modelRegistry.find
+					? {
+							resolveProviderModelReference: (provider: string, modelId: string) =>
+								modelRegistry.find!(provider, modelId),
+						}
+					: {}),
 			}).model,
 		family: (model: Model<Api>): string => modelFamilyToken(model.id) || model.provider.toLowerCase(),
 	};

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -1243,6 +1243,7 @@ async function resolveMemoryModel(options: {
 		const resolved = resolveModelRoleValue(requestedModel, modelRegistry.getAll(), {
 			settings: session.settings,
 			matchPreferences: getModelMatchPreferences(session.settings),
+			resolveProviderModelReference: (provider, modelId) => modelRegistry.find(provider, modelId),
 		});
 		if (resolved.model) return resolved.model;
 	}

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -558,7 +558,12 @@ async function resolveMnemopiProviderOptions(
 	}
 
 	try {
-		const resolved = resolveRoleSelection(["tiny", "smol"], settings, modelRegistry.getAvailable());
+		const resolved = resolveRoleSelection(
+			["tiny", "smol"],
+			settings,
+			modelRegistry.getAvailable(),
+			(provider, modelId) => modelRegistry.find(provider, modelId),
+		);
 		const model = resolved?.model;
 		if (!model) {
 			logger.warn("Mnemopi: llmMode=smol but no tiny/smol model resolved; continuing without LLM.");

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -67,6 +67,7 @@ export function resolveRoleAssignments(
 	settings: Settings,
 	allModels: ReadonlyArray<Model>,
 	autoCandidates: ReadonlyArray<Model>,
+	resolveProviderModelReference?: (provider: string, modelId: string) => Model | undefined,
 ): RoleAssignments {
 	const resolvedThinkingLevel = (
 		role: string,
@@ -91,7 +92,11 @@ export function resolveRoleAssignments(
 		const roleValue = settings.getModelRole(role);
 		if (!roleValue) continue;
 		configuredRoles.add(role);
-		const resolved = resolveModelRoleValue(roleValue, catalog, { settings, matchPreferences });
+		const resolved = resolveModelRoleValue(roleValue, catalog, {
+			settings,
+			matchPreferences,
+			resolveProviderModelReference,
+		});
 		if (resolved.model) {
 			roles[role] = {
 				model: resolved.model,
@@ -105,7 +110,11 @@ export function resolveRoleAssignments(
 		const candidates = [...autoCandidates];
 		for (const role of knownRoles) {
 			if (configuredRoles.has(role)) continue;
-			const resolved = resolveModelRoleValue(`pi/${role}`, candidates, { settings, matchPreferences });
+			const resolved = resolveModelRoleValue(`pi/${role}`, candidates, {
+				settings,
+				matchPreferences,
+				resolveProviderModelReference,
+			});
 			if (!resolved.model) continue;
 			roles[role] = {
 				model: resolved.model,

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -28,7 +28,12 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
-import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValue } from "../../config/model-resolver";
+import {
+	createScopeAwareModelResolver,
+	type ModelRoleLookup,
+	type ResolvedModelRoleValue,
+	resolveModelRoleValue,
+} from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
 import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
@@ -310,8 +315,14 @@ export class ModelHubComponent implements Component {
 
 	/** Resolve every known role: configured values first, auto-selection for the rest. */
 	#reloadRoles(autoCandidates: ReadonlyArray<Model>): void {
-		const allModels = this.#scopedModels.length > 0 ? autoCandidates : this.#registry.getAll();
-		this.#roles = resolveRoleAssignments(this.#settings, allModels, autoCandidates);
+		const scoped = this.#scopedModels.length > 0;
+		const allModels = scoped ? autoCandidates : this.#registry.getAll();
+		this.#roles = resolveRoleAssignments(
+			this.#settings,
+			allModels,
+			autoCandidates,
+			createScopeAwareModelResolver(this.#registry, autoCandidates, scoped),
+		);
 	}
 
 	/** Rebuild items, roles, and the sidebar from the registry's in-memory state. */
@@ -815,7 +826,12 @@ export class ModelHubComponent implements Component {
 					? (this.#settings.getProjectModelRole(scopedRole) ?? this.#settings.getGlobalModelRole(scopedRole))
 					: this.#settings.getGlobalModelRole(scopedRole),
 		};
-		return resolveModelRoleValue(roleValue, allModels, { settings: this.#settings, roleLookup });
+		const scoped = this.#scopedModels.length > 0;
+		return resolveModelRoleValue(roleValue, allModels, {
+			settings: this.#settings,
+			roleLookup,
+			resolveProviderModelReference: createScopeAwareModelResolver(this.#registry, allModels, scoped),
+		});
 	}
 
 	#thinkingLevelForScope(role: string, scope: ModelRoleSelectionScope): ConfiguredThinkingLevel {

--- a/packages/coding-agent/src/modes/components/model-picker.ts
+++ b/packages/coding-agent/src/modes/components/model-picker.ts
@@ -7,6 +7,7 @@
 import type { Model } from "@oh-my-pi/pi-ai";
 import type { Component, TUI } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
+import { createScopeAwareModelResolver } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import type { ResolvedRoleModel } from "../../session/agent-session";
 import { theme } from "../theme/theme";
@@ -156,8 +157,14 @@ export class ModelPickerComponent implements Component {
 			}
 		}
 
-		const allModels = this.#scopedModels.length > 0 ? models : this.#registry.getAll();
-		const roles = resolveRoleAssignments(this.#settings, allModels, models);
+		const scoped = this.#scopedModels.length > 0;
+		const allModels = scoped ? models : this.#registry.getAll();
+		const roles = resolveRoleAssignments(
+			this.#settings,
+			allModels,
+			models,
+			createScopeAwareModelResolver(this.#registry, models, scoped),
+		);
 		const storage = this.#settings.getStorage();
 		const mruOrder = storage?.getModelUsageOrder() ?? [];
 		this.#modelItems = buildBrowserItems(models);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -16,6 +16,7 @@ import {
 import { reset as resetCapabilities } from "../../capability";
 import { showGitOverlay } from "../../cli/git-tui";
 import {
+	createScopeAwareModelResolver,
 	formatModelSelectorValue,
 	resolveAdvisorRoleSelection,
 	resolveModelRoleValue,
@@ -298,6 +299,7 @@ export class SelectorController {
 			const advisorRoleSel = resolveAdvisorRoleSelection(
 				this.ctx.settings,
 				this.ctx.session.modelRegistry.getAvailable(),
+				(provider, modelId) => this.ctx.session.modelRegistry.find(provider, modelId),
 			);
 			const defaultAdvisorModel = advisorRoleSel?.model;
 			const deps: AdvisorConfigDeps = {
@@ -996,10 +998,17 @@ export class SelectorController {
 								exposesPersistedFallback
 							) {
 								const scopedModels = this.ctx.session.scopedModels.map(sm => sm.model);
+								const scopeFiltered =
+									scopedModels.length > 0 || (this.ctx.settings.get("enabledModels")?.length ?? 0) > 0;
 								const availableModels =
 									scopedModels.length > 0 ? scopedModels : this.ctx.session.getAvailableModels();
 								const resolved = resolveModelRoleValue(fallbackRoleValue, availableModels, {
 									settings: this.ctx.settings,
+									resolveProviderModelReference: createScopeAwareModelResolver(
+										this.ctx.session.modelRegistry,
+										availableModels,
+										scopeFiltered,
+									),
 								});
 								if (resolved.model) {
 									const fallbackModel = resolved.model;

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
@@ -70,7 +70,9 @@ class ModelSceneController implements SetupSceneController {
 	#syncModels(): void {
 		const registry = this.host.ctx.session.modelRegistry;
 		const available = registry.getAvailable();
-		const roles = resolveRoleAssignments(this.host.ctx.settings, registry.getAll(), available);
+		const roles = resolveRoleAssignments(this.host.ctx.settings, registry.getAll(), available, (provider, modelId) =>
+			registry.find(provider, modelId),
+		);
 		const storage = this.host.ctx.settings.getStorage();
 		const items = buildBrowserItems(available);
 		sortModelItems(items, { roles, mruOrder: storage?.getModelUsageOrder() ?? [] });

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -58,6 +58,7 @@ import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode
 import { shouldInlineToolDescriptors } from "./config/inline-tool-descriptors-mode";
 import { isAuthenticated, kNoAuth, ModelRegistry } from "./config/model-registry";
 import {
+	createScopeAwareModelResolver,
 	formatModelSelectorValue,
 	formatModelString,
 	formatModelStringWithRouting,
@@ -69,6 +70,7 @@ import {
 	resolveCliModel,
 	resolveConfiguredModelPatterns,
 	resolveModelRoleValue,
+	resolveProviderModelReference,
 } from "./config/model-resolver";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { applyProviderGlobalsFromSettings } from "./config/provider-globals";
@@ -1469,10 +1471,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			? modelRegistry.getAvailableForProviders(explicitDefaultProviders)
 			: resolveAllowedModels(modelRegistry, settings, modelMatchPreferences),
 	);
+	const modelScopeFiltered = (settings.get("enabledModels")?.length ?? 0) > 0;
+	const scopeAwareReference = createScopeAwareModelResolver(modelRegistry, allowedModels, modelScopeFiltered);
 	let defaultRoleSpec = logger.time("resolveDefaultModelRole", () =>
 		resolveModelRoleValue(defaultRoleValue, allowedModels, {
 			settings,
 			matchPreferences: modelMatchPreferences,
+			resolveProviderModelReference: scopeAwareReference,
 		}),
 	);
 	let model = options.model;
@@ -1503,8 +1508,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					failedSessionModel ??= sessionModelStr;
 					continue;
 				}
-
-				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
+				const restoredModel =
+					modelRegistry.find(parsedModel.provider, parsedModel.id) ??
+					resolveProviderModelReference(parsedModel.provider, parsedModel.id, modelRegistry.getAll());
 				if (restoredModel && hasModelAuth(restoredModel)) {
 					model = restoredModel;
 					restoredSessionModelIndex = i;
@@ -2262,6 +2268,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			}
 			const allModels = modelRegistry.getAll();
 			const availableModels = modelRegistry.getAvailable();
+			// Registry-backed resolution so a deferred OpenRouter `@preset/…`
+			// fallback in this function still carries provider settings and
+			// preset-specific `modelOverrides`, matching startup paths that
+			// already resolve through the registry.
+			const resolveReference = modelRegistry.find
+				? (provider: string, modelId: string) => modelRegistry.find!(provider, modelId)
+				: undefined;
 			const expandedModelPatterns = deferredModelPatterns.flatMap(pattern =>
 				pattern.split(",").flatMap(selector => {
 					const trimmedSelector = selector.trim();
@@ -2292,9 +2305,17 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 							modelLookup: modelRegistry,
 						};
 						const originalSelector = resolved.configuredPatterns[0];
-						const availableOriginal = parseModelPattern(originalSelector, availableModels, matchPreferences);
+						const availableOriginal = parseModelPattern(
+							originalSelector,
+							availableModels,
+							matchPreferences,
+							undefined,
+							resolveReference,
+						);
 						const originalModel =
-							availableOriginal.model ?? parseModelPattern(originalSelector, allModels, matchPreferences).model;
+							availableOriginal.model ??
+							parseModelPattern(originalSelector, allModels, matchPreferences, undefined, resolveReference)
+								.model;
 						const chainKey = resolveRetryFallbackChainKey(
 							fallbackContext,
 							originalSelector,
@@ -2337,14 +2358,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				}),
 			);
 			const resolutionModels = expandedModelPatterns.some(
-				({ pattern }) => parseModelPattern(pattern, availableModels, matchPreferences).model,
+				({ pattern }) =>
+					parseModelPattern(pattern, availableModels, matchPreferences, undefined, resolveReference).model,
 			)
 				? availableModels
 				: allModels;
 			let usageFallbackTriggered = false;
 			for (let patternIndex = 0; patternIndex < expandedModelPatterns.length; patternIndex += 1) {
 				const { pattern, retryFallback } = expandedModelPatterns[patternIndex];
-				const primary = parseModelPattern(pattern, resolutionModels, matchPreferences);
+				const primary = parseModelPattern(pattern, resolutionModels, matchPreferences, undefined, resolveReference);
 				if (!primary.model || (retryFallback && !hasModelAuth(primary.model))) continue;
 				let hasUsageFallbackCandidate = false;
 				for (
@@ -2356,6 +2378,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						expandedModelPatterns[candidateIndex].pattern,
 						resolutionModels,
 						matchPreferences,
+						undefined,
+						resolveReference,
 					);
 					if (candidate.model && hasModelAuth(candidate.model)) {
 						hasUsageFallbackCandidate = true;
@@ -2427,6 +2451,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 							options.modelPatternAuthFallback,
 							resolutionModels,
 							matchPreferences,
+							undefined,
+							resolveReference,
 						);
 						if (fallback.model) {
 							const fallbackKey = await modelRegistry.getApiKey(fallback.model);
@@ -2447,7 +2473,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					const seenSelectors = new Set<string>([primarySelector]);
 					const fallbackSelectors: string[] = [];
 					for (const fallbackEntry of expandedModelPatterns.slice(patternIndex + 1)) {
-						const fallback = parseModelPattern(fallbackEntry.pattern, resolutionModels, matchPreferences);
+						const fallback = parseModelPattern(
+							fallbackEntry.pattern,
+							resolutionModels,
+							matchPreferences,
+							undefined,
+							resolveReference,
+						);
 						if (!fallback.model) continue;
 						const fallbackSelector = formatModelSelectorValue(
 							formatModelStringWithRouting(fallback.model),
@@ -2534,9 +2566,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				// Re-resolve the allowed set: extension factories and discovery
 				// refreshes above may have registered models not visible earlier.
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+				const scopeAwareFallbackReference = createScopeAwareModelResolver(
+					modelRegistry,
+					fallbackCandidates,
+					modelScopeFiltered,
+				);
 				const reResolvedRoleSpec = resolveModelRoleValue(settings.getModelRole("default"), fallbackCandidates, {
 					settings,
 					matchPreferences: modelMatchPreferences,
+					resolveProviderModelReference: scopeAwareFallbackReference,
 				});
 				if (!reResolvedRoleSpec.model) return false;
 				defaultRoleSpec = reResolvedRoleSpec;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -103,7 +103,7 @@ import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, type AsyncJob, AsyncJobManager } fro
 import { reset as resetCapabilities } from "../capability";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
-import type { ResolvedModelRoleValue } from "../config/model-resolver";
+import { type ResolvedModelRoleValue, resolveProviderModelReference } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily } from "../config/service-tier";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -8145,6 +8145,28 @@ export class AgentSession {
 					const provider = targetModelStr.slice(0, slashIdx);
 					const modelId = targetModelStr.slice(slashIdx + 1);
 					match = availableModels.find(m => m.provider === provider && m.id === modelId);
+					if (!match) {
+						// A preset is synthesized (absent from `getAvailable()`), so a
+						// configured `modelOverrides` entry on its id must be applied
+						// during restore too. Resolve through the registry's `find` (which
+						// applies `#applyPresetOverride`) for presets whose provider is in
+						// the available set; otherwise fall back to the candidate-
+						// authoritative array resolver so an unavailable provider is never
+						// silently restored.
+						const isPreset = modelId.trim().toLowerCase().startsWith("@preset/");
+						const providerAvailable = availableModels.some(
+							m => m.provider.toLowerCase() === provider.toLowerCase(),
+						);
+						match =
+							isPreset && providerAvailable
+								? this.#modelRegistry.find(provider, modelId)
+								: resolveProviderModelReference(
+										provider,
+										modelId,
+										availableModels,
+										this.#modelRegistry.getProviderOverride(provider),
+									);
+					}
 					if (match) break;
 				}
 				if (match) {

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -184,12 +184,23 @@ export class ModelControls {
 		this.#serviceTierByFamily = tiers;
 	}
 	resolveRoleModel(role: string): Model | undefined {
-		return resolveRoleModelFull(this.#host.settings, role, this.#host.modelRegistry.getAvailable(), this.#model)
-			.model;
+		return resolveRoleModelFull(
+			this.#host.settings,
+			role,
+			this.#host.modelRegistry.getAvailable(),
+			this.#model,
+			(provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
+		).model;
 	}
 
 	resolveRoleModelWithThinking(role: string): ResolvedModelRoleValue {
-		return resolveRoleModelFull(this.#host.settings, role, this.#host.modelRegistry.getAvailable(), this.#model);
+		return resolveRoleModelFull(
+			this.#host.settings,
+			role,
+			this.#host.modelRegistry.getAvailable(),
+			this.#model,
+			(provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
+		);
 	}
 
 	resolveTemporaryModelThinkingLevel(model: Model): ConfiguredThinkingLevel | undefined {
@@ -204,6 +215,7 @@ export class ModelControls {
 			const resolved = resolveModelRoleValue(roleValue, availableModels, {
 				settings: this.#host.settings,
 				matchPreferences,
+				resolveProviderModelReference: (provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
 			});
 			if (!resolved.explicitThinkingLevel || resolved.thinkingLevel === undefined || !resolved.model) continue;
 			if (modelsAreEqual(resolved.model, model)) return resolved.thinkingLevel;
@@ -334,6 +346,7 @@ export class ModelControls {
 			const resolved = resolveModelRoleValue(roleModelStr, availableModels, {
 				settings: this.#host.settings,
 				matchPreferences,
+				resolveProviderModelReference: (provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
 			});
 			if (!resolved.model) continue;
 
@@ -484,7 +497,9 @@ export class ModelControls {
 		const all = this.#host.modelRegistry.getAvailable();
 		const patterns = this.#host.settings.get("enabledModels");
 		if (!patterns || patterns.length === 0) return all;
-		return filterAvailableModelsByEnabledPatterns(all, patterns, this.#host.settings);
+		return filterAvailableModelsByEnabledPatterns(all, patterns, this.#host.settings, (provider, modelId) =>
+			this.#host.modelRegistry.find(provider, modelId),
+		);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/session/role-models.ts
+++ b/packages/coding-agent/src/session/role-models.ts
@@ -69,6 +69,7 @@ export function resolveRoleModelFull(
 	role: string,
 	availableModels: Model[],
 	currentModel: Model | undefined,
+	resolveProviderModelReference?: (provider: string, modelId: string) => Model | undefined,
 ): ResolvedModelRoleValue {
 	const roleModelStr =
 		role === "default"
@@ -81,5 +82,6 @@ export function resolveRoleModelFull(
 	return resolveModelRoleValue(roleModelStr, availableModels, {
 		settings,
 		matchPreferences: getModelMatchPreferences(settings),
+		resolveProviderModelReference,
 	});
 }

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -630,7 +630,11 @@ export class SessionAdvisors {
 					continue;
 				}
 			} else {
-				const sel = resolveAdvisorRoleSelection(this.#host.settings, this.#host.modelRegistry.getAvailable());
+				const sel = resolveAdvisorRoleSelection(
+					this.#host.settings,
+					this.#host.modelRegistry.getAvailable(),
+					(provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
+				);
 				if (!sel) {
 					this.#advisorStatuses.set(slug, { name: config.name, status: "no_model" });
 					if (emitWarnings) {
@@ -1749,7 +1753,11 @@ export class SessionAdvisors {
 		if (this.#advisors.length > 0) {
 			return this.#advisors.some(a => this.#host.modelRegistry.isUsingOAuth(a.model));
 		}
-		const sel = resolveAdvisorRoleSelection(this.#host.settings, this.#host.modelRegistry.getAvailable());
+		const sel = resolveAdvisorRoleSelection(
+			this.#host.settings,
+			this.#host.modelRegistry.getAvailable(),
+			(provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
+		);
 		return sel ? this.#host.modelRegistry.isUsingOAuth(sel.model) : false;
 	}
 	/**

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2113,7 +2113,13 @@ export class SessionMaintenance {
 		addCandidate(preferredModel ?? undefined);
 		for (const role of MODEL_ROLE_IDS) {
 			addCandidate(
-				resolveRoleModelFull(this.#host.settings, role, availableModels, preferredModel ?? undefined).model,
+				resolveRoleModelFull(
+					this.#host.settings,
+					role,
+					availableModels,
+					preferredModel ?? undefined,
+					(provider, modelId) => this.#host.modelRegistry.find(provider, modelId),
+				).model,
 			);
 		}
 

--- a/packages/coding-agent/src/session/unexpected-stop-classifier.ts
+++ b/packages/coding-agent/src/session/unexpected-stop-classifier.ts
@@ -85,7 +85,12 @@ export async function classifyUnexpectedStop(
 }
 
 async function classifyOnline(text: string, deps: ClassifyUnexpectedStopDeps): Promise<boolean | undefined> {
-	const resolved = resolveRoleSelection(["tiny", "smol"], deps.settings, deps.registry.getAvailable());
+	const resolved = resolveRoleSelection(
+		["tiny", "smol"],
+		deps.settings,
+		deps.registry.getAvailable(),
+		(provider, modelId) => deps.registry.find(provider, modelId),
+	);
 	const model = resolved?.model;
 	if (!model) {
 		throw new Error("unexpected-stop: no tiny/smol model available for classification");

--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -169,7 +169,9 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 		const resolvePattern = (pattern: string | undefined): Model<Api> | undefined => {
 			if (!pattern) return undefined;
 			const expanded = expandRoleAlias(pattern, this.session.settings);
-			return resolveModelFromString(expanded, availableModels, matchPreferences);
+			return resolveModelFromString(expanded, availableModels, matchPreferences, (provider, modelId) =>
+				modelRegistry.find(provider, modelId),
+			);
 		};
 
 		const activeModelPattern = this.session.getActiveModelString?.() ?? this.session.getModelString?.();

--- a/packages/coding-agent/src/tts/speech-enhancer.ts
+++ b/packages/coding-agent/src/tts/speech-enhancer.ts
@@ -76,6 +76,7 @@ export class SpeechEnhancer {
 			const model = resolveModelRoleValue("@tiny", registry.getAvailable(), {
 				settings,
 				matchPreferences: getModelMatchPreferences(settings),
+				resolveProviderModelReference: (provider, modelId) => registry.find(provider, modelId),
 			}).model;
 			if (!model) return null;
 			const apiKey = await registry.getApiKey(model, sessionId);

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -59,6 +59,7 @@ function getSmolModelCandidates(
 	const configuredSmol = resolveModelRoleValue(settings.getModelRole("smol"), availableModels, {
 		settings,
 		matchPreferences,
+		resolveProviderModelReference: (provider, modelId) => registry.find(provider, modelId),
 	});
 	addCandidate(configuredSmol.model, concreteThinkingLevel(configuredSmol.thinkingLevel));
 

--- a/packages/coding-agent/src/utils/image-vision-fallback.ts
+++ b/packages/coding-agent/src/utils/image-vision-fallback.ts
@@ -39,7 +39,7 @@ const DESCRIPTION_UNAVAILABLE_NOTE =
 	"[Image description unavailable: the vision model returned no usable text. The image was saved for further analysis.]";
 
 /** Registry surface needed to resolve a vision model and authorize requests. */
-export type VisionFallbackRegistry = Pick<ModelRegistry, "getAvailable" | "getApiKey" | "resolver">;
+export type VisionFallbackRegistry = Pick<ModelRegistry, "getAvailable" | "getApiKey" | "resolver" | "find">;
 
 export interface DescribeAttachedImagesDeps {
 	/** Active (text-only) model the prompt is destined for. */
@@ -107,7 +107,9 @@ function resolveVisionModel(deps: DescribeAttachedImagesDeps): Model<Api> | unde
 	const resolvePattern = (pattern: string | undefined): Model<Api> | undefined => {
 		if (!pattern) return undefined;
 		const expanded = expandRoleAlias(pattern, deps.settings);
-		const model = resolveModelFromString(expanded, available, preferences);
+		const model = resolveModelFromString(expanded, available, preferences, (provider, modelId) =>
+			deps.modelRegistry.find(provider, modelId),
+		);
 		return model?.input.includes("image") ? model : undefined;
 	};
 	return (

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -112,7 +112,9 @@ function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel
 	const availableModels = registry.getAvailable();
 	if (availableModels.length === 0) return undefined;
 
-	const titleModel = resolveRoleSelection(["tiny", "commit", "smol"], settings, availableModels)?.model;
+	const titleModel = resolveRoleSelection(["tiny", "commit", "smol"], settings, availableModels, (provider, modelId) =>
+		registry.find(provider, modelId),
+	)?.model;
 	if (titleModel) return titleModel;
 
 	if (currentModel) return currentModel;

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -191,6 +191,63 @@ describe("ModelRegistry runtime provider registration", () => {
 		expectProviderHeader(registry, providerName, runtimeHeader, undefined);
 	});
 
+	test("case-varied preset lookup preserves merged config → runtime provider settings", async () => {
+		// Config override for openrouter.
+		fs.writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					openrouter: {
+						baseUrl: "https://config-gateway.example/v1",
+						headers: { "X-Provider-Header": "config-value" },
+						compat: { supportsUsageInStreaming: false },
+						disableStrictTools: true,
+						remoteCompaction: {
+							enabled: true,
+							api: "openai-responses",
+							endpoint: "https://config-gateway.example/v1/responses/provider-compact",
+							model: "provider-compact",
+						},
+						transport: "pi-native",
+					},
+				},
+			}),
+		);
+		await registry.refresh("offline");
+		// Runtime override: runtime wins on the shared header key, both keys present.
+		registry.registerProvider(
+			"openrouter",
+			{
+				baseUrl: "https://runtime-gateway.example/v1",
+				headers: { "X-Provider-Header": "runtime-wins", "X-Runtime-Header": "runtime" },
+			},
+			"ext://runtime",
+		);
+
+		const override = registry.getProviderOverride("OPENROUTER");
+		expect(override?.baseUrl).toBe("https://runtime-gateway.example/v1");
+		expect(override?.headers?.["X-Provider-Header"]).toBe("runtime-wins");
+		expect(override?.headers?.["X-Runtime-Header"]).toBe("runtime");
+		// Config-only fields survive a partial runtime override.
+		expect(override?.transport).toBe("pi-native");
+		expect((override?.compat as { disableStrictTools?: boolean } | undefined)?.disableStrictTools).toBe(true);
+		expect((override?.compat as { supportsUsageInStreaming?: boolean } | undefined)?.supportsUsageInStreaming).toBe(
+			false,
+		);
+		expect(override?.remoteCompaction).toMatchObject({
+			enabled: true,
+			api: "openai-responses",
+			model: "provider-compact",
+		});
+
+		// The case-varied selector resolves the preset with the merged settings.
+		const preset = registry.find("OPENROUTER", "@preset/custom-openrouter-preset");
+		expect(preset).toBeDefined();
+		expect(preset?.baseUrl).toBe("https://runtime-gateway.example/v1");
+		expect(preset?.headers?.["X-Provider-Header"]).toBe("runtime-wins");
+		expect(preset?.transport).toBe("pi-native");
+	});
+
 	test("registerProvider keeps runtime header objects live for request-time reads", () => {
 		const providerHeaders: Record<string, string> = { "X-Request-ID": "request-1" };
 		const modelHeaders: Record<string, string> = { "X-Message-ID": "message-1" };

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -239,6 +239,109 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	describe("OpenRouter preset provider-scoped settings", () => {
+		let presetRegistry: ModelRegistry;
+		beforeAll(() => {
+			presetRegistry = readonlyRegistry({
+				providers: {
+					openrouter: {
+						baseUrl: "https://gateway.example/v1",
+						headers: { "X-Provider-Header": "provider-value" },
+						compat: { supportsUsageInStreaming: false },
+						disableStrictTools: true,
+						remoteCompaction: {
+							enabled: true,
+							api: "openai-responses",
+							endpoint: "https://gateway.example/v1/responses/provider-compact",
+							model: "provider-compact",
+						},
+						transport: "pi-native",
+						modelOverrides: {
+							"anthropic/claude-sonnet-4": { headers: { "X-Custom-Model-Header": "value" } },
+						},
+					},
+				},
+			});
+		});
+
+		test("preset uses provider headers, never per-model override headers", () => {
+			const preset = presetRegistry.find("openrouter", "@preset/custom-openrouter-preset");
+			expect(preset).toBeDefined();
+			expect(preset?.provider).toBe("openrouter");
+			expect(preset?.headers).toEqual({ "X-Provider-Header": "provider-value" });
+			expect(preset?.headers?.["X-Custom-Model-Header"]).toBeUndefined();
+		});
+
+		test("preset carries provider transport settings", () => {
+			const preset = presetRegistry.find("openrouter", "@preset/custom-openrouter-preset");
+			expect(preset?.baseUrl).toBe("https://gateway.example/v1");
+			expect(preset?.transport).toBe("pi-native");
+		});
+
+		test("preset carries provider compat and compaction settings", () => {
+			const preset = presetRegistry.find("openrouter", "@preset/custom-openrouter-preset");
+			const compat = preset?.compatConfig as
+				| { disableStrictTools?: boolean; supportsUsageInStreaming?: boolean }
+				| undefined;
+			expect(compat?.disableStrictTools).toBe(true);
+			expect(compat?.supportsUsageInStreaming).toBe(false);
+			expect(preset?.remoteCompaction).toMatchObject({
+				enabled: true,
+				api: "openai-responses",
+				endpoint: "https://gateway.example/v1/responses/provider-compact",
+				model: "provider-compact",
+			});
+		});
+
+		test("preset retains provider settings with a case-varied provider spelling", () => {
+			const preset = presetRegistry.find("OPENROUTER", "@preset/custom-openrouter-preset");
+			expect(preset).toBeDefined();
+			expect(preset?.baseUrl).toBe("https://gateway.example/v1");
+			expect(preset?.headers).toEqual({ "X-Provider-Header": "provider-value" });
+			expect(preset?.transport).toBe("pi-native");
+			const compat = preset?.compatConfig as { disableStrictTools?: boolean } | undefined;
+			expect(compat?.disableStrictTools).toBe(true);
+		});
+
+		test("preset override can enable image input for a vision-capable routed model", () => {
+			const visionRegistry = readonlyRegistry({
+				providers: {
+					openrouter: {
+						baseUrl: "https://gateway.example/v1",
+						modelOverrides: {
+							"@preset/custom-openrouter-preset": { input: ["text", "image"] },
+						},
+					},
+				},
+			});
+			const preset = visionRegistry.find("openrouter", "@preset/custom-openrouter-preset");
+			expect(preset).toBeDefined();
+			expect(preset?.input).toEqual(["text", "image"]);
+		});
+
+		test("getProviderOverride materializes live header values", () => {
+			const prior = Bun.env.OMP_TEST_HEADER;
+			Bun.env.OMP_TEST_HEADER = "from-env";
+			try {
+				const registry = readonlyRegistry({
+					providers: {
+						openrouter: {
+							baseUrl: "https://gateway.example/v1",
+							headers: { "X-Env": "OMP_TEST_HEADER" },
+						},
+					},
+				});
+				// Config-only override: header sources must be materialized (env/`!cmd`
+				// resolved) before consumers read them, never raw `models.yml` placeholders.
+				expect(registry.getProviderOverride("openrouter")?.headers?.["X-Env"]).toBe("from-env");
+				expect(registry.getProviderHeaders("openrouter")?.["X-Env"]).toBe("from-env");
+			} finally {
+				if (prior === undefined) delete Bun.env.OMP_TEST_HEADER;
+				else Bun.env.OMP_TEST_HEADER = prior;
+			}
+		});
+	});
+
 	describe("Bedrock inference profile ARN fallback", () => {
 		let registry: ModelRegistry;
 		beforeAll(() => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
+import type { Api, Model, ModelSpec } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
 import {
+	createScopeAwareModelResolver,
 	expandRoleAlias,
 	extractExplicitThinkingSelector,
 	filterAvailableModelsByEnabledPatterns,
@@ -21,6 +23,7 @@ import {
 	resolveModelOverride,
 	resolveModelRoleValue,
 	resolveModelScope,
+	resolveProviderModelReference,
 } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { DEFAULT_MODEL_ROLE_ALIAS, LEGACY_MODEL_ROLE_ALIAS_PREFIX } from "@oh-my-pi/pi-coding-agent/config/model-roles";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -1556,6 +1559,130 @@ describe("resolveCliModel", () => {
 		expect(result.model?.id).toBe("z-ai/glm-4.7-20251222:nitro");
 	});
 
+	test("resolves OpenRouter preset selectors to a cloned catalog model", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "openrouter/@preset/custom-openrouter-preset",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.api).toBe("openrouter");
+		const compat = result.model?.compat;
+		expect(compat && "wireModelIdMode" in compat ? compat.wireModelIdMode : undefined).toBe("openrouter");
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.model?.requestModelId).toBe("@preset/custom-openrouter-preset");
+		expect(result.model?.thinking?.efforts).toContain(Effort.High);
+		expect(result.model?.contextWindow).toBeGreaterThan(0);
+		expect(result.model?.maxTokens).toBeGreaterThan(0);
+		expect(result.model?.reasoning).toBe(true);
+		// Presets are unknown-modality virtual references; the default stays
+		// text-only so a text-only routed model is not forced to accept images
+		// (a vision preset opts in via a per-model override on the preset id).
+		expect(result.model?.input).toEqual(["text"]);
+		expect(result.selector).toBe("openrouter/@preset/custom-openrouter-preset");
+	});
+
+	test("resolves an OpenRouter preset selector with an uppercase prefix", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "openrouter/@PRESET/custom-openrouter-preset",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.model?.requestModelId).toBe("@preset/custom-openrouter-preset");
+	});
+
+	test("parses thinking suffixes after OpenRouter preset selectors", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "openrouter/@preset/custom-openrouter-preset:high",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.model?.requestModelId).toBe("@preset/custom-openrouter-preset");
+		expect(result.thinkingLevel).toBe(Effort.High);
+	});
+
+	test("parses thinking suffixes with separate --provider/--model flags", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliProvider: "openrouter",
+			cliModel: "@preset/custom-openrouter-preset:high",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.model?.requestModelId).toBe("@preset/custom-openrouter-preset");
+		expect(result.thinkingLevel).toBe(Effort.High);
+	});
+
+	test("resolves an explicit OpenRouter provider with a bare preset id", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliProvider: "openrouter",
+			cliModel: "@preset/custom-openrouter-preset",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.model?.requestModelId).toBe("@preset/custom-openrouter-preset");
+	});
+
+	test("rejects an empty @preset/ selector", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "openrouter/@preset/",
+			modelRegistry: registry,
+		});
+
+		expect(result.model).toBeUndefined();
+		expect(result.error).toContain("not found");
+	});
+
+	test("does not resolve a preset selector when no openrouter model is available", () => {
+		const registry = { getAll: () => mockModels, getAvailable: () => mockModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "openrouter/@preset/custom-openrouter-preset",
+			modelRegistry: registry,
+		});
+
+		expect(result.model).toBeUndefined();
+		expect(result.error).toContain("not found");
+	});
+
 	test("accepts Bedrock inference profile ARNs and preserves thinking suffixes", () => {
 		const defaultBedrockModel = createBedrockDefaultModel();
 		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
@@ -2040,6 +2167,27 @@ describe("provider routing selector (@upstream)", () => {
 		expect(result.selector).toBe("openrouter/z-ai/glm-4.7@cerebras");
 		expect(openRouterOnly(result.model)).toEqual(["cerebras"]);
 	});
+
+	test("resolveCliModel routes an OpenRouter preset through @upstream", () => {
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
+		const result = resolveCliModel({
+			cliModel: "openrouter/@preset/custom-openrouter-preset@cerebras",
+			modelRegistry: registry,
+		});
+		expect(result.error).toBeUndefined();
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.selector).toBe("openrouter/@preset/custom-openrouter-preset@cerebras");
+		expect(openRouterOnly(result.model)).toEqual(["cerebras"]);
+	});
+
+	test("routes an OpenRouter preset through an @upstream slug (parseModelPattern)", () => {
+		const result = parseModelPattern("openrouter/@preset/custom-openrouter-preset@cerebras", allModels);
+		expect(result.model?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result.upstream).toBe("cerebras");
+		expect(openRouterOnly(result.model)).toEqual(["cerebras"]);
+	});
 });
 
 describe("filterAvailableModelsByEnabledPatterns", () => {
@@ -2243,5 +2391,181 @@ describe("effort-tier variant aliases", () => {
 	test("consumed X-thinking twins resolve via the grammar fallback", () => {
 		expect(parseModelPattern("venice/kimi-k2-thinking", variantModels).model?.id).toBe("kimi-k2");
 		expect(parseModelPattern("kimi-k2-thinking", variantModels).model?.id).toBe("kimi-k2");
+	});
+});
+
+describe("resolveProviderModelReference OpenRouter preset fallback", () => {
+	test("synthesizes a preset model from an available OpenRouter provider row", () => {
+		const result = resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset", allModels);
+		expect(result).toBeDefined();
+		expect(result?.provider).toBe("openrouter");
+		expect(result?.id).toBe("@preset/custom-openrouter-preset");
+		expect(result?.requestModelId).toBe("@preset/custom-openrouter-preset");
+		expect(result?.thinking?.efforts).toContain(Effort.High);
+	});
+
+	test("returns undefined when no OpenRouter provider row is available", () => {
+		const result = resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset", mockModels);
+		expect(result).toBeUndefined();
+	});
+
+	test("returns undefined for empty @preset/ id", () => {
+		expect(resolveProviderModelReference("openrouter", "@preset/", allModels)).toBeUndefined();
+		expect(resolveProviderModelReference("openrouter", "@preset", allModels)).toBeUndefined();
+	});
+
+	test("rejects preset slugs that contain selector delimiters", () => {
+		expect(
+			resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset@cerebras", allModels),
+		).toBeUndefined();
+		expect(
+			resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset:high", allModels),
+		).toBeUndefined();
+	});
+
+	test("never inherits per-model transport metadata from an OpenRouter row", () => {
+		const template = buildModel({
+			id: "z-ai/glm-4.7",
+			name: "GLM 4.7",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://gateway.example/v1",
+			// These are row-level transport headers (modelOverrides.targeted): the
+			// preset must not copy them, or every preset request would carry a
+			// header that was scoped to one catalog model.
+			headers: { "X-Custom-Model-Header": "value" },
+			transport: "pi-native",
+			reasoning: true,
+			thinking: { mode: "budget", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] },
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		} as ModelSpec<"openrouter">);
+
+		const result = resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset", [template]);
+		expect(result?.baseUrl).toBe("https://gateway.example/v1");
+		expect(result?.headers).toBeUndefined();
+		expect(result?.transport).toBeUndefined();
+	});
+
+	test("preserves provider-level transport fields from provider settings", () => {
+		const template = buildModel({
+			id: "z-ai/glm-4.7",
+			name: "GLM 4.7",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://gateway.example/v1",
+			headers: { "X-Custom-Model-Header": "value" },
+			reasoning: true,
+			thinking: { mode: "budget", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] },
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		} as ModelSpec<"openrouter">);
+		const settings = {
+			baseUrl: "https://provider.example/v1",
+			headers: { "X-Provider-Header": "value" },
+			compat: { disableStrictTools: true },
+			remoteCompaction: { enabled: true, api: "openai-responses" },
+			transport: "pi-native",
+		} as const;
+
+		const result = resolveProviderModelReference(
+			"openrouter",
+			"@preset/custom-openrouter-preset",
+			[template],
+			settings,
+		);
+		expect(result?.baseUrl).toBe("https://provider.example/v1");
+		expect(result?.headers).toEqual({ "X-Provider-Header": "value" });
+		expect(result?.transport).toBe("pi-native");
+		// Per-model row header never leaks through, even with settings present.
+		expect(result?.headers?.["X-Custom-Model-Header"]).toBeUndefined();
+		expect((result?.compatConfig as { disableStrictTools?: boolean } | undefined)?.disableStrictTools).toBe(true);
+		expect(result?.remoteCompaction).toMatchObject({ enabled: true, api: "openai-responses" });
+	});
+
+	test("keeps a usable context window so proactive compaction can trigger", () => {
+		// A null sentinel disables SessionMaintenance's compaction threshold
+		// (it gates on `contextWindow > 0`), forcing overflow/recovery to the
+		// upstream limit instead of compacting first. Presets must carry a
+		// positive window.
+		const result = resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset", allModels);
+		expect(result?.contextWindow).toBeGreaterThan(0);
+		expect(result?.maxTokens).toBeGreaterThan(0);
+	});
+
+	test("does not resolve an excluded non-preset catalog model through the registry resolver", () => {
+		// `enabledModels` permits `openrouter/model-a` but a role names
+		// `openrouter/model-b`. The registry resolver must not leak the
+		// excluded `model-b` (present in the full catalog, absent from the
+		// candidate set) — only preset ids may use the registry resolver.
+		const modelA = buildModel({
+			id: "model-a",
+			name: "model-a",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		} as ModelSpec<"openrouter">);
+		const modelB = buildModel({
+			id: "model-b",
+			name: "model-b",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		} as ModelSpec<"openrouter">);
+
+		const resolver = () => modelB;
+		const result = parseModelPattern("openrouter/model-b", [modelA], undefined, undefined, resolver);
+		expect(result.model).toBeUndefined();
+	});
+
+	test("resolveModelFromString resolves a preset through the registry resolver", () => {
+		const resolver = (provider: string, modelId: string) =>
+			resolveProviderModelReference(provider, modelId, allModels);
+		const result = resolveModelFromString(
+			"openrouter/@preset/custom-openrouter-preset",
+			allModels,
+			undefined,
+			resolver,
+		);
+		expect(result?.provider).toBe("openrouter");
+		expect(result?.id).toBe("@preset/custom-openrouter-preset");
+	});
+
+	test("keeps preset resolution within the enabled-models scope", () => {
+		const preset = resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset", allModels);
+		expect(preset).toBeDefined();
+		const registry = { find: () => preset };
+		// Scope-filtered, preset NOT in the candidate set → not admitted.
+		const filtered = createScopeAwareModelResolver(registry, [allModels[0]!], true);
+		expect(filtered?.("openrouter", "@preset/custom-openrouter-preset")).toBeUndefined();
+		// Scope-filtered, preset admitted (present in the candidate set) → returned.
+		const admitted = createScopeAwareModelResolver(registry, [preset!], true);
+		expect(admitted?.("openrouter", "@preset/custom-openrouter-preset")).toBe(preset);
+		// Unfiltered scope → returned regardless of candidate set.
+		const unfiltered = createScopeAwareModelResolver(registry, [], false);
+		expect(unfiltered?.("openrouter", "@preset/custom-openrouter-preset")).toBe(preset);
+	});
+
+	test("defaults presets to text-only so a text-only routed model is not forced to accept images", () => {
+		// Presets never know the routed upstream's modality. Defaulting to
+		// image-capable would turn attachments on a text-only model into wire
+		// errors; a vision preset opts in via a per-model override on the preset
+		// id (ModelRegistry.find applies `modelOverrides` to the preset).
+		const result = resolveProviderModelReference("openrouter", "@preset/custom-openrouter-preset", allModels);
+		expect(result?.input).toEqual(["text"]);
 	});
 });


### PR DESCRIPTION
## What

Recognize `openrouter/@preset/{slug}` as a model selector (CLI, `modelRoles`, `omp bench`) and send wire id `@preset/{slug}` without appending OpenRouter routing variants (`:nitro` / `:floor` / `:online` / `:exacto`).

The selector resolves to a synthetic OpenRouter model built over the dedicated `openrouter` transport, deriving provider-level transport (`baseUrl`) from an available OpenRouter row without copying model capabilities: neutral `contextWindow`/`maxTokens`/`input`/`cost`, a canonical `@preset/{slug}` id/requestModelId, and generic reasoning-effort control. Sessions persisted as `openrouter/@preset/{slug}` restore across startup resume and in-process session switching. Prefix casing is canonicalized and variant suppression is case-insensitive (`@PRESET/free` never gets a variant suffix).

## Why

OpenRouter presets are account-side configs, not catalog `/v1/models` rows, so `openrouter/@preset/free` currently fails with `Model not found` and silently falls back in `modelRoles` ([#755](https://github.com/can1357/oh-my-pi/issues/755)).

## Testing

- `bun test packages/ai/test/openai-completions-compat.test.ts`
- `bun test packages/coding-agent/test/model-resolver.test.ts`
- Live: `bun src/cli.ts bench openrouter/@preset/free --runs 1 --profile chat --par 1 --max-tokens 16` from `packages/coding-agent`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
