### PR TITLE
fix(session): handled missing usage in session stats

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed imported and legacy sessions with missing assistant usage metadata dropping RPC lifecycle events ([#9743](https://github.com/can1357/oh-my-pi/issues/9743)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -99,14 +99,17 @@ export class SessionStatsTracker {
 			if (message.role === "assistant") {
 				const assistant = message;
 				toolCalls += assistant.content.filter(content => content.type === "toolCall").length;
-				totalInput += assistant.usage.input;
-				totalOutput += assistant.usage.output;
-				totalReasoning += assistant.usage.reasoningTokens ?? 0;
-				totalCacheRead += assistant.usage.cacheRead;
-				totalCacheWrite += assistant.usage.cacheWrite;
-				totalTokens += assistant.usage.totalTokens;
-				totalPremiumRequests += assistant.usage.premiumRequests ?? 0;
-				totalCost += assistant.usage.cost.total;
+				// Persisted and imported transcripts can predate usage metadata despite the current message type.
+				const usage = assistant.usage;
+				if (!usage) continue;
+				totalInput += usage.input;
+				totalOutput += usage.output;
+				totalReasoning += usage.reasoningTokens ?? 0;
+				totalCacheRead += usage.cacheRead;
+				totalCacheWrite += usage.cacheWrite;
+				totalTokens += usage.totalTokens;
+				totalPremiumRequests += usage.premiumRequests ?? 0;
+				totalCost += usage.cost.total;
 			}
 			if (message.role === "toolResult" && message.toolName === "task") {
 				const usage = taskToolUsage(message.details);

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -6,6 +6,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentSession session stats", () => {
 	let authStorage: AuthStorage;
@@ -85,6 +86,91 @@ describe("AgentSession session stats", () => {
 			percent: (120_000 / model.contextWindow) * 100,
 		});
 		expect(stats.contextUsage).toEqual(directUsage);
+	});
+
+	it("treats persisted assistant messages without usage as zero-cost history", async () => {
+		const model = modelRegistry.getAll().find(candidate => candidate.contextWindow && candidate.contextWindow > 0);
+		if (!model) {
+			throw new Error("Expected bundled model with a context window");
+		}
+
+		using tempDir = TempDir.createSync("@omp-session-stats-");
+		const sessionFile = `${tempDir.path()}/repro.jsonl`;
+		await Bun.write(
+			sessionFile,
+			[
+				{
+					type: "session",
+					version: 3,
+					id: "00000000-0000-4000-8000-000000000001",
+					timestamp: "2026-01-01T00:00:00.000Z",
+					cwd: tempDir.path(),
+				},
+				{
+					type: "message",
+					id: "u1",
+					parentId: null,
+					timestamp: "2026-01-01T00:00:01.000Z",
+					message: { role: "user", content: "Initial question", timestamp: 1 },
+				},
+				{
+					type: "message",
+					id: "a1",
+					parentId: "u1",
+					timestamp: "2026-01-01T00:00:02.000Z",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "Prior answer" }],
+						timestamp: 2,
+					},
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n"),
+		);
+		const sessionManager = await SessionManager.open(sessionFile, undefined, undefined, {
+			initialCwd: tempDir.path(),
+			suppressBreadcrumb: true,
+		});
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: sessionManager.buildSessionContext().messages,
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		const stats = session.getSessionStats();
+
+		expect(stats.assistantMessages).toBe(1);
+		expect(stats.tokens).toEqual({
+			input: 0,
+			output: 0,
+			reasoning: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		});
+		expect(stats.cost).toBe(0);
+
+		const lifecycleEvents: string[] = [];
+		const agentEnd = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "turn_start" || event.type === "agent_end") lifecycleEvents.push(event.type);
+			if (event.type === "agent_end") agentEnd.resolve();
+		});
+		agent.emitExternalEvent({ type: "turn_start" });
+		agent.emitExternalEvent({ type: "agent_end", messages: [] });
+		await agentEnd.promise;
+
+		expect(lifecycleEvents).toEqual(["turn_start", "agent_end"]);
 	});
 
 	it("reconstructs persisted and active tool-loop context when provider prompt usage is unavailable", async () => {


### PR DESCRIPTION
## Repro

A v3 session JSONL containing an assistant message without `usage` was loaded through `SessionManager`, then exercised with `bun test packages/coding-agent/test/agent-session-stats.test.ts --timeout 20000`. Before the fix, the focused test exited 1 with `TypeError: undefined is not an object (evaluating 'assistant.usage.input')` from `SessionStatsTracker.getSessionStats()`.

## Cause

`packages/coding-agent/src/session/session-stats.ts` counted every assistant message but unconditionally dereferenced `assistant.usage`. Persisted and imported transcripts can lack that metadata at runtime even though the current `AssistantMessage` type requires it, so the `turn_start` and `agent_end` handlers rejected before emitting their public lifecycle events.

## Fix

- Count assistant messages and tool calls independently of usage metadata.
- Skip token and cost aggregation when an assistant record has no usage.
- Cover a persisted v3 transcript without usage and assert both zero-valued stats and emitted `turn_start`/`agent_end` events.
- Document the user-facing fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/agent-session-stats.test.ts --timeout 20000` passes 3 tests with 0 failures. `bun run check` in `packages/coding-agent` passes Biome and `tsgo`; the pre-publish `bun check` gate also passed.

Fixes #9743