### PR TITLE
fix(coding-agent): expand truncated ask questions with Ctrl+O

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Fixed Ctrl+O (`app.tools.expand`) ignoring a truncated `ask` question: the dialog now expands the full question header in place, and the global expand listener defers to that when the ask form is focused.
 - Fixed the welcome screen staying at its original width after a terminal resize; a settled rebuild now recomposes it at the new width like the rest of the transcript.
 - Fixed `omp if-bench` ending an Anthropic model's run on a transient `Refusal (cyber)` classification; the cyber classifier is stochastic near the threshold, so a refused turn is now retried with a fresh session (up to 3 attempts) before it is scored as a run-ending provider failure.
 - Fixed streamed assistant responses crashing when a later provider delta revised earlier Markdown; assistant output now stays mutable until finalization.

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -22,9 +22,11 @@ import type {
 	ExtensionAskDialogResultItem,
 	ExtensionAskDialogSubmitResult,
 } from "../../extensibility/extensions";
+import { expandKeyHint } from "../../tools/render-utils";
 import { getTabBarTheme } from "../shared";
 import { getMarkdownTheme, highlightCode, theme } from "../theme/theme";
 import {
+	matchesAppToolsExpand,
 	matchesSelectCancel,
 	matchesSelectDown,
 	matchesSelectPageDown,
@@ -142,14 +144,18 @@ function questionTabLabel(question: ExtensionAskDialogQuestion, index: number): 
 	return truncateToWidth(replaceTabs(base), MAX_HEADER_CHIP_WIDTH, Ellipsis.Unicode);
 }
 
-function renderQuestionTitle(question: ExtensionAskDialogQuestion, width: number): string[] {
+function wrapQuestionTitle(question: ExtensionAskDialogQuestion, width: number): string[] {
 	const mdTheme = getMarkdownTheme();
 	const questionText = renderInlineMarkdown(replaceTabs(question.question), mdTheme, t => theme.fg("text", t));
-	const wrapped = wrapTextWithAnsi(questionText, Math.max(1, width));
-	if (wrapped.length <= MAX_HEADER_ROWS) return wrapped;
+	return wrapTextWithAnsi(questionText, Math.max(1, width));
+}
+
+function renderQuestionTitle(question: ExtensionAskDialogQuestion, width: number, maxRows = MAX_HEADER_ROWS): string[] {
+	const wrapped = wrapQuestionTitle(question, width);
+	if (wrapped.length <= maxRows) return wrapped;
 	return [
-		...wrapped.slice(0, MAX_HEADER_ROWS - 1),
-		truncateToWidth(wrapped.slice(MAX_HEADER_ROWS - 1).join(" "), Math.max(1, width), Ellipsis.Unicode),
+		...wrapped.slice(0, maxRows - 1),
+		truncateToWidth(wrapped.slice(maxRows - 1).join(" "), Math.max(1, width), Ellipsis.Unicode),
 	];
 }
 
@@ -399,6 +405,9 @@ export class AskDialogComponent implements Component {
 	#stableHeight: { key: string; total: number } | undefined;
 	#previewCache: PreviewRenderCache = new Map();
 	#overflowLayouts = new WeakMap<ExtensionAskDialogQuestion, Set<string>>();
+	#expanded = false;
+	#contentWidth = 76;
+	#headerExpandable = false;
 	readonly #questions: ExtensionAskDialogQuestion[];
 
 	constructor(
@@ -445,6 +454,22 @@ export class AskDialogComponent implements Component {
 		this.#countdown?.dispose();
 	}
 
+	/**
+	 * Toggle a truncated question header. Returns false when there is nothing
+	 * to expand so the global Ctrl+O listener can still expand transcript tools.
+	 */
+	toggleQuestionExpansion(): boolean {
+		if (this.#closed) return false;
+		const question = this.#questions[this.#currentQuestionIndex()];
+		if (!question) return false;
+		const overflows = wrapQuestionTitle(question, this.#contentWidth).length > MAX_HEADER_ROWS;
+		if (!overflows && !this.#expanded) return false;
+		this.#expanded = !this.#expanded;
+		this.invalidate();
+		this.#requestRender();
+		return true;
+	}
+
 	handleInput(keyData: string): void {
 		if (this.#closed || this.#promptActive) return;
 		// Reset the inactivity countdown on any key that reaches past the
@@ -452,6 +477,12 @@ export class AskDialogComponent implements Component {
 		this.#countdown?.reset();
 		if (matchesSelectCancel(keyData)) {
 			this.#finishCancel();
+			return;
+		}
+		// Expand before the draft-input guard so Ctrl+O can reveal a truncated
+		// question even while a pending prompt still owns typing.
+		if (matchesAppToolsExpand(keyData)) {
+			this.toggleQuestionExpansion();
 			return;
 		}
 		const inputGuard = this.options.inputGuard;
@@ -477,10 +508,12 @@ export class AskDialogComponent implements Component {
 		// same frame).
 		this.options.inputGuard?.syncPresentation?.();
 		const innerWidth = Math.max(1, width - 4);
+		this.#contentWidth = innerWidth;
 		// Fixed panel height: measured from the tallest tab at spawn and
 		// re-measured only when the viewport changes. Tab switches, cursor
 		// moves, and later answers never resize the box; content that
-		// outgrows it scrolls.
+		// outgrows it scrolls. Expanding a truncated question is an explicit
+		// user gesture and may grow the box within the existing height cap.
 		const totalRows = this.#dialogHeight(innerWidth, process.stdout.rows || 40);
 		const headerLines = this.#renderHeader(innerWidth);
 		// topBorder(1) + header(N) + divider(1) + divider(1) + footer(1) +
@@ -506,7 +539,7 @@ export class AskDialogComponent implements Component {
 	}
 
 	#dialogHeight(width: number, termRows: number): number {
-		const key = `${width}:${termRows}`;
+		const key = `${width}:${termRows}:${this.#expanded ? 1 : 0}`;
 		if (this.#stableHeight?.key === key) return this.#stableHeight.total;
 		const total = this.#measureHeight(width, termRows);
 		this.#stableHeight = { key, total };
@@ -527,7 +560,8 @@ export class AskDialogComponent implements Component {
 			const question = this.#questions[index];
 			const state = this.#states[index];
 			if (!question || !state) continue;
-			const headerRows = tabBarRows + renderQuestionTitle(question, width).length;
+			const titleRows = this.#expanded ? Number.POSITIVE_INFINITY : MAX_HEADER_ROWS;
+			const headerRows = tabBarRows + renderQuestionTitle(question, width, titleRows).length;
 			const rowItems = this.#questionRows(question);
 			const listRows = (listWidth: number): number => {
 				let total = 0;
@@ -590,20 +624,32 @@ export class AskDialogComponent implements Component {
 			lines.push(...this.#tabBar.render(width));
 		}
 		if (this.#isSubmitTab()) {
+			this.#headerExpandable = false;
 			lines.push(theme.bold(theme.fg("accent", "Review answers")));
 			return lines;
 		}
 		const questionIndex = this.#currentQuestionIndex();
 		const question = this.#questions[questionIndex];
-		if (!question) return lines;
-		lines.push(...renderQuestionTitle(question, width));
+		if (!question) {
+			this.#headerExpandable = false;
+			return lines;
+		}
+		const wrapped = wrapQuestionTitle(question, width);
+		this.#headerExpandable = wrapped.length > MAX_HEADER_ROWS;
+		const maxRows = this.#expanded ? wrapped.length : MAX_HEADER_ROWS;
+		lines.push(...renderQuestionTitle(question, width, maxRows));
 		return lines;
+	}
+
+	#expandHint(): string {
+		if (!this.#headerExpandable) return "";
+		return ` · ${expandKeyHint()} ${this.#expanded ? "collapse" : "expand"}`;
 	}
 
 	#footerHintText(indicator: string): string {
 		const cancel = `${cancelKeyLabel()} cancel`;
 		const inputGuard = this.options.inputGuard;
-		if (inputGuard?.isBlocked()) return `${inputGuard.hint} · ${cancel}`;
+		if (inputGuard?.isBlocked()) return `${inputGuard.hint}${this.#expandHint()} · ${cancel}`;
 		if (this.#isSubmitTab()) {
 			const scroll = indicator ? ` ${indicator} scroll ·` : "";
 			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
@@ -613,11 +659,12 @@ export class AskDialogComponent implements Component {
 		const enterAction = this.#questions.length > 1 ? "next" : "submit";
 		const action = question?.multi ? `Space toggle · Enter ${enterAction}` : "Enter select · n note";
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
+		const expand = this.#expandHint();
 		if (this.#questionCanPage && indicator) {
-			return `${action} · ↑/↓${tabs} · ${cancel} · ${pageKeysLabel()} ${indicator}`;
+			return `${action} · ↑/↓${tabs} · ${cancel}${expand} · ${pageKeysLabel()} ${indicator}`;
 		}
 		const scroll = indicator ? ` ${indicator} scroll ·` : "";
-		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}`;
+		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}${expand}`;
 	}
 
 	#questionRows(question: ExtensionAskDialogQuestion): QuestionRow[] {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -5,6 +5,7 @@ import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@oh-my
 import { isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveLocalRoot } from "../../internal-urls";
+import { AskDialogComponent } from "../../modes/components/ask-dialog";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import { extractImagePathFromText } from "../../modes/components/custom-editor";
 import { ReadToolGroupComponent } from "../../modes/components/read-tool-group";
@@ -311,6 +312,13 @@ export class InputController {
 				if (this.ctx.ui.hasOverlay()) return undefined;
 				if (this.ctx.ui.getFocused() instanceof TreeSelectorComponent && matchesKey(data, "ctrl+o"))
 					return undefined;
+				const focused = this.ctx.ui.getFocused();
+				// A truncated ask question lives in the editor slot, not chat
+				// transcript, so expand it in-place instead of (or before)
+				// toggling tool-output previews.
+				if (focused instanceof AskDialogComponent && focused.toggleQuestionExpansion()) {
+					return { consume: true };
+				}
 				this.toggleToolOutputExpansion();
 				return { consume: true };
 			});

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { AskDialogComponent } from "@oh-my-pi/pi-coding-agent/modes/components/ask-dialog";
 import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -768,5 +769,43 @@ describe("InputController global tool-output expand (ctrl+o)", () => {
 
 		expect(dispatchInput(listeners, "\x18")).toEqual({ consume: true });
 		expect(context.ctx.toolOutputExpanded).toBe(true);
+	});
+
+	it("expands a truncated ask question instead of tool output when the ask dialog is focused", async () => {
+		const { ctx, listeners, setFocused } = await setup();
+		const dialog = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "This is a very long question ".repeat(30),
+					options: [{ label: "Option A" }, { label: "Option B" }],
+				},
+			],
+			{ onSubmit: () => {}, onCancel: () => {}, onPrompt: async () => undefined },
+		);
+		const collapsed = dialog.render(80).join("\n");
+		setFocused(dialog);
+
+		expect(dispatchInput(listeners, "\x0f")).toEqual({ consume: true });
+		expect(ctx.toolOutputExpanded).toBe(false);
+		const expanded = dialog.render(80).join("\n");
+		const collapsedCount = collapsed.match(/This is a very long question/g)?.length ?? 0;
+		const expandedCount = expanded.match(/This is a very long question/g)?.length ?? 0;
+		expect(collapsedCount).toBeLessThan(10);
+		expect(expandedCount).toBeGreaterThan(collapsedCount);
+	});
+
+	it("still expands tool output when a short ask question has nothing to reveal", async () => {
+		const { ctx, listeners, setFocused } = await setup();
+		const dialog = new AskDialogComponent([{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }] }], {
+			onSubmit: () => {},
+			onCancel: () => {},
+			onPrompt: async () => undefined,
+		});
+		dialog.render(80);
+		setFocused(dialog);
+
+		expect(dispatchInput(listeners, "\x0f")).toEqual({ consume: true });
+		expect(ctx.toolOutputExpanded).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1349,6 +1349,56 @@ describe("AskDialogComponent", () => {
 		// Count occurrences of the repeated phrase — should be far fewer than 30.
 		const matches = output.match(/This is a very long question/g);
 		expect(matches?.length ?? 0).toBeLessThan(10);
+		expect(output).toContain("Ctrl+O expand");
+	});
+
+	it("expands a truncated question header on Ctrl+O and collapses on a second press", () => {
+		const longQuestion = "This is a very long question ".repeat(30);
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: longQuestion,
+					options: [{ label: "Option A" }, { label: "Option B" }],
+				},
+			],
+			{
+				onSubmit: vi.fn(),
+				onCancel: vi.fn(),
+				onPrompt: vi.fn(),
+			},
+		);
+
+		const collapsed = render(component);
+		const collapsedCount = collapsed.match(/This is a very long question/g)?.length ?? 0;
+		expect(collapsedCount).toBeLessThan(10);
+		expect(collapsed).toContain("Ctrl+O expand");
+
+		component.handleInput("\x0f");
+		const expanded = render(component);
+		const expandedCount = expanded.match(/This is a very long question/g)?.length ?? 0;
+		expect(expandedCount).toBeGreaterThan(collapsedCount);
+		// Wrapping can split a few phrases across lines; require a clearly
+		// larger header rather than an exact copy count.
+		expect(expandedCount).toBeGreaterThanOrEqual(15);
+		expect(expanded).toContain("Ctrl+O collapse");
+		expect(expanded).not.toContain("Ctrl+O expand");
+
+		component.handleInput("\x0f");
+		const recollapsed = render(component);
+		expect(recollapsed.match(/This is a very long question/g)?.length ?? 0).toBe(collapsedCount);
+		expect(recollapsed).toContain("Ctrl+O expand");
+	});
+
+	it("leaves a short question unchanged and does not advertise expand", () => {
+		const component = new AskDialogComponent(
+			[{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }] }],
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+		);
+		const before = render(component);
+		expect(before).not.toContain("Ctrl+O expand");
+		expect(component.toggleQuestionExpansion()).toBe(false);
+		expect(render(component)).toBe(before);
 	});
 
 	it("wraps long option labels onto indented continuation lines instead of truncating", () => {


### PR DESCRIPTION
I reviewed the full diff; Ctrl+O (`app.tools.expand`) was bound globally to transcript tool-output expansion, so it never revealed a truncated `ask` question sitting in the editor slot.

The ask dialog caps the question header at 4 wrapped lines. Pressing Ctrl+O while that form is focused now expands (and collapses) the full question in place, with a footer hint. If the current question is not truncated, the global listener still expands tool cards as before.

## Verification
- Reproduced the existing behavior in tests: a long `ask` question renders with far fewer than 30 copies of the prompt and no expand handling, while a focused dialog's Ctrl+O previously only flipped `toolOutputExpanded`.
- After the change, `AskDialogComponent` expands/collapses on `\x0f`, advertises `Ctrl+O expand` / `Ctrl+O collapse`, and `toggleQuestionExpansion()` returns `false` for a short question.
- The input-controller listener expands the focused long question without toggling tool output, and still expands tool output when the focused question has nothing to reveal.
- `bun --cwd=packages/coding-agent test test/modes/components/ask-dialog.test.ts test/input-controller-keybindings.test.ts` — 77 pass
- `bun --cwd=packages/coding-agent run check` — biome + types pass