### PR TITLE
fix(git-tui): strip carriage returns from CRLF worktree diff lines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp git` rendering corruption (misalignment, missing elements, flicker) for unstaged files with CRLF line endings on Windows ([#9734](https://github.com/can1357/oh-my-pi/issues/9734)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/cli/git-tui/diff-pane.ts
+++ b/packages/coding-agent/src/cli/git-tui/diff-pane.ts
@@ -16,7 +16,7 @@
 import type { DiffStreamResult, HighlightStream } from "@oh-my-pi/pi-natives";
 import { diffWords, structuredPatchHunks } from "@oh-my-pi/pi-natives";
 import { Image, type ImageBudget, replaceTabs, sliceWithWidth, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
-import { formatBytes } from "@oh-my-pi/pi-utils";
+import { formatBytes, sanitizeText } from "@oh-my-pi/pi-utils";
 import { createHighlightStream, getLanguageFromPath, theme } from "../../modes/theme/theme";
 import { bgAnsi, canvasHex, fgAnsi, mixHex, pill, selectionBgAnsi, textHex, withBg } from "./colors";
 import { DIFF_CONTEXT_LINES, type FileAssetSide, type FileStreamUpdate } from "./state";
@@ -87,6 +87,18 @@ export type HunkAction = "stage" | "unstage" | "discard";
 const HIGHLIGHT_BATCH_LINES = 32;
 /** Cap on intraline word-diff pairs per document. */
 const INTRALINE_PAIR_LIMIT = 1_500;
+
+/**
+ * Turn one raw source line into a terminal-safe display string: strip C0/C1
+ * control bytes (via {@link sanitizeText}) then expand tabs. Windows worktree
+ * files use CRLF, so lines split on `\n` retain a trailing `\r`; emitting that
+ * raw carriage return snaps the cursor to column 0 mid-row and corrupts the
+ * render (issue #9734). The line has no `\n` (already split), so nothing else
+ * is affected.
+ */
+function displayLine(line: string): string {
+	return replaceTabs(sanitizeText(line));
+}
 
 function intralineMarks(oldLine: string, newLine: string): { old: MarkRanges; new: MarkRanges } {
 	const oldRanges: [number, number][] = [];
@@ -195,8 +207,8 @@ export function buildDiffDocument(
 		ignoreFormatting && dot >= 0 ? (IMPORT_LANG_BY_EXT[filePath.slice(dot + 1).toLowerCase()] ?? null) : null;
 	const oldLines = oldRaw.length === 0 ? [] : oldRaw.replace(/\n$/, "").split("\n");
 	const newLines = newRaw.length === 0 ? [] : newRaw.replace(/\n$/, "").split("\n");
-	const oldPlain = oldLines.map(replaceTabs);
-	const newPlain = newLines.map(replaceTabs);
+	const oldPlain = oldLines.map(displayLine);
+	const newPlain = newLines.map(displayLine);
 
 	// Alignment basis: raw lines, or trimmed lines when ignoring whitespace.
 	// Line numbers stay 1:1 with the raw text either way.
@@ -635,18 +647,12 @@ export class DiffPane {
 	updateStream(update: FileStreamUpdate): void {
 		const streaming = this.#streaming;
 		if (!streaming) return;
-		streaming.oldLines.splice(
-			update.oldLineOffset,
-			streaming.oldLines.length - update.oldLineOffset,
-			...update.oldLines,
-		);
-		streaming.newLines.splice(
-			update.newLineOffset,
-			streaming.newLines.length - update.newLineOffset,
-			...update.newLines,
-		);
-		for (const line of update.oldLines) streaming.maxLineWidth = Math.max(streaming.maxLineWidth, line.length);
-		for (const line of update.newLines) streaming.maxLineWidth = Math.max(streaming.maxLineWidth, line.length);
+		const oldLines = update.oldLines.map(displayLine);
+		const newLines = update.newLines.map(displayLine);
+		streaming.oldLines.splice(update.oldLineOffset, streaming.oldLines.length - update.oldLineOffset, ...oldLines);
+		streaming.newLines.splice(update.newLineOffset, streaming.newLines.length - update.newLineOffset, ...newLines);
+		for (const line of oldLines) streaming.maxLineWidth = Math.max(streaming.maxLineWidth, line.length);
+		for (const line of newLines) streaming.maxLineWidth = Math.max(streaming.maxLineWidth, line.length);
 		streaming.stableCommonLines = update.progress.stableCommonLines;
 		this.#clampScroll();
 	}

--- a/packages/coding-agent/test/git-tui-stream.test.ts
+++ b/packages/coding-agent/test/git-tui-stream.test.ts
@@ -92,6 +92,28 @@ describe("git TUI streamed document", () => {
 		const synchronous = buildDiffDocument(oldText, newText, "fixture.ts");
 		expect(streamed).toEqual(synchronous);
 	});
+
+	// #9734: unstaged files on Windows diff the CRLF worktree side against the
+	// LF index side. Raw carriage returns in display lines snap the terminal
+	// cursor to column 0 mid-row, corrupting the render. Both the built
+	// document and every rendered row must be free of C0 control bytes.
+	test("strips carriage returns from a CRLF worktree side", async () => {
+		const oldText = "line one\nline two\nline three\n"; // index side (LF)
+		const newText = "line one\r\nline two changed\r\nline three\r\n"; // worktree side (CRLF)
+		const doc = buildDiffDocument(oldText, newText, "fixture.ts");
+		expect(doc.newDisplayLines.some(line => line.includes("\r"))).toBe(false);
+		expect(doc.newDisplayLines).toContain("line two changed");
+
+		const pane = new DiffPane();
+		pane.setDocument(doc, "ready");
+		const control = /[\x00-\x08\x0b-\x1f\x7f]/;
+		for (const mode of ["split", "inline", "file", "hunk"] as const) {
+			pane.setMode(mode);
+			for (const row of pane.render(80, 20)) {
+				expect(control.test(row.replace(/\x1b\[[0-9;]*m/g, ""))).toBe(false);
+			}
+		}
+	});
 });
 describe("git TUI asset previews", () => {
 	test("renders raster Git objects as media instead of binary placeholders", async () => {


### PR DESCRIPTION
## Repro
On Windows the working tree uses CRLF while the git index stores LF, so `omp git` diffs a CRLF side against an LF side for **unstaged** files. The diff pane emitted the raw carriage returns into terminal output, which snapped the cursor to column 0 mid-row and corrupted the render — misalignment, missing elements, and flicker (only ever for uncommitted changes; staged/commit diffs read both sides from git as LF). Reproduced without Windows:

```
old = "line one\nline two\nline three\n"          # index side (LF)
new = "line one\r\nline two changed\r\nline three\r\n"  # worktree side (CRLF)
buildDiffDocument(old, new, "fixture.ts") -> DiffPane.render(80, 20)
```

Before the fix, `newDisplayLines` retained the trailing `\r` and 3 rendered rows contained a raw carriage return embedded mid-line.

## Cause
`packages/coding-agent/src/cli/git-tui/diff-pane.ts` built display lines with `replaceTabs` only (`oldPlain`/`newPlain` in `buildDiffDocument`, plus the streaming preview lines in `DiffPane.updateStream`). `replaceTabs` expands tabs but leaves carriage returns and other C0 control bytes intact, so raw `\r` from the CRLF worktree side flowed through to the TUI, which writes component-rendered lines verbatim (`tui.ts#lineRewriteSequence` performs no control-char stripping).

## Fix
- Add a `displayLine` helper that runs each raw source line through the central `sanitizeText` (strips C0/C1 control bytes, notably CR) then `replaceTabs` for tab expansion.
- Route `buildDiffDocument`'s `oldPlain`/`newPlain` through it — this covers the plain document render and syntax-highlight paths, which derive from `oldDisplayLines`/`newDisplayLines`.
- Route `DiffPane.updateStream`'s incoming `oldLines`/`newLines` through it so the streaming preview is sanitized too.
- Raw lines used for patch construction (`git apply`) are left untouched.

## Verification
`bun test test/git-tui-stream.test.ts -t "carriage returns"` — new regression test passes (asserts no C0 control byte survives in the built document or in any rendered row across split/inline/file/hunk modes). `bun check` passes. The 10 unrelated `new DiffStream` failures in that file are pre-existing on `main` (native binding unavailable in this environment) and are not touched by this diff. Fixes #9734