### PR TITLE
Add extension-owned runtime OAuth resolvers

### DIFF
--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -34,11 +34,14 @@ export interface ApiKeyResolveContext {
 	signal?: AbortSignal;
 }
 
+/** Resolves a credential value through the bounded auth retry context. */
+export type AuthResolver<T> = (ctx: ApiKeyResolveContext) => Promise<T | undefined> | T | undefined;
+
 /**
  * Resolves the API key to send for a request, retried through the a/b/c policy
  * described on {@link ApiKeyResolveContext}.
  */
-export type ApiKeyResolver = (ctx: ApiKeyResolveContext) => Promise<string | undefined> | string | undefined;
+export type ApiKeyResolver = AuthResolver<string>;
 
 /** A static bearer string, or a {@link ApiKeyResolver} that mints/rotates one. */
 export type ApiKey = string | ApiKeyResolver;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added extension-owned runtime API-key and structured OAuth resolvers, including Codex web search support without persisting externally managed credentials.
 - Added an explicit append-only transcript declaration and width-independent stable-row API for components that can guarantee an immutable history prefix across later updates.
 - Added `:img` read selector to rasterize local SVG/SVGZ files for vision input.
 - Added side-by-side image and SVG previews to `omp git`, including local Git LFS object resolution and explicit placeholders for unavailable or unsupported binary content.

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -48,7 +48,9 @@ export function createApiKeyResolver(
 	registry: Pick<ApiKeyResolverRegistry, "getApiKeyForProvider" | "authStorage">,
 	provider: string,
 	options: ApiKeyResolverOptions = {},
+	runtimeResolver?: ApiKeyResolver,
 ): ApiKeyResolver {
+	if (runtimeResolver) return runtimeResolver;
 	const { sessionId, baseUrl, modelId } = options;
 	return async ({ lastChance, error, signal, previousKey }) => {
 		if (error === undefined) {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { ApiKeyResolver, FetchImpl, UsageProvider } from "@oh-my-pi/pi-ai";
+import type { ApiKeyResolver, AuthResolver, FetchImpl, OAuthAccess, UsageProvider } from "@oh-my-pi/pi-ai";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { registerOAuthProvider, unregisterOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
@@ -130,6 +130,9 @@ function guardrailOverrideFields(override: ProviderOverride): Partial<ModelSpec<
 	return fields;
 }
 
+/** Structured OAuth resolver registered by an extension for one provider. */
+export type RuntimeOAuthResolver = AuthResolver<OAuthAccess>;
+
 /** Result of loading custom models config. */
 interface CustomModelsResult {
 	models?: CustomModelOverlay[];
@@ -216,6 +219,8 @@ export class ModelRegistry {
 	// models registered by extensions survive the model selector's offline reload.
 	#runtimeModelOverlays: CustomModelOverlay[] = [];
 	#runtimeProviderApiKeys: Map<string, string> = new Map();
+	#runtimeProviderApiKeyResolvers: Map<string, ApiKeyResolver> = new Map();
+	#runtimeProviderOAuthResolvers: Map<string, RuntimeOAuthResolver> = new Map();
 	#runtimeProviderOverrides: Map<string, ProviderOverride> = new Map();
 	// Credential-aware model projections registered via
 	// `registerProvider({ oauth: { modifyModels } })`. Persisted for the same
@@ -1969,7 +1974,10 @@ export class ModelRegistry {
 			if (available === undefined) {
 				available =
 					!disabledProviders.has(provider) &&
-					(this.#keylessProviders.has(provider) || this.authStorage.hasAuth(provider));
+					(this.#runtimeProviderApiKeyResolvers.has(provider) ||
+						this.#runtimeProviderOAuthResolvers.has(provider) ||
+						this.#keylessProviders.has(provider) ||
+						this.authStorage.hasAuth(provider));
 				byProvider.set(provider, available);
 			}
 			return available;
@@ -2029,6 +2037,8 @@ export class ModelRegistry {
 	hasConfiguredAuth(model: Model<Api>): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(model.provider);
 		return (
+			this.#runtimeProviderApiKeyResolvers.has(model.provider) ||
+			this.#runtimeProviderOAuthResolvers.has(model.provider) ||
 			isCommandConfigValue(keyConfig) ||
 			this.#keylessProviders.has(model.provider) ||
 			this.authStorage.hasResolvableAuth(model.provider)
@@ -2145,6 +2155,11 @@ export class ModelRegistry {
 		sessionId?: string,
 		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined> {
+		const runtimeResolver = this.#runtimeProviderApiKeyResolvers.get(provider);
+		if (runtimeResolver) {
+			const error = options?.forceRefresh ? new Error("API key refresh requested") : undefined;
+			return runtimeResolver({ lastChance: false, error, signal: options?.signal });
+		}
 		const commandKey = this.#resolveCommandBackedApiKey(
 			provider,
 			options?.forceRefresh ? { forceCommandRefresh: true } : undefined,
@@ -2173,13 +2188,23 @@ export class ModelRegistry {
 	resolver(target: string | ApiKeyResolverModel, optionsOrSessionId?: ApiKeyResolverOptions | string): ApiKeyResolver {
 		const options = typeof optionsOrSessionId === "string" ? { sessionId: optionsOrSessionId } : optionsOrSessionId;
 		if (typeof target === "string") {
-			return createApiKeyResolver(this, target, options);
+			return createApiKeyResolver(this, target, options, this.#runtimeProviderApiKeyResolvers.get(target));
 		}
-		return createApiKeyResolver(this, target.provider, {
-			...options,
-			baseUrl: target.baseUrl,
-			modelId: target.id,
-		});
+		return createApiKeyResolver(
+			this,
+			target.provider,
+			{
+				...options,
+				baseUrl: target.baseUrl,
+				modelId: target.id,
+			},
+			this.#runtimeProviderApiKeyResolvers.get(target.provider),
+		);
+	}
+
+	/** Return the extension-owned structured OAuth resolver for a provider. */
+	getRuntimeOAuthResolver(provider: string): RuntimeOAuthResolver | undefined {
+		return this.#runtimeProviderOAuthResolvers.get(provider);
 	}
 
 	async #peekApiKeyForProvider(provider: string): Promise<string | undefined> {
@@ -2200,6 +2225,8 @@ export class ModelRegistry {
 
 	#clearRuntimeProviderState(providerName: string): void {
 		this.#runtimeProviderApiKeys.delete(providerName);
+		this.#runtimeProviderApiKeyResolvers.delete(providerName);
+		this.#runtimeProviderOAuthResolvers.delete(providerName);
 		this.#runtimeProviderOverrides.delete(providerName);
 		this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
 		this.#runtimeModelManagers.delete(providerName);
@@ -2287,6 +2314,7 @@ export class ModelRegistry {
 				apiKey: config.apiKey,
 				api: config.api,
 				oauthConfigured: Boolean(config.oauth),
+				resolverConfigured: Boolean(config.resolveApiKey || config.resolveOAuth),
 				models: (config.models ?? []) as ProviderValidationModel[],
 			},
 			"runtime-register",
@@ -2330,6 +2358,12 @@ export class ModelRegistry {
 			this.#reloadStaticModels();
 		}
 
+		if (config.resolveApiKey) {
+			this.#runtimeProviderApiKeyResolvers.set(providerName, config.resolveApiKey);
+		}
+		if (config.resolveOAuth) {
+			this.#runtimeProviderOAuthResolvers.set(providerName, config.resolveOAuth);
+		}
 		// Extension usage providers override built-ins/configured resolvers for the
 		// provider lifetime. #clearRuntimeProviderState removes this override when
 		// the owning extension is unregistered or replaced.
@@ -2541,6 +2575,8 @@ export class ModelRegistry {
 export interface ProviderConfigInput {
 	baseUrl?: string;
 	apiKey?: string;
+	resolveApiKey?: ApiKeyResolver;
+	resolveOAuth?: RuntimeOAuthResolver;
 	api?: Api;
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -24,6 +24,7 @@ export interface ProviderValidationConfig {
 	api?: Api;
 	auth?: ProviderAuthMode;
 	oauthConfigured?: boolean;
+	resolverConfigured?: boolean;
 	discovery?: ProviderDiscovery;
 	compat?: ModelSpec<Api>["compat"];
 	remoteCompaction?: unknown;
@@ -67,12 +68,12 @@ export function validateProviderConfiguration(
 		}
 		const requiresAuth =
 			mode === "runtime-register"
-				? !config.apiKey && !config.oauthConfigured
+				? !config.apiKey && !config.oauthConfigured && !config.resolverConfigured
 				: !config.apiKey && (config.auth ?? "apiKey") !== "none" && (config.auth ?? "apiKey") !== "oauth";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"
-					? `Provider ${providerName}: "apiKey" or "oauth" is required when defining models.`
+					? `Provider ${providerName}: "apiKey", "oauth", "resolveApiKey", or "resolveOAuth" is required when defining models.`
 					: `Provider ${providerName}: "apiKey" is required when defining custom models unless auth is "none" or "oauth".`,
 			);
 		}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -22,6 +22,7 @@ import type {
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type {
 	Api,
+	ApiKeyResolver,
 	AssistantMessageEvent,
 	AssistantMessageEventStream,
 	Context,
@@ -52,7 +53,7 @@ import type {
 } from "@oh-my-pi/pi-tui";
 import type { logger as PiLogger } from "@oh-my-pi/pi-utils";
 import type { KeybindingsManager } from "../../config/keybindings";
-import type { ModelRegistry } from "../../config/model-registry";
+import type { ModelRegistry, RuntimeOAuthResolver } from "../../config/model-registry";
 import type { EditToolDetails } from "../../edit";
 import type { PythonResult } from "../../eval/py/executor";
 import type { BashResult } from "../../exec/bash-executor";
@@ -1538,8 +1539,12 @@ export interface ExtensionAPI {
 export interface ProviderConfig {
 	/** Base URL for the API endpoint. Required when defining models. */
 	baseUrl?: string;
-	/** API key or environment variable name. Required when defining models unless oauth is provided. */
+	/** API key or environment variable name. Required when defining models unless a resolver or OAuth is provided. */
 	apiKey?: string;
+	/** Runtime bearer resolver. Takes precedence over command, config, and stored credentials. */
+	resolveApiKey?: ApiKeyResolver;
+	/** Runtime structured OAuth resolver for identity-aware transports such as Codex web search. */
+	resolveOAuth?: RuntimeOAuthResolver;
 	/** API type identifier. Required when registering streamSimple or when models don't specify one. */
 	api?: Api;
 	/** Custom streaming function for non-built-in APIs. */

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -5,6 +5,7 @@
  * the official ChatGPT backend for OAuth logins.
  */
 import {
+	type ApiKeyResolver,
 	type AuthStorage,
 	type FetchImpl,
 	type Model,
@@ -791,34 +792,64 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 			},
 		);
 	} else {
-		const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
-		if (!seed) {
-			throw new Error(
-				"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
+		const runtimeResolver = params.modelRegistry?.getRuntimeOAuthResolver("openai-codex");
+		if (runtimeResolver) {
+			let currentAccess: OAuthAccess | undefined;
+			const bearerResolver: ApiKeyResolver = async context => {
+				currentAccess = await runtimeResolver(context);
+				return currentAccess?.accessToken;
+			};
+			result = await withAuth(
+				bearerResolver,
+				accessToken => {
+					const accountId = currentAccess?.accountId ?? getCodexAccountId(accessToken);
+					if (!accountId) {
+						throw new Error("Codex OAuth credential is missing a ChatGPT account id");
+					}
+					return runCodexSearchCandidates({
+						auth: { accessToken, accountId },
+						params,
+						query,
+						modelCandidates,
+						modelWasConfigured: configuredModel !== undefined,
+						transport,
+					});
+				},
+				{
+					signal: params.signal,
+					missingKeyMessage: "Codex runtime OAuth credentials are unavailable.",
+				},
+			);
+		} else {
+			const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
+			if (!seed) {
+				throw new Error(
+					"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
+				);
+			}
+
+			result = await withOAuthAccess(
+				params.authStorage,
+				"openai-codex",
+				access => {
+					// A refreshed/rotated credential can carry a different bearer and
+					// ChatGPT account id than the seed used to select the first attempt.
+					const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
+					if (!accountId) {
+						throw new Error("Codex OAuth credential is missing a ChatGPT account id");
+					}
+					return runCodexSearchCandidates({
+						auth: { accessToken: access.accessToken, accountId },
+						params,
+						query,
+						modelCandidates,
+						modelWasConfigured: configuredModel !== undefined,
+						transport,
+					});
+				},
+				{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
 			);
 		}
-
-		result = await withOAuthAccess(
-			params.authStorage,
-			"openai-codex",
-			access => {
-				// A refreshed/rotated credential can carry a different bearer and
-				// ChatGPT account id than the seed used to select the first attempt.
-				const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
-				if (!accountId) {
-					throw new Error("Codex OAuth credential is missing a ChatGPT account id");
-				}
-				return runCodexSearchCandidates({
-					auth: { accessToken: access.accessToken, accountId },
-					params,
-					query,
-					modelCandidates,
-					modelWasConfigured: configuredModel !== undefined,
-					transport,
-				});
-			},
-			{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
-		);
 	}
 
 	let sources = result.sources;

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -10,6 +10,7 @@ import {
 	type FetchImpl,
 	getCustomApi,
 	type Model,
+	type OAuthAccess,
 } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
@@ -579,6 +580,30 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(registry.authStorage.hasAuth("runtime-provider")).toBe(true);
 
 		delete process.env.TEST_RUNTIME_KEY;
+	});
+
+	test("extension runtime resolvers own bearer and structured OAuth resolution", async () => {
+		const providerName = "openai-codex";
+		const model = registry.getAll().find(candidate => candidate.provider === providerName);
+		if (!model) throw new Error("expected bundled OpenAI Codex model");
+		const resolveApiKey = vi.fn(() => "runtime-access");
+		const oauthAccess: OAuthAccess = {
+			accessToken: "runtime-access",
+			accountId: "runtime-account",
+			email: "runtime@example.com",
+		};
+		const resolveOAuth = vi.fn(() => oauthAccess);
+
+		registry.registerProvider(providerName, { resolveApiKey, resolveOAuth }, "ext://runtime");
+
+		expect(registry.hasConfiguredAuth(model)).toBe(true);
+		expect(await registry.resolver(providerName)({ lastChance: false, error: undefined })).toBe("runtime-access");
+		expect(await registry.getRuntimeOAuthResolver(providerName)?.({ lastChance: false, error: undefined })).toEqual(
+			oauthAccess,
+		);
+
+		registry.clearSourceRegistrations("ext://runtime");
+		expect(registry.getRuntimeOAuthResolver(providerName)).toBeUndefined();
 	});
 
 	test("extension-registered custom API handler survives model refresh", async () => {

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -307,6 +307,44 @@ describe("searchCodex model selection", () => {
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
+	it("uses extension runtime OAuth for the official Codex endpoint", async () => {
+		const getOAuthAccess = vi.fn(() => {
+			throw new Error("stored OAuth must not be consulted");
+		});
+		const runtimeOAuth = vi.fn(() => ({
+			accessToken: "runtime-oauth-token",
+			accountId: "runtime-account",
+			email: "runtime@example.com",
+		}));
+		const runtimeRegistry = {
+			find() {
+				return undefined;
+			},
+			getProviderBaseUrl() {
+				return undefined;
+			},
+			getProviderHeaders() {
+				return undefined;
+			},
+			getRuntimeOAuthResolver() {
+				return runtimeOAuth;
+			},
+		} as unknown as ModelRegistry;
+
+		const result = await searchCodex({
+			...makeSearchParams("runtime OAuth search", mockCodexFetch("gpt-5.6-luna")),
+			authStorage: { getOAuthAccess } as unknown as AuthStorage,
+			modelRegistry: runtimeRegistry,
+		});
+
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("authorization")).toBe("Bearer runtime-oauth-token");
+		expect(headers.get("chatgpt-account-id")).toBe("runtime-account");
+		expect(runtimeOAuth).toHaveBeenCalledWith({ lastChance: false, error: undefined, signal: undefined });
+		expect(getOAuthAccess).not.toHaveBeenCalled();
+		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
+	});
+
 	it("applies the configured request timeout to Codex search", async () => {
 		const timeoutSignal = new AbortController().signal;
 		const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);


### PR DESCRIPTION
## ELI5
Extensions can now lend OMP a credential for the lifetime of a process without copying it into OMP's account database. Identity-aware features such as Codex web search receive the same account id and bearer as normal model requests.

> Human-authored request (verbatim): “A gente não pode fazer o plugin criar um OAuth?”

## What changed
- add generic `AuthResolver<T>` plus extension `resolveApiKey` and structured `resolveOAuth` provider hooks
- keep runtime resolvers source-scoped and remove them when an extension unloads or hands off ownership
- make resolver-only providers available during startup/model preflight
- let official Codex web search prefer runtime OAuth while preserving stored-OAuth and custom-endpoint behavior
- pass the normal bounded auth retry context through to extension-owned resolvers

## Why
Orca launches OMP with a selected Codex account in an isolated home. A runtime resolver lets an extension use that account for chat and web search without persisting or mixing externally managed accounts in OMP's SQLite credential store.

## Verification
- `bun test packages/coding-agent/test/model-registry-runtime-provider.test.ts packages/coding-agent/test/tools/web-search-codex.test.ts` — 61 pass, 0 fail
- focused `biome check` on all eight changed TypeScript files — clean
- real source CLI search with an Orca-managed runtime OAuth extension — Codex search returned an OpenAI answer and citation via `gpt-5.6-luna`
- package typechecks were attempted but exceeded the 600-second local timeout without emitting a diagnostic

## Review notes
- **Platforms:** TypeScript-only credential routing; no platform-specific filesystem behavior.
- **Local/SSH/remote:** resolver ownership follows the existing extension source lifecycle; no host assumptions added.
- **Providers:** generic hooks; only Codex web search consumes structured OAuth in this PR.
- **Performance:** one provider-keyed map lookup on auth resolution.
- **UI:** no visual change.
- **Security:** runtime credentials remain in process memory and are not persisted or logged; official-vs-custom endpoint protections remain unchanged.
