### PR TITLE
fix(ai): strip ArkType optional markers from JSON Schema property keys

### DIFF
--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -37,10 +37,18 @@ function isArkJsonAst(value: unknown): boolean {
 	);
 }
 
-function parseArkObjectKey(key: string): { name: string; description?: string } {
+function parseArkObjectKey(key: string): { name: string; description?: string; optional?: boolean } {
 	const match = /^(.*?)\s*\/\*\*\s*([\s\S]*?)\s*\*\/\s*$/.exec(key);
-	if (!match) return { name: key };
-	return { name: match[1].trim(), description: match[2].trim() };
+	const withComment = match ? { name: match[1].trim(), description: match[2].trim() } : { name: key };
+	// A trailing `?` is ArkType's optional marker, not part of the property name.
+	// A live ArkType Type loses it in `toJsonSchema()`, but a definition that has
+	// been serialized and restored arrives as a plain object whose keys still
+	// carry it, and it then reaches the wire verbatim. Anthropic rejects any
+	// property key outside /^[a-zA-Z0-9_.-]{1,64}$/, so the whole request 400s.
+	if (withComment.name.endsWith("?") && withComment.name.length > 1) {
+		return { ...withComment, name: withComment.name.slice(0, -1), optional: true };
+	}
+	return withComment;
 }
 
 function withArkKeyDescription(schema: unknown, description: string | undefined): unknown {
@@ -275,8 +283,19 @@ function normalizeArkPropertyComments(node: unknown): void {
 			let propertySchema = properties[key];
 			if (parsed.description) {
 				propertySchema = withArkKeyDescription(propertySchema, parsed.description);
+			}
+			// Rename whenever the parsed name differs, not only when a comment was
+			// found. An optional marker changes the name with no description present,
+			// and the previous condition let that key through unrenamed.
+			if (targetKey !== key) {
 				delete properties[key];
 				properties[targetKey] = propertySchema;
+			}
+			// An ArkType optional is by definition not required. Mapping the marker
+			// off the name without this would promote `cwd?` to a required `cwd`.
+			if (parsed.optional && Array.isArray(obj.required)) {
+				obj.required = (obj.required as unknown[]).filter(name => name !== targetKey);
+				if ((obj.required as unknown[]).length === 0) delete obj.required;
 			}
 			normalizeArkPropertyComments(propertySchema);
 		}

--- a/packages/ai/test/tool-wire-schema-arktype-optional-keys.test.ts
+++ b/packages/ai/test/tool-wire-schema-arktype-optional-keys.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
+import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema/wire";
+
+/**
+ * A tool whose `parameters` survived a serialization round-trip: the live
+ * ArkType Type is gone and only a plain JSON Schema object remains, its keys
+ * still carrying ArkType's `?` optional marker.
+ *
+ * `toolWireSchema` short-circuits a live ArkType Type through `toJsonSchema()`,
+ * which drops the marker, so this shape is the one that reached the wire intact
+ * and made Anthropic reject the whole request:
+ *
+ *   400 tools.4.custom.input_schema.properties:
+ *       Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
+ */
+const ANTHROPIC_PROPERTY_KEY = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+function wire(parameters: unknown): Record<string, unknown> {
+	return toolWireSchema({ name: "_bash", description: "run a command", parameters } as unknown as Tool);
+}
+
+function propertyKeys(schema: Record<string, unknown>): string[] {
+	return Object.keys((schema.properties ?? {}) as Record<string, unknown>);
+}
+
+describe("toolWireSchema: ArkType optional markers in plain JSON Schema keys", () => {
+	test("strips the marker so every key satisfies Anthropic's property-key pattern", () => {
+		const schema = wire({
+			type: "object",
+			properties: {
+				command: { type: "string", description: "command to execute" },
+				"env?": { type: "object" },
+				"timeout?": { type: "number" },
+				"cwd?": { type: "string", description: "working directory" },
+				"pty?": { type: "boolean" },
+			},
+			required: ["command"],
+		});
+
+		expect(propertyKeys(schema)).toEqual(["command", "env", "timeout", "cwd", "pty"]);
+		for (const key of propertyKeys(schema)) expect(key).toMatch(ANTHROPIC_PROPERTY_KEY);
+		expect(schema.required).toEqual(["command"]);
+	});
+
+	test("an optional key listed in required is not promoted to required", () => {
+		// Dropping the marker off the name without this would turn `cwd?` into a
+		// required `cwd`, quietly changing the tool's contract.
+		const schema = wire({
+			type: "object",
+			properties: { "cwd?": { type: "string" } },
+			required: ["cwd?"],
+		});
+
+		expect(propertyKeys(schema)).toEqual(["cwd"]);
+		expect(schema.required).toBeUndefined();
+	});
+
+	test("normalizes nested objects and $defs, not just the root", () => {
+		const schema = wire({
+			type: "object",
+			properties: { outer: { type: "object", properties: { "inner?": { type: "string" } } } },
+			$defs: { A: { type: "object", properties: { "x?": { type: "string" } } } },
+		});
+
+		const outer = (schema.properties as Record<string, Record<string, unknown>>).outer;
+		expect(Object.keys((outer.properties ?? {}) as Record<string, unknown>)).toEqual(["inner"]);
+		const defs = (schema.$defs ?? {}) as Record<string, Record<string, unknown>>;
+		expect(Object.keys((defs.A.properties ?? {}) as Record<string, unknown>)).toEqual(["x"]);
+	});
+
+	test("a key that is only a question mark is left alone", () => {
+		// Not an ArkType optional - there is no name in front of the marker, so
+		// stripping it would invent an empty property name.
+		const schema = wire({ type: "object", properties: { "?": { type: "string" } } });
+		expect(propertyKeys(schema)).toEqual(["?"]);
+	});
+
+	test("a schema with nothing to normalize is unchanged", () => {
+		const schema = wire({
+			type: "object",
+			properties: { command: { type: "string" } },
+			required: ["command"],
+		});
+		expect(propertyKeys(schema)).toEqual(["command"]);
+		expect(schema.required).toEqual(["command"]);
+	});
+});


### PR DESCRIPTION
Fixes #9730.

`toolWireSchema` lets ArkType's `?` optional marker through to the wire when a tool's `parameters` arrive as a plain JSON Schema object, so Anthropic rejects the whole request:

```
400 tools.4.custom.input_schema.properties:
    Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
```

## Why only sometimes

`toolWireSchema` has three paths and only the third leaks:

| `tool.parameters` | path | marker |
|---|---|---|
| live ArkType `Type` | `arkToWireSchema` -> `toJsonSchema()` | dropped |
| serialized ArkType AST | `arkJsonAstToWire` | never present, `required`/`optional` are separate arrays |
| plain JSON Schema object | passthrough | **survives** |

A definition that has been serialized and restored is a plain object whose keys still read `"cwd?"`. `parseArkObjectKey` strips a trailing `/** comment */` but not the marker, and `normalizeArkPropertyComments` only renamed a property when it had found a comment - so a key carrying a marker and no comment was left alone. Nothing downstream catches it either: the Anthropic sanitizer in `providers/anthropic.ts` filters schema *keywords*, not property *names*.

That is also why it is intermittent rather than constant, which is what made it hard to spot.

## Change

- `parseArkObjectKey` strips a trailing `?` and reports `optional`. Guarded on length so a key that is only `"?"` keeps its name instead of becoming empty.
- `normalizeArkPropertyComments` renames whenever the parsed name differs, not only when a comment was found.
- An optional key is removed from `required`. Without this, dropping the marker promotes `cwd?` to a required `cwd` and quietly changes the tool's contract.

## Tests

`packages/ai/test/tool-wire-schema-arktype-optional-keys.test.ts`, five cases: the reported `_bash` shape, the required-promotion trap, nested objects and `$defs`, the bare-`?` guard, and a schema with nothing to normalize.

Before:

```
property keys: ["command","cwd?","pty?","timeout?"]
```

After:

```
property keys: ["command","cwd","pty","timeout"]
```
