### PR TITLE
feat(extensions): add opt-in modern ESM fast path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -287,6 +287,7 @@
 - Added repeat read warning hints when identical file content is read multiple times.
 - Explicit DAP adapters can now attach without a PID or port when `attachDefaults` provide the target arguments.
 - Added `isProjectTrusted()` compatibility shim to `ExtensionContext` for extensions targeting upstream per-directory trust gates.
+- Extension packages can declare `omp.compatibility: "modern-esm"` to skip legacy graph rewriting and load through Bun's native ESM cache.
 
 ### Changed
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -393,10 +393,15 @@ interface ImportedExtensionModule {
 	error: string | null;
 }
 
-async function readExtensionCompatibility(extensionPath: string): Promise<ExtensionCompatibility | undefined> {
+async function readExtensionCompatibility(
+	extensionPath: string,
+	manifestCache: Map<string, Promise<ExtensionManifest | null>>,
+): Promise<ExtensionCompatibility | undefined> {
 	const manifestPath = getExtensionManifestPath(extensionPath);
 	if (manifestPath) {
-		const manifest = await readExtensionManifest(manifestPath);
+		const cached = manifestCache.get(manifestPath) ?? readExtensionManifest(manifestPath);
+		manifestCache.set(manifestPath, cached);
+		const manifest = await cached;
 		return manifest?.compatibility === "modern-esm" || manifest?.compatibility === "legacy"
 			? manifest.compatibility
 			: undefined;
@@ -404,7 +409,10 @@ async function readExtensionCompatibility(extensionPath: string): Promise<Extens
 	const realPath = await fs.realpath(extensionPath).catch(() => extensionPath);
 	let directory = path.dirname(realPath);
 	while (true) {
-		const manifest = await readExtensionManifest(path.join(directory, "package.json"));
+		const candidatePath = path.join(directory, "package.json");
+		const cached = manifestCache.get(candidatePath) ?? readExtensionManifest(candidatePath);
+		manifestCache.set(candidatePath, cached);
+		const manifest = await cached;
 		if (manifest)
 			return manifest.compatibility === "modern-esm" || manifest.compatibility === "legacy"
 				? manifest.compatibility
@@ -415,10 +423,14 @@ async function readExtensionCompatibility(extensionPath: string): Promise<Extens
 	}
 }
 
-async function importExtensionModule(extensionPath: string, cwd: string): Promise<ImportedExtensionModule> {
+async function importExtensionModule(
+	extensionPath: string,
+	cwd: string,
+	manifestCache: Map<string, Promise<ExtensionManifest | null>>,
+): Promise<ImportedExtensionModule> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
 	try {
-		const compatibility = await readExtensionCompatibility(resolvedPath);
+		const compatibility = await readExtensionCompatibility(resolvedPath, manifestCache);
 		const module = (await withHostGuard(() =>
 			compatibility === "modern-esm" ? loadRuntimeModule(resolvedPath) : loadLegacyPiModule(resolvedPath),
 		)) as LoadedExtensionModule;
@@ -489,7 +501,9 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 	const resolvedEventBus = eventBus ?? new EventBus();
 	const runtime = new ExtensionRuntime();
 
-	const imported = await Promise.all(paths.map(extPath => importExtensionModule(extPath, cwd)));
+	const manifestCache = new Map<string, Promise<ExtensionManifest | null>>();
+
+	const imported = await Promise.all(paths.map(extPath => importExtensionModule(extPath, cwd, manifestCache)));
 
 	for (let i = 0; i < paths.length; i++) {
 		const extPath = paths[i]!;

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -31,8 +31,9 @@ import type { CustomMessagePayload } from "../../session/messages";
 import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../tools/file-write-fallback";
 import { EventBus } from "../../utils/event-bus";
 import * as TypeBox from "../legacy-typebox";
+import { loadRuntimeModule } from "../module-loader";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/legacy-pi-compat";
-import { getAllPluginExtensionPaths } from "../plugins/loader";
+import { getAllPluginExtensionPaths, getExtensionManifestPath } from "../plugins/loader";
 
 import { resolvePath, withHostGuard } from "../utils";
 import type {
@@ -51,10 +52,18 @@ import type {
 	ToolInfo,
 } from "./types";
 
-installLegacyPiSpecifierShim();
-
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 type LoadedExtensionModule = ExtensionFactory | { default?: ExtensionFactory };
+type ExtensionCompatibility = "legacy" | "modern-esm";
+
+type ExtensionManifest = {
+	extensions?: string[];
+	themes?: string[];
+	skills?: string[];
+	compatibility?: ExtensionCompatibility;
+};
+
+installLegacyPiSpecifierShim();
 
 function getExtensionFactory(module: LoadedExtensionModule): ExtensionFactory | null {
 	const candidate = typeof module === "function" ? module : module.default;
@@ -384,20 +393,42 @@ interface ImportedExtensionModule {
 	error: string | null;
 }
 
+async function readExtensionCompatibility(extensionPath: string): Promise<ExtensionCompatibility | undefined> {
+	const manifestPath = getExtensionManifestPath(extensionPath);
+	if (manifestPath) {
+		const manifest = await readExtensionManifest(manifestPath);
+		return manifest?.compatibility === "modern-esm" || manifest?.compatibility === "legacy"
+			? manifest.compatibility
+			: undefined;
+	}
+	const realPath = await fs.realpath(extensionPath).catch(() => extensionPath);
+	let directory = path.dirname(realPath);
+	while (true) {
+		const manifest = await readExtensionManifest(path.join(directory, "package.json"));
+		if (manifest)
+			return manifest.compatibility === "modern-esm" || manifest.compatibility === "legacy"
+				? manifest.compatibility
+				: undefined;
+		const parent = path.dirname(directory);
+		if (parent === directory) return undefined;
+		directory = parent;
+	}
+}
+
 async function importExtensionModule(extensionPath: string, cwd: string): Promise<ImportedExtensionModule> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
 	try {
-		const module = (await withHostGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
+		const compatibility = await readExtensionCompatibility(resolvedPath);
+		const module = (await withHostGuard(() =>
+			compatibility === "modern-esm" ? loadRuntimeModule(resolvedPath) : loadLegacyPiModule(resolvedPath),
+		)) as LoadedExtensionModule;
 		const factory = getExtensionFactory(module);
-
-		if (typeof factory !== "function") {
+		if (typeof factory !== "function")
 			return {
 				factory: null,
 				resolvedPath,
 				error: `Extension does not export a valid factory function: ${extensionPath}`,
 			};
-		}
-
 		return { factory, resolvedPath, error: null };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -479,12 +510,6 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 		errors,
 		runtime,
 	};
-}
-
-interface ExtensionManifest {
-	extensions?: string[];
-	themes?: string[];
-	skills?: string[];
 }
 
 async function readExtensionManifest(packageJsonPath: string): Promise<ExtensionManifest | null> {

--- a/packages/coding-agent/src/extensibility/module-loader.ts
+++ b/packages/coding-agent/src/extensibility/module-loader.ts
@@ -1,0 +1,4 @@
+/** Runtime-selected module loading boundary for user and plugin modules. */
+export async function loadRuntimeModule(modulePath: string): Promise<unknown> {
+	return import(modulePath);
+}

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -21,6 +21,37 @@ export interface ScopedInstalledPlugin extends InstalledPlugin {
 installLegacyPiSpecifierShim();
 
 const enabledPluginsCache = new Map<string, Promise<ScopedInstalledPlugin[]>>();
+const extensionManifestPaths = new Map<string, string>();
+
+function nearestExtensionManifestPath(extensionPath: string, packageRoot: string): string | undefined {
+	let directory = path.dirname(extensionPath);
+	const root = path.resolve(packageRoot);
+	while (true) {
+		const candidate = path.join(directory, "package.json");
+		if (fs.existsSync(candidate)) {
+			try {
+				const pkg = JSON.parse(fs.readFileSync(candidate, "utf8")) as {
+					omp?: { extensions?: unknown };
+					pi?: { extensions?: unknown };
+				};
+				if (pkg.omp || pkg.pi) return candidate;
+			} catch {}
+		}
+		if (directory === root) return undefined;
+		const parent = path.dirname(directory);
+		if (parent === directory || !directory.startsWith(root + path.sep)) return undefined;
+		directory = parent;
+	}
+}
+export function setExtensionManifestPath(extensionPath: string, manifestPath: string): void {
+	extensionManifestPaths.set(path.resolve(extensionPath), manifestPath);
+}
+export function getExtensionManifestPath(extensionPath: string): string | undefined {
+	const key = path.resolve(extensionPath);
+	const manifestPath = extensionManifestPaths.get(key);
+	extensionManifestPaths.delete(key);
+	return manifestPath;
+}
 
 function enabledPluginsCacheKey(cwd: string, home?: string): string {
 	return `${path.resolve(cwd)}\0${home === undefined ? "" : path.resolve(home)}`;
@@ -384,9 +415,7 @@ function resolveManifestEntryFiles(joined: string, expandDirectory: boolean): st
 function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "commands" | "extensions"): string[] {
 	const resolved: string[] = [];
 	for (const entry of resolvePluginManifestEntries(plugin, key)) {
-		if (entry.resolvedPath) {
-			resolved.push(entry.resolvedPath);
-		}
+		if (entry.resolvedPath) resolved.push(entry.resolvedPath);
 	}
 	return resolved;
 }
@@ -401,49 +430,42 @@ function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "c
 export function resolvePluginManifestEntries(
 	plugin: InstalledPlugin,
 	key: "tools" | "hooks" | "commands" | "extensions",
-): Array<{ entry: string; resolvedPath: string | null }> {
-	const declared: Array<{ entry: string; resolvedPath: string | null }> = [];
+): Array<{ entry: string; resolvedPath: string | null; manifestPath: string }> {
+	const declared: Array<{ entry: string; resolvedPath: string | null; manifestPath: string }> = [];
 	const manifest = plugin.manifest;
+	const manifestPath = path.join(plugin.path, "package.json");
 
 	const expandDirectory = key === "extensions";
-	const resolveEntry = (entry: string): Array<{ entry: string; resolvedPath: string | null }> => {
+	const resolveEntry = (
+		entry: string,
+	): Array<{ entry: string; resolvedPath: string | null; manifestPath: string }> => {
 		const files = resolveManifestEntryFiles(path.join(plugin.path, entry), expandDirectory);
-		return files.length > 0 ? files.map(resolvedPath => ({ entry, resolvedPath })) : [{ entry, resolvedPath: null }];
+		return files.length > 0
+			? files.map(resolvedPath => ({ entry, resolvedPath, manifestPath }))
+			: [{ entry, resolvedPath: null, manifestPath }];
 	};
 
 	const base = manifest[key];
 	if (base) {
 		const entries = Array.isArray(base) ? base : [base];
-		for (const entry of entries) {
-			declared.push(...resolveEntry(entry));
-		}
+		for (const entry of entries) declared.push(...resolveEntry(entry));
 	}
 
 	if (manifest.features && plugin.enabledFeatures) {
 		const enabledSet = new Set(plugin.enabledFeatures);
 		for (const [featName, feat] of Object.entries(manifest.features)) {
-			if (!enabledSet.has(featName)) continue;
-			if (feat[key]) {
-				for (const entry of feat[key]) {
-					declared.push(...resolveEntry(entry));
-				}
-			}
+			if (!enabledSet.has(featName) || !feat[key]) continue;
+			for (const entry of feat[key]) declared.push(...resolveEntry(entry));
 		}
 	} else if (manifest.features && plugin.enabledFeatures === null) {
-		// null means use defaults - enable features with default: true
-		for (const [_featName, feat] of Object.entries(manifest.features)) {
-			if (!feat.default) continue;
-			if (feat[key]) {
-				for (const entry of feat[key]) {
-					declared.push(...resolveEntry(entry));
-				}
-			}
+		for (const feat of Object.values(manifest.features)) {
+			if (!feat.default || !feat[key]) continue;
+			for (const entry of feat[key]) declared.push(...resolveEntry(entry));
 		}
 	}
 
 	return declared;
 }
-
 export function resolvePluginToolPaths(plugin: InstalledPlugin): string[] {
 	return resolvePluginPaths(plugin, "tools");
 }
@@ -514,7 +536,14 @@ export async function getAllPluginExtensionPaths(cwd: string): Promise<string[]>
 	const paths: string[] = [];
 
 	for (const plugin of plugins) {
-		paths.push(...resolvePluginExtensionPaths(plugin));
+		for (const entry of resolvePluginManifestEntries(plugin, "extensions")) {
+			if (!entry.resolvedPath) continue;
+			paths.push(entry.resolvedPath);
+			extensionManifestPaths.set(
+				path.resolve(entry.resolvedPath),
+				nearestExtensionManifestPath(entry.resolvedPath, plugin.path) ?? entry.manifestPath,
+			);
+		}
 	}
 
 	return paths;

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -15,7 +15,7 @@ import { resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { loadExtensions } from "../extensions/loader";
 import { refreshBunGitCache } from "./bun-git-cache";
 import { type GitSource, parseGitUrl } from "./git-url";
-import { resolvePluginManifestEntries } from "./loader";
+import { resolvePluginManifestEntries, setExtensionManifestPath } from "./loader";
 import { getInstalledPluginsRegistryPath, readInstalledPluginsRegistry } from "./marketplace/registry";
 import { parsePluginId } from "./marketplace/types";
 import { extractPackageName, parsePluginSpec } from "./parser";
@@ -388,32 +388,23 @@ export class PluginManager {
 
 	async #validateInstalledExtensions(plugin: InstalledPlugin): Promise<void> {
 		const declaredEntries = resolvePluginManifestEntries(plugin, "extensions");
-		if (declaredEntries.length === 0) {
-			return;
-		}
-
+		if (declaredEntries.length === 0) return;
 		const errors: string[] = [];
 		const loadable: string[] = [];
-		for (const { entry, resolvedPath } of declaredEntries) {
-			if (resolvedPath === null) {
-				errors.push(`${entry}: declared extension entry not found on disk`);
-			} else {
+		for (const { entry, resolvedPath, manifestPath } of declaredEntries) {
+			if (resolvedPath === null) errors.push(`${entry}: declared extension entry not found on disk`);
+			else {
 				loadable.push(resolvedPath);
+				setExtensionManifestPath(resolvedPath, manifestPath);
 			}
 		}
-
 		if (loadable.length > 0) {
 			const result = await loadExtensions(loadable, this.#cwd);
-			for (const failure of result.errors) {
-				errors.push(`${failure.path}: ${failure.error}`);
-			}
+			for (const failure of result.errors) errors.push(`${failure.path}: ${failure.error}`);
 		}
-
-		if (errors.length > 0) {
+		if (errors.length > 0)
 			throw new Error(`Plugin ${plugin.name} extension validation failed:\n${errors.join("\n")}`);
-		}
 	}
-
 	// ==========================================================================
 	// Install / Uninstall
 	// ==========================================================================

--- a/packages/coding-agent/src/extensibility/plugins/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/types.ts
@@ -31,19 +31,18 @@ export interface PluginManifest {
 	version: string;
 	/** Human-readable description */
 	description?: string;
-
 	/** Entry point for base tools (relative path from package root) */
 	tools?: string;
 	/** Entry point for base hooks (relative path from package root) */
 	hooks?: string;
 	/** Extension entry points (relative paths from package root) */
 	extensions?: string[];
+	/** Declares that extension entrypoints use native ESM semantics. */
+	compatibility?: "legacy" | "modern-esm";
 	/** Command files (relative paths from package root) */
 	commands?: string[];
-
-	/** Feature definitions for selective installation */
+	/** Feature definitions for selective plugin installation */
 	features?: Record<string, PluginFeature>;
-
 	/** Settings schema for plugin configuration */
 	settings?: Record<string, PluginSettingSchema>;
 }

--- a/packages/coding-agent/test/extension-loader-concurrency.test.ts
+++ b/packages/coding-agent/test/extension-loader-concurrency.test.ts
@@ -125,4 +125,61 @@ export default function okExtension() {
 		expect(result.extensions.map(ext => ext.path)).toEqual([okPath]);
 		expect(eventsGlobal[EVENTS_KEY]).toContain("ok:factory");
 	});
+
+	it("uses native module caching for manifest-declared modern ESM extensions", async () => {
+		writeModule(
+			"package.json",
+			JSON.stringify({ omp: { extensions: ["./src/index.ts"], compatibility: "modern-esm" } }),
+		);
+		const dependencyPath = writeModule("src/dependency.ts", `export const label = "modern-cached";`);
+		const extensionPath = writeModule(
+			"src/index.ts",
+			`import { label } from "./dependency"; export default function (pi) { pi.setLabel(label); }`,
+		);
+
+		const first = await loadExtensions([extensionPath], project!.path());
+		expect(first.errors).toEqual([]);
+		expect(first.extensions[0]?.label).toBe("modern-cached");
+
+		fs.writeFileSync(dependencyPath, `export const label = "modern-updated";`);
+		const second = await loadExtensions([extensionPath], project!.path());
+		expect(second.errors).toEqual([]);
+		expect(second.extensions[0]?.label).toBe("modern-cached");
+	});
+
+	it("does not inherit modern mode across a nested declaring manifest", async () => {
+		writeModule("package.json", JSON.stringify({ omp: { compatibility: "modern-esm" } }));
+		writeModule("nested/package.json", JSON.stringify({ omp: { extensions: ["./index.ts"] } }));
+		const dependencyPath = writeModule("nested/dependency.ts", `export const label = "nested-legacy";`);
+		const extensionPath = writeModule(
+			"nested/index.ts",
+			`import { label } from "./dependency"; export default function (pi) { pi.setLabel(label); }`,
+		);
+
+		const first = await loadExtensions([extensionPath], project!.path());
+		expect(first.extensions[0]?.label).toBe("nested-legacy");
+
+		fs.writeFileSync(dependencyPath, `export const label = "nested-updated";`);
+		const second = await loadExtensions([extensionPath], project!.path());
+		expect(second.errors).toEqual([]);
+		expect(second.extensions[0]?.label).toBe("nested-updated");
+	});
+
+	it("keeps extensions without modern metadata on the compatibility loader", async () => {
+		writeModule("package.json", JSON.stringify({ omp: { extensions: ["./index.ts"] } }));
+		const dependencyPath = writeModule("dependency.ts", `export const label = "legacy-reloaded";`);
+		const extensionPath = writeModule(
+			"index.ts",
+			`import { label } from "./dependency"; export default function (pi) { pi.setLabel(label); }`,
+		);
+
+		const first = await loadExtensions([extensionPath], project!.path());
+		expect(first.errors).toEqual([]);
+		expect(first.extensions[0]?.label).toBe("legacy-reloaded");
+
+		fs.writeFileSync(dependencyPath, `export const label = "legacy-updated";`);
+		const second = await loadExtensions([extensionPath], project!.path());
+		expect(second.errors).toEqual([]);
+		expect(second.extensions[0]?.label).toBe("legacy-updated");
+	});
 });

--- a/packages/coding-agent/test/extension-loader-modern-esm.test.ts
+++ b/packages/coding-agent/test/extension-loader-modern-esm.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+
+describe("extension compatibility dispatch", () => {
+  test("loads modern-esm extensions without legacy graph preparation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omp-modern-esm-"));
+    await writeFile(join(root, "package.json"), JSON.stringify({ type: "module", omp: { compatibility: "modern-esm" } }));
+    await writeFile(join(root, "extension.ts"), "export default pi => pi.setLabel(\"modern\");\n");
+    const result = await loadExtensions([join(root, "extension.ts")], root);
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+  });
+
+  test("keeps extensions without modern metadata on the legacy path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omp-legacy-esm-"));
+    await writeFile(join(root, "extension.ts"), "export default pi => pi.setLabel(\"legacy\");\n");
+    const result = await loadExtensions([join(root, "extension.ts")], root);
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add an opt-in `omp.compatibility: "modern-esm"` extension manifest mode and route modern ESM extensions through the runtime module-loader boundary instead of the legacy compatibility graph scanner.

## Scope

- Preserve legacy loading when compatibility is absent, invalid, or explicitly `legacy`.
- Preserve declaring manifest ownership for nested, escaped, symlinked, and install-time extension entries.
- Deduplicate manifest reads within an extension load pass.
- Keep host guards, concurrent imports, deterministic factory binding, and per-session runtime isolation unchanged.
- Add focused regression coverage for modern ESM dispatch and extension-loader concurrency.

## Performance

In the production-sized Mobile20 core plugin, the modern ESM path reduced observed extension-loading time from roughly 2–10+ seconds in legacy runs to approximately 0.46–1.0 seconds in the rebuilt 18.0.4 artifact. This has brought a substantial benefit to my local startup workflow with a custom plugin.

## Verification

Focused extension-loader tests cover modern ESM dispatch, manifest ownership, and concurrency. The legacy path remains the default unless a plugin opts in through its manifest.