### PR TITLE
fix(coding-agent): guard assistant message usage in getSessionStats

### DIFF
--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -99,14 +99,16 @@ export class SessionStatsTracker {
 			if (message.role === "assistant") {
 				const assistant = message;
 				toolCalls += assistant.content.filter(content => content.type === "toolCall").length;
-				totalInput += assistant.usage.input;
-				totalOutput += assistant.usage.output;
-				totalReasoning += assistant.usage.reasoningTokens ?? 0;
-				totalCacheRead += assistant.usage.cacheRead;
-				totalCacheWrite += assistant.usage.cacheWrite;
-				totalTokens += assistant.usage.totalTokens;
-				totalPremiumRequests += assistant.usage.premiumRequests ?? 0;
-				totalCost += assistant.usage.cost.total;
+				if (assistant.usage) {
+					totalInput += assistant.usage.input;
+					totalOutput += assistant.usage.output;
+					totalReasoning += assistant.usage.reasoningTokens ?? 0;
+					totalCacheRead += assistant.usage.cacheRead;
+					totalCacheWrite += assistant.usage.cacheWrite;
+					totalTokens += assistant.usage.totalTokens;
+					totalPremiumRequests += assistant.usage.premiumRequests ?? 0;
+					totalCost += assistant.usage.cost.total;
+				}
 			}
 			if (message.role === "toolResult" && message.toolName === "task") {
 				const usage = taskToolUsage(message.details);

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -177,4 +177,49 @@ describe("AgentSession session stats", () => {
 			await candidateSession.dispose();
 		}
 	});
+
+	it("computes stats safely when assistant messages lack usage", () => {
+		const model = modelRegistry.getAll().find(candidate => candidate.contextWindow && candidate.contextWindow > 0);
+		if (!model?.contextWindow) {
+			throw new Error("Expected bundled model with a context window");
+		}
+
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: "Hello",
+				timestamp: 1,
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Not logged in · Please run /login" }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				stopReason: "stop",
+				timestamp: 2,
+			} as AssistantMessage,
+		];
+
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages,
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		const stats = session.getSessionStats();
+		expect(stats.assistantMessages).toBe(1);
+		expect(stats.tokens.input).toBe(0);
+		expect(stats.tokens.output).toBe(0);
+		expect(stats.tokens.total).toBe(0);
+	});
 });


### PR DESCRIPTION
## What

Guards `message.usage` in `SessionStatsTracker.getSessionStats()` so assistant messages without a recorded `usage` property (e.g. from local slash commands like `/login`, imported transcripts, or legacy sessions) do not cause a `TypeError`.

## Why

Fixes #9743.

When session history contains an assistant message where `usage` is undefined, `SessionStatsTracker.getSessionStats()` throws `TypeError: undefined is not an object (evaluating 'h.usage.input')`. Because `getSessionStats()` is invoked in event listeners on `turn_start` and `agent_end`, the listener crashes and drops both `turn_start` and `agent_end` on the RPC stream.

I reviewed the full diff; this change adds the missing null check around `assistant.usage` in the session stats message loop and adds a unit test verifying that session stats compute cleanly when assistant messages lack `usage`.

## Testing

- Unit test added in `packages/coding-agent/test/agent-session-stats.test.ts` verifying `getSessionStats()` with missing `usage`.
- `bun test packages/coding-agent/test/agent-session-stats.test.ts` passes (3 passed, 0 failed).
- Verified against black-box reproduction with real `omp --mode rpc-ui`: `turn_start` and `agent_end` emit cleanly with 0 listener rejections.
- `biome check` passes on changed files.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
