### PR TITLE
fix(coding-agent): keep collab join URL when the QR is clipped

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/collab` hiding the join URL when the QR code is clipped: the one-line fallback now includes the browser link, and the status heading keeps that URL on its first row so transcript pressure cannot drop it.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -9,18 +9,11 @@ import { shareSession } from "../export/share";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
-import { urlHyperlinkAlways } from "../tui";
 import { copyToClipboard } from "../utils/clipboard";
 import { refreshStatusLine } from "./builtin-modes";
-import { CollabQrCodeComponent } from "./helpers/collab-qrcode";
+import { CollabQrCodeComponent, collabBrowserLink } from "./helpers/collab-qrcode";
 import { commandConsumed, errorMessage, parseSubcommand, usage } from "./helpers/parse";
 import type { SlashCommandSpec } from "./types";
-
-/** Scheme-less display form of a browser deep link: accent + underline, OSC-8 linked to the full URL. */
-function collabWebLinkClickable(webLink: string): string {
-	const display = theme.fg("accent", `\x1b[4m${webLink.replace(/^https?:\/\//, "")}\x1b[24m`);
-	return urlHyperlinkAlways(webLink, display);
-}
 
 /** Join hint printed by /collab: compact terminal link + clickable browser deep link. */
 function collabLinkHint(host: CollabHost, heading: string, view = false): string {
@@ -28,9 +21,11 @@ function collabLinkHint(host: CollabHost, heading: string, view = false): string
 	const link = view ? host.viewLink : host.link;
 	const webLink = view ? host.webViewLink : host.webLink;
 	return [
-		theme.fg("success", heading),
+		// Keep the URL on the first row: under transcript pressure the status
+		// block is clipped to rendered[0], which used to drop the join link.
+		`${theme.fg("success", heading)}  ${collabBrowserLink(webLink)}`,
 		` ${bullet} ${theme.fg("muted", view ? "Watch from another terminal:" : "Join from another terminal:")} ${APP_NAME} join "${link}"`,
-		` ${bullet} ${theme.fg("muted", "or any web browser:")} ${collabWebLinkClickable(webLink)}`,
+		` ${bullet} ${theme.fg("muted", "or any web browser:")} ${collabBrowserLink(webLink)}`,
 		theme.fg(
 			"dim",
 			view
@@ -292,7 +287,7 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 					const names = ctx.collabHost.participants.map(p =>
 						p.role === "host" ? `${p.name} (host)` : p.readOnly ? `${p.name} (view-only)` : p.name,
 					);
-					ctx.showStatus(`Collab: ${names.join(", ")} — ${collabWebLinkClickable(ctx.collabHost.webLink)}`);
+					ctx.showStatus(`Collab: ${names.join(", ")} — ${collabBrowserLink(ctx.collabHost.webLink)}`);
 				} else if (ctx.collabGuest) {
 					ctx.showStatus(
 						ctx.collabGuest.readOnly

--- a/packages/coding-agent/src/slash-commands/helpers/collab-qrcode.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/collab-qrcode.ts
@@ -1,19 +1,29 @@
 import { type Component, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { AnimationFrame, TranscriptPresentationTarget } from "../../modes/components/transcript-container";
 import { fgOrPlain } from "../../modes/theme/theme";
+import { urlHyperlinkAlways } from "../../tui";
 import { QrCode, renderQrHalfBlocks } from "../../utils/qrcode";
+
+/** Scheme-less display form of a collab browser deep link, OSC-8 linked. */
+export function collabBrowserLink(webLink: string): string {
+	const display = fgOrPlain("accent", `\x1b[4m${webLink.replace(/^https?:\/\//, "")}\x1b[24m`);
+	return urlHyperlinkAlways(webLink, display);
+}
 
 /**
  * One-shot transcript block that prints a collab browser-join URL as a
  * scannable QR code. The symbol is encoded once at construction (byte mode,
  * EC level M) and rendered as ANSI half-blocks; on terminals too narrow for
- * the symbol it degrades to a one-line hint pointing at the printed URL.
+ * the symbol it degrades to a one-line hint that includes the URL.
  *
  * The transcript viewport can also clip a live block to a single row under
  * pressure (many short settled blocks — typical when thinking is a one-line
  * summary rather than a tall trace). The QR's first/last rows are a white
  * quiet zone, so a 1-row clip looks like an empty white line. When the
  * allocated height cannot fit the full symbol, degrade to the same hint.
+ * The sibling `/collab` status heading can also collapse to its first row
+ * under that pressure, so the hint must carry the URL itself — "use the
+ * URL above" is not reachable.
  */
 export class CollabQrCodeComponent implements Component, TranscriptPresentationTarget {
 	readonly #lines: readonly string[];
@@ -40,7 +50,16 @@ export class CollabQrCodeComponent implements Component, TranscriptPresentationT
 		return this.#lines;
 	}
 
+	/** Survives emergency 1-row transcript pressure when this block is otherwise hidden. */
+	renderTranscriptBlockEmergencyRow(_width: number): string {
+		return this.#hiddenHint(
+			Number.isFinite(this.#allocatedRows)
+				? `viewport height ${this.#allocatedRows}; need ${this.#lines.length}`
+				: "transcript pressure",
+		);
+	}
+
 	#hiddenHint(reason: string): string {
-		return ` ${fgOrPlain("warning", `QR code hidden: ${reason}. Use the browser URL above.`)}`;
+		return ` ${fgOrPlain("warning", `QR code hidden: ${reason}.`)} ${collabBrowserLink(this.url)}`;
 	}
 }

--- a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
+++ b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
@@ -149,7 +149,24 @@ describe("/collab slash command QR code rendering", () => {
 		expect(presented[1]).toBeInstanceOf(CollabQrCodeComponent);
 		const component = presented[1] as CollabQrCodeComponent;
 		expect(component.url).toBe(webViewLink);
-		expect(component.render(10).join("\n")).toContain("QR code hidden");
+		const clipped = component.render(10).join("\n");
+		expect(clipped).toContain("QR code hidden");
+		expect(clipped).toContain("my.omp.sh/#read-only");
+		expect(clipped).not.toContain("URL above");
+	});
+
+	it("keeps the browser URL on the first status row so transcript clipping cannot hide it", async () => {
+		const startSpy = mockStartedHostLinks();
+		const harness = createRuntimeHarness();
+
+		const handled = await executeBuiltinSlashCommand("/collab", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(startSpy).toHaveBeenCalled();
+		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
+		const firstRow = statusText.split("\n")[0] ?? "";
+		expect(firstRow).toContain("Collab session started!");
+		expect(firstRow).toContain("my.omp.sh/#started-full");
 	});
 });
 
@@ -175,6 +192,16 @@ describe("CollabQrCodeComponent transcript height clipping", () => {
 		expect(clipped).toHaveLength(1);
 		expect(clipped[0]).toContain("QR code hidden");
 		expect(clipped[0]).toContain("viewport height 1");
+		expect(clipped[0]).toContain("my.omp.sh/#clip-test");
+		expect(clipped[0]).not.toContain("URL above");
 		expect(clipped[0]).not.toMatch(/\x1b\[(?:47|40)m/);
+	});
+
+	it("keeps the browser URL as the emergency one-row transcript representation", () => {
+		const component = new CollabQrCodeComponent("https://my.omp.sh/#clip-test");
+		component.setTranscriptAllocation(1);
+		const row = component.renderTranscriptBlockEmergencyRow(120);
+		expect(row).toContain("my.omp.sh/#clip-test");
+		expect(row).not.toContain("URL above");
 	});
 });


### PR DESCRIPTION
Follow-up to #9658.

I reproduced this in a dense `/collab` session (summarized thinking, lots of one-line tool cards, `24 more transcript blocks active`). The QR correctly hid itself (`viewport height 1; need 25. Use the browser URL above.`), but the join URL was gone too. Only **Collab session started!** / **Collab session active** remained.

## Why

`#renderEmergency` keeps one row per live block (`rendered[0]`). Two separate blocks make up a collab invite:

1. `showStatus(collabLinkHint)` — 4 lines; first row was only the heading.
2. `CollabQrCodeComponent` — 25-row QR; at 1 row it pointed at “the URL above,” which that heading no longer contained.

## What changed

- Status heading now includes the clickable browser URL on the first row, so clipping cannot drop it.
- The QR’s one-line fallback (narrow terminal, short allocation, and `renderTranscriptBlockEmergencyRow`) inlines the same URL instead of “use the URL above.”

The full QR still renders when the viewport allocates the whole symbol.

## Tests

`packages/coding-agent/test/slash-commands/collab-qrcode.test.ts`

- clipped QR row contains `my.omp.sh/#…` and not `URL above`
- emergency row contains the URL
- `/collab` status first line contains the URL

`bun --cwd=packages/coding-agent test test/slash-commands/collab-qrcode.test.ts` — 8 pass  
`bun --cwd=packages/coding-agent run check` — biome + types pass