### PR TITLE
fix(tui): hide system XML wrappers in async-result and todo-nudge tree rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `async-result` and `mid-run-todo-nudge` rows in `/tree` displaying internal `<system-notice>`/`<system-reminder>` XML wrappers instead of readable text ([#9755](https://github.com/can1357/oh-my-pi/issues/9755)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -107,6 +107,16 @@ function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
 	return { qualifier: [...advisors, ...severities].join(", "), text: notes.join(" ") };
 }
 
+/**
+ * Strip the model-facing `<system-notice>` / `<system-reminder>` (and any other
+ * `<system-*>`) wrapper tags framing injects around custom-message content, so
+ * the session tree shows the human-readable body rather than the XML envelope
+ * (issue #9755, following the advisor fix in #9708).
+ */
+function stripSystemWrapperTags(content: string): string {
+	return content.replace(/<\/?system-[\w-]+(?:\s[^>]*)?>/gi, "");
+}
+
 class TreeList implements Component {
 	#flatNodes: FlatNode[] = [];
 	#filteredNodes: FlatNode[] = [];
@@ -424,7 +434,9 @@ class TreeList implements Component {
 					if (qualifier) parts.push(qualifier);
 					if (text) parts.push(text);
 				} else {
-					const content = typeof entry.content === "string" ? entry.content : this.#extractContent(entry.content);
+					const content = stripSystemWrapperTags(
+						typeof entry.content === "string" ? entry.content : this.#extractContent(entry.content),
+					);
 					if (content) parts.push(content);
 				}
 				break;
@@ -719,13 +731,14 @@ class TreeList implements Component {
 					result = theme.fg("customMessageLabel", label) + normalize(text);
 					break;
 				}
-				const content =
+				const content = stripSystemWrapperTags(
 					typeof entry.content === "string"
 						? entry.content
 						: entry.content
 								.filter((c): c is { type: "text"; text: string } => c.type === "text")
 								.map(c => c.text)
-								.join("");
+								.join(""),
+				);
 				result = theme.fg("customMessageLabel", `[${entry.customType}]: `) + normalize(content);
 				break;
 			}

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -108,13 +108,12 @@ function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
 }
 
 /**
- * Strip the model-facing `<system-notice>` / `<system-reminder>` (and any other
- * `<system-*>`) wrapper tags framing injects around custom-message content, so
- * the session tree shows the human-readable body rather than the XML envelope
- * (issue #9755, following the advisor fix in #9708).
+ * Strip one model-facing `<system-*>` envelope from custom-message content.
+ * Nested system tags belong to the recorded payload and remain visible.
  */
 function stripSystemWrapperTags(content: string): string {
-	return content.replace(/<\/?system-[\w-]+(?:\s[^>]*)?>/gi, "");
+	const match = content.match(/^\s*<(system-[\w-]+)(?:\s[^>]*)?>\s*([\s\S]*?)\s*<\/\1>\s*$/i);
+	return match?.[2] ?? content;
 }
 
 class TreeList implements Component {

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -112,7 +112,7 @@ function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
  * Nested system tags belong to the recorded payload and remain visible.
  */
 function stripSystemWrapperTags(content: string): string {
-	const match = content.match(/^\s*<(system-[\w-]+)(?:\s[^>]*)?>\s*([\s\S]*?)\s*<\/\1>\s*$/i);
+	const match = content.match(/^\s*<(system-[\w-]+)(?:\s+(?:[^"'<>]|"[^"]*"|'[^']*')*)?>\s*([\s\S]*?)\s*<\/\1>\s*$/i);
 	return match?.[2] ?? content;
 }
 

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -116,6 +116,9 @@ function stripSystemWrapperTags(content: string): string {
 	return match?.[2] ?? content;
 }
 
+/** Per-message cap on text folded into the tree search index. */
+const SEARCH_TEXT_LIMIT = 200;
+
 class TreeList implements Component {
 	#flatNodes: FlatNode[] = [];
 	#filteredNodes: FlatNode[] = [];
@@ -433,9 +436,7 @@ class TreeList implements Component {
 					if (qualifier) parts.push(qualifier);
 					if (text) parts.push(text);
 				} else {
-					const content = stripSystemWrapperTags(
-						typeof entry.content === "string" ? entry.content : this.#extractContent(entry.content),
-					);
+					const content = stripSystemWrapperTags(this.#joinTextContent(entry.content)).slice(0, SEARCH_TEXT_LIMIT);
 					if (content) parts.push(content);
 				}
 				break;
@@ -730,14 +731,7 @@ class TreeList implements Component {
 					result = theme.fg("customMessageLabel", label) + normalize(text);
 					break;
 				}
-				const content = stripSystemWrapperTags(
-					typeof entry.content === "string"
-						? entry.content
-						: entry.content
-								.filter((c): c is { type: "text"; text: string } => c.type === "text")
-								.map(c => c.text)
-								.join(""),
-				);
+				const content = stripSystemWrapperTags(this.#joinTextContent(entry.content));
 				result = theme.fg("customMessageLabel", `[${entry.customType}]: `) + normalize(content);
 				break;
 			}
@@ -792,14 +786,24 @@ class TreeList implements Component {
 	}
 
 	#extractContent(content: unknown): string {
-		const maxLen = 200;
-		if (typeof content === "string") return content.slice(0, maxLen);
+		return this.#joinTextContent(content).slice(0, SEARCH_TEXT_LIMIT);
+	}
+
+	/** Concatenate every text block (or return a string as-is) with no length cap. */
+	#joinTextContent(content: unknown): string {
+		if (typeof content === "string") return content;
 		if (Array.isArray(content)) {
 			let result = "";
 			for (const c of content) {
-				if (typeof c === "object" && c !== null && "type" in c && c.type === "text") {
-					result += (c as { text: string }).text;
-					if (result.length >= maxLen) return result.slice(0, maxLen);
+				if (
+					typeof c === "object" &&
+					c !== null &&
+					"type" in c &&
+					c.type === "text" &&
+					"text" in c &&
+					typeof c.text === "string"
+				) {
+					result += c.text;
 				}
 			}
 			return result;

--- a/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
@@ -74,4 +74,16 @@ describe("TreeSelectorComponent system-wrapper message rendering", () => {
 		expect(rendered).not.toContain("<system-notice");
 		expect(rendered).not.toContain("reason=");
 	});
+
+	it("preserves system tags contained in an async-result payload", () => {
+		const rendered = render(
+			customMessageTree(
+				"async-result",
+				"<system-notice>\nResult: <system-reminder>literal payload</system-reminder>\n</system-notice>",
+			),
+		);
+
+		expect(rendered).toContain("[async-result]: Result: <system-reminder>literal payload</system-reminder>");
+		expect(rendered).not.toContain("<system-notice>");
+	});
 });

--- a/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+function customMessageTree(customType: string, content: string): SessionTreeNode[] {
+	return [
+		{
+			entry: {
+				type: "custom_message",
+				id: "wrapper-entry",
+				parentId: null,
+				timestamp: "2026-08-25T00:00:00.000Z",
+				customType,
+				content,
+				display: true,
+			},
+			children: [],
+		},
+	];
+}
+
+function render(tree: SessionTreeNode[]): string {
+	const selector = new TreeSelectorComponent(
+		tree,
+		tree[0]?.entry.id ?? null,
+		60,
+		() => {},
+		() => {},
+	);
+	return Bun.stripANSI(selector.render(120).join("\n"));
+}
+
+describe("TreeSelectorComponent system-wrapper message rendering", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("strips the <system-reminder> wrapper from a mid-run-todo-nudge row", () => {
+		const rendered = render(
+			customMessageTree(
+				"mid-run-todo-nudge",
+				"<system-reminder>\n2 todo items still open. Keep working.\n</system-reminder>",
+			),
+		);
+
+		expect(rendered).toContain("[mid-run-todo-nudge]: 2 todo items still open. Keep working.");
+		expect(rendered).not.toContain("<system-reminder>");
+		expect(rendered).not.toContain("</system-reminder>");
+	});
+
+	it("strips the <system-notice> wrapper from an async-result row", () => {
+		const rendered = render(
+			customMessageTree(
+				"async-result",
+				"<system-notice>\nBackground job bg_1 has completed.\nDone.\n</system-notice>",
+			),
+		);
+
+		expect(rendered).toContain("[async-result]: Background job bg_1 has completed. Done.");
+		expect(rendered).not.toContain("<system-notice>");
+		expect(rendered).not.toContain("</system-notice>");
+	});
+
+	it("strips a system wrapper that carries attributes", () => {
+		const rendered = render(
+			customMessageTree(
+				"background-tan-dispatch",
+				'<system-notice reason="background_task_dispatched" job="bg_9">\nDispatched.\n</system-notice>',
+			),
+		);
+
+		expect(rendered).toContain("[background-tan-dispatch]: Dispatched.");
+		expect(rendered).not.toContain("<system-notice");
+		expect(rendered).not.toContain("reason=");
+	});
+});

--- a/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
@@ -20,6 +20,35 @@ function customMessageTree(customType: string, content: string): SessionTreeNode
 	];
 }
 
+function arrayCustomMessageTree(customType: string, blocks: string[]): SessionTreeNode[] {
+	return [
+		{
+			entry: {
+				type: "custom_message",
+				id: "wrapper-entry",
+				parentId: null,
+				timestamp: "2026-08-25T00:00:00.000Z",
+				customType,
+				content: blocks.map(text => ({ type: "text" as const, text })),
+				display: true,
+			},
+			children: [],
+		},
+	];
+}
+
+function searchResult(tree: SessionTreeNode[], query: string): string {
+	const selector = new TreeSelectorComponent(
+		tree,
+		tree[0]?.entry.id ?? null,
+		60,
+		() => {},
+		() => {},
+	);
+	for (const ch of query) selector.handleInput(ch);
+	return Bun.stripANSI(selector.render(120).join("\n"));
+}
+
 function render(tree: SessionTreeNode[]): string {
 	const selector = new TreeSelectorComponent(
 		tree,
@@ -98,5 +127,13 @@ describe("TreeSelectorComponent system-wrapper message rendering", () => {
 
 		expect(rendered).toContain("[async-result]: Result: <system-reminder>literal payload</system-reminder>");
 		expect(rendered).not.toContain("<system-notice>");
+	});
+
+	it("keeps the outer wrapper out of the search index for a long array-valued message", () => {
+		const body = `Background job bg_1 completed. ${"detail ".repeat(60)}`.trim();
+		const tree = arrayCustomMessageTree("async-result", [`<system-notice>\n${body}\n</system-notice>`]);
+
+		expect(searchResult(tree, "system-notice")).toContain("No entries match");
+		expect(searchResult(tree, "Background")).not.toContain("No entries match");
 	});
 });

--- a/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-system-wrapper.test.ts
@@ -75,6 +75,19 @@ describe("TreeSelectorComponent system-wrapper message rendering", () => {
 		expect(rendered).not.toContain("reason=");
 	});
 
+	it("strips a system wrapper whose quoted attributes contain greater-than signs", () => {
+		const rendered = render(
+			customMessageTree(
+				"ttsr-interrupt",
+				'<system-interrupt reason="rule_violation" rule="coverage > 80%" path="rules/watch>dog.md">\nOutput interrupted.\n</system-interrupt>',
+			),
+		);
+
+		expect(rendered).toContain("[ttsr-interrupt]: Output interrupted.");
+		expect(rendered).not.toContain("coverage > 80%");
+		expect(rendered).not.toContain("watch>dog.md");
+	});
+
 	it("preserves system tags contained in an async-result payload", () => {
 		const rendered = render(
 			customMessageTree(


### PR DESCRIPTION
## Repro
Opening `/tree` shows `async-result` and `mid-run-todo-nudge` rows with their raw model-facing XML wrappers (`<system-notice>` / `<system-reminder>`) instead of readable text — the same class of defect fixed for advisor rows in #9708. Rendering these `custom_message` entries through `TreeSelectorComponent` reproduces it:

```
[mid-run-todo-nudge]: <system-reminder> 2 todo items still open. keep working. </system-reminder>
[async-result]: <system-notice> Background job bg_1 has completed. Done. </system-notice>
```

## Cause
`TreeList` in `packages/coding-agent/src/modes/components/tree-selector.ts` rendered `custom_message` content verbatim in both the search-index path (`case "custom_message"` around the `parts.push` branch) and the row-render path (the `result = ... normalize(content)` branch). The advisor case was special-cased by #9708 to read `details.notes`, but every other system-wrapped custom message (`async-result`, `mid-run-todo-nudge`, `background-tan-dispatch`, etc.) still fell through to the raw content, which carries the `<system-notice>` / `<system-reminder>` envelope produced by the prompt templates.

## Fix
- Added `stripSystemWrapperTags()` next to `advisorTreeDisplay()`, removing `<system-*>` opening/closing tags (with optional attributes) from custom-message content.
- Applied it in both the tree search-index builder and the row renderer so filtering and display agree.
- Added `tree-selector-system-wrapper.test.ts` covering the two reported types plus an attribute-carrying wrapper.
- Added a changelog entry under `[Unreleased]`.

## Verification
`bun test test/modes/components/tree-selector-system-wrapper.test.ts test/modes/components/tree-selector-advisor.test.ts` — 7 pass, 0 fail. The rows now render `[mid-run-todo-nudge]: 2 todo items still open...` and `[async-result]: Background job bg_1 has completed. Done.` with no XML. Fixes #9755