### PR TITLE
fix(config): refresh command-backed provider headers after 401

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed command-backed (`!command`) provider and model-override header credentials staying pinned to their stale value after an HTTP 401; the auth retry now re-runs those commands and sends the refreshed headers. ([#9760](https://github.com/can1357/oh-my-pi/issues/9760))
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/config/model-config-values.ts
+++ b/packages/coding-agent/src/config/model-config-values.ts
@@ -18,6 +18,21 @@ export function isCommandConfigValue(valueConfig: string | undefined): valueConf
 	return valueConfig?.startsWith("!") === true;
 }
 
+/**
+ * Drop the cached result (and any negative-cache backoff) for a command-backed
+ * config value so the next {@link resolveConfigValue} re-runs the command.
+ *
+ * Used by the 401 auth-retry path to force every command-backed credential a
+ * provider carries — API key AND header values — to re-mint, not just the
+ * apiKey (which alone was covered before). Non-command values are ignored.
+ */
+export function invalidateCommandConfig(valueConfig: string | undefined): void {
+	if (!isCommandConfigValue(valueConfig)) return;
+	const command = valueConfig.slice(1).trim();
+	commandValueCache.delete(command);
+	commandFailureRetryAt.delete(command);
+}
+
 function resolveCommandConfig(command: string, options?: ResolveConfigValueOptions): string | undefined {
 	if (options?.forceCommandRefresh === true) {
 		commandValueCache.delete(command);

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -4,6 +4,7 @@ import { isVertexExpressOpenAIUrl } from "@oh-my-pi/pi-catalog/hosts";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models";
 import { toModelSpec } from "@oh-my-pi/pi-catalog/provider-models/bundled-references";
 import { isRecord } from "@oh-my-pi/pi-utils";
+import { createLiveConfigHeaders } from "./model-config-values";
 import type { ModelOverride } from "./models-config-schema";
 /** Provider override config (baseUrl, headers, apiKey, compat, transport) without custom models */
 export interface ProviderOverride {
@@ -232,7 +233,10 @@ export function applyModelPatch(base: Model<Api>, patch: ModelPatch, transport: 
 	let compat: ModelSpec<Api>["compat"];
 	if (transport === "merge") {
 		if (patch.headers) {
-			result.headers = { ...base.headers, ...patch.headers };
+			// Route merged headers through the live proxy so command-backed (`!cmd`)
+			// override values stay re-resolvable — a 401 refresh invalidates their
+			// cache and the next request re-runs the command (#9760).
+			result.headers = createLiveConfigHeaders([base.headers, patch.headers]);
 		}
 		compat = mergeCompat(base.compatConfig, patch.compat);
 	} else {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -52,6 +52,7 @@ import {
 import {
 	type CommandApiKeyResolution,
 	createLiveConfigHeaders,
+	invalidateCommandConfig,
 	isCommandConfigValue,
 	resolveConfigHeaders,
 	resolveConfigValue,
@@ -194,6 +195,11 @@ export class ModelRegistry {
 	#internedStaticModels: Map<string, Model<Api>> = new Map();
 	#providerLookupSnapshots: Map<string, Model<Api>[]> = new Map();
 	#customProviderApiKeys: Map<string, string> = new Map();
+	// Every command-backed (`!cmd`) config value a provider carries — apiKey plus
+	// provider/model-override header values — keyed by provider. The 401 auth
+	// retry invalidates these command caches so refreshed credentials reach the
+	// retry request through the live header proxy, not just the apiKey (#9760).
+	#commandConfigsByProvider: Map<string, Set<string>> = new Map();
 	#keylessProviders: Set<string> = new Set();
 	#discoverableProviders: DiscoveryProviderConfig[] = [];
 	#customModelOverlays: CustomModelOverlay[] = [];
@@ -243,6 +249,38 @@ export class ModelRegistry {
 		}
 		this.authStorage.removeConfigApiKey(provider);
 		return { configured: true };
+	}
+
+	/**
+	 * Accumulate every command-backed (`!cmd`) config value from an apiKey and a
+	 * header record into `target`. Used at load time to record which commands a
+	 * provider depends on so the 401 refresh path can invalidate all of them.
+	 */
+	#collectCommandConfigValues(
+		target: Set<string>,
+		apiKey: string | undefined,
+		headers: Record<string, string> | undefined,
+	): void {
+		if (isCommandConfigValue(apiKey)) target.add(apiKey);
+		if (!headers) return;
+		for (const key in headers) {
+			const value = headers[key];
+			if (isCommandConfigValue(value)) target.add(value);
+		}
+	}
+
+	/**
+	 * Drop the process-cached results of every command-backed config value a
+	 * provider carries (apiKey plus provider/model-override header commands) so
+	 * the next resolve re-runs them. Invoked on the 401 force-refresh path: the
+	 * apiKey alone was refreshed before, leaving command-backed header
+	 * credentials pinned to their stale value across the retry (#9760).
+	 */
+	#invalidateProviderCommandConfigs(provider: string): void {
+		invalidateCommandConfig(this.#customProviderApiKeys.get(provider));
+		const configs = this.#commandConfigsByProvider.get(provider);
+		if (!configs) return;
+		for (const config of configs) invalidateCommandConfig(config);
 	}
 
 	#installProviderApiKey(provider: string, keyConfig: string): void {
@@ -639,6 +677,7 @@ export class ModelRegistry {
 		this.#runtimeAuthoritativeProviders.clear();
 		this.#internedStaticModels.clear();
 		this.#providerLookupSnapshots.clear();
+		this.#commandConfigsByProvider.clear();
 	}
 
 	#knownStaticProviders(): string[] {
@@ -1158,6 +1197,8 @@ export class ModelRegistry {
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
+			const commandConfigs = new Set<string>();
+			this.#collectCommandConfigValues(commandConfigs, providerConfig.apiKey, providerConfig.headers);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/guardrail*/transport are present
 			if (
 				providerConfig.baseUrl ||
@@ -1176,7 +1217,7 @@ export class ModelRegistry {
 						providerConfig.discovery?.type === "litellm"
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
 							: providerConfig.baseUrl,
-					headers: resolvedProviderHeaders,
+					headers: providerConfig.headers,
 					apiKey: providerConfig.apiKey,
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
@@ -1218,17 +1259,18 @@ export class ModelRegistry {
 				this.#installProviderApiKey(providerName, providerConfig.apiKey);
 			}
 
-			// Parse per-model overrides
+			// Parse per-model overrides. Header values are kept raw (`!cmd` intact)
+			// so the downstream live proxy re-resolves them per request, letting a
+			// 401 refresh reach header-carried credentials (#9760).
 			if (providerConfig.modelOverrides) {
 				const perModel = new Map<string, ModelOverride>();
 				for (const [modelId, override] of Object.entries(providerConfig.modelOverrides)) {
-					perModel.set(
-						modelId,
-						override.headers ? { ...override, headers: resolveConfigHeaders(override.headers) } : override,
-					);
+					this.#collectCommandConfigValues(commandConfigs, undefined, override.headers);
+					perModel.set(modelId, override);
 				}
 				allModelOverrides.set(providerName, perModel);
 			}
+			if (commandConfigs.size > 0) this.#commandConfigsByProvider.set(providerName, commandConfigs);
 		}
 
 		return {
@@ -1906,7 +1948,6 @@ export class ModelRegistry {
 		for (const [providerName, providerConfig] of Object.entries(config.providers ?? {})) {
 			const modelDefs = providerConfig.models ?? [];
 			if (modelDefs.length === 0) continue; // Override-only, no custom models
-			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
 			if (providerConfig.apiKey) {
 				this.#installProviderApiKey(providerName, providerConfig.apiKey);
 			}
@@ -1918,7 +1959,7 @@ export class ModelRegistry {
 					providerName,
 					providerConfig.baseUrl!,
 					providerConfig.api as Api | undefined,
-					resolvedProviderHeaders,
+					providerConfig.headers,
 					providerConfig.apiKey,
 					providerConfig.authHeader,
 					providerCompat,
@@ -2145,6 +2186,7 @@ export class ModelRegistry {
 		sessionId?: string,
 		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined> {
+		if (options?.forceRefresh) this.#invalidateProviderCommandConfigs(provider);
 		const commandKey = this.#resolveCommandBackedApiKey(
 			provider,
 			options?.forceRefresh ? { forceCommandRefresh: true } : undefined,

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { streamSimple } from "@oh-my-pi/pi-ai";
 import { withAuth } from "@oh-my-pi/pi-ai/auth-retry";
-import type { Api, Model } from "@oh-my-pi/pi-ai/types";
+import type { Api, Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -30,6 +31,55 @@ function failedTrackingCommand(counterFile: string): string {
 	if (process.platform !== "win32") return `printf 1 >> ${shellQuote(counterFile)}; exit 1`;
 	const script = `const fs=require("node:fs");fs.appendFileSync(${JSON.stringify(counterFile)}, "1");process.exit(1);`;
 	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+/** Command that prints the *current* trimmed contents of `file` on each run. */
+function stdoutFileCommand(file: string): string {
+	if (process.platform !== "win32") return `IFS= read -r t < ${shellQuote(file)}; printf %s "$t"`;
+	const script = `const fs=require("node:fs");process.stdout.write(fs.readFileSync(${JSON.stringify(file)}, "utf8").trim());`;
+	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+/** Minimal successful chat-completions SSE stream for the openai-completions provider. */
+function okChatCompletionStream(): Response {
+	const chunks = [
+		JSON.stringify({
+			id: "cmpl",
+			object: "chat.completion.chunk",
+			choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }],
+		}),
+		JSON.stringify({
+			id: "cmpl",
+			object: "chat.completion.chunk",
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		}),
+		"[DONE]",
+	];
+	return new Response(chunks.map(c => `data: ${c}\n\n`).join(""), {
+		status: 200,
+		headers: { "Content-Type": "text/event-stream" },
+	});
+}
+
+/**
+ * Fetch that records each request's credential headers, 401s until BOTH the
+ * bearer and the tenant header carry their refreshed values, then streams a
+ * successful completion.
+ */
+function refreshGateFetch(seen: Array<{ auth?: string; tenant?: string }>): FetchImpl {
+	return async (_url, init) => {
+		const headers = (init?.headers ?? {}) as Record<string, string>;
+		const auth = headers.Authorization;
+		const tenant = headers["x-tenant-token"];
+		seen.push({ auth, tenant });
+		if (auth !== "Bearer fresh-bearer" || tenant !== "fresh-tenant") {
+			return new Response(JSON.stringify({ error: { message: "invalid api key", type: "authentication_error" } }), {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+		return okChatCompletionStream();
+	};
 }
 
 describe("ModelRegistry command-resolved models.yml values", () => {
@@ -235,5 +285,103 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 
 		// The command should have only run once.
 		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+	});
+
+	test("401 refreshes a command-backed provider header and retries with the fresh value", async () => {
+		const bearerFile = path.join(tempDir, "bearer.txt");
+		const tenantFile = path.join(tempDir, "tenant.txt");
+		fs.writeFileSync(bearerFile, "stale-bearer");
+		fs.writeFileSync(tenantFile, "stale-tenant");
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: `!${stdoutFileCommand(bearerFile)}`,
+						headers: { "x-tenant-token": `!${stdoutFileCommand(tenantFile)}` },
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+		if (!model) throw new Error("Expected custom model");
+		// Reading the header proxy caches the stale value, as the first live
+		// request would. The rotation below is only observed on the retry if the
+		// 401 path actually invalidates the command cache and re-runs it.
+		expect(model.headers?.["x-tenant-token"]).toBe("stale-tenant");
+		// The credential backend rotates both tokens out-of-band.
+		fs.writeFileSync(bearerFile, "fresh-bearer");
+		fs.writeFileSync(tenantFile, "fresh-tenant");
+
+		const seen: Array<{ auth?: string; tenant?: string }> = [];
+		const context: Context = { systemPrompt: ["s"], messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+		const streamHandle = streamSimple(model, context, {
+			apiKey: registry.resolver(model),
+			fetch: refreshGateFetch(seen),
+			maxTokens: 16,
+		});
+		for await (const _event of streamHandle) {
+			// drain
+		}
+		const result = await streamHandle.result();
+
+		expect(result.stopReason).not.toBe("error");
+		expect(seen).toEqual([
+			{ auth: "Bearer stale-bearer", tenant: "stale-tenant" },
+			{ auth: "Bearer fresh-bearer", tenant: "fresh-tenant" },
+		]);
+	});
+
+	test("401 refreshes a command-backed modelOverrides header and retries with the fresh value", async () => {
+		const bearerFile = path.join(tempDir, "bearer.txt");
+		const tenantFile = path.join(tempDir, "tenant.txt");
+		fs.writeFileSync(bearerFile, "stale-bearer");
+		fs.writeFileSync(tenantFile, "stale-tenant");
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: `!${stdoutFileCommand(bearerFile)}`,
+						models: [{ id: "custom-model", name: "Custom Model" }],
+						modelOverrides: {
+							"custom-model": { headers: { "x-tenant-token": `!${stdoutFileCommand(tenantFile)}` } },
+						},
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+		if (!model) throw new Error("Expected custom model");
+		expect(model.headers?.["x-tenant-token"]).toBe("stale-tenant");
+		fs.writeFileSync(bearerFile, "fresh-bearer");
+		fs.writeFileSync(tenantFile, "fresh-tenant");
+
+		const seen: Array<{ auth?: string; tenant?: string }> = [];
+		const context: Context = { systemPrompt: ["s"], messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+		const streamHandle = streamSimple(model, context, {
+			apiKey: registry.resolver(model),
+			fetch: refreshGateFetch(seen),
+			maxTokens: 16,
+		});
+		for await (const _event of streamHandle) {
+			// drain
+		}
+		const result = await streamHandle.result();
+
+		expect(result.stopReason).not.toBe("error");
+		expect(seen).toEqual([
+			{ auth: "Bearer stale-bearer", tenant: "stale-tenant" },
+			{ auth: "Bearer fresh-bearer", tenant: "fresh-tenant" },
+		]);
 	});
 });


### PR DESCRIPTION
## Repro
A custom `openai-completions` provider whose bearer **and** a second auth header are command-backed (`!command`) stays 401 after a credential rotation. Driving `streamSimple()` with a mock fetch that 401s stale tokens, then rotating both tokens out-of-band, the retry re-sends the stale header:

```yaml
providers:
  custom-proxy:
    baseUrl: https://proxy.company.com/v1
    api: openai-completions
    apiKey: "!mint-bearer"
    headers:
      x-tenant-token: "!mint-tenant"
```

```
seen: [
  { auth: "Bearer stale-bearer", tenant: "stale-tenant" },   // attempt 1 -> 401
  { auth: "Bearer fresh-bearer", tenant: "stale-tenant" }    // retry: bearer refreshed, tenant header STALE -> 401
]
stopReason: error
```

Same failure when the command-backed header is a `modelOverrides.<id>.headers` entry.

## Cause
Explicit config header values (`providers.<p>.headers`, `modelOverrides.<id>.headers`) were materialized statically at load via `resolveConfigHeaders` in `ModelRegistry.#loadCustomModels`/`#parseModels`, and `modelOverrides` headers were frozen again by the plain spread in `applyModelPatch` (`config/model-patch.ts`). The 401 force-refresh path (`getApiKeyForProvider({ forceRefresh })` → `#resolveCommandBackedApiKey`) only invalidated the **apiKey** command cache. PR #8253 made the apiKey/`authHeader`-derived `Authorization` live and refreshable but left command-backed header values pinned to their process-cached value across the retry.

## Fix
- `config/model-config-values.ts`: add `invalidateCommandConfig(value)` to drop a `!command`'s cached result and negative-cache backoff.
- `config/model-registry.ts`: keep provider and model-override header sources raw so they resolve through the live header proxy; track every command-backed config value per provider (`#commandConfigsByProvider`, populated in `#loadCustomModels`, cleared in `#resetStaticComposition`); on `getApiKeyForProvider({ forceRefresh })` invalidate the whole set (apiKey + headers) via `#invalidateProviderCommandConfigs`.
- `config/model-patch.ts`: route merged model-override headers through `createLiveConfigHeaders` so command values stay re-resolvable after invalidation.

## Verification
`bun test test/model-registry-command-values.test.ts` — 7 pass, incl. two new streaming (`streamSimple`) regressions asserting the retry carries the refreshed provider-level and `modelOverrides` header. `bun test` across the 8 `model-registry-*` suites — 151 pass. `bun check` — clean. Fixes #9760