### PR TITLE
fix(cursor): sanitize foreign tool-call ids for history replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor rejecting resumed/forked sessions whose history came from a Responses-family provider (e.g. Codex) with an opaque `resource_exhausted` by sanitizing composite `callId|itemId` tool-call ids before replay ([#9754](https://github.com/can1357/oh-my-pi/issues/9754)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Breaking Changes

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -194,7 +194,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types";
-import { normalizeSystemPrompts } from "../utils";
+import { normalizeSystemPrompts, normalizeToolCallId } from "../utils";
 import {
 	type CursorExecResolvedCarrier,
 	clearStreamingPartialJson,
@@ -4747,9 +4747,15 @@ function buildCursorAssistantContent(
 				});
 			}
 		} else if (item.type === "toolCall") {
+			// Foreign responses-family history carries composite `"{callId}|{itemId}"`
+			// tool-call ids (encodeResponsesToolCallId). The `|` violates Cursor's
+			// tool-call-id charset (`^[a-zA-Z0-9_-]+$`), so replaying it verbatim
+			// gets the whole Run rejected as opaque resource_exhausted. Sanitize the
+			// id everywhere it reaches the wire; the tool-result side normalizes the
+			// same id identically, so the call/result pairing stays intact.
 			content.push({
 				type: "tool-call",
-				toolCallId: item.id,
+				toolCallId: normalizeToolCallId(item.id),
 				toolName: item.name,
 				args: normalizeCursorMcpArguments(item.arguments),
 			});
@@ -4866,14 +4872,15 @@ function buildRootPromptMessagesJson(
 		} else if (msg.role === "toolResult") {
 			// Emit even when the result text is empty: the assistant `tool-call` is
 			// already in history, so dropping the pair would replay an orphaned call.
+			const toolCallId = normalizeToolCallId(msg.toolCallId);
 			pushJson({
 				role: "tool",
-				id: msg.toolCallId,
+				id: toolCallId,
 				content: [
 					{
 						type: "tool-result",
 						toolName: msg.toolName,
-						toolCallId: msg.toolCallId,
+						toolCallId,
 						result: toolResultToText(msg),
 						...(msg.isError ? { isError: true } : {}),
 					},
@@ -4963,11 +4970,12 @@ function createCursorMcpResult(result: ToolResultMessage) {
 }
 
 function createCursorToolCallStep(toolCall: ToolCall, result: ToolResultMessage | undefined) {
+	const toolCallId = normalizeToolCallId(toolCall.id);
 	const mcpCall = create(McpToolCallSchema, {
 		args: create(McpArgsSchema, {
 			name: toolCall.name,
 			args: encodeCursorMcpArguments(toolCall),
-			toolCallId: toolCall.id,
+			toolCallId,
 			providerIdentifier: "pi-agent",
 			toolName: toolCall.name,
 		}),
@@ -4978,7 +4986,7 @@ function createCursorToolCallStep(toolCall: ToolCall, result: ToolResultMessage 
 			case: "toolCall",
 			value: create(ToolCallSchema, {
 				tool: { case: "mcpToolCall", value: mcpCall },
-				toolCallId: toolCall.id,
+				toolCallId,
 			}),
 		},
 	});

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1004,6 +1004,65 @@ describe("Cursor history encoding", () => {
 		}
 	});
 
+	it("sanitizes foreign responses composite tool-call ids for Cursor replay", () => {
+		// openai-codex/responses history stores composite `"{callId}|{itemId}"`
+		// tool-call ids (encodeResponsesToolCallId). The `|` is invalid for
+		// Cursor's tool-call-id charset and gets the whole Run rejected as
+		// resource_exhausted, so it must be normalized identically on the call
+		// and result sides.
+		const compositeId = "call_abc123|fc_def456";
+		const sanitizedId = "call_abc123_fc_def456";
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Read package.json", timestamp: 1 },
+			{
+				...cursorAssistant(
+					"gpt-5.6-sol",
+					[{ type: "toolCall", id: compositeId, name: "read", arguments: { path: "package.json" } }],
+					2,
+					"toolUse",
+				),
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+			},
+			{
+				role: "toolResult",
+				toolCallId: compositeId,
+				toolName: "read",
+				content: [{ type: "text", text: "{}" }],
+				isError: false,
+				timestamp: 3,
+			},
+			{ role: "user", content: "Continue.", timestamp: 4 },
+		];
+
+		const history = buildCursorHistoryForTest(messages, undefined, "cursor-composer-2.5");
+		expect(history.rootPromptMessagesJson).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Read package.json" }] },
+			{
+				role: "assistant",
+				content: [{ type: "tool-call", toolCallId: sanitizedId, toolName: "read", args: { path: "package.json" } }],
+			},
+			{
+				role: "tool",
+				id: sanitizedId,
+				content: [{ type: "tool-result", toolName: "read", toolCallId: sanitizedId, result: "{}" }],
+			},
+		]);
+		expect(history.turnStepMessagesJson).toEqual([
+			[
+				expect.objectContaining({
+					toolCall: expect.objectContaining({
+						toolCallId: sanitizedId,
+						mcpToolCall: expect.objectContaining({
+							args: expect.objectContaining({ toolCallId: sanitizedId }),
+						}),
+					}),
+				}),
+			],
+		]);
+		expect(JSON.stringify(history)).not.toContain("|");
+	});
+
 	it("preserves image-only user turns in root prompt history and conversation turns", () => {
 		const imageData = "aW1hZ2U=";
 		const history = buildCursorHistoryForTest([


### PR DESCRIPTION
## Repro
Switching an existing session to `cursor/gpt-5.6-sol` after it accumulated `openai-codex` history fails instantly with Connect `resource_exhausted` (errorId 528384, 0 tokens); a fresh Cursor session and foreign histories without tool calls both succeed, and `/fork` cannot recover. Reproduced in-repo with `buildCursorHistoryForTest` on an `openai-codex` assistant turn whose tool-call id is `encodeResponsesToolCallId("call_abc123", "fc_def456")` = `call_abc123|fc_def456`: the composite id leaks verbatim into the assistant `tool-call`, the paired tool result, and the conversation-turn `ToolCall`/`McpArgs`.

## Cause
pi-ai mints composite `"{callId}|{itemId}"` tool-call ids via `encodeResponsesToolCallId` (`openai-shared.ts`). Cursor's history builders in `packages/ai/src/providers/cursor.ts` (`buildCursorAssistantContent`, the tool-result branch of `buildRootPromptMessagesJson`, and `createCursorToolCallStep`) replay `item.id` / `msg.toolCallId` verbatim. The `|` violates the tool-call-id charset (`^[a-zA-Z0-9_-]+$`) that omp already sanitizes before sending to Responses backends (`wireCallId` in `openai-responses-server.ts`), so Cursor's `AgentService/Run` rejects the reconstructed request as opaque `resource_exhausted` 528384. Because the ids are rebuilt from the transcript every request, a new `conversationId` via `/fork` can't recover.

## Fix
- Import the existing `normalizeToolCallId` helper (`../utils`) into the Cursor provider.
- Sanitize the emitted tool-call id at every wire point: `buildCursorAssistantContent` (assistant `tool-call`), the `toolResult` branch of `buildRootPromptMessagesJson` (`id` + `toolCallId`), and `createCursorToolCallStep` (`ToolCall.toolCallId` + `McpArgs.toolCallId`).
- Normalization is applied only at emission; internal pairing lookups keep the original ids, and call/result sides normalize the same id identically, so pairing stays intact. Native Cursor ids are already charset-valid and pass through unchanged.

## Verification
`bun test packages/ai/test/cursor-exec-handlers.test.ts` — 46 pass, including the new `sanitizes foreign responses composite tool-call ids for Cursor replay` regression test (asserts the composite `|` id is normalized identically across the assistant call, tool result, and turn step, and never reaches the wire). The pre-existing `keeps foreign thinking out of turns when switching to a non-K3 Cursor model` test still passes, confirming intended foreign-history replay is preserved. Note: the live Cursor `resource_exhausted` reject requires Cursor OAuth and could not be exercised here; verification covers the reconstructed wire shape that triggers it.

Fixes #9754